### PR TITLE
fix(crux health): default to production + informative network errors (QUA-479)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ crux/coverage/
 .claude/worktree-cleanup.log
 .claude/worktrees/
 .claude/backups/
+.claude/scheduled_tasks.lock
 
 # MCP config (contains tokens)
 .mcp.json

--- a/crux/commands/health.ts
+++ b/crux/commands/health.ts
@@ -17,7 +17,7 @@ const SCRIPTS = {
   check: {
     script: 'health/health-check.ts',
     description: 'Run all wellness checks',
-    passthrough: ['ci', 'json', 'check', 'report', 'auto-issue', 'cleanup-labels'],
+    passthrough: ['ci', 'json', 'check', 'report', 'auto-issue', 'cleanup-labels', 'local'],
   },
 };
 
@@ -45,6 +45,8 @@ Options:
   --report        Aggregate markdown report to stdout
   --auto-issue    Manage GitHub wellness issue (create/update/close)
   --cleanup-labels Auto-remove stale working labels (>8 hours)
+  --local         Check a local dev server (localhost:3002) instead of production.
+                  Default behavior is to check production via PROD_LONGTERMWIKI_SERVER_URL. (QUA-479)
 
 Environment:
   LONGTERMWIKI_SERVER_URL        Wiki-server URL (required for most checks)

--- a/crux/health/health-check.test.ts
+++ b/crux/health/health-check.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for crux health helpers introduced in QUA-479:
+ *   - describeFetchError() turns opaque network errors into actionable messages
+ *   - fetchJson() surfaces errorDetail when the request can't even connect
+ *
+ * These tests exercise the error path without spinning up a real server, by
+ * pointing fetchJson at addresses that cannot possibly answer.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { describeFetchError, fetchJson } from './health-check.ts';
+
+describe('describeFetchError', () => {
+  it('classifies ECONNREFUSED and hints at --local for localhost targets', () => {
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:3002'), { code: 'ECONNREFUSED' }),
+    });
+
+    const msg = describeFetchError('http://localhost:3002/health', err);
+
+    expect(msg).toContain('http://localhost:3002/health');
+    expect(msg).toContain('ECONNREFUSED');
+    expect(msg).toContain('--local');
+    expect(msg).toContain('WIKI_SERVER_ENV');
+  });
+
+  it('classifies ECONNREFUSED without a localhost hint for remote targets', () => {
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+    });
+
+    const msg = describeFetchError('https://wiki-server.k8s.quantifieduncertainty.org/health', err);
+
+    expect(msg).toContain('ECONNREFUSED');
+    expect(msg).not.toContain('--local');
+    expect(msg).not.toContain('WIKI_SERVER_ENV');
+  });
+
+  it('classifies ENOTFOUND DNS failures', () => {
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('getaddrinfo ENOTFOUND does-not-exist.invalid'), { code: 'ENOTFOUND' }),
+    });
+
+    const msg = describeFetchError('https://does-not-exist.invalid/health', err);
+
+    expect(msg).toContain('DNS lookup failed');
+    expect(msg).toContain('ENOTFOUND');
+    expect(msg).toContain('does-not-exist.invalid');
+  });
+
+  it('classifies AbortSignal timeouts as TimeoutError', () => {
+    // AbortSignal.timeout() rejects with a DOMException named 'TimeoutError'.
+    const err = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    });
+
+    const msg = describeFetchError('https://wiki-server.k8s.quantifieduncertainty.org/health', err);
+
+    expect(msg).toContain('timed out');
+    expect(msg).toContain('15s');
+  });
+
+  it('classifies ECONNRESET', () => {
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+    });
+
+    const msg = describeFetchError('https://example.com/health', err);
+
+    expect(msg).toContain('ECONNRESET');
+    expect(msg).toContain('reset by peer');
+  });
+
+  it('falls back to a generic message for unknown errors', () => {
+    const err = new Error('something weird happened');
+
+    const msg = describeFetchError('https://example.com/health', err);
+
+    expect(msg).toContain('https://example.com/health');
+    expect(msg).toContain('network error');
+    expect(msg).toContain('something weird happened');
+  });
+
+  it('handles non-Error thrown values without crashing', () => {
+    const msg = describeFetchError('https://example.com/health', 'string error');
+
+    expect(msg).toContain('https://example.com/health');
+    expect(msg).toContain('string error');
+  });
+});
+
+describe('module import hygiene', () => {
+  it('does not mutate WIKI_SERVER_ENV when imported (only when dispatched as a script)', () => {
+    // The module sets WIKI_SERVER_ENV=prod at load time when invoked as a
+    // crux-dispatched script. Importing it for tests must NOT fire that side
+    // effect, or other tests that care about WIKI_SERVER_ENV (e.g.
+    // sync-session.test.ts, client.test.ts) see pollution across the worker.
+    // By the time this test runs, the module has already been imported above;
+    // if the guard worked, process.env.WIKI_SERVER_ENV is still whatever the
+    // test runner started with — crucially, not force-set to 'prod'.
+    const current = process.env.WIKI_SERVER_ENV;
+    // Either it's undefined/empty (normal test runner state) or it was set to
+    // something OTHER than 'prod' intentionally by the test harness. What must
+    // NOT happen is that an unset value became 'prod' purely from the import.
+    if (current === 'prod') {
+      // If it's 'prod', something else set it — verify process.argv[1] doesn't
+      // look like the health-check script, which would legitimately justify it.
+      expect(process.argv[1] ?? '').not.toMatch(/health[\\/-]?check/);
+    }
+  });
+});
+
+describe('fetchJson', () => {
+  it('returns ok:false with errorDetail when the target refuses the connection', async () => {
+    // 127.0.0.1:59_999 is an ephemeral-range port with no listener in test env.
+    // Node fetch reliably rejects with ECONNREFUSED, which the helper should
+    // classify and include in errorDetail.
+    const result = await fetchJson('http://127.0.0.1:59999/health');
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.data).toBeNull();
+    expect(result.errorDetail).toBeTruthy();
+    expect(result.errorDetail).toContain('127.0.0.1:59999');
+    expect(result.errorDetail).toContain('ECONNREFUSED');
+    // The host is a localhost target, so the --local hint should fire.
+    expect(result.errorDetail).toContain('--local');
+  }, 10_000);
+
+  it('returns ok:false with errorDetail when DNS resolution fails', async () => {
+    const result = await fetchJson('http://does-not-exist-qua-479.invalid/health');
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(result.errorDetail).toBeTruthy();
+    // Should mention the unresolvable hostname so the user can spot typos.
+    expect(result.errorDetail).toContain('does-not-exist-qua-479.invalid');
+  }, 10_000);
+});

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -10,7 +10,8 @@
  *   .github/workflows/ci-pr-health.yml
  *
  * Usage:
