### PR TITLE
fix(sourcing): empty state for unchecked records on detail page (QUA-419)

### DIFF
--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
@@ -20,6 +20,7 @@ import { getEntityHref } from "@data/entity-nav";
 import { getKBFactById, getKBEntity, getKBProperty } from "@/data/factbase";
 import { inferDataSource } from "@/app/grants/grants-data-source";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
+import { UncheckedSourcingState } from "@/components/sourcing/UncheckedSourcingState";
 
 import { canonicalizeSourcingRecordType } from "./canonicalize-record-type";
 
@@ -292,6 +293,21 @@ export default async function SourcingDetailPage({ params }: PageProps) {
       detailResult.error.type === "server-error" &&
       detailResult.error.status === 404
     ) {
+      // QUA-419: No verdicts yet is the common case — render an empty
+      // state when the record itself exists in the source table. Only
+      // notFound() when the record is genuinely missing.
+      if (recordResult.ok) {
+        const rawName = namesResult.ok ? namesResult.data.names[recordId] : null;
+        const stripped = rawName?.startsWith("new:") ? rawName.slice(4).trim() : rawName;
+        return (
+          <UncheckedSourcingState
+            recordType={recordType}
+            recordId={recordId}
+            displayName={stripped ?? `${formatRecordType(recordType)} ${recordId}`}
+            recordHref={getRecordHref(recordType, recordId)}
+          />
+        );
+      }
       notFound();
     }
     return (

--- a/apps/web/src/components/sourcing/UncheckedSourcingState.test.tsx
+++ b/apps/web/src/components/sourcing/UncheckedSourcingState.test.tsx
@@ -1,0 +1,63 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UncheckedSourcingState } from "./UncheckedSourcingState";
+
+describe("UncheckedSourcingState", () => {
+  it("renders record name, type pill, and unchecked message", () => {
+    render(
+      <UncheckedSourcingState
+        recordType="wiki-page"
+        recordId="page:anthropic:overview"
+        displayName="Anthropic Overview"
+        recordHref="/wiki/anthropic"
+      />
+    );
+
+    expect(screen.getByText("Anthropic Overview")).toBeInTheDocument();
+    expect(screen.getByText("page:anthropic:overview")).toBeInTheDocument();
+    expect(screen.getByText(/Not yet source-checked/i)).toBeInTheDocument();
+    expect(screen.getByText(/has not been run through the source-check pipeline/i)).toBeInTheDocument();
+  });
+
+  it("renders View the record link when recordHref is provided", () => {
+    render(
+      <UncheckedSourcingState
+        recordType="grant"
+        recordId="g_abc123"
+        displayName="AI Safety Grant"
+        recordHref="/grants/g_abc123"
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /view the record/i });
+    expect(link).toHaveAttribute("href", "/grants/g_abc123");
+  });
+
+  it("omits View the record link when recordHref is null", () => {
+    render(
+      <UncheckedSourcingState
+        recordType="investment"
+        recordId="inv_xyz"
+        displayName="Test Investment"
+        recordHref={null}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: /view the record/i })).toBeNull();
+  });
+
+  it("always renders the All Source Checks back link", () => {
+    render(
+      <UncheckedSourcingState
+        recordType="grant"
+        recordId="g1"
+        displayName="x"
+        recordHref={null}
+      />
+    );
+
+    const back = screen.getByRole("link", { name: /all source checks/i });
+    expect(back).toHaveAttribute("href", "/sourcing");
+  });
+});

--- a/apps/web/src/components/sourcing/UncheckedSourcingState.tsx
+++ b/apps/web/src/components/sourcing/UncheckedSourcingState.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { ArrowLeft, CircleHelp } from "lucide-react";
+import { formatRecordType } from "@/app/sourcing/sourcing-shared";
+
+/**
+ * Rendered on `/sourcing/<type>/<id>` when the record exists in its source
+ * table but has no `source_check_verdicts` row yet (i.e. unchecked, the common
+ * case for wiki-pages, investments, policy-stakeholders, etc.).
+ *
+ * Previously such URLs returned a raw Next.js 404 (QUA-419).
+ */
+export function UncheckedSourcingState({
+  recordType,
+  recordId,
+  displayName,
+  recordHref,
+}: {
+  recordType: string;
+  recordId: string;
+  displayName: string;
+  recordHref: string | null;
+}) {
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-8">
+      <Link
+        href="/sourcing"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+      >
+        <ArrowLeft className="w-3.5 h-3.5" />
+        All Source Checks
+      </Link>
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground mb-2">
+        <span>{formatRecordType(recordType)}</span>
+      </div>
+      <h1 className="text-2xl font-bold mb-1">{displayName}</h1>
+      <p className="text-sm text-muted-foreground mb-6 font-mono">{recordId}</p>
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6">
+        <div className="flex items-start gap-3">
+          <CircleHelp className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+          <div className="space-y-2 text-sm">
+            <p className="font-medium">Not yet source-checked</p>
+            <p className="text-muted-foreground">
+              This record exists in the database but has not been run through
+              the source-check pipeline yet. Once checked, this page will show
+              per-source verdicts, evidence, and links to the sources used.
+            </p>
+            {recordHref && (
+              <p className="pt-1">
+                <Link
+                  href={recordHref}
+                  className="text-primary hover:underline"
+                >
+                  View the record →
+                </Link>
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes QUA-419. `/sourcing/<type>/<id>` returned a raw Next.js 404 whenever the record had no `source_check_verdicts` row yet — which is the common case for wiki-pages (0% checked), investments (~74% unchecked), policy-stakeholders (~64%), and several other table types. Every dot click on an unchecked record was a dead end.

The record itself still exists in its source table (`/api/record-lookup/` returns 200 with full record data). Reuse that data to render a proper "not yet source-checked" empty state instead of 404.

## Fix

- New `UncheckedSourcingState` component (server-render, ~60 lines) with back link / type pill / title scaffolding, an explainer, and a link to the actual record.
- Page flow in `sourcing/[recordType]/[recordId]/page.tsx` now branches on the detail 404: if `recordResult.ok`, render the empty state; otherwise fall through to `notFound()` so genuinely-missing URLs still 404.

## Tests

- Unit tests for `UncheckedSourcingState` covering the with-link, no-link, and back-link render variants (4 passing).
- `tsc --noEmit` clean.

## Test plan

- [x] `vitest run src/components/sourcing/UncheckedSourcingState.test.tsx` — 4 passing
- [ ] Manual: `/sourcing/wiki-page/<any-unchecked-id>` on prod after deploy → 200 with empty state
- [ ] Manual: `/sourcing/grant/garbage123xyz` → still 404