### PR TITLE
feat(sourcing): redirect plural record types to canonical singular (QUA-399)

### DIFF
--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.test.ts
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { canonicalizeSourcingRecordType } from "./canonicalize-record-type";
+
+describe("canonicalizeSourcingRecordType", () => {
+  it("maps plural grants → singular grant", () => {
+    expect(canonicalizeSourcingRecordType("grants")).toBe("grant");
+  });
+
+  it("maps hyphenated plurals", () => {
+    expect(canonicalizeSourcingRecordType("board-seats")).toBe("board-seat");
+    expect(canonicalizeSourcingRecordType("funding-programs")).toBe("funding-program");
+    expect(canonicalizeSourcingRecordType("funding-rounds")).toBe("funding-round");
+    expect(canonicalizeSourcingRecordType("policy-stakeholders")).toBe("policy-stakeholder");
+  });
+
+  it("maps publications, divisions, investments, citations, wiki-pages", () => {
+    expect(canonicalizeSourcingRecordType("publications")).toBe("publication");
+    expect(canonicalizeSourcingRecordType("divisions")).toBe("division");
+    expect(canonicalizeSourcingRecordType("investments")).toBe("investment");
+    expect(canonicalizeSourcingRecordType("citations")).toBe("citation");
+    expect(canonicalizeSourcingRecordType("wiki-pages")).toBe("wiki-page");
+  });
+
+  it("returns null for already-canonical singular forms", () => {
+    expect(canonicalizeSourcingRecordType("grant")).toBeNull();
+    expect(canonicalizeSourcingRecordType("publication")).toBeNull();
+    expect(canonicalizeSourcingRecordType("board-seat")).toBeNull();
+    expect(canonicalizeSourcingRecordType("fact")).toBeNull();
+    expect(canonicalizeSourcingRecordType("entity")).toBeNull();
+    expect(canonicalizeSourcingRecordType("personnel")).toBeNull();
+  });
+
+  it("returns null for unknown record types (letting the page fall through to notFound)", () => {
+    expect(canonicalizeSourcingRecordType("nonsense")).toBeNull();
+    expect(canonicalizeSourcingRecordType("")).toBeNull();
+    expect(canonicalizeSourcingRecordType("Grants")).toBeNull();
+  });
+});

--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.ts
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.ts
@@ -1,0 +1,17 @@
+const PLURAL_TO_SINGULAR: Record<string, string> = {
+  grants: "grant",
+  publications: "publication",
+  divisions: "division",
+  investments: "investment",
+  personnels: "personnel",
+  "board-seats": "board-seat",
+  "funding-programs": "funding-program",
+  "funding-rounds": "funding-round",
+  "policy-stakeholders": "policy-stakeholder",
+  citations: "citation",
+  "wiki-pages": "wiki-page",
+};
+
+export function canonicalizeSourcingRecordType(recordType: string): string | null {
+  return PLURAL_TO_SINGULAR[recordType] ?? null;
+}

--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft, Database, ExternalLink } from "lucide-react";
@@ -20,6 +20,8 @@ import { getEntityHref } from "@data/entity-nav";
 import { getKBFactById, getKBEntity, getKBProperty } from "@/data/factbase";
 import { inferDataSource } from "@/app/grants/grants-data-source";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
+
+import { canonicalizeSourcingRecordType } from "./canonicalize-record-type";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
@@ -220,6 +222,11 @@ export async function generateMetadata({
   const recordType = decodeURIComponent(rawParams.recordType);
   const recordId = decodeURIComponent(rawParams.recordId);
 
+  const canonicalType = canonicalizeSourcingRecordType(recordType);
+  if (canonicalType) {
+    permanentRedirect(`/sourcing/${canonicalType}/${encodeURIComponent(recordId)}`);
+  }
+
   // Try to resolve a human-readable name
   const namesResult = await fetchDetailed<RpcSourcingResolveNamesResult>(
     `/api/sourcing/resolve-names?record_type=${encodeURIComponent(recordType)}&record_ids=${encodeURIComponent(recordId)}`,
@@ -245,6 +252,11 @@ export default async function SourcingDetailPage({ params }: PageProps) {
   // recordId (e.g. "page:1day-sooner:fn3" instead of "page%3A1day-sooner%3Afn3").
   const recordType = decodeURIComponent(rawParams.recordType);
   const recordId = decodeURIComponent(rawParams.recordId);
+
+  const canonicalType = canonicalizeSourcingRecordType(recordType);
+  if (canonicalType) {
+    permanentRedirect(`/sourcing/${canonicalType}/${encodeURIComponent(recordId)}`);
+  }
 
   // Map recordType back to source table name for record-lookup API
   const RECORD_TYPE_TO_TABLE: Record<string, string> = {


### PR DESCRIPTION
## Summary

Stale Amazonbot crawl cache (pre-QUA-237) is hitting `/sourcing/grants/<id>`, `/sourcing/publications/<id>`, etc. ~318 404s in a 30-min production window. Zero plural URLs are emitted by current code; the bot is re-visiting cached URLs from before the `/source-checks/` → `/sourcing/` rename.

Add a small `PLURAL_TO_SINGULAR` map and `permanentRedirect()` (308) in the `[recordType]/[recordId]` route. Bots update their index, our 404 logs stay clean, and any surviving external backlinks keep working.

## Changes

- `apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.ts` — new helper with a small, closed map of known plural forms
- `apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx` — call `canonicalizeSourcingRecordType()` in both `generateMetadata` and the page handler, `permanentRedirect()` if the type is a plural
- `apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.test.ts` — 5 unit tests covering plural→singular mapping, singular pass-through, and unknown-type fall-through

Fixes QUA-399

## Test plan

- [x] `apps/web` typecheck clean (`tsc --noEmit`)
- [x] `pnpm build` succeeds (route renders as `ƒ /sourcing/[recordType]/[recordId]`)
- [x] `pnpm crux w validate gate --scope=content --fix` passes
- [x] New unit test suite passes (5/5)
- [ ] Post-deploy: `curl -sI https://www.longtermwiki.com/sourcing/grants/puWuLWaR5g` returns `308` with `Location: /sourcing/grant/puWuLWaR5g`
- [ ] Post-deploy: `curl -sI https://www.longtermwiki.com/sourcing/grant/puWuLWaR5g` still returns `200` (no regression on canonical form)

## Background

Found during review of Vercel production logs on 2026-04-13. The plural-form 404s were 85% of all 404s in the sample. See QUA-399 for full breakdown.
