### PR TITLE
docs(sourcing-ratchet): freeze baseline at 7 per QUA-296

### DIFF
--- a/crux/validate/.sourcing-baseline.json
+++ b/crux/validate/.sourcing-baseline.json
@@ -5,5 +5,5 @@
   "route": 2,
   "total": 7,
   "updatedAt": "2026-04-12T19:16:58.756Z",
-  "notes": "Ratchet baseline for source-check → sourcing rename. Only lower this value; never raise without justification. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella)."
+  "notes": "FROZEN per QUA-296. The 5 non-route references (hyphenated + camelCase) are structural: they bind to DB columns source_check_evidence and source_check_verdicts via Drizzle. Driving total below 5 requires renaming those tables (rejected as high-risk for cosmetic gain — see QUA-296). Route references (currently 2) will drop to 0 once QUA-301 client migration completes. Until then, do not lower the total without first reading QUA-296. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella), QUA-296 (freeze decision)."
 }

--- a/crux/validate/validate-sourcing-lint-guard.ts
+++ b/crux/validate/validate-sourcing-lint-guard.ts
@@ -289,9 +289,14 @@ function main(): void {
   if (updateMode) {
     const { counts, filesScanned } = scanCodebase();
     const notes =
-      'Ratchet baseline for source-check → sourcing rename. ' +
-      'Only lower this value; never raise without justification. ' +
-      'Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella).';
+      'FROZEN per QUA-296. The 5 non-route references (hyphenated + camelCase) ' +
+      'are structural: they bind to DB columns source_check_evidence and ' +
+      'source_check_verdicts via Drizzle. Driving total below 5 requires ' +
+      'renaming those tables (rejected as high-risk for cosmetic gain — see ' +
+      'QUA-296). Route references will drop to 0 once QUA-301 client migration ' +
+      'completes. Until then, do not lower the total without first reading ' +
+      'QUA-296. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella), ' +
+      'QUA-296 (freeze decision).';
     writeBaseline(counts, notes);
     console.log(`${c.green}Baseline updated.${c.reset}`);
     console.log(`  Files scanned: ${filesScanned}`);


### PR DESCRIPTION
## Summary
Updates the sourcing-ratchet baseline notes to declare the current floor (5 non-route + 2 route = 7) as **structural**. The 5 non-route references bind to DB columns `source_check_evidence` and `source_check_verdicts` via Drizzle and cannot be eliminated without renaming the underlying tables.

After review under QUA-296, the rename was rejected as high-risk for cosmetic gain (column names are not user-facing). Both the JSON `notes` field and the validator's hardcoded `--update` notes string now point at QUA-296 so future readers (and re-runs of `--update`) preserve the explanation.

## What changed
- `crux/validate/.sourcing-baseline.json` — notes field rewritten with the freeze rationale
- `crux/validate/validate-sourcing-lint-guard.ts` — `--update` mode notes string matched to the JSON

## What didn't change
- The numeric baseline (still `total: 7`)
- Any validator behavior — `validate-sourcing-lint-guard.ts` still reports "At baseline (7 references across 1444 files)"
- Any tests — all 14 existing tests still pass

## Test plan
- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` → "At baseline (7 references across 1444 files)"
- [x] `pnpm vitest run crux/validate/validate-sourcing-lint-guard.test.ts` → 14/14 pass
- [ ] CI green

Closes QUA-296
