### PR TITLE
fix(build): harden fetchRecordVerdicts against transient HTTP errors (QUA-421)

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -1,0 +1,334 @@
+/**
+ * Tests for fetchJsonWithRetry + fetchRecordVerdicts strict-mode behavior
+ * (QUA-421).
+ *
+ * Before QUA-421, a single transient HTTP failure during paginated fetches
+ * of /api/sourcing/verdicts would cause the entire record-verdicts.json to
+ * come out empty, silently zeroing every source-check dot on the site. These
+ * tests guard against re-introducing that behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  fetchJsonWithRetry,
+  fetchRecordVerdicts,
+  isStrictVerdictsMode,
+  setFullBuildMode,
+} from '../wiki-server-data.mjs';
+
+/** Build a minimal Response-like object for the mocked fetch. */
+function mockResponse({ ok, status = 200, json = null } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => json,
+  };
+}
+
+/** Collect calls in order and return canned results from a queue. */
+function makeQueueFetcher(responses) {
+  const calls = [];
+  const queue = [...responses];
+  const fetcher = async (url, _init) => {
+    calls.push(url);
+    if (queue.length === 0) {
+      throw new Error(`queue exhausted; unexpected call to ${url}`);
+    }
+    const next = queue.shift();
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  return { fetcher, calls };
+}
+
+describe('fetchJsonWithRetry', () => {
+  // Use a zero-sleep so the exponential-backoff doesn't slow tests.
+  const noSleep = async () => {};
+
+  it('returns the parsed body on a successful first attempt', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: [{ recordType: 'grant', recordId: 'g1' }] } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.data.verdicts).toHaveLength(1);
+  });
+
+  it('retries on HTTP 500 and returns the next successful response', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: true, json: { verdicts: [] } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries on HTTP 429 (rate limit)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 429 }),
+      mockResponse({ ok: true, json: { ok: 1 } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries on network errors (thrown by fetch itself)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      new Error('ECONNRESET'),
+      mockResponse({ ok: true, json: { ok: 1 } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('does NOT retry on HTTP 404 (caller bug)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 404 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.retryable).toBe(false);
+    expect(calls).toHaveLength(1); // no retry
+  });
+
+  it('does NOT retry on HTTP 400', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 400 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('returns failure after exhausting all retry attempts', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.retryable).toBe(true);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('uses exponential backoff between attempts', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: true, json: {} }),
+    ]);
+    const sleeps = [];
+    const sleepImpl = async (ms) => {
+      sleeps.push(ms);
+    };
+    await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl,
+      attempts: 3,
+      backoffMs: 100,
+    });
+    expect(sleeps).toEqual([100, 200]); // 100ms before attempt 2, 200ms before attempt 3
+  });
+});
+
+describe('isStrictVerdictsMode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.STRICT_VERDICTS;
+    delete process.env.CI;
+    setFullBuildMode(false);
+  });
+
+  afterEach(() => {
+    // Restore only the two env vars we touch (don't clobber vitest/node state).
+    process.env.CI = originalEnv.CI;
+    if (originalEnv.STRICT_VERDICTS !== undefined) {
+      process.env.STRICT_VERDICTS = originalEnv.STRICT_VERDICTS;
+    }
+    setFullBuildMode(false);
+  });
+
+  it('is non-strict in local dev (no CI, no full build, no override)', () => {
+    expect(isStrictVerdictsMode()).toBe(false);
+  });
+
+  it('is strict when CI=true', () => {
+    process.env.CI = 'true';
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+
+  it('is strict when full-build mode is on', () => {
+    setFullBuildMode(true);
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+
+  it('STRICT_VERDICTS=0 overrides CI strictness (escape hatch)', () => {
+    process.env.CI = 'true';
+    process.env.STRICT_VERDICTS = '0';
+    expect(isStrictVerdictsMode()).toBe(false);
+  });
+
+  it('STRICT_VERDICTS=1 forces strict even in local dev', () => {
+    process.env.STRICT_VERDICTS = '1';
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+});
+
+describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
+  const originalServerUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const noSleep = async () => {};
+
+  beforeEach(() => {
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://fake-server';
+    delete process.env.CI;
+    delete process.env.STRICT_VERDICTS;
+    setFullBuildMode(false);
+  });
+
+  afterEach(() => {
+    if (originalServerUrl !== undefined) {
+      process.env.LONGTERMWIKI_SERVER_URL = originalServerUrl;
+    } else {
+      delete process.env.LONGTERMWIKI_SERVER_URL;
+    }
+    setFullBuildMode(false);
+  });
+
+  it('returns the collected map on fully successful paginated fetches', async () => {
+    // Single page with 2 verdicts, then a short page to terminate pagination.
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({
+        ok: true,
+        json: {
+          verdicts: [
+            { recordType: 'grant', recordId: 'g1', verdict: 'confirmed' },
+            { recordType: 'grant', recordId: 'g2', verdict: 'partial' },
+          ],
+        },
+      }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(Object.keys(result)).toEqual(['grant:g1', 'grant:g2']);
+  });
+
+  it('keys per-field verdicts as "recordType:recordId:fieldName"', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({
+        ok: true,
+        json: {
+          verdicts: [
+            { recordType: 'grant', recordId: 'g1', fieldName: null, verdict: 'confirmed' },
+            { recordType: 'grant', recordId: 'g1', fieldName: 'amount', verdict: 'partial' },
+          ],
+        },
+      }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(result['grant:g1']?.verdict).toBe('confirmed');
+    expect(result['grant:g1:amount']?.verdict).toBe('partial');
+  });
+
+  it('in STRICT mode: throws when a page fails after all retries', async () => {
+    process.env.STRICT_VERDICTS = '1';
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    await expect(
+      fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep }),
+    ).rejects.toThrow(/record-verdicts.*strict mode/i);
+  });
+
+  it('in NON-STRICT mode: returns partial results when a page fails', async () => {
+    // Non-strict: CI not set, STRICT_VERDICTS not set, fullBuildMode not set.
+    const firstPage = Array.from({ length: 200 }, (_, i) => ({
+      recordType: 'grant',
+      recordId: `g${i}`,
+      verdict: 'confirmed',
+    }));
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: firstPage } }),
+      // Page 2 fails — exhausts retries
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    // We got page 1's 200 verdicts before the failure; old behavior
+    // returned {} and discarded everything. New behavior preserves them.
+    expect(Object.keys(result)).toHaveLength(200);
+    expect(result['grant:g0']).toBeDefined();
+  });
+
+  it('returns empty map when LONGTERMWIKI_SERVER_URL is not set', async () => {
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    const result = await fetchRecordVerdicts({});
+    expect(result).toEqual({});
+  });
+
+  it('retries on transient 500s and still completes successfully', async () => {
+    const firstPage = [
+      { recordType: 'grant', recordId: 'g1', verdict: 'confirmed' },
+    ];
+    const { fetcher, calls } = makeQueueFetcher([
+      // Attempt 1: flaky 500
+      mockResponse({ ok: false, status: 500 }),
+      // Attempt 2: succeeds
+      mockResponse({ ok: true, json: { verdicts: firstPage } }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(result['grant:g1']?.verdict).toBe('confirmed');
+    expect(calls).toHaveLength(2);
+  });
+
+  it('paginates correctly: issues offset=0, 200, 400 until a short page', async () => {
+    const mkFullPage = (start) =>
+      Array.from({ length: 200 }, (_, i) => ({
+        recordType: 'grant',
+        recordId: `g${start + i}`,
+        verdict: 'confirmed',
+      }));
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: mkFullPage(0) } }),
+      mockResponse({ ok: true, json: { verdicts: mkFullPage(200) } }),
+      mockResponse({ ok: true, json: { verdicts: [{ recordType: 'grant', recordId: 'g-last', verdict: 'confirmed' }] } }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(Object.keys(result)).toHaveLength(401);
+    expect(calls[0]).toContain('offset=0');
+    expect(calls[1]).toContain('offset=200');
+    expect(calls[2]).toContain('offset=400');
+  });
+});

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -82,6 +82,104 @@ export function buildHeaders() {
   return headers;
 }
 
