### PR TITLE
docs(audits): add §12 pre-cutover prerequisites checklist (QUA-523)

### DIFF
--- a/docs/audits/phase-3-equivalence-audit.md
+++ b/docs/audits/phase-3-equivalence-audit.md
@@ -488,7 +488,7 @@ rg 'data\.experts|data\.estimates|data\.glossary|data\.funders' apps/web/src/ cr
 
 If any of these grep commands return non-test results, the field is no longer dead and the deletion plan needs to be revised. If still empty, safe to delete from `database.json` writes in `build-data.mjs`.
 
-`database.resources` is also write-only today (write at `build-data.mjs:515`, but the runtime `loadResources()` at `apps/web/src/data/tablebase.ts:645` reads from a separate `resources.json` file with only a backward-compat fallback to `database.resources`). Same triple-check applies if the cutover wants to drop it.
+`database.resources` is **never present in `database.json`** — see § 3 line 150 of this audit. It's set in memory at `build-data.mjs:515` but stripped at write time by `writeMainOutputFiles()` at `apps/web/scripts/lib/output-writer.mjs:54` (where `resources: _resources` is destructured out alongside other Phase-4 lazy-loaded fields). Resources are written to a separate `resources.json` file instead, and the runtime `loadResources()` at `apps/web/src/data/tablebase.ts:645` reads from there. A fallback path to `database.resources` exists in `loadResources()` as backward-compat for older builds but is dead-by-construction in the current pipeline. **No cutover deletion needed for `database.resources` from `database.json`** — it isn't there. The cutover may optionally remove the dead in-memory assignment at `build-data.mjs:511-558` and the dead `loadResources()` fallback for cleanliness, but neither is strictly required.
 
 ### Cutover correctness checks
 

--- a/docs/audits/phase-3-equivalence-audit.md
+++ b/docs/audits/phase-3-equivalence-audit.md
@@ -461,6 +461,55 @@ Recommended next steps, in order:
 - ❌ Detect Type E (order-only array diffs) separately — these are folded into Type C. See `diffTypedEntities` in `build-data-from-pg.mjs` for rationale.
 - ❌ Audit non-`typedEntities` `database.json` fields: `resources` (PG-primary, out of scope), `kb` (covered separately via `audit-factbase-pg.mjs`), `pages`/`idRegistry`/`stats`/`tagIndex`/`pathRegistry`/`backlinks`/`relatedGraph`/`pageResources` (all derived at build time from the same sources — equivalent by construction)
 
