### PR TITLE
QUA-303 Phase 0: sourcing rename audit + draft migration scripts

### DIFF
--- a/apps/wiki-server/scripts/phase1-sourcing-rename-rollback.sql
+++ b/apps/wiki-server/scripts/phase1-sourcing-rename-rollback.sql
@@ -1,0 +1,48 @@
+-- QUA-303 Phase 1 ROLLBACK — reverse the sourcing_* rename.
+-- Use only if Phase 1 caused an issue AND Phase 2 (code update) has NOT deployed yet.
+-- Once Phase 2 is deployed, rollback requires reverting that PR instead.
+--
+-- This script is safe to run while the back-compat views exist: it drops the views,
+-- renames tables back, and restores all original names.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- 1. Drop the back-compat views (they point to the new names).
+DROP VIEW IF EXISTS source_check_evidence;
+DROP VIEW IF EXISTS source_check_verdicts;
+
+-- 2. Rename tables back to the old names.
+ALTER TABLE sourcing_evidence RENAME TO source_check_evidence;
+ALTER TABLE sourcing_verdicts RENAME TO source_check_verdicts;
+
+-- 3. Restore check constraint names.
+ALTER TABLE source_check_evidence RENAME CONSTRAINT chk_sourcing_evidence_verdict
+  TO chk_source_check_evidence_verdict;
+ALTER TABLE source_check_verdicts RENAME CONSTRAINT chk_sourcing_verdicts_verdict
+  TO chk_source_check_verdicts_verdict;
+
+-- 4. Restore FK + PK constraint names.
+ALTER TABLE source_check_evidence RENAME CONSTRAINT sourcing_evidence_resource_id_fkey
+  TO verification_evidence_resource_id_fkey;
+ALTER TABLE source_check_evidence RENAME CONSTRAINT sourcing_evidence_pkey
+  TO verification_evidence_pkey;
+
+-- 5. Restore sequence name.
+ALTER SEQUENCE sourcing_evidence_id_seq RENAME TO verification_evidence_id_seq;
+
+-- 6. Restore index names.
+ALTER INDEX idx_sourcing_ev_record   RENAME TO idx_sce_record;
+ALTER INDEX idx_sourcing_ev_entity   RENAME TO idx_sce_entity;
+ALTER INDEX idx_sourcing_ev_verdict  RENAME TO idx_sce_verdict;
+ALTER INDEX idx_sourcing_ev_checked  RENAME TO idx_sce_checked;
+ALTER INDEX idx_sourcing_ev_dedup    RENAME TO idx_sce_dedup;
+ALTER INDEX idx_sourcing_vr_pk       RENAME TO idx_scv_pk;
+ALTER INDEX idx_sourcing_vr_verdict  RENAME TO idx_scv_verdict;
+ALTER INDEX idx_sourcing_vr_recheck  RENAME TO idx_scv_recheck;
+ALTER INDEX idx_sourcing_vr_entity   RENAME TO idx_scv_entity;
+ALTER INDEX idx_sourcing_vr_type     RENAME TO idx_scv_type;
+
+COMMIT;

