### PR TITLE
feat: tag non-verifiable FactBase properties (QUA-247)

### DIFF
--- a/crux/commands/factbase-sourcing.test.ts
+++ b/crux/commands/factbase-sourcing.test.ts
@@ -122,6 +122,30 @@ describe('crux fb sourcing --dry-run', () => {
       expect(fact.source).toMatch(/^https?:\/\//);
     }
   });
+
+  it('skips facts with nonVerifiable properties (QUA-247)', async () => {
+    // Anthropic has secondary-valuation, equity-stake-percent, equity-value,
+    // and employee-tender-offer facts — all marked nonVerifiable in properties.yaml.
+    // These should be excluded from the dry-run output.
+    const NON_VERIFIABLE_PROPERTIES = [
+      'secondary-valuation',
+      'equity-stake-percent',
+      'equity-value',
+      'employee-tender-offer',
+    ];
+
+    const result = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output) as Array<{ propertyId: string }>;
+
+    for (const fact of data) {
+      expect(NON_VERIFIABLE_PROPERTIES).not.toContain(fact.propertyId);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -261,6 +261,12 @@ export async function storeSourcingResult(result: SourcingResult): Promise<void>
 /**
  * Collect facts to sourcing based on the command options.
  */
+/** Check if a fact's property is marked nonVerifiable in the property registry. */
+function isNonVerifiable(graph: Graph, fact: Fact): boolean {
+  const property = graph.getProperty(fact.propertyId);
+  return property?.nonVerifiable === true;
+}
+
 function collectFacts(
   kb: LoadedKB,
   options: VerifyCommandOptions,
@@ -274,7 +280,7 @@ function collectFacts(
       const facts = graph.getFacts(entity.id);
       const match = facts.find((f: Fact) => f.id === options.fact);
       if (match) {
-        if (match.source) {
+        if (match.source && !isNonVerifiable(graph, match)) {
           factsToVerify.push({ entity, fact: match });
         }
         break;
@@ -286,7 +292,7 @@ function collectFacts(
     if (entity) {
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
-        if (fact.source && !fact.id.startsWith('inv_')) {
+        if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
           factsToVerify.push({ entity, fact });
         }
       }
@@ -296,7 +302,7 @@ function collectFacts(
     for (const entity of graph.getAllEntities()) {
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
-        if (fact.source && !fact.id.startsWith('inv_')) {
+        if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
           factsToVerify.push({ entity, fact });
         }
       }

--- a/crux/commands/verify-entity.ts
+++ b/crux/commands/verify-entity.ts
@@ -107,6 +107,10 @@ async function discoverFactClaims(entityId: string): Promise<VerifiableClaim[]> 
     for (const fact of facts) {
       if (!fact.source) continue;
       const property = graph.getProperty(fact.propertyId);
+      // Skip facts whose property is marked nonVerifiable (e.g. secondary-valuation,
+      // equity-stake-percent) — these come from private/proprietary data that the
+      // sourcing system cannot verify. QUA-247.
+      if (property?.nonVerifiable) continue;
       const value = formatFactValue(fact, property, graph);
       claims.push({
         recordType: 'fact',

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -191,6 +191,11 @@ export function collectFactItems(
       if (!fact.source || fact.id.startsWith('inv_')) continue;
 
       const property = graph.getProperty(fact.propertyId);
+
+      // Skip facts whose property is marked nonVerifiable (e.g. secondary-valuation,
+      // equity-stake-percent) — these come from private/proprietary data that the
+      // sourcing system cannot verify. QUA-247.
+      if (property?.nonVerifiable) continue;
       const formattedValue = formatFactValue(fact, property, graph);
       const existing = existingVerdicts.get(fact.id);
 

--- a/packages/factbase/data/properties.yaml
+++ b/packages/factbase/data/properties.yaml
@@ -48,6 +48,7 @@ properties:
     unit: USD
     category: financial
     temporal: true
+    nonVerifiable: true
     appliesTo: [organization]
     display:
       divisor: 1e9
@@ -463,6 +464,7 @@ properties:
     unit: percent
     category: financial
     temporal: true
+    nonVerifiable: true
     appliesTo: [person, organization]
     display:
       suffix: "%"
@@ -474,6 +476,7 @@ properties:
     unit: USD
     category: financial
     temporal: true
+    nonVerifiable: true
     appliesTo: [person, organization]
     display:
       divisor: 1e9
@@ -620,6 +623,7 @@ properties:
     unit: USD
     category: financial
     temporal: true
+    nonVerifiable: true
     appliesTo: [organization]
     display:
       divisor: 1e9

--- a/packages/factbase/src/types.ts
+++ b/packages/factbase/src/types.ts
@@ -108,6 +108,10 @@ export interface Property {
   computed?: boolean;
   /** If true, values change over time (revenue, headcount). asOf = "measured at". */
   temporal?: boolean;
+  /** If true, facts with this property come from private/proprietary data and
+   *  cannot be verified by the sourcing system. The orchestrator skips them
+   *  instead of marking them "unverifiable". */
+  nonVerifiable?: boolean;
 }
 
 // ── Type Schemas ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Some FactBase properties (`secondary-valuation`, `equity-stake-percent`, `equity-value`, `employee-tender-offer`) represent data from private/proprietary sources that the sourcing system cannot verify against public URLs. These were being sent to the LLM for verification and always coming back as "unverifiable," wasting API calls.

This PR:
- Adds a `nonVerifiable` boolean field to the FactBase `Property` type
- Tags 4 properties as `nonVerifiable: true` in `properties.yaml`
- Updates both the standalone `crux fb sourcing` command and the orchestrated sourcing pipeline (`collectFactItems`) to skip facts with non-verifiable properties
- Adds a test verifying non-verifiable properties are excluded from the dry-run output

## Properties tagged

| Property | Rationale |
|----------|-----------|
| `secondary-valuation` | Implied valuations from private secondary markets / analyst estimates |
| `equity-stake-percent` | Ownership percentages from private cap table data |
| `equity-value` | Dollar values derived from private equity data |
| `employee-tender-offer` | Private employee share sale programs |

## Test plan

- [x] New test: `skips facts with nonVerifiable properties (QUA-247)` — runs dry-run on Anthropic entity and confirms no non-verifiable properties appear
- [x] All existing tests pass (5420 passed)
- [x] `pnpm build` passes
- [x] Sourcing lint guard passes (no new `source-check` references)

Fixes QUA-247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certain properties are now automatically excluded from fact sourcing workflows across all modes, preventing processing of facts marked as non-verifiable to ensure only verifiable data is collected for downstream analysis.

* **Tests**
  * Added test coverage to validate property exclusion behavior in dry-run sourcing mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->