### PR TITLE
feat(entity-profile): shared EntityProfileShell for organizations, people, ai-models

### DIFF
--- a/.claude/rules/entity-profile-pages.md
+++ b/.claude/rules/entity-profile-pages.md
@@ -1,0 +1,122 @@
+# Entity Profile Pages — Use `EntityProfileShell`
+
+Every directory-detail page (`/organizations/[slug]`, `/people/[slug]`,
+`/ai-models/[slug]`, and analogous pages for projects, legislation, benchmarks,
+etc.) **must** use the shared `EntityProfileShell` component instead of
+hand-rolling its own wrapper layout.
+
+## Why this exists
+
+Previously every entity profile page hand-wrote its own outer container,
+breadcrumbs, header (avatar / title / pills / coverage badge / sourcing
+dot), stat-card grid, and sidebar layout. Each time a cross-cutting piece of
+chrome needed to change ("show the sourcing rollup next to the title",
+"add a coverage popover", "change the Data link style") we had to touch every
+page individually, and features silently drifted between types. See QUA-328,
+which replaces QUA-117 / QUA-194 / QUA-152 / QUA-205 — all of which were
+"add X to every entity page" tickets that existed only because the layout
+wasn't shared.
+
+The shell gives each page a single canonical code path for:
+
+- outer container + breadcrumbs
+- header title row with title, type pills, coverage popover, and sourcing
+  rollup badge
+- metadata row, header-link pills, optional footer (e.g. founders)
+- stat cards
+- tabs (via `ProfileTabs`) or free children
+- optional right-hand sidebar (2-column grid layout)
+
+Adding a new "show on all entity pages" item is a one-line change inside
+`EntityProfileShell.tsx`.
+
+## Files
+
+- `apps/web/src/components/entity/EntityProfileShell.tsx` — the shell component
+  (server component; safe to render from any Next.js page or layout)
+- `apps/web/src/components/entity/entity-sourcing.ts` —
+  `fetchEntitySourcingSummary()` + `rollupVerdictFromSummary()` for the
+  sourcing rollup badge
+- Reference implementations:
+  - `apps/web/src/app/organizations/[slug]/page.tsx` (uses the shell with
+    `tabs` and no sidebar)
+  - `apps/web/src/app/organizations/[slug]/data/page.tsx` (uses the shell with
+    `children` — the long-form data table — and the same slot-builder helper)
+  - `apps/web/src/app/people/[slug]/page.tsx` (uses `tabs` **and** `sidebar`
+    for the 2-column people layout)
+  - `apps/web/src/app/ai-models/[slug]/page.tsx` (uses `children` + `sidebar`
+    with no tabs)
+
+## API at a glance
+
+```tsx
+<EntityProfileShell
+  breadcrumbs={[{ label: "Organizations", href: "/organizations" }, { label: entity.name }]}
+  entityId={entity.id}
+  avatar={<InitialsCircle name={entity.name} />}
+  title={entity.name}
+  aliases={entity.aliases}
+  titlePills={<>...</>}              // badges next to the title
+  coverage={{ score, signals }}       // data-coverage popover (optional)
+  verdict={rollupVerdict}             // sourcing rollup verdict (optional)
+  subtitle={entity.description}
+  metadata={<>Founded ... · HQ ... · website</>}
+  headerLinks={[{ label: "Wiki page", href: wikiHref }, { label: "Data", href: `/organizations/${entity.id}/data` }]}
+  headerFooter={<FoundersList founders={founders} />}
+  statCards={<StatCardsGrid cards={cards} />}
+  tabs={tabs}                         // ProfileTab[]
+  tabsAriaLabel="Organization sections"
+  sidebar={<SidebarContent />}        // optional right-hand sidebar
+>
+  {/* Optional children render inside the main column below tabs */}
+</EntityProfileShell>
+```
+
+- When `sidebar` is provided, the main column renders in a `lg:grid-cols-3`
+  2-column layout with the sidebar on the right.
+- When `tabs` is provided, `ProfileTabs` is rendered automatically — pages
+  should not import `ProfileTabs` directly anymore.
+- The sourcing rollup dot is **always** rendered in the header, using
+  `SourcingDot` + `recordVerdictToStatus`, so every entity page has a
+  consistent sourcing badge. Pass `verdict` as the raw verdict string
+  (`"confirmed" | "contradicted" | ...`) or `null` for "unchecked".
+
+## Fetching the sourcing rollup
+
+Use the helper from `@/components/entity/entity-sourcing`:
+
+```ts
+const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entity.stableId, slug]);
+const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
+```
+
+`fetchEntitySourcingSummary` takes one or more candidate identifiers
+(slug, stableId, numericId) and matches any of them against the upstream row,
+which makes it robust to whichever form the wiki-server recorded the verdict
+under. The call is ISR-cached (default 300s) so every per-page request for the
+same build shares a single network fetch.
+
+`rollupVerdictFromSummary` picks the most actionable verdict present
+(`contradicted > outdated > partial > unverifiable > confirmed > unchecked`),
+or `null` when no verdicts exist.
+
+## When NOT to use the shell
+
+- **Dashboards** (`/internal/*`) — these have their own layout patterns,
+  described in `.claude/rules/internal-dashboards.md`.
+- **Wiki pages** (`/wiki/E<N>`) — MDX content uses its own article layout.
+- **Directory index pages** (`/organizations`, `/people`) — the shell is for
+  the per-entity detail pages, not the list pages.
+
+## Adding a new entity type directory
+
+When adding a new directory (e.g. `/policies/[slug]`), your detail page should:
+
+1. Resolve the entity and fetch its data as usual.
+2. Call `fetchEntitySourcingSummary` for the sourcing rollup.
+3. Render `<EntityProfileShell>` with the slots it needs.
+4. Leave the per-type sections as either `tabs` or `children`, and optional
+   `sidebar` content.
+
+Do not introduce a new per-type wrapper component. If the shell is missing a
+slot you need, **add the slot to the shell** rather than forking the layout.

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -57,6 +57,10 @@ const TABBED_PAGES = [
   "/people/dario-amodei",
   "/people/sam-altman",
   "/people/demis-hassabis",
+  // AI models — newly tabbed in QUA-328 EntityProfileShell migration
+  "/ai-models/claude-opus-4-5",
+  "/ai-models/gemini-2-5-pro",
+  "/ai-models/gpt-4o",
 ];
 
 /** Pages with stat cards — check for empty values. */
