### PR TITLE
fix(pr-patrol): stop self-feedback loop and fix merge-queue mutation (QUA-472, QUA-473)

### DIFF
--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -192,6 +192,24 @@ export function extractBlockingComments(pr: GqlPrNode): BlockingComment[] {
   for (const c of comments) {
     if (!c?.author?.login) continue;
 
+    // Filter 0: skip patrol's own status/event markers — patrol runs under an
+    // OWNER-authored token, so its own comments would otherwise trip the
+    // authority filter below and produce a self-feedback infinite loop
+    // (QUA-472). Match on both the visible "🤖 **PR Patrol**" prefix used by
+    // event comments (enqueued, attempt, fix-complete, abandoned, timeout,
+    // stuck) AND the hidden `<!-- pr-patrol-* -->` HTML marker used to
+    // identify status panels. `startsWith` on the emoji prefix covers
+    // every buildXxxComment() in crux/pr-patrol/comments.ts; the HTML
+    // marker is `includes()`-checked because status panel bodies start with
+    // the marker on their own line, not the emoji.
+    const body = c.body ?? '';
+    if (
+      body.startsWith('\u{1F916} **PR Patrol**') ||
+      body.includes('<!-- pr-patrol-')
+    ) {
+      continue;
+    }
+
     // Filter 1: must be newer than the last push.
     const createdMs = new Date(c.createdAt).getTime();
     if (!Number.isFinite(createdMs)) continue;
@@ -199,14 +217,14 @@ export function extractBlockingComments(pr: GqlPrNode): BlockingComment[] {
 
     // Filter 2: authority OR urgency.
     const authority = AUTHORITATIVE_ASSOCIATIONS.has(c.authorAssociation);
-    const urgency = matchesUrgencyKeyword(c.body ?? '');
+    const urgency = matchesUrgencyKeyword(body);
     if (!authority && !urgency) continue;
 
     blocking.push({
       author: c.author.login,
       authorAssociation: c.authorAssociation,
       authorType: c.author.__typename ?? 'User',
-      body: c.body ?? '',
+      body,
       createdAt: c.createdAt,
       viewerDidAuthor: c.viewerDidAuthor ?? false,
     });

--- a/crux/lib/pr-analysis/enriched-scan.test.ts
+++ b/crux/lib/pr-analysis/enriched-scan.test.ts
@@ -186,6 +186,87 @@ describe('extractBlockingComments', () => {
     });
     expect(extractBlockingComments(pr)).toHaveLength(1);
   });
+
+  // ── QUA-472 — skip patrol's own self-authored markers ───────────────────
+  //
+  // Before this fix, patrol's own event comments ("🤖 **PR Patrol** —
+  // Attempting fix for: ...") and status panels ("<!-- pr-patrol-status
+  // -->") were authored under an OWNER token and therefore passed the
+  // authority filter in Filter 2 above. On the next cycle, detectIssues()
+  // saw those as blocking → self-authored-feedback → infinite loop of
+  // posting "Attempting fix for: self-authored-feedback" comments.
+  //
+  // Regression guard: any comment starting with the patrol emoji+bold
+  // prefix OR containing the hidden HTML marker must be filtered out, even
+  // when posted by an OWNER/MEMBER/COLLABORATOR.
+  describe('QUA-472 self-feedback loop — skips patrol-authored markers', () => {
+    const MARKER_BODIES = [
+      // Event comments (buildXxxComment builders in crux/pr-patrol/comments.ts)
+      '\u{1F916} **PR Patrol** \u{2014} Attempting fix for: bot-review-major',
+      '\u{1F916} **PR Patrol** \u{2014} Fix attempt complete (42s, 10 max turns, model: sonnet).',
+      '\u{1F916} **PR Patrol** \u{2014} Added to the merge queue. GitHub will run CI and merge automatically.',
+      '\u{1F916} **PR Patrol** \u{2014} Failed to add to merge queue: HTTP 500',
+      '\u{1F916} **PR Patrol** \u{2014} Abandoning after 3 failed fix attempts. Escalating to coordinator (Opus).',
+      '\u{1F916} **PR Patrol** \u{2014} Fix attempt timed out after 30m (attempt 2).',
+      '\u{1F916} **PR Patrol** \u{2014} Agent determined this issue needs escalation to coordinator (Opus) (no code changes made).',
+      '\u{1F916} **PR Patrol** \u{2014} Stuck for 5 consecutive cycles without signal change. Escalating to coordinator (Opus).',
+      // Status panel body (marker is on its own first line, then the title)
+      '<!-- pr-patrol-status -->\n\u{1F916} **PR Patrol Status**\n\n| Check | Status |',
+    ];
+
+    for (const body of MARKER_BODIES) {
+      it(`skips OWNER-authored patrol marker: ${body.slice(0, 60).replace(/\n/g, '\\n')}...`, () => {
+        const pr = makePrNode({
+          comments: {
+            nodes: [{
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body,
+              createdAt: '2026-04-10T12:00:00Z',
+              viewerDidAuthor: true,
+            }],
+          },
+        });
+        expect(extractBlockingComments(pr)).toEqual([]);
+      });
+    }
+
+    it('still returns real OWNER blocking comments alongside patrol markers', () => {
+      // The core regression scenario: three comments from an OWNER, only
+      // the human one should come back.
+      const pr = makePrNode({
+        comments: {
+          nodes: [
+            {
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body: '\u{1F916} **PR Patrol** \u{2014} Attempting fix for: bot-review-major',
+              createdAt: '2026-04-10T12:00:00Z',
+              viewerDidAuthor: true,
+            },
+            {
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body: '<!-- pr-patrol-status -->\n\u{1F916} **PR Patrol Status**\n\nStage: merging',
+              createdAt: '2026-04-10T12:01:00Z',
+              viewerDidAuthor: true,
+            },
+            {
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body: '\u26A0\uFE0F This will break prod — please hold off',
+              createdAt: '2026-04-10T12:02:00Z',
+              viewerDidAuthor: true,
+            },
+          ],
+        },
+      });
+      const blocking = extractBlockingComments(pr);
+      expect(blocking).toHaveLength(1);
+      expect(blocking[0].author).toBe('OAGr');
+      expect(blocking[0].body).toContain('will break prod');
+    });
+  });
 });
 
 // ── isSelfAuthored ───────────────────────────────────────────────────────────

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -156,7 +156,7 @@ export interface MergeCandidate {
   branch: string;
   createdAt: string;
   headOid: string;
-  nodeId: string; // GraphQL node ID for enqueuePullRequestForMerge
+  nodeId: string; // GraphQL node ID for enablePullRequestAutoMerge
   eligible: boolean;
   blockReasons: MergeBlockReason[];
 }
