### PR TITLE
fix(market-fetcher): warn on Manifold null-probability markets (QUA-187)

### DIFF
--- a/crux/tablebase/market-fetcher.test.ts
+++ b/crux/tablebase/market-fetcher.test.ts
@@ -124,4 +124,44 @@ describe('fetchManifoldQuestion', () => {
     expect(msg).toContain('404');
     expect(msg).not.toContain('outcomeType');
   });
+
+  it('does not warn about outcomeType when fetch throws (network error)', async () => {
+    fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    const result = await fetchManifoldQuestion('unreachable-slug');
+
+    // The catch block returns null and emits a single error warning —
+    // it should NOT fall through to the outcomeType/probability warn path.
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('unreachable-slug');
+    expect(msg).toContain('ECONNREFUSED');
+    expect(msg).not.toContain('outcomeType');
+  });
+
+  it('treats probability=0 as a valid BINARY probability (not null)', async () => {
+    // Edge case: Manifold may return 0 or 1 for a confident market. The
+    // fetcher must preserve the 0 (not coerce it to null) and not warn.
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        id: 'zero',
+        outcomeType: 'BINARY',
+        probability: 0,
+        uniqueBettorCount: 5,
+      })
+    );
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    const result = await fetchManifoldQuestion('zero-prob-market');
+
+    expect(result).toEqual({
+      probability: 0,
+      probabilityLow: null,
+      probabilityHigh: null,
+      numForecasters: 5,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/crux/tablebase/market-fetcher.test.ts
+++ b/crux/tablebase/market-fetcher.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the wiki-server client (imported transitively by market-fetcher.ts)
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe('fetchManifoldQuestion', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  const mockResponse = (body: unknown, ok = true, status = 200) =>
+    ({
+      ok,
+      status,
+      json: async () => body,
+    }) as unknown as Response;
+
+  it('returns probability and does NOT warn for BINARY markets', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        id: 'abc',
+        outcomeType: 'BINARY',
+        probability: 0.73,
+        uniqueBettorCount: 42,
+      })
+    );
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    const result = await fetchManifoldQuestion('will-x-happen');
+
+    expect(result).toEqual({
+      probability: 0.73,
+      probabilityLow: null,
+      probabilityHigh: null,
+      numForecasters: 42,
+    });
+    // No warning for a valid BINARY market
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits a WARN naming the outcomeType for MULTIPLE_CHOICE markets', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        id: 'xyz',
+        outcomeType: 'MULTIPLE_CHOICE',
+        // probability absent — Manifold only populates it for BINARY
+        uniqueBettorCount: 101,
+      })
+    );
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    const result = await fetchManifoldQuestion('some-poll-slug');
+
+    // Still returns the SnapshotData shape with null probability, so the
+    // caller's guard at market-fetcher.ts:~359 skips it from upsert.
+    expect(result).toMatchObject({ probability: null });
+
+    // The critical assertion: we WARN with market id + outcomeType so the
+    // skip is traceable instead of silent.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('some-poll-slug');
+    expect(msg).toContain('MULTIPLE_CHOICE');
+    expect(msg).toContain('QUA-188');
+  });
+
+  it('emits a WARN for BINARY markets that nonetheless return null probability', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        id: 'def',
+        outcomeType: 'BINARY',
+        // probability absent — e.g. resolved or closed
+      })
+    );
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    await fetchManifoldQuestion('resolved-market');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('resolved-market');
+    expect(msg).toContain('BINARY');
+    expect(msg).toContain('null probability');
+  });
+
+  it('handles missing outcomeType gracefully and still warns', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        id: 'ghi',
+        // no outcomeType, no probability — malformed response
+      })
+    );
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    await fetchManifoldQuestion('weird-slug');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('weird-slug');
+    expect(msg).toContain('UNKNOWN');
+  });
+
+  it('does not warn about outcomeType when the HTTP request fails', async () => {
+    fetchSpy.mockResolvedValue(mockResponse({}, false, 404));
+
+    const { fetchManifoldQuestion } = await import('./market-fetcher.ts');
+    const result = await fetchManifoldQuestion('missing-slug');
+
+    expect(result).toBeNull();
+    // Exactly one warn, about the HTTP status — NOT the outcomeType path.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('404');
+    expect(msg).not.toContain('outcomeType');
+  });
+});

