### PR TITLE
fix(tablebase): 4 sync handler cleanups (QUA-433..436)

### DIFF
--- a/apps/wiki-server/src/__tests__/format-currency.test.ts
+++ b/apps/wiki-server/src/__tests__/format-currency.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { formatMoney } from '../routes/shared/format-currency.js';
+
+describe('formatMoney', () => {
+  it('formats USD with $ symbol', () => {
+    expect(formatMoney(1_000_000, 'USD')).toBe('$1,000,000');
+  });
+
+  it('formats EUR with € symbol', () => {
+    expect(formatMoney(1_000_000, 'EUR')).toBe('€1,000,000');
+  });
+
+  it('formats GBP with £ symbol', () => {
+    expect(formatMoney(500_000, 'GBP')).toBe('£500,000');
+  });
+
+  it('formats JPY with ¥ symbol', () => {
+    expect(formatMoney(100_000_000, 'JPY')).toBe('¥100,000,000');
+  });
+
+  it('lowercases currency code input and still formats correctly', () => {
+    expect(formatMoney(1000, 'eur')).toBe('€1,000');
+  });
+
+  it('defaults to USD when currency is null', () => {
+    expect(formatMoney(500, null)).toBe('$500');
+  });
+
+  it('defaults to USD when currency is undefined', () => {
+    expect(formatMoney(500, undefined)).toBe('$500');
+  });
+
+  it('returns null for null amount', () => {
+    expect(formatMoney(null, 'USD')).toBeNull();
+  });
+
+  it('returns null for undefined amount', () => {
+    expect(formatMoney(undefined, 'USD')).toBeNull();
+  });
+
+  it('accepts string-encoded amounts (Drizzle numeric)', () => {
+    expect(formatMoney('2500000', 'USD')).toBe('$2,500,000');
+  });
+
+  it('returns null for non-numeric strings', () => {
+    expect(formatMoney('not a number', 'USD')).toBeNull();
+  });
+
+  it('returns null for NaN', () => {
+    expect(formatMoney(Number.NaN, 'USD')).toBeNull();
+  });
+
+  it('returns null for Infinity', () => {
+    expect(formatMoney(Number.POSITIVE_INFINITY, 'USD')).toBeNull();
+  });
+
+  it('drops fractional cents for whole-unit display', () => {
+    expect(formatMoney(1234.56, 'USD')).toBe('$1,235');
+  });
+
+  it('handles zero', () => {
+    expect(formatMoney(0, 'USD')).toBe('$0');
+  });
+
+  it('handles negative amounts', () => {
+    expect(formatMoney(-1000, 'USD')).toBe('-$1,000');
+  });
+
+  it('falls back to plain number formatting for malformed currency codes', () => {
+    // Intl.NumberFormat throws RangeError when the currency code isn't a
+    // well-formed 3-letter string. The helper must catch and return the
+    // amount as a number-only string rather than crashing the sync handler.
+    const result = formatMoney(1000, 'TOOLONG');
+    expect(result).not.toBeNull();
+    expect(result).toContain('1,000');
+  });
+});

--- a/apps/wiki-server/src/__tests__/things.test.ts
+++ b/apps/wiki-server/src/__tests__/things.test.ts
@@ -26,6 +26,7 @@ function makeThing(overrides: Record<string, unknown> = {}): Record<string, unkn
     description: null,
     source_url: null,
     wiki_id: null,
+    parent_title: null,
     created_at: now,
     updated_at: now,
     synced_at: now,
