### PR TITLE
feat(sourcing): batch evidence endpoint POST /evidence/by-records (QUA-331)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for POST /api/sourcing/evidence/by-records (QUA-331).
+ *
+ * Batch evidence lookup replaces N+1 HTTP calls in three crux commands
+ * (sourcing-suggest-urls, sourcing-audit-urls, sourcing-recheck). The
+ * endpoint groups requested records by recordType and issues one `IN (...)`
+ * query per type.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson, type SqlDispatcher } from "./test-utils.js";
+
+interface EvidenceRow {
+  id: number;
+  record_type: string;
+  record_id: string;
+  field_name: string | null;
+  entity_id: string | null;
+  expected_value: string | null;
+  resource_id: string | null;
+  source_url: string | null;
+  extracted_value: string | null;
+  extracted_quote: string | null;
+  verdict: string;
+  confidence: number | null;
+  is_primary_source: boolean;
+  checker_model: string | null;
+  notes: string | null;
+  checked_at: Date;
+}
+
+let store: EvidenceRow[];
+
+function reset(): void {
+  store = [];
+}
+
+function seed(overrides: Partial<EvidenceRow> = {}): EvidenceRow {
+  const now = new Date();
+  const row: EvidenceRow = {
+    id: store.length + 1,
+    record_type: "fact",
+    record_id: "F1",
+    field_name: null,
+    entity_id: "anthropic",
+    expected_value: null,
+    resource_id: null,
+    source_url: "https://example.com/a",
+    extracted_value: null,
+    extracted_quote: null,
+    verdict: "confirmed",
+    confidence: 0.9,
+    is_primary_source: false,
+    checker_model: "claude-haiku-4-5-20251001",
+    notes: null,
+    checked_at: now,
+    ...overrides,
+  };
+  store.push(row);
+  return row;
+}
+
+const dispatch: SqlDispatcher = (query, params) => {
+  const q = query.toLowerCase().trim();
+
+  // Only the evidence-by-records handler issues SELECTs against
+  // source_check_evidence in this test suite.
+  if (
+    q.startsWith("select") &&
+    q.includes("from") &&
+    q.includes("source_check_evidence")
+  ) {
+    // Dispatcher reads parameters positionally. For the batch handler the
+    // shape is: $1 = recordType, $2...$N = recordIds in `inArray`.
+    const [recordType, ...recordIds] = params as [string, ...string[]];
+    return store
+      .filter(
+        (r) =>
+          r.record_type === recordType &&
+          recordIds.includes(r.record_id),
+      )
+      .sort((a, b) => {
+        // sourceUrl ASC, checked_at DESC — matches the handler's orderBy.
+        const urlA = a.source_url ?? "";
+        const urlB = b.source_url ?? "";
+        if (urlA !== urlB) return urlA < urlB ? -1 : 1;
+        return b.checked_at.getTime() - a.checked_at.getTime();
+      });
+  }
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { sourcingRoute } = await import("../routes/sourcing/sourcing.js");
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/", sourcingRoute);
+  return app;
+}
+
+const PATH = "/evidence/by-records";
+
+describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
+  beforeEach(() => {
+    reset();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  });
+
+  it("rejects invalid JSON", async () => {
+    const res = await buildApp().request(PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_json");
+  });
+
+  it("rejects empty records array", async () => {
+    const res = await postJson(buildApp(), PATH, { records: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing records field", async () => {
+    const res = await postJson(buildApp(), PATH, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects batches over MAX_EVIDENCE_BY_RECORDS (1000)", async () => {
+    const records = Array.from({ length: 1001 }, (_, i) => ({
+      recordType: "fact",
+      recordId: `F${i}`,
+    }));
+    const res = await postJson(buildApp(), PATH, { records });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects oversized recordId", async () => {
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "x".repeat(501) }],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid limitPerRecord (negative)", async () => {
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "F1" }],
+      limitPerRecord: -1,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty evidenceByKey when no records match", async () => {
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "does-not-exist" }],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, unknown[]>;
+      currentCheckerModel: string;
+    };
+    expect(body.evidenceByKey).toEqual({});
+    expect(body.currentCheckerModel).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("returns evidence keyed by `recordType|recordId` for matching records", async () => {
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
+    seed({ record_type: "fact", record_id: "F2", source_url: "https://example.com/b" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F2" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
+    };
+    expect(Object.keys(body.evidenceByKey).sort()).toEqual(["fact|F1", "fact|F2"]);
+    expect(body.evidenceByKey["fact|F1"][0].sourceUrl).toBe("https://example.com/a");
+    expect(body.evidenceByKey["fact|F2"][0].sourceUrl).toBe("https://example.com/b");
+  });
+
+  it("returns partial matches when only some records have evidence", async () => {
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F-missing" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { evidenceByKey: Record<string, unknown[]> };
+    // Missing records are absent from the map — not empty arrays — so
+    // callers can distinguish "no evidence" from "skipped".
+    expect(Object.keys(body.evidenceByKey)).toEqual(["fact|F1"]);
+    expect("fact|F-missing" in body.evidenceByKey).toBe(false);
+  });
+
+  it("deduplicates duplicate records in the request", async () => {
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F1" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
+    };
+    // Single bucket, single evidence row — duplicates collapsed.
+    expect(body.evidenceByKey["fact|F1"]).toHaveLength(1);
+  });
+
+  it("respects limitPerRecord cap across multiple evidence rows", async () => {
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/b" });
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/c" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "F1" }],
+      limitPerRecord: 2,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
+    };
+    expect(body.evidenceByKey["fact|F1"]).toHaveLength(2);
+    // Ordered by sourceUrl ASC — first two are 'a' and 'b'.
+    expect(body.evidenceByKey["fact|F1"].map((e) => e.sourceUrl)).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
+  it("handles multiple record types in one request (one IN query per type)", async () => {
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/fact1" });
+    seed({ record_type: "grant", record_id: "G1", source_url: "https://example.com/grant1" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "grant", recordId: "G1" },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
+    };
+    expect(body.evidenceByKey["fact|F1"][0].sourceUrl).toBe("https://example.com/fact1");
+    expect(body.evidenceByKey["grant|G1"][0].sourceUrl).toBe("https://example.com/grant1");
+  });
+
+  it("returns isStale=true when checker_model differs from CURRENT_CHECKER_MODEL", async () => {
+    seed({
+      record_type: "fact",
+      record_id: "F1",
+      checker_model: "some-old-model",
+    });
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "F1" }],
+    });
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ isStale: boolean }>>;
+    };
+    expect(body.evidenceByKey["fact|F1"][0].isStale).toBe(true);
+  });
+});

--- a/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
@@ -31,9 +31,16 @@ interface EvidenceRow {
 }
 
 let store: EvidenceRow[];
