### PR TITLE
fix(sourcing): use sourcing terminology in UncheckedSourcingState

### DIFF
--- a/apps/web/src/components/sourcing/UncheckedSourcingState.test.tsx
+++ b/apps/web/src/components/sourcing/UncheckedSourcingState.test.tsx
@@ -16,8 +16,8 @@ describe("UncheckedSourcingState", () => {
 
     expect(screen.getByText("Anthropic Overview")).toBeInTheDocument();
     expect(screen.getByText("page:anthropic:overview")).toBeInTheDocument();
-    expect(screen.getByText(/Not yet source-checked/i)).toBeInTheDocument();
-    expect(screen.getByText(/has not been run through the source-check pipeline/i)).toBeInTheDocument();
+    expect(screen.getByText(/Not yet sourced/i)).toBeInTheDocument();
+    expect(screen.getByText(/has not been run through the sourcing pipeline/i)).toBeInTheDocument();
   });
 
   it("renders View the record link when recordHref is provided", () => {

--- a/apps/web/src/components/sourcing/UncheckedSourcingState.tsx
+++ b/apps/web/src/components/sourcing/UncheckedSourcingState.tsx
@@ -38,10 +38,10 @@ export function UncheckedSourcingState({
         <div className="flex items-start gap-3">
           <CircleHelp className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
           <div className="space-y-2 text-sm">
-            <p className="font-medium">Not yet source-checked</p>
+            <p className="font-medium">Not yet sourced</p>
             <p className="text-muted-foreground">
               This record exists in the database but has not been run through
-              the source-check pipeline yet. Once checked, this page will show
+              the sourcing pipeline yet. Once sourced, this page will show
               per-source verdicts, evidence, and links to the sources used.
             </p>
             {recordHref && (


### PR DESCRIPTION
## Summary

Fixes the main branch CI failure from run #24372982794.

**Root cause**: PR #4306 added `UncheckedSourcingState.tsx` with legacy `source-check` terminology in two places:
- `"Not yet source-checked"` (heading)
- `"source-check pipeline"` (description)

This pushed the sourcing lint guard ratchet from baseline 1 to 3, causing the `validate-sourcing-lint-guard.test.ts` assertion to fail on main.

**Fix**: Replace the two occurrences with `sourcing` terminology per the ongoing QUA-102 rename:
- `"Not yet source-checked"` → `"Not yet sourced"`
- `"source-check pipeline"` → `"sourcing pipeline"`

Also updates the test assertions to match the new text.

## Verification

```
At baseline (1 references across 1467 files)
```

The validator confirms we're back at the frozen baseline of 1 (the remaining `sourceCheckedAt` Drizzle binding per QUA-303).