### PR TITLE
fix: correct budget math in flagship-curate research loop

### DIFF
--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -624,11 +624,18 @@ async function curateEntity(
       const batchSize = 10;
       for (let i = 0; i < records.length; i += batchSize) {
         const batch = records.slice(i, i + batchSize);
+        // Recompute remaining budget at each batch — research calls accumulate
+        // cost in the tracker, so a stale captured value underestimates what's left.
+        const remaining = budget - tracker.totalCost;
+        if (remaining <= 0) {
+          console.log(`  ${c.yellow}Budget exhausted during research${c.reset}`);
+          break;
+        }
         const batchResults = await researchSourcesForRecords(
           entity,
           batch,
           tracker,
-          budgetRemaining - tracker.totalCost,
+          remaining,
         );
         researched.push(...batchResults);
 


### PR DESCRIPTION
## Summary

Follow-up to PR #4163 (QUA-220). The research batch loop was passing a double-subtracted budget value, causing premature skipping of research.

## The bug

```ts
const budgetRemaining = budget - tracker.totalCost;  // computed once
// ...
for (const batch of batches) {
  await researchSourcesForRecords(entity, batch, tracker, budgetRemaining - tracker.totalCost);
  //                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  //                                   = (budget - tracker.totalCost) - tracker.totalCost
  //                                   = budget - 2 * tracker.totalCost
}
```

As research accumulated cost in the tracker, the value passed shrank twice as fast as it should have. `researchSourcesForRecords` then compared the estimated batch cost against this wrong value and reported "estimated cost exceeds remaining budget" even when budget was left.

## The fix

Recompute `remaining = budget - tracker.totalCost` fresh at each batch iteration, and break early if exhausted.

## Test plan

- [x] Existing 13 tests still pass
- [x] TypeScript compiles (no new errors from flagship-curate)
- [x] No safety concern (bug was in the conservative direction — budget was under-estimated, not over-spent)

Generated with [Claude Code](https://claude.com/claude-code)