### PR TITLE
fix(health): honor WIKI_SERVER_ENV=prod in crux health

### DIFF
--- a/crux/health/checks/job-queue.ts
+++ b/crux/health/checks/job-queue.ts
@@ -24,6 +24,7 @@
  */
 
 import type { CheckResult } from '../health-check.ts';
+import { getServerUrl, getApiKey } from '../../lib/wiki-server/client.ts';
 
 // ---------------------------------------------------------------------------
 // Thresholds (exported for tests)
@@ -151,11 +152,12 @@ export function evaluateJobStats(data: JobStatsResponse): EvaluationResult {
 export async function checkJobQueue(): Promise<CheckResult> {
   const name = 'Job queue';
 
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL ?? '';
-  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY ?? '';
+  // Honor WIKI_SERVER_ENV=prod via the shared client helpers. See QUA-318.
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
 
   if (!serverUrl) {
-    return { name, ok: true, summary: 'Skipped (LONGTERMWIKI_SERVER_URL not set)' };
+    return { name, ok: true, summary: 'Skipped (wiki-server URL not set)' };
   }
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -27,6 +27,7 @@
 
 import { getColors } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
+import { getServerUrl, getApiKey } from '../lib/wiki-server/client.ts';
 import { checkJobQueue } from './checks/job-queue.ts';
 import { checkPrQuality } from './checks/pr-quality.ts';
 import { checkCiMainHealth } from './checks/ci-main-health.ts';
@@ -43,9 +44,12 @@ const REPORT_MODE = args.includes('--report');
 const AUTO_ISSUE = args.includes('--auto-issue');
 const CLEANUP_LABELS = args.includes('--cleanup-labels');
 
-const SERVER_URL = process.env.LONGTERMWIKI_SERVER_URL ?? '';
-const API_KEY = process.env.LONGTERMWIKI_SERVER_API_KEY ?? '';
-const WIKI_PUBLIC_URL = process.env.WIKI_PUBLIC_URL ?? '';
+// Resolve wiki-server URL/API key via the shared client helpers so
+// WIKI_SERVER_ENV=prod (which reads PROD_LONGTERMWIKI_*) works here
+// the same way it does for every other crux command. See QUA-318.
+const SERVER_URL = getServerUrl();
+const API_KEY = getApiKey();
+const WIKI_PUBLIC_URL = process.env.WIKI_PUBLIC_URL || 'https://www.longtermwiki.com';
 
 // Count lower bounds — alert if DB drops significantly below these baselines
 const MIN_PAGES = 600;
@@ -372,10 +376,6 @@ export async function checkFrontend(): Promise<CheckResult> {
   const name = 'Frontend';
   const detail: string[] = [];
   const failures: string[] = [];
-
-  if (!WIKI_PUBLIC_URL) {
-    return { name, ok: true, summary: 'Skipped (WIKI_PUBLIC_URL not set)', detail: ['Set WIKI_PUBLIC_URL to enable frontend checks'] };
-  }
 
   const pages = [
     { label: 'Homepage', path: '/' },


### PR DESCRIPTION
## Summary

- `crux health` now uses `getServerUrl()` / `getApiKey()` from the shared wiki-server client, honoring `WIKI_SERVER_ENV=prod` like every other crux command.
- `WIKI_PUBLIC_URL` falls back to `https://www.longtermwiki.com` when unset (removes the false-negative skip).
- Eliminates the "Server & DB: HTTP 0" and "Data freshness: HTTP 0" false FAILs observed in `/deploy` Step 5 from agent slots.

## Why

`/deploy` Step 5 is mandatory to run `crux health`, but in agent slots the local wiki-server isn't running (`.env` points at `localhost:3113`), so both checks reported HTTP 0. Root cause was `health-check.ts` (and `checks/job-queue.ts`) reading `process.env.LONGTERMWIKI_*` directly instead of the canonical resolver.

Root-cause analysis: QUA-318 Ozzie comment (2026-04-12).

Fixes QUA-318.

## Test plan
- [x] `pnpm exec tsc --noEmit -p crux/tsconfig.json` passes (0 errors in `crux/health/`)
- [x] `WIKI_SERVER_ENV=prod pnpm crux health` shows PASS for Server & DB + Data freshness + Frontend + Job queue
- [x] Existing wiki-server/client tests still pass (22/22)
- [x] Existing job-queue tests still pass (17/17)
- [x] Pre-push gate: 39/39 checks passed
