### PR TITLE
fix: align service_health_incidents.severity CHECK with actual usage

### DIFF
--- a/apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql
+++ b/apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql
@@ -152,7 +152,7 @@ END $$;
 DO $$ BEGIN
   ALTER TABLE "service_health_incidents"
     ADD CONSTRAINT chk_shi_severity
-    CHECK (severity IN ('P0', 'P1', 'P2'));
+    CHECK (severity IN ('critical', 'warning', 'info'));
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 

--- a/apps/wiki-server/drizzle/0175_fix_shi_severity_constraint.sql
+++ b/apps/wiki-server/drizzle/0175_fix_shi_severity_constraint.sql
@@ -1,0 +1,21 @@
+-- Fix migration 0173: the CHECK constraint for service_health_incidents.severity
+-- used ('P0', 'P1', 'P2') but the application writes 'critical' (per
+-- groundskeeper/src/incident-buffer.ts and health-check.ts). Production has 4
+-- rows with severity='critical', causing the ADD CONSTRAINT in 0173 to fail.
+--
+-- The P0/P1/P2 taxonomy was never implemented in code. Align the constraint
+-- with actual usage: critical/warning/info.
+--
+-- Strategy: drop the old constraint if it exists, then create the correct one.
+
+DO $$ BEGIN
+  ALTER TABLE "service_health_incidents" DROP CONSTRAINT IF EXISTS chk_shi_severity;
+EXCEPTION WHEN undefined_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "service_health_incidents"
+    ADD CONSTRAINT chk_shi_severity
+    CHECK (severity IN ('critical', 'warning', 'info'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1226,6 +1226,13 @@
       "when": 1784534400000,
       "tag": "0174_fix_groundskeeper_event_constraint",
       "breakpoints": true
+    },
+    {
+      "idx": 175,
+      "version": "7",
+      "when": 1784620800000,
+      "tag": "0175_fix_shi_severity_constraint",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Migration 0173 failed on deploy (again): the CHECK constraint for `service_health_incidents.severity` used `('P0', 'P1', 'P2')` but the groundskeeper actually writes `'critical'` (see `groundskeeper/src/incident-buffer.ts` and `health-check.ts`).
- Production has 4 rows with `severity = 'critical'`, causing the ADD CONSTRAINT to fail.
- The `P0/P1/P2` taxonomy was never implemented in code.
- Adds migration 0175 to drop and recreate the constraint with the correct values.
- Updates 0173 so re-runs don't fail.
- I also systematically checked **all 36 other CHECK constraints** in migration 0173 against production data — **this is the only mismatch**.

## Context

This is the second unblock PR for release #4180 — first was #4178 (groundskeeper event types). The old server continues running, no outage.

## Test plan

- [x] Queried production data for all 36 other constraints in 0173 — all clean
- [x] Confirmed `severity: "critical"` is the only value written by groundskeeper (grep across apps/groundskeeper/)
- [x] Migration 0175 is idempotent (DROP IF EXISTS + EXCEPTION WHEN duplicate_object)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation for service health incident severity levels to ensure consistent enforcement of severity categorization across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->