### PR TITLE
feat(qua-336): enrich Linear/GH start comments with slot, host, agent-id

### DIFF
--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -184,9 +184,13 @@ describe('linear start', () => {
       'QUA-184',
       expect.stringContaining('starting work')
     );
-    // Branch name from the mocked execSync is interpolated into the comment
     const commentBody = commentOnIssueMock.mock.calls[0][1];
+    // Branch name (from mocked execSync) is in the comment
     expect(commentBody).toContain('claude/qua-184-test-branch');
+    // Enriched fields (QUA-336): branch is a claude/* branch so no main warning
+    expect(commentBody).not.toContain('⚠');
+    // Host is always set (from os.hostname()) — assert the field label is present
+    expect(commentBody).toContain('**Host:**');
   });
 });
 

--- a/crux/commands/issues.ts
+++ b/crux/commands/issues.ts
@@ -19,6 +19,7 @@ import { readFileSync } from 'fs';
 import { createLogger } from '../lib/output.ts';
 import { githubApi, githubApiPaginated, REPO } from '../lib/github.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
+import { buildStartCommentBody, getSessionContext } from '../lib/session/session-context.ts';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { parseIntOpt, parseRequiredInt } from '../lib/cli.ts';
 import { listActiveAgents, registerAgent } from '../lib/wiki-server/active-agents.ts';
@@ -500,7 +501,8 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
     };
   }
 
-  const branch = currentBranch();
+  const ctx = getSessionContext();
+  const branch = ctx.branch;
 
   // Check for active-agent conflicts (best-effort — don't block if server is down)
   if (!options.force) {
@@ -539,10 +541,9 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   });
 
   // Post start comment
