### PR TITLE
fix(crux): ws review-pass-2 fixes (QUA-339 follow-up)

### DIFF
--- a/crux/commands/agent-workspace.ts
+++ b/crux/commands/agent-workspace.ts
@@ -842,36 +842,63 @@ function makeTmuxExec(): TmuxExec {
   };
 }
 
+/** Format a thrown error for a user-facing CommandResult. */
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
 async function sentinelWrite(_args: string[], options: RoleOptions): Promise<CommandResult> {
   const role = parseRole(options);
   if (typeof role !== 'string') return { exitCode: 1, output: role.error };
   const env = makeSentinelEnv();
-  const { path, sentinel } = writeSentinelImpl(role, env);
-  if (options.json) {
+  try {
+    const { path, sentinel } = writeSentinelImpl(role, env);
+    if (options.json) {
+      return { exitCode: 0, output: JSON.stringify({ ok: true, role, path, sentinel }, null, 2) };
+    }
+    return { exitCode: 0, output: `wrote sentinel: ${path}` };
+  } catch (e) {
+    const msg = `sentinel-write failed: ${errMsg(e)}`;
     return {
-      exitCode: 0,
-      output: JSON.stringify({ ok: true, role, path, sentinel }, null, 2),
+      exitCode: 1,
+      output: options.json ? JSON.stringify({ ok: false, role, error: msg }, null, 2) : msg,
     };
   }
-  return { exitCode: 0, output: `wrote sentinel: ${path}` };
 }
 
 async function sentinelTouch(_args: string[], options: RoleOptions): Promise<CommandResult> {
   const role = parseRole(options);
   if (typeof role !== 'string') return { exitCode: 1, output: role.error };
   const env = makeSentinelEnv();
-  const { path, touched } = touchSentinelImpl(role, env);
-  if (options.json) {
-    return { exitCode: 0, output: JSON.stringify({ ok: true, role, path, touched }, null, 2) };
+  try {
+    const { path, touched } = touchSentinelImpl(role, env);
+    if (options.json) {
+      return { exitCode: 0, output: JSON.stringify({ ok: true, role, path, touched }, null, 2) };
+    }
+    return { exitCode: 0, output: touched ? `touched ${path}` : `(no sentinel at ${path} to touch)` };
+  } catch (e) {
+    const msg = `sentinel-touch failed: ${errMsg(e)}`;
+    return {
+      exitCode: 1,
+      output: options.json ? JSON.stringify({ ok: false, role, error: msg }, null, 2) : msg,
+    };
   }
-  return { exitCode: 0, output: touched ? `touched ${path}` : `(no sentinel at ${path} to touch)` };
 }
 
 async function sentinelCheck(_args: string[], options: RoleOptions): Promise<CommandResult> {
   const role = parseRole(options);
   if (typeof role !== 'string') return { exitCode: 1, output: role.error };
   const env = makeSentinelEnv();
-  const result = checkConflictImpl(role, env);
+  let result: ReturnType<typeof checkConflictImpl>;
+  try {
+    result = checkConflictImpl(role, env);
+  } catch (e) {
+    const msg = `sentinel-check failed: ${errMsg(e)}`;
+    return {
+      exitCode: 1,
+      output: options.json ? JSON.stringify({ ok: false, role, error: msg }, null, 2) : msg,
+    };
+  }
 
   if (options.json) {
     const exit = result.conflict?.kind === 'same-session' ? 2 : 0;
@@ -928,7 +955,16 @@ async function tmuxClaim(_args: string[], options: RoleOptions): Promise<Command
   const role = parseRole(options);
   if (typeof role !== 'string') return { exitCode: 1, output: role.error };
   const exec = makeTmuxExec();
-  const result = claimWindowImpl(role, exec);
+  let result: ReturnType<typeof claimWindowImpl>;
+  try {
+    result = claimWindowImpl(role, exec);
+  } catch (e) {
+    const msg = `tmux-claim failed: ${errMsg(e)}`;
+    return {
+      exitCode: 1,
+      output: options.json ? JSON.stringify({ ok: false, role, error: msg }, null, 2) : msg,
+    };
+  }
   if (options.json) {
     return { exitCode: result.status === 'error' ? 1 : 0, output: JSON.stringify(result, null, 2) };
   }

--- a/crux/lib/agent-workspace/__tests__/sentinel.test.ts
+++ b/crux/lib/agent-workspace/__tests__/sentinel.test.ts
@@ -311,4 +311,41 @@ describe('checkConflict', () => {
     const r = checkConflict('slots', env);
     expect(r.conflict).toBeNull();
   });
+
+  it('always prefers same-session over other-session, regardless of iteration order', () => {
+    // Reproducer for the priority bug: filesystem readdir order on Linux
+    // is filesystem-dependent. If a cross-session sentinel iterates first,
+    // the pre-fix code returned other-session and silently exit-0'd —
+    // masking the role-conflation blocker.
+    const env = new FakeEnv({ env: { TMUX_PANE: '%69' }, panes: ['%69', '%99'] });
+    // FakeEnv.listMatching sorts alphabetically. Use names that put the
+    // CROSS-session sentinel first so the iteration encounters it before
+    // the same-session one.
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-00cross',
+      'role=releases tmux_pane=%99 ppid=10 created=1700000000 host=h user=0',
+    );
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-69',
+      'role=releases tmux_pane=%69 ppid=10 created=1700000000 host=h user=0',
+    );
+    const r = checkConflict('slots', env);
+    expect(r.conflict).not.toBeNull();
+    expect(r.conflict?.kind).toBe('same-session');
+    expect(r.conflict?.path).toBe('/tmp/lw-coord-sentinel-releases-69');
+  });
+
+  it('reports other-session when no same-session conflict exists, even with multiple cross-session sentinels', () => {
+    const env = new FakeEnv({ env: { TMUX_PANE: '%1' }, panes: ['%1', '%2', '%3'] });
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-2',
+      'role=releases tmux_pane=%2 ppid=10 created=1700000000 host=h user=0',
+    );
+    env.writeFile(
+      '/tmp/lw-coord-sentinel-releases-3',
+      'role=releases tmux_pane=%3 ppid=11 created=1700000000 host=h user=0',
+    );
+    const r = checkConflict('slots', env);
+    expect(r.conflict?.kind).toBe('other-session');
+  });
 });

