### PR TITLE
docs: require prod enum enumeration before CHECK constraints

### DIFF
--- a/.claude/rules/database-migrations.md
+++ b/.claude/rules/database-migrations.md
@@ -55,7 +55,9 @@ The gate check (`validate-drizzle-journal.ts`) warns if it detects CREATE UNIQUE
 
 **Never write a CHECK constraint's allowed-value list from code or memory.** Enumerate against prod data first, or the migration will fail when it encounters values the author didn't know existed.
 
-Incident context: Migrations 0173 (`chk_hrs_level`) and `service_health_incidents.severity` both shipped CHECK constraints whose `IN (...)` lists excluded live values already present in the table. 0173 cascaded into a ~12h prod outage (QUA-302); severity required a follow-up fix (#4202). Both root-caused to "author inspected the schema/enum type and didn't query actual column values."
+Incident context: two enum-gap incidents in the same week. Migration 0173's `groundskeeper_runs.event` constraint omitted three valid values already in prod (`circuit_breaker_reset`, `half_open_attempt`, `half_open_success`), blocking the #4167 release at ArgoCD PreSync until #4178 landed. `service_health_incidents.severity` shipped with a similarly incomplete allowlist and needed #4202. Both root-caused to the same mistake: author inspected the TypeScript enum / Zod schema instead of querying the column's live distinct values.
+
+(Note: migration 0173's `chk_hrs_level` *also* caused a separate ~12h outage (QUA-302), but that was lock contention, not an enum gap — see the `NOT VALID` pattern below.)
 
 **Required procedure before writing any `CHECK (col IN (...))` constraint:**
 

--- a/.claude/rules/database-migrations.md
+++ b/.claude/rules/database-migrations.md
@@ -51,6 +51,25 @@ Reference implementations: `0108_natural_key_uniqueness.sql`, `0143_dedup_fundin
 
 The gate check (`validate-drizzle-journal.ts`) warns if it detects CREATE UNIQUE INDEX with hardcoded DELETEs.
 
+## Adding CHECK constraints on enum columns — MANDATORY pattern
+
+**Never write a CHECK constraint's allowed-value list from code or memory.** Enumerate against prod data first, or the migration will fail when it encounters values the author didn't know existed.
+
+Incident context: Migrations 0173 (`chk_hrs_level`) and `service_health_incidents.severity` both shipped CHECK constraints whose `IN (...)` lists excluded live values already present in the table. 0173 cascaded into a ~12h prod outage (QUA-302); severity required a follow-up fix (#4202). Both root-caused to "author inspected the schema/enum type and didn't query actual column values."
+
+**Required procedure before writing any `CHECK (col IN (...))` constraint:**
+
+1. Query prod for the full distinct-value set:
+   ```sql
+   SELECT col, count(*) FROM my_table GROUP BY col ORDER BY count DESC;
+   ```
+2. Paste the output into the PR description under a `### Enum enumeration` heading.
+3. Build the `IN (...)` list from that output, not from an enum type, TypeScript union, or your recollection of "the valid values."
+4. If the live set contains values you think should be invalid, **add them to the constraint anyway** and file a separate cleanup ticket. A migration is not the place to retroactively narrow an enum.
+5. For large tables, combine with the `NOT VALID` + `VALIDATE CONSTRAINT` pattern below.
+
+This applies equally to new constraints and to ALTERing existing ones to a tighter set.
+
 ## When Drizzle migrations work fine
 
 Most migrations: adding columns, creating tables, adding indexes on small tables, inserting rows. These complete in seconds and work through the normal Drizzle migration runner.


### PR DESCRIPTION
## Summary

From the 2026-04-12 retrospective: two CHECK-constraint incidents in 7 days (migration 0173 → ~12h prod outage, `service_health_incidents.severity` → #4202) both root-caused to authors building `IN (...)` allowlists from schema inspection or memory, missing values that were already live in the table.

This adds a MANDATORY section to `.claude/rules/database-migrations.md` requiring:

1. `SELECT DISTINCT` against prod before writing the constraint
2. Paste the output into the PR under `### Enum enumeration`
3. Include all live values even if some "shouldn't" be valid (file a separate cleanup ticket instead of narrowing the enum in the constraint migration)

Docs-only, no behavior change.

## Test plan

- [x] Proofread the new section reads cleanly
- [ ] Reviewer confirms the procedure is actionable for future migrations
