### PR TITLE
feat(gate): validate-tsconfig-aliases — @wiki-server/* path alias parity check

### DIFF
--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -289,6 +289,17 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-483: keeps @wiki-server/* path alias keys identical between
+    // crux/tsconfig.json and apps/web/tsconfig.json. Drift causes fake
+    // "Cannot find module" errors in the crux tsc check and silently
+    // inflates the crux-tsc-baseline. Cheap and deterministic — blocking.
+    id: 'tsconfig-aliases',
+    name: 'tsconfig @wiki-server/* alias parity',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-tsconfig-aliases.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // QUA-294: enforces NOT VALID on ADD CONSTRAINT for large tables.
     // Migration 0173 caused a ~12h prod deploy stall by taking ACCESS
     // EXCLUSIVE on hallucination_risk_snapshots without NOT VALID.

--- a/crux/validate/validate-tsconfig-aliases.test.ts
+++ b/crux/validate/validate-tsconfig-aliases.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for validate-tsconfig-aliases.
+ *
+ * The validator keeps @wiki-server/* alias key sets identical between
+ * crux/tsconfig.json and apps/web/tsconfig.json. Drift causes fake
+ * TS errors in the crux tsc check (QUA-483).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { diffAliases } from './validate-tsconfig-aliases.ts';
+
+const REPO_ROOT = `${__dirname}/../..`;
+
+function run(cmd: string): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(`${cmd} 2>&1`, {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (e: unknown) {
+    const err = e as { stdout?: string; status?: number };
+    return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };
+  }
+}
+
+describe('validate-tsconfig-aliases', () => {
+  describe('diffAliases (pure function)', () => {
+    it('returns empty drift when both sets are identical', () => {
+      const a = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
+      const b = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
+      expect(diffAliases(a, b)).toEqual({ onlyInCrux: [], onlyInAppsWeb: [] });
+    });
+
+    it('detects keys missing from crux', () => {
+      const crux = new Set(['@wiki-server/foo-route']);
+      const appsWeb = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
+      expect(diffAliases(crux, appsWeb)).toEqual({
+        onlyInCrux: [],
+        onlyInAppsWeb: ['@wiki-server/bar-route'],
+      });
+    });
+
+    it('detects keys missing from apps/web', () => {
+      const crux = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
+      const appsWeb = new Set(['@wiki-server/foo-route']);
+      expect(diffAliases(crux, appsWeb)).toEqual({
+        onlyInCrux: ['@wiki-server/bar-route'],
+        onlyInAppsWeb: [],
+      });
+    });
+
+    it('detects drift in both directions', () => {
+      const crux = new Set(['@wiki-server/foo-route', '@wiki-server/baz-route']);
+      const appsWeb = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
+      expect(diffAliases(crux, appsWeb)).toEqual({
+        onlyInCrux: ['@wiki-server/baz-route'],
+        onlyInAppsWeb: ['@wiki-server/bar-route'],
+      });
+    });
+
+    it('sorts violation lists for stable output', () => {
+      const crux = new Set<string>();
+      const appsWeb = new Set([
+        '@wiki-server/zeta-route',
+        '@wiki-server/alpha-route',
+        '@wiki-server/mu-route',
+      ]);
+      expect(diffAliases(crux, appsWeb).onlyInAppsWeb).toEqual([
+        '@wiki-server/alpha-route',
+        '@wiki-server/mu-route',
+        '@wiki-server/zeta-route',
+      ]);
+    });
+
+    it('returns empty drift for two empty sets', () => {
+      expect(diffAliases(new Set(), new Set())).toEqual({ onlyInCrux: [], onlyInAppsWeb: [] });
+    });
+  });
+
+  describe('end-to-end on real codebase', () => {
+    it('passes on the current tsconfigs (both in sync)', () => {
+      const result = run('npx tsx crux/validate/validate-tsconfig-aliases.ts');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('aliases in sync');
+    }, 15_000);
+  });
+});

--- a/crux/validate/validate-tsconfig-aliases.test.ts
+++ b/crux/validate/validate-tsconfig-aliases.test.ts
@@ -1,14 +1,23 @@
 /**
  * Tests for validate-tsconfig-aliases.
  *
- * The validator keeps @wiki-server/* alias key sets identical between
- * crux/tsconfig.json and apps/web/tsconfig.json. Drift causes fake
- * TS errors in the crux tsc check (QUA-483).
+ * The validator keeps @wiki-server/* alias keys AND resolved target
+ * paths identical between crux/tsconfig.json and apps/web/tsconfig.json.
+ * Drift along either axis causes fake "Cannot find module" errors in
+ * the crux tsc check (QUA-483).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
-import { diffAliases } from './validate-tsconfig-aliases.ts';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  diffAliases,
+  resolveAliasTarget,
+  runCheck,
+  type TsConfigEntry,
+} from './validate-tsconfig-aliases.ts';
 
 const REPO_ROOT = `${__dirname}/../..`;
 
@@ -27,56 +36,265 @@ function run(cmd: string): { stdout: string; exitCode: number } {
 }
 
 describe('validate-tsconfig-aliases', () => {
-  describe('diffAliases (pure function)', () => {
-    it('returns empty drift when both sets are identical', () => {
-      const a = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
-      const b = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
-      expect(diffAliases(a, b)).toEqual({ onlyInCrux: [], onlyInAppsWeb: [] });
+  describe('resolveAliasTarget', () => {
+    it('resolves a simple relative target from the tsconfig directory', () => {
+      const result = resolveAliasTarget('/repo/crux/tsconfig.json', '.', '../apps/web/src/foo.ts');
+      expect(result).toBe('/repo/apps/web/src/foo.ts');
     });
 
-    it('detects keys missing from crux', () => {
-      const crux = new Set(['@wiki-server/foo-route']);
-      const appsWeb = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
-      expect(diffAliases(crux, appsWeb)).toEqual({
-        onlyInCrux: [],
-        onlyInAppsWeb: ['@wiki-server/bar-route'],
-      });
+    it('applies a custom baseUrl', () => {
+      const result = resolveAliasTarget(
+        '/repo/apps/web/tsconfig.json',
+        './src',
+        'components/button.tsx'
+      );
+      expect(result).toBe('/repo/apps/web/src/components/button.tsx');
     });
 
-    it('detects keys missing from apps/web', () => {
-      const crux = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
-      const appsWeb = new Set(['@wiki-server/foo-route']);
-      expect(diffAliases(crux, appsWeb)).toEqual({
-        onlyInCrux: ['@wiki-server/bar-route'],
-        onlyInAppsWeb: [],
-      });
+    it('normalizes .. segments in the pattern', () => {
+      // /repo/crux + ../apps/web/../wiki-server/x.ts
+      // = /repo/crux/../apps/web/../wiki-server/x.ts
+      // = /repo/apps/web/../wiki-server/x.ts
+      // = /repo/apps/wiki-server/x.ts
+      const result = resolveAliasTarget(
+        '/repo/crux/tsconfig.json',
+        '.',
+        '../apps/web/../wiki-server/x.ts'
+      );
+      expect(result).toBe('/repo/apps/wiki-server/x.ts');
+    });
+  });
+
+  describe('diffAliases', () => {
+    const CRUX = '/repo/crux/tsconfig.json';
+    const APPS_WEB = '/repo/apps/web/tsconfig.json';
+
+    it('treats differently-spelled-but-same-absolute-path targets as matching', () => {
+      // crux/tsconfig uses "../apps/wiki-server/..." (relative to crux/)
+      // apps/web/tsconfig uses "../wiki-server/..." (relative to apps/web/)
+      // Both resolve to the SAME absolute path: /repo/apps/wiki-server/src/facts.ts
+      const crux = {
+        '@wiki-server/facts-route': ['../apps/wiki-server/src/routes/factbase/facts.ts'],
+      };
+      const appsWeb = {
+        '@wiki-server/facts-route': ['../wiki-server/src/routes/factbase/facts.ts'],
+      };
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result.onlyInFirst).toEqual([]);
+      expect(result.onlyInSecond).toEqual([]);
+      expect(result.targetMismatches).toEqual([]);
     });
 
-    it('detects drift in both directions', () => {
-      const crux = new Set(['@wiki-server/foo-route', '@wiki-server/baz-route']);
-      const appsWeb = new Set(['@wiki-server/foo-route', '@wiki-server/bar-route']);
-      expect(diffAliases(crux, appsWeb)).toEqual({
-        onlyInCrux: ['@wiki-server/baz-route'],
-        onlyInAppsWeb: ['@wiki-server/bar-route'],
-      });
+    it('detects keys missing from first config', () => {
+      const crux = {};
+      const appsWeb = { '@wiki-server/foo-route': ['../wiki-server/src/foo.ts'] };
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result.onlyInSecond).toEqual(['@wiki-server/foo-route']);
+      expect(result.onlyInFirst).toEqual([]);
+      expect(result.targetMismatches).toEqual([]);
     });
 
-    it('sorts violation lists for stable output', () => {
-      const crux = new Set<string>();
-      const appsWeb = new Set([
-        '@wiki-server/zeta-route',
+    it('detects keys missing from second config', () => {
+      const crux = { '@wiki-server/bar-route': ['../apps/wiki-server/src/bar.ts'] };
+      const appsWeb = {};
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result.onlyInFirst).toEqual(['@wiki-server/bar-route']);
+      expect(result.onlyInSecond).toEqual([]);
+    });
+
+    it('detects target-path drift when keys match but files differ', () => {
+      const crux = {
+        '@wiki-server/foo-route': ['../apps/wiki-server/src/routes/old-foo.ts'],
+      };
+      const appsWeb = {
+        '@wiki-server/foo-route': ['../wiki-server/src/routes/new-foo.ts'],
+      };
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result.targetMismatches).toHaveLength(1);
+      expect(result.targetMismatches[0].key).toBe('@wiki-server/foo-route');
+      expect(result.targetMismatches[0].first[0]).toContain('old-foo.ts');
+      expect(result.targetMismatches[0].second[0]).toContain('new-foo.ts');
+    });
+
+    it('sorts missing-key lists', () => {
+      const crux = {};
+      const appsWeb = {
+        '@wiki-server/zeta-route': ['../wiki-server/src/z.ts'],
+        '@wiki-server/alpha-route': ['../wiki-server/src/a.ts'],
+        '@wiki-server/mu-route': ['../wiki-server/src/m.ts'],
+      };
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result.onlyInSecond).toEqual([
         '@wiki-server/alpha-route',
         '@wiki-server/mu-route',
-      ]);
-      expect(diffAliases(crux, appsWeb).onlyInAppsWeb).toEqual([
-        '@wiki-server/alpha-route',
-        '@wiki-server/mu-route',
         '@wiki-server/zeta-route',
       ]);
     });
 
-    it('returns empty drift for two empty sets', () => {
-      expect(diffAliases(new Set(), new Set())).toEqual({ onlyInCrux: [], onlyInAppsWeb: [] });
+    it('ignores non-wiki-server aliases', () => {
+      // The real tsconfigs also have @/*, @components/* etc.
+      // Our extract-before-diff flow already filters, so diffAliases
+      // itself just receives filtered maps — but verify it doesn't
+      // accidentally fail on empty shared sets.
+      const crux = {};
+      const appsWeb = {};
+      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      expect(result).toEqual({ onlyInFirst: [], onlyInSecond: [], targetMismatches: [] });
+    });
+  });
+
+  describe('runCheck with temp fixtures', () => {
+    let tmpRoot: string;
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'validate-tsconfig-aliases-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    function writeConfig(rel: string, content: object): TsConfigEntry {
+      const fullPath = join(tmpRoot, rel);
+      mkdirSync(join(fullPath, '..'), { recursive: true });
+      writeFileSync(fullPath, JSON.stringify(content, null, 2));
+      return { label: rel, path: fullPath };
+    }
+
+    it('passes when both tsconfigs have identical key-and-target sets', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@wiki-server/facts-route': ['../apps/wiki-server/src/routes/factbase/facts.ts'],
+          },
+        },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@wiki-server/facts-route': ['../wiki-server/src/routes/factbase/facts.ts'],
+          },
+        },
+      });
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(true);
+      expect(result.errors).toBe(0);
+    });
+
+    it('fails when a key is missing from one tsconfig', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        compilerOptions: { paths: {} },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@wiki-server/new-route': ['../wiki-server/src/routes/new.ts'],
+          },
+        },
+      });
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(false);
+      expect(result.errors).toBe(1);
+      expect(result.drift.onlyInSecond).toEqual(['@wiki-server/new-route']);
+    });
+
+    it('fails when keys match but targets resolve to different files', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@wiki-server/foo-route': ['../apps/wiki-server/src/routes/old-foo.ts'],
+          },
+        },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@wiki-server/foo-route': ['../wiki-server/src/routes/new-foo.ts'],
+          },
+        },
+      });
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(false);
+      expect(result.errors).toBe(1);
+      expect(result.drift.targetMismatches).toHaveLength(1);
+    });
+
+    it('rejects a config that uses extends', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        extends: '../base.json',
+        compilerOptions: { paths: {} },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: { paths: {} },
+      });
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(false);
+      expect(result.errors).toBe(1);
+    });
+
+    it('ignores non-@wiki-server aliases', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@/*': ['./src/*'],
+            '@wiki-server/foo-route': ['../apps/wiki-server/src/foo.ts'],
+          },
+        },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@components/*': ['./src/components/*'],
+            '@wiki-server/foo-route': ['../wiki-server/src/foo.ts'],
+          },
+        },
+      });
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(true);
+    });
+
+    it('throws with a clear message when a config file is missing', () => {
+      const a: TsConfigEntry = { label: 'crux/tsconfig.json', path: join(tmpRoot, 'does-not-exist.json') };
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: { paths: {} },
+      });
+      expect(() => runCheck({ tsconfigs: [a, b], silent: true })).toThrow(
+        /Could not read crux\/tsconfig\.json/
+      );
+    });
+
+    it('throws with a clear message when a config is not valid JSON', () => {
+      const malformedPath = join(tmpRoot, 'bad.json');
+      mkdirSync(tmpRoot, { recursive: true });
+      writeFileSync(malformedPath, '{ not valid json }');
+      const a: TsConfigEntry = { label: 'bad.json', path: malformedPath };
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: { paths: {} },
+      });
+      expect(() => runCheck({ tsconfigs: [a, b], silent: true })).toThrow(
+        /Could not parse bad\.json as JSON/
+      );
+    });
+
+    it('exits with code 1 when invoked as a script on a drifted fixture', () => {
+      const a = writeConfig('crux/tsconfig.json', {
+        compilerOptions: {
+          paths: {
+            '@wiki-server/foo-route': ['../apps/wiki-server/src/foo.ts'],
+          },
+        },
+      });
+      const b = writeConfig('apps/web/tsconfig.json', {
+        compilerOptions: { paths: {} },
+      });
+      // Use the programmatic runCheck path with a fixture instead of
+      // spawning a subprocess with env overrides — simpler and equivalent
+      // for covering the exit-code contract via the same code path.
+      const result = runCheck({ tsconfigs: [a, b], silent: true });
+      expect(result.passed).toBe(false);
+      expect(result.errors).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/crux/validate/validate-tsconfig-aliases.test.ts
+++ b/crux/validate/validate-tsconfig-aliases.test.ts
@@ -16,6 +16,7 @@ import {
   diffAliases,
   resolveAliasTarget,
   runCheck,
+  type AliasSide,
   type TsConfigEntry,
 } from './validate-tsconfig-aliases.ts';
 
@@ -66,50 +67,62 @@ describe('validate-tsconfig-aliases', () => {
   });
 
   describe('diffAliases', () => {
-    const CRUX = '/repo/crux/tsconfig.json';
-    const APPS_WEB = '/repo/apps/web/tsconfig.json';
+    const cruxSide = (paths: Record<string, string[]>): AliasSide => ({
+      paths,
+      tsconfigPath: '/repo/crux/tsconfig.json',
+      baseUrl: '.',
+    });
+    const appsWebSide = (paths: Record<string, string[]>): AliasSide => ({
+      paths,
+      tsconfigPath: '/repo/apps/web/tsconfig.json',
+      baseUrl: '.',
+    });
 
     it('treats differently-spelled-but-same-absolute-path targets as matching', () => {
       // crux/tsconfig uses "../apps/wiki-server/..." (relative to crux/)
       // apps/web/tsconfig uses "../wiki-server/..." (relative to apps/web/)
       // Both resolve to the SAME absolute path: /repo/apps/wiki-server/src/facts.ts
-      const crux = {
-        '@wiki-server/facts-route': ['../apps/wiki-server/src/routes/factbase/facts.ts'],
-      };
-      const appsWeb = {
-        '@wiki-server/facts-route': ['../wiki-server/src/routes/factbase/facts.ts'],
-      };
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      const result = diffAliases(
+        cruxSide({
+          '@wiki-server/facts-route': ['../apps/wiki-server/src/routes/factbase/facts.ts'],
+        }),
+        appsWebSide({
+          '@wiki-server/facts-route': ['../wiki-server/src/routes/factbase/facts.ts'],
+        })
+      );
       expect(result.onlyInFirst).toEqual([]);
       expect(result.onlyInSecond).toEqual([]);
       expect(result.targetMismatches).toEqual([]);
     });
 
     it('detects keys missing from first config', () => {
-      const crux = {};
-      const appsWeb = { '@wiki-server/foo-route': ['../wiki-server/src/foo.ts'] };
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      const result = diffAliases(
+        cruxSide({}),
+        appsWebSide({ '@wiki-server/foo-route': ['../wiki-server/src/foo.ts'] })
+      );
       expect(result.onlyInSecond).toEqual(['@wiki-server/foo-route']);
       expect(result.onlyInFirst).toEqual([]);
       expect(result.targetMismatches).toEqual([]);
     });
 
     it('detects keys missing from second config', () => {
-      const crux = { '@wiki-server/bar-route': ['../apps/wiki-server/src/bar.ts'] };
-      const appsWeb = {};
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      const result = diffAliases(
+        cruxSide({ '@wiki-server/bar-route': ['../apps/wiki-server/src/bar.ts'] }),
+        appsWebSide({})
+      );
       expect(result.onlyInFirst).toEqual(['@wiki-server/bar-route']);
       expect(result.onlyInSecond).toEqual([]);
     });
 
     it('detects target-path drift when keys match but files differ', () => {
-      const crux = {
-        '@wiki-server/foo-route': ['../apps/wiki-server/src/routes/old-foo.ts'],
-      };
-      const appsWeb = {
-        '@wiki-server/foo-route': ['../wiki-server/src/routes/new-foo.ts'],
-      };
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      const result = diffAliases(
+        cruxSide({
+          '@wiki-server/foo-route': ['../apps/wiki-server/src/routes/old-foo.ts'],
+        }),
+        appsWebSide({
+          '@wiki-server/foo-route': ['../wiki-server/src/routes/new-foo.ts'],
+        })
+      );
       expect(result.targetMismatches).toHaveLength(1);
       expect(result.targetMismatches[0].key).toBe('@wiki-server/foo-route');
       expect(result.targetMismatches[0].first[0]).toContain('old-foo.ts');
@@ -117,13 +130,14 @@ describe('validate-tsconfig-aliases', () => {
     });
 
     it('sorts missing-key lists', () => {
-      const crux = {};
-      const appsWeb = {
-        '@wiki-server/zeta-route': ['../wiki-server/src/z.ts'],
-        '@wiki-server/alpha-route': ['../wiki-server/src/a.ts'],
-        '@wiki-server/mu-route': ['../wiki-server/src/m.ts'],
-      };
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+      const result = diffAliases(
+        cruxSide({}),
+        appsWebSide({
+          '@wiki-server/zeta-route': ['../wiki-server/src/z.ts'],
+          '@wiki-server/alpha-route': ['../wiki-server/src/a.ts'],
+          '@wiki-server/mu-route': ['../wiki-server/src/m.ts'],
+        })
+      );
       expect(result.onlyInSecond).toEqual([
         '@wiki-server/alpha-route',
         '@wiki-server/mu-route',
@@ -131,14 +145,8 @@ describe('validate-tsconfig-aliases', () => {
       ]);
     });
 
-    it('ignores non-wiki-server aliases', () => {
-      // The real tsconfigs also have @/*, @components/* etc.
-      // Our extract-before-diff flow already filters, so diffAliases
-      // itself just receives filtered maps — but verify it doesn't
-      // accidentally fail on empty shared sets.
-      const crux = {};
-      const appsWeb = {};
-      const result = diffAliases(crux, CRUX, '.', appsWeb, APPS_WEB, '.');
+    it('returns empty drift for two empty path sets', () => {
+      const result = diffAliases(cruxSide({}), appsWebSide({}));
       expect(result).toEqual({ onlyInFirst: [], onlyInSecond: [], targetMismatches: [] });
     });
   });

--- a/crux/validate/validate-tsconfig-aliases.ts
+++ b/crux/validate/validate-tsconfig-aliases.ts
@@ -1,13 +1,23 @@
 #!/usr/bin/env node
 
 /**
- * Validate that @wiki-server/* path alias keys stay in sync between
+ * Validate that @wiki-server/* path aliases stay in sync between
  * crux/tsconfig.json and apps/web/tsconfig.json.
  *
- * Drift between these tsconfigs causes fake "Cannot find module
- * '@wiki-server/*-route'" errors in the crux tsc check (transitively,
- * via apps/web/src/lib/wiki-server.ts) and silently inflates the
- * crux-tsc-baseline, hiding real errors.
+ * Checks two axes of drift:
+ *   1. Key parity — both configs must declare the same @wiki-server/*
+ *      alias keys.
+ *   2. Target parity — for each shared key, the target path in each
+ *      config must resolve (relative to that config's baseUrl) to the
+ *      same absolute file. Target-path drift is the more common and
+ *      more insidious failure mode: the keys still match so naive
+ *      key-set checks pass, but one side points at a stale or wrong
+ *      file and the crux tsc check emits fake "Cannot find module"
+ *      errors that silently inflate the crux-tsc-baseline.
+ *
+ * Neither config currently uses `extends`. The validator fails loudly
+ * if one ever gains an `extends` clause, because resolving extends is
+ * out of scope and silently ignoring it would mask real drift.
  *
  * See QUA-483.
  *
@@ -15,80 +25,221 @@
  */
 
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { getColors } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 
 const ALIAS_PREFIX = '@wiki-server/';
 
