### PR TITLE
chore: maintenance sweep 2026-04-12 (audit + stale issue triage)

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -150,7 +150,7 @@ audits:
     frequency: weekly
     added: "2026-03-04"
     added_by_pr: 1630
-    last_checked: "2026-04-05"
+    last_checked: "2026-04-12"
     last_result: pass
     history:
       - date: "2026-03-29"
@@ -160,6 +160,10 @@ audits:
       - date: "2026-04-05"
         result: pass
         checked_by: "manual"
+      - date: "2026-04-12"
+        result: pass
+        checked_by: "agent-maintain"
+        notes: "vercel.json ignoreCommand is correct (apps/web/vercel.json: exits 1 only when VERCEL_GIT_COMMIT_REF=production, else exits 0 to skip). Dashboard verification not performed (requires Vercel UI auth)."
   - id: active-agents-dashboard-adoption
     category: feature-health
     description: "Agent Activity dashboard (E1281) is populated with data and referenced by maintenance or agent sessions"


### PR DESCRIPTION
## Summary
- Recorded `vercel-production-only` audit as pass (config verified; dashboard check deferred)
- Closed 4 stale `priority:low` legacy GitHub issues (#1256, #1484, #1689, #1672) with note to refile in Linear if still wanted

## Context
Maintenance sweep for 2026-04-12. The `groundskeeper-health` audit remains overdue — it requires the System Health dashboard (E927) which needs auth not available from an agent slot; deferred to a coordinator session.

## Test plan
- [x] No code changes; config-only update to `.claude/audits.yaml`
- [x] Gate: N/A for YAML-only config edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audit tracking records with verification status and configuration notes for production environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->