### PR TITLE
refactor(tablebase): convert 3 pilot routes to v2 factory shorthand

### DIFF
--- a/apps/wiki-server/src/routes/tablebase/divisions.ts
+++ b/apps/wiki-server/src/routes/tablebase/divisions.ts
@@ -55,6 +55,8 @@ const SyncDivisionItemSchema = z.object({
   sourcing: InlineSourcingSchema.optional(),
 });
 
+// Batch schema keeps both `id` and `slug` uniqueness refinements.
+// `naturalKey` could cover one, but not both, so we stay on batchSchema.
 const SyncDivisionsBatchSchema = z.object({
   items: z
     .array(SyncDivisionItemSchema)
@@ -197,22 +199,10 @@ const divisionsApp = new Hono()
       table: divisions,
       batchSchema: SyncDivisionsBatchSchema,
       enforceSourcing: true,
-      toRow: (item) => ({
-        id: item.id,
-        slug: item.slug ?? null,
-        parentOrgId: item.parentOrgId,
-        name: item.name,
-        divisionType: item.divisionType,
-        lead: item.lead ?? null,
-        status: item.status ?? null,
-        startDate: item.startDate ?? null,
-        endDate: item.endDate ?? null,
-        website: item.website ?? null,
-        source: item.source ?? null,
-        notes: item.notes ?? null,
-      }),
-      // COALESCE preservation: preserve existing values when sync payload sends null.
-      // This is the only escape hatch divisions needs (its 1-hook budget per Phase 0 audit).
+      entityRefs: ["parentOrgId"],
+      // COALESCE preservation: preserve existing values when sync payload
+      // sends null. Conflicts with the auto-derived SET clause, so we
+      // override it here (divisions' 1-hook escape hatch per Phase 0 audit).
       conflictSet: {
         slug: sql`excluded.slug`,
         parentOrgId: sql`excluded.parent_org_id`,
@@ -228,9 +218,6 @@ const divisionsApp = new Hono()
         syncedAt: sql`now()`,
         updatedAt: sql`now()`,
       },
-      entityRefFields: (items) => [
-        { fieldName: "parentOrgId", ids: items.map((i) => i.parentOrgId) },
-      ],
       thingsTitleIds: (items) => [...new Set(items.map((d) => d.parentOrgId))],
       toThing: (item, titleMap) => ({
         id: item.id,

--- a/apps/wiki-server/src/routes/tablebase/personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/personnel.ts
@@ -71,6 +71,9 @@ const SyncPersonnelItemSchema = z.object({
   claimIds: z.array(z.number().int().positive()).optional(),
 });
 
+// Batch schema retains the `noDuplicateIds` refinement. `naturalKey`
+// covers the (personId, organizationId, role, roleType) composite, so
+// we can't also use it for the id-level dedup check.
 const SyncPersonnelBatchSchema = z.object({
   items: z
     .array(SyncPersonnelItemSchema)
@@ -352,15 +355,17 @@ const personnelApp = new Hono<{ Variables: ResolvedEntityVars }>()
         `${item.personId}::${item.organizationId}::${item.role}::${item.roleType}`,
       naturalKeyError:
         "Duplicate (personId, organizationId, role, roleType) in batch — each personnel record must be unique by person + org + role",
-      entityRefFields: (items) => [
-        { fieldName: "personId", ids: items.map((i) => i.personId) },
-        { fieldName: "organizationId", ids: items.map((i) => i.organizationId) },
-      ],
+      entityRefs: ["personId", "organizationId"],
       auditRecordType: "personnel",
       claimSupport: {
         recordType: "personnel",
         getClaimIds: (item) => item.claimIds ?? [],
       },
+      // toRow is kept so the auto-derived SET clause only touches fields
+      // owned by the sync payload. Dropping it would let the default mapper
+      // include personEntityId/personDisplayName/orgEntityId/orgDisplayName
+      // (which are NOT in the item schema), null them on upsert, and
+      // temporarily clobber state before fkResolve re-populates them.
       toRow: (item) => ({
         id: item.id,
         personId: item.personId,

--- a/apps/wiki-server/src/routes/tablebase/political-scores.ts
+++ b/apps/wiki-server/src/routes/tablebase/political-scores.ts
@@ -17,19 +17,6 @@ import { createSyncHandler } from "./sync-factory.js";
 
 const MAX_PAGE_SIZE = 500;
 
-const VALID_SCORE_TYPES = [
-  "environmental",
-  "animal_welfare",
-  "foreign_policy",
-  "nuclear",
-  "civil_liberties",
-  "conservative",
-  "progressive",
-  "business",
-  "labor",
-  "overall",
-] as const;
-
 // ---- Query schemas ----
 
 const ListQuery = z.object({
@@ -55,10 +42,6 @@ const SyncItemSchema = z.object({
   scoreType: z.string().max(100).nullable().optional(),
   sourceUrl: z.string().max(2000).nullable().optional(),
   notes: z.string().max(5000).nullable().optional(),
-});
-
-const SyncBatchSchema = z.object({
-  items: z.array(SyncItemSchema).min(1).max(200),
 });
 
 // ---- Helpers ----
@@ -217,7 +200,12 @@ const politicalScoresApp = new Hono()
     createSyncHandler({
       name: "political-scores",
       table: politicalScores,
-      batchSchema: SyncBatchSchema,
+      syncSchema: SyncItemSchema,
+      entityRefs: ["politicianEntityId", "scorerEntityId"],
+      // Drizzle's numeric() insert type is `string`; Zod schema emits
+      // numbers. Keep a minimal toRow just for the coercion — all other
+      // fields could use the default mapper, but toRow must be complete
+      // when provided.
       toRow: (item, now) => ({
         id: item.id,
         politicianEntityId: item.politicianEntityId,
@@ -233,18 +221,6 @@ const politicalScoresApp = new Hono()
         syncedAt: now,
         updatedAt: now,
       }),
-      entityRefFields: (items) => [
-        {
-          fieldName: "politicianEntityId",
-          ids: items.map((i) => i.politicianEntityId),
-        },
-        {
-          fieldName: "scorerEntityId",
-          ids: items
-            .map((i) => i.scorerEntityId)
-            .filter((id): id is string => id != null),
-        },
-      ],
     }),
   )
 


### PR DESCRIPTION
## Summary

- `personnel.ts`, `divisions.ts`, `political-scores.ts` converted from v1 verbose `createSyncHandler` config to v2 `syncSchema`/`entityRefs` shorthand.
- Net **-32 lines** (21 insertions / 53 deletions).
- Mechanical conversion; semantically identical.

## Why

QUA-234. Cosmetic cleanup — bring the original pilot routes in line with the DRY pattern added in #4115.

Fixes QUA-234.

## Test plan
- [x] `pnpm exec tsc --noEmit -p apps/wiki-server/tsconfig.json` clean
- [x] Full wiki-server vitest run: 1041 passed / 21 skipped
- [x] Response shapes unchanged (verified via tsc inference)
