### PR TITLE
fix(scripts): resolve LW_DIR two levels up in tmux-rename-loop.sh (QUA-480)

### DIFF
--- a/scripts/tmux-rename-loop.sh
+++ b/scripts/tmux-rename-loop.sh
@@ -15,7 +15,10 @@
 #   pkill -f tmux-rename-loop.sh
 
 set -u
-LW_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Script lives at <workspace>/main/scripts/tmux-rename-loop.sh.
+# Workspace root (where `ws` lives) is two levels up from this script, not one
+# (QUA-480 — previous resolution pointed at lw/main/ws which doesn't exist).
+LW_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 INTERVAL=300  # 5 minutes
 
 # Run inside whichever tmux server is active for the current user.


### PR DESCRIPTION
## Summary

The tmux-rename-loop background script resolved `LW_DIR` one level too shallow, so every 5-minute tick errored out silently. Operators assumed it was working because `pgrep` saw the PID, but tmux tabs kept drifting for ~36 hours before anyone noticed.

## Root cause

Script lives at `<workspace>/main/scripts/tmux-rename-loop.sh`. It resolved:

```bash
LW_DIR="$(cd "$(dirname "$0")/.." && pwd)"
```

- `dirname $0` → `lw/main/scripts`
- `+/..` → `lw/main`
- `$LW_DIR/ws` → `lw/main/ws` ❌ (`ws` is at `lw/ws`, one level up)

Every tick logged to `/tmp/lw-fix-tabs.log`:

```
./main/scripts/tmux-rename-loop.sh: line 27: /Users/.../lw/main/ws: No such file or directory
```

The per-slot heartbeat hooks still ran on active sessions, so partial coverage masked it — only idle / zsh / coordinator windows drifted.

## Fix

Resolve `LW_DIR` two levels up so it lands at the workspace root. Added a comment explaining why, referencing QUA-480.

## Test plan

- [x] `bash -n scripts/tmux-rename-loop.sh` — syntax clean
- [x] Verified `LW_DIR` now resolves to `lw/` (not `lw/main/`) by running manually
- [x] Ran `./ws fix-tabs` from the restarted loop — renamed 11 drifted tabs successfully
- [x] Pre-push gate passes (no bypass)

## Follow-ups (not blocking)

Filed in QUA-480:
1. `/setup-slot-orchestration` should verify the loop is actually working (tail the log, not just `pgrep`)
2. Consider calling `crux agent-workspace fix-tabs` directly instead of going through the `./ws` shell wrapper, to drop the path dependency entirely

Closes QUA-480

🤖 Generated with [Claude Code](https://claude.com/claude-code)