### PR TITLE
feat(pr-patrol): wire health gate into cycle loop (QUA-300 Phase 3)

### DIFF
--- a/.claude/commands/maintain-pr-patrol.md
+++ b/.claude/commands/maintain-pr-patrol.md
@@ -17,7 +17,13 @@ Before scanning or fixing any PR, check fleet-level health. The daemon (`crux/pr
 pnpm exec tsx -e "import('./crux/pr-patrol/health-gate.ts').then(m => m.runHealthGate().then(d => { console.log(JSON.stringify({ proceed: d.proceed, reason: d.reason, emitted: d.emittedIssues.length }, null, 2)); process.exit(d.proceed ? 0 : 2); }))"
 ```
 
-If the gate returns `proceed: false` (exit code 2), it has already logged the escalation and written a `health_gate_tripped` JSONL event. **Do NOT then go fix PRs** — the gate's entire purpose is to stop the symptom-patch cycle.
+If the gate returns `proceed: false` (exit code 2), **do NOT then go fix PRs** — the gate's entire purpose is to stop the symptom-patch cycle. Note: `proceed: false` can result from any of three conditions, which emit different JSONL events (or none):
+
+- **A new unhealthy fingerprint** → emits `health_gate_tripped` + `cycle_summary{health_gate_tripped: true}`.
+- **All unhealthy fingerprints cooldown-suppressed** → still halts PR work, but emits only `cycle_summary{health_gate_tripped: true}` (no new `health_gate_tripped` event, because the same escalation was emitted within the last 30 min).
+- **Third consecutive scanner error** → emits `health_scan_error` + halts. No `health_gate_tripped` in this path.
+
+Check `~/.cache/pr-patrol/runs.jsonl` for the specific event to understand why the gate tripped before deciding how to respond.
 
 When the gate is red, **DO NOT**:
 - Bump a ratchet baseline to unblock a CI signal

--- a/.claude/commands/maintain-pr-patrol.md
+++ b/.claude/commands/maintain-pr-patrol.md
@@ -9,6 +9,26 @@ Scan all open PRs for issues and fix them in priority order.
 
 **CONTINUOUS OPERATION:** After completing a scan+fix cycle, wait 2-3 minutes then scan again. Keep looping until the user says to stop or switches tasks. Do NOT stop after one pass and wait for re-invocation — "patrol" means continuous monitoring.
 
+## Health gate — MANDATORY first step each cycle
+
+Before scanning or fixing any PR, check fleet-level health. The daemon (`crux/pr-patrol/index.ts`) does this automatically at the start of `runCheckCycle`, but if you're running patrol by hand, invoke it explicitly:
+
+```bash
+pnpm exec tsx -e "import('./crux/pr-patrol/health-gate.ts').then(m => m.runHealthGate().then(d => { console.log(JSON.stringify({ proceed: d.proceed, reason: d.reason, emitted: d.emittedIssues.length }, null, 2)); process.exit(d.proceed ? 0 : 2); }))"
+```
+
+If the gate returns `proceed: false` (exit code 2), it has already logged the escalation and written a `health_gate_tripped` JSONL event. **Do NOT then go fix PRs** — the gate's entire purpose is to stop the symptom-patch cycle.
+
+When the gate is red, **DO NOT**:
+- Bump a ratchet baseline to unblock a CI signal
+- Revert a rename because endpoints are 404ing on prod (the deploy is probably stuck, not the rename)
+- Dispatch an agent to fix a PR whose failure is a symptom of the fleet-level issue
+- Merge a "fix the fix" PR into a pipeline that's already broken
+
+Instead: escalate to the coordinator. The escalation reason names the specific subsystem (deploy pipeline, main CI, ratchet drift) and points at the prescriptive fix pattern. See `.claude/rules/patrol-health-gate.md`.
+
+Emergency escape hatch: `PATROL_DISABLE_HEALTH_GATE=1` bypasses the gate entirely. Use ONLY when the gate itself is broken, never to work around a red prod.
+
 ## Branch Agent mode (Phase 1 — per-PR watchdog)
 
 For PRs needing sustained attention, use **branch-agent** instead of waiting for the daemon:

--- a/.claude/rules/patrol-health-gate.md
+++ b/.claude/rules/patrol-health-gate.md
@@ -65,7 +65,37 @@ If you're mid-way through a PR and notice:
 
 **Stop.** File a Linear ticket describing the pattern and escalate to the coordinator. This is exactly what the 2026-04-11 cascade looked like in its second PR; everyone who continued past that signal spent effort on a problem that wasn't the real one.
 
-See also:
+## Troubleshooting
+
+**Gate seems stuck "green" while prod is red.** Check the scan-error counter:
+
+```bash
+cat ~/.cache/pr-patrol/state/health-gate-cooldown.json | jq '.["__scan_error_count__"]'
+```
+
+If ≥ 3, the scanner has been failing for multiple cycles and the gate has flipped to halt. Inspect recent `health_scan_error` entries in `~/.cache/pr-patrol/runs.jsonl`.
+
+**Gate trips repeatedly after the underlying issue is fixed.** The cooldown file is the source of truth:
+
+```bash
+# Clear everything:
+rm ~/.cache/pr-patrol/state/health-gate-cooldown.json
+# Or clear one fingerprint:
+jq 'del(.["deploy-stuck"])' ~/.cache/pr-patrol/state/health-gate-cooldown.json | sponge ~/.cache/pr-patrol/state/health-gate-cooldown.json
+```
+
+**Reading escalation events**:
+
+```bash
+# Most recent gate trips:
+jq -c 'select(.type == "health_gate_tripped")' ~/.cache/pr-patrol/runs.jsonl | tail -10
+
+# Scan errors:
+jq -c 'select(.type == "health_scan_error")' ~/.cache/pr-patrol/runs.jsonl | tail -10
+```
+
+## See also
+
 - `.claude/rules/proactive-github-filing.md` § "Mandatory tracking — red flags"
 - QUA-297 — Health-Gate Patrol parent issue + retrospective
 - `crux/pr-patrol/health-scan.ts` — the scanners

--- a/.claude/rules/patrol-health-gate.md
+++ b/.claude/rules/patrol-health-gate.md
@@ -75,12 +75,24 @@ cat ~/.cache/pr-patrol/state/health-gate-cooldown.json | jq '.["__scan_error_cou
 
 If ≥ 3, the scanner has been failing for multiple cycles and the gate has flipped to halt. Inspect recent `health_scan_error` entries in `~/.cache/pr-patrol/runs.jsonl`.
 
-**Gate trips repeatedly after the underlying issue is fixed.** The cooldown file is the source of truth:
+**Gate keeps returning `proceed: false` after you think the issue is fixed.** The cooldown file only rate-limits escalation emission — it does *not* control whether `runHealthGate()` trips. If the scanners still report unhealthy, the gate will still halt regardless of cooldown state. Inspect the scanners directly:
 
 ```bash
-# Clear everything:
+# See exactly which scanner is unhealthy and why:
+pnpm crux gh pr-patrol health-scan
+
+# Drill into the signals:
+pnpm crux gh pr-patrol health-scan --deploy    # deploy-stuck
+pnpm crux gh pr-patrol health-scan --ci        # main-ci-red
+pnpm crux gh pr-patrol health-scan --ratchet   # ratchet-drift
+```
+
+If a scanner is still flagging, fix the underlying condition (unstick the deploy, unbreak main CI, revert a bad ratchet bump). Only clear the cooldown file to reset *escalation rate-limiting* (e.g., to force a fresh JSONL `health_gate_tripped` event once you've fixed the issue):
+
+```bash
+# Reset escalation rate-limit only (does NOT stop the gate from tripping):
 rm ~/.cache/pr-patrol/state/health-gate-cooldown.json
-# Or clear one fingerprint:
+# Or reset one fingerprint:
 jq 'del(.["deploy-stuck"])' ~/.cache/pr-patrol/state/health-gate-cooldown.json | sponge ~/.cache/pr-patrol/state/health-gate-cooldown.json
 ```
 

--- a/.claude/rules/patrol-health-gate.md
+++ b/.claude/rules/patrol-health-gate.md
@@ -1,0 +1,72 @@
+# PR Patrol — Health Gate (QUA-297)
+
+The patrol loop checks **fleet-level health** before doing any per-PR work. When prod is stuck or main CI is red across multiple commits or a ratchet is being bumped repeatedly, the patrol **halts PR fixing** and escalates — instead of churning out symptom-patches.
+
+## The rule
+
+**If you're writing code to silence a CI signal, stop. Check main health first.**
+
+Specifically, when the health gate trips, do NOT:
+
+- Bump a baseline file to get CI green
+- Revert a rename because endpoints are 404ing
+- Add `it.skip()` to a failing test without an issue number
+- Merge a "fix the fix" PR into a pipeline that's already broken
+- Dispatch an agent to work on the Nth PR in a cascade
+
+Instead: **root-cause the fleet-level signal the gate flagged.** The escalation message names the exact subsystem (deploy pipeline, main CI, ratchet drift) and points at the prescriptive fix pattern.
+
+## Why this exists
+
+The 2026-04-11→12 retrospective: wiki-server deploy was stuck on migration 0173 for ~12h. Deploy #4167 failed PreSync at 22:57 UTC. Deploy #4180 failed the same way. Meanwhile, 7+ PRs silenced downstream symptoms (baseline bumps, route-axis pause, client reverts, re-migrate attempts, misdiagnosed "alias" issues). No agent asked "why does main keep drifting in this subsystem?"
+
+Per-PR detectors don't catch this pattern. The signal is fleet-level:
+
+- "Last 2 production deploys both failed" (deploy-stuck, score 200)
+- "Main CI has been red across 3 consecutive commits" (main-ci-red, score 180)
+- "The same baseline file has been bumped 3× in 24h in the same direction" (ratchet-drift, score 150)
+
+All three outrank every per-PR issue (conflict=100, stuck=85, ci-failure=80, …) so they surface before patrol dispatches a wasteful fix.
+
+## How the gate works
+
+At the start of every patrol cycle, `runHealthGate()` calls `healthScan()`:
+
+```
+cycle start
+  ├── HEALTH GATE
+  │    ├── healthScan()   (deploy + main CI + ratchet drift)
+  │    ├── if unhealthy:
+  │    │    ├── emit JSONL event  (coordinator reads this)
+  │    │    ├── log red warning   (human visibility)
+  │    │    ├── return early      (skip PR work this cycle)
+  │    └── else: proceed
+  ├── 0a. Check tracked main-fix PR
+  ├── 0b. Check main branch CI (per-PR signal, not fleet)
+  ├── 1. Fetch PRs → detect → rank → fix
+  └── ...
+```
+
+Per-fingerprint cooldown (30min) prevents spam when an underlying issue takes hours to resolve. The same "deploy-stuck" signal is re-emitted at most once per 30min, but the patrol still halts PR work on every cycle that sees unhealthy state — the cooldown only affects whether we write another escalation line, not whether we keep touching PRs.
+
+## When the gate misbehaves
+
+`PATROL_DISABLE_HEALTH_GATE=1` bypasses the gate entirely. Use this only when the gate itself is broken and needs debugging — NOT when prod is red and you want the patrol to "keep working anyway."
+
+The patrol logs loudly when the bypass is engaged. If you see the bypass warning in the logs, treat it as a P0 incident: someone (or some process) is explicitly suppressing the safety check.
+
+## For agents writing PRs
+
+If you're mid-way through a PR and notice:
+
+- The same baseline you're about to bump was bumped yesterday too
+- A rename you're about to revert was reverted last week
+- A test you're about to skip was skipped 3 times before
+
+**Stop.** File a Linear ticket describing the pattern and escalate to the coordinator. This is exactly what the 2026-04-11 cascade looked like in its second PR; everyone who continued past that signal spent effort on a problem that wasn't the real one.
+
+See also:
+- `.claude/rules/proactive-github-filing.md` § "Mandatory tracking — red flags"
+- QUA-297 — Health-Gate Patrol parent issue + retrospective
+- `crux/pr-patrol/health-scan.ts` — the scanners
+- `crux/pr-patrol/health-gate.ts` — the gate wiring

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  runHealthGate,
+  fingerprintIssue,
+  HEALTH_GATE_COOLDOWN_MINUTES,
+  DISABLE_ENV_VAR,
+  type HealthGateDeps,
+} from './health-gate.ts';
+import type { HealthScanResult, HealthIssue } from './health-scan.ts';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-04-12T20:00:00Z');
+
+function healthyScan(): HealthScanResult {
+  return {
+    healthy: true,
+    deploy: {
+      healthy: true,
+      reason: 'latest production deploy succeeded',
+      lastSuccessfulDeployAt: NOW,
+      failingDeploys: [],
+    },
+    mainCi: {
+      healthy: true,
+      reason: 'latest main CI runs succeeded',
+      failingCount: 0,
+      redStreakStarted: null,
+      failingCommits: [],
+    },
+    ratchet: {
+      healthy: true,
+      reason: 'all ratchet baselines within thresholds',
+      drifts: [],
+    },
+    issues: [],
+  };
+}
+
+function unhealthyScan(issues: HealthIssue[]): HealthScanResult {
+  return {
+    healthy: false,
+    deploy: {
+      healthy: issues.every((i) => i.type !== 'deploy-stuck'),
+      reason: '',
+      lastSuccessfulDeployAt: null,
+      failingDeploys: [],
+    },
+    mainCi: {
+      healthy: issues.every((i) => i.type !== 'main-ci-red'),
+      reason: '',
+      failingCount: 0,
+      redStreakStarted: null,
+      failingCommits: [],
+    },
+    ratchet: {
+      healthy: issues.every((i) => i.type !== 'ratchet-drift'),
+      reason: '',
+      drifts: [],
+    },
+    issues,
+  };
+}
+
+function deployStuckIssue(overrides: Partial<HealthIssue> = {}): HealthIssue {
+  return {
+    type: 'deploy-stuck',
+    score: 200,
+    reason: '2 consecutive production deploy failures',
+    url: 'https://example.com/run/1',
+    detectedAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory cooldown store used across tests. Reset between tests.
+ */
+function inMemoryCooldown() {
+  const map = new Map<string, Date>();
+  return {
+    get: (fp: string) => map.get(fp) ?? null,
+    set: (fp: string, at: Date) => {
+      map.set(fp, at);
+    },
+    _map: map,
+  };
+}
+
+function makeDeps(overrides: Partial<HealthGateDeps> = {}): HealthGateDeps & {
+  events: Array<Record<string, unknown>>;
+  logs: string[];
+} {
+  const events: Array<Record<string, unknown>> = [];
+  const logs: string[] = [];
+  return {
+    now: () => NOW,
+    env: {},
+    writeEvent: (entry) => events.push(entry),
+    log: (msg) => logs.push(msg),
+    cooldownStore: inMemoryCooldown(),
+    ...overrides,
+    events,
+    logs,
+  };
+}
+
+// ── Env escape hatch ─────────────────────────────────────────────────────────
+
+describe('runHealthGate — env escape hatch', () => {
+  it(`bypasses the gate when ${DISABLE_ENV_VAR}=1`, async () => {
+    const deps = makeDeps({ env: { [DISABLE_ENV_VAR]: '1' } });
+    // Scanner should NOT be called — use one that throws if invoked.
+    const scan = async () => {
+      throw new Error('scanner should not be called when gate is bypassed');
+    };
+    const decision = await runHealthGate({ ...deps, scan });
+    expect(decision.proceed).toBe(true);
+    expect(decision.bypassed).toBe(true);
+    expect(deps.logs.some((l) => l.includes('BYPASSED'))).toBe(true);
+    expect(deps.events).toHaveLength(0);
+  });
+
+  it('does NOT bypass when env var is unset', async () => {
+    const deps = makeDeps({ env: {} });
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+    expect(decision.bypassed).toBe(false);
+    expect(decision.proceed).toBe(false);
+  });
+
+  it('does NOT bypass when env var is set to "0"', async () => {
+    const deps = makeDeps({ env: { [DISABLE_ENV_VAR]: '0' } });
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => healthyScan(),
+    });
+    expect(decision.bypassed).toBe(false);
+  });
+});
+
+// ── Healthy path ─────────────────────────────────────────────────────────────
+
+describe('runHealthGate — healthy', () => {
+  it('returns proceed=true with no events when all scanners green', async () => {
+    const deps = makeDeps();
+    const decision = await runHealthGate({ ...deps, scan: async () => healthyScan() });
+    expect(decision.proceed).toBe(true);
+    expect(decision.emittedIssues).toHaveLength(0);
+    expect(deps.events).toHaveLength(0);
+  });
+});
+
+// ── Scanner failure ──────────────────────────────────────────────────────────
+
+describe('runHealthGate — scanner error', () => {
+  it('logs + records an error event + lets patrol proceed (does not masquerade as healthy)', async () => {
+    const deps = makeDeps();
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error('GitHub API 503');
+      },
+    });
+    expect(decision.proceed).toBe(true);
+    expect(deps.events).toHaveLength(1);
+    expect(deps.events[0]).toMatchObject({
+      type: 'health_scan_error',
+      error: 'GitHub API 503',
+    });
+  });
+});
+
+// ── Unhealthy path ───────────────────────────────────────────────────────────
+
+describe('runHealthGate — unhealthy', () => {
+  it('returns proceed=false, emits a JSONL event for each issue', async () => {
+    const deps = makeDeps();
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () =>
+        unhealthyScan([
+          deployStuckIssue(),
+          {
+            type: 'main-ci-red',
+            score: 180,
+            reason: '3 consecutive main failures',
+            detectedAt: NOW.toISOString(),
+          },
+        ]),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.emittedIssues).toHaveLength(2);
+    expect(deps.events).toHaveLength(2);
+    expect(deps.events[0]).toMatchObject({
+      type: 'health_gate_tripped',
+      issue_type: 'deploy-stuck',
+      score: 200,
+    });
+    expect(deps.events[1]).toMatchObject({
+      type: 'health_gate_tripped',
+      issue_type: 'main-ci-red',
+    });
+  });
+
+  it('skips PR work even when every signal is cooldown-suppressed', async () => {
+    const store = inMemoryCooldown();
+    // Pre-populate: deploy-stuck emitted 10min ago (within cooldown).
+    store.set('deploy-stuck', new Date(NOW.getTime() - 10 * 60_000));
+
+    const deps = makeDeps({ cooldownStore: store });
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+
+    expect(decision.proceed).toBe(false); // MUST skip even with cooldown
+    expect(decision.emittedIssues).toHaveLength(0);
+    expect(decision.suppressedIssues).toHaveLength(1);
+    expect(deps.events).toHaveLength(0); // no new JSONL emission
+  });
+});
+
+// ── Cooldown ─────────────────────────────────────────────────────────────────
+
+describe('runHealthGate — cooldown', () => {
+  it('emits once, then suppresses a repeat within the cooldown window', async () => {
+    const store = inMemoryCooldown();
+    const events: Array<Record<string, unknown>> = [];
+
+    // First call — no prior state, should emit.
+    await runHealthGate({
+      now: () => NOW,
+      env: {},
+      writeEvent: (e) => events.push(e),
+      log: () => {},
+      cooldownStore: store,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+    expect(events).toHaveLength(1);
+
+    // Second call, 5min later (well under 30min cooldown). Should suppress.
+    const later = new Date(NOW.getTime() + 5 * 60_000);
+    const decision = await runHealthGate({
+      now: () => later,
+      env: {},
+      writeEvent: (e) => events.push(e),
+      log: () => {},
+      cooldownStore: store,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+    expect(events).toHaveLength(1); // no new event
+    expect(decision.emittedIssues).toHaveLength(0);
+    expect(decision.suppressedIssues).toHaveLength(1);
+    expect(decision.proceed).toBe(false);
+  });
+
+  it('re-emits after the cooldown window has passed', async () => {
+    const store = inMemoryCooldown();
+    const events: Array<Record<string, unknown>> = [];
+
+    await runHealthGate({
+      now: () => NOW,
+      env: {},
+      writeEvent: (e) => events.push(e),
+      log: () => {},
+      cooldownStore: store,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+
+    const wayLater = new Date(NOW.getTime() + (HEALTH_GATE_COOLDOWN_MINUTES + 1) * 60_000);
+    await runHealthGate({
+      now: () => wayLater,
+      env: {},
+      writeEvent: (e) => events.push(e),
+      log: () => {},
+      cooldownStore: store,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+
+    expect(events).toHaveLength(2);
+  });
+
+  it('cooldowns are fingerprint-scoped (ratchet-drift for different files do not suppress each other)', async () => {
+    const store = inMemoryCooldown();
+    const events: Array<Record<string, unknown>> = [];
+
+    const driftA: HealthIssue = {
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'sourcing baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+    };
+    const driftB: HealthIssue = {
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'review-marker baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+    };
+
+    // Pre-fill: sourcing already in cooldown
+    store.set('ratchet-drift:sourcing', new Date(NOW.getTime() - 5 * 60_000));
+
+    const decision = await runHealthGate({
+      now: () => NOW,
+      env: {},
+      writeEvent: (e) => events.push(e),
+      log: () => {},
+      cooldownStore: store,
+      scan: async () => unhealthyScan([driftA, driftB]),
+    });
+
+    // sourcing suppressed, review-marker emitted
+    expect(decision.emittedIssues).toHaveLength(1);
+    expect(decision.emittedIssues[0].reason).toContain('review-marker');
+    expect(decision.suppressedIssues).toHaveLength(1);
+    expect(events).toHaveLength(1);
+  });
+});
+
+// ── Fingerprint ──────────────────────────────────────────────────────────────
+
+describe('fingerprintIssue', () => {
+  it('collapses deploy-stuck issues to a single fingerprint regardless of URL', () => {
+    const a = fingerprintIssue(deployStuckIssue({ url: 'https://a.example' }));
+    const b = fingerprintIssue(deployStuckIssue({ url: 'https://b.example' }));
+    expect(a).toBe(b);
+    expect(a).toBe('deploy-stuck');
+  });
+
+  it('separates ratchet-drift fingerprints by file name', () => {
+    const a = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'sourcing baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+    });
+    const b = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'review-marker baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+    });
+    expect(a).not.toBe(b);
+    expect(a).toBe('ratchet-drift:sourcing');
+    expect(b).toBe('ratchet-drift:review-marker');
+  });
+});

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -4,6 +4,7 @@ import {
   runHealthGate,
   fingerprintIssue,
   HEALTH_GATE_COOLDOWN_MINUTES,
+  MAX_CONSECUTIVE_SCAN_ERRORS,
   DISABLE_ENV_VAR,
   type HealthGateDeps,
 } from './health-gate.ts';
@@ -79,12 +80,18 @@ function deployStuckIssue(overrides: Partial<HealthIssue> = {}): HealthIssue {
  */
 function inMemoryCooldown() {
   const map = new Map<string, Date>();
+  const counts = new Map<string, number>();
   return {
     get: (fp: string) => map.get(fp) ?? null,
     set: (fp: string, at: Date) => {
       map.set(fp, at);
     },
+    getCount: (key: string) => counts.get(key) ?? 0,
+    setCount: (key: string, n: number) => {
+      counts.set(key, n);
+    },
     _map: map,
+    _counts: counts,
   };
 }
 
@@ -140,6 +147,27 @@ describe('runHealthGate — env escape hatch', () => {
     });
     expect(decision.bypassed).toBe(false);
   });
+
+  it('rate-limits the bypass warning across cycles (log spam mitigation)', async () => {
+    const store = inMemoryCooldown();
+    const logs: string[] = [];
+    const common = {
+      env: { [DISABLE_ENV_VAR]: '1' },
+      writeEvent: () => {},
+      log: (msg: string) => logs.push(msg),
+      cooldownStore: store,
+      scan: async () => healthyScan(),
+    };
+
+    await runHealthGate({ ...common, now: () => NOW });
+    const soonAfter = new Date(NOW.getTime() + 5 * 60_000);
+    await runHealthGate({ ...common, now: () => soonAfter });
+    const wayLater = new Date(NOW.getTime() + (HEALTH_GATE_COOLDOWN_MINUTES + 1) * 60_000);
+    await runHealthGate({ ...common, now: () => wayLater });
+
+    const bypassLogs = logs.filter((l) => l.includes('BYPASSED'));
+    expect(bypassLogs).toHaveLength(2); // first, and one after cooldown elapsed
+  });
 });
 
 // ── Healthy path ─────────────────────────────────────────────────────────────
@@ -157,7 +185,7 @@ describe('runHealthGate — healthy', () => {
 // ── Scanner failure ──────────────────────────────────────────────────────────
 
 describe('runHealthGate — scanner error', () => {
-  it('logs + records an error event + lets patrol proceed (does not masquerade as healthy)', async () => {
+  it('logs + records an error event + lets patrol proceed on the first failure', async () => {
     const deps = makeDeps();
     const decision = await runHealthGate({
       ...deps,
@@ -170,7 +198,45 @@ describe('runHealthGate — scanner error', () => {
     expect(deps.events[0]).toMatchObject({
       type: 'health_scan_error',
       error: 'GitHub API 503',
+      consecutive_errors: 1,
     });
+  });
+
+  it(`HALTS patrol after ${MAX_CONSECUTIVE_SCAN_ERRORS} consecutive failures (regression: fail-open-forever risk)`, async () => {
+    const store = inMemoryCooldown();
+    const deps = { ...makeDeps({ cooldownStore: store }) };
+    const scan = async () => {
+      throw new Error('missing API key');
+    };
+
+    let lastDecision;
+    for (let i = 0; i < MAX_CONSECUTIVE_SCAN_ERRORS; i++) {
+      lastDecision = await runHealthGate({ ...deps, scan });
+    }
+    // First N-1 proceed; Nth halts
+    expect(lastDecision!.proceed).toBe(false);
+    expect(lastDecision!.reason).toContain('consecutively');
+    expect(store.getCount('__scan_error_count__')).toBe(MAX_CONSECUTIVE_SCAN_ERRORS);
+  });
+
+  it('resets the error counter on a successful scan (so the halt only fires on a true streak)', async () => {
+    const store = inMemoryCooldown();
+    // Pre-populate: 2 consecutive errors (1 short of halt)
+    store.setCount('__scan_error_count__', MAX_CONSECUTIVE_SCAN_ERRORS - 1);
+    const deps = { ...makeDeps({ cooldownStore: store }) };
+
+    // One successful scan clears the counter
+    await runHealthGate({ ...deps, scan: async () => healthyScan() });
+    expect(store.getCount('__scan_error_count__')).toBe(0);
+
+    // Now a single failure should NOT halt (counter restarted from 0)
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error('transient');
+      },
+    });
+    expect(decision.proceed).toBe(true);
   });
 });
 

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -18,7 +18,7 @@
  * so the gate is unit-testable without network or filesystem.
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { healthScan as realHealthScan, type HealthScanResult, type HealthIssue } from './health-scan.ts';
 import { appendJsonl, JSONL_FILE, STATE_DIR, ensureDirs, cl, log as realLog } from './state.ts';
@@ -33,11 +33,22 @@ import { appendJsonl, JSONL_FILE, STATE_DIR, ensureDirs, cl, log as realLog } fr
  */
 export const HEALTH_GATE_COOLDOWN_MINUTES = 30;
 
+/**
+ * After this many consecutive scan failures, the gate flips from fail-open
+ * ("proceed with caution") to fail-closed ("halt, something's wrong"). Without
+ * this, a misconfigured env or removed GitHub endpoint would let patrol run
+ * forever while pretending prod is healthy.
+ */
+export const MAX_CONSECUTIVE_SCAN_ERRORS = 3;
+
 /** Env var to bypass the gate. Value `1` disables it. */
 export const DISABLE_ENV_VAR = 'PATROL_DISABLE_HEALTH_GATE';
 
 /** State file where last-emission timestamps per fingerprint are kept. */
 const HEALTH_GATE_STATE_FILE = join(STATE_DIR, 'health-gate-cooldown.json');
+
+/** Reserved fingerprint used to track consecutive scan-error count. */
+const SCAN_ERROR_COUNTER_KEY = '__scan_error_count__';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -68,6 +79,10 @@ export interface HealthGateDeps {
   cooldownStore?: {
     get: (fingerprint: string) => Date | null;
     set: (fingerprint: string, at: Date) => void;
+    /** Read a plain numeric counter (for consecutive scan-error tracking). */
+    getCount?: (key: string) => number;
+    /** Write a plain numeric counter. */
+    setCount?: (key: string, n: number) => void;
   };
 }
 
@@ -93,37 +108,72 @@ export function fingerprintIssue(issue: HealthIssue): string {
 
 // ── Cooldown store (filesystem-backed) ───────────────────────────────────────
 
+function readStore(): Record<string, string> {
+  if (!existsSync(HEALTH_GATE_STATE_FILE)) return {};
+  try {
+    return JSON.parse(readFileSync(HEALTH_GATE_STATE_FILE, 'utf-8')) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write atomically so concurrent patrol cycles can't clobber each other
+ * mid-update: write to a unique temp file, then rename onto the target.
+ * `rename` is atomic on POSIX (same filesystem). Race between readStore and
+ * writeStore can still lose a concurrent update (last-writer-wins), but that's
+ * acceptable for cooldown — worst case is one extra escalation emitted.
+ */
+function writeStore(store: Record<string, string>): void {
+  ensureDirs();
+  const tmp = `${HEALTH_GATE_STATE_FILE}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(store, null, 2));
+  renameSync(tmp, HEALTH_GATE_STATE_FILE);
+}
+
 function defaultCooldownStore() {
   return {
     get(fingerprint: string): Date | null {
-      if (!existsSync(HEALTH_GATE_STATE_FILE)) return null;
-      try {
-        const raw = JSON.parse(readFileSync(HEALTH_GATE_STATE_FILE, 'utf-8')) as Record<
-          string,
-          string
-        >;
-        const iso = raw[fingerprint];
-        return iso ? new Date(iso) : null;
-      } catch {
-        return null;
-      }
+      const iso = readStore()[fingerprint];
+      return iso ? new Date(iso) : null;
     },
     set(fingerprint: string, at: Date): void {
-      ensureDirs();
-      let store: Record<string, string> = {};
-      if (existsSync(HEALTH_GATE_STATE_FILE)) {
-        try {
-          store = JSON.parse(readFileSync(HEALTH_GATE_STATE_FILE, 'utf-8')) as Record<
-            string,
-            string
-          >;
-        } catch {
-          /* ignore parse errors — treat as empty */
-        }
-      }
+      const store = readStore();
       store[fingerprint] = at.toISOString();
-      writeFileSync(HEALTH_GATE_STATE_FILE, JSON.stringify(store, null, 2));
+      writeStore(store);
     },
+    getCount(key: string): number {
+      const raw = readStore()[key];
+      const n = raw ? Number.parseInt(raw, 10) : 0;
+      return Number.isFinite(n) ? n : 0;
+    },
+    setCount(key: string, n: number): void {
+      const store = readStore();
+      store[key] = String(n);
+      writeStore(store);
+    },
+  };
+}
+
+/** Build a stub HealthScanResult for the "scan failed" / "bypassed" paths. */
+function syntheticScanFailureResult(message: string): HealthScanResult {
+  return {
+    healthy: true,
+    deploy: {
+      healthy: true,
+      reason: `scan failed: ${message}`,
+      lastSuccessfulDeployAt: null,
+      failingDeploys: [],
+    },
+    mainCi: {
+      healthy: true,
+      reason: `scan failed: ${message}`,
+      failingCount: 0,
+      redStreakStarted: null,
+      failingCommits: [],
+    },
+    ratchet: { healthy: true, reason: `scan failed: ${message}`, drifts: [] },
+    issues: [],
   };
 }
 
@@ -144,37 +194,21 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
 
   const now = nowFn();
 
-  // Escape hatch first — if disabled, we never even run the scan.
+  // Escape hatch first — if disabled, we never even run the scan. Rate-limit
+  // the bypass warning via a dedicated fingerprint so the log isn't flooded
+  // every cycle during an extended outage.
   if (env[DISABLE_ENV_VAR] === '1') {
-    log(`${cl.yellow}⚠ ${DISABLE_ENV_VAR}=1 — health gate BYPASSED${cl.reset}`);
-    // Build a minimal synthetic "healthy" result so downstream consumers don't
-    // have to special-case the bypass path.
-    const synthetic: HealthScanResult = {
-      healthy: true,
-      deploy: {
-        healthy: true,
-        reason: 'health gate bypassed',
-        lastSuccessfulDeployAt: null,
-        failingDeploys: [],
-      },
-      mainCi: {
-        healthy: true,
-        reason: 'health gate bypassed',
-        failingCount: 0,
-        redStreakStarted: null,
-        failingCommits: [],
-      },
-      ratchet: {
-        healthy: true,
-        reason: 'health gate bypassed',
-        drifts: [],
-      },
-      issues: [],
-    };
+    const BYPASS_FP = '__bypass_warning__';
+    const lastBypassLog = cooldown.get(BYPASS_FP);
+    const cooldownMs = HEALTH_GATE_COOLDOWN_MINUTES * 60_000;
+    if (!lastBypassLog || now.getTime() - lastBypassLog.getTime() >= cooldownMs) {
+      log(`${cl.yellow}⚠ ${DISABLE_ENV_VAR}=1 — health gate BYPASSED${cl.reset}`);
+      cooldown.set(BYPASS_FP, now);
+    }
     return {
       proceed: true,
       reason: '',
-      result: synthetic,
+      result: syntheticScanFailureResult('health gate bypassed'),
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: true,
@@ -184,39 +218,48 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
   let result: HealthScanResult;
   try {
     result = await scan();
+    // Successful scan — reset the consecutive-error counter so the halt-
+    // threshold only fires on a true streak, not cumulative failures over days.
+    cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
   } catch (e) {
-    // Scanner failed (GitHub 5xx, rate limit, network). Don't silently look
-    // healthy — log and let the patrol proceed. Policy choice: a transient
-    // GitHub hiccup shouldn't halt PR work, but it also shouldn't masquerade
-    // as "all clear". Record the failure, keep going.
+    // Scanner failed. Policy: a transient GitHub hiccup shouldn't halt PR
+    // work. But if the scanner fails N consecutive times, something's wrong
+    // with our observability — flip to halt to prevent silent forever-proceed.
     const message = e instanceof Error ? e.message : String(e);
-    log(`${cl.yellow}⚠ Health scan failed — proceeding with caution: ${message}${cl.reset}`);
+    const prevCount = cooldown.getCount?.(SCAN_ERROR_COUNTER_KEY) ?? 0;
+    const newCount = prevCount + 1;
+    cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, newCount);
+
     writeEvent({
       type: 'health_scan_error',
       timestamp: now.toISOString(),
       error: message,
+      consecutive_errors: newCount,
     });
+
+    if (newCount >= MAX_CONSECUTIVE_SCAN_ERRORS) {
+      log(
+        `${cl.red}✗ Health scan has failed ${newCount}× in a row — HALTING patrol work. ` +
+          `Last error: ${message}${cl.reset}`,
+      );
+      return {
+        proceed: false,
+        reason: `scan failed ${newCount}× consecutively: ${message}`,
+        result: syntheticScanFailureResult(message),
+        emittedIssues: [],
+        suppressedIssues: [],
+        bypassed: false,
+      };
+    }
+
+    log(
+      `${cl.yellow}⚠ Health scan failed (${newCount}/${MAX_CONSECUTIVE_SCAN_ERRORS}) — ` +
+        `proceeding with caution: ${message}${cl.reset}`,
+    );
     return {
       proceed: true,
       reason: '',
-      result: {
-        healthy: true,
-        deploy: {
-          healthy: true,
-          reason: `scan failed: ${message}`,
-          lastSuccessfulDeployAt: null,
-          failingDeploys: [],
-        },
-        mainCi: {
-          healthy: true,
-          reason: `scan failed: ${message}`,
-          failingCount: 0,
-          redStreakStarted: null,
-          failingCommits: [],
-        },
-        ratchet: { healthy: true, reason: `scan failed: ${message}`, drifts: [] },
-        issues: [],
-      },
+      result: syntheticScanFailureResult(message),
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: false,

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -1,0 +1,288 @@
+/**
+ * PR Patrol — Health gate (QUA-300 Phase 3).
+ *
+ * Wires the Phase 1 + Phase 2 scanners (health-scan.ts) into the patrol loop
+ * as a precondition. When any health-scan sub-check is unhealthy, the gate
+ *   1. emits an escalation entry to the JSONL log (coordinator reads this),
+ *   2. logs a red warning to stderr for human visibility,
+ *   3. tells the caller to skip PR scan/fix for this cycle.
+ *
+ * Cooldown: the same failure fingerprint is only re-emitted once per
+ * HEALTH_GATE_COOLDOWN_MINUTES, so a hours-long outage doesn't spam the log.
+ *
+ * Escape hatch: `PATROL_DISABLE_HEALTH_GATE=1` bypasses the gate entirely.
+ * Intended for emergencies where the gate itself is misbehaving. Logs loudly
+ * when engaged.
+ *
+ * All dependencies (scanner, clock, JSONL writer, logger, env) are injectable
+ * so the gate is unit-testable without network or filesystem.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { healthScan as realHealthScan, type HealthScanResult, type HealthIssue } from './health-scan.ts';
+import { appendJsonl, JSONL_FILE, STATE_DIR, ensureDirs, cl, log as realLog } from './state.ts';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Minimum gap between emissions of the same escalation fingerprint. Set to
+ * 30min so a stuck prod deploy doesn't spam the log every patrol cycle (which
+ * can run as often as every 5min), while still reminding the coordinator on a
+ * human-comfortable cadence.
+ */
+export const HEALTH_GATE_COOLDOWN_MINUTES = 30;
+
+/** Env var to bypass the gate. Value `1` disables it. */
+export const DISABLE_ENV_VAR = 'PATROL_DISABLE_HEALTH_GATE';
+
+/** State file where last-emission timestamps per fingerprint are kept. */
+const HEALTH_GATE_STATE_FILE = join(STATE_DIR, 'health-gate-cooldown.json');
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface HealthGateDecision {
+  /** True when the caller should proceed with normal PR scan/fix work. */
+  proceed: boolean;
+  /** Why we're skipping (empty string when proceeding). */
+  reason: string;
+  /** The full scan result (for logging / downstream use). */
+  result: HealthScanResult;
+  /** Issues that actually triggered an escalation (after cooldown filtering). */
+  emittedIssues: HealthIssue[];
+  /** Issues that were suppressed by cooldown. */
+  suppressedIssues: HealthIssue[];
+  /** True when the env escape hatch was engaged. */
+  bypassed: boolean;
+}
+
+export interface HealthGateDeps {
+  scan?: () => Promise<HealthScanResult>;
+  now?: () => Date;
+  env?: Record<string, string | undefined>;
+  /** JSONL writer. Defaults to appendJsonl → ~/.cache/pr-patrol/runs.jsonl. */
+  writeEvent?: (entry: Record<string, unknown>) => void;
+  /** Human-visible log. Defaults to state.ts `log()` (stderr). */
+  log?: (msg: string) => void;
+  /** Cooldown store. Defaults to the on-disk JSON file. */
+  cooldownStore?: {
+    get: (fingerprint: string) => Date | null;
+    set: (fingerprint: string, at: Date) => void;
+  };
+}
+
+// ── Fingerprinting ───────────────────────────────────────────────────────────
+
+/**
+ * Stable identifier for a health issue used for cooldown deduplication.
+ * Collapses `deploy-stuck` issues to a single key per cycle even if the
+ * failing run URL differs, so retries of the same deploy failure don't
+ * keep resetting the cooldown.
+ */
+export function fingerprintIssue(issue: HealthIssue): string {
+  // For ratchet drift we want separate cooldowns per file — include the reason
+  // snippet that names the file. For deploy-stuck / main-ci-red, the type
+  // alone is stable enough.
+  if (issue.type === 'ratchet-drift') {
+    // Extract the first word or two before "baseline" to scope per-file.
+    const match = issue.reason.match(/^(\S+(?:\s\S+)?)\s+baseline/);
+    return `ratchet-drift:${match?.[1] ?? 'unknown'}`;
+  }
+  return issue.type;
+}
+
+// ── Cooldown store (filesystem-backed) ───────────────────────────────────────
+
+function defaultCooldownStore() {
+  return {
+    get(fingerprint: string): Date | null {
+      if (!existsSync(HEALTH_GATE_STATE_FILE)) return null;
+      try {
+        const raw = JSON.parse(readFileSync(HEALTH_GATE_STATE_FILE, 'utf-8')) as Record<
+          string,
+          string
+        >;
+        const iso = raw[fingerprint];
+        return iso ? new Date(iso) : null;
+      } catch {
+        return null;
+      }
+    },
+    set(fingerprint: string, at: Date): void {
+      ensureDirs();
+      let store: Record<string, string> = {};
+      if (existsSync(HEALTH_GATE_STATE_FILE)) {
+        try {
+          store = JSON.parse(readFileSync(HEALTH_GATE_STATE_FILE, 'utf-8')) as Record<
+            string,
+            string
+          >;
+        } catch {
+          /* ignore parse errors — treat as empty */
+        }
+      }
+      store[fingerprint] = at.toISOString();
+      writeFileSync(HEALTH_GATE_STATE_FILE, JSON.stringify(store, null, 2));
+    },
+  };
+}
+
+// ── Gate ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Run the health gate. Returns a decision telling the caller whether to
+ * proceed with PR work. Side effects (JSONL event, log line, cooldown
+ * update) happen via the injected deps.
+ */
+export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGateDecision> {
+  const scan = deps.scan ?? realHealthScan;
+  const nowFn = deps.now ?? (() => new Date());
+  const env = deps.env ?? process.env;
+  const writeEvent = deps.writeEvent ?? ((entry) => appendJsonl(JSONL_FILE, entry));
+  const log = deps.log ?? realLog;
+  const cooldown = deps.cooldownStore ?? defaultCooldownStore();
+
+  const now = nowFn();
+
+  // Escape hatch first — if disabled, we never even run the scan.
+  if (env[DISABLE_ENV_VAR] === '1') {
+    log(`${cl.yellow}⚠ ${DISABLE_ENV_VAR}=1 — health gate BYPASSED${cl.reset}`);
+    // Build a minimal synthetic "healthy" result so downstream consumers don't
+    // have to special-case the bypass path.
+    const synthetic: HealthScanResult = {
+      healthy: true,
+      deploy: {
+        healthy: true,
+        reason: 'health gate bypassed',
+        lastSuccessfulDeployAt: null,
+        failingDeploys: [],
+      },
+      mainCi: {
+        healthy: true,
+        reason: 'health gate bypassed',
+        failingCount: 0,
+        redStreakStarted: null,
+        failingCommits: [],
+      },
+      ratchet: {
+        healthy: true,
+        reason: 'health gate bypassed',
+        drifts: [],
+      },
+      issues: [],
+    };
+    return {
+      proceed: true,
+      reason: '',
+      result: synthetic,
+      emittedIssues: [],
+      suppressedIssues: [],
+      bypassed: true,
+    };
+  }
+
+  let result: HealthScanResult;
+  try {
+    result = await scan();
+  } catch (e) {
+    // Scanner failed (GitHub 5xx, rate limit, network). Don't silently look
+    // healthy — log and let the patrol proceed. Policy choice: a transient
+    // GitHub hiccup shouldn't halt PR work, but it also shouldn't masquerade
+    // as "all clear". Record the failure, keep going.
+    const message = e instanceof Error ? e.message : String(e);
+    log(`${cl.yellow}⚠ Health scan failed — proceeding with caution: ${message}${cl.reset}`);
+    writeEvent({
+      type: 'health_scan_error',
+      timestamp: now.toISOString(),
+      error: message,
+    });
+    return {
+      proceed: true,
+      reason: '',
+      result: {
+        healthy: true,
+        deploy: {
+          healthy: true,
+          reason: `scan failed: ${message}`,
+          lastSuccessfulDeployAt: null,
+          failingDeploys: [],
+        },
+        mainCi: {
+          healthy: true,
+          reason: `scan failed: ${message}`,
+          failingCount: 0,
+          redStreakStarted: null,
+          failingCommits: [],
+        },
+        ratchet: { healthy: true, reason: `scan failed: ${message}`, drifts: [] },
+        issues: [],
+      },
+      emittedIssues: [],
+      suppressedIssues: [],
+      bypassed: false,
+    };
+  }
+
+  if (result.healthy) {
+    return {
+      proceed: true,
+      reason: '',
+      result,
+      emittedIssues: [],
+      suppressedIssues: [],
+      bypassed: false,
+    };
+  }
+
+  // System is unhealthy — split issues into emitted vs suppressed by cooldown.
+  const emitted: HealthIssue[] = [];
+  const suppressed: HealthIssue[] = [];
+  const cooldownMs = HEALTH_GATE_COOLDOWN_MINUTES * 60_000;
+
+  for (const issue of result.issues) {
+    const fp = fingerprintIssue(issue);
+    const last = cooldown.get(fp);
+    if (last && now.getTime() - last.getTime() < cooldownMs) {
+      suppressed.push(issue);
+      continue;
+    }
+    emitted.push(issue);
+    cooldown.set(fp, now);
+  }
+
+  // Always log + always skip PR work when unhealthy — even if every signal is
+  // cooldown-suppressed. Suppression only affects whether we write another
+  // JSONL escalation; the patrol still must not touch PRs while prod is red.
+  for (const issue of emitted) {
+    log(
+      `${cl.red}✗ Health gate: ${issue.type} (score ${issue.score}) — ${issue.reason}${cl.reset}`,
+    );
+    writeEvent({
+      type: 'health_gate_tripped',
+      timestamp: now.toISOString(),
+      issue_type: issue.type,
+      score: issue.score,
+      reason: issue.reason,
+      url: issue.url ?? null,
+    });
+  }
+
+  for (const issue of suppressed) {
+    log(
+      `${cl.dim}  (cooldown: ${issue.type} already escalated in the last ${HEALTH_GATE_COOLDOWN_MINUTES}min)${cl.reset}`,
+    );
+  }
+
+  log(
+    `${cl.red}Health gate: system unhealthy — skipping PR scan/fix this cycle.${cl.reset}`,
+  );
+
+  return {
+    proceed: false,
+    reason: result.issues.map((i) => `${i.type}: ${i.reason}`).join(' | '),
+    result,
+    emittedIssues: emitted,
+    suppressedIssues: suppressed,
+    bypassed: false,
+  };
+}

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -834,12 +834,11 @@ describe('checkRatchetDriftForFile (mocked git)', () => {
     expect(result.reason).toContain('no commits');
   });
 
-  it('returns stable when git log fails (propagates reason, not a false-positive drift)', () => {
+  it('throws when git log fails so runHealthGate counts it as a scanner error (not fail-open)', () => {
     const runGit = () => ({ ok: false, output: '', stderr: 'fatal: not a git repository' });
-    const result = checkRatchetDriftForFile(cfg, { now: NOW }, runGit);
-    expect(result.drifted).toBe(false);
-    expect(result.reason).toContain('git log failed');
-    expect(result.reason).toContain('not a git repository');
+    expect(() => checkRatchetDriftForFile(cfg, { now: NOW }, runGit)).toThrow(
+      /git log failed.*not a git repository/,
+    );
   });
 
   it('uses --since=<iso> derived from `now` (not git wall-clock relative date)', () => {

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -6,6 +6,8 @@ import {
   evaluateRatchetDrift,
   combineHealth,
   combineRatchetDrift,
+  checkRatchetDriftForFile,
+  readBaselineTotal,
   mapRollupState,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
@@ -20,6 +22,7 @@ import {
   type BaselineObservation,
   type RatchetDriftResult,
 } from './health-scan.ts';
+import type { RatchetConfig } from './ratchet-config.ts';
 
 function emptyRatchet(): RatchetDriftResult {
   return combineRatchetDrift([]);
@@ -635,6 +638,223 @@ describe('combineHealth with ratchet drift', () => {
     const scores = combined.issues.map((i) => i.score);
     expect(scores[0]).toBeGreaterThan(scores[1]);
     expect(scores[1]).toBeGreaterThan(scores[2]);
+  });
+});
+
+// ── readBaselineTotal (numeric-type handling) ────────────────────────────────
+
+describe('readBaselineTotal', () => {
+  const cfg: RatchetConfig = {
+    file: 'x.json',
+    name: 'x',
+    totalField: 'total',
+    badDirection: 'up',
+  };
+
+  it('reads a numeric total', () => {
+    const runGit = () => ({ ok: true, output: '{"total": 23}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBe(23);
+  });
+
+  it('coerces a numeric-string total (regression: validators may serialize as string)', () => {
+    const runGit = () => ({ ok: true, output: '{"total": "23"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBe(23);
+  });
+
+  it('returns null for non-numeric string', () => {
+    const runGit = () => ({ ok: true, output: '{"total": "pending"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null when the field is missing', () => {
+    const runGit = () => ({ ok: true, output: '{"other": 1}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    const runGit = () => ({ ok: true, output: 'not-json', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null when git show fails (file absent at ref)', () => {
+    const runGit = () => ({ ok: false, output: '', stderr: 'fatal: path not in tree' });
+    expect(readBaselineTotal('HEAD', cfg, runGit)).toBeNull();
+  });
+
+  it('returns null for Infinity / NaN (both JSON and string forms)', () => {
+    // JSON doesn't allow Infinity, but the string-coercion branch could hit it.
+    const runGit1 = () => ({ ok: true, output: '{"total": "Infinity"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit1)).toBeNull();
+    const runGit2 = () => ({ ok: true, output: '{"total": "NaN"}', stderr: '' });
+    expect(readBaselineTotal('HEAD', cfg, runGit2)).toBeNull();
+  });
+});
+
+// ── checkRatchetDriftForFile (I/O wrapper, mocked gitSafe) ───────────────────
+
+describe('checkRatchetDriftForFile (mocked git)', () => {
+  const NOW = new Date('2026-04-12T20:00:00Z');
+  const cfg: RatchetConfig = {
+    file: 'crux/validate/.sourcing-baseline.json',
+    name: 'sourcing',
+    totalField: 'total',
+    badDirection: 'up',
+  };
+
+  function makeGit(
+    logOutput: string,
+    showResponses: Record<string, { ok: boolean; output: string; stderr?: string }> = {},
+  ) {
+    return (...args: string[]) => {
+      if (args[0] === 'log') {
+        return { ok: true, output: logOutput, stderr: '' };
+      }
+      if (args[0] === 'show' && args[1] === '-s') {
+        // commitTimestamp: `git show -s --format=%ct <ref>`
+        const ref = args[3];
+        const resp = showResponses[`ts:${ref}`];
+        return resp ?? { ok: false, output: '', stderr: 'not found' };
+      }
+      if (args[0] === 'show') {
+        // readBaselineTotal: `git show <ref>:<file>`
+        const spec = args[1];
+        const resp = showResponses[spec];
+        return resp ?? { ok: false, output: '', stderr: 'not found' };
+      }
+      return { ok: false, output: '', stderr: 'unexpected git call' };
+    };
+  }
+
+  function epoch(iso: string): string {
+    return String(Math.floor(new Date(iso).getTime() / 1000));
+  }
+
+  it('fires when 3 upward bumps appear in the window (file existed before window)', () => {
+    const c1 = { iso: '2026-04-12T10:00:00Z' };
+    const c2 = { iso: '2026-04-12T14:00:00Z' };
+    const c3 = { iso: '2026-04-12T18:00:00Z' };
+    // git log newest-first:
+    const logOutput = [
+      `c3 ${epoch(c3.iso)}`,
+      `c2 ${epoch(c2.iso)}`,
+      `c1 ${epoch(c1.iso)}`,
+    ].join('\n');
+    const showResponses = {
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 2}',
+        stderr: '',
+      },
+      'ts:c1^': { ok: true, output: epoch('2026-04-11T23:00:00Z'), stderr: '' },
+      'c1:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 5}',
+        stderr: '',
+      },
+      'c2:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 10}',
+        stderr: '',
+      },
+      'c3:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 23}',
+        stderr: '',
+      },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+    expect(result.bumps.map((b) => [b.from, b.to])).toEqual([
+      [2, 5],
+      [5, 10],
+      [10, 23],
+    ]);
+  });
+
+  it('handles a file created mid-window (parent-of-first-commit has no file) — 3 later bumps still fire', () => {
+    // File is created by c1 at total=2. Parent c1^ doesn't have the file.
+    // Subsequent commits c2=5, c3=10, c4=23. The evaluator sees observations
+    // [c1=2, c2=5, c3=10, c4=23] — parent is skipped cleanly.
+    const logOutput = [
+      `c4 ${epoch('2026-04-12T18:00:00Z')}`,
+      `c3 ${epoch('2026-04-12T15:00:00Z')}`,
+      `c2 ${epoch('2026-04-12T12:00:00Z')}`,
+      `c1 ${epoch('2026-04-12T09:00:00Z')}`,
+    ].join('\n');
+    const showResponses = {
+      // Parent of c1 has no file — git show returns non-ok
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: false,
+        output: '',
+        stderr: 'fatal: path not in tree',
+      },
+      'c1:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 2}', stderr: '' },
+      'c2:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 5}', stderr: '' },
+      'c3:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 10}', stderr: '' },
+      'c4:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 23}', stderr: '' },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+  });
+
+  it('handles a comment-only commit (touches file but leaves total unchanged)', () => {
+    // c1 touches file but keeps total at 5; c2 bumps to 10; c3 bumps to 23.
+    // Only c1→c2 (up) and c2→c3 (up) are bumps. Plus parent→c1 (2→5, up) if
+    // parent is readable. That gives 3 bumps total.
+    const logOutput = [
+      `c3 ${epoch('2026-04-12T18:00:00Z')}`,
+      `c2 ${epoch('2026-04-12T15:00:00Z')}`,
+      `c1 ${epoch('2026-04-12T12:00:00Z')}`,
+    ].join('\n');
+    const showResponses = {
+      'c1^:crux/validate/.sourcing-baseline.json': {
+        ok: true,
+        output: '{"total": 5}',
+        stderr: '',
+      },
+      'ts:c1^': { ok: true, output: epoch('2026-04-12T09:00:00Z'), stderr: '' },
+      // c1 touched the file but didn't change the total
+      'c1:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 5}', stderr: '' },
+      'c2:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 10}', stderr: '' },
+      'c3:crux/validate/.sourcing-baseline.json': { ok: true, output: '{"total": 23}', stderr: '' },
+    };
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, makeGit(logOutput, showResponses));
+    // Bumps: parent→c1 (5=5, no bump), c1→c2 (5→10 up), c2→c3 (10→23 up) = 2
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(2);
+  });
+
+  it('returns stable+zero-bumps when git log has no commits in the window', () => {
+    const runGit = makeGit('');
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, runGit);
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(0);
+    expect(result.reason).toContain('no commits');
+  });
+
+  it('returns stable when git log fails (propagates reason, not a false-positive drift)', () => {
+    const runGit = () => ({ ok: false, output: '', stderr: 'fatal: not a git repository' });
+    const result = checkRatchetDriftForFile(cfg, { now: NOW }, runGit);
+    expect(result.drifted).toBe(false);
+    expect(result.reason).toContain('git log failed');
+    expect(result.reason).toContain('not a git repository');
+  });
+
+  it('uses --since=<iso> derived from `now` (not git wall-clock relative date)', () => {
+    // Capture the --since arg to verify it matches `now - windowHours`.
+    let capturedSince: string | null = null;
+    const runGit = (...args: string[]) => {
+      if (args[0] === 'log') {
+        const sinceArg = args.find((a) => a.startsWith('--since='));
+        capturedSince = sinceArg?.replace('--since=', '') ?? null;
+        return { ok: true, output: '', stderr: '' };
+      }
+      return { ok: false, output: '', stderr: '' };
+    };
+    checkRatchetDriftForFile(cfg, { now: NOW, windowHours: 24 }, runGit);
+    expect(capturedSince).toBe(new Date(NOW.getTime() - 24 * 3_600_000).toISOString());
   });
 });
 

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -3,16 +3,27 @@ import { describe, it, expect } from 'vitest';
 import {
   evaluateDeployStatus,
   evaluateMainCi,
+  evaluateRatchetDrift,
   combineHealth,
+  combineRatchetDrift,
   mapRollupState,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
   DEPLOY_STALE_THRESHOLD_HOURS,
   DEPLOY_STUCK_SCORE,
   MAIN_CI_RED_SCORE,
+  RATCHET_DRIFT_SCORE,
+  RATCHET_DRIFT_MIN_BUMPS,
+  RATCHET_DRIFT_WINDOW_HOURS,
   type WorkflowRun,
   type CommitStatus,
+  type BaselineObservation,
+  type RatchetDriftResult,
 } from './health-scan.ts';
+
+function emptyRatchet(): RatchetDriftResult {
+  return combineRatchetDrift([]);
+}
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -237,7 +248,7 @@ describe('combineHealth', () => {
   it('returns healthy with empty issues when both sub-scanners are healthy', () => {
     const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
     const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(true);
     expect(combined.issues).toHaveLength(0);
   });
@@ -248,7 +259,7 @@ describe('combineHealth', () => {
       run({ id: 2, conclusion: 'failure' }),
     ]);
     const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(false);
     expect(combined.issues).toHaveLength(1);
     expect(combined.issues[0].type).toBe('deploy-stuck');
@@ -264,7 +275,7 @@ describe('combineHealth', () => {
       commit({ sha: 'b', conclusion: 'failure' }),
       commit({ sha: 'c', conclusion: 'failure' }),
     ]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.healthy).toBe(false);
     expect(combined.issues).toHaveLength(1);
     expect(combined.issues[0].type).toBe('main-ci-red');
@@ -282,7 +293,7 @@ describe('combineHealth', () => {
       commit({ sha: 'b', conclusion: 'failure' }),
       commit({ sha: 'c', conclusion: 'failure' }),
     ]);
-    const combined = combineHealth(deploy, mainCi, now);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
     expect(combined.issues).toHaveLength(2);
     expect(combined.issues[0].type).toBe('deploy-stuck');
     expect(combined.issues[1].type).toBe('main-ci-red');
@@ -369,6 +380,263 @@ describe('evaluateMainCi — mid-list pending interruption', () => {
 });
 
 // ── mapRollupState — GraphQL enum coverage ──────────────────────────────────
+
+// ── evaluateRatchetDrift (pure) ──────────────────────────────────────────────
+
+describe('evaluateRatchetDrift', () => {
+  const NOW = new Date('2026-04-12T20:00:00Z');
+
+  function obs(hoursAgo: number, total: number | null, commit = `c${hoursAgo}`): BaselineObservation {
+    return {
+      commit,
+      committedAt: new Date(NOW.getTime() - hoursAgo * 3_600_000),
+      total,
+    };
+  }
+
+  it('fires on 3 monotonic upward bumps within 24h (bad direction = up)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 5), obs(5, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+    expect(result.direction).toBe('up');
+    expect(result.bumps.map((b) => [b.from, b.to])).toEqual([
+      [2, 5],
+      [5, 10],
+      [10, 23],
+    ]);
+  });
+
+  it('does NOT fire with only 2 bumps in window (below threshold of 3)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(5, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(2);
+  });
+
+  it('does NOT fire when 3 bumps span a 48h window (rate-limited)', () => {
+    // 3 bumps, but spread across 48h — only the last one is in the 24h window.
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(48, 2), obs(36, 5), obs(30, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW, windowHours: 24 },
+    );
+    expect(result.drifted).toBe(false);
+    // Only the 30h→1h transition is seen as a bump in the windowed view,
+    // because the pre-window parent observation was filtered out.
+    expect(result.bumpCount).toBeLessThan(3);
+  });
+
+  it('does NOT fire on alternating-direction bumps', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 5), obs(8, 20), obs(5, 7), obs(1, 30)],
+      { badDirection: 'up', now: NOW },
+    );
+    // Sequence: 5→20 (up), 20→7 (down, reset), 7→30 (up) → bad-direction streak=1
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(1);
+  });
+
+  it('resets the streak when a good-direction bump interrupts (fix landed mid-window)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 5), obs(6, 10), obs(4, 4), obs(2, 8)],
+      { badDirection: 'up', now: NOW },
+    );
+    // 2→5 up, 5→10 up (streak=2), 10→4 DOWN (reset), 4→8 up (streak=1)
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(1);
+  });
+
+  it('ignores no-op commits (total unchanged) without counting them as bumps', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, 2), obs(8, 2), obs(6, 5), obs(4, 5), obs(2, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3); // 2→5, 5→10, 10→23
+  });
+
+  it('skips observations with null total (file absent at that commit)', () => {
+    const result = evaluateRatchetDrift(
+      'sourcing.json',
+      'sourcing',
+      [obs(10, null), obs(8, 2), obs(5, 5), obs(3, 10), obs(1, 23)],
+      { badDirection: 'up', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.bumpCount).toBe(3);
+  });
+
+  it('validates constants', () => {
+    expect(RATCHET_DRIFT_MIN_BUMPS).toBe(3);
+    expect(RATCHET_DRIFT_WINDOW_HOURS).toBe(24);
+  });
+
+  it('fires on 3 downward bumps when bad direction = down (e.g., coverage ratchet)', () => {
+    const result = evaluateRatchetDrift(
+      'coverage.json',
+      'coverage',
+      [obs(10, 100), obs(8, 95), obs(5, 90), obs(1, 80)],
+      { badDirection: 'down', now: NOW },
+    );
+    expect(result.drifted).toBe(true);
+    expect(result.direction).toBe('down');
+    expect(result.bumpCount).toBe(3);
+    expect(result.reason).toContain('↓');
+  });
+
+  it('returns a stable-reason for empty observations', () => {
+    const result = evaluateRatchetDrift('x.json', 'x', [], {
+      badDirection: 'up',
+      now: NOW,
+    });
+    expect(result.drifted).toBe(false);
+    expect(result.bumpCount).toBe(0);
+    expect(result.reason).toContain('stable');
+  });
+});
+
+// ── combineRatchetDrift ──────────────────────────────────────────────────────
+
+describe('combineRatchetDrift', () => {
+  it('is healthy when no ratchets are registered', () => {
+    const result = combineRatchetDrift([]);
+    expect(result.healthy).toBe(true);
+    expect(result.reason).toContain('no ratchet');
+  });
+
+  it('is healthy when all registered ratchets are within thresholds', () => {
+    const result = combineRatchetDrift([
+      {
+        file: 'a.json',
+        name: 'a',
+        direction: null,
+        bumpCount: 0,
+        bumps: [],
+        drifted: false,
+        reason: 'ok',
+      },
+    ]);
+    expect(result.healthy).toBe(true);
+  });
+
+  it('is unhealthy when any ratchet drifted', () => {
+    const result = combineRatchetDrift([
+      {
+        file: 'a.json',
+        name: 'a',
+        direction: 'up',
+        bumpCount: 3,
+        bumps: [],
+        drifted: true,
+        reason: 'a bumped 3×',
+      },
+      {
+        file: 'b.json',
+        name: 'b',
+        direction: null,
+        bumpCount: 0,
+        bumps: [],
+        drifted: false,
+        reason: 'ok',
+      },
+    ]);
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toBe('a bumped 3×');
+  });
+});
+
+// ── combineHealth + ratchet integration ──────────────────────────────────────
+
+describe('combineHealth with ratchet drift', () => {
+  const now = new Date('2026-04-12T07:00:00Z');
+
+  it('emits a ratchet-drift issue when a baseline drifted', () => {
+    const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
+    const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
+    const ratchet: RatchetDriftResult = {
+      healthy: false,
+      reason: 'sourcing bumped 3× ↑',
+      drifts: [
+        {
+          file: 'sourcing.json',
+          name: 'sourcing',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'sourcing bumped 3× ↑',
+        },
+      ],
+    };
+    const combined = combineHealth(deploy, mainCi, ratchet, now);
+    expect(combined.healthy).toBe(false);
+    expect(combined.issues).toHaveLength(1);
+    expect(combined.issues[0].type).toBe('ratchet-drift');
+    expect(combined.issues[0].score).toBe(RATCHET_DRIFT_SCORE);
+    expect(combined.issues[0].reason).toBe('sourcing bumped 3× ↑');
+  });
+
+  it('ranks deploy-stuck > main-ci-red > ratchet-drift', () => {
+    expect(DEPLOY_STUCK_SCORE).toBeGreaterThan(MAIN_CI_RED_SCORE);
+    expect(MAIN_CI_RED_SCORE).toBeGreaterThan(RATCHET_DRIFT_SCORE);
+    // And ratchet-drift still outranks per-PR conflict (100)
+    expect(RATCHET_DRIFT_SCORE).toBeGreaterThan(100);
+  });
+
+  it('emits all three issues when everything is unhealthy', () => {
+    const deploy = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure' }),
+      run({ id: 2, conclusion: 'failure' }),
+    ]);
+    const mainCi = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    const ratchet: RatchetDriftResult = {
+      healthy: false,
+      reason: 'drift',
+      drifts: [
+        {
+          file: 'x.json',
+          name: 'x',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'x bumped 3×',
+        },
+      ],
+    };
+    const combined = combineHealth(deploy, mainCi, ratchet, now);
+    expect(combined.issues.map((i) => i.type)).toEqual([
+      'deploy-stuck',
+      'main-ci-red',
+      'ratchet-drift',
+    ]);
+    // Issues are pushed in the order they're checked — which is also the
+    // priority order. Verify scores are monotonically decreasing.
+    const scores = combined.issues.map((i) => i.score);
+    expect(scores[0]).toBeGreaterThan(scores[1]);
+    expect(scores[1]).toBeGreaterThan(scores[2]);
+  });
+});
 
 describe('mapRollupState', () => {
   it('maps SUCCESS → success', () => {

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -337,11 +337,19 @@ export function evaluateRatchetDrift(
   const minBumps = options.minBumps ?? RATCHET_DRIFT_MIN_BUMPS;
   const windowStart = now.getTime() - windowHours * 3_600_000;
 
-  // Keep only observations inside the window — sorted oldest → newest so
-  // consecutive-pair deltas flow naturally.
-  const inWindow = observations
-    .filter((o) => o.committedAt.getTime() >= windowStart)
-    .sort((a, b) => a.committedAt.getTime() - b.committedAt.getTime());
+  // Sort oldest → newest so consecutive-pair deltas flow naturally. Keep
+  // the most recent observation immediately before windowStart (if any) as
+  // the baseline — checkRatchetDriftForFile() intentionally adds `firstCommit^`
+  // so bump #1 can be compared against its pre-window parent. Filtering it out
+  // would undercount sequences like parent(26h) → bump(23h) → bump(12h) → bump(1h).
+  const ordered = [...observations].sort(
+    (a, b) => a.committedAt.getTime() - b.committedAt.getTime(),
+  );
+  const firstInWindowIdx = ordered.findIndex(
+    (o) => o.committedAt.getTime() >= windowStart,
+  );
+  const inWindow =
+    firstInWindowIdx <= 0 ? ordered : ordered.slice(firstInWindowIdx - 1);
 
   // A good-direction bump resets the counter; bad-direction bumps accumulate.
   // Track the counter + the bumps that contributed to the current streak so
@@ -456,7 +464,16 @@ export function checkRatchetDriftForFile(
     config.file,
   );
 
-  if (!logResult.ok || !logResult.output) {
+  // Scanner failure ≠ healthy. If git log fails we can't judge drift, so throw
+  // to let runHealthGate()'s consecutive-error counter halt patrol — rather
+  // than returning drifted:false and silently disabling this scanner.
+  if (!logResult.ok) {
+    throw new Error(
+      `ratchet-drift scanner: git log failed for ${config.file}: ${logResult.stderr || 'unknown error'}`,
+    );
+  }
+
+  if (!logResult.output) {
     return {
       file: config.file,
       name: config.name,
@@ -464,10 +481,7 @@ export function checkRatchetDriftForFile(
       bumpCount: 0,
       bumps: [],
       drifted: false,
-      reason:
-        !logResult.ok
-          ? `git log failed for ${config.file}: ${logResult.stderr || 'unknown error'}`
-          : `${config.name} baseline: no commits in the last ${windowHours}h`,
+      reason: `${config.name} baseline: no commits in the last ${windowHours}h`,
     };
   }
 

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -14,6 +14,8 @@
  */
 
 import { REPO, githubApi, githubGraphQL } from '../lib/github.ts';
+import { gitSafe } from '../lib/git.ts';
+import { RATCHET_BASELINES, type RatchetConfig } from './ratchet-config.ts';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -50,6 +52,26 @@ export const DEPLOY_STUCK_SCORE = 200;
 /** Score bonus for a main-CI red streak. Below deploy-stuck but above per-PR. */
 export const MAIN_CI_RED_SCORE = 180;
 
+/**
+ * Min bumps in the bad direction within the window before ratchet-drift fires.
+ * Chosen at 3 because 2 can easily be legitimate rebase-flurry; 3+ is when
+ * the "we're papering over something" pattern emerges.
+ */
+export const RATCHET_DRIFT_MIN_BUMPS = 3;
+
+/**
+ * Sliding window for ratchet-drift detection. 24h aligns with the retrospective
+ * incident where a baseline moved 3+ times in the same night.
+ */
+export const RATCHET_DRIFT_WINDOW_HOURS = 24;
+
+/**
+ * Score bonus for a ratchet-drift signal. Below deploy-stuck + main-ci-red but
+ * still above every per-PR issue so it surfaces before the patrol re-dispatches
+ * another bump attempt.
+ */
+export const RATCHET_DRIFT_SCORE = 150;
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface WorkflowRun {
@@ -85,7 +107,7 @@ export interface MainCiResult {
   failingCommits: CommitStatus[];
 }
 
-export type HealthIssueType = 'deploy-stuck' | 'main-ci-red';
+export type HealthIssueType = 'deploy-stuck' | 'main-ci-red' | 'ratchet-drift';
 
 export interface HealthIssue {
   type: HealthIssueType;
@@ -97,10 +119,47 @@ export interface HealthIssue {
   detectedAt: string;
 }
 
+/**
+ * One observation of a ratchet baseline at a specific commit.
+ * `total === null` means the file didn't exist at that commit (or couldn't be
+ * read / parsed) — the evaluator treats it as "no data point" and skips it.
+ */
+export interface BaselineObservation {
+  commit: string;
+  committedAt: Date;
+  total: number | null;
+}
+
+export interface RatchetDriftForFile {
+  file: string;
+  name: string;
+  /** How the total moved — only populated when drift is flagged. */
+  direction: 'up' | 'down' | null;
+  /** Number of bumps in the bad direction within the window. */
+  bumpCount: number;
+  /** The specific bumps that tripped the threshold (oldest → newest). */
+  bumps: Array<{
+    commit: string;
+    committedAt: string;
+    from: number;
+    to: number;
+  }>;
+  /** True when the count exceeds the threshold in the bad direction. */
+  drifted: boolean;
+  reason: string;
+}
+
+export interface RatchetDriftResult {
+  healthy: boolean;
+  reason: string;
+  drifts: RatchetDriftForFile[];
+}
+
 export interface HealthScanResult {
   healthy: boolean;
   deploy: DeployStatusResult;
   mainCi: MainCiResult;
+  ratchet: RatchetDriftResult;
   issues: HealthIssue[];
 }
 
@@ -250,12 +309,239 @@ export function evaluateMainCi(commits: CommitStatus[]): MainCiResult {
 }
 
 /**
+ * Given observations of a ratchet baseline (oldest → newest) and a window,
+ * decide whether the file has drifted in the bad direction.
+ *
+ * Rules:
+ *  - Only observations within `windowHours` of `now` are considered.
+ *  - Consecutive observations where `total` changed and both values are
+ *    non-null form a "bump". Direction = sign(to - from).
+ *  - Bumps in the bad direction count; bumps in the good direction RESET
+ *    the counter — we only care about unchecked drift. (A legitimate fix
+ *    that moves the number down shouldn't be hidden by yesterday's bad bump.)
+ *  - Drift fires when bad-direction bumps ≥ `minBumps`.
+ */
+export function evaluateRatchetDrift(
+  file: string,
+  name: string,
+  observations: BaselineObservation[],
+  options: {
+    badDirection: 'up' | 'down';
+    now?: Date;
+    windowHours?: number;
+    minBumps?: number;
+  },
+): RatchetDriftForFile {
+  const now = options.now ?? new Date();
+  const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
+  const minBumps = options.minBumps ?? RATCHET_DRIFT_MIN_BUMPS;
+  const windowStart = now.getTime() - windowHours * 3_600_000;
+
+  // Keep only observations inside the window — sorted oldest → newest so
+  // consecutive-pair deltas flow naturally.
+  const inWindow = observations
+    .filter((o) => o.committedAt.getTime() >= windowStart)
+    .sort((a, b) => a.committedAt.getTime() - b.committedAt.getTime());
+
+  // A good-direction bump resets the counter; bad-direction bumps accumulate.
+  // Track the counter + the bumps that contributed to the current streak so
+  // the escalation message can name them.
+  let badBumps: RatchetDriftForFile['bumps'] = [];
+
+  for (let i = 1; i < inWindow.length; i++) {
+    const prev = inWindow[i - 1];
+    const curr = inWindow[i];
+    if (prev.total === null || curr.total === null) continue;
+    if (curr.total === prev.total) continue;
+
+    const direction: 'up' | 'down' = curr.total > prev.total ? 'up' : 'down';
+    if (direction === options.badDirection) {
+      badBumps.push({
+        commit: curr.commit,
+        committedAt: curr.committedAt.toISOString(),
+        from: prev.total,
+        to: curr.total,
+      });
+    } else {
+      // A fix in the good direction invalidates the streak.
+      badBumps = [];
+    }
+  }
+
+  const bumpCount = badBumps.length;
+  const drifted = bumpCount >= minBumps;
+
+  if (drifted) {
+    const arrow = options.badDirection === 'up' ? '↑' : '↓';
+    const first = badBumps[0];
+    const last = badBumps[bumpCount - 1];
+    return {
+      file,
+      name,
+      direction: options.badDirection,
+      bumpCount,
+      bumps: badBumps,
+      drifted: true,
+      reason:
+        `${name} baseline bumped ${bumpCount}× ${arrow} in the last ${windowHours}h ` +
+        `(${first.from} → ${last.to}). Do NOT bump again — investigate the underlying cause.`,
+    };
+  }
+
+  return {
+    file,
+    name,
+    direction: bumpCount > 0 ? options.badDirection : null,
+    bumpCount,
+    bumps: badBumps,
+    drifted: false,
+    reason:
+      bumpCount === 0
+        ? `${name} baseline stable over the last ${windowHours}h`
+        : `${name} baseline bumped ${bumpCount}× (below ≥${minBumps} threshold — monitoring)`,
+  };
+}
+
+/**
+ * Collapse a list of per-file drift results into the aggregate RatchetDriftResult.
+ * Pure.
+ */
+export function combineRatchetDrift(drifts: RatchetDriftForFile[]): RatchetDriftResult {
+  const drifted = drifts.filter((d) => d.drifted);
+  if (drifted.length === 0) {
+    return {
+      healthy: true,
+      reason:
+        drifts.length === 0
+          ? 'no ratchet baselines registered'
+          : 'all ratchet baselines within thresholds',
+      drifts,
+    };
+  }
+
+  return {
+    healthy: false,
+    reason: drifted.map((d) => d.reason).join(' | '),
+    drifts,
+  };
+}
+
+/**
+ * Read a registered ratchet's history over the last `windowHours` via git log
+ * and evaluate for drift. Each commit that touched the file contributes one
+ * observation; the file is read at that commit via `git show`.
+ *
+ * Unlike `checkDeployStatus` / `checkMainCi`, this scanner is local-only — no
+ * network, no GitHub API. It runs against the current working tree's git repo.
+ */
+export function checkRatchetDriftForFile(
+  config: RatchetConfig,
+  options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+): RatchetDriftForFile {
+  const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
+  const since = `${windowHours} hours ago`;
+
+  // One commit per line: `<sha> <unix-ts>`
+  const logResult = gitSafe(
+    'log',
+    `--since=${since}`,
+    '--format=%H %ct',
+    '--',
+    config.file,
+  );
+
+  if (!logResult.ok || !logResult.output) {
+    return {
+      file: config.file,
+      name: config.name,
+      direction: null,
+      bumpCount: 0,
+      bumps: [],
+      drifted: false,
+      reason:
+        !logResult.ok
+          ? `git log failed for ${config.file}: ${logResult.stderr || 'unknown error'}`
+          : `${config.name} baseline: no commits in the last ${windowHours}h`,
+    };
+  }
+
+  // git log is newest-first; we want oldest-first for evaluation.
+  const lines = logResult.output.split('\n').filter(Boolean).reverse();
+
+  // Include the "before" state: the parent of the earliest in-window commit.
+  // Without it we'd miss bump #1 (can't compute from/to for the first commit).
+  const firstCommit = lines[0]?.split(' ')[0];
+  const observations: BaselineObservation[] = [];
+
+  if (firstCommit) {
+    const parentTotal = readBaselineTotal(`${firstCommit}^`, config);
+    if (parentTotal !== null) {
+      const parentTs = commitTimestamp(`${firstCommit}^`);
+      if (parentTs) {
+        observations.push({
+          commit: `${firstCommit}^`,
+          committedAt: parentTs,
+          total: parentTotal,
+        });
+      }
+    }
+  }
+
+  for (const line of lines) {
+    const [sha, ts] = line.split(' ');
+    if (!sha || !ts) continue;
+    observations.push({
+      commit: sha,
+      committedAt: new Date(Number.parseInt(ts, 10) * 1000),
+      total: readBaselineTotal(sha, config),
+    });
+  }
+
+  return evaluateRatchetDrift(config.file, config.name, observations, {
+    badDirection: config.badDirection,
+    now: options.now,
+    windowHours,
+    minBumps: options.minBumps,
+  });
+}
+
+/** Run the drift scan across every registered baseline. */
+export function checkRatchetDrift(
+  options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+  baselines: readonly RatchetConfig[] = RATCHET_BASELINES,
+): RatchetDriftResult {
+  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options));
+  return combineRatchetDrift(drifts);
+}
+
+function readBaselineTotal(ref: string, config: RatchetConfig): number | null {
+  const result = gitSafe('show', `${ref}:${config.file}`);
+  if (!result.ok) return null;
+  try {
+    const parsed = JSON.parse(result.output);
+    const value = (parsed as Record<string, unknown>)[config.totalField];
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function commitTimestamp(ref: string): Date | null {
+  const result = gitSafe('show', '-s', '--format=%ct', ref);
+  if (!result.ok) return null;
+  const ts = Number.parseInt(result.output, 10);
+  if (!Number.isFinite(ts)) return null;
+  return new Date(ts * 1000);
+}
+
+/**
  * Combine deploy + main-CI evaluations into a single HealthScanResult.
  * Pure — takes the two sub-results and assembles the issue list for the queue.
  */
 export function combineHealth(
   deploy: DeployStatusResult,
   mainCi: MainCiResult,
+  ratchet: RatchetDriftResult,
   now: Date = new Date(),
 ): HealthScanResult {
   const issues: HealthIssue[] = [];
@@ -281,10 +567,21 @@ export function combineHealth(
     });
   }
 
+  for (const drift of ratchet.drifts) {
+    if (!drift.drifted) continue;
+    issues.push({
+      type: 'ratchet-drift',
+      score: RATCHET_DRIFT_SCORE,
+      reason: drift.reason,
+      detectedAt,
+    });
+  }
+
   return {
-    healthy: deploy.healthy && mainCi.healthy,
+    healthy: deploy.healthy && mainCi.healthy && ratchet.healthy,
     deploy,
     mainCi,
+    ratchet,
     issues,
   };
 }
@@ -433,5 +730,6 @@ export async function healthScan(now: Date = new Date()): Promise<HealthScanResu
     checkDeployStatus({ now }),
     checkMainCi(),
   ]);
-  return combineHealth(deploy, mainCi, now);
+  const ratchet = checkRatchetDrift({ now });
+  return combineHealth(deploy, mainCi, ratchet, now);
 }

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -437,14 +437,20 @@ export function combineRatchetDrift(drifts: RatchetDriftForFile[]): RatchetDrift
 export function checkRatchetDriftForFile(
   config: RatchetConfig,
   options: { now?: Date; windowHours?: number; minBumps?: number } = {},
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
 ): RatchetDriftForFile {
+  const now = options.now ?? new Date();
   const windowHours = options.windowHours ?? RATCHET_DRIFT_WINDOW_HOURS;
-  const since = `${windowHours} hours ago`;
+
+  // Thread `now` into git's --since so the window used by git log matches the
+  // window used by the evaluator. Without this, a custom `now` (e.g. a test
+  // clock) would desync from git's wall-clock --since interpretation.
+  const sinceIso = new Date(now.getTime() - windowHours * 3_600_000).toISOString();
 
   // One commit per line: `<sha> <unix-ts>`
-  const logResult = gitSafe(
+  const logResult = runGit(
     'log',
-    `--since=${since}`,
+    `--since=${sinceIso}`,
     '--format=%H %ct',
     '--',
     config.file,
@@ -474,9 +480,14 @@ export function checkRatchetDriftForFile(
   const observations: BaselineObservation[] = [];
 
   if (firstCommit) {
-    const parentTotal = readBaselineTotal(`${firstCommit}^`, config);
+    // Try to include the "before" state: the parent of the earliest in-window
+    // commit. If the parent doesn't exist (root commit) or the file didn't
+    // exist there (newly created mid-window), we just skip — the observation
+    // chain starts at firstCommit itself. That means commit #1 in the window
+    // can't be counted as a bump (no "from" value), but commits #2+ still are.
+    const parentTotal = readBaselineTotal(`${firstCommit}^`, config, runGit);
     if (parentTotal !== null) {
-      const parentTs = commitTimestamp(`${firstCommit}^`);
+      const parentTs = commitTimestamp(`${firstCommit}^`, runGit);
       if (parentTs) {
         observations.push({
           commit: `${firstCommit}^`,
@@ -493,13 +504,13 @@ export function checkRatchetDriftForFile(
     observations.push({
       commit: sha,
       committedAt: new Date(Number.parseInt(ts, 10) * 1000),
-      total: readBaselineTotal(sha, config),
+      total: readBaselineTotal(sha, config, runGit),
     });
   }
 
   return evaluateRatchetDrift(config.file, config.name, observations, {
     badDirection: config.badDirection,
-    now: options.now,
+    now,
     windowHours,
     minBumps: options.minBumps,
   });
@@ -509,25 +520,43 @@ export function checkRatchetDriftForFile(
 export function checkRatchetDrift(
   options: { now?: Date; windowHours?: number; minBumps?: number } = {},
   baselines: readonly RatchetConfig[] = RATCHET_BASELINES,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
 ): RatchetDriftResult {
-  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options));
+  const drifts = baselines.map((cfg) => checkRatchetDriftForFile(cfg, options, runGit));
   return combineRatchetDrift(drifts);
 }
 
-function readBaselineTotal(ref: string, config: RatchetConfig): number | null {
-  const result = gitSafe('show', `${ref}:${config.file}`);
+/**
+ * Exported for testing. Accepts numbers AND numeric strings — some validators
+ * serialize totals as strings to avoid precision loss, and silently dropping
+ * those would let drift go undetected.
+ */
+export function readBaselineTotal(
+  ref: string,
+  config: RatchetConfig,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
+): number | null {
+  const result = runGit('show', `${ref}:${config.file}`);
   if (!result.ok) return null;
   try {
     const parsed = JSON.parse(result.output);
-    const value = (parsed as Record<string, unknown>)[config.totalField];
-    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+    const raw = (parsed as Record<string, unknown>)[config.totalField];
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    if (typeof raw === 'string') {
+      const coerced = Number(raw);
+      return Number.isFinite(coerced) ? coerced : null;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-function commitTimestamp(ref: string): Date | null {
-  const result = gitSafe('show', '-s', '--format=%ct', ref);
+function commitTimestamp(
+  ref: string,
+  runGit: (...args: string[]) => { ok: boolean; output: string; stderr: string } = gitSafe,
+): Date | null {
+  const result = runGit('show', '-s', '--format=%ct', ref);
   if (!result.ok) return null;
   const ts = Number.parseInt(result.output, 10);
   if (!Number.isFinite(ts)) return null;

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -682,6 +682,9 @@ export function readRecentLogs(count: number): string {
           `  Overlap: PR #${entry.pr_a} ↔ PR #${entry.pr_b} (${entry.shared_files} shared files)`,
         );
       } else if (entry.type === 'cycle_summary') {
+        const gateInfo = entry.health_gate_tripped
+          ? `, health_gate=tripped (${entry.health_gate_reason ?? 'unknown'})`
+          : '';
         const mainFix = entry.main_branch_fix ? ', main_branch_fix=true' : '';
         const enqueueInfo = entry.prs_enqueued?.length
           ? `, enqueued=[${entry.prs_enqueued.map((n: number) => `#${n}`).join(', ')}]`
@@ -692,7 +695,7 @@ export function readRecentLogs(count: number): string {
             ? `, merge-blocked=${entry.merge_candidates}`
             : '';
         output.push(
-          `  Cycle #${entry.cycle_number}: scanned=${entry.prs_scanned}, queue=${entry.queue_size}, processed=${entry.pr_processed ?? 'none'}${mainFix}${enqueueInfo}${mergeInfo}`,
+          `  Cycle #${entry.cycle_number}: scanned=${entry.prs_scanned}, queue=${entry.queue_size}, processed=${entry.pr_processed ?? 'none'}${gateInfo}${mainFix}${enqueueInfo}${mergeInfo}`,
         );
       }
     } catch {

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -113,6 +113,7 @@ import {
 } from './execution.ts';
 import { checkDeployHealth as libCheckDeployHealth } from '../lib/pr-analysis/deploy-status.ts';
 import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
+import { runHealthGate } from './health-gate.ts';
 import { runReflection } from './reflection.ts';
 
 const cl = getColors();
@@ -275,6 +276,25 @@ async function runCheckCycle(
   config: PatrolConfig,
 ): Promise<void> {
   logHeader(`Check cycle #${cycleCount}`);
+
+  // 0. Health gate (QUA-300 Phase 3) — check fleet-level signals FIRST.
+  // If any of deploy-stuck / main-ci-red / ratchet-drift fires, skip PR work
+  // this cycle and escalate. This is the precondition that keeps patrol from
+  // churning out symptom-fix PRs while a deploy is stuck or a ratchet is
+  // drifting. See .claude/rules/patrol-health-gate.md for the rationale.
+  const gate = await runHealthGate();
+  if (!gate.proceed) {
+    appendJsonl(JSONL_FILE_INTERNAL, {
+      type: 'cycle_summary',
+      cycle_number: cycleCount,
+      prs_scanned: 0,
+      queue_size: 0,
+      pr_processed: null,
+      health_gate_tripped: true,
+      health_gate_reason: gate.reason,
+    });
+    return;
+  }
 
   // 0a. Check if a tracked main-branch fix PR has been merged
   let skipMainFix = false;

--- a/crux/pr-patrol/ratchet-config.ts
+++ b/crux/pr-patrol/ratchet-config.ts
@@ -1,0 +1,50 @@
+/**
+ * PR Patrol — Ratchet baseline registry (QUA-299 Phase 2).
+ *
+ * Ratchet files lock in a count (violations, stubs, etc.) and can only move
+ * in one "good" direction. The ratchet-drift scanner flags when the same
+ * baseline is bumped N times in M hours, which usually means downstream
+ * agents are silencing CI instead of fixing the underlying cause.
+ *
+ * This file is the single place to register new ratchets. Adding a baseline
+ * here makes it subject to the drift scan — no other wiring is needed.
+ */
+
+export interface RatchetConfig {
+  /** Path relative to the git repo root. */
+  file: string;
+  /**
+   * Human-readable name for escalation messages, e.g. "sourcing rename
+   * ratchet". Kept short because it appears in patrol queue reasons.
+   */
+  name: string;
+  /**
+   * JSON property inside the baseline file whose value is the enforced
+   * total. Nested paths like `"route.total"` are not supported today —
+   * baselines in this repo are flat objects.
+   */
+  totalField: string;
+  /**
+   * Which direction counts as "bad". If `up`, an increasing total is drift
+   * (the usual case — more violations slipping in). If `down`, a decreasing
+   * total is drift (rare — e.g., a coverage ratchet going backwards).
+   */
+  badDirection: 'up' | 'down';
+}
+
+/**
+ * Baselines subject to drift scanning.
+ *
+ * Keep this list small. A file belongs here only if:
+ *   1. It has a single numeric field that represents enforced total
+ *   2. Legitimate changes move it in one direction only
+ *   3. Repeated bumps in the bad direction are a red flag, not routine
+ */
+export const RATCHET_BASELINES: readonly RatchetConfig[] = [
+  {
+    file: 'crux/validate/.sourcing-baseline.json',
+    name: 'sourcing rename',
+    totalField: 'total',
+    badDirection: 'up',
+  },
+];


### PR DESCRIPTION
## Summary

Phase 3 of QUA-297 (Health-Gate Patrol). Wires the Phase 1 (`deploy-stuck`, `main-ci-red`) + Phase 2 (`ratchet-drift`) signals into the patrol loop as a **precondition gate**. When any scanner is unhealthy, the patrol halts PR work for that cycle and escalates — instead of churning out symptom-fix PRs while prod is stuck.

This is what turns Phases 1 + 2 from "more signals in the queue" into an actual gate.

## What's new

- **`crux/pr-patrol/health-gate.ts`** — `runHealthGate(deps)` with fully injectable dependencies (scan, now, env, writeEvent, log, cooldownStore). Called at the top of `runCheckCycle`.
- **`crux/pr-patrol/index.ts`** — 0th step of every cycle: `runHealthGate()`. If unhealthy, write `health_gate_tripped` JSONL event + `cycle_summary` with `health_gate_tripped: true` + return early.
- **`.claude/rules/patrol-health-gate.md`** — permanent rule doc: "if you're writing code to silence a CI signal, stop. Check main health first." Includes troubleshooting commands.
- **`.claude/commands/maintain-pr-patrol.md`** — updated with the health-gate as mandatory first step + list of red-gate don'ts.

## Behavior

| Condition | Outcome |
|-----------|---------|
| All scanners green | Proceed to normal PR scan/fix |
| Any scanner unhealthy | Skip PR work + emit JSONL escalation (rate-limited 30min per fingerprint) |
| Scanner throws (GitHub 5xx) | Proceed with caution on 1st–2nd error; **halt** on 3rd consecutive error |
| `PATROL_DISABLE_HEALTH_GATE=1` | Bypass gate entirely (logs once per 30min) |
| All issues cooldown-suppressed | Still halt PR work — cooldown only affects JSONL emission |

Cooldown file at `~/.cache/pr-patrol/state/health-gate-cooldown.json`. Writes are atomic (temp + rename) so concurrent patrol invocations don't clobber each other.

## Review findings applied

Ran `/agent-review-pr` before pushing. Found + fixed (2 HIGH + 1 LOW):
- **HIGH**: Scanner-error path was fail-open-forever. Added a consecutive-error counter (threshold: 3) that flips to halt + resets on first successful scan.
- **HIGH**: Cooldown file had race condition on concurrent writes. Switched to atomic write (tmp + rename).
- **LOW**: Bypass warning logged every cycle → now rate-limited to once per cooldown window.

3 MEDIUM items filed as **QUA-309** for follow-up (structured `fingerprintKey` field, permanent-red-state fallback, multi-repo `config.repo` threading).

## Test plan

- [x] 15 health-gate tests (bypass, healthy, unhealthy, scanner error + streak halt + counter reset, cooldown emit/suppress/expiry, fingerprint scoping, skip-on-all-suppressed, bypass rate-limit)
- [x] 342 total pr-patrol tests pass (up from 327 in Phase 2)
- [x] Typecheck clean on new files
- [x] Live `healthScan()` on prod returns healthy (consistent with recent deploys)

## Stacked on

This branch includes #4216 + #4218 commits. Rebases cleanly once they merge. Close this PR if Phase 2 doesn't land.

Fixes QUA-300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Health gate now blocks PR Patrol at cycle start for fleet-level issues (deploy/CI/baseline drift), emits clear cycle summaries when tripped, and rate-limits repeated alerts.
  * Baseline drift detection added to health scans with configurable thresholds and per-fingerprint cooldowns.

* **Documentation**
  * Added operational guidance, explicit “do not” actions while gate is red, escalation flow, and an emergency bypass with strict use guidance.

* **Tests**
  * Expanded tests covering health gate behavior, cooldowns, bypass, scan errors, and ratchet-drift detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->