### PR TITLE
fix(sourcing): runtime guard against composite-key recordIds (QUA-423 phase 2)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@dagrejs/dagre": "^1.1.8",
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/sourcing-types": "workspace:*",
     "@quri/squiggle-components": "^0.10.0",
     "@quri/squiggle-lang": "^0.10.0",
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/apps/web/src/app/sourcing/__tests__/sourcing-href.test.ts
+++ b/apps/web/src/app/sourcing/__tests__/sourcing-href.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for getSourcingHref / getStoredVerdictHref runtime guards (QUA-423 phase 2).
+ *
+ * The QUA-417 bug shipped because getSourcingHref and getRecordVerdict
+ * accepted any string as recordId. This suite locks in that the runtime
+ * guard (via isCandidateRecordId) rejects the specific composite-key
+ * shape that caused QUA-417, without regressing real-world PK shapes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getSourcingHref,
+  getStoredVerdictHref,
+} from "../sourcing-shared";
+
+describe("getSourcingHref — QUA-423 phase 2 runtime guard", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns a URL for valid record PKs", () => {
+    expect(getSourcingHref("grant", "8NUnVSueLS")).toBe(
+      "/sourcing/grant/8NUnVSueLS",
+    );
+    expect(getSourcingHref("personnel", "sid_A4XoubikkQ")).toBe(
+      "/sourcing/personnel/sid_A4XoubikkQ",
+    );
+    expect(getSourcingHref("fact", "f_mEKUPPFYRg")).toBe(
+      "/sourcing/fact/f_mEKUPPFYRg",
+    );
+  });
+
+  it("returns undefined for the exact QUA-417 composite-key shape", () => {
+    // conn.key built from ownerEntityId + "-" + record.key
+    expect(
+      getSourcingHref("grant", "sid_ULjDXpSLCI-8NUnVSueLS"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for other sid_-prefixed composites", () => {
+    expect(getSourcingHref("grant", "sid_abc-sid_def")).toBeUndefined();
+    expect(getSourcingHref("personnel", "sid_x-y")).toBeUndefined();
+  });
+
+  it("returns undefined for two-numeric-ID composites", () => {
+    expect(getSourcingHref("funding-round", "12345-67890")).toBeUndefined();
+  });
+
+  it("returns undefined for empty strings", () => {
+    expect(getSourcingHref("grant", "")).toBeUndefined();
+  });
+
+  it("does NOT flag legitimate hyphenated slugs (false-positive guard)", () => {
+    // Some sourcing pipelines use hyphenated IDs — must not break these.
+    expect(getSourcingHref("wiki-page", "some-name-2024")).toBe(
+      "/sourcing/wiki-page/some-name-2024",
+    );
+    expect(getSourcingHref("publication", "arxiv-2310-12345")).toBe(
+      "/sourcing/publication/arxiv-2310-12345",
+    );
+    expect(getSourcingHref("grant", "1-2")).toBe("/sourcing/grant/1-2");
+  });
+
+  it("URL-encodes recordId and recordType (special chars)", () => {
+    const href = getSourcingHref("wiki-page", "foo/bar");
+    expect(href).toBe("/sourcing/wiki-page/foo%2Fbar");
+  });
+
+  it("logs a dev-mode warning naming the caller and recordId on guard failure", () => {
+    getSourcingHref("grant", "sid_ULjDXpSLCI-8NUnVSueLS");
+    expect(warnSpy).toHaveBeenCalled();
+    const msg = warnSpy.mock.calls[0][0];
+    expect(msg).toContain("getSourcingHref");
+    expect(msg).toContain("sid_ULjDXpSLCI-8NUnVSueLS");
+    expect(msg).toMatch(/QUA-417/);
+  });
+});
+
+describe("getStoredVerdictHref — always returns string", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("matches getSourcingHref for valid inputs", () => {
+    expect(getStoredVerdictHref("grant", "8NUnVSueLS")).toBe(
+      "/sourcing/grant/8NUnVSueLS",
+    );
+  });
+
+  it("falls back to /sourcing index when the guard rejects (never undefined)", () => {
+    const result = getStoredVerdictHref("grant", "sid_abc-sid_def");
+    expect(result).toBe("/sourcing");
+    expect(typeof result).toBe("string");
+    // Two warnings fire: one from getSourcingHref's guard + one from
+    // getStoredVerdictHref's fallback notice.
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("has string return type (compile check)", () => {
+    // If the return type drifts to `string | undefined`, this assignment
+    // fails at tsc time. That's the whole point of getStoredVerdictHref
+    // over getSourcingHref.
+    const href: string = getStoredVerdictHref("grant", "g1");
+    expect(href).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/sourcing/sourcing-shared.tsx
+++ b/apps/web/src/app/sourcing/sourcing-shared.tsx
@@ -4,6 +4,7 @@ import {
   SOURCE_CHECK_VERDICT_DESCRIPTIONS,
   SOURCE_CHECK_VERDICT_PRIORITY,
 } from "@/components/shared/verdict-styles";
+import { isCandidateRecordId } from "@longterm-wiki/sourcing-types";
 
 // ── Verdict styling (from shared module) ────────────────────────────────
 // Cast to Record<string, ...> so consumers can index with `string` verdict keys
@@ -89,9 +90,76 @@ export function getRecordHref(recordType: string, recordId: string): string | nu
   }
 }
 
-/** Get the URL for the sourcing detail page. */
-export function getSourcingHref(recordType: string, recordId: string): string {
+/** The sourcing index — used as a safe fallback when an ID would otherwise
+ *  build a 404 URL. See getStoredVerdictHref for why. */
+const SOURCING_INDEX_HREF = "/sourcing";
+
+/** Build the `/sourcing/:recordType/:recordId` path without any guards.
+ *  Callers are responsible for having already verified the IDs. */
+function buildSourcingPath(recordType: string, recordId: string): string {
   return `/sourcing/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`;
+}
+
+/**
+ * Get the URL for the sourcing detail page.
+ *
+ * QUA-423 phase 2: runtime guard against malformed record IDs. If `recordId`
+ * looks like a composite React key (e.g. `sid_ULjDXpSLCI-8NUnVSueLS` — the
+ * QUA-417 bug shape), returns `undefined` instead of building a 404 URL.
+ * Dot components already skip the `<a>` wrapper when `href` is undefined, so
+ * a malformed ID silently renders as a non-clickable dot rather than a
+ * broken link.
+ *
+ * The runtime check is the pragmatic half of the QUA-423 plan: it catches
+ * the real bug class without churning the ~70 existing call sites to wrap
+ * raw strings with `asRecordId()`. Compile-time narrowing via `RecordId<T>`
+ * is an optional follow-up once call sites stabilize.
+ */
+export function getSourcingHref(
+  recordType: string,
+  recordId: string,
+): string | undefined {
+  if (!isCandidateRecordId(recordId)) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sourcing] getSourcingHref(${JSON.stringify(recordType)}, ${JSON.stringify(recordId)}): ` +
+          `recordId failed isCandidateRecordId guard (likely a composite React key — see QUA-417). ` +
+          `Returning undefined; the receiving dot will render non-clickable.`,
+      );
+    }
+    return undefined;
+  }
+  return buildSourcingPath(recordType, recordId);
+}
+
+/**
+ * Variant of getSourcingHref for callers rendering rows that already came
+ * from the sourcing verdict store (e.g. /api/sourcing/verdicts). Every row
+ * there has a valid recordType + recordId by construction, so the href is
+ * always definable.
+ *
+ * Defense in depth: if the value somehow fails the guard (orphan row,
+ * mis-typed fixture), falls back to the sourcing index with a dev-mode
+ * warning — strictly better than rendering a 404 URL. Return type is
+ * `string` (not `string | undefined`) so Next.js `<Link>` accepts it
+ * without caller-side fallbacks.
+ */
+export function getStoredVerdictHref(
+  recordType: string,
+  recordId: string,
+): string {
+  const href = getSourcingHref(recordType, recordId);
+  if (href) return href;
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[sourcing] getStoredVerdictHref: no href for stored verdict ` +
+        `${recordType}:${recordId} — falling back to ${SOURCING_INDEX_HREF}. ` +
+        `This suggests an orphaned record_type in source_check_verdicts.`,
+    );
+  }
+  return SOURCING_INDEX_HREF;
 }
 
 /**

--- a/apps/web/src/app/sourcing/sourcing-table.tsx
+++ b/apps/web/src/app/sourcing/sourcing-table.tsx
@@ -5,7 +5,7 @@ import {
   VerdictBadge,
   formatRecordType,
   getRecordHref,
-  getSourcingHref,
+  getStoredVerdictHref,
 } from "./sourcing-shared";
 
 interface SourcingTableProps {
@@ -20,10 +20,10 @@ function resolveClaimDisplay(
   v: RpcSourcingVerdictRow,
   names: Record<string, string>,
   claims: Record<string, string>
-): { text: string; href: string | null; isFallback: boolean } {
+): { text: string; href: string; isFallback: boolean } {
   const claimKey = `${v.recordType}:${v.recordId}:${v.fieldName ?? ""}`;
   const claim = claims[claimKey];
-  const detailHref = getSourcingHref(v.recordType, v.recordId);
+  const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
   if (claim) {
     return { text: claim, href: detailHref, isFallback: false };
   }
@@ -53,7 +53,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
       {/* ── Mobile card list (< sm) ──────────────────────────────────────── */}
       <div className="block sm:hidden space-y-2">
         {verdicts.map((v) => {
-          const detailHref = getSourcingHref(v.recordType, v.recordId);
+          const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
           const recordName = names[v.recordId];
           const entityName = v.entityId ? names[v.entityId] : null;
           const { text: claimText } = resolveClaimDisplay(v, names, claims);
@@ -110,7 +110,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
           </thead>
           <tbody>
             {verdicts.map((v) => {
-              const detailHref = getSourcingHref(v.recordType, v.recordId);
+              const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
               const recordName = names[v.recordId];
               const recordHref = getRecordHref(v.recordType, v.recordId);
               const entityName = v.entityId ? names[v.entityId] : null;

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -14,7 +14,7 @@ import type { RpcSourcingDetailResult } from "@/lib/wiki-server";
 import {
   VerdictBadge,
   formatRecordType,
-  getSourcingHref,
+  getStoredVerdictHref,
 } from "../../sourcing/sourcing-shared";
 import { isAnySid } from "@longterm-wiki/id-utils";
 
@@ -497,7 +497,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
         )}
         {VERDICT_SOURCE_TABLES.has(thing.sourceTable) && (
           <Link
-            href={getSourcingHref(recordType, thing.sourceId)}
+            href={getStoredVerdictHref(recordType, thing.sourceId)}
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
           >
             <ShieldCheck className="h-3.5 w-3.5" />
@@ -622,7 +622,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
           </div>
           <div className="mt-3">
             <Link
-              href={getSourcingHref(recordType, thing.sourceId)}
+              href={getStoredVerdictHref(recordType, thing.sourceId)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               View full evidence
@@ -643,7 +643,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
               This record has not been sourcinged yet.
             </p>
             <Link
-              href={getSourcingHref(recordType, thing.sourceId)}
+              href={getStoredVerdictHref(recordType, thing.sourceId)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mt-2"
             >
               View source check page

--- a/apps/web/src/data/__tests__/field-verdicts.test.ts
+++ b/apps/web/src/data/__tests__/field-verdicts.test.ts
@@ -172,3 +172,82 @@ describe("getRecordVerdictStats — per-field entry filtering", () => {
     expect(stats.contradicted).toBe(0);
   });
 });
+
+// ── QUA-423 phase 2: runtime guard in getRecordVerdict + getFieldVerdict ──
+//
+// The QUA-417 bug was callers passing a composite React key (`${owner}-${id}`)
+// to getRecordVerdict. Before phase 2 this silently returned null (the key
+// didn't exist in the verdict map); now it explicitly returns null at the
+// guard, logs a dev-mode warning, and skips the map lookup entirely.
+
+describe("getRecordVerdict / getFieldVerdict — QUA-423 composite-key guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const mockVerdicts = buildMockVerdicts();
+    vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
+      const p = String(filePath);
+      if (p.includes("record-verdicts.json")) return JSON.stringify(mockVerdicts);
+      if (p.includes("database.json")) return JSON.stringify(mockDatabase);
+      if (p.includes("factbase-data.json")) {
+        return JSON.stringify({ entities: {}, facts: {}, slugToEntityId: {} });
+      }
+      return "{}";
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it("returns the verdict for a valid raw record PK", async () => {
+    const { getRecordVerdict } = await import("../tablebase");
+    const v = getRecordVerdict("grant", "g_001");
+    expect(v?.verdict).toBe("confirmed");
+  });
+
+  it("returns null for the QUA-417 composite-key shape (no silent lookup)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getRecordVerdict } = await import("../tablebase");
+
+    // sid_-prefixed composite (the exact shape that shipped)
+    const v = getRecordVerdict("grant", "sid_ULjDXpSLCI-g_001");
+    expect(v).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toContain("getRecordVerdict");
+    expect(String(warn.mock.calls[0][0])).toMatch(/QUA-417/);
+    warn.mockRestore();
+  });
+
+  it("returns null on empty string recordId (caller forgot a guard)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getRecordVerdict } = await import("../tablebase");
+    expect(getRecordVerdict("grant", "")).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("does NOT flag legitimate hyphenated IDs (false-positive guard)", async () => {
+    const { getRecordVerdict } = await import("../tablebase");
+    // Expect null because the key isn't in the mock, but the guard should
+    // NOT short-circuit and warn — these are legitimate IDs.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(getRecordVerdict("wiki-page", "some-name-2024")).toBeNull();
+    expect(getRecordVerdict("publication", "arxiv-2310-12345")).toBeNull();
+    // No warnings fired for these shapes.
+    for (const call of warn.mock.calls) {
+      expect(String(call[0])).not.toMatch(/QUA-417/);
+    }
+    warn.mockRestore();
+  });
+
+  it("getFieldVerdict applies the same guard", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getFieldVerdict } = await import("../tablebase");
+
+    // Valid: returns the per-field verdict
+    expect(getFieldVerdict("grant", "g_001", "amount")?.verdict).toBe("confirmed");
+
+    // Composite key: guarded
+    const v = getFieldVerdict("grant", "sid_abc-sid_def", "amount");
+    expect(v).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toContain("getFieldVerdict");
+    warn.mockRestore();
+  });
+});

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -36,6 +36,7 @@ import {
 import type { ValidSubcategory } from "./valid-subcategories";
 import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 import { extractDomain } from "@/lib/resource-types";
+import { isCandidateRecordId } from "@longterm-wiki/sourcing-types";
 
 // Re-export for consumers
 export type { WithSource };
@@ -1088,14 +1089,51 @@ function getRecordVerdicts(): Record<string, RecordVerdict> {
   }
 }
 
-/** Get the sourcing verdict for a specific record */
+/**
+ * Shared dev-mode warning for the QUA-417 composite-key bug class.
+ * No-op in production.
+ */
+function warnMalformedRecordId(
+  fn: string,
+  recordType: string,
+  recordId: string,
+): void {
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[sourcing] ${fn}(${JSON.stringify(recordType)}, ${JSON.stringify(recordId)}): ` +
+        `recordId failed isCandidateRecordId guard (likely a composite React key — see QUA-417). ` +
+        `Returning null; the caller's verdict lookup would have silently missed anyway.`,
+    );
+  }
+}
+
+/**
+ * Get the sourcing verdict for a specific record.
+ *
+ * QUA-423 phase 2: runtime guard against composite React keys passed as
+ * recordId (the QUA-417 bug shape). Returns null fast in dev mode with a
+ * console.warn pointing callers at the real fix.
+ */
 export function getRecordVerdict(recordType: string, recordId: string): RecordVerdict | null {
+  if (!isCandidateRecordId(recordId)) {
+    warnMalformedRecordId("getRecordVerdict", recordType, recordId);
+    return null;
+  }
   return getRecordVerdicts()[`${recordType}:${recordId}`] ?? null;
 }
 
-/** Get the sourcing verdict for a specific field of a record.
- * Returns null if no per-field verdict exists for this field. */
+/**
+ * Get the sourcing verdict for a specific field of a record.
+ * Returns null if no per-field verdict exists for this field.
+ *
+ * QUA-423 phase 2: same composite-key guard as getRecordVerdict.
+ */
 export function getFieldVerdict(recordType: string, recordId: string, fieldName: string): RecordVerdict | null {
+  if (!isCandidateRecordId(recordId)) {
+    warnMalformedRecordId("getFieldVerdict", recordType, recordId);
+    return null;
+  }
   return getRecordVerdicts()[`${recordType}:${recordId}:${fieldName}`] ?? null;
 }
 

--- a/apps/wiki-server/package.json
+++ b/apps/wiki-server/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/sourcing-types": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.4",

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -31,84 +31,27 @@ export const PageIdSchema = z.string().min(1).max(200);
 
 // ---------------------------------------------------------------------------
 // Record Source-Checks
+//
+// QUA-424: Canonical definitions now live in `@longterm-wiki/sourcing-types`
+// so the frontend and backend share one source of truth. Re-exported here
+// for backwards compatibility — existing imports of VALID_RECORD_TYPES,
+// SOURCING_EXEMPT_TYPES, etc. from `@wiki-server/api-types` continue to
+// work. New code should import from the shared package directly.
 // ---------------------------------------------------------------------------
 
-export const VALID_RECORD_TYPES = [
-  "grant",
-  "personnel",
-  "division",
-  "funding-program",
-  "funding-round",
-  "investment",
-  "equity-position",
-  "policy-stakeholder",
-  "publication",
-  "benchmark-result",
-  "entity-event",
-  "entity-assessment",
-  "secondary-market-price",
-  "citation",
-  "wiki-page",
-  "fact",
-] as const;
-
-export type RecordType = (typeof VALID_RECORD_TYPES)[number];
-
-/**
- * Record types that are exempt from sourcing verification.
- *
- * These are data classes where the ingestion source IS the canonical reference,
- * so running sourcing verification against them produces noise rather than signal.
- * They are excluded from coverage metrics, recheck queues, and the sourcing
- * pipeline. The exemption is explicit — without this list, nothing prevents
- * someone from accidentally running sourcing on these types and polluting
- * the verdicts table.
- *
- * Criteria for exemption:
- *   1. Data is ingested directly from an authoritative API (Manifold, arXiv, etc.)
- *   2. The source URL in the record IS the canonical reference — re-checking it
- *      against external sources is circular
- *   3. Data is computed/derived from other already-verified records
- *
- * When adding a new exempt type, document the reason inline.
- */
-export const SOURCING_EXEMPT_TYPES = [
-  // Ingested directly from benchmark provider APIs (e.g., provider docs, eval harnesses).
-  // The benchmark scores ARE the canonical data — no external source to verify against.
-  "benchmark-result",
-
-  // Computed by the citation accuracy system, not manually entered data.
-  // Citation accuracy has its own separate verification pipeline.
-  "citation",
-
-  // LLM-generated or editorial assessments (importance, risk, etc.).
-  // These are opinions/judgments, not factual claims that can be sourcing-checked.
-  "entity-assessment",
-
-  // Time-series pricing data ingested from secondary market APIs.
-  // The API response IS the canonical price — re-checking it is circular.
-  "secondary-market-price",
-] as const;
-
-export type SourcingExemptType = (typeof SOURCING_EXEMPT_TYPES)[number];
-
-/**
- * Check whether a record type is exempt from sourcing verification.
- * Use this instead of manual array checks to ensure consistency.
- */
-export function isSourcingExempt(recordType: string): boolean {
-  return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
-}
-
-export const VALID_SOURCE_CHECK_VERDICTS = [
-  "confirmed",
-  "contradicted",
-  "unverifiable",
-  "outdated",
-  "partial",
-] as const;
-
-export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];
+export {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+  VALID_SOURCE_CHECK_VERDICTS,
+  isSourcingExempt,
+  isValidRecordType,
+  isLinkableSourcingType,
+} from "@longterm-wiki/sourcing-types";
+export type {
+  RecordType,
+  SourcingExemptType,
+  SourcingVerdict,
+} from "@longterm-wiki/sourcing-types";
 
 // ---------------------------------------------------------------------------
 // Edit Logs

