### PR TITLE
fix(flagship-curate): guard Step 4 reset on Step 3 success and Step 5 budget (QUA-382)

### DIFF
--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -25,6 +25,17 @@ const mockStoreVerdict = vi.fn();
 const mockApiRequest = vi.fn();
 const mockSuggestResources = vi.fn();
 const mockCommentOnIssue = vi.fn();
+// Hoisted so the `vi.mock('../lib/llm.ts', ...)` factory (itself hoisted to
+// the top of the file) can reference it directly. The QUA-378 tests cast the
+// imported `callLlm` symbol to a vi.fn and call `.mockRejectedValueOnce()` on
+// it — that only works if `callLlm` IS the hoisted vi.fn, not a wrapper.
+const { mockCallLlm } = vi.hoisted(() => ({
+  mockCallLlm: vi.fn(async () => ({
+    text: '[]',
+    usage: { input_tokens: 100, output_tokens: 50 },
+    model: 'claude-haiku-4-5-20251001',
+  })),
+}));
 
 vi.mock('../lib/wiki-server/entities.ts', () => ({
   getEntity: (...args: unknown[]) => mockGetEntity(...args),
@@ -62,11 +73,7 @@ vi.mock('../lib/llm.ts', async (importOriginal) => {
   return {
     ...actual,
     createLlmClient: vi.fn(() => ({})),
-    callLlm: vi.fn(async () => ({
-      text: '[]', // empty research results
-      usage: { input_tokens: 100, output_tokens: 50 },
-      model: 'claude-haiku-4-5-20251001',
-    })),
+    callLlm: mockCallLlm,
     MODELS: { haiku: 'claude-haiku-4-5-20251001', sonnet: 'claude-sonnet-4-6', opus: 'claude-opus-4-6' },
   };
 });
@@ -153,6 +160,12 @@ function makePersonnel(items: Array<{ id: string; source?: string; displayName?:
 describe('flagship-curate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the callLlm mock to its default empty-array response.
+    mockCallLlm.mockImplementation(async () => ({
+      text: '[]',
+      usage: { input_tokens: 100, output_tokens: 50 },
+      model: 'claude-haiku-4-5-20251001',
+    }));
     // Suppress console output during tests
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -532,6 +545,220 @@ describe('flagship-curate', () => {
       });
 
       expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe('Step 4 reset guard (QUA-382)', () => {
+    // Helper: set up an entity with 3 records that all need curation. All
+    // three have verdict=partial so discoverRecordsNeedingCuration preserves
+    // their insertion order when passing them to the research step.
+    // The research LLM returns URLs for indexes 0 and 1, skipping index 2.
+    function setupThreeRecordScenario() {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'partial', displayName: 'Alice' },
+          { recordType: 'personnel', recordId: 'p2', verdict: 'partial', displayName: 'Bob' },
+          { recordType: 'personnel', recordId: 'p3', verdict: 'partial', displayName: 'Carol' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(
+        makePersonnel([{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }]),
+      );
+      mockSyncPersonnel.mockResolvedValue({ ok: true, data: { updated: 2 } });
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+      // Research LLM: return URLs for p1 (index 0) and p2 (index 1), skip p3.
+      mockCallLlm.mockResolvedValue({
+        text: JSON.stringify([
+          { index: 0, urls: ['https://example.com/alice'], reasoning: 'Team page' },
+          { index: 1, urls: ['https://example.com/bob'], reasoning: 'Team page' },
+        ]),
+        usage: { input_tokens: 100, output_tokens: 50 },
+        model: 'claude-haiku-4-5-20251001',
+      });
+    }
+
+    function resetCalls() {
+      return mockStoreVerdict.mock.calls
+        .map((call) => call[0] as { recordId: string; verdict: string } | undefined)
+        .filter((arg) => arg?.verdict === 'unchecked');
+    }
+
+    it('resets only records whose URLs were successfully ingested in Step 3', async () => {
+      setupThreeRecordScenario();
+      // p1 URL succeeds, p2 URL fails.
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'ok', contentLength: 100, title: 'Alice' },
+          { url: 'https://example.com/bob', resourceId: 'r2', status: 'error', contentLength: 0, title: null },
+        ],
+        fetchedCount: 1,
+        cachedCount: 0,
+        errorCount: 1,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      const resets = resetCalls();
+      const resetIds = resets.map((r) => r!.recordId).sort();
+      // Only p1 should be reset. p2's URL errored, p3 had no URL.
+      expect(resetIds).toEqual(['p1']);
+    });
+
+    it('skips Step 4 entirely when Step 3 produces no successful ingests', async () => {
+      setupThreeRecordScenario();
+      // All URLs fail.
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'error', contentLength: 0, title: null },
+          { url: 'https://example.com/bob', resourceId: 'r2', status: 'error', contentLength: 0, title: null },
+        ],
+        fetchedCount: 0,
+        cachedCount: 0,
+        errorCount: 2,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
+    });
+
+    it('skips Step 4 entirely when suggestResources throws', async () => {
+      setupThreeRecordScenario();
+      mockSuggestResources.mockRejectedValue(new Error('firecrawl not installed'));
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
+    });
+
+    it('skips Step 4 entirely when Step 2 research returns no URLs', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'partial', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+      // Research LLM returns empty array — no new URLs.
+      mockCallLlm.mockResolvedValue({
+        text: '[]',
+        usage: { input_tokens: 100, output_tokens: 50 },
+        model: 'claude-haiku-4-5-20251001',
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockSuggestResources).not.toHaveBeenCalled();
+      expect(resetCalls()).toEqual([]);
+    });
+
+    it('--skip-research resets all eligible records (no Step 3 gate)', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'partial', displayName: 'Alice' },
+          { recordType: 'personnel', recordId: 'p2', verdict: 'unverifiable', displayName: 'Bob' },
+          { recordType: 'personnel', recordId: 'p3', verdict: 'confirmed', displayName: 'Carol' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(
+        makePersonnel([{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }]),
+      );
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        'skip-research': true,
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      // suggestResources must not have been called — research was skipped.
+      expect(mockSuggestResources).not.toHaveBeenCalled();
+      // p1 (partial) and p2 (unverifiable) reset; p3 (confirmed) is excluded
+      // before reset because it doesn't appear in records-needing-curation.
+      const resetIds = resetCalls().map((r) => r!.recordId).sort();
+      expect(resetIds).toEqual(['p1', 'p2']);
+    });
+
+    it('skips Step 4 entirely when the verify budget is exhausted', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'partial', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+      // Research LLM burns the entire budget so verifyBudget ends up ≤ 0.
+      mockCallLlm.mockResolvedValue({
+        text: JSON.stringify([
+          { index: 0, urls: ['https://example.com/alice'], reasoning: 'Team page' },
+        ]),
+        usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        model: 'claude-haiku-4-5-20251001',
+      });
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'ok', contentLength: 100, title: 'Alice' },
+        ],
+        fetchedCount: 1,
+        cachedCount: 0,
+        errorCount: 0,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '0.0001', // too small — verifyBudget drops to ≤ 0 after research
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
+    });
+
+    it('does not reset contradicted records (only unverifiable/partial/outdated are resettable)', async () => {
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'contradicted', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        'skip-research': true,
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
     });
   });
 

