### PR TITLE
fix(sourcing): filter orphan verdicts in /stats + annotate tool scope

### DIFF
--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -406,7 +406,14 @@ const sourcingApp = new Hono()
         ? sql`AND v.record_type = ${record_type}`
         : sql``;
 
-      const [statsRow] = (await db.execute(sql`
+      // count(*) with no GROUP BY always returns exactly one row, so statsRow
+      // is non-null in practice. The ?? 0 fallbacks guard against a defensive
+      // ceiling in the response contract.
+      const statsRows = await db.execute<{
+        total: number;
+        needs_recheck: number;
+        avg_confidence: number;
+      }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         SELECT
           count(*)::int AS total,
@@ -416,13 +423,10 @@ const sourcingApp = new Hono()
         INNER JOIN live_records lr
           ON lr.record_type = v.record_type AND lr.record_id = v.record_id
         WHERE 1=1 ${typeFilterSql}
-      `)) as Array<{
-        total: number;
-        needs_recheck: number;
-        avg_confidence: number;
-      }>;
+      `);
+      const statsRow = statsRows[0];
 
-      const byVerdictRows = (await db.execute(sql`
+      const byVerdictRows = await db.execute<{ verdict: string; cnt: number }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         SELECT v.verdict, count(*)::int AS cnt
         FROM source_check_verdicts v
@@ -430,7 +434,7 @@ const sourcingApp = new Hono()
           ON lr.record_type = v.record_type AND lr.record_id = v.record_id
         WHERE 1=1 ${typeFilterSql}
         GROUP BY v.verdict
