### PR TITLE
refactor: migrate /api/source-checks/ calls to /api/sourcing/ (actually reduce legacy refs)

### DIFF
--- a/crux/lib/sourcing-context.ts
+++ b/crux/lib/sourcing-context.ts
@@ -64,7 +64,7 @@ async function fetchActionableVerdicts(
     ACTIONABLE_VERDICTS.map((verdict) =>
       apiRequest<VerdictsResponse>(
         'GET',
-        `/api/source-checks/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
+        `/api/sourcing/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
       )
     )
   );

--- a/crux/lib/wiki-server/__tests__/sourcing.test.ts
+++ b/crux/lib/wiki-server/__tests__/sourcing.test.ts
@@ -47,7 +47,7 @@ describe('getVerdictsByEntity', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/by-entity/sid_abc123',
+      '/api/sourcing/by-entity/sid_abc123',
     );
   });
 
@@ -64,7 +64,7 @@ describe('getVerdictsByEntity', () => {
     });
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toContain('/api/source-checks/by-entity/sid_abc123?');
+    expect(url).toContain('/api/sourcing/by-entity/sid_abc123?');
     expect(url).toContain('limit=10');
     expect(url).toContain('offset=20');
     expect(url).toContain('verdict=contradicted');
@@ -91,7 +91,7 @@ describe('getVerdictsByEntity', () => {
     await getVerdictsByEntity('sid_abc123');
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toBe('/api/source-checks/by-entity/sid_abc123');
+    expect(url).toBe('/api/sourcing/by-entity/sid_abc123');
     expect(url).not.toContain('?');
   });
 });
@@ -117,7 +117,7 @@ describe('getVerdictsByPage', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/by-page/anthropic',
+      '/api/sourcing/by-page/anthropic',
     );
   });
 
@@ -156,7 +156,7 @@ describe('getFailures', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/failures',
+      '/api/sourcing/failures',
     );
   });
 
@@ -210,7 +210,7 @@ describe('getStaleVerdicts', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/stale',
+      '/api/sourcing/stale',
     );
   });
 
@@ -264,7 +264,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/verdicts?verdict=contradicted&limit=200',
+      '/api/sourcing/verdicts?verdict=contradicted&limit=200',
     );
   });
 
