### PR TITLE
refactor(github): MissingTokenError class for robust classification (QUA-482)

### DIFF
--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -1,28 +1,27 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getGitHubToken, MissingTokenError, isMissingTokenError } from './github.ts';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  getGitHubToken,
+  isMissingTokenError,
+  MissingTokenError,
+  MISSING_TOKEN_HELP_MESSAGE,
+} from './github.ts';
 
+// Use `vi.stubEnv()` instead of mutating `process.env` directly. stubEnv is
+// scoped per-test and reset by `vi.unstubAllEnvs()`, so parallel workers
+// reading GITHUB_TOKEN (e.g. enriched-scan.test.ts) don't race with this
+// file's mutations.
 describe('getGitHubToken', () => {
-  let originalToken: string | undefined;
-
-  beforeEach(() => {
-    originalToken = process.env.GITHUB_TOKEN;
-  });
-
   afterEach(() => {
-    if (originalToken === undefined) {
-      delete process.env.GITHUB_TOKEN;
-    } else {
-      process.env.GITHUB_TOKEN = originalToken;
-    }
+    vi.unstubAllEnvs();
   });
 
   it('throws MissingTokenError when GITHUB_TOKEN is undefined', () => {
-    delete process.env.GITHUB_TOKEN;
+    vi.stubEnv('GITHUB_TOKEN', undefined as unknown as string);
     expect(() => getGitHubToken()).toThrow(MissingTokenError);
   });
 
   it('throws MissingTokenError when GITHUB_TOKEN is the empty string', () => {
-    process.env.GITHUB_TOKEN = '';
+    vi.stubEnv('GITHUB_TOKEN', '');
     expect(() => getGitHubToken()).toThrow(MissingTokenError);
   });
 
@@ -30,7 +29,7 @@ describe('getGitHubToken', () => {
     // Regression: whitespace-only values used to pass the truthy check and
     // reach the GitHub API verbatim, producing a transient-looking 401 instead
     // of immediate permanent-fault classification. See QUA-482 minor review.
-    process.env.GITHUB_TOKEN = '   ';
+    vi.stubEnv('GITHUB_TOKEN', '   ');
     let caught: unknown;
     try {
       getGitHubToken();
@@ -42,17 +41,80 @@ describe('getGitHubToken', () => {
   });
 
   it('throws MissingTokenError when GITHUB_TOKEN is tabs and newlines only', () => {
-    process.env.GITHUB_TOKEN = '\t\n  \t';
+    vi.stubEnv('GITHUB_TOKEN', '\t\n  \t');
     expect(() => getGitHubToken()).toThrow(MissingTokenError);
   });
 
   it('returns the token when GITHUB_TOKEN is a valid value', () => {
-    process.env.GITHUB_TOKEN = 'ghp_abc123';
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_abc123');
     expect(getGitHubToken()).toBe('ghp_abc123');
   });
 
   it('returns the trimmed token when GITHUB_TOKEN has surrounding whitespace', () => {
-    process.env.GITHUB_TOKEN = '  ghp_abc123\n';
+    // Common when users do `GITHUB_TOKEN=$(cat token.txt)` with a trailing
+    // newline. Previously sent verbatim and returned 401; now trimmed.
+    vi.stubEnv('GITHUB_TOKEN', '  ghp_abc123\n');
     expect(getGitHubToken()).toBe('ghp_abc123');
+  });
+});
+
+describe('MissingTokenError', () => {
+  it('has name === "MissingTokenError" for serialized classification', () => {
+    // Load-bearing: downstream log/telemetry code that JSON-serializes errors
+    // or crosses a subprocess boundary loses `instanceof` and must rely on
+    // `.name`. Pin this so a rename can't silently break classifiers.
+    const err = new MissingTokenError();
+    expect(err.name).toBe('MissingTokenError');
+  });
+
+  it('uses the shared MISSING_TOKEN_HELP_MESSAGE', () => {
+    const err = new MissingTokenError();
+    expect(err.message).toBe(MISSING_TOKEN_HELP_MESSAGE);
+  });
+
+  it('extends Error so stack traces work', () => {
+    const err = new MissingTokenError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.stack).toBeTruthy();
+  });
+});
+
+describe('isMissingTokenError', () => {
+  it('accepts real MissingTokenError instances', () => {
+    expect(isMissingTokenError(new MissingTokenError())).toBe(true);
+  });
+
+  it('accepts serialized errors with matching .name (cross-realm / JSON roundtrip)', () => {
+    // A real scenario: a subprocess throws MissingTokenError, the parent
+    // captures stderr, reconstructs the error as a plain object, and hands
+    // it to the classifier. `instanceof` fails across the boundary — only
+    // `.name` survives. The classifier must still recognize it.
+    const serialized = { name: 'MissingTokenError', message: 'anything' };
+    expect(isMissingTokenError(serialized)).toBe(true);
+
+    const roundTripped = JSON.parse(
+      JSON.stringify({ name: 'MissingTokenError', message: 'x' }),
+    );
+    expect(isMissingTokenError(roundTripped)).toBe(true);
+  });
+
+  it('rejects plain Error instances, even with matching message content', () => {
+    // QUA-482: the whole point of the refactor is that a plain Error whose
+    // message happens to contain "GITHUB_TOKEN not set" must NOT be classified
+    // as a missing-token error. Guard against future regressions.
+    expect(isMissingTokenError(new Error(MISSING_TOKEN_HELP_MESSAGE))).toBe(false);
+    expect(
+      isMissingTokenError(
+        new Error('upstream log: "GITHUB_TOKEN not set" appeared'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects non-error falsy / primitive values', () => {
+    expect(isMissingTokenError(null)).toBe(false);
+    expect(isMissingTokenError(undefined)).toBe(false);
+    expect(isMissingTokenError('MissingTokenError')).toBe(false);
+    expect(isMissingTokenError(42)).toBe(false);
+    expect(isMissingTokenError({})).toBe(false);
   });
 });

--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getGitHubToken, MissingTokenError, isMissingTokenError } from './github.ts';
+
+describe('getGitHubToken', () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.GITHUB_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalToken;
+    }
+  });
+
+  it('throws MissingTokenError when GITHUB_TOKEN is undefined', () => {
+    delete process.env.GITHUB_TOKEN;
+    expect(() => getGitHubToken()).toThrow(MissingTokenError);
+  });
+
+  it('throws MissingTokenError when GITHUB_TOKEN is the empty string', () => {
+    process.env.GITHUB_TOKEN = '';
+    expect(() => getGitHubToken()).toThrow(MissingTokenError);
+  });
+
+  it('throws MissingTokenError when GITHUB_TOKEN is whitespace-only', () => {
+    // Regression: whitespace-only values used to pass the truthy check and
+    // reach the GitHub API verbatim, producing a transient-looking 401 instead
+    // of immediate permanent-fault classification. See QUA-482 minor review.
+    process.env.GITHUB_TOKEN = '   ';
+    let caught: unknown;
+    try {
+      getGitHubToken();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MissingTokenError);
+    expect(isMissingTokenError(caught)).toBe(true);
+  });
+
+  it('throws MissingTokenError when GITHUB_TOKEN is tabs and newlines only', () => {
+    process.env.GITHUB_TOKEN = '\t\n  \t';
+    expect(() => getGitHubToken()).toThrow(MissingTokenError);
+  });
+
+  it('returns the token when GITHUB_TOKEN is a valid value', () => {
+    process.env.GITHUB_TOKEN = 'ghp_abc123';
+    expect(getGitHubToken()).toBe('ghp_abc123');
+  });
+
+  it('returns the trimmed token when GITHUB_TOKEN has surrounding whitespace', () => {
+    process.env.GITHUB_TOKEN = '  ghp_abc123\n';
+    expect(getGitHubToken()).toBe('ghp_abc123');
+  });
+});

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -18,18 +18,31 @@
 export const REPO = 'quantified-uncertainty/longterm-wiki';
 
 /**
+ * Canonical help message for every code path that wants to tell the user
+ * how to set `GITHUB_TOKEN`. Kept in one place so the 7+ display call sites
+ * (health-check summaries, wellness-report, pr-quality, ci-main-health,
+ * github-lookup, pr-patrol index/parallel) don't drift from each other.
+ */
+export const MISSING_TOKEN_HELP_MESSAGE =
+  'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
+  'Set it with: export GITHUB_TOKEN=<your-token>';
+
+/**
  * Thrown by `getGitHubToken()` when the `GITHUB_TOKEN` environment variable is
  * missing or empty. Callers that need to distinguish "permanent config fault"
  * from "transient GitHub hiccup" should use `isMissingTokenError()` rather
  * than grepping error messages — see QUA-482 for why string-matching the
  * signal is brittle.
+ *
+ * The constructor deliberately takes no arguments. Allowing a custom message
+ * would let a caller `throw new MissingTokenError('unrelated condition')` and
+ * trip the patrol's permanent-halt classifier on something that isn't
+ * actually a missing token. The class exists as a stable classifier signal,
+ * not a general-purpose error wrapper.
  */
 export class MissingTokenError extends Error {
-  constructor(
-    message = 'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
-      'Set it with: export GITHUB_TOKEN=<your-token>',
-  ) {
-    super(message);
+  constructor() {
+    super(MISSING_TOKEN_HELP_MESSAGE);
     this.name = 'MissingTokenError';
   }
 }
@@ -37,9 +50,19 @@ export class MissingTokenError extends Error {
 /**
  * Type guard for `MissingTokenError`. Prefer this over `msg.includes(...)` so
  * the error signal can evolve without silently breaking classifiers.
+ *
+ * Also matches serialized errors where only `.name === 'MissingTokenError'`
+ * survives the boundary (JSON logs, subprocess stderr → parent catch). The
+ * `instanceof` check catches the happy path; the `.name` check catches
+ * cross-realm / serialized cases.
  */
 export function isMissingTokenError(err: unknown): err is MissingTokenError {
-  return err instanceof MissingTokenError;
+  if (err instanceof MissingTokenError) return true;
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { name?: unknown }).name === 'MissingTokenError'
+  );
 }
 
 /**

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -18,15 +18,37 @@
 export const REPO = 'quantified-uncertainty/longterm-wiki';
 
 /**
- * Get the GitHub token from the environment or throw a clear error.
+ * Thrown by `getGitHubToken()` when the `GITHUB_TOKEN` environment variable is
+ * missing or empty. Callers that need to distinguish "permanent config fault"
+ * from "transient GitHub hiccup" should use `isMissingTokenError()` rather
+ * than grepping error messages — see QUA-482 for why string-matching the
+ * signal is brittle.
+ */
+export class MissingTokenError extends Error {
+  constructor(
+    message = 'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
+      'Set it with: export GITHUB_TOKEN=<your-token>',
+  ) {
+    super(message);
+    this.name = 'MissingTokenError';
+  }
+}
+
+/**
+ * Type guard for `MissingTokenError`. Prefer this over `msg.includes(...)` so
+ * the error signal can evolve without silently breaking classifiers.
+ */
+export function isMissingTokenError(err: unknown): err is MissingTokenError {
+  return err instanceof MissingTokenError;
+}
+
+/**
+ * Get the GitHub token from the environment or throw a `MissingTokenError`.
  */
 export function getGitHubToken(): string {
   const token = process.env.GITHUB_TOKEN;
   if (!token) {
-    throw new Error(
-      'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
-      'Set it with: export GITHUB_TOKEN=<your-token>'
-    );
+    throw new MissingTokenError();
   }
   return token;
 }

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -44,9 +44,14 @@ export function isMissingTokenError(err: unknown): err is MissingTokenError {
 
 /**
  * Get the GitHub token from the environment or throw a `MissingTokenError`.
+ *
+ * Whitespace-only values (e.g. `'   '`) are treated as missing. Without the
+ * trim, a stray-whitespace env var would pass the truthy check and be sent
+ * verbatim to the GitHub API, causing a transient-looking 401 instead of the
+ * immediate permanent-fault classification that `MissingTokenError` signals.
  */
 export function getGitHubToken(): string {
-  const token = process.env.GITHUB_TOKEN;
+  const token = process.env.GITHUB_TOKEN?.trim();
   if (!token) {
     throw new MissingTokenError();
   }

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -300,7 +300,9 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
       },
     });
     expect(decision.proceed).toBe(true);