--- a/apps/wiki-server/scripts/phase1-sourcing-rename.sql
+++ b/apps/wiki-server/scripts/phase1-sourcing-rename.sql
@@ -1,0 +1,94 @@
+-- QUA-303 Phase 1: rename source_check_* tables to sourcing_*, create back-compat views.
+-- DRAFT — not yet wired into a Drizzle migration. See docs/audits/qua-303-sourcing-rename-audit.md.
+--
+-- WHY A MANUAL SCRIPT (not a Drizzle migration):
+--   - This is metadata-only (`ALTER TABLE ... RENAME` does not scan rows, unlike 0173's
+--     `ADD CONSTRAINT CHECK` which scanned 3.3M rows under ACCESS EXCLUSIVE).
+--   - But we still want the views intact for the rolling-deploy window, which means
+--     Phase 2 (code update) needs to deploy with views in place. A Drizzle migration
+--     at startup would atomically rename tables in lockstep with the new code — but
+--     any old pod still running during the rolling window would see its queries fail.
+--   - Running Phase 1 as a separate manual step lets us verify views work in prod BEFORE
+--     any code change deploys.
+--
+-- PRECONDITIONS (re-check at run time — see docs/audits/qua-303-sourcing-rename-audit.md):
+--   - wiki-server deploys clean for ≥48h after ratchet-guard fix 2026-04-14 00:52 UTC
+--   - job-worker-health groundskeeper circuit breaker not active
+--   - `source_check_evidence` and `source_check_verdicts` row counts match pre-audit ±delta
+--   - No FK changes since audit (`\d+` inspection)
+--
+-- ROLLBACK: see phase1-sourcing-rename-rollback.sql
+
+BEGIN;
+
+-- Use a short lock_timeout to fail fast if anything holds a conflicting lock.
+-- Unlike 0173 (which needed the scan to complete), RENAME is instant once the lock
+-- is acquired, so 5s is generous.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- 1. Rename tables.
+ALTER TABLE source_check_evidence RENAME TO sourcing_evidence;
+ALTER TABLE source_check_verdicts RENAME TO sourcing_verdicts;
+
+-- 2. Rename check constraints to match new table names (purely cosmetic but keeps
+--    constraint names grep-aligned with table names).
+ALTER TABLE sourcing_evidence RENAME CONSTRAINT chk_source_check_evidence_verdict
+  TO chk_sourcing_evidence_verdict;
+ALTER TABLE sourcing_verdicts RENAME CONSTRAINT chk_source_check_verdicts_verdict
+  TO chk_sourcing_verdicts_verdict;
+
+-- 3. Rename FK constraint (only one — evidence → resources).
+ALTER TABLE sourcing_evidence RENAME CONSTRAINT verification_evidence_resource_id_fkey
+  TO sourcing_evidence_resource_id_fkey;
+
+-- 4. Rename primary key constraint.
+ALTER TABLE sourcing_evidence RENAME CONSTRAINT verification_evidence_pkey
+  TO sourcing_evidence_pkey;
+
+-- 5. Rename sequence (cosmetic — nextval() still works regardless).
+ALTER SEQUENCE verification_evidence_id_seq RENAME TO sourcing_evidence_id_seq;
+
+-- 6. Rename indexes to sc* → sourcing_ev / sourcing_vr prefix.
+ALTER INDEX idx_sce_record   RENAME TO idx_sourcing_ev_record;
+ALTER INDEX idx_sce_entity   RENAME TO idx_sourcing_ev_entity;
+ALTER INDEX idx_sce_verdict  RENAME TO idx_sourcing_ev_verdict;
+ALTER INDEX idx_sce_checked  RENAME TO idx_sourcing_ev_checked;
+ALTER INDEX idx_sce_dedup    RENAME TO idx_sourcing_ev_dedup;
+ALTER INDEX idx_scv_pk       RENAME TO idx_sourcing_vr_pk;
+ALTER INDEX idx_scv_verdict  RENAME TO idx_sourcing_vr_verdict;
+ALTER INDEX idx_scv_recheck  RENAME TO idx_sourcing_vr_recheck;
+ALTER INDEX idx_scv_entity   RENAME TO idx_sourcing_vr_entity;
+ALTER INDEX idx_scv_type     RENAME TO idx_sourcing_vr_type;
+
+-- 7. Create back-compat views under the old names.
+--    Auto-updatable views (simple `SELECT * FROM table`) support INSERT / UPDATE /
+--    DELETE / ON CONFLICT in PostgreSQL 9.3+. Old pods can continue writing through
+--    these views until Phase 2 deploy completes.
+CREATE VIEW source_check_evidence AS SELECT * FROM sourcing_evidence;
+CREATE VIEW source_check_verdicts AS SELECT * FROM sourcing_verdicts;
+
+-- 8. Verify view updatability (check-only, no mutation).
+DO $$
+DECLARE
+  ev_updatable text;
+  vr_updatable text;
+BEGIN
+  SELECT is_updatable INTO ev_updatable
+    FROM information_schema.views WHERE table_name = 'source_check_evidence';
+  SELECT is_updatable INTO vr_updatable
+    FROM information_schema.views WHERE table_name = 'source_check_verdicts';
+  IF ev_updatable <> 'YES' OR vr_updatable <> 'YES' THEN
+    RAISE EXCEPTION 'Back-compat views are not auto-updatable: evidence=%, verdicts=%',
+      ev_updatable, vr_updatable;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- Post-run smoke check (run separately, not in the transaction):
+--   SELECT count(*) FROM sourcing_evidence;        -- expect ~13,556+
+--   SELECT count(*) FROM source_check_evidence;    -- expect same count via view
+--   INSERT INTO source_check_verdicts (record_type, record_id, verdict)
+--     VALUES ('__phase1_smoke__', 'test', 'unchecked');
+--   DELETE FROM source_check_verdicts WHERE record_id = 'test' AND record_type = '__phase1_smoke__';