@@ -66,6 +70,8 @@ const STAT_CARD_PAGES = [
   "/organizations/google-deepmind",
   "/organizations/meta-ai",
   "/organizations/microsoft",
+  "/ai-models/claude-opus-4-5",
+  "/ai-models/gemini-2-5-pro",
 ];
 
 /** Simple pages — load and check text, no tab clicking needed. */

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -6,7 +6,6 @@ import {
   resolveAiModelBySlug,
   getAiModelSlugs,
   getRelatedModels,
-  isModelFamily,
 } from "../ai-model-utils";
 import { resolveSlugAlias } from "@/data/factbase";
 import {
@@ -14,13 +13,18 @@ import {
   SAFETY_LEVEL_COLORS,
   formatContext,
 } from "../ai-model-constants";
-import { ProfileStatCard } from "@/components/directory";
+import { ProfileStatCard, type ProfileTab } from "@/components/directory";
 import {
   computeAiModelCoverage,
   getAiModelSignals,
 } from "@/components/coverage/coverage-score";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
-import { BenchmarkScorecard } from "./benchmark-scorecard";
+import {
+  OverviewTab,
+  PricingTab,
+  BenchmarksTab,
+  FamilyTab,
+} from "./tabs";
 
 export function generateStaticParams() {
   return getAiModelSlugs().map((slug) => ({ slug }));
@@ -37,10 +41,6 @@ export async function generateMetadata({
     title: entity ? `${entity.title} | AI Models` : "AI Model Not Found",
     description: entity?.description ?? undefined,
   };
-}
-
-function formatPrice(price: number): string {
-  return `\$${price.toFixed(2)}`;
 }
 
 export default async function AiModelDetailPage({
@@ -72,9 +72,6 @@ export default async function AiModelDetailPage({
       (!m.modelFamily || m.modelFamily !== entity.modelFamily),
   );
 
-  // Is this a family entry?
-  const isFamily = isModelFamily(entity);
-
   // Build stat cards
   const stats: Array<{
     label: string;
@@ -104,6 +101,50 @@ export default async function AiModelDetailPage({
 
   if (entity.safetyLevel) {
     stats.push({ label: "Safety Level", value: entity.safetyLevel });
+  }
+
+  // ── Build tabs ──
+  // Tabs hide automatically via ProfileTabs when count === 0, so a model
+  // with no pricing won't show the Pricing tab, etc.
+  const tabs: ProfileTab[] = [
+    {
+      id: "overview",
+      label: "Overview",
+      content: <OverviewTab entity={entity} />,
+    },
+  ];
+
+  if (entity.inputPrice != null || entity.outputPrice != null) {
+    tabs.push({
+      id: "pricing",
+      label: "Pricing",
+      content: <PricingTab entity={entity} />,
+    });
+  }
+
+  if (entity.benchmarks.length > 0) {
+    tabs.push({
+      id: "benchmarks",
+      label: "Benchmarks",
+      count: entity.benchmarks.length,
+      content: <BenchmarksTab entity={entity} />,
+    });
+  }
+
+  if (sameFamily.length > 0 || sameDeveloper.length > 0) {
+    tabs.push({
+      id: "family",
+      label: "Family",
+      count: sameFamily.length + sameDeveloper.length,
+      content: (
+        <FamilyTab
+          entity={entity}
+          sameFamily={sameFamily}
+          sameDeveloper={sameDeveloper}
+          developerName={developerEntity?.title ?? "Developer"}
+        />
+      ),
+    });
   }
 
   const titlePills = (
@@ -166,9 +207,10 @@ export default async function AiModelDetailPage({
     </div>
   );
 
+  // Sidebar: Details + Tags. Capabilities moved into the Overview tab so
+  // the sidebar stays focused on canonical metadata.
   const sidebar = (
     <>
-      {/* Model details */}
       <section>
         <h2 className="text-lg font-bold tracking-tight mb-4">Details</h2>
         <div className="border border-border/60 rounded-xl bg-card">
@@ -193,35 +235,9 @@ export default async function AiModelDetailPage({
             }
           />
           <DetailRow label="Safety Level" value={entity.safetyLevel} />
-          {entity.modality.length > 0 && (
-            <DetailRow label="Modality" value={entity.modality.join(", ")} />
-          )}
         </div>
       </section>
 
-      {/* Capabilities */}
-      {entity.capabilities.length > 0 && (
-        <section>
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Capabilities
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {entity.capabilities.length}
-            </span>
-          </h2>
-          <div className="flex flex-wrap gap-1.5">
-            {entity.capabilities.map((cap) => (
-              <span
-                key={cap}
-                className="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-medium border border-border/60 bg-card text-muted-foreground"
-              >
-                {cap}
-              </span>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Tags */}
       {entity.tags.length > 0 && (
         <section>
           <h2 className="text-lg font-bold tracking-tight mb-4">Tags</h2>
@@ -253,178 +269,10 @@ export default async function AiModelDetailPage({
       subtitle={entity.description || undefined}
       headerLinks={headerLinks}
       statCards={statCards}
+      tabs={tabs}
+      tabsAriaLabel="AI model sections"
       sidebar={sidebar}
-    >
-      <div className="space-y-8">
-        {/* Pricing */}
-        {(entity.inputPrice != null || entity.outputPrice != null) && (
-          <section>
-            <h2 className="text-lg font-bold tracking-tight mb-4">Pricing</h2>
-            <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                    <th className="py-2.5 px-4 text-left font-medium">Type</th>
-                    <th className="py-2.5 px-4 text-right font-medium">
-                      Price per MTok
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {entity.inputPrice != null && (
-                    <tr className="hover:bg-muted/20 transition-colors">
-                      <td className="py-2.5 px-4">Input</td>
-                      <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
-                        {formatPrice(entity.inputPrice)}
-                      </td>
-                    </tr>
-                  )}
-                  {entity.outputPrice != null && (
-                    <tr className="hover:bg-muted/20 transition-colors">
-                      <td className="py-2.5 px-4">Output</td>
-                      <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
-                        {formatPrice(entity.outputPrice)}
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </section>
-        )}
-
-        {/* Benchmarks */}
-        {entity.benchmarks.length > 0 && (
-          <section>
-            <h2 className="text-lg font-bold tracking-tight mb-4">
-              Benchmarks
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                {entity.benchmarks.length}
-              </span>
-            </h2>
-            <BenchmarkScorecard
-              benchmarks={entity.benchmarks}
-              modelId={entity.id}
-            />
-          </section>
-        )}
-
-        {/* Family models */}
-        {sameFamily.length > 0 && (
-          <section>
-            <h2 className="text-lg font-bold tracking-tight mb-4">
-              {entity.modelFamily} Family
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                {sameFamily.length}
-              </span>
-            </h2>
-            <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                    <th className="py-2.5 px-4 text-left font-medium">Model</th>
-                    <th className="py-2.5 px-4 text-left font-medium">Tier</th>
-                    <th className="py-2.5 px-4 text-left font-medium">
-                      Released
-                    </th>
-                    <th className="py-2.5 px-4 text-right font-medium">
-                      Input $/MTok
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {sameFamily
-                    .sort((a, b) =>
-                      (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
-                    )
-                    .map((m) => (
-                      <tr
-                        key={m.id}
-                        className="hover:bg-muted/20 transition-colors"
-                      >
-                        <td className="py-2.5 px-4">
-                          <Link
-                            href={`/ai-models/${m.id}`}
-                            className="font-medium hover:text-primary transition-colors"
-                          >
-                            {m.title}
-                          </Link>
-                        </td>
-                        <td className="py-2.5 px-4 text-muted-foreground capitalize">
-                          {m.modelTier ?? (
-                            <span className="text-muted-foreground/40">&mdash;</span>
-                          )}
-                        </td>
-                        <td className="py-2.5 px-4 text-muted-foreground">
-                          {m.releaseDate ?? (
-                            <span className="text-muted-foreground/40">&mdash;</span>
-                          )}
-                        </td>
-                        <td className="py-2.5 px-4 text-right tabular-nums">
-                          {m.inputPrice != null ? (
-                            formatPrice(m.inputPrice)
-                          ) : (
-                            <span className="text-muted-foreground/40">&mdash;</span>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
-        )}
-
-        {/* Other models from same developer */}
-        {sameDeveloper.length > 0 && (
-          <section>
-            <h2 className="text-lg font-bold tracking-tight mb-4">
-              Other {developerEntity?.title ?? "Developer"} Models
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                {sameDeveloper.length}
-              </span>
-            </h2>
-            <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
-              {sameDeveloper
-                .sort((a, b) =>
-                  (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
-                )
-                .slice(0, 10)
-                .map((m) => (
-                  <div key={m.id} className="px-4 py-3">
-                    <div className="flex items-center justify-between gap-2">
-                      <Link
-                        href={`/ai-models/${m.id}`}
-                        className="font-medium text-sm hover:text-primary transition-colors"
-                      >
-                        {m.title}
-                      </Link>
-                      <span className="text-xs text-muted-foreground tabular-nums">
-                        {m.releaseDate ?? (
-                          <span className="text-muted-foreground/40">&mdash;</span>
-                        )}
-                      </span>
-                    </div>
-                    {m.modelFamily && (
-                      <div className="text-xs text-muted-foreground/60 mt-0.5">
-                        {m.modelFamily}{" "}
-                        {m.modelTier ? `(${m.modelTier})` : ""}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              {sameDeveloper.length > 10 && (
-                <div className="px-4 py-3 text-center">
-                  <span className="text-xs text-muted-foreground">
-                    Showing 10 of {sameDeveloper.length} models
-                  </span>
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-      </div>
-    </EntityProfileShell>
+    />
   );
 }
 

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -24,7 +24,7 @@ import {
   PricingTab,
   BenchmarksTab,
   FamilyTab,
-} from "./tabs";
+} from "@/app/ai-models/[slug]/tabs";
 
 export function generateStaticParams() {
   return getAiModelSlugs().map((slug) => ({ slug }));

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -14,8 +14,13 @@ import {
   SAFETY_LEVEL_COLORS,
   formatContext,
 } from "../ai-model-constants";
-import { Breadcrumbs, ProfileStatCard } from "@/components/directory";
-import { safeHref } from "@/lib/directory-utils";
+import { ProfileStatCard } from "@/components/directory";
+import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 import { BenchmarkScorecard } from "./benchmark-scorecard";
 
 export function generateStaticParams() {
@@ -51,6 +56,9 @@ export default async function AiModelDetailPage({
     if (canonical) permanentRedirect(`/ai-models/${canonical}`);
     return notFound();
   }
+
+  const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entity.stableId ?? "", slug]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // Resolve developer
   const developerEntity = entity.developer
@@ -102,86 +110,163 @@ export default async function AiModelDetailPage({
     stats.push({ label: "Safety Level", value: entity.safetyLevel });
   }
 
-  return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      <Breadcrumbs
-        items={[
-          { label: "AI Models", href: "/ai-models" },
-          { label: entity.title },
-        ]}
-      />
+  const titlePills = (
+    <>
+      {entity.developer && (
+        <Link
+          href={`/organizations/${entity.developer}`}
+          className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold hover:opacity-80 transition-opacity ${
+            DEVELOPER_COLORS[entity.developer] ??
+            "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          }`}
+        >
+          {developerEntity?.title ?? entity.developer}
+        </Link>
+      )}
+      {entity.openWeight && (
+        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300">
+          Open Weight
+        </span>
+      )}
+      {entity.safetyLevel && (
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold ${
+            SAFETY_LEVEL_COLORS[entity.safetyLevel] ??
+            "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          }`}
+        >
+          {entity.safetyLevel}
+        </span>
+      )}
+    </>
+  );
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2 flex-wrap">
-          <h1 className="text-3xl font-extrabold tracking-tight">
-            {entity.title}
-          </h1>
-          {entity.developer && (
-            <Link
-              href={`/organizations/${entity.developer}`}
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold hover:opacity-80 transition-opacity ${
-                DEVELOPER_COLORS[entity.developer] ??
-                "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-              }`}
-            >
-              {developerEntity?.title ?? entity.developer}
-            </Link>
+  const headerLinks = [
+    ...(entity.wikiId && getPageById(entity.id)
+      ? [{ label: "Wiki page", href: `/wiki/${entity.wikiId}` }]
+      : []),
+    { label: "Data", href: `/ai-models/${slug}/data` },
+  ];
+
+  const coverageScore = computeAiModelCoverage({
+    developer: entity.developer,
+    releaseDate: entity.releaseDate,
+    inputPrice: entity.inputPrice,
+    outputPrice: entity.outputPrice,
+    contextWindow: entity.contextWindow,
+    parameterCount: entity.parameterCount,
+    safetyLevel: entity.safetyLevel,
+    benchmarkCount: entity.benchmarks.length,
+    wikiId: entity.wikiId,
+  });
+  const coverageSignals: string[] = [];
+  if (entity.inputPrice != null || entity.outputPrice != null) coverageSignals.push("Pricing");
+  if (entity.contextWindow != null) coverageSignals.push("Context window");
+  if (entity.parameterCount) coverageSignals.push("Parameter count");
+  if (entity.safetyLevel) coverageSignals.push("Safety level");
+  if (entity.benchmarks.length >= 3) coverageSignals.push("Benchmarks");
+  if (entity.wikiId) coverageSignals.push("Wiki page");
+
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
+    </div>
+  );
+
+  const sidebar = (
+    <>
+      {/* Model details */}
+      <section>
+        <h2 className="text-lg font-bold tracking-tight mb-4">Details</h2>
+        <div className="border border-border/60 rounded-xl bg-card">
+          <DetailRow label="Model Family" value={entity.modelFamily} />
+          <DetailRow label="Tier" value={entity.modelTier} capitalize />
+          <DetailRow label="Generation" value={entity.generation} />
+          <DetailRow label="Release Date" value={entity.releaseDate} />
+          <DetailRow label="Parameters" value={entity.parameterCount} />
+          <DetailRow
+            label="Context Window"
+            value={
+              entity.contextWindow != null
+                ? `${formatContext(entity.contextWindow)} tokens`
+                : undefined
+            }
+          />
+          <DetailRow label="Training Cutoff" value={entity.trainingCutoff} />
+          <DetailRow
+            label="Open Weight"
+            value={
+              entity.openWeight != null ? (entity.openWeight ? "Yes" : "No") : undefined
+            }
+          />
+          <DetailRow label="Safety Level" value={entity.safetyLevel} />
+          {entity.modality.length > 0 && (
+            <DetailRow label="Modality" value={entity.modality.join(", ")} />
           )}
-          {entity.openWeight && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300">
-              Open Weight
+        </div>
+      </section>
+
+      {/* Capabilities */}
+      {entity.capabilities.length > 0 && (
+        <section>
+          <h2 className="text-lg font-bold tracking-tight mb-4">
+            Capabilities
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              {entity.capabilities.length}
             </span>
-          )}
-          {entity.safetyLevel && (
-            <span
-              className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold ${
-                SAFETY_LEVEL_COLORS[entity.safetyLevel] ??
-                "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-              }`}
-            >
-              {entity.safetyLevel}
-            </span>
-          )}
-        </div>
-
-        {entity.description && (
-          <p className="text-muted-foreground text-sm max-w-3xl leading-relaxed">
-            {entity.description}
-          </p>
-        )}
-
-        <div className="flex items-center gap-4 mt-3 text-sm">
-          {entity.wikiId && getPageById(entity.id) && (
-            <Link
-              href={`/wiki/${entity.wikiId}`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              Wiki page &rarr;
-            </Link>
-          )}
-          <Link
-            href={`/ai-models/${slug}/data`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Data &rarr;
-          </Link>
-        </div>
-      </div>
-
-      {/* Stat cards */}
-      {stats.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-          {stats.map((s) => (
-            <ProfileStatCard key={s.label} {...s} />
-          ))}
-        </div>
+          </h2>
+          <div className="flex flex-wrap gap-1.5">
+            {entity.capabilities.map((cap) => (
+              <span
+                key={cap}
+                className="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-medium border border-border/60 bg-card text-muted-foreground"
+              >
+                {cap}
+              </span>
+            ))}
+          </div>
+        </section>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main content */}
-        <div className="lg:col-span-2 space-y-8">
-          {/* Pricing */}
+      {/* Tags */}
+      {entity.tags.length > 0 && (
+        <section>
+          <h2 className="text-lg font-bold tracking-tight mb-4">Tags</h2>
+          <div className="flex flex-wrap gap-1.5">
+            {entity.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted/50 text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "AI Models", href: "/ai-models" },
+        { label: entity.title },
+      ]}
+      entityId={entity.id}
+      title={entity.title}
+      titlePills={titlePills}
+      coverage={{ score: coverageScore, signals: coverageSignals }}
+      verdict={rollupVerdict}
+      subtitle={entity.description || undefined}
+      headerLinks={headerLinks}
+      statCards={statCards}
+      sidebar={sidebar}
+    >
+      <div className="space-y-8">
+        {/* Pricing */}
           {(entity.inputPrice != null || entity.outputPrice != null) && (
             <section>
               <h2 className="text-lg font-bold tracking-tight mb-4">
@@ -350,95 +435,8 @@ export default async function AiModelDetailPage({
               </div>
             </section>
           )}
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-8">
-          {/* Model details */}
-          <section>
-            <h2 className="text-lg font-bold tracking-tight mb-4">Details</h2>
-            <div className="border border-border/60 rounded-xl bg-card">
-              <DetailRow label="Model Family" value={entity.modelFamily} />
-              <DetailRow label="Tier" value={entity.modelTier} capitalize />
-              <DetailRow label="Generation" value={entity.generation} />
-              <DetailRow label="Release Date" value={entity.releaseDate} />
-              <DetailRow
-                label="Parameters"
-                value={entity.parameterCount}
-              />
-              <DetailRow
-                label="Context Window"
-                value={
-                  entity.contextWindow != null
-                    ? `${formatContext(entity.contextWindow)} tokens`
-                    : undefined
-                }
-              />
-              <DetailRow
-                label="Training Cutoff"
-                value={entity.trainingCutoff}
-              />
-              <DetailRow
-                label="Open Weight"
-                value={
-                  entity.openWeight != null
-                    ? entity.openWeight
-                      ? "Yes"
-                      : "No"
-                    : undefined
-                }
-              />
-              <DetailRow label="Safety Level" value={entity.safetyLevel} />
-              {entity.modality.length > 0 && (
-                <DetailRow
-                  label="Modality"
-                  value={entity.modality.join(", ")}
-                />
-              )}
-            </div>
-          </section>
-
-          {/* Capabilities */}
-          {entity.capabilities.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Capabilities
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {entity.capabilities.length}
-                </span>
-              </h2>
-              <div className="flex flex-wrap gap-1.5">
-                {entity.capabilities.map((cap) => (
-                  <span
-                    key={cap}
-                    className="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-medium border border-border/60 bg-card text-muted-foreground"
-                  >
-                    {cap}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Tags */}
-          {entity.tags.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">Tags</h2>
-              <div className="flex flex-wrap gap-1.5">
-                {entity.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted/50 text-muted-foreground"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
       </div>
-    </div>
+    </EntityProfileShell>
   );
 }
 

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -15,7 +15,10 @@ import {
   formatContext,
 } from "../ai-model-constants";
 import { ProfileStatCard } from "@/components/directory";
-import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
+import {
+  computeAiModelCoverage,
+  getAiModelSignals,
+} from "@/components/coverage/coverage-score";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   fetchEntitySourcingSummary,
@@ -57,7 +60,7 @@ export default async function AiModelDetailPage({
     return notFound();
   }
 
-  const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entity.stableId ?? "", slug]);
+  const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entity.stableId ?? entity.id, slug]);
   const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // Resolve developer
@@ -148,7 +151,7 @@ export default async function AiModelDetailPage({
     { label: "Data", href: `/ai-models/${slug}/data` },
   ];
 
-  const coverageScore = computeAiModelCoverage({
+  const coverageInput = {
     developer: entity.developer,
     releaseDate: entity.releaseDate,
     inputPrice: entity.inputPrice,
@@ -158,14 +161,9 @@ export default async function AiModelDetailPage({
     safetyLevel: entity.safetyLevel,
     benchmarkCount: entity.benchmarks.length,
     wikiId: entity.wikiId,
-  });
-  const coverageSignals: string[] = [];
-  if (entity.inputPrice != null || entity.outputPrice != null) coverageSignals.push("Pricing");
-  if (entity.contextWindow != null) coverageSignals.push("Context window");
-  if (entity.parameterCount) coverageSignals.push("Parameter count");
-  if (entity.safetyLevel) coverageSignals.push("Safety level");
-  if (entity.benchmarks.length >= 3) coverageSignals.push("Benchmarks");
-  if (entity.wikiId) coverageSignals.push("Wiki page");
+  };
+  const coverageScore = computeAiModelCoverage(coverageInput);
+  const coverageSignals = getAiModelSignals(coverageInput);
 
   const statCards = stats.length > 0 && (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -267,174 +265,172 @@ export default async function AiModelDetailPage({
     >
       <div className="space-y-8">
         {/* Pricing */}
-          {(entity.inputPrice != null || entity.outputPrice != null) && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Pricing
-              </h2>
-              <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                      <th className="py-2.5 px-4 text-left font-medium">
-                        Type
-                      </th>
-                      <th className="py-2.5 px-4 text-right font-medium">
-                        Price per MTok
-                      </th>
+        {(entity.inputPrice != null || entity.outputPrice != null) && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">Pricing</h2>
+            <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-4 text-left font-medium">Type</th>
+                    <th className="py-2.5 px-4 text-right font-medium">
+                      Price per MTok
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {entity.inputPrice != null && (
+                    <tr className="hover:bg-muted/20 transition-colors">
+                      <td className="py-2.5 px-4">Input</td>
+                      <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
+                        {formatPrice(entity.inputPrice)}
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/50">
-                    {entity.inputPrice != null && (
-                      <tr className="hover:bg-muted/20 transition-colors">
-                        <td className="py-2.5 px-4">Input</td>
-                        <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
-                          {formatPrice(entity.inputPrice)}
+                  )}
+                  {entity.outputPrice != null && (
+                    <tr className="hover:bg-muted/20 transition-colors">
+                      <td className="py-2.5 px-4">Output</td>
+                      <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
+                        {formatPrice(entity.outputPrice)}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Benchmarks */}
+        {entity.benchmarks.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Benchmarks
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {entity.benchmarks.length}
+              </span>
+            </h2>
+            <BenchmarkScorecard
+              benchmarks={entity.benchmarks}
+              modelId={entity.id}
+            />
+          </section>
+        )}
+
+        {/* Family models */}
+        {sameFamily.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              {entity.modelFamily} Family
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {sameFamily.length}
+              </span>
+            </h2>
+            <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-4 text-left font-medium">Model</th>
+                    <th className="py-2.5 px-4 text-left font-medium">Tier</th>
+                    <th className="py-2.5 px-4 text-left font-medium">
+                      Released
+                    </th>
+                    <th className="py-2.5 px-4 text-right font-medium">
+                      Input $/MTok
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {sameFamily
+                    .sort((a, b) =>
+                      (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
+                    )
+                    .map((m) => (
+                      <tr
+                        key={m.id}
+                        className="hover:bg-muted/20 transition-colors"
+                      >
+                        <td className="py-2.5 px-4">
+                          <Link
+                            href={`/ai-models/${m.id}`}
+                            className="font-medium hover:text-primary transition-colors"
+                          >
+                            {m.title}
+                          </Link>
+                        </td>
+                        <td className="py-2.5 px-4 text-muted-foreground capitalize">
+                          {m.modelTier ?? (
+                            <span className="text-muted-foreground/40">&mdash;</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-4 text-muted-foreground">
+                          {m.releaseDate ?? (
+                            <span className="text-muted-foreground/40">&mdash;</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-4 text-right tabular-nums">
+                          {m.inputPrice != null ? (
+                            formatPrice(m.inputPrice)
+                          ) : (
+                            <span className="text-muted-foreground/40">&mdash;</span>
+                          )}
                         </td>
                       </tr>
-                    )}
-                    {entity.outputPrice != null && (
-                      <tr className="hover:bg-muted/20 transition-colors">
-                        <td className="py-2.5 px-4">Output</td>
-                        <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
-                          {formatPrice(entity.outputPrice)}
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
-          {/* Benchmarks */}
-          {entity.benchmarks.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Benchmarks
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {entity.benchmarks.length}
-                </span>
-              </h2>
-              <BenchmarkScorecard
-                benchmarks={entity.benchmarks}
-                modelId={entity.id}
-              />
-            </section>
-          )}
-
-          {/* Family models */}
-          {sameFamily.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                {entity.modelFamily} Family
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {sameFamily.length}
-                </span>
-              </h2>
-              <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                      <th className="py-2.5 px-4 text-left font-medium">
-                        Model
-                      </th>
-                      <th className="py-2.5 px-4 text-left font-medium">
-                        Tier
-                      </th>
-                      <th className="py-2.5 px-4 text-left font-medium">
-                        Released
-                      </th>
-                      <th className="py-2.5 px-4 text-right font-medium">
-                        Input $/MTok
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/50">
-                    {sameFamily
-                      .sort((a, b) =>
-                        (b.releaseDate ?? "").localeCompare(
-                          a.releaseDate ?? "",
-                        ),
-                      )
-                      .map((m) => (
-                        <tr
-                          key={m.id}
-                          className="hover:bg-muted/20 transition-colors"
-                        >
-                          <td className="py-2.5 px-4">
-                            <Link
-                              href={`/ai-models/${m.id}`}
-                              className="font-medium hover:text-primary transition-colors"
-                            >
-                              {m.title}
-                            </Link>
-                          </td>
-                          <td className="py-2.5 px-4 text-muted-foreground capitalize">
-                            {m.modelTier ?? <span className="text-muted-foreground/40">&mdash;</span>}
-                          </td>
-                          <td className="py-2.5 px-4 text-muted-foreground">
-                            {m.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
-                          </td>
-                          <td className="py-2.5 px-4 text-right tabular-nums">
-                            {m.inputPrice != null
-                              ? formatPrice(m.inputPrice)
-                              : <span className="text-muted-foreground/40">&mdash;</span>}
-                          </td>
-                        </tr>
-                      ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
-
-          {/* Other models from same developer */}
-          {sameDeveloper.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold tracking-tight mb-4">
-                Other {developerEntity?.title ?? "Developer"} Models
-                <span className="ml-2 text-sm font-normal text-muted-foreground">
-                  {sameDeveloper.length}
-                </span>
-              </h2>
-              <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
-                {sameDeveloper
-                  .sort((a, b) =>
-                    (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
-                  )
-                  .slice(0, 10)
-                  .map((m) => (
-                    <div key={m.id} className="px-4 py-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <Link
-                          href={`/ai-models/${m.id}`}
-                          className="font-medium text-sm hover:text-primary transition-colors"
-                        >
-                          {m.title}
-                        </Link>
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                          {m.releaseDate ?? <span className="text-muted-foreground/40">&mdash;</span>}
-                        </span>
-                      </div>
-                      {m.modelFamily && (
-                        <div className="text-xs text-muted-foreground/60 mt-0.5">
-                          {m.modelFamily}{" "}
-                          {m.modelTier ? `(${m.modelTier})` : ""}
-                        </div>
-                      )}
+        {/* Other models from same developer */}
+        {sameDeveloper.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Other {developerEntity?.title ?? "Developer"} Models
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {sameDeveloper.length}
+              </span>
+            </h2>
+            <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+              {sameDeveloper
+                .sort((a, b) =>
+                  (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
+                )
+                .slice(0, 10)
+                .map((m) => (
+                  <div key={m.id} className="px-4 py-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <Link
+                        href={`/ai-models/${m.id}`}
+                        className="font-medium text-sm hover:text-primary transition-colors"
+                      >
+                        {m.title}
+                      </Link>
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        {m.releaseDate ?? (
+                          <span className="text-muted-foreground/40">&mdash;</span>
+                        )}
+                      </span>
                     </div>
-                  ))}
-                {sameDeveloper.length > 10 && (
-                  <div className="px-4 py-3 text-center">
-                    <span className="text-xs text-muted-foreground">
-                      Showing 10 of {sameDeveloper.length} models
-                    </span>
+                    {m.modelFamily && (
+                      <div className="text-xs text-muted-foreground/60 mt-0.5">
+                        {m.modelFamily}{" "}
+                        {m.modelTier ? `(${m.modelTier})` : ""}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            </section>
-          )}
+                ))}
+              {sameDeveloper.length > 10 && (
+                <div className="px-4 py-3 text-center">
+                  <span className="text-xs text-muted-foreground">
+                    Showing 10 of {sameDeveloper.length} models
+                  </span>
+                </div>
+              )}
+            </div>
+          </section>
+        )}
       </div>
     </EntityProfileShell>
   );

--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -20,10 +20,6 @@ import {
   getAiModelSignals,
 } from "@/components/coverage/coverage-score";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
-import {
-  fetchEntitySourcingSummary,
-  rollupVerdictFromSummary,
-} from "@/components/entity/entity-sourcing";
 import { BenchmarkScorecard } from "./benchmark-scorecard";
 
 export function generateStaticParams() {
@@ -59,9 +55,6 @@ export default async function AiModelDetailPage({
     if (canonical) permanentRedirect(`/ai-models/${canonical}`);
     return notFound();
   }
-
-  const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entity.stableId ?? entity.id, slug]);
-  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // Resolve developer
   const developerEntity = entity.developer
@@ -145,7 +138,7 @@ export default async function AiModelDetailPage({
   );
 
   const headerLinks = [
-    ...(entity.wikiId && getPageById(entity.id)
+    ...(entity.wikiId && getPageById(entity.wikiId)
       ? [{ label: "Wiki page", href: `/wiki/${entity.wikiId}` }]
       : []),
     { label: "Data", href: `/ai-models/${slug}/data` },
@@ -257,7 +250,6 @@ export default async function AiModelDetailPage({
       title={entity.title}
       titlePills={titlePills}
       coverage={{ score: coverageScore, signals: coverageSignals }}
-      verdict={rollupVerdict}
       subtitle={entity.description || undefined}
       headerLinks={headerLinks}
       statCards={statCards}

--- a/apps/web/src/app/ai-models/[slug]/tabs.tsx
+++ b/apps/web/src/app/ai-models/[slug]/tabs.tsx
@@ -1,0 +1,238 @@
+import Link from "next/link";
+import type { AiModelEntity } from "@/data";
+import { BenchmarkScorecard } from "./benchmark-scorecard";
+
+/**
+ * Per-tab content components for the AI model profile page. Each tab is a
+ * pure render function that takes the entity (and any related data) and
+ * returns a React node. Tabs without data are filtered out by ProfileTabs
+ * via the `count === 0` rule.
+ */
+
+function formatPrice(price: number): string {
+  return `$${price.toFixed(2)}`;
+}
+
+export function OverviewTab({ entity }: { entity: AiModelEntity }) {
+  const hasContent =
+    entity.modality.length > 0 || entity.capabilities.length > 0;
+
+  if (!hasContent) {
+    return (
+      <div className="border border-border/40 border-dashed rounded-xl px-6 py-10 text-center">
+        <p className="text-sm text-muted-foreground/60">
+          No additional overview information recorded yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {entity.modality.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Modality
+          </h3>
+          <p className="text-sm">{entity.modality.join(", ")}</p>
+        </section>
+      )}
+
+      {entity.capabilities.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Capabilities
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {entity.capabilities.length}
+            </span>
+          </h3>
+          <div className="flex flex-wrap gap-1.5">
+            {entity.capabilities.map((cap) => (
+              <span
+                key={cap}
+                className="inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-medium border border-border/60 bg-card text-muted-foreground"
+              >
+                {cap}
+              </span>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export function PricingTab({ entity }: { entity: AiModelEntity }) {
+  return (
+    <section>
+      <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th className="py-2.5 px-4 text-left font-medium">Type</th>
+              <th className="py-2.5 px-4 text-right font-medium">
+                Price per MTok
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {entity.inputPrice != null && (
+              <tr className="hover:bg-muted/20 transition-colors">
+                <td className="py-2.5 px-4">Input</td>
+                <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
+                  {formatPrice(entity.inputPrice)}
+                </td>
+              </tr>
+            )}
+            {entity.outputPrice != null && (
+              <tr className="hover:bg-muted/20 transition-colors">
+                <td className="py-2.5 px-4">Output</td>
+                <td className="py-2.5 px-4 text-right tabular-nums font-semibold">
+                  {formatPrice(entity.outputPrice)}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export function BenchmarksTab({ entity }: { entity: AiModelEntity }) {
+  return <BenchmarkScorecard benchmarks={entity.benchmarks} modelId={entity.id} />;
+}
+
+export function FamilyTab({
+  entity,
+  sameFamily,
+  sameDeveloper,
+  developerName,
+}: {
+  entity: AiModelEntity;
+  sameFamily: AiModelEntity[];
+  sameDeveloper: AiModelEntity[];
+  developerName: string;
+}) {
+  return (
+    <div className="space-y-8">
+      {sameFamily.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+            {entity.modelFamily} Family
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {sameFamily.length}
+            </span>
+          </h3>
+          <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                  <th className="py-2.5 px-4 text-left font-medium">Model</th>
+                  <th className="py-2.5 px-4 text-left font-medium">Tier</th>
+                  <th className="py-2.5 px-4 text-left font-medium">Released</th>
+                  <th className="py-2.5 px-4 text-right font-medium">
+                    Input $/MTok
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {sameFamily
+                  .sort((a, b) =>
+                    (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
+                  )
+                  .map((m) => (
+                    <tr
+                      key={m.id}
+                      className="hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="py-2.5 px-4">
+                        <Link
+                          href={`/ai-models/${m.id}`}
+                          className="font-medium hover:text-primary transition-colors"
+                        >
+                          {m.title}
+                        </Link>
+                      </td>
+                      <td className="py-2.5 px-4 text-muted-foreground capitalize">
+                        {m.modelTier ?? (
+                          <span className="text-muted-foreground/40">
+                            &mdash;
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2.5 px-4 text-muted-foreground">
+                        {m.releaseDate ?? (
+                          <span className="text-muted-foreground/40">
+                            &mdash;
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2.5 px-4 text-right tabular-nums">
+                        {m.inputPrice != null ? (
+                          formatPrice(m.inputPrice)
+                        ) : (
+                          <span className="text-muted-foreground/40">
+                            &mdash;
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {sameDeveloper.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+            Other {developerName} Models
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {sameDeveloper.length}
+            </span>
+          </h3>
+          <div className="border border-border/60 rounded-xl bg-card divide-y divide-border/40">
+            {sameDeveloper
+              .sort((a, b) =>
+                (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""),
+              )
+              .slice(0, 10)
+              .map((m) => (
+                <div key={m.id} className="px-4 py-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      href={`/ai-models/${m.id}`}
+                      className="font-medium text-sm hover:text-primary transition-colors"
+                    >
+                      {m.title}
+                    </Link>
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {m.releaseDate ?? (
+                        <span className="text-muted-foreground/40">
+                          &mdash;
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                  {m.modelFamily && (
+                    <div className="text-xs text-muted-foreground/60 mt-0.5">
+                      {m.modelFamily} {m.modelTier ? `(${m.modelTier})` : ""}
+                    </div>
+                  )}
+                </div>
+              ))}
+            {sameDeveloper.length > 10 && (
+              <div className="px-4 py-3 text-center">
+                <span className="text-xs text-muted-foreground">
+                  Showing 10 of {sameDeveloper.length} models
+                </span>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/ai-models/[slug]/tabs.tsx
+++ b/apps/web/src/app/ai-models/[slug]/tabs.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { AiModelEntity } from "@/data";
-import { BenchmarkScorecard } from "./benchmark-scorecard";
+import { BenchmarkScorecard } from "@/app/ai-models/[slug]/benchmark-scorecard";
 
 /**
  * Per-tab content components for the AI model profile page. Each tab is a

--- a/apps/web/src/app/organizations/[slug]/data/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/data/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
-import { OrgProfileHeader } from "../org-profile-header";
+import { buildOrgShellSlots } from "../org-profile-header";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 import { resolveOrgEntity, loadOrgHeaderData } from "../org-data";
 import { OrgDataBody } from "./org-data-body";
 
@@ -27,16 +32,18 @@ export default async function OrgDataPage({
 
   const { entity } = result;
   const headerData = loadOrgHeaderData(entity, slug);
+  const entityStableId = entity.stableId ?? entity.id;
+  const sourcingSummary = await fetchEntitySourcingSummary([entity.id, entityStableId, slug]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
+
+  const shellSlots = buildOrgShellSlots(
+    { ...headerData, verdict: rollupVerdict },
+    { activePage: "data", breadcrumbSuffix: "Data" },
+  );
 
   return (
-    <div className="max-w-[90rem] mx-auto px-6 py-8">
-      <OrgProfileHeader
-        data={headerData}
-        breadcrumbSuffix="Data"
-        activePage="data"
-      />
-
+    <EntityProfileShell {...shellSlots}>
       <OrgDataBody slug={slug} />
-    </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-profile-header.tsx
@@ -1,14 +1,14 @@
 import Link from "next/link";
-import { Breadcrumbs } from "@/components/directory";
-import { CoveragePopover } from "@/components/coverage/CoveragePopover";
-import { computeOrgCoverage, getOrgSignals, type OrgCoverageInput } from "@/components/coverage/coverage-score";
-import { SourcingDot } from "@/components/sourcing/SourcingDot";
-import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
+import {
+  computeOrgCoverage,
+  getOrgSignals,
+  type OrgCoverageInput,
+} from "@/components/coverage/coverage-score";
 import {
   formatKBDate,
   shortDomain,
 } from "@/components/wiki/factbase/format";
+import type { EntityProfileShellHeaderLink } from "@/components/entity/EntityProfileShell";
 import { safeHref } from "./org-shared";
 import {
   ORG_TYPE_LABELS,
@@ -20,9 +20,10 @@ import {
 } from "./org-data";
 
 /**
- * Shared profile header for organization pages.
- * Renders breadcrumbs, avatar, name, badges, metadata, and founders.
- * Used by both the main profile page and the /data sub-page.
+ * Shell-slot builder for organization profile pages.
+ *
+ * Turns an `OrgHeaderData` record into the prop bag that `EntityProfileShell`
+ * accepts. Used by both `/organizations/[slug]` and `/organizations/[slug]/data`.
  */
 
 export interface OrgHeaderData {
@@ -37,23 +38,35 @@ export interface OrgHeaderData {
   websiteUrl: string | null;
   wikiHref: string | null;
   founders: AuthorRef[];
-  /** Pre-computed coverage scoring input for the popover */
+  /** Pre-computed coverage scoring input. */
   coverageInput?: OrgCoverageInput;
-  /** Aggregate sourcing verdict for the entity (e.g. "confirmed", "contradicted") */
+  /** Aggregate sourcing verdict for the entity. */
   verdict?: string | null;
 }
 
-export function OrgProfileHeader({
-  data,
-  breadcrumbSuffix,
-  activePage,
-}: {
-  data: OrgHeaderData;
-  /** Extra breadcrumb segment after the entity name (e.g., "Data") */
-  breadcrumbSuffix?: string;
-  /** Which page is currently active: "profile" or "data" */
-  activePage?: "profile" | "data";
-}) {
+export interface OrgShellSlots {
+  entityId: string;
+  avatar: React.ReactNode;
+  title: string;
+  aliases: string[] | undefined;
+  titlePills: React.ReactNode;
+  coverage?: { score: number; signals: string[] };
+  verdict: string | null;
+  metadata: React.ReactNode;
+  headerLinks: EntityProfileShellHeaderLink[];
+  headerFooter: React.ReactNode;
+  breadcrumbs: Array<{ label: string; href?: string }>;
+}
+
+export function buildOrgShellSlots(
+  data: OrgHeaderData,
+  options: {
+    activePage?: "profile" | "data";
+    breadcrumbSuffix?: string;
+  } = {},
+): OrgShellSlots {
+  const { activePage, breadcrumbSuffix } = options;
+
   const initials = data.name
     .split(/[\s-]+/)
     .filter(Boolean)
@@ -62,143 +75,115 @@ export function OrgProfileHeader({
     .join("")
     .toUpperCase();
 
-  const breadcrumbItems: Array<{ label: string; href?: string }> = [
+  const avatar = (
+    <div
+      className="w-14 h-14 rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-xl font-bold text-primary/70"
+      aria-hidden="true"
+    >
+      {initials}
+    </div>
+  );
+
+  const titlePills = (
+    <>
+      {data.orgType && (
+        <Link
+          href={`/organizations?type=${data.orgType}`}
+          className={`px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider hover:opacity-80 transition-opacity ${
+            ORG_TYPE_COLORS[data.orgType] ?? DEFAULT_ORG_TYPE_COLOR
+          }`}
+        >
+          {ORG_TYPE_LABELS[data.orgType] ?? data.orgType}
+        </Link>
+      )}
+      {data.orgStatus && data.orgStatus in ORG_STATUS_COLORS && (
+        <span
+          className={`px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
+            ORG_STATUS_COLORS[data.orgStatus]
+          }`}
+        >
+          {ORG_STATUS_LABELS[data.orgStatus] ?? data.orgStatus}
+        </span>
+      )}
+    </>
+  );
+
+  const metadata = (
+    <>
+      {data.foundedDateStr && (
+        <span>
+          Founded {formatKBDate(data.foundedDateStr)}
+          {data.orgAge && <span suppressHydrationWarning> ({data.orgAge})</span>}
+        </span>
+      )}
+      {data.hqText && <span>HQ: {data.hqText}</span>}
+      {data.websiteUrl && (
+        <a
+          href={safeHref(data.websiteUrl)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:text-primary/80 font-medium transition-colors"
+        >
+          {shortDomain(data.websiteUrl)} &#8599;
+        </a>
+      )}
+    </>
+  );
+
+  const headerLinks: EntityProfileShellHeaderLink[] = [];
+  if (data.wikiHref) {
+    headerLinks.push({ label: "Wiki page", href: data.wikiHref });
+  }
+  headerLinks.push({
+    label: "Data",
+    href: `/organizations/${data.id}/data`,
+    active: activePage === "data",
+  });
+
+  const headerFooter = data.founders.length > 0 && (
+    <p className="text-sm text-muted-foreground">
+      Founded by{" "}
+      {data.founders.map((f, i) => (
+        <span key={i}>
+          {i > 0 && (i === data.founders.length - 1 ? ", and " : ", ")}
+          {f.href ? (
+            <Link href={f.href} className="text-primary hover:underline">
+              {f.name}
+            </Link>
+          ) : (
+            f.name
+          )}
+        </span>
+      ))}
+    </p>
+  );
+
+  const breadcrumbs: Array<{ label: string; href?: string }> = [
     { label: "Organizations", href: "/organizations" },
   ];
   if (breadcrumbSuffix) {
-    breadcrumbItems.push({
-      label: data.name,
-      href: `/organizations/${data.id}`,
-    });
-    breadcrumbItems.push({ label: breadcrumbSuffix });
+    breadcrumbs.push({ label: data.name, href: `/organizations/${data.id}` });
+    breadcrumbs.push({ label: breadcrumbSuffix });
   } else {
-    breadcrumbItems.push({ label: data.name });
+    breadcrumbs.push({ label: data.name });
   }
 
-  return (
-    <div className="mb-6">
-      <Breadcrumbs items={breadcrumbItems} />
-
-      <div className="flex items-start gap-5">
-        {/* Org avatar/icon */}
-        <div
-          className="shrink-0 w-14 h-14 rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-xl font-bold text-primary/70"
-          aria-hidden="true"
-        >
-          {initials}
-        </div>
-        <div className="min-w-0">
-          <div className="flex items-center gap-3 mb-1 flex-wrap">
-            <h1 className="text-2xl font-extrabold tracking-tight">
-              {data.name}
-            </h1>
-            {data.orgType && (
-              <Link
-                href={`/organizations?type=${data.orgType}`}
-                className={`px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider hover:opacity-80 transition-opacity ${
-                  ORG_TYPE_COLORS[data.orgType] ?? DEFAULT_ORG_TYPE_COLOR
-                }`}
-              >
-                {ORG_TYPE_LABELS[data.orgType] ?? data.orgType}
-              </Link>
-            )}
-            {data.orgStatus &&
-              data.orgStatus in ORG_STATUS_COLORS && (
-                <span
-                  className={`px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider ${
-                    ORG_STATUS_COLORS[data.orgStatus]
-                  }`}
-                >
-                  {ORG_STATUS_LABELS[data.orgStatus] ?? data.orgStatus}
-                </span>
-              )}
-            {data.coverageInput && (
-              <CoveragePopover
-                score={computeOrgCoverage(data.coverageInput)}
-                signals={getOrgSignals(data.coverageInput)}
-                size="md"
-              />
-            )}
-            <SourcingDot
-              status={recordVerdictToStatus(data.verdict)}
-              originalVerdict={data.verdict}
-              size="md"
-              href={getSourcingHref("entity", data.id)}
-            />
-          </div>
-          {data.aliases && data.aliases.length > 0 && (
-            <p className="text-xs text-muted-foreground/70 mb-0.5">
-              Also known as: {data.aliases.join(", ")}
-            </p>
-          )}
-
-          <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap">
-            {data.foundedDateStr && (
-              <span>
-                Founded {formatKBDate(data.foundedDateStr)}
-                {data.orgAge && (
-                  <span suppressHydrationWarning> ({data.orgAge})</span>
-                )}
-              </span>
-            )}
-            {data.hqText && <span>HQ: {data.hqText}</span>}
-            {data.websiteUrl && (
-              <a
-                href={safeHref(data.websiteUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                {shortDomain(data.websiteUrl)} &#8599;
-              </a>
-            )}
-
-            {/* Page navigation pills */}
-            <span className="flex items-center gap-1.5 ml-1">
-              {data.wikiHref && (
-                <Link
-                  href={data.wikiHref}
-                  className="px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors border text-muted-foreground border-border/50 hover:bg-muted/50"
-                >
-                  Wiki page
-                </Link>
-              )}
-              <Link
-                href={`/organizations/${data.id}/data`}
-                className={`px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors border ${
-                  activePage === "data"
-                    ? "bg-primary/10 text-primary border-primary/20"
-                    : "text-muted-foreground border-border/50 hover:bg-muted/50"
-                }`}
-              >
-                Data
-              </Link>
-            </span>
-          </div>
-
-          {data.founders.length > 0 && (
-            <p className="text-sm text-muted-foreground mt-1">
-              Founded by{" "}
-              {data.founders.map((f, i) => (
-                <span key={i}>
-                  {i > 0 &&
-                    (i === data.founders.length - 1 ? ", and " : ", ")}
-                  {f.href ? (
-                    <Link
-                      href={f.href}
-                      className="text-primary hover:underline"
-                    >
-                      {f.name}
-                    </Link>
-                  ) : (
-                    f.name
-                  )}
-                </span>
-              ))}
-            </p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+  return {
+    entityId: data.id,
+    avatar,
+    title: data.name,
+    aliases: data.aliases,
+    titlePills,
+    coverage: data.coverageInput
+      ? {
+          score: computeOrgCoverage(data.coverageInput),
+          signals: getOrgSignals(data.coverageInput),
+        }
+      : undefined,
+    verdict: data.verdict ?? null,
+    metadata,
+    headerLinks,
+    headerFooter,
+    breadcrumbs,
+  };
 }

--- a/apps/web/src/app/organizations/[slug]/org-tabs.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-tabs.tsx
@@ -1,7 +1,0 @@
-"use client";
-
-/**
- * Re-export ProfileTabs for backward compatibility with existing org page imports.
- */
-export { ProfileTabs as OrgProfileTabs } from "@/components/directory/ProfileTabs";
-export type { ProfileTab as OrgTab } from "@/components/directory/ProfileTabs";

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -25,7 +25,12 @@ import {
   FactsPanel,
 } from "@/components/directory";
 
-import { OrgProfileHeader } from "./org-profile-header";
+import { buildOrgShellSlots } from "./org-profile-header";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 import { RelatedPages } from "@/components/RelatedPages";
 
 // Shared components & helpers
@@ -102,7 +107,7 @@ import type { RpcGrantsByEntityResult } from "@/lib/wiki-server";
 import Markdown from "react-markdown";
 
 // Client-side tabs
-import { OrgProfileTabs, type OrgTab } from "./org-tabs";
+import { type OrgTab } from "./org-tabs";
 
 // ISR revalidation: refresh PG personnel data every hour (matches divisions/grants pages)
 export const revalidate = 3600;
@@ -150,9 +155,9 @@ export default async function OrgProfilePage({
   const { entity } = result;
   const data = loadOrgPageData(entity, slug);
 
-  // ── Fetch PG data (personnel + market data + grants) in parallel ──
+  // ── Fetch PG data (personnel + market data + grants + sourcing) in parallel ──
   const entityStableId = entity.stableId ?? entity.id;
-  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData] = await Promise.all([
+  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData, sourcingSummary] = await Promise.all([
     fetchPgPersonnel(entityStableId),
     fetchMarketData(entity.id),
     fetchFromWikiServer<RpcGrantsByEntityResult>(
@@ -163,7 +168,9 @@ export default async function OrgProfilePage({
       `/api/grants/by-entity/${encodeURIComponent(entityStableId)}?role=grantee&limit=1&offset=0`,
       { revalidate: 3600, timeoutMs: 10_000 },
     ),
+    fetchEntitySourcingSummary([entity.id, entityStableId, slug]),
   ]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // PG grants: check if wiki-server has grants for this org (as funder)
   if (!pgGrantsData && entityStableId) {
@@ -709,30 +716,30 @@ export default async function OrgProfilePage({
     wikiPageId: entity.wikiPageId,
   };
 
-  const headerData = {
-    id: entity.id,
-    name: entity.name,
-    aliases: entity.aliases,
-    orgType: data.orgType,
-    orgStatus: data.orgStatus,
-    foundedDateStr: data.foundedDateStr ?? null,
-    orgAge: data.orgAge ?? null,
-    hqText: data.hqText,
-    websiteUrl: data.websiteUrl,
-    wikiHref: data.wikiHref,
-    founders: data.founders,
-    coverageInput,
-    // entity has no sourcing verdicts yet; needs server-side roll-up from
-    // personnel/grant/division children (QUA-136)
-    verdict: null,
-  };
+  const shellSlots = buildOrgShellSlots(
+    {
+      id: entity.id,
+      name: entity.name,
+      aliases: entity.aliases,
+      orgType: data.orgType,
+      orgStatus: data.orgStatus,
+      foundedDateStr: data.foundedDateStr ?? null,
+      orgAge: data.orgAge ?? null,
+      hqText: data.hqText,
+      websiteUrl: data.websiteUrl,
+      wikiHref: data.wikiHref,
+      founders: data.founders,
+      coverageInput,
+      verdict: rollupVerdict,
+    },
+    { activePage: "profile" },
+  );
 
   return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8 overflow-x-hidden">
-      <OrgProfileHeader data={headerData} activePage="profile" />
-
-      {/* ── Tabbed content ─────────────────────────────────────── */}
-      <OrgProfileTabs tabs={tabs} ariaLabel="Organization sections" />
-    </div>
+    <EntityProfileShell
+      {...shellSlots}
+      tabs={tabs}
+      tabsAriaLabel="Organization sections"
+    />
   );
 }

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -106,8 +106,7 @@ import { fetchFromWikiServer } from "@/lib/wiki-server";
 import type { RpcGrantsByEntityResult } from "@/lib/wiki-server";
 import Markdown from "react-markdown";
 
-// Client-side tabs
-import { type OrgTab } from "./org-tabs";
+import type { ProfileTab as OrgTab } from "@/components/directory";
 
 // ISR revalidation: refresh PG personnel data every hour (matches divisions/grants pages)
 export const revalidate = 3600;

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -30,10 +30,6 @@ import {
   type ProfileTab,
 } from "@/components/directory";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
-import {
-  fetchEntitySourcingSummary,
-  rollupVerdictFromSummary,
-} from "@/components/entity/entity-sourcing";
 import { formatKBDate } from "@/components/wiki/factbase/format";
 import { getPersonEntityById, getTypedEntityById, isPerson } from "@/data";
 import type { Entity } from "@longterm-wiki/factbase";
@@ -231,14 +227,12 @@ export default async function PersonProfilePage({
 
   // Political data from wiki-server. Scores/offices/votes/finance are not yet
   // in database.json — see https://github.com/quantified-uncertainty/longterm-wiki/discussions/3639
-  const [politicalScores, politicalOffices, campaignFinance, politicalVotes, sourcingSummary] = await Promise.all([
+  const [politicalScores, politicalOffices, campaignFinance, politicalVotes] = await Promise.all([
     fetchPoliticalScores(entity.id),
     fetchPoliticalOffices(entity.id),
     fetchCampaignFinance(entity.id),
     fetchPoliticalVotes(entity.id),
-    fetchEntitySourcingSummary([entity.id, entity.stableId ?? entity.id, slug]),
   ]);
-  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
@@ -445,7 +439,6 @@ export default async function PersonProfilePage({
         score: computePersonCoverage(covInput),
         signals: getPersonSignals(covInput),
       }}
-      verdict={rollupVerdict}
       subtitle={subtitle}
       headerLinks={headerLinks}
       statCards={statCards}

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -26,11 +26,14 @@ import {
 } from "@/lib/directory-utils";
 import {
   ProfileStatCard,
-  Breadcrumbs,
   FactsPanel,
-  ProfileTabs,
   type ProfileTab,
 } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 import { formatKBDate } from "@/components/wiki/factbase/format";
 import { getPersonEntityById, getTypedEntityById, isPerson } from "@/data";
 import type { Entity } from "@longterm-wiki/factbase";
@@ -228,12 +231,14 @@ export default async function PersonProfilePage({
 
   // Political data from wiki-server. Scores/offices/votes/finance are not yet
   // in database.json — see https://github.com/quantified-uncertainty/longterm-wiki/discussions/3639
-  const [politicalScores, politicalOffices, campaignFinance, politicalVotes] = await Promise.all([
+  const [politicalScores, politicalOffices, campaignFinance, politicalVotes, sourcingSummary] = await Promise.all([
     fetchPoliticalScores(entity.id),
     fetchPoliticalOffices(entity.id),
     fetchCampaignFinance(entity.id),
     fetchPoliticalVotes(entity.id),
+    fetchEntitySourcingSummary([entity.id, entity.stableId ?? "", slug]),
   ]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
   // All facts for count
   const allFacts = getKBFacts(entity.id).filter(
@@ -381,115 +386,72 @@ export default async function PersonProfilePage({
     });
   }
 
-  return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      <Breadcrumbs
-        items={[
-          { label: "People", href: "/people" },
-          { label: entity.name },
-        ]}
-      />
+  const covInput = {
+    role: roleFact?.value.type === "text" ? roleFact.value.value : null,
+    employerId: employedByFact?.value.type === "ref" ? employedByFact.value.value : null,
+    bornYear: bornYearFact?.value.type === "number" ? bornYearFact.value.value : null,
+    netWorthNum: netWorthFact?.value.type === "number" ? netWorthFact.value.value : null,
+    positionCount: positions.length,
+    publicationCount: 0,
+    careerHistoryCount: careerHistory.length,
+    wikiPageId: entity.wikiPageId,
+  };
 
-      {/* Header */}
-      <div className="flex items-start gap-5 mb-8">
-        <div className="shrink-0 w-16 h-16 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-2xl font-bold text-primary/70">
-          {initials}
-        </div>
-        <div>
-          <div className="flex items-center gap-3 mb-1">
-            <h1 className="text-3xl font-extrabold tracking-tight">
-              {entity.name}
-            </h1>
-            {(() => {
-              const covInput = {
-                role: roleFact?.value.type === "text" ? roleFact.value.value : null,
-                employerId: employedByFact?.value.type === "ref" ? employedByFact.value.value : null,
-                bornYear: bornYearFact?.value.type === "number" ? bornYearFact.value.value : null,
-                netWorthNum: netWorthFact?.value.type === "number" ? netWorthFact.value.value : null,
-                positionCount: positions.length,
-                publicationCount: 0,
-                careerHistoryCount: careerHistory.length,
-                wikiPageId: entity.wikiPageId,
-              };
-              return (
-                <CoveragePopover
-                  score={computePersonCoverage(covInput)}
-                  signals={getPersonSignals(covInput)}
-                  size="md"
-                />
-              );
-            })()}
-          </div>
-          {entity.aliases && entity.aliases.length > 0 && (
-            <p className="text-sm text-muted-foreground/70 mb-1">
-              Also known as: {entity.aliases.join(", ")}
-            </p>
-          )}
-          {notableForFact?.value.type === "text" && (
-            <p className="text-sm text-muted-foreground max-w-2xl leading-relaxed">
-              {notableForFact.value.value}
-            </p>
-          )}
-          <div className="flex items-center gap-4 mt-2 text-sm">
-            {entityWebsite && safeHref(entityWebsite) !== "#" && (
-              <a
-                href={safeHref(entityWebsite)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  className="w-3.5 h-3.5"
-                  aria-hidden="true"
-                >
-                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
-                </svg>
-                Website &rarr;
-              </a>
-            )}
-            {wikiHref && (
-              <Link
-                href={wikiHref}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                Wiki page &rarr;
-              </Link>
-            )}
-            <Link
-              href={`/people/${slug}/data`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              Data &rarr;
-            </Link>
-          </div>
-        </div>
-      </div>
-
-      {/* Stat cards */}
-      {stats.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-          {stats.map((s) => (
-            <ProfileStatCard key={s.label} {...s} />
-          ))}
-        </div>
-      )}
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main content — tabbed */}
-        <div className="lg:col-span-2">
-          <ProfileTabs tabs={tabs} ariaLabel="Person sections" />
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-8">
-          <SocialLinks facts={socialLinkFacts} />
-          {allFacts.length > 0 && (
-            <FactsPanel facts={allFacts} entityId={entity.id} />
-          )}
-        </div>
-      </div>
+  const avatar = (
+    <div className="w-14 h-14 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-xl font-bold text-primary/70">
+      {initials}
     </div>
+  );
+
+  const headerLinks = [
+    ...(entityWebsite && safeHref(entityWebsite) !== "#"
+      ? [{ label: "Website", href: safeHref(entityWebsite), external: true }]
+      : []),
+    ...(wikiHref ? [{ label: "Wiki page", href: wikiHref }] : []),
+    { label: "Data", href: `/people/${slug}/data` },
+  ];
+
+  const subtitle =
+    notableForFact?.value.type === "text" ? notableForFact.value.value : null;
+
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
+    </div>
+  );
+
+  const sidebar = (
+    <>
+      <SocialLinks facts={socialLinkFacts} />
+      {allFacts.length > 0 && (
+        <FactsPanel facts={allFacts} entityId={entity.id} />
+      )}
+    </>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "People", href: "/people" },
+        { label: entity.name },
+      ]}
+      entityId={entity.id}
+      avatar={avatar}
+      title={entity.name}
+      aliases={entity.aliases}
+      coverage={{
+        score: computePersonCoverage(covInput),
+        signals: getPersonSignals(covInput),
+      }}
+      verdict={rollupVerdict}
+      subtitle={subtitle}
+      headerLinks={headerLinks}
+      statCards={statCards}
+      tabs={tabs}
+      tabsAriaLabel="Person sections"
+      sidebar={sidebar}
+    />
   );
 }

--- a/apps/web/src/app/people/[slug]/page.tsx
+++ b/apps/web/src/app/people/[slug]/page.tsx
@@ -236,7 +236,7 @@ export default async function PersonProfilePage({
     fetchPoliticalOffices(entity.id),
     fetchCampaignFinance(entity.id),
     fetchPoliticalVotes(entity.id),
-    fetchEntitySourcingSummary([entity.id, entity.stableId ?? "", slug]),
+    fetchEntitySourcingSummary([entity.id, entity.stableId ?? entity.id, slug]),
   ]);
   const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
@@ -398,7 +398,7 @@ export default async function PersonProfilePage({
   };
 
   const avatar = (
-    <div className="w-14 h-14 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-xl font-bold text-primary/70">
+    <div className="w-16 h-16 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-2xl font-bold text-primary/70">
       {initials}
     </div>
   );

--- a/apps/web/src/components/coverage/coverage-score.ts
+++ b/apps/web/src/components/coverage/coverage-score.ts
@@ -116,6 +116,17 @@ export function computeAiModelCoverage(row: AiModelCoverageInput): number {
   return 1;
 }
 
+export function getAiModelSignals(row: AiModelCoverageInput): string[] {
+  const signals: string[] = [];
+  if (row.inputPrice != null || row.outputPrice != null) signals.push("Pricing");
+  if (row.contextWindow != null) signals.push("Context window");
+  if (row.parameterCount) signals.push("Parameter count");
+  if (row.safetyLevel) signals.push("Safety level");
+  if ((row.benchmarkCount ?? 0) >= 3) signals.push("Benchmarks");
+  if (row.wikiId) signals.push("Wiki page");
+  return signals;
+}
+
 // ── Legislation scoring ─────────────────────────────────────────────
 
 export interface LegislationCoverageInput {

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -1,0 +1,212 @@
+import Link from "next/link";
+import {
+  Breadcrumbs,
+  ProfileTabs,
+  type ProfileTab,
+} from "@/components/directory";
+import { CoveragePopover } from "@/components/coverage/CoveragePopover";
+import { SourcingDot } from "@/components/sourcing/SourcingDot";
+import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
+
+/**
+ * `EntityProfileShell` is the canonical layout for every entity profile page
+ * (organizations, people, ai-models, projects, etc.). It renders the outer
+ * container, breadcrumbs, header (title + pills + coverage + sourcing
+ * rollup badge), optional stat cards, and either a `ProfileTabs` block or free
+ * body content, with an optional right-hand sidebar.
+ *
+ * Per-entity-type pages provide slot content via props. Adding a new item that
+ * should appear on all entity pages (a new badge, a new header row, etc.) is a
+ * one-line edit to this file.
+ *
+ * Sourcing rollup badge: pass `verdict` (a raw sourcing verdict string,
+ * typically obtained via `fetchEntitySourcingSummary` + `rollupVerdictFromSummary`).
+ * The shell renders a single `SourcingDot` from one code path.
+ */
+
+export interface EntityProfileShellHeaderLink {
+  label: string;
+  href: string;
+  /** If true, renders as <a target="_blank"> instead of <Link> */
+  external?: boolean;
+  /** Highlights the link — used for the currently-active sub-page (e.g. Data) */
+  active?: boolean;
+}
+
+export interface EntityProfileShellProps {
+  // ── Navigation ──────────────────────────────────────────────────────
+  breadcrumbs: Array<{ label: string; href?: string }>;
+
+  // ── Header ──────────────────────────────────────────────────────────
+  /** Entity identifier passed to SourcingDot (`getSourcingHref("entity", entityId)`). */
+  entityId: string;
+  /** Optional avatar node (e.g. initials circle). Omitted when null/undefined. */
+  avatar?: React.ReactNode;
+  /** Main entity title. */
+  title: string;
+  /** Aliases rendered below the title row as "Also known as: ..." */
+  aliases?: string[];
+  /** Badges/pills rendered on the same row as the title (type, status, etc.). */
+  titlePills?: React.ReactNode;
+  /**
+   * Data-coverage score (1-4) and its signal list. When provided, the shell
+   * renders a `CoveragePopover` next to the title row.
+   */
+  coverage?: { score: number; signals: string[] };
+  /**
+   * Aggregate sourcing rollup verdict ("confirmed" | "contradicted" | ...).
+   * Use `null` for "unchecked"/no data. The shell always renders a SourcingDot
+   * so every entity page has a visible sourcing badge.
+   */
+  verdict?: string | null;
+  /** Subtitle/description block rendered immediately below the title row. */
+  subtitle?: React.ReactNode;
+  /** Metadata row — founded date, HQ, website, etc. */
+  metadata?: React.ReactNode;
+  /**
+   * Links row — wiki page, Data sub-page, external website, etc. Each is
+   * rendered as a compact pill.
+   */
+  headerLinks?: EntityProfileShellHeaderLink[];
+  /** Extra content below the header (e.g. founders list). */
+  headerFooter?: React.ReactNode;
+
+  // ── Body ────────────────────────────────────────────────────────────
+  /** Stat cards row rendered between the header and the main body. */
+  statCards?: React.ReactNode;
+  /** When provided, the shell renders a `ProfileTabs` block in the main column. */
+  tabs?: ProfileTab[];
+  tabsAriaLabel?: string;
+  /**
+   * Body content for the main column. Used when the page has no tabs, or
+   * when tabs are passed and additional content should render below them.
+   */
+  children?: React.ReactNode;
+  /**
+   * Right-hand sidebar. When non-null, the main body renders in a 3-col grid
+   * (main col = 2/3, sidebar = 1/3). When absent, body is full-width.
+   */
+  sidebar?: React.ReactNode;
+}
+
+export function EntityProfileShell({
+  breadcrumbs,
+  entityId,
+  avatar,
+  title,
+  aliases,
+  titlePills,
+  coverage,
+  verdict,
+  subtitle,
+  metadata,
+  headerLinks,
+  headerFooter,
+  statCards,
+  tabs,
+  tabsAriaLabel = "Entity sections",
+  children,
+  sidebar,
+}: EntityProfileShellProps) {
+  const hasTabs = tabs && tabs.length > 0;
+
+  const mainContent = (
+    <>
+      {hasTabs && <ProfileTabs tabs={tabs} ariaLabel={tabsAriaLabel} />}
+      {children}
+    </>
+  );
+
+  return (
+    <div className="max-w-[70rem] mx-auto px-6 py-8 overflow-x-hidden">
+      <Breadcrumbs items={breadcrumbs} />
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-start gap-5">
+          {avatar != null && <div className="shrink-0">{avatar}</div>}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-3 mb-1 flex-wrap">
+              <h1 className="text-2xl font-extrabold tracking-tight">{title}</h1>
+              {titlePills}
+              {coverage && (
+                <CoveragePopover
+                  score={coverage.score}
+                  signals={coverage.signals}
+                  size="md"
+                />
+              )}
+              <SourcingDot
+                status={recordVerdictToStatus(verdict ?? null)}
+                originalVerdict={verdict ?? null}
+                size="md"
+                href={getSourcingHref("entity", entityId)}
+              />
+            </div>
+
+            {aliases && aliases.length > 0 && (
+              <p className="text-xs text-muted-foreground/70 mb-0.5">
+                Also known as: {aliases.join(", ")}
+              </p>
+            )}
+
+            {subtitle && (
+              <div className="text-sm text-muted-foreground max-w-3xl leading-relaxed mt-1">
+                {subtitle}
+              </div>
+            )}
+
+            {(metadata || (headerLinks && headerLinks.length > 0)) && (
+              <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap mt-2">
+                {metadata}
+                {headerLinks && headerLinks.length > 0 && (
+                  <span className="flex items-center gap-1.5 ml-1">
+                    {headerLinks.map((link) => {
+                      const className = `px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors border ${
+                        link.active
+                          ? "bg-primary/10 text-primary border-primary/20"
+                          : "text-muted-foreground border-border/50 hover:bg-muted/50"
+                      }`;
+                      if (link.external) {
+                        return (
+                          <a
+                            key={link.href}
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={className}
+                          >
+                            {link.label}
+                          </a>
+                        );
+                      }
+                      return (
+                        <Link key={link.href} href={link.href} className={className}>
+                          {link.label}
+                        </Link>
+                      );
+                    })}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {headerFooter && <div className="mt-1">{headerFooter}</div>}
+          </div>
+        </div>
+      </div>
+
+      {statCards && <div className="mb-8">{statCards}</div>}
+
+      {sidebar != null ? (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-2 min-w-0">{mainContent}</div>
+          <div className="space-y-8">{sidebar}</div>
+        </div>
+      ) : (
+        mainContent
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -171,7 +171,7 @@ export function EntityProfileShell({
                       if (link.external) {
                         return (
                           <a
-                            key={link.href}
+                            key={link.label}
                             href={link.href}
                             target="_blank"
                             rel="noopener noreferrer"
@@ -182,7 +182,7 @@ export function EntityProfileShell({
                         );
                       }
                       return (
-                        <Link key={link.href} href={link.href} className={className}>
+                        <Link key={link.label} href={link.href} className={className}>
                           {link.label}
                         </Link>
                       );

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -137,12 +137,14 @@ export function EntityProfileShell({
                   size="md"
                 />
               )}
-              <SourcingDot
-                status={recordVerdictToStatus(verdict ?? null)}
-                originalVerdict={verdict ?? null}
-                size="md"
-                href={getSourcingHref("entity", entityId)}
-              />
+              {verdict !== undefined && (
+                <SourcingDot
+                  status={recordVerdictToStatus(verdict ?? null)}
+                  originalVerdict={verdict ?? null}
+                  size="md"
+                  href={getSourcingHref("entity", entityId)}
+                />
+              )}
             </div>
 
             {aliases && aliases.length > 0 && (

--- a/apps/web/src/components/entity/__tests__/entity-sourcing.test.ts
+++ b/apps/web/src/components/entity/__tests__/entity-sourcing.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { rollupVerdictFromSummary } from "../entity-sourcing";
+
+const zeroCounts = {
+  confirmed: 0,
+  contradicted: 0,
+  outdated: 0,
+  partial: 0,
+  unverifiable: 0,
+  unchecked: 0,
+};
+
+describe("rollupVerdictFromSummary", () => {
+  it("returns null for null summary", () => {
+    expect(rollupVerdictFromSummary(null)).toBeNull();
+    expect(rollupVerdictFromSummary(undefined)).toBeNull();
+  });
+
+  it("returns null when all verdict counts are zero", () => {
+    expect(rollupVerdictFromSummary(zeroCounts)).toBeNull();
+  });
+
+  it("returns the only verdict when only one is present", () => {
+    expect(rollupVerdictFromSummary({ ...zeroCounts, confirmed: 5 })).toBe(
+      "confirmed",
+    );
+    expect(rollupVerdictFromSummary({ ...zeroCounts, contradicted: 1 })).toBe(
+      "contradicted",
+    );
+    expect(rollupVerdictFromSummary({ ...zeroCounts, unchecked: 10 })).toBe(
+      "unchecked",
+    );
+  });
+
+  it("prefers contradicted over all other verdicts", () => {
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 100,
+        contradicted: 1,
+        outdated: 10,
+        partial: 5,
+        unverifiable: 3,
+        unchecked: 50,
+      }),
+    ).toBe("contradicted");
+  });
+
+  it("prefers outdated over partial/unverifiable/confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 10,
+        outdated: 1,
+        partial: 5,
+        unverifiable: 3,
+        unchecked: 50,
+      }),
+    ).toBe("outdated");
+  });
+
+  it("prefers partial over unverifiable/confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 10,
+        partial: 1,
+        unverifiable: 3,
+        unchecked: 50,
+      }),
+    ).toBe("partial");
+  });
+
+  it("prefers unverifiable over confirmed/unchecked", () => {
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 10,
+        unverifiable: 1,
+        unchecked: 50,
+      }),
+    ).toBe("unverifiable");
+  });
+
+  it("prefers confirmed over unchecked", () => {
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 1,
+        unchecked: 50,
+      }),
+    ).toBe("confirmed");
+  });
+
+  it("ignores extra fields beyond the required verdict counts", () => {
+    // Caller may pass the full RpcEntitySummaryRow; rollup should still work
+    expect(
+      rollupVerdictFromSummary({
+        ...zeroCounts,
+        confirmed: 3,
+        // Simulate additional fields from the upstream row
+        entityId: "anthropic",
+        totalVerdicts: 3,
+        avgConfidence: 0.9,
+        totalRecords: 7,
+      } as Parameters<typeof rollupVerdictFromSummary>[0]),
+    ).toBe("confirmed");
+  });
+});

--- a/apps/web/src/components/entity/entity-sourcing.ts
+++ b/apps/web/src/components/entity/entity-sourcing.ts
@@ -1,0 +1,60 @@
+import { fetchFromWikiServer, type RpcEntitySummaryRow, type RpcEntitySummaryResult } from "@/lib/wiki-server";
+import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
+
+/**
+ * Fetches the per-entity sourcing summary for a single entity from the
+ * wiki-server `/api/sourcing/entity-summary` endpoint.
+ *
+ * The upstream endpoint returns ALL entity summaries in one call — Next.js ISR
+ * caches that response for `revalidateSeconds` so subsequent per-page calls
+ * share a single fetch.
+ *
+ * The upstream row's `entityId` may be either a slug or a stableId depending
+ * on how each verdict was recorded. Pass any known identifiers for the
+ * entity (slug, stableId, numericId) and the helper will match on any.
+ */
+export async function fetchEntitySourcingSummary(
+  candidateIds: string | readonly string[],
+  { revalidateSeconds = 300 }: { revalidateSeconds?: number } = {},
+): Promise<RpcEntitySummaryRow | null> {
+  const ids = Array.isArray(candidateIds) ? candidateIds : [candidateIds];
+  const filtered = ids.filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (filtered.length === 0) return null;
+  const result = await fetchFromWikiServer<RpcEntitySummaryResult>(
+    "/api/sourcing/entity-summary",
+    { revalidate: revalidateSeconds, timeoutMs: 10_000 },
+  );
+  if (!result) return null;
+  const idSet = new Set(filtered);
+  return result.summaries.find((row) => idSet.has(row.entityId)) ?? null;
+}
+
+/**
+ * Reduces a per-entity verdict count row to a single rollup verdict, preferring
+ * the most actionable verdict present (contradicted > outdated > partial > ...).
+ * Returns null when no verdicts are recorded.
+ */
+export function rollupVerdictFromSummary(
+  summary: Pick<
+    RpcEntitySummaryRow,
+    "confirmed" | "contradicted" | "outdated" | "partial" | "unverifiable" | "unchecked"
+  > | null | undefined,
+): string | null {
+  if (!summary) return null;
+  const counts: Array<[string, number]> = [
+    ["contradicted", summary.contradicted],
+    ["outdated", summary.outdated],
+    ["partial", summary.partial],
+    ["unverifiable", summary.unverifiable],
+    ["confirmed", summary.confirmed],
+    ["unchecked", summary.unchecked],
+  ];
+  const present = counts.filter(([, n]) => n > 0);
+  if (present.length === 0) return null;
+  present.sort(
+    ([a], [b]) =>
+      (SOURCE_CHECK_VERDICT_PRIORITY[a] ?? 99) -
+      (SOURCE_CHECK_VERDICT_PRIORITY[b] ?? 99),
+  );
+  return present[0][0];
+}

--- a/apps/web/src/components/entity/entity-sourcing.ts
+++ b/apps/web/src/components/entity/entity-sourcing.ts
@@ -1,29 +1,46 @@
+import { cache } from "react";
 import { fetchFromWikiServer, type RpcEntitySummaryRow, type RpcEntitySummaryResult } from "@/lib/wiki-server";
 import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
 
+const SUMMARY_REVALIDATE_SECONDS = 300;
+
 /**
- * Fetches the per-entity sourcing summary for a single entity from the
- * wiki-server `/api/sourcing/entity-summary` endpoint.
+ * Fetches the full `/api/sourcing/entity-summary` response once per request.
  *
- * The upstream endpoint returns ALL entity summaries in one call — Next.js ISR
- * caches that response for `revalidateSeconds` so subsequent per-page calls
- * share a single fetch.
+ * Wrapped in React's per-request `cache()` so concurrent entity-profile page
+ * renders in the same build/ISR pass share one network fetch instead of
+ * each triggering their own (the upstream endpoint returns ALL entity
+ * summaries, so per-page scatter-fetching is wasteful).
+ *
+ * Next.js ISR also caches the underlying `fetch()` across requests for
+ * `SUMMARY_REVALIDATE_SECONDS` (5 minutes), so successive builds also share
+ * the result at the HTTP layer. Returns null when the wiki-server is
+ * unreachable (fetchFromWikiServer catches network/HTTP errors internally).
+ */
+const fetchSourcingSummaryList = cache(
+  async (): Promise<RpcEntitySummaryResult | null> =>
+    fetchFromWikiServer<RpcEntitySummaryResult>(
+      "/api/sourcing/entity-summary",
+      { revalidate: SUMMARY_REVALIDATE_SECONDS, timeoutMs: 10_000 },
+    ),
+);
+
+/**
+ * Looks up the sourcing summary row for a single entity.
  *
  * The upstream row's `entityId` may be either a slug or a stableId depending
- * on how each verdict was recorded. Pass any known identifiers for the
- * entity (slug, stableId, numericId) and the helper will match on any.
+ * on how each verdict was recorded. Pass any known identifiers for the entity
+ * (slug, stableId, numericId) and the helper will match on any.
  */
 export async function fetchEntitySourcingSummary(
   candidateIds: string | readonly string[],
-  { revalidateSeconds = 300 }: { revalidateSeconds?: number } = {},
 ): Promise<RpcEntitySummaryRow | null> {
   const ids = Array.isArray(candidateIds) ? candidateIds : [candidateIds];
-  const filtered = ids.filter((id): id is string => typeof id === "string" && id.length > 0);
-  if (filtered.length === 0) return null;
-  const result = await fetchFromWikiServer<RpcEntitySummaryResult>(
-    "/api/sourcing/entity-summary",
-    { revalidate: revalidateSeconds, timeoutMs: 10_000 },
+  const filtered = ids.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
   );
+  if (filtered.length === 0) return null;
+  const result = await fetchSourcingSummaryList();
   if (!result) return null;
   const idSet = new Set(filtered);
   return result.summaries.find((row) => idSet.has(row.entityId)) ?? null;


### PR DESCRIPTION
## Summary

Replaces hand-rolled profile layouts for `/organizations/[slug]`, `/organizations/[slug]/data`, `/people/[slug]`, and `/ai-models/[slug]` with a single canonical `EntityProfileShell` server component.

The shell owns: outer container, breadcrumbs, header (title + type pills + coverage popover + sourcing rollup badge), stat cards, optional `ProfileTabs`, and an optional right-hand sidebar. Adding a new "show on every entity page" item is a one-line edit to `EntityProfileShell.tsx` instead of editing three page files.

The sourcing rollup badge is wired through a new `fetchEntitySourcingSummary` + `rollupVerdictFromSummary` pair. The fetch is wrapped in React `cache()` so concurrent page renders share one in-flight request to `/api/sourcing/entity-summary` (unblocked by QUA-327 in #4232). Every profile page now renders a `SourcingDot` from one code path.

Replaces the per-page work previously tracked by QUA-117, QUA-194, QUA-152, and QUA-205 — those tickets only existed because the layout wasn't shared.

## Key changes

- **New**: `apps/web/src/components/entity/EntityProfileShell.tsx` — the shared shell (server component, slot-based API).
- **New**: `apps/web/src/components/entity/entity-sourcing.ts` — `fetchEntitySourcingSummary()` (ISR + React `cache()` dedup) and `rollupVerdictFromSummary()` (priority-ordered verdict reducer).
- **New**: `getAiModelSignals()` in `coverage-score.ts` — matches the existing `getOrgSignals` / `getPersonSignals` pattern so inline signal lists don't drift from scorers.
- **New**: `.claude/rules/entity-profile-pages.md` — explains the shell pattern for future entity-type work.
- **Migrated**: the 4 profile pages (org, org/data, person, ai-model) to use the shell. `org-profile-header.tsx` is refactored into a `buildOrgShellSlots()` slot builder used by both org profile and `/data` sub-pages.
- **Deleted**: dead `org-tabs.tsx` pass-through — `ProfileTab` type now imported directly from `@/components/directory`.
- **Tests**: 9 new unit tests for `rollupVerdictFromSummary` covering null/empty/priority-ordering/extra-fields.

## Test plan

- [x] `pnpm build` exits 0 (full Next.js build for ~2200 wiki pages + all entity profiles)
- [x] `pnpm test` — 1458 tests pass (9 new)
- [x] `pnpm crux w validate gate --no-cache` — 47/47 checks pass (4 advisory)
- [x] Typecheck clean for apps/web
- [x] Playwright `e2e/render-audit.spec.ts` passes against local build for all 3 entity types
- [x] Ad-hoc Playwright smoke of `/organizations/anthropic`, `/organizations/anthropic?tab=people`, `/organizations/anthropic?tab=funding`, `/organizations/anthropic/data`, `/organizations/openai`, `/organizations/google-deepmind`, `/people/sam-altman`, `/people/dario-amodei`, `/people/demis-hassabis`, `/ai-models/claude-opus-4`, `/ai-models/gpt-4` — all 200, breadcrumbs present, sourcing dot rendered, no page errors
- [x] `/agent-review-pr` — 15 findings, 8 fixed, 4 documented, 3 dismissed (see commit `85a02eb`)
- [x] Sourcing lint guard at baseline (7/7)

## Notes

- The shell **adds** a sourcing dot to people and ai-models pages (previously only orgs had one). Per the QUA-328 acceptance criteria ("Source-check rollup badge renders from a single code path"), this is intentional — every entity page now shows a consistent badge.
- The `/organizations/[slug]/data` sub-page is also migrated, to validate the `children` + `breadcrumbSuffix` slot pattern.
- `org-profile-header.tsx` still lives under `organizations/[slug]` because its slots are organization-specific (orgType pills, founders list, HQ row). Future entity types with rich type-specific headers should follow the same "slot builder" pattern rather than inline JSX in the page.

Fixes QUA-328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared Entity Profile Shell to standardize profile pages and a tabbed layout for AI model, organization, and people profiles.
  * Added AI-model coverage signals and visible sourcing verdict indicators on entity pages.

* **Refactor**
  * Migrated per-entity page layouts to the new shell and moved page sections into tabs and slot-based props.

* **Documentation**
  * Added guidelines for using the Entity Profile Shell.

* **Tests**
  * Added unit tests for sourcing verdict rollup and extended render-audit routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->