### PR TITLE
feat(pr-patrol): structured fingerprint + repo threading for health-gate (QUA-309)

### DIFF
--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -414,4 +414,86 @@ describe('fingerprintIssue', () => {
     expect(a).toBe('ratchet-drift:sourcing');
     expect(b).toBe('ratchet-drift:review-marker');
   });
+
+  // ── QUA-309: structured fingerprintKey ─────────────────────────────────────
+
+  it('prefers structured fingerprintKey over reason regex when both are present', () => {
+    const fp = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      // Reason text that the regex would parse as "different baseline"
+      reason: 'sourcing baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+      fingerprintKey: 'review-marker', // Override
+    });
+    expect(fp).toBe('ratchet-drift:review-marker');
+  });
+
+  it('uses structured fingerprintKey for non-ratchet issue types', () => {
+    const fp = fingerprintIssue({
+      type: 'main-ci-red',
+      score: 180,
+      reason: 'main has been red for 5 commits',
+      detectedAt: NOW.toISOString(),
+      fingerprintKey: 'workflow-X',
+    });
+    expect(fp).toBe('main-ci-red:workflow-X');
+  });
+
+  it('falls back to type alone when fingerprintKey absent for non-ratchet types', () => {
+    const fp = fingerprintIssue({
+      type: 'main-ci-red',
+      score: 180,
+      reason: 'main is red',
+      detectedAt: NOW.toISOString(),
+    });
+    expect(fp).toBe('main-ci-red');
+  });
+
+  it('falls back to regex parsing when ratchet issue has no fingerprintKey (back-compat)', () => {
+    // Older HealthIssue objects in the cooldown store predate the
+    // fingerprintKey field. The regex fallback must still work.
+    const fp = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'legacy-ratchet baseline bumped 3× ↑',
+      detectedAt: NOW.toISOString(),
+      // intentionally no fingerprintKey
+    });
+    expect(fp).toBe('ratchet-drift:legacy-ratchet');
+  });
+
+  it('falls back to "unknown" suffix when ratchet reason cannot be regex-parsed', () => {
+    const fp = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'something completely different',
+      detectedAt: NOW.toISOString(),
+    });
+    expect(fp).toBe('ratchet-drift:unknown');
+  });
+
+  it('survives a reason text edit when fingerprintKey is set (the bug QUA-309 fixes)', () => {
+    // Imagine the reason string format changes from "X baseline bumped..."
+    // to "Baseline X has drifted...". Without fingerprintKey, the regex
+    // would return "unknown" for both files and collapse them. With
+    // fingerprintKey, separation is preserved.
+    const a = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'Baseline foo has drifted 3× upward in 24h',
+      detectedAt: NOW.toISOString(),
+      fingerprintKey: 'foo',
+    });
+    const b = fingerprintIssue({
+      type: 'ratchet-drift',
+      score: 150,
+      reason: 'Baseline bar has drifted 3× upward in 24h',
+      detectedAt: NOW.toISOString(),
+      fingerprintKey: 'bar',
+    });
+    expect(a).toBe('ratchet-drift:foo');
+    expect(b).toBe('ratchet-drift:bar');
+    expect(a).not.toBe(b);
+  });
 });

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -84,6 +84,12 @@ export interface HealthGateDeps {
     /** Write a plain numeric counter. */
     setCount?: (key: string, n: number) => void;
   };
+  /**
+   * Override the GitHub repo scanned by the default `realHealthScan`. Has no
+   * effect when a custom `scan` is provided. Defaults to the package's
+   * `REPO` constant. (QUA-309)
+   */
+  repo?: string;
 }
 
 // ── Fingerprinting ───────────────────────────────────────────────────────────
