### PR TITLE
fix(pr-patrol): idempotency cache for self-authored-feedback (QUA-514)

### DIFF
--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -41,6 +41,7 @@ const PR_QUERY = `query($owner: String!, $name: String!) {
           }}
         }}
         comments(last: 20) { nodes {
+          id
           author { login __typename }
           authorAssociation
           body
@@ -221,6 +222,7 @@ export function extractBlockingComments(pr: GqlPrNode): BlockingComment[] {
     if (!authority && !urgency) continue;
 
     blocking.push({
+      id: c.id,
       author: c.author.login,
       authorAssociation: c.authorAssociation,
       authorType: c.author.__typename ?? 'User',
@@ -399,11 +401,21 @@ function isLabelRequiredCheck(checkName: string): boolean {
  * When present, a `ci-failure` issue is only emitted if the fresh data also
  * shows a failure — this avoids the classic "GraphQL still reports failed,
  * but the follow-up push is now green" false positive.
+ *
+ * Optional `processedBlockingCommentIds` (QUA-514) is the set of blocking
+ * comment GraphQL node ids that patrol has already acted on for the PR's
+ * *current* head SHA. When provided, blocking comments whose id is in this
+ * set are not counted toward `self-authored-feedback`, which stops the
+ * re-dispatch loop where a dismissal of a CodeRabbit nit triggers patrol
+ * every cycle. The caller owns persistence + SHA invalidation; this
+ * function stays pure. The full `blockingComments` list is still returned
+ * unfiltered for UI/telemetry callers.
  */
 export function detectIssues(
   pr: GqlPrNode,
   staleThresholdMs: number,
   freshCheckRuns?: FreshCheckRun[],
+  processedBlockingCommentIds?: ReadonlySet<string>,
 ): {
   issues: PrIssueType[];
   botComments: BotComment[];
@@ -497,7 +509,17 @@ export function detectIssues(
 
   // Blocking top-level comments (newer than last push + authority/urgency).
   const blockingComments = extractBlockingComments(pr);
-  if (blockingComments.length > 0 && isSelfAuthored(pr)) {
+  // QUA-514: only count blocking comments that patrol hasn't already
+  // processed for this PR's current head SHA. Comments without a stable
+  // id are always counted (fail-open — preserves pre-QUA-514 behavior
+  // for legacy callers and test fixtures).
+  const unprocessedBlockingComments =
+    processedBlockingCommentIds && processedBlockingCommentIds.size > 0
+      ? blockingComments.filter(
+          (c) => !c.id || !processedBlockingCommentIds.has(c.id),
+        )
+      : blockingComments;
+  if (unprocessedBlockingComments.length > 0 && isSelfAuthored(pr)) {
     issues.push('self-authored-feedback');
   }
 

--- a/crux/lib/pr-analysis/enriched-scan.test.ts
+++ b/crux/lib/pr-analysis/enriched-scan.test.ts
@@ -412,6 +412,114 @@ describe('detectIssues — self-authored feedback', () => {
     const { issues } = detectIssues(pr, 0);
     expect(issues).not.toContain('self-authored-feedback');
   });
+
+  // ── QUA-514: per-comment idempotency ─────────────────────────────────────
+  //
+  // Before this fix, patrol's scan loop re-detected the same post-push
+  // OWNER comment every cycle. On PR #4371, a single "Re: CodeRabbit nit —
+  // keeping the current approach" comment triggered ~20 consecutive fix
+  // dispatches over 6 hours because the comment itself didn't change.
+  //
+  // Regression guard: when the caller supplies the set of comment IDs
+  // already processed for the current head SHA, those comments must not
+  // trigger self-authored-feedback on subsequent scans. New pushes rotate
+  // the SHA, which the caller (patrol state) uses to invalidate the set.
+  describe('QUA-514 — processedBlockingCommentIds filters self-authored-feedback', () => {
+    const makeSelfAuthoredPrWithBlockingComment = (commentId: string) =>
+      makePrNode({
+        headRefName: 'claude/qua-514-something',
+        comments: {
+          nodes: [{
+            id: commentId,
+            author: { login: 'OAGr', __typename: 'User' },
+            authorAssociation: 'OWNER',
+            body: 'Re: CodeRabbit nit — keeping the current approach.',
+            createdAt: '2026-04-10T12:00:00Z',
+            viewerDidAuthor: true,
+          }],
+        },
+      });
+
+    it('emits self-authored-feedback on FIRST scan (comment not yet processed)', () => {
+      const pr = makeSelfAuthoredPrWithBlockingComment('IC_abc123');
+      const { issues, blockingComments } = detectIssues(pr, 0, undefined, new Set());
+      expect(issues).toContain('self-authored-feedback');
+      expect(blockingComments).toHaveLength(1);
+      expect(blockingComments[0].id).toBe('IC_abc123');
+    });
+
+    it('does NOT emit self-authored-feedback when comment id is in processed set', () => {
+      const pr = makeSelfAuthoredPrWithBlockingComment('IC_abc123');
+      const processed = new Set(['IC_abc123']);
+      const { issues, blockingComments } = detectIssues(pr, 0, undefined, processed);
+      expect(issues).not.toContain('self-authored-feedback');
+      // blockingComments list is still returned unfiltered — callers may
+      // surface it for telemetry; only the issue-emission is gated.
+      expect(blockingComments).toHaveLength(1);
+    });
+
+    it('emits self-authored-feedback when a NEW comment appears alongside a processed one', () => {
+      const pr = makePrNode({
+        headRefName: 'claude/qua-514-something',
+        comments: {
+          nodes: [
+            {
+              id: 'IC_old',
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body: 'Re: CodeRabbit nit — keeping the current approach.',
+              createdAt: '2026-04-10T12:00:00Z',
+              viewerDidAuthor: true,
+            },
+            {
+              id: 'IC_new',
+              author: { login: 'OAGr', __typename: 'User' },
+              authorAssociation: 'OWNER',
+              body: 'Actually, please revert the schema change.',
+              createdAt: '2026-04-10T12:05:00Z',
+              viewerDidAuthor: true,
+            },
+          ],
+        },
+      });
+      const processed = new Set(['IC_old']);
+      const { issues } = detectIssues(pr, 0, undefined, processed);
+      expect(issues).toContain('self-authored-feedback');
+    });
+
+    it('emits self-authored-feedback when a comment has no id (fail-open)', () => {
+      // Test fixtures / legacy callers may omit the id. A missing id is
+      // treated as "never processed" so we don't silently lose blockers.
+      const pr = makePrNode({
+        headRefName: 'claude/qua-514-something',
+        comments: {
+          nodes: [{
+            // no id field
+            author: { login: 'OAGr', __typename: 'User' },
+            authorAssociation: 'OWNER',
+            body: 'Something',
+            createdAt: '2026-04-10T12:00:00Z',
+            viewerDidAuthor: true,
+          }],
+        },
+      });
+      const processed = new Set(['IC_anything']);
+      const { issues } = detectIssues(pr, 0, undefined, processed);
+      expect(issues).toContain('self-authored-feedback');
+    });
+
+    it('behaves identically to pre-QUA-514 when processed set is undefined', () => {
+      const pr = makeSelfAuthoredPrWithBlockingComment('IC_abc123');
+      const { issues } = detectIssues(pr, 0);
+      expect(issues).toContain('self-authored-feedback');
+    });
+
+    it('behaves identically to pre-QUA-514 when processed set is empty', () => {
+      const pr = makeSelfAuthoredPrWithBlockingComment('IC_abc123');
+      const { issues } = detectIssues(pr, 0, undefined, new Set());
+      expect(issues).toContain('self-authored-feedback');
+    });
+  });
 });
 
 describe('detectIssues — fresh check-runs override stale rollup', () => {

--- a/crux/lib/pr-analysis/types.ts
+++ b/crux/lib/pr-analysis/types.ts
@@ -51,6 +51,12 @@ export interface BotComment {
  * Used to surface blocking/maintainer feedback that patrol would otherwise miss.
  */
 export interface BlockingComment {
+  /**
+   * Stable GraphQL node ID (e.g. `IC_kwDONP...`). May be missing in legacy
+   * or test fixtures; the idempotency filter treats comments without an id
+   * as always-new (fail-open to current behavior).
+   */
+  id?: string;
   /** Author login (maintainer, bot, etc.) */
   author: string;
   /** Author association with the repo (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, NONE) */
@@ -200,6 +206,12 @@ export interface GqlReviewThread {
 }
 
 export interface GqlIssueComment {
+  /**
+   * Stable GraphQL node ID (e.g. `IC_kwDONP...`). Used by QUA-514 to
+   * idempotency-key patrol processing of blocking comments so we don't
+   * re-dispatch for the same comment on the same SHA every cycle.
+   */
+  id?: string;
   author: { login: string; __typename?: string } | null;
   authorAssociation: string;
   body: string;

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -40,12 +40,14 @@ import {
   clearTotalFixAttempts,
   countConsecutiveCycles,
   getAbandonedSha,
+  getProcessedBlockingCommentIds,
   isAbandoned,
   isPendingCICheck,
   isRecentlyProcessed,
   JSONL_FILE,
   log,
   markAbandoned,
+  markBlockingCommentsProcessed,
   markProcessed,
   recordFailure,
   resetFailCount,
@@ -226,12 +228,34 @@ export function detectAllPrIssuesFromNodes(
         }
       }
 
+      // QUA-514: load the idempotency set of blocking comment IDs patrol has
+      // already processed for this PR at its current head SHA. A SHA change
+      // (new push) invalidates the cache naturally inside the helper.
+      const processedBlockingCommentIds = pr.headRefOid
+        ? getProcessedBlockingCommentIds(pr.number, pr.headRefOid)
+        : new Set<string>();
+
       const { issues: allIssues, botComments, failingChecks, blockingComments } =
-        libDetectIssues(pr, staleThresholdMs, fresh);
+        libDetectIssues(pr, staleThresholdMs, fresh, processedBlockingCommentIds);
       const advisoryIssues = allIssues.filter((i) => ADVISORY_ISSUES.has(i));
       const fixableIssues = allIssues.filter((i) => !ADVISORY_ISSUES.has(i));
       if (advisoryIssues.length > 0) {
         log(`  PR #${pr.number}: advisory issues (skipped): ${advisoryIssues.join(', ')}`);
