### PR TITLE
fix(build): retry + fail-fast in fetchRecordVerdicts (QUA-421)

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-record-verdicts.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-record-verdicts.test.mjs
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchRecordVerdicts } from "../wiki-server-data.mjs";
+
+const origEnv = { ...process.env };
+const origFetch = global.fetch;
+const origSetTimeout = global.setTimeout;
+
+function mockResponse(status, body) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+describe("fetchRecordVerdicts (QUA-421)", () => {
+  beforeEach(() => {
+    process.env.LONGTERMWIKI_SERVER_URL = "http://wiki.example";
+    process.env.STRICT_VERDICTS = "1";
+    // Fire-and-forget: skip real backoff delays
+    global.setTimeout = ((cb, _ms) => {
+      Promise.resolve().then(cb);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    global.setTimeout = origSetTimeout;
+    global.fetch = origFetch;
+    process.env = { ...origEnv };
+  });
+
+  it("builds verdict map from paginated results", async () => {
+    const pages = [
+      {
+        verdicts: Array.from({ length: 200 }, (_, i) => ({
+          recordType: "grant",
+          recordId: `g${i}`,
+          verdict: "confirmed",
+        })),
+      },
+      {
+        verdicts: [
+          { recordType: "grant", recordId: "final", verdict: "contradicted" },
+        ],
+      },
+    ];
+    let call = 0;
+    global.fetch = vi.fn(() => mockResponse(200, pages[call++]));
+
+    const result = await fetchRecordVerdicts();
+    expect(Object.keys(result)).toHaveLength(201);
+    expect(result["grant:final"].verdict).toBe("contradicted");
+  });
+
+  it("retries on transient 500 then succeeds", async () => {
+    let n = 0;
+    global.fetch = vi.fn(() => {
+      n++;
+      if (n < 3) return mockResponse(500, {});
+      return mockResponse(200, { verdicts: [] });
+    });
+
+    const result = await fetchRecordVerdicts();
+    expect(result).toEqual({});
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws in strict mode after all retries fail (does NOT silently return {})", async () => {
+    global.fetch = vi.fn(() => mockResponse(500, {}));
+    await expect(fetchRecordVerdicts()).rejects.toThrow(/fetchRecordVerdicts failed/);
+  });
+
+  it("returns partial collected results when STRICT_VERDICTS=0", async () => {
+    process.env.STRICT_VERDICTS = "0";
+    let call = 0;
+    global.fetch = vi.fn(() => {
+      call++;
+      if (call === 1) {
+        return mockResponse(200, {
+          verdicts: Array.from({ length: 200 }, (_, i) => ({
+            recordType: "grant",
+            recordId: `g${i}`,
+            verdict: "confirmed",
+          })),
+        });
+      }
+      // Persistent 500 on page 2 — all retries fail
+      return mockResponse(500, {});
+    });
+
+    const result = await fetchRecordVerdicts();
+    expect(Object.keys(result)).toHaveLength(200);
+    expect(result["grant:g0"].verdict).toBe("confirmed");
+  });
+
+  it("returns {} when LONGTERMWIKI_SERVER_URL is unset", async () => {
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    const result = await fetchRecordVerdicts();
+    expect(result).toEqual({});
+  });
+});

--- a/apps/web/scripts/lib/__tests__/fetch-record-verdicts.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-record-verdicts.test.mjs
@@ -99,4 +99,13 @@ describe("fetchRecordVerdicts (QUA-421)", () => {
     const result = await fetchRecordVerdicts();
     expect(result).toEqual({});
   });
+
+  it("CI=true forces strict mode even when STRICT_VERDICTS=0", async () => {
+    // Defends against a leaked STRICT_VERDICTS=0 env var silently shipping
+    // an empty verdict map from a CI build.
+    process.env.CI = "true";
+    process.env.STRICT_VERDICTS = "0";
+    global.fetch = vi.fn(() => mockResponse(500, {}));
+    await expect(fetchRecordVerdicts()).rejects.toThrow(/fetchRecordVerdicts failed/);
+  });
 });

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -562,8 +562,37 @@ export async function fetchResearchAreaDetails(areaIds) {
 }
 
 /**
+ * Fetch a single page of record verdicts with retry + backoff. Throws on
+ * exhaustion so the caller can decide whether partial data is acceptable.
+ */
+async function fetchVerdictPage(serverUrl, headers, offset, pageSize) {
+  const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
+  const delaysMs = [0, 1000, 2000, 4000]; // 4 attempts with backoff
+  let lastError = null;
+  for (const delay of delaysMs) {
+    if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+    try {
+      const resp = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
+      if (resp.ok) return await resp.json();
+      lastError = new Error(`HTTP ${resp.status}`);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  throw lastError ?? new Error('fetchVerdictPage: unknown error');
+}
+
+/**
  * Fetch verification verdicts from wiki-server (unified verification system).
  * Returns a map keyed by "recordType:recordId" -> verdict info.
+ *
+ * QUA-421: previously returned `{}` silently on any error mid-pagination,
+ * which zeroed record-verdicts.json and made every source-check dot render
+ * as "unchecked" until the next successful build. Now:
+ *   - retries each page up to 4 attempts (backoff 1s/2s/4s)
+ *   - throws on persistent failure rather than silently returning `{}`
+ *   - `STRICT_VERDICTS=0` opts out locally (treat errors as warning, return
+ *     whatever was collected); any other value (default) is strict
  */
 export async function fetchRecordVerdicts() {
   const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
@@ -573,19 +602,14 @@ export async function fetchRecordVerdicts() {
   }
 
   const headers = buildHeaders();
+  const strict = process.env.STRICT_VERDICTS !== '0';
+  const pageSize = 200;
+  const verdicts = {};
+  let offset = 0;
 
   try {
-    const pageSize = 200;
-    const verdicts = {};
-    let offset = 0;
     while (true) {
-      const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
-      if (!resp.ok) {
-        logWikiServerWarning('record-verdicts', `HTTP ${resp.status}`);
-        return {};
-      }
-      const data = await resp.json();
+      const data = await fetchVerdictPage(serverUrl, headers, offset, pageSize);
       const items = data.verdicts || [];
       for (const v of items) {
         const entry = {
@@ -606,18 +630,29 @@ export async function fetchRecordVerdicts() {
       if (items.length < pageSize) break;
       offset += pageSize;
     }
-
-    const count = Object.keys(verdicts).length;
-    if (count > 0) {
-      console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
-    } else {
-      console.log('  record-verdicts: 0 verdicts (none computed yet)');
-    }
-    return verdicts;
   } catch (err) {
-    logWikiServerWarning('record-verdicts', err instanceof Error ? err.message : String(err));
-    return {};
+    const msg = err instanceof Error ? err.message : String(err);
+    const collected = Object.keys(verdicts).length;
+    if (strict) {
+      throw new Error(
+        `fetchRecordVerdicts failed after retries at offset=${offset} (${collected} verdicts collected): ${msg}. ` +
+          `Set STRICT_VERDICTS=0 to continue with partial data in local dev.`
+      );
+    }
+    logWikiServerWarning(
+      'record-verdicts',
+      `${msg} at offset=${offset}; returning ${collected} partial verdicts (STRICT_VERDICTS=0)`
+    );
+    return verdicts;
   }
+
+  const count = Object.keys(verdicts).length;
+  if (count > 0) {
+    console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
+  } else {
+    console.log('  record-verdicts: 0 verdicts (none computed yet)');
+  }
+  return verdicts;
 }
 
 /**

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -602,7 +602,9 @@ export async function fetchRecordVerdicts() {
   }
 
   const headers = buildHeaders();
-  const strict = process.env.STRICT_VERDICTS !== '0';
+  // CI is always strict — STRICT_VERDICTS=0 cannot opt-out of strict mode
+  // in CI so a leaked env var can't quietly ship an empty verdict map.
+  const strict = process.env.CI === 'true' || process.env.STRICT_VERDICTS !== '0';
   const pageSize = 200;
   const verdicts = {};
   let offset = 0;


### PR DESCRIPTION
## Summary

Fixes QUA-421. `fetchRecordVerdicts` in `apps/web/scripts/lib/wiki-server-data.mjs` silently returned `{}` on any HTTP error mid-pagination, zeroing `apps/web/src/data/record-verdicts.json`. The frontend then rendered every source-check dot as "unchecked" until the next successful build. Logged only as a warning — a high-severity sleeper bug.

## Fix

- Per-page retry with exponential backoff (4 attempts, 0s / 1s / 2s / 4s).
- Strict by default: persistent failures now **throw** with an error message including the offset and the count of verdicts already collected. Build fails loudly instead of shipping empty data.
- `STRICT_VERDICTS=0` opts out locally for dev — returns partial results with a warning.
- Preserves partial results across the catch boundary (the prior version discarded every collected page on the first error).

## Tests

New vitest suite (`scripts/lib/__tests__/fetch-record-verdicts.test.mjs`, 5 tests, ~6ms):

- paginated happy path builds the full map
- transient 500 → retry → success
- strict-mode throws on retry exhaustion (regression: does NOT silently return `{}`)
- `STRICT_VERDICTS=0` returns partial collected data
- missing `LONGTERMWIKI_SERVER_URL` → no-op `{}` unchanged

Backoff delays are mocked via a fake `setTimeout` so the suite runs fast.

## Test plan

- [x] `vitest run scripts/lib/__tests__/fetch-record-verdicts.test.mjs` — 5 passing
