### PR TITLE
fix(FBCellValue): format string-typed numeric values from PG tables (QUA-82)

### DIFF
--- a/apps/web/src/components/wiki/factbase/FBCellValue.tsx
+++ b/apps/web/src/components/wiki/factbase/FBCellValue.tsx
@@ -151,6 +151,19 @@ export function FBCellValue({ value, fieldName, fieldDef }: FBCellValueProps) {
     );
   }
 
+  // Drizzle numeric() columns return strings; coerce known currency/fraction
+  // columns to numbers and delegate back to the existing number paths above.
+  if (
+    typeof value === "string" &&
+    value.length > 0 &&
+    (CURRENCY_FIELD_NAMES.has(fieldName) || isFractionField(fieldName, fieldDef))
+  ) {
+    const n = Number(value);
+    if (Number.isFinite(n)) {
+      return <FBCellValue value={n} fieldName={fieldName} fieldDef={fieldDef} />;
+    }
+  }
+
   // Role badges for known role values
   if (fieldName === "role" && typeof value === "string") {
     const roleLower = value.toLowerCase();

--- a/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
+++ b/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
@@ -249,14 +249,28 @@ describe("FBCellValue", () => {
       expect(screen.getByText("not a number")).toBeInTheDocument();
     });
 
-    it("does not crash on empty string in currency field", () => {
+    it("renders empty output for empty string in currency field", () => {
+      // Empty string hits the length guard in the new block and falls through
+      // to formatKBCellValue which stringifies to "".
       const { container } = render(<FBCellValue value="" fieldName="raised" />);
-      expect(container).toBeTruthy();
+      expect(container.textContent).toBe("");
     });
 
     it("handles non-finite strings gracefully", () => {
       render(<FBCellValue value="Infinity" fieldName="valuation" />);
       expect(screen.getByText("Infinity")).toBeInTheDocument();
+    });
+
+    it("formats string-typed zero as $0", () => {
+      render(<FBCellValue value="0" fieldName="raised" />);
+      expect(screen.getByText("$0")).toBeInTheDocument();
+    });
+
+    it("formats negative string currency correctly", () => {
+      // Would only occur for NAV-style fields, but the parse path handles it.
+      render(<FBCellValue value="-5000000" fieldName="amount" />);
+      const el = screen.getByText(/5 million/);
+      expect(el.textContent).toMatch(/-|\$/);
     });
   });
 });

--- a/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
+++ b/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
@@ -200,4 +200,63 @@ describe("FBCellValue", () => {
     render(<FBCellValue value={50_000_000} fieldName="amount" />);
     expect(screen.getByText("$50 million")).toBeInTheDocument();
   });
+
+  // Drizzle numeric() columns return JS strings. These tests guard the
+  // coerce-then-delegate path in FBCellValue against regressions.
+  describe("string-typed PG numeric fallback", () => {
+    it("formats string-typed funding round raised as USD", () => {
+      render(<FBCellValue value="8000000000" fieldName="raised" />);
+      expect(screen.getByText("$8 billion")).toBeInTheDocument();
+    });
+
+    it("formats string-typed valuation as USD", () => {
+      render(<FBCellValue value="380000000000" fieldName="valuation" />);
+      expect(screen.getByText("$380 billion")).toBeInTheDocument();
+    });
+
+    it("formats camelCase raisedLow (PG column) as USD", () => {
+      render(<FBCellValue value="2600000000" fieldName="raisedLow" />);
+      expect(screen.getByText("$2.6 billion")).toBeInTheDocument();
+    });
+
+    it("formats impliedValuation as USD", () => {
+      render(<FBCellValue value="61500000000" fieldName="impliedValuation" />);
+      expect(screen.getByText("$61.5 billion")).toBeInTheDocument();
+    });
+
+    it("formats string-typed fraction field as percentage", () => {
+      const fieldDef: FieldDef = { type: "number", description: "" };
+      render(<FBCellValue value="0.05" fieldName="stake" fieldDef={fieldDef} />);
+      expect(screen.getByText("5%")).toBeInTheDocument();
+    });
+
+    it("respects explicit unit from schema over default USD", () => {
+      const fieldDef: FieldDef = { type: "number", unit: "percent", description: "" };
+      const { container } = render(
+        <FBCellValue value="0.12" fieldName="raised" fieldDef={fieldDef} />
+      );
+      expect(container.textContent).toContain("%");
+      expect(container.textContent).not.toContain("$");
+    });
+
+    it("leaves non-currency string values to existing paths", () => {
+      render(<FBCellValue value="123" fieldName="notes" />);
+      expect(screen.getByText("123")).toBeInTheDocument();
+    });
+
+    it("does not crash on non-numeric string in currency field", () => {
+      render(<FBCellValue value="not a number" fieldName="amount" />);
+      expect(screen.getByText("not a number")).toBeInTheDocument();
+    });
+
+    it("does not crash on empty string in currency field", () => {
+      const { container } = render(<FBCellValue value="" fieldName="raised" />);
+      expect(container).toBeTruthy();
+    });
+
+    it("handles non-finite strings gracefully", () => {
+      render(<FBCellValue value="Infinity" fieldName="valuation" />);
+      expect(screen.getByText("Infinity")).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes raw `8000000000`-style numbers rendering on `/organizations/anthropic` and other org pages. The render-monitor Playwright job was failing on every run.

## Root cause

PG-primary Drizzle `numeric()` columns return JS strings (not numbers) from the wiki-server API. `FBCellValue` had branches for `typeof value === "number"` currency and schema-typed numeric paths, but nothing for the string-typed case. String values fell through every branch and rendered raw via `formatKBCellValue`'s `String(value)` fallback.

## Fix

Coerce string-typed values to numbers when the field is a known currency (`CURRENCY_FIELD_NAMES`) or fraction field, then **delegate back to the existing number paths** via a recursive `FBCellValue` call. This is a 13-line guard that produces identical output to the number branches without duplicating the formatting logic.

```tsx
// Drizzle numeric() columns return strings; coerce known currency/fraction
// columns to numbers and delegate back to the existing number paths above.
if (
  typeof value === "string" &&
  value.length > 0 &&
  (CURRENCY_FIELD_NAMES.has(fieldName) || isFractionField(fieldName, fieldDef))
) {
  const n = Number(value);
  if (Number.isFinite(n)) {
    return <FBCellValue value={n} fieldName={fieldName} fieldDef={fieldDef} />;
  }
}
```

The guard is placed after the schema-typed paths and before the role-badge / URL fallbacks, so it only catches values the existing number paths would have handled had the data been typed.

## Test plan

- [x] 10 new regression tests cover the PG-string path — funding rounds raised, valuation, camelCase `raisedLow`, `impliedValuation`, fraction fields, explicit schema unit override, non-numeric fallthrough, empty string, and non-finite (`Infinity`) inputs
- [x] All 34 `FBCellValue.test.tsx` tests pass
- [x] `npx tsc --noEmit` clean for `apps/web`
- [ ] Post-deploy: verify `/organizations/anthropic` renders formatted funding rounds (render-monitor workflow covers this)

Fixes QUA-82
