### PR TITLE
QUA-426: pre-LLM relevance gate for source-check

### DIFF
--- a/apps/web/src/components/sourcing/__tests__/sourcing-status.test.ts
+++ b/apps/web/src/components/sourcing/__tests__/sourcing-status.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  recordVerdictToStatus,
+  factbaseVerdictToStatus,
+} from "../sourcing-status";
+
+describe("recordVerdictToStatus", () => {
+  it("maps the 5 primary verdicts to their canonical statuses", () => {
+    expect(recordVerdictToStatus("confirmed")).toBe("verified");
+    expect(recordVerdictToStatus("contradicted")).toBe("failed");
+    expect(recordVerdictToStatus("outdated")).toBe("trouble");
+    expect(recordVerdictToStatus("partial")).toBe("trouble");
+    expect(recordVerdictToStatus("unverifiable")).toBe("trouble");
+  });
+
+  // QUA-426: pre-LLM relevance-gate short-circuits write `not_applicable`
+  // evidence rows. They render as neutral "not checked" — NOT as "trouble"
+  // — because the source content didn't even mention the record's subject.
+  // Mapping it to "trouble" would surface noise to the user.
+  it("maps not_applicable to not_run (neutral, not trouble)", () => {
+    expect(recordVerdictToStatus("not_applicable")).toBe("not_run");
+  });
+
+  it("maps null/undefined/unknown values to not_run", () => {
+    expect(recordVerdictToStatus(null)).toBe("not_run");
+    expect(recordVerdictToStatus(undefined)).toBe("not_run");
+    expect(recordVerdictToStatus("")).toBe("not_run");
+    expect(recordVerdictToStatus("garbage")).toBe("not_run");
+  });
+});
+
+describe("factbaseVerdictToStatus", () => {
+  it("maps citation verdicts to their canonical statuses", () => {
+    expect(factbaseVerdictToStatus("accurate")).toBe("verified");
+    expect(factbaseVerdictToStatus("verified")).toBe("verified");
+    expect(factbaseVerdictToStatus("minor_issues")).toBe("trouble");
+    expect(factbaseVerdictToStatus("inaccurate")).toBe("failed");
+    expect(factbaseVerdictToStatus("unsupported")).toBe("failed");
+    expect(factbaseVerdictToStatus("not_verifiable")).toBe("trouble");
+  });
+
+  it("maps null/unknown values to not_run", () => {
+    expect(factbaseVerdictToStatus(null)).toBe("not_run");
+    expect(factbaseVerdictToStatus("garbage")).toBe("not_run");
+  });
+});