--- a/apps/wiki-server/scripts/phase3-drop-sourcing-views.sql
+++ b/apps/wiki-server/scripts/phase3-drop-sourcing-views.sql
@@ -2,14 +2,22 @@
 -- DRAFT — see docs/audits/qua-303-sourcing-rename-audit.md.
 --
 -- Run only after ≥7 days of Phase 2 (code update) being deployed AND after confirming
--- via pg_stat_statements (or application logs) that no queries are still hitting the
--- legacy view names.
+-- that no queries are still hitting the legacy view names.
 --
--- Verification query to run BEFORE this script:
---   SELECT query, calls FROM pg_stat_statements
---   WHERE query ILIKE '%source_check_evidence%' OR query ILIKE '%source_check_verdicts%'
---   ORDER BY calls DESC;
--- Expect zero rows, or only the smoke-test INSERT/DELETE from Phase 1.
+-- Observability options (pg_stat_statements is NOT currently installed in prod):
+--   1. Postgres logs: enable `log_statement = 'mod'` temporarily and grep for the
+--      view names, or filter existing slow-query logs.
+--   2. Application logs: grep wiki-server / groundskeeper / crux job logs for the
+--      legacy identifiers. Phase 2 renames them out of source code, so any hit after
+--      the Phase 2 deploy indicates a missed call site.
+--   3. Codebase double-check: `grep -rn "source_check_evidence\|source_check_verdicts"
+--      --include="*.ts" --include="*.sql"` should return only historical Drizzle
+--      migrations and this script's own comments.
+--   4. Install pg_stat_statements ad-hoc if deeper observability is needed:
+--      `CREATE EXTENSION pg_stat_statements;` — requires shared_preload_libraries setting.
+--
+-- The views are auto-updatable, so an app pod querying them will succeed transparently —
+-- there is no error signal to rely on. The verification is proactive, not reactive.
 
 BEGIN;
 

