### PR TITLE
fix(pr-patrol): bugs from /agent-review-pr on health-scan (QUA-298 follow-up)

### DIFF
--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateDeployStatus,
   evaluateMainCi,
   combineHealth,
+  mapRollupState,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
   DEPLOY_STALE_THRESHOLD_HOURS,
@@ -291,5 +292,100 @@ describe('combineHealth', () => {
   it('both issue scores outrank the highest per-PR issue score (conflict=100)', () => {
     expect(DEPLOY_STUCK_SCORE).toBeGreaterThan(100);
     expect(MAIN_CI_RED_SCORE).toBeGreaterThan(100);
+  });
+});
+
+// ── Regression: leading in-progress deploy does not hide failing streak ─────
+
+describe('evaluateDeployStatus — in-progress at head', () => {
+  it('skips a leading null-conclusion run and still sees the failing streak under it', () => {
+    const result = evaluateDeployStatus([
+      run({ id: 9, conclusion: null, status: 'in_progress', createdAt: '2026-04-12T07:00:00Z' }),
+      run({ id: 1, conclusion: 'failure', createdAt: '2026-04-12T06:01:00Z' }),
+      run({ id: 2, conclusion: 'failure', createdAt: '2026-04-11T22:57:00Z' }),
+      run({ id: 3, conclusion: 'success', createdAt: '2026-04-11T18:29:00Z' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.failingDeploys.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('treats all-pending as healthy (nothing resolved yet)', () => {
+    const result = evaluateDeployStatus([
+      run({ id: 1, conclusion: null, status: 'in_progress' }),
+      run({ id: 2, conclusion: null, status: 'queued' }),
+    ]);
+    expect(result.healthy).toBe(true);
+  });
+});
+
+// ── Regression: pending mid-list does not collapse into fake streak ─────────
+
+describe('evaluateMainCi — mid-list pending interruption', () => {
+  it('does NOT collapse [fail, pending, fail, fail] into a 3-streak', () => {
+    // Pre-fix this returned streak=3. Post-fix: only LEADING pending is skipped;
+    // a pending mid-list breaks the streak the same way a success would.
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'pending' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+      commit({ sha: 'd', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(1);
+  });
+
+  it('skips only the leading pending when it precedes a 3-failure streak', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'pending', conclusion: 'pending' }),
+      commit({ sha: 'a', conclusion: 'failure', createdAt: '2026-04-12T06:00:00Z' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure', createdAt: '2026-04-12T04:00:00Z' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.failingCount).toBe(3);
+  });
+
+  it('treats null conclusion the same as pending at the head', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'unknown', conclusion: null }),
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.failingCount).toBe(3);
+  });
+
+  it('treats a neutral conclusion as not-failure (breaks streak)', () => {
+    const result = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'neutral' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+      commit({ sha: 'd', conclusion: 'failure' }),
+    ]);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(1);
+  });
+});
+
+// ── mapRollupState — GraphQL enum coverage ──────────────────────────────────
+
+describe('mapRollupState', () => {
+  it('maps SUCCESS → success', () => {
+    expect(mapRollupState('SUCCESS')).toBe('success');
+  });
+  it('maps FAILURE and ERROR → failure', () => {
+    expect(mapRollupState('FAILURE')).toBe('failure');
+    expect(mapRollupState('ERROR')).toBe('failure');
+  });
+  it('maps PENDING and EXPECTED → pending', () => {
+    expect(mapRollupState('PENDING')).toBe('pending');
+    expect(mapRollupState('EXPECTED')).toBe('pending');
+  });
+  it('maps NEUTRAL → neutral (not dropped to null)', () => {
+    expect(mapRollupState('NEUTRAL')).toBe('neutral');
+  });
+  it('maps null → null', () => {
+    expect(mapRollupState(null)).toBeNull();
   });
 });

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -111,10 +111,13 @@ export interface HealthScanResult {
  * whether the deploy pipeline is healthy.
  *
  * Rules:
- *  - ≥ DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES failures at the head of the list → unhealthy
- *  - Last successful deploy older than DEPLOY_STALE_THRESHOLD_HOURS with at least
- *    one failure since → unhealthy (catches the "nothing deploying" case too)
+ *  - ≥ DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES failures at the head → unhealthy
+ *  - Last successful deploy older than DEPLOY_STALE_THRESHOLD_HOURS AND at least
+ *    one failure since → unhealthy (age + hint of breakage)
  *  - Otherwise healthy, even if there's a single old failure buried in the list
+ *
+ * Note: "no deploys in 6h" alone is not flagged — the repo may simply be quiet.
+ * A failure since the last success is required to rule out "nothing to deploy".
  */
 export function evaluateDeployStatus(
   runs: WorkflowRun[],
@@ -129,18 +132,25 @@ export function evaluateDeployStatus(
     };
   }
 
+  // Skip LEADING in-progress runs (conclusion null). An in-progress run at the
+  // head shouldn't hide a failing streak underneath — treat it as "not yet
+  // resolved" and look at what's already settled.
+  let headIdx = 0;
+  while (headIdx < runs.length && runs[headIdx].conclusion === null) headIdx++;
+  const resolved = runs.slice(headIdx);
+
   let consecutiveFailures = 0;
-  for (const run of runs) {
+  for (const run of resolved) {
     if (run.conclusion === 'failure') consecutiveFailures++;
     else break;
   }
 
-  const lastSuccess = runs.find((r) => r.conclusion === 'success') ?? null;
+  const lastSuccess = resolved.find((r) => r.conclusion === 'success') ?? null;
   const lastSuccessfulDeployAt = lastSuccess ? new Date(lastSuccess.createdAt) : null;
-  const failingDeploys = runs.slice(0, consecutiveFailures);
+  const failingDeploys = resolved.slice(0, consecutiveFailures);
 
   if (consecutiveFailures >= DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES) {
-    const last = runs[0];
+    const last = resolved[0];
     const reason =
       `${consecutiveFailures} consecutive production deploy failures ` +
       `(most recent: ${last.displayTitle} at ${last.createdAt})`;
@@ -183,7 +193,18 @@ export function evaluateDeployStatus(
  * Pending checks at the head are skipped (not counted as either pass or fail).
  */
 export function evaluateMainCi(commits: CommitStatus[]): MainCiResult {
-  const resolved = commits.filter((c) => c.conclusion !== 'pending' && c.conclusion !== null);
+  // Skip LEADING pending / null commits only. Stripping pending globally would
+  // collapse [fail, pending, fail, fail] into a fake 3-streak. Pending in the
+  // middle of the list breaks the streak like any other non-failure would.
+  let start = 0;
+  while (
+    start < commits.length &&
+    (commits[start].conclusion === 'pending' || commits[start].conclusion === null)
+  ) {
+    start++;
+  }
+  const resolved = commits.slice(start);
+
   if (resolved.length === 0) {
     return {
       healthy: true,
@@ -299,7 +320,8 @@ export async function checkDeployStatus(
   const limit = options.limit ?? 5;
 
   const resp = await githubApi<ListRunsResponse>(
-    `/repos/${REPO}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=${limit}`,
+    `/repos/${REPO}/actions/workflows/${encodeURIComponent(workflow)}/runs` +
+      `?branch=${encodeURIComponent(branch)}&per_page=${limit}`,
   );
 
   const runs: WorkflowRun[] = resp.workflow_runs.map((r) => ({
@@ -325,7 +347,7 @@ interface MainCommitsGql {
             committedDate: string;
             url: string;
             statusCheckRollup: {
-              state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED';
+              state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL';
             } | null;
           }>;
         };
@@ -388,20 +410,28 @@ export async function checkMainCi(
   return evaluateMainCi(commits);
 }
 
-function mapRollupState(
-  state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | null,
+export function mapRollupState(
+  state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL' | null,
 ): CommitStatus['conclusion'] {
   if (state === 'SUCCESS') return 'success';
   if (state === 'FAILURE' || state === 'ERROR') return 'failure';
   if (state === 'PENDING' || state === 'EXPECTED') return 'pending';
+  if (state === 'NEUTRAL') return 'neutral';
   return null;
 }
 
 /**
  * Run both scanners and combine into one HealthScanResult. Intended to be
  * called at the start of each patrol cycle (Phase 3 wiring).
+ *
+ * Throws if either GitHub call fails (5xx, rate limit, network). Phase 3 is
+ * responsible for deciding policy on scanner failure — a transient API hiccup
+ * shouldn't silently look like "healthy".
  */
-export async function healthScan(): Promise<HealthScanResult> {
-  const [deploy, mainCi] = await Promise.all([checkDeployStatus(), checkMainCi()]);
-  return combineHealth(deploy, mainCi);
+export async function healthScan(now: Date = new Date()): Promise<HealthScanResult> {
+  const [deploy, mainCi] = await Promise.all([
+    checkDeployStatus({ now }),
+    checkMainCi(),
+  ]);
+  return combineHealth(deploy, mainCi, now);
 }


### PR DESCRIPTION
## Summary

Follow-up to #4210 (QUA-298 Phase 1). `/agent-review-pr` ran after #4210 merged and found real bugs that I missed before shipping. This PR fixes them on a fresh branch.

## Bugs fixed

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | URL params not encoded in `checkDeployStatus` — a branch like `"production&per_page=100"` would corrupt the query | `encodeURIComponent(workflow)` + `encodeURIComponent(branch)` |
| HIGH | GraphQL `statusCheckRollup.state` could return `NEUTRAL` (missing from the declared type union) — fell through to `null` and was filtered as unresolved | Added to union + `mapRollupState` returns `'neutral'` |
| MEDIUM | `evaluateMainCi` filtered pending commits **globally**, so `[fail, pending, fail, fail]` collapsed into a fake 3-streak false-positive | Only skip LEADING pending/null entries |
| MEDIUM | `evaluateDeployStatus` broke the streak on `conclusion: null` runs — an in-progress deploy at head hid a failing streak underneath | Skip leading in-progress runs, continue evaluating |
| MEDIUM | `healthScan()` created a fresh `new Date()` in two places — tiny clock-skew between sub-results | Thread a single `now` through both sub-checks and `combineHealth` |
| LOW | Doc-comment on staleness rule misleadingly said "catches nothing deploying" | Clarified: a failure since last success is still required |
| — | `mapRollupState` was internal → no test coverage | Exported + 5 direct tests |

## Tests

- 11 new regression tests (32 total, up from 21)
- Covers all bugs above + the `mapRollupState` enum coverage that was missing
- Live dry-run against prod still returns `{healthy: true, issues: []}`

## Test plan

- [x] All 32 health-scan tests pass
- [x] Full `crux/pr-patrol/` suite (298 tests) still green
- [x] Typecheck clean on changed files
- [x] Live prod probe returns healthy

Refs QUA-298 (now follow-up)
Refs QUA-297 (parent)

Fixes QUA-298
