### PR TITLE
fix(ci): add --pr=<N> flag to crux gh ci status (QUA-410)

### DIFF
--- a/crux/ci/ci-status.ts
+++ b/crux/ci/ci-status.ts
@@ -7,6 +7,7 @@
  *   crux ci status              Show current check-run status
  *   crux ci status --wait       Poll every 30s until all checks complete
  *   crux ci status --sha=abc    Check a specific commit SHA
+ *   crux ci status --pr=NNN     Check PR NNN's current head SHA (fresh, not cached)
  *
  * Requires GITHUB_TOKEN environment variable.
  */
@@ -14,11 +15,13 @@
 import { execSync } from 'child_process';
 import { getColors } from '../lib/output.ts';
 import { githubApi, REPO } from '../lib/github.ts';
+import { resolvePrHeadSha } from './resolve-pr-head.ts';
 
 const args: string[] = process.argv.slice(2);
 const WAIT_MODE: boolean = args.includes('--wait');
 const CI_MODE: boolean = args.includes('--ci') || process.env.CI === 'true';
 const SHA_ARG = args.find((a) => a.startsWith('--sha='))?.split('=')[1];
+const PR_ARG = args.find((a) => a.startsWith('--pr='))?.split('=')[1];
 const POLL_INTERVAL = 30_000; // 30 seconds
 const MAX_POLLS = 40; // 20 minutes max
 
@@ -39,8 +42,9 @@ interface CheckRunsResponse {
   }>;
 }
 
-function getSha(): string {
+async function getSha(): Promise<string> {
   if (SHA_ARG) return SHA_ARG;
+  if (PR_ARG) return await resolvePrHeadSha(PR_ARG);
   return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
 }
 
@@ -116,9 +120,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  const sha = getSha();
-
   if (!WAIT_MODE) {
+    const sha = await getSha();
     const data = await fetchCheckRuns(sha);
     const { anyFailed } = printStatus(data, sha);
     process.exit(anyFailed ? 1 : 0);
@@ -137,6 +140,9 @@ async function main(): Promise<void> {
       await sleep(POLL_INTERVAL);
     }
 
+    // QUA-410: re-resolve SHA each poll so --pr=N tracks head movement
+    // (rebases, new merges into main) between polls.
+    const sha = await getSha();
     const data = await fetchCheckRuns(sha);
     const { allDone, anyFailed } = printStatus(data, sha);
 

--- a/crux/ci/resolve-pr-head.test.ts
+++ b/crux/ci/resolve-pr-head.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolvePrHeadSha } from "./resolve-pr-head.ts";
+
+describe("resolvePrHeadSha (QUA-410)", () => {
+  it("returns the head sha for a numeric PR number", async () => {
+    const api = vi.fn(async () => ({ head: { sha: "abc123def4567890" } }));
+    const sha = await resolvePrHeadSha("4258", api as never);
+    expect(sha).toBe("abc123def4567890");
+    expect(api).toHaveBeenCalledTimes(1);
+    expect(api.mock.calls[0][0]).toMatch(/\/pulls\/4258$/);
+  });
+
+  it("always fetches fresh (no local cache) across calls", async () => {
+    // Simulate the PR head moving between two invocations.
+    const shas = ["oldSha1234567890", "newSha1234567890"];
+    const api = vi.fn(async () => ({ head: { sha: shas.shift()! } }));
+    const first = await resolvePrHeadSha("4258", api as never);
+    const second = await resolvePrHeadSha("4258", api as never);
+    expect(first).toBe("oldSha1234567890");
+    expect(second).toBe("newSha1234567890");
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects non-numeric PR values", async () => {
+    const api = vi.fn();
+    await expect(resolvePrHeadSha("main", api as never)).rejects.toThrow(/Invalid --pr value/);
+    await expect(resolvePrHeadSha("abc", api as never)).rejects.toThrow(/Invalid --pr value/);
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it("throws when the API response lacks a head.sha", async () => {
+    const api = vi.fn(async () => ({}));
+    await expect(resolvePrHeadSha("4258", api as never)).rejects.toThrow(/Could not resolve head SHA/);
+  });
+});

--- a/crux/ci/resolve-pr-head.ts
+++ b/crux/ci/resolve-pr-head.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolve a PR's current head SHA via the GitHub API.
+ *
+ * Used by `crux gh ci status --pr=<N>` so the CLI always reports on the PR's
+ * live state, not a stale local snapshot. (QUA-410)
+ */
+
+import { githubApi, REPO } from '../lib/github.ts';
+
+export async function resolvePrHeadSha(
+  prNumber: string,
+  api: typeof githubApi = githubApi,
+): Promise<string> {
+  if (!/^\d+$/.test(prNumber)) {
+    throw new Error(`Invalid --pr value: ${prNumber} (must be numeric)`);
+  }
+  const pr = await api<{ head: { sha: string } }>(
+    `/repos/${REPO}/pulls/${prNumber}`,
+  );
+  if (!pr?.head?.sha) {
+    throw new Error(`Could not resolve head SHA for PR #${prNumber}`);
+  }
+  return pr.head.sha;
+}

--- a/crux/commands/ci.ts
+++ b/crux/commands/ci.ts
@@ -13,7 +13,7 @@ const SCRIPTS = {
   status: {
     script: 'ci/ci-status.ts',
     description: 'Check GitHub CI check-run status',
-    passthrough: ['ci', 'wait', 'sha'],
+    passthrough: ['ci', 'wait', 'sha', 'pr'],
   },
   'pause-actions': {
     script: 'ci/ci-pause-actions.ts',
@@ -90,6 +90,7 @@ ${commandList}
 Options:
   --wait          Poll every 30s until all checks complete
   --sha=<sha>     Check a specific commit (default: HEAD)
+  --pr=<N>        Check PR N's current head SHA (resolved fresh from API)
   --ci            JSON output
   --json          JSON output (main-status)
 
@@ -97,6 +98,7 @@ Examples:
   crux gh ci status                  Show current CI status
   crux gh ci status --wait           Poll until all checks complete
   crux gh ci status --sha=abc123     Check a specific commit
+  crux gh ci status --pr=4258        Check PR #4258 current head
   crux gh ci main-status             Is main branch CI green or red?
   crux gh ci main-status --json      Machine-readable output
   crux gh ci pause-actions            Pause all automated workflows


### PR DESCRIPTION
## Summary

Fixes QUA-410. `.claude/commands/deploy.md` documented `pnpm crux gh ci status --pr=<N>`, but the `--pr` flag was silently dropped — `crux/commands/ci.ts` didn't list it in `passthrough`, and `ci-status.ts` fell back to `git rev-parse HEAD`. From `coord/` (which stays on `main`) this returned main's SHA, not the PR's head, so release monitoring saw stale check results while the release PR's head had moved on due to new merges.

## Fix

- Add `--pr=<N>` to the passthrough list and the status script.
- New `resolvePrHeadSha(prNumber)` helper (`crux/ci/resolve-pr-head.ts`) that hits `GET /repos/.../pulls/<N>` on every invocation — no local caching. The returned SHA is always the PR's live head.
- In `--wait` mode, re-resolve the SHA before each poll so the monitor tracks head movement during a release.
- Update help text / examples in both files.

## Tests

- `crux/ci/resolve-pr-head.test.ts` (vitest, 4 tests): fresh fetch every call (two consecutive calls return different SHAs — the regression guard), non-numeric PR value rejected, missing `head.sha` throws. Uses an injected `api` function so no real network mocking is needed.

## Test plan

- [x] `vitest run crux/ci/resolve-pr-head.test.ts` — 4 passing
- [x] `tsc --noEmit` clean
