### PR TITLE
fix(ci): wire PROD_LONGTERMWIKI_* to unprefixed repo secrets (QUA-396)

### DIFF
--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -49,8 +49,9 @@ jobs:
         env:
           WIKI_SERVER_ENV: prod
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.PROD_LONGTERMWIKI_SERVER_URL }}
-          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-396: repo secrets are unprefixed — no PROD_ variant exists.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
 
       # Run all validators via the unified daily runner.
       # WIKI_SERVER_ENV=prod causes validators to read PROD_LONGTERMWIKI_*
@@ -59,6 +60,7 @@ jobs:
         id: validate
         env:
           WIKI_SERVER_ENV: prod
-          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.PROD_LONGTERMWIKI_SERVER_URL }}
-          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-396: repo secrets are unprefixed — no PROD_ variant exists.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
         run: npx tsx crux/validate/validate-daily.ts --ci

--- a/.github/workflows/flagship-curate.yml
+++ b/.github/workflows/flagship-curate.yml
@@ -64,8 +64,9 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.PROD_LONGTERMWIKI_SERVER_URL }}
-      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
+      # QUA-396: repo secrets are unprefixed — no PROD_ variant exists.
+      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       # Assign inputs to env vars to avoid shell injection (GH Actions best practice)
       INPUT_LIMIT: ${{ inputs.limit || '5' }}
       INPUT_BUDGET: ${{ inputs.budget || '10' }}

--- a/.github/workflows/sourcing-recheck.yml
+++ b/.github/workflows/sourcing-recheck.yml
@@ -49,8 +49,9 @@ jobs:
     env:
       WIKI_SERVER_ENV: prod
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.PROD_LONGTERMWIKI_SERVER_URL }}
-      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
+      # QUA-396: repo secrets are unprefixed — no PROD_ variant exists.
+      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
       INPUT_BUDGET: ${{ inputs.budget || '15' }}

--- a/.github/workflows/sourcing.yml
+++ b/.github/workflows/sourcing.yml
@@ -48,8 +48,9 @@ jobs:
     env:
       WIKI_SERVER_ENV: prod
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.PROD_LONGTERMWIKI_SERVER_URL }}
-      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.PROD_LONGTERMWIKI_SERVER_API_KEY }}
+      # QUA-396: repo secrets are unprefixed — no PROD_ variant exists.
+      PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+      PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
       INPUT_BUDGET: ${{ inputs.budget || '50' }}


### PR DESCRIPTION
## Summary

Fixes QUA-396. Four workflows referenced `secrets.PROD_LONGTERMWIKI_SERVER_URL` and `secrets.PROD_LONGTERMWIKI_SERVER_API_KEY`, but the repo secrets are unprefixed — `gh secret list` shows only `LONGTERMWIKI_SERVER_URL` and `LONGTERMWIKI_SERVER_API_KEY`. GitHub silently substitutes empty strings for missing secrets, so every dispatched run of these workflows has been a silent no-op (or a hard-fail, depending on the command's error path) for possibly weeks.

Exposed by the 2026-04-13 #2 post-deploy verification, where `sourcing-recheck` hard-failed (the new strict code path from QUA-380) and `flagship-curate` reported `success` while silently processing zero entities.

## Affected workflows

- `.github/workflows/data-validation.yml` (2 sites)
- `.github/workflows/flagship-curate.yml`
- `.github/workflows/sourcing-recheck.yml`
- `.github/workflows/sourcing.yml`

## Fix

Map the existing repo secrets to the expected env var names (Option 1 from the ticket). `WIKI_SERVER_ENV=prod` stays, so crux still reads `PROD_LONGTERMWIKI_*` at runtime.

## Follow-up

Option 4 — hardening `crux/commands/flagship-curate.ts` against the `unavailable` error path so future config drift fails loudly — is a larger scope and will go in a separate PR.

## Test plan

Verification requires manual dispatch after merge (the secret mapping is the thing under test and can only be validated post-merge in CI):

- [x] `gh secret list -R quantified-uncertainty/longterm-wiki` confirmed only unprefixed secrets exist
- [ ] Post-merge: `gh workflow run sourcing-recheck.yml -f dry_run=true` and expect a clean run
- [ ] Post-merge: `gh workflow run flagship-curate.yml` with defaults and expect non-zero entities considered
