### PR TITLE
fix(ci): populate commit SHA in regression issue title (QUA-389)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,15 +411,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need at least 2 commits so the commit message lookup below resolves
+          # the triggering commit, not just its tree.
+          fetch-depth: 2
 
       - name: File regression issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find the merge commit that likely caused the failure
-          LAST_MERGE=$(git log --merges --oneline -1 --format="%H %s")
-          LAST_SHA=$(echo "$LAST_MERGE" | cut -d' ' -f1)
-          LAST_MSG=$(echo "$LAST_MERGE" | cut -d' ' -f2-)
+          # On push to main, github.sha IS the merge commit. Use it directly
+          # instead of scanning git log (which fails with default fetch-depth=1).
+          LAST_SHA="${{ github.sha }}"
+          LAST_MSG=$(git log -1 --format="%s" "$LAST_SHA")
 
           # Extract PR number from merge commit message if present
           PR_NUM=$(echo "$LAST_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#')


### PR DESCRIPTION
## Summary

Fixes the `file-regression-issue` job that auto-files a GitHub issue when CI breaks on main. The job used `actions/checkout@v4` with the default `fetch-depth=1`, so `git log --merges --oneline -1` returned nothing and `LAST_SHA` was empty.

Result: issues titled literally **"CI broken on main after"** with body `after merging commit \`\`` — e.g. QUA-389, QUA-390, QUA-394 filed today, all with empty commit refs.

## Fix

- Use `github.sha` directly. On a push to `main`, that's already the merge commit — no need to scan git log.
- Bump `fetch-depth` to 2 so `git log -1 --format=%s` can resolve the commit message.

## Test plan

- [x] Workflow YAML parsed locally (intentional edit, `.github/workflows/ci.yml` syntactically valid)
- [x] Reviewed: `github.sha` on `push` events IS the merge commit (GH Actions docs)
- [ ] Next real CI failure on main produces an issue titled `CI broken on main after <7-char SHA> (from PR #NNNN)` — deferred, can't force a real main-CI failure to reproduce

Closes QUA-389

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>