### PR TITLE
fix(sourcing): replace unsafe regex table-name fallback with allowlist (QUA-420)

### DIFF
--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/page.tsx
@@ -22,6 +22,7 @@ import { inferDataSource } from "@/app/grants/grants-data-source";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
 
 import { canonicalizeSourcingRecordType } from "./canonicalize-record-type";
+import { recordTypeToTable } from "@/lib/sourcing/record-type-table-map";
 
 export const revalidate = 3600;
 export const dynamicParams = true;
@@ -258,15 +259,13 @@ export default async function SourcingDetailPage({ params }: PageProps) {
     permanentRedirect(`/sourcing/${canonicalType}/${encodeURIComponent(recordId)}`);
   }
 
-  // Map recordType back to source table name for record-lookup API
-  const RECORD_TYPE_TO_TABLE: Record<string, string> = {
-    grant: "grants", personnel: "personnel", division: "divisions",
-    investment: "investments", "funding-round": "funding_rounds",
-    "funding-program": "funding_programs", publication: "publications",
-    "wiki-page": "wiki_pages", "policy-stakeholder": "policy_stakeholders",
-    citation: "citation_quotes",
-  };
-  const sourceTable = RECORD_TYPE_TO_TABLE[recordType] ?? recordType.replace(/-/g, "_") + "s";
+  // QUA-420: only hit record-lookup for types with a known table. The old
+  // regex fallback (`recordType.replace(/-/g, "_") + "s"`) produced garbage
+  // names like `entity_s` and `fact_s`.
+  const sourceTable = recordTypeToTable(recordType);
+  if (!sourceTable) {
+    notFound();
+  }
 
   // Fetch detail (verdicts + evidence), names, and the actual DB record in parallel
   const [detailResult, namesResult, recordResult] = await Promise.all([

--- a/apps/web/src/lib/sourcing/record-type-table-map.test.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  RECORD_TYPE_TO_TABLE,
+  recordTypeToTable,
+} from "./record-type-table-map";
+import {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+} from "@wiki-server/api-types";
+
+describe("recordTypeToTable", () => {
+  it("maps known recordType to table name", () => {
+    expect(recordTypeToTable("grant")).toBe("grants");
+    expect(recordTypeToTable("funding-round")).toBe("funding_rounds");
+    expect(recordTypeToTable("policy-stakeholder")).toBe("policy_stakeholders");
+    expect(recordTypeToTable("fact")).toBe("facts");
+  });
+
+  it("returns null for unknown recordType (no regex fallback)", () => {
+    // QUA-420 regression: these previously returned garbage like "entity_s"
+    expect(recordTypeToTable("entity")).toBeNull();
+    expect(recordTypeToTable("race")).toBeNull();
+    expect(recordTypeToTable("race-candidate")).toBeNull();
+    expect(recordTypeToTable("unknown-garbage")).toBeNull();
+    expect(recordTypeToTable("")).toBeNull();
+  });
+
+  it("covers every non-exempt VALID_RECORD_TYPES entry", () => {
+    // secondary-market-price is exempt and has no record-lookup table; everything
+    // else in VALID_RECORD_TYPES must have a mapping.
+    const exempt = new Set<string>([...SOURCING_EXEMPT_TYPES]);
+    const missing: string[] = [];
+    for (const t of VALID_RECORD_TYPES) {
+      if (exempt.has(t)) continue;
+      if (!(t in RECORD_TYPE_TO_TABLE)) missing.push(t);
+    }
+    expect(missing, `Missing RECORD_TYPE_TO_TABLE entries: ${missing.join(", ")}`).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/sourcing/record-type-table-map.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.ts
@@ -1,0 +1,36 @@
+/**
+ * Maps a sourcing `recordType` (e.g. "funding-round") to the wiki-server
+ * record-lookup source table name (e.g. "funding_rounds").
+ *
+ * Centralized here so callers don't guess the table name via regex
+ * (QUA-420 — `recordType.replace(/-/g, "_") + "s"` generated garbage like
+ * `entity_s`, `fact_s`, `race_s`).
+ *
+ * Keep in sync with `VALID_RECORD_TYPES` in `apps/wiki-server/src/api-types.ts`
+ * and `VALID_SOURCE_TABLES` in `apps/wiki-server/src/routes/tablebase/record-lookup.ts`.
+ */
+
+export const RECORD_TYPE_TO_TABLE = {
+  grant: "grants",
+  personnel: "personnel",
+  division: "divisions",
+  "funding-program": "funding_programs",
+  "funding-round": "funding_rounds",
+  investment: "investments",
+  "equity-position": "equity_positions",
+  "policy-stakeholder": "policy_stakeholders",
+  publication: "publications",
+  "benchmark-result": "benchmark_results",
+  "entity-event": "entity_events",
+  "entity-assessment": "entity_assessments",
+  citation: "citation_quotes",
+  "wiki-page": "wiki_pages",
+  fact: "facts",
+} as const satisfies Record<string, string>;
+
+export type KnownRecordType = keyof typeof RECORD_TYPE_TO_TABLE;
+
+/** Returns the source table name for a known recordType, or null otherwise. */
+export function recordTypeToTable(recordType: string): string | null {
+  return (RECORD_TYPE_TO_TABLE as Record<string, string>)[recordType] ?? null;
+}


### PR DESCRIPTION
## Summary

Fixes QUA-420. The sourcing detail page generated garbage source-table names via `recordType.replace(/-/g, "_") + "s"` for any type not already in its local map: `entity` → `entity_s`, `fact` → `fact_s`, `race` → `race_s`. These were passed to `/api/record-lookup/<table>/<id>`, producing opaque failures instead of a clean 404.

## Fix

- Extract the mapping into `apps/web/src/lib/sourcing/record-type-table-map.ts` as a closed allowlist. `recordTypeToTable()` returns the table name or `null` — no regex guessing.
- `sourcing/[recordType]/[recordId]/page.tsx`: unknown type → `notFound()` directly. Allowlist covers every non-exempt `VALID_RECORD_TYPES` entry.

## Tests

Unit test asserts known types map, unknown types return null (regression on the `_s`-suffix garbage), and every non-exempt `VALID_RECORD_TYPES` has an entry.

## Test plan

- [x] `vitest run src/lib/sourcing/` — 3 passing
- [x] `tsc --noEmit` clean

## Follow-up

QUA-408 Phase 4 — when `VALID_RECORD_TYPES` is extracted into a shared package, the allowlist becomes `Record<RecordType, string>` with compile-time exhaustiveness.
