### PR TITLE
refactor(tablebase): auto-mount routes from registry (QUA-454)

### DIFF
--- a/apps/wiki-server/src/__tests__/mount-registry.test.ts
+++ b/apps/wiki-server/src/__tests__/mount-registry.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Coverage check for QUA-454: the tablebase mount registry must stay in
+ * sync with the filesystem. This test is the regression gate that
+ * prevents a new tablebase route file from being added without also
+ * registering it (the exact "route file exists but never wired into
+ * app.ts" drift QUA-454 exists to fix).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync } from "fs";
+import { join } from "path";
+import {
+  TABLEBASE_MOUNTS,
+  TABLEBASE_MANUAL_MOUNTS,
+} from "../routes/tablebase/mount-registry.js";
+
+// Route files that live in `routes/tablebase/` but are NOT Hono routes.
+// (Constants modules, internal helpers, the registry file itself, etc.)
+const NON_ROUTE_FILES = new Set<string>([
+  "index.ts",
+  "mount-registry.ts",
+  "sync-factory.ts",
+  "sync-factory.test-d.ts",
+  "sync-factory-flag.ts",
+  "sourcing-schema.ts",
+  "audit-log.ts",
+  "write-inline-verdicts.ts",
+  "entity-profile-descriptions.ts",
+]);
+
+const ROUTES_DIR = join(
+  new URL(".", import.meta.url).pathname,
+  "..",
+  "routes",
+  "tablebase",
+);
+
+function listRouteFiles(): string[] {
+  return readdirSync(ROUTES_DIR)
+    .filter(
+      (f) =>
+        f.endsWith(".ts") &&
+        !f.endsWith(".test.ts") &&
+        !f.endsWith(".test-d.ts") &&
+        !NON_ROUTE_FILES.has(f),
+    )
+    .map((f) => f.replace(/\.ts$/, ""))
+    .sort();
+}
+
+/** Path "/api/foo-bar" → filename "foo-bar". */
+function pathToFilename(mountPath: string): string {
+  return mountPath.replace(/^\/api\//, "");
+}
+
+describe("TABLEBASE_MOUNTS registry (QUA-454)", () => {
+  it("has no duplicate mount paths", () => {
+    const paths = TABLEBASE_MOUNTS.map((m) => m.path);
+    const unique = new Set(paths);
+    expect(paths).toHaveLength(unique.size);
+  });
+
+  it("every path starts with /api/ and is kebab-case", () => {
+    for (const { path } of TABLEBASE_MOUNTS) {
+      expect(path).toMatch(/^\/api\/[a-z][a-z0-9-]*$/);
+    }
+  });
+
+  it("every mount has a non-null route object", () => {
+    for (const { path, route } of TABLEBASE_MOUNTS) {
+      expect(route, `route for ${path}`).toBeDefined();
+      expect(route, `route for ${path}`).not.toBeNull();
+    }
+  });
+
+  it("registry + manual-mount list cover every route file on disk", () => {
+    const onDisk = new Set(listRouteFiles());
+    const registered = new Set(
+      TABLEBASE_MOUNTS.map((m) => pathToFilename(m.path)),
+    );
+    const manual = new Set<string>(TABLEBASE_MANUAL_MOUNTS);
+
+    // Routes on disk but in neither set → silent drift (QUA-454's failure mode #1)
+    const missing = [...onDisk].filter(
+      (f) => !registered.has(f) && !manual.has(f),
+    );
+    expect(missing, "route files missing from registry or manual list").toEqual([]);
+
+    // Entries in registry or manual list but not on disk → stale reference
+    const registeredOrManual = new Set([...registered, ...manual]);
+    const stale = [...registeredOrManual].filter((f) => !onDisk.has(f));
+    expect(stale, "registry entries pointing at nonexistent files").toEqual([]);
+  });
+
+  it("registry and manual-mount list are disjoint", () => {
+    const registered = new Set(
+      TABLEBASE_MOUNTS.map((m) => pathToFilename(m.path)),
+    );
+    const overlap = TABLEBASE_MANUAL_MOUNTS.filter((f) => registered.has(f));
+    expect(overlap, "routes listed in both auto-mount and manual-mount").toEqual([]);
+  });
+
+  it("contains at least 25 auto-mounted routes (regression guard)", () => {
+    // If this count drops below 25, someone probably accidentally moved
+    // routes into the manual list or deleted entries. Adjust only if you
+    // truly added an exclusion — and then update this number AND the
+    // mount-registry.ts header comment.
+    expect(TABLEBASE_MOUNTS.length).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -8,33 +8,16 @@ import {
   createDefaultRateLimiters,
 } from "./rate-limit.js";
 // TableBase routes — typed relational entity records
+// Most routes are mounted automatically via TABLEBASE_MOUNTS (QUA-454).
+// The 5 imports below are the ones mounted manually in this file because
+// they either have special semantics or serve as the cross-base index —
+// see `mount-registry.ts` header for the full rationale.
 import { entitiesRoute } from "./routes/tablebase/entities.js";
 import { idsRoute } from "./routes/tablebase/ids.js";
-import { personnelRoute } from "./routes/tablebase/personnel.js";
-import { peopleRoute } from "./routes/tablebase/people.js";
-import { grantsRoute } from "./routes/tablebase/grants.js";
-import { divisionsRoute } from "./routes/tablebase/divisions.js";
-import { divisionPersonnelRoute } from "./routes/tablebase/division-personnel.js";
-import { investmentsRoute } from "./routes/tablebase/investments.js";
-import { fundingRoundsRoute } from "./routes/tablebase/funding-rounds.js";
-import { equityPositionsRoute } from "./routes/tablebase/equity-positions.js";
-import { fundingProgramsRoute } from "./routes/tablebase/funding-programs.js";
-import { benchmarksRoute } from "./routes/tablebase/benchmarks.js";
-import { benchmarkResultsRoute } from "./routes/tablebase/benchmark-results.js";
 import { thingsRoute } from "./routes/tablebase/things.js";
-import { secondaryMarketPricesRoute } from "./routes/tablebase/secondary-market-prices.js";
-import { predictionMarketsRoute } from "./routes/tablebase/prediction-markets.js";
-import { politicalRacesRoute } from "./routes/tablebase/political-races.js";
-import { politicalScoresRoute } from "./routes/tablebase/political-scores.js";
-import { politicalOfficesRoute } from "./routes/tablebase/political-offices.js";
-import { politicalVotesRoute } from "./routes/tablebase/political-votes.js";
-import { campaignFinanceRoute } from "./routes/tablebase/campaign-finance.js";
 import { blueskyRoute } from "./routes/tablebase/bluesky.js";
-import { talentFlowsRoute } from "./routes/tablebase/talent-flows.js";
 import { dataSourcesRoute } from "./routes/tablebase/data-sources.js";
-import { platformAccountsRoute } from "./routes/tablebase/platform-accounts.js";
-import { coverageScansRoute } from "./routes/tablebase/coverage-scans.js";
-import { scannerResultsRoute } from "./routes/tablebase/scanner-results.js";
+import { TABLEBASE_MOUNTS } from "./routes/tablebase/mount-registry.js";
 
 // Unified sourcing system (replaces legacy factbase + record sourcing)
 import { sourcingRoute } from "./routes/sourcing/sourcing.js";
@@ -42,15 +25,6 @@ import { urlSuggestionsRoute } from "./routes/sourcing/url-suggestions.js";
 
 // Claims-first sourcing system (#3253)
 import { claimsRoute } from "./routes/claims/claims.js";
-import { researchAreasRoute } from "./routes/tablebase/research-areas.js";
-import { policyStakeholdersRoute } from "./routes/tablebase/policy-stakeholders.js";
-import { entityEventsRoute } from "./routes/tablebase/entity-events.js";
-import { entityAssessmentsRoute } from "./routes/tablebase/entity-assessments.js";
-import { publicationsRoute } from "./routes/tablebase/publications.js";
-import { websiteSourcesRoute } from "./routes/tablebase/website-sources.js";
-import { entityResourcesRoute } from "./routes/tablebase/entity-resources.js";
-import { entityProfileRoute } from "./routes/tablebase/entity-profile.js";
-import { recordLookupRoute } from "./routes/tablebase/record-lookup.js";
 
 // FactBase routes — structured triples with temporal data
 import { factsRoute } from "./routes/factbase/facts.js";
@@ -192,9 +166,24 @@ export function createApp() {
   // Routes are grouped by which data layer ("Base") they primarily serve.
   // See content/docs/internal/data-architecture.mdx for the Three Bases guide.
 
-  // TableBase routes — YAML entity/resource catalog
+  // TableBase routes — excluded from the auto-mount registry because each
+  // has bespoke concerns (see mount-registry.ts header). Everything else
+  // in tablebase/ is mounted via TABLEBASE_MOUNTS below.
   app.route("/api/ids", idsRoute);
   app.route("/api/entities", entitiesRoute);
+  app.route("/api/things", thingsRoute);
+  app.route("/api/bluesky", blueskyRoute);
+  app.route("/api/data-sources", dataSourcesRoute);
+
+  // TableBase routes — auto-mounted from the registry (QUA-454).
+  // Adding a new tablebase route? Append to `mount-registry.ts` — this
+  // loop picks it up on next restart. The registry test enforces that
+  // the set matches the filesystem.
+  for (const { path, route } of TABLEBASE_MOUNTS) {
+    app.route(path, route);
+  }
+
+  // WikiBase & shared routes that happen to live next to TableBase
   app.route("/api/resources", resourcesRoute);
   app.route("/api/summaries", summariesRoute);
   app.route("/api/links", linksRoute);
@@ -219,48 +208,8 @@ export function createApp() {
   // Claims-first sourcing (#3253)
   app.route("/api/claims", claimsRoute);
 
-  // Financial data routes (operational — personnel, grants, funding)
-  app.route("/api/personnel", personnelRoute);
-  app.route("/api/people", peopleRoute);
-  app.route("/api/grants", grantsRoute);
-  app.route("/api/funding-rounds", fundingRoundsRoute);
-  app.route("/api/investments", investmentsRoute);
-  app.route("/api/equity-positions", equityPositionsRoute);
-  app.route("/api/secondary-market-prices", secondaryMarketPricesRoute);
-  app.route("/api/prediction-markets", predictionMarketsRoute);
-  app.route("/api/political-races", politicalRacesRoute);
-  app.route("/api/political-scores", politicalScoresRoute);
-  app.route("/api/political-offices", politicalOfficesRoute);
-  app.route("/api/political-votes", politicalVotesRoute);
-  app.route("/api/campaign-finance", campaignFinanceRoute);
-  app.route("/api/bluesky", blueskyRoute);
-  app.route("/api/talent-flows", talentFlowsRoute);
-  app.route("/api/platform-accounts", platformAccountsRoute);
-  app.route("/api/divisions", divisionsRoute);
-  app.route("/api/division-personnel", divisionPersonnelRoute);
-  app.route("/api/funding-programs", fundingProgramsRoute);
-  app.route("/api/benchmarks", benchmarksRoute);
-  app.route("/api/benchmark-results", benchmarkResultsRoute);
-  app.route("/api/data-sources", dataSourcesRoute);
+  // WikiBase assessments (not in the TableBase registry — separate concern)
   app.route("/api/assessments", assessmentsRoute);
-
-  // Cross-Base: unified things index
-  app.route("/api/things", thingsRoute);
-  app.route("/api/research-areas", researchAreasRoute);
-  app.route("/api/policy-stakeholders", policyStakeholdersRoute);
-  app.route("/api/entity-events", entityEventsRoute);
-  app.route("/api/entity-assessments", entityAssessmentsRoute);
-  app.route("/api/publications", publicationsRoute);
-  app.route("/api/website-sources", websiteSourcesRoute);
-  app.route("/api/entity-resources", entityResourcesRoute);
-  app.route("/api/coverage-scans", coverageScansRoute);
-  app.route("/api/scanner-results", scannerResultsRoute);
-
-  // Aggregated entity profile (reads from all TableBase tables)
-  app.route("/api/entity-profile", entityProfileRoute);
-
-  // Single-record lookup by table + ID (for things detail views)
-  app.route("/api/record-lookup", recordLookupRoute);
 
 
   // Agent & session tracking (operational)

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -1,0 +1,144 @@
+/**
+ * TableBase route mount registry (QUA-454 Phase 1 of 3 replacing QUA-146).
+ *
+ * Centralizes the list of `{path, route}` pairs that `app.ts` mounts for
+ * TableBase routes. Replaces ~33 hand-written `.route()` calls in `app.ts`.
+ *
+ * Adding a new tablebase route: import it here and append one entry to
+ * `TABLEBASE_MOUNTS`. `app.ts` picks it up automatically on next restart.
+ *
+ * A validator (QUA-456) enforces that every route file on disk has a
+ * matching entry here and vice versa, so the registry can't silently drift
+ * from the filesystem.
+ *
+ * ## Exclusion list
+ *
+ * Five routes are deliberately mounted MANUALLY in `app.ts` rather than
+ * through this registry, matching the sync-factory exclusion list in
+ * `.claude/rules/tablebase-sync-factory.md`:
+ *
+ * - `entities` — slug displacement + statement_timeout overrides
+ * - `things` — IT IS the cross-base index
+ * - `bluesky` — only `/sync/:did`, no standard `/sync`
+ * - `data-sources` — multi-table writes per call
+ * - `ids` — sequence-based ID allocation
+ *
+ * Keeping these manual isolates any future deviation in their mount
+ * behavior (custom middleware, alternate path prefixes, etc.) from the
+ * common case.
+ */
+
+import type { Hono } from "hono";
+
+import { benchmarkResultsRoute } from "./benchmark-results.js";
+import { benchmarksRoute } from "./benchmarks.js";
+import { campaignFinanceRoute } from "./campaign-finance.js";
+import { coverageScansRoute } from "./coverage-scans.js";
+import { divisionPersonnelRoute } from "./division-personnel.js";
+import { divisionsRoute } from "./divisions.js";
+import { entityAssessmentsRoute } from "./entity-assessments.js";
+import { entityEventsRoute } from "./entity-events.js";
+import { entityProfileRoute } from "./entity-profile.js";
+import { entityResourcesRoute } from "./entity-resources.js";
+import { equityPositionsRoute } from "./equity-positions.js";
+import { fundingProgramsRoute } from "./funding-programs.js";
+import { fundingRoundsRoute } from "./funding-rounds.js";
+import { grantsRoute } from "./grants.js";
+import { investmentsRoute } from "./investments.js";
+import { peopleRoute } from "./people.js";
+import { personnelRoute } from "./personnel.js";
+import { platformAccountsRoute } from "./platform-accounts.js";
+import { policyStakeholdersRoute } from "./policy-stakeholders.js";
+import { politicalOfficesRoute } from "./political-offices.js";
+import { politicalRacesRoute } from "./political-races.js";
+import { politicalScoresRoute } from "./political-scores.js";
+import { politicalVotesRoute } from "./political-votes.js";
+import { predictionMarketsRoute } from "./prediction-markets.js";
+import { publicationsRoute } from "./publications.js";
+import { recordLookupRoute } from "./record-lookup.js";
+import { researchAreasRoute } from "./research-areas.js";
+import { scannerResultsRoute } from "./scanner-results.js";
+import { secondaryMarketPricesRoute } from "./secondary-market-prices.js";
+import { talentFlowsRoute } from "./talent-flows.js";
+import { websiteSourcesRoute } from "./website-sources.js";
+
+/**
+ * The widest Hono route type that still satisfies `app.route()`. Every
+ * concrete route file in this package declares something narrower (e.g.,
+ * `Hono<{ Variables: ResolvedEntityVars }, ...>` for the routes that use
+ * the `resolveEntityId` middleware, with a schema type inferred from each
+ * method-chain step), but they all assign to this shape because the
+ * generic parameters are unconstrained.
+ *
+ * Using `Hono` (no generics) would default to `Hono<BlankEnv, BlankSchema>`
+ * and reject narrowed variants — see the TS2322 errors QUA-454 hit on the
+ * first-attempt typing. Parameterizing on `any` is the idiomatic escape
+ * hatch for a mount-time heterogeneous collection.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHonoRoute = Hono<any, any, any>;
+
+/** A single tablebase route mount entry. */
+export interface TablebaseMount {
+  /** Absolute API path prefix (always starts with `/api/`). */
+  path: string;
+  /** The Hono route to mount at that path. */
+  route: AnyHonoRoute;
+}
+
+/**
+ * All TableBase routes mounted automatically by `app.ts`. Sorted by path
+ * for easier review. The 5 excluded routes (entities, things, bluesky,
+ * data-sources, ids) are NOT in this list — see the file header for why.
+ *
+ * Each route is declared narrowly (e.g. `Hono<Vars, ...>`). They widen to
+ * plain `Hono` through the structural-assignability rules — no runtime
+ * casts are needed.
+ */
+export const TABLEBASE_MOUNTS: readonly TablebaseMount[] = [
+  { path: "/api/benchmark-results", route: benchmarkResultsRoute },
+  { path: "/api/benchmarks", route: benchmarksRoute },
+  { path: "/api/campaign-finance", route: campaignFinanceRoute },
+  { path: "/api/coverage-scans", route: coverageScansRoute },
+  { path: "/api/division-personnel", route: divisionPersonnelRoute },
+  { path: "/api/divisions", route: divisionsRoute },
+  { path: "/api/entity-assessments", route: entityAssessmentsRoute },
+  { path: "/api/entity-events", route: entityEventsRoute },
+  { path: "/api/entity-profile", route: entityProfileRoute },
+  { path: "/api/entity-resources", route: entityResourcesRoute },
+  { path: "/api/equity-positions", route: equityPositionsRoute },
+  { path: "/api/funding-programs", route: fundingProgramsRoute },
+  { path: "/api/funding-rounds", route: fundingRoundsRoute },
+  { path: "/api/grants", route: grantsRoute },
+  { path: "/api/investments", route: investmentsRoute },
+  { path: "/api/people", route: peopleRoute },
+  { path: "/api/personnel", route: personnelRoute },
+  { path: "/api/platform-accounts", route: platformAccountsRoute },
+  { path: "/api/policy-stakeholders", route: policyStakeholdersRoute },
+  { path: "/api/political-offices", route: politicalOfficesRoute },
+  { path: "/api/political-races", route: politicalRacesRoute },
+  { path: "/api/political-scores", route: politicalScoresRoute },
+  { path: "/api/political-votes", route: politicalVotesRoute },
+  { path: "/api/prediction-markets", route: predictionMarketsRoute },
+  { path: "/api/publications", route: publicationsRoute },
+  { path: "/api/record-lookup", route: recordLookupRoute },
+  { path: "/api/research-areas", route: researchAreasRoute },
+  { path: "/api/scanner-results", route: scannerResultsRoute },
+  { path: "/api/secondary-market-prices", route: secondaryMarketPricesRoute },
+  { path: "/api/talent-flows", route: talentFlowsRoute },
+  { path: "/api/website-sources", route: websiteSourcesRoute },
+];
+
+/**
+ * Route files that are intentionally NOT auto-mounted. Kept in sync with
+ * the header comment and the manual mounts in `app.ts`. Exposed for the
+ * QUA-456 validator so it knows which files to exclude from the
+ * "every route file has a registry entry" check.
+ */
+export const TABLEBASE_MANUAL_MOUNTS = [
+  "entities",
+  "ids",
+  "things",
+  "bluesky",
+  "data-sources",
+] as const;

--- a/crux/validate/validate-tablebase-completeness.ts
+++ b/crux/validate/validate-tablebase-completeness.ts
@@ -113,6 +113,10 @@ const NON_ROUTE_FILES = new Set([
   "sync-factory.ts",
   "sync-factory-flag.ts",
   "sync-factory.test-d.ts",
+  // QUA-454: auto-mount registry. Imports routes, doesn't define them.
+  "mount-registry.ts",
+  // Column description overlay for entity-profile. Constants module, not a route.
+  "entity-profile-descriptions.ts",
 ]);
 
 // ── Analysis ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes QUA-454

## Summary

Part 1 of 3 replacing QUA-146 (Tablebase Route Systematization project). Extracts the ~33 hand-written `.route()` calls for TableBase routes in `apps/wiki-server/src/app.ts` into a new `TABLEBASE_MOUNTS` array in `apps/wiki-server/src/routes/tablebase/mount-registry.ts`. `app.ts` now iterates the array instead of listing routes individually.

## Why

Two real failure modes this eliminates:

1. **Route file exists but never wired into `app.ts`** → silent 404s in production. This has happened before — the fix was always "find the missing `.route()` call." Now the registry test catches it in CI.
2. **Silent drift between `crux/tablebase/table-registry.ts` and the filesystem** — a separate problem the QUA-456 follow-up validator will handle, but this PR makes the wiki-server-side mount table explicit and testable, which is prerequisite to that.

Net **−51 lines in app.ts** (289 → 238); 31 tablebase route mounts consolidated into one typed array + a `for` loop.

## Design

### `apps/wiki-server/src/routes/tablebase/mount-registry.ts` (new, 144 lines)

Exports `TABLEBASE_MOUNTS: readonly TablebaseMount[]` where each entry is `{ path: string; route: Hono<any, any, any> }`. The `any` generic parameters are the idiomatic escape hatch for a heterogeneous collection of narrowly-typed Hono routes — the first-attempt typing with `Hono` (default generics) failed TS2322 because routes that use `ResolvedEntityVars` env or method-chained schemas aren't structurally assignable to `Hono<BlankEnv, BlankSchema>`. Also exports `TABLEBASE_MANUAL_MOUNTS` — the list of route filenames that the registry test uses to compute the "on disk but not registered" drift set.

### `apps/wiki-server/src/app.ts`

Replaces ~33 lines of `app.route("/api/foo", fooRoute)` with:

```ts
for (const { path, route } of TABLEBASE_MOUNTS) {
  app.route(path, route);
}
```

Adds 5 manual mounts for the routes deliberately excluded from the registry:

```ts
app.route("/api/ids", idsRoute);
app.route("/api/entities", entitiesRoute);
app.route("/api/things", thingsRoute);
app.route("/api/bluesky", blueskyRoute);
app.route("/api/data-sources", dataSourcesRoute);
```

These match the sync-factory exclusion list in `.claude/rules/tablebase-sync-factory.md` — they have bespoke concerns (slug displacement on entities, cross-base indexing on things, non-standard sync path on bluesky, multi-table writes on data-sources, sequence-based ID allocation on ids).

### `apps/wiki-server/src/__tests__/mount-registry.test.ts` (new, 110 lines, **6 tests**)

The regression gate for QUA-454:

1. **no duplicate mount paths** — trivial sanity check, but cheap insurance
2. **every path starts with `/api/` and is kebab-case** — format lock
3. **every mount has a non-null route** — catches import-typo bugs
4. **registry + manual-mount list cover every route file on disk** — ***the core drift check***. Reads the filesystem, subtracts known non-route files (schemas, utilities, the registry itself), and asserts the set equals registered + manual. If this fails, either a new route file was added without a registry entry OR an entry was left pointing at a deleted file.
5. **registry and manual-mount list are disjoint** — no double-mount
6. **≥25 entries (regression guard)** — catches accidental deletion / mass moves into the manual list

### `crux/validate/validate-tablebase-completeness.ts`

Adds `mount-registry.ts` and `entity-profile-descriptions.ts` to `NON_ROUTE_FILES` so the completeness validator doesn't flag them as malformed routes. `entity-profile-descriptions.ts` is a pre-existing column description overlay for `entity-profile.ts` — not a route — and was silently ignored before; I'm adding it to the exclusion list now to prevent future confusion.

## Excluded routes — full list

The 5 routes mounted manually in `app.ts` (NOT in the registry):

| Route | Path | Reason for manual mount |
|---|---|---|
| `entities` | `/api/entities` | Slug displacement + statement_timeout overrides |
| `ids` | `/api/ids` | Sequence-based ID allocation (`nextval('entity_id_seq')`) |
| `things` | `/api/things` | IT IS the cross-base index — not a TableBase member |
| `bluesky` | `/api/bluesky` | Only has `/sync/:did` (external-API variant), no standard `/sync` |
| `data-sources` | `/api/data-sources` | Multi-table writes per call (resources + tabular_sources + snapshots) |

This list is mirrored in `mount-registry.ts` header, `TABLEBASE_MANUAL_MOUNTS`, and the test's `NON_ROUTE_FILES` set. The sync-factory exclusion list in `.claude/rules/tablebase-sync-factory.md` matches 1:1.

## What's NOT in this PR

- **Crux table-registry auto-mount**: the wiki-server registry is self-contained. QUA-456 (Part 3 of 3) will add a cross-file validator checking that the crux `TABLE_CONFIGS` set matches the wiki-server registry + manual list.
- **`crux tb scaffold <name>`**: QUA-455 (Part 2 of 3) is the generator that creates boilerplate for new entity types.
- **Non-tablebase routes**: sourcing, claims, pages, health, operational routes etc. are untouched. The scope of this PR is strictly the `routes/tablebase/*` directory.

## Test plan

- [x] `pnpm --filter wiki-server test` — **1194 passed** (was 1188 pre-PR; +6 new registry tests), 21 skipped
- [x] `pnpm --filter wiki-server typecheck` — clean
- [x] `pnpm build` — full web + data build succeeds
- [x] `pnpm crux w validate gate` — all 42 blocking gate checks pass
- [x] `npx tsx crux/validate/validate-tablebase-completeness.ts` — no blocking findings (mount-registry.ts correctly excluded)
- [x] Drift injection smoke-test: manually add a fake route file (`apps/wiki-server/src/routes/tablebase/fake-route.ts`) and confirm `mount-registry.test.ts` fails with a readable "route files missing from registry" error — *tested locally before commit*
- [ ] CI green on GitHub

## Follow-up

- **QUA-455**: `crux tb scaffold <name>` generator that creates the route file + registry entry + crux table-registry entry in one step, so adding a new entity type is a one-command operation.
- **QUA-456**: cross-file validator that pairs the wiki-server registry against the crux `TABLE_CONFIGS` registry, catching drift between the CLI's view of tablebase routes and the server's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to ensure tablebase route registry consistency with actual route files on disk.

* **Chores**
  * Refactored tablebase route registration system for improved maintainability and centralized route metadata management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->