### PR TITLE
feat(pr-patrol): cross-PR dependency surfacing (QUA-287 Phase 3)

### DIFF
--- a/crux/lib/pr-analysis/dependency-surfacing.test.ts
+++ b/crux/lib/pr-analysis/dependency-surfacing.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for QUA-287 Phase 3 — cross-PR dependency surfacing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyDependencySurfacing,
+  extractPrRefsFromText,
+  extractPrReferences,
+} from './dependency-surfacing.ts';
+import { computeScore, HUB_BOOST } from './scoring.ts';
+import type { DetectedPr, GqlPrNode } from './types.ts';
+
+function makePrNode(overrides: Partial<GqlPrNode> = {}): GqlPrNode {
+  return {
+    id: 'PR_n',
+    number: 1,
+    title: 'Test',
+    headRefName: 'claude/x',
+    headRefOid: 'sha',
+    mergeable: 'MERGEABLE',
+    isDraft: false,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-10T00:00:00Z',
+    body: '',
+    author: { login: 'u' },
+    labels: { nodes: [] },
+    commits: {
+      nodes: [{
+        commit: {
+          committedDate: '2026-04-10T00:00:00Z',
+          statusCheckRollup: { contexts: { nodes: [] } },
+        },
+      }],
+    },
+    reviewThreads: { nodes: [] },
+    comments: { nodes: [] },
+    timelineItems: { nodes: [] },
+    ...overrides,
+  };
+}
+
+function makeDetected(overrides: Partial<DetectedPr> = {}): DetectedPr {
+  return {
+    number: 1,
+    title: 'Test',
+    branch: 'claude/x',
+    createdAt: '2026-04-01T00:00:00Z',
+    issues: [],
+    botComments: [],
+    labels: [],
+    ...overrides,
+  };
+}
+
+// ── extractPrRefsFromText ────────────────────────────────────────────────────
+
+describe('extractPrRefsFromText', () => {
+  it('finds isolated #NNNN tokens', () => {
+    expect(extractPrRefsFromText('depends on #4186 merging first')).toEqual([4186]);
+  });
+
+  it('returns multiple unique refs in order of first appearance', () => {
+    expect(extractPrRefsFromText('#10, #20, then #10 again, and #30'))
+      .toEqual([10, 20, 30]);
+  });
+
+  it('ignores tokens embedded in alphanumeric context', () => {
+    // v1.2#100 is a weird token, not a PR ref
+    expect(extractPrRefsFromText('version v1.2#100 rollback')).toEqual([]);
+  });
+
+  it('accepts refs at start of string', () => {
+    expect(extractPrRefsFromText('#42 is the answer')).toEqual([42]);
+  });
+
+  it('returns empty for null/undefined/empty', () => {
+    expect(extractPrRefsFromText(null)).toEqual([]);
+    expect(extractPrRefsFromText(undefined)).toEqual([]);
+    expect(extractPrRefsFromText('')).toEqual([]);
+  });
+
+  it('rejects zero and negative (regex only matches non-negative digits anyway)', () => {
+    expect(extractPrRefsFromText('see #0 and #-5')).toEqual([]);
+  });
+});
+
+// ── extractPrReferences ──────────────────────────────────────────────────────
+
+describe('extractPrReferences', () => {
+  it('finds body refs and validates against open PRs', () => {
+    const pr = makePrNode({
+      number: 100,
+      body: 'Blocked on #200 and #300; also see #9999',
+    });
+    // #9999 is not in the open set, so it should be filtered
+    const refs = extractPrReferences(pr, new Set([200, 300, 100]));
+    expect(refs).toEqual([
+      { pr: 200, reason: 'body-reference' },
+      { pr: 300, reason: 'body-reference' },
+    ]);
+  });
+
+  it('finds failing-check refs and attributes them to gate-error', () => {
+    const pr = makePrNode({ number: 100, body: null });
+    const refs = extractPrReferences(
+      pr,
+      new Set([200, 100]),
+      ['ci/gate: waiting for #200 to merge'],
+    );
+    expect(refs).toEqual([{ pr: 200, reason: 'gate-error' }]);
+  });
+
+  it('dedupes refs across body and failing checks (first reason wins)', () => {
+    const pr = makePrNode({
+      number: 100,
+      body: 'Blocked on #200',
+    });
+    const refs = extractPrReferences(
+      pr,
+      new Set([200, 100]),
+      ['ci/gate: #200 must merge'],
+    );
+    // body-reference seen first, gate-error skipped as dup
+    expect(refs).toEqual([{ pr: 200, reason: 'body-reference' }]);
+  });
+
+  it('skips self-reference', () => {
+    const pr = makePrNode({
+      number: 100,
+      body: 'See #100 (this PR)',
+    });
+    expect(extractPrReferences(pr, new Set([100]))).toEqual([]);
+  });
+
+  it('filters merged/closed PRs (not in open set)', () => {
+    const pr = makePrNode({ number: 100, body: 'Fixes #50 (already merged)' });
+    expect(extractPrReferences(pr, new Set([100]))).toEqual([]);
+  });
+});
+
+// ── applyDependencySurfacing ─────────────────────────────────────────────────
+
+describe('applyDependencySurfacing', () => {
+  it('populates blockedOnPrs from body references', () => {
+    const nodes = [
+      makePrNode({ number: 100, body: 'Blocks on #200' }),
+      makePrNode({ number: 200, body: '' }),
+    ];
+    const detected = [makeDetected({ number: 100 }), makeDetected({ number: 200 })];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toEqual([
+      { pr: 200, reason: 'body-reference' },
+    ]);
+    expect(detected[1].blockedOnPrs).toBeUndefined();
+  });
+
+  it('populates blockedOnPrs from failing-check messages', () => {
+    const nodes = [
+      makePrNode({ number: 100 }),
+      makePrNode({ number: 200 }),
+    ];
+    const detected = [
+      makeDetected({ number: 100, failingChecks: ['ci/gate: waiting for #200'] }),
+      makeDetected({ number: 200 }),
+    ];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toEqual([
+      { pr: 200, reason: 'gate-error' },
+    ]);
+  });
+
+  it('inverts timelineItems: cross-ref on Y from source X → X.blockedOnPrs += Y', () => {
+    // PR 200's timeline shows "PR 100 referenced me", so 100 → 200.
+    const nodes = [
+      makePrNode({ number: 100 }),
+      makePrNode({
+        number: 200,
+        timelineItems: {
+          nodes: [{
+            __typename: 'CrossReferencedEvent',
+            source: { __typename: 'PullRequest', number: 100, state: 'OPEN' },
+            createdAt: '2026-04-10T00:00:00Z',
+          }],
+        },
+      }),
+    ];
+    const detected = [makeDetected({ number: 100 }), makeDetected({ number: 200 })];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toEqual([
+      { pr: 200, reason: 'timeline-reference' },
+    ]);
+  });
+
+  it('ignores CrossReferencedEvent from Issue source (only PR sources surface)', () => {
+    const nodes = [
+      makePrNode({
+        number: 100,
+        timelineItems: {
+          nodes: [{
+            __typename: 'CrossReferencedEvent',
+            source: { __typename: 'Issue', number: 500 },
+            createdAt: '2026-04-10T00:00:00Z',
+          }],
+        },
+      }),
+    ];
+    const detected = [makeDetected({ number: 100 })];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toBeUndefined();
+  });
+
+  it('gives body/gate-error reasons precedence over timeline-reference (dedup)', () => {
+    // PR 100 body mentions #200 AND timeline on 200 shows source=100.
+    // Expect body-reference, not timeline-reference, because body is attached first.
+    const nodes = [
+      makePrNode({ number: 100, body: 'Depends on #200' }),
+      makePrNode({
+        number: 200,
+        timelineItems: {
+          nodes: [{
+            __typename: 'CrossReferencedEvent',
+            source: { __typename: 'PullRequest', number: 100, state: 'OPEN' },
+            createdAt: '2026-04-10T00:00:00Z',
+          }],
+        },
+      }),
+    ];
+    const detected = [makeDetected({ number: 100 }), makeDetected({ number: 200 })];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toEqual([
+      { pr: 200, reason: 'body-reference' },
+    ]);
+  });
+
+  it('aggregates blocksOthers across all detected PRs', () => {
+    // PRs 100, 101, 102 all block on 200. 200 should have blocksOthers=3.
+    const nodes = [
+      makePrNode({ number: 100, body: 'See #200' }),
+      makePrNode({ number: 101, body: 'Waiting for #200' }),
+      makePrNode({ number: 102, body: 'Blocked on #200' }),
+      makePrNode({ number: 200 }),
+    ];
+    const detected = [
+      makeDetected({ number: 100 }),
+      makeDetected({ number: 101 }),
+      makeDetected({ number: 102 }),
+      makeDetected({ number: 200 }),
+    ];
+    applyDependencySurfacing(detected, nodes);
+    const pr200 = detected.find((p) => p.number === 200)!;
+    expect(pr200.blocksOthers).toBe(3);
+    expect(detected.find((p) => p.number === 100)!.blocksOthers).toBeUndefined();
+  });
+
+  it('no-ops cleanly on empty detected list', () => {
+    expect(() => applyDependencySurfacing([], [])).not.toThrow();
+  });
+
+  it('skips refs to PRs not in the open scan (filters merged/closed)', () => {
+    // PR 999 is NOT in rawNodes → should be filtered despite body reference.
+    const nodes = [makePrNode({ number: 100, body: 'Fixes #999' })];
+    const detected = [makeDetected({ number: 100 })];
+    applyDependencySurfacing(detected, nodes);
+    expect(detected[0].blockedOnPrs).toBeUndefined();
+  });
+});
+
+// ── Scoring integration ──────────────────────────────────────────────────────
+
+describe('computeScore hub boost', () => {
+  it('adds HUB_BOOST to stuck PRs blocking ≥2 others', () => {
+    const base: DetectedPr = makeDetected({
+      number: 200,
+      issues: ['stuck'],
+      stuckCycles: 3,
+      blocksOthers: 2,
+    });
+    const scoreWithHub = computeScore(base);
+    const scoreWithoutHub = computeScore({ ...base, blocksOthers: undefined });
+    expect(scoreWithHub - scoreWithoutHub).toBe(HUB_BOOST);
+  });
+
+  it('does not boost when stuckCycles < 3', () => {
+    const pr = makeDetected({
+      number: 200,
+      issues: ['stuck'],
+      stuckCycles: 2,
+      blocksOthers: 5,
+    });
+    const hubless = computeScore({ ...pr, blocksOthers: undefined });
+    expect(computeScore(pr)).toBe(hubless);
+  });
+
+  it('does not boost when blocksOthers < 2', () => {
+    const pr = makeDetected({
+      number: 200,
+      issues: ['stuck'],
+      stuckCycles: 5,
+      blocksOthers: 1,
+    });
+    const hubless = computeScore({ ...pr, blocksOthers: undefined });
+    expect(computeScore(pr)).toBe(hubless);
+  });
+});

