### PR TITLE
QUA-313 sub-PR 2: sourcing-sample-coverage CLI (heuristic hit-rate reporter)

### DIFF
--- a/crux/commands/sourcing-sample-coverage.test.ts
+++ b/crux/commands/sourcing-sample-coverage.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for `crux sourcing-sample-coverage` pure helpers.
+ *
+ * Focus: parseSampleSize, parseSeed, createRng (mulberry32 properties),
+ * sampleWithoutReplacement (no replacement + reproducibility), and
+ * computeCoverageStats (bucketing, gate verdict, byDomain sorting).
+ *
+ * The command's control flow (loadResourcesPGFirst + flag handling) is
+ * verified by running against prod data manually; these tests pin down the
+ * pure logic so regressions are caught mechanically.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSampleSize,
+  parseSeed,
+  createRng,
+  sampleWithoutReplacement,
+  computeCoverageStats,
+} from './sourcing-sample-coverage.ts';
+
+// ── parseSampleSize ─────────────────────────────────────────────────
+
+describe('parseSampleSize', () => {
+  it('returns default 500 when omitted', () => {
+    expect(parseSampleSize(undefined)).toBe(500);
+  });
+
+  it('parses numeric string', () => {
+    expect(parseSampleSize('100')).toBe(100);
+    expect(parseSampleSize('2500')).toBe(2500);
+  });
+
+  it('clamps above MAX_SAMPLE_SIZE (5000)', () => {
+    expect(parseSampleSize('99999')).toBe(5000);
+    expect(parseSampleSize('5001')).toBe(5000);
+  });
+
+  it('returns default on non-numeric input', () => {
+    expect(parseSampleSize('abc')).toBe(500);
+    expect(parseSampleSize('')).toBe(500);
+    expect(parseSampleSize(null)).toBe(500);
+  });
+
+  it('returns default on zero or negative', () => {
+    expect(parseSampleSize('0')).toBe(500);
+    expect(parseSampleSize('-10')).toBe(500);
+    expect(parseSampleSize(-10)).toBe(500);
+  });
+
+  it('accepts numeric value directly', () => {
+    expect(parseSampleSize(1000)).toBe(1000);
+  });
+});
+
+// ── parseSeed ───────────────────────────────────────────────────────
+
+describe('parseSeed', () => {
+  it('returns null when omitted', () => {
+    expect(parseSeed(undefined)).toBeNull();
+    expect(parseSeed(null)).toBeNull();
+    expect(parseSeed('')).toBeNull();
+  });
+
+  it('parses numeric strings to uint32', () => {
+    expect(parseSeed('0')).toBe(0);
+    expect(parseSeed('1')).toBe(1);
+    expect(parseSeed('42')).toBe(42);
+    expect(parseSeed('4294967295')).toBe(4294967295);
+  });
+
+  it('returns null on non-numeric input', () => {
+    expect(parseSeed('abc')).toBeNull();
+    expect(parseSeed('1.5')).toBe(1); // parseInt truncates
+  });
+
+  it('returns null on negative input', () => {
+    expect(parseSeed('-1')).toBeNull();
+    expect(parseSeed(-5)).toBeNull();
+  });
+});
+
+// ── createRng (mulberry32) ──────────────────────────────────────────
+
+describe('createRng', () => {
+  it('produces the same sequence for the same seed', () => {
+    const a = createRng(42);
+    const b = createRng(42);
+    for (let i = 0; i < 10; i++) {
+      expect(a()).toBe(b());
+    }
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = createRng(1);
+    const b = createRng(2);
+    const firstA = a();
+    const firstB = b();
+    expect(firstA).not.toBe(firstB);
+  });
+
+  it('returns floats in [0, 1)', () => {
+    const rng = createRng(12345);
+    for (let i = 0; i < 1000; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('seed 0 is distinct from seed 1 (no off-by-one weirdness)', () => {
+    const a = createRng(0);
+    const b = createRng(1);
+    expect(a()).not.toBe(b());
+  });
+});
+
+// ── sampleWithoutReplacement ────────────────────────────────────────
+
+describe('sampleWithoutReplacement', () => {
+  const pool = Array.from({ length: 100 }, (_, i) => i);
+
+  it('returns exactly sampleSize items when pool >= sampleSize', () => {
+    const result = sampleWithoutReplacement(pool, 10, createRng(1));
+    expect(result).toHaveLength(10);
+  });
+
+  it('returns no duplicates (true "without replacement")', () => {
+    const result = sampleWithoutReplacement(pool, 50, createRng(1));
+    expect(new Set(result).size).toBe(50);
+  });
+
+  it('returns pool.length items when sampleSize >= pool.length', () => {
+    const result = sampleWithoutReplacement(pool, 500, createRng(1));
+    expect(result).toHaveLength(100);
+    // Every element in pool is present exactly once
+    expect(new Set(result)).toEqual(new Set(pool));
+  });
+
+  it('returns empty for empty pool', () => {
+    expect(sampleWithoutReplacement([], 10, createRng(1))).toEqual([]);
+  });
+
+  it('returns empty for zero sample size', () => {
+    expect(sampleWithoutReplacement(pool, 0, createRng(1))).toEqual([]);
+  });
+
+  it('returns empty for negative sample size', () => {
+    expect(sampleWithoutReplacement(pool, -5, createRng(1))).toEqual([]);
+  });
+
+  it('does not mutate the input pool', () => {
+    const copy = [...pool];
+    sampleWithoutReplacement(pool, 50, createRng(1));
+    expect(pool).toEqual(copy);
+  });
+
+  it('is deterministic for the same seed', () => {
+    const a = sampleWithoutReplacement(pool, 30, createRng(42));
+    const b = sampleWithoutReplacement(pool, 30, createRng(42));
+    expect(a).toEqual(b);
+  });
+
+  it('produces different samples for different seeds', () => {
+    const a = sampleWithoutReplacement(pool, 30, createRng(1));
+    const b = sampleWithoutReplacement(pool, 30, createRng(2));
+    expect(a).not.toEqual(b);
+  });
+
+  it('falls back to Math.random when rng is null', () => {
+    const result = sampleWithoutReplacement(pool, 10, null);
+    expect(result).toHaveLength(10);
+    expect(new Set(result).size).toBe(10);
+  });
+
+  it('distribution: samples a single element uniformly (rough check)', () => {
+    const counts = new Map<number, number>();
+    for (let i = 0; i < 10000; i++) {
+      const [picked] = sampleWithoutReplacement(pool, 1, createRng(i));
+      counts.set(picked, (counts.get(picked) ?? 0) + 1);
+    }
+    // Every element in the 100-item pool should have been picked at least once.
+    expect(counts.size).toBe(100);
+    // No single element should dominate (>2x uniform).
+    for (const cnt of counts.values()) {
+      expect(cnt).toBeLessThan(200);
+    }
+  });
+});
+
+// ── computeCoverageStats ────────────────────────────────────────────
+
+describe('computeCoverageStats', () => {
+  it('counts fast-path hits for bare-domain URLs', () => {
+    const sample = [
+      { url: 'https://anthropic.com/' },
+      { url: 'https://openai.com/' },
+      { url: 'https://example.com/' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.sampled).toBe(3);
+    expect(stats.fastPathHits).toBe(3);
+    expect(stats.fastPathHitRate).toBe(1.0);
+    expect(stats.meetsThreshold).toBe(true);
+  });
+
+  it('does NOT count deep URLs as fast-path hits', () => {
+    const sample = [
+      { url: 'https://example.com/blog/2024/post' },
+      { url: 'https://example.com/team/jane-doe' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.fastPathHits).toBe(0);
+    expect(stats.flagHits).toBe(0);
+  });
+
+  it('computes hit rate correctly on mixed input', () => {
+    const sample = [
+      { url: 'https://anthropic.com/' },        // fast-path
+      { url: 'https://openai.com/' },           // fast-path
+      { url: 'https://openai.com/about' },      // fast-path (flag=0.85, fp=0.85)
+      { url: 'https://example.com/blog/post' }, // not
+      { url: 'https://arxiv.org/abs/2301.00001' }, // not
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.fastPathHits).toBe(3);
+    expect(stats.fastPathHitRate).toBeCloseTo(0.6, 5);
+    expect(stats.meetsThreshold).toBe(true);
+  });
+
+  it('triggers STOP verdict below the 40% gate', () => {
+    const sample = [
+      { url: 'https://example.com/' },          // 1 fast-path
+      { url: 'https://example.com/blog/post' }, // 4 non-hits
+      { url: 'https://example.com/team/jane' },
+      { url: 'https://example.com/docs/api' },
+      { url: 'https://arxiv.org/abs/2301' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.fastPathHitRate).toBeCloseTo(0.2, 5);
+    expect(stats.meetsThreshold).toBe(false);
+  });
+
+  it('respects a custom gate threshold', () => {
+    const sample = [
+      { url: 'https://example.com/' },
+      { url: 'https://example.com/blog/post' },
+    ];
+    // 50% hit rate
+    expect(computeCoverageStats(sample, 0.4).meetsThreshold).toBe(true);
+    expect(computeCoverageStats(sample, 0.6).meetsThreshold).toBe(false);
+  });
+
+  it('counts unparseable URLs separately', () => {
+    const sample = [
+      { url: 'not a url' },
+      { url: 'https://example.com/' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.unparseable).toBe(1);
+    expect(stats.fastPathHits).toBe(1);
+  });
+
+  it('counts empty URL as unparseable', () => {
+    const sample = [
+      { url: '' },
+      { url: 'https://example.com/' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.unparseable).toBe(1);
+    expect(stats.fastPathHits).toBe(1);
+  });
+
+  it('tracks nullPurposeButConfident for PDFs', () => {
+    const sample = [
+      { url: 'https://example.com/report.pdf' }, // PDF: purpose=null, confidence=0.9
+      { url: 'https://example.com/' },           // fast-path
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.nullPurposeButConfident).toBe(1);
+    expect(stats.fastPathHits).toBe(1);
+  });
+
+  it('byDomain sorted by fast-path hit count descending', () => {
+    const sample = [
+      { url: 'https://anthropic.com/' },
+      { url: 'https://anthropic.com/about' },
+      { url: 'https://anthropic.com/contact' },
+      { url: 'https://openai.com/' },
+      { url: 'https://openai.com/about' },
+      { url: 'https://google.com/' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.byDomain[0].host).toBe('anthropic.com');
+    expect(stats.byDomain[0].fastPathHits).toBe(3);
+    expect(stats.byDomain[1].host).toBe('openai.com');
+    expect(stats.byDomain[1].fastPathHits).toBe(2);
+    expect(stats.byDomain[2].host).toBe('google.com');
+  });
+
+  it('byDomain filters out domains with zero fast-path hits', () => {
+    const sample = [
+      { url: 'https://example.com/' },               // anthropic.com has 0 hits
+      { url: 'https://arxiv.org/abs/2301.00001' },   // arxiv has 0 hits (deep path)
+    ];
+    const stats = computeCoverageStats(sample);
+    // example.com had a fast-path hit; arxiv.org has 0 — filtered out
+    expect(stats.byDomain.map((d) => d.host)).toEqual(['example.com']);
+  });
+
+  it('normalizes www. prefix for domain grouping', () => {
+    const sample = [
+      { url: 'https://www.anthropic.com/' },
+      { url: 'https://anthropic.com/' },
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.byDomain).toHaveLength(1);
+    expect(stats.byDomain[0].host).toBe('anthropic.com');
+    expect(stats.byDomain[0].fastPathHits).toBe(2);
+  });
+
+  it('handles empty sample gracefully', () => {
+    const stats = computeCoverageStats([]);
+    expect(stats.sampled).toBe(0);
+    expect(stats.fastPathHits).toBe(0);
+    expect(stats.fastPathHitRate).toBe(0);
+    expect(stats.meetsThreshold).toBe(false);
+    expect(stats.byDomain).toEqual([]);
+  });
+
+  it('handles URLs with tracking params alone as homepage', () => {
+    // utm_* params should not disqualify a bare domain from being a homepage
+    const sample = [{ url: 'https://example.com/?utm_source=x' }];
+    const stats = computeCoverageStats(sample);
+    expect(stats.fastPathHits).toBe(1);
+  });
+
+  it('does NOT count URLs with data-like query params as homepage', () => {
+    const sample = [
+      { url: 'https://example.com/?id=42' },  // data param → not homepage
+      { url: 'https://youtube.com/?v=abc' },   // data param → not homepage
+    ];
+    const stats = computeCoverageStats(sample);
+    expect(stats.fastPathHits).toBe(0);
+  });
+});

--- a/crux/commands/sourcing-sample-coverage.ts
+++ b/crux/commands/sourcing-sample-coverage.ts
@@ -1,0 +1,375 @@
+/**
+ * Source-Check URL Heuristic — Sample Coverage Reporter
+ *
+ * Read-only. Samples N resources from the wiki-server list (or the local PG
+ * snapshot as a fallback), runs `classifyByUrl` on each URL, and reports:
+ *
+ *   - fast-path hit rate (confidence >= FAST_PATH_THRESHOLD, 0.8)
+ *   - flag-threshold hit rate (confidence >= FLAG_THRESHOLD, 0.7)
+ *   - domain breakdown of fast-path hits
+ *   - whether the fast-path hit rate meets the Phase 3 backfill gate (>= 40%)
+ *
+ * The backfill gate exists because the `backfill-resource-purpose` script
+ * (sub-PR 4) will spend real LLM budget on the residual LLM-classify load.
+ * At a 40% heuristic hit rate, ~12k of 20k resources still need an LLM call.
+ * Below 40%, we stop and improve the heuristic before committing the $.
+ *
+ * Phase 3 sub-PR 2 of QUA-313 / Discussion #4221. No writes, no LLM calls,
+ * no wiki-server mutations. Safe to run repeatedly.
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { loadResourcesPGFirst } from '../resource-io.ts';
+import { classifyByUrl } from './sourcing-audit-urls.ts';
+import type { Resource } from '../resource-types.ts';
+
+// ── Module constants ────────────────────────────────────────────────
+
+/** Default sample size. Matches the ≥40% gate's statistical comfort zone. */
+const DEFAULT_SAMPLE_SIZE = 500;
+const MAX_SAMPLE_SIZE = 5000;
+
+/** Gate threshold for the Phase 3 backfill — below this, improve the heuristic. */
+const BACKFILL_GATE_THRESHOLD = 0.4;
+
+/** Confidence cutoffs — must match `crux/lib/sourcing/url-quality.ts`. */
+const FAST_PATH_THRESHOLD = 0.8;
+const FLAG_THRESHOLD = 0.7;
+
+/** Truncation limits for human-readable mode only. */
+const TOP_DOMAINS_SHOWN = 20;
+
+// ── ANSI helpers ────────────────────────────────────────────────────
+
+function useColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  return !!process.stdout.isTTY;
+}
+
+const ANSI = {
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+} as const;
+
+const bold = (s: string) => (useColor() ? `${ANSI.bold}${s}${ANSI.reset}` : s);
+const green = (s: string) => (useColor() ? `${ANSI.green}${s}${ANSI.reset}` : s);
+const yellow = (s: string) => (useColor() ? `${ANSI.yellow}${s}${ANSI.reset}` : s);
+const red = (s: string) => (useColor() ? `${ANSI.red}${s}${ANSI.reset}` : s);
+
+// ── Pure helpers (exported for tests) ───────────────────────────────
+
+/** Parse and clamp a user-supplied `--sample-size`. */
+export function parseSampleSize(raw: unknown): number {
+  if (raw === undefined) return DEFAULT_SAMPLE_SIZE;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_SAMPLE_SIZE;
+  return Math.min(n, MAX_SAMPLE_SIZE);
+}
+
+/**
+ * Parse a user-supplied --seed into a uint32 RNG seed. Returns null when
+ * omitted so the caller falls back to Math.random.
+ */
+export function parseSeed(raw: unknown): number | null {
+  if (raw === undefined || raw === null || raw === '') return null;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n >>> 0;
+}
+
+/**
+ * Deterministic uint32 RNG — mulberry32. Used only when `--seed` is given
+ * so the sample is reproducible across runs for the same dataset.
+ */
+export function createRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return function mulberry32(): number {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Fisher–Yates partial sample. Returns `min(sampleSize, pool.length)` items
+ * without replacement. If `rng` is `null`, uses `Math.random`.
+ *
+ * Deterministic when called with a mulberry32 RNG of fixed seed. Operates on
+ * a copy of the pool so the caller's array is untouched.
+ */
+export function sampleWithoutReplacement<T>(
+  pool: readonly T[],
+  sampleSize: number,
+  rng: (() => number) | null,
+): T[] {
+  const rand = rng ?? Math.random;
+  const n = Math.min(sampleSize, pool.length);
+  if (n <= 0) return [];
+  // Copy so we don't mutate the caller's array; FY is O(n) swaps in-place on the copy.
+  const arr = [...pool];
+  for (let i = 0; i < n; i++) {
+    const j = i + Math.floor(rand() * (arr.length - i));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr.slice(0, n);
+}
+
+/**
+ * Hit-rate statistics summarized from a sample. Pure function — used to
+ * derive both human-readable and --json output.
+ */
+export interface CoverageStats {
+  sampled: number;
+  fastPathHits: number;
+  fastPathHitRate: number;
+  flagHits: number;
+  flagHitRate: number;
+  meetsThreshold: boolean;
+  threshold: number;
+  byDomain: Array<{ host: string; fastPathHits: number; total: number }>;
+  nullPurposeButConfident: number;
+  unparseable: number;
+}
+
+/** Extract the normalized hostname for a URL, or a sentinel on failure. */
+function extractHostSafe(raw: string): string {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    if (host.startsWith('www.')) host = host.slice(4);
+    return host;
+  } catch {
+    return '(invalid-url)';
+  }
+}
+
+/**
+ * Classify every item in `sample`, aggregate counts, and return stats.
+ * Pure — does not touch the network, fs, or wiki-server.
+ */
+export function computeCoverageStats(
+  sample: ReadonlyArray<{ url: string }>,
+  gateThreshold: number = BACKFILL_GATE_THRESHOLD,
+): CoverageStats {
+  let fastPathHits = 0;
+  let flagHits = 0;
+  let unparseable = 0;
+  let nullPurposeButConfident = 0;
+  const domainMap = new Map<string, { host: string; fastPathHits: number; total: number }>();
+
+  for (const r of sample) {
+    if (!r.url) {
+      unparseable++;
+      continue;
+    }
+    const cls = classifyByUrl(r.url);
+    const host = extractHostSafe(r.url);
+
+    if (cls.reasons.includes('unparseable')) {
+      unparseable++;
+      continue;
+    }
+
+    // Track "confident but not a homepage" — e.g., PDFs at 0.9 confidence.
+    // This is useful telemetry because the heuristic is saying "I know what
+    // this is, and it's NOT a homepage". The LLM still has to fill
+    // summary/key_points/etc., but the classifier signal is strong.
+    if (cls.purpose === null && cls.confidence >= FAST_PATH_THRESHOLD) {
+      nullPurposeButConfident++;
+    }
+
+    const isFlag = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
+    const isFastPath = cls.purpose === 'homepage' && cls.confidence >= FAST_PATH_THRESHOLD;
+    if (isFlag) flagHits++;
+    if (isFastPath) fastPathHits++;
+
+    let entry = domainMap.get(host);
+    if (!entry) {
+      entry = { host, fastPathHits: 0, total: 0 };
+      domainMap.set(host, entry);
+    }
+    entry.total++;
+    if (isFastPath) entry.fastPathHits++;
+  }
+
+  const sampled = sample.length;
+  const fastPathHitRate = sampled > 0 ? fastPathHits / sampled : 0;
+  const flagHitRate = sampled > 0 ? flagHits / sampled : 0;
+
+  const byDomain = [...domainMap.values()]
+    .filter((d) => d.fastPathHits > 0)
+    .sort((a, b) => {
+      if (b.fastPathHits !== a.fastPathHits) return b.fastPathHits - a.fastPathHits;
+      return b.total - a.total;
+    });
+
+  return {
+    sampled,
+    fastPathHits,
+    fastPathHitRate,
+    flagHits,
+    flagHitRate,
+    meetsThreshold: fastPathHitRate >= gateThreshold,
+    threshold: gateThreshold,
+    byDomain,
+    nullPurposeButConfident,
+    unparseable,
+  };
+}
+
+// ── Command ─────────────────────────────────────────────────────────
+
+interface SampleCoverageOptions extends BaseOptions {
+  'sample-size'?: string;
+  sampleSize?: string;
+  seed?: string;
+  json?: boolean;
+}
+
+async function sampleCoverageCommand(
+  _args: string[],
+  options: SampleCoverageOptions,
+): Promise<CommandResult> {
+  const sampleSize = parseSampleSize(options['sample-size'] ?? options.sampleSize);
+  const seed = parseSeed(options.seed);
+  const isJson = !!options.json;
+
+  if (!isJson) {
+    console.log(bold('Source-Check URL Heuristic — Sample Coverage'));
+    console.log(`Sample size: ${sampleSize}${seed !== null ? ` (seed=${seed})` : ''}`);
+    console.log('');
+    console.log('Loading resources from wiki-server (or PG snapshot fallback)...');
+  }
+
+  let resources: Resource[];
+  try {
+    resources = await loadResourcesPGFirst();
+  } catch (err) {
+    return {
+      exitCode: 1,
+      output: `Failed to load resources: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Pool = resources with a URL. Skip blanks so they don't distort the ratio.
+  const pool = resources.filter((r) => !!r.url);
+  if (pool.length === 0) {
+    return {
+      exitCode: 1,
+      output: 'No resources with URLs found. Check wiki-server connectivity or PG snapshot.',
+    };
+  }
+
+  const rng = seed !== null ? createRng(seed) : null;
+  const sample = sampleWithoutReplacement(pool, sampleSize, rng);
+  const stats = computeCoverageStats(sample);
+
+  if (isJson) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        ...stats,
+        poolSize: pool.length,
+        requestedSampleSize: sampleSize,
+        seed,
+      }),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    output: formatHumanOutput(stats, pool.length),
+  };
+}
+
+function formatHumanOutput(stats: CoverageStats, poolSize: number): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(bold('=== Sample Coverage ==='));
+  lines.push(`Pool size:              ${poolSize} resources with URLs`);
+  lines.push(`Sampled:                ${stats.sampled}`);
+  lines.push(`Unparseable URLs:       ${stats.unparseable}`);
+  lines.push('');
+
+  const fpPct = (stats.fastPathHitRate * 100).toFixed(1);
+  const flagPct = (stats.flagHitRate * 100).toFixed(1);
+  const thresholdPct = (stats.threshold * 100).toFixed(0);
+
+  lines.push(bold('Hit rates'));
+  lines.push(`Fast-path (conf ≥ 0.8): ${stats.fastPathHits}/${stats.sampled} (${fpPct}%)`);
+  lines.push(`Flag (conf ≥ 0.7):      ${stats.flagHits}/${stats.sampled} (${flagPct}%)`);
+  lines.push(`Confident non-homepage: ${stats.nullPurposeButConfident}/${stats.sampled}`);
+  lines.push('');
+
+  const verdict = stats.meetsThreshold
+    ? green(`✓ PROCEED — fast-path rate ${fpPct}% ≥ ${thresholdPct}% gate`)
+    : red(`✗ STOP — fast-path rate ${fpPct}% < ${thresholdPct}% gate — improve heuristic first`);
+  lines.push(bold('Backfill gate'));
+  lines.push(`  ${verdict}`);
+  lines.push('');
+
+  if (stats.byDomain.length > 0) {
+    lines.push(bold('Top domains (by fast-path hit count)'));
+    lines.push('-'.repeat(72));
+    lines.push(bold(`  ${'Hits'.padStart(5)}  ${'Total'.padStart(5)}  Domain`));
+    for (const d of stats.byDomain.slice(0, TOP_DOMAINS_SHOWN)) {
+      lines.push(`  ${String(d.fastPathHits).padStart(5)}  ${String(d.total).padStart(5)}  ${d.host}`);
+    }
+    if (stats.byDomain.length > TOP_DOMAINS_SHOWN) {
+      lines.push(`  ... and ${stats.byDomain.length - TOP_DOMAINS_SHOWN} more domains with fast-path hits`);
+    }
+    lines.push('');
+  }
+
+  lines.push('Next steps:');
+  if (stats.meetsThreshold) {
+    lines.push('  1. Proceed with sub-PR 3 (sourcing-mark) and sub-PR 4 (backfill-resource-purpose).');
+    lines.push('  2. Size the LLM budget cap to cover the residual (non-fast-path) resources.');
+  } else {
+    lines.push('  1. Do NOT run the backfill yet — the heuristic is too coarse.');
+    lines.push('  2. Review the "Confident non-homepage" count — even when fast-path hits are below');
+    lines.push('     the gate, the heuristic may already be confident on non-homepage URLs.');
+    lines.push('  3. Consider extending HOMEPAGE_PATHS / DATA_PARAM_KEYS to reduce ambiguous cases.');
+  }
+  if (stats.unparseable > stats.sampled / 10) {
+    lines.push('');
+    lines.push(yellow(`⚠ ${stats.unparseable} unparseable URLs (>10% of sample) — investigate data quality.`));
+  }
+  return lines.join('\n');
+}
+
+// ── Exports ─────────────────────────────────────────────────────────
+
+export const commands = {
+  default: sampleCoverageCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check URL Heuristic — Sample Coverage Reporter
+
+Usage:
+  crux sourcing-sample-coverage [options]
+
+Options:
+  --sample-size=N        Random sample size (default: 500, max: 5000)
+  --seed=N               Seed the RNG for reproducible samples (uint32)
+  --json                 Machine-readable output
+
+Output:
+  Fast-path hit rate, flag-threshold hit rate, domain breakdown of
+  heuristic homepage hits, and a gate verdict (≥40% → proceed with
+  Phase 3 backfill; below → improve the heuristic first).
+
+No writes, no LLM calls. Safe to run repeatedly.
+
+Reads the full resource list from wiki-server (or falls back to the
+local PG snapshot if the server is unreachable).
+`.trim();
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -97,6 +97,7 @@ import * as verifyOrchestrateCommands from './commands/sourcing-orchestrate.ts';
 import * as sourcingRecheckCommands from './commands/sourcing-recheck.ts';
 import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
 import * as sourcingBackfillHomepagesCommands from './commands/sourcing-backfill-homepages.ts';
+import * as sourcingSampleCoverageCommands from './commands/sourcing-sample-coverage.ts';
 import * as sourcingSuggestUrlsCommands from './commands/sourcing-suggest-urls.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
@@ -187,6 +188,7 @@ const domains = {
   'sourcing-recheck': sourcingRecheckCommands,
   'sourcing-audit-urls': sourcingAuditUrlsCommands,
   'sourcing-backfill-homepages': sourcingBackfillHomepagesCommands,
+  'sourcing-sample-coverage': sourcingSampleCoverageCommands,
   'sourcing-suggest-urls': sourcingSuggestUrlsCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,


### PR DESCRIPTION
## Summary

Second shippable slice of QUA-313 / URL-Quality Phase 3 ([Discussion #4221](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4221)). Read-only CLI that samples N resources, runs the URL heuristic against each, and reports the fast-path hit rate.

## Role in the revised Phase 3 plan

This command is the *measurement tool* that drove the Phase 3 re-scope. After running it against prod:

```
$ WIKI_SERVER_ENV=prod pnpm crux sourcing-sample-coverage --sample-size=500 --seed=42

Pool: 22693, sampled: 500
Fast-path hits:      14 (2.8%)
Confident non-home:  5
```

Four independent samples converged at 2–4% (seed=1: 4.2%, seed=42: 2.8%, seed=99: 3.2%, seed=7 @ 2000: 3.5%). The "non-hits" are **legitimate content URLs** — LessWrong posts, EA Forum posts, arxiv/CSET/FHI PDFs, Reuters/RAND articles. The heuristic is correctly returning `purpose=null` at confidence 0.1 for deep paths and 0.9 for PDFs.

**The Phase 3 plan's 40% assumption came from a denominator mismatch:** PR #4222's Phase 1 audit measured ~20% homepage rate on **stuck-verdict evidence** (a biased subset of ~200), and the plan extrapolated that as a whole-corpus rate. The whole corpus is dominated by specific content; 2–4% is what a healthy wiki looks like.

See Linear QUA-313 comment for the full write-up.

## Revised Phase 3 plan

After reviewing the finding, Phase 3 is being executed as **A + B in parallel**:

- **(A) Narrow tactical cleanup** — ship a small `sourcing-backfill-homepages` command that sets `resource_purpose='homepage'` on the ~500 deterministic fast-path hits via `upsertResourceBatch`. No LLM cost, idempotent, fail-fast. This closes QUA-313's literal deliverable cheaply.
- **(B) Root-cause investigation** for the 3,277 stuck `unverifiable`/`partial` verdicts from QUA-113 — dead-link rate, paywall rate, JS-heavy page rate, `citation_content` cache completeness. Filed as a separate Linear ticket. Homepage URLs are one of many causes, not the dominant one.

The other sub-PRs from the original plan (`sourcing-mark` CLI, full corpus LLM backfill, homepage pill UX, dashboard sparkline) are **dropped or deferred** — they were sized for a 40%-hit-rate world that doesn't exist.

## Scope of this PR

### `crux/commands/sourcing-sample-coverage.ts` (new)

New flat command. Options:
- `--sample-size=N` — random sample size (default 500, max 5000)
- `--seed=N` — uint32 for reproducible samples
- `--json` — machine-readable output

Loads resources via `loadResourcesPGFirst()` (same pattern as `classify.ts`), samples without replacement via Fisher–Yates + mulberry32, runs `classifyByUrl` on each, and reports:
- Fast-path hit rate (confidence ≥ 0.8)
- Flag hit rate (confidence ≥ 0.7)
- "Confident non-homepage" count (PDFs at 0.9 etc.)
- byDomain breakdown of fast-path hits (top 20)
- Backfill gate verdict (≥ 40% → PROCEED, else STOP)

No writes, no LLM calls, no wiki-server mutations. Safe to run repeatedly.

### `crux.mjs`

Registers the new command as a flat entry alongside `sourcing-audit-urls` and `sourcing-recheck`.

### Pure-logic helpers (exported for tests)

- `parseSampleSize(raw)` — clamped to [1, 5000], default 500
- `parseSeed(raw)` — uint32 or null
- `createRng(seed)` — mulberry32 (tiny, deterministic)
- `sampleWithoutReplacement(pool, n, rng)` — Fisher-Yates partial, no mutation
- `computeCoverageStats(sample, gateThreshold?)` — pure stats

## Tests

`crux/commands/sourcing-sample-coverage.test.ts` (new, **39 tests**): `parseSampleSize`, `parseSeed`, `createRng` (determinism + distribution), `sampleWithoutReplacement` (no dupes, full pool edge case, determinism, Math.random fallback, 10k-trial uniform-distribution spot-check), `computeCoverageStats` (bucketing, thresholds, unparseable, PDFs, domain sort, www. normalization).

## Verification

- [x] `npx vitest run crux/commands/sourcing-sample-coverage.test.ts` — **39/39 pass**
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — zero errors
- [x] `pnpm crux w validate gate --fix` — **48/48 pass**
- [x] `pnpm build` — clean
- [x] Prod smoke test at seeds 1, 7, 42, 99 — all converged 2.8–4.2%
- [x] Non-hit URLs manually inspected — all legitimate content (LessWrong, EA Forum, arxiv, RAND, etc.)
- [ ] CI green on push
- [ ] `gate:rules-ok` label added (requires human review of protected `crux/commands/` paths)

## Test plan

- [x] Tests pass
- [x] Gate clean
- [x] Build clean
- [x] Prod smoke test
- [ ] `gate:rules-ok` label added (waiting on human)

Fixes QUA-313