### PR TITLE
block release PR creation when previous prod deploy failed (QUA-295)

### DIFF
--- a/crux/commands/health.ts
+++ b/crux/commands/health.ts
@@ -32,13 +32,15 @@ Commands:
 
 Options:
   --check=<name>  Run only a specific check:
-                    server       Server & DB health
-                    api          API smoke tests
-                    actions      GitHub Actions workflow health
-                    frontend     Public frontend availability
-                    freshness    Data freshness
-                    job-queue    Job queue health
-                    pr-quality   PR & issue quality
+                    server              Server & DB health
+                    api                 API smoke tests
+                    actions             GitHub Actions workflow health
+                    ci-main             CI runs on main branch
+                    wiki-server-deploy  Last wiki-server deploy status (QUA-295)
+                    frontend            Public frontend availability
+                    freshness           Data freshness
+                    job-queue           Job queue health
+                    pr-quality          PR & issue quality
   --json          JSON output (all results as structured data)
   --report        Aggregate markdown report to stdout
   --auto-issue    Manage GitHub wellness issue (create/update/close)

--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { categorizeCommit, groupCommits, generateReleaseBody } from './release.ts';
+import {
+  categorizeCommit,
+  groupCommits,
+  generateReleaseBody,
+  evaluateReleasePreflight,
+} from './release.ts';
+import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
 
 // ── categorizeCommit ─────────────────────────────────────────────────────────
 
@@ -176,5 +182,102 @@ describe('generateReleaseBody', () => {
     expect(body).toContain('### Documentation');
     expect(body).toContain('### Infrastructure');
     expect(body).toContain('### Other');
+  });
+});
+
+// ── evaluateReleasePreflight ─────────────────────────────────────────────────
+
+describe('evaluateReleasePreflight', () => {
+  const healthySuccess: DeployHealthStatus = {
+    healthy: true,
+    lastDeploy: {
+      status: 'success',
+      sha: 'abc1234567',
+      url: 'https://github.com/org/repo/actions/runs/1',
+      timestamp: '2026-04-12T10:00:00Z',
+    },
+    failingSince: null,
+  };
+
+  const failedDeploy: DeployHealthStatus = {
+    healthy: false,
+    lastDeploy: {
+      status: 'failure',
+      sha: 'def4567890',
+      url: 'https://github.com/org/repo/actions/runs/2',
+      timestamp: '2026-04-12T11:00:00Z',
+    },
+    failingSince: '2026-04-12T11:00:00Z',
+  };
+
+  it('passes when deploy healthy', () => {
+    const decision = evaluateReleasePreflight(healthySuccess, { force: false });
+    expect(decision.ok).toBe(true);
+    if (decision.ok) expect(decision.warning).toBeNull();
+  });
+
+  it('passes when no prior deploy data (fail-open)', () => {
+    const decision = evaluateReleasePreflight(
+      { healthy: true, lastDeploy: null, failingSince: null },
+      { force: false },
+    );
+    expect(decision.ok).toBe(true);
+  });
+
+  it('passes defensively when healthy=false but lastDeploy=null', () => {
+    // Shouldn't happen per checkDeployHealth's contract, but guard anyway.
+    const decision = evaluateReleasePreflight(
+      { healthy: false, lastDeploy: null, failingSince: null },
+      { force: false },
+    );
+    expect(decision.ok).toBe(true);
+  });
+
+  it('blocks when last deploy failed', () => {
+    const decision = evaluateReleasePreflight(failedDeploy, { force: false });
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toContain('failure');
+      expect(decision.reason).toContain('def4567');
+      expect(decision.reason).toContain('QUA-295');
+      expect(decision.reason).toContain('--force');
+      expect(decision.lastDeployUrl).toBe('https://github.com/org/repo/actions/runs/2');
+    }
+  });
+
+  it('blocks when last deploy was cancelled', () => {
+    const decision = evaluateReleasePreflight(
+      {
+        healthy: false,
+        lastDeploy: {
+          status: 'cancelled',
+          sha: 'aaa1111222',
+          url: 'https://github.com/org/repo/actions/runs/3',
+          timestamp: '2026-04-12T12:00:00Z',
+        },
+        failingSince: '2026-04-12T12:00:00Z',
+      },
+      { force: false },
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) expect(decision.reason).toContain('cancelled');
+  });
+
+  it('--force bypasses failed deploy with a loud warning', () => {
+    const decision = evaluateReleasePreflight(failedDeploy, { force: true });
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.warning).not.toBeNull();
+      expect(decision.warning).toContain('--force override');
+      expect(decision.warning).toContain('failure');
+      expect(decision.warning).toContain('def4567');
+      expect(decision.warning).toContain('https://github.com/org/repo/actions/runs/2');
+    }
+  });
+
+  it('--force with healthy deploy still has no warning', () => {
+    const decision = evaluateReleasePreflight(healthySuccess, { force: true });
+    expect(decision.ok).toBe(true);
+    if (decision.ok) expect(decision.warning).toBeNull();
   });
 });

