### PR TITLE
feat(crux): ws subcommands for coordinator sentinel, tmux-claim, and doctors

### DIFF
--- a/crux/commands/__tests__/agent-workspace-rename.test.ts
+++ b/crux/commands/__tests__/agent-workspace-rename.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the @lw-coord-role marker integration in renameTmuxWindows.
+ *
+ * The function itself shells out to `tmux`; we mock at the child_process
+ * boundary using vi.mock so the test exercises the real branching logic
+ * without touching a real tmux session.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execCalls: Array<{ cmd: string; opts?: unknown }> = [];
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execSync: vi.fn((cmd: string, opts?: unknown) => {
+      execCalls.push({ cmd, opts });
+      return execScript(cmd);
+    }),
+  };
+});
+
+vi.mock('../../lib/content-types.ts', () => ({ PROJECT_ROOT: '/lw/main' }));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: () => true,
+    readdirSync: () => [],
+    statSync: () => ({ isDirectory: () => true }) as never,
+  };
+});
+
+let scriptedExec: (cmd: string) => string = () => '';
+function execScript(cmd: string): string {
+  return scriptedExec(cmd);
+}
+
+beforeEach(() => {
+  execCalls.length = 0;
+  scriptedExec = () => '';
+  process.env.TMUX = '/tmp/tmux-501/default,1,0';
+});
+
+describe('renameTmuxWindows + @lw-coord-role marker', () => {
+  it('skips marked windows entirely (no rename-window call)', async () => {
+    const mod = await import('../agent-workspace.ts');
+    const fns = mod as unknown as { commands: Record<string, (a: string[], o: object) => Promise<{ exitCode: number; output?: string }>> };
+    expect(fns.commands['fix-tabs']).toBeDefined();
+
+    scriptedExec = (cmd) => {
+      if (cmd.startsWith('tmux -V')) return 'tmux 3.3a\n';
+      if (cmd.includes('@lw-coord-role')) {
+        // Window @0 is marked "slots", @1 has no marker
+        return '0|||slots\n1|||\n';
+      }
+      if (cmd.startsWith('tmux list-windows')) {
+        // The "lw root" window @1 — should be renamed to LW
+        return '1|||/lw|||old-name\n0|||/lw|||slots\n';
+      }
+      if (cmd.startsWith('git ')) return 'main';
+      return '';
+    };
+
+    const result = await fns.commands['fix-tabs']([], {});
+    expect(result.exitCode).toBe(0);
+    // Only window 1 ("LW" candidate) should have been renamed
+    const renames = execCalls.filter((c) => c.cmd.includes('rename-window'));
+    expect(renames).toHaveLength(1);
+    expect(renames[0].cmd).toContain('-t "1"');
+    expect(renames[0].cmd).toContain('"LW"');
+    // window 0 (marked "slots") MUST NOT appear in any rename-window call
+    expect(renames.every((c) => !c.cmd.includes('-t "0"'))).toBe(true);
+  });
+
+  it('falls back to legacy behavior on tmux <3.0 (no marker query result)', async () => {
+    const mod = await import('../agent-workspace.ts');
+    const fns = mod as unknown as { commands: Record<string, (a: string[], o: object) => Promise<{ exitCode: number; output?: string }>> };
+
+    scriptedExec = (cmd) => {
+      if (cmd.startsWith('tmux -V')) return 'tmux 2.9a\n';
+      if (cmd.includes('@lw-coord-role')) return '';
+      if (cmd.startsWith('tmux list-windows')) return '0|||/lw|||old\n';
+      if (cmd.startsWith('git ')) return 'main';
+      return '';
+    };
+
+    await fns.commands['fix-tabs']([], {});
+    const renames = execCalls.filter((c) => c.cmd.includes('rename-window'));
+    expect(renames).toHaveLength(1);
+    expect(renames[0].cmd).toContain('"LW"');
+  });
+
+  it('renames slot window when no marker is set', async () => {
+    const mod = await import('../agent-workspace.ts');
+    const fns = mod as unknown as { commands: Record<string, (a: string[], o: object) => Promise<{ exitCode: number; output?: string }>> };
+
+    scriptedExec = (cmd) => {
+      if (cmd.startsWith('tmux -V')) return 'tmux 3.3a\n';
+      if (cmd.includes('@lw-coord-role')) return '5|||\n';
+      if (cmd.startsWith('tmux list-windows')) return '5|||/lw/a3|||old\n';
+      if (cmd.startsWith('git ')) return 'feature-x';
+      return '';
+    };
+
+    await fns.commands['fix-tabs']([], {});
+    const renames = execCalls.filter((c) => c.cmd.includes('rename-window'));
+    expect(renames).toHaveLength(1);
+    expect(renames[0].cmd).toContain('A3:feature-x');
+  });
+});

--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -11,12 +11,45 @@
  *   crux sys agent-workspace clean [N]       Remove idle agent slots (on main, no changes)
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync, statSync, copyFileSync, mkdirSync } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  lstatSync,
+  copyFileSync,
+  mkdirSync,
+  unlinkSync,
+  utimesSync,
+} from 'fs';
 import { join, dirname } from 'path';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
+import os from 'os';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
+import {
+  type Role,
+  type SentinelEnv,
+  writeSentinel as writeSentinelImpl,
+  touchSentinel as touchSentinelImpl,
+  checkConflict as checkConflictImpl,
+} from '../lib/agent-workspace/sentinel.ts';
+import {
+  type TmuxExec,
+  type TmuxExecResult,
+  claimWindow as claimWindowImpl,
+} from '../lib/agent-workspace/tmux.ts';
+import {
+  runDoctor,
+  renderPretty as renderDoctorPretty,
+  renderJson as renderDoctorJson,
+  exitCodeFor as doctorExitCode,
+} from '../lib/agent-workspace/doctor/runner.ts';
+import { realDoctorEnv } from '../lib/agent-workspace/doctor/env.ts';
+import { SLOTS_CHECKS } from '../lib/agent-workspace/doctor/slots.ts';
+import { RELEASES_CHECKS } from '../lib/agent-workspace/doctor/releases.ts';
 
 interface CommandOptions extends BaseOptions {
   ci?: boolean;
@@ -639,14 +672,55 @@ async function refresh(_args: string[], _options: CommandOptions): Promise<Comma
 // fix-tabs — rename tmux windows to match actual slot + branch
 // ---------------------------------------------------------------------------
 
+/**
+ * Read the @lw-coord-role marker for every tmux window.
+ *
+ * Returns a map of window-index → role string ("slots"|"releases") for windows
+ * that have the marker set. Requires tmux ≥ 3.0 for `#{@user-option}` format
+ * substitution; older tmux returns an empty map (caller falls back to the
+ * pre-marker behavior, which is safe because the rename loop just renames
+ * everything as before).
+ */
+function readRoleMarkers(): Map<string, string> {
+  const markers = new Map<string, string>();
+  // Probe tmux version once. <3.0 doesn't support #{@user-option} → bail.
+  try {
+    const version = execSync('tmux -V', { encoding: 'utf-8', timeout: 3000 }).trim();
+    const m = version.match(/(\d+)\.(\d+)/);
+    if (!m || Number(m[1]) < 3) return markers;
+  } catch {
+    return markers;
+  }
+  try {
+    const raw = execSync(
+      `tmux list-windows -a -F '#{window_index}|||#{@lw-coord-role}'`,
+      { encoding: 'utf-8', timeout: 5000 },
+    );
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      const parts = line.split('|||');
+      if (parts.length < 2) continue;
+      const role = parts[1].trim();
+      if (role === 'slots' || role === 'releases') markers.set(parts[0], role);
+    }
+  } catch { /* ignore — empty marker map is harmless */ }
+  return markers;
+}
+
 /** Scan all tmux windows and rename those whose pane CWD is an agent slot or the coordinator */
 function renameTmuxWindows(lwDir: string): string[] {
   if (!process.env.TMUX) return [];
 
   const windows = listTmuxWindows();
+  const roleMarkers = readRoleMarkers();
   const renamed: string[] = [];
 
   for (const win of windows) {
+    // Coordinator-claimed window: skip entirely so /agent-slots-start and
+    // /agent-releases-start can keep their chosen window names. The marker
+    // is set BEFORE rename inside claimWindow() so we never miss it here.
+    if (roleMarkers.has(win.index)) continue;
+
     // Coordinator window — lw/ root (not a slot)
     if (win.cwd === lwDir) {
       if (win.name !== 'LW') {
@@ -699,6 +773,196 @@ async function fixTabs(_args: string[], _options: CommandOptions): Promise<Comma
 }
 
 // ---------------------------------------------------------------------------
+// Sentinel + tmux-claim + doctor (QUA-339)
+// ---------------------------------------------------------------------------
+
+interface RoleOptions extends CommandOptions {
+  role?: string;
+}
+
+function parseRole(opts: RoleOptions): Role | { error: string } {
+  const v = opts.role;
+  if (v === 'slots' || v === 'releases') return v;
+  return { error: `--role must be 'slots' or 'releases' (got: ${v ?? 'missing'})` };
+}
+
+/** Real-world SentinelEnv backed by node:fs and live tmux. */
+function makeSentinelEnv(): SentinelEnv {
+  return {
+    now: () => new Date(),
+    env: process.env,
+    hostname: () => os.hostname(),
+    uid: () => (typeof process.getuid === 'function' ? process.getuid() : 0),
+    ppid: () => process.ppid,
+    readFile(path) {
+      try { return readFileSync(path, 'utf-8'); } catch { return null; }
+    },
+    writeFile(path, content) { writeFileSync(path, content); },
+    touch(path) {
+      const now = new Date();
+      utimesSync(path, now, now);
+    },
+    statMtime(path) {
+      try { return Math.floor(statSync(path).mtimeMs / 1000); } catch { return null; }
+    },
+    unlink(path) {
+      try { unlinkSync(path); } catch { /* already gone */ }
+    },
+    listMatching(dir, prefix) {
+      try {
+        return readdirSync(dir)
+          .filter((n) => n.startsWith(prefix))
+          .map((n) => `${dir}/${n}`);
+      } catch { return []; }
+    },
+    listTmuxPanes() {
+      if (!process.env.TMUX) return null;
+      try {
+        const r = execSync(`tmux list-panes -a -F '#{pane_id}'`, { encoding: 'utf-8', timeout: 3000 });
+        return r.split('\n').map((s) => s.trim()).filter(Boolean);
+      } catch { return null; }
+    },
+    pidAlive(pid) {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    },
+  };
+}
+
+/** Real-world TmuxExec backed by spawnSync. */
+function makeTmuxExec(): TmuxExec {
+  return {
+    inTmux: () => process.env.TMUX ?? null,
+    run(args: string[]): TmuxExecResult {
+      const r = spawnSync('tmux', args, { encoding: 'utf-8', timeout: 5000 });
+      if (r.error) {
+        return { stdout: r.stdout ?? '', stderr: r.stderr ?? r.error.message, code: 1 };
+      }
+      return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.status ?? 0 };
+    },
+  };
+}
+
+async function sentinelWrite(_args: string[], options: RoleOptions): Promise<CommandResult> {
+  const role = parseRole(options);
+  if (typeof role !== 'string') return { exitCode: 1, output: role.error };
+  const env = makeSentinelEnv();
+  const { path, sentinel } = writeSentinelImpl(role, env);
+  if (options.json) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({ ok: true, role, path, sentinel }, null, 2),
+    };
+  }
+  return { exitCode: 0, output: `wrote sentinel: ${path}` };
+}
+
+async function sentinelTouch(_args: string[], options: RoleOptions): Promise<CommandResult> {
+  const role = parseRole(options);
+  if (typeof role !== 'string') return { exitCode: 1, output: role.error };
+  const env = makeSentinelEnv();
+  const { path, touched } = touchSentinelImpl(role, env);
+  if (options.json) {
+    return { exitCode: 0, output: JSON.stringify({ ok: true, role, path, touched }, null, 2) };
+  }
+  return { exitCode: 0, output: touched ? `touched ${path}` : `(no sentinel at ${path} to touch)` };
+}
+
+async function sentinelCheck(_args: string[], options: RoleOptions): Promise<CommandResult> {
+  const role = parseRole(options);
+  if (typeof role !== 'string') return { exitCode: 1, output: role.error };
+  const env = makeSentinelEnv();
+  const result = checkConflictImpl(role, env);
+
+  if (options.json) {
+    const exit = result.conflict?.kind === 'same-session' ? 2 : 0;
+    return {
+      exitCode: exit,
+      output: JSON.stringify(
+        {
+          ok: exit === 0,
+          role,
+          ourPath: result.ourPath,
+          conflict: result.conflict,
+          cleaned: result.cleaned,
+        },
+        null,
+        2,
+      ),
+    };
+  }
+
+  if (!result.conflict) {
+    const tail = result.cleaned > 0 ? ` (cleaned ${result.cleaned} stale)` : '';
+    return { exitCode: 0, output: `✓ no role conflict${tail}` };
+  }
+  if (result.conflict.kind === 'same-session') {
+    const banner = [
+      '======================================================================',
+      'ROLE CONFLATION DETECTED — this Claude session previously ran the',
+      'OTHER coordinator startup skill.',
+      '',
+      '  • slots owns:   PR patrol, tmux rename, slot lifecycle, dispatch',
+      '  • releases owns: ops/ writes, release PRs, deploys, prod incidents',
+      '',
+      'Running both in one session means: PR patrol may compete with a',
+      'release window, ops edits may race PR patrol iterations, context',
+      'fills twice as fast, tmux rename loops may double-fire.',
+      '',
+      'WHAT TO DO:',
+      '  1. (RECOMMENDED) Open a new tmux window (Ctrl-b c), cd to lw/,',
+      `     run the OTHER startup skill there. Leave THIS session as ${role}.`,
+      '  2. (IF YOU ARE SURE) Re-run with --force to override.',
+      '======================================================================',
+      `existing sentinel: ${result.conflict.path}`,
+    ].join('\n');
+    return { exitCode: 2, output: banner };
+  }
+  // cross-session: expected and informational
+  return {
+    exitCode: 0,
+    output: `✓ other role (${result.conflict.sentinel.role}) running in a DIFFERENT session — that's expected. Proceeding.`,
+  };
+}
+
+async function tmuxClaim(_args: string[], options: RoleOptions): Promise<CommandResult> {
+  const role = parseRole(options);
+  if (typeof role !== 'string') return { exitCode: 1, output: role.error };
+  const exec = makeTmuxExec();
+  const result = claimWindowImpl(role, exec);
+  if (options.json) {
+    return { exitCode: result.status === 'error' ? 1 : 0, output: JSON.stringify(result, null, 2) };
+  }
+  if (result.status === 'skipped-no-tmux') {
+    return { exitCode: 0, output: '(not in tmux — skipping window rename)' };
+  }
+  if (result.status === 'skipped-no-current') {
+    return { exitCode: 0, output: `(no current tmux window — skipping: ${result.detail})` };
+  }
+  if (result.status === 'error') {
+    return { exitCode: 1, output: `error: ${result.detail}` };
+  }
+  const markerNote = result.markerUnsupported
+    ? ' (tmux <3.0: skipped @lw-coord-role marker)'
+    : ` (marker: @lw-coord-role=${result.marker})`;
+  return { exitCode: 0, output: `✓ tmux window renamed to '${result.finalName}'${markerNote}` };
+}
+
+async function doctor(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const which = args.find((a) => !a.startsWith('-'));
+  if (which !== 'slots' && which !== 'releases') {
+    return {
+      exitCode: 1,
+      output: 'Usage: crux ws doctor <slots|releases> [--json]',
+    };
+  }
+  const env = realDoctorEnv(getLwDir());
+  const checks = which === 'slots' ? SLOTS_CHECKS : RELEASES_CHECKS;
+  const report = await runDoctor(which, checks, env);
+  const output = options.json ? renderDoctorJson(report) : renderDoctorPretty(report);
+  return { exitCode: doctorExitCode(report.worst), output };
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
@@ -711,6 +975,11 @@ export const commands: Record<string, (args: string[], options: CommandOptions) 
   open,
   refresh,
   'fix-tabs': fixTabs,
+  'sentinel-write': sentinelWrite,
+  'sentinel-check': sentinelCheck,
+  'sentinel-touch': sentinelTouch,
+  'tmux-claim': tmuxClaim,
+  doctor,
 };
 
 export function getHelp(): string {
@@ -734,6 +1003,15 @@ Commands:
   open <N>          Open a tmux window at slot N (--claude to launch claude)
   refresh           Pull latest main in idle slots (on main, clean)
   fix-tabs          Rename tmux tabs to match actual slot + branch
+
+Coordinator lifecycle (QUA-339):
+  sentinel-write   --role=slots|releases  Write the role-conflation sentinel
+  sentinel-touch   --role=slots|releases  Refresh sentinel mtime (long sessions)
+  sentinel-check   --role=slots|releases  Detect conflict; exit 2 = same-session
+  tmux-claim       --role=slots|releases  Rename window + set @lw-coord-role marker
+  doctor slots                            Run all 11 slots-doctor checks
+  doctor releases                         Run all 12 releases-doctor checks
+  (all support --json for skill consumption)
 
 Port assignments (deterministic from slot number):
   Agent N → Next.js on port (3010+N), wiki-server on port (3110+N)

--- a/crux/lib/agent-workspace/__tests__/sentinel.test.ts
+++ b/crux/lib/agent-workspace/__tests__/sentinel.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  deriveSessionKey,
+  sentinelPath,
+  serializeSentinel,
+  parseSentinel,
+  isLive,
+  buildOurSentinel,
+  writeSentinel,
+  touchSentinel,
+  checkConflict,
+  TTL_SECONDS,
+  type Sentinel,
+  type SentinelEnv,
+} from '../sentinel.ts';
+
+/** Minimal in-memory env for sentinel tests. */
+class FakeEnv implements SentinelEnv {
+  files: Map<string, { content: string; mtime: number }> = new Map();
+  panes: string[] | null = null;
+  alivePids: Set<number> = new Set();
+  env: NodeJS.ProcessEnv;
+  private current: Date;
+
+  constructor(opts: {
+    nowSec?: number;
+    env?: NodeJS.ProcessEnv;
+    panes?: string[] | null;
+    alivePids?: number[];
+  } = {}) {
+    this.current = new Date((opts.nowSec ?? 1_700_000_000) * 1000);
+    this.env = opts.env ?? {};
+    this.panes = opts.panes === undefined ? null : opts.panes;
+    if (opts.alivePids) for (const p of opts.alivePids) this.alivePids.add(p);
+  }
+
+  now() { return this.current; }
+  setNow(secs: number) { this.current = new Date(secs * 1000); }
+  readFile(path: string) { return this.files.get(path)?.content ?? null; }
+  writeFile(path: string, content: string) {
+    this.files.set(path, { content, mtime: Math.floor(this.current.getTime() / 1000) });
+  }
+  touch(path: string) {
+    const f = this.files.get(path);
+    if (!f) throw new Error(`touch: missing ${path}`);
+    f.mtime = Math.floor(this.current.getTime() / 1000);
+  }
+  statMtime(path: string) { return this.files.get(path)?.mtime ?? null; }
+  unlink(path: string) { this.files.delete(path); }
+  listMatching(dir: string, prefix: string) {
+    const results: string[] = [];
+    for (const k of this.files.keys()) {
+      const idx = k.lastIndexOf('/');
+      const parent = idx >= 0 ? k.slice(0, idx) : '';
+      const name = k.slice(idx + 1);
+      if (parent === dir && name.startsWith(prefix)) results.push(k);
+    }
+    return results.sort();
+  }
+  listTmuxPanes() { return this.panes; }
+  pidAlive(pid: number) { return this.alivePids.has(pid); }
+  hostname() { return 'test-host'; }
+  uid() { return 501; }
+  ppid() { return 9999; }
+}
+
+describe('deriveSessionKey', () => {
+  it('strips leading % from TMUX_PANE', () => {
+    expect(deriveSessionKey({ TMUX_PANE: '%69' }, 1234)).toBe('69');
+  });
+  it('passes through TMUX_PANE without % verbatim', () => {
+    expect(deriveSessionKey({ TMUX_PANE: '69' }, 1234)).toBe('69');
+  });
+  it('falls back to pid-<ppid> when TMUX_PANE absent', () => {
+    expect(deriveSessionKey({}, 1234)).toBe('pid-1234');
+  });
+  it('falls back to pid-<ppid> when TMUX_PANE empty', () => {
+    expect(deriveSessionKey({ TMUX_PANE: '' }, 99)).toBe('pid-99');
+  });
+});
+
+describe('sentinelPath', () => {
+  it('builds /tmp/lw-coord-sentinel-<role>-<key>', () => {
+    expect(sentinelPath('slots', '69')).toBe('/tmp/lw-coord-sentinel-slots-69');
+    expect(sentinelPath('releases', 'pid-12')).toBe('/tmp/lw-coord-sentinel-releases-pid-12');
+  });
+});
+
+describe('serialize/parse round-trip', () => {
+  it('round-trips a full sentinel', () => {
+    const s: Sentinel = {
+      role: 'slots',
+      tmuxPane: '%69',
+      ppid: 28086,
+      created: 1_744_478_400,
+      host: 'ozzie-mbp',
+      user: 501,
+    };
+    const text = serializeSentinel(s);
+    expect(text).toBe('role=slots tmux_pane=%69 ppid=28086 created=1744478400 host=ozzie-mbp user=501\n');
+    expect(parseSentinel(text)).toEqual(s);
+  });
+  it('round-trips a non-tmux sentinel (empty pane)', () => {
+    const s: Sentinel = {
+      role: 'releases',
+      tmuxPane: '',
+      ppid: 1,
+      created: 100,
+      host: 'h',
+      user: 0,
+    };
+    expect(parseSentinel(serializeSentinel(s))).toEqual(s);
+  });
+  it('rejects malformed lines', () => {
+    expect(parseSentinel('')).toBeNull();
+    expect(parseSentinel('garbage with no equals')).toBeNull();
+    expect(parseSentinel('role=invalid tmux_pane=%1 ppid=1 created=1 host=h user=0')).toBeNull();
+    expect(parseSentinel('role=slots tmux_pane=%1 ppid=NaN created=1 host=h user=0')).toBeNull();
+  });
+});
+
+describe('isLive', () => {
+  let env: FakeEnv;
+  beforeEach(() => {
+    env = new FakeEnv({ nowSec: 1_000_000, panes: ['%1', '%2', '%69'], alivePids: [10, 20] });
+  });
+
+  it('returns expired when sentinel mtime > 24h ago', () => {
+    env.writeFile('/tmp/x', 'role=slots tmux_pane=%69 ppid=10 created=1 host=h user=0');
+    env.setNow(1_000_000 + TTL_SECONDS + 5);
+    const result = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(result.live).toBe(false);
+    expect(result.reason).toBe('expired');
+  });
+
+  it('returns expired when file is missing', () => {
+    expect(isLive('/tmp/missing', null, env)).toMatchObject({ live: false, reason: 'expired' });
+  });
+
+  it('returns live when pane is in tmux pane list', () => {
+    env.writeFile('/tmp/x', 'role=slots tmux_pane=%69 ppid=10 created=1 host=h user=0');
+    const result = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(result.live).toBe(true);
+    expect(result.reason).toBe('fresh');
+  });
+
+  it('returns pane-gone when pane is not in tmux list', () => {
+    env.writeFile('/tmp/x', 'role=slots tmux_pane=%999 ppid=10 created=1 host=h user=0');
+    const result = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(result.live).toBe(false);
+    expect(result.reason).toBe('pane-gone');
+  });
+
+  it('falls back to ppid liveness when no pane', () => {
+    env.writeFile('/tmp/x', 'role=slots tmux_pane= ppid=10 created=1 host=h user=0');
+    const r = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(r.live).toBe(true);
+  });
+
+  it('returns pid-gone when ppid no longer alive', () => {
+    env.writeFile('/tmp/x', 'role=slots tmux_pane= ppid=99999 created=1 host=h user=0');
+    const r = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(r.live).toBe(false);
+    expect(r.reason).toBe('pid-gone');
+  });
+
+  it('treats unparseable as live (do not destroy unknown formats)', () => {
+    env.writeFile('/tmp/x', 'totally not a sentinel');
+    const r = isLive('/tmp/x', null, env);
+    expect(r.live).toBe(true);
+    expect(r.reason).toBe('unparseable');
+  });
+
+  it('treats tmux unavailable as live (cannot disprove)', () => {
+    env.panes = null; // not in tmux
+    env.writeFile('/tmp/x', 'role=slots tmux_pane=%99 ppid=10 created=1 host=h user=0');
+    const r = isLive('/tmp/x', parseSentinel(env.readFile('/tmp/x')!)!, env);
+    expect(r.live).toBe(true);
+  });
+});
+
+describe('writeSentinel + buildOurSentinel', () => {
+  it('writes to the correct path with our session key', () => {
+    const env = new FakeEnv({
+      nowSec: 100,
+      env: { TMUX_PANE: '%42', PPID: '777' },
+      panes: ['%42'],
+    });
+    const { path, sentinel } = writeSentinel('slots', env);
+    expect(path).toBe('/tmp/lw-coord-sentinel-slots-42');
+    expect(sentinel.role).toBe('slots');
+    expect(sentinel.created).toBe(100);
+    expect(sentinel.host).toBe('test-host');
+    expect(env.readFile(path)).toContain('role=slots');
+    expect(env.readFile(path)).toContain('tmux_pane=%42');
+  });
+
+  it('uses pid-<PPID> path when not in tmux', () => {
+    const env = new FakeEnv({ nowSec: 100, env: { PPID: '555' } });
+    const { path } = writeSentinel('releases', env);
+    expect(path).toBe('/tmp/lw-coord-sentinel-releases-pid-555');
+  });
+});
+
+describe('touchSentinel', () => {
+  it('touches existing file', () => {
+    const env = new FakeEnv({ nowSec: 100, env: { TMUX_PANE: '%1' } });
+    writeSentinel('slots', env);
+    env.setNow(500);
+    const r = touchSentinel('slots', env);
+    expect(r.touched).toBe(true);
+    expect(env.statMtime('/tmp/lw-coord-sentinel-slots-1')).toBe(500);
+  });
+  it('returns touched=false if absent', () => {
+    const env = new FakeEnv({ nowSec: 100, env: { TMUX_PANE: '%1' } });
+    expect(touchSentinel('slots', env).touched).toBe(false);
+  });
+});
+
+describe('checkConflict', () => {
+  it('returns no conflict when no other-role sentinels exist', () => {
+    const env = new FakeEnv({ env: { TMUX_PANE: '%1' }, panes: ['%1'] });
+    const r = checkConflict('slots', env);
+    expect(r.conflict).toBeNull();
+    expect(r.cleaned).toBe(0);
+  });
+
+  it('detects same-session conflict (role conflation)', () => {
+    const env = new FakeEnv({ nowSec: 100, env: { TMUX_PANE: '%69' }, panes: ['%69'] });
+    // Other-role sentinel from the SAME pane → role conflation
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-69',
+      'role=releases tmux_pane=%69 ppid=10 created=100 host=h user=0',
+    );
+    const r = checkConflict('slots', env);
+    expect(r.conflict).not.toBeNull();
+    expect(r.conflict?.kind).toBe('same-session');
+    expect(r.conflict?.path).toBe('/tmp/lw-coord-sentinel-releases-69');
+  });
+
+  it('detects cross-session conflict (other role in DIFFERENT pane = expected)', () => {
+    const env = new FakeEnv({ env: { TMUX_PANE: '%1' }, panes: ['%1', '%2'] });
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-2',
+      'role=releases tmux_pane=%2 ppid=10 created=1700000000 host=h user=0',
+    );
+    const r = checkConflict('slots', env);
+    expect(r.conflict?.kind).toBe('other-session');
+  });
+
+  it('removes stale sentinels and reports them as cleaned', () => {
+    const env = new FakeEnv({
+      nowSec: 1_000_000 + TTL_SECONDS + 100,
+      env: { TMUX_PANE: '%1' },
+      panes: ['%1'],
+    });
+    // Manually inject an OLD sentinel (mtime in the distant past)
+    env.files.set('/tmp/lw-coord-sentinel-releases-99', {
+      content: 'role=releases tmux_pane=%99 ppid=10 created=1 host=h user=0',
+      mtime: 1_000_000 - 1, // long ago
+    });
+    const r = checkConflict('slots', env);
+    expect(r.cleaned).toBe(1);
+    expect(r.conflict).toBeNull();
+    expect(env.readFile('/tmp/lw-coord-sentinel-releases-99')).toBeNull();
+  });
+
+  it('only checks the OTHER role, not our own role', () => {
+    const env = new FakeEnv({ env: { TMUX_PANE: '%1' }, panes: ['%1'] });
+    // A live sentinel for OUR role from a different pane: not a conflict
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-slots-99',
+      'role=slots tmux_pane=%99 ppid=10 created=1700000000 host=h user=0',
+    );
+    const r = checkConflict('slots', env);
+    expect(r.conflict).toBeNull();
+  });
+});

