### PR TITLE
fix(data-quality): loosen legacy_alnum10 regex to match any 10-char alnum

### DIFF
--- a/apps/wiki-server/src/__tests__/data-quality-id-format.test.ts
+++ b/apps/wiki-server/src/__tests__/data-quality-id-format.test.ts
@@ -151,6 +151,31 @@ describe("captureIdFormatAudit", () => {
     expect(result.totals.other).toBe(0);
   });
 
+  it("legacy_alnum10 regex matches naked 10-char alnums (QUA-499)", async () => {
+    const { ID_FORMAT_REGEXES } = await import(
+      "../routes/operational/data-quality.js"
+    );
+    const re = new RegExp(ID_FORMAT_REGEXES.legacy_alnum10);
+    // The canonical example from the ticket — has upper + lower, no digit.
+    expect(re.test("gNRivVEYsw")).toBe(true);
+    // Mixed-case with digit still matches.
+    expect(re.test("aB3cD4eF5g")).toBe(true);
+    // All-lowercase alnum.
+    expect(re.test("abcdefghij")).toBe(true);
+    // Prefixed canonical forms must NOT match (length > 10).
+    expect(re.test("f_gNRivVEYsw")).toBe(false);
+    expect(re.test("sid_gNRivVEY")).toBe(false);
+    // Pure hex8 (8 chars) — wrong length.
+    expect(re.test("abc12345")).toBe(false);
+    // Pure hex16 (16 chars) — wrong length.
+    expect(re.test("abcdef0123456789")).toBe(false);
+    // Non-alnum rejected.
+    expect(re.test("gNRivVEY-w")).toBe(false);
+    // 9 or 11 chars rejected.
+    expect(re.test("gNRivVEYs")).toBe(false);
+    expect(re.test("gNRivVEYsww")).toBe(false);
+  });
+
   it("negative-safe: named sum > total still produces non-negative other", async () => {
     // Degenerate case — shouldn't happen in prod but we clamp with Math.max(0, ...)
     const result = await runCapture({

--- a/apps/wiki-server/src/routes/operational/data-quality.ts
+++ b/apps/wiki-server/src/routes/operational/data-quality.ts
@@ -55,12 +55,16 @@ import {
 //   - facts.fact_id                        → bucket for fact IDs
 //   - resources.id (primary key)           → bucket for resource IDs
 
-const ID_FORMAT_REGEXES = {
+export const ID_FORMAT_REGEXES = {
   canonical_f: "^f_[A-Za-z0-9]{8,}$",
   canonical_sid: "^sid_[A-Za-z0-9]{10}$",
   legacy_hex8: "^[0-9a-f]{8}$",
-  legacy_alnum10:
-    "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[A-Za-z0-9]{10}$",
+  // Any naked 10-char alphanumeric. Canonical forms (`f_<10>` is 12 chars,
+  // `sid_<10>` is 14 chars) and hex8/hex16 (8 / 16 chars) cannot match this
+  // length, so there's no overlap. An earlier version required
+  // upper+lower+digit, which silently undercounted ~776 prod fact IDs that
+  // happened to have no digit (e.g. `gNRivVEYsw`). See QUA-499.
+  legacy_alnum10: "^[A-Za-z0-9]{10}$",
   legacy_hex16: "^[0-9a-f]{16}$",
 } as const;
 


### PR DESCRIPTION
## Summary

The `legacy_alnum10` regex in `apps/wiki-server/src/routes/operational/data-quality.ts` required upper + lower + digit, which silently bucketed ~776 naked fact IDs (e.g. `gNRivVEYsw`) into `other` and made the `/internal/data-quality` dashboard report "clean" while `facts.fact_id` was only ~65% canonical — worse than no audit. Replaced with `^[A-Za-z0-9]{10}$`. Canonical forms (`f_<10>` = 12 chars, `sid_<10>` = 14 chars) and hex8/hex16 have different lengths, so no overlap.

## Key changes

- **`apps/wiki-server/src/routes/operational/data-quality.ts`** — regex loosened to `^[A-Za-z0-9]{10}$`; `ID_FORMAT_REGEXES` now exported so the regex can be unit-tested directly.
- **`apps/wiki-server/src/__tests__/data-quality-id-format.test.ts`** — new unit test covering the canonical ticket example (`gNRivVEYsw`), mixed-case + digit, all-lowercase, prefixed canonical forms (must NOT match), hex8/hex16 wrong-length rejection, non-alnum rejection, and 9/11-char rejection.

## Acceptance criteria (from QUA-499)

- [x] Regex updated to `^[A-Za-z0-9]{10}$`.
- [x] Snapshot test asserts the regex matches `gNRivVEYsw` and does NOT match `f_gNRivVEYsw`, `sid_gNRivVEYsw`, or pure hex strings like `abc12345`.
- [ ] Post-merge: dashboard count for `facts.legacy_alnum10` increases from ~0 to ~776 against current prod (the 776 move from `other` → `legacy_alnum10`, not disappear).

## Test plan

- [x] `pnpm build` — PASS
- [x] `pnpm test` — PASS (6561 passed / 26 pre-existing skips)
- [x] `pnpm crux w validate gate --fix` — PASS (53/53 checks)
- [x] Targeted unit test `data-quality-id-format.test.ts` — PASS (6 tests)
- [ ] Post-merge: verify `/internal/data-quality` dashboard shows ~776 fact IDs in `legacy_alnum10` bucket and a corresponding drop in `other`.

Fixes QUA-499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Relaxed validation rules for legacy alphanumeric identifiers. They now accept any 10-character alphanumeric string, removing previous requirements for mixed case and digit inclusion.

* **Tests**
  * Added test coverage for alphanumeric identifier format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->