--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -21,6 +21,10 @@ import {
   parseDeployTasksFromBody,
   preserveCheckedState,
 } from '../lib/deploy-tasks/detect.ts';
+import {
+  checkDeployHealth,
+  type DeployHealthStatus,
+} from '../lib/pr-analysis/deploy-status.ts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -265,6 +269,58 @@ async function ensureLabel(): Promise<void> {
   }
 }
 
+// ── Pre-flight: previous-deploy health check ────────────────────────────────
+
+export type ReleasePreflightDecision =
+  | { ok: true; warning: string | null }
+  | { ok: false; reason: string; lastDeployUrl: string | null };
+
+/**
+ * Decide whether to allow creating a new release PR based on the health of
+ * the previous production deploy.
+ *
+ * Blocks when the most recent completed `wiki-server-docker.yml` run did not
+ * conclude with `success` — the cascade that motivated QUA-295 happened
+ * because release PRs kept getting cut on top of a silently-broken deploy.
+ *
+ * When `force` is true, returns `ok: true` with a warning string instead of
+ * blocking, so the caller can log a loud override message.
+ *
+ * Fail-open: a `healthy: true, lastDeploy: null` status (no data / API error)
+ * is treated as pass. `checkDeployHealth` already fails open on network errors.
+ */
+export function evaluateReleasePreflight(
+  deployHealth: DeployHealthStatus,
+  options: { force: boolean },
+): ReleasePreflightDecision {
+  if (deployHealth.healthy) {
+    return { ok: true, warning: null };
+  }
+
+  const last = deployHealth.lastDeploy;
+  // Shouldn't happen: healthy=false requires lastDeploy, but be defensive.
+  if (!last) return { ok: true, warning: null };
+
+  const shortSha = last.sha.slice(0, 7);
+  const reason =
+    `Previous production deploy concluded "${last.status}" ` +
+    `(${shortSha} at ${last.timestamp}). ` +
+    `Fix the deploy pipeline before cutting a new release PR — ` +
+    `otherwise merges pile up on a stale prod image (see QUA-295). ` +
+    `Pass --force to override if you have manually verified prod is healthy.`;
+
+  if (options.force) {
+    return {
+      ok: true,
+      warning:
+        `--force override: previous deploy is "${last.status}" (${shortSha}). ` +
+        `Proceeding anyway. Run: ${last.url}`,
+    };
+  }
+
+  return { ok: false, reason, lastDeployUrl: last.url };
+}
+
 // ── Main command ─────────────────────────────────────────────────────────────
 
 /**
@@ -272,11 +328,30 @@ async function ensureLabel(): Promise<void> {
  *
  * Options:
  *   --dry-run    Preview what would happen without creating/updating the PR.
+ *   --force      Override the previous-deploy-failed pre-flight block.
  */
 async function create(_args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(Boolean(options.ci));
   const c = log.colors;
   const dryRun = Boolean(options.dryRun ?? options['dry-run']);
+  const force = Boolean(options.force);
+
+  // Pre-flight: refuse to cut a new release PR if the previous production
+  // deploy is not in a `success` state. See QUA-295 for the motivating
+  // incident (2026-04-12 cascade). Runs before git fetch so a failing deploy
+  // gives fast, clear feedback without touching the local working tree.
+  const deployHealth = await checkDeployHealth();
+  const preflight = evaluateReleasePreflight(deployHealth, { force });
+  if (!preflight.ok) {
+    let output = `${c.red}✗ Release blocked:${c.reset} ${preflight.reason}\n`;
+    if (preflight.lastDeployUrl) {
+      output += `  Failing run: ${preflight.lastDeployUrl}\n`;
+    }
+    return { output, exitCode: 1 };
+  }
+  if (preflight.warning) {
+    log.warn(preflight.warning);
+  }
 
   // Fetch latest remote refs
   git('fetch', 'origin', 'main', 'production');
@@ -391,7 +466,15 @@ Commands:
 
 Options (create):
   --dry-run             Preview what would happen without creating/updating the PR.
+  --force               Override the previous-deploy-failed pre-flight block.
+                        Use only after manually verifying prod is healthy.
   --ci                  JSON output for CI pipelines.
+
+Pre-flight:
+  Refuses to create or update a release PR when the most recent completed
+  wiki-server-docker.yml run did not conclude 'success'. This prevents the
+  QUA-295 cascade pattern where release PRs stack up on top of a silently-
+  broken production deploy.
 
 The release PR includes:
   - Standardized title: "release: YYYY-MM-DD" (or "#2" for same-day re-releases)
@@ -402,5 +485,6 @@ The release PR includes:
 Examples:
   pnpm crux gh release create               # Create or update release PR
   pnpm crux gh release create --dry-run     # Preview without creating
+  pnpm crux gh release create --force       # Override pre-flight block
 `.trim();
 }

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -13,9 +13,10 @@
  *   crux health                      Run all checks
  *   crux health --check=server       Server & DB only
  *   crux health --check=api          API smoke tests only
- *   crux health --check=actions      GitHub Actions workflow health
- *   crux health --check=ci-main      CI runs on main branch (0 runs in 24h = alert)
- *   crux health --check=frontend     Public frontend availability
+ *   crux health --check=actions           GitHub Actions workflow health
+ *   crux health --check=ci-main            CI runs on main branch (0 runs in 24h = alert)
+ *   crux health --check=wiki-server-deploy Last wiki-server deploy status (QUA-295)
+ *   crux health --check=frontend           Public frontend availability
  *   crux health --check=freshness    Data freshness
  *   crux health --check=job-queue    Job queue health
  *   crux health --check=pr-quality   PR & issue quality
@@ -31,6 +32,7 @@ import { getServerUrl, getApiKey } from '../lib/wiki-server/client.ts';
 import { checkJobQueue } from './checks/job-queue.ts';
 import { checkPrQuality } from './checks/pr-quality.ts';
 import { checkCiMainHealth } from './checks/ci-main-health.ts';
+import { checkDeployHealth } from '../lib/pr-analysis/deploy-status.ts';
 import { buildWellnessReport, manageWellnessIssue } from './wellness-report.ts';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -369,6 +371,65 @@ export async function checkActions(): Promise<CheckResult> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Check 3b: Wiki-server deploy health (QUA-295)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function checkWikiServerDeploy(): Promise<CheckResult> {
+  const name = 'Wiki-server deploy';
+
+  if (!process.env.GITHUB_TOKEN) {
+    return {
+      name,
+      ok: false,
+      summary: 'GITHUB_TOKEN not set',
+      detail: ['Set GITHUB_TOKEN to enable deploy health checks'],
+    };
+  }
+
+  const health = await checkDeployHealth();
+  if (!health.lastDeploy) {
+    return {
+      name,
+      ok: true,
+      summary: 'No recent deploy data',
+      detail: ['wiki-server-docker.yml has no completed runs in the query window'],
+    };
+  }
+
+  const { status, sha, url, timestamp } = health.lastDeploy;
+  const shortSha = sha.slice(0, 7);
+  const ageH = hoursAgo(timestamp);
+  const detail = [
+    `Last deploy: ${status} (${shortSha})`,
+    `Timestamp: ${timestamp} (${ageH}h ago)`,
+    `Run: ${url}`,
+  ];
+
+  if (!health.healthy) {
+    detail.push(
+      `Release PRs are blocked until this deploy succeeds (see QUA-295).`,
+      `Use --force on crux gh release create only after manually verifying prod.`,
+    );
+    if (health.failingSince && health.failingSince !== timestamp) {
+      detail.push(`Failing since: ${health.failingSince}`);
+    }
+    return {
+      name,
+      ok: false,
+      summary: `Last deploy '${status}' (${shortSha}, ${ageH}h ago)`,
+      detail,
+    };
+  }
+
+  return {
+    name,
+    ok: true,
+    summary: `Last deploy success (${shortSha}, ${ageH}h ago)`,
+    detail,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Check 4: Frontend availability
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -483,6 +544,7 @@ const ALL_CHECKS: Record<string, () => Promise<CheckResult>> = {
   api: checkApi,
   actions: checkActions,
   'ci-main': checkCiMainHealth,
+  'wiki-server-deploy': checkWikiServerDeploy,
   frontend: checkFrontend,
   freshness: checkFreshness,
   'job-queue': checkJobQueue,
@@ -505,7 +567,7 @@ async function main(): Promise<void> {
   } else {
     // Run all checks. Independent checks run in parallel; API smoke tests
     // depend on server health so they run after.
-    const independentChecks = ['server', 'actions', 'ci-main', 'frontend', 'freshness', 'job-queue', 'pr-quality'] as const;
+    const independentChecks = ['server', 'actions', 'ci-main', 'wiki-server-deploy', 'frontend', 'freshness', 'job-queue', 'pr-quality'] as const;
 
     if (!JSON_MODE && !REPORT_MODE) {
       console.log('  Running independent checks in parallel...');


### PR DESCRIPTION
## Summary

Adds a pre-flight check to `crux gh release create` that refuses to create or update a release PR when the most recent completed `wiki-server-docker.yml` run did not conclude `success`. Prevents the 2026-04-12 cascade where release PRs kept getting cut on top of a silently-broken production deploy while main drifted 12+ hours ahead of prod.

Fixes QUA-295

## Changes

- **`crux/commands/release.ts`**: new `evaluateReleasePreflight()` pure function + wired into `create()` before `git fetch`. `--force` override logs a loud warning and proceeds.
- **`crux/commands/release.test.ts`**: 7 new tests covering healthy pass, failed block, cancelled block, `--force` bypass, no-data fail-open, and the defensive `healthy: false + lastDeploy: null` guard.
- **`crux/health/health-check.ts`**: new `checkWikiServerDeploy()` check registered in `ALL_CHECKS` and `independentChecks`. Surfaces the stale-deploy state in the routine `crux sys health` sweep so oncall can see it without running release create.
- **`crux/commands/health.ts`**: help text now lists the new `wiki-server-deploy` check.

## Semantics

- **Blocks on**: `failure`, `cancelled`, `timed_out`, `startup_failure`, `action_required`, `neutral`, `skipped`, `stale` (anything where `conclusion !== 'success'`).
- **Fail-open on**: API error, no completed runs, `healthy: false + lastDeploy: null` defensive guard. Matches the existing `checkDeployHealth` contract.
- **`--force`**: logs a loud warning naming the bad deploy's status + URL, then proceeds. Intended for "I have manually verified prod is actually fine."

## Test plan

- [x] `pnpm vitest run crux/commands/release.test.ts crux/lib/pr-analysis/deploy-status.test.ts` — 27 pass (22 release + 5 deploy-status)
- [x] `pnpm crux gh release create --dry-run` — smoke test against live prod (currently healthy; pre-flight passes through)
- [x] `pnpm crux sys health --check=wiki-server-deploy` — smoke test against live prod (pass, 1h ago)
- [x] Typecheck: no new errors in changed files (pre-existing crux baseline unchanged)
- [ ] CI green

## Known limits

- `checkWikiServerDeploy` has no dedicated unit test because `crux/health/health-check.ts` runs `main()` at import time, so importing from vitest would trigger a full health sweep. The underlying `checkDeployHealth` has full coverage (`crux/lib/pr-analysis/deploy-status.test.ts`) and the new function is a thin formatting wrapper. Filing as follow-up: refactor `health-check.ts` to guard `main()` behind an `import.meta.url === ...` check so its exports become unit-testable.

## Follow-ups in this subsystem (not blocking)

- **QUA-303** (Rename `source_check_*` DB tables → `sourcing_*`) is blocked waiting on this issue. The 2026-04-18 safe-to-start date for QUA-303 also depends on 7 consecutive green deploys — landing this check unblocks future iterations of the same cascade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wiki-server-deploy` health check to monitor wiki-server deployment status.
  * Added pre-flight validation for release creation that blocks releases when the last deployment failed.
  * Added `--force` flag to override release pre-flight checks when necessary.

* **Documentation**
  * Updated help text for health and release commands to document new checks and the `--force` option.

* **Tests**
  * Added test coverage for release preflight validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->