-  const body =
-    `🤖 Claude Code starting work on this issue.\n\n` +
-    `**Branch:** \`${branch}\`\n\n` +
-    `Will post an update here when a PR is ready for review.`;
+  const body = buildStartCommentBody(ctx, {
+    trailing: 'Will post an update here when a PR is ready for review.',
+  });
 
   await githubApi(`/repos/${REPO}/issues/${issueNum}/comments`, {
     method: 'POST',
@@ -564,6 +565,7 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   let output = '';
   output += `${c.green}✓${c.reset} Started tracking issue #${issueNum}: ${issue.title}\n`;
   output += `  Branch: ${c.cyan}${branch}${c.reset}\n`;
+  if (ctx.slot !== null) output += `  Slot: ${c.cyan}a${ctx.slot}${c.reset}\n`;
   output += `  Label \`${CLAUDE_WORKING_LABEL}\` added.\n`;
   output += `  Comment posted on ${issue.html_url}\n`;
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -37,6 +37,7 @@ import { resolve as resolvePath } from 'path';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
 import { findAllLinearIds, parseLinearId, resolveLinearId } from '../lib/linear/parse-id.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
+import { buildStartCommentBody, getSessionContext } from '../lib/session/session-context.ts';
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 
@@ -190,16 +191,14 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
     return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
   }
 
-  const branch = currentBranch();
+  const ctx = getSessionContext();
   await updateIssueState(id, 'In Progress');
-  await commentOnIssue(
-    id,
-    `🤖 Claude Code starting work on this issue.\n\n**Branch:** \`${branch}\`\n\nWill post an update when a PR is ready for review.`,
-  );
+  await commentOnIssue(id, buildStartCommentBody(ctx));
 
   let out = '';
   out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → In Progress\n`;
-  out += `  Branch: ${c.cyan}${branch}${c.reset}\n`;
+  out += `  Branch: ${c.cyan}${ctx.branch}${c.reset}\n`;
+  if (ctx.slot !== null) out += `  Slot: ${c.cyan}a${ctx.slot}${c.reset}\n`;
   out += `  ${issue.url}\n`;
   return { output: out, exitCode: 0 };
 }

--- a/crux/lib/session/session-context.test.ts
+++ b/crux/lib/session/session-context.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for session-context.ts — the shared helper that builds the
+ * "starting work" comment body for `crux linear start` and `crux gh issues start`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildStartCommentBody,
+  getSessionContext,
+  type SessionContext,
+  type SessionContextDeps,
+} from './session-context.ts';
+
+// ---------------------------------------------------------------------------
+// getSessionContext — pure, dependency-injected so no fs/git mocking required
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<SessionContextDeps>): SessionContextDeps {
+  const files = new Map<string, string>();
+  return {
+    cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10',
+    gitBranch: () => 'claude/qua-336-test',
+    hostnameFn: () => 'dev-mbp',
+    fileExists: (p: string) => files.has(p),
+    readFile: (p: string) => {
+      const v = files.get(p);
+      if (v === undefined) throw new Error(`no such file: ${p}`);
+      return v;
+    },
+    ...overrides,
+  };
+}
+
+describe('getSessionContext', () => {
+  it('resolves slot from directory basename matching /^a\\d+$/', () => {
+    const ctx = getSessionContext(makeDeps({}));
+    expect(ctx.slot).toBe(10);
+    expect(ctx.branch).toBe('claude/qua-336-test');
+    expect(ctx.host).toBe('dev-mbp');
+    expect(ctx.agentId).toBeNull();
+  });
+
+  it('falls back to .agent-slot when directory name does not match', () => {
+    const files = new Map<string, string>([
+      ['/Users/dev/workspace/.agent-slot', '7\n'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/workspace',
+      gitBranch: () => 'main',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p) ?? (() => { throw new Error(); })(),
+    });
+    expect(ctx.slot).toBe(7);
+  });
+
+  it('returns null slot when neither directory nor slot file works', () => {
+    const ctx = getSessionContext({
+      cwd: '/tmp/someplace',
+      gitBranch: () => 'main',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: () => false,
+      readFile: () => { throw new Error('unreachable'); },
+    });
+    expect(ctx.slot).toBeNull();
+  });
+
+  it('ignores non-numeric .agent-slot contents', () => {
+    const files = new Map<string, string>([
+      ['/tmp/wat/.agent-slot', 'oops\n'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/tmp/wat',
+      gitBranch: () => 'main',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p)!,
+    });
+    expect(ctx.slot).toBeNull();
+  });
+
+  it('reads agent ID from .claude/agent-id when present', () => {
+    const files = new Map<string, string>([
+      ['/Users/dev/Documents/GitHub.nosync/lw/a10/.claude/agent-id', '1234\n'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10',
+      gitBranch: () => 'claude/qua-336-test',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p)!,
+    });
+    expect(ctx.agentId).toBe(1234);
+  });
+
+  it('ignores malformed agent-id file', () => {
+    const files = new Map<string, string>([
+      ['/Users/dev/Documents/GitHub.nosync/lw/a10/.claude/agent-id', 'garbage'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10',
+      gitBranch: () => 'claude/qua-336-test',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p)!,
+    });
+    expect(ctx.agentId).toBeNull();
+  });
+
+  it('returns unknown-branch when git fails', () => {
+    const ctx = getSessionContext({
+      cwd: '/tmp/wat',
+      gitBranch: () => { throw new Error('not a git repo'); },
+      hostnameFn: () => 'dev-mbp',
+      fileExists: () => false,
+      readFile: () => { throw new Error(); },
+    });
+    expect(ctx.branch).toBe('unknown-branch');
+  });
+
+  it('normalizes empty branch to "unknown-branch"', () => {
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10',
+      gitBranch: () => '',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: () => false,
+      readFile: () => { throw new Error(); },
+    });
+    expect(ctx.branch).toBe('unknown-branch');
+  });
+
+  it('normalizes empty hostname to null', () => {
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10',
+      gitBranch: () => 'claude/qua-336-test',
+      hostnameFn: () => '',
+      fileExists: () => false,
+      readFile: () => { throw new Error(); },
+    });
+    expect(ctx.host).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildStartCommentBody
+// ---------------------------------------------------------------------------
+
+function ctx(partial: Partial<SessionContext> = {}): SessionContext {
+  return {
+    slot: 10,
+    branch: 'claude/qua-336-test',
+    host: 'dev-mbp',
+    agentId: null,
+    ...partial,
+  };
+}
+
+describe('buildStartCommentBody', () => {
+  it('includes slot, branch, and host when all present', () => {
+    const body = buildStartCommentBody(ctx());
+    expect(body).toContain('**Slot:** a10');
+    expect(body).toContain('**Branch:** `claude/qua-336-test`');
+    expect(body).toContain('**Host:** dev-mbp');
+    expect(body).not.toContain('⚠');
+  });
+
+  it('includes agent ID when present', () => {
+    const body = buildStartCommentBody(ctx({ agentId: 1234 }));
+    expect(body).toContain('**Active agent ID:** #1234');
+    expect(body).toContain('E925 dashboard');
+  });
+
+  it('omits fields cleanly when null', () => {
+    const body = buildStartCommentBody(ctx({ slot: null, host: null, agentId: null }));
+    expect(body).not.toContain('**Slot:**');
+    expect(body).not.toContain('**Host:**');
+    expect(body).not.toContain('**Active agent ID:**');
+    expect(body).toContain('**Branch:**');
+  });
+
+  it('flags main branch with a visible warning marker', () => {
+    const body = buildStartCommentBody(ctx({ branch: 'main' }));
+    expect(body).toContain('**Branch:** `main` ⚠');
+    expect(body).toContain("init'd before feature branch");
+  });
+
+  it('flags master branch the same way', () => {
+    const body = buildStartCommentBody(ctx({ branch: 'master' }));
+    expect(body).toContain('**Branch:** `master` ⚠');
+  });
+
+  it('does not flag claude/qua-* branches', () => {
+    const body = buildStartCommentBody(ctx({ branch: 'claude/qua-336-foo' }));
+    expect(body).not.toContain('⚠');
+  });
+
+  it('uses the default trailing sentence when not overridden', () => {
+    const body = buildStartCommentBody(ctx());
+    expect(body).toContain('Will post an update when a PR is ready for review.');
+  });
+
+  it('honors a custom trailing sentence (for GitHub-issues variant)', () => {
+    const body = buildStartCommentBody(ctx(), {
+      trailing: 'Will post an update here when a PR is ready for review.',
+    });
+    expect(body).toContain('Will post an update here when a PR is ready for review.');
+  });
+
+  it('starts with the emoji header', () => {
+    const body = buildStartCommentBody(ctx());
+    expect(body.startsWith('🤖 Claude Code starting work on this issue.')).toBe(true);
+  });
+
+  it('produces deterministic output for a given context (stable formatting)', () => {
+    const body1 = buildStartCommentBody(ctx({ agentId: 42 }));
+    const body2 = buildStartCommentBody(ctx({ agentId: 42 }));
+    expect(body1).toBe(body2);
+  });
+});

--- a/crux/lib/session/session-context.test.ts
+++ b/crux/lib/session/session-context.test.ts
@@ -79,6 +79,47 @@ describe('getSessionContext', () => {
     expect(ctx.slot).toBeNull();
   });
 
+  it('rejects mixed-content .agent-slot (leading digits then garbage)', () => {
+    // parseInt('10abc') silently returns 10; strict parser must reject it.
+    const files = new Map<string, string>([
+      ['/tmp/wat/.agent-slot', '10abc'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/tmp/wat',
+      gitBranch: () => 'main',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p)!,
+    });
+    expect(ctx.slot).toBeNull();
+  });
+
+  it('rejects negative slot numbers', () => {
+    const files = new Map<string, string>([
+      ['/tmp/wat/.agent-slot', '-5'],
+    ]);
+    const ctx = getSessionContext({
+      cwd: '/tmp/wat',
+      gitBranch: () => 'main',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: (p) => files.has(p),
+      readFile: (p) => files.get(p)!,
+    });
+    expect(ctx.slot).toBeNull();
+  });
+
+  it('finds slot by walking up from a subdirectory', () => {
+    // Agents sometimes run crux from e.g. /lw/a10/apps/web
+    const ctx = getSessionContext({
+      cwd: '/Users/dev/Documents/GitHub.nosync/lw/a10/apps/web',
+      gitBranch: () => 'claude/qua-336-test',
+      hostnameFn: () => 'dev-mbp',
+      fileExists: () => false,
+      readFile: () => { throw new Error(); },
+    });
+    expect(ctx.slot).toBe(10);
+  });
+
   it('reads agent ID from .claude/agent-id when present', () => {
     const files = new Map<string, string>([
       ['/Users/dev/Documents/GitHub.nosync/lw/a10/.claude/agent-id', '1234\n'],
@@ -215,5 +256,30 @@ describe('buildStartCommentBody', () => {
     const body1 = buildStartCommentBody(ctx({ agentId: 42 }));
     const body2 = buildStartCommentBody(ctx({ agentId: 42 }));
     expect(body1).toBe(body2);
+  });
+
+  // Security: the branch name comes from `git branch --show-current` and the
+  // host from os.hostname(). Neither is fully trusted — a branch containing a
+  // backtick would break out of the markdown code span and could inject
+  // formatting into the posted comment.
+
+  it('sanitizes backticks in branch names (markdown code-span safety)', () => {
+    const body = buildStartCommentBody(ctx({ branch: 'claude/qua-1-`evil`' }));
+    expect(body).not.toContain('`claude/qua-1-`evil`'); // the backtick was stripped
+    expect(body).toContain("`claude/qua-1-'evil'`"); // replaced with single quote
+  });
+
+  it('sanitizes backticks and markdown metacharacters in host', () => {
+    const body = buildStartCommentBody(ctx({ host: 'weird-`host`-with-[brackets]' }));
+    expect(body).toContain('**Host:** weird-host-with-brackets');
+  });
+
+  it('renders a malicious branch without breaking out of the code span', () => {
+    const body = buildStartCommentBody(ctx({ branch: 'evil`\n## Injected Heading' }));
+    // No raw backtick survives inside the branch span — verifies the code span stays closed
+    const branchLine = body.split('\n').find((l) => l.startsWith('**Branch:**'))!;
+    // Count backticks on the branch line: exactly two (the opening and closing code span)
+    const backticks = (branchLine.match(/`/g) ?? []).length;
+    expect(backticks).toBe(2);
   });
 });

--- a/crux/lib/session/session-context.ts
+++ b/crux/lib/session/session-context.ts
@@ -1,0 +1,153 @@
+/**
+ * Session context — slot, branch, host, and agent ID for the current session.
+ *
+ * Used by `crux linear start` and `crux gh issues start` to build a rich
+ * start-comment body so audits can tell real in-progress sessions apart from
+ * orphan "init'd on main but never branched" claims.
+ *
+ * All fields except `branch` are best-effort and may be null if the
+ * surrounding environment (tmux, E925 registration, directory layout) isn't
+ * what we expect. The helper never throws on missing sources.
+ *
+ * See QUA-336 for the incident that motivated this.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { hostname } from 'os';
+import { basename, join } from 'path';
+
+export interface SessionContext {
+  slot: number | null;
+  branch: string;
+  host: string | null;
+  agentId: number | null;
+}
+
+export interface SessionContextDeps {
+  cwd?: string;
+  agentIdPath?: string;
+  slotFilePath?: string;
+  gitBranch?: () => string;
+  hostnameFn?: () => string;
+  fileExists?: (p: string) => boolean;
+  readFile?: (p: string) => string;
+}
+
+function readIntFile(
+  path: string,
+  fileExists: (p: string) => boolean,
+  readFile: (p: string) => string,
+): number | null {
+  try {
+    if (!fileExists(path)) return null;
+    const raw = readFile(path).trim();
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSessionContext(deps: SessionContextDeps = {}): SessionContext {
+  const cwd = deps.cwd ?? process.cwd();
+  const fileExists = deps.fileExists ?? existsSync;
+  const readFile = deps.readFile ?? ((p: string) => readFileSync(p, 'utf-8'));
+
+  const gitBranch =
+    deps.gitBranch ??
+    (() => {
+      try {
+        return execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+      } catch {
+        return 'unknown-branch';
+      }
+    });
+
+  const hostnameFn =
+    deps.hostnameFn ??
+    (() => {
+      try {
+        return hostname();
+      } catch {
+        return '';
+      }
+    });
+
+  let branch: string;
+  try {
+    branch = gitBranch() || 'unknown-branch';
+  } catch {
+    branch = 'unknown-branch';
+  }
+
+  // Slot resolution: directory basename is canonical (self-healing, set by
+  // workspace layout). `.agent-slot` is a fallback for legacy layouts.
+  let slot: number | null = null;
+  const dirName = basename(cwd);
+  const dirMatch = dirName.match(/^a(\d+)$/);
+  if (dirMatch) {
+    slot = Number.parseInt(dirMatch[1], 10);
+  } else {
+    const slotFilePath = deps.slotFilePath ?? join(cwd, '.agent-slot');
+    slot = readIntFile(slotFilePath, fileExists, readFile);
+  }
+
+  // Agent ID from E925 registration — written by .claude/hooks/session-start.sh
+  // after a successful POST /api/active-agents. Missing in sessions where the
+  // wiki-server was unreachable at start time, which is normal for slot agents.
+  const agentIdPath = deps.agentIdPath ?? join(cwd, '.claude/agent-id');
+  const agentId = readIntFile(agentIdPath, fileExists, readFile);
+
+  const host = hostnameFn().trim() || null;
+
+  return { slot, branch, host, agentId };
+}
+
+export interface BuildStartCommentOptions {
+  trailing?: string;
+}
+
+/**
+ * Build the markdown body for a Linear or GitHub "starting work" comment.
+ *
+ * Includes slot + branch + host + agent-id when available, and flags
+ * `main` / `master` branches with a visible warning so audits can distinguish
+ * orphan claims from real sessions.
+ */
+export function buildStartCommentBody(
+  ctx: SessionContext,
+  opts: BuildStartCommentOptions = {},
+): string {
+  const lines: string[] = [
+    '🤖 Claude Code starting work on this issue.',
+    '',
+  ];
+
+  if (ctx.slot !== null) {
+    lines.push(`**Slot:** a${ctx.slot}`);
+  }
+
+  const branchDisplay = ctx.branch || 'unknown-branch';
+  const isMainish = branchDisplay === 'main' || branchDisplay === 'master';
+  if (isMainish) {
+    lines.push(
+      `**Branch:** \`${branchDisplay}\` ⚠ (init'd before feature branch was created — expect a follow-up comment when the branch appears)`,
+    );
+  } else {
+    lines.push(`**Branch:** \`${branchDisplay}\``);
+  }
+
+  if (ctx.host) {
+    lines.push(`**Host:** ${ctx.host}`);
+  }
+
+  if (ctx.agentId !== null) {
+    lines.push(`**Active agent ID:** #${ctx.agentId} (E925 dashboard)`);
+  }
+
+  lines.push('');
+  lines.push(opts.trailing ?? 'Will post an update when a PR is ready for review.');
+
+  return lines.join('\n');
+}

--- a/crux/lib/session/session-context.ts
+++ b/crux/lib/session/session-context.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { hostname } from 'os';
-import { basename, join } from 'path';
+import { basename, dirname, join } from 'path';
 
 export interface SessionContext {
   slot: number | null;
@@ -34,6 +34,19 @@ export interface SessionContextDeps {
   readFile?: (p: string) => string;
 }
 
+/**
+ * Strict non-negative integer parse: requires the entire trimmed string to be
+ * digits. Rejects `"1234garbage"`, `"-5"`, `""`, and non-finite numbers. Used
+ * for reading `.agent-slot` and `.claude/agent-id` where a typo or stray byte
+ * shouldn't silently become a valid number.
+ */
+function parseStrictNonNegativeInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
 function readIntFile(
   path: string,
   fileExists: (p: string) => boolean,
@@ -41,12 +54,55 @@ function readIntFile(
 ): number | null {
   try {
     if (!fileExists(path)) return null;
-    const raw = readFile(path).trim();
-    const n = Number.parseInt(raw, 10);
-    return Number.isFinite(n) ? n : null;
+    return parseStrictNonNegativeInt(readFile(path));
   } catch {
     return null;
   }
+}
+
+/**
+ * Walk up from `cwd` looking for a directory named `a<N>` (the agent-slot
+ * root). Returns the slot number when found. Agents sometimes run crux from
+ * subdirectories of their slot (apps/web, crux, etc.) — without this walk,
+ * the slot field would silently go missing from start comments.
+ */
+function findSlotFromAncestors(cwd: string): number | null {
+  let current = cwd;
+  for (let i = 0; i < 10; i++) {
+    const match = basename(current).match(/^a(\d+)$/);
+    if (match) {
+      const n = Number.parseInt(match[1], 10);
+      if (Number.isSafeInteger(n)) return n;
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return null;
+}
+
+/**
+ * Escape a value for safe inclusion inside a markdown backtick code span.
+ * A branch name containing a backtick would break out of the span and turn
+ * the rest of the comment into rendered markdown. Control characters
+ * (newlines especially) would split the code span across lines. Branches
+ * with such characters are rare but valid under git's ref rules, so strip
+ * rather than reject. Caps length to guard against pathological input.
+ */
+function sanitizeForCodeSpan(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/`/g, "'").replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+}
+
+/**
+ * Escape a value for safe inclusion as inline markdown text. Strips the
+ * few characters that could introduce formatting or links when the value
+ * comes from an untrusted-enough source (git, os.hostname), plus control
+ * characters and enforces a length cap.
+ */
+function sanitizeForInlineText(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[`*_\[\]<>]/g, '').replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
 }
 
 export function getSessionContext(deps: SessionContextDeps = {}): SessionContext {
@@ -56,39 +112,21 @@ export function getSessionContext(deps: SessionContextDeps = {}): SessionContext
 
   const gitBranch =
     deps.gitBranch ??
-    (() => {
-      try {
-        return execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
-      } catch {
-        return 'unknown-branch';
-      }
-    });
+    (() => execSync('git branch --show-current', { encoding: 'utf-8' }).trim());
 
-  const hostnameFn =
-    deps.hostnameFn ??
-    (() => {
-      try {
-        return hostname();
-      } catch {
-        return '';
-      }
-    });
+  const hostnameFn = deps.hostnameFn ?? hostname;
 
   let branch: string;
   try {
-    branch = gitBranch() || 'unknown-branch';
+    branch = gitBranch().trim() || 'unknown-branch';
   } catch {
     branch = 'unknown-branch';
   }
 
-  // Slot resolution: directory basename is canonical (self-healing, set by
-  // workspace layout). `.agent-slot` is a fallback for legacy layouts.
-  let slot: number | null = null;
-  const dirName = basename(cwd);
-  const dirMatch = dirName.match(/^a(\d+)$/);
-  if (dirMatch) {
-    slot = Number.parseInt(dirMatch[1], 10);
-  } else {
+  // Slot resolution: walk ancestors for `a<N>` first (canonical). Fall back
+  // to `.agent-slot` for legacy layouts that don't use the a<N> convention.
+  let slot = findSlotFromAncestors(cwd);
+  if (slot === null) {
     const slotFilePath = deps.slotFilePath ?? join(cwd, '.agent-slot');
     slot = readIntFile(slotFilePath, fileExists, readFile);
   }
@@ -99,7 +137,13 @@ export function getSessionContext(deps: SessionContextDeps = {}): SessionContext
   const agentIdPath = deps.agentIdPath ?? join(cwd, '.claude/agent-id');
   const agentId = readIntFile(agentIdPath, fileExists, readFile);
 
-  const host = hostnameFn().trim() || null;
+  let host: string | null;
+  try {
+    const raw = hostnameFn().trim();
+    host = raw || null;
+  } catch {
+    host = null;
+  }
 
   return { slot, branch, host, agentId };
 }
@@ -114,6 +158,9 @@ export interface BuildStartCommentOptions {
  * Includes slot + branch + host + agent-id when available, and flags
  * `main` / `master` branches with a visible warning so audits can distinguish
  * orphan claims from real sessions.
+ *
+ * Branch and host are sanitized to prevent markdown injection from unusual
+ * git ref names or hostname characters.
  */
 export function buildStartCommentBody(
   ctx: SessionContext,
@@ -128,18 +175,19 @@ export function buildStartCommentBody(
     lines.push(`**Slot:** a${ctx.slot}`);
   }
 
-  const branchDisplay = ctx.branch || 'unknown-branch';
-  const isMainish = branchDisplay === 'main' || branchDisplay === 'master';
+  const branchRaw = ctx.branch || 'unknown-branch';
+  const branchSafe = sanitizeForCodeSpan(branchRaw);
+  const isMainish = branchRaw === 'main' || branchRaw === 'master';
   if (isMainish) {
     lines.push(
-      `**Branch:** \`${branchDisplay}\` ⚠ (init'd before feature branch was created — expect a follow-up comment when the branch appears)`,
+      `**Branch:** \`${branchSafe}\` ⚠ (init'd before feature branch was created — expect a follow-up comment when the branch appears)`,
     );
   } else {
-    lines.push(`**Branch:** \`${branchDisplay}\``);
+    lines.push(`**Branch:** \`${branchSafe}\``);
   }
 
   if (ctx.host) {
-    lines.push(`**Host:** ${ctx.host}`);
+    lines.push(`**Host:** ${sanitizeForInlineText(ctx.host)}`);
   }
 
   if (ctx.agentId !== null) {


### PR DESCRIPTION
## Summary

Enriches the start comment posted by `crux linear start` and `crux gh issues start` so audits can tell real in-progress sessions from orphans. Motivated by the 2026-04-12 Linear audit where QUA-313 and QUA-328 both had start comments claiming `Branch: main` — one had a real PR in flight, the other had zero work, and nothing in the comment distinguished them.

## Problem

`crux linear start` previously posted:

```
🤖 Claude Code starting work on this issue.

**Branch:** `<git branch --show-current>`
```

When `crux sys agent-checklist init --linear=QUA-NNN` runs before the agent creates its `claude/qua-NNN-*` feature branch, the comment captures `Branch: main`. Later branch creation doesn't update it. The audit bucket fills with `Branch: main` comments that can't be distinguished without manually cross-checking `git branch -r` and `gh pr list`.

Beyond the branch field, the comment had no identifying metadata — no way to tell which agent slot claimed the issue, no correlation to the E925 active-agents registration.

## Changes

### New `crux/lib/session/session-context.ts`

- `getSessionContext(deps?)` — collects `{slot, branch, host, agentId}` best-effort:
  - **Slot**: walks up from cwd looking for an `a<N>` directory (works from subdirectories like `a10/apps/web`); falls back to `.agent-slot` for legacy layouts.
  - **Branch**: `git branch --show-current` with try/catch fallback to `unknown-branch`.
  - **Host**: `os.hostname()` with fallback to `null`.
  - **Agent ID**: reads `.claude/agent-id` (written by `session-start.sh` after successful E925 registration).
- `buildStartCommentBody(ctx, opts?)` — builds the markdown comment. Includes each field when present, flags `main`/`master` branches with a visible ⚠ warning, and sanitizes branch/host for markdown code-span safety.
- Fully dependency-injected for pure unit testing — no fs/git mocking required.

### Hardening from `/agent-review-pr` (Phase 3 subagent red-team)

- **Strict int parser**: `parseStrictNonNegativeInt()` requires the whole trimmed string to be digits. Replaces `Number.parseInt` which silently accepted `"10abc"` as `10`, `"-5"` as `-5`, etc. Protects against typos and stray bytes in `.agent-slot` and `.claude/agent-id`.
- **Markdown sanitization**: branch names and hostnames are stripped of backticks, control characters (including newlines), and markdown metacharacters (`*_[]<>`) before interpolation. 200-char length cap. Previously a branch containing a backtick or newline would break out of the code span — the red-team test with `'evil`
## Injected Heading'` caught this before merge.
- **Ancestor directory walk**: slot resolution walks up parent dirs so agents running crux from a subdirectory still get slot info.

### Wiring

- `crux/commands/linear.ts::start()` — calls `getSessionContext()` + `buildStartCommentBody()` instead of hand-building the string. Surfaces slot in CLI output.
- `crux/commands/issues.ts::start()` — same for legacy GitHub `issues start`.
- No behavior change for the happy path — a correctly-branched session still gets the same information it got before, plus slot/host/agent-id.

### Example output

**Happy path** (on a `claude/qua-*` branch):
```
🤖 Claude Code starting work on this issue.

**Slot:** a10
**Branch:** `claude/qua-336-enrich-start-comment`
**Host:** MacBook-Pro-4.local
**Active agent ID:** #1234 (E925 dashboard)

Will post an update when a PR is ready for review.
```

**Warning path** (init'd before feature branch):
```
🤖 Claude Code starting work on this issue.

**Slot:** a10
**Branch:** `main` ⚠ (init'd before feature branch was created — expect a follow-up comment when the branch appears)
**Host:** MacBook-Pro-4.local

Will post an update when a PR is ready for review.
```

## Tests

25 unit tests in `crux/lib/session/session-context.test.ts`:

- **Slot resolution**: directory basename, `.agent-slot` fallback, subdirectory walk, mixed-content rejection (`"10abc"`), negative number rejection, missing-file fallback.
- **Agent ID**: file read, malformed file rejection, missing file.
- **Branch**: git success, git failure, empty → `unknown-branch`.
- **Host**: normal, empty → `null`.
- **Comment body**: all fields present, each field omitted individually, `main` warning, `master` warning, `claude/*` no-warning, custom trailing, determinism.
- **Sanitization**: backtick in branch, markdown metachars in host, newline injection attempt (verifies exactly 2 backticks on the branch line — caught a real bug during review).

1 existing test in `crux/commands/__tests__/linear.test.ts` updated to assert `**Host:**` appears in the comment body and no `⚠` is present for claude branches.

**All 50 affected tests pass. Full crux sweep (3849 tests) green. Full `pnpm test` (5825 tests) green.**

## Out of scope

- **Concurrent-agent dedup on ticket claim** — covered by QUA-304.
- **Auto-creating feature branch inside `init`** — follow-up. The root cause of "init on main" is a doc conflict: `CLAUDE.md` says "init first", `agent-session-workflow.md` says "branch first then init". Either path is fine, but they should agree.
- **Back-filling start comments on existing open tickets** — manual cleanup.

## Verification

- [x] `pnpm build` — clean
- [x] `pnpm test` — 5825/5825 pass
- [x] `pnpm crux w validate gate --fix` — 41/41 blocking checks pass
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] Targeted `tsc` on crux: my 5 files clean (existing baseline errors elsewhere unrelated)
- [x] `/agent-review-pr` — ran, 3 HIGH + 2 MED findings fixed, red-team caught 1 real bug
- [x] End-to-end CLI exercise: `getSessionContext()` + `buildStartCommentBody()` produce correct output in real session and synthetic `main` context

## Test plan

- [x] Unit tests pass
- [x] Build clean
- [x] Gate green
- [x] Review marker valid
- [ ] CI green on push
- [ ] Verify posted start comment on QUA-336 contains the new fields (will be visible after `crux linear done` posts the completion comment)

Fixes QUA-336
