### PR TITLE
fix: update sourcing client paths from /api/sourcing/ to /api/source-checks/

### DIFF
--- a/crux/lib/sourcing-context.ts
+++ b/crux/lib/sourcing-context.ts
@@ -64,7 +64,7 @@ async function fetchActionableVerdicts(
     ACTIONABLE_VERDICTS.map((verdict) =>
       apiRequest<VerdictsResponse>(
         'GET',
-        `/api/sourcing/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
+        `/api/source-checks/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
       )
     )
   );

--- a/crux/lib/wiki-server/__tests__/sourcing.test.ts
+++ b/crux/lib/wiki-server/__tests__/sourcing.test.ts
@@ -47,7 +47,7 @@ describe('getVerdictsByEntity', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/by-entity/sid_abc123',
+      '/api/source-checks/by-entity/sid_abc123',
     );
   });
 
@@ -64,7 +64,7 @@ describe('getVerdictsByEntity', () => {
     });
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toContain('/api/sourcing/by-entity/sid_abc123?');
+    expect(url).toContain('/api/source-checks/by-entity/sid_abc123?');
     expect(url).toContain('limit=10');
     expect(url).toContain('offset=20');
     expect(url).toContain('verdict=contradicted');
@@ -91,7 +91,7 @@ describe('getVerdictsByEntity', () => {
     await getVerdictsByEntity('sid_abc123');
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toBe('/api/sourcing/by-entity/sid_abc123');
+    expect(url).toBe('/api/source-checks/by-entity/sid_abc123');
     expect(url).not.toContain('?');
   });
 });
@@ -117,7 +117,7 @@ describe('getVerdictsByPage', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/by-page/anthropic',
+      '/api/source-checks/by-page/anthropic',
     );
   });
 
@@ -156,7 +156,7 @@ describe('getFailures', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/failures',
+      '/api/source-checks/failures',
     );
   });
 
@@ -210,7 +210,7 @@ describe('getStaleVerdicts', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/stale',
+      '/api/source-checks/stale',
     );
   });
 
@@ -264,7 +264,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/verdicts?verdict=contradicted&limit=200',
+      '/api/source-checks/verdicts?verdict=contradicted&limit=200',
     );
   });
 
