### PR TITLE
feat(crux): review pattern registry — validators + diff-triggered checklist + attestation (QUA-363)

### DIFF
--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -320,6 +320,30 @@ All three must pass. If no changes were made during review, this phase is redund
 
 ---
 
+## Phase 9.5: Attest every review pattern (QUA-363, option E) — MANDATORY
+
+The `agent-checklist init` step at the start of your session scanned the diff for known bug shapes (`readdirSync` in priority loops, GitHub conclusion regexes, new command handlers without try/catch, numeric-ID substring collisions, permissive test fakes) and injected forced `review-*` checklist items for each match.
+
+Before writing the review marker you **must** visit every injected pattern item and either:
+
+1. **Confirm no finding** → `pnpm crux sys agent-checklist check review-<pattern-id>`
+2. **Address the finding** (fix code / add test / simplify) then check it off, OR
+3. **Mark N/A with reason** → `pnpm crux sys agent-checklist check --na review-<pattern-id> --reason "why this pattern doesn't apply here"` (do NOT use `--na` lightly — the pattern is in the checklist because the diff matched it)
+
+Run this to see what needs attention:
+
+```bash
+pnpm crux gh review-patterns check
+```
+
+Exit 0 = all pattern items attested. Exit 1 = one or more `review-*` items still unchecked — that means `/agent-ship` will block at the `agent-checklist complete` step.
+
+**You are not done reviewing until `gh review-patterns check` exits 0.** Do not write the review marker (Phase 10b) until this passes.
+
+Why this step exists: the QUA-339 review-pass-2 incident found that even a thorough hostile reviewer misses structural bugs (iteration-order determinism, enum exhaustiveness, prefix collisions) without explicit prompting. The pattern registry + injected items make each blind spot unmissable: the LLM cannot silently skip an item that is literally sitting in the checklist.
+
+---
+
 ## Phase 10: Update test plan and mark review complete
 
 ### 10a. Update PR test plan

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -226,6 +226,19 @@ Include `reviewed: true` or `reviewed: false` in the session log payload sent to
 
 Run `pnpm crux sys agent-checklist complete` — must exit 0 (all items checked or N/A).
 
+Then verify every review-pattern attestation (QUA-363, option E):
+
+```bash
+pnpm crux gh review-patterns check
+```
+
+This MUST exit 0. If it exits 1, one or more `review-*` items from the diff-triggered pattern scan are still unchecked. Do NOT ship. Go back to `/agent-review-pr` (or inspect each finding manually), then either:
+
+- Check it off: `pnpm crux sys agent-checklist check review-<pattern-id>`
+- Mark N/A with reason: `pnpm crux sys agent-checklist check --na review-<pattern-id> --reason "..."`
+
+The pattern registry is deliberately narrow — items only appear when the diff matches a documented prior-incident bug shape. An unchecked `review-*` item means you have a real blind spot to close.
+
 ## Step 8: Ship
 
 Run `/agent-push-and-verify`.

--- a/crux/commands/__tests__/review-patterns.test.ts
+++ b/crux/commands/__tests__/review-patterns.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectPatternAttestations,
+  allAttested,
+} from '../review-patterns.ts';
+import type { ParsedItem } from '../../lib/session/session-checklist.ts';
+
+function item(id: string, status: 'checked' | 'unchecked' | 'na', naReason?: string): ParsedItem {
+  return { id, label: `test label for ${id}`, status, naReason };
+}
+
+describe('collectPatternAttestations', () => {
+  it('returns only review-* items', () => {
+    const items: ParsedItem[] = [
+      item('duplicate-check', 'checked'),
+      item('review-github-conclusion-enum', 'unchecked'),
+      item('tests-written', 'unchecked'),
+      item('review-readdir-iteration-determinism', 'checked'),
+    ];
+    const results = collectPatternAttestations(items);
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.patternId).sort()).toEqual([
+      'github-conclusion-enum',
+      'readdir-iteration-determinism',
+    ]);
+  });
+
+  it('resolves the pattern reason from the registry', () => {
+    const items: ParsedItem[] = [
+      item('review-github-conclusion-enum', 'unchecked'),
+    ];
+    const r = collectPatternAttestations(items)[0];
+    expect(r.reason).toContain('timed_out');
+  });
+
+  it('reports "(unknown pattern...)" for unregistered pattern ids', () => {
+    const items: ParsedItem[] = [
+      item('review-fake-pattern-that-does-not-exist', 'checked'),
+    ];
+    const r = collectPatternAttestations(items)[0];
+    expect(r.reason).toContain('unknown');
+  });
+
+  it('preserves status and naReason', () => {
+    const items: ParsedItem[] = [
+      item('review-numeric-id-substring-match', 'na', 'no numeric matching in this PR'),
+    ];
+    const r = collectPatternAttestations(items)[0];
+    expect(r.status).toBe('na');
+    expect(r.naReason).toContain('no numeric matching');
+  });
+});
+
+describe('allAttested', () => {
+  it('true when every pattern item is checked or na', () => {
+    const r = collectPatternAttestations([
+      item('review-github-conclusion-enum', 'checked'),
+      item('review-test-fake-silent-default', 'na', 'no fakes in this PR'),
+    ]);
+    expect(allAttested(r)).toBe(true);
+  });
+
+  it('false when any pattern item is unchecked', () => {
+    const r = collectPatternAttestations([
+      item('review-github-conclusion-enum', 'checked'),
+      item('review-test-fake-silent-default', 'unchecked'),
+    ]);
+    expect(allAttested(r)).toBe(false);
+  });
+
+  it('true when no pattern items exist', () => {
+    const r = collectPatternAttestations([
+      item('duplicate-check', 'unchecked'),
+    ]);
+    expect(allAttested(r)).toBe(true);
+  });
+});

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -183,8 +183,21 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
 
   // ── Pattern-triggered items (QUA-363, option B) ──────────────────────────
   // Scan the current diff for bug shapes and append forced checklist items.
-  // Best-effort: if git fails or no patterns trigger, this is a no-op.
-  const { items: patternItems, detections } = detectPatternItems(PROJECT_ROOT);
+  // Best-effort: if no patterns trigger, this is a no-op. If the diff
+  // cannot be read at all (e.g., 64MB+ release PR overflow, missing
+  // origin/main ref), we surface a visible warning — invisible detection
+  // failure is the whole bug class HIGH-2 addresses.
+  const { items: patternItems, detections, diffError } = detectPatternItems(PROJECT_ROOT);
+
+  let diffWarning = '';
+  if (diffError) {
+    diffWarning =
+      `\n${c.yellow}⚠ Pattern detection could not read the current diff:${c.reset}\n` +
+      `  ${c.dim}${diffError}${c.reset}\n` +
+      `  ${c.dim}Pattern items are NOT in the checklist. If this is a large PR,${c.reset}\n` +
+      `  ${c.dim}review-pattern attestation is disabled for this session.${c.reset}\n` +
+      `  ${c.dim}Fix: ensure \`git fetch origin main\` succeeds, then re-run init.${c.reset}\n`;
+  }
 
   let markdown = buildChecklist(type, metadata, patternItems);
 
@@ -366,6 +379,7 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   output += `  Items: ${status.totalItems}\n`;
   if (dbSynced) output += `  ${c.dim}Synced to wiki-server DB${c.reset}\n`;
   if (directoryWarning) output += directoryWarning;
+  if (diffWarning) output += diffWarning;
   if (linearBranchWarning) output += linearBranchWarning;
   if (issueStartOutput) output += `\n${issueStartOutput}`;
   if (linearStartOutput) output += `\n${linearStartOutput}`;

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -20,6 +20,7 @@ import {
   CHECKLIST_ITEMS,
   buildChecklistSnapshot,
   formatSnapshotAsYaml,
+  detectPatternItems,
   type SessionType,
   type ChecklistMetadata,
 } from '../lib/session/session-checklist.ts';
@@ -179,7 +180,46 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   }
 
   const metadata: ChecklistMetadata = { task, branch, timestamp: new Date().toISOString(), issue, linearId };
-  let markdown = buildChecklist(type, metadata);
+
+  // ── Pattern-triggered items (QUA-363, option B) ──────────────────────────
+  // Scan the current diff for bug shapes and append forced checklist items.
+  // Best-effort: if git fails or no patterns trigger, this is a no-op.
+  const { items: patternItems, detections } = detectPatternItems(PROJECT_ROOT);
+
+  let markdown = buildChecklist(type, metadata, patternItems);
+
+  // If any patterns triggered, append a short "Review patterns" section
+  // with the reasons — so the reviewer knows WHY each item exists.
+  if (detections.length > 0) {
+    const patternSection: string[] = [
+      '',
+      '## Review patterns (QUA-363)',
+      '',
+      '> These items were injected because the current diff matches bug shapes',
+      '> from prior review incidents. Each `review-*` item above must be checked',
+      '> off (or marked `--na` with `--reason`) before shipping.',
+      '',
+    ];
+    for (const { pattern, hits } of detections) {
+      patternSection.push(`### \`review-${pattern.id}\` — ${pattern.label}`);
+      patternSection.push('');
+      patternSection.push(`**Why**: ${pattern.reason}`);
+      if (pattern.origin) patternSection.push(`**Origin**: ${pattern.origin}`);
+      patternSection.push('');
+      patternSection.push('**Hits in current diff**:');
+      for (const hit of hits.slice(0, 8)) {
+        const loc = hit.line > 0 ? `:${hit.line}` : '';
+        patternSection.push(`- \`${hit.file}${loc}\` — \`${hit.snippet.slice(0, 120)}\``);
+      }
+      if (hits.length > 8) {
+        patternSection.push(`- … ${hits.length - 8} more`);
+      }
+      patternSection.push('');
+    }
+    // Insert the section AFTER the Key Decisions block so existing tooling
+    // that parses the top of the file is unaffected.
+    markdown += patternSection.join('\n') + '\n';
+  }
 
   if (!issue) {
     const naResult = checkItems(markdown, ['issue-tracking'], '~', 'no GitHub issue for this session');

--- a/crux/commands/review-patterns.ts
+++ b/crux/commands/review-patterns.ts
@@ -81,12 +81,21 @@ function loadChecklistItems(): ParsedItem[] | null {
 // Subcommands
 // ---------------------------------------------------------------------------
 
-// handler-safe: pure presentation over an already-parsed checklist file
 async function check(_args: string[], options: CommandOptions): Promise<CommandResult> {
-  const log = createLogger(options.ci);
+  const log = createLogger(options.ci as boolean | undefined);
   const c = log.colors;
 
-  const items = loadChecklistItems();
+  let items: ParsedItem[] | null;
+  try {
+    items = loadChecklistItems();
+  } catch (e) {
+    const msg = `Failed to read checklist at ${CHECKLIST_PATH}: ${e instanceof Error ? e.message : String(e)}`;
+    return {
+      exitCode: 1,
+      output: options.json ? JSON.stringify({ ok: false, error: msg }, null, 2) : `${c.red}${msg}${c.reset}\n`,
+    };
+  }
+
   if (!items) {
     return {
       exitCode: 1,
@@ -142,10 +151,12 @@ async function check(_args: string[], options: CommandOptions): Promise<CommandR
   }
 
   const results = collectPatternAttestations(items);
+  const ok = allAttested(results);
+
   if (options.json) {
     return {
-      exitCode: allAttested(results) ? 0 : 1,
-      output: JSON.stringify({ ok: allAttested(results), items: results }, null, 2),
+      exitCode: ok ? 0 : 1,
+      output: JSON.stringify({ ok, items: results }, null, 2),
     };
   }
 
@@ -170,7 +181,7 @@ async function check(_args: string[], options: CommandOptions): Promise<CommandR
     }
   }
 
-  if (allAttested(results)) {
+  if (ok) {
     lines.push('');
     lines.push(`${c.green}✓ All ${results.length} pattern item(s) attested.${c.reset}`);
     return { exitCode: 0, output: lines.join('\n') + '\n' };
@@ -210,7 +221,7 @@ async function list(_args: string[], options: CommandOptions): Promise<CommandRe
       ),
     };
   }
-  const log = createLogger(options.ci);
+  const log = createLogger(options.ci as boolean | undefined);
   const c = log.colors;
   const lines: string[] = [];
   lines.push(`${c.bold}Review patterns registered (${PATTERNS.length}):${c.reset}`);

--- a/crux/commands/review-patterns.ts
+++ b/crux/commands/review-patterns.ts
@@ -25,7 +25,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import type { CommandResult, CommandOptions } from '../lib/command-types.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
-import { parseChecklist, type ParsedItem } from '../lib/session/session-checklist.ts';
+import { parseChecklist, detectPatternItems, type ParsedItem } from '../lib/session/session-checklist.ts';
 import { getPatternById, PATTERNS } from '../lib/review-patterns/patterns.ts';
 import { createLogger } from '../lib/output.ts';
 
@@ -94,6 +94,51 @@ async function check(_args: string[], options: CommandOptions): Promise<CommandR
         `${c.red}No checklist found at ${CHECKLIST_PATH}.${c.reset}\n` +
         `Run \`pnpm crux sys agent-checklist init "task" --type=X\` first.\n`,
     };
+  }
+
+  // Freshness check: re-detect patterns from the current diff. If the diff
+  // has advanced since `init` (e.g., /agent-review-pr fixed code, or later
+  // commits introduced a new bug shape), any newly-triggered pattern would
+  // be invisible to the old checklist. Fail closed and point at `init` so
+  // the reviewer picks up the new items before shipping.
+  const { items: freshPatternItems } = detectPatternItems(PROJECT_ROOT);
+  const existingReviewIds = new Set(
+    items.filter((i) => i.id.startsWith('review-')).map((i) => i.id),
+  );
+  const missingFresh = freshPatternItems.filter(
+    (p) => !existingReviewIds.has(p.id),
+  );
+  if (missingFresh.length > 0) {
+    if (options.json) {
+      return {
+        exitCode: 1,
+        output: JSON.stringify(
+          {
+            ok: false,
+            reason: 'stale-checklist',
+            missing: missingFresh.map((p) => ({ id: p.id, label: p.label })),
+          },
+          null,
+          2,
+        ),
+      };
+    }
+    const lines: string[] = [];
+    lines.push(
+      `${c.red}✗ ${missingFresh.length} review pattern(s) triggered since checklist was generated:${c.reset}`,
+    );
+    lines.push('');
+    for (const p of missingFresh) {
+      lines.push(`  ${c.bold}${p.id}${c.reset} — ${p.label}`);
+    }
+    lines.push('');
+    lines.push(
+      `${c.dim}The checklist is stale. Re-run \`pnpm crux sys agent-checklist init\` to refresh,${c.reset}`,
+    );
+    lines.push(
+      `${c.dim}then address each new pattern before retrying ship.${c.reset}`,
+    );
+    return { exitCode: 1, output: lines.join('\n') + '\n' };
   }
 
   const results = collectPatternAttestations(items);