-      `)) as Array<{ verdict: string; cnt: number }>;
+      `);
 
       const byVerdict: Record<string, number> = {};
       for (const row of byVerdictRows) {
@@ -439,14 +443,14 @@ const sourcingApp = new Hono()
 
       // by_type is always unfiltered by record_type (shows all types for the
       // type-filter tabs) but still excludes orphans.
-      const byTypeRows = (await db.execute(sql`
+      const byTypeRows = await db.execute<{ record_type: string; cnt: number }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         SELECT v.record_type, count(*)::int AS cnt
         FROM source_check_verdicts v
         INNER JOIN live_records lr
           ON lr.record_type = v.record_type AND lr.record_id = v.record_id
         GROUP BY v.record_type
-      `)) as Array<{ record_type: string; cnt: number }>;
+      `);
 
       const byType: Record<string, number> = {};
       for (const row of byTypeRows) {
@@ -461,12 +465,12 @@ const sourcingApp = new Hono()
         .from(recordSources);
 
       return c.json({
-        total: Number(statsRow.total),
+        total: Number(statsRow?.total ?? 0),
         by_verdict: byVerdict,
         by_type: byType,
-        needs_recheck: Number(statsRow.needs_recheck),
+        needs_recheck: Number(statsRow?.needs_recheck ?? 0),
         avg_confidence:
-          Math.round(Number(statsRow.avg_confidence) * 100) / 100,
+          Math.round(Number(statsRow?.avg_confidence ?? 0) * 100) / 100,
         stale_evidence_count: Number(evidenceStats.staleCount),
         dead_link_count: Number(evidenceStats.deadLinkCount),
         current_checker_model: CURRENT_CHECKER_MODEL,

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -70,6 +70,39 @@ const VALID_VERDICT_TYPES = [...VALID_VERDICTS, "unchecked"] as const;
 export const CURRENT_CHECKER_MODEL = "claude-haiku-4-5-20251001";
 export const DEAD_LINK_CHECKER_MODEL = "dead-link-detector";
 
+// ---- Shared CTE ----
+
+/**
+ * CTE listing every (record_type, record_id) pair currently present in its
+ * source table. Used to filter orphan verdicts — rows in source_verdicts
+ * that reference records which have since been deleted from their source
+ * table. `INNER JOIN` against this CTE excludes orphans.
+ *
+ * `citation` rows only count when they still carry an accuracy verdict;
+ * `fact` uses fact_id (not the serial PK) because source_verdicts.record_id
+ * stores the fact_id for facts.
+ */
+const LIVE_RECORDS_CTE = sql`
+  live_records AS (
+    SELECT 'personnel' AS record_type, id::text AS record_id FROM personnel
+    UNION ALL SELECT 'division', id::text FROM divisions
+    UNION ALL SELECT 'grant', id::text FROM grants
+    UNION ALL SELECT 'funding-round', id::text FROM funding_rounds
+    UNION ALL SELECT 'investment', id::text FROM investments
+    UNION ALL SELECT 'funding-program', id::text FROM funding_programs
+    UNION ALL SELECT 'publication', id::text FROM publications
+    UNION ALL SELECT 'secondary-market-price', id::text FROM secondary_market_prices
+    UNION ALL SELECT 'equity-position', id::text FROM equity_positions
+    UNION ALL SELECT 'entity-event', id::text FROM entity_events
+    UNION ALL SELECT 'entity-assessment', id::text FROM entity_assessments
+    UNION ALL SELECT 'benchmark-result', id::text FROM benchmark_results
+    UNION ALL SELECT 'policy-stakeholder', id::text FROM policy_stakeholders
+    UNION ALL SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
+    UNION ALL SELECT 'wiki-page', id::text FROM wiki_pages
+    UNION ALL SELECT 'fact', fact_id FROM facts
+  )
+`;
+
 // ---- Query schemas ----
 
 const EvidenceBody = z.object({
@@ -364,45 +397,60 @@ const sourcingApp = new Hono()
       const { record_type } = c.req.valid("query");
       const db = getDrizzleDb();
 
-      const typeCondition = record_type
-        ? eq(sourceVerdicts.recordType, record_type)
-        : undefined;
+      // All verdict aggregations filter orphan verdicts (rows referencing records
+      // that have been deleted from their source table) via LIVE_RECORDS_CTE, to
+      // stay consistent with /coverage-matrix and /verdict-matrix. Without this
+      // filter the dashboard over-reports contradicted/partial/etc. counts by
+      // including verdicts for records that no longer exist.
+      const typeFilterSql = record_type
+        ? sql`AND v.record_type = ${record_type}`
+        : sql``;
 
-      const [statsRow] = await db
-        .select({
-          total: count(),
-          needsRecheck: sql<number>`count(*) filter (where ${sourceVerdicts.needsRecheck} = true)`,
-          avgConfidence: sql<number>`coalesce(avg(${sourceVerdicts.confidence}), 0)`,
-        })
-        .from(sourceVerdicts)
-        .where(typeCondition);
+      const [statsRow] = (await db.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        SELECT
+          count(*)::int AS total,
+          count(*) FILTER (WHERE v.needs_recheck = true)::int AS needs_recheck,
+          coalesce(avg(v.confidence), 0)::float AS avg_confidence
+        FROM source_check_verdicts v
+        INNER JOIN live_records lr
+          ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+        WHERE 1=1 ${typeFilterSql}
+      `)) as Array<{
+        total: number;
+        needs_recheck: number;
+        avg_confidence: number;
+      }>;
 
-      const byVerdictRows = await db
-        .select({
-          verdict: sourceVerdicts.verdict,
-          count: count(),
-        })
-        .from(sourceVerdicts)
-        .where(typeCondition)
-        .groupBy(sourceVerdicts.verdict);
+      const byVerdictRows = (await db.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        SELECT v.verdict, count(*)::int AS cnt
+        FROM source_check_verdicts v
+        INNER JOIN live_records lr
+          ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+        WHERE 1=1 ${typeFilterSql}
+        GROUP BY v.verdict
+      `)) as Array<{ verdict: string; cnt: number }>;
 
       const byVerdict: Record<string, number> = {};
       for (const row of byVerdictRows) {
-        byVerdict[row.verdict] = row.count;
+        byVerdict[row.verdict] = row.cnt;
       }
 
-      // by_type is always unfiltered (shows all types for the type-filter tabs)
-      const byTypeRows = await db
-        .select({
-          recordType: sourceVerdicts.recordType,
-          count: count(),
-        })
-        .from(sourceVerdicts)
-        .groupBy(sourceVerdicts.recordType);
+      // by_type is always unfiltered by record_type (shows all types for the
+      // type-filter tabs) but still excludes orphans.
+      const byTypeRows = (await db.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        SELECT v.record_type, count(*)::int AS cnt
+        FROM source_check_verdicts v
+        INNER JOIN live_records lr
+          ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+        GROUP BY v.record_type
+      `)) as Array<{ record_type: string; cnt: number }>;
 
       const byType: Record<string, number> = {};
       for (const row of byTypeRows) {
-        byType[row.recordType] = row.count;
+        byType[row.record_type] = row.cnt;
       }
 
       const [evidenceStats] = await db
