### PR TITLE
test(wiki-server): unbrick 19 orphaned sourcing-enforcement tests (QUA-477)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import { enforceSourcing } from '../sourcing-enforcement.js';
+import { enforceSourcing } from '../routes/shared/sourcing-enforcement.js';
 
 // Helper to create a minimal Hono test context with a given table name
 function createTestApp(tableName = 'personnel') {


### PR DESCRIPTION
## Summary

One-file move that unbricks 19 previously-unrun tests.

`apps/wiki-server/src/routes/shared/__tests__/sourcing-enforcement.test.ts` existed but didn't match vitest's `include` glob (`src/__tests__/**/*.test.ts`), so none of its tests were executing. Noticed while adding `format-money.test.ts` in another session — that new file hit the same trap before I moved it.

## What changes

- `git mv apps/wiki-server/src/routes/shared/__tests__/sourcing-enforcement.test.ts → apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts`
- Adjust the one affected import: `'../sourcing-enforcement.js'` → `'../routes/shared/sourcing-enforcement.js'`

No source code changes. No test behavior changes. Purely making existing tests runnable.

## Before / after

- Before: `pnpm test sourcing-enforcement` → 0 tests found, exit 1
- After: `pnpm test sourcing-enforcement` → 19 tests passing

## Why it matters

The 19 tests cover `enforceSourcing`:
- Table allowlist behavior (personnel/grants/investments/etc. vs ignored tables)
- Bypass-via-flag gating (`forceSkipSourcing` reason logging)
- Empty-array handling
- Nested sourcing payload support
- Error shapes

They represent real coverage that was silently absent. Some of this ground is re-tested in other files, but not exhaustively.

## Test plan

- [x] `pnpm test sourcing-enforcement` (apps/wiki-server) — 19 passed
- [x] `pnpm test` (apps/wiki-server full) — 1132 passed (was 1113 without the move, +19)
- [x] No type changes → tsc clean

## Follow-up

Meta: the existence of `src/routes/**/__tests__/` directories that vitest doesn't scan is a trap waiting to catch the next author. Worth a broader sweep in a follow-up — either broaden the include glob or remove the empty `__tests__` sub-directories. Filed tracking note on QUA-477 for that discussion. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-477
