### PR TITLE
Enable RELEVANCE_GATE_ENABLED in sourcing-recheck workflow (QUA-426)

### DIFF
--- a/.github/workflows/sourcing-recheck.yml
+++ b/.github/workflows/sourcing-recheck.yml
@@ -53,6 +53,14 @@ jobs:
       PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
       PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # QUA-426: enable the pre-LLM relevance gate. Short-circuits record-kind
+      # items to `not_applicable` when source content does not mention the
+      # record's subject, avoiding wasted LLM calls on generic org pages.
+      # Introduced as dark-default in PR #4349; enabled here on the recheck
+      # workflow first because the stale-reverify cohort (previously-
+      # unverifiable items) is where the gate provides value. Revert by
+      # deleting this line.
+      RELEVANCE_GATE_ENABLED: "true"
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
       INPUT_BUDGET: ${{ inputs.budget || '15' }}
       INPUT_LIMIT: ${{ inputs.limit || '500' }}


### PR DESCRIPTION
## Summary

One-line enablement of the QUA-426 pre-LLM relevance gate, shipped in [PR #4349](https://github.com/quantified-uncertainty/longterm-wiki/pull/4349) as dark-default. Flipping it on in `.github/workflows/sourcing-recheck.yml` so the weekly stale-reverify run exercises the gate against the cohort it was designed for.

## What the gate does

At `apps/wiki-server/src/routes/..` — actually at `crux/lib/sourcing/item-verifier.ts:418-441` — before calling the LLM on a record-kind source-check, run a cheap substring match: does the fetched source content even mention the record's subject (person name, org name, grantee)? If not, short-circuit to a `not_applicable` verdict instead of burning tokens on a page that obviously can't confirm or contradict the claim.

The canonical example from the PR body: Amanda Askell at Anthropic with `anthropic.com/` attached as a source. The bare Anthropic homepage does not mention "Amanda Askell", so the LLM burned tokens reading boilerplate and returned `unverifiable 0.95`, polluting Amanda's rollup. The gate catches this pre-LLM.

## Why `sourcing-recheck.yml` and not `sourcing.yml`

Two scheduled workflows invoke `crux verify-orchestrate`:

| Workflow | Cohort | Fit for the gate |
|---|---|---|
| `.github/workflows/sourcing.yml` (Mon 04:00 UTC, `$50` budget) | Dominated by **never-verified** items (priority-ordered first), most of which have uncached sources anyway | Low value — most items error at `fetchSourceContent()` before reaching the gate, per today's manual sample run where 44/50 of the `never-verified personnel` cohort errored as `not_cached` |
| `.github/workflows/sourcing-recheck.yml` (Mon 08:00 UTC, `$15` budget, `--limit=500`) | **Stale-reverify** of already-verified items, including the ~thousands of `unverifiable` verdicts the gate is designed to replace | **High value** — this is the exact target cohort from PR #4349's rollout plan ("run against currently-unverifiable records") |

So: enable here first, observe for a week, then enable in `sourcing.yml` as a follow-up.

## Why this is safe to merge

1. **Migration 0180 already applied in prod.** The `not_applicable` verdict is present in both CHECK constraints (`chk_source_check_evidence_verdict` and `chk_source_check_verdicts_verdict`) — verified directly against prod via `kubectl run psql` after today's release deploy. The gate's new verdict value will not hit a constraint violation.
2. **Code path validated in prod.** A manual sample today (`WIKI_SERVER_ENV=prod RELEVANCE_GATE_ENABLED=true pnpm crux verify-orchestrate personnel --limit=50`) flowed 6 personnel items through the gate's code path. All 6 correctly passed through (subjects were found in source content) and verdicts were written to `source_check_verdicts` under the new constraint. No crashes, no bad data.
3. **Dark-launch by design.** PR #4349 built the gate as opt-in so production can toggle it without a code deploy. This PR is the toggle.
4. **Reversible in seconds.** Revert = delete 8 lines.

## Diff

```yaml
# .github/workflows/sourcing-recheck.yml
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # QUA-426: enable the pre-LLM relevance gate. Short-circuits record-kind
+      # items to `not_applicable` when source content does not mention the
+      # record's subject, avoiding wasted LLM calls on generic org pages.
+      # Introduced as dark-default in PR #4349; enabled here on the recheck
+      # workflow first because the stale-reverify cohort (previously-
+      # unverifiable items) is where the gate provides value. Revert by
+      # deleting this line.
+      RELEVANCE_GATE_ENABLED: "true"
       # Assign inputs to env vars to avoid shell injection (GitHub Actions best practice)
```

## Verification plan

**Before merge**: gate check (covers workflow YAML schema), CodeRabbit scan of the diff.

**After merge — run manually instead of waiting for cron**:

```bash
gh workflow run sourcing-recheck.yml \
  -R quantified-uncertainty/longterm-wiki \
  --field record_type=personnel \
  --field limit=100 \
  --field budget=3
```

Then after the run completes (~15 min):

```sql
-- Total kill rate
SELECT count(*) FROM source_check_verdicts WHERE verdict='not_applicable';

-- Kill rate by record type
SELECT record_type, count(*)
FROM source_check_verdicts
WHERE verdict='not_applicable'
GROUP BY record_type
ORDER BY count(*) DESC;

-- Spot-check a few to verify the short-circuit was correct
SELECT record_type, record_id, reasoning
FROM source_check_verdicts
WHERE verdict='not_applicable'
LIMIT 20;
```

Grep the workflow run log for `[relevance_gate]` reasoning lines — each gate fire emits one. Report kill rate + any obvious false-negatives in a QUA-426 comment.

## Follow-up sequencing

1. **This PR** — enable in `sourcing-recheck.yml`, observe for 7 days.
2. **If kill rate looks healthy and no false-negative complaints**, follow-up PR to enable in `sourcing.yml` (the fresh Mon 04:00 UTC run).
3. **If the recheck run exposes issues** (false-negative bursts, unexpected errors), revert this PR. Single-line delete. No data corruption possible — `not_applicable` is an additive verdict value, existing rows are unaffected.

## Test plan

- [x] Diff reviewed — 8 lines added, zero lines removed, workflow structure unchanged
- [x] Gate runs on this change (CI will run the standard workflow-yaml validator)
- [x] Migration 0180 already applied in prod (verified via direct DB query after today's deploy)
- [x] Gate code path already exercised in prod with manual sample (6 items flowed cleanly)
- [ ] Post-merge: manual `workflow_dispatch` with `record_type=personnel --limit=100 --budget=3` and grep for `[relevance_gate]` lines
- [ ] Post-merge: prod DB query for `not_applicable` kill rate by record type

## Related

- Parent: [QUA-426](https://linear.app/quantifieduncertainty/issue/QUA-426) — Pre-LLM relevance gate
- Introducing PR: [#4349](https://github.com/quantified-uncertainty/longterm-wiki/pull/4349) — shipped in release 2026-04-14 #4
- Migration 0180: added `not_applicable` to both source-check CHECK constraints (shipped and verified in prod today)

Fixes QUA-426 (closes out the deployment rollout step from the PR #4349 plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
