### PR TITLE
feat(crux): add linear project subcommands (QUA-357)

### DIFF
--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -14,6 +14,10 @@ const {
   commentOnIssueMock,
   searchIssuesMock,
   fetchRemoteWorkflowStatesMock,
+  listProjectsMock,
+  getProjectMock,
+  updateProjectMock,
+  createProjectUpdateMock,
 } = vi.hoisted(() => ({
   getIssueMock: vi.fn(),
   getCommentsMock: vi.fn(),
@@ -21,6 +25,10 @@ const {
   commentOnIssueMock: vi.fn(),
   searchIssuesMock: vi.fn(),
   fetchRemoteWorkflowStatesMock: vi.fn(),
+  listProjectsMock: vi.fn(),
+  getProjectMock: vi.fn(),
+  updateProjectMock: vi.fn(),
+  createProjectUpdateMock: vi.fn(),
 }));
 
 vi.mock('../../lib/linear/issues.ts', () => ({
@@ -29,6 +37,13 @@ vi.mock('../../lib/linear/issues.ts', () => ({
   updateIssueState: updateIssueStateMock,
   commentOnIssue: commentOnIssueMock,
   searchIssues: searchIssuesMock,
+}));
+
+vi.mock('../../lib/linear/projects.ts', () => ({
+  listProjects: listProjectsMock,
+  getProject: getProjectMock,
+  updateProject: updateProjectMock,
+  createProjectUpdate: createProjectUpdateMock,
 }));
 
 vi.mock('../../lib/linear/workflow-states.ts', () => ({
@@ -345,5 +360,219 @@ describe('linear parse', () => {
     const r = await commands.parse(['claude/qua-184-foo', '--json'], { ci: true });
     expect(r.exitCode).toBe(0);
     expect(r.output.trim()).toBe('QUA-184');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project
+// ---------------------------------------------------------------------------
+
+const mockProject = {
+  id: '6f9c8f44-7d33-4573-a017-a2200b8b22da',
+  name: 'Content Quality & Enrichment',
+  description: 'Editorial workstreams.',
+  content: '# Long-form body',
+  state: 'backlog',
+  progress: 0.2,
+  startDate: null,
+  targetDate: '2026-05-01',
+  url: 'https://linear.app/quantifieduncertainty/project/content-quality-enrichment-xyz',
+  updatedAt: '2026-04-13T00:00:00Z',
+  lead: null,
+};
+
+describe('linear project', () => {
+  it('prints help when no subcommand given', async () => {
+    const r = await commands.project([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+    expect(r.output).toContain('list');
+    expect(r.output).toContain('view');
+    expect(r.output).toContain('update');
+    expect(r.output).toContain('comment');
+  });
+
+  it('prints help for "help" subcommand with exit 0', async () => {
+    const r = await commands.project(['help'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('rejects unknown subcommand', async () => {
+    const r = await commands.project(['foo'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Unknown subcommand');
+  });
+
+  describe('list', () => {
+    it('prints all projects grouped by state', async () => {
+      listProjectsMock.mockResolvedValueOnce([
+        mockProject,
+        { ...mockProject, id: 'x', name: 'Done Project', state: 'completed', progress: 1 },
+      ]);
+      const r = await commands.project(['list'], { ci: true });
+      expect(r.exitCode).toBe(0);
+      expect(r.output).toContain('Content Quality & Enrichment');
+      expect(r.output).toContain('Done Project');
+    });
+
+    it('emits JSON with --json', async () => {
+      listProjectsMock.mockResolvedValueOnce([mockProject]);
+      const r = await commands.project(['list'], { ci: true, json: true });
+      const parsed = JSON.parse(r.output);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('Content Quality & Enrichment');
+    });
+  });
+
+  describe('view', () => {
+    it('prints usage when no ref given', async () => {
+      const r = await commands.project(['view'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Usage');
+    });
+
+    it('prints not-found when project is missing', async () => {
+      getProjectMock.mockResolvedValueOnce(null);
+      const r = await commands.project(['view', 'Nope'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('not found');
+    });
+
+    it('prints the project body on success', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      const r = await commands.project(['view', 'Content Quality & Enrichment'], { ci: true });
+      expect(r.exitCode).toBe(0);
+      expect(r.output).toContain('Content Quality & Enrichment');
+      expect(r.output).toContain('Long-form body');
+      expect(r.output).toContain('Editorial workstreams');
+    });
+
+    it('emits JSON with --json', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      const r = await commands.project(['view', 'Content Quality & Enrichment'], { ci: true, json: true });
+      const parsed = JSON.parse(r.output);
+      expect(parsed.name).toBe('Content Quality & Enrichment');
+    });
+  });
+
+  describe('update', () => {
+    it('prints usage when no ref given', async () => {
+      const r = await commands.project(['update'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Usage');
+    });
+
+    it('rejects when no fields to update', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      const r = await commands.project(['update', 'Content Quality & Enrichment'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Nothing to update');
+      expect(updateProjectMock).not.toHaveBeenCalled();
+    });
+
+    it('applies inline --description and --content updates', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      updateProjectMock.mockResolvedValueOnce({ ...mockProject, description: 'New', content: 'New body' });
+      const r = await commands.project(
+        ['update', 'Content Quality & Enrichment'],
+        { ci: true, description: 'New', content: 'New body' },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(updateProjectMock).toHaveBeenCalledWith(mockProject.id, {
+        description: 'New',
+        content: 'New body',
+      });
+    });
+
+    it('reads content from --content-file', async () => {
+      // writeFileSync before import: use a temp file path that exists
+      const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'linear-test-'));
+      const file = join(dir, 'content.md');
+      writeFileSync(file, '# From file');
+
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      updateProjectMock.mockResolvedValueOnce({ ...mockProject, content: '# From file' });
+
+      const r = await commands.project(
+        ['update', 'Content Quality & Enrichment'],
+        { ci: true, contentFile: file },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(updateProjectMock).toHaveBeenCalledWith(mockProject.id, {
+        content: '# From file',
+      });
+      unlinkSync(file);
+    });
+
+    it('content-file takes precedence over inline --content', async () => {
+      const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'linear-test-'));
+      const file = join(dir, 'content.md');
+      writeFileSync(file, 'from file');
+
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      updateProjectMock.mockResolvedValueOnce(mockProject);
+
+      await commands.project(
+        ['update', 'Content Quality & Enrichment'],
+        { ci: true, content: 'inline', contentFile: file },
+      );
+      expect(updateProjectMock).toHaveBeenCalledWith(mockProject.id, {
+        content: 'from file',
+      });
+      unlinkSync(file);
+    });
+  });
+
+  describe('comment', () => {
+    it('prints usage when no ref given', async () => {
+      const r = await commands.project(['comment'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Usage');
+    });
+
+    it('rejects empty body', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      const r = await commands.project(['comment', 'Content Quality & Enrichment'], { ci: true });
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Empty body');
+      expect(createProjectUpdateMock).not.toHaveBeenCalled();
+    });
+
+    it('posts an inline comment', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      createProjectUpdateMock.mockResolvedValueOnce(undefined);
+      const r = await commands.project(
+        ['comment', 'Content Quality & Enrichment', 'Shipped', 'phase', '5'],
+        { ci: true },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(createProjectUpdateMock).toHaveBeenCalledWith(mockProject.id, 'Shipped phase 5');
+    });
+
+    it('reads comment body from --body-file', async () => {
+      const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'linear-test-'));
+      const file = join(dir, 'body.md');
+      writeFileSync(file, 'From file body');
+
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      createProjectUpdateMock.mockResolvedValueOnce(undefined);
+      const r = await commands.project(
+        ['comment', 'Content Quality & Enrichment'],
+        { ci: true, bodyFile: file },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(createProjectUpdateMock).toHaveBeenCalledWith(mockProject.id, 'From file body');
+      unlinkSync(file);
+    });
   });
 });

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -508,6 +508,28 @@ describe('linear project', () => {
       unlinkSync(file);
     });
 
+    it('applies name/state/start-date/target-date updates', async () => {
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      updateProjectMock.mockResolvedValueOnce({ ...mockProject, name: 'Renamed', state: 'started' });
+      const r = await commands.project(
+        ['update', 'Content Quality & Enrichment'],
+        {
+          ci: true,
+          name: 'Renamed',
+          state: 'started',
+          startDate: '2026-05-01',
+          targetDate: '2026-06-30',
+        },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(updateProjectMock).toHaveBeenCalledWith(mockProject.id, {
+        name: 'Renamed',
+        state: 'started',
+        startDate: '2026-05-01',
+        targetDate: '2026-06-30',
+      });
+    });
+
     it('content-file takes precedence over inline --content', async () => {
       const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
       const { tmpdir } = await import('os');

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -578,6 +578,25 @@ describe('linear project', () => {
       expect(createProjectUpdateMock).toHaveBeenCalledWith(mockProject.id, 'Shipped phase 5');
     });
 
+    it('rejects a whitespace-only --body-file body', async () => {
+      const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
+      const { tmpdir } = await import('os');
+      const { join } = await import('path');
+      const dir = mkdtempSync(join(tmpdir(), 'linear-test-'));
+      const file = join(dir, 'blank.md');
+      writeFileSync(file, '   \n\t\n  ');
+
+      getProjectMock.mockResolvedValueOnce(mockProject);
+      const r = await commands.project(
+        ['comment', 'Content Quality & Enrichment'],
+        { ci: true, bodyFile: file },
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.output).toContain('Empty body');
+      expect(createProjectUpdateMock).not.toHaveBeenCalled();
+      unlinkSync(file);
+    });
+
     it('reads comment body from --body-file', async () => {
       const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
       const { tmpdir } = await import('os');

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -26,6 +26,13 @@ import {
   updateIssueState,
 } from '../lib/linear/issues.ts';
 import {
+  createProjectUpdate,
+  getProject,
+  listProjects,
+  updateProject,
+  type UpdateProjectInput,
+} from '../lib/linear/projects.ts';
+import {
   auditInProgress,
   extractFixesIds,
   STALE_DAYS,
@@ -50,6 +57,12 @@ interface CommandOptions extends BaseOptions {
   description?: string;
   descriptionFile?: string;
   priority?: string;
+  content?: string;
+  contentFile?: string;
+  name?: string;
+  state?: string;
+  startDate?: string;
+  targetDate?: string;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -669,6 +682,124 @@ async function leakCheck(_args: string[], options: CommandOptions): Promise<Comm
 }
 
 // ---------------------------------------------------------------------------
+// project — list / view / update / comment
+// ---------------------------------------------------------------------------
+
+const PROJECT_SUB_HELP = `Usage: crux linear project <list|view|update|comment> [args]
+
+Subcommands:
+  list                                         List all projects
+  view <ref>                                    Show project details (ref = UUID or exact name)
+  update <ref> [--description=...] [--content=...|--content-file=<path>]
+                                                [--name=...] [--state=...] [--start-date=...] [--target-date=...]
+  comment <ref> <message> | --body-file=<path>  Post a project update (Linear's project-timeline post)
+
+  Project refs accept a UUID or a case-insensitive exact project name, so
+  'Content Quality & Enrichment' works the same as the project's UUID.
+
+  --description sets the short one-line summary (card text). --content sets
+  the long-form markdown body on the project page — you almost always want
+  --content, not --description.`;
+
+async function project(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  if (!sub || sub === 'help' || sub === '--help') {
+    return { output: PROJECT_SUB_HELP + '\n', exitCode: sub ? 0 : 1 };
+  }
+
+  if (sub === 'list') {
+    const projects = await listProjects();
+    if (options.json) {
+      return { output: JSON.stringify(projects, null, 2) + '\n', exitCode: 0 };
+    }
+    projects.sort((a, b) => a.state.localeCompare(b.state) || a.name.localeCompare(b.name));
+    let out = `${c.bold}Linear projects (${projects.length})${c.reset}\n`;
+    for (const p of projects) {
+      const pct = Math.round(p.progress * 100);
+      out += `  ${c.cyan}${p.name}${c.reset}  ${c.dim}[${p.state}]${c.reset} ${pct}%`;
+      if (p.targetDate) out += ` ${c.dim}target=${p.targetDate}${c.reset}`;
+      out += `\n    ${c.dim}${p.description ?? '(no description)'}${c.reset}\n`;
+    }
+    return { output: out, exitCode: 0 };
+  }
+
+  if (sub === 'view') {
+    const ref = rest.find((a) => !a.startsWith('--'));
+    if (!ref) return { output: `${c.red}Usage: crux linear project view <uuid-or-name>${c.reset}\n`, exitCode: 1 };
+    const p = await getProject(ref);
+    if (!p) return { output: `${c.red}Project "${ref}" not found${c.reset}\n`, exitCode: 1 };
+    if (options.json) return { output: JSON.stringify(p, null, 2) + '\n', exitCode: 0 };
+
+    let out = '';
+    out += `${c.bold}${p.name}${c.reset} ${c.dim}[${p.state}]${c.reset}\n`;
+    out += `  ${c.dim}id:${c.reset} ${p.id}\n`;
+    out += `  ${c.dim}progress:${c.reset} ${Math.round(p.progress * 100)}%`;
+    if (p.startDate) out += `  ${c.dim}start:${c.reset} ${p.startDate}`;
+    if (p.targetDate) out += `  ${c.dim}target:${c.reset} ${p.targetDate}`;
+    if (p.lead) out += `  ${c.dim}lead:${c.reset} ${p.lead.name}`;
+    out += `\n  ${c.dim}url:${c.reset} ${p.url}\n`;
+    out += `  ${c.dim}updated:${c.reset} ${p.updatedAt.slice(0, 10)}\n`;
+    out += `\n${c.bold}Description:${c.reset} ${p.description ?? c.dim + '(none)' + c.reset}\n`;
+    out += `\n${c.bold}Content:${c.reset}\n${p.content ?? c.dim + '(none)' + c.reset}\n`;
+    return { output: out, exitCode: 0 };
+  }
+
+  if (sub === 'update') {
+    const ref = rest.find((a) => !a.startsWith('--'));
+    if (!ref) return { output: `${c.red}Usage: crux linear project update <uuid-or-name> [flags]${c.reset}\n`, exitCode: 1 };
+    const p = await getProject(ref);
+    if (!p) return { output: `${c.red}Project "${ref}" not found${c.reset}\n`, exitCode: 1 };
+
+    const contentFromFile = readBodyFlag(options.contentFile);
+    const input: UpdateProjectInput = {};
+    if (options.name) input.name = options.name;
+    if (options.description !== undefined) input.description = options.description;
+    if (contentFromFile !== null) input.content = contentFromFile;
+    else if (options.content !== undefined) input.content = options.content;
+    if (options.state) input.state = options.state;
+    if (options.startDate) input.startDate = options.startDate;
+    if (options.targetDate) input.targetDate = options.targetDate;
+
+    if (Object.keys(input).length === 0) {
+      return {
+        output: `${c.red}Nothing to update. Pass --description, --content=..., --content-file=<path>, --name, --state, --start-date, or --target-date${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+
+    const updated = await updateProject(p.id, input);
+    if (options.json) return { output: JSON.stringify(updated, null, 2) + '\n', exitCode: 0 };
+    let out = `${c.green}✓${c.reset} Updated ${c.cyan}${updated.name}${c.reset} — ${Object.keys(input).join(', ')}\n`;
+    out += `  ${updated.url}\n`;
+    return { output: out, exitCode: 0 };
+  }
+
+  if (sub === 'comment') {
+    const ref = rest.find((a) => !a.startsWith('--'));
+    if (!ref) return { output: `${c.red}Usage: crux linear project comment <uuid-or-name> <message> | --body-file=<path>${c.reset}\n`, exitCode: 1 };
+    const p = await getProject(ref);
+    if (!p) return { output: `${c.red}Project "${ref}" not found${c.reset}\n`, exitCode: 1 };
+
+    const bodyFromFile = readBodyFlag(options.bodyFile);
+    const body = bodyFromFile ?? rest.slice(1).filter((a) => !a.startsWith('--')).join(' ').trim();
+    if (!body) {
+      return { output: `${c.red}Empty body. Pass inline or --body-file=<path>${c.reset}\n`, exitCode: 1 };
+    }
+    await createProjectUpdate(p.id, body);
+    return {
+      output: `${c.green}✓${c.reset} Posted update on ${c.cyan}${p.name}${c.reset}\n  ${p.url}\n`,
+      exitCode: 0,
+    };
+  }
+
+  return { output: `${c.red}Unknown subcommand: ${sub}${c.reset}\n\n${PROJECT_SUB_HELP}\n`, exitCode: 1 };
+}
+
+// ---------------------------------------------------------------------------
 // Command registry
 // ---------------------------------------------------------------------------
 
@@ -685,6 +816,7 @@ export const commands = {
   'leak-check': leakCheck,
   'states-list': statesList,
   parse,
+  project,
 };
 
 export function getHelp(): string {
@@ -703,6 +835,7 @@ Commands:
   leak-check                    Scan current session for QUA refs beyond the primary; warn about leaks
   states-list                   Show current QUA team workflow state IDs
   parse <string>                Extract a Linear ID from a string (debug helper)
+  project <sub>                 Project commands: list, view, update, comment (see 'crux linear project help')
 
 Options (create):
   --description=<text>       Issue description (inline)
@@ -727,6 +860,15 @@ Global options:
 Environment:
   LINEAR_API_KEY      Required. Stored in .env.base at the workspace root.
 
+Options (project update):
+  --description=<text>        Short one-line summary (card text)
+  --content=<text>            Long-form markdown body (rendered on project page)
+  --content-file=<path>       Long-form body from file (safe for multiline)
+  --name=<text>               Rename the project
+  --state=<name>              Project state: backlog, planned, started, paused, completed, canceled
+  --start-date=<YYYY-MM-DD>   Project start date
+  --target-date=<YYYY-MM-DD>  Project target date
+
 Examples:
   crux linear create "Broken login page" --description="The login form crashes on submit"
   crux linear create "Add retry logic" --description-file=/tmp/desc.md --priority=3
@@ -737,5 +879,9 @@ Examples:
   crux linear comment QUA-184 "Landed in commit abc123"
   crux linear comment QUA-184 --body-file=/tmp/note.md
   crux linear states-list
+  crux linear project list
+  crux linear project view "Content Quality & Enrichment"
+  crux linear project update "Data Integrity" --content-file=/tmp/data-integrity.md
+  crux linear project comment "Source-Check & Verification" "Shipped Phase 5"
 `;
 }

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -779,14 +779,17 @@ async function project(args: string[], options: CommandOptions): Promise<Command
   }
 
   if (sub === 'comment') {
-    const ref = rest.find((a) => !a.startsWith('--'));
+    // Locate the ref positionally so flags *before* the ref (e.g.
+    // `--body-file=... "My Project"`) don't get swept into the inline body.
+    const refIndex = rest.findIndex((a) => !a.startsWith('--'));
+    const ref = refIndex >= 0 ? rest[refIndex] : undefined;
     if (!ref) return { output: `${c.red}Usage: crux linear project comment <uuid-or-name> <message> | --body-file=<path>${c.reset}\n`, exitCode: 1 };
     const p = await getProject(ref);
     if (!p) return { output: `${c.red}Project "${ref}" not found${c.reset}\n`, exitCode: 1 };
 
     const bodyFromFile = readBodyFlag(options.bodyFile);
-    const body = bodyFromFile ?? rest.slice(1).filter((a) => !a.startsWith('--')).join(' ').trim();
-    if (!body) {
+    const body = bodyFromFile ?? rest.slice(refIndex + 1).filter((a) => !a.startsWith('--')).join(' ');
+    if (body.trim() === '') {
       return { output: `${c.red}Empty body. Pass inline or --body-file=<path>${c.reset}\n`, exitCode: 1 };
     }
     await createProjectUpdate(p.id, body);

--- a/crux/lib/linear/__tests__/projects.test.ts
+++ b/crux/lib/linear/__tests__/projects.test.ts
@@ -45,13 +45,61 @@ describe('projects.ts', () => {
   });
 
   describe('listProjects', () => {
-    it('returns all projects from the QUA team', async () => {
+    it('returns all projects on a single page (hasNextPage=false)', async () => {
       globalThis.fetch = vi.fn().mockResolvedValue(
-        jsonResponse({ data: { projects: { nodes: [fixture, { ...fixture, id: 'other', name: 'Other' }] } } }),
+        jsonResponse({
+          data: {
+            projects: {
+              nodes: [fixture, { ...fixture, id: 'other', name: 'Other' }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        }),
       ) as unknown as typeof fetch;
       const all = await listProjects();
       expect(all).toHaveLength(2);
       expect(all[0].name).toBe('Content Quality & Enrichment');
+    });
+
+    it('paginates across multiple pages with cursor', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              projects: {
+                nodes: [fixture, { ...fixture, id: 'p2', name: 'Page1-B' }],
+                pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              projects: {
+                nodes: [{ ...fixture, id: 'p3', name: 'Page2-A' }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          }),
+        );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const all = await listProjects();
+      expect(all).toHaveLength(3);
+      expect(all.map((p) => p.name)).toEqual([
+        'Content Quality & Enrichment',
+        'Page1-B',
+        'Page2-A',
+      ]);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      // First call: after=null; second call: after="cursor-1".
+      const firstBody = JSON.parse(fetchFn.mock.calls[0][1].body);
+      const secondBody = JSON.parse(fetchFn.mock.calls[1][1].body);
+      expect(firstBody.variables.after).toBeNull();
+      expect(secondBody.variables.after).toBe('cursor-1');
     });
   });
 
@@ -80,20 +128,30 @@ describe('projects.ts', () => {
 
     it('falls back to case-insensitive name lookup when ref is not a UUID', async () => {
       const fetchFn = vi.fn().mockResolvedValue(
-        jsonResponse({ data: { projects: { nodes: [fixture, { ...fixture, id: 'x', name: 'Other' }] } } }),
+        jsonResponse({
+          data: {
+            projects: {
+              nodes: [fixture, { ...fixture, id: 'x', name: 'Other' }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        }),
       );
       globalThis.fetch = fetchFn as unknown as typeof fetch;
       const p = await getProject('content quality & enrichment');
       expect(p).not.toBeNull();
       expect(p!.id).toBe(PROJECT_UUID);
-      // Should have called the list query, not the single-project query
+      // Should have called the paginated list query, not the single-project query
       const body = JSON.parse(fetchFn.mock.calls[0][1].body);
-      expect(body.query).toContain('projects(first: 100');
+      expect(body.query).toContain('projects(');
+      expect(body.query).toContain('pageInfo');
     });
 
     it('returns null when name does not match exactly (no substring match)', async () => {
       globalThis.fetch = vi.fn().mockResolvedValue(
-        jsonResponse({ data: { projects: { nodes: [fixture] } } }),
+        jsonResponse({
+          data: { projects: { nodes: [fixture], pageInfo: { hasNextPage: false, endCursor: null } } },
+        }),
       ) as unknown as typeof fetch;
       const p = await getProject('Content Quality');  // partial — must not match
       expect(p).toBeNull();
@@ -102,13 +160,45 @@ describe('projects.ts', () => {
     it('rejects a malformed UUID as a name lookup (falls through to list)', async () => {
       // "not-a-uuid-but-close" should not match the UUID regex → name lookup
       const fetchFn = vi.fn().mockResolvedValue(
-        jsonResponse({ data: { projects: { nodes: [] } } }),
+        jsonResponse({
+          data: { projects: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } },
+        }),
       );
       globalThis.fetch = fetchFn as unknown as typeof fetch;
       const p = await getProject('not-a-uuid-but-close');
       expect(p).toBeNull();
       const body = JSON.parse(fetchFn.mock.calls[0][1].body);
-      expect(body.query).toContain('projects(first:');
+      expect(body.query).toContain('projects(');
+    });
+
+    it('resolves a name that lives on a later page via pagination', async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              projects: {
+                nodes: [{ ...fixture, id: 'a', name: 'Alpha' }],
+                pageInfo: { hasNextPage: true, endCursor: 'c1' },
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: {
+              projects: {
+                nodes: [fixture],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          }),
+        );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+      const p = await getProject('Content Quality & Enrichment');
+      expect(p).not.toBeNull();
+      expect(p!.id).toBe(PROJECT_UUID);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/crux/lib/linear/__tests__/projects.test.ts
+++ b/crux/lib/linear/__tests__/projects.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  listProjects,
+  getProject,
+  updateProject,
+  createProjectUpdate,
+  linearProjectUrl,
+  type LinearProject,
+} from '../projects.ts';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const PROJECT_UUID = '6f9c8f44-7d33-4573-a017-a2200b8b22da';
+
+const fixture: LinearProject = {
+  id: PROJECT_UUID,
+  name: 'Content Quality & Enrichment',
+  description: 'Editorial workstreams.',
+  content: '# Content\n\nLong-form body.',
+  state: 'backlog',
+  progress: 0.2,
+  startDate: null,
+  targetDate: '2026-05-01',
+  url: 'https://linear.app/quantifieduncertainty/project/content-quality-enrichment-xyz',
+  updatedAt: '2026-04-13T00:00:00Z',
+  lead: null,
+};
+
+describe('projects.ts', () => {
+  let originalFetch: typeof fetch;
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalKey = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = 'lin_test_key';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = originalKey;
+  });
+
+  describe('listProjects', () => {
+    it('returns all projects from the QUA team', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projects: { nodes: [fixture, { ...fixture, id: 'other', name: 'Other' }] } } }),
+      ) as unknown as typeof fetch;
+      const all = await listProjects();
+      expect(all).toHaveLength(2);
+      expect(all[0].name).toBe('Content Quality & Enrichment');
+    });
+  });
+
+  describe('getProject', () => {
+    it('fetches by UUID', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { project: fixture } }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+      const p = await getProject(PROJECT_UUID);
+      expect(p).not.toBeNull();
+      expect(p!.id).toBe(PROJECT_UUID);
+      // Should have called the single-project query, not the list query
+      const call = fetchFn.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.query).toContain('project(id: $id)');
+    });
+
+    it('returns null for missing UUID', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ errors: [{ message: 'Entity not found' }] }),
+      ) as unknown as typeof fetch;
+      const p = await getProject(PROJECT_UUID);
+      expect(p).toBeNull();
+    });
+
+    it('falls back to case-insensitive name lookup when ref is not a UUID', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projects: { nodes: [fixture, { ...fixture, id: 'x', name: 'Other' }] } } }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+      const p = await getProject('content quality & enrichment');
+      expect(p).not.toBeNull();
+      expect(p!.id).toBe(PROJECT_UUID);
+      // Should have called the list query, not the single-project query
+      const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+      expect(body.query).toContain('projects(first: 100');
+    });
+
+    it('returns null when name does not match exactly (no substring match)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projects: { nodes: [fixture] } } }),
+      ) as unknown as typeof fetch;
+      const p = await getProject('Content Quality');  // partial — must not match
+      expect(p).toBeNull();
+    });
+
+    it('rejects a malformed UUID as a name lookup (falls through to list)', async () => {
+      // "not-a-uuid-but-close" should not match the UUID regex → name lookup
+      const fetchFn = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projects: { nodes: [] } } }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+      const p = await getProject('not-a-uuid-but-close');
+      expect(p).toBeNull();
+      const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+      expect(body.query).toContain('projects(first:');
+    });
+  });
+
+  describe('updateProject', () => {
+    it('sends a projectUpdate mutation with the input fields', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projectUpdate: { success: true, project: { ...fixture, content: 'NEW' } } } }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      const result = await updateProject(PROJECT_UUID, { content: 'NEW' });
+      expect(result.content).toBe('NEW');
+
+      const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+      expect(body.query).toContain('projectUpdate(');
+      expect(body.variables.id).toBe(PROJECT_UUID);
+      expect(body.variables.input).toEqual({ content: 'NEW' });
+    });
+
+    it('throws when the mutation reports failure', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projectUpdate: { success: false, project: fixture } } }),
+      ) as unknown as typeof fetch;
+      await expect(updateProject(PROJECT_UUID, { name: 'x' })).rejects.toThrow(/refused to update/);
+    });
+
+    it('refuses to run with a non-UUID id', async () => {
+      await expect(updateProject('content-quality', { name: 'x' })).rejects.toThrow(/expected UUID/);
+    });
+  });
+
+  describe('createProjectUpdate', () => {
+    it('sends a projectUpdateCreate mutation', async () => {
+      const fetchFn = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projectUpdateCreate: { success: true } } }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+      await createProjectUpdate(PROJECT_UUID, 'Shipped phase 5');
+      const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+      expect(body.query).toContain('projectUpdateCreate(');
+      expect(body.variables.input.projectId).toBe(PROJECT_UUID);
+      expect(body.variables.input.body).toBe('Shipped phase 5');
+    });
+
+    it('throws on failure', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { projectUpdateCreate: { success: false } } }),
+      ) as unknown as typeof fetch;
+      await expect(createProjectUpdate(PROJECT_UUID, 'x')).rejects.toThrow(/refused to create/);
+    });
+
+    it('refuses non-UUID id', async () => {
+      await expect(createProjectUpdate('content-quality', 'x')).rejects.toThrow(/expected UUID/);
+    });
+  });
+
+  describe('linearProjectUrl', () => {
+    it('builds a url from a slug', () => {
+      expect(linearProjectUrl('content-quality-enrichment-xyz')).toBe(
+        'https://linear.app/quantifieduncertainty/project/content-quality-enrichment-xyz',
+      );
+    });
+  });
+});

--- a/crux/lib/linear/__tests__/projects.test.ts
+++ b/crux/lib/linear/__tests__/projects.test.ts
@@ -4,7 +4,6 @@ import {
   getProject,
   updateProject,
   createProjectUpdate,
-  linearProjectUrl,
   type LinearProject,
 } from '../projects.ts';
 
@@ -59,6 +58,26 @@ describe('projects.ts', () => {
       const all = await listProjects();
       expect(all).toHaveLength(2);
       expect(all[0].name).toBe('Content Quality & Enrichment');
+    });
+
+    it('exits the loop when endCursor is null even if hasNextPage is true', async () => {
+      // Defensive: some GraphQL servers occasionally return hasNextPage=true
+      // with a null endCursor. We treat a null cursor as the end of the stream
+      // so the loop can't spin forever.
+      const fetchFn = vi.fn().mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            projects: {
+              nodes: [fixture],
+              pageInfo: { hasNextPage: true, endCursor: null },
+            },
+          },
+        }),
+      );
+      globalThis.fetch = fetchFn as unknown as typeof fetch;
+      const all = await listProjects();
+      expect(all).toHaveLength(1);
+      expect(fetchFn).toHaveBeenCalledTimes(1);
     });
 
     it('paginates across multiple pages with cursor', async () => {
@@ -256,11 +275,4 @@ describe('projects.ts', () => {
     });
   });
 
-  describe('linearProjectUrl', () => {
-    it('builds a url from a slug', () => {
-      expect(linearProjectUrl('content-quality-enrichment-xyz')).toBe(
-        'https://linear.app/quantifieduncertainty/project/content-quality-enrichment-xyz',
-      );
-    });
-  });
 });

