### PR TITLE
feat(sourcing): raise PROMPT_CONTENT_LENGTH to 30K, consolidate stale copies (QUA-342)

### DIFF
--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -29,6 +29,7 @@ import {
   SOURCE_CHECK_ADDITIONAL_CONSIDERATIONS,
   SOURCE_CHECK_RESPONSE_FORMAT,
 } from '../lib/sourcing/prompt-guidelines.ts';
+import { SOURCE_CHECK_CONSTANTS } from '../lib/sourcing/types.ts';
 import { loadGraphFull, resolveEntity } from '../lib/factbase-loader.ts';
 import type { LoadedKB } from '../lib/factbase-loader.ts';
 
@@ -160,8 +161,7 @@ async function verifySingleFact(
   // sourcing with the partial content — the LLM may still extract useful info.
   const sourceText = fetchResult.content;
 
-  // Truncate source text for prompt
-  const truncatedSource = sourceText.slice(0, 12000);
+  const truncatedSource = sourceText.slice(0, SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH);
 
   const prompt = buildSourcingPrompt(entity, fact, property, formattedValue, truncatedSource);
 

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -141,7 +141,7 @@ Previous reasoning: ${previousReasoning}
 
 Source text (excerpt):
 ---
-${sourceText.slice(0, 4000)}
+${sourceText.slice(0, SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH)}
 ---
 
 Re-verify this record against the source text. Has anything changed since the last check?

--- a/crux/commands/sourcing-wiki-pages.ts
+++ b/crux/commands/sourcing-wiki-pages.ts
@@ -38,6 +38,7 @@ import {
   SOURCE_CHECK_ADDITIONAL_CONSIDERATIONS,
   SOURCE_CHECK_RESPONSE_FORMAT,
 } from '../lib/sourcing/prompt-guidelines.ts';
+import { SOURCE_CHECK_CONSTANTS } from '../lib/sourcing/types.ts';
 import type { WikiPageVerifyItem } from '../lib/sourcing/types.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 import type { FactBaseFact } from '../lib/sourcing/wiki-page-claims.ts';
@@ -235,7 +236,7 @@ Source URL: ${item.sourceUrl}
 
 Source text (excerpt):
 ---
-${sourceText.slice(0, 4000)}
+${sourceText.slice(0, SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH)}
 ---
 
 Context from the wiki page where this claim appears:

--- a/crux/commands/verify-entity.ts
+++ b/crux/commands/verify-entity.ts
@@ -27,11 +27,12 @@ import { getSourcingStats } from '../lib/wiki-server/sourcing-client.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { fetchSourceContent as fetchCachedContent } from '../lib/sourcing/source-fetcher.ts';
 import { storeSourcingEvidence, storeAggregateVerdict } from '../lib/sourcing/verdict-handler.ts';
+import { SOURCE_CHECK_CONSTANTS } from '../lib/sourcing/types.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const PROMPT_CONTENT_LENGTH = 4000;
+const { PROMPT_CONTENT_LENGTH } = SOURCE_CHECK_CONSTANTS;
 const DEFAULT_BUDGET = 5;
 const DEFAULT_LIMIT = 50;
 

--- a/crux/lib/sourcing/types.ts
+++ b/crux/lib/sourcing/types.ts
@@ -71,8 +71,14 @@ export const SOURCE_CHECK_CONSTANTS = {
    *  (smarter extraction, search within page). DB stores unlimited text. */
   MAX_CONTENT_LENGTH: 500_000,
   FETCH_TIMEOUT_MS: 15_000,
-  /** Max chars of source text to include in LLM sourcing prompts */
-  PROMPT_CONTENT_LENGTH: 12000,
+  /**
+   * Max chars of source text to include in LLM sourcing prompts.
+   * 30K ≈ 7-8K Haiku input tokens. QUA-342 investigation found stuck
+   * verdicts were dominated by content truncation — the relevant section of
+   * long documents (SEC proxies, arXiv, long Wikipedia articles) sat past
+   * the previous 12K/4K cutoffs. Sources beyond this still need chunking.
+   */
+  PROMPT_CONTENT_LENGTH: 30_000,
   /** Estimated cost per LLM sourcing call in USD */
   ESTIMATED_COST_PER_VERIFICATION: 0.01,
 } as const;


### PR DESCRIPTION
## Summary

QUA-342 investigation found that prompt truncation is the dominant cause of stuck `unverifiable`/`partial` source-check verdicts (~2,292 live records). Long source documents (SEC proxies, arXiv papers, long Wikipedia articles) have the relevant section past byte 12K, so the LLM never saw it. `citation_content` caches up to 100K per URL — over 88% of the fetched bytes were discarded before the prompt even ran.

This PR raises the global `SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH` from 12K → 30K and consolidates the 4 stale copies scattered across sourcing commands into a single canonical constant.

## Changes

| File | Before | After |
|---|---|---|
| `crux/lib/sourcing/types.ts` | `PROMPT_CONTENT_LENGTH: 12000` | `30_000` with QUA-342 docstring |
| `crux/commands/factbase-sourcing.ts` | `slice(0, 12000)` hard-coded | `SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH` |
| `crux/commands/sourcing-recheck.ts` | `slice(0, 4000)` hard-coded | `SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH` (**7.5x raise**) |
| `crux/commands/sourcing-wiki-pages.ts` | `slice(0, 4000)` hard-coded | `SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH` (**7.5x raise**) |
| `crux/commands/verify-entity.ts` | `const PROMPT_CONTENT_LENGTH = 4000` shadowing the shared one | imports + destructures canonical |

After this PR there is **one** source of truth for the truncation cap; future tuning is a one-line edit.

## Cost impact

Haiku input is ~$0.25/MTok. For a full `crux fb sourcing` pass (~2,800 calls):
- Old: ~12K source + 3K boilerplate ≈ 4K tokens input → ~$3/run
- New: ~30K source + 3K boilerplate ≈ 8.3K tokens input → ~$6/run

Roughly +$3 per full `fb sourcing` pass + similar deltas on recheck / wiki-pages (proportional to run volume). Acceptable given (a) the stuck-cohort count (~2,292 records) should drop substantially and (b) retries at the old cap produced dead-weight work.

## Expected impact

Per QUA-342 report: **>50% of the stuck cohort** (~1,100+ records) should become resolvable once the prompt sees the relevant section of their source documents. This unblocks parts of QUA-307 (264 contradicted citation verdicts) and the broader source-quality cleanup.

## Out of scope

- **Retrieval / chunking** for sources >30K chars (SEC proxies that run 50K+). Documented as follow-up in `SOURCE_CHECK_CONSTANTS` docstring.
- **Extracted-quote field** in the LLM response schema (would massively improve debuggability for future stuck-verdict investigations). Separate ticket.
- **Backfilling `citation_content` for the ~22% of stuck records with no cached content** — different failure mode, tracked separately.

## Test plan

- [x] `npx vitest run commands/factbase-sourcing` — 11 tests pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors from touched files
- [x] `grep -rn "PROMPT_CONTENT_LENGTH" crux` — all 7 call sites now use the canonical constant, no orphans
- [ ] Post-deploy: spot-check a small `crux fb sourcing --limit=10` run against an entity with long sources (e.g. `anthropic`) and verify verdicts improve

Fixes QUA-342
