### PR TITLE
fix: include @longterm-wiki/factbase in wiki-server Docker image

### DIFF
--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /repo
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
 COPY packages/id-utils/package.json ./packages/id-utils/
+COPY packages/factbase/package.json ./packages/factbase/
 
 # Install wiki-server and its workspace dependencies
 RUN pnpm install --frozen-lockfile --filter wiki-server...
@@ -16,6 +17,7 @@ RUN pnpm install --frozen-lockfile --filter wiki-server...
 # Copy server source and workspace packages it depends on
 COPY apps/wiki-server/ ./apps/wiki-server/
 COPY packages/id-utils/ ./packages/id-utils/
+COPY packages/factbase/ ./packages/factbase/
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary

Hotfix for **QUA-449** — the 2026-04-14 release (PR #4324) failed to deploy
the wiki-server because the container crashed at startup with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@longterm-wiki/factbase'
imported from /repo/apps/wiki-server/src/routes/factbase/facts.ts
```

Commit `43b3bf938` (QUA-397) added `@longterm-wiki/factbase` as a workspace
dependency of `apps/wiki-server`, but `apps/wiki-server/Dockerfile` was not
updated to COPY `packages/factbase/` into the image. ArgoCD correctly
skipped the deploy, so prod is still running the previous healthy image.

Mirrors the existing `@longterm-wiki/id-utils` pattern (commit `3c78b4d24`
"fix: include @longterm-wiki/id-utils in wiki-server Docker image"). Two
lines added, both symmetric with the id-utils lines already in place.

Follow-up to file separately: a gate validator that cross-references
`workspace:*` deps in `apps/wiki-server/package.json` with `COPY` lines
in the Dockerfile, so this class of break fails at PR time instead of
at release time. Intentionally out of scope for this hotfix.

Fixes QUA-449

## Test plan

- [x] `pnpm --filter wiki-server typecheck` passes locally (after installing
      the new workspace link).
- [x] Diff is symmetric with the existing `packages/id-utils/` COPY lines.
- [ ] Merge → watch `wiki-server-docker.yml` run → expect smoke test to
      pass with image starting cleanly.
- [ ] Release rerun deploys successfully.

## Deploy Checklist

- [ ] After merge, re-run the failed wiki-server docker workflow (or merge
      a fresh release PR) so the production deploy proceeds.