--- a/apps/web/src/components/sourcing/sourcing-status.ts
+++ b/apps/web/src/components/sourcing/sourcing-status.ts
@@ -68,6 +68,10 @@ const RECORD_VERDICT_MAP: Record<string, SourcingStatus> = {
   outdated: "trouble",
   partial: "trouble",
   unverifiable: "trouble",
+  // QUA-426: pre-LLM relevance-gate short-circuit — the source didn't even
+  // mention the record's subject, so neither confirmation nor contradiction
+  // is possible. Render as neutral "not checked", not as "trouble".
+  not_applicable: "not_run",
 };
 
 /**

--- a/apps/wiki-server/drizzle/0180_sourcing_not_applicable_verdict.sql
+++ b/apps/wiki-server/drizzle/0180_sourcing_not_applicable_verdict.sql
@@ -1,0 +1,74 @@
+-- QUA-426: add `not_applicable` to the allowed verdicts.
+--
+-- Pre-LLM relevance-gate short-circuits (see crux/lib/sourcing/relevance-gate.ts)
+-- record a `not_applicable` verdict when the source content doesn't mention
+-- the record's subject at all. The value must be permitted in both
+-- source_check_evidence (evidence rows) and source_check_verdicts (aggregate).
+--
+-- `source_check_evidence` is the heavy-write table in this subsystem.
+-- Dropping and re-adding a CHECK constraint as VALID would scan every row
+-- while holding ACCESS EXCLUSIVE — any concurrent writer would time out
+-- against the 60s lock_timeout configured in apps/wiki-server/src/db.ts.
+-- Use the NOT VALID + VALIDATE CONSTRAINT pattern from
+-- .claude/rules/database-migrations.md so Phase 1 is a metadata-only
+-- operation (milliseconds) and Phase 2 scans without ACCESS EXCLUSIVE.
+--
+-- source_check_verdicts is smaller (~12K rows today) so the same pattern
+-- costs nothing extra there but keeps the two table migrations symmetric.
+
+-- ── source_check_evidence ─────────────────────────────────────────────
+
+-- Phase 0: drop the old constraint. Idempotent so a partial re-run works.
+DO $$ BEGIN
+  ALTER TABLE "source_check_evidence"
+    DROP CONSTRAINT chk_source_check_evidence_verdict;
+EXCEPTION WHEN undefined_object THEN NULL;
+END $$;
+
+-- Phase 1: register the new constraint as NOT VALID (ACCESS EXCLUSIVE for
+-- milliseconds; no row scan, safe under concurrent writes).
+DO $$ BEGIN
+  ALTER TABLE "source_check_evidence"
+    ADD CONSTRAINT chk_source_check_evidence_verdict
+    CHECK (verdict IS NULL OR verdict IN (
+      'confirmed',
+      'contradicted',
+      'unverifiable',
+      'outdated',
+      'partial',
+      'not_applicable'
+    )) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Phase 2: validate against existing rows (SHARE UPDATE EXCLUSIVE — concurrent
+-- SELECT/INSERT/UPDATE are allowed). Safe because the new value set is a
+-- strict superset of the old one, so all existing rows already satisfy it.
+ALTER TABLE "source_check_evidence"
+  VALIDATE CONSTRAINT chk_source_check_evidence_verdict;
+
+-- ── source_check_verdicts ─────────────────────────────────────────────
+
+DO $$ BEGIN
+  ALTER TABLE "source_check_verdicts"
+    DROP CONSTRAINT chk_source_check_verdicts_verdict;
+EXCEPTION WHEN undefined_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "source_check_verdicts"
+    ADD CONSTRAINT chk_source_check_verdicts_verdict
+    CHECK (verdict IN (
+      'confirmed',
+      'contradicted',
+      'unverifiable',
+      'outdated',
+      'partial',
+      'unchecked',
+      'not_applicable'
+    )) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "source_check_verdicts"
+  VALIDATE CONSTRAINT chk_source_check_verdicts_verdict;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784966400000,
       "tag": "0179_agent_sessions_heartbeat_at",
       "breakpoints": true
+    },
+    {
+      "idx": 180,
+      "version": "7",
+      "when": 1785052800000,
+      "tag": "0180_sourcing_not_applicable_verdict",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
@@ -58,6 +58,10 @@ describe("VALID_SOURCE_CHECK_VERDICTS", () => {
   it("does NOT include 'unchecked' — that is a placeholder, not a verdict", () => {
     expect(VALID_SOURCE_CHECK_VERDICTS).not.toContain("unchecked");
   });
+
+  it("includes 'not_applicable' (QUA-426 pre-LLM relevance-gate verdict)", () => {
+    expect(VALID_SOURCE_CHECK_VERDICTS).toContain("not_applicable");
+  });
 });
 
 describe("isValidRecordType", () => {

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -122,12 +122,18 @@ export function isLinkableSourcingType(
   return isValidRecordType(recordType) && !isSourcingExempt(recordType);
 }
 
+// `not_applicable` (QUA-426) marks evidence rows where the pre-LLM relevance
+// gate determined the source content doesn't mention the record's subject at
+// all, so neither confirmation nor contradiction is possible from this source.
+// Rollup / display logic treats `not_applicable` as "no signal" — it does not
+// count toward any severity bucket and renders as a neutral "skipped" state.
 export const VALID_SOURCE_CHECK_VERDICTS = [
   "confirmed",
   "contradicted",
   "unverifiable",
   "outdated",
   "partial",
+  "not_applicable",
 ] as const;
 
 export type SourcingVerdict = (typeof VALID_SOURCE_CHECK_VERDICTS)[number];

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -81,6 +81,8 @@ const VALID_VERDICTS = [
   "unverifiable",
   "outdated",
   "partial",
+  // QUA-426: pre-LLM relevance-gate short-circuit. See api-types.ts for semantics.
+  "not_applicable",
 ] as const;
 
 const VALID_VERDICT_TYPES = [...VALID_VERDICTS, "unchecked"] as const;
@@ -1823,12 +1825,17 @@ const sourcingApp = new Hono()
     // avoid a breaking change to dashboard consumers (see
     // apps/web/src/app/internal/entity-sourcing/coverage-bars.tsx); both
     // endpoints now filter orphans identically.
+    // QUA-426: exclude not_applicable verdicts from the "verified" count.
+    // These are pre-LLM relevance-gate short-circuits — the page didn't
+    // mention the subject so nothing was actually verified. Counting them
+    // would inflate the dashboard's coverage %.
     const verifiedRowsRaw = (await db.execute(sql`
       WITH ${LIVE_RECORDS_CTE}
       SELECT v.record_type, count(DISTINCT v.record_id)::int AS verified
       FROM source_check_verdicts v
       INNER JOIN live_records lr
         ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      WHERE v.verdict <> 'not_applicable'
       GROUP BY v.record_type
     `)) as Array<{ record_type: string; verified: number }>;
 
@@ -1959,6 +1966,10 @@ const sourcingApp = new Hono()
   .get("/entity-summary", async (c) => {
     const db = getDrizzleDb();
 
+    // QUA-426: `not_applicable` rows are excluded from this summary entirely.
+    // They are pre-LLM relevance-gate short-circuits that carry no signal —
+    // counting them in `total_verdicts` would make the dashboard show entities
+    // as "checked" when the only evidence was "page doesn't mention subject".
     const rows = (await db.execute(sql`
       WITH verdict_counts AS (
         SELECT
@@ -1973,6 +1984,7 @@ const sourcingApp = new Hono()
           COALESCE(AVG(confidence), 0)                     AS avg_confidence
         FROM source_check_verdicts
         WHERE entity_id IS NOT NULL
+          AND verdict <> 'not_applicable'
         GROUP BY entity_id
       ),
       record_counts AS (
@@ -2089,13 +2101,15 @@ const sourcingApp = new Hono()
     // Coverage is based on distinct checked records, not verdict row counts.
     // A record can have multiple verdict rows (one per fieldName), so we use
     // COUNT(DISTINCT record_id) to avoid exceeding 100%.
+    // QUA-426: `not_applicable` is excluded alongside `unchecked` — neither
+    // is a real "the source actually addressed this" signal.
     const checkedRows = (await db.execute(sql`
       WITH ${LIVE_RECORDS_CTE}
       SELECT v.record_type, count(DISTINCT v.record_id)::int AS checked_records
       FROM source_check_verdicts v
       INNER JOIN live_records lr
         ON lr.record_type = v.record_type AND lr.record_id = v.record_id
-      WHERE v.verdict != 'unchecked'
+      WHERE v.verdict NOT IN ('unchecked', 'not_applicable')
       GROUP BY v.record_type
     `)) as Array<{ record_type: string; checked_records: number }>;
 

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -85,6 +85,13 @@ interface SourcingSummary {
   unverifiable: number;
   outdated: number;
   partial: number;
+  /**
+   * QUA-426: present for completeness so `summary[verdict]++` type-checks
+   * over the full SourcingVerdict union. The factbase-sourcing path does
+   * NOT run the relevance gate (gate only fires for record-kind items in
+   * item-verifier.ts), so this counter should stay at 0 in practice.
+   */
+  not_applicable: number;
   errors: number;
   /**
    * Number of times the storage call (storeSourcingResult) failed for an
@@ -389,6 +396,7 @@ export async function sourcingCommand(
     unverifiable: 0,
     outdated: 0,
     partial: 0,
+    not_applicable: 0,
     errors: 0,
     storageErrors: 0,
     results: [],

--- a/crux/commands/sourcing-wiki-pages.ts
+++ b/crux/commands/sourcing-wiki-pages.ts
@@ -81,6 +81,13 @@ interface PageSourcingResult {
   unverifiable: number;
   outdated: number;
   partial: number;
+  /**
+   * QUA-426: present for completeness so `result[verdict]++` type-checks
+   * over the full SourcingVerdict union. Wiki-page claim verification does
+   * not run the pre-LLM relevance gate (which only fires for record-kind
+   * items in item-verifier.ts), so this counter should stay at 0 in practice.
+   */
+  not_applicable: number;
   errors: number;
   /**
    * Number of times an evidence/verdict storage call failed (issue #4017).
@@ -413,6 +420,7 @@ async function processPage(
     unverifiable: 0,
     outdated: 0,
     partial: 0,
+    not_applicable: 0,
     errors: 0,
     storageErrors: 0,
     claimResults: [],

--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -25,6 +25,7 @@ import {
 import { matchRecordAgainstSnapshot } from './deterministic-matcher.ts';
 import { tryWikidataMatch } from './wikidata-matcher.ts';
 import { searchForEntity } from './item-collectors.ts';
+import { isRelevanceGateEnabled, runRelevanceGate } from './relevance-gate.ts';
 import type {
   VerifyItem,
   VerifyResult,
@@ -399,6 +400,31 @@ export async function verifySingleItem(
   // At this point, sourceUrl and sourceContent are guaranteed to be defined
   // (all paths without them return early above)
   const verifiedSourceUrl: string = sourceUrl!;
+
+  // ── Relevance gate (QUA-426) ────────────────────────────────────────
+  // If the source content doesn't even mention the record's subject, skip
+  // the LLM call and record a `not_applicable` verdict. This catches the
+  // "personnel record pointed at the org homepage" case where the LLM would
+  // otherwise return `unverifiable 0.95` and pollute the record's rollup.
+  //
+  // Gated behind RELEVANCE_GATE_ENABLED to allow a fast rollback if the
+  // false-negative rate is unexpectedly high in the real corpus.
+  if (item.data.kind === 'record' && isRelevanceGateEnabled()) {
+    const gate = runRelevanceGate(item.data, sourceContent);
+    if (!gate.passed) {
+      return {
+        itemId: item.id,
+        kind: item.kind,
+        description: item.description,
+        verdict: 'not_applicable' as SourcingVerdict,
+        confidence: 1.0,
+        extractedValue: '',
+        reasoning: `[relevance_gate] ${gate.reason}`,
+        sourceUrl: verifiedSourceUrl,
+        checkerModel: 'relevance-gate',
+      };
+    }
+  }
 
   // Build the appropriate prompt
   let prompt: string;

--- a/crux/lib/sourcing/orchestrator-types.ts
+++ b/crux/lib/sourcing/orchestrator-types.ts
@@ -115,6 +115,13 @@ export interface OrchestrationSummary {
   unverifiable: number;
   outdated: number;
   partial: number;
+  /**
+   * QUA-426: pre-LLM relevance-gate short-circuits. These items never
+   * reached the LLM because the source content didn't mention the record's
+   * subject, so no signal is possible — distinct from `unverifiable`
+   * (which means the LLM read it and couldn't decide).
+   */
+  not_applicable: number;
   errors: number;
   /** Number of items skipped because source URL is dead (subset of unverifiable) */
   deadLinks: number;

