### PR TITLE
fix(deploy-tasks): auto-roll-off PRs already on production (QUA-450 Fix 3)

### DIFF
--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -261,13 +261,15 @@ describe('fetchMergedPrsInWindow (QUA-450 review)', () => {
       throw new Error(`Unexpected page fetch: ${endpoint}`);
     });
 
-    const result = await fetchMergedPrsInWindow(cutoff, api as never, {
+    const { prs, truncated } = await fetchMergedPrsInWindow(cutoff, api as never, {
       perPage: 2,
       maxPages: 10,
     });
 
     // Merged PRs inside the window: 1, 3, 4 (5 onwards are too old; 2 not merged).
-    expect(result.map((p) => p.number).sort()).toEqual([1, 3, 4]);
+    expect(prs.map((p) => p.number).sort()).toEqual([1, 3, 4]);
+    // allPastCutoff on page 3 is a natural termination — not truncation.
+    expect(truncated).toBe(false);
     // We should have made 3 calls — page 3 is where we stop (all past cutoff).
     // page=4 must NOT be fetched.
     expect(api).toHaveBeenCalledTimes(3);
@@ -279,8 +281,33 @@ describe('fetchMergedPrsInWindow (QUA-450 review)', () => {
     const api = vi.fn(async () => [
       makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 }),
     ]);
-    await fetchMergedPrsInWindow(cutoff, api as never, { perPage: 1, maxPages: 2 });
+    const { truncated } = await fetchMergedPrsInWindow(cutoff, api as never, {
+      perPage: 1,
+      maxPages: 2,
+    });
     expect(api).toHaveBeenCalledTimes(2);
+    // Hitting the cap without `allPastCutoff` or a short page is the exact
+    // silent-loss case CodeRabbit flagged (comment 3077100107): we MUST report
+    // the scan as truncated so callers can warn the operator.
+    expect(truncated).toBe(true);
+  });
+
+  it('returns truncated=false when allPastCutoff fires naturally', async () => {
+    // Every PR on page 1 is past the cutoff — `allPastCutoff` trips on page 1
+    // and the loop exits naturally, so truncated MUST be false even though
+    // maxPages=1 (i.e. the cap would have forced termination anyway).
+    const cutoff = new Date(NOW - 14 * DAY);
+    const api = vi.fn(async () => [
+      makePr({ number: 1, mergedDaysAgo: 60, updatedDaysAgo: 40 }),
+      makePr({ number: 2, mergedDaysAgo: 90, updatedDaysAgo: 50 }),
+    ]);
+    const { prs, truncated } = await fetchMergedPrsInWindow(cutoff, api as never, {
+      perPage: 2,
+      maxPages: 1,
+    });
+    expect(prs).toEqual([]); // both outside the window
+    expect(truncated).toBe(false);
+    expect(api).toHaveBeenCalledTimes(1);
   });
 
   it('stops on empty page', async () => {
@@ -289,11 +316,33 @@ describe('fetchMergedPrsInWindow (QUA-450 review)', () => {
       .fn()
       .mockResolvedValueOnce([makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 })])
       .mockResolvedValueOnce([]);
-    const result = await fetchMergedPrsInWindow(cutoff, api as never, {
+    const { prs, truncated } = await fetchMergedPrsInWindow(cutoff, api as never, {
       perPage: 1,
       maxPages: 5,
     });
-    expect(result.map((p) => p.number)).toEqual([1]);
+    expect(prs.map((p) => p.number)).toEqual([1]);
+    expect(truncated).toBe(false);
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns truncated=false when a short final page terminates the scan', async () => {
+    // perPage=2 and the final page returns only 1 row (< perPage). The
+    // "short page" branch must set truncated=false so pending/verify don't
+    // emit a spurious warning.
+    const cutoff = new Date(NOW - 14 * DAY);
+    const api = vi
+      .fn()
+      .mockResolvedValueOnce([
+        makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 }),
+        makePr({ number: 2, mergedDaysAgo: 2, updatedDaysAgo: 1 }),
+      ])
+      .mockResolvedValueOnce([makePr({ number: 3, mergedDaysAgo: 3, updatedDaysAgo: 2 })]);
+    const { prs, truncated } = await fetchMergedPrsInWindow(cutoff, api as never, {
+      perPage: 2,
+      maxPages: 5,
+    });
+    expect(prs.map((p) => p.number).sort()).toEqual([1, 2, 3]);
+    expect(truncated).toBe(false);
     expect(api).toHaveBeenCalledTimes(2);
   });
 });
@@ -494,5 +543,163 @@ describe('commands.verify — roll-off wiring (QUA-450 review)', () => {
     expect(parsed.results.length).toBeGreaterThan(0);
     expect(parsed.summary.rolledOff).toBe(0);
     expect(parsed.summary.compareFailures).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commands.pending / commands.verify — truncation surfacing
+// (QUA-450 review follow-up — CodeRabbit comment 3077100107)
+//
+// `fetchMergedPrsInWindow` uses a hard `maxPages` safety cap. If the loop
+// exhausts that cap without hitting `allPastCutoff` or a short/empty page,
+// the result set is a partial scan and merged PRs on later pages are silently
+// omitted — exactly the missing-task problem the first pagination fix was
+// supposed to kill. These tests pin the contract that both `pending` and
+// `verify` surface `truncated: true` in their CI JSON output so coordinators
+// never trust a silently-truncated scan.
+// ---------------------------------------------------------------------------
+
+describe('commands.pending — truncation surfacing', () => {
+  const NOW = new Date().getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  const DEPLOY_TASK_BODY = [
+    '## Deploy Checklist',
+    '<!-- deploy-tasks:v1 -->',
+    '- [ ] Restart wiki-server',
+    '<!-- /deploy-tasks -->',
+  ].join('\n');
+
+  function prFixture(number: number, mergedDaysAgo: number) {
+    return {
+      number,
+      title: `PR ${number}`,
+      body: DEPLOY_TASK_BODY,
+      merged_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+      merge_commit_sha: `sha-${number}`,
+      updated_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+    };
+  }
+
+  beforeEach(() => {
+    mockGithubApi.mockReset();
+  });
+
+  it('emits truncated=true in CI JSON when every page is full and inside the cutoff window', async () => {
+    // Every page returns a full 100 entries inside the cutoff — the loop
+    // never hits `allPastCutoff` or a short page, so it exits only because
+    // it reaches the default `maxPages=10` cap.
+    let callCount = 0;
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        callCount++;
+        // 100-row full page, all inside the 14-day window
+        return Array.from({ length: 100 }, (_, i) =>
+          prFixture(10_000 + callCount * 1000 + i, 1),
+        );
+      }
+      if (endpoint.includes('/compare/')) {
+        return { ahead_by: 7 }; // keep everything — no roll-off
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.pending([], { ci: true });
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.truncated).toBe(true);
+    // Default maxPages=10 means we made exactly 10 pulls calls.
+    const pullsCalls = mockGithubApi.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('/pulls?'),
+    );
+    expect(pullsCalls).toHaveLength(10);
+  });
+
+  it('emits truncated=false in CI JSON when a short page naturally terminates discovery', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        // One short page — well under perPage=100 — terminates discovery
+        // naturally. No truncation.
+        return [prFixture(700, 1), prFixture(701, 2)];
+      }
+      if (endpoint.includes('/compare/')) {
+        return { ahead_by: 7 };
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.pending([], { ci: true });
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.truncated).toBe(false);
+  });
+});
+
+describe('commands.verify — truncation surfacing', () => {
+  const NOW = new Date().getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  const DEPLOY_TASK_BODY = [
+    '## Deploy Checklist',
+    '<!-- deploy-tasks:v1 -->',
+    '- [ ] `route` Check wiki-server health — `curl -sf "$WIKI_SERVER_URL/health" | jq .`',
+    '<!-- /deploy-tasks -->',
+  ].join('\n');
+
+  function prFixture(number: number, mergedDaysAgo: number) {
+    return {
+      number,
+      title: `PR ${number}`,
+      body: DEPLOY_TASK_BODY,
+      merged_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+      merge_commit_sha: `sha-${number}`,
+      updated_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+    };
+  }
+
+  beforeEach(() => {
+    mockGithubApi.mockReset();
+  });
+
+  it('emits truncated=true in the summary when every page is full and inside the window', async () => {
+    let callCount = 0;
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        callCount++;
+        return Array.from({ length: 100 }, (_, i) =>
+          prFixture(20_000 + callCount * 1000 + i, 1),
+        );
+      }
+      if (endpoint.includes('/compare/')) {
+        return { ahead_by: 7 };
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.verify([], { ci: true, dryRun: true });
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.summary.truncated).toBe(true);
+    const pullsCalls = mockGithubApi.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('/pulls?'),
+    );
+    expect(pullsCalls).toHaveLength(10);
+  });
+
+  it('emits truncated=false in the summary when discovery terminates naturally', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [prFixture(800, 1), prFixture(801, 2)];
+      }
+      if (endpoint.includes('/compare/')) {
+        return { ahead_by: 7 };
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.verify([], { ci: true, dryRun: true });
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.summary.truncated).toBe(false);
   });
 });