- *   crux health                      Run all checks
+ *   crux health                      Run all checks (against production)
+ *   crux health --local              Check local dev server instead of production
  *   crux health --check=server       Server & DB only
  *   crux health --check=api          API smoke tests only
  *   crux health --check=actions           GitHub Actions workflow health
@@ -24,6 +25,11 @@
  *   crux health --report             Aggregate markdown report to stdout
  *   crux health --auto-issue         Manage GitHub wellness issue
  *   crux health --cleanup-labels     Auto-remove stale working labels
+ *
+ * Note: `crux health` is unambiguously about production. The command
+ * defaults to WIKI_SERVER_ENV=prod so it works from any directory without
+ * the env-var prefix slots normally need. Pass `--local` to check a local
+ * dev server on localhost:3002 instead. See QUA-479.
  */
 
 import { getColors } from '../lib/output.ts';
@@ -39,12 +45,31 @@ import { buildWellnessReport, manageWellnessIssue } from './wellness-report.ts';
 // Config & types
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Detect whether this module is being executed directly (crux dispatch) vs
+// imported (tests). Must be computed before any top-level side effects so
+// importing the module for tests doesn't mutate process.env or kick off the
+// full health sweep. See the `main()` invocation at the bottom of the file.
+const INVOKED_AS_SCRIPT =
+  typeof process.argv[1] === 'string' && /health[\\/-]?check(?:\.ts|\.js|\.mjs)?$/.test(process.argv[1]);
+
 const args = process.argv.slice(2);
 const JSON_MODE = args.includes('--json') || args.includes('--ci');
 const CHECK_ARG = args.find((a) => a.startsWith('--check='))?.split('=')[1];
 const REPORT_MODE = args.includes('--report');
 const AUTO_ISSUE = args.includes('--auto-issue');
 const CLEANUP_LABELS = args.includes('--cleanup-labels');
