### PR TITLE
refactor(sourcing): QUA-331 follow-up polish

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts
@@ -84,10 +84,16 @@ const dispatch: SqlDispatcher = (query, params) => {
     // the clause under a refactor — the old positional `[type, ...ids]`
     // was fragile enough to mask bugs.
     //
-    // `inArray` expands to `record_id IN ($3, $4, $5, ...)`; we find the
-    // first $N after `record_id` and take everything from there.
-    const recordTypeMatch = query.match(/"record_type"\s*=\s*\$(\d+)/);
-    const recordIdInMatch = query.match(/"record_id"\s+in\s*\(([\s\S]*?)\)/i);
+    // Regex is anchored to the fully-qualified column
+    // (`"source_check_evidence"."record_type"`) so a future JOIN that
+    // introduces a same-named column on another table can't accidentally
+    // match the wrong param slot.
+    const recordTypeMatch = query.match(
+      /"source_check_evidence"\."record_type"\s*=\s*\$(\d+)/,
+    );
+    const recordIdInMatch = query.match(
+      /"source_check_evidence"\."record_id"\s+in\s*\(([\s\S]*?)\)/i,
+    );
     if (!recordTypeMatch || !recordIdInMatch) return [];
 
     const recordType = String(params[Number(recordTypeMatch[1]) - 1]);
@@ -128,7 +134,9 @@ function lastSelectRecordIds(): string[] {
     ) {
       continue;
     }
-    const m = query.match(/"record_id"\s+in\s*\(([\s\S]*?)\)/i);
+    const m = query.match(
+      /"source_check_evidence"\."record_id"\s+in\s*\(([\s\S]*?)\)/i,
+    );
     if (!m) continue;
     return [...m[1].matchAll(/\$(\d+)/g)].map((pm) =>
       String(params[Number(pm[1]) - 1]),

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -216,12 +216,8 @@ const EvidenceByRecordsBody = z.object({
   limitPerRecord: z.number().int().min(1).max(MAX_PAGE_SIZE),
 });
 
-/**
- * Join (recordType, recordId) into a stable response-map key.
- * Kept in sync with `evidenceRecordKey` in the crux client
- * (`crux/lib/wiki-server/sourcing-client.ts`).
- */
-export function evidenceRecordKey(recordType: string, recordId: string): string {
+/** Must match `evidenceRecordKey` in crux/lib/wiki-server/sourcing-client.ts. */
+function evidenceRecordKey(recordType: string, recordId: string): string {
   return `${recordType}|${recordId}`;
 }
 

--- a/crux/commands/sourcing-audit-urls.ts
+++ b/crux/commands/sourcing-audit-urls.ts
@@ -18,6 +18,8 @@ import {
   listVerdicts,
   getEvidenceByRecords,
   evidenceRecordKey,
+  MAX_EVIDENCE_BY_RECORDS,
+  type EvidenceByRecordsResult,
 } from '../lib/wiki-server/sourcing-client.ts';
 import {
   classifyByUrl,
@@ -30,15 +32,6 @@ import {
 export { classifyByUrl, normalizeUrlForJoin, extractHost };
 
 // ── Module constants ──
-
-/**
- * Max records per batch evidence request. QUA-331 — matches the server
- * cap `MAX_EVIDENCE_BY_RECORDS` in sourcing.ts. In practice one chunk is
- * enough (listVerdicts clamps server-side to 200, so default `--verdict`
- * sets produce ≤1000 records); the chunk loop is defensive in case that
- * clamp grows or callers add more verdict types.
- */
-const EVIDENCE_BATCH_SIZE = 1000;
 
 /** Evidence rows fetched per verdict record. Most records have 1–2. */
 const EVIDENCE_PER_RECORD = 5;
@@ -161,16 +154,12 @@ async function auditCommand(
     console.log('Fetching evidence for each (this may take a minute)...');
   }
 
-  // ── Step 2: batch-fetch evidence (QUA-331) ──
-  // Accumulate across chunks into one map, then iterate `verdictRecords`
-  // in input order so report output stays deterministic regardless of
-  // server-side grouping.
-  const allEvidence: Record<
-    string,
-    Array<{ sourceUrl: string | null; fieldName: string | null }>
-  > = {};
-  for (let i = 0; i < verdictRecords.length; i += EVIDENCE_BATCH_SIZE) {
-    const chunk = verdictRecords.slice(i, i + EVIDENCE_BATCH_SIZE);
+  // Accumulate evidence across chunks, then iterate `verdictRecords` in
+  // input order so report output stays deterministic regardless of
+  // server-side grouping by recordType.
+  const allEvidence: EvidenceByRecordsResult['evidenceByKey'] = {};
+  for (let i = 0; i < verdictRecords.length; i += MAX_EVIDENCE_BY_RECORDS) {
+    const chunk = verdictRecords.slice(i, i + MAX_EVIDENCE_BY_RECORDS);
     const res = await getEvidenceByRecords(
       chunk.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
       { limitPerRecord: EVIDENCE_PER_RECORD },

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -26,6 +26,7 @@ import {
   listVerdicts,
   getEvidenceByRecords,
   evidenceRecordKey,
+  MAX_EVIDENCE_BY_RECORDS,
   listUrlSuggestions,
   upsertUrlSuggestions,
 } from '../lib/wiki-server/sourcing-client.ts';
@@ -290,14 +291,14 @@ async function suggestCommand(
     return { v, claimText, entityName, skipReason };
   });
 
-  // QUA-331: batch-fetch evidence once before the per-record task loop
-  // instead of N calls inside it. Only fetch for rows we will actually
-  // process — no point loading evidence for records that will be skipped.
+  // Batch-fetch evidence once before the per-record task loop instead
+  // of N calls inside it. Only fetch for rows we will actually process.
   const needsEvidence = prepared.filter((p) => p.skipReason === null);
   const existingUrlByKey = new Map<string, string | null>();
-  if (needsEvidence.length > 0) {
+  for (let i = 0; i < needsEvidence.length; i += MAX_EVIDENCE_BY_RECORDS) {
+    const chunk = needsEvidence.slice(i, i + MAX_EVIDENCE_BY_RECORDS);
     const evidenceRes = await getEvidenceByRecords(
-      needsEvidence.map((p) => ({ recordType: p.v.recordType, recordId: p.v.recordId })),
+      chunk.map((p) => ({ recordType: p.v.recordType, recordId: p.v.recordId })),
       { limitPerRecord: 5 },
     );
     if (!evidenceRes.ok) {

--- a/crux/lib/wiki-server/sourcing-client.test.ts
+++ b/crux/lib/wiki-server/sourcing-client.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { evidenceRecordKey } from './sourcing-client.ts';
+
+describe('evidenceRecordKey', () => {
+  // Must match the server's implementation in
+  // apps/wiki-server/src/routes/sourcing/sourcing.ts — if either copy
+  // drifts from this format, callers of getEvidenceByRecords silently
+  // get `undefined` on every lookup.
+  it('joins recordType and recordId with a pipe delimiter', () => {
+    expect(evidenceRecordKey('fact', 'F1')).toBe('fact|F1');
+    expect(evidenceRecordKey('grant', 'g_abc123')).toBe('grant|g_abc123');
+    expect(evidenceRecordKey('personnel', '42')).toBe('personnel|42');
+  });
+
+  it('produces distinct keys for distinct inputs', () => {
+    expect(evidenceRecordKey('fact', 'F1')).not.toBe(
+      evidenceRecordKey('grant', 'F1'),
+    );
+    expect(evidenceRecordKey('fact', 'F1')).not.toBe(
+      evidenceRecordKey('fact', 'F2'),
+    );
+  });
+});

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -94,7 +94,16 @@ export async function getEvidenceByRecord(
 }
 
 /**
- * Batch-fetch evidence for many records in a single request (QUA-331).
+ * Max records per batch evidence request. Must match the server's
+ * `MAX_EVIDENCE_BY_RECORDS` in
+ * `apps/wiki-server/src/routes/sourcing/sourcing.ts`. Callers that
+ * might exceed this (e.g. scans driven by `--limit` flags) should
+ * chunk their input and call `getEvidenceByRecords` per chunk.
+ */
+export const MAX_EVIDENCE_BY_RECORDS = 1000;
+
+/**
+ * Batch-fetch evidence for many records in a single request.
  * Replaces N+1 loops over `getEvidenceByRecord`. The server groups by
  * `recordType` and issues one `IN (...)` query per type.
  *
@@ -121,11 +130,7 @@ export async function getEvidenceByRecords(
   );
 }
 
-/**
- * Build the response-map key used by `getEvidenceByRecords`.
- * Kept in sync with `evidenceRecordKey` in the server route
- * (`apps/wiki-server/src/routes/sourcing/sourcing.ts`).
- */
+/** Must match `evidenceRecordKey` in apps/wiki-server/src/routes/sourcing/sourcing.ts. */
 export function evidenceRecordKey(recordType: string, recordId: string): string {
   return `${recordType}|${recordId}`;
 }


### PR DESCRIPTION
## Summary

Post-merge cleanup on top of PR #4291 (QUA-331 batch evidence endpoint). Two hostile-review cycles and one `/simplify` pass surfaced findings worth shipping as a small follow-up:

### Adds
- **Contract tests for `evidenceRecordKey`** — `crux/lib/wiki-server/sourcing-client.test.ts` pins `evidenceRecordKey('fact', 'F1') === 'fact|F1'`. Combined with the 17 route tests that already assert on literal `"fact|F1"` keys, drift between the server and client copies of this helper now fails at least one test on at least one side — previously the only guard was a code comment.
- **`MAX_EVIDENCE_BY_RECORDS` export** in `sourcing-client.ts` — single source of truth that mirrors the server cap. Replaces per-file `EVIDENCE_BATCH_SIZE = 1000` constants duplicated across `sourcing-audit-urls.ts` and `sourcing-suggest-urls.ts`.
- **Defensive chunked loop** in `sourcing-suggest-urls.ts` for symmetry with `sourcing-audit-urls.ts`. Today's `--limit` paths fit in one batch, but the symmetry keeps both commands safe if `listVerdicts`'s server clamp ever grows.

### Tightens
- Anchored the test dispatcher's SQL regex in `sourcing-evidence-by-records.test.ts` to `"source_check_evidence"."record_type"` so a future JOIN against a same-named column on another table can't match the wrong param slot and make the dedup test pass for the wrong reason.
- Dropped unused `export` on the server-side `evidenceRecordKey` (the handler uses it internally; the client copy is the public face of the contract).
- Replaced inline narrow type `Record<string, Array<{sourceUrl: string \| null; ...}>>` in `sourcing-audit-urls.ts` with `EvidenceByRecordsResult['evidenceByKey']` so server response-shape changes fail at compile time instead of runtime.

### Trims
- Shrunk the server-side `evidenceRecordKey` docstring from 12 lines to 1. The old version named specific test counts ("17-test suite") that would rot and restated invariants the tests already pin.
- Removed narration comments (`QUA-331:`, "Chunk for symmetry with…") that added no technical signal.
- Deleted a trivial "is a pure function" test that would pass for any pure-or-impure implementation returning the same literal on two calls.

## Not included (explicit follow-up material)

- **Parallelize `byType` iteration in the server handler.** The efficiency reviewer flagged that `sourcing.ts`'s handler awaits one `inArray` query per recordType sequentially — `Promise.all` would reduce latency by N× where N = distinct recordTypes in the request (typically 1–3, up to 10 realistic). Real win, but it's a behavioral change on a merged endpoint that deserves its own ticket explicitly considering DB pool saturation under load.

## Test plan

- [x] `apps/wiki-server && npx tsc --noEmit` clean
- [x] `npx tsx crux/validate/validate-crux-tsc.ts` at baseline 69
- [x] `apps/wiki-server && npx vitest run` — 1057 tests pass
- [x] `crux && npx vitest run lib/wiki-server/sourcing-client.test.ts` — 2 new contract tests pass
- [x] `pnpm crux w validate gate --fix` — 45/45 checks pass
- [ ] CI green

Fixes QUA-331
