### PR TITLE
fix: content-based f_ fact ID detection (QUA-354 followup to QUA-346)

### DIFF
--- a/.claude/rules/source-check-system.md
+++ b/.claude/rules/source-check-system.md
@@ -15,9 +15,9 @@ Agents have repeatedly proposed "add a coverage/source-check score column to X" 
 - **Migration**: `0127` unified the legacy `record_verifications` + `record_verdicts` + `factbase_resource_verifications` + `factbase_verdicts` into these two tables. Don't create new verdict tables.
 - `things.verdict` — removed. Verdicts now live only in `source_check_verdicts`.
 
-## 2. Wiki-server endpoints (`/api/source-checks/*`)
+## 2. Wiki-server endpoints (`/api/sourcing/*`)
 
-All in `apps/wiki-server/src/routes/source-check/source-checks.ts`, mounted in `app.ts:203`.
+All in `apps/wiki-server/src/routes/sourcing/sourcing.ts`, mounted in `app.ts`. The legacy `/api/source-checks/*` path is kept as a backward-compat alias.
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -73,7 +73,7 @@ If you're about to add a "show source-check status on X page", first grep for `R
 ## 6. Internal dashboards
 
 - **Source Checks** (E2200) — `/internal/entity-source-checks/` — main dashboard. Subcomponents: `action-queue.tsx`, `claims-viewer.tsx`, `coverage-bars.tsx`, `source-check-tabs.tsx`
-- **Source Check Coverage** — `/internal/source-check-coverage/` — loads `/api/source-checks/stats`, coverage-matrix, verdict-matrix
+- **Source Check Coverage** — `/internal/source-check-coverage/` — loads `/api/sourcing/stats`, coverage-matrix, verdict-matrix
 - **Citation Accuracy** (E917) — `/internal/citation-accuracy/`
 - **Data Quality** (E2600) — `/internal/data-quality/`
 - **People Coverage** (E1099) — entity coverage scores for people

--- a/apps/web/e2e/production-release-verification.spec.ts
+++ b/apps/web/e2e/production-release-verification.spec.ts
@@ -192,12 +192,12 @@ test.describe("5. Legislation pages", () => {
   });
 });
 
-// ─── 6. Source Checks dashboard ────────────────────────────────────────────
+// ─── 6. Sourcing dashboard ────────────────────────────────────────────────
 