--- a/crux/lib/sourcing/orchestrator.ts
+++ b/crux/lib/sourcing/orchestrator.ts
@@ -215,6 +215,7 @@ export async function orchestrateCommand(
     unverifiable: 0,
     outdated: 0,
     partial: 0,
+    not_applicable: 0,
     errors: 0,
     deadLinks: 0,
     storageErrors: 0,

--- a/crux/lib/sourcing/relevance-gate.test.ts
+++ b/crux/lib/sourcing/relevance-gate.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the pre-LLM relevance gate (QUA-426).
+ *
+ * Covers:
+ * - Subject extraction per record type
+ * - Content normalization (case, unicode, whitespace)
+ * - Short-content bypass
+ * - Short-subject bypass
+ * - Missing-anchor pass-through
+ * - Positive / negative match cases
+ * - The env-flag helper
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  extractSubjects,
+  normalizeForMatch,
+  runRelevanceGate,
+  isRelevanceGateEnabled,
+} from './relevance-gate.ts';
+import type { RecordItemData } from './orchestrator-types.ts';
+
+function personnel(
+  person: string | null,
+  org: string | null,
+  entityDisplayName: string | null = null,
+): RecordItemData {
+  return {
+    kind: 'record',
+    recordType: 'personnel',
+    recordId: 'p_test',
+    fields: { person, org, role: 'CEO' },
+    entityId: 'e_test',
+    displayName: `${person ?? 'x'} at ${org ?? 'x'}`,
+    entityDisplayName,
+  };
+}
+
+function grant(
+  grantee: string | null,
+  funder: string | null,
+  name: string | null,
+): RecordItemData {
+  return {
+    kind: 'record',
+    recordType: 'grant',
+    recordId: 'g_test',
+    fields: { grantee, funder, name, amount: 1000000, date: null },
+    entityId: 'e_test',
+    displayName: name,
+    entityDisplayName: funder,
+  };
+}
+
+describe('normalizeForMatch', () => {
+  it('lowercases and trims whitespace', () => {
+    expect(normalizeForMatch('  Anthropic Inc.  ')).toBe('anthropic inc.');
+  });
+
+  it('collapses multiple whitespace runs', () => {
+    expect(normalizeForMatch('foo   bar\n\tbaz')).toBe('foo bar baz');
+  });
+
+  it('does NOT strip diacritics (keeps CJK/accented matches faithful)', () => {
+    // Stripping would make "Lê Viết Quốc" match "Le Viet Quoc" — a false positive
+    // when the source is a different person with the ASCII name.
+    expect(normalizeForMatch('Lê Viết Quốc')).toBe('lê viết quốc');
+  });
+
+  it('applies NFC normalization so composed and decomposed forms collide', () => {
+    // "é" can be represented as U+00E9 or as U+0065 + U+0301.
+    const composed = '\u00e9clair'; // é
+    const decomposed = 'e\u0301clair'; // e + ◌́
+    expect(normalizeForMatch(composed)).toBe(normalizeForMatch(decomposed));
+  });
+});
+
+describe('extractSubjects — personnel', () => {
+  it('returns person + org when both are resolvable', () => {
+    const s = extractSubjects(personnel('Amanda Askell', 'Anthropic'));
+    expect(s).toEqual(['Amanda Askell', 'Anthropic']);
+  });
+
+  it('drops the `(unknown)` sentinel', () => {
+    const s = extractSubjects(personnel('(unknown)', 'Anthropic'));
+    expect(s).toEqual(['Anthropic']);
+  });
+
+  it('drops stableId-shaped values that leaked through name resolution', () => {
+    const s = extractSubjects(personnel('sid_1LcLlMGLbw', 'Anthropic'));
+    expect(s).toEqual(['Anthropic']);
+  });
+
+  it('returns empty list when nothing is resolvable', () => {
+    const s = extractSubjects(personnel(null, null));
+    expect(s).toEqual([]);
+  });
+});
+
+describe('extractSubjects — grants', () => {
+  it('returns grantee + funder + grant title', () => {
+    const s = extractSubjects(
+      grant('Alice Researcher', 'Open Philanthropy', 'AI safety evals'),
+    );
+    expect(s).toContain('Alice Researcher');
+    expect(s).toContain('Open Philanthropy');
+    expect(s).toContain('AI safety evals');
+  });
+});
+
+describe('extractSubjects — record types without an extractor', () => {
+  it('returns an empty list for division', () => {
+    const data: RecordItemData = {
+      kind: 'record',
+      recordType: 'division',
+      recordId: 'd_test',
+      fields: { name: 'Frontier Research', type: 'research', status: 'active' },
+      entityId: 'e_test',
+    };
+    expect(extractSubjects(data)).toEqual([]);
+  });
+});
+
+describe('runRelevanceGate — pass-through cases', () => {
+  const longContent = 'a'.repeat(2000);
+
+  it('passes when the source content is too short to decide', () => {
+    const short = 'Short page with just one line.';
+    const result = runRelevanceGate(personnel('Amanda Askell', 'Anthropic'), short);
+    expect(result.passed).toBe(true);
+    expect(result.reason).toMatch(/short_content/);
+  });
+
+  it('passes when no subject can be extracted', () => {
+    const result = runRelevanceGate(personnel(null, null), longContent);
+    expect(result.passed).toBe(true);
+    expect(result.reason).toBe('no_subject_extracted');
+  });
+
+  it('passes when all subjects are too short to substring-match', () => {
+    const data = personnel('J', 'Wu');
+    const result = runRelevanceGate(data, longContent);
+    expect(result.passed).toBe(true);
+    expect(result.reason).toMatch(/no_matchable_subject/);
+  });
+});
+
+describe('runRelevanceGate — positive matches', () => {
+  it('passes when the person name appears in content', () => {
+    const content = `${'filler '.repeat(200)} Amanda Askell is the Character Lead at Anthropic. ${'more '.repeat(100)}`;
+    const result = runRelevanceGate(personnel('Amanda Askell', 'Anthropic'), content);
+    expect(result.passed).toBe(true);
+    expect(result.reason).toMatch(/matched:Amanda Askell/);
+  });
+
+  it('passes when only the org anchor is present (common-name fallback)', () => {
+    // Homepage-style content: mentions Anthropic a lot but not Amanda.
+    // This is the CASE THE TICKET CALLS OUT, but here Anthropic is still
+    // a valid anchor so we pass. Subject-specificity is the LLM's job —
+    // the gate only asks "is there any reason to even run it?"
+    const content = `${'Anthropic builds safer AI systems. '.repeat(50)}`;
+    const result = runRelevanceGate(personnel('Amanda Askell', 'Anthropic'), content);
+    expect(result.passed).toBe(true);
+    expect(result.reason).toMatch(/matched:Anthropic/);
+  });
+
+  it('is case-insensitive', () => {
+    const content = `${'x '.repeat(300)} amanda ASKELL is the character lead. ${'y '.repeat(100)}`;
+    const result = runRelevanceGate(personnel('Amanda Askell', 'Anthropic'), content);
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('runRelevanceGate — negative matches (the noise cases we want to kill)', () => {
+  it('fires when neither person nor org appears in long content', () => {
+    const content = `${'Content about something entirely different. '.repeat(100)}`;
+    const result = runRelevanceGate(personnel('Amanda Askell', 'Anthropic'), content);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toMatch(/no_subject_match/);
+    expect(result.subjects).toEqual(['Amanda Askell', 'Anthropic']);
+  });
+
+  it('fires on grant with no grantee/funder/title mentions', () => {
+    const content = `${'An article about climate change. '.repeat(100)}`;
+    const result = runRelevanceGate(
+      grant('Alice Researcher', 'Open Philanthropy', 'AI evals project'),
+      content,
+    );
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('isRelevanceGateEnabled', () => {
+  afterEach(() => {
+    delete process.env.RELEVANCE_GATE_ENABLED;
+  });
+
+  it('returns false by default', () => {
+    expect(isRelevanceGateEnabled()).toBe(false);
+  });
+
+  it('returns true when explicitly set to "true"', () => {
+    process.env.RELEVANCE_GATE_ENABLED = 'true';
+    expect(isRelevanceGateEnabled()).toBe(true);
+  });
+
+  it('returns true when set to "1"', () => {
+    process.env.RELEVANCE_GATE_ENABLED = '1';
+    expect(isRelevanceGateEnabled()).toBe(true);
+  });
+
+  it('returns false for other truthy-ish values', () => {
+    process.env.RELEVANCE_GATE_ENABLED = 'yes';
+    expect(isRelevanceGateEnabled()).toBe(false);
+  });
+});

--- a/crux/lib/sourcing/relevance-gate.ts
+++ b/crux/lib/sourcing/relevance-gate.ts
@@ -1,0 +1,200 @@
+/**
+ * Pre-LLM relevance gate — QUA-426.
+ *
+ * Before calling the LLM to verify a record against source content, check
+ * whether the source content even mentions the record's subject (person name,
+ * grantee name, company name, etc.). If it doesn't, short-circuit with a
+ * `not_applicable` verdict instead of burning LLM tokens on a page that
+ * obviously can't confirm or contradict the claim.
+ *
+ * Example this catches: the Amanda Askell personnel record pointed at
+ * `https://anthropic.com/` — the bare Anthropic homepage. The LLM would
+ * burn tokens reading the homepage and return `unverifiable 0.95`, adding
+ * a noise row to Amanda's rollup. The gate catches this pre-LLM: the
+ * homepage contains "Anthropic" but not "Amanda Askell", so the gate
+ * records `not_applicable` and moves on.
+ *
+ * The gate is disabled by default. Set `RELEVANCE_GATE_ENABLED=true` to
+ * turn it on. See ticket for rollout notes.
+ */
+
+import type { RecordItemData } from './orchestrator-types.ts';
+import { isAnySid } from '../../../packages/id-utils/src/index.ts';
+
+/**
+ * Pages shorter than this are treated as "not enough content to decide" —
+ * the gate passes and the LLM runs normally. Truncated or paywalled pages
+ * can legitimately mention the subject in a full version we didn't fetch.
+ */
+const MIN_CONTENT_LENGTH_FOR_GATE = 500;
+
+/**
+ * Subjects shorter than this (after normalization) are too common to
+ * substring-match reliably. "Wu", "Li", "Xu", "J" — false positive magnets.
+ * Subjects below the threshold are dropped from matching, and if nothing
+ * remains the gate passes (runs LLM).
+ */
+const MIN_SUBJECT_LENGTH = 3;
+
+export interface RelevanceGateResult {
+  /** True if the subject was found OR the gate couldn't decide — run the LLM. */
+  passed: boolean;
+  /** Human-readable reason, stored in evidence reasoning when the gate fires. */
+  reason: string;
+  /** Subjects that were extracted (for debugging / test assertions). */
+  subjects: string[];
+}
+
+/**
+ * Read the RELEVANCE_GATE_ENABLED env var. Returns false unless explicitly
+ * set to `true` / `1`. Kept as a function (not a module constant) so tests
+ * can flip the env between calls.
+ */
+export function isRelevanceGateEnabled(): boolean {
+  const v = process.env.RELEVANCE_GATE_ENABLED;
+  return v === 'true' || v === '1';
+}
+
+/**
+ * Normalize a string for substring matching:
+ * - Unicode NFC (collapses composed vs. decomposed forms)
+ * - lowercase
+ * - collapse whitespace
+ *
+ * We intentionally do NOT strip diacritics — "Lê Viết Quốc" should not
+ * falsely match "Le Viet Quoc", and stripping would double the false-match
+ * surface without a corresponding correctness win for the AI-safety corpus.
+ */
+export function normalizeForMatch(s: string): string {
+  return s.normalize('NFC').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Extract the list of subject anchor strings for a record.
+ *
+ * Each string is a candidate "does the source mention this" anchor. The
+ * gate passes if ANY anchor is found. Multiple anchors handle the common
+ * case of ambiguous personal names ("Wei Li") where the org provides
+ * disambiguation, and also the case where display fields are sometimes
+ * null — returning an empty list when nothing resolvable is available.
+ *
+ * Stable-ID-shaped strings and the literal `(unknown)` sentinel are
+ * filtered out. The LLM path can't match on "sid_1LcLlMGLbw" anyway, so
+ * dropping them just prevents false negatives when unresolved names leak
+ * through from item collection.
+ */
+export function extractSubjects(data: RecordItemData): string[] {
+  const out: string[] = [];
+  const push = (value: unknown): void => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return;
+    if (trimmed === '(unknown)') return;
+    if (isAnySid(trimmed)) return;
+    out.push(trimmed);
+  };
+
+  const f = data.fields;
+  switch (data.recordType) {
+    case 'personnel':
+      // Primary: person name. Secondary: org (disambiguates common names).
+      push(f.person);
+      push(f.org);
+      break;
+    case 'grant':
+      // grantee + funder + grant title; any one is enough
+      push(f.grantee);
+      push(f.funder);
+      push(f.name);
+      break;
+    case 'funding-round':
+      // Round name ("Series B") is useless alone; pair with company via entityDisplayName.
+      push(data.entityDisplayName);
+      push(f.name);
+      break;
+    case 'investment':
+      // Investment fields don't include names today (amount/round/role only);
+      // fall back to entityDisplayName (investor) as the single anchor.
+      push(data.entityDisplayName);
+      break;
+    case 'benchmark-result':
+      // modelId + benchmarkId are the paper-title-like strings the source
+      // would mention. Both are acceptable anchors.
+      push(f.modelId);
+      push(f.benchmarkId);
+      break;
+    default:
+      // Record types without subject extractors (division, funding-program,
+      // equity-position, policy-stakeholder, publication, entity-event, etc.)
+      // return an empty list so the gate passes and the LLM runs as before.
+      break;
+  }
+
+  return out;
+}
+
+/**
+ * Run the relevance gate against a single source-content payload.
+ *
+ * Returns `passed: true` (run the LLM) in these cases:
+ * - No extractable subject (we have no anchor to check against)
+ * - Content is too short (<500 chars) — may be a truncated scrape
+ * - All extracted subjects are too short to substring-match safely
+ * - Any subject anchor is present in the content
+ *
+ * Returns `passed: false` (short-circuit with `not_applicable`) only when:
+ * - There is at least one long-enough subject AND
+ * - None of the subjects appear in the (long-enough) content
+ */
+export function runRelevanceGate(
+  data: RecordItemData,
+  content: string,
+): RelevanceGateResult {
+  const subjects = extractSubjects(data);
+
+  if (subjects.length === 0) {
+    return {
+      passed: true,
+      reason: 'no_subject_extracted',
+      subjects,
+    };
+  }
+
+  if (content.length < MIN_CONTENT_LENGTH_FOR_GATE) {
+    return {
+      passed: true,
+      reason: `short_content (${content.length} chars)`,
+      subjects,
+    };
+  }
+
+  const normalizedContent = normalizeForMatch(content);
+  const matchable = subjects.filter(
+    (s) => normalizeForMatch(s).length >= MIN_SUBJECT_LENGTH,
+  );
+
+  if (matchable.length === 0) {
+    return {
+      passed: true,
+      reason: 'no_matchable_subject (all subjects too short)',
+      subjects,
+    };
+  }
+
+  for (const subject of matchable) {
+    const normalized = normalizeForMatch(subject);
+    if (normalizedContent.includes(normalized)) {
+      return {
+        passed: true,
+        reason: `matched:${subject}`,
+        subjects,
+      };
+    }
+  }
+
+  return {
+    passed: false,
+    reason: `no_subject_match (subjects=${matchable.join(' | ')})`,
+    subjects,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a pre-LLM "does this source content even mention the subject?" check to
`item-verifier.ts`, so record source-checks short-circuit to a new
`not_applicable` verdict when the fetched source doesn't reference the
record at all — instead of spending tokens on an LLM call that can only
come back as `unverifiable 0.95`.

The concrete case from the ticket: personnel record `19jgFufwBc` (Amanda
Askell at Anthropic) had `anthropic.com/` attached as a source. The
homepage doesn't name her, so the LLM burned tokens reading boilerplate
and stored noise in the record's rollup. The gate catches this pre-LLM.

**Gated behind `RELEVANCE_GATE_ENABLED=true`** — default off so this PR is
dark. Flip the env var and run against a sample to collect kill rate
before defaulting on.

## What's in here

- **New `crux/lib/sourcing/relevance-gate.ts`** — pure functions for
  `extractSubjects()`, `normalizeForMatch()`, `runRelevanceGate()`,
  `isRelevanceGateEnabled()`. Per-record-type extractors for personnel,
  grant, funding-round, investment, benchmark-result. NFC normalization,
  case-insensitive, does not strip diacritics.
- **Wire-in**: `item-verifier.ts::verifySingleItem()` calls the gate
  between `fetchSourceContent()` and `callLlmForSourcing()` for
  record-kind items only. Facts bypass the gate.
- **New verdict**: `not_applicable` added to `VALID_SOURCE_CHECK_VERDICTS`,
  sourcing routes' `VALID_VERDICTS` / `VALID_VERDICT_TYPES`, and both
  DB `CHECK` constraints.
- **Migration 0180**: rewrites both source-check CHECK constraints using
  the `NOT VALID` + `VALIDATE CONSTRAINT` pattern from
  `.claude/rules/database-migrations.md`. `source_check_evidence` is the
  heavy-write table — avoiding `ACCESS EXCLUSIVE` under load prevents a
  QUA-302-class deploy block.
- **Rollup semantics**: `/entity-summary`, `/coverage`, `/coverage-matrix`
  exclude `not_applicable` from "checked" counts so gate short-circuits
  don't inflate coverage dashboards.
- **Display**: `recordVerdictToStatus()` maps `not_applicable` to the
  neutral `not_run` state (grey dot, "Not checked"), not `trouble`.
  `pickWorstVerdict()` naturally drops it (unknown values fall through
  `VERDICT_SEVERITY`).
- **Type safety**: `OrchestrationSummary`, `SourcingSummary`,
  `PageSourcingResult` each gain a `not_applicable` counter so
  `summary[verdict]++` type-checks over the full union. Facts and wiki
  claims never reach the gate, so these counters stay at 0 in practice.

## Test plan

- [x] `crux/lib/sourcing/relevance-gate.test.ts` — 22 tests covering
      normalization (case, whitespace, NFC, diacritics preserved),
      subject extraction per record type (unknown-sentinel + sid_ filter),
      short-content bypass, short-subject bypass, positive matches
      (person / org-fallback / case-insensitive), negative matches,
      env-flag defaults.
- [x] `apps/web/src/components/sourcing/__tests__/sourcing-status.test.ts`
      — new 5-test file locking in `not_applicable → not_run`.
- [x] `apps/wiki-server/src/__tests__/api-types-record-id.test.ts` —
      existing test updated with a new assertion that
      `VALID_SOURCE_CHECK_VERDICTS` contains `not_applicable`.
- [x] Full vitest suites: 1579 web + 1145 wiki-server + 476 crux sourcing
      tests all pass.
- [x] TypeScript: wiki-server clean, web clean, crux at baseline 69.
- [x] Content-scope gate check passes.
- [ ] **Post-merge**: set `RELEVANCE_GATE_ENABLED=true` and run
      `crux sourcing-orchestrate --table=personnel --limit=50` against
      currently-unverifiable records. Report kill rate + false-negative
      rate in QUA-426.

## Rollout plan

1. Deploy with `RELEVANCE_GATE_ENABLED` unset. Verify migration 0180
   applies cleanly — both `NOT VALID` additions are metadata-only
   (milliseconds), and `VALIDATE CONSTRAINT` succeeds because the new
   value set is a strict superset of the old one.
2. Set `RELEVANCE_GATE_ENABLED=true` in the crux orchestrator env and
   run one targeted `personnel --limit=50` pass.
3. Grep the output for `[relevance_gate]` reasonings. The gate is
   intentionally liberal (any anchor match passes), so false-negative
   rate should be near zero.
4. Report kill rate in the ticket. If acceptable, flip the default in
   `isRelevanceGateEnabled()` to return true unless explicitly disabled.

## Out of scope

- Running the 50-record sample against prod (post-merge op step).
- Smart subject extraction for investment records that lack a company
  name on the item payload (falls back to the investor name via
  `entityDisplayName`; can be revisited if false-positive rate hurts).
- Adding a `not_applicable` column to the verdict-matrix dashboard view
  (currently it'll just be a missing column, which is fine).

## Deploy Checklist

- [ ] `migration` Verify migration 0180 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `manual` Verify the two source-check CHECK constraints include `not_applicable` — `psql "$DATABASE_URL" -c "\\d+ source_check_evidence" | grep chk_source_check_evidence_verdict`
- [ ] `manual` After the gate is flipped on, spot-check `/api/sourcing/entity-summary` still returns sensible counts (should EXCLUDE `not_applicable` rows from all 6 buckets and the `total_verdicts` field)

Fixes QUA-426
