### PR TITLE
feat(linear): block duplicate session claims in crux linear start (QUA-406)

### DIFF
--- a/.claude/rules/github-issue-tracking.md
+++ b/.claude/rules/github-issue-tracking.md
@@ -21,6 +21,35 @@ For GitHub: posts a start comment and adds the `agent:working` label.
 
 **Note:** `crux sys agent-checklist init` handles both automatically when `--linear=QUA-NNN` or `--issue=N` is provided. You rarely need to call these manually.
 
+## Dedup check — `crux linear start` refuses competing claims
+
+Both `crux linear start QUA-NNN` and `crux sys agent-checklist init --linear=QUA-NNN` run a **dedup pre-check** before posting anything to Linear. The check looks for two signals that another session is already working on the issue:
+
+1. **Recent start comments** — A `🤖 Claude Code starting work` comment posted in the last 24h from a **different slot** (e.g., a9 while you're on a5), not yet superseded by a `🤖 Claude Code finished work` comment.
+2. **Open PRs** — Any open PR in the wiki repo whose title or body mentions the Linear ID.
+
+Either signal is sufficient to block. On a collision, both commands exit with **code 2** (distinct from 1 for other errors), print the detected claim(s)/PR(s), and refuse to write any local session state (checklist file, DB row, active-agent registration). This means a colliding `init` leaves **no artifact** — you can fix the race and re-run without cleanup.
+
+Re-running from the **same slot** is NOT a collision — it's treated as session resumption (init-crash recovery, etc.). The slot is derived from the `a<N>` ancestor of the current working directory.
+
+Both checks are **fail-open**: if the Linear or GitHub API is unreachable, the dedup helper returns empty and the start proceeds. A transient API glitch should not wedge every session on the machine. The downside is a rare missed collision when both APIs are down simultaneously.
+
+### Bypassing with `--force`
+
+If the other session is genuinely abandoned or you have explicit permission to take over, pass `--force`:
+
+```bash
+pnpm crux linear start QUA-NNN --force
+# or
+pnpm crux sys agent-checklist init "..." --linear=QUA-NNN --force
+```
+
+`--force` **skips** the dedup check entirely. The start comment is annotated with a visible `⚠ Claimed with --force` marker so the duplication is captured in Linear history.
+
+### Historical note — QUA-406
+
+The dedup check was added after a 2026-04-13 incident where two concurrent sessions on the same machine (slots a9 and a16) each shipped a competing PR for QUA-397. Prior to that, `crux linear start` unconditionally posted a start comment regardless of existing claims, and the session-tracking rule described below was aspirational. See QUA-406 for the full post-mortem and fix set.
+
 ## At Session End (when shipping)
 
 After the work is committed and pushed (via `/agent-push-and-verify`), signal completion:
@@ -67,7 +96,7 @@ PRBODY
 ## Why This Matters
 
 - Linear is the source of truth for project status — stale "In Progress" issues mislead the team
-- Prevents multiple sessions picking up the same issue simultaneously
+- The dedup check (above) prevents multiple sessions from picking up the same issue simultaneously. Without it, two agents can spend hours independently shipping competing PRs for the same ticket (QUA-406 incident)
 - Creates a paper trail connecting branches/PRs to the originating issue
 - `crux` commands validate for corruption — raw curl/jq commands are vulnerable to shell-expansion bugs
 

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -19,6 +19,7 @@ const {
   updateProjectMock,
   createProjectUpdateMock,
   githubApiMock,
+  getSessionContextMock,
 } = vi.hoisted(() => ({
   getIssueMock: vi.fn(),
   getCommentsMock: vi.fn(),
@@ -31,6 +32,12 @@ const {
   updateProjectMock: vi.fn(),
   createProjectUpdateMock: vi.fn(),
   githubApiMock: vi.fn(),
+  getSessionContextMock: vi.fn(() => ({
+    slot: 5 as number | null,
+    branch: 'claude/qua-184-test-branch',
+    host: 'test-host' as string | null,
+    agentId: null as number | null,
+  })),
 }));
 
 vi.mock('../../lib/linear/issues.ts', () => ({
@@ -57,6 +64,23 @@ vi.mock('../../lib/github.ts', () => ({
   githubApi: githubApiMock,
   REPO: 'quantified-uncertainty/longterm-wiki',
 }));
+
+// Mock the session context so the slot is deterministic. Without this,
+// `getSessionContext()` walks ancestor dirs and picks up whatever `a<N>`
+// the test runner happens to sit in — which is `a5` on the dev laptop
+// but `null` on GitHub Actions runners at `/home/runner/work/...`.
+// That divergence makes same-slot vs cross-slot dedup tests flaky.
+// `buildStartCommentBody` is passed through via importActual since we
+// want the production formatting.
+vi.mock('../../lib/session/session-context.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/session/session-context.ts')>(
+    '../../lib/session/session-context.ts',
+  );
+  return {
+    ...actual,
+    getSessionContext: getSessionContextMock,
+  };
+});
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(() => 'claude/qua-184-test-branch'),

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -18,6 +18,7 @@ const {
   getProjectMock,
   updateProjectMock,
   createProjectUpdateMock,
+  githubApiMock,
 } = vi.hoisted(() => ({
   getIssueMock: vi.fn(),
   getCommentsMock: vi.fn(),
@@ -29,6 +30,7 @@ const {
   getProjectMock: vi.fn(),
   updateProjectMock: vi.fn(),
   createProjectUpdateMock: vi.fn(),
+  githubApiMock: vi.fn(),
 }));
 
 vi.mock('../../lib/linear/issues.ts', () => ({
@@ -48,6 +50,12 @@ vi.mock('../../lib/linear/projects.ts', () => ({
 
 vi.mock('../../lib/linear/workflow-states.ts', () => ({
   fetchRemoteWorkflowStates: fetchRemoteWorkflowStatesMock,
+}));
+
+// Mock the GitHub transport so the dedup PR search doesn't hit the network.
+vi.mock('../../lib/github.ts', () => ({
+  githubApi: githubApiMock,
+  REPO: 'quantified-uncertainty/longterm-wiki',
 }));
 
 vi.mock('child_process', () => ({
@@ -72,6 +80,15 @@ const mockIssue = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Reset mock implementations too — clearAllMocks only clears call records
+  // and leaves queued `mockResolvedValueOnce` values intact. Without this,
+  // a test that queues a Once value without consuming it will poison the
+  // next test's mock queue.
+  getCommentsMock.mockReset();
+  githubApiMock.mockReset();
+  // Default: dedup checks find nothing. Individual tests override.
+  getCommentsMock.mockResolvedValue([]);
+  githubApiMock.mockResolvedValue({ items: [] });
 });
 
 // ---------------------------------------------------------------------------
@@ -206,6 +223,192 @@ describe('linear start', () => {
     expect(commentBody).not.toContain('⚠');
     // Host is always set (from os.hostname()) — assert the field label is present
     expect(commentBody).toContain('**Host:**');
+  });
+
+  // ── Dedup (QUA-406) ──────────────────────────────────────────────────────
+
+  it('blocks with exit=2 when another slot has a recent unreleased start claim', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    // Recent start from a9 (different slot) — no finish comment after it.
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body:
+          '🤖 Claude Code starting work on this issue.\n\n' +
+          '**Slot:** a9\n' +
+          '**Branch:** `claude/qua-184-other-work`\n' +
+          '**Host:** MacBook-Pro-4.local\n',
+        createdAt: new Date().toISOString(),
+        user: { name: 'bot' },
+      },
+    ]);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('already claimed');
+    expect(r.output).toContain('a9');
+    expect(r.output).toContain('claude/qua-184-other-work');
+    expect(r.output).toContain('--force');
+    // No state change or comment should have been posted.
+    expect(updateIssueStateMock).not.toHaveBeenCalled();
+    expect(commentOnIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('allows re-running start from the same slot (init crash recovery)', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    // Prior start from the SAME slot as the test runner. The tests run from
+    // `.../lw/a5/...` so `getSessionContext().slot === 5`. A prior claim from
+    // a5 is treated as our own earlier session resuming, not a collision.
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body:
+          '🤖 Claude Code starting work on this issue.\n\n' +
+          '**Slot:** a5\n' +
+          '**Branch:** `claude/qua-184-earlier-attempt`\n',
+        createdAt: new Date().toISOString(),
+        user: { name: 'bot' },
+      },
+    ]);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalled();
+  });
+
+  it('treats stale (>24h) start comments as released', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const oldTs = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body:
+          '🤖 Claude Code starting work on this issue.\n\n' +
+          '**Slot:** a9\n**Branch:** `claude/qua-184-stale`\n',
+        createdAt: oldTs,
+        user: { name: 'bot' },
+      },
+    ]);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('treats a finish comment as releasing prior start claims', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const now = Date.now();
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body:
+          '🤖 Claude Code starting work on this issue.\n\n' +
+          '**Slot:** a9\n**Branch:** `claude/qua-184-done`\n',
+        createdAt: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+        user: { name: 'bot' },
+      },
+      {
+        id: 'c2',
+        body: '🤖 Claude Code finished work on this issue.',
+        createdAt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        user: { name: 'bot' },
+      },
+    ]);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('blocks with exit=2 when an open PR mentions the Linear ID', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    githubApiMock.mockResolvedValueOnce({
+      items: [
+        {
+          number: 4296,
+          title: 'fix(sourcing): eliminate raw ID leaks (QUA-184)',
+          html_url: 'https://github.com/quantified-uncertainty/longterm-wiki/pull/4296',
+          body: 'Fixes QUA-184',
+          pull_request: {},
+        },
+      ],
+    });
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('#4296');
+    expect(r.output).toContain('already claimed');
+    expect(updateIssueStateMock).not.toHaveBeenCalled();
+    expect(commentOnIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('--force bypasses dedup and annotates the start comment', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body:
+          '🤖 Claude Code starting work on this issue.\n\n' +
+          '**Slot:** a9\n**Branch:** `claude/qua-184-other`\n',
+        createdAt: new Date().toISOString(),
+        user: { name: 'bot' },
+      },
+    ]);
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true, force: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalled();
+    const commentBody = commentOnIssueMock.mock.calls[0][1];
+    expect(commentBody).toContain('Claimed with `--force`');
+    // When --force is set, the dedup API shouldn't have been called at all.
+    expect(getCommentsMock).not.toHaveBeenCalled();
+    expect(githubApiMock).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the Linear comments API throws', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getCommentsMock.mockRejectedValueOnce(new Error('Linear is down'));
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalled();
+  });
+
+  it('fails open when the GitHub search API throws', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    githubApiMock.mockRejectedValueOnce(new Error('rate limit exceeded'));
+    updateIssueStateMock.mockResolvedValueOnce({
+      identifier: 'QUA-184',
+      state: 'In Progress',
+    });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands.start(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalled();
   });
 });
 

