### PR TITLE
infra(audits): add e2e-post-deploy-red-streak daily check (QUA-411)

### DIFF
--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -398,32 +398,18 @@ audits:
     category: infrastructure
     description: "e2e-post-deploy.yml has not been in a multi-run red streak — silent post-deploy test failures are caught within a day (QUA-411)."
     check_type: automated
+    # Logic lives in crux/commands/audits.ts::workflowRedStreakCommand.
+    # Pure evaluator (evaluateWorkflowRedStreak) has unit tests; the
+    # subcommand fails closed on fetch errors. Thresholds are tunable via
+    # --limit / --threshold. See QUA-411 / PR #4319.
     check_command: |
-      failures=$(gh run list -R quantified-uncertainty/longterm-wiki \
-        --workflow=e2e-post-deploy.yml --limit 5 \
-        --json conclusion --jq '[.[] | select(.conclusion == "failure")] | length' 2>/dev/null)
-      # Fail-closed: a fetch error is a real failure, not a pass. Silent
-      # success on missing data is the exact pattern this audit exists to
-      # catch. Requires gh auth + network (runs locally; see how_to_verify).
-      if [ -z "$failures" ]; then
-        echo "FAIL: could not fetch workflow run history — check gh auth / network"
-        exit 1
-      fi
-      echo "failures_in_last_5=$failures threshold=3"
-      if [ "$failures" -ge 3 ]; then
-        echo "FAIL: e2e-post-deploy has $failures failures in its last 5 runs — red streak likely"
-        gh run list -R quantified-uncertainty/longterm-wiki \
-          --workflow=e2e-post-deploy.yml --limit 5 \
-          --json createdAt,conclusion,url --jq '.[] | "  \(.createdAt) \(.conclusion) \(.url)"' 2>/dev/null
-        exit 1
-      else
-        echo "PASS: $failures/5 recent runs failed — within tolerance"
-      fi
+      pnpm crux sys audits workflow-red-streak --workflow=e2e-post-deploy.yml --limit=5 --threshold=3
     how_to_verify: |
-      The check_command inspects the last 5 runs of e2e-post-deploy.yml.
-      If 3+ of the last 5 have failed, the workflow is likely in a sustained
-      red streak (per QUA-411 incident: 4 consecutive failures went unnoticed
-      for 18+ hours). On fail:
+      The check_command runs `crux sys audits workflow-red-streak` which
+      inspects the last 5 runs of e2e-post-deploy.yml. If 3+ of the last 5
+      have failed, the workflow is likely in a sustained red streak (per
+      QUA-411 incident: 4 consecutive failures went unnoticed for 18+ hours).
+      On fail:
       1. Open the most recent failing run URL.
       2. Compare failing test names across runs — if identical, it's a
          real regression, not flakiness.

--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -402,9 +402,12 @@ audits:
       failures=$(gh run list -R quantified-uncertainty/longterm-wiki \
         --workflow=e2e-post-deploy.yml --limit 5 \
         --json conclusion --jq '[.[] | select(.conclusion == "failure")] | length' 2>/dev/null)
+      # Fail-closed: a fetch error is a real failure, not a pass. Silent
+      # success on missing data is the exact pattern this audit exists to
+      # catch. Requires gh auth + network (runs locally; see how_to_verify).
       if [ -z "$failures" ]; then
-        echo "WARN: could not fetch workflow run history"
-        exit 0
+        echo "FAIL: could not fetch workflow run history — check gh auth / network"
+        exit 1
       fi
       echo "failures_in_last_5=$failures threshold=3"
       if [ "$failures" -ge 3 ]; then

--- a/.claude/audits.yaml
+++ b/.claude/audits.yaml
@@ -394,6 +394,46 @@ audits:
         result: pass
         checked_by: "manual"
         notes: "103697 snapshots / 140000 threshold (74%); 761 unique pages. Cascade FK fix from PR #4261 deployed today."
