### PR TITLE
refactor(sourcing): dedupe normalizeUrl in suggest-urls

### DIFF
--- a/crux/lib/sourcing/suggest-urls.ts
+++ b/crux/lib/sourcing/suggest-urls.ts
@@ -21,6 +21,7 @@ import {
   type SearchHit,
 } from "../search/research-agent.ts";
 import { getApiKey } from "../api-keys.ts";
+import { normalizeUrlForJoin as normalizeUrl } from "./url-quality.ts";
 
 /** Version tag for stored suggestions — bump when the generator changes shape. */
 export const GENERATOR_MODEL = "qua-64/suggest-urls-v1";
@@ -84,24 +85,6 @@ export function buildSearchQuery(opts: {
     .filter(Boolean)
     .join(" ")
     .slice(0, 300);
-}
-
-const TRACKING_PARAMS = [
-  "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
-  "ref", "ref_src",
-];
-
-function normalizeUrl(url: string): string {
-  try {
-    const u = new URL(url);
-    u.hostname = u.hostname.toLowerCase();
-    u.hash = "";
-    for (const p of TRACKING_PARAMS) u.searchParams.delete(p);
-    const s = u.toString();
-    return s.endsWith("/") && u.pathname !== "/" ? s.slice(0, -1) : s;
-  } catch {
-    return url;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- `crux/lib/sourcing/suggest-urls.ts` no longer defines a local `TRACKING_PARAMS` + `normalizeUrl`; it imports `normalizeUrlForJoin` from `./url-quality.ts` instead.
- Picks up the wider tracking-param list (`fbclid`, `gclid`, `yclid`, `msclkid`, `_ga`, plus `mc_` / `oly_` prefixes) that the local copy was missing.

## Why

QUA-312 extracted the canonical URL-normalization helper to `url-quality.ts`. The local copy in `suggest-urls.ts` was the follow-up debt; this closes it.

Fixes QUA-332.

## Test plan
- [x] `pnpm exec tsc --noEmit -p crux/tsconfig.json` — no new errors (pre-existing unrelated errors only)
- [x] `pnpm exec vitest run crux/lib/sourcing/` — 429 tests pass (including 12 suggest-urls generator tests)
- [x] Gate check passed (all 39 checks, no new failures)
