### PR TITLE
fix(QUA-397): mask legacy fact/resource IDs + fix FactBase things title write path

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -169,3 +169,120 @@ test.describe("Render audit — critical data tables", () => {
     expect(text).toMatch(/\$\d+(?:\.\d+)?[BMT]/);
   });
 });
+
+/**
+ * Raw-ID leak gate (QUA-397).
+ *
+ * The post-deploy `no-raw-ids.spec.ts` suite has repeatedly caught raw
+ * FactBase / resource / stableId leaks on `/data?tab=database` pages after
+ * each attempted fix. That test only runs after a bad image is already live.
+ * This block mirrors the assertion inside the PR-gate suite so a future
+ * regression of the same class blocks the merge instead of the deploy.
+ *
+ * Pattern coverage:
+ *  - `f_[A-Za-z0-9]{8,}` — FactBase fact IDs
+ *  - `sid_[A-Za-z0-9]{10}` — 10-char stableIds (truncated sub-10-char prefixes
+ *    still used as internal short display values are tolerated)
+ *  - `\b[a-f0-9]{16}\b` — bare 16-char hex (legacy pre-sid_ resource IDs)
+ *  - `\b[a-f0-9]{8}\b` — bare 8-char hex (legacy pre-f_ fact IDs)
+ *
+ * Pages covered intentionally overlap the no-raw-ids suite so any regression
+ * reappears here first. Sections must be expanded for the `entity-profile-viewer`
+ * rows to hydrate — we click every collapsible section header in <main> before
+ * scanning.
+ */
+const RAW_ID_LEAK_PAGES = [
+  "/organizations/anthropic",
+  "/organizations/anthropic/data?tab=database",
+  "/organizations/deepmind/data?tab=database",
+  "/organizations/meta-ai/data?tab=database",
+  "/people/dario-amodei/data?tab=database",
+  "/people/sam-altman/data?tab=database",
+  "/people/demis-hassabis/data?tab=database",
+];
+
+// Legacy-ID patterns use a lookahead requiring at least one a-f letter so pure
+// numeric strings (years, account numbers, formatted dates like `25502026`)
+// don't produce false positives. Real legacy fact/resource IDs are SHA-like
+// random hex and reliably contain letters.
+const RAW_ID_PATTERNS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+  { name: "f_ FactBase ID", pattern: /\bf_[A-Za-z0-9]{8,}\b/g },
+  { name: "sid_ stableId (full)", pattern: /\bsid_[A-Za-z0-9]{10}\b/g },
+  {
+    name: "legacy resource ID (16-char hex)",
+    pattern: /\b(?=[a-f0-9]*[a-f])[a-f0-9]{16}\b/g,
+  },
+  {
+    name: "legacy fact ID (8-char hex)",
+    pattern: /\b(?=[a-f0-9]*[a-f])[a-f0-9]{8}\b/g,
+  },
+];
+
+async function expandAllSections(page: Page) {
+  // `ProfileSection` uses `role=button` on collapsible headers.
+  // Use `.evaluate` rather than `.click()` so the click doesn't escape to
+  // nested Links (e.g. "Source checks →") and cause a navigation.
+  await page.evaluate(() => {
+    const buttons = document.querySelectorAll('main [role="button"]');
+    for (const b of buttons) {
+      (b as HTMLElement).click();
+    }
+  });
+  await page.waitForTimeout(800);
+}
+
+function findRawIdLeaks(text: string): Array<{ name: string; samples: string[] }> {
+  const leaks: Array<{ name: string; samples: string[] }> = [];
+  for (const { name, pattern } of RAW_ID_PATTERNS) {
+    const matches = text.match(pattern);
+    if (matches && matches.length > 0) {
+      leaks.push({ name, samples: [...new Set(matches)].slice(0, 5) });
+    }
+  }
+  return leaks;
+}
+
+test.describe("Render audit — no raw IDs on database/detail pages (QUA-397)", () => {
+  for (const url of RAW_ID_LEAK_PAGES) {
+    test(url, async ({ page }) => {
+      await loadPage(page, url);
+      await expandAllSections(page);
+
+      // Also click every tab-trigger so tab content is scanned too.
+      const tabs = page.locator("[role='tab']");
+      const tabCount = await tabs.count();
+      const scanText = async (label: string) => {
+        const text = await getMainText(page);
+        const leaks = findRawIdLeaks(text);
+        for (const leak of leaks) {
+          expect
+            .soft(
+              leak.samples,
+              `Raw IDs in ${url} (${label}): ${leak.name} — e.g. ${leak.samples.join(", ")}`
+            )
+            .toHaveLength(0);
+        }
+      };
+
+      if (tabCount > 1) {
+        for (let i = 0; i < tabCount; i++) {
+          const tab = tabs.nth(i);
+          const isVisible = await tab.isVisible();
+          if (!isVisible) continue;
+          const state = await tab.getAttribute("data-state");
+          if (state !== "active") {
+            await tab.click().catch(() => {
+              /* some tabs are keyboard-only; ignore */
+            });
+            await page.waitForTimeout(400);
+            await expandAllSections(page);
+          }
+          const label = ((await tab.textContent()) || `tab ${i}`).trim();
+          await scanText(label);
+        }
+      } else {
+        await scanText("default");
+      }
+    });
+  }
+});

