### PR TITLE
feat(sourcing): extract VALID_RECORD_TYPES into @longterm-wiki/sourcing-types (QUA-424)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@dagrejs/dagre": "^1.1.8",
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/sourcing-types": "workspace:*",
     "@quri/squiggle-components": "^0.10.0",
     "@quri/squiggle-lang": "^0.10.0",
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -1,0 +1,334 @@
+/**
+ * Tests for fetchJsonWithRetry + fetchRecordVerdicts strict-mode behavior
+ * (QUA-421).
+ *
+ * Before QUA-421, a single transient HTTP failure during paginated fetches
+ * of /api/sourcing/verdicts would cause the entire record-verdicts.json to
+ * come out empty, silently zeroing every source-check dot on the site. These
+ * tests guard against re-introducing that behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  fetchJsonWithRetry,
+  fetchRecordVerdicts,
+  isStrictVerdictsMode,
+  setFullBuildMode,
+} from '../wiki-server-data.mjs';
+
+/** Build a minimal Response-like object for the mocked fetch. */
+function mockResponse({ ok, status = 200, json = null } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => json,
+  };
+}
+
+/** Collect calls in order and return canned results from a queue. */
+function makeQueueFetcher(responses) {
+  const calls = [];
+  const queue = [...responses];
+  const fetcher = async (url, _init) => {
+    calls.push(url);
+    if (queue.length === 0) {
+      throw new Error(`queue exhausted; unexpected call to ${url}`);
+    }
+    const next = queue.shift();
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  return { fetcher, calls };
+}
+
+describe('fetchJsonWithRetry', () => {
+  // Use a zero-sleep so the exponential-backoff doesn't slow tests.
+  const noSleep = async () => {};
+
+  it('returns the parsed body on a successful first attempt', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: [{ recordType: 'grant', recordId: 'g1' }] } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.data.verdicts).toHaveLength(1);
+  });
+
+  it('retries on HTTP 500 and returns the next successful response', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: true, json: { verdicts: [] } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries on HTTP 429 (rate limit)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 429 }),
+      mockResponse({ ok: true, json: { ok: 1 } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries on network errors (thrown by fetch itself)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      new Error('ECONNRESET'),
+      mockResponse({ ok: true, json: { ok: 1 } }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('does NOT retry on HTTP 404 (caller bug)', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 404 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.retryable).toBe(false);
+    expect(calls).toHaveLength(1); // no retry
+  });
+
+  it('does NOT retry on HTTP 400', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 400 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('returns failure after exhausting all retry attempts', async () => {
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl: noSleep,
+      attempts: 3,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.retryable).toBe(true);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('uses exponential backoff between attempts', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: false, status: 500 }),
+      mockResponse({ ok: true, json: {} }),
+    ]);
+    const sleeps = [];
+    const sleepImpl = async (ms) => {
+      sleeps.push(ms);
+    };
+    await fetchJsonWithRetry('http://x', {
+      fetchImpl: fetcher,
+      sleepImpl,
+      attempts: 3,
+      backoffMs: 100,
+    });
+    expect(sleeps).toEqual([100, 200]); // 100ms before attempt 2, 200ms before attempt 3
+  });
+});
+
+describe('isStrictVerdictsMode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.STRICT_VERDICTS;
+    delete process.env.CI;
+    setFullBuildMode(false);
+  });
+
+  afterEach(() => {
+    // Restore only the two env vars we touch (don't clobber vitest/node state).
+    process.env.CI = originalEnv.CI;
+    if (originalEnv.STRICT_VERDICTS !== undefined) {
+      process.env.STRICT_VERDICTS = originalEnv.STRICT_VERDICTS;
+    }
+    setFullBuildMode(false);
+  });
+
+  it('is non-strict in local dev (no CI, no full build, no override)', () => {
+    expect(isStrictVerdictsMode()).toBe(false);
+  });
+
+  it('is strict when CI=true', () => {
+    process.env.CI = 'true';
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+
+  it('is strict when full-build mode is on', () => {
+    setFullBuildMode(true);
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+
+  it('STRICT_VERDICTS=0 overrides CI strictness (escape hatch)', () => {
+    process.env.CI = 'true';
+    process.env.STRICT_VERDICTS = '0';
+    expect(isStrictVerdictsMode()).toBe(false);
+  });
+
+  it('STRICT_VERDICTS=1 forces strict even in local dev', () => {
+    process.env.STRICT_VERDICTS = '1';
+    expect(isStrictVerdictsMode()).toBe(true);
+  });
+});
+
+describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
+  const originalServerUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const noSleep = async () => {};
+
+  beforeEach(() => {
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://fake-server';
+    delete process.env.CI;
+    delete process.env.STRICT_VERDICTS;
+    setFullBuildMode(false);
+  });
+
+  afterEach(() => {
+    if (originalServerUrl !== undefined) {
+      process.env.LONGTERMWIKI_SERVER_URL = originalServerUrl;
+    } else {
+      delete process.env.LONGTERMWIKI_SERVER_URL;
+    }
+    setFullBuildMode(false);
+  });
+
+  it('returns the collected map on fully successful paginated fetches', async () => {
+    // Single page with 2 verdicts, then a short page to terminate pagination.
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({
+        ok: true,
+        json: {
+          verdicts: [
+            { recordType: 'grant', recordId: 'g1', verdict: 'confirmed' },
+            { recordType: 'grant', recordId: 'g2', verdict: 'partial' },
+          ],
+        },
+      }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(Object.keys(result)).toEqual(['grant:g1', 'grant:g2']);
+  });
+
+  it('keys per-field verdicts as "recordType:recordId:fieldName"', async () => {
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({
+        ok: true,
+        json: {
+          verdicts: [
+            { recordType: 'grant', recordId: 'g1', fieldName: null, verdict: 'confirmed' },
+            { recordType: 'grant', recordId: 'g1', fieldName: 'amount', verdict: 'partial' },
+          ],
+        },
+      }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(result['grant:g1']?.verdict).toBe('confirmed');
+    expect(result['grant:g1:amount']?.verdict).toBe('partial');
+  });
+
+  it('in STRICT mode: throws when a page fails after all retries', async () => {
+    process.env.STRICT_VERDICTS = '1';
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    await expect(
+      fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep }),
+    ).rejects.toThrow(/record-verdicts.*strict mode/i);
+  });
+
+  it('in NON-STRICT mode: returns partial results when a page fails', async () => {
+    // Non-strict: CI not set, STRICT_VERDICTS not set, fullBuildMode not set.
+    const firstPage = Array.from({ length: 200 }, (_, i) => ({
+      recordType: 'grant',
+      recordId: `g${i}`,
+      verdict: 'confirmed',
+    }));
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: firstPage } }),
+      // Page 2 fails — exhausts retries
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    // We got page 1's 200 verdicts before the failure; old behavior
+    // returned {} and discarded everything. New behavior preserves them.
+    expect(Object.keys(result)).toHaveLength(200);
+    expect(result['grant:g0']).toBeDefined();
+  });
+
+  it('returns empty map when LONGTERMWIKI_SERVER_URL is not set', async () => {
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    const result = await fetchRecordVerdicts({});
+    expect(result).toEqual({});
+  });
+
+  it('retries on transient 500s and still completes successfully', async () => {
+    const firstPage = [
+      { recordType: 'grant', recordId: 'g1', verdict: 'confirmed' },
+    ];
+    const { fetcher, calls } = makeQueueFetcher([
+      // Attempt 1: flaky 500
+      mockResponse({ ok: false, status: 500 }),
+      // Attempt 2: succeeds
+      mockResponse({ ok: true, json: { verdicts: firstPage } }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(result['grant:g1']?.verdict).toBe('confirmed');
+    expect(calls).toHaveLength(2);
+  });
+
+  it('paginates correctly: issues offset=0, 200, 400 until a short page', async () => {
+    const mkFullPage = (start) =>
+      Array.from({ length: 200 }, (_, i) => ({
+        recordType: 'grant',
+        recordId: `g${start + i}`,
+        verdict: 'confirmed',
+      }));
+    const { fetcher, calls } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: mkFullPage(0) } }),
+      mockResponse({ ok: true, json: { verdicts: mkFullPage(200) } }),
+      mockResponse({ ok: true, json: { verdicts: [{ recordType: 'grant', recordId: 'g-last', verdict: 'confirmed' }] } }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(Object.keys(result)).toHaveLength(401);
+    expect(calls[0]).toContain('offset=0');
+    expect(calls[1]).toContain('offset=200');
+    expect(calls[2]).toContain('offset=400');
+  });
+});

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -82,6 +82,104 @@ export function buildHeaders() {
   return headers;
 }
 