--- a/crux/lib/pr-analysis/dependency-surfacing.ts
+++ b/crux/lib/pr-analysis/dependency-surfacing.ts
@@ -1,0 +1,166 @@
+/**
+ * PR Analysis — Cross-PR dependency surfacing (QUA-287 Phase 3).
+ *
+ * Extracts outgoing PR dependencies for each detected PR:
+ *   1. `timelineItems(CROSS_REFERENCED_EVENT)` — structural: when PR A appears
+ *      as the `source` of a cross-ref event on PR B, A → B (A mentions B).
+ *   2. `#NNNN` tokens in the PR body — textual signal of dependency.
+ *   3. `#NNNN` tokens in failing-check context strings — "gate error"
+ *      signal (e.g. a CI message like "waiting on #4186 to merge").
+ *
+ * Refs are validated against the set of currently-open PR numbers to drop
+ * issue references, merged PRs, and noise tokens like "#1 priority".
+ *
+ * A second pass computes `blocksOthers` for each PR — how many OTHER open
+ * PRs list this PR in their `blockedOnPrs`. This enables scoring to boost
+ * stuck PRs blocking multiple dependents.
+ */
+
+import type {
+  DetectedPr,
+  GqlPrNode,
+  PrDependencyReason,
+} from './types.ts';
+
+/**
+ * Regex matching `#NNNN` issue/PR references in free text.
+ * Captures the number in group 1. Uses a negative lookbehind for alphanumeric
+ * characters to avoid matching things like `v#123` or `abc#123`.
+ */
+const PR_REF_RE = /(?:^|[^\w])#(\d+)\b/g;
+
+/**
+ * Extract PR numbers referenced in a block of text.
+ * Returns unique numbers in the order they first appear.
+ */
+export function extractPrRefsFromText(text: string | null | undefined): number[] {
+  if (!text) return [];
+  const found: number[] = [];
+  const seen = new Set<number>();
+  for (const match of text.matchAll(PR_REF_RE)) {
+    const n = Number(match[1]);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    if (seen.has(n)) continue;
+    seen.add(n);
+    found.push(n);
+  }
+  return found;
+}
+
+/**
+ * Extract outgoing PR refs for a single PR.
+ *
+ * @param pr         The raw GraphQL PR node.
+ * @param openPrs    Set of PR numbers present in the current scan (validation filter).
+ * @param failingChecks  Optional failing-check context strings (e.g. `['ci/gate: #4186 pending']`).
+ * @returns          Deduped list of refs with the most structural reason kept first.
+ */
+export function extractPrReferences(
+  pr: GqlPrNode,
+  openPrs: Set<number>,
+  failingChecks?: string[],
+): Array<{ pr: number; reason: PrDependencyReason }> {
+  const result: Array<{ pr: number; reason: PrDependencyReason }> = [];
+  const seen = new Set<number>();
+
+  const tryAdd = (num: number, reason: PrDependencyReason): void => {
+    if (!Number.isFinite(num) || num <= 0) return;
+    if (num === pr.number) return; // self-ref
+    if (!openPrs.has(num)) return; // validation: must be an open PR in current scan
+    if (seen.has(num)) return;
+    seen.add(num);
+    result.push({ pr: num, reason });
+  };
+
+  // 1. Structural: timelineItems source PRs.
+  //    NOTE: a CrossReferencedEvent on PR A with source=B means B → A (B mentions A).
+  //    So from A's perspective, these are INCOMING refs, not A's outgoing dependencies.
+  //    The applyDependencySurfacing() caller handles the inversion across the full
+  //    PR set. extractPrReferences() only returns OUTGOING dependencies derived from
+  //    A's own body + failing checks.
+
+  // 2. Body: `#NNNN` tokens.
+  for (const n of extractPrRefsFromText(pr.body)) tryAdd(n, 'body-reference');
+
+  // 3. Failing-check contexts: `#NNNN` tokens.
+  for (const text of failingChecks ?? []) {
+    for (const n of extractPrRefsFromText(text)) tryAdd(n, 'gate-error');
+  }
+
+  return result;
+}
+
+/**
+ * Populate `blockedOnPrs` and `blocksOthers` on every detected PR.
+ *
+ * Mutates `detected` in place. Safe to call with an empty list.
+ *
+ * Two passes:
+ *   1. Outgoing: extractPrReferences (body + failing-checks) for each detected PR.
+ *   2. Structural inversion: for each raw PR node Y, read Y.timelineItems; for
+ *      each CrossReferencedEvent with source = X (open PR), X → Y. Append Y to
+ *      X.blockedOnPrs with reason 'timeline-reference' (dedup by PR number, so
+ *      if Y was already added via body/gate-error, that reason wins).
+ *   3. Aggregation: compute `blocksOthers[A] = count of detected PRs listing A in blockedOnPrs`.
+ */
+export function applyDependencySurfacing(
+  detected: DetectedPr[],
+  rawNodes: GqlPrNode[],
+): void {
+  if (detected.length === 0) return;
+
+  const detectedByNumber = new Map<number, DetectedPr>();
+  for (const d of detected) detectedByNumber.set(d.number, d);
+
+  // Validate against the full open-PR set, not just `detected` — a PR filtered
+  // out of `detected` (e.g. draft, bot-authored) can still be a legitimate
+  // dependency target. We still only *attach* blockedOnPrs to detected PRs.
+  const openPrs = new Set<number>(rawNodes.map((n) => n.number));
+
+  const nodeByNumber = new Map<number, GqlPrNode>();
+  for (const n of rawNodes) nodeByNumber.set(n.number, n);
+
+  // Pass 1: outgoing refs from body + failing-check messages.
+  for (const pr of detected) {
+    const node = nodeByNumber.get(pr.number);
+    if (!node) continue;
+    const refs = extractPrReferences(node, openPrs, pr.failingChecks);
+    if (refs.length > 0) {
+      pr.blockedOnPrs = refs;
+    }
+  }
+
+  // Pass 2: invert timelineItems to pick up structural outgoing refs.
+  // On PR Y, CrossReferencedEvent.source = X means X → Y.
+  for (const yNode of rawNodes) {
+    const events = yNode.timelineItems?.nodes ?? [];
+    for (const ev of events) {
+      if (ev.__typename !== 'CrossReferencedEvent') continue;
+      const source = ev.source;
+      if (!source || source.__typename !== 'PullRequest') continue;
+      const xNum = source.number;
+      if (typeof xNum !== 'number' || xNum === yNode.number) continue;
+      // Only surface on detected PRs (the ones that will be scored/rendered).
+      const xPr = detectedByNumber.get(xNum);
+      if (!xPr) continue;
+      // Skip if Y isn't in the current open set or is the same PR.
+      if (!openPrs.has(yNode.number)) continue;
+      // Dedup against body/gate-error reasons (those win — more actionable).
+      const existing = xPr.blockedOnPrs ??= [];
+      if (existing.some((r) => r.pr === yNode.number)) continue;
+      existing.push({ pr: yNode.number, reason: 'timeline-reference' });
+    }
+  }
+
+  // Pass 3: aggregate blocksOthers.
+  const blocksCount = new Map<number, number>();
+  for (const pr of detected) {
+    for (const ref of pr.blockedOnPrs ?? []) {
+      blocksCount.set(ref.pr, (blocksCount.get(ref.pr) ?? 0) + 1);
+    }
+  }
+  for (const pr of detected) {
+    const count = blocksCount.get(pr.number) ?? 0;
+    if (count > 0) pr.blocksOthers = count;
+  }
+}

