### PR TITLE
feat(hooks): surface and enforce wip-checklist.md mid-session (QUA-515)

### DIFF
--- a/.claude/hooks/inject-wip-checklist.sh
+++ b/.claude/hooks/inject-wip-checklist.sh
@@ -1,69 +1,42 @@
 #!/usr/bin/env bash
 #
-# UserPromptSubmit hook — surfaces .claude/wip-checklist.md state on every user turn.
-#
-# Why: the checklist is created by `crux sys agent-checklist init` at session
-# start but nothing makes the agent re-read it mid-session. Under context
-# pressure, agents reliably forget the file exists and skip the quality gates
-# the checklist was meant to enforce. See QUA-515.
-#
-# What: emits a compact <system-reminder> with the progress count and the slugs
-# of unchecked items. Emitted to stdout, which Claude Code injects as context
-# for the upcoming turn.
-#
-# When: every user-prompt turn. No-op if .claude/wip-checklist.md is missing
-# (so quick-fix sessions that skip /agent-init don't get noise).
-#
-# Format reference for the checklist:
-#   1. [ ] `slug-name` Human label
-#   2. [x] `slug-name` Human label    (done)
-#   15. [~] `slug-name` Human label   (N/A)
+# UserPromptSubmit hook — injects .claude/wip-checklist.md state into every
+# user turn as a <system-reminder>, so the agent can't "forget" the checklist
+# exists after /agent-init prints it once. Silent no-op when the file is
+# missing (quick-fix sessions, pre-init turns). See QUA-515.
 #
 
 set -uo pipefail
 
-# Prefer the harness-provided project dir. Fall back to script-relative path
-# for manual testing. Using CLAUDE_PROJECT_DIR is robust against symlinks and
-# worktree drift (where script-relative resolution can land in the wrong clone).
+# CLAUDE_PROJECT_DIR is symlink-safe; fall back for manual testing.
 REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
 
-# No checklist → silent no-op. Quick-fix sessions and pre-/agent-init turns
-# should not get the reminder.
 if [ ! -f "$CHECKLIST" ]; then
   exit 0
 fi
 
-# Count items by status. Match lines like "N. [ ] `slug` ..." anchored to the
-# bracket pair so we don't accidentally count list bullets in the "Key Decisions"
-# section. `grep -c` exits non-zero on zero matches, so we fall through to wc -l
-# and tr to keep the count clean (no trailing newline that breaks $((arithmetic))).
+# grep -c exits non-zero on zero matches, so use wc -l + tr to keep counts
+# clean for arithmetic. POSIX [[:space:]] for BSD/GNU portability (macOS sed
+# doesn't grok \s).
 count_lines() {
   grep -E "$1" "$CHECKLIST" 2>/dev/null | wc -l | tr -d '[:space:]'
 }
-# Use POSIX character classes for BSD/GNU portability (macOS sed doesn't grok \s).
 DONE=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[x\][[:space:]]+`')
 NA=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[~\][[:space:]]+`')
 TODO=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`')
 TOTAL=$((DONE + NA + TODO))
 
-# Empty checklist (no items matched) → no-op. The file might be malformed or
-# in the middle of being written.
 if [ "$TOTAL" -eq 0 ]; then
   exit 0
 fi
 
-# Extract slugs of unchecked items. Each line looks like:
-#   N. [ ] `slug-name` Human label
-# We grep for those lines, then pull just the first backtick-wrapped token.
-# Two-stage so we can use a tight POSIX ERE on each side.
 UNCHECKED_SLUGS=""
 if [ "$TODO" -gt 0 ]; then
-  # awk: on each unchecked line, pull just the FIRST backtick-wrapped token
-  # (the slug). Defends against human labels that themselves contain backticks
-  # like "Use `foo` to bar".
-  # Strip angle brackets from slugs to prevent prompt-injection via a
-  # crafted `</system-reminder>` slug leaking into the reminder block below.
+  # awk pulls only the FIRST backtick-wrapped token per line — defends against
+  # human labels containing backticks like "Use `foo` to bar". tr -d '<>'
+  # strips angle brackets so a crafted slug can't inject `</system-reminder>`
+  # into the reminder block below.
   UNCHECKED_SLUGS=$(awk '
     /^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`/ {
       n = split($0, parts, "`")
@@ -75,9 +48,6 @@ if [ "$TODO" -gt 0 ]; then
     | sed 's/,/, /g')
 fi
 
