### PR TITLE
feat(linear): crux linear hygiene + 2026-04-14 refactor archive

### DIFF
--- a/.claude/rules/linear-integration.md
+++ b/.claude/rules/linear-integration.md
@@ -133,6 +133,8 @@ The parser in `crux/lib/linear/parse-id.ts` uses an allowlist of known team keys
 
 See **`.claude/rules/linear-project-ownership.md`** for the decision rules on which of the 6 open QUA projects a new issue belongs in. The boundaries between Automation & Infrastructure, Source-Check & Verification, Data Integrity, Dashboards & Visibility, Content Quality & Enrichment, and Coordinator & Agent Tooling are non-obvious and get crossed repeatedly without an explicit doctrine. File new issues with a project from the start — orphans accumulate and the 2026-04-14 refactor pass had to move 22 issues between projects.
 
+**Hygiene scan**: `pnpm crux linear hygiene` reports orphan issues, label drift, priority gaps, and stuck tickets. Run quarterly (or when the backlog feels messy) to catch drift. Source: `crux/lib/linear/hygiene.ts`. Full refactor history: [`docs/audits/2026-04-14-linear-refactor.md`](../../docs/audits/2026-04-14-linear-refactor.md).
+
 ## 10. Key files
 
 | File | Purpose |

--- a/.claude/rules/linear-project-ownership.md
+++ b/.claude/rules/linear-project-ownership.md
@@ -110,10 +110,34 @@ Example: QUA-224 (Grafana dashboard, Dashboards) depends on QUA-221 (Agent Sessi
 
 ## Historical: why this doc exists
 
-2026-04-14 Linear refactor pass found:
+The 2026-04-14 Linear refactor pass found:
 - **16 orphan issues** (no project)
 - **22 issues in the wrong project** (sourcing split 3 ways being the worst cluster)
 - **3 closed umbrella issues** still cited as "Current focus" in project descriptions
 - **22 → 0 labels** after removing migration-era cruft
 
 The root cause of miscategorization wasn't malice — it was that the boundary between adjacent projects (sourcing/data-integrity, dashboards/automation, coordinator/automation) had never been written down. This doc is that boundary. Update it when a new systematic miscategorization emerges; don't let scope doctrine drift back into "gut feel."
+
+Full findings + methodology: [`docs/audits/2026-04-14-linear-refactor.md`](../../docs/audits/2026-04-14-linear-refactor.md).
+
+## The `crux linear hygiene` tool
+
+Run this quarterly (or any time the backlog feels messy):
+
+```bash
+pnpm crux linear hygiene          # human-readable report
+pnpm crux linear hygiene --json   # machine-readable
+```
+
+Scans all open QUA issues and reports:
+- Orphan count (issues with no project)
+- Label hygiene (coverage %, singleton labels, over-labeled issues)
+- Assignee coverage
+- Priority gaps (unprioritized count)
+- Stuck "In Progress" issues (>14 days since `startedAt`)
+- Thin tickets (<80 char description)
+- Open issue count per project
+
+If orphan count > 0, the new issues need projects assigned. If label count > 0 again, someone re-introduced a label and you need to decide whether to keep it (see § "Labels were the real discovery" in the audit doc).
+
+Source: `crux/lib/linear/hygiene.ts` + the `hygiene` entry in `crux/commands/linear.ts`.

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -39,6 +39,7 @@ import {
   type AuditBucket,
   type AuditEntry,
 } from '../lib/linear/audit.ts';
+import { runHygieneAudit, formatHygieneReport } from '../lib/linear/hygiene.ts';
 import { githubApi } from '../lib/github.ts';
 import { resolve as resolvePath } from 'path';
 import { fetchRemoteWorkflowStates } from '../lib/linear/workflow-states.ts';
@@ -377,6 +378,16 @@ async function done(args: string[], options: CommandOptions): Promise<CommandRes
   out += `${c.green}✓${c.reset} ${c.cyan}${id}${c.reset} → ${targetState}\n`;
   if (options.pr) out += `  PR: ${options.pr}\n`;
   return { output: out, exitCode: 0 };
+}
+
+async function hygiene(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  const report = await runHygieneAudit();
+  if (options.json) {
+    return { output: JSON.stringify(report, null, 2) + '\n', exitCode: 0 };
+  }
+  return { output: formatHygieneReport(report, c) + '\n', exitCode: 0 };
 }
 
 async function statesList(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -944,6 +955,7 @@ export const commands = {
   start,
   done,
   audit,
+  hygiene,
   'verify-pr': verifyPr,
   'leak-check': leakCheck,
   'states-list': statesList,
@@ -963,6 +975,7 @@ Commands:
   start <QUA-NNN>               Move issue to In Progress + post start comment
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
   audit                         Classify In Progress issues by PR health (shipped/orphan/epic/active)
+  hygiene                       Metadata hygiene scan: orphans, label coverage, priority gaps, stuck tickets
   verify-pr <PR>                Watchdog: ensure merged PR's Fixes QUA-NNN issues are actually Done
   leak-check                    Scan current session for QUA refs beyond the primary; warn about leaks
   states-list                   Show current QUA team workflow state IDs

--- a/crux/lib/linear/hygiene.ts
+++ b/crux/lib/linear/hygiene.ts
@@ -1,0 +1,330 @@
+/**
+ * Linear hygiene audit — read-only scan of the QUA team's open issues.
+ *
+ * Detects:
+ *   - Orphans (open issues with no project)
+ *   - Label hygiene (coverage %, singleton labels, over-labeled issues)
+ *   - Assignee coverage
+ *   - Priority coverage (unprioritized %)
+ *   - Stuck "In Progress" issues (> N days since startedAt)
+ *   - Thin tickets (<80 char description)
+ *   - Open issue count per project
+ *
+ * Complements `lib/linear/audit.ts` which classifies In Progress issues
+ * by PR health (shipped/orphan/epic/active). This module is about the
+ * orthogonal dimension — metadata hygiene across ALL open issues.
+ *
+ * Derived from the 2026-04-14 refactor pass. See
+ * `docs/audits/2026-04-14-linear-refactor.md` for the original findings.
+ *
+ * Usage:
+ *   - CLI: `pnpm crux linear hygiene` (wired in `crux/commands/linear.ts`)
+ *   - Programmatic: `import { runHygieneAudit } from '../lib/linear/hygiene.ts'`
+ */
+
+import { linearGraphQL } from './client.ts';
+import type { Colors } from '../output.ts';
+
+export interface HygieneIssue {
+  identifier: string;
+  title: string;
+  priority: number;
+  state: { name: string; type: string };
+  project: { id: string; name: string } | null;
+  assignee: { name: string } | null;
+  labels: { nodes: { name: string }[] };
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+}
+
+export interface HygieneReport {
+  totalOpen: number;
+  fetchedAt: string;
+
+  // Orphans
+  orphans: HygieneIssue[];
+
+  // Labels
+  issuesWithZeroLabels: number;
+  issuesWithManyLabels: number; // ≥5 labels
+  uniqueLabels: number;
+  topLabels: Array<{ name: string; count: number }>;
+  singletonLabels: string[];
+
+  // Assignees
+  unassignedCount: number;
+  assigneeBreakdown: Array<{ name: string; count: number }>;
+
+  // Priority
+  priorityBreakdown: Array<{ priority: number; label: string; count: number }>;
+  unprioritizedCount: number;
+
+  // Stuck
+  stuckInProgress: Array<{
+    identifier: string;
+    title: string;
+    assignee: string;
+    daysSinceStart: number;
+  }>;
+
+  // Thin tickets
+  thinTicketCount: number;
+
+  // Per-project counts
+  openByProject: Array<{ name: string; count: number }>;
+}
+
+const PRIORITY_LABEL: Record<number, string> = {
+  0: 'none',
+  1: 'urgent',
+  2: 'high',
+  3: 'medium',
+  4: 'low',
+};
+
+type FetchedIssue = HygieneIssue & { description: string | null };
+
+interface FetchResponse {
+  team: {
+    issues: {
+      nodes: FetchedIssue[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  };
+}
+
+async function fetchOpenIssues(teamId: string): Promise<FetchedIssue[]> {
+  const all: FetchedIssue[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const data: FetchResponse = await linearGraphQL<FetchResponse>(
+      `query($teamId: String!, $after: String) {
+        team(id: $teamId) {
+          issues(
+            first: 100
+            after: $after
+            filter: { state: { type: { nin: ["completed", "canceled"] } } }
+          ) {
+            nodes {
+              identifier title priority description
+              state { name type }
+              project { id name }
+              assignee { name }
+              labels { nodes { name } }
+              createdAt updatedAt startedAt
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { teamId, after: cursor },
+    );
+    all.push(...data.team.issues.nodes);
+    if (!data.team.issues.pageInfo.hasNextPage) break;
+    cursor = data.team.issues.pageInfo.endCursor;
+  }
+  return all;
+}
+
+async function getQuaTeamId(): Promise<string> {
+  const data = await linearGraphQL<{
+    teams: { nodes: Array<{ id: string; key: string }> };
+  }>(`query { teams { nodes { id key } } }`);
+  const qua = data.teams.nodes.find((t) => t.key === 'QUA');
+  if (!qua) throw new Error('QUA team not found in Linear workspace');
+  return qua.id;
+}
+
+const STUCK_DAYS_THRESHOLD = 14;
+const THIN_DESCRIPTION_CHARS = 80;
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+export async function runHygieneAudit(): Promise<HygieneReport> {
+  const teamId = await getQuaTeamId();
+  const rawIssues = await fetchOpenIssues(teamId);
+
+  const now = Date.now();
+
+  // ── Orphans ──
+  const orphans = rawIssues.filter((i) => !i.project);
+
+  // ── Labels ──
+  const issuesWithZeroLabels = rawIssues.filter((i) => i.labels.nodes.length === 0).length;
+  const issuesWithManyLabels = rawIssues.filter((i) => i.labels.nodes.length >= 5).length;
+  const labelCounts = new Map<string, number>();
+  for (const issue of rawIssues) {
+    for (const l of issue.labels.nodes) {
+      labelCounts.set(l.name, (labelCounts.get(l.name) ?? 0) + 1);
+    }
+  }
+  const topLabels = [...labelCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 20)
+    .map(([name, count]) => ({ name, count }));
+  const singletonLabels = [...labelCounts.entries()]
+    .filter(([, c]) => c === 1)
+    .map(([name]) => name)
+    .sort();
+
+  // ── Assignees ──
+  const unassignedCount = rawIssues.filter((i) => !i.assignee).length;
+  const assigneeCounts = new Map<string, number>();
+  for (const i of rawIssues) {
+    const name = i.assignee?.name ?? '(unassigned)';
+    assigneeCounts.set(name, (assigneeCounts.get(name) ?? 0) + 1);
+  }
+  const assigneeBreakdown = [...assigneeCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }));
+
+  // ── Priority ──
+  const priorityCounts = new Map<number, number>();
+  for (const i of rawIssues) {
+    priorityCounts.set(i.priority, (priorityCounts.get(i.priority) ?? 0) + 1);
+  }
+  const priorityBreakdown = [...priorityCounts.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([priority, count]) => ({
+      priority,
+      label: PRIORITY_LABEL[priority] ?? String(priority),
+      count,
+    }));
+  const unprioritizedCount = priorityCounts.get(0) ?? 0;
+
+  // ── Stuck In Progress ──
+  const stuckInProgress = rawIssues
+    .filter((i) => i.state.type === 'started' && i.startedAt)
+    .map((i) => ({
+      identifier: i.identifier,
+      title: i.title,
+      assignee: i.assignee?.name ?? 'unassigned',
+      daysSinceStart: Math.round((now - Date.parse(i.startedAt!)) / DAY_MS),
+    }))
+    .filter((i) => i.daysSinceStart > STUCK_DAYS_THRESHOLD)
+    .sort((a, b) => b.daysSinceStart - a.daysSinceStart);
+
+  // ── Thin tickets ──
+  const thinTicketCount = rawIssues.filter(
+    (i) => (i.description ?? '').trim().length < THIN_DESCRIPTION_CHARS,
+  ).length;
+
+  // ── Per-project ──
+  const projectCounts = new Map<string, number>();
+  for (const i of rawIssues) {
+    const key = i.project?.name ?? '(orphan)';
+    projectCounts.set(key, (projectCounts.get(key) ?? 0) + 1);
+  }
+  const openByProject = [...projectCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }));
+
+  // Strip `description` from orphans before returning — the report is
+  // meant to be printed; we don't want giant bodies in the output.
+  const orphansLite: HygieneIssue[] = orphans.map(({ description: _d, ...rest }) => rest);
+
+  return {
+    totalOpen: rawIssues.length,
+    fetchedAt: new Date().toISOString(),
+    orphans: orphansLite,
+    issuesWithZeroLabels,
+    issuesWithManyLabels,
+    uniqueLabels: labelCounts.size,
+    topLabels,
+    singletonLabels,
+    unassignedCount,
+    assigneeBreakdown,
+    priorityBreakdown,
+    unprioritizedCount,
+    stuckInProgress,
+    thinTicketCount,
+    openByProject,
+  };
+}
+
+export function formatHygieneReport(r: HygieneReport, c: Colors): string {
+  const lines: string[] = [];
+
+  lines.push(`${c.bold}${c.blue}Linear Hygiene — QUA team${c.reset}`);
+  lines.push(`${c.dim}Fetched: ${r.fetchedAt}${c.reset}`);
+  lines.push('');
+  lines.push(`Total open issues: ${c.bold}${r.totalOpen}${c.reset}`);
+  lines.push('');
+
+  // Orphans
+  const orphansColor = r.orphans.length === 0 ? c.green : c.yellow;
+  lines.push(`${c.bold}Orphans (no project):${c.reset} ${orphansColor}${r.orphans.length}${c.reset}`);
+  if (r.orphans.length > 0) {
+    for (const i of r.orphans.sort((a, b) => a.priority - b.priority)) {
+      const pri = PRIORITY_LABEL[i.priority] ?? String(i.priority);
+      lines.push(`  ${i.identifier}  ${pri}  [${i.state.name}]  ${i.title.slice(0, 72)}`);
+    }
+  }
+  lines.push('');
+
+  // Label hygiene
+  const labelCoveragePct = Math.round(
+    ((r.totalOpen - r.issuesWithZeroLabels) / Math.max(1, r.totalOpen)) * 100,
+  );
+  lines.push(`${c.bold}Label hygiene:${c.reset}`);
+  lines.push(`  Issues with 0 labels: ${r.issuesWithZeroLabels}/${r.totalOpen}  (${100 - labelCoveragePct}% unlabeled)`);
+  lines.push(`  Issues with ≥5 labels: ${r.issuesWithManyLabels}`);
+  lines.push(`  Unique labels in use: ${r.uniqueLabels}`);
+  if (r.topLabels.length > 0) {
+    lines.push(`  Top labels:`);
+    for (const { name, count } of r.topLabels.slice(0, 10)) {
+      lines.push(`    ${count.toString().padStart(4)}  ${name}`);
+    }
+  }
+  if (r.singletonLabels.length > 0) {
+    lines.push(
+      `  Singleton labels (used once — potential typo/cruft): ${r.singletonLabels.length}`,
+    );
+    if (r.singletonLabels.length <= 15) {
+      lines.push(`    ${r.singletonLabels.join(', ')}`);
+    }
+  }
+  lines.push('');
+
+  // Assignees
+  lines.push(`${c.bold}Assignees:${c.reset}`);
+  lines.push(`  Unassigned: ${r.unassignedCount}/${r.totalOpen}`);
+  for (const { name, count } of r.assigneeBreakdown) {
+    lines.push(`    ${count.toString().padStart(4)}  ${name}`);
+  }
+  lines.push('');
+
+  // Priority
+  lines.push(`${c.bold}Priority:${c.reset}`);
+  for (const { label, count } of r.priorityBreakdown) {
+    lines.push(`    ${count.toString().padStart(4)}  ${label}`);
+  }
+  lines.push(`  Unprioritized: ${r.unprioritizedCount}/${r.totalOpen}`);
+  lines.push('');
+
+  // Stuck
+  const stuckColor = r.stuckInProgress.length === 0 ? c.green : c.yellow;
+  lines.push(
+    `${c.bold}Stuck "In Progress" (>${STUCK_DAYS_THRESHOLD} days):${c.reset} ${stuckColor}${r.stuckInProgress.length}${c.reset}`,
+  );
+  for (const i of r.stuckInProgress) {
+    lines.push(
+      `  ${i.identifier}  ${i.daysSinceStart}d  ${i.assignee}  ${i.title.slice(0, 60)}`,
+    );
+  }
+  lines.push('');
+
+  // Thin tickets
+  lines.push(
+    `${c.bold}Thin tickets (< ${THIN_DESCRIPTION_CHARS} chars):${c.reset} ${r.thinTicketCount}`,
+  );
+  lines.push('');
+
+  // Per-project
+  lines.push(`${c.bold}Open by project:${c.reset}`);
+  for (const { name, count } of r.openByProject) {
+    lines.push(`    ${count.toString().padStart(4)}  ${name}`);
+  }
+
+  return lines.join('\n');
+}

--- a/docs/audits/2026-04-14-linear-refactor.md
+++ b/docs/audits/2026-04-14-linear-refactor.md
@@ -1,0 +1,102 @@
+# Linear Refactor — 2026-04-14
+
+One-page summary of the Linear hygiene / project / epic / description deep-audit pass that ran during a 2026-04-14 agent session. This doc is **historical reference only** — all findings were fixed during the session. The ongoing tooling that replaces ad-hoc audits is `crux linear hygiene` (added in this pass).
+
+Linked from:
+
+- [`docs/audits/README.md`](./README.md)
+- [`.claude/rules/linear-project-ownership.md`](../../.claude/rules/linear-project-ownership.md) (the doctrine this session produced)
+- [`.claude/rules/linear-integration.md`](../../.claude/rules/linear-integration.md) § 9 (hygiene tool reference)
+
+## What triggered it
+
+After completing the Tablebase Route Systematization project (QUA-367/454/455/456 + cleanup, 5 PRs), I ran a routine orphan-scan against the QUA team's open issues. The user's reaction — *"these aren't that many changes, given tons of issues. some have a bunch of labels, some have none"* — triggered a deeper pass that uncovered systematic label, description, and scope-boundary problems the first-pass audit missed.
+
+## Methodology
+
+Three parallel subagents analyzed a single snapshot dump of all 183 open QUA issues + 8 projects, each focused on a different dimension:
+
+1. **Projects subagent** — scope drift, description staleness, inter-project overlap, dead umbrella refs
+2. **Epics subagent** — parent-child hierarchy, orphaned sub-issues, epic candidates without structure
+3. **Descriptions subagent** — stub markers, stale PR references, self-contained titles, vague temporal language
+
+A verification pass then ground-truthed the load-bearing claims against live Linear state before execution (one subagent false positive was caught: QUA-385 is legitimate open work, not a done-and-forgot).
+
+## Findings
+
+### Project scope
+- **16 orphan issues** (no project)
+- **22 issues in the wrong project** — worst cluster: sourcing work split across 3 projects (Source-Check & Verification, Data Integrity, Automation & Infrastructure)
+- **3 closed umbrella issues** still cited as "Current focus" in live project descriptions: QUA-110 (Source-Check parent umbrella, Done), QUA-356 + QUA-363 (Coordinator "HIGH priority", both Done)
+- **2 projects at 97-83% progress** with single trailing issues — Tablebase Route Systematization and AI Power & Influence Mapping, both closable after moving the tagalongs
+
+### Labels (the biggest surprise)
+- **66% of issues had 0 labels** before cleanup
+- **22 unique labels** in use, half of which were migration-era cruft from a past tool import:
+  - `Migrated` (56 issues) — legacy one-shot marker
+  - `priority:urgent/high/medium/low` (69 issues, 19 disagreeing with Linear's built-in priority field — evidence of one-way drift)
+  - `model:haiku/sonnet/opus` (58 issues) — which LLM worked the issue, archaeology
+  - `agent:filed` (38 issues) — "an agent filed this," always-true signal
+  - 8 singleton labels (`groundskeeper-autofix`, `data-quality`, `tech-debt`, etc.)
+- **`Bug` label at 2/189 coverage** — 10% of actual bugs had the label; filtering by `Bug` hid 90% of bugs
+- **`content` label was 100% redundant** with Content Quality & Enrichment project — all 7 instances in that project
+- **`epic` label was 100% redundant** with Linear's native parent-issue feature — all 3 instances had actual sub-issues
+
+### Epic / parent-child hierarchy
+- **QUA-183 "Coordinator & Agent Tooling" umbrella** was 64% done (7/11 children) but still in Backlog state — evidence of stale parent states across the team
+- **QUA-362 "Epic: Finish EntityProfileShell migration — 12 detail pages remain"** had **zero sub-issues** despite explicitly calling itself an Epic in the title. 14 actionable detail pages listed in the body.
+- **QUA-408 was closed** but had 4 open orphaned children (QUA-425, QUA-424, QUA-442, QUA-470)
+- **7 issues orphaned from closed QUA-110** (Source-Check Quality Push) — intentional, continuing as independent work
+
+### Descriptions
+- 17% of open issues had detectable rot (mostly minor temporal-language drift)
+- 2 P0 intake stubs with unresolved TBD/XXX markers (QUA-391, QUA-383) — judgment call: real bugs with minor nits in Scope sections, not blockers
+- 1 false positive from the descriptions subagent (QUA-385 misread as "should-close" — actually legitimate follow-up work)
+
+## Fixes applied
+
+| Action | Count |
+|---|---|
+| Orphan issues assigned to projects | 16 → 0 (cleanup), 4 new drift by EOD |
+| Duplicate issues closed | 1 (QUA-465 duplicate of QUA-470) |
+| Project content rewrites | 2 (Coordinator, Source-Check) |
+| Projects completed | 2 (Tablebase Route Systematization, AI Power & Influence Mapping) |
+| Issues re-projected | 22 |
+| Labels deleted (definitions) | 23 → 0 (full purge, Option B) |
+| Label associations removed | ~204 |
+| Priority fields synced from stale labels | 10 |
+| Umbrella issues closed | 1 (QUA-183) |
+| Epics decomposed | 1 (QUA-362 → 6 child issues QUA-485..QUA-490) |
+| Parent title fixes | 1 (QUA-362 "12 pages" → "14 pages") |
+
+## Before / after
+
+| Metric | Before | After |
+|---|---|---|
+| Open issues | 194 | ~185 (8 closed mid-session + new filings) |
+| Orphans | 16 (8%) | 0 |
+| Duplicates | 1 | 0 |
+| Active projects | 8 | 6 |
+| Unique labels | 22 | 0 |
+| Issues with ≥5 labels | 41 | 0 |
+| Issues with 0 labels | 124 (66%) | 185 (100%) |
+| Stuck "In Progress" (>14d) | 0 | 0 |
+| Unprioritized | 33 (17%) | 23 (12%) |
+
+## What this pass produced
+
+1. **`crux/lib/linear/hygiene.ts`** + **`crux linear hygiene`** CLI command — re-runnable metadata hygiene scan (orphans, label coverage, priority gaps, stuck tickets, per-project counts). Run quarterly to catch drift.
+2. **[`.claude/rules/linear-project-ownership.md`](../../.claude/rules/linear-project-ownership.md)** — the scope-boundary doctrine that now prevents the 3-way sourcing split from re-emerging, clarifies dashboards vs automation, and lists what doesn't belong in Coordinator.
+3. **This document** — archive of the 2026-04-14 findings, linked from the README and rule docs so it's findable when someone asks "why did we do X with labels / projects / QUA-183?"
+
+## The one takeaway for future agents
+
+**Labels were the real discovery.** The team had been running for months with a label taxonomy inherited from a past tool migration, where labels duplicated the built-in priority field, tracked which LLM worked the issue, or were pure migration markers. 66% of issues had 0 labels anyway — the team had effectively decided not to use labels, without actually deleting them. The aggressive fix (Option B: zero labels, use projects + priority + parent-issue hierarchy for everything) matched actual team behavior and removed decision anxiety about whether to label new issues.
+
+If label hygiene drifts back into "some issues have many, some have none," that's evidence the same thing is happening again — trust the empty state over the populated one, because the empty state reflects revealed preference.
+
+## Cross-references
+
+- **Rule**: [`.claude/rules/linear-project-ownership.md`](../../.claude/rules/linear-project-ownership.md) — scope-boundary doctrine derived from this audit
+- **Tool**: `pnpm crux linear hygiene` (source: `crux/lib/linear/hygiene.ts`, `crux/commands/linear.ts`)
+- **Related audit**: [`docs/audits/things-denormalization-audit.md`](./things-denormalization-audit.md) — adjacent-dimension audit for PG write-site inventory

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -16,8 +16,11 @@ Each audit should link back to the Linear ticket that scoped it and forward to t
 |---|---|---|---|
 | [`things-denormalization-audit.md`](./things-denormalization-audit.md) | Every write site and consumer of `things.title` / `things.description` / `things.parent_title`, plus the `*_display_name` sibling pattern across 13 tables. Precondition for eliminating write-time denormalization. | Complete 2026-04-13 | [QUA-414](https://linear.app/quantifieduncertainty/issue/QUA-414) / [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) Tier 4b |
 | [`qua-303-sourcing-rename-audit.md`](./qua-303-sourcing-rename-audit.md) | Full PG FK / view / index / call-site inventory for the `source_check_*` → `sourcing_*` rename. Draft Phase 1 + Phase 3 migration SQL in `apps/wiki-server/scripts/`. Precondition for QUA-303 execution. | Complete 2026-04-13 | [QUA-303](https://linear.app/quantifieduncertainty/issue/QUA-303) / [QUA-102](https://linear.app/quantifieduncertainty/issue/QUA-102) umbrella |
+| [`2026-04-14-linear-refactor.md`](./2026-04-14-linear-refactor.md) | Linear metadata hygiene + project scope + epic hierarchy + label taxonomy deep audit. 16 orphans assigned, 22 issues re-projected, 22 labels purged (zero now), 2 projects closed, 1 epic decomposed. Produced `crux linear hygiene` tool + `linear-project-ownership.md` doctrine. | Complete 2026-04-14 | No single ticket — spans QUA-183, QUA-362, QUA-465 (dup), and the AI Power / Tablebase projects |
 
 ## Related rules files
 
 - `.claude/rules/entity-sync-pipeline.md` — sync handler infrastructure (points here for `things` write paths)
 - `.claude/rules/three-bases-architecture.md` — TableBase/FactBase/WikiBase ontology (points here for `things` cross-base index)
+- `.claude/rules/linear-project-ownership.md` — scope-boundary doctrine derived from `2026-04-14-linear-refactor.md`
+- `.claude/rules/linear-integration.md` — Linear ↔ GitHub integration (§ 9 links project ownership + `crux linear hygiene`)


### PR DESCRIPTION
Follow-up to #4366 (project ownership doctrine). Commits the reusable audit tooling and archives the 2026-04-14 refactor findings so they persist past the next `/tmp` clear.

## What's new

### `pnpm crux linear hygiene` (new command)

Metadata hygiene scan for all open QUA team issues. Reports:

- **Orphans** (no project assigned)
- **Label hygiene** (coverage %, unique count, singleton labels, over-labeled issues)
- **Assignee coverage**
- **Priority gaps** (unprioritized count)
- **Stuck "In Progress"** (>14 days since `startedAt`)
- **Thin tickets** (<80 char description)
- **Open count per project**

Supports `--json` for machine consumption. Pure read-only — never writes to Linear.

**Smoke-tested**: on first run post-cleanup, immediately found **4 new orphan issues** that had been filed between the session's manual orphan purge and now. Proves the tool's value as a re-runnable drift catcher.

Complements the existing `crux linear audit` command, which classifies *In Progress* issues by PR health (shipped/orphan/epic/active). `hygiene` is the orthogonal dimension — metadata hygiene across **all** open issues.

### `docs/audits/2026-04-14-linear-refactor.md` (archive)

One-page summary of the Linear deep-audit pass with:
- Methodology (3 parallel subagents + verification)
- Concrete findings (16 orphans, 22 miscategorized, 3 closed-umbrella refs, 22-label taxonomy drift, 1 64%-done-but-backlog umbrella, 1 childless epic)
- Before/after metrics table
- "The one takeaway" reflection on why Option B (zero labels) was the right call
- Cross-references forward to the rule doc and tool

### Cross-references for findability

The user's key caveat was *"docs/audits/2026-04-14-linear-refactor.md will likely get lost unless we have links to it or some data in other places about it."* Solved via:

1. **`docs/audits/README.md`** — new table row + related-rules section entry
2. **`.claude/rules/linear-project-ownership.md`** — "Historical: why this doc exists" section links forward to the audit, new "`crux linear hygiene`" tool section
3. **`.claude/rules/linear-integration.md` § 9** — hygiene command reference + audit link

So anyone reading the project ownership rule (auto-loaded in every agent session via `CLAUDE.md`) can trace back to the audit. Anyone running `pnpm crux linear hygiene` can find the rule doc. Anyone browsing `docs/audits/README.md` sees the refactor alongside the existing audits.

## Files touched

- **new** `crux/lib/linear/hygiene.ts` (330 lines) — pure audit logic + formatter
- **edit** `crux/commands/linear.ts` (+13 lines) — CLI wrapper + help text registration
- **new** `docs/audits/2026-04-14-linear-refactor.md` (102 lines) — archive doc
- **edit** `docs/audits/README.md` (+3 lines) — audit index entry + related rules
- **edit** `.claude/rules/linear-project-ownership.md` (+26 lines) — tool section + archive link
- **edit** `.claude/rules/linear-integration.md` (+2 lines) — hygiene tool pointer in § 9

**Net: +475 lines**, primarily the library + doc.

## Test plan

- [x] `pnpm crux linear hygiene` — 193 issues scanned, 4 orphans correctly reported (QUA-482, 483, 484, 491), labels 0, stuck 0
- [x] `pnpm crux linear hygiene --json` — valid JSON output
- [x] `apps/web/node_modules/.bin/tsc --noEmit -p crux/tsconfig.json` — 27 errors (at baseline, no new errors introduced)
- [x] `pnpm --filter wiki-server typecheck` — clean
- [x] All 5 cross-reference links resolve (README → audit, rules → audit, audit → rules, audit → tool, ownership rule → tool)
- [ ] CI green on GitHub

## Discarded (done, not reusable)

The 2026-04-14 session produced ~2000 lines of one-shot /tmp scripts:
- `linear-execute.ts`, `linear-execute-round2.ts`, `linear-label-cleanup.ts`, `linear-labels-option-b.ts`, `linear-qua362-split.ts` — one-shot mutations, work is done
- `linear-label-check.ts`, `linear-label-verify.ts`, `linear-verify-findings.ts`, `linear-full-read.ts` — verification one-offs
- `linear-dump.json` (740K) — ephemeral snapshot
- `linear-findings-{projects,epics,descriptions}.md` — subagent raw reports, subsumed into the condensed archive doc

All deleted from `/tmp` during this PR. The reusable pieces (the core audit + dump logic) are now first-class in `crux/lib/linear/hygiene.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
