### PR TITLE
feat: formalize SOURCING_EXEMPT_TYPES (QUA-191)

### DIFF
--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -31,6 +31,8 @@ interface CoverageMatrixResult {
     };
     coveragePercent: number;
     greenPercent: number;
+    /** Whether this record type is exempt from sourcing verification */
+    exempt?: boolean;
   }>;
   totals: {
     totalRecords: number;
@@ -38,6 +40,8 @@ interface CoverageMatrixResult {
     confirmedPercent: number;
     coveragePercent: number;
   };
+  /** Record types that are exempt from sourcing verification */
+  exemptTypes?: string[];
 }
 
 /** Shape returned by GET /api/sourcing/verdict-matrix */
@@ -377,7 +381,12 @@ export async function SourcingCoverageContent() {
       )}
 
       {/* ── (d) Coverage Matrix ──────────────────────────────────────── */}
-      {coverageMatrix.tables.length > 0 && (
+      {coverageMatrix.tables.length > 0 && (() => {
+        const exemptSet = new Set(coverageMatrix.exemptTypes ?? []);
+        const nonExemptTables = coverageMatrix.tables.filter((t) => !t.exempt && !exemptSet.has(t.recordType));
+        const exemptTables = coverageMatrix.tables.filter((t) => t.exempt || exemptSet.has(t.recordType));
+
+        return (
         <div className="not-prose mb-8">
           <h2 className="text-lg font-semibold mb-3">
             Coverage Matrix
@@ -385,6 +394,9 @@ export async function SourcingCoverageContent() {
           <p className="text-sm text-muted-foreground mb-3">
             Per-record-type breakdown: total records in each table vs how many have been sourcinged,
             and what percentage are confirmed green.
+            {exemptTables.length > 0 && (
+              <> Exempt types (data ingested from canonical APIs) are shown separately and excluded from totals.</>
+            )}
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm border-collapse">
@@ -399,7 +411,7 @@ export async function SourcingCoverageContent() {
                 </tr>
               </thead>
               <tbody>
-                {coverageMatrix.tables.map((t) => {
+                {nonExemptTables.map((t) => {
                   const checked =
                     t.checkedRecords ??
                     (t.verdicts.confirmed +
@@ -447,10 +459,41 @@ export async function SourcingCoverageContent() {
                     </tr>
                   );
                 })}
+                {exemptTables.length > 0 && (
+                  <>
+                    <tr className="border-t border-border/40">
+                      <td colSpan={6} className="py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Exempt (canonical API sources)
+                      </td>
+                    </tr>
+                    {exemptTables.map((t) => (
+                      <tr
+                        key={t.recordType}
+                        className="border-b border-border/30 hover:bg-muted/30 opacity-60"
+                      >
+                        <td className="py-2 px-3 font-medium text-muted-foreground">
+                          {t.recordType}
+                          <span className="ml-2 text-xs bg-muted px-1.5 py-0.5 rounded">exempt</span>
+                        </td>
+                        <td className="text-right py-2 px-3 tabular-nums text-muted-foreground">
+                          {t.totalRecords.toLocaleString()}
+                        </td>
+                        <td colSpan={4} className="text-center py-2 px-3 text-xs text-muted-foreground italic">
+                          Not subject to sourcing verification
+                        </td>
+                      </tr>
+                    ))}
+                  </>
+                )}
               </tbody>
               <tfoot>
                 <tr className="border-t-2 border-border/60 font-semibold">
-                  <td className="py-2 px-3">Totals</td>
+                  <td className="py-2 px-3">
+                    Totals
+                    {exemptTables.length > 0 && (
+                      <span className="ml-2 text-xs font-normal text-muted-foreground">(excl. exempt)</span>
+                    )}
+                  </td>
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.totalRecords.toLocaleString()}
                   </td>
@@ -468,7 +511,8 @@ export async function SourcingCoverageContent() {
             </table>
           </div>
         </div>
-      )}
+        );
+      })()}
 
       {/* ── (e) Verdict Heatmap ──────────────────────────────────────── */}
       {(Object.keys(verdictMatrix.matrix).length > 0 || coverageMatrix.tables.length > 0) && (() => {

--- a/apps/wiki-server/src/__tests__/sourcing-exempt-types.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-exempt-types.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  SOURCING_EXEMPT_TYPES,
+  VALID_RECORD_TYPES,
+  isSourcingExempt,
+} from "../api-types.js";
+
+describe("SOURCING_EXEMPT_TYPES", () => {
+  it("contains only types that are also in VALID_RECORD_TYPES or are known non-VALID types", () => {
+    // Every exempt type should either be a valid record type (subset of existing types)
+    // or a known type that exists in the system but isn't in VALID_RECORD_TYPES.
+    // This prevents typos in the exempt list from silently passing.
+    const knownTypes = new Set([
+      ...VALID_RECORD_TYPES,
+      // Types that exist in the system but aren't in VALID_RECORD_TYPES:
+      "prediction-market-questions",
+      "platform-accounts",
+      "bluesky",
+      "website-sources",
+      "data-sources",
+    ]);
+
+    for (const exemptType of SOURCING_EXEMPT_TYPES) {
+      expect(
+        knownTypes.has(exemptType),
+        `Exempt type "${exemptType}" is not a known record type — possible typo`,
+      ).toBe(true);
+    }
+  });
+
+  it("does not contain all VALID_RECORD_TYPES (some must remain non-exempt)", () => {
+    // Sanity check: at least some record types should require verification
+    const nonExemptCount = VALID_RECORD_TYPES.filter(
+      (t) => !isSourcingExempt(t),
+    ).length;
+    expect(nonExemptCount).toBeGreaterThan(0);
+    // At minimum, personnel and grants should always require verification
+    expect(isSourcingExempt("personnel")).toBe(false);
+    expect(isSourcingExempt("grant")).toBe(false);
+  });
+
+  it("has no duplicates", () => {
+    const unique = new Set(SOURCING_EXEMPT_TYPES);
+    expect(unique.size).toBe(SOURCING_EXEMPT_TYPES.length);
+  });
+});
+
+describe("isSourcingExempt", () => {
+  it("returns true for exempt types", () => {
+    for (const t of SOURCING_EXEMPT_TYPES) {
+      expect(isSourcingExempt(t)).toBe(true);
+    }
+  });
+
+  it("returns false for non-exempt record types", () => {
+    expect(isSourcingExempt("personnel")).toBe(false);
+    expect(isSourcingExempt("grant")).toBe(false);
+    expect(isSourcingExempt("division")).toBe(false);
+    expect(isSourcingExempt("investment")).toBe(false);
+    expect(isSourcingExempt("funding-round")).toBe(false);
+  });
+
+  it("returns false for unknown/empty strings", () => {
+    expect(isSourcingExempt("")).toBe(false);
+    expect(isSourcingExempt("nonexistent-type")).toBe(false);
+    expect(isSourcingExempt("BENCHMARK-RESULT")).toBe(false); // case-sensitive
+  });
+
+  it("currently exempts the expected types", () => {
+    // This test documents the current exempt list.
+    // Update this when adding/removing exempt types.
+    expect(isSourcingExempt("benchmark-result")).toBe(true);
+    expect(isSourcingExempt("citation")).toBe(true);
+    expect(isSourcingExempt("entity-assessment")).toBe(true);
+    expect(isSourcingExempt("secondary-market-price")).toBe(true);
+  });
+
+  it("does not exempt core verification-required types", () => {
+    const mustVerify = [
+      "personnel",
+      "grant",
+      "division",
+      "funding-program",
+      "funding-round",
+      "investment",
+      "equity-position",
+      "policy-stakeholder",
+      "entity-event",
+    ];
+    for (const t of mustVerify) {
+      expect(
+        isSourcingExempt(t),
+        `"${t}" should NOT be exempt — it requires sourcing verification`,
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -53,6 +53,52 @@ export const VALID_RECORD_TYPES = [
 
 export type RecordType = (typeof VALID_RECORD_TYPES)[number];
 
+/**
+ * Record types that are exempt from sourcing verification.
+ *
+ * These are data classes where the ingestion source IS the canonical reference,
+ * so running sourcing verification against them produces noise rather than signal.
+ * They are excluded from coverage metrics, recheck queues, and the sourcing
+ * pipeline. The exemption is explicit — without this list, nothing prevents
+ * someone from accidentally running sourcing on these types and polluting
+ * the verdicts table.
+ *
+ * Criteria for exemption:
+ *   1. Data is ingested directly from an authoritative API (Manifold, arXiv, etc.)
+ *   2. The source URL in the record IS the canonical reference — re-checking it
+ *      against external sources is circular
+ *   3. Data is computed/derived from other already-verified records
+ *
+ * When adding a new exempt type, document the reason inline.
+ */
+export const SOURCING_EXEMPT_TYPES = [
+  // Ingested directly from benchmark provider APIs (e.g., provider docs, eval harnesses).
+  // The benchmark scores ARE the canonical data — no external source to verify against.
+  "benchmark-result",
+
+  // Computed by the citation accuracy system, not manually entered data.
+  // Citation accuracy has its own separate verification pipeline.
+  "citation",
+
+  // LLM-generated or editorial assessments (importance, risk, etc.).
+  // These are opinions/judgments, not factual claims that can be sourcing-checked.
+  "entity-assessment",
+
+  // Time-series pricing data ingested from secondary market APIs.
+  // The API response IS the canonical price — re-checking it is circular.
+  "secondary-market-price",
+] as const;
+
+export type SourcingExemptType = (typeof SOURCING_EXEMPT_TYPES)[number];
+
+/**
+ * Check whether a record type is exempt from sourcing verification.
+ * Use this instead of manual array checks to ensure consistency.
+ */
+export function isSourcingExempt(recordType: string): boolean {
+  return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
+}
+
 export const VALID_SOURCE_CHECK_VERDICTS = [
   "confirmed",
   "contradicted",

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -41,6 +41,10 @@ import {
   invalidJsonError,
   escapeIlike,
 } from "../shared/utils.js";
+import {
+  SOURCING_EXEMPT_TYPES,
+  isSourcingExempt,
+} from "../../api-types.js";
 
 // ---- Constants ----
 
@@ -418,6 +422,7 @@ const sourcingApp = new Hono()
         stale_evidence_count: Number(evidenceStats.staleCount),
         dead_link_count: Number(evidenceStats.deadLinkCount),
         current_checker_model: CURRENT_CHECKER_MODEL,
+        exempt_types: [...SOURCING_EXEMPT_TYPES],
       });
     }
   )
@@ -1617,13 +1622,14 @@ const sourcingApp = new Hono()
       .map((recordType) => {
         const total = totalsByType[recordType] ?? 0;
         const verified = verifiedByType[recordType] ?? 0;
+        const exempt = isSourcingExempt(recordType);
         const percentage =
           total > 0 ? Math.round((verified / total) * 10000) / 100 : 0;
-        return { recordType, total, verified, percentage };
+        return { recordType, total, verified, percentage, exempt };
       })
       .sort((a, b) => a.recordType.localeCompare(b.recordType));
 
-    return c.json({ coverage });
+    return c.json({ coverage, exemptTypes: [...SOURCING_EXEMPT_TYPES] });
   })
 
   // ---- GET /due-for-recheck ----
@@ -1652,6 +1658,15 @@ const sourcingApp = new Hono()
     const conditions = [dueConditions];
     if (record_type) {
       conditions.push(eq(sourceVerdicts.recordType, record_type));
+    }
+    // Exclude exempt types from the recheck queue — they don't need verification
+    if (SOURCING_EXEMPT_TYPES.length > 0) {
+      conditions.push(
+        sql`${sourceVerdicts.recordType} NOT IN (${sql.join(
+          SOURCING_EXEMPT_TYPES.map((t) => sql`${t}`),
+          sql`, `,
+        )})`,
+      );
     }
     // Push min_priority into SQL so the total count and pagination are correct.
     // The CASE expression is wrapped in a subquery to avoid repeating it.
@@ -1918,6 +1933,7 @@ const sourcingApp = new Hono()
       ...Object.keys(verdictsByType),
     ]);
 
+    // Grand totals exclude exempt types — they don't participate in coverage metrics
     let grandTotalRecords = 0;
     let grandCheckedRecords = 0;
     let grandTotalVerdicts = 0;
@@ -1928,6 +1944,7 @@ const sourcingApp = new Hono()
         const totalRecords = totalsByType[recordType] ?? 0;
         const verdicts = verdictsByType[recordType] ?? {};
         const checkedRecords = checkedByType[recordType] ?? 0;
+        const exempt = isSourcingExempt(recordType);
 
         const confirmed = verdicts["confirmed"] ?? 0;
         const partial = verdicts["partial"] ?? 0;
@@ -1949,10 +1966,13 @@ const sourcingApp = new Hono()
             ? Math.round((confirmed / totalVerdicts) * 1000) / 10
             : 0;
 
-        grandTotalRecords += totalRecords;
-        grandCheckedRecords += checkedRecords;
-        grandTotalVerdicts += totalVerdicts;
-        grandConfirmed += confirmed;
+        // Only non-exempt types contribute to grand totals
+        if (!exempt) {
+          grandTotalRecords += totalRecords;
+          grandCheckedRecords += checkedRecords;
+          grandTotalVerdicts += totalVerdicts;
+          grandConfirmed += confirmed;
+        }
 
         return {
           recordType,
@@ -1968,6 +1988,7 @@ const sourcingApp = new Hono()
           },
           coveragePercent,
           greenPercent,
+          exempt,
         };
       })
       .sort((a, b) => b.totalRecords - a.totalRecords);
@@ -1986,6 +2007,7 @@ const sourcingApp = new Hono()
             ? Math.round((grandCheckedRecords / grandTotalRecords) * 1000) / 10
             : 0,
       },
+      exemptTypes: [...SOURCING_EXEMPT_TYPES],
     });
   })
 
