### PR TITLE
docs: mandatory issue tracking + session-end enumeration

### DIFF
--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -58,6 +58,28 @@ Then read `.claude/wip-checklist.md` and keep it updated as you work.
 
 ## Step 2: Session End — BEFORE considering work complete
 
+### Step 2a: Enumerate every problem you observed this session — MANDATORY
+
+Before running `/agent-ship` or `/agent-end`, produce an explicit list of **every problem you noticed during the session**, including ones that weren't part of your task. For each, mark one of three dispositions:
+
+- `fixed` — resolved inside the PR(s) this session shipped. No ticket needed.
+- `filed:QUA-NNN` — a Linear (or legacy GitHub) ticket exists. Paste the ID. If you're the one filing, file before ending.
+- `deferred:<reason>` — knowingly not fixed and not filed. Reason must be one the user would accept (e.g., "out of scope and already known — see QUA-NNN", "speculative, no observed impact yet"). "I'll remember" is not a valid deferral.
+
+This list should appear in your session-end summary to the user, verbatim. Example:
+
+```
+Observed this session:
+- Build fails for entities without lastEdited         → filed:QUA-412
+- Duplicate validation block in gate.ts               → deferred: tech debt, not blocking
+- /internal/facts 404 on prod                         → fixed (this PR)
+- QUA-156 marked Done but migration actually stuck    → filed:QUA-302 (Urgent)
+```
+
+You cannot end the session until every observation has a disposition. **"I'll remember for next time" is explicitly forbidden** — the 2026-04-11 incident cascade happened because problems were noticed but never tracked. See `.claude/rules/proactive-github-filing.md` § "Mandatory tracking — red flags" for which observations *must* be filed (not just deferred).
+
+### Step 2b: Close out
+
 **If shipping a PR:** Run `/agent-ship`. It verifies the checklist, polishes the PR, pushes, monitors CI, and closes the session.
 
 **If NOT shipping** (research, abandoned, maintenance): Run `/agent-end`. It marks the session as completed, updates Linear/GitHub issues, and cleans up local artifacts.

--- a/.claude/rules/proactive-github-filing.md
+++ b/.claude/rules/proactive-github-filing.md
@@ -63,6 +63,28 @@ For longer descriptions, use `--description-file=/tmp/description.md`.
 - **Evidence required**: You must have *observed* the problem in the current session — do not file speculative or hypothetical issues. Point to a specific file, error message, or behavior you encountered.
 - **Volume target**: 0-2 issues per session is normal. If you're finding 10+ problems, file the top 2-3 and batch the rest into one umbrella issue.
 
