### PR TITLE
fix: post-merge cleanup for PRs #4158 and #4173

### DIFF
--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -764,6 +764,11 @@ export async function syncPolicyStakeholders(typedEntities) {
   }
 
   // Sync individually to handle FK errors gracefully (some entityIds may not exist in PG)
+  // Bypass sourcing enforcement: stakeholder YAML does not yet carry sourcing data;
+  // hard enforcement was enabled in QUA-248 before coverage was backfilled.
+  // TODO(QUA-248): remove forceSkipSourcing once stakeholder sourcing is backfilled.
+  const skipSourcing =
+    'forceSkipSourcing=true&reason=build-data%3Apolicy-stakeholder-sync';
   let synced = 0;
   let skipped = 0;
   try {
@@ -771,7 +776,7 @@ export async function syncPolicyStakeholders(typedEntities) {
     const batchSize = 50;
     for (let i = 0; i < items.length; i += batchSize) {
       const batch = items.slice(i, i + batchSize);
-      const resp = await fetch(`${serverUrl}/api/policy-stakeholders/sync`, {
+      const resp = await fetch(`${serverUrl}/api/policy-stakeholders/sync?${skipSourcing}`, {
         method: 'POST',
         headers,
         body: JSON.stringify({ items: batch }),
@@ -784,7 +789,7 @@ export async function syncPolicyStakeholders(typedEntities) {
         // Batch failed — try items individually to skip bad FK references
         for (const item of batch) {
           try {
-            const r = await fetch(`${serverUrl}/api/policy-stakeholders/sync`, {
+            const r = await fetch(`${serverUrl}/api/policy-stakeholders/sync?${skipSourcing}`, {
               method: 'POST',
               headers,
               body: JSON.stringify({ items: [item] }),

--- a/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
+++ b/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
@@ -374,6 +374,15 @@ const entries: AutomationEntry[] = [
     status: "disabled",
     file: "apps/groundskeeper/src/tasks/issue-responder.ts",
   },
+  {
+    name: "GK: TableBase Scan",
+    type: "Groundskeeper",
+    schedule: "Daily 05:00 UTC",
+    description:
+      "Scans TableBase records for sourcing coverage and writes scanner-results artifacts used by the coverage dashboard.",
+    status: "active",
+    file: "apps/groundskeeper/src/tasks/tablebase-scan.ts",
+  },
 
   // -- K8s Long-Running Services --
   {
@@ -610,6 +619,7 @@ export function AutomationLandscapeContent() {
               <li>03:00 -- Snapshot retention cleanup (GK)</li>
               <li>04:00 -- Wiki-server data export + Source-check (Mon)</li>
               <li>04:30 -- Resources snapshot refresh</li>
+              <li>05:00 -- TableBase scan (GK)</li>
               <li>06:00 -- Data quality snapshot (GK) + Auto-update enqueue (GK)</li>
               <li>07:00 -- Daily data validation + Entity/fact sync (Mon)</li>
               <li>07:30 -- Scheduled maintenance (weekdays)</li>


### PR DESCRIPTION
## Summary

Post-merge review of PRs #4158 (automation landscape) and #4173 (expand sourcing enforcement) found two issues worth fixing.

### PR #4173 — build-data breakage for policy-stakeholders

QUA-248 enabled server-side hard enforcement of sourcing for `policy-stakeholders`, but `syncPolicyStakeholders` in `apps/web/scripts/lib/wiki-server-data.mjs` does not attach `sourcing` data to sync items (stakeholder YAML has no sourcing field yet).

Every build-data run would now silently reject all stakeholder records with 400 errors (the build falls through on sync failure, so build passes — but stakeholders stop flowing to the `policy_stakeholders` and `things` tables).

Fix: pass `?forceSkipSourcing=true&reason=build-data:policy-stakeholder-sync` to the sync calls. This is the documented escape hatch for pre-backfill pipelines (same pattern used by personnel/grants import scripts).

Follow-up: QUA-248 should backfill sourcing on stakeholder YAML, then we can drop the bypass.

### PR #4158 — missing groundskeeper task

The automation landscape dashboard omitted the `tablebase-scan` groundskeeper task. It is enabled by default (`TASK_TABLEBASE_SCAN_ENABLED=true`) and runs daily at 05:00 UTC — verified in `apps/groundskeeper/src/config.ts`.

Added the entry and a 05:00 line in the daily timeline.

## Test plan

- [x] `pnpm build` passes
- [x] Read the escape-hatch semantics in `sourcing-enforcement.ts` to confirm `forceSkipSourcing=true&reason=...` is the intended mechanism