+const LOCAL_MODE = args.includes('--local');
+
+// Default to production unless --local was passed (QUA-479). `crux health`
+// is semantically "is production healthy?", so it should work from any
+// directory (coord/, agent slots, worktrees) without requiring users to
+// remember `WIKI_SERVER_ENV=prod`. Respect an explicit pre-set value so
+// callers who set it themselves keep their choice. Gated on INVOKED_AS_SCRIPT
+// so importing this module from tests does not mutate process.env and
+// pollute other tests (sync-session.test.ts, client.test.ts both care).
+if (INVOKED_AS_SCRIPT && !LOCAL_MODE && !process.env.WIKI_SERVER_ENV) {
+  process.env.WIKI_SERVER_ENV = 'prod';
+}
 
 // Resolve wiki-server URL/API key via the shared client helpers so
 // WIKI_SERVER_ENV=prod (which reads PROD_LONGTERMWIKI_*) works here
@@ -86,7 +111,69 @@ export interface CheckResult {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function fetchJson(url: string, authHeader?: string): Promise<{ ok: boolean; status: number; data: unknown }> {
+export interface FetchJsonResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  /** Populated when status === 0 (network error). Human-readable diagnostic. */
+  errorDetail?: string;
+}
+
+/**
+ * Inspect a thrown error and build a diagnostic message for `fetchJson`.
+ * Exposed so the test suite can exercise it without spinning up a server.
+ *
+ * Converts opaque "HTTP 0" failures into an informative string covering:
+ *   - which URL failed
+ *   - the OS-level error code (ECONNREFUSED / ENOTFOUND / ETIMEDOUT / ...)
+ *   - the underlying error message
+ *   - a hint when the target looks like a local dev server (QUA-479)
+ */
+export function describeFetchError(url: string, err: unknown): string {
+  const isLocalTarget = /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(?::|\/|$)/i.test(url);
+
+  // AbortSignal.timeout() rejects with a DOMException named 'TimeoutError'.
+  const errName = err instanceof Error ? err.name : '';
+  if (errName === 'TimeoutError' || errName === 'AbortError') {
+    return `${url} timed out after 15s`;
+  }
+
+  // Node's fetch wraps undici network errors; the real cause lives in err.cause.
+  const cause = err instanceof Error && 'cause' in err ? (err as Error & { cause: unknown }).cause : undefined;
+  const code =
+    cause && typeof cause === 'object' && 'code' in cause
+      ? String((cause as { code: unknown }).code)
+      : '';
+  const causeMessage =
+    cause instanceof Error
+      ? cause.message
+      : cause && typeof cause === 'object' && 'message' in cause
+        ? String((cause as { message: unknown }).message)
+        : err instanceof Error
+          ? err.message
+          : String(err);
+
+  if (code === 'ECONNREFUSED') {
+    const hint = isLocalTarget
+      ? ` — no server running on that port. Omit --local (or unset WIKI_SERVER_ENV) to check production instead.`
+      : '';
+    return `${url} refused the connection (ECONNREFUSED)${hint}`;
+  }
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+    return `${url} — DNS lookup failed (${code}): ${causeMessage}`;
+  }
+  if (code === 'ETIMEDOUT') {
+    return `${url} — connection timed out (ETIMEDOUT)`;
+  }
+  if (code === 'ECONNRESET') {
+    return `${url} — connection reset by peer (ECONNRESET)`;
+  }
+
+  const codeSuffix = code ? ` (${code})` : '';
+  return `${url} — network error${codeSuffix}: ${causeMessage}`;
+}
+
+export async function fetchJson(url: string, authHeader?: string): Promise<FetchJsonResult> {
   try {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (authHeader) headers['Authorization'] = authHeader;
@@ -96,7 +183,7 @@ async function fetchJson(url: string, authHeader?: string): Promise<{ ok: boolea
     try { data = await res.json(); } catch { /* body may not be JSON */ }
     return { ok: res.ok, status: res.status, data };
   } catch (err) {
-    return { ok: false, status: 0, data: null };
+    return { ok: false, status: 0, data: null, errorDetail: describeFetchError(url, err) };
   }
 }
 
@@ -118,10 +205,19 @@ export async function checkServer(): Promise<CheckResult> {
     return { name, ok: false, summary: 'LONGTERMWIKI_SERVER_URL not set', detail: ['Set LONGTERMWIKI_SERVER_URL environment variable'] };
   }
 
-  const { ok, status, data } = await fetchJson(`${SERVER_URL}/health`);
+  const { ok, status, data, errorDetail } = await fetchJson(`${SERVER_URL}/health`);
 
   if (!ok) {
-    return { name, ok: false, summary: `Health endpoint unreachable (HTTP ${status})`, detail: [`GET /health returned HTTP ${status}`] };
+    if (status === 0 && errorDetail) {
+      // errorDetail already includes the URL; don't repeat it.
+      return { name, ok: false, summary: `Health endpoint unreachable — ${errorDetail}`, detail: [errorDetail] };
+    }
+    return {
+      name,
+      ok: false,
+      summary: `Health endpoint unreachable (HTTP ${status})`,
+      detail: [`GET /health returned HTTP ${status}`],
+    };
   }
 
   const h = data as Record<string, unknown>;
@@ -229,10 +325,11 @@ export async function checkApi(): Promise<CheckResult> {
   ];
 
   for (const t of tests) {
-    const { ok, status, data } = await fetchJson(t.url, auth);
+    const { ok, status, data, errorDetail } = await fetchJson(t.url, auth);
     if (!ok) {
-      detail.push(`FAIL  ${t.label}: HTTP ${status}`);
-      failures.push(`${t.label}: HTTP ${status}`);
+      const msg = status === 0 && errorDetail ? errorDetail : `HTTP ${status}`;
+      detail.push(`FAIL  ${t.label}: ${msg}`);
+      failures.push(`${t.label}: ${msg}`);
     } else if (t.check && !t.check(data)) {
       detail.push(`FAIL  ${t.label}: HTTP 200 but content check failed`);
       failures.push(`${t.label}: unexpected response shape`);
@@ -445,12 +542,13 @@ export async function checkFrontend(): Promise<CheckResult> {
 
   for (const p of pages) {
     const url = `${WIKI_PUBLIC_URL}${p.path}`;
-    const { ok, status } = await fetchJson(url);
+    const { ok, status, errorDetail } = await fetchJson(url);
     if (ok) {
       detail.push(`PASS  ${p.label}: HTTP 200`);
     } else {
-      detail.push(`FAIL  ${p.label}: HTTP ${status}`);
-      failures.push(`${p.label}: HTTP ${status}`);
+      const msg = status === 0 && errorDetail ? errorDetail : `HTTP ${status}`;
+      detail.push(`FAIL  ${p.label}: ${msg}`);
+      failures.push(`${p.label}: ${msg}`);
     }
   }
 
@@ -493,8 +591,12 @@ export async function checkFreshness(): Promise<CheckResult> {
       detail.push(`INFO  Last page sync: date unavailable`);
     }
   } else {
-    detail.push(`FAIL  Pages list: HTTP ${pagesResp.status}`);
-    failures.push(`Pages list unavailable (HTTP ${pagesResp.status})`);
+    const msg =
+      pagesResp.status === 0 && pagesResp.errorDetail
+        ? pagesResp.errorDetail
+        : `HTTP ${pagesResp.status}`;
+    detail.push(`FAIL  Pages list: ${msg}`);
+    failures.push(`Pages list unavailable (${msg})`);
   }
 
   // Most recent auto-update run — skip cleanly if endpoint returns 404 (route may not exist)
@@ -517,7 +619,11 @@ export async function checkFreshness(): Promise<CheckResult> {
       detail.push(`INFO  Last auto-update run: no runs found`);
     }
   } else {
-    detail.push(`SKIP  Auto-update runs: HTTP ${runsResp.status}`);
+    const msg =
+      runsResp.status === 0 && runsResp.errorDetail
+        ? runsResp.errorDetail
+        : `HTTP ${runsResp.status}`;
+    detail.push(`SKIP  Auto-update runs: ${msg}`);
   }
 
   // Most recent agent session — response: { sessions: [...], total, limit, offset }
@@ -561,8 +667,17 @@ async function main(): Promise<void> {
       console.error(`Unknown check: ${CHECK_ARG}. Available: ${Object.keys(ALL_CHECKS).join(', ')}`);
       process.exit(1);
     }
-    if (!JSON_MODE && !REPORT_MODE) process.stdout.write(`  Running ${CHECK_ARG}...`);
+    if (!JSON_MODE && !REPORT_MODE) console.log(`  Running ${CHECK_ARG}...`);
     const result = await fn();
+    if (!JSON_MODE && !REPORT_MODE) {
+      const icon = result.ok ? `${c.green}PASS${c.reset}` : `${c.red}FAIL${c.reset}`;
+      console.log(`  ${icon}  ${result.name.padEnd(24)} ${c.dim}${result.summary}${c.reset}`);
+      if (result.detail && !result.ok) {
+        for (const line of result.detail) {
+          console.log(`        ${c.dim}${line}${c.reset}`);
+        }
+      }
+    }
     results = [result];
   } else {
     // Run all checks. Independent checks run in parallel; API smoke tests
@@ -651,7 +766,11 @@ async function main(): Promise<void> {
   process.exit(allOk ? 0 : 1);
 }
 
-main().catch((err) => {
-  console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Only auto-run when executed as a script (crux dispatch). Importing this
+// module for tests must not kick off the full health sweep.
+if (INVOKED_AS_SCRIPT) {
+  main().catch((err) => {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

`crux health` is semantically "is production healthy?" — it should work from any directory (coord/, agent slots, worktrees) without requiring `WIKI_SERVER_ENV=prod` as a prefix. This PR sets that default inside the script and adds `--local` as the opt-out for checking a local dev server.

It also upgrades the error surface: opaque `HTTP 0` failures now become actionable diagnostics (`ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`, `TimeoutError`, …) with a localhost-target hint pointing at `--local` / `WIKI_SERVER_ENV=prod`. Drive-by fix: `--check=<name>` (single-check) mode now prints the same per-check FAIL/detail lines as the full sweep — previously it just said "1 check(s) failed" with no context.

## Key changes

- `crux/health/health-check.ts`:
  - Default `WIKI_SERVER_ENV=prod` when `--local` is not passed (gated on script invocation; importing the module in tests is a no-op so other tests that care about `WIKI_SERVER_ENV` don't get polluted).
  - New `describeFetchError(url, err)` classifier — exported so tests can exercise it without spinning up a server.
  - `fetchJson` returns `errorDetail` on status 0; all call sites surface it in failure summaries and detail lines.
  - `--check=<name>` mode now prints per-check output like the full sweep.
  - `main()` is only auto-invoked when the module is executed as a script, not on import.
- `crux/commands/health.ts`: add `--local` to the passthrough list and document it in `getHelp()`.
- `.gitignore`: ignore `.claude/scheduled_tasks.lock`.

## Test plan

- [x] `pnpm vitest run crux/health/health-check.test.ts` — 10 tests pass (error classifier, fetchJson against unreachable targets, module-import hygiene invariant).
- [x] `pnpm vitest run crux/health/... crux/wiki-server/sync-session.test.ts crux/lib/wiki-server/client.test.ts` — 43 tests pass; no pollution of the two `WIKI_SERVER_ENV`-sensitive suites.
- [x] `npx tsc -p crux/tsconfig.json --noEmit` — no new errors in touched files.
- [x] Manual repro of the ticket scenario (running `crux health` from an agent slot with no `WIKI_SERVER_ENV` set) — previously gave "HTTP 0" against localhost:3113; now hits production by default.

Fixes QUA-479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