@@ -245,7 +245,7 @@ export interface BlockedOnPr {
 }
 
 export interface GqlPrNode {
-  id: string; // GraphQL node ID (e.g. "PR_kwDON..."), needed for enqueuePullRequestForMerge
+  id: string; // GraphQL node ID (e.g. "PR_kwDON..."), needed for enablePullRequestAutoMerge
   number: number;
   title: string;
   /** PR state: OPEN, CLOSED, or MERGED. Present when the GQL query requests it. */

--- a/crux/pr-patrol/merge.test.ts
+++ b/crux/pr-patrol/merge.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for crux/pr-patrol/merge.ts
+ *
+ * QUA-473 regression: `enqueuePullRequestForMerge` is a phantom mutation —
+ * it does not exist on GitHub's GraphQL schema and every call failed
+ * at runtime with `Field 'enqueuePullRequestForMerge' doesn't exist on
+ * type 'Mutation'`. The correct mutation is `enablePullRequestAutoMerge`
+ * with input type `EnablePullRequestAutoMergeInput`.
+ *
+ * These tests lock in the correct mutation name + shape so nobody can
+ * regress it again without failing CI.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the github lib BEFORE importing the module under test.
+vi.mock('../lib/github.ts', () => ({
+  REPO: 'quantified-uncertainty/longterm-wiki',
+  githubApi: vi.fn(),
+  githubGraphQL: vi.fn(),
+}));
+
+// Mock state.ts so we don't touch the real ~/.cache/pr-patrol JSONL file
+// or try to create directories during unit tests.
+vi.mock('./state.ts', () => ({
+  appendJsonl: vi.fn(),
+  cl: new Proxy({}, { get: () => '' }),
+  JSONL_FILE: '/tmp/test-runs.jsonl',
+  log: vi.fn(),
+}));
+
+// Mock comments.ts to avoid real comment-posting over HTTP.
+vi.mock('./comments.ts', () => ({
+  buildEnqueuedComment: vi.fn(() => 'enqueued'),
+  buildEnqueueFailedComment: vi.fn((reason: string) => `failed: ${reason}`),
+  postEventComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock pr-analysis re-exports — merge.ts only re-exports them, the tests
+// don't exercise them, but vitest resolves the whole import graph.
+vi.mock('../lib/pr-analysis/index.ts', () => ({
+  checkMergeEligibility: vi.fn(),
+  findMergeCandidates: vi.fn(),
+}));
+
+import { enqueuePr } from './merge.ts';
+import * as githubLib from '../lib/github.ts';
+import type { MergeCandidate, PatrolConfig } from './types.ts';
+
+const mockGraphQL = vi.mocked(githubLib.githubGraphQL);
+const mockApi = vi.mocked(githubLib.githubApi);
+
+function makeCandidate(overrides: Partial<MergeCandidate> = {}): MergeCandidate {
+  return {
+    number: 4242,
+    title: 'Example PR',
+    branch: 'claude/qua-999-example',
+    createdAt: '2026-04-13T00:00:00Z',
+    headOid: 'deadbeefcafebabe1234567890abcdef12345678',
+    nodeId: 'PR_kwDOtest4242',
+    eligible: true,
+    blockReasons: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<PatrolConfig> = {}): PatrolConfig {
+  return {
+    repo: 'quantified-uncertainty/longterm-wiki',
+    intervalSeconds: 60,
+    maxTurns: 10,
+    cooldownSeconds: 300,
+    staleHours: 72,
+    model: 'sonnet',
+    skipPerms: false,
+    once: false,
+    dryRun: false,
+    verbose: false,
+    reflectionInterval: 5,
+    timeoutMinutes: 30,
+    ...overrides,
+  };
+}
+
+describe('enqueuePr (QUA-473)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The `addLabel` call goes through githubApi — default to success.
+    mockApi.mockResolvedValue(undefined);
+  });
+
+  it('uses the `enablePullRequestAutoMerge` mutation (NOT the phantom `enqueuePullRequestForMerge`)', async () => {
+    // First GraphQL call is the mutation; second call (if any) is the
+    // status-probe query from isInMergeQueue() fallback path.
+    mockGraphQL.mockResolvedValueOnce({
+      enablePullRequestAutoMerge: {
+        pullRequest: {
+          id: 'PR_kwDOtest4242',
+          autoMergeRequest: { enabledAt: '2026-04-13T10:00:00Z' },
+        },
+      },
+    } as unknown as never);
+
+    const outcome = await enqueuePr(makeCandidate(), makeConfig());
+
+    expect(outcome).toBe('enqueued');
+
+    // At least one GraphQL call happened — the first one is the mutation.
+    expect(mockGraphQL).toHaveBeenCalled();
+    const [mutation, variables] = mockGraphQL.mock.calls[0];
+    const mutationStr = String(mutation);
+
+    // Positive assertion: the correct mutation name is present.
+    expect(mutationStr).toContain('enablePullRequestAutoMerge');
+    // Regression guard: the phantom name must never come back.
+    expect(mutationStr).not.toContain('enqueuePullRequestForMerge');
+
+    // Input shape: must pass pullRequestId + expectedHeadOid + mergeMethod.
+    expect(mutationStr).toContain('pullRequestId: $prId');
+    expect(mutationStr).toContain('expectedHeadOid: $expectedHeadOid');
+    expect(mutationStr).toContain('mergeMethod:');
+
+    // Variable declarations must match the variables actually passed so
+    // GraphQL doesn't reject with "variable declared but not used".
+    expect(mutationStr).toContain('$prId: ID!');
+    expect(mutationStr).toContain('$expectedHeadOid: GitObjectID');
+
+    // Variables are forwarded from the candidate.
+    expect(variables).toEqual({
+      prId: 'PR_kwDOtest4242',
+      expectedHeadOid: 'deadbeefcafebabe1234567890abcdef12345678',
+    });
+  });
+
+  it('uses MERGE as the merge method (repo uses merge commits, not squash)', async () => {
+    mockGraphQL.mockResolvedValueOnce({
+      enablePullRequestAutoMerge: {
+        pullRequest: { id: 'x', autoMergeRequest: { enabledAt: 'x' } },
+      },
+    } as unknown as never);
+
+    await enqueuePr(makeCandidate(), makeConfig());
+
+    const mutationStr = String(mockGraphQL.mock.calls[0][0]);
+    expect(mutationStr).toContain('mergeMethod: MERGE');
+  });
+
+  it('dry-run mode does not call the GraphQL mutation', async () => {
+    const outcome = await enqueuePr(
+      makeCandidate(),
+      makeConfig({ dryRun: true }),
+    );
+    expect(outcome).toBe('dry-run');
+    expect(mockGraphQL).not.toHaveBeenCalled();
+  });
+});

--- a/crux/pr-patrol/merge.ts
+++ b/crux/pr-patrol/merge.ts
@@ -1,9 +1,9 @@
 /**
- * PR Patrol — Merge queue execution (daemon-specific)
+ * PR Patrol — Auto-merge execution (daemon-specific)
  *
  * Pure merge eligibility checking lives in crux/lib/pr-analysis/merge-check.ts.
- * This module handles the actual merge queue enqueue and undraft execution with:
- *   - GitHub GraphQL API calls (enqueuePullRequestForMerge, undraft mutation)
+ * This module handles the actual auto-merge enable and undraft execution with:
+ *   - GitHub GraphQL API calls (enablePullRequestAutoMerge, markPullRequestReadyForReview)
  *   - Label management (stage:merging)
  *   - JSONL logging
  *   - Comment posting
@@ -85,25 +85,39 @@ async function removeLabel(prNum: number, repo: string, label: string): Promise<
   });
 }
 
-// ── Merge queue queries ──────────────────────────────────────────────────
-
-const ENQUEUE_MUTATION = `mutation($prId: ID!, $expectedHeadOid: GitObjectID) {
-  enqueuePullRequestForMerge(input: {
+// ── Auto-merge mutation ──────────────────────────────────────────────────
+//
+// GitHub GraphQL has no `enqueuePullRequestForMerge` mutation — that name is
+// a phantom. The canonical way to ask GitHub to merge a PR as soon as it is
+// eligible (branch-protection checks green, no outstanding reviews) is
+// `enablePullRequestAutoMerge` with an `EnablePullRequestAutoMergeInput`.
+//
+// The repo merges via "Create a merge commit" (see `git log` on origin/main
+// — every PR lands as a true two-parent merge commit, not a squash), so we
+// pass `mergeMethod: MERGE`. `expectedHeadOid` gives us optimistic
+// concurrency: if a new commit has landed on the PR branch between
+// candidate selection and mutation, GitHub will reject rather than
+// auto-merge a stale SHA.
+const ENABLE_AUTO_MERGE_MUTATION = `mutation EnableAutoMerge($prId: ID!, $expectedHeadOid: GitObjectID!) {
+  enablePullRequestAutoMerge(input: {
     pullRequestId: $prId
     expectedHeadOid: $expectedHeadOid
+    mergeMethod: MERGE
   }) {
-    mergeQueueEntry {
+    pullRequest {
       id
-      position
+      autoMergeRequest {
+        enabledAt
+      }
     }
   }
 }`;
 
-/** Check whether a PR is currently in the merge queue (read-only). */
-const QUEUE_STATUS_QUERY = `query($prId: ID!) {
+/** Check whether a PR has auto-merge enabled (read-only). */
+const AUTO_MERGE_STATUS_QUERY = `query($prId: ID!) {
   node(id: $prId) {
     ... on PullRequest {
-      mergeQueueEntry { id position }
+      autoMergeRequest { enabledAt }
     }
   }
 }`;
@@ -111,9 +125,9 @@ const QUEUE_STATUS_QUERY = `query($prId: ID!) {
 async function isInMergeQueue(nodeId: string): Promise<boolean> {
   try {
     const data = await githubGraphQL<{
-      node: { mergeQueueEntry: { id: string; position: number } | null } | null;
-    }>(QUEUE_STATUS_QUERY, { prId: nodeId });
-    return data.node?.mergeQueueEntry != null;
+      node: { autoMergeRequest: { enabledAt: string | null } | null } | null;
+    }>(AUTO_MERGE_STATUS_QUERY, { prId: nodeId });
+    return data.node?.autoMergeRequest != null;
   } catch {
     // If the query fails, assume indeterminate — safer to keep the label
     return true;
@@ -148,8 +162,10 @@ export async function enqueuePr(
     // Add stage:merging label first to prevent double-enqueue on next cycle
     await addLabel(candidate.number, config.repo, LABELS.STAGE_MERGING);
 
-    // Enqueue via GraphQL mutation — uses node ID and head SHA for optimistic concurrency
-    await githubGraphQL(ENQUEUE_MUTATION, {
+    // Enable auto-merge via GraphQL mutation — uses node ID and head SHA
+    // for optimistic concurrency. GitHub will run CI on the PR branch and
+    // merge automatically once all branch-protection conditions pass.
+    await githubGraphQL(ENABLE_AUTO_MERGE_MUTATION, {
       prId: candidate.nodeId,
       expectedHeadOid: candidate.headOid,
     });


### PR DESCRIPTION
## Summary

Fixes two PR Patrol bugs in a single PR.

### QUA-472 — patrol self-feedback infinite loop

`extractBlockingComments()` in `crux/lib/pr-analysis/detection.ts` filtered
comments by `(authority OR urgency)`. Because PR Patrol posts its own status
and event comments under an OWNER-associated token, those comments passed
the authority filter and were classified as "blocking" on the next cycle.
On `claude/*` branches, `detectIssues()` then emitted `self-authored-feedback`
and patrol attempted to "fix" its own comments — a loop.

**Fix**: before the authority/urgency check, skip any comment whose body
- starts with the visible `🤖 **PR Patrol**` event-comment prefix, OR
- contains the hidden `<!-- pr-patrol-` HTML marker used by the status panel.

Both markers are defined in `crux/pr-patrol/comments.ts`. The filter matches
every `buildXxxComment()` builder (enqueued, enqueue-failed, attempt,
complete, abandonment, timeout, no-op, stuck) plus the upserted status panel.

### QUA-473 — wrong GraphQL mutation `enqueuePullRequestForMerge`

`crux/pr-patrol/merge.ts` called a GraphQL mutation named
`enqueuePullRequestForMerge`, which does not exist on GitHub's GraphQL
schema. Every enqueue attempt failed at runtime with:

```
Field 'enqueuePullRequestForMerge' doesn't exist on type 'Mutation'
```

**Fix**: replaced with `enablePullRequestAutoMerge`, the real mutation that
asks GitHub to merge a PR as soon as branch-protection checks pass. Input
uses `EnablePullRequestAutoMergeInput` with `pullRequestId` + `expectedHeadOid`
+ `mergeMethod: MERGE`. The merge method was chosen by inspecting `origin/main`:
every landed PR is a true two-parent merge commit (confirmed via
`git log --format='%p' origin/main`), so the repo uses "Create a merge
commit", not squash.

The read-side `isInMergeQueue()` now queries `autoMergeRequest { enabledAt }`
instead of `mergeQueueEntry` — same semantics (is auto-merge set up?), real
field.

### Tests

- **QUA-472**: 10 new cases in `crux/lib/pr-analysis/enriched-scan.test.ts`
  inside a new `QUA-472 self-feedback loop` describe block. Covers all 8
  `buildXxxComment` builder bodies plus the status panel body, each posted
  by an OWNER, asserting `extractBlockingComments()` returns `[]`. A final
  mixed-input test posts three OWNER comments — two patrol markers + one
  real `⚠️ This will break prod` — and asserts only the human comment
  comes back.
- **QUA-473**: new `crux/pr-patrol/merge.test.ts` with 3 cases. Mocks
  `githubGraphQL` and asserts:
  1. The mutation string contains `enablePullRequestAutoMerge`, the
     correct variable declarations (`$prId: ID!`, `$expectedHeadOid: GitObjectID`),
     `pullRequestId: $prId`, `expectedHeadOid: $expectedHeadOid`, and does
     NOT contain the phantom `enqueuePullRequestForMerge`. Verifies the
     variables forwarded to GraphQL match the candidate's `nodeId` and `headOid`.
  2. `mergeMethod: MERGE` is present.
  3. Dry-run mode skips the GraphQL call entirely.

All 86 in-scope tests pass (`enriched-scan`, `merge`, `detection`).
Full patrol sweep: `473 passed` across 18 test files in this slot.

`pnpm typecheck:tooling` — at baseline (69 crux errors, unchanged).

### Non-functional cleanup

- Updated two stale comments in `crux/lib/pr-analysis/types.ts` and the
  `merge.ts` file header that still referenced the phantom mutation name.

## Test plan

- [x] `npx vitest run crux/lib/pr-analysis/enriched-scan.test.ts crux/pr-patrol/merge.test.ts` — 45 tests pass
- [x] `npx vitest run crux/lib/pr-analysis crux/pr-patrol --exclude='.claude/**'` — 473 tests pass
- [x] `pnpm typecheck:tooling` — at baseline (69 crux errors, no regressions)
- [x] `pnpm crux w validate gate --fix` — all 42 gate checks passed (4 advisory, unchanged)
- [x] Push clean without `--no-verify`

Closes QUA-472
Closes QUA-473
