### PR TITLE
fix(crux health): pin --local to explicit URL, fix slot ambiguity (QUA-491)

### DIFF
--- a/crux/commands/health.ts
+++ b/crux/commands/health.ts
@@ -45,8 +45,9 @@ Options:
   --report        Aggregate markdown report to stdout
   --auto-issue    Manage GitHub wellness issue (create/update/close)
   --cleanup-labels Auto-remove stale working labels (>8 hours)
-  --local         Check a local dev server (localhost:3002) instead of production.
-                  Default behavior is to check production via PROD_LONGTERMWIKI_SERVER_URL. (QUA-479)
+  --local         Check a local dev server at http://localhost:3002 (main clone default).
+  --local=URL     Check a specific local dev server URL (e.g. http://localhost:3011 for slot a1).
+                  Default behavior is to check production via PROD_LONGTERMWIKI_SERVER_URL. (QUA-479, QUA-491)
 
 Environment:
   LONGTERMWIKI_SERVER_URL        Wiki-server URL (required for most checks)

--- a/crux/health/health-check.test.ts
+++ b/crux/health/health-check.test.ts
@@ -9,7 +9,43 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { describeFetchError, fetchJson } from './health-check.ts';
+import {
+  describeFetchError,
+  fetchJson,
+  parseLocalModeUrl,
+  DEFAULT_LOCAL_URL,
+} from './health-check.ts';
+
+describe('parseLocalModeUrl (QUA-491)', () => {
+  it('returns null when --local is not passed', () => {
+    expect(parseLocalModeUrl([])).toBeNull();
+    expect(parseLocalModeUrl(['--json', '--check=server'])).toBeNull();
+  });
+
+  it('returns the default localhost URL for bare --local', () => {
+    expect(parseLocalModeUrl(['--local'])).toBe(DEFAULT_LOCAL_URL);
+    expect(parseLocalModeUrl(['--json', '--local'])).toBe(DEFAULT_LOCAL_URL);
+  });
+
+  it('returns the explicit URL for --local=URL', () => {
+    expect(parseLocalModeUrl(['--local=http://localhost:3011'])).toBe(
+      'http://localhost:3011',
+    );
+    expect(parseLocalModeUrl(['--local=http://127.0.0.1:4000'])).toBe(
+      'http://127.0.0.1:4000',
+    );
+  });
+
+  it('does not match unrelated args that share the --local prefix', () => {
+    expect(parseLocalModeUrl(['--locality=x'])).toBeNull();
+  });
+
+  it('is order-independent', () => {
+    expect(parseLocalModeUrl(['--check=server', '--local=http://h:1', '--json']))
+      .toBe('http://h:1');
+  });
+});
+
 
 describe('describeFetchError', () => {
   it('classifies ECONNREFUSED and hints at --local for localhost targets', () => {

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -11,7 +11,8 @@
  *
  * Usage:
  *   crux health                      Run all checks (against production)
- *   crux health --local              Check local dev server instead of production
+ *   crux health --local              Check local dev server at http://localhost:3002
+ *   crux health --local=http://...   Check a specific local dev server URL
  *   crux health --check=server       Server & DB only
  *   crux health --check=api          API smoke tests only
  *   crux health --check=actions           GitHub Actions workflow health
@@ -29,7 +30,8 @@
  * Note: `crux health` is unambiguously about production. The command
  * defaults to WIKI_SERVER_ENV=prod so it works from any directory without
  * the env-var prefix slots normally need. Pass `--local` to check a local
- * dev server on localhost:3002 instead. See QUA-479.
+ * dev server at http://localhost:3002, or `--local=http://localhost:3011`
+ * to pin to a specific URL. See QUA-479, QUA-491.
  */
 
 import { getColors } from '../lib/output.ts';
@@ -58,17 +60,57 @@ const CHECK_ARG = args.find((a) => a.startsWith('--check='))?.split('=')[1];
 const REPORT_MODE = args.includes('--report');
 const AUTO_ISSUE = args.includes('--auto-issue');
 const CLEANUP_LABELS = args.includes('--cleanup-labels');
-const LOCAL_MODE = args.includes('--local');
+/**
+ * Default URL used by `--local` when no explicit value is given. This is the
+ * port the main workspace clone's wiki-server listens on — see CLAUDE.md's
+ * port table. Agent slots use different ports (3011+), so users running
+ * `crux health --local` from a slot should pass `--local=http://localhost:3011`
+ * etc. (QUA-491).
+ */
+export const DEFAULT_LOCAL_URL = 'http://localhost:3002';
+
+/**
+ * Parse the `--local[=URL]` CLI flag.
+ *
+ * Before QUA-491, `--local` just skipped the prod-env guard and let the
+ * current directory's `.env` choose the URL — which made the command
+ * slot-dependent (`lw/main` → localhost:3002, `lw/a11/.env` → whatever
+ * symlink it had). Now `--local` always pins an explicit URL so behavior
+ * is independent of cwd.
+ *
+ * Returns:
+ *   - `null` when `--local` is not passed
+ *   - `DEFAULT_LOCAL_URL` for bare `--local`
+ *   - The value after `=` for `--local=http://...`
+ */
+export function parseLocalModeUrl(argv: readonly string[]): string | null {
+  const arg = argv.find((a) => a === '--local' || a.startsWith('--local='));
+  if (!arg) return null;
+  if (arg === '--local') return DEFAULT_LOCAL_URL;
+  return arg.slice('--local='.length);
+}
+
+const LOCAL_URL = parseLocalModeUrl(args);
+const LOCAL_MODE = LOCAL_URL !== null;
 
 // Default to production unless --local was passed (QUA-479). `crux health`
 // is semantically "is production healthy?", so it should work from any
 // directory (coord/, agent slots, worktrees) without requiring users to
-// remember `WIKI_SERVER_ENV=prod`. Respect an explicit pre-set value so
-// callers who set it themselves keep their choice. Gated on INVOKED_AS_SCRIPT
-// so importing this module from tests does not mutate process.env and
-// pollute other tests (sync-session.test.ts, client.test.ts both care).
-if (INVOKED_AS_SCRIPT && !LOCAL_MODE && !process.env.WIKI_SERVER_ENV) {
-  process.env.WIKI_SERVER_ENV = 'prod';
+// remember `WIKI_SERVER_ENV=prod`. When --local is passed, pin the URL
+// explicitly instead of letting the current .env decide (QUA-491) — otherwise
+// `--local` is slot-ambiguous. Respect an explicit pre-set WIKI_SERVER_ENV
+// so callers who set it themselves keep their choice. Gated on
+// INVOKED_AS_SCRIPT so importing this module from tests does not mutate
+// process.env and pollute other tests (sync-session.test.ts, client.test.ts
+// both care).
+if (INVOKED_AS_SCRIPT) {
+  if (LOCAL_MODE) {
+    // Clear WIKI_SERVER_ENV so getServerUrl() reads the non-prod prefix.
+    delete process.env.WIKI_SERVER_ENV;
+    process.env.LONGTERMWIKI_SERVER_URL = LOCAL_URL!;
+  } else if (!process.env.WIKI_SERVER_ENV) {
+    process.env.WIKI_SERVER_ENV = 'prod';
+  }
 }
 
 // Resolve wiki-server URL/API key via the shared client helpers so


### PR DESCRIPTION
## Summary

`crux health --local` was advertised as "check localhost:3002" but actually read `$LONGTERMWIKI_SERVER_URL` from the current directory's `.env`, making it slot-dependent (`lw/a11/` could end up hitting slot a3's port).

This PR parses `--local[=URL]` explicitly:

- bare `--local` → `http://localhost:3002` (main clone default, matches the advertised help text)
- `--local=http://localhost:3011` → pin to that URL (e.g. slot a1's port)

The top-level env-setting block now sets `LONGTERMWIKI_SERVER_URL` directly and clears `WIKI_SERVER_ENV`, so the resolved URL no longer depends on cwd. `parseLocalModeUrl()` is extracted as a pure helper with 5 unit tests covering null / bare / explicit / prefix-collision / order-independent cases.

Fixes QUA-491

## Test plan

- [x] `pnpm vitest run crux/health/health-check.test.ts` — 15 pass (10 existing + 5 new)
- [x] Help text in `crux/commands/health.ts` updated to document `--local=URL`
- [x] Module docstring updated with QUA-491 cross-reference
