### PR TITLE
fix(deploy-tasks): distinguish PAT-blocked from real failures in verify (QUA-409)

### DIFF
--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { checkPsqlRunnable } from './deploy-tasks.ts';
+import { checkPsqlRunnable, isPatBlockedError } from './deploy-tasks.ts';
 
 describe('checkPsqlRunnable', () => {
   const PSQL_CMD =
@@ -94,5 +94,30 @@ describe('checkPsqlRunnable', () => {
       getDatabaseUrl: () => undefined,
     });
     expect(result).toEqual({ runnable: true });
+  });
+});
+
+describe('isPatBlockedError (QUA-409)', () => {
+  it('matches the canonical GitHub PAT error string', () => {
+    expect(
+      isPatBlockedError(
+        'could not create workflow dispatch event: HTTP 403: Resource not accessible by personal access token',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(isPatBlockedError('RESOURCE NOT ACCESSIBLE BY PERSONAL ACCESS TOKEN')).toBe(true);
+  });
+
+  it('does NOT match unrelated 403s or other errors', () => {
+    expect(isPatBlockedError('HTTP 403: forbidden')).toBe(false);
+    expect(isPatBlockedError('psql: connection refused')).toBe(false);
+    expect(isPatBlockedError('HTTP 404: Not Found')).toBe(false);
+  });
+
+  it('handles empty / undefined output safely', () => {
+    expect(isPatBlockedError(undefined)).toBe(false);
+    expect(isPatBlockedError('')).toBe(false);
   });
 });

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -174,10 +174,29 @@ interface VerifyResult {
   prTitle: string;
   task: string;
   command: string | null;
-  status: 'pass' | 'fail' | 'skip';
+  /**
+   * - pass: verify command succeeded
+   * - fail: real failure — needs investigation
+   * - skip: prerequisite missing (e.g. psql), dry-run, or no verify command
+   * - needs-ui: command returned HTTP 403 "Resource not accessible by personal
+   *   access token" — only fixable by dispatching from the GitHub UI or
+   *   granting the PAT `actions:write`. Distinguishable from `fail` so
+   *   coordinator scans don't drown in PAT-blocked rows each release. (QUA-409)
+   */
+  status: 'pass' | 'fail' | 'skip' | 'needs-ui';
   exitCode?: number;
   output?: string;
   skipReason?: string;
+}
+
+/**
+ * Detect the GitHub "Resource not accessible by personal access token" error,
+ * which surfaces when a `gh workflow run` task is verified with a PAT lacking
+ * `actions:write`. (QUA-409)
+ */
+export function isPatBlockedError(output: string | undefined): boolean {
+  if (!output) return false;
+  return /Resource not accessible by personal access token/i.test(output);
 }
 
 /**
@@ -340,12 +359,16 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
       }
 
       const { exitCode, output } = runVerifyCommand(command, timeoutMs);
+      let status: VerifyResult['status'];
+      if (exitCode === 0) status = 'pass';
+      else if (isPatBlockedError(output)) status = 'needs-ui';
+      else status = 'fail';
       results.push({
         pr: pr.number,
         prTitle: pr.title,
         task: item.text,
         command,
-        status: exitCode === 0 ? 'pass' : 'fail',
+        status,
         exitCode,
         output,
       });
@@ -354,13 +377,17 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
 
   const passed = results.filter((r) => r.status === 'pass').length;
   const failed = results.filter((r) => r.status === 'fail').length;
+  const needsUi = results.filter((r) => r.status === 'needs-ui').length;
   const skipped = results.filter((r) => r.status === 'skip').length;
 
   if (options.ci) {
     return {
       output:
         JSON.stringify(
-          { results, summary: { passed, failed, skipped, total: results.length } },
+          {
+            results,
+            summary: { passed, failed, needsUi, skipped, total: results.length },
+          },
           null,
           2
         ) + '\n',
@@ -394,6 +421,7 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
       let badge: string;
       if (r.status === 'pass') badge = `${c.green}PASS${c.reset}`;
       else if (r.status === 'fail') badge = `${c.red}FAIL${c.reset}`;
+      else if (r.status === 'needs-ui') badge = `${c.yellow}NEEDS-UI${c.reset}`;
       else badge = `${c.yellow}SKIP${c.reset}`;
       lines.push(`  ${badge}  ${r.task}`);
       if (r.status === 'fail' && r.output) {
@@ -405,6 +433,11 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
         lines.push(`        ${c.dim}exit=${r.exitCode}${c.reset}`);
         lines.push(indented);
       }
+      if (r.status === 'needs-ui') {
+        lines.push(
+          `        ${c.dim}Local PAT lacks actions:write — dispatch from GitHub UI.${c.reset}`
+        );
+      }
       if (r.status === 'skip' && r.skipReason) {
         lines.push(`        ${c.dim}${r.skipReason}${c.reset}`);
       }
@@ -412,10 +445,12 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
     lines.push('');
   }
 
+  const needsUiPart =
+    needsUi > 0 ? `, ${c.yellow}${needsUi} needs-ui${c.reset}` : '';
   lines.push(
     `${c.bold}Summary:${c.reset} ${c.green}${passed} passed${c.reset}, ${
       failed > 0 ? c.red : c.dim
-    }${failed} failed${c.reset}, ${c.dim}${skipped} skipped${c.reset}`
+    }${failed} failed${c.reset}${needsUiPart}, ${c.dim}${skipped} skipped${c.reset}`
   );
 
   return {


### PR DESCRIPTION
## Summary

Fixes QUA-409 (partial — PAT-blocked detection). Every release, `crux gh deploy-tasks verify` flagged `gh workflow run <...>` tasks as **FAIL** because the local PAT lacks `actions:write`. Coordinators learned to ignore the whole verifier output because real failures looked identical to these phantom ones.

## Fix

Introduce a dedicated `needs-ui` verify status for GitHub's 403 error ("Resource not accessible by personal access token"):

- Detected by `isPatBlockedError()` on the command's combined output.
- Rendered as a yellow **NEEDS-UI** badge with a short hint to dispatch from the GitHub UI.
- Counted separately in the summary; does **not** flip the verify exit code (real FAIL still does).
- `--ci` JSON summary now carries `needsUi` alongside `passed` / `failed` / `skipped`.

Real FAIL rows (non-PAT errors) stay red and continue to fail the run.

## Out of scope

Three other categories from the ticket are left for separate, larger PRs:

1. psql-via-kubectl auto-routing
2. Auto-roll-off of tasks from PRs that have been on production for >24h
3. Route-path detection via registration instead of filename

## Tests

- `isPatBlockedError` unit tests (4): canonical string, case-insensitive, unrelated 403, empty/undefined.
- Existing `checkPsqlRunnable` suite still passes (9 tests).

## Test plan

- [x] `vitest run crux/commands/deploy-tasks.test.ts` — 12 passing
