### PR TITLE
fix(pr): branch-encoded Linear ID wins over stale wip-checklist (QUA-457)

### DIFF
--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -193,6 +193,28 @@ describe('injectLinearRefs', () => {
     expect(result.body).toBe(body);
   });
 
+  it('does NOT warn about checklist when its ID is already injected via --linear', () => {
+    // Edge case: branch=qua-184, --linear=QUA-110, checklist=QUA-110.
+    // Checklist ID is already in linearIds via --linear, so "ignored" warning
+    // would be misleading.
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-110', 'QUA-110');
+    expect(result.injected).toEqual(['QUA-184', 'QUA-110']);
+    expect(result.warnings.some((w) => w.includes('checklist Linear ID QUA-110 ignored'))).toBe(false);
+  });
+
+  it('branch-matching --linear produces no warning', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184', null);
+    expect(result.injected).toEqual(['QUA-184']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('mixed --linear list: warns for disagreeing ID, silent for matching one', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184,QUA-155', null);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/--linear=QUA-155 disagrees with branch/);
+  });
+
   it('branch ID wins over stale checklist; --linear still adds explicit ID', () => {
     // QUA-457: when branch encodes an ID, checklist is ignored (may be stale).
     // Explicit --linear still injects its ID on top.

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -140,16 +140,37 @@ describe('injectLinearRefs', () => {
     expect(result.body).toContain('Fixes QUA-151');
   });
 
-  it('injects from checklist metadata', () => {
+  it('injects from checklist metadata when branch has NO Linear ID', () => {
     const result = injectLinearRefs('## Summary', 'claude/some-branch', undefined, 'QUA-110');
     expect(result.injected).toEqual(['QUA-110']);
     expect(result.body).toContain('Fixes QUA-110');
+  });
+
+  // QUA-457: the exact regression from PR #4306
+  it('IGNORES stale checklist ID when branch encodes a different Linear ID', () => {
+    const result = injectLinearRefs(
+      '## Summary',
+      'claude/qua-419-sourcing-detail-empty-state',
+      undefined,
+      'QUA-418', // stale from prior session
+    );
+    expect(result.injected).toEqual(['QUA-419']);
+    expect(result.body).toContain('Fixes QUA-419');
+    expect(result.body).not.toContain('Fixes QUA-418');
+    expect(result.warnings.join(' ')).toMatch(/checklist Linear ID QUA-418 ignored/);
+  });
+
+  it('warns when --linear disagrees with branch-encoded ID but still injects both', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-155', null);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
+    expect(result.warnings.join(' ')).toMatch(/--linear=QUA-155 disagrees with branch/);
   });
 
   it('deduplicates across sources', () => {
     const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184', 'QUA-184');
     expect(result.injected).toEqual(['QUA-184']);
     expect(result.body.match(/Fixes QUA-184/g)?.length).toBe(1);
+    expect(result.warnings).toEqual([]);
   });
 
   it('skips already-referenced IDs', () => {
@@ -172,12 +193,15 @@ describe('injectLinearRefs', () => {
     expect(result.body).toBe(body);
   });
 
-  it('combines branch + explicit + checklist IDs', () => {
+  it('branch ID wins over stale checklist; --linear still adds explicit ID', () => {
+    // QUA-457: when branch encodes an ID, checklist is ignored (may be stale).
+    // Explicit --linear still injects its ID on top.
     const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-155', 'QUA-110');
-    expect(result.injected).toEqual(['QUA-184', 'QUA-155', 'QUA-110']);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
     expect(result.body).toContain('Fixes QUA-184');
     expect(result.body).toContain('Fixes QUA-155');
-    expect(result.body).toContain('Fixes QUA-110');
+    expect(result.body).not.toContain('Fixes QUA-110');
+    expect(result.warnings.some((w) => w.includes('QUA-110 ignored'))).toBe(true);
   });
 });
 

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -189,7 +189,12 @@ export function injectLinearRefs(
   // wrong ID into the PR body (QUA-457).
   if (!branchLinearId && checklistLinearId && !linearIds.includes(checklistLinearId)) {
     linearIds.push(checklistLinearId);
-  } else if (branchLinearId && checklistLinearId && checklistLinearId !== branchLinearId) {
+  } else if (
+    branchLinearId &&
+    checklistLinearId &&
+    checklistLinearId !== branchLinearId &&
+    !linearIds.includes(checklistLinearId) // don't warn if --linear already injected this ID
+  ) {
     warnings.push(
       `checklist Linear ID ${checklistLinearId} ignored (branch-encoded ${branchLinearId} takes precedence)`,
     );

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -141,17 +141,32 @@ export function bigramSimilarity(a: string, b: string): number {
 }
 
 /**
- * Collect Linear IDs from branch name, explicit flag, and checklist metadata,
- * then inject `Fixes QUA-NNN` lines into the PR body for any not already referenced.
- * Linear's GitHub integration auto-moves issues to Done on PR merge when it sees these.
+ * Collect Linear IDs from branch name, explicit flag, and (as a last-resort
+ * fallback) checklist metadata, then inject `Fixes QUA-NNN` lines into the
+ * PR body for any not already referenced. Linear's GitHub integration
+ * auto-moves issues to Done on PR merge when it sees these.
+ *
+ * Source precedence (QUA-457):
+ *   1. Branch name (e.g. `claude/qua-184-...`) — the canonical source.
+ *   2. Explicit `--linear` flag(s) — added on top.
+ *   3. `.claude/wip-checklist.md` `> Linear: QUA-NNN` — used ONLY when the
+ *      branch name itself encodes no Linear ID. When the branch does encode
+ *      an ID, the checklist is ignored. This prevents a stale checklist from
+ *      a prior session leaking the wrong Linear ID into the current ticket's
+ *      PR body (see PR #4306 incident).
+ *
+ * Emits a mismatch warning (returned as `warnings`) when the explicit
+ * `--linear` disagrees with the branch-encoded ID — the caller can print
+ * this so operators notice the inconsistency before shipping.
  */
 export function injectLinearRefs(
   body: string,
   branch: string,
   explicitLinear: string | undefined,
   checklistLinearId: string | null,
-): { body: string; injected: string[] } {
+): { body: string; injected: string[]; warnings: string[] } {
   const linearIds: string[] = [];
+  const warnings: string[] = [];
 
   const branchLinearId = parseLinearId(branch);
   if (branchLinearId) linearIds.push(branchLinearId);
@@ -159,12 +174,25 @@ export function injectLinearRefs(
   if (explicitLinear) {
     for (const token of explicitLinear.split(',')) {
       const parsed = parseLinearId(token.trim());
-      if (parsed && !linearIds.includes(parsed)) linearIds.push(parsed);
+      if (!parsed) continue;
+      if (branchLinearId && parsed !== branchLinearId && !linearIds.includes(parsed)) {
+        warnings.push(
+          `--linear=${parsed} disagrees with branch "${branch}" (${branchLinearId}); injecting both`,
+        );
+      }
+      if (!linearIds.includes(parsed)) linearIds.push(parsed);
     }
   }
 
-  if (checklistLinearId && !linearIds.includes(checklistLinearId)) {
+  // Checklist is a last-resort fallback ONLY when the branch doesn't carry a
+  // Linear ID. Otherwise, a stale checklist from a prior session can leak a
+  // wrong ID into the PR body (QUA-457).
+  if (!branchLinearId && checklistLinearId && !linearIds.includes(checklistLinearId)) {
     linearIds.push(checklistLinearId);
+  } else if (branchLinearId && checklistLinearId && checklistLinearId !== branchLinearId) {
+    warnings.push(
+      `checklist Linear ID ${checklistLinearId} ignored (branch-encoded ${branchLinearId} takes precedence)`,
+    );
   }
 
   const alreadyReferenced = new Set(
@@ -172,12 +200,13 @@ export function injectLinearRefs(
   );
   const toInject = linearIds.filter(id => !alreadyReferenced.has(id));
 
-  if (toInject.length === 0) return { body, injected: [] };
+  if (toInject.length === 0) return { body, injected: [], warnings };
 
   const refs = toInject.map(id => `Fixes ${id}`).join('\n');
   return {
     body: body.trimEnd() + '\n\n' + refs + '\n',
     injected: toInject,
+    warnings,
   };
 }
 
@@ -405,6 +434,9 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
     }
 
     const result = injectLinearRefs(body, branch, options.linear as string | undefined, checklistLinearId);
+    for (const w of result.warnings) {
+      log.warn(w);
+    }
     if (result.injected.length > 0) {
       body = result.body;
       log.info(`Auto-injected Linear reference(s): ${result.injected.join(', ')}`);


### PR DESCRIPTION
## Summary

Fixes QUA-457. PR #4306 was created with `Fixes QUA-418` auto-injected into its body while its branch was `claude/qua-419-sourcing-detail-empty-state`. Root cause: `.claude/wip-checklist.md` carried a `> Linear: QUA-418` line from the prior ticket's session, and `injectLinearRefs` treated the checklist as a co-equal source alongside the branch.

## Fix

Change source precedence in `injectLinearRefs` (`crux/commands/pr.ts`):

1. **Branch name** (canonical).
2. **Explicit `--linear`** flag(s) — added on top.
3. **Checklist** `> Linear: QUA-NNN` — used **only** when the branch itself encodes no Linear ID. When the branch does encode an ID, the checklist is ignored.

Also: return `warnings: string[]` and surface them via `log.warn` at the callsite. Warnings fire when:

- `--linear=X` disagrees with the branch-encoded ID (both still injected, but operator sees it).
- A checklist ID is ignored because the branch takes precedence.

Suppressed the "ignored" warning when the checklist ID coincides with one already injected via `--linear` (reviewer finding — avoid misleading warning).

## Tests

- New test reproducing the exact #4306 scenario (branch=qua-419, stale checklist=qua-418 → branch wins, warning fires).
- `--linear` disagreeing with branch → both inject, warning fires.
- `--linear` matching branch → no warning.
- Mixed `--linear` list (`QUA-184,QUA-155`) with branch=qua-184 → only the disagreeing ID triggers warning.
- Checklist coincidence with `--linear` → no warning.

37 tests pass total (4 new for QUA-457).

## Test plan

- [x] `vitest run crux/commands/pr.test.ts` — 37 passing
- [x] Returned `warnings` field is wired into callsite `log.warn`