--- a/crux/lib/agent-workspace/doctor/__tests__/fake-env.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/fake-env.ts
@@ -86,11 +86,12 @@ export class FakeDoctorEnv implements DoctorEnv {
     const key = [cmd, ...args].join(' ');
     const handler = this.execs.get(key);
     if (handler) return handler(cmd, args);
-    // Try a prefix match (helpful when args list is long)
-    for (const [k, h] of this.execs.entries()) {
-      if (key === k) return h(cmd, args);
-    }
-    return { stdout: '', stderr: '', code: 0 };
+    // Fail loud on unregistered exec calls. Returning a silent {code:0}
+    // success here used to let checks pass by accident (empty stdout =
+    // "git status clean", etc.). Tests must register every expected
+    // exec via setExec; if a new check adds an exec call, the failure
+    // message names the key so it's trivial to fix.
+    throw new Error(`FakeDoctorEnv: no exec handler registered for: ${key}`);
   }
   async fetch(url: string): Promise<FetchResult> {
     return this.fetches.get(url) ?? { ok: false, status: 0, body: '', headers: {}, networkError: true };

--- a/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/releases.test.ts
@@ -198,6 +198,45 @@ describe('checkReleasePr', () => {
     );
     expect((await checkReleasePr.run(env)).status).toBe('skipped');
   });
