### PR TITLE
review: address tier1/tier2 PR review findings

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -178,8 +178,11 @@ test.describe("Render audit — no dead entity sourcing links (QUA-418)", () => 
     "/organizations/anthropic",
     "/people/dario-amodei",
     "/ai-models/claude-opus-4-5",
+    // Directory index pages — same dead-link class, fixed as QUA-418 follow-up
+    "/organizations",
+    "/people",
   ]) {
-    test(`header has no /sourcing/entity/ href on ${url}`, async ({ page }) => {
+    test(`no /sourcing/entity/ href on ${url}`, async ({ page }) => {
       await loadPage(page, url);
       const hrefs = await page.locator('a[href^="/sourcing/entity/"]').count();
       expect(hrefs, `${url} has ${hrefs} dead /sourcing/entity/ link(s)`).toBe(0);

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -13,7 +13,6 @@ import { compareOrgRows } from "@/app/organizations/org-sort";
 import type { OrgSortKey } from "@/app/organizations/org-sort";
 import { ORG_TYPE_LABELS, ORG_TYPE_COLORS, DEFAULT_ORG_TYPE_COLOR } from "@/app/organizations/org-constants";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
 import { useServerTable } from "@/hooks/use-server-table";
 import { formatCompactCurrency, formatCompactNumber as formatCompactNum } from "@/lib/format-compact";
@@ -590,7 +589,8 @@ export function OrganizationsTable({
                     {/* Completion Score */}
                     {visibleColumns.has("completionScore") && (
                       <td className="py-2.5 px-3 text-center">
-                        <RecordStatusDots coverageScore={row.completionScore} verdict={row.verdictString} sourcingHref={row.verdictString ? getSourcingHref("entity", row.id) : undefined} />
+                        {/* QUA-418 follow-up: `entity` is not a real record_type, so /sourcing/entity/<id> 404s. Omit href. */}
+                        <RecordStatusDots coverageScore={row.completionScore} verdict={row.verdictString} />
                       </td>
                     )}
 

--- a/apps/web/src/app/people/people-table.tsx
+++ b/apps/web/src/app/people/people-table.tsx
@@ -17,7 +17,6 @@ import type { PeopleSortKey } from "./people-sort";
 import { isPersonMeaningful } from "./people-filter";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computePersonCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface PersonRow {
   id: string;
@@ -669,7 +668,8 @@ export function PeopleTable({
                     )}
                     {/* Coverage */}
                     <td className="py-2.5 px-3 text-center">
-                      <RecordStatusDots coverageScore={computePersonCoverage(row)} verdict={row.verdictString} sourcingHref={row.verdictString ? getSourcingHref("entity", row.id) : undefined} />
+                      {/* QUA-418 follow-up: `entity` is not a real record_type, so /sourcing/entity/<id> 404s. Omit href. */}
+                      <RecordStatusDots coverageScore={computePersonCoverage(row)} verdict={row.verdictString} />
                     </td>
                   </tr>
                 ))}

--- a/apps/web/src/lib/sourcing/record-type-table-map.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.ts
@@ -6,8 +6,12 @@
  * (QUA-420 — `recordType.replace(/-/g, "_") + "s"` generated garbage like
  * `entity_s`, `fact_s`, `race_s`).
  *
- * Keep in sync with `VALID_RECORD_TYPES` in `apps/wiki-server/src/api-types.ts`
- * and `VALID_SOURCE_TABLES` in `apps/wiki-server/src/routes/tablebase/record-lookup.ts`.
+ * Keep in sync with `VALID_RECORD_TYPES` in `apps/wiki-server/src/api-types.ts`.
+ *
+ * Note: `citation_quotes` and `wiki_pages` are web-side entries for types
+ * that are NOT in `VALID_SOURCE_TABLES` on the wiki-server. Record-lookup
+ * will return 400 for those; the page handles that gracefully by falling
+ * through to notFound() when `recordResult.ok` is false.
  */
 
 export const RECORD_TYPE_TO_TABLE = {

--- a/crux/ci/ci-status.ts
+++ b/crux/ci/ci-status.ts
@@ -20,8 +20,8 @@ import { resolvePrHeadSha } from './resolve-pr-head.ts';
 const args: string[] = process.argv.slice(2);
 const WAIT_MODE: boolean = args.includes('--wait');
 const CI_MODE: boolean = args.includes('--ci') || process.env.CI === 'true';
-const SHA_ARG = args.find((a) => a.startsWith('--sha='))?.split('=')[1];
-const PR_ARG = args.find((a) => a.startsWith('--pr='))?.split('=')[1];
+const SHA_ARG = args.find((a) => a.startsWith('--sha='))?.split('=')[1]?.trim();
+const PR_ARG = args.find((a) => a.startsWith('--pr='))?.split('=')[1]?.trim();
 const POLL_INTERVAL = 30_000; // 30 seconds
 const MAX_POLLS = 40; // 20 minutes max
 
@@ -132,6 +132,7 @@ async function main(): Promise<void> {
     console.log(`${c.dim}Polling CI status every 30s (max ${MAX_POLLS} polls)...${c.reset}`);
   }
 
+  let lastSha: string | null = null;
   for (let i = 0; i < MAX_POLLS; i++) {
     if (i > 0) {
       if (!CI_MODE) {
@@ -143,6 +144,12 @@ async function main(): Promise<void> {
     // QUA-410: re-resolve SHA each poll so --pr=N tracks head movement
     // (rebases, new merges into main) between polls.
     const sha = await getSha();
+    if (lastSha && lastSha !== sha && !CI_MODE) {
+      console.log(
+        `${c.yellow}  SHA changed: ${lastSha.slice(0, 8)} → ${sha.slice(0, 8)} (rebase or new commit)${c.reset}`,
+      );
+    }
+    lastSha = sha;
     const data = await fetchCheckRuns(sha);
     const { allDone, anyFailed } = printStatus(data, sha);
 

--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -110,8 +110,14 @@ describe('isPatBlockedError (QUA-409)', () => {
     expect(isPatBlockedError('RESOURCE NOT ACCESSIBLE BY PERSONAL ACCESS TOKEN')).toBe(true);
   });
 
+  it('matches fine-grained PAT / installation token variants', () => {
+    expect(isPatBlockedError('HTTP 403: Resource not accessible by integration')).toBe(true);
+    expect(isPatBlockedError('HTTP 403: Resource not accessible by user')).toBe(true);
+  });
+
   it('does NOT match unrelated 403s or other errors', () => {
     expect(isPatBlockedError('HTTP 403: forbidden')).toBe(false);
+    expect(isPatBlockedError('HTTP 403: Must have admin rights')).toBe(false);
     expect(isPatBlockedError('psql: connection refused')).toBe(false);
     expect(isPatBlockedError('HTTP 404: Not Found')).toBe(false);
   });

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -190,13 +190,15 @@ interface VerifyResult {
 }
 
 /**
- * Detect the GitHub "Resource not accessible by personal access token" error,
- * which surfaces when a `gh workflow run` task is verified with a PAT lacking
- * `actions:write`. (QUA-409)
+ * Detect the GitHub "Resource not accessible by ..." family of errors,
+ * which surface when a `gh workflow run` / `gh api` task is verified with a
+ * token that lacks the required scope (classic PAT missing `actions:write`,
+ * fine-grained PAT, or an installation token). (QUA-409)
  */
 export function isPatBlockedError(output: string | undefined): boolean {
   if (!output) return false;
-  return /Resource not accessible by personal access token/i.test(output);
+  // Covers "...by personal access token", "...by integration", "...by user".
+  return /Resource not accessible by (?:personal access token|integration|user)/i.test(output);
 }
 
 /**
@@ -361,7 +363,9 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
       const { exitCode, output } = runVerifyCommand(command, timeoutMs);
       let status: VerifyResult['status'];
       if (exitCode === 0) status = 'pass';
-      else if (isPatBlockedError(output)) status = 'needs-ui';
+      // Gate PAT-blocked detection on `gh ` commands so an unrelated 403
+      // (e.g. curl against a third-party API) isn't miscategorized.
+      else if (/\bgh\b/.test(command) && isPatBlockedError(output)) status = 'needs-ui';
       else status = 'fail';
       results.push({
         pr: pr.number,
@@ -435,7 +439,7 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
       }
       if (r.status === 'needs-ui') {
         lines.push(
-          `        ${c.dim}Local PAT lacks actions:write — dispatch from GitHub UI.${c.reset}`
+          `        ${c.dim}Token lacks actions:write — dispatch from GitHub UI or grant the scope.${c.reset}`
         );
       }
       if (r.status === 'skip' && r.skipReason) {


### PR DESCRIPTION
## Summary

Consolidated follow-up from the strict review pass on the tier1/tier2 release batch. Four separately-scoped polish items, grouped into one small diff for review convenience.

### QUA-418 follow-up — directory tables had the same dead-link bug

`apps/web/src/app/people/people-table.tsx:672` and `apps/web/src/app/organizations/organizations-table.tsx:593` were calling `getSourcingHref("entity", row.id)` — exact same `/sourcing/entity/<id>` 404 pattern the merged PR fixed in the shell. Caught by the reviewer running `rg 'getSourcingHref.*"entity"'` across `apps/web/src`.

- Omit the `sourcingHref` prop (matches the shell's "defer to QUA-408 Phase 2" rationale).
- Drop the now-unused `getSourcingHref` import in both files.
- Extend `render-audit.spec.ts` to cover `/organizations` and `/people` index pages so this class of regression doesn't slip again.

### QUA-409 follow-up — broaden PAT regex + gate on `gh` commands

- Regex now covers `Resource not accessible by {personal access token | integration | user}` — fine-grained PATs and installation tokens in addition to classic PATs.
- Gate PAT detection on commands containing `gh` so unrelated 403s (e.g. a curl) aren't miscategorized.
- Update NEEDS-UI hint to "Token lacks actions:write — dispatch from GitHub UI or grant the scope."
- Two new tests for the integration/user variants; `HTTP 403: Must have admin rights` stays FAIL.

### QUA-410 follow-up — polish

- Trim whitespace on `--pr` / `--sha` CLI args.
- Log a yellow `SHA changed: X → Y (rebase or new commit)` line in `--wait` mode when the PR head moves between polls. Improves release-monitoring clarity.

### QUA-420 follow-up — doc accuracy

`record-type-table-map.ts` said "Keep in sync with `VALID_SOURCE_TABLES`" but `citation_quotes` and `wiki_pages` are intentionally web-side-only entries that fall through to `notFound()` when record-lookup 400s. Clarify the note.

## Test plan

- [x] `vitest run crux/commands/deploy-tasks.test.ts` — 13 passing (incl. 2 new variant tests)
- [x] `cd apps/web && vitest run src/lib/sourcing/record-type-table-map.test.ts` — 3 passing
- [x] `tsc --noEmit` clean
- [ ] Playwright render-audit: run against prod after deploy to confirm directory pages have no `/sourcing/entity/` links
