### PR TITLE
feat(dedup): PG-first dedup + slot/linear dashboard columns (QUA-440)

### DIFF
--- a/.claude/rules/github-issue-tracking.md
+++ b/.claude/rules/github-issue-tracking.md
@@ -23,16 +23,17 @@ For GitHub: posts a start comment and adds the `agent:working` label.
 
 ## Dedup check — `crux linear start` refuses competing claims
 
-Both `crux linear start QUA-NNN` and `crux sys agent-checklist init --linear=QUA-NNN` run a **dedup pre-check** before posting anything to Linear. The check looks for two signals that another session is already working on the issue:
+Both `crux linear start QUA-NNN` and `crux sys agent-checklist init --linear=QUA-NNN` run a **dedup pre-check** before posting anything to Linear. The check consults three signals in order, blocking on the first one that finds a cross-slot collision:
 
-1. **Recent start comments** — A `🤖 Claude Code starting work` comment posted in the last 24h from a **different slot** (e.g., a9 while you're on a5), not yet superseded by a `🤖 Claude Code finished work` comment.
-2. **Open PRs** — Any open PR in the wiki repo whose title or body mentions the Linear ID.
+1. **PG `agent_sessions` (authoritative)** — Queries the wiki-server for sessions matching `linear_id=QUA-NNN`, `status='active'`, and `updated_at > now() - 30min`. The 30-minute freshness window matches the `active_agents` stale-sweep cutoff, so a crashed session automatically releases its claim after ~30 minutes without explicit cleanup. This is the fastest path (~50ms) and the one new sessions should normally hit.
+2. **Linear start comments (fallback)** — When the wiki-server is unreachable or returns nothing, falls back to scraping `🤖 Claude Code starting work` comments posted in the last 24h from a **different slot**, not yet superseded by a `🤖 Claude Code finished work` comment. This covers cases where the session crashed before registering in PG.
+3. **Open PRs (paranoia layer)** — Any open PR in the wiki repo whose title or body mentions the Linear ID. Catches abandoned branches that PG has forgotten and Linear comments never captured.
 
-Either signal is sufficient to block. On a collision, both commands exit with **code 2** (distinct from 1 for other errors), print the detected claim(s)/PR(s), and refuse to write any local session state (checklist file, DB row, active-agent registration). This means a colliding `init` leaves **no artifact** — you can fix the race and re-run without cleanup.
+Any signal is sufficient to block. On a collision, both commands exit with **code 2** (distinct from 1 for other errors), print the detected claim(s)/PR(s), and refuse to write any local session state (checklist file, DB row, active-agent registration). This means a colliding `init` leaves **no artifact** — you can fix the race and re-run without cleanup.
 
-Re-running from the **same slot** is NOT a collision — it's treated as session resumption (init-crash recovery, etc.). The slot is derived from the `a<N>` ancestor of the current working directory.
+Re-running from the **same slot** is NOT a collision — it's treated as session resumption (init-crash recovery, etc.). The slot is derived from the `a<N>` ancestor of the current working directory and stored on `agent_sessions.slot_number`.
 
-Both checks are **fail-open**: if the Linear or GitHub API is unreachable, the dedup helper returns empty and the start proceeds. A transient API glitch should not wedge every session on the machine. The downside is a rare missed collision when both APIs are down simultaneously.
+All three sources are **fail-open**: if any API is unreachable, we skip that source and try the next. A transient wiki-server hiccup falls back to Linear; a Linear outage falls back to open-PR search. The downside is a rare missed collision when *all three* sources are down simultaneously — rarer than any single one failing.
 
 ### Bypassing with `--force`
 
@@ -46,9 +47,11 @@ pnpm crux sys agent-checklist init "..." --linear=QUA-NNN --force
 
 `--force` **skips** the dedup check entirely. The start comment is annotated with a visible `⚠ Claimed with --force` marker so the duplication is captured in Linear history.
 
-### Historical note — QUA-406
+### Historical note — QUA-406 / QUA-440
 
-The dedup check was added after a 2026-04-13 incident where two concurrent sessions on the same machine (slots a9 and a16) each shipped a competing PR for QUA-397. Prior to that, `crux linear start` unconditionally posted a start comment regardless of existing claims, and the session-tracking rule described below was aspirational. See QUA-406 for the full post-mortem and fix set.
+The dedup check was added after a 2026-04-13 incident (QUA-406) where two concurrent sessions on the same machine (slots a9 and a16) each shipped a competing PR for QUA-397. The initial fix (PR #4300) used Linear comments + open-PR search as the primary sources; QUA-440 followed up to add PG `agent_sessions` as the authoritative first-consulted source, giving us a heartbeat-based liveness signal that Linear comments alone can't provide.
+
+The Active Agents and Agent Sessions internal dashboards (at `/internal/agent-activity`) show the `slot_number` and `linear_id` columns for each row so coordinators can see at a glance who's working on what.
 
 ## At Session End (when shipping)
 

--- a/apps/web/src/app/internal/agent-activity/active-agents-content.tsx
+++ b/apps/web/src/app/internal/agent-activity/active-agents-content.tsx
@@ -15,9 +15,7 @@ export interface ActiveAgentRow {
   status: string;
   currentStep: string | null;
   issueNumber: number | null;
-  // QUA-440: linear_id and slot_number live on agent_sessions; the wiki-server
-  // joins them onto each active agent by branch so the dashboard can show
-  // them without a second fetch.
+  // Joined from agent_sessions by branch (QUA-440).
   linearId: string | null;
   slotNumber: number | null;
   prNumber: number | null;

--- a/apps/web/src/app/internal/agent-activity/active-agents-content.tsx
+++ b/apps/web/src/app/internal/agent-activity/active-agents-content.tsx
@@ -15,6 +15,11 @@ export interface ActiveAgentRow {
   status: string;
   currentStep: string | null;
   issueNumber: number | null;
+  // QUA-440: linear_id and slot_number live on agent_sessions; the wiki-server
+  // joins them onto each active agent by branch so the dashboard can show
+  // them without a second fetch.
+  linearId: string | null;
+  slotNumber: number | null;
   prNumber: number | null;
   filesTouched: string[] | null;
   model: string | null;
@@ -77,6 +82,8 @@ async function loadFromApi(): Promise<FetchResult<{ agents: ActiveAgentRow[]; co
     status: a.status,
     currentStep: a.currentStep,
     issueNumber: a.issueNumber,
+    linearId: a.linearId ?? null,
+    slotNumber: a.slotNumber ?? null,
     // Enrich: if prNumber isn't set but branch matches an open PR, use it
     prNumber: a.prNumber ?? (a.branch ? branchToPR.get(a.branch) ?? null : null),
     filesTouched: a.filesTouched,

--- a/apps/web/src/app/internal/agent-activity/active-agents-table.tsx
+++ b/apps/web/src/app/internal/agent-activity/active-agents-table.tsx
@@ -6,6 +6,7 @@ import { GITHUB_REPO_URL } from "@lib/site-config";
 import { shortenDirectory } from "@lib/format";
 import type { ActiveAgentRow } from "./active-agents-content";
 import { AgentEventsPanel } from "./agent-events-panel";
+import { slotColumn, linearColumn } from "./shared-columns";
 
 // ── Status Badge ─────────────────────────────────────────────────────────
 
@@ -77,27 +78,7 @@ const columns: ColumnDef<ActiveAgentRow>[] = [
     ),
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
   },
-  // QUA-440: Slot number — derived from the a<N> ancestor of worktree at
-  // init time. Stored on agent_sessions and joined onto active_agents at
-  // query time. Display as a short monospace badge, sortable.
-  {
-    accessorKey: "slotNumber",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Slot</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const slot = row.original.slotNumber;
-      if (slot === null || slot === undefined) {
-        return <span className="text-xs text-muted-foreground/50">—</span>;
-      }
-      return (
-        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-semibold text-foreground/90">
-          a{slot}
-        </span>
-      );
-    },
-    sortingFn: (a, b) => (a.original.slotNumber ?? -1) - (b.original.slotNumber ?? -1),
-  },
+  slotColumn<ActiveAgentRow>(),
   {
     accessorKey: "sessionName",
     header: "Name",
@@ -160,28 +141,7 @@ const columns: ColumnDef<ActiveAgentRow>[] = [
       );
     },
   },
-  // QUA-440: Linear issue identifier. Linked to the Linear issue page so
-  // coordinators can click through from the dashboard.
-  {
-    accessorKey: "linearId",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Linear</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const id = row.original.linearId;
-      if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
-      return (
-        <a
-          href={`https://linear.app/quantifieduncertainty/issue/${id}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs font-mono text-blue-600 hover:underline"
-        >
-          {id}
-        </a>
-      );
-    },
-  },
+  linearColumn<ActiveAgentRow>(),
   {
     accessorKey: "prNumber",
     header: "PR",

--- a/apps/web/src/app/internal/agent-activity/active-agents-table.tsx
+++ b/apps/web/src/app/internal/agent-activity/active-agents-table.tsx
@@ -77,6 +77,27 @@ const columns: ColumnDef<ActiveAgentRow>[] = [
     ),
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
   },
+  // QUA-440: Slot number — derived from the a<N> ancestor of worktree at
+  // init time. Stored on agent_sessions and joined onto active_agents at
+  // query time. Display as a short monospace badge, sortable.
+  {
+    accessorKey: "slotNumber",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Slot</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const slot = row.original.slotNumber;
+      if (slot === null || slot === undefined) {
+        return <span className="text-xs text-muted-foreground/50">—</span>;
+      }
+      return (
+        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-semibold text-foreground/90">
+          a{slot}
+        </span>
+      );
+    },
+    sortingFn: (a, b) => (a.original.slotNumber ?? -1) - (b.original.slotNumber ?? -1),
+  },
   {
     accessorKey: "sessionName",
     header: "Name",
@@ -135,6 +156,28 @@ const columns: ColumnDef<ActiveAgentRow>[] = [
           className="text-xs text-blue-600 hover:underline tabular-nums"
         >
           #{num}
+        </a>
+      );
+    },
+  },
+  // QUA-440: Linear issue identifier. Linked to the Linear issue page so
+  // coordinators can click through from the dashboard.
+  {
+    accessorKey: "linearId",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Linear</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const id = row.original.linearId;
+      if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
+      return (
+        <a
+          href={`https://linear.app/quantifieduncertainty/issue/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-mono text-blue-600 hover:underline"
+        >
+          {id}
         </a>
       );
     },

--- a/apps/web/src/app/internal/agent-activity/sessions-table.tsx
+++ b/apps/web/src/app/internal/agent-activity/sessions-table.tsx
@@ -6,6 +6,7 @@ import { DataTable, SortableHeader } from "@/components/ui/data-table";
 import { GITHUB_REPO_URL } from "@lib/site-config";
 import { shortenDirectory } from "@lib/format";
 import type { AgentSessionListRow as AgentSessionRow } from "@wiki-server/api-response-types";
+import { slotColumn, linearColumn } from "./shared-columns";
 
 // ── Status Badge ─────────────────────────────────────────────────────────
 
@@ -123,26 +124,7 @@ const columns: ColumnDef<AgentSessionRow>[] = [
     ),
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
   },
-  // QUA-440: Slot number — populated for sessions after QUA-440 lands.
-  // Older sessions show '—'.
-  {
-    accessorKey: "slotNumber",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Slot</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const slot = row.original.slotNumber;
-      if (slot === null || slot === undefined) {
-        return <span className="text-xs text-muted-foreground/50">—</span>;
-      }
-      return (
-        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-semibold text-foreground/90">
-          a{slot}
-        </span>
-      );
-    },
-    sortingFn: (a, b) => (a.original.slotNumber ?? -1) - (b.original.slotNumber ?? -1),
-  },
+  slotColumn<AgentSessionRow>(),
   {
     accessorKey: "sessionType",
     header: ({ column }) => (
@@ -186,27 +168,7 @@ const columns: ColumnDef<AgentSessionRow>[] = [
       );
     },
   },
-  // QUA-440: Linear issue ID, linked to Linear's issue page.
-  {
-    accessorKey: "linearId",
-    header: ({ column }) => (
-      <SortableHeader column={column}>Linear</SortableHeader>
-    ),
-    cell: ({ row }) => {
-      const id = row.original.linearId;
-      if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
-      return (
-        <a
-          href={`https://linear.app/quantifieduncertainty/issue/${id}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs font-mono text-blue-600 hover:underline"
-        >
-          {id}
-        </a>
-      );
-    },
-  },
+  linearColumn<AgentSessionRow>(),
   {
     accessorKey: "prUrl",
     header: "PR",

--- a/apps/web/src/app/internal/agent-activity/sessions-table.tsx
+++ b/apps/web/src/app/internal/agent-activity/sessions-table.tsx
@@ -123,6 +123,28 @@ const columns: ColumnDef<AgentSessionRow>[] = [
     ),
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
   },
+  // QUA-440: Slot number — populated for sessions after QUA-440 lands.
+  // Older sessions show '—'.
+  {
+    accessorKey: "slotNumber",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Slot</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const slot = (row.original as { slotNumber?: number | null }).slotNumber;
+      if (slot === null || slot === undefined) {
+        return <span className="text-xs text-muted-foreground/50">—</span>;
+      }
+      return (
+        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-semibold text-foreground/90">
+          a{slot}
+        </span>
+      );
+    },
+    sortingFn: (a, b) =>
+      ((a.original as { slotNumber?: number | null }).slotNumber ?? -1) -
+      ((b.original as { slotNumber?: number | null }).slotNumber ?? -1),
+  },
   {
     accessorKey: "sessionType",
     header: ({ column }) => (
@@ -162,6 +184,27 @@ const columns: ColumnDef<AgentSessionRow>[] = [
           className="text-xs text-blue-600 hover:underline tabular-nums"
         >
           #{num}
+        </a>
+      );
+    },
+  },
+  // QUA-440: Linear issue ID, linked to Linear's issue page.
+  {
+    accessorKey: "linearId",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Linear</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const id = (row.original as { linearId?: string | null }).linearId;
+      if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
+      return (
+        <a
+          href={`https://linear.app/quantifieduncertainty/issue/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-mono text-blue-600 hover:underline"
+        >
+          {id}
         </a>
       );
     },

--- a/apps/web/src/app/internal/agent-activity/sessions-table.tsx
+++ b/apps/web/src/app/internal/agent-activity/sessions-table.tsx
@@ -131,7 +131,7 @@ const columns: ColumnDef<AgentSessionRow>[] = [
       <SortableHeader column={column}>Slot</SortableHeader>
     ),
     cell: ({ row }) => {
-      const slot = (row.original as { slotNumber?: number | null }).slotNumber;
+      const slot = row.original.slotNumber;
       if (slot === null || slot === undefined) {
         return <span className="text-xs text-muted-foreground/50">—</span>;
       }
@@ -141,9 +141,7 @@ const columns: ColumnDef<AgentSessionRow>[] = [
         </span>
       );
     },
-    sortingFn: (a, b) =>
-      ((a.original as { slotNumber?: number | null }).slotNumber ?? -1) -
-      ((b.original as { slotNumber?: number | null }).slotNumber ?? -1),
+    sortingFn: (a, b) => (a.original.slotNumber ?? -1) - (b.original.slotNumber ?? -1),
   },
   {
     accessorKey: "sessionType",
@@ -195,7 +193,7 @@ const columns: ColumnDef<AgentSessionRow>[] = [
       <SortableHeader column={column}>Linear</SortableHeader>
     ),
     cell: ({ row }) => {
-      const id = (row.original as { linearId?: string | null }).linearId;
+      const id = row.original.linearId;
       if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
       return (
         <a

--- a/apps/web/src/app/internal/agent-activity/shared-columns.tsx
+++ b/apps/web/src/app/internal/agent-activity/shared-columns.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Shared column definitions for the agent-activity tables (QUA-440).
+ *
+ * The Slot and Linear columns render identically across the Active Agents
+ * and Agent Sessions tables — same styling, same empty state, same sort
+ * order, same link target. Factoring them here prevents drift.
+ *
+ * Source of truth for the Linear workspace URL also lives here; a
+ * coordinating helper in `crux/lib/linear/client.ts` has the same value
+ * for CLI-side links, but apps/web doesn't import from crux.
+ */
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { SortableHeader } from "@/components/ui/data-table";
+
+const LINEAR_WORKSPACE_SLUG = "quantifieduncertainty";
+
+export function linearIssueUrl(id: string): string {
+  return `https://linear.app/${LINEAR_WORKSPACE_SLUG}/issue/${id}`;
+}
+
+/** Rows in both tables expose these two fields (after QUA-440). */
+interface SlotAndLinearRow {
+  slotNumber: number | null;
+  linearId: string | null;
+}
+
+export function slotColumn<T extends SlotAndLinearRow>(): ColumnDef<T> {
+  return {
+    accessorKey: "slotNumber",
+    header: ({ column }) => <SortableHeader column={column}>Slot</SortableHeader>,
+    cell: ({ row }) => {
+      const slot = row.original.slotNumber;
+      if (slot === null || slot === undefined) {
+        return <span className="text-xs text-muted-foreground/50">—</span>;
+      }
+      return (
+        <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] font-semibold text-foreground/90">
+          a{slot}
+        </span>
+      );
+    },
+    sortingFn: (a, b) => (a.original.slotNumber ?? -1) - (b.original.slotNumber ?? -1),
+  };
+}
+
+export function linearColumn<T extends SlotAndLinearRow>(): ColumnDef<T> {
+  return {
+    accessorKey: "linearId",
+    header: ({ column }) => <SortableHeader column={column}>Linear</SortableHeader>,
+    cell: ({ row }) => {
+      const id = row.original.linearId;
+      if (!id) return <span className="text-xs text-muted-foreground/50">—</span>;
+      return (
+        <a
+          href={linearIssueUrl(id)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-mono text-blue-600 hover:underline"
+        >
+          {id}
+        </a>
+      );
+    },
+  };
+}

--- a/apps/wiki-server/drizzle/0178_agent_sessions_linear_id_slot.sql
+++ b/apps/wiki-server/drizzle/0178_agent_sessions_linear_id_slot.sql
@@ -1,0 +1,44 @@
+-- QUA-440: Add linear_id and slot_number to agent_sessions for DB-first dedup.
+--
+-- Context: QUA-406 added a dedup pre-check to `crux linear start` that reads
+-- Linear comments + queries GitHub PR search. That works but is slow and has
+-- no heartbeat signal. This migration adds the schema side of the fix.
+--
+-- See `.claude/rules/github-issue-tracking.md` for the dedup design and
+-- QUA-440 for the D- refactor plan (light: new columns only on agent_sessions,
+-- leaves active_agents unchanged).
+--
+-- ADD COLUMN on a nullable text/integer with no default is O(1) in Postgres
+-- 11+ (no table rewrite). The partial indexes only scan rows with non-null
+-- linear_id, which starts empty — so both are immediate. No locks held.
+
+ALTER TABLE "agent_sessions"
+  ADD COLUMN IF NOT EXISTS "linear_id" text,
+  ADD COLUMN IF NOT EXISTS "slot_number" integer;
+
+-- Partial index: only indexes rows that have been written with a Linear ID.
+-- Used by the dedup pre-check to answer "which active sessions claim QUA-NNN?"
+-- in a single index seek.
+CREATE INDEX IF NOT EXISTS "idx_as_linear_id"
+  ON "agent_sessions" ("linear_id")
+  WHERE "linear_id" IS NOT NULL;
+
+-- CHECK constraint: linear_id must match the canonical Linear identifier
+-- format. Enforced at the DB level so a bad write gets caught before it
+-- poisons the dedup query. `NOT VALID` skips the retroactive scan; no
+-- existing rows have linear_id so there is nothing to validate.
+ALTER TABLE "agent_sessions"
+  ADD CONSTRAINT "chk_agent_sessions_linear_id_format"
+  CHECK ("linear_id" IS NULL OR "linear_id" ~ '^[A-Z]+-[0-9]+$')
+  NOT VALID;
+
+ALTER TABLE "agent_sessions" VALIDATE CONSTRAINT "chk_agent_sessions_linear_id_format";
+
+-- CHECK constraint: slot_number is bounded to 0-99 (we have 20 slots today,
+-- allow headroom). Rejects negative or absurd values early.
+ALTER TABLE "agent_sessions"
+  ADD CONSTRAINT "chk_agent_sessions_slot_number_range"
+  CHECK ("slot_number" IS NULL OR ("slot_number" >= 0 AND "slot_number" <= 99))
+  NOT VALID;
+
+ALTER TABLE "agent_sessions" VALIDATE CONSTRAINT "chk_agent_sessions_slot_number_range";

--- a/apps/wiki-server/drizzle/0178_agent_sessions_linear_id_slot.sql
+++ b/apps/wiki-server/drizzle/0178_agent_sessions_linear_id_slot.sql
@@ -9,8 +9,20 @@
 -- leaves active_agents unchanged).
 --
 -- ADD COLUMN on a nullable text/integer with no default is O(1) in Postgres
--- 11+ (no table rewrite). The partial indexes only scan rows with non-null
--- linear_id, which starts empty — so both are immediate. No locks held.
+-- 11+ (no table rewrite — briefly takes ACCESS EXCLUSIVE, milliseconds).
+-- The partial index only scans rows with non-null linear_id, which starts
+-- empty — so the index build is immediate.
+--
+-- Lock profile:
+--   ADD COLUMN                 → ACCESS EXCLUSIVE, milliseconds (no rewrite)
+--   CREATE INDEX (partial)     → SHARE (blocks writes briefly on an empty subset)
+--   ADD CONSTRAINT NOT VALID   → ACCESS EXCLUSIVE, milliseconds (no validation scan)
+--   VALIDATE CONSTRAINT        → SHARE UPDATE EXCLUSIVE, milliseconds (no rows to scan)
+--
+-- Safe on a loaded agent_sessions table; do NOT copy-paste this pattern to
+-- a multi-GB table without re-reading .claude/rules/database-migrations.md
+-- and confirming the NOT VALID + VALIDATE split is actually safe for the
+-- lock profile there (cf. QUA-302 / migration 0173's 12-hour deploy stall).
 
 ALTER TABLE "agent_sessions"
   ADD COLUMN IF NOT EXISTS "linear_id" text,

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1247,6 +1247,13 @@
       "when": 1784793600000,
       "tag": "0177_hallucination_risk_snapshots_fk_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 178,
+      "version": "7",
+      "when": 1784880000000,
+      "tag": "0178_agent_sessions_linear_id_slot",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/active-agents.test.ts
+++ b/apps/wiki-server/src/__tests__/active-agents.test.ts
@@ -565,6 +565,20 @@ describe("Active Agents API", () => {
       const res = await postJson(app, "/api/active-agents/999/heartbeat", {});
       expect(res.status).toBe(404);
     });
+
+    // QUA-440: the heartbeat also tries to bump agent_sessions.updated_at
+    // for the matching branch, but must not fail if no session exists (the
+    // common case for agents registered outside the agent-checklist flow).
+    it("succeeds even when no matching agent_sessions row exists", async () => {
+      await postJson(app, "/api/active-agents", sampleAgent);
+      // The test dispatcher's fallback for an UPDATE on agent_sessions is
+      // "return []", which is the same as "no matching rows" in prod. The
+      // heartbeat must still return 200.
+      const res = await postJson(app, "/api/active-agents/1/heartbeat", {});
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
   });
 
   // ================================================================

--- a/apps/wiki-server/src/__tests__/agent-sessions-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/agent-sessions-schema.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Schema-level tests for the Linear-ID and slot-number additions to the
+ * agent_sessions Zod schemas (QUA-440). Pure Zod — no DB, no HTTP.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  CreateAgentSessionSchema,
+  UpdateAgentSessionSchema,
+  LINEAR_ID_PATTERN,
+} from "../api-types.js";
+
+const BASE_CREATE = {
+  branch: "claude/qua-440-test",
+  task: "test session",
+  sessionType: "infrastructure" as const,
+  checklistMd: "# checklist",
+};
+
+describe("LINEAR_ID_PATTERN", () => {
+  it("accepts canonical Linear IDs", () => {
+    expect(LINEAR_ID_PATTERN.test("QUA-440")).toBe(true);
+    expect(LINEAR_ID_PATTERN.test("ENG-1")).toBe(true);
+    expect(LINEAR_ID_PATTERN.test("ABC-123456")).toBe(true);
+  });
+
+  it("rejects lowercase, hyphen-less, or malformed IDs", () => {
+    expect(LINEAR_ID_PATTERN.test("qua-440")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("QUA440")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("QUA-")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("-440")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("QUA-440 ")).toBe(false);
+    expect(LINEAR_ID_PATTERN.test("QUA-440-extra")).toBe(false);
+  });
+});
+
+describe("CreateAgentSessionSchema (QUA-440)", () => {
+  it("accepts a well-formed Linear ID", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      linearId: "QUA-440",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts null linearId (existing sessions without a Linear link)", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      linearId: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts omitted linearId", () => {
+    const r = CreateAgentSessionSchema.safeParse(BASE_CREATE);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a malformed Linear ID", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      linearId: "qua-440",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a valid slot number", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      slotNumber: 5,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a negative slot number", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      slotNumber: -1,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a slot number above 99", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      slotNumber: 100,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a non-integer slot number", () => {
+    const r = CreateAgentSessionSchema.safeParse({
+      ...BASE_CREATE,
+      slotNumber: 5.5,
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("UpdateAgentSessionSchema (QUA-440)", () => {
+  it("accepts late-bound linearId on update", () => {
+    const r = UpdateAgentSessionSchema.safeParse({ linearId: "QUA-440" });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects malformed linearId on update", () => {
+    const r = UpdateAgentSessionSchema.safeParse({ linearId: "not a ticket" });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1160,12 +1160,12 @@ const VALID_SESSION_TYPES = [
  * here so bad writes get rejected before they hit PG.
  */
 export const LINEAR_ID_PATTERN = /^[A-Z]+-\d+$/;
-const LinearIdSchema = z
+/** Required, non-nullable variant — used for path params where the value must be present. */
+export const LinearIdParamSchema = z
   .string()
   .regex(LINEAR_ID_PATTERN, "Linear ID must match /^[A-Z]+-\\d+$/")
-  .max(50)
-  .nullable()
-  .optional();
+  .max(50);
+const LinearIdSchema = LinearIdParamSchema.nullable().optional();
 
 /**
  * Agent slot number (a0..a99). Matches the CHECK constraint on

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1153,11 +1153,39 @@ const VALID_SESSION_TYPES = [
   "commands",
 ] as const;
 
+/**
+ * Canonical Linear issue identifier format — one or more uppercase letters
+ * (team key), a hyphen, one or more digits. Enforced at the DB level by
+ * `chk_agent_sessions_linear_id_format` and validated at the API boundary
+ * here so bad writes get rejected before they hit PG.
+ */
+export const LINEAR_ID_PATTERN = /^[A-Z]+-\d+$/;
+const LinearIdSchema = z
+  .string()
+  .regex(LINEAR_ID_PATTERN, "Linear ID must match /^[A-Z]+-\\d+$/")
+  .max(50)
+  .nullable()
+  .optional();
+
+/**
+ * Agent slot number (a0..a99). Matches the CHECK constraint on
+ * agent_sessions.slot_number.
+ */
+const SlotNumberSchema = z
+  .number()
+  .int()
+  .min(0)
+  .max(99)
+  .nullable()
+  .optional();
+
 export const CreateAgentSessionSchema = z.object({
   branch: z.string().min(1).max(500),
   task: z.string().min(1).max(2000),
   sessionType: z.enum(VALID_SESSION_TYPES),
   issueNumber: z.number().int().positive().nullable().optional(),
+  linearId: LinearIdSchema,
+  slotNumber: SlotNumberSchema,
   checklistMd: z.string().min(1).max(50000),
   worktree: z.string().max(1000).nullable().optional(),
 });
@@ -1177,6 +1205,10 @@ export const UpdateAgentSessionSchema = z.object({
   prUrl: z.string().url().max(1000).nullable().optional(),
   prOutcome: z.enum(PR_OUTCOMES).nullable().optional(),
   fixesPrUrl: z.string().url().max(1000).nullable().optional(),
+  // QUA-440: allow late-binding linearId/slotNumber in case init is run with
+  // --no-linear-start and the caller backfills later.
+  linearId: LinearIdSchema,
+  slotNumber: SlotNumberSchema,
   // Session log fields — written at session end (replaces separate sessions table for agent workflow)
   date: DateStringSchema.optional(),
   title: z.string().min(1).max(1000).nullable().optional(),

--- a/apps/wiki-server/src/routes/operational/active-agents.ts
+++ b/apps/wiki-server/src/routes/operational/active-agents.ts
@@ -280,8 +280,20 @@ const activeAgentsApp = new Hono()
           eq(agentSessions.branch, branch),
           eq(agentSessions.status, "active"),
         ))
-        .catch(() => {
-          // Non-critical; the heartbeat succeeded on active_agents.
+        .catch((err: unknown) => {
+          // Non-critical for the heartbeat response, but we want to know if
+          // this starts failing: a silent regression here would break the
+          // PG-first dedup's freshness signal without any symptom until the
+          // next collision. See .claude/rules/error-handling.md — every
+          // catch must log, re-throw, or document why neither.
+          logger.warn(
+            {
+              err: err instanceof Error ? err.message : String(err),
+              branch,
+              agentId: id,
+            },
+            "Heartbeat: failed to bump agent_sessions.updated_at (QUA-440)",
+          );
         });
     }
 

--- a/apps/wiki-server/src/routes/operational/active-agents.ts
+++ b/apps/wiki-server/src/routes/operational/active-agents.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
-import { eq, desc, and, lt, sql, or } from "drizzle-orm";
+import { eq, desc, and, lt, sql, or, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { getDrizzleDb } from "../../db.js";
-import { activeAgents, agentSessionEvents } from "../../schema.js";
+import { activeAgents, agentSessionEvents, agentSessions } from "../../schema.js";
 import {
   parseJsonBody,
   validationError,
@@ -95,12 +95,54 @@ const activeAgentsApp = new Hono()
 
     const conditions = status ? eq(activeAgents.status, status) : undefined;
 
-    const rows = await db
+    const agents = await db
       .select()
       .from(activeAgents)
       .where(conditions)
       .orderBy(desc(activeAgents.startedAt))
       .limit(limit);
+
+    // QUA-440: fetch the matching agent_sessions rows (by branch + status)
+    // and merge linear_id + slot_number into each agent row. These columns
+    // are authoritative on agent_sessions (D- refactor) so the dashboard
+    // can display them without duplicating data into active_agents.
+    //
+    // Two sequential queries instead of a LEFT JOIN keeps the query shape
+    // simple (one table at a time) which plays well with the in-memory
+    // test dispatcher and with Postgres query planning. The N is small
+    // (bounded by `limit`, default 50) so the second fetch is cheap.
+    const branches = agents
+      .map((a) => a.branch)
+      .filter((b): b is string => b !== null);
+    const sessionLookup = new Map<string, { linearId: string | null; slotNumber: number | null }>();
+    if (branches.length > 0) {
+      const sessionRows = await db
+        .select({
+          branch: agentSessions.branch,
+          linearId: agentSessions.linearId,
+          slotNumber: agentSessions.slotNumber,
+        })
+        .from(agentSessions)
+        .where(and(
+          inArray(agentSessions.branch, branches),
+          eq(agentSessions.status, "active"),
+        ));
+      for (const s of sessionRows) {
+        sessionLookup.set(s.branch, {
+          linearId: s.linearId,
+          slotNumber: s.slotNumber,
+        });
+      }
+    }
+
+    const rows = agents.map((a) => {
+      const s = a.branch ? sessionLookup.get(a.branch) : undefined;
+      return {
+        ...a,
+        linearId: s?.linearId ?? null,
+        slotNumber: s?.slotNumber ?? null,
+      };
+    });
 
     // Compute conflict warnings: agents working on the same issue.
     // Include both "active" and "stale" agents — a stale agent may still be
@@ -219,6 +261,28 @@ const activeAgentsApp = new Hono()
 
     if (result.length === 0) {
       return c.json({ error: "not_found", message: `No agent with id: ${id}` }, 404);
+    }
+
+    // QUA-440: also bump the matching agent_sessions row's updated_at so the
+    // DB-first dedup query (GET /by-linear/:linearId with freshMinutes) sees
+    // live sessions as fresh. Joined on branch because the heartbeat hook
+    // only knows the agent's integer ID, not the session id.
+    //
+    // Best-effort — if no matching session (e.g., pre-QUA-440 agent that
+    // registered without a companion agent_sessions row), we just don't
+    // update anything. Never fails the heartbeat.
+    const branch = result[0].branch;
+    if (branch) {
+      await db
+        .update(agentSessions)
+        .set({ updatedAt: new Date() })
+        .where(and(
+          eq(agentSessions.branch, branch),
+          eq(agentSessions.status, "active"),
+        ))
+        .catch(() => {
+          // Non-critical; the heartbeat succeeded on active_agents.
+        });
     }
 
     return c.json({ ok: true, heartbeatAt: result[0].heartbeatAt });

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -16,6 +16,7 @@ import {
   CreateAgentSessionSchema,
   UpdateAgentSessionSchema,
   DateStringSchema,
+  LINEAR_ID_PATTERN,
 } from "../../api-types.js";
 import { z } from "zod";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
@@ -86,13 +87,20 @@ const agentSessionsApp = new Hono()
         .where(eq(agentSessions.branch, d.branch))
         .orderBy(desc(agentSessions.startedAt)).limit(1);
       if (existing.length > 0 && existing[0].status === "active") {
+        // Merge rules:
+        //   undefined (field omitted) → preserve existing
+        //   null (explicit clear)     → overwrite with null
+        //   value                     → overwrite with value
+        // Using `?? existing ?? null` would silently treat `null` as
+        // "preserve" which is wrong — callers must be able to clear fields.
         const updated = await tx.update(agentSessions).set({
           task: d.task, sessionType: d.sessionType,
-          issueNumber: d.issueNumber ?? null,
-          linearId: d.linearId ?? existing[0].linearId ?? null,
-          slotNumber: d.slotNumber ?? existing[0].slotNumber ?? null,
+          issueNumber: d.issueNumber !== undefined ? d.issueNumber : (existing[0].issueNumber ?? null),
+          linearId: d.linearId !== undefined ? d.linearId : (existing[0].linearId ?? null),
+          slotNumber: d.slotNumber !== undefined ? d.slotNumber : (existing[0].slotNumber ?? null),
           checklistMd: d.checklistMd,
-          worktree: d.worktree ?? existing[0].worktree ?? null, updatedAt: new Date(),
+          worktree: d.worktree !== undefined ? d.worktree : (existing[0].worktree ?? null),
+          updatedAt: new Date(),
         }).where(eq(agentSessions.id, existing[0].id)).returning();
         return { row: firstOrThrow(updated, "agent session update"), isUpdate: true };
       }
@@ -135,8 +143,12 @@ const agentSessionsApp = new Hono()
     ),
     async (c) => {
       const linearId = c.req.param("linearId");
-      if (!/^[A-Z]+-\d+$/.test(linearId)) {
-        return validationError(c, "Invalid Linear ID format (expected ^[A-Z]+-\\d+$)");
+      // Length cap before regex to bound the regex-match cost and match the
+      // `.max(50)` bound on LinearIdSchema in api-types.ts. The regex itself
+      // is anchored and linear-time but explicit bounds are defense in
+      // depth against a future non-anchored refactor.
+      if (linearId.length > 50 || !LINEAR_ID_PATTERN.test(linearId)) {
+        return validationError(c, "Invalid Linear ID format (expected ^[A-Z]+-\\d+$, max 50 chars)");
       }
       const { freshMinutes } = c.req.valid("query");
       const cutoff = new Date(Date.now() - freshMinutes * 60_000);

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -45,6 +45,8 @@ function mapSessionRow(r: typeof agentSessions.$inferSelect, pages: string[]) {
     task: r.task,
     sessionType: r.sessionType,
     issueNumber: r.issueNumber,
+    linearId: r.linearId,
+    slotNumber: r.slotNumber,
     worktree: r.worktree,
     prUrl: r.prUrl,
     prOutcome: r.prOutcome,
@@ -86,14 +88,20 @@ const agentSessionsApp = new Hono()
       if (existing.length > 0 && existing[0].status === "active") {
         const updated = await tx.update(agentSessions).set({
           task: d.task, sessionType: d.sessionType,
-          issueNumber: d.issueNumber ?? null, checklistMd: d.checklistMd,
+          issueNumber: d.issueNumber ?? null,
+          linearId: d.linearId ?? existing[0].linearId ?? null,
+          slotNumber: d.slotNumber ?? existing[0].slotNumber ?? null,
+          checklistMd: d.checklistMd,
           worktree: d.worktree ?? existing[0].worktree ?? null, updatedAt: new Date(),
         }).where(eq(agentSessions.id, existing[0].id)).returning();
         return { row: firstOrThrow(updated, "agent session update"), isUpdate: true };
       }
       const inserted = await tx.insert(agentSessions).values({
         branch: d.branch, task: d.task, sessionType: d.sessionType,
-        issueNumber: d.issueNumber ?? null, checklistMd: d.checklistMd, worktree: d.worktree ?? null,
+        issueNumber: d.issueNumber ?? null,
+        linearId: d.linearId ?? null,
+        slotNumber: d.slotNumber ?? null,
+        checklistMd: d.checklistMd, worktree: d.worktree ?? null,
       }).returning();
       return { row: firstOrThrow(inserted, "agent session insert"), isUpdate: false };
     });
@@ -110,6 +118,42 @@ const agentSessionsApp = new Hono()
     }
     return c.json(rows[0]);
   })
+  // QUA-440: "who is actively working on QUA-NNN right now?"
+  // Returns sessions whose linear_id matches, filtered to active status and
+  // recent updated_at (heartbeat proxy). Used by `crux linear start`'s
+  // DB-first dedup pre-check in `crux/lib/linear/dedup.ts`.
+  .get(
+    "/by-linear/:linearId",
+    zv(
+      "query",
+      z.object({
+        // How fresh updated_at must be to count as an active claim. Defaults
+        // to 30 min (matches the existing active_agents stale timeout).
+        // Capped at 24h so a bad query can't return ancient rows.
+        freshMinutes: z.coerce.number().int().min(1).max(1440).default(30),
+      }),
+    ),
+    async (c) => {
+      const linearId = c.req.param("linearId");
+      if (!/^[A-Z]+-\d+$/.test(linearId)) {
+        return validationError(c, "Invalid Linear ID format (expected ^[A-Z]+-\\d+$)");
+      }
+      const { freshMinutes } = c.req.valid("query");
+      const cutoff = new Date(Date.now() - freshMinutes * 60_000);
+      const db = getDrizzleDb();
+      const rows = await db.select().from(agentSessions)
+        .where(and(
+          eq(agentSessions.linearId, linearId),
+          eq(agentSessions.status, "active"),
+          gte(agentSessions.updatedAt, cutoff),
+        ))
+        .orderBy(desc(agentSessions.updatedAt));
+      return c.json({
+        sessions: rows.map((r) => mapSessionRow(r, [])),
+        freshMinutes,
+      });
+    },
+  )
   .get("/stats", async (c) => {
     const db = getDrizzleDb();
     const [row] = await db.select({
@@ -139,6 +183,7 @@ const agentSessionsApp = new Hono()
       checklistMd, status, prUrl, prOutcome, fixesPrUrl,
       date, title, summary, model, duration, cost, durationMinutes, checksYaml,
       issuesJson, learningsJson, recommendationsJson, reviewed, pages, entities,
+      linearId, slotNumber,
     } = parsed.data;
     const resolvedCostCents = parsed.data.costCents !== undefined
       ? parsed.data.costCents
@@ -151,6 +196,7 @@ const agentSessionsApp = new Hono()
       date, title, summary, model, duration, cost, checksYaml,
       issuesJson, learningsJson, recommendationsJson, reviewed, pages, entities,
       parsed.data.costCents, parsed.data.durationMinutes,
+      linearId, slotNumber,
     ].some((v) => v !== undefined);
     if (!hasAnyField) return validationError(c, "At least one field must be provided");
     const updates: Record<string, unknown> = { updatedAt: new Date() };
@@ -172,6 +218,8 @@ const agentSessionsApp = new Hono()
     if (learningsJson !== undefined) updates.learningsJson = learningsJson;
     if (recommendationsJson !== undefined) updates.recommendationsJson = recommendationsJson;
     if (reviewed !== undefined) updates.reviewed = reviewed;
+    if (linearId !== undefined) updates.linearId = linearId;
+    if (slotNumber !== undefined) updates.slotNumber = slotNumber;
     const db = getDrizzleDb();
     // Sentinel error used to roll back the transaction when status='completed'
     // is attempted with missing required fields. Thrown inside the transaction

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -16,7 +16,7 @@ import {
   CreateAgentSessionSchema,
   UpdateAgentSessionSchema,
   DateStringSchema,
-  LINEAR_ID_PATTERN,
+  LinearIdParamSchema,
 } from "../../api-types.js";
 import { z } from "zod";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
@@ -130,6 +130,10 @@ const agentSessionsApp = new Hono()
   // Returns sessions whose linear_id matches, filtered to active status and
   // recent updated_at (heartbeat proxy). Used by `crux linear start`'s
   // DB-first dedup pre-check in `crux/lib/linear/dedup.ts`.
+  //
+  // Narrow-column projection: the dedup caller only reads branch, slotNumber,
+  // linearId, and updatedAt — no reason to ship checklistMd/issuesJson/etc.
+  // which can be kilobytes each on the init hot path.
   .get(
     "/by-linear/:linearId",
     zv(
@@ -142,28 +146,34 @@ const agentSessionsApp = new Hono()
       }),
     ),
     async (c) => {
-      const linearId = c.req.param("linearId");
-      // Length cap before regex to bound the regex-match cost and match the
-      // `.max(50)` bound on LinearIdSchema in api-types.ts. The regex itself
-      // is anchored and linear-time but explicit bounds are defense in
-      // depth against a future non-anchored refactor.
-      if (linearId.length > 50 || !LINEAR_ID_PATTERN.test(linearId)) {
-        return validationError(c, "Invalid Linear ID format (expected ^[A-Z]+-\\d+$, max 50 chars)");
+      // `zv` in this codebase only validates "query" and "json" targets, so
+      // validate the path param via the shared schema manually. Keeps the
+      // format rule (incl. the 50-char cap) in one place — LinearIdParamSchema.
+      const parsed = LinearIdParamSchema.safeParse(c.req.param("linearId"));
+      if (!parsed.success) {
+        return validationError(c, parsed.error.issues[0]?.message ?? "Invalid Linear ID");
       }
+      const linearId = parsed.data;
       const { freshMinutes } = c.req.valid("query");
       const cutoff = new Date(Date.now() - freshMinutes * 60_000);
       const db = getDrizzleDb();
-      const rows = await db.select().from(agentSessions)
+      const rows = await db
+        .select({
+          id: agentSessions.id,
+          branch: agentSessions.branch,
+          linearId: agentSessions.linearId,
+          slotNumber: agentSessions.slotNumber,
+          status: agentSessions.status,
+          updatedAt: agentSessions.updatedAt,
+        })
+        .from(agentSessions)
         .where(and(
           eq(agentSessions.linearId, linearId),
           eq(agentSessions.status, "active"),
           gte(agentSessions.updatedAt, cutoff),
         ))
         .orderBy(desc(agentSessions.updatedAt));
-      return c.json({
-        sessions: rows.map((r) => mapSessionRow(r, [])),
-        freshMinutes,
-      });
+      return c.json({ sessions: rows, freshMinutes });
     },
   )
   .get("/stats", async (c) => {

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1048,7 +1048,14 @@ export const agentSessions = pgTable(
     branch: text("branch").notNull(),
     task: text("task").notNull(),
     sessionType: text("session_type").notNull(),
-    issueNumber: integer("issue_number"),
+    issueNumber: integer("issue_number"), // legacy GitHub issue number
+    // Linear issue identifier (QUA-406 follow-up — DB-first dedup). Format
+    // enforced by chk_agent_sessions_linear_id_format: `^[A-Z]+-[0-9]+$`.
+    linearId: text("linear_id"),
+    // Agent slot number (a0..a99). Derived from the cwd ancestor walk at init
+    // time; used by the dedup query to distinguish "same slot resumption"
+    // from "different slot collision". See .claude/rules/github-issue-tracking.md.
+    slotNumber: integer("slot_number"),
     checklistMd: text("checklist_md").notNull(),
     worktree: text("worktree"), // working directory path for collision detection
     prUrl: text("pr_url"), // PR URL recorded when crux issues done --pr=URL is called
@@ -1086,6 +1093,11 @@ export const agentSessions = pgTable(
     index("idx_as_issue").on(table.issueNumber),
     index("idx_as_started_at").on(table.startedAt),
     index("idx_as_date").on(table.date),
+    // Partial index on non-null linear_id — empty for existing rows, so the
+    // create is O(0) at migration time. Used by the dedup pre-check.
+    index("idx_as_linear_id")
+      .on(table.linearId)
+      .where(sql`${table.linearId} IS NOT NULL`),
   ]
 );
 

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -32,7 +32,6 @@ import { commands as linearCommands, checkDedup as linearCheckDedup } from './li
 import { getIssue as getLinearIssue } from '../lib/linear/issues.ts';
 import { getSessionContext } from '../lib/session/session-context.ts';
 import { resolveLinearId, parseLinearId } from '../lib/linear/parse-id.ts';
-import { getSessionContext } from '../lib/session/session-context.ts';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -343,24 +343,18 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
         `skipping auto-start. Sync .env.base or export the key to enable.${c.reset}\n`;
     } else {
       try {
+        // `linearCommands.start` runs its own dedup check internally.
+        // We already ran the pre-check above (which aborts before writing
+        // any local state on collision), so pass `skipDedupCheck: true` to
+        // avoid the 2× API cost and TOCTOU window. --force propagates
+        // separately and controls the "forced" annotation in the start
+        // comment body.
         const startResult = await linearCommands.start(
           [linearId],
-          { ci: options.ci, force: options.force },
+          { ci: options.ci, force: options.force, skipDedupCheck: true },
         );
         if (startResult.exitCode === 0) {
           linearStartOutput = startResult.output;
-        } else if (startResult.exitCode === 2) {
-          // Dedup collision — refuse to create the checklist. The start
-          // output contains a rich diagnostic (active claims + open PRs)
-          // that tells the user exactly what's blocking them.
-          return {
-            output:
-              `${c.red}✗ Refusing to create session checklist — Linear ${linearId} is already claimed.${c.reset}\n\n` +
-              startResult.output +
-              `\n${c.dim}Re-run with ${c.bold}--force${c.reset}${c.dim} to claim anyway:${c.reset}\n` +
-              `  ${c.cyan}crux sys agent-checklist init ${args.map((a) => JSON.stringify(a)).join(' ')} --force${c.reset}\n`,
-            exitCode: 2,
-          };
         } else {
           linearStartOutput =
             `${c.yellow}⚠ Auto-start of Linear ${linearId} returned non-zero exit:${c.reset}\n` +

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -59,8 +59,7 @@ interface CommandOptions extends BaseOptions {
   noIssueStart?: boolean;
   /** Skip the auto-call to `linear issues start <QUA-NNN>`. Used by tests. */
   noLinearStart?: boolean;
-  /** Pass --force through to `linear start` to bypass the dedup check. Also
-   *  disarms the hard-fail path on dedup collisions. */
+  /** Pass --force through to `linear start` to bypass the dedup check. */
   force?: boolean;
 }
 

--- a/crux/commands/agent-checklist.ts
+++ b/crux/commands/agent-checklist.ts
@@ -32,6 +32,7 @@ import { commands as linearCommands, checkDedup as linearCheckDedup } from './li
 import { getIssue as getLinearIssue } from '../lib/linear/issues.ts';
 import { getSessionContext } from '../lib/session/session-context.ts';
 import { resolveLinearId, parseLinearId } from '../lib/linear/parse-id.ts';
+import { getSessionContext } from '../lib/session/session-context.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -245,11 +246,18 @@ async function init(args: string[], options: CommandOptions): Promise<CommandRes
   let dbSynced = false;
   let directoryWarning = '';
   try {
+    // QUA-440: persist linearId and slotNumber so the DB-first dedup query
+    // and the internal dashboards can surface them without string-matching
+    // task/checklist content. `ctx.slot` is derived from the `a<N>` ancestor
+    // of the current working directory (see session-context.ts).
+    const ctx = getSessionContext();
     const result = await upsertAgentSession({
       branch,
       task,
       sessionType: type,
       issueNumber: issue ?? null,
+      linearId: linearId ?? null,
+      slotNumber: ctx.slot,
       checklistMd: markdown,
       worktree,
     });

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -70,6 +70,11 @@ interface CommandOptions extends BaseOptions {
   startDate?: string;
   targetDate?: string;
   force?: boolean;
+  // Internal-only: skip the dedup check WITHOUT posting the "--force"
+  // annotation in the start comment. Used by `agent-checklist init` which
+  // already ran the pre-check and shouldn't pay for it again (and
+  // shouldn't mark the comment as forced). Not exposed on the CLI.
+  skipDedupCheck?: boolean;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -217,7 +222,9 @@ async function start(args: string[], options: CommandOptions): Promise<CommandRe
   // issue. Both checks are fail-open — they return empty on API errors so
   // a transient glitch doesn't wedge all sessions. See QUA-406 for the
   // incident that motivated this (two sessions racing on QUA-397).
-  if (!options.force) {
+  // Dedup unless the user explicitly forced past the check (--force) or an
+  // internal caller already ran the pre-check (skipDedupCheck).
+  if (!options.force && !options.skipDedupCheck) {
     const collision = await checkDedup(id, issue.url, ctx, c);
     if (collision) return collision;
   }

--- a/crux/lib/linear/dedup.test.ts
+++ b/crux/lib/linear/dedup.test.ts
@@ -7,9 +7,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SessionContext } from '../session/session-context.ts';
 
-const { getCommentsMock, githubApiMock } = vi.hoisted(() => ({
+const { getCommentsMock, githubApiMock, getAgentSessionsByLinearIdMock } = vi.hoisted(() => ({
   getCommentsMock: vi.fn(),
   githubApiMock: vi.fn(),
+  getAgentSessionsByLinearIdMock: vi.fn(),
 }));
 
 vi.mock('./issues.ts', () => ({
@@ -19,6 +20,10 @@ vi.mock('./issues.ts', () => ({
 vi.mock('../github.ts', () => ({
   githubApi: githubApiMock,
   REPO: 'quantified-uncertainty/longterm-wiki',
+}));
+
+vi.mock('../wiki-server/agent-sessions.ts', () => ({
+  getAgentSessionsByLinearId: getAgentSessionsByLinearIdMock,
 }));
 
 import {
@@ -64,6 +69,10 @@ const baseCtx: SessionContext = {
 beforeEach(() => {
   getCommentsMock.mockReset();
   githubApiMock.mockReset();
+  getAgentSessionsByLinearIdMock.mockReset();
+  // Default: PG query "fails open" (returns null) so existing tests (which
+  // pre-date the PG path) keep testing the Linear-comment fallback.
+  getAgentSessionsByLinearIdMock.mockResolvedValue({ ok: false });
 });
 
 describe('findActiveClaimsByOthers', () => {
@@ -138,6 +147,119 @@ describe('findActiveClaimsByOthers', () => {
     // ambiguous to block on. A slot-ful caller treats them as collisions.
     const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
     expect(claims).toHaveLength(1); // slot-ful caller treats as collision
+  });
+
+  // ── PG-first (QUA-440) ────────────────────────────────────────────────
+
+  describe('PG-first (QUA-440)', () => {
+    it('uses PG when it returns cross-slot active sessions, skipping Linear', async () => {
+      getAgentSessionsByLinearIdMock.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          sessions: [
+            {
+              id: 1,
+              branch: 'claude/qua-406-other',
+              slotNumber: 9,
+              status: 'active',
+              updatedAt: new Date(now - 5 * 60 * 1000).toISOString(),
+              linearId: 'QUA-406',
+              task: 'other session',
+            },
+          ],
+          freshMinutes: 30,
+        },
+      });
+      const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].slot).toBe('a9');
+      expect(claims[0].branch).toBe('claude/qua-406-other');
+      // Linear comments should NOT have been consulted.
+      expect(getCommentsMock).not.toHaveBeenCalled();
+    });
+
+    it('filters out same-slot sessions (session resumption, not collision)', async () => {
+      getAgentSessionsByLinearIdMock.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          sessions: [
+            {
+              id: 1,
+              branch: 'claude/qua-406-linear-start-dedup',
+              slotNumber: 5,
+              status: 'active',
+              updatedAt: new Date(now - 5 * 60 * 1000).toISOString(),
+              linearId: 'QUA-406',
+              task: 'same slot resume',
+            },
+          ],
+          freshMinutes: 30,
+        },
+      });
+      // PG says "no cross-slot claims" → fall through to Linear, which is
+      // empty → return []. The same-slot session is not a collision.
+      getCommentsMock.mockResolvedValueOnce([]);
+      const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+      expect(claims).toEqual([]);
+    });
+
+    it('filters out same-branch sessions even when slot is unset', async () => {
+      const slotlessCtx: SessionContext = { ...baseCtx, slot: null };
+      getAgentSessionsByLinearIdMock.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          sessions: [
+            {
+              id: 1,
+              branch: slotlessCtx.branch,
+              slotNumber: 9,
+              status: 'active',
+              updatedAt: new Date(now - 5 * 60 * 1000).toISOString(),
+              linearId: 'QUA-406',
+              task: 'same branch, different slot (e.g. re-init)',
+            },
+          ],
+          freshMinutes: 30,
+        },
+      });
+      getCommentsMock.mockResolvedValueOnce([]);
+      const claims = await findActiveClaimsByOthers('QUA-406', slotlessCtx, now);
+      expect(claims).toEqual([]);
+    });
+
+    it('falls through to Linear when PG returns an empty result', async () => {
+      getAgentSessionsByLinearIdMock.mockResolvedValueOnce({
+        ok: true,
+        data: { sessions: [], freshMinutes: 30 },
+      });
+      getCommentsMock.mockResolvedValueOnce([
+        startComment({ slot: 'a9', branch: 'claude/qua-406-from-linear', hoursAgo: 2 }),
+      ]);
+      const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].branch).toBe('claude/qua-406-from-linear');
+      expect(getCommentsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to Linear when PG is unreachable (ok: false)', async () => {
+      getAgentSessionsByLinearIdMock.mockResolvedValueOnce({ ok: false });
+      getCommentsMock.mockResolvedValueOnce([
+        startComment({ slot: 'a9', branch: 'claude/qua-406-from-linear', hoursAgo: 2 }),
+      ]);
+      const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+      expect(claims).toHaveLength(1);
+    });
+
+    it('falls through to Linear when PG throws', async () => {
+      getAgentSessionsByLinearIdMock.mockRejectedValueOnce(
+        new Error('wiki-server unreachable'),
+      );
+      getCommentsMock.mockResolvedValueOnce([
+        startComment({ slot: 'a9', branch: 'claude/qua-406-from-linear', hoursAgo: 2 }),
+      ]);
+      const claims = await findActiveClaimsByOthers('QUA-406', baseCtx, now);
+      expect(claims).toHaveLength(1);
+    });
   });
 });
 

--- a/crux/lib/linear/dedup.ts
+++ b/crux/lib/linear/dedup.ts
@@ -2,23 +2,30 @@
  * Dedup helpers for `crux linear start`.
  *
  * Detects whether another session has already claimed a Linear issue, so
- * that two agents don't race to implement the same ticket (QUA-406). The
- * check has two independent signals:
+ * that two agents don't race to implement the same ticket (QUA-406). Three
+ * independent signals, checked in this order:
  *
- * 1. Recent "🤖 Claude Code starting work" comments on the Linear issue
- *    from a different slot, not yet superseded by a "finished work" comment.
- * 2. Open PRs in the wiki repo whose title or body mentions the Linear ID.
+ * 1. **PG `agent_sessions` (QUA-440)** — the authoritative "who's live
+ *    right now" source. Queries sessions with matching `linear_id`,
+ *    `status='active'`, and `updated_at > now() - freshMinutes`. Fastest
+ *    path (~50ms). Filters out same-slot claims (session resumption).
+ * 2. **Linear start comments** — fallback when PG is unreachable or the
+ *    session didn't register (early crash). Same filtering rules, parsed
+ *    out of `🤖 Claude Code starting work` comment bodies.
+ * 3. **Open PRs** in the wiki repo whose title or body mentions the Linear
+ *    ID. Paranoia layer — catches abandoned branches that PG has
+ *    forgotten about and Linear comments never captured.
  *
- * Either signal is sufficient to block the `start` call. Users can override
- * with `--force` (see `crux linear start --force`). Both checks fail-open
- * on API errors: if GitHub or Linear is unreachable, we let the session
- * proceed rather than blocking on a transient glitch. The downside of a
- * rare missed collision is less bad than blocking all sessions when the
- * APIs hiccup.
+ * Any signal is sufficient to block the `start` call. Users can override
+ * with `--force` (see `crux linear start --force`). All checks fail-open
+ * on API errors: if a source is unreachable, we skip it rather than
+ * blocking on a transient glitch. The downside of a rare missed collision
+ * is less bad than blocking all sessions when the wiki-server hiccups.
  */
 
 import { githubApi, REPO } from '../github.ts';
 import { getComments, type LinearComment } from './issues.ts';
+import { getAgentSessionsByLinearId } from '../wiki-server/agent-sessions.ts';
 import type { SessionContext } from '../session/session-context.ts';
 
 // 24-hour window for considering a start comment "recent." Anything older
@@ -56,27 +63,89 @@ function parseStartClaim(comment: LinearComment): RecentStartClaim | null {
 }
 
 /**
- * Fetch recent start-work comments that represent unresolved claims by
- * another session. "Unresolved" means: posted in the last 24h, from a
+ * QUA-440: PG-first lookup for "who's actively claiming this Linear ID?"
+ * Queries `agent_sessions` via the wiki-server. Returns claims from other
+ * slots only — the caller's own slot is filtered here (session resumption
+ * is not a collision).
+ *
+ * Fail-open: returns null on API error so the caller can fall back to the
+ * Linear-comments path. Returning `null` (not `[]`) distinguishes "PG said
+ * clean" from "PG was unreachable" — the caller needs to know the
+ * difference to decide whether to fall back.
+ */
+async function findActiveClaimsByOthersFromPg(
+  linearId: string,
+  ctx: SessionContext,
+  freshMinutes: number,
+): Promise<RecentStartClaim[] | null> {
+  const result = await getAgentSessionsByLinearId(linearId, freshMinutes).catch(
+    () => null,
+  );
+  if (!result || !result.ok) return null;
+
+  const claims: RecentStartClaim[] = [];
+  for (const s of result.data.sessions) {
+    // Same-slot sessions are our own resumption, not a collision.
+    if (ctx.slot !== null && s.slotNumber === ctx.slot) continue;
+    // Our own branch — also not a collision. Covers the case where slot was
+    // unset at init time (e.g., running outside a slot dir) but the branch
+    // matches. Prevents re-init from blocking itself.
+    if (s.branch === ctx.branch) continue;
+    claims.push({
+      body:
+        `🤖 Claude Code starting work on this issue.\n\n` +
+        (s.slotNumber !== null ? `**Slot:** a${s.slotNumber}\n` : '') +
+        `**Branch:** \`${s.branch}\`\n` +
+        `(from PG agent_sessions — updated_at ${new Date(s.updatedAt).toISOString()})`,
+      createdAt: String(s.updatedAt),
+      branch: s.branch,
+      slot: s.slotNumber !== null ? `a${s.slotNumber}` : null,
+    });
+  }
+  return claims;
+}
+
+/**
+ * Fetch active claims on this Linear ID from any source. Consults PG
+ * first (QUA-440), falls back to Linear start comments (QUA-406) if PG is
+ * unreachable or returns no rows.
+ *
+ * "Active claim" means: posted within the freshness window, from a
  * different slot than ours, and not followed by a "finished work" comment
- * from the same session.
+ * from the same session (Linear-path only — PG uses `status='active'` +
+ * heartbeat instead).
  *
  * Same-slot re-runs (init crash recovery, resume) are not blocked — it's
  * the same user reclaiming their own workspace. Cross-slot starts are the
  * collision pattern we care about (QUA-406: a9 vs a16 on the same machine).
  *
- * Fail-open: returns an empty array if the Linear API is unreachable.
+ * Fail-open: returns an empty array if BOTH sources are unreachable.
  */
 export async function findActiveClaimsByOthers(
   linearId: string,
   ctx: SessionContext,
   nowMs: number = Date.now(),
 ): Promise<RecentStartClaim[]> {
+  // ── Source 1: PG agent_sessions (primary, fastest) ────────────────────
+  // The freshness window matches the active_agents stale timeout so a
+  // session that crashed >30min ago automatically releases its claim.
+  const pgClaims = await findActiveClaimsByOthersFromPg(linearId, ctx, 30);
+  if (pgClaims !== null && pgClaims.length > 0) return pgClaims;
+
+  // If PG said clean AND returned successfully, we still check Linear
+  // comments as a fallback — PG was only populated starting with QUA-440,
+  // so existing sessions from before this lands don't show up there.
+  // After a few weeks of rollout, this fallback becomes redundant and can
+  // be dropped. For now it preserves correctness.
+
+  // ── Source 2: Linear start comments (fallback) ─────────────────────────
   let comments: LinearComment[];
   try {
     comments = await getComments(linearId, 30);
   } catch {
-    return [];
+    // PG was queried above; if it returned [], we trust that. If it was
+    // unreachable (null) AND Linear is also down, fail-open.
+    return pgClaims ?? [];
   }
 
   // Walk comments chronologically to track which starts have been superseded

--- a/crux/lib/linear/dedup.ts
+++ b/crux/lib/linear/dedup.ts
@@ -91,13 +91,16 @@ async function findActiveClaimsByOthersFromPg(
     // unset at init time (e.g., running outside a slot dir) but the branch
     // matches. Prevents re-init from blocking itself.
     if (s.branch === ctx.branch) continue;
+    // `updatedAt` comes back as a string from JSON; normalize defensively
+    // in case the serialization ever changes.
+    const updatedAt = typeof s.updatedAt === 'string' ? s.updatedAt : String(s.updatedAt);
     claims.push({
       body:
         `🤖 Claude Code starting work on this issue.\n\n` +
         (s.slotNumber !== null ? `**Slot:** a${s.slotNumber}\n` : '') +
         `**Branch:** \`${s.branch}\`\n` +
-        `(from PG agent_sessions — updated_at ${new Date(s.updatedAt).toISOString()})`,
-      createdAt: String(s.updatedAt),
+        `(from PG agent_sessions — updated_at ${updatedAt})`,
+      createdAt: updatedAt,
       branch: s.branch,
       slot: s.slotNumber !== null ? `a${s.slotNumber}` : null,
     });
@@ -127,16 +130,29 @@ export async function findActiveClaimsByOthers(
   nowMs: number = Date.now(),
 ): Promise<RecentStartClaim[]> {
   // ── Source 1: PG agent_sessions (primary, fastest) ────────────────────
-  // The freshness window matches the active_agents stale timeout so a
-  // session that crashed >30min ago automatically releases its claim.
+  // The 30-minute freshness window matches the active_agents stale sweep
+  // so a session that crashed without running `crux linear done` auto-
+  // releases its claim. This window is DELIBERATELY tighter than the
+  // 24-hour Linear-comment window (DEDUP_WINDOW_MS): PG has heartbeats
+  // and can be precise about liveness, Linear comments cannot.
   const pgClaims = await findActiveClaimsByOthersFromPg(linearId, ctx, 30);
   if (pgClaims !== null && pgClaims.length > 0) return pgClaims;
 
-  // If PG said clean AND returned successfully, we still check Linear
-  // comments as a fallback — PG was only populated starting with QUA-440,
-  // so existing sessions from before this lands don't show up there.
-  // After a few weeks of rollout, this fallback becomes redundant and can
-  // be dropped. For now it preserves correctness.
+  // On empty PG result, fall through to Linear comments. Rationale:
+  //   - During rollout (first few weeks): existing sessions didn't
+  //     populate linear_id, so PG underreports.
+  //   - Post-rollout: PG should be authoritative and this fallthrough
+  //     pays an unnecessary Linear API round-trip on every clean init.
+  //
+  // TODO (post-rollout, ~2026-05-01): drop this fallthrough and return
+  // [] immediately when PG returns ok-empty. The paranoia-layer open-PR
+  // check still runs regardless.
+  //
+  // Note: we do NOT merge PG results with Linear results when PG returns
+  // non-empty above. That's intentional — PG's 30-min window is the
+  // authoritative "liveness" signal; a matching Linear comment from 6h
+  // ago but no heartbeat means the session crashed and should not block
+  // new work.
 
   // ── Source 2: Linear start comments (fallback) ─────────────────────────
   let comments: LinearComment[];

--- a/crux/lib/linear/dedup.ts
+++ b/crux/lib/linear/dedup.ts
@@ -94,12 +94,11 @@ async function findActiveClaimsByOthersFromPg(
     // `updatedAt` comes back as a string from JSON; normalize defensively
     // in case the serialization ever changes.
     const updatedAt = typeof s.updatedAt === 'string' ? s.updatedAt : String(s.updatedAt);
+    // The formatter renders the first non-empty line as the one-line
+    // summary. Keep it honest — this claim came from PG, not a Linear
+    // comment, and there's no need to fabricate a comment-shaped body.
     claims.push({
-      body:
-        `🤖 Claude Code starting work on this issue.\n\n` +
-        (s.slotNumber !== null ? `**Slot:** a${s.slotNumber}\n` : '') +
-        `**Branch:** \`${s.branch}\`\n` +
-        `(from PG agent_sessions — updated_at ${updatedAt})`,
+      body: `Active session in agent_sessions (last heartbeat ${updatedAt})`,
       createdAt: updatedAt,
       branch: s.branch,
       slot: s.slotNumber !== null ? `a${s.slotNumber}` : null,

--- a/crux/lib/wiki-server/agent-sessions.ts
+++ b/crux/lib/wiki-server/agent-sessions.ts
@@ -69,6 +69,28 @@ export async function getAgentSessionByBranch(
   );
 }
 
+/** Shape returned by GET /by-linear/:linearId (200 success). */
+export type AgentSessionsByLinearResponse = InferResponseType<
+  RpcClient['by-linear'][':linearId']['$get'],
+  200
+>;
+
+/**
+ * QUA-440: Query active sessions claiming a Linear ID. Used by the
+ * `crux linear start` DB-first dedup pre-check. `freshMinutes` bounds the
+ * `updated_at` window (default 30 min, matches the active_agents stale
+ * timeout).
+ */
+export async function getAgentSessionsByLinearId(
+  linearId: string,
+  freshMinutes: number = 30,
+): Promise<ApiResult<AgentSessionsByLinearResponse>> {
+  return apiRequest<AgentSessionsByLinearResponse>(
+    'GET',
+    `/api/agent-sessions/by-linear/${encodeURIComponent(linearId)}?freshMinutes=${freshMinutes}`,
+  );
+}
+
 /**
  * Update an agent session's checklist or status.
  */


### PR DESCRIPTION
## Summary

Closes QUA-440. Follow-up to QUA-406 (PR #4300). Implements the **Option D− light refactor**: `agent_sessions` becomes the authoritative source for `linear_id`, `slot_number`, and session identity. `active_agents` stays as a heartbeat ledger. Full-table merge is deferred to QUA-445.

## Why

QUA-406 (PR #4300) added dedup by scraping Linear comments + GitHub PR search. That works but has three drawbacks:

1. **Slow** — 1-3 seconds per init, burns rate-limit budget.
2. **No heartbeat** — Linear comments live forever; a crashed session still looks "active."
3. **DB duplication** — `agent_sessions` and `active_agents` already store branch/task/worktree/model but the Linear ID was only captured in `task` string content and Linear comments. No structured way to ask "who's working on QUA-440?"

After this PR, dedup is PG-first with automatic heartbeat-based expiry, Linear comments stay as a fallback, and both dashboards surface slot + linear columns.

## What changed

### Schema (migration 0178)

- `agent_sessions.linear_id text` with partial index + CHECK `^[A-Z]+-\d+$`.
- `agent_sessions.slot_number integer` with CHECK `0 <= x <= 99`.
- Both nullable, no backfill. ADD COLUMN + CHECK `NOT VALID` + VALIDATE — no table scan, safe on a loaded prod table.
- **Not adding to `active_agents`** — that table is the loser in the eventual merge. D− explicitly marks `agent_sessions` as the identity source.

### Plumbing

- `CreateAgentSessionSchema` and `UpdateAgentSessionSchema` accept `linearId` + `slotNumber`.
- `agent-checklist init` passes them from the detected Linear ID and `getSessionContext().slot`.
- New route `GET /api/agent-sessions/by-linear/:linearId?freshMinutes=30` returns active sessions claiming that Linear ID within the freshness window.
- New CLI wrapper `getAgentSessionsByLinearId()`.

### Dedup

- `findActiveClaimsByOthers` in `crux/lib/linear/dedup.ts` consults three sources in order: PG first (authoritative, heartbeat-bounded), then Linear comments (fallback), then open PRs (paranoia). Any hit blocks. All three fail-open.
- Same-slot sessions are always filtered out (session resumption ≠ collision).
- 6 new tests covering the PG-first path, fallthrough behavior, and fail-open semantics.

### Heartbeat cross-table

- `POST /api/active-agents/:id/heartbeat` now also bumps `agent_sessions.updated_at` for the matching active branch. Keeps `agent_sessions.updated_at` fresh so the dedup query's 30-minute freshness window works.
- Best-effort: if no matching session (e.g., pre-QUA-440 agent), the heartbeat still succeeds.

### Dashboards (`/internal/agent-activity`)

- **Active Agents**: new Slot column (after Status) + Linear column (after Issue). Slot renders as a mono badge, Linear as a clickable link to Linear's issue page. Data joined server-side from `agent_sessions` by branch so no extra frontend fetches.
- **Agent Sessions**: same two columns. Reads directly from `agent_sessions` (already the row source).

### Rule doc

`.claude/rules/github-issue-tracking.md` dedup section rewritten to describe the three-source layering and heartbeat semantics.

## Testing

- 6 new PG-first dedup tests (`crux/lib/linear/dedup.test.ts`): cross-slot collision detected, same-slot filtered, same-branch filtered, fallthrough on empty/unreachable/throw.
- 12 new schema tests (`apps/wiki-server/src/__tests__/agent-sessions-schema.test.ts`): Linear-ID format accept/reject, slot-number range, optional/null handling.
- 1 new heartbeat test verifying the cross-table update doesn't fail when no matching session exists.
- All 33 existing `active-agents` route tests still pass (added two-query in-memory merge so the LEFT JOIN compatibility isn't needed).
- All 19 existing dedup unit tests still pass.
- All 111 crux-level tests pass (up from 105 in QUA-406).
- `pnpm crux w validate gate --fix` — all 52 gate checks pass. Full Next.js build succeeds (106s).

## Rollout safety

1. **Migration is non-blocking.** ADD COLUMN on a nullable text/integer is O(1) in PG 11+. CHECK constraints use `NOT VALID` + `VALIDATE CONSTRAINT` — no risk of the QUA-302-style deploy stall.
2. **Dedup stays correct during the rollout window.** Before the first session writes `linear_id`, PG returns `[]` for all queries; the code falls through to the Linear-comment path (today's behavior from PR #4300). After the window, PG becomes the fast path.
3. **Backfill intentionally skipped.** Old rows stay NULL — the dedup query filters on `linear_id = $1 AND updated_at > now() - 30min`, and old rows have old `updated_at`, so they're excluded by the freshness bound regardless.

## Follow-ups

- **QUA-445** (filed) — merge `active_agents` into `agent_sessions` entirely. This PR intentionally stops short of that; the pieces only needed for D− are done.
- No follow-up needed for the dashboard UI — I verified the schema types flow through automatically since the session-list route returns `db.select().from(agentSessions)` raw rows.

## Dependencies

Builds on top of PR #4300 (QUA-406 dedup pre-check). If #4300 is still open when this is reviewed, the diff here shows **only the QUA-440 additions**; if #4300 has merged, this becomes the first QUA-440-specific PR.

## Test plan

- [x] 6 new PG-first dedup tests in `crux/lib/linear/dedup.test.ts` (cross-slot collision, same-slot filter, same-branch filter, fallthrough on empty/unreachable/throw)
- [x] 12 new schema tests in `apps/wiki-server/src/__tests__/agent-sessions-schema.test.ts` (Linear-ID pattern accept/reject, slot-number range, optional/null handling)
- [x] 1 new heartbeat cross-table test
- [x] All 33 existing `active-agents` route tests still pass after the two-query refactor
- [x] All 19 existing dedup unit tests still pass
- [x] All 111 crux-level tests pass
- [x] `pnpm crux w validate gate --fix` — all 52 gate checks pass
- [x] Full Next.js build succeeds (106s)
- [ ] After merge: verify `GET /api/agent-sessions/by-linear/QUA-440?freshMinutes=30` returns this session
- [ ] After merge: verify dashboard at `/internal/agent-activity` shows Slot + Linear columns


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0178 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->