+// ---------------------------------------------------------------------------
+// Retryable fetch helper (QUA-421)
+//
+// Several build-time fetchers (notably fetchRecordVerdicts) used to return {}
+// on any non-2xx response, which meant a single transient 5xx during a
+// multi-page pagination wiped the ENTIRE collected result. A flaky upstream
+// for 100ms could silently zero out a whole JSON file the frontend depends
+// on, with the error only showing up as a warning the build still passed.
+//
+// fetchJsonWithRetry wraps fetch() with exponential backoff (1s/2s/4s by
+// default) and returns a discriminated union. Callers decide whether a
+// terminal failure should throw (strict / CI) or degrade gracefully.
+// ---------------------------------------------------------------------------
+
+/**
+ * Sleep for `ms` milliseconds. Extracted so tests can replace it with a no-op.
+ * @internal
+ */
+export function _defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch JSON with per-attempt timeout and exponential-backoff retry.
+ *
+ * Retries on: network errors, AbortError (timeout), and HTTP 5xx / 429.
+ * Does NOT retry on HTTP 4xx (except 429) — those are caller bugs.
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {HeadersInit} [opts.headers]
+ * @param {number} [opts.timeoutMs]    Per-attempt timeout (default 30s).
+ * @param {number} [opts.attempts]     Total attempts incl. first try (default 3).
+ * @param {number} [opts.backoffMs]    Base backoff (default 1000). Doubled each retry.
+ * @param {typeof fetch} [opts.fetchImpl]  Override for tests.
+ * @param {(ms: number) => Promise<void>} [opts.sleepImpl]  Override for tests.
+ * @returns {Promise<{ok: true, data: any} | {ok: false, reason: string, status?: number, retryable: boolean}>}
+ */
+export async function fetchJsonWithRetry(url, opts = {}) {
+  const {
+    headers = {},
+    timeoutMs = 30_000,
+    attempts = 3,
+    backoffMs = 1000,
+    fetchImpl = fetch,
+    sleepImpl = _defaultSleep,
+  } = opts;
+
+  let lastReason = 'unknown';
+  let lastStatus;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let retryable = false;
+    try {
+      const resp = await fetchImpl(url, {
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        return { ok: true, data };
+      }
+      lastStatus = resp.status;
+      // 5xx and 429 are retryable; everything else is a caller bug.
+      retryable = resp.status >= 500 || resp.status === 429;
+      lastReason = `HTTP ${resp.status}`;
+    } catch (err) {
+      // Network errors, aborts (timeout), JSON parse failures — treat as retryable.
+      retryable = true;
+      lastReason = err instanceof Error ? err.message : String(err);
+    }
+
+    if (!retryable || attempt === attempts) {
+      return { ok: false, reason: lastReason, status: lastStatus, retryable };
+    }
+    // Exponential backoff: backoffMs, backoffMs*2, backoffMs*4, ...
+    await sleepImpl(backoffMs * 2 ** (attempt - 1));
+  }
+
+  // Unreachable: the loop either returns ok or takes the !retryable/final-attempt exit.
+  return { ok: false, reason: lastReason, status: lastStatus, retryable: false };
+}
+
+/**
+ * Should the build FAIL (throw) on wiki-server errors, vs. degrade gracefully?
+ *
+ * Strict by default in CI and in full-build mode. Local dev defaults to
+ * non-strict (degrade gracefully). Either behavior is overridable:
+ *   STRICT_VERDICTS=1  → force strict even locally
+ *   STRICT_VERDICTS=0  → force non-strict even in CI (escape hatch)
+ */
+export function isStrictVerdictsMode() {
+  const override = process.env.STRICT_VERDICTS;
+  if (override === '0') return false;
+  if (override === '1') return true;
+  return process.env.CI === 'true' || fullBuildMode;
+}
+
 /**
  * Fetch latest edit dates per page from the wiki-server API.
  * Falls back to an empty map if the server is unavailable.
@@ -564,8 +662,18 @@ export async function fetchResearchAreaDetails(areaIds) {
 /**
  * Fetch verification verdicts from wiki-server (unified verification system).
  * Returns a map keyed by "recordType:recordId" -> verdict info.
+ *
+ * QUA-421: hardened against transient HTTP errors. Each page is fetched via
+ * `fetchJsonWithRetry` (3 attempts, exponential backoff). If a page ultimately
+ * fails:
+ *   - in strict mode (CI / full build): throw — fail the build loudly instead
+ *     of shipping an empty record-verdicts.json that silently zeroes every
+ *     source-check dot on the site
+ *   - in non-strict mode (local dev): log a loud warning and return the
+ *     partial result collected so far — still strictly better than the old
+ *     behavior of returning {} and discarding everything
  */