+
+  // GitHub conclusions that should be treated as failing. The pre-fix regex
+  // /fail|cancel|error/i MISSED timed_out and action_required. One test per
+  // conclusion in FAILING_CONCLUSIONS to prevent future regex drift.
+  it.each([
+    ['failure'],
+    ['cancelled'],
+    ['timed_out'],
+    ['action_required'],
+    ['startup_failure'],
+  ])('treats conclusion=%s as a failing check', async (conclusion) => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok(JSON.stringify([{
+        number: 77, title: 'T', createdAt: new Date(NOW_MS - 60 * 60 * 1000).toISOString(),
+        isDraft: false, statusCheckRollup: [{ conclusion }],
+      }])),
+    );
+    const r = await checkReleasePr.run(env);
+    expect(r.status).toBe('fail');
+    expect(r.summary).toContain('#77');
+  });
+
+  it.each([
+    ['success'],
+    ['neutral'],
+    ['skipped'],
+  ])('treats conclusion=%s as NOT failing', async (conclusion) => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh pr list --repo quantified-uncertainty/longterm-wiki --base production --state open --json number,title,createdAt,isDraft,mergeable,statusCheckRollup',
+      ok(JSON.stringify([{
+        number: 88, title: 'T', createdAt: new Date(NOW_MS - 60 * 60 * 1000).toISOString(),
+        isDraft: false, statusCheckRollup: [{ conclusion }],
+      }])),
+    );
+    expect((await checkReleasePr.run(env)).status).toBe('ok');
+  });
 });
 
 describe('checkDeployTasks', () => {
@@ -290,6 +329,22 @@ describe('checkProdCiRecent', () => {
       'gh run list --repo quantified-uncertainty/longterm-wiki --branch production --limit 20 --json status,conclusion,createdAt',
       ok(JSON.stringify([
         { status: 'completed', conclusion: 'failure', createdAt: new Date(NOW_MS - 1000).toISOString() },
+      ])),
+    );
+    expect((await checkProdCiRecent.run(env)).status).toBe('warn');
+  });
+  // Previously this check used /failure|cancelled|timed_out/ but MISSED
+  // action_required and startup_failure. Share the FAILING_CONCLUSIONS
+  // allowlist with checkReleasePr via isFailingConclusion().
+  it.each([
+    ['action_required'],
+    ['startup_failure'],
+  ])('catches conclusion=%s', async (conclusion) => {
+    const env = new FakeDoctorEnv({ now: new Date(NOW_MS) });
+    env.setExec(
+      'gh run list --repo quantified-uncertainty/longterm-wiki --branch production --limit 20 --json status,conclusion,createdAt',
+      ok(JSON.stringify([
+        { status: 'completed', conclusion, createdAt: new Date(NOW_MS - 1000).toISOString() },
       ])),
     );
     expect((await checkProdCiRecent.run(env)).status).toBe('warn');

--- a/crux/lib/agent-workspace/doctor/__tests__/slots.test.ts
+++ b/crux/lib/agent-workspace/doctor/__tests__/slots.test.ts
@@ -267,6 +267,24 @@ describe('checkHungWikiServer', () => {
     expect(r.status).toBe('warn');
     expect(r.detail).toContain('a7');
   });
+  // Regression: pre-fix substring match flagged /lw/a10 processes as
+  // running in /lw/a1 because "/lw/a10".includes("/lw/a1") is true.
+  it('does NOT match /lw/a10 process against /lw/a1 slot (prefix collision)', async () => {
+    const env = envWithSlots([1]); // ONLY a1 is a real slot here
+    env.setExec('pgrep -fa wiki-server', ok('300 node /lw/a10/apps/wiki-server/dist/index.js\n'));
+    const r = await checkHungWikiServer.run(env);
+    expect(r.status).toBe('ok');
+  });
+  it('correctly attributes when both a1 and a10 are real slots', async () => {
+    const env = envWithSlots([1, 10]);
+    env.setExec(
+      'pgrep -fa wiki-server',
+      ok('300 node /lw/a10/apps/wiki-server/dist/index.js\n'),
+    );
+    const r = await checkHungWikiServer.run(env);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('a10');
+  });
 });
 
 describe('SLOTS_CHECKS registry', () => {

--- a/crux/lib/agent-workspace/doctor/releases.ts
+++ b/crux/lib/agent-workspace/doctor/releases.ts
@@ -11,6 +11,31 @@ import type { DoctorCheck, DoctorEnv } from './types.ts';
 
 const RELDIR_CANDIDATES = ['releases', 'coord'];
 
+/**
+ * The set of GitHub check-run conclusion values that indicate failure.
+ *
+ * Per the GitHub Checks API, `conclusion` is one of:
+ *   success | failure | cancelled | timed_out | action_required |
+ *   neutral | skipped | stale | startup_failure
+ *
+ * Anything in this set should be treated as a failed check. A previous
+ * implementation used the regex /fail|cancel|error/i which silently
+ * missed `timed_out` and `action_required`, letting timed-out CI on a
+ * release PR read as "no failing checks". Use the allowlist instead.
+ */
+const FAILING_CONCLUSIONS = new Set([
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+]);
+
+function isFailingConclusion(conclusion: string | null | undefined): boolean {
+  if (!conclusion) return false;
+  return FAILING_CONCLUSIONS.has(conclusion.toLowerCase());
+}
+
 function resolveReldir(env: DoctorEnv): { name: string; path: string; bothExist: boolean } | null {
   const present = RELDIR_CANDIDATES.filter((d) => {
     const st = env.stat(env.resolve(d));
@@ -202,7 +227,7 @@ export const checkReleasePr: DoctorCheck = {
     const ageMs = env.now().getTime() - new Date(pr.createdAt).getTime();
     const ageHours = ageMs / 1000 / 60 / 60;
     const checks = pr.statusCheckRollup ?? [];
-    const failing = checks.filter((c) => c.conclusion && /fail|cancel|error/i.test(c.conclusion));
+    const failing = checks.filter((c) => isFailingConclusion(c.conclusion));
 
     if (ageMs < 5 * 60 * 1000 && checks.length === 0) {
       return { status: 'info', summary: `#${pr.number} (warming up)` };
@@ -313,7 +338,7 @@ export const checkProdCiRecent: DoctorCheck = {
     try { runs = JSON.parse(r.stdout); } catch { return { status: 'warn', summary: 'unparseable gh output' }; }
     const cutoff = env.now().getTime() - 24 * 60 * 60 * 1000;
     const recent = runs.filter((rn) => new Date(rn.createdAt).getTime() >= cutoff);
-    const failed = recent.filter((rn) => /failure|cancelled|timed_out/.test(rn.conclusion));
+    const failed = recent.filter((rn) => isFailingConclusion(rn.conclusion));
     if (failed.length === 0) {
       return { status: 'ok', summary: `0 failures in last 24h (${recent.length} runs)` };
     }

--- a/crux/lib/agent-workspace/doctor/slots.ts
+++ b/crux/lib/agent-workspace/doctor/slots.ts
@@ -380,8 +380,13 @@ export const checkHungWikiServer: DoctorCheck = {
       .split('\n')
       .map((l) => l.trim())
       .filter((l) => l.length > 0);
+    // Match on a trailing `/` so `/lw/a1` doesn't accidentally match
+    // `/lw/a10` via prefix substring. Must look for `<path>/` inside the
+    // command line or `<path>` at end-of-string (less common but safe).
     const slotPaths = listSlotDirs(env).map((s) => s.path);
-    const hung = lines.filter((l) => slotPaths.some((p) => l.includes(p)));
+    const hung = lines.filter((l) =>
+      slotPaths.some((p) => l.includes(`${p}/`) || l.endsWith(p)),
+    );
     if (hung.length === 0) return { status: 'ok', summary: 'none in slot dirs' };
     return {
       status: 'warn',

--- a/crux/lib/agent-workspace/sentinel.ts
+++ b/crux/lib/agent-workspace/sentinel.ts
@@ -256,9 +256,14 @@ export function touchSentinel(role: Role, env: SentinelEnv): { path: string; tou
 /**
  * Scan for conflicting sentinels from the OTHER role.
  *
- * Returns the first live conflict found, classified by whether it shares
- * our session key (same-session = role conflation, the blocker) or comes
- * from a different session (cross-session = expected, informational).
+ * Classifies each live conflict as same-session (role conflation, the
+ * blocker) or other-session (cross-session = expected, informational).
+ *
+ * IMPORTANT: a same-session conflict ALWAYS wins over an other-session
+ * one. Iteration order from `listMatching` is filesystem-dependent on
+ * Linux (`readdirSync` is unsorted), so without an explicit priority a
+ * stale-but-live cross-session sentinel could mask the very same-session
+ * conflict the guard exists to detect.
  *
  * Stale sentinels of the other role are removed opportunistically.
  */
@@ -270,7 +275,8 @@ export function checkConflict(role: Role, env: SentinelEnv): SentinelCheckResult
   const otherPrefix = `${SENTINEL_PREFIX}-${other}-`;
   const candidates = env.listMatching(SENTINEL_DIR, otherPrefix);
 
-  let conflict: Conflict | null = null;
+  let sameSession: Conflict | null = null;
+  let otherSession: Conflict | null = null;
   let cleaned = 0;
 
   for (const path of candidates) {
@@ -282,15 +288,22 @@ export function checkConflict(role: Role, env: SentinelEnv): SentinelCheckResult
       cleaned += 1;
       continue;
     }
-    if (conflict != null || parsed == null) continue;
-    // Determine session match: prefer pane id, fall back to ppid match
+    if (parsed == null) continue;
     const sentinelKey =
       parsed.tmuxPane && parsed.tmuxPane.startsWith('%')
         ? parsed.tmuxPane.slice(1)
         : parsed.tmuxPane || `pid-${parsed.ppid}`;
     const kind: ConflictKind = sentinelKey === ourKey ? 'same-session' : 'other-session';
-    conflict = { kind, path, sentinel: parsed, ageSeconds: liveness.ageSeconds };
+    const found: Conflict = { kind, path, sentinel: parsed, ageSeconds: liveness.ageSeconds };
+    if (kind === 'same-session') {
+      // Same-session is the blocker. Capture and stop scanning — no
+      // other-session conflict can override it, and the caller doesn't
+      // need a second one of the same kind.
+      sameSession = found;
+      break;
+    }
+    if (otherSession == null) otherSession = found;
   }
 
-  return { ourPath, conflict, cleaned };
+  return { ourPath, conflict: sameSession ?? otherSession, cleaned };
 }


### PR DESCRIPTION
## Summary

Follow-up to #4245 (QUA-339 PR 1). A second `/agent-review-pr` pass caught **2 HIGH** and **3 MEDIUM** bugs that the first-pass reviewer missed. All fixes have regression tests.

### HIGH 1 — `sentinel.ts:checkConflict` same-session priority

The loop returned the **first** conflict it encountered in `listMatching` iteration order. `readdirSync` on Linux is filesystem-dependent (unsorted), so a stale-but-live cross-session sentinel that happened to sort first would silently downgrade a real role-conflation blocker to "expected cross-session" → exit 0 → **the guard fails to fire when it matters most**.

**Fix**: track same-session and other-session separately, always prefer same-session. Regression test with an alphabetically-first cross-session sentinel ensures iteration order cannot mask the conflict.

### HIGH 2 — `releases.ts` failing-check regex gap

`checkReleasePr` used `/fail|cancel|error/i` which **missed `timed_out` and `action_required`**. A release PR with a timed-out check reported as "fresh, no failing checks". Sibling `checkProdCiRecent` used `/failure|cancelled|timed_out/` — also missed `action_required` and `startup_failure`.

**Fix**: extracted a shared `FAILING_CONCLUSIONS` allowlist + `isFailingConclusion()` helper, used in both checks. Table-driven regression tests for every conclusion.

### MED 3 — sentinel/tmux handlers had no try/catch

`sentinelWrite`, `sentinelTouch`, `sentinelCheck`, `tmuxClaim` wrapped their impls with no error handling. A filesystem error (EACCES on `/tmp`, EDQUOT, etc.) would surface as an uncaught exception with a raw Node stack trace, crashing the calling skill instead of returning a clean `CommandResult`.

**Fix**: each handler now wraps its impl in try/catch returning exit 1 with a formatted error (respecting `--json` mode).

### MED 4 — `checkHungWikiServer` prefix collision

Substring match `"/lw/a10".includes("/lw/a1")` → true. A wiki-server running in a10 matched both `/lw/a1` and `/lw/a10` patterns, misattributing to a1.

**Fix**: match on `${path}/` with end-of-string fallback. Regression tests for the false-positive case and the correct two-slot case.

### MED 5 — `FakeDoctorEnv.exec` silent-success default

Unregistered exec keys returned `{code: 0, stdout: ''}` — tests could pass by accident (empty stdout = "git status clean").

**Fix**: throws with the unregistered key name. All 154 existing tests already register their expected execs, so no tests broke.

### Low-impact, deferred

- `claimWindow` race between `list-windows` and `rename-window` (cosmetic; tmux allows duplicate names)
- `checkReleasePr` requests `mergeable` field but never reads it
- `checkEnvDrift` strict mtime comparison sensitive to noop `touch`
- `buildOurSentinel` produces `pid-NaN` if PPID non-numeric

These are tracked as follow-up observations; none are blockers.

## Test plan

- [x] 154/154 agent-workspace tests passing (up from 143; +11 new regression tests)
- [x] 6003/6003 full test suite passing
- [x] `pnpm crux w validate gate --fix --no-cache` — all 41 gate checks passing
- [x] Crux typecheck clean on all new/modified code
- [x] End-to-end smoke: `ws sentinel-write slots` + `ws sentinel-check releases` correctly produces the same-session banner with exit 2
- [x] `/agent-review-pr` second pass (fresh hostile reviewer) caught these 5 bugs; all fixed with regression tests

Fixes QUA-339
