### PR TITLE
chore(maintain): refresh overdue audits (2026-04-13)

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -35,7 +35,7 @@ audits:
       "heartbeat OK" messages.
     frequency: weekly
     added: "2026-03-04"
-    last_checked: "2026-04-05"
+    last_checked: "2026-04-13"
     last_result: pass
     history:
       - date: "2026-03-29"
@@ -43,6 +43,9 @@ audits:
         checked_by: "manual"
 
       - date: "2026-04-05"
+        result: pass
+        checked_by: "manual"
+      - date: "2026-04-13"
         result: pass
         checked_by: "manual"
   - id: agent-sessions-logged
@@ -57,7 +60,7 @@ audits:
       A large gap means agents are completing work without logging sessions.
     frequency: weekly
     added: "2026-03-04"
-    last_checked: "2026-04-06"
+    last_checked: "2026-04-13"
     last_result: pass
     history:
       - date: "2026-03-29"
@@ -82,6 +85,9 @@ audits:
       - date: "2026-04-06"
         result: pass
         checked_by: "manual"
+      - date: "2026-04-13"
+        result: pass
+        checked_by: "manual"
   - id: scheduled-workflows-running
     category: infrastructure
     description: "All scheduled GitHub Actions (server-api-health, frontend-data-health, ci-pr-health, scheduled-maintenance, server-health-monitor) ran within expected windows. Note: auto-update intentionally disabled (PR #2592)."
@@ -102,7 +108,7 @@ audits:
       Note: auto-update.yml intentionally disabled since PR #2592 — excluded from this check.
     frequency: weekly
     added: "2026-03-04"
-    last_checked: "2026-04-11"
+    last_checked: "2026-04-13"
     last_result: fail
     last_result_note: "ci-pr-health failing (auto-update 100% failure rate triggers job queue check); scheduled-maintenance hit max turns (60)"
     history:
@@ -136,6 +142,9 @@ audits:
         result: fail
         checked_by: "manual"
         notes: "server-api-health OK, frontend-data-health OK, server-health-monitor OK. ci-pr-health failing (auto-update 100% failure flagged as job queue issue, #4107 open). scheduled-maintenance hit max turns (60) on 2026-04-10."
+      - date: "2026-04-13"
+        result: fail
+        checked_by: "manual"
   - id: vercel-production-only
     category: infrastructure
     description: "Vercel ONLY builds the production branch — no builds for main, claude/*, issue branches, or PR previews"


### PR DESCRIPTION
## Summary
- Refresh 3 overdue audit items (`groundskeeper-health`, `agent-sessions-logged`, `scheduled-workflows-running`)
- 0 overdue audits remaining
- Filed QUA-353 for observed `crux sys audits check --note` bug (notes not persisting to YAML history entries)

## Maintenance sweep findings (2026-04-13)
- **PRs merged today**: 32 (incl. 2 releases)
- **Session log issues**: 0
- **GitHub issues recently resolved**: 10 (all already closed)
- **Linear queue**: 21 active, 4 P1/P2 ready for dispatch
- **Failed audits**: `scheduled-workflows-running` — scheduled-maintenance.yml hit max-turns, tracked as #4138
- **Codebase cruft**: 29 files >1000 lines (no action taken — requires review)

## Test plan
- [x] Audits list shows 0 overdue items
- [x] `.claude/audits.yaml` diff is clean (3 history entries added)