+// ---------------------------------------------------------------------------
+// Retryable fetch helper (QUA-421)
+//
+// Several build-time fetchers (notably fetchRecordVerdicts) used to return {}
+// on any non-2xx response, which meant a single transient 5xx during a
+// multi-page pagination wiped the ENTIRE collected result. A flaky upstream
+// for 100ms could silently zero out a whole JSON file the frontend depends
+// on, with the error only showing up as a warning the build still passed.
+//
+// fetchJsonWithRetry wraps fetch() with exponential backoff (1s/2s/4s by
+// default) and returns a discriminated union. Callers decide whether a
+// terminal failure should throw (strict / CI) or degrade gracefully.
+// ---------------------------------------------------------------------------
+
+/**
+ * Sleep for `ms` milliseconds. Extracted so tests can replace it with a no-op.
+ * @internal
+ */
+export function _defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch JSON with per-attempt timeout and exponential-backoff retry.
+ *
+ * Retries on: network errors, AbortError (timeout), and HTTP 5xx / 429.
+ * Does NOT retry on HTTP 4xx (except 429) — those are caller bugs.
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {HeadersInit} [opts.headers]
+ * @param {number} [opts.timeoutMs]    Per-attempt timeout (default 30s).
+ * @param {number} [opts.attempts]     Total attempts incl. first try (default 3).
+ * @param {number} [opts.backoffMs]    Base backoff (default 1000). Doubled each retry.
+ * @param {typeof fetch} [opts.fetchImpl]  Override for tests.
+ * @param {(ms: number) => Promise<void>} [opts.sleepImpl]  Override for tests.
+ * @returns {Promise<{ok: true, data: any} | {ok: false, reason: string, status?: number, retryable: boolean}>}
+ */
+export async function fetchJsonWithRetry(url, opts = {}) {
+  const {
+    headers = {},
+    timeoutMs = 30_000,
+    attempts = 3,
+    backoffMs = 1000,
+    fetchImpl = fetch,
+    sleepImpl = _defaultSleep,
+  } = opts;
+
+  let lastReason = 'unknown';
+  let lastStatus;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let retryable = false;
+    try {
+      const resp = await fetchImpl(url, {
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        return { ok: true, data };
+      }
+      lastStatus = resp.status;
+      // 5xx and 429 are retryable; everything else is a caller bug.
+      retryable = resp.status >= 500 || resp.status === 429;
+      lastReason = `HTTP ${resp.status}`;
+    } catch (err) {
+      // Network errors, aborts (timeout), JSON parse failures — treat as retryable.
+      retryable = true;
+      lastReason = err instanceof Error ? err.message : String(err);
+    }
+
+    if (!retryable || attempt === attempts) {
+      return { ok: false, reason: lastReason, status: lastStatus, retryable };
+    }
+    // Exponential backoff: backoffMs, backoffMs*2, backoffMs*4, ...
+    await sleepImpl(backoffMs * 2 ** (attempt - 1));
+  }
+
+  // Unreachable: the loop either returns ok or takes the !retryable/final-attempt exit.
+  return { ok: false, reason: lastReason, status: lastStatus, retryable: false };
+}
+
+/**
+ * Should the build FAIL (throw) on wiki-server errors, vs. degrade gracefully?
+ *
+ * Strict by default in CI and in full-build mode. Local dev defaults to
+ * non-strict (degrade gracefully). Either behavior is overridable:
+ *   STRICT_VERDICTS=1  → force strict even locally
+ *   STRICT_VERDICTS=0  → force non-strict even in CI (escape hatch)
+ */
+export function isStrictVerdictsMode() {
+  const override = process.env.STRICT_VERDICTS;
+  if (override === '0') return false;
+  if (override === '1') return true;
+  return process.env.CI === 'true' || fullBuildMode;
+}
+
 /**
  * Fetch latest edit dates per page from the wiki-server API.
  * Falls back to an empty map if the server is unavailable.
@@ -564,8 +662,18 @@ export async function fetchResearchAreaDetails(areaIds) {
 /**
  * Fetch verification verdicts from wiki-server (unified verification system).
  * Returns a map keyed by "recordType:recordId" -> verdict info.
+ *
+ * QUA-421: hardened against transient HTTP errors. Each page is fetched via
+ * `fetchJsonWithRetry` (3 attempts, exponential backoff). If a page ultimately
+ * fails:
+ *   - in strict mode (CI / full build): throw — fail the build loudly instead
+ *     of shipping an empty record-verdicts.json that silently zeroes every
+ *     source-check dot on the site
+ *   - in non-strict mode (local dev): log a loud warning and return the
+ *     partial result collected so far — still strictly better than the old
+ *     behavior of returning {} and discarding everything
  */
