### PR TITLE
fix(deploy-tasks): SKIP psql verify when psql/DATABASE_URL missing

### DIFF
--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for deploy-tasks command handlers.
+ *
+ * Covers:
+ * - checkPsqlRunnable: gates psql verify commands when psql or DATABASE_URL
+ *   are missing from the local environment (QUA-319).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkPsqlRunnable } from './deploy-tasks.ts';
+
+describe('checkPsqlRunnable', () => {
+  const PSQL_CMD =
+    'psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"';
+  const CURL_CMD = 'curl -sf "$WIKI_SERVER_URL/health" | jq .';
+
+  it('returns runnable=true for non-psql commands regardless of env', () => {
+    const result = checkPsqlRunnable(CURL_CMD, {
+      hasPsql: () => false,
+      getDatabaseUrl: () => undefined,
+    });
+    expect(result).toEqual({ runnable: true });
+  });
+
+  it('returns runnable=false with actionable reason when DATABASE_URL is unset', () => {
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => true,
+      getDatabaseUrl: () => undefined,
+    });
+    expect(result.runnable).toBe(false);
+    if (!result.runnable) {
+      expect(result.reason).toMatch(/DATABASE_URL is not set/);
+      expect(result.reason).toMatch(/DB access|export DATABASE_URL/);
+    }
+  });
+
+  it('returns runnable=false when DATABASE_URL is empty string', () => {
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => true,
+      getDatabaseUrl: () => '',
+    });
+    expect(result.runnable).toBe(false);
+    if (!result.runnable) {
+      expect(result.reason).toMatch(/DATABASE_URL is not set/);
+    }
+  });
+
+  it('returns runnable=false when DATABASE_URL is whitespace-only', () => {
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => true,
+      getDatabaseUrl: () => '   ',
+    });
+    expect(result.runnable).toBe(false);
+  });
+
+  it('returns runnable=false with actionable reason when psql is not on PATH', () => {
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => false,
+      getDatabaseUrl: () => 'postgres://localhost/test',
+    });
+    expect(result.runnable).toBe(false);
+    if (!result.runnable) {
+      expect(result.reason).toMatch(/psql is not installed/);
+      expect(result.reason).toMatch(/Install the Postgres client|machine with psql/);
+    }
+  });
+
+  it('returns runnable=true when both psql is present and DATABASE_URL is set', () => {
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => true,
+      getDatabaseUrl: () => 'postgres://localhost/test',
+    });
+    expect(result).toEqual({ runnable: true });
+  });
+
+  it('prioritizes DATABASE_URL check over psql check', () => {
+    // When both are missing, the DATABASE_URL message is more actionable
+    // (env vars are faster to set than installing a binary).
+    const result = checkPsqlRunnable(PSQL_CMD, {
+      hasPsql: () => false,
+      getDatabaseUrl: () => undefined,
+    });
+    expect(result.runnable).toBe(false);
+    if (!result.runnable) {
+      expect(result.reason).toMatch(/DATABASE_URL/);
+      expect(result.reason).not.toMatch(/psql is not installed/);
+    }
+  });
+
+  it('does not match commands that merely contain "psql" as a substring', () => {
+    // `\bpsql\b` boundary means "psqlfoo" or "mypsql" shouldn't trigger
+    const result = checkPsqlRunnable('echo mypsqlbar', {
+      hasPsql: () => false,
+      getDatabaseUrl: () => undefined,
+    });
+    expect(result).toEqual({ runnable: true });
+  });
+});

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -177,6 +177,68 @@ interface VerifyResult {
   status: 'pass' | 'fail' | 'skip';
   exitCode?: number;
   output?: string;
+  skipReason?: string;
+}
+
+/**
+ * Determine whether a `psql`-based verify command can actually run in the
+ * current environment. Returns `{ runnable: true }` for non-psql commands and
+ * for psql commands when both `psql` is on PATH and `DATABASE_URL` is set.
+ *
+ * Exported for unit testing. Callers can inject a probe via `deps` to avoid
+ * shelling out in tests.
+ *
+ * This exists because `crux gh deploy-tasks verify` is typically invoked from
+ * coordinator workstations that don't have `psql` installed and don't carry
+ * `DATABASE_URL` in their environment (the DB lives in k8s). Without this
+ * pre-check, every migration task reports FAIL with exit 127, eroding the
+ * signal-to-noise ratio of `/deploy` Step 5 — see QUA-319.
+ */
+export function checkPsqlRunnable(
+  command: string,
+  deps: {
+    hasPsql?: () => boolean;
+    getDatabaseUrl?: () => string | undefined;
+  } = {}
+): { runnable: true } | { runnable: false; reason: string } {
+  // Only gate psql commands. Other verify patterns (curl, gh, pnpm) are
+  // either ambient on any workstation or already fail loudly for other reasons.
+  if (!/\bpsql\b/.test(command)) {
+    return { runnable: true };
+  }
+
+  const getDatabaseUrl = deps.getDatabaseUrl ?? (() => process.env.DATABASE_URL);
+  const hasPsql = deps.hasPsql ?? defaultHasPsql;
+
+  const dbUrl = getDatabaseUrl();
+  if (!dbUrl || dbUrl.trim() === '') {
+    return {
+      runnable: false,
+      reason:
+        'DATABASE_URL is not set — cannot run psql verification locally. Run this from a deploy environment with DB access, or export DATABASE_URL before retrying.',
+    };
+  }
+
+  if (!hasPsql()) {
+    return {
+      runnable: false,
+      reason:
+        'psql is not installed on PATH — cannot run psql verification locally. Install the Postgres client or run this from a machine with psql + DB access.',
+    };
+  }
+
+  return { runnable: true };
+}
+
+let cachedHasPsql: boolean | undefined;
+function defaultHasPsql(): boolean {
+  if (cachedHasPsql !== undefined) return cachedHasPsql;
+  const probe = spawnSync('command', ['-v', 'psql'], {
+    shell: true,
+    stdio: 'ignore',
+  });
+  cachedHasPsql = probe.status === 0;
+  return cachedHasPsql;
 }
 
 /**
@@ -264,6 +326,19 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
         continue;
       }
 
+      const runnable = checkPsqlRunnable(command);
+      if (!runnable.runnable) {
+        results.push({
+          pr: pr.number,
+          prTitle: pr.title,
+          task: item.text,
+          command,
+          status: 'skip',
+          skipReason: runnable.reason,
+        });
+        continue;
+      }
+
       const { exitCode, output } = runVerifyCommand(command, timeoutMs);
       results.push({
         pr: pr.number,
@@ -329,6 +404,9 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
           .join('\n');
         lines.push(`        ${c.dim}exit=${r.exitCode}${c.reset}`);
         lines.push(indented);
+      }
+      if (r.status === 'skip' && r.skipReason) {
+        lines.push(`        ${c.dim}${r.skipReason}${c.reset}`);
       }
     }
     lines.push('');


### PR DESCRIPTION
## Summary

- `crux gh deploy-tasks verify` now reports `skip` (not `fail`) for `psql` tasks when `psql` is missing on PATH or `DATABASE_URL` is unset.
- Skip messages are actionable: they say exactly what's missing and how to fix (run from deploy environment, install psql, export env var).
- Exit code for `--ci` no longer spuriously returns 1 when verify tasks are un-runnable locally.

## Why

Coordinator workstations don't have `psql` installed and don't have `DATABASE_URL` in `.env.base` (DB lives in k8s). Every `/deploy` Step 5 surfaced spurious FAILs for migration tasks on healthy releases, training agents to ignore verify failures — exactly the wrong lesson.

The fix pre-checks psql commands before running them and emits `status: 'skip'` with a dimmed `skipReason` note, instead of letting `bash -c psql ...` fail with exit 127 (command not found) and get classified as a real FAIL.

Fixes QUA-319.

## Changes

- `crux/commands/deploy-tasks.ts`:
  - New exported `checkPsqlRunnable(command, deps?)` helper with injectable probe for tests.
  - Called from `verify()` after the dry-run check and before `runVerifyCommand()` — same point-of-decision pattern as the existing dry-run path.
  - Added `skipReason` field to `VerifyResult` (surfaces in both JSON and human output).
  - `defaultHasPsql()` caches the probe so N psql tasks trigger one `command -v psql` invocation.
- `crux/commands/deploy-tasks.test.ts` (new):
  - 8 unit tests covering non-psql, missing DATABASE_URL (undefined/empty/whitespace), missing psql binary, both present, priority ordering, and word-boundary false-match protection.

## Verification

- `pnpm exec tsc --noEmit -p crux/tsconfig.json` — 161 errors, same as `origin/main` (no new errors introduced).
- `pnpm exec vitest run crux/commands/deploy-tasks.test.ts` — 8/8 passing.
- Ran `pnpm crux gh deploy-tasks verify` on this workstation (no psql installed): previously reported 3 FAILs for migration tasks; now reports 3 SKIPs with the DATABASE_URL message. The remaining PASS/FAIL breakdown reflects real non-psql verify results only.

## Test plan

- [x] `pnpm exec tsc --noEmit -p crux/tsconfig.json` passes (no regressions vs main)
- [x] `pnpm exec vitest run crux/commands/deploy-tasks.test.ts` passes (8/8)
- [x] `pnpm crux gh deploy-tasks verify` on a coordinator machine without psql → SKIP, not FAIL
- [x] `pnpm crux gh deploy-tasks verify --ci` — JSON output includes `skipReason` field
- [x] `--dry-run` still short-circuits to `[dry-run]` skip before the psql check fires


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deploy tasks now gracefully skip when `psql` is unavailable or required database configuration is missing, with actionable error guidance to help users resolve issues.

* **Tests**
  * Added comprehensive test coverage for deploy task validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->