--- a/crux/lib/agent-workspace/__tests__/sentinel.test.ts
+++ b/crux/lib/agent-workspace/__tests__/sentinel.test.ts
@@ -86,6 +86,42 @@ describe('sentinelPath', () => {
   });
 });
 
+describe('deriveSessionKey — hostile TMUX_PANE', () => {
+  it('strips path-traversal characters', () => {
+    expect(deriveSessionKey({ TMUX_PANE: '%../../etc/passwd' }, 9)).toBe('etcpasswd');
+  });
+  it('falls back to pid when the sanitized result is empty', () => {
+    expect(deriveSessionKey({ TMUX_PANE: '%///' }, 42)).toBe('pid-42');
+  });
+  it('preserves underscore and dash', () => {
+    expect(deriveSessionKey({ TMUX_PANE: 'abc_123-xyz' }, 0)).toBe('abc_123-xyz');
+  });
+});
+
+describe('serialize — host sanitization', () => {
+  it('replaces whitespace in hostname so parse round-trips', () => {
+    const s: Sentinel = {
+      role: 'slots', tmuxPane: '%1', ppid: 1, created: 1,
+      host: "Ozzie's MacBook", user: 0,
+    };
+    const text = serializeSentinel(s);
+    // No embedded whitespace in the host field
+    expect(text.match(/host=\S+/)?.[0]).toBe('host=Ozzie\'s_MacBook');
+    // Round-trip succeeds despite the original having spaces
+    const parsed = parseSentinel(text);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.host).toBe("Ozzie's_MacBook");
+  });
+  it('replaces `=` in hostname so field list stays delimited', () => {
+    const s: Sentinel = {
+      role: 'slots', tmuxPane: '%1', ppid: 1, created: 1,
+      host: 'a=b=c', user: 0,
+    };
+    const parsed = parseSentinel(serializeSentinel(s));
+    expect(parsed?.host).toBe('a_b_c');
+  });
+});
+
 describe('serialize/parse round-trip', () => {
   it('round-trips a full sentinel', () => {
     const s: Sentinel = {

--- a/crux/lib/agent-workspace/__tests__/tmux.test.ts
+++ b/crux/lib/agent-workspace/__tests__/tmux.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTmuxVersion,
+  probeTmuxVersion,
+  listWindowsWithMarkers,
+  claimWindow,
+  ROLE_MARKER,
+  type TmuxExec,
+  type TmuxExecResult,
+} from '../tmux.ts';
+
+/** Minimal TmuxExec stub; records every call for assertions. */
+class FakeTmux implements TmuxExec {
+  calls: string[][] = [];
+  constructor(
+    private inSession: boolean,
+    private replies: ((args: string[]) => TmuxExecResult)[],
+  ) {}
+  inTmux() { return this.inSession ? '/tmp/tmux-501/default,123,0' : null; }
+  run(args: string[]): TmuxExecResult {
+    this.calls.push(args);
+    const handler = this.replies.shift();
+    if (!handler) throw new Error(`unexpected tmux call: ${args.join(' ')}`);
+    return handler(args);
+  }
+}
+
+const ok = (stdout: string): TmuxExecResult => ({ stdout, stderr: '', code: 0 });
+const err = (stderr: string, code = 1): TmuxExecResult => ({ stdout: '', stderr, code });
+
+describe('parseTmuxVersion', () => {
+  it('parses 3.3a', () => {
+    const v = parseTmuxVersion('tmux 3.3a');
+    expect(v.major).toBe(3);
+    expect(v.minor).toBe(3);
+    expect(v.supportsUserOptionFormat).toBe(true);
+  });
+  it('parses 3.0', () => {
+    const v = parseTmuxVersion('tmux 3.0');
+    expect(v.supportsUserOptionFormat).toBe(true);
+  });
+  it('parses 2.9 as unsupported', () => {
+    const v = parseTmuxVersion('tmux 2.9a');
+    expect(v.major).toBe(2);
+    expect(v.supportsUserOptionFormat).toBe(false);
+  });
+  it('handles next-3.5 dev builds', () => {
+    const v = parseTmuxVersion('tmux next-3.5');
+    expect(v.major).toBe(3);
+    expect(v.minor).toBe(5);
+    expect(v.supportsUserOptionFormat).toBe(true);
+  });
+  it('returns 0.0 for unparseable (master, etc)', () => {
+    const v = parseTmuxVersion('tmux master');
+    expect(v.major).toBe(0);
+    expect(v.supportsUserOptionFormat).toBe(false);
+  });
+});
+
+describe('probeTmuxVersion', () => {
+  it('returns null when not in tmux', () => {
+    const t = new FakeTmux(false, []);
+    expect(probeTmuxVersion(t)).toBeNull();
+  });
+  it('returns parsed version when tmux -V succeeds', () => {
+    const t = new FakeTmux(true, [() => ok('tmux 3.3a\n')]);
+    const v = probeTmuxVersion(t)!;
+    expect(v.major).toBe(3);
+    expect(v.minor).toBe(3);
+  });
+  it('returns null when tmux -V fails', () => {
+    const t = new FakeTmux(true, [() => err('command not found')]);
+    expect(probeTmuxVersion(t)).toBeNull();
+  });
+});
+
+describe('listWindowsWithMarkers', () => {
+  it('uses marker format on tmux ≥ 3.0 and parses role tags', () => {
+    const t = new FakeTmux(true, [
+      (args) => {
+        expect(args).toContain('list-windows');
+        expect(args.join(' ')).toContain(ROLE_MARKER);
+        return ok('@1\t0\tslots\tslots\n@2\t1\tnotes\t\n@3\t2\treleases\treleases\n');
+      },
+    ]);
+    const v = parseTmuxVersion('tmux 3.3a');
+    const wins = listWindowsWithMarkers(t, v);
+    expect(wins).toEqual([
+      { windowId: '@1', index: '0', name: 'slots', role: 'slots' },
+      { windowId: '@2', index: '1', name: 'notes', role: null },
+      { windowId: '@3', index: '2', name: 'releases', role: 'releases' },
+    ]);
+  });
+
+  it('omits marker format on tmux < 3.0 and returns role=null for all', () => {
+    const t = new FakeTmux(true, [
+      (args) => {
+        expect(args.join(' ')).not.toContain(ROLE_MARKER);
+        return ok('@1\t0\tslots\n@2\t1\tnotes\n');
+      },
+    ]);
+    const v = parseTmuxVersion('tmux 2.9a');
+    const wins = listWindowsWithMarkers(t, v);
+    expect(wins.map((w) => w.role)).toEqual([null, null]);
+    expect(wins).toHaveLength(2);
+  });
+
+  it('returns unmarked windows when version is null (tmux unavailable)', () => {
+    const t = new FakeTmux(true, [
+      () => ok('@1\t0\tslots\n@2\t1\tnotes\n'),
+    ]);
+    const wins = listWindowsWithMarkers(t, null);
+    expect(wins).toHaveLength(2);
+    expect(wins.every((w) => w.role === null)).toBe(true);
+  });
+
+  it('returns [] when list-windows fails', () => {
+    const t = new FakeTmux(true, [() => err('no server')]);
+    expect(listWindowsWithMarkers(t, parseTmuxVersion('tmux 3.3'))).toEqual([]);
+  });
+
+  it('ignores unknown role values', () => {
+    const t = new FakeTmux(true, [() => ok('@1\t0\tweird\tbogus\n')]);
+    const v = parseTmuxVersion('tmux 3.3');
+    expect(listWindowsWithMarkers(t, v)[0].role).toBeNull();
+  });
+});
+
+describe('claimWindow', () => {
+  it('skips when not in tmux', () => {
+    const t = new FakeTmux(false, []);
+    const r = claimWindow('slots', t);
+    expect(r.status).toBe('skipped-no-tmux');
+    expect(t.calls).toHaveLength(0);
+  });
+
+  it('on tmux ≥ 3.0: probes version, finds current, sets marker BEFORE renaming', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3a\n'),                  // -V
+      () => ok('@7\n'),                         // display-message current
+      () => ok('main\nnotes\n'),                // list-windows existing
+      () => ok(''),                             // set-option marker
+      () => ok(''),                             // rename-window
+    ]);
+    const r = claimWindow('slots', t);
+    expect(r.status).toBe('claimed');
+    expect(r.finalName).toBe('slots');
+    expect(r.marker).toBe('slots');
+    expect(r.markerUnsupported).toBe(false);
+
+    // CRITICAL: set-option must come before rename-window
+    const setIdx = t.calls.findIndex((c) => c.includes('set-option'));
+    const renameIdx = t.calls.findIndex((c) => c.includes('rename-window'));
+    expect(setIdx).toBeGreaterThan(-1);
+    expect(renameIdx).toBeGreaterThan(setIdx);
+
+    // set-option targets the current window id
+    expect(t.calls[setIdx]).toEqual([
+      'set-option', '-w', '-t', '@7', ROLE_MARKER, 'slots',
+    ]);
+    expect(t.calls[renameIdx]).toEqual(['rename-window', '-t', '@7', 'slots']);
+  });
+
+  it('picks role-2 when a window already named "slots" exists', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3\n'),
+      () => ok('@5\n'),
+      () => ok('slots\nmain\n'),                // collision
+      () => ok(''),
+      () => ok(''),
+    ]);
+    const r = claimWindow('slots', t);
+    expect(r.status).toBe('claimed');
+    expect(r.finalName).toBe('slots-2');
+  });
+
+  it('picks role-3 when both slots and slots-2 exist', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3\n'),
+      () => ok('@5\n'),
+      () => ok('slots\nslots-2\nmain\n'),
+      () => ok(''),
+      () => ok(''),
+    ]);
+    expect(claimWindow('slots', t).finalName).toBe('slots-3');
+  });
+
+  it('on tmux < 3.0: skips marker, still renames, sets markerUnsupported', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 2.9a\n'),
+      () => ok('@9\n'),
+      () => ok('main\n'),
+      () => ok(''),                             // rename only — no set-option call
+    ]);
+    const r = claimWindow('releases', t);
+    expect(r.status).toBe('claimed');
+    expect(r.markerUnsupported).toBe(true);
+    expect(r.marker).toBeUndefined();
+    // Verify set-option was NOT called
+    expect(t.calls.some((c) => c.includes('set-option'))).toBe(false);
+  });
+
+  it('returns error when set-option fails', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3\n'),
+      () => ok('@1\n'),
+      () => ok('main\n'),
+      () => err('permission denied'),
+    ]);
+    const r = claimWindow('slots', t);
+    expect(r.status).toBe('error');
+    expect(r.detail).toContain('permission denied');
+  });
+
+  it('returns error when rename fails', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3\n'),
+      () => ok('@1\n'),
+      () => ok('main\n'),
+      () => ok(''),
+      () => err('cannot rename'),
+    ]);
+    const r = claimWindow('slots', t);
+    expect(r.status).toBe('error');
+    expect(r.detail).toContain('cannot rename');
+  });
+
+  it('returns skipped-no-current when display-message returns empty', () => {
+    const t = new FakeTmux(true, [
+      () => ok('tmux 3.3\n'),
+      () => err('no current window'),
+    ]);
+    expect(claimWindow('slots', t).status).toBe('skipped-no-current');
+  });
+});

