### PR TITLE
fix(entity): drop dead /sourcing/entity/ href on profile shell (QUA-418)

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -169,3 +169,20 @@ test.describe("Render audit — critical data tables", () => {
     expect(text).toMatch(/\$\d+(?:\.\d+)?[BMT]/);
   });
 });
+
+test.describe("Render audit — no dead entity sourcing links (QUA-418)", () => {
+  // Entity profile pages render a SourcingDot in the header. It must NOT
+  // link to /sourcing/entity/<id> — that path is not a real record_type
+  // and always 404s. Regression test for QUA-418.
+  for (const url of [
+    "/organizations/anthropic",
+    "/people/dario-amodei",
+    "/ai-models/claude-opus-4-5",
+  ]) {
+    test(`header has no /sourcing/entity/ href on ${url}`, async ({ page }) => {
+      await loadPage(page, url);
+      const hrefs = await page.locator('a[href^="/sourcing/entity/"]').count();
+      expect(hrefs, `${url} has ${hrefs} dead /sourcing/entity/ link(s)`).toBe(0);
+    });
+  }
+});

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -7,7 +7,6 @@ import {
 import { CoveragePopover } from "@/components/coverage/CoveragePopover";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 /**
  * `EntityProfileShell` is the canonical layout for every entity profile page
@@ -39,8 +38,12 @@ export interface EntityProfileShellProps {
   breadcrumbs: Array<{ label: string; href?: string }>;
 
   // ── Header ──────────────────────────────────────────────────────────
-  /** Entity identifier passed to SourcingDot (`getSourcingHref("entity", entityId)`). */
-  entityId: string;
+  /**
+   * @deprecated QUA-418 — no longer used. Entity-level rollup pages are
+   * deferred to QUA-408 Phase 2. Kept in the interface so callers don't
+   * need to churn; safe to remove when a caller cleanup ships.
+   */
+  entityId?: string;
   /** Optional avatar node (e.g. initials circle). Omitted when null/undefined. */
   avatar?: React.ReactNode;
   /** Main entity title. */
@@ -92,7 +95,6 @@ export interface EntityProfileShellProps {
 
 export function EntityProfileShell({
   breadcrumbs,
-  entityId,
   avatar,
   title,
   aliases,
@@ -142,7 +144,9 @@ export function EntityProfileShell({
                   status={recordVerdictToStatus(verdict ?? null)}
                   originalVerdict={verdict ?? null}
                   size="md"
-                  href={getSourcingHref("entity", entityId)}
+                  // QUA-418: no href — "entity" is not a real record_type in
+                  // VALID_RECORD_TYPES, so /sourcing/entity/<id> always 404s.
+                  // Entity-level rollup pages are deferred to QUA-408 Phase 2.
                 />
               )}
             </div>


### PR DESCRIPTION
## Summary

Fixes QUA-418. The `SourcingDot` rendered in the header of every entity profile page (organizations, people, AI models, legislation, benchmarks, projects) linked to `/sourcing/entity/<id>`, but `"entity"` is not in `VALID_RECORD_TYPES` — that URL always 404s. The dot's displayed status was still correct (it's a rollup from `fetchEntitySourcingSummary`); only the href target was dead.

## Fix

Drop the `href` prop from the `SourcingDot` render in `EntityProfileShell.tsx` and leave a comment pointing at QUA-408 Phase 2 (where the derived entity-rollup page will naturally live). Remove the now-unused `getSourcingHref` import. Mark the `entityId` prop `@deprecated` + optional so existing callers don't have to churn.

## Regression check

Added a Playwright test in `render-audit.spec.ts` asserting that three representative profile pages (`/organizations/anthropic`, `/people/dario-amodei`, `/ai-models/claude-opus-4-5`) have **zero** `<a href^="/sourcing/entity/">` elements.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] e2e: `npx playwright test e2e/render-audit.spec.ts -g "no dead entity sourcing"` (to run against prod once deployed)

## Refs

- QUA-211 (Category A pass that missed this file)
- QUA-408 Phase 2 (future home for derived entity rollups)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed dead sourcing links from entity profile pages.

* **Tests**
  * Added validation test to detect and prevent broken sourcing links on entity profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->