--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -4,10 +4,36 @@
  * Covers:
  * - checkPsqlRunnable: gates psql verify commands when psql or DATABASE_URL
  *   are missing from the local environment (QUA-319).
+ * - isPatBlockedError: detects GitHub PAT-blocked errors (QUA-409).
+ * - isCommitOnProduction: unit tests for the compare-API helper (QUA-450).
+ * - fetchMergedPrsInWindow: paginate-until-cutoff helper (QUA-450 review).
+ * - commands.pending / commands.verify: integration-style tests that stub
+ *   `githubApi` end-to-end so regressions in the roll-off wiring
+ *   (`rolledOff`, `--include-deployed`) are caught even when
+ *   `isCommitOnProduction` itself is correct (QUA-450 review).
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { checkPsqlRunnable, isPatBlockedError, isCommitOnProduction } from './deploy-tasks.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the github lib before importing the command under test. We use
+// `vi.hoisted()` so the mock functions are defined before the module factory
+// runs — the module picks up the hoisted references, and each test can then
+// call `mockGithubApi.mockImplementation(...)` to script responses.
+const { mockGithubApi } = vi.hoisted(() => ({
+  mockGithubApi: vi.fn(),
+}));
+vi.mock('../lib/github.ts', () => ({
+  REPO: 'quantified-uncertainty/longterm-wiki',
+  githubApi: mockGithubApi,
+}));
+
+import {
+  checkPsqlRunnable,
+  isPatBlockedError,
+  isCommitOnProduction,
+  fetchMergedPrsInWindow,
+  commands,
+} from './deploy-tasks.ts';
 
 describe('checkPsqlRunnable', () => {
   const PSQL_CMD =
@@ -129,27 +155,30 @@ describe('isPatBlockedError (QUA-409)', () => {
 });
 
 describe('isCommitOnProduction (QUA-450)', () => {
-  it('returns true when compare.ahead_by === 0 (commit is on production)', async () => {
+  it('returns { on: true } when compare.ahead_by === 0 (commit is on production)', async () => {
     const api = vi.fn(async () => ({ ahead_by: 0, behind_by: 42 }));
-    expect(await isCommitOnProduction('abc123', api as never)).toBe(true);
+    const res = await isCommitOnProduction('abc123', api as never);
+    expect(res).toEqual({ on: true });
     expect(api.mock.calls[0][0]).toMatch(/compare\/production\.\.\.abc123/);
   });
 
-  it('returns false when compare.ahead_by > 0 (commit ahead of production)', async () => {
+  it('returns { on: false } when compare.ahead_by > 0 (commit ahead of production)', async () => {
     const api = vi.fn(async () => ({ ahead_by: 5, behind_by: 10 }));
-    expect(await isCommitOnProduction('abc123', api as never)).toBe(false);
+    expect(await isCommitOnProduction('abc123', api as never)).toEqual({ on: false });
   });
 
-  it('fail-open on API error (returns false → keep task visible, do NOT silently roll off)', async () => {
+  it('fail-open on API error: returns { on: false, error } so caller can log degraded behavior', async () => {
     const api = vi.fn(async () => {
       throw new Error('404 Not Found');
     });
-    expect(await isCommitOnProduction('missing-sha', api as never)).toBe(false);
+    const res = await isCommitOnProduction('missing-sha', api as never);
+    expect(res.on).toBe(false);
+    expect(res.error).toMatch(/404 Not Found/);
   });
 
-  it('returns false for empty sha without calling API', async () => {
+  it('returns { on: false } for empty sha without calling API', async () => {
     const api = vi.fn();
-    expect(await isCommitOnProduction('', api as never)).toBe(false);
+    expect(await isCommitOnProduction('', api as never)).toEqual({ on: false });
     expect(api).not.toHaveBeenCalled();
   });
 
@@ -157,5 +186,313 @@ describe('isCommitOnProduction (QUA-450)', () => {
     const api = vi.fn(async () => ({ ahead_by: 0 }));
     await isCommitOnProduction('weird/sha with spaces', api as never);
     expect(api.mock.calls[0][0]).toMatch(/weird%2Fsha%20with%20spaces/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchMergedPrsInWindow (QUA-450 review)
+// ---------------------------------------------------------------------------
+
+describe('fetchMergedPrsInWindow (QUA-450 review)', () => {
+  const NOW = new Date('2026-04-14T00:00:00Z').getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  // Helper: build a fake PrData-shaped row.
+  function makePr(overrides: {
+    number: number;
+    mergedDaysAgo?: number | null;
+    updatedDaysAgo: number;
+    body?: string | null;
+    title?: string;
+  }) {
+    return {
+      number: overrides.number,
+      title: overrides.title ?? `PR ${overrides.number}`,
+      body: overrides.body ?? null,
+      merged_at:
+        overrides.mergedDaysAgo === undefined || overrides.mergedDaysAgo === null
+          ? null
+          : new Date(NOW - overrides.mergedDaysAgo * DAY).toISOString(),
+      merge_commit_sha: `sha-${overrides.number}`,
+      updated_at: new Date(NOW - overrides.updatedDaysAgo * DAY).toISOString(),
+    };
+  }
+
+  it('paginates until a full page is past the cutoff and returns only merged-in-window PRs', async () => {
+    // cutoff = 14 days ago
+    const cutoff = new Date(NOW - 14 * DAY);
+
+    // perPage = 2 so that each scripted page is "full" (won't trigger the
+    // short-page stop condition). Stop condition must be "all updated_at past
+    // cutoff", not "short page".
+    const page1 = [
+      makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 }),
+      makePr({ number: 2, mergedDaysAgo: null, updatedDaysAgo: 2 }), // closed not merged
+    ];
+    const page2 = [
+      // Long-lived branch merged today — the old single-page `sort=created`
+      // fetch missed exactly this case. `updated_at` is recent so we keep
+      // going past this page.
+      makePr({ number: 3, mergedDaysAgo: 0, updatedDaysAgo: 1 }),
+      makePr({ number: 4, mergedDaysAgo: 8, updatedDaysAgo: 3 }),
+    ];
+    const page3 = [
+      // First fully-past-cutoff page — `every updated_at < cutoff` trips,
+      // so we stop here and do NOT fetch page 4.
+      makePr({ number: 5, mergedDaysAgo: 60, updatedDaysAgo: 40 }),
+      makePr({ number: 6, mergedDaysAgo: 90, updatedDaysAgo: 50 }),
+    ];
+    const page4 = [
+      makePr({ number: 7, mergedDaysAgo: 100, updatedDaysAgo: 95 }),
+      makePr({ number: 8, mergedDaysAgo: 120, updatedDaysAgo: 100 }),
+    ];
+
+    // Match `&page=N` (not `per_page=N`!) via the `&page=` prefix.
+    const pageMatch = (endpoint: string): string => {
+      const m = endpoint.match(/&page=(\d+)/);
+      return m ? m[1] : '';
+    };
+    const api = vi.fn(async (endpoint: string) => {
+      const p = pageMatch(endpoint);
+      if (p === '1') return page1;
+      if (p === '2') return page2;
+      if (p === '3') return page3;
+      if (p === '4') return page4;
+      throw new Error(`Unexpected page fetch: ${endpoint}`);
+    });
+
+    const result = await fetchMergedPrsInWindow(cutoff, api as never, {
+      perPage: 2,
+      maxPages: 10,
+    });
+
+    // Merged PRs inside the window: 1, 3, 4 (5 onwards are too old; 2 not merged).
+    expect(result.map((p) => p.number).sort()).toEqual([1, 3, 4]);
+    // We should have made 3 calls — page 3 is where we stop (all past cutoff).
+    // page=4 must NOT be fetched.
+    expect(api).toHaveBeenCalledTimes(3);
+    expect(api.mock.calls[0][0]).toMatch(/sort=updated&direction=desc/);
+  });
+
+  it('respects maxPages safety cap even if cutoff is never crossed', async () => {
+    const cutoff = new Date(NOW - 365 * DAY);
+    const api = vi.fn(async () => [
+      makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 }),
+    ]);
+    await fetchMergedPrsInWindow(cutoff, api as never, { perPage: 1, maxPages: 2 });
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops on empty page', async () => {
+    const cutoff = new Date(NOW - 14 * DAY);
+    const api = vi
+      .fn()
+      .mockResolvedValueOnce([makePr({ number: 1, mergedDaysAgo: 1, updatedDaysAgo: 0 })])
+      .mockResolvedValueOnce([]);
+    const result = await fetchMergedPrsInWindow(cutoff, api as never, {
+      perPage: 1,
+      maxPages: 5,
+    });
+    expect(result.map((p) => p.number)).toEqual([1]);
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commands.pending / commands.verify — end-to-end roll-off wiring (QUA-450 review)
+//
+// These are command-level integration tests that stub `githubApi` at the
+// module boundary and invoke the exported `commands.pending` / `commands.verify`
+// handlers exactly as the CLI does. They catch regressions where `pending` or
+// `verify` stop honoring `rolledOff` / `--include-deployed` even when
+// `isCommitOnProduction` is still correct in isolation.
+// ---------------------------------------------------------------------------
+
+describe('commands.pending — roll-off wiring (QUA-450 review)', () => {
+  const NOW = new Date().getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  const DEPLOY_TASK_BODY = [
+    '## Deploy Checklist',
+    '<!-- deploy-tasks:v1 -->',
+    '- [ ] Restart wiki-server',
+    '<!-- /deploy-tasks -->',
+  ].join('\n');
+
+  function prFixture(number: number, mergedDaysAgo: number) {
+    return {
+      number,
+      title: `PR ${number}`,
+      body: DEPLOY_TASK_BODY,
+      merged_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+      merge_commit_sha: `sha-${number}`,
+      updated_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+    };
+  }
+
+  beforeEach(() => {
+    mockGithubApi.mockReset();
+  });
+
+  it('rolls off PRs whose merge commit is already on production; surfaces rolledOff count', async () => {
+    // pending() will:
+    //   1. fetch /pulls (paginated) — return two PRs, stop after page 1
+    //   2. for each candidate, fetch /compare/production...<sha>
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [prFixture(100, 1), prFixture(101, 2)];
+      }
+      if (endpoint.includes('/compare/production...sha-100')) {
+        return { ahead_by: 0 }; // deployed — roll off
+      }
+      if (endpoint.includes('/compare/production...sha-101')) {
+        return { ahead_by: 7 }; // not deployed — keep
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.pending([], { ci: true });
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.pendingPrs).toHaveLength(1);
+    expect(parsed.pendingPrs[0].number).toBe(101);
+    expect(parsed.rolledOff).toBe(1);
+    expect(parsed.compareFailures).toBe(0);
+  });
+
+  it('keeps deployed PRs when --include-deployed is set; rolledOff and compareFailures both 0', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [prFixture(200, 1), prFixture(201, 2)];
+      }
+      throw new Error(`Should not call compare when includeDeployed=true: ${endpoint}`);
+    });
+
+    const result = await commands.pending([], { ci: true, includeDeployed: true });
+    const parsed = JSON.parse(result.output);
+
+    // Both PRs kept; no compare calls made.
+    expect(parsed.pendingPrs.map((p: { number: number }) => p.number).sort()).toEqual([200, 201]);
+    expect(parsed.rolledOff).toBe(0);
+    expect(parsed.compareFailures).toBe(0);
+    // Assert the compare API was never called — short-circuit is critical
+    // because the compare API is the expensive path.
+    const compareCalls = mockGithubApi.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('/compare/'),
+    );
+    expect(compareCalls).toHaveLength(0);
+  });
+
+  it('surfaces compareFailures when the compare API errors; still fail-opens (keeps task visible)', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) return [prFixture(300, 1)];
+      if (endpoint.includes('/compare/production...sha-300')) {
+        throw new Error('HTTP 500: upstream connect error');
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.pending([], { ci: true });
+    const parsed = JSON.parse(result.output);
+
+    // Fail-open: the task stays visible, and `compareFailures` surfaces the
+    // degraded roll-off so operators know `rolledOff: 0` may be misleading.
+    expect(parsed.pendingPrs).toHaveLength(1);
+    expect(parsed.rolledOff).toBe(0);
+    expect(parsed.compareFailures).toBe(1);
+  });
+});
+
+describe('commands.verify — roll-off wiring (QUA-450 review)', () => {
+  const NOW = new Date().getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  // Verify iterates unchecked tasks and tries to run their embedded verify
+  // commands. We use `--dry-run` so we don't actually execute anything.
+  // The em-dash + backticked command is the canonical format parsed by
+  // `extractVerifyCommand`.
+  const DEPLOY_TASK_BODY = [
+    '## Deploy Checklist',
+    '<!-- deploy-tasks:v1 -->',
+    '- [ ] `route` Check wiki-server health — `curl -sf "$WIKI_SERVER_URL/health" | jq .`',
+    '<!-- /deploy-tasks -->',
+  ].join('\n');
+
+  function prFixture(number: number, mergedDaysAgo: number) {
+    return {
+      number,
+      title: `PR ${number}`,
+      body: DEPLOY_TASK_BODY,
+      merged_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+      merge_commit_sha: `sha-${number}`,
+      updated_at: new Date(NOW - mergedDaysAgo * DAY).toISOString(),
+    };
+  }
+
+  beforeEach(() => {
+    mockGithubApi.mockReset();
+  });
+
+  it('rolls off deployed PRs before verification; rolledOff count reaches the summary', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [prFixture(400, 1), prFixture(401, 2)];
+      }
+      if (endpoint.includes('/compare/production...sha-400')) return { ahead_by: 0 };
+      if (endpoint.includes('/compare/production...sha-401')) return { ahead_by: 1 };
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.verify([], { ci: true, dryRun: true });
+    const parsed = JSON.parse(result.output);
+
+    // Only PR 401's task made it through to verification (as a dry-run skip).
+    const verifiedPrs = [...new Set(parsed.results.map((r: { pr: number }) => r.pr))];
+    expect(verifiedPrs).toEqual([401]);
+    expect(parsed.summary.rolledOff).toBe(1);
+    expect(parsed.summary.compareFailures).toBe(0);
+  });
+
+  it('--include-deployed runs verify for all PRs; rolledOff=0, no compare calls made', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [prFixture(500, 1), prFixture(501, 2)];
+      }
+      throw new Error(`Should not call compare when includeDeployed=true: ${endpoint}`);
+    });
+
+    const result = await commands.verify([], {
+      ci: true,
+      dryRun: true,
+      includeDeployed: true,
+    });
+    const parsed = JSON.parse(result.output);
+
+    const verifiedPrs = [...new Set(parsed.results.map((r: { pr: number }) => r.pr))].sort();
+    expect(verifiedPrs).toEqual([500, 501]);
+    expect(parsed.summary.rolledOff).toBe(0);
+    expect(parsed.summary.compareFailures).toBe(0);
+    const compareCalls = mockGithubApi.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes('/compare/'),
+    );
+    expect(compareCalls).toHaveLength(0);
+  });
+
+  it('surfaces compareFailures in the summary when compare API fails', async () => {
+    mockGithubApi.mockImplementation(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) return [prFixture(600, 1)];
+      if (endpoint.includes('/compare/')) {
+        throw new Error('HTTP 502 Bad Gateway');
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const result = await commands.verify([], { ci: true, dryRun: true });
+    const parsed = JSON.parse(result.output);
+
+    // Fail-open: PR is still verified.
+    expect(parsed.results.length).toBeGreaterThan(0);
+    expect(parsed.summary.rolledOff).toBe(0);
+    expect(parsed.summary.compareFailures).toBe(1);
   });
 });

--- a/crux/commands/deploy-tasks.test.ts
+++ b/crux/commands/deploy-tasks.test.ts
@@ -6,8 +6,8 @@
  *   are missing from the local environment (QUA-319).
  */
 
-import { describe, it, expect } from 'vitest';
-import { checkPsqlRunnable, isPatBlockedError } from './deploy-tasks.ts';
+import { describe, it, expect, vi } from 'vitest';
+import { checkPsqlRunnable, isPatBlockedError, isCommitOnProduction } from './deploy-tasks.ts';
 
 describe('checkPsqlRunnable', () => {
   const PSQL_CMD =
@@ -125,5 +125,37 @@ describe('isPatBlockedError (QUA-409)', () => {
   it('handles empty / undefined output safely', () => {
     expect(isPatBlockedError(undefined)).toBe(false);
     expect(isPatBlockedError('')).toBe(false);
+  });
+});
+
+describe('isCommitOnProduction (QUA-450)', () => {
+  it('returns true when compare.ahead_by === 0 (commit is on production)', async () => {
+    const api = vi.fn(async () => ({ ahead_by: 0, behind_by: 42 }));
+    expect(await isCommitOnProduction('abc123', api as never)).toBe(true);
+    expect(api.mock.calls[0][0]).toMatch(/compare\/production\.\.\.abc123/);
+  });
+
+  it('returns false when compare.ahead_by > 0 (commit ahead of production)', async () => {
+    const api = vi.fn(async () => ({ ahead_by: 5, behind_by: 10 }));
+    expect(await isCommitOnProduction('abc123', api as never)).toBe(false);
+  });
+
+  it('fail-open on API error (returns false → keep task visible, do NOT silently roll off)', async () => {
+    const api = vi.fn(async () => {
+      throw new Error('404 Not Found');
+    });
+    expect(await isCommitOnProduction('missing-sha', api as never)).toBe(false);
+  });
+
+  it('returns false for empty sha without calling API', async () => {
+    const api = vi.fn();
+    expect(await isCommitOnProduction('', api as never)).toBe(false);
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it('URL-encodes the commit sha', async () => {
+    const api = vi.fn(async () => ({ ahead_by: 0 }));
+    await isCommitOnProduction('weird/sha with spaces', api as never);
+    expect(api.mock.calls[0][0]).toMatch(/weird%2Fsha%20with%20spaces/);
   });
 });

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -91,12 +91,24 @@ interface PrData {
   body: string | null;
   merged_at: string | null;
   merge_commit_sha: string | null;
+  updated_at: string | null;
 }
 
 function daysAgo(dateStr: string): number {
   const then = new Date(dateStr);
   const now = new Date();
   return Math.floor((now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Result of a commit-on-production check. `on` is the answer; `error` is set
+ * to a short message when the compare call failed (so we know to surface
+ * degraded roll-off behavior to the operator instead of silently reporting
+ * `rolledOff: 0`).
+ */
+export interface CommitOnProductionResult {
+  on: boolean;
+  error?: string;
 }
 
 /**
@@ -108,46 +120,109 @@ function daysAgo(dateStr: string): number {
  * (QUA-450 Fix 3 — tasks for old PRs kept showing up in `deploy-tasks
  * pending/verify` output on every new release, drowning the real signal).
  *
- * Exported for unit testing.
+ * Exported for unit testing. Returns a `{ on, error? }` tuple so callers can
+ * distinguish "confirmed not deployed" from "compare call failed, assumed
+ * not deployed".
  */
 export async function isCommitOnProduction(
   commitSha: string,
   api: typeof githubApi = githubApi,
-): Promise<boolean> {
-  if (!commitSha) return false;
+): Promise<CommitOnProductionResult> {
+  if (!commitSha) return { on: false };
   try {
     const result = await api<{ ahead_by: number }>(
       `/repos/${REPO}/compare/production...${encodeURIComponent(commitSha)}`,
     );
-    return result.ahead_by === 0;
-  } catch {
+    return { on: result.ahead_by === 0 };
+  } catch (e) {
     // If compare fails (network error, unknown SHA, production branch
     // missing), treat as "not deployed" — i.e. keep the task visible.
     // Fail-open here, because the opposite (fail-closed = silently roll
     // off everything on any glitch) is the exact silent-drop bug we fear.
-    return false;
+    // The error is bubbled up so the caller can count failures and report
+    // degraded roll-off behavior instead of reporting rolledOff: 0.
+    const msg = e instanceof Error ? e.message : String(e);
+    return { on: false, error: msg };
   }
 }
 
 /**
  * Filter a list of PRs to drop those whose merge commit is already on
  * production. When `includeDeployed` is true, returns the list unchanged.
- * Returns both the filtered list and the number of rolled-off PRs so the
- * caller can log it.
+ * Returns both the filtered list, the number of rolled-off PRs, and the
+ * number of compare failures so the caller can log degraded behavior.
  */
 async function rollOffDeployedPrs<T extends { number: number; merge_commit_sha: string | null }>(
   prs: T[],
   includeDeployed: boolean,
-): Promise<{ kept: T[]; rolledOff: number }> {
-  if (includeDeployed) return { kept: prs, rolledOff: 0 };
+): Promise<{ kept: T[]; rolledOff: number; compareFailures: number }> {
+  if (includeDeployed) return { kept: prs, rolledOff: 0, compareFailures: 0 };
   const checks = await Promise.all(
-    prs.map(async (pr) => ({
-      pr,
-      deployed: pr.merge_commit_sha ? await isCommitOnProduction(pr.merge_commit_sha) : false,
-    })),
+    prs.map(async (pr) => {
+      if (!pr.merge_commit_sha) return { pr, deployed: false, error: undefined as string | undefined };
+      const res = await isCommitOnProduction(pr.merge_commit_sha);
+      return { pr, deployed: res.on, error: res.error };
+    }),
   );
   const kept = checks.filter((c) => !c.deployed).map((c) => c.pr);
-  return { kept, rolledOff: prs.length - kept.length };
+  const compareFailures = checks.filter((c) => c.error !== undefined).length;
+  return { kept, rolledOff: prs.length - kept.length, compareFailures };
+}
+
+/**
+ * Fetch merged PRs that were merged within `lookbackDays` of now, paginating
+ * over GitHub's Pulls API until we're confident no younger merged PRs remain.
+ *
+ * Sorts by `updated` descending. For any PR, `updated_at >= merged_at`, so
+ * once a full page's `updated_at` values are all older than the cutoff, every
+ * subsequent page is guaranteed to have `merged_at < cutoff` as well — no more
+ * merged PRs in the window are reachable and we can stop.
+ *
+ * Rationale (QUA-450 review): the previous implementation only looked at the
+ * first 30 PRs sorted by `created`, which silently dropped any PR whose
+ * creation was older than the 30 most-recently-created closed PRs. Long-lived
+ * branches merged today, or any PR pushed past the first page by closure
+ * volume, were silently skipped — losing their deploy tasks entirely.
+ *
+ * `maxPages` is a hard safety cap so a broken cutoff comparison can't cause
+ * an unbounded scan.
+ */
+export async function fetchMergedPrsInWindow(
+  cutoff: Date,
+  api: typeof githubApi = githubApi,
+  opts: { perPage?: number; maxPages?: number } = {},
+): Promise<PrData[]> {
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 10;
+  const result: PrData[] = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const batch = await api<PrData[]>(
+      `/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=${page}`,
+    );
+    if (!Array.isArray(batch) || batch.length === 0) break;
+
+    for (const pr of batch) {
+      // Only merged PRs with merge_at inside the cutoff window matter.
+      if (pr.merged_at && new Date(pr.merged_at) >= cutoff) {
+        result.push(pr);
+      }
+    }
+
+    // Stop when every PR in this page has `updated_at < cutoff`. Because
+    // `updated_at >= merged_at`, this also guarantees every subsequent page's
+    // merged_at is older than cutoff.
+    const allPastCutoff = batch.every((pr) => {
+      const updated = pr.updated_at ? new Date(pr.updated_at) : null;
+      return updated !== null && updated < cutoff;
+    });
+    if (allPastCutoff) break;
+
+    // Short final page — no more results at all.
+    if (batch.length < perPage) break;
+  }
+
+  return result;
 }
 
 async function pending(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -158,22 +233,26 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
-  const rawPrs = await githubApi<PrData[]>(
-    `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
-  );
+  // Paginate by updated-desc until we've seen everything inside the cutoff.
+  // QUA-450 review fix: the previous `sort=created&per_page=30` single page
+  // silently dropped any merged PR older than the 30 most-recently-created
+  // closed PRs.
+  const rawPrs = await fetchMergedPrsInWindow(cutoff);
 
-  // Narrow to merged PRs in the lookback window with deploy tasks before
-  // the (potentially expensive) per-PR production-ancestry check.
+  // Narrow to merged PRs with deploy tasks before the (potentially
+  // expensive) per-PR production-ancestry check. `fetchMergedPrsInWindow`
+  // already guarantees `merged_at >= cutoff`, so we only re-check the body.
   const candidates = rawPrs.filter((pr) => {
-    if (!pr.merged_at) return false;
-    if (new Date(pr.merged_at) < cutoff) return false;
     if (!pr.body) return false;
     const parsed = parseDeployTasksFromBody(pr.body);
     return parsed !== null && parsed.unchecked > 0;
   });
 
   // QUA-450: drop PRs whose code is already on production.
-  const { kept: prs, rolledOff } = await rollOffDeployedPrs(candidates, includeDeployed);
+  const { kept: prs, rolledOff, compareFailures } = await rollOffDeployedPrs(
+    candidates,
+    includeDeployed,
+  );
 
   const pendingPrs: Array<{
     number: number;
@@ -196,17 +275,29 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
 
   if (options.ci) {
     return {
-      output: JSON.stringify({ pendingPrs, lookbackDays, rolledOff }, null, 2) + '\n',
+      output:
+        JSON.stringify(
+          { pendingPrs, lookbackDays, rolledOff, compareFailures },
+          null,
+          2,
+        ) + '\n',
       exitCode: 0,
     };
   }
+
+  // If the compare API is glitching, `rolledOff: 0` could just mean
+  // "we never successfully checked". Surface that to the operator.
+  const compareWarning =
+    compareFailures > 0
+      ? ` ${c.yellow}[${compareFailures} compare failure${compareFailures === 1 ? '' : 's'} — roll-off degraded]${c.reset}`
+      : '';
 
   if (pendingPrs.length === 0) {
     const rolledOffNote = rolledOff > 0
       ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
       : '';
     return {
-      output: `${c.green}No pending deploy tasks. All clear!${c.reset}${rolledOffNote}\n`,
+      output: `${c.green}No pending deploy tasks. All clear!${c.reset}${rolledOffNote}${compareWarning}\n`,
       exitCode: 0,
     };
   }
@@ -217,7 +308,7 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
     ? ` ${c.dim}[${rolledOff} rolled off]${c.reset}`
     : '';
   lines.push(
-    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'})${rolledOffNote}:\n`
+    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'})${rolledOffNote}${compareWarning}:\n`
   );
 
   for (const pr of pendingPrs) {
@@ -373,21 +464,23 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
-  const rawPrs = await githubApi<PrData[]>(
-    `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
-  );
+  // QUA-450 review fix: paginate by updated-desc instead of `sort=created`
+  // first-page-only, so long-lived PRs merged inside the window aren't
+  // silently skipped. See `fetchMergedPrsInWindow` for the stop condition.
+  const rawPrs = await fetchMergedPrsInWindow(cutoff);
 
   // Narrow to merged-with-tasks before the per-PR compare call.
   const candidates = rawPrs.filter((pr) => {
-    if (!pr.merged_at) return false;
-    if (new Date(pr.merged_at) < cutoff) return false;
     if (!pr.body) return false;
     const parsed = parseDeployTasksFromBody(pr.body);
     return parsed !== null && parsed.unchecked > 0;
   });
 
   // QUA-450: drop PRs whose code is already on production.
-  const { kept: prs, rolledOff } = await rollOffDeployedPrs(candidates, includeDeployed);
+  const { kept: prs, rolledOff, compareFailures } = await rollOffDeployedPrs(
+    candidates,
+    includeDeployed,
+  );
 
   const results: VerifyResult[] = [];
 
@@ -466,7 +559,15 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
         JSON.stringify(
           {
             results,
-            summary: { passed, failed, needsUi, skipped, rolledOff, total: results.length },
+            summary: {
+              passed,
+              failed,
+              needsUi,
+              skipped,
+              rolledOff,
+              compareFailures,
+              total: results.length,
+            },
           },
           null,
           2
@@ -475,12 +576,17 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
     };
   }
 
+  const compareWarning =
+    compareFailures > 0
+      ? ` ${c.yellow}[${compareFailures} compare failure${compareFailures === 1 ? '' : 's'} — roll-off degraded]${c.reset}`
+      : '';
+
   if (results.length === 0) {
     const rolledOffNote = rolledOff > 0
       ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
       : '';
     return {
-      output: `${c.green}No pending deploy tasks to verify.${c.reset}${rolledOffNote}\n`,
+      output: `${c.green}No pending deploy tasks to verify.${c.reset}${rolledOffNote}${compareWarning}\n`,
       exitCode: 0,
     };
   }
@@ -494,7 +600,8 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
 
   const lines: string[] = [];
   const headerSuffix = (dryRun ? ' (dry-run)' : '') +
-    (rolledOff > 0 ? ` ${c.dim}[${rolledOff} PR${rolledOff === 1 ? '' : 's'} rolled off]${c.reset}` : '');
+    (rolledOff > 0 ? ` ${c.dim}[${rolledOff} PR${rolledOff === 1 ? '' : 's'} rolled off]${c.reset}` : '') +
+    compareWarning;
   lines.push(`${c.bold}Deploy Tasks Verification${c.reset}${headerSuffix}\n`);
 
   for (const [prNum, prResults] of byPr) {

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -90,6 +90,7 @@ interface PrData {
   title: string;
   body: string | null;
   merged_at: string | null;
+  merge_commit_sha: string | null;
 }
 
 function daysAgo(dateStr: string): number {
@@ -98,16 +99,81 @@ function daysAgo(dateStr: string): number {
   return Math.floor((now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24));
 }
 
+/**
+ * Returns true if the given commit is already on production — i.e. it has
+ * been deployed. Uses GitHub's compare API: `production...{sha}` with
+ * `ahead_by === 0` means {sha} has no commits not already on production.
+ *
+ * Used to auto-roll-off deploy tasks from PRs whose code is already live
+ * (QUA-450 Fix 3 — tasks for old PRs kept showing up in `deploy-tasks
+ * pending/verify` output on every new release, drowning the real signal).
+ *
+ * Exported for unit testing.
+ */
+export async function isCommitOnProduction(
+  commitSha: string,
+  api: typeof githubApi = githubApi,
+): Promise<boolean> {
+  if (!commitSha) return false;
+  try {
+    const result = await api<{ ahead_by: number }>(
+      `/repos/${REPO}/compare/production...${encodeURIComponent(commitSha)}`,
+    );
+    return result.ahead_by === 0;
+  } catch {
+    // If compare fails (network error, unknown SHA, production branch
+    // missing), treat as "not deployed" — i.e. keep the task visible.
+    // Fail-open here, because the opposite (fail-closed = silently roll
+    // off everything on any glitch) is the exact silent-drop bug we fear.
+    return false;
+  }
+}
+
+/**
+ * Filter a list of PRs to drop those whose merge commit is already on
+ * production. When `includeDeployed` is true, returns the list unchanged.
+ * Returns both the filtered list and the number of rolled-off PRs so the
+ * caller can log it.
+ */
+async function rollOffDeployedPrs<T extends { number: number; merge_commit_sha: string | null }>(
+  prs: T[],
+  includeDeployed: boolean,
+): Promise<{ kept: T[]; rolledOff: number }> {
+  if (includeDeployed) return { kept: prs, rolledOff: 0 };
+  const checks = await Promise.all(
+    prs.map(async (pr) => ({
+      pr,
+      deployed: pr.merge_commit_sha ? await isCommitOnProduction(pr.merge_commit_sha) : false,
+    })),
+  );
+  const kept = checks.filter((c) => !c.deployed).map((c) => c.pr);
+  return { kept, rolledOff: prs.length - kept.length };
+}
+
 async function pending(_args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(Boolean(options.ci));
   const c = log.colors;
   const lookbackDays = Number(options.days) || 14;
+  const includeDeployed = Boolean(options.includeDeployed ?? options['include-deployed']);
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
-  const prs = await githubApi<PrData[]>(
+  const rawPrs = await githubApi<PrData[]>(
     `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
   );
+
+  // Narrow to merged PRs in the lookback window with deploy tasks before
+  // the (potentially expensive) per-PR production-ancestry check.
+  const candidates = rawPrs.filter((pr) => {
+    if (!pr.merged_at) return false;
+    if (new Date(pr.merged_at) < cutoff) return false;
+    if (!pr.body) return false;
+    const parsed = parseDeployTasksFromBody(pr.body);
+    return parsed !== null && parsed.unchecked > 0;
+  });
+
+  // QUA-450: drop PRs whose code is already on production.
+  const { kept: prs, rolledOff } = await rollOffDeployedPrs(candidates, includeDeployed);
 
   const pendingPrs: Array<{
     number: number;
@@ -117,41 +183,41 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
   }> = [];
 
   for (const pr of prs) {
-    if (!pr.merged_at) continue;
-    const mergedDate = new Date(pr.merged_at);
-    if (mergedDate < cutoff) continue;
-    if (!pr.body) continue;
-
-    const parsed = parseDeployTasksFromBody(pr.body);
-    if (!parsed || parsed.unchecked === 0) continue;
-
+    const parsed = parseDeployTasksFromBody(pr.body!);
+    if (!parsed) continue; // narrowed above, but satisfy TS
     const unchecked = parsed.items.filter((t) => !t.checked).map((t) => t.text);
     pendingPrs.push({
       number: pr.number,
       title: pr.title,
-      mergedDaysAgo: daysAgo(pr.merged_at),
+      mergedDaysAgo: daysAgo(pr.merged_at!),
       uncheckedTasks: unchecked,
     });
   }
 
   if (options.ci) {
     return {
-      output: JSON.stringify({ pendingPrs, lookbackDays }, null, 2) + '\n',
+      output: JSON.stringify({ pendingPrs, lookbackDays, rolledOff }, null, 2) + '\n',
       exitCode: 0,
     };
   }
 
   if (pendingPrs.length === 0) {
+    const rolledOffNote = rolledOff > 0
+      ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
+      : '';
     return {
-      output: `${c.green}No pending deploy tasks. All clear!${c.reset}\n`,
+      output: `${c.green}No pending deploy tasks. All clear!${c.reset}${rolledOffNote}\n`,
       exitCode: 0,
     };
   }
 
   const totalUnchecked = pendingPrs.reduce((sum, pr) => sum + pr.uncheckedTasks.length, 0);
   const lines: string[] = [];
+  const rolledOffNote = rolledOff > 0
+    ? ` ${c.dim}[${rolledOff} rolled off]${c.reset}`
+    : '';
   lines.push(
-    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'}):\n`
+    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'})${rolledOffNote}:\n`
   );
 
   for (const pr of pendingPrs) {
@@ -303,20 +369,30 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   const lookbackDays = Number(options.days) || 14;
   const dryRun = Boolean(options.dryRun ?? options['dry-run']);
   const timeoutMs = Number(options.timeout) || 30_000;
+  const includeDeployed = Boolean(options.includeDeployed ?? options['include-deployed']);
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
-  const prs = await githubApi<PrData[]>(
+  const rawPrs = await githubApi<PrData[]>(
     `/repos/${REPO}/pulls?state=closed&sort=created&direction=desc&per_page=30`
   );
+
+  // Narrow to merged-with-tasks before the per-PR compare call.
+  const candidates = rawPrs.filter((pr) => {
+    if (!pr.merged_at) return false;
+    if (new Date(pr.merged_at) < cutoff) return false;
+    if (!pr.body) return false;
+    const parsed = parseDeployTasksFromBody(pr.body);
+    return parsed !== null && parsed.unchecked > 0;
+  });
+
+  // QUA-450: drop PRs whose code is already on production.
+  const { kept: prs, rolledOff } = await rollOffDeployedPrs(candidates, includeDeployed);
 
   const results: VerifyResult[] = [];
 
   for (const pr of prs) {
-    if (!pr.merged_at) continue;
-    if (new Date(pr.merged_at) < cutoff) continue;
-    if (!pr.body) continue;
-
+    if (!pr.body) continue; // narrowed above
     const parsed = parseDeployTasksFromBody(pr.body);
     if (!parsed || parsed.unchecked === 0) continue;
 
@@ -390,7 +466,7 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
         JSON.stringify(
           {
             results,
-            summary: { passed, failed, needsUi, skipped, total: results.length },
+            summary: { passed, failed, needsUi, skipped, rolledOff, total: results.length },
           },
           null,
           2
@@ -400,8 +476,11 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   }
 
   if (results.length === 0) {
+    const rolledOffNote = rolledOff > 0
+      ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
+      : '';
     return {
-      output: `${c.green}No pending deploy tasks to verify.${c.reset}\n`,
+      output: `${c.green}No pending deploy tasks to verify.${c.reset}${rolledOffNote}\n`,
       exitCode: 0,
     };
   }
@@ -414,9 +493,9 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   }
 
   const lines: string[] = [];
-  lines.push(
-    `${c.bold}Deploy Tasks Verification${c.reset}${dryRun ? ' (dry-run)' : ''}\n`
-  );
+  const headerSuffix = (dryRun ? ' (dry-run)' : '') +
+    (rolledOff > 0 ? ` ${c.dim}[${rolledOff} PR${rolledOff === 1 ? '' : 's'} rolled off]${c.reset}` : '');
+  lines.push(`${c.bold}Deploy Tasks Verification${c.reset}${headerSuffix}\n`);
 
   for (const [prNum, prResults] of byPr) {
     const title = prResults[0].prTitle;
@@ -551,6 +630,8 @@ Options (detect):
 
 Options (pending):
   --days=N              Lookback window in days (default: 14).
+  --include-deployed    Show tasks from PRs already on production (by default
+                        they are rolled off — QUA-450).
   --ci                  JSON output.
 
 Options (inject):
@@ -561,6 +642,8 @@ Options (verify):
   --days=N              Lookback window in days (default: 14).
   --timeout=N           Per-command timeout in milliseconds (default: 30000).
   --dry-run             Print commands without executing them.
+  --include-deployed    Verify tasks from PRs already on production (by
+                        default they are rolled off — QUA-450).
   --ci                  JSON output.
 
 Environment for verify:

--- a/crux/commands/deploy-tasks.ts
+++ b/crux/commands/deploy-tasks.ts
@@ -186,26 +186,40 @@ async function rollOffDeployedPrs<T extends { number: number; merge_commit_sha: 
  *
  * `maxPages` is a hard safety cap so a broken cutoff comparison can't cause
  * an unbounded scan.
+ *
+ * Returns `{ prs, truncated }` where `truncated` is `true` iff the loop
+ * exhausted `maxPages` without either `allPastCutoff` or a short/empty page
+ * naturally terminating the scan. When `truncated` is `true`, merged PRs on
+ * later pages are silently omitted — callers MUST surface this to operators so
+ * the missing-task problem doesn't reappear under higher PR volume. (QUA-450
+ * review follow-up — CodeRabbit comment 3077100107.)
  */
 export async function fetchMergedPrsInWindow(
   cutoff: Date,
   api: typeof githubApi = githubApi,
   opts: { perPage?: number; maxPages?: number } = {},
-): Promise<PrData[]> {
+): Promise<{ prs: PrData[]; truncated: boolean }> {
   const perPage = opts.perPage ?? 100;
   const maxPages = opts.maxPages ?? 10;
-  const result: PrData[] = [];
+  const prs: PrData[] = [];
+  // Assume truncation until a natural termination condition fires. If we
+  // finish the for-loop without hitting a break, `truncated` stays `true`.
+  let truncated = true;
 
   for (let page = 1; page <= maxPages; page++) {
     const batch = await api<PrData[]>(
       `/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=${page}`,
     );
-    if (!Array.isArray(batch) || batch.length === 0) break;
+    if (!Array.isArray(batch) || batch.length === 0) {
+      // Empty page — GitHub has no more results at all.
+      truncated = false;
+      break;
+    }
 
     for (const pr of batch) {
       // Only merged PRs with merge_at inside the cutoff window matter.
       if (pr.merged_at && new Date(pr.merged_at) >= cutoff) {
-        result.push(pr);
+        prs.push(pr);
       }
     }
 
@@ -216,13 +230,19 @@ export async function fetchMergedPrsInWindow(
       const updated = pr.updated_at ? new Date(pr.updated_at) : null;
       return updated !== null && updated < cutoff;
     });
-    if (allPastCutoff) break;
+    if (allPastCutoff) {
+      truncated = false;
+      break;
+    }
 
     // Short final page — no more results at all.
-    if (batch.length < perPage) break;
+    if (batch.length < perPage) {
+      truncated = false;
+      break;
+    }
   }
 
-  return result;
+  return { prs, truncated };
 }
 
 async function pending(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -237,7 +257,7 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
   // QUA-450 review fix: the previous `sort=created&per_page=30` single page
   // silently dropped any merged PR older than the 30 most-recently-created
   // closed PRs.
-  const rawPrs = await fetchMergedPrsInWindow(cutoff);
+  const { prs: rawPrs, truncated } = await fetchMergedPrsInWindow(cutoff);
 
   // Narrow to merged PRs with deploy tasks before the (potentially
   // expensive) per-PR production-ancestry check. `fetchMergedPrsInWindow`
@@ -277,7 +297,7 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
     return {
       output:
         JSON.stringify(
-          { pendingPrs, lookbackDays, rolledOff, compareFailures },
+          { pendingPrs, lookbackDays, rolledOff, compareFailures, truncated },
           null,
           2,
         ) + '\n',
@@ -292,12 +312,19 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
       ? ` ${c.yellow}[${compareFailures} compare failure${compareFailures === 1 ? '' : 's'} — roll-off degraded]${c.reset}`
       : '';
 
+  // If discovery hit the page cap, `pendingPrs` may silently omit merged PRs
+  // on later pages. Tell the operator so they can rerun with a bigger cap.
+  // (QUA-450 review follow-up — CodeRabbit comment 3077100107.)
+  const truncationWarning = truncated
+    ? ` ${c.yellow}[${rawPrs.length} merged PRs discovered; truncated at page cap — some may be missing]${c.reset}`
+    : '';
+
   if (pendingPrs.length === 0) {
     const rolledOffNote = rolledOff > 0
       ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
       : '';
     return {
-      output: `${c.green}No pending deploy tasks. All clear!${c.reset}${rolledOffNote}${compareWarning}\n`,
+      output: `${c.green}No pending deploy tasks. All clear!${c.reset}${rolledOffNote}${compareWarning}${truncationWarning}\n`,
       exitCode: 0,
     };
   }
@@ -308,7 +335,7 @@ async function pending(_args: string[], options: CommandOptions): Promise<Comman
     ? ` ${c.dim}[${rolledOff} rolled off]${c.reset}`
     : '';
   lines.push(
-    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'})${rolledOffNote}${compareWarning}:\n`
+    `${c.bold}Pending Deploy Tasks${c.reset} (${totalUnchecked} unchecked across ${pendingPrs.length} PR${pendingPrs.length === 1 ? '' : 's'})${rolledOffNote}${compareWarning}${truncationWarning}:\n`
   );
 
   for (const pr of pendingPrs) {
@@ -467,7 +494,7 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   // QUA-450 review fix: paginate by updated-desc instead of `sort=created`
   // first-page-only, so long-lived PRs merged inside the window aren't
   // silently skipped. See `fetchMergedPrsInWindow` for the stop condition.
-  const rawPrs = await fetchMergedPrsInWindow(cutoff);
+  const { prs: rawPrs, truncated } = await fetchMergedPrsInWindow(cutoff);
 
   // Narrow to merged-with-tasks before the per-PR compare call.
   const candidates = rawPrs.filter((pr) => {
@@ -566,6 +593,7 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
               skipped,
               rolledOff,
               compareFailures,
+              truncated,
               total: results.length,
             },
           },
@@ -581,12 +609,19 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
       ? ` ${c.yellow}[${compareFailures} compare failure${compareFailures === 1 ? '' : 's'} — roll-off degraded]${c.reset}`
       : '';
 
+  // If discovery hit the page cap, later pages were silently omitted. Surface
+  // it so operators can rerun with a bigger cap.
+  // (QUA-450 review follow-up — CodeRabbit comment 3077100107.)
+  const truncationWarning = truncated
+    ? ` ${c.yellow}[${rawPrs.length} merged PRs discovered; truncated at page cap — some may be missing]${c.reset}`
+    : '';
+
   if (results.length === 0) {
     const rolledOffNote = rolledOff > 0
       ? ` ${c.dim}(${rolledOff} task-bearing PR${rolledOff === 1 ? '' : 's'} rolled off — already on production)${c.reset}`
       : '';
     return {
-      output: `${c.green}No pending deploy tasks to verify.${c.reset}${rolledOffNote}${compareWarning}\n`,
+      output: `${c.green}No pending deploy tasks to verify.${c.reset}${rolledOffNote}${compareWarning}${truncationWarning}\n`,
       exitCode: 0,
     };
   }
@@ -601,7 +636,8 @@ async function verify(_args: string[], options: CommandOptions): Promise<Command
   const lines: string[] = [];
   const headerSuffix = (dryRun ? ' (dry-run)' : '') +
     (rolledOff > 0 ? ` ${c.dim}[${rolledOff} PR${rolledOff === 1 ? '' : 's'} rolled off]${c.reset}` : '') +
-    compareWarning;
+    compareWarning +
+    truncationWarning;
   lines.push(`${c.bold}Deploy Tasks Verification${c.reset}${headerSuffix}\n`);
 
   for (const [prNum, prResults] of byPr) {


### PR DESCRIPTION
## Summary

Fixes QUA-450 Fix 3 (one of three sub-categories from the original ticket; the other two are tracked in QUA-461).

`crux gh deploy-tasks pending` and `verify` were surfacing tasks from PRs whose code had already shipped to production. During release monitoring the coordinator had to mentally filter the noise and real pending tasks got drowned.

## Fix

- `isCommitOnProduction(sha)` hits GitHub's compare API at `production...{sha}`; `ahead_by === 0` means the sha is an ancestor of production → already deployed.
- `rollOffDeployedPrs(prs, includeDeployed)` filters the candidate list in parallel.
- `pending` and `verify` narrow to merged+with-tasks first (cheap), then compare-check what's left. Output shows `[N rolled off]` so the filter isn't invisible.
- New `--include-deployed` flag opts out of the roll-off.
- Adds `merge_commit_sha` to the `PrData` interface.
- JSON CI output includes a `rolledOff` field.

## Safety

**Fail-open on any compare error** (404, network, missing `production` branch). Silent-drop would be worse than a false-positive — keep the task visible and let the coordinator see it.

## Tests

5 new unit tests for `isCommitOnProduction`: happy path, commit ahead, API error (fail-open), empty sha short-circuit, URL-encoding. Reviewer confirmed `ahead_by` semantics are correct and the narrow-then-filter ordering is right.

## Out of scope

The other two QUA-450 sub-categories — psql via kubectl, route-path detection via route registration — are filed as **QUA-461**.

## Test plan

- [x] `vitest run crux/commands/deploy-tasks.test.ts` — 17 passing (5 new)
- [x] `tsc --noEmit` clean
- [x] Reviewer pass — no blockers, one nice-to-have (optional debug-warn on compare error) deferred


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pending` and `verify` now exclude PRs already deployed to production by default; added `--include-deployed` to opt in.
  * Command output now reports rolled-off counts and compare-warning indicators in both JSON and human-readable summaries.

* **Documentation**
  * CLI help updated to document the `--include-deployed` behavior.

* **Tests**
  * Expanded test coverage for commit-on-production checks, pagination/windowed PR fetching, and end-to-end pending/verify flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->