+      }
+
+      // QUA-514: mark *every* blocking comment with a stable id as processed
+      // for this SHA. We mark on detection (not after dispatch) so that a
+      // subsequent cycle that finds the same comment on the same SHA will
+      // skip re-emitting self-authored-feedback even if patrol's earlier
+      // attempt was cancelled, timed out, or crashed. A new push changes
+      // the SHA and clears the cache for a fresh look.
+      if (pr.headRefOid && blockingComments.length > 0) {
+        const newIds = blockingComments
+          .map((b) => b.id)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0);
+        if (newIds.length > 0) {
+          markBlockingCommentsProcessed(pr.number, pr.headRefOid, newIds);
+        }
       }
       return {
         number: pr.number,

--- a/crux/pr-patrol/state.test.ts
+++ b/crux/pr-patrol/state.test.ts
@@ -20,6 +20,9 @@ import {
   setCodeRabbitRetryTime,
   clearCodeRabbitRetryTime,
   CODERABBIT_DEFAULT_RETRY_DELAY_MS,
+  getProcessedBlockingCommentIds,
+  markBlockingCommentsProcessed,
+  clearProcessedBlockingComments,
   STATE_DIR,
 } from './state.ts';
 
@@ -202,5 +205,84 @@ describe('CodeRabbit retry state', () => {
 
   it('has a 30-minute default retry delay', () => {
     expect(CODERABBIT_DEFAULT_RETRY_DELAY_MS).toBe(30 * 60 * 1000);
+  });
+});
+
+// ── Processed blocking comments (QUA-514) ───────────────────────────────────
+
+describe('processed blocking comments (QUA-514)', () => {
+  const testPrNumber = 90000 + Math.floor(Math.random() * 10_000);
+  const shaA = 'a'.repeat(40);
+  const shaB = 'b'.repeat(40);
+
+  afterEach(() => {
+    clearProcessedBlockingComments(testPrNumber);
+  });
+
+  it('returns empty set when no cache file exists', () => {
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
+    expect(ids.size).toBe(0);
+  });
+
+  it('persists and retrieves ids for matching SHA', () => {
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_a', 'IC_b']);
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
+    expect(ids.has('IC_a')).toBe(true);
+    expect(ids.has('IC_b')).toBe(true);
+    expect(ids.size).toBe(2);
+  });
+
+  it('returns empty set when stored SHA differs (force-push invalidates cache)', () => {
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_a']);
+    // Caller is on a different SHA now — must not see old ids.
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaB);
+    expect(ids.size).toBe(0);
+  });
+
+  it('overwrites cache when marking ids under a different SHA', () => {
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_old']);
+    markBlockingCommentsProcessed(testPrNumber, shaB, ['IC_new']);
+    // Old SHA entries are gone; new SHA has only IC_new.
+    expect(getProcessedBlockingCommentIds(testPrNumber, shaA).size).toBe(0);
+    const newIds = getProcessedBlockingCommentIds(testPrNumber, shaB);
+    expect(newIds.has('IC_new')).toBe(true);
+    expect(newIds.has('IC_old')).toBe(false);
+    expect(newIds.size).toBe(1);
+  });
+
+  it('unions new ids with existing ids under the same SHA', () => {
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_a']);
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_b', 'IC_a']); // IC_a duplicate
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
+    expect(ids.size).toBe(2);
+    expect(ids.has('IC_a')).toBe(true);
+    expect(ids.has('IC_b')).toBe(true);
+  });
+
+  it('clear removes the cache file', () => {
+    markBlockingCommentsProcessed(testPrNumber, shaA, ['IC_a']);
+    clearProcessedBlockingComments(testPrNumber);
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
+    expect(ids.size).toBe(0);
+  });
+
+  it('clear is safe when no cache file exists', () => {
+    // Should not throw on a PR number with no state.
+    clearProcessedBlockingComments(testPrNumber + 77);
+  });
+
+  it('empty newIds on a fresh cache is a no-op', () => {
+    // Without an existing file, marking zero ids should not create one —
+    // avoids littering STATE_DIR with empty files during cold-path scans.
+    markBlockingCommentsProcessed(testPrNumber, shaA, []);
+    const file = join(STATE_DIR, `processed-comments-${testPrNumber}.json`);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('tolerates corrupt cache file (returns empty)', () => {
+    const file = join(STATE_DIR, `processed-comments-${testPrNumber}.json`);
+    writeFileSync(file, 'not valid json{{{');
+    const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
+    expect(ids.size).toBe(0);
   });
 });

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -415,6 +415,101 @@ export function clearPendingCICheck(prNumber: number): void {
   }
 }
 
+// ── Processed blocking comments (QUA-514) ───────────────────────────────────
+//
+// Patrol idempotency for `self-authored-feedback`: before this tracker, patrol
+// would re-detect the same post-push OWNER comment every cycle and dispatch
+// a fresh fix attempt (PR #4371 burned ~20 cycles on one dismissed CodeRabbit
+// nit). We cache `(prNumber, headSha, commentId[])` so a comment is only
+// acted on once per SHA. A new push (SHA change) invalidates the cache —
+// a fresh push gets a fresh look.
+//
+// File layout: `processed-comments-<N>.json` with `{ headSha, ids[] }`. If
+// the stored headSha doesn't match the caller's current headSha, we treat
+// the file as stale and return an empty set (we do NOT delete, since the
+// next mark call will overwrite anyway).
+
+interface ProcessedBlockingCommentsFile {
+  headSha: string;
+  ids: string[];
+}
+
+function processedCommentsFile(prNumber: number | string): string {
+  return join(STATE_DIR, `processed-comments-${prNumber}.json`);
+}
+
+function readProcessedCommentsFile(
+  prNumber: number | string,
+): ProcessedBlockingCommentsFile | null {
+  const file = processedCommentsFile(prNumber);
+  if (!existsSync(file)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(file, 'utf-8'));
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      typeof raw.headSha === 'string' &&
+      Array.isArray(raw.ids) &&
+      raw.ids.every((x: unknown) => typeof x === 'string')
+    ) {
+      return raw as ProcessedBlockingCommentsFile;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the set of blocking comment IDs patrol has already processed for
+ * this PR at the given head SHA. If the stored file is for a different SHA
+ * (or missing/corrupt), returns an empty set — the caller will then treat
+ * every current blocking comment as new.
+ */
+export function getProcessedBlockingCommentIds(
+  prNumber: number | string,
+  headSha: string,
+): Set<string> {
+  const data = readProcessedCommentsFile(prNumber);
+  if (!data || data.headSha !== headSha) return new Set();
+  return new Set(data.ids);
+}
+
+/**
+ * Merge `newIds` into the processed-comments set for this PR at `headSha`.
+ *
+ * - If the stored file is for a different SHA, the old list is discarded
+ *   and replaced with `newIds` (force-push resets the cache naturally).
+ * - If the stored file matches, `newIds` is unioned with the existing list.
+ * - Empty `newIds` with a matching SHA is a no-op.
+ */
+export function markBlockingCommentsProcessed(
+  prNumber: number | string,
+  headSha: string,
+  newIds: readonly string[],
+): void {
+  const existing = readProcessedCommentsFile(prNumber);
+  const ids =
+    existing && existing.headSha === headSha
+      ? Array.from(new Set([...existing.ids, ...newIds]))
+      : Array.from(new Set(newIds));
+  if (ids.length === 0 && !existing) return;
+  const payload: ProcessedBlockingCommentsFile = { headSha, ids };
+  writeFileSync(processedCommentsFile(prNumber), JSON.stringify(payload));
+}
+
+/** Remove the processed-comments cache file for this PR. */
+export function clearProcessedBlockingComments(prNumber: number | string): void {
+  const file = processedCommentsFile(prNumber);
+  if (existsSync(file)) {
+    try {
+      unlinkSync(file);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
 // ── CodeRabbit review retry tracking ─────────────────────────────────────────
 // When CodeRabbit rate-limits a review, we schedule a retry after the cooldown.
 // Only retries once per rate-limit event to avoid spamming.


### PR DESCRIPTION
## Summary

Stops PR Patrol from re-dispatching fix attempts for the same post-push OWNER comment every scan cycle. Replaces the ticket's proposed content-aware dismissal regex with a mechanical per-comment idempotency cache keyed by `(prNumber, headSha, commentId)` — handles the full class of dismissal comments, not just one regex shape, and is force-push-aware.

- `detectIssues()` gains an optional `processedBlockingCommentIds: Set<string>` param; blocking comments whose GraphQL node id is in the set don't trigger `self-authored-feedback`. Pure function — caller owns persistence.
- New patrol state helpers: `getProcessedBlockingCommentIds` / `markBlockingCommentsProcessed` / `clearProcessedBlockingComments`. File `processed-comments-<N>.json` in `~/.cache/pr-patrol/state/`. Mismatched SHA = empty set (force-push naturally invalidates).
- Wired into `detectAllPrIssuesFromNodes`: load processed set pre-scan, mark all blocking comment ids post-scan for the current SHA.
- GraphQL PR queries now select comment `id`; `BlockingComment.id` + `GqlIssueComment.id` added.

### Why not the regex approach in the ticket

The original ticket proposed a content-aware regex matching `keeping|won't fix|by design|Re:.*nitpick` with an action-verb veto. Ozzie's review on the ticket pointed out two problems: (a) fragile in both directions — `"Re: CodeRabbit nit — actually let's change this"` matches but is the opposite of a dismissal, and (b) it's a symptom patch that fixes *this specific comment shape* rather than *why patrol re-detects the same comment every cycle*. A new class of comment (non-English, quoted reply with added commentary) would trip the same loop.

Per-comment idempotency handles the full bug class mechanically. First detection still emits `self-authored-feedback` and still dispatches one fix attempt; repeat detections of the same `(commentId, headSha)` are suppressed. A force-push rotates the SHA and the cache entries for old SHAs naturally stop matching — fresh push gets a fresh look.

### Scope caveat

`self-authored-feedback` only fires when `isSelfAuthored(pr) === true`, which checks `pr.headRefName.startsWith('claude/')`. This fix only affects patrol runs against agent-authored PRs — human PRs with similar comments were never in scope.

## Test plan

- [x] Unit tests for the pure filter in `crux/lib/pr-analysis/enriched-scan.test.ts`:
  - Emits `self-authored-feedback` on first scan (comment not yet processed)
  - Does NOT emit when comment id is in the processed set
  - Still emits when a new comment appears alongside a processed one
  - Fails open when a comment has no id (legacy fixtures, test doubles)
  - Identical behavior to pre-QUA-514 when the processed set is undefined or empty
- [x] State tests in `crux/pr-patrol/state.test.ts`:
  - Empty set when no cache file exists
  - Persist + retrieve round-trip
  - SHA mismatch returns empty set (force-push invalidation)
  - New SHA overwrites old ids
  - Union-on-merge under same SHA
  - `clear()` removes the file and is safe when file is missing
  - Empty `newIds` on a fresh cache is a no-op (no empty file littering)
  - Corrupt JSON tolerance (returns empty)
- [x] Full test suite green (6628 tests, +3 vs baseline)
- [x] `crux w validate gate --fix` green

Fixes QUA-514
