### PR TITLE
feat(sourcing): worst-entities leaderboard on Source Checks dashboard (QUA-153)

### DIFF
--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -1,9 +1,11 @@
+import { Suspense } from "react";
 import {
   fetchDetailed,
   withApiFallback,
 } from "@lib/wiki-server";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { getTypedEntities } from "@data/tablebase";
+import { WorstEntitiesWidget } from "./worst-entities";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -262,6 +264,17 @@ export async function SourcingCoverageContent() {
           </div>
         );
       })()}
+
+      {/* ── (a2) Worst entities leaderboard (QUA-153) ───────────────── */}
+      <Suspense
+        fallback={
+          <div className="not-prose mb-8 text-sm text-muted-foreground py-6 text-center border border-border/60 rounded-lg">
+            Loading worst-entities leaderboard…
+          </div>
+        }
+      >
+        <WorstEntitiesWidget />
+      </Suspense>
 
       {/* ── (b) Entities by Type ────────────────────────────────── */}
       <div className="not-prose mb-8">

--- a/apps/web/src/app/internal/sourcing-coverage/worst-entities.test.ts
+++ b/apps/web/src/app/internal/sourcing-coverage/worst-entities.test.ts
@@ -3,6 +3,7 @@ import type { RpcEntitySummaryRow } from "@lib/wiki-server";
 import {
   computeNonGreenCount,
   computeWorstEntities,
+  type EntityResolver,
   type WorstEntityRow,
 } from "./worst-entities";
 
@@ -22,9 +23,15 @@ function row(overrides: Partial<RpcEntitySummaryRow> = {}): RpcEntitySummaryRow 
   };
 }
 
-function lookup(entries: Record<string, { name: string; href: string | null }>) {
-  return new Map(Object.entries(entries));
+/** Resolver that returns a canned display for known IDs, raw ID otherwise. */
+function makeResolver(
+  table: Record<string, { name: string; href: string }> = {},
+): EntityResolver {
+  return (entityId) =>
+    table[entityId] ?? { name: entityId, href: `/wiki/${entityId}` };
 }
+
+const fallbackResolver = makeResolver();
 
 describe("computeNonGreenCount", () => {
   it("sums contradicted + outdated + partial + unverifiable + unchecked", () => {
@@ -62,7 +69,7 @@ describe("computeWorstEntities", () => {
       row({ entityId: "clean-corp", confirmed: 10 }),
       row({ entityId: "dirty-corp", contradicted: 3 }),
     ];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result).toHaveLength(1);
     expect(result[0].entityId).toBe("dirty-corp");
   });
@@ -73,7 +80,7 @@ describe("computeWorstEntities", () => {
       row({ entityId: "b", outdated: 12 }), // 12
       row({ entityId: "c", unchecked: 8 }), // 8
     ];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result.map((r) => r.entityId)).toEqual(["b", "c", "a"]);
     expect(result.map((r) => r.nonGreenCount)).toEqual([12, 8, 5]);
   });
@@ -84,7 +91,7 @@ describe("computeWorstEntities", () => {
       row({ entityId: "huge", contradicted: 3, totalRecords: 500 }),
       row({ entityId: "mid", contradicted: 3, totalRecords: 50 }),
     ];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result.map((r) => r.entityId)).toEqual(["huge", "mid", "tiny"]);
   });
 