-    expect(deps.events[0]).toMatchObject({ type: 'health_scan_error' });
+    // Use `.some()` rather than `events[0]` so the assertion survives a
+    // future refactor that adds a leading event (e.g. a telemetry marker).
+    expect(deps.events.some((e) => e.type === 'health_scan_error')).toBe(true);
     expect(
       deps.events.some((e) => e.type === 'health_gate_missing_token'),
     ).toBe(false);

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
+import { MissingTokenError } from '../lib/github.ts';
 import {
   runHealthGate,
   fingerprintIssue,
@@ -259,10 +260,7 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
     const decision = await runHealthGate({
       ...deps,
       scan: async () => {
-        throw new Error(
-          'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
-            'Set it with: export GITHUB_TOKEN=<your-token>',
-        );
+        throw new MissingTokenError();
       },
     });
 
@@ -285,6 +283,27 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
     });
     expect(decision.proceed).toBe(true);
     expect(deps.events[0]).toMatchObject({ type: 'health_scan_error' });
+  });
+
+  it('does NOT misclassify errors that merely echo the legacy signal string', async () => {
+    // QUA-482: the classifier now uses `instanceof MissingTokenError`, not
+    // substring-matching. A generic Error whose message happens to contain
+    // 'GITHUB_TOKEN not set' (e.g. a log line echoed back from a subprocess)
+    // must NOT trip the permanent-halt path.
+    const deps = makeDeps();
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => {
+        throw new Error(
+          'upstream log: "GITHUB_TOKEN not set" appeared in a prior run',
+        );
+      },
+    });
+    expect(decision.proceed).toBe(true);
+    expect(deps.events[0]).toMatchObject({ type: 'health_scan_error' });
+    expect(
+      deps.events.some((e) => e.type === 'health_gate_missing_token'),
+    ).toBe(false);
   });
 });
 

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -20,6 +20,7 @@
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { isMissingTokenError } from '../lib/github.ts';
 import { healthScan as realHealthScan, type HealthScanResult, type HealthIssue } from './health-scan.ts';
 import { appendJsonl, JSONL_FILE, STATE_DIR, ensureDirs, cl, log as realLog } from './state.ts';
 
