### PR TITLE
feat(flagship-curate): abort batch on Anthropic credit exhaustion (QUA-378)

### DIFF
--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -93,6 +93,9 @@ vi.mock('./sourcing-orchestrate.ts', () => ({
 // ── Import after mocks ─────────────────────────────────────────────────
 
 import { commands, formatSummaryMarkdown } from './flagship-curate.ts';
+import { CreditExhaustedError } from '../lib/resilience.ts';
+import { callLlm } from '../lib/llm.ts';
+import { orchestrateCommand } from './sourcing-orchestrate.ts';
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -374,6 +377,161 @@ describe('flagship-curate', () => {
       // Should not have tried to research or update anything
       expect(mockSuggestResources).not.toHaveBeenCalled();
       expect(mockSyncPersonnel).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Credit-exhaustion handling (QUA-378) ────────────────────────────
+  describe('credit exhaustion (QUA-378)', () => {
+    it('aborts with exit code 2 when research throws CreditExhaustedError', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'unchecked', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      // Make the research call fail with credit-exhausted on the first attempt.
+      (callLlm as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new CreditExhaustedError(
+          '400 invalid_request_error: Your credit balance is too low',
+          null,
+        ),
+      );
+
+      // Silence stderr for the abort banner.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '1',
+      });
+
+      expect(result.exitCode).toBe(2);
+      const bannerText = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(bannerText).toContain('ABORTED');
+      expect(bannerText).toContain('credit balance');
+      expect(bannerText).toContain('QUA-378');
+      // Reset at Step 4 must not have run (Step 2 threw before we got there).
+      expect(mockStoreVerdict).not.toHaveBeenCalled();
+    });
+
+    it('aborts with exit code 2 when verification output contains credit-balance error', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'unchecked', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+
+      // Make orchestrate-sourcing return output with the credit-exhausted
+      // fingerprint (simulating every per-item LLM call returning a 400).
+      (orchestrateCommand as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        exitCode: 0,
+        output:
+          '[1/1] RECORD Personnel: Alice\n' +
+          '  ERROR: LLM call failed: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."},"request_id":"req_X"}\n' +
+          'Verification complete. Cost: $0.000',
+      });
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '1',
+        // Skip research so we reach verification with an empty researched set.
+        'skip-research': true,
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(
+        errorSpy.mock.calls.map((c) => c.join(' ')).join('\n'),
+      ).toContain('ABORTED');
+    });
+
+    it('batch mode: halts remaining orgs after the first credit-exhausted org', async () => {
+      // Three candidate orgs; findEntitiesNeedingCuration fetches all and
+      // then sorts by non-confirmed verdict count. We give each the same
+      // count so order is stable (insertion order wins on ties).
+      mockApiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          entities: [
+            { id: 'alpha', stableId: 'sid_alpha', title: 'Alpha', entityType: 'organization' },
+            { id: 'bravo', stableId: 'sid_bravo', title: 'Bravo', entityType: 'organization' },
+            { id: 'charlie', stableId: 'sid_charlie', title: 'Charlie', entityType: 'organization' },
+          ],
+          total: 3,
+        },
+      });
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'unchecked', displayName: 'X' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+
+      // First call succeeds (alpha processes normally). Second call — during
+      // bravo's research — throws credit-exhausted. Everything after must
+      // be skipped without invoking callLlm again.
+      (callLlm as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          text: '[]',
+          usage: { input_tokens: 10, output_tokens: 10 },
+          model: 'claude-haiku-4-5-20251001',
+        })
+        .mockRejectedValueOnce(new CreditExhaustedError('credit balance is too low', null))
+        .mockImplementation(async () => {
+          throw new Error('callLlm should not be invoked after credit exhaustion');
+        });
+
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await commands.default([], {
+        all: true,
+        budget: '5',
+        limit: '3',
+        iterations: '1', // single-iteration so alpha completes on its one research call
+        ci: true,
+      });
+
+      expect(result.exitCode).toBe(2);
+      const json = JSON.parse(result.output);
+      expect(json.aborted).toBe('credit_exhausted');
+      // Alpha completed its one iteration; bravo threw during its research
+      // call; charlie never started. Both bravo (abandoned) and charlie
+      // (never started) count as skippedDueToCredits.
+      expect(json.results.length).toBe(1);
+      expect(json.results[0].entity).toBe('Alpha');
+      expect(json.skippedDueToCredits).toBe(2);
+    });
+
+    it('detects credit errors via the raw substring match (not just CreditExhaustedError instance)', async () => {
+      // If a caller forgets to wrap a raw error, the top-level batch loop
+      // still catches it via isCreditExhaustedError(). This guards against
+      // the "works in unit tests, fails in prod" drift.
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'unchecked', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      (callLlm as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        // NOT wrapped in CreditExhaustedError — raw 400 body
+        new Error(
+          '400 invalid_request_error: Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+        ),
+      );
+
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '1',
+      });
+
+      expect(result.exitCode).toBe(2);
     });
   });
 

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -23,6 +23,7 @@
 import type { CommandResult } from '../lib/command-types.ts';
 import { CostTracker } from '../lib/cost-tracker.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
