### PR TITLE
fix(audits): bearer auth + first check for hallucination-risk-snapshots-rowcount

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -362,7 +362,9 @@ audits:
     description: "hallucination_risk_snapshots row count stays under 140,000 (2× the ~70K target). Growth beyond this threshold indicates the retention task or FK cascade has stopped working — historically this has been a prod-stability issue (QUA-352, QUA-302)."
     check_type: hybrid
     check_command: |
-      curl -sSf --max-time 10 https://wiki-server.k8s.quantifieduncertainty.org/api/hallucination-risk/stats \
+      curl -sSf --max-time 10 \
+        -H "Authorization: Bearer ${PROD_LONGTERMWIKI_SERVER_API_KEY:-$LONGTERMWIKI_SERVER_API_KEY}" \
+        https://wiki-server.k8s.quantifieduncertainty.org/api/hallucination-risk/stats \
         | jq -er '.totalSnapshots | numbers' \
         | awk '{
             n=$1;
@@ -373,7 +375,9 @@ audits:
     how_to_verify: |
       The check_command curls the wiki-server /api/hallucination-risk/stats endpoint
       (which returns totalSnapshots computed from pg_class.reltuples — fast, no seq scan)
-      and fails if the value exceeds 140,000 (2× the 70,000 target).
+      and fails if the value exceeds 140,000 (2× the 70,000 target). All /api/* routes
+      require bearer auth (see app.ts:189), so the check sources the key from
+      PROD_LONGTERMWIKI_SERVER_API_KEY (preferred for prod) or LONGTERMWIKI_SERVER_API_KEY.
       If this fails:
       1. Check groundskeeper run history for the snapshot-retention task (Groundskeeper Runs dashboard, E926)
       2. Verify LONGTERMWIKI_SERVER_API_KEY is set in the groundskeeper k8s deployment
@@ -382,9 +386,14 @@ audits:
     frequency: weekly
     added: "2026-04-12"
     added_by_pr: 4261
-    last_checked: null
-    last_result: null
-    history: []
+    last_checked: "2026-04-13"
+    last_result: pass
+    last_result_note: "103697 snapshots / 140000 threshold (74%); 761 unique pages. Cascade FK fix from PR #4261 deployed today."
+    history:
+      - date: "2026-04-13"
+        result: pass
+        checked_by: "manual"
+        notes: "103697 snapshots / 140000 threshold (74%); 761 unique pages. Cascade FK fix from PR #4261 deployed today."
   - id: audits-system-adoption
     category: process
     description: "This audits system itself is being used — items are checked on schedule, not abandoned"


### PR DESCRIPTION
## Summary

`/maintain` sweep on 2026-04-13 found the `hallucination-risk-snapshots-rowcount` audit was failing silently:

- `check_command` curls `/api/hallucination-risk/stats` without auth, but all `/api/*` routes require bearer auth (`apps/wiki-server/src/app.ts:189`). Result: 401, empty output, audit stuck as `never checked`.
- `last_checked: null` since the audit was added on 2026-04-12 (added by the QUA-352 PR cleanup), so this was the first attempt.

## Fix

- Source the bearer token from `PROD_LONGTERMWIKI_SERVER_API_KEY` (preferred) or `LONGTERMWIKI_SERVER_API_KEY` (fallback). Both keys live in `../.env.base`, which agent slots symlink and `crux sys audits run-auto` exposes via the inherited environment.
- Record today's check: **103,697 snapshots / 140,000 threshold (74%, 761 unique pages)**. Cascade FK fix from #4261 is in place, so retention should now keep the rowcount stable.
- Fix invalid YAML in the `history` block: `history: []` followed by sequence items would have failed parsing on the next write.
- `how_to_verify` now mentions the auth requirement so the next agent doesn't repeat the diagnosis.

## Verification

```
$ pnpm crux sys audits run-auto
hallucination-risk-snapshots-rowcount (hybrid)
  Output:
    reltuples=103697 threshold=140000
    PASS: within threshold
```

## Test plan

- [x] `pnpm crux sys audits list` shows the audit as `checked (pass)` instead of `never checked`
- [x] `pnpm crux sys audits run-auto` runs the new command and emits `PASS: within threshold`
- [x] `pnpm crux w validate gate --scope=content --fix` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by adding authentication to internal API monitoring requests.
  * Updated internal audit configurations and verification documentation for API endpoint monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->