### PR TITLE
qua-349: harden fix-inaccuracies proposals with 3 quality filters

### DIFF
--- a/crux/citations/fix-inaccuracies.test.ts
+++ b/crux/citations/fix-inaccuracies.test.ts
@@ -13,7 +13,11 @@ import {
   applyFixes,
   enrichFromApi,
   repairJsonBackslashEscapes,
+  escapeDollarDigits,
+  countPreservedComponents,
+  filterProposals,
 } from './fix-inaccuracies.ts';
+import type { FixProposal } from './fix-inaccuracies.ts';
 import type { FlaggedCitation } from './export-dashboard.ts';
 import type { SectionRewrite } from './fix-inaccuracies.ts';
 
@@ -130,6 +134,279 @@ describe('parseLLMFixResponse', () => {
     const result = parseLLMFixResponse(input);
     expect(result).toHaveLength(1);
     expect(result[0].original).toBe('a \\$ b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QUA-349: proposal quality filters
+// ---------------------------------------------------------------------------
+
+describe('escapeDollarDigits', () => {
+  it('escapes bare $digit', () => {
+    expect(escapeDollarDigits('costs $50 today')).toBe('costs \\$50 today');
+  });
+
+  it('escapes multiple occurrences', () => {
+    expect(escapeDollarDigits('$100 vs $57.2 million')).toBe('\\$100 vs \\$57.2 million');
+  });
+
+  it('does not touch already-escaped \\$digit', () => {
+    expect(escapeDollarDigits('costs \\$50')).toBe('costs \\$50');
+  });
+
+  it('does not touch $ not followed by a digit', () => {
+    expect(escapeDollarDigits('$foo and $bar')).toBe('$foo and $bar');
+  });
+
+  it('does not touch $ preceded by an identifier char (variable-like)', () => {
+    expect(escapeDollarDigits('abc$1 and xyz$9')).toBe('abc$1 and xyz$9');
+  });
+
+  it('handles the QUA-349 examples from the dry-run', () => {
+    expect(escapeDollarDigits('midterm elections. With $100 million raised...'))
+      .toBe('midterm elections. With \\$100 million raised...');
+    expect(escapeDollarDigits('goodfire...raised a total of $57.2 million.'))
+      .toBe('goodfire...raised a total of \\$57.2 million.');
+    expect(escapeDollarDigits('$8 billion was missing from its balance sheet'))
+      .toBe('\\$8 billion was missing from its balance sheet');
+  });
+
+  it('handles leading $ at position 0', () => {
+    expect(escapeDollarDigits('$5 for all')).toBe('\\$5 for all');
+  });
+});
+
+describe('countPreservedComponents', () => {
+  it('counts EntityLink', () => {
+    expect(countPreservedComponents('hello <EntityLink id="x"> world')).toBe(1);
+  });
+
+  it('counts multiple component types', () => {
+    const s = 'see <EntityLink id="a"/> and <F id="b"/> and <Calc expr="1+1"/>';
+    expect(countPreservedComponents(s)).toBe(3);
+  });
+
+  it('counts repeated instances of the same component', () => {
+    expect(countPreservedComponents('<F id="a"/> <F id="b"/> <F id="c"/>')).toBe(3);
+  });
+
+  it('returns 0 for plain text', () => {
+    expect(countPreservedComponents('no components here')).toBe(0);
+  });
+
+  it('matches only word-boundary tags, not prefixes', () => {
+    // <Foo> must not count as an <F>
+    expect(countPreservedComponents('<Foo id="x"/>')).toBe(0);
+  });
+
+  it('counts FBFactValue and FBF as separate components', () => {
+    expect(countPreservedComponents('<FBF id="a"/> <FBFactValue id="b"/>')).toBe(2);
+  });
+});
+
+describe('filterProposals', () => {
+  function makeProposal(p: Partial<FixProposal>): FixProposal {
+    return {
+      footnote: 1,
+      original: 'original text',
+      replacement: 'replacement text',
+      explanation: 'test',
+      fixType: 'rewrite',
+      ...p,
+    };
+  }
+
+  it('keeps clean proposals', () => {
+    const p = makeProposal({ original: 'abc', replacement: 'def' });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.escapedCount).toBe(0);
+  });
+
+  // Bug 1: $digit escape
+
+  it('escapes bare $digit in replacement without rejecting', () => {
+    const p = makeProposal({
+      original: 'costs about 50 bucks',
+      replacement: 'costs about $50',
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0].replacement).toBe('costs about \\$50');
+    expect(result.escapedCount).toBe(1);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it('leaves already-escaped \\$digit alone', () => {
+    const p = makeProposal({
+      original: 'one',
+      replacement: 'costs \\$50 total',
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept[0].replacement).toBe('costs \\$50 total');
+    expect(result.escapedCount).toBe(0);
+  });
+
+  // Bug 2: component preservation
+
+  it('rejects proposals that drop an EntityLink', () => {
+    const p = makeProposal({
+      original: 'see <EntityLink id="anthropic"/> for more',
+      replacement: 'see Anthropic for more',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0].reason).toBe('component-drop');
+  });
+
+  it('rejects proposals that drop an <F> fact ref', () => {
+    const p = makeProposal({
+      original: 'revenue was <F id="a" path="b"/> last year',
+      replacement: 'revenue was $5B last year',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('component-drop');
+  });
+
+  it('rejects proposals that drop one of multiple components', () => {
+    const p = makeProposal({
+      original: '<EntityLink id="a"/> spent <F id="x"/> on research',
+      replacement: '<EntityLink id="a"/> spent money on research',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('component-drop');
+  });
+
+  it('accepts proposals that preserve all components', () => {
+    const p = makeProposal({
+      original: '<EntityLink id="a"/> spent five dollars',
+      replacement: '<EntityLink id="a"/> spent six dollars',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it('accepts proposals that add components', () => {
+    const p = makeProposal({
+      original: 'Anthropic raised money',
+      replacement: '<EntityLink id="anthropic"/> raised money',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+  });
+
+  // Bug 3: shrink rejection
+
+  it('rejects rewrite proposals that shrink below 40%', () => {
+    const p = makeProposal({
+      original: 'Key techniques taught at CFAR workshops include rationality training, debiasing exercises, and applied Bayesian reasoning',
+      replacement: 'CFAR runs workshops',
+      fixType: 'rewrite',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('shrink');
+  });
+
+  it('allows remove_detail to shrink arbitrarily', () => {
+    const p = makeProposal({
+      original: 'a very long detailed explanation of many things that deserves removal',
+      replacement: 'short',
+      fixType: 'remove_detail',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it('allows remove_ref to shrink arbitrarily', () => {
+    const p = makeProposal({
+      original: 'Anthropic is a company[^5].',
+      replacement: 'Anthropic is a company.',
+      fixType: 'remove_ref',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+  });
+
+  it('keeps proposals that shrink slightly (above 40%)', () => {
+    const p = makeProposal({
+      original: 'ABCDEFGHIJ', // 10 chars
+      replacement: 'ABCDEF', // 6 chars, 60%
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+  });
+
+  it('rejects correct-action shrink below 40%', () => {
+    const p = makeProposal({
+      original: 'Very detailed original text that has many words and provides context',
+      replacement: 'Short.',
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe('shrink');
+  });
+
+  // Combined / regression
+
+  it('applies escape before component check (escape is lossless)', () => {
+    const p = makeProposal({
+      original: 'costs <F id="a"/> today',
+      replacement: 'costs $50 with <F id="a"/> context',
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0].replacement).toBe('costs \\$50 with <F id="a"/> context');
+    expect(result.escapedCount).toBe(1);
+  });
+
+  it('blueprint-biosecurity regression: $1,000,000 bare dollar escaped', () => {
+    // The specific pattern that caused the QUA-349 blueprint-biosecurity
+    // regression: LLM returned `$1,000,000` unescaped in a `correct` action.
+    const p = makeProposal({
+      original: 'Up to \\$1M in grants are available.',
+      replacement: 'Up to $1,000,000 in grants are available.',
+      fixType: 'correct',
+    });
+    const result = filterProposals([p]);
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept[0].replacement).toBe('Up to \\$1,000,000 in grants are available.');
+  });
+
+  it('mixed batch: keeps clean, rejects buggy, escapes recoverable', () => {
+    const clean = makeProposal({ footnote: 1, original: 'aaa', replacement: 'bbb' });
+    const escaped = makeProposal({ footnote: 2, original: 'aaa', replacement: '$50', fixType: 'correct' });
+    const dropped = makeProposal({ footnote: 3, original: 'x <F id="a"/> y', replacement: 'x y' });
+    const shrunk = makeProposal({
+      footnote: 4,
+      original: 'this is a long original phrase that should not shrink',
+      replacement: 'nope',
+      fixType: 'rewrite',
+    });
+
+    const result = filterProposals([clean, escaped, dropped, shrunk]);
+    expect(result.kept).toHaveLength(2);
+    expect(result.kept.map((p) => p.footnote).sort()).toEqual([1, 2]);
+    expect(result.rejected).toHaveLength(2);
+    expect(result.escapedCount).toBe(1);
+  });
+
+  it('handles empty proposal list', () => {
+    const result = filterProposals([]);
+    expect(result.kept).toEqual([]);
+    expect(result.rejected).toEqual([]);
+    expect(result.escapedCount).toBe(0);
   });
 });
 

--- a/crux/citations/fix-inaccuracies.test.ts
+++ b/crux/citations/fix-inaccuracies.test.ts
@@ -13,10 +13,11 @@ import {
   applyFixes,
   enrichFromApi,
   repairJsonBackslashEscapes,
-  escapeDollarDigits,
   countPreservedComponents,
   filterProposals,
+  FIX_ACTIONS,
 } from './fix-inaccuracies.ts';
+import { escapeDollarDigits } from '../lib/patterns.ts';
 import type { FixProposal } from './fix-inaccuracies.ts';
 import type { FlaggedCitation } from './export-dashboard.ts';
 import type { SectionRewrite } from './fix-inaccuracies.ts';
@@ -407,6 +408,17 @@ describe('filterProposals', () => {
     expect(result.kept).toEqual([]);
     expect(result.rejected).toEqual([]);
     expect(result.escapedCount).toBe(0);
+  });
+});
+
+describe('FIX_ACTIONS drift guard', () => {
+  // If someone renames an action in SYSTEM_PROMPT without updating FIX_ACTIONS,
+  // the shrink filter silently stops matching. This test pins the pairing.
+  it('includes every action the system prompt lists', () => {
+    // Mirror of the action vocabulary in the SYSTEM_PROMPT fix_type line.
+    // Update BOTH simultaneously if the prompt changes.
+    const promptActions = ['rewrite', 'correct', 'soften', 'remove_ref', 'remove_detail'];
+    expect([...FIX_ACTIONS].sort()).toEqual(promptActions.sort());
   });
 });
 

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -928,6 +928,109 @@ export function repairJsonBackslashEscapes(input: string): string {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Proposal quality filters (QUA-349)
+// ---------------------------------------------------------------------------
+
+/**
+ * Components that carry cross-reference / provenance meaning in wiki MDX.
+ * Dropping one silently breaks linking or fact sourcing.
+ */
+const PRESERVED_COMPONENTS = ['EntityLink', 'F', 'R', 'FBF', 'FBFactValue', 'Calc'];
+
+/**
+ * Actions where the replacement is *expected* to be shorter than the original
+ * (the whole point of the action is to delete content). Shrink filter skips these.
+ */
+const SHRINK_EXEMPT_ACTIONS = new Set(['remove_ref', 'remove_detail']);
+
+/** Minimum length ratio (replacement/original) allowed for non-shrink-exempt actions. */
+const SHRINK_MIN_RATIO = 0.4;
+
+/**
+ * Escape bare `$digit` to `\$digit` so MDX doesn't interpret it as a JSX
+ * expression and the `dollar-signs` gate check doesn't fail. Leaves
+ * already-escaped `\$digit` untouched and ignores `$` preceded by other
+ * identifier characters (e.g. a variable like `abc$1`).
+ */
+export function escapeDollarDigits(s: string): string {
+  // Negative lookbehind for backslash (already escaped) and word chars
+  // (not a bare price). `?!` lookahead ensures a digit follows.
+  return s.replace(/(?<![\\\w])\$(?=\d)/g, '\\$');
+}
+
+/** Count preserved component tags in a string. */
+export function countPreservedComponents(s: string): number {
+  let total = 0;
+  for (const name of PRESERVED_COMPONENTS) {
+    const re = new RegExp(`<${name}\\b`, 'g');
+    const matches = s.match(re);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+export interface FilteredProposals {
+  kept: FixProposal[];
+  rejected: Array<{
+    proposal: FixProposal;
+    reason: 'component-drop' | 'shrink';
+    detail: string;
+  }>;
+  escapedCount: number;
+}
+
+/**
+ * Apply proposal quality filters post-parse:
+ *   1. Escape bare `$digit` → `\$digit` in the replacement (non-rejecting).
+ *   2. Reject proposals that drop a preserved component (<EntityLink>, <F>, etc.).
+ *   3. Reject proposals with len(replacement) < SHRINK_MIN_RATIO * len(original),
+ *      unless fixType is in SHRINK_EXEMPT_ACTIONS.
+ *
+ * See QUA-349 for the dry-run evidence that motivated each filter.
+ */
+export function filterProposals(proposals: FixProposal[]): FilteredProposals {
+  const kept: FixProposal[] = [];
+  const rejected: FilteredProposals['rejected'] = [];
+  let escapedCount = 0;
+
+  for (const raw of proposals) {
+    // Filter 1: escape bare $digit in replacement (does not reject)
+    const escaped = escapeDollarDigits(raw.replacement);
+    const p: FixProposal = escaped === raw.replacement ? raw : { ...raw, replacement: escaped };
+    if (escaped !== raw.replacement) escapedCount++;
+
+    // Filter 2: component preservation check
+    const originalComponents = countPreservedComponents(p.original);
+    const replacementComponents = countPreservedComponents(p.replacement);
+    if (replacementComponents < originalComponents) {
+      rejected.push({
+        proposal: p,
+        reason: 'component-drop',
+        detail: `replacement has ${replacementComponents} preserved components; original had ${originalComponents}`,
+      });
+      continue;
+    }
+
+    // Filter 3: unjustified shrink
+    if (!SHRINK_EXEMPT_ACTIONS.has(p.fixType) && p.original.length > 0) {
+      const ratio = p.replacement.length / p.original.length;
+      if (ratio < SHRINK_MIN_RATIO) {
+        rejected.push({
+          proposal: p,
+          reason: 'shrink',
+          detail: `replacement is ${Math.round(ratio * 100)}% of original length (min ${Math.round(SHRINK_MIN_RATIO * 100)}% for fixType=${p.fixType})`,
+        });
+        continue;
+      }
+    }
+
+    kept.push(p);
+  }
+
+  return { kept, rejected, escapedCount };
+}
+
 /** Parse LLM response into fix proposals. */
 export function parseLLMFixResponse(content: string): FixProposal[] {
   const cleaned = stripCodeFences(content);
@@ -999,7 +1102,29 @@ export async function generateFixesForPage(
     title: 'LongtermWiki Fix Inaccuracies',
   });
 
-  return parseLLMFixResponse(response);
+  const parsed = parseLLMFixResponse(response);
+  const filtered = filterProposals(parsed);
+
+  if (filtered.rejected.length > 0 || filtered.escapedCount > 0) {
+    const parts: string[] = [];
+    if (filtered.escapedCount > 0) {
+      parts.push(`${filtered.escapedCount} $digit escape(s)`);
+    }
+    if (filtered.rejected.length > 0) {
+      const byReason = filtered.rejected.reduce<Record<string, number>>((acc, r) => {
+        acc[r.reason] = (acc[r.reason] ?? 0) + 1;
+        return acc;
+      }, {});
+      const reasonStr = Object.entries(byReason).map(([k, v]) => `${v} ${k}`).join(', ');
+      parts.push(`${filtered.rejected.length} rejected (${reasonStr})`);
+    }
+    console.warn(`  [filter] ${pageId}: ${parts.join('; ')}`);
+    for (const r of filtered.rejected) {
+      console.warn(`    [-] [^${r.proposal.footnote}] ${r.reason}: ${r.detail}`);
+    }
+  }
+
+  return filtered.kept;
 }
 
 // ---------------------------------------------------------------------------

--- a/crux/citations/fix-inaccuracies.ts
+++ b/crux/citations/fix-inaccuracies.ts
@@ -40,7 +40,7 @@ import yaml from 'js-yaml';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
 import { findPageFile } from '../lib/file-utils.ts';
-import { stripFrontmatter } from '../lib/patterns.ts';
+import { stripFrontmatter, escapeDollarDigits } from '../lib/patterns.ts';
 import { callOpenRouter, stripCodeFences, DEFAULT_CITATION_MODEL, checkClaimAccuracy } from '../lib/quote-extractor.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { appendEditLog } from '../lib/session/edit-log.ts';
@@ -933,41 +933,33 @@ export function repairJsonBackslashEscapes(input: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * The action vocabulary the LLM is instructed to choose from (see SYSTEM_PROMPT).
+ * Keeping this as a const array lets TS verify that SHRINK_EXEMPT_ACTIONS can only
+ * reference known actions — if SYSTEM_PROMPT's list is renamed without updating
+ * here, the type check fails.
+ */
+export const FIX_ACTIONS = ['rewrite', 'correct', 'soften', 'remove_ref', 'remove_detail'] as const;
+export type FixAction = (typeof FIX_ACTIONS)[number];
+
+/**
  * Components that carry cross-reference / provenance meaning in wiki MDX.
  * Dropping one silently breaks linking or fact sourcing.
  */
-const PRESERVED_COMPONENTS = ['EntityLink', 'F', 'R', 'FBF', 'FBFactValue', 'Calc'];
+const PRESERVED_COMPONENT_RE = /<(EntityLink|F|R|FBF|FBFactValue|Calc)\b/g;
 
 /**
  * Actions where the replacement is *expected* to be shorter than the original
  * (the whole point of the action is to delete content). Shrink filter skips these.
  */
-const SHRINK_EXEMPT_ACTIONS = new Set(['remove_ref', 'remove_detail']);
+const SHRINK_EXEMPT_ACTIONS: ReadonlySet<FixAction> = new Set(['remove_ref', 'remove_detail']);
 
 /** Minimum length ratio (replacement/original) allowed for non-shrink-exempt actions. */
 const SHRINK_MIN_RATIO = 0.4;
 
-/**
- * Escape bare `$digit` to `\$digit` so MDX doesn't interpret it as a JSX
- * expression and the `dollar-signs` gate check doesn't fail. Leaves
- * already-escaped `\$digit` untouched and ignores `$` preceded by other
- * identifier characters (e.g. a variable like `abc$1`).
- */
-export function escapeDollarDigits(s: string): string {
-  // Negative lookbehind for backslash (already escaped) and word chars
-  // (not a bare price). `?!` lookahead ensures a digit follows.
-  return s.replace(/(?<![\\\w])\$(?=\d)/g, '\\$');
-}
-
 /** Count preserved component tags in a string. */
 export function countPreservedComponents(s: string): number {
-  let total = 0;
-  for (const name of PRESERVED_COMPONENTS) {
-    const re = new RegExp(`<${name}\\b`, 'g');
-    const matches = s.match(re);
-    if (matches) total += matches.length;
-  }
-  return total;
+  const matches = s.match(PRESERVED_COMPONENT_RE);
+  return matches ? matches.length : 0;
 }
 
 export interface FilteredProposals {
@@ -995,12 +987,10 @@ export function filterProposals(proposals: FixProposal[]): FilteredProposals {
   let escapedCount = 0;
 
   for (const raw of proposals) {
-    // Filter 1: escape bare $digit in replacement (does not reject)
     const escaped = escapeDollarDigits(raw.replacement);
     const p: FixProposal = escaped === raw.replacement ? raw : { ...raw, replacement: escaped };
     if (escaped !== raw.replacement) escapedCount++;
 
-    // Filter 2: component preservation check
     const originalComponents = countPreservedComponents(p.original);
     const replacementComponents = countPreservedComponents(p.replacement);
     if (replacementComponents < originalComponents) {
@@ -1012,8 +1002,7 @@ export function filterProposals(proposals: FixProposal[]): FilteredProposals {
       continue;
     }
 
-    // Filter 3: unjustified shrink
-    if (!SHRINK_EXEMPT_ACTIONS.has(p.fixType) && p.original.length > 0) {
+    if (!SHRINK_EXEMPT_ACTIONS.has(p.fixType as FixAction) && p.original.length > 0) {
       const ratio = p.replacement.length / p.original.length;
       if (ratio < SHRINK_MIN_RATIO) {
         rejected.push({

--- a/crux/lib/patterns.ts
+++ b/crux/lib/patterns.ts
@@ -82,6 +82,23 @@ export const UNESCAPED_DOLLAR_RE = /(?<!\\)\$(\d)/g;
 /** Double-escaped \\$ in MDX body. */
 export const DOUBLE_ESCAPED_DOLLAR_RE = /\\\\\$/g;
 
+/**
+ * Unescaped `$` followed by a digit, excluding identifier-prefixed forms
+ * like `abc$1` (jQuery variables). Used when sanitizing LLM-generated
+ * content before it enters MDX. Stricter than `UNESCAPED_DOLLAR_RE`
+ * because it also rejects the `\w` lookbehind.
+ */
+export const BARE_DOLLAR_DIGIT_RE = /(?<![\\\w])\$(?=\d)/g;
+
+/**
+ * Escape bare `$digit` to `\$digit` so MDX doesn't interpret it as a JSX
+ * expression and the `dollar-signs` gate check doesn't fail. Leaves
+ * already-escaped `\$digit` and identifier-prefixed `abc$1` untouched.
+ */
+export function escapeDollarDigits(s: string): string {
+  return s.replace(BARE_DOLLAR_DIGIT_RE, '\\$');
+}
+
 /** Less-than before a digit or escaped dollar. Used by comparison-operators rule. */
 export const LESS_THAN_BEFORE_NUM_RE = /<(\d|\\?\$)/g;
 


### PR DESCRIPTION
## Summary

Adds `filterProposals()` post-parse in `crux/citations/fix-inaccuracies.ts` to catch the three systematic bugs surfaced in the 2026-04-12 dry-run ([QUA-349](https://linear.app/quantifieduncertainty/issue/QUA-349)):

1. **Escape bare `$digit` → `\$digit`** — 13/480 proposals in the dry-run broke the `dollar-signs` gate check. The blueprint-biosecurity apply regressed a page 1→4 flagged because of this. Moved `escapeDollarDigits()` to `crux/lib/patterns.ts` alongside the other dollar-sign patterns.
2. **Reject component drops** — 16/480 proposals silently dropped `<EntityLink>`, `<F>`, `<R>`, `<FBF>`, `<FBFactValue>`, or `<Calc>`, breaking wiki cross-references and fact provenance.
3. **Reject unjustified shrinks** — 20/480 proposals shrank content below 40% of the original without being a `remove_*` action, collapsing detailed claims to one-liners.

Rejections are logged per-page so bulk runs stay observable. The `FIX_ACTIONS` union is pinned to the SYSTEM_PROMPT action list, so renaming an action in the prompt breaks type-check on `SHRINK_EXEMPT_ACTIONS` instead of silently degrading filter behavior.

## Unblocks

- QUA-307 (Clean up 264 contradicted citation verdicts) — this was the blocker identified in the QUA-307 2026-04-12 investigation.

## Test plan

- [x] Unit tests cover each filter independently and in combination (27 new tests in `crux/citations/fix-inaccuracies.test.ts`, 86 tests total in the file pass)
- [x] Blueprint-biosecurity regression fixture (`$1,000,000` in a `correct` action) gets escaped to `\$1,000,000`
- [x] Adversarial inputs: leading `$`, already-escaped `\$`, variable-like `abc$1`, empty proposals list, mixed-batch keep/reject
- [x] Drift-guard test pins `FIX_ACTIONS` against the SYSTEM_PROMPT's action vocabulary
- [x] `pnpm build` green
- [x] `pnpm test` green (6355 tests pass)
- [x] `pnpm crux w validate gate --fix` green (51/51)

## Out of scope (deferred to follow-up if still needed)

Bug 4 from the ticket — LLM-level redundancy detection (the blueprint pattern where the tool appended a fact already present earlier in the sentence) — was prompt/quality work separate from the mechanical post-LLM filters. If QUA-307 still trips on it after this lands, file a follow-up.

Fixes QUA-349