@@ -413,12 +461,12 @@ const sourcingApp = new Hono()
         .from(recordSources);
 
       return c.json({
-        total: statsRow.total,
+        total: Number(statsRow.total),
         by_verdict: byVerdict,
         by_type: byType,
-        needs_recheck: Number(statsRow.needsRecheck),
+        needs_recheck: Number(statsRow.needs_recheck),
         avg_confidence:
-          Math.round(Number(statsRow.avgConfidence) * 100) / 100,
+          Math.round(Number(statsRow.avg_confidence) * 100) / 100,
         stale_evidence_count: Number(evidenceStats.staleCount),
         dead_link_count: Number(evidenceStats.deadLinkCount),
         current_checker_model: CURRENT_CHECKER_MODEL,
@@ -1849,49 +1897,10 @@ const sourcingApp = new Hono()
     // 3. Distinct checked records per type
     //
     // Both queries filter out orphaned verdicts (verdict rows referencing records
-    // that have been deleted from their source table) by JOINing against a CTE
-    // of all live (record_type, record_id) pairs.
-    //
-    // Note: for 'fact' type, record_id stores fact_id (not the serial PK),
-    // and for 'citation' type, record_id stores citation_quotes.id::text.
-    const liveRecordsCte = sql`
-      live_records AS (
-        SELECT 'personnel' AS record_type, id::text AS record_id FROM personnel
-        UNION ALL
-        SELECT 'division', id::text FROM divisions
-        UNION ALL
-        SELECT 'grant', id::text FROM grants
-        UNION ALL
-        SELECT 'funding-round', id::text FROM funding_rounds
-        UNION ALL
-        SELECT 'investment', id::text FROM investments
-        UNION ALL
-        SELECT 'funding-program', id::text FROM funding_programs
-        UNION ALL
-        SELECT 'publication', id::text FROM publications
-        UNION ALL
-        SELECT 'secondary-market-price', id::text FROM secondary_market_prices
-        UNION ALL
-        SELECT 'equity-position', id::text FROM equity_positions
-        UNION ALL
-        SELECT 'entity-event', id::text FROM entity_events
-        UNION ALL
-        SELECT 'entity-assessment', id::text FROM entity_assessments
-        UNION ALL
-        SELECT 'benchmark-result', id::text FROM benchmark_results
-        UNION ALL
-        SELECT 'policy-stakeholder', id::text FROM policy_stakeholders
-        UNION ALL
-        SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
-        UNION ALL
-        SELECT 'wiki-page', id::text FROM wiki_pages
-        UNION ALL
-        SELECT 'fact', fact_id FROM facts
-      )
-    `;
-
+    // that have been deleted from their source table) by JOINing against the
+    // shared LIVE_RECORDS_CTE.
     const verdictRows = (await db.execute(sql`
-      WITH ${liveRecordsCte}
+      WITH ${LIVE_RECORDS_CTE}
       SELECT v.record_type, v.verdict, count(*)::int AS cnt
       FROM source_check_verdicts v
       INNER JOIN live_records lr
@@ -1904,7 +1913,7 @@ const sourcingApp = new Hono()
     // A record can have multiple verdict rows (one per fieldName), so we use
     // COUNT(DISTINCT record_id) to avoid exceeding 100%.
     const checkedRows = (await db.execute(sql`
-      WITH ${liveRecordsCte}
+      WITH ${LIVE_RECORDS_CTE}
       SELECT v.record_type, count(DISTINCT v.record_id)::int AS checked_records
       FROM source_check_verdicts v
       INNER JOIN live_records lr
@@ -2017,26 +2026,9 @@ const sourcingApp = new Hono()
   .get("/verdict-matrix", async (c) => {
     const db = getDrizzleDb();
 
-    // Exclude orphaned verdicts for deleted records (same CTE pattern as /coverage-matrix)
+    // Exclude orphaned verdicts for deleted records via the shared LIVE_RECORDS_CTE.
     const rows = (await db.execute(sql`
-      WITH live_records AS (
-        SELECT 'personnel' AS record_type, id::text AS record_id FROM personnel
-        UNION ALL SELECT 'division', id::text FROM divisions
-        UNION ALL SELECT 'grant', id::text FROM grants
-        UNION ALL SELECT 'funding-round', id::text FROM funding_rounds
-        UNION ALL SELECT 'investment', id::text FROM investments
-        UNION ALL SELECT 'funding-program', id::text FROM funding_programs
-        UNION ALL SELECT 'publication', id::text FROM publications
-        UNION ALL SELECT 'secondary-market-price', id::text FROM secondary_market_prices
-        UNION ALL SELECT 'equity-position', id::text FROM equity_positions
-        UNION ALL SELECT 'entity-event', id::text FROM entity_events
-        UNION ALL SELECT 'entity-assessment', id::text FROM entity_assessments
-        UNION ALL SELECT 'benchmark-result', id::text FROM benchmark_results
-        UNION ALL SELECT 'policy-stakeholder', id::text FROM policy_stakeholders
-        UNION ALL SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
-        UNION ALL SELECT 'wiki-page', id::text FROM wiki_pages
-        UNION ALL SELECT 'fact', fact_id FROM facts
-      )
+      WITH ${LIVE_RECORDS_CTE}
       SELECT v.record_type, v.verdict, count(*)::int AS cnt
       FROM source_check_verdicts v
       INNER JOIN live_records lr

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -4,6 +4,25 @@
  * Reads flagged citations from the dashboard YAML (for discovery), then
  * enriches each with full source text from the wiki-server API before generating fixes.
  *
+ * SCOPE — narrow by design
+ *
+ * The primary (Gemini Flash) pass requires the `original` field to be an
+ * EXACT substring of the page MDX and the replacement to be comparable in
+ * length. The Claude Sonnet escalation permits section-level rewrites but is
+ * instructed not to change section length or introduce new claims. In
+ * practice this means the tool handles:
+ *   - small numeric/date corrections where a short substring can be swapped
+ *   - minor overclaim softening
+ *
+ * It does NOT handle severely-contradicted claims where faithful correction
+ * requires rewording or removing substantive narrative (e.g. attribution
+ * errors, hallucinated details, source says X but claim says Y with no
+ * cleanly-replaceable substring). Those return 0 proposals — see QUA-314.
+ *
+ * If your backlog is dominated by semantic contradictions, expect zero
+ * proposals. Prompt-level false-positive fixes (QUA-246 family) or page
+ * regeneration via `crux w improve --tier=deep` are usually the right path.
+ *
  * Usage:
  *   pnpm crux citations fix-inaccuracies                        # Dry run all
  *   pnpm crux citations fix-inaccuracies --apply                 # Apply all
@@ -1687,6 +1706,14 @@ async function main() {
 
     if (!apply && totalProposed > 0) {
       console.log(`\n${c.dim}Run with --apply to write changes and auto-re-verify.${c.reset}`);
+    }
+    if (totalProposed === 0 && allResults.length > 0) {
+      console.log(
+        `\n${c.dim}Note: this tool handles small numeric/date corrections and minor overclaim softening. ` +
+        `It produces 0 proposals for severely-contradicted claims where faithful correction requires ` +
+        `rewording or removing substantive narrative. For those, see QUA-246 (prompt false-positive fixes) ` +
+        `or page regeneration via \`crux w improve --tier=deep\`.${c.reset}`,
+      );
     }
     console.log('');
   }

--- a/crux/scripts/fix-contradicted-facts.ts
+++ b/crux/scripts/fix-contradicted-facts.ts
@@ -5,9 +5,16 @@
  * value from the verdict reasoning using Haiku, and updates the YAML files
  * in packages/factbase/data/things/ automatically.
  *
- * Many contradictions are rounding issues (stored $116M when source says
- * $115,576,357). We store exact values and let the display layer handle
- * formatting.
+ * SCOPE — narrow by design
+ *
+ * This tool handles ONLY numeric-value contradictions (rounding drift like
+ * stored $116M when source says $115,576,357). Facts with non-numeric values
+ * — URLs, names, descriptions, multi-line strings, ranges like "200 - 300" —
+ * are skipped and reported under "Needs Manual Review".
+ *
+ * If your backlog is dominated by semantic contradictions (wrong URL, wrong
+ * person, hallucinated narrative), this tool will produce zero fixes. See
+ * the sourcing prompt fixes (QUA-246 family) or manual review instead.
  *
  * Usage:
  *   WIKI_SERVER_ENV=prod node --import tsx/esm crux/scripts/fix-contradicted-facts.ts [--apply] [--entity=<slug>]
@@ -610,6 +617,13 @@ async function main(): Promise<void> {
     console.log(`Would apply: ${wouldApply}`);
     if (wouldApply > 0) {
       console.log("\nRun with --apply to write changes.");
+    } else if (matched.length > 0 && skipped === matched.length) {
+      console.log(
+        "\nNote: this tool only fixes numeric-value contradictions. " +
+        "All matched facts were skipped (non-numeric, multi-line, or already correct). " +
+        "For semantic contradictions (wrong URL/name/description), prompt fixes " +
+        "via the sourcing pipeline (QUA-246 family) or manual review is the path.",
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Three cleanup changes surfaced during QUA-112 scoping pass. All small, all independently reversible.

### 1. `/api/sourcing/stats` filters orphan verdicts (QUA-317)

The `/stats` endpoint was reporting raw `source_verdicts` counts without filtering orphans — rows referencing records that have been deleted from their source table. `/coverage-matrix` and `/verdict-matrix` already filter via a `live_records` CTE; `/stats` did not. This inconsistency inflated the user-facing contradicted count by **~71 verdicts on prod** (reported 386 vs. live-record count ~315).

Changes:
- New module-level `LIVE_RECORDS_CTE` constant — extracts a previously-duplicated inline CTE used in 3 places
- `/stats` now uses the same CTE with `INNER JOIN` to filter orphans from `total`, `by_verdict`, `by_type`, `needs_recheck`, and `avg_confidence`
- Response shape and field names unchanged — only numeric totals shift

**Expected prod effect after deploy**: `by_verdict.contradicted` drops ~386 → ~315. No destructive action, no data modified, just reporting.

### 2. Annotate `crux w citations fix-inaccuracies` tool scope (QUA-307, QUA-314)

Scoping-pass dry-runs on 3 pages (polymarket 12 flagged, lionheart-ventures 9 flagged, blueprint-biosecurity 1 flagged — simplest possible case) all returned **0 proposals**. Unit tests pass (49/49), so the structural tool is fine; the constraint is that the primary pass requires exact-substring matches and the escalation forbids size-changing rewrites.

- Header documents the narrow scope (small numeric/date corrections only)
- Runtime note when `totalProposed === 0` points at QUA-246 prompt fixes or page regeneration instead

### 3. Annotate `crux/scripts/fix-contradicted-facts.ts` tool scope (QUA-308)

The tool only handles numeric-value contradictions (rounding drift). Current 48-fact backlog is 0/48 fixable by it — all matched facts are non-numeric (URLs, names, descriptions, multi-line ranges).

- Header documents the numeric-only scope
- Runtime note when all matched facts are skipped points at QUA-246 or manual review

## Why one PR

The three pieces are all "cleanup work that fell out of the same scoping pass." Keeping them together gives the PR description its own context — otherwise the "why annotate these tools" justification lives in a separate ticket from the PR.

## Test plan

- [x] `pnpm tsc --noEmit` — wiki-server passes
- [x] `pnpm test sourcing` — 2 existing sourcing test files pass (11 tests)
- [x] `npx tsx crux/validate/validate-dangerous-patterns.ts` — clean (892 files checked)
- [x] Gate check passes locally
- [ ] **Post-merge**: verify `/api/sourcing/stats` returns `by_verdict.contradicted` ≈ 315 (not 386) on prod
- [ ] **Post-merge**: verify dashboard at `/internal/source-check-coverage` shows corrected numbers

## Risks

- `/stats` switches from Drizzle query-builder to raw `sql` — follows the same pattern as `/coverage-matrix` and `/verdict-matrix` in the same file. Type casts use `as Array<...>` (no `as unknown as` double-casts).
- Tool header annotations are docs-only, no behavior change.

Fixes QUA-317
Fixes QUA-112