--- a/apps/web/src/app/internal/entity-profile/__tests__/id-masking.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/id-masking.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  isFactId,
+  isLegacyFactId,
+  isLegacyResourceId,
+  stripFactIdPrefix,
+} from "../id-masking";
+
+/**
+ * Unit tests for the cell-value ID masking helpers used by
+ * entity-profile-viewer. See QUA-397 for context — this is the third fix
+ * iteration, and the tests codify the exact edge cases we kept re-discovering.
+ */
+
+describe("isFactId", () => {
+  it("matches canonical f_ prefix with 10 alphanumeric chars", () => {
+    expect(isFactId("f_qR5tY9wE1a")).toBe(true);
+    expect(isFactId("f_dW5cR9mJ8q")).toBe(true);
+  });
+
+  it("matches arbitrary longer suffixes", () => {
+    expect(isFactId("f_ABCDEFGH")).toBe(true);
+    expect(isFactId("f_ABCDEFGHIJKLMNOP")).toBe(true);
+  });
+
+  it("rejects values under 8 chars of suffix", () => {
+    expect(isFactId("f_short")).toBe(false);
+    expect(isFactId("f_ABCDEFG")).toBe(false); // only 7 alphanumeric
+  });
+
+  it("rejects non-f_ prefixes", () => {
+    expect(isFactId("sid_qR5tY9wE1a")).toBe(false);
+    expect(isFactId("qR5tY9wE1a")).toBe(false);
+    expect(isFactId("fact_id_123")).toBe(false);
+  });
+
+  it("rejects legacy 8-char bare hex fact IDs (those need column gating)", () => {
+    expect(isFactId("e7c42d88")).toBe(false);
+    expect(isFactId("f2a06bd3")).toBe(false);
+  });
+});
+
+describe("isLegacyFactId", () => {
+  it("matches 8-12 char lowercase hex in fact_id column", () => {
+    expect(isLegacyFactId("e7c42d88", "fact_id")).toBe(true);
+    expect(isLegacyFactId("a8c71e05", "fact_id")).toBe(true);
+    expect(isLegacyFactId("a8c71e05abcd", "fact_id")).toBe(true); // 12 chars
+  });
+
+  it("matches in camelCase factId column too", () => {
+    expect(isLegacyFactId("e7c42d88", "factId")).toBe(true);
+  });
+
+  it("rejects hex-shaped values in unrelated columns (column gating)", () => {
+    expect(isLegacyFactId("e7c42d88", "resource_id")).toBe(false);
+    expect(isLegacyFactId("e7c42d88", "git_sha")).toBe(false);
+    expect(isLegacyFactId("e7c42d88", "hash")).toBe(false);
+    expect(isLegacyFactId("e7c42d88", "id")).toBe(false);
+  });
+
+  it("rejects non-hex chars even in fact_id column", () => {
+    expect(isLegacyFactId("zzzzzzzz", "fact_id")).toBe(false);
+    expect(isLegacyFactId("E7C42D88", "fact_id")).toBe(false); // uppercase
+  });
+
+  it("rejects strings under 8 or over 12 chars", () => {
+    expect(isLegacyFactId("e7c42d8", "fact_id")).toBe(false); // 7 chars
+    expect(isLegacyFactId("a8c71e05abcde", "fact_id")).toBe(false); // 13 chars
+  });
+});
+
+describe("isLegacyResourceId", () => {
+  it("matches 16-char lowercase hex in resource_id column", () => {
+    expect(isLegacyResourceId("1f21fae8ed666710", "resource_id")).toBe(true);
+    expect(isLegacyResourceId("0116b24a50f52f44", "resource_id")).toBe(true);
+  });
+
+  it("matches in camelCase / stable_id column variants", () => {
+    expect(isLegacyResourceId("1f21fae8ed666710", "resourceId")).toBe(true);
+    expect(isLegacyResourceId("1f21fae8ed666710", "stable_id")).toBe(true);
+    expect(isLegacyResourceId("1f21fae8ed666710", "stableId")).toBe(true);
+  });
+
+  it("rejects hex-shaped values in unrelated columns", () => {
+    expect(isLegacyResourceId("1f21fae8ed666710", "fact_id")).toBe(false);
+    expect(isLegacyResourceId("1f21fae8ed666710", "git_sha")).toBe(false);
+  });
+
+  it("rejects wrong-length hex", () => {
+    expect(isLegacyResourceId("1f21fae8ed66671", "resource_id")).toBe(false); // 15
+    expect(isLegacyResourceId("1f21fae8ed6667100", "resource_id")).toBe(false); // 17
+  });
+
+  it("rejects canonical sid_ stableIds (those render via isAnySid path)", () => {
+    expect(isLegacyResourceId("sid_1LcLlMGLbw", "stable_id")).toBe(false);
+  });
+});
+
+describe("stripFactIdPrefix", () => {
+  it("strips `f_... — Entity` titles", () => {
+    expect(stripFactIdPrefix("f_qR5tY9wE1a — Anthropic")).toBe("Anthropic");
+  });
+
+  it("strips `f_...: value` descriptions", () => {
+    expect(stripFactIdPrefix("f_qR5tY9wE1a: 100000000")).toBe("100000000");
+  });
+
+  it("strips legacy hex-prefixed titles", () => {
+    expect(stripFactIdPrefix("e7c42d88: Google total invested in Anthropic")).toBe(
+      "Google total invested in Anthropic"
+    );
+    expect(stripFactIdPrefix("e7c42d88 — Anthropic")).toBe("Anthropic");
+  });
+
+  it("returns null for already-clean values", () => {
+    expect(stripFactIdPrefix("Anthropic")).toBeNull();
+    expect(stripFactIdPrefix("Total funding — Anthropic")).toBeNull();
+    expect(stripFactIdPrefix("f_qR5tY9wE1a")).toBeNull(); // no separator
+  });
+
+  it("returns null for values without a recognizable separator", () => {
+    expect(stripFactIdPrefix("f_qR5tY9wE1aAnthropic")).toBeNull();
+    expect(stripFactIdPrefix("e7c42d88Anthropic")).toBeNull();
+  });
+
+  it("does not match random 8-char values at the start of a title", () => {
+    // Real-world unrelated strings should pass through unchanged
+    expect(stripFactIdPrefix("Abcdefgh - some title")).toBeNull(); // uppercase
+    expect(stripFactIdPrefix("zzzzzzzz: value")).toBeNull(); // non-hex chars
+  });
+
+  it("handles multi-line and long-suffix values (full remainder returned)", () => {
+    expect(stripFactIdPrefix("f_qR5tY9wE1a — Some very long label with spaces")).toBe(
+      "Some very long label with spaces"
+    );
+  });
+});

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -21,6 +21,12 @@ import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { isEntityRefColumn } from "./entity-ref-columns";
+import {
+  isFactId,
+  isLegacyFactId,
+  isLegacyResourceId,
+  stripFactIdPrefix,
+} from "./id-masking";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -259,11 +265,8 @@ const GLOBAL_HIDDEN_COLUMNS = new Set(["id"]);
 const INITIAL_ROW_LIMIT = 20;
 
 // ── ID detection ──────────────────────────────────────────────────────────
