### PR TITLE
fix(flagship-curate): fail loudly on wiki-server unavailable (QUA-452)

### DIFF
--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -406,6 +406,7 @@ describe('flagship-curate', () => {
       mockApiRequest.mockResolvedValue({
         ok: false,
         error: 'unavailable',
+        message: 'wiki-server connection refused',
         status: 503,
       });
 
@@ -417,6 +418,9 @@ describe('flagship-curate', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.output).toMatch(/Failed to fetch entities from wiki-server/);
+      expect(result.output).toMatch(/unavailable/);
+      // Human-readable message preserved alongside the error code (review finding).
+      expect(result.output).toMatch(/wiki-server connection refused/);
       expect(result.output).toMatch(/QUA-452/);
       // Must NOT silently report "no entities found" — that was the bug.
       expect(result.output).not.toMatch(/No entities found needing curation/);

--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -398,6 +398,31 @@ describe('flagship-curate', () => {
     });
   });
 
+  // ── Wiki-server unavailable (QUA-452) ────────────────────────────
+  describe('wiki-server unavailable (QUA-452)', () => {
+    it('exits non-zero and surfaces the error when /api/entities fails', async () => {
+      // Batch mode: no explicit --entity, so flagship-curate calls
+      // findEntitiesNeedingCuration → /api/entities. Simulate server down.
+      mockApiRequest.mockResolvedValue({
+        ok: false,
+        error: 'unavailable',
+        status: 503,
+      });
+
+      const result = await commands.default([], {
+        all: true,
+        limit: '1',
+        budget: '1',
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toMatch(/Failed to fetch entities from wiki-server/);
+      expect(result.output).toMatch(/QUA-452/);
+      // Must NOT silently report "no entities found" — that was the bug.
+      expect(result.output).not.toMatch(/No entities found needing curation/);
+    });
+  });
+
   // ── Credit-exhaustion handling (QUA-378) ────────────────────────────
   describe('credit exhaustion (QUA-378)', () => {
     it('aborts with exit code 2 when research throws CreditExhaustedError', async () => {

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -148,8 +148,19 @@ async function resolveEntity(identifier: string): Promise<ResolvedEntity | null>
 /**
  * Find organizations with the worst sourcing coverage.
  * Returns entities sorted by number of non-confirmed verdicts (worst first).
+ *
+ * QUA-452: distinguishes "server unreachable" from "no entities found".
+ * Prior behavior silently returned `[]` on wiki-server error, which the
+ * caller reported as "No entities found needing curation." — a classic
+ * silent-success bug (same shape as QUA-352, QUA-396). Now returns a
+ * discriminated result so the caller fails loudly when the server is
+ * unavailable.
  */
-async function findEntitiesNeedingCuration(limit: number): Promise<ResolvedEntity[]> {
+type FindEntitiesResult =
+  | { ok: true; entities: ResolvedEntity[] }
+  | { ok: false; error: string };
+
+async function findEntitiesNeedingCuration(limit: number): Promise<FindEntitiesResult> {
   // Fetch organizations with verdict summary
   const result = await apiRequest<{
     entities: Array<{
@@ -165,8 +176,7 @@ async function findEntitiesNeedingCuration(limit: number): Promise<ResolvedEntit
   }>('GET', `/api/entities?entityType=organization&limit=200`);
 
   if (!result.ok) {
-    console.warn(`${LOG_PREFIX} Failed to fetch entities: ${result.error}`);
-    return [];
+    return { ok: false, error: String(result.error) };
   }
 
   // For each entity, check how many non-confirmed verdicts exist
@@ -196,7 +206,7 @@ async function findEntitiesNeedingCuration(limit: number): Promise<ResolvedEntit
 
   // Sort: most non-confirmed verdicts first
   scored.sort((a, b) => b.needsCuration - a.needsCuration);
-  return scored.slice(0, limit).map((s) => s.entity);
+  return { ok: true, entities: scored.slice(0, limit).map((s) => s.entity) };
 }
 
 // ── Record Discovery ───────────────────────────────────────────────────
@@ -1098,7 +1108,15 @@ Options:
     entities = [entity];
   } else {
     console.log('Finding entities needing curation...');
-    entities = await findEntitiesNeedingCuration(limit);
+    const findResult = await findEntitiesNeedingCuration(limit);
+    if (!findResult.ok) {
+      // QUA-452: fail loudly instead of reporting "no entities found".
+      return {
+        exitCode: 1,
+        output: `${LOG_PREFIX} Failed to fetch entities from wiki-server: ${findResult.error}. Not treating as "no entities found" — see QUA-452.`,
+      };
+    }
+    entities = findResult.entities;
     if (entities.length === 0) {
       return { exitCode: 0, output: 'No entities found needing curation.' };
     }

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -176,7 +176,8 @@ async function findEntitiesNeedingCuration(limit: number): Promise<FindEntitiesR
   }>('GET', `/api/entities?entityType=organization&limit=200`);
 
   if (!result.ok) {
-    return { ok: false, error: String(result.error) };
+    // Preserve both error code and human-readable message for CI logs.
+    return { ok: false, error: `${result.error}: ${result.message}` };
   }
 
   // For each entity, check how many non-confirmed verdicts exist


### PR DESCRIPTION
## Summary

Fixes QUA-452. `flagship-curate` silently reported `"No entities found needing curation."` when the wiki-server was unreachable (exactly the bug QUA-396's post-deploy verification caught — before #4313 restored the secret). Same silent-success pattern as QUA-352 / QUA-396.

## Fix

- `findEntitiesNeedingCuration` now returns a discriminated result: `{ ok: true, entities } | { ok: false, error }`. On `apiRequest` failure, returns `ok: false` with both the error code (`'unavailable'`, etc.) and the human-readable message joined (`${error}: ${message}`) for CI logs.
- Caller in `commands.default` checks `ok` and returns `exitCode: 1` with `"Failed to fetch entities from wiki-server: <error>. Not treating as 'no entities found' — see QUA-452."`. The "no entities found" success path only fires on an empty list from a successful response.

## Review pass

Reviewer flagged lossy error propagation (was passing only the enum code, dropping `result.message`). Fixed — now surfaces both. Strengthened the test to assert the human-readable message is in the output.

## Known deferred scope

Per the review, the inner-loop `getVerdictsByEntity` calls around line 190 still silently `continue` on per-entity failure. Same silent-success class but different blast radius — defensible to skip a single entity's verdicts vs. abort the entire batch. **Filing as a follow-up ticket rather than expanding this PR.**

## Tests

- New test (QUA-452 suite): batch mode with mocked unavailable response → exitCode=1, output contains `"Failed to fetch entities"`, `"unavailable"`, `"wiki-server connection refused"`, `"QUA-452"`; does NOT contain `"No entities found needing curation"`.

## Test plan

- [x] `vitest run crux/commands/flagship-curate.test.ts` — 56 passing (1 new)
- [x] `tsc --noEmit` clean