+/**
+ * Every SQL query the route dispatches, with its parameter array.
+ * Tests use this to assert on batching/dedup behavior at the SQL layer
+ * (not just the response shape, which can mask bugs like missing dedup).
+ */
+let capturedQueries: Array<{ query: string; params: unknown[] }>;
 
 function reset(): void {
   store = [];
+  capturedQueries = [];
 }
 
 function seed(overrides: Partial<EvidenceRow> = {}): EvidenceRow {
@@ -62,6 +69,7 @@ function seed(overrides: Partial<EvidenceRow> = {}): EvidenceRow {
 }
 
 const dispatch: SqlDispatcher = (query, params) => {
+  capturedQueries.push({ query, params: [...params] });
   const q = query.toLowerCase().trim();
 
   // Only the evidence-by-records handler issues SELECTs against
@@ -71,9 +79,23 @@ const dispatch: SqlDispatcher = (query, params) => {
     q.includes("from") &&
     q.includes("source_check_evidence")
   ) {
-    // Dispatcher reads parameters positionally. For the batch handler the
-    // shape is: $1 = recordType, $2...$N = recordIds in `inArray`.
-    const [recordType, ...recordIds] = params as [string, ...string[]];
+    // Parse the WHERE clause to find which param positions correspond
+    // to record_type and record_id. This is robust to Drizzle reordering
+    // the clause under a refactor — the old positional `[type, ...ids]`
+    // was fragile enough to mask bugs.
+    //
+    // `inArray` expands to `record_id IN ($3, $4, $5, ...)`; we find the
+    // first $N after `record_id` and take everything from there.
+    const recordTypeMatch = query.match(/"record_type"\s*=\s*\$(\d+)/);
+    const recordIdInMatch = query.match(/"record_id"\s+in\s*\(([\s\S]*?)\)/i);
+    if (!recordTypeMatch || !recordIdInMatch) return [];
+
+    const recordType = String(params[Number(recordTypeMatch[1]) - 1]);
+    const idParamIndices = [...recordIdInMatch[1].matchAll(/\$(\d+)/g)].map(
+      (m) => Number(m[1]) - 1,
+    );
+    const recordIds = idParamIndices.map((i) => String(params[i]));
+
     return store
       .filter(
         (r) =>
@@ -90,6 +112,30 @@ const dispatch: SqlDispatcher = (query, params) => {
   }
   return [];
 };
+
+/**
+ * Extract the recordId param values from the most recent
+ * `SELECT ... FROM source_check_evidence` query. Used by dedup and
+ * batching tests to assert on the SQL layer, not just the response.
+ */
+function lastSelectRecordIds(): string[] {
+  for (let i = capturedQueries.length - 1; i >= 0; i--) {
+    const { query, params } = capturedQueries[i];
+    if (
+      !query.toLowerCase().includes("from") ||
+      !query.includes("source_check_evidence") ||
+      !query.toLowerCase().startsWith("select")
+    ) {
+      continue;
+    }
+    const m = query.match(/"record_id"\s+in\s*\(([\s\S]*?)\)/i);
+    if (!m) continue;
+    return [...m[1].matchAll(/\$(\d+)/g)].map((pm) =>
+      String(params[Number(pm[1]) - 1]),
+    );
+  }
+  return [];
+}
 
 vi.mock("../db.js", () => mockDbModule(dispatch));
 
@@ -121,12 +167,19 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
   });
 
   it("rejects empty records array", async () => {
-    const res = await postJson(buildApp(), PATH, { records: [] });
+    const res = await postJson(buildApp(), PATH, { records: [], limitPerRecord: 5 });
     expect(res.status).toBe(400);
   });
 
   it("rejects missing records field", async () => {
-    const res = await postJson(buildApp(), PATH, {});
+    const res = await postJson(buildApp(), PATH, { limitPerRecord: 5 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing limitPerRecord (required to avoid unbounded row fetches)", async () => {
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "F1" }],
+    });
     expect(res.status).toBe(400);
   });
 
@@ -135,15 +188,41 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
       recordType: "fact",
       recordId: `F${i}`,
     }));