-# Emit a system-reminder-style block. Claude Code picks this up from stdout
-# and injects it as context for the upcoming turn. The MEMORY.md auto-context
-# loader uses the same channel.
 echo "<system-reminder>"
 echo "Session checklist: $DONE/$TOTAL done${NA:+ ($NA N/A)}. File: .claude/wip-checklist.md"
 if [ "$TODO" -gt 0 ]; then

--- a/.claude/hooks/inject-wip-checklist.sh
+++ b/.claude/hooks/inject-wip-checklist.sh
@@ -22,7 +22,10 @@
 
 set -uo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# Prefer the harness-provided project dir. Fall back to script-relative path
+# for manual testing. Using CLAUDE_PROJECT_DIR is robust against symlinks and
+# worktree drift (where script-relative resolution can land in the wrong clone).
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
 
 # No checklist → silent no-op. Quick-fix sessions and pre-/agent-init turns
@@ -59,12 +62,15 @@ if [ "$TODO" -gt 0 ]; then
   # awk: on each unchecked line, pull just the FIRST backtick-wrapped token
   # (the slug). Defends against human labels that themselves contain backticks
   # like "Use `foo` to bar".
+  # Strip angle brackets from slugs to prevent prompt-injection via a
+  # crafted `</system-reminder>` slug leaking into the reminder block below.
   UNCHECKED_SLUGS=$(awk '
     /^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`/ {
       n = split($0, parts, "`")
       if (n >= 3) print parts[2]
     }
   ' "$CHECKLIST" 2>/dev/null \
+    | tr -d '<>' \
     | paste -sd ',' - \
     | sed 's/,/, /g')
 fi

--- a/.claude/hooks/inject-wip-checklist.sh
+++ b/.claude/hooks/inject-wip-checklist.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# UserPromptSubmit hook — surfaces .claude/wip-checklist.md state on every user turn.
+#
+# Why: the checklist is created by `crux sys agent-checklist init` at session
+# start but nothing makes the agent re-read it mid-session. Under context
+# pressure, agents reliably forget the file exists and skip the quality gates
+# the checklist was meant to enforce. See QUA-515.
+#
+# What: emits a compact <system-reminder> with the progress count and the slugs
+# of unchecked items. Emitted to stdout, which Claude Code injects as context
+# for the upcoming turn.
+#
+# When: every user-prompt turn. No-op if .claude/wip-checklist.md is missing
+# (so quick-fix sessions that skip /agent-init don't get noise).
+#
+# Format reference for the checklist:
+#   1. [ ] `slug-name` Human label
+#   2. [x] `slug-name` Human label    (done)
+#   15. [~] `slug-name` Human label   (N/A)
+#
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
+
+# No checklist → silent no-op. Quick-fix sessions and pre-/agent-init turns
+# should not get the reminder.
+if [ ! -f "$CHECKLIST" ]; then
+  exit 0
+fi
+
+# Count items by status. Match lines like "N. [ ] `slug` ..." anchored to the
+# bracket pair so we don't accidentally count list bullets in the "Key Decisions"
+# section. `grep -c` exits non-zero on zero matches, so we fall through to wc -l
+# and tr to keep the count clean (no trailing newline that breaks $((arithmetic))).
+count_lines() {
+  grep -E "$1" "$CHECKLIST" 2>/dev/null | wc -l | tr -d '[:space:]'
+}
+# Use POSIX character classes for BSD/GNU portability (macOS sed doesn't grok \s).
+DONE=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[x\][[:space:]]+`')
+NA=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[~\][[:space:]]+`')
+TODO=$(count_lines '^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`')
+TOTAL=$((DONE + NA + TODO))
+
+# Empty checklist (no items matched) → no-op. The file might be malformed or
+# in the middle of being written.
+if [ "$TOTAL" -eq 0 ]; then
+  exit 0
+fi
+
+# Extract slugs of unchecked items. Each line looks like:
+#   N. [ ] `slug-name` Human label
+# We grep for those lines, then pull just the first backtick-wrapped token.
+# Two-stage so we can use a tight POSIX ERE on each side.
+UNCHECKED_SLUGS=""
+if [ "$TODO" -gt 0 ]; then
+  # awk: on each unchecked line, pull just the FIRST backtick-wrapped token
+  # (the slug). Defends against human labels that themselves contain backticks
+  # like "Use `foo` to bar".
+  UNCHECKED_SLUGS=$(awk '
+    /^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`/ {
+      n = split($0, parts, "`")
+      if (n >= 3) print parts[2]
+    }
+  ' "$CHECKLIST" 2>/dev/null \
+    | paste -sd ',' - \
+    | sed 's/,/, /g')
+fi
+
+# Emit a system-reminder-style block. Claude Code picks this up from stdout
+# and injects it as context for the upcoming turn. The MEMORY.md auto-context
+# loader uses the same channel.
+echo "<system-reminder>"
+echo "Session checklist: $DONE/$TOTAL done${NA:+ ($NA N/A)}. File: .claude/wip-checklist.md"
+if [ "$TODO" -gt 0 ]; then
+  echo "Unchecked: $UNCHECKED_SLUGS"
+  echo ""
+  echo "Before shipping, work through every unchecked item or mark it N/A with a justification. Don't end the session until each item has a disposition. The Stop hook will block session-end if items remain unchecked."
+fi
+echo "</system-reminder>"

