### PR TITLE
review(QUA-352): strengthen rate-limit tests + comment fixes

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -381,7 +381,7 @@ audits:
       4. Confirm the FK has ON DELETE CASCADE: `SELECT confdeltype FROM pg_constraint WHERE conname = 'hallucination_risk_snapshots_page_id_wiki_pages_id_fk'` — should be 'c'
     frequency: weekly
     added: "2026-04-12"
-    added_by_pr: null  # QUA-352 PR
+    added_by_pr: 4261
     last_checked: null
     last_result: null
     history: []

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -14,7 +14,10 @@ vi.mock("../notify.js", () => ({
   sendDiscordNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { snapshotRetention } from "./snapshot-retention.js";
+import {
+  snapshotRetention,
+  __resetMissingKeyRateLimitForTest,
+} from "./snapshot-retention.js";
 import { sendDiscordNotification } from "../notify.js";
 import type { Config } from "../config.js";
 
@@ -53,6 +56,7 @@ describe("snapshotRetention", () => {
     config = makeConfig();
     process.env["LONGTERMWIKI_SERVER_API_KEY"] = "test-key";
     sendDiscordNotificationMock.mockClear();
+    __resetMissingKeyRateLimitForTest();
   });
 
   afterEach(() => {
@@ -138,28 +142,47 @@ describe("snapshotRetention", () => {
   });
 
   it("rate-limits the missing-API-key Discord warning to once per day", async () => {
-    // Use a fresh module instance so the module-level `lastMissingKeyWarnAt`
-    // counter is reset — otherwise the previous test's call has already
-    // tripped the counter inside the same process.
-    vi.resetModules();
-    const freshModule = await import("./snapshot-retention.js");
-    const notifyModule = await import("../notify.js");
-    const freshDiscordMock = vi.mocked(notifyModule.sendDiscordNotification);
-    freshDiscordMock.mockClear();
-
     delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     // First call fires a Discord warning.
-    const r1 = await freshModule.snapshotRetention(config);
+    const r1 = await snapshotRetention(config);
     expect(r1.success).toBe(false);
-    expect(freshDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendDiscordNotificationMock).toHaveBeenCalledTimes(1);
 
     // Second call within the same process/day must NOT fire a second warning.
-    const r2 = await freshModule.snapshotRetention(config);
+    const r2 = await snapshotRetention(config);
     expect(r2.success).toBe(false);
-    expect(freshDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendDiscordNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fires the missing-API-key Discord warning after 24h elapses", async () => {
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.useFakeTimers();
+    try {
+      const t0 = new Date("2026-04-12T00:00:00Z").getTime();
+      vi.setSystemTime(t0);
+
+      // First call at t=0 fires.
+      await snapshotRetention(config);
+      expect(sendDiscordNotificationMock).toHaveBeenCalledTimes(1);
+
+      // Just under 24h later — still suppressed.
+      vi.setSystemTime(t0 + 24 * 60 * 60 * 1000 - 1000);
+      await snapshotRetention(config);
+      expect(sendDiscordNotificationMock).toHaveBeenCalledTimes(1);
+
+      // Just over 24h later — fires again.
+      vi.setSystemTime(t0 + 24 * 60 * 60 * 1000 + 1000);
+      await snapshotRetention(config);
+      expect(sendDiscordNotificationMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("still runs second cleanup when first throws", async () => {

--- a/apps/groundskeeper/src/tasks/snapshot-retention.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.ts
@@ -9,8 +9,15 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 // Module-level state so the missing-API-key Discord alert fires at most once
 // per day even if the task is configured to run more often than daily. Resets
 // on process restart, which is desirable — a pod restart warrants a fresh
-// warning so operators know the key is still missing.
+// warning so operators know the key is still missing. Assumes the groundskeeper
+// runs as a singleton deployment (replicas=1); multi-replica scaling would
+// produce up to N alerts per day, one per replica.
 let lastMissingKeyWarnAt = 0;
+
+/** Test-only: reset the missing-API-key rate-limit counter. */
+export function __resetMissingKeyRateLimitForTest(): void {
+  lastMissingKeyWarnAt = 0;
+}
 
 interface CleanupResult {
   deleted: number;

--- a/apps/wiki-server/scripts/validate-hallucination-risk-snapshots-fk.sql
+++ b/apps/wiki-server/scripts/validate-hallucination-risk-snapshots-fk.sql
@@ -9,9 +9,9 @@
 -- Usage:
 --   psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/validate-hallucination-risk-snapshots-fk.sql
 --
--- Safe to re-run: the validation is idempotent, and the NOT EXISTS guard
--- aborts cleanly if the FK was already validated (convalidated = true) so
--- reruns don't take a lock unnecessarily.
+-- Safe to re-run: the validation is idempotent, and the `convalidated` check
+-- returns early if the FK was already validated so reruns don't take a lock
+-- unnecessarily.
 
 DO $$
 DECLARE


### PR DESCRIPTION
## Summary

Follow-up fixes from `/agent-review-pr` after PR #4261 (QUA-352 Phase 3) was merged. These are targeted improvements to the test harness and comments that didn't block shipping the original fix but were flagged by a hostile code-review subagent.

Refs QUA-352.

## Changes

- **`snapshot-retention.ts`**: export `__resetMissingKeyRateLimitForTest()` so tests can reset the module-level `lastMissingKeyWarnAt` counter via a typed helper. Also documents that the counter assumes `replicas=1` for the groundskeeper deployment (multi-replica would produce up to N alerts per day).
- **`snapshot-retention.test.ts`**:
  - Rewrite the existing "rate-limits once per day" test to call the reset helper in `beforeEach` instead of the fragile `vi.resetModules()` + dynamic re-import pattern. The re-import pattern is sensitive to vitest's mock-hoisting semantics and is known to break across vitest upgrades.
  - Add a new test **`re-fires the missing-API-key Discord warning after 24h elapses`** using `vi.useFakeTimers()` + `vi.setSystemTime()` that advances past `ONE_DAY_MS` and verifies the warning re-fires. The previous tests only covered back-to-back suppression (t=0 + t≈0), not the reset path.
- **`validate-hallucination-risk-snapshots-fk.sql`**: fix a misleading comment that said "the NOT EXISTS guard aborts cleanly" when the actual early-return is on `convalidated`. The script hasn't been run on prod yet (it's the post-deploy manual step), so the comment is still live documentation.
- **`.claude/audits.yaml`**: set `added_by_pr: 4261` (was `null` at PR-write time because the merged PR number wasn't known).

## Groundskeeper snapshot-retention tests: 7 → 8

New test count: 8 passing. The added 24h-reset test catches a regression where `lastMissingKeyWarnAt = Infinity` (or similar) would silently pass all prior tests.

## Explicitly not included

The hostile review also flagged that migration `0177_hallucination_risk_snapshots_fk_cascade.sql` uses a dynamic `pg_constraint` drop that in principle could match a single-column FK on `page_id` referencing a table other than `wiki_pages`. The fix would be to add `con.confrelid = 'wiki_pages'::regclass` to the WHERE clause. That's defensible but **not worth a new migration now that 0177 has already run on prod** — a follow-up migration would either be a no-op (the FK has already been recreated with CASCADE) or would thrash it unnecessarily. If the migration ever ships to a new environment, the existing code has been revisited and the risk is hypothetical (no other FK on that column exists).

## Test plan

- [x] `npx vitest run apps/groundskeeper/src/tasks/snapshot-retention.test.ts` — 8/8 pass
- [x] `npx tsc --noEmit` on wiki-server and groundskeeper — clean
- [x] Existing tests still pass after the reset-helper refactor (`beforeEach` runs the reset in every test, not just the ones that test the missing-key path)

Fixes QUA-352
