### PR TITLE
fix(agent-ship): require .claude/simplify-done marker for large PRs

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -122,6 +122,7 @@ Remove untracked session artifacts and discard any unstaged changes (modified ho
 ```bash
 rm -f .claude/wip-checklist.md .claude/wip-context.md
 git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/simplify-done 2>/dev/null || rm -f .claude/simplify-done
 git checkout -- .claude/hooks/ 2>/dev/null || true
 ```
 

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -80,6 +80,39 @@ Print this message and run the review:
 
 If the review marker is valid (SHA + diff hash match HEAD), continue without re-running.
 
+### Simplify marker check (PRs with ≥200 lines changed)
+
+`/agent-review-pr` does one simplification pass as part of its adaptive plan. For larger PRs, a dedicated `/simplify` pass is still required — otherwise a token "simplification" slipped into review fixes can satisfy the review marker without a real pass. Enforce this only when the diff is big enough to make a second pass worthwhile.
+
+Reuse the lines-changed count from the top of Step 2b. If `lines changed < 200`, print `Simplify: skipped (PR below 200-line threshold)` and continue. Otherwise check the marker the same way as review-done:
+
+```bash
+if [ -f .claude/simplify-done ]; then
+  MARKER_SHA=$(awk '{print $2}' .claude/simplify-done)
+  MARKER_HASH=$(awk '{print $4}' .claude/simplify-done)
+  HEAD_SHA=$(git rev-parse HEAD)
+  CURRENT_HASH=$(git diff $(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)...HEAD | shasum -a 256 | cut -c1-12)
+  if [ "$MARKER_SHA" = "$HEAD_SHA" ] && [ -n "$MARKER_HASH" ] && [ "$MARKER_HASH" = "$CURRENT_HASH" ]; then
+    echo "SIMPLIFIED (SHA + diff hash match)"
+  elif [ "$MARKER_SHA" != "$HEAD_SHA" ]; then
+    echo "STALE (marker SHA ${MARKER_SHA:0:8} != HEAD ${HEAD_SHA:0:8}) — re-run /simplify"
+  else
+    echo "STALE (diff hash mismatch) — re-run /simplify"
+  fi
+else
+  echo "NOT_SIMPLIFIED — run /simplify before /agent-ship"
+fi
+```
+
+**If the marker is missing or stale, stop and run `/simplify`.** Do not ship without it. After `/simplify` completes and any resulting changes are committed, write the marker against the final state:
+
+```bash
+DIFF_HASH=$(git diff $(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)...HEAD | shasum -a 256 | cut -c1-12)
+echo "simplified $(git rev-parse HEAD) $(date -u +%Y-%m-%dT%H:%M:%SZ) ${DIFF_HASH}" >| .claude/simplify-done
+```
+
+The `simplify` skill is a system skill and cannot be edited from this repo, so the marker must be written by hand after running it. Below the 200-line threshold the marker is optional; at or above it, it is required to ship. Rationale for 200 (vs. the gate's 300-line review threshold): `/simplify` is cheaper than `/agent-review-pr` and earlier enforcement catches mid-sized PRs before they grow.
+
 ## Step 3: Complete unchecked items
 
 For each unchecked item in the checklist:
@@ -204,6 +237,7 @@ Clean up session artifacts and discard any unstaged changes (modified hooks, del
 ```bash
 rm -f .claude/wip-checklist.md .claude/wip-context.md
 git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/simplify-done 2>/dev/null || rm -f .claude/simplify-done
 git checkout -- .claude/hooks/ 2>/dev/null || true
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ crux/coverage/
 .claude/session.pid
 .claude/last-heartbeat
 .claude/review-done
+.claude/simplify-done
 .claude/worktree-cleanup.log
 .claude/worktrees/
 .claude/backups/

--- a/crux/commands/agent-reset.ts
+++ b/crux/commands/agent-reset.ts
@@ -355,6 +355,16 @@ function scanCleanupItems(): CleanupItem[] {
     });
   }
 
+  // Stale simplify marker
+  const simplifyDonePath = join(process.cwd(), '.claude', 'simplify-done');
+  if (existsSync(simplifyDonePath)) {
+    items.push({
+      category: 'checklist',
+      description: 'Stale simplify marker (.claude/simplify-done)',
+      detail: simplifyDonePath,
+    });
+  }
+
   // Stale context file
   const contextPath = join(process.cwd(), '.claude', 'wip-context.md');
   if (existsSync(contextPath)) {


### PR DESCRIPTION
## Summary

- `/agent-ship` Step 2b now checks for `.claude/simplify-done` when `lines changed >= 200`, mirroring the existing `.claude/review-done` scheme (SHA + diff-hash validation, stale detection).
- `/agent-end` and `/agent-ship` session cleanup remove the marker alongside `review-done`.
- `crux sys agent-reset` scans for a stale `simplify-done` as a cleanup candidate.
- `.claude/simplify-done` added to `.gitignore`.

## Why

QUA-330. Unenforced phases get skipped — QUA-64 review found a token simplification merged into MEDIUM fixes; the user caught it manually. `/agent-review-pr` had a non-skippable marker check; `/simplify` didn't. This closes the gap for PRs large enough to warrant a dedicated simplification pass.

## Design notes

- **Threshold: 200 lines changed.** The existing review-marker gate fires at >5 files OR >300 lines. `/simplify` is cheaper than `/agent-review-pr`, so a lower threshold catches mid-sized PRs before they grow. Only lines are checked (no file threshold) to keep the rule simple.
- **Marker format mirrors review-done exactly.** `simplified <SHA> <ISO-timestamp> <12-char diff-hash>`. Same invalidation rules (SHA changes, diff changes).
- **The `/simplify` skill is a built-in system skill** — not in `.claude/commands/`, not in any installed plugin under `~/.claude/plugins/`. It cannot be edited from this repo, so the marker is written manually by the agent after running the skill. agent-ship.md spells out the one-liner. A follow-up could move simplify into a project-local command so the write happens automatically; noted but out of scope.
- Below threshold: the check prints `Simplify: skipped (PR below 200-line threshold)` and continues. No behavior change for small PRs.

## Test plan
- [x] Frontmatter/markdown still parses (verified `head -20 agent-ship.md`)
- [x] `crux/commands/agent-reset.ts` type-checks clean (pre-existing baseline errors elsewhere, none in changed file)
- [x] No new tests required — markdown skills have no test harness; agent-reset change is a mechanical add of a path-existence check mirroring the review-done one

Fixes QUA-330