--- a/.claude/hooks/verify-checklist-on-stop.sh
+++ b/.claude/hooks/verify-checklist-on-stop.sh
@@ -1,83 +1,60 @@
 #!/usr/bin/env bash
 #
 # Stop hook — blocks session end when .claude/wip-checklist.md has unchecked
-# items AND the agent's last message signals ship intent.
-#
-# Why: /agent-ship verifies the checklist as part of the ship workflow, but
-# nothing catches the path where the agent tries to END the session WITHOUT
-# going through /agent-ship (announcing "ready to ship", /agent-end, etc.).
-# This hook is the second line of defense for QUA-515.
-#
-# Why not block every Stop unconditionally: Stop fires after every assistant
-# turn, not just at session-end. Blocking every Stop would force Claude into
-# a forced-continue loop on every single turn — agent would never yield to
-# the user until the checklist was 100% clear. Far too aggressive.
-#
-# Instead, we narrow to ship-intent: only block if the agent's final message
-# contains language suggesting it's trying to wrap the session (ship, done,
-# ready, /agent-ship, /agent-end, "ready to ship", etc.). That's the exact
-# moment /agent-ship verification would fire, so the hook catches the same
-# class of bypass without the turn-by-turn overhead.
-#
-# Fail-open: any error reading the transcript or checklist → allow the stop.
-# We never brick sessions.
+# items AND the agent's last message signals ship intent. Narrowed to
+# ship-intent on purpose: blocking every Stop would force Claude into a
+# forced-continue loop on every single assistant turn. Fails open on any
+# error — never bricks sessions. See QUA-515.
 #
 
 set -uo pipefail
 
-# Prefer the harness-provided project dir. Fall back to script-relative path
-# for manual testing. Using CLAUDE_PROJECT_DIR is robust against symlinks and
-# worktree drift (where script-relative resolution can land in the wrong clone).
+# CLAUDE_PROJECT_DIR is symlink-safe; fall back for manual testing.
 REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
 
-# No checklist → allow. Sessions without /agent-init shouldn't trip.
 if [ ! -f "$CHECKLIST" ]; then
   exit 0
 fi
 
-# Required tools — fail open with a loud stderr warning if missing. A silent
-# no-op when jq is missing is a defense-in-depth failure we want to know about.
+# A silent no-op when jq is missing would be a defense-in-depth failure we
+# want to know about. Fail open with a loud stderr warning instead.
 if ! command -v jq >/dev/null 2>&1; then
   echo "verify-checklist-on-stop: jq not found — hook disabled" >&2
   exit 0
 fi
 
-# Read hook input JSON. The Stop hook receives transcript_path (JSONL file
-# with the conversation) via stdin. Parse defensively — if stdin is empty or
-# malformed, fail open.
 INPUT_JSON=$(cat 2>/dev/null || true)
 if [ -z "$INPUT_JSON" ]; then
   exit 0
 fi
 
-TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+# Single jq call extracts both fields — saves a subprocess spawn on the
+# hot path (this hook fires on every assistant turn).
+read -r TRANSCRIPT_PATH STOP_HOOK_ACTIVE < <(echo "$INPUT_JSON" \
+  | jq -r '[(.transcript_path // ""), ((.stop_hook_active // false) | tostring)] | @tsv' 2>/dev/null \
+  || echo $'\tfalse')
+
 if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   exit 0
 fi
 
