### PR TITLE
feat(pr-review): narrow-patch detector for /agent-review-pr (QUA-356)

### DIFF
--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -112,6 +112,20 @@ pnpm crux w validate gate --fix
 
 ## Phase 3: Diff review (subagent) — ≥30 lines changed
 
+### 3a. Narrow-patch signature check (always, fast)
+
+Before spawning the review subagent, run the narrow-patch detector. It flags the "column-name-gated value probe" pattern that produced the QUA-316 → QUA-346 → QUA-354 cascade, where raw `f_xxx` fact IDs were masked one column at a time until a content-based regex replaced both narrow patches.
+
+```bash
+npx tsx crux/pr-review/detect-narrow-patch.ts
+```
+
+The detector fires at MEDIUM severity when the diff adds a conditional that *both* gates on a literal column name (`columnName === "..."`, `field.name === "..."`, etc.) *and* probes the value's signature (`.startsWith(`, `.test(`, `.match(`, `.includes(`). Pure formatting transforms (`toFixed`, `Intl.NumberFormat`, `formatCurrency`) are not flagged.
+
+**Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `.claude/rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
+
+### 3b. Hostile reviewer subagent
+
 Use the Agent tool to spawn a fresh subagent (subagent_type: "general-purpose") with NO prior context.
 
 Provide it with the full diff (`git diff main...HEAD`) and this prompt:

--- a/crux/pr-review/detect-narrow-patch.ts
+++ b/crux/pr-review/detect-narrow-patch.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * CLI entry for the narrow-patch detector (QUA-356).
+ *
+ * Usage (from the repo root):
+ *   npx tsx crux/pr-review/detect-narrow-patch.ts
+ *
+ * Reads `git diff <base>...HEAD` (default base: `main`), runs the detector,
+ * and prints findings. Exits 0 always — this is an advisory hint, not a gate.
+ * `/agent-review-pr` invokes it in Phase 3 alongside the hostile-reviewer
+ * subagent.
+ *
+ * Options:
+ *   --base=<ref>   Git base to diff against (default: main)
+ *   --stdin        Read the diff from stdin instead of running git
+ *   --json         Emit findings as JSON
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { detectNarrowPatches, formatFindings } from "./narrow-patch-detector.ts";
+
+function parseArgs(argv: string[]): {
+  base: string;
+  stdin: boolean;
+  json: boolean;
+} {
+  const args = { base: "main", stdin: false, json: false };
+  for (const arg of argv) {
+    if (arg === "--stdin") args.stdin = true;
+    else if (arg === "--json") args.json = true;
+    else if (arg.startsWith("--base=")) args.base = arg.slice("--base=".length);
+  }
+  return args;
+}
+
+function readDiff(opts: { base: string; stdin: boolean }): string {
+  if (opts.stdin) {
+    return readFileSync(0, "utf8");
+  }
+  try {
+    return execSync(`git diff ${opts.base}...HEAD`, {
+      encoding: "utf8",
+      maxBuffer: 50 * 1024 * 1024,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`detect-narrow-patch: failed to run git diff: ${msg}`);
+    process.exit(0); // advisory — never block
+  }
+}
+
+function main(): void {
+  const opts = parseArgs(process.argv.slice(2));
+  const diff = readDiff(opts);
+  const findings = detectNarrowPatches(diff);
+
+  if (opts.json) {
+    console.log(JSON.stringify(findings, null, 2));
+  } else {
+    console.log(formatFindings(findings));
+  }
+  process.exit(0);
+}
+
+main();

--- a/crux/pr-review/detect-narrow-patch.ts
+++ b/crux/pr-review/detect-narrow-patch.ts
@@ -16,54 +16,44 @@
  *   --json         Emit findings as JSON
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { parseCliArgs } from "../lib/cli.ts";
+import { gitSafe, isValidBranchName } from "../lib/git.ts";
 import { detectNarrowPatches, formatFindings } from "./narrow-patch-detector.ts";
 
-// Allowlist for the --base flag: the characters that appear in legitimate git
-// refnames (letters, digits, `._/-`). We run the git command via execFileSync
-// with an array argument, but a stray `--` or flag-like value would still
-// confuse git — the allowlist makes that impossible.
-const REFNAME_RE = /^[A-Za-z0-9._/-]+$/;
-
-function parseArgs(argv: string[]): {
+interface Options {
   base: string;
   stdin: boolean;
   json: boolean;
-} {
-  const args = { base: "main", stdin: false, json: false };
-  for (const arg of argv) {
-    if (arg === "--stdin") args.stdin = true;
-    else if (arg === "--json") args.json = true;
-    else if (arg.startsWith("--base=")) args.base = arg.slice("--base=".length);
-  }
-  return args;
 }
 
-function readDiff(opts: { base: string; stdin: boolean }): string {
+function resolveOptions(argv: string[]): Options {
+  const parsed = parseCliArgs(argv);
+  return {
+    base: typeof parsed.base === "string" ? parsed.base : "main",
+    stdin: parsed.stdin === true,
+    json: parsed.json === true,
+  };
+}
+
+function readDiff(opts: Options): string {
   if (opts.stdin) {
     return readFileSync(0, "utf8");
   }
-  if (!REFNAME_RE.test(opts.base)) {
-    console.error(
-      `detect-narrow-patch: invalid --base value "${opts.base}" (must match ${REFNAME_RE})`
-    );
+  if (!isValidBranchName(opts.base)) {
+    console.error(`detect-narrow-patch: invalid --base value "${opts.base}"`);
     process.exit(0); // advisory — never block
   }
-  try {
-    return execFileSync("git", ["diff", `${opts.base}...HEAD`], {
-      encoding: "utf8",
-      maxBuffer: 50 * 1024 * 1024,
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`detect-narrow-patch: failed to run git diff: ${msg}`);
+  const result = gitSafe("diff", `${opts.base}...HEAD`);
+  if (!result.ok) {
+    console.error(`detect-narrow-patch: git diff failed: ${result.stderr}`);
     process.exit(0); // advisory — never block
   }
+  return result.output;
 }
 
 function main(): void {
-  const opts = parseArgs(process.argv.slice(2));
+  const opts = resolveOptions(process.argv.slice(2));
   const diff = readDiff(opts);
   const findings = detectNarrowPatches(diff);
 

--- a/crux/pr-review/detect-narrow-patch.ts
+++ b/crux/pr-review/detect-narrow-patch.ts
@@ -16,9 +16,15 @@
  *   --json         Emit findings as JSON
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { detectNarrowPatches, formatFindings } from "./narrow-patch-detector.ts";
+
+// Allowlist for the --base flag: the characters that appear in legitimate git
+// refnames (letters, digits, `._/-`). We run the git command via execFileSync
+// with an array argument, but a stray `--` or flag-like value would still
+// confuse git — the allowlist makes that impossible.
+const REFNAME_RE = /^[A-Za-z0-9._/-]+$/;
 
 function parseArgs(argv: string[]): {
   base: string;
@@ -38,8 +44,14 @@ function readDiff(opts: { base: string; stdin: boolean }): string {
   if (opts.stdin) {
     return readFileSync(0, "utf8");
   }
+  if (!REFNAME_RE.test(opts.base)) {
+    console.error(
+      `detect-narrow-patch: invalid --base value "${opts.base}" (must match ${REFNAME_RE})`
+    );
+    process.exit(0); // advisory — never block
+  }
   try {
-    return execSync(`git diff ${opts.base}...HEAD`, {
+    return execFileSync("git", ["diff", `${opts.base}...HEAD`], {
       encoding: "utf8",
       maxBuffer: 50 * 1024 * 1024,
     });

--- a/crux/pr-review/narrow-patch-detector.test.ts
+++ b/crux/pr-review/narrow-patch-detector.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectNarrowPatches,
+  parseDiff,
+  formatFindings,
+} from "./narrow-patch-detector.ts";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+// Excerpt of the real QUA-346 / PR #4257 diff. This is the exact shape we want
+// to flag: a conditional added to a generic cell renderer that gates on a
+// literal column name AND probes the value's signature with startsWith.
+const QUA_346_DIFF = `diff --git a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+index 4aac1f341..1fcb9b6c3 100644
+--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
++++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+@@ -339,6 +339,23 @@ function CellValue({
+     return <JsonValue value={value} />;
+   }
+
++  // FactBase fact IDs (f_xxx) -> render as link with "view →" label instead of leaking raw ID.
++  if (
++    (columnName === "fact_id" || columnName === "factId") &&
++    typeof value === "string" &&
++    value.startsWith("f_")
++  ) {
++    return (
++      <Link
++        href={\`/factbase/fact/\${encodeURIComponent(value)}\`}
++        className="text-blue-600 dark:text-blue-400 hover:underline text-[11px]"
++        title={value}
++      >
++        view →
++      </Link>
++    );
++  }
++
+   // Entity reference columns -> show resolved name as link
+   const isEntityRef = isEntityRefColumn(columnName);
+`;
+
+// The proper systemic fix (QUA-354 / PR #4268): replaces the column-name gate
+// with a content-based regex. This should NOT flag — the added block no longer
+// contains a column-name literal equality.
+const QUA_354_PROPER_FIX_DIFF = `diff --git a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+index 1fcb9b6c3..6af073f14 100644
+--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
++++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+@@ -258,6 +258,13 @@ const GLOBAL_HIDDEN_COLUMNS = new Set(["id"]);
+ /** Max rows to show initially before "Show all" */
+ const INITIAL_ROW_LIMIT = 20;
+
++// ── ID detection ──────────────────────────────────────────────────────────
++
++// FactBase fact IDs are \`f_\` + 8-12 alphanumeric chars.
++// Used by the cell renderer to detect raw fact IDs in any column and link them
++// to /factbase/fact/<id> instead of leaking the raw ID as visible text.
++const FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
++
+ // ── Numeric formatting columns ────────────────────────────────────────────
+
+ /** Columns representing monetary amounts (Drizzle returns numeric() as strings) */
+@@ -340,11 +347,10 @@ function CellValue({
+   }
+
+   // FactBase fact IDs (f_xxx) -> render as link with "view →" label instead of leaking raw ID.
+-  if (
+-    (columnName === "fact_id" || columnName === "factId") &&
+-    typeof value === "string" &&
+-    value.startsWith("f_")
+-  ) {
++  // Content-based, not column-name-gated: any cell value matching the fact-ID format gets
++  // rendered as a link, no matter which column it lives in.
++  if (typeof value === "string" && FACT_ID_RE.test(value)) {
+     return (
+       <Link
+         href={\`/factbase/fact/\${encodeURIComponent(value)}\`}
+`;
+
+// False-positive guard #1: pure currency formatting. Adds a conditional gated
+// on a column name, but the body uses toLocaleString — no value probe. Must NOT
+// flag.
+const CURRENCY_FORMAT_DIFF = `diff --git a/apps/web/src/components/cell-formatter.tsx b/apps/web/src/components/cell-formatter.tsx
+index 1111111..2222222 100644
+--- a/apps/web/src/components/cell-formatter.tsx
++++ b/apps/web/src/components/cell-formatter.tsx
+@@ -10,6 +10,11 @@ export function Cell({ columnName, value }) {
+     return <span>{value}</span>;
+   }
+
++  if (columnName === "revenue" && typeof value === "number") {
++    return <span>\${value.toLocaleString("en-US")}</span>;
++  }
++
+   return <span>{String(value)}</span>;
+ }
+`;
+
+// False-positive guard #2: pure percentage formatting using toFixed.
+const PERCENT_FORMAT_DIFF = `diff --git a/apps/web/src/components/cell-formatter.tsx b/apps/web/src/components/cell-formatter.tsx
+index 1111111..2222222 100644
+--- a/apps/web/src/components/cell-formatter.tsx
++++ b/apps/web/src/components/cell-formatter.tsx
+@@ -10,6 +10,10 @@ export function Cell({ columnName, value }) {
+     return <span>{value}</span>;
+   }
+
++  if (columnName === "growth_rate" && typeof value === "number") {
++    return <span>{(value * 100).toFixed(1)}%</span>;
++  }
++
+   return <span>{String(value)}</span>;
+ }
+`;
+
+// False-positive guard #3: unrelated refactor. No column-name gate, no value probe.
+const UNRELATED_REFACTOR_DIFF = `diff --git a/crux/lib/helpers.ts b/crux/lib/helpers.ts
+index 1111111..2222222 100644
+--- a/crux/lib/helpers.ts
++++ b/crux/lib/helpers.ts
+@@ -5,6 +5,10 @@ export function sum(nums: number[]): number {
+   return nums.reduce((a, b) => a + b, 0);
+ }
+
++export function avg(nums: number[]): number {
++  return nums.length === 0 ? 0 : sum(nums) / nums.length;
++}
++
+ export function clamp(n: number, lo: number, hi: number): number {
+   return Math.max(lo, Math.min(hi, n));
+ }
+`;
+
+// False-positive guard #4: content-based probe WITHOUT a column gate. This is
+// the RIGHT pattern — should not flag even though it probes the value.
+const CONTENT_BASED_DIFF = `diff --git a/apps/web/src/components/cell-formatter.tsx b/apps/web/src/components/cell-formatter.tsx
+index 1111111..2222222 100644
+--- a/apps/web/src/components/cell-formatter.tsx
++++ b/apps/web/src/components/cell-formatter.tsx
+@@ -10,6 +10,10 @@ export function Cell({ columnName, value }) {
+     return <span>{value}</span>;
+   }
+
++  if (typeof value === "string" && /^f_[A-Za-z0-9]{8,}$/.test(value)) {
++    return <Link href={\`/factbase/fact/\${value}\`}>view →</Link>;
++  }
++
+   return <span>{String(value)}</span>;
+ }
+`;
+
+// False-positive guard #5: test file with the signature. Tests legitimately
+// contain the pattern as fixtures — should be skipped.
+const TEST_FILE_DIFF = `diff --git a/apps/web/src/components/cell-formatter.test.tsx b/apps/web/src/components/cell-formatter.test.tsx
+index 1111111..2222222 100644
+--- a/apps/web/src/components/cell-formatter.test.tsx
++++ b/apps/web/src/components/cell-formatter.test.tsx
+@@ -10,6 +10,15 @@ describe("Cell", () => {
+     expect(true).toBe(true);
+   });
+
++  it("flags legacy pattern", () => {
++    const value = "f_abc";
++    const columnName = "fact_id";
++    if (columnName === "fact_id" && value.startsWith("f_")) {
++      expect(true).toBe(true);
++    }
++  });
++
+ });
+`;
+
+// ─── parseDiff tests ──────────────────────────────────────────────────────
+
+describe("parseDiff", () => {
+  it("extracts file name and added lines from a single-hunk diff", () => {
+    const hunks = parseDiff(QUA_346_DIFF);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].file).toBe(
+      "apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx"
+    );
+    expect(hunks[0].newStartLine).toBe(339);
+    const addedJoined = hunks[0].addedLines.map((l) => l.text).join("\n");
+    expect(addedJoined).toContain(`columnName === "fact_id"`);
+    expect(addedJoined).toContain(`value.startsWith("f_")`);
+  });
+
+  it("tracks correct line numbers on the new side", () => {
+    const hunks = parseDiff(QUA_346_DIFF);
+    const columnGateLine = hunks[0].addedLines.find((l) =>
+      l.text.includes(`columnName === "fact_id"`)
+    );
+    expect(columnGateLine).toBeDefined();
+    // The gate should be on or after newStartLine.
+    expect(columnGateLine!.line).toBeGreaterThanOrEqual(339);
+  });
+
+  it("returns empty when the diff is empty", () => {
+    expect(parseDiff("")).toEqual([]);
+  });
+
+  it("handles multi-hunk diffs", () => {
+    const hunks = parseDiff(QUA_354_PROPER_FIX_DIFF);
+    expect(hunks.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─── detectNarrowPatches tests ────────────────────────────────────────────
+
+describe("detectNarrowPatches — acceptance fixtures", () => {
+  it("fires on the QUA-346 diff (the canonical narrow patch)", () => {
+    const findings = detectNarrowPatches(QUA_346_DIFF);
+    expect(findings).toHaveLength(1);
+    const [f] = findings;
+    expect(f.severity).toBe("MEDIUM");
+    expect(f.file).toBe(
+      "apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx"
+    );
+    expect(f.relatedIncidents).toContain("QUA-316");
+    expect(f.relatedIncidents).toContain("QUA-346");
+    expect(f.message).toMatch(/narrow-patch/i);
+    expect(f.message).toMatch(/content-based/i);
+    // Path contains "viewer" → renderer-file message variant.
+    expect(f.message).toMatch(/renderer|formatter|validator/i);
+  });
+
+  it("does NOT fire on the QUA-354 proper systemic fix", () => {
+    const findings = detectNarrowPatches(QUA_354_PROPER_FIX_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does NOT fire on pure currency formatting (toLocaleString)", () => {
+    const findings = detectNarrowPatches(CURRENCY_FORMAT_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does NOT fire on pure percentage formatting (toFixed)", () => {
+    const findings = detectNarrowPatches(PERCENT_FORMAT_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does NOT fire on unrelated refactors", () => {
+    const findings = detectNarrowPatches(UNRELATED_REFACTOR_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does NOT fire on content-based probes without a column gate", () => {
+    const findings = detectNarrowPatches(CONTENT_BASED_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does NOT fire on test files even when the signature matches", () => {
+    const findings = detectNarrowPatches(TEST_FILE_DIFF);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("returns empty array on empty diff", () => {
+    expect(detectNarrowPatches("")).toEqual([]);
+  });
+});
+
+// ─── Adversarial / edge-case variants ─────────────────────────────────────
+
+describe("detectNarrowPatches — variants of the same signature", () => {
+  it("flags `.test(` probes (regex match)", () => {
+    const diff = `diff --git a/apps/web/src/components/render.tsx b/apps/web/src/components/render.tsx
+--- a/apps/web/src/components/render.tsx
++++ b/apps/web/src/components/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "entity_id" && /^sid_/.test(value)) {
++    return <Link href={\`/wiki/\${value}\`}>view →</Link>;
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toContain("render.tsx");
+  });
+
+  it("flags `.includes(` probes", () => {
+    const diff = `diff --git a/apps/web/src/components/render.tsx b/apps/web/src/components/render.tsx
+--- a/apps/web/src/components/render.tsx
++++ b/apps/web/src/components/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "ref" && value.includes("sid_")) {
++    return <Link href={\`/wiki/\${value}\`}>view →</Link>;
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags `.match(` probes", () => {
+    const diff = `diff --git a/apps/web/src/components/render.tsx b/apps/web/src/components/render.tsx
+--- a/apps/web/src/components/render.tsx
++++ b/apps/web/src/components/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "slug" && value.match(/^sid_/)) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags `field.name === 'x'` variants", () => {
+    const diff = `diff --git a/apps/web/src/components/render.tsx b/apps/web/src/components/render.tsx
+--- a/apps/web/src/components/render.tsx
++++ b/apps/web/src/components/render.tsx
+@@ -5,0 +6,5 @@
++  if (field.name === "fact_id" && value.startsWith("f_")) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+  });
+
+  it("emits the non-renderer message variant for paths without renderer keywords", () => {
+    const diff = `diff --git a/crux/lib/other/misc.ts b/crux/lib/other/misc.ts
+--- a/crux/lib/other/misc.ts
++++ b/crux/lib/other/misc.ts
+@@ -5,0 +6,5 @@
++  if (columnName === "fact_id" && value.startsWith("f_")) {
++    return "masked";
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    // Message should still reference QUA-316/QUA-346 but not claim renderer path.
+    expect(findings[0].message).toMatch(/QUA-316.*QUA-346|QUA-346.*QUA-316/);
+    expect(findings[0].message).not.toMatch(
+      /renderer\/formatter\/validator, which/
+    );
+  });
+});
+
+// ─── formatFindings ───────────────────────────────────────────────────────
+
+describe("formatFindings", () => {
+  it("prints 'no matches' for empty findings", () => {
+    expect(formatFindings([])).toContain("no matches");
+  });
+
+  it("prints each finding with file:line, message, related, snippet", () => {
+    const findings = detectNarrowPatches(QUA_346_DIFF);
+    const out = formatFindings(findings);
+    expect(out).toContain("[MEDIUM]");
+    expect(out).toContain("entity-profile-viewer.tsx");
+    expect(out).toContain("QUA-316, QUA-346");
+    expect(out).toContain("snippet:");
+  });
+});

--- a/crux/pr-review/narrow-patch-detector.test.ts
+++ b/crux/pr-review/narrow-patch-detector.test.ts
@@ -339,6 +339,212 @@ describe("detectNarrowPatches — variants of the same signature", () => {
   });
 });
 
+// ─── Regression tests for issues found during self-review ────────────────
+
+describe("detectNarrowPatches — regressions from review", () => {
+  it("handles paths that contain `/b/` segments (uses +++ b/ for filename)", () => {
+    // Regression: original parseDiff used `\bb/(.+)$` against the `diff --git`
+    // header, which greedily matched the first `b/` in the path.
+    const diff = `diff --git a/src/b/component.tsx b/src/b/component.tsx
+index 1111..2222 100644
+--- a/src/b/component.tsx
++++ b/src/b/component.tsx
+@@ -10,0 +11,5 @@
++  if (columnName === "fact_id" && value.startsWith("f_")) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    const hunks = parseDiff(diff);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].file).toBe("src/b/component.tsx");
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toBe("src/b/component.tsx");
+  });
+
+  it("handles CRLF line endings", () => {
+    // Regression: split("\n") leaves trailing \r, which used to fall into the
+    // unknown-line branch and silently abort the hunk.
+    const unixDiff = `diff --git a/src/render.tsx b/src/render.tsx
+--- a/src/render.tsx
++++ b/src/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "fact_id" && value.startsWith("f_")) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    const crlfDiff = unixDiff.replace(/\n/g, "\r\n");
+    const findings = detectNarrowPatches(crlfDiff);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toBe("src/render.tsx");
+    expect(findings[0].line).toBeGreaterThanOrEqual(6);
+  });
+
+  it("does NOT co-fire when two unrelated changes sit in the same hunk", () => {
+    // Regression: the old implementation joined all added lines per hunk and
+    // tested the regexes against the joined text, so an unrelated column gate
+    // in one edit and an unrelated value probe in another would co-fire.
+    // Now the detector splits into contiguous runs.
+    const diff = `diff --git a/src/render.tsx b/src/render.tsx
+--- a/src/render.tsx
++++ b/src/render.tsx
+@@ -10,6 +10,14 @@
+   if (value == null) return null;
+
++  // unrelated format change — gates on column name, no probe
++  if (columnName === "revenue") {
++    return formatCurrency(value);
++  }
++
+   return <span>{value}</span>;
+ }
+
++// totally separate helper added lower in the same hunk — uses .startsWith but
++// does NOT gate on a column name, so by itself it's fine.
++export function hasFactPrefix(v: string): boolean {
++  return v.startsWith("f_");
++}
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags `field.name === 'x'` specifically (not `name === 'x'`)", () => {
+    // Regression: `name === "x"` is too broad (common object-lookup idiom).
+    // The `key` alternative was also removed for the same reason.
+    const nakedName = `diff --git a/src/helper.ts b/src/helper.ts
+--- a/src/helper.ts
++++ b/src/helper.ts
+@@ -5,0 +6,5 @@
++  if (name === "fact_id" && value.startsWith("f_")) {
++    return "masked";
++  }
++
+`;
+    expect(detectNarrowPatches(nakedName)).toHaveLength(0);
+
+    const nakedKey = `diff --git a/src/helper.ts b/src/helper.ts
+--- a/src/helper.ts
++++ b/src/helper.ts
+@@ -5,0 +6,5 @@
++  if (key === "fact_id" && value.startsWith("f_")) {
++    return "masked";
++  }
++
+`;
+    expect(detectNarrowPatches(nakedKey)).toHaveLength(0);
+
+    // But the qualified forms (field.name, row.column) still flag.
+    const qualified = `diff --git a/src/helper.ts b/src/helper.ts
+--- a/src/helper.ts
++++ b/src/helper.ts
+@@ -5,0 +6,5 @@
++  if (field.name === "fact_id" && value.startsWith("f_")) {
++    return "masked";
++  }
++
+`;
+    expect(detectNarrowPatches(qualified)).toHaveLength(1);
+  });
+
+  it("flags `.search(` and `.exec(` value probes (added in review)", () => {
+    const diffSearch = `diff --git a/src/render.tsx b/src/render.tsx
+--- a/src/render.tsx
++++ b/src/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "slug" && value.search(/^sid_/) >= 0) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    expect(detectNarrowPatches(diffSearch)).toHaveLength(1);
+
+    const diffExec = `diff --git a/src/render.tsx b/src/render.tsx
+--- a/src/render.tsx
++++ b/src/render.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "slug" && /^sid_/.exec(value)) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    expect(detectNarrowPatches(diffExec)).toHaveLength(1);
+  });
+
+  it("skips deleted files (+++ /dev/null) without crashing", () => {
+    const diff = `diff --git a/src/old.tsx b/src/old.tsx
+deleted file mode 100644
+index 1111..0000
+--- a/src/old.tsx
++++ /dev/null
+@@ -1,5 +0,0 @@
+-if (columnName === "fact_id" && value.startsWith("f_")) {
+-  return <Link>view →</Link>;
+-}
+`;
+    expect(() => detectNarrowPatches(diff)).not.toThrow();
+    expect(detectNarrowPatches(diff)).toHaveLength(0);
+  });
+
+  it("handles multi-file diffs (each file parsed independently)", () => {
+    const diff = `diff --git a/src/a.tsx b/src/a.tsx
+--- a/src/a.tsx
++++ b/src/a.tsx
+@@ -5,0 +6,5 @@
++  if (columnName === "fact_id" && value.startsWith("f_")) {
++    return null;
++  }
++
+diff --git a/src/b.tsx b/src/b.tsx
+--- a/src/b.tsx
++++ b/src/b.tsx
+@@ -10,0 +11,3 @@
++export function unrelated() {
++  return 42;
++}
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toBe("src/a.tsx");
+  });
+
+  it("handles hunk headers without line-count commas (@@ -1 +1 @@)", () => {
+    const diff = `diff --git a/src/x.ts b/src/x.ts
+--- a/src/x.ts
++++ b/src/x.ts
+@@ -1 +1,5 @@
+-export const x = 1;
++if (columnName === "fact_id" && value.startsWith("f_")) {
++  return null;
++}
++export const x = 2;
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reports a precise line number for the column-gate line", () => {
+    const diff = `diff --git a/src/render.tsx b/src/render.tsx
+--- a/src/render.tsx
++++ b/src/render.tsx
+@@ -10,0 +11,6 @@
++  // a comment
++  const prefix = "f_";
++  if (columnName === "fact_id" && value.startsWith(prefix)) {
++    return <Link>view →</Link>;
++  }
++
+`;
+    const findings = detectNarrowPatches(diff);
+    expect(findings).toHaveLength(1);
+    // The gate is on the 3rd added line (line 13 in the new file).
+    expect(findings[0].line).toBe(13);
+  });
+});
+
 // ─── formatFindings ───────────────────────────────────────────────────────
 
 describe("formatFindings", () => {

--- a/crux/pr-review/narrow-patch-detector.ts
+++ b/crux/pr-review/narrow-patch-detector.ts
@@ -1,0 +1,227 @@
+/**
+ * Narrow-patch detector (QUA-356)
+ *
+ * Flags a diff pattern that has historically masked a class-shaped bug behind a
+ * one-component, column-name-gated check. The canonical example is QUA-346:
+ * masking raw FactBase `f_xxx` IDs in `CellValue` only when the column name is
+ * `fact_id` / `factId`, instead of doing content-based detection regardless of
+ * column. QUA-316 was the first narrow patch in the same class; QUA-354 / PR
+ * #4268 is the proper systemic fix that replaced both with a regex on the value.
+ *
+ * This detector is an advisory review-time hint, not a gate check. It fires at
+ * MEDIUM severity when the added lines contain BOTH:
+ *   1. A column-name-literal equality gate, e.g. `columnName === "fact_id"` or
+ *      `column.name === "x"` or `field.name === "y"`.
+ *   2. A value-signature probe: `.startsWith(`, `.endsWith(`, `.test(`,
+ *      `.match(`, `.includes(` on the value itself.
+ *
+ * False-positive guards:
+ *   - Pure formatting blocks (`toFixed`, `Intl.NumberFormat`, `formatCurrency`,
+ *     `formatPercent`, `toLocaleString`) that do NOT probe the value's signature
+ *     are allowed through — they transform the value rather than masking it.
+ *   - Diffs without both a column-name gate AND a value probe never fire.
+ *   - Test files are skipped (test fixtures deliberately contain the signature).
+ *
+ * Output shape matches the hostile-reviewer finding format in
+ * `.claude/commands/agent-review-pr.md` Phase 3.
+ */
+
+export interface NarrowPatchFinding {
+  severity: "MEDIUM";
+  file: string;
+  line: number;
+  message: string;
+  snippet: string;
+  relatedIncidents: string[];
+}
+
+// Matches `columnName === "fact_id"`, `column.name === 'x'`, `field.name === \`y\``,
+// and the loose `key === "literal"` shape. Uses `===` or `==`.
+const COLUMN_NAME_GATE_RE =
+  /\b(?:columnName|fieldName|column\.name|col\.name|field\.name|colName|key)\s*===?\s*["'`][A-Za-z_][\w-]*["'`]/;
+
+// Matches `.startsWith(`, `.endsWith(`, `.test(`, `.match(`, `.includes(` on any
+// receiver. These are "probe the value for a signature" calls — the exact
+// anti-pattern in QUA-316/QUA-346.
+const VALUE_SIGNATURE_RE = /\.\s*(?:startsWith|endsWith|includes|test|match)\s*\(/;
+
+// Pure-formatting calls that transform (not probe) the value. If an added block
+// only contains these (and no VALUE_SIGNATURE_RE match), we ignore it. This is
+// defensive — the primary filter is requiring a VALUE_SIGNATURE_RE hit.
+const FORMATTING_RE =
+  /\b(?:toFixed|toLocaleString|Intl\.NumberFormat|formatCurrency|formatPercent|formatNumber|formatValue)\b/;
+
+// File paths that look like generic renderers/column rules/formatters/validators.
+// Used only to strengthen the message — the detector fires regardless of path.
+const RENDERER_PATH_RE =
+  /(?:render|cell|column|viewer|display|formatter|format-|validate-|validator)/i;
+
+interface ParsedHunk {
+  file: string;
+  newStartLine: number;
+  addedLines: Array<{ line: number; text: string }>;
+}
+
+/**
+ * Parse a unified diff into per-file hunks with line numbers for the added side.
+ */
+export function parseDiff(diff: string): ParsedHunk[] {
+  const hunks: ParsedHunk[] = [];
+  const parts = diff.split(/^diff --git /m);
+  for (let i = 1; i < parts.length; i++) {
+    const block = parts[i];
+    const firstNewline = block.indexOf("\n");
+    const header = firstNewline === -1 ? block : block.slice(0, firstNewline);
+    const bMatch = header.match(/\bb\/(.+)$/);
+    if (!bMatch) continue;
+    const file = bMatch[1].trim();
+
+    const lines = block.split("\n");
+    let j = 0;
+    while (j < lines.length) {
+      const line = lines[j];
+      const hunkHeader = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (!hunkHeader) {
+        j++;
+        continue;
+      }
+      const newStart = Number(hunkHeader[1]);
+      const added: Array<{ line: number; text: string }> = [];
+      let cursor = newStart;
+      j++;
+      while (j < lines.length && !lines[j].startsWith("@@ ")) {
+        const raw = lines[j];
+        if (raw.startsWith("+++") || raw.startsWith("---")) {
+          j++;
+          continue;
+        }
+        if (raw.startsWith("+")) {
+          added.push({ line: cursor, text: raw.slice(1) });
+          cursor++;
+        } else if (raw.startsWith("-")) {
+          // removal — does not advance the new-file cursor
+        } else if (raw.startsWith(" ")) {
+          cursor++;
+        } else if (raw === "\\ No newline at end of file") {
+          // ignore
+        } else if (raw === "") {
+          cursor++;
+        } else {
+          break;
+        }
+        j++;
+      }
+      if (added.length > 0) {
+        hunks.push({ file, newStartLine: newStart, addedLines: added });
+      }
+    }
+  }
+  return hunks;
+}
+
+/**
+ * Scans a unified diff for the narrow-patch signature and returns MEDIUM
+ * findings for each match. Never returns CRITICAL/HIGH — this rule is a hint,
+ * not a blocker.
+ */
+export function detectNarrowPatches(diff: string): NarrowPatchFinding[] {
+  const findings: NarrowPatchFinding[] = [];
+  const hunks = parseDiff(diff);
+
+  for (const hunk of hunks) {
+    if (hunk.addedLines.length === 0) continue;
+    if (!isCodeFile(hunk.file)) continue;
+    if (isTestFile(hunk.file)) continue;
+
+    const addedText = hunk.addedLines.map((l) => l.text).join("\n");
+
+    const hasColumnGate = COLUMN_NAME_GATE_RE.test(addedText);
+    const hasValueProbe = VALUE_SIGNATURE_RE.test(addedText);
+
+    if (!hasColumnGate || !hasValueProbe) continue;
+
+    const isPureFormatter =
+      FORMATTING_RE.test(addedText) && !VALUE_SIGNATURE_RE.test(addedText);
+    if (isPureFormatter) continue;
+
+    let lineNo = hunk.newStartLine;
+    for (const entry of hunk.addedLines) {
+      if (COLUMN_NAME_GATE_RE.test(entry.text)) {
+        lineNo = entry.line;
+        break;
+      }
+    }
+
+    const snippet = trimmedSnippet(addedText);
+    const isRendererFile = RENDERER_PATH_RE.test(hunk.file);
+    const message = buildMessage(isRendererFile);
+
+    findings.push({
+      severity: "MEDIUM",
+      file: hunk.file,
+      line: lineNo,
+      message,
+      snippet,
+      relatedIncidents: ["QUA-316", "QUA-346"],
+    });
+  }
+
+  return findings;
+}
+
+function isCodeFile(file: string): boolean {
+  return /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(file);
+}
+
+function isTestFile(file: string): boolean {
+  return /\.(?:test|spec)\.[tj]sx?$/.test(file) || file.includes("/__tests__/");
+}
+
+function trimmedSnippet(text: string): string {
+  const MAX = 400;
+  if (text.length <= MAX) return text;
+  return text.slice(0, MAX) + "\n…";
+}
+
+function buildMessage(isRendererFile: boolean): string {
+  const base =
+    "Narrow-patch signature detected: the added block gates on a literal column " +
+    "name AND probes the value's signature (startsWith/test/match/includes). " +
+    "This is the exact shape behind QUA-316 and QUA-346, where raw `f_xxx` fact " +
+    "IDs were masked one column at a time until QUA-354 replaced it with a " +
+    "content-based regex. ";
+  const cta =
+    "Before shipping, ask: can this be content-based (match the value's shape " +
+    "regardless of which column it lives in) instead of column-name-gated? If " +
+    "yes, do that instead — it prevents the recurring per-column patch loop.";
+  if (isRendererFile) {
+    return (
+      base +
+      "The file path looks like a generic renderer/formatter/validator, which " +
+      "makes a content-based fix especially likely to be the right call. " +
+      cta
+    );
+  }
+  return base + cta;
+}
+
+/** Pretty-print findings for CLI or review output. */
+export function formatFindings(findings: NarrowPatchFinding[]): string {
+  if (findings.length === 0) {
+    return "narrow-patch-detector: no matches";
+  }
+  const lines: string[] = [];
+  lines.push(`narrow-patch-detector: ${findings.length} finding(s)`);
+  lines.push("");
+  for (const f of findings) {
+    lines.push(`[${f.severity}] ${f.file}:${f.line}`);
+    lines.push(`  ${f.message}`);
+    lines.push(`  related: ${f.relatedIncidents.join(", ")}`);
+    lines.push("  snippet:");
+    for (const s of f.snippet.split("\n").slice(0, 8)) {
+      lines.push(`    ${s}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/crux/pr-review/narrow-patch-detector.ts
+++ b/crux/pr-review/narrow-patch-detector.ts
@@ -10,17 +10,23 @@
  *
  * This detector is an advisory review-time hint, not a gate check. It fires at
  * MEDIUM severity when the added lines contain BOTH:
- *   1. A column-name-literal equality gate, e.g. `columnName === "fact_id"` or
- *      `column.name === "x"` or `field.name === "y"`.
- *   2. A value-signature probe: `.startsWith(`, `.endsWith(`, `.test(`,
- *      `.match(`, `.includes(` on the value itself.
+ *   1. A column-name-literal equality gate — the column identifier
+ *      (columnName, fieldName, column.name, field.name, etc.) compared for
+ *      strict equality against a quoted literal.
+ *   2. A value-signature probe — one of the string/regex methods startsWith,
+ *      endsWith, includes, test, match, search, or exec called on the value.
+ *
+ * The examples are deliberately written in prose here instead of as code
+ * fragments, so the detector does not self-fire on its own docstring. See the
+ * tests for the canonical code shapes.
  *
  * False-positive guards:
- *   - Pure formatting blocks (`toFixed`, `Intl.NumberFormat`, `formatCurrency`,
- *     `formatPercent`, `toLocaleString`) that do NOT probe the value's signature
- *     are allowed through — they transform the value rather than masking it.
+ *   - Both patterns must appear in the same CONTIGUOUS run of added lines.
+ *     Two unrelated changes in one hunk (one adding a column gate elsewhere,
+ *     one adding a value probe) never co-fire.
  *   - Diffs without both a column-name gate AND a value probe never fire.
  *   - Test files are skipped (test fixtures deliberately contain the signature).
+ *   - Non-code files (markdown, YAML, SQL, config) are skipped.
  *
  * Output shape matches the hostile-reviewer finding format in
  * `.claude/commands/agent-review-pr.md` Phase 3.
@@ -35,21 +41,18 @@ export interface NarrowPatchFinding {
   relatedIncidents: string[];
 }
 
-// Matches `columnName === "fact_id"`, `column.name === 'x'`, `field.name === \`y\``,
-// and the loose `key === "literal"` shape. Uses `===` or `==`.
+// Matches a column identifier (columnName, fieldName, column.name, col.name,
+// field.name, colName, or any `<receiver>.column`) strict-equality tested
+// against a quoted string literal. The `key` alternative was removed after
+// review — too broad (common object-lookup idiom).
 const COLUMN_NAME_GATE_RE =
-  /\b(?:columnName|fieldName|column\.name|col\.name|field\.name|colName|key)\s*===?\s*["'`][A-Za-z_][\w-]*["'`]/;
+  /\b(?:columnName|fieldName|colName|column\.name|col\.name|field\.name|\w+\.column)\s*===?\s*["'`][A-Za-z_][\w-]*["'`]/;
 
-// Matches `.startsWith(`, `.endsWith(`, `.test(`, `.match(`, `.includes(` on any
-// receiver. These are "probe the value for a signature" calls — the exact
-// anti-pattern in QUA-316/QUA-346.
-const VALUE_SIGNATURE_RE = /\.\s*(?:startsWith|endsWith|includes|test|match)\s*\(/;
-
-// Pure-formatting calls that transform (not probe) the value. If an added block
-// only contains these (and no VALUE_SIGNATURE_RE match), we ignore it. This is
-// defensive — the primary filter is requiring a VALUE_SIGNATURE_RE hit.
-const FORMATTING_RE =
-  /\b(?:toFixed|toLocaleString|Intl\.NumberFormat|formatCurrency|formatPercent|formatNumber|formatValue)\b/;
+// Matches a method call that probes a value's signature: one of startsWith,
+// endsWith, includes, test, match, search, or exec invoked via dot-call on any
+// receiver. This is the exact anti-pattern in QUA-316/QUA-346.
+const VALUE_SIGNATURE_RE =
+  /\.\s*(?:startsWith|endsWith|includes|test|match|search|exec)\s*\(/;
 
 // File paths that look like generic renderers/column rules/formatters/validators.
 // Used only to strengthen the message — the detector fires regardless of path.
@@ -64,20 +67,52 @@ interface ParsedHunk {
 
 /**
  * Parse a unified diff into per-file hunks with line numbers for the added side.
+ *
+ * Uses the `+++ b/<path>` line for the filename (NOT the `diff --git a/X b/Y`
+ * header) because the `diff --git` header is whitespace-split and breaks on
+ * paths that contain spaces or `/b/` segments. The `+++ b/<path>` line is the
+ * canonical new-file path and is always present for modified/added files.
+ *
+ * CRLF line endings are normalized at input so Windows-sourced diffs parse
+ * identically to Unix diffs.
  */
 export function parseDiff(diff: string): ParsedHunk[] {
   const hunks: ParsedHunk[] = [];
-  const parts = diff.split(/^diff --git /m);
+  // Normalize CRLF → LF so trailing \r doesn't fall through to the unknown-line
+  // branch and silently abort a hunk.
+  const normalized = diff.replace(/\r\n/g, "\n").replace(/\r/g, "");
+  const parts = normalized.split(/^diff --git /m);
+
   for (let i = 1; i < parts.length; i++) {
     const block = parts[i];
-    const firstNewline = block.indexOf("\n");
-    const header = firstNewline === -1 ? block : block.slice(0, firstNewline);
-    const bMatch = header.match(/\bb\/(.+)$/);
-    if (!bMatch) continue;
-    const file = bMatch[1].trim();
-
     const lines = block.split("\n");
+
+    // Walk once: pick up the `+++ b/<path>` filename, then parse hunks. If the
+    // block has `+++ /dev/null` (file deleted), skip — there are no added lines.
+    let file: string | null = null;
     let j = 0;
+    while (j < lines.length) {
+      const line = lines[j];
+      if (line.startsWith("+++ b/")) {
+        file = line.slice("+++ b/".length);
+        j++;
+        break;
+      }
+      if (line.startsWith("+++ /dev/null")) {
+        file = null;
+        j++;
+        break;
+      }
+      if (line.startsWith("@@ ")) {
+        // Reached hunks without finding a +++ b/ line (binary diff, rename with
+        // no content change, etc.) — nothing to collect.
+        break;
+      }
+      j++;
+    }
+    if (file == null) continue;
+
+    // Now parse hunks.
     while (j < lines.length) {
       const line = lines[j];
       const hunkHeader = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
@@ -91,10 +126,6 @@ export function parseDiff(diff: string): ParsedHunk[] {
       j++;
       while (j < lines.length && !lines[j].startsWith("@@ ")) {
         const raw = lines[j];
-        if (raw.startsWith("+++") || raw.startsWith("---")) {
-          j++;
-          continue;
-        }
         if (raw.startsWith("+")) {
           added.push({ line: cursor, text: raw.slice(1) });
           cursor++;
@@ -105,8 +136,10 @@ export function parseDiff(diff: string): ParsedHunk[] {
         } else if (raw === "\\ No newline at end of file") {
           // ignore
         } else if (raw === "") {
-          cursor++;
+          // Blank entry from trailing split — don't advance cursor (empty
+          // context lines show up as a single space in unified diff, not as "").
         } else {
+          // Unknown content — we've walked off the hunk (rare).
           break;
         }
         j++;
@@ -120,9 +153,38 @@ export function parseDiff(diff: string): ParsedHunk[] {
 }
 
 /**
+ * Split a hunk's added lines into contiguous runs — groups of lines with
+ * consecutive new-file line numbers. Two unrelated changes in the same hunk
+ * end up as separate runs, which lets the detector avoid cross-change false
+ * positives.
+ */
+function contiguousRuns(
+  hunk: ParsedHunk
+): Array<Array<{ line: number; text: string }>> {
+  const runs: Array<Array<{ line: number; text: string }>> = [];
+  let current: Array<{ line: number; text: string }> = [];
+  let prevLine = -1;
+  for (const entry of hunk.addedLines) {
+    if (current.length === 0 || entry.line === prevLine + 1) {
+      current.push(entry);
+    } else {
+      runs.push(current);
+      current = [entry];
+    }
+    prevLine = entry.line;
+  }
+  if (current.length > 0) runs.push(current);
+  return runs;
+}
+
+/**
  * Scans a unified diff for the narrow-patch signature and returns MEDIUM
  * findings for each match. Never returns CRITICAL/HIGH — this rule is a hint,
  * not a blocker.
+ *
+ * Fires once per contiguous added-line run (not once per hunk): two unrelated
+ * edits in the same hunk do NOT co-fire unless both the column-name gate and
+ * the value-signature probe appear in the SAME added-line run.
  */
 export function detectNarrowPatches(diff: string): NarrowPatchFinding[] {
   const findings: NarrowPatchFinding[] = [];
@@ -133,37 +195,37 @@ export function detectNarrowPatches(diff: string): NarrowPatchFinding[] {
     if (!isCodeFile(hunk.file)) continue;
     if (isTestFile(hunk.file)) continue;
 
-    const addedText = hunk.addedLines.map((l) => l.text).join("\n");
+    const runs = contiguousRuns(hunk);
+    for (const run of runs) {
+      const runText = run.map((l) => l.text).join("\n");
 
-    const hasColumnGate = COLUMN_NAME_GATE_RE.test(addedText);
-    const hasValueProbe = VALUE_SIGNATURE_RE.test(addedText);
+      if (!COLUMN_NAME_GATE_RE.test(runText)) continue;
+      if (!VALUE_SIGNATURE_RE.test(runText)) continue;
 
-    if (!hasColumnGate || !hasValueProbe) continue;
-
-    const isPureFormatter =
-      FORMATTING_RE.test(addedText) && !VALUE_SIGNATURE_RE.test(addedText);
-    if (isPureFormatter) continue;
-
-    let lineNo = hunk.newStartLine;
-    for (const entry of hunk.addedLines) {
-      if (COLUMN_NAME_GATE_RE.test(entry.text)) {
-        lineNo = entry.line;
-        break;
+      // Locate the specific line with the column-name gate, for a precise
+      // pointer. Fall back to the first line of the run if the gate spans
+      // multiple lines.
+      let lineNo = run[0].line;
+      for (const entry of run) {
+        if (COLUMN_NAME_GATE_RE.test(entry.text)) {
+          lineNo = entry.line;
+          break;
+        }
       }
+
+      const snippet = trimmedSnippet(runText);
+      const isRendererFile = RENDERER_PATH_RE.test(hunk.file);
+      const message = buildMessage(isRendererFile);
+
+      findings.push({
+        severity: "MEDIUM",
+        file: hunk.file,
+        line: lineNo,
+        message,
+        snippet,
+        relatedIncidents: ["QUA-316", "QUA-346"],
+      });
     }
-
-    const snippet = trimmedSnippet(addedText);
-    const isRendererFile = RENDERER_PATH_RE.test(hunk.file);
-    const message = buildMessage(isRendererFile);
-
-    findings.push({
-      severity: "MEDIUM",
-      file: hunk.file,
-      line: lineNo,
-      message,
-      snippet,
-      relatedIncidents: ["QUA-316", "QUA-346"],
-    });
   }
 
   return findings;

--- a/crux/pr-review/narrow-patch-detector.ts
+++ b/crux/pr-review/narrow-patch-detector.ts
@@ -1,35 +1,12 @@
 /**
- * Narrow-patch detector (QUA-356)
+ * Narrow-patch detector (QUA-356). Advisory review-time scanner for the
+ * "column-name-gated value probe" pattern — a diff shape that historically
+ * masked class-shaped bugs behind per-column patches (QUA-316 → QUA-346 →
+ * QUA-354). Fires MEDIUM when an added contiguous run contains BOTH a column
+ * identifier strict-equality gate AND a value-signature probe method call.
  *
- * Flags a diff pattern that has historically masked a class-shaped bug behind a
- * one-component, column-name-gated check. The canonical example is QUA-346:
- * masking raw FactBase `f_xxx` IDs in `CellValue` only when the column name is
- * `fact_id` / `factId`, instead of doing content-based detection regardless of
- * column. QUA-316 was the first narrow patch in the same class; QUA-354 / PR
- * #4268 is the proper systemic fix that replaced both with a regex on the value.
- *
- * This detector is an advisory review-time hint, not a gate check. It fires at
- * MEDIUM severity when the added lines contain BOTH:
- *   1. A column-name-literal equality gate — the column identifier
- *      (columnName, fieldName, column.name, field.name, etc.) compared for
- *      strict equality against a quoted literal.
- *   2. A value-signature probe — one of the string/regex methods startsWith,
- *      endsWith, includes, test, match, search, or exec called on the value.
- *
- * The examples are deliberately written in prose here instead of as code
- * fragments, so the detector does not self-fire on its own docstring. See the
- * tests for the canonical code shapes.
- *
- * False-positive guards:
- *   - Both patterns must appear in the same CONTIGUOUS run of added lines.
- *     Two unrelated changes in one hunk (one adding a column gate elsewhere,
- *     one adding a value probe) never co-fire.
- *   - Diffs without both a column-name gate AND a value probe never fire.
- *   - Test files are skipped (test fixtures deliberately contain the signature).
- *   - Non-code files (markdown, YAML, SQL, config) are skipped.
- *
- * Output shape matches the hostile-reviewer finding format in
- * `.claude/commands/agent-review-pr.md` Phase 3.
+ * Skips test files and non-code files. Both patterns must land in the same
+ * contiguous run so two unrelated edits in one hunk don't co-fire.
  */
 
 export interface NarrowPatchFinding {
@@ -41,28 +18,33 @@ export interface NarrowPatchFinding {
   relatedIncidents: string[];
 }
 
-// Matches a column identifier (columnName, fieldName, column.name, col.name,
-// field.name, colName, or any `<receiver>.column`) strict-equality tested
-// against a quoted string literal. The `key` alternative was removed after
-// review — too broad (common object-lookup idiom).
+// Column identifier strict-equality tested against a quoted string literal.
+// Intentionally excludes bare `key`/`name` (too broad — common object-lookup
+// idioms).
 const COLUMN_NAME_GATE_RE =
   /\b(?:columnName|fieldName|colName|column\.name|col\.name|field\.name|\w+\.column)\s*===?\s*["'`][A-Za-z_][\w-]*["'`]/;
 
-// Matches a method call that probes a value's signature: one of startsWith,
-// endsWith, includes, test, match, search, or exec invoked via dot-call on any
-// receiver. This is the exact anti-pattern in QUA-316/QUA-346.
+// Value-signature probe: one of startsWith, endsWith, includes, test, match,
+// search, or exec invoked via dot-call on any receiver.
 const VALUE_SIGNATURE_RE =
   /\.\s*(?:startsWith|endsWith|includes|test|match|search|exec)\s*\(/;
 
-// File paths that look like generic renderers/column rules/formatters/validators.
-// Used only to strengthen the message — the detector fires regardless of path.
+// Renderer/formatter/validator path hint — used only to strengthen the
+// message, not to gate firing.
 const RENDERER_PATH_RE =
   /(?:render|cell|column|viewer|display|formatter|format-|validate-|validator)/i;
+
+const RELATED_INCIDENTS: readonly string[] = ["QUA-316", "QUA-346"];
+
+interface AddedLine {
+  line: number;
+  text: string;
+}
 
 interface ParsedHunk {
   file: string;
   newStartLine: number;
-  addedLines: Array<{ line: number; text: string }>;
+  addedLines: AddedLine[];
 }
 
 /**
@@ -121,7 +103,7 @@ export function parseDiff(diff: string): ParsedHunk[] {
         continue;
       }
       const newStart = Number(hunkHeader[1]);
-      const added: Array<{ line: number; text: string }> = [];
+      const added: AddedLine[] = [];
       let cursor = newStart;
       j++;
       while (j < lines.length && !lines[j].startsWith("@@ ")) {
@@ -158,11 +140,9 @@ export function parseDiff(diff: string): ParsedHunk[] {
  * end up as separate runs, which lets the detector avoid cross-change false
  * positives.
  */
-function contiguousRuns(
-  hunk: ParsedHunk
-): Array<Array<{ line: number; text: string }>> {
-  const runs: Array<Array<{ line: number; text: string }>> = [];
-  let current: Array<{ line: number; text: string }> = [];
+function contiguousRuns(hunk: ParsedHunk): AddedLine[][] {
+  const runs: AddedLine[][] = [];
+  let current: AddedLine[] = [];
   let prevLine = -1;
   for (const entry of hunk.addedLines) {
     if (current.length === 0 || entry.line === prevLine + 1) {
@@ -223,7 +203,7 @@ export function detectNarrowPatches(diff: string): NarrowPatchFinding[] {
         line: lineNo,
         message,
         snippet,
-        relatedIncidents: ["QUA-316", "QUA-346"],
+        relatedIncidents: [...RELATED_INCIDENTS],
       });
     }
   }
@@ -245,26 +225,24 @@ function trimmedSnippet(text: string): string {
   return text.slice(0, MAX) + "\n…";
 }
 
+const MESSAGE_BASE =
+  "Narrow-patch signature detected: the added block gates on a literal column " +
+  "name AND probes the value's signature (startsWith/test/match/includes). " +
+  "This is the exact shape behind QUA-316 and QUA-346, where raw `f_xxx` fact " +
+  "IDs were masked one column at a time until QUA-354 replaced it with a " +
+  "content-based regex. ";
+
+const MESSAGE_RENDERER_NOTE =
+  "The file path looks like a generic renderer/formatter/validator, which " +
+  "makes a content-based fix especially likely to be the right call. ";
+
+const MESSAGE_CTA =
+  "Before shipping, ask: can this be content-based (match the value's shape " +
+  "regardless of which column it lives in) instead of column-name-gated? If " +
+  "yes, do that instead — it prevents the recurring per-column patch loop.";
+
 function buildMessage(isRendererFile: boolean): string {
-  const base =
-    "Narrow-patch signature detected: the added block gates on a literal column " +
-    "name AND probes the value's signature (startsWith/test/match/includes). " +
-    "This is the exact shape behind QUA-316 and QUA-346, where raw `f_xxx` fact " +
-    "IDs were masked one column at a time until QUA-354 replaced it with a " +
-    "content-based regex. ";
-  const cta =
-    "Before shipping, ask: can this be content-based (match the value's shape " +
-    "regardless of which column it lives in) instead of column-name-gated? If " +
-    "yes, do that instead — it prevents the recurring per-column patch loop.";
-  if (isRendererFile) {
-    return (
-      base +
-      "The file path looks like a generic renderer/formatter/validator, which " +
-      "makes a content-based fix especially likely to be the right call. " +
-      cta
-    );
-  }
-  return base + cta;
+  return MESSAGE_BASE + (isRendererFile ? MESSAGE_RENDERER_NOTE : "") + MESSAGE_CTA;
 }
 
 /** Pretty-print findings for CLI or review output. */


### PR DESCRIPTION
## Summary

Adds a lightweight detector that flags the "column-name-gated value probe" diff pattern — the shape that caused the QUA-316 → QUA-346 → QUA-354 cascade, where raw `f_xxx` fact IDs were masked one column at a time until a content-based regex replaced both narrow patches.

The detector is advisory-only (never blocks) and is wired into `/agent-review-pr` Phase 3a so it fires before the hostile-reviewer subagent spins up.

## Key Changes

- **`crux/pr-review/narrow-patch-detector.ts`** — pure function `detectNarrowPatches(diff)` that parses a unified diff, splits added lines into contiguous runs, and fires MEDIUM when a run contains BOTH a column-identifier strict-equality gate AND a value-signature probe (`.startsWith`/`.test`/`.match`/`.includes`/`.search`/`.exec`).
- **`crux/pr-review/detect-narrow-patch.ts`** — CLI entry. Uses the shared `parseCliArgs`, `gitSafe`, and `isValidBranchName` helpers from `crux/lib/`. Supports `--base=<ref>`, `--stdin`, `--json`.
- **`crux/pr-review/narrow-patch-detector.test.ts`** — 28 vitest tests. Canonical fixture is a slice of the real QUA-346 / PR #4257 diff (asserts line 344 is flagged). Proper QUA-354 fix diff is asserted NOT to flag. False-positive fixtures cover currency/percent formatting, unrelated refactors, content-based probes without a gate, test files, deleted files, multi-file diffs, CRLF line endings, `b/`-in-path filenames, unrelated edits in the same hunk, and `name`/`key` bare identifiers.
- **`.claude/commands/agent-review-pr.md`** — Phase 3 split into 3a (narrow-patch check, always runs, fast) and 3b (hostile reviewer subagent). 3a instructs the agent on how to act on a hit and cross-references `proactive-github-filing.md` § "N+ related symptoms".

## Why the signature is narrow

The regex requires a **qualified** column identifier (`columnName`, `fieldName`, `column.name`, `field.name`, `<receiver>.column`). Bare `name === "x"` / `key === "x"` are intentionally excluded — too common as object-lookup idioms. Pure formatters (`toFixed`, `Intl.NumberFormat`, `formatCurrency`) don't probe value signatures so they slip through the value-probe check and never fire.

Both patterns must appear in the **same contiguous added-line run**, so two unrelated edits in one hunk cannot co-fire.

## Test plan

- [x] `npx vitest run crux/pr-review/narrow-patch-detector.test.ts` — 28/28 pass
- [x] Dogfood: detector run against its own diff → no findings (self-fire guarded in docstring)
- [x] Regression: `gh pr diff 4257 | detect-narrow-patch --stdin` → 1 finding at `entity-profile-viewer.tsx:344`
- [x] Regression: `gh pr diff 4268 | detect-narrow-patch --stdin` (proper QUA-354 fix) → 0 findings
- [x] Shell injection attempt: `--base='$(echo pwned)'` → rejected by `isValidBranchName` guard
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in `crux/pr-review/`
- [x] `pnpm crux w validate gate --scope=content --fix` — all checks pass
- [x] Full `/agent-review-pr` flow: hostile-reviewer subagent round caught 6 MEDIUM + 1 HIGH (shell injection, filename regex bug, dead formatter branch, CRLF handling, hunk-join false positives, overly broad `key` regex) — all fixed before shipping
- [x] `/simplify` pass: reused `parseCliArgs`/`gitSafe`/`isValidBranchName` from `crux/lib/`, extracted `AddedLine` type, hoisted message constants

## Acceptance criteria (from QUA-356)

- [x] `/agent-review-pr` has a narrow-patch detection rule that fires on the signature
- [x] Rule references QUA-316/QUA-346 priors
- [x] Test case: QUA-346 original diff (column-name-gated `f_` check) flags
- [x] False-positive guard: pure formatting changes (currency, percentage) don't trigger

Fixes QUA-356
