### PR TITLE
refactor: rename apps/web formatValue to formatNumberWithUnit

### DIFF
--- a/apps/web/src/components/wiki/factbase/FBFactValue.tsx
+++ b/apps/web/src/components/wiki/factbase/FBFactValue.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { getKBFacts, getKBLatest, getKBProperty, getKBFactSourcing } from "@data/factbase";
 import type { Fact } from "@longterm-wiki/factbase";
 import { CURRENCIES, resolveCurrency } from "@longterm-wiki/factbase/currencies";
-import { formatValue } from "@lib/format-value";
+import { formatNumberWithUnit } from "@lib/format-value";
 import { formatKBFactValue, formatKBDate, isUrl } from "./format";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { factbaseVerdictToStatus } from "@/components/sourcing/sourcing-status";
@@ -108,7 +108,7 @@ export function FBFactValue({
           <span className="block text-muted-foreground">
             Currency: {CURRENCIES[currencyCode].name} ({currencyCode})
             {fact.usdEquivalent != null && (
-              <> (~{formatValue(fact.usdEquivalent, "USD")})</>
+              <> (~{formatNumberWithUnit(fact.usdEquivalent, "USD")})</>
             )}
           </span>
         )}

--- a/apps/web/src/components/wiki/factbase/format.ts
+++ b/apps/web/src/components/wiki/factbase/format.ts
@@ -1,11 +1,11 @@
 /**
  * Shared formatting utilities for KB rendering components.
  *
- * Uses the smart `formatValue` from format-value.ts for numbers with known
+ * Uses `formatNumberWithUnit` from format-value.ts for numbers with known
  * units, and falls back to PropertyDisplay (divisor/prefix/suffix) otherwise.
  */
 
-import { formatValue as smartFormatValue } from "@lib/format-value";
+import { formatNumberWithUnit as smartFormatValue } from "@lib/format-value";
 import { CURRENCIES } from "@longterm-wiki/factbase/currencies";
 import type { Fact, FieldDef, PropertyDisplay } from "@longterm-wiki/factbase";
 import type { FactBaseRecordEntry } from "@data/factbase";

--- a/apps/web/src/lib/__tests__/format-value.test.ts
+++ b/apps/web/src/lib/__tests__/format-value.test.ts
@@ -2,219 +2,219 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatStructuredValue,
-  formatValue,
+  formatNumberWithUnit,
   formatValueRange,
 } from "../format-value";
 
