### PR TITLE
content: remove placeholder Key Links from ai-actor-feedback-loops

### DIFF
--- a/content/docs/knowledge-base/models/ai-actor-feedback-loops.mdx
+++ b/content/docs/knowledge-base/models/ai-actor-feedback-loops.mdx
@@ -26,13 +26,6 @@ import {EntityLink, R, KBF, Calc, DataInfoBox, DataExternalLinks} from '@compone
 | **Relation to Other Models** | Extends <EntityLink id="E418">AI Safety Multi-Actor Strategic Landscape</EntityLink>; complements <EntityLink id="E417">AI Risk Feedback Loop & Cascade Model</EntityLink> |
 | **Key Limitation** | Quantitative estimates are approximate; loop interactions are nonlinear and context-dependent |
 
-## Key Links
-
-| Source | Link |
-|--------|------|
-| Official Website | [zonkafeedback.com](https://www.zonkafeedback.com/blog/ai-feedback-loop) |
-| Wikipedia | [en.wikipedia.org](https://en.wikipedia.org/wiki/Reinforcement_learning_from_human_feedback) |
-
 ## Overview
 
 The AI Actor Feedback Loops model maps the causal relationships between the major actors in the AI safety ecosystem—frontier labs, governments, investors, talent pools, and open-source communities—and analyzes how their interactions create self-reinforcing dynamics that shape the trajectory of AI development and governance. Unlike models focused on a single feedback mechanism (such as the <EntityLink id="E296">Sycophancy Feedback Loop Model</EntityLink> or the <EntityLink id="E196">AI Media-Policy Feedback Loop Model</EntityLink>), this framework examines the full multi-actor system to identify where feedback loops accelerate risk and where intervention points might exist.


### PR DESCRIPTION
## Summary

Follow-up cleanup for an already-merged Phase 1 page. The `crux w create` pipeline injected a two-row "Key Links" table with off-topic placeholders (zonkafeedback.com customer-feedback SaaS, generic Wikipedia RLHF page) that flagged on coderabbit review of PR #4197 but after Phase 1 (#4191) had already merged.

Removing the section entirely — the page's own Sources section holds the actual citations (Tom Davidson / Forethought, Glickman & Sharot, etc.).

## Test plan
- [x] Gate passes (`pnpm crux w validate gate --scope=content`)
- [ ] CI green

## Context
Part of the [AI Power & Influence Mapping](https://linear.app/quantifieduncertainty/project/ai-power-and-influence-mapping-b2a41c770e0b) follow-up hygiene.