--- a/crux/commands/agent-checklist.test.ts
+++ b/crux/commands/agent-checklist.test.ts
@@ -8,7 +8,7 @@
  * - check: marks items, handles --na
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock fs operations
 vi.mock('fs', () => ({
@@ -33,11 +33,32 @@ vi.mock('child_process', () => ({
 // Mock the Linear command module so auto-start doesn't hit the network.
 // `vi.mock` is hoisted above imports, so the mock factory uses `vi.hoisted`
 // to expose the spy back to the test body.
-const { linearStartMock } = vi.hoisted(() => ({
-  linearStartMock: vi.fn(async () => ({ output: '', exitCode: 0 })),
+const { linearStartMock, linearCheckDedupMock, getLinearIssueMock, getSessionContextMock } = vi.hoisted(() => ({
+  linearStartMock: vi.fn<(...a: unknown[]) => Promise<{ output: string; exitCode: number }>>(
+    async () => ({ output: '', exitCode: 0 }),
+  ),
+  linearCheckDedupMock: vi.fn<(...a: unknown[]) => Promise<{ output: string; exitCode: number } | null>>(
+    async () => null,
+  ),
+  getLinearIssueMock: vi.fn<(...a: unknown[]) => Promise<Record<string, unknown> | null>>(
+    async () => null,
+  ),
+  getSessionContextMock: vi.fn(() => ({
+    slot: null as number | null,
+    branch: 'claude/test-branch-ABC',
+    host: 'test-host' as string | null,
+    agentId: null as number | null,
+  })),
 }));
 vi.mock('./linear.ts', () => ({
   commands: { start: linearStartMock },
+  checkDedup: linearCheckDedupMock,
+}));
+vi.mock('../lib/linear/issues.ts', () => ({
+  getIssue: getLinearIssueMock,
+}));
+vi.mock('../lib/session/session-context.ts', () => ({
+  getSessionContext: getSessionContextMock,
 }));
 
 // Mock wiki-server agent-sessions (best-effort DB sync)
@@ -351,6 +372,125 @@ describe('agent-checklist init', () => {
     const writtenContent = mockWriteFileSync.mock.calls[0][1] as string;
     expect(writtenContent).toContain('> Linear: QUA-999');
     expect(writtenContent).not.toContain('> Linear: QUA-184');
+  });
+
+  // ── Dedup pre-check (QUA-406) ────────────────────────────────────────────
+
+  describe('Linear dedup pre-check', () => {
+    const originalKey = process.env.LINEAR_API_KEY;
+
+    beforeEach(() => {
+      // Reset implementations, not just call records. `clearAllMocks` in the
+      // outer `beforeEach` doesn't clear queued `mockResolvedValueOnce` values,
+      // so without this a test that sets a Once and doesn't consume it (e.g.
+      // the `--force` test) will poison the next test's mock queue.
+      linearCheckDedupMock.mockReset();
+      linearCheckDedupMock.mockResolvedValue(null);
+      getLinearIssueMock.mockReset();
+      linearStartMock.mockReset();
+      linearStartMock.mockResolvedValue({ output: '', exitCode: 0 });
+
+      process.env.LINEAR_API_KEY = 'test-key';
+      getLinearIssueMock.mockResolvedValue({
+        id: 'uuid-1',
+        identifier: 'QUA-406',
+        title: 'Test',
+        url: 'https://linear.app/qua/QUA-406',
+        description: '',
+        priority: 2,
+        state: { id: 's1', name: 'Backlog', type: 'backlog' },
+        team: { id: 't1', key: 'QUA' },
+        parent: null,
+        project: null,
+        labels: { nodes: [] },
+      });
+    });
+
+    afterEach(() => {
+      if (originalKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = originalKey;
+    });
+
+    it('hard-fails with exit 2 when another session has claimed the issue', async () => {
+      linearCheckDedupMock.mockResolvedValueOnce({
+        output: 'Active claim from slot a9 on branch claude/qua-406-other',
+        exitCode: 2,
+      });
+
+      const result = await initNoSideEffects(['Work on QUA-406'], {
+        type: 'bugfix',
+        linear: 'QUA-406',
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.output).toContain('Refusing to initialize session');
+      expect(result.output).toContain('QUA-406');
+      expect(result.output).toContain('--force');
+      // CRITICAL: the checklist must NOT have been written.
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      // And the later linear start should not have run either.
+      expect(linearStartMock).not.toHaveBeenCalled();
+    });
+
+    it('proceeds normally when pre-check finds no collision', async () => {
+      linearCheckDedupMock.mockResolvedValueOnce(null);
+
+      const result = await initNoSideEffects(['Work on QUA-406'], {
+        type: 'bugfix',
+        linear: 'QUA-406',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+      expect(linearCheckDedupMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('bypasses the pre-check when --force is set', async () => {
+      linearCheckDedupMock.mockResolvedValueOnce({
+        output: 'Active claim',
+        exitCode: 2,
+      });
+
+      const result = await initNoSideEffects(['Work on QUA-406'], {
+        type: 'bugfix',
+        linear: 'QUA-406',
+        force: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+      // Pre-check should not have been consulted at all.
+      expect(linearCheckDedupMock).not.toHaveBeenCalled();
+      // But the later linear start should still run (with force=true).
+      expect(linearStartMock).toHaveBeenCalledWith(
+        ['QUA-406'],
+        expect.objectContaining({ force: true }),
+      );
+    });
+
+    it('fails open when the pre-check helper throws', async () => {
+      linearCheckDedupMock.mockRejectedValueOnce(new Error('Linear down'));
+
+      const result = await initNoSideEffects(['Work on QUA-406'], {
+        type: 'bugfix',
+        linear: 'QUA-406',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the pre-check when LINEAR_API_KEY is not set', async () => {
+      delete process.env.LINEAR_API_KEY;
+
+      const result = await initNoSideEffects(['Work on QUA-406'], {
+        type: 'bugfix',
+        linear: 'QUA-406',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(linearCheckDedupMock).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -28,7 +28,9 @@ import { upsertAgentSession, updateAgentSession, getAgentSessionByBranch } from 
 import { registerAgent, listActiveAgents } from '../lib/wiki-server/active-agents.ts';
 import { syncToMain } from '../lib/git.ts';
 import { commands as issuesCommands } from './issues.ts';
-import { commands as linearCommands } from './linear.ts';
+import { commands as linearCommands, checkDedup as linearCheckDedup } from './linear.ts';
+import { getIssue as getLinearIssue } from '../lib/linear/issues.ts';
+import { getSessionContext } from '../lib/session/session-context.ts';
 import { resolveLinearId, parseLinearId } from '../lib/linear/parse-id.ts';
 
 // ---------------------------------------------------------------------------
@@ -57,6 +59,9 @@ interface CommandOptions extends BaseOptions {
   noIssueStart?: boolean;
   /** Skip the auto-call to `linear issues start <QUA-NNN>`. Used by tests. */
   noLinearStart?: boolean;
+  /** Pass --force through to `linear start` to bypass the dedup check. Also
+   *  disarms the hard-fail path on dedup collisions. */
+  force?: boolean;
 }
 
 interface GitHubIssueResponse {
@@ -155,6 +160,43 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   if (!linearId) {
     const detected = resolveLinearId([branch, task]);
     if (detected) linearId = detected;
+  }
+
+  // ── Dedup pre-check ───────────────────────────────────────────────────────
+  // If the issue is already claimed by another session, refuse to write ANY
+  // local state (checklist, DB row, active-agent registration). Running this
+  // BEFORE any file writes prevents half-initialized session state when two
+  // agents race on the same ticket. See QUA-406.
+  //
+  // The check is gated on LINEAR_API_KEY being present (same conditions as
+  // the later auto-call to `linear start`). If the key is missing or the
+  // Linear API is unreachable, we fail-open — better than wedging init.
+  if (
+    linearId &&
+    !options.noLinearStart &&
+    !options.force &&
+    process.env.LINEAR_API_KEY
+  ) {
+    try {
+      const issue = await getLinearIssue(linearId);
+      if (issue) {
+        const ctx = getSessionContext();
+        const collision = await linearCheckDedup(linearId, issue.url, ctx, c);
+        if (collision) {
+          return {
+            output:
+              `${c.red}✗ Refusing to initialize session — Linear ${linearId} is already claimed.${c.reset}\n\n` +
+              collision.output +
+              `\n${c.dim}Re-run with ${c.bold}--force${c.reset}${c.dim} to claim anyway:${c.reset}\n` +
+              `  ${c.cyan}crux sys agent-checklist init ${args.map((a) => JSON.stringify(a)).join(' ')} --force${c.reset}\n`,
+            exitCode: 2,
+          };
+        }
+      }
+    } catch {
+      // Fail-open on pre-check errors (missing helper, network glitch).
+      // The later `linear start` call will still run and post a start comment.
+    }
   }
 
   // Warn if Linear ID detected but branch name doesn't encode it.
@@ -281,8 +323,11 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   }
 
   // ── Auto-call `linear issues start <QUA-NNN>` ────────────────────────────
-  // Same best-effort semantics as the GitHub start above: failure (missing
-  // LINEAR_API_KEY, network error, issue already Done) never fails the init.
+  // Dedup collisions (exit code 2) are hard-fail: the checklist is NOT
+  // written, and init returns non-zero so the user sees the collision
+  // before committing to a session. All other errors (missing key, network
+  // glitch, issue-not-found) remain best-effort warnings — we don't want
+  // a transient API blip to wedge every init.
   let linearStartOutput = '';
   if (linearId && !options.noLinearStart) {
     if (!process.env.LINEAR_API_KEY) {
@@ -291,9 +336,24 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
         `skipping auto-start. Sync .env.base or export the key to enable.${c.reset}\n`;
     } else {
       try {
-        const startResult = await linearCommands.start([linearId], { ci: options.ci });
+        const startResult = await linearCommands.start(
+          [linearId],
+          { ci: options.ci, force: options.force },
+        );
         if (startResult.exitCode === 0) {
           linearStartOutput = startResult.output;
+        } else if (startResult.exitCode === 2) {
+          // Dedup collision — refuse to create the checklist. The start
+          // output contains a rich diagnostic (active claims + open PRs)
+          // that tells the user exactly what's blocking them.
+          return {
+            output:
+              `${c.red}✗ Refusing to create session checklist — Linear ${linearId} is already claimed.${c.reset}\n\n` +
+              startResult.output +
+              `\n${c.dim}Re-run with ${c.bold}--force${c.reset}${c.dim} to claim anyway:${c.reset}\n` +
+              `  ${c.cyan}crux sys agent-checklist init ${args.map((a) => JSON.stringify(a)).join(' ')} --force${c.reset}\n`,
+            exitCode: 2,
+          };
         } else {
           linearStartOutput =
             `${c.yellow}⚠ Auto-start of Linear ${linearId} returned non-zero exit:${c.reset}\n` +

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -43,6 +43,12 @@ import { githubApi } from '../lib/github.ts';
 import { resolve as resolvePath } from 'path';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
 import { findAllLinearIds, parseLinearId, resolveLinearId } from '../lib/linear/parse-id.ts';
+import {
+  findActiveClaimsByOthers,
+  findOpenPrsMentioningLinearId,
+  type OpenPrMatch,
+  type RecentStartClaim,
+} from '../lib/linear/dedup.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
 import { buildStartCommentBody, getSessionContext } from '../lib/session/session-context.ts';
 import { execSync } from 'child_process';
@@ -63,6 +69,7 @@ interface CommandOptions extends BaseOptions {
   state?: string;
   startDate?: string;
   targetDate?: string;
+  force?: boolean;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -194,7 +201,7 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear start <QUA-NNN>${c.reset}\n`,
+      output: `${c.red}Usage: crux linear start <QUA-NNN> [--force]${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -205,15 +212,102 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   }
 
   const ctx = getSessionContext();
+
+  // Dedup: block if another session appears to have already claimed this
+  // issue. Both checks are fail-open — they return empty on API errors so
+  // a transient glitch doesn't wedge all sessions. See QUA-406 for the
+  // incident that motivated this (two sessions racing on QUA-397).
+  if (!options.force) {
+    const collision = await checkDedup(id, issue.url, ctx, c);
+    if (collision) return collision;
+  }
+
   await updateIssueState(id, 'In Progress');
-  await commentOnIssue(id, buildStartCommentBody(ctx));
+  const trailing = options.force
+    ? '⚠ Claimed with `--force` — another session may already be working on this issue.\nWill post an update when a PR is ready for review.'
+    : undefined;
+  await commentOnIssue(id, buildStartCommentBody(ctx, { trailing }));
 
   let out = '';
   out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → In Progress\n`;
   out += `  Branch: ${c.cyan}${ctx.branch}${c.reset}\n`;
   if (ctx.slot !== null) out += `  Slot: ${c.cyan}a${ctx.slot}${c.reset}\n`;
+  if (options.force) {
+    out += `  ${c.yellow}⚠ Forced past dedup check${c.reset}\n`;
+  }
   out += `  ${issue.url}\n`;
   return { output: out, exitCode: 0 };
+}
+
+/**
+ * Run the dedup checks used by `crux linear start` and return a
+ * pre-formatted CollisionError `CommandResult` (exit code 2) when another
+ * session already appears to own the issue. Returns `null` when the call
+ * site may proceed.
+ *
+ * Exported so `agent-checklist init` can pre-check before writing any
+ * session state to disk.
+ */
+export async function checkDedup(
+  id: string,
+  issueUrl: string,
+  ctx: import('../lib/session/session-context.ts').SessionContext,
+  c: ReturnType<typeof createLogger>['colors'],
+): Promise<CommandResult | null> {
+  const [activeClaims, openPrs] = await Promise.all([
+    findActiveClaimsByOthers(id, ctx),
+    findOpenPrsMentioningLinearId(id),
+  ]);
+
+  if (activeClaims.length === 0 && openPrs.length === 0) return null;
+
+  // Exit code 2 = dedup collision (distinct from 1 = other error).
+  // `agent-checklist init` treats 2 as a hard-fail and refuses to create
+  // the checklist; 1 still falls back to a soft warning.
+  return {
+    output: formatCollisionError(id, issueUrl, activeClaims, openPrs, c),
+    exitCode: 2,
+  };
+}
+
+function formatCollisionError(
+  id: string,
+  url: string,
+  claims: RecentStartClaim[],
+  openPrs: OpenPrMatch[],
+  c: ReturnType<typeof createLogger>['colors'],
+): string {
+  let out = `${c.red}✗ ${id} is already claimed by another session.${c.reset}\n\n`;
+
+  if (claims.length > 0) {
+    const label = claims.length === 1 ? 'Active claim' : `${claims.length} active claims`;
+    out += `  ${c.bold}${label}${c.reset} (last 24h, from a different slot):\n`;
+    for (const claim of claims) {
+      const firstLine = claim.body.split('\n').find((l) => l.trim().length > 0) ?? '';
+      const tag =
+        `slot=${claim.slot ?? '?'} ` +
+        `branch=${claim.branch ?? '?'} ` +
+        `at=${claim.createdAt}`;
+      out += `    ${c.dim}${tag}${c.reset}\n`;
+      out += `    ${firstLine.slice(0, 120)}\n`;
+    }
+    out += '\n';
+  }
+
+  if (openPrs.length > 0) {
+    const label = openPrs.length === 1 ? 'Open PR' : `${openPrs.length} open PRs`;
+    out += `  ${c.bold}${label}${c.reset} referencing ${id}:\n`;
+    for (const pr of openPrs) {
+      out += `    ${c.cyan}#${pr.number}${c.reset} ${pr.title}\n`;
+      out += `    ${c.dim}${pr.url}${c.reset}\n`;
+    }
+    out += '\n';
+  }
+
+  out += `  ${c.yellow}Investigate the existing session before starting a new one.${c.reset}\n`;
+  out += `  Issue: ${url}\n\n`;
+  out += `  To claim anyway (e.g. the other session is abandoned), pass ${c.bold}--force${c.reset}.\n`;
+  return out;
 }
 
 async function done(args: string[], options: CommandOptions): Promise<CommandResult> {

--- a/crux/lib/linear/dedup.test.ts
+++ b/crux/lib/linear/dedup.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the dedup helpers used by `crux linear start`. Covers the
+ * pure filtering logic: what counts as an "active claim by another
+ * session" vs a stale / same-slot / released claim.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionContext } from '../session/session-context.ts';
+
+const { getCommentsMock, githubApiMock } = vi.hoisted(() => ({
+  getCommentsMock: vi.fn(),
+  githubApiMock: vi.fn(),
+}));
+
+vi.mock('./issues.ts', () => ({
+  getComments: getCommentsMock,
+}));
+
+vi.mock('../github.ts', () => ({
+  githubApi: githubApiMock,
+  REPO: 'quantified-uncertainty/longterm-wiki',
+}));
+
+import {
+  findActiveClaimsByOthers,
+  findOpenPrsMentioningLinearId,
+} from './dedup.ts';
+
+const now = Date.parse('2026-04-13T22:00:00Z');
+
+function startComment(opts: {
+  slot?: string;
+  branch?: string;
+  hoursAgo: number;
+  id?: string;
+}) {
+  const lines = ['🤖 Claude Code starting work on this issue.', ''];
+  if (opts.slot) lines.push(`**Slot:** ${opts.slot}`);
+  if (opts.branch) lines.push(`**Branch:** \`${opts.branch}\``);
+  return {
+    id: opts.id ?? `c-${Math.random()}`,
+    body: lines.join('\n'),
+    createdAt: new Date(now - opts.hoursAgo * 60 * 60 * 1000).toISOString(),
+    user: { name: 'bot' },
+  };
+}
+
+function finishComment(hoursAgo: number) {
+  return {
+    id: `c-fin-${Math.random()}`,
+    body: '🤖 Claude Code finished work on this issue.',
+    createdAt: new Date(now - hoursAgo * 60 * 60 * 1000).toISOString(),
+    user: { name: 'bot' },
+  };
+}
+
+const baseCtx: SessionContext = {
+  slot: 5,
+  branch: 'claude/qua-406-linear-start-dedup',
+  host: 'test-host',
+  agentId: null,
+};
+
+beforeEach(() => {
+  getCommentsMock.mockReset();
+  githubApiMock.mockReset();
+});
+
+describe('findActiveClaimsByOthers', () => {
+  it('returns empty when there are no comments', async () => {
+    getCommentsMock.mockResolvedValueOnce([]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toEqual([]);
+  });
+
+  it('returns empty when the only start comment is from our own slot', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      startComment({ slot: 'a5', branch: 'claude/qua-406-earlier', hoursAgo: 2 }),
+    ]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toEqual([]);
+  });
+
+  it('flags a recent start comment from a different slot', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      startComment({ slot: 'a9', branch: 'claude/qua-406-other', hoursAgo: 2 }),
+    ]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].slot).toBe('a9');
+    expect(claims[0].branch).toBe('claude/qua-406-other');
+  });
+
+  it('ignores start comments older than 24h', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      startComment({ slot: 'a9', branch: 'claude/qua-406-old', hoursAgo: 36 }),
+    ]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toEqual([]);
+  });
+
+  it('treats a later finish comment as releasing prior start claims', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      startComment({ slot: 'a9', branch: 'claude/qua-406-done', hoursAgo: 3 }),
+      finishComment(2),
+    ]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toEqual([]);
+  });
+
+  it('keeps a start claim posted AFTER the finish comment', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      startComment({ slot: 'a9', branch: 'claude/qua-406-done', hoursAgo: 5 }),
+      finishComment(4),
+      startComment({ slot: 'a9', branch: 'claude/qua-406-restart', hoursAgo: 1 }),
+    ]);
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].branch).toBe('claude/qua-406-restart');
+  });
+
+  it('fails open when getComments throws', async () => {
+    getCommentsMock.mockRejectedValueOnce(new Error('Linear unreachable'));
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toEqual([]);
+  });
+
+  it('handles start comments missing slot/branch fields gracefully', async () => {
+    getCommentsMock.mockResolvedValueOnce([
+      {
+        id: 'c1',
+        body: '🤖 Claude Code starting work on this issue.',
+        createdAt: new Date(now - 60 * 60 * 1000).toISOString(),
+        user: { name: 'bot' },
+      },
+    ]);
+    // Orphan claims (no slot) from a slot-less caller are ignored — too
+    // ambiguous to block on. A slot-ful caller treats them as collisions.
+    const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+    expect(claims).toHaveLength(1); // slot-ful caller treats as collision
+  });
+});
+
+describe('findOpenPrsMentioningLinearId', () => {
+  it('returns empty on no matches', async () => {
+    githubApiMock.mockResolvedValueOnce({ items: [] });
+    const prs = await findOpenPrsMentioningLinearId('QUA-406');
+    expect(prs).toEqual([]);
+  });
+
+  it('returns PRs whose title or body mentions the ID', async () => {
+    githubApiMock.mockResolvedValueOnce({
+      items: [
+        {
+          number: 4296,
+          title: 'fix: raw ID leaks (QUA-406)',
+          html_url: 'https://github.com/x/y/pull/4296',
+          body: 'Fixes QUA-406',
+          pull_request: {},
+        },
+      ],
+    });
+    const prs = await findOpenPrsMentioningLinearId('QUA-406');
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(4296);
+    expect(prs[0].url).toBe('https://github.com/x/y/pull/4296');
+  });
+
+  it('filters out issues (non-PR results from /search/issues)', async () => {
+    githubApiMock.mockResolvedValueOnce({
+      items: [
+        {
+          number: 100,
+          title: 'bug: QUA-406 unrelated',
+          html_url: 'https://github.com/x/y/issues/100',
+          body: 'QUA-406 is mentioned but this is an issue',
+          // no pull_request field
+        },
+        {
+          number: 4296,
+          title: 'fix: QUA-406',
+          html_url: 'https://github.com/x/y/pull/4296',
+          body: '',
+          pull_request: {},
+        },
+      ],
+    });
+    const prs = await findOpenPrsMentioningLinearId('QUA-406');
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(4296);
+  });
+
+  it('filters out weak matches where the ID is not a word boundary', async () => {
+    githubApiMock.mockResolvedValueOnce({
+      items: [
+        {
+          number: 1,
+          title: 'prefix QUA-4069 suffix', // QUA-406 is NOT a substring hit
+          html_url: 'https://github.com/x/y/pull/1',
+          body: '',
+          pull_request: {},
+        },
+      ],
+    });
+    const prs = await findOpenPrsMentioningLinearId('QUA-406');
+    expect(prs).toEqual([]);
+  });
+
+  it('fails open when githubApi throws', async () => {
+    githubApiMock.mockRejectedValueOnce(new Error('rate limit exceeded'));
+    const prs = await findOpenPrsMentioningLinearId('QUA-406');
+    expect(prs).toEqual([]);
+  });
+});

--- a/crux/lib/linear/dedup.ts
+++ b/crux/lib/linear/dedup.ts
@@ -1,0 +1,176 @@
+/**
+ * Dedup helpers for `crux linear start`.
+ *
+ * Detects whether another session has already claimed a Linear issue, so
+ * that two agents don't race to implement the same ticket (QUA-406). The
+ * check has two independent signals:
+ *
+ * 1. Recent "🤖 Claude Code starting work" comments on the Linear issue
+ *    from a different slot, not yet superseded by a "finished work" comment.
+ * 2. Open PRs in the wiki repo whose title or body mentions the Linear ID.
+ *
+ * Either signal is sufficient to block the `start` call. Users can override
+ * with `--force` (see `crux linear start --force`). Both checks fail-open
+ * on API errors: if GitHub or Linear is unreachable, we let the session
+ * proceed rather than blocking on a transient glitch. The downside of a
+ * rare missed collision is less bad than blocking all sessions when the
+ * APIs hiccup.
+ */
+
+import { githubApi, REPO } from '../github.ts';
+import { getComments, type LinearComment } from './issues.ts';
+import type { SessionContext } from '../session/session-context.ts';
+
+// 24-hour window for considering a start comment "recent." Anything older
+// is treated as stale and ignored — if a session has been claimed for >24h
+// without completing, it's probably abandoned or in need of manual review,
+// and blocking new claims on it would be worse than letting them through.
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export interface RecentStartClaim {
+  /** The original comment body (for display in error messages). */
+  body: string;
+  /** ISO timestamp when the comment was posted. */
+  createdAt: string;
+  /** Branch parsed from `**Branch:** \`<name>\``, or null if not present. */
+  branch: string | null;
+  /** Slot parsed from `**Slot:** a<N>`, or null if not present. */
+  slot: string | null;
+}
+
+const START_COMMENT_MARKER = /🤖\s*Claude Code starting work/;
+const FINISH_COMMENT_MARKER = /🤖\s*Claude Code finished work/;
+const BRANCH_LINE = /\*\*Branch:\*\*\s*`([^`]+)`/;
+const SLOT_LINE = /\*\*Slot:\*\*\s*(a\d+)/;
+
+function parseStartClaim(comment: LinearComment): RecentStartClaim | null {
+  if (!START_COMMENT_MARKER.test(comment.body)) return null;
+  const branchMatch = comment.body.match(BRANCH_LINE);
+  const slotMatch = comment.body.match(SLOT_LINE);
+  return {
+    body: comment.body,
+    createdAt: comment.createdAt,
+    branch: branchMatch ? branchMatch[1] : null,
+    slot: slotMatch ? slotMatch[1] : null,
+  };
+}
+
+/**
+ * Fetch recent start-work comments that represent unresolved claims by
+ * another session. "Unresolved" means: posted in the last 24h, from a
+ * different slot than ours, and not followed by a "finished work" comment
+ * from the same session.
+ *
+ * Same-slot re-runs (init crash recovery, resume) are not blocked — it's
+ * the same user reclaiming their own workspace. Cross-slot starts are the
+ * collision pattern we care about (QUA-406: a9 vs a16 on the same machine).
+ *
+ * Fail-open: returns an empty array if the Linear API is unreachable.
+ */
+export async function findActiveClaimsByOthers(
+  linearId: string,
+  ctx: SessionContext,
+  nowMs: number = Date.now(),
+): Promise<RecentStartClaim[]> {
+  let comments: LinearComment[];
+  try {
+    comments = await getComments(linearId, 30);
+  } catch {
+    return [];
+  }
+
+  // Walk comments chronologically to track which starts have been superseded
+  // by a later finish. Linear returns comments oldest-first from getComments.
+  // A single "finish" comment supersedes any prior unresolved start because
+  // we can't tell sessions apart from the finish comment body — the `done`
+  // command posts a generic "finished work" marker with no slot info.
+  const sorted = [...comments].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+
+  const activeClaims: RecentStartClaim[] = [];
+  for (const c of sorted) {
+    if (FINISH_COMMENT_MARKER.test(c.body)) {
+      // Any prior unresolved claim is considered released.
+      activeClaims.length = 0;
+      continue;
+    }
+    const claim = parseStartClaim(c);
+    if (!claim) continue;
+    activeClaims.push(claim);
+  }
+
+  const ourSlot = ctx.slot !== null ? `a${ctx.slot}` : null;
+
+  return activeClaims.filter((claim) => {
+    // Stale claim → not a collision.
+    if (nowMs - new Date(claim.createdAt).getTime() >= DEDUP_WINDOW_MS) {
+      return false;
+    }
+    // Same slot as us → treat as our own prior claim (resume/retry).
+    // Both slots null → ambiguous (both running outside a slot dir); don't
+    // block, since the main collision case the ticket documents is two
+    // different slots.
+    if (ourSlot && claim.slot && claim.slot === ourSlot) return false;
+    if (!ourSlot && !claim.slot) return false;
+    return true;
+  });
+}
+
+export interface OpenPrMatch {
+  number: number;
+  title: string;
+  url: string;
+}
+
+interface GhSearchItem {
+  number: number;
+  title: string;
+  html_url: string;
+  body: string | null;
+  pull_request?: unknown;
+}
+
+interface GhSearchResponse {
+  items: GhSearchItem[];
+}
+
+/**
+ * Find open PRs in the wiki repo whose title or body mentions the Linear ID.
+ * Used by `crux linear start` to detect a competing branch before posting a
+ * new start claim.
+ *
+ * Fail-open: returns an empty array if the GitHub search API is unreachable
+ * or rate-limited. The comment-based check still runs and provides defense
+ * in depth.
+ */
+export async function findOpenPrsMentioningLinearId(
+  linearId: string,
+): Promise<OpenPrMatch[]> {
+  const q = `${linearId} repo:${REPO} is:pr is:open`;
+  const encoded = encodeURIComponent(q);
+
+  let resp: GhSearchResponse;
+  try {
+    resp = await githubApi<GhSearchResponse>(
+      `/search/issues?q=${encoded}&per_page=10`,
+    );
+  } catch {
+    return [];
+  }
+
+  // Defensive client-side confirmation: GitHub search is token-based and
+  // can occasionally return weak matches. Require the exact ID string to
+  // appear in the title or body.
+  const escaped = linearId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const ref = new RegExp(`\\b${escaped}\\b`, 'i');
+
+  return (resp.items ?? [])
+    .filter((item) => item.pull_request !== undefined)
+    .filter((item) => ref.test(item.title) || ref.test(item.body ?? ''))
+    .map((item) => ({
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+    }));
+}


### PR DESCRIPTION
## Summary

Closes QUA-406. Adds a dedup pre-check to `crux linear start` so two concurrent sessions can't race to claim the same Linear issue. Previously, `start()` had zero dedup — it unconditionally posted a "starting work" comment regardless of existing claims. On 2026-04-13 this caused slots a9 and a16 on the same machine to independently ship competing PRs for QUA-397 (PR #4296 and PR #4297), burning significant compute before the collision was noticed.

## What changed

- **`crux linear start` pre-check** — before posting anything, look for two signals of an active competing session:
  1. Recent `🤖 Claude Code starting work` comments from a **different slot** in the last 24h, not yet superseded by a `🤖 Claude Code finished work` comment.
  2. Open PRs in the wiki repo whose title or body mentions the Linear ID.
  
  Either signal blocks the call with **exit code 2**. The error lists the detected claim(s)/PR(s) so you know who to talk to. Verified live against QUA-397 — correctly flags 3 prior claims + PR #4296.

- **`--force` override** — bypasses the dedup check entirely. The start comment is annotated with `⚠ Claimed with --force despite existing session(s)` so the duplication is captured in Linear history.

- **`agent-checklist init` propagation** — runs the dedup pre-check BEFORE writing any session state (checklist file, DB row, active-agent registration). On collision, init returns exit 2 and leaves **no local artifact**, so a colliding init can be re-run after the race is resolved without cleanup. `init --force` threads through to `linear start --force`.

- **Same-slot = same session** — the slot is the canonical "this is me" signal (derived from the `a<N>` ancestor of `cwd`). A prior claim with the same slot is treated as init-crash recovery or explicit resume, not a collision.

- **Fail-open on API errors** — both `findActiveClaimsByOthers` and `findOpenPrsMentioningLinearId` return `[]` on exception. A Linear or GitHub outage will not wedge every session on the machine. The rare missed-collision cost is less bad than blocking all starts on a transient API glitch.

- **Rule update** — `.claude/rules/github-issue-tracking.md` now describes the actual dedup behavior instead of the aspirational "prevents multiple sessions" language that was the root cause of the ticket's trust hazard.

## Out of scope (will follow up)

These came up in the QUA-406 investigation but are not in this PR to keep the diff focused:

- `./ws list` cross-reference with open PRs and running `claude` processes per slot. The ticket framed this as "stale git state" but `list` reads live via `execSync` — the real weakness is no correlation with Linear/PR state. Not a dedup issue per se; file a follow-up if the coordinator wants slot visibility into who owns what.
- `crux sys dispatch --linear=QUA-NNN --slot=N` wrapper that enforces a pre-flight dedup check structurally so coordinators can't skip it under context pressure.
- Coordinator-side pre-dispatch hook — a symmetric rule that a coordinator dispatching a slot MUST run `crux linear view` + `gh pr list --search QUA-NNN` first. Complements this PR's server-side check.

## Test plan

- [x] Unit tests for `findActiveClaimsByOthers` and `findOpenPrsMentioningLinearId` (13 tests in `crux/lib/linear/dedup.test.ts`) covering: empty, same-slot same-session, cross-slot collision, 24h staleness window, finish-releases-prior, PR filtering, word-boundary false-positives, and fail-open on both APIs.
- [x] End-to-end tests in `crux/commands/__tests__/linear.test.ts` (+11 new): happy path, different-slot collision, same-slot resumption, stale >24h, finish-supersedes-start, open-PR collision, `--force` bypass, both fail-open paths.
- [x] Integration tests in `crux/commands/agent-checklist.test.ts` (+5 new): hard-fail with exit 2 and no checklist written on collision, normal proceed on no collision, `--force` bypass, fail-open, and skip when `LINEAR_API_KEY` is unset.
- [x] Full crux test suite run: 105/105 relevant tests pass. Pre-existing unrelated failures in `fix-contradicted-facts`, `validate-sourcing-coverage`, and two `ci-*` files are not touched by this diff.
- [x] `pnpm crux w validate gate --fix` — all 51 gate checks pass, no new advisories.
- [x] `pnpm build` — succeeds.
- [x] Live smoke test: ran `pnpm crux linear start QUA-397` against the real ticket — correctly returns exit 2, lists 3 prior claims (a9, a16, a16) and open PR #4296.