--- a/packages/sourcing-types/package.json
+++ b/packages/sourcing-types/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@longterm-wiki/sourcing-types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/sourcing-types/src/index.ts
+++ b/packages/sourcing-types/src/index.ts
@@ -136,3 +136,147 @@ export function isLinkableSourcingType(
 ): recordType is Exclude<RecordType, SourcingExemptType> {
   return isValidRecordType(recordType) && !isSourcingExempt(recordType);
 }
+
+// ── Branded record IDs (QUA-423) ──────────────────────────────────────────
+//
+// A `RecordId<T>` is a string tagged with a record-type-literal at the type
+// level. Tagging is done via an intersection with a phantom object type that
+// carries two read-only brands: a common "RecordId" marker (so any RecordId
+// carries the brand) and a type-specific `__type: T` (so `RecordId<"grant">`
+// is not assignable to `RecordId<"personnel">` or vice versa).
+//
+// Why brands, not just `type RecordId<T> = string`? If the alias were a raw
+// string, passing any string — a composite React key, a slug, an unrelated
+// id — would type-check fine. That's exactly how QUA-417's composite-key
+// bug shipped: `conn.key` (owner + "-" + record_key) was a plain string
+// happily accepted by `getRecordVerdict(recordType: string, recordId: string)`.
+//
+// With brands, the only way to get a `RecordId<T>` is through `asRecordId()`,
+// which has a runtime check for obviously-composite shapes (e.g. a value
+// that contains a hyphen AND has a `sid_` prefix on BOTH sides) and would
+// have thrown at dev time for the funding-connections bug.
+
+/**
+ * Opaque, type-tagged record ID. Construct only via `asRecordId()`.
+ *
+ * Two records of different types are not assignable to each other at the type
+ * level: `RecordId<"grant">` is distinct from `RecordId<"personnel">`. This
+ * is load-bearing for `getSourcingHref(type, id)` — callers can't accidentally
+ * pass a grant ID where a personnel ID was expected.
+ */
+export type RecordId<T extends RecordType = RecordType> = string & {
+  readonly __brand: "RecordId";
+  readonly __type: T;
+};
+
+/**
+ * Thrown by `asRecordId()` when the input clearly isn't a raw record PK.
+ * Exported so callers can handle it distinctly from generic runtime errors
+ * (e.g. log + fall back to `null` in non-strict contexts).
+ */
+export class InvalidRecordIdError extends Error {
+  constructor(
+    public readonly recordType: string,
+    public readonly rawId: string,
+    reason: string,
+  ) {
+    super(
+      `asRecordId(${JSON.stringify(recordType)}, ${JSON.stringify(rawId)}): ${reason}`,
+    );
+    this.name = "InvalidRecordIdError";
+  }
+}
+
+/**
+ * Heuristic: does this look like a composite React key rather than a raw PK?
+ *
+ * The QUA-417 bug was `conn.key = \`${ownerEntityId}-${record.key}\``. The
+ * ownerEntityId was a `sid_`-prefixed stableId (entity PK) and record.key
+ * was a 10-char alphanumeric grant PK — e.g. `sid_ULjDXpSLCI-8NUnVSueLS`.
+ *
+ * Shapes caught:
+ *   - `sid_X-<alphanumRight>`   → stableId + anything alphanumeric (the QUA-417 shape)
+ *   - `<numericLeft>-<numericRight>` with substantial digit runs on both sides
+ *
+ * Does NOT flag legitimate hyphenated IDs (e.g. `some-name-2024`, `arxiv-2310-12345`)
+ * because legit slugs don't start with `sid_` and don't have pure multi-digit
+ * runs on both sides of a hyphen.
+ *
+ * Intentionally narrow — false negatives are fine (a real PK won't match
+ * the stable form); false positives on real PKs would break legitimate callers.
+ */
+function looksLikeCompositeKey(rawId: string): boolean {
+  // Starts with `sid_...` followed by `-` and more content on the right:
+  // this is the QUA-417 shape (`sid_<owner>-<grantPK>`), or two stableIds
+  // joined (`sid_X-sid_Y`). Anything with sid_ immediately followed by `-`
+  // is a composite: stableIds themselves don't contain hyphens.
+  if (/^sid_[A-Za-z0-9]+-[A-Za-z0-9]+/.test(rawId)) return true;
+  // Two multi-digit numeric IDs joined: `12345-67890` but NOT `1-2` or `a-b`
+  // (those could be legitimate slugs).
+  if (/^\d{3,}-\d{3,}$/.test(rawId)) return true;
+  return false;
+}
+
+/**
+ * Construct a `RecordId<T>` from a raw string.
+ *
+ * Runtime guards catch obvious mistakes at dev/test time:
+ *   - Empty strings (caller passed undefined/null by mistake)
+ *   - Excessive length (caller passed a display name or URL)
+ *   - Composite-key shapes (React `key=` values, `${a}-${b}` concatenations)
+ *
+ * Throws `InvalidRecordIdError` on rejection. Callers that need a non-throwing
+ * variant can guard with `isCandidateRecordId()` below.
+ *
+ * NOTE: This does NOT validate `recordType` — use `isValidRecordType()` for
+ * that. Narrowing type param `T extends RecordType` is a compile-time guard;
+ * at runtime a caller could still pass an unregistered string. The function
+ * focuses exclusively on ID-shape validation.
+ */
+export function asRecordId<T extends RecordType>(
+  recordType: T,
+  rawId: string,
+): RecordId<T> {
+  if (typeof rawId !== "string") {
+    throw new InvalidRecordIdError(
+      recordType,
+      String(rawId),
+      `rawId must be string, got ${typeof rawId}`,
+    );
+  }
+  if (rawId.length === 0) {
+    throw new InvalidRecordIdError(recordType, rawId, "empty string");
+  }
+  if (rawId.length > 200) {
+    throw new InvalidRecordIdError(
+      recordType,
+      rawId.slice(0, 50) + "...",
+      `length ${rawId.length} exceeds 200 — likely a URL or display name`,
+    );
+  }
+  if (looksLikeCompositeKey(rawId)) {
+    throw new InvalidRecordIdError(
+      recordType,
+      rawId,
+      "looks like a composite React key (e.g. `${owner}-${record}`); " +
+        "pass the raw PK instead. QUA-417 shipped exactly this bug on " +
+        "funding-connections.tsx.",
+    );
+  }
+  return rawId as RecordId<T>;
+}
+
+/**
+ * Non-throwing check: does this string pass the `asRecordId` runtime guards?
+ *
+ * Useful at system boundaries (e.g. URL params, API responses) where you
+ * want to reject malformed inputs and render a 404 instead of crashing.
+ */
+export function isCandidateRecordId(rawId: unknown): rawId is string {
+  return (
+    typeof rawId === "string" &&
+    rawId.length > 0 &&
+    rawId.length <= 200 &&
+    !looksLikeCompositeKey(rawId)
+  );
+}