+  - id: e2e-post-deploy-red-streak
+    category: infrastructure
+    description: "e2e-post-deploy.yml has not been in a multi-run red streak — silent post-deploy test failures are caught within a day (QUA-411)."
+    check_type: automated
+    check_command: |
+      failures=$(gh run list -R quantified-uncertainty/longterm-wiki \
+        --workflow=e2e-post-deploy.yml --limit 5 \
+        --json conclusion --jq '[.[] | select(.conclusion == "failure")] | length' 2>/dev/null)
+      if [ -z "$failures" ]; then
+        echo "WARN: could not fetch workflow run history"
+        exit 0
+      fi
+      echo "failures_in_last_5=$failures threshold=3"
+      if [ "$failures" -ge 3 ]; then
+        echo "FAIL: e2e-post-deploy has $failures failures in its last 5 runs — red streak likely"
+        gh run list -R quantified-uncertainty/longterm-wiki \
+          --workflow=e2e-post-deploy.yml --limit 5 \
+          --json createdAt,conclusion,url --jq '.[] | "  \(.createdAt) \(.conclusion) \(.url)"' 2>/dev/null
+        exit 1
+      else
+        echo "PASS: $failures/5 recent runs failed — within tolerance"
+      fi
+    how_to_verify: |
+      The check_command inspects the last 5 runs of e2e-post-deploy.yml.
+      If 3+ of the last 5 have failed, the workflow is likely in a sustained
+      red streak (per QUA-411 incident: 4 consecutive failures went unnoticed
+      for 18+ hours). On fail:
+      1. Open the most recent failing run URL.
+      2. Compare failing test names across runs — if identical, it's a
+         real regression, not flakiness.
+      3. Either fix the regression or file a ticket with the failing test
+         names and a link to the run.
+      The larger watcher (Option 1 in QUA-411) — a groundskeeper task that
+      posts to Discord automatically — is tracked separately as a follow-up.
+    frequency: daily
+    added: "2026-04-13"
+    added_by_pr: 4319
+    last_checked: null
+    last_result: null
+    history: []
   - id: audits-system-adoption
     category: process
     description: "This audits system itself is being used — items are checked on schedule, not abandoned"

--- a/crux/commands/audits.ts
+++ b/crux/commands/audits.ts
@@ -18,7 +18,7 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { parse as parseYaml } from 'yaml';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
@@ -850,6 +850,169 @@ Examples:
 }
 
 // ---------------------------------------------------------------------------
