### PR TITLE
refactor: drop /api/source-checks alias + fix sourcing-recheck workflow (QUA-358, QUA-380)

### DIFF
--- a/.github/workflows/sourcing-recheck.yml
+++ b/.github/workflows/sourcing-recheck.yml
@@ -1,7 +1,7 @@
-name: Source-Check Recheck
-run-name: "Source-Check Recheck${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
+name: Sourcing Recheck
+run-name: "Sourcing Recheck${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
 
-# Re-verifies stale source-check verdicts on a weekly schedule.
+# Re-verifies stale sourcing verdicts on a weekly schedule.
 # Detects when previously-verified data becomes contradicted by updated sources.
 
 on:
@@ -35,7 +35,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: source-check-recheck
+  group: sourcing-recheck
   cancel-in-progress: false
 
 jobs:
@@ -71,8 +71,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run source-check recheck
+      - name: Run sourcing recheck
         run: |
+          set -eo pipefail
           ARGS="--budget=${INPUT_BUDGET} --limit=${INPUT_LIMIT}"
           if [ -n "${INPUT_RECORD_TYPE}" ]; then
             ARGS="$ARGS --type=${INPUT_RECORD_TYPE}"
@@ -80,7 +81,7 @@ jobs:
           if [ "${INPUT_DRY_RUN}" = "true" ]; then
             ARGS="$ARGS --dry-run"
           fi
-          pnpm crux source-check-recheck $ARGS --ci 2>&1 | tee /tmp/recheck-output.txt
+          pnpm crux sourcing-recheck $ARGS --ci 2>&1 | tee /tmp/recheck-output.txt
 
       - name: Check for verdict flips
         if: always()
@@ -89,6 +90,6 @@ jobs:
           if grep -q '"changed":' /tmp/recheck-output.txt 2>/dev/null; then
             CHANGED=$(cat /tmp/recheck-output.txt | jq -r '.changed // 0' 2>/dev/null || echo "0")
             if [ "$CHANGED" -gt "0" ]; then