--- a/crux/lib/linear/projects.ts
+++ b/crux/lib/linear/projects.ts
@@ -11,7 +11,7 @@
  * first so name collisions with UUID-shaped strings can't occur.
  */
 
-import { linearGraphQL, LINEAR_WORKSPACE_SLUG } from './client.ts';
+import { linearGraphQL } from './client.ts';
 import { QUA_TEAM_ID } from './workflow-states.ts';
 
 export interface LinearProject {
@@ -60,17 +60,17 @@ export async function listProjects(): Promise<LinearProject[]> {
         pageInfo: { hasNextPage: boolean; endCursor: string | null };
       };
     } = await linearGraphQL(
-      `query Projects($after: String) {
+      `query Projects($teamId: ID!, $after: String) {
         projects(
           first: 100
           after: $after
-          filter: { accessibleTeams: { id: { eq: "${QUA_TEAM_ID}" } } }
+          filter: { accessibleTeams: { id: { eq: $teamId } } }
         ) {
           nodes { ${PROJECT_FIELDS} }
           pageInfo { hasNextPage endCursor }
         }
       }`,
-      { after },
+      { teamId: QUA_TEAM_ID, after },
     );
     all.push(...data.projects.nodes);
     after = data.projects.pageInfo.hasNextPage ? data.projects.pageInfo.endCursor : null;
@@ -173,7 +173,3 @@ export async function createProjectUpdate(
   }
 }
 
-/** Build a Linear project URL for display (the API already returns `url` but this is a convenience for constructed references). */
-export function linearProjectUrl(slug: string): string {
-  return `https://linear.app/${LINEAR_WORKSPACE_SLUG}/project/${slug}`;
-}