--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -704,6 +704,57 @@ describe('flagship-curate', () => {
       expect(resetIds).toEqual(['p1', 'p2']);
     });
 
+    it('treats fresh-cache hits (status=ok, contentLength=null) as successful', async () => {
+      // The cached path in suggest-resources.ts returns status 'ok' with
+      // contentLength null (content exists but wasn't re-fetched, so length
+      // is unknown). These should still count as successful ingests.
+      setupThreeRecordScenario();
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'ok', contentLength: null, title: 'Alice (cached)' },
+          { url: 'https://example.com/bob', resourceId: 'r2', status: 'ok', contentLength: null, title: 'Bob (cached)' },
+        ],
+        fetchedCount: 0,
+        cachedCount: 2,
+        errorCount: 0,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      const resetIds = resetCalls().map((r) => r!.recordId).sort();
+      expect(resetIds).toEqual(['p1', 'p2']);
+    });
+
+    it('treats paywall and dead statuses as failures (records not reset)', async () => {
+      // Records whose URLs all came back as paywall/dead should not be
+      // reset — the verifier may reject paywall content and strand them
+      // at 'unchecked', which is the original QUA-382 bug.
+      setupThreeRecordScenario();
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'paywall', contentLength: 500, title: 'Alice' },
+          { url: 'https://example.com/bob', resourceId: 'r2', status: 'dead', contentLength: 0, title: null },
+        ],
+        fetchedCount: 0,
+        cachedCount: 0,
+        errorCount: 0,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
+    });
+
     it('skips Step 4 entirely when the verify budget is exhausted', async () => {
       mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
       mockGetVerdictsByEntity.mockResolvedValue(
@@ -734,6 +785,32 @@ describe('flagship-curate', () => {
         entity: 'anthropic',
         budget: '0.0001', // too small — verifyBudget drops to ≤ 0 after research
         iterations: '1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(resetCalls()).toEqual([]);
+    });
+
+    it('guard still applies across multiple iterations (iterations=2)', async () => {
+      // With iterations=2, the guard must hold on both passes: Step 4 of
+      // iteration 2 must still only reset records that got new sources in
+      // iteration 2's own Step 3. Here Step 3 fails on both iterations, so
+      // no resets should ever fire.
+      setupThreeRecordScenario();
+      mockSuggestResources.mockResolvedValue({
+        resources: [
+          { url: 'https://example.com/alice', resourceId: 'r1', status: 'error', contentLength: 0, title: null },
+          { url: 'https://example.com/bob', resourceId: 'r2', status: 'error', contentLength: 0, title: null },
+        ],
+        fetchedCount: 0,
+        cachedCount: 0,
+        errorCount: 2,
+      });
+
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        iterations: '2',
       });
 
       expect(result.exitCode).toBe(0);

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -389,16 +389,29 @@ If you cannot find a good URL for a record, omit it from the array.`;
 
 // ── Source Registration & Ingest ────────────────────────────────────────
 
+interface IngestResult {
+  registered: number;
+  ingested: number;
+  errors: number;
+  /**
+   * Record IDs that had at least one URL successfully registered and ingested
+   * (fresh from cache or freshly fetched with status='ok'). Only these records
+   * are safe to reset in Step 4 — records whose URLs all errored out would lose
+   * their prior verdicts for no gain.
+   */
+  successfulRecordIds: Set<string>;
+}
+
 /**
  * Register discovered URLs as resources and wait for content ingestion.
  */
 async function registerAndIngestSources(
   researched: ResearchedSource[],
   entityId: string,
-): Promise<{ registered: number; ingested: number; errors: number }> {
+): Promise<IngestResult> {
   const allUrls = researched.flatMap((r) => r.urls);
   if (allUrls.length === 0) {
-    return { registered: 0, ingested: 0, errors: 0 };
+    return { registered: 0, ingested: 0, errors: 0, successfulRecordIds: new Set() };
   }
 
   // Deduplicate
@@ -417,16 +430,29 @@ async function registerAndIngestSources(
     const ingested = result.fetchedCount + result.cachedCount;
     const errors = result.errorCount;
 
+    // Map URL -> suggest-resources status so we can tell which records got
+    // *something* usable back.
+    const urlStatus = new Map<string, string>();
+    for (const r of result.resources) {
+      urlStatus.set(r.url, r.status);
+    }
+
+    const successfulRecordIds = new Set<string>();
+    for (const r of researched) {
+      const anyOk = r.urls.some((u) => urlStatus.get(u) === 'ok');
+      if (anyOk) successfulRecordIds.add(r.recordId);
+    }
+
     console.log(
-      `  Registered: ${registered} | Ingested: ${ingested} | Cached: ${result.cachedCount} | Errors: ${errors}`,
+      `  Registered: ${registered} | Ingested: ${ingested} | Cached: ${result.cachedCount} | Errors: ${errors} | Records with new sources: ${successfulRecordIds.size}`,
     );
 
-    return { registered, ingested, errors };
+    return { registered, ingested, errors, successfulRecordIds };
   } catch (e: unknown) {
     console.warn(
       `${LOG_PREFIX} Source registration failed: ${e instanceof Error ? e.message : String(e)}`,
     );
-    return { registered: 0, ingested: 0, errors: uniqueUrls.length };
+    return { registered: 0, ingested: 0, errors: uniqueUrls.length, successfulRecordIds: new Set() };
   }
 }
 
@@ -483,15 +509,21 @@ async function updatePersonnelSources(
 /**
  * Reset stale verdicts (unverifiable/partial/outdated) to unchecked
  * so the verification pass rechecks them with the new sources.
+ *
+ * If `allowedRecordIds` is provided, only records whose IDs are in that set
+ * will be reset. Pass `null` to allow all records (used in `--skip-research`
+ * mode where the user explicitly opted in to re-verify existing sources).
  */
 async function resetStaleVerdicts(
   records: RecordNeedingCuration[],
+  allowedRecordIds: Set<string> | null,
 ): Promise<number> {
   let resetCount = 0;
   const resettable = new Set(['unverifiable', 'partial', 'outdated']);
 
   for (const record of records) {
     if (!resettable.has(record.verdict)) continue;
+    if (allowedRecordIds !== null && !allowedRecordIds.has(record.recordId)) continue;
 
     try {
       await storeVerdict({
@@ -691,9 +723,10 @@ async function curateEntity(
     }
 
     // Step 3: Register new sources and wait for ingest
+    let ingestResult: IngestResult | null = null;
     if (researched.length > 0) {
       console.log(`\n  ${c.bold}Step 3: Registering and ingesting sources...${c.reset}`);
-      await registerAndIngestSources(researched, entity.stableId);
+      ingestResult = await registerAndIngestSources(researched, entity.stableId);
 
       // Step 3b: Update personnel records with new source URLs
       const updatedCount = await updatePersonnelSources(entity, researched, records);
@@ -704,13 +737,38 @@ async function curateEntity(
       console.log(`\n  ${c.bold}Step 3: No new sources to register${c.reset}`);
     }
 
-    // Step 4: Reset stale verdicts
-    console.log(`\n  ${c.bold}Step 4: Resetting stale verdicts...${c.reset}`);
-    const resetCount = await resetStaleVerdicts(records);
-    console.log(`  Reset ${resetCount} verdicts to unchecked`);
+    // Step 5 budget — computed before Step 4 so we don't reset records we
+    // have no budget to re-verify.
+    const verifyBudget = Math.min(budget - tracker.totalCost, 2.0); // Cap per-entity verify at $2
+
+    // Step 4: Reset stale verdicts — atomically guarded on Step 3 success and
+    // Step 5 budget availability. See QUA-382.
+    //
+    // Eligibility rules:
+    //   * `--skip-research`: reset everything (user opted in to re-verify
+    //     existing sources)
+    //   * Otherwise: only reset records whose URLs were successfully ingested
+    //     by Step 3. If no record got new sources, skip the reset entirely.
+    //   * In either case: if Step 5 has no budget, skip the reset — a reset
+    //     without re-verification strictly degrades the entity.
+    if (verifyBudget <= 0) {
+      console.log(`\n  ${c.bold}Step 4: Skipping reset (no verify budget — would strand records at unchecked)${c.reset}`);
+    } else if (skipResearch) {
+      console.log(`\n  ${c.bold}Step 4: Resetting stale verdicts (--skip-research mode)...${c.reset}`);
+      const resetCount = await resetStaleVerdicts(records, null);
+      console.log(`  Reset ${resetCount} verdicts to unchecked`);
+    } else {
+      const allowed = ingestResult?.successfulRecordIds ?? new Set<string>();
+      if (allowed.size === 0) {
+        console.log(`\n  ${c.bold}Step 4: Skipping reset (no records got new sources from Step 3)${c.reset}`);
+      } else {
+        console.log(`\n  ${c.bold}Step 4: Resetting stale verdicts for ${allowed.size} records with new sources...${c.reset}`);
+        const resetCount = await resetStaleVerdicts(records, allowed);
+        console.log(`  Reset ${resetCount} verdicts to unchecked`);
+      }
+    }
 
     // Step 5: Run verification
-    const verifyBudget = Math.min(budget - tracker.totalCost, 2.0); // Cap per-entity verify at $2
     if (verifyBudget > 0) {
       console.log(`\n  ${c.bold}Step 5: Running sourcing verification ($${verifyBudget.toFixed(2)} budget)...${c.reset}`);
       const verifyResult = await runVerification(entity, verifyBudget, recordLimit, tableFilter);

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -394,10 +394,15 @@ interface IngestResult {
   ingested: number;
   errors: number;
   /**
-   * Record IDs that had at least one URL successfully registered and ingested
-   * (fresh from cache or freshly fetched with status='ok'). Only these records
-   * are safe to reset in Step 4 — records whose URLs all errored out would lose
-   * their prior verdicts for no gain.
+   * Record IDs that had at least one URL come back with status='ok' from
+   * suggestResources — i.e. freshly fetched OR fresh-cache hits (the cached
+   * path in suggest-resources.ts coerces to status 'ok' with contentLength
+   * null). Only these records are safe to reset in Step 4.
+   *
+   * Intentionally excluded: 'error' | 'paywall' | 'dead'. Content is missing
+   * or unusable for those — resetting would let the verifier re-run against
+   * nothing and strand the record at 'unchecked' (the original QUA-382 bug).
+   * If paywall-detected records ever become safe to re-verify, revisit.
    */
   successfulRecordIds: Set<string>;
 }


### PR DESCRIPTION
## Summary

`flagship-curate` Step 4 (`resetStaleVerdicts`) was unconditionally resetting `unverifiable/partial/outdated` verdicts to `unchecked`, regardless of whether Step 2 (research) found URLs, Step 3 (source ingest) actually succeeded, or Step 5 (verify) had any budget. If any of those failed, records were stranded at `unchecked` with no rollback — the entity was left strictly worse off than before the run.

Observed on the 2026-04-13 Anthropic run: 15 records reset to `unchecked` while Step 3 had `firecrawl not installed` and Step 5 was killed.

## Fix

Option B from the issue: guard Step 4 on (a) whether Step 3 actually produced successful ingests, per-record, and (b) whether Step 5 has budget.

- `registerAndIngestSources` now returns `successfulRecordIds: Set<string>` — derived from `suggestResources` URL-level results where `status === 'ok'` (covers fresh fetches *and* fresh-cache hits).
- `paywall | dead | error` are intentionally excluded — resetting would let the verifier run against missing/partial content and re-strand the record at `unchecked` (the original bug). Documented on `IngestResult.successfulRecordIds`.
- `resetStaleVerdicts` takes an optional `allowedRecordIds` filter. `null` = reset everything (used by `--skip-research`).
- Step 4 is now guarded by three conditions, evaluated in order:
  1. `verifyBudget <= 0` → skip entirely (no point resetting if Step 5 can't run)
  2. `--skip-research` → reset everything (user explicitly opted in to re-verify existing sources)
  3. Otherwise → reset only records whose URLs were successfully ingested; skip entirely if none
- `verifyBudget` is now computed *before* Step 4 (was after — another latent bug in the same block).

## Test plan

- [x] `pnpm test` — 42 unit tests in `flagship-curate.test.ts`, 10 new covering:
  - Per-record filter (one URL succeeds, one fails → only the success is reset)
  - All Step 3 URLs fail → Step 4 skipped entirely
  - `suggestResources` throws → Step 4 skipped entirely
  - Research returns no URLs → Step 4 skipped entirely
  - `--skip-research` pass-through → all eligible records reset
  - `verifyBudget <= 0` → Step 4 skipped entirely
  - Fresh-cache hits (`status='ok'`, `contentLength=null`) → treated as successful
  - Paywall/dead statuses → treated as failures
  - Multi-iteration (`iterations=2`) → guard holds on both passes
  - (Existing) `contradicted` records never reset
- [x] `pnpm build` passes
- [x] `pnpm crux w validate gate` passes
- [x] `/agent-review-pr` — hostile review found + fixed: paywall/dead docs, cache-path test, paywall test, multi-iter test

## Linear

Fixes QUA-382

## Related

- QUA-378 (credit exhaustion abort) — companion fix, merged
- QUA-379 (summary mislabels regressions) — companion, separate
- QUA-113 / QUA-114 — past and future regression work
