### PR TITLE
release: 2026-04-14 #2

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -188,9 +188,13 @@ describe('isStrictVerdictsMode', () => {
     expect(isStrictVerdictsMode()).toBe(true);
   });
 
-  it('is strict when full-build mode is on', () => {
+  it('is NON-strict in full-build mode alone (agent gates run full-build locally without prod creds)', () => {
+    // Regression: the original predicate also fired on fullBuildMode=true,
+    // which made the pre-push gate throw whenever localhost:3112 was down —
+    // agents routinely run the gate without a local wiki-server. Only
+    // `CI=true` (which carries prod credentials) should flip to strict.
     setFullBuildMode(true);
-    expect(isStrictVerdictsMode()).toBe(true);
+    expect(isStrictVerdictsMode()).toBe(false);
   });
 
   it('STRICT_VERDICTS=0 overrides CI strictness (escape hatch)', () => {

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -168,16 +168,23 @@ export async function fetchJsonWithRetry(url, opts = {}) {
 /**
  * Should the build FAIL (throw) on wiki-server errors, vs. degrade gracefully?
  *
- * Strict by default in CI and in full-build mode. Local dev defaults to
- * non-strict (degrade gracefully). Either behavior is overridable:
- *   STRICT_VERDICTS=1  → force strict even locally
- *   STRICT_VERDICTS=0  → force non-strict even in CI (escape hatch)
+ * Strict by default in CI only (`CI=true`) — CI has authenticated prod
+ * credentials and a failing fetch there indicates a real regression worth
+ * halting the build over. Local dev (including full-build mode run from the
+ * gate) defaults to non-strict: when localhost:3112 is down or an agent slot
+ * doesn't have server access, we'd rather return a partial result with a
+ * loud warning than hard-fail the gate for a reason unrelated to the agent's
+ * changes.
+ *
+ * Overrides:
+ *   STRICT_VERDICTS=1  → force strict even locally (test the strict path)
+ *   STRICT_VERDICTS=0  → force non-strict even in CI (emergency escape hatch)
  */
 export function isStrictVerdictsMode() {
   const override = process.env.STRICT_VERDICTS;
   if (override === '0') return false;
   if (override === '1') return true;
-  return process.env.CI === 'true' || fullBuildMode;
+  return process.env.CI === 'true';
 }
 
 /**

--- a/apps/web/src/app/sourcing/__tests__/sourcing-href.test.ts
+++ b/apps/web/src/app/sourcing/__tests__/sourcing-href.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for getSourcingHref / getStoredVerdictHref runtime guards (QUA-423).
+ *
+ * The QUA-417 bug shipped because getSourcingHref accepted any string as
+ * recordId. This suite locks in the runtime guard (via isCandidateRecordId
+ * from api-types) rejecting the composite-key shape without regressing
+ * real-world PKs.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getSourcingHref,
+  getStoredVerdictHref,
+} from "../sourcing-shared";
+
+describe("getSourcingHref — QUA-423 runtime guard", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns a URL for valid record PKs", () => {
+    expect(getSourcingHref("grant", "8NUnVSueLS")).toBe(
+      "/sourcing/grant/8NUnVSueLS",
+    );
+    expect(getSourcingHref("personnel", "sid_A4XoubikkQ")).toBe(
+      "/sourcing/personnel/sid_A4XoubikkQ",
+    );
+    expect(getSourcingHref("fact", "f_mEKUPPFYRg")).toBe(
+      "/sourcing/fact/f_mEKUPPFYRg",
+    );
+  });
+
+  it("returns undefined for the exact QUA-417 composite-key shape", () => {
+    expect(
+      getSourcingHref("grant", "sid_ULjDXpSLCI-8NUnVSueLS"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for other sid_-prefixed composites", () => {
+    expect(getSourcingHref("grant", "sid_abc-sid_def")).toBeUndefined();
+    expect(getSourcingHref("personnel", "sid_x-y")).toBeUndefined();
+  });
+
+  it("returns undefined for two-numeric-ID composites", () => {
+    expect(getSourcingHref("funding-round", "12345-67890")).toBeUndefined();
+  });
+
+  it("returns undefined for empty strings", () => {
+    expect(getSourcingHref("grant", "")).toBeUndefined();
+  });
+
+  it("does NOT flag legitimate hyphenated slugs (false-positive guard)", () => {
+    expect(getSourcingHref("wiki-page", "some-name-2024")).toBe(
+      "/sourcing/wiki-page/some-name-2024",
+    );
+    expect(getSourcingHref("publication", "arxiv-2310-12345")).toBe(
+      "/sourcing/publication/arxiv-2310-12345",
+    );
+    expect(getSourcingHref("grant", "1-2")).toBe("/sourcing/grant/1-2");
+  });
+
+  it("URL-encodes recordId and recordType (special chars)", () => {
+    expect(getSourcingHref("wiki-page", "foo/bar")).toBe(
+      "/sourcing/wiki-page/foo%2Fbar",
+    );
+  });
+
+  it("logs a dev-mode warning naming the caller and recordId on guard failure", () => {
+    getSourcingHref("grant", "sid_ULjDXpSLCI-8NUnVSueLS");
+    expect(warnSpy).toHaveBeenCalled();
+    const msg = warnSpy.mock.calls[0][0];
+    expect(msg).toContain("getSourcingHref");
+    expect(msg).toContain("sid_ULjDXpSLCI-8NUnVSueLS");
+    expect(msg).toMatch(/QUA-417/);
+  });
+});
+
+describe("getStoredVerdictHref — always returns string", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("matches getSourcingHref for valid inputs", () => {
+    expect(getStoredVerdictHref("grant", "8NUnVSueLS")).toBe(
+      "/sourcing/grant/8NUnVSueLS",
+    );
+  });
+
+  it("falls back to /sourcing index on guard failure (never undefined)", () => {
+    const result = getStoredVerdictHref("grant", "sid_abc-sid_def");
+    expect(result).toBe("/sourcing");
+    expect(typeof result).toBe("string");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("has string return type (compile check)", () => {
+    // If the return type drifts to `string | undefined`, this assignment
+    // fails at tsc time. That's the whole point of getStoredVerdictHref
+    // over getSourcingHref.
+    const href: string = getStoredVerdictHref("grant", "g1");
+    expect(href).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/sourcing/sourcing-shared.tsx
+++ b/apps/web/src/app/sourcing/sourcing-shared.tsx
@@ -4,6 +4,7 @@ import {
   SOURCE_CHECK_VERDICT_DESCRIPTIONS,
   SOURCE_CHECK_VERDICT_PRIORITY,
 } from "@/components/shared/verdict-styles";
+import { isCandidateRecordId } from "@wiki-server/api-types";
 
 // ── Verdict styling (from shared module) ────────────────────────────────
 // Cast to Record<string, ...> so consumers can index with `string` verdict keys
@@ -89,9 +90,69 @@ export function getRecordHref(recordType: string, recordId: string): string | nu
   }
 }
 
-/** Get the URL for the sourcing detail page. */
-export function getSourcingHref(recordType: string, recordId: string): string {
+/** The sourcing index — safe fallback when an ID would otherwise build a
+ *  404 URL. See getStoredVerdictHref. */
+const SOURCING_INDEX_HREF = "/sourcing";
+
+/** Build the `/sourcing/:recordType/:recordId` path without any guards.
+ *  Caller is responsible for having verified the IDs. */
+function buildSourcingPath(recordType: string, recordId: string): string {
   return `/sourcing/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`;
+}
+
+/**
+ * Get the URL for the sourcing detail page.
+ *
+ * QUA-423: runtime guard against composite React keys (`${owner}-${record}`)
+ * — the shape that shipped in QUA-417. If `recordId` fails the
+ * `isCandidateRecordId` check, returns `undefined` instead of building a URL
+ * that would 404. Dot components already skip the `<a>` wrapper when `href`
+ * is undefined, so a malformed ID silently renders as a non-clickable dot
+ * rather than a broken link.
+ */
+export function getSourcingHref(
+  recordType: string,
+  recordId: string,
+): string | undefined {
+  if (!isCandidateRecordId(recordId)) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sourcing] getSourcingHref(${JSON.stringify(recordType)}, ${JSON.stringify(recordId)}): ` +
+          `recordId failed isCandidateRecordId guard (likely a composite React key — see QUA-417). ` +
+          `Returning undefined; the receiving dot will render non-clickable.`,
+      );
+    }
+    return undefined;
+  }
+  return buildSourcingPath(recordType, recordId);
+}
+
+/**
+ * Variant for callers rendering rows that already came from the sourcing
+ * verdict store (e.g. /api/sourcing/verdicts). Every row there has a valid
+ * recordType + recordId by construction, so the href is always definable.
+ *
+ * Defense in depth: if somehow called with a malformed ID (orphan row,
+ * mis-typed fixture), falls back to the sourcing index with a dev-mode
+ * warning — never returns undefined. Return type is `string`, so Next.js
+ * `<Link>` accepts it without caller-side fallbacks.
+ */
+export function getStoredVerdictHref(
+  recordType: string,
+  recordId: string,
+): string {
+  const href = getSourcingHref(recordType, recordId);
+  if (href) return href;
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[sourcing] getStoredVerdictHref: no href for stored verdict ` +
+        `${recordType}:${recordId} — falling back to ${SOURCING_INDEX_HREF}. ` +
+        `This suggests an orphaned record_type in source_check_verdicts.`,
+    );
+  }
+  return SOURCING_INDEX_HREF;
 }
 
 /**

--- a/apps/web/src/app/sourcing/sourcing-table.tsx
+++ b/apps/web/src/app/sourcing/sourcing-table.tsx
@@ -5,7 +5,7 @@ import {
   VerdictBadge,
   formatRecordType,
   getRecordHref,
-  getSourcingHref,
+  getStoredVerdictHref,
 } from "./sourcing-shared";
 
 interface SourcingTableProps {
@@ -20,10 +20,10 @@ function resolveClaimDisplay(
   v: RpcSourcingVerdictRow,
   names: Record<string, string>,
   claims: Record<string, string>
-): { text: string; href: string | null; isFallback: boolean } {
+): { text: string; href: string; isFallback: boolean } {
   const claimKey = `${v.recordType}:${v.recordId}:${v.fieldName ?? ""}`;
   const claim = claims[claimKey];
-  const detailHref = getSourcingHref(v.recordType, v.recordId);
+  const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
   if (claim) {
     return { text: claim, href: detailHref, isFallback: false };
   }
@@ -53,7 +53,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
       {/* ── Mobile card list (< sm) ──────────────────────────────────────── */}
       <div className="block sm:hidden space-y-2">
         {verdicts.map((v) => {
-          const detailHref = getSourcingHref(v.recordType, v.recordId);
+          const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
           const recordName = names[v.recordId];
           const entityName = v.entityId ? names[v.entityId] : null;
           const { text: claimText } = resolveClaimDisplay(v, names, claims);
@@ -110,7 +110,7 @@ export function SourcingTable({ verdicts, names, hrefs, claims }: SourcingTableP
           </thead>
           <tbody>
             {verdicts.map((v) => {
-              const detailHref = getSourcingHref(v.recordType, v.recordId);
+              const detailHref = getStoredVerdictHref(v.recordType, v.recordId);
               const recordName = names[v.recordId];
               const recordHref = getRecordHref(v.recordType, v.recordId);
               const entityName = v.entityId ? names[v.entityId] : null;

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -14,7 +14,7 @@ import type { RpcSourcingDetailResult } from "@/lib/wiki-server";
 import {
   VerdictBadge,
   formatRecordType,
-  getSourcingHref,
+  getStoredVerdictHref,
 } from "../../sourcing/sourcing-shared";
 import { isAnySid } from "@longterm-wiki/id-utils";
 
@@ -497,7 +497,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
         )}
         {VERDICT_SOURCE_TABLES.has(thing.sourceTable) && (
           <Link
-            href={getSourcingHref(recordType, thing.sourceId)}
+            href={getStoredVerdictHref(recordType, thing.sourceId)}
             className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
           >
             <ShieldCheck className="h-3.5 w-3.5" />
@@ -622,7 +622,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
           </div>
           <div className="mt-3">
             <Link
-              href={getSourcingHref(recordType, thing.sourceId)}
+              href={getStoredVerdictHref(recordType, thing.sourceId)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               View full evidence
@@ -643,7 +643,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
               This record has not been sourcinged yet.
             </p>
             <Link
-              href={getSourcingHref(recordType, thing.sourceId)}
+              href={getStoredVerdictHref(recordType, thing.sourceId)}
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mt-2"
             >
               View source check page

--- a/apps/web/src/data/__tests__/field-verdicts.test.ts
+++ b/apps/web/src/data/__tests__/field-verdicts.test.ts
@@ -172,3 +172,80 @@ describe("getRecordVerdictStats — per-field entry filtering", () => {
     expect(stats.contradicted).toBe(0);
   });
 });
+
+// ── QUA-423: runtime guard in getRecordVerdict + getFieldVerdict ──────────
+//
+// The QUA-417 bug was callers passing a composite React key (`${owner}-${id}`)
+// to getRecordVerdict. Before the guard, this silently returned null (key
+// didn't exist in the verdict map); now it returns null at the guard with a
+// dev-mode warning pointing at the real fix.
+
+describe("getRecordVerdict / getFieldVerdict — QUA-423 composite-key guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const mockVerdicts = buildMockVerdicts();
+    vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
+      const p = String(filePath);
+      if (p.includes("record-verdicts.json")) return JSON.stringify(mockVerdicts);
+      if (p.includes("database.json")) return JSON.stringify(mockDatabase);
+      if (p.includes("factbase-data.json")) {
+        return JSON.stringify({ entities: {}, facts: {}, slugToEntityId: {} });
+      }
+      return "{}";
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it("returns the verdict for a valid raw record PK", async () => {
+    const { getRecordVerdict } = await import("../tablebase");
+    const v = getRecordVerdict("grant", "g_001");
+    expect(v?.verdict).toBe("confirmed");
+  });
+
+  it("returns null for the QUA-417 composite-key shape (no silent lookup)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getRecordVerdict } = await import("../tablebase");
+
+    const v = getRecordVerdict("grant", "sid_ULjDXpSLCI-g_001");
+    expect(v).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toContain("getRecordVerdict");
+    expect(String(warn.mock.calls[0][0])).toMatch(/QUA-417/);
+    warn.mockRestore();
+  });
+
+  it("returns null on empty string recordId (caller forgot a guard)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getRecordVerdict } = await import("../tablebase");
+    expect(getRecordVerdict("grant", "")).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("does NOT flag legitimate hyphenated IDs (false-positive guard)", async () => {
+    const { getRecordVerdict } = await import("../tablebase");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Null because not in mock, but no QUA-417 warning should fire.
+    expect(getRecordVerdict("wiki-page", "some-name-2024")).toBeNull();
+    expect(getRecordVerdict("publication", "arxiv-2310-12345")).toBeNull();
+    for (const call of warn.mock.calls) {
+      expect(String(call[0])).not.toMatch(/QUA-417/);
+    }
+    warn.mockRestore();
+  });
+
+  it("getFieldVerdict applies the same guard", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getFieldVerdict } = await import("../tablebase");
+
+    // Valid: per-field lookup succeeds
+    expect(getFieldVerdict("grant", "g_001", "amount")?.verdict).toBe("confirmed");
+
+    // Composite: guarded
+    const v = getFieldVerdict("grant", "sid_abc-sid_def", "amount");
+    expect(v).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toContain("getFieldVerdict");
+    warn.mockRestore();
+  });
+});

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -36,6 +36,7 @@ import {
 import type { ValidSubcategory } from "./valid-subcategories";
 import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 import { extractDomain } from "@/lib/resource-types";
+import { isCandidateRecordId } from "@wiki-server/api-types";
 
 // Re-export for consumers
 export type { WithSource };
@@ -1088,14 +1089,52 @@ function getRecordVerdicts(): Record<string, RecordVerdict> {
   }
 }
 
-/** Get the sourcing verdict for a specific record */
+/**
+ * Shared dev-mode warning for the QUA-417 composite-key bug class.
+ * No-op in production.
+ */
+function warnMalformedRecordId(
+  fn: string,
+  recordType: string,
+  recordId: string,
+): void {
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[sourcing] ${fn}(${JSON.stringify(recordType)}, ${JSON.stringify(recordId)}): ` +
+        `recordId failed isCandidateRecordId guard (likely a composite React key — see QUA-417). ` +
+        `Returning null; the verdict lookup would have silently missed anyway.`,
+    );
+  }
+}
+
+/**
+ * Get the sourcing verdict for a specific record.
+ *
+ * QUA-423: runtime guard against composite React keys passed as recordId
+ * (the QUA-417 bug shape). Returns null fast + dev-mode warning pointing at
+ * the real fix, rather than silently missing the lookup and returning null
+ * for a different reason.
+ */
 export function getRecordVerdict(recordType: string, recordId: string): RecordVerdict | null {
+  if (!isCandidateRecordId(recordId)) {
+    warnMalformedRecordId("getRecordVerdict", recordType, recordId);
+    return null;
+  }
   return getRecordVerdicts()[`${recordType}:${recordId}`] ?? null;
 }
 
-/** Get the sourcing verdict for a specific field of a record.
- * Returns null if no per-field verdict exists for this field. */
+/**
+ * Get the sourcing verdict for a specific field of a record.
+ * Returns null if no per-field verdict exists for this field.
+ *
+ * QUA-423: same composite-key guard as getRecordVerdict.
+ */
 export function getFieldVerdict(recordType: string, recordId: string, fieldName: string): RecordVerdict | null {
+  if (!isCandidateRecordId(recordId)) {
+    warnMalformedRecordId("getFieldVerdict", recordType, recordId);
+    return null;
+  }
   return getRecordVerdicts()[`${recordType}:${recordId}:${fieldName}`] ?? null;
 }
 

--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /repo
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
 COPY packages/id-utils/package.json ./packages/id-utils/
+COPY packages/factbase/package.json ./packages/factbase/
 
 # Install wiki-server and its workspace dependencies
 RUN pnpm install --frozen-lockfile --filter wiki-server...
@@ -16,6 +17,7 @@ RUN pnpm install --frozen-lockfile --filter wiki-server...
 # Copy server source and workspace packages it depends on
 COPY apps/wiki-server/ ./apps/wiki-server/
 COPY packages/id-utils/ ./packages/id-utils/
+COPY packages/factbase/ ./packages/factbase/
 
 ENV NODE_ENV=production
 

--- a/apps/wiki-server/drizzle/0179_agent_sessions_heartbeat_at.sql
+++ b/apps/wiki-server/drizzle/0179_agent_sessions_heartbeat_at.sql
@@ -1,0 +1,34 @@
+-- QUA-445 Phase B: add heartbeat_at to agent_sessions.
+--
+-- Sets up agent_sessions to replace active_agents as the liveness source
+-- of truth. The heartbeat hook will populate BOTH active_agents.heartbeat_at
+-- AND agent_sessions.heartbeat_at during the transition (QUA-440 started
+-- this on updated_at; this migration adds a dedicated column so updated_at
+-- can go back to its normal meaning of "row last touched for any reason"
+-- instead of "liveness signal").
+--
+-- When active_agents is dropped in QUA-445 Phase E, this column becomes
+-- the only heartbeat record and powers the dashboard's "last heartbeat
+-- Nm ago" cell.
+--
+-- Lock profile (same pattern as migration 0178):
+--   ADD COLUMN  → ACCESS EXCLUSIVE, milliseconds, no rewrite (nullable
+--                 timestamptz, no default)
+--   CREATE INDEX (partial on non-null heartbeat_at for status='active')
+--               → SHARE briefly; index is empty at migration time
+--
+-- No backfill: existing rows stay NULL. The dedup query already uses
+-- updated_at with a 30-min window, so nothing breaks. After this migration
+-- lands, new heartbeats populate heartbeat_at; a follow-up phase will
+-- switch dedup/dashboard to prefer heartbeat_at when non-null, falling
+-- back to updated_at for pre-QUA-445 rows.
+
+ALTER TABLE "agent_sessions"
+  ADD COLUMN IF NOT EXISTS "heartbeat_at" timestamptz;
+
+-- Partial index scoped to active sessions with a heartbeat. The dedup
+-- query filters on status + heartbeat freshness, so this is the exact
+-- access pattern. Small index: only active rows, usually <50 on prod.
+CREATE INDEX IF NOT EXISTS "idx_as_heartbeat_at_active"
+  ON "agent_sessions" ("heartbeat_at")
+  WHERE "heartbeat_at" IS NOT NULL AND "status" = 'active';

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1254,6 +1254,13 @@
       "when": 1784880000000,
       "tag": "0178_agent_sessions_linear_id_slot",
       "breakpoints": true
+    },
+    {
+      "idx": 179,
+      "version": "7",
+      "when": 1784966400000,
+      "tag": "0179_agent_sessions_heartbeat_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/active-agents.test.ts
+++ b/apps/wiki-server/src/__tests__/active-agents.test.ts
@@ -566,9 +566,10 @@ describe("Active Agents API", () => {
       expect(res.status).toBe(404);
     });
 
-    // QUA-440: the heartbeat also tries to bump agent_sessions.updated_at
-    // for the matching branch, but must not fail if no session exists (the
-    // common case for agents registered outside the agent-checklist flow).
+    // QUA-440/445 Phase B: the heartbeat also bumps
+    // agent_sessions.heartbeat_at + updated_at for the matching branch,
+    // but must not fail if no session exists (the common case for agents
+    // registered outside the agent-checklist flow).
     it("succeeds even when no matching agent_sessions row exists", async () => {
       await postJson(app, "/api/active-agents", sampleAgent);
       // The test dispatcher's fallback for an UPDATE on agent_sessions is

--- a/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for QUA-423 branded RecordId<T> + runtime predicates in api-types.ts.
+ *
+ * The QUA-417 bug shipped because getRecordVerdict / getSourcingHref accepted
+ * any string as recordId — a composite React key (`${owner}-${record}`) was
+ * silently accepted, every verdict lookup missed, every dot rendered as
+ * "unchecked" and 404'd. This suite locks in the runtime defense.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  VALID_RECORD_TYPES,
+  SOURCING_EXEMPT_TYPES,
+  VALID_SOURCE_CHECK_VERDICTS,
+  isSourcingExempt,
+  isValidRecordType,
+  isLinkableSourcingType,
+  asRecordId,
+  isCandidateRecordId,
+  InvalidRecordIdError,
+  type RecordType,
+  type RecordId,
+} from "../api-types.js";
+
+describe("VALID_RECORD_TYPES", () => {
+  it("contains the known sourcing types", () => {
+    expect(VALID_RECORD_TYPES).toContain("grant");
+    expect(VALID_RECORD_TYPES).toContain("personnel");
+    expect(VALID_RECORD_TYPES).toContain("fact");
+    expect(VALID_RECORD_TYPES).toContain("wiki-page");
+  });
+
+  it("does not contain unregistered types flagged in QUA-416", () => {
+    expect(VALID_RECORD_TYPES).not.toContain("entity");
+    expect(VALID_RECORD_TYPES).not.toContain("race");
+    expect(VALID_RECORD_TYPES).not.toContain("race-candidate");
+    expect(VALID_RECORD_TYPES).not.toContain("model-release");
+    expect(VALID_RECORD_TYPES).not.toContain("prediction-question");
+    expect(VALID_RECORD_TYPES).not.toContain("project");
+  });
+
+  it("is frozen in length — adding a type is a schema change", () => {
+    expect(VALID_RECORD_TYPES.length).toBe(16);
+  });
+});
+
+describe("SOURCING_EXEMPT_TYPES invariants", () => {
+  it("every exempt type is also a valid record type", () => {
+    for (const t of SOURCING_EXEMPT_TYPES) {
+      expect(
+        (VALID_RECORD_TYPES as readonly string[]).includes(t),
+        `exempt type "${t}" missing from VALID_RECORD_TYPES`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("VALID_SOURCE_CHECK_VERDICTS", () => {
+  it("does NOT include 'unchecked' — that is a placeholder, not a verdict", () => {
+    expect(VALID_SOURCE_CHECK_VERDICTS).not.toContain("unchecked");
+  });
+});
+
+describe("isValidRecordType", () => {
+  it("narrows string to RecordType when valid", () => {
+    const raw: string = "grant";
+    if (isValidRecordType(raw)) {
+      const _typed: RecordType = raw;
+      expect(_typed).toBe("grant");
+    }
+  });
+
+  it("returns false for QUA-416 dead types", () => {
+    expect(isValidRecordType("entity")).toBe(false);
+    expect(isValidRecordType("race")).toBe(false);
+    expect(isValidRecordType("model-release")).toBe(false);
+    expect(isValidRecordType("project")).toBe(false);
+    expect(isValidRecordType("")).toBe(false);
+    expect(isValidRecordType("garbage-123")).toBe(false);
+  });
+});
+
+describe("isLinkableSourcingType", () => {
+  it("returns true for valid, non-exempt types", () => {
+    expect(isLinkableSourcingType("grant")).toBe(true);
+    expect(isLinkableSourcingType("personnel")).toBe(true);
+    expect(isLinkableSourcingType("fact")).toBe(true);
+    expect(isLinkableSourcingType("wiki-page")).toBe(true);
+  });
+
+  it("returns false for exempt types (even though they ARE valid)", () => {
+    expect(isLinkableSourcingType("benchmark-result")).toBe(false);
+    expect(isLinkableSourcingType("citation")).toBe(false);
+    expect(isLinkableSourcingType("entity-assessment")).toBe(false);
+    expect(isLinkableSourcingType("secondary-market-price")).toBe(false);
+  });
+
+  it("excludes all SOURCING_EXEMPT_TYPES by construction", () => {
+    for (const exempt of SOURCING_EXEMPT_TYPES) {
+      expect(
+        isLinkableSourcingType(exempt),
+        `exempt type "${exempt}" should not be linkable`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("asRecordId — QUA-423", () => {
+  it("accepts valid PK shapes", () => {
+    // Brand is erased at runtime; value is the same string.
+    expect(asRecordId("grant", "8NUnVSueLS")).toBe("8NUnVSueLS");
+    expect(asRecordId("personnel", "sid_A4XoubikkQ")).toBe("sid_A4XoubikkQ");
+    expect(asRecordId("fact", "f_mEKUPPFYRg")).toBe("f_mEKUPPFYRg");
+    expect(asRecordId("funding-round", "42")).toBe("42");
+    expect(asRecordId("wiki-page", "anthropic")).toBe("anthropic");
+  });
+
+  it("throws on empty strings", () => {
+    expect(() => asRecordId("grant", "")).toThrow(InvalidRecordIdError);
+  });
+
+  it("throws on excessively long strings", () => {
+    expect(() => asRecordId("grant", "x".repeat(201))).toThrow(
+      /length 201 exceeds 200/,
+    );
+  });
+
+  it("throws on the exact QUA-417 composite-key shape", () => {
+    // conn.key = `${ownerEntityId}-${record.key}`
+    expect(() => asRecordId("grant", "sid_ULjDXpSLCI-8NUnVSueLS")).toThrow(
+      /composite React key/,
+    );
+  });
+
+  it("throws on sid_X-sid_Y composites", () => {
+    expect(() => asRecordId("grant", "sid_abc-sid_def")).toThrow(
+      InvalidRecordIdError,
+    );
+  });
+
+  it("throws on two-multi-digit-numeric composites", () => {
+    expect(() => asRecordId("funding-round", "12345-67890")).toThrow(
+      /composite/,
+    );
+  });
+
+  it("does NOT flag legitimate hyphenated slugs (false-positive guard)", () => {
+    expect(() => asRecordId("wiki-page", "some-name-2024")).not.toThrow();
+    expect(() => asRecordId("publication", "arxiv-2310-12345")).not.toThrow();
+    expect(() => asRecordId("grant", "1-2")).not.toThrow();
+    expect(() => asRecordId("personnel", "a-b-c-d")).not.toThrow();
+  });
+
+  it("error message references QUA-417 for debuggability", () => {
+    try {
+      asRecordId("grant", "sid_abc-sid_def");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvalidRecordIdError);
+      const err = e as InvalidRecordIdError;
+      expect(err.recordType).toBe("grant");
+      expect(err.rawId).toBe("sid_abc-sid_def");
+      expect(err.message).toMatch(/QUA-417/);
+    }
+  });
+});
+
+describe("isCandidateRecordId", () => {
+  it("accepts the same shapes asRecordId accepts", () => {
+    expect(isCandidateRecordId("8NUnVSueLS")).toBe(true);
+    expect(isCandidateRecordId("sid_A4XoubikkQ")).toBe(true);
+    expect(isCandidateRecordId("some-name-2024")).toBe(true);
+  });
+
+  it("rejects what asRecordId throws on", () => {
+    expect(isCandidateRecordId("")).toBe(false);
+    expect(isCandidateRecordId("x".repeat(201))).toBe(false);
+    expect(isCandidateRecordId("sid_abc-sid_def")).toBe(false);
+    expect(isCandidateRecordId("sid_ULjDXpSLCI-8NUnVSueLS")).toBe(false);
+    expect(isCandidateRecordId("12345-67890")).toBe(false);
+  });
+
+  it("rejects non-string inputs without throwing", () => {
+    expect(isCandidateRecordId(undefined)).toBe(false);
+    expect(isCandidateRecordId(null)).toBe(false);
+    expect(isCandidateRecordId(42)).toBe(false);
+    expect(isCandidateRecordId({})).toBe(false);
+  });
+
+  it("narrows unknown → string via type guard", () => {
+    const raw: unknown = "8NUnVSueLS";
+    if (isCandidateRecordId(raw)) {
+      const _s: string = raw;
+      expect(_s).toBe("8NUnVSueLS");
+    }
+  });
+});
+
+describe("RecordId<T> type distinctness (compile-time)", () => {
+  it("treats different record types as distinct branded types", () => {
+    const grantId: RecordId<"grant"> = asRecordId("grant", "g1");
+    const personnelId: RecordId<"personnel"> = asRecordId("personnel", "p1");
+
+    function takeGrant(id: RecordId<"grant">): string {
+      return id;
+    }
+    expect(takeGrant(grantId)).toBe("g1");
+    // takeGrant(personnelId);  ← would not compile: types incompatible
+
+    // Brand is erased at runtime.
+    expect(grantId).toBe("g1");
+    expect(personnelId).toBe("p1");
+  });
+});

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -100,6 +100,28 @@ export function isSourcingExempt(recordType: string): boolean {
   return (SOURCING_EXEMPT_TYPES as readonly string[]).includes(recordType);
 }
 
+/**
+ * Narrowing type guard: is this string one of the registered record types?
+ *
+ * Useful at FE boundaries (URL params, API responses) so a typo or unregistered
+ * type fails at the guard rather than silently building a 404 URL or missing a
+ * verdict lookup.
+ */
+export function isValidRecordType(recordType: string): recordType is RecordType {
+  return (VALID_RECORD_TYPES as readonly string[]).includes(recordType);
+}
+
+/**
+ * Is this record type both registered AND non-exempt — i.e. would have stored
+ * verdicts worth linking to from a dot? Equivalent to:
+ *   isValidRecordType(t) && !isSourcingExempt(t)
+ */
+export function isLinkableSourcingType(
+  recordType: string,
+): recordType is Exclude<RecordType, SourcingExemptType> {
+  return isValidRecordType(recordType) && !isSourcingExempt(recordType);
+}
+
 export const VALID_SOURCE_CHECK_VERDICTS = [
   "confirmed",
   "contradicted",
@@ -109,6 +131,135 @@ export const VALID_SOURCE_CHECK_VERDICTS = [
 ] as const;
 
 export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];
+
+// ── Branded record IDs (QUA-423) ──────────────────────────────────────────
+//
+// A `RecordId<T>` is a string tagged with a record-type literal at the type
+// level. The only way to obtain one is through `asRecordId()`, which performs
+// runtime checks for obvious misuse — empty string, excessive length, or the
+// composite-key shape that shipped in QUA-417 (`${ownerEntityId}-${record.key}`
+// passed where the raw record PK was expected).
+//
+// Why brands, not `type RecordId<T> = string`? A raw string alias accepts any
+// string, including composite React keys. The QUA-417 bug class only surfaces
+// in code review, not the type checker. With brands, the only way to get a
+// `RecordId<T>` is to wrap via `asRecordId()` — which runs the shape guards.
+
+/**
+ * Opaque, type-tagged record ID. Construct only via `asRecordId()`.
+ *
+ * `RecordId<"grant">` is not assignable to `RecordId<"personnel">` or vice
+ * versa — the compile-time distinction makes mixed-up record types a type
+ * error rather than a runtime miss.
+ */
+export type RecordId<T extends RecordType = RecordType> = string & {
+  readonly __brand: "RecordId";
+  readonly __type: T;
+};
+
+/**
+ * Thrown by `asRecordId()` when the input clearly isn't a raw record PK.
+ * Carries structured fields (`recordType`, `rawId`) so callers can handle
+ * programmatically vs. log as a generic error.
+ */
+export class InvalidRecordIdError extends Error {
+  constructor(
+    public readonly recordType: string,
+    public readonly rawId: string,
+    reason: string,
+  ) {
+    super(
+      `asRecordId(${JSON.stringify(recordType)}, ${JSON.stringify(rawId)}): ${reason}`,
+    );
+    this.name = "InvalidRecordIdError";
+  }
+}
+
+/**
+ * Heuristic: does this look like a composite React key rather than a raw PK?
+ *
+ * The QUA-417 bug was `conn.key = \`${ownerEntityId}-${record.key}\``. The
+ * ownerEntityId was a `sid_`-prefixed stableId and record.key was a 10-char
+ * alphanumeric grant PK — e.g. `sid_ULjDXpSLCI-8NUnVSueLS`.
+ *
+ * Shapes caught:
+ *   - `sid_X-<alphanumRight>`   → stableId + anything (the QUA-417 shape)
+ *   - `<multi-digit>-<multi-digit>`  → two numeric PKs joined
+ *
+ * Does NOT flag legitimate hyphenated IDs (`some-name-2024`, `arxiv-2310-12345`).
+ * Intentionally narrow — false negatives are fine (real PKs don't match this);
+ * false positives on real PKs would break legitimate callers.
+ */
+function looksLikeCompositeKey(rawId: string): boolean {
+  // `sid_...-...` — stableIds themselves don't contain hyphens, so anything
+  // starting with `sid_` followed by `-` is always a composite.
+  if (/^sid_[A-Za-z0-9]+-[A-Za-z0-9]+/.test(rawId)) return true;
+  // Two multi-digit numeric IDs joined, but NOT `1-2` / `a-b` (legit slugs).
+  if (/^\d{3,}-\d{3,}$/.test(rawId)) return true;
+  return false;
+}
+
+/**
+ * Construct a `RecordId<T>` from a raw string.
+ *
+ * Runtime guards catch obvious mistakes at dev/test time:
+ *   - Empty strings (caller passed undefined/null by mistake)
+ *   - Excessive length (caller passed a display name or URL)
+ *   - Composite-key shapes (the QUA-417 bug)
+ *
+ * Throws `InvalidRecordIdError` on rejection. For a non-throwing boundary
+ * check use `isCandidateRecordId()`.
+ *
+ * NOTE: Does not validate `recordType` — use `isValidRecordType()` for that.
+ * The `T extends RecordType` type param is compile-time only; at runtime a
+ * caller could still hand in an unregistered string.
+ */
+export function asRecordId<T extends RecordType>(
+  recordType: T,
+  rawId: string,
+): RecordId<T> {
+  if (typeof rawId !== "string") {
+    throw new InvalidRecordIdError(
+      recordType,
+      String(rawId),
+      `rawId must be string, got ${typeof rawId}`,
+    );
+  }
+  if (rawId.length === 0) {
+    throw new InvalidRecordIdError(recordType, rawId, "empty string");
+  }
+  if (rawId.length > 200) {
+    throw new InvalidRecordIdError(
+      recordType,
+      rawId.slice(0, 50) + "...",
+      `length ${rawId.length} exceeds 200 — likely a URL or display name`,
+    );
+  }
+  if (looksLikeCompositeKey(rawId)) {
+    throw new InvalidRecordIdError(
+      recordType,
+      rawId,
+      "looks like a composite React key (e.g. `${owner}-${record}`); " +
+        "pass the raw PK instead. QUA-417 shipped exactly this bug on " +
+        "funding-connections.tsx.",
+    );
+  }
+  return rawId as RecordId<T>;
+}
+
+/**
+ * Non-throwing check: does this value pass the same runtime guards as
+ * `asRecordId()`? Useful at system boundaries (URL params, API responses)
+ * where you'd want to render a 404 rather than crash.
+ */
+export function isCandidateRecordId(rawId: unknown): rawId is string {
+  return (
+    typeof rawId === "string" &&
+    rawId.length > 0 &&
+    rawId.length <= 200 &&
+    !looksLikeCompositeKey(rawId)
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Edit Logs

--- a/apps/wiki-server/src/routes/operational/active-agents.ts
+++ b/apps/wiki-server/src/routes/operational/active-agents.ts
@@ -273,9 +273,15 @@ const activeAgentsApp = new Hono()
     // update anything. Never fails the heartbeat.
     const branch = result[0].branch;
     if (branch) {
+      // QUA-445 Phase B: bump both heartbeat_at (dedicated liveness
+      // column, new) and updated_at (bumped on any touch for compat with
+      // the existing dedup query, which still filters on updated_at for
+      // rows predating this migration). Post-Phase-D the dedup query
+      // switches to heartbeat_at exclusively.
+      const now = new Date();
       await db
         .update(agentSessions)
-        .set({ updatedAt: new Date() })
+        .set({ heartbeatAt: now, updatedAt: now })
         .where(and(
           eq(agentSessions.branch, branch),
           eq(agentSessions.status, "active"),
@@ -292,7 +298,7 @@ const activeAgentsApp = new Hono()
               branch,
               agentId: id,
             },
-            "Heartbeat: failed to bump agent_sessions.updated_at (QUA-440)",
+            "Heartbeat: failed to bump agent_sessions (QUA-440/445)",
           );
         });
     }

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -57,6 +57,7 @@ function mapSessionRow(r: typeof agentSessions.$inferSelect, pages: string[]) {
     completedAt: r.completedAt,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
+    heartbeatAt: r.heartbeatAt,
     date: r.date,
     title: r.title,
     summary: r.summary,

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1086,6 +1086,12 @@ export const agentSessions = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    // Dedicated liveness signal, separate from updated_at (which bumps on
+    // any row touch). Written by the heartbeat hook; read by the dedup
+    // freshness filter. Part of the QUA-445 agent_sessions-as-primary
+    // migration path — will fully replace active_agents.heartbeat_at in
+    // Phase E of that ticket.
+    heartbeatAt: timestamp("heartbeat_at", { withTimezone: true }),
   },
   (table) => [
     index("idx_as_branch").on(table.branch),
@@ -1098,6 +1104,11 @@ export const agentSessions = pgTable(
     index("idx_as_linear_id")
       .on(table.linearId)
       .where(sql`${table.linearId} IS NOT NULL`),
+    // Partial index on active sessions with a heartbeat (QUA-445 Phase B).
+    // Matches the dedup query's access pattern.
+    index("idx_as_heartbeat_at_active")
+      .on(table.heartbeatAt)
+      .where(sql`${table.heartbeatAt} IS NOT NULL AND ${table.status} = 'active'`),
   ]
 );
 

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -193,6 +193,28 @@ describe('injectLinearRefs', () => {
     expect(result.body).toBe(body);
   });
 
+  it('does NOT warn about checklist when its ID is already injected via --linear', () => {
+    // Edge case: branch=qua-184, --linear=QUA-110, checklist=QUA-110.
+    // Checklist ID is already in linearIds via --linear, so "ignored" warning
+    // would be misleading.
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-110', 'QUA-110');
+    expect(result.injected).toEqual(['QUA-184', 'QUA-110']);
+    expect(result.warnings.some((w) => w.includes('checklist Linear ID QUA-110 ignored'))).toBe(false);
+  });
+
+  it('branch-matching --linear produces no warning', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184', null);
+    expect(result.injected).toEqual(['QUA-184']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('mixed --linear list: warns for disagreeing ID, silent for matching one', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184,QUA-155', null);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/--linear=QUA-155 disagrees with branch/);
+  });
+
   it('branch ID wins over stale checklist; --linear still adds explicit ID', () => {
     // QUA-457: when branch encodes an ID, checklist is ignored (may be stale).
     // Explicit --linear still injects its ID on top.

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -140,16 +140,37 @@ describe('injectLinearRefs', () => {
     expect(result.body).toContain('Fixes QUA-151');
   });
 
-  it('injects from checklist metadata', () => {
+  it('injects from checklist metadata when branch has NO Linear ID', () => {
     const result = injectLinearRefs('## Summary', 'claude/some-branch', undefined, 'QUA-110');
     expect(result.injected).toEqual(['QUA-110']);
     expect(result.body).toContain('Fixes QUA-110');
+  });
+
+  // QUA-457: the exact regression from PR #4306
+  it('IGNORES stale checklist ID when branch encodes a different Linear ID', () => {
+    const result = injectLinearRefs(
+      '## Summary',
+      'claude/qua-419-sourcing-detail-empty-state',
+      undefined,
+      'QUA-418', // stale from prior session
+    );
+    expect(result.injected).toEqual(['QUA-419']);
+    expect(result.body).toContain('Fixes QUA-419');
+    expect(result.body).not.toContain('Fixes QUA-418');
+    expect(result.warnings.join(' ')).toMatch(/checklist Linear ID QUA-418 ignored/);
+  });
+
+  it('warns when --linear disagrees with branch-encoded ID but still injects both', () => {
+    const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-155', null);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
+    expect(result.warnings.join(' ')).toMatch(/--linear=QUA-155 disagrees with branch/);
   });
 
   it('deduplicates across sources', () => {
     const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-184', 'QUA-184');
     expect(result.injected).toEqual(['QUA-184']);
     expect(result.body.match(/Fixes QUA-184/g)?.length).toBe(1);
+    expect(result.warnings).toEqual([]);
   });
 
   it('skips already-referenced IDs', () => {
@@ -172,12 +193,15 @@ describe('injectLinearRefs', () => {
     expect(result.body).toBe(body);
   });
 
-  it('combines branch + explicit + checklist IDs', () => {
+  it('branch ID wins over stale checklist; --linear still adds explicit ID', () => {
+    // QUA-457: when branch encodes an ID, checklist is ignored (may be stale).
+    // Explicit --linear still injects its ID on top.
     const result = injectLinearRefs('## Summary', 'claude/qua-184-fix', 'QUA-155', 'QUA-110');
-    expect(result.injected).toEqual(['QUA-184', 'QUA-155', 'QUA-110']);
+    expect(result.injected).toEqual(['QUA-184', 'QUA-155']);
     expect(result.body).toContain('Fixes QUA-184');
     expect(result.body).toContain('Fixes QUA-155');
-    expect(result.body).toContain('Fixes QUA-110');
+    expect(result.body).not.toContain('Fixes QUA-110');
+    expect(result.warnings.some((w) => w.includes('QUA-110 ignored'))).toBe(true);
   });
 });
 

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -189,7 +189,12 @@ export function injectLinearRefs(
   // wrong ID into the PR body (QUA-457).
   if (!branchLinearId && checklistLinearId && !linearIds.includes(checklistLinearId)) {
     linearIds.push(checklistLinearId);
-  } else if (branchLinearId && checklistLinearId && checklistLinearId !== branchLinearId) {
+  } else if (
+    branchLinearId &&
+    checklistLinearId &&
+    checklistLinearId !== branchLinearId &&
+    !linearIds.includes(checklistLinearId) // don't warn if --linear already injected this ID
+  ) {
     warnings.push(
       `checklist Linear ID ${checklistLinearId} ignored (branch-encoded ${branchLinearId} takes precedence)`,
     );

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -141,17 +141,32 @@ export function bigramSimilarity(a: string, b: string): number {
 }
 
 /**
- * Collect Linear IDs from branch name, explicit flag, and checklist metadata,
- * then inject `Fixes QUA-NNN` lines into the PR body for any not already referenced.
- * Linear's GitHub integration auto-moves issues to Done on PR merge when it sees these.
+ * Collect Linear IDs from branch name, explicit flag, and (as a last-resort
+ * fallback) checklist metadata, then inject `Fixes QUA-NNN` lines into the
+ * PR body for any not already referenced. Linear's GitHub integration
+ * auto-moves issues to Done on PR merge when it sees these.
+ *
+ * Source precedence (QUA-457):
+ *   1. Branch name (e.g. `claude/qua-184-...`) — the canonical source.
+ *   2. Explicit `--linear` flag(s) — added on top.
+ *   3. `.claude/wip-checklist.md` `> Linear: QUA-NNN` — used ONLY when the
+ *      branch name itself encodes no Linear ID. When the branch does encode
+ *      an ID, the checklist is ignored. This prevents a stale checklist from
+ *      a prior session leaking the wrong Linear ID into the current ticket's
+ *      PR body (see PR #4306 incident).
+ *
+ * Emits a mismatch warning (returned as `warnings`) when the explicit
+ * `--linear` disagrees with the branch-encoded ID — the caller can print
+ * this so operators notice the inconsistency before shipping.
  */
 export function injectLinearRefs(
   body: string,
   branch: string,
   explicitLinear: string | undefined,
   checklistLinearId: string | null,
-): { body: string; injected: string[] } {
+): { body: string; injected: string[]; warnings: string[] } {
   const linearIds: string[] = [];
+  const warnings: string[] = [];
 
   const branchLinearId = parseLinearId(branch);
   if (branchLinearId) linearIds.push(branchLinearId);
@@ -159,12 +174,25 @@ export function injectLinearRefs(
   if (explicitLinear) {
     for (const token of explicitLinear.split(',')) {
       const parsed = parseLinearId(token.trim());
-      if (parsed && !linearIds.includes(parsed)) linearIds.push(parsed);
+      if (!parsed) continue;
+      if (branchLinearId && parsed !== branchLinearId && !linearIds.includes(parsed)) {
+        warnings.push(
+          `--linear=${parsed} disagrees with branch "${branch}" (${branchLinearId}); injecting both`,
+        );
+      }
+      if (!linearIds.includes(parsed)) linearIds.push(parsed);
     }
   }
 
-  if (checklistLinearId && !linearIds.includes(checklistLinearId)) {
+  // Checklist is a last-resort fallback ONLY when the branch doesn't carry a
+  // Linear ID. Otherwise, a stale checklist from a prior session can leak a
+  // wrong ID into the PR body (QUA-457).
+  if (!branchLinearId && checklistLinearId && !linearIds.includes(checklistLinearId)) {
     linearIds.push(checklistLinearId);
+  } else if (branchLinearId && checklistLinearId && checklistLinearId !== branchLinearId) {
+    warnings.push(
+      `checklist Linear ID ${checklistLinearId} ignored (branch-encoded ${branchLinearId} takes precedence)`,
+    );
   }
 
   const alreadyReferenced = new Set(
@@ -172,12 +200,13 @@ export function injectLinearRefs(
   );
   const toInject = linearIds.filter(id => !alreadyReferenced.has(id));
 
-  if (toInject.length === 0) return { body, injected: [] };
+  if (toInject.length === 0) return { body, injected: [], warnings };
 
   const refs = toInject.map(id => `Fixes ${id}`).join('\n');
   return {
     body: body.trimEnd() + '\n\n' + refs + '\n',
     injected: toInject,
+    warnings,
   };
 }
 
@@ -405,6 +434,9 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
     }
 
     const result = injectLinearRefs(body, branch, options.linear as string | undefined, checklistLinearId);
+    for (const w of result.warnings) {
+      log.warn(w);
+    }
     if (result.injected.length > 0) {
       body = result.body;
       log.info(`Auto-injected Linear reference(s): ${result.injected.join(', ')}`);

--- a/crux/validate/validate-factbase-record-refs.ts
+++ b/crux/validate/validate-factbase-record-refs.ts
@@ -137,8 +137,43 @@ export function buildEntityLookup(database: {
 // Known baseline — tracked by GitHub issues
 // ---------------------------------------------------------------------------
 
-/** Allow specific orphan refs through as warnings; populate per QUA ticket. */
-const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set<string>();
+/**
+ * Allow specific orphan refs through as warnings; populate per QUA ticket.
+ *
+ * Current entries: 34 sid_ references that resurfaced after the 2026-04-13
+ * baseline clear (commit aded8ac69). Tracked in QUA-459 for cleanup. Each
+ * entry is an orphan that exists in prod FactBase records but has no
+ * matching entity in `packages/factbase/data/things/`. Do NOT add to this
+ * list without a linked ticket — new orphans are bugs, not noise.
+ */
+const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set<string>([
+  // Grant recipient orphans (QUA-459)
+  "sid_GlobalGive",
+  "sid_Orthogonal",
+  "sid_conjecture",
+  "sid_Kurzgesagt",
+  "sid_Futurewise",
+  "sid_lighthaven",
+  "sid_Janaagraha",
+  "sid_Exscientia",
+  // Investment investor orphans (QUA-459)
+  "sid_B5JzHeWvow",
+  "sid_dbDEGrJbUp",
+  "sid_69J7QKcqyX",
+  "sid_Kvfo7x5bqf",
+  "sid_rWgCE08sfW",
+  "sid_dzlCIZ45dZ",
+  "sid_B6ZUV8iv17",
+  "sid_F1bFJHm9RA",
+  "sid_ntlgFVJrPg",
+  "sid_oEH5GwWtow",
+  // Personnel / board-seat person orphans (QUA-459)
+  "sid_QAmTpCO5iQ",
+  "sid_t1PPwNe3x7",
+  "sid_2WGRkU8nio",
+  "sid_L0huEH4GSF",
+  "sid_PUlCEEDFup",
+]);
 
 // ---------------------------------------------------------------------------
 // Field scanning

--- a/docs/audits/active-agents-column-audit.md
+++ b/docs/audits/active-agents-column-audit.md
@@ -1,0 +1,71 @@
+# active_agents Column Audit (QUA-445 Phase A)
+
+**Context:** QUA-445 proposes merging `active_agents` into `agent_sessions`. Before moving columns, audit which of the "unique-to-active_agents" columns are actually written programmatically vs. dead.
+
+**Date:** 2026-04-14
+**Scope:** Columns on `active_agents` that have no equivalent on `agent_sessions`: `session_name`, `current_step`, `files_touched`, `heartbeat_at`, `metadata`.
+
+## Findings
+
+### `current_step` — ACTIVE, keep
+
+Write paths:
+
+| File | Call site | Frequency |
+|------|-----------|-----------|
+| `apps/groundskeeper/src/scheduler.ts:260` | `currentStep: \`${name}: ${result.summary ?? event} (${Math.round(durationMs / 1000)}s)\`` | Every task completion in the groundskeeper loop (~every 30-60s) |
+| `apps/groundskeeper/src/scheduler.ts:343` | `currentStep: \`${name}: ERROR — ${errorMessage.slice(0, 100)}\`` | On every groundskeeper task error |
+| `apps/groundskeeper/src/wiki-server.ts:176` | `updates: { currentStep?: string; status?: string }` — shared wrapper | Via scheduler.ts above |
+| `crux/worker/run.ts:206, 218` | `currentStep: 'Processing X job(s)...' / 'Polling for jobs'` | Every worker poll cycle |
+| `crux/commands/agents.ts:241` | `if (options.step !== undefined) updates.currentStep = options.step;` | Manual CLI: `crux agents update --step="..."` |
+
+Writes are frequent (groundskeeper updates every task completion). The column is load-bearing on the Active Agents dashboard for human visibility. **Preserve** — when `active_agents` is dropped, `current_step` needs to move to `agent_sessions`.
+
+### `files_touched` — DEAD-ISH, defer removal
+
+Write paths:
+
+| File | Call site | Frequency |
+|------|-----------|-----------|
+| `crux/commands/agents.ts:246` | `if (options.files !== undefined) updates.filesTouched = options.files.split(',').map(f => f.trim())` | Manual CLI only: `crux agents update --files=a,b,c` |
+
+No programmatic writers. Only a manual CLI flag that's rarely (never?) used in practice.
+
+**Options:**
+1. Drop in Phase E along with the table.
+2. Repurpose to auto-populate from git diff at checklist complete time (nice-to-have, out of scope for QUA-445).
+
+**Decision:** don't migrate to `agent_sessions`. When `active_agents` is dropped, `--files` silently becomes a no-op; document at that time.
+
+### `heartbeat_at` — CORE, moving in Phase B
+
+Core liveness signal. `heartbeat_at` column added to `agent_sessions` in migration 0179 (this PR). Heartbeat hook now populates both tables' `heartbeat_at`.
+
+### `session_name` — DORMANT
+
+Grep shows no writers; only readers on the dashboard (`agent-activity/active-agents-table.tsx:87`). Field reads come from `active_agents.sessionName` which is never set by anything.
+
+**Decision:** drop at Phase E drop-time; dashboard will lose the Name column, which is fine since it's always blank today.
+
+### `metadata` (jsonb) — DORMANT
+
+No writers. Defined in schema but unused.
+
+**Decision:** drop at Phase E. If a use case emerges, put it on `agent_sessions`.
+
+## Summary for Phase B
+
+Columns that must migrate to `agent_sessions` before dropping `active_agents`:
+
+- `heartbeat_at` — **done in this PR** (migration 0179)
+- `current_step` — needs a follow-up PR adding the column + updating groundskeeper + worker writers. **Not in this PR.** Filed as Phase C work.
+
+Columns that can be dropped without migration:
+
+- `files_touched` — manual CLI only, effectively unused
+- `session_name` — no writers
+- `metadata` — no writers
+
+## Next phase (Phase C)
+
+Add `current_step` to `agent_sessions`. Update groundskeeper and worker to write there in addition to `active_agents`. Keep `active_agents.current_step` writes until the dashboard flip in Phase D.


### PR DESCRIPTION
## Release 2026-04-14

**11 commits** since last release.

> [!WARNING]
> Production has **29 commits** not on main (hotfixes or merge commits).
> Review carefully to ensure these won't be overwritten.

### Features
- feat(agent-sessions): Phase A+B — audit + heartbeat_at column (QUA-445)

### Fixes
- fix(pr): branch-encoded Linear ID wins over stale wip-checklist (QUA-457)
- fix: include @longterm-wiki/factbase in wiki-server Docker image
- fix(build): isStrictVerdictsMode — gate on CI=true, not fullBuildMode (QUA-421 follow-up)
- fix(sourcing): branded RecordId<T> + runtime guards against composite-key bug (QUA-423)

### Other
- review: suppress misleading warning when checklist ID already injected
- test: re-baseline FactBase record-refs validator (QUA-459)

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0179 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `migration` Verify migration 0178 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4307)_
- [ ] `ci` Modified workflow "sourcing recheck" — verify it runs successfully after merge — `gh run list --workflow="sourcing-recheck.yml" --limit=1 --json status,conclusion` _(from PR #4277)_
- [ ] `manual` Trigger sourcing-recheck.yml manually after merge to verify QUA-380 fix — do not wait for the weekly cron. Expect the crux step to print real output (not `Unknown domain`) and the job to complete without pipefail tripping — `gh workflow run sourcing-recheck.yml -R quantified-uncertainty/longterm-wiki -f dry_run=true` _(from PR #4277)_
<!-- /deploy-tasks -->

---
[Full diff](https://github.com/quantified-uncertainty/longterm-wiki/compare/production...main)