@@ -49,20 +50,6 @@ const HEALTH_GATE_STATE_FILE = join(STATE_DIR, 'health-gate-cooldown.json');
 
 /** Reserved fingerprint used to track consecutive scan-error count. */
 const SCAN_ERROR_COUNTER_KEY = '__scan_error_count__';
-
-/**
- * Signal string emitted by `getGitHubToken()` in `crux/lib/github.ts` when the
- * env var is missing. Used to classify scan failures so a permanent config
- * error halts patrol immediately instead of cycling through
- * MAX_CONSECUTIVE_SCAN_ERRORS (QUA-395).
- */
-const MISSING_TOKEN_ERROR_SIGNAL = 'GITHUB_TOKEN not set';
-
-/** True when the error is from a missing GITHUB_TOKEN. */
-function isMissingTokenError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg.includes(MISSING_TOKEN_ERROR_SIGNAL);
-}
 
 // ── Types ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replace brittle string-matching on `'GITHUB_TOKEN not set'` with a proper `MissingTokenError` class and `isMissingTokenError()` type guard in `crux/lib/github.ts`.

- `getGitHubToken()` now throws `MissingTokenError` (message preserved for humans)
- `crux/pr-patrol/health-gate.ts` imports the shared type guard instead of defining a local `msg.includes(...)` classifier
- Regression test confirms unrelated errors that happen to echo the legacy signal are no longer misclassified as permanent-halt

This closes QUA-482 (flagged during QUA-395 /simplify review) and removes the failure mode where a future message reword would silently return `false` from classifiers and burn through `MAX_CONSECUTIVE_SCAN_ERRORS` on a permanent config fault.

Fixes QUA-482

## Test plan

- [x] `pnpm vitest run crux/pr-patrol/` — 360 pass (includes new `instanceof`-based regression test)
- [x] `pnpm vitest run crux/lib/search/providers/github-search.test.ts` — 8 pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection and clearer messaging when the GitHub token is missing or only whitespace.

* **Refactor**
  * Centralized and standardized token validation and error signaling across checks.

* **Tests**
  * Added comprehensive tests covering token reading, trimming, error type/name, and classifier behavior (including serialized/cross-realm cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->