### PR TITLE
fix(crux health): harden --local parser (QUA-491 follow-up from review)

### DIFF
--- a/crux/health/health-check.test.ts
+++ b/crux/health/health-check.test.ts
@@ -13,6 +13,7 @@ import {
   describeFetchError,
   fetchJson,
   parseLocalModeUrl,
+  resolveHealthEnvOverrides,
   DEFAULT_LOCAL_URL,
 } from './health-check.ts';
 
@@ -27,12 +28,43 @@ describe('parseLocalModeUrl (QUA-491)', () => {
     expect(parseLocalModeUrl(['--json', '--local'])).toBe(DEFAULT_LOCAL_URL);
   });
 
-  it('returns the explicit URL for --local=URL', () => {
+  it('returns the default for --local= with empty value', () => {
+    // Edge case from review: a user who types `--local=` by accident should
+    // get the sensible default, not an empty string that makes getServerUrl()
+    // return '' and then fail opaquely downstream.
+    expect(parseLocalModeUrl(['--local='])).toBe(DEFAULT_LOCAL_URL);
+  });
+
+  it('returns the explicit URL for --local=URL with loopback hosts', () => {
     expect(parseLocalModeUrl(['--local=http://localhost:3011'])).toBe(
       'http://localhost:3011',
     );
     expect(parseLocalModeUrl(['--local=http://127.0.0.1:4000'])).toBe(
       'http://127.0.0.1:4000',
+    );
+    expect(parseLocalModeUrl(['--local=http://[::1]:3002'])).toBe(
+      'http://[::1]:3002',
+    );
+  });
+
+  it('rejects non-loopback hosts to prevent API-key leakage', () => {
+    // Footgun defense: a stale LONGTERMWIKI_SERVER_API_KEY in .env would be
+    // forwarded as a Bearer header to whatever URL this flag accepts. Limit
+    // the flag to loopback so typos can't leak credentials to a real host.
+    expect(() =>
+      parseLocalModeUrl(['--local=https://wiki-server.k8s.quantifieduncertainty.org']),
+    ).toThrow(/non-loopback host/);
+    expect(() => parseLocalModeUrl(['--local=http://example.com'])).toThrow(
+      /non-loopback host/,
+    );
+  });
+
+  it('rejects unparseable URLs with a clear error', () => {
+    expect(() => parseLocalModeUrl(['--local=not a url'])).toThrow(
+      /Invalid --local URL/,
+    );
+    expect(() => parseLocalModeUrl(['--local=:::'])).toThrow(
+      /Invalid --local URL/,
     );
   });
 
@@ -41,8 +73,63 @@ describe('parseLocalModeUrl (QUA-491)', () => {
   });
 
   it('is order-independent', () => {
-    expect(parseLocalModeUrl(['--check=server', '--local=http://h:1', '--json']))
-      .toBe('http://h:1');
+    expect(parseLocalModeUrl(['--check=server', '--local=http://localhost:1', '--json']))
+      .toBe('http://localhost:1');
+  });
+
+  it('returns the first --local variant when both bare and explicit are passed', () => {
+    // Undocumented but stable: argv.find() returns the first match. This
+    // test pins the behavior so a future refactor can't silently change it.
+    expect(parseLocalModeUrl(['--local', '--local=http://localhost:9999'])).toBe(
+      DEFAULT_LOCAL_URL,
+    );
+    expect(parseLocalModeUrl(['--local=http://localhost:9999', '--local'])).toBe(
+      'http://localhost:9999',
+    );
+  });
+});
+
+describe('resolveHealthEnvOverrides (QUA-491)', () => {
+  it('defaults to WIKI_SERVER_ENV=prod when neither --local nor WIKI_SERVER_ENV is set', () => {
+    const overrides = resolveHealthEnvOverrides([], {});
+    expect(overrides).toEqual({
+      setEnv: { WIKI_SERVER_ENV: 'prod' },
+      unsetEnv: [],
+      localUrl: null,
+    });
+  });
+
+  it('respects a pre-set WIKI_SERVER_ENV when --local is absent', () => {
+    const overrides = resolveHealthEnvOverrides([], { WIKI_SERVER_ENV: 'staging' });
+    expect(overrides).toEqual({ setEnv: {}, unsetEnv: [], localUrl: null });
+  });
+
+  it('pins LONGTERMWIKI_SERVER_URL and clears WIKI_SERVER_ENV for bare --local', () => {
+    const overrides = resolveHealthEnvOverrides(['--local'], {});
+    expect(overrides).toEqual({
+      setEnv: { LONGTERMWIKI_SERVER_URL: DEFAULT_LOCAL_URL },
+      unsetEnv: ['WIKI_SERVER_ENV'],
+      localUrl: DEFAULT_LOCAL_URL,
+    });
+  });
+
+  it('--local wins over a pre-set WIKI_SERVER_ENV=prod', () => {
+    // Regression: previously, `--local` just skipped the prod-guard block,
+    // which meant a pre-set WIKI_SERVER_ENV=prod would beat --local and the
+    // flag would be silently ignored. Now --local is authoritative.
+    const overrides = resolveHealthEnvOverrides(
+      ['--local=http://localhost:3011'],
+      { WIKI_SERVER_ENV: 'prod' },
+    );
+    expect(overrides.setEnv.LONGTERMWIKI_SERVER_URL).toBe('http://localhost:3011');
+    expect(overrides.unsetEnv).toContain('WIKI_SERVER_ENV');
+    expect(overrides.localUrl).toBe('http://localhost:3011');
+  });
+
+  it('propagates parseLocalModeUrl errors so the caller can exit cleanly', () => {
+    expect(() =>
+      resolveHealthEnvOverrides(['--local=https://example.com'], {}),
+    ).toThrow(/non-loopback host/);
   });
 });
 

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -70,6 +70,14 @@ const CLEANUP_LABELS = args.includes('--cleanup-labels');
 export const DEFAULT_LOCAL_URL = 'http://localhost:3002';
 
 /**
+ * Hostnames accepted for `--local=URL`. `--local` is semantically "point at a
+ * loopback dev server" — restricting the host prevents a footgun where a
+ * stale `LONGTERMWIKI_SERVER_API_KEY` in `.env` gets forwarded as a `Bearer`
+ * header to a real remote server the user typed by mistake.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '::1']);
+
+/**
  * Parse the `--local[=URL]` CLI flag.
  *
  * Before QUA-491, `--local` just skipped the prod-env guard and let the
@@ -80,37 +88,97 @@ export const DEFAULT_LOCAL_URL = 'http://localhost:3002';
  *
  * Returns:
  *   - `null` when `--local` is not passed
- *   - `DEFAULT_LOCAL_URL` for bare `--local`
- *   - The value after `=` for `--local=http://...`
+ *   - `DEFAULT_LOCAL_URL` for bare `--local` or `--local=` (empty value)
+ *   - The (validated) value after `=` for `--local=http://localhost:PORT`
+ *
+ * Throws when the explicit URL is unparseable or points at a non-loopback
+ * host. The caller is expected to catch and print a clean CLI error.
  */
 export function parseLocalModeUrl(argv: readonly string[]): string | null {
   const arg = argv.find((a) => a === '--local' || a.startsWith('--local='));
   if (!arg) return null;
   if (arg === '--local') return DEFAULT_LOCAL_URL;
-  return arg.slice('--local='.length);
+  const rawValue = arg.slice('--local='.length);
+  if (rawValue === '') return DEFAULT_LOCAL_URL;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawValue);
+  } catch {
+    throw new Error(
+      `Invalid --local URL: ${JSON.stringify(rawValue)}. ` +
+        `Expected an absolute URL like http://localhost:3011`,
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `--local=${rawValue} points at non-loopback host "${parsed.hostname}". ` +
+        `--local only accepts localhost / 127.0.0.1 / ::1 URLs so that ` +
+        `stale API keys are never sent to a remote server. ` +
+        `Drop --local to check production, or use a loopback URL.`,
+    );
+  }
+  return rawValue;
 }
 
