### PR TITLE
fix: mask raw f_ factIds on entity data pages

### DIFF
--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -167,11 +167,15 @@ export function CategoryFactSection({
                             <FactValueDisplay fact={fact} property={property} />
                           </td>
                           <td className="py-1.5 pr-3">
+                            {/* The factId is an internal identifier; we keep it in the href
+                                for deep links but render a short label so raw `f_...` IDs don't
+                                leak into visible page text (caught by the no-raw-ids e2e spec). */}
                             <Link
                               href={`/factbase/fact/${fact.id}`}
-                              className="text-blue-600 hover:underline dark:text-blue-400 font-mono text-xs"
+                              className="text-blue-600 hover:underline dark:text-blue-400 text-xs"
+                              title={fact.id}
                             >
-                              {fact.id}
+                              view &rarr;
                             </Link>
                           </td>
                           <td className="py-1.5 pl-1">


### PR DESCRIPTION
## Summary

Fix raw FactBase fact IDs (`f_` prefix) leaking on 6 prod data pages:

- `/internal/facts`
- `/organizations/deepmind/data?tab=database`
- `/organizations/meta-ai/data?tab=database`
- `/people/dario-amodei/data?tab=database`
- `/people/sam-altman/data?tab=database`
- `/people/demis-hassabis/data?tab=database`

These pages render `CategoryFactSection` from `apps/web/src/components/factbase/entity-fact-display.tsx`, which displayed raw `fact.id` (e.g. `f_KtTrbGQynQ`) as visible text in the "Fact ID" column. PR #4195 fixed the equivalent `sid_` leak but didn't cover `f_`. A follow-up (1f1479270) masked the ID in the `/internal/facts` explorer table; this PR applies the same treatment to the second display site.

## Root cause

`CategoryFactSection` rendered:

```tsx
<Link href={`/factbase/fact/${fact.id}`} className="...font-mono text-xs">
  {fact.id}
</Link>
```

Deep-link was fine, but the cell text was the raw `f_...` ID. Playwright `e2e/no-raw-ids.spec.ts` caught this after the 2026-04-12 release.

## Fix

Replace cell text with a `view →` label. Keep `fact.id` in the `href` for deep links and in the `title` attribute for hover (not `innerText`).

## Test plan

- [x] Playwright `e2e/no-raw-ids.spec.ts` — all 6 previously-failing pages now pass locally (dev server on `:3015`). The one remaining failure is a `/organizations` directory-page dev-server compile-timeout, unrelated.
- [x] `pnpm build` — exit 0
- [x] `pnpm test` — 5688/5715 pass (1 pre-existing flake in `validate-sourcing-coverage` timing out at 5s; not caused by this PR)
- [x] `pnpm crux w validate gate --fix` — 43/43 checks pass
- [x] `/agent-review-pr` — triaged as tiny UI-only change; build + tests + gate + Playwright sufficient

## Regression coverage

`apps/web/e2e/no-raw-ids.spec.ts` is the permanent regression check — it runs against prod post-deploy. Same spec already catches `sid_` and `[object Object]`.

Fixes QUA-316
