### PR TITLE
fix(people): use raw grant PK not composite key for verdict/sourcing (QUA-417)

### DIFF
--- a/apps/web/src/app/people/[slug]/funding-connections.tsx
+++ b/apps/web/src/app/people/[slug]/funding-connections.tsx
@@ -61,7 +61,7 @@ export function FundingConnections({
         </div>
         <div className="divide-y divide-border/40">
           {displayed.map((conn) => {
-            const verdict = getRecordVerdict("grant", String(conn.key))?.verdict;
+            const verdict = getRecordVerdict("grant", conn.recordKey)?.verdict;
             return (
             <div key={conn.key} className="px-5 pr-12 py-3.5 relative">
               <div className="absolute top-3.5 right-4">
@@ -70,7 +70,7 @@ export function FundingConnections({
                     filledFieldCount: (conn.amount ? 1 : 0) + (conn.date ? 1 : 0) + (conn.source ? 1 : 0),
                   })}
                   verdict={verdict}
-                  sourcingHref={getSourcingHref("grant", String(conn.key))}
+                  sourcingHref={getSourcingHref("grant", conn.recordKey)}
                 />
               </div>
               <div className="flex items-center gap-2 flex-wrap">

--- a/apps/web/src/app/people/people-utils.test.ts
+++ b/apps/web/src/app/people/people-utils.test.ts
@@ -463,6 +463,9 @@ describe("getFundingConnectionsForPerson", () => {
       expect(result[0].name).toBe("AI Safety Grant");
       expect(result[0].amount).toBe(1000000);
       expect(result[0].viaOrg).toEqual({ id: "org1", name: "Anthropic", slug: "org1" });
+      // QUA-417: recordKey is the raw grant PK, key is the composite React key
+      expect(result[0].recordKey).toBe("g1");
+      expect(result[0].key).toBe("org1-g1");
     });
 
     it("resolves counterparty for gave grants", () => {

--- a/apps/web/src/app/people/people-utils.ts
+++ b/apps/web/src/app/people/people-utils.ts
@@ -176,8 +176,10 @@ export function getCareerHistory(personEntityId: string): CareerHistoryEntry[] {
 // -- Funding connections ---------------------------------------------------
 
 export interface FundingConnection {
-  /** Unique key for React rendering */
+  /** Unique key for React rendering (composite: owner + record key) */
   key: string;
+  /** Raw grant record PK — use for verdict/sourcing lookups, not `key` */
+  recordKey: string;
   /** Grant display name */
   name: string;
   /** Whether this person's org gave or received the grant, or the person directly received it */
@@ -325,6 +327,7 @@ export function getFundingConnectionsForPerson(
         : null;
       connections.push({
         key: compositeKey,
+        recordKey: record.key,
         name: parsed.name,
         direction: "gave",
         viaOrg: resolveOrg(funderOrgId),
@@ -347,6 +350,7 @@ export function getFundingConnectionsForPerson(
       seen.add(compositeKey);
       connections.push({
         key: compositeKey,
+        recordKey: record.key,
         name: parsed.name,
         direction: "personal",
         viaOrg: null,
@@ -389,6 +393,7 @@ export function getFundingConnectionsForPerson(
         seen.add(compositeKey);
         connections.push({
           key: compositeKey,
+          recordKey: record.key,
           name: parsed.name,
           direction: "received",
           viaOrg: resolveOrg(recipientEntityId),


### PR DESCRIPTION
## Summary

Fixes QUA-417. Every grant dot on `/people/<slug>?tab=funding` showed "unchecked" status and 404ed on click, because `funding-connections.tsx` was passing the React composite key (`${ownerEntityId}-${recordKey}`) to `getRecordVerdict("grant", …)` and `getSourcingHref("grant", …)`. The verdict store and sourcing routes index by the raw grant PK.

## Fix

Add a separate `recordKey: string` field on `FundingConnection` set to `record.key` (the grants-table PK). Pass `conn.recordKey` to the verdict/sourcing helpers. Keep `conn.key` as the composite for the React `key=` prop.

## Changes

- `apps/web/src/app/people/people-utils.ts` — new `recordKey` field on the interface + 3 push sites
- `apps/web/src/app/people/[slug]/funding-connections.tsx` — swap `conn.key` → `conn.recordKey` at the two helper callsites (also drops redundant `String(...)` wrapping)
- `apps/web/src/app/people/people-utils.test.ts` — regression assertion on `recordKey` vs `key`

## Test plan

- [x] `vitest run src/app/people/people-utils.test.ts` — 25 passing
- [x] `tsc --noEmit` clean
- [ ] Verify on prod: `/people/adam-gleave?tab=funding` grant dots show real verdicts and click-through works

## Follow-up

Systemic defense is tracked in QUA-423 (branded `RecordId<T>` type).
