### PR TITLE
rules: slot isolation + enforcement hooks + Fix-Systems principle

### DIFF
--- a/.claude/hooks/block-other-slots.sh
+++ b/.claude/hooks/block-other-slots.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Block commands that cd into or operate on other agent slots.
+# Each slot is an independent workspace — touching another slot's files
+# can corrupt active sessions and cause irreversible data loss.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# Get current slot from CLAUDE_PROJECT_DIR
+CURRENT_SLOT=$(basename "$CLAUDE_PROJECT_DIR")
+
+# Check for cd/pushd into other slot directories
+if echo "$COMMAND" | grep -qE '(cd|pushd)\s+.*/lw/a[0-9]+' ; then
+  # Extract the target slot
+  TARGET=$(echo "$COMMAND" | grep -oE '/lw/a[0-9]+' | head -1 | sed 's|.*/||')
+  if [ "$TARGET" != "$CURRENT_SLOT" ] && [ -n "$TARGET" ]; then
+    echo "BLOCKED: Cannot cd into slot $TARGET — it may have an active Claude session."
+    echo "  You own slot $CURRENT_SLOT only. Other slots are off-limits."
+    echo "  For branch isolation, use /tmp/ worktrees from lw/main instead."
+    exit 2
+  fi
+fi
+
+# Also block pkill/killall that could hit other sessions
+if echo "$COMMAND" | grep -qE '(pkill|killall)\s+.*(claude|next|node)'; then
+  echo "BLOCKED: pkill/killall commands targeting claude/next/node are prohibited."
+  echo "  They can kill processes in other agent slots."
+  echo "  Kill specific PIDs instead, after verifying they belong to your session."
+  exit 2
+fi

--- a/.claude/hooks/block-tmux-kill.sh
+++ b/.claude/hooks/block-tmux-kill.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Block tmux kill-window/kill-session/kill-pane commands
+# These destroy other agents' sessions and cause irreversible data loss.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if echo "$COMMAND" | grep -qE 'tmux\s+(kill-window|kill-session|kill-pane|kill-server)'; then
+  echo "BLOCKED: tmux kill commands are prohibited — they destroy other agents' active sessions."
+  echo "  If you need to close a tmux window, ask the user to do it manually."
+  echo "  Other agents may have hours of accumulated context that cannot be recovered."
+  exit 2
+fi

