### PR TITLE
review: second-pass hardening on MissingTokenError classifier (QUA-482 follow-up)

### DIFF
--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -6,10 +6,12 @@ import {
   MISSING_TOKEN_HELP_MESSAGE,
 } from './github.ts';
 
-// Use `vi.stubEnv()` instead of mutating `process.env` directly. stubEnv is
-// scoped per-test and reset by `vi.unstubAllEnvs()`, so parallel workers
-// reading GITHUB_TOKEN (e.g. enriched-scan.test.ts) don't race with this
-// file's mutations.
+// Use `vi.stubEnv()` instead of mutating `process.env` directly. This is
+// the vitest-blessed pattern for per-test env overrides and is auto-reverted
+// by `vi.unstubAllEnvs()` in afterEach. `crux/vitest.config.ts` currently
+// sets `fileParallelism: false` so there is no active cross-file race, but
+// stubEnv is still safer if that config ever flips — and it makes the
+// test's scope explicit without a hand-rolled save/restore in beforeEach.
 describe('getGitHubToken', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -84,18 +86,35 @@ describe('isMissingTokenError', () => {
     expect(isMissingTokenError(new MissingTokenError())).toBe(true);
   });
 
-  it('accepts serialized errors with matching .name (cross-realm / JSON roundtrip)', () => {
-    // A real scenario: a subprocess throws MissingTokenError, the parent
+  it('accepts serialized errors with matching .name AND string .message', () => {
+    // Real scenario: a subprocess throws MissingTokenError, the parent
     // captures stderr, reconstructs the error as a plain object, and hands
     // it to the classifier. `instanceof` fails across the boundary — only
-    // `.name` survives. The classifier must still recognize it.
+    // `.name` and `.message` survive. The classifier must still recognize it.
     const serialized = { name: 'MissingTokenError', message: 'anything' };
     expect(isMissingTokenError(serialized)).toBe(true);
 
+    // Real JSON roundtrip — the form `JSON.stringify(new MissingTokenError())`
+    // produces once the error is passed through structured clone or rebuilt
+    // from `Error.toJSON()` output.
     const roundTripped = JSON.parse(
       JSON.stringify({ name: 'MissingTokenError', message: 'x' }),
     );
     expect(isMissingTokenError(roundTripped)).toBe(true);
+  });
+
+  it('rejects bare {name} objects without a string message (duck-typing guard)', () => {
+    // Security: the serialized-error branch must not accept arbitrary
+    // attacker-crafted JSON blobs that happen to set `name`. Real serialized
+    // errors always carry a `.message` — require it to narrow the false-
+    // positive surface.
+    expect(isMissingTokenError({ name: 'MissingTokenError' })).toBe(false);
+    expect(
+      isMissingTokenError({ name: 'MissingTokenError', message: 123 }),
+    ).toBe(false);
+    expect(
+      isMissingTokenError({ name: 'MissingTokenError', message: null }),
+    ).toBe(false);
   });
 
   it('rejects plain Error instances, even with matching message content', () => {

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -52,26 +52,36 @@ export class MissingTokenError extends Error {
  * the error signal can evolve without silently breaking classifiers.
  *
  * Also matches serialized errors where only `.name === 'MissingTokenError'`
- * survives the boundary (JSON logs, subprocess stderr → parent catch). The
- * `instanceof` check catches the happy path; the `.name` check catches
- * cross-realm / serialized cases.
+ * survives the boundary (JSON logs, subprocess stderr → parent catch). To
+ * reduce the duck-typing attack surface, the serialized branch additionally
+ * requires a string `.message` field — a bare `{ name: 'MissingTokenError' }`
+ * object is rejected. Real `Error.toJSON()` / structured-clone output always
+ * includes a message, so this narrows away arbitrary attacker-crafted
+ * objects without rejecting any legitimate serialized error.
+ *
+ * NOTE: If you ever subclass `MissingTokenError` and set a different `.name`
+ * on the subclass, `instanceof` still matches (correct), but serialized
+ * subclass instances will NOT be classified here. Update this guard if that
+ * case becomes real.
  */
 export function isMissingTokenError(err: unknown): err is MissingTokenError {
   if (err instanceof MissingTokenError) return true;
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    (err as { name?: unknown }).name === 'MissingTokenError'
-  );
+  if (typeof err !== 'object' || err === null) return false;
+  const obj = err as { name?: unknown; message?: unknown };
+  return obj.name === 'MissingTokenError' && typeof obj.message === 'string';
 }
 
 /**
- * Get the GitHub token from the environment or throw a `MissingTokenError`.
+ * Return the whitespace-stripped `GITHUB_TOKEN` env var, or throw a
+ * `MissingTokenError` when it is absent, empty, or whitespace-only.
  *
- * Whitespace-only values (e.g. `'   '`) are treated as missing. Without the
- * trim, a stray-whitespace env var would pass the truthy check and be sent
- * verbatim to the GitHub API, causing a transient-looking 401 instead of the
- * immediate permanent-fault classification that `MissingTokenError` signals.
+ * The return value is always `.trim()`-ed. Callers that need the raw env
+ * var (verbatim passthrough) should read `process.env.GITHUB_TOKEN`
+ * directly. Without the trim, a stray-whitespace value (e.g. from
+ * `GITHUB_TOKEN=$(cat token.txt)` where the file has a trailing newline)
+ * would pass the truthy check and be sent verbatim to the GitHub API,
+ * causing a transient-looking 401 instead of the immediate permanent-fault
+ * classification that `MissingTokenError` signals.
  */
 export function getGitHubToken(): string {
   const token = process.env.GITHUB_TOKEN?.trim();


### PR DESCRIPTION
## Summary

Follow-up to #4372 (merged) addressing findings from a second `/agent-review-pr` hostile-review pass on the post-hardening state. Three LOW findings, all worth landing now to cement the classifier's semantics while the context is fresh.

### Fixes

1. **Tighten duck-typing guard in `isMissingTokenError()`**. The serialized-error branch previously accepted any object with `.name === 'MissingTokenError'`. Now also requires `typeof .message === 'string'`. Real serialized errors (`Error.toJSON`, structured clone) always carry a message, so this narrows the attacker-crafted-object surface without rejecting any legitimate path. Added regression test for bare-`{name}` / wrong-type-message rejection.

2. **Correct the `vi.stubEnv()` rationale comment** in `github.test.ts`. The original comment claimed parallel-worker races, but `crux/vitest.config.ts` sets `fileParallelism: false` so no such race exists today. Updated the comment to note `stubEnv` remains the vitest-blessed pattern and is safer if that config ever flips.

3. **Fix docstring drift on `getGitHubToken()`**. Docstring now explicitly states the return value is whitespace-stripped, so callers that need the raw env var won't be surprised by silent trimming.

### Red-team results

Ran `isMissingTokenError` against 15 adversarial inputs:

```
reject: null / undefined / empty object / string "MissingTokenError"
reject: { name: "MissingTokenError" }                    (no message)
reject: { name: "MissingTokenError", message: 42|null }  (wrong type)
reject: plain Error echoing "GITHUB_TOKEN not set"
accept: real MissingTokenError / valid serialized form /
        null-proto / frozen / array-with-properties
```

Two edge cases accept (empty-string message, array with injected properties) but aren't exploitable — an attacker with execution context can already `throw new MissingTokenError()` directly.

Fixes QUA-482 (follow-up only — original closed by #4372)

## Test plan

- [x] `pnpm vitest run crux/lib/github.test.ts` — 14 pass (was 13, +1 duck-typing rejection test)
- [x] `pnpm vitest run crux/pr-patrol/` — 373 pass (no regressions)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean for touched files
- [x] `pnpm crux w validate gate --scope=code` — 45/45 blocking gate checks pass
- [x] Red-team sweep on `isMissingTokenError` with 15 adversarial inputs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened token error validation to reject malformed error objects.

* **Tests**
  * Enhanced test coverage for error classification edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->