### PR TITLE
feat(linear view): surface sub-issues so agents see the breakdown (QUA-481)

### DIFF
--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -130,6 +130,34 @@ async function view(args: string[], options: CommandOptions): Promise<CommandRes
   if (issue.description) {
     out += `\n${issue.description.slice(0, 1000)}${issue.description.length > 1000 ? '\n…(truncated)' : ''}\n`;
   }
+  const children = issue.children?.nodes ?? [];
+  if (children.length > 0) {
+    // Non-terminal states first so agents reading an epic see open work above
+    // shipped work — the point of the block is to prevent re-filing existing
+    // sub-issues (QUA-481 post-mortem).
+    const isTerminal = (type: string) =>
+      type === 'completed' || type === 'canceled';
+    const stateRank = (name: string): number => {
+      const r: Record<string, number> = {
+        'In Progress': 0, 'In Review': 1, 'Todo': 2, 'Backlog': 3,
+        'Triage': 4, 'Done': 5, 'Canceled': 6, 'Duplicate': 7,
+      };
+      return r[name] ?? 8;
+    };
+    const sorted = [...children].sort((a, b) => {
+      const at = isTerminal(a.state.type) ? 1 : 0;
+      const bt = isTerminal(b.state.type) ? 1 : 0;
+      if (at !== bt) return at - bt;
+      const sr = stateRank(a.state.name) - stateRank(b.state.name);
+      if (sr !== 0) return sr;
+      return a.identifier.localeCompare(b.identifier);
+    });
+    out += `\n${c.bold}Children (${children.length}):${c.reset}\n`;
+    for (const ch of sorted) {
+      const stateColor = isTerminal(ch.state.type) ? c.dim : c.yellow;
+      out += `  ${c.cyan}${ch.identifier}${c.reset} ${stateColor}[${ch.state.name}]${c.reset} ${priorityLabel(ch.priority)} — ${ch.title}\n`;
+    }
+  }
   if (comments.length > 0) {
     out += `\n${c.bold}Comments (${comments.length}):${c.reset}\n`;
     for (const cm of comments) {

--- a/crux/lib/linear/__tests__/issues.test.ts
+++ b/crux/lib/linear/__tests__/issues.test.ts
@@ -31,6 +31,7 @@ const fullIssueFixture = {
   parent: null,
   project: null,
   labels: { nodes: [] },
+  children: { nodes: [] },
 };
 
 describe('issues.ts — transport helpers', () => {
@@ -89,6 +90,63 @@ describe('issues.ts — transport helpers', () => {
       ) as unknown as typeof fetch;
 
       await expect(getIssue('QUA-184')).rejects.toThrow(/Authentication/);
+    });
+
+    // QUA-481: children are surfaced in `view` output so agents reading a
+    // parent epic see the existing breakdown instead of re-deriving it from
+    // the description. Regression-guards the GraphQL shape.
+    it('parses children nodes when present', async () => {
+      const fixtureWithChildren = {
+        ...fullIssueFixture,
+        identifier: 'QUA-221',
+        children: {
+          nodes: [
+            {
+              identifier: 'QUA-222',
+              title: 'Phase 0',
+              priority: 1,
+              url: 'https://linear.app/quantifieduncertainty/issue/QUA-222',
+              state: { name: 'Done', type: 'completed' },
+            },
+            {
+              identifier: 'QUA-223',
+              title: 'Phase 1',
+              priority: 2,
+              url: 'https://linear.app/quantifieduncertainty/issue/QUA-223',
+              state: { name: 'Done', type: 'completed' },
+            },
+            {
+              identifier: 'QUA-224',
+              title: 'Phase 2',
+              priority: 3,
+              url: 'https://linear.app/quantifieduncertainty/issue/QUA-224',
+              state: { name: 'Backlog', type: 'backlog' },
+            },
+          ],
+        },
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: fixtureWithChildren } })
+      ) as unknown as typeof fetch;
+
+      const issue = await getIssue('QUA-221');
+      expect(issue!.children.nodes).toHaveLength(3);
+      expect(issue!.children.nodes[0].identifier).toBe('QUA-222');
+      expect(issue!.children.nodes[0].state.type).toBe('completed');
+      expect(issue!.children.nodes[2].state.name).toBe('Backlog');
+    });
+
+    it('requests children in the GraphQL query', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { issue: fullIssueFixture } })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await getIssue('QUA-184');
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.query).toMatch(/children\(first:\s*50\)/);
+      expect(body.query).toMatch(/nodes\s*\{[^}]*identifier/);
     });
   });
 

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -13,6 +13,14 @@ import {
   type WorkflowStateName,
 } from './workflow-states.ts';
 
