### PR TITLE
fix(research-areas): tighten Zod schemas to match CHECK enum constraints

### DIFF
--- a/apps/wiki-server/src/__tests__/research-areas-enum-validation.test.ts
+++ b/apps/wiki-server/src/__tests__/research-areas-enum-validation.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- Dispatcher ----
+//
+// All tests in this file exercise Zod schema rejection, which happens
+// BEFORE any SQL is dispatched. A no-op dispatcher is sufficient.
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validateEntityRefs runs: SELECT ... FROM entities WHERE id = ANY(...)
+  // (via unnest). Return every requested id as "present" so the accept-path
+  // tests get past validation.
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return (params as unknown[]).map((p) => ({ ref: p }));
+  }
+
+  // Everything else (inserts, upserts) — no-op.
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+describe("Research areas — CHECK constraint enum enforcement (QUA-283)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  // ---- SyncOrgLinkSchema.role ----
+
+  describe("POST /api/research-areas/sync-organizations", () => {
+    it("rejects role values outside the CHECK enum with 400", async () => {
+      // 'partially-addresses' is NOT in the CHECK list
+      // ('pioneer', 'active', 'major', 'funder', 'emerging').
+      // Pre-fix this passed Zod and exploded at the DB with a 500.
+      const res = await postJson(app, "/api/research-areas/sync-organizations", {
+        items: [
+          {
+            researchAreaId: "mech-interp",
+            organizationId: "org-test",
+            role: "partially-addresses",
+          },
+        ],
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("validation_error");
+      // Zod enum rejection messages include allowed values; just confirm
+      // one of them is cited so future drift in the message format doesn't
+      // silently pass this test.
+      expect(body.message).toMatch(/pioneer|active|major|funder|emerging/);
+    });
+
+    it("accepts every valid role value at the schema level", async () => {
+      // The DB dispatcher is a no-op, so a successful run through Zod +
+      // entity-ref + insert returns 200. If any of these role values got
+      // rejected by the new z.enum this test would fail with 400.
+      for (const role of ["pioneer", "active", "major", "funder", "emerging"]) {
+        const res = await postJson(
+          app,
+          "/api/research-areas/sync-organizations",
+          {
+            items: [
+              {
+                researchAreaId: "mech-interp",
+                organizationId: "org-test",
+                role,
+              },
+            ],
+          },
+        );
+        expect(res.status, `role=${role}`).toBe(200);
+      }
+    });
+  });
+
+  // ---- SyncRiskLinkSchema.relevance ----
+
+  describe("POST /api/research-areas/sync-risks — relevance", () => {
+    it("rejects relevance values outside the CHECK enum with 400", async () => {
+      const res = await postJson(app, "/api/research-areas/sync-risks", {
+        items: [
+          {
+            researchAreaId: "mech-interp",
+            riskId: "misalignment",
+            relevance: "partially-addresses",
+          },
+        ],
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("validation_error");
+      expect(body.message).toMatch(/addresses|studies|exacerbates/);
+    });
+
+    it("accepts every valid relevance value", async () => {
+      for (const relevance of ["addresses", "studies", "exacerbates"]) {
+        const res = await postJson(app, "/api/research-areas/sync-risks", {
+          items: [
+            {
+              researchAreaId: "mech-interp",
+              riskId: "misalignment",
+              relevance,
+            },
+          ],
+        });
+        expect(res.status, `relevance=${relevance}`).toBe(200);
+      }
+    });
+  });
+
+  // ---- SyncRiskLinkSchema.effectiveness ----
+
+  describe("POST /api/research-areas/sync-risks — effectiveness", () => {
+    it("rejects effectiveness values outside the CHECK enum with 400", async () => {
+      const res = await postJson(app, "/api/research-areas/sync-risks", {
+        items: [
+          {
+            researchAreaId: "mech-interp",
+            riskId: "misalignment",
+            effectiveness: "stellar",
+          },
+        ],
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("validation_error");
+      expect(body.message).toMatch(/high|moderate|low|uncertain/);
+    });
+
+    it("accepts null effectiveness (nullable optional)", async () => {
+      const res = await postJson(app, "/api/research-areas/sync-risks", {
+        items: [
+          {
+            researchAreaId: "mech-interp",
+            riskId: "misalignment",
+            effectiveness: null,
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts every valid effectiveness value", async () => {
+      for (const effectiveness of ["high", "moderate", "low", "uncertain"]) {
+        const res = await postJson(app, "/api/research-areas/sync-risks", {
+          items: [
+            {
+              researchAreaId: "mech-interp",
+              riskId: "misalignment",
+              effectiveness,
+            },
+          ],
+        });
+        expect(res.status, `effectiveness=${effectiveness}`).toBe(200);
+      }
+    });
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -41,6 +41,24 @@ const VALID_STATUSES = [
   "archived",
 ] as const;
 
+// CHECK constraints — must match apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql
+const VALID_ORG_ROLES = [
+  "pioneer",
+  "active",
+  "major",
+  "funder",
+  "emerging",
+] as const;
+
+const VALID_RISK_RELEVANCE = ["addresses", "studies", "exacerbates"] as const;
+
+const VALID_RISK_EFFECTIVENESS = [
+  "high",
+  "moderate",
+  "low",
+  "uncertain",
+] as const;
+
 // ---- Query schemas ----
 
 const AllQuery = z.object({
@@ -73,7 +91,7 @@ const SyncOrgLinkSchema = z.object({
     z.object({
       researchAreaId: z.string().min(1).max(200),
       organizationId: z.string().min(1).max(200),
-      role: z.string().max(50).optional().default("active"),
+      role: z.enum(VALID_ORG_ROLES).optional().default("active"),
       notes: z.string().max(2000).nullable().optional(),
     })
   ).min(1).max(500),
@@ -111,8 +129,8 @@ const SyncRiskLinkSchema = z.object({
     z.object({
       researchAreaId: z.string().min(1).max(200),
       riskId: z.string().min(1).max(200),
-      relevance: z.string().max(50).optional().default("addresses"),
-      effectiveness: z.string().max(50).nullable().optional(),
+      relevance: z.enum(VALID_RISK_RELEVANCE).optional().default("addresses"),
+      effectiveness: z.enum(VALID_RISK_EFFECTIVENESS).nullable().optional(),
       notes: z.string().max(2000).nullable().optional(),
     })
   ).min(1).max(500),


### PR DESCRIPTION
## Summary

- `SyncOrgLinkSchema.role` → `z.enum(['pioneer','active','major','funder','emerging'])`
- `SyncRiskLinkSchema.relevance` → `z.enum(['addresses','studies','exacerbates'])`
- `SyncRiskLinkSchema.effectiveness` → `z.enum(['high','moderate','low','uncertain']).nullable().optional()`
- New unit test (`research-areas-enum-validation.test.ts`, 7 cases) confirms Zod now rejects freeform values with a 400 and still accepts every valid enum member (plus `null` for nullable effectiveness).

## Why

PR #4160 / QUA-156 added CHECK constraints to `research_area_organizations.role`, `research_area_risks.relevance`, and `research_area_risks.effectiveness`, but the three Zod schemas in `research-areas.ts` stayed `z.string().max(50)`. Freeform values (e.g., `relevance: "partially-addresses"`) passed Zod and then failed at the DB with a CHECK violation, surfacing as a 500 instead of a clean 400.

Enum values are pulled directly from `apps/wiki-server/drizzle/0173_add_check_constraints_phase2.sql` (the source of truth), with a comment in the code linking back to that file.

## Verification

- `pnpm exec tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- `pnpm exec vitest run apps/wiki-server/src/__tests__/` — 1023 passed, 21 skipped (including 7 new cases)
- Reviewed all crux callers (`crux/commands/research-areas.ts`): they pass only `"funder"` and `"active"`, both in the new enum → no migration risk
- Audited every other `z.string().max(...)` field in `research-areas.ts` against migration CHECK lists — the other two constrained enum columns (`research_areas.status`, `research_area_evaluations.evaluator_type`) are already using `z.enum(...)`; nothing else needs tightening in this file

## Follow-up

A generic `validate-zod-check-parity.ts` gate validator (parses migration CHECK constraints and asserts matching `z.enum` in the route's Zod schema) would catch this entire class of drift mechanically. Out of scope for this PR — tracking separately.

Fixes QUA-283.

## Test plan
- [x] `pnpm exec tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] New unit test: POST with `relevance: "partially-addresses"` returns 400 with allowed-values in the error message
- [x] Full wiki-server vitest suite — no regressions