+## Mandatory tracking — red flags that MUST produce a ticket
+
+The patterns below have a documented history of getting lost when an agent "just flags it verbally" or "assumes someone else will handle it." If you observe any of these, **you must file or reopen a Linear ticket before ending the session.** Not doing so is a violation of this rule, not a judgement call.
+
+| Red flag | Required action | Rationale |
+|---|---|---|
+| **Prod incident observed** (failed deploy, stuck migration, 5xx spike, prod endpoint returning wrong status) | File **Urgent/P0** Linear ticket with root cause + prescribed fix + link to evidence. Do NOT just mention it in PR comments or chat. | 2026-04-11 incident: wiki-server deploy stuck 12+h because the failure was "noticed" but never ticketed. |
+| **Symptom patch** (baseline bump, `test.skip()`, catch-and-swallow in an error path that previously threw, commented-out code, `// TODO` without issue number, silencing a validator you don't understand) | File a separate ticket naming (a) the symptom that was patched, (b) the suspected root cause, (c) what would let us unpatch. Link from the patching PR. | Symptom patches are permanent by default. Without a ticket, nobody ever unpatches them. |
+| **Misdiagnosis discovered** (you or another session filed a ticket with the wrong root cause, or a ticket's scope turned out to be pointing at the wrong thing) | Close the wrong ticket with a "misdiagnosed — actual cause is X" comment **and** file the correct ticket. Don't silently abandon. | Abandoned wrong tickets waste future agent time (they're still in the backlog). |
+| **Premature "Done"** (parent/epic ticket was closed while residual work remains — e.g., PR merged closing the ticket but a follow-up piece is still needed) | Reopen the parent ticket with a "partial completion — see remaining work" comment, OR file a follow-up ticket and link it before ending the session. | 2026-04-11 incident: QUA-156 closed Done when its migration actually bricked the deploy. Closure masked the failure. |
+| **N+ related symptoms in a narrow window** (≥2 consecutive baseline bumps in the same file, ≥2 PRs reverting each other, ≥2 patches silencing the same validator) | **Stop patching.** File a ticket describing the pattern and why you stopped. Escalate to the coordinator. | 2026-04-11 incident: 7 PRs in 24h patched sourcing-ratchet symptoms while the real problem (stuck deploy) was untracked. Any one agent stopping at symptom #2 would have caught it. |
+
+### When in doubt, file
+
+If you're unsure whether something meets the bar above, **file it.** False-positive tickets are cheap (close with "actually fine"). False-negative missed root causes are expensive — see the 2026-04-11 cascade.
+
+### Not a red flag
+
+- Things you fix completely in this session — no ticket needed, the PR is the record.
+- Style/cleanup observations you have no evidence hurt anyone — use the "Do NOT file issues for..." list above.
+- Work you're about to ship in the same PR — not a follow-up, just part of the PR.
+
 ## GitHub Discussions
 
 Use `crux gh epic create` for **open-ended questions** that don't have a clear fix ("Should we restructure X?", "What's our strategy for Y?"). Issues are for concrete actionable tasks; discussions are for decisions that need human input. Discussions stay on GitHub — they are not tracked in Linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ pnpm crux sys agent-checklist init "Task description" --type=X   # if not on an 
 
 At session end, run `/agent-ship` (if shipping a PR) or `/agent-end` (if not). Never push directly to `main`.
 
+**Track what you discover.** Before ending any session, enumerate every problem you observed and mark each `fixed | filed:QUA-NNN | deferred:<reason>`. Certain red flags (prod incidents, symptom patches, misdiagnoses, premature "Done", N+ repeated symptoms) MUST produce a Linear ticket — "I'll remember" is not a valid disposition. See `.claude/rules/proactive-github-filing.md` § "Mandatory tracking" and `.claude/rules/agent-session-workflow.md` § "Step 2a".
+
 ## Quick Reference
 
 Commands are organized into groups by data layer. Use short prefixes for convenience:


### PR DESCRIPTION
## Summary

Addresses the systemic failure mode from the 2026-04-11/12 incident (tracked in [QUA-297](https://linear.app/quantifieduncertainty/issue/QUA-297) and [QUA-302](https://linear.app/quantifieduncertainty/issue/QUA-302)). During that window, problems were observed but never tracked, so seven+ symptom-management PRs patched the wrong things for 12 hours while the real issue (stuck migration 0173) sat unnoticed.

## Changes — docs only, no code

1. **`.claude/rules/proactive-github-filing.md`** — new section **"Mandatory tracking — red flags that MUST produce a ticket"**. Five patterns with explicit required actions: prod incident, symptom patch, misdiagnosis, premature Done, N+ repeated symptoms.

2. **`.claude/rules/agent-session-workflow.md`** — new **Step 2a** before `/agent-ship`/`/agent-end`: enumerate every problem observed this session, mark each `fixed | filed:QUA-NNN | deferred:<reason>`. "I'll remember" is explicitly disallowed.

3. **`CLAUDE.md`** — one paragraph under MANDATORY FIRST ACTION pointing at both new rule sections.

## Why this works

The existing rules say "file issues when you find friction" but are advisory. The 2026-04-11 retrospective shows agents consistently skipped this in practice. Making the session-end enumeration non-optional creates the forcing function that was missing.

## Test plan

- [x] Gate check passes (46 checks green)
- [x] No code changes, so no unit tests needed
- [x] First real session after merge: verify Step 2a enumeration shows up in /agent-end output

## Rollback

`git revert`. No migrations, no env vars, no runtime impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow guidelines for session completion and problem tracking to enhance issue disposition tracking and accountability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->