### PR TITLE
fix(QUA-327): missing comma in /api/sourcing/entity-summary CTEs

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-entity-summary.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-entity-summary.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { type SqlDispatcher, mockDbModule } from "./test-utils";
+
+// Capture every SQL query the route dispatches so we can assert on its shape.
+let capturedQueries: string[] = [];
+
+const dispatch: SqlDispatcher = (query, _params) => {
+  capturedQueries.push(query);
+  // Entity-summary returns a list of rows; an empty array is a valid response.
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+describe("GET /api/sourcing/entity-summary", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns 200 with an empty summaries array when no rows exist", async () => {
+    const res = await app.request("/api/sourcing/entity-summary");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { summaries: unknown[] };
+    expect(body).toEqual({ summaries: [] });
+  });
+
+  it("dispatches a syntactically valid CTE query (regression for QUA-327)", async () => {
+    // QUA-327: the entity-summary handler had a SQL syntax error — a missing
+    // comma between the `record_counts` and `all_entities` CTEs caused the
+    // endpoint to 500 with a Postgres syntax error. Guard against the exact
+    // pattern coming back.
+    await app.request("/api/sourcing/entity-summary");
+
+    const cteQueries = capturedQueries.filter(
+      (q) => q.includes("verdict_counts") && q.includes("all_entities"),
+    );
+    expect(cteQueries.length).toBeGreaterThan(0);
+
+    for (const q of cteQueries) {
+      // The fix: the closing `)` of `record_counts` MUST be followed by a
+      // comma before `all_entities AS (`, not directly by `all_entities`.
+      expect(
+        /\)\s+all_entities\s+AS\s*\(/i.test(q),
+        `entity-summary query has a missing-comma bug between CTEs:\n${q}`,
+      ).toBe(false);
+      expect(
+        /\)\s*,\s*all_entities\s+AS\s*\(/i.test(q),
+        `entity-summary query is missing the comma before all_entities CTE:\n${q}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -1758,7 +1758,7 @@ const sourcingApp = new Hono()
         JOIN things t2 ON t1.parent_thing_id = t2.id
         WHERE t2.thing_type = 'entity'
         GROUP BY t2.source_id
-      )
+      ),
       all_entities AS (
         SELECT entity_id FROM verdict_counts
         UNION


### PR DESCRIPTION
## Summary

`GET /api/sourcing/entity-summary` has been returning 500 in prod since commit `f47939306` (2026-04-05). The query declared two adjacent CTEs without a comma between them:

```sql
record_counts AS (
  ...
)              -- ❌ missing comma
all_entities AS (
  SELECT entity_id FROM verdict_counts
  ...
)
```

Postgres rejects this as a syntax error, so the `/internal/entities` dashboard's per-entity sourcing summary has been silently broken for ~7 days. The fix is a single character — adding the missing comma.

## What changed

- `apps/wiki-server/src/routes/sourcing/sourcing.ts` — added the missing `,` between `record_counts` and `all_entities`.
- `apps/wiki-server/src/__tests__/sourcing-entity-summary.test.ts` — new regression test that mocks the DB, captures the dispatched SQL, and asserts the CTE list is properly comma-separated. Verified the test fails when the comma is removed.

## Notes on the Linear issue

The Linear issue's reproduction (`?entityId=anthropic`) is slightly off — the endpoint takes no query params and returns ALL entities in one shot. The 500 happened on every call regardless of parameters. The dashboard at `/internal/entities` is the visible casualty.

## Test plan

- [x] `pnpm test` (wiki-server) — 988 tests pass including the new regression
- [x] `tsc --noEmit` clean
- [x] Validation gate passes
- [ ] After merge: verify `/internal/entities` shows non-zero sourcing columns for entities

Closes QUA-327
