### PR TITLE
feat: mandatory self-review for dispatched subagents (QUA-251)

### DIFF
--- a/.claude/rules/dispatched-agent-review.md
+++ b/.claude/rules/dispatched-agent-review.md
@@ -1,0 +1,63 @@
+# Dispatched Agent Review — MANDATORY
+
+When a coordinator session dispatches subagents to work on issues and create PRs, **every dispatch prompt MUST instruct the agent to run `/agent-review-pr` before creating the PR**. Do not instruct subagents to run `pnpm crux gh pr create` directly.
+
+## Why
+
+The existing `/agent-ship` workflow has `/agent-review-pr` as a mandatory, non-skippable Step 2b. But when a coordinator dispatches subagents with prompts like "do the work, run `pnpm build`, run `pnpm crux gh pr create`", the subagents bypass the entire `/agent-ship` flow and skip the review step.
+
+Session on 2026-04-11: 15 PRs dispatched across 2 waves with "skip-the-ship-flow" prompts. All 15 passed build+tests. Retrospective review found **8 real issues (~53% hit rate)**, including:
+- 2 deploy-blockers (CHECK constraints missing enum values, silent sync failure)
+- 1 critical correctness bug (validation ran after transaction commit)
+- 1 budget double-subtraction
+- 1 partial sweep (missed a 3rd entry point for the same check)
+- 1 cross-service deploy-order bug
+- 1 false claim of "simplification" that was never actually committed
+
+The review step exists. It works. Dispatched agents just weren't reaching it.
+
+## How to apply
+
+### For coordinators dispatching subagents
+
+Every dispatch prompt ending in "create a PR" must include this phrase:
+
+```
+### Before creating the PR:
+Run `/agent-review-pr` on your changes — it's adaptive and scales to PR size. Address every finding before proceeding to PR creation.
+
+### Creating the PR:
+Use `/agent-ship` (not raw `pnpm crux gh pr create`). This runs the full ship workflow including the mandatory review step, deploy task detection, Linear updates, and session logging.
+```
+
+### For the coordinator after dispatch
+
+When a dispatched agent reports completion, verify:
+1. `gh pr view <N>` — PR exists
+2. `gh pr view <N> --json body --jq '.body' | grep -i "review"` — review was mentioned in PR body (optional heuristic)
+3. Read the agent's report for the phrase "ran `/agent-review-pr`" or "ran `/agent-ship`"
+
+If an agent reports creating a PR without mentioning the review step, **run `/agent-review-pr` on the PR yourself before considering it shipped**.
+
+### Never trust claims without verification
+
+If an agent claims to have simplified code, fixed bugs, or applied review findings:
+- `git log --oneline <branch> -5` — confirm commits exist
+- `git show --stat <commit>` — confirm the claim matches the diff
+- `gh pr diff <N>` — confirm the remote state
+
+See `.claude/memory/feedback_verify_agent_claims.md` for the pattern.
+
+## Anti-patterns to avoid
+
+**Bad dispatch prompt:**
+```
+Do the work. Run `pnpm build` and `pnpm test`. Then push and run `pnpm crux gh pr create`.
+```
+
+**Good dispatch prompt:**
+```
+Do the work. Run `pnpm build` and `pnpm test`. Then run `/agent-review-pr` on your changes. Address every finding. Then run `/agent-ship` to push, verify CI, and close the session.
+```
+
+The difference: 1 extra line, 50%+ bug rate reduction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 - `.claude/rules/auto-update-system.md` — Auto-update system
 - `.claude/rules/worktree-isolation-bug.md` — Known Claude Code worktree CWD bug (DO NOT USE `isolation: "worktree"`)
 - `.claude/rules/linear-integration.md` — Linear-GitHub integration, branch naming, auto-close, `crux linear` commands
+- `.claude/rules/dispatched-agent-review.md` — Dispatched subagents MUST run `/agent-review-pr` + `/agent-ship`, never raw `gh pr create`
 
 ## Subsystem Maps — Read BEFORE proposing work in these areas
 

