### PR TITLE
fix(create-pipeline): hard-fail register-sources on zero citations (QUA-290)

### DIFF
--- a/crux/authoring/creator/source-fetching.test.ts
+++ b/crux/authoring/creator/source-fetching.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { registerResearchSources, extractUrls } from './source-fetching.ts';
+
+// Mock the resource-lookup module so tests don't hit the real resource YAML.
+// Default returns null (treat every URL as new).
+vi.mock('../../lib/search/resource-lookup.ts', () => ({
+  getResourceByUrl: vi.fn(() => null),
+}));
+
+interface TestContext {
+  topicDir: string;
+  saved: Record<string, string | object>;
+  logs: Array<{ phase: string; message: string }>;
+}
+
+function makeContext(): { ctx: TestContext; phaseCtx: Parameters<typeof registerResearchSources>[1] } {
+  const topicDir = fs.mkdtempSync(path.join(os.tmpdir(), 'register-sources-test-'));
+  const ctx: TestContext = { topicDir, saved: {}, logs: [] };
+  const phaseCtx: Parameters<typeof registerResearchSources>[1] = {
+    log: (phase: string, message: string) => {
+      ctx.logs.push({ phase, message });
+    },
+    saveResult: (_topic: string, filename: string, data: string | object) => {
+      ctx.saved[filename] = data;
+      return path.join(topicDir, filename);
+    },
+    getTopicDir: (_topic: string) => topicDir,
+  };
+  return { ctx, phaseCtx };
+}
+
+describe('registerResearchSources — QUA-290 hard-fail behavior', () => {
+  let ctx: TestContext;
+  let phaseCtx: Parameters<typeof registerResearchSources>[1];
+
+  beforeEach(() => {
+    const made = makeContext();
+    ctx = made.ctx;
+    phaseCtx = made.phaseCtx;
+  });
+
+  afterEach(() => {
+    if (ctx.topicDir && fs.existsSync(ctx.topicDir)) {
+      fs.rmSync(ctx.topicDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when perplexity-research.json is missing', async () => {
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(
+      /no Perplexity research file found/,
+    );
+  });
+
+  it('throws QUA-290-tagged error when research file is missing', async () => {
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(/QUA-290/);
+  });
+
+  it('throws when research file exists but has zero citation URLs', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({ sources: [{ citations: [], content: 'some research' }] }),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(
+      /0 usable citation URLs/,
+    );
+  });
+
+  it('throws when research file has only non-http citations', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({
+        sources: [{ citations: ['not-a-url', 'ftp://example.com', '', null] }],
+      }),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(
+      /0 usable citation URLs/,
+    );
+  });
+
+  it('throws when sources array is empty', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({ sources: [] }),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(
+      /0 usable citation URLs/,
+    );
+  });
+
+  it('throws when sources is missing entirely', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({}),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(
+      /0 usable citation URLs/,
+    );
+  });
+
+  it('error mentions QUA-290 for traceability', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({ sources: [] }),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow(/QUA-290/);
+  });
+
+  it('succeeds when research file has at least one valid http URL', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({
+        sources: [
+          {
+            citations: ['https://example.com/paper-1', 'https://anthropic.com/research'],
+            content: 'research',
+          },
+        ],
+      }),
+    );
+
+    const result = await registerResearchSources('test-topic', phaseCtx);
+    expect(result.success).toBe(true);
+    expect(result.total).toBe(2);
+    expect(ctx.saved['registered-sources.json']).toBeDefined();
+  });
+
+  it('does not write registered-sources.json when throwing', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({ sources: [] }),
+    );
+    await expect(registerResearchSources('test-topic', phaseCtx)).rejects.toThrow();
+    expect(ctx.saved['registered-sources.json']).toBeUndefined();
+  });
+
+  it('deduplicates URLs across sources before counting', async () => {
+    fs.writeFileSync(
+      path.join(ctx.topicDir, 'perplexity-research.json'),
+      JSON.stringify({
+        sources: [
+          { citations: ['https://example.com/a', 'https://example.com/b'] },
+          { citations: ['https://example.com/a', 'https://example.com/c'] },
+        ],
+      }),
+    );
+
+    const result = await registerResearchSources('test-topic', phaseCtx);
+    expect(result.total).toBe(3);
+  });
+});
+
+describe('extractUrls — sanity check (existing behavior)', () => {
+  it('extracts a single URL from text', () => {
+    expect(extractUrls('see https://example.com here')).toEqual(['https://example.com']);
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(extractUrls('https://example.com, https://other.com.')).toEqual([
+      'https://example.com',
+      'https://other.com',
+    ]);
+  });
+});

