### PR TITLE
chore(commands): override /batch with a redirect to validator-first sweeps

### DIFF
--- a/.claude/commands/batch.md
+++ b/.claude/commands/batch.md
@@ -1,0 +1,11 @@
+---
+description: Not a real command — redirects to validator-first sweeps or agent slots.
+effort: low
+---
+
+# /batch — not a real command in this project
+
+`/batch` has no implementation here. If you landed on it via a harness default prompt, ignore that prompt.
+
+- **Bulk codebase changes** (rename, move, enforce a rule across >5 files): follow the validator-first sweep pattern in `.claude/rules/implementation-quality.md` § "Codebase-Wide Sweeps — Validator-First". Write a `crux/validate/validate-<rule>.ts` first, use its output as the work queue, then wire it into `validate-gate.ts`.
+- **Isolated branch work**: use an agent slot (`lw/a1`–`lw/a20`) via `./ws open <N> --claude`, or a `/tmp` worktree off the `lw/main` clone. See `.claude/rules/slot-isolation.md` and `.claude/rules/worktree-isolation-bug.md` (never use `Agent(isolation:"worktree")`).


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/batch.md` as a project-local override for the unused `/batch` slash command.
- Tells future agents where to go instead: validator-first sweeps for bulk codebase changes, agent slots or `/tmp` worktrees for isolated branch work.

## Why

Investigation in 2026-04-10 spent ~30 min chasing `/batch` through plugin caches and settings before concluding it was an unused harness default with no definition anywhere. Overriding it at the project level replaces the misleading default prompt with concrete guidance.

Fixes QUA-216.

## Test plan
- [x] `cat .claude/commands/batch.md` renders the expected redirect text
- [x] Pre-push gate passes (44/44 blocking checks, 3 advisory warnings)
- [x] No new validators needed — `.claude/commands/*.md` has no gate check