--- a/crux/lib/linear/projects.ts
+++ b/crux/lib/linear/projects.ts
@@ -1,0 +1,151 @@
+/**
+ * Typed helpers for Linear Project operations.
+ *
+ * Projects group related issues in Linear. This module lets `crux linear project`
+ * commands list, view, update, and post updates to projects — mirroring the
+ * patterns in `issues.ts` for QUA-NNN operations.
+ *
+ * Lookup semantics: all operations that take a "project ref" accept either a
+ * UUID (e.g. `6f9c8f44-7d33-4573-a017-a2200b8b22da`) or a case-insensitive
+ * exact name match (e.g. `Content Quality & Enrichment`). UUIDs are checked
+ * first so name collisions with UUID-shaped strings can't occur.
+ */
+
+import { linearGraphQL, LINEAR_WORKSPACE_SLUG } from './client.ts';
+import { QUA_TEAM_ID } from './workflow-states.ts';
+
+export interface LinearProject {
+  id: string;
+  name: string;
+  /** Short summary — the "description" field in Linear's UI. */
+  description: string | null;
+  /** Long-form markdown body — the "content" field in Linear's UI (what you edit in the project page). */
+  content: string | null;
+  state: string;
+  progress: number;
+  startDate: string | null;
+  targetDate: string | null;
+  url: string;
+  updatedAt: string;
+  lead: { id: string; name: string } | null;
+}
+
+const PROJECT_FIELDS = `
+  id name description content state progress
+  startDate targetDate url updatedAt
+  lead { id name }
+`;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(s: string): boolean {
+  return UUID_RE.test(s);
+}
+
+/** List every project accessible from the QUA team. */
+export async function listProjects(): Promise<LinearProject[]> {
+  const data = await linearGraphQL<{ projects: { nodes: LinearProject[] } }>(
+    `query Projects { projects(first: 100, filter: { accessibleTeams: { id: { eq: "${QUA_TEAM_ID}" } } }) { nodes { ${PROJECT_FIELDS} } } }`,
+    {},
+  );
+  return data.projects.nodes;
+}
+
+/**
+ * Resolve a project by UUID or exact name. Returns null if not found.
+ *
+ * Names are matched case-insensitively but must be exact — we don't do
+ * substring matching because projects often share words ("Source-Check &
+ * Verification" vs a hypothetical "Source Audit") and the wrong match is
+ * worse than a miss.
+ */
+export async function getProject(ref: string): Promise<LinearProject | null> {
+  if (isUuid(ref)) {
+    try {
+      const data = await linearGraphQL<{ project: LinearProject | null }>(
+        `query P($id: String!) { project(id: $id) { ${PROJECT_FIELDS} } }`,
+        { id: ref },
+      );
+      return data.project ?? null;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/Entity not found|EntityNotFound/i.test(msg)) return null;
+      throw e;
+    }
+  }
+
+  // Name lookup — fetch all and match case-insensitively.
+  const all = await listProjects();
+  const needle = ref.toLowerCase();
+  return all.find((p) => p.name.toLowerCase() === needle) ?? null;
+}
+
+export interface UpdateProjectInput {
+  name?: string;
+  description?: string;
+  content?: string;
+  state?: string;
+  startDate?: string;
+  targetDate?: string;
+}
+
+/**
+ * Update a project. Any omitted field is left unchanged.
+ *
+ * Note: Linear's `description` is a short one-line summary (shown in cards);
+ * `content` is the long-form markdown body rendered on the project page. You
+ * almost always want to update `content`, not `description`.
+ */
+export async function updateProject(
+  id: string,
+  input: UpdateProjectInput,
+): Promise<LinearProject> {
+  if (!isUuid(id)) {
+    throw new Error(`updateProject: expected UUID, got "${id}". Call getProject() first to resolve a name.`);
+  }
+  const data = await linearGraphQL<{
+    projectUpdate: { success: boolean; project: LinearProject };
+  }>(
+    `mutation U($id: String!, $input: ProjectUpdateInput!) {
+      projectUpdate(id: $id, input: $input) {
+        success
+        project { ${PROJECT_FIELDS} }
+      }
+    }`,
+    { id, input },
+  );
+  if (!data.projectUpdate.success) {
+    throw new Error(`Linear refused to update project ${id}`);
+  }
+  return data.projectUpdate.project;
+}
+
+/**
+ * Post a project update (Linear's equivalent of a comment on a project).
+ *
+ * Project updates are the status posts you see in the project timeline — they
+ * support markdown and are the right place to announce milestones or log
+ * audit passes.
+ */
+export async function createProjectUpdate(
+  id: string,
+  body: string,
+): Promise<void> {
+  if (!isUuid(id)) {
+    throw new Error(`createProjectUpdate: expected UUID, got "${id}". Call getProject() first to resolve a name.`);
+  }
+  const data = await linearGraphQL<{ projectUpdateCreate: { success: boolean } }>(
+    `mutation U($input: ProjectUpdateCreateInput!) {
+      projectUpdateCreate(input: $input) { success }
+    }`,
+    { input: { projectId: id, body } },
+  );
+  if (!data.projectUpdateCreate.success) {
+    throw new Error(`Linear refused to create project update on ${id}`);
+  }
+}
+
+/** Build a Linear project URL for display (the API already returns `url` but this is a convenience for constructed references). */
+export function linearProjectUrl(slug: string): string {
+  return `https://linear.app/${LINEAR_WORKSPACE_SLUG}/project/${slug}`;
+}