-export async function fetchRecordVerdicts() {
+export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
   const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
   if (!serverUrl) {
     console.log('  record-verdicts: skipped (LONGTERMWIKI_SERVER_URL not set)');
@@ -573,51 +681,70 @@ export async function fetchRecordVerdicts() {
   }
 
   const headers = buildHeaders();
+  const strict = isStrictVerdictsMode();
 
-  try {
-    const pageSize = 200;
-    const verdicts = {};
-    let offset = 0;
-    while (true) {
-      const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
-      const resp = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
-      if (!resp.ok) {
-        logWikiServerWarning('record-verdicts', `HTTP ${resp.status}`);
-        return {};
+  const pageSize = 200;
+  const verdicts = {};
+  let offset = 0;
+
+  while (true) {
+    const url = `${serverUrl}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
+    const result = await fetchJsonWithRetry(url, {
+      headers,
+      timeoutMs: 30_000,
+      fetchImpl,
+      sleepImpl,
+    });
+
+    if (!result.ok) {
+      const partial = Object.keys(verdicts).length;
+      const reason = result.status
+        ? `${result.reason} at offset=${offset} after retries`
+        : `${result.reason} at offset=${offset} after retries`;
+      if (strict) {
+        // Strict: throw so the build fails loudly.
+        throw new Error(
+          `record-verdicts: ${reason}. ${partial} verdicts were collected ` +
+            `before the failure; refusing to ship a partial/empty ` +
+            `record-verdicts.json in strict mode. Set STRICT_VERDICTS=0 to ` +
+            `force degraded behavior locally.`
+        );
       }
-      const data = await resp.json();
-      const items = data.verdicts || [];
-      for (const v of items) {
-        const entry = {
-          verdict: v.verdict,
-          confidence: v.confidence,
-          sourcesChecked: v.sourcesChecked,
-          needsRecheck: v.needsRecheck,
-          lastComputedAt: v.lastComputedAt,
-        };
-        if (v.fieldName) {
-          // Per-field verdict: keyed as "recordType:recordId:fieldName"
-          verdicts[`${v.recordType}:${v.recordId}:${v.fieldName}`] = entry;
-        } else {
-          // Whole-row verdict: keyed as "recordType:recordId"
-          verdicts[`${v.recordType}:${v.recordId}`] = entry;
-        }
-      }
-      if (items.length < pageSize) break;
-      offset += pageSize;
+      logWikiServerWarning(
+        'record-verdicts',
+        `${reason} — returning ${partial} partial result(s) (non-strict mode)`
+      );
+      return verdicts;
     }
 
-    const count = Object.keys(verdicts).length;
-    if (count > 0) {
-      console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
-    } else {
-      console.log('  record-verdicts: 0 verdicts (none computed yet)');
+    const items = result.data.verdicts || [];
+    for (const v of items) {
+      const entry = {
+        verdict: v.verdict,
+        confidence: v.confidence,
+        sourcesChecked: v.sourcesChecked,
+        needsRecheck: v.needsRecheck,
+        lastComputedAt: v.lastComputedAt,
+      };
+      if (v.fieldName) {
+        // Per-field verdict: keyed as "recordType:recordId:fieldName"
+        verdicts[`${v.recordType}:${v.recordId}:${v.fieldName}`] = entry;
+      } else {
+        // Whole-row verdict: keyed as "recordType:recordId"
+        verdicts[`${v.recordType}:${v.recordId}`] = entry;
+      }
     }
-    return verdicts;
-  } catch (err) {
-    logWikiServerWarning('record-verdicts', err instanceof Error ? err.message : String(err));
-    return {};
+    if (items.length < pageSize) break;
+    offset += pageSize;
   }
+
+  const count = Object.keys(verdicts).length;
+  if (count > 0) {
+    console.log(`  record-verdicts: ${count} verdicts fetched from PG`);
+  } else {
+    console.log('  record-verdicts: 0 verdicts (none computed yet)');
+  }
+  return verdicts;
 }
 
 /**

--- a/apps/wiki-server/package.json
+++ b/apps/wiki-server/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/sourcing-types": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.4",

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -31,84 +31,27 @@ export const PageIdSchema = z.string().min(1).max(200);
 
 // ---------------------------------------------------------------------------
 // Record Source-Checks
+//
+// QUA-424: Canonical definitions now live in `@longterm-wiki/sourcing-types`
+// so the frontend and backend share one source of truth. Re-exported here
+// for backwards compatibility — existing imports of VALID_RECORD_TYPES,
+// SOURCING_EXEMPT_TYPES, etc. from `@wiki-server/api-types` continue to
+// work. New code should import from the shared package directly.
 // ---------------------------------------------------------------------------
 
-export const VALID_RECORD_TYPES = [
-  "grant",
-  "personnel",
-  "division",
-  "funding-program",
-  "funding-round",
-  "investment",
-  "equity-position",
-  "policy-stakeholder",
-  "publication",
-  "benchmark-result",
-  "entity-event",
-  "entity-assessment",
-  "secondary-market-price",
-  "citation",
-  "wiki-page",
-  "fact",
-] as const;
-
-export type RecordType = (typeof VALID_RECORD_TYPES)[number];
-
-/**
- * Record types that are exempt from sourcing verification.
- *
- * These are data classes where the ingestion source IS the canonical reference,
- * so running sourcing verification against them produces noise rather than signal.
- * They are excluded from coverage metrics, recheck queues, and the sourcing
- * pipeline. The exemption is explicit — without this list, nothing prevents
- * someone from accidentally running sourcing on these types and polluting
- * the verdicts table.
- *
- * Criteria for exemption:
- *   1. Data is ingested directly from an authoritative API (Manifold, arXiv, etc.)
- *   2. The source URL in the record IS the canonical reference — re-checking it
- *      against external sources is circular
- *   3. Data is computed/derived from other already-verified records
- *
- * When adding a new exempt type, document the reason inline.
- */
-export const SOURCING_EXEMPT_TYPES = [
-  // Ingested directly from benchmark provider APIs (e.g., provider docs, eval harnesses).
-  // The benchmark scores ARE the canonical data — no external source to verify against.
-  "benchmark-result",
-
-  // Computed by the citation accuracy system, not manually entered data.
-  // Citation accuracy has its own separate verification pipeline.
-  "citation",
-
-  // LLM-generated or editorial assessments (importance, risk, etc.).
-  // These are opinions/judgments, not factual claims that can be sourcing-checked.
-  "entity-assessment",
-
-  // Time-series pricing data ingested from secondary market APIs.
-  // The API response IS the canonical price — re-checking it is circular.
-  "secondary-market-price",
-] as const;
-
-export type SourcingExemptType = (typeof SOURCING_EXEMPT_TYPES)[number];
-
-/**
- * Check whether a record type is exempt from sourcing verification.
- * Use this instead of manual array checks to ensure consistency.
- */
-export function isSourcingExempt(recordType: string): boolean {
-  return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
-}
-
-export const VALID_SOURCE_CHECK_VERDICTS = [
-  "confirmed",
-  "contradicted",
-  "unverifiable",
-  "outdated",
-  "partial",
-] as const;
-
-export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];
+export {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+  VALID_SOURCE_CHECK_VERDICTS,
+  isSourcingExempt,
+  isValidRecordType,
+  isLinkableSourcingType,
+} from "@longterm-wiki/sourcing-types";
+export type {
+  RecordType,
+  SourcingExemptType,
+  SourcingVerdict,
+} from "@longterm-wiki/sourcing-types";
 
 // ---------------------------------------------------------------------------
 // Edit Logs

--- a/packages/sourcing-types/package.json
+++ b/packages/sourcing-types/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@longterm-wiki/sourcing-types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/sourcing-types/src/index.ts
+++ b/packages/sourcing-types/src/index.ts
@@ -1,0 +1,138 @@
+/**
+ * @longterm-wiki/sourcing-types — Canonical sourcing record-type and verdict
+ * definitions shared by wiki-server, apps/web, and crux.
+ *
+ * This package exists so the frontend and backend cannot drift on the set of
+ * record types the sourcing pipeline supports. Before it, VALID_RECORD_TYPES
+ * lived in `apps/wiki-server/src/api-types.ts` and the frontend imported it
+ * via a backend-to-frontend path alias — a dependency direction that broke
+ * the "apps don't depend on each other" invariant. Now both apps depend on
+ * this package (QUA-424, QUA-408 Phase 4 category S).
+ *
+ * Scope is deliberately narrow: constants, types, and pure helpers. Zod
+ * schemas stay in `apps/wiki-server/src/api-types.ts` next to the request
+ * validators that use them.
+ */
+
+// ── Record types ──────────────────────────────────────────────────────────
+
+/**
+ * The canonical list of record types supported by the sourcing pipeline.
+ * Adding a new type here requires matching server-side storage + read-path
+ * rendering; removing a type requires cleaning up `source_check_verdicts`.
+ *
+ * Kept as a readonly tuple so `RecordType` is a string-literal union.
+ */
+export const VALID_RECORD_TYPES = [
+  "grant",
+  "personnel",
+  "division",
+  "funding-program",
+  "funding-round",
+  "investment",
+  "equity-position",
+  "policy-stakeholder",
+  "publication",
+  "benchmark-result",
+  "entity-event",
+  "entity-assessment",
+  "secondary-market-price",
+  "citation",
+  "wiki-page",
+  "fact",
+] as const;
+
+export type RecordType = (typeof VALID_RECORD_TYPES)[number];
+
+/**
+ * Record types that are exempt from sourcing verification.
+ *
+ * These are data classes where the ingestion source IS the canonical reference,
+ * so running sourcing verification against them produces noise rather than signal.
+ * They are excluded from coverage metrics, recheck queues, and the sourcing
+ * pipeline. The exemption is explicit — without this list, nothing prevents
+ * someone from accidentally running sourcing on these types and polluting
+ * the verdicts table.
+ *
+ * Criteria for exemption:
+ *   1. Data is ingested directly from an authoritative API (Manifold, arXiv, etc.)
+ *   2. The source URL in the record IS the canonical reference — re-checking it
+ *      against external sources is circular
+ *   3. Data is computed/derived from other already-verified records
+ *
+ * When adding a new exempt type, document the reason inline.
+ */
+export const SOURCING_EXEMPT_TYPES = [
+  // Ingested directly from benchmark provider APIs (e.g., provider docs, eval harnesses).
+  // The benchmark scores ARE the canonical data — no external source to verify against.
+  "benchmark-result",
+
+  // Computed by the citation accuracy system, not manually entered data.
+  // Citation accuracy has its own separate verification pipeline.
+  "citation",
+
+  // LLM-generated or editorial assessments (importance, risk, etc.).
+  // These are opinions/judgments, not factual claims that can be sourcing-checked.
+  "entity-assessment",
+
+  // Time-series pricing data ingested from secondary market APIs.
+  // The API response IS the canonical price — re-checking it is circular.
+  "secondary-market-price",
+] as const;
+
+export type SourcingExemptType = (typeof SOURCING_EXEMPT_TYPES)[number];
+
+// ── Verdicts ──────────────────────────────────────────────────────────────
+
+/**
+ * Valid source-check verdict states written by the LLM sourcing pipeline.
+ * Does not include `unchecked`, which is a placeholder the pipeline writes
+ * before running a check — not a verdict produced by it.
+ */
+export const VALID_SOURCE_CHECK_VERDICTS = [
+  "confirmed",
+  "contradicted",
+  "unverifiable",
+  "outdated",
+  "partial",
+] as const;
+
+export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a record type is exempt from sourcing verification.
+ * Use this instead of manual array checks to ensure consistency.
+ *
+ * Accepts `string` (not `RecordType`) because callers often hold
+ * user-supplied or stored strings. Returns false for unknown types.
+ */
+export function isSourcingExempt(recordType: string): boolean {
+  return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
+}
+
+/**
+ * Check whether a record type is in the canonical sourcing list.
+ * Useful for guarding FE helpers (getSourcingHref, getRecordVerdict) at the
+ * boundary — an unregistered type passed in should quietly degrade rather
+ * than linking to a 404.
+ */
+export function isValidRecordType(recordType: string): recordType is RecordType {
+  return (VALID_RECORD_TYPES as readonly string[]).includes(recordType);
+}
+
+/**
+ * Check whether a record type is both a valid sourcing type AND not exempt —
+ * i.e., would have stored verdicts worth linking to. Equivalent to:
+ *
+ *   isValidRecordType(t) && !isSourcingExempt(t)
+ *
+ * Used by `getSourcingHref` to decide whether to return a real URL or
+ * `undefined` (which makes the receiving dot non-clickable).
+ */
+export function isLinkableSourcingType(
+  recordType: string,
+): recordType is Exclude<RecordType, SourcingExemptType> {
+  return isValidRecordType(recordType) && !isSourcingExempt(recordType);
+}

--- a/packages/sourcing-types/tests/index.test.ts
+++ b/packages/sourcing-types/tests/index.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+  VALID_SOURCE_CHECK_VERDICTS,
+  isSourcingExempt,
+  isValidRecordType,
+  isLinkableSourcingType,
+  type RecordType,
+  type SourcingExemptType,
+  type SourcingVerdict,
+} from "../src/index.js";
+
+describe("VALID_RECORD_TYPES", () => {
+  it("contains the known sourcing types", () => {
+    expect(VALID_RECORD_TYPES).toContain("grant");
+    expect(VALID_RECORD_TYPES).toContain("personnel");
+    expect(VALID_RECORD_TYPES).toContain("fact");
+    expect(VALID_RECORD_TYPES).toContain("wiki-page");
+  });
+
+  it("does not contain unregistered types flagged in QUA-416", () => {
+    // These are types the UI tried to link to but the backend never stored.
+    expect(VALID_RECORD_TYPES).not.toContain("entity");
+    expect(VALID_RECORD_TYPES).not.toContain("race");
+    expect(VALID_RECORD_TYPES).not.toContain("race-candidate");
+    expect(VALID_RECORD_TYPES).not.toContain("model-release");
+    expect(VALID_RECORD_TYPES).not.toContain("prediction-question");
+    expect(VALID_RECORD_TYPES).not.toContain("project");
+  });
+
+  it("is frozen in length — adding a type is a schema change", () => {
+    // Adjust this when the sourcing pipeline genuinely grows a new type.
+    // The explicit count catches silent removals via merge conflict.
+    expect(VALID_RECORD_TYPES.length).toBe(16);
+  });
+});
+
+describe("SOURCING_EXEMPT_TYPES", () => {
+  it("contains the four known exempt types", () => {
+    expect([...SOURCING_EXEMPT_TYPES].sort()).toEqual([
+      "benchmark-result",
+      "citation",
+      "entity-assessment",
+      "secondary-market-price",
+    ]);
+  });
+
+  it("every exempt type is also a valid record type (invariant)", () => {
+    // If this fails, either the exempt list references a nonexistent type
+    // or VALID_RECORD_TYPES dropped one without updating exempts.
+    for (const t of SOURCING_EXEMPT_TYPES) {
+      expect(
+        (VALID_RECORD_TYPES as readonly string[]).includes(t),
+        `exempt type "${t}" missing from VALID_RECORD_TYPES`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("VALID_SOURCE_CHECK_VERDICTS", () => {
+  it("matches the five verdict states the LLM pipeline can produce", () => {
+    expect([...VALID_SOURCE_CHECK_VERDICTS].sort()).toEqual([
+      "confirmed",
+      "contradicted",
+      "outdated",
+      "partial",
+      "unverifiable",
+    ]);
+  });
+
+  it("does NOT include 'unchecked' — that is a placeholder, not a verdict", () => {
+    expect(VALID_SOURCE_CHECK_VERDICTS).not.toContain("unchecked");
+  });
+});
+
+describe("isSourcingExempt", () => {
+  it("returns true for known exempt types", () => {
+    expect(isSourcingExempt("benchmark-result")).toBe(true);
+    expect(isSourcingExempt("citation")).toBe(true);
+    expect(isSourcingExempt("entity-assessment")).toBe(true);
+    expect(isSourcingExempt("secondary-market-price")).toBe(true);
+  });
+
+  it("returns false for non-exempt valid types", () => {
+    expect(isSourcingExempt("grant")).toBe(false);
+    expect(isSourcingExempt("personnel")).toBe(false);
+    expect(isSourcingExempt("fact")).toBe(false);
+  });
+
+  it("returns false for unregistered types (no crash)", () => {
+    expect(isSourcingExempt("entity")).toBe(false);
+    expect(isSourcingExempt("race")).toBe(false);
+    expect(isSourcingExempt("")).toBe(false);
+  });
+});
+
+describe("isValidRecordType", () => {
+  it("narrows string to RecordType when valid", () => {
+    const raw: string = "grant";
+    if (isValidRecordType(raw)) {
+      // Compile check: raw is narrowed to RecordType inside the block.
+      const _typed: RecordType = raw;
+      expect(_typed).toBe("grant");
+    }
+  });
+
+  it("returns false for unregistered types flagged in QUA-416", () => {
+    expect(isValidRecordType("entity")).toBe(false);
+    expect(isValidRecordType("race")).toBe(false);
+    expect(isValidRecordType("model-release")).toBe(false);
+    expect(isValidRecordType("prediction-question")).toBe(false);
+    expect(isValidRecordType("project")).toBe(false);
+    expect(isValidRecordType("")).toBe(false);
+    expect(isValidRecordType("garbage-123")).toBe(false);
+  });
+});
+
+describe("isLinkableSourcingType", () => {
+  it("returns true for valid, non-exempt types", () => {
+    expect(isLinkableSourcingType("grant")).toBe(true);
+    expect(isLinkableSourcingType("personnel")).toBe(true);
+    expect(isLinkableSourcingType("fact")).toBe(true);
+    expect(isLinkableSourcingType("wiki-page")).toBe(true);
+  });
+
+  it("returns false for exempt types (even though they ARE valid)", () => {
+    expect(isLinkableSourcingType("benchmark-result")).toBe(false);
+    expect(isLinkableSourcingType("citation")).toBe(false);
+    expect(isLinkableSourcingType("entity-assessment")).toBe(false);
+    expect(isLinkableSourcingType("secondary-market-price")).toBe(false);
+  });
+
+  it("returns false for unregistered types", () => {
+    expect(isLinkableSourcingType("entity")).toBe(false);
+    expect(isLinkableSourcingType("race")).toBe(false);
+    expect(isLinkableSourcingType("model-release")).toBe(false);
+    expect(isLinkableSourcingType("project")).toBe(false);
+  });
+
+  it("excludes all SOURCING_EXEMPT_TYPES by construction", () => {
+    for (const exempt of SOURCING_EXEMPT_TYPES) {
+      expect(
+        isLinkableSourcingType(exempt),
+        `exempt type "${exempt}" should not be linkable`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("type compatibility", () => {
+  it("SourcingExemptType is a subset of RecordType (compile check)", () => {
+    // Compile-time: if SourcingExemptType includes a value not in RecordType,
+    // this assignment fails and the whole test file won't build.
+    const exempt: SourcingExemptType = "benchmark-result";
+    const asRecordType: RecordType = exempt;
+    expect(asRecordType).toBe("benchmark-result");
+  });
+
+  it("SourcingVerdict is a string-literal union, not generic string", () => {
+    const v: SourcingVerdict = "confirmed";
+    expect(v).toBe("confirmed");
+  });
+});

--- a/packages/sourcing-types/tsconfig.json
+++ b/packages/sourcing-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/sourcing-types':
+        specifier: workspace:*
+        version: link:../../packages/sourcing-types
       '@quri/squiggle-components':
         specifier: ^0.10.0
         version: 0.10.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -348,6 +351,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/sourcing-types':
+        specifier: workspace:*
+        version: link:../../packages/sourcing-types
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
@@ -394,6 +400,15 @@ importers:
         version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/id-utils:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/sourcing-types:
     devDependencies:
       typescript:
         specifier: ^5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - "apps/groundskeeper"
   - "packages/factbase"
   - "packages/id-utils"
+  - "packages/sourcing-types"


### PR DESCRIPTION
## Summary

Extract `VALID_RECORD_TYPES`, `SOURCING_EXEMPT_TYPES`, `VALID_SOURCE_CHECK_VERDICTS`, and related helpers from `apps/wiki-server/src/api-types.ts` into a new shared workspace package `@longterm-wiki/sourcing-types`.

## Why

Before this change, the frontend imported these types from the backend via a `@wiki-server/api-types` path alias. That broke the "apps don't depend on each other" invariant and made silent drift possible on rename/move. The dead-link bug cluster (QUA-416/417/418) surfaced the cost — when FE code passed `"entity"`, `"race"`, `"model-release"` etc. to `getSourcingHref`, nothing in the type system caught that those weren't in `VALID_RECORD_TYPES`.

This PR lays the foundation (a stable shared import path) for **QUA-423 branded `RecordId<T>`**, which will make passing a composite key or a dead type a compile error.

## What moved

| Export | Before | After |
|---|---|---|
| `VALID_RECORD_TYPES` | `apps/wiki-server/src/api-types.ts` | `@longterm-wiki/sourcing-types` (re-exported from api-types.ts for backcompat) |
| `SOURCING_EXEMPT_TYPES` | same | same |
| `VALID_SOURCE_CHECK_VERDICTS` | same | same |
| `RecordType`, `SourcingExemptType`, `SourcingVerdict` | same | same |
| `isSourcingExempt()` | same | same |

## What's new (not previously in api-types.ts)

Two helpers that were repeatedly inlined at call sites get a canonical home:

```ts
export function isValidRecordType(recordType: string): recordType is RecordType;
export function isLinkableSourcingType(recordType: string):
  recordType is Exclude<RecordType, SourcingExemptType>;
```

`isLinkableSourcingType` is the single predicate `getSourcingHref` needs to decide whether a link would 404 — same check QUA-416 attempted inline. Both are type guards, so callers get narrowing for free.

## What did NOT move

- Zod schemas (`EvidenceBody`, `VerdictUpsertBody`, etc.) stay in `api-types.ts` next to the request validators that use them. The shared package is pure constants + types + predicates.
- Existing import sites of `@wiki-server/api-types` continue to work unchanged — `api-types.ts` re-exports every name. Migrating FE callers to import directly from the package is a mechanical follow-up.

## Follows `@longterm-wiki/id-utils` pattern

Same shape as the existing `packages/id-utils` package: `package.json` with `workspace:*` deps, `tsconfig.json`, `src/index.ts`, `tests/index.test.ts` with vitest. Added to `pnpm-workspace.yaml`.

## Test plan

**New package** — `packages/sourcing-types/tests/index.test.ts` (18 cases):

- [x] Known valid types present (grant, personnel, fact, wiki-page)
- [x] Unregistered types absent (entity, race, model-release, project, prediction-question)
- [x] `VALID_RECORD_TYPES.length === 16` (catches silent merge-drift)
- [x] `SOURCING_EXEMPT_TYPES` = {benchmark-result, citation, entity-assessment, secondary-market-price}
- [x] Invariant: every exempt type is also a valid type
- [x] `VALID_SOURCE_CHECK_VERDICTS` excludes 'unchecked' (it's a placeholder, not a verdict)
- [x] `isSourcingExempt` / `isValidRecordType` / `isLinkableSourcingType` predicates
- [x] `isLinkableSourcingType` excludes all exempt types by construction
- [x] Type narrowing compiles (guards work)
- [x] `SourcingExemptType` is assignable to `RecordType` (compile check)

**Regression** — existing suites still pass:

- [x] `pnpm --filter wiki-server test` — 1066 pass (55 files, 1 skip)
- [x] `pnpm --filter longterm-next test` — 1539 pass (85 files)
- [x] `npx tsc --noEmit` clean in both apps

## Deploy / migration

No code changes required for consumers. `api-types.ts` re-exports every name, so existing imports of `@wiki-server/api-types` keep working. Future commits can migrate call sites to `@longterm-wiki/sourcing-types` directly, but that's not required for this PR.

Closes QUA-424

Refs QUA-408 Phase 4 category S (single source of truth), QUA-423 (branded `RecordId<T>` — depends on stable import path for `RecordType`)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry mechanism for wiki-server data fetching with exponential backoff between attempts
  * Added configurable strict mode for handling wiki-server verdict failures (fail-fast or graceful degradation)

* **Tests**
  * Added comprehensive test suite for retry logic and error handling
  * Added validation tests for sourcing type definitions and helper functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->