-export async function fetchRecordVerdicts() {
+export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
   const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
   if (!serverUrl) {
     console.log('  record-verdicts: skipped (LONGTERMWIKI_SERVER_URL not set)');
@@ -573,51 +681,70 @@ export async function fetchRecordVerdicts() {
   }
 
   const headers = buildHeaders();
+  const strict = isStrictVerdictsMode();
 
-  try {
-    const pageSize = 200;
-    const verdicts = {};
-    let offset = 0;
-    while (true) {
-      const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
-      if (!resp.ok) {
-        logWikiServerWarning('record-verdicts', `HTTP ${resp.status}`);
-        return {};
+  const pageSize = 200;
+  const verdicts = {};
+  let offset = 0;
+
+  while (true) {
+    const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
+    const result = await fetchJsonWithRetry(url, {
+      headers,
+      timeoutMs: 30_000,
+      fetchImpl,
+      sleepImpl,
+    });
+
+    if (!result.ok) {
+      const partial = Object.keys(verdicts).length;
+      const reason = result.status
+        ? `${result.reason} at offset=${offset} after retries`
+        : `${result.reason} at offset=${offset} after retries`;
+      if (strict) {
+        // Strict: throw so the build fails loudly.
+        throw new Error(
+          `record-verdicts: ${reason}. ${partial} verdicts were collected ` +
+            `before the failure; refusing to ship a partial/empty ` +
+            `record-verdicts.json in strict mode. Set STRICT_VERDICTS=0 to ` +
+            `force degraded behavior locally.`
+        );
       }
-      const data = await resp.json();
-      const items = data.verdicts || [];
-      for (const v of items) {
-        const entry = {
-          verdict: v.verdict,
-          confidence: v.confidence,
-          sourcesChecked: v.sourcesChecked,
-          needsRecheck: v.needsRecheck,
-          lastComputedAt: v.lastComputedAt,
-        };
-        if (v.fieldName) {
-          // Per-field verdict: keyed as "recordType:recordId:fieldName"
-          verdicts[`${v.recordType}:${v.recordId}:${v.fieldName}`] = entry;
-        } else {
-          // Whole-row verdict: keyed as "recordType:recordId"
-          verdicts[`${v.recordType}:${v.recordId}`] = entry;
-        }
-      }
-      if (items.length < pageSize) break;
-      offset += pageSize;
+      logWikiServerWarning(
+        'record-verdicts',
+        `${reason} — returning ${partial} partial result(s) (non-strict mode)`
+      );
+      return verdicts;
     }
 
-    const count = Object.keys(verdicts).length;
-    if (count > 0) {
-      console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
-    } else {
-      console.log('  record-verdicts: 0 verdicts (none computed yet)');
+    const items = result.data.verdicts || [];
+    for (const v of items) {
+      const entry = {
+        verdict: v.verdict,
+        confidence: v.confidence,
+        sourcesChecked: v.sourcesChecked,
+        needsRecheck: v.needsRecheck,
+        lastComputedAt: v.lastComputedAt,
+      };
+      if (v.fieldName) {
+        // Per-field verdict: keyed as "recordType:recordId:fieldName"
+        verdicts[`${v.recordType}:${v.recordId}:${v.fieldName}`] = entry;
+      } else {
+        // Whole-row verdict: keyed as "recordType:recordId"
+        verdicts[`${v.recordType}:${v.recordId}`] = entry;
+      }
     }
-    return verdicts;
-  } catch (err) {
-    logWikiServerWarning('record-verdicts', err instanceof Error ? err.message : String(err));
-    return {};
+    if (items.length < pageSize) break;
+    offset += pageSize;
   }
+
+  const count = Object.keys(verdicts).length;
+  if (count > 0) {
+    console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
+  } else {
+    console.log('  record-verdicts: 0 verdicts (none computed yet)');
+  }
+  return verdicts;
 }
 
 /**


### PR DESCRIPTION
## Summary

Before this change, a single transient HTTP failure during the paginated fetch of `/api/sourcing/verdicts` would cause the entire `record-verdicts.json` to come out empty, silently zeroing every source-check dot on the site until the next successful build — hours of UX regression with no loud signal.

The old flow:

```js
while (true) {
  const resp = await fetch(url, ...);
  if (!resp.ok) {
    logWikiServerWarning(...);
    return {};            // ← silent full-reset on any 5xx
  }
  // ... collect items ...
}
```

## Fix

Three pieces:

1. **`fetchJsonWithRetry(url, opts)`** — new helper that wraps `fetch()` with per-attempt 30s timeout, 3 attempts by default, exponential backoff (1s/2s/4s). Retries on 5xx, 429, and network errors; does **not** retry on 4xx (caller bugs). Returns a discriminated union `{ ok: true, data } | { ok: false, reason, status?, retryable }` so callers decide terminal-failure policy.

2. **`isStrictVerdictsMode()`** — central predicate for strict-vs-degraded behavior:
   - **Strict by default** in CI (`CI=true`) and full-build mode
   - **Opt in** locally with `STRICT_VERDICTS=1`
   - **Opt out** in CI with `STRICT_VERDICTS=0` (escape hatch)

3. **`fetchRecordVerdicts` rewritten** around both helpers. On terminal failure:
   - **Strict** → throw (build fails loudly — `record-verdicts.json` is not written empty)
   - **Non-strict** → log warning + return **partial** results collected so far

Both behaviors are strictly better than the old `return {}` that discarded every previously-collected page.

The existing callers in `build-data.mjs` need no changes — `fetchRecordVerdicts`'s signature is backwards-compatible (new optional `{ fetchImpl, sleepImpl }` arg for tests).

## Test plan

New test suite `apps/web/scripts/lib/__tests__/fetch-retry.test.mjs` — 20 cases:

**`fetchJsonWithRetry`** (8 cases):
- [x] Success on first attempt
- [x] Retries on HTTP 500 until success
- [x] Retries on HTTP 429 (rate limit)
- [x] Retries on network errors (thrown by fetch)
- [x] Does NOT retry on HTTP 404 (caller bug)
- [x] Does NOT retry on HTTP 400
- [x] Returns failure after exhausting all attempts
- [x] Uses exponential backoff (100ms, 200ms) between attempts

**`isStrictVerdictsMode`** (5 cases):
- [x] Non-strict in local dev
- [x] Strict when `CI=true`
- [x] Strict when full-build mode is on
- [x] `STRICT_VERDICTS=0` overrides CI strictness
- [x] `STRICT_VERDICTS=1` forces strict locally

**`fetchRecordVerdicts`** (7 cases):
- [x] Returns collected map on fully successful fetches
- [x] Per-field verdicts keyed as `recordType:recordId:fieldName`
- [x] **STRICT mode throws** when a page fails after retries
- [x] **Non-strict mode returns partial** (page 1 succeeded, page 2 failed) — old behavior returned `{}`
- [x] Returns empty map when `LONGTERMWIKI_SERVER_URL` is not set
- [x] Retries on transient 500s and still completes
- [x] Paginates correctly with offsets 0, 200, 400...

Other gates:
- [x] `pnpm test` — 1539 pass (85 files)
- [x] `npx tsc --noEmit` clean

Closes QUA-421

Refs QUA-408 Phase 4 (category W — fail-fast at write path replacing what would otherwise be a new gate validator)