@@ -278,7 +278,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/verdicts?verdict=confirmed&limit=50',
+      '/api/sourcing/verdicts?verdict=confirmed&limit=50',
     );
   });
 });

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -34,14 +34,14 @@ export type VerdictListEntry = ListVerdictsResult['verdicts'][number];
 export async function storeEvidence(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreEvidenceResult>> {
-  return apiRequest<StoreEvidenceResult>('POST', '/api/source-checks/evidence', body);
+  return apiRequest<StoreEvidenceResult>('POST', '/api/sourcing/evidence', body);
 }
 
 /** Store an aggregate verdict for a record. */
 export async function storeVerdict(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreVerdictResult>> {
-  return apiRequest<StoreVerdictResult>('POST', '/api/source-checks/verdicts', body);
+  return apiRequest<StoreVerdictResult>('POST', '/api/sourcing/verdicts', body);
 }
 
 /** List verdicts with optional filters. */
@@ -56,7 +56,7 @@ export async function listVerdicts(
   const qs = params.toString();
   return apiRequest<ListVerdictsResult>(
     'GET',
-    `/api/source-checks/verdicts${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/verdicts${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -67,7 +67,7 @@ export async function getVerdictByRecord(
 ): Promise<ApiResult<VerdictByRecordResult>> {
   return apiRequest<VerdictByRecordResult>(
     'GET',
-    `/api/source-checks/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
+    `/api/sourcing/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
   );
 }
 
@@ -82,13 +82,13 @@ export async function getEvidenceByRecord(
   const qs = params.toString();
   return apiRequest<EvidenceByRecordResult>(
     'GET',
-    `/api/source-checks/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
+    `/api/sourcing/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
   );
 }
 
 /** Get sourcing statistics. */
 export async function getSourcingStats(): Promise<ApiResult<SourcingStatsResult>> {
-  return apiRequest<SourcingStatsResult>('GET', '/api/source-checks/stats');
+  return apiRequest<SourcingStatsResult>('GET', '/api/sourcing/stats');
 }
 
 /** Get records due for re-check. */
@@ -101,6 +101,6 @@ export async function getDueForRecheck(
   const qs = params.toString();
   return apiRequest<DueForRecheckResult>(
     'GET',
-    `/api/source-checks/due-for-recheck${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/due-for-recheck${qs ? `?${qs}` : ''}`,
   );
 }

--- a/crux/lib/wiki-server/sourcing.ts
+++ b/crux/lib/wiki-server/sourcing.ts
@@ -39,7 +39,7 @@ export async function getVerdictsByType(
 ): Promise<ApiResult<VerdictsResponse>> {
   return apiRequest<VerdictsResponse>(
     'GET',
-    `/api/source-checks/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
+    `/api/sourcing/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
   );
 }
 
@@ -57,7 +57,7 @@ export async function getVerdictsByEntity(
   const qs = params.toString();
   return apiRequest<ByEntityResponse>(
     'GET',
-    `/api/source-checks/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -74,7 +74,7 @@ export async function getVerdictsByPage(
   const qs = params.toString();
   return apiRequest<ByPageResponse>(
     'GET',
-    `/api/source-checks/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -99,7 +99,7 @@ export async function getFailures(
   const qs = params.toString();
   return apiRequest<FailuresResponse>(
     'GET',
-    `/api/source-checks/failures${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/failures${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -124,7 +124,7 @@ export async function getStaleVerdicts(
   const qs = params.toString();
   return apiRequest<StaleResponse>(
     'GET',
-    `/api/source-checks/stale${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/stale${qs ? `?${qs}` : ''}`,
   );
 }
 

--- a/crux/scripts/backfill-fact-entity-ids.ts
+++ b/crux/scripts/backfill-fact-entity-ids.ts
@@ -137,7 +137,7 @@ async function fetchNullEntityVerdicts(): Promise<VerdictRow[]> {
   while (rows.length < total) {
     const res = await apiFetch(
       "GET",
-      `/api/source-checks/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
+      `/api/sourcing/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
     );
     if (!res.ok) {
       console.error(`Failed to fetch verdicts: ${res.error}`);
@@ -245,7 +245,7 @@ async function main() {
       sourcesChecked: row.sourcesChecked ?? undefined,
     };
 
-    const res = await apiFetch("POST", "/api/source-checks/verdicts", body);
+    const res = await apiFetch("POST", "/api/sourcing/verdicts", body);
 
     if (res.ok) {
       success++;

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -450,7 +450,7 @@ async function scanSourceQuality(): Promise<TableScanResult> {
   while (true) {
     const result = await apiRequest<{ verdicts: VerdictRow[]; total: number }>(
       'GET',
-      `/api/source-checks/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
+      `/api/sourcing/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
     );
     if (!result.ok) {
       console.warn(`[tablebase] Failed to fetch unverifiable verdicts: ${result.message}`);

--- a/crux/validate/validate-sourcing-names.ts
+++ b/crux/validate/validate-sourcing-names.ts
@@ -52,7 +52,7 @@ export async function validateSourcingNames(): Promise<{
     // Fetch a sample of verdicts
     const verdictsResult = await apiRequest<VerdictsResponse>(
       'GET',
-      `/api/source-checks/verdicts?record_type=${recordType}&limit=20`
+      `/api/sourcing/verdicts?record_type=${recordType}&limit=20`
     );
 
     if (!verdictsResult.ok) {
@@ -92,7 +92,7 @@ export async function validateSourcingNames(): Promise<{
     const idList = [...recordIds].join(',');
     const namesResult = await apiRequest<ResolveNamesResponse>(
       'GET',
-      `/api/source-checks/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
+      `/api/sourcing/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
     );
 
     if (!namesResult.ok) {


### PR DESCRIPTION
Instead of bumping the sourcing ratchet baseline every time it fails, migrate the actual client calls.

## Changes
- Migrated 16 `/api/source-checks/` URL references to `/api/sourcing/` across crux client code (scanner, backfill scripts, validation, wiki-server clients)
- Updated matching test expectations in `sourcing.test.ts`

## Safety
Server-side backward-compat alias at `apps/wiki-server/src/app.ts:207` maps `/api/source-checks/*` → `sourcingRoute` so there's no runtime breakage. The alias can be removed later when all callers are migrated.

## Impact
- Sourcing ratchet count: 23 → 7 (back to baseline)
- Unblocks main CI without bumping the baseline
- Reduces legacy refs by 16 (substantial progress toward QUA-238)

## Test
- [x] `pnpm test` — 261 test files, 5460 tests pass

See QUA-238.