@@ -92,7 +99,7 @@ describe("computeWorstEntities", () => {
     const summaries = Array.from({ length: 30 }, (_, i) =>
       row({ entityId: `e${i}`, contradicted: i + 1 }),
     );
-    const result = computeWorstEntities(summaries, lookup({}), 5);
+    const result = computeWorstEntities(summaries, fallbackResolver, 5);
     expect(result).toHaveLength(5);
     // Top 5 should be the 5 highest contradicted counts: e29, e28, e27, e26, e25
     expect(result.map((r) => r.entityId)).toEqual(["e29", "e28", "e27", "e26", "e25"]);
@@ -102,15 +109,15 @@ describe("computeWorstEntities", () => {
     const summaries = Array.from({ length: 25 }, (_, i) =>
       row({ entityId: `e${i}`, contradicted: i + 1 }),
     );
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result).toHaveLength(20);
   });
 
-  it("resolves display name and href from the lookup when present", () => {
+  it("resolves display name and href from the resolver when known", () => {
     const summaries = [row({ entityId: "anthropic", contradicted: 1 })];
     const result = computeWorstEntities(
       summaries,
-      lookup({
+      makeResolver({
         anthropic: { name: "Anthropic", href: "/wiki/E42" },
       }),
     );
@@ -118,11 +125,28 @@ describe("computeWorstEntities", () => {
     expect(result[0].href).toBe("/wiki/E42");
   });
 
-  it("falls back to entityId as display name when unknown", () => {
+  it("falls back to resolver's default for unknown IDs", () => {
     const summaries = [row({ entityId: "mystery-entity", contradicted: 1 })];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result[0].displayName).toBe("mystery-entity");
-    expect(result[0].href).toBe(null);
+    expect(result[0].href).toBe("/wiki/mystery-entity");
+  });
+
+  it("renders every row even when no IDs resolve to a friendly name", () => {
+    // Guards against a past shape where missing lookups returned no row at all.
+    const summaries = [
+      row({ entityId: "x1", contradicted: 5 }),
+      row({ entityId: "x2", contradicted: 3 }),
+    ];
+    const result = computeWorstEntities(summaries, fallbackResolver);
+    expect(result).toHaveLength(2);
+    expect(result[0].displayName).toBe("x1");
+    expect(result[1].displayName).toBe("x2");
+  });
+
+  it("limit=0 returns an empty array (documented behavior)", () => {
+    const summaries = [row({ entityId: "a", contradicted: 1 })];
+    expect(computeWorstEntities(summaries, fallbackResolver, 0)).toEqual([]);
   });
 
   it("keeps the full per-verdict breakdown on each row", () => {
@@ -138,7 +162,7 @@ describe("computeWorstEntities", () => {
         totalRecords: 100,
       }),
     ];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     const r: WorstEntityRow = result[0];
     expect(r.contradicted).toBe(2);
     expect(r.outdated).toBe(3);
@@ -151,7 +175,7 @@ describe("computeWorstEntities", () => {
   });
 
   it("returns an empty array for empty input", () => {
-    expect(computeWorstEntities([], lookup({}))).toEqual([]);
+    expect(computeWorstEntities([], fallbackResolver)).toEqual([]);
   });
 
   it("works with only unchecked verdicts (no contradicted)", () => {
@@ -160,7 +184,7 @@ describe("computeWorstEntities", () => {
       row({ entityId: "all-unchecked", unchecked: 7 }),
       row({ entityId: "mix", contradicted: 5 }),
     ];
-    const result = computeWorstEntities(summaries, lookup({}));
+    const result = computeWorstEntities(summaries, fallbackResolver);
     expect(result.map((r) => r.entityId)).toEqual(["all-unchecked", "mix"]);
   });
 });

--- a/apps/web/src/app/internal/sourcing-coverage/worst-entities.test.ts
+++ b/apps/web/src/app/internal/sourcing-coverage/worst-entities.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import type { RpcEntitySummaryRow } from "@lib/wiki-server";
+import {
+  computeNonGreenCount,
+  computeWorstEntities,
+  type WorstEntityRow,
+} from "./worst-entities";
+
+function row(overrides: Partial<RpcEntitySummaryRow> = {}): RpcEntitySummaryRow {
+  return {
+    entityId: "anthropic",
+    confirmed: 0,
+    contradicted: 0,
+    outdated: 0,
+    partial: 0,
+    unverifiable: 0,
+    unchecked: 0,
+    totalVerdicts: 0,
+    avgConfidence: 0,
+    totalRecords: 0,
+    ...overrides,
+  };
+}
+
+function lookup(entries: Record<string, { name: string; href: string | null }>) {
+  return new Map(Object.entries(entries));
+}
+
+describe("computeNonGreenCount", () => {
+  it("sums contradicted + outdated + partial + unverifiable + unchecked", () => {
+    expect(
+      computeNonGreenCount(
+        row({
+          confirmed: 100,
+          contradicted: 2,
+          outdated: 3,
+          partial: 1,
+          unverifiable: 4,
+          unchecked: 5,
+        }),
+      ),
+    ).toBe(15);
+  });
+
+  it("returns 0 when every record is confirmed", () => {
+    expect(computeNonGreenCount(row({ confirmed: 50 }))).toBe(0);
+  });
+
+  it("ignores confirmed in the tally", () => {
+    // A bug that double-counted confirmed would return 10 here, not 5.
+    expect(
+      computeNonGreenCount(
+        row({ confirmed: 5, contradicted: 3, outdated: 2 }),
+      ),
+    ).toBe(5);
+  });
+});
+
+describe("computeWorstEntities", () => {
+  it("drops entities with zero non-green verdicts", () => {
+    const summaries = [
+      row({ entityId: "clean-corp", confirmed: 10 }),
+      row({ entityId: "dirty-corp", contradicted: 3 }),
+    ];
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result).toHaveLength(1);
+    expect(result[0].entityId).toBe("dirty-corp");
+  });
+
+  it("sorts by nonGreenCount descending", () => {
+    const summaries = [
+      row({ entityId: "a", contradicted: 5 }), // 5
+      row({ entityId: "b", outdated: 12 }), // 12
+      row({ entityId: "c", unchecked: 8 }), // 8
+    ];
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result.map((r) => r.entityId)).toEqual(["b", "c", "a"]);
+    expect(result.map((r) => r.nonGreenCount)).toEqual([12, 8, 5]);
+  });
+
+  it("breaks ties by totalRecords descending (bigger entities rank higher)", () => {
+    const summaries = [
+      row({ entityId: "tiny", contradicted: 3, totalRecords: 5 }),
+      row({ entityId: "huge", contradicted: 3, totalRecords: 500 }),
+      row({ entityId: "mid", contradicted: 3, totalRecords: 50 }),
+    ];
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result.map((r) => r.entityId)).toEqual(["huge", "mid", "tiny"]);
+  });
+
+  it("caps the output at the requested limit", () => {
+    const summaries = Array.from({ length: 30 }, (_, i) =>
+      row({ entityId: `e${i}`, contradicted: i + 1 }),
+    );
+    const result = computeWorstEntities(summaries, lookup({}), 5);
+    expect(result).toHaveLength(5);
+    // Top 5 should be the 5 highest contradicted counts: e29, e28, e27, e26, e25
+    expect(result.map((r) => r.entityId)).toEqual(["e29", "e28", "e27", "e26", "e25"]);
+  });
+
+  it("defaults the limit to 20", () => {
+    const summaries = Array.from({ length: 25 }, (_, i) =>
+      row({ entityId: `e${i}`, contradicted: i + 1 }),
+    );
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result).toHaveLength(20);
+  });
+
+  it("resolves display name and href from the lookup when present", () => {
+    const summaries = [row({ entityId: "anthropic", contradicted: 1 })];
+    const result = computeWorstEntities(
+      summaries,
+      lookup({
+        anthropic: { name: "Anthropic", href: "/wiki/E42" },
+      }),
+    );
+    expect(result[0].displayName).toBe("Anthropic");
+    expect(result[0].href).toBe("/wiki/E42");
+  });
+
+  it("falls back to entityId as display name when unknown", () => {
+    const summaries = [row({ entityId: "mystery-entity", contradicted: 1 })];
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result[0].displayName).toBe("mystery-entity");
+    expect(result[0].href).toBe(null);
+  });
+
+  it("keeps the full per-verdict breakdown on each row", () => {
+    const summaries = [
+      row({
+        entityId: "acme",
+        contradicted: 2,
+        outdated: 3,
+        partial: 1,
+        unverifiable: 4,
+        unchecked: 5,
+        totalVerdicts: 15,
+        totalRecords: 100,
+      }),
+    ];
+    const result = computeWorstEntities(summaries, lookup({}));
+    const r: WorstEntityRow = result[0];
+    expect(r.contradicted).toBe(2);
+    expect(r.outdated).toBe(3);
+    expect(r.partial).toBe(1);
+    expect(r.unverifiable).toBe(4);
+    expect(r.unchecked).toBe(5);
+    expect(r.totalVerdicts).toBe(15);
+    expect(r.totalRecords).toBe(100);
+    expect(r.nonGreenCount).toBe(15);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(computeWorstEntities([], lookup({}))).toEqual([]);
+  });
+
+  it("works with only unchecked verdicts (no contradicted)", () => {
+    // A previously-speculated bug: ranking ignored unchecked records.
+    const summaries = [
+      row({ entityId: "all-unchecked", unchecked: 7 }),
+      row({ entityId: "mix", contradicted: 5 }),
+    ];
+    const result = computeWorstEntities(summaries, lookup({}));
+    expect(result.map((r) => r.entityId)).toEqual(["all-unchecked", "mix"]);
+  });
+});

--- a/apps/web/src/app/internal/sourcing-coverage/worst-entities.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/worst-entities.tsx
@@ -1,0 +1,198 @@
+import Link from "next/link";
+import { fetchDetailed, type RpcEntitySummaryRow } from "@lib/wiki-server";
+import { getTypedEntities, getEntityHref } from "@data";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface WorstEntityRow {
+  entityId: string;
+  displayName: string;
+  href: string | null;
+  nonGreenCount: number;
+  contradicted: number;
+  outdated: number;
+  partial: number;
+  unverifiable: number;
+  unchecked: number;
+  totalVerdicts: number;
+  totalRecords: number;
+}
+
+interface EntityLookupEntry {
+  name: string;
+  href: string | null;
+}
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────
+
+/**
+ * "Non-green" verdicts are everything that isn't `confirmed`: things that
+ * are wrong, stale, partially-supported, unverifiable, or never checked.
+ * The ticket frames this as "where to run verification next."
+ */
+export function computeNonGreenCount(row: RpcEntitySummaryRow): number {
+  return (
+    row.contradicted +
+    row.outdated +
+    row.partial +
+    row.unverifiable +
+    row.unchecked
+  );
+}
+
+/**
+ * Rank entities by count of non-green records, drop fully-green ones, and
+ * take the top `limit` (default 20). Ties break by total records
+ * descending so bigger entities float up over tiny stubs with the same
+ * absolute bad count.
+ */
+export function computeWorstEntities(
+  summaries: readonly RpcEntitySummaryRow[],
+  entityLookup: ReadonlyMap<string, EntityLookupEntry>,
+  limit = 20,
+): WorstEntityRow[] {
+  const rows: WorstEntityRow[] = [];
+  for (const s of summaries) {
+    const nonGreen = computeNonGreenCount(s);
+    if (nonGreen === 0) continue;
+    const info = entityLookup.get(s.entityId);
+    rows.push({
+      entityId: s.entityId,
+      displayName: info?.name ?? s.entityId,
+      href: info?.href ?? null,
+      nonGreenCount: nonGreen,
+      contradicted: s.contradicted,
+      outdated: s.outdated,
+      partial: s.partial,
+      unverifiable: s.unverifiable,
+      unchecked: s.unchecked,
+      totalVerdicts: s.totalVerdicts,
+      totalRecords: s.totalRecords,
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.nonGreenCount !== b.nonGreenCount) {
+      return b.nonGreenCount - a.nonGreenCount;
+    }
+    return b.totalRecords - a.totalRecords;
+  });
+  return rows.slice(0, limit);
+}
+
+// ── Data loading (server-only) ───────────────────────────────────────────
+
+async function loadEntitySummaries(): Promise<RpcEntitySummaryRow[]> {
+  const result = await fetchDetailed<{ summaries: RpcEntitySummaryRow[] }>(
+    "/api/sourcing/entity-summary",
+    { revalidate: 300 },
+  );
+  if (!result.ok) return [];
+  return result.data.summaries ?? [];
+}
+
+function buildEntityLookup(): Map<string, EntityLookupEntry> {
+  const lookup = new Map<string, EntityLookupEntry>();
+  const entities = getTypedEntities();
+  for (const e of entities) {
+    const entry: EntityLookupEntry = {
+      name: e.title || e.id,
+      href: getEntityHref(e.id, e.entityType) ?? null,
+    };
+    // entity-summary.entityId may be either a slug or a stableId; index
+    // both so the lookup resolves regardless of which form came back.
+    lookup.set(e.id, entry);
+    if (e.stableId) lookup.set(e.stableId, entry);
+  }
+  return lookup;
+}
+
+// ── Server component ─────────────────────────────────────────────────────
+
+/**
+ * Worst-entities leaderboard: top 20 entities by count of non-green
+ * (contradicted / outdated / partial / unverifiable / unchecked) records.
+ * Feeds prioritization — "where to run verification next."
+ */
+export async function WorstEntitiesWidget() {
+  const summaries = await loadEntitySummaries();
+  const lookup = buildEntityLookup();
+  const worst = computeWorstEntities(summaries, lookup);
+
+  return (
+    <div className="not-prose mb-8">
+      <h2 className="text-lg font-semibold mb-1">Worst Entities</h2>
+      <p className="text-sm text-muted-foreground mb-3">
+        Top 20 entities ranked by count of non-green records (contradicted,
+        outdated, partial, unverifiable, or unchecked). Use this list to
+        prioritize the next verification run.
+      </p>
+      {worst.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-6 text-center border border-border/60 rounded-lg">
+          No non-green verdicts found. Either everything is clean or the
+          entity-summary endpoint returned no data.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm tabular-nums">
+            <thead>
+              <tr className="border-b border-border/60 text-xs text-muted-foreground">
+                <th className="text-left py-2 pr-3 font-medium w-8">#</th>
+                <th className="text-left py-2 pr-3 font-medium">Entity</th>
+                <th className="text-right py-2 pr-3 font-medium">Non-green</th>
+                <th className="text-right py-2 pr-3 font-medium">Contra</th>
+                <th className="text-right py-2 pr-3 font-medium">Outdated</th>
+                <th className="text-right py-2 pr-3 font-medium">Partial</th>
+                <th className="text-right py-2 pr-3 font-medium">Unverif</th>
+                <th className="text-right py-2 pr-3 font-medium">Unchecked</th>
+                <th className="text-right py-2 pr-3 font-medium">Records</th>
+              </tr>
+            </thead>
+            <tbody>
+              {worst.map((row, idx) => (
+                <tr
+                  key={row.entityId}
+                  className="border-b border-border/40 last:border-0"
+                >
+                  <td className="py-2 pr-3 text-muted-foreground">{idx + 1}</td>
+                  <td className="py-2 pr-3 font-medium">
+                    {row.href ? (
+                      <Link
+                        href={row.href}
+                        className="text-primary hover:underline"
+                      >
+                        {row.displayName}
+                      </Link>
+                    ) : (
+                      row.displayName
+                    )}
+                  </td>
+                  <td className="py-2 pr-3 text-right font-semibold">
+                    {row.nonGreenCount}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-red-600">
+                    {row.contradicted || ""}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-amber-600">
+                    {row.outdated || ""}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-amber-500">
+                    {row.partial || ""}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-orange-600">
+                    {row.unverifiable || ""}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-muted-foreground">
+                    {row.unchecked || ""}
+                  </td>
+                  <td className="py-2 pr-3 text-right text-muted-foreground">
+                    {row.totalRecords}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/sourcing-coverage/worst-entities.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/worst-entities.tsx
@@ -1,13 +1,17 @@
 import Link from "next/link";
 import { fetchDetailed, type RpcEntitySummaryRow } from "@lib/wiki-server";
-import { getTypedEntities, getEntityHref } from "@data";
+import {
+  getTypedEntityById,
+  getTypedEntityByStableId,
+  getEntityHref,
+} from "@data";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
 export interface WorstEntityRow {
   entityId: string;
   displayName: string;
-  href: string | null;
+  href: string;
   nonGreenCount: number;
   contradicted: number;
   outdated: number;
@@ -18,9 +22,8 @@ export interface WorstEntityRow {
   totalRecords: number;
 }
 
-interface EntityLookupEntry {
-  name: string;
-  href: string | null;
+export interface EntityResolver {
+  (entityId: string): { name: string; href: string };
 }
 
 // ── Pure helpers (unit-tested) ───────────────────────────────────────────
@@ -48,18 +51,18 @@ export function computeNonGreenCount(row: RpcEntitySummaryRow): number {
  */
 export function computeWorstEntities(
   summaries: readonly RpcEntitySummaryRow[],
-  entityLookup: ReadonlyMap<string, EntityLookupEntry>,
+  resolve: EntityResolver,
   limit = 20,
 ): WorstEntityRow[] {
   const rows: WorstEntityRow[] = [];
   for (const s of summaries) {
     const nonGreen = computeNonGreenCount(s);
     if (nonGreen === 0) continue;
-    const info = entityLookup.get(s.entityId);
+    const { name, href } = resolve(s.entityId);
     rows.push({
       entityId: s.entityId,
-      displayName: info?.name ?? s.entityId,
-      href: info?.href ?? null,
+      displayName: name,
+      href,
       nonGreenCount: nonGreen,
       contradicted: s.contradicted,
       outdated: s.outdated,
@@ -81,29 +84,50 @@ export function computeWorstEntities(
 
 // ── Data loading (server-only) ───────────────────────────────────────────
 
-async function loadEntitySummaries(): Promise<RpcEntitySummaryRow[]> {
-  const result = await fetchDetailed<{ summaries: RpcEntitySummaryRow[] }>(
-    "/api/sourcing/entity-summary",
-    { revalidate: 300 },
-  );
-  if (!result.ok) return [];
-  return result.data.summaries ?? [];
+type SummariesState =
+  | { status: "ok"; summaries: RpcEntitySummaryRow[] }
+  | { status: "error"; message: string };
+
+function formatApiErrorMessage(
+  error: { type: string; message?: string; status?: number; statusText?: string },
+): string {
+  if (error.type === "not-configured") return "wiki-server not configured";
+  if (error.type === "connection-error")
+    return `connection error: ${error.message ?? "unknown"}`;
+  if (error.type === "server-error")
+    return `server ${error.status ?? "?"} ${error.statusText ?? ""}`.trim();
+  return "unknown error";
 }
 
-function buildEntityLookup(): Map<string, EntityLookupEntry> {
-  const lookup = new Map<string, EntityLookupEntry>();
-  const entities = getTypedEntities();
-  for (const e of entities) {
-    const entry: EntityLookupEntry = {
-      name: e.title || e.id,
-      href: getEntityHref(e.id, e.entityType) ?? null,
-    };
-    // entity-summary.entityId may be either a slug or a stableId; index
-    // both so the lookup resolves regardless of which form came back.
-    lookup.set(e.id, entry);
-    if (e.stableId) lookup.set(e.stableId, entry);
+async function loadEntitySummaries(): Promise<SummariesState> {
+  const result = await fetchDetailed<{ summaries: RpcEntitySummaryRow[] }>(
+    "/api/sourcing/entity-summary",
+    // Fresh priorities matter — operators re-check this dashboard right
+    // after running a verification batch.
+    { revalidate: 60 },
+  );
+  if (!result.ok) {
+    return { status: "error", message: formatApiErrorMessage(result.error) };
   }
-  return lookup;
+  return { status: "ok", summaries: result.data.summaries ?? [] };
+}
+
+/**
+ * Resolve an entity-summary `entityId` (slug, sid_ prefixed, or bare 10-char)
+ * to a display name + href using the canonical lookup helpers. Falls back
+ * to the raw ID if nothing matches, so we never break the UI on an
+ * unexpected ID shape.
+ */
+export function resolveEntityDisplay(entityId: string): {
+  name: string;
+  href: string;
+} {
+  const entity =
+    getTypedEntityByStableId(entityId) ?? getTypedEntityById(entityId);
+  const name = entity?.title || entityId;
+  // getEntityHref handles slug / sid_* / bare 10-char / wikiId uniformly.
+  const href = getEntityHref(entityId);
+  return { name, href };
 }
 
 // ── Server component ─────────────────────────────────────────────────────
@@ -114,9 +138,7 @@ function buildEntityLookup(): Map<string, EntityLookupEntry> {
  * Feeds prioritization — "where to run verification next."
  */
 export async function WorstEntitiesWidget() {
-  const summaries = await loadEntitySummaries();
-  const lookup = buildEntityLookup();
-  const worst = computeWorstEntities(summaries, lookup);
+  const state = await loadEntitySummaries();
 
   return (
     <div className="not-prose mb-8">
@@ -126,73 +148,106 @@ export async function WorstEntitiesWidget() {
         outdated, partial, unverifiable, or unchecked). Use this list to
         prioritize the next verification run.
       </p>
-      {worst.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-6 text-center border border-border/60 rounded-lg">
-          No non-green verdicts found. Either everything is clean or the
-          entity-summary endpoint returned no data.
-        </p>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm tabular-nums">
-            <thead>
-              <tr className="border-b border-border/60 text-xs text-muted-foreground">
-                <th className="text-left py-2 pr-3 font-medium w-8">#</th>
-                <th className="text-left py-2 pr-3 font-medium">Entity</th>
-                <th className="text-right py-2 pr-3 font-medium">Non-green</th>
-                <th className="text-right py-2 pr-3 font-medium">Contra</th>
-                <th className="text-right py-2 pr-3 font-medium">Outdated</th>
-                <th className="text-right py-2 pr-3 font-medium">Partial</th>
-                <th className="text-right py-2 pr-3 font-medium">Unverif</th>
-                <th className="text-right py-2 pr-3 font-medium">Unchecked</th>
-                <th className="text-right py-2 pr-3 font-medium">Records</th>
-              </tr>
-            </thead>
-            <tbody>
-              {worst.map((row, idx) => (
-                <tr
-                  key={row.entityId}
-                  className="border-b border-border/40 last:border-0"
-                >
-                  <td className="py-2 pr-3 text-muted-foreground">{idx + 1}</td>
-                  <td className="py-2 pr-3 font-medium">
-                    {row.href ? (
-                      <Link
-                        href={row.href}
-                        className="text-primary hover:underline"
-                      >
-                        {row.displayName}
-                      </Link>
-                    ) : (
-                      row.displayName
-                    )}
-                  </td>
-                  <td className="py-2 pr-3 text-right font-semibold">
-                    {row.nonGreenCount}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-red-600">
-                    {row.contradicted || ""}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-amber-600">
-                    {row.outdated || ""}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-amber-500">
-                    {row.partial || ""}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-orange-600">
-                    {row.unverifiable || ""}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-muted-foreground">
-                    {row.unchecked || ""}
-                  </td>
-                  <td className="py-2 pr-3 text-right text-muted-foreground">
-                    {row.totalRecords}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <WorstEntitiesBody state={state} />
+    </div>
+  );
+}
+
+function WorstEntitiesBody({ state }: { state: SummariesState }) {
+  if (state.status === "error") {
+    return (
+      <p className="text-sm text-amber-600 py-6 text-center border border-amber-500/40 rounded-lg">
+        Could not load entity-summary from wiki-server:{" "}
+        <code className="text-[11px]">{state.message}</code>. Leaderboard
+        unavailable until the endpoint recovers.
+      </p>
+    );
+  }
+
+  const worst = computeWorstEntities(state.summaries, resolveEntityDisplay);
+
+  if (worst.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-6 text-center border border-border/60 rounded-lg">
+        No non-green verdicts found across {state.summaries.length} entities.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm tabular-nums">
+        <caption className="sr-only">
+          Top 20 entities ranked by count of non-green verdicts
+        </caption>
+        <thead>
+          <tr className="border-b border-border/60 text-xs text-muted-foreground">
+            <th scope="col" className="text-left py-2 pr-3 font-medium w-8">
+              #
+            </th>
+            <th scope="col" className="text-left py-2 pr-3 font-medium">
+              Entity
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Non-green
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Contra
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Outdated
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Partial
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Unverif
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Unchecked
+            </th>
+            <th scope="col" className="text-right py-2 pr-3 font-medium">
+              Records
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {worst.map((row, idx) => (
+            <tr
+              key={row.entityId}
+              className="border-b border-border/40 last:border-0"
+            >
+              <td className="py-2 pr-3 text-muted-foreground">{idx + 1}</td>
+              <td className="py-2 pr-3 font-medium">
+                <Link href={row.href} className="text-primary hover:underline">
+                  {row.displayName}
+                </Link>
+              </td>
+              <td className="py-2 pr-3 text-right font-semibold">
+                {row.nonGreenCount}
+              </td>
+              <td className="py-2 pr-3 text-right text-red-600">
+                {row.contradicted || ""}
+              </td>
+              <td className="py-2 pr-3 text-right text-amber-600">
+                {row.outdated || ""}
+              </td>
+              <td className="py-2 pr-3 text-right text-amber-500">
+                {row.partial || ""}
+              </td>
+              <td className="py-2 pr-3 text-right text-orange-600">
+                {row.unverifiable || ""}
+              </td>
+              <td className="py-2 pr-3 text-right text-muted-foreground">
+                {row.unchecked || ""}
+              </td>
+              <td className="py-2 pr-3 text-right text-muted-foreground">
+                {row.totalRecords}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a top-20 "Worst Entities" leaderboard to the Source Checks dashboard Coverage tab (E2200), ranking entities by count of non-green records (contradicted + outdated + partial + unverifiable + unchecked). Feeds prioritization — "where to run verification next."

## Implementation

- **No new API endpoint.** Reuses `/api/sourcing/entity-summary`, which already returns per-entity verdict counts in one query.
- **Pure helper `computeWorstEntities()`** handles ranking (non-green desc, tie-break by totalRecords desc), filter (drop fully-green), limit cap. Unit-tested in isolation.
- **Injected `EntityResolver`** function decouples the ranking logic from the runtime ID→name/href lookup; the server component wires in `getTypedEntityByStableId` + `getEntityHref` which handle all three `entityId` forms (slug, `sid_` prefixed, bare 10-char).
- **Distinct error state**: if the endpoint is unreachable, renders an amber error callout with the underlying API error instead of silently conflating with "all clean."
- **`revalidate: 60`** (not the default 300) since operators re-check this dashboard right after running a verification batch.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm test` (apps/web) — 1490 tests, 15 new
- [x] `pnpm crux w validate gate --fix` — 51/51 blocking checks pass
- [x] Hostile review: 2 HIGH + 3 MEDIUM findings, all addressed (or a LOW left for a follow-up polish PR)
- [x] Type check clean (apps/web, apps/wiki-server, crux)

## Unit test coverage (15 tests)

- `computeNonGreenCount` formula correctness (no double-counting `confirmed`)
- Drops fully-green entities
- Sorts by `nonGreenCount` desc
- Tie-breaks by `totalRecords` desc
- Limit cap (5, 0, default 20)
- Display name + href resolution (known & unknown IDs)
- Guards against "no IDs resolve" regression
- Unchecked-only ranking
- Empty input
- Preserves full per-verdict breakdown on each row

## Deploy Checklist

- [ ] Post-merge: visually confirm the widget renders with real prod data at `/internal/entity-sourcing` → Coverage tab

Fixes QUA-153
