### PR TITLE
Add groundskeeper e2e-post-deploy watcher (QUA-451)

### DIFF
--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -40,6 +40,7 @@ export interface Config {
     autoUpdateEnqueue: AutoUpdateEnqueueConfig;
     jobFailureTriage: TaskConfig;
     tablebaseScan: TaskConfig;
+    e2ePostDeployWatcher: TaskConfig;
   };
 }
 
@@ -140,6 +141,11 @@ export function loadConfig(): Config {
         enabled: envBool("TASK_TABLEBASE_SCAN_ENABLED", true),
         schedule:
           process.env["TASK_TABLEBASE_SCAN_SCHEDULE"] ?? "0 5 * * *", // daily at 5am UTC
+      },
+      e2ePostDeployWatcher: {
+        enabled: envBool("TASK_E2E_POST_DEPLOY_WATCHER_ENABLED", true),
+        schedule:
+          process.env["TASK_E2E_POST_DEPLOY_WATCHER_SCHEDULE"] ?? "15 * * * *", // hourly at :15
       },
     },
   };

--- a/apps/groundskeeper/src/incident-buffer.test.ts
+++ b/apps/groundskeeper/src/incident-buffer.test.ts
@@ -55,6 +55,7 @@ function makeConfig(): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -13,6 +13,7 @@ import { jobWorkerHealth } from "./tasks/job-worker-health.js";
 import { autoUpdateEnqueue } from "./tasks/auto-update-enqueue.js";
 import { jobFailureTriage } from "./tasks/job-failure-triage.js";
 import { tablebaseScan } from "./tasks/tablebase-scan.js";
+import { e2ePostDeployWatcher } from "./tasks/e2e-post-deploy-watcher.js";
 import { logger } from "./logger.js";
 
 const config = loadConfig();
@@ -64,6 +65,10 @@ logger.info({
     tablebaseScan: {
       enabled: config.tasks.tablebaseScan.enabled,
       schedule: config.tasks.tablebaseScan.schedule,
+    },
+    e2ePostDeployWatcher: {
+      enabled: config.tasks.e2ePostDeployWatcher.enabled,
+      schedule: config.tasks.e2ePostDeployWatcher.schedule,
     },
   },
 }, "Groundskeeper starting");
@@ -150,6 +155,14 @@ registerTask(
   config.tasks.tablebaseScan.schedule,
   config.tasks.tablebaseScan.enabled,
   () => tablebaseScan(config)
+);
+
+registerTask(
+  config,
+  "e2e-post-deploy-watcher",
+  config.tasks.e2ePostDeployWatcher.schedule,
+  config.tasks.e2ePostDeployWatcher.enabled,
+  () => e2ePostDeployWatcher(config)
 );
 
 // Register as an active agent (best-effort)