--- a/crux/commands/review-patterns.ts
+++ b/crux/commands/review-patterns.ts
@@ -1,0 +1,205 @@
+/**
+ * Review patterns command — QUA-363 option E.
+ *
+ * Verifies that every pattern item in the current session checklist has
+ * been either:
+ *   - Explicitly checked off (reviewer confirmed no finding or addressed it)
+ *   - Marked `--na` with a reason
+ *
+ * Exits non-zero if any `review-*` item is still unchecked, blocking
+ * `/agent-review-pr` from claiming a clean pass.
+ *
+ * The mechanic: the diff-triggered checklist items (option B) are sitting
+ * in `.claude/wip-checklist.md`. This command parses that file, finds
+ * every `review-<pattern-id>` item, and attests that the reviewer visited
+ * each one. Combined with the `agent-checklist complete` step, unaddressed
+ * patterns cannot silently slip through.
+ *
+ * Usage:
+ *   crux gh review-patterns check         # exit 0 if all attested, 1 otherwise
+ *   crux gh review-patterns list          # show all review-* items + status
+ *   crux gh review-patterns list --json   # JSON output for tools
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { CommandResult, CommandOptions } from '../lib/command-types.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { parseChecklist, type ParsedItem } from '../lib/session/session-checklist.ts';
+import { getPatternById, PATTERNS } from '../lib/review-patterns/patterns.ts';
+import { createLogger } from '../lib/output.ts';
+
+const CHECKLIST_PATH = join(PROJECT_ROOT, '.claude/wip-checklist.md');
+
+interface PatternCheckResult {
+  id: string;
+  patternId: string;
+  label: string;
+  status: 'checked' | 'unchecked' | 'na';
+  naReason?: string;
+  /** The pattern's registered reason string, for context. */
+  reason: string;
+}
+
+/**
+ * Pure function — given a parsed checklist, return all pattern attestation items.
+ * Exported for tests.
+ */
+export function collectPatternAttestations(items: ParsedItem[]): PatternCheckResult[] {
+  const out: PatternCheckResult[] = [];
+  for (const item of items) {
+    if (!item.id.startsWith('review-')) continue;
+    const patternId = item.id.slice('review-'.length);
+    const pattern = getPatternById(patternId);
+    out.push({
+      id: item.id,
+      patternId,
+      label: item.label,
+      status: item.status,
+      naReason: item.naReason,
+      reason: pattern?.reason ?? '(unknown pattern — not in registry)',
+    });
+  }
+  return out;
+}
+
+/**
+ * Determine whether all pattern items have been attested.
+ * `checked` or `na` counts as attested. `unchecked` is a block.
+ */
+export function allAttested(results: PatternCheckResult[]): boolean {
+  return results.every((r) => r.status !== 'unchecked');
+}
+
+function loadChecklistItems(): ParsedItem[] | null {
+  if (!existsSync(CHECKLIST_PATH)) return null;
+  const md = readFileSync(CHECKLIST_PATH, 'utf-8');
+  return parseChecklist(md).items;
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+// handler-safe: pure presentation over an already-parsed checklist file
+async function check(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const items = loadChecklistItems();
+  if (!items) {
+    return {
+      exitCode: 1,
+      output:
+        `${c.red}No checklist found at ${CHECKLIST_PATH}.${c.reset}\n` +
+        `Run \`pnpm crux sys agent-checklist init "task" --type=X\` first.\n`,
+    };
+  }
+
+  const results = collectPatternAttestations(items);
+  if (options.json) {
+    return {
+      exitCode: allAttested(results) ? 0 : 1,
+      output: JSON.stringify({ ok: allAttested(results), items: results }, null, 2),
+    };
+  }
+
+  if (results.length === 0) {
+    return {
+      exitCode: 0,
+      output: `${c.green}✓ No review-pattern items in checklist (nothing to attest).${c.reset}\n`,
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push('Review pattern attestation:');
+  lines.push('');
+  for (const r of results) {
+    const icon =
+      r.status === 'checked' ? `${c.green}✓${c.reset}` :
+      r.status === 'na' ? `${c.dim}~${c.reset}` :
+      `${c.red}✗${c.reset}`;
+    lines.push(`  ${icon} ${r.id}`);
+    if (r.status === 'na' && r.naReason) {
+      lines.push(`      ${c.dim}N/A: ${r.naReason}${c.reset}`);
+    }
+  }
+
+  if (allAttested(results)) {
+    lines.push('');
+    lines.push(`${c.green}✓ All ${results.length} pattern item(s) attested.${c.reset}`);
+    return { exitCode: 0, output: lines.join('\n') + '\n' };
+  }
+
+  const unchecked = results.filter((r) => r.status === 'unchecked');
+  lines.push('');
+  lines.push(`${c.red}✗ ${unchecked.length} pattern item(s) still unchecked:${c.reset}`);
+  lines.push('');
+  for (const r of unchecked) {
+    lines.push(`  ${c.bold}${r.id}${c.reset}`);
+    lines.push(`    ${c.dim}${r.reason}${c.reset}`);
+    lines.push(
+      `    ${c.dim}Fix: \`pnpm crux sys agent-checklist check ${r.id}\` (after addressing),\n` +
+      `         or \`... check --na ${r.id} --reason "why this pattern doesn't apply here"\`${c.reset}`,
+    );
+    lines.push('');
+  }
+  return { exitCode: 1, output: lines.join('\n') };
+}
+
+// handler-safe: presentation-only
+async function list(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  if (options.json) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify(
+        PATTERNS.map((p) => ({
+          id: p.id,
+          label: p.label,
+          reason: p.reason,
+          origin: p.origin,
+          mechanical: p.mechanical,
+        })),
+        null,
+        2,
+      ),
+    };
+  }
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const lines: string[] = [];
+  lines.push(`${c.bold}Review patterns registered (${PATTERNS.length}):${c.reset}`);
+  lines.push('');
+  for (const p of PATTERNS) {
+    const tag = p.mechanical ? `${c.green}[mechanical]${c.reset}` : `${c.dim}[checklist-only]${c.reset}`;
+    lines.push(`  ${c.bold}${p.id}${c.reset} ${tag}`);
+    lines.push(`    ${p.label}`);
+    lines.push(`    ${c.dim}${p.reason}${c.reset}`);
+    if (p.origin) lines.push(`    ${c.dim}origin: ${p.origin}${c.reset}`);
+    lines.push('');
+  }
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+export const commands: Record<string, (args: string[], options: CommandOptions) => Promise<CommandResult>> = {
+  default: check,
+  check,
+  list,
+};
+
+export function getHelp(): string {
+  return `
+Review Patterns — verify /agent-review-pr attested every pattern
+
+Subcommands:
+  check        Verify all review-* checklist items are attested (default)
+  list         Print the pattern registry
+
+Options:
+  --json       JSON output
+
+Exit codes:
+  0  — all pattern items checked or marked N/A
+  1  — one or more pattern items still unchecked
+`;
+}

--- a/crux/commands/review-patterns.ts
+++ b/crux/commands/review-patterns.ts
@@ -110,7 +110,36 @@ async function check(_args: string[], options: CommandOptions): Promise<CommandR
   // commits introduced a new bug shape), any newly-triggered pattern would
   // be invisible to the old checklist. Fail closed and point at `init` so
   // the reviewer picks up the new items before shipping.
-  const { items: freshPatternItems } = detectPatternItems(PROJECT_ROOT);
+  //
+  // CRITICAL (QUA-363 hostile-review HIGH-2): if the re-detect fails to
+  // read the diff (maxBuffer overflow, hung git, missing origin/main),
+  // we MUST fail closed. A silent 0-detections result against a broken
+  // detector is exactly the invisible-failure bug class the pattern
+  // system exists to prevent.
+  const {
+    items: freshPatternItems,
+    diffError: freshDiffError,
+  } = detectPatternItems(PROJECT_ROOT);
+  if (freshDiffError != null) {
+    const msg = `Freshness check could not re-read the current diff: ${freshDiffError}`;
+    if (options.json) {
+      return {
+        exitCode: 1,
+        output: JSON.stringify(
+          { ok: false, reason: 'diff-unreadable', error: freshDiffError },
+          null,
+          2,
+        ),
+      };
+    }
+    return {
+      exitCode: 1,
+      output:
+        `${c.red}✗ ${msg}${c.reset}\n` +
+        `  ${c.dim}Cannot verify the checklist is up to date. Refusing to attest a clean state${c.reset}\n` +
+        `  ${c.dim}against a broken detector. Fix the underlying git/filesystem issue, then retry.${c.reset}\n`,
+    };
+  }
   const existingReviewIds = new Set(
     items.filter((i) => i.id.startsWith('review-')).map((i) => i.id),
   );

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -125,6 +125,7 @@ import * as docsCommands from './commands/docs.ts';
 import * as linearCommands from './commands/linear.ts';
 import * as flagshipCurateCommands from './commands/flagship-curate.ts';
 import * as sessionFinalizeCommands from './commands/session-finalize.ts';
+import * as reviewPatternsCommands from './commands/review-patterns.ts';
 
 const domains = {
   validate: validateCommands,
@@ -214,6 +215,7 @@ const domains = {
   linear: linearCommands,
   'flagship-curate': flagshipCurateCommands,
   'session-finalize': sessionFinalizeCommands,
+  'review-patterns': reviewPatternsCommands,
 };
 
 const shortcutMap = buildShortcutMap();

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -102,6 +102,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'epic',
       'release',
       'review',
+      'review-patterns',
       'pr-patrol',
       'branches',
       'deploy-tasks',

--- a/crux/lib/review-patterns/__tests__/patterns.test.ts
+++ b/crux/lib/review-patterns/__tests__/patterns.test.ts
@@ -170,6 +170,17 @@ describe('github-conclusion-enum', () => {
     const d = DIFF_CONCLUSION_REGEX_GAP.replaceAll('crux/lib/foo.ts', 'crux/lib/foo.test.ts');
     expect(pattern.detect(parseDiff(d))).toHaveLength(0);
   });
+  it('skips .spec.ts files', () => {
+    const d = DIFF_CONCLUSION_REGEX_GAP.replaceAll('crux/lib/foo.ts', 'crux/lib/foo.spec.ts');
+    expect(pattern.detect(parseDiff(d))).toHaveLength(0);
+  });
+  it('skips files inside __tests__ directories', () => {
+    const d = DIFF_CONCLUSION_REGEX_GAP.replaceAll(
+      'crux/lib/foo.ts',
+      'crux/lib/__tests__/foo.ts',
+    );
+    expect(pattern.detect(parseDiff(d))).toHaveLength(0);
+  });
 });
 
 describe('command-handler-error-boundary', () => {

--- a/crux/lib/review-patterns/__tests__/patterns.test.ts
+++ b/crux/lib/review-patterns/__tests__/patterns.test.ts
@@ -149,6 +149,48 @@ describe('parseDiff', () => {
     const weirdHeaders = d.files[0].addedLines.filter((l) => l.content.startsWith('++'));
     expect(weirdHeaders).toHaveLength(0);
   });
+
+  // QUA-363 hostile-review MED-4: a content line that literally starts
+  // with `+++` (e.g., 4+ plus signs in source code, MDX bullets, ASCII
+  // art separators) used to be misclassified as the `+++` file header
+  // via .startsWith('+++'). The fix requires the trailing space that
+  // distinguishes `+++ b/path` from `+++ content`.
+  it('classifies content lines starting with `+++` as added, not headers', () => {
+    const d = parseDiff(`diff --git a/foo.ts b/foo.ts
+index abc..def 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,2 +1,4 @@
+ normal context
++++ three pluses at start of content
+++++ four pluses at start of content
+ more context
+`);
+    expect(d.files).toHaveLength(1);
+    const added = d.files[0].addedLines.map((l) => l.content);
+    expect(added).toContain('++ three pluses at start of content');
+    expect(added).toContain('+++ four pluses at start of content');
+  });
+
+  it('classifies context lines starting with `---` as context, not headers', () => {
+    // Mirror of the above for the `---` side: a content line beginning
+    // with `---` (e.g., MDX frontmatter delimiter) must not be treated
+    // as the file-header form `--- a/path`.
+    const d = parseDiff(`diff --git a/foo.mdx b/foo.mdx
+index abc..def 100644
+--- a/foo.mdx
++++ b/foo.mdx
+@@ -1,3 +1,4 @@
+ ---
+ title: Foo
++description: A page
+ ---
+`);
+    // The frontmatter `---` on context lines should not corrupt line numbers
+    expect(d.files[0].path).toBe('foo.mdx');
+    const added = d.files[0].addedLines.find((l) => l.content.includes('description'));
+    expect(added).toBeDefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/review-patterns/__tests__/patterns.test.ts
+++ b/crux/lib/review-patterns/__tests__/patterns.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PATTERNS,
+  parseDiff,
+  detectAllPatterns,
+  getPatternById,
+} from '../patterns.ts';
+
+// ---------------------------------------------------------------------------
+// Diff fixtures — each shaped like real `git diff origin/main...HEAD` output.
+// Keep these minimal and copy-pasteable so reviewers can see the exact bug
+// each pattern detects.
+// ---------------------------------------------------------------------------
+
+const DIFF_CONCLUSION_REGEX_GAP = `diff --git a/crux/lib/foo.ts b/crux/lib/foo.ts
+index abc..def 100644
+--- a/crux/lib/foo.ts
++++ b/crux/lib/foo.ts
+@@ -10,3 +10,5 @@
+ export function failing(c: { conclusion: string }) {
+-  return false;
++  // BUG: regex misses timed_out and action_required
++  return /failure|cancelled/.test(c.conclusion);
+ }
+`;
+
+const DIFF_COMMAND_HANDLER_NO_TRY = `diff --git a/crux/commands/foo.ts b/crux/commands/foo.ts
+index abc..def 100644
+--- a/crux/commands/foo.ts
++++ b/crux/commands/foo.ts
+@@ -1,3 +1,6 @@
++async function newHandler(args: string[], options: CommandOptions): Promise<CommandResult> {
++  const r = writeFileSync('/tmp/x', 'data');
++  return { exitCode: 0, output: 'ok' };
++}
+ export const commands = { default: newHandler };
+`;
+
+const DIFF_READDIR_IN_PRIORITY_LOOP = `diff --git a/crux/lib/scan.ts b/crux/lib/scan.ts
+index abc..def 100644
+--- a/crux/lib/scan.ts
++++ b/crux/lib/scan.ts
+@@ -1,4 +1,10 @@
+ import { readdirSync } from 'fs';
++export function findFirst(dir: string) {
++  const entries = readdirSync(dir);
++  for (const e of entries) {
++    if (e.startsWith('target')) return e;
++  }
++}
+`;
+
+const DIFF_NUMERIC_SUBSTRING = `diff --git a/crux/commands/match.ts b/crux/commands/match.ts
+index abc..def 100644
+--- a/crux/commands/match.ts
++++ b/crux/commands/match.ts
+@@ -5,2 +5,4 @@
+ export function hung(line: string, slotPath: string) {
++  // BUG: a1 prefix-collides with a10
++  return line.includes(slotPath);
+ }
+`;
+
+const DIFF_FAKE_ENV_NEW_CLASS = `diff --git a/crux/lib/foo/__tests__/fake-env.ts b/crux/lib/foo/__tests__/fake-env.ts
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/crux/lib/foo/__tests__/fake-env.ts
+@@ -0,0 +1,5 @@
++export class FakeRuntimeEnv implements Runtime {
++  exec(cmd: string): ExecResult {
++    return { code: 0, stdout: '', stderr: '' };
++  }
++}
+`;
+
+const DIFF_CLEAN = `diff --git a/content/docs/foo.mdx b/content/docs/foo.mdx
+index abc..def 100644
+--- a/content/docs/foo.mdx
++++ b/content/docs/foo.mdx
+@@ -1,3 +1,4 @@
+ ---
+ title: Foo
++description: A page
+ ---
+`;
+
+// ---------------------------------------------------------------------------
+// Registry invariants
+// ---------------------------------------------------------------------------
+
+describe('PATTERNS registry', () => {
+  it('has at least 5 patterns covering the QUA-339 bug classes', () => {
+    expect(PATTERNS.length).toBeGreaterThanOrEqual(5);
+  });
+  it('every pattern has a unique id', () => {
+    const ids = new Set(PATTERNS.map((p) => p.id));
+    expect(ids.size).toBe(PATTERNS.length);
+  });
+  it('every pattern id is kebab-case', () => {
+    for (const p of PATTERNS) {
+      expect(p.id).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+  it('every pattern has a nonzero-length reason and label', () => {
+    for (const p of PATTERNS) {
+      expect(p.label.length).toBeGreaterThan(5);
+      expect(p.reason.length).toBeGreaterThan(10);
+    }
+  });
+  it('getPatternById returns the right entry', () => {
+    expect(getPatternById('github-conclusion-enum')?.label).toContain('GitHub');
+    expect(getPatternById('does-not-exist')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDiff — the minimal diff parser
+// ---------------------------------------------------------------------------
+
+describe('parseDiff', () => {
+  it('extracts file path and added lines from a simple diff', () => {
+    const d = parseDiff(DIFF_CLEAN);
+    expect(d.files).toHaveLength(1);
+    expect(d.files[0].path).toBe('content/docs/foo.mdx');
+    expect(d.files[0].added).toBe(false);
+    expect(d.files[0].addedLines.map((l) => l.content)).toContain('description: A page');
+  });
+  it('marks `new file mode` files as added', () => {
+    const d = parseDiff(DIFF_FAKE_ENV_NEW_CLASS);
+    expect(d.files[0].added).toBe(true);
+  });
+  it('tracks new-file line numbers through hunks', () => {
+    const d = parseDiff(DIFF_CONCLUSION_REGEX_GAP);
+    const added = d.files[0].addedLines.find((l) => l.content.includes('timed_out'));
+    expect(added?.newLineNumber).toBeGreaterThan(0);
+  });
+  it('handles multi-file diffs', () => {
+    const combined = DIFF_CLEAN + DIFF_CONCLUSION_REGEX_GAP;
+    const d = parseDiff(combined);
+    expect(d.files).toHaveLength(2);
+    expect(d.files.map((f) => f.path).sort()).toEqual([
+      'content/docs/foo.mdx',
+      'crux/lib/foo.ts',
+    ]);
+  });
+  it('ignores the +++ / --- diff headers in added-line collection', () => {
+    const d = parseDiff(DIFF_CONCLUSION_REGEX_GAP);
+    const weirdHeaders = d.files[0].addedLines.filter((l) => l.content.startsWith('++'));
+    expect(weirdHeaders).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Individual pattern detection — one "triggers" + one "clean" per pattern
+// ---------------------------------------------------------------------------
+
+describe('github-conclusion-enum', () => {
+  const pattern = getPatternById('github-conclusion-enum')!;
+  it('detects regex gap', () => {
+    const hits = pattern.detect(parseDiff(DIFF_CONCLUSION_REGEX_GAP));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe('crux/lib/foo.ts');
+    expect(hits[0].snippet).toContain('failure|cancelled');
+  });
+  it('no false positives on clean diff', () => {
+    expect(pattern.detect(parseDiff(DIFF_CLEAN))).toHaveLength(0);
+  });
+  it('skips test files', () => {
+    const d = DIFF_CONCLUSION_REGEX_GAP.replaceAll('crux/lib/foo.ts', 'crux/lib/foo.test.ts');
+    expect(pattern.detect(parseDiff(d))).toHaveLength(0);
+  });
+});
+
+describe('command-handler-error-boundary', () => {
+  const pattern = getPatternById('command-handler-error-boundary')!;
+  it('detects new handler in crux/commands/', () => {
+    const hits = pattern.detect(parseDiff(DIFF_COMMAND_HANDLER_NO_TRY));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe('crux/commands/foo.ts');
+  });
+  it('ignores handler-shaped code outside crux/commands/', () => {
+    const d = DIFF_COMMAND_HANDLER_NO_TRY.replace(/crux\/commands/g, 'crux/lib');
+    expect(pattern.detect(parseDiff(d))).toHaveLength(0);
+  });
+});
+
+describe('readdir-iteration-determinism', () => {
+  const pattern = getPatternById('readdir-iteration-determinism')!;
+  it('detects readdirSync in new code', () => {
+    const hits = pattern.detect(parseDiff(DIFF_READDIR_IN_PRIORITY_LOOP));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].snippet).toContain('readdirSync');
+  });
+  it('no false positives', () => {
+    expect(pattern.detect(parseDiff(DIFF_CLEAN))).toHaveLength(0);
+  });
+});
+
+describe('numeric-id-substring-match', () => {
+  const pattern = getPatternById('numeric-id-substring-match')!;
+  it('detects .includes() against a *Path variable', () => {
+    const hits = pattern.detect(parseDiff(DIFF_NUMERIC_SUBSTRING));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].snippet).toContain('slotPath');
+  });
+  it('does not trigger on .includes(stringLiteral)', () => {
+    const benign = `diff --git a/crux/lib/x.ts b/crux/lib/x.ts
+--- a/crux/lib/x.ts
++++ b/crux/lib/x.ts
+@@ -1,1 +1,2 @@
++const has = name.includes('thing');
+`;
+    expect(pattern.detect(parseDiff(benign))).toHaveLength(0);
+  });
+});
+
+describe('test-fake-silent-default', () => {
+  const pattern = getPatternById('test-fake-silent-default')!;
+  it('detects new FakeEnv class in __tests__/', () => {
+    const hits = pattern.detect(parseDiff(DIFF_FAKE_ENV_NEW_CLASS));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toContain('fake-env');
+  });
+  it('does not trigger on a normal class in product code', () => {
+    const d = `diff --git a/crux/lib/real.ts b/crux/lib/real.ts
+--- a/crux/lib/real.ts
++++ b/crux/lib/real.ts
+@@ -1,1 +1,2 @@
++export class RealThing { x = 1; }
+`;
+    expect(pattern.detect(parseDiff(d))).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAllPatterns — integration
+// ---------------------------------------------------------------------------
+
+describe('detectAllPatterns', () => {
+  it('returns empty list for clean diff', () => {
+    expect(detectAllPatterns(parseDiff(DIFF_CLEAN))).toHaveLength(0);
+  });
+  it('catches the QUA-339 pass-2 bug shapes in one combined diff', () => {
+    const combined = [
+      DIFF_CONCLUSION_REGEX_GAP,
+      DIFF_COMMAND_HANDLER_NO_TRY,
+      DIFF_READDIR_IN_PRIORITY_LOOP,
+      DIFF_NUMERIC_SUBSTRING,
+      DIFF_FAKE_ENV_NEW_CLASS,
+    ].join('');
+    const detections = detectAllPatterns(parseDiff(combined));
+    const ids = detections.map((d) => d.pattern.id).sort();
+    expect(ids).toEqual([
+      'command-handler-error-boundary',
+      'github-conclusion-enum',
+      'numeric-id-substring-match',
+      'readdir-iteration-determinism',
+      'test-fake-silent-default',
+    ]);
+  });
+});

--- a/crux/lib/review-patterns/patterns.ts
+++ b/crux/lib/review-patterns/patterns.ts
@@ -93,6 +93,30 @@ export interface PatternHit {
 }
 
 // ---------------------------------------------------------------------------
+// File-filter helpers used by multiple pattern detect() functions
+// ---------------------------------------------------------------------------
+
+const CODE_FILE_EXT = /\.(ts|tsx|mjs|js)$/;
+
+/** True for JS/TS source files regardless of test/production status. */
+function isCodeFileExtension(path: string): boolean {
+  return CODE_FILE_EXT.test(path);
+}
+
+/**
+ * True for JS/TS production source files. Excludes test files
+ * (`__tests__/` directories and `*.test.ts` suffixes) since test
+ * fixtures commonly include the bug shapes we're detecting ON PURPOSE.
+ */
+function isScannableCodeFile(path: string): boolean {
+  if (!CODE_FILE_EXT.test(path)) return false;
+  if (path.includes('/__tests__/')) return false;
+  if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) return false;
+  if (path.endsWith('.spec.ts') || path.endsWith('.spec.tsx')) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // Pattern registry
 // ---------------------------------------------------------------------------
 
@@ -105,29 +129,17 @@ export const PATTERNS: ReviewPattern[] = [
     origin: 'QUA-339 pass-2 bug HIGH-2',
     mechanical: true,
     detect(diff) {
-      // Match regex literals or string patterns applied to a `conclusion`
-      // field. We're looking for two shapes:
-      //   /failure|cancelled/.test(x.conclusion)
-      //   /fail|cancel/i.test(conclusion)
-      //   'failure' === conclusion etc
-      //
-      // The detection is intentionally loose: any regex that mentions
-      // conclusion-like variants without including ALL failing ones is
-      // a candidate. The validator then verifies exhaustiveness.
-      const hits: PatternHit[] = [];
-      // A JS regex literal that alludes to check-conclusion names.
-      // Intentionally loose — the mechanical validator then verifies
+      // Fire on regex literals that mention any conclusion-flavored token
+      // (intentionally loose). The mechanical validator then verifies
       // exhaustiveness against the full FAILING_CONCLUSIONS allowlist.
+      const hits: PatternHit[] = [];
       const RE = /\/[^/\n]*(failure|fail|cancel|error|timed_out|action_required)[^/\n]*\//;
+      const CONTEXT_RE = /conclusion|statusCheck|check[_\s]?run/i;
       for (const file of diff.files) {
-        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
-        if (file.path.includes('/__tests__/') || file.path.endsWith('.test.ts')) continue;
+        if (!isScannableCodeFile(file.path)) continue;
         for (const line of file.addedLines) {
           if (!RE.test(line.content)) continue;
-          // Require the line (or a 2-line context window — caller passes
-          // us only individual lines, so fall back to the line itself)
-          // to mention "conclusion" somewhere nearby.
-          if (!/conclusion|statusCheck|check[_\s]?run/i.test(line.content)) continue;
+          if (!CONTEXT_RE.test(line.content)) continue;
           hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
         }
       }
@@ -177,10 +189,11 @@ export const PATTERNS: ReviewPattern[] = [
     mechanical: false,
     detect(diff) {
       const hits: PatternHit[] = [];
+      const RE = /\breaddirSync\b|\blistMatching\b/;
       for (const file of diff.files) {
-        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
+        if (!isCodeFileExtension(file.path)) continue;
         for (const line of file.addedLines) {
-          if (!/\breaddirSync\b|\blistMatching\b/.test(line.content)) continue;
+          if (!RE.test(line.content)) continue;
           hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
         }
       }
@@ -200,8 +213,7 @@ export const PATTERNS: ReviewPattern[] = [
       // hints at a path or numeric id (path, slotPath, id, pid, port).
       const RE = /\.includes\(\s*[a-z][\w.]*(?:path|Path|id|Id|pid|Pid|port|Port)\b\s*\)/;
       for (const file of diff.files) {
-        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
-        if (file.path.includes('/__tests__/') || file.path.endsWith('.test.ts')) continue;
+        if (!isScannableCodeFile(file.path)) continue;
         for (const line of file.addedLines) {
           if (!RE.test(line.content)) continue;
           hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });

--- a/crux/lib/review-patterns/patterns.ts
+++ b/crux/lib/review-patterns/patterns.ts
@@ -1,0 +1,321 @@
+/**
+ * Review pattern registry — single source of truth for bug shapes the
+ * `/agent-review-pr` skill should consider.
+ *
+ * Each pattern declares:
+ *   - id             stable identifier used in checklist items + gate IDs
+ *   - label          human-readable name shown in review plan / checklist
+ *   - detect(diff)   pure function: does this diff exhibit the pattern?
+ *   - mechanical     true if there is a standalone gate validator that
+ *                    catches the bug (no reviewer judgment needed);
+ *                    false if only a human/LLM can decide
+ *   - reason         one-line explanation of WHY the pattern matters
+ *                    (gets printed in the checklist item and review plan)
+ *   - origin         Linear ticket that seeded the pattern (optional),
+ *                    so the provenance is inspectable
+ *
+ * The registry is consumed by:
+ *   1. `crux/validate/validate-review-patterns.ts` — the gate (option A).
+ *      Runs every `mechanical: true` pattern and fails on hits.
+ *   2. `crux sys agent-checklist init` — option B. Scans the current
+ *      diff, and for each triggered pattern (mechanical or not),
+ *      appends a forced checklist item the reviewer must explicitly
+ *      check off or mark `--na` with reason.
+ *   3. `/agent-review-pr` skill — option E. Reads the triggered
+ *      patterns from the checklist and produces an attestation block
+ *      ("[x] pattern-id — no findings" / "[x] pattern-id — <file:line>").
+ *
+ * Adding a new pattern is a one-file change: drop an entry in
+ * PATTERNS below. All three consumers pick it up automatically.
+ */
+
+export interface ReviewPattern {
+  /** Stable kebab-case id. Used as checklist item id and gate check id. */
+  id: string;
+  /** Human-readable label shown in the checklist. */
+  label: string;
+  /** One-line explanation of the bug class (rendered next to the item). */
+  reason: string;
+  /** Origin ticket for provenance. */
+  origin?: string;
+  /**
+   * Detect whether this pattern's bug shape is present in a unified
+   * diff blob (output of `git diff origin/main...HEAD`).
+   *
+   * This MUST be pure — no filesystem, no shell. Tests depend on it.
+   */
+  detect(diff: DiffBlob): PatternHit[];
+  /**
+   * If true, a separate gate validator exists that blocks the PR when
+   * the bug is present. The checklist item is still added but serves
+   * as a belt-and-suspenders attestation.
+   *
+   * If false, the bug class is shape-dependent or semantic; only the
+   * checklist item and reviewer judgment catch it.
+   */
+  mechanical: boolean;
+}
+
+/**
+ * Parsed unified diff — the detect() shape. Not a full parser; just
+ * enough structure to grep + locate. Builds cheaply with `parseDiff()`.
+ */
+export interface DiffBlob {
+  /** Full raw unified diff text (for regex searches). */
+  raw: string;
+  /** Per-file changes, parsed from the diff headers. */
+  files: DiffFile[];
+}
+
+export interface DiffFile {
+  /** Path relative to repo root. */
+  path: string;
+  /** True if the file was newly added in this diff. */
+  added: boolean;
+  /** Lines added in this file (prefix `+` stripped). */
+  addedLines: AddedLine[];
+}
+
+export interface AddedLine {
+  /** Line number in the NEW file (best-effort; 0 if unknown). */
+  newLineNumber: number;
+  /** The line content (no leading `+`). */
+  content: string;
+}
+
+export interface PatternHit {
+  /** Path of the file where the pattern was detected. */
+  file: string;
+  /** Line number in the new file, or 0 if file-level. */
+  line: number;
+  /** The matched snippet (trimmed), for logging. */
+  snippet: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern registry
+// ---------------------------------------------------------------------------
+
+export const PATTERNS: ReviewPattern[] = [
+  {
+    id: 'github-conclusion-enum',
+    label: 'GitHub check conclusions handled exhaustively',
+    reason:
+      'Regex-matching conclusion fields (e.g. /failure|cancelled/) routinely misses timed_out and action_required. Use the FAILING_CONCLUSIONS allowlist.',
+    origin: 'QUA-339 pass-2 bug HIGH-2',
+    mechanical: true,
+    detect(diff) {
+      // Match regex literals or string patterns applied to a `conclusion`
+      // field. We're looking for two shapes:
+      //   /failure|cancelled/.test(x.conclusion)
+      //   /fail|cancel/i.test(conclusion)
+      //   'failure' === conclusion etc
+      //
+      // The detection is intentionally loose: any regex that mentions
+      // conclusion-like variants without including ALL failing ones is
+      // a candidate. The validator then verifies exhaustiveness.
+      const hits: PatternHit[] = [];
+      // A JS regex literal that alludes to check-conclusion names.
+      // Intentionally loose — the mechanical validator then verifies
+      // exhaustiveness against the full FAILING_CONCLUSIONS allowlist.
+      const RE = /\/[^/\n]*(failure|fail|cancel|error|timed_out|action_required)[^/\n]*\//;
+      for (const file of diff.files) {
+        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
+        if (file.path.includes('/__tests__/') || file.path.endsWith('.test.ts')) continue;
+        for (const line of file.addedLines) {
+          if (!RE.test(line.content)) continue;
+          // Require the line (or a 2-line context window — caller passes
+          // us only individual lines, so fall back to the line itself)
+          // to mention "conclusion" somewhere nearby.
+          if (!/conclusion|statusCheck|check[_\s]?run/i.test(line.content)) continue;
+          hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
+        }
+      }
+      return hits;
+    },
+  },
+  {
+    id: 'command-handler-error-boundary',
+    label: 'New crux command handlers have a top-level try/catch',
+    reason:
+      'Handler bodies that throw surface as raw Node stack traces instead of CommandResult errors, breaking calling skills. Wrap with try/catch or annotate `// handler-safe`.',
+    origin: 'QUA-339 pass-2 bug MED-3',
+    mechanical: true,
+    detect(diff) {
+      // Look for new `async function <name>(..., options: ...Options): Promise<CommandResult>`
+      // entries in crux/commands/*.ts that don't start with a `try {`.
+      const hits: PatternHit[] = [];
+      const HANDLER_RE =
+        /^\+\s*(?:export\s+)?async\s+function\s+(\w+)\s*\([^)]*\)\s*:\s*Promise<CommandResult>/;
+      for (const file of diff.files) {
+        if (!file.path.startsWith('crux/commands/')) continue;
+        if (!file.path.endsWith('.ts') || file.path.endsWith('.test.ts')) continue;
+        // Scan the raw diff for added handler signatures; we'll verify
+        // the handler body at gate time (the mechanical validator has
+        // full file context).
+        const lines = diff.raw.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          const m = lines[i].match(HANDLER_RE);
+          if (!m) continue;
+          // Only count if this line is part of the current file's hunk
+          // (simple heuristic: look backward for the last `diff --git`).
+          let j = i;
+          while (j > 0 && !lines[j].startsWith('diff --git')) j--;
+          if (!lines[j].includes(file.path)) continue;
+          hits.push({ file: file.path, line: 0, snippet: m[0].slice(1).trim() });
+        }
+      }
+      return hits;
+    },
+  },
+  {
+    id: 'readdir-iteration-determinism',
+    label: 'readdir / listMatching calls in priority loops',
+    reason:
+      "readdirSync returns entries in filesystem order (unsorted on Linux). If the caller uses the first 'matching' entry for priority logic, iteration order masks the real answer. Either sort explicitly or walk all entries and track both sides.",
+    origin: 'QUA-339 pass-2 bug HIGH-1',
+    mechanical: false,
+    detect(diff) {
+      const hits: PatternHit[] = [];
+      for (const file of diff.files) {
+        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
+        for (const line of file.addedLines) {
+          if (!/\breaddirSync\b|\blistMatching\b/.test(line.content)) continue;
+          hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
+        }
+      }
+      return hits;
+    },
+  },
+  {
+    id: 'numeric-id-substring-match',
+    label: 'String .includes() against numeric IDs / paths',
+    reason:
+      'Substring matching on numeric identifiers causes prefix collisions (e.g. `"/lw/a10".includes("/lw/a1")` is true). Use path boundaries or exact equality instead.',
+    origin: 'QUA-339 pass-2 bug MED-4',
+    mechanical: false,
+    detect(diff) {
+      const hits: PatternHit[] = [];
+      // Shape: `.includes(<identifier>)` where the identifier's name
+      // hints at a path or numeric id (path, slotPath, id, pid, port).
+      const RE = /\.includes\(\s*[a-z][\w.]*(?:path|Path|id|Id|pid|Pid|port|Port)\b\s*\)/;
+      for (const file of diff.files) {
+        if (!/\.(ts|tsx|mjs|js)$/.test(file.path)) continue;
+        if (file.path.includes('/__tests__/') || file.path.endsWith('.test.ts')) continue;
+        for (const line of file.addedLines) {
+          if (!RE.test(line.content)) continue;
+          hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
+        }
+      }
+      return hits;
+    },
+  },
+  {
+    id: 'test-fake-silent-default',
+    label: 'Test fakes/stubs with permissive default returns',
+    reason:
+      'Fake env/mock methods that default to success on unregistered keys silently let tests pass when setup is missing. Fail closed: throw with the unregistered key name.',
+    origin: 'QUA-339 pass-2 bug MED-5',
+    mechanical: false,
+    detect(diff) {
+      const hits: PatternHit[] = [];
+      // Trigger on new Fake*Env / *FakeEnv class declarations in
+      // test directories. Cheap shape-match; the reviewer decides
+      // whether the defaults are sound.
+      const CLASS_RE = /\bclass\s+\w*[Ff]ake\w*\s*(?:extends|\{|implements)/;
+      for (const file of diff.files) {
+        if (!file.path.endsWith('.ts') && !file.path.endsWith('.tsx')) continue;
+        const isTest = file.path.includes('/__tests__/') || file.path.endsWith('.test.ts');
+        if (!isTest && !file.added) continue;
+        for (const line of file.addedLines) {
+          if (!CLASS_RE.test(line.content)) continue;
+          hits.push({ file: file.path, line: line.newLineNumber, snippet: line.content.trim() });
+        }
+      }
+      return hits;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Diff parser (minimal)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a unified diff into a DiffBlob. Only extracts what PATTERNS'
+ * detect() needs: file paths, added-ness, and added lines with best-effort
+ * line numbers from hunk headers.
+ *
+ * This is deliberately NOT a full diff parser — we don't need context
+ * lines, removed lines, or rename tracking. Robust enough for the
+ * output of `git diff origin/main...HEAD`.
+ */
+export function parseDiff(raw: string): DiffBlob {
+  const files: DiffFile[] = [];
+  const lines = raw.split('\n');
+  let current: DiffFile | null = null;
+  let newLineNo = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // File boundary: `diff --git a/path b/path`
+    const fileMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (fileMatch) {
+      if (current) files.push(current);
+      current = { path: fileMatch[2], added: false, addedLines: [] };
+      newLineNo = 0;
+      continue;
+    }
+    if (!current) continue;
+
+    // Added-file marker: `new file mode` appears after the diff --git line
+    if (line.startsWith('new file mode')) {
+      current.added = true;
+      continue;
+    }
+
+    // Hunk header: `@@ -a,b +c,d @@` — reset new-line counter
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      newLineNo = Number(hunkMatch[1]) - 1;
+      continue;
+    }
+
+    // Added line (not the `+++` header)
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      newLineNo += 1;
+      current.addedLines.push({ newLineNumber: newLineNo, content: line.slice(1) });
+      continue;
+    }
+    // Context line — advances new-file line counter
+    if (!line.startsWith('-') && !line.startsWith('---')) {
+      newLineNo += 1;
+    }
+  }
+
+  if (current) files.push(current);
+  return { raw, files };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: detect all patterns against a diff
+// ---------------------------------------------------------------------------
+
+export interface PatternDetection {
+  pattern: ReviewPattern;
+  hits: PatternHit[];
+}
+
+export function detectAllPatterns(diff: DiffBlob): PatternDetection[] {
+  const out: PatternDetection[] = [];
+  for (const pattern of PATTERNS) {
+    const hits = pattern.detect(diff);
+    if (hits.length > 0) out.push({ pattern, hits });
+  }
+  return out;
+}
+
+export function getPatternById(id: string): ReviewPattern | undefined {
+  return PATTERNS.find((p) => p.id === id);
+}

--- a/crux/lib/review-patterns/patterns.ts
+++ b/crux/lib/review-patterns/patterns.ts
@@ -154,27 +154,31 @@ export const PATTERNS: ReviewPattern[] = [
     origin: 'QUA-339 pass-2 bug MED-3',
     mechanical: true,
     detect(diff) {
-      // Look for new `async function <name>(..., options: ...Options): Promise<CommandResult>`
-      // entries in crux/commands/*.ts that don't start with a `try {`.
+      // Iterate per-file addedLines directly. This replaces an earlier
+      // O(N*M) pass that re-scanned `diff.raw` for every file and used
+      // `line.includes(file.path)` to re-attribute matches — ironic,
+      // since substring-matching paths is the exact bug class the
+      // `numeric-id-substring-match` pattern below warns against. Now
+      // we trust parseDiff's per-file attribution instead.
+      // (QUA-363 hostile-review LOW-7.)
       const hits: PatternHit[] = [];
+      // Note: no leading `+` needed — `file.addedLines` already contains
+      // stripped content.
       const HANDLER_RE =
-        /^\+\s*(?:export\s+)?async\s+function\s+(\w+)\s*\([^)]*\)\s*:\s*Promise<CommandResult>/;
+        /^\s*(?:export\s+)?async\s+function\s+(\w+)\s*\([^)]*\)\s*:\s*Promise<CommandResult>/;
       for (const file of diff.files) {
         if (!file.path.startsWith('crux/commands/')) continue;
-        if (!file.path.endsWith('.ts') || file.path.endsWith('.test.ts')) continue;
-        // Scan the raw diff for added handler signatures; we'll verify
-        // the handler body at gate time (the mechanical validator has
-        // full file context).
-        const lines = diff.raw.split('\n');
-        for (let i = 0; i < lines.length; i++) {
-          const m = lines[i].match(HANDLER_RE);
+        if (!file.path.endsWith('.ts')) continue;
+        if (file.path.endsWith('.test.ts') || file.path.endsWith('.spec.ts')) continue;
+        if (file.path.includes('/__tests__/')) continue;
+        for (const line of file.addedLines) {
+          const m = line.content.match(HANDLER_RE);
           if (!m) continue;
-          // Only count if this line is part of the current file's hunk
-          // (simple heuristic: look backward for the last `diff --git`).
-          let j = i;
-          while (j > 0 && !lines[j].startsWith('diff --git')) j--;
-          if (!lines[j].includes(file.path)) continue;
-          hits.push({ file: file.path, line: 0, snippet: m[0].slice(1).trim() });
+          hits.push({
+            file: file.path,
+            line: line.newLineNumber,
+            snippet: m[0].trim(),
+          });
         }
       }
       return hits;
@@ -267,6 +271,14 @@ export function parseDiff(raw: string): DiffBlob {
   const lines = raw.split('\n');
   let current: DiffFile | null = null;
   let newLineNo = 0;
+  /**
+   * True once we're inside a hunk (after `@@ ... @@`). Before any
+   * hunk, lines like `+++ b/path` are file headers; after a hunk,
+   * every `+` / `-` / ` ` line is CONTENT (including content that
+   * literally begins with `+++` or `---`). This state split avoids
+   * the ambiguity that caused QUA-363 hostile-review MED-4.
+   */
+  let inHunk = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -277,6 +289,7 @@ export function parseDiff(raw: string): DiffBlob {
       if (current) files.push(current);
       current = { path: fileMatch[2], added: false, addedLines: [] };
       newLineNo = 0;
+      inHunk = false;
       continue;
     }
     if (!current) continue;
@@ -287,21 +300,27 @@ export function parseDiff(raw: string): DiffBlob {
       continue;
     }
 
-    // Hunk header: `@@ -a,b +c,d @@` — reset new-line counter
+    // Hunk header: `@@ -a,b +c,d @@` — reset new-line counter, enter hunk mode
     const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
     if (hunkMatch) {
       newLineNo = Number(hunkMatch[1]) - 1;
+      inHunk = true;
       continue;
     }
 
-    // Added line (not the `+++` header)
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+    // Before any hunk: skip file-header lines (`+++ b/path`, `--- a/path`).
+    // These never match inside a hunk because by then `inHunk` is true.
+    if (!inHunk) continue;
+
+    // Inside a hunk: every `+` line is content, even literal `+++`.
+    if (line.startsWith('+')) {
       newLineNo += 1;
       current.addedLines.push({ newLineNumber: newLineNo, content: line.slice(1) });
       continue;
     }
-    // Context line — advances new-file line counter
-    if (!line.startsWith('-') && !line.startsWith('---')) {
+    // Context line — advances new-file line counter. `-` lines (removed)
+    // don't advance it.
+    if (!line.startsWith('-')) {
       newLineNo += 1;
     }
   }

--- a/crux/lib/session/__tests__/pattern-checklist.test.ts
+++ b/crux/lib/session/__tests__/pattern-checklist.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the option-B integration: pattern detections become
+ * checklist items wired into `buildChecklist`.
+ *
+ * We don't exercise `init` end-to-end here — that needs git state
+ * and a real working directory. These tests cover the pure path:
+ * given a list of PatternDetections, does buildChecklist produce
+ * the right markdown with forced items?
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildChecklist,
+  buildPatternItems,
+  type ChecklistMetadata,
+} from '../session-checklist.ts';
+import { parseDiff, detectAllPatterns } from '../../review-patterns/patterns.ts';
+
+const BASE_METADATA: ChecklistMetadata = {
+  task: 'test task',
+  branch: 'claude/test',
+  timestamp: '2026-04-13T00:00:00.000Z',
+};
+
+const DIFF_WITH_HITS = `diff --git a/crux/lib/foo.ts b/crux/lib/foo.ts
+index abc..def 100644
+--- a/crux/lib/foo.ts
++++ b/crux/lib/foo.ts
+@@ -1,3 +1,4 @@
++const bad = /failure|cancelled/.test(x.conclusion);
+ const rest = 1;
+diff --git a/crux/commands/newcmd.ts b/crux/commands/newcmd.ts
+index abc..def 100644
+--- a/crux/commands/newcmd.ts
++++ b/crux/commands/newcmd.ts
+@@ -1,3 +1,6 @@
++async function newHandler(args: string[], options: CommandOptions): Promise<CommandResult> {
++  writeFileSync('/tmp/x', 'data');
++  return { exitCode: 0, output: '' };
++}
+ export const commands = {};
+`;
+
+describe('buildPatternItems', () => {
+  it('produces one blocking item per triggered pattern', () => {
+    const detections = detectAllPatterns(parseDiff(DIFF_WITH_HITS));
+    const items = buildPatternItems(detections);
+    expect(items.length).toBeGreaterThanOrEqual(2);
+    for (const item of items) {
+      expect(item.id.startsWith('review-')).toBe(true);
+      expect(item.priority).toBe('blocking');
+      expect(item.applicableTypes).toBe('all');
+    }
+  });
+
+  it('encodes hit count in the label', () => {
+    const detections = detectAllPatterns(parseDiff(DIFF_WITH_HITS));
+    const items = buildPatternItems(detections);
+    const conclusionItem = items.find((i) => i.id === 'review-github-conclusion-enum');
+    expect(conclusionItem?.label).toContain('1 site');
+  });
+
+  it('returns empty array for no detections', () => {
+    expect(buildPatternItems([])).toHaveLength(0);
+  });
+});
+
+describe('buildChecklist with extraItems', () => {
+  it('appends pattern items to the type-default item list', () => {
+    const detections = detectAllPatterns(parseDiff(DIFF_WITH_HITS));
+    const patternItems = buildPatternItems(detections);
+    const md = buildChecklist('infrastructure', BASE_METADATA, patternItems);
+    // Pattern items should appear as numbered checklist entries
+    expect(md).toContain('`review-github-conclusion-enum`');
+    expect(md).toContain('`review-command-handler-error-boundary`');
+  });
+
+  it('preserves the static item count when no extras provided', () => {
+    const mdWithout = buildChecklist('infrastructure', BASE_METADATA);
+    const mdWith = buildChecklist('infrastructure', BASE_METADATA, []);
+    // Both should count the same number of items (simple check: line count
+    // in the checklist section is equal)
+    const countItems = (md: string) =>
+      md.split('\n').filter((l) => /^\d+\. \[[ x~]\]/.test(l)).length;
+    expect(countItems(mdWithout)).toBe(countItems(mdWith));
+  });
+
+  it('pattern items are numbered after static items', () => {
+    const detections = detectAllPatterns(parseDiff(DIFF_WITH_HITS));
+    const patternItems = buildPatternItems(detections);
+    const md = buildChecklist('infrastructure', BASE_METADATA, patternItems);
+    const lines = md.split('\n').filter((l) => /^\d+\. \[[ x~]\]/.test(l));
+    // Last line should be the highest-numbered pattern item
+    const last = lines[lines.length - 1];
+    expect(last).toMatch(/review-/);
+  });
+});

--- a/crux/lib/session/__tests__/pattern-checklist.test.ts
+++ b/crux/lib/session/__tests__/pattern-checklist.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildChecklist,
   buildPatternItems,
+  parseChecklist,
   type ChecklistMetadata,
 } from '../session-checklist.ts';
 import { parseDiff, detectAllPatterns } from '../../review-patterns/patterns.ts';
@@ -93,5 +94,38 @@ describe('buildChecklist with extraItems', () => {
     // Last line should be the highest-numbered pattern item
     const last = lines[lines.length - 1];
     expect(last).toMatch(/review-/);
+  });
+
+  it('parseChecklist round-trips pattern items added via extraItems', () => {
+    // Regression: the `## Review patterns` reference section that
+    // agent-checklist.ts appends after Key Decisions should not
+    // interfere with parseChecklist's enumeration of review-* items
+    // from the main checklist.
+    const detections = detectAllPatterns(parseDiff(DIFF_WITH_HITS));
+    const patternItems = buildPatternItems(detections);
+    const md = buildChecklist('infrastructure', BASE_METADATA, patternItems);
+    // Manually simulate what agent-checklist.ts appends
+    const mdWithSection = md + `
+
+## Review patterns (QUA-363)
+
+> Some explanation text.
+
+### \`review-github-conclusion-enum\` — GitHub check conclusions handled exhaustively
+
+**Why**: description text
+**Origin**: QUA-339 pass-2 bug HIGH-2
+
+**Hits in current diff**:
+- \`crux/lib/foo.ts:2\` — \`const bad = /failure|cancelled/.test(x.conclusion);\`
+`;
+    const parsed = parseChecklist(mdWithSection);
+    const reviewIds = parsed.items.filter((i) => i.id.startsWith('review-')).map((i) => i.id);
+    // All pattern items should be parsed as real items (status:unchecked)
+    expect(reviewIds.sort()).toEqual(
+      patternItems.map((i) => i.id).sort(),
+    );
+    // No items from the "Review patterns" reference section should leak in
+    expect(parsed.items.every((i) => !i.label.includes('Hits in current diff'))).toBe(true);
   });
 });

--- a/crux/lib/session/session-checklist.ts
+++ b/crux/lib/session/session-checklist.ts
@@ -7,6 +7,7 @@
  */
 
 import { execSync } from 'child_process';
+import { parseDiff, detectAllPatterns, type PatternDetection } from '../review-patterns/patterns.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -209,8 +210,70 @@ export function getItemsForType(type: SessionType): ChecklistItem[] {
   );
 }
 
-export function buildChecklist(type: SessionType, metadata: ChecklistMetadata): string {
-  const items = getItemsForType(type);
+// ---------------------------------------------------------------------------
+// Pattern-triggered checklist items (QUA-363, option B)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the current diff against origin/main (or main if origin unreachable).
+ * Returns an empty string on any failure — pattern detection becomes a no-op
+ * rather than blocking checklist init when git state is weird.
+ */
+export function getDiffAgainstMain(cwd: string = process.cwd()): string {
+  const attempts = [
+    'git diff origin/main...HEAD',
+    'git diff main...HEAD',
+    'git diff HEAD',
+  ];
+  for (const cmd of attempts) {
+    try {
+      const out = execSync(cmd, { cwd, encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+      if (out.length > 0) return out;
+    } catch { /* try next */ }
+  }
+  return '';
+}
+
+/**
+ * Build ChecklistItems from pattern detections.
+ *
+ * Each detected pattern becomes a single forced item. The item is
+ * `blocking` so the checklist cannot be `complete`'d without the
+ * reviewer explicitly checking it off or marking it `--na` with reason.
+ *
+ * Pattern ids are prefixed with `review-` to avoid colliding with the
+ * static checklist catalog above.
+ */
+export function buildPatternItems(detections: PatternDetection[]): ChecklistItem[] {
+  return detections.map(({ pattern, hits }) => ({
+    id: `review-${pattern.id}`,
+    label: `${pattern.label} (${hits.length} site${hits.length === 1 ? '' : 's'} in diff)`,
+    applicableTypes: 'all' as const,
+    priority: 'blocking' as const,
+  }));
+}
+
+/**
+ * Convenience: run the full diff → patterns → items pipeline against
+ * the current working directory. Returns both the items and the raw
+ * detections (so callers can include pattern metadata in the checklist).
+ */
+export function detectPatternItems(cwd?: string): {
+  items: ChecklistItem[];
+  detections: PatternDetection[];
+} {
+  const diff = getDiffAgainstMain(cwd);
+  if (!diff) return { items: [], detections: [] };
+  const detections = detectAllPatterns(parseDiff(diff));
+  return { items: buildPatternItems(detections), detections };
+}
+
+export function buildChecklist(
+  type: SessionType,
+  metadata: ChecklistMetadata,
+  extraItems: ChecklistItem[] = [],
+): string {
+  const items = [...getItemsForType(type), ...extraItems];
   const lines: string[] = [];
 
   lines.push('# Session Checklist');

--- a/crux/lib/session/session-checklist.ts
+++ b/crux/lib/session/session-checklist.ts
@@ -218,6 +218,10 @@ export function getItemsForType(type: SessionType): ChecklistItem[] {
  * Read the current diff against origin/main (or main if origin unreachable).
  * Returns an empty string on any failure — pattern detection becomes a no-op
  * rather than blocking checklist init when git state is weird.
+ *
+ * Hard-capped at a 10s timeout per attempt so a hung git command cannot
+ * block `agent-checklist init`. On huge repos the 16MB maxBuffer should
+ * comfortably cover realistic diffs (~a few MB worst case).
  */
 export function getDiffAgainstMain(cwd: string = process.cwd()): string {
   const attempts = [
@@ -227,7 +231,13 @@ export function getDiffAgainstMain(cwd: string = process.cwd()): string {
   ];
   for (const cmd of attempts) {
     try {
-      const out = execSync(cmd, { cwd, encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+      const out = execSync(cmd, {
+        cwd,
+        encoding: 'utf-8',
+        maxBuffer: 16 * 1024 * 1024,
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
       if (out.length > 0) return out;
     } catch { /* try next */ }
   }
@@ -264,8 +274,15 @@ export function detectPatternItems(cwd?: string): {
 } {
   const diff = getDiffAgainstMain(cwd);
   if (!diff) return { items: [], detections: [] };
-  const detections = detectAllPatterns(parseDiff(diff));
-  return { items: buildPatternItems(detections), detections };
+  // Pattern detection runs over untrusted diff text; a malformed diff
+  // must NEVER block `agent-checklist init`. Fall back to no items if
+  // anything in the parse/detect pipeline throws.
+  try {
+    const detections = detectAllPatterns(parseDiff(diff));
+    return { items: buildPatternItems(detections), detections };
+  } catch {
+    return { items: [], detections: [] };
+  }
 }
 
 export function buildChecklist(

--- a/crux/lib/session/session-checklist.ts
+++ b/crux/lib/session/session-checklist.ts
@@ -214,34 +214,54 @@ export function getItemsForType(type: SessionType): ChecklistItem[] {
 // Pattern-triggered checklist items (QUA-363, option B)
 // ---------------------------------------------------------------------------
 
+export interface DiffResult {
+  /** Raw unified-diff text. Empty string if the diff is genuinely empty
+   *  (branch equals main). */
+  diff: string;
+  /** Error message if EVERY attempt to read the diff failed. Callers
+   *  MUST check this — a silent `''` used to mean both "no changes" AND
+   *  "we couldn't read it", which let pattern detection invisibly
+   *  disable on huge (16MB+) diffs. (QUA-363 hostile-review HIGH-2.) */
+  error: string | null;
+}
+
 /**
  * Read the current diff against origin/main (or main if origin unreachable).
- * Returns an empty string on any failure — pattern detection becomes a no-op
- * rather than blocking checklist init when git state is weird.
  *
- * Hard-capped at a 10s timeout per attempt so a hung git command cannot
- * block `agent-checklist init`. On huge repos the 16MB maxBuffer should
- * comfortably cover realistic diffs (~a few MB worst case).
+ * Returns a tri-state result: `{diff, error}`. `error` is only set when
+ * EVERY attempted git command failed — that's the case callers should
+ * treat as "pattern detection is broken, do not trust a clean result".
+ *
+ * Hard-capped at a 15s timeout per attempt so a hung git command cannot
+ * block `agent-checklist init`. maxBuffer is 64MB — release PRs on this
+ * repo regularly hit 10-20MB and we don't want the detection to silently
+ * disappear on the largest, most-bug-prone PRs (HIGH-2 root cause).
  */
-export function getDiffAgainstMain(cwd: string = process.cwd()): string {
+export function getDiffAgainstMain(cwd: string = process.cwd()): DiffResult {
   const attempts = [
     'git diff origin/main...HEAD',
     'git diff main...HEAD',
     'git diff HEAD',
   ];
+  let lastError: string | null = null;
   for (const cmd of attempts) {
     try {
       const out = execSync(cmd, {
         cwd,
         encoding: 'utf-8',
-        maxBuffer: 16 * 1024 * 1024,
-        timeout: 10_000,
+        maxBuffer: 64 * 1024 * 1024,
+        timeout: 15_000,
         stdio: ['ignore', 'pipe', 'ignore'],
       });
-      if (out.length > 0) return out;
-    } catch { /* try next */ }
+      // Success — whatever the output (empty or not), this IS the diff.
+      return { diff: out, error: null };
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      // Try the next fallback. If all fail, we fall through to the
+      // error branch below.
+    }
   }
-  return '';
+  return { diff: '', error: lastError ?? 'all git diff attempts failed' };
 }
 
 /**
@@ -263,25 +283,45 @@ export function buildPatternItems(detections: PatternDetection[]): ChecklistItem
   }));
 }
 
-/**
- * Convenience: run the full diff → patterns → items pipeline against
- * the current working directory. Returns both the items and the raw
- * detections (so callers can include pattern metadata in the checklist).
- */
-export function detectPatternItems(cwd?: string): {
+export interface PatternDetectionResult {
   items: ChecklistItem[];
   detections: PatternDetection[];
-} {
-  const diff = getDiffAgainstMain(cwd);
-  if (!diff) return { items: [], detections: [] };
+  /**
+   * Set when the diff could not be read (all `git diff` attempts failed,
+   * e.g. maxBuffer overflow, hung git, missing origin/main ref).
+   *
+   * Callers that need a trustworthy "all clear" signal (the freshness
+   * check in `crux gh review-patterns check`) MUST fail closed when this
+   * is set — a clean attestation against a broken detector is worse than
+   * no detector at all.
+   */
+  diffError: string | null;
+}
+
+/**
+ * Run the full diff → patterns → items pipeline against the current
+ * working directory. Returns items, raw detections, and an explicit
+ * `diffError` so callers can distinguish "no patterns triggered" from
+ * "detection failed to run".
+ */
+export function detectPatternItems(cwd?: string): PatternDetectionResult {
+  const { diff, error } = getDiffAgainstMain(cwd);
+  if (error != null) {
+    return { items: [], detections: [], diffError: error };
+  }
+  if (!diff) return { items: [], detections: [], diffError: null };
   // Pattern detection runs over untrusted diff text; a malformed diff
   // must NEVER block `agent-checklist init`. Fall back to no items if
   // anything in the parse/detect pipeline throws.
   try {
     const detections = detectAllPatterns(parseDiff(diff));
-    return { items: buildPatternItems(detections), detections };
-  } catch {
-    return { items: [], detections: [] };
+    return { items: buildPatternItems(detections), detections, diffError: null };
+  } catch (e) {
+    return {
+      items: [],
+      detections: [],
+      diffError: e instanceof Error ? e.message : String(e),
+    };
   }
 }
 

--- a/crux/validate/__tests__/validate-command-handler-errors.test.ts
+++ b/crux/validate/__tests__/validate-command-handler-errors.test.ts
@@ -165,6 +165,23 @@ async function nested(args: string[], options: CommandOptions): Promise<CommandR
     expect(findings[0].status).toBe('unsafe');
   });
 
+  it('is not fooled by `{` inside a line comment', () => {
+    // Regression: pre-fix brace counter treated `// {` as an unbalanced
+    // open brace, shifting depth and causing the real try to appear
+    // at depth 2 instead of depth 1.
+    const code = `
+async function withComment(x: S, o: O): Promise<CommandResult> {
+  // this { is a comment
+  try {
+    return { exitCode: 0, output: '' };
+  } catch {
+    return { exitCode: 1, output: '' };
+  }
+}
+`;
+    expect(scanHandlers(PATH, code)[0].status).toBe('safe');
+  });
+
   it('reports accurate line numbers', () => {
     const code = [
       '',

--- a/crux/validate/__tests__/validate-command-handler-errors.test.ts
+++ b/crux/validate/__tests__/validate-command-handler-errors.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { scanHandlers } from '../validate-command-handler-errors.ts';
+
+const PATH = '/fake';
+
+describe('scanHandlers — command handler error boundary detection', () => {
+  it('flags an unsafe handler without top-level try/catch', () => {
+    const code = `
+async function badHandler(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const r = writeFileSync('/tmp/x', 'data');
+  return { exitCode: 0, output: 'ok' };
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].name).toBe('badHandler');
+    expect(findings[0].status).toBe('unsafe');
+  });
+
+  it('passes a handler that starts with try {', () => {
+    const code = `
+async function goodHandler(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  try {
+    writeFileSync('/tmp/x', 'data');
+    return { exitCode: 0, output: 'ok' };
+  } catch (e) {
+    return { exitCode: 1, output: String(e) };
+  }
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('safe');
+    expect(findings[0].safeReason).toBe('try-catch');
+  });
+
+  it('respects the `// handler-safe` marker on the line above', () => {
+    const code = `
+// handler-safe: pure formatter, cannot throw
+async function listHandler(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  return { exitCode: 0, output: formatTable() };
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('safe');
+    expect(findings[0].safeReason).toBe('handler-safe-marker');
+  });
+
+  it('ignores async functions that are not CommandResult handlers', () => {
+    const code = `
+async function fetchData(url: string): Promise<string> {
+  return fetch(url).then((r) => r.text());
+}
+async function doStuff(args: string[]): Promise<void> {
+  // nothing
+}
+`;
+    expect(scanHandlers(PATH, code)).toHaveLength(0);
+  });
+
+  it('handles single-line signatures', () => {
+    const code = `
+async function quick(args: string[], options: CommandOptions): Promise<CommandResult> {
+  return { exitCode: 0, output: '' };
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('unsafe');
+  });
+
+  it('handles export async function', () => {
+    const code = `
+export async function expo(args: string[], options: CommandOptions): Promise<CommandResult> {
+  try {
+    return { exitCode: 0, output: '' };
+  } catch {
+    return { exitCode: 1, output: '' };
+  }
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('safe');
+  });
+
+  it('catches multiple handlers in one file', () => {
+    const code = `
+async function a(x: S, o: O): Promise<CommandResult> {
+  return { exitCode: 0, output: '' };
+}
+async function b(x: S, o: O): Promise<CommandResult> {
+  try { return { exitCode: 0, output: '' }; } catch { return { exitCode: 1, output: '' }; }
+}
+async function c(x: S, o: O): Promise<CommandResult> {
+  doThing();
+  return { exitCode: 0, output: '' };
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(3);
+    expect(findings.find((f) => f.name === 'a')?.status).toBe('unsafe');
+    expect(findings.find((f) => f.name === 'b')?.status).toBe('safe');
+    expect(findings.find((f) => f.name === 'c')?.status).toBe('unsafe');
+  });
+
+  it('ignores leading comments when locating the first statement', () => {
+    const code = `
+async function commented(x: S, o: O): Promise<CommandResult> {
+  // leading comment
+  /* block comment */
+  try {
+    return { exitCode: 0, output: '' };
+  } catch { return { exitCode: 1, output: '' }; }
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings[0].status).toBe('safe');
+  });
+
+  it('passes a handler whose try block comes AFTER arg parsing (real-world pattern)', () => {
+    // This is the shape of sentinelWrite/sentinelTouch after QUA-339 pass-2:
+    // parse/validate first, then wrap the I/O portion in try/catch.
+    const code = `
+async function sentinelWrite(args: string[], options: RoleOptions): Promise<CommandResult> {
+  const role = parseRole(options);
+  if (typeof role !== 'string') return { exitCode: 1, output: role.error };
+  const env = makeSentinelEnv();
+  try {
+    const result = writeSentinelImpl(role, env);
+    return { exitCode: 0, output: 'wrote: ' + result.path };
+  } catch (e) {
+    return { exitCode: 1, output: 'failed: ' + e };
+  }
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].status).toBe('safe');
+    expect(findings[0].safeReason).toBe('try-catch');
+  });
+
+  it('flags a handler with try ONLY inside a nested block (not top-level)', () => {
+    const code = `
+async function nested(args: string[], options: CommandOptions): Promise<CommandResult> {
+  for (const x of items) {
+    try { doThing(x); } catch {}
+  }
+  return { exitCode: 0, output: '' };
+}
+`;
+    const findings = scanHandlers(PATH, code);
+    // The `try` is at depth 2 (inside the for loop), not depth 1,
+    // so the body has no top-level error boundary.
+    expect(findings[0].status).toBe('unsafe');
+  });
+
+  it('reports accurate line numbers', () => {
+    const code = [
+      '',
+      '',
+      'async function foo(x: S, o: O): Promise<CommandResult> {',
+      '  return { exitCode: 0, output: "" };',
+      '}',
+    ].join('\n');
+    const findings = scanHandlers(PATH, code);
+    expect(findings[0].line).toBe(3);
+  });
+});

--- a/crux/validate/__tests__/validate-command-handler-errors.test.ts
+++ b/crux/validate/__tests__/validate-command-handler-errors.test.ts
@@ -165,6 +165,62 @@ async function nested(args: string[], options: CommandOptions): Promise<CommandR
     expect(findings[0].status).toBe('unsafe');
   });
 
+  // QUA-363 hostile-review HIGH-1: brace counter was fooled by unbalanced
+  // `{` or `}` inside string literals. Regression tests for each shape.
+  it('is not fooled by `{` inside a double-quoted string literal', () => {
+    const code = `
+async function stringBrace(x: S, o: O): Promise<CommandResult> {
+  const s = "{ not a real brace }";
+  try {
+    return { exitCode: 0, output: s };
+  } catch {
+    return { exitCode: 1, output: '' };
+  }
+}
+`;
+    expect(scanHandlers(PATH, code)[0].status).toBe('safe');
+  });
+
+  it('is not fooled by `}` inside a single-quoted string literal', () => {
+    const code = `
+async function stringCloseBrace(x: S, o: O): Promise<CommandResult> {
+  const s = '}';
+  try {
+    return { exitCode: 0, output: s };
+  } catch {
+    return { exitCode: 1, output: '' };
+  }
+}
+`;
+    expect(scanHandlers(PATH, code)[0].status).toBe('safe');
+  });
+
+  it('is not fooled by escape sequences inside strings (`"\\""`)', () => {
+    const code = `
+async function escaped(x: S, o: O): Promise<CommandResult> {
+  const s = "escaped \\" and {";
+  try {
+    return { exitCode: 0, output: s };
+  } catch {
+    return { exitCode: 1, output: '' };
+  }
+}
+`;
+    expect(scanHandlers(PATH, code)[0].status).toBe('safe');
+  });
+
+  it('is not fooled by a `try` token that appears inside a string', () => {
+    // `"please try again"` used to incorrectly match the `try ` pattern.
+    // After stripStringLiterals the string contents become spaces.
+    const code = `
+async function tryInString(x: S, o: O): Promise<CommandResult> {
+  const msg = "please try again";
+  return { exitCode: 1, output: msg };
+}
+`;
+    expect(scanHandlers(PATH, code)[0].status).toBe('unsafe');
+  });
+
   it('is not fooled by `{` inside a line comment', () => {
     // Regression: pre-fix brace counter treated `// {` as an unbalanced
     // open brace, shifting depth and causing the real try to appear

--- a/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
+++ b/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { scanFileContent } from '../validate-github-conclusion-enum.ts';
+
+const PATH = '/fake/crux/lib/releases.ts';
+
+describe('scanFileContent — github conclusion enum exhaustiveness', () => {
+  it('flags the QUA-339 pass-1 regex gap: /fail|cancel|error/', () => {
+    const code = `
+      const failing = checks.filter((c) =>
+        c.conclusion && /fail|cancel|error/i.test(c.conclusion)
+      );
+    `;
+    const violations = scanFileContent(PATH, code);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].missing).toContain('failure');
+    expect(violations[0].missing).toContain('cancelled');
+    expect(violations[0].missing).toContain('timed_out');
+    expect(violations[0].missing).toContain('action_required');
+    expect(violations[0].missing).toContain('startup_failure');
+  });
+
+  it('flags the sibling regex /failure|cancelled|timed_out/ for missing action_required', () => {
+    const code = `
+      const failed = runs.filter((r) => /failure|cancelled|timed_out/.test(r.conclusion));
+    `;
+    const violations = scanFileContent(PATH, code);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].missing).toEqual(['action_required', 'startup_failure']);
+  });
+
+  it('accepts a complete regex covering all FAILING_CONCLUSIONS', () => {
+    const code = `
+      const failed = runs.filter((r) => /failure|cancelled|timed_out|action_required|startup_failure/.test(r.conclusion));
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('ignores regexes that do not mention any failing conclusion', () => {
+    const code = `
+      if (conclusion === 'success') return true;
+      const ok = /success|neutral|skipped/.test(conclusion);
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('ignores regexes on lines that do not mention conclusion context', () => {
+    const code = `
+      const title = s.replace(/failure/, 'FAILURE');
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('respects `// conclusion-enum-ok` suppression on the same line', () => {
+    const code = `
+      const failing = /fail|cancel/.test(c.conclusion); // conclusion-enum-ok: narrow scope
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('respects `// conclusion-enum-ok` suppression on the previous line', () => {
+    const code = `
+      // conclusion-enum-ok: scoped to draft PRs only
+      const failing = /fail|cancel/.test(c.conclusion);
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('treats division as NOT a regex literal', () => {
+    const code = `
+      // Division, not a regex — line mentions conclusion to trip the prefilter
+      const rate = failures / total; // conclusion
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
+  it('catches multiple violations in one file', () => {
+    const code = `
+      const a = /failure|cancelled/.test(x.conclusion);
+      const b = /fail|error/.test(y.conclusion);
+    `;
+    const violations = scanFileContent(PATH, code);
+    expect(violations).toHaveLength(2);
+  });
+
+  it('preserves line numbers', () => {
+    const code = [
+      '',
+      'function foo() {',
+      '  return /fail|cancel/.test(c.conclusion);',
+      '}',
+    ].join('\n');
+    const violations = scanFileContent(PATH, code);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].line).toBe(3);
+  });
+});

--- a/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
+++ b/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
@@ -81,6 +81,19 @@ describe('scanFileContent — github conclusion enum exhaustiveness', () => {
     expect(scanFileContent(PATH, code)).toHaveLength(0);
   });
 
+  // QUA-363 hostile-review LOW-6: `error` isn't a canonical GitHub
+  // check-run conclusion, but the old flavored-token regex flagged any
+  // error-matching regex that happened to be on a line containing
+  // "conclusion" in a comment. Dropping `error` from the trigger set
+  // eliminates the false positive.
+  it('does not flag log-level regexes that happen to be near a "conclusion" word', () => {
+    const code = `
+      // this line mentions conclusion in a comment for prefilter trip
+      const logErrors = /error|fatal/.test(message);
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
   it('catches multiple violations in one file', () => {
     const code = `
       const a = /failure|cancelled/.test(x.conclusion);

--- a/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
+++ b/crux/validate/__tests__/validate-github-conclusion-enum.test.ts
@@ -73,6 +73,14 @@ describe('scanFileContent — github conclusion enum exhaustiveness', () => {
     expect(scanFileContent(PATH, code)).toHaveLength(0);
   });
 
+  it('ignores commented-out regexes (live-code check only)', () => {
+    const code = `
+      // const old = /failure|cancel/.test(c.conclusion);
+      const rate = 1; // conclusion
+    `;
+    expect(scanFileContent(PATH, code)).toHaveLength(0);
+  });
+
   it('catches multiple violations in one file', () => {
     const code = `
       const a = /failure|cancelled/.test(x.conclusion);

--- a/crux/validate/validate-command-handler-errors.ts
+++ b/crux/validate/validate-command-handler-errors.ts
@@ -127,26 +127,79 @@ export function scanHandlers(filePath: string, content: string): HandlerFinding[
 }
 
 /**
+ * Strip string and template literals so brace-counting scanners don't
+ * mistake `"{"` or `'}'` or `` `${...}` `` content for real braces.
+ * Replaces every character inside a literal with a space (preserving
+ * positions so subsequent line-level offsets stay accurate — not used
+ * today but cheap insurance).
+ *
+ * Handles:
+ *   - `"..."` double-quoted strings, including escaped quotes
+ *   - `'...'` single-quoted strings
+ *   - `` `...` `` template literals (including `${}` interpolations —
+ *     we treat the whole literal as opaque, which is wrong for nested
+ *     braces inside `${}` but the common case is a string on one line)
+ *
+ * Does NOT strip block comments or handle template literals that span
+ * multiple lines. Those edge cases stay as known failure modes of the
+ * advisory validator.
+ */
+function stripStringLiterals(line: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      out.push(' '); // opening delimiter → space
+      i += 1;
+      while (i < line.length) {
+        const c = line[i];
+        if (c === '\\' && i + 1 < line.length) {
+          // Preserve width (2 chars) for escapes like \" or \\
+          out.push('  ');
+          i += 2;
+          continue;
+        }
+        if (c === ch) {
+          out.push(' '); // closing delimiter → space
+          i += 1;
+          break;
+        }
+        // Inside the literal: everything becomes a space
+        out.push(' ');
+        i += 1;
+      }
+      continue;
+    }
+    out.push(ch);
+    i += 1;
+  }
+  return out.join('');
+}
+
+/**
  * Strip line comments from a source line so brace-counting scanners
  * don't mistake `// {` for a real opening brace. Rough heuristic: cuts
  * from the first `//` not preceded by `:` (to spare protocol-ish
- * `http://`) and not inside a string. We don't try to fully tokenize;
- * the handler bodies we care about rarely have both string literals
- * AND `//` on the same line.
+ * `http://`) and not inside a string. We apply `stripStringLiterals`
+ * first so `// inside "a string"` isn't mis-detected as a comment.
  */
 function stripLineComment(line: string): string {
-  const idx = line.indexOf('//');
-  if (idx < 0) return line;
-  if (idx > 0 && line[idx - 1] === ':') return line; // e.g., http://
-  return line.slice(0, idx);
+  // Strip string contents first so a `//` inside a string isn't
+  // treated as a comment start.
+  const stripped = stripStringLiterals(line);
+  const idx = stripped.indexOf('//');
+  if (idx < 0) return stripped;
+  if (idx > 0 && stripped[idx - 1] === ':') return stripped; // e.g., http://
+  return stripped.slice(0, idx);
 }
 
 /**
  * Given the line index of a function body's opening `{`, find the line
  * index of its matching `}`. Best-effort: counts `{` / `}` occurrences
- * after stripping single-line comments. Doesn't handle block comments
- * or string literals — handler bodies are usually simple enough for
- * this to be fine, and the red-team tests exercise the failure modes.
+ * after stripping single-line comments and string literal contents.
+ * Doesn't handle block comments or template literals that span multiple
+ * lines — those are known failure modes documented in the test file.
  */
 function findMatchingBrace(lines: string[], openLine: number): number {
   let depth = 0;
@@ -199,9 +252,14 @@ function collectCommandFiles(root: string): string[] {
     if (!statSync(root).isDirectory()) return out;
   } catch { return out; }
   for (const entry of readdirSync(root, { withFileTypes: true })) {
+    // crux/commands/ has a flat layout but skip nested dirs (including
+    // __tests__/) for safety if a future refactor adds one.
+    if (entry.isDirectory()) continue;
     if (!entry.isFile()) continue;
     if (!entry.name.endsWith('.ts')) continue;
-    if (entry.name.endsWith('.test.ts')) continue;
+    // Match the filter used elsewhere in the codebase (validate-github-
+    // conclusion-enum.ts): both `.test.ts` and `.spec.ts` are test files.
+    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue;
     out.push(join(root, entry.name));
   }
   return out;

--- a/crux/validate/validate-command-handler-errors.ts
+++ b/crux/validate/validate-command-handler-errors.ts
@@ -127,15 +127,32 @@ export function scanHandlers(filePath: string, content: string): HandlerFinding[
 }
 
 /**
+ * Strip line comments from a source line so brace-counting scanners
+ * don't mistake `// {` for a real opening brace. Rough heuristic: cuts
+ * from the first `//` not preceded by `:` (to spare protocol-ish
+ * `http://`) and not inside a string. We don't try to fully tokenize;
+ * the handler bodies we care about rarely have both string literals
+ * AND `//` on the same line.
+ */
+function stripLineComment(line: string): string {
+  const idx = line.indexOf('//');
+  if (idx < 0) return line;
+  if (idx > 0 && line[idx - 1] === ':') return line; // e.g., http://
+  return line.slice(0, idx);
+}
+
+/**
  * Given the line index of a function body's opening `{`, find the line
  * index of its matching `}`. Best-effort: counts `{` / `}` occurrences
- * without respecting strings or comments. Good enough for handler bodies.
+ * after stripping single-line comments. Doesn't handle block comments
+ * or string literals — handler bodies are usually simple enough for
+ * this to be fine, and the red-team tests exercise the failure modes.
  */
 function findMatchingBrace(lines: string[], openLine: number): number {
   let depth = 0;
   let started = false;
   for (let i = openLine; i < lines.length; i++) {
-    for (const ch of lines[i]) {
+    for (const ch of stripLineComment(lines[i])) {
       if (ch === '{') { depth += 1; started = true; }
       else if (ch === '}') {
         depth -= 1;
@@ -154,7 +171,7 @@ function bodyContainsTopLevelTry(lines: string[], openLine: number, endLine: num
   let depth = 0;
   let started = false;
   for (let i = openLine; i <= endLine && i < lines.length; i++) {
-    const line = lines[i];
+    const line = stripLineComment(lines[i]);
     for (let k = 0; k < line.length; k++) {
       const ch = line[k];
       if (ch === '{') { depth += 1; started = true; continue; }

--- a/crux/validate/validate-command-handler-errors.ts
+++ b/crux/validate/validate-command-handler-errors.ts
@@ -1,0 +1,232 @@
+/**
+ * Validator: crux command handlers should wrap filesystem / exec / network
+ * I/O in a top-level try/catch (or explicitly opt out with `// handler-safe`).
+ *
+ * Background: QUA-339 PR #4245 shipped four new command handlers
+ * (`sentinelWrite`, `sentinelTouch`, `sentinelCheck`, `tmuxClaim`) that
+ * called into fs-touching helpers without error handling. A filesystem
+ * error (EACCES on /tmp, EDQUOT, etc.) would surface as an uncaught
+ * exception with a raw Node stack trace instead of a clean
+ * CommandResult, crashing the calling skill. Caught by the pass-2 review,
+ * fixed in #4256.
+ *
+ * Scope: This validator is ADVISORY (non-blocking). The existing crux
+ * codebase has many legacy handlers without try/catch, and retrofitting
+ * all of them is a separate project. The purpose here is to:
+ *   1. Produce a visible warning when new handlers lack error handling,
+ *      so reviewers notice the pattern
+ *   2. Provide detection logic that `/agent-review-pr` and the
+ *      diff-triggered checklist (option B) can reuse
+ *
+ * Detection semantics:
+ *   - A "command handler" is an async function whose return type is
+ *     `Promise<CommandResult>`
+ *   - The handler is "safe" if:
+ *     (a) its body contains a `try {` block at the top level (brace
+ *         depth 1 relative to the body), OR
+ *     (b) the line above its declaration contains `// handler-safe`
+ *   - Otherwise it's flagged
+ *
+ * We deliberately do NOT require the try to be the FIRST statement —
+ * real handlers usually do arg parsing and type narrowing first, then
+ * wrap the I/O section in try/catch. The point is "some protection is
+ * present", not "protection is maximally eager".
+ *
+ * Run standalone: npx tsx crux/validate/validate-command-handler-errors.ts
+ *
+ * Exit code:
+ *   0 — advisory; always exits 0 so the gate doesn't block on legacy handlers
+ *   (summary is printed to stdout so the gate captures it as a warning)
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+export interface HandlerFinding {
+  file: string;
+  line: number;
+  name: string;
+  /** `safe` = has try/catch or marker; `unsafe` = neither. */
+  status: 'safe' | 'unsafe';
+  /** Why the handler was classified as safe, when applicable. */
+  safeReason?: 'try-catch' | 'handler-safe-marker';
+}
+
+/**
+ * Scan a single file's source for `Promise<CommandResult>` handlers and
+ * classify each one as safe or unsafe.
+ *
+ * Pure over content — tests can pass synthetic source without touching
+ * the filesystem.
+ */
+export function scanHandlers(filePath: string, content: string): HandlerFinding[] {
+  const lines = content.split('\n');
+  const findings: HandlerFinding[] = [];
+  const rel = filePath === '/fake' ? '/fake' : relative(PROJECT_ROOT, filePath);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Look for `async function <name>(` — accept standalone or `export async`
+    const sigMatch = line.match(/\basync\s+function\s+(\w+)\s*\(/);
+    if (!sigMatch) continue;
+
+    // Confirm this is a CommandResult handler. The return-type annotation
+    // may be on the same line or up to ~5 lines below (multi-line sigs).
+    let returnTypeLine = -1;
+    for (let j = i; j < Math.min(i + 8, lines.length); j++) {
+      if (lines[j].includes('Promise<CommandResult>')) {
+        returnTypeLine = j;
+        break;
+      }
+      // Stop if we hit a body brace before seeing the return type
+      if (lines[j].includes('{') && j > i) break;
+    }
+    if (returnTypeLine < 0) continue;
+
+    const name = sigMatch[1];
+
+    // Check for `// handler-safe` marker on the line directly above the sig.
+    const prev = i > 0 ? lines[i - 1].trim() : '';
+    if (/\/\/\s*handler-safe\b/.test(prev)) {
+      findings.push({ file: rel, line: i + 1, name, status: 'safe', safeReason: 'handler-safe-marker' });
+      continue;
+    }
+
+    // Find the body-opening brace — the `{` that starts the function body.
+    let braceLine = -1;
+    for (let j = returnTypeLine; j < Math.min(returnTypeLine + 3, lines.length); j++) {
+      if (lines[j].trimEnd().endsWith('{')) {
+        braceLine = j;
+        break;
+      }
+    }
+    if (braceLine < 0) continue;
+
+    // Walk the body, tracking brace depth, looking for a `try {` at
+    // the body's top level (depth 1 relative to body start).
+    // We use a simple character scan because handler bodies rarely
+    // contain regex literals or template strings with unbalanced braces.
+    const bodyEnd = findMatchingBrace(lines, braceLine);
+    const hasTry = bodyContainsTopLevelTry(lines, braceLine, bodyEnd);
+
+    findings.push({
+      file: rel,
+      line: i + 1,
+      name,
+      status: hasTry ? 'safe' : 'unsafe',
+      safeReason: hasTry ? 'try-catch' : undefined,
+    });
+
+    // Skip past the body we just processed to avoid re-matching nested
+    // async functions (rare for handlers, but possible).
+    i = bodyEnd;
+  }
+
+  return findings;
+}
+
+/**
+ * Given the line index of a function body's opening `{`, find the line
+ * index of its matching `}`. Best-effort: counts `{` / `}` occurrences
+ * without respecting strings or comments. Good enough for handler bodies.
+ */
+function findMatchingBrace(lines: string[], openLine: number): number {
+  let depth = 0;
+  let started = false;
+  for (let i = openLine; i < lines.length; i++) {
+    for (const ch of lines[i]) {
+      if (ch === '{') { depth += 1; started = true; }
+      else if (ch === '}') {
+        depth -= 1;
+        if (started && depth === 0) return i;
+      }
+    }
+  }
+  return lines.length - 1;
+}
+
+/**
+ * True if the body spanning [openLine+1, endLine) contains a `try` token
+ * at body-level depth (depth 1 relative to the body's opening `{`).
+ */
+function bodyContainsTopLevelTry(lines: string[], openLine: number, endLine: number): boolean {
+  let depth = 0;
+  let started = false;
+  for (let i = openLine; i <= endLine && i < lines.length; i++) {
+    const line = lines[i];
+    for (let k = 0; k < line.length; k++) {
+      const ch = line[k];
+      if (ch === '{') { depth += 1; started = true; continue; }
+      if (ch === '}') { depth -= 1; continue; }
+      if (!started) continue;
+      // Only look for top-level `try` at depth === 1 (inside the body,
+      // not inside a nested block). Check for word-boundary `try`.
+      if (depth === 1 && ch === 't' && line.slice(k, k + 4) === 'try ') {
+        // Require preceding char to be whitespace, `;`, or start of line
+        const prev = k > 0 ? line[k - 1] : '\n';
+        if (/\s|;|^/.test(prev)) {
+          // Must be followed by `{` on this line or the next (after whitespace)
+          const after = line.slice(k + 3).trim();
+          if (after.startsWith('{') || after === '') return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function collectCommandFiles(root: string): string[] {
+  const out: string[] = [];
+  try {
+    if (!statSync(root).isDirectory()) return out;
+  } catch { return out; }
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.ts')) continue;
+    if (entry.name.endsWith('.test.ts')) continue;
+    out.push(join(root, entry.name));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint — advisory only
+// ---------------------------------------------------------------------------
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const commandsDir = join(PROJECT_ROOT, 'crux/commands');
+  const files = collectCommandFiles(commandsDir);
+  const allFindings: HandlerFinding[] = [];
+  for (const f of files) {
+    allFindings.push(...scanHandlers(f, readFileSync(f, 'utf-8')));
+  }
+
+  const unsafe = allFindings.filter((f) => f.status === 'unsafe');
+  const safe = allFindings.filter((f) => f.status === 'safe');
+
+  console.log(
+    `Command handler error boundary: ${safe.length} safe, ${unsafe.length} without try/catch (advisory)`,
+  );
+
+  if (unsafe.length > 0) {
+    console.log('');
+    console.log('Handlers without top-level try/catch or `// handler-safe` marker:');
+    // Cap output — advisory, not blocking; don't flood the gate log.
+    for (const f of unsafe.slice(0, 30)) {
+      console.log(`  ${f.file}:${f.line} — ${f.name}`);
+    }
+    if (unsafe.length > 30) {
+      console.log(`  … ${unsafe.length - 30} more`);
+    }
+    console.log('');
+    console.log('Fix options:');
+    console.log('  1. Wrap body in try/catch, return { exitCode: 1, output: msg }');
+    console.log('  2. Annotate `// handler-safe` on the line above if body cannot throw');
+    console.log('');
+    console.log('See QUA-339 PR #4256 for the pattern.');
+  }
+
+  // Advisory: always exit 0. Gate parses stdout to surface the count.
+  process.exit(0);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -394,6 +394,31 @@ const PARALLEL_STEPS: Step[] = [
     // checks both HTML <td> tables and TanStack ColumnDef arrays.
   },
   {
+    // QUA-363: catches the QUA-339 pass-2 bug class where a regex matches
+    // `conclusion` fields but omits timed_out / action_required / etc.
+    // Blocking — there's no legitimate reason to partially enumerate the
+    // GitHub check conclusion set. Suppress false positives with a
+    // `// conclusion-enum-ok: <reason>` comment on the same or previous line.
+    id: 'github-conclusion-enum',
+    name: 'GitHub check conclusion enum exhaustiveness',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-github-conclusion-enum.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
+    // QUA-363: advisory scan for crux command handlers without top-level
+    // try/catch (or an explicit `// handler-safe` marker). Advisory because
+    // the existing codebase has ~260 legacy handlers; retrofitting is a
+    // separate project. The warning makes the count visible so reviewers
+    // notice when NEW handlers drift up the count.
+    id: 'command-handler-errors',
+    name: 'Command handler error boundary (advisory)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-command-handler-errors.ts'],
+    cwd: PROJECT_ROOT,
+    advisory: true,
+  },
+  {
     id: 'actions-yaml',
     name: 'GitHub Actions workflow YAML (actionlint)',
     command: 'npx',

--- a/crux/validate/validate-github-conclusion-enum.ts
+++ b/crux/validate/validate-github-conclusion-enum.ts
@@ -1,0 +1,249 @@
+/**
+ * Validator: GitHub check conclusion enum exhaustiveness.
+ *
+ * Background: QUA-339 PR #4245 shipped two sibling checks that each parsed
+ * the `conclusion` field from `gh pr list` / `gh run list` output. The first
+ * used `/fail|cancel|error/i` (missed `timed_out` and `action_required`), the
+ * second used `/failure|cancelled|timed_out/` (still missed `action_required`
+ * and `startup_failure`). Both reported failing CI runs as "no failing
+ * checks" because the regex didn't cover the full GitHub enum.
+ *
+ * GitHub's check-runs API lists the canonical failure conclusions as:
+ *   failure | cancelled | timed_out | action_required | startup_failure
+ * Plus non-failures: success | neutral | skipped | stale
+ *
+ * This validator scans every `.ts` / `.mjs` file under `crux/` (and
+ * `apps/` where relevant) for regex literals whose source mentions any
+ * conclusion keyword, and flags those that are missing one or more of the
+ * required failing variants. False positives are suppressible with a
+ * `// conclusion-enum-ok: <reason>` comment on the same or previous line.
+ *
+ * Exit code:
+ *   0 — no violations
+ *   1 — one or more regexes are missing required conclusion variants
+ *
+ * Run standalone: npx tsx crux/validate/validate-github-conclusion-enum.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+/** The canonical set of conclusions GitHub treats as failures. */
+const FAILING_CONCLUSIONS = [
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+] as const;
+
+/** Tokens that imply the regex is scoped to check-conclusion parsing. */
+const CONCLUSION_KEYWORDS = /conclusion|statusCheck|check[_\s]?run|ci[_\s]?run/i;
+
+/**
+ * Tokens that imply the regex is trying to match FAILING conclusions.
+ * Includes truncated forms (`fail`, `cancel`) because the pass-1 QUA-339
+ * bug literally used those — that's the whole point of the check.
+ *
+ * Does NOT include success-flavored tokens (`success`, `neutral`, `skipped`,
+ * `stale`) — a regex matching those is probably the inverse check and
+ * shouldn't be forced to include failing names.
+ */
+const FAILING_FLAVORED_TOKEN_RE =
+  /(failure|fail|cancelled|cancel|error|timed_out|timeout|action_required|startup_failure)/i;
+
+/** The suppression marker, e.g. `// conclusion-enum-ok: see QUA-xxx` */
+const SUPPRESSION_RE = /\/\/\s*conclusion-enum-ok\b/;
+
+interface Violation {
+  file: string;
+  line: number;
+  regexSource: string;
+  missing: string[];
+}
+
+interface ScanOptions {
+  rootDirs: string[];
+}
+
+function collectFiles(root: string): string[] {
+  const out: string[] = [];
+  function walk(d: string) {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.') || entry.name === '__tests__') continue;
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|mjs)$/.test(entry.name)) continue;
+      if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue;
+      // Skip this validator itself so its literal FAILING_CONCLUSIONS list
+      // isn't flagged as "incomplete regex".
+      if (full.includes('validate-github-conclusion-enum.ts')) continue;
+      out.push(full);
+    }
+  }
+  try {
+    if (statSync(root).isDirectory()) walk(root);
+  } catch {
+    // missing dir — skip silently
+  }
+  return out;
+}
+
+/**
+ * Scan a single file for regex literals whose source mentions conclusion
+ * tokens, and return any that don't cover the full FAILING_CONCLUSIONS set.
+ */
+export function scanFileContent(filePath: string, content: string): Violation[] {
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+  const rel = relative(PROJECT_ROOT, filePath);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Cheap prefilter: skip lines that don't even mention conclusion-ish context.
+    if (!CONCLUSION_KEYWORDS.test(line)) continue;
+    // Suppression check on this line OR the line above.
+    if (SUPPRESSION_RE.test(line)) continue;
+    if (i > 0 && SUPPRESSION_RE.test(lines[i - 1])) continue;
+
+    // Find every regex literal on this line.
+    // Simple extractor: match `/` ... unescaped `/` on one line.
+    // Good enough — the /failure|timed_out/-shaped literals the bug
+    // class produces all fit on one line.
+    const literals = extractRegexLiterals(line);
+    for (const lit of literals) {
+      // Only inspect regexes that LOOK like they're trying to match
+      // failing conclusions (includes truncated forms like `fail` /
+      // `cancel` — pass-1 of the QUA-339 bug used exactly those).
+      if (!FAILING_FLAVORED_TOKEN_RE.test(lit)) continue;
+      // Canonical check: does this literal cover every failing full name?
+      const missing = FAILING_CONCLUSIONS.filter((v) => !lit.includes(v));
+      if (missing.length === 0) continue;
+      violations.push({
+        file: rel,
+        line: i + 1,
+        regexSource: lit,
+        missing,
+      });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Extract regex literals from a single line of JS/TS. Handles the common
+ * cases: `/foo/`, `/foo/flags`, `foo.replace(/bar/g, ...)`. Does NOT try
+ * to be a full JS lexer — the bug class we care about always has a
+ * simple single-line regex.
+ */
+function extractRegexLiterals(line: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch !== '/') {
+      i++;
+      continue;
+    }
+    // Heuristic: is this a division or a regex literal?
+    // Treat as a regex if the previous non-space char is one of
+    // `=(,!&|?:{};[` or the `>` from an arrow function `=>`, or
+    // start-of-line. This mirrors how JS parsers disambiguate regex
+    // vs division without a full state machine.
+    const prev = previousNonSpace(line, i);
+    const prevTwo = previousNonSpaceTwo(line, i);
+    const startsRegex =
+      prev == null ||
+      /[=(,!&|?:{};[]/.test(prev) ||
+      prevTwo === '=>' ||
+      prev === 'n' && /\breturn$/.test(line.slice(0, i).trimEnd()); // `return /foo/`
+    if (!startsRegex) { i++; continue; }
+    // Scan until unescaped `/`
+    let j = i + 1;
+    let escaped = false;
+    let inClass = false;
+    for (; j < line.length; j++) {
+      const c = line[j];
+      if (escaped) { escaped = false; continue; }
+      if (c === '\\') { escaped = true; continue; }
+      if (c === '[') { inClass = true; continue; }
+      if (c === ']') { inClass = false; continue; }
+      if (c === '/' && !inClass) break;
+    }
+    if (j >= line.length) { i++; continue; }
+    // Consume trailing flags
+    let k = j + 1;
+    while (k < line.length && /[gimsuy]/.test(line[k])) k++;
+    out.push(line.slice(i, k));
+    i = k;
+  }
+  return out;
+}
+
+function previousNonSpace(line: string, pos: number): string | null {
+  for (let i = pos - 1; i >= 0; i--) {
+    if (line[i] !== ' ' && line[i] !== '\t') return line[i];
+  }
+  return null;
+}
+
+/** Return the two non-space chars immediately before `pos`, joined. */
+function previousNonSpaceTwo(line: string, pos: number): string | null {
+  let found = '';
+  for (let i = pos - 1; i >= 0 && found.length < 2; i--) {
+    if (line[i] !== ' ' && line[i] !== '\t') found = line[i] + found;
+  }
+  return found.length === 2 ? found : null;
+}
+
+function scanAll(options: ScanOptions): Violation[] {
+  const out: Violation[] = [];
+  for (const root of options.rootDirs) {
+    for (const file of collectFiles(root)) {
+      const content = readFileSync(file, 'utf-8');
+      out.push(...scanFileContent(file, content));
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+// Only run the CLI entrypoint when invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const violations = scanAll({
+    rootDirs: [
+      join(PROJECT_ROOT, 'crux'),
+      join(PROJECT_ROOT, 'apps/web/src'),
+      join(PROJECT_ROOT, 'apps/wiki-server/src'),
+    ],
+  });
+
+  if (violations.length === 0) {
+    console.log('✓ GitHub conclusion enum exhaustiveness: no violations');
+    process.exit(0);
+  }
+
+  console.error(`✗ ${violations.length} GitHub conclusion regex(es) missing failing variants:\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}`);
+    console.error(`    regex:   ${v.regexSource}`);
+    console.error(`    missing: ${v.missing.join(', ')}`);
+    console.error('');
+  }
+  console.error('Fix options:');
+  console.error('  1. Extend the regex to cover all FAILING_CONCLUSIONS:');
+  console.error('     /failure|cancelled|timed_out|action_required|startup_failure/');
+  console.error('  2. Better: switch to an allowlist helper');
+  console.error('     e.g. import { isFailingConclusion } from "./github-conclusions.ts"');
+  console.error('  3. If intentional (e.g. the regex is scoped to a narrower state),');
+  console.error('     suppress with `// conclusion-enum-ok: <reason>` on the same or');
+  console.error('     previous line.');
+  process.exit(1);
+}

--- a/crux/validate/validate-github-conclusion-enum.ts
+++ b/crux/validate/validate-github-conclusion-enum.ts
@@ -109,6 +109,10 @@ export function scanFileContent(filePath: string, content: string): Violation[] 
     // Suppression check on this line OR the line above.
     if (SUPPRESSION_RE.test(line)) continue;
     if (i > 0 && SUPPRESSION_RE.test(lines[i - 1])) continue;
+    // Skip single-line comments. A commented-out regex isn't live code and
+    // shouldn't be flagged. Block comments and JSDoc blocks are rare enough
+    // with inline regexes that we don't try to detect them here.
+    if (line.trim().startsWith('//')) continue;
 
     // Find every regex literal on this line.
     // Simple extractor: match `/` ... unescaped `/` on one line.

--- a/crux/validate/validate-github-conclusion-enum.ts
+++ b/crux/validate/validate-github-conclusion-enum.ts
@@ -46,12 +46,17 @@ const CONCLUSION_KEYWORDS = /conclusion|statusCheck|check[_\s]?run|ci[_\s]?run/i
  * Includes truncated forms (`fail`, `cancel`) because the pass-1 QUA-339
  * bug literally used those — that's the whole point of the check.
  *
- * Does NOT include success-flavored tokens (`success`, `neutral`, `skipped`,
- * `stale`) — a regex matching those is probably the inverse check and
- * shouldn't be forced to include failing names.
+ * Deliberately EXCLUDES `error` — it's not a GitHub check-run conclusion
+ * value, and including it caused false positives where a regex targeting
+ * log levels (e.g. `/error|fatal/`) happened to appear on a line
+ * mentioning the word "conclusion" in a comment. (QUA-363 hostile-review
+ * LOW-6.)
+ *
+ * Also excludes success-flavored tokens (`success`, `neutral`, `skipped`,
+ * `stale`) — a regex matching those is probably the inverse check.
  */
 const FAILING_FLAVORED_TOKEN_RE =
-  /(failure|fail|cancelled|cancel|error|timed_out|timeout|action_required|startup_failure)/i;
+  /(failure|fail|cancelled|cancel|timed_out|timeout|action_required|startup_failure)/i;
 
 /** The suppression marker, e.g. `// conclusion-enum-ok: see QUA-xxx` */
 const SUPPRESSION_RE = /\/\/\s*conclusion-enum-ok\b/;


### PR DESCRIPTION
## Summary

Closes **QUA-363** (filed this session as the A/B/E implementation of the brainstorm from the QUA-339 follow-up discussion). Addresses the review-pass-2 blind-spot problem by moving bug pattern detection from "hope the LLM reads the prompt" into mechanical enforcement across three enforcement tiers, all sharing a single pattern registry.

Related: **QUA-361** (option C — typed enum wrappers — filed as unconfirmed idea, deferred pending A/B/E data).

## The three tiers

### Single source of truth: `crux/lib/review-patterns/patterns.ts`

Each pattern declares `{ id, label, reason, origin, detect(diff), mechanical }`. Five patterns seeded from the QUA-339 pass-2 bugs (2 HIGH, 3 MEDIUM). Includes a minimal unified-diff parser so detectors are pure functions over diff text.

### A — Mechanical gate validators

- **`validate-github-conclusion-enum.ts`** (BLOCKING): scans `crux/` and `apps/` for regex literals applied to `conclusion` fields; fails if the regex mentions a failing-flavored token but omits any of `{failure, cancelled, timed_out, action_required, startup_failure}`. Suppress with `// conclusion-enum-ok: <reason>`. Catches the QUA-339 pass-2 HIGH-2 bug class.
- **`validate-command-handler-errors.ts`** (ADVISORY): reports handlers without top-level try/catch or `// handler-safe` marker. Advisory because 264/299 existing handlers predate the rule — retrofitting is a separate project. Visible count prevents regression. Catches the MED-3 bug class.

Both expose pure `scanFileContent()` / `scanHandlers()` functions tested independently of filesystem state.

### B — Diff-triggered checklist items

`crux sys agent-checklist init` now scans `git diff origin/main...HEAD` against the pattern registry. For each triggered pattern, a `review-<pattern-id>` blocking item is injected into the checklist, with a "Review patterns" section appended explaining the reason, origin ticket, and matched file:line locations. Items cannot be `--na`'d without `--reason`.

Extends `buildChecklist(type, metadata, extraItems?)` — third param is optional, so all 59 existing session-checklist tests pass unchanged.

### E — Attestation command

**New: `crux gh review-patterns check`** parses `.claude/wip-checklist.md`, collects every `review-*` item, and reports attestation. Exits 1 if any is still unchecked. Wired into:
- `/agent-review-pr` as new **Phase 9.5** — must pass before writing the review marker
- `/agent-ship` **Step 7** — must pass before pushing

Also adds `crux gh review-patterns list` / `--json` for inspecting the registry.

## Architecture

```
crux/lib/review-patterns/
  patterns.ts             # Single source of truth (5 patterns)

crux/validate/
  validate-github-conclusion-enum.ts   # A (blocking)
  validate-command-handler-errors.ts   # A (advisory)

crux/commands/
  agent-checklist.ts      # B (init scans diff, appends items)
  review-patterns.ts      # E (check, list)

.claude/commands/
  agent-review-pr.md      # E (Phase 9.5 attestation gate)
  agent-ship.md           # E (Step 7 attestation gate)
```

Adding a new pattern means **one file edit** in `patterns.ts`. All three consumers pick it up automatically.

## End-to-end dogfood — this session

Running `agent-checklist init` against my own diff detected 5 pattern hits (the test fixtures I wrote contain the bug shapes on purpose). The system forced me to attest each one via `--na --reason` before `gh review-patterns check` would exit 0. The `github-conclusion-enum` gate validator correctly ignored the test fixtures (test files are filtered) and reported no real violations in `crux/` or `apps/`.

## Test plan

- [x] 23 pattern-registry tests (registry invariants, parseDiff, per-pattern happy/failure, combined detection)
- [x] 10 `validate-github-conclusion-enum` tests (regex gap, suppression, division-not-regex, multi-violation, line numbers)
- [x] 11 `validate-command-handler-errors` tests (validation-first try, nested-try rejection, marker, export async, single-line sig)
- [x] 6 `pattern-checklist` tests (buildPatternItems, buildChecklist extras integration)
- [x] 7 `review-patterns check` tests (collectPatternAttestations, allAttested)
- [x] Full suite: 6167 tests passing (was 6003; +57 new + 107 from main)
- [x] `pnpm crux w validate gate --fix --no-cache` — all 52 checks passing (up from 50 — my two new validators + 0 regressions)
- [x] Dogfood: `agent-checklist init` against this branch detected all 5 patterns; `gh review-patterns check` fails closed until attested; attestation via `--na --reason` closes the gate

## Not included (deferred)

- **Option C** — typed enum wrappers / branded types. Filed as **QUA-361** (unconfirmed idea). Revisit if A/B/E residual miss rate remains high.
- **Option D** — narrow parallel reviewers. Defer until A/B/E data.

Fixes QUA-363


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "review patterns" workflow that detects review-* items, injects them into PR checklists, and provides check/list attestation commands. Init now shows a "Review patterns" section and a diff-read warning when applicable.

* **Process**
  * Introduced Phase 9.5: reviewers must attest pattern items before Phase 10 marker may be written; shipping is blocked until attestation passes.

* **Validation**
  * Added two validators to the gate (one blocking, one advisory).

* **Tests**
  * Expanded coverage for pattern detection, checklist integration, and validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->