@@ -278,7 +278,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/sourcing/verdicts?verdict=confirmed&limit=50',
+      '/api/source-checks/verdicts?verdict=confirmed&limit=50',
     );
   });
 });

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -34,14 +34,14 @@ export type VerdictListEntry = ListVerdictsResult['verdicts'][number];
 export async function storeEvidence(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreEvidenceResult>> {
-  return apiRequest<StoreEvidenceResult>('POST', '/api/sourcing/evidence', body);
+  return apiRequest<StoreEvidenceResult>('POST', '/api/source-checks/evidence', body);
 }
 
 /** Store an aggregate verdict for a record. */
 export async function storeVerdict(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreVerdictResult>> {
-  return apiRequest<StoreVerdictResult>('POST', '/api/sourcing/verdicts', body);
+  return apiRequest<StoreVerdictResult>('POST', '/api/source-checks/verdicts', body);
 }
 
 /** List verdicts with optional filters. */
@@ -56,7 +56,7 @@ export async function listVerdicts(
   const qs = params.toString();
   return apiRequest<ListVerdictsResult>(
     'GET',
-    `/api/sourcing/verdicts${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/verdicts${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -67,7 +67,7 @@ export async function getVerdictByRecord(
 ): Promise<ApiResult<VerdictByRecordResult>> {
   return apiRequest<VerdictByRecordResult>(
     'GET',
-    `/api/sourcing/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
+    `/api/source-checks/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
   );
 }
 
@@ -82,13 +82,13 @@ export async function getEvidenceByRecord(
   const qs = params.toString();
   return apiRequest<EvidenceByRecordResult>(
     'GET',
-    `/api/sourcing/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
+    `/api/source-checks/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
   );
 }
 
 /** Get sourcing statistics. */
 export async function getSourcingStats(): Promise<ApiResult<SourcingStatsResult>> {
-  return apiRequest<SourcingStatsResult>('GET', '/api/sourcing/stats');
+  return apiRequest<SourcingStatsResult>('GET', '/api/source-checks/stats');
 }
 
 /** Get records due for re-check. */
@@ -101,6 +101,6 @@ export async function getDueForRecheck(
   const qs = params.toString();
   return apiRequest<DueForRecheckResult>(
     'GET',
-    `/api/sourcing/due-for-recheck${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/due-for-recheck${qs ? `?${qs}` : ''}`,
   );
 }

--- a/crux/lib/wiki-server/sourcing.ts
+++ b/crux/lib/wiki-server/sourcing.ts
@@ -39,7 +39,7 @@ export async function getVerdictsByType(
 ): Promise<ApiResult<VerdictsResponse>> {
   return apiRequest<VerdictsResponse>(
     'GET',
-    `/api/sourcing/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
+    `/api/source-checks/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
   );
 }
 
@@ -57,7 +57,7 @@ export async function getVerdictsByEntity(
   const qs = params.toString();
   return apiRequest<ByEntityResponse>(
     'GET',
-    `/api/sourcing/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -74,7 +74,7 @@ export async function getVerdictsByPage(
   const qs = params.toString();
   return apiRequest<ByPageResponse>(
     'GET',
-    `/api/sourcing/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -99,7 +99,7 @@ export async function getFailures(
   const qs = params.toString();
   return apiRequest<FailuresResponse>(
     'GET',
-    `/api/sourcing/failures${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/failures${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -124,7 +124,7 @@ export async function getStaleVerdicts(
   const qs = params.toString();
   return apiRequest<StaleResponse>(
     'GET',
-    `/api/sourcing/stale${qs ? `?${qs}` : ''}`,
+    `/api/source-checks/stale${qs ? `?${qs}` : ''}`,
   );
 }
 

--- a/crux/scripts/backfill-fact-entity-ids.ts
+++ b/crux/scripts/backfill-fact-entity-ids.ts
@@ -137,7 +137,7 @@ async function fetchNullEntityVerdicts(): Promise<VerdictRow[]> {
   while (rows.length < total) {
     const res = await apiFetch(
       "GET",
-      `/api/sourcing/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
+      `/api/source-checks/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
     );
     if (!res.ok) {
       console.error(`Failed to fetch verdicts: ${res.error}`);
@@ -245,7 +245,7 @@ async function main() {
       sourcesChecked: row.sourcesChecked ?? undefined,
     };
 
-    const res = await apiFetch("POST", "/api/sourcing/verdicts", body);
+    const res = await apiFetch("POST", "/api/source-checks/verdicts", body);
 
     if (res.ok) {
       success++;

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -450,7 +450,7 @@ async function scanSourceQuality(): Promise<TableScanResult> {
   while (true) {
     const result = await apiRequest<{ verdicts: VerdictRow[]; total: number }>(
       'GET',
-      `/api/sourcing/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
+      `/api/source-checks/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
     );
     if (!result.ok) {
       console.warn(`[tablebase] Failed to fetch unverifiable verdicts: ${result.message}`);

--- a/crux/validate/validate-sourcing-names.ts
+++ b/crux/validate/validate-sourcing-names.ts
@@ -52,7 +52,7 @@ export async function validateSourcingNames(): Promise<{
     // Fetch a sample of verdicts
     const verdictsResult = await apiRequest<VerdictsResponse>(
       'GET',
-      `/api/sourcing/verdicts?record_type=${recordType}&limit=20`
+      `/api/source-checks/verdicts?record_type=${recordType}&limit=20`
     );
 
     if (!verdictsResult.ok) {
@@ -92,7 +92,7 @@ export async function validateSourcingNames(): Promise<{
     const idList = [...recordIds].join(',');
     const namesResult = await apiRequest<ResolveNamesResponse>(
       'GET',
-      `/api/sourcing/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
+      `/api/source-checks/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
     );
 
     if (!namesResult.ok) {


### PR DESCRIPTION
## Summary

- Update all crux sourcing client API paths from `/api/sourcing/` to `/api/source-checks/`
- The sourcing route is mounted at `/api/source-checks/` in production. The `/api/sourcing/` alias exists in code (app.ts:207) but the deployed server returns 404 for it
- This caused all verdict storage from the verify-orchestrate pipeline to silently fail with "bad_request" — verdicts were computed by the LLM but never persisted
- Updates 7 files with 27 URL path references

**Impact**: Unblocks the entire source-check backfill pipeline. Without this, running `verify-orchestrate` computes verdicts at LLM cost but throws them away.

Also fixes `verify-orchestrate stats` and `verify-orchestrate contradicted` which were failing with `bad_request`.

## Test plan
- [x] `WIKI_SERVER_ENV=prod pnpm crux verify-orchestrate stats` now returns data instead of "bad_request"
- [x] Direct curl to `/api/source-checks/evidence` confirms the endpoint works

Fixes QUA-245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated sourcing and fact-checking API endpoints to a unified routing namespace, improving system maintainability and consistency across verification operations.
  * Updated verdict storage and retrieval, evidence management, source quality scanning, validation processes, and data backfill operations to use the new endpoint structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->