+export interface LinearChildIssue {
+  identifier: string;
+  title: string;
+  priority: number;
+  url: string;
+  state: { name: string; type: string };
+}
+
 export interface LinearIssue {
   id: string;
   identifier: string;
@@ -25,6 +33,7 @@ export interface LinearIssue {
   parent: { identifier: string; title: string } | null;
   project: { id: string; name: string } | null;
   labels: { nodes: Array<{ name: string }> };
+  children: { nodes: LinearChildIssue[] };
 }
 
 export interface LinearComment {
@@ -54,6 +63,15 @@ export async function getIssue(identifier: string): Promise<LinearIssue | null> 
           parent { identifier title }
           project { id name }
           labels { nodes { name } }
+          children(first: 50) {
+            nodes {
+              identifier
+              title
+              priority
+              url
+              state { name type }
+            }
+          }
         }
       }`,
       { id: identifier },


### PR DESCRIPTION
## Summary

`crux linear view` now shows a **Children (N):** section listing the parent epic's sub-issues, with non-terminal states (Backlog / Todo / In Progress / In Review) first and terminal states (Done / Canceled) dimmed at the bottom. Until this PR, `view` showed description/state/priority/project/parent but not children, so agents reading a multi-phase parent epic had no in-terminal signal that earlier phases already shipped — they re-derived a plan from the (often stale) description body.

## Motivation — QUA-471 post-mortem

Yesterday's session on QUA-221 ("Agent Session Logging Rebuild") filed 4 duplicate sub-issues (QUA-466/467/468/469, all canceled) before discovering QUA-222/223/224 already existed, because `view` didn't show them. The stale `phases_done: 0` frontmatter in the parent body made it worse — the agent trusted the description and didn't sanity-check against Linear's actual child state. Fixing the view output is the smallest, highest-leverage systemic fix for the class.

## What changed

- `crux/lib/linear/issues.ts`: added `LinearChildIssue` + `children: { nodes: LinearChildIssue[] }` to the `LinearIssue` type and the `getIssue` GraphQL query (`children(first: 50)` with `identifier`, `title`, `priority`, `url`, `state { name type }`).
- `crux/commands/linear.ts` (`view` command): render `Children (N):` when non-empty, sort non-terminal-before-terminal then by state name then by identifier. Terminal children are dimmed.
- `crux/lib/linear/__tests__/issues.test.ts`: 2 new tests — one parsing a fixture with 3 children in mixed states, one asserting the GraphQL query string literally includes `children(first: 50)` and `nodes { identifier`.

## Live verification

```
$ pnpm crux linear view QUA-221
…
Children (8):
  QUA-224 [Backlog]  medium — Phase 2: Grafana dashboard via existing Loki/Promtail stack
  QUA-222 [Done]     urgent — Phase 0: Fix slot .env so heartbeats reach prod wiki-server
  QUA-223 [Done]     high   — Phase 1: SessionEnd hook + finalize command + hard-fail validation
  QUA-471 [Done]     urgent — findLatestTranscript slug derivation misses dots…
  QUA-466 [Canceled] high   — Phase 0: Fix slot .env so heartbeats reach prod wiki-server
  QUA-467 [Canceled] high   — Phase 1a: agent_sessions hard-fail validation + sweep job
  QUA-468 [Canceled] high   — Phase 1b: SessionEnd hook + sys session-finalize + transcript parser
  QUA-469 [Canceled] medium — Phase 2: Grafana agent-session dashboard via Loki + retention
```

A week ago, seeing this would have prevented QUA-471's wrong turn.

## Scope cuts

- **1 level only.** Grandchildren are deliberately out of scope — the goal is to prevent re-filing direct children, not to tree-render epics. If an agent needs the whole tree, `crux linear view <grandchild>` still surfaces its own parent link.
- **No `--json` changes.** The existing `--json` output already returns the full GraphQL response, so it picks up children automatically.
- **No `view` on project references.** This PR only touches issue view; project view is a separate code path.

## Test plan

- [x] `npx vitest run crux/lib/linear/__tests__/issues.test.ts` — 36/36 pass (2 new)
- [x] `pnpm crux w validate gate --scope=content --fix` — 5/5 pass
- [x] Live `crux linear view QUA-221` shows the 8 children with correct state ordering (non-terminal first, terminal dimmed at bottom)
- [x] Live `crux linear view QUA-471` (no children) — renders without a "Children" section (no empty header regression)

Fixes QUA-481