--- a/apps/groundskeeper/src/run-tracker.test.ts
+++ b/apps/groundskeeper/src/run-tracker.test.ts
@@ -34,6 +34,7 @@ function makeConfig(runLogPath: string): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -58,6 +58,7 @@ function makeConfig(): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
+++ b/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../notify.js", () => ({
+  sendDiscordNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+const listWorkflowRunsMock = vi.fn();
+vi.mock("../github.js", () => ({
+  getOctokit: () => ({
+    rest: { actions: { listWorkflowRuns: listWorkflowRunsMock } },
+  }),
+  parseRepo: () => ({ owner: "o", repo: "r" }),
+}));
+
+import {
+  e2ePostDeployWatcher,
+  evaluateWatcher,
+  __resetAlertRateLimitForTest,
+} from "./e2e-post-deploy-watcher.js";
+import { sendDiscordNotification } from "../notify.js";
+import type { Config } from "../config.js";
+
+const sendDiscordMock = vi.mocked(sendDiscordNotification);
+
+function makeConfig(): Config {
+  return {
+    githubAppId: "x",
+    githubInstallationId: "x",
+    githubAppPrivateKey: "x",
+    githubRepo: "o/r",
+    wikiServerUrl: "http://localhost:3000",
+    discordWebhookUrl: "http://localhost/webhook",
+    dailyRunCap: 20,
+    runLogPath: "/tmp/run-log.json",
+    circuitBreakerCooldownMs: 1_800_000,
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      issueResponder: { enabled: false, schedule: "*/10 * * * *" },
+      githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
+      snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 30 },
+      sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
+      jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
+      autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: true, schedule: "15 * * * *" },
+    },
+  };
+}
+
+function makeRun(conclusion: string | null, ageMs: number, n = 0) {
+  return {
+    conclusion,
+    createdAt: new Date(Date.now() - ageMs).toISOString(),
+    htmlUrl: `https://gh.test/run/${n}`,
+  };
+}
+
+describe("evaluateWatcher", () => {
+  it("only counts failures inside the window", () => {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const runs = [
+      makeRun("failure", 60_000, 1),
+      makeRun("failure", 23 * 60 * 60 * 1000, 2),
+      makeRun("failure", 48 * 60 * 60 * 1000, 3), // outside
+      makeRun("success", 120_000, 4),
+    ];
+    const r = evaluateWatcher(runs, cutoff, 3);
+    expect(r.failures.length).toBe(2);
+    expect(r.considered).toBe(3);
+    expect(r.shouldAlert).toBe(false);
+  });
+
+  it("alerts at threshold", () => {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const runs = [
+      makeRun("failure", 1_000, 1),
+      makeRun("failure", 2_000, 2),
+      makeRun("failure", 3_000, 3),
+      makeRun("success", 4_000, 4),
+    ];
+    const r = evaluateWatcher(runs, cutoff, 3);
+    expect(r.shouldAlert).toBe(true);
+  });
+
+  it("does not count cancelled/timed_out as failures", () => {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const runs = [
+      makeRun("cancelled", 1_000, 1),
+      makeRun("timed_out", 2_000, 2),
+      makeRun("failure", 3_000, 3),
+    ];
+    const r = evaluateWatcher(runs, cutoff, 3);
+    expect(r.failures.length).toBe(1);
+    expect(r.shouldAlert).toBe(false);
+  });
+});
+
+describe("e2ePostDeployWatcher", () => {
+  let config: Config;
+
+  beforeEach(() => {
+    config = makeConfig();
+    sendDiscordMock.mockClear();
+    listWorkflowRunsMock.mockReset();
+    __resetAlertRateLimitForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("succeeds silently when below threshold", async () => {
+    listWorkflowRunsMock.mockResolvedValue({
+      data: {
+        workflow_runs: [
+          { conclusion: "success", created_at: new Date().toISOString(), html_url: "x" },
+          { conclusion: "failure", created_at: new Date().toISOString(), html_url: "x" },
+        ],
+      },
+    });
+    const r = await e2ePostDeployWatcher(config);
+    expect(r.success).toBe(true);
+    expect(sendDiscordMock).not.toHaveBeenCalled();
+  });
+
+  it("alerts when 3+ failures in last 24h", async () => {
+    const now = Date.now();
+    listWorkflowRunsMock.mockResolvedValue({
+      data: {
+        workflow_runs: [
+          { conclusion: "failure", created_at: new Date(now - 1000).toISOString(), html_url: "https://gh.test/run/1" },
+          { conclusion: "failure", created_at: new Date(now - 2000).toISOString(), html_url: "https://gh.test/run/2" },
+          { conclusion: "failure", created_at: new Date(now - 3000).toISOString(), html_url: "https://gh.test/run/3" },
+        ],
+      },
+    });
+    const r = await e2ePostDeployWatcher(config);
+    expect(r.success).toBe(true);
+    expect(r.summary).toContain("alert fired");
+    expect(sendDiscordMock).toHaveBeenCalledTimes(1);
+    const msg = sendDiscordMock.mock.calls[0]?.[1] as string;
+    expect(msg).toContain("red streak");
+    expect(msg).toContain("https://gh.test/run/1");
+  });
+
+  it("rate-limits alerts to once per 6h", async () => {
+    const runs = [
+      { conclusion: "failure", created_at: new Date().toISOString(), html_url: "a" },
+      { conclusion: "failure", created_at: new Date().toISOString(), html_url: "b" },
+      { conclusion: "failure", created_at: new Date().toISOString(), html_url: "c" },
+    ];
+    listWorkflowRunsMock.mockResolvedValue({ data: { workflow_runs: runs } });
+
+    await e2ePostDeployWatcher(config);
+    await e2ePostDeployWatcher(config);
+    expect(sendDiscordMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fires after 6h", async () => {
+    vi.useFakeTimers();
+    const t0 = new Date("2026-04-14T00:00:00Z").getTime();
+    vi.setSystemTime(t0);
+    listWorkflowRunsMock.mockImplementation(async () => ({
+      data: {
+        workflow_runs: [
+          { conclusion: "failure", created_at: new Date(Date.now() - 1000).toISOString(), html_url: "a" },
+          { conclusion: "failure", created_at: new Date(Date.now() - 2000).toISOString(), html_url: "b" },
+          { conclusion: "failure", created_at: new Date(Date.now() - 3000).toISOString(), html_url: "c" },
+        ],
+      },
+    }));
+
+    await e2ePostDeployWatcher(config);
+    expect(sendDiscordMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(t0 + 6 * 60 * 60 * 1000 - 1000);
+    await e2ePostDeployWatcher(config);
+    expect(sendDiscordMock).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(t0 + 6 * 60 * 60 * 1000 + 1000);
+    await e2ePostDeployWatcher(config);
+    expect(sendDiscordMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed on API error without alerting", async () => {
+    listWorkflowRunsMock.mockRejectedValue(new Error("boom"));
+    const r = await e2ePostDeployWatcher(config);
+    expect(r.success).toBe(false);
+    expect(r.summary).toContain("Failed to fetch runs");
+    expect(sendDiscordMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.ts
+++ b/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.ts
@@ -10,7 +10,9 @@ const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 const WORKFLOW_FILE = "e2e-post-deploy.yml";
 const FAILURE_THRESHOLD = 3;
 const LOOKBACK_MS = TWENTY_FOUR_HOURS_MS;
-const FETCH_LIMIT = 20;
+// e2e-post-deploy fires once per production deploy (typically ≤10/day).
+// 50 gives plenty of headroom so a 24h window is never silently truncated.
+const FETCH_LIMIT = 50;
 
 // Rate-limit Discord alerts per fingerprint. Module-level state; resets on
 // process restart, same pattern as snapshot-retention.ts.
@@ -69,12 +71,17 @@ export async function e2ePostDeployWatcher(
       repo,
       workflow_id: WORKFLOW_FILE,
       per_page: FETCH_LIMIT,
+      status: "completed",
     });
-    runs = data.workflow_runs.map((r) => ({
-      conclusion: r.conclusion,
-      htmlUrl: r.html_url,
-      createdAt: r.created_at,
-    }));
+    // Sort newest-first explicitly so `failures[0]` in the alert is reliably
+    // the most recent failing run regardless of GitHub's default ordering.
+    runs = data.workflow_runs
+      .map((r) => ({
+        conclusion: r.conclusion,
+        htmlUrl: r.html_url,
+        createdAt: r.created_at,
+      }))
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger.error({ error: msg }, "Failed to fetch workflow runs");

--- a/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.ts
+++ b/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.ts
@@ -1,0 +1,134 @@
+import type { Config } from "../config.js";
+import { getOctokit, parseRepo } from "../github.js";
+import { logger as rootLogger } from "../logger.js";
+import { sendDiscordNotification } from "../notify.js";
+
+const logger = rootLogger.child({ task: "e2e-post-deploy-watcher" });
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const WORKFLOW_FILE = "e2e-post-deploy.yml";
+const FAILURE_THRESHOLD = 3;
+const LOOKBACK_MS = TWENTY_FOUR_HOURS_MS;
+const FETCH_LIMIT = 20;
+
+// Rate-limit Discord alerts per fingerprint. Module-level state; resets on
+// process restart, same pattern as snapshot-retention.ts.
+const lastAlertAt = new Map<string, number>();
+
+/** Test-only: reset rate-limit state. */
+export function __resetAlertRateLimitForTest(): void {
+  lastAlertAt.clear();
+}
+
+interface RunRef {
+  conclusion: string | null;
+  htmlUrl: string;
+  createdAt: string;
+}
+
+export interface WatcherEvaluation {
+  failures: RunRef[];
+  considered: number;
+  shouldAlert: boolean;
+}
+
+/**
+ * Pure evaluator: given recent runs (newest first) and a cutoff, count
+ * failures within the window and decide whether the alert threshold is hit.
+ * `failure` conclusion only; `cancelled` / `timed_out` / `startup_failure`
+ * are treated as infra noise (matches evaluateWorkflowRedStreak in audits.ts).
+ */
+export function evaluateWatcher(
+  runs: RunRef[],
+  cutoffMs: number,
+  threshold: number,
+): WatcherEvaluation {
+  const inWindow = runs.filter((r) => {
+    const t = Date.parse(r.createdAt);
+    return Number.isFinite(t) && t >= cutoffMs;
+  });
+  const failures = inWindow.filter((r) => r.conclusion === "failure");
+  return {
+    failures,
+    considered: inWindow.length,
+    shouldAlert: failures.length >= threshold,
+  };
+}
+
+export async function e2ePostDeployWatcher(
+  config: Config,
+): Promise<{ success: boolean; summary?: string }> {
+  const octokit = getOctokit(config);
+  const { owner, repo } = parseRepo(config);
+
+  let runs: RunRef[];
+  try {
+    const { data } = await octokit.rest.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: WORKFLOW_FILE,
+      per_page: FETCH_LIMIT,
+    });
+    runs = data.workflow_runs.map((r) => ({
+      conclusion: r.conclusion,
+      htmlUrl: r.html_url,
+      createdAt: r.created_at,
+    }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ error: msg }, "Failed to fetch workflow runs");
+    // Fail-closed: we don't know if there's a red streak, so return failure
+    // but don't spam Discord — the scheduler's consecutive-failure tracking
+    // covers sustained GitHub API outages.
+    return { success: false, summary: `Failed to fetch runs: ${msg}` };
+  }
+
+  const cutoff = Date.now() - LOOKBACK_MS;
+  const evalResult = evaluateWatcher(runs, cutoff, FAILURE_THRESHOLD);
+
+  const summary =
+    `${evalResult.failures.length}/${evalResult.considered} ${WORKFLOW_FILE} ` +
+    `runs failed in last 24h (threshold=${FAILURE_THRESHOLD})`;
+
+  if (!evalResult.shouldAlert) {
+    logger.info(
+      { failures: evalResult.failures.length, considered: evalResult.considered },
+      summary,
+    );
+    return { success: true, summary };
+  }
+
+  const fingerprint = `${WORKFLOW_FILE}:threshold=${FAILURE_THRESHOLD}`;
+  const now = Date.now();
+  const last = lastAlertAt.get(fingerprint) ?? 0;
+  if (now - last < SIX_HOURS_MS) {
+    logger.info(
+      { fingerprint, lastAlertAgeMs: now - last },
+      "Alert suppressed (rate-limited to 1 per 6h)",
+    );
+    return { success: true, summary: `${summary} (alert suppressed)` };
+  }
+
+  lastAlertAt.set(fingerprint, now);
+  const mostRecentFailure = evalResult.failures[0];
+  const message =
+    `⚠️ **e2e-post-deploy red streak** — ${evalResult.failures.length}/${evalResult.considered} ` +
+    `runs of \`${WORKFLOW_FILE}\` failed in the last 24h ` +
+    `(threshold=${FAILURE_THRESHOLD}). ` +
+    (mostRecentFailure
+      ? `Most recent failure: ${mostRecentFailure.htmlUrl}. `
+      : "") +
+    `See QUA-411 / QUA-451.`;
+
+  try {
+    await sendDiscordNotification(config, message);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error({ error: msg }, "Failed to send Discord alert");
+    return { success: false, summary: `${summary} (Discord send failed: ${msg})` };
+  }
+
+  logger.warn({ failures: evalResult.failures.length }, `Alert fired: ${summary}`);
+  return { success: true, summary: `${summary} (alert fired)` };
+}

--- a/apps/groundskeeper/src/tasks/health-check.test.ts
+++ b/apps/groundskeeper/src/tasks/health-check.test.ts
@@ -86,6 +86,7 @@ function makeConfig(overrides?: Partial<Config>): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
     ...overrides,
   };

--- a/apps/groundskeeper/src/tasks/issue-responder.test.ts
+++ b/apps/groundskeeper/src/tasks/issue-responder.test.ts
@@ -103,6 +103,7 @@ function makeConfig(): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
+++ b/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
@@ -83,6 +83,7 @@ function makeConfig(): Config {
       },
       jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/session-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/session-sweep.test.ts
@@ -41,6 +41,7 @@ function makeConfig(): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -45,6 +45,7 @@ function makeConfig(keep = 100): Config {
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
       jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
   };
 }

--- a/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
+++ b/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
@@ -38,6 +38,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
       },
       jobFailureTriage: { enabled: true, schedule: "0 */6 * * *" },
       tablebaseScan: { enabled: true, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
     },
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Carries Option 1 from QUA-411: an hourly groundskeeper task that watches `e2e-post-deploy.yml` runs and pings Discord when the failure rate signals a silent post-deploy regression.

- `apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.ts` — new task. Fetches the last 50 *completed* runs via the GitHub App, sorts newest-first, counts `failure` conclusions in the last 24h, and emits a Discord alert when ≥3 failures are seen. Rate-limited to 1 alert per 6h per fingerprint, matching the snapshot-retention pattern. Fail-closed on API errors (returns failure but does not spam Discord — the scheduler's consecutive-failure tracker covers sustained outages).
- `config.ts` / `index.ts` — wires the task in with cron default `15 * * * *` (hourly at :15) and env override `TASK_E2E_POST_DEPLOY_WATCHER_{ENABLED,SCHEDULE}`.
- 8 new vitest cases covering: window math, threshold, ignored conclusions (`cancelled`/`timed_out`), happy path, alert path, rate limiting (immediate + fake-timer 6h boundary), and fail-closed-no-alert on API error.

The PR #4319 audit entry stays as the manual backstop; this is the automatic alerting pass.

## Test plan
- [x] `npx tsc --noEmit` (apps/groundskeeper) — clean
- [x] `npx vitest run src/tasks/e2e-post-deploy-watcher.test.ts` — 8/8 pass
- [x] `pnpm crux w validate gate --fix` — 49/49 pass (3 advisory warnings unrelated)
- [x] `/agent-review-pr` — hostile review found 3 actionable issues (status filter, fetch limit, sort), all fixed
- [ ] Merge → next groundskeeper deploy picks it up; first run inside 1h. Verify with `kubectl logs groundskeeper -c groundskeeper | grep e2e-post-deploy-watcher`.
- [ ] If `e2e-post-deploy.yml` is currently in a red streak, expect an immediate Discord alert on first cycle.

Fixes QUA-451