-    const res = await postJson(buildApp(), PATH, { records });
+    const res = await postJson(buildApp(), PATH, { records, limitPerRecord: 5 });
     expect(res.status).toBe(400);
   });
 
   it("rejects oversized recordId", async () => {
     const res = await postJson(buildApp(), PATH, {
       records: [{ recordType: "fact", recordId: "x".repeat(501) }],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(400);
+  });
+
+  it("parameterizes SQL-injection-shaped recordIds (not string-interpolated)", async () => {
+    // Adversarial recordId. Drizzle uses postgres.js parameter binding,
+    // so this should show up as a literal param value, not inlined into
+    // the query. Expect 200 + empty result (no matching row), not 500
+    // (SQL parse error) or any row leakage.
+    const payload = "'; DROP TABLE source_check_evidence; --";
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: payload }],
+      limitPerRecord: 5,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { evidenceByKey: Record<string, unknown[]> };
+    expect(body.evidenceByKey).toEqual({});
+
+    // The payload must appear in params, NOT in the query text.
+    const evSelect = capturedQueries.find(
+      (c) =>
+        c.query.toLowerCase().startsWith("select") &&
+        c.query.includes("source_check_evidence"),
+    );
+    expect(evSelect).toBeDefined();
+    expect(evSelect?.query.includes("DROP TABLE")).toBe(false);
+    expect(evSelect?.params).toContain(payload);
   });
 
   it("rejects invalid limitPerRecord (negative)", async () => {
@@ -154,9 +233,18 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects limitPerRecord over MAX_PAGE_SIZE (200)", async () => {
+    const res = await postJson(buildApp(), PATH, {
+      records: [{ recordType: "fact", recordId: "F1" }],
+      limitPerRecord: 201,
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("returns empty evidenceByKey when no records match", async () => {
     const res = await postJson(buildApp(), PATH, {
       records: [{ recordType: "fact", recordId: "does-not-exist" }],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -176,6 +264,7 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
         { recordType: "fact", recordId: "F1" },
         { recordType: "fact", recordId: "F2" },
       ],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -194,6 +283,7 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
         { recordType: "fact", recordId: "F1" },
         { recordType: "fact", recordId: "F-missing" },
       ],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { evidenceByKey: Record<string, unknown[]> };
@@ -203,24 +293,25 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
     expect("fact|F-missing" in body.evidenceByKey).toBe(false);
   });
 
-  it("deduplicates duplicate records in the request", async () => {
+  it("deduplicates duplicate records at the SQL layer", async () => {
     seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
 
     const res = await postJson(buildApp(), PATH, {
       records: [
         { recordType: "fact", recordId: "F1" },
         { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F1" },
       ],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
-    };
-    // Single bucket, single evidence row — duplicates collapsed.
-    expect(body.evidenceByKey["fact|F1"]).toHaveLength(1);
+    // Assert on the SQL layer: only ONE `F1` should be in the IN clause,
+    // not three. A response-shape-only assertion would pass regardless of
+    // whether dedup happened.
+    expect(lastSelectRecordIds()).toEqual(["F1"]);
   });
 
-  it("respects limitPerRecord cap across multiple evidence rows", async () => {
+  it("respects limitPerRecord cap for a single record", async () => {
     seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
     seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/b" });
     seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/c" });
@@ -241,6 +332,36 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
     ]);
   });
 
+  it("applies limitPerRecord PER RECORD, not globally, when rows are interleaved", async () => {
+    // SQL orderBy is sourceUrl ASC, so rows come back in this order:
+    // A-rec1, A-rec2, B-rec1, B-rec2, C-rec1, C-rec2. A global LIMIT of 1
+    // would yield only A-rec1; a correct per-record cap yields A-rec1 +
+    // A-rec2 (first row each). This test guards the explicit handler
+    // comment about "cap is per (recordType, recordId)".
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/a" });
+    seed({ record_type: "fact", record_id: "F2", source_url: "https://example.com/b" });
+    seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/c" });
+    seed({ record_type: "fact", record_id: "F2", source_url: "https://example.com/d" });
+
+    const res = await postJson(buildApp(), PATH, {
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F2" },
+      ],
+      limitPerRecord: 1,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      evidenceByKey: Record<string, Array<{ sourceUrl: string }>>;
+    };
+    // Both records present; each has exactly 1 row (the first by
+    // sourceUrl ASC, which is row 'a' for F1 and row 'b' for F2).
+    expect(body.evidenceByKey["fact|F1"]).toHaveLength(1);
+    expect(body.evidenceByKey["fact|F2"]).toHaveLength(1);
+    expect(body.evidenceByKey["fact|F1"][0].sourceUrl).toBe("https://example.com/a");
+    expect(body.evidenceByKey["fact|F2"][0].sourceUrl).toBe("https://example.com/b");
+  });
+
   it("handles multiple record types in one request (one IN query per type)", async () => {
     seed({ record_type: "fact", record_id: "F1", source_url: "https://example.com/fact1" });
     seed({ record_type: "grant", record_id: "G1", source_url: "https://example.com/grant1" });
@@ -250,6 +371,7 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
         { recordType: "fact", recordId: "F1" },
         { recordType: "grant", recordId: "G1" },
       ],
+      limitPerRecord: 5,
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -257,20 +379,38 @@ describe("POST /api/sourcing/evidence/by-records (QUA-331)", () => {
     };
     expect(body.evidenceByKey["fact|F1"][0].sourceUrl).toBe("https://example.com/fact1");
     expect(body.evidenceByKey["grant|G1"][0].sourceUrl).toBe("https://example.com/grant1");
+
+    // SQL-layer assertion: one SELECT per recordType, not one massive IN.
+    const selects = capturedQueries.filter(
+      ({ query }) =>
+        query.toLowerCase().startsWith("select") &&
+        query.includes("source_check_evidence"),
+    );
+    expect(selects).toHaveLength(2);
   });
 
-  it("returns isStale=true when checker_model differs from CURRENT_CHECKER_MODEL", async () => {
+  it("sets isStale=true for stale checker_model and false for current", async () => {
     seed({
       record_type: "fact",
       record_id: "F1",
       checker_model: "some-old-model",
     });
+    seed({
+      record_type: "fact",
+      record_id: "F2",
+      checker_model: "claude-haiku-4-5-20251001",
+    });
     const res = await postJson(buildApp(), PATH, {
-      records: [{ recordType: "fact", recordId: "F1" }],
+      records: [
+        { recordType: "fact", recordId: "F1" },
+        { recordType: "fact", recordId: "F2" },
+      ],
+      limitPerRecord: 5,
     });
     const body = (await res.json()) as {
       evidenceByKey: Record<string, Array<{ isStale: boolean }>>;
     };
     expect(body.evidenceByKey["fact|F1"][0].isStale).toBe(true);
+    expect(body.evidenceByKey["fact|F2"][0].isStale).toBe(false);
   });
 });

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -190,6 +190,37 @@ const EvidenceQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
+/**
+ * QUA-331: batch evidence lookup. Avoids N+1 HTTP calls when callers need
+ * evidence for many records at once (e.g. `crux sourcing-suggest-urls`,
+ * `sourcing-audit-urls`, `sourcing-recheck`). Grouped by recordType on the
+ * server so each type resolves to one `IN (...)` query.
+ */
+const MAX_EVIDENCE_BY_RECORDS = 1000;
+const EvidenceByRecordsBody = z.object({
+  records: z
+    .array(
+      z.object({
+        recordType: z.string().min(1).max(50),
+        recordId: z.string().min(1).max(MAX_ID_LENGTH),
+      })
+    )
+    .min(1)
+    .max(MAX_EVIDENCE_BY_RECORDS),
+  /**
+   * Optional per-record row cap. Callers that just need the first
+   * `sourceUrl` (`sourcing-suggest-urls`, `sourcing-recheck`) pass a small
+   * value. `sourcing-audit-urls` needs all URLs to classify each one and
+   * leaves it unset.
+   */
+  limitPerRecord: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
+});
+
+/** Join (recordType, recordId) into a stable response-map key. */
+export function evidenceRecordKey(recordType: string, recordId: string): string {
+  return `${recordType}|${recordId}`;
+}
+
 const DueForRecheckQuery = z.object({
   limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
@@ -701,6 +732,72 @@ const sourcingApp = new Hono()
       });
     }
   )
+
+  // ---- POST /evidence/by-records ----
+  // QUA-331: batch evidence lookup. Replaces N+1 calls to
+  // `GET /evidence/:recordType/:recordId` in sourcing-suggest-urls,
+  // sourcing-audit-urls, and sourcing-recheck. Groups requested records by
+  // recordType and issues one `IN (...)` query per type (usually 1–2 total).
+  // Does NOT return `claimProvenance` — the per-record subquery would
+  // defeat the purpose of batching, and no caller needs it here.
+  .post("/evidence/by-records", async (c) => {
+    const raw = await parseJsonBody(c);
+    if (!raw) return invalidJsonError(c);
+
+    const parsed = EvidenceByRecordsBody.safeParse(raw);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+    const { records, limitPerRecord } = parsed.data;
+
+    // Group by recordType so each type resolves to a single IN query.
+    // Deduplicate recordIds per type — callers may pass duplicates.
+    const byType = new Map<string, Set<string>>();
+    for (const r of records) {
+      let set = byType.get(r.recordType);
+      if (!set) {
+        set = new Set<string>();
+        byType.set(r.recordType, set);
+      }
+      set.add(r.recordId);
+    }
+
+    const db = getDrizzleDb();
+
+    const evidenceByKey: Record<string, ReturnType<typeof mapEvidenceRow>[]> = {};
+    for (const [recordType, idSet] of byType) {
+      const ids = [...idSet];
+      if (ids.length === 0) continue;
+
+      const rows = await db
+        .select()
+        .from(recordSources)
+        .where(
+          and(
+            eq(recordSources.recordType, recordType),
+            inArray(recordSources.recordId, ids),
+          )
+        )
+        .orderBy(recordSources.sourceUrl, desc(recordSources.checkedAt));
+
+      // Bucket by recordId and cap per record (in app, not SQL, since the
+      // cap is per (recordType, recordId) and LIMIT applies to the whole
+      // result set).
+      for (const row of rows) {
+        const key = evidenceRecordKey(row.recordType, row.recordId);
+        let bucket = evidenceByKey[key];
+        if (!bucket) {
+          bucket = [];
+          evidenceByKey[key] = bucket;
+        }
+        if (limitPerRecord != null && bucket.length >= limitPerRecord) continue;
+        bucket.push(mapEvidenceRow(row));
+      }
+    }
+
+    return c.json({
+      evidenceByKey,
+      currentCheckerModel: CURRENT_CHECKER_MODEL,
+    });
+  })
 
   // ---- POST /evidence ----
   // Upserts on (recordType, recordId, sourceUrl, checkerModel) to prevent duplicates.

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -208,15 +208,19 @@ const EvidenceByRecordsBody = z.object({
     .min(1)
     .max(MAX_EVIDENCE_BY_RECORDS),
   /**
-   * Optional per-record row cap. Callers that just need the first
-   * `sourceUrl` (`sourcing-suggest-urls`, `sourcing-recheck`) pass a small
-   * value. `sourcing-audit-urls` needs all URLs to classify each one and
-   * leaves it unset.
+   * Required per-record row cap. Callers must be explicit about payload
+   * size — an unbounded fetch across 1000 records could load millions of
+   * evidence rows into memory. A small value (e.g. 5) is sufficient for
+   * "find the first non-null source URL" use cases.
    */
-  limitPerRecord: z.number().int().min(1).max(MAX_PAGE_SIZE).optional(),
+  limitPerRecord: z.number().int().min(1).max(MAX_PAGE_SIZE),
 });
 
-/** Join (recordType, recordId) into a stable response-map key. */
+/**
+ * Join (recordType, recordId) into a stable response-map key.
+ * Kept in sync with `evidenceRecordKey` in the crux client
+ * (`crux/lib/wiki-server/sourcing-client.ts`).
+ */
 export function evidenceRecordKey(recordType: string, recordId: string): string {
   return `${recordType}|${recordId}`;
 }
@@ -764,16 +768,13 @@ const sourcingApp = new Hono()
 
     const evidenceByKey: Record<string, ReturnType<typeof mapEvidenceRow>[]> = {};
     for (const [recordType, idSet] of byType) {
-      const ids = [...idSet];
-      if (ids.length === 0) continue;
-
       const rows = await db
         .select()
         .from(recordSources)
         .where(
           and(
             eq(recordSources.recordType, recordType),
-            inArray(recordSources.recordId, ids),
+            inArray(recordSources.recordId, [...idSet]),
           )
         )
         .orderBy(recordSources.sourceUrl, desc(recordSources.checkedAt));
@@ -788,7 +789,7 @@ const sourcingApp = new Hono()
           bucket = [];
           evidenceByKey[key] = bucket;
         }
-        if (limitPerRecord != null && bucket.length >= limitPerRecord) continue;
+        if (bucket.length >= limitPerRecord) continue;
         bucket.push(mapEvidenceRow(row));
       }
     }

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -14,7 +14,11 @@
  */
 
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
-import { listVerdicts, getEvidenceByRecord } from '../lib/wiki-server/sourcing-client.ts';
+import {
+  listVerdicts,
+  getEvidenceByRecords,
+  evidenceRecordKey,
+} from '../lib/wiki-server/sourcing-client.ts';
 import {
   classifyByUrl,
   normalizeUrlForJoin,
@@ -27,8 +31,12 @@ export { classifyByUrl, normalizeUrlForJoin, extractHost };
 
 // ── Module constants ──
 
-/** Parallel evidence-fetch requests. Keeps the wiki-server load light. */
-const CONCURRENCY = 8;
+/**
+ * Max records per batch evidence request. QUA-331 — the server caps at
+ * 1000; we chunk at 1000 so a `--limit=2000` × 2 verdicts = 4000-record
+ * scan resolves in 4 HTTP calls instead of 4000.
+ */
+const EVIDENCE_BATCH_SIZE = 1000;
 
 /** Evidence rows fetched per verdict record. Most records have 1–2. */
 const EVIDENCE_PER_RECORD = 5;
@@ -151,38 +159,49 @@ async function auditCommand(
     console.log('Fetching evidence for each (this may take a minute)...');
   }
 
-  // ── Step 2: fetch evidence per record ──
-  // N+1 pattern — acceptable for audit use (default --limit=100 => ~200 req).
-  // A dedicated bulk endpoint is a QUA-313 follow-up if this becomes slow.
+  // ── Step 2: batch-fetch evidence (QUA-331) ──
+  // One HTTP call per 1000-record chunk instead of one per record.
+  // Index verdict metadata by key so we can join evidence rows back to
+  // `verdict` without re-querying.
+  const verdictByKey = new Map<string, { recordType: string; recordId: string; verdict: string }>();
+  for (const v of verdictRecords) {
+    verdictByKey.set(evidenceRecordKey(v.recordType, v.recordId), v);
+  }
+
   const rows: AuditRow[] = [];
-  for (let i = 0; i < verdictRecords.length; i += CONCURRENCY) {
-    const slice = verdictRecords.slice(i, i + CONCURRENCY);
-    const results = await Promise.all(
-      slice.map(async (v) => {
-        const res = await getEvidenceByRecord(v.recordType, v.recordId, { limit: EVIDENCE_PER_RECORD });
-        if (!res.ok) return [];
-        const out: AuditRow[] = [];
-        for (const e of res.data.evidence) {
-          if (!e.sourceUrl) continue;
-          const sourceUrl = e.sourceUrl;
-          const cls = classifyByUrl(sourceUrl);
-          const flagged = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
-          out.push({
-            recordType: v.recordType,
-            recordId: v.recordId,
-            fieldName: e.fieldName,
-            verdict: v.verdict,
-            sourceUrl,
-            host: extractHost(sourceUrl),
-            flagged,
-            flagReasons: cls.reasons,
-            confidence: cls.confidence,
-          });
-        }
-        return out;
-      }),
+  for (let i = 0; i < verdictRecords.length; i += EVIDENCE_BATCH_SIZE) {
+    const chunk = verdictRecords.slice(i, i + EVIDENCE_BATCH_SIZE);
+    const res = await getEvidenceByRecords(
+      chunk.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
+      { limitPerRecord: EVIDENCE_PER_RECORD },
     );
-    for (const r of results) rows.push(...r);
+    if (!res.ok) {
+      return {
+        exitCode: 1,
+        output: `Failed to batch-fetch evidence: ${res.message ?? 'unknown error'}`,
+      };
+    }
+    for (const [key, evidenceRows] of Object.entries(res.data.evidenceByKey)) {
+      const v = verdictByKey.get(key);
+      if (!v) continue; // should not happen — server echoes only requested keys
+      for (const e of evidenceRows) {
+        if (!e.sourceUrl) continue;
+        const sourceUrl = e.sourceUrl;
+        const cls = classifyByUrl(sourceUrl);
+        const flagged = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
+        rows.push({
+          recordType: v.recordType,
+          recordId: v.recordId,
+          fieldName: e.fieldName,
+          verdict: v.verdict,
+          sourceUrl,
+          host: extractHost(sourceUrl),
+          flagged,
+          flagReasons: cls.reasons,
+          confidence: cls.confidence,
+        });
+      }
+    }
   }
 
   // ── Step 3: aggregate by domain (over ALL rows, so totals are accurate

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -32,9 +32,11 @@ export { classifyByUrl, normalizeUrlForJoin, extractHost };
 // ── Module constants ──
 
 /**
- * Max records per batch evidence request. QUA-331 — the server caps at
- * 1000; we chunk at 1000 so a `--limit=2000` × 2 verdicts = 4000-record
- * scan resolves in 4 HTTP calls instead of 4000.
+ * Max records per batch evidence request. QUA-331 — matches the server
+ * cap `MAX_EVIDENCE_BY_RECORDS` in sourcing.ts. In practice one chunk is
+ * enough (listVerdicts clamps server-side to 200, so default `--verdict`
+ * sets produce ≤1000 records); the chunk loop is defensive in case that
+ * clamp grows or callers add more verdict types.
  */
 const EVIDENCE_BATCH_SIZE = 1000;
 
@@ -160,15 +162,13 @@ async function auditCommand(
   }
 
   // ── Step 2: batch-fetch evidence (QUA-331) ──
-  // One HTTP call per 1000-record chunk instead of one per record.
-  // Index verdict metadata by key so we can join evidence rows back to
-  // `verdict` without re-querying.
-  const verdictByKey = new Map<string, { recordType: string; recordId: string; verdict: string }>();
-  for (const v of verdictRecords) {
-    verdictByKey.set(evidenceRecordKey(v.recordType, v.recordId), v);
-  }
-
-  const rows: AuditRow[] = [];
+  // Accumulate across chunks into one map, then iterate `verdictRecords`
+  // in input order so report output stays deterministic regardless of
+  // server-side grouping.
+  const allEvidence: Record<
+    string,
+    Array<{ sourceUrl: string | null; fieldName: string | null }>
+  > = {};
   for (let i = 0; i < verdictRecords.length; i += EVIDENCE_BATCH_SIZE) {
     const chunk = verdictRecords.slice(i, i + EVIDENCE_BATCH_SIZE);
     const res = await getEvidenceByRecords(
@@ -181,26 +181,29 @@ async function auditCommand(
         output: `Failed to batch-fetch evidence: ${res.message ?? 'unknown error'}`,
       };
     }
-    for (const [key, evidenceRows] of Object.entries(res.data.evidenceByKey)) {
-      const v = verdictByKey.get(key);
-      if (!v) continue; // should not happen — server echoes only requested keys
-      for (const e of evidenceRows) {
-        if (!e.sourceUrl) continue;
-        const sourceUrl = e.sourceUrl;
-        const cls = classifyByUrl(sourceUrl);
-        const flagged = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
-        rows.push({
-          recordType: v.recordType,
-          recordId: v.recordId,
-          fieldName: e.fieldName,
-          verdict: v.verdict,
-          sourceUrl,
-          host: extractHost(sourceUrl),
-          flagged,
-          flagReasons: cls.reasons,
-          confidence: cls.confidence,
-        });
-      }
+    Object.assign(allEvidence, res.data.evidenceByKey);
+  }
+
+  const rows: AuditRow[] = [];
+  for (const v of verdictRecords) {
+    const evidenceRows = allEvidence[evidenceRecordKey(v.recordType, v.recordId)];
+    if (!evidenceRows) continue;
+    for (const e of evidenceRows) {
+      if (!e.sourceUrl) continue;
+      const sourceUrl = e.sourceUrl;
+      const cls = classifyByUrl(sourceUrl);
+      const flagged = cls.purpose === 'homepage' && cls.confidence >= FLAG_THRESHOLD;
+      rows.push({
+        recordType: v.recordType,
+        recordId: v.recordId,
+        fieldName: e.fieldName,
+        verdict: v.verdict,
+        sourceUrl,
+        host: extractHost(sourceUrl),
+        flagged,
+        flagReasons: cls.reasons,
+        confidence: cls.confidence,
+      });
     }
   }
 

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -113,31 +113,32 @@ interface RecheckSummary {
  * HTTP call. Returns a map keyed by `recordType|recordId`. Missing keys
  * mean no evidence row carried a `sourceUrl` (or the record was absent
  * from the evidence table) — the caller treats that as "no URL".
+ *
+ * Throws on HTTP failure so the caller aborts the whole scan. The old
+ * per-record path swallowed errors and returned null per item; with a
+ * batch call, swallowing would turn a single network blip into "every
+ * record has no URL" for the entire scan, which is indistinguishable
+ * from a real data shortage. Better to fail loudly.
  */
-async function fetchSourceUrls(
-  items: DueItem[],
-): Promise<Map<string, string>> {
+async function fetchSourceUrls(items: DueItem[]): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   if (items.length === 0) return result;
 
-  try {
-    const response = await getEvidenceByRecords(
-      items.map((i) => ({ recordType: i.recordType, recordId: i.recordId })),
-      { limitPerRecord: 5 },
+  const response = await getEvidenceByRecords(
+    items.map((i) => ({ recordType: i.recordType, recordId: i.recordId })),
+    { limitPerRecord: 5 },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Batch evidence fetch failed: ${response.message ?? 'unknown error'}`,
     );
-    if (!response.ok || !response.data?.evidenceByKey) return result;
-
-    for (const [key, rows] of Object.entries(response.data.evidenceByKey)) {
-      const firstUrl = rows.find((e) => e.sourceUrl)?.sourceUrl;
-      if (firstUrl) result.set(key, firstUrl);
-    }
-    return result;
-  } catch (e: unknown) {
-    console.warn(
-      `${LOG_PREFIX} Failed to batch-fetch source URLs: ${e instanceof Error ? e.message : String(e)}`,
-    );
-    return result;
   }
+
+  for (const [key, rows] of Object.entries(response.data.evidenceByKey)) {
+    const firstUrl = rows.find((e) => e.sourceUrl)?.sourceUrl;
+    if (firstUrl) result.set(key, firstUrl);
+  }
+  return result;
 }
 
 // ── LLM re-check ─────────────────────────────────────────────
@@ -367,8 +368,17 @@ async function recheckCommand(
   console.log(`\n\x1b[1mRechecking ${itemsToRecheck.length} items (est. \$${estimatedCost.toFixed(2)})...\x1b[0m\n`);
 
   // QUA-331: pre-fetch every source URL in one batch call rather than
-  // one-per-item inside the loop.
-  const sourceUrlsByKey = await fetchSourceUrls(itemsToRecheck);
+  // one-per-item inside the loop. Abort on failure — see `fetchSourceUrls`
+  // docstring for why swallowing here would mask real data shortages.
+  let sourceUrlsByKey: Map<string, string>;
+  try {
+    sourceUrlsByKey = await fetchSourceUrls(itemsToRecheck);
+  } catch (e: unknown) {
+    return {
+      exitCode: 1,
+      output: `${LOG_PREFIX} ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
 
   for (let i = 0; i < itemsToRecheck.length; i++) {
     const item = itemsToRecheck[i];

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -12,7 +12,12 @@
  */
 
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
-import { storeVerdict as storeVerdictRpc, getDueForRecheck, getEvidenceByRecord } from '../lib/wiki-server/sourcing-client.ts';
+import {
+  storeVerdict as storeVerdictRpc,
+  getDueForRecheck,
+  getEvidenceByRecords,
+  evidenceRecordKey,
+} from '../lib/wiki-server/sourcing-client.ts';
 import { createLlmClient } from '../lib/llm.ts';
 import {
   fetchSourceContent,
@@ -104,23 +109,34 @@ interface RecheckSummary {
 // ── Source URL resolution ────────────────────────────────────────────
 
 /**
- * Attempt to find the source URL for a record that needs rechecking.
- * Checks the existing evidence table for previously used source URLs.
+ * QUA-331: batch-fetch source URLs for a list of due items in a single
+ * HTTP call. Returns a map keyed by `recordType|recordId`. Missing keys
+ * mean no evidence row carried a `sourceUrl` (or the record was absent
+ * from the evidence table) — the caller treats that as "no URL".
  */
-async function resolveSourceUrl(recordType: string, recordId: string): Promise<string | null> {
+async function fetchSourceUrls(
+  items: DueItem[],
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  if (items.length === 0) return result;
+
   try {
-    const response = await getEvidenceByRecord(recordType, recordId, { limit: 5 });
+    const response = await getEvidenceByRecords(
+      items.map((i) => ({ recordType: i.recordType, recordId: i.recordId })),
+      { limitPerRecord: 5 },
+    );
+    if (!response.ok || !response.data?.evidenceByKey) return result;
 
-    if (!response.ok || !response.data?.evidence) return null;
-
-    // Return the most recent non-null source URL
-    for (const e of response.data.evidence) {
-      if (e.sourceUrl) return e.sourceUrl;
+    for (const [key, rows] of Object.entries(response.data.evidenceByKey)) {
+      const firstUrl = rows.find((e) => e.sourceUrl)?.sourceUrl;
+      if (firstUrl) result.set(key, firstUrl);
     }
-    return null;
+    return result;
   } catch (e: unknown) {
-    console.warn(`${LOG_PREFIX} Failed to resolve source URL for ${recordType}/${recordId}: ${e instanceof Error ? e.message : String(e)}`);
-    return null;
+    console.warn(
+      `${LOG_PREFIX} Failed to batch-fetch source URLs: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return result;
   }
 }
 
@@ -167,9 +183,9 @@ Respond with ONLY a JSON object (no markdown code fences):
 async function recheckSingleItem(
   item: DueItem,
   client: ReturnType<typeof createLlmClient>,
+  sourceUrl: string | null,
 ): Promise<RecheckResult | RecheckError> {
-  // Step 1: Find the source URL
-  const sourceUrl = await resolveSourceUrl(item.recordType, item.recordId);
+  // Step 1: Source URL already resolved via the batch pre-fetch
   if (!sourceUrl) {
     return {
       recordType: item.recordType,
@@ -350,12 +366,17 @@ async function recheckCommand(
 
   console.log(`\n\x1b[1mRechecking ${itemsToRecheck.length} items (est. \$${estimatedCost.toFixed(2)})...\x1b[0m\n`);
 
+  // QUA-331: pre-fetch every source URL in one batch call rather than
+  // one-per-item inside the loop.
+  const sourceUrlsByKey = await fetchSourceUrls(itemsToRecheck);
+
   for (let i = 0; i < itemsToRecheck.length; i++) {
     const item = itemsToRecheck[i];
     const label = `${item.recordType}/${item.recordId}`.slice(0, 60);
     console.log(`  [${i + 1}/${itemsToRecheck.length}] ${label} (was: ${item.verdict})`);
 
-    const result = await recheckSingleItem(item, client);
+    const sourceUrl = sourceUrlsByKey.get(evidenceRecordKey(item.recordType, item.recordId)) ?? null;
+    const result = await recheckSingleItem(item, client, sourceUrl);
 
     if ('error' in result) {
       summary.errors++;

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -24,7 +24,8 @@ import type {
 } from '../lib/command-types.ts';
 import {
   listVerdicts,
-  getEvidenceByRecord,
+  getEvidenceByRecords,
+  evidenceRecordKey,
   listUrlSuggestions,
   upsertUrlSuggestions,
 } from '../lib/wiki-server/sourcing-client.ts';
@@ -270,6 +271,25 @@ async function suggestCommand(
     ? await fetchPendingRecordKeys(recordTypeFilter, log)
     : new Set<string>();
 
+  // QUA-331: batch-fetch evidence for every verdict row in one HTTP call
+  // instead of N calls inside the per-record task. We only need the first
+  // non-null sourceUrl per record, so limitPerRecord=5 matches the old
+  // per-call limit.
+  const existingUrlByKey = new Map<string, string | null>();
+  const evidenceRes = await getEvidenceByRecords(
+    verdictRows.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
+    { limitPerRecord: 5 },
+  );
+  if (!evidenceRes.ok) {
+    return {
+      exitCode: 1,
+      output: `Failed to batch-fetch evidence: ${evidenceRes.message ?? 'unknown error'}`,
+    };
+  }
+  for (const [key, rows] of Object.entries(evidenceRes.data.evidenceByKey)) {
+    existingUrlByKey.set(key, rows.find((e) => e.sourceUrl)?.sourceUrl ?? null);
+  }
+
   const toUpsert: Parameters<typeof upsertUrlSuggestions>[0] = [];
 
   const tasks = verdictRows.map((v) => async () => {
@@ -300,9 +320,7 @@ async function suggestCommand(
       return;
     }
 
-    const evidence = await getEvidenceByRecord(v.recordType, v.recordId, { limit: 5 });
-    const existingUrl =
-      (evidence.ok && evidence.data.evidence.find((e) => e.sourceUrl)?.sourceUrl) || null;
+    const existingUrl = existingUrlByKey.get(evidenceRecordKey(v.recordType, v.recordId)) ?? null;
 
     if (dryRun) {
       log(`  [dry-run] ${v.recordType}/${v.recordId} field=${v.fieldName ?? '(row)'} entity="${entityName.slice(0, 40)}"`);

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -271,28 +271,50 @@ async function suggestCommand(
     ? await fetchPendingRecordKeys(recordTypeFilter, log)
     : new Set<string>();
 
-  // QUA-331: batch-fetch evidence for every verdict row in one HTTP call
-  // instead of N calls inside the per-record task. We only need the first
-  // non-null sourceUrl per record, so limitPerRecord=5 matches the old
-  // per-call limit.
+  // Pre-compute claim/entity text and the skip verdict so the pre-fetch
+  // filter and the per-task loop agree without duplicating logic.
+  type PreparedRow = {
+    v: (typeof verdictRows)[number];
+    claimText: string;
+    entityName: string;
+    skipReason: 'no-claim' | 'had-suggestion' | null;
+  };
+  const prepared: PreparedRow[] = verdictRows.map((v) => {
+    const claimText = v.reasoning?.trim() || v.displayName?.trim() || '';
+    const entityName =
+      v.entityDisplayName?.trim() || v.entityId?.trim() || v.displayName?.trim() || '';
+    let skipReason: PreparedRow['skipReason'] = null;
+    if (!claimText || !entityName) skipReason = 'no-claim';
+    else if (skipExisting && pendingKeys.has(`${v.recordType}|${v.recordId}`))
+      skipReason = 'had-suggestion';
+    return { v, claimText, entityName, skipReason };
+  });
+
+  // QUA-331: batch-fetch evidence once before the per-record task loop
+  // instead of N calls inside it. Only fetch for rows we will actually
+  // process — no point loading evidence for records that will be skipped.
+  const needsEvidence = prepared.filter((p) => p.skipReason === null);
   const existingUrlByKey = new Map<string, string | null>();
-  const evidenceRes = await getEvidenceByRecords(
-    verdictRows.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
-    { limitPerRecord: 5 },
-  );
-  if (!evidenceRes.ok) {
-    return {
-      exitCode: 1,
-      output: `Failed to batch-fetch evidence: ${evidenceRes.message ?? 'unknown error'}`,
-    };
-  }
-  for (const [key, rows] of Object.entries(evidenceRes.data.evidenceByKey)) {
-    existingUrlByKey.set(key, rows.find((e) => e.sourceUrl)?.sourceUrl ?? null);
+  if (needsEvidence.length > 0) {
+    const evidenceRes = await getEvidenceByRecords(
+      needsEvidence.map((p) => ({ recordType: p.v.recordType, recordId: p.v.recordId })),
+      { limitPerRecord: 5 },
+    );
+    if (!evidenceRes.ok) {
+      return {
+        exitCode: 1,
+        output: `Failed to batch-fetch evidence: ${evidenceRes.message ?? 'unknown error'}`,
+      };
+    }
+    for (const [key, rows] of Object.entries(evidenceRes.data.evidenceByKey)) {
+      existingUrlByKey.set(key, rows.find((e) => e.sourceUrl)?.sourceUrl ?? null);
+    }
   }
 
   const toUpsert: Parameters<typeof upsertUrlSuggestions>[0] = [];
 
-  const tasks = verdictRows.map((v) => async () => {
+  const tasks = prepared.map((p) => async () => {
+    const { v, claimText, entityName, skipReason } = p;
     summary.scanned++;
 
     // Shared budget gate: once tripped, pending tasks short-circuit without
@@ -305,17 +327,11 @@ async function suggestCommand(
       return;
     }
 
-    // Claim text comes from the sourcing LLM's reasoning; fall back to the
-    // record's displayName when reasoning is missing.
-    const claimText = v.reasoning?.trim() || v.displayName?.trim() || '';
-    const entityName =
-      v.entityDisplayName?.trim() || v.entityId?.trim() || v.displayName?.trim() || '';
-    if (!claimText || !entityName) {
+    if (skipReason === 'no-claim') {
       summary.skippedNoClaim++;
       return;
     }
-
-    if (skipExisting && pendingKeys.has(`${v.recordType}|${v.recordId}`)) {
+    if (skipReason === 'had-suggestion') {
       summary.skippedHadSuggestion++;
       return;
     }

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -26,6 +26,7 @@ export type ListVerdictsResult = InferResponseType<RpcClient['verdicts']['$get']
 export type VerdictByRecordResult = InferResponseType<RpcClient['verdicts'][':recordType'][':recordId']['$get'], 200>;
 export type DueForRecheckResult = InferResponseType<RpcClient['due-for-recheck']['$get'], 200>;
 export type EvidenceByRecordResult = InferResponseType<RpcClient['evidence'][':recordType'][':recordId']['$get'], 200>;
+export type EvidenceByRecordsResult = InferResponseType<RpcClient['evidence']['by-records']['$post'], 200>;
 export type SourcingStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
 export type CleanupOrphansResult = InferResponseType<RpcClient['cleanup-orphans']['$post'], 200>;
 
@@ -90,6 +91,35 @@ export async function getEvidenceByRecord(
     'GET',
     `/api/sourcing/evidence/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}${qs ? '?' + qs : ''}`,
   );
+}
+
+/**
+ * Batch-fetch evidence for many records in a single request (QUA-331).
+ * Replaces N+1 loops over `getEvidenceByRecord`. The server groups by
+ * `recordType` and issues one `IN (...)` query per type.
+ *
+ * Returns `evidenceByKey[recordKey(rt, rid)]` — records with no evidence
+ * are absent from the map (not empty arrays), so callers can distinguish
+ * "queried, no evidence" from "skipped".
+ *
+ * `limitPerRecord` caps the number of evidence rows returned per record.
+ * Callers that just need the first `sourceUrl` should pass a small value
+ * (e.g. 5) to reduce payload size.
+ */
+export async function getEvidenceByRecords(
+  records: Array<{ recordType: string; recordId: string }>,
+  options?: { limitPerRecord?: number },
+): Promise<ApiResult<EvidenceByRecordsResult>> {
+  return apiRequest<EvidenceByRecordsResult>(
+    'POST',
+    '/api/sourcing/evidence/by-records',
+    { records, limitPerRecord: options?.limitPerRecord },
+  );
+}
+
+/** Build the response-map key used by `getEvidenceByRecords`. */
+export function evidenceRecordKey(recordType: string, recordId: string): string {
+  return `${recordType}|${recordId}`;
 }
 
 /** Get sourcing statistics. */

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -5,7 +5,7 @@
  * Response types are inferred from the Hono RPC route type via InferResponseType<>.
  */
 
-import { apiRequest, type ApiResult } from './client.ts';
+import { apiRequest, batchedRequest, type ApiResult } from './client.ts';
 import type { hc, InferResponseType } from 'hono/client';
 import type { SourcingRoute } from '../../../apps/wiki-server/src/routes/sourcing/sourcing.ts';
 import type {
@@ -102,22 +102,30 @@ export async function getEvidenceByRecord(
  * are absent from the map (not empty arrays), so callers can distinguish
  * "queried, no evidence" from "skipped".
  *
- * `limitPerRecord` caps the number of evidence rows returned per record.
- * Callers that just need the first `sourceUrl` should pass a small value
- * (e.g. 5) to reduce payload size.
+ * `limitPerRecord` is required: it caps the number of evidence rows
+ * returned per record and forces callers to be explicit about payload
+ * size. Callers that just need the first `sourceUrl` pass a small value
+ * (e.g. 5); auditors that classify every URL pass something larger.
+ *
+ * Uses `batchedRequest` (30s timeout) because the batched endpoint is
+ * inherently slower than a point lookup.
  */
 export async function getEvidenceByRecords(
   records: Array<{ recordType: string; recordId: string }>,
-  options?: { limitPerRecord?: number },
+  options: { limitPerRecord: number },
 ): Promise<ApiResult<EvidenceByRecordsResult>> {
-  return apiRequest<EvidenceByRecordsResult>(
+  return batchedRequest<EvidenceByRecordsResult>(
     'POST',
     '/api/sourcing/evidence/by-records',
-    { records, limitPerRecord: options?.limitPerRecord },
+    { records, limitPerRecord: options.limitPerRecord },
   );
 }
 
-/** Build the response-map key used by `getEvidenceByRecords`. */
+/**
+ * Build the response-map key used by `getEvidenceByRecords`.
+ * Kept in sync with `evidenceRecordKey` in the server route
+ * (`apps/wiki-server/src/routes/sourcing/sourcing.ts`).
+ */
 export function evidenceRecordKey(recordType: string, recordId: string): string {
   return `${recordType}|${recordId}`;
 }


### PR DESCRIPTION
## Summary

Adds `POST /api/sourcing/evidence/by-records` to replace N+1 HTTP loops in three crux commands. Grouping by `recordType` server-side means each type resolves to a single `IN (...)` query — usually 1–2 total queries for any batch.

- `sourcing-suggest-urls`: 1000 calls → 1
- `sourcing-audit-urls`:   1000 calls → 1 per 1000-record chunk
- `sourcing-recheck`:      N calls    → 1

Per the ticket's estimate, combined with the already-landed concurrency improvements, wall time on a 1000-record scan drops from ~35 min → ~5 min.

## How it works

**New endpoint** (`apps/wiki-server/src/routes/sourcing/sourcing.ts`):

- Zod body: `{ records: Array<{recordType, recordId}>, limitPerRecord?: number }` — `.min(1).max(1000)` on records, `recordType` ≤ 50 chars, `recordId` ≤ `MAX_ID_LENGTH` (500).
- Deduplicates and groups by `recordType`, then issues one `inArray(recordSources.recordId, ids)` query per type.
- Preserves the same `orderBy(sourceUrl ASC, checkedAt DESC)` as the single-record endpoint so `find((e) => e.sourceUrl)` returns the same "first non-null URL" that callers expect.
- Returns `{ evidenceByKey: Record<"recordType|recordId", EvidenceRow[]>, currentCheckerModel }`. **Missing records are absent from the map, not empty arrays** — lets callers distinguish "no evidence" from "skipped".
- `limitPerRecord` is applied in-app, not in SQL, because a SQL `LIMIT` caps the whole result set, not per-record.
- **Does NOT return `claimProvenance`** — the per-record subquery used by the single-record endpoint would defeat the purpose of batching, and no caller needs it here.

**New client** (`crux/lib/wiki-server/sourcing-client.ts`):

- `getEvidenceByRecords(records, { limitPerRecord })` — response type inferred via `InferResponseType<SourcingRoute['evidence']['by-records']['$post'], 200>`.
- `evidenceRecordKey(rt, rid)` helper for looking up results client-side.

**Caller migration**:

- `sourcing-suggest-urls.ts` — pre-fetches all verdict rows once before the concurrency loop; the per-task body becomes a `Map.get` lookup.
- `sourcing-audit-urls.ts` — chunks at `EVIDENCE_BATCH_SIZE = 1000` to handle `--limit=2000 × 2 verdicts = 4000` scans. Drops the `CONCURRENCY` constant since one batch call replaces the parallelized per-record loop.
- `sourcing-recheck.ts` — `fetchSourceUrls(items)` replaces `resolveSourceUrl(type, id)`; `recheckSingleItem` now takes `sourceUrl` as a parameter.

## Tests

13 vitest tests in `apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts`, covering every acceptance criterion:

- Invalid JSON → 400
- Empty `records` array → 400
- Missing `records` field → 400
- Batch over 1000 records → 400
- Oversize `recordId` → 400
- Negative `limitPerRecord` → 400
- Unknown records → empty `evidenceByKey`
- Matching records → keyed by `recordType|recordId`
- Partial matches → missing keys absent (not empty arrays)
- Duplicate request records → single bucket
- `limitPerRecord` cap respected across multiple rows (including ordering check)
- Multiple record types in one request → one IN query per type
- `isStale` flag propagates from `checker_model`

All 1053 wiki-server tests pass. Crux tsc ratchet: at baseline (86).

## Out of scope / follow-ups

- `crux/commands/legislation/verify-stakeholders.ts:171` also calls `getEvidenceByRecord` inside a loop. Not in the QUA-331 scope; worth migrating as a follow-up.
- The existing `GET /evidence/:recordType/:recordId` is kept — still used by wiki-server internal callers and kept for backwards compat.

## Test plan

- [x] `pnpm vitest run` in `apps/wiki-server` (1053 pass)
- [x] `npx tsc --noEmit` in `apps/wiki-server` (clean)
- [x] `npx tsx crux/validate/validate-crux-tsc.ts` (at baseline 86)
- [x] `pnpm crux w validate gate --fix --no-cache` (43 checks pass)
- [ ] CI green

Closes QUA-331
