### PR TITLE
feat: ws-refresh-loop.sh + wire into /admin-setup

### DIFF
--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -13,8 +13,8 @@ The skill is **idempotent** — it can be re-run safely. Background loops are on
 
 ## What this skill does
 
-1. Starts background loops (tmux rename, optionally PR patrol)
-2. Pulls latest `main/` and `ops/` to get current state
+1. Starts background loops (tmux rename, ws refresh, optionally PR patrol)
+2. Pulls latest `main/` and `ops/` and runs a one-shot `./ws refresh` to reset merged-PR slots
 3. Prints orientation: production health, stale work, ready-for-dispatch queue
 4. Reports what's running and what's stale
 
@@ -41,7 +41,24 @@ echo "Started rename loop, PID $!"
 
 If `scripts/tmux-rename-loop.sh` doesn't exist, fall back to running `./ws fix-tabs` once and noting that the loop script needs to be created.
 
-**1b. PR patrol loop** (optional — ask user before starting)
+**1b. ws refresh loop** — every 15 minutes, resets slots whose PRs merged and pulls latest main in idle slots. Only touches idle/merged slots; never disturbs active work.
+
+Check if it's already running:
+```bash
+pgrep -f ws-refresh-loop.sh && echo "✓ ws-refresh loop already running" || echo "✗ not running"
+```
+
+If not running, start it:
+```bash
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw
+nohup ./scripts/ws-refresh-loop.sh > /tmp/lw-ws-refresh.log 2>&1 &
+disown
+echo "Started ws-refresh loop, PID $!"
+```
+
+If `scripts/ws-refresh-loop.sh` doesn't exist, fall back to noting that the loop script needs to be created; Section 2 still runs a one-shot refresh.
+
+**1c. PR patrol loop** (optional — ask user before starting)
 
 Check for an existing PR patrol process:
 ```bash
@@ -50,7 +67,7 @@ pgrep -f "pr-patrol" && echo "✓ PR patrol already running" || echo "✗ not ru
 
 If the user wants it started, follow the standard PR patrol startup procedure (typically `pnpm crux gh pr-patrol` from `lw/coord` or `lw/main`). Do NOT start it without user confirmation — PR patrol uses real LLM budget.
 
-### Section 2: Pull latest
+### Section 2: Pull latest + refresh slots
 
 ```bash
 git -C /Users/ozziegooen/Documents/GitHub.nosync/lw/main pull --ff-only
@@ -58,6 +75,14 @@ git -C /Users/ozziegooen/Documents/GitHub.nosync/lw/ops pull --ff-only
 ```
 
 If either pull fails (diverged), report it and ask the user how to proceed — do not auto-resolve.
+
+Then do a one-shot `./ws refresh` so the coordinator starts with a clean slot map (the loop from Section 1b catches subsequent merges, but the first run gives immediate feedback):
+
+```bash
+/Users/ozziegooen/Documents/GitHub.nosync/lw/ws refresh 2>&1 | tail -20
+```
+
+This only resets slots whose PRs have merged; slots with active work are left alone.
 
 ### Section 3: Production health
 
@@ -104,7 +129,7 @@ Print a single concise summary block:
 ```
 === Admin session ready ===
 Date:        2026-04-10
-Background:  rename-loop ✓ | pr-patrol [✓ or –]
+Background:  rename-loop ✓ | ws-refresh ✓ | pr-patrol [✓ or –]
 Production:  healthy | uptime Xs
 Linear:      N stale In Progress | M ready P1/P2
 CI (main):   N failures in last 24h

--- a/scripts/ws-refresh-loop.sh
+++ b/scripts/ws-refresh-loop.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Background loop that runs `./ws refresh` every 15 minutes so slots whose
+# PR merged get auto-reset to main without waiting for the next coordinator
+# session start.
+#
+# `./ws refresh` only resets slots whose PRs merged and pulls latest main in
+# idle slots — it does not touch slots with active uncommitted work.
+#
+# Usage:
+#   nohup ./scripts/ws-refresh-loop.sh > /tmp/lw-ws-refresh.log 2>&1 &
+#   disown
+#
+# Stop:
+#   pkill -f ws-refresh-loop.sh
+
+set -u
+LW_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INTERVAL=900  # 15 minutes
+
+echo "[lw-ws-refresh] Started PID $$, interval ${INTERVAL}s, lw=${LW_DIR}"
+while true; do
+  echo "[$(date +%H:%M:%S)] ./ws refresh"
+  "$LW_DIR/ws" refresh 2>&1 | sed "s|^|[$(date +%H:%M:%S)] |"
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- New `scripts/ws-refresh-loop.sh` — background loop runs `./ws refresh` every 15 min so slots whose PRs merge get auto-reset without waiting for the next coordinator session.
- `/admin-setup` skill now starts the loop (idempotent via `pgrep`) and runs a one-shot `./ws refresh` on startup so the slot map is clean immediately.
- Orientation summary includes `ws-refresh` status alongside `rename-loop` and `pr-patrol`.

Motivation: prior to this, branch/slot cleanup relied on the human running `./ws refresh` manually at "start of day" (per `lw/README.md`). Slots with merged PRs accumulate until then. This change automates it while a coordinator session is open, without introducing a launchd job or LLM-cost `/loop` skill.

`./ws refresh` only resets slots whose PRs have merged; slots with active uncommitted work are left alone.

## Test plan
- [ ] `bash -n scripts/ws-refresh-loop.sh` — syntax OK
- [ ] Run `./scripts/ws-refresh-loop.sh` briefly; confirm it calls `./ws refresh` on each tick and logs to stdout
- [ ] Re-run `/admin-setup` twice; confirm `pgrep` guard prevents duplicate loop starts
- [ ] `pgrep -f ws-refresh-loop.sh` shows exactly one PID after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)