@@ -2035,7 +2057,7 @@ const sourcingApp = new Hono()
       totals[row.verdict] = (totals[row.verdict] ?? 0) + row.cnt;
     }
 
-    return c.json({ matrix, totals });
+    return c.json({ matrix, totals, exemptTypes: [...SOURCING_EXEMPT_TYPES] });
   });
 
 // ---- Exports ----

--- a/crux/lib/sourcing/item-collectors.test.ts
+++ b/crux/lib/sourcing/item-collectors.test.ts
@@ -274,6 +274,9 @@ describe('funding-round name resolution guard', () => {
 });
 
 // ── Benchmark result name resolution guard ───────────────────────────
+// Note: benchmark-result is now a SOURCE_CHECK_EXEMPT_TYPE (data ingested from
+// benchmark provider APIs). The exempt filter runs before name resolution, so
+// these tests verify that exempt types produce no items regardless of name quality.
 
 describe('benchmark-result name resolution guard', () => {
   function setupBenchmarkMock(records: Record<string, unknown>[]) {
@@ -284,18 +287,19 @@ describe('benchmark-result name resolution guard', () => {
     });
   }
 
-  it('includes records where model name is resolvable', async () => {
+  it('skips benchmark-result entirely because it is an exempt type', async () => {
     setupBenchmarkMock([{
       id: 'br-1',
       modelResolvedName: 'GPT-4',
       sourceUrl: 'https://example.com/benchmarks',
     }]);
 
+    // benchmark-result is exempt from sourcing verification — no items should be collected
     const items = await collectRecordItems(new Map(), undefined, 'benchmark-result');
-    expect(items).toHaveLength(1);
+    expect(items).toHaveLength(0);
   });
 
-  it('skips records where model name is unresolvable', async () => {
+  it('skips records where model name is unresolvable (also exempt)', async () => {
     setupBenchmarkMock([{
       id: 'br-2',
       modelId: 'NPPTvNqRXA',
@@ -304,5 +308,20 @@ describe('benchmark-result name resolution guard', () => {
 
     const items = await collectRecordItems(new Map(), undefined, 'benchmark-result');
     expect(items).toHaveLength(0);
+  });
+});
+
+// ── Exempt type filtering ────────────────────────────────────────────
+
+describe('exempt type filtering', () => {
+  it('skips all exempt types when scanning without table filter', async () => {
+    // Mock all API endpoints to return empty arrays
+    mockApiRequest.mockResolvedValue(mockEmptyResponse());
+
+    const items = await collectRecordItems(new Map());
+    // The function should not call APIs for exempt types, so no items.
+    // This test primarily verifies the function doesn't crash when
+    // exempt types are filtered out.
+    expect(items).toEqual([]);
   });
 });

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -10,7 +10,7 @@ import type { Fact, Entity as FBEntity } from '../../../packages/factbase/src/ty
 import { formatFactValue } from '../../../packages/factbase/src/format.ts';
 import { apiRequest } from '../wiki-server/client.ts';
 import { listVerdicts } from '../wiki-server/sourcing-client.ts';
-import { VALID_RECORD_TYPES, type RecordType } from '../../../apps/wiki-server/src/api-types.ts';
+import { VALID_RECORD_TYPES, type RecordType, isSourcingExempt } from '../../../apps/wiki-server/src/api-types.ts';
 import { resolveName, isResolvableName, extractEntityId, extractEntityDisplayName } from './record-fields.ts';
 import {
   ENTITY_TYPE_PRIORITY,
@@ -233,11 +233,14 @@ export async function collectRecordItems(
 
   // Determine which record types to scan
   // --table filters to a specific record type (e.g. "personnel", "grant")
-  const typesToScan = tableFilter
+  // Exempt types are excluded — their data comes from canonical APIs and
+  // doesn't benefit from sourcing verification (see SOURCING_EXEMPT_TYPES).
+  const typesToScan = (tableFilter
     ? VALID_RECORD_TYPES.filter(t => t === tableFilter)
     : entityTypeFilter
       ? VALID_RECORD_TYPES.filter(t => t === entityTypeFilter)
-      : [...VALID_RECORD_TYPES];
+      : [...VALID_RECORD_TYPES]
+  ).filter(t => !isSourcingExempt(t));
 
   for (const recordType of typesToScan) {
     let apiBasePath: string;


### PR DESCRIPTION
## Summary

Formalizes which record types are exempt from sourcing verification, so the system stops producing noise for data that can't meaningfully be source-checked.

- Added `SOURCING_EXEMPT_TYPES` constant with 4 exempt types: `benchmark-result`, `citation`, `entity-assessment`, `secondary-market-price`
- Updated 5 API endpoints to exclude/flag exempt types
- Coverage matrix dashboard separates exempt types into muted section with badges
- Sourcing pipeline filters out exempt types before scanning
- 8 new tests including safety guards (core types can never be exempt)

## Test plan

- [x] Wiki-server tests pass (915 tests)
- [x] Exempt types tests pass (8 tests)
- [x] Gate check passes
- [x] `pnpm build` passes

Fixes QUA-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)