@@ -93,7 +94,9 @@ function dispatch(query: string, params: unknown[]): unknown[] {
 
   // --- things: INSERT ... ON CONFLICT DO UPDATE ---
   if (q.includes("insert into") && q.includes('"things"')) {
-    const COLS = 10; // id, thingType, title, parentThingId, sourceTable, sourceId, entityType, description, sourceUrl, wikiId
+    // id, thingType, title, parentThingId, sourceTable, sourceId, entityType,
+    // description, sourceUrl, wikiId, parentTitle
+    const COLS = 11;
     const numRows = params.length / COLS;
     const rows: Record<string, unknown>[] = [];
     const now = new Date();
@@ -119,6 +122,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         description: params[o + 7],
         source_url: params[o + 8],
         wiki_id: params[o + 9],
+        parent_title: params[o + 10],
         created_at: existing?.created_at ?? now,
         updated_at: now,
         synced_at: now,
@@ -358,6 +362,28 @@ describe("Things API", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.upserted).toBe(2);
+    });
+
+    it("persists parentTitle when supplied (QUA-435)", async () => {
+      const res = await postJson(app, "/api/things/sync", {
+        things: [
+          {
+            id: "thing-grant-1",
+            thingType: "grant",
+            title: "Grant to X",
+            sourceTable: "grants",
+            sourceId: "g1",
+            parentTitle: "Open Philanthropy",
+          },
+        ],
+      });
+
+      expect(res.status).toBe(200);
+      const stored = Array.from(thingsStore.values()).find(
+        (r) => r.source_id === "g1",
+      );
+      expect(stored).toBeDefined();
+      expect(stored?.parent_title).toBe("Open Philanthropy");
     });
 
     it("rejects duplicate (sourceTable, sourceId) pairs within a batch", async () => {

--- a/apps/wiki-server/src/routes/shared/format-currency.ts
+++ b/apps/wiki-server/src/routes/shared/format-currency.ts
@@ -1,0 +1,31 @@
+/**
+ * Format a numeric amount with its currency code for display in things.description
+ * and similar user-visible strings.
+ *
+ * Uses `Intl.NumberFormat` with `style: 'currency'` so the output respects the
+ * currency's native symbol (USD → $, EUR → €, GBP → £, JPY → ¥, etc.) and
+ * locale conventions. Amounts are rendered without cents since domain-table
+ * values (grants, funding rounds) are always whole-unit figures.
+ *
+ * Invalid or unknown currency codes fall back to the numeric-only `toLocaleString`
+ * rendering so the formatter can never throw at write time.
+ */
+export function formatMoney(
+  amount: number | string | null | undefined,
+  currency: string | null | undefined
+): string | null {
+  if (amount == null) return null;
+  const n = typeof amount === "number" ? amount : Number(amount);
+  if (!Number.isFinite(n)) return null;
+
+  const code = (currency ?? "USD").toUpperCase();
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: code,
+      maximumFractionDigits: 0,
+    }).format(n);
+  } catch {
+    return n.toLocaleString("en-US");
+  }
+}

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -14,6 +14,7 @@ import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-enti
 import { formatEntityRef } from "../shared/entity-ref.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { formatMoney } from "../shared/format-currency.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
@@ -272,7 +273,8 @@ const fundingRoundsApp = new Hono<{ Variables: ResolvedEntityVars }>()
         sourceUrl: item.source,
         parentTitle: titleMap.get(item.companyId) ?? item.companyDisplayName ?? item.companyId,
         description: [
-          item.raised != null ? `raised $${Number(item.raised).toLocaleString()}` : null,
+          // funding_rounds has no currency column; values are implicitly USD.
+          item.raised != null ? `raised ${formatMoney(item.raised, "USD")}` : null,
           item.instrument,
           item.leadInvestor ? `led by ${item.leadInvestorDisplayName ?? item.leadInvestor}` : null,
         ].filter(Boolean).join(", ") || null,

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -23,6 +23,7 @@ import {
 } from "../shared/utils.js";
 import { parseSort, buildSearchCondition } from "../shared/query-helpers.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
+import { formatMoney } from "../shared/format-currency.js";
 import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { formatEntityRef } from "../shared/entity-ref.js";
@@ -753,7 +754,7 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
             g.granteeId
               ? `to ${titleMap.get(g.granteeId) ?? g.granteeId}`
               : null,
-            g.amount != null ? `$${Number(g.amount).toLocaleString()}` : null,
+            formatMoney(g.amount, g.currency),
             g.date,
           ].filter(Boolean).join(", ") || null,
         }))

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -433,7 +433,6 @@ const researchAreasApp = new Hono()
         sourceId: item.id,
         description: item.description,
         sourceUrl: item.source,
-        href: `/research-areas/${item.id}`,
       }),
     }),
   )

--- a/apps/wiki-server/src/routes/tablebase/things.ts
+++ b/apps/wiki-server/src/routes/tablebase/things.ts
@@ -561,6 +561,7 @@ const thingsApp = new Hono()
       description: item.description ?? null,
       sourceUrl: item.sourceUrl ?? null,
       wikiId: item.wikiId ?? null,