--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -51,6 +51,11 @@ const PR_QUERY = `query($owner: String!, $name: String!) {
           __typename
           ... on CrossReferencedEvent {
             createdAt
+            source {
+              __typename
+              ... on PullRequest { number state }
+              ... on Issue { number }
+            }
           }
         }}
       }
@@ -91,6 +96,11 @@ const SINGLE_PR_QUERY = `query($owner: String!, $name: String!, $number: Int!) {
         __typename
         ... on CrossReferencedEvent {
           createdAt
+          source {
+            __typename
+            ... on PullRequest { number state }
+            ... on Issue { number }
+          }
         }
       }}
     }

--- a/crux/lib/pr-analysis/index.ts
+++ b/crux/lib/pr-analysis/index.ts
@@ -36,8 +36,10 @@ export type {
   GqlReviewThread,
   GqlIssueComment,
   GqlCrossReferencedEvent,
+  GqlCrossReferencedEventSource,
   GqlPrNode,
   PrOverlap,
+  PrDependencyReason,
   AutoRebaseResult,
 } from './types.ts';
 
@@ -70,9 +72,19 @@ export {
 export {
   ISSUE_SCORES,
   APPROVED_BONUS,
+  HUB_BOOST,
+  HUB_BLOCKS_THRESHOLD,
   computeScore,
   rankPrs,
 } from './scoring.ts';
+
+// ── Cross-PR dependency surfacing ────────────────────────────────────────────
+
+export {
+  applyDependencySurfacing,
+  extractPrReferences,
+  extractPrRefsFromText,
+} from './dependency-surfacing.ts';
 
 // ── CI status ────────────────────────────────────────────────────────────────
 

--- a/crux/lib/pr-analysis/scoring.ts
+++ b/crux/lib/pr-analysis/scoring.ts
@@ -34,6 +34,16 @@ export const ISSUE_SCORES: Record<PrIssueType, number> = {
 /** Bonus for PRs with stage:approved — they're one fix away from merging. */
 export const APPROVED_BONUS = 100;
 
+/**
+ * Priority bump for stuck "hub" PRs — a PR that has been stuck for several
+ * cycles AND is referenced by ≥2 other open PRs is blocking the queue, so we
+ * bump it past a plain stuck PR to get it resolved first. QUA-287 Phase 3.
+ */
+export const HUB_BOOST = 150;
+
+/** Threshold for counting as a hub (see HUB_BOOST). */
+export const HUB_BLOCKS_THRESHOLD = 2;
+
 /** Pure function — computes priority score for a detected PR. */
 export function computeScore(pr: DetectedPr): number {
   let score = 0;
@@ -46,6 +56,14 @@ export function computeScore(pr: DetectedPr): number {
   // Approved PRs get a priority boost — fixing them unblocks a merge
   if (pr.labels?.includes(LABELS.STAGE_APPROVED)) {
     score += APPROVED_BONUS;
+  }
+
+  // Hub boost: stuck PR blocking ≥2 other open PRs goes to the front of the queue.
+  if (
+    (pr.stuckCycles ?? 0) >= 3 &&
+    (pr.blocksOthers ?? 0) >= HUB_BLOCKS_THRESHOLD
+  ) {
+    score += HUB_BOOST;
   }
 
   return score;

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -122,7 +122,28 @@ export interface DetectedPr {
    * is set.
    */
   stuckReason?: string;
+  /**
+   * Other open PRs this PR has an outgoing dependency on — extracted from
+   * CrossReferencedEvent timeline items and from `#NNNN` tokens in the PR
+   * body and failing-check messages. Only PRs present in the current open
+   * scan are recorded (merged/closed refs are filtered). QUA-287 Phase 3.
+   */
+  blockedOnPrs?: Array<{ pr: number; reason: PrDependencyReason }>;
+  /**
+   * Number of other open PRs that list this PR in their `blockedOnPrs`.
+   * Computed in the second pass of `applyDependencySurfacing`. Used by
+   * scoring to boost priority of hub PRs blocking multiple others.
+   */
+  blocksOthers?: number;
 }
+
+export type PrDependencyReason =
+  /** GitHub CrossReferencedEvent — structural evidence this PR mentions the other */
+  | 'timeline-reference'
+  /** `#NNNN` token found in the PR body */
+  | 'body-reference'
+  /** `#NNNN` token found in a failing check's context/output */
+  | 'gate-error';
 
 export interface ScoredPr extends DetectedPr {
   score: number;
@@ -199,9 +220,23 @@ export interface GqlIssueComment {
   viewerDidAuthor: boolean;
 }
 
+export interface GqlCrossReferencedEventSource {
+  __typename?: 'PullRequest' | 'Issue';
+  /** PR or issue number of the referencing item. */
+  number?: number;
+  /** PR state (OPEN, CLOSED, MERGED) — only populated for PullRequest sources. */
+  state?: string;
+}
+
 export interface GqlCrossReferencedEvent {
   __typename?: 'CrossReferencedEvent';
-  source?: unknown;
+  /**
+   * The item that referenced this PR. `source.number` is the PR/issue number
+   * that mentioned this PR (the referencer). Note this is an *incoming*
+   * cross-reference: on PR A, a CrossReferencedEvent with source=B means
+   * "B referenced A", i.e. B → A.
+   */
+  source?: GqlCrossReferencedEventSource;
   createdAt?: string;
 }
 

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -98,6 +98,7 @@ import {
   fetchOpenPrs as daemonFetchOpenPrs,
 } from './detection.ts';
 import { detectCodeRabbitRateLimited } from '../lib/pr-analysis/detection.ts';
+import { applyDependencySurfacing } from '../lib/pr-analysis/dependency-surfacing.ts';
 import { rankPrs as daemonRankPrs } from './scoring.ts';
 import {
   findMergeCandidates as daemonFindMergeCandidates,
@@ -348,6 +349,10 @@ async function runCheckCycle(
   // inside applyStuckCycleDetection and do not abort the cycle.
   await applyStuckCycleDetection(detected, allPrs);
 
+  // Surface cross-PR dependencies (QUA-287 Phase 3). Must run after stuck
+  // detection so `blocksOthers` + `stuckCycles` can jointly drive the hub boost.
+  applyDependencySurfacing(detected, allPrs);
+
   let fixedPr: number | null = null;
 
   // 1b. Check for PR file overlaps (informational — posts warnings)
@@ -380,8 +385,14 @@ async function runCheckCycle(
         log('');
         log(`${cl.bold}Fix queue${cl.reset} (${ranked.length} items):`);
         for (const pr of ranked) {
+          const chain = pr.blockedOnPrs && pr.blockedOnPrs.length > 0
+            ? `  ${cl.dim}→ ${pr.blockedOnPrs.map((r) => `#${r.pr}`).join(', ')}${cl.reset}`
+            : '';
+          const hub = (pr.blocksOthers ?? 0) >= 2
+            ? `  ${cl.yellow}blocks ${pr.blocksOthers}${cl.reset}`
+            : '';
           log(
-            `  [score=${pr.score}] PR ${cl.cyan}#${pr.number}${cl.reset}: ${pr.issues.join(',')} ${cl.dim}—${cl.reset} ${pr.title}`,
+            `  [score=${pr.score}] PR ${cl.cyan}#${pr.number}${cl.reset}: ${pr.issues.join(',')} ${cl.dim}—${cl.reset} ${pr.title}${chain}${hub}`,
           );
         }
         log('');


### PR DESCRIPTION
## Summary
- Surface cross-PR dependencies in the fix queue so "A blocked on B" is explicit, not buried in retry logs
- Detection sources (dedup precedence): body `#NNNN` tokens → failing-check contexts → inverted `CrossReferencedEvent` timeline items
- Queue render now shows blocked chain (`→ #N, #M`) and a "blocks N" badge for hubs
- Scoring adds `HUB_BOOST` (+150) when `stuckCycles ≥ 3 && blocksOthers ≥ 2` so stuck hub PRs jump to the top

## Context
Phase 3 of QUA-284 (Fresh-Signal-First PR Patrol). Builds on Phase 1 (#4196, `timelineItems` plumbing) and Phase 2 (#4199, `stuckCycles`). Both dependencies merged today.

## Implementation
- `crux/lib/pr-analysis/dependency-surfacing.ts` (new)
  - `extractPrRefsFromText(text)` — finds `#NNNN` tokens with word-boundary guards
  - `extractPrReferences(pr, openPrs, failingChecks?)` — body + gate-error refs, validated against open PR set
  - `applyDependencySurfacing(detected, rawNodes)` — three-pass: (1) body/gate per PR, (2) invert timeline `CrossReferencedEvent.source` across all nodes, (3) aggregate `blocksOthers`
- GraphQL queries in `detection.ts` now fetch `CrossReferencedEvent.source` (PullRequest `number`/`state`, Issue `number`)
- `scoring.ts`: `HUB_BOOST` / `HUB_BLOCKS_THRESHOLD` constants + gate in `computeScore`
- `pr-patrol/index.ts`: wires `applyDependencySurfacing` into the scan loop (after stuck detection), renders chain + hub annotations in the fix-queue log
- All refs validated against the current open-PR set → merged/closed PRs and issue numbers dropped automatically

## Test plan
- [x] 22 new tests in `crux/lib/pr-analysis/dependency-surfacing.test.ts` cover text extraction, open-set validation, structural inversion, dedup precedence, `blocksOthers` aggregation, scoring boost gates, and adversarial inputs (self-ref, zero/negative, null/empty, merged-ref filter)
- [x] Full `pr-analysis` + `pr-patrol` test suite: 361 tests pass (15 files)
- [x] Gate check passes (48 checks)
- [x] Typecheck: no new errors in changed files (crux baseline advisory)

Fixes QUA-287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