+## 12. Pre-cutover prerequisites checklist
+
+Forward-looking list of items the future Phase 3 cutover PR must verify before deleting any columns, fields, or files. § 11 above covers what *this audit* didn't do; this section covers what the *cutover PR* must do.
+
+### Pre-work tickets must all be merged
+
+The cutover cannot start until these 4 tickets have shipped to main:
+
+- [ ] [QUA-519](https://linear.app/quantifieduncertainty/issue/QUA-519) — Fix `relatedEntries` sync bug (HIGH)
+- [ ] [QUA-520](https://linear.app/quantifieduncertainty/issue/QUA-520) — Migrate `data/organizations.yaml` (MEDIUM) — also fixes Finding #6 affiliation drift as a side effect (see Finding #6 root cause analysis)
+- [ ] [QUA-521](https://linear.app/quantifieduncertainty/issue/QUA-521) — Persistent `id_registry` for wikiId (MEDIUM)
+- [ ] [QUA-522](https://linear.app/quantifieduncertainty/issue/QUA-522) — `/api/entities/export` bulk endpoint (LOW)
+
+After all four ship, re-run `build-data-from-pg.mjs` against fresh prod and verify the diff count drops as expected (relatedEntries→0, organizations.yaml fields→0, wikiIds→0, etc.).
+
+### Dead-write triple-check before deletion
+
+The audit claims the following `database.json` top-level fields are unread (`grep` of `apps/web/src/` returns zero matches as of 2026-04-15). Re-verify at cutover time, when months may have passed and new consumers may have appeared:
+
+```bash
+# Run from repo root before deleting any of these from build-data.mjs:
+rg 'database\.experts|database\.estimates|database\.glossary|database\.funders|database\.organizations' apps/web/src/ crux/
+rg 'data\.experts|data\.estimates|data\.glossary|data\.funders' apps/web/src/ crux/
+```
+
+If any of these grep commands return non-test results, the field is no longer dead and the deletion plan needs to be revised. If still empty, safe to delete from `database.json` writes in `build-data.mjs`.
+
+`database.resources` is also write-only today (write at `build-data.mjs:515`, but the runtime `loadResources()` at `apps/web/src/data/tablebase.ts:645` reads from a separate `resources.json` file with only a backward-compat fallback to `database.resources`). Same triple-check applies if the cutover wants to drop it.
+
+### Cutover correctness checks
+
+Before merging the cutover PR:
+
+- [ ] `build-data.mjs` reads from PG (via `build-data-from-pg.mjs` evolved into the production reader), not YAML
+- [ ] Diff a fresh PG-sourced `database.json` against a YAML-sourced one — should be byte-identical except for known-acceptable structural changes
+- [ ] Playwright render-audit passes against a build using the new reader
+- [ ] `pnpm build` + `pnpm test` green
+- [ ] Vercel build can complete using the new reader (i.e., it has whatever PG access we decided on — read-replica, snapshot pattern, or live prod with cached fallback)
+
+### Vercel build-time PG access
+
+The user flagged this as a concern in the QUA-510 framing discussion. Pick the access pattern before the cutover PR:
+
+- **Option A — Read replica**: Vercel build connects to a follower DB more available than prod
+- **Option B — Nightly snapshot**: dump PG nightly to a file, build reads the snapshot unless `FORCE_LIVE_DB=1`
+- **Option C — Cached last-good**: if PG unreachable at build time, fall back to the previous build's `database.json`
+
+The cutover PR body must document which option was chosen + why.
+
 ## Appendix A — How to reproduce
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a new "§12 — Pre-cutover prerequisites checklist" section to `docs/audits/phase-3-equivalence-audit.md` capturing forward-looking items the future Phase 3 cutover PR must verify before deleting any columns / files / fields.

§ 11 already covers what *this audit* didn't do; § 12 is the complementary forward-looking section: what the *cutover PR* must do.

## Scope (49-line markdown addition)

The new section enumerates:

1. **Pre-work tickets must all be merged** — checklist of QUA-519 / QUA-520 / QUA-521 / QUA-522 + the re-verification step (re-run `build-data-from-pg.mjs` after they ship and confirm the diff count drops as expected)
2. **Dead-write triple-check before deletion** — concrete `rg` commands to re-verify that `database.experts/estimates/glossary/funders/organizations/resources` are still unread at cutover time (months may have passed since the audit). Plus a note on `database.resources` being write-only via the `loadResources()` fallback path.
3. **Cutover correctness checks** — PG-vs-YAML diff, Playwright render-audit, `pnpm build` + `pnpm test`, Vercel build verification
4. **Vercel build-time PG access** — three options (read-replica / nightly snapshot / cached last-good), and a requirement that the cutover PR document which was chosen + why

## Why this matters

These items came out of the QUA-510 review on PR #4384 as "minor notes / things worth verifying" but weren't worth standalone tickets. Bundling them into the audit document itself (rather than as scattered Linear comments or a forgotten coordinator note) means the cutover PR author will find them when they read the audit before starting work.

## What's NOT in this PR

#1 (Finding #6 affiliation examples) and #2 (resources coverage status) from the original [QUA-523 ticket body](https://linear.app/quantifieduncertainty/issue/QUA-523) **were already addressed** by the audit's `address missed acceptance criteria` commit (87933cde4) on the original branch before merge. Discovered during investigation and documented in the QUA-523 ticket comment.

So this PR is just #3 — the new §12 section.

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` passes (docs-only change, content-scope is sufficient)
- [x] No code paths modified — markdown addition only
- [x] Cross-references to QUA-519/520/521/522 are correct (Linear)

## Why `--no-verify` is NOT used

Pre-push gate ran cleanly. Checklist items unrelated to docs-only changes (tests-written, red-team, retry-safety, prompt-security, contract-alignment) are marked N/A with reasons via `crux sys agent-checklist check --na`.

Closes QUA-523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pre-cutover prerequisites checklist outlining deployment requirements, including data regeneration steps, validation checks, and database access strategy options for upcoming release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->