### PR TITLE
fix(sourcing): unbreak main CI by aligning concurrency.ts comment with ratchet (QUA-390)

### DIFF
--- a/crux/lib/sourcing/concurrency.ts
+++ b/crux/lib/sourcing/concurrency.ts
@@ -1,5 +1,5 @@
 /**
- * Concurrency guard for source-check pipelines (QUA-150).
+ * Concurrency guard for sourcing pipelines (QUA-150).
  *
  * On 2026-04-09, running the sourcing orchestrator with `--concurrency=20`
  * overwhelmed the wiki-server with concurrent writes and tripped the


### PR DESCRIPTION
## Summary

One-line doc-comment fix to unblock main CI. PR #4276 (QUA-150) introduced a new `source-check` literal in the module header comment of `crux/lib/sourcing/concurrency.ts`, bumping the `validate-sourcing-lint-guard` ratchet total from 1 → 2 and failing the baseline test on every subsequent commit to `main`. The ratchet baseline is frozen at 1 per QUA-358 / QUA-303 (the single remaining reference is a Drizzle column binding gated on the `source_checked_at` rename). The fix aligns the doc comment with the "sourcing" terminology the ratchet exists to enforce.

## Root cause

- Commit `46c460e03` (PR #4276) introduced the comment "Concurrency guard for source-check pipelines (QUA-150)" in the new file `crux/lib/sourcing/concurrency.ts`.
- That file is inside the ratchet's scan scope (`crux/`), is not in the skip list, and is not a `.test.ts` file — so the new literal counted.
- Ratchet test at `crux/validate/validate-sourcing-lint-guard.test.ts:131` began failing: `runCheck().passed === false` on every main commit after `46c460e0`, including `7ed92500`, `403b999f`, `09e52667`, `1e1f9c8f`.
- Downstream effect: patrol health-gate correctly flagged `main-ci-red` with a 4-commit streak; auto-file watcher also opened QUA-389 and QUA-390 for the cascade.

## Fix

Change the doc comment from "source-check pipelines" → "sourcing pipelines". The module is already under `crux/lib/sourcing/`, so the updated terminology is self-consistent.

## Why not bump the baseline?

The baseline notes explicitly say: "Driving total below 1 requires renaming that column, which is gated by QUA-303 (DO NOT START YET)." The single reference the baseline permits is the `sourceCheckedAt` Drizzle binding on `claim_sources.source_checked_at`. Bumping the baseline to 2 to accommodate a doc comment would mask the exact regressions the ratchet exists to catch.

## Verification

```
$ npx tsx crux/validate/validate-sourcing-lint-guard.ts
At baseline (1 references across 1458 files)
  1458 files scanned

$ pnpm vitest run crux/validate/validate-sourcing-lint-guard.test.ts
✓ 14 tests passed
```

## Test plan

- [x] Ratchet passes locally
- [x] Unit tests pass locally
- [ ] Main CI green after merge (fleet-level health-gate clears)

Fixes QUA-390
Fixes QUA-389
