### PR TITLE
QUA-313 sub-PR 3: sourcing-backfill-homepages CLI (narrow tactical cleanup)

### DIFF
--- a/crux/commands/sourcing-backfill-homepages.test.ts
+++ b/crux/commands/sourcing-backfill-homepages.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for `crux sourcing-backfill-homepages` pure helpers.
+ *
+ * Focus: `selectCandidates` (filter + idempotency), `groupByDomain`,
+ * `parseLimit`. The command's control flow (--dry-run / --apply gating,
+ * chunked writes, upsertResourceBatch call) is exercised via prod dry-run
+ * smoke tests outside the unit suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectCandidates,
+  groupByDomain,
+  parseLimit,
+  type BackfillCandidate,
+} from './sourcing-backfill-homepages.ts';
+import type { Resource } from '../resource-types.ts';
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+function r(
+  overrides: { id: string; url: string; title?: string; type?: string; enrichment_status?: string | null },
+): Resource {
+  return {
+    id: overrides.id,
+    url: overrides.url,
+    title: overrides.title ?? `Title for ${overrides.id}`,
+    type: overrides.type ?? 'web',
+    enrichment_status: overrides.enrichment_status ?? null,
+  } as unknown as Resource;
+}
+
+// ── selectCandidates ────────────────────────────────────────────────
+
+describe('selectCandidates', () => {
+  it('returns bare-domain URLs as candidates', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://anthropic.com/' }),
+      r({ id: 'r2', url: 'https://openai.com/' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id).sort()).toEqual(['r1', 'r2']);
+    for (const c of result) {
+      expect(c.confidence).toBeGreaterThanOrEqual(0.8);
+    }
+  });
+
+  it('returns /about-style paths as candidates', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://openai.com/about' }),
+      r({ id: 'r2', url: 'https://google.com/contact' }),
+      r({ id: 'r3', url: 'https://example.com/index.html' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(3);
+  });
+
+  it('skips deep paths (articles, papers)', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://www.lesswrong.com/posts/abc/some-article' }),
+      r({ id: 'r2', url: 'https://arxiv.org/abs/2301.00001' }),
+      r({ id: 'r3', url: 'https://example.com/blog/2024/my-post' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips PDFs (confident non-homepage)', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://example.com/report.pdf' }),
+      r({ id: 'r2', url: 'https://example.com/doc.pdf' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips URLs with data-like query params (not homepages)', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://example.com/?id=42' }),
+      r({ id: 'r2', url: 'https://youtube.com/?v=abc' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps bare domains with utm_* tracking params', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://example.com/?utm_source=x&utm_campaign=y' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(1);
+  });
+
+  it('skips resources without a URL', () => {
+    const pool = [
+      r({ id: 'r1', url: '' }),
+      r({ id: 'r2', url: 'https://anthropic.com/' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r2');
+  });
+
+  it('skips already-classified resources (idempotency)', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://anthropic.com/', enrichment_status: 'classified' }),
+      r({ id: 'r2', url: 'https://openai.com/', enrichment_status: null }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r2');
+  });
+
+  it('skips already-enriched and already-reviewed resources', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://anthropic.com/', enrichment_status: 'enriched' }),
+      r({ id: 'r2', url: 'https://openai.com/', enrichment_status: 'reviewed' }),
+      r({ id: 'r3', url: 'https://example.com/', enrichment_status: null }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r3');
+  });
+
+  it('respects a custom threshold', () => {
+    // /about has confidence 0.85; raising threshold to 0.9 excludes it,
+    // but bare-domain (0.95) remains.
+    const pool = [
+      r({ id: 'r1', url: 'https://anthropic.com/about' }), // 0.85
+      r({ id: 'r2', url: 'https://openai.com/' }),          // 0.95
+    ];
+    const result = selectCandidates(pool, 0.9);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r2');
+  });
+
+  it('normalizes www. prefix in the host field', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://www.anthropic.com/' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result[0].host).toBe('anthropic.com');
+  });
+
+  it('returns an empty array for an empty pool', () => {
+    expect(selectCandidates([])).toEqual([]);
+  });
+
+  it('handles mixed pool with realistic distribution (2-4% hit rate)', () => {
+    // 100 resources: 3 homepages, 97 deep-path articles
+    const pool: Resource[] = [];
+    for (let i = 0; i < 97; i++) {
+      pool.push(r({ id: `post${i}`, url: `https://lesswrong.com/posts/${i}/slug` }));
+    }
+    pool.push(r({ id: 'hp1', url: 'https://anthropic.com/' }));
+    pool.push(r({ id: 'hp2', url: 'https://openai.com/' }));
+    pool.push(r({ id: 'hp3', url: 'https://google.com/about' }));
+
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(3);
+    expect(new Set(result.map((c) => c.id))).toEqual(new Set(['hp1', 'hp2', 'hp3']));
+  });
+
+  it('returns classifier reasons alongside the candidate', () => {
+    const pool = [r({ id: 'r1', url: 'https://anthropic.com/' })];
+    const result = selectCandidates(pool);
+    expect(result[0].reasons).toContain('root-path');
+  });
+
+  it('skips URL shorteners (confidence 0, purpose=null)', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://bit.ly/abc123' }),
+      r({ id: 'r2', url: 'https://t.co/xyz' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips Wayback-wrapped non-homepage URLs but keeps wrapped bare domains', () => {
+    const pool = [
+      r({ id: 'r1', url: 'https://web.archive.org/web/20240101000000/https://anthropic.com/' }),
+      r({ id: 'r2', url: 'https://web.archive.org/web/20240101000000/https://lesswrong.com/posts/abc/slug' }),
+    ];
+    const result = selectCandidates(pool);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r1');
+  });
+});
+
+// ── groupByDomain ───────────────────────────────────────────────────
+
+describe('groupByDomain', () => {
+  function cand(id: string, host: string): BackfillCandidate {
+    return { id, url: `https://${host}/`, host, confidence: 0.95, reasons: [] };
+  }
+
+  it('counts candidates per host', () => {
+    const result = groupByDomain([
+      cand('a', 'anthropic.com'),
+      cand('b', 'anthropic.com'),
+      cand('c', 'openai.com'),
+    ]);
+    expect(result).toEqual([
+      { host: 'anthropic.com', count: 2, sampleId: 'a' },
+      { host: 'openai.com', count: 1, sampleId: 'c' },
+    ]);
+  });
+
+  it('sorts by count descending, then host alphabetically', () => {
+    const result = groupByDomain([
+      cand('1', 'z.com'),
+      cand('2', 'a.com'),
+      cand('3', 'a.com'),
+      cand('4', 'b.com'),
+      cand('5', 'b.com'),
+    ]);
+    expect(result.map((d) => d.host)).toEqual(['a.com', 'b.com', 'z.com']);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(groupByDomain([])).toEqual([]);
+  });
+
+  it('sampleId is the first candidate seen for that host', () => {
+    const result = groupByDomain([
+      cand('alice', 'example.com'),
+      cand('bob', 'example.com'),
+      cand('carol', 'example.com'),
+    ]);
+    expect(result[0].sampleId).toBe('alice');
+  });
+});
+
+// ── parseLimit ──────────────────────────────────────────────────────
+
+describe('parseLimit', () => {
+  it('returns null when omitted', () => {
+    expect(parseLimit(undefined)).toBeNull();
+    expect(parseLimit(null)).toBeNull();
+    expect(parseLimit('')).toBeNull();
+  });
+
+  it('parses numeric strings', () => {
+    expect(parseLimit('10')).toBe(10);
+    expect(parseLimit('500')).toBe(500);
+    expect(parseLimit(100)).toBe(100);
+  });
+
+  it('returns null on non-numeric input', () => {
+    expect(parseLimit('abc')).toBeNull();
+  });
+
+  it('returns null on zero or negative', () => {
+    expect(parseLimit('0')).toBeNull();
+    expect(parseLimit('-1')).toBeNull();
+    expect(parseLimit(-10)).toBeNull();
+  });
+
+  it('does NOT clamp to any max (unlike sample-size)', () => {
+    // parseLimit is just a cap; the command can accept any positive count.
+    expect(parseLimit('999999')).toBe(999999);
+  });
+});

--- a/crux/commands/sourcing-backfill-homepages.ts
+++ b/crux/commands/sourcing-backfill-homepages.ts
@@ -1,0 +1,360 @@
+/**
+ * Source-Check URL Heuristic — Narrow Homepage Backfill
+ *
+ * Populates `resource_purpose='homepage'` on the ~500 resources whose URLs
+ * deterministically classify as a landing page (bare domain, /about, /contact,
+ * etc.) with confidence >= FAST_PATH_THRESHOLD (0.8). No LLM calls, no
+ * ambiguous resources — the heuristic either says "yes, homepage, confident"
+ * or the resource is skipped.
+ *
+ * Phase 3 sub-PR 3 of QUA-313 / Discussion #4221 (revised plan, option A).
+ *
+ * The original Phase 3 plan assumed a 40% corpus-wide homepage rate and
+ * sized a full LLM backfill around it. The `sourcing-sample-coverage`
+ * command (sub-PR 2) measured the actual rate at 2-4% and found that the
+ * non-homepage URLs are legitimate content (articles, papers, PDFs). This
+ * command ships the "narrow tactical cleanup" interpretation: populate
+ * `resource_purpose` on the hits, drop the rest of the plan.
+ *
+ * Defaults to --dry-run. --apply writes via `upsertResourceBatch` with
+ * `{ resourcePurpose: 'homepage', enrichmentStatus: 'classified' }` in
+ * chunks of 100, fail-fast on any batch error (so partial-failure state
+ * doesn't accumulate). Idempotent: the filter excludes already-classified
+ * rows so rerunning is safe.
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { loadResourcesPGFirst } from '../resource-io.ts';
+import { upsertResourceBatch, type UpsertResourceItem } from '../lib/wiki-server/resources.ts';
+import { classifyByUrl } from './sourcing-audit-urls.ts';
+import type { Resource } from '../resource-types.ts';
+
+// ── Module constants ────────────────────────────────────────────────
+
+/**
+ * Minimum confidence to be considered a fast-path homepage. Matches the
+ * threshold in `crux/lib/sourcing/url-quality.ts::FAST_PATH_THRESHOLD`
+ * (0.8) and the threshold used by QUA-312's `classify.ts` fast-path.
+ */
+const FAST_PATH_THRESHOLD = 0.8;
+
+/** Write chunk size. 100 is below the server's 200 cap, leaves retry headroom. */
+const WRITE_CHUNK = 100;
+
+/** Output-truncation limits for human-readable mode. */
+const SAMPLE_URLS_SHOWN = 20;
+const TOP_DOMAINS_SHOWN = 20;
+
+// ── ANSI helpers ────────────────────────────────────────────────────
+
+function useColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  return !!process.stdout.isTTY;
+}
+
+const ANSI = {
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  dim: '\x1b[2m',
+} as const;
+
+const bold = (s: string) => (useColor() ? `${ANSI.bold}${s}${ANSI.reset}` : s);
+const green = (s: string) => (useColor() ? `${ANSI.green}${s}${ANSI.reset}` : s);
+const yellow = (s: string) => (useColor() ? `${ANSI.yellow}${s}${ANSI.reset}` : s);
+const dim = (s: string) => (useColor() ? `${ANSI.dim}${s}${ANSI.reset}` : s);
+
+// ── Pure helpers (exported for tests) ───────────────────────────────
+
+export interface BackfillCandidate {
+  id: string;
+  url: string;
+  host: string;
+  confidence: number;
+  reasons: string[];
+}
+
+/** Extract the normalized hostname for a URL, or a sentinel on failure. */
+function extractHostSafe(raw: string): string {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    if (host.startsWith('www.')) host = host.slice(4);
+    return host;
+  } catch {
+    return '(invalid-url)';
+  }
+}
+
+/**
+ * Filter the resource pool to only fast-path homepage candidates that
+ * still need classification. Skips resources that are:
+ *   - missing a URL
+ *   - already `classified` / `enriched` / `reviewed`
+ *   - classified by the URL heuristic as non-homepage (or ambiguous < 0.8)
+ *
+ * Pure function — no network, no fs. Used by both the command and the
+ * tests.
+ */
+export function selectCandidates(
+  resources: ReadonlyArray<Resource>,
+  threshold: number = FAST_PATH_THRESHOLD,
+): BackfillCandidate[] {
+  const out: BackfillCandidate[] = [];
+  for (const r of resources) {
+    if (!r.url) continue;
+    // Skip resources already classified, enriched, or reviewed. `classified`
+    // is what this command writes, so excluding it makes rerunning idempotent.
+    const status = (r as Resource & { enrichment_status?: string | null }).enrichment_status;
+    if (status === 'classified' || status === 'enriched' || status === 'reviewed') {
+      continue;
+    }
+    const cls = classifyByUrl(r.url);
+    if (cls.purpose !== 'homepage' || cls.confidence < threshold) continue;
+    out.push({
+      id: r.id,
+      url: r.url,
+      host: extractHostSafe(r.url),
+      confidence: cls.confidence,
+      reasons: cls.reasons,
+    });
+  }
+  return out;
+}
+
+/**
+ * Group candidates by domain and rank by frequency. Used in both dry-run
+ * output and JSON output so operators can sanity-check the target set at
+ * a glance.
+ */
+export function groupByDomain(
+  candidates: ReadonlyArray<BackfillCandidate>,
+): Array<{ host: string; count: number; sampleId: string }> {
+  const map = new Map<string, { host: string; count: number; sampleId: string }>();
+  for (const c of candidates) {
+    const existing = map.get(c.host);
+    if (existing) {
+      existing.count++;
+    } else {
+      map.set(c.host, { host: c.host, count: 1, sampleId: c.id });
+    }
+  }
+  return [...map.values()].sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.host.localeCompare(b.host);
+  });
+}
+
+/** Parse and clamp the --limit flag. Undefined → no limit. */
+export function parseLimit(raw: unknown): number | null {
+  if (raw === undefined || raw === null || raw === '') return null;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+// ── Command ─────────────────────────────────────────────────────────
+
+interface BackfillOptions extends BaseOptions {
+  apply?: boolean;
+  'dry-run'?: boolean;
+  dryRun?: boolean;
+  limit?: string;
+  json?: boolean;
+}
+
+async function backfillCommand(
+  _args: string[],
+  options: BackfillOptions,
+): Promise<CommandResult> {
+  // --dry-run is the default. --apply flips to write mode. If the user
+  // passes both, --dry-run wins (safer default).
+  const explicitDryRun = options['dry-run'] || options.dryRun;
+  const shouldApply = !!options.apply && !explicitDryRun;
+  const dryRun = !shouldApply;
+  const limit = parseLimit(options.limit);
+  const isJson = !!options.json;
+
+  if (!isJson) {
+    console.log(bold('Source-Check URL Heuristic — Homepage Backfill'));
+    console.log(dryRun ? dim('Mode: DRY RUN (use --apply to write)') : green('Mode: APPLY — will write to prod'));
+    if (limit !== null) console.log(`Limit: ${limit} resources`);
+    console.log('');
+    console.log('Loading resources from wiki-server (or PG snapshot fallback)...');
+  }
+
+  let resources: Resource[];
+  try {
+    resources = await loadResourcesPGFirst();
+  } catch (err) {
+    return {
+      exitCode: 1,
+      output: `Failed to load resources: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const candidates = selectCandidates(resources);
+  const limited = limit !== null ? candidates.slice(0, limit) : candidates;
+  const byDomain = groupByDomain(limited);
+
+  // ── JSON output (dry-run or apply both supported) ──
+  if (isJson) {
+    if (dryRun) {
+      return {
+        exitCode: 0,
+        output: JSON.stringify({
+          mode: 'dry-run',
+          poolSize: resources.length,
+          eligibleCount: candidates.length,
+          plannedWrites: limited.length,
+          byDomain,
+        }),
+      };
+    }
+    // Apply + JSON: run the writes, then emit the result.
+    const writeOutcome = await writeChunked(limited);
+    return {
+      exitCode: writeOutcome.ok ? 0 : 1,
+      output: JSON.stringify({
+        mode: 'apply',
+        poolSize: resources.length,
+        eligibleCount: candidates.length,
+        attempted: limited.length,
+        written: writeOutcome.written,
+        error: writeOutcome.error ?? null,
+        byDomain,
+      }),
+    };
+  }
+
+  // ── Human output ──
+  if (limited.length === 0) {
+    console.log('');
+    console.log(green('✓ No homepage backfill candidates remain. Already up to date.'));
+    return { exitCode: 0, output: '' };
+  }
+
+  console.log('');
+  console.log(bold('=== Homepage backfill plan ==='));
+  console.log(`Pool size:        ${resources.length}`);
+  console.log(`Eligible:         ${candidates.length}`);
+  if (limit !== null && candidates.length > limit) {
+    console.log(`Planned writes:   ${limited.length} ${dim(`(--limit=${limit} of ${candidates.length})`)}`);
+  } else {
+    console.log(`Planned writes:   ${limited.length}`);
+  }
+  console.log(`Cost:             $0 (no LLM calls)`);
+  console.log('');
+
+  console.log(bold('Top domains'));
+  console.log('-'.repeat(72));
+  console.log(bold(`  ${'Count'.padStart(5)}  Domain`));
+  for (const d of byDomain.slice(0, TOP_DOMAINS_SHOWN)) {
+    console.log(`  ${String(d.count).padStart(5)}  ${d.host}`);
+  }
+  if (byDomain.length > TOP_DOMAINS_SHOWN) {
+    console.log(`  ... and ${byDomain.length - TOP_DOMAINS_SHOWN} more domains`);
+  }
+  console.log('');
+
+  console.log(bold(`Sample URLs (first ${SAMPLE_URLS_SHOWN})`));
+  console.log('-'.repeat(72));
+  for (const c of limited.slice(0, SAMPLE_URLS_SHOWN)) {
+    const url = c.url.length > 65 ? c.url.slice(0, 62) + '...' : c.url;
+    console.log(`  [conf=${c.confidence.toFixed(2)}] ${url}`);
+  }
+  console.log('');
+
+  if (dryRun) {
+    console.log(yellow('Dry run — no writes performed. Re-run with --apply to execute.'));
+    return { exitCode: 0, output: '' };
+  }
+
+  // ── Apply path ──
+  console.log(bold(`Writing ${limited.length} classifications in chunks of ${WRITE_CHUNK}...`));
+  const outcome = await writeChunked(limited, (batchIdx, total) => {
+    console.log(`  batch ${batchIdx}/${total} — ${green('ok')}`);
+  });
+
+  if (!outcome.ok) {
+    return {
+      exitCode: 1,
+      output: `\nFast-path batch write failed: ${outcome.error}\n  Written so far: ${outcome.written}\n`,
+    };
+  }
+
+  console.log('');
+  console.log(green(`✓ Wrote ${outcome.written} homepage classifications.`));
+  return { exitCode: 0, output: '' };
+}
+
+interface WriteOutcome {
+  ok: boolean;
+  written: number;
+  error?: string;
+}
+
+async function writeChunked(
+  candidates: ReadonlyArray<BackfillCandidate>,
+  onChunkOk?: (batchIdx: number, total: number) => void,
+): Promise<WriteOutcome> {
+  let written = 0;
+  const total = Math.ceil(candidates.length / WRITE_CHUNK);
+  for (let i = 0; i < candidates.length; i += WRITE_CHUNK) {
+    const chunk = candidates.slice(i, i + WRITE_CHUNK);
+    const items: UpsertResourceItem[] = chunk.map((c) => ({
+      id: c.id,
+      url: c.url,
+      resourcePurpose: 'homepage',
+      enrichmentStatus: 'classified',
+    }));
+    const result = await upsertResourceBatch(items);
+    if (!result.ok) {
+      return { ok: false, written, error: result.message ?? 'unknown error' };
+    }
+    written += chunk.length;
+    onChunkOk?.(Math.floor(i / WRITE_CHUNK) + 1, total);
+  }
+  return { ok: true, written };
+}
+
+// ── Exports ─────────────────────────────────────────────────────────
+
+export const commands = {
+  default: backfillCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check URL Heuristic — Homepage Backfill
+
+Usage:
+  crux sourcing-backfill-homepages [options]
+
+Options:
+  --apply                Write the classifications. Without this flag the
+                         command runs as a dry run (no writes).
+  --dry-run              Explicitly opt into dry-run mode (default). If both
+                         --dry-run and --apply are passed, --dry-run wins.
+  --limit=N              Cap the number of resources to process. Useful for
+                         testing with a small batch first.
+  --json                 Machine-readable output.
+
+What it does:
+  Finds resources whose URL shape is an obvious landing page (bare domain,
+  /about, /contact, /home, /index, etc.) and writes
+  \`resource_purpose='homepage'\` + \`enrichment_status='classified'\` via
+  upsertResourceBatch. No LLM calls. Idempotent — already-classified
+  resources are filtered out, so rerunning is safe.
+
+Why narrow:
+  The original URL-Quality Phase 3 plan assumed a ~40% heuristic hit rate
+  and sized a full LLM backfill around it. The \`sourcing-sample-coverage\`
+  tool (QUA-313 sub-PR 2) measured the actual rate at 2-4% — most wiki
+  resources are specific articles/papers, not landing pages, which is
+  correct behavior for a healthy wiki. This command ships the narrow
+  tactical cleanup (~500 deterministic hits, $0 cost) and defers the
+  rest of the plan. See Discussion #4221 for context.
+`.trim();
+}

--- a/crux/commands/sourcing-backfill-homepages.ts
+++ b/crux/commands/sourcing-backfill-homepages.ts
@@ -309,7 +309,16 @@ async function writeChunked(
       resourcePurpose: 'homepage',
       enrichmentStatus: 'classified',
     }));
-    const result = await upsertResourceBatch(items);
+    let result: Awaited<ReturnType<typeof upsertResourceBatch>>;
+    try {
+      result = await upsertResourceBatch(items);
+    } catch (err) {
+      return {
+        ok: false,
+        written,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
     if (!result.ok) {
       return { ok: false, written, error: result.message ?? 'unknown error' };
     }

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -96,6 +96,7 @@ import * as factbaseMigrateEntitiesCommands from './commands/factbase-migrate-en
 import * as verifyOrchestrateCommands from './commands/sourcing-orchestrate.ts';
 import * as sourcingRecheckCommands from './commands/sourcing-recheck.ts';
 import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
+import * as sourcingBackfillHomepagesCommands from './commands/sourcing-backfill-homepages.ts';
 import * as sourcingSuggestUrlsCommands from './commands/sourcing-suggest-urls.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
@@ -185,6 +186,7 @@ const domains = {
   'verify-orchestrate': verifyOrchestrateCommands,
   'sourcing-recheck': sourcingRecheckCommands,
   'sourcing-audit-urls': sourcingAuditUrlsCommands,
+  'sourcing-backfill-homepages': sourcingBackfillHomepagesCommands,
   'sourcing-suggest-urls': sourcingSuggestUrlsCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,


### PR DESCRIPTION
## Summary

Third shippable slice of QUA-313 / URL-Quality Phase 3 ([Discussion #4221](https://github.com/quantified-uncertainty/longterm-wiki/discussions/4221), revised plan **option A**). Narrow backfill command that populates `resource_purpose='homepage'` on resources whose URLs deterministically classify as landing pages. **No LLM, no residual, no wiki-server schema changes.**

## Why narrow

The original Phase 3 plan assumed a ~40% heuristic hit rate and sized a full LLM backfill around it. Sub-PR 2's `sourcing-sample-coverage` tool measured the actual rate at 2–4% and found that non-homepage URLs are legitimate content (LessWrong posts, arxiv papers, CSET reports, etc.) — exactly what a healthy wiki should link to.

After reviewing the finding, Phase 3 was re-scoped as **A + B in parallel**:
- **A (this PR)**: narrow tactical cleanup — populate `resource_purpose` on the deterministic homepage hits, drop the LLM residual from scope.
- **B (QUA-342)**: root-cause investigation for the 3,277 stuck verdicts from QUA-113, since homepage URLs are one of many causes, not the dominant one.

## Prod dry-run smoke-test

Unlike sub-PR 2's 2–4% on the full 22,693 pool, this command also filters to resources that aren't already `classified` / `enriched` / `reviewed`. Most of the corpus has already been through a classify batch, so the eligibility count is **40**, not ~500:

```
$ WIKI_SERVER_ENV=prod pnpm crux sourcing-backfill-homepages

Pool size:        22693
Eligible:         40
Planned writes:   40
Cost:             $0 (no LLM calls)
```

All 40 are legitimate org landing pages: `thefuturesociety.org`, `cdt.org`, `lawfare.com`, `pitchbook.com`, `politico.com`, `theglobalfund.org`, `anthropic.io`, `farlabs.org`, etc. — exactly the deterministic correctness fix this command was designed for.

## Scope

### `crux/commands/sourcing-backfill-homepages.ts` (new)

New flat command:

| Flag | Purpose |
|---|---|
| `--apply` | Write the classifications (dry-run is default) |
| `--dry-run` | Explicit dry-run mode (takes precedence over `--apply`) |
| `--limit=N` | Cap the number of writes |
| `--json` | Machine-readable output |

Writes via `upsertResourceBatch` (typed client) in chunks of 100 with fail-fast error handling. `selectCandidates` filter skips:
- Resources without a URL
- Resources already in `classified` / `enriched` / `reviewed` status
- URLs that classify as non-homepage or below `FAST_PATH_THRESHOLD` (0.8)

**Idempotent**: the status filter excludes already-classified rows, so rerunning is safe.

### `crux.mjs`

Registers the new flat command alongside `sourcing-audit-urls` and `sourcing-sample-coverage`.

### Pure helpers (exported for tests)

- `selectCandidates(resources, threshold?)` — filter + bucket
- `groupByDomain(candidates)` — aggregate for reporting
- `parseLimit(raw)` — CLI flag parser

## Tests

`crux/commands/sourcing-backfill-homepages.test.ts` (new, **25 tests**):

- **`selectCandidates`** (16 tests): bare-domain → candidate, /about paths → candidate, deep paths → skipped, PDFs → skipped, data-param query → skipped, utm_* tracking only → still homepage, missing URL → skipped, already-classified / enriched / reviewed → skipped, custom threshold, www. normalization, empty pool, realistic 2-4% distribution (3 homepages in 100 articles), classifier reasons propagated, URL shorteners → skipped, Wayback-wrap with bare-domain inner → kept, Wayback-wrap with deep inner → skipped
- **`groupByDomain`** (4 tests): count per host, sort by count desc + host alphabetical, empty input, sampleId is first-seen
- **`parseLimit`** (5 tests): null when omitted, numeric string, non-numeric, zero/negative, no upper clamp

## Verification

- [x] `npx vitest run crux/commands/sourcing-backfill-homepages.test.ts` — **25/25 pass**
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — zero errors
- [x] `pnpm crux w validate gate --fix` — **48/48 gate checks pass**
- [x] `pnpm build` — clean
- [x] `WIKI_SERVER_ENV=prod pnpm crux sourcing-backfill-homepages` — dry-run output above
- [x] `pnpm crux sourcing-backfill-homepages --help` — help text renders
- [ ] CI green on push
- [ ] `gate:rules-ok` label added (requires human review of protected `crux/commands/` paths)

## Follow-ups

- **QUA-342** (option B): root-cause investigation for the 3,277 stuck verdicts. Filed tonight, research task not a code task.
- **After this PR merges**: run `WIKI_SERVER_ENV=prod pnpm crux sourcing-backfill-homepages --apply` once to write the 40 classifications. One-time cleanup.
- **Not filing a recurring job** — the eligibility count will stay low and can be rerun manually as new resources come in.

## Test plan

- [x] Tests pass
- [x] Gate clean
- [x] Build clean
- [x] Prod dry-run smoke test
- [ ] CI green on push
- [ ] `gate:rules-ok` label added

Fixes QUA-313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command for homepage resource classification using URL heuristics with confidence threshold (0.8+).
  * Supports dry-run and apply modes; apply mode processes in batches of 100.
  * Supports `--limit` parameter and `--json` output for structured results.

* **Tests**
  * Added comprehensive test suite covering filtering logic, domain grouping, parameter parsing, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->