### PR TITLE
feat: wire href on all SourcingDot render sites (QUA-207)

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -8,6 +8,7 @@ import { PaginationControls } from "@/components/directory/PaginationControls";
 import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS, formatContext } from "./ai-model-constants";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface AiModelRow {
   id: string;
@@ -411,6 +412,7 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                       wikiId: row.wikiId,
                     })}
                     verdict={row.verdictString}
+                    sourcingHref={row.verdictString ? getSourcingHref("ai-model", row.id) : undefined}
                   />
                 </td>
               </tr>

--- a/apps/web/src/app/approaches/approaches-table.tsx
+++ b/apps/web/src/app/approaches/approaches-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface ApproachRow {
   id: string;
@@ -142,6 +143,7 @@ export function ApproachesTable({ rows }: { rows: ApproachRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeGenericCoverage({ description: row.description, tags: row.tags, wikiId: row.wikiId })}
                     verdict={row.verdictString}
+                    sourcingHref={row.verdictString ? getSourcingHref("approach", row.id) : undefined}
                   />
                 </td>
 

--- a/apps/web/src/app/benchmarks/benchmarks-table.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-table.tsx
@@ -6,6 +6,7 @@ import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeBenchmarkCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface BenchmarkRow {
   id: string;
@@ -234,6 +235,7 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeBenchmarkCoverage(row)}
                     verdict={row.verdictString}
+                    sourcingHref={row.verdictString ? getSourcingHref("benchmark", row.id) : undefined}
                   />
                 </td>
               </tr>

--- a/apps/web/src/app/events/events-table.tsx
+++ b/apps/web/src/app/events/events-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface EventRow {
   id: string;
@@ -173,6 +174,7 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeGenericCoverage({ description: row.description, tags: row.tags, wikiId: row.wikiId, filledFieldCount: (row.status ? 1 : 0) })}
                     verdict={row.verdictString}
+                    sourcingHref={row.verdictString ? getSourcingHref("event", row.id) : undefined}
                   />
                 </td>
 

--- a/apps/web/src/app/legislation/[slug]/page.tsx
+++ b/apps/web/src/app/legislation/[slug]/page.tsx
@@ -48,6 +48,7 @@ import { StakeholderTable, type StakeholderRow } from "./stakeholder-table";
 import { ProvisionCard } from "./provision-card";
 import { getSourceDisplayName } from "../source-display-names";
 import { LegislationVotes, fetchLegislationVotes } from "@/components/political";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export function generateStaticParams() {
   return getPolicySlugs().map((slug) => ({ slug }));
@@ -68,17 +69,20 @@ export async function generateMetadata({
   };
 }
 
-/** Resolve sourcing verdict for a stakeholder (server-side only). */
-function resolveVerdict(
+/** Resolve sourcing verdict and sourcing href for a stakeholder (server-side only). */
+function resolveStakeholderSourcing(
   policyStableId: string | undefined,
   stakeholderName: string,
-): { verdict: string; confidence: number | null } | null {
-  if (!policyStableId) return null;
+): { verdict: { verdict: string; confidence: number | null } | null; sourcingHref: string | undefined } {
+  if (!policyStableId) return { verdict: null, sourcingHref: undefined };
   const stakeholderId = getPolicyStakeholderId(policyStableId, stakeholderName);
-  if (!stakeholderId) return null;
+  if (!stakeholderId) return { verdict: null, sourcingHref: undefined };
   const v = getRecordVerdict("policy-stakeholder", stakeholderId);
-  if (!v) return null;
-  return { verdict: v.verdict, confidence: v.confidence };
+  if (!v) return { verdict: null, sourcingHref: undefined };
+  return {
+    verdict: { verdict: v.verdict, confidence: v.confidence },
+    sourcingHref: getSourcingHref("policy-stakeholder", stakeholderId),
+  };
 }
 
 /** Status pipeline stages for the visual timeline. */
@@ -160,19 +164,23 @@ export default async function LegislationDetailPage({
     (importanceOrder[a.importance ?? ""] ?? 3) - (importanceOrder[b.importance ?? ""] ?? 3);
 
   // Convert raw stakeholders to StakeholderRow with resolved hrefs, source names, and verdicts
-  const toRow = (s: (typeof entity.stakeholders)[number]): StakeholderRow => ({
-    name: s.name,
-    entityId: s.entityId,
-    position: s.position,
-    role: s.role,
-    importance: s.importance,
-    reason: s.reason,
-    source: s.source,
-    sourceName: s.source ? getSourceDisplayName(s.source) : undefined,
-    context: s.context,
-    href: resolveEntityHref(s.entityId),
-    verdict: resolveVerdict(entity.stableId, s.name),
-  });
+  const toRow = (s: (typeof entity.stakeholders)[number]): StakeholderRow => {
+    const sourcing = resolveStakeholderSourcing(entity.stableId, s.name);
+    return {
+      name: s.name,
+      entityId: s.entityId,
+      position: s.position,
+      role: s.role,
+      importance: s.importance,
+      reason: s.reason,
+      source: s.source,
+      sourceName: s.source ? getSourceDisplayName(s.source) : undefined,
+      context: s.context,
+      href: resolveEntityHref(s.entityId),
+      verdict: sourcing.verdict,
+      sourcingHref: sourcing.sourcingHref,
+    };
+  };
 
   const supporters = entity.stakeholders.filter((s) => s.position === "support").sort(byImportance).map(toRow);
   const opponents = entity.stakeholders.filter((s) => s.position === "oppose").sort(byImportance).map(toRow);

--- a/apps/web/src/app/legislation/[slug]/stakeholder-table.tsx
+++ b/apps/web/src/app/legislation/[slug]/stakeholder-table.tsx
@@ -191,6 +191,8 @@ export interface StakeholderRow {
   href: string | null;
   /** Pre-resolved sourcing verdict (serializable). Resolved server-side. */
   verdict: { verdict: string; confidence: number | null } | null;
+  /** Link to the sourcing detail page for this stakeholder. */
+  sourcingHref?: string;
 }
 
 interface StakeholderTableProps {
@@ -312,6 +314,7 @@ export function StakeholderTable({
                     status={recordVerdictToStatus(stakeholder.verdict?.verdict)}
                     originalVerdict={stakeholder.verdict?.verdict}
                     size="md"
+                    href={stakeholder.sourcingHref}
                   />
                 </td>
               </tr>

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -13,6 +13,7 @@ import { compareOrgRows } from "@/app/organizations/org-sort";
 import type { OrgSortKey } from "@/app/organizations/org-sort";
 import { ORG_TYPE_LABELS, ORG_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR } from "@/app/organizations/org-constants";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
 import { useServerTable } from "@/hooks/use-server-table";
 import { formatCompactCurrency, formatCompactNumber as formatCompactNum } from "@/lib/format-compact";
@@ -589,7 +590,7 @@ export function OrganizationsTable({
                     {/* Completion Score */}
                     {visibleColumns.has("completionScore") && (
                       <td className="py-2.5 px-3 text-center">
-                        <RecordStatusDots coverageScore={row.completionScore} verdict={row.verdictString} />
+                        <RecordStatusDots coverageScore={row.completionScore} verdict={row.verdictString} sourcingHref={row.verdictString ? getSourcingHref("entity", row.id) : undefined} />
                       </td>
                     )}
 

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -17,6 +17,7 @@ import type { PeopleSortKey } from "./people-sort";
 import { isPersonMeaningful } from "./people-filter";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computePersonCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface PersonRow {
   id: string;
@@ -668,7 +669,7 @@ export function PeopleTable({
                     )}
                     {/* Coverage */}
                     <td className="py-2.5 px-3 text-center">
-                      <RecordStatusDots coverageScore={computePersonCoverage(row)} verdict={row.verdictString} />
+                      <RecordStatusDots coverageScore={computePersonCoverage(row)} verdict={row.verdictString} sourcingHref={row.verdictString ? getSourcingHref("entity", row.id) : undefined} />
                     </td>
                   </tr>
                 ))}

--- a/apps/web/src/app/projects/projects-table.tsx
+++ b/apps/web/src/app/projects/projects-table.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeProjectCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface ProjectRow {
   id: string;
@@ -148,6 +149,7 @@ export function ProjectsTable({ rows }: { rows: ProjectRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeProjectCoverage(row)}
                     verdict={row.verdictString}
+                    sourcingHref={row.verdictString ? getSourcingHref("project", row.id) : undefined}
                   />
                 </td>
 

--- a/apps/web/src/components/sourcing/FactSourcingDot.tsx
+++ b/apps/web/src/components/sourcing/FactSourcingDot.tsx
@@ -13,11 +13,14 @@ export function FactSourcingDot({
   sourceUrl,
   size = "sm",
   className,
+  href,
 }: {
   factId: string;
   sourceUrl?: string | null;
   size?: "sm" | "md";
   className?: string;
+  /** Link to sourcing detail page. Defaults to `/sourcing/fact/<factId>` when a verdict exists. */
+  href?: string;
 }) {
   const sourcing = getFactBaseFactSourcing(factId);
   if (!sourcing) return null;
@@ -28,6 +31,7 @@ export function FactSourcingDot({
       sourceUrl={sourceUrl}
       size={size}
       className={className}
+      href={href ?? `/sourcing/fact/${encodeURIComponent(factId)}`}
     />
   );
 }

--- a/apps/web/src/components/wiki/factbase/FBEntityFacts.tsx
+++ b/apps/web/src/components/wiki/factbase/FBEntityFacts.tsx
@@ -104,7 +104,7 @@ function TimeSeriesProperty({
               </span>
               {item.fact.source && isUrl(item.fact.source) && (
                 <span className="inline-flex items-center gap-1 whitespace-nowrap">
-                  {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" />}
+                  {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" href={`/sourcing/fact/${encodeURIComponent(item.fact.id)}`} />}
                   <a
                     href={item.fact.source}
                     className="text-xs text-primary/60 hover:text-primary hover:underline"
@@ -161,7 +161,7 @@ function SingleValueProperty({
             ({formatKBDate(fact.asOf)})
           </span>
         )}
-        {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" />}
+        {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" href={`/sourcing/fact/${encodeURIComponent(fact.id)}`} />}
       </div>
     </div>
   );

--- a/apps/web/src/components/wiki/factbase/FBFactValue.tsx
+++ b/apps/web/src/components/wiki/factbase/FBFactValue.tsx
@@ -135,19 +135,19 @@ export function FBFactValue({
                 >
                   Link
                 </a>
-                {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" />}
+                {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" href={`/sourcing/fact/${encodeURIComponent(fact.id)}`} />}
               </span>
             ) : (
               <span className="inline-flex items-center gap-1">
                 Source: {fact.source}
-                {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" />}
+                {sourcing && <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" href={`/sourcing/fact/${encodeURIComponent(fact.id)}`} />}
               </span>
             )}
           </span>
         )}
         {sourcing && (
           <span className="block text-muted-foreground/80 mt-0.5">
-            <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" />
+            <SourcingDot status={factbaseVerdictToStatus(sourcing)} originalVerdict={sourcing} size="sm" href={`/sourcing/fact/${encodeURIComponent(fact.id)}`} />
           </span>
         )}
         {/* Fact detail link */}


### PR DESCRIPTION
## Summary

- Wire `href`/`sourcingHref` on every `SourcingDot` and `RecordStatusDots` render site so users can click through to sourcing detail pages
- 8 directory tables (organizations, people, events, approaches, ai-models, benchmarks, projects) gain `sourcingHref` on `RecordStatusDots`
- `stakeholder-table.tsx` threads `sourcingHref` through `StakeholderRow` to `SourcingDot`
- `FactSourcingDot` now defaults `href` to `/sourcing/fact/<factId>` — all FactBase render sites automatically get click-through
- `FBFactValue` and `FBEntityFacts` inline `SourcingDot` calls now include `href`
- Legislation table intentionally skipped — its verdict is aggregated from multiple policy-stakeholder records with no single detail page

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (1 pre-existing unrelated failure in sourcing-lint-guard)
- [x] TypeScript type check passes (no new errors)
- [x] Verified every `<SourcingDot` call in the codebase has `href` wired
- [x] Verified every `<RecordStatusDots` call has `sourcingHref` (except legislation, intentionally skipped)

Fixes QUA-207

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>