### PR TITLE
chore(internal-docs): batched cleanup (QUA-374/375/376/377)

### DIFF
--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -354,6 +354,7 @@ export function getInternalNav(): NavSection[] {
       items: [
         { label: "Architecture", href: internalHref("architecture") },
         { label: "Data Architecture", href: internalHref("data-architecture") },
+        { label: "Data Architecture Overview", href: internalHref("data-architecture-overview") },
         { label: "Data System Authority", href: internalHref("data-system-authority") },
         { label: "Wiki Generation", href: internalHref("wiki-generation-architecture") },
         { label: "Content Pipeline", href: internalHref("content-pipeline-architecture") },

--- a/content/docs/internal/documentation-maintenance.mdx
+++ b/content/docs/internal/documentation-maintenance.mdx
@@ -61,12 +61,8 @@ Some documentation can be auto-generated from code:
 |--------------|-------------------|
 | CLI help text | `pnpm crux --help` |
 | Database schema | Extract from wiki-server API types |
-| Validation rules | List from `scripts/validate/` |
+| Validation rules | List from `crux/validate/` |
 | Cost estimates | Pull from actual API usage |
-
-<Aside type="tip">
-Consider adding a `pnpm generate-docs` script that updates generated sections.
-</Aside>
 
 ### 4. PR Checklist
 

--- a/content/docs/internal/page-types.mdx
+++ b/content/docs/internal/page-types.mdx
@@ -386,14 +386,14 @@ This catches pages where someone manually typed `quality: 75` or an LLM suggeste
 
 ### Fixing Pages with Manual Quality
 
-If you see: `Quality (X) set without ratings - use 'pnpm regrade page-id'`
+If you see: `Quality (X) set without ratings - use 'pnpm crux w improve <page-id>'`
 
 Run:
 ```bash
-pnpm regrade page-id
+pnpm crux w improve page-id --tier=standard --apply
 ```
 
-This will use Claude to properly grade the page and set both `quality` and `ratings`.
+This will use Claude to improve and properly grade the page, setting both `quality` and `ratings`.
 
 ---
 
@@ -436,11 +436,8 @@ pnpm validate
 # Run quality-source check specifically
 pnpm crux validate unified --rules=quality-source
 
-# Grade a specific page
-pnpm regrade page-id
-
-# Grade all ungraded pages
-node scripts/content/grade-content.mjs --skip-graded --apply
+# Improve and re-grade a specific page
+pnpm crux w improve page-id --tier=standard --apply
 ```
 
 ---

--- a/content/docs/internal/project-roadmap.md
+++ b/content/docs/internal/project-roadmap.md
@@ -37,7 +37,7 @@ The project has mature infrastructure:
   - Target: All pages with importance > 60 and quality < 40
 
 - [ ] **Citation coverage** - Many pages lack external citations
-  - Resource manager can convert links: `pnpm resources process [page] --apply`
+  - Resource manager can convert links: `pnpm crux w resources process [page] --apply`
   - Goal: Every substantive claim has a source
 
 ### Tooling (Low Priority)

--- a/content/docs/knowledge-base/responses/longterm-wiki.mdx
+++ b/content/docs/knowledge-base/responses/longterm-wiki.mdx
@@ -21,7 +21,7 @@ import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 | **Scope** | AI safety focused | ≈550 pages covering risks, interventions, organizations, cruxes |
 | **Content Model** | Curated synthesis | Editorial control, quality scoring, not community wiki |
 | **Unique Value** | Crux mapping | Explicit uncertainty tracking, worldview→priority linkages |
-| **Technical** | Modern stack | Astro/Starlight, React, interactive causal diagrams |
+| **Technical** | Modern stack | Next.js 15 + App Router, React, interactive causal diagrams |
 | **Open Source** | Fully | MIT licensed, GitHub repository |
 | **Status** | Active development | Launched 2025, ongoing content expansion |
 
@@ -36,7 +36,7 @@ import {DataInfoBox, Mermaid, EntityLink} from '@components/wiki';
 | **Website** | [longtermwiki.com](https://www.longtermwiki.com/) |
 | **GitHub** | [github.com/quantified-uncertainty/longterm-wiki](https://github.com/quantified-uncertainty/longterm-wiki) |
 | **License** | MIT |
-| **Platform** | Static site (Astro/Starlight) |
+| **Platform** | Next.js 15 (App Router) |
 
 ## Overview
 
@@ -240,7 +240,7 @@ Structured YAML databases enable data-aware components:
 
 | Layer | Technology | Purpose |
 |-------|------------|---------|
-| **Framework** | Astro 5 + Starlight | Static site generation, documentation theme |
+| **Framework** | Next.js 15 (App Router) | React Server Components, file-based routing |
 | **Components** | React 19 | Interactive UI components |
 | **Styling** | Tailwind CSS 4 | Utility-first styling |
 | **Type Safety** | TypeScript + Zod | Compile-time and runtime validation |
@@ -346,7 +346,7 @@ The [Similar Projects Analysis](/wiki/E881) identified key success factors:
 | **Quality control** | Automated grading, 6-dimension scoring | Consistent content standards |
 | **Cross-linking** | 550+ pages with stable entity references | Knowledge graph navigation |
 | **Open source** | MIT license, public GitHub | Transparency, reproducibility |
-| **Modern stack** | Astro, React, TypeScript | Fast, maintainable, accessible |
+| **Modern stack** | Next.js 15, React, TypeScript | Fast, maintainable, accessible |
 | **Interactive visualizations** | ReactFlow graphs, Mermaid diagrams | Complex relationships made legible |
 
 ### Limitations

--- a/crux/lib/rules/style-guide.test.ts
+++ b/crux/lib/rules/style-guide.test.ts
@@ -123,15 +123,6 @@ describe('style-guide rule', () => {
   });
 
   describe('skips', () => {
-    it('skips style guide pages', () => {
-      const content = mockContent(
-        '## Some broken page',
-        { path: 'content/docs/internal/style-guides/models.mdx' },
-      );
-      const issues = check(styleGuideRule, content);
-      expect(issues.length).toBe(0);
-    });
-
     it('skips index pages', () => {
       const content = mockContent(
         '## Some page',

--- a/crux/lib/rules/style-guide.ts
+++ b/crux/lib/rules/style-guide.ts
@@ -262,11 +262,6 @@ export const styleGuideRule = {
     const body = contentFile.body || '';
     const raw = contentFile.raw || '';
 
-    // Skip style guide pages themselves
-    if (filePath.includes('/style-guides/')) {
-      return issues;
-    }
-
     // Skip index pages
     if (contentFile.isIndex) {
       return issues;


### PR DESCRIPTION
## Summary

Four small internal-doc tickets surfaced during the QUA-131/132/133 PR reviews, explicitly batched per Ozzie's comment on each ticket: *"These 4 internal-doc cleanup tickets are all small (file:line verified in audit 2026-04-13). Consider batching as a single /internal-docs-cleanup PR."*

| Ticket | Fix |
|---|---|
| **QUA-374** | Add `data-architecture-overview` (E2179) to the Architecture sidebar in `wiki-nav.ts` — was an orphan since ~2026-04-09 |
| **QUA-375** | Remove dead `/style-guides/` skip branch from `crux/lib/rules/style-guide.ts` + the test that fabricated a path to exercise it |
| **QUA-376** | Replace `pnpm regrade`, `pnpm resources process`, `pnpm generate-docs` references in 3 internal docs with the canonical `pnpm crux w improve …` and `pnpm crux w resources process …` paths |
| **QUA-377** | Replace 4 residual `Astro 5 + Starlight` mentions in `content/docs/knowledge-base/responses/longterm-wiki.mdx` with `Next.js 15 (App Router)` after the QUA-131 about-this-wiki rewrite |

Net: 7 files, +12 / −32.

## Per-ticket notes

**QUA-374**: Mirrors the 3 entries added to `getInternalNav()` in PR #4260 (QUA-133). Added under the Architecture section between `data-architecture` and `data-system-authority`. The root-cause fix (deriving nav from frontmatter `subcategory`) is out of scope and tracked separately.

**QUA-375**: Confirmed via `find content/docs -type d -name style-guides` → no matches anywhere. Only `*-style-guide.mdx` flat files exist in `content/docs/internal/`, which already match the rule's normal flow. Vitest passes 12/12 after removing the fabricated test case.

**QUA-376**: For the speculative `pnpm generate-docs` Aside in `documentation-maintenance.mdx`, took option 2 from the ticket ("Remove the reference if the command was never implemented and the doc still reads coherently without it"). Also corrected the validation rules pointer from `scripts/validate/` (deleted long ago) to `crux/validate/`.

**QUA-377**: Left the `data-architecture-overview.mdx:637` mention alone — it's a comparison row listing Hugo/Astro as static-site-generator alternatives to Next.js, not a description of our stack, so removing it would lose information.

## Test plan

- [x] `npx vitest run crux/lib/rules/style-guide.test.ts` → 12/12 pass
- [x] `pnpm crux w validate gate --scope=content --fix` → all 5 checks pass
- [x] `cd apps/web && npx tsc --noEmit | grep wiki-nav` → 0 errors
- [x] `grep -rn 'pnpm regrade\|pnpm resources \|pnpm generate-docs' content/docs` → 0 hits
- [x] `grep -n Astro content/docs/knowledge-base/responses/longterm-wiki.mdx` → 0 hits

Fixes QUA-374
Fixes QUA-375
Fixes QUA-376
Fixes QUA-377