-# If stop_hook_active is true, this hook has already fired in the current
-# forced-continue cycle — don't re-block or we risk a loop.
-STOP_HOOK_ACTIVE=$(echo "$INPUT_JSON" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+# stop_hook_active=true means we already fired in the current forced-continue
+# cycle — don't re-block or we risk a loop.
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
-# Pull the text of the last assistant turn from the JSONL transcript.
-# Notes on the jq filter:
-# - `.message.content` is sometimes a string (simple text turn) and sometimes
-#   an array of typed blocks (text, tool_use, thinking, etc.). We handle both:
-#   strings pass through; arrays are filtered to text blocks and joined.
-# - We only look at the tail of the transcript (`tail -n 500`). For long
-#   sessions the full JSONL can be tens of MB; Claude Code gives this hook a
-#   short timeout (5s). The ship-intent phrase lives in the last message
-#   anyway, so reading the whole file is wasteful and timeout-prone.
-# - We filter to non-empty text AFTER the join so turns that are entirely
-#   tool_use blocks with no text don't shadow an older real message.
-# Ordering assumption: the assistant turn that triggers Stop is already
-# written to the transcript by the time this hook fires. If that assumption
-# is ever wrong, the hook inspects a stale message and falls through to
-# fail-open — no worse than not having the hook at all.
+# Pull the last assistant turn's text from the transcript.
+# - `.message.content` may be a string (simple turn) or an array of typed
+#   blocks (text, tool_use, thinking, ...). Handle both.
+# - `tail -n 500` caps input — long sessions produce tens of MB of JSONL and
+#   this hook has a 5s timeout.
+# - Filter to non-empty text AFTER the join, so turns that are entirely
+#   tool_use (no text) don't shadow the previous real message.
+# - Ordering assumption: the triggering assistant turn is written to the
+#   transcript before Stop fires. If that's ever wrong, we inspect a stale
+#   message and fall through to fail-open — no worse than not having the hook.
 LAST_ASSISTANT_TEXT=$(tail -n 500 "$TRANSCRIPT_PATH" 2>/dev/null \
   | jq -rR '
       fromjson?
@@ -91,26 +68,19 @@ LAST_ASSISTANT_TEXT=$(tail -n 500 "$TRANSCRIPT_PATH" 2>/dev/null \
   | grep -v '^$' \
   | tail -n 1 || true)
 
-# If we can't find an assistant message, fail open. Transcript may be empty
-# (first-turn) or in a different format.
 if [ -z "$LAST_ASSISTANT_TEXT" ]; then
   exit 0
 fi
 
-# Detect ship intent. Case-insensitive match against a compact list of phrases
-# agents commonly use when trying to wrap the session.
-#
-# We match against only the LAST 600 characters of the assistant message, not
-# the whole thing. Ship intent lives in the closing paragraph; earlier text
-# that mentions "the PR" or "ready for review" while discussing other work
-# shouldn't trip the hook.
+# Only match the last 600 chars of the message. Ship intent lives in the
+# closing paragraph; historical mentions of "the PR" or "ready for review"
+# while discussing other work shouldn't trip the hook.
 TAIL_TEXT=$(printf '%s' "$LAST_ASSISTANT_TEXT" | tail -c 600)
 
 if ! printf '%s' "$TAIL_TEXT" | grep -iqE '(/agent-ship|/agent-end|ready to (ship|merge|review)|ready for review|shipping (now|the pr)|session (is )?(done|complete)|work is (done|complete)|wrap (this|the session) up|time to ship|pr is (up|ready|open(ed)?)|opened (the )?pr|pushed (and|the) (changes|pr|commit)|committed and pushed|nothing (else|more) to do|all done|all set|pr #[0-9]+)'; then
   exit 0
 fi
 
-# Ship intent detected. Now check the checklist.
 UNCHECKED=$(awk '
   /^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`/ {
     n = split($0, parts, "`")
@@ -122,9 +92,9 @@ if [ -z "$UNCHECKED" ]; then
   exit 0
 fi
 
-# Sanitize slugs before echoing to stderr. Stderr on a blocked Stop becomes
-# context for the agent's next turn, so a crafted slug with `</system-reminder>`
-# or angle brackets could inject instructions. Strip them defensively.
+# Strip angle brackets from slugs before echoing. Stderr on a blocked Stop
+# becomes context for the agent's next turn, so a crafted slug with
+# `</system-reminder>` could inject instructions otherwise.
 SLUG_LIST=$(echo "$UNCHECKED" | tr -d '<>' | paste -sd ',' - | sed 's/,/, /g')
 COUNT=$(echo "$UNCHECKED" | wc -l | tr -d '[:space:]')
 

--- a/.claude/hooks/verify-checklist-on-stop.sh
+++ b/.claude/hooks/verify-checklist-on-stop.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Stop hook — blocks session end when .claude/wip-checklist.md has unchecked
+# items AND the agent's last message signals ship intent.
+#
+# Why: /agent-ship verifies the checklist as part of the ship workflow, but
+# nothing catches the path where the agent tries to END the session WITHOUT
+# going through /agent-ship (announcing "ready to ship", /agent-end, etc.).
+# This hook is the second line of defense for QUA-515.
+#
+# Why not block every Stop unconditionally: Stop fires after every assistant
+# turn, not just at session-end. Blocking every Stop would force Claude into
+# a forced-continue loop on every single turn — agent would never yield to
+# the user until the checklist was 100% clear. Far too aggressive.
+#
+# Instead, we narrow to ship-intent: only block if the agent's final message
+# contains language suggesting it's trying to wrap the session (ship, done,
+# ready, /agent-ship, /agent-end, "ready to ship", etc.). That's the exact
+# moment /agent-ship verification would fire, so the hook catches the same
+# class of bypass without the turn-by-turn overhead.
+#
+# Fail-open: any error reading the transcript or checklist → allow the stop.
+# We never brick sessions.
+#
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
+
+# No checklist → allow. Sessions without /agent-init shouldn't trip.
+if [ ! -f "$CHECKLIST" ]; then
+  exit 0
+fi
+
+# Read hook input JSON. The Stop hook receives transcript_path (JSONL file
+# with the conversation) via stdin. Parse defensively — if stdin is empty or
+# malformed, fail open.
+INPUT_JSON=$(cat 2>/dev/null || true)
+if [ -z "$INPUT_JSON" ]; then
+  exit 0
+fi
+
+TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# If stop_hook_active is true, this hook has already fired in the current
+# forced-continue cycle — don't re-block or we risk a loop.
+STOP_HOOK_ACTIVE=$(echo "$INPUT_JSON" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# Pull the text of the last assistant turn from the JSONL transcript. Claude
+# Code writes one message per line. We filter to assistant messages and take
+# the last non-empty one (macOS has no `tac`, so filter-then-tail).
+LAST_ASSISTANT_TEXT=$(jq -rR 'fromjson? | select(.message.role == "assistant") | .message.content // [] | map(select(.type == "text") | .text // "") | join(" ")' "$TRANSCRIPT_PATH" 2>/dev/null \
+  | grep -v '^$' \
+  | tail -n 1 || true)
+
+# If we can't find an assistant message, fail open. Transcript may be empty
+# (first-turn) or in a different format.
+if [ -z "$LAST_ASSISTANT_TEXT" ]; then
+  exit 0
+fi
+
+# Detect ship intent. Case-insensitive, word-boundary-ish match against a
+# compact list of phrases agents commonly use when trying to wrap the session.
+# Deliberately narrow — false positives here cause turn-by-turn blocking,
+# which is exactly what we're avoiding.
+if ! echo "$LAST_ASSISTANT_TEXT" | grep -iqE '(/agent-ship|/agent-end|ready to ship|ready to merge|ready for review|shipping (now|the pr)|session (is )?(done|complete)|work is (done|complete)|wrap (this|the session) up|time to ship)'; then
+  exit 0
+fi
+
+# Ship intent detected. Now check the checklist.
+UNCHECKED=$(awk '
+  /^[[:space:]]*[0-9]+\.[[:space:]]+\[ \][[:space:]]+`/ {
+    n = split($0, parts, "`")
+    if (n >= 3) print parts[2]
+  }
+' "$CHECKLIST" 2>/dev/null)
+
+if [ -z "$UNCHECKED" ]; then
+  exit 0
+fi
+
+SLUG_LIST=$(echo "$UNCHECKED" | paste -sd ',' - | sed 's/,/, /g')
+COUNT=$(echo "$UNCHECKED" | wc -l | tr -d '[:space:]')
+
+cat >&2 <<EOF
+BLOCKED: Your last message signals the session is ready to wrap up, but the
+session checklist has $COUNT unchecked item(s):
+
+  $SLUG_LIST
+
+Before ending the session, do ONE of the following:
+  1. Work through each item, then mark it [x] in .claude/wip-checklist.md
+  2. Mark items N/A with a justification — change "[ ]" to "[~]" and add
+     "<!-- N/A: <reason> -->" on the same line
+  3. Run /agent-ship — it performs this same verification with more context
+     and runs the full review + push + CI flow
+  4. If you're abandoning the session, run /agent-end — it marks unchecked
+     items as abandoned with the reason and removes the local checklist
+
+See QUA-515 for why this hook exists. Do NOT mark items [x] without
+actually doing them — the checklist is the only gate that catches review,
+test, and security gaps before they ship.
+EOF
+exit 2

--- a/.claude/hooks/verify-checklist-on-stop.sh
+++ b/.claude/hooks/verify-checklist-on-stop.sh
@@ -25,11 +25,21 @@
 
 set -uo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# Prefer the harness-provided project dir. Fall back to script-relative path
+# for manual testing. Using CLAUDE_PROJECT_DIR is robust against symlinks and
+# worktree drift (where script-relative resolution can land in the wrong clone).
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CHECKLIST="$REPO_ROOT/.claude/wip-checklist.md"
 
 # No checklist → allow. Sessions without /agent-init shouldn't trip.
 if [ ! -f "$CHECKLIST" ]; then
+  exit 0
+fi
+
+# Required tools — fail open with a loud stderr warning if missing. A silent
+# no-op when jq is missing is a defense-in-depth failure we want to know about.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "verify-checklist-on-stop: jq not found — hook disabled" >&2
   exit 0
 fi
 
@@ -53,10 +63,31 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
-# Pull the text of the last assistant turn from the JSONL transcript. Claude
-# Code writes one message per line. We filter to assistant messages and take
-# the last non-empty one (macOS has no `tac`, so filter-then-tail).
-LAST_ASSISTANT_TEXT=$(jq -rR 'fromjson? | select(.message.role == "assistant") | .message.content // [] | map(select(.type == "text") | .text // "") | join(" ")' "$TRANSCRIPT_PATH" 2>/dev/null \
+# Pull the text of the last assistant turn from the JSONL transcript.
+# Notes on the jq filter:
+# - `.message.content` is sometimes a string (simple text turn) and sometimes
+#   an array of typed blocks (text, tool_use, thinking, etc.). We handle both:
+#   strings pass through; arrays are filtered to text blocks and joined.
+# - We only look at the tail of the transcript (`tail -n 500`). For long
+#   sessions the full JSONL can be tens of MB; Claude Code gives this hook a
+#   short timeout (5s). The ship-intent phrase lives in the last message
+#   anyway, so reading the whole file is wasteful and timeout-prone.
+# - We filter to non-empty text AFTER the join so turns that are entirely
+#   tool_use blocks with no text don't shadow an older real message.
+# Ordering assumption: the assistant turn that triggers Stop is already
+# written to the transcript by the time this hook fires. If that assumption
+# is ever wrong, the hook inspects a stale message and falls through to
+# fail-open — no worse than not having the hook at all.
+LAST_ASSISTANT_TEXT=$(tail -n 500 "$TRANSCRIPT_PATH" 2>/dev/null \
+  | jq -rR '
+      fromjson?
+      | select(.message.role == "assistant")
+      | .message.content
+      | if type == "string" then .
+        elif type == "array" then
+          (map(select(.type == "text") | .text // "") | join(" "))
+        else "" end
+    ' 2>/dev/null \
   | grep -v '^$' \
   | tail -n 1 || true)
 
@@ -66,11 +97,16 @@ if [ -z "$LAST_ASSISTANT_TEXT" ]; then
   exit 0
 fi
 
-# Detect ship intent. Case-insensitive, word-boundary-ish match against a
-# compact list of phrases agents commonly use when trying to wrap the session.
-# Deliberately narrow — false positives here cause turn-by-turn blocking,
-# which is exactly what we're avoiding.
-if ! echo "$LAST_ASSISTANT_TEXT" | grep -iqE '(/agent-ship|/agent-end|ready to ship|ready to merge|ready for review|shipping (now|the pr)|session (is )?(done|complete)|work is (done|complete)|wrap (this|the session) up|time to ship)'; then
+# Detect ship intent. Case-insensitive match against a compact list of phrases
+# agents commonly use when trying to wrap the session.
+#
+# We match against only the LAST 600 characters of the assistant message, not
+# the whole thing. Ship intent lives in the closing paragraph; earlier text
+# that mentions "the PR" or "ready for review" while discussing other work
+# shouldn't trip the hook.
+TAIL_TEXT=$(printf '%s' "$LAST_ASSISTANT_TEXT" | tail -c 600)
+
+if ! printf '%s' "$TAIL_TEXT" | grep -iqE '(/agent-ship|/agent-end|ready to (ship|merge|review)|ready for review|shipping (now|the pr)|session (is )?(done|complete)|work is (done|complete)|wrap (this|the session) up|time to ship|pr is (up|ready|open(ed)?)|opened (the )?pr|pushed (and|the) (changes|pr|commit)|committed and pushed|nothing (else|more) to do|all done|all set|pr #[0-9]+)'; then
   exit 0
 fi
 
@@ -86,7 +122,10 @@ if [ -z "$UNCHECKED" ]; then
   exit 0
 fi
 
-SLUG_LIST=$(echo "$UNCHECKED" | paste -sd ',' - | sed 's/,/, /g')
+# Sanitize slugs before echoing to stderr. Stderr on a blocked Stop becomes
+# context for the agent's next turn, so a crafted slug with `</system-reminder>`
+# or angle brackets could inject instructions. Strip them defensively.
+SLUG_LIST=$(echo "$UNCHECKED" | tr -d '<>' | paste -sd ',' - | sed 's/,/, /g')
 COUNT=$(echo "$UNCHECKED" | wc -l | tr -d '[:space:]')
 
 cat >&2 <<EOF

--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -56,6 +56,17 @@ Valid types: `content`, `infrastructure`, `bugfix`, `refactor`, `commands`. Defa
 
 Then read `.claude/wip-checklist.md` and keep it updated as you work.
 
+### How the checklist is enforced mid-session — hook layers (QUA-515)
+
+The checklist is not a nice-to-have piece of paper the agent can forget exists. Two hooks surface and enforce it:
+
+- **`.claude/hooks/inject-wip-checklist.sh`** (`UserPromptSubmit` event) — emits a compact `<system-reminder>` on every user turn with the progress count (`3/16 done`) and the slugs of still-unchecked items. If the file is missing (quick-fix session, pre-init turn), the hook is a silent no-op. The point: the checklist is in the prompt on every turn, so "I forgot the file existed" is no longer a possible failure mode. Same mechanism `MEMORY.md` auto-context uses.
+- **`.claude/hooks/verify-checklist-on-stop.sh`** (`Stop` event) — reads the agent's last assistant message from the transcript and checks for ship-intent phrases (`/agent-ship`, `ready to ship`, `ready for review`, `session done`, etc.). If the agent is trying to wrap the session AND there are still unchecked items, the hook blocks the stop (exit 2) and lists what's left. The hook is narrow on purpose: blocking every Stop would loop the agent on every turn, so it only fires at the moment of real shipping intent. Fails open on transcript read errors and no-ops when the checklist file is missing.
+
+Both hooks are registered in `.claude/settings.json`. If you need to bypass one (e.g., debugging the hook itself), temporarily move the file aside — do not add an `env` bypass flag, the enforcement exists precisely because bypasses get left on.
+
+To check items off during a session, edit `.claude/wip-checklist.md` directly: change `[ ]` to `[x]` for done items, or `[~]` with `<!-- N/A: reason -->` for items that don't apply. The Layer 1 reminder updates on the next user turn.
+
 ## Step 2: Session End — BEFORE considering work complete
 
 ### Step 2a: Enumerate every problem you observed this session — MANDATORY

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,6 +100,28 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-wip-checklist.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/verify-checklist-on-stop.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Closes the gap that caused the QUA-505 + QUA-508 session incident: agents forget `.claude/wip-checklist.md` exists after `/agent-init` prints it once, then ship without running review/simplify/red-team/etc. Adds two hooks per the QUA-515 layered design.

- **`inject-wip-checklist.sh`** (`UserPromptSubmit`) — emits a compact `<system-reminder>` on every user turn with progress count and unchecked slugs. No-op when the file is missing (quick-fix sessions aren't penalized).
- **`verify-checklist-on-stop.sh`** (`Stop`) — reads the last assistant message from `transcript_path`, matches against ship-intent phrases (`/agent-ship`, `ready to ship`, `opened the PR`, `PR #NNN`, `all done`, etc.), and if the agent is trying to wrap the session AND unchecked items remain, exits 2 with stderr listing them. Narrowed to ship-intent on purpose — blocking every `Stop` would force-continue the agent on every turn.

Both are wired in `.claude/settings.json` and documented in `.claude/rules/agent-session-workflow.md`.

## Design notes

- **Layer 1** alone would satisfy the ticket ("Layer 1 alone is probably sufficient"). Layer 2 is the belt-and-suspenders second line of defense for the exact failure mode in the QUA-515 incident: the agent announced "Ready to ship" without checking the checklist.
- **Ship-intent matching** is intentionally narrow and applied to the last 600 chars of the assistant message only. Historical mentions of "ready to ship" while discussing past work shouldn't trip the hook. False positives loop the agent on every turn, so the regex list was chosen conservatively.
- **Fail-open everywhere.** Missing `jq` logs a stderr warning and exits 0. Empty stdin, missing `transcript_path`, string-form vs array-form `.message.content`, `stop_hook_active=true` loop guard — all fail open. The hook never bricks a session.
- **POSIX character classes** (`[[:space:]]`) throughout — BSD sed/grep don't grok `\s`, the first draft silently matched nothing on macOS.
- **`CLAUDE_PROJECT_DIR`** preferred over script-relative `REPO_ROOT` resolution — robust against symlinks and worktree drift.
- **Slug sanitization** — `tr -d '<>'` on slugs before emitting, so a crafted `</system-reminder>` slug can't inject instructions through the reminder block.
- **Efficiency** — Stop hook uses `tail -n 500` on the transcript before `jq` (long sessions produce tens of MB of JSONL under a 5s hook timeout), and merges two `jq` calls into one via `@tsv` + `read` to save a subprocess spawn per Stop event.
- **Layer 3** (status-line integration) deferred. Can add later if Layer 1 + 2 prove insufficient.

## Test plan

Manual test matrix (no bash test framework in `.claude/hooks/`, all hooks are hand-tested per project convention):

- [x] Layer 1 — real checklist with unchecked items → emits `<system-reminder>` with progress + slug list
- [x] Layer 1 — all-checked checklist → emits `N/N done` header only (no unchecked list)
- [x] Layer 1 — missing `wip-checklist.md` → silent no-op
- [x] Layer 1 — `TODO=0` path → clean output, no `head: illegal line count` error
- [x] Layer 1 — human labels containing backticks → awk pulls only the first backtick token per line
- [x] Layer 2 — string-form `.message.content` (Claude Code simple turns) → correctly parsed
- [x] Layer 2 — array-form `.message.content` with text + trailing `tool_use` → correctly parsed
- [x] Layer 2 — last message is pure `tool_use` with no text → falls back to earlier real text message
- [x] Layer 2 — ship intent in HEAD of 800-char message (beyond 600-char tail) → does NOT block
- [x] Layer 2 — no ship intent anywhere → allows
- [x] Layer 2 — `stop_hook_active=true` → allows (loop guard)
- [x] Layer 2 — empty stdin → fail-open
- [x] Layer 2 — missing `transcript_path` → fail-open
- [x] Layer 2 — missing `jq` → stderr warning, fail-open
- [x] Layer 2 — ship intent + unchecked items → blocks with exit 2 and slug list
- [x] Layer 2 — ship intent + all checked items → allows
- [x] `jq` precedence for `.stop_hook_active // false | tostring` → verified with true/false/missing inputs, all produce correct string values after `@tsv` coercion
- [x] `pnpm crux w validate gate --fix` → clean (51 checks pass, 3 pre-existing advisories)

## Post-merge verification

After this merges, start a fresh Claude Code session in a slot and verify:

1. `/agent-init` creates `.claude/wip-checklist.md` as before.
2. On the next user turn, the assistant's context includes a `<system-reminder>` block with `Session checklist: N/M done. Unchecked: ...` — the injection is happening.
3. After doing some work, type "I'm ready to ship" (or similar). The Stop hook should block with the list of unchecked items.
4. Mark items off / N/A them, then try to ship again — block lifts.

No code is deployed (hook scripts are client-side only), no migrations, no env vars, no CI config. Detector confirmed no deploy tasks.

Fixes QUA-515