-const LOCAL_URL = parseLocalModeUrl(args);
-const LOCAL_MODE = LOCAL_URL !== null;
+/**
+ * Pure function describing the env mutations `crux health` should apply for
+ * a given argv + current env. Extracted so the side-effect block below is
+ * integration-testable. Callers apply `delete`/`set` to `process.env`
+ * themselves — this helper never touches globals.
+ */
+export interface HealthEnvOverrides {
+  setEnv: Record<string, string>;
+  unsetEnv: readonly string[];
+  localUrl: string | null;
+}
 
-// Default to production unless --local was passed (QUA-479). `crux health`
-// is semantically "is production healthy?", so it should work from any
-// directory (coord/, agent slots, worktrees) without requiring users to
-// remember `WIKI_SERVER_ENV=prod`. When --local is passed, pin the URL
-// explicitly instead of letting the current .env decide (QUA-491) — otherwise
-// `--local` is slot-ambiguous. Respect an explicit pre-set WIKI_SERVER_ENV
-// so callers who set it themselves keep their choice. Gated on
-// INVOKED_AS_SCRIPT so importing this module from tests does not mutate
+export function resolveHealthEnvOverrides(
+  argv: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+): HealthEnvOverrides {
+  const localUrl = parseLocalModeUrl(argv);
+  if (localUrl !== null) {
+    // `--local` wins over a pre-set WIKI_SERVER_ENV. Pinning the URL is the
+    // whole point of QUA-491: if we left WIKI_SERVER_ENV=prod in place,
+    // getServerUrl() would keep reading PROD_LONGTERMWIKI_SERVER_URL and the
+    // --local flag would be silently ignored.
+    return {
+      setEnv: { LONGTERMWIKI_SERVER_URL: localUrl },
+      unsetEnv: ['WIKI_SERVER_ENV'],
+      localUrl,
+    };
+  }
+  // Default to production, but respect an explicit pre-set WIKI_SERVER_ENV.
+  if (!env.WIKI_SERVER_ENV) {
+    return { setEnv: { WIKI_SERVER_ENV: 'prod' }, unsetEnv: [], localUrl: null };
+  }
+  return { setEnv: {}, unsetEnv: [], localUrl: null };
+}
+
+// `crux health` is semantically "is production healthy?", so it defaults to
+// WIKI_SERVER_ENV=prod and works from any directory (coord/, agent slots,
+// worktrees) without requiring users to remember the env var (QUA-479).
+// `--local[=URL]` pins a loopback URL explicitly instead of trusting the
+// current .env (QUA-491) — otherwise `--local` is slot-ambiguous. Gated on
+// INVOKED_AS_SCRIPT so importing this module from tests doesn't mutate
 // process.env and pollute other tests (sync-session.test.ts, client.test.ts
 // both care).
