### PR TITLE
fix(e2e): mask f_ fact IDs on data?tab=database + /source-checks redirect

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -38,6 +38,17 @@ const nextConfig: NextConfig = {
         destination: "/wiki/E755",
         permanent: false,
       },
+      // Source Checks dashboard was renamed to /sourcing (QUA-346)
+      {
+        source: "/source-checks",
+        destination: "/sourcing",
+        permanent: true,
+      },
+      {
+        source: "/source-checks/:path*",
+        destination: "/sourcing/:path*",
+        permanent: true,
+      },
       {
         source: "/wiki/E1043",
         destination: "/resources",

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -339,6 +339,23 @@ function CellValue({
     return <JsonValue value={value} />;
   }
 
+  // FactBase fact IDs (f_xxx) -> render as link with "view →" label instead of leaking raw ID.
+  if (
+    (columnName === "fact_id" || columnName === "factId") &&
+    typeof value === "string" &&
+    value.startsWith("f_")
+  ) {
+    return (
+      <Link
+        href={`/factbase/fact/${encodeURIComponent(value)}`}
+        className="text-blue-600 dark:text-blue-400 hover:underline text-[11px]"
+        title={value}
+      >
+        view →
+      </Link>
+    );
+  }
+
   // Entity reference columns -> show resolved name as link
   const isEntityRef = isEntityRefColumn(columnName);
 


### PR DESCRIPTION
## Summary

Fixes the two clusters of post-deploy e2e failures in QUA-346.

### Cluster 1: `f_` FactBase IDs leaking on `?tab=database` pages

`EntityProfileViewer`'s `CellValue` rendered the `fact_id` column as raw text, so after client-side hydration `/{orgs,people}/*/data?tab=database` showed visible `f_xxxxx` IDs. Mirrors the PR #4224 fix for `CategoryFactSection`: render the ID as a `view →` link to `/factbase/fact/<id>` and keep the full ID in `title`/`href` for dev use.

### Cluster 2: `/source-checks` 404

The dashboard was renamed to `/sourcing` (QUA-237) without a redirect, so bookmarks and the e2e redirect tests (`production-release-verification.spec.ts`, `verify-redirects-misc.spec.ts`) hit 404. Added permanent 308 redirects for `/source-checks` and `/source-checks/:path*` in `next.config.ts`.

## Test plan

- [x] Existing `e2e/no-raw-ids.spec.ts` — "People/Organization data pages" tests cover the fix path
- [x] Existing `e2e/production-release-verification.spec.ts:198` — `/source-checks` status
- [x] Existing `e2e/verify-redirects-misc.spec.ts:109` — `/source-checks?q=…` status
- [ ] CI e2e-post-deploy run green on next deploy (verified post-merge)

Fixes QUA-346