@@ -93,8 +99,15 @@ export interface HealthGateDeps {
  * Collapses `deploy-stuck` issues to a single key per cycle even if the
  * failing run URL differs, so retries of the same deploy failure don't
  * keep resetting the cooldown.
+ *
+ * Prefers `issue.fingerprintKey` when set (structured, populated by
+ * `combineHealth`). Falls back to regex-parsing `issue.reason` for backward
+ * compatibility with older HealthIssue objects in the cooldown store. (QUA-309)
  */
 export function fingerprintIssue(issue: HealthIssue): string {
+  if (issue.fingerprintKey) {
+    return `${issue.type}:${issue.fingerprintKey}`;
+  }
   // For ratchet drift we want separate cooldowns per file — include the reason
   // snippet that names the file. For deploy-stuck / main-ci-red, the type
   // alone is stable enough.
@@ -185,7 +198,7 @@ function syntheticScanFailureResult(message: string): HealthScanResult {
  * update) happen via the injected deps.
  */
 export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGateDecision> {
-  const scan = deps.scan ?? realHealthScan;
+  const scan = deps.scan ?? (() => realHealthScan({ repo: deps.repo }));
   const nowFn = deps.now ?? (() => new Date());
   const env = deps.env ?? process.env;
   const writeEvent = deps.writeEvent ?? ((entry) => appendJsonl(JSONL_FILE, entry));

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -595,6 +595,59 @@ describe('combineHealth with ratchet drift', () => {
     expect(combined.issues[0].reason).toBe('sourcing bumped 3× ↑');
   });
 
+  // ── QUA-309: structured fingerprintKey ──────────────────────────────────────
+
+  it('populates fingerprintKey on ratchet-drift issues from drift.name', () => {
+    const deploy = evaluateDeployStatus([run({ conclusion: 'success' })]);
+    const mainCi = evaluateMainCi([commit({ conclusion: 'success' })]);
+    const ratchet: RatchetDriftResult = {
+      healthy: false,
+      reason: 'two files drifted',
+      drifts: [
+        {
+          file: 'sourcing.json',
+          name: 'sourcing',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'sourcing bumped 3× ↑',
+        },
+        {
+          file: 'review-marker.json',
+          name: 'review-marker',
+          direction: 'up',
+          bumpCount: 3,
+          bumps: [],
+          drifted: true,
+          reason: 'review-marker bumped 3× ↑',
+        },
+      ],
+    };
+    const combined = combineHealth(deploy, mainCi, ratchet, now);
+    const driftIssues = combined.issues.filter((i) => i.type === 'ratchet-drift');
+    expect(driftIssues).toHaveLength(2);
+    expect(driftIssues[0].fingerprintKey).toBe('sourcing');
+    expect(driftIssues[1].fingerprintKey).toBe('review-marker');
+  });
+
+  it('does not populate fingerprintKey on deploy-stuck or main-ci-red issues', () => {
+    const deploy = evaluateDeployStatus([
+      run({ id: 1, conclusion: 'failure' }),
+      run({ id: 2, conclusion: 'failure' }),
+    ]);
+    const mainCi = evaluateMainCi([
+      commit({ sha: 'a', conclusion: 'failure' }),
+      commit({ sha: 'b', conclusion: 'failure' }),
+      commit({ sha: 'c', conclusion: 'failure' }),
+    ]);
+    const combined = combineHealth(deploy, mainCi, emptyRatchet(), now);
+    const deployStuck = combined.issues.find((i) => i.type === 'deploy-stuck');
+    const mainCiRed = combined.issues.find((i) => i.type === 'main-ci-red');
+    expect(deployStuck?.fingerprintKey).toBeUndefined();
+    expect(mainCiRed?.fingerprintKey).toBeUndefined();
+  });
+
   it('ranks deploy-stuck > main-ci-red > ratchet-drift', () => {
     expect(DEPLOY_STUCK_SCORE).toBeGreaterThan(MAIN_CI_RED_SCORE);
     expect(MAIN_CI_RED_SCORE).toBeGreaterThan(RATCHET_DRIFT_SCORE);

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -117,6 +117,16 @@ export interface HealthIssue {
   /** Most-relevant link (failing run URL, failing commit URL). */
   url?: string;
   detectedAt: string;
+  /**
+   * Optional structured key used by the gate's cooldown fingerprint. When set,
+   * the gate prefers this over regex-parsing the `reason` string. Used by
+   * ratchet-drift to scope cooldowns per file: the fingerprint becomes
+   * `<type>:<fingerprintKey>` instead of relying on a brittle reason match.
+   * Set this whenever the issue type needs sub-cooldowns (per file, per
+   * workflow, etc.). Leave undefined when the type alone is the right scope.
+   * (QUA-309)
+   */
+  fingerprintKey?: string;
 }
 
 /**
@@ -617,6 +627,9 @@ export function combineHealth(
       score: RATCHET_DRIFT_SCORE,
       reason: drift.reason,
       detectedAt,
+      // Per-file cooldown key. Without this, the gate has to regex-parse
+      // `reason` to scope per file — fragile if reason text changes.
+      fingerprintKey: drift.name,
     });
   }
 
@@ -653,14 +666,17 @@ export async function checkDeployStatus(
     branch?: string;
     limit?: number;
     now?: Date;
+    /** Override the default `owner/name`. Defaults to the package's REPO constant. */
+    repo?: string;
   } = {},
 ): Promise<DeployStatusResult> {
   const workflow = options.workflow ?? WIKI_SERVER_DEPLOY_WORKFLOW;
   const branch = options.branch ?? 'production';
   const limit = options.limit ?? 5;
+  const repo = options.repo ?? REPO;
 
   const resp = await githubApi<ListRunsResponse>(
-    `/repos/${REPO}/actions/workflows/${encodeURIComponent(workflow)}/runs` +
+    `/repos/${repo}/actions/workflows/${encodeURIComponent(workflow)}/runs` +
       `?branch=${encodeURIComponent(branch)}&per_page=${limit}`,
   );
 
@@ -767,11 +783,18 @@ export function mapRollupState(
  * Throws if either GitHub call fails (5xx, rate limit, network). Phase 3 is
  * responsible for deciding policy on scanner failure — a transient API hiccup
  * shouldn't silently look like "healthy".
+ *
+ * Pass `repo` (e.g. `"my-org/my-repo"`) to scan a non-default repository.
+ * Defaults to the package's `REPO` constant. (QUA-309)
  */
-export async function healthScan(now: Date = new Date()): Promise<HealthScanResult> {
+export async function healthScan(
+  options: { now?: Date; repo?: string } = {},
+): Promise<HealthScanResult> {
+  const now = options.now ?? new Date();
+  const repo = options.repo;
   const [deploy, mainCi] = await Promise.all([
-    checkDeployStatus({ now }),
-    checkMainCi(),
+    checkDeployStatus({ now, repo }),
+    checkMainCi({ repo }),
   ]);
   const ratchet = checkRatchetDrift({ now });
   return combineHealth(deploy, mainCi, ratchet, now);


### PR DESCRIPTION
## Summary
Two follow-ups from the QUA-300 review. The third item in the ticket (permanent-red fallback) is **intentionally deferred** per the ticket author's note: *"maybe only file this if we actually observe the failure mode in prod."*

### (1) Structured fingerprint — fixes a latent ratchet-drift cooldown bug
`fingerprintIssue()` in `health-gate.ts` regex-parses `issue.reason` to extract a per-file scope for ratchet-drift cooldowns:

```ts
const match = issue.reason.match(/^(\S+(?:\s\S+)?)\s+baseline/);
return `ratchet-drift:${match?.[1] ?? 'unknown'}`;
```

If anyone edits the reason string template in `health-scan.ts`'s `evaluateRatchetDrift`, every per-file cooldown collapses to `ratchet-drift:unknown` and stops scoping correctly — multiple files would share a single 30-min cooldown.

**Fix:** add an optional `fingerprintKey?: string` field to `HealthIssue`. `combineHealth()` populates it from `drift.name`. `fingerprintIssue()` prefers the structured key over the regex fallback. The regex path is retained for back-compat with older `HealthIssue` objects already in the cooldown store.

### (3) Optional repo threading
`checkDeployStatus()` previously hardcoded the package's `REPO` constant in its URL path; only `checkMainCi()` accepted a `repo?` override. Adds the same option to `checkDeployStatus()`, threads it through `healthScan()`'s new options-object signature, and adds a `repo?` to `HealthGateDeps` so `runHealthGate()` can pass it through to the default scan call. All defaults preserved — patrol entry point and existing tests are unchanged.

`healthScan` signature change: `healthScan(options?: {now?, repo?})` instead of `healthScan(now: Date)`. The only call site outside tests is `realHealthScan` in `health-gate.ts`, which is wrapped to pass `{repo}`.

## Out of scope
- **(2) Permanent-red fallback** — deferred per author note. Would let patrol resume PR work after N+ cycles of unhealthy state, with a counter in the cooldown store. The author flagged this as speculative until the failure mode is observed in prod. Filing a follow-up ticket if/when the need is observed.

## Test plan
- [x] `pnpm vitest run crux/pr-patrol/health-gate.test.ts crux/pr-patrol/health-scan.test.ts` → 84/84 pass (was 76; added 8 new)
- [x] 6 new fingerprint tests in `health-gate.test.ts`: structured key precedence, fallback for non-ratchet types, fallback to regex for legacy ratchet issues, "reason text edit doesn't break scoping" regression test (the bug QUA-309 documents)
- [x] 2 new `combineHealth` tests in `health-scan.test.ts`: ratchet-drift issues get `fingerprintKey` from `drift.name`; deploy-stuck / main-ci-red issues do not
- [x] Crux TS error count unchanged at 87 (QUA-338-tracked baseline)
- [ ] CI green

Closes QUA-309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Implemented structured fingerprinting for health issues to enable more reliable issue identification and prevent false collapses when issue descriptions change
- Extended health scanning with optional repository-level configuration for improved multi-repository workflow support
- Enhanced ratchet-drift tracking with explicit fingerprint keys derived from drift sources for better issue deduplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->