### PR TITLE
fix(pr-patrol): halt cleanly on missing GITHUB_TOKEN (QUA-395)

### DIFF
--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -103,7 +103,9 @@ function makeDeps(overrides: Partial<HealthGateDeps> = {}): HealthGateDeps & {
   const logs: string[] = [];
   return {
     now: () => NOW,
-    env: {},
+    // Default env has GITHUB_TOKEN present. The dedicated missing-token tests
+    // override this with an empty env or a stripped-token env (QUA-395).
+    env: { GITHUB_TOKEN: 'test-token' },
     writeEvent: (entry) => events.push(entry),
     log: (msg) => logs.push(msg),
     cooldownStore: inMemoryCooldown(),
@@ -130,7 +132,7 @@ describe('runHealthGate — env escape hatch', () => {
   });
 
   it('does NOT bypass when env var is unset', async () => {
-    const deps = makeDeps({ env: {} });
+    const deps = makeDeps({ env: { GITHUB_TOKEN: 'test-token' } });
     const decision = await runHealthGate({
       ...deps,
       scan: async () => unhealthyScan([deployStuckIssue()]),
@@ -140,7 +142,7 @@ describe('runHealthGate — env escape hatch', () => {
   });
 
   it('does NOT bypass when env var is set to "0"', async () => {
-    const deps = makeDeps({ env: { [DISABLE_ENV_VAR]: '0' } });
+    const deps = makeDeps({ env: { [DISABLE_ENV_VAR]: '0', GITHUB_TOKEN: 'test-token' } });
     const decision = await runHealthGate({
       ...deps,
       scan: async () => healthyScan(),
@@ -179,6 +181,110 @@ describe('runHealthGate — healthy', () => {
     expect(decision.proceed).toBe(true);
     expect(decision.emittedIssues).toHaveLength(0);
     expect(deps.events).toHaveLength(0);
+  });
+});
+
+// ── Missing GITHUB_TOKEN (QUA-395) ───────────────────────────────────────────
+
+describe('runHealthGate — missing GITHUB_TOKEN', () => {
+  it('halts immediately when GITHUB_TOKEN is unset (does not call scan)', async () => {
+    const deps = makeDeps({ env: {} });
+    let scanCalled = false;
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        scanCalled = true;
+        return healthyScan();
+      },
+    });
+
+    expect(scanCalled).toBe(false);
+    expect(decision.proceed).toBe(false);
+    expect(decision.bypassed).toBe(false);
+    expect(decision.reason).toContain('GITHUB_TOKEN');
+    expect(deps.events).toHaveLength(1);
+    expect(deps.events[0]).toMatchObject({
+      type: 'health_gate_missing_token',
+      reason: 'GITHUB_TOKEN not set in environment',
+    });
+    expect(deps.logs.some((l) => l.includes('GITHUB_TOKEN not set'))).toBe(true);
+  });
+
+  it('halts immediately when GITHUB_TOKEN is empty string (falsy)', async () => {
+    const deps = makeDeps({ env: { GITHUB_TOKEN: '' } });
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => healthyScan(),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.reason).toContain('GITHUB_TOKEN');
+  });
+
+  it('resets the consecutive-error counter when halting on missing token', async () => {
+    // Pre-populate: 2 prior scan errors. Missing token should wipe this so
+    // a subsequent real scan isn't artificially near MAX_CONSECUTIVE_SCAN_ERRORS.
+    const store = inMemoryCooldown();
+    store.setCount('__scan_error_count__', MAX_CONSECUTIVE_SCAN_ERRORS - 1);
+    const deps = makeDeps({ env: {}, cooldownStore: store });
+
+    await runHealthGate({
+      ...deps,
+      scan: async () => healthyScan(),
+    });
+    expect(store.getCount('__scan_error_count__')).toBe(0);
+  });
+
+  it('bypass env var still takes precedence over missing-token halt', async () => {
+    // Operator explicitly bypassing the gate — respect it even when the
+    // token is missing. Without this, bypass couldn't rescue a stuck patrol.
+    const deps = makeDeps({ env: { [DISABLE_ENV_VAR]: '1' } }); // no GITHUB_TOKEN
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error('scan should not be called when bypassed');
+      },
+    });
+    expect(decision.bypassed).toBe(true);
+    expect(decision.proceed).toBe(true);
+  });
+
+  it('classifies token errors thrown from scan as permanent (not counted as transient)', async () => {
+    // Edge case: env.GITHUB_TOKEN looks present at gate entry, but the scan's
+    // internal call to getGitHubToken() reads process.env and finds nothing.
+    // The error bubbles up and we classify it as permanent — no counter bump.
+    const store = inMemoryCooldown();
+    store.setCount('__scan_error_count__', 0);
+    const deps = makeDeps({ cooldownStore: store });
+
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error(
+          'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
+            'Set it with: export GITHUB_TOKEN=<your-token>',
+        );
+      },
+    });
+
+    expect(decision.proceed).toBe(false);
+    expect(decision.reason).toContain('GITHUB_TOKEN');
+    // Counter did not tick up — permanent errors shouldn't use streak budget.
+    expect(store.getCount('__scan_error_count__')).toBe(0);
+    expect(deps.events.some((e) => e.type === 'health_gate_missing_token')).toBe(true);
+  });
+
+  it('does NOT misclassify unrelated errors as missing-token', async () => {
+    // Regression: a generic "GitHub API 500" mustn't get caught by the token
+    // classifier. Normal errors go through the consecutive-error path.
+    const deps = makeDeps();
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error('GitHub API returned 500');
+      },
+    });
+    expect(decision.proceed).toBe(true);
+    expect(deps.events[0]).toMatchObject({ type: 'health_scan_error' });
   });
 });
 
