### PR TITLE
QUA-149: Clean up orphaned source-check verdicts

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration tests for POST /api/sourcing/cleanup-orphans (QUA-149).
+ *
+ * The handler runs up to 6 SQL statements depending on dryRun:
+ *  - SELECT orphan verdicts
+ *  - SELECT orphan evidence
+ *  - SELECT orphan url-suggestions
+ *  - (non-dryRun only) DELETE orphan verdicts
+ *  - (non-dryRun only) DELETE orphan evidence
+ *  - (non-dryRun only) DELETE orphan url-suggestions
+ *
+ * The mock dispatcher distinguishes these by query substring and returns
+ * canned rows so we can assert on the counts the handler reports.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { type SqlDispatcher, mockDbModule, postJson } from "./test-utils";
+
+let capturedQueries: string[] = [];
+
+// Canned row sets per table. Tests can mutate these in beforeEach.
+let verdictRows: Array<{ record_type: string; record_id: string; field_name: string | null }> = [];
+let evidenceRows: Array<{ id: number; record_type: string }> = [];
+let suggestionRows: Array<{ id: number; record_type: string }> = [];
+
+const dispatch: SqlDispatcher = (query, _params) => {
+  capturedQueries.push(query);
+  // Route the query to the right canned result based on which table it reads/writes.
+  // DELETE queries also match on table name.
+  if (query.match(/from\s+source_check_verdicts/i) || query.match(/delete\s+from\s+source_check_verdicts/i)) {
+    return verdictRows;
+  }
+  if (query.match(/from\s+source_check_evidence/i) || query.match(/delete\s+from\s+source_check_evidence/i)) {
+    return evidenceRows;
+  }
+  if (query.match(/from\s+sourcing_url_suggestions/i) || query.match(/delete\s+from\s+sourcing_url_suggestions/i)) {
+    return suggestionRows;
+  }
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+describe("POST /api/sourcing/cleanup-orphans", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    verdictRows = [];
+    evidenceRows = [];
+    suggestionRows = [];
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns dryRun=true and zero counts when no orphans exist", async () => {
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      dryRun: boolean;
+      deleted: { verdicts: number; evidence: number; suggestions: number };
+      byType: Record<string, unknown>;
+    };
+    expect(body.dryRun).toBe(true);
+    expect(body.deleted).toEqual({ verdicts: 0, evidence: 0, suggestions: 0 });
+    expect(body.byType).toEqual({});
+  });
+
+  it("counts orphans across verdicts/evidence/suggestions in dry-run", async () => {
+    verdictRows = [
+      { record_type: "personnel", record_id: "p1", field_name: null },
+      { record_type: "personnel", record_id: "p2", field_name: "role" },
+      { record_type: "grant", record_id: "g1", field_name: null },
+    ];
+    evidenceRows = [
+      { id: 10, record_type: "personnel" },
+      { id: 11, record_type: "grant" },
+    ];
+    suggestionRows = [{ id: 20, record_type: "personnel" }];
+
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      dryRun: boolean;
+      deleted: { verdicts: number; evidence: number; suggestions: number };
+      byType: Record<string, { verdicts: number; evidence: number; suggestions: number }>;
+    };
+    expect(body.dryRun).toBe(true);
+    expect(body.deleted).toEqual({ verdicts: 3, evidence: 2, suggestions: 1 });
+    expect(body.byType.personnel).toEqual({ verdicts: 2, evidence: 1, suggestions: 1 });
+    expect(body.byType.grant).toEqual({ verdicts: 1, evidence: 1, suggestions: 0 });
+  });
+
+  it("does NOT run DELETE statements in dry-run mode", async () => {
+    verdictRows = [{ record_type: "personnel", record_id: "p1", field_name: null }];
+    await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: true });
+    const deletes = capturedQueries.filter((q) => /^\s*with[\s\S]+delete\s+from/i.test(q));
+    expect(deletes.length).toBe(0);
+  });
+
+  it("runs DELETE statements when dryRun=false", async () => {
+    verdictRows = [{ record_type: "personnel", record_id: "p1", field_name: null }];
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: false });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { dryRun: boolean };
+    expect(body.dryRun).toBe(false);
+
+    // Expect one DELETE per table in the transaction.
+    const deleteVerdicts = capturedQueries.filter((q) =>
+      /delete\s+from\s+source_check_verdicts/i.test(q),
+    );
+    const deleteEvidence = capturedQueries.filter((q) =>
+      /delete\s+from\s+source_check_evidence/i.test(q),
+    );
+    const deleteSuggestions = capturedQueries.filter((q) =>
+      /delete\s+from\s+sourcing_url_suggestions/i.test(q),
+    );
+    expect(deleteVerdicts.length).toBe(1);
+    expect(deleteEvidence.length).toBe(1);
+    expect(deleteSuggestions.length).toBe(1);
+  });
+
+  it("scopes SELECTs by record_type when recordType is provided", async () => {
+    await postJson(app, "/api/sourcing/cleanup-orphans", {
+      recordType: "personnel",
+    });
+    // Every SELECT that touches the three target tables should include the
+    // record_type filter. Check by substring since the mock stringifies
+    // parameters as positional placeholders.
+    const scopedSelects = capturedQueries.filter(
+      (q) =>
+        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
+        /record_type\s*=/i.test(q),
+    );
+    expect(scopedSelects.length).toBe(3);
+  });
+
+  it("only touches record_types present in LIVE_RECORDS_CTE", async () => {
+    // Assert the handler constrains the delete/select set via
+    // `record_type IN (SELECT DISTINCT record_type FROM live_records)`.
+    // That's the protection against deleting unknown-type rows.
+    await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    const queriesWithGuard = capturedQueries.filter(
+      (q) =>
+        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
+        /record_type\s+in\s*\(\s*select\s+distinct\s+record_type\s+from\s+live_records/i.test(q),
+    );
+    expect(queriesWithGuard.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses NOT EXISTS against live_records to find orphans", async () => {
+    await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    const notExistsQueries = capturedQueries.filter(
+      (q) =>
+        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
+        /not\s+exists\s*\(\s*select\s+1\s+from\s+live_records/i.test(q),
+    );
+    expect(notExistsQueries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("rejects invalid JSON body", async () => {
+    const res = await app.request("/api/sourcing/cleanup-orphans", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects oversized recordType", async () => {
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
+      recordType: "x".repeat(100),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts
@@ -1,60 +1,127 @@
 /**
  * Integration tests for POST /api/sourcing/cleanup-orphans (QUA-149).
  *
- * The handler runs up to 6 SQL statements depending on dryRun:
- *  - SELECT orphan verdicts
- *  - SELECT orphan evidence
- *  - SELECT orphan url-suggestions
- *  - (non-dryRun only) DELETE orphan verdicts
- *  - (non-dryRun only) DELETE orphan evidence
- *  - (non-dryRun only) DELETE orphan url-suggestions
+ * The handler runs up to 3 SQL statements per call:
+ *  - dry-run:   3× `SELECT record_type, COUNT(*) ... GROUP BY record_type`
+ *  - non-dry:   3× `DELETE ... RETURNING record_type` (inside a transaction)
  *
- * The mock dispatcher distinguishes these by query substring and returns
- * canned rows so we can assert on the counts the handler reports.
+ * The mock dispatcher distinguishes these by query shape and routes to the
+ * appropriate canned result set. Tests mutate the canned sets per-test to
+ * model different database states.
+ *
+ * The dispatcher also records the `(query, params)` pairs it sees so tests
+ * can assert on actual parameter values instead of matching substrings —
+ * the previous version of these tests matched `/record_type\s*=/` which
+ * hit the unrelated JOIN clauses and produced false-positive assertions.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { type SqlDispatcher, mockDbModule, postJson } from "./test-utils";
 
-let capturedQueries: string[] = [];
+interface CapturedCall {
+  query: string;
+  params: unknown[];
+  insideTransaction: boolean;
+}
 
-// Canned row sets per table. Tests can mutate these in beforeEach.
-let verdictRows: Array<{ record_type: string; record_id: string; field_name: string | null }> = [];
-let evidenceRows: Array<{ id: number; record_type: string }> = [];
-let suggestionRows: Array<{ id: number; record_type: string }> = [];
+let capturedCalls: CapturedCall[] = [];
+let beginCallCount = 0;
+let insideTransaction = false;
 
-const dispatch: SqlDispatcher = (query, _params) => {
-  capturedQueries.push(query);
-  // Route the query to the right canned result based on which table it reads/writes.
-  // DELETE queries also match on table name.
-  if (query.match(/from\s+source_check_verdicts/i) || query.match(/delete\s+from\s+source_check_verdicts/i)) {
-    return verdictRows;
+// Canned result sets per table. Tests mutate these in beforeEach.
+// - `groupRows*` feed the dry-run GROUP BY SELECTs.
+// - `deletedRows*` feed the non-dryRun DELETE ... RETURNING.
+// When non-empty, deleted* wins if the query is a DELETE.
+let groupRowsVerdicts: Array<{ record_type: string; cnt: number }> = [];
+let groupRowsEvidence: Array<{ record_type: string; cnt: number }> = [];
+let groupRowsSuggestions: Array<{ record_type: string; cnt: number }> = [];
+let deletedRowsVerdicts: Array<{ record_type: string }> = [];
+let deletedRowsEvidence: Array<{ record_type: string }> = [];
+let deletedRowsSuggestions: Array<{ record_type: string }> = [];
+
+function classifyQuery(query: string): {
+  table: "verdicts" | "evidence" | "suggestions" | "other";
+  kind: "delete" | "select" | "other";
+} {
+  const isDelete = /^\s*with[\s\S]+delete\s+from/i.test(query);
+  const isSelect = !isDelete && /select/i.test(query);
+  let table: "verdicts" | "evidence" | "suggestions" | "other" = "other";
+  if (/source_check_verdicts/.test(query)) table = "verdicts";
+  else if (/source_check_evidence/.test(query)) table = "evidence";
+  else if (/sourcing_url_suggestions/.test(query)) table = "suggestions";
+  return {
+    table,
+    kind: isDelete ? "delete" : isSelect ? "select" : "other",
+  };
+}
+
+const dispatch: SqlDispatcher = (query, params) => {
+  capturedCalls.push({ query, params, insideTransaction });
+  const { table, kind } = classifyQuery(query);
+  if (kind === "delete") {
+    if (table === "verdicts") return deletedRowsVerdicts;
+    if (table === "evidence") return deletedRowsEvidence;
+    if (table === "suggestions") return deletedRowsSuggestions;
   }
-  if (query.match(/from\s+source_check_evidence/i) || query.match(/delete\s+from\s+source_check_evidence/i)) {
-    return evidenceRows;
-  }
-  if (query.match(/from\s+sourcing_url_suggestions/i) || query.match(/delete\s+from\s+sourcing_url_suggestions/i)) {
-    return suggestionRows;
+  if (kind === "select") {
+    if (table === "verdicts") return groupRowsVerdicts;
+    if (table === "evidence") return groupRowsEvidence;
+    if (table === "suggestions") return groupRowsSuggestions;
   }
   return [];
 };
 
-vi.mock("../db.js", () => mockDbModule(dispatch));
+vi.mock("../db.js", () => {
+  // Patch mockSql.begin so tests can verify the handler wraps all three
+  // DELETEs in a single transaction. Each captured call records whether
+  // it happened inside a begin()/end() window.
+  return mockDbModule(dispatch).then((mod) => {
+    const mockSql = mod.getDb();
+    const origBegin = mockSql.begin.bind(mockSql);
+    mockSql.begin = async (fn: (tx: typeof mockSql) => Promise<unknown>) => {
+      beginCallCount += 1;
+      insideTransaction = true;
+      try {
+        return await origBegin(fn);
+      } finally {
+        insideTransaction = false;
+      }
+    };
+    return mod;
+  });
+});
 
 const { createApp } = await import("../app.js");
+
+function queriesForTable(
+  table: "verdicts" | "evidence" | "suggestions",
+  kind: "delete" | "select",
+): CapturedCall[] {
+  return capturedCalls.filter((c) => {
+    const classified = classifyQuery(c.query);
+    return classified.table === table && classified.kind === kind;
+  });
+}
 
 describe("POST /api/sourcing/cleanup-orphans", () => {
   let app: Hono;
 
   beforeEach(() => {
-    capturedQueries = [];
-    verdictRows = [];
-    evidenceRows = [];
-    suggestionRows = [];
+    capturedCalls = [];
+    beginCallCount = 0;
+    insideTransaction = false;
+    groupRowsVerdicts = [];
+    groupRowsEvidence = [];
+    groupRowsSuggestions = [];
+    deletedRowsVerdicts = [];
+    deletedRowsEvidence = [];
+    deletedRowsSuggestions = [];
     delete process.env.LONGTERMWIKI_SERVER_API_KEY;
     app = createApp();
   });
+
+  // ── dry-run path ──
 
   it("returns dryRun=true and zero counts when no orphans exist", async () => {
     const res = await postJson(app, "/api/sourcing/cleanup-orphans", {});
@@ -69,94 +136,212 @@ describe("POST /api/sourcing/cleanup-orphans", () => {
     expect(body.byType).toEqual({});
   });
 
-  it("counts orphans across verdicts/evidence/suggestions in dry-run", async () => {
-    verdictRows = [
-      { record_type: "personnel", record_id: "p1", field_name: null },
-      { record_type: "personnel", record_id: "p2", field_name: "role" },
-      { record_type: "grant", record_id: "g1", field_name: null },
+  it("aggregates dry-run GROUP BY counts into byType and totals", async () => {
+    groupRowsVerdicts = [
+      { record_type: "personnel", cnt: 2 },
+      { record_type: "grant", cnt: 1 },
     ];
-    evidenceRows = [
-      { id: 10, record_type: "personnel" },
-      { id: 11, record_type: "grant" },
+    groupRowsEvidence = [
+      { record_type: "personnel", cnt: 1 },
+      { record_type: "grant", cnt: 1 },
     ];
-    suggestionRows = [{ id: 20, record_type: "personnel" }];
+    groupRowsSuggestions = [{ record_type: "personnel", cnt: 1 }];
 
     const res = await postJson(app, "/api/sourcing/cleanup-orphans", {});
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       dryRun: boolean;
       deleted: { verdicts: number; evidence: number; suggestions: number };
-      byType: Record<string, { verdicts: number; evidence: number; suggestions: number }>;
+      byType: Record<
+        string,
+        { verdicts: number; evidence: number; suggestions: number }
+      >;
     };
     expect(body.dryRun).toBe(true);
     expect(body.deleted).toEqual({ verdicts: 3, evidence: 2, suggestions: 1 });
-    expect(body.byType.personnel).toEqual({ verdicts: 2, evidence: 1, suggestions: 1 });
-    expect(body.byType.grant).toEqual({ verdicts: 1, evidence: 1, suggestions: 0 });
+    expect(body.byType.personnel).toEqual({
+      verdicts: 2,
+      evidence: 1,
+      suggestions: 1,
+    });
+    expect(body.byType.grant).toEqual({
+      verdicts: 1,
+      evidence: 1,
+      suggestions: 0,
+    });
+  });
+
+  it("dry-run uses GROUP BY record_type — not a raw row scan", async () => {
+    await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    // All three dry-run SELECTs must include `GROUP BY .record_type`.
+    // This is the memory protection — without GROUP BY a million-orphan
+    // result set would be materialized in Node.
+    const groupByQueries = capturedCalls.filter((c) =>
+      /group\s+by\s+\w+\.record_type/i.test(c.query),
+    );
+    expect(groupByQueries.length).toBe(3);
   });
 
   it("does NOT run DELETE statements in dry-run mode", async () => {
-    verdictRows = [{ record_type: "personnel", record_id: "p1", field_name: null }];
     await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: true });
-    const deletes = capturedQueries.filter((q) => /^\s*with[\s\S]+delete\s+from/i.test(q));
+    const deletes = capturedCalls.filter(
+      (c) => classifyQuery(c.query).kind === "delete",
+    );
     expect(deletes.length).toBe(0);
   });
 
-  it("runs DELETE statements when dryRun=false", async () => {
-    verdictRows = [{ record_type: "personnel", record_id: "p1", field_name: null }];
-    const res = await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: false });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { dryRun: boolean };
-    expect(body.dryRun).toBe(false);
+  // ── non-dry-run path ──
 
-    // Expect one DELETE per table in the transaction.
-    const deleteVerdicts = capturedQueries.filter((q) =>
-      /delete\s+from\s+source_check_verdicts/i.test(q),
-    );
-    const deleteEvidence = capturedQueries.filter((q) =>
-      /delete\s+from\s+source_check_evidence/i.test(q),
-    );
-    const deleteSuggestions = capturedQueries.filter((q) =>
-      /delete\s+from\s+sourcing_url_suggestions/i.test(q),
-    );
-    expect(deleteVerdicts.length).toBe(1);
-    expect(deleteEvidence.length).toBe(1);
-    expect(deleteSuggestions.length).toBe(1);
+  it("runs DELETE RETURNING statements when dryRun=false", async () => {
+    deletedRowsVerdicts = [{ record_type: "personnel" }];
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
+      dryRun: false,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      dryRun: boolean;
+      deleted: { verdicts: number; evidence: number; suggestions: number };
+    };
+    expect(body.dryRun).toBe(false);
+    expect(body.deleted.verdicts).toBe(1);
+
+    expect(queriesForTable("verdicts", "delete").length).toBe(1);
+    expect(queriesForTable("evidence", "delete").length).toBe(1);
+    expect(queriesForTable("suggestions", "delete").length).toBe(1);
   });
 
-  it("scopes SELECTs by record_type when recordType is provided", async () => {
+  it("every DELETE statement includes `RETURNING record_type`", async () => {
+    await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: false });
+    const deletes = capturedCalls.filter(
+      (c) => classifyQuery(c.query).kind === "delete",
+    );
+    expect(deletes.length).toBe(3);
+    for (const d of deletes) {
+      expect(
+        /returning\s+\w+\.record_type/i.test(d.query),
+        `DELETE missing RETURNING record_type:\n${d.query}`,
+      ).toBe(true);
+    }
+  });
+
+  it("aggregates non-dry-run byType from DELETE RETURNING rows", async () => {
+    deletedRowsVerdicts = [
+      { record_type: "personnel" },
+      { record_type: "personnel" },
+      { record_type: "grant" },
+    ];
+    deletedRowsEvidence = [{ record_type: "grant" }];
+    deletedRowsSuggestions = [{ record_type: "personnel" }];
+
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
+      dryRun: false,
+    });
+    const body = (await res.json()) as {
+      dryRun: boolean;
+      deleted: { verdicts: number; evidence: number; suggestions: number };
+      byType: Record<
+        string,
+        { verdicts: number; evidence: number; suggestions: number }
+      >;
+    };
+    expect(body.dryRun).toBe(false);
+    expect(body.deleted).toEqual({ verdicts: 3, evidence: 1, suggestions: 1 });
+    expect(body.byType.personnel).toEqual({
+      verdicts: 2,
+      evidence: 0,
+      suggestions: 1,
+    });
+    expect(body.byType.grant).toEqual({
+      verdicts: 1,
+      evidence: 1,
+      suggestions: 0,
+    });
+  });
+
+  it("wraps all three DELETEs in a single transaction", async () => {
+    // Instrumented begin() spy flips `insideTransaction` for the duration
+    // of the begin()/end() window. Every DELETE must record insideTransaction=true.
+    // If a future refactor pulls a DELETE out of the transaction, that
+    // DELETE will record insideTransaction=false and this test will fail.
+    await postJson(app, "/api/sourcing/cleanup-orphans", { dryRun: false });
+    expect(beginCallCount).toBe(1);
+    const deletes = capturedCalls.filter(
+      (c) => classifyQuery(c.query).kind === "delete",
+    );
+    expect(deletes.length).toBe(3);
+    for (const d of deletes) {
+      expect(
+        d.insideTransaction,
+        `DELETE ran outside transaction:\n${d.query}`,
+      ).toBe(true);
+    }
+  });
+
+  // ── recordType scoping ──
+
+  it("passes recordType through as a bound SQL parameter (not interpolated)", async () => {
     await postJson(app, "/api/sourcing/cleanup-orphans", {
       recordType: "personnel",
     });
-    // Every SELECT that touches the three target tables should include the
-    // record_type filter. Check by substring since the mock stringifies
-    // parameters as positional placeholders.
-    const scopedSelects = capturedQueries.filter(
-      (q) =>
-        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
-        /record_type\s*=/i.test(q),
-    );
-    expect(scopedSelects.length).toBe(3);
+    // `personnel` must appear in the bound params array for each of the
+    // three dry-run SELECTs — not in the query string. Drizzle emits
+    // positional placeholders for interpolated values, so finding the
+    // literal in params (not in query) is the correct assertion.
+    const selectsPerTable = {
+      verdicts: queriesForTable("verdicts", "select"),
+      evidence: queriesForTable("evidence", "select"),
+      suggestions: queriesForTable("suggestions", "select"),
+    };
+    for (const [, calls] of Object.entries(selectsPerTable)) {
+      expect(calls.length).toBe(1);
+      expect(calls[0].params).toContain("personnel");
+    }
   });
 
-  it("only touches record_types present in LIVE_RECORDS_CTE", async () => {
-    // Assert the handler constrains the delete/select set via
-    // `record_type IN (SELECT DISTINCT record_type FROM live_records)`.
-    // That's the protection against deleting unknown-type rows.
+  it("omits the recordType filter when recordType is not provided", async () => {
     await postJson(app, "/api/sourcing/cleanup-orphans", {});
-    const queriesWithGuard = capturedQueries.filter(
-      (q) =>
-        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
-        /record_type\s+in\s*\(\s*select\s+distinct\s+record_type\s+from\s+live_records/i.test(q),
+    // Without recordType, the bound parameter list for each table's SELECT
+    // should NOT contain a spurious type string.
+    const allSelects = capturedCalls.filter(
+      (c) => classifyQuery(c.query).kind === "select",
+    );
+    for (const call of allSelects) {
+      expect(call.params).not.toContain("personnel");
+    }
+  });
+
+  it("rejects empty-string recordType (would silently scan all types)", async () => {
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
+      recordType: "",
+    });
+    expect(res.status).toBe(400);
+    expect(capturedCalls.length).toBe(0);
+  });
+
+  it("rejects oversized recordType", async () => {
+    const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
+      recordType: "x".repeat(100),
+    });
+    expect(res.status).toBe(400);
+    expect(capturedCalls.length).toBe(0);
+  });
+
+  // ── safety rails ──
+
+  it("only touches record_types present in LIVE_RECORDS_CTE", async () => {
+    await postJson(app, "/api/sourcing/cleanup-orphans", {});
+    const queriesWithGuard = capturedCalls.filter((c) =>
+      /record_type\s+in\s*\(\s*select\s+distinct\s+record_type\s+from\s+live_records/i.test(
+        c.query,
+      ),
     );
     expect(queriesWithGuard.length).toBeGreaterThanOrEqual(3);
   });
 
   it("uses NOT EXISTS against live_records to find orphans", async () => {
     await postJson(app, "/api/sourcing/cleanup-orphans", {});
-    const notExistsQueries = capturedQueries.filter(
-      (q) =>
-        /from\s+(source_check_verdicts|source_check_evidence|sourcing_url_suggestions)/i.test(q) &&
-        /not\s+exists\s*\(\s*select\s+1\s+from\s+live_records/i.test(q),
+    const notExistsQueries = capturedCalls.filter((c) =>
+      /not\s+exists\s*\(\s*select\s+1\s+from\s+live_records/i.test(c.query),
     );
     expect(notExistsQueries.length).toBeGreaterThanOrEqual(3);
   });
@@ -170,9 +355,9 @@ describe("POST /api/sourcing/cleanup-orphans", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rejects oversized recordType", async () => {
+  it("rejects non-boolean dryRun", async () => {
     const res = await postJson(app, "/api/sourcing/cleanup-orphans", {
-      recordType: "x".repeat(100),
+      dryRun: "maybe",
     });
     expect(res.status).toBe(400);
   });

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -228,6 +228,24 @@ const ByPageQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
+/**
+ * QUA-149: cleanup-orphans request body.
+ *
+ * `dryRun` (default true) reports how many rows *would* be deleted without
+ * touching the database. Callers must pass `dryRun: false` explicitly to
+ * perform the actual delete — this avoids accidental destructive calls.
+ *
+ * `recordType` optionally scopes cleanup to a single type (e.g., "personnel").
+ * If omitted, all known record types in LIVE_RECORDS_CTE are considered.
+ * Unknown record types (not in the CTE) are always left alone, even when
+ * `dryRun: false`, because we have no live-records source for them and
+ * can't tell whether they're orphaned or not.
+ */
+const CleanupOrphansBody = z.object({
+  dryRun: z.boolean().default(true),
+  recordType: z.string().max(50).optional(),
+});
+
 const VALID_ERROR_TYPES = [
   "contradicted",
   "outdated",
@@ -2099,6 +2117,153 @@ const sourcingApp = new Hono()
     }
 
     return c.json({ matrix, totals, exemptTypes: [...SOURCING_EXEMPT_TYPES] });
+  })
+
+  // ---- POST /cleanup-orphans (QUA-149) ----
+  //
+  // Delete verdict / evidence / url-suggestion rows whose (record_type, record_id)
+  // no longer has a live row in its source table. Dashboard stats filter orphans
+  // out at query time via LIVE_RECORDS_CTE, but the underlying rows accumulate
+  // (e.g., 1002 personnel verdicts for 724 records) and skew any raw COUNT(*).
+  //
+  // Safety rails:
+  //   - `dryRun` defaults to true. Pass `dryRun: false` explicitly to delete.
+  //   - Only record_types listed in LIVE_RECORDS_CTE are touched. Rows with an
+  //     unknown record_type are left alone.
+  //   - All deletes run inside a single transaction.
+  .post("/cleanup-orphans", async (c) => {
+    const raw = await parseJsonBody(c);
+    if (!raw) return invalidJsonError(c);
+
+    const parsed = CleanupOrphansBody.safeParse(raw);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const { dryRun, recordType } = parsed.data;
+    const db = getDrizzleDb();
+
+    const typeFilter = recordType
+      ? sql`AND v.record_type = ${recordType}`
+      : sql``;
+
+    // Rows targeted for deletion: known record_type, but the (type, id) pair
+    // is missing from live_records. Returned verbatim so dryRun/non-dryRun
+    // share the same counting logic.
+    const verdictOrphansSql = sql`
+      WITH ${LIVE_RECORDS_CTE}
+      SELECT v.record_type, v.record_id, v.field_name
+      FROM source_check_verdicts v
+      WHERE v.record_type IN (SELECT DISTINCT record_type FROM live_records)
+        ${typeFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM live_records lr
+          WHERE lr.record_type = v.record_type AND lr.record_id = v.record_id
+        )
+    `;
+    const evidenceOrphansSql = sql`
+      WITH ${LIVE_RECORDS_CTE}
+      SELECT e.id, e.record_type
+      FROM source_check_evidence e
+      WHERE e.record_type IN (SELECT DISTINCT record_type FROM live_records)
+        ${recordType ? sql`AND e.record_type = ${recordType}` : sql``}
+        AND NOT EXISTS (
+          SELECT 1 FROM live_records lr
+          WHERE lr.record_type = e.record_type AND lr.record_id = e.record_id
+        )
+    `;
+    const suggestionOrphansSql = sql`
+      WITH ${LIVE_RECORDS_CTE}
+      SELECT s.id, s.record_type
+      FROM sourcing_url_suggestions s
+      WHERE s.record_type IN (SELECT DISTINCT record_type FROM live_records)
+        ${recordType ? sql`AND s.record_type = ${recordType}` : sql``}
+        AND NOT EXISTS (
+          SELECT 1 FROM live_records lr
+          WHERE lr.record_type = s.record_type AND lr.record_id = s.record_id
+        )
+    `;
+
+    // Count-then-delete pattern. The COUNT runs even in non-dryRun mode so
+    // we can build byType without a second scan. Dry-run short-circuits
+    // before the DELETE statements.
+    const [verdictRows, evidenceRows, suggestionRows] = await Promise.all([
+      db.execute<{
+        record_type: string;
+        record_id: string;
+        field_name: string | null;
+      }>(verdictOrphansSql),
+      db.execute<{ id: number | string; record_type: string }>(evidenceOrphansSql),
+      db.execute<{ id: number | string; record_type: string }>(suggestionOrphansSql),
+    ]);
+
+    const byType: Record<
+      string,
+      { verdicts: number; evidence: number; suggestions: number }
+    > = {};
+    const bump = (type: string, key: "verdicts" | "evidence" | "suggestions") => {
+      const slot = byType[type] ?? { verdicts: 0, evidence: 0, suggestions: 0 };
+      slot[key] += 1;
+      byType[type] = slot;
+    };
+    for (const r of verdictRows) bump(r.record_type, "verdicts");
+    for (const r of evidenceRows) bump(r.record_type, "evidence");
+    for (const r of suggestionRows) bump(r.record_type, "suggestions");
+
+    const counts = {
+      verdicts: verdictRows.length,
+      evidence: evidenceRows.length,
+      suggestions: suggestionRows.length,
+    };
+
+    if (dryRun) {
+      return c.json({
+        dryRun: true,
+        deleted: counts,
+        byType,
+      });
+    }
+
+    // Non-dry-run: run the deletes in a single transaction. We re-run the
+    // same NOT EXISTS condition inside DELETE so the operation is atomic —
+    // no reliance on the IDs we just fetched, which avoids TOCTOU issues
+    // if the table changes between the SELECT and DELETE.
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        DELETE FROM source_check_verdicts v
+        WHERE v.record_type IN (SELECT DISTINCT record_type FROM live_records)
+          ${typeFilter}
+          AND NOT EXISTS (
+            SELECT 1 FROM live_records lr
+            WHERE lr.record_type = v.record_type AND lr.record_id = v.record_id
+          )
+      `);
+      await tx.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        DELETE FROM source_check_evidence e
+        WHERE e.record_type IN (SELECT DISTINCT record_type FROM live_records)
+          ${recordType ? sql`AND e.record_type = ${recordType}` : sql``}
+          AND NOT EXISTS (
+            SELECT 1 FROM live_records lr
+            WHERE lr.record_type = e.record_type AND lr.record_id = e.record_id
+          )
+      `);
+      await tx.execute(sql`
+        WITH ${LIVE_RECORDS_CTE}
+        DELETE FROM sourcing_url_suggestions s
+        WHERE s.record_type IN (SELECT DISTINCT record_type FROM live_records)
+          ${recordType ? sql`AND s.record_type = ${recordType}` : sql``}
+          AND NOT EXISTS (
+            SELECT 1 FROM live_records lr
+            WHERE lr.record_type = s.record_type AND lr.record_id = s.record_id
+          )
+      `);
+    });
+
+    return c.json({
+      dryRun: false,
+      deleted: counts,
+      byType,
+    });
   });
 
 // ---- Exports ----

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -243,7 +243,9 @@ const ByPageQuery = z.object({
  */
 const CleanupOrphansBody = z.object({
   dryRun: z.boolean().default(true),
-  recordType: z.string().max(50).optional(),
+  // Empty string would silently match no rows; reject it to force callers
+  // to omit the field when they want to scan every type.
+  recordType: z.string().min(1).max(50).optional(),
 });
 
 const VALID_ERROR_TYPES = [
@@ -2141,129 +2143,179 @@ const sourcingApp = new Hono()
     const { dryRun, recordType } = parsed.data;
     const db = getDrizzleDb();
 
-    const typeFilter = recordType
+    // Per-table type-filter clauses. Each DELETE/SELECT uses a different
+    // table alias, so the filter has to be parameterized by alias.
+    const verdictTypeFilter = recordType
       ? sql`AND v.record_type = ${recordType}`
       : sql``;
+    const evidenceTypeFilter = recordType
+      ? sql`AND e.record_type = ${recordType}`
+      : sql``;
+    const suggestionTypeFilter = recordType
+      ? sql`AND s.record_type = ${recordType}`
+      : sql``;
 
-    // Rows targeted for deletion: known record_type, but the (type, id) pair
-    // is missing from live_records. Returned verbatim so dryRun/non-dryRun
-    // share the same counting logic.
-    const verdictOrphansSql = sql`
-      WITH ${LIVE_RECORDS_CTE}
-      SELECT v.record_type, v.record_id, v.field_name
-      FROM source_check_verdicts v
-      WHERE v.record_type IN (SELECT DISTINCT record_type FROM live_records)
-        ${typeFilter}
-        AND NOT EXISTS (
-          SELECT 1 FROM live_records lr
-          WHERE lr.record_type = v.record_type AND lr.record_id = v.record_id
-        )
-    `;
-    const evidenceOrphansSql = sql`
-      WITH ${LIVE_RECORDS_CTE}
-      SELECT e.id, e.record_type
-      FROM source_check_evidence e
-      WHERE e.record_type IN (SELECT DISTINCT record_type FROM live_records)
-        ${recordType ? sql`AND e.record_type = ${recordType}` : sql``}
-        AND NOT EXISTS (
-          SELECT 1 FROM live_records lr
-          WHERE lr.record_type = e.record_type AND lr.record_id = e.record_id
-        )
-    `;
-    const suggestionOrphansSql = sql`
-      WITH ${LIVE_RECORDS_CTE}
-      SELECT s.id, s.record_type
-      FROM sourcing_url_suggestions s
-      WHERE s.record_type IN (SELECT DISTINCT record_type FROM live_records)
-        ${recordType ? sql`AND s.record_type = ${recordType}` : sql``}
-        AND NOT EXISTS (
-          SELECT 1 FROM live_records lr
-          WHERE lr.record_type = s.record_type AND lr.record_id = s.record_id
-        )
-    `;
-
-    // Count-then-delete pattern. The COUNT runs even in non-dryRun mode so
-    // we can build byType without a second scan. Dry-run short-circuits
-    // before the DELETE statements.
-    const [verdictRows, evidenceRows, suggestionRows] = await Promise.all([
-      db.execute<{
-        record_type: string;
-        record_id: string;
-        field_name: string | null;
-      }>(verdictOrphansSql),
-      db.execute<{ id: number | string; record_type: string }>(evidenceOrphansSql),
-      db.execute<{ id: number | string; record_type: string }>(suggestionOrphansSql),
-    ]);
-
-    const byType: Record<
-      string,
-      { verdicts: number; evidence: number; suggestions: number }
-    > = {};
-    const bump = (type: string, key: "verdicts" | "evidence" | "suggestions") => {
-      const slot = byType[type] ?? { verdicts: 0, evidence: 0, suggestions: 0 };
-      slot[key] += 1;
-      byType[type] = slot;
-    };
-    for (const r of verdictRows) bump(r.record_type, "verdicts");
-    for (const r of evidenceRows) bump(r.record_type, "evidence");
-    for (const r of suggestionRows) bump(r.record_type, "suggestions");
-
-    const counts = {
-      verdicts: verdictRows.length,
-      evidence: evidenceRows.length,
-      suggestions: suggestionRows.length,
+    // Aggregate returns { byType, counts } where counts.verdicts is the
+    // sum across all types. For DELETE RETURNING we get one row per
+    // deleted record; for the dry-run GROUP BY we get one row per type
+    // with a pre-computed `cnt`.
+    type GroupRow = { record_type: string; cnt: number };
+    const aggregate = (
+      verdictGroups: readonly GroupRow[],
+      evidenceGroups: readonly GroupRow[],
+      suggestionGroups: readonly GroupRow[],
+    ) => {
+      const byType: Record<
+        string,
+        { verdicts: number; evidence: number; suggestions: number }
+      > = {};
+      const bump = (
+        type: string,
+        key: "verdicts" | "evidence" | "suggestions",
+        delta: number,
+      ) => {
+        const slot =
+          byType[type] ?? { verdicts: 0, evidence: 0, suggestions: 0 };
+        slot[key] += delta;
+        byType[type] = slot;
+      };
+      let verdicts = 0;
+      let evidence = 0;
+      let suggestions = 0;
+      for (const r of verdictGroups) {
+        const n = Number(r.cnt);
+        bump(r.record_type, "verdicts", n);
+        verdicts += n;
+      }
+      for (const r of evidenceGroups) {
+        const n = Number(r.cnt);
+        bump(r.record_type, "evidence", n);
+        evidence += n;
+      }
+      for (const r of suggestionGroups) {
+        const n = Number(r.cnt);
+        bump(r.record_type, "suggestions", n);
+        suggestions += n;
+      }
+      return { byType, counts: { verdicts, evidence, suggestions } };
     };
 
     if (dryRun) {
-      return c.json({
-        dryRun: true,
-        deleted: counts,
-        byType,
-      });
+      // Dry-run: GROUP BY returns O(types) rows regardless of orphan
+      // count, so a million-row orphan set still fits in memory. No
+      // transaction because nothing is mutated; the reported counts
+      // may legitimately drift by the time a later --apply runs.
+      const [verdictGroups, evidenceGroups, suggestionGroups] =
+        await Promise.all([
+          db.execute<GroupRow>(sql`
+            WITH ${LIVE_RECORDS_CTE}
+            SELECT v.record_type, count(*)::int AS cnt
+            FROM source_check_verdicts v
+            WHERE v.record_type IN (SELECT DISTINCT record_type FROM live_records)
+              ${verdictTypeFilter}
+              AND NOT EXISTS (
+                SELECT 1 FROM live_records lr
+                WHERE lr.record_type = v.record_type AND lr.record_id = v.record_id
+              )
+            GROUP BY v.record_type
+          `),
+          db.execute<GroupRow>(sql`
+            WITH ${LIVE_RECORDS_CTE}
+            SELECT e.record_type, count(*)::int AS cnt
+            FROM source_check_evidence e
+            WHERE e.record_type IN (SELECT DISTINCT record_type FROM live_records)
+              ${evidenceTypeFilter}
+              AND NOT EXISTS (
+                SELECT 1 FROM live_records lr
+                WHERE lr.record_type = e.record_type AND lr.record_id = e.record_id
+              )
+            GROUP BY e.record_type
+          `),
+          db.execute<GroupRow>(sql`
+            WITH ${LIVE_RECORDS_CTE}
+            SELECT s.record_type, count(*)::int AS cnt
+            FROM sourcing_url_suggestions s
+            WHERE s.record_type IN (SELECT DISTINCT record_type FROM live_records)
+              ${suggestionTypeFilter}
+              AND NOT EXISTS (
+                SELECT 1 FROM live_records lr
+                WHERE lr.record_type = s.record_type AND lr.record_id = s.record_id
+              )
+            GROUP BY s.record_type
+          `),
+        ]);
+
+      const { byType, counts } = aggregate(
+        verdictGroups,
+        evidenceGroups,
+        suggestionGroups,
+      );
+      return c.json({ dryRun: true, deleted: counts, byType });
     }
 
-    // Non-dry-run: run the deletes in a single transaction. We re-run the
-    // same NOT EXISTS condition inside DELETE so the operation is atomic —
-    // no reliance on the IDs we just fetched, which avoids TOCTOU issues
-    // if the table changes between the SELECT and DELETE.
-    await db.transaction(async (tx) => {
-      await tx.execute(sql`
+    // Non-dry-run: `DELETE … RETURNING record_type` inside a transaction
+    // gives the exact set of rows removed, so the reported byType/counts
+    // always reflect the actual DB state change — no TOCTOU gap between
+    // a pre-count SELECT and the DELETE. We then GROUP the returned rows
+    // in-process (O(rows) Node memory, but the row count is bounded by
+    // what we just removed — on the order of hundreds in practice).
+    const deleted = await db.transaction(async (tx) => {
+      const v = await tx.execute<{ record_type: string }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         DELETE FROM source_check_verdicts v
         WHERE v.record_type IN (SELECT DISTINCT record_type FROM live_records)
-          ${typeFilter}
+          ${verdictTypeFilter}
           AND NOT EXISTS (
             SELECT 1 FROM live_records lr
             WHERE lr.record_type = v.record_type AND lr.record_id = v.record_id
           )
+        RETURNING v.record_type
       `);
-      await tx.execute(sql`
+      const e = await tx.execute<{ record_type: string }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         DELETE FROM source_check_evidence e
         WHERE e.record_type IN (SELECT DISTINCT record_type FROM live_records)
-          ${recordType ? sql`AND e.record_type = ${recordType}` : sql``}
+          ${evidenceTypeFilter}
           AND NOT EXISTS (
             SELECT 1 FROM live_records lr
             WHERE lr.record_type = e.record_type AND lr.record_id = e.record_id
           )
+        RETURNING e.record_type
       `);
-      await tx.execute(sql`
+      const s = await tx.execute<{ record_type: string }>(sql`
         WITH ${LIVE_RECORDS_CTE}
         DELETE FROM sourcing_url_suggestions s
         WHERE s.record_type IN (SELECT DISTINCT record_type FROM live_records)
-          ${recordType ? sql`AND s.record_type = ${recordType}` : sql``}
+          ${suggestionTypeFilter}
           AND NOT EXISTS (
             SELECT 1 FROM live_records lr
             WHERE lr.record_type = s.record_type AND lr.record_id = s.record_id
           )
+        RETURNING s.record_type
       `);
+      return { v, e, s };
     });
 
-    return c.json({
-      dryRun: false,
-      deleted: counts,
-      byType,
-    });
+    // Convert the raw RETURNING rows into GroupRow shape (one row per
+    // record_type with a cnt) so the aggregate helper can share code
+    // with the dry-run path.
+    const toGroups = (rows: readonly { record_type: string }[]): GroupRow[] => {
+      const counts = new Map<string, number>();
+      for (const r of rows) {
+        counts.set(r.record_type, (counts.get(r.record_type) ?? 0) + 1);
+      }
+      return Array.from(counts.entries()).map(([record_type, cnt]) => ({
+        record_type,
+        cnt,
+      }));
+    };
+
+    const { byType, counts } = aggregate(
+      toGroups(deleted.v),
+      toGroups(deleted.e),
+      toGroups(deleted.s),
+    );
+    return c.json({ dryRun: false, deleted: counts, byType });
   });
 
 // ---- Exports ----

--- a/crux/commands/sourcing-cleanup-orphans.ts
+++ b/crux/commands/sourcing-cleanup-orphans.ts
@@ -1,0 +1,134 @@
+/**
+ * Source-Check Orphan Cleanup (QUA-149)
+ *
+ * Deletes source-check verdict / evidence / url-suggestion rows whose record
+ * no longer exists in its source table. Dashboard queries already filter these
+ * out at read time, but the raw COUNT(*)s (e.g., 1002 personnel verdicts for
+ * 724 records) are what made the coverage matrix show nonsense like 127%.
+ *
+ * Usage:
+ *   crux sourcing-cleanup-orphans                  Dry-run, all known types
+ *   crux sourcing-cleanup-orphans --apply          Actually delete
+ *   crux sourcing-cleanup-orphans --type=personnel Scope to one record type
+ *   crux sourcing-cleanup-orphans --ci             Machine-readable JSON output
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { cleanupOrphanVerdicts, type CleanupOrphansResult } from '../lib/wiki-server/sourcing-client.ts';
+
+interface CleanupOptions extends BaseOptions {
+  apply?: boolean;
+  type?: string;
+  ci?: boolean;
+}
+
+function formatOutput(result: CleanupOrphansResult, _applied: boolean): string {
+  const lines: string[] = [];
+  const { dryRun, deleted, byType } = result;
+  const header = dryRun
+    ? '\x1b[1mSource-Check Orphan Cleanup (dry-run)\x1b[0m'
+    : '\x1b[1;32mSource-Check Orphan Cleanup — applied\x1b[0m';
+  lines.push(header);
+  lines.push('');
+
+  const total = deleted.verdicts + deleted.evidence + deleted.suggestions;
+  if (total === 0) {
+    lines.push('No orphan rows found. Nothing to do.');
+    return lines.join('\n');
+  }
+
+  lines.push(`  Verdicts:    ${deleted.verdicts.toLocaleString()}`);
+  lines.push(`  Evidence:    ${deleted.evidence.toLocaleString()}`);
+  lines.push(`  Suggestions: ${deleted.suggestions.toLocaleString()}`);
+  lines.push('');
+
+  const byTypeEntries = Object.entries(byType).sort(
+    ([, a], [, b]) => (b.verdicts + b.evidence + b.suggestions) - (a.verdicts + a.evidence + a.suggestions),
+  );
+  if (byTypeEntries.length > 0) {
+    lines.push('By record type:');
+    const maxTypeLen = Math.max(...byTypeEntries.map(([t]) => t.length));
+    for (const [type, counts] of byTypeEntries) {
+      lines.push(
+        `  ${type.padEnd(maxTypeLen)}  verdicts=${counts.verdicts}  evidence=${counts.evidence}  suggestions=${counts.suggestions}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (dryRun) {
+    lines.push('This was a dry run. Re-run with \x1b[1m--apply\x1b[0m to delete these rows.');
+  } else {
+    lines.push('\x1b[32mDeletion complete.\x1b[0m');
+  }
+  return lines.join('\n');
+}
+
+async function cleanupCommand(
+  _args: string[],
+  options: CleanupOptions,
+): Promise<CommandResult> {
+  const apply = Boolean(options.apply);
+  const recordType = options.type as string | undefined;
+
+  const response = await cleanupOrphanVerdicts({
+    dryRun: !apply,
+    recordType,
+  });
+
+  if (!response.ok) {
+    return {
+      exitCode: 1,
+      output: `Failed to clean up orphans: ${response.message}`,
+    };
+  }
+
+  const result = response.data;
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify(result, null, 2),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    output: formatOutput(result, apply),
+  };
+}
+
+// ── Exports ──────────────────────────────────────────────────────────
+
+export const commands = {
+  default: cleanupCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check Orphan Cleanup — delete verdict/evidence rows for deleted records
+
+Background:
+  Dashboard queries filter out "orphan" verdicts (rows referencing records
+  that have been deleted from their source table) at read time, but the raw
+  rows accumulate. This skews raw COUNT(*) statistics and has produced
+  visible bugs like "personnel coverage 127%" in the coverage matrix.
+
+Usage:
+  crux sourcing-cleanup-orphans                  Dry-run over all known types
+  crux sourcing-cleanup-orphans --apply          Actually delete orphan rows
+  crux sourcing-cleanup-orphans --type=personnel Scope to one record type
+  crux sourcing-cleanup-orphans --ci             Machine-readable JSON output
+
+Options:
+  --apply     Delete matched rows (default is dry-run)
+  --type=X    Filter by record type (e.g., personnel, grant, fact)
+  --ci        JSON output for CI pipelines
+
+Safety:
+  - Default is dry-run. You must pass --apply to delete.
+  - Only record_types listed in LIVE_RECORDS_CTE are touched. Rows with an
+    unknown record_type are left alone.
+  - Deletes run inside a single transaction; partial writes are impossible.
+`.trim();
+}

--- a/crux/commands/sourcing-cleanup-orphans.ts
+++ b/crux/commands/sourcing-cleanup-orphans.ts
@@ -22,7 +22,7 @@ interface CleanupOptions extends BaseOptions {
   ci?: boolean;
 }
 
-function formatOutput(result: CleanupOrphansResult, _applied: boolean): string {
+function formatOutput(result: CleanupOrphansResult): string {
   const lines: string[] = [];
   const { dryRun, deleted, byType } = result;
   const header = dryRun
@@ -94,7 +94,7 @@ async function cleanupCommand(
 
   return {
     exitCode: 0,
-    output: formatOutput(result, apply),
+    output: formatOutput(result),
   };
 }
 
@@ -129,6 +129,10 @@ Safety:
   - Default is dry-run. You must pass --apply to delete.
   - Only record_types listed in LIVE_RECORDS_CTE are touched. Rows with an
     unknown record_type are left alone.
-  - Deletes run inside a single transaction; partial writes are impossible.
+  - With --apply, all three DELETEs run in one transaction (rolled back on
+    any error) and the reported counts come from DELETE ... RETURNING, so
+    they exactly match what was removed — no SELECT/DELETE drift.
+  - Dry-run counts come from a SELECT and may legitimately drift from a
+    later --apply if the database changes between the two calls.
 `.trim();
 }

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -99,6 +99,7 @@ import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
 import * as sourcingBackfillHomepagesCommands from './commands/sourcing-backfill-homepages.ts';
 import * as sourcingSampleCoverageCommands from './commands/sourcing-sample-coverage.ts';
 import * as sourcingSuggestUrlsCommands from './commands/sourcing-suggest-urls.ts';
+import * as sourcingCleanupOrphansCommands from './commands/sourcing-cleanup-orphans.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
 import * as sourcingWikiPagesCommands from './commands/sourcing-wiki-pages.ts';
@@ -190,6 +191,7 @@ const domains = {
   'sourcing-backfill-homepages': sourcingBackfillHomepagesCommands,
   'sourcing-sample-coverage': sourcingSampleCoverageCommands,
   'sourcing-suggest-urls': sourcingSuggestUrlsCommands,
+  'sourcing-cleanup-orphans': sourcingCleanupOrphansCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,
   'qa-sweep': qaSweepCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -82,6 +82,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'verify',
       'verify-orchestrate',
       'sourcing-recheck',
+      'sourcing-cleanup-orphans',
       'migrate-citations',
       'legislation',
       'bluesky',

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -27,6 +27,7 @@ export type VerdictByRecordResult = InferResponseType<RpcClient['verdicts'][':re
 export type DueForRecheckResult = InferResponseType<RpcClient['due-for-recheck']['$get'], 200>;
 export type EvidenceByRecordResult = InferResponseType<RpcClient['evidence'][':recordType'][':recordId']['$get'], 200>;
 export type SourcingStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type CleanupOrphansResult = InferResponseType<RpcClient['cleanup-orphans']['$post'], 200>;
 
 /** A single verdict entry from the list. */
 export type VerdictListEntry = ListVerdictsResult['verdicts'][number];
@@ -94,6 +95,21 @@ export async function getEvidenceByRecord(
 /** Get sourcing statistics. */
 export async function getSourcingStats(): Promise<ApiResult<SourcingStatsResult>> {
   return apiRequest<SourcingStatsResult>('GET', '/api/sourcing/stats');
+}
+
+/**
+ * Clean up orphaned source-check rows for deleted records (QUA-149).
+ *
+ * `dryRun` defaults to true — callers must pass `dryRun: false` explicitly
+ * to delete. `recordType` scopes cleanup to a single type.
+ */
+export async function cleanupOrphanVerdicts(
+  options?: { dryRun?: boolean; recordType?: string },
+): Promise<ApiResult<CleanupOrphansResult>> {
+  return apiRequest<CleanupOrphansResult>('POST', '/api/sourcing/cleanup-orphans', {
+    dryRun: options?.dryRun ?? true,
+    ...(options?.recordType ? { recordType: options.recordType } : {}),
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `POST /api/sourcing/cleanup-orphans` and a `crux tb sourcing-cleanup-orphans` CLI wrapper. Dashboard queries already filter orphan verdicts out at read time via `LIVE_RECORDS_CTE`, but the raw rows pile up and skew `COUNT(*)` — the "personnel coverage 127%" coverage-matrix bug was downstream of this.

## What it does

- Walks `source_check_verdicts`, `source_check_evidence`, and `sourcing_url_suggestions` for rows whose `(record_type, record_id)` pair doesn't resolve in `LIVE_RECORDS_CTE`.
- Defaults to **dry-run**. Callers must pass `dryRun: false` (or `--apply` on the CLI) to delete.
- Only record_types listed in the CTE are touched. Rows with an unknown record_type are left alone so a silent schema drift can't trigger mass deletions.
- Runs all three deletes in a single transaction.
- Returns per-type counts so dashboards can show what got removed.

## Files

- `apps/wiki-server/src/routes/sourcing/sourcing.ts` — new `POST /cleanup-orphans` handler
- `crux/lib/wiki-server/sourcing-client.ts` — RPC client
- `crux/commands/sourcing-cleanup-orphans.ts` — CLI command
- `crux/crux.mjs`, `crux/lib/groups.ts` — command registration under `tb` group
- `apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts` — 9 integration tests

## Test plan

- [x] `vitest run src/__tests__/sourcing-cleanup-orphans.test.ts` — 9/9
- [x] Full wiki-server vitest — 1033 pass, 21 skip (baseline)
- [x] `pnpm crux w validate gate --fix` — all 50 checks pass
- [ ] After merge: `WIKI_SERVER_ENV=prod crux tb sourcing-cleanup-orphans` (dry-run on prod)
- [ ] After merge + spot-check: re-run with `--apply` to actually clean up the 1002→724 personnel drift

Fixes QUA-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added orphan cleanup functionality for sourcing records with dry-run preview support
  * New CLI command to execute cleanup operations with optional record type filtering
  * New API endpoint to remove orphaned records from sourcing tables
  * Cleanup operations report deletion counts and breakdown by record type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->