--- a/crux/lib/linear/projects.ts
+++ b/crux/lib/linear/projects.ts
@@ -42,13 +42,41 @@ function isUuid(s: string): boolean {
   return UUID_RE.test(s);
 }
 
-/** List every project accessible from the QUA team. */
+/**
+ * List every project accessible from the QUA team.
+ *
+ * Uses cursor-based pagination so the result is not capped at Linear's 100-item
+ * page limit. `getProject()` falls back to this function for name resolution,
+ * so any project beyond page 1 would be unreachable by name without pagination.
+ */
 export async function listProjects(): Promise<LinearProject[]> {
-  const data = await linearGraphQL<{ projects: { nodes: LinearProject[] } }>(
-    `query Projects { projects(first: 100, filter: { accessibleTeams: { id: { eq: "${QUA_TEAM_ID}" } } }) { nodes { ${PROJECT_FIELDS} } } }`,
-    {},
-  );
-  return data.projects.nodes;
+  const all: LinearProject[] = [];
+  let after: string | null = null;
+
+  do {
+    const data: {
+      projects: {
+        nodes: LinearProject[];
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      };
+    } = await linearGraphQL(
+      `query Projects($after: String) {
+        projects(
+          first: 100
+          after: $after
+          filter: { accessibleTeams: { id: { eq: "${QUA_TEAM_ID}" } } }
+        ) {
+          nodes { ${PROJECT_FIELDS} }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`,
+      { after },
+    );
+    all.push(...data.projects.nodes);
+    after = data.projects.pageInfo.hasNextPage ? data.projects.pageInfo.endCursor : null;
+  } while (after);
+
+  return all;
 }
 
 /**


### PR DESCRIPTION
## Summary

- New `crux linear project` subcommand group: `list`, `view`, `update`, `comment`. Refs accept either a Linear project UUID or a case-insensitive exact project name, so callers can type `"Content Quality & Enrichment"` without copy-pasting a UUID.
- `update` supports `--description`, `--content`, `--content-file`, `--name`, `--state`, `--start-date`, `--target-date`. `--content-file` takes precedence over inline `--content` for safe multiline input.
- `comment` creates a Linear project update (the markdown posts on the project timeline) — inline or `--body-file`.
- **Used immediately** to refresh all 6 active project descriptions + long-form content bodies with current focus (2026-04-13), umbrella-ticket links, and per-project context. Projects were last updated 2026-04-08 to 2026-04-11 and were stale after this week's reorg pass.

New files:
- `crux/lib/linear/projects.ts` — typed helpers (`listProjects`, `getProject`, `updateProject`, `createProjectUpdate`, `linearProjectUrl`)
- `crux/lib/linear/__tests__/projects.test.ts` — 13 tests, fully mocked `globalThis.fetch`

Modified:
- `crux/commands/linear.ts` — new `project` command, registered in the shared `commands` map and help text
- `crux/commands/__tests__/linear.test.ts` — 19 new tests covering list/view/update/comment subcommands (including `--content-file` precedence, empty-body rejection, unknown subcommands, and a full multi-field update)

## Test plan

- [x] `pnpm vitest run crux/lib/linear/ crux/commands/__tests__/linear.test.ts` — **152 tests pass** (34 existing linear + 18 new for `project`, 13 new lib tests)
- [x] `pnpm build` — passes
- [x] `pnpm crux w validate gate --fix` — all 50 gate checks pass (4 pre-existing advisories unrelated to this PR)
- [x] End-to-end dogfooding: ran `pnpm crux linear project update` on all 6 active projects with `--content-file` and `--description`; all succeeded. Verified content round-trips via `crux linear project view`.
- [x] `pnpm crux linear project list/view/update/comment --help` renders help correctly
- [x] Unknown subcommand prints help + exits 1; empty body rejected; not-found refs print a clean error

## Notes on the description refresh

Each project now has:
- A one-line description pointing at its umbrella ticket
- A long-form content body with current focus (URGENT/HIGH items listed by QUA-NNN), key subsystems, and a goal statement
- Links to the relevant `.claude/rules/` docs where applicable (page-authoring, source-check-system, validation-gate-system, entity-sync-pipeline, etc.)

Not touched:
- **Tablebase Route Systematization** (completed 100%, content intact)
- **AI Power & Influence Mapping** (97% progress, content already good)

Fixes QUA-357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linear project management commands: list, view, update, comment with help, usage examples and JSON output.
  * Accepts project refs by UUID or exact name; supports file-based input for content/body and validates required fields and UUIDs.

* **Tests**
  * Added comprehensive tests covering CLI behaviors, API interactions, pagination, input validation, and success/error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->