+let LOCAL_MODE = false;
 if (INVOKED_AS_SCRIPT) {
-  if (LOCAL_MODE) {
-    // Clear WIKI_SERVER_ENV so getServerUrl() reads the non-prod prefix.
-    delete process.env.WIKI_SERVER_ENV;
-    process.env.LONGTERMWIKI_SERVER_URL = LOCAL_URL!;
-  } else if (!process.env.WIKI_SERVER_ENV) {
-    process.env.WIKI_SERVER_ENV = 'prod';
+  let overrides: HealthEnvOverrides;
+  try {
+    overrides = resolveHealthEnvOverrides(args, process.env);
+  } catch (e) {
+    // `c` (getColors) is initialized below; use raw ANSI here to avoid a
+    // forward reference at module load time.
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`\x1b[31m✗ ${msg}\x1b[0m`);
+    process.exit(1);
   }
+  for (const key of overrides.unsetEnv) delete process.env[key];
+  for (const [key, value] of Object.entries(overrides.setEnv)) process.env[key] = value;
+  LOCAL_MODE = overrides.localUrl !== null;
 }
 
 // Resolve wiki-server URL/API key via the shared client helpers so


### PR DESCRIPTION
## Summary

Follow-up to #4374 (merged) addressing findings from the post-merge `/agent-review-pr` hostile-review pass on QUA-491.

Three fixes, one refactor:

1. **`--local=` with empty value** used to return `''` and set `LONGTERMWIKI_SERVER_URL=''`, which bubbled up as an opaque "URL not set" downstream. Now coerces to `DEFAULT_LOCAL_URL`.

2. **Non-loopback hosts rejected**. Before this change, `--local=https://example.com` was silently accepted — a stale `LONGTERMWIKI_SERVER_API_KEY` in a slot `.env` would be forwarded as a `Bearer` header to whatever URL the user typed. `parseLocalModeUrl()` now requires a loopback hostname (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) and throws with a usage-style error otherwise. Unparseable URLs also throw with a clean message.

3. **Side-effect block now integration-testable.** Extracted `resolveHealthEnvOverrides(argv, env)` as a pure helper; the module-top `INVOKED_AS_SCRIPT` block just applies the returned set/unset instructions. This lets us assert on the precedence matrix (including "`--local` wins over a pre-set `WIKI_SERVER_ENV=prod`") without process.env hacks.

Test file now covers: empty `--local=`, loopback hosts (`localhost` / `127.0.0.1` / `[::1]`), non-loopback rejection, unparseable URL rejection, duplicate-flag argv-order pinning, and the full env override matrix (9 new tests; 24 total in this file).

Related: QUA-491 (original fix in #4374, merged)

## Test plan

- [x] `pnpm vitest run crux/health/health-check.test.ts` — 24 pass (15 pre-existing + 9 new)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean for touched files
- [x] `pnpm crux health --local=https://example.com` — rejected with clear error, exit 1
- [x] `pnpm crux health --local --check=server` — resolves to `http://localhost:3002` (ECONNREFUSED as expected in a slot)
- [x] `pnpm crux health --check=server --json` — still hits prod by default

Fixes QUA-491
