### PR TITLE
refactor(qua-397): review follow-up — extract formatFactLabel + fix critical prefix-strip bug

### DIFF
--- a/apps/web/src/app/internal/entity-profile/__tests__/sanitize-raw-ids.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/sanitize-raw-ids.test.ts
@@ -20,16 +20,35 @@ describe("sanitizeRawIds", () => {
       expect(sanitizeRawIds("f_mEKUPPFYRg: 2010-09")).toBe("2010-09");
     });
 
-    it("strips legacy 8-char hex prefix (`e7c42d88: value`)", () => {
-      expect(sanitizeRawIds("e7c42d88: $1,000,000")).toBe("$1,000,000");
-    });
-
-    it("strips legacy 12-char hex prefix", () => {
-      expect(sanitizeRawIds("a8c71e05abcd — Anthropic")).toBe("Anthropic");
+    it("strips legacy 10-char mixed-case alnum prefix (`2Y4ope8OxA — Entity`)", () => {
+      // Legacy pre-`f_` fact ID format — requires entropy gate on post-match
+      // verification (upper + lower + digit) to distinguish from real words.
+      expect(sanitizeRawIds("2Y4ope8OxA — Google DeepMind")).toBe("Google DeepMind");
+      expect(sanitizeRawIds("XUSIG6vsPw: London")).toBe("London");
     });
 
     it("handles single hyphen + space between id and value", () => {
       expect(sanitizeRawIds("f_qR5tY9wE1a - Some Title")).toBe("Some Title");
+    });
+
+    it("does NOT strip 10-char English words that match the regex shape", () => {
+      // Regression: the prefix regex alternative `[A-Za-z0-9]{10}` is too loose
+      // on its own — entropy gate `looksLikeLegacyFactId` (requires digit) is
+      // load-bearing. Adversarial review flagged this as critical.
+      expect(sanitizeRawIds("Washington — Seattle")).toBe("Washington — Seattle");
+      expect(sanitizeRawIds("California: 1850")).toBe("California: 1850");
+      expect(sanitizeRawIds("Manchester — UK")).toBe("Manchester — UK");
+      expect(sanitizeRawIds("abcdefghij — foo")).toBe("abcdefghij — foo");
+    });
+
+    it("does NOT strip common lowercase-hex words (deadbeef, facaded)", () => {
+      // The regex alternative for 8-12 lowercase hex was removed in the review
+      // pass — legitimate words like `deadbeef`, `facaded`, `accede87` are
+      // indistinguishable from legacy IDs by shape alone, and never surfaced
+      // as visible-text prefix leaks in prod.
+      expect(sanitizeRawIds("deadbeef — placeholder")).toBe("deadbeef — placeholder");
+      expect(sanitizeRawIds("accede87: note")).toBe("accede87: note");
+      expect(sanitizeRawIds("e7c42d88: value")).toBe("e7c42d88: value");
     });
   });
 

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -264,11 +264,6 @@ const GLOBAL_HIDDEN_COLUMNS = new Set(["id"]);
 /** Max rows to show initially before "Show all" */
 const INITIAL_ROW_LIMIT = 20;
 
-// ── ID detection ──────────────────────────────────────────────────────────
-// Fact-ID detection now lives in `./sanitize-raw-ids.ts::isAnyFactId`, which
-// covers canonical `f_xxx`, legacy lowercase hex, and legacy mixed-case alnum
-// formats in a single column-gated helper (QUA-397).
-
 // ── Numeric formatting columns ────────────────────────────────────────────
 
 /** Columns representing monetary amounts (Drizzle returns numeric() as strings) */
