### PR TITLE
feat(pr-patrol): fleet-level health scanner (QUA-298 Phase 1)

### DIFF
--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  evaluateDeployStatus,
+  evaluateMainCi,
+  combineHealth,
+  DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
+  MAIN_CI_RED_STREAK_MIN,
+  DEPLOY_STALE_THRESHOLD_HOURS,
+  DEPLOY_STUCK_SCORE,
+  MAIN_CI_RED_SCORE,
+  type WorkflowRun,
+  type CommitStatus,
+} from './health-scan.ts';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function run(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    id: 1,
+    conclusion: 'success',
+    status: 'completed',
+    createdAt: '2026-04-12T06:01:00Z',
+    htmlUrl: 'https://github.com/example/run/1',
+    displayTitle: 'Example run',
+    headBranch: 'production',
+    ...overrides,
+  };
+}
+
+function commit(overrides: Partial<CommitStatus> = {}): CommitStatus {
+  return {
+    sha: 'abc123',
+    url: 'https://github.com/example/commit/abc123',
+    createdAt: '2026-04-12T06:01:00Z',
+    conclusion: 'success',
+    ...overrides,
+  };
+}
+
+// ── evaluateDeployStatus ─────────────────────────────────────────────────────
+
+describe('evaluateDeployStatus', () => {
+  it('returns healthy when there are no runs', () => {
+    const result = evaluateDeployStatus([]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingDeploys).toHaveLength(0);
+    expect(result.lastSuccessfulDeployAt).toBeNull();
+  });
+
+  it('returns healthy when the latest run succeeded', () => {
+    const result = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'success', createdAt: '2026-04-12T06:00:00Z' }),
+      run({ id: 2, conclusion: 'failure', createdAt: '2026-04-12T05:00:00Z' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.reason).toMatch(/succeeded/);
+    expect(result.lastSuccessfulDeployAt?.toISOString()).toBe('2026-04-12T06:00:00.000Z');
+    expect(result.failingDeploys).toHaveLength(0);
+  });
+
+  it('treats a single recent failure as a flap (not yet unhealthy)', () => {
+    const now = new Date('2026-04-12T07:00:00Z');
+    const result = evaluateDeployStatus(
+      [
+        run({ id: 1, conclusion: 'failure', createdAt: '2026-04-12T06:30:00Z' }),
+        run({ id: 2, conclusion: 'success', createdAt: '2026-04-12T06:00:00Z' }),
+      ],
+      now,
+    );
+    expect(result.healthy).toBe(true);
+    expect(result.reason).toMatch(/flap/);
+    expect(result.failingDeploys).toHaveLength(1);
+  });
+
+  it('flags deploy-stuck on ≥2 consecutive failures at the head', () => {
+    const result = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure', createdAt: '2026-04-12T06:01:00Z', displayTitle: 'release #4180' }),
+      run({ id: 2, conclusion: 'failure', createdAt: '2026-04-11T22:57:00Z', displayTitle: 'release #4167' }),
+      run({ id: 3, conclusion: 'success', createdAt: '2026-04-11T18:29:00Z' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toContain('2 consecutive');
+    expect(result.reason).toContain('release #4180');
+    expect(result.failingDeploys).toHaveLength(2);
+    expect(result.failingDeploys[0].id).toBe(1);
+    expect(result.lastSuccessfulDeployAt?.toISOString()).toBe('2026-04-11T18:29:00.000Z');
+  });
+
+  it('validates the consecutive-failures threshold is exactly 2', () => {
+    expect(DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES).toBe(2);
+  });
+
+  it('flags as unhealthy if last success is >staleness threshold and 1 failure since', () => {
+    const now = new Date('2026-04-13T00:00:00Z');
+    const result = evaluateDeployStatus(
+      [
+        run({ id: 1, conclusion: 'failure', createdAt: '2026-04-12T23:00:00Z' }),
+        run({ id: 2, conclusion: 'success', createdAt: '2026-04-12T15:00:00Z' }),
+      ],
+      now,
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/h ago/);
+    const ageHours = (now.getTime() - new Date('2026-04-12T15:00:00Z').getTime()) / 3_600_000;
+    expect(ageHours).toBeGreaterThan(DEPLOY_STALE_THRESHOLD_HOURS);
+  });
+
+  it('does not flag staleness when no failures observed', () => {
+    const now = new Date('2026-04-13T00:00:00Z');
+    const result = evaluateDeployStatus(
+      [run({ id: 1, conclusion: 'success', createdAt: '2026-04-12T15:00:00Z' })],
+      now,
+    );
+    expect(result.healthy).toBe(true);
+  });
+
+  it('ignores non-failure conclusions (cancelled, skipped) for streak counting', () => {
+    const result = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'cancelled', createdAt: '2026-04-12T06:00:00Z' }),
+      run({ id: 2, conclusion: 'failure', createdAt: '2026-04-12T05:00:00Z' }),
+      run({ id: 3, conclusion: 'failure', createdAt: '2026-04-12T04:00:00Z' }),
+      run({ id: 4, conclusion: 'success', createdAt: '2026-04-12T03:00:00Z' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingDeploys).toHaveLength(0);
+  });
+
+  it('historical fixture: the 2026-04-11→12 incident — would flag after deploy #4167 failed', () => {
+    const result = evaluateDeployStatus([
+      run({
+        id: 4180,
+        conclusion: 'failure',
+        createdAt: '2026-04-12T06:01:21Z',
+        displayTitle: 'Merge pull request #4180',
+        htmlUrl: 'https://github.com/quantified-uncertainty/longterm-wiki/actions/runs/4180',
+      }),
+      run({
+        id: 4167,
+        conclusion: 'failure',
+        createdAt: '2026-04-11T22:57:41Z',
+        displayTitle: 'Merge pull request #4167',
+      }),
+      run({
+        id: 4148,
+        conclusion: 'success',
+        createdAt: '2026-04-11T18:29:07Z',
+      }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toContain('2 consecutive');
+    expect(result.failingDeploys[0].htmlUrl).toContain('4180');
+    expect(result.lastSuccessfulDeployAt?.toISOString()).toBe('2026-04-11T18:29:07.000Z');
+  });
+});
+
+// ── evaluateMainCi ───────────────────────────────────────────────────────────
+
+describe('evaluateMainCi', () => {
+  it('returns healthy on an empty list', () => {
+    const result = evaluateMainCi([]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(0);
+  });
+
+  it('returns healthy when the latest resolved commit is success', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'success' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(0);
+  });
+
+  it('skips pending commits at the head and evaluates resolved ones', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'pending', conclusion: 'pending' }),
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.failingCount).toBe(3);
+  });
+
+  it('treats a 2-failure streak as healthy (below ≥3 threshold — flap)', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'success' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(2);
+    expect(result.reason).toMatch(/flap/);
+  });
+
+  it('flags main-ci-red on a 3-failure streak', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure', createdAt: '2026-04-12T06:00:00Z' }),
+      commit({ sha: 'b', conclusion: 'failure', createdAt: '2026-04-12T05:00:00Z' }),
+      commit({
+        sha: 'c',
+        conclusion: 'failure',
+        createdAt: '2026-04-12T04:00:00Z',
+      }),
+      commit({ sha: 'd', conclusion: 'success', createdAt: '2026-04-12T03:00:00Z' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.failingCount).toBe(3);
+    expect(result.redStreakStarted?.toISOString()).toBe('2026-04-12T04:00:00.000Z');
+    expect(result.reason).toContain('3 consecutive');
+  });
+
+  it('validates the red-streak threshold is exactly 3', () => {
+    expect(MAIN_CI_RED_STREAK_MIN).toBe(3);
+  });
+
+  it('does not fire for failures interrupted by a success', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'success' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+      commit({ sha: 'd', conclusion: 'failure' }),
+      commit({ sha: 'e', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(1);
+  });
+});
+
+// ── combineHealth ────────────────────────────────────────────────────────────
+
+describe('combineHealth', () => {
+  const now = new Date('2026-04-12T07:00:00Z');
+
+  it('returns healthy with empty issues when both sub-scanners are healthy', () => {
+    const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
+    const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
+    const combined = combineHealth(deploy, mainCi, now);
+    expect(combined.healthy).toBe(true);
+    expect(combined.issues).toHaveLength(0);
+  });
+
+  it('emits a deploy-stuck issue with correct score + failing url', () => {
+    const deploy = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure', htmlUrl: 'https://example.com/1' }),
+      run({ id: 2, conclusion: 'failure' }),
+    ]);
+    const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
+    const combined = combineHealth(deploy, mainCi, now);
+    expect(combined.healthy).toBe(false);
+    expect(combined.issues).toHaveLength(1);
+    expect(combined.issues[0].type).toBe('deploy-stuck');
+    expect(combined.issues[0].score).toBe(DEPLOY_STUCK_SCORE);
+    expect(combined.issues[0].url).toBe('https://example.com/1');
+    expect(combined.issues[0].detectedAt).toBe(now.toISOString());
+  });
+
+  it('emits a main-ci-red issue with correct score + commit url', () => {
+    const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
+    const mainCi = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure', url: 'https://example.com/commit/a' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    const combined = combineHealth(deploy, mainCi, now);
+    expect(combined.healthy).toBe(false);
+    expect(combined.issues).toHaveLength(1);
+    expect(combined.issues[0].type).toBe('main-ci-red');
+    expect(combined.issues[0].score).toBe(MAIN_CI_RED_SCORE);
+    expect(combined.issues[0].url).toBe('https://example.com/commit/a');
+  });
+
+  it('emits both issues with deploy-stuck scored above main-ci-red', () => {
+    const deploy = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure' }),
+      run({ id: 2, conclusion: 'failure' }),
+    ]);
+    const mainCi = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    const combined = combineHealth(deploy, mainCi, now);
+    expect(combined.issues).toHaveLength(2);
+    expect(combined.issues[0].type).toBe('deploy-stuck');
+    expect(combined.issues[1].type).toBe('main-ci-red');
+    expect(combined.issues[0].score).toBeGreaterThan(combined.issues[1].score);
+  });
+
+  it('both issue scores outrank the highest per-PR issue score (conflict=100)', () => {
+    expect(DEPLOY_STUCK_SCORE).toBeGreaterThan(100);
+    expect(MAIN_CI_RED_SCORE).toBeGreaterThan(100);
+  });
+});

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -1,0 +1,407 @@
+/**
+ * PR Patrol — Fleet-level health scanner (QUA-298 Phase 1).
+ *
+ * Detects system-level health signals that per-PR scanners miss:
+ *   - Last production deploy failed (or consecutive deploys failing)
+ *   - Main CI red streak across multiple commits
+ *
+ * Phase 1 scope (this file): emit detections. Phase 3 wires them into the
+ * patrol loop as a precondition gate. See QUA-297 for the full retrospective.
+ *
+ * Pure evaluation functions take already-fetched data, so they can be unit
+ * tested without network. The outer `checkDeployStatus()` / `checkMainCi()`
+ * wrappers do the I/O and then delegate to the pure functions.
+ */
+
+import { REPO, githubApi, githubGraphQL } from '../lib/github.ts';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Workflow file for the wiki-server production deploy. A failure here means
+ * the migration / build / smoke-test pipeline broke.
+ */
+export const WIKI_SERVER_DEPLOY_WORKFLOW = 'wiki-server-docker.yml';
+
+/**
+ * Min consecutive failed deploys (from most recent, on production branch)
+ * before we consider the deploy pipeline stuck. Requires ≥2 to avoid flapping
+ * on a single transient failure.
+ */
+export const DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES = 2;
+
+/**
+ * Min consecutive failed main-CI runs before we flag a red streak. Set higher
+ * than deploy (3 vs 2) because main CI historically flaps more often than
+ * production deploys.
+ */
+export const MAIN_CI_RED_STREAK_MIN = 3;
+
+/**
+ * If the most recent successful deploy is older than this, the pipeline is
+ * considered stale — even if no explicit failure is observed yet. Catches the
+ * case where CI hasn't run at all for hours.
+ */
+export const DEPLOY_STALE_THRESHOLD_HOURS = 6;
+
+/** Score bonus for the deploy-stuck signal. Must outrank all per-PR issues. */
+export const DEPLOY_STUCK_SCORE = 200;
+
+/** Score bonus for a main-CI red streak. Below deploy-stuck but above per-PR. */
+export const MAIN_CI_RED_SCORE = 180;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface WorkflowRun {
+  id: number;
+  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | null;
+  status: string;
+  createdAt: string;
+  htmlUrl: string;
+  displayTitle: string;
+  headBranch: string;
+}
+
+export interface CommitStatus {
+  sha: string;
+  url: string;
+  createdAt: string;
+  /** Aggregate CI conclusion across check runs + commit status for this commit. */
+  conclusion: 'success' | 'failure' | 'pending' | 'neutral' | null;
+}
+
+export interface DeployStatusResult {
+  healthy: boolean;
+  reason: string;
+  lastSuccessfulDeployAt: Date | null;
+  failingDeploys: WorkflowRun[];
+}
+
+export interface MainCiResult {
+  healthy: boolean;
+  reason: string;
+  failingCount: number;
+  redStreakStarted: Date | null;
+  failingCommits: CommitStatus[];
+}
+
+export type HealthIssueType = 'deploy-stuck' | 'main-ci-red';
+
+export interface HealthIssue {
+  type: HealthIssueType;
+  score: number;
+  /** Human-readable summary suitable for coordinator escalation. */
+  reason: string;
+  /** Most-relevant link (failing run URL, failing commit URL). */
+  url?: string;
+  detectedAt: string;
+}
+
+export interface HealthScanResult {
+  healthy: boolean;
+  deploy: DeployStatusResult;
+  mainCi: MainCiResult;
+  issues: HealthIssue[];
+}
+
+// ── Pure evaluators (no I/O — unit-testable) ─────────────────────────────────
+
+/**
+ * Given recent workflow runs on the production branch (newest first), decide
+ * whether the deploy pipeline is healthy.
+ *
+ * Rules:
+ *  - ≥ DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES failures at the head of the list → unhealthy
+ *  - Last successful deploy older than DEPLOY_STALE_THRESHOLD_HOURS with at least
+ *    one failure since → unhealthy (catches the "nothing deploying" case too)
+ *  - Otherwise healthy, even if there's a single old failure buried in the list
+ */
+export function evaluateDeployStatus(
+  runs: WorkflowRun[],
+  now: Date = new Date(),
+): DeployStatusResult {
+  if (runs.length === 0) {
+    return {
+      healthy: true,
+      reason: 'no recent deploy runs observed',
+      lastSuccessfulDeployAt: null,
+      failingDeploys: [],
+    };
+  }
+
+  let consecutiveFailures = 0;
+  for (const run of runs) {
+    if (run.conclusion === 'failure') consecutiveFailures++;
+    else break;
+  }
+
+  const lastSuccess = runs.find((r) => r.conclusion === 'success') ?? null;
+  const lastSuccessfulDeployAt = lastSuccess ? new Date(lastSuccess.createdAt) : null;
+  const failingDeploys = runs.slice(0, consecutiveFailures);
+
+  if (consecutiveFailures >= DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES) {
+    const last = runs[0];
+    const reason =
+      `${consecutiveFailures} consecutive production deploy failures ` +
+      `(most recent: ${last.displayTitle} at ${last.createdAt})`;
+    return {
+      healthy: false,
+      reason,
+      lastSuccessfulDeployAt,
+      failingDeploys,
+    };
+  }
+
+  if (lastSuccessfulDeployAt && consecutiveFailures >= 1) {
+    const ageHours = (now.getTime() - lastSuccessfulDeployAt.getTime()) / 3_600_000;
+    if (ageHours > DEPLOY_STALE_THRESHOLD_HOURS) {
+      return {
+        healthy: false,
+        reason:
+          `last successful deploy was ${ageHours.toFixed(1)}h ago and ` +
+          `there has been at least one failure since`,
+        lastSuccessfulDeployAt,
+        failingDeploys,
+      };
+    }
+  }
+
+  return {
+    healthy: true,
+    reason:
+      consecutiveFailures === 0
+        ? 'latest production deploy succeeded'
+        : `single deploy failure observed (not yet ≥${DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES} consecutive — likely a flap)`,
+    lastSuccessfulDeployAt,
+    failingDeploys,
+  };
+}
+
+/**
+ * Given recent commits on main (newest first), decide whether CI is healthy.
+ * A red streak of ≥ MAIN_CI_RED_STREAK_MIN at the head of the list is unhealthy.
+ * Pending checks at the head are skipped (not counted as either pass or fail).
+ */
+export function evaluateMainCi(commits: CommitStatus[]): MainCiResult {
+  const resolved = commits.filter((c) => c.conclusion !== 'pending' && c.conclusion !== null);
+  if (resolved.length === 0) {
+    return {
+      healthy: true,
+      reason: 'no resolved main CI runs observed',
+      failingCount: 0,
+      redStreakStarted: null,
+      failingCommits: [],
+    };
+  }
+
+  let streak = 0;
+  for (const c of resolved) {
+    if (c.conclusion === 'failure') streak++;
+    else break;
+  }
+
+  const failingCommits = resolved.slice(0, streak);
+  const redStreakStarted =
+    failingCommits.length > 0
+      ? new Date(failingCommits[failingCommits.length - 1].createdAt)
+      : null;
+
+  if (streak >= MAIN_CI_RED_STREAK_MIN) {
+    return {
+      healthy: false,
+      reason: `main CI has ${streak} consecutive failing commits (streak started ${redStreakStarted?.toISOString()})`,
+      failingCount: streak,
+      redStreakStarted,
+      failingCommits,
+    };
+  }
+
+  return {
+    healthy: true,
+    reason:
+      streak === 0
+        ? 'latest main CI runs succeeded'
+        : `${streak} main CI failure(s) observed (below ≥${MAIN_CI_RED_STREAK_MIN} threshold — likely a flap)`,
+    failingCount: streak,
+    redStreakStarted,
+    failingCommits,
+  };
+}
+
+/**
+ * Combine deploy + main-CI evaluations into a single HealthScanResult.
+ * Pure — takes the two sub-results and assembles the issue list for the queue.
+ */
+export function combineHealth(
+  deploy: DeployStatusResult,
+  mainCi: MainCiResult,
+  now: Date = new Date(),
+): HealthScanResult {
+  const issues: HealthIssue[] = [];
+  const detectedAt = now.toISOString();
+
+  if (!deploy.healthy) {
+    issues.push({
+      type: 'deploy-stuck',
+      score: DEPLOY_STUCK_SCORE,
+      reason: deploy.reason,
+      url: deploy.failingDeploys[0]?.htmlUrl,
+      detectedAt,
+    });
+  }
+
+  if (!mainCi.healthy) {
+    issues.push({
+      type: 'main-ci-red',
+      score: MAIN_CI_RED_SCORE,
+      reason: mainCi.reason,
+      url: mainCi.failingCommits[0]?.url,
+      detectedAt,
+    });
+  }
+
+  return {
+    healthy: deploy.healthy && mainCi.healthy,
+    deploy,
+    mainCi,
+    issues,
+  };
+}
+
+// ── I/O wrappers ─────────────────────────────────────────────────────────────
+
+interface ListRunsResponse {
+  workflow_runs: Array<{
+    id: number;
+    conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | null;
+    status: string;
+    created_at: string;
+    html_url: string;
+    display_title: string;
+    head_branch: string;
+  }>;
+}
+
+/**
+ * Fetch the last N production-branch runs for the wiki-server deploy workflow
+ * and evaluate health.
+ */
+export async function checkDeployStatus(
+  options: {
+    workflow?: string;
+    branch?: string;
+    limit?: number;
+    now?: Date;
+  } = {},
+): Promise<DeployStatusResult> {
+  const workflow = options.workflow ?? WIKI_SERVER_DEPLOY_WORKFLOW;
+  const branch = options.branch ?? 'production';
+  const limit = options.limit ?? 5;
+
+  const resp = await githubApi<ListRunsResponse>(
+    `/repos/${REPO}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=${limit}`,
+  );
+
+  const runs: WorkflowRun[] = resp.workflow_runs.map((r) => ({
+    id: r.id,
+    conclusion: r.conclusion,
+    status: r.status,
+    createdAt: r.created_at,
+    htmlUrl: r.html_url,
+    displayTitle: r.display_title,
+    headBranch: r.head_branch,
+  }));
+
+  return evaluateDeployStatus(runs, options.now);
+}
+
+interface MainCommitsGql {
+  repository: {
+    ref: {
+      target: {
+        history: {
+          nodes: Array<{
+            oid: string;
+            committedDate: string;
+            url: string;
+            statusCheckRollup: {
+              state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED';
+            } | null;
+          }>;
+        };
+      };
+    };
+  };
+}
+
+const MAIN_COMMITS_QUERY = /* GraphQL */ `
+  query MainCiCommits($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      ref(qualifiedName: "refs/heads/main") {
+        target {
+          ... on Commit {
+            history(first: $first) {
+              nodes {
+                oid
+                committedDate
+                url
+                statusCheckRollup {
+                  state
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch the last N commits on main and their aggregate CI conclusion, then
+ * evaluate for a red streak.
+ */
+export async function checkMainCi(
+  options: {
+    limit?: number;
+    repo?: string;
+  } = {},
+): Promise<MainCiResult> {
+  const limit = options.limit ?? 5;
+  const [owner, name] = (options.repo ?? REPO).split('/');
+
+  const data = await githubGraphQL<MainCommitsGql>(MAIN_COMMITS_QUERY, {
+    owner,
+    name,
+    first: limit,
+  });
+
+  const nodes = data.repository?.ref?.target?.history?.nodes ?? [];
+
+  const commits: CommitStatus[] = nodes.map((n) => ({
+    sha: n.oid,
+    url: n.url,
+    createdAt: n.committedDate,
+    conclusion: mapRollupState(n.statusCheckRollup?.state ?? null),
+  }));
+
+  return evaluateMainCi(commits);
+}
+
+function mapRollupState(
+  state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | null,
+): CommitStatus['conclusion'] {
+  if (state === 'SUCCESS') return 'success';
+  if (state === 'FAILURE' || state === 'ERROR') return 'failure';
+  if (state === 'PENDING' || state === 'EXPECTED') return 'pending';
+  return null;
+}
+
+/**
+ * Run both scanners and combine into one HealthScanResult. Intended to be
+ * called at the start of each patrol cycle (Phase 3 wiring).
+ */
+export async function healthScan(): Promise<HealthScanResult> {
+  const [deploy, mainCi] = await Promise.all([checkDeployStatus(), checkMainCi()]);
+  return combineHealth(deploy, mainCi);
+}

--- a/crux/pr-patrol/scoring.ts
+++ b/crux/pr-patrol/scoring.ts
@@ -21,6 +21,17 @@ export {
   rankPrs,
 } from '../lib/pr-analysis/index.ts';
 
+// ── Fleet-level health scores (QUA-298 Phase 1) ──────────────────────────────
+// Health-gate signals are not per-PR issues — they're surfaced here so the
+// two score constants live alongside ISSUE_SCORES for discoverability.
+// Phase 3 wires them into the patrol loop as a precondition gate.
+export {
+  DEPLOY_STUCK_SCORE,
+  MAIN_CI_RED_SCORE,
+  type HealthIssueType,
+  type HealthIssue,
+} from './health-scan.ts';
+
 // ── Cross-PR dependency priority boost (QUA-287 Phase 3) ─────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of QUA-297 (Health-Gate Patrol). Adds `crux/pr-patrol/health-scan.ts` with fleet-level signals the per-PR patrol can't see:

- **deploy-stuck** (score 200) — ≥2 consecutive failed production deploys, or last success >6h ago with a failure since
- **main-ci-red** (score 180) — ≥3 consecutive failing commits on main

Pure evaluators (`evaluateDeployStatus`, `evaluateMainCi`, `combineHealth`) take already-fetched data — unit-testable without network. I/O wrappers fetch via GitHub REST + GraphQL.

Phase 3 (QUA-300) wires this into the patrol loop as a precondition gate. This PR only emits detections.

## Context

Motivated by the 2026-04-11→12 incident: wiki-server deploy stuck ~12h on migration 0173 lock-timeout, unnoticed while 7+ PRs patched downstream symptoms (see QUA-297 retrospective).

Tests include a historical fixture encoding that incident (deploys #4180 + #4167 consecutive failures) and verify the scanner would flag `deploy-stuck` before the downstream symptom-fix PR cascade would have been needed.

Live dry-run against current prod returns healthy (consistent with the `/health` probe).

## Test plan

- [x] 21 unit tests pass (`crux/pr-patrol/health-scan.test.ts`)
- [x] Full `crux/pr-patrol/` suite (287 tests) unchanged
- [x] Live dry-run against prod returns `{healthy: true, issues: []}`
- [x] Historical fixture (incident replay) flags `deploy-stuck`
- [x] Single-flap (1 failure then success) does NOT flag
- [x] 2-commit main-CI failure is below the `main-ci-red` threshold (flap)
- [x] Content gate passes

## Not in this PR

- Phase 2 (QUA-299) — ratchet-drift scanner
- Phase 3 (QUA-300) — gate ordering + PR-fix suppression

Fixes QUA-298