--- a/apps/wiki-server/scripts/phase3-drop-sourcing-views.sql
+++ b/apps/wiki-server/scripts/phase3-drop-sourcing-views.sql
@@ -1,0 +1,29 @@
+-- QUA-303 Phase 3: drop back-compat views after the grace period.
+-- DRAFT — see docs/audits/qua-303-sourcing-rename-audit.md.
+--
+-- Run only after ≥7 days of Phase 2 (code update) being deployed AND after confirming
+-- via pg_stat_statements (or application logs) that no queries are still hitting the
+-- legacy view names.
+--
+-- Verification query to run BEFORE this script:
+--   SELECT query, calls FROM pg_stat_statements
+--   WHERE query ILIKE '%source_check_evidence%' OR query ILIKE '%source_check_verdicts%'
+--   ORDER BY calls DESC;
+-- Expect zero rows, or only the smoke-test INSERT/DELETE from Phase 1.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+DROP VIEW IF EXISTS source_check_evidence;
+DROP VIEW IF EXISTS source_check_verdicts;
+
+COMMIT;
+
+-- Post-run verification:
+--   SELECT table_name FROM information_schema.tables
+--   WHERE table_schema='public'
+--     AND (table_name ILIKE 'source_check%' OR table_name ILIKE 'sourcing_%')
+--   ORDER BY table_name;
+-- Expect: sourcing_evidence, sourcing_url_suggestions, sourcing_verdicts.
+-- (source_check_evidence and source_check_verdicts should NOT appear.)

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -15,6 +15,7 @@ Each audit should link back to the Linear ticket that scoped it and forward to t
 | File | Scope | Status | Linear |
 |---|---|---|---|
 | [`things-denormalization-audit.md`](./things-denormalization-audit.md) | Every write site and consumer of `things.title` / `things.description` / `things.parent_title`, plus the `*_display_name` sibling pattern across 13 tables. Precondition for eliminating write-time denormalization. | Complete 2026-04-13 | [QUA-414](https://linear.app/quantifieduncertainty/issue/QUA-414) / [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) Tier 4b |
+| [`qua-303-sourcing-rename-audit.md`](./qua-303-sourcing-rename-audit.md) | Full PG FK / view / index / call-site inventory for the `source_check_*` → `sourcing_*` rename. Draft Phase 1 + Phase 3 migration SQL in `apps/wiki-server/scripts/`. Precondition for QUA-303 execution. | Complete 2026-04-13 | [QUA-303](https://linear.app/quantifieduncertainty/issue/QUA-303) / [QUA-102](https://linear.app/quantifieduncertainty/issue/QUA-102) umbrella |
 
 ## Related rules files
 

--- a/docs/audits/qua-303-sourcing-rename-audit.md
+++ b/docs/audits/qua-303-sourcing-rename-audit.md
@@ -1,0 +1,204 @@
+# QUA-303 Sourcing Rename — Phase 0 Audit
+
+**Scope:** Final phase of the `source_check_*` → `sourcing_*` rename (parent: QUA-102). Inventory of PG objects, Drizzle bindings, SQL call sites, and code consumers so Phase 1 (the actual DDL) has complete context.
+
+**Linear:** [QUA-303](https://linear.app/quantifieduncertainty/issue/QUA-303). Precondition tracker: [QUA-351](https://linear.app/quantifieduncertainty/issue/QUA-351) scheduled 2026-04-19.
+
+**Phase 0 deliverables (this PR):** audit doc + draft migration SQL in `apps/wiki-server/scripts/` (not wired to Drizzle journal). No prod DDL. No schema.ts edits. No call-site edits.
+
+---
+
+## Preconditions re-check (2026-04-13)
+
+The QUA-303 ticket filed six preconditions. Status after this audit:
+
+| # | Precondition | Status | Notes |
+|---|---|---|---|
+| 1 | 7 consecutive green wiki-server deploys | ❌ **5 of 7** | Clean since 0173 fix 2026-04-12 06:01 UTC (#4180, #4215, #4225, #4258, #4295). ~43h at audit time. |
+| 2 | Ratchet baseline flat at 7 for 7 days | ✅ **Flat at 1 (not 7)** | `crux/validate/.sourcing-baseline.json` frozen at 1 since QUA-296. The lone remaining ref is `sourceCheckedAt` on `_archived_claim_sources` — archived table, all-NULL column, not used in live code. |
+| 3 | Alias `/api/source-checks/*` unused by externals | ✅ **Retired** | QUA-358 (commit `76978aa52`) dropped the alias. This precondition no longer applies. |
+| 4 | FK audit complete | ✅ **Complete (see below)** | Scope is much smaller than the ticket assumed. |
+| 5 | No active incident on adjacent systems | ⚠️ **TWO flags** | (a) Main CI cascade of 9 failures 2026-04-14 00:31–00:46 UTC from `validate-sourcing-lint-guard` test; resolved by PR #4312 at 00:52 UTC. (b) Groundskeeper `job-worker-health` circuit breaker **actively tripped** since 2026-04-13 22:20 UTC, failing half-hourly without a captured `error_message`. Deploy pipeline unaffected by either. |
+| 6 | QUA-295 done | ✅ | PR #4250 shipped. |
+
+### Revised safe-start date
+
+**Original target:** 2026-04-18 (7 days post-0173).
+
+**Revised Phase 1 target:** **2026-04-16 01:00 UTC minimum, contingent on (a) 48h clean main CI after the ratchet-guard fix at 2026-04-14 00:52 UTC, and (b) `job-worker-health` circuit breaker resolved or root-caused.**
+
+Rationale for shortening by 2 days: the FK audit shows 0 inbound FKs and 0 views on both tables, alias precondition already met by QUA-358, ratchet already at 1, and the primary column rename is on an archived table. The original 7-day window was calendar-conservative with an unknown-unknowns margin; with the FK blast radius documented, that margin is much smaller.
+
+---
+
+## PG object inventory (prod, 2026-04-13)
+
+### `source_check_evidence` (→ `sourcing_evidence`)
+
+- **Rows:** 13,556
+- **Sequence:** `verification_evidence_id_seq` (historical name from migration 0131 rename — unchanged intentionally)
+- **Primary key:** `verification_evidence_pkey` on `id`
+- **Indexes:**
+  - `idx_sce_record` btree (record_type, record_id)
+  - `idx_sce_entity` btree (entity_id)
+  - `idx_sce_verdict` btree (verdict)
+  - `idx_sce_checked` btree (checked_at)
+  - `idx_sce_dedup` UNIQUE btree (record_type, record_id, COALESCE(source_url, ''), COALESCE(checker_model, ''))
+- **Check constraints:** `chk_source_check_evidence_verdict` (verdict IN 5 values)
+- **Outbound FKs:** `verification_evidence_resource_id_fkey` → `resources(id) ON DELETE SET NULL`
+- **Inbound FKs:** **none**
+- **Views depending on it:** **none**
+
+### `source_check_verdicts` (→ `sourcing_verdicts`)
+
+- **Rows:** 12,740
+- **No primary key constraint** (uses unique index for identity)
+- **Indexes:**
+  - `idx_scv_pk` UNIQUE btree (record_type, record_id, COALESCE(field_name, ''))
+  - `idx_scv_verdict` btree (verdict)
+  - `idx_scv_recheck` btree (needs_recheck)
+  - `idx_scv_entity` btree (entity_id)
+  - `idx_scv_type` btree (record_type)
+- **Check constraints:** `chk_source_check_verdicts_verdict` (verdict IN 6 values)
+- **Outbound FKs:** **none**
+- **Inbound FKs:** **none**
+- **Views depending on it:** **none**
+
+### `claim_sources.source_checked_at` (→ cosmetic)
+
+- **Live table:** does not exist.
+- **Archived table:** `_archived_claim_sources` (renamed in migration 0065). 585 rows, `source_checked_at` column is all NULL.
+- **Drizzle binding:** `sourceCheckedAt` at `apps/wiki-server/src/schema.ts:580`.
+- **Other code references:** none. `grep -rn "sourceCheckedAt"` returns only `schema.ts`.
+- **Conclusion:** Renaming this column is cosmetic cleanup of an archived table. It is the lone ref keeping the ratchet at 1. Renaming it drops the ratchet to 0.
+
+---
+
+## Write-activity profile (last 48h, prod)
+
+| Hour (UTC) | `source_check_evidence` writes | `source_check_verdicts` writes |
+|---|---|---|
+| 2026-04-13 02:00 | 8 | 4 |
+| 2026-04-13 10:00 | 473 | 568 |
+| 2026-04-13 11:00 | 34 | 90 |
+| 2026-04-13 19:00 | 32 | 32 |
+| All other hours | 0 | 0 |
+
+Bursty and low-volume — peak 568 writes/hour, most hours idle. An `ALTER TABLE RENAME` is metadata-only (milliseconds, no row scan, no data copy), so the "heavy-write tables" concern in the ticket overstates real-time risk. Contrast with 0173's `ADD CONSTRAINT` on a 905 MB / 3.3M-row table which did a full scan under ACCESS EXCLUSIVE.
+
+---
+
+## Code call-site inventory
+
+### Drizzle bindings in schema.ts
+
+| Line | JS export | PG table |
+|---|---|---|
+| 1670 | `recordSources` | `source_check_evidence` |
+| 1716 | `sourceVerdicts` | `source_check_verdicts` |
+| 580 | `sourceCheckedAt` (col prop) | `source_checked_at` on `_archived_claim_sources` |
+
+### Consumers of `sourceVerdicts` / `recordSources` (9 files)
+
+Found via `grep -rn "sourceVerdicts\|recordSources" --include="*.ts"`:
+
+```
+apps/wiki-server/src/routes/shared/sourcing-join.ts
+apps/wiki-server/src/routes/sourcing/sourcing.ts
+apps/wiki-server/src/routes/tablebase/entity-profile.ts
+apps/wiki-server/src/routes/tablebase/grants.ts
+apps/wiki-server/src/routes/tablebase/personnel.ts
+apps/wiki-server/src/routes/tablebase/scanner-results.ts
+apps/wiki-server/src/routes/tablebase/things.ts
+apps/wiki-server/src/routes/wikibase/citations.ts
+apps/wiki-server/src/schema.ts
+```
+
+### Raw SQL references to `source_check_evidence` / `source_check_verdicts` (live, non-migration)
+
+Found via `grep -rn "source_check_evidence\|source_check_verdicts" --include="*.ts" --include="*.sql"` minus historical Drizzle migrations:
+
+| File | Refs |
+|---|---|
+| `apps/wiki-server/src/schema.ts` | 7 (table names, doc comments) |
+| `apps/wiki-server/src/routes/sourcing/sourcing.ts` | 15 |
+| `apps/wiki-server/src/routes/shared/sourcing-join.ts` | 4 |
+| `apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts` | 4 |
+| `apps/wiki-server/src/routes/tablebase/things.ts` | 3 |
+| `apps/wiki-server/src/routes/operational/data-quality.ts` | 2 |
+| `apps/wiki-server/src/routes/wikibase/citations.ts` | 1 |
+| `apps/wiki-server/src/routes/wikibase/pages.ts` | 1 |
+| `apps/wiki-server/src/__tests__/sourcing-evidence-by-records.test.ts` | 11 |
+| `apps/wiki-server/src/__tests__/citations.test.ts` | 4 |
+| `apps/wiki-server/src/__tests__/sourcing-coverage.test.ts` | 2 |
+| `apps/wiki-server/src/__tests__/sourcing-cleanup-orphans.test.ts` | 2 |
+| `apps/wiki-server/src/__tests__/scanner-results.test.ts` | 1 |
+| `apps/web/src/data/entity-nav.ts` | 1 |
+| `apps/web/src/data/tablebase.ts` | — (grep hit, doc/string) |
+| `apps/web/src/lib/citation-data.ts` | 2 |
+| `crux/lib/job-handlers/claim-sourcing.ts` | 1 |
+| `crux/scripts/backfill-fact-entity-ids.ts` | 1 |
+| `crux/commands/migrate-citations.ts` | 1 |
+| `crux/validate/validate-sourcing-lint-guard.ts` | 2 (part of the ratchet itself) |
+| `crux/lib/sourcing-dedup.test.ts` | 1 |
+| `crux/lib/sourcing/bare-id-resolution.test.ts` | 1 |
+
+Historical Drizzle migrations (`apps/wiki-server/drizzle/*.sql`) are frozen-in-time and must not be rewritten.
+
+---
+
+## Recommended phased rollout
+
+Metadata-only renames (no row scan) do not need the full "manual script + NOT VALID" pattern that 0173 needed. The precedent is migration 0131 (verification → source_check) which renamed both tables as a normal Drizzle migration with no incident. The previous rename succeeded in prod with the same PG, same approximate row counts.
+
+However, rolling deploys create a window where old pods are still serving with the old code (reading the old table name). A clean `ALTER TABLE RENAME` mid-deploy would make old-pod queries fail with `relation "source_check_evidence" does not exist`.
+
+Two valid patterns:
+
+### Pattern A — Big-bang (one PR)
+
+1. Drizzle migration renames both tables (metadata-only, instant).
+2. Same PR updates `schema.ts` bindings + all call sites.
+3. Deploy. Rolling window makes old pods briefly error.
+
+**Tradeoff:** Simple, one PR. Accepts ~60s of old-pod 500s during K8s rolling deploy.
+
+### Pattern B — Views for grace window (3 PRs)
+
+1. **Phase 1 PR:** Drizzle migration renames tables and creates views with the old names.
+   - `ALTER TABLE source_check_evidence RENAME TO sourcing_evidence;`
+   - `CREATE VIEW source_check_evidence AS SELECT * FROM sourcing_evidence;`
+   - Old code keeps working via the view (PostgreSQL auto-updatable views support INSERT/UPDATE/DELETE on simple `SELECT * FROM table` views, including `ON CONFLICT`).
+2. **Phase 2 PR:** Update `schema.ts` bindings + all call sites to new names. Deploy atomically.
+3. **Phase 3 PR (≥7 days later):** Drop the views.
+
+**Tradeoff:** Three PRs, zero old-pod errors. Recommended given the 0173 history.
+
+This PR drafts **Pattern B** scripts. See `apps/wiki-server/scripts/phase1-sourcing-rename.sql` and `apps/wiki-server/scripts/phase3-drop-sourcing-views.sql`.
+
+---
+
+## Reproducing this audit
+
+```bash
+# FK / index / view audit
+psql "$PRODUCTION_DB_URL" <<'SQL'
+\d+ source_check_evidence
+\d+ source_check_verdicts
+SELECT conname, conrelid::regclass, confrelid::regclass
+FROM pg_constraint
+WHERE contype='f' AND (confrelid::regclass::text IN ('source_check_evidence','source_check_verdicts')
+                      OR conrelid::regclass::text IN ('source_check_evidence','source_check_verdicts'));
+SELECT dependent_view.relname, source_table.relname
+FROM pg_depend JOIN pg_rewrite ON pg_depend.objid=pg_rewrite.oid
+JOIN pg_class dependent_view ON pg_rewrite.ev_class=dependent_view.oid
+JOIN pg_class source_table ON pg_depend.refobjid=source_table.oid
+WHERE source_table.relname IN ('source_check_evidence','source_check_verdicts')
+  AND dependent_view.relkind='v';
+SQL
+
+# Call-site inventory
+grep -rn "sourceVerdicts\|recordSources" --include="*.ts" | grep -v node_modules
+grep -rn "source_check_evidence\|source_check_verdicts" --include="*.ts" --include="*.sql" | grep -v node_modules
+grep -rn "sourceCheckedAt" --include="*.ts"
+```


### PR DESCRIPTION
## Summary

Phase 0 of QUA-303 (`source_check_*` → `sourcing_*` DB rename): **audit + draft SQL only, no prod DDL**.

- `docs/audits/qua-303-sourcing-rename-audit.md` — precondition re-check (last 48h), full PG object inventory (FKs, indexes, views, constraints, sequences), write-activity profile, code call-site inventory, phased rollout plan
- `apps/wiki-server/scripts/phase1-sourcing-rename.sql` — draft Phase 1 DDL (rename tables + all indexes/constraints/sequence + create back-compat views). Full dry-run inside a ROLLBACK-wrapped transaction passed against prod: all 17 DDL statements executed cleanly, back-compat views are auto-insertable/updatable, INSERT+DELETE through views work
- `apps/wiki-server/scripts/phase1-sourcing-rename-rollback.sql` — reverse script for Phase 1
- `apps/wiki-server/scripts/phase3-drop-sourcing-views.sql` — drop back-compat views after grace period

## Key audit findings

**Blast radius is much smaller than the QUA-303 ticket assumed:**
- `source_check_evidence`: 13,556 rows, 0 inbound FKs, 0 views, 1 outbound FK (→resources)
- `source_check_verdicts`: 12,740 rows, 0 FKs, 0 views
- `claim_sources.source_checked_at` is on the archived table `_archived_claim_sources` (585 rows, all-NULL column, only referenced in schema.ts) — cosmetic cleanup
- Alias precondition already retired by QUA-358
- Ratchet already at 1 (not 7) — one ref left
- Write volume is bursty and low (peak 568 writes/hour, most hours idle)

**Adjacent-system flags raised during audit (must clear before Phase 1):**
1. Main CI ratchet-guard cascade 2026-04-14 00:31–00:46 UTC — resolved by PR #4312 at 00:52 UTC
2. Groundskeeper `job-worker-health` circuit breaker actively tripped since 2026-04-13 22:20 UTC

## Revised Phase 1 timeline

Original target: 2026-04-18 (7 days post-0173).

Revised target: **2026-04-16 01:00 UTC minimum**, contingent on (a) 48h clean main CI after 00:52 UTC 2026-04-14 fix, and (b) `job-worker-health` circuit breaker resolved.

Shortening justified by the FK audit (0 inbound FKs / 0 views) + alias retired + ratchet at 1 + primary column is on archived table.

## Test plan

- [x] Full migration dry-run (BEGIN / all 17 DDL / ROLLBACK) against prod — passed
- [x] View updatability confirmed via `information_schema.views` (both `is_updatable='YES'` and `is_insertable_into='YES'`)
- [x] INSERT through view creates row in underlying table, DELETE through view removes it
- [x] All target PG object names verified to exist (2 tables, 1 FK, 1 PK, 2 check constraints, 1 sequence, 10 indexes)
- [x] Content gate passes
- [ ] No Phase 1 execution until preconditions re-checked (see audit doc § "Preconditions re-check")

Fixes QUA-303
