### PR TITLE
fix: clear KNOWN_BASELINE_REFS — orphan sids no longer reproduce (QUA-89, QUA-99)

### DIFF
--- a/crux/validate/validate-factbase-record-refs.ts
+++ b/crux/validate/validate-factbase-record-refs.ts
@@ -137,19 +137,8 @@ export function buildEntityLookup(database: {
 // Known baseline — tracked by GitHub issues
 // ---------------------------------------------------------------------------
 
-/**
- * Known unresolvable refs tracked by GitHub issues.
- * Downgraded from error to warning so they don't block unrelated PRs.
- * Remove entries as their issues are resolved.
- */
-const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set([
-  // #3914: Investment/grant records reference non-existent entities
-  "sid_B5JzHeWvow", "sid_Kvfo7x5bqf", "sid_rWgCE08sfW", "sid_dbDEGrJbUp",
-  "sid_69J7QKcqyX", "sid_dzlCIZ45dZ", "sid_B6ZUV8iv17", "sid_F1bFJHm9RA",
-  "sid_ntlgFVJrPg", "sid_oEH5GwWtow",
-  "sid_GlobalGive", "sid_Orthogonal", "sid_Futurewise", "sid_lighthaven",
-  "sid_Janaagraha", "sid_conjecture", "sid_Kurzgesagt", "sid_Exscientia",
-]);
+/** Allow specific orphan refs through as warnings; populate per QUA ticket. */
+const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set<string>();
 
 // ---------------------------------------------------------------------------
 // Field scanning


### PR DESCRIPTION
## Summary

Clears the 18-entry `KNOWN_BASELINE_REFS` escape hatch in `validate-factbase-record-refs.ts`. A fresh `WIKI_SERVER_ENV=prod pnpm build-data:quick` against prod confirms all historically-tracked orphan `sid_` refs are absent from both `database.json` and `factbase-data.json`:

| Cohort | Sids | Ticket |
|---|---|---|
| Personnel enrichment (ARENA Alignment x4, Merantix, Apollo Research) | `sid_QAmTpCO5iQ`, `sid_t1PPwNe3x7`, `sid_2WGRkU8nio`, `sid_L0huEH4GSF`, `sid_PUlCEEDFup`, `sid_VnQlQzYOjk` | QUA-99 |
| FactBase investor refs | `sid_B5JzHeWvow`, `sid_Kvfo7x5bqf`, `sid_rWgCE08sfW`, `sid_dbDEGrJbUp`, `sid_69J7QKcqyX`, `sid_dzlCIZ45dZ` | QUA-89 |
| Older #3914 cohort | `sid_B6ZUV8iv17`, `sid_F1bFJHm9RA`, `sid_ntlgFVJrPg`, `sid_oEH5GwWtow`, `sid_GlobalGive`, `sid_Orthogonal`, `sid_Futurewise`, `sid_lighthaven`, `sid_Janaagraha`, `sid_conjecture`, `sid_Kurzgesagt`, `sid_Exscientia` | legacy |

The `KNOWN_BASELINE_REFS` variable itself is kept (empty set) with a one-line comment explaining how to use it for future orphans.

## Why this is safe

The validator's 27 existing unit tests exercise all the control-flow around `KNOWN_BASELINE_REFS` (error-vs-warning promotion, sid-kind classification, etc.). With the set empty, any new orphan refs will now error instead of warn — which is the intended behavior. The escape hatch is still available if a future session needs to file a new sid against a specific QUA ticket.

## Test plan

- [x] `pnpm build-data:quick` against prod — all 18 sids absent from both output files
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate` — factbase-record-refs check still passes
- [x] 27 existing `validate-factbase-record-refs.test.ts` tests pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors

Fixes QUA-89
Fixes QUA-99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unresolved reference validation now treats failures as errors instead of warnings for stricter validation, with the exception of legacy paths which retain their previous warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->