### PR TITLE
fix(factbase): strip Constellation Brands facts from EA Constellation entity

### DIFF
--- a/packages/factbase/data/things/constellation.yaml
+++ b/packages/factbase/data/things/constellation.yaml
@@ -1,25 +1,2 @@
 entity: sid_jwe4re7Ggo
-facts:
-  [
-    {
-        id: Rx7TaITzhQ,
-        property: founded-date,
-        value: "1945",
-        source: https://www.wikidata.org/wiki/Q1128160,
-        notes: From Wikidata Q1128160
-      },
-    {
-        id: VxFKo3Ig1g,
-        property: headquarters,
-        value: Victor,
-        source: https://www.wikidata.org/wiki/Q1128160,
-        notes: From Wikidata Q1128160
-      },
-    {
-        id: 7wGAEYs8GQ,
-        property: website,
-        value: http://www.cbrands.com,
-        source: https://www.wikidata.org/wiki/Q1128160,
-        notes: From Wikidata Q1128160
-      }
-  ]
+facts: []


### PR DESCRIPTION
## Summary
- The FactBase entry for `constellation` (sid_jwe4re7Ggo — the Berkeley AI-safety co-working space, constellation.org) held three facts imported from Wikidata Q1128160, which is **Constellation Brands** (the alcohol distributor, cbrands.com).
- Live-visible as wrong data on https://www.longtermwiki.com/organizations/constellation/data (founded 1945, HQ Victor, website cbrands.com).
- This PR empties the facts list in `packages/factbase/data/things/constellation.yaml`. We don't have authoritative replacements, so `facts: []` is the right short-term state.

## Systemic risk — QUA-447
Wikidata importer matched by name/slug without checking entity type. 47 Wikidata-sourced facts exist across 20 FactBase files; any entity with a slug colliding with a more famous Wikidata entry can be silently contaminated. Filed QUA-447 with proposed mitigations (type-aware import, persist QID, sweep existing data).

## Test plan
- [x] `pnpm crux w validate gate --scope=content --fix` passes
- [x] `pnpm crux fb show constellation` now shows 0 facts instead of 3 contaminated ones
- [ ] After deploy: verify https://www.longtermwiki.com/organizations/constellation/data no longer shows alcohol-co facts

Closes QUA-447 partial — the immediate contamination is removed; systemic fix tracked on the ticket.
