### PR TITLE
fix(things): address CodeRabbit findings on QUA-470 composer PR

### DIFF
--- a/apps/wiki-server/src/__tests__/personnel-composer.test.ts
+++ b/apps/wiki-server/src/__tests__/personnel-composer.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
+import { generateSid } from "@longterm-wiki/id-utils";
 import { composeThing, hasComposer } from "../routes/shared/compose-thing.js";
 
 // IMPORTANT: importing the personnel route registers the composer as a side
@@ -40,15 +41,19 @@ describe("personnel composer (QUA-470)", () => {
 
   describe("4-step person-name fallback", () => {
     it("step 1: titleMap entry for personEntityId wins", () => {
+      // Use generated SIDs so the test exercises real stableId shape, not a
+      // hand-rolled literal. Per CLAUDE.md: never manually invent IDs.
+      const personSid = generateSid();
+      const personIdRaw = generateSid();
       const row: PersonnelRow = {
-        personId: "sid_abc1234567",
+        personId: personIdRaw,
         personDisplayName: "Display Name",
-        personEntityId: "sid_xyz9876543",
+        personEntityId: personSid,
         role: "CEO",
         organizationId: "anthropic",
       };
       const titleMap = new Map([
-        ["sid_xyz9876543", "Dario Amodei"],
+        [personSid, "Dario Amodei"],
         ["anthropic", "Anthropic"],
       ]);
       const result = composeThing<PersonnelRow>("personnel", row, titleMap);
@@ -58,9 +63,9 @@ describe("personnel composer (QUA-470)", () => {
 
     it("step 2: falls back to personDisplayName when entity not in titleMap", () => {
       const row: PersonnelRow = {
-        personId: "sid_abc1234567",
+        personId: generateSid(),
         personDisplayName: "Display Name",
-        personEntityId: "sid_xyz9876543",
+        personEntityId: generateSid(),
         role: "CTO",
         organizationId: "openai",
       };
@@ -71,7 +76,7 @@ describe("personnel composer (QUA-470)", () => {
 
     it("step 2: falls back to personDisplayName when personEntityId is null", () => {
       const row: PersonnelRow = {
-        personId: "sid_abc1234567",
+        personId: generateSid(),
         personDisplayName: "Display Name",
         personEntityId: null,
         role: "Engineer",
@@ -113,8 +118,9 @@ describe("personnel composer (QUA-470)", () => {
       // This is the documented leak path — preserved by the prototype because
       // Phase 4b-B.1 is a refactor-only step. Phase 4b-B.2 will eliminate it
       // by computing titles at read time.
+      const bareSid = generateSid();
       const row: PersonnelRow = {
-        personId: "sid_abc1234567",
+        personId: bareSid,
         personDisplayName: null,
         personEntityId: null,
         role: "Researcher",
@@ -123,7 +129,7 @@ describe("personnel composer (QUA-470)", () => {
       const titleMap = new Map([["openai", "OpenAI"]]);
       const result = composeThing<PersonnelRow>("personnel", row, titleMap);
       // cleanPersonId returns null for sid_, so we fall through to personId itself.
-      expect(result.title).toBe("sid_abc1234567 — Researcher at OpenAI");
+      expect(result.title).toBe(`${bareSid} — Researcher at OpenAI`);
     });
   });
 

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, desc, sql } from "drizzle-orm";
+import { eq, count, desc, sql, inArray } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { benchmarkResults, benchmarks } from "../../schema.js";
 import {
@@ -207,10 +207,22 @@ const benchmarkResultsApp = new Hono()
         }
         return null;
       },
-      // QUA-470: pre-resolve model + benchmark titles for the composer.
-      thingsTitleIds: (items) => [
-        ...new Set(items.flatMap((it) => [it.modelId, it.benchmarkId])),
-      ],
+      // QUA-470: pre-resolve model titles via entities (modelId is an entity
+      // slug/stableId) and benchmark titles via the benchmarks table through
+      // augmentTitleMap (benchmarkId points at benchmarks, NOT entities —
+      // resolveEntityTitles would silently miss it).
+      thingsTitleIds: (items) => [...new Set(items.map((it) => it.modelId))],
+      augmentTitleMap: async (tx, items, titleMap) => {
+        const benchmarkIds = [
+          ...new Set(items.map((i) => i.benchmarkId)),
+        ].filter((id): id is string => !!id);
+        if (benchmarkIds.length === 0) return;
+        const rows = await tx
+          .select({ id: benchmarks.id, name: benchmarks.name })
+          .from(benchmarks)
+          .where(inArray(benchmarks.id, benchmarkIds));
+        for (const r of rows) titleMap.set(r.id, r.name);
+      },
       toThing: (item, titleMap) => {
         const composed = composeThing<BenchmarkResultComposerRow>(
           "benchmark-result",

--- a/apps/wiki-server/src/routes/tablebase/division-personnel.ts
+++ b/apps/wiki-server/src/routes/tablebase/division-personnel.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, sql, desc } from "drizzle-orm";
+import { eq, count, sql, desc, inArray } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { divisionPersonnel } from "../../schema.js";
+import { divisionPersonnel, divisions } from "../../schema.js";
 import {
   paginationQuery,
   zv,
@@ -194,10 +194,20 @@ const divisionPersonnelApp = new Hono()
       syncedAt: sql`now()`,
       updatedAt: sql`now()`,
     },
-    // QUA-470: pre-resolve person + division titles for the composer.
-    thingsTitleIds: (items) => [
-      ...new Set(items.flatMap((it) => [it.personId, it.divisionId])),
-    ],
+    // QUA-470: personId resolves via entities, but divisionId points at the
+    // divisions table. Use augmentTitleMap to fetch division names directly.
+    thingsTitleIds: (items) => [...new Set(items.map((it) => it.personId))],
+    augmentTitleMap: async (tx, items, titleMap) => {
+      const divisionIds = [
+        ...new Set(items.map((i) => i.divisionId)),
+      ].filter((id): id is string => !!id);
+      if (divisionIds.length === 0) return;
+      const rows = await tx
+        .select({ id: divisions.id, name: divisions.name })
+        .from(divisions)
+        .where(inArray(divisions.id, divisionIds));
+      for (const r of rows) titleMap.set(r.id, r.name);
+    },
     toThing: (item, titleMap) => {
       const composed = composeThing<DivisionPersonnelComposerRow>(
         "division-personnel",

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -26,7 +26,15 @@ interface EntityResourceComposerRow {
 // resourceIds and entityIds use different prefixes.
 registerComposer<EntityResourceComposerRow>("entity-resource", (row, titleMap) => ({
   title: titleMap.get(row.resourceId) ?? row.resourceId,
-  description: row.authoredByEntity ? "authored" : row.isSubject ? "about" : null,
+  // "linked" fallback keeps plain-link rows searchable. SyncItemSchema
+  // defaults both booleans to false, so the plain-link path is the common
+  // case; returning null would drop the relationship label entirely from
+  // things.description.
+  description: row.authoredByEntity
+    ? "authored"
+    : row.isSubject
+      ? "about"
+      : "linked",
   parentTitle: titleMap.get(row.entityId) ?? row.entityId,
 }));
 

--- a/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
+++ b/apps/wiki-server/src/routes/tablebase/funding-rounds.ts
@@ -32,21 +32,29 @@ interface FundingRoundComposerRow {
   leadInvestorDisplayName?: string | null;
 }
 
-registerComposer<FundingRoundComposerRow>("funding-round", (row, titleMap) => ({
-  title: row.name + (row.date ? ` (${row.date})` : ""),
-  description:
-    [
-      row.raised != null ? `raised ${formatMoney(row.raised, "USD")}` : null,
-      row.instrument,
-      row.leadInvestor
-        ? `led by ${row.leadInvestorDisplayName ?? row.leadInvestor}`
-        : null,
-    ]
-      .filter(Boolean)
-      .join(", ") || null,
-  parentTitle:
-    titleMap.get(row.companyId) ?? row.companyDisplayName ?? row.companyId,
-}));
+registerComposer<FundingRoundComposerRow>("funding-round", (row, titleMap) => {
+  // Normalize: prefer display name; fall back to the raw leadInvestor with
+  // the `new:` sentinel prefix stripped. Checking `leadInvestorDisplayName`
+  // independently catches rows where the display name was populated without
+  // a matching raw ID.
+  const leadInvestorName =
+    row.leadInvestorDisplayName ??
+    row.leadInvestor?.replace(/^new:\s*/, "").trim() ??
+    null;
+  return {
+    title: row.name + (row.date ? ` (${row.date})` : ""),
+    description:
+      [
+        row.raised != null ? `raised ${formatMoney(row.raised, "USD")}` : null,
+        row.instrument,
+        leadInvestorName ? `led by ${leadInvestorName}` : null,
+      ]
+        .filter(Boolean)
+        .join(", ") || null,
+    parentTitle:
+      titleMap.get(row.companyId) ?? row.companyDisplayName ?? row.companyId,
+  };
+});
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -252,8 +252,41 @@ export interface SyncConfig<TItem, TTable extends PgTable> {
   /**
    * Entity IDs to resolve to titles for the `parentTitle` field on things rows.
    * Default: empty (no titles resolved).
+   *
+   * Only resolves IDs from the `entities` table. If your route references
+   * non-entity tables (e.g. `benchmarks`, `divisions`), use `augmentTitleMap`
+   * to populate additional (id → title) pairs before `toThing` runs.
    */
   thingsTitleIds?: (items: TItem[]) => string[];
+
+  /**
+   * Hook for pre-resolving title-map entries from non-entity tables.
+   *
+   * Runs after `thingsTitleIds` → `resolveEntityTitles`, but before `toThing`.
+   * Called with the Drizzle transaction handle, the items batch, and the
+   * mutable `titleMap` that `toThing` will receive. Handlers use this to
+   * SELECT from their own reference tables (e.g. `benchmarks`, `divisions`)
+   * and merge `(id → title)` pairs into the map.
+   *
+   * Example (benchmark-results):
+   * ```ts
+   * augmentTitleMap: async (tx, items, titleMap) => {
+   *   const ids = [...new Set(items.map((i) => i.benchmarkId))];
+   *   const rows = await tx.select({ id: benchmarks.id, name: benchmarks.name })
+   *     .from(benchmarks)
+   *     .where(inArray(benchmarks.id, ids));
+   *   for (const r of rows) titleMap.set(r.id, r.name);
+   * }
+   * ```
+   *
+   * QUA-470: introduced for routes whose composers reference rows in domain
+   * tables that `resolveEntityTitles` doesn't know about.
+   */
+  augmentTitleMap?: (
+    tx: Tx,
+    items: TItem[],
+    titleMap: Map<string, string>,
+  ) => Promise<void>;
 
   // ---- Entity FK resolution (post-upsert backfill) ----
 
@@ -667,6 +700,11 @@ export function createSyncHandler<
             titleIds.length > 0
               ? await resolveEntityTitles(tx, titleIds)
               : new Map<string, string>();
+          // QUA-470: let handlers populate the title map from non-entity
+          // tables (benchmarks, divisions, etc.) before toThing composes.
+          if (config.augmentTitleMap) {
+            await config.augmentTitleMap(tx, items, titleMap);
+          }
           const thingsRows = items.map((item) => config.toThing!(item, titleMap));
           await upsertThingsInTx(tx, thingsRows);
         });

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -542,6 +542,8 @@ const resourcesApp = new Hono()
             id: resources.id,
             url: resources.url,
             title: resources.title,
+            summary: resources.summary,
+            stableId: resources.stableId,
           });
 
         results = upsertedRows.map((r) => ({ id: r.id, url: r.url }));
@@ -594,20 +596,46 @@ const resourcesApp = new Hono()
           WHERE id IN (${idList})
         `);
 
-        // Dual-write to things table via dispatch composer (QUA-470)
+        // Dual-write to things table via dispatch composer (QUA-470).
+        // Compose from the *persisted* row (not the request item) so partial
+        // batch updates that omit title/summary don't rewrite things.title
+        // back to the URL. The conflictSet uses COALESCE to preserve those
+        // fields; reading from .returning() mirrors that semantics.
+        const persistedById = new Map(upsertedRows.map((row) => [row.id, row]));
         await upsertThingsInTx(
           tx,
           items.map((r) => {
-            const composed = composeThing<ResourceComposerRow>("resource", r, new Map());
+            const persisted = persistedById.get(r.id);
+            if (!persisted) {
+              // Should not happen: every inserted/updated row is returned by
+              // onConflictDoUpdate. Fall back defensively to the request item
+              // rather than crashing the batch.
+              const composed = composeThing<ResourceComposerRow>("resource", r, new Map());
+              return {
+                id: r.stableId || r.id,
+                thingType: "resource" as const,
+                title: composed.title,
+                description: composed.description,
+                parentTitle: composed.parentTitle,
+                sourceTable: "resources",
+                sourceId: r.id,
+                sourceUrl: r.url,
+              };
+            }
+            const composed = composeThing<ResourceComposerRow>(
+              "resource",
+              persisted,
+              new Map(),
+            );
             return {
-              id: r.stableId || r.id,
+              id: persisted.stableId ?? persisted.id,
               thingType: "resource" as const,
               title: composed.title,
               description: composed.description,
               parentTitle: composed.parentTitle,
               sourceTable: "resources",
-              sourceId: r.id,
-              sourceUrl: r.url,
+              sourceId: persisted.id,
+              sourceUrl: persisted.url,
             };
           })
         );


### PR DESCRIPTION
## Summary

Six review findings from CodeRabbit on the merged [PR #4344](https://github.com/quantified-uncertainty/longterm-wiki/pull/4344) (QUA-470 Phase 4b-B.1). 3 MAJOR fixes real bugs, 3 MINOR are quality/correctness improvements. This follow-up carries them forward onto main (the review-fix commit landed after #4344 was already merged).

## Major fixes (3)

### 1. `benchmark-results`: `benchmarkId` resolves via `benchmarks`, not `entities`

`thingsTitleIds` fed into `resolveEntityTitles` only resolves rows from the `entities` table, but `benchmarkId` points at the `benchmarks` table. The composer was silently leaking raw benchmark slugs into `things.title` / `things.parent_title`.

**Fix**: extend `createSyncHandler` with a new `augmentTitleMap` hook that runs after `resolveEntityTitles` but before `toThing`. `benchmark-results.ts` now fetches benchmark names via `augmentTitleMap`, and `thingsTitleIds` returns only `modelId`.

### 2. `division-personnel`: `divisionId` resolves via `divisions`, not `entities`

Same class of bug — `divisionId` points at `divisions`, not `entities`. Now uses `augmentTitleMap` to fetch division names directly.

### 3. `wikibase/resources`: compose from persisted row, not request item

The bulk upsert uses `COALESCE` on `conflictSet` to preserve `title` / `summary` / `stableId` on partial batch updates. The original composer read from the request item, so a partial update that omitted those fields would rewrite `things.title` back to the URL. Also `r.stableId || r.id` would flip the `things.id` key on partial updates.

**Fix**: expand `.returning()` to include `summary` and `stableId`, build a `persistedById` Map, and compose from the persisted row. Use `persisted.stableId ?? persisted.id` for the thing key.

## Minor fixes (3)

### 4. `entity-resources`: `"linked"` fallback keeps plain-link rows searchable

`SyncItemSchema` defaults both booleans to `false`, so valid rows hit the "plain link" path. Returning `null` dropped the relationship label entirely. Use `"linked"` fallback.

### 5. `funding-rounds`: normalize `leadInvestor` name + strip `new:` sentinel

`leadInvestorDisplayName` can be populated independently of `leadInvestor`. The old branch only checked `leadInvestor`, so display-name-only rows lost the "led by" fragment. Also wrote raw `new:` sentinels into descriptions. Fix: normalize to a single `leadInvestorName` that prefers display name, strips `^new:\s*`, and is checked for presence.

### 6. `personnel-composer.test.ts`: use `generateSid()`, not hardcoded literals

Per CLAUDE.md rule. Five hardcoded `sid_abc1234567` literals replaced with `generateSid()` calls from `@longterm-wiki/id-utils`.

## Factory extension

New optional `augmentTitleMap(tx, items, titleMap)` hook on `createSyncHandler`. Runs in Phase 6 between `resolveEntityTitles` and `toThing`, lets handlers populate `(id → title)` pairs from non-entity tables. Additive and backward-compatible.

## Risk

Low. The 3 major fixes are bug corrections (composer would leak raw IDs without them). The `augmentTitleMap` hook is additive — existing handlers behave identically to before.

## Test plan

- [x] `pnpm test` (apps/wiki-server) — 1188 passed, 0 regressions
- [x] `pnpm test personnel-composer compose-thing composer-coverage` — 25 passed
- [x] `npx tsc --noEmit` (wiki-server) — clean
- [x] `pnpm crux w validate gate` — 49/49 passed

## References

- Parent PR: [#4344](https://github.com/quantified-uncertainty/longterm-wiki/pull/4344) (QUA-470)
- Epic: [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408)
- Follow-up: [QUA-476](https://linear.app/quantifieduncertainty/issue/QUA-476) Phase 4b-B.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-470
