### PR TITLE
fix(sourcing): rename legacy source-check terms in orphan cleanup comments (QUA-390)

### DIFF
--- a/crux/commands/sourcing-cleanup-orphans.ts
+++ b/crux/commands/sourcing-cleanup-orphans.ts
@@ -1,7 +1,7 @@
 /**
- * Source-Check Orphan Cleanup (QUA-149)
+ * Sourcing Orphan Cleanup (QUA-149)
  *
- * Deletes source-check verdict / evidence / url-suggestion rows whose record
+ * Deletes sourcing verdict / evidence / url-suggestion rows whose record
  * no longer exists in its source table. Dashboard queries already filter these
  * out at read time, but the raw COUNT(*)s (e.g., 1002 personnel verdicts for
  * 724 records) are what made the coverage matrix show nonsense like 127%.

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -98,7 +98,7 @@ export async function getSourcingStats(): Promise<ApiResult<SourcingStatsResult>
 }
 
 /**
- * Clean up orphaned source-check rows for deleted records (QUA-149).
+ * Clean up orphaned sourcing rows for deleted records (QUA-149).
  *
  * `dryRun` defaults to true — callers must pass `dryRun: false` explicitly
  * to delete. `recordType` scopes cleanup to a single type.


### PR DESCRIPTION
## Summary
- Renames 2 `source-check` legacy terms in doc comments to `sourcing`
- Fixes `validate-sourcing-lint-guard.test.ts` failing on main CI (ratchet rose from 1 to 3)
- Both references were introduced in PR #4273; PR #4286 (QUA-390) fixed one in concurrency.ts but missed these two

## Root cause
PR #4273 (`qua-149-orphaned-source-check-verdicts`) added:
- `sourcing-client.ts:101` — doc comment "Clean up orphaned **source-check** rows"
- `sourcing-cleanup-orphans.ts:2,4` — module header "**Source-Check** Orphan Cleanup" + "Deletes **source-check** verdict"

PR #4286 fixed a different occurrence but missed these two, leaving the total at 3 vs the baseline of 1.

## Test plan
- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` passes at baseline (1 reference)
- [x] Gate checks pass (43/43 blocking checks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)