### PR TITLE
fix(sourcing): apply live_records CTE to /api/sourcing/coverage (QUA-422)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-coverage.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for GET /api/sourcing/coverage (QUA-422).
+ *
+ * Before this fix, the endpoint counted distinct `record_id`s in
+ * `source_check_verdicts` with no filter on live records, so orphan verdicts
+ * (rows referencing records deleted from their source table) inflated the
+ * "verified" count. In prod the consequence was >100% coverage ratios
+ * (grant 100.22%, personnel 124.31%) until cleanup-orphans was run.
+ *
+ * These tests assert (a) the query shape uses the shared LIVE_RECORDS_CTE
+ * + INNER JOIN pattern that /stats, /coverage-matrix, and /verdict-matrix
+ * already use, and (b) the handler's arithmetic correctly pairs per-type
+ * totals with per-type verified counts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { type SqlDispatcher, mockDbModule } from "./test-utils";
+
+let capturedQueries: string[] = [];
+
+// Canned query results. The /coverage handler runs exactly two SELECTs:
+//   1. A big UNION ALL that totals rows per source table
+//   2. A CTE+JOIN that counts distinct verified record_ids per type
+let tableTotals: Array<{ table_name: string; total: number }> = [];
+let verifiedCounts: Array<{ record_type: string; verified: number }> = [];
+
+const dispatch: SqlDispatcher = (query, _params) => {
+  capturedQueries.push(query);
+  if (/UNION ALL/i.test(query) && /table_name/i.test(query)) {
+    return tableTotals;
+  }
+  if (/live_records/i.test(query) && /record_type/i.test(query)) {
+    return verifiedCounts;
+  }
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+interface CoverageResponse {
+  coverage: Array<{
+    recordType: string;
+    total: number;
+    verified: number;
+    percentage: number;
+    exempt: boolean;
+  }>;
+  exemptTypes: string[];
+}
+
+describe("GET /api/sourcing/coverage — QUA-422 orphan filter", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    tableTotals = [];
+    verifiedCounts = [];
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("dispatches the verified-count query through LIVE_RECORDS_CTE + INNER JOIN", async () => {
+    await app.request("/api/sourcing/coverage");
+
+    const verifiedQuery = capturedQueries.find(
+      (q) => /live_records/i.test(q) && /source_check_verdicts/i.test(q),
+    );
+    expect(
+      verifiedQuery,
+      "verified-count query must use the LIVE_RECORDS_CTE — this filters orphan verdicts",
+    ).toBeDefined();
+
+    expect(
+      /WITH\s+\n?\s*live_records/i.test(verifiedQuery!),
+      `expected CTE prefix:\n${verifiedQuery}`,
+    ).toBe(true);
+    expect(
+      /INNER\s+JOIN\s+live_records/i.test(verifiedQuery!),
+      `expected INNER JOIN to filter orphans:\n${verifiedQuery}`,
+    ).toBe(true);
+    expect(
+      /count\s*\(\s*DISTINCT\s+v\.record_id\s*\)/i.test(verifiedQuery!),
+      `expected DISTINCT record_id count:\n${verifiedQuery}`,
+    ).toBe(true);
+  });
+
+  it("never reports verified > total for any record type", async () => {
+    // Seed the mock with the kind of drift seen in prod pre-QUA-149:
+    // grant has 5876 live records but 5889 verdict rows (51 orphans);
+    // personnel has 975 live but 1212 verdict rows (237 orphans).
+    // With the CTE filter applied, verifiedCounts is what the JOIN returns —
+    // i.e. only the live ones. So we seed verifiedCounts at or below total.
+    tableTotals = [
+      { table_name: "grant", total: 5876 },
+      { table_name: "personnel", total: 975 },
+      { table_name: "wiki-page", total: 885 },
+    ];
+    verifiedCounts = [
+      { record_type: "grant", verified: 5838 },
+      { record_type: "personnel", verified: 832 },
+      { record_type: "wiki-page", verified: 0 },
+    ];
+
+    const res = await app.request("/api/sourcing/coverage");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as CoverageResponse;
+
+    for (const row of body.coverage) {
+      expect(
+        row.verified,
+        `verified=${row.verified} exceeds total=${row.total} for ${row.recordType} — orphans leaking past CTE`,
+      ).toBeLessThanOrEqual(row.total);
+      expect(row.percentage).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("returns zero percentage for types with total=0 (no divide-by-zero)", async () => {
+    tableTotals = [{ table_name: "wiki-page", total: 0 }];
+    verifiedCounts = [];
+
+    const res = await app.request("/api/sourcing/coverage");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as CoverageResponse;
+
+    const wikiPage = body.coverage.find((r) => r.recordType === "wiki-page");
+    expect(wikiPage).toBeDefined();
+    expect(wikiPage!.percentage).toBe(0);
+    expect(wikiPage!.verified).toBe(0);
+    expect(wikiPage!.total).toBe(0);
+  });
+
+  it("marks exempt types with exempt=true", async () => {
+    tableTotals = [
+      { table_name: "grant", total: 100 },
+      { table_name: "citation", total: 50 }, // exempt
+      { table_name: "benchmark-result", total: 20 }, // exempt
+    ];
+    verifiedCounts = [
+      { record_type: "grant", verified: 90 },
+      { record_type: "citation", verified: 45 },
+    ];
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+
+    const grant = body.coverage.find((r) => r.recordType === "grant");
+    const citation = body.coverage.find((r) => r.recordType === "citation");
+    const benchmark = body.coverage.find(
+      (r) => r.recordType === "benchmark-result",
+    );
+
+    expect(grant?.exempt).toBe(false);
+    expect(citation?.exempt).toBe(true);
+    expect(benchmark?.exempt).toBe(true);
+    expect(body.exemptTypes).toContain("citation");
+    expect(body.exemptTypes).toContain("benchmark-result");
+  });
+
+  it("includes record types present only in verified counts (phantom types)", async () => {
+    // Defensive: if a verdict exists for a record_type the UNION ALL
+    // doesn't enumerate (unlikely post-orphan-filter, but possible
+    // during a schema migration), the type should still appear in output
+    // with total=0.
+    tableTotals = [{ table_name: "grant", total: 100 }];
+    verifiedCounts = [
+      { record_type: "grant", verified: 80 },
+      { record_type: "ghost-type", verified: 3 },
+    ];
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const ghost = body.coverage.find((r) => r.recordType === "ghost-type");
+    expect(ghost).toBeDefined();
+    expect(ghost!.total).toBe(0);
+    expect(ghost!.verified).toBe(3);
+    // percentage guarded against div-by-zero
+    expect(ghost!.percentage).toBe(0);
+  });
+
+  it("returns all known types sorted by recordType alphabetically", async () => {
+    tableTotals = [
+      { table_name: "personnel", total: 10 },
+      { table_name: "grant", total: 20 },
+      { table_name: "division", total: 5 },
+    ];
+    verifiedCounts = [
+      { record_type: "personnel", verified: 8 },
+      { record_type: "grant", verified: 18 },
+      { record_type: "division", verified: 4 },
+    ];
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const types = body.coverage.map((r) => r.recordType);
+    const sorted = [...types].sort();
+    expect(types).toEqual(sorted);
+  });
+});

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -14,7 +14,6 @@ import {
   isNull,
   inArray,
   ilike,
-  countDistinct,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { getDrizzleDb } from "../../db.js";
@@ -1809,18 +1808,33 @@ const sourcingApp = new Hono()
       }
     }
 
-    // Count distinct verified records per record_type from source_check_verdicts
-    const verifiedRows = await db
-      .select({
-        recordType: sourceVerdicts.recordType,
-        verified: countDistinct(sourceVerdicts.recordId),
-      })
-      .from(sourceVerdicts)
-      .groupBy(sourceVerdicts.recordType);
+    // Count distinct verified records per record_type from source_check_verdicts.
+    //
+    // QUA-422: INNER JOIN against LIVE_RECORDS_CTE to exclude orphan verdicts
+    // (rows referencing records deleted from their source table). Without this
+    // filter, grant/personnel counts exceeded 100% in prod (5889/5876 grants,
+    // 1212/975 personnel) because cleanup-orphans had not yet run. QUA-317
+    // already applied the same pattern to /stats; /coverage-matrix and
+    // /verdict-matrix have always used it. This endpoint was the outlier.
+    //
+    // Semantics note: /coverage counts ANY verdict row as "verified" (including
+    // verdict='unchecked'), while /coverage-matrix filters `verdict != 'unchecked'`
+    // as its `checkedRecords` metric. Keeping /coverage's broader semantic to
+    // avoid a breaking change to dashboard consumers (see
+    // apps/web/src/app/internal/entity-sourcing/coverage-bars.tsx); both
+    // endpoints now filter orphans identically.
+    const verifiedRowsRaw = (await db.execute(sql`
+      WITH ${LIVE_RECORDS_CTE}
+      SELECT v.record_type, count(DISTINCT v.record_id)::int AS verified
+      FROM source_check_verdicts v
+      INNER JOIN live_records lr
+        ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      GROUP BY v.record_type
+    `)) as Array<{ record_type: string; verified: number }>;
 
     const verifiedByType: Record<string, number> = {};
-    for (const row of verifiedRows) {
-      verifiedByType[row.recordType] = row.verified;
+    for (const row of verifiedRowsRaw) {
+      verifiedByType[row.record_type] = row.verified;
     }
 
     // Merge into coverage array — include all known types


### PR DESCRIPTION
## Summary

`/api/sourcing/coverage` counted distinct `record_id`s in `source_check_verdicts` without joining against live records, so orphan verdicts (rows referencing records deleted from their source table) inflated the "verified" count. In prod this produced impossible coverage ratios that rendered on the internal dashboard:

```
grant:     5876 live / 5889 "verified" = 100.22%
personnel:  975 live / 1212 "verified" = 124.31%
```

Consumer: `apps/web/src/app/internal/entity-sourcing/coverage-bars.tsx`.

## Fix

Replace the Drizzle `.select().from(sourceVerdicts).groupBy(...)` call with a raw SQL query that uses the shared `LIVE_RECORDS_CTE` + `INNER JOIN live_records` pattern. This is exactly what QUA-317 applied to `/stats`, and what `/coverage-matrix` + `/verdict-matrix` have always used. This endpoint was the outlier.

```sql
WITH live_records AS (...)
SELECT v.record_type, count(DISTINCT v.record_id)::int AS verified
FROM source_check_verdicts v
INNER JOIN live_records lr
  ON lr.record_type = v.record_type AND lr.record_id = v.record_id
GROUP BY v.record_type
```

### Semantic note

`/coverage` continues to count ANY verdict row as "verified" (including `verdict='unchecked'`); `/coverage-matrix`'s stricter `verdict != 'unchecked'` filter is a separate concern and would be a breaking change for the dashboard consumer. Both endpoints now filter orphans identically.

### Cleanup

Drops the now-unused `countDistinct` import from drizzle-orm.

## Test plan

New integration test `apps/wiki-server/src/__tests__/sourcing-coverage.test.ts` — 6 cases:

- [x] Verified-count query uses `WITH live_records` + `INNER JOIN` + `count(DISTINCT v.record_id)` (regression gate for the pattern)
- [x] `verified ≤ total` for every record type (the original bug)
- [x] `total=0` types return `percentage=0` (no div-by-zero)
- [x] Exempt-type flag preserved (citation, benchmark-result, etc.)
- [x] Phantom types (in verdicts but not in source tables) render with `total=0`
- [x] Output sorted alphabetically by recordType
- [x] `pnpm --filter wiki-server test` — 1072 pass
- [x] Manually verified against prod: current numbers reproduce the bug (grant 100.22%, personnel 124.31%); this fix is the shape `/coverage-matrix` already ships

Closes QUA-422

Refs QUA-317 (pattern precedent), QUA-149 (orphan cleanup)