--- a/crux/lib/agent-workspace/doctor/__tests__/fake-env.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/fake-env.ts
@@ -1,0 +1,105 @@
+/**
+ * Reusable in-memory DoctorEnv for tests.
+ *
+ * Files: { path → { content, mtime, isSymlink, symlinkTarget } }
+ * Dirs:  { path → string[] of immediate children }
+ * Exec:  { "<cmd> <args>" → ExecResult } (matched by exact joined args)
+ * Fetch: { url → FetchResult }
+ *
+ * Anything not registered returns a sensible default (file missing, dir
+ * empty, exec exit 0 with empty stdout, fetch network error). Tests should
+ * register only the entries that matter for each scenario.
+ */
+
+import type { DoctorEnv, ExecResult, FetchResult, FileStat } from '../types.ts';
+
+export interface FakeFile {
+  content?: string;
+  mtime?: number;
+  isSymlink?: boolean;
+  symlinkTarget?: string;
+  isDir?: boolean;
+  size?: number;
+}
+
+export class FakeDoctorEnv implements DoctorEnv {
+  lwDir = '/lw';
+  env: NodeJS.ProcessEnv = {};
+  files = new Map<string, FakeFile>();
+  /** Map of dir path → list of immediate child names. */
+  dirs = new Map<string, string[]>();
+  /** Map of `cmd argA argB` → reply factory. */
+  execs = new Map<string, (cmd: string, args: string[]) => ExecResult>();
+  fetches = new Map<string, FetchResult>();
+  private current: Date;
+
+  constructor(opts: { now?: Date | number; lwDir?: string; env?: NodeJS.ProcessEnv } = {}) {
+    if (opts.lwDir) this.lwDir = opts.lwDir;
+    if (opts.env) this.env = opts.env;
+    if (opts.now instanceof Date) this.current = opts.now;
+    else if (typeof opts.now === 'number') this.current = new Date(opts.now * 1000);
+    else this.current = new Date('2026-04-12T14:32:08Z');
+  }
+
+  // ---- mutation helpers used by tests ----
+  setFile(path: string, file: FakeFile) {
+    this.files.set(path, { mtime: Math.floor(this.current.getTime() / 1000), size: 0, ...file });
+    return this;
+  }
+  setDir(path: string, children: string[]) {
+    this.files.set(path, { isDir: true, mtime: Math.floor(this.current.getTime() / 1000), size: 0 });
+    this.dirs.set(path, children);
+    return this;
+  }
+  setExec(key: string, reply: ExecResult | ((cmd: string, args: string[]) => ExecResult)) {
+    this.execs.set(key, typeof reply === 'function' ? reply : () => reply);
+    return this;
+  }
+  setFetch(url: string, reply: FetchResult) {
+    this.fetches.set(url, reply);
+    return this;
+  }
+  setNow(d: Date) { this.current = d; return this; }
+
+  // ---- DoctorEnv impl ----
+  now() { return this.current; }
+  exists(p: string) { return this.files.has(p); }
+  stat(p: string): FileStat | null {
+    const f = this.files.get(p);
+    if (!f) return null;
+    return {
+      isFile: !f.isDir && !f.isSymlink,
+      isDir: !!f.isDir,
+      isSymlink: !!f.isSymlink,
+      mtime: f.mtime ?? 0,
+      size: f.size ?? 0,
+    };
+  }
+  readlink(p: string) {
+    const f = this.files.get(p);
+    if (!f || !f.isSymlink) return null;
+    return f.symlinkTarget ?? '';
+  }
+  readFile(p: string) { return this.files.get(p)?.content ?? null; }
+  listDir(p: string) { return this.dirs.get(p) ?? []; }
+  exec(cmd: string, args: string[]): ExecResult {
+    const key = [cmd, ...args].join(' ');
+    const handler = this.execs.get(key);
+    if (handler) return handler(cmd, args);
+    // Try a prefix match (helpful when args list is long)
+    for (const [k, h] of this.execs.entries()) {
+      if (key === k) return h(cmd, args);
+    }
+    return { stdout: '', stderr: '', code: 0 };
+  }
+  async fetch(url: string): Promise<FetchResult> {
+    return this.fetches.get(url) ?? { ok: false, status: 0, body: '', headers: {}, networkError: true };
+  }
+  resolve(...parts: string[]) {
+    return [this.lwDir, ...parts].join('/');
+  }
+}
+
+export const ok = (stdout = '', stderr = ''): ExecResult => ({ stdout, stderr, code: 0 });
+export const fail = (stderr = '', code = 1): ExecResult => ({ stdout: '', stderr, code });
+export const notFound = (): ExecResult => ({ stdout: '', stderr: '', code: 1, notFound: true });

--- a/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkDirState,
+  checkDepsCurrent,
+  checkOpsState,
+  checkOpsDivergence,
+  checkReleasePr,
+  checkDeployTasks,
+  checkProdEdge,
+  checkProdCiRecent,
+  checkK8sPods,
+  checkArgocdSync,
+  checkReleaseBranchStale,
+  checkSessionClockSkew,
+  RELEASES_CHECKS,
+} from '../releases.ts';
+import { FakeDoctorEnv, ok, fail, notFound } from './fake-env.ts';
+
+const NOW_SEC = 1_744_000_000;
+const NOW_MS = NOW_SEC * 1000;
+
+function envWithReleasesDir() {
+  const env = new FakeDoctorEnv({ now: NOW_SEC });
+  env.setFile('/lw/releases', { isDir: true });
+  return env;
+}
+
+describe('checkDirState', () => {
+  it('ok when releases/ on main, clean, .env -> ../.env.base', async () => {
+    const env = envWithReleasesDir();
+    env.setExec('git -C /lw/releases branch --show-current', ok('main\n'));
+    env.setExec('git -C /lw/releases status --porcelain', ok());
+    env.setFile('/lw/releases/.env', { isSymlink: true, symlinkTarget: '../.env.base' });
+    expect((await checkDirState.run(env)).status).toBe('ok');
+  });
+  it('fails when on a non-main branch', async () => {
+    const env = envWithReleasesDir();
+    env.setExec('git -C /lw/releases branch --show-current', ok('hotfix\n'));
+    env.setExec('git -C /lw/releases status --porcelain', ok());
+    env.setFile('/lw/releases/.env', { isSymlink: true, symlinkTarget: '../.env.base' });
+    const r = await checkDirState.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('hotfix');
+  });
+  it('fails with mid-rebase state and emits the abort suggestion', async () => {
+    const env = envWithReleasesDir();
+    env.setFile('/lw/releases/.git/rebase-merge', { isDir: true });
+    env.setExec('git -C /lw/releases branch --show-current', ok('main\n'));
+    env.setExec('git -C /lw/releases status --porcelain', ok());
+    env.setFile('/lw/releases/.env', { isSymlink: true, symlinkTarget: '../.env.base' });
+    const r = await checkDirState.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.action).toContain('rebase --abort');
+  });
+  it('fails LOUDLY when both releases/ and coord/ exist (rename in flight)', async () => {
+    const env = envWithReleasesDir();
+    env.setFile('/lw/coord', { isDir: true });
+    const r = await checkDirState.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('BOTH');
+  });
+  it('falls back to coord/ when only coord/ exists', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setFile('/lw/coord', { isDir: true });
+    env.setExec('git -C /lw/coord branch --show-current', ok('main\n'));
+    env.setExec('git -C /lw/coord status --porcelain', ok());
+    env.setFile('/lw/coord/.env', { isSymlink: true, symlinkTarget: '../.env.base' });
+    const r = await checkDirState.run(env);
+    expect(r.status).toBe('ok');
+    expect(r.summary).toContain('coord/');
+  });
+});
+
+describe('checkDepsCurrent', () => {
+  it('ok when lock is older than node_modules/.pnpm', async () => {
+    const env = envWithReleasesDir();
+    env.setFile('/lw/releases/pnpm-lock.yaml', { mtime: NOW_SEC - 1000 });
+    env.setFile('/lw/releases/node_modules/.pnpm', { isDir: true, mtime: NOW_SEC - 500 });
+    expect((await checkDepsCurrent.run(env)).status).toBe('ok');
+  });
+  it('warns when lock is newer than node_modules/.pnpm', async () => {
+    const env = envWithReleasesDir();
+    env.setFile('/lw/releases/pnpm-lock.yaml', { mtime: NOW_SEC });
+    env.setFile('/lw/releases/node_modules/.pnpm', { isDir: true, mtime: NOW_SEC - 1000 });
+    expect((await checkDepsCurrent.run(env)).status).toBe('warn');
+  });
+});
+
+describe('checkOpsState', () => {
+  it('ok when clean and recently fetched', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops status --porcelain', ok());
+    env.setFile('/lw/ops/.git/FETCH_HEAD', { mtime: NOW_SEC - 600 });
+    expect((await checkOpsState.run(env)).status).toBe('ok');
+  });
+  it('warns when dirty', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops status --porcelain', ok(' M k8s/foo.yaml\n'));
+    env.setFile('/lw/ops/.git/FETCH_HEAD', { mtime: NOW_SEC - 60 });
+    expect((await checkOpsState.run(env)).status).toBe('warn');
+  });
+  it('warns when last fetch >60min ago', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops status --porcelain', ok());
+    env.setFile('/lw/ops/.git/FETCH_HEAD', { mtime: NOW_SEC - 60 * 60 * 3 });
+    expect((await checkOpsState.run(env)).status).toBe('warn');
+  });
+});
+
+describe('checkOpsDivergence', () => {
+  it('ok when up to date', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops rev-list --left-right --count HEAD...origin/main', ok('0\t0\n'));
+    expect((await checkOpsDivergence.run(env)).status).toBe('ok');
+  });
+  it('ok when behind only', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops rev-list --left-right --count HEAD...origin/main', ok('0\t3\n'));
+    expect((await checkOpsDivergence.run(env)).status).toBe('ok');
+  });
+  it('fails when local commits ahead', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops rev-list --left-right --count HEAD...origin/main', ok('2\t1\n'));
+    const r = await checkOpsDivergence.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('2');
+  });
+});
+
+describe('checkReleasePr', () => {
+  it('ok when no open release PR', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok('[]'),
+    );
+    expect((await checkReleasePr.run(env)).status).toBe('ok');
+  });
+  it('fails when open PR has failing checks', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok(JSON.stringify([{
+        number: 1234, title: 'Release', createdAt: new Date(NOW_MS - 60 * 60 * 1000).toISOString(),
+        isDraft: false, statusCheckRollup: [{ conclusion: 'failure' }],
+      }])),
+    );
+    const r = await checkReleasePr.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('#1234');
+  });
+  it('warns when PR is >24h old without failures', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok(JSON.stringify([{
+        number: 9, title: 'Old', createdAt: new Date(NOW_MS - 30 * 60 * 60 * 1000).toISOString(),
+        isDraft: false, statusCheckRollup: [{ conclusion: 'success' }],
+      }])),
+    );
+    const r = await checkReleasePr.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('30h');
+  });
+  it('info when fresh PR has no checks yet (warming up)', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok(JSON.stringify([{
+        number: 11, title: 'Fresh', createdAt: new Date(NOW_MS - 60 * 1000).toISOString(),
+        isDraft: false, statusCheckRollup: [],
+      }])),
+    );
+    expect((await checkReleasePr.run(env)).status).toBe('info');
+  });
+  it('skips when gh CLI missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      notFound(),
+    );
+    expect((await checkReleasePr.run(env)).status).toBe('skipped');
+  });
+});
+
+describe('checkDeployTasks', () => {
+  it('ok with 0 pending', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pnpm -s crux gh deploy-tasks pending --json', ok('{"count":0,"tasks":[]}'));
+    expect((await checkDeployTasks.run(env)).status).toBe('ok');
+  });
+  it('warns with pending tasks', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pnpm -s crux gh deploy-tasks pending --json', ok('{"count":3,"tasks":[1,2,3]}'));
+    const r = await checkDeployTasks.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('3');
+  });
+});
+
+describe('checkProdEdge', () => {
+  it('ok on 200 with status=ok and no migrationError', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch('https://www.longtermwiki.com/api/health', {
+      ok: true, status: 200, body: '{"status":"ok"}', headers: {},
+    });
+    expect((await checkProdEdge.run(env)).status).toBe('ok');
+  });
+  it('fails on migrationError', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch('https://www.longtermwiki.com/api/health', {
+      ok: true, status: 200, body: '{"status":"degraded","migrationError":"lock_timeout"}', headers: {},
+    });
+    const r = await checkProdEdge.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('lock_timeout');
+  });
+  it('fails on non-200', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch('https://www.longtermwiki.com/api/health', {
+      ok: false, status: 503, body: '', headers: {},
+    });
+    expect((await checkProdEdge.run(env)).status).toBe('fail');
+  });
+  it('fails on timeout', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch('https://www.longtermwiki.com/api/health', {
+      ok: false, status: 0, body: '', headers: {}, timedOut: true,
+    });
+    expect((await checkProdEdge.run(env)).status).toBe('fail');
+  });
+});
+
+describe('checkProdCiRecent', () => {
+  it('ok with no failures in last 24h', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh run list --repo quantified-uncertainty/longterm-wiki --branch production --limit 20 --json status,conclusion,createdAt',
+      ok(JSON.stringify([
+        { status: 'completed', conclusion: 'success', createdAt: new Date(NOW_MS - 1000).toISOString() },
+      ])),
+    );
+    expect((await checkProdCiRecent.run(env)).status).toBe('ok');
+  });
+  it('warns on a recent failure', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh run list --repo quantified-uncertainty/longterm-wiki --branch production --limit 20 --json status,conclusion,createdAt',
+      ok(JSON.stringify([
+        { status: 'completed', conclusion: 'failure', createdAt: new Date(NOW_MS - 1000).toISOString() },
+      ])),
+    );
+    expect((await checkProdCiRecent.run(env)).status).toBe('warn');
+  });
+});
+
+describe('checkK8sPods', () => {
+  it('skips when kubectl missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('kubectl -n longterm-wiki get pods -o json', notFound());
+    expect((await checkK8sPods.run(env)).status).toBe('skipped');
+  });
+  it('ok when all pods Running with no restart spike', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec('kubectl -n longterm-wiki get pods -o json', ok(JSON.stringify({
+      items: [{
+        metadata: { name: 'wiki-server-0', creationTimestamp: new Date(NOW_MS - 86400000).toISOString() },
+        status: { phase: 'Running', containerStatuses: [{ restartCount: 0 }] },
+      }],
+    })));
+    expect((await checkK8sPods.run(env)).status).toBe('ok');
+  });
+  it('fails when a pod is not Running', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec('kubectl -n longterm-wiki get pods -o json', ok(JSON.stringify({
+      items: [{
+        metadata: { name: 'wiki-server-0', creationTimestamp: new Date(NOW_MS - 1000).toISOString() },
+        status: { phase: 'Pending', containerStatuses: [] },
+      }],
+    })));
+    expect((await checkK8sPods.run(env)).status).toBe('fail');
+  });
+  it('fails on restart spike (>5 restarts in <1h)', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec('kubectl -n longterm-wiki get pods -o json', ok(JSON.stringify({
+      items: [{
+        metadata: { name: 'wiki-server-0', creationTimestamp: new Date(NOW_MS - 30 * 60 * 1000).toISOString() },
+        status: { phase: 'Running', containerStatuses: [{ restartCount: 6 }] },
+      }],
+    })));
+    expect((await checkK8sPods.run(env)).status).toBe('fail');
+  });
+});
+
+describe('checkArgocdSync', () => {
+  it('skips when argocd missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('argocd app list -o json', notFound());
+    expect((await checkArgocdSync.run(env)).status).toBe('skipped');
+  });
+  it('ok when all longterm apps Synced/Healthy', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('argocd app list -o json', ok(JSON.stringify([
+      { metadata: { name: 'longterm-wiki-server' }, status: { sync: { status: 'Synced' }, health: { status: 'Healthy' } } },
+    ])));
+    expect((await checkArgocdSync.run(env)).status).toBe('ok');
+  });
+  it('fails on OutOfSync or Degraded', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('argocd app list -o json', ok(JSON.stringify([
+      { metadata: { name: 'longterm-wiki-server' }, status: { sync: { status: 'OutOfSync' }, health: { status: 'Healthy' } } },
+    ])));
+    expect((await checkArgocdSync.run(env)).status).toBe('fail');
+  });
+});
+
+describe('checkReleaseBranchStale', () => {
+  it('info when no release branches', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(
+      'gh api repos/quantified-uncertainty/longterm-wiki/branches --paginate -q .[].name',
+      ok('main\nproduction\n'),
+    );
+    expect((await checkReleaseBranchStale.run(env)).status).toBe('info');
+  });
+  it('info with count when release branches exist', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(
+      'gh api repos/quantified-uncertainty/longterm-wiki/branches --paginate -q .[].name',
+      ok('main\nrelease/v1\nrelease/v2\n'),
+    );
+    const r = await checkReleaseBranchStale.run(env);
+    expect(r.status).toBe('info');
+    expect(r.summary).toContain('2');
+  });
+});
+
+describe('checkSessionClockSkew', () => {
+  it('ok when within 60s', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setFetch('https://api.github.com', {
+      ok: true, status: 200, body: '', headers: { date: new Date(NOW_MS - 5000).toUTCString() },
+    });
+    expect((await checkSessionClockSkew.run(env)).status).toBe('ok');
+  });
+  it('warns on >60s skew', async () => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setFetch('https://api.github.com', {
+      ok: true, status: 200, body: '', headers: { date: new Date(NOW_MS - 5 * 60 * 1000).toUTCString() },
+    });
+    expect((await checkSessionClockSkew.run(env)).status).toBe('warn');
+  });
+  it('skips on network error', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch('https://api.github.com', {
+      ok: false, status: 0, body: '', headers: {}, networkError: true,
+    });
+    expect((await checkSessionClockSkew.run(env)).status).toBe('skipped');
+  });
+});
+
+describe('RELEASES_CHECKS registry', () => {
+  it('contains all 12 checks', () => {
+    expect(RELEASES_CHECKS).toHaveLength(12);
+  });
+  it('all checks have unique ids', () => {
+    const ids = new Set(RELEASES_CHECKS.map((c) => c.id));
+    expect(ids.size).toBe(RELEASES_CHECKS.length);
+  });
+});

--- a/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
@@ -108,6 +108,17 @@ describe('checkOpsState', () => {
     env.setFile('/lw/ops/.git/FETCH_HEAD', { mtime: NOW_SEC - 60 * 60 * 3 });
     expect((await checkOpsState.run(env)).status).toBe('warn');
   });