+import { CreditExhaustedError, isCreditExhaustedError } from '../lib/resilience.ts';
 import { parseJsonResponse } from '../lib/anthropic.ts';
 import { getEntity, searchEntities } from '../lib/wiki-server/entities.ts';
 import { getPersonnelByEntity, syncPersonnel } from '../lib/wiki-server/personnel.ts';
@@ -365,6 +366,19 @@ If you cannot find a good URL for a record, omit it from the array.`;
       }
     }
   } catch (e: unknown) {
+    // Credit exhaustion must propagate so the batch loop can abort — any
+    // other error is a per-batch anomaly that shouldn't kill the rest of
+    // Step 2. Check both the typed error (expected) and the raw substring
+    // (defense-in-depth, in case a caller upstream forgot to wrap). See
+    // QUA-378.
+    if (isCreditExhaustedError(e)) {
+      throw e instanceof CreditExhaustedError
+        ? e
+        : new CreditExhaustedError(
+            e instanceof Error ? e.message : String(e),
+            e,
+          );
+    }
     console.warn(
       `${LOG_PREFIX} Research failed: ${e instanceof Error ? e.message : String(e)}`,
     );
@@ -527,6 +541,18 @@ async function runVerification(
   }
 
   const result = await orchestrateCommand([], options);
+
+  // Orchestrate-sourcing catches per-item LLM errors and writes them into
+  // result.output as "ERROR: LLM call failed: ...". If credits have run out,
+  // every record fails this way and the batch would otherwise march on. Scan
+  // the output for the credit-exhaustion fingerprint and surface it as a
+  // typed error so the batch loop can abort. See QUA-378.
+  if (isCreditExhaustedError(result.output)) {
+    throw new CreditExhaustedError(
+      'Anthropic credit balance too low (detected in verification output)',
+      null,
+    );
+  }
 
   // Parse verdict counts from output (best-effort)
   const verdictCounts: Record<string, number> = {};
@@ -987,8 +1013,18 @@ Options:
     }
   }
 
-  // Process each entity
+  // Process each entity. A CreditExhaustedError bubbling out of any call
+  // path below aborts the whole batch — billing errors aren't transient and
+  // continuing would just accumulate wasted no-op "runs" that look successful
+  // in the summary. See QUA-378.
+  let creditExhausted = false;
+  let skippedDueToCredits = 0;
   for (const entity of entities) {
+    if (creditExhausted) {
+      skippedDueToCredits++;
+      continue;
+    }
+
     // Check budget before starting a new entity
     if (tracker.totalCost >= budget) {
       console.log(`\n${c.yellow}Budget limit reached ($${tracker.totalCost.toFixed(3)} / $${budget.toFixed(2)}) — stopping.${c.reset}`);
@@ -1006,22 +1042,40 @@ Options:
     const costBefore = tracker.totalCost;
     const researchBefore = tracker.breakdown()['flagship-curate-research'] ?? 0;
 
-    const result = await curateEntity(entity, {
-      budget: entityBudget,
-      recordLimit,
-      tableFilter,
-      dryRun,
-      skipResearch,
-      iterations,
-      tracker,
-    });
+    try {
+      const result = await curateEntity(entity, {
+        budget: entityBudget,
+        recordLimit,
+        tableFilter,
+        dryRun,
+        skipResearch,
+        iterations,
+        tracker,
+      });
 
-    const researchAfter = tracker.breakdown()['flagship-curate-research'] ?? 0;
-    result.totalCost = tracker.totalCost - costBefore;
-    result.researchCost = researchAfter - researchBefore;
-    result.verifyCost = result.totalCost - result.researchCost;
+      const researchAfter = tracker.breakdown()['flagship-curate-research'] ?? 0;
+      result.totalCost = tracker.totalCost - costBefore;
+      result.researchCost = researchAfter - researchBefore;
+      result.verifyCost = result.totalCost - result.researchCost;
 
-    results.push(result);
+      results.push(result);
+    } catch (e: unknown) {
+      if (e instanceof CreditExhaustedError || isCreditExhaustedError(e)) {
+        // The current entity counts as "skipped" too — its work was
+        // abandoned mid-flight, not completed.
+        skippedDueToCredits++;
+        const remainingAfterThis = entities.length - results.length - skippedDueToCredits;
+        console.error(
+          `\n${c.bold}${c.red}✖ ABORTED: Anthropic credit balance is too low.${c.reset}\n` +
+          `  Halting batch during '${entity.title}'. ` +
+          `${remainingAfterThis} org${remainingAfterThis === 1 ? '' : 's'} will be skipped.\n` +
+          `  Top up credits and re-run. ${c.dim}(QUA-378)${c.reset}`,
+        );
+        creditExhausted = true;
+        continue;
+      }
+      throw e;
+    }
   }
 
   // Format output
@@ -1057,9 +1111,14 @@ Options:
     }
   }
 
+  // Exit non-zero when credit exhaustion halted the run. The summary and
+  // any partial results still go out on stdout, but CI / wrapper scripts
+  // can now distinguish "nothing to curate" (0) from "billing broken" (2).
+  const exitCode = creditExhausted ? 2 : 0;
+
   if (options.ci) {
     return {
-      exitCode: 0,
+      exitCode,
       output: JSON.stringify({
         results: results.map((r) => ({
           entity: r.entity.title,
@@ -1073,11 +1132,13 @@ Options:
         })),
         totalCost: tracker.totalCost,
         breakdown: tracker.breakdown(),
+        aborted: creditExhausted ? 'credit_exhausted' : undefined,
+        skippedDueToCredits,
       }, null, 2),
     };
   }
 
-  return { exitCode: 0, output };
+  return { exitCode, output };
 }
 
 // ── Exports ────────────────────────────────────────────────────────────

--- a/crux/lib/llm.ts
+++ b/crux/lib/llm.ts
@@ -556,4 +556,9 @@ export async function runLlmAgent(
 
 // Re-export commonly used dependencies so consumers don't need multiple imports
 export { MODELS } from './anthropic.ts';
-export { withRetry, startHeartbeat } from './resilience.ts';
+export {
+  withRetry,
+  startHeartbeat,
+  CreditExhaustedError,
+  isCreditExhaustedError,
+} from './resilience.ts';

--- a/crux/lib/resilience.test.ts
+++ b/crux/lib/resilience.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withRetry, CreditExhaustedError, isCreditExhaustedError } from './resilience.ts';
+
+describe('resilience', () => {
+  describe('isCreditExhaustedError', () => {
+    it('matches the exact Anthropic 400 body', () => {
+      const err = new Error(
+        'LLM call failed: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011"}',
+      );
+      expect(isCreditExhaustedError(err)).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isCreditExhaustedError(new Error('Credit Balance Is Too Low'))).toBe(true);
+    });
+
+    it('accepts a plain string', () => {
+      expect(isCreditExhaustedError('your credit balance is too low')).toBe(true);
+    });
+
+    it('recognises a CreditExhaustedError instance', () => {
+      expect(isCreditExhaustedError(new CreditExhaustedError('x', null))).toBe(true);
+    });
+
+    it('rejects unrelated errors', () => {
+      expect(isCreditExhaustedError(new Error('timeout'))).toBe(false);
+      expect(isCreditExhaustedError(new Error('429 rate_limit'))).toBe(false);
+      expect(isCreditExhaustedError(new Error('overloaded'))).toBe(false);
+      expect(isCreditExhaustedError(null)).toBe(false);
+      expect(isCreditExhaustedError(undefined)).toBe(false);
+    });
+  });
+
+  describe('withRetry', () => {
+    it('throws CreditExhaustedError on credit-balance errors without retrying', async () => {
+      const fn = vi.fn(async () => {
+        throw new Error(
+          '400 invalid_request_error: Your credit balance is too low to access the Anthropic API.',
+        );
+      });
+
+      await expect(withRetry(fn, { maxRetries: 3, label: 'test' })).rejects.toBeInstanceOf(
+        CreditExhaustedError,
+      );
+      // Credit errors are terminal — must not retry.
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves the original error on CreditExhaustedError', async () => {
+      const original = new Error('credit balance is too low');
+      const fn = vi.fn(async () => {
+        throw original;
+      });
+      try {
+        await withRetry(fn);
+        expect.fail('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(CreditExhaustedError);
+        expect((e as CreditExhaustedError).originalError).toBe(original);
+        expect((e as CreditExhaustedError).message).toContain('credit balance');
+      }
+    });
+
+    it('still retries transient errors (429, timeout, overloaded)', async () => {
+      let calls = 0;
+      const fn = vi.fn(async () => {
+        calls++;
+        if (calls < 2) throw new Error('timeout');
+        return 'ok';
+      });
+      const result = await withRetry(fn, { maxRetries: 2, label: 'test', onRetry: () => {} });
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws non-retryable non-credit errors immediately', async () => {
+      const fn = vi.fn(async () => {
+        throw new Error('invalid JSON response');
+      });
+      await expect(withRetry(fn, { maxRetries: 3 })).rejects.toThrow('invalid JSON response');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('CreditExhaustedError', () => {
+    it('has the expected name for instanceof-less checks', () => {
+      const err = new CreditExhaustedError('test', null);
+      expect(err.name).toBe('CreditExhaustedError');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/crux/lib/resilience.ts
+++ b/crux/lib/resilience.ts
@@ -15,6 +15,31 @@ export interface RetryOptions {
   onRetry?: (message: string) => void;
 }
 
+/**
+ * Thrown when the Anthropic API reports the account is out of credits.
+ * Non-retryable, non-recoverable — long batch jobs should catch this, abort
+ * remaining work, and exit non-zero instead of silently marching forward.
+ * See QUA-378.
+ */
+export class CreditExhaustedError extends Error {
+  readonly originalError: unknown;
+  constructor(message: string, originalError: unknown) {
+    super(message);
+    this.name = 'CreditExhaustedError';
+    this.originalError = originalError;
+  }
+}
+
+/** Matches the Anthropic 400 body returned when the account is out of credits. */
+const CREDIT_EXHAUSTED_PATTERN = /credit balance is too low/i;
+
+/** True if the value looks like an Anthropic credit-exhaustion error. */
+export function isCreditExhaustedError(err: unknown): boolean {
+  if (err instanceof CreditExhaustedError) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return CREDIT_EXHAUSTED_PATTERN.test(message);
+}
+
 const RETRYABLE_PATTERNS = [
   'timeout',
   'ECONNRESET',
@@ -39,6 +64,12 @@ export async function withRetry<T>(
       return await fn();
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
+      // Credit exhaustion is terminal — never retry, always surface as a
+      // typed error so batch runners can abort the whole run instead of
+      // per-call-catching and silently continuing.
+      if (isCreditExhaustedError(error)) {
+        throw new CreditExhaustedError(error.message, err);
+      }
       const isRetryable = RETRYABLE_PATTERNS.some((p) => error.message.includes(p));
       if (!isRetryable || attempt === maxRetries) throw err;
       const delay = Math.pow(2, attempt + 1) * 1000; // 2s, 4s


### PR DESCRIPTION
## Summary

Fixes [QUA-378](https://linear.app/quantifieduncertainty/issue/QUA-378). Makes `crux tb flagship-curate --all` **abort** when the Anthropic API returns `credit balance is too low` instead of silently marching through every remaining org.

## Incident context

2026-04-13 overnight run: `flagship-curate --all --budget=10 --limit=20` exhausted Anthropic credits at org 18/20 (ASML). The tool then:
- Logged ~15 per-record `400 credit balance is too low` errors for ASML
- Proceeded to Brookings (org 19) — ~15 more credit errors, $0.00 of real work done
- Proceeded to Conjecture (org 20) — same, $0.00 done
- Exited `0` with `Totals: 20 entities processed` as if healthy

The summary labeled the 3 skipped orgs as "no change" rather than "skipped due to API failure". Without reading the full log, the run looked successful.

## Fix

### `crux/lib/resilience.ts` — typed error at the retry choke point
- New `CreditExhaustedError` class + `isCreditExhaustedError()` helper
- `withRetry()` detects the `credit balance is too low` fingerprint and wraps the raw Anthropic error as `CreditExhaustedError` — **never retries** (credits don't replenish mid-run)
- Every `callLlm` / `streamLlmCall` / `runLlmAgent` / direct `streamingCreate` caller benefits automatically

### `crux/commands/flagship-curate.ts` — propagation + batch abort
- **Research step catch** re-throws credit errors instead of swallowing them at the per-batch boundary. Defense-in-depth: also catches raw substring matches in case a caller upstream forgot to wrap.
- **`runVerification`** scans `orchestrateCommand` output for the credit-exhaustion fingerprint (orchestrate-sourcing catches per-item LLM errors into `{ error: string }` results, so we can't rely on an exception from that layer). String-sniff → throw typed error.
- **Batch loop** wraps `curateEntity` in try/catch. On `CreditExhaustedError`:
  - Prints a clear abort banner naming which org was aborted and how many will be skipped
  - Sets `creditExhausted = true`, skips remaining orgs (incrementing `skippedDueToCredits`)
  - Returns `exitCode: 2` (not `0`) so CI / wrapper scripts can distinguish billing failure from "nothing to curate"
- **CI JSON output** now includes `aborted: "credit_exhausted"` and `skippedDueToCredits` for parsers

### Design decisions
- **Fail-fast (N=1) instead of N-consecutive (ticket suggested N=5)**: credits don't replenish mid-run, so a counter just wastes more money before the same abort fires.
- **Detection at `withRetry`, not `callLlm`**: single choke point for all LLM consumers.
- **String-sniff for verification** rather than threading a typed throw through `orchestrate-sourcing`'s per-item aggregation — that layer would need a broader refactor. Surgical workaround until then.

## Tests

**`crux/lib/resilience.test.ts`** (new, 10 cases):
- `isCreditExhaustedError` detection across Error instances, plain strings, case variations, null/undefined
- `withRetry` throws `CreditExhaustedError` for credit errors **without retrying** (asserts `fn.toHaveBeenCalledTimes(1)`)
- `withRetry` still retries 429/timeout/overloaded
- `withRetry` still throws non-credit non-retryable errors immediately
- `CreditExhaustedError` preserves `originalError` for debugging

**`crux/commands/flagship-curate.test.ts`** (4 new cases):
- Research throws → `exitCode === 2`, abort banner mentions `QUA-378`, Step 4 reset **did not run** (error happened before it)
- Verification output containing `credit balance is too low` → `exitCode === 2`
- Batch `--all` with 3 orgs: alpha completes, bravo throws, charlie skipped → `results.length === 1`, `skippedDueToCredits === 2`, `aborted === 'credit_exhausted'`, exit 2
- Raw (unwrapped) 400 body is caught at the batch layer via `isCreditExhaustedError` substring match — guards against "works in unit tests, fails in prod" drift

**All 42 tests pass** (10 resilience + 32 flagship-curate).

## Verification

- [x] `pnpm vitest run crux/lib/resilience.test.ts crux/commands/flagship-curate.test.ts` → **42/42 pass**
- [x] `pnpm crux w validate gate --fix` → **50/50 checks pass** (4 advisory warnings are pre-existing)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — baseline of 100 pre-existing errors **unchanged**; my files clean except for line 463 `forceSkipSourceCheck` which is [QUA-337](https://linear.app/quantifieduncertainty/issue/QUA-337) (already In Progress, unrelated)
- [x] `npx tsc --noEmit -p apps/web` → clean
- [x] No cross-package blast radius: `crux/lib/resilience.ts` is only imported from within `crux/`

## Observed this session

- `fixed` (this PR) — credit-exhaustion silent fall-through in flagship-curate
- `filed:QUA-379` — summary mislabels regressions as "no change"
- `filed:QUA-382` — Step 4 reset must be atomic with Step 5 re-verify (the deeper root cause)
- `filed:QUA-383` — research Step 2 silently drops records when LLM returns prose
- `deferred` — 4 pre-existing failures in `crux/wiki-server/snapshot-resources.test.ts` (data-quality thresholds on resource snapshot; unrelated to this PR, not touched). Worth a separate ticket if not already tracked.
- `deferred` — pre-existing crux typecheck baseline of 100 errors. Unchanged by this PR.

## Test plan

- [x] Unit tests green
- [x] Full validation gate green
- [x] TypeScript clean on touched files
- [ ] CI green on push
- [ ] Next time credits run out, batch aborts cleanly instead of silently continuing

Fixes QUA-378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credit exhaustion detection in batch operations. When API credits are depleted, the system now exits with code 2 and automatically skips remaining items instead of attempting to process them.
  * Improved error reporting in JSON output with abort status and count of skipped items, providing better visibility into batch operation failures due to credit limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->