--- a/packages/sourcing-types/src/index.ts
+++ b/packages/sourcing-types/src/index.ts
@@ -1,0 +1,138 @@
+/**
+ * @longterm-wiki/sourcing-types — Canonical sourcing record-type and verdict
+ * definitions shared by wiki-server, apps/web, and crux.
+ *
+ * This package exists so the frontend and backend cannot drift on the set of
+ * record types the sourcing pipeline supports. Before it, VALID_RECORD_TYPES
+ * lived in `apps/wiki-server/src/api-types.ts` and the frontend imported it
+ * via a backend-to-frontend path alias — a dependency direction that broke
+ * the "apps don't depend on each other" invariant. Now both apps depend on
+ * this package (QUA-424, QUA-408 Phase 4 category S).
+ *
+ * Scope is deliberately narrow: constants, types, and pure helpers. Zod
+ * schemas stay in `apps/wiki-server/src/api-types.ts` next to the request
+ * validators that use them.
+ */
+
+// ── Record types ──────────────────────────────────────────────────────────
+
+/**
+ * The canonical list of record types supported by the sourcing pipeline.
+ * Adding a new type here requires matching server-side storage + read-path
+ * rendering; removing a type requires cleaning up `source_check_verdicts`.
+ *
+ * Kept as a readonly tuple so `RecordType` is a string-literal union.
+ */
+export const VALID_RECORD_TYPES = [
+  "grant",
+  "personnel",
+  "division",
+  "funding-program",
+  "funding-round",
+  "investment",
+  "equity-position",
+  "policy-stakeholder",
+  "publication",
+  "benchmark-result",
+  "entity-event",
+  "entity-assessment",
+  "secondary-market-price",
+  "citation",
+  "wiki-page",
+  "fact",
+] as const;
+
+export type RecordType = (typeof VALID_RECORD_TYPES)[number];
+
+/**
+ * Record types that are exempt from sourcing verification.
+ *
+ * These are data classes where the ingestion source IS the canonical reference,
+ * so running sourcing verification against them produces noise rather than signal.
+ * They are excluded from coverage metrics, recheck queues, and the sourcing
+ * pipeline. The exemption is explicit — without this list, nothing prevents
+ * someone from accidentally running sourcing on these types and polluting
+ * the verdicts table.
+ *
+ * Criteria for exemption:
+ *   1. Data is ingested directly from an authoritative API (Manifold, arXiv, etc.)
+ *   2. The source URL in the record IS the canonical reference — re-checking it
+ *      against external sources is circular
+ *   3. Data is computed/derived from other already-verified records
+ *
+ * When adding a new exempt type, document the reason inline.
+ */
+export const SOURCING_EXEMPT_TYPES = [
+  // Ingested directly from benchmark provider APIs (e.g., provider docs, eval harnesses).
+  // The benchmark scores ARE the canonical data — no external source to verify against.
+  "benchmark-result",
+
+  // Computed by the citation accuracy system, not manually entered data.
+  // Citation accuracy has its own separate verification pipeline.
+  "citation",
+
+  // LLM-generated or editorial assessments (importance, risk, etc.).
+  // These are opinions/judgments, not factual claims that can be sourcing-checked.
+  "entity-assessment",
+
+  // Time-series pricing data ingested from secondary market APIs.
+  // The API response IS the canonical price — re-checking it is circular.
+  "secondary-market-price",
+] as const;
+
+export type SourcingExemptType = (typeof SOURCING_EXEMPT_TYPES)[number];
+
+// ── Verdicts ──────────────────────────────────────────────────────────────
+
+/**
+ * Valid source-check verdict states written by the LLM sourcing pipeline.
+ * Does not include `unchecked`, which is a placeholder the pipeline writes
+ * before running a check — not a verdict produced by it.
+ */
+export const VALID_SOURCE_CHECK_VERDICTS = [
+  "confirmed",
+  "contradicted",
+  "unverifiable",
+  "outdated",
+  "partial",
+] as const;
+
+export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a record type is exempt from sourcing verification.
+ * Use this instead of manual array checks to ensure consistency.
+ *
+ * Accepts `string` (not `RecordType`) because callers often hold
+ * user-supplied or stored strings. Returns false for unknown types.
+ */
+export function isSourcingExempt(recordType: string): boolean {
+  return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
+}
+
+/**
+ * Check whether a record type is in the canonical sourcing list.
+ * Useful for guarding FE helpers (getSourcingHref, getRecordVerdict) at the
+ * boundary — an unregistered type passed in should quietly degrade rather
+ * than linking to a 404.
+ */
+export function isValidRecordType(recordType: string): recordType is RecordType {
+  return (VALID_RECORD_TYPES as readonly string[]).includes(recordType);
+}
+
+/**
+ * Check whether a record type is both a valid sourcing type AND not exempt —
+ * i.e., would have stored verdicts worth linking to. Equivalent to:
+ *
+ *   isValidRecordType(t) && !isSourcingExempt(t)
+ *
+ * Used by `getSourcingHref` to decide whether to return a real URL or
+ * `undefined` (which makes the receiving dot non-clickable).
+ */
+export function isLinkableSourcingType(
+  recordType: string,
+): recordType is Exclude<RecordType, SourcingExemptType> {
+  return isValidRecordType(recordType) && !isSourcingExempt(recordType);
+}