-              echo "::warning::$CHANGED verdict(s) changed during recheck — review source-check dashboard"
+              echo "::warning::$CHANGED verdict(s) changed during recheck — review sourcing dashboard"
             fi
           fi

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -205,8 +205,6 @@ export function createApp() {
   // Unified sourcing system — mount sub-routes before the catch-all parent.
   app.route("/api/sourcing/url-suggestions", urlSuggestionsRoute);
   app.route("/api/sourcing", sourcingRoute);
-  // Backward-compat alias: old /api/source-checks/* → /api/sourcing/*
-  app.route("/api/source-checks", sourcingRoute);
 
   // WikiBase routes — prose content and page metadata
   app.route("/api/pages", pagesRoute);

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -8,7 +8,7 @@
  *   2. Research better source URLs for records missing good sources
  *   3. Register new URLs via POST /api/resources/suggest and wait for ingest
  *   4. Reset stale verdicts to unchecked
- *   5. Run source-check verification for the entity
+ *   5. Run sourcing verification for the entity
  *   6. Report results
  *
  * Usage:
@@ -145,7 +145,7 @@ async function resolveEntity(identifier: string): Promise<ResolvedEntity | null>
 }
 
 /**
- * Find organizations with the worst source-check coverage.
+ * Find organizations with the worst sourcing coverage.
  * Returns entities sorted by number of non-confirmed verdicts (worst first).
  */
 async function findEntitiesNeedingCuration(limit: number): Promise<ResolvedEntity[]> {
@@ -686,7 +686,7 @@ async function curateEntity(
     // Step 5: Run verification
     const verifyBudget = Math.min(budget - tracker.totalCost, 2.0); // Cap per-entity verify at $2
     if (verifyBudget > 0) {
-      console.log(`\n  ${c.bold}Step 5: Running source-check verification ($${verifyBudget.toFixed(2)} budget)...${c.reset}`);
+      console.log(`\n  ${c.bold}Step 5: Running sourcing verification ($${verifyBudget.toFixed(2)} budget)...${c.reset}`);
       const verifyResult = await runVerification(entity, verifyBudget, recordLimit, tableFilter);
       console.log(`  Verification complete. Cost: $${verifyResult.cost.toFixed(3)}`);
     } else {
@@ -1119,7 +1119,7 @@ Pipeline per entity:
   3. Register new URLs via /api/resources/suggest + ingest content
   4. Update personnel records with new source URLs
   5. Reset stale verdicts to unchecked
-  6. Run source-check verification
+  6. Run sourcing verification
   7. Report before/after comparison
 
 Cost estimate:

--- a/crux/validate/.sourcing-baseline.json
+++ b/crux/validate/.sourcing-baseline.json
@@ -1,9 +1,9 @@
 {
-  "hyphenated": 4,
+  "hyphenated": 0,
   "camelCase": 1,
   "PascalCase": 0,
-  "route": 2,
-  "total": 7,
-  "updatedAt": "2026-04-12T19:16:58.756Z",
-  "notes": "FROZEN per QUA-296. The 5 non-route references (hyphenated + camelCase) are structural: they bind to DB columns source_check_evidence and source_check_verdicts via Drizzle. Driving total below 5 requires renaming those tables (rejected as high-risk for cosmetic gain — see QUA-296). Route references (currently 2) will drop to 0 once QUA-301 client migration completes. Until then, do not lower the total without first reading QUA-296. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella), QUA-296 (freeze decision)."
+  "route": 0,
+  "total": 1,
+  "updatedAt": "2026-04-13T00:00:00.000Z",
+  "notes": "FROZEN at 1 per QUA-358 + QUA-303. The single remaining ref is the Drizzle binding `sourceCheckedAt` on `claim_sources.source_checked_at` (schema.ts). Driving total to 0 requires renaming that column, which is gated by QUA-303 (DO NOT START YET — see QUA-351 for precondition tracker). Do not lower without completing the column rename. Route + hyphenated axes previously held 6 refs (2 alias routes + 4 flagship-curate comments); both were zeroed by QUA-358. Tracked under QUA-103 (lint guard), QUA-102 (rename umbrella), QUA-296 (freeze decision), QUA-303 (DB column rename), QUA-358 (alias drop)."
 }


### PR DESCRIPTION
## Summary

Completes the `source-check → sourcing` rename started in QUA-102/QUA-237 by:

1. **Dropping the `/api/source-checks` backward-compat alias** (QUA-358) in `apps/wiki-server/src/app.ts`. All internal clients were migrated to `/api/sourcing/*` via QUA-301/#4212 and we have no external API users.
2. **Fixing a silent incident discovered during red-team** (QUA-380): `.github/workflows/sourcing-recheck.yml` has been calling a removed command name (`source-check-recheck`) since 2026-04-11 when QUA-237 renamed it to `sourcing-recheck`. GitHub Actions has been reporting "success" because the step uses `| tee` without `pipefail`, masking crux's non-zero exit. **No sourcing rechecks have run for 2 days.**
3. **Bonus cleanup**: 4 hyphenated `source-check` refs in `crux/commands/flagship-curate.ts` comments/log strings renamed to `sourcing`. Zero functional change.

## Sourcing baseline impact

`.sourcing-baseline.json`: total **7 → 1**.

| Axis | Before | After | Why |
|---|---|---|---|
| `route` | 2 | 0 | Alias dropped (this PR) |
| `hyphenated` | 4 | 0 | flagship-curate comments renamed (this PR) |
| `camelCase` | 1 | 1 | `sourceCheckedAt` Drizzle binding — gated by QUA-303 (DO NOT START YET per QUA-351) |

The remaining `camelCase: 1` is the Drizzle JS binding on `claim_sources.source_checked_at`. Driving it to 0 requires the DB column rename that QUA-303 is tracking. Baseline notes updated to record that the remaining ref is structural, not cosmetic.

## QUA-380 evidence

Most recent scheduled run (2026-04-13T09:58:46Z) logs:

```
> node --import tsx/esm crux/crux.mjs "source-check-recheck" "--budget=15" "--limit=500" "--ci"

Unknown domain: source-check-recheck
Available domains: validate, analyze, ..., sourcing-recheck, ...
```

The next step's verdict-flip detection greps the tee'd output for `"changed":` — since crux never ran, no changes are ever detected, and no warnings are ever emitted. Zero user-facing signal the automation was broken.

## Changes

| File | What |
|---|---|
| `apps/wiki-server/src/app.ts` | Delete `/api/source-checks` route alias (2 lines) |
| `.github/workflows/sourcing-recheck.yml` | Rename `source-check-recheck` → `sourcing-recheck`, add `set -eo pipefail`, sync cosmetic strings (workflow name, run-name, concurrency group, step name) |
| `crux/commands/flagship-curate.ts` | 4 comment/log-string renames |
| `crux/validate/.sourcing-baseline.json` | Lower total 7 → 1 with updated notes |

## Follow-ups filed

- **QUA-380** — This PR fixes the immediate symptom. Closed by merge.
- **QUA-381** — Audit other workflows for the `| tee` without `pipefail` masking pattern. Separate sweep PR.
- **QUA-303** — DB column rename for `sourceCheckedAt` (already existed, gated).

## Red-team summary

- Grepped `apps/web/src/`, `apps/wiki-server/src/`, `crux/` for any remaining `/api/source-check` callers → 0 (outside test/validator files that reference the pattern literal)
- Validated yaml syntax of the modified workflow (`js-yaml` parse + inspection of job graph)
- Checked for inter-workflow `needs:` dependencies on the old job names → 0
- Confirmed `sourcing.yml` (different workflow) calls `verify-orchestrate` (unrenamed), so it's working despite cosmetic `source-check` leftovers — deliberately out of scope

## Test plan

- [x] Wiki-server tests: 1024/1024 pass
- [x] Sourcing lint guard tests: 14/14 pass
- [x] TypeScript (wiki-server): clean
- [x] `pnpm crux w validate gate --fix`: 48/48 pass (3 advisory warnings unrelated to this PR)
- [x] Sourcing lint guard at new baseline: passes at `total: 1`
- [x] yaml-lint of modified workflow: valid
- [ ] CI green on push
- [ ] **Post-merge: manually trigger `sourcing-recheck.yml` via `workflow_dispatch` with `dry_run=true` to verify crux actually runs** (see deploy checklist)

Closes QUA-358
Fixes QUA-380


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `ci` Modified workflow "sourcing recheck" — verify it runs successfully after merge — `gh run list --workflow="sourcing-recheck.yml" --limit=1 --json status,conclusion`
- [ ] `manual` Trigger sourcing-recheck.yml manually after merge to verify QUA-380 fix — do not wait for the weekly cron. Expect the crux step to print real output (not `Unknown domain`) and the job to complete without pipefail tripping — `gh workflow run sourcing-recheck.yml -R quantified-uncertainty/longterm-wiki -f dry_run=true`
<!-- /deploy-tasks -->
