### PR TITLE
fix(ci): remove redundant pnpm version from flagship-curate + sourcing-recheck

### DIFF
--- a/.github/workflows/flagship-curate.yml
+++ b/.github/workflows/flagship-curate.yml
@@ -78,8 +78,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sourcing-recheck.yml
+++ b/.github/workflows/sourcing-recheck.yml
@@ -62,8 +62,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

`pnpm/action-setup@v4` now rejects specifying the pnpm version in both the action config *and* `package.json`'s `packageManager` field. Two workflows still had both, and they error out at the pnpm setup step with `ERR_PNPM_BAD_PM_VERSION` before running any job.

This bit release PR #4225's deploy flow: PR #4233's deploy task asked us to trigger `flagship-curate` via `workflow_dispatch` as the first paid-run smoke, and it failed immediately at step 4. `sourcing-recheck.yml` has the same bug and would fail on its next Monday 08:00 UTC cron.

## Fix

Delete the four-line `with: version: 9` block from both workflows and let `package.json`'s `packageManager: pnpm@9.15.4` be the single source of truth, matching every other workflow in the repo (~30 others already do this).

```diff
 - uses: pnpm/action-setup@v4
-  with:
-    version: 9
```

## Scope check

Grepped `pnpm/action-setup@v4` across all ~30 workflows. Only these two files had the broken block:

- `.github/workflows/flagship-curate.yml` (just shipped in PR #4233, failing now)
- `.github/workflows/sourcing-recheck.yml` (weekly cron, would fail next Monday)

Every other workflow (`ci.yml`, `auto-update.yml`, `e2e-post-deploy.yml`, `sync-entities-facts.yml`, `job-worker.yml`, …) correctly omits `with: version:`. One-line deletion from two files, same root cause, same fix.

## Test plan

- [x] `pnpm crux w validate gate --fix` — all 44 blocking checks pass (3 advisory pre-existing baseline warnings, unrelated)
- [ ] After merge: re-trigger `flagship-curate` via `workflow_dispatch` with the defaults (PR #4233's deploy task) and confirm it gets past the pnpm-action-setup step
- [ ] `sourcing-recheck` will self-verify on its next Monday 08:00 UTC tick

## Out of scope

A gate validator that flags `pnpm/action-setup@vN` immediately followed by a `with: version:` block would prevent copy-paste regressions. Not urgent — only 2 files regressed — filing as a follow-up on QUA-347 comment.

Fixes QUA-347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration defaults for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->