--- a/crux/tablebase/market-fetcher.ts
+++ b/crux/tablebase/market-fetcher.ts
@@ -124,13 +124,20 @@ async function fetchMetaculusQuestion(
 
 interface ManifoldMarketResponse {
   id: string;
+  outcomeType?: string;
   probability?: number;
   totalLiquidity?: number;
   volume?: number;
   uniqueBettorCount?: number;
 }
 
-async function fetchManifoldQuestion(
+// Manifold only populates `probability` for BINARY markets. Every other
+// outcomeType (MULTIPLE_CHOICE, PSEUDO_NUMERIC, NUMERIC, FREE_RESPONSE, POLL,
+// STONK, BOUNTIED_QUESTION) returns null and cannot be stored as a single
+// scalar probability snapshot. Tracked by QUA-187 (warn) and QUA-188 (schema).
+const MANIFOLD_BINARY_OUTCOME_TYPE = "BINARY";
+
+export async function fetchManifoldQuestion(
   platformQuestionId: string
 ): Promise<SnapshotData | null> {
   // Discovery stores IDs as "user/slug" or just "slug" — API needs just the slug
@@ -153,9 +160,28 @@ async function fetchManifoldQuestion(
     }
 
     const data = (await response.json()) as ManifoldMarketResponse;
+    const outcomeType = data.outcomeType ?? "UNKNOWN";
+    const probability = data.probability ?? null;
+
+    // Warn (don't silently drop) when Manifold returns a non-scalar market.
+    // Only BINARY markets carry a `probability` field — everything else needs
+    // the multi-outcome schema work tracked in QUA-188. Without this warning
+    // such markets disappear into `skippedCount` and the frontend shows "–"
+    // with no diagnostic trail.
+    if (probability == null) {
+      if (outcomeType !== MANIFOLD_BINARY_OUTCOME_TYPE) {
+        console.warn(
+          `  ⚠ Manifold market ${platformQuestionId} skipped: outcomeType=${outcomeType} has no scalar probability (only BINARY is supported; see QUA-188 for multi-outcome support)`
+        );
+      } else {
+        console.warn(
+          `  ⚠ Manifold market ${platformQuestionId} skipped: BINARY market returned null probability (possibly resolved or closed)`
+        );
+      }
+    }
 
     return {
-      probability: data.probability ?? null,
+      probability,
       probabilityLow: null,
       probabilityHigh: null,
       numForecasters: data.uniqueBettorCount ?? null,

--- a/crux/tablebase/market-fetcher.ts
+++ b/crux/tablebase/market-fetcher.ts
@@ -169,15 +169,13 @@ export async function fetchManifoldQuestion(
     // such markets disappear into `skippedCount` and the frontend shows "–"
     // with no diagnostic trail.
     if (probability == null) {
-      if (outcomeType !== MANIFOLD_BINARY_OUTCOME_TYPE) {
-        console.warn(
-          `  ⚠ Manifold market ${platformQuestionId} skipped: outcomeType=${outcomeType} has no scalar probability (only BINARY is supported; see QUA-188 for multi-outcome support)`
-        );
-      } else {
-        console.warn(
-          `  ⚠ Manifold market ${platformQuestionId} skipped: BINARY market returned null probability (possibly resolved or closed)`
-        );
-      }
+      const reason =
+        outcomeType !== MANIFOLD_BINARY_OUTCOME_TYPE
+          ? `outcomeType=${outcomeType} has no scalar probability (only BINARY is supported; see QUA-188 for multi-outcome support)`
+          : `BINARY market returned null probability (possibly resolved or closed)`;
+      console.warn(
+        `  ⚠ Manifold market ${platformQuestionId} skipped: ${reason}`
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Manifold's API only populates `probability` for BINARY markets. Every other `outcomeType` (MULTIPLE_CHOICE, PSEUDO_NUMERIC, NUMERIC, FREE_RESPONSE, POLL, STONK, BOUNTIED_QUESTION) returns `null`, and the caller's upsert guard (`if (result && result.probability != null)` in `fetchMarketSnapshots`) was silently dropping them into `skippedCount`. End result: org market-data tabs showed `–` with no diagnostic trail.

This is the **short-term fix (Option #1 + #3 from QUA-187)**. Schema work for genuine multi-outcome support — new columns, per-outcome snapshots, frontend rendering — is out of scope and tracked in **QUA-188**.

## Changes

- `crux/tablebase/market-fetcher.ts`
  - Add `outcomeType?: string` to the `ManifoldMarketResponse` interface
  - In `fetchManifoldQuestion`, when `probability == null`, emit a `console.warn` naming the market id and the reason:
    - Non-BINARY: `outcomeType=MULTIPLE_CHOICE has no scalar probability (only BINARY is supported; see QUA-188 for multi-outcome support)`
    - BINARY with null: `BINARY market returned null probability (possibly resolved or closed)`
  - Export the function for unit testing
  - The caller's upsert guard at the bottom of `fetchMarketSnapshots` is **unchanged** — the function still returns `{ probability: null, ... }` for non-BINARY markets and they still get counted as skipped. The only behavioral change is that the skip is now visible in logs.
- `crux/tablebase/market-fetcher.test.ts` (new, 5 tests)
  - BINARY happy path: returns probability, no warn
  - MULTIPLE_CHOICE: warns with market id + outcomeType + QUA-188 pointer
  - BINARY with null probability (resolved/closed): warns with distinct message
  - Missing `outcomeType` field: warns with `UNKNOWN`
  - HTTP 404: single HTTP-status warn, no outcomeType warn

## What was NOT changed

- **No schema changes.** Out of scope; see QUA-188.
- **No discovery-time filter.** `crux/tablebase/market-discovery.ts` is an LLM + web-search agent that never touches the Manifold API directly, so filtering there would require a second API round-trip per discovered market. The fetcher-side warn gives us the diagnostic trail we need until QUA-188 lands and we can fetch-and-store the non-BINARY markets properly.
- **Guard direction unchanged.** Verified with `grep -n "probability == null\|probability != null"` — upsert guard at line ~359 still reads `!= null`.

## Test plan

- [x] `pnpm exec vitest run crux/tablebase/market-fetcher.test.ts` — 5/5 passing
- [x] `pnpm exec vitest run crux/tablebase/` — 85/85 passing (no regressions across tablebase tests)
- [x] `pnpm exec tsc --noEmit -p crux/tsconfig.json` — no new errors in modified files
- [x] Gate check: 41/41 green
- [x] Grep confirms guard direction is unchanged

Fixes QUA-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market data fetcher function is now publicly available for direct use.

* **Bug Fixes**
  * Enhanced error handling and diagnostic warnings for unsupported market types and missing probability values.
  * Improved graceful handling of invalid HTTP responses.

* **Tests**
  * Added comprehensive test suite covering market data fetching scenarios, including edge cases and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->