### PR TITLE
fix(linear): trim whitespace in no-auto-close label match (QUA-505 follow-up)

### DIFF
--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -366,15 +366,47 @@ describe('classifyEntry — no-auto-close label', () => {
     expect(e.reason).toContain('#5');
   });
 
-  it('case-insensitive label match (No-Auto-Close, NO-AUTO-CLOSE)', () => {
-    for (const labelName of ['No-Auto-Close', 'NO-AUTO-CLOSE', 'no-auto-close']) {
+  it('label match is case-insensitive and whitespace-tolerant', () => {
+    // Real risk: Linear's label UI allows trailing spaces on paste, and some
+    // users type variants like "No-Auto-Close". Red-team execution confirmed
+    // the bare-string check missed these. The normalizer is .trim().toLowerCase().
+    const variants = [
+      'no-auto-close',
+      'No-Auto-Close',
+      'NO-AUTO-CLOSE',
+      'no-auto-close ',
+      ' no-auto-close',
+      '  NO-AUTO-CLOSE  ',
+      'no-auto-close\n',
+    ];
+    for (const labelName of variants) {
       const issue = makeIssue({ labels: { nodes: [{ name: labelName }] } });
       const items = [
         makePr({ number: 1, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
       ];
       const e = classifyEntry(issue, items, makeChildrenResult([]));
-      expect(e.bucket, `label="${labelName}"`).toBe('active');
+      expect(e.bucket, `label=${JSON.stringify(labelName)}`).toBe('active');
       expect(e.reason).toContain('no-auto-close');
+    }
+  });
+
+  it('label match does NOT accept unrelated strings or unicode lookalikes', () => {
+    // Guard against overly-lenient matching: a unicode-hyphen variant is a
+    // different codepoint and should NOT match.
+    const imposters = [
+      'auto-close',           // missing "no-"
+      'no_auto_close',        // underscores
+      'noautoclose',          // no separators
+      'No‑Auto‑Close',        // unicode hyphen U+2011
+      '',
+    ];
+    for (const labelName of imposters) {
+      const issue = makeIssue({ labels: { nodes: [{ name: labelName }] } });
+      const items = [
+        makePr({ number: 1, state: 'closed', mergedAt: '2026-04-10T00:00:00Z' }),
+      ];
+      const e = classifyEntry(issue, items, makeChildrenResult([]));
+      expect(e.bucket, `label=${JSON.stringify(labelName)}`).toBe('shipped');
     }
   });
 });

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -54,17 +54,10 @@ const RESOLVED_STATE_TYPES = new Set(['completed', 'canceled']);
 
 /**
  * Label that opts an issue out of `audit --fix` auto-closure regardless of PR
- * state or sub-issue state. Escape hatch for long-running tickets that don't
- * fit the parent-with-open-children pattern but still shouldn't auto-close
- * (e.g. tracking tickets that intentionally outlive their initial PR).
+ * or sub-issue state. Escape hatch for long-running tickets that don't fit the
+ * parent-with-open-children pattern but still shouldn't auto-close.
  */
 export const NO_AUTO_CLOSE_LABEL = 'no-auto-close';
-
-function hasNoAutoCloseLabel(issue: LinearTriageIssue): boolean {
-  return issue.labels.nodes.some(
-    (l) => l.name.toLowerCase() === NO_AUTO_CLOSE_LABEL,
-  );
-}
 
 /**
  * GitHub auto-close keywords. Mirrors GitHub's documented set verbatim:
@@ -233,7 +226,9 @@ export function classifyEntry(
   let bucket: AuditBucket;
   let reason: string;
 
-  const noAutoClose = hasNoAutoCloseLabel(issue);
+  const noAutoClose = issue.labels.nodes.some(
+    (l) => l.name.trim().toLowerCase() === NO_AUTO_CLOSE_LABEL,
+  );
 
   if (openPRs.length > 0) {
     bucket = 'active';


### PR DESCRIPTION
## Summary

Follow-up to #4383. Rigorous red-team execution of `classifyEntry()` against adversarial label names found that the case-insensitive match from #4383 silently failed on whitespace variants:

- `"no-auto-close "` (trailing space)
- `" no-auto-close"` (leading space)
- `"  NO-AUTO-CLOSE  "` (both + uppercase)
- `"no-auto-close
"` (trailing newline)

Linear's label UI allows paste-in whitespace and users routinely type labels with accidental trailing spaces. Without this fix, a user who set the opt-out label with any whitespace contamination would get zero protection — `audit --fix` would still auto-close their issue.

## Fix

Normalize via `.trim().toLowerCase()` instead of `.toLowerCase()` alone. The match remains strict enough to reject unicode lookalikes (`No‑Auto‑Close` with U+2011), underscores (`no_auto_close`), and missing prefixes (`auto-close`).

Also inlined the single-call-site `hasNoAutoCloseLabel` helper (simplification pass).

## Test plan

- [x] 35/35 audit unit tests pass (replaced the case-only test with 7-variant trim+case matrix; added imposter test for unrelated strings and unicode lookalikes)
- [x] `pnpm crux w validate gate --no-cache` clean (49/49, 3 pre-existing advisories)
- [x] `/tmp/redteam-classify.mts` — 12 adversarial input categories, 24/24 assertions pass
- [x] `pnpm build` clean
- [x] Live-verified against Linear: `pnpm crux linear audit --json` correctly classifies QUA-408, QUA-154, QUA-442 as `active` with parent-epic reasons; `--fix` would auto-close 0 issues in the current backlog

## End-to-end verification against live Linear state

| Issue | Bucket | Reason |
|---|---|---|
| QUA-408 | active | parent epic — 4 open children; latest PR #4301 merged 1d ago but more phases in flight |
| QUA-154 | active | parent epic — 8 open children tracking remaining work |
| QUA-442 | active | parent epic — 1 open child tracking remaining work |

**0 issues would be auto-closed by `--fix`** in the current backlog. Before #4383, all three parent epics would have been misclassified as `shipped`.

## How this was found

This follow-up exists because #4383's review was shortcut — I ran the hostile reviewer subagent but skipped Phase 6b red-team *execution* (per `.claude/rules/implementation-quality.md`, red-team should "actually try" adversarial inputs, not just threat-model them). When the user pushed back and required rigorous testing, I wrote `/tmp/redteam-classify.mts` to probe 12 adversarial input categories against `classifyEntry`, and the whitespace case immediately failed.

Related: QUA-515 tracks the broader "agents skip `.claude/wip-checklist.md` enforcement" pattern that caused this session's review shortcut in the first place.

Fixes QUA-505