--- a/crux/lib/dispatch-prompt-template.ts
+++ b/crux/lib/dispatch-prompt-template.ts
@@ -1,0 +1,48 @@
+/**
+ * Standard review/ship instructions to append to subagent dispatch prompts.
+ *
+ * Coordinators dispatching subagents should include the output of
+ * `reviewAndShipInstructions()` at the end of their dispatch prompt so the
+ * subagent runs `/agent-review-pr` and `/agent-ship` instead of creating PRs
+ * directly via `pnpm crux gh pr create`.
+ *
+ * Background: see `.claude/rules/dispatched-agent-review.md`. A session on
+ * 2026-04-11 dispatched 15 PRs where subagents bypassed the ship flow. ~53%
+ * had real bugs that only adversarial review caught.
+ */
+
+/**
+ * Standard instructions to run /agent-review-pr and /agent-ship at the end of
+ * a subagent's work. Append this to the dispatch prompt after the task-specific
+ * body.
+ */
+export function reviewAndShipInstructions(): string {
+  return `
+### Before creating the PR
+
+Run \`/agent-review-pr\` on your changes — it's adaptive and scales to PR size. Address every finding before proceeding. Do NOT skip this step. Do NOT use \`pnpm crux gh pr create\` directly.
+
+### Creating the PR
+
+Use \`/agent-ship\` — it runs the full workflow including the mandatory review step, deploy task detection, Linear updates, and session logging. Do NOT bypass it.
+
+### Reporting back
+
+When you report completion, include:
+1. The PR URL (confirm via \`gh pr view <N>\`)
+2. Output of \`git show --stat HEAD\` so the coordinator can verify your commit actually contains the claimed changes
+3. A summary of review findings (if any) and what you did about them
+`.trimStart();
+}
+
+/**
+ * A shorter variant for quick dispatches where the full instructions would be
+ * overkill (e.g. trivial typo fixes). Still points to /agent-ship.
+ */
+export function shortShipInstructions(): string {
+  return `
+### Shipping
+
+When done, use \`/agent-ship\` (not raw \`gh pr create\`). It handles review, deploy tasks, and Linear updates.
+`.trimStart();
+}


### PR DESCRIPTION
## Summary

When a coordinator dispatches subagents with prompts like "do the work, run `pnpm build`/`pnpm test`, then `pnpm crux gh pr create`", the subagents bypass `/agent-ship` entirely and skip the mandatory `/agent-review-pr` step (which is Step 2b of `/agent-ship`).

**Session evidence (2026-04-11):** 15 PRs dispatched this way. Retrospective review found 8 real issues (~53% hit rate):
- 2 deploy-blockers (CHECK constraints missing enum values, policy-stakeholders silent sync failure)
- 1 critical transaction bug (SessionEnd validation ran after commit, saved bad state)
- 1 budget math double-subtraction
- 1 partial sweep (missed 3rd entry point for same check)
- 1 cross-service deploy-order bug
- 1 false claim of "simplification" never actually committed
- 1 dead endpoint after follow-up PR removed it

## What this PR adds

- **`.claude/rules/dispatched-agent-review.md`** — The rule itself. Explains why the existing `/agent-review-pr` step wasn't reaching dispatched agents, and the mandatory pattern going forward.
- **`crux/lib/dispatch-prompt-template.ts`** — Helper exporting `reviewAndShipInstructions()` and `shortShipInstructions()` that coordinators append to dispatch prompts.
- **`CLAUDE.md`** — Reference to the rule in Detailed Guides.

This PR does NOT change the existing `/agent-ship` / `/agent-review-pr` workflow — it documents the convention that dispatched subagents must go through `/agent-ship` to reach the already-mandatory review step.

## Test plan

- [x] `pnpm build` — passes (no behavior changed, only docs + an unused helper)
- [x] New files are well-formed markdown / TypeScript
- [x] CLAUDE.md reference works

Fixes QUA-251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive procedural guidelines establishing standardized requirements for code review and approval workflows throughout the development pipeline.

* **Chores**
  * Implemented workflow instruction templates and coordination utilities to ensure consistent execution of development processes and proper integration of all workflow stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->