-describe("formatValue", () => {
+describe("formatNumberWithUnit", () => {
   describe("USD (prefix currency)", () => {
     it("formats sub-million values with $ prefix", () => {
-      expect(formatValue(500, "USD")).toBe("$500");
+      expect(formatNumberWithUnit(500, "USD")).toBe("$500");
     });
 
     it("formats thousands with comma separator", () => {
-      expect(formatValue(1500, "USD")).toBe("$1,500");
+      expect(formatNumberWithUnit(1500, "USD")).toBe("$1,500");
     });
 
     it("formats millions", () => {
-      expect(formatValue(2.5e6, "USD")).toBe("$2.5 million");
+      expect(formatNumberWithUnit(2.5e6, "USD")).toBe("$2.5 million");
     });
 
     it("formats billions", () => {
-      expect(formatValue(30e9, "USD")).toBe("$30 billion");
+      expect(formatNumberWithUnit(30e9, "USD")).toBe("$30 billion");
     });
 
     it("formats trillions", () => {
-      expect(formatValue(1.5e12, "USD")).toBe("$1.5 trillion");
+      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5 trillion");
     });
 
     it("formats zero", () => {
-      expect(formatValue(0, "USD")).toBe("$0");
+      expect(formatNumberWithUnit(0, "USD")).toBe("$0");
     });
 
     it("cleans trailing .0 from round numbers", () => {
-      expect(formatValue(380e9, "USD")).toBe("$380 billion");
-      expect(formatValue(100e6, "USD")).toBe("$100 million");
-      expect(formatValue(1e12, "USD")).toBe("$1 trillion");
+      expect(formatNumberWithUnit(380e9, "USD")).toBe("$380 billion");
+      expect(formatNumberWithUnit(100e6, "USD")).toBe("$100 million");
+      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1 trillion");
     });
 
     it("preserves meaningful decimals", () => {
-      expect(formatValue(2.5e9, "USD")).toBe("$2.5 billion");
-      expect(formatValue(1.5e12, "USD")).toBe("$1.5 trillion");
-      expect(formatValue(3.7e6, "USD")).toBe("$3.7 million");
+      expect(formatNumberWithUnit(2.5e9, "USD")).toBe("$2.5 billion");
+      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5 trillion");
+      expect(formatNumberWithUnit(3.7e6, "USD")).toBe("$3.7 million");
     });
   });
 
   describe("negative values with prefix currency", () => {
     it("places negative sign before the currency symbol", () => {
-      expect(formatValue(-850e6, "USD")).toBe("-$850 million");
+      expect(formatNumberWithUnit(-850e6, "USD")).toBe("-$850 million");
     });
 
     it("handles negative billions", () => {
-      expect(formatValue(-30e9, "USD")).toBe("-$30 billion");
+      expect(formatNumberWithUnit(-30e9, "USD")).toBe("-$30 billion");
     });
 
     it("handles negative trillions", () => {
-      expect(formatValue(-1.5e12, "USD")).toBe("-$1.5 trillion");
+      expect(formatNumberWithUnit(-1.5e12, "USD")).toBe("-$1.5 trillion");
     });
 
     it("handles negative sub-million values", () => {
-      expect(formatValue(-500, "USD")).toBe("-$500");
+      expect(formatNumberWithUnit(-500, "USD")).toBe("-$500");
     });
   });
 
   describe("boundary values at magnitude thresholds", () => {
     it("formats exactly 1e6 as million", () => {
-      expect(formatValue(1e6, "USD")).toBe("$1 million");
+      expect(formatNumberWithUnit(1e6, "USD")).toBe("$1 million");
     });
 
     it("formats exactly 1e9 as billion", () => {
-      expect(formatValue(1e9, "USD")).toBe("$1 billion");
+      expect(formatNumberWithUnit(1e9, "USD")).toBe("$1 billion");
     });
 
     it("formats exactly 1e12 as trillion", () => {
-      expect(formatValue(1e12, "USD")).toBe("$1 trillion");
+      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1 trillion");
     });
 
     it("formats just below 1e6 as a plain number", () => {
-      expect(formatValue(999999, "USD")).toBe("$999,999");
+      expect(formatNumberWithUnit(999999, "USD")).toBe("$999,999");
     });
   });
 
   describe("suffix currencies (SEK, NOK)", () => {
     it("formats SEK with suffix kr", () => {
-      expect(formatValue(100e6, "SEK")).toBe("100 million kr");
+      expect(formatNumberWithUnit(100e6, "SEK")).toBe("100 million kr");
     });
 
     it("formats SEK billions with suffix kr", () => {
-      expect(formatValue(5e9, "SEK")).toBe("5 billion kr");
+      expect(formatNumberWithUnit(5e9, "SEK")).toBe("5 billion kr");
     });
 
     it("formats SEK trillions with suffix kr", () => {
-      expect(formatValue(2e12, "SEK")).toBe("2 trillion kr");
+      expect(formatNumberWithUnit(2e12, "SEK")).toBe("2 trillion kr");
     });
 
     it("formats NOK sub-million with suffix kr", () => {
-      expect(formatValue(5000, "NOK")).toBe("5,000 kr");
+      expect(formatNumberWithUnit(5000, "NOK")).toBe("5,000 kr");
     });
 
     it("places negative sign correctly for suffix currencies", () => {
-      expect(formatValue(-100e6, "SEK")).toBe("-100 million kr");
+      expect(formatNumberWithUnit(-100e6, "SEK")).toBe("-100 million kr");
     });
   });
 
   describe("other prefix currencies", () => {
     it("formats GBP with pound sign", () => {
-      expect(formatValue(100e6, "GBP")).toBe("\u00A3100 million");
+      expect(formatNumberWithUnit(100e6, "GBP")).toBe("\u00A3100 million");
     });
 
     it("formats EUR with euro sign", () => {
-      expect(formatValue(50e9, "EUR")).toBe("\u20AC50 billion");
+      expect(formatNumberWithUnit(50e9, "EUR")).toBe("\u20AC50 billion");
     });
 
     it("formats JPY with yen sign", () => {
-      expect(formatValue(1e12, "JPY")).toBe("\u00A51 trillion");
+      expect(formatNumberWithUnit(1e12, "JPY")).toBe("\u00A51 trillion");
     });
 
     it("formats CAD with C$ prefix", () => {
-      expect(formatValue(200e6, "CAD")).toBe("C$200 million");
+      expect(formatNumberWithUnit(200e6, "CAD")).toBe("C$200 million");
     });
   });
 
   describe("percent unit", () => {
     it("formats whole numbers", () => {
-      expect(formatValue(40, "percent")).toBe("40%");
+      expect(formatNumberWithUnit(40, "percent")).toBe("40%");
     });
 
     it("formats decimal percentages", () => {
-      expect(formatValue(99.9, "percent")).toBe("99.9%");
+      expect(formatNumberWithUnit(99.9, "percent")).toBe("99.9%");
     });
 
     it("formats 100%", () => {
-      expect(formatValue(100, "percent")).toBe("100%");
+      expect(formatNumberWithUnit(100, "percent")).toBe("100%");
     });
 
     it("formats 0%", () => {
-      expect(formatValue(0, "percent")).toBe("0%");
+      expect(formatNumberWithUnit(0, "percent")).toBe("0%");
     });
   });
 
   describe("count and tokens units", () => {
     it("formats count with comma separator", () => {
-      expect(formatValue(1500, "count")).toBe("1,500");
+      expect(formatNumberWithUnit(1500, "count")).toBe("1,500");
     });
 
     it("formats count millions", () => {
-      expect(formatValue(2.5e6, "count")).toBe("2.5 million");
+      expect(formatNumberWithUnit(2.5e6, "count")).toBe("2.5 million");
     });
 
     it("formats count billions", () => {
-      expect(formatValue(2.5e9, "count")).toBe("2.5 billion");
+      expect(formatNumberWithUnit(2.5e9, "count")).toBe("2.5 billion");
     });
 
     it("formats count trillions", () => {
-      expect(formatValue(1e12, "count")).toBe("1 trillion");
+      expect(formatNumberWithUnit(1e12, "count")).toBe("1 trillion");
     });
 
     it("formats tokens the same as count", () => {
-      expect(formatValue(200000, "tokens")).toBe("200,000");
-      expect(formatValue(1e9, "tokens")).toBe("1 billion");
+      expect(formatNumberWithUnit(200000, "tokens")).toBe("200,000");
+      expect(formatNumberWithUnit(1e9, "tokens")).toBe("1 billion");
     });
   });
 
   describe("currency override parameter", () => {
     it("overrides unit currency with explicit currency", () => {
-      expect(formatValue(100e6, "USD", "GBP")).toBe("\u00A3100 million");
+      expect(formatNumberWithUnit(100e6, "USD", "GBP")).toBe("\u00A3100 million");
     });
 
     it("does not apply currency override when unit is percent", () => {
-      expect(formatValue(40, "percent", "GBP")).toBe("40%");
+      expect(formatNumberWithUnit(40, "percent", "GBP")).toBe("40%");
     });
 
     it("does not apply currency override when unit is count", () => {
-      expect(formatValue(1500, "count", "GBP")).toBe("1,500");
+      expect(formatNumberWithUnit(1500, "count", "GBP")).toBe("1,500");
     });
 
     it("applies currency override when unit is also a currency", () => {
-      expect(formatValue(50e6, "USD", "EUR")).toBe("\u20AC50 million");
+      expect(formatNumberWithUnit(50e6, "USD", "EUR")).toBe("\u20AC50 million");
     });
   });
 
   describe("fallback (no unit or unknown unit)", () => {
     it("formats with no unit", () => {
-      expect(formatValue(1500)).toBe("1,500");
+      expect(formatNumberWithUnit(1500)).toBe("1,500");
     });
 
     it("formats millions with no unit", () => {
-      expect(formatValue(5e6)).toBe("5 million");
+      expect(formatNumberWithUnit(5e6)).toBe("5 million");
     });
 
     it("formats billions with no unit", () => {
-      expect(formatValue(3e9)).toBe("3 billion");
+      expect(formatNumberWithUnit(3e9)).toBe("3 billion");
     });
 
     it("formats trillions with no unit", () => {
-      expect(formatValue(2e12)).toBe("2 trillion");
+      expect(formatNumberWithUnit(2e12)).toBe("2 trillion");
     });
 
     it("handles null unit", () => {
-      expect(formatValue(1000, null)).toBe("1,000");
+      expect(formatNumberWithUnit(1000, null)).toBe("1,000");
     });
 
     it("handles undefined unit", () => {
-      expect(formatValue(1000, undefined)).toBe("1,000");
+      expect(formatNumberWithUnit(1000, undefined)).toBe("1,000");
     });
 
     it("uses scientific notation for very large numbers (>= 1e15)", () => {
-      expect(formatValue(1e26, "FLOP")).toBe("10^26");
+      expect(formatNumberWithUnit(1e26, "FLOP")).toBe("10^26");
     });
 
     it("includes mantissa when not exactly 1", () => {
-      expect(formatValue(2.5e20)).toBe("2.5 × 10^20");
+      expect(formatNumberWithUnit(2.5e20)).toBe("2.5 × 10^20");
     });
 
     it("omits mantissa when approximately 1", () => {
-      expect(formatValue(1e18)).toBe("10^18");
+      expect(formatNumberWithUnit(1e18)).toBe("10^18");
     });
   });
 });

--- a/apps/web/src/lib/format-value.ts
+++ b/apps/web/src/lib/format-value.ts
@@ -1,5 +1,7 @@
 /**
- * Shared value formatting for structured data display.
+ * Unit-tagged number formatting (hardcoded million/billion/trillion thresholds
+ * and CURRENCIES lookup). Prefer `formatValue` from `@longterm-wiki/factbase/format`
+ * when a Property definition is available -- it's property.display-driven.
  *
  * Ported from build-data.mjs formatFactNumber/formatFactRange and extended
  * for use by both the facts system and the claims system.
@@ -42,14 +44,14 @@ function withCurrency(sym: string, position: "prefix" | "suffix", formatted: str
  * Format a single number into a human-readable string based on unit.
  *
  * Examples:
- *   formatValue(850000000, "USD")              -> "$850 million"
- *   formatValue(100000000, "USD", "GBP")       -> "£100 million"
- *   formatValue(30000000000, "USD")            -> "$30 billion"
- *   formatValue(40, "percent")                 -> "40%"
- *   formatValue(1500, "count")                 -> "1,500"
- *   formatValue(200000, "tokens")              -> "200,000"
+ *   formatNumberWithUnit(850000000, "USD")              -> "$850 million"
+ *   formatNumberWithUnit(100000000, "USD", "GBP")       -> "£100 million"
+ *   formatNumberWithUnit(30000000000, "USD")            -> "$30 billion"
+ *   formatNumberWithUnit(40, "percent")                 -> "40%"
+ *   formatNumberWithUnit(1500, "count")                 -> "1,500"
+ *   formatNumberWithUnit(200000, "tokens")              -> "200,000"
  */
-export function formatValue(n: number | null | undefined, unit?: string | null, currency?: string | null): string {
+export function formatNumberWithUnit(n: number | null | undefined, unit?: string | null, currency?: string | null): string {
   if (n == null) return "";
   const cur = resolveCurrencyInfo(unit, currency);
   if (cur !== null) {
@@ -132,7 +134,7 @@ export function formatStructuredValue(
 ): string {
   const n = Number(rawValue);
   if (Number.isFinite(n) && rawValue.trim() !== "") {
-    return formatValue(n, unit);
+    return formatNumberWithUnit(n, unit);
   }
   return rawValue;
 }

--- a/packages/factbase/src/format.ts
+++ b/packages/factbase/src/format.ts
@@ -1,5 +1,8 @@
 /**
- * Shared formatting utilities for KB data.
+ * Shared formatting utilities for KB data. Contains the canonical, property-driven
+ * `formatValue` (takes a Property definition for display config). For raw
+ * unit-tagged numbers without a Property, see `formatNumberWithUnit` in
+ * apps/web/src/lib/format-value.ts.
  *
  * Used by CLI tools, frontend components, and any other consumer
  * that needs human-readable representations of KB values.


### PR DESCRIPTION
## Summary

- Renamed `apps/web/src/lib/format-value.ts::formatValue` to `formatNumberWithUnit` to disambiguate from the property-driven `packages/factbase/src/format.ts::formatValue`.
- All importers updated (5 files touched total: source, test, 2 component importers, + 1 header comment in the canonical factbase file).
- `packages/factbase::formatValue` remains the canonical property-driven formatter.
- Added disambiguating header comments to both `format-value.ts` and `packages/factbase/src/format.ts` pointing at each other.

## Why

QUA-209 — two `formatValue` exports with different signatures caused grep-by-name ambiguity and risked wrong-import bugs. The rename is the minimum defensible fix; full consolidation of the other overlapping `format*` helpers is a multi-PR effort tracked separately.

## Scope (deliberately narrow)

- Renamed to disambiguate
- **Not in this PR** (follow-ups):
  - Consolidate `formatKBNumber` / `formatCompactNumber` / `formatKBCellValue` into canonical location
  - A third `formatValue` exists in `apps/web/src/lib/calc-engine.ts` with yet another signature (`formatValue(n, {format: "currency"})`). Not renamed here to keep this PR surgical — should be addressed as a follow-up (likely rename to `formatCalcValue`).
  - Gate check to block new `format*` exports outside a canonical file

## Verification

- `pnpm exec tsc --noEmit -p apps/web/tsconfig.json` — clean (exit 0)
- `pnpm exec vitest run apps/web/src/lib/__tests__/format-value.test.ts` — 72/72 passing
- Grep for dynamic `"formatValue"` string references — none found (only test `describe` blocks, which are scoped)
- No barrel export for `apps/web/src/lib` — no re-export chain to update

Fixes QUA-209 (partial).

## Test plan
- [x] Typecheck clean
- [x] Tests green (72 tests in format-value.test.ts)
- [x] All 2 production importers updated (FBFactValue.tsx, components/wiki/factbase/format.ts)