+  it('clamps future FETCH_HEAD mtime (clock skew) to 0, no negative display', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setFile('/lw/ops', { isDir: true });
+    env.setExec('git -C /lw/ops status --porcelain', ok());
+    // mtime in the future — can happen after a restore-from-backup
+    env.setFile('/lw/ops/.git/FETCH_HEAD', { mtime: NOW_SEC + 999 });
+    const r = await checkOpsState.run(env);
+    expect(r.status).toBe('ok');
+    expect(r.summary).not.toContain('-');
+    expect(r.summary).toContain('0m');
+  });
 });
 
 describe('checkOpsDivergence', () => {
@@ -190,31 +201,60 @@ describe('checkReleasePr', () => {
 });
 
 describe('checkDeployTasks', () => {
-  it('ok with 0 pending', async () => {
+  const KEY = 'pnpm -s crux gh deploy-tasks pending';
+  it('ok when no unchecked markers in output', async () => {
     const env = new FakeDoctorEnv();
-    env.setExec('pnpm -s crux gh deploy-tasks pending --json', ok('{"count":0,"tasks":[]}'));
+    env.setExec(KEY, ok('No pending deploy tasks.\n'));
     expect((await checkDeployTasks.run(env)).status).toBe('ok');
   });
-  it('warns with pending tasks', async () => {
+  it('counts ☐ markers as pending', async () => {
     const env = new FakeDoctorEnv();
-    env.setExec('pnpm -s crux gh deploy-tasks pending --json', ok('{"count":3,"tasks":[1,2,3]}'));
+    env.setExec(KEY, ok('PR #1\n  ☐ `ci` Verify CI\n  ☐ `migration` Apply 0173\n'));
     const r = await checkDeployTasks.run(env);
     expect(r.status).toBe('warn');
-    expect(r.summary).toContain('3');
+    expect(r.summary).toContain('2');
+  });
+  it('counts [ ] markers as pending', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(KEY, ok('PR #2\n  [ ] check thing\n'));
+    const r = await checkDeployTasks.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('1');
+  });
+  it('strips ANSI color codes before counting', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(KEY, ok('\x1b[33m☐\x1b[0m task one\n\x1b[33m☐\x1b[0m task two\n'));
+    expect((await checkDeployTasks.run(env)).summary).toContain('2');
+  });
+  it('skips when pnpm missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(KEY, notFound());
+    expect((await checkDeployTasks.run(env)).status).toBe('skipped');
   });
 });
 
 describe('checkProdEdge', () => {
-  it('ok on 200 with status=ok and no migrationError', async () => {
+  const URL = 'https://wiki-server.k8s.quantifieduncertainty.org/health';
+  it('ok on 200 with status=healthy (actual wiki-server contract)', async () => {
     const env = new FakeDoctorEnv();
-    env.setFetch('https://www.longtermwiki.com/api/health', {
-      ok: true, status: 200, body: '{"status":"ok"}', headers: {},
-    });
+    env.setFetch(URL, { ok: true, status: 200, body: '{"status":"healthy"}', headers: {} });
+    const r = await checkProdEdge.run(env);
+    expect(r.status).toBe('ok');
+    expect(r.summary).toContain('healthy');
+  });
+  it('ok on 200 with status=ok (defensive alternate contract)', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch(URL, { ok: true, status: 200, body: '{"status":"ok"}', headers: {} });
     expect((await checkProdEdge.run(env)).status).toBe('ok');
+  });
+  it('fails on degraded status', async () => {
+    const env = new FakeDoctorEnv();
+    env.setFetch(URL, { ok: true, status: 200, body: '{"status":"degraded"}', headers: {} });
+    expect((await checkProdEdge.run(env)).status).toBe('fail');
   });
   it('fails on migrationError', async () => {
     const env = new FakeDoctorEnv();
-    env.setFetch('https://www.longtermwiki.com/api/health', {
+    env.setFetch(URL, {
       ok: true, status: 200, body: '{"status":"degraded","migrationError":"lock_timeout"}', headers: {},
     });
     const r = await checkProdEdge.run(env);
@@ -223,16 +263,12 @@ describe('checkProdEdge', () => {
   });
   it('fails on non-200', async () => {
     const env = new FakeDoctorEnv();
-    env.setFetch('https://www.longtermwiki.com/api/health', {
-      ok: false, status: 503, body: '', headers: {},
-    });
+    env.setFetch(URL, { ok: false, status: 503, body: '', headers: {} });
     expect((await checkProdEdge.run(env)).status).toBe('fail');
   });
   it('fails on timeout', async () => {
     const env = new FakeDoctorEnv();
-    env.setFetch('https://www.longtermwiki.com/api/health', {
-      ok: false, status: 0, body: '', headers: {}, timedOut: true,
-    });
+    env.setFetch(URL, { ok: false, status: 0, body: '', headers: {}, timedOut: true });
     expect((await checkProdEdge.run(env)).status).toBe('fail');
   });
 });

--- a/crux/lib/agent-workspace/doctor/__tests__/runner.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/runner.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { runDoctor, renderPretty, exitCodeFor } from '../runner.ts';
+import type { DoctorCheck, DoctorEnv } from '../types.ts';
+
+const stubEnv: DoctorEnv = {
+  lwDir: '/lw',
+  now: () => new Date('2026-04-12T14:32:08'),
+  env: {},
+  exists: () => false,
+  stat: () => null,
+  readlink: () => null,
+  readFile: () => null,
+  listDir: () => [],
+  exec: () => ({ stdout: '', stderr: '', code: 0 }),
+  fetch: async () => ({ ok: true, status: 200, body: '', headers: {} }),
+  resolve: (...p) => p.join('/'),
+};
+
+const okCheck = (id: string, summary = 'fine'): DoctorCheck => ({
+  id,
+  label: id,
+  run: async () => ({ status: 'ok', summary }),
+});
+
+const failCheck = (id: string, summary: string, action?: string): DoctorCheck => ({
+  id,
+  label: id,
+  run: async () => ({ status: 'fail', summary, action }),
+});
+
+const warnCheck = (id: string, summary: string): DoctorCheck => ({
+  id,
+  label: id,
+  run: async () => ({ status: 'warn', summary, action: 'do the thing' }),
+});
+
+describe('runDoctor', () => {
+  it('aggregates results and reports the worst status', async () => {
+    const r = await runDoctor('slots', [okCheck('a'), warnCheck('b', 'b warn'), failCheck('c', 'c fail')], stubEnv);
+    expect(r.summary.ok).toBe(1);
+    expect(r.summary.warn).toBe(1);
+    expect(r.summary.fail).toBe(1);
+    expect(r.worst).toBe('fail');
+  });
+
+  it('catches thrown errors and converts to fail', async () => {
+    const throwing: DoctorCheck = {
+      id: 't', label: 't', run: async () => { throw new Error('boom'); },
+    };
+    const r = await runDoctor('slots', [throwing], stubEnv);
+    expect(r.checks[0].status).toBe('fail');
+    expect(r.checks[0].detail).toContain('boom');
+  });
+
+  it('records duration for each check', async () => {
+    const r = await runDoctor('slots', [okCheck('a')], stubEnv);
+    expect(r.checks[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('runs sequentially when parallel=false', async () => {
+    const order: string[] = [];
+    const c = (id: string): DoctorCheck => ({
+      id, label: id,
+      run: async () => { order.push(id); return { status: 'ok', summary: '' }; },
+    });
+    await runDoctor('slots', [c('a'), c('b'), c('c')], stubEnv, { parallel: false });
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('exitCodeFor', () => {
+  it('maps statuses to exit codes', () => {
+    expect(exitCodeFor('ok')).toBe(0);
+    expect(exitCodeFor('info')).toBe(0);
+    expect(exitCodeFor('skipped')).toBe(0);
+    expect(exitCodeFor('warn')).toBe(1);
+    expect(exitCodeFor('fail')).toBe(2);
+  });
+});
+
+describe('renderPretty', () => {
+  it('shows header, status icons, runtime, and what-to-do block', async () => {
+    const r = await runDoctor(
+      'slots',
+      [okCheck('rename-loop', '1 process'), warnCheck('env-drift', 'a4 stale'), failCheck('disk', 'full', 'free space')],
+      stubEnv,
+    );
+    const text = renderPretty(r);
+    expect(text).toContain('=== /agent-slots-doctor');
+    expect(text).toContain('rename-loop');
+    expect(text).toContain('env-drift');
+    expect(text).toContain('What to do:');
+    expect(text).toContain('do the thing');
+    expect(text).toContain('free space');
+  });
+
+  it('omits what-to-do block when no warnings/failures with actions', async () => {
+    const r = await runDoctor('slots', [okCheck('a')], stubEnv);
+    const text = renderPretty(r);
+    expect(text).not.toContain('What to do:');
+  });
+});

--- a/crux/lib/agent-workspace/doctor/__tests__/runner.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/runner.test.ts
@@ -57,6 +57,24 @@ describe('runDoctor', () => {
     expect(r.checks[0].durationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('refuses to report green when every check is skipped (nothing actually verified)', async () => {
+    const skipCheck = (id: string): DoctorCheck => ({
+      id, label: id,
+      run: async () => ({ status: 'skipped' as const, summary: 'tool missing' }),
+    });
+    const r = await runDoctor('slots', [skipCheck('a'), skipCheck('b')], stubEnv);
+    // Worst bubbles to warn because 0 ok + 0 fail + 0 warn + only skipped
+    expect(r.worst).toBe('warn');
+  });
+
+  it('does NOT escalate when at least one check passed', async () => {
+    const skipCheck: DoctorCheck = {
+      id: 'sk', label: 'sk', run: async () => ({ status: 'skipped' as const, summary: '' }),
+    };
+    const r = await runDoctor('slots', [okCheck('a'), skipCheck], stubEnv);
+    expect(r.worst).toBe('ok');
+  });
+
   it('runs sequentially when parallel=false', async () => {
     const order: string[] = [];
     const c = (id: string): DoctorCheck => ({

--- a/crux/lib/agent-workspace/doctor/__tests__/slots.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/slots.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkRenameLoop,
+  checkPrPatrol,
+  checkRenameLogAge,
+  checkEnvDrift,
+  checkAgentSlotMarker,
+  checkMergedDirty,
+  checkMidRebase,
+  checkDevServerInventory,
+  checkTmuxNamedWindows,
+  checkDiskSpace,
+  checkHungWikiServer,
+  SLOTS_CHECKS,
+} from '../slots.ts';
+import { FakeDoctorEnv, ok, fail, notFound } from './fake-env.ts';
+
+const NOW_SEC = 1_744_000_000;
+
+function envWithSlots(slots: number[]) {
+  const env = new FakeDoctorEnv({ now: NOW_SEC });
+  env.setDir('/lw', slots.map((n) => `a${n}`));
+  for (const n of slots) env.setFile(`/lw/a${n}`, { isDir: true });
+  return env;
+}
+
+describe('checkRenameLoop', () => {
+  it('ok when exactly one process', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pgrep -fa tmux-rename-loop.sh', ok('41832 /bin/bash scripts/tmux-rename-loop.sh\n'));
+    expect(await checkRenameLoop.run(env)).toMatchObject({ status: 'ok' });
+  });
+  it('warns when not running', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pgrep -fa tmux-rename-loop.sh', { stdout: '', stderr: '', code: 1 });
+    const r = await checkRenameLoop.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('not running');
+  });
+  it('warns when multiple processes', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pgrep -fa tmux-rename-loop.sh', ok('1 /bin/bash scripts/tmux-rename-loop.sh\n2 /bin/bash scripts/tmux-rename-loop.sh\n'));
+    const r = await checkRenameLoop.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('2');
+  });
+  it('skips when pgrep is missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pgrep -fa tmux-rename-loop.sh', notFound());
+    expect((await checkRenameLoop.run(env)).status).toBe('skipped');
+  });
+});
+
+describe('checkPrPatrol', () => {
+  it('always informational', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('pgrep -fa pr-patrol', { stdout: '', stderr: '', code: 1 });
+    expect((await checkPrPatrol.run(env)).status).toBe('info');
+  });
+});
+
+describe('checkRenameLogAge', () => {
+  it('ok when log is fresh and clean', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setDir('/tmp', ['lw-fix-tabs.log']);
+    env.setFile('/tmp/lw-fix-tabs.log', { content: 'renamed: a3:main\n', mtime: NOW_SEC - 30 });
+    const r = await checkRenameLogAge.run(env);
+    expect(r.status).toBe('ok');
+    expect(r.summary).toContain('30s');
+  });
+  it('warns on errors', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setDir('/tmp', ['lw-fix-tabs.log']);
+    env.setFile('/tmp/lw-fix-tabs.log', { content: 'error: tmux died\n', mtime: NOW_SEC - 30 });
+    const r = await checkRenameLogAge.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('error');
+  });
+  it('warns when stale', async () => {
+    const env = new FakeDoctorEnv({ now: NOW_SEC });
+    env.setDir('/tmp', ['lw-fix-tabs.log']);
+    env.setFile('/tmp/lw-fix-tabs.log', { content: '', mtime: NOW_SEC - 60 * 60 });
+    const r = await checkRenameLogAge.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('stalled');
+  });
+  it('info when log is missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setDir('/tmp', []);
+    expect((await checkRenameLogAge.run(env)).status).toBe('info');
+  });
+});
+
+describe('checkEnvDrift', () => {
+  it('ok when all slot envs are fresh files', async () => {
+    const env = envWithSlots([1, 2]);
+    env.setFile('/lw/.env.base', { content: '', mtime: NOW_SEC - 100 });
+    env.setFile('/lw/a1/.env', { content: '', mtime: NOW_SEC - 50 });
+    env.setFile('/lw/a2/.env', { content: '', mtime: NOW_SEC - 50 });
+    expect((await checkEnvDrift.run(env)).status).toBe('ok');
+  });
+  it('warns on stale, missing, and symlinked envs', async () => {
+    const env = envWithSlots([1, 2, 3]);
+    env.setFile('/lw/.env.base', { content: '', mtime: NOW_SEC - 100 });
+    env.setFile('/lw/a1/.env', { content: '', mtime: NOW_SEC - 200 }); // stale
+    env.setFile('/lw/a2/.env', { isSymlink: true, symlinkTarget: '../.env.base' }); // symlink
+    // a3 missing entirely
+    const r = await checkEnvDrift.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('a1');
+    expect(r.detail).toContain('a2');
+    expect(r.detail).toContain('a3');
+  });
+  it('skips when .env.base missing', async () => {
+    const env = envWithSlots([1]);
+    expect((await checkEnvDrift.run(env)).status).toBe('skipped');
+  });
+});
+
+describe('checkAgentSlotMarker', () => {
+  it('ok when all markers match', async () => {
+    const env = envWithSlots([1, 2]);
+    env.setFile('/lw/a1/.agent-slot', { content: '1\n' });
+    env.setFile('/lw/a2/.agent-slot', { content: '2' });
+    expect((await checkAgentSlotMarker.run(env)).status).toBe('ok');
+  });
+  it('warns on mismatch', async () => {
+    const env = envWithSlots([3]);
+    env.setFile('/lw/a3/.agent-slot', { content: '99' });
+    const r = await checkAgentSlotMarker.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('a3');
+  });
+  it('warns on missing marker', async () => {
+    const env = envWithSlots([5]);
+    expect((await checkAgentSlotMarker.run(env)).status).toBe('warn');
+  });
+});
+
+describe('checkMergedDirty', () => {
+  it('ok with no merged-dirty slots', async () => {
+    const env = envWithSlots([1]);
+    env.setExec('git -C /lw/a1 branch --show-current', ok('main\n'));
+    expect((await checkMergedDirty.run(env)).status).toBe('ok');
+  });
+  it('warns when merged branch has uncommitted work', async () => {
+    const env = envWithSlots([4]);
+    env.setExec('git -C /lw/a4 branch --show-current', ok('claude/old-thing\n'));
+    env.setExec('git -C /lw/a4 status --porcelain', ok(' M file.ts\n'));
+    env.setExec('git -C /lw/a4 merge-base --is-ancestor HEAD origin/main', ok());
+    const r = await checkMergedDirty.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('a4');
+  });
+  it('ok when dirty but branch is NOT merged', async () => {
+    const env = envWithSlots([4]);
+    env.setExec('git -C /lw/a4 branch --show-current', ok('claude/active\n'));
+    env.setExec('git -C /lw/a4 status --porcelain', ok(' M f\n'));
+    env.setExec('git -C /lw/a4 merge-base --is-ancestor HEAD origin/main', fail('', 1));
+    expect((await checkMergedDirty.run(env)).status).toBe('ok');
+  });
+});
+
+describe('checkMidRebase', () => {
+  it('ok when no rebase state exists', async () => {
+    const env = envWithSlots([1]);
+    expect((await checkMidRebase.run(env)).status).toBe('ok');
+  });
+  it('fails when rebase-merge directory exists', async () => {
+    const env = envWithSlots([2]);
+    env.setFile('/lw/a2/.git/rebase-merge', { isDir: true });
+    const r = await checkMidRebase.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.detail).toContain('a2');
+  });
+  it('fails on CHERRY_PICK_HEAD', async () => {
+    const env = envWithSlots([3]);
+    env.setFile('/lw/a3/.git/CHERRY_PICK_HEAD', { content: 'abc' });
+    expect((await checkMidRebase.run(env)).status).toBe('fail');
+  });
+});
+
+describe('checkDevServerInventory', () => {
+  it('info when no listeners', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('lsof -iTCP:3010-3030 -sTCP:LISTEN -P -n', { stdout: '', stderr: '', code: 1 });
+    const r = await checkDevServerInventory.run(env);
+    expect(r.status).toBe('info');
+  });
+  it('info (never auto-act) when listeners present', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec(
+      'lsof -iTCP:3010-3030 -sTCP:LISTEN -P -n',
+      ok('COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nnext 12345 ozzie 21u IPv4 0t0 TCP *:3014 (LISTEN)\n'),
+    );
+    const r = await checkDevServerInventory.run(env);
+    expect(r.status).toBe('info');
+    expect(r.summary).toContain('NEVER auto-kill');
+    expect(r.detail).toContain('3014');
+  });
+  it('skips when lsof missing', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('lsof -iTCP:3010-3030 -sTCP:LISTEN -P -n', notFound());
+    expect((await checkDevServerInventory.run(env)).status).toBe('skipped');
+  });
+});
+
+describe('checkTmuxNamedWindows', () => {
+  it('skipped when not in tmux', async () => {
+    const env = new FakeDoctorEnv();
+    expect((await checkTmuxNamedWindows.run(env)).status).toBe('skipped');
+  });
+  it('ok when all slot windows match real slots', async () => {
+    const env = envWithSlots([1, 2]);
+    env.env = { TMUX: 'x' };
+    env.setExec('tmux list-windows -a -F #{window_name}', ok('A1:main\nA2:main\nLW\n'));
+    expect((await checkTmuxNamedWindows.run(env)).status).toBe('ok');
+  });
+  it('warns on orphan windows', async () => {
+    const env = envWithSlots([1]);
+    env.env = { TMUX: 'x' };
+    env.setExec('tmux list-windows -a -F #{window_name}', ok('A1:main\nA9:dead\n'));
+    const r = await checkTmuxNamedWindows.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('A9');
+  });
+});
+
+describe('checkDiskSpace', () => {
+  it('ok with plenty of space', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('df -k /lw', ok(
+      'Filesystem 1K-blocks Used Avail Capacity Mounted\n' +
+      '/dev/disk1 268435456 100000000 168435456 38% /\n',
+    ));
+    const r = await checkDiskSpace.run(env);
+    expect(r.status).toBe('ok');
+  });
+  it('warns when below 5GB', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('df -k /lw', ok(
+      'Filesystem 1K-blocks Used Avail Capacity Mounted\n' +
+      '/dev/disk1 268435456 264435456 4000000 99% /\n',
+    ));
+    expect((await checkDiskSpace.run(env)).status).toBe('warn');
+  });
+  it('warns when below 10%', async () => {
+    const env = new FakeDoctorEnv();
+    env.setExec('df -k /lw', ok(
+      'Filesystem 1K-blocks Used Avail Capacity Mounted\n' +
+      '/dev/disk1 100000000 95000000 5000000 95% /\n',
+    ));
+    expect((await checkDiskSpace.run(env)).status).toBe('warn');
+  });
+});
+
+describe('checkHungWikiServer', () => {
+  it('ok when none in slot dirs', async () => {
+    const env = envWithSlots([1]);
+    env.setExec('pgrep -fa wiki-server', ok('100 node /lw/main/apps/wiki-server/dist/index.js\n'));
+    expect((await checkHungWikiServer.run(env)).status).toBe('ok');
+  });
+  it('warns when wiki-server runs from a slot', async () => {
+    const env = envWithSlots([7]);
+    env.setExec('pgrep -fa wiki-server', ok('200 node /lw/a7/apps/wiki-server/dist/index.js\n'));
+    const r = await checkHungWikiServer.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('a7');
+  });
+});
+
+describe('SLOTS_CHECKS registry', () => {
+  it('contains all 11 checks', () => {
+    expect(SLOTS_CHECKS).toHaveLength(11);
+  });
+  it('all checks have unique ids', () => {
+    const ids = new Set(SLOTS_CHECKS.map((c) => c.id));
+    expect(ids.size).toBe(SLOTS_CHECKS.length);
+  });
+});

--- a/crux/lib/agent-workspace/doctor/env.ts
+++ b/crux/lib/agent-workspace/doctor/env.ts
@@ -1,0 +1,113 @@
+/**
+ * Production DoctorEnv — backed by node:fs, node:child_process, and global fetch.
+ *
+ * Tests should NOT import this; they construct their own in-memory envs that
+ * implement the same interface from `./types.ts`.
+ */
+
+import { existsSync, readFileSync, readdirSync, lstatSync, readlinkSync } from 'node:fs';
+import { resolve as pathResolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import type { DoctorEnv, ExecOpts, ExecResult, FetchOpts, FetchResult, FileStat } from './types.ts';
+
+export function realDoctorEnv(lwDir: string): DoctorEnv {
+  return {
+    lwDir,
+    now: () => new Date(),
+    env: process.env,
+
+    exists(p: string) {
+      try { return existsSync(p); } catch { return false; }
+    },
+
+    stat(p: string): FileStat | null {
+      try {
+        const s = lstatSync(p);
+        return {
+          isFile: s.isFile(),
+          isDir: s.isDirectory(),
+          isSymlink: s.isSymbolicLink(),
+          mtime: Math.floor(s.mtimeMs / 1000),
+          size: s.size,
+        };
+      } catch {
+        return null;
+      }
+    },
+
+    readlink(p: string) {
+      try {
+        const s = lstatSync(p);
+        if (!s.isSymbolicLink()) return null;
+        return readlinkSync(p);
+      } catch {
+        return null;
+      }
+    },
+
+    readFile(p: string) {
+      try { return readFileSync(p, 'utf-8'); } catch { return null; }
+    },
+
+    listDir(p: string) {
+      try { return readdirSync(p); } catch { return []; }
+    },
+
+    exec(cmd: string, args: string[], opts: ExecOpts = {}): ExecResult {
+      try {
+        const r = spawnSync(cmd, args, {
+          cwd: opts.cwd,
+          timeout: opts.timeoutMs ?? 5000,
+          encoding: 'utf-8',
+          maxBuffer: 4 * 1024 * 1024,
+        });
+        if (r.error) {
+          const err = r.error as NodeJS.ErrnoException;
+          return {
+            stdout: r.stdout ?? '',
+            stderr: r.stderr ?? err.message,
+            code: typeof r.status === 'number' ? r.status : 1,
+            notFound: err.code === 'ENOENT',
+            timedOut: r.signal === 'SIGTERM',
+          };
+        }
+        return {
+          stdout: r.stdout ?? '',
+          stderr: r.stderr ?? '',
+          code: r.status ?? 0,
+          timedOut: r.signal === 'SIGTERM',
+        };
+      } catch (e) {
+        return { stdout: '', stderr: e instanceof Error ? e.message : String(e), code: 1 };
+      }
+    },
+
+    async fetch(url: string, opts: FetchOpts = {}): Promise<FetchResult> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 5000);
+      try {
+        const r = await fetch(url, { headers: opts.headers, signal: controller.signal });
+        const body = await r.text();
+        const headers: Record<string, string> = {};
+        r.headers.forEach((v, k) => { headers[k] = v; });
+        return { ok: r.ok, status: r.status, body, headers };
+      } catch (e) {
+        const aborted = e instanceof Error && e.name === 'AbortError';
+        return {
+          ok: false,
+          status: 0,
+          body: '',
+          headers: {},
+          networkError: !aborted,
+          timedOut: aborted,
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+
+    resolve(...parts: string[]) {
+      return pathResolve(lwDir, ...parts);
+    },
+  };
+}

--- a/crux/lib/agent-workspace/doctor/releases.ts
+++ b/crux/lib/agent-workspace/doctor/releases.ts
@@ -131,7 +131,11 @@ export const checkOpsState: DoctorCheck = {
 
     const fetchHead = env.stat(`${opsPath}/.git/FETCH_HEAD`);
     let lastFetchAge = Infinity;
-    if (fetchHead) lastFetchAge = Math.floor(env.now().getTime() / 1000) - fetchHead.mtime;
+    if (fetchHead) {
+      // Clamp at 0 — backup restores or clock skew can put mtime in the future,
+      // which would print "last pull -3m ago". Treat as "just now" instead.
+      lastFetchAge = Math.max(0, Math.floor(env.now().getTime() / 1000) - fetchHead.mtime);
+    }
 
     const issues: string[] = [];
     if (dirty) issues.push('uncommitted changes');
@@ -139,7 +143,7 @@ export const checkOpsState: DoctorCheck = {
       issues.push(`last fetch ${Math.round(lastFetchAge / 60)}min ago`);
     }
     if (issues.length === 0) {
-      const minutes = Math.max(0, Math.round(lastFetchAge / 60));
+      const minutes = Math.round(lastFetchAge / 60);
       return { status: 'ok', summary: `clean, last pull ${minutes}m ago` };
     }
     return {
@@ -228,16 +232,22 @@ export const checkReleasePr: DoctorCheck = {
 // 6. deploy-tasks — pending tasks awaiting verification
 // ---------------------------------------------------------------------------
 
+/**
+ * Count unchecked `[ ]` lines in `crux gh deploy-tasks pending` output.
+ * The crux subcommand prints human-readable text (no --json today), so we
+ * parse the `☐` / `[ ]` markers instead of asking for structured output
+ * we don't have. If the format changes, this check falls back to info.
+ */
 export const checkDeployTasks: DoctorCheck = {
   id: 'deploy-tasks',
   label: 'deploy-tasks',
   async run(env) {
-    const r = env.exec('pnpm', ['-s', 'crux', 'gh', 'deploy-tasks', 'pending', '--json'], { timeoutMs: 10000 });
+    const r = env.exec('pnpm', ['-s', 'crux', 'gh', 'deploy-tasks', 'pending'], { timeoutMs: 15000 });
     if (r.notFound) return { status: 'skipped', summary: 'pnpm/crux not available' };
     if (r.code !== 0) return { status: 'warn', summary: 'deploy-tasks pending failed', detail: r.stderr };
-    let payload: { count?: number; tasks?: unknown[] };
-    try { payload = JSON.parse(r.stdout); } catch { return { status: 'info', summary: 'unparseable output (older crux?)' }; }
-    const count = payload.count ?? payload.tasks?.length ?? 0;
+    // Strip ANSI and count lines with an unchecked marker
+    const stripped = r.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+    const count = (stripped.match(/(^|\n)\s*(☐|\[ \])/g) ?? []).length;
     if (count === 0) return { status: 'ok', summary: '0 pending' };
     return {
       status: 'warn',
@@ -251,11 +261,20 @@ export const checkDeployTasks: DoctorCheck = {
 // 7. prod-edge — single curl to /api/health (delegates to /health for deep dive)
 // ---------------------------------------------------------------------------
 
+/**
+ * Single-call prod smoke test. Hits the wiki-server /health endpoint
+ * (NOT the Next.js app — that has no health route). Expects the
+ * documented `{ "status": "healthy", ... }` contract.
+ *
+ * Deep diagnostics live in the `/health` skill; this check exists so the
+ * releases doctor can answer "is prod fine enough to proceed?" in ~300ms
+ * without pulling in the full health workflow.
+ */
 export const checkProdEdge: DoctorCheck = {
   id: 'prod-edge',
   label: 'prod-edge',
   async run(env) {
-    const url = 'https://www.longtermwiki.com/api/health';
+    const url = 'https://wiki-server.k8s.quantifieduncertainty.org/health';
     const r = await env.fetch(url, { timeoutMs: 5000 });
     if (r.timedOut) return { status: 'fail', summary: 'timed out', action: 'Run /health and /incident.' };
     if (r.networkError) return { status: 'fail', summary: 'network error', action: 'Run /health.' };
@@ -265,10 +284,12 @@ export const checkProdEdge: DoctorCheck = {
     if (body.migrationError) {
       return { status: 'fail', summary: `migration error: ${body.migrationError}`, action: 'Run /health then /incident.' };
     }
-    if (body.status !== 'ok') {
+    // Accept both 'healthy' (wiki-server contract) and 'ok' (defensive: some
+    // endpoints use this convention). Anything else is a real fail.
+    if (body.status !== 'healthy' && body.status !== 'ok') {
       return { status: 'fail', summary: `status=${body.status}`, action: 'Run /health then /incident.' };
     }
-    return { status: 'ok', summary: `200 status=ok` };
+    return { status: 'ok', summary: `200 status=${body.status}` };
   },
 };
 

--- a/crux/lib/agent-workspace/doctor/releases.ts
+++ b/crux/lib/agent-workspace/doctor/releases.ts
@@ -1,0 +1,442 @@
+/**
+ * Releases-doctor checks (12 read-only diagnostics for the releases coordinator).
+ *
+ * All checks are pure over a DoctorEnv. Defaults to `releases/` working
+ * clone with `coord/` fallback during the rename window.
+ *
+ * Hard rule: never resets, pulls, installs, or deploys. Just observes.
+ */
+
+import type { DoctorCheck, DoctorEnv } from './types.ts';
+
+const RELDIR_CANDIDATES = ['releases', 'coord'];
+
+function resolveReldir(env: DoctorEnv): { name: string; path: string; bothExist: boolean } | null {
+  const present = RELDIR_CANDIDATES.filter((d) => {
+    const st = env.stat(env.resolve(d));
+    return st && st.isDir;
+  });
+  if (present.length === 0) return null;
+  return {
+    name: present[0],
+    path: env.resolve(present[0]),
+    bothExist: present.length > 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. dir-state — branch, porcelain, .env symlink, rebase state
+// ---------------------------------------------------------------------------
+
+export const checkDirState: DoctorCheck = {
+  id: 'dir-state',
+  label: 'dir-state',
+  async run(env) {
+    const dir = resolveReldir(env);
+    if (!dir) return { status: 'fail', summary: 'neither releases/ nor coord/ exists', action: 'Run /agent-releases-start.' };
+    if (dir.bothExist) {
+      return {
+        status: 'fail',
+        summary: 'BOTH releases/ AND coord/ exist (rename in flight)',
+        action: 'Pick one; the other is leftover from an interrupted rename.',
+      };
+    }
+
+    const issues: string[] = [];
+    // rebase / merge / cherry-pick state
+    for (const f of ['.git/rebase-merge', '.git/rebase-apply', '.git/CHERRY_PICK_HEAD', '.git/MERGE_HEAD']) {
+      if (env.stat(`${dir.path}/${f}`)) issues.push(`mid-rebase/merge: ${f}`);
+    }
+
+    // branch + porcelain
+    const branch = env.exec('git', ['-C', dir.path, 'branch', '--show-current'], { timeoutMs: 3000 });
+    if (branch.code !== 0) issues.push('git branch --show-current failed');
+    else if (branch.stdout.trim() !== 'main') issues.push(`on branch ${branch.stdout.trim()} (expected main)`);
+
+    const status = env.exec('git', ['-C', dir.path, 'status', '--porcelain'], { timeoutMs: 3000 });
+    if (status.code !== 0) issues.push('git status failed');
+    else if (status.stdout.trim().length > 0) issues.push(`uncommitted changes (${status.stdout.split('\n').filter(Boolean).length} files)`);
+
+    // .env symlink
+    const envPath = `${dir.path}/.env`;
+    const envStat = env.stat(envPath);
+    if (!envStat) issues.push('.env missing');
+    else if (!envStat.isSymlink) issues.push('.env is not a symlink');
+    else {
+      const target = env.readlink(envPath);
+      if (target !== '../.env.base') issues.push(`.env -> ${target} (expected ../.env.base)`);
+    }
+
+    if (issues.length === 0) {
+      return { status: 'ok', summary: `${dir.name}/ on main, clean, .env -> ../.env.base` };
+    }
+    if (issues.some((i) => i.startsWith('mid-rebase'))) {
+      return {
+        status: 'fail',
+        summary: issues.join('; '),
+        action: `git -C ${dir.name} rebase --abort (or finish the rebase)`,
+      };
+    }
+    return {
+      status: 'fail',
+      summary: issues.join('; '),
+      action: `Review ${dir.name}/ state; ./ws reset-releases when safe.`,
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 2. deps-current — pnpm-lock newer than node_modules/.pnpm?
+// ---------------------------------------------------------------------------
+
+export const checkDepsCurrent: DoctorCheck = {
+  id: 'deps-current',
+  label: 'deps-current',
+  async run(env) {
+    const dir = resolveReldir(env);
+    if (!dir) return { status: 'skipped', summary: 'no releases dir' };
+    const lock = env.stat(`${dir.path}/pnpm-lock.yaml`);
+    const pnpmDir = env.stat(`${dir.path}/node_modules/.pnpm`);
+    if (!lock) return { status: 'skipped', summary: 'pnpm-lock.yaml missing' };
+    if (!pnpmDir) {
+      return { status: 'warn', summary: 'node_modules/.pnpm missing', action: `cd ${dir.name} && pnpm install` };
+    }
+    if (lock.mtime > pnpmDir.mtime) {
+      return {
+        status: 'warn',
+        summary: 'pnpm-lock.yaml newer than node_modules/.pnpm',
+        action: `cd ${dir.name} && pnpm install`,
+      };
+    }
+    return { status: 'ok', summary: 'pnpm-lock.yaml unchanged' };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. ops-state — clean and recently fetched
+// ---------------------------------------------------------------------------
+
+export const checkOpsState: DoctorCheck = {
+  id: 'ops-state',
+  label: 'ops-state',
+  async run(env) {
+    const opsPath = env.resolve('ops');
+    if (!env.stat(opsPath)) return { status: 'skipped', summary: 'ops/ not present' };
+
+    const status = env.exec('git', ['-C', opsPath, 'status', '--porcelain'], { timeoutMs: 3000 });
+    if (status.code !== 0) return { status: 'warn', summary: 'git status failed in ops/' };
+
+    let dirty = false;
+    if (status.stdout.trim().length > 0) dirty = true;
+
+    const fetchHead = env.stat(`${opsPath}/.git/FETCH_HEAD`);
+    let lastFetchAge = Infinity;
+    if (fetchHead) lastFetchAge = Math.floor(env.now().getTime() / 1000) - fetchHead.mtime;
+
+    const issues: string[] = [];
+    if (dirty) issues.push('uncommitted changes');
+    if (lastFetchAge > 60 * 60) {
+      issues.push(`last fetch ${Math.round(lastFetchAge / 60)}min ago`);
+    }
+    if (issues.length === 0) {
+      const minutes = Math.max(0, Math.round(lastFetchAge / 60));
+      return { status: 'ok', summary: `clean, last pull ${minutes}m ago` };
+    }
+    return {
+      status: 'warn',
+      summary: issues.join('; '),
+      action: 'Review status; git -C ops fetch to refresh.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 4. ops-divergence — local commits vs origin/main
+// ---------------------------------------------------------------------------
+
+export const checkOpsDivergence: DoctorCheck = {
+  id: 'ops-divergence',
+  label: 'ops-divergence',
+  async run(env) {
+    const opsPath = env.resolve('ops');
+    if (!env.stat(opsPath)) return { status: 'skipped', summary: 'ops/ not present' };
+    const r = env.exec('git', ['-C', opsPath, 'rev-list', '--left-right', '--count', 'HEAD...origin/main'], { timeoutMs: 3000 });
+    if (r.code !== 0) return { status: 'warn', summary: 'rev-list failed' };
+    const m = r.stdout.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!m) return { status: 'warn', summary: `unparseable: ${r.stdout.trim()}` };
+    const ahead = Number(m[1]);
+    const behind = Number(m[2]);
+    if (ahead === 0) return { status: 'ok', summary: behind === 0 ? 'up to date with origin/main' : `${behind} behind origin/main` };
+    return {
+      status: 'fail',
+      summary: `${ahead} local commit(s) ahead of origin/main`,
+      action: 'Investigate local commits in ops/; rebase or push as appropriate.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 5. release-pr — open release PR health
+// ---------------------------------------------------------------------------
+
+export const checkReleasePr: DoctorCheck = {
+  id: 'release-pr',
+  label: 'release-pr',
+  async run(env) {
+    const r = env.exec('gh', [
+      'pr', 'list', '--repo', 'quantified-uncertainty/longterm-wiki',
+      '--base', 'production', '--state', 'open',
+      '--json', 'number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+    ], { timeoutMs: 8000 });
+    if (r.notFound) return { status: 'skipped', summary: 'gh CLI not installed' };
+    if (r.code !== 0) return { status: 'warn', summary: 'gh pr list failed', detail: r.stderr };
+    let prs: Array<{ number: number; title: string; createdAt: string; isDraft: boolean; mergeable?: string; statusCheckRollup?: Array<{ conclusion?: string }> }>;
+    try { prs = JSON.parse(r.stdout); } catch { return { status: 'warn', summary: 'unparseable gh output' }; }
+    if (prs.length === 0) return { status: 'ok', summary: 'no open release PR' };
+
+    const pr = prs[0];
+    const ageMs = env.now().getTime() - new Date(pr.createdAt).getTime();
+    const ageHours = ageMs / 1000 / 60 / 60;
+    const checks = pr.statusCheckRollup ?? [];
+    const failing = checks.filter((c) => c.conclusion && /fail|cancel|error/i.test(c.conclusion));
+
+    if (ageMs < 5 * 60 * 1000 && checks.length === 0) {
+      return { status: 'info', summary: `#${pr.number} (warming up)` };
+    }
+    if (failing.length > 0) {
+      return {
+        status: 'fail',
+        summary: `#${pr.number} "${pr.title}" — ${failing.length} failing check(s)`,
+        action: `gh run view --log-failed (PR #${pr.number})`,
+      };
+    }
+    if (pr.isDraft && ageHours > 2) {
+      return { status: 'warn', summary: `#${pr.number} draft for ${ageHours.toFixed(0)}h`, action: 'Promote draft or close.' };
+    }
+    if (ageHours > 24) {
+      return {
+        status: 'warn',
+        summary: `#${pr.number} ${ageHours.toFixed(0)}h old`,
+        action: 'Old release PR — investigate or merge.',
+      };
+    }
+    return { status: 'ok', summary: `#${pr.number} fresh, no failing checks` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 6. deploy-tasks — pending tasks awaiting verification
+// ---------------------------------------------------------------------------
+
+export const checkDeployTasks: DoctorCheck = {
+  id: 'deploy-tasks',
+  label: 'deploy-tasks',
+  async run(env) {
+    const r = env.exec('pnpm', ['-s', 'crux', 'gh', 'deploy-tasks', 'pending', '--json'], { timeoutMs: 10000 });
+    if (r.notFound) return { status: 'skipped', summary: 'pnpm/crux not available' };
+    if (r.code !== 0) return { status: 'warn', summary: 'deploy-tasks pending failed', detail: r.stderr };
+    let payload: { count?: number; tasks?: unknown[] };
+    try { payload = JSON.parse(r.stdout); } catch { return { status: 'info', summary: 'unparseable output (older crux?)' }; }
+    const count = payload.count ?? payload.tasks?.length ?? 0;
+    if (count === 0) return { status: 'ok', summary: '0 pending' };
+    return {
+      status: 'warn',
+      summary: `${count} pending deploy task(s)`,
+      action: 'pnpm crux gh deploy-tasks verify',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 7. prod-edge — single curl to /api/health (delegates to /health for deep dive)
+// ---------------------------------------------------------------------------
+
+export const checkProdEdge: DoctorCheck = {
+  id: 'prod-edge',
+  label: 'prod-edge',
+  async run(env) {
+    const url = 'https://www.longtermwiki.com/api/health';
+    const r = await env.fetch(url, { timeoutMs: 5000 });
+    if (r.timedOut) return { status: 'fail', summary: 'timed out', action: 'Run /health and /incident.' };
+    if (r.networkError) return { status: 'fail', summary: 'network error', action: 'Run /health.' };
+    if (!r.ok) return { status: 'fail', summary: `HTTP ${r.status}`, action: 'Run /health and /incident.' };
+    let body: { status?: string; migrationError?: string };
+    try { body = JSON.parse(r.body); } catch { return { status: 'fail', summary: `unparseable body (HTTP ${r.status})`, action: 'Run /health.' }; }
+    if (body.migrationError) {
+      return { status: 'fail', summary: `migration error: ${body.migrationError}`, action: 'Run /health then /incident.' };
+    }
+    if (body.status !== 'ok') {
+      return { status: 'fail', summary: `status=${body.status}`, action: 'Run /health then /incident.' };
+    }
+    return { status: 'ok', summary: `200 status=ok` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 8. prod-ci-recent — failures on the production branch in the last 24h
+// ---------------------------------------------------------------------------
+
+export const checkProdCiRecent: DoctorCheck = {
+  id: 'prod-ci-recent',
+  label: 'prod-ci-recent',
+  async run(env) {
+    const r = env.exec('gh', [
+      'run', 'list',
+      '--repo', 'quantified-uncertainty/longterm-wiki',
+      '--branch', 'production', '--limit', '20',
+      '--json', 'status,conclusion,createdAt',
+    ], { timeoutMs: 8000 });
+    if (r.notFound) return { status: 'skipped', summary: 'gh CLI not installed' };
+    if (r.code !== 0) return { status: 'warn', summary: 'gh run list failed' };
+    let runs: Array<{ status: string; conclusion: string; createdAt: string }>;
+    try { runs = JSON.parse(r.stdout); } catch { return { status: 'warn', summary: 'unparseable gh output' }; }
+    const cutoff = env.now().getTime() - 24 * 60 * 60 * 1000;
+    const recent = runs.filter((rn) => new Date(rn.createdAt).getTime() >= cutoff);
+    const failed = recent.filter((rn) => /failure|cancelled|timed_out/.test(rn.conclusion));
+    if (failed.length === 0) {
+      return { status: 'ok', summary: `0 failures in last 24h (${recent.length} runs)` };
+    }
+    return {
+      status: 'warn',
+      summary: `${failed.length} failed run(s) in last 24h`,
+      action: 'gh run view <id> --log-failed',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 9. k8s-pods — Running with no recent restart spike
+// ---------------------------------------------------------------------------
+
+export const checkK8sPods: DoctorCheck = {
+  id: 'k8s-pods',
+  label: 'k8s-pods',
+  async run(env) {
+    const r = env.exec('kubectl', ['-n', 'longterm-wiki', 'get', 'pods', '-o', 'json'], { timeoutMs: 8000 });
+    if (r.notFound) return { status: 'skipped', summary: 'kubectl not installed' };
+    if (r.code !== 0) return { status: 'skipped', summary: 'kubectl unauthenticated or failed' };
+    let payload: { items?: Array<{ metadata: { name: string; creationTimestamp: string }; status: { phase: string; containerStatuses?: Array<{ restartCount: number }> } }> };
+    try { payload = JSON.parse(r.stdout); } catch { return { status: 'warn', summary: 'unparseable kubectl json' }; }
+    const items = payload.items ?? [];
+    if (items.length === 0) return { status: 'warn', summary: 'no pods returned' };
+
+    const issues: string[] = [];
+    const now = env.now().getTime();
+    for (const pod of items) {
+      const phase = pod.status.phase;
+      if (phase !== 'Running') {
+        issues.push(`${pod.metadata.name}: ${phase}`);
+        continue;
+      }
+      const ageMs = now - new Date(pod.metadata.creationTimestamp).getTime();
+      const restarts = pod.status.containerStatuses?.reduce((acc, c) => acc + c.restartCount, 0) ?? 0;
+      // Threshold from spec red team: restartCount > 5 AND pod age < 1h
+      if (restarts > 5 && ageMs < 60 * 60 * 1000) {
+        issues.push(`${pod.metadata.name}: ${restarts} restarts in <1h`);
+      }
+    }
+    if (issues.length === 0) return { status: 'ok', summary: `${items.length} pods Running, no restart spike` };
+    return {
+      status: 'fail',
+      summary: `${issues.length} pod issue(s)`,
+      detail: issues.join('\n'),
+      action: 'kubectl describe pod <name>; consider /incident.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 10. argocd-sync — apps Synced + Healthy
+// ---------------------------------------------------------------------------
+
+export const checkArgocdSync: DoctorCheck = {
+  id: 'argocd-sync',
+  label: 'argocd-sync',
+  async run(env) {
+    const r = env.exec('argocd', ['app', 'list', '-o', 'json'], { timeoutMs: 8000 });
+    if (r.notFound) return { status: 'skipped', summary: 'argocd CLI not installed' };
+    if (r.code !== 0) return { status: 'skipped', summary: 'argocd unauthenticated or failed' };
+    let apps: Array<{ metadata: { name: string }; status: { sync: { status: string }; health: { status: string } } }>;
+    try { apps = JSON.parse(r.stdout); } catch { return { status: 'warn', summary: 'unparseable argocd json' }; }
+    const lw = apps.filter((a) => /longterm/.test(a.metadata.name));
+    if (lw.length === 0) return { status: 'info', summary: 'no longterm-wiki apps in argocd' };
+    const issues: string[] = [];
+    for (const a of lw) {
+      if (a.status.sync.status !== 'Synced' || a.status.health.status !== 'Healthy') {
+        issues.push(`${a.metadata.name}: ${a.status.sync.status}/${a.status.health.status}`);
+      }
+    }
+    if (issues.length === 0) return { status: 'ok', summary: `${lw.length} apps Synced+Healthy` };
+    return {
+      status: 'fail',
+      summary: issues.join('; '),
+      action: 'argocd app sync <name> with user approval.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 11. release-branch-stale — orphan release/* branches >7d
+// ---------------------------------------------------------------------------
+
+export const checkReleaseBranchStale: DoctorCheck = {
+  id: 'release-branch-stale',
+  label: 'release-branch-stale',
+  async run(env) {
+    const r = env.exec('gh', [
+      'api', 'repos/quantified-uncertainty/longterm-wiki/branches',
+      '--paginate', '-q', '.[].name',
+    ], { timeoutMs: 8000 });
+    if (r.notFound) return { status: 'skipped', summary: 'gh CLI not installed' };
+    if (r.code !== 0) return { status: 'skipped', summary: 'gh api failed' };
+    const releaseBranches = r.stdout.split('\n').filter((b) => b.trim().startsWith('release/'));
+    if (releaseBranches.length === 0) return { status: 'info', summary: 'no release/* branches on remote' };
+    // We can't cheaply check >7d age without N PR queries. Spec says
+    // "only warn on branches >7d with no PR ever; silent otherwise."
+    // For the doctor, just count and let the user investigate.
+    return { status: 'info', summary: `${releaseBranches.length} release/* branch(es) — review manually if stale` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 12. session-clock-skew — system clock vs gh api Date header
+// ---------------------------------------------------------------------------
+
+export const checkSessionClockSkew: DoctorCheck = {
+  id: 'session-clock',
+  label: 'session-clock',
+  async run(env) {
+    const r = await env.fetch('https://api.github.com', { timeoutMs: 5000 });
+    if (r.timedOut || r.networkError) return { status: 'skipped', summary: 'cannot reach api.github.com' };
+    const dateHdr = r.headers['date'] ?? r.headers['Date'];
+    if (!dateHdr) return { status: 'skipped', summary: 'no Date header from gh api' };
+    const ghTime = new Date(dateHdr).getTime();
+    if (Number.isNaN(ghTime)) return { status: 'skipped', summary: 'unparseable Date header' };
+    const skew = Math.abs(env.now().getTime() - ghTime) / 1000;
+    if (skew <= 60) return { status: 'ok', summary: `within ${Math.round(skew)}s of gh api clock` };
+    return {
+      status: 'warn',
+      summary: `clock skew ${Math.round(skew)}s`,
+      action: 'Sync system clock (sntp -sS time.apple.com).',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const RELEASES_CHECKS: DoctorCheck[] = [
+  checkDirState,
+  checkDepsCurrent,
+  checkOpsState,
+  checkOpsDivergence,
+  checkReleasePr,
+  checkDeployTasks,
+  checkProdEdge,
+  checkProdCiRecent,
+  checkK8sPods,
+  checkArgocdSync,
+  checkReleaseBranchStale,
+  checkSessionClockSkew,
+];

--- a/crux/lib/agent-workspace/doctor/runner.ts
+++ b/crux/lib/agent-workspace/doctor/runner.ts
@@ -1,0 +1,151 @@
+/**
+ * Doctor runner — executes a list of checks and renders the result.
+ *
+ * Output modes:
+ *   - pretty: human-scannable text per the QUA-326 specs
+ *   - json:   structured object (for `--json` flag)
+ *
+ * Exit code: worst result wins (fail → 2, warn → 1, ok → 0).
+ */
+
+import type { CheckResult, CheckStatus, DoctorCheck, DoctorEnv } from './types.ts';
+
+export interface RunOptions {
+  /** Run checks in parallel. Default true; set false for deterministic test ordering. */
+  parallel?: boolean;
+}
+
+export interface RunReport {
+  role: 'slots' | 'releases';
+  startedAt: string;
+  runtimeMs: number;
+  checks: CheckResult[];
+  summary: Record<CheckStatus, number>;
+  /** Worst status among all checks. */
+  worst: CheckStatus;
+}
+
+const STATUS_ORDER: Record<CheckStatus, number> = {
+  ok: 0,
+  info: 0,
+  skipped: 0,
+  warn: 1,
+  fail: 2,
+};
+
+const ICONS: Record<CheckStatus, string> = {
+  ok: '✓',
+  warn: '!',
+  fail: '✗',
+  info: '–',
+  skipped: '–',
+};
+
+export async function runDoctor(
+  role: 'slots' | 'releases',
+  checks: DoctorCheck[],
+  env: DoctorEnv,
+  opts: RunOptions = {},
+): Promise<RunReport> {
+  const startedAt = env.now();
+  const startMs = startedAt.getTime();
+
+  const runOne = async (c: DoctorCheck): Promise<CheckResult> => {
+    const t0 = Date.now();
+    try {
+      const partial = await c.run(env);
+      return { id: c.id, label: c.label, durationMs: Date.now() - t0, ...partial };
+    } catch (err) {
+      return {
+        id: c.id,
+        label: c.label,
+        status: 'fail',
+        summary: 'check threw an error',
+        detail: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - t0,
+      };
+    }
+  };
+
+  const parallel = opts.parallel ?? true;
+  const results: CheckResult[] = parallel
+    ? await Promise.all(checks.map(runOne))
+    : await checksSequential(checks, runOne);
+
+  const summary: Record<CheckStatus, number> = { ok: 0, warn: 0, fail: 0, info: 0, skipped: 0 };
+  let worst: CheckStatus = 'ok';
+  for (const r of results) {
+    summary[r.status] += 1;
+    if (STATUS_ORDER[r.status] > STATUS_ORDER[worst]) worst = r.status;
+  }
+
+  return {
+    role,
+    startedAt: formatTimestamp(startedAt),
+    runtimeMs: Date.now() - startMs,
+    checks: results,
+    summary,
+    worst,
+  };
+}
+
+async function checksSequential(
+  checks: DoctorCheck[],
+  runOne: (c: DoctorCheck) => Promise<CheckResult>,
+): Promise<CheckResult[]> {
+  const out: CheckResult[] = [];
+  for (const c of checks) out.push(await runOne(c));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+export function renderPretty(report: RunReport): string {
+  const lines: string[] = [];
+  const header = `=== /agent-${report.role}-doctor — ${report.startedAt} ===`;
+  lines.push(header, '');
+
+  const labelWidth = Math.max(...report.checks.map((c) => c.label.length), 12);
+  for (const c of report.checks) {
+    const icon = ICONS[c.status];
+    const label = c.label.padEnd(labelWidth);
+    lines.push(`${icon} ${label}  ${c.summary}`);
+    if (c.detail && c.status !== 'ok') {
+      for (const dl of c.detail.split('\n')) lines.push(`    ${dl}`);
+    }
+  }
+
+  lines.push('');
+  const issues =
+    `${report.summary.fail} failure${report.summary.fail === 1 ? '' : 's'}, ` +
+    `${report.summary.warn} warning${report.summary.warn === 1 ? '' : 's'}` +
+    (report.summary.skipped ? `, ${report.summary.skipped} skipped` : '');
+  lines.push(`Runtime: ${(report.runtimeMs / 1000).toFixed(1)}s  Issues: ${issues}`);
+
+  const actionable = report.checks.filter((c) => c.action && (c.status === 'warn' || c.status === 'fail'));
+  if (actionable.length > 0) {
+    lines.push('', 'What to do:');
+    for (const c of actionable) {
+      lines.push(`  ${ICONS[c.status]} ${c.label}: ${c.action}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderJson(report: RunReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function exitCodeFor(worst: CheckStatus): number {
+  if (worst === 'fail') return 2;
+  if (worst === 'warn') return 1;
+  return 0;
+}
+
+function formatTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/crux/lib/agent-workspace/doctor/runner.ts
+++ b/crux/lib/agent-workspace/doctor/runner.ts
@@ -79,6 +79,14 @@ export async function runDoctor(
     if (STATUS_ORDER[r.status] > STATUS_ORDER[worst]) worst = r.status;
   }
 
+  // If nothing actually succeeded (every check skipped/info) we do NOT have
+  // evidence that the session is healthy — refuse to report green. A fresh
+  // CI box missing pgrep/gh/kubectl/lsof would otherwise score a misleading
+  // "all clear" exit 0.
+  if (summary.ok === 0 && summary.fail === 0 && summary.warn === 0 && results.length > 0) {
+    worst = 'warn';
+  }
+
   return {
     role,
     startedAt: formatTimestamp(startedAt),

--- a/crux/lib/agent-workspace/doctor/slots.ts
+++ b/crux/lib/agent-workspace/doctor/slots.ts
@@ -1,0 +1,436 @@
+/**
+ * Slots-doctor checks (11 read-only diagnostics for the slots coordinator).
+ *
+ * All checks are pure over a DoctorEnv. None mutate state, none kill
+ * processes, none touch ./releases/ or ./ops/ (those belong to the
+ * releases doctor). Each check should complete in well under a second so
+ * the full suite stays under the 15-second target.
+ */
+
+import type { DoctorCheck, DoctorEnv } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// 1. tmux-rename-loop process
+// ---------------------------------------------------------------------------
+
+export const checkRenameLoop: DoctorCheck = {
+  id: 'rename-loop',
+  label: 'rename-loop',
+  async run(env) {
+    const r = env.exec('pgrep', ['-fa', 'tmux-rename-loop.sh']);
+    if (r.notFound) {
+      return { status: 'skipped', summary: 'pgrep not available' };
+    }
+    const lines = r.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.includes('agent-workspace.ts'));
+    if (lines.length === 0) {
+      return {
+        status: 'warn',
+        summary: 'not running',
+        action: 'Re-run /agent-slots-start to relaunch the rename loop.',
+      };
+    }
+    if (lines.length > 1) {
+      const pids = lines.map((l) => l.split(/\s+/)[0]).join(', ');
+      return {
+        status: 'warn',
+        summary: `${lines.length} processes (PIDs ${pids})`,
+        detail: lines.join('\n'),
+        action: 'Multiple rename-loop processes — surface PIDs to user before killing.',
+      };
+    }
+    const pid = lines[0].split(/\s+/)[0];
+    return { status: 'ok', summary: `1 process (PID ${pid})` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 2. PR patrol process — informational only
+// ---------------------------------------------------------------------------
+
+export const checkPrPatrol: DoctorCheck = {
+  id: 'pr-patrol',
+  label: 'pr-patrol',
+  async run(env) {
+    const r = env.exec('pgrep', ['-fa', 'pr-patrol']);
+    if (r.notFound) return { status: 'skipped', summary: 'pgrep not available' };
+    const lines = r.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.includes('agent-workspace.ts'));
+    if (lines.length === 0) return { status: 'info', summary: 'not running (informational)' };
+    return { status: 'info', summary: `${lines.length} process(es) running` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. rename-log freshness
+// ---------------------------------------------------------------------------
+
+export const checkRenameLogAge: DoctorCheck = {
+  id: 'rename-log-age',
+  label: 'rename-log-age',
+  async run(env) {
+    // Per red team #8: glob log files, pick newest
+    const candidates = env.listDir('/tmp')
+      .filter((n) => n.startsWith('lw-fix-tabs.log'))
+      .map((n) => `/tmp/${n}`);
+    if (candidates.length === 0) {
+      return { status: 'info', summary: 'no log file (loop may not have run yet)' };
+    }
+    let newest: { path: string; mtime: number } | null = null;
+    for (const p of candidates) {
+      const st = env.stat(p);
+      if (!st) continue;
+      if (!newest || st.mtime > newest.mtime) newest = { path: p, mtime: st.mtime };
+    }
+    if (!newest) return { status: 'info', summary: 'no readable log file' };
+
+    const ageSec = Math.floor(env.now().getTime() / 1000) - newest.mtime;
+    const ageStr = ageSec < 120 ? `${ageSec}s` : `${Math.round(ageSec / 60)}min`;
+
+    const content = env.readFile(newest.path) ?? '';
+    const errLines = content
+      .split('\n')
+      .filter((l) => /\b(error|fail|failed|panic)\b/i.test(l))
+      .slice(-3);
+
+    if (ageSec > 15 * 60) {
+      return {
+        status: 'warn',
+        summary: `last activity ${ageStr} ago (rename loop may be stalled)`,
+        detail: errLines.length > 0 ? errLines.join('\n') : undefined,
+        action: `tail ${newest.path}`,
+      };
+    }
+    if (errLines.length > 0) {
+      return {
+        status: 'warn',
+        summary: `last activity ${ageStr} ago, ${errLines.length} recent error line(s)`,
+        detail: errLines.join('\n'),
+        action: `tail ${newest.path}`,
+      };
+    }
+    return { status: 'ok', summary: `last activity ${ageStr} ago, no errors` };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 4. .env drift across slots
+// ---------------------------------------------------------------------------
+
+export const checkEnvDrift: DoctorCheck = {
+  id: 'env-drift',
+  label: 'env-drift',
+  async run(env) {
+    const basePath = env.resolve('.env.base');
+    const baseStat = env.stat(basePath);
+    if (!baseStat) {
+      return {
+        status: 'skipped',
+        summary: '.env.base missing — cannot compare slot envs',
+      };
+    }
+    const slots = listSlotDirs(env);
+    if (slots.length === 0) return { status: 'info', summary: 'no slots configured' };
+
+    const issues: string[] = [];
+    for (const slot of slots) {
+      const envPath = `${slot.path}/.env`;
+      const st = env.stat(envPath);
+      if (!st) {
+        issues.push(`${slot.name}/.env missing`);
+        continue;
+      }
+      if (st.isSymlink) {
+        issues.push(`${slot.name}/.env is a symlink (slots use regular files)`);
+        continue;
+      }
+      if (st.mtime < baseStat.mtime) {
+        const ageDays = Math.floor((baseStat.mtime - st.mtime) / 86400);
+        issues.push(`${slot.name}/.env stale (mtime ${ageDays}d < .env.base)`);
+      }
+    }
+
+    if (issues.length === 0) return { status: 'ok', summary: `${slots.length}/${slots.length} slots in sync` };
+    return {
+      status: 'warn',
+      summary: `${issues.length} drift issue(s)`,
+      detail: issues.join('\n'),
+      action: 'Run ./ws sync-env to refresh slot .env files; surface symlinked slots to user.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 5. .agent-slot marker matches slot number
+// ---------------------------------------------------------------------------
+
+export const checkAgentSlotMarker: DoctorCheck = {
+  id: 'agent-slot-marker',
+  label: 'agent-slot-marker',
+  async run(env) {
+    const slots = listSlotDirs(env);
+    if (slots.length === 0) return { status: 'info', summary: 'no slots configured' };
+
+    const mismatches: string[] = [];
+    for (const slot of slots) {
+      const markerPath = `${slot.path}/.agent-slot`;
+      const content = env.readFile(markerPath);
+      if (content == null) {
+        mismatches.push(`${slot.name}: .agent-slot missing`);
+        continue;
+      }
+      const trimmed = content.trim();
+      if (trimmed !== String(slot.number)) {
+        mismatches.push(`${slot.name}: .agent-slot=${trimmed} (expected ${slot.number})`);
+      }
+    }
+    if (mismatches.length === 0) {
+      return { status: 'ok', summary: `${slots.length}/${slots.length} slots correct` };
+    }
+    return {
+      status: 'warn',
+      summary: `${mismatches.length} mismatch(es)`,
+      detail: mismatches.join('\n'),
+      action: 'Slot identity drift — surface to user; ./ws reset <N> may help.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 6. merged-PR slots with uncommitted changes
+// ---------------------------------------------------------------------------
+
+export const checkMergedDirty: DoctorCheck = {
+  id: 'merged-dirty',
+  label: 'merged-dirty',
+  async run(env) {
+    const slots = listSlotDirs(env);
+    if (slots.length === 0) return { status: 'info', summary: 'no slots configured' };
+
+    const dirty: string[] = [];
+    for (const slot of slots) {
+      const branchR = env.exec('git', ['-C', slot.path, 'branch', '--show-current'], { timeoutMs: 3000 });
+      if (branchR.code !== 0) continue;
+      const branch = branchR.stdout.trim();
+      // We can't tell "merged PR" without a network call; proxy is "branch != main and dirty".
+      if (branch === 'main' || branch === '') continue;
+      const statusR = env.exec('git', ['-C', slot.path, 'status', '--porcelain'], { timeoutMs: 3000 });
+      if (statusR.code !== 0) continue;
+      const isDirty = statusR.stdout.trim().length > 0;
+      // Check whether this branch has been merged into origin/main
+      const mergedR = env.exec('git', ['-C', slot.path, 'merge-base', '--is-ancestor', 'HEAD', 'origin/main'], { timeoutMs: 3000 });
+      const merged = mergedR.code === 0;
+      if (merged && isDirty) dirty.push(`${slot.name} (${branch})`);
+    }
+    if (dirty.length === 0) return { status: 'ok', summary: 'no merged-but-dirty slots' };
+    return {
+      status: 'warn',
+      summary: `${dirty.length} slot(s) with uncommitted work on merged branches`,
+      detail: dirty.join('\n'),
+      action: 'Open each slot — uncommitted work would be lost on ./ws refresh. Ask user.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 7. mid-rebase detection
+// ---------------------------------------------------------------------------
+
+export const checkMidRebase: DoctorCheck = {
+  id: 'mid-rebase',
+  label: 'mid-rebase',
+  async run(env) {
+    const slots = listSlotDirs(env);
+    if (slots.length === 0) return { status: 'info', summary: 'no slots configured' };
+
+    const rebasing: string[] = [];
+    for (const slot of slots) {
+      const a = env.stat(`${slot.path}/.git/rebase-merge`);
+      const b = env.stat(`${slot.path}/.git/rebase-apply`);
+      const c = env.stat(`${slot.path}/.git/CHERRY_PICK_HEAD`);
+      const d = env.stat(`${slot.path}/.git/MERGE_HEAD`);
+      if (a || b || c || d) rebasing.push(slot.name);
+    }
+    if (rebasing.length === 0) return { status: 'ok', summary: 'no in-progress rebases' };
+    return {
+      status: 'fail',
+      summary: `${rebasing.length} slot(s) with in-progress rebase/merge/cherry-pick`,
+      detail: rebasing.join('\n'),
+      action: 'Do NOT run ./ws refresh. Abort or finish the rebase first.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 8. dev-server inventory (NEVER auto-act)
+// ---------------------------------------------------------------------------
+
+export const checkDevServerInventory: DoctorCheck = {
+  id: 'dev-server-inventory',
+  label: 'dev-server-inventory',
+  async run(env) {
+    const r = env.exec('lsof', ['-iTCP:3010-3030', '-sTCP:LISTEN', '-P', '-n'], { timeoutMs: 5000 });
+    if (r.notFound) return { status: 'skipped', summary: 'lsof not available' };
+    if (r.code !== 0) return { status: 'info', summary: 'no listeners on 3010-3030' };
+    // Parse lsof output: lines look like "next 12345 user  21u  IPv4 ..."
+    const lines = r.stdout.split('\n').filter((l, i) => i > 0 && l.trim().length > 0);
+    if (lines.length === 0) return { status: 'info', summary: 'no listeners on 3010-3030' };
+    const summary: string[] = [];
+    for (const l of lines) {
+      const cols = l.split(/\s+/);
+      const name = cols[0];
+      const pid = cols[1];
+      const portMatch = l.match(/:(\d+)\s/);
+      if (!portMatch) continue;
+      summary.push(`port ${portMatch[1]}: ${name} (PID ${pid})`);
+    }
+    return {
+      status: 'info',
+      summary: `${summary.length} dev server(s) listening (NEVER auto-kill — could hit user's main on 3001)`,
+      detail: summary.join('\n'),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 9. tmux windows match real slots
+// ---------------------------------------------------------------------------
+
+export const checkTmuxNamedWindows: DoctorCheck = {
+  id: 'tmux-named-windows',
+  label: 'tmux-named-windows',
+  async run(env) {
+    if (!env.env.TMUX) return { status: 'skipped', summary: 'not in tmux' };
+    const r = env.exec('tmux', ['list-windows', '-a', '-F', '#{window_name}'], { timeoutMs: 3000 });
+    if (r.code !== 0) return { status: 'skipped', summary: 'tmux list-windows failed' };
+    const slotPattern = /^[Aa](\d+)/;
+    const slotWindows = r.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => slotPattern.test(l));
+    const realSlots = new Set(listSlotDirs(env).map((s) => s.number));
+
+    const orphans: string[] = [];
+    for (const w of slotWindows) {
+      const m = w.match(slotPattern);
+      if (!m) continue;
+      if (!realSlots.has(Number(m[1]))) orphans.push(w);
+    }
+    if (orphans.length === 0) {
+      return { status: 'ok', summary: `${slotWindows.length} slot-named windows, all match` };
+    }
+    return {
+      status: 'warn',
+      summary: `${orphans.length} orphan window(s)`,
+      detail: orphans.join('\n'),
+      action: './ws fix-tabs to resync window names.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 10. disk space
+// ---------------------------------------------------------------------------
+
+export const checkDiskSpace: DoctorCheck = {
+  id: 'disk-space',
+  label: 'disk-space',
+  async run(env) {
+    const r = env.exec('df', ['-k', env.lwDir], { timeoutMs: 3000 });
+    if (r.code !== 0 || r.notFound) return { status: 'skipped', summary: 'df not available' };
+    const lines = r.stdout.split('\n').filter((l) => l.trim().length > 0);
+    if (lines.length < 2) return { status: 'skipped', summary: 'df output unparseable' };
+    const cols = lines[1].split(/\s+/);
+    // POSIX df -k: Filesystem 1K-blocks Used Avail Capacity Mounted
+    const total = Number(cols[1]);
+    const avail = Number(cols[3]);
+    const device = cols[0];
+    if (!Number.isFinite(total) || !Number.isFinite(avail)) {
+      return { status: 'skipped', summary: 'df output unparseable' };
+    }
+    const availGB = avail / 1024 / 1024;
+    const pct = (avail / total) * 100;
+    const summary = `${availGB.toFixed(0)}G free (${pct.toFixed(0)}% of ${(total / 1024 / 1024).toFixed(0)}G, ${device})`;
+    if (availGB < 5 || pct < 10) {
+      return {
+        status: 'warn',
+        summary,
+        action: 'Free space before next ./ws refresh.',
+      };
+    }
+    return { status: 'ok', summary };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 11. hung wiki-server processes inside slot dirs
+// ---------------------------------------------------------------------------
+
+export const checkHungWikiServer: DoctorCheck = {
+  id: 'hung-wiki-server',
+  label: 'hung-wiki-server',
+  async run(env) {
+    const r = env.exec('pgrep', ['-fa', 'wiki-server'], { timeoutMs: 3000 });
+    if (r.notFound) return { status: 'skipped', summary: 'pgrep not available' };
+    const lines = r.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    const slotPaths = listSlotDirs(env).map((s) => s.path);
+    const hung = lines.filter((l) => slotPaths.some((p) => l.includes(p)));
+    if (hung.length === 0) return { status: 'ok', summary: 'none in slot dirs' };
+    return {
+      status: 'warn',
+      summary: `${hung.length} wiki-server process(es) in slot dirs`,
+      detail: hung.join('\n'),
+      action: 'Slots should use prod wiki-server, not local. Ask user before killing.',
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SlotDir {
+  name: string;
+  number: number;
+  path: string;
+}
+
+/** List `aN` directories under lwDir. */
+function listSlotDirs(env: DoctorEnv): SlotDir[] {
+  const entries = env.listDir(env.lwDir);
+  const slots: SlotDir[] = [];
+  for (const name of entries) {
+    const m = name.match(/^a(\d+)$/);
+    if (!m) continue;
+    const path = env.resolve(name);
+    const st = env.stat(path);
+    if (!st || !st.isDir) continue;
+    slots.push({ name, number: Number(m[1]), path });
+  }
+  return slots.sort((a, b) => a.number - b.number);
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const SLOTS_CHECKS: DoctorCheck[] = [
+  checkRenameLoop,
+  checkPrPatrol,
+  checkRenameLogAge,
+  checkEnvDrift,
+  checkAgentSlotMarker,
+  checkMergedDirty,
+  checkMidRebase,
+  checkDevServerInventory,
+  checkTmuxNamedWindows,
+  checkDiskSpace,
+  checkHungWikiServer,
+];

--- a/crux/lib/agent-workspace/doctor/types.ts
+++ b/crux/lib/agent-workspace/doctor/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Doctor check framework — types shared by slots-doctor and releases-doctor.
+ *
+ * Each check is a pure function over a DoctorEnv. The runner executes them,
+ * collects results, and renders pretty or JSON output. Tests inject a fake
+ * DoctorEnv to exercise checks without hitting the real filesystem, network,
+ * or shell.
+ */
+
+export type CheckStatus = 'ok' | 'warn' | 'fail' | 'info' | 'skipped';
+
+export interface CheckResult {
+  id: string;
+  label: string;
+  status: CheckStatus;
+  /** One-line summary printed inline next to the status icon. */
+  summary: string;
+  /** Optional multi-line context shown only when status is non-ok. */
+  detail?: string;
+  /** Suggested remediation, shown in the "What to do" footer block. */
+  action?: string;
+  /** Time the check spent running, in milliseconds (set by runner). */
+  durationMs?: number;
+}
+
+export interface DoctorCheck {
+  id: string;
+  label: string;
+  run(env: DoctorEnv): Promise<Omit<CheckResult, 'id' | 'label' | 'durationMs'>>;
+}
+
+// ---------------------------------------------------------------------------
+// DoctorEnv — the entire surface a check is allowed to touch.
+// ---------------------------------------------------------------------------
+
+export interface ExecOpts {
+  cwd?: string;
+  /** Hard timeout in ms. Default 5000. */
+  timeoutMs?: number;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+  /** True if the binary was not found on PATH. */
+  notFound?: boolean;
+  /** True if execution was cut off by the timeout. */
+  timedOut?: boolean;
+}
+
+export interface FileStat {
+  isFile: boolean;
+  isDir: boolean;
+  isSymlink: boolean;
+  /** Mtime in unix-epoch seconds. */
+  mtime: number;
+  size: number;
+}
+
+export interface FetchOpts {
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
+export interface FetchResult {
+  ok: boolean;
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+  /** True if the request failed before any HTTP response was received. */
+  networkError?: boolean;
+  /** True if cut off by timeout. */
+  timedOut?: boolean;
+}
+
+/**
+ * The DoctorEnv abstracts every external dependency a check can use.
+ *
+ * Implementations:
+ *   - `realDoctorEnv()` — backed by node:fs, node:child_process, undici/fetch
+ *   - test fakes — pure in-memory maps + scripted exec replies
+ */
+export interface DoctorEnv {
+  /** Workspace root, e.g. `/Users/ozzie/.../lw`. */
+  lwDir: string;
+  now(): Date;
+  env: NodeJS.ProcessEnv;
+
+  // ---- filesystem ----
+  exists(path: string): boolean;
+  stat(path: string): FileStat | null;
+  /** Reads target of symlink, or null if not a symlink. */
+  readlink(path: string): string | null;
+  readFile(path: string): string | null;
+  /** Returns immediate children (filenames, not full paths), or [] if not a directory. */
+  listDir(path: string): string[];
+
+  // ---- shell ----
+  exec(cmd: string, args: string[], opts?: ExecOpts): ExecResult;
+
+  // ---- network ----
+  fetch(url: string, opts?: FetchOpts): Promise<FetchResult>;
+
+  // ---- meta ----
+  /** Returns a path resolved against lwDir. */
+  resolve(...parts: string[]): string;
+}

--- a/crux/lib/agent-workspace/sentinel.ts
+++ b/crux/lib/agent-workspace/sentinel.ts
@@ -90,9 +90,20 @@ export interface SentinelEnv {
 export function deriveSessionKey(env: NodeJS.ProcessEnv, ppid: number): string {
   const pane = env.TMUX_PANE;
   if (pane && pane.length > 0) {
-    return pane.startsWith('%') ? pane.slice(1) : pane;
+    const raw = pane.startsWith('%') ? pane.slice(1) : pane;
+    return sanitizeSessionKey(raw) || `pid-${ppid}`;
   }
   return `pid-${ppid}`;
+}
+
+/**
+ * Strip any character that could make the session key escape `/tmp/`. The
+ * legitimate inputs are tmux pane ids (`\d+`) and our own `pid-<n>`
+ * fallback; anything else is rejected to prevent a hostile TMUX_PANE from
+ * steering writes into unrelated paths.
+ */
+function sanitizeSessionKey(s: string): string {
+  return s.replace(/[^A-Za-z0-9_-]/g, '');
 }
 
 export function sentinelPath(role: Role, sessionKey: string): string {
@@ -112,10 +123,21 @@ export function otherRole(role: Role): Role {
  *
  * Format chosen to be human-readable in `cat`, parseable in bash, and
  * resistant to corruption by intermediate `sed`/`grep` pipes.
+ *
+ * We sanitize `host` to drop whitespace because macOS computer names can
+ * contain spaces (e.g. "Ozzie's MacBook"), and whitespace in a value would
+ * split the key=value pairs at parse time — making our own sentinel
+ * unparseable and silently defeating the role-conflation guard.
  */
 export function serializeSentinel(s: Sentinel): string {
   const pane = s.tmuxPane.startsWith('%') || s.tmuxPane === '' ? s.tmuxPane : `%${s.tmuxPane}`;
-  return `role=${s.role} tmux_pane=${pane} ppid=${s.ppid} created=${s.created} host=${s.host} user=${s.user}\n`;
+  const host = sanitizeFieldValue(s.host);
+  return `role=${s.role} tmux_pane=${pane} ppid=${s.ppid} created=${s.created} host=${host} user=${s.user}\n`;
+}
+
+/** Replace whitespace and `=` with `_` so a value never splits the field list. */
+function sanitizeFieldValue(v: string): string {
+  return v.replace(/[\s=]+/g, '_');
 }
 
 /**

--- a/crux/lib/agent-workspace/sentinel.ts
+++ b/crux/lib/agent-workspace/sentinel.ts
@@ -1,0 +1,274 @@
+/**
+ * Coordinator session sentinel — role-conflation guard.
+ *
+ * Two coordinator roles ("slots" and "releases") MUST live in separate
+ * Claude Code sessions. The sentinel is a /tmp file each startup skill
+ * writes; the other role's startup checks for a live sentinel from the
+ * SAME tmux pane / process to detect role conflation in one session.
+ *
+ * This module is pure: all environment access (fs, env, time, tmux) is
+ * injected via a SentinelEnv. Tests provide an in-memory env.
+ */
+
+export type Role = 'slots' | 'releases';
+
+export const SENTINEL_DIR = '/tmp';
+export const SENTINEL_PREFIX = 'lw-coord-sentinel';
+export const TTL_SECONDS = 86_400; // 24h — matches QUA-326 decision
+
+/** Parsed sentinel file contents (single key=value line). */
+export interface Sentinel {
+  role: Role;
+  /** tmux pane id with leading `%` (e.g. `%69`); empty string if non-tmux startup */
+  tmuxPane: string;
+  /** parent pid — used as fallback liveness signal when no tmux pane */
+  ppid: number;
+  /** unix epoch seconds */
+  created: number;
+  host: string;
+  /** numeric uid */
+  user: number;
+}
+
+export type ConflictKind = 'same-session' | 'other-session';
+
+export interface Conflict {
+  kind: ConflictKind;
+  path: string;
+  sentinel: Sentinel;
+  ageSeconds: number;
+}
+
+export interface SentinelCheckResult {
+  /** Path of OUR sentinel for this role (whether or not it exists). */
+  ourPath: string;
+  /** First conflict found, if any. */
+  conflict: Conflict | null;
+  /** Number of stale sentinels removed during this scan. */
+  cleaned: number;
+}
+
+export interface SentinelEnv {
+  now(): Date;
+  /** Return file contents or null if absent. */
+  readFile(path: string): string | null;
+  writeFile(path: string, content: string): void;
+  /** Touch (update mtime). Throws if file does not exist. */
+  touch(path: string): void;
+  /** Return mtime in unix-epoch-seconds, or null if file missing/unreadable. */
+  statMtime(path: string): number | null;
+  /** Delete a file. No-op if it does not exist. */
+  unlink(path: string): void;
+  /** List filenames in dir matching prefix (returns full paths). */
+  listMatching(dir: string, prefix: string): string[];
+  /**
+   * Return all live tmux pane ids (e.g. `["%1","%2","%69"]`).
+   * Returns `null` when not in tmux or tmux not available.
+   */
+  listTmuxPanes(): string[] | null;
+  /** Return true if process with this pid exists (kill -0). */
+  pidAlive(pid: number): boolean;
+  /** Process env — for $TMUX_PANE / $PPID / $TMUX detection at write time. */
+  env: NodeJS.ProcessEnv;
+  hostname(): string;
+  uid(): number;
+  /** Process pid (for fallback PPID when env.PPID missing). */
+  ppid(): number;
+}
+
+// ---------------------------------------------------------------------------
+// Path + key derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the per-session key used in the sentinel filename.
+ *
+ * Preference: `TMUX_PANE` minus its leading `%`. Falls back to `pid-<PPID>`
+ * for non-tmux startups. Stable across Bash subprocesses within one Claude
+ * session because Claude Code exports `TMUX_PANE` to all tools.
+ */
+export function deriveSessionKey(env: NodeJS.ProcessEnv, ppid: number): string {
+  const pane = env.TMUX_PANE;
+  if (pane && pane.length > 0) {
+    return pane.startsWith('%') ? pane.slice(1) : pane;
+  }
+  return `pid-${ppid}`;
+}
+
+export function sentinelPath(role: Role, sessionKey: string): string {
+  return `${SENTINEL_DIR}/${SENTINEL_PREFIX}-${role}-${sessionKey}`;
+}
+
+export function otherRole(role: Role): Role {
+  return role === 'slots' ? 'releases' : 'slots';
+}
+
+// ---------------------------------------------------------------------------
+// Serialize / parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a sentinel to its single-line key=value form.
+ *
+ * Format chosen to be human-readable in `cat`, parseable in bash, and
+ * resistant to corruption by intermediate `sed`/`grep` pipes.
+ */
+export function serializeSentinel(s: Sentinel): string {
+  const pane = s.tmuxPane.startsWith('%') || s.tmuxPane === '' ? s.tmuxPane : `%${s.tmuxPane}`;
+  return `role=${s.role} tmux_pane=${pane} ppid=${s.ppid} created=${s.created} host=${s.host} user=${s.user}\n`;
+}
+
+/**
+ * Parse a sentinel file. Returns null on any malformed input — we never
+ * fail-open on garbage; callers should treat unparseable as absent.
+ */
+export function parseSentinel(content: string): Sentinel | null {
+  const line = content.split('\n').find((l) => l.trim().length > 0);
+  if (!line) return null;
+  const fields: Record<string, string> = {};
+  for (const tok of line.trim().split(/\s+/)) {
+    const eq = tok.indexOf('=');
+    if (eq <= 0) return null;
+    fields[tok.slice(0, eq)] = tok.slice(eq + 1);
+  }
+  const role = fields.role;
+  if (role !== 'slots' && role !== 'releases') return null;
+  const ppid = Number(fields.ppid);
+  const created = Number(fields.created);
+  const user = Number(fields.user);
+  if (!Number.isFinite(ppid) || !Number.isFinite(created) || !Number.isFinite(user)) return null;
+  return {
+    role,
+    tmuxPane: fields.tmux_pane ?? '',
+    ppid,
+    created,
+    host: fields.host ?? '',
+    user,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Liveness
+// ---------------------------------------------------------------------------
+
+export interface LivenessResult {
+  live: boolean;
+  reason: 'fresh' | 'expired' | 'pane-gone' | 'pid-gone' | 'unparseable';
+  ageSeconds: number;
+}
+
+/**
+ * Decide whether a sentinel file represents a live coordinator session.
+ *
+ * Strategy:
+ * 1. Mtime > TTL → expired (laptop sleep tolerance: 24h, not 12h)
+ * 2. If `tmux_pane` set AND we have a live tmux pane list → pane must still exist
+ * 3. Else if `ppid` set → `kill -0 ppid` must succeed
+ * 4. Otherwise treat as live (fail-closed: when in doubt, do not delete)
+ *
+ * Unparseable sentinels are treated as live to avoid clobbering
+ * sentinels written by a future format we don't understand yet.
+ */
+export function isLive(
+  path: string,
+  parsed: Sentinel | null,
+  env: SentinelEnv,
+): LivenessResult {
+  const mtime = env.statMtime(path);
+  if (mtime == null) return { live: false, reason: 'expired', ageSeconds: Infinity };
+  const nowSec = Math.floor(env.now().getTime() / 1000);
+  const age = nowSec - mtime;
+  if (age > TTL_SECONDS) return { live: false, reason: 'expired', ageSeconds: age };
+  if (!parsed) return { live: true, reason: 'unparseable', ageSeconds: age };
+
+  if (parsed.tmuxPane) {
+    const panes = env.listTmuxPanes();
+    if (panes != null) {
+      if (!panes.includes(parsed.tmuxPane)) {
+        return { live: false, reason: 'pane-gone', ageSeconds: age };
+      }
+    }
+    // panes == null: tmux unavailable, can't disprove → fall through to live
+  } else if (parsed.ppid > 0) {
+    if (!env.pidAlive(parsed.ppid)) {
+      return { live: false, reason: 'pid-gone', ageSeconds: age };
+    }
+  }
+  return { live: true, reason: 'fresh', ageSeconds: age };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level operations: write, check, touch
+// ---------------------------------------------------------------------------
+
+export function buildOurSentinel(role: Role, env: SentinelEnv): { path: string; sentinel: Sentinel } {
+  const ppid = Number(env.env.PPID ?? env.ppid());
+  const sessionKey = deriveSessionKey(env.env, ppid);
+  const pane = env.env.TMUX_PANE ?? '';
+  const sentinel: Sentinel = {
+    role,
+    tmuxPane: pane,
+    ppid: Number.isFinite(ppid) ? ppid : 0,
+    created: Math.floor(env.now().getTime() / 1000),
+    host: env.hostname(),
+    user: env.uid(),
+  };
+  return { path: sentinelPath(role, sessionKey), sentinel };
+}
+
+export function writeSentinel(role: Role, env: SentinelEnv): { path: string; sentinel: Sentinel } {
+  const { path, sentinel } = buildOurSentinel(role, env);
+  env.writeFile(path, serializeSentinel(sentinel));
+  return { path, sentinel };
+}
+
+export function touchSentinel(role: Role, env: SentinelEnv): { path: string; touched: boolean } {
+  const ppid = Number(env.env.PPID ?? env.ppid());
+  const sessionKey = deriveSessionKey(env.env, ppid);
+  const path = sentinelPath(role, sessionKey);
+  if (env.statMtime(path) == null) return { path, touched: false };
+  env.touch(path);
+  return { path, touched: true };
+}
+
+/**
+ * Scan for conflicting sentinels from the OTHER role.
+ *
+ * Returns the first live conflict found, classified by whether it shares
+ * our session key (same-session = role conflation, the blocker) or comes
+ * from a different session (cross-session = expected, informational).
+ *
+ * Stale sentinels of the other role are removed opportunistically.
+ */
+export function checkConflict(role: Role, env: SentinelEnv): SentinelCheckResult {
+  const ppid = Number(env.env.PPID ?? env.ppid());
+  const ourKey = deriveSessionKey(env.env, ppid);
+  const ourPath = sentinelPath(role, ourKey);
+  const other = otherRole(role);
+  const otherPrefix = `${SENTINEL_PREFIX}-${other}-`;
+  const candidates = env.listMatching(SENTINEL_DIR, otherPrefix);
+
+  let conflict: Conflict | null = null;
+  let cleaned = 0;
+
+  for (const path of candidates) {
+    const content = env.readFile(path);
+    const parsed = content == null ? null : parseSentinel(content);
+    const liveness = isLive(path, parsed, env);
+    if (!liveness.live) {
+      env.unlink(path);
+      cleaned += 1;
+      continue;
+    }
+    if (conflict != null || parsed == null) continue;
+    // Determine session match: prefer pane id, fall back to ppid match
+    const sentinelKey =
+      parsed.tmuxPane && parsed.tmuxPane.startsWith('%')
+        ? parsed.tmuxPane.slice(1)
+        : parsed.tmuxPane || `pid-${parsed.ppid}`;
+    const kind: ConflictKind = sentinelKey === ourKey ? 'same-session' : 'other-session';
+    conflict = { kind, path, sentinel: parsed, ageSeconds: liveness.ageSeconds };
+  }
+
+  return { ourPath, conflict, cleaned };
+}

--- a/crux/lib/agent-workspace/tmux.ts
+++ b/crux/lib/agent-workspace/tmux.ts
@@ -1,0 +1,208 @@
+/**
+ * Tmux helpers for the coordinator role lifecycle.
+ *
+ * - Version probe (some features need tmux ≥ 3.0)
+ * - Window claim: rename to role name + set @lw-coord-role marker so the
+ *   periodic rename loop knows not to clobber it
+ * - Marker query: bulk-read @lw-coord-role across all windows in one call
+ *
+ * Pure: all shell access goes through an injected `TmuxExec` so tests
+ * never have to fork a real tmux.
+ */
+
+export type Role = 'slots' | 'releases';
+
+export const ROLE_MARKER = '@lw-coord-role';
+
+export interface TmuxExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+export interface TmuxExec {
+  /** Returns the value of TMUX env var, or null if not in a tmux session. */
+  inTmux(): string | null;
+  /**
+   * Run `tmux <args>`. Implementations should NOT throw on non-zero exit;
+   * return the result with code/stderr so callers can branch.
+   */
+  run(args: string[]): TmuxExecResult;
+}
+
+// ---------------------------------------------------------------------------
+// Version probe
+// ---------------------------------------------------------------------------
+
+export interface TmuxVersion {
+  raw: string;
+  major: number;
+  minor: number;
+  /** True when version ≥ 3.0 (required for `#{@user-option}` format strings). */
+  supportsUserOptionFormat: boolean;
+}
+
+/**
+ * Parse `tmux -V` output. Handles common forms:
+ *   "tmux 3.3a"
+ *   "tmux 3.4"
+ *   "tmux 2.9a"
+ *   "tmux next-3.5"
+ *   "tmux master"  (returns 0.0)
+ */
+export function parseTmuxVersion(raw: string): TmuxVersion {
+  const trimmed = raw.trim();
+  const m = trimmed.match(/(\d+)\.(\d+)/);
+  if (!m) {
+    return { raw: trimmed, major: 0, minor: 0, supportsUserOptionFormat: false };
+  }
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  return {
+    raw: trimmed,
+    major,
+    minor,
+    supportsUserOptionFormat: major > 3 || (major === 3 && minor >= 0),
+  };
+}
+
+export function probeTmuxVersion(exec: TmuxExec): TmuxVersion | null {
+  if (exec.inTmux() == null) return null;
+  const r = exec.run(['-V']);
+  if (r.code !== 0) return null;
+  return parseTmuxVersion(r.stdout);
+}
+
+// ---------------------------------------------------------------------------
+// Window listing + marker query
+// ---------------------------------------------------------------------------
+
+export interface TmuxWindowMarker {
+  windowId: string; // e.g. "@7"
+  index: string;    // e.g. "3"
+  name: string;
+  role: Role | null; // null if unmarked
+}
+
+/**
+ * Bulk-query all windows across all sessions, returning each window's
+ * id/index/name and `@lw-coord-role` marker (or null).
+ *
+ * Requires tmux ≥ 3.0 for `#{@user-option}` substitution. On older tmux
+ * (or when version probe fails) returns marker=null for every window —
+ * caller should treat that as "no markers", which means the rename loop
+ * will fall back to its current behavior (rename everything).
+ */
+export function listWindowsWithMarkers(
+  exec: TmuxExec,
+  version: TmuxVersion | null,
+): TmuxWindowMarker[] {
+  const useMarker = version?.supportsUserOptionFormat ?? false;
+  const fmt = useMarker
+    ? `#{window_id}\t#{window_index}\t#{window_name}\t#{${ROLE_MARKER}}`
+    : `#{window_id}\t#{window_index}\t#{window_name}`;
+  const r = exec.run(['list-windows', '-a', '-F', fmt]);
+  if (r.code !== 0) return [];
+  const out: TmuxWindowMarker[] = [];
+  for (const line of r.stdout.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    const role = useMarker ? normalizeRole(parts[3] ?? '') : null;
+    out.push({
+      windowId: parts[0],
+      index: parts[1],
+      name: parts[2],
+      role,
+    });
+  }
+  return out;
+}
+
+function normalizeRole(s: string): Role | null {
+  const v = s.trim();
+  if (v === 'slots' || v === 'releases') return v;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Window claim
+// ---------------------------------------------------------------------------
+
+export interface ClaimResult {
+  status: 'claimed' | 'skipped-no-tmux' | 'skipped-no-current' | 'error';
+  finalName?: string;
+  marker?: Role;
+  detail?: string;
+  /** If the version probe says markers are unsupported, this is set. */
+  markerUnsupported?: boolean;
+}
+
+/**
+ * Claim the current tmux window for `role`.
+ *
+ * Steps (order matters for race-safety):
+ *   1. Probe tmux version.
+ *   2. List existing window names; pick `<role>` or `<role>-N` to avoid collision.
+ *   3. SET the marker FIRST so the rename loop (which reads the marker
+ *      before deciding whether to rename) never sees the window without it.
+ *   4. Rename the window.
+ *
+ * Idempotent: re-running with the same role on a marked window finds the
+ * existing name in step 2 and may pick a different suffix; callers should
+ * tolerate this (it's still our window, just renumbered).
+ */
+export function claimWindow(role: Role, exec: TmuxExec): ClaimResult {
+  if (exec.inTmux() == null) {
+    return { status: 'skipped-no-tmux', detail: 'TMUX env var not set' };
+  }
+  const version = probeTmuxVersion(exec);
+  const markerUnsupported = version != null && !version.supportsUserOptionFormat;
+
+  // Find current window id (so we know which one to operate on)
+  const cur = exec.run(['display-message', '-p', '#{window_id}']);
+  if (cur.code !== 0 || !cur.stdout.trim()) {
+    return { status: 'skipped-no-current', detail: 'tmux display-message failed' };
+  }
+  const currentId = cur.stdout.trim();
+
+  // Existing windows (current session only — names are session-scoped for select-window)
+  const list = exec.run(['list-windows', '-F', '#{window_name}']);
+  const existing = new Set(
+    list.code === 0
+      ? list.stdout.split('\n').map((s) => s.trim()).filter(Boolean)
+      : [],
+  );
+
+  let finalName = role as string;
+  if (existing.has(finalName)) {
+    let n = 2;
+    while (existing.has(`${role}-${n}`)) n += 1;
+    finalName = `${role}-${n}`;
+  }
+
+  // 1. Set marker BEFORE rename (race fix from QUA-326 red team)
+  if (!markerUnsupported) {
+    const set = exec.run(['set-option', '-w', '-t', currentId, ROLE_MARKER, role]);
+    if (set.code !== 0) {
+      return {
+        status: 'error',
+        detail: `set-option ${ROLE_MARKER} failed: ${set.stderr}`,
+        markerUnsupported,
+      };
+    }
+  }
+
+  // 2. Rename
+  const ren = exec.run(['rename-window', '-t', currentId, finalName]);
+  if (ren.code !== 0) {
+    return { status: 'error', detail: `rename-window failed: ${ren.stderr}`, markerUnsupported };
+  }
+
+  return {
+    status: 'claimed',
+    finalName,
+    marker: markerUnsupported ? undefined : role,
+    markerUnsupported,
+  };
+}

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -114,7 +114,6 @@ export const GROUPS: Record<string, GroupDef> = {
     domains: [
       'agents',
       'agent-checklist',
-      'agent-workspace',
       'agent-session-events',
       'jobs',
       'sessions',
@@ -135,6 +134,12 @@ export const GROUPS: Record<string, GroupDef> = {
     description: 'Linear — issues, workflow states, agent session tracking',
     domains: ['linear'],
     flattened: ['linear'],
+  },
+  ws: {
+    shortcut: 'ws',
+    description: 'Workspace — agent slots, sentinels, tmux, doctors (lw/ root)',
+    domains: ['agent-workspace'],
+    flattened: ['agent-workspace'],
   },
 };
 


### PR DESCRIPTION
## Summary

Adds the TypeScript primitives that QUA-339's renamed startup skills will call, replacing the ~700 lines of bash that shipped inside skill markdown in QUA-334. This is **PR 1 of 4** in the QUA-339 series; PR 2-4 live in the lw repo.

### New `crux ws` subcommands

- `ws sentinel-write / check / touch --role=slots|releases` — role-conflation guard with 24h TTL, tmux pane + ppid liveness, and opportunistic stale cleanup
- `ws tmux-claim --role=slots|releases` — rename window, set `@lw-coord-role` marker (tmux ≥3.0) with proper ordering so the rename loop never sees the window un-marked
- `ws doctor slots` — all 11 read-only slots checks per the QUA-326 spec
- `ws doctor releases` — all 12 read-only releases checks per the QUA-326 spec
- All support `--json` so skills can branch without stdout grepping
- New top-level `ws` group in `crux/lib/groups.ts`; legacy `crux agent-workspace …` still works

### Modified `renameTmuxWindows()`

Bulk-queries `@lw-coord-role` via `tmux list-windows -F '#{@user-option}'` and **skips windows with the marker set**, so startup skills can claim a window without the rename loop clobbering it 5 min later. Graceful fallback on tmux <3.0.

### Helper architecture

All logic lives in pure helper modules under `crux/lib/agent-workspace/` with dependency-injected envs (`SentinelEnv`, `TmuxExec`, `DoctorEnv`) so every primitive has unit tests. 143 tests across 6 files, all passing. Real-env adapters for production are in `crux/commands/agent-workspace.ts` and `crux/lib/agent-workspace/doctor/env.ts`.

### Review findings (all fixed in commit 2)

`/agent-review-pr` hostile reviewer caught 6 real bugs:

1. **Sentinel parser broken on hostnames with whitespace** (HIGH) — macOS names like `"Ozzie's MacBook"` made our own sentinel unparseable, silently disabling the role-conflation guard. Fix: sanitize host via `/[\s=]+/`.
2. **`checkProdEdge` called wrong URL + wrong status field** — hit `longtermwiki.com/api/health` (non-existent, returns the SPA 404) and expected `status=ok`. Real endpoint is `wiki-server.k8s.quantifieduncertainty.org/health` returning `"healthy"`. Verified against live prod.
3. **`checkDeployTasks` used `--json` flag that doesn't exist** — parsed text output instead (ANSI-strip + count `☐`/`[ ]` markers).
4. **`TMUX_PANE` path-traversal via `deriveSessionKey`** — hostile `%../../etc/passwd` would steer writes. Now strip non-`[A-Za-z0-9_-]`.
5. **`checkOpsState` printed negative "last pull -3m ago"** on clock skew. Clamped.
6. **Doctor runner reported "all ok" when every check was skipped** (fresh CI box missing gh/kubectl/etc). Now escalates to warn when zero checks produced an ok/warn/fail result.

13 regression tests added for the fixes.

### What's NOT in PR 1 (deferred, by design)

- `ws list --json` (PR 2)
- Filesystem rename `coord/` → `releases/` (PR 3, lw repo)
- New `/agent-*-start` / `/agent-*-doctor` / `/agent-init` skill files (PR 4, lw repo)

## Test plan

- [x] `npx vitest run crux/lib/agent-workspace` — 143/143 passing
- [x] `pnpm test` — 5989 passing, 0 new failures
- [x] `pnpm build` — exit 0
- [x] `pnpm crux w validate gate --fix` — all 41 gate checks passing
- [x] Crux typecheck clean on new files (unrelated baseline advisory warnings ignored)
- [x] Smoke-tested CLI end-to-end: `ws sentinel-write/check/touch`, `ws tmux-claim`, `ws doctor slots`, `ws doctor releases`
- [x] `ws sentinel-check --role=releases` correctly fired same-session conflict banner (exit code 2) after writing a `slots` sentinel in the same session
- [x] `ws doctor releases` run against real prod returns `prod-edge ✓ 200 status=healthy`
- [x] Hostile review via `/agent-review-pr` subagent, 6 real findings all fixed with regression tests
- [x] Adversarial input tests: hostile `TMUX_PANE`, hostnames with spaces/`=`, stale/unparseable/pane-gone/pid-gone sentinels, clock skew, empty kubectl output, missing gh/pgrep/lsof
- [ ] Post-merge: verify no rename-loop clobbering after lw-repo PRs land marker-setting startup skills

Fixes QUA-339
