### PR TITLE
feat(pr-patrol): ratchet-drift scanner (QUA-299 Phase 2)

### DIFF
--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -6,6 +6,8 @@ import {
   evaluateRatchetDrift,
   combineHealth,
   combineRatchetDrift,
+  checkRatchetDriftForFile,
+  readBaselineTotal,
   mapRollupState,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
@@ -20,6 +22,7 @@ import {
   type BaselineObservation,
   type RatchetDriftResult,
 } from './health-scan.ts';
+import type { RatchetConfig } from './ratchet-config.ts';
 
 function emptyRatchet(): RatchetDriftResult {
   return combineRatchetDrift([]);
@@ -635,6 +638,223 @@ describe('combineHealth with ratchet drift', () => {
     const scores = combined.issues.map((i) => i.score);
     expect(scores[0]).toBeGreaterThan(scores[1]);
     expect(scores[1]).toBeGreaterThan(scores[2]);
+  });
+});
+
+// ── readBaselineTotal (numeric-type handling) ────────────────────────────────
+
+describe('readBaselineTotal', () => {
+  const cfg: RatchetConfig = {
+    file: 'x.json',
+    name: 'x',
+    totalField: 'total',
+    badDirection: 'up',
+  };
+
+  it('reads a numeric total', () => {
+    const runGit = () => ({ ok: true, output: '{"total": 23}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBe(23);
+  });
+
+  it('coerces a numeric-string total (regression: validators may serialize as string)', () => {
+    const runGit = () => ({ ok: true, output: '{"total": "23"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBe(23);
+  });
+
+  it('returns null for non-numeric string', () => {
+    const runGit = () => ({ ok: true, output: '{"total": "pending"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null when the field is missing', () => {
+    const runGit = () => ({ ok: true, output: '{"other": 1}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    const runGit = () => ({ ok: true, output: 'not-json', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null when git show fails (file absent at ref)', () => {
+    const runGit = () => ({ ok: false, output: '', stderr: 'fatal: path not in tree' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null for Infinity / NaN (both JSON and string forms)', () => {
+    // JSON doesn't allow Infinity, but the string-coercion branch could hit it.
+    const runGit1 = () => ({ ok: true, output: '{"total": "Infinity"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit1)).toBeNull();
+    const runGit2 = () => ({ ok: true, output: '{"total": "NaN"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit2)).toBeNull();
+  });
+});
+
+// ── checkRatchetDriftForFile (I/O wrapper, mocked gitSafe) ───────────────────
+
+describe('checkRatchetDriftForFile (mocked git)', () => {
+  const NOW = new Date('2026-04-12T20:00:00Z');
+  const cfg: RatchetConfig = {
+    file: 'crux/validate/.sourcing-baseline.json',
+    name: 'sourcing',
+    totalField: 'total',
+    badDirection: 'up',
+  };
+
+  function makeGit(
+    logOutput: string,
+    showResponses: Record<string, { ok: boolean; output: string; stderr?: string }> = {},
+  ) {
+    return (...args: string[]) => {
+      if (args[0] === 'log') {
+        return { ok: true, output: logOutput, stderr: '' };
+      }
+      if (args[0] === 'show' && args[1] === '-s') {
+        // commitTimestamp: `git show -s --format=%ct <ref>`
+        const ref = args[3];
+        const resp = showResponses[`ts:${ref}`];
+        return resp ?? { ok: false, output: '', stderr: 'not found' };
+      }
+      if (args[0] === 'show') {
+        // readBaselineTotal: `git show <ref>:<file>`
+        const spec = args[1];
+        const resp = showResponses[spec];
+        return resp ?? { ok: false, output: '', stderr: 'not found' };
+      }
+      return { ok: false, output: '', stderr: 'unexpected git call' };
+    };
+  }
+
+  function epoch(iso: string): string {
+    return String(Math.floor(new Date(iso).getTime() / 1000));
+  }
+
+  it('fires when 3 upward bumps appear in the window (file existed before window)', () => {
+    const c1 = { iso: '2026-04-12T10:00:00Z' };
+    const c2 = { iso: '2026-04-12T14:00:00Z' };
+    const c3 = { iso: '2026-04-12T18:00:00Z' };
+    // git log newest-first:
+    const logOutput = [
+      `c3 ${epoch(c3.iso)}`,
+      `c2 ${epoch(c2.iso)}`,
+      `c1 ${epoch(c1.iso)}`,
+    ].join('\n');
+    const showResponses = {
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 2}',
+        stderr: '',
+      },
+      'ts:c1^': { ok: true, output: epoch('2026-04-11T23:00:00Z'), stderr: '' },
+      'c1:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 5}',
+        stderr: '',
+      },
+      'c2:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 10}',
+        stderr: '',
+      },
+      'c3:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 23}',
+        stderr: '',
+      },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+    expect(result.bumps.map((b) => [b.from, b.to])).toEqual([
+      [2, 5],
+      [5, 10],
+      [10, 23],
+    ]);
+  });
+
+  it('handles a file created mid-window (parent-of-first-commit has no file) — 3 later bumps still fire', () => {
+    // File is created by c1 at total=2. Parent c1^ doesn't have the file.
+    // Subsequent commits c2=5, c3=10, c4=23. The evaluator sees observations
+    // [c1=2, c2=5, c3=10, c4=23] — parent is skipped cleanly.
+    const logOutput = [
+      `c4 ${epoch('2026-04-12T18:00:00Z')}`,
+      `c3 ${epoch('2026-04-12T15:00:00Z')}`,
+      `c2 ${epoch('2026-04-12T12:00:00Z')}`,
+      `c1 ${epoch('2026-04-12T09:00:00Z')}`,
+    ].join('\n');
+    const showResponses = {
+      // Parent of c1 has no file — git show returns non-ok
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: false,
+        output: '',
+        stderr: 'fatal: path not in tree',
+      },
+      'c1:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 2}', stderr: '' },
+      'c2:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 5}', stderr: '' },
+      'c3:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 10}', stderr: '' },
+      'c4:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 23}', stderr: '' },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+  });
+
+  it('handles a comment-only commit (touches file but leaves total unchanged)', () => {
+    // c1 touches file but keeps total at 5; c2 bumps to 10; c3 bumps to 23.
+    // Only c1→c2 (up) and c2→c3 (up) are bumps. Plus parent→c1 (2→5, up) if
+    // parent is readable. That gives 3 bumps total.
+    const logOutput = [
+      `c3 ${epoch('2026-04-12T18:00:00Z')}`,
+      `c2 ${epoch('2026-04-12T15:00:00Z')}`,
+      `c1 ${epoch('2026-04-12T12:00:00Z')}`,
+    ].join('\n');
+    const showResponses = {
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 5}',
+        stderr: '',
+      },
+      'ts:c1^': { ok: true, output: epoch('2026-04-12T09:00:00Z'), stderr: '' },
+      // c1 touched the file but didn't change the total
+      'c1:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 5}', stderr: '' },
+      'c2:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 10}', stderr: '' },
+      'c3:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 23}', stderr: '' },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    // Bumps: parent→c1 (5=5, no bump), c1→c2 (5→10 up), c2→c3 (10→23 up) = 2
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(2);
+  });
+
+  it('returns stable+zero-bumps when git log has no commits in the window', () => {
+    const runGit = makeGit('');
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, runGit);
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(0);
+    expect(result.reason).toContain('no commits');
+  });
+
+  it('returns stable when git log fails (propagates reason, not a false-positive drift)', () => {
+    const runGit = () => ({ ok: false, output: '', stderr: 'fatal: not a git repository' });
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, runGit);
+    expect(result.drifted).toBe(false);
+    expect(result.reason).toContain('git log failed');
+    expect(result.reason).toContain('not a git repository');
+  });
+
+  it('uses --since=<iso> derived from `now` (not git wall-clock relative date)', () => {
+    // Capture the --since arg to verify it matches `now - windowHours`.
+    let capturedSince: string | null = null;
+    const runGit = (...args: string[]) => {
+      if (args[0] === 'log') {
+        const sinceArg = args.find((a) => a.startsWith('--since='));
+        capturedSince = sinceArg?.replace('--since=', '') ?? null;
+        return { ok: true, output: '', stderr: '' };
+      }
+      return { ok: false, output: '', stderr: '' };
+    };
+    checkRatchetDriftForFile(cfg, { now: NOW, windowHours: 24 }, runGit);
+    expect(capturedSince).toBe(new Date(NOW.getTime() - 24 * 3_600_000).toISOString());
   });
 });
 

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -3,16 +3,27 @@ import { describe, it, expect } from 'vitest';
 import {
   evaluateDeployStatus,
   evaluateMainCi,
+  evaluateRatchetDrift,
   combineHealth,
+  combineRatchetDrift,
   mapRollupState,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
   DEPLOY_STALE_THRESHOLD_HOURS,
   DEPLOY_STUCK_SCORE,
   MAIN_CI_RED_SCORE,
+  RATCHET_DRIFT_SCORE,
+  RATCHET_DRIFT_MIN_BUMPS,
+  RATCHET_DRIFT_WINDOW_HOURS,
   type WorkflowRun,
   type CommitStatus,
+  type BaselineObservation,
+  type RatchetDriftResult,
 } from './health-scan.ts';
+
+function emptyRatchet(): RatchetDriftResult {
+  return combineRatchetDrift([]);
+}
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -237,7 +248,7 @@ describe('combineHealth', () => {
   it('returns healthy with empty issues when both sub-scanners are healthy', () => {
     const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
     const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(true);
     expect(combined.issues).toHaveLength(0);
   });
@@ -248,7 +259,7 @@ describe('combineHealth', () => {
       run({ id: 2, conclusion: 'failure' }),
     ]);
     const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(false);
     expect(combined.issues).toHaveLength(1);
     expect(combined.issues[0].type).toBe('deploy-stuck');
@@ -264,7 +275,7 @@ describe('combineHealth', () => {
       commit({ sha: 'b', conclusion: 'failure' }),
       commit({ sha: 'c', conclusion: 'failure' }),
     ]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(false);
     expect(combined.issues).toHaveLength(1);
     expect(combined.issues[0].type).toBe('main-ci-red');
@@ -282,7 +293,7 @@ describe('combineHealth', () => {
       commit({ sha: 'b', conclusion: 'failure' }),
       commit({ sha: 'c', conclusion: 'failure' }),
     ]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.issues).toHaveLength(2);
     expect(combined.issues[0].type).toBe('deploy-stuck');
     expect(combined.issues[1].type).toBe('main-ci-red');
@@ -369,6 +380,263 @@ describe('evaluateMainCi — mid-list pending interruption', () => {
 });
 
 // ── mapRollupState — GraphQL enum coverage ──────────────────────────────────
+
+// ── evaluateRatchetDrift (pure) ──────────────────────────────────────────────
+
+describe('evaluateRatchetDrift', () => {
+  const NOW = new Date('2026-04-12T20:00:00Z');
+
+  function obs(hoursAgo: number, total: number | null, commit = `c${hoursAgo}`): BaselineObservation {
+    return {
+      commit,
+      committedAt: new Date(NOW.getTime() - hoursAgo * 3_600_000),
+      total,
+    };
+  }
+
+  it('fires on 3 monotonic upward bumps within 24h (bad direction = up)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 5), obs(5, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+    expect(result.direction).toBe('up');
+    expect(result.bumps.map((b) => [b.from, b.to])).toEqual([
+      [2, 5],
+      [5, 10],
+      [10, 23],
+    ]);
+  });
+
+  it('does NOT fire with only 2 bumps in window (below threshold of 3)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(5, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(2);
+  });
+
+  it('does NOT fire when 3 bumps span a 48h window (rate-limited)', () => {
+    // 3 bumps, but spread across 48h — only the last one is in the 24h window.
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(48, 2), obs(36, 5), obs(30, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW, windowHours: 24 },
+    );
+    expect(result.drifted).toBe(false);
+    // Only the 30h→1h transition is seen as a bump in the windowed view,
+    // because the pre-window parent observation was filtered out.
+    expect(result.bumpCount).toBeLessThan(3);
+  });
+
+  it('does NOT fire on alternating-direction bumps', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 5), obs(8, 20), obs(5, 7), obs(1, 30)],
+      { badDirection: 'up', now: NOW },
+    );
+    // Sequence: 5→20 (up), 20→7 (down, reset), 7→30 (up) → bad-direction streak=1
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(1);
+  });
+
+  it('resets the streak when a good-direction bump interrupts (fix landed mid-window)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 5), obs(6, 10), obs(4, 4), obs(2, 8)],
+      { badDirection: 'up', now: NOW },
+    );
+    // 2→5 up, 5→10 up (streak=2), 10→4 DOWN (reset), 4→8 up (streak=1)
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(1);
+  });
+
+  it('ignores no-op commits (total unchanged) without counting them as bumps', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 2), obs(6, 5), obs(4, 5), obs(2, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3); // 2→5, 5→10, 10→23
+  });
+
+  it('skips observations with null total (file absent at that commit)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, null), obs(8, 2), obs(5, 5), obs(3, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+  });
+
+  it('validates constants', () => {
+    expect(RATCHET_DRIFT_MIN_BUMPS).toBe(3);
+    expect(RATCHET_DRIFT_WINDOW_HOURS).toBe(24);
+  });
+
+  it('fires on 3 downward bumps when bad direction = down (e.g., coverage ratchet)', () => {
+    const result = evaluateRatchetDrift(
+      'coverage.json',
+      'coverage',
+      [obs(10, 100), obs(8, 95), obs(5, 90), obs(1, 80)],
+      { badDirection: 'down', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.direction).toBe('down');
+    expect(result.bumpCount).toBe(3);
+    expect(result.reason).toContain('↓');
+  });
+
+  it('returns a stable-reason for empty observations', () => {
+    const result = evaluateRatchetDrift('x.json', 'x', [], {
+      badDirection: 'up',
+      now: NOW,
+    });
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(0);
+    expect(result.reason).toContain('stable');
+  });
+});
+
+// ── combineRatchetDrift ──────────────────────────────────────────────────────
+
+describe('combineRatchetDrift', () => {
+  it('is healthy when no ratchets are registered', () => {
+    const result = combineRatchetDrift([]);
+    expect(result.healthy).toBe(true);
+    expect(result.reason).toContain('no ratchet');
+  });
+
+  it('is healthy when all registered ratchets are within thresholds', () => {
+    const result = combineRatchetDrift([
+      {
+        file: 'a.json',
+        name: 'a',
+        direction: null,
+        bumpCount: 0,
+        bumps: [],
+        drifted: false,
+        reason: 'ok',
+      },
+    ]);
+    expect(result.healthy).toBe(true);
+  });
+
+  it('is unhealthy when any ratchet drifted', () => {
+    const result = combineRatchetDrift([
+      {
+        file: 'a.json',
+        name: 'a',
+        direction: 'up',
+        bumpCount: 3,
+        bumps: [],
+        drifted: true,
+        reason: 'a bumped 3×',
+      },
+      {
+        file: 'b.json',
+        name: 'b',
+        direction: null,
+        bumpCount: 0,
+        bumps: [],
+        drifted: false,
+        reason: 'ok',
+      },
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toBe('a bumped 3×');
+  });
+});
+
+// ── combineHealth + ratchet integration ──────────────────────────────────────
+
+describe('combineHealth with ratchet drift', () => {
+  const now = new Date('2026-04-12T07:00:00Z');
+
+  it('emits a ratchet-drift issue when a baseline drifted', () => {
+    const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
+    const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
+    const ratchet: RatchetDriftResult = {
+      healthy: false,
+      reason: 'sourcing bumped 3× ↑',
+      drifts: [
+        {
+          file: 'sourcing.json',
+          name: 'sourcing',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'sourcing bumped 3× ↑',
+        },
+      ],
+    };
+    const combined = combineHealth(deploy, mainCi, ratchet, now);
+    expect(combined.healthy).toBe(false);
+    expect(combined.issues).toHaveLength(1);
+    expect(combined.issues[0].type).toBe('ratchet-drift');
+    expect(combined.issues[0].score).toBe(RATCHET_DRIFT_SCORE);
+    expect(combined.issues[0].reason).toBe('sourcing bumped 3× ↑');
+  });
+
+  it('ranks deploy-stuck > main-ci-red > ratchet-drift', () => {
+    expect(DEPLOY_STUCK_SCORE).toBeGreaterThan(MAIN_CI_RED_SCORE);
+    expect(MAIN_CI_RED_SCORE).toBeGreaterThan(RATCHET_DRIFT_SCORE);
+    // And ratchet-drift still outranks per-PR conflict (100)
+    expect(RATCHET_DRIFT_SCORE).toBeGreaterThan(100);
+  });
+
+  it('emits all three issues when everything is unhealthy', () => {
+    const deploy = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure' }),
+      run({ id: 2, conclusion: 'failure' }),
+    ]);
+    const mainCi = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    const ratchet: RatchetDriftResult = {
+      healthy: false,
+      reason: 'drift',
+      drifts: [
+        {
+          file: 'x.json',
+          name: 'x',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'x bumped 3×',
+        },
+      ],
+    };
+    const combined = combineHealth(deploy, mainCi, ratchet, now);
+    expect(combined.issues.map((i) => i.type)).toEqual([
+      'deploy-stuck',
+      'main-ci-red',
+      'ratchet-drift',
+    ]);
+    // Issues are pushed in the order they're checked — which is also the
+    // priority order. Verify scores are monotonically decreasing.
+    const scores = combined.issues.map((i) => i.score);
+    expect(scores[0]).toBeGreaterThan(scores[1]);
+    expect(scores[1]).toBeGreaterThan(scores[2]);
+  });
+});
 
 describe('mapRollupState', () => {
   it('maps SUCCESS → success', () => {

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -14,6 +14,8 @@
  */
 
 import { REPO, githubApi, githubGraphQL } from '../lib/github.ts';
+import { gitSafe } from '../lib/git.ts';
+import { RATCHET_BASELINES, type RatchetConfig } from './ratchet-config.ts';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -50,6 +52,26 @@ export const DEPLOY_STUCK_SCORE = 200;
 /** Score bonus for a main-CI red streak. Below deploy-stuck but above per-PR. */
 export const MAIN_CI_RED_SCORE = 180;
 
+/**
+ * Min bumps in the bad direction within the window before ratchet-drift fires.
+ * Chosen at 3 because 2 can easily be legitimate rebase-flurry; 3+ is when
+ * the "we're papering over something" pattern emerges.
+ */
+export const RATCHET_DRIFT_MIN_BUMPS = 3;
+
+/**
+ * Sliding window for ratchet-drift detection. 24h aligns with the retrospective
+ * incident where a baseline moved 3+ times in the same night.
+ */
+export const RATCHET_DRIFT_WINDOW_HOURS = 24;
+
+/**
+ * Score bonus for a ratchet-drift signal. Below deploy-stuck + main-ci-red but
+ * still above every per-PR issue so it surfaces before the patrol re-dispatches
+ * another bump attempt.
+ */
+export const RATCHET_DRIFT_SCORE = 150;
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface WorkflowRun {
@@ -85,7 +107,7 @@ export interface MainCiResult {
   failingCommits: CommitStatus[];
 }
 
-export type HealthIssueType = 'deploy-stuck' | 'main-ci-red';
+export type HealthIssueType = 'deploy-stuck' | 'main-ci-red' | 'ratchet-drift';
 
 export interface HealthIssue {
   type: HealthIssueType;
@@ -97,10 +119,47 @@ export interface HealthIssue {
   detectedAt: string;
 }
 
+/**
+ * One observation of a ratchet baseline at a specific commit.
+ * `total === null` means the file didn't exist at that commit (or couldn't be
+ * read / parsed) — the evaluator treats it as "no data point" and skips it.
+ */
+export interface BaselineObservation {
+  commit: string;
+  committedAt: Date;
+  total: number | null;
+}
+
+export interface RatchetDriftForFile {
+  file: string;
+  name: string;
+  /** How the total moved — only populated when drift is flagged. */
+  direction: 'up' | 'down' | null;
+  /** Number of bumps in the bad direction within the window. */
+  bumpCount: number;
+  /** The specific bumps that tripped the threshold (oldest → newest). */
+  bumps: Array<{
+    commit: string;
+    committedAt: string;
+    from: number;
+    to: number;
+  }>;
+  /** True when the count exceeds the threshold in the bad direction. */
+  drifted: boolean;
+  reason: string;
+}
+
+export interface RatchetDriftResult {
+  healthy: boolean;
+  reason: string;
+  drifts: RatchetDriftForFile[];
+}
+
 export interface HealthScanResult {
   healthy: boolean;
   deploy: DeployStatusResult;
   mainCi: MainCiResult;
+  ratchet: RatchetDriftResult;
   issues: HealthIssue[];
 }
 
@@ -250,12 +309,239 @@ export function evaluateMainCi(commits: CommitStatus[]): MainCiResult {
 }
 
 /**
+ * Given observations of a ratchet baseline (oldest → newest) and a window,
+ * decide whether the file has drifted in the bad direction.
+ *
+ * Rules:
+ *  - Only observations within `windowHours` of `now` are considered.
+ *  - Consecutive observations where `total` changed and both values are
+ *    non-null form a "bump". Direction = sign(to - from).
+ *  - Bumps in the bad direction count; bumps in the good direction RESET
+ *    the counter — we only care about unchecked drift. (A legitimate fix
+ *    that moves the number down shouldn't be hidden by yesterday's bad bump.)
+ *  - Drift fires when bad-direction bumps ≥ `minBumps`.
+ */
+export function evaluateRatchetDrift(
+  file: string,
+  name: string,
+  observations: BaselineObservation[],
+  options: {
+    badDirection: 'up' | 'down';
+    now?: Date;
+    windowHours?: number;
+    minBumps?: number;
+  },
+): RatchetDriftForFile {
+  const now = options.now ?? new Date();
+  const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
+  const minBumps = options.minBumps ?? RATCHET_DRIFT_MIN_BUMPS;
+  const windowStart = now.getTime() - windowHours * 3_600_000;
+
+  // Keep only observations inside the window — sorted oldest → newest so
+  // consecutive-pair deltas flow naturally.
+  const inWindow = observations
+    .filter((o) => o.committedAt.getTime() >= windowStart)
+    .sort((a, b) => a.committedAt.getTime() - b.committedAt.getTime());
+
+  // A good-direction bump resets the counter; bad-direction bumps accumulate.
+  // Track the counter + the bumps that contributed to the current streak so
+  // the escalation message can name them.
+  let badBumps: RatchetDriftForFile['bumps'] = [];
+
+  for (let i = 1; i < inWindow.length; i++) {
+    const prev = inWindow[i - 1];
+    const curr = inWindow[i];
+    if (prev.total === null || curr.total === null) continue;
+    if (curr.total === prev.total) continue;
+
+    const direction: 'up' | 'down' = curr.total > prev.total ? 'up' : 'down';
+    if (direction === options.badDirection) {
+      badBumps.push({
+        commit: curr.commit,
+        committedAt: curr.committedAt.toISOString(),
+        from: prev.total,
+        to: curr.total,
+      });
+    } else {
+      // A fix in the good direction invalidates the streak.
+      badBumps = [];
+    }
+  }
+
+  const bumpCount = badBumps.length;
+  const drifted = bumpCount >= minBumps;
+
+  if (drifted) {
+    const arrow = options.badDirection === 'up' ? '↑' : '↓';
+    const first = badBumps[0];
+    const last = badBumps[bumpCount - 1];
+    return {
+      file,
+      name,
+      direction: options.badDirection,
+      bumpCount,
+      bumps: badBumps,
+      drifted: true,
+      reason:
+        `${name} baseline bumped ${bumpCount}× ${arrow} in the last ${windowHours}h ` +
+        `(${first.from} → ${last.to}). Do NOT bump again — investigate the underlying cause.`,
+    };
+  }
+
+  return {
+    file,
+    name,
+    direction: bumpCount > 0 ? options.badDirection : null,
+    bumpCount,
+    bumps: badBumps,
+    drifted: false,
+    reason:
+      bumpCount === 0
+        ? `${name} baseline stable over the last ${windowHours}h`
+        : `${name} baseline bumped ${bumpCount}× (below ≥${minBumps} threshold — monitoring)`,
+  };
+}
+
+/**
+ * Collapse a list of per-file drift results into the aggregate RatchetDriftResult.
+ * Pure.
+ */
+export function combineRatchetDrift(drifts: RatchetDriftForFile[]): RatchetDriftResult {
+  const drifted = drifts.filter((d) => d.drifted);
+  if (drifted.length === 0) {
+    return {
+      healthy: true,
+      reason:
+        drifts.length === 0
+          ? 'no ratchet baselines registered'
+          : 'all ratchet baselines within thresholds',
+      drifts,
+    };
+  }
+
+  return {
+    healthy: false,
+    reason: drifted.map((d) => d.reason).join(' | '),
+    drifts,
+  };
+}
+
+/**
+ * Read a registered ratchet's history over the last `windowHours` via git log
+ * and evaluate for drift. Each commit that touched the file contributes one
+ * observation; the file is read at that commit via `git show`.
+ *
+ * Unlike `checkDeployStatus` / `checkMainCi`, this scanner is local-only — no
+ * network, no GitHub API. It runs against the current working tree's git repo.
+ */
+export function checkRatchetDriftForFile(
+  config: RatchetConfig,
+  options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+): RatchetDriftForFile {
+  const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
+  const since = `${windowHours} hours ago`;
+
+  // One commit per line: `<sha> <unix-ts>`
+  const logResult = gitSafe(
+    'log',
+    `--since=${since}`,
+    '--format=%H %ct',
+    '--',
+    config.file,
+  );
+
+  if (!logResult.ok || !logResult.output) {
+    return {
+      file: config.file,
+      name: config.name,
+      direction: null,
+      bumpCount: 0,
+      bumps: [],
+      drifted: false,
+      reason:
+        !logResult.ok
+          ? `git log failed for ${config.file}: ${logResult.stderr || 'unknown error'}`
+          : `${config.name} baseline: no commits in the last ${windowHours}h`,
+    };
+  }
+
+  // git log is newest-first; we want oldest-first for evaluation.
+  const lines = logResult.output.split('\n').filter(Boolean).reverse();
+
+  // Include the "before" state: the parent of the earliest in-window commit.
+  // Without it we'd miss bump #1 (can't compute from/to for the first commit).
+  const firstCommit = lines[0]?.split(' ')[0];
+  const observations: BaselineObservation[] = [];
+
+  if (firstCommit) {
+    const parentTotal = readBaselineTotal(`${firstCommit}^`, config);
+    if (parentTotal !== null) {
+      const parentTs = commitTimestamp(`${firstCommit}^`);
+      if (parentTs) {
+        observations.push({
+          commit: `${firstCommit}^`,
+          committedAt: parentTs,
+          total: parentTotal,
+        });
+      }
+    }
+  }
+
+  for (const line of lines) {
+    const [sha, ts] = line.split(' ');
+    if (!sha || !ts) continue;
+    observations.push({
+      commit: sha,
+      committedAt: new Date(Number.parseInt(ts, 10) * 1000),
+      total: readBaselineTotal(sha, config),
+    });
+  }
+
+  return evaluateRatchetDrift(config.file, config.name, observations, {
+    badDirection: config.badDirection,
+    now: options.now,
+    windowHours,
+    minBumps: options.minBumps,
+  });
+}
+
+/** Run the drift scan across every registered baseline. */
+export function checkRatchetDrift(
+  options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+  baselines: readonly RatchetConfig[] = RATCHET_BASELINES,
+): RatchetDriftResult {
+  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options));
+  return combineRatchetDrift(drifts);
+}
+
+function readBaselineTotal(ref: string, config: RatchetConfig): number | null {
+  const result = gitSafe('show', `${ref}:${config.file}`);
+  if (!result.ok) return null;
+  try {
+    const parsed = JSON.parse(result.output);
+    const value = (parsed as Record<string, unknown>)[config.totalField];
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function commitTimestamp(ref: string): Date | null {
+  const result = gitSafe('show', '-s', '--format=%ct', ref);
+  if (!result.ok) return null;
+  const ts = Number.parseInt(result.output, 10);
+  if (!Number.isFinite(ts)) return null;
+  return new Date(ts * 1000);
+}
+
+/**
  * Combine deploy + main-CI evaluations into a single HealthScanResult.
  * Pure — takes the two sub-results and assembles the issue list for the queue.
  */
 export function combineHealth(
   deploy: DeployStatusResult,
   mainCi: MainCiResult,
+  ratchet: RatchetDriftResult,
   now: Date = new Date(),
 ): HealthScanResult {
   const issues: HealthIssue[] = [];
@@ -281,10 +567,21 @@ export function combineHealth(
     });
   }
 
+  for (const drift of ratchet.drifts) {
+    if (!drift.drifted) continue;
+    issues.push({
+      type: 'ratchet-drift',
+      score: RATCHET_DRIFT_SCORE,
+      reason: drift.reason,
+      detectedAt,
+    });
+  }
+
   return {
-    healthy: deploy.healthy && mainCi.healthy,
+    healthy: deploy.healthy && mainCi.healthy && ratchet.healthy,
     deploy,
     mainCi,
+    ratchet,
     issues,
   };
 }
@@ -433,5 +730,6 @@ export async function healthScan(now: Date = new Date()): Promise<HealthScanResu
     checkDeployStatus({ now }),
     checkMainCi(),
   ]);
-  return combineHealth(deploy, mainCi, now);
+  const ratchet = checkRatchetDrift({ now });
+  return combineHealth(deploy, mainCi, ratchet, now);
 }

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -437,14 +437,20 @@ export function combineRatchetDrift(drifts: RatchetDriftForFile[]): RatchetDrift
 export function checkRatchetDriftForFile(
   config: RatchetConfig,
   options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
 ): RatchetDriftForFile {
+  const now = options.now ?? new Date();
   const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
-  const since = `${windowHours} hours ago`;
+
+  // Thread `now` into git's --since so the window used by git log matches the
+  // window used by the evaluator. Without this, a custom `now` (e.g. a test
+  // clock) would desync from git's wall-clock --since interpretation.
+  const sinceIso = new Date(now.getTime() - windowHours * 3_600_000).toISOString();
 
   // One commit per line: `<sha> <unix-ts>`
-  const logResult = gitSafe(
+  const logResult = runGit(
     'log',
-    `--since=${since}`,
+    `--since=${sinceIso}`,
     '--format=%H %ct',
     '--',
     config.file,
@@ -474,9 +480,14 @@ export function checkRatchetDriftForFile(
   const observations: BaselineObservation[] = [];
 
   if (firstCommit) {
-    const parentTotal = readBaselineTotal(`${firstCommit}^`, config);
+    // Try to include the "before" state: the parent of the earliest in-window
+    // commit. If the parent doesn't exist (root commit) or the file didn't
+    // exist there (newly created mid-window), we just skip — the observation
+    // chain starts at firstCommit itself. That means commit #1 in the window
+    // can't be counted as a bump (no "from" value), but commits #2+ still are.
+    const parentTotal = readBaselineTotal(`${firstCommit}^`, config, runGit);
     if (parentTotal !== null) {
-      const parentTs = commitTimestamp(`${firstCommit}^`);
+      const parentTs = commitTimestamp(`${firstCommit}^`, runGit);
       if (parentTs) {
         observations.push({
           commit: `${firstCommit}^`,
@@ -493,13 +504,13 @@ export function checkRatchetDriftForFile(
     observations.push({
       commit: sha,
       committedAt: new Date(Number.parseInt(ts, 10) * 1000),
-      total: readBaselineTotal(sha, config),
+      total: readBaselineTotal(sha, config, runGit),
     });
   }
 
   return evaluateRatchetDrift(config.file, config.name, observations, {
     badDirection: config.badDirection,
-    now: options.now,
+    now,
     windowHours,
     minBumps: options.minBumps,
   });
@@ -509,25 +520,43 @@ export function checkRatchetDriftForFile(
 export function checkRatchetDrift(
   options: { now?: Date; windowHours?: number; minBumps?: number } = {},
   baselines: readonly RatchetConfig[] = RATCHET_BASELINES,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
 ): RatchetDriftResult {
-  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options));
+  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options, runGit));
   return combineRatchetDrift(drifts);
 }
 
-function readBaselineTotal(ref: string, config: RatchetConfig): number | null {
-  const result = gitSafe('show', `${ref}:${config.file}`);
+/**
+ * Exported for testing. Accepts numbers AND numeric strings — some validators
+ * serialize totals as strings to avoid precision loss, and silently dropping
+ * those would let drift go undetected.
+ */
+export function readBaselineTotal(
+  ref: string,
+  config: RatchetConfig,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
+): number | null {
+  const result = runGit('show', `${ref}:${config.file}`);
   if (!result.ok) return null;
   try {
     const parsed = JSON.parse(result.output);
-    const value = (parsed as Record<string, unknown>)[config.totalField];
-    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+    const raw = (parsed as Record<string, unknown>)[config.totalField];
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    if (typeof raw === 'string') {
+      const coerced = Number(raw);
+      return Number.isFinite(coerced) ? coerced : null;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-function commitTimestamp(ref: string): Date | null {
-  const result = gitSafe('show', '-s', '--format=%ct', ref);
+function commitTimestamp(
+  ref: string,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
+): Date | null {
+  const result = runGit('show', '-s', '--format=%ct', ref);
   if (!result.ok) return null;
   const ts = Number.parseInt(result.output, 10);
   if (!Number.isFinite(ts)) return null;

--- a/crux/pr-patrol/ratchet-config.ts
+++ b/crux/pr-patrol/ratchet-config.ts
@@ -1,0 +1,50 @@
+/**
+ * PR Patrol — Ratchet baseline registry (QUA-299 Phase 2).
+ *
+ * Ratchet files lock in a count (violations, stubs, etc.) and can only move
+ * in one "good" direction. The ratchet-drift scanner flags when the same
+ * baseline is bumped N times in M hours, which usually means downstream
+ * agents are silencing CI instead of fixing the underlying cause.
+ *
+ * This file is the single place to register new ratchets. Adding a baseline
+ * here makes it subject to the drift scan — no other wiring is needed.
+ */
+
+export interface RatchetConfig {
+  /** Path relative to the git repo root. */
+  file: string;
+  /**
+   * Human-readable name for escalation messages, e.g. "sourcing rename
+   * ratchet". Kept short because it appears in patrol queue reasons.
+   */
+  name: string;
+  /**
+   * JSON property inside the baseline file whose value is the enforced
+   * total. Nested paths like `"route.total"` are not supported today —
+   * baselines in this repo are flat objects.
+   */
+  totalField: string;
+  /**
+   * Which direction counts as "bad". If `up`, an increasing total is drift
+   * (the usual case — more violations slipping in). If `down`, a decreasing
+   * total is drift (rare — e.g., a coverage ratchet going backwards).
+   */
+  badDirection: 'up' | 'down';
+}
+
+/**
+ * Baselines subject to drift scanning.
+ *
+ * Keep this list small. A file belongs here only if:
+ *   1. It has a single numeric field that represents enforced total
+ *   2. Legitimate changes move it in one direction only
+ *   3. Repeated bumps in the bad direction are a red flag, not routine
+ */
+export const RATCHET_BASELINES: readonly RatchetConfig[] = [
+  {
+    file: 'crux/validate/.sourcing-baseline.json',
+    name: 'sourcing rename',
+    totalField: 'total',
+    badDirection: 'up',
+  },
+];


### PR DESCRIPTION
## Summary

Phase 2 of QUA-297 (Health-Gate Patrol). Adds a ratchet-drift scanner to the fleet-level health module from Phase 1 (#4210). Detects the "we're papering over something" pattern — same baseline file bumped ≥3 times in 24h in the bad direction.

Motivated by the 2026-04-11 incident: the sourcing ratchet was bumped 3+ times overnight while the real cause (stuck deploy) went undetected. This scanner would have fired before the 3rd bump landed.

## What's new

- **`crux/pr-patrol/ratchet-config.ts`** — single registry for baselines subject to drift scanning (currently just `.sourcing-baseline.json`). One place to add new ratchets.
- **`evaluateRatchetDrift()`** — pure function. Filters observations to the window, counts bumps in the bad direction. A good-direction bump resets the streak (a legitimate fix shouldn't be hidden by yesterday's bad bump).
- **`combineRatchetDrift()`** — aggregates per-file results.
- **`checkRatchetDriftForFile()` / `checkRatchetDrift()`** — I/O wrappers. Local-only (git log + git show). Accept an injected `runGit` so they're testable without touching the real repo.
- **`combineHealth()`** now takes a 3rd `RatchetDriftResult` arg and emits a `ratchet-drift` issue (score 150).
- **`healthScan()`** runs all three scanners.

## Scoring

deploy-stuck (200) > main-ci-red (180) > **ratchet-drift (150)** > conflict (100) > ... per-PR issues. Health-gate signals outrank every per-PR signal so they surface before patrol dispatches a wasteful fix.

## Test plan

- [x] 61 tests (48 pure evaluator + 13 I/O wrapper with mocked git) — was 32 before this PR
- [x] 327 total pr-patrol tests pass (up from 314)
- [x] Live dry-run on this repo returns `{healthy: true, drifts: 1}` (one baseline registered, stable)
- [x] Historical fixture: 3 upward bumps in 24h fires; 2 bumps does not; 3 bumps across 48h does not (rate-limited); alternating direction does not; good-direction fix resets the streak
- [x] I/O wrapper tested: file-created-mid-window (parent SHA has no file) still works; comment-only commits don't count; git-log failure returns stable with reason; `--since=<iso>` is derived from injected `now`

## Review pass

Ran `/agent-review-pr` before pushing. Findings applied:
- HIGH: `readBaselineTotal` now accepts numeric-string totals (some validators serialize this way)
- HIGH: Parent-SHA lookup gracefully handles "file created mid-window"
- MEDIUM: `checkRatchetDriftForFile` now has 7 mocked-git tests (was untested)
- MEDIUM: `now` threaded into git's `--since=<iso>` instead of wall-clock relative parser

## Stacked on #4216

This branch includes the review fixes from #4216 (Phase 1 follow-up). Rebasing is clean once #4216 merges.

## Not in this PR

- Phase 3 (QUA-300) — wiring signals into the patrol loop as a precondition gate
- Scope-aware suppression (v2)

Fixes QUA-299