+      parentTitle: item.parentTitle ?? null,
     }),
     conflictTarget: [things.sourceTable, things.sourceId],
     conflictSet: {
@@ -572,6 +573,7 @@ const thingsApp = new Hono()
       description: sql`excluded.description`,
       sourceUrl: sql`excluded.source_url`,
       wikiId: sql`excluded.wiki_id`,
+      parentTitle: sql`excluded.parent_title`,
       syncedAt: sql`now()`,
       updatedAt: sql`now()`,
     },

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2591,6 +2591,7 @@ export const VALID_THING_TYPES = [
   "policy-stakeholder",
   "entity-event",
   "entity-assessment",
+  "entity-resource",
   "publication",
   "political-race",
   "race-candidate",


### PR DESCRIPTION
## Summary

Four small tablebase-sync handler fixes surfaced by the QUA-414 denormalization audit. All four touch different handlers; bundled because they share reviewer context and each would be a trivial standalone PR.

- **QUA-433** — Add `"entity-resource"` to `VALID_THING_TYPES`. `entity-resources.ts` has been writing `thingType: "entity-resource"` via `upsertThingsInTx` since the things table existed, but the canonical enum omitted it. The value is consistent with other join-table types already in the list (`investment`, `equity-position`, `personnel`, `division-personnel`), so option 1 ("add to enum") is applied rather than option 2 ("remove the things write"). No `thingHref()` case is added — join-table things types return `null` href, matching existing behavior.
- **QUA-434** — Remove the dead `href` field from `research-areas.ts::toThing`. `ThingSyncInput` never accepted `href`, so the field was silently dropped. `thingHref()` computes research-area URLs at read time from `sourceId`, so nothing depended on the dropped value. The optional "tighten `ThingSyncInput`" follow-up in the ticket is deferred — scope creep for this PR.
- **QUA-435** — Wire `parentTitle` through `/api/things/sync`. The Zod schema already accepted it, but the factory `toRow` and `conflictSet` both omitted it, so the column was silently nulled for every row coming in through this route. Fix adds `parentTitle` to both + a regression test that posts a row with `parentTitle` and asserts the column is populated.
- **QUA-436** — Replace hardcoded `$` in `grants.ts` / `funding-rounds.ts` `things.description` composers with a new `formatMoney()` helper (`apps/wiki-server/src/routes/shared/format-currency.ts`) that uses `Intl.NumberFormat` with `style: "currency"`. `grants.ts` now passes `g.currency` through, so EUR/GBP/JPY/etc. render with the correct native symbol. `funding_rounds` **has no currency column** — the schema comment declares USD-only — so the call site passes `"USD"` explicitly and routes through the same helper, which means a future `currency` column migration can drop straight in without touching the call site again. The ticket body's "both tables have a currency column" claim is incorrect re: funding_rounds.

### Why bundled

Each fix is <10 lines of code. Four separate PRs would have been pure reviewer overhead given the shared subsystem (tablebase sync handlers) and the shared audit origin (QUA-414 §6). The tests and the gate run once for the bundle.

## Test plan

- [x] `pnpm --filter wiki-server test` — 1131 passing, including new tests
- [x] New `format-currency.test.ts` — 17 cases covering USD/EUR/GBP/JPY symbols, null/undefined amount, string-encoded amounts, NaN, Infinity, zero, negatives, lowercase code, malformed code fallback
- [x] `things.test.ts` — new regression test asserts `parentTitle` persists via `/api/things/sync`; the 22 pre-existing tests still pass after bumping the mock's `COLS` constant from 10 to 11
- [x] `pnpm crux w validate gate --fix` — 51/51 pass (3 advisory warnings are pre-existing)
- [x] `tsc --noEmit` — clean on wiki-server and apps/web

## Out of scope / noted

- Tightening `ThingSyncInput` to a `satisfies`-strict type (QUA-434 optional) — deferred, not requested.
- Adding `funding_rounds.currency` column (QUA-436 schema gap) — out of scope; the helper call already passes `"USD"` so the migration can drop in without code changes.

Closes QUA-433
Closes QUA-434
Closes QUA-435
Closes QUA-436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-currency formatting support with international currency symbols (USD, EUR, GBP, JPY).
  * Parent title field added to entity metadata.
  * New "entity-resource" entity type introduced.

* **Improvements**
  * Currency formatting now consistently applied across funding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->