### PR TITLE
fix: add missing groundskeeper event types to CHECK constraint

### DIFF
--- a/apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql
+++ b/apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql
@@ -144,7 +144,7 @@ END $$;
 DO $$ BEGIN
   ALTER TABLE "groundskeeper_runs"
     ADD CONSTRAINT chk_gkr_event
-    CHECK (event IN ('success', 'failure', 'error', 'circuit_breaker_tripped', 'skipped'));
+    CHECK (event IN ('success', 'failure', 'error', 'circuit_breaker_tripped', 'circuit_breaker_reset', 'half_open_attempt', 'half_open_success', 'skipped'));
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 

--- a/apps/wiki-server/drizzle/0174_fix_groundskeeper_event_constraint.sql
+++ b/apps/wiki-server/drizzle/0174_fix_groundskeeper_event_constraint.sql
@@ -1,0 +1,32 @@
+-- Fix migration 0173: the CHECK constraint for groundskeeper_runs.event was
+-- missing three valid event types that already exist in production data:
+-- 'circuit_breaker_reset', 'half_open_attempt', 'half_open_success'.
+--
+-- These values are defined in VALID_GK_EVENTS (api-types.ts) and accepted by
+-- the Zod schema, but were omitted from the CHECK constraint, causing the
+-- migration job to fail on deploy.
+--
+-- Strategy: drop the old constraint if it exists, then create the correct one.
+
+-- Drop the incomplete constraint (if 0173 partially succeeded on a prior attempt)
+DO $$ BEGIN
+  ALTER TABLE "groundskeeper_runs" DROP CONSTRAINT IF EXISTS chk_gkr_event;
+EXCEPTION WHEN undefined_object THEN NULL;
+END $$;
+
+-- Add the correct constraint with all valid event types
+DO $$ BEGIN
+  ALTER TABLE "groundskeeper_runs"
+    ADD CONSTRAINT chk_gkr_event
+    CHECK (event IN (
+      'success',
+      'failure',
+      'error',
+      'circuit_breaker_tripped',
+      'circuit_breaker_reset',
+      'half_open_attempt',
+      'half_open_success',
+      'skipped'
+    ));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1219,6 +1219,13 @@
       "when": 1784448000000,
       "tag": "0173_add_check_constraints_phase2",
       "breakpoints": true
+    },
+    {
+      "idx": 174,
+      "version": "7",
+      "when": 1784534400000,
+      "tag": "0174_fix_groundskeeper_event_constraint",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1354,7 +1354,7 @@ export const groundskeeperRuns = pgTable(
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     taskName: text("task_name").notNull(),
-    event: text("event").notNull(), // success | failure | error | circuit_breaker_tripped | skipped
+    event: text("event").notNull(), // success | failure | error | circuit_breaker_tripped | circuit_breaker_reset | half_open_attempt | half_open_success | skipped
     success: boolean("success").notNull(),
     durationMs: integer("duration_ms"),
     summary: text("summary"),


### PR DESCRIPTION
## Summary

- Migration 0173 failed on deploy because the CHECK constraint for `groundskeeper_runs.event` omitted 3 valid event types that exist in production data: `circuit_breaker_reset`, `half_open_attempt`, `half_open_success`
- These are defined in `VALID_GK_EVENTS` (api-types.ts) and used by the groundskeeper circuit breaker
- Adds migration 0174 to drop and recreate the constraint with all 8 valid event types
- Also fixes the original 0173 constraint and the schema.ts comment

## Context

The release PR #4167 deploy failed at the ArgoCD PreSync phase — the migration job hit backoff limit (3 retries). The old server continued running (no outage). This PR unblocks the deploy.

## Test plan

- [x] Verified production data: `half_open_attempt` (414 rows) and `half_open_success` (9 rows) exist
- [x] Constraint values match `VALID_GK_EVENTS` in api-types.ts
- [x] Migration 0174 is idempotent (DROP IF EXISTS + EXCEPTION WHEN duplicate_object)
- [x] Gate check passes

Generated with [Claude Code](https://claude.com/claude-code)