### PR TITLE
QUA-113: Source-check URL audit command

### DIFF
--- a/crux/commands/sourcing-audit-urls.test.ts
+++ b/crux/commands/sourcing-audit-urls.test.ts
@@ -79,6 +79,40 @@ describe('classifyByUrl', () => {
     expect(classifyByUrl('https://example.com/#deep-anchor-ref').purpose).toBeNull();
   });
 
+  it('ignores short/common fragments like #top', () => {
+    // '#top' has length 4; threshold is > 4 → still a homepage
+    expect(classifyByUrl('https://example.com/#top').purpose).toBe('homepage');
+    expect(classifyByUrl('https://example.com/#').purpose).toBe('homepage');
+  });
+
+  it('returns reason=query-data-param for data-like query params', () => {
+    const r = classifyByUrl('https://example.com/?id=42');
+    expect(r.reasons).toContain('query-data-param');
+  });
+
+  it('is case-insensitive for homepage paths', () => {
+    expect(classifyByUrl('https://example.com/ABOUT').purpose).toBe('homepage');
+    expect(classifyByUrl('https://example.com/Index.HTML').purpose).toBe('homepage');
+  });
+
+  it('returns confidence 0 with reason=unparseable for bad input', () => {
+    const r = classifyByUrl('not a url');
+    expect(r.confidence).toBe(0);
+    expect(r.reasons).toContain('unparseable');
+  });
+
+  it('handles IPv6 hosts without crashing', () => {
+    // Node accepts http://[::1]/ — classifier should not throw
+    const r = classifyByUrl('http://[::1]/');
+    expect(r.purpose).toBe('homepage');
+  });
+
+  it('ignores userinfo in URL', () => {
+    // Credentials in URL should not affect classification
+    const r = classifyByUrl('https://user:pass@example.com/');
+    expect(r.purpose).toBe('homepage');
+  });
+
   // ── Wayback-prefixed ──
   it('unwraps Wayback URLs and classifies the inner URL', () => {
     const r1 = classifyByUrl('https://web.archive.org/web/20240101000000/https://example.com/');

--- a/crux/commands/sourcing-audit-urls.test.ts
+++ b/crux/commands/sourcing-audit-urls.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for sourcing-audit-urls URL classifier helpers.
+ *
+ * Focus: `classifyByUrl` + `normalizeUrlForJoin` + `extractHost`.
+ * The command's control flow is covered by manual prod runs; these tests
+ * pin down the URL-heuristic behavior so QUA-312 extracts it without
+ * regressing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyByUrl,
+  normalizeUrlForJoin,
+  extractHost,
+} from './sourcing-audit-urls.ts';
+
+describe('classifyByUrl', () => {
+  // ── Obvious homepages ──
+  it.each([
+    'https://example.com',
+    'https://example.com/',
+    'http://example.com',
+    'https://www.example.com',
+    'https://example.com/?utm_source=x',  // root with tracking params still homepage
+  ])('classifies bare/root domain as homepage: %s', (url) => {
+    const r = classifyByUrl(url);
+    expect(r.purpose).toBe('homepage');
+    expect(r.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it.each([
+    'https://example.com/about',
+    'https://example.com/about/',
+    'https://example.com/about-us',
+    'https://example.com/contact',
+    'https://example.com/home.html',
+    'https://example.com/index.html',
+    'https://example.com/index',
+  ])('classifies known homepage-adjacent path as homepage: %s', (url) => {
+    const r = classifyByUrl(url);
+    expect(r.purpose).toBe('homepage');
+    expect(r.confidence).toBeGreaterThanOrEqual(0.8);
+  });
+
+  // ── NOT homepages ──
+  it.each([
+    'https://example.com/blog/2024/my-post',
+    'https://example.com/team/jane-doe',
+    'https://example.com/docs/api/reference',
+    'https://example.com/products/widget-2000',
+  ])('classifies deep paths as NOT homepage: %s', (url) => {
+    const r = classifyByUrl(url);
+    expect(r.purpose).toBeNull();
+    expect(r.confidence).toBeLessThan(0.5);
+  });
+
+  it('classifies PDFs as never homepage regardless of depth', () => {
+    expect(classifyByUrl('https://example.com/report.pdf').purpose).toBeNull();
+    expect(classifyByUrl('https://example.com/reports/annual/2024.PDF').purpose).toBeNull();
+    // Even a bare-domain PDF (served from /) is not a homepage
+    const r = classifyByUrl('https://example.com/doc.pdf');
+    expect(r.purpose).toBeNull();
+    expect(r.reasons).toContain('pdf');
+  });
+
+  it('classifies URLs with data-like query params as NOT homepage', () => {
+    expect(classifyByUrl('https://example.com/?id=42').purpose).toBeNull();
+    expect(classifyByUrl('https://youtube.com/?v=abc123').purpose).toBeNull();
+    expect(classifyByUrl('https://example.com/search?q=foo').purpose).toBeNull();
+  });
+
+  it('does NOT classify URL with utm_ params alone as non-homepage', () => {
+    // utm_* is tracking, not data — root should still classify as homepage
+    expect(classifyByUrl('https://example.com/?utm_source=x&utm_medium=y').purpose).toBe('homepage');
+  });
+
+  it('treats meaningful fragments (deep anchors) as not homepage', () => {
+    expect(classifyByUrl('https://twitter.com/status#1234567890').purpose).toBeNull();
+    expect(classifyByUrl('https://example.com/#deep-anchor-ref').purpose).toBeNull();
+  });
+
+  // ── Wayback-prefixed ──
+  it('unwraps Wayback URLs and classifies the inner URL', () => {
+    const r1 = classifyByUrl('https://web.archive.org/web/20240101000000/https://example.com/');
+    expect(r1.purpose).toBe('homepage');
+    expect(r1.reasons).toContain('wayback-wrapped');
+
+    const r2 = classifyByUrl('https://web.archive.org/web/20240101000000/https://example.com/docs/api/v2');
+    expect(r2.purpose).toBeNull();
+  });
+
+  it('handles Wayback URLs without inner scheme', () => {
+    // Some Wayback URLs omit the scheme after the timestamp
+    const r = classifyByUrl('https://web.archive.org/web/20240101000000/example.com/');
+    expect(r.purpose).toBe('homepage');
+  });
+
+  // ── URL shorteners ──
+  it.each([
+    'https://bit.ly/abc123',
+    'https://t.co/shortcode',
+    'https://tinyurl.com/xyz',
+    'https://goo.gl/abc',
+  ])('refuses to classify URL shorteners: %s', (url) => {
+    const r = classifyByUrl(url);
+    expect(r.purpose).toBeNull();
+    expect(r.reasons).toContain('shortener');
+  });
+
+  // ── Malformed / unusual ──
+  it('handles unparseable URLs gracefully', () => {
+    expect(classifyByUrl('not a url').purpose).toBeNull();
+    expect(classifyByUrl('').purpose).toBeNull();
+    expect(classifyByUrl('http://').purpose).toBeNull();
+  });
+
+  it('skips non-http(s) schemes', () => {
+    expect(classifyByUrl('mailto:foo@example.com').reasons).toContain('non-http-scheme');
+    expect(classifyByUrl('file:///etc/passwd').reasons).toContain('non-http-scheme');
+    expect(classifyByUrl('ftp://example.com/').reasons).toContain('non-http-scheme');
+  });
+
+  it('is case-insensitive for host', () => {
+    const a = classifyByUrl('https://EXAMPLE.com/');
+    const b = classifyByUrl('https://example.com/');
+    expect(a.purpose).toBe(b.purpose);
+  });
+});
+
+describe('normalizeUrlForJoin', () => {
+  it('strips trailing slash from non-root paths', () => {
+    expect(normalizeUrlForJoin('https://example.com/foo/')).toBe('https://example.com/foo');
+    expect(normalizeUrlForJoin('https://example.com/foo')).toBe('https://example.com/foo');
+  });
+
+  it('keeps root path (empty, not a trailing slash)', () => {
+    expect(normalizeUrlForJoin('https://example.com/')).toBe('https://example.com');
+    expect(normalizeUrlForJoin('https://example.com')).toBe('https://example.com');
+  });
+
+  it('strips www. prefix', () => {
+    expect(normalizeUrlForJoin('https://www.example.com/foo')).toBe('https://example.com/foo');
+  });
+
+  it('lowercases host but preserves path case', () => {
+    expect(normalizeUrlForJoin('https://EXAMPLE.com/FooBar')).toBe('https://example.com/FooBar');
+  });
+
+  it('strips fragment', () => {
+    expect(normalizeUrlForJoin('https://example.com/foo#section')).toBe('https://example.com/foo');
+  });
+
+  it('strips common tracking params', () => {
+    expect(normalizeUrlForJoin('https://example.com/?utm_source=x&utm_campaign=y'))
+      .toBe('https://example.com');
+    expect(normalizeUrlForJoin('https://example.com/foo?fbclid=x&id=42'))
+      .toBe('https://example.com/foo?id=42');
+    expect(normalizeUrlForJoin('https://example.com/?gclid=abc&msclkid=xyz'))
+      .toBe('https://example.com');
+  });
+
+  it('preserves meaningful query params', () => {
+    expect(normalizeUrlForJoin('https://example.com/search?q=foo&page=2'))
+      .toBe('https://example.com/search?q=foo&page=2');
+  });
+
+  it('drops default ports', () => {
+    expect(normalizeUrlForJoin('https://example.com:443/foo')).toBe('https://example.com/foo');
+    expect(normalizeUrlForJoin('http://example.com:80/foo')).toBe('http://example.com/foo');
+  });
+
+  it('preserves non-default ports', () => {
+    expect(normalizeUrlForJoin('https://example.com:8443/foo')).toBe('https://example.com:8443/foo');
+  });
+
+  it('falls back to lowercased raw string for unparseable URLs', () => {
+    expect(normalizeUrlForJoin('not a url')).toBe('not a url');
+    expect(normalizeUrlForJoin('  GARBAGE  ')).toBe('garbage');
+  });
+});
+
+describe('extractHost', () => {
+  it('returns lowercased hostname without www', () => {
+    expect(extractHost('https://www.EXAMPLE.com/foo')).toBe('example.com');
+    expect(extractHost('https://example.com')).toBe('example.com');
+    expect(extractHost('http://subdomain.example.com/')).toBe('subdomain.example.com');
+  });
+
+  it('returns sentinel for invalid URLs', () => {
+    expect(extractHost('not a url')).toBe('(invalid-url)');
+    expect(extractHost('')).toBe('(invalid-url)');
+  });
+});

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -16,6 +16,75 @@
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { listVerdicts, getEvidenceByRecord } from '../lib/wiki-server/sourcing-client.ts';
 
+// ── Module constants ──
+
+/** Confidence threshold: classifyByUrl score ≥ this marks a row as "flagged homepage". */
+const FLAG_THRESHOLD = 0.7;
+
+/** Parallel evidence-fetch requests. Keeps the wiki-server load light. */
+const CONCURRENCY = 8;
+
+/** Evidence rows fetched per verdict record. Most records have 1–2. */
+const EVIDENCE_PER_RECORD = 5;
+
+/** Default verdicts to audit. */
+const DEFAULT_VERDICTS = ['unverifiable', 'partial'];
+
+/** Default per-verdict fetch limit; capped to CLAMP_LIMIT. */
+const DEFAULT_LIMIT = 100;
+const CLAMP_LIMIT = 2000;
+
+/** Output-truncation limits (human-readable mode only). */
+const TOP_DOMAINS_SHOWN = 30;
+const TOP_SAMPLES_SHOWN = 20;
+const SAMPLE_IDS_PER_DOMAIN = 3;
+
+/** Query parameters that indicate tracking, not data content. */
+const TRACKING_PREFIXES = ['utm_', 'mc_', 'oly_'];
+const TRACKING_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
+
+/** Query parameters that indicate specific content (force non-homepage classification). */
+const DATA_PARAM_KEYS = new Set(['id', 'v', 'q', 'search', 'article', 'item', 'page', 'post']);
+
+/** Known URL shorteners — cannot classify without following the redirect. */
+const SHORTENERS = new Set([
+  'bit.ly', 't.co', 'goo.gl', 'tinyurl.com', 'ow.ly', 'buff.ly',
+  'is.gd', 'shorturl.at', 'rb.gy', 'cutt.ly',
+]);
+
+/** Single-segment paths that act as homepages on most sites. */
+const HOMEPAGE_PATHS = new Set([
+  '/about', '/about-us', '/about_us', '/aboutus',
+  '/contact', '/contact-us', '/contactus',
+  '/home', '/home.html', '/index', '/index.html', '/index.htm',
+  '/welcome', '/main',
+]);
+
+/** True if the caller wants ANSI color codes (TTY and NO_COLOR unset). */
+function useColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  return !!process.stdout.isTTY;
+}
+
+const ANSI = {
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+} as const;
+
+const bold = (s: string) => (useColor() ? `${ANSI.bold}${s}${ANSI.reset}` : s);
+const yellow = (s: string) => (useColor() ? `${ANSI.yellow}${s}${ANSI.reset}` : s);
+
+/** Parse and clamp a user-supplied `--limit`. Guards against NaN, negative, oversize. */
+function clampLimit(raw: unknown): number {
+  if (raw === undefined) return DEFAULT_LIMIT;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, CLAMP_LIMIT);
+}
+
 // ── URL classifier (inline; extracted to crux/lib/sourcing/url-quality.ts in QUA-312) ──
 
 /**
@@ -62,11 +131,6 @@ export function classifyByUrl(raw: string): {
     return { purpose: null, confidence: 0.2, reasons: ['wayback-unresolved'] };
   }
 
-  // Known URL shorteners — cannot classify without following
-  const SHORTENERS = new Set([
-    'bit.ly', 't.co', 'goo.gl', 'tinyurl.com', 'ow.ly', 'buff.ly',
-    'is.gd', 'shorturl.at', 'rb.gy', 'cutt.ly',
-  ]);
   if (SHORTENERS.has(host)) {
     return { purpose: null, confidence: 0, reasons: ['shortener'] };
   }
@@ -79,32 +143,21 @@ export function classifyByUrl(raw: string): {
   // Normalize path for analysis
   const path = url.pathname.replace(/\/+$/, '') || '/';
   const depth = path === '/' ? 0 : path.split('/').filter(Boolean).length;
-  const hasFragment = url.hash.length > 0 && url.hash !== '#';
-
-  // Meaningful fragment (Twitter status, deep anchor) — not homepage, regardless of depth.
-  // Short fragments like "#top" or "#" are ignored.
-  if (hasFragment && url.hash.length > 3) {
+  // Meaningful fragment (e.g., Twitter status ID, deep anchor) — not homepage.
+  // Ignore `#`, `#top`, or anything ≤ 4 characters including the leading `#`.
+  if (url.hash.length > 4) {
     return { purpose: null, confidence: 0.3, reasons: ['deep-fragment'] };
   }
 
-  // Query strings: distinguish tracking-only (utm_*, fbclid, etc.) from data params.
-  const TRACKING_PREFIXES = ['utm_', 'mc_', 'oly_'];
-  const TRACKING_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
-  const DATA_PARAM_KEYS = new Set(['id', 'v', 'q', 'search', 'article', 'item', 'page', 'post']);
-  let hasDataParam = false;
+  // Named data params (?id=, ?q=, ?v=, ...) force NOT-homepage even at root.
+  // Tracking-only queries (utm_*, fbclid, ...) are ignored. Other non-tracking,
+  // non-data params (e.g., ?campaign=x) are treated as benign — imperfect but
+  // keeps false-positive rate low.
   for (const k of url.searchParams.keys()) {
     const keyLower = k.toLowerCase();
-    if (TRACKING_EXACT.has(keyLower)) continue;
-    if (TRACKING_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
-    // Any non-tracking param is "content-bearing" — most specifically, data-param keys
-    // force NOT-homepage even at root.
     if (DATA_PARAM_KEYS.has(keyLower)) {
-      hasDataParam = true;
-      break;
+      return { purpose: null, confidence: 0.2, reasons: ['query-data-param'] };
     }
-  }
-  if (hasDataParam) {
-    return { purpose: null, confidence: 0.2, reasons: ['query-data-param'] };
   }
 
   // Depth 0: bare domain or root path (tracking-only query is fine)
@@ -113,13 +166,6 @@ export function classifyByUrl(raw: string): {
     return { purpose: 'homepage', confidence: 0.95, reasons };
   }
 
-  // Known homepage-adjacent single-segment paths
-  const HOMEPAGE_PATHS = new Set([
-    '/about', '/about-us', '/about_us', '/aboutus',
-    '/contact', '/contact-us', '/contactus',
-    '/home', '/home.html', '/index', '/index.html', '/index.htm',
-    '/welcome', '/main',
-  ]);
   if (depth === 1 && HOMEPAGE_PATHS.has(path.toLowerCase())) {
     reasons.push(`homepage-path:${path.toLowerCase()}`);
     return { purpose: 'homepage', confidence: 0.85, reasons };
@@ -161,14 +207,12 @@ export function normalizeUrlForJoin(raw: string): string {
       ? ''
       : `:${url.port}`;
 
-  // Strip common tracking params
-  const TRACKING_PARAM_PREFIXES = ['utm_', 'mc_', 'oly_'];
-  const TRACKING_PARAM_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
+  // Strip common tracking params (utm_*, fbclid, etc.); preserve data params.
   const filteredParams = new URLSearchParams();
   for (const [k, v] of url.searchParams.entries()) {
     const keyLower = k.toLowerCase();
-    if (TRACKING_PARAM_EXACT.has(keyLower)) continue;
-    if (TRACKING_PARAM_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
+    if (TRACKING_EXACT.has(keyLower)) continue;
+    if (TRACKING_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
     filteredParams.append(k, v);
   }
   const qs = filteredParams.toString();
@@ -220,21 +264,18 @@ interface DomainSummary {
   sampleRecordIds: string[];
 }
 
-/** Minimum confidence from classifyByUrl to mark as flagged homepage. */
-const FLAG_THRESHOLD = 0.7;
-
 async function auditCommand(
   _args: string[],
   options: AuditOptions,
 ): Promise<CommandResult> {
-  const verdictFilterRaw = options.verdict ?? 'unverifiable,partial';
+  const verdictFilterRaw = options.verdict ?? DEFAULT_VERDICTS.join(',');
   const verdicts = verdictFilterRaw.split(',').map((v) => v.trim()).filter(Boolean);
-  const limit = options.limit ? parseInt(String(options.limit), 10) : 100;
+  const limit = clampLimit(options.limit);
   const badUrlOnly = options['bad-url-only'] || options.badUrlOnly;
   const isJson = options.json;
 
   if (!isJson) {
-    console.log('\x1b[1mSource-Check URL Audit\x1b[0m');
+    console.log(bold('Source-Check URL Audit'));
     console.log(`Verdicts: ${verdicts.join(', ')}`);
     console.log(`Limit:    ${limit} verdicts`);
     console.log('');
@@ -263,7 +304,9 @@ async function auditCommand(
   if (verdictRecords.length === 0) {
     return {
       exitCode: 0,
-      output: isJson ? JSON.stringify({ rows: [], domains: [], total: 0 }) : 'No verdicts matched.',
+      output: isJson
+        ? JSON.stringify({ rows: [], domains: [], total: 0, totalFlagged: 0 })
+        : 'No verdicts matched.',
     };
   }
 
@@ -307,11 +350,10 @@ async function auditCommand(
     for (const r of results) rows.push(...r);
   }
 
-  const filteredRows = badUrlOnly ? rows.filter((r) => r.flagged) : rows;
-
-  // ── Step 3: aggregate by domain ──
+  // ── Step 3: aggregate by domain (over ALL rows, so totals are accurate
+  // regardless of --bad-url-only; callers can filter the sample rows client-side).
   const domainMap = new Map<string, DomainSummary>();
-  for (const r of filteredRows) {
+  for (const r of rows) {
     let d = domainMap.get(r.host);
     if (!d) {
       d = {
@@ -326,33 +368,39 @@ async function auditCommand(
     d.total++;
     if (r.flagged) d.flagged++;
     d.byRecordType[r.recordType] = (d.byRecordType[r.recordType] ?? 0) + 1;
-    if (d.sampleRecordIds.length < 3) {
+    if (d.sampleRecordIds.length < SAMPLE_IDS_PER_DOMAIN) {
       d.sampleRecordIds.push(`${r.recordType}/${r.recordId}`);
     }
   }
 
-  const domains = [...domainMap.values()].sort((a, b) => {
-    // Rank by flagged-count first (most "homepage-like"), then by total
-    if (b.flagged !== a.flagged) return b.flagged - a.flagged;
-    return b.total - a.total;
-  });
+  const domains = [...domainMap.values()]
+    // When --bad-url-only, drop domains with no flagged rows so the table isn't noise.
+    .filter((d) => (badUrlOnly ? d.flagged > 0 : true))
+    .sort((a, b) => {
+      // Rank by flagged-count first (most "homepage-like"), then by total
+      if (b.flagged !== a.flagged) return b.flagged - a.flagged;
+      return b.total - a.total;
+    });
+
+  const sampleRows = badUrlOnly ? rows.filter((r) => r.flagged) : rows;
+  const totalFlagged = rows.filter((r) => r.flagged).length;
 
   // ── Step 4: output ──
   if (isJson) {
     return {
       exitCode: 0,
       output: JSON.stringify({
-        rows: filteredRows,
+        rows: sampleRows,
         domains,
-        total: filteredRows.length,
-        totalFlagged: rows.filter((r) => r.flagged).length,
+        total: sampleRows.length,
+        totalFlagged,
       }),
     };
   }
 
   return {
     exitCode: 0,
-    output: formatHumanOutput(filteredRows, domains, rows.filter((r) => r.flagged).length, verdicts),
+    output: formatHumanOutput(sampleRows, domains, totalFlagged, verdicts),
   };
 }
 
@@ -364,34 +412,34 @@ function formatHumanOutput(
 ): string {
   const lines: string[] = [];
   lines.push('');
-  lines.push('\x1b[1m=== Audit Summary ===\x1b[0m');
+  lines.push(bold('=== Audit Summary ==='));
   lines.push(`Evidence rows:       ${rows.length}`);
   lines.push(`Flagged as homepage: ${totalFlaggedOverall}`);
   lines.push(`Unique domains:      ${domains.length}`);
   lines.push(`Verdict filter:      ${verdicts.join(', ')}`);
   lines.push('');
 
-  lines.push('\x1b[1mTop domains (by flagged count, then total):\x1b[0m');
+  lines.push(bold('Top domains (by flagged count, then total):'));
   lines.push('-'.repeat(100));
-  const header = `${'Flagged'.padStart(7)}  ${'Total'.padStart(5)}  ${'Domain'.padEnd(40)}  Record types`;
-  lines.push(`\x1b[1m${header}\x1b[0m`);
-  for (const d of domains.slice(0, 30)) {
+  lines.push(bold(`${'Flagged'.padStart(7)}  ${'Total'.padStart(5)}  ${'Domain'.padEnd(40)}  Record types`));
+  for (const d of domains.slice(0, TOP_DOMAINS_SHOWN)) {
     const types = Object.entries(d.byRecordType)
       .sort((a, b) => b[1] - a[1])
       .map(([t, n]) => `${t}:${n}`)
       .join(' ');
-    const flaggedStr = d.flagged > 0 ? `\x1b[33m${String(d.flagged).padStart(7)}\x1b[0m` : String(d.flagged).padStart(7);
+    const flaggedStr = d.flagged > 0
+      ? yellow(String(d.flagged).padStart(7))
+      : String(d.flagged).padStart(7);
     lines.push(`${flaggedStr}  ${String(d.total).padStart(5)}  ${d.host.padEnd(40)}  ${types}`);
   }
-  if (domains.length > 30) {
-    lines.push(`  ... and ${domains.length - 30} more domains`);
+  if (domains.length > TOP_DOMAINS_SHOWN) {
+    lines.push(`  ... and ${domains.length - TOP_DOMAINS_SHOWN} more domains`);
   }
   lines.push('');
 
-  // Show first 20 flagged rows with their URLs
-  const flagged = rows.filter((r) => r.flagged).slice(0, 20);
+  const flagged = rows.filter((r) => r.flagged).slice(0, TOP_SAMPLES_SHOWN);
   if (flagged.length > 0) {
-    lines.push('\x1b[1mSample flagged evidence:\x1b[0m');
+    lines.push(bold('Sample flagged evidence:'));
     lines.push('-'.repeat(100));
     for (const r of flagged) {
       const id = r.recordId.length > 24 ? r.recordId.slice(0, 22) + '..' : r.recordId;

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -1,0 +1,445 @@
+/**
+ * Source-Check URL Audit — identifies evidence rows whose source URL points at
+ * a generic homepage or a dead/paywalled page, ranked by domain and record type.
+ *
+ * Read-only; no LLM calls; no wiki-server writes. Intended workflow:
+ *   1. Run `crux sourcing-audit-urls` to get a ranked list of offender domains.
+ *   2. Manually inspect top offenders and fix bad URLs (replace homepages with
+ *      specific pages, or delete evidence where no better URL exists).
+ *   3. Run `crux sourcing-recheck` on the corrected subset.
+ *
+ * Phase 1 of QUA-113. Follow-ups: QUA-312 (extract URL classifier to shared
+ * module, wire into classifier + re-ingest pipeline), QUA-313 (backfill +
+ * sourcing-mark). See GitHub Discussion #4221 for full plan.
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { listVerdicts, getEvidenceByRecord } from '../lib/wiki-server/sourcing-client.ts';
+
+// ── URL classifier (inline; extracted to crux/lib/sourcing/url-quality.ts in QUA-312) ──
+
+/**
+ * Classify a URL by shape alone. Deterministic, no network. Used both to
+ * flag homepage sources in the audit and (in Phase 2) as a fast-path for
+ * resource classification.
+ *
+ * Confidence is calibrated so that >= 0.8 is "write directly, skip LLM" in
+ * future callers. This command treats >= 0.7 as homepage-flagged.
+ */
+export function classifyByUrl(raw: string): {
+  purpose: 'homepage' | null;
+  confidence: number;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { purpose: null, confidence: 0, reasons: ['unparseable'] };
+  }
+
+  // Non-http(s) — skip (file://, mailto:, etc.)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { purpose: null, confidence: 0, reasons: ['non-http-scheme'] };
+  }
+
+  const host = url.hostname.toLowerCase();
+
+  // Wayback prefix — classify by the inner URL
+  if (host === 'web.archive.org' || host === 'archive.org') {
+    const match = url.pathname.match(/\/web\/[^/]+\/(.+)$/);
+    if (match) {
+      const inner = match[1].startsWith('http')
+        ? match[1]
+        : `https://${match[1]}`;
+      const innerResult = classifyByUrl(inner);
+      return {
+        ...innerResult,
+        reasons: ['wayback-wrapped', ...innerResult.reasons],
+      };
+    }
+    return { purpose: null, confidence: 0.2, reasons: ['wayback-unresolved'] };
+  }
+
+  // Known URL shorteners — cannot classify without following
+  const SHORTENERS = new Set([
+    'bit.ly', 't.co', 'goo.gl', 'tinyurl.com', 'ow.ly', 'buff.ly',
+    'is.gd', 'shorturl.at', 'rb.gy', 'cutt.ly',
+  ]);
+  if (SHORTENERS.has(host)) {
+    return { purpose: null, confidence: 0, reasons: ['shortener'] };
+  }
+
+  // PDF: never a homepage regardless of path depth
+  if (url.pathname.toLowerCase().endsWith('.pdf')) {
+    return { purpose: null, confidence: 0.9, reasons: ['pdf'] };
+  }
+
+  // Normalize path for analysis
+  const path = url.pathname.replace(/\/+$/, '') || '/';
+  const depth = path === '/' ? 0 : path.split('/').filter(Boolean).length;
+  const hasFragment = url.hash.length > 0 && url.hash !== '#';
+
+  // Meaningful fragment (Twitter status, deep anchor) — not homepage, regardless of depth.
+  // Short fragments like "#top" or "#" are ignored.
+  if (hasFragment && url.hash.length > 3) {
+    return { purpose: null, confidence: 0.3, reasons: ['deep-fragment'] };
+  }
+
+  // Query strings: distinguish tracking-only (utm_*, fbclid, etc.) from data params.
+  const TRACKING_PREFIXES = ['utm_', 'mc_', 'oly_'];
+  const TRACKING_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
+  const DATA_PARAM_KEYS = new Set(['id', 'v', 'q', 'search', 'article', 'item', 'page', 'post']);
+  let hasDataParam = false;
+  for (const k of url.searchParams.keys()) {
+    const keyLower = k.toLowerCase();
+    if (TRACKING_EXACT.has(keyLower)) continue;
+    if (TRACKING_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
+    // Any non-tracking param is "content-bearing" — most specifically, data-param keys
+    // force NOT-homepage even at root.
+    if (DATA_PARAM_KEYS.has(keyLower)) {
+      hasDataParam = true;
+      break;
+    }
+  }
+  if (hasDataParam) {
+    return { purpose: null, confidence: 0.2, reasons: ['query-data-param'] };
+  }
+
+  // Depth 0: bare domain or root path (tracking-only query is fine)
+  if (depth === 0) {
+    reasons.push('root-path');
+    return { purpose: 'homepage', confidence: 0.95, reasons };
+  }
+
+  // Known homepage-adjacent single-segment paths
+  const HOMEPAGE_PATHS = new Set([
+    '/about', '/about-us', '/about_us', '/aboutus',
+    '/contact', '/contact-us', '/contactus',
+    '/home', '/home.html', '/index', '/index.html', '/index.htm',
+    '/welcome', '/main',
+  ]);
+  if (depth === 1 && HOMEPAGE_PATHS.has(path.toLowerCase())) {
+    reasons.push(`homepage-path:${path.toLowerCase()}`);
+    return { purpose: 'homepage', confidence: 0.85, reasons };
+  }
+
+  // Deep paths (2+ segments) — almost never homepages
+  if (depth >= 2) {
+    return { purpose: null, confidence: 0.1, reasons: [`depth:${depth}`] };
+  }
+
+  // Depth 1 with no matching homepage path — ambiguous
+  return { purpose: null, confidence: 0.4, reasons: [`depth:1:${path}`] };
+}
+
+/**
+ * Canonical URL form for comparing/grouping evidence URLs and resource URLs.
+ * Strips: trailing slash, www., fragment, default ports, common tracking
+ * params (utm_*, fbclid, gclid). Lowercases host.
+ *
+ * NOT a replacement for the 9 existing URL normalizers in the codebase —
+ * those serve different semantics. This one is for audit-join + domain grouping.
+ */
+export function normalizeUrlForJoin(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return raw.trim().toLowerCase();
+  }
+
+  // Lowercase host; strip www.
+  let host = url.hostname.toLowerCase();
+  if (host.startsWith('www.')) host = host.slice(4);
+
+  // Drop default ports
+  const portSuffix =
+    (url.port === '' || (url.protocol === 'http:' && url.port === '80') ||
+      (url.protocol === 'https:' && url.port === '443'))
+      ? ''
+      : `:${url.port}`;
+
+  // Strip common tracking params
+  const TRACKING_PARAM_PREFIXES = ['utm_', 'mc_', 'oly_'];
+  const TRACKING_PARAM_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
+  const filteredParams = new URLSearchParams();
+  for (const [k, v] of url.searchParams.entries()) {
+    const keyLower = k.toLowerCase();
+    if (TRACKING_PARAM_EXACT.has(keyLower)) continue;
+    if (TRACKING_PARAM_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
+    filteredParams.append(k, v);
+  }
+  const qs = filteredParams.toString();
+
+  // Strip trailing slash from path (but keep "/" for root)
+  const path = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
+
+  return `${url.protocol}//${host}${portSuffix}${path}${qs ? '?' + qs : ''}`;
+}
+
+/** Extract just the host portion, normalized, for domain grouping. */
+export function extractHost(raw: string): string {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    if (host.startsWith('www.')) host = host.slice(4);
+    return host;
+  } catch {
+    return '(invalid-url)';
+  }
+}
+
+// ── Command ──────────────────────────────────────────────────────────
+
+interface AuditOptions extends BaseOptions {
+  verdict?: string;
+  'bad-url-only'?: boolean;
+  badUrlOnly?: boolean;
+  limit?: string;
+  json?: boolean;
+}
+
+interface AuditRow {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  verdict: string;
+  sourceUrl: string;
+  host: string;
+  flagged: boolean;
+  flagReasons: string[];
+  confidence: number;
+}
+
+interface DomainSummary {
+  host: string;
+  total: number;
+  flagged: number;
+  byRecordType: Record<string, number>;
+  sampleRecordIds: string[];
+}
+
+/** Minimum confidence from classifyByUrl to mark as flagged homepage. */
+const FLAG_THRESHOLD = 0.7;
+
+async function auditCommand(
+  _args: string[],
+  options: AuditOptions,
+): Promise<CommandResult> {
+  const verdictFilterRaw = options.verdict ?? 'unverifiable,partial';
+  const verdicts = verdictFilterRaw.split(',').map((v) => v.trim()).filter(Boolean);
+  const limit = options.limit ? parseInt(String(options.limit), 10) : 100;
+  const badUrlOnly = options['bad-url-only'] || options.badUrlOnly;
+  const isJson = options.json;
+
+  if (!isJson) {
+    console.log('\x1b[1mSource-Check URL Audit\x1b[0m');
+    console.log(`Verdicts: ${verdicts.join(', ')}`);
+    console.log(`Limit:    ${limit} verdicts`);
+    console.log('');
+  }
+
+  // ── Step 1: fetch verdict records (one query per verdict type) ──
+  const verdictRecords: Array<{ recordType: string; recordId: string; verdict: string }> = [];
+  for (const v of verdicts) {
+    if (!isJson) console.log(`Fetching verdicts where verdict=${v}...`);
+    const res = await listVerdicts({ verdict: v, limit });
+    if (!res.ok) {
+      return {
+        exitCode: 1,
+        output: `Failed to fetch verdicts (${v}): ${res.message ?? 'unknown error'}`,
+      };
+    }
+    for (const row of res.data.verdicts) {
+      verdictRecords.push({
+        recordType: row.recordType,
+        recordId: row.recordId,
+        verdict: row.verdict,
+      });
+    }
+  }
+
+  if (verdictRecords.length === 0) {
+    return {
+      exitCode: 0,
+      output: isJson ? JSON.stringify({ rows: [], domains: [], total: 0 }) : 'No verdicts matched.',
+    };
+  }
+
+  if (!isJson) {
+    console.log(`  Found ${verdictRecords.length} verdict record(s) across ${verdicts.length} verdict type(s).`);
+    console.log('Fetching evidence for each (this may take a minute)...');
+  }
+
+  // ── Step 2: fetch evidence per record ──
+  // N+1 pattern — acceptable for audit use (default --limit=100 => ~200 req).
+  // A dedicated bulk endpoint is a QUA-313 follow-up if this becomes slow.
+  const rows: AuditRow[] = [];
+  const CONCURRENCY = 8;
+  for (let i = 0; i < verdictRecords.length; i += CONCURRENCY) {
+    const slice = verdictRecords.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      slice.map(async (v) => {
+        const res = await getEvidenceByRecord(v.recordType, v.recordId, { limit: 5 });
+        if (!res.ok) return [];
+        const out: AuditRow[] = [];
+        for (const e of res.data.evidence) {
+          if (!e.sourceUrl) continue;
+          const sourceUrl = e.sourceUrl;
+          const cls = classifyByUrl(sourceUrl);
+          const flagged = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
+          out.push({
+            recordType: v.recordType,
+            recordId: v.recordId,
+            fieldName: e.fieldName,
+            verdict: v.verdict,
+            sourceUrl,
+            host: extractHost(sourceUrl),
+            flagged,
+            flagReasons: cls.reasons,
+            confidence: cls.confidence,
+          });
+        }
+        return out;
+      }),
+    );
+    for (const r of results) rows.push(...r);
+  }
+
+  const filteredRows = badUrlOnly ? rows.filter((r) => r.flagged) : rows;
+
+  // ── Step 3: aggregate by domain ──
+  const domainMap = new Map<string, DomainSummary>();
+  for (const r of filteredRows) {
+    let d = domainMap.get(r.host);
+    if (!d) {
+      d = {
+        host: r.host,
+        total: 0,
+        flagged: 0,
+        byRecordType: {},
+        sampleRecordIds: [],
+      };
+      domainMap.set(r.host, d);
+    }
+    d.total++;
+    if (r.flagged) d.flagged++;
+    d.byRecordType[r.recordType] = (d.byRecordType[r.recordType] ?? 0) + 1;
+    if (d.sampleRecordIds.length < 3) {
+      d.sampleRecordIds.push(`${r.recordType}/${r.recordId}`);
+    }
+  }
+
+  const domains = [...domainMap.values()].sort((a, b) => {
+    // Rank by flagged-count first (most "homepage-like"), then by total
+    if (b.flagged !== a.flagged) return b.flagged - a.flagged;
+    return b.total - a.total;
+  });
+
+  // ── Step 4: output ──
+  if (isJson) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        rows: filteredRows,
+        domains,
+        total: filteredRows.length,
+        totalFlagged: rows.filter((r) => r.flagged).length,
+      }),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    output: formatHumanOutput(filteredRows, domains, rows.filter((r) => r.flagged).length, verdicts),
+  };
+}
+
+function formatHumanOutput(
+  rows: AuditRow[],
+  domains: DomainSummary[],
+  totalFlaggedOverall: number,
+  verdicts: string[],
+): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push('\x1b[1m=== Audit Summary ===\x1b[0m');
+  lines.push(`Evidence rows:       ${rows.length}`);
+  lines.push(`Flagged as homepage: ${totalFlaggedOverall}`);
+  lines.push(`Unique domains:      ${domains.length}`);
+  lines.push(`Verdict filter:      ${verdicts.join(', ')}`);
+  lines.push('');
+
+  lines.push('\x1b[1mTop domains (by flagged count, then total):\x1b[0m');
+  lines.push('-'.repeat(100));
+  const header = `${'Flagged'.padStart(7)}  ${'Total'.padStart(5)}  ${'Domain'.padEnd(40)}  Record types`;
+  lines.push(`\x1b[1m${header}\x1b[0m`);
+  for (const d of domains.slice(0, 30)) {
+    const types = Object.entries(d.byRecordType)
+      .sort((a, b) => b[1] - a[1])
+      .map(([t, n]) => `${t}:${n}`)
+      .join(' ');
+    const flaggedStr = d.flagged > 0 ? `\x1b[33m${String(d.flagged).padStart(7)}\x1b[0m` : String(d.flagged).padStart(7);
+    lines.push(`${flaggedStr}  ${String(d.total).padStart(5)}  ${d.host.padEnd(40)}  ${types}`);
+  }
+  if (domains.length > 30) {
+    lines.push(`  ... and ${domains.length - 30} more domains`);
+  }
+  lines.push('');
+
+  // Show first 20 flagged rows with their URLs
+  const flagged = rows.filter((r) => r.flagged).slice(0, 20);
+  if (flagged.length > 0) {
+    lines.push('\x1b[1mSample flagged evidence:\x1b[0m');
+    lines.push('-'.repeat(100));
+    for (const r of flagged) {
+      const id = r.recordId.length > 24 ? r.recordId.slice(0, 22) + '..' : r.recordId;
+      const field = r.fieldName ? `.${r.fieldName}` : '';
+      const url = r.sourceUrl.length > 60 ? r.sourceUrl.slice(0, 57) + '...' : r.sourceUrl;
+      lines.push(`  ${r.verdict.padEnd(14)} ${r.recordType.padEnd(18)} ${(id + field).padEnd(28)} ${url}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Next steps:');
+  lines.push('  1. Inspect the top domains above. Common patterns: bare-domain links,');
+  lines.push('     /about pages, broken redirects to landing pages.');
+  lines.push('  2. For each offender: replace the URL with a specific data page,');
+  lines.push('     or delete the evidence if no better URL exists.');
+  lines.push('  3. After fixes, run: crux sourcing-recheck --type=<record-type>');
+
+  return lines.join('\n');
+}
+
+// ── Exports ──────────────────────────────────────────────────────────
+
+export const commands = {
+  default: auditCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check URL Audit — identify evidence rows whose source URL is a homepage
+
+Usage:
+  crux sourcing-audit-urls [options]
+
+Options:
+  --verdict=X,Y          Comma-separated verdict filter (default: unverifiable,partial)
+  --limit=N              Max verdict records to fetch per verdict type (default: 100)
+  --bad-url-only         Show only evidence rows flagged as homepage
+  --json                 Machine-readable output
+
+Output:
+  Ranked list of domains by flagged-count (homepage-like URLs), then by total
+  evidence-row count. Sample flagged URLs shown at the bottom.
+
+Workflow:
+  1. Run this command to identify top-offender domains.
+  2. Inspect and fix bad URLs (replace homepages with specific data pages).
+  3. Run crux sourcing-recheck on the corrected subset to re-verify.
+
+Requires WIKI_SERVER_ENV=prod in agent slots (no local wiki-server).
+`.trim();
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -95,6 +95,7 @@ import * as backfillPrOutcomesCommands from './commands/backfill-pr-outcomes.ts'
 import * as factbaseMigrateEntitiesCommands from './commands/factbase-migrate-entities.ts';
 import * as verifyOrchestrateCommands from './commands/sourcing-orchestrate.ts';
 import * as sourcingRecheckCommands from './commands/sourcing-recheck.ts';
+import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
 import * as sourcingWikiPagesCommands from './commands/sourcing-wiki-pages.ts';
@@ -182,6 +183,7 @@ const domains = {
   verify: verifyEntityCommands,
   'verify-orchestrate': verifyOrchestrateCommands,
   'sourcing-recheck': sourcingRecheckCommands,
+  'sourcing-audit-urls': sourcingAuditUrlsCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,
   'qa-sweep': qaSweepCommands,


### PR DESCRIPTION
## Summary

Phase 1 of QUA-113 (plan: [Discussion #4221](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4221)). Adds `crux sourcing-audit-urls`, a read-only command that identifies source-check evidence rows whose source URL points at a generic homepage, ranked by domain and record type. No LLM calls, no wiki-server writes, no schema changes.

## Motivation

~3,277 source-check verdicts are stuck at `unverifiable` (1,230) or `partial` (2,047). Many are caused by source URLs pointing at landing pages instead of specific data pages. This command gives operators a systematic way to find them.

## Key changes

- **`crux/commands/sourcing-audit-urls.ts`** — new command. Inline `classifyByUrl(url)` URL-quality heuristic + `normalizeUrlForJoin(url)` + `extractHost(url)`. Queries existing `listVerdicts` + `getEvidenceByRecord` endpoints (no wiki-server changes). Aggregates by domain.
- **`crux/commands/sourcing-audit-urls.test.ts`** — 47 tests covering adversarial URL inputs: root paths, bare domains, deep paths, PDFs, query params (tracking vs data), fragments (`#top` ignored, deep anchors flagged), Wayback prefix unwrapping, URL shorteners, case-insensitivity, IPv6 hosts, userinfo, and unparseable URLs.
- **`crux.mjs`** — register the new flat command alongside `sourcing-recheck`.

## Prod smoke test (--limit=200)

40+ homepage-flagged evidence rows across 28 domains. Top offenders:

```
Flagged  Total  Domain                        Record types
      6      6  codeforamerica.org            fact:6
      3      3  manifund.org                  grant:62 funding-program:2 division:1
      3      3  redqueenbio.com               fact:3
      3      3  yonadavshavit.com             fact:3
      2      2  x.ai                          fact:5
      2      2  mithrilsecurity.io            fact:2
      2      2  law-ai.org                    fact:2
      2      2  freedomhouse.org              fact:6
```

All correctly classified — bare domains and `/about` pages on `x.ai`, `openai.com`, etc.

## Review notes

Hostile-review subagent found 16 issues: 1 false positive (Wayback-regex claim; verified not an issue), 10 fixed (tracking-param dedup, limit validation, TTY-gated ANSI, fragment-threshold comment/code mismatch, aggregation double-counting with `--bad-url-only`, empty-response schema drift, magic numbers → module constants, 6 new tests for return branches), 5 accepted (test harness for command body deferred to QUA-312; shortener list known-incomplete).

## Follow-ups

- **QUA-312** — extract URL classifier to shared `crux/lib/sourcing/url-quality.ts`, wire into `classify.ts` + `resource-enrich.ts`, fix the `contentChanged` skip-guard bypass in resource-enrich
- **QUA-313** — backfill `resource_purpose` across 20k resources + `sourcing-mark` command + wiki-server API extension

## Test plan

- [x] `npx vitest run crux/commands/sourcing-audit-urls.test.ts` — 47 tests pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean for new file (86 pre-existing baseline errors unchanged)
- [x] `pnpm crux w validate gate --fix` — 48/48 checks pass
- [x] `WIKI_SERVER_ENV=prod pnpm crux sourcing-audit-urls --limit=30` — produces expected output
- [x] `WIKI_SERVER_ENV=prod pnpm crux sourcing-audit-urls --limit=30 --bad-url-only` — correctly filters to flagged-only
- [x] `pnpm crux sourcing-audit-urls --help` — help text accurate

## Deploy notes

Deploy-task detector flagged `NO_COLOR` env var — false positive. `NO_COLOR` is a widely-adopted convention the command honors client-side, not a production env var that needs setting.

Fixes QUA-113
