### PR TITLE
docs: wire things-denormalization audit into agent discovery paths (QUA-414 followup)

### DIFF
--- a/.claude/rules/entity-sync-pipeline.md
+++ b/.claude/rules/entity-sync-pipeline.md
@@ -2,6 +2,8 @@
 
 Subsystem map for the YAML → sync → PG pipeline and the tablebase route infrastructure. **Read this before writing a new sync endpoint, delete handler, or entity validation** — the shared helpers and factories are missed constantly.
 
+> **If your new handler writes to `things.title` / `things.description` / `things.parent_title`, or adds a `*_display_name` column**: read `docs/audits/things-denormalization-audit.md` first. It enumerates all 22 existing write sites, the 5 handlers that leak raw IDs today (subsumed by [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) Tier 4b), and the `search_vector` GENERATED column constraint that any replacement must preserve. Adding a 23rd bespoke title composer without reading the audit is the fastest way to recreate QUA-397.
+
 ## Why this file exists
 
 Recent rework incidents in this subsystem include:

--- a/.claude/rules/three-bases-architecture.md
+++ b/.claude/rules/three-bases-architecture.md
@@ -4,6 +4,8 @@ Subsystem map for the TableBase / FactBase / WikiBase architecture. **Read this 
 
 **Canonical source**: the wiki page at `content/docs/internal/data-architecture.mdx` (E1334) has the full version with mermaid diagrams, table inventories, and migration history. This file is the *agent cheat-sheet* — read this first, follow the link if you need depth.
 
+> **For the cross-base `things` table specifically**: see `docs/audits/things-denormalization-audit.md` for the full write-site inventory, the `search_vector` GENERATED column constraint, and the `*_display_name` sibling pattern audit. Directly informs how [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) Tier 4b will normalize this layer.
+
 ---
 
 ## The three layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,3 +219,4 @@ These are "mental model" maps. They list the components, endpoints, helpers, and
 - `.claude/rules/three-bases-architecture.md` — TableBase/FactBase/WikiBase naming and which layer owns what
 - `.claude/rules/id-system.md` — `numericId` vs `stableId` vs `tableId`, allocation, validation
 - `.claude/rules/validation-gate-system.md` — `crux/validate/` 80+ validators, gate wiring, blocking vs advisory
+- `docs/audits/things-denormalization-audit.md` — **Read before adding or modifying any sync handler that writes to `things.title` / `things.description` / `things.parent_title`**, or before proposing a new `*_display_name` cache column. Inventory of all 22 write sites, the `search_vector` GENERATED column constraint that shapes normalization, the `*_display_name` sibling pattern (~20 columns across 13 tables). Input to Data Integrity Tier 4b — see [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408).

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,22 @@
+# Audits
+
+Long-form enumerations of subsystem state produced by focused audit sessions. Each audit is **read-only knowledge, not shipping code** — it inventories write sites, consumers, derived columns, and bugs across a specific codebase area so a later implementation PR has complete context.
+
+When to add to this directory:
+
+- A refactor's precondition is "know every place X is touched" and the answer is >10 sites
+- An architectural decision depends on enumerating a constraint across many files
+- A future implementer needs to be able to re-verify completeness with `rg` — the audit ends with the exact grep commands that reproduce its conclusions
+
+Each audit should link back to the Linear ticket that scoped it and forward to the ticket(s) it blocks or informs.
+
+## Current audits
+
+| File | Scope | Status | Linear |
+|---|---|---|---|
+| [`things-denormalization-audit.md`](./things-denormalization-audit.md) | Every write site and consumer of `things.title` / `things.description` / `things.parent_title`, plus the `*_display_name` sibling pattern across 13 tables. Precondition for eliminating write-time denormalization. | Complete 2026-04-13 | [QUA-414](https://linear.app/quantifieduncertainty/issue/QUA-414) / [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) Tier 4b |
+
+## Related rules files
+
+- `.claude/rules/entity-sync-pipeline.md` — sync handler infrastructure (points here for `things` write paths)
+- `.claude/rules/three-bases-architecture.md` — TableBase/FactBase/WikiBase ontology (points here for `things` cross-base index)


### PR DESCRIPTION
## Summary

The `docs/audits/things-denormalization-audit.md` file that landed in #4301 has **zero inbound links**. Future agents touching `things.title` / `things.description` / `things.parent_title` would have no reason to find it.

Three overlapping pointer locations so at least one path succeeds, plus an index file:

1. **`CLAUDE.md`** — added to the "Subsystem Maps" list loaded at every session start
2. **`.claude/rules/entity-sync-pipeline.md`** — callout at top of a file agents already read when writing sync handlers
3. **`.claude/rules/three-bases-architecture.md`** — pointer at top of the ontology reference for the cross-base `things` index
4. **`docs/audits/README.md`** (new) — directory index explaining the audit category, lists current audits, links back

Also: propagated the 4 key audit findings into Linear comments on **QUA-408** (scope expansion, `search_vector` hard constraint, 22-vs-20 write-site count, 5 latent-leak handlers), **QUA-415** (backfill partially subsumed by Tier 4b), and **QUA-407** (canonical-ID migration is parallel-safe with Tier 4b).

## Why this matters

During the QUA-397 / QUA-408 session the user raised a legitimate concern: *"how do we make sure the file from this is noticed by future Agents? I'm nervous it will be forgotten."* The audit is 324 lines of genuinely load-bearing enumeration (22 write sites, the `GENERATED ALWAYS` constraint on `search_vector`, the `*_display_name` sibling pattern). Losing it would force Phase 4b-B to re-discover from scratch.

## Test plan

- [x] Docs-only diff (4 files, 27 insertions, 0 deletions) — no build/test impact
- [x] Audit file path used in all 4 new references matches the real filename
- [x] Each pointer phrases the trigger condition (when would an agent need this file?) rather than just linking
- [x] Linear comments posted on QUA-408 / QUA-415 / QUA-407 summarize the 4 findings so the user doesn't have to remember them

Fixes QUA-414 (followup — original audit shipped in #4301)
