### PR TITLE
docs(rules): add dispatcher pre-flight rule (QUA-438)

### DIFF
--- a/.claude/rules/dispatched-agent-review.md
+++ b/.claude/rules/dispatched-agent-review.md
@@ -2,6 +2,78 @@
 
 When a coordinator session dispatches subagents to work on issues and create PRs, **every dispatch prompt MUST instruct the agent to run `/agent-review-pr` before creating the PR**. Do not instruct subagents to run `pnpm crux gh pr create` directly.
 
+Dispatchers also have their own pre-flight responsibilities — see the **Dispatcher pre-flight** section below. This rule covers both sides of the dispatch: the coordinator (dispatcher) and the slot agent (dispatched).
+
+## Dispatcher pre-flight — MANDATORY
+
+Before writing a dispatch brief for any Linear-tracked ticket, the coordinator MUST run all three of the following checks and confirm no existing claim is in flight:
+
+1. **Linear state** — Run `pnpm crux linear view QUA-NNN`. Confirm the issue is **not already In Progress with a recent (<24h) start comment from a different session**. Recent start comments mean a slot already picked this up.
+2. **Open PRs** — Run `gh pr list -R quantified-uncertainty/longterm-wiki --search "QUA-NNN in:body" --state all --json number,state,headRefName`. Confirm **no open PR references the ticket**. A closed-unmerged PR is usually fine (investigate the close reason); an open PR almost always means another session is iterating on it.
+3. **Active slots** — Run `./ws list` (or `pnpm crux sys sessions list` once QUA-413 ships). Confirm **no other slot is currently on a `claude/qua-NNN-*` branch** or has an uncommitted working tree that suggests it's on the same ticket.
+
+**If any check surfaces an existing claim, abort the dispatch.** Either (a) investigate the existing session first and confirm it's abandoned/stuck before taking over with `--force`, or (b) comment on the existing PR instead of opening a new one, or (c) wait for the in-flight session to ship.
+
+### Why this rule exists — QUA-406 / QUA-397
+
+On 2026-04-13, the coordinator filed QUA-397, the user started a slot a9 session on it and shipped PR #4296, and then the **same coordinator session dispatched slot a16 to fix the same bugs 3 hours later** without running any of the three checks above. The result: two competing PRs, ~$100+ of wasted compute, and PR #4297 had to be closed.
+
+This wasn't a tooling gap — the tooling fixes in QUA-406 (PR #4300) and QUA-440 (PR #4307) closed the server-side holes. This is the **coordinator-side** gap: a dispatcher with all the information to prevent duplication still dispatched anyway. A rule catches behavior under context pressure in a way that code checks can't.
+
+### Preferred enforcement — `crux sys dispatch`
+
+Once QUA-437 ships, `pnpm crux sys dispatch --linear=QUA-NNN --slot=N` will enforce all three pre-flight checks structurally and refuse on collision. **That wrapper is the preferred way to dispatch going forward** — it makes the rule unskippable under context pressure.
+
+Hand-dispatch via `./ws open <N> --claude` + a hand-written brief is permitted only when the wrapper is unavailable, and in that case the coordinator is **personally** responsible for running all three checks before writing the brief.
+
+### Escape hatch — `--force` with explicit reason
+
+For genuine emergencies (prod-down incident response, explicit hotfix authorization from the user), a coordinator may bypass the pre-flight with `--force`. Every `--force` dispatch MUST:
+
+1. Post a comment on the existing Linear issue explaining why the claim is being taken over.
+2. Explicitly state in the dispatch brief: `⚠ Forced past dispatcher pre-flight — reason: <reason>`.
+3. Reconcile with the prior session afterward (close the prior PR, coordinate the branch handoff, or document the abandonment in Linear).
+
+`--force` is NOT a way to dispatch faster — it's a way to override the check when the rule's purpose (preventing duplicate work) is already satisfied by out-of-band coordination.
+
+### Scope — what this rule does NOT cover
+
+- **Non-dispatch work.** If the coordinator is doing the work itself (editing in `coord/` or its own slot), `crux linear start` dedup handles it. This rule is only for dispatching to a slot.
+- **Research / exploration dispatches with no Linear ticket.** If there's no ticket, there's nothing to dedup. The rule only fires when `--linear=QUA-NNN` is present on the dispatch.
+- **Dispatches to an existing in-flight session on the same ticket** (e.g., the coordinator is adding follow-up instructions to a slot that's already working the ticket). In this case the slot is not a new claimant; skip the pre-flight but note the context in the brief.
+
+### Compliant dispatch brief — template
+
+Use this as the header of every hand-written dispatch brief (typically saved under `lw/dispatch/qua-NNN.md` in the workspace repo). The three checkboxes must be ticked before the brief is handed off to a slot — an unticked box means the brief is incomplete and MUST NOT be used.
+
+```markdown
+# Dispatch: QUA-NNN — <short description>
+
+**Linear:** https://linear.app/quantifieduncertainty/issue/QUA-NNN (P?)
+**Slot:** a??
+**Branch to create:** `claude/qua-nnn-<short-description>`
+**Dispatched by:** <coordinator session identifier, e.g. "slot-orchestration 2026-04-14">
+
+## Dispatcher pre-flight — verified before this brief was written
+
+- [ ] **Linear state** — `pnpm crux linear view QUA-NNN` shows no recent cross-slot claim
+- [ ] **Open PRs** — `gh pr list -R quantified-uncertainty/longterm-wiki --search "QUA-NNN in:body" --state all` returns no open PR
+- [ ] **Active slots** — `./ws list` shows no other slot on `claude/qua-nnn-*`
+
+(If this is a --force dispatch: replace the three boxes with `⚠ Forced past pre-flight — reason: <reason>` and post a reconciliation note on the Linear issue.)
+
+## What you're fixing
+
+<One-paragraph framing, linking to the Linear issue body for details.>
+
+## Ship checklist — MANDATORY
+
+Before creating the PR: run `/agent-review-pr`.
+Creating the PR: use `/agent-ship`, not raw `pnpm crux gh pr create`.
+```
+
+A file at `lw/dispatch/TEMPLATE.md` in the workspace repo containing this template is a nice-to-have but not required by this rule — the template lives here, canonically, inside the rule itself, so it's always loaded into every coordinator session automatically.
+
 ## Why
 
 The existing `/agent-ship` workflow has `/agent-review-pr` as a mandatory, non-skippable Step 2b. But when a coordinator dispatches subagents with prompts like "do the work, run `pnpm build`, run `pnpm crux gh pr create`", the subagents bypass the entire `/agent-ship` flow and skip the review step.

--- a/.claude/rules/github-issue-tracking.md
+++ b/.claude/rules/github-issue-tracking.md
@@ -21,6 +21,8 @@ For GitHub: posts a start comment and adds the `agent:working` label.
 
 **Note:** `crux sys agent-checklist init` handles both automatically when `--linear=QUA-NNN` or `--issue=N` is provided. You rarely need to call these manually.
 
+**Coordinators dispatching to a slot:** this check (`crux linear start`) fires in the slot, not in the coordinator. The coordinator has a separate pre-flight responsibility — see `.claude/rules/dispatched-agent-review.md` § "Dispatcher pre-flight" for the three mandatory checks to run before writing a dispatch brief (Linear state, open PRs, active slots). Skipping those checks is how the QUA-406/QUA-397 duplicate-work incident happened.
+
 ## Dedup check — `crux linear start` refuses competing claims
 
 Both `crux linear start QUA-NNN` and `crux sys agent-checklist init --linear=QUA-NNN` run a **dedup pre-check** before posting anything to Linear. The check consults three signals in order, blocking on the first one that finds a cross-slot collision:


### PR DESCRIPTION
## Summary

Closes QUA-438. Docs-only — adds the coordinator-side pre-flight rule that complements the server-side dedup in QUA-406 (PR #4300) and QUA-440 (PR #4307).

## Why

QUA-406's post-mortem identified two distinct gaps:
- **Tooling** — `crux linear start` had no dedup. Fixed in PR #4300.
- **Behavioral** — a coordinator who filed QUA-397 then dispatched another slot to fix the same bugs 3 hours later, despite having all the information to prevent it. That's what caused the duplicate-PR incident (#4296 + #4297).

Tooling can't catch a dispatcher that never calls the tool. This PR adds the rule that mandates the coordinator run three checks before every dispatch brief.

## What changed

- **`.claude/rules/dispatched-agent-review.md`** — new "Dispatcher pre-flight — MANDATORY" section listing the three required checks: `crux linear view`, `gh pr list --search`, `./ws list`. Documents the `--force` escape hatch for emergencies and points at QUA-437's future wrapper as the preferred enforcement. Embeds a dispatch-brief template inline (with the three checkboxes) so every coordinator session loads it automatically.
- **`.claude/rules/github-issue-tracking.md`** — one-paragraph cross-reference to the new section, right under the existing "At Session Start" content.

## Scope

AC items from the ticket and how they land:

- [x] `dispatched-agent-review.md` gains the "Dispatcher pre-flight" section with three checks — **done in this PR**
- [x] `github-issue-tracking.md` cross-references the new rule — **done in this PR**
- [x] Dispatch brief template with a "Pre-flight checks complete" checkbox — **embedded in `dispatched-agent-review.md` as a fenced markdown block**, always loaded into coordinator sessions. Avoids creating a separate file in the `lw/` workspace repo (different git repo, out of slot-agent scope).
- [ ] `setup-slot-orchestration.md` references the new rule — **deferred to a follow-up PR against `longtermwiki-configs`** (that file lives in the `lw/` workspace repo, not in `longterm-wiki`)
- [x] No new code (enforcement is QUA-437's job)

## Test plan

- [x] `pnpm crux w validate gate --fix --no-cache` — all 52 gate checks pass
- [x] Rule file renders cleanly as markdown (verified via preview)
- [x] Both rule files already load into every session via the auto-memory system (they're listed in CLAUDE.md's "Detailed Guides" section)
- [x] No code changes, no new tests needed
- [ ] After merge: open a follow-up PR on `longtermwiki-configs` to add the one-line reference in `setup-slot-orchestration.md` near its "Ready-for-dispatch queue" section