@@ -300,7 +406,7 @@ describe('runHealthGate — cooldown', () => {
     // First call — no prior state, should emit.
     await runHealthGate({
       now: () => NOW,
-      env: {},
+      env: { GITHUB_TOKEN: "test-token" },
       writeEvent: (e) => events.push(e),
       log: () => {},
       cooldownStore: store,
@@ -312,7 +418,7 @@ describe('runHealthGate — cooldown', () => {
     const later = new Date(NOW.getTime() + 5 * 60_000);
     const decision = await runHealthGate({
       now: () => later,
-      env: {},
+      env: { GITHUB_TOKEN: "test-token" },
       writeEvent: (e) => events.push(e),
       log: () => {},
       cooldownStore: store,
@@ -330,7 +436,7 @@ describe('runHealthGate — cooldown', () => {
 
     await runHealthGate({
       now: () => NOW,
-      env: {},
+      env: { GITHUB_TOKEN: "test-token" },
       writeEvent: (e) => events.push(e),
       log: () => {},
       cooldownStore: store,
@@ -340,7 +446,7 @@ describe('runHealthGate — cooldown', () => {
     const wayLater = new Date(NOW.getTime() + (HEALTH_GATE_COOLDOWN_MINUTES + 1) * 60_000);
     await runHealthGate({
       now: () => wayLater,
-      env: {},
+      env: { GITHUB_TOKEN: "test-token" },
       writeEvent: (e) => events.push(e),
       log: () => {},
       cooldownStore: store,
@@ -372,7 +478,7 @@ describe('runHealthGate — cooldown', () => {
 
     const decision = await runHealthGate({
       now: () => NOW,
-      env: {},
+      env: { GITHUB_TOKEN: "test-token" },
       writeEvent: (e) => events.push(e),
       log: () => {},
       cooldownStore: store,

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -50,6 +50,20 @@ const HEALTH_GATE_STATE_FILE = join(STATE_DIR, 'health-gate-cooldown.json');
 /** Reserved fingerprint used to track consecutive scan-error count. */
 const SCAN_ERROR_COUNTER_KEY = '__scan_error_count__';
 
+/**
+ * Signal string emitted by `getGitHubToken()` in `crux/lib/github.ts` when the
+ * env var is missing. Used to classify scan failures so a permanent config
+ * error halts patrol immediately instead of cycling through
+ * MAX_CONSECUTIVE_SCAN_ERRORS (QUA-395).
+ */
+const MISSING_TOKEN_ERROR_SIGNAL = 'GITHUB_TOKEN not set';
+
+/** True when the error is from a missing GITHUB_TOKEN. */
+function isMissingTokenError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes(MISSING_TOKEN_ERROR_SIGNAL);
+}
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface HealthGateDecision {
@@ -228,6 +242,36 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
     };
   }
 
+  // GITHUB_TOKEN is a permanent config requirement — not a transient network
+  // blip. If it's missing, fail-fast with a clear halt instead of letting the
+  // scan throw into the consecutive-error catch path below, which would burn
+  // through MAX_CONSECUTIVE_SCAN_ERRORS on a permanent error (QUA-395).
+  // `runDaemon` already preflight-checks the same var, so reaching this branch
+  // means either (a) the gate is called from a non-daemon entry point, or
+  // (b) the env changed between daemon startup and the first scan.
+  if (!env.GITHUB_TOKEN) {
+    log(
+      `${cl.red}✗ GITHUB_TOKEN not set — health gate cannot scan GitHub. ` +
+        `Halting patrol until token is set.${cl.reset}`,
+    );
+    writeEvent({
+      type: 'health_gate_missing_token',
+      timestamp: now.toISOString(),
+      reason: 'GITHUB_TOKEN not set in environment',
+    });
+    // Reset the consecutive-error counter: this is a config fault, not a
+    // streak, and leaving it high would poison the next real scan attempt.
+    cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
+    return {
+      proceed: false,
+      reason: 'GITHUB_TOKEN not set in environment',
+      result: syntheticScanFailureResult('GITHUB_TOKEN not set'),
+      emittedIssues: [],
+      suppressedIssues: [],
+      bypassed: false,
+    };
+  }
+
   let result: HealthScanResult;
   try {
     result = await scan();
@@ -239,6 +283,33 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
     // work. But if the scanner fails N consecutive times, something's wrong
     // with our observability — flip to halt to prevent silent forever-proceed.
     const message = e instanceof Error ? e.message : String(e);
+
+    // Missing-token errors are permanent config faults, not transient.
+    // Halt immediately instead of cycling the consecutive-error counter, and
+    // reset the counter so a subsequent real scan isn't artificially near the
+    // halt threshold (QUA-395). Covers the edge case where env.GITHUB_TOKEN
+    // was present at the start of runHealthGate but a nested call reads
+    // process.env directly and finds it missing.
+    if (isMissingTokenError(e)) {
+      cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
+      writeEvent({
+        type: 'health_gate_missing_token',
+        timestamp: now.toISOString(),
+        reason: message,
+      });
+      log(
+        `${cl.red}✗ GITHUB_TOKEN became unavailable during scan — halting patrol.${cl.reset}`,
+      );
+      return {
+        proceed: false,
+        reason: 'GITHUB_TOKEN not set in environment',
+        result: syntheticScanFailureResult(message),
+        emittedIssues: [],
+        suppressedIssues: [],
+        bypassed: false,
+      };
+    }
+
     const prevCount = cooldown.getCount?.(SCAN_ERROR_COUNTER_KEY) ?? 0;
     const newCount = prevCount + 1;
     cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, newCount);


### PR DESCRIPTION
## Summary

The PR patrol health-gate was throwing "GITHUB_TOKEN not set" errors into the catch-all consecutive-error path, cycling `MAX_CONSECUTIVE_SCAN_ERRORS` on a permanent config fault and halting patrol only after burning the streak budget. This masked the real cause in the logs as `consecutive_errors: 1, 2, 3` instead of a clear token-missing signal.

Two defenses added to `runHealthGate()`:

1. **Early check** — if `env.GITHUB_TOKEN` is missing, fail-fast with a clear halt and reset the error counter (permanent fault, not a streak).
2. **Catch classification** — if a scan throws the token-missing error mid-run (edge case: token revoked between cycles), classify as permanent and halt without bumping the counter.

The `PATROL_DISABLE_HEALTH_GATE=1` bypass still takes precedence so operators can force through when the gate itself misbehaves.

## Why

Observed errors (from QUA-395):
```
timestamp: 2026-04-12T23:02:22, consecutive_errors: 1
timestamp: 2026-04-12T23:34:06, consecutive_errors: 2
timestamp: 2026-04-13T13:22:08, consecutive_errors: 3
```

All three were `'GITHUB_TOKEN not set...'` being classified as transient network errors. Eventually halted after 3, but with a misleading "consecutive errors" framing and zero signal that the cause was a permanent config fault.

## Test plan

- [x] New `runHealthGate — missing GITHUB_TOKEN` test group:
  - Halts immediately when token is unset; scan never called
  - Empty-string token also halts
  - Error counter is reset on halt (not poisoned for next scan)
  - Bypass env var still takes precedence over missing-token halt
  - Token error *thrown from scan* is classified as permanent (counter not incremented)
  - Unrelated errors (`GitHub API 500`) still go through the normal transient path
- [x] All 21 existing health-gate tests still pass (updated `makeDeps` default env to include `GITHUB_TOKEN: 'test-token'`)
- [x] `npx tsc --noEmit` clean for the changed files

Closes QUA-395