--- a/packages/sourcing-types/tests/index.test.ts
+++ b/packages/sourcing-types/tests/index.test.ts
@@ -6,7 +6,11 @@ import {
   isSourcingExempt,
   isValidRecordType,
   isLinkableSourcingType,
+  asRecordId,
+  isCandidateRecordId,
+  InvalidRecordIdError,
   type RecordType,
+  type RecordId,
   type SourcingExemptType,
   type SourcingVerdict,
 } from "../src/index.js";
@@ -160,5 +164,141 @@ describe("type compatibility", () => {
   it("SourcingVerdict is a string-literal union, not generic string", () => {
     const v: SourcingVerdict = "confirmed";
     expect(v).toBe("confirmed");
+  });
+});
+
+// ── Branded RecordId<T> (QUA-423) ─────────────────────────────────────────
+
+describe("asRecordId", () => {
+  it("returns the raw string wrapped as RecordId<T> on a valid PK", () => {
+    const id = asRecordId("grant", "8NUnVSueLS");
+    // Runtime value is the same string; brand is erased at runtime.
+    expect(id).toBe("8NUnVSueLS");
+    // Compile-time: id is typed as RecordId<"grant"> — test the assignment.
+    const grantId: RecordId<"grant"> = id;
+    expect(grantId).toBe("8NUnVSueLS");
+  });
+
+  it("accepts various real-world PK shapes", () => {
+    // sid_-prefixed stableIds (entity PKs in many tables)
+    expect(asRecordId("personnel", "sid_A4XoubikkQ")).toBe("sid_A4XoubikkQ");
+    // 10-char alphanumeric grant PKs (what prod actually uses)
+    expect(asRecordId("grant", "8NUnVSueLS")).toBe("8NUnVSueLS");
+    // f_-prefixed fact IDs
+    expect(asRecordId("fact", "f_mEKUPPFYRg")).toBe("f_mEKUPPFYRg");
+    // Short numeric IDs (funding-round, investment use these)
+    expect(asRecordId("funding-round", "42")).toBe("42");
+    // Slug-shaped IDs (some legacy rows)
+    expect(asRecordId("wiki-page", "anthropic")).toBe("anthropic");
+  });
+
+  it("throws on empty strings (caller likely passed undefined)", () => {
+    expect(() => asRecordId("grant", "")).toThrow(InvalidRecordIdError);
+  });
+
+  it("throws on excessively long strings (likely a URL or title)", () => {
+    const tooLong = "x".repeat(201);
+    expect(() => asRecordId("grant", tooLong)).toThrow(
+      /length 201 exceeds 200/,
+    );
+  });
+
+  it("throws on composite React keys: sid_X-sid_Y (the QUA-417 bug shape)", () => {
+    // This is exactly the value conn.key had in funding-connections.tsx
+    // before QUA-417. The runtime guard catches it at the boundary.
+    expect(() => asRecordId("grant", "sid_ULjDXpSLCI-8NUnVSueLS")).toThrow(
+      /composite React key/,
+    );
+    expect(() => asRecordId("grant", "sid_abc-sid_def")).toThrow(
+      InvalidRecordIdError,
+    );
+  });
+
+  it("throws on composite numeric-ID shapes: 123-456", () => {
+    expect(() => asRecordId("funding-round", "12345-67890")).toThrow(
+      /composite/,
+    );
+  });
+
+  it("does NOT flag legitimate hyphenated slugs (false-positive guard)", () => {
+    // These legitimate PK shapes contain hyphens but aren't composite keys.
+    expect(() => asRecordId("wiki-page", "some-name-2024")).not.toThrow();
+    expect(() => asRecordId("publication", "arxiv-2310-12345")).not.toThrow();
+    expect(() => asRecordId("grant", "1-2")).not.toThrow(); // short numeric both sides — not composite
+    expect(() => asRecordId("personnel", "a-b-c-d")).not.toThrow();
+  });
+
+  it("throws with a clear error message referencing QUA-417", () => {
+    try {
+      asRecordId("grant", "sid_abc-sid_def");
+      throw new Error("expected asRecordId to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvalidRecordIdError);
+      const err = e as InvalidRecordIdError;
+      expect(err.recordType).toBe("grant");
+      expect(err.rawId).toBe("sid_abc-sid_def");
+      expect(err.message).toMatch(/QUA-417/);
+    }
+  });
+
+  it("enforces recordType at the type level (compile check)", () => {
+    // This test passes by compilation — if RecordType drifts from
+    // VALID_RECORD_TYPES, the literal below no longer satisfies T.
+    const id = asRecordId("grant", "g1");
+    const grantId: RecordId<"grant"> = id;
+    expect(grantId).toBeDefined();
+    // Not assignable across types:
+    // const wrong: RecordId<"personnel"> = id;  ← would not compile
+  });
+});
+
+describe("isCandidateRecordId", () => {
+  it("accepts valid PK shapes (same set asRecordId accepts)", () => {
+    expect(isCandidateRecordId("8NUnVSueLS")).toBe(true);
+    expect(isCandidateRecordId("sid_A4XoubikkQ")).toBe(true);
+    expect(isCandidateRecordId("f_mEKUPPFYRg")).toBe(true);
+    expect(isCandidateRecordId("some-name-2024")).toBe(true);
+  });
+
+  it("rejects what asRecordId would throw on", () => {
+    expect(isCandidateRecordId("")).toBe(false);
+    expect(isCandidateRecordId("x".repeat(201))).toBe(false);
+    expect(isCandidateRecordId("sid_abc-sid_def")).toBe(false);
+    expect(isCandidateRecordId("12345-67890")).toBe(false);
+  });
+
+  it("rejects non-string inputs without throwing", () => {
+    expect(isCandidateRecordId(undefined)).toBe(false);
+    expect(isCandidateRecordId(null)).toBe(false);
+    expect(isCandidateRecordId(42)).toBe(false);
+    expect(isCandidateRecordId({})).toBe(false);
+  });
+
+  it("narrows the type to string when true (compile check)", () => {
+    const raw: unknown = "8NUnVSueLS";
+    if (isCandidateRecordId(raw)) {
+      const _s: string = raw; // narrowed to string
+      expect(_s).toBe("8NUnVSueLS");
+    }
+  });
+});
+
+describe("RecordId<T> type distinctness (compile-time)", () => {
+  it("treats different record types as distinct branded types", () => {
+    // These compile — which is the test.
+    const grantId: RecordId<"grant"> = asRecordId("grant", "g1");
+    const personnelId: RecordId<"personnel"> = asRecordId("personnel", "p1");
+
+    // A function typed to accept only grant IDs can't be called with a
+    // personnel ID at compile time:
+    function takeGrant(id: RecordId<"grant">): string {
+      return id;
+    }
+    expect(takeGrant(grantId)).toBe("g1");
+    // takeGrant(personnelId);  ← would not compile: types incompatible
+
+    // Brand is erased at runtime — strings still equal themselves.
+    expect(grantId).toBe("g1");
+    expect(personnelId).toBe("p1");
   });
 });

--- a/packages/sourcing-types/tests/index.test.ts
+++ b/packages/sourcing-types/tests/index.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+  VALID_SOURCE_CHECK_VERDICTS,
+  isSourcingExempt,
+  isValidRecordType,
+  isLinkableSourcingType,
+  type RecordType,
+  type SourcingExemptType,
+  type SourcingVerdict,
+} from "../src/index.js";
+
+describe("VALID_RECORD_TYPES", () => {
+  it("contains the known sourcing types", () => {
+    expect(VALID_RECORD_TYPES).toContain("grant");
+    expect(VALID_RECORD_TYPES).toContain("personnel");
+    expect(VALID_RECORD_TYPES).toContain("fact");
+    expect(VALID_RECORD_TYPES).toContain("wiki-page");
+  });
+
+  it("does not contain unregistered types flagged in QUA-416", () => {
+    // These are types the UI tried to link to but the backend never stored.
+    expect(VALID_RECORD_TYPES).not.toContain("entity");
+    expect(VALID_RECORD_TYPES).not.toContain("race");
+    expect(VALID_RECORD_TYPES).not.toContain("race-candidate");
+    expect(VALID_RECORD_TYPES).not.toContain("model-release");
+    expect(VALID_RECORD_TYPES).not.toContain("prediction-question");
+    expect(VALID_RECORD_TYPES).not.toContain("project");
+  });
+
+  it("is frozen in length — adding a type is a schema change", () => {
+    // Adjust this when the sourcing pipeline genuinely grows a new type.
+    // The explicit count catches silent removals via merge conflict.
+    expect(VALID_RECORD_TYPES.length).toBe(16);
+  });
+});
+
+describe("SOURCING_EXEMPT_TYPES", () => {
+  it("contains the four known exempt types", () => {
+    expect([...SOURCING_EXEMPT_TYPES].sort()).toEqual([
+      "benchmark-result",
+      "citation",
+      "entity-assessment",
+      "secondary-market-price",
+    ]);
+  });
+
+  it("every exempt type is also a valid record type (invariant)", () => {
+    // If this fails, either the exempt list references a nonexistent type
+    // or VALID_RECORD_TYPES dropped one without updating exempts.
+    for (const t of SOURCING_EXEMPT_TYPES) {
+      expect(
+        (VALID_RECORD_TYPES as readonly string[]).includes(t),
+        `exempt type "${t}" missing from VALID_RECORD_TYPES`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("VALID_SOURCE_CHECK_VERDICTS", () => {
+  it("matches the five verdict states the LLM pipeline can produce", () => {
+    expect([...VALID_SOURCE_CHECK_VERDICTS].sort()).toEqual([
+      "confirmed",
+      "contradicted",
+      "outdated",
+      "partial",
+      "unverifiable",
+    ]);
+  });
+
+  it("does NOT include 'unchecked' — that is a placeholder, not a verdict", () => {
+    expect(VALID_SOURCE_CHECK_VERDICTS).not.toContain("unchecked");
+  });
+});
+
+describe("isSourcingExempt", () => {
+  it("returns true for known exempt types", () => {
+    expect(isSourcingExempt("benchmark-result")).toBe(true);
+    expect(isSourcingExempt("citation")).toBe(true);
+    expect(isSourcingExempt("entity-assessment")).toBe(true);
+    expect(isSourcingExempt("secondary-market-price")).toBe(true);
+  });
+
+  it("returns false for non-exempt valid types", () => {
+    expect(isSourcingExempt("grant")).toBe(false);
+    expect(isSourcingExempt("personnel")).toBe(false);
+    expect(isSourcingExempt("fact")).toBe(false);
+  });
+
+  it("returns false for unregistered types (no crash)", () => {
+    expect(isSourcingExempt("entity")).toBe(false);
+    expect(isSourcingExempt("race")).toBe(false);
+    expect(isSourcingExempt("")).toBe(false);
+  });
+});
+
+describe("isValidRecordType", () => {
+  it("narrows string to RecordType when valid", () => {
+    const raw: string = "grant";
+    if (isValidRecordType(raw)) {
+      // Compile check: raw is narrowed to RecordType inside the block.
+      const _typed: RecordType = raw;
+      expect(_typed).toBe("grant");
+    }
+  });
+
+  it("returns false for unregistered types flagged in QUA-416", () => {
+    expect(isValidRecordType("entity")).toBe(false);
+    expect(isValidRecordType("race")).toBe(false);
+    expect(isValidRecordType("model-release")).toBe(false);
+    expect(isValidRecordType("prediction-question")).toBe(false);
+    expect(isValidRecordType("project")).toBe(false);
+    expect(isValidRecordType("")).toBe(false);
+    expect(isValidRecordType("garbage-123")).toBe(false);
+  });
+});
+
+describe("isLinkableSourcingType", () => {
+  it("returns true for valid, non-exempt types", () => {
+    expect(isLinkableSourcingType("grant")).toBe(true);
+    expect(isLinkableSourcingType("personnel")).toBe(true);
+    expect(isLinkableSourcingType("fact")).toBe(true);
+    expect(isLinkableSourcingType("wiki-page")).toBe(true);
+  });
+
+  it("returns false for exempt types (even though they ARE valid)", () => {
+    expect(isLinkableSourcingType("benchmark-result")).toBe(false);
+    expect(isLinkableSourcingType("citation")).toBe(false);
+    expect(isLinkableSourcingType("entity-assessment")).toBe(false);
+    expect(isLinkableSourcingType("secondary-market-price")).toBe(false);
+  });
+
+  it("returns false for unregistered types", () => {
+    expect(isLinkableSourcingType("entity")).toBe(false);
+    expect(isLinkableSourcingType("race")).toBe(false);
+    expect(isLinkableSourcingType("model-release")).toBe(false);
+    expect(isLinkableSourcingType("project")).toBe(false);
+  });
+
+  it("excludes all SOURCING_EXEMPT_TYPES by construction", () => {
+    for (const exempt of SOURCING_EXEMPT_TYPES) {
+      expect(
+        isLinkableSourcingType(exempt),
+        `exempt type "${exempt}" should not be linkable`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("type compatibility", () => {
+  it("SourcingExemptType is a subset of RecordType (compile check)", () => {
+    // Compile-time: if SourcingExemptType includes a value not in RecordType,
+    // this assignment fails and the whole test file won't build.
+    const exempt: SourcingExemptType = "benchmark-result";
+    const asRecordType: RecordType = exempt;
+    expect(asRecordType).toBe("benchmark-result");
+  });
+
+  it("SourcingVerdict is a string-literal union, not generic string", () => {
+    const v: SourcingVerdict = "confirmed";
+    expect(v).toBe("confirmed");
+  });
+});

--- a/packages/sourcing-types/tsconfig.json
+++ b/packages/sourcing-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/sourcing-types':
+        specifier: workspace:*
+        version: link:../../packages/sourcing-types
       '@quri/squiggle-components':
         specifier: ^0.10.0
         version: 0.10.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -348,6 +351,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/sourcing-types':
+        specifier: workspace:*
+        version: link:../../packages/sourcing-types
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
@@ -394,6 +400,15 @@ importers:
         version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/id-utils:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/sourcing-types:
     devDependencies:
       typescript:
         specifier: ^5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - "apps/groundskeeper"
   - "packages/factbase"
   - "packages/id-utils"
+  - "packages/sourcing-types"


### PR DESCRIPTION
## Summary

Wire the QUA-423 phase 1 runtime guard (`isCandidateRecordId`) into the three frontend helpers that the QUA-417 bug funneled through: `getSourcingHref`, `getRecordVerdict`, `getFieldVerdict`. Each now fast-returns when the recordId looks like a composite React key or is malformed.

## Why pragmatic phase 2

My original QUA-423 plan said phase 2 = "narrow signatures to require `RecordId<T>` + migrate the ~17 call sites". Grepping the current codebase: 70 call sites across 41 files. That's a large mechanical migration whose defensive value is equivalent to running the runtime check inside the helpers — at least for the QUA-417 bug class, which is the shipped incident we're defending against.

This PR ships the runtime half. The composite-key bug is caught identically; no call-site churn; rollback is trivial. Compile-time signature narrowing is noted as an optional follow-up if call sites ever stabilize enough to justify the review cost.

## The guard

```tsx
if (!isCandidateRecordId(recordId)) {
  console.warn(`[sourcing] ${fn}: ... see QUA-417`);
  return undefined | null;   // depending on the helper
}
```

Each helper now:

| Helper | Behavior on guard-fail |
|---|---|
| `getSourcingHref` | returns `undefined` → dot renders non-clickable |
| `getRecordVerdict` | returns `null` → caller branches as "no verdict" |
| `getFieldVerdict` | returns `null` → same |

Dev mode logs a pointed warning referencing QUA-417 so future contributors hitting the same bug class get a link to the real fix.

## Signature change cascade

`getSourcingHref` returned `string` before; now `string | undefined`. 7 callers across 2 files that fed the return into `<Link href={...}>` needed handling. Rather than wrapping each call with `?? "/sourcing"` fallbacks, added a companion:

```ts
export function getStoredVerdictHref(recordType, recordId): string
```

For callers rendering rows that already came from `/api/sourcing/verdicts` (where recordType + recordId are valid by construction). Return type is `string`, so `<Link>` accepts it directly. Defense-in-depth: falls back to `/sourcing` index with a dev-mode warning if somehow called with a malformed ID.

## Files

| File | Change |
|---|---|
| `apps/web/src/app/sourcing/sourcing-shared.tsx` | `getSourcingHref` return type → `string \| undefined`; add `getStoredVerdictHref` |
| `apps/web/src/data/tablebase.ts` | `getRecordVerdict`, `getFieldVerdict` guarded |
| `apps/web/src/app/sourcing/sourcing-table.tsx` | Use `getStoredVerdictHref` (4 sites + 1 type narrow) |
| `apps/web/src/app/things/[id]/page.tsx` | Use `getStoredVerdictHref` (3 sites) |
| **New**: `apps/web/src/app/sourcing/__tests__/sourcing-href.test.ts` | 11 tests |
| `apps/web/src/data/__tests__/field-verdicts.test.ts` | +5 tests for the guard |

## Test plan

**New runtime-guard tests** (11 cases):

- [x] Returns URL for valid PKs (`8NUnVSueLS`, `sid_A4XoubikkQ`, `f_mEKUPPFYRg`)
- [x] Returns undefined for the exact QUA-417 shape (`sid_ULjDXpSLCI-8NUnVSueLS`)
- [x] Returns undefined for `sid_X-sid_Y` and `12345-67890` composites
- [x] Returns undefined for empty string
- [x] Does NOT flag legitimate hyphenated IDs (`some-name-2024`, `arxiv-2310-12345`, `1-2`)
- [x] URL-encodes recordType + recordId properly
- [x] Dev-mode warning fires with a QUA-417 reference
- [x] `getStoredVerdictHref` falls back to `/sourcing` (never undefined)
- [x] `getStoredVerdictHref`'s string return type holds at compile time

**`getRecordVerdict` / `getFieldVerdict` guard tests** (+5 cases):

- [x] Returns verdict for valid PKs
- [x] Returns null on QUA-417 composite-key shape + logs warning with "QUA-417"
- [x] Returns null on empty string recordId
- [x] Does NOT flag legitimate hyphenated IDs (no QUA-417 warning)
- [x] `getFieldVerdict` applies the same guard

**Regression suite**:

- [x] `pnpm test` (apps/web) — 1555 pass (86 files)
- [x] `npx tsc --noEmit` clean in apps/web

## Stack

Stacked on:
- [#4320](https://github.com/quantified-uncertainty/longterm-wiki/pull/4320) (QUA-424 shared package)
- [#4322](https://github.com/quantified-uncertainty/longterm-wiki/pull/4322) (QUA-423 phase 1 — branded type + `isCandidateRecordId`)

Rebase onto main after those merge.

Closes QUA-423 phase 2

Refs QUA-417 (specific bug this prevents), QUA-408 Phase 4 category W (runtime assertion at the choke point)