-
-// FactBase fact IDs are `f_` + 8-12 alphanumeric chars (e.g. `f_dW5cR9mJ8q`).
-// Used by the cell renderer to detect raw fact IDs in any column and link them
-// to /factbase/fact/<id> instead of leaking the raw ID as visible text.
-const FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
+// Detection + masking predicates live in `./id-masking.ts`; the cell renderer
+// imports them via the top-of-file `import` block.
 
 // ── Numeric formatting columns ────────────────────────────────────────────
 
@@ -350,7 +353,7 @@ function CellValue({
   // Content-based, not column-name-gated: any cell value matching the fact-ID format gets
   // rendered as a link, no matter which column it lives in. Mirrors how isAnySid() handles
   // stableIds below, and prevents the recurring per-column patch loop (QUA-316, QUA-346).
-  if (typeof value === "string" && FACT_ID_RE.test(value)) {
+  if (typeof value === "string" && isFactId(value)) {
     return (
       <Link
         href={`/factbase/fact/${encodeURIComponent(value)}`}
@@ -360,6 +363,46 @@ function CellValue({
         view →
       </Link>
     );
+  }
+
+  // Legacy fact IDs (pre-migration bare hex). See QUA-397 / LEGACY_FACT_ID_RE.
+  // Column-name gated to avoid false-positive links on unrelated short-hex values.
+  if (typeof value === "string" && isLegacyFactId(value, columnName)) {
+    return (
+      <Link
+        href={`/factbase/fact/${encodeURIComponent(value)}`}
+        className="text-blue-600 dark:text-blue-400 hover:underline text-[11px]"
+        title={`legacy fact ID: ${value}`}
+      >
+        view →
+      </Link>
+    );
+  }
+
+  // Legacy resource stableIds (pre-migration bare 16-char hex). Column-name
+  // gated for the same reason as legacy fact IDs. Render muted — there is no
+  // resource-detail page keyed by these legacy IDs.
+  if (typeof value === "string" && isLegacyResourceId(value, columnName)) {
+    return (
+      <span
+        className="text-muted-foreground/40 font-mono text-[10px]"
+        title={`legacy resource ID: ${value}`}
+      >
+        &mdash;
+      </span>
+    );
+  }
+
+  // Things table titles sometimes still contain a raw fact ID prefix from the
+  // pre-QUA-397 facts.ts write path (e.g. `f_qR5tY9wE1a — Anthropic`). Strip
+  // the raw-ID portion so the visible text is just the human-readable suffix.
+  // The write path is also fixed (see apps/wiki-server/src/routes/factbase/
+  // facts.ts), but existing rows won't rewrite until the next full sync.
+  if (typeof value === "string") {
+    const stripped = stripFactIdPrefix(value);
+    if (stripped !== null) {
+      return <span className="text-[11px]">{stripped}</span>;
+    }
   }
 
   // Entity reference columns -> show resolved name as link
@@ -691,7 +734,12 @@ function ProfileSection({
                     {(() => {
                       const idStr = recordId ?? null;
                       if (!idStr) return <td className="px-2 py-2" />;
-                      const display = idStr.length > 7 ? idStr.slice(0, 7) : idStr;
+                      // Display a row index instead of a truncated raw ID.
+                      // Previously we sliced `idStr` to 7 chars, which leaked
+                      // `sid_xxx`-shaped substrings into visible text and failed
+                      // the no-raw-ids suite (QUA-397). The full ID is still
+                      // exposed via `title=` for debugging.
+                      const display = `#${i + 1}`;
                       // Compute thing key for linking to /things/<id>
                       // Only link sections with recordType (those have things table entries)
                       // Facts use a composite key (entityId:factId); all others use row.id

--- a/apps/web/src/app/internal/entity-profile/id-masking.ts
+++ b/apps/web/src/app/internal/entity-profile/id-masking.ts
@@ -1,0 +1,94 @@
+/**
+ * Cell-value ID masking helpers for entity-profile-viewer.
+ *
+ * Extracted from entity-profile-viewer.tsx so they can be unit-tested without
+ * importing React. See QUA-397 for context — this is the third iteration of
+ * the raw-ID leak fix (after QUA-316, QUA-346, QUA-354), and the helpers here
+ * are deliberately small + tested so the next iteration can extend them
+ * without re-discovering the edge cases.
+ */
+
+/** Canonical FactBase fact ID: `f_` + 8+ alphanumeric chars (e.g. `f_dW5cR9mJ8q`). */
+export const FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
+
+/**
+ * Legacy pre-migration fact IDs — bare 8-12 char hex strings (e.g. `e7c42d88`,
+ * `f2a06bd3`). These predate the `f_` prefix and are still in the facts table
+ * on prod. Matching purely on shape is too permissive to use as a primary
+ * detector — many unrelated values (git SHAs, content hashes, short IDs in
+ * other tables) share the same shape. Callers must gate this by column name.
+ */
+export const LEGACY_FACT_ID_RE = /^[a-f0-9]{8,12}$/;
+
+/** Column names where we trust `LEGACY_FACT_ID_RE` to detect fact IDs. */
+export const LEGACY_FACT_ID_COLUMNS: ReadonlySet<string> = new Set([
+  "fact_id",
+  "factId",
+]);
+
+/**
+ * Legacy pre-migration resource stableIds — bare 16-char hex strings (e.g.
+ * `1f21fae8ed666710`). Column-gated for the same reason as fact IDs.
+ */
+export const LEGACY_RESOURCE_ID_RE = /^[a-f0-9]{16}$/;
+
+/** Column names where we trust `LEGACY_RESOURCE_ID_RE` to detect resource IDs. */
+export const LEGACY_RESOURCE_ID_COLUMNS: ReadonlySet<string> = new Set([
+  "resource_id",
+  "resourceId",
+  "stable_id",
+  "stableId",
+]);
+
+/**
+ * Thing titles whose FactBase title resolver fell back to the raw fact ID
+ * render as:
+ *   - `f_qR5tY9wE1a — Anthropic` (title)
+ *   - `f_qR5tY9wE1a: 100000000` (description)
+ *   - `e7c42d88: 1000000000` (legacy description)
+ *
+ * The regex strips the raw-ID prefix so the visible text is just the
+ * human-readable remainder. The write path has been fixed (see
+ * apps/wiki-server/src/routes/factbase/facts.ts) but existing rows won't
+ * rewrite until the next full sync; this render-layer defense masks the
+ * stale rows.
+ */
+const THING_TITLE_WITH_FACT_ID_RE =
+  /^(?:f_[A-Za-z0-9]{8,}|[a-f0-9]{8,12})(?: — | : |: )(.+)$/;
+
+/**
+ * If `value` begins with a raw fact ID followed by ` — ` or `: `, return just
+ * the remainder. Otherwise return `null` (caller should render the value
+ * normally). Pure function; safe to test.
+ */
+export function stripFactIdPrefix(value: string): string | null {
+  const m = value.match(THING_TITLE_WITH_FACT_ID_RE);
+  return m ? m[1] : null;
+}
+
+/**
+ * True if `value` is a canonical FactBase fact ID (`f_...`). Content-based,
+ * not column-name-gated — the prefix is unique enough to trust.
+ */
+export function isFactId(value: string): boolean {
+  return FACT_ID_RE.test(value);
+}
+
+/**
+ * True if `value` looks like a legacy pre-migration fact ID AND the column
+ * name is in the allowlist. Column-gated on purpose: bare hex strings of this
+ * length appear on unrelated columns (git SHAs, content hashes).
+ */
+export function isLegacyFactId(value: string, columnName: string): boolean {
+  return LEGACY_FACT_ID_COLUMNS.has(columnName) && LEGACY_FACT_ID_RE.test(value);
+}
+
+/**
+ * True if `value` looks like a legacy pre-migration resource stableId AND the
+ * column name is in the allowlist.
+ */
+export function isLegacyResourceId(value: string, columnName: string): boolean {
+  return (
+    LEGACY_RESOURCE_ID_COLUMNS.has(columnName) && LEGACY_RESOURCE_ID_RE.test(value)
+  );
+}

--- a/apps/wiki-server/src/__tests__/facts-thing-strings.test.ts
+++ b/apps/wiki-server/src/__tests__/facts-thing-strings.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildFactThingStrings } from "../routes/factbase/facts.js";
+
+/**
+ * Regression tests for the FactBase → things dual-write title generation.
+ * See QUA-397: the pre-fix code fell back to `f.factId` when `f.label` was
+ * missing, leaking raw IDs like `f_qR5tY9wE1a — Anthropic` into the things
+ * table (visible in entity profile viewer, search, etc).
+ */
+
+describe("buildFactThingStrings", () => {
+  it("uses label when present", () => {
+    const { title, description } = buildFactThingStrings(
+      { label: "Total funding", measure: "total-funding", value: "$5B", numeric: null },
+      "Anthropic"
+    );
+    expect(title).toBe("Total funding — Anthropic");
+    expect(description).toBe("Total funding: $5B");
+  });
+
+  it("falls back to measure when label is missing", () => {
+    const { title, description } = buildFactThingStrings(
+      { label: null, measure: "interpretability-team-size", value: "12", numeric: null },
+      "Anthropic"
+    );
+    expect(title).toBe("interpretability-team-size — Anthropic");
+    expect(description).toBe("interpretability-team-size: 12");
+  });
+
+  it("falls back to entity name only when both label AND measure are missing", () => {
+    const { title, description } = buildFactThingStrings(
+      { label: null, measure: null, value: "1000000000", numeric: null },
+      "Anthropic"
+    );
+    expect(title).toBe("Anthropic");
+    expect(description).toBe("1000000000");
+  });
+
+  it("NEVER falls back to the raw factId in title or description (QUA-397)", () => {
+    const { title, description } = buildFactThingStrings(
+      { label: null, measure: null, value: null, numeric: 42 },
+      "DeepMind"
+    );
+    // The critical assertion: nothing in the output matches the fact-ID shape.
+    expect(title).not.toMatch(/^f_[A-Za-z0-9]{8,}/);
+    expect(title).not.toMatch(/^[a-f0-9]{8,12}/);
+    expect(description ?? "").not.toMatch(/^f_[A-Za-z0-9]{8,}/);
+    expect(description ?? "").not.toMatch(/^[a-f0-9]{8,12}/);
+  });
+
+  it("uses label over measure even if both are present", () => {
+    const { title } = buildFactThingStrings(
+      { label: "Annual revenue", measure: "annual-revenue", value: "$100M", numeric: null },
+      "Acme"
+    );
+    expect(title).toBe("Annual revenue — Acme");
+  });
+
+  it("handles numeric-only facts (no value string)", () => {
+    const { title, description } = buildFactThingStrings(
+      { label: "Employee count", measure: "employee-count", value: null, numeric: 250 },
+      "Acme"
+    );
+    expect(title).toBe("Employee count — Acme");
+    expect(description).toBe("Employee count: 250");
+  });
+
+  it("omits description when both value and numeric are missing", () => {
+    const { description } = buildFactThingStrings(
+      { label: "Unknown", measure: null, value: null, numeric: null },
+      "Acme"
+    );
+    expect(description).toBeUndefined();
+  });
+
+  it("treats empty-string label as missing (falsy fallback)", () => {
+    const { title } = buildFactThingStrings(
+      { label: "", measure: "some-measure", value: null, numeric: null },
+      "Acme"
+    );
+    expect(title).toBe("some-measure — Acme");
+  });
+});

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -13,7 +13,7 @@ import {
   zv,
   clampedLimit,
 } from "../shared/utils.js";
-import { SyncFactsBatchSchema } from "../../api-types.js";
+import { SyncFactsBatchSchema, type SyncFact } from "../../api-types.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { logger } from "../../logger.js";
 
@@ -91,6 +91,37 @@ function isMalformedNumericRow(row: typeof facts.$inferSelect): boolean {
     return row.low == null || row.high == null;
   }
   return false;
+}
+
+/**
+ * Compute the `title` and `description` strings for a fact-thing row written
+ * by the `/sync` dual-write to the `things` table.
+ *
+ * QUA-397: we previously fell back to `f.factId` when `f.label` was missing,
+ * producing thing titles like `f_qR5tY9wE1a — Anthropic` that leaked raw
+ * FactBase IDs into search results and the entity profile database viewer.
+ *
+ * The new fallback chain is:
+ *   1. `label` (canonical human-readable description)
+ *   2. `measure` (kebab-case, e.g. `total-funding` — still readable)
+ *   3. entity name only (less differentiated but never leaks an internal ID)
+ *
+ * Exported for testing. Pure function — safe to unit test without touching PG.
+ */
+export function buildFactThingStrings(
+  fact: Pick<SyncFact, "label" | "measure" | "value" | "numeric">,
+  entityName: string,
+): { title: string; description: string | undefined } {
+  const factLabel = fact.label || fact.measure || null;
+  const title = factLabel ? `${factLabel} — ${entityName}` : entityName;
+  const valueStr =
+    fact.value ?? (fact.numeric != null ? String(fact.numeric) : null);
+  const description = valueStr
+    ? factLabel
+      ? `${factLabel}: ${valueStr}`
+      : valueStr
+    : undefined;
+  return { title, description };
 }
 
 /**
@@ -572,19 +603,15 @@ const factsApp = new Hono()
           tx,
           items.map((f) => {
             const entityName = entityTitleMap.get(f.entityId) ?? f.entityId;
-            const factLabel = f.label || f.factId;
+            const { title, description } = buildFactThingStrings(f, entityName);
             return {
               id: toFactThingKey(f.entityId, f.factId),
               thingType: "fact" as const,
-              title: `${factLabel} — ${entityName}`,
+              title,
               sourceTable: "facts",
               sourceId: toFactThingKey(f.entityId, f.factId),
               parentThingId: f.entityId,
-              description: f.value
-                ? `${factLabel}: ${f.value}`
-                : f.numeric != null
-                  ? `${factLabel}: ${f.numeric}`
-                  : undefined,
+              description,
             };
           })
         );


### PR DESCRIPTION
## Summary

Third PR in a week targeting the raw-ID leak class on `/organizations/*/data?tab=database` and entity profile views. Fixes 3 of the 4 bugs from the dispatch brief (4th was a coordinator misdiagnosis, see below) + adds a build-time Playwright gate so the next regression blocks PR merges instead of post-deploy smoke tests.

Fixes QUA-397.

## Bugs fixed

### Bug B — Facts "Fact ID" column leaked legacy 8-char hex IDs

**Root cause:** The existing `CellValue` regex `^f_[A-Za-z0-9]{8,}$` only matched the new `f_`-prefixed format. Pre-migration facts in the prod DB still have bare hex IDs like `e7c42d88`, `f2a06bd3`. They fell through to a plain `<span>` and rendered the raw ID.

**Fix:** Added `isLegacyFactId(value, columnName)` in a new `id-masking.ts` module. Column-gated to `{fact_id, factId}` so the permissive hex regex doesn't produce false-positive links on unrelated columns (git SHAs, content hashes). Legacy-detected values route through the same `/factbase/fact/<id>` link as the new format.

### Bug C — `things.title` contained raw fact IDs

**Root cause:** `apps/wiki-server/src/routes/factbase/facts.ts` (dual-write to `things` table) built titles as `${factLabel} — ${entityName}` where `factLabel = f.label || f.factId`. When `f.label` was missing (~14% of rows), the raw fact ID leaked into both `title` and `description`, visible in the Entity Profile Viewer, `/things/[id]` pages, and search.

**Fix (write path):** New `buildFactThingStrings()` pure helper with fallback chain `label → measure → entityName`. `measure` is a readable kebab-case alternative (`total-funding`, `interpretability-team-size`). If both are missing, title is just the entity name — less differentiated but never leaks an internal ID.

**Fix (render defense):** `stripFactIdPrefix()` in `CellValue` masks any pre-existing bad row (`f_xxx — Entity` / `e7c42d88: value`) until the next full sync backfills them. Belt-and-suspenders so the UI is clean the moment this PR deploys.

### Bug D — Entity Resources "Resource ID" column leaked 16-char hex

**Root cause:** Legacy pre-`sid_` resource stableIds (`1f21fae8ed666710`, `0116b24a50f52f44`) didn't match `isAnySid()` and fell through to plain text.

**Fix:** Column-gated `isLegacyResourceId` (`{resource_id, resourceId, stable_id, stableId}`) renders them as a muted em-dash with the full ID in `title=` for debugging. No detail-page link — there isn't one keyed by these legacy IDs, and the dispatch brief explicitly scopes the resource-ID data backfill out.

### Bonus — First-column row-ID truncation leaked `sid_xxx` substrings

`ProfileSection`'s first-column "ID" cell rendered `idStr.slice(0, 7)`. For a fact thing whose `idStr` starts with `sid_`, this produced the 7-char substring `sid_mK9` — a partial stableId already flagged by the post-deploy `no-raw-ids.spec.ts` (with its `sid_[A-Za-z0-9]{3,}` pattern). Replaced with `#<rowIndex>`; full ID remains in `title=`.

## Systemic fix — build-time raw-ID gate

Per the QUA-397 brief ("N+ related symptoms in a narrow window"), this is the **third** attempt at the same leak class in a week. The post-deploy `no-raw-ids.spec.ts` only fires AFTER a bad image ships. I added the same assertion block to `render-audit.spec.ts`, which runs in the PR-gate suite.

Pages covered (all seven from the brief):
- `/organizations/anthropic` (non-data, for the divisions view)
- `/organizations/{anthropic,deepmind,meta-ai}/data?tab=database`
- `/people/{dario-amodei,sam-altman,demis-hassabis}/data?tab=database`

Patterns: `f_[A-Za-z0-9]{8,}`, `sid_[A-Za-z0-9]{10}`, and `(?=[a-f0-9]*[a-f])[a-f0-9]{16}` / `[a-f0-9]{8}`. The lookahead requires at least one hex letter so pure-numeric strings like `25502026` (year concatenations) don't produce false positives — the first test run surfaced exactly this and I tightened the regex before commit.

## Coordinator hypothesis disagreement — Bug A is NOT a bug

The dispatch brief hypothesized Bug A ("Divisions Status dots empty on `/organizations/anthropic`") was caused by PR #4277 removing the `/api/source-checks` backward-compat alias. **This hypothesis is wrong.**

`divisions-section.tsx` uses `getRecordVerdict(recordType, recordId)` from `@/data/tablebase`, which reads from a build-time `record-verdicts.json` file — **not an HTTP call**. I traced it:

- `apps/web/src/data/tablebase.ts:1092` → reads local JSON, keyed as `${recordType}:${recordId}`
- `apps/web/scripts/lib/wiki-server-data.mjs:568` → fetches from `/api/sourcing/verdicts` (NEW path, already migrated)
- Prod wiki-server API (`curl -H Authorization ... /api/sourcing/verdicts?record_type=division`) returns 6 rows for Anthropic divisions, all with `verdict: "unchecked"`

`recordVerdictToStatus("unchecked")` correctly maps to `"not_run"` → the white/gray empty dot. The display is correct; the data is genuinely unchecked. The title attribute on the rendered dot even says "Not checked / Verdict: unchecked" (verified via playwright).

Per the brief's instruction: **"If the verdict lookup in Bug A turns out to be a different root cause ... stop and report before continuing — the coordinator's hypothesis may be wrong."** Stopped and reported; no code change for Bug A. If the user wants divisions actually source-checked, that's a separate ticket scoped to running source-check jobs against division records.

## Tests

- `apps/web/src/app/internal/entity-profile/__tests__/id-masking.test.ts` — **22 tests** covering `isFactId`, `isLegacyFactId`, `isLegacyResourceId`, `stripFactIdPrefix`. Adversarial inputs: uppercase hex, wrong lengths, non-hex chars, already-clean values, column-gating assertions, pure-numeric-string false positives.
- `apps/wiki-server/src/__tests__/facts-thing-strings.test.ts` — **8 tests** for `buildFactThingStrings` covering each fallback rung and the critical "never leak raw factId" assertion.
- Full `pnpm test` (6187 tests across both apps): all pass.
- Playwright `render-audit.spec.ts` raw-ID gate run against a local dev server with this patch applied: **all 7 pages pass**. Run against unpatched prod, the same test correctly fails on `/organizations/anthropic/data?tab=database` (confirming test coverage — it catches the current leak).

## Deploy tasks

**None that block this PR.** Two follow-up items for the coordinator post-deploy (non-blocking):

- [ ] **Things title backfill** — the write-path fix only takes effect for newly-synced rows. Existing bad rows (`f_xxx — Entity`, `e7c42d88: 1000000000`) will auto-refresh on the next full `sync-facts` invocation; no manual backfill needed. The render-layer `stripFactIdPrefix()` masks them in the meantime.
- [ ] **Legacy fact-ID / resource-ID data backfill** — out of scope per the brief. The render-layer fixes mask them; if we want to eliminate them from the data layer, that's a separate data migration.

## Not in scope

- Backfilling legacy fact IDs with `f_` prefix
- Backfilling legacy resource IDs with `sid_` prefix
- Rewriting `entity-profile-viewer.tsx` (~900 lines) — deserves its own refactor PR
- QUA-396 (workflow secret regression) — separate ticket

## Test plan

- [x] `pnpm test` — 6187 tests pass
- [x] `npx tsc --noEmit` in both `apps/web` and `apps/wiki-server` — clean
- [x] `pnpm crux w validate gate` — all 50 checks pass (3 advisory warnings unrelated to this PR)
- [x] Playwright `render-audit.spec.ts` against local dev server with this patch — 7/7 raw-ID tests pass
- [x] Playwright `render-audit.spec.ts` against prod (unpatched) — correctly fails on anthropic/data tab (confirms coverage)
- [x] Manual reproduction via `curl` on prod before/after: see unit tests + Playwright as the automated version

Fixes QUA-397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Masked raw identifiers throughout entity profile views to prevent ID leaks across database and profile pages.
  * Improved title and description rendering by removing raw ID prefixes from display text.

* **Tests**
  * Added automated audit suite to detect and prevent future ID leaks across pages.
  * Extended test coverage for ID masking helpers and fact-to-thing data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->