### PR TITLE
fix(citations): repair invalid JSON backslash escapes in fix-inaccuracies

### DIFF
--- a/crux/citations/fix-inaccuracies.test.ts
+++ b/crux/citations/fix-inaccuracies.test.ts
@@ -12,6 +12,7 @@ import {
   parseLLMFixResponse,
   applyFixes,
   enrichFromApi,
+  repairJsonBackslashEscapes,
 } from './fix-inaccuracies.ts';
 import type { FlaggedCitation } from './export-dashboard.ts';
 import type { SectionRewrite } from './fix-inaccuracies.ts';
@@ -102,6 +103,57 @@ describe('parseLLMFixResponse', () => {
 
   it('returns empty array for non-array JSON', () => {
     expect(parseLLMFixResponse('{"key": "value"}')).toEqual([]);
+  });
+
+  // Regression: prod LLM responses mirrored MDX-escaped `\$100K` verbatim
+  // into JSON strings as `"\$100K"` — invalid JSON that previously produced
+  // 0 proposals (QUA-314). parseLLMFixResponse must recover via escape repair.
+  it('recovers from invalid backslash escapes (e.g. \\$ in MDX-escaped claims)', () => {
+    const input = `[
+      {
+        "footnote": 9,
+        "original": "Awards of ≈\\$100K each distributed through milestone-based contracts.",
+        "replacement": "Awards distributed through milestone-based contracts.",
+        "explanation": "source does not support \\$100K figure",
+        "fix_type": "rewrite"
+      }
+    ]`;
+    const result = parseLLMFixResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].footnote).toBe(9);
+    expect(result[0].original).toBe('Awards of ≈\\$100K each distributed through milestone-based contracts.');
+    expect(result[0].replacement).toBe('Awards distributed through milestone-based contracts.');
+  });
+
+  it('recovers from invalid backslash escapes inside code fences', () => {
+    const input = '```json\n' + `[{"footnote":1,"original":"a \\$ b","replacement":"c","explanation":"","fix_type":""}]` + '\n```';
+    const result = parseLLMFixResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].original).toBe('a \\$ b');
+  });
+});
+
+describe('repairJsonBackslashEscapes', () => {
+  it('preserves valid JSON escapes', () => {
+    const s = '"a\\n\\t\\r\\"\\\\\\/b"';
+    expect(repairJsonBackslashEscapes(s)).toBe(s);
+    expect(() => JSON.parse(repairJsonBackslashEscapes(s))).not.toThrow();
+  });
+
+  it('doubles backslashes before invalid escape chars', () => {
+    const s = '"\\$100K"';
+    const repaired = repairJsonBackslashEscapes(s);
+    expect(JSON.parse(repaired)).toBe('\\$100K');
+  });
+
+  it('handles multiple invalid escapes in one string', () => {
+    const s = '"\\$ \\< \\%"';
+    expect(JSON.parse(repairJsonBackslashEscapes(s))).toBe('\\$ \\< \\%');
+  });
+
+  it('handles mixed valid and invalid escapes', () => {
+    const s = '"line\\n\\$val"';
+    expect(JSON.parse(repairJsonBackslashEscapes(s))).toBe('line\n\\$val');
   });
 });
 

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -468,22 +468,24 @@ Where:
 /** Parse the second opinion response. */
 function parseSecondOpinionResponse(text: string): { agree: boolean; verdict: string; reason: string } {
   const cleaned = stripCodeFences(text);
-  let parsed: { agree?: boolean; verdict?: string; reason?: string } | null = null;
+  let parsed: unknown = null;
   try {
-    parsed = JSON.parse(cleaned) as { agree?: boolean; verdict?: string; reason?: string };
+    parsed = JSON.parse(cleaned);
   } catch {
     try {
-      parsed = JSON.parse(repairJsonBackslashEscapes(cleaned)) as {
-        agree?: boolean; verdict?: string; reason?: string;
-      };
+      parsed = JSON.parse(repairJsonBackslashEscapes(cleaned));
     } catch {
       return { agree: true, verdict: 'not_verifiable', reason: 'Failed to parse response' };
     }
   }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { agree: true, verdict: 'not_verifiable', reason: 'Failed to parse response' };
+  }
+  const obj = parsed as { agree?: boolean; verdict?: string; reason?: string };
   return {
-    agree: parsed.agree !== false,
-    verdict: typeof parsed.verdict === 'string' ? parsed.verdict : 'not_verifiable',
-    reason: typeof parsed.reason === 'string' ? parsed.reason : '',
+    agree: obj.agree !== false,
+    verdict: typeof obj.verdict === 'string' ? obj.verdict : 'not_verifiable',
+    reason: typeof obj.reason === 'string' ? obj.reason : '',
   };
 }
 

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -467,17 +467,24 @@ Where:
 
 /** Parse the second opinion response. */
 function parseSecondOpinionResponse(text: string): { agree: boolean; verdict: string; reason: string } {
+  const cleaned = stripCodeFences(text);
+  let parsed: { agree?: boolean; verdict?: string; reason?: string } | null = null;
   try {
-    const cleaned = stripCodeFences(text);
-    const parsed = JSON.parse(cleaned) as { agree?: boolean; verdict?: string; reason?: string };
-    return {
-      agree: parsed.agree !== false,
-      verdict: typeof parsed.verdict === 'string' ? parsed.verdict : 'not_verifiable',
-      reason: typeof parsed.reason === 'string' ? parsed.reason : '',
-    };
+    parsed = JSON.parse(cleaned) as { agree?: boolean; verdict?: string; reason?: string };
   } catch {
-    return { agree: true, verdict: 'not_verifiable', reason: 'Failed to parse response' };
+    try {
+      parsed = JSON.parse(repairJsonBackslashEscapes(cleaned)) as {
+        agree?: boolean; verdict?: string; reason?: string;
+      };
+    } catch {
+      return { agree: true, verdict: 'not_verifiable', reason: 'Failed to parse response' };
+    }
   }
+  return {
+    agree: parsed.agree !== false,
+    verdict: typeof parsed.verdict === 'string' ? parsed.verdict : 'not_verifiable',
+    reason: typeof parsed.reason === 'string' ? parsed.reason : '',
+  };
 }
 
 export interface SecondOpinionResult {
@@ -886,30 +893,68 @@ function buildSourceEvidence(c: EnrichedFlaggedCitation): string | null {
   return parts.length > 0 ? parts.join('\n') : null;
 }
 
+/**
+ * Repair invalid JSON backslash escapes by doubling backslashes that precede
+ * a character which is not a valid JSON escape (`"`, `\`, `/`, `b`, `f`, `n`,
+ * `r`, `t`, `u`). LLMs frequently mirror MDX-escaped text like `\$100K` into
+ * JSON strings literally, producing `"\$100K"` — which is not valid JSON.
+ * Preserving the literal backslash requires rewriting that to `"\\$100K"`.
+ */
+export function repairJsonBackslashEscapes(input: string): string {
+  return input.replace(/\\(.)/g, (_m, c: string) => {
+    if ('"\\/bfnrtu'.includes(c)) return '\\' + c;
+    return '\\\\' + c;
+  });
+}
+
 /** Parse LLM response into fix proposals. */
 export function parseLLMFixResponse(content: string): FixProposal[] {
   const cleaned = stripCodeFences(content);
-  try {
-    const parsed = JSON.parse(cleaned);
-    if (!Array.isArray(parsed)) return [];
+  const parsed = tryParseJson(cleaned);
+  if (!Array.isArray(parsed)) return [];
 
-    return parsed
-      .filter(
-        (p: Record<string, unknown>) =>
-          typeof p.original === 'string' &&
-          typeof p.replacement === 'string' &&
-          p.original.length > 0 &&
-          p.original !== p.replacement,
-      )
-      .map((p: Record<string, unknown>) => ({
-        footnote: typeof p.footnote === 'number' ? p.footnote : 0,
-        original: p.original as string,
-        replacement: p.replacement as string,
-        explanation: typeof p.explanation === 'string' ? p.explanation : '',
-        fixType: typeof p.fix_type === 'string' ? p.fix_type : 'unknown',
-      }));
-  } catch {
-    return [];
+  return parsed
+    .filter(
+      (p: Record<string, unknown>) =>
+        typeof p.original === 'string' &&
+        typeof p.replacement === 'string' &&
+        p.original.length > 0 &&
+        p.original !== p.replacement,
+    )
+    .map((p: Record<string, unknown>) => ({
+      footnote: typeof p.footnote === 'number' ? p.footnote : 0,
+      original: p.original as string,
+      replacement: p.replacement as string,
+      explanation: typeof p.explanation === 'string' ? p.explanation : '',
+      fixType: typeof p.fix_type === 'string' ? p.fix_type : 'unknown',
+    }));
+}
+
+/**
+ * Attempt to JSON.parse `s`; on failure, repair invalid backslash escapes and
+ * retry. Returns `null` on unrecoverable failure. Emits a warning if the
+ * initial parse failed so silent breakage (e.g., the `\$` bug that produced
+ * 0 proposals in prod) is visible.
+ */
+function tryParseJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch (err1) {
+    const repaired = repairJsonBackslashEscapes(s);
+    try {
+      const result = JSON.parse(repaired);
+      console.warn(
+        `  [warn] LLM returned JSON with invalid backslash escapes — repaired. ` +
+        `First error: ${err1 instanceof Error ? err1.message : String(err1)}`,
+      );
+      return result;
+    } catch (err2) {
+      console.warn(
+        `  [warn] Failed to parse LLM JSON response (even after escape repair): ` +
+        `${err2 instanceof Error ? err2.message : String(err2)}`,
+      );
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The `crux w citations fix-inaccuracies` tool produced **0 proposals** in prod for all flagged citations, despite all 49 unit tests passing (QUA-314).

**Root cause**: LLMs mirror MDX-escaped text like `\$100K` verbatim into JSON string values (e.g. `"Awards of ≈\$100K each..."`). `\$` is not a valid JSON escape sequence, so `JSON.parse()` throws and the silent `catch { return []; }` in `parseLLMFixResponse` returned zero proposals. The mocked unit tests never exercised this code path because their test fixtures were already valid JSON.

## Fix

- Add `repairJsonBackslashEscapes()` that doubles backslashes preceding characters which are not valid JSON escape chars (`"\/bfnrtu`), preserving them as literal backslashes.
- Parser now attempts `JSON.parse`, falls back to parsing the repaired string, and emits a `console.warn` (instead of silently returning `[]`) so future parse failures are visible.
- Apply the same repair to `parseSecondOpinionResponse`.
- Add 6 regression tests; 55 total pass.

## Verification (prod)

All three repro cases from QUA-314 now produce proposals:

| Page | Flagged | Before | After |
|---|---|---|---|
| blueprint-biosecurity | 1 | 0 | 1 |
| polymarket | 12 | 0 | 12 |

## Test plan

- [x] `pnpm vitest run crux/citations/fix-inaccuracies.test.ts` — 55/55 pass
- [x] Dry-run against blueprint-biosecurity produces 1 proposal
- [x] Dry-run against polymarket produces 12 proposals

Fixes QUA-314

Unblocks QUA-307.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced citation response parsing with automatic recovery mechanism for invalid JSON escape sequences
* Improved fallback handling to ensure reliable citation processing when responses contain formatting issues or parsing errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->