--- a/.claude/rules/slot-isolation.md
+++ b/.claude/rules/slot-isolation.md
@@ -1,0 +1,52 @@
+# Slot Isolation — NEVER Touch Other Agent Slots
+
+## The Rule
+
+Each agent slot (`lw/a1` through `lw/a20`) is an **independent workspace** with its own Claude Code session. You own exactly ONE slot — the one you're running in. Every other slot is off-limits.
+
+## What You Must NEVER Do
+
+1. **Never `cd` into another slot's directory** — not even to "check" something
+2. **Never dispatch subagents to another slot** — use `/tmp/` worktrees instead
+3. **Never kill tmux windows** for other slots — they may have active sessions
+4. **Never run commands** that affect other slots (e.g., `pkill` matching patterns that could hit their processes)
+5. **Never assume a slot is idle** — what looks idle from outside may have hours of accumulated session context
+
+## Why This Matters — Incident History
+
+This rule exists because of two real incidents in a single session:
+
+1. **Slot corruption**: A patrol agent dispatched subagents to a5 and a6 to fix PRs. Those slots had other sessions that were disrupted by the branch checkouts.
+2. **Session destruction**: The same agent later killed "stale" tmux windows without checking. This destroyed an active Claude session in a3 that was working on PR #4010, losing all session context and in-progress reasoning.
+
+## What To Do Instead
+
+| Need | Solution |
+|------|----------|
+| Fix code on another branch | Create `/tmp/` worktree from `lw/main` clone |
+| Edit PR metadata (body, labels) | Use `gh` CLI — no checkout needed |
+| Check another slot's status | Use `./ws list` from the workspace root |
+| Kill a process or tmux window | **Ask the user first** — always |
+
+## For Patrol / Coordinator Sessions
+
+PR patrol sessions frequently need to fix code on branches they don't own. The correct workflow:
+
+```bash
+# From the main clone (NOT from another slot):
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main
+git fetch origin
+git worktree add /tmp/fix-<PR#> <branch-name>
+cd /tmp/fix-<PR#>
+# ... symlink node_modules, fix, push ...
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main
+git worktree remove /tmp/fix-<PR#>
+```
+
+## Destructive Actions Require Confirmation
+
+Before ANY destructive action on shared resources, ask the user:
+- Killing processes (`kill`, `pkill`)
+- Removing tmux windows (`tmux kill-window`)
+- Deleting files outside your slot
+- Force-pushing to branches you didn't create

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,14 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-tmux-kill.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-other-slots.sh\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-raw-gh-pr.sh\""
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,21 @@ Adding a new directory requires: schema in `entity-schemas.ts`, transform in `en
 
 - **Thorough over fast.** Robust implementations that handle edge cases beat quick ones that only cover the happy path. See `.claude/rules/implementation-quality.md`.
 
+## Problem-Solving: Fix Systems, Not Instances
+
+When you encounter any problem — a bug, a process failure, a repeated mistake — **do not jump to fixing the specific instance.** First, think one or more levels up:
+
+1. **What class of problem is this?** (e.g., "patrol missed a check" → "check name matching is brittle")
+2. **What systemic change prevents the entire class?** (e.g., use substring matching instead of exact strings)
+3. **Can you go even more meta?** (e.g., "why do we have hardcoded names at all? Can we derive them from the API?")
+4. **Implement the systemic fix** — update code, rules, hooks, docs, or tests
+5. **Then** fix the specific instance
+
+This applies to everything: code bugs, process failures, documentation gaps, agent behavior issues. The goal is that each problem you encounter makes the system permanently more robust, not just patches the symptom. Inspired by Toyota's 5 Whys, Google SRE blameless postmortems, and the principle that you can't fix behavior but you can fix systems.
+
 ## Key Conventions
 
+- **Slot isolation — CRITICAL**: Each agent slot (`a1`–`a20`) is an independent workspace that may have an active Claude session. **NEVER** interact with slots you don't own: no `cd` into them, no dispatching subagents to them, no killing their tmux windows, no running commands in their directories. If you need branch isolation for PR fixes, use `/tmp/` worktrees from the `main/` clone. If you need to kill a process or tmux window, **ask the user first** — what looks idle from outside may have active work. Violating this rule has caused data loss (destroyed active sessions with in-progress work). See `.claude/rules/slot-isolation.md`.
 - **Branch discipline**: Never switch branches mid-session — PreToolUse hooks block `git checkout <branch>`, `git switch`, and `git stash`. **Do NOT use `isolation: "worktree"` in Agent calls** — it has a [confirmed Claude Code bug](https://github.com/anthropics/claude-code/issues/42282) that corrupts the parent session's working directory and bricks the session. For branch isolation, use agent workspace slots (`lw/a1`–`lw/a15`). See `.claude/rules/worktree-isolation-bug.md`. To create a new branch from the current one, `git checkout -b claude/<description>` is allowed. Never edit files on `main` — a PreToolUse hook blocks Edit/Write on main. If a dev server was running, restart it after switching branches (Next.js serves from the current working directory, not the branch the server was started from).
 - **Path aliases**: `@/`, `@components/`, `@data/`, `@lib/` in app code
 - **Entity types**: Canonical list in `apps/web/src/data/entity-type-names.ts`


### PR DESCRIPTION
## Summary

Ships the slot-isolation rule + two enforcement hooks + a general "Fix Systems, Not Instances" principle. Addresses the incident where a patrol agent destroyed an active session in a different slot by checking out branches into that slot's directory and terminating its tmux window.

## Changes

| File | What |
|---|---|
| `.claude/rules/slot-isolation.md` (new) | Explicit rule: agents own exactly one slot, never touch other slots' directories/tmux, must ask before destructive actions on shared resources |
| `.claude/hooks/block-other-slots.sh` (new) | PreToolUse hook: blocks cd/writes/commands targeting a different slot than the current one |
| `.claude/hooks/block-tmux-kill.sh` (new) | PreToolUse hook: blocks `tmux kill-*` commands that silently destroy active sessions |
| `.claude/settings.json` | Wire both hooks into PreToolUse |
| `CLAUDE.md` | Add "Problem-Solving: Fix Systems, Not Instances" section (5-step process) + slot-isolation bullet in Key Conventions pointing at the new rule |

## Why now

Real incident earlier in the session: a patrol agent running in one slot dispatched subagents to other slots to rebase PRs, disrupting those slots' active Claude sessions. Later in the same session, the same agent identified "stale" tmux windows and killed them — one belonged to an active session working on an in-progress PR. Lost hours of accumulated reasoning.

The hooks are defense in depth — the rule is the authoritative source, the hooks are a cheap backstop when an agent forgets.

## Test plan

- [x] Gate check passes (46 checks green)
- [x] `.claude/settings.json` valid JSON
- [x] Both new hooks are executable (`chmod +x` set in git)
- [ ] Post-merge: cd into a sibling slot from another slot should block
- [ ] Post-merge: tmux kill-window attempt should block

## Rollback

`git revert`. No code changes, no CI wiring, no runtime changes other than the new PreToolUse hooks (which block obvious misuse; false positives surface as denied tool calls, not data loss).
