### PR TITLE
refactor: migrate crux clients to /api/sourcing/ (re-do #4186)

### DIFF
--- a/crux/lib/sourcing-context.ts
+++ b/crux/lib/sourcing-context.ts
@@ -64,7 +64,7 @@ async function fetchActionableVerdicts(
     ACTIONABLE_VERDICTS.map((verdict) =>
       apiRequest<VerdictsResponse>(
         'GET',
-        `/api/source-checks/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
+        `/api/sourcing/verdicts?entity_id=${encodeURIComponent(entityId)}&verdict=${verdict}&limit=50`,
       )
     )
   );

--- a/crux/lib/wiki-server/__tests__/sourcing.test.ts
+++ b/crux/lib/wiki-server/__tests__/sourcing.test.ts
@@ -47,7 +47,7 @@ describe('getVerdictsByEntity', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/by-entity/sid_abc123',
+      '/api/sourcing/by-entity/sid_abc123',
     );
   });
 
@@ -64,7 +64,7 @@ describe('getVerdictsByEntity', () => {
     });
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toContain('/api/source-checks/by-entity/sid_abc123?');
+    expect(url).toContain('/api/sourcing/by-entity/sid_abc123?');
     expect(url).toContain('limit=10');
     expect(url).toContain('offset=20');
     expect(url).toContain('verdict=contradicted');
@@ -91,7 +91,7 @@ describe('getVerdictsByEntity', () => {
     await getVerdictsByEntity('sid_abc123');
 
     const url = mockApiRequest.mock.calls[0][1];
-    expect(url).toBe('/api/source-checks/by-entity/sid_abc123');
+    expect(url).toBe('/api/sourcing/by-entity/sid_abc123');
     expect(url).not.toContain('?');
   });
 });
@@ -117,7 +117,7 @@ describe('getVerdictsByPage', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/by-page/anthropic',
+      '/api/sourcing/by-page/anthropic',
     );
   });
 
@@ -156,7 +156,7 @@ describe('getFailures', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/failures',
+      '/api/sourcing/failures',
     );
   });
 
@@ -210,7 +210,7 @@ describe('getStaleVerdicts', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/stale',
+      '/api/sourcing/stale',
     );
   });
 
@@ -264,7 +264,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/verdicts?verdict=contradicted&limit=200',
+      '/api/sourcing/verdicts?verdict=contradicted&limit=200',
     );
   });
 
@@ -278,7 +278,7 @@ describe('getVerdictsByType', () => {
 
     expect(mockApiRequest).toHaveBeenCalledWith(
       'GET',
-      '/api/source-checks/verdicts?verdict=confirmed&limit=50',
+      '/api/sourcing/verdicts?verdict=confirmed&limit=50',
     );
   });
 });

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -34,14 +34,14 @@ export type VerdictListEntry = ListVerdictsResult['verdicts'][number];
 export async function storeEvidence(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreEvidenceResult>> {
-  return apiRequest<StoreEvidenceResult>('POST', '/api/source-checks/evidence', body);
+  return apiRequest<StoreEvidenceResult>('POST', '/api/sourcing/evidence', body);
 }
 
 /** Store an aggregate verdict for a record. */
 export async function storeVerdict(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreVerdictResult>> {
-  return apiRequest<StoreVerdictResult>('POST', '/api/source-checks/verdicts', body);
+  return apiRequest<StoreVerdictResult>('POST', '/api/sourcing/verdicts', body);
 }
 
 /** List verdicts with optional filters. */
@@ -56,7 +56,7 @@ export async function listVerdicts(
   const qs = params.toString();
   return apiRequest<ListVerdictsResult>(
     'GET',
-    `/api/source-checks/verdicts${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/verdicts${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -67,7 +67,7 @@ export async function getVerdictByRecord(
 ): Promise<ApiResult<VerdictByRecordResult>> {
   return apiRequest<VerdictByRecordResult>(
     'GET',
-    `/api/source-checks/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
+    `/api/sourcing/verdicts/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`,
   );
 }
 
@@ -82,13 +82,13 @@ export async function getEvidenceByRecord(
   const qs = params.toString();
   return apiRequest<EvidenceByRecordResult>(
     'GET',
-    `/api/source-checks/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
+    `/api/sourcing/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
   );
 }
 
 /** Get sourcing statistics. */
 export async function getSourcingStats(): Promise<ApiResult<SourcingStatsResult>> {
-  return apiRequest<SourcingStatsResult>('GET', '/api/source-checks/stats');
+  return apiRequest<SourcingStatsResult>('GET', '/api/sourcing/stats');
 }
 
 /** Get records due for re-check. */
@@ -101,6 +101,6 @@ export async function getDueForRecheck(
   const qs = params.toString();
   return apiRequest<DueForRecheckResult>(
     'GET',
-    `/api/source-checks/due-for-recheck${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/due-for-recheck${qs ? `?${qs}` : ''}`,
   );
 }

--- a/crux/lib/wiki-server/sourcing.ts
+++ b/crux/lib/wiki-server/sourcing.ts
@@ -39,7 +39,7 @@ export async function getVerdictsByType(
 ): Promise<ApiResult<VerdictsResponse>> {
   return apiRequest<VerdictsResponse>(
     'GET',
-    `/api/source-checks/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
+    `/api/sourcing/verdicts?verdict=${encodeURIComponent(verdict)}&limit=${limit}`,
   );
 }
 
@@ -57,7 +57,7 @@ export async function getVerdictsByEntity(
   const qs = params.toString();
   return apiRequest<ByEntityResponse>(
     'GET',
-    `/api/source-checks/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/by-entity/${encodeURIComponent(entityId)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -74,7 +74,7 @@ export async function getVerdictsByPage(
   const qs = params.toString();
   return apiRequest<ByPageResponse>(
     'GET',
-    `/api/source-checks/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/by-page/${encodeURIComponent(pageSlug)}${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -99,7 +99,7 @@ export async function getFailures(
   const qs = params.toString();
   return apiRequest<FailuresResponse>(
     'GET',
-    `/api/source-checks/failures${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/failures${qs ? `?${qs}` : ''}`,
   );
 }
 
@@ -124,7 +124,7 @@ export async function getStaleVerdicts(
   const qs = params.toString();
   return apiRequest<StaleResponse>(
     'GET',
-    `/api/source-checks/stale${qs ? `?${qs}` : ''}`,
+    `/api/sourcing/stale${qs ? `?${qs}` : ''}`,
   );
 }
 

--- a/crux/scripts/backfill-fact-entity-ids.ts
+++ b/crux/scripts/backfill-fact-entity-ids.ts
@@ -137,7 +137,7 @@ async function fetchNullEntityVerdicts(): Promise<VerdictRow[]> {
   while (rows.length < total) {
     const res = await apiFetch(
       "GET",
-      `/api/source-checks/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
+      `/api/sourcing/verdicts?record_type=fact&limit=${PAGE}&offset=${offset}`,
     );
     if (!res.ok) {
       console.error(`Failed to fetch verdicts: ${res.error}`);
@@ -245,7 +245,7 @@ async function main() {
       sourcesChecked: row.sourcesChecked ?? undefined,
     };
 
-    const res = await apiFetch("POST", "/api/source-checks/verdicts", body);
+    const res = await apiFetch("POST", "/api/sourcing/verdicts", body);
 
     if (res.ok) {
       success++;

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -450,7 +450,7 @@ async function scanSourceQuality(): Promise<TableScanResult> {
   while (true) {
     const result = await apiRequest<{ verdicts: VerdictRow[]; total: number }>(
       'GET',
-      `/api/source-checks/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
+      `/api/sourcing/verdicts?verdict=unverifiable&limit=${pageSize}&offset=${offset}`,
     );
     if (!result.ok) {
       console.warn(`[tablebase] Failed to fetch unverifiable verdicts: ${result.message}`);

--- a/crux/validate/.sourcing-baseline.json
+++ b/crux/validate/.sourcing-baseline.json
@@ -2,8 +2,8 @@
   "hyphenated": 4,
   "camelCase": 1,
   "PascalCase": 0,
-  "route": 18,
-  "total": 23,
-  "updatedAt": "2026-04-12T03:02:06.560Z",
+  "route": 2,
+  "total": 7,
+  "updatedAt": "2026-04-12T19:16:58.756Z",
   "notes": "Ratchet baseline for source-check → sourcing rename. Only lower this value; never raise without justification. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella)."
 }

--- a/crux/validate/validate-sourcing-names.ts
+++ b/crux/validate/validate-sourcing-names.ts
@@ -52,7 +52,7 @@ export async function validateSourcingNames(): Promise<{
     // Fetch a sample of verdicts
     const verdictsResult = await apiRequest<VerdictsResponse>(
       'GET',
-      `/api/source-checks/verdicts?record_type=${recordType}&limit=20`
+      `/api/sourcing/verdicts?record_type=${recordType}&limit=20`
     );
 
     if (!verdictsResult.ok) {
@@ -92,7 +92,7 @@ export async function validateSourcingNames(): Promise<{
     const idList = [...recordIds].join(',');
     const namesResult = await apiRequest<ResolveNamesResponse>(
       'GET',
-      `/api/source-checks/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
+      `/api/sourcing/resolve-names?record_type=${recordType}&record_ids=${encodeURIComponent(idList)}`
     );
 
     if (!namesResult.ok) {


### PR DESCRIPTION
## Summary

Re-does the client migration that PR #4186 attempted. #4186 was closed because prod `/api/sourcing/` returned 404 at the time — that was actually a symptom of a stuck deploy (migration 0173 lock timeout), not a real alias bug. Once deploy #4180 succeeded on retry, `/api/sourcing/` became available in prod.

**Verified against prod (2026-04-12):**
- `GET /api/sourcing/stats` → 200 with valid JSON
- `GET /api/source-checks/stats` → 200 with identical payload (via alias at `app.ts:207`)

## Changes

Migrates 18 route references from `/api/source-checks/` → `/api/sourcing/` in crux client code:

| File | Refs |
|---|---|
| `crux/lib/wiki-server/sourcing.ts` | 6 |
| `crux/lib/wiki-server/sourcing-client.ts` | 6 |
| `crux/lib/sourcing-context.ts` | 1 |
| `crux/tablebase/scanner.ts` | 1 |
| `crux/validate/validate-sourcing-names.ts` | 2 |
| `crux/scripts/backfill-fact-entity-ids.ts` | 2 |
| `crux/lib/wiki-server/__tests__/sourcing.test.ts` | 8 (test assertions) |

## Ratchet

Baseline regenerated: **23 → 7** (-16 enforced, 18 route refs eliminated; 2 remaining route refs are the backward-compat alias itself at `app.ts:207`).

Remaining 7 refs breakdown:
- 4 hyphenated: `source_check_evidence` / `source_check_verdicts` PG table / column bindings
- 1 camelCase: similar binding
- 2 route: the backward-compat alias itself in `app.ts`

These cannot move without a data migration (separate decision — see #4193 closing comment for context).

## Correction

PR #4194 was retitled mid-flight; its merge only changed `.claude/commands/maintain-pr-patrol.md`, NOT the ratchet validator. The `countInText` change described in #4194's PR body never landed on main. No validator changes needed in this PR — the ratchet was already correctly counting all four axes.

## Test plan

- [x] `npx vitest run crux/lib/wiki-server/__tests__/sourcing.test.ts crux/validate/validate-sourcing-lint-guard.test.ts` — 31/31 pass
- [x] `npx tsc --noEmit --project crux/tsconfig.json` on changed files — no new errors (pre-existing baseline errors on unrelated files)
- [x] `pnpm crux w validate gate --scope=content --fix` — green
- [x] Prod endpoints verified with auth token (both paths return identical payloads)
- [x] Ratchet baseline regenerated and committed

## Related

- Closes #4193 (misdiagnosed as alias bug; actual cause was stuck deploy)
- Supersedes closed #4186
- Unwinds #4175 (which was correct at the time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