+// workflow-red-streak command
+// ---------------------------------------------------------------------------
+//
+// Fetches the last N runs of a GitHub Actions workflow and fails if the
+// number of `failure` conclusions meets a threshold — a "red streak"
+// signal that a silent post-deploy test failure is persisting.
+//
+// This replaces an earlier bash-embedded check_command (see PR #4319 /
+// QUA-411). Moving it to TypeScript:
+//   - makes the logic testable (see workflow-red-streak.test.ts)
+//   - fails closed on fetch errors without fragile `set -e` semantics
+//   - keeps audits.yaml `check_command` to a single line
+
+export interface WorkflowRun {
+  conclusion: string | null;
+  createdAt?: string;
+  url?: string;
+}
+
+export interface RedStreakResult {
+  status: 'pass' | 'fail';
+  failures: number;
+  totalConsidered: number;
+  threshold: number;
+  message: string;
+  /** Included on fail so the caller can print offending runs. */
+  failingRuns?: WorkflowRun[];
+}
+
+/**
+ * Pure evaluator — given a list of workflow runs (newest first) and a
+ * failure-count threshold, decide whether the workflow is in a red streak.
+ *
+ * Treated as failures: conclusion === 'failure'. `cancelled`, `timed_out`,
+ * and `startup_failure` are intentionally NOT counted — they are usually
+ * infra flakes rather than test regressions. Tighten the set here if the
+ * audit needs to be stricter.
+ */
+export function evaluateWorkflowRedStreak(
+  runs: WorkflowRun[],
+  threshold: number,
+): RedStreakResult {
+  const failingRuns = runs.filter(r => r.conclusion === 'failure');
+  const failures = failingRuns.length;
+  const totalConsidered = runs.length;
+  if (failures >= threshold) {
+    return {
+      status: 'fail',
+      failures,
+      totalConsidered,
+      threshold,
+      message: `FAIL: ${failures}/${totalConsidered} recent runs failed — red streak likely (threshold=${threshold})`,
+      failingRuns,
+    };
+  }
+  return {
+    status: 'pass',
+    failures,
+    totalConsidered,
+    threshold,
+    message: `PASS: ${failures}/${totalConsidered} recent runs failed — within tolerance (threshold=${threshold})`,
+  };
+}
+
+/**
+ * Fetch the last N runs of a workflow via `gh run list --json ...`.
+ * Returns null on any failure (missing gh, network error, unparseable JSON).
+ * Callers must treat null as fail-closed — the whole point of this audit is
+ * to catch silent-failure patterns, so we never pass on missing data.
+ */
+export function fetchWorkflowRuns(
+  workflow: string,
+  repo: string,
+  limit: number,
+  opts: { exec?: typeof execFileSync } = {},
+): WorkflowRun[] | null {
+  const exec = opts.exec ?? execFileSync;
+  try {
+    const stdout = exec('gh', [
+      'run', 'list',
+      '--repo', repo,
+      '--workflow', workflow,
+      '--limit', String(limit),
+      '--json', 'conclusion,createdAt,url',
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 20_000,
+    });
+    const parsed = JSON.parse(String(stdout));
+    if (!Array.isArray(parsed)) return null;
+    return parsed.map((r): WorkflowRun => ({
+      conclusion: typeof r?.conclusion === 'string' ? r.conclusion : null,
+      createdAt: typeof r?.createdAt === 'string' ? r.createdAt : undefined,
+      url: typeof r?.url === 'string' ? r.url : undefined,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+async function workflowRedStreakCommand(
+  _args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const workflow = options.workflow as string | undefined;
+  if (!workflow) {
+    return {
+      exitCode: 1,
+      output: `Usage: crux sys audits workflow-red-streak --workflow=<name> [--limit=5] [--threshold=3] [--repo=owner/name]
+
+  Check a GitHub Actions workflow's recent run history for a red streak.
+  Exits 1 if >= threshold of the last <limit> runs failed, or if the run
+  history could not be fetched (fail-closed).
+
+Options:
+  --workflow=X      Workflow file name (e.g. e2e-post-deploy.yml) — required
+  --limit=N         How many recent runs to consider [default: 5]
+  --threshold=N     Fail if at least N of the last <limit> runs failed [default: 3]
+  --repo=owner/name GitHub repo [default: quantified-uncertainty/longterm-wiki]`,
+    };
+  }
+
+  const limit = parsePositiveInt(options.limit, 5);
+  const threshold = parsePositiveInt(options.threshold, 3);
+  const repo = (options.repo as string | undefined) ?? 'quantified-uncertainty/longterm-wiki';
+
+  const runs = fetchWorkflowRuns(workflow, repo, limit);
+  if (runs === null) {
+    // Fail-closed: a fetch error is a real failure, not a pass. Silent
+    // success on missing data is the exact pattern this audit exists to catch.
+    return {
+      exitCode: 1,
+      output: `FAIL: could not fetch workflow run history for ${workflow} — check gh auth / network`,
+    };
+  }
+
+  const result = evaluateWorkflowRedStreak(runs, threshold);
+  const lines: string[] = [
+    `workflow=${workflow} failures_in_last_${result.totalConsidered}=${result.failures} threshold=${result.threshold}`,
+    result.message,
+  ];
+  if (result.status === 'fail' && result.failingRuns) {
+    for (const r of result.failingRuns) {
+      lines.push(`  ${r.createdAt ?? '?'} ${r.conclusion} ${r.url ?? ''}`.trimEnd());
+    }
+  }
+  return {
+    exitCode: result.status === 'fail' ? 1 : 0,
+    output: lines.join('\n'),
+  };
+}
+
+function parsePositiveInt(v: unknown, fallback: number): number {
+  if (typeof v === 'number' && Number.isFinite(v) && v > 0) return Math.floor(v);
+  if (typeof v === 'string') {
+    const n = Number(v);
+    if (Number.isFinite(n) && n > 0) return Math.floor(n);
+  }
+  return fallback;
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
@@ -859,6 +1022,7 @@ export const commands = {
   add: addCommand,
   'run-auto': runAutoCommand,
   report: reportCommand,
+  'workflow-red-streak': workflowRedStreakCommand,
   default: listCommand,
 };
 
@@ -870,11 +1034,12 @@ Track ongoing properties we expect to be true about the system,
 plus one-time post-merge check items tied to specific PRs.
 
 Commands:
-  list              Show all audit items (default), highlight overdue
-  check <id>        Record a check result (with auto-recorded history)
-  add "desc"        Add a new audit item via CLI (no manual YAML editing)
-  run-auto          Run automated/hybrid checks, show output
-  report            Full report for maintenance sweep
+  list                  Show all audit items (default), highlight overdue
+  check <id>            Record a check result (with auto-recorded history)
+  add "desc"            Add a new audit item via CLI (no manual YAML editing)
+  run-auto              Run automated/hybrid checks, show output
+  report                Full report for maintenance sweep
+  workflow-red-streak   Fail if a GH Actions workflow has N+ recent failures
 
 Options (list):
   --pending         Only show overdue / never-checked items
@@ -910,5 +1075,6 @@ Examples:
   crux sys audits add "Check Y weekly" --type=ongoing --interval=weekly
   crux sys audits run-auto                            # Run automated checks
   crux sys audits report                              # Summary for maintenance
+  crux sys audits workflow-red-streak --workflow=e2e-post-deploy.yml  # Red-streak check
 `;
 }

--- a/crux/commands/workflow-red-streak.test.ts
+++ b/crux/commands/workflow-red-streak.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the workflow-red-streak audit subcommand (QUA-411 / PR #4319).
+ *
+ * Covers:
+ * - evaluateWorkflowRedStreak: pure logic — threshold math, status-only
+ *   counting (no `cancelled`/`timed_out`), empty input, all-pass, all-fail.
+ * - fetchWorkflowRuns: error paths — gh missing, bad JSON, non-array,
+ *   runtime throw. The happy path is covered by a stub `exec`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateWorkflowRedStreak,
+  fetchWorkflowRuns,
+  type WorkflowRun,
+} from './audits.ts';
+
+// ---------------------------------------------------------------------------
+// evaluateWorkflowRedStreak
+// ---------------------------------------------------------------------------
+
+describe('evaluateWorkflowRedStreak', () => {
+  const mk = (concs: Array<string | null>): WorkflowRun[] =>
+    concs.map((c, i) => ({
+      conclusion: c,
+      createdAt: `2026-04-13T0${i}:00:00Z`,
+      url: `https://example/run/${i}`,
+    }));
+
+  it('passes when zero failures in recent runs', () => {
+    const r = evaluateWorkflowRedStreak(mk(['success', 'success', 'success', 'success', 'success']), 3);
+    expect(r.status).toBe('pass');
+    expect(r.failures).toBe(0);
+    expect(r.totalConsidered).toBe(5);
+    expect(r.message).toContain('PASS');
+    expect(r.failingRuns).toBeUndefined();
+  });
+
+  it('passes when failures < threshold', () => {
+    const r = evaluateWorkflowRedStreak(mk(['failure', 'success', 'failure', 'success', 'success']), 3);
+    expect(r.status).toBe('pass');
+    expect(r.failures).toBe(2);
+    expect(r.message).toContain('PASS');
+  });
+
+  it('fails when failures === threshold', () => {
+    const r = evaluateWorkflowRedStreak(mk(['failure', 'failure', 'failure', 'success', 'success']), 3);
+    expect(r.status).toBe('fail');
+    expect(r.failures).toBe(3);
+    expect(r.message).toContain('FAIL');
+    expect(r.failingRuns).toHaveLength(3);
+  });
+
+  it('fails when failures > threshold', () => {
+    const r = evaluateWorkflowRedStreak(mk(['failure', 'failure', 'failure', 'failure', 'failure']), 3);
+    expect(r.status).toBe('fail');
+    expect(r.failures).toBe(5);
+    expect(r.totalConsidered).toBe(5);
+  });
+
+  it('does NOT count cancelled / timed_out / startup_failure as failures', () => {
+    // These are infra flakes, not test regressions — intentionally excluded.
+    const r = evaluateWorkflowRedStreak(
+      mk(['cancelled', 'timed_out', 'startup_failure', 'success', 'success']),
+      3,
+    );
+    expect(r.failures).toBe(0);
+    expect(r.status).toBe('pass');
+  });
+
+  it('does NOT count null conclusion (in-progress) as failure', () => {
+    const r = evaluateWorkflowRedStreak(mk([null, null, null, 'success', 'success']), 3);
+    expect(r.failures).toBe(0);
+    expect(r.status).toBe('pass');
+  });
+
+  it('handles an empty run list (no data) as pass with 0/0', () => {
+    // Note: the subcommand translates a fetch error into fail-closed before
+    // reaching this function, so empty-array input represents "gh returned
+    // no runs" (e.g., brand-new workflow), not "we couldn't fetch".
+    const r = evaluateWorkflowRedStreak([], 3);
+    expect(r.status).toBe('pass');
+    expect(r.failures).toBe(0);
+    expect(r.totalConsidered).toBe(0);
+  });
+
+  it('threshold of 1 fails on a single failure', () => {
+    const r = evaluateWorkflowRedStreak(mk(['failure', 'success', 'success']), 1);
+    expect(r.status).toBe('fail');
+    expect(r.failures).toBe(1);
+    expect(r.failingRuns).toHaveLength(1);
+  });
+
+  it('reports threshold and totals in the message', () => {
+    const r = evaluateWorkflowRedStreak(mk(['failure', 'failure', 'failure']), 3);
+    expect(r.message).toContain('3/3');
+    expect(r.message).toContain('threshold=3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWorkflowRuns
+// ---------------------------------------------------------------------------
+
+describe('fetchWorkflowRuns', () => {
+  it('returns parsed runs on happy path', () => {
+    const fakeExec = (() =>
+      JSON.stringify([
+        { conclusion: 'success', createdAt: '2026-04-13T00:00:00Z', url: 'https://x/1' },
+        { conclusion: 'failure', createdAt: '2026-04-12T00:00:00Z', url: 'https://x/2' },
+      ])) as unknown as typeof import('child_process').execFileSync;
+
+    const runs = fetchWorkflowRuns('e2e-post-deploy.yml', 'owner/repo', 5, { exec: fakeExec });
+    expect(runs).not.toBeNull();
+    expect(runs!).toHaveLength(2);
+    expect(runs![0].conclusion).toBe('success');
+    expect(runs![1].conclusion).toBe('failure');
+    expect(runs![1].url).toBe('https://x/2');
+  });
+
+  it('returns null when gh fails (throws)', () => {
+    const fakeExec = (() => {
+      throw new Error('gh: command not found');
+    }) as unknown as typeof import('child_process').execFileSync;
+    const runs = fetchWorkflowRuns('w.yml', 'o/r', 5, { exec: fakeExec });
+    expect(runs).toBeNull();
+  });
+
+  it('returns null on unparseable JSON', () => {
+    const fakeExec = (() => 'not json at all') as unknown as typeof import('child_process').execFileSync;
+    const runs = fetchWorkflowRuns('w.yml', 'o/r', 5, { exec: fakeExec });
+    expect(runs).toBeNull();
+  });
+
+  it('returns null on non-array JSON', () => {
+    const fakeExec = (() =>
+      JSON.stringify({ error: 'rate limited' })) as unknown as typeof import('child_process').execFileSync;
+    const runs = fetchWorkflowRuns('w.yml', 'o/r', 5, { exec: fakeExec });
+    expect(runs).toBeNull();
+  });
+
+  it('coerces malformed entries to safe shape (no throw)', () => {
+    const fakeExec = (() =>
+      JSON.stringify([
+        { conclusion: 'success' }, // missing createdAt/url
+        { conclusion: 123, url: null }, // bogus types
+        {}, // empty
+      ])) as unknown as typeof import('child_process').execFileSync;
+
+    const runs = fetchWorkflowRuns('w.yml', 'o/r', 5, { exec: fakeExec });
+    expect(runs).toEqual([
+      { conclusion: 'success', createdAt: undefined, url: undefined },
+      { conclusion: null, createdAt: undefined, url: undefined },
+      { conclusion: null, createdAt: undefined, url: undefined },
+    ]);
+  });
+
+  it('returns empty array when gh returns no runs', () => {
+    const fakeExec = (() => '[]') as unknown as typeof import('child_process').execFileSync;
+    const runs = fetchWorkflowRuns('w.yml', 'o/r', 5, { exec: fakeExec });
+    expect(runs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes QUA-411 (partial — audit-based detection). `e2e-post-deploy.yml` was in a 4+ run red streak for 18+ hours on 2026-04-13 with nothing alerting — the same silent-failure pattern as QUA-352 and QUA-396. The only reason anyone noticed is that a coordinator happened to run `gh run list` during release verification.

## Fix

As an immediate safeguard, add an automated audit `e2e-post-deploy-red-streak` that fails when `e2e-post-deploy.yml` has 3+ failures in its last 5 runs. It:

- Runs daily (`frequency: daily`)
- Participates in the `pnpm crux sys audits list` maintenance sweep
- On fail, prints the timestamps + URLs of each recent failing run so the next audit pass surfaces an actionable signal immediately

## Out of scope

Option 1 from the ticket — a groundskeeper watcher that posts to Discord with rate-limiting — is a larger scope and will go in a follow-up PR. This one just gets us off zero.

## Test plan

- [x] `pnpm crux sys audits list` shows the new audit
- [x] Running the embedded `check_command` against the current repo correctly detects the 5/5 red streak from the ticket evidence (verified locally)
