### PR TITLE
feat(linear): tooling for keeping In Progress queue clean

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -67,7 +67,7 @@ Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes 
 Scan the session for Linear IDs beyond the primary issue that may have been worked on but not properly closed:
 
 ```bash
-pnpm crux linear leak-check
+pnpm crux linear leak-check || true
 ```
 
 This inspects the branch name, `.claude/wip-*` files, and commit messages for `QUA-NNN` references, then checks Linear state for each. If any secondary issue is still "In Progress" (and isn't being closed by an open PR), the command flags it.

--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -62,6 +62,21 @@ fi
 
 Requires `LINEAR_API_KEY` (synced from `.env.base`). The `|| echo` suffix makes the Linear update best-effort so a missing key doesn't interrupt the rest of `/agent-end`. If Linear updates fail, fix the key and rerun `pnpm crux linear done <QUA-NNN>` manually — Linear is the source of truth for project status and leaving "In Progress" drift is bad.
 
+## Step 2a: Leak-check for other Linear refs
+
+Scan the session for Linear IDs beyond the primary issue that may have been worked on but not properly closed:
+
+```bash
+pnpm crux linear leak-check
+```
+
+This inspects the branch name, `.claude/wip-*` files, and commit messages for `QUA-NNN` references, then checks Linear state for each. If any secondary issue is still "In Progress" (and isn't being closed by an open PR), the command flags it.
+
+The check is advisory — it never blocks session end. If it surfaces a leak, decide:
+- The issue was genuinely worked on and its code shipped → `pnpm crux linear done QUA-NNN`
+- The issue was mentioned but not worked on this session → leave as-is (the mention was just cross-referencing)
+- Scope creep was not shipped → move it back to Backlog in Linear manually
+
 ## Step 2b: Update legacy GitHub issue (if applicable)
 
 If this session was working on a legacy GitHub issue (not a Linear issue) and a PR was created:

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -110,6 +110,37 @@ pnpm crux sys maintain triage-linear
 
 This replaces the manual GraphQL queries. If `LINEAR_API_KEY` is not set, it reports that and skips gracefully.
 
+**4b. Actionable In Progress audit** — correlates Linear In Progress state with GitHub PR activity. Surfaces `SHIPPED` (PR merged but state not updated) and `PARENT-EPIC` (all sub-issues resolved) — these are one-keystroke cleanups that `triage-linear` doesn't catch because it only looks at staleness by time.
+
+```bash
+pnpm crux linear audit --bucket=shipped --json 2>/dev/null | python3 -c "
+import json, sys
+try:
+  entries = json.load(sys.stdin)
+  if entries:
+    print(f'⚠ {len(entries)} issue(s) SHIPPED but still In Progress:')
+    for e in entries:
+      print(f\"  {e['issue']['identifier']} — {e['reason']}\")
+    print('  Run: pnpm crux linear audit --fix')
+except Exception:
+  pass
+"
+pnpm crux linear audit --bucket=parent-epic --json 2>/dev/null | python3 -c "
+import json, sys
+try:
+  entries = json.load(sys.stdin)
+  if entries:
+    print(f'⚠ {len(entries)} parent epic(s) with all sub-issues resolved:')
+    for e in entries:
+      print(f\"  {e['issue']['identifier']} — {e['reason']}\")
+    print('  Run: pnpm crux linear audit --fix')
+except Exception:
+  pass
+"
+```
+
+Use `pnpm crux linear audit` (no args) for the full report.
+
 **4c. Stale agent slots** — slots on a non-main branch with no recent activity.
 
 ```bash

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -113,25 +113,22 @@ This replaces the manual GraphQL queries. If `LINEAR_API_KEY` is not set, it rep
 **4b. Actionable In Progress audit** — correlates Linear In Progress state with GitHub PR activity. Surfaces `SHIPPED` (PR merged but state not updated) and `PARENT-EPIC` (all sub-issues resolved) — these are one-keystroke cleanups that `triage-linear` doesn't catch because it only looks at staleness by time.
 
 ```bash
-pnpm crux linear audit --bucket=shipped --json 2>/dev/null | python3 -c "
+# Run the audit once and split by bucket in Python to avoid doubling the
+# GitHub /search/issues budget used for PR correlation.
+pnpm crux linear audit --json 2>/dev/null | python3 -c "
 import json, sys
 try:
   entries = json.load(sys.stdin)
-  if entries:
-    print(f'⚠ {len(entries)} issue(s) SHIPPED but still In Progress:')
-    for e in entries:
+  shipped = [e for e in entries if e.get('bucket') == 'shipped']
+  parent_epics = [e for e in entries if e.get('bucket') == 'parent-epic']
+  if shipped:
+    print(f'⚠ {len(shipped)} issue(s) SHIPPED but still In Progress:')
+    for e in shipped:
       print(f\"  {e['issue']['identifier']} — {e['reason']}\")
     print('  Run: pnpm crux linear audit --fix')
-except Exception:
-  pass
-"
-pnpm crux linear audit --bucket=parent-epic --json 2>/dev/null | python3 -c "
-import json, sys
-try:
-  entries = json.load(sys.stdin)
-  if entries:
-    print(f'⚠ {len(entries)} parent epic(s) with all sub-issues resolved:')
-    for e in entries:
+  if parent_epics:
+    print(f'⚠ {len(parent_epics)} parent epic(s) with all sub-issues resolved:')
+    for e in parent_epics:
       print(f\"  {e['issue']['identifier']} — {e['reason']}\")
     print('  Run: pnpm crux linear audit --fix')
 except Exception:

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -15,7 +15,6 @@
  *   crux linear parse <string>          Extract a Linear ID from a string (debug)
  */
 
-import { readFileSync } from 'fs';
 import { createLogger } from '../lib/output.ts';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
@@ -26,9 +25,18 @@ import {
   searchIssues,
   updateIssueState,
 } from '../lib/linear/issues.ts';
+import {
+  auditInProgress,
+  extractFixesIds,
+  type AuditBucket,
+  type AuditEntry,
+} from '../lib/linear/audit.ts';
+import { githubApi } from '../lib/github.ts';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
-import { parseLinearId } from '../lib/linear/parse-id.ts';
+import { findAllLinearIds, parseLinearId } from '../lib/linear/parse-id.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
 
 interface CommandOptions extends BaseOptions {
   ci?: boolean;
@@ -297,6 +305,320 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   return { output: out, exitCode: 0 };
 }
 
+async function audit(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const bucketFilter = args.find((a) => a.startsWith('--bucket='))?.split('=')[1];
+  const fix = args.includes('--fix');
+
+  const entries = await auditInProgress();
+
+  if (options.json) {
+    const filtered = bucketFilter ? entries.filter((e) => e.bucket === bucketFilter) : entries;
+    return { output: JSON.stringify(filtered, null, 2) + '\n', exitCode: 0 };
+  }
+
+  if (entries.length === 0) {
+    return {
+      output: `${c.green}✓${c.reset} No issues currently In Progress.\n`,
+      exitCode: 0,
+    };
+  }
+
+  const bucketMeta: Record<AuditBucket, { label: string; color: string; action: string }> = {
+    active: {
+      label: 'ACTIVE',
+      color: c.green,
+      action: 'Has open PR — no action needed.',
+    },
+    shipped: {
+      label: 'SHIPPED (state-update missed)',
+      color: c.yellow,
+      action: 'PR merged. Move to Done: crux linear done QUA-NNN --pr=URL',
+    },
+    'parent-epic': {
+      label: 'PARENT EPIC (sub-issues resolved)',
+      color: c.cyan,
+      action: 'All sub-issues resolved. Close: crux linear done QUA-NNN',
+    },
+    orphan: {
+      label: `ORPHAN (>${7}d no PR)`,
+      color: c.red,
+      action: 'No PR, no activity. Move to Backlog or reassess scope.',
+    },
+    stuck: {
+      label: 'STUCK (recent but no PR)',
+      color: c.dim,
+      action: 'Check if active — may need to move back to Backlog.',
+    },
+  };
+
+  const groups: Record<AuditBucket, AuditEntry[]> = {
+    active: [],
+    shipped: [],
+    'parent-epic': [],
+    orphan: [],
+    stuck: [],
+  };
+  for (const e of entries) {
+    if (bucketFilter && e.bucket !== bucketFilter) continue;
+    groups[e.bucket].push(e);
+  }
+
+  let out = '';
+  out += `${c.bold}Linear In-Progress audit (${entries.length} issues)${c.reset}\n\n`;
+
+  const order: AuditBucket[] = ['shipped', 'parent-epic', 'orphan', 'stuck', 'active'];
+  for (const bucket of order) {
+    const items = groups[bucket];
+    if (items.length === 0) continue;
+    const meta = bucketMeta[bucket];
+    out += `${meta.color}${c.bold}${meta.label} (${items.length})${c.reset}\n`;
+    out += `${c.dim}${meta.action}${c.reset}\n`;
+    for (const e of items) {
+      out += `  ${meta.color}${e.issue.identifier}${c.reset} — ${e.issue.title}\n`;
+      out += `    ${c.dim}${e.reason}${c.reset}\n`;
+    }
+    out += '\n';
+  }
+
+  const actionable = groups.shipped.length + groups['parent-epic'].length + groups.orphan.length;
+  if (actionable > 0) {
+    out += `${c.bold}${actionable} issue(s) need action.${c.reset} Use ${c.cyan}--bucket=shipped${c.reset}/etc. to filter, ${c.cyan}--fix${c.reset} to auto-close SHIPPED + PARENT EPIC, or ${c.cyan}--json${c.reset} for scripting.\n`;
+  } else {
+    out += `${c.green}✓${c.reset} All In Progress issues look healthy.\n`;
+  }
+
+  if (fix) {
+    const toFix = [...groups.shipped, ...groups['parent-epic']];
+    if (toFix.length === 0) {
+      out += `\n${c.dim}Nothing to fix.${c.reset}\n`;
+    } else {
+      out += `\n${c.bold}Applying fixes (${toFix.length})...${c.reset}\n`;
+      for (const e of toFix) {
+        try {
+          await updateIssueState(e.issue.identifier, 'Done');
+          const prRef = e.mergedPRs[0]
+            ? `\n\n**PR:** ${e.mergedPRs[0].url}`
+            : e.bucket === 'parent-epic'
+              ? '\n\nAll sub-issues resolved.'
+              : '';
+          await commentOnIssue(
+            e.issue.identifier,
+            `🤖 Auto-closed by \`crux linear audit --fix\`: ${e.reason}.${prRef}`,
+          );
+          out += `  ${c.green}✓${c.reset} ${e.issue.identifier} → Done\n`;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          out += `  ${c.red}✗${c.reset} ${e.issue.identifier} — ${msg}\n`;
+        }
+      }
+    }
+  }
+
+  return { output: out, exitCode: 0 };
+}
+
+/**
+ * Watchdog: given a merged PR, ensure its linked Linear issues are actually Done.
+ *
+ * This catches cases where Linear's GitHub integration silently drops a webhook
+ * or the PR body's Fixes line didn't match Linear's parser. Safe to run
+ * repeatedly — it's a no-op if the issues are already Done.
+ */
+async function verifyPr(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const prArg = args.find((a) => !a.startsWith('--'));
+  if (!prArg) {
+    return {
+      output: `${c.red}Usage: crux linear verify-pr <PR_NUMBER>${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+  const prNum = parseInt(prArg.replace(/^#/, ''), 10);
+  if (Number.isNaN(prNum)) {
+    return {
+      output: `${c.red}Invalid PR number: ${prArg}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  interface GhPullResponse {
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    merged: boolean;
+    merged_at: string | null;
+    html_url: string;
+  }
+  const pr = await githubApi<GhPullResponse>(`/repos/quantified-uncertainty/longterm-wiki/pulls/${prNum}`);
+
+  if (!pr.merged) {
+    return {
+      output: `${c.dim}PR #${prNum} not merged — nothing to verify.${c.reset}\n`,
+      exitCode: 0,
+    };
+  }
+
+  const ids = extractFixesIds(pr.body ?? '');
+  if (ids.length === 0) {
+    return {
+      output: `${c.yellow}PR #${prNum} (merged) has no Fixes QUA-NNN refs — cannot verify.${c.reset}\n`,
+      exitCode: 0,
+    };
+  }
+
+  let out = `${c.bold}Verifying PR #${prNum} → ${ids.length} Linear issue(s)${c.reset}\n`;
+  let corrected = 0;
+
+  for (const id of ids) {
+    const issue = await getIssue(id);
+    if (!issue) {
+      out += `  ${c.yellow}?${c.reset} ${id} — not found\n`;
+      continue;
+    }
+    if (issue.state.name === 'Done' || issue.state.name === 'Canceled') {
+      out += `  ${c.green}✓${c.reset} ${id} — already ${issue.state.name}\n`;
+      continue;
+    }
+    try {
+      await updateIssueState(id, 'Done');
+      await commentOnIssue(
+        id,
+        `🤖 State reconciled by watchdog: PR ${pr.html_url} merged but issue was still "${issue.state.name}".`,
+      );
+      out += `  ${c.yellow}→${c.reset} ${id} — ${issue.state.name} → Done (corrected)\n`;
+      corrected += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      out += `  ${c.red}✗${c.reset} ${id} — ${msg}\n`;
+    }
+  }
+
+  if (corrected > 0) {
+    out += `\n${c.yellow}${corrected} issue(s) corrected.${c.reset} Linear's integration likely missed the webhook — PR body or branch name may need clearer refs.\n`;
+  } else {
+    out += `\n${c.green}✓${c.reset} All linked issues already in terminal state.\n`;
+  }
+
+  return { output: out, exitCode: 0 };
+}
+
+/**
+ * Session leak-check: scan the current branch/session for QUA-NNN references
+ * beyond the primary issue, and warn about any that are still In Progress
+ * without a closing PR. Run at /agent-end to catch "touched 3 issues, only
+ * closed 1" patterns.
+ */
+async function leakCheck(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const sources: string[] = [];
+
+  const branch = currentBranch();
+  if (branch) sources.push(branch);
+
+  for (const path of ['.claude/wip-checklist.md', '.claude/wip-context.md']) {
+    if (existsSync(path)) {
+      try {
+        sources.push(readFileSync(path, 'utf-8'));
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  try {
+    const mergeBase = execSync('git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    if (mergeBase) {
+      const commits = execSync(`git log ${mergeBase}..HEAD --format=%B`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+      sources.push(commits);
+    }
+  } catch {
+    // detached, no main, etc. — skip
+  }
+
+  const allIds = new Set<string>();
+  for (const src of sources) {
+    for (const id of findAllLinearIds(src)) allIds.add(id);
+  }
+
+  // The primary issue is the one the session is tracking (from branch or checklist).
+  const primary = parseLinearId(branch ?? '') ?? null;
+
+  const secondary = [...allIds].filter((id) => id !== primary).sort();
+
+  if (secondary.length === 0) {
+    return {
+      output: options.json
+        ? JSON.stringify({ primary, secondary: [], warnings: [] }, null, 2) + '\n'
+        : `${c.green}✓${c.reset} No secondary Linear refs found.${primary ? ` (primary: ${primary})` : ''}\n`,
+      exitCode: 0,
+    };
+  }
+
+  // For each secondary, check Linear state.
+  const warnings: Array<{
+    id: string;
+    state: string;
+    message: string;
+  }> = [];
+
+  for (const id of secondary) {
+    const issue = await getIssue(id);
+    if (!issue) continue;
+    const state = issue.state.name;
+    if (state === 'In Progress') {
+      warnings.push({
+        id,
+        state,
+        message: `referenced in this session but still In Progress — did work leak across issues?`,
+      });
+    } else if (state === 'In Review') {
+      warnings.push({
+        id,
+        state,
+        message: `In Review — confirm its PR is actually open and linked`,
+      });
+    }
+  }
+
+  if (options.json) {
+    return {
+      output: JSON.stringify({ primary, secondary, warnings }, null, 2) + '\n',
+      exitCode: 0,
+    };
+  }
+
+  let out = '';
+  if (primary) out += `${c.dim}Primary session issue: ${primary}${c.reset}\n`;
+  out += `${c.bold}Secondary Linear refs found (${secondary.length}):${c.reset} ${secondary.join(', ')}\n`;
+
+  if (warnings.length === 0) {
+    out += `${c.green}✓${c.reset} All secondary refs are in terminal state or pre-start.\n`;
+  } else {
+    out += `\n${c.yellow}${c.bold}${warnings.length} potential leak(s):${c.reset}\n`;
+    for (const w of warnings) {
+      out += `  ${c.yellow}⚠${c.reset} ${w.id} [${w.state}] — ${w.message}\n`;
+    }
+    out += `\n${c.dim}If these issues should be closed, run: crux linear done <QUA-NNN>${c.reset}\n`;
+    out += `${c.dim}If they should be moved back to Backlog, do so in Linear.${c.reset}\n`;
+  }
+
+  return { output: out, exitCode: 0 };
+}
+
 // ---------------------------------------------------------------------------
 // Command registry
 // ---------------------------------------------------------------------------
@@ -309,6 +631,9 @@ export const commands = {
   create,
   start,
   done,
+  audit,
+  'verify-pr': verifyPr,
+  'leak-check': leakCheck,
   'states-list': statesList,
   parse,
 };
@@ -324,6 +649,9 @@ Commands:
   comment <QUA-NNN> <message>   Post a comment on an issue
   start <QUA-NNN>               Move issue to In Progress + post start comment
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
+  audit                         Classify In Progress issues by PR health (shipped/orphan/epic/active)
+  verify-pr <PR>                Watchdog: ensure merged PR's Fixes QUA-NNN issues are actually Done
+  leak-check                    Scan current session for QUA refs beyond the primary; warn about leaks
   states-list                   Show current QUA team workflow state IDs
   parse <string>                Extract a Linear ID from a string (debug helper)
 
@@ -337,6 +665,11 @@ Options (comment):
 
 Options (done):
   --pr=URL            PR URL to include in the completion comment; moves to In Review
+
+Options (audit):
+  --bucket=<name>     Filter to one bucket: shipped, parent-epic, orphan, stuck, active
+  --fix               Auto-close SHIPPED and PARENT-EPIC issues (move to Done with comment)
+  --json              Machine-readable output
 
 Global options:
   --json              Machine-readable output where supported

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -28,12 +28,14 @@ import {
 import {
   auditInProgress,
   extractFixesIds,
+  STALE_DAYS,
   type AuditBucket,
   type AuditEntry,
 } from '../lib/linear/audit.ts';
 import { githubApi } from '../lib/github.ts';
+import { resolve as resolvePath } from 'path';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
-import { findAllLinearIds, parseLinearId } from '../lib/linear/parse-id.ts';
+import { findAllLinearIds, parseLinearId, resolveLinearId } from '../lib/linear/parse-id.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
@@ -312,6 +314,13 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
   const bucketFilter = args.find((a) => a.startsWith('--bucket='))?.split('=')[1];
   const fix = args.includes('--fix');
 
+  if (fix && options.json) {
+    return {
+      output: `${c.red}--fix and --json cannot be combined. Pick one: --json prints classification, --fix mutates Linear state.${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
   const entries = await auditInProgress();
 
   if (options.json) {
@@ -343,7 +352,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
       action: 'All sub-issues resolved. Close: crux linear done QUA-NNN',
     },
     orphan: {
-      label: `ORPHAN (>${7}d no PR)`,
+      label: `ORPHAN (>${STALE_DAYS}d no PR)`,
       color: c.red,
       action: 'No PR, no activity. Move to Backlog or reassess scope.',
     },
@@ -390,6 +399,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
     out += `${c.green}✓${c.reset} All In Progress issues look healthy.\n`;
   }
 
+  let fixFailures = 0;
   if (fix) {
     const toFix = [...groups.shipped, ...groups['parent-epic']];
     if (toFix.length === 0) {
@@ -399,6 +409,8 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
       for (const e of toFix) {
         try {
           await updateIssueState(e.issue.identifier, 'Done');
+          // mergedPRs is sorted newest-first by classifyPRs() — [0] is the
+          // most recent merge, matching the reason string.
           const prRef = e.mergedPRs[0]
             ? `\n\n**PR:** ${e.mergedPRs[0].url}`
             : e.bucket === 'parent-epic'
@@ -412,12 +424,13 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           out += `  ${c.red}✗${c.reset} ${e.issue.identifier} — ${msg}\n`;
+          fixFailures += 1;
         }
       }
     }
   }
 
-  return { output: out, exitCode: 0 };
+  return { output: out, exitCode: fixFailures > 0 ? 1 : 0 };
 }
 
 /**
@@ -474,6 +487,7 @@ async function verifyPr(args: string[], options: CommandOptions): Promise<Comman
 
   let out = `${c.bold}Verifying PR #${prNum} → ${ids.length} Linear issue(s)${c.reset}\n`;
   let corrected = 0;
+  let failures = 0;
 
   for (const id of ids) {
     const issue = await getIssue(id);
@@ -481,8 +495,12 @@ async function verifyPr(args: string[], options: CommandOptions): Promise<Comman
       out += `  ${c.yellow}?${c.reset} ${id} — not found\n`;
       continue;
     }
-    if (issue.state.name === 'Done' || issue.state.name === 'Canceled') {
-      out += `  ${c.green}✓${c.reset} ${id} — already ${issue.state.name}\n`;
+    // Only reconcile from active workflow states (In Progress / In Review).
+    // If a user has deliberately moved the issue elsewhere — Backlog, Todo,
+    // Canceled, Duplicate, or already Done — respect that. The watchdog's
+    // job is recovering from missed webhooks, not overriding human decisions.
+    if (issue.state.type !== 'started') {
+      out += `  ${c.dim}—${c.reset} ${id} [${issue.state.name}] — not in active state, skipping\n`;
       continue;
     }
     try {
@@ -496,16 +514,17 @@ async function verifyPr(args: string[], options: CommandOptions): Promise<Comman
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       out += `  ${c.red}✗${c.reset} ${id} — ${msg}\n`;
+      failures += 1;
     }
   }
 
   if (corrected > 0) {
     out += `\n${c.yellow}${corrected} issue(s) corrected.${c.reset} Linear's integration likely missed the webhook — PR body or branch name may need clearer refs.\n`;
-  } else {
-    out += `\n${c.green}✓${c.reset} All linked issues already in terminal state.\n`;
+  } else if (failures === 0) {
+    out += `\n${c.green}✓${c.reset} All linked issues already in terminal state or not actively In Progress.\n`;
   }
 
-  return { output: out, exitCode: 0 };
+  return { output: out, exitCode: failures > 0 ? 1 : 0 };
 }
 
 /**
@@ -518,17 +537,35 @@ async function leakCheck(_args: string[], options: CommandOptions): Promise<Comm
   const log = createLogger(options.ci);
   const c = log.colors;
 
+  // Resolve paths relative to the repo root, not process.cwd(), so the
+  // command works correctly when invoked from a nested directory or via a
+  // skill that doesn't cd first.
+  let repoRoot: string;
+  try {
+    repoRoot = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    repoRoot = process.cwd();
+  }
+
   const sources: string[] = [];
+  const skipped: string[] = [];
 
   const branch = currentBranch();
   if (branch) sources.push(branch);
 
-  for (const path of ['.claude/wip-checklist.md', '.claude/wip-context.md']) {
-    if (existsSync(path)) {
+  let checklistContent: string | null = null;
+  for (const rel of ['.claude/wip-checklist.md', '.claude/wip-context.md']) {
+    const abs = resolvePath(repoRoot, rel);
+    if (existsSync(abs)) {
       try {
-        sources.push(readFileSync(path, 'utf-8'));
+        const content = readFileSync(abs, 'utf-8');
+        sources.push(content);
+        if (rel.endsWith('wip-checklist.md')) checklistContent = content;
       } catch {
-        // best-effort
+        skipped.push(rel);
       }
     }
   }
@@ -544,9 +581,11 @@ async function leakCheck(_args: string[], options: CommandOptions): Promise<Comm
         stdio: ['pipe', 'pipe', 'ignore'],
       });
       sources.push(commits);
+    } else {
+      skipped.push('git log (no merge-base with main)');
     }
   } catch {
-    // detached, no main, etc. — skip
+    skipped.push('git log (merge-base lookup failed)');
   }
 
   const allIds = new Set<string>();
@@ -554,18 +593,28 @@ async function leakCheck(_args: string[], options: CommandOptions): Promise<Comm
     for (const id of findAllLinearIds(src)) allIds.add(id);
   }
 
-  // The primary issue is the one the session is tracking (from branch or checklist).
-  const primary = parseLinearId(branch ?? '') ?? null;
+  // Primary issue: prefer an explicit `> Linear: QUA-NNN` line in the checklist
+  // (added by /agent-init), then fall back to the branch name. Mirrors how
+  // /agent-end and /agent-ship resolve the session's tracked issue.
+  const checklistLine = checklistContent
+    ? /^> Linear: (QUA-\d+)/im.exec(checklistContent)?.[1] ?? null
+    : null;
+  const primary = resolveLinearId([checklistLine, branch]);
 
   const secondary = [...allIds].filter((id) => id !== primary).sort();
 
   if (secondary.length === 0) {
-    return {
-      output: options.json
-        ? JSON.stringify({ primary, secondary: [], warnings: [] }, null, 2) + '\n'
-        : `${c.green}✓${c.reset} No secondary Linear refs found.${primary ? ` (primary: ${primary})` : ''}\n`,
-      exitCode: 0,
-    };
+    if (options.json) {
+      return {
+        output: JSON.stringify({ primary, secondary: [], warnings: [], skipped }, null, 2) + '\n',
+        exitCode: 0,
+      };
+    }
+    let out = `${c.green}✓${c.reset} No secondary Linear refs found.${primary ? ` (primary: ${primary})` : ''}\n`;
+    if (skipped.length > 0) {
+      out += `${c.dim}Skipped sources: ${skipped.join(', ')}${c.reset}\n`;
+    }
+    return { output: out, exitCode: 0 };
   }
 
   // For each secondary, check Linear state.
@@ -596,13 +645,14 @@ async function leakCheck(_args: string[], options: CommandOptions): Promise<Comm
 
   if (options.json) {
     return {
-      output: JSON.stringify({ primary, secondary, warnings }, null, 2) + '\n',
+      output: JSON.stringify({ primary, secondary, warnings, skipped }, null, 2) + '\n',
       exitCode: 0,
     };
   }
 
   let out = '';
   if (primary) out += `${c.dim}Primary session issue: ${primary}${c.reset}\n`;
+  if (skipped.length > 0) out += `${c.dim}Skipped sources: ${skipped.join(', ')}${c.reset}\n`;
   out += `${c.bold}Secondary Linear refs found (${secondary.length}):${c.reset} ${secondary.join(', ')}\n`;
 
   if (warnings.length === 0) {

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -490,20 +490,20 @@ async function verifyPr(args: string[], options: CommandOptions): Promise<Comman
   let failures = 0;
 
   for (const id of ids) {
-    const issue = await getIssue(id);
-    if (!issue) {
-      out += `  ${c.yellow}?${c.reset} ${id} — not found\n`;
-      continue;
-    }
-    // Only reconcile from active workflow states (In Progress / In Review).
-    // If a user has deliberately moved the issue elsewhere — Backlog, Todo,
-    // Canceled, Duplicate, or already Done — respect that. The watchdog's
-    // job is recovering from missed webhooks, not overriding human decisions.
-    if (issue.state.type !== 'started') {
-      out += `  ${c.dim}—${c.reset} ${id} [${issue.state.name}] — not in active state, skipping\n`;
-      continue;
-    }
     try {
+      const issue = await getIssue(id);
+      if (!issue) {
+        out += `  ${c.yellow}?${c.reset} ${id} — not found\n`;
+        continue;
+      }
+      // Only reconcile from active workflow states (In Progress / In Review).
+      // If a user has deliberately moved the issue elsewhere — Backlog, Todo,
+      // Canceled, Duplicate, or already Done — respect that. The watchdog's
+      // job is recovering from missed webhooks, not overriding human decisions.
+      if (issue.state.type !== 'started') {
+        out += `  ${c.dim}—${c.reset} ${id} [${issue.state.name}] — not in active state, skipping\n`;
+        continue;
+      }
       await updateIssueState(id, 'Done');
       await commentOnIssue(
         id,

--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { extractFixesIds } from '../audit.ts';
+
+describe('extractFixesIds', () => {
+  it('extracts Fixes QUA-NNN references', () => {
+    const body = `## Summary\n\nFixes QUA-184\nCloses QUA-185\nResolves QUA-186`;
+    expect(extractFixesIds(body)).toEqual(['QUA-184', 'QUA-185', 'QUA-186']);
+  });
+
+  it('is case-insensitive and dedupes', () => {
+    const body = `fixes qua-42\nFixes QUA-42\nFIXES QUA-42`;
+    expect(extractFixesIds(body)).toEqual(['QUA-42']);
+  });
+
+  it('does not match bare QUA-NNN without a keyword', () => {
+    const body = `This is about QUA-999 but not closing it.`;
+    expect(extractFixesIds(body)).toEqual([]);
+  });
+
+  it('returns empty for no matches', () => {
+    expect(extractFixesIds('')).toEqual([]);
+    expect(extractFixesIds('nothing to see')).toEqual([]);
+  });
+
+  it('handles multiple references with mixed separators', () => {
+    const body = `Fixes QUA-1
+      Closes   QUA-2
+Resolves\tQUA-3`;
+    expect(extractFixesIds(body)).toEqual(['QUA-1', 'QUA-2', 'QUA-3']);
+  });
+});

--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { classifyEntry, classifyPRs, extractFixesIds, STALE_DAYS } from '../audit.ts';
-import type { LinearChildIssue, LinearTriageIssue } from '../issues.ts';
+import type { LinearChildIssue, LinearChildrenResult, LinearTriageIssue } from '../issues.ts';
+
+function makeChildrenResult(nodes: LinearChildIssue[], hasMore = false): LinearChildrenResult {
+  return { nodes, hasMore };
+}
 
 function makeIssue(overrides: Partial<LinearTriageIssue> = {}): LinearTriageIssue {
   return {
@@ -118,7 +122,7 @@ describe('classifyEntry — bucket assignment', () => {
       makePr({ number: 10, state: 'open' }),
       makePr({ number: 9, state: 'closed', mergedAt: '2026-04-01T00:00:00Z' }),
     ];
-    const e = classifyEntry(issue, items, []);
+    const e = classifyEntry(issue, items, makeChildrenResult([]));
     expect(e.bucket).toBe('active');
     expect(e.reason).toContain('#10');
   });
@@ -126,7 +130,7 @@ describe('classifyEntry — bucket assignment', () => {
   it('returns SHIPPED when only merged PRs exist', () => {
     const issue = makeIssue();
     const items = [makePr({ number: 5, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' })];
-    const e = classifyEntry(issue, items, []);
+    const e = classifyEntry(issue, items, makeChildrenResult([]));
     expect(e.bucket).toBe('shipped');
     expect(e.reason).toContain('#5');
     expect(e.reason).toContain('merged');
@@ -138,7 +142,7 @@ describe('classifyEntry — bucket assignment', () => {
       makePr({ number: 1, state: 'closed', mergedAt: '2026-04-01T00:00:00Z' }),
       makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
     ];
-    const e = classifyEntry(issue, items, []);
+    const e = classifyEntry(issue, items, makeChildrenResult([]));
     expect(e.reason).toContain('#2');
     expect(e.mergedPRs[0].number).toBe(2);
   });
@@ -149,7 +153,7 @@ describe('classifyEntry — bucket assignment', () => {
       makeChild({ name: 'Done', type: 'completed' }),
       makeChild({ name: 'Canceled', type: 'canceled' }),
     ];
-    const e = classifyEntry(issue, [], children);
+    const e = classifyEntry(issue, [], makeChildrenResult(children));
     expect(e.bucket).toBe('parent-epic');
     expect(e.childCount).toBe(2);
     expect(e.unresolvedChildren).toEqual([]);
@@ -161,33 +165,33 @@ describe('classifyEntry — bucket assignment', () => {
       makeChild({ name: 'Done', type: 'completed' }),
       makeChild({ name: 'In Progress', type: 'started' }),
     ];
-    const e = classifyEntry(issue, [], children);
+    const e = classifyEntry(issue, [], makeChildrenResult(children));
     expect(e.bucket).not.toBe('parent-epic');
     expect(e.unresolvedChildren).toHaveLength(1);
   });
 
   it('returns ORPHAN when stale beyond STALE_DAYS with no PR or children', () => {
     const issue = makeIssue({ updatedAt: daysAgo(STALE_DAYS + 5) });
-    const e = classifyEntry(issue, [], []);
+    const e = classifyEntry(issue, [], makeChildrenResult([]));
     expect(e.bucket).toBe('orphan');
     expect(e.reason).toContain('Backlog');
   });
 
   it('returns STUCK when recent with no PR or children', () => {
     const issue = makeIssue({ updatedAt: daysAgo(1) });
-    const e = classifyEntry(issue, [], []);
+    const e = classifyEntry(issue, [], makeChildrenResult([]));
     expect(e.bucket).toBe('stuck');
   });
 
   it('boundary: exactly STALE_DAYS old is still STUCK, not ORPHAN', () => {
     const issue = makeIssue({ updatedAt: daysAgo(STALE_DAYS) });
-    const e = classifyEntry(issue, [], []);
+    const e = classifyEntry(issue, [], makeChildrenResult([]));
     expect(e.bucket).toBe('stuck');
   });
 
   it('an empty children list does NOT trigger PARENT-EPIC', () => {
     const issue = makeIssue();
-    const e = classifyEntry(issue, [], []);
+    const e = classifyEntry(issue, [], makeChildrenResult([]));
     expect(e.bucket).not.toBe('parent-epic');
   });
 
@@ -198,8 +202,8 @@ describe('classifyEntry — bucket assignment', () => {
       makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
     ];
     const children = [makeChild({ name: 'Done', type: 'completed' })];
-    expect(classifyEntry(issue, items, children).bucket).toBe('active');
-    expect(classifyEntry(issue, [items[1]], children).bucket).toBe('shipped');
-    expect(classifyEntry(issue, [], children).bucket).toBe('parent-epic');
+    expect(classifyEntry(issue, items, makeChildrenResult(children)).bucket).toBe('active');
+    expect(classifyEntry(issue, [items[1]], makeChildrenResult(children)).bucket).toBe('shipped');
+    expect(classifyEntry(issue, [], makeChildrenResult(children)).bucket).toBe('parent-epic');
   });
 });

--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -1,10 +1,65 @@
 import { describe, it, expect } from 'vitest';
-import { extractFixesIds } from '../audit.ts';
+import { classifyEntry, classifyPRs, extractFixesIds, STALE_DAYS } from '../audit.ts';
+import type { LinearChildIssue, LinearTriageIssue } from '../issues.ts';
+
+function makeIssue(overrides: Partial<LinearTriageIssue> = {}): LinearTriageIssue {
+  return {
+    identifier: 'QUA-100',
+    title: 'Test issue',
+    priority: 3,
+    updatedAt: new Date().toISOString(),
+    state: { name: 'In Progress', type: 'started' },
+    assignee: null,
+    parent: null,
+    project: null,
+    labels: { nodes: [] },
+    ...overrides,
+  };
+}
+
+function makePr(overrides: {
+  number?: number;
+  state?: 'open' | 'closed';
+  mergedAt?: string | null;
+  body?: string | null;
+} = {}) {
+  return {
+    number: overrides.number ?? 1,
+    title: 'PR title',
+    html_url: `https://github.com/x/y/pull/${overrides.number ?? 1}`,
+    body: overrides.body ?? null,
+    state: overrides.state ?? 'open',
+    pull_request: { merged_at: overrides.mergedAt ?? null },
+  };
+}
+
+function makeChild(state: { name: string; type: string }): LinearChildIssue {
+  return { identifier: 'QUA-X', title: 'Child', state };
+}
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
 
 describe('extractFixesIds', () => {
-  it('extracts Fixes QUA-NNN references', () => {
+  it('extracts canonical Fixes/Closes/Resolves references', () => {
     const body = `## Summary\n\nFixes QUA-184\nCloses QUA-185\nResolves QUA-186`;
     expect(extractFixesIds(body)).toEqual(['QUA-184', 'QUA-185', 'QUA-186']);
+  });
+
+  it('handles every GitHub auto-close keyword variant', () => {
+    const body = [
+      'close QUA-1', 'closes QUA-2', 'closed QUA-3',
+      'fix QUA-4', 'fixes QUA-5', 'fixed QUA-6',
+      'resolve QUA-7', 'resolves QUA-8', 'resolved QUA-9',
+    ].join('\n');
+    expect(extractFixesIds(body)).toEqual(
+      ['QUA-1','QUA-2','QUA-3','QUA-4','QUA-5','QUA-6','QUA-7','QUA-8','QUA-9'],
+    );
+  });
+
+  it('accepts colon and extra whitespace between keyword and id', () => {
+    const body = `Fixes: QUA-10\nCloses:   QUA-11\nResolved:\tQUA-12`;
+    expect(extractFixesIds(body)).toEqual(['QUA-10', 'QUA-11', 'QUA-12']);
   });
 
   it('is case-insensitive and dedupes', () => {
@@ -17,15 +72,134 @@ describe('extractFixesIds', () => {
     expect(extractFixesIds(body)).toEqual([]);
   });
 
+  it('does not match keyword with no following id', () => {
+    expect(extractFixesIds('Fixes the bug. Closes the discussion.')).toEqual([]);
+  });
+
   it('returns empty for no matches', () => {
     expect(extractFixesIds('')).toEqual([]);
     expect(extractFixesIds('nothing to see')).toEqual([]);
   });
+});
 
-  it('handles multiple references with mixed separators', () => {
-    const body = `Fixes QUA-1
-      Closes   QUA-2
-Resolves\tQUA-3`;
-    expect(extractFixesIds(body)).toEqual(['QUA-1', 'QUA-2', 'QUA-3']);
+describe('classifyPRs', () => {
+  it('separates open and merged PRs', () => {
+    const items = [
+      makePr({ number: 1, state: 'open' }),
+      makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
+      makePr({ number: 3, state: 'closed', mergedAt: null }), // abandoned
+    ];
+    const { openPRs, mergedPRs } = classifyPRs(items);
+    expect(openPRs.map((p) => p.number)).toEqual([1]);
+    expect(mergedPRs.map((p) => p.number)).toEqual([2]);
+  });
+
+  it('sorts merged PRs newest-first', () => {
+    const items = [
+      makePr({ number: 1, state: 'closed', mergedAt: '2026-04-01T00:00:00Z' }),
+      makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
+      makePr({ number: 3, state: 'closed', mergedAt: '2026-04-05T00:00:00Z' }),
+    ];
+    const { mergedPRs } = classifyPRs(items);
+    expect(mergedPRs.map((p) => p.number)).toEqual([2, 3, 1]);
+  });
+
+  it('handles empty input', () => {
+    const { openPRs, mergedPRs } = classifyPRs([]);
+    expect(openPRs).toEqual([]);
+    expect(mergedPRs).toEqual([]);
+  });
+});
+
+describe('classifyEntry — bucket assignment', () => {
+  it('returns ACTIVE when an open PR exists, regardless of merged history', () => {
+    const issue = makeIssue();
+    const items = [
+      makePr({ number: 10, state: 'open' }),
+      makePr({ number: 9, state: 'closed', mergedAt: '2026-04-01T00:00:00Z' }),
+    ];
+    const e = classifyEntry(issue, items, []);
+    expect(e.bucket).toBe('active');
+    expect(e.reason).toContain('#10');
+  });
+
+  it('returns SHIPPED when only merged PRs exist', () => {
+    const issue = makeIssue();
+    const items = [makePr({ number: 5, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' })];
+    const e = classifyEntry(issue, items, []);
+    expect(e.bucket).toBe('shipped');
+    expect(e.reason).toContain('#5');
+    expect(e.reason).toContain('merged');
+  });
+
+  it('SHIPPED reason picks the newest merge when there are multiple', () => {
+    const issue = makeIssue();
+    const items = [
+      makePr({ number: 1, state: 'closed', mergedAt: '2026-04-01T00:00:00Z' }),
+      makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
+    ];
+    const e = classifyEntry(issue, items, []);
+    expect(e.reason).toContain('#2');
+    expect(e.mergedPRs[0].number).toBe(2);
+  });
+
+  it('returns PARENT-EPIC when all sub-issues are resolved', () => {
+    const issue = makeIssue();
+    const children = [
+      makeChild({ name: 'Done', type: 'completed' }),
+      makeChild({ name: 'Canceled', type: 'canceled' }),
+    ];
+    const e = classifyEntry(issue, [], children);
+    expect(e.bucket).toBe('parent-epic');
+    expect(e.childCount).toBe(2);
+    expect(e.unresolvedChildren).toEqual([]);
+  });
+
+  it('does NOT return PARENT-EPIC when at least one sub-issue is still active', () => {
+    const issue = makeIssue();
+    const children = [
+      makeChild({ name: 'Done', type: 'completed' }),
+      makeChild({ name: 'In Progress', type: 'started' }),
+    ];
+    const e = classifyEntry(issue, [], children);
+    expect(e.bucket).not.toBe('parent-epic');
+    expect(e.unresolvedChildren).toHaveLength(1);
+  });
+
+  it('returns ORPHAN when stale beyond STALE_DAYS with no PR or children', () => {
+    const issue = makeIssue({ updatedAt: daysAgo(STALE_DAYS + 5) });
+    const e = classifyEntry(issue, [], []);
+    expect(e.bucket).toBe('orphan');
+    expect(e.reason).toContain('Backlog');
+  });
+
+  it('returns STUCK when recent with no PR or children', () => {
+    const issue = makeIssue({ updatedAt: daysAgo(1) });
+    const e = classifyEntry(issue, [], []);
+    expect(e.bucket).toBe('stuck');
+  });
+
+  it('boundary: exactly STALE_DAYS old is still STUCK, not ORPHAN', () => {
+    const issue = makeIssue({ updatedAt: daysAgo(STALE_DAYS) });
+    const e = classifyEntry(issue, [], []);
+    expect(e.bucket).toBe('stuck');
+  });
+
+  it('an empty children list does NOT trigger PARENT-EPIC', () => {
+    const issue = makeIssue();
+    const e = classifyEntry(issue, [], []);
+    expect(e.bucket).not.toBe('parent-epic');
+  });
+
+  it('priority: open PR beats merged PR beats parent epic', () => {
+    const issue = makeIssue();
+    const items = [
+      makePr({ number: 1, state: 'open' }),
+      makePr({ number: 2, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
+    ];
+    const children = [makeChild({ name: 'Done', type: 'completed' })];
+    expect(classifyEntry(issue, items, children).bucket).toBe('active');
+    expect(classifyEntry(issue, [items[1]], children).bucket).toBe('shipped');
+    expect(classifyEntry(issue, [], children).bucket).toBe('parent-epic');
   });
 });

--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -80,6 +80,24 @@ describe('extractFixesIds', () => {
     expect(extractFixesIds('Fixes the bug. Closes the discussion.')).toEqual([]);
   });
 
+  it('does NOT match when keyword is mid-word (hotfix, postfix, prefix)', () => {
+    // Regression for CodeRabbit critical finding on PR #4229. Without the
+    // leading \b, "hotfix QUA-1" would match `fix QUA-1` and the watchdog
+    // would auto-close the wrong issue.
+    expect(extractFixesIds('hotfix QUA-100')).toEqual([]);
+    expect(extractFixesIds('postfix QUA-200')).toEqual([]);
+    expect(extractFixesIds('prefix QUA-300')).toEqual([]);
+    expect(extractFixesIds('unfixes QUA-400')).toEqual([]);
+    expect(extractFixesIds('foreclosed QUA-500')).toEqual([]);
+  });
+
+  it('still matches at line start, after punctuation, and after whitespace', () => {
+    expect(extractFixesIds('Fixes QUA-1')).toEqual(['QUA-1']);
+    expect(extractFixesIds('See [issue]: closes QUA-2')).toEqual(['QUA-2']);
+    expect(extractFixesIds('. Resolves QUA-3')).toEqual(['QUA-3']);
+    expect(extractFixesIds('(fix QUA-4)')).toEqual(['QUA-4']);
+  });
+
   it('returns empty for no matches', () => {
     expect(extractFixesIds('')).toEqual([]);
     expect(extractFixesIds('nothing to see')).toEqual([]);
@@ -168,6 +186,21 @@ describe('classifyEntry — bucket assignment', () => {
     const e = classifyEntry(issue, [], makeChildrenResult(children));
     expect(e.bucket).not.toBe('parent-epic');
     expect(e.unresolvedChildren).toHaveLength(1);
+  });
+
+  it('does NOT return PARENT-EPIC when child list is truncated, even if all fetched are resolved', () => {
+    // Regression for CodeRabbit major finding on PR #4229. With hasMore=true,
+    // children #101+ might still be active — auto-closing the parent would
+    // be a destructive false positive.
+    const issue = makeIssue({ updatedAt: daysAgo(2) });
+    const children = [
+      makeChild({ name: 'Done', type: 'completed' }),
+      makeChild({ name: 'Done', type: 'completed' }),
+    ];
+    const e = classifyEntry(issue, [], makeChildrenResult(children, true));
+    expect(e.bucket).not.toBe('parent-epic');
+    // Should fall through to stuck/orphan based on age — recent → stuck
+    expect(e.bucket).toBe('stuck');
   });
 
   it('returns ORPHAN when stale beyond STALE_DAYS with no PR or children', () => {

--- a/crux/lib/linear/__tests__/parse-id.test.ts
+++ b/crux/lib/linear/__tests__/parse-id.test.ts
@@ -118,8 +118,17 @@ describe('findAllLinearIds', () => {
     expect(findAllLinearIds('')).toEqual([]);
   });
 
-  it('dedupes case variants to canonical form', () => {
-    const body = 'QUA-1 qua-1 Qua-1';
-    expect(findAllLinearIds(body)).toEqual(['QUA-1']);
+  it('matches lowercase and mixed-case bare tokens, deduped to canonical form', () => {
+    // Commit messages and pasted Linear URL slugs use lowercase commonly,
+    // so findAllLinearIds is intentionally case-insensitive on bare tokens
+    // (unlike parseLinearId which is case-sensitive on bare tokens to avoid
+    // mis-classifying random caps in prose).
+    expect(findAllLinearIds('QUA-1 qua-1 Qua-1')).toEqual(['QUA-1']);
+    expect(findAllLinearIds('only lowercase qua-7 here')).toEqual(['QUA-7']);
+  });
+
+  it('finds multiple distinct ids regardless of case', () => {
+    const body = 'fixed qua-1, then qua-2, finally QUA-3';
+    expect(findAllLinearIds(body).sort()).toEqual(['QUA-1', 'QUA-2', 'QUA-3']);
   });
 });

--- a/crux/lib/linear/__tests__/parse-id.test.ts
+++ b/crux/lib/linear/__tests__/parse-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseLinearId, resolveLinearId } from '../parse-id.ts';
+import { findAllLinearIds, parseLinearId, resolveLinearId } from '../parse-id.ts';
 
 describe('parseLinearId', () => {
   it('extracts ID from a canonical claude branch name', () => {
@@ -99,5 +99,27 @@ describe('resolveLinearId', () => {
   it('returns null when no source has a match', () => {
     expect(resolveLinearId([null, undefined, 'plain text'])).toBeNull();
     expect(resolveLinearId([])).toBeNull();
+  });
+});
+
+describe('findAllLinearIds', () => {
+  it('finds every QUA reference in a multi-line string', () => {
+    const body = `Fixes QUA-100\nAlso touches QUA-200 and QUA-300.\n(see QUA-100 again)`;
+    expect(findAllLinearIds(body).sort()).toEqual(['QUA-100', 'QUA-200', 'QUA-300']);
+  });
+
+  it('includes branch-pattern hits', () => {
+    expect(findAllLinearIds('claude/qua-42-rename')).toContain('QUA-42');
+  });
+
+  it('returns empty for null/undefined/empty', () => {
+    expect(findAllLinearIds(null)).toEqual([]);
+    expect(findAllLinearIds(undefined)).toEqual([]);
+    expect(findAllLinearIds('')).toEqual([]);
+  });
+
+  it('dedupes case variants to canonical form', () => {
+    const body = 'QUA-1 qua-1 Qua-1';
+    expect(findAllLinearIds(body)).toEqual(['QUA-1']);
   });
 });

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -40,25 +40,79 @@ interface GhSearchItem {
   body: string | null;
   state: 'open' | 'closed';
   pull_request?: { merged_at: string | null };
-  closed_at: string | null;
 }
 
 interface GhSearchResponse {
   total_count: number;
+  incomplete_results?: boolean;
   items: GhSearchItem[];
 }
 
-const STALE_DAYS = 7;
+export const STALE_DAYS = 7;
 const RESOLVED_STATE_TYPES = new Set(['completed', 'canceled']);
 
 /**
- * Search GitHub for PRs referencing any of the given Linear IDs in their body
- * or title. One search call covers all IDs at once — GitHub's search API lets
- * you OR terms together, so we can audit 30 issues with a single request.
+ * GitHub auto-close keywords. Mirrors GitHub's documented set verbatim:
+ * https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
  *
- * Falls back to per-issue search if the combined query exceeds GitHub's limit.
+ * Used by both the audit's "shipped" classifier and the verify-pr watchdog,
+ * so the two stay in sync with what GitHub itself recognizes.
  */
-async function searchPRsForIssues(
+const CLOSE_KEYWORDS =
+  'close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved';
+
+/**
+ * Build a regex matching any GitHub-style auto-close reference to `id` in a
+ * PR body. Accepts optional colon and any whitespace between keyword and id
+ * (`Fixes QUA-1`, `Fixed: QUA-1`, `closes\nQUA-1`).
+ *
+ * Escapes the id for regex safety even though current Linear ids are
+ * `[A-Z]+-\d+` and need no escaping — defends against future format changes.
+ */
+function closesReferenceRegex(id: string): RegExp {
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*${escaped}\\b`, 'i');
+}
+
+/**
+ * Limit the number of concurrently-running async tasks. Used to cap fan-out
+ * to Linear and GitHub APIs so the audit doesn't trip rate limits in teams
+ * with hundreds of In Progress issues.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Search GitHub for PRs that auto-close each Linear ID, returning a
+ * `id → PR list` map.
+ *
+ * Strategy: chunk ids into groups of ≤5 (GitHub search rejects queries with
+ * >5 AND/OR/NOT operators) and fire one search per chunk. This stays well
+ * under GitHub's strict 30 req/min cap on `/search/issues`, which a per-id
+ * query strategy blows through immediately on a busy team.
+ *
+ * GitHub's search returns any PR that mentions any of the ids; client-side
+ * we then verify each PR body contains an auto-close keyword reference (not
+ * a bare prose mention like "follow-up to QUA-NNN"), which makes the
+ * classifier robust to GitHub search's tokenization quirks and any operator
+ * precedence ambiguity in the OR-with-qualifier query form.
+ */
+export async function searchPRsForIssues(
   ids: string[],
 ): Promise<Map<string, GhSearchItem[]>> {
   const result = new Map<string, GhSearchItem[]>();
@@ -66,11 +120,13 @@ async function searchPRsForIssues(
 
   if (ids.length === 0) return result;
 
-  // GitHub's search API rejects queries with >5 AND/OR/NOT operators.
-  // 5 ORs means 6 terms max — use 5 to stay safely under the limit.
   const CHUNK = 5;
   for (let i = 0; i < ids.length; i += CHUNK) {
     const chunk = ids.slice(i, i + CHUNK);
+    // Repeat `repo:` and `is:pr` after each id so the qualifiers bind to the
+    // whole expression regardless of GitHub's OR-vs-qualifier precedence —
+    // any GitHub-search query in any documented form treats `is:pr` and
+    // `repo:` as global filters; the OR connects only the bare terms.
     const orClause = chunk.join(' OR ');
     const q = `${orClause} repo:${REPO} is:pr`;
     const encoded = encodeURIComponent(q);
@@ -82,15 +138,31 @@ async function searchPRsForIssues(
       );
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
+      // GitHub's /search/issues caps at 30 req/min — much tighter than the
+      // core API. The audit makes one call per chunk-of-5 issues (so a team
+      // with 100 active issues uses 20 of the 30/min budget per run). On
+      // re-runs in quick succession, surface the rate limit clearly.
+      if (/rate limit exceeded/i.test(msg)) {
+        throw new Error(
+          `GitHub /search/issues rate limit exceeded (30 req/min). Wait ~60s and re-run, or scope down with --bucket=<name>.`,
+        );
+      }
       throw new Error(`GitHub PR search failed: ${msg}`);
+    }
+
+    if (resp.total_count > resp.items.length) {
+      // Surface truncation rather than silently misclassifying a SHIPPED
+      // issue as orphan. 100 results per chunk-of-5 issues is a generous cap;
+      // exceeding it suggests unusual cross-referencing that warrants a glance.
+      console.warn(
+        `[linear audit] chunk ${chunk.join(',')}: GitHub returned ${resp.items.length}/${resp.total_count} PRs (truncated).`,
+      );
     }
 
     for (const item of resp.items) {
       const body = item.body ?? '';
       for (const id of chunk) {
-        // Only count PRs that actually close the issue via Fixes/Closes/Resolves.
-        // A bare mention in prose (e.g. "follow-up to QUA-NNN") is not a close.
-        const closesRe = new RegExp(`(?:Fixes|Closes|Resolves)\\s+${id}\\b`, 'i');
+        const closesRe = closesReferenceRegex(id);
         if (closesRe.test(body)) {
           result.get(id)!.push(item);
         }
@@ -101,7 +173,7 @@ async function searchPRsForIssues(
   return result;
 }
 
-function classifyPRs(items: GhSearchItem[]): {
+export function classifyPRs(items: GhSearchItem[]): {
   openPRs: AuditEntry['openPRs'];
   mergedPRs: AuditEntry['mergedPRs'];
 } {
@@ -121,6 +193,8 @@ function classifyPRs(items: GhSearchItem[]): {
     }
     // closed-but-not-merged PRs are ignored — they represent abandoned attempts
   }
+  // Sort merged newest-first so callers can pick `[0]` and trust it.
+  mergedPRs.sort((a, b) => new Date(b.mergedAt).getTime() - new Date(a.mergedAt).getTime());
   return { openPRs, mergedPRs };
 }
 
@@ -129,16 +203,65 @@ function daysSince(iso: string): number {
   return Math.floor(ms / (1000 * 60 * 60 * 24));
 }
 
+export function classifyEntry(
+  issue: LinearTriageIssue,
+  items: GhSearchItem[],
+  children: LinearChildIssue[],
+): AuditEntry {
+  const { openPRs, mergedPRs } = classifyPRs(items);
+  const unresolvedChildren = children.filter(
+    (c) => !RESOLVED_STATE_TYPES.has(c.state.type),
+  );
+  const daysInactive = daysSince(issue.updatedAt);
+
+  let bucket: AuditBucket;
+  let reason: string;
+
+  if (openPRs.length > 0) {
+    bucket = 'active';
+    const prList = openPRs.map((p) => `#${p.number}`).join(', ');
+    reason = `open PR ${prList}`;
+  } else if (mergedPRs.length > 0) {
+    bucket = 'shipped';
+    // mergedPRs is sorted newest-first by classifyPRs.
+    const latest = mergedPRs[0];
+    reason = `PR #${latest.number} merged ${daysSince(latest.mergedAt)}d ago but state not updated`;
+  } else if (children.length > 0 && unresolvedChildren.length === 0) {
+    bucket = 'parent-epic';
+    reason = `${children.length} sub-issues all resolved — safe to close`;
+  } else if (daysInactive > STALE_DAYS) {
+    bucket = 'orphan';
+    reason = `no PR, no activity in ${daysInactive}d — move to Backlog`;
+  } else {
+    bucket = 'stuck';
+    reason = `no PR yet (${daysInactive}d since last update)`;
+  }
+
+  return {
+    issue,
+    bucket,
+    reason,
+    openPRs,
+    mergedPRs,
+    childCount: children.length,
+    unresolvedChildren,
+    daysInactive,
+  };
+}
+
 /**
  * Fetch In Progress issues and classify each.
  *
- * Concurrency: Linear children queries run in parallel (small, fast).
- * GitHub PR search is batched into chunks of 15 IDs.
+ * Concurrency: Linear children queries run with a small concurrency cap to
+ * stay under Linear's GraphQL rate limits even on teams with many issues.
+ * GitHub PR search runs one query per id with the same cap.
  */
 export async function auditInProgress(): Promise<AuditEntry[]> {
-  // Use state type "started" which includes In Progress AND In Review.
-  // Audit focuses on In Progress — In Review is naturally waiting on PR merge.
-  const all = await listIssuesByStateType(['started'], 100);
+  // Linear's `started` state type covers In Progress AND In Review. Audit
+  // focuses on In Progress — In Review is naturally waiting on PR merge.
+  // Hard cap at 200 to bound concurrent fan-out; teams with more than that
+  // many simultaneously-active issues have bigger problems than this audit.
+  const all = await listIssuesByStateType(['started'], 200);
   const issues = all.filter((i) => i.state.name === 'In Progress');
 
   if (issues.length === 0) return [];
@@ -147,55 +270,16 @@ export async function auditInProgress(): Promise<AuditEntry[]> {
 
   const [prMap, childrenPairs] = await Promise.all([
     searchPRsForIssues(ids),
-    Promise.all(
-      issues.map(async (i) => [i.identifier, await getIssueChildren(i.identifier)] as const),
+    mapWithConcurrency(issues, 5, async (i) =>
+      [i.identifier, await getIssueChildren(i.identifier)] as const,
     ),
   ]);
   const childrenMap = new Map(childrenPairs);
 
   return issues.map((issue) => {
     const items = prMap.get(issue.identifier) ?? [];
-    const { openPRs, mergedPRs } = classifyPRs(items);
     const children = childrenMap.get(issue.identifier) ?? [];
-    const unresolvedChildren = children.filter(
-      (c) => !RESOLVED_STATE_TYPES.has(c.state.type),
-    );
-    const daysInactive = daysSince(issue.updatedAt);
-
-    let bucket: AuditBucket;
-    let reason: string;
-
-    if (openPRs.length > 0) {
-      bucket = 'active';
-      const prList = openPRs.map((p) => `#${p.number}`).join(', ');
-      reason = `open PR ${prList}`;
-    } else if (mergedPRs.length > 0) {
-      bucket = 'shipped';
-      const latest = mergedPRs
-        .slice()
-        .sort((a, b) => (a.mergedAt < b.mergedAt ? 1 : -1))[0];
-      reason = `PR #${latest.number} merged ${daysSince(latest.mergedAt)}d ago but state not updated`;
-    } else if (children.length > 0 && unresolvedChildren.length === 0) {
-      bucket = 'parent-epic';
-      reason = `${children.length} sub-issues all resolved — safe to close`;
-    } else if (daysInactive > STALE_DAYS) {
-      bucket = 'orphan';
-      reason = `no PR, no activity in ${daysInactive}d — move to Backlog`;
-    } else {
-      bucket = 'stuck';
-      reason = `no PR yet (${daysInactive}d since last update)`;
-    }
-
-    return {
-      issue,
-      bucket,
-      reason,
-      openPRs,
-      mergedPRs,
-      childCount: children.length,
-      unresolvedChildren,
-      daysInactive,
-    };
+    return classifyEntry(issue, items, children);
   });
 }
 
@@ -204,11 +288,19 @@ export async function auditInProgress(): Promise<AuditEntry[]> {
 // ---------------------------------------------------------------------------
 
 /**
- * Given a merged PR, return the Linear IDs it closes (from `Fixes QUA-NNN`
- * style lines) and their current state. Used by the post-merge watchdog.
+ * Given a PR body, return the Linear IDs it auto-closes. Mirrors GitHub's
+ * full set of close keywords (`fix|fixes|fixed|close|closes|closed|resolve
+ * |resolves|resolved`) plus an optional colon and any whitespace separator.
+ *
+ * Used by the verify-pr watchdog to know which Linear issues should be Done
+ * after a merge — only IDs explicitly auto-closed are touched, never bare
+ * mentions in prose.
  */
 export function extractFixesIds(prBody: string): string[] {
-  const re = /(?:Fixes|Closes|Resolves)\s+(QUA-\d+)/gi;
+  const re = new RegExp(
+    `(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*(QUA-\\d+)`,
+    'gi',
+  );
   const ids = new Set<string>();
   let m: RegExpExecArray | null;
   while ((m = re.exec(prBody)) !== null) {

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -1,0 +1,218 @@
+/**
+ * Linear In-Progress audit — classify "In Progress" issues by PR health.
+ *
+ * The triage-linear command flags issues by age alone. Audit correlates
+ * Linear state with GitHub PR activity so the report is directly actionable:
+ * which issues are genuinely active, which shipped but the state didn't update,
+ * which are parent epics whose phases all landed, and which are truly orphaned.
+ */
+
+import { githubApi, REPO } from '../github.ts';
+import {
+  getIssueChildren,
+  listIssuesByStateType,
+  type LinearChildIssue,
+  type LinearTriageIssue,
+} from './issues.ts';
+
+export type AuditBucket =
+  | 'active'
+  | 'shipped'
+  | 'parent-epic'
+  | 'orphan'
+  | 'stuck';
+
+export interface AuditEntry {
+  issue: LinearTriageIssue;
+  bucket: AuditBucket;
+  reason: string;
+  openPRs: Array<{ number: number; title: string; url: string }>;
+  mergedPRs: Array<{ number: number; title: string; url: string; mergedAt: string }>;
+  childCount: number;
+  unresolvedChildren: LinearChildIssue[];
+  daysInactive: number;
+}
+
+interface GhSearchItem {
+  number: number;
+  title: string;
+  html_url: string;
+  body: string | null;
+  state: 'open' | 'closed';
+  pull_request?: { merged_at: string | null };
+  closed_at: string | null;
+}
+
+interface GhSearchResponse {
+  total_count: number;
+  items: GhSearchItem[];
+}
+
+const STALE_DAYS = 7;
+const RESOLVED_STATE_TYPES = new Set(['completed', 'canceled']);
+
+/**
+ * Search GitHub for PRs referencing any of the given Linear IDs in their body
+ * or title. One search call covers all IDs at once — GitHub's search API lets
+ * you OR terms together, so we can audit 30 issues with a single request.
+ *
+ * Falls back to per-issue search if the combined query exceeds GitHub's limit.
+ */
+async function searchPRsForIssues(
+  ids: string[],
+): Promise<Map<string, GhSearchItem[]>> {
+  const result = new Map<string, GhSearchItem[]>();
+  for (const id of ids) result.set(id, []);
+
+  if (ids.length === 0) return result;
+
+  // GitHub's search API rejects queries with >5 AND/OR/NOT operators.
+  // 5 ORs means 6 terms max — use 5 to stay safely under the limit.
+  const CHUNK = 5;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const orClause = chunk.join(' OR ');
+    const q = `${orClause} repo:${REPO} is:pr`;
+    const encoded = encodeURIComponent(q);
+
+    let resp: GhSearchResponse;
+    try {
+      resp = await githubApi<GhSearchResponse>(
+        `/search/issues?q=${encoded}&per_page=100`,
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`GitHub PR search failed: ${msg}`);
+    }
+
+    for (const item of resp.items) {
+      const body = item.body ?? '';
+      for (const id of chunk) {
+        // Only count PRs that actually close the issue via Fixes/Closes/Resolves.
+        // A bare mention in prose (e.g. "follow-up to QUA-NNN") is not a close.
+        const closesRe = new RegExp(`(?:Fixes|Closes|Resolves)\\s+${id}\\b`, 'i');
+        if (closesRe.test(body)) {
+          result.get(id)!.push(item);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function classifyPRs(items: GhSearchItem[]): {
+  openPRs: AuditEntry['openPRs'];
+  mergedPRs: AuditEntry['mergedPRs'];
+} {
+  const openPRs: AuditEntry['openPRs'] = [];
+  const mergedPRs: AuditEntry['mergedPRs'] = [];
+  for (const p of items) {
+    const mergedAt = p.pull_request?.merged_at ?? null;
+    if (p.state === 'open') {
+      openPRs.push({ number: p.number, title: p.title, url: p.html_url });
+    } else if (mergedAt) {
+      mergedPRs.push({
+        number: p.number,
+        title: p.title,
+        url: p.html_url,
+        mergedAt,
+      });
+    }
+    // closed-but-not-merged PRs are ignored — they represent abandoned attempts
+  }
+  return { openPRs, mergedPRs };
+}
+
+function daysSince(iso: string): number {
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Fetch In Progress issues and classify each.
+ *
+ * Concurrency: Linear children queries run in parallel (small, fast).
+ * GitHub PR search is batched into chunks of 15 IDs.
+ */
+export async function auditInProgress(): Promise<AuditEntry[]> {
+  // Use state type "started" which includes In Progress AND In Review.
+  // Audit focuses on In Progress — In Review is naturally waiting on PR merge.
+  const all = await listIssuesByStateType(['started'], 100);
+  const issues = all.filter((i) => i.state.name === 'In Progress');
+
+  if (issues.length === 0) return [];
+
+  const ids = issues.map((i) => i.identifier);
+
+  const [prMap, childrenPairs] = await Promise.all([
+    searchPRsForIssues(ids),
+    Promise.all(
+      issues.map(async (i) => [i.identifier, await getIssueChildren(i.identifier)] as const),
+    ),
+  ]);
+  const childrenMap = new Map(childrenPairs);
+
+  return issues.map((issue) => {
+    const items = prMap.get(issue.identifier) ?? [];
+    const { openPRs, mergedPRs } = classifyPRs(items);
+    const children = childrenMap.get(issue.identifier) ?? [];
+    const unresolvedChildren = children.filter(
+      (c) => !RESOLVED_STATE_TYPES.has(c.state.type),
+    );
+    const daysInactive = daysSince(issue.updatedAt);
+
+    let bucket: AuditBucket;
+    let reason: string;
+
+    if (openPRs.length > 0) {
+      bucket = 'active';
+      const prList = openPRs.map((p) => `#${p.number}`).join(', ');
+      reason = `open PR ${prList}`;
+    } else if (mergedPRs.length > 0) {
+      bucket = 'shipped';
+      const latest = mergedPRs
+        .slice()
+        .sort((a, b) => (a.mergedAt < b.mergedAt ? 1 : -1))[0];
+      reason = `PR #${latest.number} merged ${daysSince(latest.mergedAt)}d ago but state not updated`;
+    } else if (children.length > 0 && unresolvedChildren.length === 0) {
+      bucket = 'parent-epic';
+      reason = `${children.length} sub-issues all resolved — safe to close`;
+    } else if (daysInactive > STALE_DAYS) {
+      bucket = 'orphan';
+      reason = `no PR, no activity in ${daysInactive}d — move to Backlog`;
+    } else {
+      bucket = 'stuck';
+      reason = `no PR yet (${daysInactive}d since last update)`;
+    }
+
+    return {
+      issue,
+      bucket,
+      reason,
+      openPRs,
+      mergedPRs,
+      childCount: children.length,
+      unresolvedChildren,
+      daysInactive,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Watchdog: re-verify Linear state after a PR merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a merged PR, return the Linear IDs it closes (from `Fixes QUA-NNN`
+ * style lines) and their current state. Used by the post-merge watchdog.
+ */
+export function extractFixesIds(prBody: string): string[] {
+  const re = /(?:Fixes|Closes|Resolves)\s+(QUA-\d+)/gi;
+  const ids = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(prBody)) !== null) {
+    ids.add(m[1].toUpperCase());
+  }
+  return [...ids];
+}

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -12,6 +12,7 @@ import {
   getIssueChildren,
   listIssuesByStateType,
   type LinearChildIssue,
+  type LinearChildrenResult,
   type LinearTriageIssue,
 } from './issues.ts';
 
@@ -71,7 +72,7 @@ const CLOSE_KEYWORDS =
  */
 function closesReferenceRegex(id: string): RegExp {
   const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*${escaped}\\b`, 'i');
+  return new RegExp(`\\b(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*${escaped}\\b`, 'i');
 }
 
 /**
@@ -206,9 +207,10 @@ function daysSince(iso: string): number {
 export function classifyEntry(
   issue: LinearTriageIssue,
   items: GhSearchItem[],
-  children: LinearChildIssue[],
+  childrenResult: LinearChildrenResult,
 ): AuditEntry {
   const { openPRs, mergedPRs } = classifyPRs(items);
+  const children = childrenResult.nodes;
   const unresolvedChildren = children.filter(
     (c) => !RESOLVED_STATE_TYPES.has(c.state.type),
   );
@@ -226,7 +228,14 @@ export function classifyEntry(
     // mergedPRs is sorted newest-first by classifyPRs.
     const latest = mergedPRs[0];
     reason = `PR #${latest.number} merged ${daysSince(latest.mergedAt)}d ago but state not updated`;
-  } else if (children.length > 0 && unresolvedChildren.length === 0) {
+  } else if (
+    children.length > 0 &&
+    unresolvedChildren.length === 0 &&
+    !childrenResult.hasMore
+  ) {
+    // Only treat a parent as "safe to close" when we've seen the full child
+    // list — otherwise an unfetched child could still be unresolved and
+    // `audit --fix` would close the parent prematurely.
     bucket = 'parent-epic';
     reason = `${children.length} sub-issues all resolved — safe to close`;
   } else if (daysInactive > STALE_DAYS) {
@@ -275,10 +284,11 @@ export async function auditInProgress(): Promise<AuditEntry[]> {
     ),
   ]);
   const childrenMap = new Map(childrenPairs);
+  const emptyChildren: LinearChildrenResult = { nodes: [], hasMore: false };
 
   return issues.map((issue) => {
     const items = prMap.get(issue.identifier) ?? [];
-    const children = childrenMap.get(issue.identifier) ?? [];
+    const children = childrenMap.get(issue.identifier) ?? emptyChildren;
     return classifyEntry(issue, items, children);
   });
 }
@@ -298,7 +308,7 @@ export async function auditInProgress(): Promise<AuditEntry[]> {
  */
 export function extractFixesIds(prBody: string): string[] {
   const re = new RegExp(
-    `(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*(QUA-\\d+)`,
+    `\\b(?:${CLOSE_KEYWORDS})\\b\\s*:?\\s*(QUA-\\d+)`,
     'gi',
   );
   const ids = new Set<string>();

--- a/crux/lib/linear/client.ts
+++ b/crux/lib/linear/client.ts
@@ -117,7 +117,19 @@ export async function linearGraphQL<T = unknown>(
     throw new Error(`Linear GraphQL returned ${resp.status}: ${text}`);
   }
 
-  const result = (await resp.json()) as LinearGraphQLResponse<T>;
+  // Linear occasionally returns an HTML error page (Cloudflare/edge cache
+  // hiccup) with a 200 status. resp.json() then throws SyntaxError with the
+  // raw HTML in the message — surface this as a recognizable error so
+  // callers can fall back gracefully instead of bubbling a multi-KB blob.
+  let result: LinearGraphQLResponse<T>;
+  try {
+    result = (await resp.json()) as LinearGraphQLResponse<T>;
+  } catch (e) {
+    throw new Error(
+      `Linear GraphQL returned non-JSON response (likely an edge-cache HTML error page). ` +
+      `Original error: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
   if (result.errors?.length) {
     const msgs = result.errors.map((e) => e.message).join('; ');
     throw new Error(`Linear GraphQL error: ${msgs}`);

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -329,6 +329,14 @@ export async function getIssueChildren(
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (/Entity not found|EntityNotFound/i.test(msg)) return [];
+    // The audit fans out children fetches in parallel; one bad transient
+    // response (Linear edge-cache HTML, transient 5xx) shouldn't kill the
+    // whole audit. Log and return [] — the worst that happens is a parent
+    // epic doesn't get correctly classified this run.
+    if (/non-JSON response|GraphQL returned 5\d\d/i.test(msg)) {
+      console.warn(`[linear] getIssueChildren(${identifier}) failed transiently: ${msg.slice(0, 200)}`);
+      return [];
+    }
     throw e;
   }
 }

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -289,6 +289,51 @@ export interface LinearTriageIssue {
 }
 
 // ---------------------------------------------------------------------------
+// Children / parent-epic detection
+// ---------------------------------------------------------------------------
+
+export interface LinearChildIssue {
+  identifier: string;
+  title: string;
+  state: { name: string; type: string };
+}
+
+/**
+ * Fetch direct children (sub-issues) of a single Linear issue.
+ *
+ * Used by the audit command to detect parent epics whose sub-issues have
+ * all resolved — the parent can be closed but typically isn't linked to a
+ * PR, so Linear's GitHub integration won't auto-close it.
+ */
+export async function getIssueChildren(
+  identifier: string,
+): Promise<LinearChildIssue[]> {
+  try {
+    const data = await linearGraphQL<{
+      issue: { children: { nodes: LinearChildIssue[] } } | null;
+    }>(
+      `query Children($id: String!) {
+        issue(id: $id) {
+          children(first: 50) {
+            nodes {
+              identifier
+              title
+              state { name type }
+            }
+          }
+        }
+      }`,
+      { id: identifier },
+    );
+    return data.issue?.children.nodes ?? [];
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/Entity not found|EntityNotFound/i.test(msg)) return [];
+    throw e;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // List ready issues (for "next issue" picking)
 // ---------------------------------------------------------------------------
 

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -305,37 +305,55 @@ export interface LinearChildIssue {
  * all resolved — the parent can be closed but typically isn't linked to a
  * PR, so Linear's GitHub integration won't auto-close it.
  */
+export interface LinearChildrenResult {
+  nodes: LinearChildIssue[];
+  /** True if Linear reports more children than were fetched in this query. */
+  hasMore: boolean;
+}
+
 export async function getIssueChildren(
   identifier: string,
-): Promise<LinearChildIssue[]> {
+): Promise<LinearChildrenResult> {
   try {
     const data = await linearGraphQL<{
-      issue: { children: { nodes: LinearChildIssue[] } } | null;
+      issue: {
+        children: {
+          nodes: LinearChildIssue[];
+          pageInfo: { hasNextPage: boolean };
+        };
+      } | null;
     }>(
       `query Children($id: String!) {
         issue(id: $id) {
-          children(first: 50) {
+          children(first: 100) {
             nodes {
               identifier
               title
               state { name type }
             }
+            pageInfo { hasNextPage }
           }
         }
       }`,
       { id: identifier },
     );
-    return data.issue?.children.nodes ?? [];
+    const children = data.issue?.children;
+    return {
+      nodes: children?.nodes ?? [],
+      hasMore: children?.pageInfo.hasNextPage ?? false,
+    };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (/Entity not found|EntityNotFound/i.test(msg)) return [];
+    if (/Entity not found|EntityNotFound/i.test(msg)) {
+      return { nodes: [], hasMore: false };
+    }
     // The audit fans out children fetches in parallel; one bad transient
-    // response (Linear edge-cache HTML, transient 5xx) shouldn't kill the
-    // whole audit. Log and return [] — the worst that happens is a parent
-    // epic doesn't get correctly classified this run.
-    if (/non-JSON response|GraphQL returned 5\d\d/i.test(msg)) {
+    // response (Linear edge-cache HTML, transient 5xx, 15s timeout) shouldn't
+    // kill the whole audit. Log and return an empty result flagged as
+    // incomplete so callers know not to treat it as "all children resolved".
+    if (/non-JSON response|GraphQL returned 5\d\d|timed out/i.test(msg)) {
       console.warn(`[linear] getIssueChildren(${identifier}) failed transiently: ${msg.slice(0, 200)}`);
-      return [];
+      return { nodes: [], hasMore: true };
     }
     throw e;
   }

--- a/crux/lib/linear/parse-id.ts
+++ b/crux/lib/linear/parse-id.ts
@@ -60,6 +60,25 @@ export function parseLinearId(input: string | null | undefined): string | null {
 }
 
 /**
+ * Find *all* Linear IDs in an unstructured string (git log, PR body, checklist).
+ * Deduplicated and case-normalized. Branch-pattern hits are included.
+ */
+export function findAllLinearIds(input: string | null | undefined): string[] {
+  if (!input) return [];
+  const ids = new Set<string>();
+  const bareGlobal = new RegExp(BARE_ID_RE.source, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = bareGlobal.exec(input)) !== null) {
+    ids.add(`${m[1].toUpperCase()}-${m[2]}`);
+  }
+  const branchGlobal = new RegExp(BRANCH_ID_RE.source, 'gi');
+  while ((m = branchGlobal.exec(input)) !== null) {
+    ids.add(`${m[1].toUpperCase()}-${m[2]}`);
+  }
+  return [...ids];
+}
+
+/**
  * Parse a Linear ID from several sources, preferring earlier ones.
  * Designed for session-init: branch name first, then task description.
  */

--- a/crux/lib/linear/parse-id.ts
+++ b/crux/lib/linear/parse-id.ts
@@ -61,12 +61,20 @@ export function parseLinearId(input: string | null | undefined): string | null {
 
 /**
  * Find *all* Linear IDs in an unstructured string (git log, PR body, checklist).
- * Deduplicated and case-normalized. Branch-pattern hits are included.
+ * Deduplicated and case-normalized to canonical form (`QUA-N`).
+ *
+ * Matches lowercase (`qua-1`) and mixed-case (`Qua-1`) bare tokens too —
+ * commit messages, Linear URL slugs, and pasted refs use lowercase commonly.
+ * Branch-pattern hits are also included.
  */
 export function findAllLinearIds(input: string | null | undefined): string[] {
   if (!input) return [];
   const ids = new Set<string>();
-  const bareGlobal = new RegExp(BARE_ID_RE.source, 'g');
+  // Case-insensitive bare token match. The original `parseLinearId` is
+  // case-sensitive on bare tokens to avoid mis-classifying random caps in
+  // prose, but for *finding all* refs in a multi-line corpus, lowercase
+  // matches are usually intentional copy-paste from URLs.
+  const bareGlobal = new RegExp(BARE_ID_RE.source, 'gi');
   let m: RegExpExecArray | null;
   while ((m = bareGlobal.exec(input)) !== null) {
     ids.add(`${m[1].toUpperCase()}-${m[2]}`);


### PR DESCRIPTION
## Summary

Adds four pieces of upkeep tooling for the Linear-GitHub integration to catch issues that get stuck in "In Progress" after a PR ships, after a parent epic's children all close, or because a session leaked refs.

- **`crux linear audit`** — classifies In Progress issues into 5 buckets by correlating Linear state with GitHub PR activity (`Fixes/Closes/Resolves QUA-NNN` matches): SHIPPED (PR merged but state stuck), PARENT-EPIC (sub-issues all resolved), ORPHAN (>7d no PR), STUCK (recent, no PR), ACTIVE. Flags: `--bucket=<name>`, `--json`, `--fix` (auto-close SHIPPED + epics, mutually exclusive with `--json`).
- **`crux linear verify-pr <PR>`** — post-merge watchdog. Reads a merged PR, extracts linked Linear IDs, reconciles state. Only acts on issues in `started` state type (In Progress / In Review) to avoid overriding deliberate Backlog/Todo decisions.
- **`crux linear leak-check`** — scans branch name, `.claude/wip-*` files, and commit messages for `QUA-NNN` references beyond the primary issue. Wired into `/agent-end` Step 2a as advisory (never blocks session end). Resolves paths via `git rev-parse --show-toplevel` so it works from any cwd.
- **`/admin-setup` Section 4b** — calls the audit for SHIPPED + PARENT-EPIC buckets and surfaces counts with one-line fix commands so coordinator sessions see actionable cleanups on every cycle start.

### Real findings on first run

- QUA-297 (Health-Gate Patrol parent) — 3 sub-issues all resolved → PARENT EPIC
- QUA-160, QUA-203 — PRs merged days ago, state still In Progress → SHIPPED
- 4 STUCK issues with no closing PR (to triage)
- 17 ACTIVE correctly tied to open PRs

## Robustness

- All 9 GitHub auto-close keyword variants supported (`close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved`) plus optional colon and any whitespace separator. Earlier draft missed 6/9 forms — caught by `/agent-review-pr`.
- Linear children fan-out capped via `mapWithConcurrency(limit=5)` to stay under Linear's GraphQL rate limits on busy teams.
- GitHub PR search chunked into 5-OR groups to stay under `/search/issues`'s 30 req/min cap; rate limit responses surface as a friendly error.
- Linear client recognizes non-JSON edge-cache HTML responses (occasional Cloudflare hiccup) and surfaces them clearly; `getIssueChildren` swallows transient errors so one bad response doesn't kill an audit run.
- `audit --fix` and `verify-pr` return non-zero exit code on any close failure so CI wrappers can detect drift.
- `--fix` and `--json` are mutually exclusive (rejected with usage error) so one doesn't silently shadow the other.

## Test plan

- [x] `npx vitest run crux/lib/linear/` — 117 tests pass (added 20 new tests including all GitHub keyword variants, classifyEntry buckets, STALE_DAYS boundary, priority ordering)
- [x] `pnpm crux linear audit` — verified 5-bucket classification on real Linear data, SHIPPED/PARENT-EPIC/ACTIVE all detected correctly
- [x] `pnpm crux linear audit --bucket=shipped` and `--bucket=parent-epic` — bucket filter works
- [x] `pnpm crux linear audit --json --fix` — correctly rejected with usage error
- [x] `pnpm crux linear verify-pr 4220` — correctly skips Done state without touching it
- [x] `pnpm crux linear leak-check` — finds secondary refs from commit messages
- [x] `pnpm build` — passes
- [x] `pnpm test` — 5751 tests pass
- [x] `pnpm crux w validate gate --fix --no-cache` — 46/46 blocking checks pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — 0 new errors in linear/ files

## Review

Ran `/agent-review-pr` (adaptive). Hostile diff review found 5 HIGH, 9 MEDIUM, 13 LOW; the second commit on this branch addresses the 5 HIGH and 7 of the MEDIUM findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three Linear CLI commands: audit, verify-pr, and leak-check to help find and reconcile “In Progress” issues and secondary references.
  * Improved issue classification by correlating PR activity and parent-epic resolution.

* **Tests**
  * Added comprehensive tests covering audit logic and multi-ID Linear identifier detection.

* **Bug Fixes**
  * Improved handling of non-JSON responses from the Linear API.

* **Documentation**
  * Updated workflows with new audit and leak-check guidance and actionable follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->