-const TSCONFIGS = [
+export interface TsConfigEntry {
+  label: string;
+  path: string;
+}
+
+const DEFAULT_TSCONFIGS: readonly TsConfigEntry[] = [
   { label: 'crux/tsconfig.json', path: join(PROJECT_ROOT, 'crux/tsconfig.json') },
   { label: 'apps/web/tsconfig.json', path: join(PROJECT_ROOT, 'apps/web/tsconfig.json') },
 ] as const;
 
 interface TsConfig {
+  extends?: string;
   compilerOptions?: {
+    baseUrl?: string;
     paths?: Record<string, string[]>;
   };
 }
 
-function readTsConfig(path: string): TsConfig {
-  const raw = readFileSync(path, 'utf-8');
-  return JSON.parse(raw) as TsConfig;
+function readTsConfig(entry: TsConfigEntry): TsConfig {
+  let raw: string;
+  try {
+    raw = readFileSync(entry.path, 'utf-8');
+  } catch (e) {
+    throw new Error(
+      `Could not read ${entry.label} at ${entry.path}: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+  try {
+    return JSON.parse(raw) as TsConfig;
+  } catch (e) {
+    throw new Error(
+      `Could not parse ${entry.label} as JSON: ${e instanceof Error ? e.message : String(e)}. ` +
+        `(Note: this validator does not support JSONC comments — strip them or upgrade the parser.)`
+    );
+  }
 }
 
-function extractWikiServerKeys(cfg: TsConfig): Set<string> {
+function extractWikiServerPaths(cfg: TsConfig): Record<string, string[]> {
   const paths = cfg.compilerOptions?.paths ?? {};
-  return new Set(Object.keys(paths).filter((k) => k.startsWith(ALIAS_PREFIX)));
+  const result: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(paths)) {
+    if (key.startsWith(ALIAS_PREFIX)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolve a tsconfig alias target pattern to an absolute file path.
+ *
+ * Rules:
+ *   - baseUrl defaults to "." (the tsconfig's own directory) if unset
+ *   - pattern is resolved relative to baseUrl
+ *   - the result is an absolute, normalized path
+ */
+export function resolveAliasTarget(tsconfigPath: string, baseUrl: string, pattern: string): string {
+  const tsconfigDir = dirname(tsconfigPath);
+  const base = resolve(tsconfigDir, baseUrl);
+  return resolve(base, pattern);
 }
 
 export interface AliasDrift {
-  onlyInCrux: string[];
-  onlyInAppsWeb: string[];
+  onlyInFirst: string[];
+  onlyInSecond: string[];
+  /** Keys present in both configs but resolving to different absolute paths. */
+  targetMismatches: Array<{
+    key: string;
+    first: string[];
+    second: string[];
+  }>;
 }
 
-export function diffAliases(cruxKeys: Set<string>, appsWebKeys: Set<string>): AliasDrift {
-  const onlyInCrux = [...cruxKeys].filter((k) => !appsWebKeys.has(k)).sort();
-  const onlyInAppsWeb = [...appsWebKeys].filter((k) => !cruxKeys.has(k)).sort();
-  return { onlyInCrux, onlyInAppsWeb };
+export function diffAliases(
+  first: Record<string, string[]>,
+  firstTsconfigPath: string,
+  firstBaseUrl: string,
+  second: Record<string, string[]>,
+  secondTsconfigPath: string,
+  secondBaseUrl: string
+): AliasDrift {
+  const firstKeys = new Set(Object.keys(first));
+  const secondKeys = new Set(Object.keys(second));
+
+  const onlyInFirst = [...firstKeys].filter((k) => !secondKeys.has(k)).sort();
+  const onlyInSecond = [...secondKeys].filter((k) => !firstKeys.has(k)).sort();
+
+  const sharedKeys = [...firstKeys].filter((k) => secondKeys.has(k)).sort();
+  const targetMismatches: AliasDrift['targetMismatches'] = [];
+  for (const key of sharedKeys) {
+    const firstAbs = (first[key] ?? []).map((p) =>
+      resolveAliasTarget(firstTsconfigPath, firstBaseUrl, p)
+    );
+    const secondAbs = (second[key] ?? []).map((p) =>
+      resolveAliasTarget(secondTsconfigPath, secondBaseUrl, p)
+    );
+    if (firstAbs.length !== secondAbs.length || firstAbs.some((p, i) => p !== secondAbs[i])) {
+      targetMismatches.push({ key, first: firstAbs, second: secondAbs });
+    }
+  }
+
+  return { onlyInFirst, onlyInSecond, targetMismatches };
 }
 
-export function runCheck(): { passed: boolean; errors: number; drift: AliasDrift } {
+export interface RunCheckOptions {
+  /** Override the default [crux, apps/web] tsconfig pair (used by tests). */
+  tsconfigs?: readonly TsConfigEntry[];
+  /** Suppress the success banner (used by tests). */
+  silent?: boolean;
+}
+
+export interface RunCheckResult {
+  passed: boolean;
+  errors: number;
+  drift: AliasDrift;
+}
+
+export function runCheck(options: RunCheckOptions = {}): RunCheckResult {
   const c = getColors();
-  console.log(`${c.blue}Checking @wiki-server/* alias parity between tsconfigs...${c.reset}\n`);
+  const silent = options.silent ?? false;
+  const tsconfigs = options.tsconfigs ?? DEFAULT_TSCONFIGS;
 
-  const [cruxCfg, appsWebCfg] = TSCONFIGS.map(({ path }) => readTsConfig(path));
-  const cruxKeys = extractWikiServerKeys(cruxCfg);
-  const appsWebKeys = extractWikiServerKeys(appsWebCfg);
+  if (tsconfigs.length !== 2) {
+    throw new Error(
+      `validate-tsconfig-aliases expects exactly 2 tsconfigs, got ${tsconfigs.length}`
+    );
+  }
+  const [firstEntry, secondEntry] = tsconfigs;
 
-  const drift = diffAliases(cruxKeys, appsWebKeys);
-  const totalErrors = drift.onlyInCrux.length + drift.onlyInAppsWeb.length;
+  if (!silent) {
+    console.log(`${c.blue}Checking @wiki-server/* alias parity between tsconfigs...${c.reset}\n`);
+  }
+
+  const firstCfg = readTsConfig(firstEntry);
+  const secondCfg = readTsConfig(secondEntry);
+
+  // Refuse to run on configs that use `extends` — resolving the chain is
+  // out of scope and silently dropping inherited paths would mask drift.
+  for (const [entry, cfg] of [
+    [firstEntry, firstCfg],
+    [secondEntry, secondCfg],
+  ] as const) {
+    if (cfg.extends !== undefined) {
+      console.error(
+        `${c.red}${entry.label} uses "extends": "${cfg.extends}" — this validator does not support extends chains.${c.reset}`
+      );
+      console.error(
+        `${c.dim}Either resolve the chain manually or extend this validator to follow extends.${c.reset}`
+      );
+      return { passed: false, errors: 1, drift: { onlyInFirst: [], onlyInSecond: [], targetMismatches: [] } };
+    }
+  }
+
+  const firstBaseUrl = firstCfg.compilerOptions?.baseUrl ?? '.';
+  const secondBaseUrl = secondCfg.compilerOptions?.baseUrl ?? '.';
+
+  const firstPaths = extractWikiServerPaths(firstCfg);
+  const secondPaths = extractWikiServerPaths(secondCfg);
+
+  const drift = diffAliases(
+    firstPaths,
+    firstEntry.path,
+    firstBaseUrl,
+    secondPaths,
+    secondEntry.path,
+    secondBaseUrl
+  );
+
+  const totalErrors =
+    drift.onlyInFirst.length + drift.onlyInSecond.length + drift.targetMismatches.length;
 
   if (totalErrors === 0) {
-    console.log(
-      `${c.green}✓ @wiki-server/* aliases in sync (${cruxKeys.size} keys)${c.reset}`
-    );
+    if (!silent) {
+      console.log(
+        `${c.green}✓ @wiki-server/* aliases in sync (${Object.keys(firstPaths).length} keys)${c.reset}`
+      );
+    }
     return { passed: true, errors: 0, drift };
   }
 
-  console.log(
-    `${c.red}Found ${totalErrors} @wiki-server/* alias drift(s):${c.reset}\n`
+  console.error(
+    `${c.red}Found ${totalErrors} @wiki-server/* alias drift(s) between ${firstEntry.label} and ${secondEntry.label}:${c.reset}\n`
   );
-  if (drift.onlyInAppsWeb.length > 0) {
-    console.log(`  ${c.yellow}Missing from crux/tsconfig.json:${c.reset}`);
-    for (const key of drift.onlyInAppsWeb) console.log(`    - ${key}`);
-    console.log();
+  if (drift.onlyInSecond.length > 0) {
+    console.error(`  ${c.yellow}Missing from ${firstEntry.label}:${c.reset}`);
+    for (const key of drift.onlyInSecond) console.error(`    - ${key}`);
+    console.error();
   }
-  if (drift.onlyInCrux.length > 0) {
-    console.log(`  ${c.yellow}Missing from apps/web/tsconfig.json:${c.reset}`);
-    for (const key of drift.onlyInCrux) console.log(`    - ${key}`);
-    console.log();
+  if (drift.onlyInFirst.length > 0) {
+    console.error(`  ${c.yellow}Missing from ${secondEntry.label}:${c.reset}`);
+    for (const key of drift.onlyInFirst) console.error(`    - ${key}`);
+    console.error();
   }
-  console.log(
-    `${c.dim}Fix: copy the missing alias entries between the two files so both key sets match.${c.reset}`
+  if (drift.targetMismatches.length > 0) {
+    console.error(
+      `  ${c.yellow}Target-path mismatches (keys present in both but resolve to different files):${c.reset}`
+    );
+    for (const mismatch of drift.targetMismatches) {
+      console.error(`    ${mismatch.key}`);
+      console.error(`      ${firstEntry.label}:  ${mismatch.first.join(', ')}`);
+      console.error(`      ${secondEntry.label}: ${mismatch.second.join(', ')}`);
+    }
+    console.error();
+  }
+  console.error(
+    `${c.dim}Fix: align the @wiki-server/* entries so both files have the same keys and each key's target resolves to the same absolute file.${c.reset}`
   );
-  console.log(
-    `${c.dim}Context: QUA-483 — drift causes fake TS errors in the crux tsc check.${c.reset}`
+  console.error(
+    `${c.dim}Context: QUA-483 — drift causes fake "Cannot find module" errors in the crux tsc check.${c.reset}`
   );
 
   return { passed: false, errors: totalErrors, drift };

--- a/crux/validate/validate-tsconfig-aliases.ts
+++ b/crux/validate/validate-tsconfig-aliases.ts
@@ -93,6 +93,16 @@ export function resolveAliasTarget(tsconfigPath: string, baseUrl: string, patter
   return resolve(base, pattern);
 }
 
+/**
+ * One side of the comparison — bundles the @wiki-server/* paths plus
+ * everything needed to resolve them to absolute files.
+ */
+export interface AliasSide {
+  paths: Record<string, string[]>;
+  tsconfigPath: string;
+  baseUrl: string;
+}
+
 export interface AliasDrift {
   onlyInFirst: string[];
   onlyInSecond: string[];
@@ -104,28 +114,21 @@ export interface AliasDrift {
   }>;
 }
 
-export function diffAliases(
-  first: Record<string, string[]>,
-  firstTsconfigPath: string,
-  firstBaseUrl: string,
-  second: Record<string, string[]>,
-  secondTsconfigPath: string,
-  secondBaseUrl: string
-): AliasDrift {
-  const firstKeys = new Set(Object.keys(first));
-  const secondKeys = new Set(Object.keys(second));
+export function diffAliases(first: AliasSide, second: AliasSide): AliasDrift {
+  const firstKeys = new Set(Object.keys(first.paths));
+  const secondKeys = new Set(Object.keys(second.paths));
 
   const onlyInFirst = [...firstKeys].filter((k) => !secondKeys.has(k)).sort();
   const onlyInSecond = [...secondKeys].filter((k) => !firstKeys.has(k)).sort();
 
-  const sharedKeys = [...firstKeys].filter((k) => secondKeys.has(k)).sort();
+  const sharedKeys = [...firstKeys].filter((k) => secondKeys.has(k));
   const targetMismatches: AliasDrift['targetMismatches'] = [];
   for (const key of sharedKeys) {
-    const firstAbs = (first[key] ?? []).map((p) =>
-      resolveAliasTarget(firstTsconfigPath, firstBaseUrl, p)
+    const firstAbs = (first.paths[key] ?? []).map((p) =>
+      resolveAliasTarget(first.tsconfigPath, first.baseUrl, p)
     );
-    const secondAbs = (second[key] ?? []).map((p) =>
-      resolveAliasTarget(secondTsconfigPath, secondBaseUrl, p)
+    const secondAbs = (second.paths[key] ?? []).map((p) =>
+      resolveAliasTarget(second.tsconfigPath, second.baseUrl, p)
     );
     if (firstAbs.length !== secondAbs.length || firstAbs.some((p, i) => p !== secondAbs[i])) {
       targetMismatches.push({ key, first: firstAbs, second: secondAbs });
@@ -148,6 +151,43 @@ export interface RunCheckResult {
   drift: AliasDrift;
 }
 
+interface LoadedSide {
+  entry: TsConfigEntry;
+  cfg: TsConfig;
+  side: AliasSide;
+}
+
+function loadSide(entry: TsConfigEntry): LoadedSide {
+  const cfg = readTsConfig(entry);
+  return {
+    entry,
+    cfg,
+    side: {
+      paths: extractWikiServerPaths(cfg),
+      tsconfigPath: entry.path,
+      baseUrl: cfg.compilerOptions?.baseUrl ?? '.',
+    },
+  };
+}
+
+/**
+ * Refuse to run on configs that use `extends` — resolving the chain is
+ * out of scope and silently dropping inherited paths would mask drift.
+ * Returns true if the config was rejected (and prints the error).
+ */
+function rejectExtends(loaded: LoadedSide, c: ReturnType<typeof getColors>): boolean {
+  if (loaded.cfg.extends === undefined) return false;
+  console.error(
+    `${c.red}${loaded.entry.label} uses "extends": "${loaded.cfg.extends}" — this validator does not support extends chains.${c.reset}`
+  );
+  console.error(
+    `${c.dim}Either resolve the chain manually or extend this validator to follow extends.${c.reset}`
+  );
+  return true;
+}
+
+const EMPTY_DRIFT: AliasDrift = { onlyInFirst: [], onlyInSecond: [], targetMismatches: [] };
+
 export function runCheck(options: RunCheckOptions = {}): RunCheckResult {
   const c = getColors();
   const silent = options.silent ?? false;
@@ -158,69 +198,41 @@ export function runCheck(options: RunCheckOptions = {}): RunCheckResult {
       `validate-tsconfig-aliases expects exactly 2 tsconfigs, got ${tsconfigs.length}`
     );
   }
-  const [firstEntry, secondEntry] = tsconfigs;
 
   if (!silent) {
     console.log(`${c.blue}Checking @wiki-server/* alias parity between tsconfigs...${c.reset}\n`);
   }
 
-  const firstCfg = readTsConfig(firstEntry);
-  const secondCfg = readTsConfig(secondEntry);
+  const first = loadSide(tsconfigs[0]);
+  const second = loadSide(tsconfigs[1]);
 
-  // Refuse to run on configs that use `extends` — resolving the chain is
-  // out of scope and silently dropping inherited paths would mask drift.
-  for (const [entry, cfg] of [
-    [firstEntry, firstCfg],
-    [secondEntry, secondCfg],
-  ] as const) {
-    if (cfg.extends !== undefined) {
-      console.error(
-        `${c.red}${entry.label} uses "extends": "${cfg.extends}" — this validator does not support extends chains.${c.reset}`
-      );
-      console.error(
-        `${c.dim}Either resolve the chain manually or extend this validator to follow extends.${c.reset}`
-      );
-      return { passed: false, errors: 1, drift: { onlyInFirst: [], onlyInSecond: [], targetMismatches: [] } };
-    }
+  if (rejectExtends(first, c) || rejectExtends(second, c)) {
+    return { passed: false, errors: 1, drift: EMPTY_DRIFT };
   }
 
-  const firstBaseUrl = firstCfg.compilerOptions?.baseUrl ?? '.';
-  const secondBaseUrl = secondCfg.compilerOptions?.baseUrl ?? '.';
-
-  const firstPaths = extractWikiServerPaths(firstCfg);
-  const secondPaths = extractWikiServerPaths(secondCfg);
-
-  const drift = diffAliases(
-    firstPaths,
-    firstEntry.path,
-    firstBaseUrl,
-    secondPaths,
-    secondEntry.path,
-    secondBaseUrl
-  );
-
+  const drift = diffAliases(first.side, second.side);
   const totalErrors =
     drift.onlyInFirst.length + drift.onlyInSecond.length + drift.targetMismatches.length;
 
   if (totalErrors === 0) {
     if (!silent) {
       console.log(
-        `${c.green}✓ @wiki-server/* aliases in sync (${Object.keys(firstPaths).length} keys)${c.reset}`
+        `${c.green}✓ @wiki-server/* aliases in sync (${Object.keys(first.side.paths).length} keys)${c.reset}`
       );
     }
     return { passed: true, errors: 0, drift };
   }
 
   console.error(
-    `${c.red}Found ${totalErrors} @wiki-server/* alias drift(s) between ${firstEntry.label} and ${secondEntry.label}:${c.reset}\n`
+    `${c.red}Found ${totalErrors} @wiki-server/* alias drift(s) between ${first.entry.label} and ${second.entry.label}:${c.reset}\n`
   );
   if (drift.onlyInSecond.length > 0) {
-    console.error(`  ${c.yellow}Missing from ${firstEntry.label}:${c.reset}`);
+    console.error(`  ${c.yellow}Missing from ${first.entry.label}:${c.reset}`);
     for (const key of drift.onlyInSecond) console.error(`    - ${key}`);
     console.error();
   }
   if (drift.onlyInFirst.length > 0) {
-    console.error(`  ${c.yellow}Missing from ${secondEntry.label}:${c.reset}`);
+    console.error(`  ${c.yellow}Missing from ${second.entry.label}:${c.reset}`);
     for (const key of drift.onlyInFirst) console.error(`    - ${key}`);
     console.error();
   }
@@ -230,8 +242,8 @@ export function runCheck(options: RunCheckOptions = {}): RunCheckResult {
     );
     for (const mismatch of drift.targetMismatches) {
       console.error(`    ${mismatch.key}`);
-      console.error(`      ${firstEntry.label}:  ${mismatch.first.join(', ')}`);
-      console.error(`      ${secondEntry.label}: ${mismatch.second.join(', ')}`);
+      console.error(`      ${first.entry.label}:  ${mismatch.first.join(', ')}`);
+      console.error(`      ${second.entry.label}: ${mismatch.second.join(', ')}`);
     }
     console.error();
   }

--- a/crux/validate/validate-tsconfig-aliases.ts
+++ b/crux/validate/validate-tsconfig-aliases.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that @wiki-server/* path alias keys stay in sync between
+ * crux/tsconfig.json and apps/web/tsconfig.json.
+ *
+ * Drift between these tsconfigs causes fake "Cannot find module
+ * '@wiki-server/*-route'" errors in the crux tsc check (transitively,
+ * via apps/web/src/lib/wiki-server.ts) and silently inflates the
+ * crux-tsc-baseline, hiding real errors.
+ *
+ * See QUA-483.
+ *
+ * Usage: npx tsx crux/validate/validate-tsconfig-aliases.ts
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getColors } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+
+const ALIAS_PREFIX = '@wiki-server/';
+
+const TSCONFIGS = [
+  { label: 'crux/tsconfig.json', path: join(PROJECT_ROOT, 'crux/tsconfig.json') },
+  { label: 'apps/web/tsconfig.json', path: join(PROJECT_ROOT, 'apps/web/tsconfig.json') },
+] as const;
+
+interface TsConfig {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+function readTsConfig(path: string): TsConfig {
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as TsConfig;
+}
+
+function extractWikiServerKeys(cfg: TsConfig): Set<string> {
+  const paths = cfg.compilerOptions?.paths ?? {};
+  return new Set(Object.keys(paths).filter((k) => k.startsWith(ALIAS_PREFIX)));
+}
+
+export interface AliasDrift {
+  onlyInCrux: string[];
+  onlyInAppsWeb: string[];
+}
+
+export function diffAliases(cruxKeys: Set<string>, appsWebKeys: Set<string>): AliasDrift {
+  const onlyInCrux = [...cruxKeys].filter((k) => !appsWebKeys.has(k)).sort();
+  const onlyInAppsWeb = [...appsWebKeys].filter((k) => !cruxKeys.has(k)).sort();
+  return { onlyInCrux, onlyInAppsWeb };
+}
+
+export function runCheck(): { passed: boolean; errors: number; drift: AliasDrift } {
+  const c = getColors();
+  console.log(`${c.blue}Checking @wiki-server/* alias parity between tsconfigs...${c.reset}\n`);
+
+  const [cruxCfg, appsWebCfg] = TSCONFIGS.map(({ path }) => readTsConfig(path));
+  const cruxKeys = extractWikiServerKeys(cruxCfg);
+  const appsWebKeys = extractWikiServerKeys(appsWebCfg);
+
+  const drift = diffAliases(cruxKeys, appsWebKeys);
+  const totalErrors = drift.onlyInCrux.length + drift.onlyInAppsWeb.length;
+
+  if (totalErrors === 0) {
+    console.log(
+      `${c.green}✓ @wiki-server/* aliases in sync (${cruxKeys.size} keys)${c.reset}`
+    );
+    return { passed: true, errors: 0, drift };
+  }
+
+  console.log(
+    `${c.red}Found ${totalErrors} @wiki-server/* alias drift(s):${c.reset}\n`
+  );
+  if (drift.onlyInAppsWeb.length > 0) {
+    console.log(`  ${c.yellow}Missing from crux/tsconfig.json:${c.reset}`);
+    for (const key of drift.onlyInAppsWeb) console.log(`    - ${key}`);
+    console.log();
+  }
+  if (drift.onlyInCrux.length > 0) {
+    console.log(`  ${c.yellow}Missing from apps/web/tsconfig.json:${c.reset}`);
+    for (const key of drift.onlyInCrux) console.log(`    - ${key}`);
+    console.log();
+  }
+  console.log(
+    `${c.dim}Fix: copy the missing alias entries between the two files so both key sets match.${c.reset}`
+  );
+  console.log(
+    `${c.dim}Context: QUA-483 — drift causes fake TS errors in the crux tsc check.${c.reset}`
+  );
+
+  return { passed: false, errors: totalErrors, drift };
+}
+
+if (process.argv[1]?.includes('validate-tsconfig-aliases')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

Adds `crux/validate/validate-tsconfig-aliases.ts` — a blocking gate check that keeps `@wiki-server/*` path alias entries in sync between `crux/tsconfig.json` and `apps/web/tsconfig.json`. Drift between these two files causes fake `Cannot find module '@wiki-server/*-route'` errors in the crux `tsc` check (transitively, via `apps/web/src/lib/wiki-server.ts`), which silently inflates the `crux-tsc-baseline` and hides real type errors.

The QUA-337 follow-up pass manually resynced the two tsconfigs; this validator keeps them that way.

## What it checks

Two axes of drift:

1. **Key parity** — both configs must declare the same set of `@wiki-server/*` alias keys.
2. **Target parity** — for each shared key, the target path in each config must resolve (relative to each file's own `baseUrl`) to the same **absolute** file. This catches the subtler case where the keys match on both sides but one config points at a stale or wrong file.

Target-path parity is the more common and more insidious drift mode — naive key-set-only checks miss it.

## Edge cases handled

- Different relative spellings that resolve to the same absolute file (e.g. `../apps/wiki-server/...` in `crux/tsconfig.json` vs `../wiki-server/...` in `apps/web/tsconfig.json`) are treated as **matching**, not drift.
- Missing or unreadable tsconfig files produce a clear "Could not read X at Y" error with context.
- Malformed JSON produces a clear "Could not parse X as JSON" error, with an inline note that JSONC comments are not supported.
- `extends` clauses are rejected loudly rather than silently ignored — resolving the extends chain is out of scope, and silently dropping inherited paths would mask real drift.

## Test plan

- [x] 18 unit/integration tests in `validate-tsconfig-aliases.test.ts`:
  - `resolveAliasTarget` normalization (3 tests)
  - `diffAliases` with `AliasSide` object params: target drift detection, key drift in both directions, sort stability, empty path sets (6 tests)
  - `runCheck` with temp-dir fixtures: happy path, key drift, target drift, extends rejection, non-`@wiki-server` alias filtering, missing file, malformed JSON, exit-code contract on drifted fixture (8 tests)
  - End-to-end against the real repo tsconfigs (1 test)
- [x] Adversarial red-team: tested with `paths: null`, missing `compilerOptions`, extends chain — all handled gracefully without crashes
- [x] Full gate run locally — all 46-53 checks passing (the new check ran as `tsconfig @wiki-server/* alias parity`, ~11s elapsed, blocking)
- [x] `pnpm build`, `pnpm test` (new tests: 18/18), `tsc --noEmit` for app + wiki-server + crux (zero new errors introduced)
- [ ] CI green on push

## Review

- [x] `/agent-review-pr` — hostile review caught two HIGH issues:
  - Initial key-set-only check missed target-path drift → **fixed** (target resolution added)
  - Missing error handling on file I/O / JSON parse → **fixed** (context-qualified error messages)
- [x] `/simplify` — quality-review agent flagged parameter sprawl in `diffAliases` (6 positional args) → **fixed** (refactored to two `AliasSide` objects + `loadSide` helper, ~30 parallel locals collapsed)

## Follow-ups observed during this session

- QUA-496 filed: `crux/wiki-server/snapshot-resources.test.ts` has two pre-existing failing assertions (`fetched_at` 2.6% below 10% threshold, `cited_by` 20.9% below 50% threshold) — unrelated to this PR, but worth fixing so `pnpm test` is clean again.
- QUA-484 (Hono RPC client type drift) — the fake TS errors this validator was designed to prevent are still surfacing for a different reason (genuine RPC type drift, not tsconfig alias drift). Already filed, and is the next PR in the orphan-cleanup sweep.

Closes QUA-483

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new CI validation gate to enforce TypeScript path alias consistency across project configurations, preventing configuration drift during development.
  * Added comprehensive test coverage for the new validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->