--- a/crux/authoring/creator/source-fetching.ts
+++ b/crux/authoring/creator/source-fetching.ts
@@ -81,14 +81,21 @@ export function extractUrls(text: string): string[] {
  * Extract citation URLs from Perplexity research and register them for fetching.
  * Checks resource YAML files for already-known URLs; new URLs are tracked
  * in the registered-sources.json output file.
+ *
+ * Throws if no usable citation URLs are produced (missing research file or
+ * empty citation set). Synthesizing without citations would otherwise emit
+ * placeholder `[^N]: Source name (no link)` footnotes (QUA-290, QUA-291).
  */
-export async function registerResearchSources(topic: string, { log, saveResult, getTopicDir }: RegisterContext): Promise<{ success: boolean; error?: string; registered?: number; existing?: number; total?: number }> {
+export async function registerResearchSources(topic: string, { log, saveResult, getTopicDir }: RegisterContext): Promise<{ success: true; registered: number; existing: number; total: number }> {
   log('register-sources', 'Extracting and registering citation URLs...');
 
   const researchPath = path.join(getTopicDir(topic), 'perplexity-research.json');
   if (!fs.existsSync(researchPath)) {
-    log('register-sources', 'No Perplexity research found, skipping');
-    return { success: false, error: 'No research data' };
+    throw new Error(
+      'register-sources: no Perplexity research file found at ' +
+      `${researchPath}. Cannot synthesize a citable page without research data. ` +
+      'Re-run the research phase or use --source-file. (QUA-290)'
+    );
   }
 
   const research: ResearchData = JSON.parse(fs.readFileSync(researchPath, 'utf-8'));
@@ -125,6 +132,17 @@ export async function registerResearchSources(topic: string, { log, saveResult, 
   }
 
   log('register-sources', `Found ${registered.length} new sources, ${existing.length} already in resources`);
+
+  const total = registered.length + existing.length;
+  if (total === 0) {
+    throw new Error(
+      'register-sources: 0 usable citation URLs after parsing ' +
+      `${researchPath}. The research phase produced no citations — likely a ` +
+      'Perplexity timeout, rate-limit, or empty-result. Refusing to ' +
+      'synthesize a page that cannot be cited; placeholder footnotes are ' +
+      'not acceptable. (QUA-290)'
+    );
+  }
 
   saveResult(topic, 'registered-sources.json', {
     topic,

--- a/crux/authoring/page-creator.ts
+++ b/crux/authoring/page-creator.ts
@@ -344,7 +344,16 @@ async function runPipeline(topic: string, tier: string = 'standard', directions:
       log(phase, `Failed: ${error.message}`);
       results.phases[phase] = { success: false, error: error.message };
 
-      if (phase.includes('research') || phase.includes('synthesize') || phase === 'load-source-file') {
+      // Phases that produce inputs synthesis depends on. If any of these
+      // fail, continuing into synthesis would emit a broken page (e.g.,
+      // placeholder footnotes when register-sources yields zero URLs —
+      // QUA-290). Hard-fail the pipeline instead.
+      if (
+        phase.includes('research') ||
+        phase.includes('synthesize') ||
+        phase === 'load-source-file' ||
+        phase === 'register-sources'
+      ) {
         break;
       }
     }


### PR DESCRIPTION
## Summary
The `crux w create` pipeline silently emitted placeholder footnotes (`[^N]: Source name (no link)`) when the `register-sources` phase produced zero citation URLs — usually because Perplexity timed out, hit a rate limit, or returned empty `citations[]` arrays. The synthesis prompt was explicitly instructed to invent freeform footnotes when URLs were absent, and the pipeline never noticed because:

1. `registerResearchSources` returned `{success: false, error: ...}` on missing research, and `{success: true}` even when the URL count was 0. Neither path threw.
2. The `catch` block in `page-creator`'s run loop only `break`s on phases matching `/research|synthesize|load-source-file/` — `register-sources` matched none, so even a thrown error would just be logged and the pipeline would march into synthesis.

QUA-291 added an advisory `validate-placeholder-citations` gate check to **detect** the symptom after the fact. This PR fixes the **upstream cause**.

## Changes
- **`crux/authoring/creator/source-fetching.ts`** — `registerResearchSources` now THROWS when `perplexity-research.json` is missing OR when zero usable http(s) URLs are produced. Errors are tagged with `QUA-290` for traceability. Return type narrowed from `{success: boolean; error?: ...}` to `{success: true; ...}` since the failure path is now exceptional.
- **`crux/authoring/page-creator.ts`** — added `register-sources` to the break-on-failure phase set. A thrown error from this phase now halts the pipeline before synthesis runs, instead of being logged and ignored.
- **`crux/authoring/creator/source-fetching.test.ts`** (new) — 12 unit tests covering missing-file, empty citations, non-http citations, deduplication, the success path, and the QUA-290 traceability tag. Tests use a tmpdir + mocked `getResourceByUrl` to exercise the real function end-to-end.

## Out of scope (filed as follow-up)
The architectural fix is to rewrite the synthesis prompt to use `<R id="rc-...">` + `[^rc-...]` exclusively and forbid freeform `[^N]:` definitions entirely. That requires plumbing the registered resource IDs into the prompt and possibly registering URLs to the PG `resources` table (currently `registerResearchSources` only writes a JSON file). Larger scope; will file separately if not covered elsewhere.

## Test plan
- [x] `pnpm vitest run crux/authoring/creator/source-fetching.test.ts` → 12/12 pass
- [x] `pnpm vitest run crux/authoring/creator/creator.test.ts crux/authoring/creator/deployment.test.ts` → 40/40 pass (no regressions)
- [x] crux tsc error count unchanged (still 87, no new errors in touched files)
- [ ] CI green

Closes QUA-290