-test.describe("6. Source Checks", () => {
-  test("/source-checks dashboard loads", async ({ page }) => {
+test.describe("6. Sourcing", () => {
+  test("/sourcing dashboard loads", async ({ page }) => {
     const { pageErrors } = setupErrorCollector(page);
-    const response = await page.goto("/source-checks", {
+    const response = await page.goto("/sourcing", {
       waitUntil: "networkidle",
       timeout: 45000,
     });
@@ -396,25 +396,25 @@ test.describe("14. Publications", () => {
   });
 });
 
-// ─── 15. Source checks detail ──────────────────────────────────────────────
+// ─── 15. Sourcing detail ──────────────────────────────────────────────────
 
-test.describe("15. Source checks detail page", () => {
-  test("a specific source check fact page loads", async ({ page }) => {
+test.describe("15. Sourcing detail page", () => {
+  test("a specific sourcing fact page loads", async ({ page }) => {
     const { pageErrors } = setupErrorCollector(page);
 
-    // Navigate to source-checks first to find a real fact link
-    await page.goto("/source-checks", {
+    // Navigate to sourcing first to find a real fact link
+    await page.goto("/sourcing", {
       waitUntil: "networkidle",
       timeout: 45000,
     });
 
     // Try to find a link to a specific fact check
-    const factLink = page.locator('a[href*="/source-checks/fact/"]').first();
+    const factLink = page.locator('a[href*="/sourcing/fact/"]').first();
     const hasFactLink = (await factLink.count()) > 0;
 
     if (hasFactLink) {
       const href = await factLink.getAttribute("href");
-      console.log(`  Found source-check fact link: ${href}`);
+      console.log(`  Found sourcing fact link: ${href}`);
       const detailResponse = await page.goto(href!, {
         waitUntil: "networkidle",
         timeout: 45000,
@@ -425,7 +425,7 @@ test.describe("15. Source checks detail page", () => {
     } else {
       // If no fact links on the page, try a known pattern
       const detailResponse = await page.goto(
-        "/source-checks/fact/EF_ORG_0001_revenue_1",
+        "/sourcing/fact/EF_ORG_0001_revenue_1",
         { waitUntil: "networkidle", timeout: 45000 }
       );
       // May 404 if the specific ID doesn't exist — that's OK

--- a/apps/web/e2e/verify-redirects-misc.spec.ts
+++ b/apps/web/e2e/verify-redirects-misc.spec.ts
@@ -103,13 +103,13 @@ test.describe("3. Sources page (PR #3675)", () => {
   });
 });
 
-// ─── 4. Source-checks search with special characters ─────────────────────────
+// ─── 4. Sourcing search with special characters ─────────────────────────
 
-test.describe("4. Source-checks search (special chars)", () => {
-  test("/source-checks page loads and search with % and _ doesn't crash", async ({
+test.describe("4. Sourcing search (special chars)", () => {
+  test("/sourcing page loads and search with % and _ doesn't crash", async ({
     page,
   }) => {
-    const response = await page.goto("/source-checks", {
+    const response = await page.goto("/sourcing", {
       waitUntil: "networkidle",
       timeout: 30000,
     });
@@ -153,7 +153,7 @@ test.describe("4. Source-checks search (special chars)", () => {
     } else {
       // Try URL-based search if no input found
       const searchResponse = await page.goto(
-        "/source-checks?q=%25test%25",
+        "/sourcing?q=%25test%25",
         { waitUntil: "networkidle", timeout: 30000 }
       );
       const searchStatus = searchResponse?.status();
@@ -489,7 +489,7 @@ test.describe("Bonus: Key routes return valid responses", () => {
   const ROUTES = [
     { path: "/legislation/executive-order-14110", description: "EO-14110 legislation page" },
     { path: "/sources", description: "Sources page" },
-    { path: "/source-checks", description: "Source checks dashboard" },
+    { path: "/sourcing", description: "Sourcing dashboard" },
     { path: "/ai-models", description: "AI Models directory" },
     { path: "/benchmarks", description: "Benchmarks directory" },
     { path: "/grants", description: "Grants directory" },

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -258,6 +258,13 @@ const GLOBAL_HIDDEN_COLUMNS = new Set(["id"]);
 /** Max rows to show initially before "Show all" */
 const INITIAL_ROW_LIMIT = 20;
 
+// ── ID detection ──────────────────────────────────────────────────────────
+
+// FactBase fact IDs are `f_` + 8-12 alphanumeric chars (e.g. `f_dW5cR9mJ8q`).
+// Used by the cell renderer to detect raw fact IDs in any column and link them
+// to /factbase/fact/<id> instead of leaking the raw ID as visible text.
+const FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
+
 // ── Numeric formatting columns ────────────────────────────────────────────
 
 /** Columns representing monetary amounts (Drizzle returns numeric() as strings) */
@@ -340,11 +347,10 @@ function CellValue({
   }
 
   // FactBase fact IDs (f_xxx) -> render as link with "view →" label instead of leaking raw ID.
-  if (
-    (columnName === "fact_id" || columnName === "factId") &&
-    typeof value === "string" &&
-    value.startsWith("f_")
-  ) {
+  // Content-based, not column-name-gated: any cell value matching the fact-ID format gets
+  // rendered as a link, no matter which column it lives in. Mirrors how isAnySid() handles
+  // stableIds below, and prevents the recurring per-column patch loop (QUA-316, QUA-346).
+  if (typeof value === "string" && FACT_ID_RE.test(value)) {
     return (
       <Link
         href={`/factbase/fact/${encodeURIComponent(value)}`}


### PR DESCRIPTION
## Summary

Follow-up to PR #4244 (QUA-346) and PR #4224 (QUA-316) — replaces the column-name-gated `f_` fact-ID check in `entity-profile-viewer.tsx` with a content-based regex so the cell renderer catches **any** raw fact ID, not just the columns named `fact_id` / `factId`.

This is the second narrow patch in 24 hours for the same class of leak (raw `f_xxx` fact IDs surfacing in user-visible cells). Both prior PRs were column-name gated. This change makes the renderer match `^f_[A-Za-z0-9]{8,}$` regardless of column name, mirroring how `isAnySid()` handles stableId leaks elsewhere in the same file.

## Why

QUA-316 fixed `entity-fact-display.tsx` and was marked Done. Within hours QUA-346 surfaced the same leak from `entity-profile-viewer.tsx`. Both shipped as "fix the one component that's leaking" rather than "fix the class of leak". A third occurrence is just a matter of which rendering path the next agent touches.

The root fix: detect by content, not by column name.

```ts
// Before (column-gated)
if ((columnName === "fact_id" || columnName === "factId") && value.startsWith("f_")) { ... }

// After (content-based)
const FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
if (typeof value === "string" && FACT_ID_RE.test(value)) { ... }
```

## Also in this PR

Source-fixes for the `/source-checks → /sourcing` rename:

- `apps/web/e2e/verify-redirects-misc.spec.ts` — calls `/sourcing` directly
- `apps/web/e2e/production-release-verification.spec.ts` — same
- `.claude/rules/source-check-system.md` — `/api/source-checks` → `/api/sourcing`

The `next.config.ts` redirect itself stays — it's legitimate user-bookmark backward-compat.

## Followups filed

- **QUA-354** — build-time validator parallel to `validate-rendered-sid.ts` (this is the systemic miss — a build-time check would have caught both QUA-316 and QUA-346 before they shipped)
- **QUA-355** — instrument `/agent-review-pr` to track dispatched-PR clean rate
- **QUA-356** — add narrow-patch detection at review time so column-gated checks in class-shaped problems get flagged

## Test plan

- [x] `pnpm test` (apps/web) — 1449/1449 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge: `apps/web/e2e/no-raw-ids.spec.ts` against prod still passes (it's the runtime regression check for this class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