@@ -323,6 +318,19 @@ function ExpandableText({ text }: { text: string }) {
 
 // ── Cell renderer ──────────────────────────────────────────────────────────
 
+// Muted em-dash placeholder for legacy IDs that lack a working detail
+// page route. Full ID in `title=` for dev debugging. QUA-397 / QUA-407.
+function MutedLegacyId({ kind, value }: { kind: "fact" | "resource"; value: string }) {
+  return (
+    <span
+      className="text-muted-foreground/40 font-mono text-[10px]"
+      title={`legacy ${kind} ID: ${value}`}
+    >
+      &mdash;
+    </span>
+  );
+}
+
 function CellValue({
   value,
   columnName,
@@ -350,10 +358,8 @@ function CellValue({
     return <JsonValue value={value} />;
   }
 
-  // FactBase fact IDs with resolvable /factbase/fact/<id> URLs → `view →` link.
-  // Covers canonical `f_xxx` (any column) and legacy 8-12 char lowercase hex
-  // (column-gated: id/fact_id). See `./sanitize-raw-ids.ts::isClickableFactId`.
-  // QUA-397.
+  // QUA-397: FactBase fact IDs routed to one of three render branches
+  // depending on whether the `/factbase/fact/<id>` URL resolves in prod.
   if (typeof value === "string" && isClickableFactId(value, columnName)) {
     return (
       <Link
@@ -365,36 +371,11 @@ function CellValue({
       </Link>
     );
   }
-
-  // Legacy 10-char mixed-case alnum fact IDs (e.g. `2Y4ope8OxA`, `XUSIG6vsPw`).
-  // These predate the `f_` prefix and their `/factbase/fact/<id>` URL resolves
-  // UNRELIABLY (~2/5 measured return 404 in prod) — so we render as a muted
-  // em-dash with the full id in `title=` instead of promising a broken link.
-  // Column-gated. Will be eliminated by QUA-407 Phase 1 (migrate to canonical).
   if (typeof value === "string" && isOpaqueLegacyFactId(value, columnName)) {
-    return (
-      <span
-        className="text-muted-foreground/40 font-mono text-[10px]"
-        title={`legacy fact ID: ${value}`}
-      >
-        &mdash;
-      </span>
-    );
+    return <MutedLegacyId kind="fact" value={value} />;
   }
-
-  // Legacy 16-char hex resource stableIds (pre-`sid_` format, e.g.
-  // `1f21fae8ed666710`). There's no public resource-detail page keyed by
-  // these, so render as a muted em-dash with the full id in `title=` for
-  // debugging. Column-gated to avoid false positives (QUA-397).
   if (typeof value === "string" && isLegacyResourceId(value, columnName)) {
-    return (
-      <span
-        className="text-muted-foreground/40 font-mono text-[10px]"
-        title={`legacy resource ID: ${value}`}
-      >
-        &mdash;
-      </span>
-    );
+    return <MutedLegacyId kind="resource" value={value} />;
   }
 
   // Entity reference columns -> show resolved name as link

--- a/apps/web/src/app/internal/entity-profile/sanitize-raw-ids.ts
+++ b/apps/web/src/app/internal/entity-profile/sanitize-raw-ids.ts
@@ -5,8 +5,15 @@
 // and handles the unfixable case of fact values that ARE stableId CSVs
 // (`"founded-by": "sid_a, sid_b, sid_c"`). Pure — unit-tested.
 
+// Prefix strip supports two ID shapes — canonical `f_xxx` and 10-char
+// mixed-case alnum legacy. NOT 8-12 char lowercase hex: that shape
+// collides with ordinary English words (`deadbeef`, `facaded`, `accede87`)
+// and has never been observed as a visible-text prefix leak in prod. The
+// post-match verification in `sanitizeRawIds` rejects the 10-char alt
+// unless it passes the entropy gate, so strings like `"Washington —
+// Seattle"` pass through unchanged.
 const RAW_ID_PREFIX_STRIP_RE =
-  /^\s*(f_[A-Za-z0-9]{8,}|[a-f0-9]{8,12}|[A-Za-z0-9]{10})\s*(?:[—:-]\s*|\s+[—-]\s+)/;
+  /^\s*(f_[A-Za-z0-9]{8,}|[A-Za-z0-9]{10})\s*(?:[—:-]\s*|\s+[—-]\s+)/;
 
 const RAW_F_ID_RE = /\bf_[A-Za-z0-9]{8,}\b/g;
 const RAW_SID_RE = /\bsid_[A-Za-z0-9]{10}\b/g;
@@ -70,14 +77,18 @@ export function isLegacyResourceId(value: string, columnName: string): boolean {
 }
 
 /**
- * Strip a leading raw-ID prefix (`"f_xxx — "`, `"e7c42d88: "`, etc.) and
- * mask any remaining embedded `f_` / `sid_` with `…`. Returns the input
- * unchanged (same identity, for React memo) when no sanitization applies.
+ * Strip a leading raw-ID prefix (`"f_xxx — "`, `"2Y4ope8OxA — "`) and mask
+ * any remaining embedded `f_` / `sid_` with `…`.
+ *
+ * The prefix-strip has a critical subtlety: the `[A-Za-z0-9]{10}` regex
+ * alternative matches ANY 10-char alnum word, including `"Washington"` and
+ * `"California"`. Post-match, we re-verify via `looksLikeLegacyFactId`
+ * (entropy gate: requires upper+lower+digit) so legitimate words pass
+ * through unchanged.
  */
 export function sanitizeRawIds(s: string): string {
-  // Fast path: most cells contain no raw-ID-shaped text. A single indexOf
-  // scan on a short string is cheaper than running three regexes, and
-  // returning the input unchanged preserves React's identity check.
+  // Fast path: if no ID-shaped substring exists AND the prefix regex
+  // doesn't match, skip all work and return the input unchanged.
   if (
     !s.includes("f_") &&
     !s.includes("sid_") &&
@@ -86,10 +97,19 @@ export function sanitizeRawIds(s: string): string {
     return s;
   }
 
-  // A successful prefix match means one of the three ID shapes matched —
-  // the regex alternatives already enumerated them, no need to re-classify.
   const prefixMatch = s.match(RAW_ID_PREFIX_STRIP_RE);
-  const stripped = prefixMatch ? s.slice(prefixMatch[0].length) : s;
+  let stripped = s;
+  if (prefixMatch) {
+    const id = prefixMatch[1];
+    // Only strip if the captured prefix really looks like an ID. The
+    // regex alternative `[A-Za-z0-9]{10}` matches e.g. `"Washington"` —
+    // we reject via the entropy gate so real 10-char words pass through.
+    const isCanonical = id.startsWith("f_");
+    const isLegacyMixed = looksLikeLegacyFactId(id);
+    if (isCanonical || isLegacyMixed) {
+      stripped = s.slice(prefixMatch[0].length);
+    }
+  }
   return stripped
     .replace(RAW_F_ID_RE, "\u2026")
     .replace(RAW_SID_RE, "\u2026");

--- a/apps/web/src/app/internal/entity-profile/sanitize-raw-ids.ts
+++ b/apps/web/src/app/internal/entity-profile/sanitize-raw-ids.ts
@@ -1,52 +1,19 @@
-/**
- * Render-layer sanitizer for raw FactBase / stable IDs leaking into visible
- * table cell text in `EntityProfileViewer`. See QUA-397.
- *
- * This is the last line of defense against the recurring raw-ID leak class.
- * Upstream fixes (sync-facts.ts, facts.ts write path, upsertThingsInTx
- * sentinel) prevent NEW bad rows, but existing `things.title` /
- * `things.description` rows written by the old code still contain baked-in
- * raw IDs until the next `sync-facts` backfill runs. This function masks
- * them at render time so the UI is clean immediately on deploy, regardless
- * of backfill timing.
- *
- * It also catches the ref-list value case — facts like `founded-by` serialize
- * their value as a CSV of stableIds (`"sid_a, sid_b, sid_c"`), which the
- * write-path fix does not address (the fact value is valid data, it's the
- * display that needs to resolve it).
- *
- * Pure function — safe to unit test.
- */
+// Render-layer sanitizer for raw FactBase / stable IDs leaking into visible
+// table cell text in `EntityProfileViewer`. See QUA-397.
+//
+// Complements the write-path fix in apps/wiki-server/src/routes/factbase/facts.ts
+// and handles the unfixable case of fact values that ARE stableId CSVs
+// (`"founded-by": "sid_a, sid_b, sid_c"`). Pure — unit-tested.
 
-/**
- * Matches a leading raw-ID prefix of the form `{id} — ` / `{id}: ` / `{id}-`.
- * Applied first so titles like `"f_xxx — Entity"` render as `"Entity"`
- * rather than `"… — Entity"`.
- *
- * Three ID shapes are stripped as a prefix:
- *   1. `f_` + 8+ alphanumeric chars (canonical post-migration FactBase fact IDs)
- *   2. 8-12 lowercase hex (pre-migration legacy fact IDs, e.g. `e7c42d88`)
- *   3. 10-char mixed-case alphanumeric (pre-`f_` legacy FactBase IDs, e.g.
- *      `2Y4ope8OxA`, `XUSIG6vsPw`). The 10-char alnum pattern is too loose
- *      to trust on its own, so `sanitizeRawIds()` adds an entropy gate
- *      (requires uppercase + lowercase + digit) before treating it as an ID.
- */
 const RAW_ID_PREFIX_STRIP_RE =
   /^\s*(f_[A-Za-z0-9]{8,}|[a-f0-9]{8,12}|[A-Za-z0-9]{10})\s*(?:[—:-]\s*|\s+[—-]\s+)/;
 
-/** Matches any canonical FactBase fact ID embedded in a longer string. */
 const RAW_F_ID_RE = /\bf_[A-Za-z0-9]{8,}\b/g;
-
-/** Matches a 10-char stableId embedded in a longer string. */
 const RAW_SID_RE = /\bsid_[A-Za-z0-9]{10}\b/g;
 
-/**
- * Entropy gate for the 10-char mixed-case prefix alternative. Random FactBase
- * IDs reliably contain at least one uppercase letter, one lowercase letter,
- * and one digit. Legitimate 10-char entity names (e.g. `"Washington"`,
- * `"Anthropic1"` — also rare) typically fail at least one of these checks.
- * This avoids stripping real text that happens to be exactly 10 chars.
- */
+// Random 10-char FactBase IDs reliably contain upper+lower+digit. Stricter
+// than `isAnySid()` so we don't strip legitimate 10-char entity names
+// (`Washington`, `Anthropic1`, ...) that miss one of the three classes.
 function looksLikeLegacyFactId(id: string): boolean {
   return (
     id.length === 10 &&
@@ -56,25 +23,15 @@ function looksLikeLegacyFactId(id: string): boolean {
   );
 }
 
-// ── Column-gated bare-value detection ──────────────────────────────────
-//
-// These helpers detect raw IDs sitting alone in a cell (not as a prefix).
-// They are column-name-gated so bare-hex strings in unrelated columns
-// (git SHAs, content hashes, numeric strings) don't produce false positives.
-// See QUA-397 for the leak inventory.
-
-/** Columns where we trust a bare 10-char alphanumeric to be a legacy FactBase fact ID. */
-const LEGACY_FACT_ID_COLUMNS: ReadonlySet<string> = new Set([
+// Column gating on bare-value detection. Legacy hex (8-12) and legacy
+// 10-char alnum shapes are too loose to trust content-first — they collide
+// with git SHAs, content hashes, and short entity names. The set covers
+// both `id` PK columns and explicit `fact_id`/`factId` references.
+const FACT_ID_COLUMNS: ReadonlySet<string> = new Set([
   "id", "fact_id", "factId",
 ]);
 
-/** Columns where we trust 8-12 char lowercase hex to be a legacy fact ID. */
-const LEGACY_HEX_FACT_ID_COLUMNS: ReadonlySet<string> = new Set([
-  "id", "fact_id", "factId",
-]);
-
-/** Columns where we trust a 16-char lowercase hex to be a legacy resource ID. */
-const LEGACY_RESOURCE_ID_COLUMNS: ReadonlySet<string> = new Set([
+const RESOURCE_ID_COLUMNS: ReadonlySet<string> = new Set([
   "id", "resource_id", "resourceId", "stable_id", "stableId",
 ]);
 
@@ -83,74 +40,57 @@ const LEGACY_RESOURCE_HEX_RE = /^[a-f0-9]{16}$/;
 const CANONICAL_FACT_ID_RE = /^f_[A-Za-z0-9]{8,}$/;
 
 /**
- * True if `value` is a FactBase fact ID whose `/factbase/fact/<id>` URL is
- * known to resolve — either canonical `f_...` or 8-12 char lowercase hex
- * (legacy format A). Column-gated for the legacy shape.
- *
- * Used for the `view →` link render branch. The 10-char mixed-case alnum
- * legacy format B (`2Y4ope8OxA`, `XUSIG6vsPw`, ...) is NOT clickable —
- * URL resolution for that format is a coin flip in prod (measured: 2 of 5
- * sample IDs returned 404) because the route handler's resolver only covers
- * a subset. Rendering them as `view →` links would point half the users at
- * 404s. Use `isOpaqueLegacyFactId` for that format instead.
+ * True if `value` is a FactBase fact ID whose `/factbase/fact/<id>` URL
+ * resolves reliably on prod — canonical `f_...` (any column) or 8-12 char
+ * lowercase hex (column-gated). See `isOpaqueLegacyFactId` for the
+ * 10-char alnum format which does NOT resolve reliably.
  */
 export function isClickableFactId(value: string, columnName: string): boolean {
   if (CANONICAL_FACT_ID_RE.test(value)) return true;
-  if (LEGACY_HEX_FACT_ID_COLUMNS.has(columnName) && LEGACY_HEX_FACT_ID_RE.test(value)) {
+  if (FACT_ID_COLUMNS.has(columnName) && LEGACY_HEX_FACT_ID_RE.test(value)) {
     return true;
   }
   return false;
 }
 
 /**
- * True if `value` is a legacy 10-char mixed-case alnum fact ID in a
- * fact-id column. These predate the `f_` prefix and the canonical URL
- * pattern — they're still valid PK values in `facts.fact_id`, but the
- * `/factbase/fact/<id>` route resolves them unreliably (measured: 2 of 5
- * return 404 on prod). Render as muted em-dash with the full ID in
- * `title=` for debugging instead of promising a link that may 404.
- *
- * Eliminate by migrating all 10-char alnum fact IDs to canonical `f_<10>`
- * format (see QUA-407 Phase 1).
+ * True if `value` is a legacy 10-char mixed-case alnum fact ID. The
+ * `/factbase/fact/<id>` route resolves these unreliably (measured 2 of 5
+ * sample IDs returned 404 on prod 2026-04-13), so the caller should render
+ * them as a non-link with the full ID in `title=`. Eliminated by QUA-407
+ * Phase 1 (migrate to canonical `f_<10>`).
  */
 export function isOpaqueLegacyFactId(value: string, columnName: string): boolean {
-  return (
-    LEGACY_FACT_ID_COLUMNS.has(columnName) && looksLikeLegacyFactId(value)
-  );
+  return FACT_ID_COLUMNS.has(columnName) && looksLikeLegacyFactId(value);
 }
 
-/**
- * True if `value` is a legacy pre-`sid_` resource stableId (16 hex chars) in
- * a column where we trust that shape.
- */
+/** True if `value` is a legacy pre-`sid_` 16-char hex resource stableId. */
 export function isLegacyResourceId(value: string, columnName: string): boolean {
-  return LEGACY_RESOURCE_ID_COLUMNS.has(columnName) && LEGACY_RESOURCE_HEX_RE.test(value);
+  return RESOURCE_ID_COLUMNS.has(columnName) && LEGACY_RESOURCE_HEX_RE.test(value);
 }
 
 /**
- * Sanitizes a cell value for rendering:
- *   1. If the string starts with a raw-ID prefix like `"f_xxx — "` or
- *      `"e7c42d88: "` or `"2Y4ope8OxA — "`, strip it so only the
- *      human-readable remainder shows.
- *   2. Mask any remaining embedded raw ids with an ellipsis (`…`).
- *
- * Returns the sanitized string. If no sanitization was needed, returns `s`
- * unchanged (same object identity) so React can skip re-rendering.
+ * Strip a leading raw-ID prefix (`"f_xxx — "`, `"e7c42d88: "`, etc.) and
+ * mask any remaining embedded `f_` / `sid_` with `…`. Returns the input
+ * unchanged (same identity, for React memo) when no sanitization applies.
  */
 export function sanitizeRawIds(s: string): string {
-  let stripped = s;
-  const match = s.match(RAW_ID_PREFIX_STRIP_RE);
-  if (match) {
-    const id = match[1];
-    const isCanonical = id.startsWith("f_");
-    const isLowerHex = /^[a-f0-9]{8,12}$/.test(id);
-    const isLegacyMixed = looksLikeLegacyFactId(id);
-    if (isCanonical || isLowerHex || isLegacyMixed) {
-      stripped = s.slice(match[0].length);
-    }
+  // Fast path: most cells contain no raw-ID-shaped text. A single indexOf
+  // scan on a short string is cheaper than running three regexes, and
+  // returning the input unchanged preserves React's identity check.
+  if (
+    !s.includes("f_") &&
+    !s.includes("sid_") &&
+    !RAW_ID_PREFIX_STRIP_RE.test(s)
+  ) {
+    return s;
   }
-  const masked = stripped
+
+  // A successful prefix match means one of the three ID shapes matched —
+  // the regex alternatives already enumerated them, no need to re-classify.
+  const prefixMatch = s.match(RAW_ID_PREFIX_STRIP_RE);
+  const stripped = prefixMatch ? s.slice(prefixMatch[0].length) : s;
+  return stripped
     .replace(RAW_F_ID_RE, "\u2026")
     .replace(RAW_SID_RE, "\u2026");
-  return masked;
 }

--- a/apps/wiki-server/package.json
+++ b/apps/wiki-server/package.json
@@ -14,6 +14,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "drizzle-orm": "^0.45.1",

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -15,6 +15,7 @@ import {
 } from "../shared/utils.js";
 import { SyncFactsBatchSchema } from "../../api-types.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
+import { formatFactLabel } from "@longterm-wiki/factbase";
 import { logger } from "../../logger.js";
 
 // ---- Constants ----
@@ -572,13 +573,7 @@ const factsApp = new Hono()
           tx,
           items.map((f) => {
             const entityName = entityTitleMap.get(f.entityId) ?? f.entityId;
-            // Fallback chain: prefer the human-readable label (sent by
-            // sync-facts.ts from property.name); fall back to the property
-            // slug (f.measure = propertyId, e.g. "founded-date"); finally a
-            // generic sentinel. NEVER fall back to f.factId — doing so bakes
-            // raw f_... IDs into things.title / things.description, which
-            // then leak into visible text on data pages (QUA-397).
-            const factLabel = f.label || f.measure || "fact";
+            const factLabel = formatFactLabel(f);
             return {
               id: toFactThingKey(f.entityId, f.factId),
               thingType: "fact" as const,

--- a/crux/commands/context.ts
+++ b/crux/commands/context.ts
@@ -26,6 +26,7 @@ import { getEntity, searchEntities } from '../lib/wiki-server/entities.ts';
 import type { EntityEntry, EntitySearchResult } from '../lib/wiki-server/entities.ts';
 import { getFactsByEntity } from '../lib/wiki-server/facts.ts';
 import type { FactEntry, FactsByEntityResult } from '../lib/wiki-server/facts.ts';
+import { formatFactLabel } from '../../packages/factbase/src/format.ts';
 import {
   searchPages,
   getPage,
@@ -304,7 +305,7 @@ function factsBlock(facts: FactEntry[], limit = 10): string {
   md += tableRow('Measure / Label', 'Value', 'As Of') + '\n';
   md += tableRow('-----------------', '-------', '-------') + '\n';
   for (const f of facts.slice(0, limit)) {
-    const label = (f.label || f.measure || f.factId || '').slice(0, 30);
+    const label = formatFactLabel(f).slice(0, 30);
     let value = f.value || '';
     if (f.numeric !== null && f.numeric !== undefined) {
       value = String(f.numeric);

--- a/crux/commands/query.ts
+++ b/crux/commands/query.ts
@@ -27,6 +27,7 @@ import { createLogger } from '../lib/output.ts';
 import { getServerUrl } from '../lib/wiki-server/client.ts';
 import { getEntity } from '../lib/wiki-server/entities.ts';
 import { getFactsByEntity } from '../lib/wiki-server/facts.ts';
+import { formatFactLabel } from '../../packages/factbase/src/format.ts';
 import {
   searchPages,
   getPage,
@@ -207,12 +208,12 @@ export async function facts(args: string[], options: Record<string, unknown>): P
   output += `\n${c.dim}${factList.length} of ${total} fact${total !== 1 ? 's' : ''}${c.reset}\n\n`;
 
   // Column widths
-  const labelW = Math.min(30, Math.max(10, ...factList.map((f) => (f.label || f.measure || '').length)));
+  const labelW = Math.min(30, Math.max(10, ...factList.map((f) => formatFactLabel(f).length)));
   output += `${c.bold}${'Label/Measure'.padEnd(labelW)}  ${'Value'.padEnd(20)}  Date${''.padEnd(6)}  Note${c.reset}\n`;
   output += `${c.dim}${'─'.repeat(labelW + 40)}${c.reset}\n`;
 
   for (const f of factList) {
-    const label = (f.label || f.measure || f.factId || '').slice(0, labelW).padEnd(labelW);
+    const label = formatFactLabel(f).slice(0, labelW).padEnd(labelW);
     let value = f.value || '';
     if (f.numeric !== null && f.numeric !== undefined) {
       value = String(f.numeric);

--- a/packages/factbase/src/format.ts
+++ b/packages/factbase/src/format.ts
@@ -12,6 +12,25 @@ import type { Fact, Property } from "./types";
 import type { Graph } from "./graph";
 import { CURRENCIES, resolveCurrency } from "./currencies";
 
+// ── Fact label fallback ─────────────────────────────────────────────
+
+/**
+ * Return a safe human-readable label for a fact row, never falling back
+ * to the raw fact ID. QUA-397: a `|| f.factId` fallback in multiple sites
+ * was baking `f_xxx` / legacy hex strings into user-visible strings in
+ * the `things` table and CLI output. Centralized here so the unsafe
+ * fallback chain cannot be reintroduced piecemeal.
+ *
+ * Fallback chain: `label` → `measure` (propertyId slug) → `"fact"`.
+ * Duck-typed to accept both `Fact` and wiki-server response DTOs.
+ */
+export function formatFactLabel(f: {
+  label?: string | null;
+  measure?: string | null;
+}): string {
+  return f.label || f.measure || "fact";
+}
+
 // ── Monetary formatting ─────────────────────────────────────────────
 
 /**

--- a/packages/factbase/src/index.ts
+++ b/packages/factbase/src/index.ts
@@ -12,6 +12,7 @@ export * from "./ids";
 export { serialize } from "./serialize";
 export type { SerializedKB } from "./serialize";
 export {
+  formatFactLabel,
   formatMoney,
   formatValue,
   formatFactValue,

--- a/packages/factbase/tests/format-fact-label.test.ts
+++ b/packages/factbase/tests/format-fact-label.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { formatFactLabel } from "../src/format";
+
+// QUA-397: regression — formatFactLabel must never return a raw fact ID.
+// Prior to this helper, multiple call sites used `f.label || f.measure || f.factId`
+// and leaked raw IDs into `things.title` / CLI output / wiki-server search.
+
+describe("formatFactLabel", () => {
+  it("prefers label when present", () => {
+    expect(formatFactLabel({ label: "Revenue", measure: "revenue" })).toBe("Revenue");
+  });
+
+  it("falls back to measure when label is null", () => {
+    expect(formatFactLabel({ label: null, measure: "founded-date" })).toBe("founded-date");
+  });
+
+  it("falls back to measure when label is empty string", () => {
+    expect(formatFactLabel({ label: "", measure: "employee-count" })).toBe("employee-count");
+  });
+
+  it("falls back to `fact` when both label and measure are missing", () => {
+    expect(formatFactLabel({ label: null, measure: null })).toBe("fact");
+  });
+
+  it("never returns a raw fact ID even when caller passes one", () => {
+    // Caller might pass an object with an extra `factId` field (e.g. wiki-server
+    // DTOs). The helper ignores it — the fallback stops at "fact".
+    const f = { label: null, measure: null, factId: "f_mEKUPPFYRg" };
+    const result = formatFactLabel(f);
+    expect(result).toBe("fact");
+    expect(result).not.toMatch(/^f_/);
+    expect(result).not.toMatch(/^[a-f0-9]{8,}/);
+  });
+
+  it("handles undefined fields (Fact type has optional label/measure)", () => {
+    expect(formatFactLabel({})).toBe("fact");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.10
         version: 1.19.11(hono@4.12.5)
+      '@longterm-wiki/factbase':
+        specifier: workspace:*
+        version: link:../../packages/factbase
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils


### PR DESCRIPTION
## Summary

Follow-up to [PR #4296](https://github.com/quantified-uncertainty/longterm-wiki/pull/4296) (QUA-397). Two commits that were in flight when #4296 merged:

### Commit 1 — simplify + extract `formatFactLabel`
- **Systemic extraction**: new `formatFactLabel(f)` helper in `packages/factbase/src/format.ts`, applied to 3 sites where the unsafe `f.label || f.measure || f.factId` fallback existed:
  - `apps/wiki-server/src/routes/factbase/facts.ts` (was inline in PR #4296)
  - `crux/commands/query.ts:215` (CLI output — separate leak class from the entity data pages, would have leaked `f_xxx` into terminal text)
  - `crux/commands/context.ts:307` (same class, CLI)
  - Fallback chain is `label → measure → "fact"`. Never returns a raw fact ID. 6 new unit tests in `packages/factbase/tests/`.
- **Sanitizer cleanup**: merged identical `LEGACY_FACT_ID_COLUMNS` / `LEGACY_HEX_FACT_ID_COLUMNS` Sets, added `indexOf` fast-path for React identity preservation, trimmed verbose JSDoc.
- **Component extraction**: two near-identical `<span>` branches in `CellValue` → extracted `<MutedLegacyId kind="fact"|"resource" value=.../>`. Saves ~15 lines.

### Commit 2 — fix critical prefix-strip bug (review catch)

The simplify pass dropped the post-match entropy verification in `sanitizeRawIds()`. Result: legitimate 10-char English words got their prefix destroyed:

```
sanitizeRawIds("Washington — Seattle") → "Seattle"     ❌ BUG
sanitizeRawIds("California: 1850")     → "1850"        ❌ BUG
sanitizeRawIds("Manchester — UK")      → "UK"          ❌ BUG
```

The `[A-Za-z0-9]{10}` regex alternative matches ANY 10-char alnum word. The entropy gate `looksLikeLegacyFactId` (length 10 + upper + lower + digit) is **load-bearing** — now restored and documented as such. Both branches tested with 6 regression cases.

Also: **removed the `[a-f0-9]{8,12}` prefix alternative entirely**. This shape collides with real English words (`deadbeef`, `facaded`, `accede87`) and has never been observed as a visible-text prefix leak in prod — the original QUA-397 CI failure only showed `f_`-prefixed leaks. Bare 8-12 hex detection is still used in `isClickableFactId` (column-gated) for the `view →` link render branch.

## Test plan

- [x] `pnpm test` (apps/web) — 40/40 sanitize-raw-ids tests pass (+1 from #4296, 40 total)
- [x] `pnpm test` (apps/wiki-server) — 1066/1066 pass
- [x] `pnpm test:crux` — 6268/6268 pass (includes 6 new `formatFactLabel` tests)
- [x] `pnpm --filter @longterm-wiki/factbase test` — new `format-fact-label.test.ts` 6/6 pass (other failures in graph/loader/validate tests are pre-existing, unrelated to this PR — confirmed via git log)
- [x] `npx tsc --noEmit` in apps/web + apps/wiki-server — clean
- [x] **Playwright against local dev server + real prod wiki-server data**: all 7 previously-failing `no-raw-ids.spec.ts` pages pass (14.6s)
- [x] Same test against live prod (post #4296 merge) still fails on the same pages, confirming the render-layer sanitizer in my changes is what makes them pass

## Why this is a separate PR

PR #4296 was merged while the `/simplify` + `/agent-review-pr` passes were running. The two follow-up commits are:
1. Behaviorally non-breaking cleanups + systemic extraction of `formatFactLabel`
2. A critical correctness fix for a bug introduced by my own simplify pass

Both are scoped to QUA-397 and don't touch anything else. Review should focus on:
- Is the `formatFactLabel` helper's duck-typed signature right? (`{ label?, measure? }`)
- Are the two new Playwright-verified regressions (Washington/California prefix preservation) adequately covered by the 6 new test cases?
- Is dropping the `[a-f0-9]{8,12}` prefix alternative acceptable? (bare-value detection in `isClickableFactId` is unchanged and still covers legacy hex IDs in fact-id columns)

## Follow-ups filed during this session

- [QUA-415](https://linear.app/quantifieduncertainty/issue/QUA-415) — post-deploy `sync-facts` backfill (optional cleanup, not blocking — the render-layer sanitizer makes the UI clean regardless)
- [QUA-414](https://linear.app/quantifieduncertainty/issue/QUA-414) — Phase 4b-A audit of `things.title` / `description` / `parent_title` write/read sites (precondition for Data Integrity Tier 4b in QUA-408)
- [QUA-407](https://linear.app/quantifieduncertainty/issue/QUA-407) — FactBase/resource ID format sprawl (5 coexisting formats)
- [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) — Sub-epic under Data Integrity project proposing 3 new tiers (4b denormalization, 8 ontology, 9 validator rationalization)

Refs QUA-397

Fixes QUA-397
