### PR TITLE
fix(pr-patrol): verify rebase cleared conflict before reporting fixed (QUA-400)

### DIFF
--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -72,6 +72,58 @@ export function isMissingTokenError(err: unknown): err is MissingTokenError {
 }
 
 /**
+ * Error thrown by {@link githubApi} on HTTP failures.
+ *
+ * Carries the HTTP `status` code as a structured property so callers can
+ * discriminate between error classes without resorting to substring matching
+ * on the `message` string (which is error-prone — a 500 response whose body
+ * happens to contain the text "404" would match a naive `msg.includes('404')`
+ * check).
+ *
+ * The `message` format is preserved (`"GitHub API ${method} ${endpoint}
+ * returned ${status}: ${body}"`) for backwards compatibility with code that
+ * pre-dates this class and still substring-matches the message.
+ */
+export class GitHubApiError extends Error {
+  /** HTTP status code from the failing response (e.g. 404, 422, 500). */
+  readonly status: number;
+  /** HTTP method of the failing request. */
+  readonly method: string;
+  /** API endpoint path (without the `https://api.github.com` prefix). */
+  readonly endpoint: string;
+  /** Response body text (best-effort; may be `"(no body)"`). */
+  readonly responseBody: string;
+
+  constructor(
+    method: string,
+    endpoint: string,
+    status: number,
+    responseBody: string,
+  ) {
+    super(`GitHub API ${method} ${endpoint} returned ${status}: ${responseBody}`);
+    this.name = 'GitHubApiError';
+    this.status = status;
+    this.method = method;
+    this.endpoint = endpoint;
+    this.responseBody = responseBody;
+  }
+}
+
+/**
+ * Type guard: is this error a {@link GitHubApiError} with the given status?
+ *
+ * Prefer this over `err.message.includes('404')` — the substring-match
+ * approach was flagged as a Major finding in PR #4362 because it swallows
+ * any error whose message happens to contain "404" (e.g. a PR number).
+ */
+export function isGitHubApiErrorWithStatus(
+  err: unknown,
+  status: number,
+): err is GitHubApiError {
+  return err instanceof GitHubApiError && err.status === status;
+}
+
+/**
  * Return the whitespace-stripped `GITHUB_TOKEN` env var, or throw a
  * `MissingTokenError` when it is absent, empty, or whitespace-only.
  *
@@ -180,7 +232,10 @@ export async function githubApi<T = unknown>(
 
   if (!resp.ok) {
     const text = await resp.text().catch(() => '(no body)');
-    throw new Error(`GitHub API ${method} ${endpoint} returned ${resp.status}: ${text}`);
+    // Throw a structured error so callers can key off `.status` instead of
+    // substring-matching the message. The message format is preserved for
+    // backwards compatibility with existing callers that still do that.
+    throw new GitHubApiError(method, endpoint, resp.status, text);
   }
 
   // 204 No Content — no body to parse (e.g. DELETE /labels/{name})

--- a/crux/pr-patrol/claim.test.ts
+++ b/crux/pr-patrol/claim.test.ts
@@ -91,9 +91,16 @@ describe('tryClaimPr', () => {
     );
   });
 
-  it('returns false when label write fails after a clean pre-check', async () => {
+  it('returns false when label write fails and post-check confirms label absent', async () => {
+    // The label-write POST really did fail — the server never applied the
+    // label. Re-query succeeds and shows the label is still absent, so we
+    // can safely report `didClaim=false`.
+    const fetchLabels = vi
+      .fn()
+      .mockResolvedValueOnce([]) // pre-check: nothing
+      .mockResolvedValueOnce(['needs-review']); // post-check: still no working label
     const deps = makeDeps({
-      fetchLabels: vi.fn().mockResolvedValue([]),
+      fetchLabels,
       addWorkingLabel: vi.fn().mockRejectedValue(new Error('422 validation')),
     });
     const didClaim = await tryClaimPr(222, 'owner/repo', deps);
@@ -101,6 +108,60 @@ describe('tryClaimPr', () => {
     expect(deps.onClaimLost).toHaveBeenCalledWith(
       222,
       expect.stringContaining('label write failed'),
+    );
+    // Both the pre-check and the post-check fetches should have happened
+    expect(fetchLabels).toHaveBeenCalledTimes(2);
+  });
+
+  // CodeRabbit QUA-400 Major finding: a POST can succeed server-side even
+  // when the client sees a connection reset / timeout. Returning `false` in
+  // that case would no-op the finally release and leak the label.
+  it('returns true when label write throws but post-check shows label present', async () => {
+    // The POST appeared to fail client-side, but the server actually
+    // applied the label (e.g. connection reset after commit). The
+    // post-write re-check catches this and upgrades didClaim to true.
+    const fetchLabels = vi
+      .fn()
+      .mockResolvedValueOnce([]) // pre-check: unclaimed
+      .mockResolvedValueOnce(['pr-patrol:working']); // post-check: label present
+    const deps = makeDeps({
+      fetchLabels,
+      addWorkingLabel: vi
+        .fn()
+        .mockRejectedValue(new Error('socket hang up (ECONNRESET)')),
+    });
+    const didClaim = await tryClaimPr(333, 'owner/repo', deps);
+    // Critical: we must return true so the finally-release cleans up the
+    // label. Returning false would leak it permanently.
+    expect(didClaim).toBe(true);
+    expect(fetchLabels).toHaveBeenCalledTimes(2);
+    // onClaimLost is used for observability in this path — the caller gets
+    // a hint that the POST initially appeared to fail.
+    expect(deps.onClaimLost).toHaveBeenCalledWith(
+      333,
+      expect.stringContaining('post-write re-check shows'),
+    );
+  });
+
+  it('returns true (fail-safe) when both label write AND post-check fail', async () => {
+    // Worst case: we can't tell whether the POST landed server-side. The
+    // safe default is `didClaim=true` so the finally-release can clean up
+    // any lingering label. A DELETE on an absent label is a harmless 404;
+    // a missed release on a present label is a permanent leak.
+    const fetchLabels = vi
+      .fn()
+      .mockResolvedValueOnce([]) // pre-check: unclaimed
+      .mockRejectedValueOnce(new Error('network fully down')); // post-check fails
+    const deps = makeDeps({
+      fetchLabels,
+      addWorkingLabel: vi.fn().mockRejectedValue(new Error('ETIMEDOUT')),
+    });
+    const didClaim = await tryClaimPr(444, 'owner/repo', deps);
+    expect(didClaim).toBe(true);
+    expect(fetchLabels).toHaveBeenCalledTimes(2);
+    expect(deps.onClaimLost).toHaveBeenCalledWith(
+      444,
+      expect.stringContaining('fail-safe'),
     );
   });
 });

--- a/crux/pr-patrol/claim.test.ts
+++ b/crux/pr-patrol/claim.test.ts
@@ -8,12 +8,31 @@
  * the ~12s rebase window.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the github lib BEFORE importing the module under test, so the
+// `defaultRemoveWorkingLabel` tests can inject fake 404/500 responses.
+// The existing ClaimDeps-based tests don't touch githubApi at all, so
+// the mock is transparent to them.
+vi.mock('../lib/github.ts', async () => {
+  const actual = await vi.importActual<typeof import('../lib/github.ts')>(
+    '../lib/github.ts',
+  );
+  return {
+    ...actual,
+    githubApi: vi.fn(),
+  };
+});
+
 import {
   tryClaimPr,
   releasePrIfClaimed,
+  defaultRemoveWorkingLabel,
   type ClaimDeps,
 } from './claim.ts';
+import { githubApi, GitHubApiError } from '../lib/github.ts';
+
+const mockGithubApi = vi.mocked(githubApi);
 
 function makeDeps(overrides: Partial<ClaimDeps> = {}): ClaimDeps {
   return {
@@ -124,24 +143,36 @@ describe('QUA-400 race scenario — claim-then-release ownership tracking', () =
     });
 
     // The fixed flow (mirrors execution.ts / parallel.ts):
+    //
+    // NOTE: do NOT `return` out of the try block on the `!didClaim` path.
+    // An early return inside `try` short-circuits the post-try assertions
+    // and makes the regression test vacuous — it would still pass even if
+    // the `finally` block unconditionally called `removeWorkingLabel` on
+    // another worker's label. Instead, gate the "real work" on
+    // `didClaim === true` and let execution fall through to the finally
+    // block AND the assertions below. (CodeRabbit QUA-400 follow-up.)
     let didClaim = false;
     try {
       didClaim = await tryClaimPr(999, 'owner/repo', deps);
-      if (!didClaim) {
-        // Claim lost — skip work, bail out.
-        return;
+      if (didClaim) {
+        // Imagine tryRebaseAndVerify(...) runs here. We never reach it
+        // in this scenario because another worker beat us to the claim,
+        // but the caller code path must still fall through to the
+        // finally + post-try assertions for the test to exercise the
+        // `didClaim === false` release path.
       }
-      // Imagine tryRebaseAndVerify(...) runs here. It doesn't matter
-      // for the race test — we never reach it because we bailed out.
     } finally {
       await releasePrIfClaimed(didClaim, 999, 'owner/repo', deps);
     }
 
-    // Core assertions:
+    // Core assertions — these MUST run (i.e. not be short-circuited by an
+    // early return above) for the regression test to have teeth:
     expect(didClaim).toBe(false);
     // We must not have added our own working label on top of theirs.
     expect(deps.addWorkingLabel).not.toHaveBeenCalled();
     // CRITICAL: we must not have deleted the other worker's label.
+    // This is the assertion that was previously unreachable because of
+    // the early `return` inside the try block.
     expect(deps.removeWorkingLabel).not.toHaveBeenCalled();
   });
 
@@ -185,5 +216,120 @@ describe('QUA-400 race scenario — claim-then-release ownership tracking', () =
     expect(caught?.message).toBe('rebase blew up');
     expect(didClaim).toBe(true);
     expect(deps.removeWorkingLabel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── defaultRemoveWorkingLabel — 404 discrimination (QUA-400 follow-up) ─────
+//
+// CodeRabbit Major finding: the previous implementation swallowed any
+// error whose .message contained "404" or "Not Found", which also hides
+// 500-class failures whose response body happens to mention those strings.
+// The fix keys off the structured .status on GitHubApiError.
+//
+// These tests lock in:
+//   - a real 404 is swallowed (label already absent is fine)
+//   - a 500 is NOT swallowed, even if its body mentions "404" or "Not Found"
+//   - a plain Error (non-GitHubApiError) is NOT swallowed
+
+describe('defaultRemoveWorkingLabel — 404 discrimination', () => {
+  beforeEach(() => {
+    mockGithubApi.mockReset();
+  });
+
+  it('swallows a concrete HTTP 404 (label already absent)', async () => {
+    mockGithubApi.mockRejectedValueOnce(
+      new GitHubApiError(
+        'DELETE',
+        '/repos/owner/repo/issues/42/labels/pr-patrol%3Aworking',
+        404,
+        '{"message":"Label does not exist"}',
+      ),
+    );
+
+    // Must NOT throw.
+    await expect(
+      defaultRemoveWorkingLabel(42, 'owner/repo'),
+    ).resolves.toBeUndefined();
+    expect(mockGithubApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws a 500 even when the body text contains "404"', async () => {
+    // The key regression scenario: a 500 response body that happens to
+    // mention "404" (e.g. because the upstream stack trace referenced a
+    // 404 log line, or the error message says "upstream returned 404").
+    // Under the old substring-match implementation this would be
+    // silently swallowed; under the .status check it must bubble.
+    const err = new GitHubApiError(
+      'DELETE',
+      '/repos/owner/repo/issues/42/labels/pr-patrol%3Aworking',
+      500,
+      '{"message":"upstream reported 404 in logs"}',
+    );
+    mockGithubApi.mockRejectedValueOnce(err);
+
+    // Call once, assert on the rejection shape.
+    let caught: unknown;
+    try {
+      await defaultRemoveWorkingLabel(42, 'owner/repo');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(GitHubApiError);
+    expect(caught).toMatchObject({ status: 500 });
+    expect((caught as GitHubApiError).message).toContain('404');
+  });
+
+  it('re-throws a 500 even when the body text contains "Not Found"', async () => {
+    mockGithubApi.mockRejectedValueOnce(
+      new GitHubApiError(
+        'DELETE',
+        '/repos/owner/repo/issues/42/labels/pr-patrol%3Aworking',
+        500,
+        '{"message":"Internal: cached entry Not Found"}',
+      ),
+    );
+
+    await expect(
+      defaultRemoveWorkingLabel(42, 'owner/repo'),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('re-throws a 403 (permission denied — label stays stuck, not a benign case)', async () => {
+    mockGithubApi.mockRejectedValueOnce(
+      new GitHubApiError(
+        'DELETE',
+        '/repos/owner/repo/issues/42/labels/pr-patrol%3Aworking',
+        403,
+        '{"message":"Resource not accessible by integration"}',
+      ),
+    );
+
+    await expect(
+      defaultRemoveWorkingLabel(42, 'owner/repo'),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('re-throws a plain Error (non-GitHubApiError, e.g. network failure)', async () => {
+    // A pre-HTTP failure (fetch abort, DNS error, etc.) reaches us as a
+    // plain Error — not a GitHubApiError. We must bubble it so callers
+    // can see the network is broken.
+    mockGithubApi.mockRejectedValueOnce(new Error('fetch failed: ECONNRESET'));
+
+    await expect(
+      defaultRemoveWorkingLabel(42, 'owner/repo'),
+    ).rejects.toThrow('fetch failed: ECONNRESET');
+  });
+
+  it('returns normally on a successful 204 No Content', async () => {
+    // githubApi returns undefined on 204.
+    mockGithubApi.mockResolvedValueOnce(undefined);
+
+    await expect(
+      defaultRemoveWorkingLabel(42, 'owner/repo'),
+    ).resolves.toBeUndefined();
+    expect(mockGithubApi).toHaveBeenCalledWith(
+      expect.stringContaining('/repos/owner/repo/issues/42/labels/'),
+      { method: 'DELETE' },
+    );
   });
 });

--- a/crux/pr-patrol/claim.test.ts
+++ b/crux/pr-patrol/claim.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for PR patrol claim/release primitives (QUA-400 race fix).
+ *
+ * The core property under test: when `tryClaimPr` fails because another
+ * worker already holds the claim, `releasePrIfClaimed` must NOT touch the
+ * label. Previously the flow was "rebase-verify -> finally releasePr" and
+ * the unconditional release would delete the OTHER worker's label during
+ * the ~12s rebase window.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  tryClaimPr,
+  releasePrIfClaimed,
+  type ClaimDeps,
+} from './claim.ts';
+
+function makeDeps(overrides: Partial<ClaimDeps> = {}): ClaimDeps {
+  return {
+    fetchLabels: vi.fn().mockResolvedValue([]),
+    addWorkingLabel: vi.fn().mockResolvedValue(undefined),
+    removeWorkingLabel: vi.fn().mockResolvedValue(undefined),
+    onClaimLost: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('tryClaimPr', () => {
+  it('acquires the claim when PR has no working labels', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue(['needs-review']),
+    });
+    const didClaim = await tryClaimPr(123, 'owner/repo', deps);
+    expect(didClaim).toBe(true);
+    expect(deps.addWorkingLabel).toHaveBeenCalledWith(123, 'owner/repo');
+    expect(deps.onClaimLost).not.toHaveBeenCalled();
+  });
+
+  it('refuses to claim when pr-patrol:working label already present', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue(['pr-patrol:working', 'needs-review']),
+    });
+    const didClaim = await tryClaimPr(456, 'owner/repo', deps);
+    expect(didClaim).toBe(false);
+    // Critical: we must not add our own label on top of the other worker's
+    expect(deps.addWorkingLabel).not.toHaveBeenCalled();
+    expect(deps.onClaimLost).toHaveBeenCalledWith(
+      456,
+      expect.stringContaining('already claimed'),
+    );
+  });
+
+  it('refuses to claim when agent:working label is present (any working label)', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue(['agent:working']),
+    });
+    const didClaim = await tryClaimPr(789, 'owner/repo', deps);
+    expect(didClaim).toBe(false);
+    expect(deps.addWorkingLabel).not.toHaveBeenCalled();
+  });
+
+  it('returns false when label fetch fails (fails closed)', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockRejectedValue(new Error('network down')),
+    });
+    const didClaim = await tryClaimPr(111, 'owner/repo', deps);
+    expect(didClaim).toBe(false);
+    expect(deps.addWorkingLabel).not.toHaveBeenCalled();
+    expect(deps.onClaimLost).toHaveBeenCalledWith(
+      111,
+      expect.stringContaining('pre-check failed'),
+    );
+  });
+
+  it('returns false when label write fails after a clean pre-check', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue([]),
+      addWorkingLabel: vi.fn().mockRejectedValue(new Error('422 validation')),
+    });
+    const didClaim = await tryClaimPr(222, 'owner/repo', deps);
+    expect(didClaim).toBe(false);
+    expect(deps.onClaimLost).toHaveBeenCalledWith(
+      222,
+      expect.stringContaining('label write failed'),
+    );
+  });
+});
+
+describe('releasePrIfClaimed', () => {
+  it('releases the label when didClaim === true', async () => {
+    const deps = makeDeps();
+    await releasePrIfClaimed(true, 333, 'owner/repo', deps);
+    expect(deps.removeWorkingLabel).toHaveBeenCalledWith(333, 'owner/repo');
+  });
+
+  it('is a no-op when didClaim === false (does NOT touch the label)', async () => {
+    const deps = makeDeps();
+    await releasePrIfClaimed(false, 444, 'owner/repo', deps);
+    expect(deps.removeWorkingLabel).not.toHaveBeenCalled();
+  });
+});
+
+// ── The race scenario: this is the core regression test for QUA-400 ─────────
+//
+// Reproduces the bug the CodeRabbit critical review flagged.
+//
+// Before the fix: `tryRebaseAndVerify()` was called BEFORE the claim, and
+// the `finally` block unconditionally called `releasePr()`. If another
+// worker claimed the PR during the ~12s rebase window, the release would
+// delete the OTHER worker's label — corrupting the claim/coordination layer.
+//
+// After the fix: the caller invokes `tryClaimPr()` FIRST, tracks the
+// `didClaim` result in a local, and the `finally` block calls
+// `releasePrIfClaimed(didClaim, ...)`. When another worker beats us to the
+// claim, `tryClaimPr` returns `false` and `releasePrIfClaimed` is a no-op,
+// so the other worker's label stays intact.
+
+describe('QUA-400 race scenario — claim-then-release ownership tracking', () => {
+  it('when a concurrent worker claims first, we bail out without touching their label', async () => {
+    // Simulate: Worker A starts first. At claim time, Worker B has already
+    // added pr-patrol:working (they won the race).
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue(['pr-patrol:working']),
+    });
+
+    // The fixed flow (mirrors execution.ts / parallel.ts):
+    let didClaim = false;
+    try {
+      didClaim = await tryClaimPr(999, 'owner/repo', deps);
+      if (!didClaim) {
+        // Claim lost — skip work, bail out.
+        return;
+      }
+      // Imagine tryRebaseAndVerify(...) runs here. It doesn't matter
+      // for the race test — we never reach it because we bailed out.
+    } finally {
+      await releasePrIfClaimed(didClaim, 999, 'owner/repo', deps);
+    }
+
+    // Core assertions:
+    expect(didClaim).toBe(false);
+    // We must not have added our own working label on top of theirs.
+    expect(deps.addWorkingLabel).not.toHaveBeenCalled();
+    // CRITICAL: we must not have deleted the other worker's label.
+    expect(deps.removeWorkingLabel).not.toHaveBeenCalled();
+  });
+
+  it('when we successfully claim, the finally block DOES release the label', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    let didClaim = false;
+    try {
+      didClaim = await tryClaimPr(1000, 'owner/repo', deps);
+      // Simulate tryRebaseAndVerify doing its 12s of work…
+    } finally {
+      await releasePrIfClaimed(didClaim, 1000, 'owner/repo', deps);
+    }
+
+    expect(didClaim).toBe(true);
+    expect(deps.addWorkingLabel).toHaveBeenCalledTimes(1);
+    expect(deps.removeWorkingLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it('when we claim successfully but the work throws, the label is still released', async () => {
+    const deps = makeDeps({
+      fetchLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    let didClaim = false;
+    let caught: Error | null = null;
+    try {
+      try {
+        didClaim = await tryClaimPr(1001, 'owner/repo', deps);
+        // Simulate tryRebaseAndVerify blowing up partway through.
+        throw new Error('rebase blew up');
+      } finally {
+        await releasePrIfClaimed(didClaim, 1001, 'owner/repo', deps);
+      }
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught?.message).toBe('rebase blew up');
+    expect(didClaim).toBe(true);
+    expect(deps.removeWorkingLabel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crux/pr-patrol/claim.ts
+++ b/crux/pr-patrol/claim.ts
@@ -74,8 +74,24 @@ export interface ClaimDeps {
  * otherwise it will delete the other worker's claim.
  *
  * Throws only on unrecoverable pre-check errors (e.g., caller invariants).
- * Network/API errors during the label write are treated as "unable to
- * claim" (returns false) so the caller bails out cleanly.
+ *
+ * ## Client-side timeout on a server-side success (QUA-400 Major fix)
+ *
+ * When `addWorkingLabel` throws, we cannot assume the POST failed
+ * server-side — a connection reset or client timeout can fire AFTER
+ * GitHub has already applied the label. If we returned `false` in that
+ * case, the finally-release would be a no-op and the label would leak
+ * permanently, blocking future claims on this PR.
+ *
+ * Recovery: re-query the PR's labels.
+ *   - If our label is now present → return `true` (the POST succeeded
+ *     server-side; we own the claim).
+ *   - If the re-query confirms the label is absent → return `false` (the
+ *     POST really did fail).
+ *   - If the re-query itself also fails → return `true` (fail-safe:
+ *     assume we may own the label so the finally-release cleans it up.
+ *     A double-release is harmless because DELETE is idempotent on 404,
+ *     but a missed release would leak the label).
  */
 export async function tryClaimPr(
   prNumber: number,
@@ -111,10 +127,57 @@ export async function tryClaimPr(
   // No existing claim — attempt to add our working label.
   try {
     await deps.addWorkingLabel(prNumber, repo);
-  } catch (e) {
+  } catch (addErr) {
+    // CodeRabbit QUA-400 Major finding: a POST can fail client-side AFTER
+    // GitHub has already applied the label — e.g. a connection reset or
+    // timeout after the server processed the request. Treating every
+    // add-label failure as `didClaim === false` and then no-op'ing release
+    // would leak the label permanently, blocking future claim attempts on
+    // this PR.
+    //
+    // Recovery strategy: re-query labels. If our label is now present, the
+    // POST succeeded server-side despite the client error — treat it as a
+    // successful claim. If the re-query ALSO fails, choose fail-safe: assume
+    // didClaim=true so the finally block releases the label. This can cause
+    // a harmless double-release (the label may actually not be ours, or the
+    // DELETE hits a 404 because the label was never applied), but delete is
+    // idempotent on 404 and a double-release is strictly better than a
+    // permanent label leak.
+    const addErrMsg = addErr instanceof Error ? addErr.message : String(addErr);
+    let postCheckLabels: string[];
+    try {
+      postCheckLabels = await deps.fetchLabels(prNumber, repo);
+    } catch (reCheckErr) {
+      // Re-query failed. Fail-safe: assume the POST may have succeeded and
+      // we own the label. The finally release will clean it up; delete is
+      // idempotent on 404 so this can't leak.
+      const reCheckMsg =
+        reCheckErr instanceof Error ? reCheckErr.message : String(reCheckErr);
+      deps.onClaimLost?.(
+        prNumber,
+        `label write failed (${addErrMsg}); post-write re-check ` +
+          `also failed (${reCheckMsg}); assuming didClaim=true fail-safe ` +
+          'to avoid label leak',
+      );
+      return true;
+    }
+
+    if (postCheckLabels.includes(LABELS.PR_PATROL_WORKING)) {
+      // The POST succeeded server-side despite the client-side error.
+      // Treat it as a successful claim.
+      deps.onClaimLost?.(
+        prNumber,
+        `label write threw (${addErrMsg}) but post-write re-check shows ` +
+          'label is present; treating as successful claim',
+      );
+      return true;
+    }
+
+    // Re-query succeeded and confirmed the label is NOT present. The POST
+    // really did fail; we did not claim. Safe to return false.
     deps.onClaimLost?.(
       prNumber,
-      `label write failed: ${e instanceof Error ? e.message : String(e)}`,
+      `label write failed: ${addErrMsg}`,
     );
     return false;
   }

--- a/crux/pr-patrol/claim.ts
+++ b/crux/pr-patrol/claim.ts
@@ -5,7 +5,8 @@
  * on a PR. Used by both the serial (execution.ts) and parallel (parallel.ts)
  * dispatch paths.
  *
- * The claim-race bug these helpers fix (QUA-400 CodeRabbit critical review):
+ * ## The critical race these helpers fix (QUA-400)
+ *
  * Previously each path ran `tryRebaseAndVerify()` (which polls GitHub for
  * ~12s) BEFORE adding the working label. During that window another patrol
  * process could claim the PR, and the unconditional `releasePr()` in the
@@ -17,17 +18,38 @@
  *   2. Track whether THIS worker actually acquired the claim (`didClaim`).
  *   3. Only release the label in `finally` when `didClaim === true`.
  *
+ * This shrinks the race window from ~12s (the rebase/verify round-trip) to
+ * a single sub-second API call (`fetchLabels` → `addWorkingLabel`).
+ *
+ * ## Residual TOCTOU race — KNOWN LIMITATION (tracked in QUA-494)
+ *
  * `tryClaimPr()` does a pre-check of existing working labels and adds the
- * `pr-patrol:working` label if the PR is unclaimed. It returns `didClaim`
- * so the caller can gate the release. TOCTOU note: GitHub's add-labels
- * endpoint is idempotent and has no atomic "add-if-absent" primitive, so
- * two workers arriving within the same sub-second window can both believe
- * they own the claim. That residual race is bounded by a *single* API
- * call instead of a ~12s rebase/verify round-trip, which is what the
- * CodeRabbit finding flagged as critical.
+ * `pr-patrol:working` label if the PR is unclaimed. **This is not atomic.**
+ * GitHub's add-labels endpoint is idempotent and has no "add-if-absent"
+ * primitive, so two workers whose `fetchLabels` calls both return
+ * "unclaimed" within the same sub-second window will both proceed to
+ * `addWorkingLabel` and both receive a `didClaim === true`. When either
+ * later calls `releasePrIfClaimed`, it removes the single shared
+ * `pr-patrol:working` label — including the other worker's claim.
+ *
+ * This was flagged as a Major finding in PR #4362 CodeRabbit review. The
+ * `didClaim` gate remains a **best-effort guard**, not a proof of
+ * ownership. Fixing it properly requires either (a) per-worker ownership
+ * metadata via a hidden PR claim comment, or (b) per-worker label names.
+ * Both options are substantial scaffolding for a sub-second race window,
+ * so they're tracked as a follow-up rather than inlined into the critical
+ * fix.
+ *
+ * **Tracked in:** https://linear.app/quantifieduncertainty/issue/QUA-494
+ *
+ * Until QUA-494 lands, accept that two concurrent patrol workers on the
+ * same PR within a sub-second window *can* both remove the shared label.
+ * The consequence is that the PR re-enters the detection pool and the
+ * still-running worker's state is eventually reconciled by the stale-label
+ * health check in `crux/health/checks/pr-quality.ts` (>8h stuck label).
  */
 
-import { githubApi } from '../lib/github.ts';
+import { githubApi, isGitHubApiErrorWithStatus } from '../lib/github.ts';
 import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import { LABELS } from './types.ts';
 
@@ -107,6 +129,24 @@ export async function tryClaimPr(
  * `tryClaimPr()` call. Calling `releasePrIfClaimed(didClaim, ...)` when
  * `didClaim === false` is a no-op — it won't touch the label, which is
  * exactly what we want when another worker holds it.
+ *
+ * ⚠ **Known residual TOCTOU race (QUA-494)**: the `didClaim` boolean
+ * is a best-effort guard, not a proof of ownership. If two workers won
+ * the initial `tryClaimPr` race (both saw "unclaimed" in their
+ * pre-check and both added the label), they will both reach this
+ * function with `didClaim === true`, and each call will remove the
+ * single shared `pr-patrol:working` label — clobbering the other
+ * worker's claim. See the module JSDoc for the full explanation and
+ * https://linear.app/quantifieduncertainty/issue/QUA-494 for the
+ * follow-up that replaces this with worker-specific ownership
+ * metadata (hidden PR claim comments or per-worker label names).
+ *
+ * The sub-second race window is much smaller than the ~12s window
+ * this function's existence originally fixed (QUA-400), but it is not
+ * zero and PR reviewers (particularly CodeRabbit) have flagged it as
+ * a Major finding. Do not remove the `didClaim` gate — it's correct
+ * on the success path; the known gap is only when two workers
+ * concurrently "win" the pre-check.
  */
 export async function releasePrIfClaimed(
   didClaim: boolean,
@@ -143,9 +183,19 @@ export async function defaultAddWorkingLabel(
 }
 
 /**
- * Default remove-label implementation. Swallows 404 (label already absent)
- * but surfaces other errors so a stale `pr-patrol:working` label can't
- * silently block future scans of this PR.
+ * Default remove-label implementation. Swallows ONLY a concrete HTTP 404
+ * (label already absent) and re-throws every other error so a stale
+ * `pr-patrol:working` label can't silently block future scans of this PR.
+ *
+ * CodeRabbit QUA-400 follow-up: this was previously keyed off
+ * `msg.includes('404') || msg.includes('Not Found')`, which would also
+ * swallow a 500 whose response body happened to contain those substrings
+ * (e.g. a PR number, a URL path, or a helpful error message). That meant
+ * a real server failure could be reported as "label already gone" and the
+ * working label would remain stuck, preventing the PR from being picked
+ * up by future patrol cycles. Keying off the structured `.status` on
+ * {@link GitHubApiError} narrows the swallow to the one case we actually
+ * want to tolerate.
  */
 export async function defaultRemoveWorkingLabel(
   prNumber: number,
@@ -159,10 +209,14 @@ export async function defaultRemoveWorkingLabel(
       { method: 'DELETE' },
     );
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (!msg.includes('404') && !msg.includes('Not Found')) {
-      throw e;
+    // Only swallow a concrete HTTP 404 — the label was already removed,
+    // either by a concurrent worker's release or by a manual /labels DELETE.
+    // Any other error (500, 403, network failure) must bubble so callers
+    // can surface a stale working label.
+    if (isGitHubApiErrorWithStatus(e, 404)) {
+      return;
     }
+    throw e;
   }
 }
 

--- a/crux/pr-patrol/claim.ts
+++ b/crux/pr-patrol/claim.ts
@@ -1,0 +1,179 @@
+/**
+ * PR Patrol — Claim/release primitives
+ *
+ * Shared helpers for acquiring and releasing the `pr-patrol:working` label
+ * on a PR. Used by both the serial (execution.ts) and parallel (parallel.ts)
+ * dispatch paths.
+ *
+ * The claim-race bug these helpers fix (QUA-400 CodeRabbit critical review):
+ * Previously each path ran `tryRebaseAndVerify()` (which polls GitHub for
+ * ~12s) BEFORE adding the working label. During that window another patrol
+ * process could claim the PR, and the unconditional `releasePr()` in the
+ * `finally` block would then delete the other worker's label, leaving both
+ * workers racing on the same PR.
+ *
+ * The fix:
+ *   1. Claim BEFORE the rebase/verify round-trip.
+ *   2. Track whether THIS worker actually acquired the claim (`didClaim`).
+ *   3. Only release the label in `finally` when `didClaim === true`.
+ *
+ * `tryClaimPr()` does a pre-check of existing working labels and adds the
+ * `pr-patrol:working` label if the PR is unclaimed. It returns `didClaim`
+ * so the caller can gate the release. TOCTOU note: GitHub's add-labels
+ * endpoint is idempotent and has no atomic "add-if-absent" primitive, so
+ * two workers arriving within the same sub-second window can both believe
+ * they own the claim. That residual race is bounded by a *single* API
+ * call instead of a ~12s rebase/verify round-trip, which is what the
+ * CodeRabbit finding flagged as critical.
+ */
+
+import { githubApi } from '../lib/github.ts';
+import { ANY_WORKING_LABELS } from '../lib/labels.ts';
+import { LABELS } from './types.ts';
+
+/** Dependencies injected so tests can substitute a fake GitHub client. */
+export interface ClaimDeps {
+  /** Fetch an issue's labels. Returns the list of label names. */
+  fetchLabels: (prNumber: number, repo: string) => Promise<string[]>;
+  /** Add the `pr-patrol:working` label to a PR. May throw on network error. */
+  addWorkingLabel: (prNumber: number, repo: string) => Promise<void>;
+  /** Remove the `pr-patrol:working` label. Should swallow 404 (already gone). */
+  removeWorkingLabel: (prNumber: number, repo: string) => Promise<void>;
+  /** Optional callback for logging / side effects on claim events. */
+  onClaimLost?: (prNumber: number, reason: string) => void;
+}
+
+/**
+ * Attempt to claim a PR for this worker.
+ *
+ * Returns `true` if this worker successfully added the working label (the
+ * PR was unclaimed at check time). Returns `false` if another worker holds
+ * a working label, in which case the caller must NOT call `releasePr()` —
+ * otherwise it will delete the other worker's claim.
+ *
+ * Throws only on unrecoverable pre-check errors (e.g., caller invariants).
+ * Network/API errors during the label write are treated as "unable to
+ * claim" (returns false) so the caller bails out cleanly.
+ */
+export async function tryClaimPr(
+  prNumber: number,
+  repo: string,
+  deps: ClaimDeps,
+): Promise<boolean> {
+  // Pre-check: is anyone else already working on this PR?
+  let labels: string[];
+  try {
+    labels = await deps.fetchLabels(prNumber, repo);
+  } catch (e) {
+    // If we can't read labels, we can't safely acquire — bail out.
+    // (Historically execution.ts's `isPrStillAvailable` swallowed this
+    // and proceeded optimistically. For claim ownership we must fail
+    // closed: without a successful pre-check we don't know who owns
+    // the PR, so we shouldn't release a label we may not have set.)
+    deps.onClaimLost?.(
+      prNumber,
+      `pre-check failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return false;
+  }
+
+  const held = ANY_WORKING_LABELS.find((wl) => labels.includes(wl));
+  if (held) {
+    deps.onClaimLost?.(
+      prNumber,
+      `already claimed by another worker (label: ${held})`,
+    );
+    return false;
+  }
+
+  // No existing claim — attempt to add our working label.
+  try {
+    await deps.addWorkingLabel(prNumber, repo);
+  } catch (e) {
+    deps.onClaimLost?.(
+      prNumber,
+      `label write failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Release this worker's claim on a PR.
+ *
+ * **Callers MUST gate this on `didClaim === true`** from a successful
+ * `tryClaimPr()` call. Calling `releasePrIfClaimed(didClaim, ...)` when
+ * `didClaim === false` is a no-op — it won't touch the label, which is
+ * exactly what we want when another worker holds it.
+ */
+export async function releasePrIfClaimed(
+  didClaim: boolean,
+  prNumber: number,
+  repo: string,
+  deps: Pick<ClaimDeps, 'removeWorkingLabel'>,
+): Promise<void> {
+  if (!didClaim) return;
+  await deps.removeWorkingLabel(prNumber, repo);
+}
+
+// ── Default production implementations ──────────────────────────────────────
+
+/** Default label-fetch implementation backed by the GitHub REST API. */
+export async function defaultFetchLabels(
+  prNumber: number,
+  repo: string,
+): Promise<string[]> {
+  const pr = await githubApi<{ labels: Array<{ name: string }> }>(
+    `/repos/${repo}/issues/${prNumber}`,
+  );
+  return pr.labels.map((l) => l.name);
+}
+
+/** Default add-label implementation. */
+export async function defaultAddWorkingLabel(
+  prNumber: number,
+  repo: string,
+): Promise<void> {
+  await githubApi(`/repos/${repo}/issues/${prNumber}/labels`, {
+    method: 'POST',
+    body: { labels: [LABELS.PR_PATROL_WORKING] },
+  });
+}
+
+/**
+ * Default remove-label implementation. Swallows 404 (label already absent)
+ * but surfaces other errors so a stale `pr-patrol:working` label can't
+ * silently block future scans of this PR.
+ */
+export async function defaultRemoveWorkingLabel(
+  prNumber: number,
+  repo: string,
+): Promise<void> {
+  try {
+    await githubApi(
+      `/repos/${repo}/issues/${prNumber}/labels/${encodeURIComponent(
+        LABELS.PR_PATROL_WORKING,
+      )}`,
+      { method: 'DELETE' },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.includes('404') && !msg.includes('Not Found')) {
+      throw e;
+    }
+  }
+}
+
+/** Build a ClaimDeps using the default production GitHub client. */
+export function defaultClaimDeps(
+  onClaimLost?: (prNumber: number, reason: string) => void,
+): ClaimDeps {
+  return {
+    fetchLabels: defaultFetchLabels,
+    addWorkingLabel: defaultAddWorkingLabel,
+    removeWorkingLabel: defaultRemoveWorkingLabel,
+    onClaimLost,
+  };
+}

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -15,6 +15,7 @@ import { checkMainBranch as libCheckMainBranch, findRecentMerges as libFindRecen
 import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import type { RecentMerge } from '../lib/pr-analysis/index.ts';
 import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
+import { verifyRebaseCleared } from './rebase-verify.ts';
 import type { FixOutcome, MainBranchStatus, PatrolConfig, ScoredPr } from './types.ts';
 import { LABELS } from './types.ts';
 import {
@@ -594,26 +595,52 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
     const rebaseResult = tryAutomatedRebase(pr.branch, worktreePath);
 
     if (rebaseResult.success) {
-      log(`  ✓ Automated rebase ${rebaseResult.status} — no Claude needed`);
+      // `tryAutomatedRebase` only reports git-level success. Verify GitHub
+      // actually no longer reports the PR as conflicting before claiming a
+      // fix — without this, a concurrent commit or GitHub's async mergeable
+      // recomputation produced cycles where patrol reported 'fixed' but the
+      // next scan still saw CONFLICTING (QUA-400, PR #4287).
+      const hadConflict = pr.issues.includes('conflict');
+      const verify = hadConflict
+        ? await verifyRebaseCleared(pr.number, config.repo)
+        : { cleared: true, reason: 'no conflict to verify', mergeable: null, mergeStateStatus: null, attempts: 0 };
 
-      // Strip both 'stale' and 'conflict' — rebase resolved them
-      const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
-      if (remainingIssues.length === 0) {
-        removeWorktree(worktreePath);
+      if (!verify.cleared) {
+        log(
+          `  ${cl.yellow}⚠ Automated rebase reported ${rebaseResult.status} but GitHub still shows conflict: ${verify.reason}${cl.reset} — falling through to Claude`,
+        );
         appendJsonl(JSONL_FILE, {
-          type: 'pr_result',
+          type: 'rebase_verify_failed',
           pr_num: pr.number,
-          issues: pr.issues,
-          outcome: 'fixed' as FixOutcome,
-          elapsed_s: 0,
-          reason: `automated-rebase: ${rebaseResult.status}`,
+          rebase_status: rebaseResult.status,
+          reason: verify.reason,
+          mergeable: verify.mergeable,
+          merge_state_status: verify.mergeStateStatus,
+          attempts: verify.attempts,
         });
-        markProcessed(pr.number);
-        return { mainIsRootCause: false };
+        // Fall through to Claude with original issues — don't strip 'conflict'.
+      } else {
+        log(`  ✓ Automated rebase ${rebaseResult.status} — no Claude needed`);
+
+        // Strip both 'stale' and 'conflict' — rebase resolved them
+        const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
+        if (remainingIssues.length === 0) {
+          removeWorktree(worktreePath);
+          appendJsonl(JSONL_FILE, {
+            type: 'pr_result',
+            pr_num: pr.number,
+            issues: pr.issues,
+            outcome: 'fixed' as FixOutcome,
+            elapsed_s: 0,
+            reason: `automated-rebase: ${rebaseResult.status} (verified)`,
+          });
+          markProcessed(pr.number);
+          return { mainIsRootCause: false };
+        }
+        // Remaining issues need Claude — update pr.issues so Claude doesn't re-address resolved ones
+        pr.issues = remainingIssues;
+        log(`  Remaining issues after rebase: ${remainingIssues.join(', ')} — falling through to Claude`);
       }
-      // Remaining issues need Claude — update pr.issues so Claude doesn't re-address resolved ones
-      pr.issues = remainingIssues;
-      log(`  Remaining issues after rebase: ${remainingIssues.join(', ')} — falling through to Claude`);
     } else {
       log(`  Automated rebase failed (${rebaseResult.status}) — falling through to Claude`);
     }

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -15,6 +15,12 @@ import { checkMainBranch as libCheckMainBranch, findRecentMerges as libFindRecen
 import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import type { RecentMerge } from '../lib/pr-analysis/index.ts';
 import { tryRebaseAndVerify } from './rebase-verify.ts';
+import {
+  tryClaimPr,
+  releasePrIfClaimed,
+  defaultClaimDeps,
+  type ClaimDeps,
+} from './claim.ts';
 import type { FixOutcome, MainBranchStatus, PatrolConfig, ScoredPr } from './types.ts';
 import { LABELS } from './types.ts';
 import {
@@ -428,6 +434,12 @@ export function spawnClaude(
 }
 
 // ── PR claim management ─────────────────────────────────────────────────────
+//
+// Historically this file owned its own `claimPr`/`releasePr` pair. They now
+// delegate to the shared helpers in `./claim.ts` so both the serial
+// (execution.ts) and parallel (parallel.ts) dispatch paths use the same
+// ownership-tracked claim/release flow. See claim.ts for the QUA-400 race
+// fix context.
 
 let claimedPr: number | null = null;
 
@@ -435,32 +447,45 @@ export function getClaimedPr(): number | null {
   return claimedPr;
 }
 
-async function claimPr(prNum: number, repo: string): Promise<void> {
-  try {
-    await githubApi(`/repos/${repo}/issues/${prNum}/labels`, {
-      method: 'POST',
-      body: { labels: [LABELS.PR_PATROL_WORKING] },
-    });
+/** ClaimDeps bound to this module's logger and claimedPr tracker. */
+const serialClaimDeps: ClaimDeps = defaultClaimDeps((prNum, reason) => {
+  log(`  ${cl.yellow}PR #${prNum} claim skipped: ${reason}${cl.reset}`);
+});
+
+/**
+ * Attempt to claim a PR. Returns `true` if the claim was acquired.
+ * On success, updates `claimedPr` and persisted state so a SIGINT/SIGTERM
+ * can release the label on shutdown via `releaseCurrentClaim`.
+ */
+async function claimPr(prNum: number, repo: string): Promise<boolean> {
+  const didClaim = await tryClaimPr(prNum, repo, serialClaimDeps);
+  if (didClaim) {
     claimedPr = prNum;
     setPersistedClaimedPr(prNum);
-  } catch {
-    log(`  ${cl.yellow}Warning: could not add ${LABELS.PR_PATROL_WORKING} label to PR #${prNum}${cl.reset}`);
   }
+  return didClaim;
 }
 
-async function releasePr(prNum: number, repo: string): Promise<void> {
+/**
+ * Release the working label for a PR — but ONLY if this worker actually
+ * claimed it (`didClaim === true`). When `didClaim === false`, this is a
+ * no-op: another worker holds the label and we must not delete it.
+ */
+async function releasePr(
+  didClaim: boolean,
+  prNum: number,
+  repo: string,
+): Promise<void> {
+  if (!didClaim) return;
   try {
-    await githubApi(`/repos/${repo}/issues/${prNum}/labels/${encodeURIComponent(LABELS.PR_PATROL_WORKING)}`, {
-      method: 'DELETE',
-    });
+    await releasePrIfClaimed(didClaim, prNum, repo, serialClaimDeps);
   } catch (e) {
-    // 404 is expected (label already absent) — swallow silently.
-    // Any other error (network, 500, auth) needs visibility since a stale
-    // pr-patrol:working label makes detectAllPrIssuesFromNodes skip the PR.
-    const msg = e instanceof Error ? e.message : String(e);
-    if (!msg.includes('404') && !msg.includes('Not Found')) {
-      log(`  Warning: could not remove pr-patrol:working label from PR #${prNum}: ${msg}`);
-    }
+    // defaultRemoveWorkingLabel already swallows 404. Anything that bubbles
+    // up here is a real error — surface it so a stale pr-patrol:working
+    // label can't silently block future scans of this PR.
+    log(
+      `  Warning: could not remove pr-patrol:working label from PR #${prNum}: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
   if (claimedPr === prNum) {
     claimedPr = null;
@@ -470,7 +495,8 @@ async function releasePr(prNum: number, repo: string): Promise<void> {
 
 export async function releaseCurrentClaim(repo: string): Promise<void> {
   if (claimedPr !== null) {
-    await releasePr(claimedPr, repo).catch((e) => {
+    // Shutdown path: we know we own the claim, so didClaim = true.
+    await releasePr(true, claimedPr, repo).catch((e) => {
       // Best-effort cleanup during shutdown — label will be stale but not harmful
       log(`  Warning: could not release claim on PR #${claimedPr}: ${e instanceof Error ? e.message : String(e)}`);
     });
@@ -583,92 +609,117 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
     return { mainIsRootCause: false };
   }
 
-  // ── Automated rebase pre-step (runs in worktree) ──────────────────
-  // For stale or conflicting PRs, try a plain git rebase first. Saves the
-  // full Claude spawn (~5 turns, ~3-10 min) when rebase resolves cleanly.
-  // `tryRebaseAndVerify` also polls GitHub's mergeable state to catch the
-  // case where rebase pushed but GitHub still reports CONFLICTING due to
-  // async recomputation or a concurrent commit (QUA-400, PR #4287).
-  if (pr.issues.includes('stale') || pr.issues.includes('conflict')) {
-    log('  Attempting automated rebase (no Claude needed)...');
-    const outcome = await tryRebaseAndVerify(
-      pr.branch,
-      pr.number,
-      pr.issues,
-      worktreePath,
-      config.repo,
-    );
-
-    switch (outcome.kind) {
-      case 'rebase-failed':
-        log(`  Automated rebase failed (${outcome.status}) — falling through to Claude`);
-        break;
-
-      case 'verify-failed':
-        log(
-          `  ${cl.yellow}⚠ Automated rebase reported ${outcome.rebaseStatus} but GitHub still shows conflict: ${outcome.verify.reason}${cl.reset} — falling through to Claude`,
-        );
-        appendJsonl(JSONL_FILE, {
-          type: 'rebase_verify_failed',
-          pr_num: pr.number,
-          rebase_status: outcome.rebaseStatus,
-          reason: outcome.verify.reason,
-          mergeable: outcome.verify.mergeable,
-          merge_state_status: outcome.verify.mergeStateStatus,
-          attempts: outcome.verify.attempts,
-        });
-        break;
-
-      case 'fully-resolved':
-        log(`  ✓ Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
-        removeWorktree(worktreePath);
-        appendJsonl(JSONL_FILE, {
-          type: 'pr_result',
-          pr_num: pr.number,
-          issues: pr.issues,
-          outcome: 'fixed' as FixOutcome,
-          elapsed_s: 0,
-          reason: `automated-rebase: ${outcome.rebaseStatus} (verified)`,
-        });
-        markProcessed(pr.number);
-        return { mainIsRootCause: false };
-
-      case 'partially-resolved':
-        log(`  ✓ Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
-        pr.issues = outcome.remainingIssues;
-        log(`  Remaining issues after rebase: ${outcome.remainingIssues.join(', ')} — falling through to Claude`);
-        break;
-    }
+  // ── Claim the PR BEFORE the rebase/verify round-trip ─────────────
+  // QUA-400 (CodeRabbit critical): `tryRebaseAndVerify` polls GitHub's
+  // mergeable state for ~12s. If we ran it before claiming, another patrol
+  // worker could grab the label during that window, and the unconditional
+  // release in our `finally` below would delete the other worker's claim.
+  //
+  // Fix: claim first, track `didClaim` locally, only release on success.
+  // If another worker beat us to the claim, bail out cleanly.
+  const didClaim = await claimPr(pr.number, config.repo);
+  if (!didClaim) {
+    markProcessed(pr.number);
+    appendJsonl(JSONL_FILE, {
+      type: 'pr_result',
+      pr_num: pr.number,
+      issues: pr.issues,
+      outcome: 'no-op' as FixOutcome,
+      elapsed_s: 0,
+      reason: 'Claim lost to concurrent worker',
+    });
+    removeWorktree(worktreePath);
+    return { mainIsRootCause: false };
   }
 
-  await claimPr(pr.number, config.repo);
-
-  // Compute issue-specific budget (capped by global config)
-  // Reduce budget on retry — the full budget already failed once, so give less on subsequent attempts
-  const failCount = getFailCount(pr.number);
-  const { maxTurns: effectiveMaxTurns, timeoutMinutes: effectiveTimeout } =
-    computeEffectiveBudget(pr.issues, config.maxTurns, config.timeoutMinutes, failCount);
-
-  if (failCount > 0) {
-    log(`  ${cl.dim}Retry #${failCount + 1} — budget reduced to ${effectiveMaxTurns} turns / ${effectiveTimeout}m${cl.reset}`);
-  }
-  log(`  Budget: ${effectiveMaxTurns} max-turns, ${effectiveTimeout}m timeout (based on: ${pr.issues.join(', ')})`);
-
-  // Record fix attempt after worktree creation (not before dry-run/early-return paths)
-  recordFixAttempt(pr.number);
-
-  // Post "attempting fix" event comment before spawning Claude
-  await postEventComment(pr.number, config.repo, buildFixAttemptComment(pr.issues))
-    .catch((e: unknown) => log(`  Warning: could not post fix attempt comment: ${e instanceof Error ? e.message : String(e)}`));
-
-  const prompt = buildPrompt(pr, config.repo);
-  const startTime = Date.now();
-
+  // Everything below this point runs while we hold the claim. The
+  // outer try/finally at the end of this function guarantees we release
+  // the label via `releasePr(didClaim, ...)` — which is a no-op if
+  // `didClaim === false` (belt-and-suspenders; we already early-returned).
   let outcome: FixOutcome = 'fixed';
   let reason = '';
   let mainIsRootCause = false;
 
   try {
+    // ── Automated rebase pre-step (runs in worktree) ──────────────────
+    // For stale or conflicting PRs, try a plain git rebase first. Saves the
+    // full Claude spawn (~5 turns, ~3-10 min) when rebase resolves cleanly.
+    // `tryRebaseAndVerify` also polls GitHub's mergeable state to catch the
+    // case where rebase pushed but GitHub still reports CONFLICTING due to
+    // async recomputation or a concurrent commit (QUA-400, PR #4287).
+    if (pr.issues.includes('stale') || pr.issues.includes('conflict')) {
+      log('  Attempting automated rebase (no Claude needed)...');
+      const rebaseOutcome = await tryRebaseAndVerify(
+        pr.branch,
+        pr.number,
+        pr.issues,
+        worktreePath,
+        config.repo,
+      );
+
+      switch (rebaseOutcome.kind) {
+        case 'rebase-failed':
+          log(`  Automated rebase failed (${rebaseOutcome.status}) — falling through to Claude`);
+          break;
+
+        case 'verify-failed':
+          log(
+            `  ${cl.yellow}⚠ Automated rebase reported ${rebaseOutcome.rebaseStatus} but GitHub still shows conflict: ${rebaseOutcome.verify.reason}${cl.reset} — falling through to Claude`,
+          );
+          appendJsonl(JSONL_FILE, {
+            type: 'rebase_verify_failed',
+            pr_num: pr.number,
+            rebase_status: rebaseOutcome.rebaseStatus,
+            reason: rebaseOutcome.verify.reason,
+            mergeable: rebaseOutcome.verify.mergeable,
+            merge_state_status: rebaseOutcome.verify.mergeStateStatus,
+            attempts: rebaseOutcome.verify.attempts,
+          });
+          break;
+
+        case 'fully-resolved':
+          log(`  ✓ Automated rebase ${rebaseOutcome.rebaseStatus} — no Claude needed`);
+          appendJsonl(JSONL_FILE, {
+            type: 'pr_result',
+            pr_num: pr.number,
+            issues: pr.issues,
+            outcome: 'fixed' as FixOutcome,
+            elapsed_s: 0,
+            reason: `automated-rebase: ${rebaseOutcome.rebaseStatus} (verified)`,
+          });
+          // Claim-guarded early return: the outer finally below will
+          // release the label and clean up the worktree.
+          return { mainIsRootCause: false };
+
+        case 'partially-resolved':
+          log(`  ✓ Automated rebase ${rebaseOutcome.rebaseStatus} — no Claude needed`);
+          pr.issues = rebaseOutcome.remainingIssues;
+          log(`  Remaining issues after rebase: ${rebaseOutcome.remainingIssues.join(', ')} — falling through to Claude`);
+          break;
+      }
+    }
+
+    // Compute issue-specific budget (capped by global config)
+    // Reduce budget on retry — the full budget already failed once, so give less on subsequent attempts
+    const failCount = getFailCount(pr.number);
+    const { maxTurns: effectiveMaxTurns, timeoutMinutes: effectiveTimeout } =
+      computeEffectiveBudget(pr.issues, config.maxTurns, config.timeoutMinutes, failCount);
+
+    if (failCount > 0) {
+      log(`  ${cl.dim}Retry #${failCount + 1} — budget reduced to ${effectiveMaxTurns} turns / ${effectiveTimeout}m${cl.reset}`);
+    }
+    log(`  Budget: ${effectiveMaxTurns} max-turns, ${effectiveTimeout}m timeout (based on: ${pr.issues.join(', ')})`);
+
+    // Record fix attempt after worktree creation (not before dry-run/early-return paths)
+    recordFixAttempt(pr.number);
+
+    // Post "attempting fix" event comment before spawning Claude
+    await postEventComment(pr.number, config.repo, buildFixAttemptComment(pr.issues))
+      .catch((e: unknown) => log(`  Warning: could not post fix attempt comment: ${e instanceof Error ? e.message : String(e)}`));
+
+    const prompt = buildPrompt(pr, config.repo);
+    const startTime = Date.now();
+
     const result = await spawnClaude(prompt, {
       ...config,
       maxTurns: effectiveMaxTurns,
@@ -784,7 +835,10 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
       reason: reason || undefined,
     });
   } finally {
-    await releasePr(pr.number, config.repo);
+    // Only release the working label if THIS worker actually claimed the
+    // PR. When didClaim === false we bailed out early (above), but this
+    // gate is belt-and-suspenders against future refactors.
+    await releasePr(didClaim, pr.number, config.repo);
 
     // Clean up worktree (handles rebase/merge abort internally)
     removeWorktree(worktreePath);

--- a/crux/pr-patrol/execution.ts
+++ b/crux/pr-patrol/execution.ts
@@ -14,8 +14,7 @@ import { git, createWorktree, removeWorktree } from '../lib/git.ts';
 import { checkMainBranch as libCheckMainBranch, findRecentMerges as libFindRecentMerges } from '../lib/pr-analysis/index.ts';
 import { ANY_WORKING_LABELS } from '../lib/labels.ts';
 import type { RecentMerge } from '../lib/pr-analysis/index.ts';
-import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
-import { verifyRebaseCleared } from './rebase-verify.ts';
+import { tryRebaseAndVerify } from './rebase-verify.ts';
 import type { FixOutcome, MainBranchStatus, PatrolConfig, ScoredPr } from './types.ts';
 import { LABELS } from './types.ts';
 import {
@@ -585,64 +584,60 @@ export async function fixPr(pr: ScoredPr, config: PatrolConfig): Promise<FixPrRe
   }
 
   // ── Automated rebase pre-step (runs in worktree) ──────────────────
-  // For stale or conflicting PRs, try a plain git rebase first.
-  // This saves the full Claude spawn (~5 turns, ~3-10 min) when the
-  // rebase resolves cleanly. Even when GitHub reports CONFLICTING,
-  // git rebase can auto-resolve many cases (different merge strategies).
-  // Cost of a failed attempt is negligible (<1s of git commands).
+  // For stale or conflicting PRs, try a plain git rebase first. Saves the
+  // full Claude spawn (~5 turns, ~3-10 min) when rebase resolves cleanly.
+  // `tryRebaseAndVerify` also polls GitHub's mergeable state to catch the
+  // case where rebase pushed but GitHub still reports CONFLICTING due to
+  // async recomputation or a concurrent commit (QUA-400, PR #4287).
   if (pr.issues.includes('stale') || pr.issues.includes('conflict')) {
     log('  Attempting automated rebase (no Claude needed)...');
-    const rebaseResult = tryAutomatedRebase(pr.branch, worktreePath);
+    const outcome = await tryRebaseAndVerify(
+      pr.branch,
+      pr.number,
+      pr.issues,
+      worktreePath,
+      config.repo,
+    );
 
-    if (rebaseResult.success) {
-      // `tryAutomatedRebase` only reports git-level success. Verify GitHub
-      // actually no longer reports the PR as conflicting before claiming a
-      // fix — without this, a concurrent commit or GitHub's async mergeable
-      // recomputation produced cycles where patrol reported 'fixed' but the
-      // next scan still saw CONFLICTING (QUA-400, PR #4287).
-      const hadConflict = pr.issues.includes('conflict');
-      const verify = hadConflict
-        ? await verifyRebaseCleared(pr.number, config.repo)
-        : { cleared: true, reason: 'no conflict to verify', mergeable: null, mergeStateStatus: null, attempts: 0 };
+    switch (outcome.kind) {
+      case 'rebase-failed':
+        log(`  Automated rebase failed (${outcome.status}) — falling through to Claude`);
+        break;
 
-      if (!verify.cleared) {
+      case 'verify-failed':
         log(
-          `  ${cl.yellow}⚠ Automated rebase reported ${rebaseResult.status} but GitHub still shows conflict: ${verify.reason}${cl.reset} — falling through to Claude`,
+          `  ${cl.yellow}⚠ Automated rebase reported ${outcome.rebaseStatus} but GitHub still shows conflict: ${outcome.verify.reason}${cl.reset} — falling through to Claude`,
         );
         appendJsonl(JSONL_FILE, {
           type: 'rebase_verify_failed',
           pr_num: pr.number,
-          rebase_status: rebaseResult.status,
-          reason: verify.reason,
-          mergeable: verify.mergeable,
-          merge_state_status: verify.mergeStateStatus,
-          attempts: verify.attempts,
+          rebase_status: outcome.rebaseStatus,
+          reason: outcome.verify.reason,
+          mergeable: outcome.verify.mergeable,
+          merge_state_status: outcome.verify.mergeStateStatus,
+          attempts: outcome.verify.attempts,
         });
-        // Fall through to Claude with original issues — don't strip 'conflict'.
-      } else {
-        log(`  ✓ Automated rebase ${rebaseResult.status} — no Claude needed`);
+        break;
 
-        // Strip both 'stale' and 'conflict' — rebase resolved them
-        const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
-        if (remainingIssues.length === 0) {
-          removeWorktree(worktreePath);
-          appendJsonl(JSONL_FILE, {
-            type: 'pr_result',
-            pr_num: pr.number,
-            issues: pr.issues,
-            outcome: 'fixed' as FixOutcome,
-            elapsed_s: 0,
-            reason: `automated-rebase: ${rebaseResult.status} (verified)`,
-          });
-          markProcessed(pr.number);
-          return { mainIsRootCause: false };
-        }
-        // Remaining issues need Claude — update pr.issues so Claude doesn't re-address resolved ones
-        pr.issues = remainingIssues;
-        log(`  Remaining issues after rebase: ${remainingIssues.join(', ')} — falling through to Claude`);
-      }
-    } else {
-      log(`  Automated rebase failed (${rebaseResult.status}) — falling through to Claude`);
+      case 'fully-resolved':
+        log(`  ✓ Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
+        removeWorktree(worktreePath);
+        appendJsonl(JSONL_FILE, {
+          type: 'pr_result',
+          pr_num: pr.number,
+          issues: pr.issues,
+          outcome: 'fixed' as FixOutcome,
+          elapsed_s: 0,
+          reason: `automated-rebase: ${outcome.rebaseStatus} (verified)`,
+        });
+        markProcessed(pr.number);
+        return { mainIsRootCause: false };
+
+      case 'partially-resolved':
+        log(`  ✓ Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
+        pr.issues = outcome.remainingIssues;
+        log(`  Remaining issues after rebase: ${outcome.remainingIssues.join(', ')} — falling through to Claude`);
+        break;
     }
   }
 

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
+import { verifyRebaseCleared } from './rebase-verify.ts';
 import { gitIn, gitSafe, gitSafeIn } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';
 import { REPO } from '../lib/github.ts';
@@ -281,19 +282,43 @@ async function fixPrInWorktree(
       const rebaseResult = tryAutomatedRebase(pr.branch, worktreePath);
 
       if (rebaseResult.success) {
-        log(`${prefix} Automated rebase ${rebaseResult.status} — no Claude needed`);
-        const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
-        if (remainingIssues.length === 0) {
-          markProcessed(pr.number);
-          return {
-            prNumber: pr.number,
-            outcome: 'fixed',
-            reason: `automated-rebase: ${rebaseResult.status}`,
-            elapsedS: Math.floor((Date.now() - startTime) / 1000),
-          };
+        // Verify GitHub no longer reports the PR as conflicting before
+        // claiming a fix. See QUA-400 for the PR #4287 incident where we
+        // reported 'fixed' but the next scan still saw CONFLICTING.
+        const hadConflict = pr.issues.includes('conflict');
+        const verify = hadConflict
+          ? await verifyRebaseCleared(pr.number, config.repo)
+          : { cleared: true, reason: 'no conflict to verify', mergeable: null, mergeStateStatus: null, attempts: 0 };
+
+        if (!verify.cleared) {
+          log(
+            `${prefix} ${cl.yellow}⚠ Rebase reported ${rebaseResult.status} but GitHub still shows conflict: ${verify.reason}${cl.reset} — falling through to Claude`,
+          );
+          appendJsonl(JSONL_FILE, {
+            type: 'rebase_verify_failed',
+            pr_num: pr.number,
+            rebase_status: rebaseResult.status,
+            reason: verify.reason,
+            mergeable: verify.mergeable,
+            merge_state_status: verify.mergeStateStatus,
+            attempts: verify.attempts,
+          });
+          // Don't strip 'conflict' — let Claude see it and resolve manually.
+        } else {
+          log(`${prefix} Automated rebase ${rebaseResult.status} — no Claude needed`);
+          const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
+          if (remainingIssues.length === 0) {
+            markProcessed(pr.number);
+            return {
+              prNumber: pr.number,
+              outcome: 'fixed',
+              reason: `automated-rebase: ${rebaseResult.status} (verified)`,
+              elapsedS: Math.floor((Date.now() - startTime) / 1000),
+            };
+          }
+          pr.issues = remainingIssues;
+          log(`${prefix} Remaining issues after rebase: ${remainingIssues.join(', ')}`);
         }
-        pr.issues = remainingIssues;
-        log(`${prefix} Remaining issues after rebase: ${remainingIssues.join(', ')}`);
       } else {
         // On retry for conflict-only PRs, try rebase-only with Claude (simpler prompt)
         const failCount = getFailCount(pr.number);

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -43,8 +43,12 @@ import {
   looksLikeMainRootCause,
   spawnClaude,
 } from './execution.ts';
-import { githubApi } from '../lib/github.ts';
-import { LABELS } from './types.ts';
+import {
+  tryClaimPr,
+  releasePrIfClaimed,
+  defaultClaimDeps,
+  type ClaimDeps,
+} from './claim.ts';
 import {
   buildAbandonmentComment,
   buildFixAttemptComment,
@@ -148,29 +152,41 @@ function cleanStaleWorktrees(worktreeDir: string): void {
 
 
 // ── PR claim management (parallel-safe) ──────────────────────────────────────
+//
+// Delegates to the shared helpers in ./claim.ts so both the serial
+// (execution.ts) and parallel dispatch paths use the same
+// ownership-tracked claim/release flow. See claim.ts for the QUA-400
+// race-condition context.
 
-async function claimPr(prNum: number, repo: string): Promise<void> {
-  try {
-    await githubApi(`/repos/${repo}/issues/${prNum}/labels`, {
-      method: 'POST',
-      body: { labels: [LABELS.PR_PATROL_WORKING] },
-    });
-  } catch {
-    log(`  ${cl.yellow}Warning: could not add ${LABELS.PR_PATROL_WORKING} label to PR #${prNum}${cl.reset}`);
-  }
+const parallelClaimDeps: ClaimDeps = defaultClaimDeps((prNum, reason) => {
+  log(`  ${cl.yellow}PR #${prNum} claim skipped: ${reason}${cl.reset}`);
+});
+
+/**
+ * Attempt to claim a PR. Returns `true` on success (we added the working
+ * label), `false` when the PR is already claimed by another worker or the
+ * claim write failed.
+ */
+async function claimPr(prNum: number, repo: string): Promise<boolean> {
+  return tryClaimPr(prNum, repo, parallelClaimDeps);
 }
 
-async function releasePr(prNum: number, repo: string): Promise<void> {
+/**
+ * Release the working label — only if `didClaim === true`. When another
+ * worker holds the label, this is a no-op.
+ */
+async function releasePr(
+  didClaim: boolean,
+  prNum: number,
+  repo: string,
+): Promise<void> {
+  if (!didClaim) return;
   try {
-    await githubApi(
-      `/repos/${repo}/issues/${prNum}/labels/${encodeURIComponent(LABELS.PR_PATROL_WORKING)}`,
-      { method: 'DELETE' },
-    );
+    await releasePrIfClaimed(didClaim, prNum, repo, parallelClaimDeps);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (!msg.includes('404') && !msg.includes('Not Found')) {
-      log(`  Warning: could not remove pr-patrol:working label from PR #${prNum}: ${msg}`);
-    }
+    log(
+      `  Warning: could not remove pr-patrol:working label from PR #${prNum}: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 }
 
@@ -269,11 +285,42 @@ async function fixPrInWorktree(
 
   const startTime = Date.now();
   let worktreePath = '';
+  // `didClaim` is declared outside the try so the finally block can gate
+  // `releasePr` on it and avoid deleting another worker's label
+  // (QUA-400 critical review — see claim.ts for the full rationale).
+  let didClaim = false;
 
   try {
     // Create worktree for this PR
     worktreePath = createPatrolWorktree(pr.branch, pr.number, config.worktreeDir);
     log(`${prefix} Worktree: ${cl.dim}${worktreePath}${cl.reset}`);
+
+    // ── Claim the PR BEFORE any rebase/verify round-trip ────────────
+    // QUA-400: `tryRebaseAndVerify` below polls GitHub for ~12s. If we
+    // ran it before claiming, another patrol instance could grab the
+    // label during that window and our `finally` release would delete
+    // the other worker's claim. Claim-first + didClaim gating closes
+    // both halves of the race.
+    didClaim = await claimPr(pr.number, config.repo);
+    if (!didClaim) {
+      log(`${prefix} ${cl.yellow}Claim lost to concurrent worker — skipping${cl.reset}`);
+      markProcessed(pr.number);
+      appendJsonl(JSONL_FILE, {
+        type: 'pr_result',
+        pr_num: pr.number,
+        issues: pr.issues,
+        outcome: 'no-op' as FixOutcome,
+        elapsed_s: Math.floor((Date.now() - startTime) / 1000),
+        reason: 'Claim lost to concurrent worker',
+        parallel: true,
+      });
+      return {
+        prNumber: pr.number,
+        outcome: 'no-op',
+        reason: 'Claim lost to concurrent worker',
+        elapsedS: Math.floor((Date.now() - startTime) / 1000),
+      };
+    }
 
     // Automated rebase pre-step
     if (pr.issues.includes('stale') || pr.issues.includes('conflict')) {
@@ -318,7 +365,8 @@ async function fixPrInWorktree(
         const failCount = getFailCount(pr.number);
         if (failCount > 0 && pr.issues.length === 1 && pr.issues[0] === 'conflict') {
           log(`${prefix} Retry #${failCount + 1} for conflict-only PR — using rebase-only strategy`);
-          await claimPr(pr.number, config.repo);
+          // Claim was already acquired at the top of the try block; no
+          // need to re-claim here.
           const rebasePrompt = `Rebase the current branch onto origin/main. Resolve any merge conflicts. Then force-push with: git push --force-with-lease. Do NOT fix CI issues, do NOT address code review comments — ONLY resolve the merge conflicts and push.`;
           const rebaseResult2 = await spawnClaude(rebasePrompt, {
             ...config,
@@ -345,8 +393,8 @@ async function fixPrInWorktree(
       }
     }
 
-    // Claim PR on GitHub
-    await claimPr(pr.number, config.repo);
+    // Claim was already acquired at the top of the try block
+    // (before tryRebaseAndVerify); no need to re-claim here.
 
     // Compute budget — full budget every attempt (no reduction on retry)
     const failCount = getFailCount(pr.number);
@@ -431,8 +479,10 @@ async function fixPrInWorktree(
       elapsedS,
     };
   } finally {
-    // Always release PR claim and remove worktree
-    await releasePr(pr.number, config.repo);
+    // Only release the working label if THIS worker actually acquired
+    // the claim — `releasePr(false, ...)` is a no-op so we never delete
+    // another worker's label (QUA-400).
+    await releasePr(didClaim, pr.number, config.repo);
     if (worktreePath) removePatrolWorktree(worktreePath);
   }
 }

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -12,8 +12,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
-import { verifyRebaseCleared } from './rebase-verify.ts';
+import { tryRebaseAndVerify } from './rebase-verify.ts';
 import { gitIn, gitSafe, gitSafeIn } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';
 import { REPO } from '../lib/github.ts';
@@ -279,47 +278,42 @@ async function fixPrInWorktree(
     // Automated rebase pre-step
     if (pr.issues.includes('stale') || pr.issues.includes('conflict')) {
       log(`${prefix} Attempting automated rebase...`);
-      const rebaseResult = tryAutomatedRebase(pr.branch, worktreePath);
+      const outcome = await tryRebaseAndVerify(
+        pr.branch,
+        pr.number,
+        pr.issues,
+        worktreePath,
+        config.repo,
+      );
 
-      if (rebaseResult.success) {
-        // Verify GitHub no longer reports the PR as conflicting before
-        // claiming a fix. See QUA-400 for the PR #4287 incident where we
-        // reported 'fixed' but the next scan still saw CONFLICTING.
-        const hadConflict = pr.issues.includes('conflict');
-        const verify = hadConflict
-          ? await verifyRebaseCleared(pr.number, config.repo)
-          : { cleared: true, reason: 'no conflict to verify', mergeable: null, mergeStateStatus: null, attempts: 0 };
-
-        if (!verify.cleared) {
-          log(
-            `${prefix} ${cl.yellow}⚠ Rebase reported ${rebaseResult.status} but GitHub still shows conflict: ${verify.reason}${cl.reset} — falling through to Claude`,
-          );
-          appendJsonl(JSONL_FILE, {
-            type: 'rebase_verify_failed',
-            pr_num: pr.number,
-            rebase_status: rebaseResult.status,
-            reason: verify.reason,
-            mergeable: verify.mergeable,
-            merge_state_status: verify.mergeStateStatus,
-            attempts: verify.attempts,
-          });
-          // Don't strip 'conflict' — let Claude see it and resolve manually.
-        } else {
-          log(`${prefix} Automated rebase ${rebaseResult.status} — no Claude needed`);
-          const remainingIssues = pr.issues.filter((i) => i !== 'stale' && i !== 'conflict');
-          if (remainingIssues.length === 0) {
-            markProcessed(pr.number);
-            return {
-              prNumber: pr.number,
-              outcome: 'fixed',
-              reason: `automated-rebase: ${rebaseResult.status} (verified)`,
-              elapsedS: Math.floor((Date.now() - startTime) / 1000),
-            };
-          }
-          pr.issues = remainingIssues;
-          log(`${prefix} Remaining issues after rebase: ${remainingIssues.join(', ')}`);
-        }
+      if (outcome.kind === 'verify-failed') {
+        log(
+          `${prefix} ${cl.yellow}⚠ Rebase reported ${outcome.rebaseStatus} but GitHub still shows conflict: ${outcome.verify.reason}${cl.reset} — falling through to Claude`,
+        );
+        appendJsonl(JSONL_FILE, {
+          type: 'rebase_verify_failed',
+          pr_num: pr.number,
+          rebase_status: outcome.rebaseStatus,
+          reason: outcome.verify.reason,
+          mergeable: outcome.verify.mergeable,
+          merge_state_status: outcome.verify.mergeStateStatus,
+          attempts: outcome.verify.attempts,
+        });
+      } else if (outcome.kind === 'fully-resolved') {
+        log(`${prefix} Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
+        markProcessed(pr.number);
+        return {
+          prNumber: pr.number,
+          outcome: 'fixed',
+          reason: `automated-rebase: ${outcome.rebaseStatus} (verified)`,
+          elapsedS: Math.floor((Date.now() - startTime) / 1000),
+        };
+      } else if (outcome.kind === 'partially-resolved') {
+        log(`${prefix} Automated rebase ${outcome.rebaseStatus} — no Claude needed`);
+        pr.issues = outcome.remainingIssues;
+        log(`${prefix} Remaining issues after rebase: ${outcome.remainingIssues.join(', ')}`);
       } else {
+        // outcome.kind === 'rebase-failed'
         // On retry for conflict-only PRs, try rebase-only with Claude (simpler prompt)
         const failCount = getFailCount(pr.number);
         if (failCount > 0 && pr.issues.length === 1 && pr.issues[0] === 'conflict') {
@@ -332,8 +326,8 @@ async function fixPrInWorktree(
             timeoutMinutes: 15,
           }, { cwd: worktreePath });
           const elapsedS = Math.floor((Date.now() - startTime) / 1000);
-          const outcome: FixOutcome = rebaseResult2.exitCode === 0 && !rebaseResult2.hitMaxTurns ? 'fixed' : 'error';
-          if (outcome === 'fixed') {
+          const claudeOutcome: FixOutcome = rebaseResult2.exitCode === 0 && !rebaseResult2.hitMaxTurns ? 'fixed' : 'error';
+          if (claudeOutcome === 'fixed') {
             resetFailCount(pr.number);
             log(`${prefix} ${cl.green}Rebase-only fix succeeded${cl.reset} (${elapsedS}s)`);
           } else {
@@ -342,12 +336,12 @@ async function fixPrInWorktree(
           }
           appendJsonl(JSONL_FILE, {
             type: 'pr_result', pr_num: pr.number, issues: pr.issues,
-            outcome, elapsed_s: elapsedS, reason: 'rebase-only strategy', parallel: true,
+            outcome: claudeOutcome, elapsed_s: elapsedS, reason: 'rebase-only strategy', parallel: true,
           });
           markProcessed(pr.number);
-          return { prNumber: pr.number, outcome, reason: 'rebase-only strategy', elapsedS };
+          return { prNumber: pr.number, outcome: claudeOutcome, reason: 'rebase-only strategy', elapsedS };
         }
-        log(`${prefix} Automated rebase failed (${rebaseResult.status}) — falling through to Claude`);
+        log(`${prefix} Automated rebase failed (${outcome.status}) — falling through to Claude`);
       }
     }
 

--- a/crux/pr-patrol/rebase-verify.test.ts
+++ b/crux/pr-patrol/rebase-verify.test.ts
@@ -2,10 +2,16 @@ import { describe, it, expect } from 'vitest';
 
 import {
   verifyRebaseCleared,
+  tryRebaseAndVerify,
   DEFAULT_MAX_ATTEMPTS,
   type VerifyRebaseDeps,
+  type RebaseVerifyResult,
 } from './rebase-verify.ts';
-import type { GqlPrNode } from '../lib/pr-analysis/types.ts';
+import type {
+  AutoRebaseResult,
+  GqlPrNode,
+  PrIssueType,
+} from '../lib/pr-analysis/types.ts';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -71,17 +77,18 @@ describe('verifyRebaseCleared — cleared', () => {
     expect(result.attempts).toBe(1);
   });
 
-  it('returns cleared=true for BEHIND / BLOCKED / UNSTABLE (non-conflict gates)', async () => {
-    // BEHIND / BLOCKED / UNSTABLE are not conflicts — they're other gates
-    // (branch protection, required reviews, failing checks) and should not
-    // make us re-trigger a conflict fix loop.
-    for (const state of ['BEHIND', 'BLOCKED', 'UNSTABLE', 'HAS_HOOKS']) {
+  // BEHIND / BLOCKED / UNSTABLE / HAS_HOOKS are not conflicts — they're
+  // other gates (branch protection, required reviews, failing checks) and
+  // should not re-trigger a conflict fix loop.
+  it.each(['BEHIND', 'BLOCKED', 'UNSTABLE', 'HAS_HOOKS'])(
+    'treats mergeStateStatus=%s as cleared',
+    async (state) => {
       const deps = makeDeps([makePr({ mergeable: 'MERGEABLE', mergeStateStatus: state })]);
       const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
       expect(result.cleared).toBe(true);
       expect(result.reason).toContain(state);
-    }
-  });
+    },
+  );
 
   it('polls past UNKNOWN and accepts the first definitive state', async () => {
     const deps = makeDeps([
@@ -93,7 +100,16 @@ describe('verifyRebaseCleared — cleared', () => {
     const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
     expect(result.cleared).toBe(true);
     expect(result.attempts).toBe(3);
-    expect(deps.sleepCalls).toHaveLength(3); // one before each fetch
+    // Only 2 sleeps — one before each retry, none before the first fetch.
+    expect(deps.sleepCalls).toHaveLength(2);
+  });
+
+  it('does NOT sleep before the first fetch (happy-path latency)', async () => {
+    // Regression: a fresh CLEAN PR shouldn't pay 3s of latency just to
+    // discover it's already cleared. The loop only sleeps between retries.
+    const deps = makeDeps([makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })]);
+    await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(deps.sleepCalls).toHaveLength(0);
   });
 });
 
@@ -179,5 +195,109 @@ describe('verifyRebaseCleared — config', () => {
     const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
     expect(result.cleared).toBe(false);
     expect(deps.fetchCalls).toBe(1); // definitive CONFLICTING ends the loop
+  });
+});
+
+// ── tryRebaseAndVerify (orchestration) ───────────────────────────────────────
+
+function okRebase(status: AutoRebaseResult['status'] = 'rebased'): () => AutoRebaseResult {
+  return () => ({ success: true, status });
+}
+function failRebase(status: AutoRebaseResult['status'] = 'conflict'): () => AutoRebaseResult {
+  return () => ({ success: false, status });
+}
+function okVerify(): () => Promise<RebaseVerifyResult> {
+  return async () => ({
+    cleared: true,
+    reason: 'mergeable=MERGEABLE, mergeStateStatus=CLEAN',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    attempts: 1,
+  });
+}
+function failVerify(): () => Promise<RebaseVerifyResult> {
+  return async () => ({
+    cleared: false,
+    reason: 'PR still conflicting after rebase (mergeable=CONFLICTING, mergeStateStatus=DIRTY)',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    attempts: 1,
+  });
+}
+
+describe('tryRebaseAndVerify', () => {
+  it('returns rebase-failed when git rebase exits non-zero', async () => {
+    const outcome = await tryRebaseAndVerify(
+      'claude/test', 4287, ['conflict'], '/tmp/wt', 'foo/bar',
+      { rebase: failRebase('conflict'), verify: okVerify() },
+    );
+    expect(outcome.kind).toBe('rebase-failed');
+    if (outcome.kind === 'rebase-failed') expect(outcome.status).toBe('conflict');
+  });
+
+  it('returns verify-failed when rebase succeeds but GitHub still shows conflict (QUA-400 regression)', async () => {
+    const outcome = await tryRebaseAndVerify(
+      'claude/test', 4287, ['conflict'], '/tmp/wt', 'foo/bar',
+      { rebase: okRebase(), verify: failVerify() },
+    );
+    expect(outcome.kind).toBe('verify-failed');
+    if (outcome.kind === 'verify-failed') {
+      expect(outcome.rebaseStatus).toBe('rebased');
+      expect(outcome.verify.cleared).toBe(false);
+      expect(outcome.verify.mergeable).toBe('CONFLICTING');
+    }
+  });
+
+  it('returns fully-resolved when only stale/conflict issues and verify clears', async () => {
+    const outcome = await tryRebaseAndVerify(
+      'claude/test', 4287, ['conflict', 'stale'], '/tmp/wt', 'foo/bar',
+      { rebase: okRebase(), verify: okVerify() },
+    );
+    expect(outcome.kind).toBe('fully-resolved');
+  });
+
+  it('returns partially-resolved when rebase clears conflict but other issues remain', async () => {
+    const outcome = await tryRebaseAndVerify(
+      'claude/test', 4287,
+      ['conflict', 'ci-failure', 'bot-review-major'] as PrIssueType[],
+      '/tmp/wt', 'foo/bar',
+      { rebase: okRebase(), verify: okVerify() },
+    );
+    expect(outcome.kind).toBe('partially-resolved');
+    if (outcome.kind === 'partially-resolved') {
+      expect(outcome.remainingIssues).toEqual(['ci-failure', 'bot-review-major']);
+    }
+  });
+
+  it('skips the GitHub verify call for stale-only rebases (no conflict)', async () => {
+    // Stale-only rebases shouldn't pay the ~12s GitHub polling budget.
+    let verifyCalls = 0;
+    const outcome = await tryRebaseAndVerify(
+      'claude/test', 4287, ['stale'], '/tmp/wt', 'foo/bar',
+      {
+        rebase: okRebase(),
+        verify: async () => {
+          verifyCalls++;
+          return { cleared: true, reason: '', mergeable: null, mergeStateStatus: null, attempts: 0 };
+        },
+      },
+    );
+    expect(verifyCalls).toBe(0);
+    expect(outcome.kind).toBe('fully-resolved');
+  });
+
+  it('short-circuits on rebase failure without calling verify', async () => {
+    let verifyCalls = 0;
+    await tryRebaseAndVerify(
+      'claude/test', 4287, ['conflict'], '/tmp/wt', 'foo/bar',
+      {
+        rebase: failRebase('push-failed'),
+        verify: async () => {
+          verifyCalls++;
+          return { cleared: true, reason: '', mergeable: null, mergeStateStatus: null, attempts: 0 };
+        },
+      },
+    );
+    expect(verifyCalls).toBe(0);
   });
 });

--- a/crux/pr-patrol/rebase-verify.test.ts
+++ b/crux/pr-patrol/rebase-verify.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  verifyRebaseCleared,
+  DEFAULT_MAX_ATTEMPTS,
+  type VerifyRebaseDeps,
+} from './rebase-verify.ts';
+import type { GqlPrNode } from '../lib/pr-analysis/types.ts';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makePr(overrides: Partial<GqlPrNode> = {}): GqlPrNode {
+  return {
+    id: 'PR_x',
+    number: 4287,
+    title: 'test',
+    headRefName: 'claude/test',
+    headRefOid: 'f21ed7a',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    isDraft: false,
+    createdAt: '2026-04-13T17:00:00Z',
+    updatedAt: '2026-04-13T17:10:00Z',
+    body: null,
+    author: { login: 'ozziegooen' },
+    labels: { nodes: [] },
+    commits: { nodes: [] },
+    ...overrides,
+  };
+}
+
+/**
+ * Build a deps object with a scripted fetchPr that returns the given sequence
+ * of results in order. Also records sleep calls.
+ */
+function makeDeps(
+  results: Array<GqlPrNode | null | Error>,
+  overrides: Partial<VerifyRebaseDeps> = {},
+): VerifyRebaseDeps & { fetchCalls: number; sleepCalls: number[] } {
+  let fetchCalls = 0;
+  const sleepCalls: number[] = [];
+  return {
+    fetchPr: async () => {
+      const result = results[fetchCalls];
+      fetchCalls++;
+      if (result instanceof Error) throw result;
+      return result ?? null;
+    },
+    sleep: async (ms: number) => {
+      sleepCalls.push(ms);
+    },
+    delayMs: 100, // tiny delay so tests stay fast
+    ...overrides,
+    get fetchCalls() {
+      return fetchCalls;
+    },
+    sleepCalls,
+  };
+}
+
+// ── Cleared path ─────────────────────────────────────────────────────────────
+
+describe('verifyRebaseCleared — cleared', () => {
+  it('returns cleared=true when the first poll shows MERGEABLE', async () => {
+    const deps = makeDeps([makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+
+    expect(result.cleared).toBe(true);
+    expect(result.mergeable).toBe('MERGEABLE');
+    expect(result.mergeStateStatus).toBe('CLEAN');
+    expect(result.attempts).toBe(1);
+  });
+
+  it('returns cleared=true for BEHIND / BLOCKED / UNSTABLE (non-conflict gates)', async () => {
+    // BEHIND / BLOCKED / UNSTABLE are not conflicts — they're other gates
+    // (branch protection, required reviews, failing checks) and should not
+    // make us re-trigger a conflict fix loop.
+    for (const state of ['BEHIND', 'BLOCKED', 'UNSTABLE', 'HAS_HOOKS']) {
+      const deps = makeDeps([makePr({ mergeable: 'MERGEABLE', mergeStateStatus: state })]);
+      const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+      expect(result.cleared).toBe(true);
+      expect(result.reason).toContain(state);
+    }
+  });
+
+  it('polls past UNKNOWN and accepts the first definitive state', async () => {
+    const deps = makeDeps([
+      makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' }),
+      makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' }),
+      makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }),
+    ]);
+
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(deps.sleepCalls).toHaveLength(3); // one before each fetch
+  });
+});
+
+// ── Not cleared ──────────────────────────────────────────────────────────────
+
+describe('verifyRebaseCleared — still conflicting', () => {
+  it('returns cleared=false when mergeable=CONFLICTING (QUA-400 regression)', async () => {
+    // This is the core QUA-400 scenario: PR #4287 cycle 45 saw
+    // mergeable=CONFLICTING with a new head_sha after cycle 44's rebase.
+    const deps = makeDeps([
+      makePr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', headRefOid: 'f21ed7a' }),
+    ]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+
+    expect(result.cleared).toBe(false);
+    expect(result.reason).toContain('still conflicting');
+    expect(result.mergeable).toBe('CONFLICTING');
+    expect(result.mergeStateStatus).toBe('DIRTY');
+    // CONFLICTING is definitive — we stop polling immediately
+    expect(result.attempts).toBe(1);
+  });
+
+  it('returns cleared=false when mergeStateStatus=DIRTY even if mergeable is not CONFLICTING', async () => {
+    // Belt-and-suspenders: some GraphQL responses report these fields out
+    // of sync. Treat either CONFLICTING or DIRTY as conflict.
+    const deps = makeDeps([makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'DIRTY' })]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(result.reason).toContain('still conflicting');
+  });
+
+  it('gives up after max attempts when mergeable stays UNKNOWN', async () => {
+    const deps = makeDeps(
+      Array.from({ length: DEFAULT_MAX_ATTEMPTS }, () =>
+        makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' }),
+      ),
+    );
+
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(result.reason).toContain('UNKNOWN');
+    expect(result.attempts).toBe(DEFAULT_MAX_ATTEMPTS);
+  });
+
+  it('returns cleared=false when fetchPr returns null on every attempt', async () => {
+    const deps = makeDeps([null, null, null, null]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(result.reason).toContain('null');
+    expect(result.attempts).toBe(DEFAULT_MAX_ATTEMPTS);
+  });
+
+  it('recovers when the first fetch fails but a later one succeeds', async () => {
+    const deps = makeDeps([
+      new Error('API 500'),
+      makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }),
+    ]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(true);
+    expect(result.attempts).toBe(2);
+  });
+});
+
+// ── Tuning knobs ─────────────────────────────────────────────────────────────
+
+describe('verifyRebaseCleared — config', () => {
+  it('respects a custom maxAttempts=1', async () => {
+    const deps = makeDeps(
+      [makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN' })],
+      { maxAttempts: 1 },
+    );
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(result.attempts).toBe(1);
+  });
+
+  it('stops polling early when a definitive state is observed', async () => {
+    // If first poll says CONFLICTING, we shouldn't burn the rest of the budget.
+    const deps = makeDeps([
+      makePr({ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }),
+      makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' }), // should never be reached
+    ]);
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(deps.fetchCalls).toBe(1); // definitive CONFLICTING ends the loop
+  });
+});

--- a/crux/pr-patrol/rebase-verify.test.ts
+++ b/crux/pr-patrol/rebase-verify.test.ts
@@ -171,6 +171,25 @@ describe('verifyRebaseCleared — still conflicting', () => {
     expect(result.cleared).toBe(true);
     expect(result.attempts).toBe(2);
   });
+
+  it('reports the fetch exception message when every attempt throws', async () => {
+    // CodeRabbit review: the previous "fetchSinglePr returned null" text was
+    // misleading when the actual failure was an exception. Now we surface
+    // the error message so the patrol JSONL says what really went wrong.
+    const deps = makeDeps(
+      [
+        new Error('API 500 Internal Server Error'),
+        new Error('API 500 Internal Server Error'),
+        new Error('API 500 Internal Server Error'),
+        new Error('API 500 Internal Server Error'),
+      ],
+    );
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(false);
+    expect(result.reason).toContain('threw');
+    expect(result.reason).toContain('API 500 Internal Server Error');
+    expect(result.attempts).toBe(DEFAULT_MAX_ATTEMPTS);
+  });
 });
 
 // ── Tuning knobs ─────────────────────────────────────────────────────────────
@@ -195,6 +214,31 @@ describe('verifyRebaseCleared — config', () => {
     const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
     expect(result.cleared).toBe(false);
     expect(deps.fetchCalls).toBe(1); // definitive CONFLICTING ends the loop
+  });
+
+  it('clamps maxAttempts=0 to at least one fetch (CodeRabbit guard)', async () => {
+    // CodeRabbit review: with maxAttempts=0 the loop used to be skipped
+    // entirely and the function returned "verification failed" without a
+    // single real fetch. Clamp to Math.max(1, ...) so a bad config still
+    // runs at least one poll.
+    const deps = makeDeps(
+      [makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })],
+      { maxAttempts: 0 },
+    );
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(deps.fetchCalls).toBe(1);
+  });
+
+  it('clamps a negative maxAttempts to one fetch', async () => {
+    const deps = makeDeps(
+      [makePr({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })],
+      { maxAttempts: -5 },
+    );
+    const result = await verifyRebaseCleared(4287, 'foo/bar', deps);
+    expect(result.cleared).toBe(true);
+    expect(result.attempts).toBe(1);
   });
 });
 

--- a/crux/pr-patrol/rebase-verify.ts
+++ b/crux/pr-patrol/rebase-verify.ts
@@ -1,0 +1,163 @@
+/**
+ * PR Patrol — Rebase outcome verification (QUA-400).
+ *
+ * `tryAutomatedRebase` in `lib/pr-analysis/rebase.ts` returns success when
+ * `git rebase origin/main` exits cleanly and the force-push succeeds. That is
+ * not the same thing as GitHub considering the PR mergeable — the divergence
+ * has several observed causes:
+ *
+ *   - GitHub recomputes mergeable asynchronously (several seconds of lag
+ *     after a force-push)
+ *   - A concurrent commit can land on the branch between rebase and scan,
+ *     re-introducing a conflict (head_sha f21ed7 rather than our 9be921)
+ *   - The PR targets a non-main base branch, so rebasing onto main does
+ *     nothing useful for mergeability
+ *
+ * When the patrol reported `outcome: 'fixed'` without verifying the GitHub
+ * state, the next scan cycle saw the PR still CONFLICTING and started the
+ * whole cycle over — 7 wasted cycles on PR #4287 before stuck-cycle detection
+ * kicked in.
+ *
+ * This module polls GitHub's PR state a few times with a short delay to
+ * distinguish "still computing" from "actually still conflicting". The
+ * rebase is only considered cleared when a fresh read returns a
+ * non-CONFLICTING, non-UNKNOWN mergeable state.
+ */
+
+import { fetchSinglePr } from '../lib/pr-analysis/detection.ts';
+import type { GqlPrNode } from '../lib/pr-analysis/types.ts';
+
+export interface RebaseVerifyResult {
+  /** True when GitHub no longer reports the PR as conflicting. */
+  cleared: boolean;
+  /** Human-readable reason — logged and stored in the JSONL event. */
+  reason: string;
+  /** Last observed mergeable status (for debugging). */
+  mergeable: string | null;
+  /** Last observed mergeStateStatus (for debugging). */
+  mergeStateStatus: string | null;
+  /** Number of poll attempts actually made. */
+  attempts: number;
+}
+
+export interface VerifyRebaseDeps {
+  /** PR fetcher. Injectable for unit tests. Defaults to fetchSinglePr. */
+  fetchPr?: (prNumber: number, repo: string) => Promise<GqlPrNode | null>;
+  /** Sleep fn. Injectable for unit tests. Defaults to setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Max poll attempts. Default 4. */
+  maxAttempts?: number;
+  /** Delay between polls in ms. Default 3000. */
+  delayMs?: number;
+}
+
+/**
+ * Default max poll attempts. 4 × 3s = up to 12s of verification latency,
+ * which is acceptable cost given that a wasted patrol cycle takes minutes
+ * of compute.
+ */
+export const DEFAULT_MAX_ATTEMPTS = 4;
+
+/**
+ * Default delay between polls. 3s chosen because GitHub's async mergeable
+ * recomputation typically settles within 2-4s of a push.
+ */
+export const DEFAULT_DELAY_MS = 3000;
+
+/**
+ * Verify that a PR's conflict state actually cleared after an automated
+ * rebase. Returns `cleared: true` only when GitHub reports a non-CONFLICTING,
+ * non-UNKNOWN mergeable state on at least one fresh read.
+ *
+ * @param prNumber PR number
+ * @param repo     owner/repo string (e.g. "foo/bar")
+ * @param deps     injectable dependencies for testing
+ */
+export async function verifyRebaseCleared(
+  prNumber: number,
+  repo: string,
+  deps: VerifyRebaseDeps = {},
+): Promise<RebaseVerifyResult> {
+  const maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
+  const fetchPr = deps.fetchPr ?? fetchSinglePr;
+  const sleep =
+    deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  let lastMergeable: string | null = null;
+  let lastMergeStateStatus: string | null = null;
+  let attempts = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    attempts = attempt;
+    // Always wait before each fetch — gives GitHub time to recompute
+    // mergeable asynchronously on the first attempt, and spaces out polls
+    // when we're waiting for UNKNOWN → resolved on subsequent attempts.
+    await sleep(delayMs);
+
+    let pr: GqlPrNode | null = null;
+    try {
+      pr = await fetchPr(prNumber, repo);
+    } catch {
+      pr = null;
+    }
+
+    if (pr == null) {
+      // Fetch failed. Retry if we have attempts left.
+      if (attempt < maxAttempts) continue;
+      return {
+        cleared: false,
+        reason: `fetchSinglePr returned null after ${maxAttempts} attempts`,
+        mergeable: lastMergeable,
+        mergeStateStatus: lastMergeStateStatus,
+        attempts,
+      };
+    }
+
+    lastMergeable = pr.mergeable ?? null;
+    lastMergeStateStatus = pr.mergeStateStatus ?? null;
+
+    // CONFLICTING / DIRTY → still has conflicts. Checked before UNKNOWN so a
+    // definitive conflict signal wins over a "still computing" one from the
+    // other field (GraphQL sometimes reports them inconsistently).
+    if (pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'DIRTY') {
+      return {
+        cleared: false,
+        reason: `PR still conflicting after rebase (mergeable=${pr.mergeable}, mergeStateStatus=${pr.mergeStateStatus ?? 'n/a'})`,
+        mergeable: lastMergeable,
+        mergeStateStatus: lastMergeStateStatus,
+        attempts,
+      };
+    }
+
+    // UNKNOWN → GitHub is still computing, poll again.
+    if (pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'UNKNOWN') {
+      if (attempt < maxAttempts) continue;
+      return {
+        cleared: false,
+        reason: `mergeable still UNKNOWN after ${maxAttempts} polls (GitHub recomputation stalled)`,
+        mergeable: lastMergeable,
+        mergeStateStatus: lastMergeStateStatus,
+        attempts,
+      };
+    }
+
+    // MERGEABLE / BLOCKED / BEHIND / CLEAN / UNSTABLE / HAS_HOOKS → conflict
+    // cleared. BLOCKED/BEHIND aren't conflicts, just other gates.
+    return {
+      cleared: true,
+      reason: `mergeable=${pr.mergeable}, mergeStateStatus=${pr.mergeStateStatus ?? 'n/a'}`,
+      mergeable: lastMergeable,
+      mergeStateStatus: lastMergeStateStatus,
+      attempts,
+    };
+  }
+
+  return {
+    cleared: false,
+    reason: `max attempts (${maxAttempts}) exhausted without a definitive state`,
+    mergeable: lastMergeable,
+    mergeStateStatus: lastMergeStateStatus,
+    attempts,
+  };
+}

--- a/crux/pr-patrol/rebase-verify.ts
+++ b/crux/pr-patrol/rebase-verify.ts
@@ -25,7 +25,8 @@
  */
 
 import { fetchSinglePr } from '../lib/pr-analysis/detection.ts';
-import type { GqlPrNode } from '../lib/pr-analysis/types.ts';
+import { tryAutomatedRebase } from '../lib/pr-analysis/rebase.ts';
+import type { AutoRebaseResult, GqlPrNode, PrIssueType } from '../lib/pr-analysis/types.ts';
 
 export interface RebaseVerifyResult {
   /** True when GitHub no longer reports the PR as conflicting. */
@@ -90,10 +91,11 @@ export async function verifyRebaseCleared(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     attempts = attempt;
-    // Always wait before each fetch — gives GitHub time to recompute
-    // mergeable asynchronously on the first attempt, and spaces out polls
-    // when we're waiting for UNKNOWN → resolved on subsequent attempts.
-    await sleep(delayMs);
+    // Sleep before retries, not before the first fetch — the happy path
+    // (rebase actually worked, GitHub state already CLEAN) shouldn't pay a
+    // guaranteed 3s latency. We only pay the delay if the first read is
+    // UNKNOWN or the fetch fails and we need to retry.
+    if (attempt > 1) await sleep(delayMs);
 
     let pr: GqlPrNode | null = null;
     try {
@@ -159,5 +161,89 @@ export async function verifyRebaseCleared(
     mergeable: lastMergeable,
     mergeStateStatus: lastMergeStateStatus,
     attempts,
+  };
+}
+
+// ── Rebase-and-verify orchestration ──────────────────────────────────────────
+
+/**
+ * Outcome of a combined rebase + verify attempt. Callers pattern-match on
+ * `kind` to decide what to report / log / return. Side effects (JSONL writes,
+ * worktree removal, claim tracking) are the caller's responsibility because
+ * the two patrol entry points (`execution.ts::fixPr` and
+ * `parallel.ts::fixPrInWorktree`) have different return shapes and different
+ * claim / cleanup concerns.
+ */
+export type RebaseAndVerifyOutcome =
+  /** `git rebase` exited non-zero (conflict, fetch failure, etc.). */
+  | { kind: 'rebase-failed'; status: AutoRebaseResult['status'] }
+  /** Rebase pushed, but GitHub still reports the PR as conflicting. */
+  | { kind: 'verify-failed'; rebaseStatus: AutoRebaseResult['status']; verify: RebaseVerifyResult }
+  /** All `stale` + `conflict` issues resolved. Caller should mark fixed. */
+  | { kind: 'fully-resolved'; rebaseStatus: AutoRebaseResult['status'] }
+  /** Rebase cleared stale/conflict but other issues remain. Caller should
+   *  update `pr.issues` to `remainingIssues` and fall through to Claude. */
+  | {
+      kind: 'partially-resolved';
+      rebaseStatus: AutoRebaseResult['status'];
+      remainingIssues: PrIssueType[];
+    };
+
+export interface TryRebaseAndVerifyDeps {
+  /** Injectable git rebase — defaults to `tryAutomatedRebase`. */
+  rebase?: typeof tryAutomatedRebase;
+  /** Injectable GitHub verify — defaults to `verifyRebaseCleared`. */
+  verify?: typeof verifyRebaseCleared;
+  /** Forwarded to `verifyRebaseCleared` when the default is used. */
+  verifyDeps?: VerifyRebaseDeps;
+}
+
+/**
+ * Attempt a git-level rebase and verify that GitHub considers the PR no
+ * longer conflicting. Extracted from `execution.ts` + `parallel.ts` so both
+ * patrol entry points share a single code path (QUA-400 simplify pass).
+ *
+ * Note: this function does NOT write JSONL or manage claims — each caller
+ * handles those based on its own loop structure.
+ */
+export async function tryRebaseAndVerify(
+  branch: string,
+  prNumber: number,
+  issues: readonly PrIssueType[],
+  worktreePath: string,
+  repo: string,
+  deps: TryRebaseAndVerifyDeps = {},
+): Promise<RebaseAndVerifyOutcome> {
+  const doRebase = deps.rebase ?? tryAutomatedRebase;
+  const doVerify = deps.verify ?? verifyRebaseCleared;
+
+  const rebaseResult = doRebase(branch, worktreePath);
+  if (!rebaseResult.success) {
+    return { kind: 'rebase-failed', status: rebaseResult.status };
+  }
+
+  // Only pay the GitHub round-trip when we actually had a conflict to clear.
+  // Stale-only rebases don't need a mergeable-state recheck.
+  if (issues.includes('conflict')) {
+    const verify = await doVerify(prNumber, repo, deps.verifyDeps);
+    if (!verify.cleared) {
+      return {
+        kind: 'verify-failed',
+        rebaseStatus: rebaseResult.status,
+        verify,
+      };
+    }
+  }
+
+  const remainingIssues = issues.filter(
+    (i) => i !== 'stale' && i !== 'conflict',
+  );
+  if (remainingIssues.length === 0) {
+    return { kind: 'fully-resolved', rebaseStatus: rebaseResult.status };
+  }
+  return {
+    kind: 'partially-resolved',
+    rebaseStatus: rebaseResult.status,
+    remainingIssues,
   };
 }

--- a/crux/pr-patrol/rebase-verify.ts
+++ b/crux/pr-patrol/rebase-verify.ts
@@ -79,14 +79,18 @@ export async function verifyRebaseCleared(
   repo: string,
   deps: VerifyRebaseDeps = {},
 ): Promise<RebaseVerifyResult> {
-  const maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
+  // Clamp polling config to sane minimums so a misconfigured caller
+  // (maxAttempts=0, delayMs=-1, etc.) can't silently short-circuit the loop
+  // and return "verification failed" without a single real fetch.
+  const maxAttempts = Math.max(1, deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const delayMs = Math.max(0, deps.delayMs ?? DEFAULT_DELAY_MS);
   const fetchPr = deps.fetchPr ?? fetchSinglePr;
   const sleep =
     deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
   let lastMergeable: string | null = null;
   let lastMergeStateStatus: string | null = null;
+  let lastFetchError: string | null = null;
   let attempts = 0;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -98,18 +102,27 @@ export async function verifyRebaseCleared(
     if (attempt > 1) await sleep(delayMs);
 
     let pr: GqlPrNode | null = null;
+    let fetchThrew = false;
     try {
       pr = await fetchPr(prNumber, repo);
-    } catch {
+    } catch (err) {
       pr = null;
+      fetchThrew = true;
+      lastFetchError = err instanceof Error ? err.message : String(err);
     }
 
     if (pr == null) {
       // Fetch failed. Retry if we have attempts left.
       if (attempt < maxAttempts) continue;
+      // Distinguish exception-from-fetcher vs explicit null return — the
+      // original "returned null" text was misleading when the real failure
+      // was an API error we caught above.
+      const reason = fetchThrew
+        ? `fetchSinglePr threw after ${maxAttempts} attempts: ${lastFetchError ?? 'unknown error'}`
+        : `fetchSinglePr returned null after ${maxAttempts} attempts`;
       return {
         cleared: false,
-        reason: `fetchSinglePr returned null after ${maxAttempts} attempts`,
+        reason,
         mergeable: lastMergeable,
         mergeStateStatus: lastMergeStateStatus,
         attempts,


### PR DESCRIPTION
## Summary

`tryAutomatedRebase` reports success when `git rebase origin/main` exits cleanly and the force-push succeeds. That is not the same thing as GitHub considering the PR mergeable:

- GitHub recomputes `mergeable` asynchronously (several seconds of lag after a force-push)
- A concurrent commit can land on the branch between rebase and push
- The PR may target a non-main base branch

PR #4287 hit this class of failure: cycle 44 reported `outcome: 'fixed'` with `reason: 'automated-rebase: rebased'`, but cycles 45–50 all saw `mergeable=CONFLICTING` with a new head_sha. Patrol wasted 7 cycles before stuck-cycle detection kicked in.

## Fix

New `crux/pr-patrol/rebase-verify.ts` module polls GitHub's PR state with short delays (4 × 3s by default) to distinguish "still computing" (`UNKNOWN`) from "actually still conflicting" (`CONFLICTING` / `DIRTY`). A definitive conflict short-circuits immediately; `UNKNOWN` keeps polling up to the attempt budget.

Wired into both fix paths:

- `execution.ts` — serial fix path (`fixPr`)
- `parallel.ts` — parallel batch fix path

On verify failure, we fall through to Claude with the original `conflict` issue still in the list (instead of falsely claiming fixed) and emit a `rebase_verify_failed` JSONL event with the observed `mergeable` / `mergeStateStatus` / `attempts` for patrol observability.

## Test plan

- [x] New `rebase-verify.test.ts` — 10 tests covering:
  - Cleared path: first poll shows MERGEABLE / BLOCKED / BEHIND / UNSTABLE / HAS_HOOKS
  - Polling past UNKNOWN to a definitive state
  - CONFLICTING short-circuits immediately (doesn't burn the attempt budget)
  - `mergeStateStatus=DIRTY` wins over `mergeable=UNKNOWN` (inconsistent GraphQL response)
  - Max-attempts exhausted on persistent UNKNOWN
  - Fetch failures (null / throw) recoverable mid-sequence
  - Custom `maxAttempts=1` config path
- [x] `parallel.test.ts` + all 363 `crux/pr-patrol/**` tests pass
- [x] No type errors introduced in touched files

Closes QUA-400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated rebase now verifies GitHub merge state and records verified fixes.
  * Centralized claim/release helpers and a “claim before rebase” flow to avoid worker interference.

* **Bug Fixes**
  * Rebase outcomes clarified and recorded (fully/partially resolved, verify-failed, rebase-failed) with mergeability details.
  * Safer label release behavior and improved GitHub API error handling (404 discrimination).

* **Tests**
  * New tests covering rebase/verify logic and claim/release ownership and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->