### PR TITLE
fix(tablebase/entities): ref-check relatedEntries against stable_id too (QUA-519)

### DIFF
--- a/apps/wiki-server/src/__tests__/entities.test.ts
+++ b/apps/wiki-server/src/__tests__/entities.test.ts
@@ -28,11 +28,19 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   dispatchCalls.push({ query, params: [...params] });
   const q = query.toLowerCase();
 
-  // --- ref-check: SELECT id FROM entities WHERE id IN (...) ---
+  // --- ref-check: SELECT <column> AS id FROM entities WHERE <column> IN (...) ---
+  // Respect the column being queried so tests can catch slug-vs-stableId
+  // confusion (QUA-519): when the query targets entities.id, only return
+  // ids that exist as slugs; when it targets stable_id, only return
+  // stableIds. The previous column-agnostic behavior masked the bug where
+  // ref-check only looked at entities.id while YAML refs may be stableIds.
   if (q.includes("as id from") && q.includes("where") && q.includes(" in ")) {
-    // Return only IDs that exist in the entities store (check both slug and stableId)
+    const targetsStableId = q.includes("stable_id");
+    const keys: Set<string> = targetsStableId
+      ? new Set(entitiesStore.keys())
+      : new Set(slugIndex.keys());
     return params
-      .filter((p) => lookupEntity(p as string) !== undefined)
+      .filter((p) => keys.has(p as string))
       .map((p) => ({ id: p }));
   }
 
@@ -668,6 +676,42 @@ describe("Entities API", () => {
   // ---- Referential integrity ----
 
   describe("Referential integrity", () => {
+    it("preserves relatedEntries that target a stableId, not just slugs (QUA-519)", async () => {
+      // Regression: ref-check previously only queried entities.id (slug),
+      // silently stripping every stableId-based ref and writing relatedEntries:[].
+      await seedEntity(app, "openai", "OpenAI", { stableId: "hI4jK5lM6n" });
+
+      const res = await postJson(app, "/api/entities/sync", {
+        entities: [
+          {
+            id: "anthropic",
+            stableId: "aB1cD2eF3g",
+            title: "Anthropic",
+            entityType: "organization",
+            relatedEntries: [
+              // stableId reference — must resolve via entities.stable_id
+              { id: "hI4jK5lM6n", type: "organization" },
+              // genuinely missing — must still be stripped
+              { id: "nonexistent-sid", type: "organization" },
+            ],
+          },
+        ],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.upserted).toBe(1);
+
+      // Row written should still contain the stableId ref, with only the
+      // unresolved one stripped.
+      const row = entitiesStore.get("aB1cD2eF3g");
+      expect(row).toBeDefined();
+      const related = JSON.parse(row!.related_entries as string);
+      expect(related).toEqual([
+        { id: "hI4jK5lM6n", type: "organization" },
+      ]);
+    });
+
     it("strips dangling relatedEntries instead of rejecting", async () => {
       const res = await postJson(app, "/api/entities/sync", {
         entities: [

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -893,7 +893,15 @@ const entitiesApp = new Hono()
       ),
     ];
     if (relatedIds.length > 0) {
-      const missing = await checkRefsExist(db, entities, entities.id, relatedIds);
+      // relatedEntries refs may be either slugs (entities.id) or stableIds
+      // (entities.stable_id). Check both columns — a ref is only "missing" if
+      // it resolves to neither. Checking only entities.id was QUA-519: all
+      // stableId-based refs were silently stripped from PG.
+      const missingBySlug = await checkRefsExist(db, entities, entities.id, relatedIds);
+      const missing =
+        missingBySlug.length > 0
+          ? await checkRefsExist(db, entities, entities.stableId, missingBySlug)
+          : [];
       if (missing.length > 0) {
         const missingSet = new Set(missing);
         // Strip invalid references instead of rejecting the batch


### PR DESCRIPTION
## Summary

Fix QUA-519 / QUA-510 Finding #1: `relatedEntries` sync ref-check only queried `entities.id` (slug column), so every stableId-based ref was treated as "missing" and silently stripped. 481 entities had populated `relatedEntries` in YAML and `[]` in PG.

## Fix

`apps/wiki-server/src/routes/tablebase/entities.ts` — after the slug check, any refs still missing are re-checked against `entities.stable_id`. A ref is only stripped if it resolves to neither column.

```ts
const missingBySlug = await checkRefsExist(db, entities, entities.id, relatedIds);
const missing = missingBySlug.length > 0
  ? await checkRefsExist(db, entities, entities.stableId, missingBySlug)
  : [];
```

## Test

- Added a regression test in `apps/wiki-server/src/__tests__/entities.test.ts` that seeds an entity and references it by stableId, expecting the ref to survive. **Verified it fails against the pre-fix code** and passes after.
- Tightened the test mock's ref-check dispatcher to respect the column being queried. The previous dispatcher was column-agnostic (checked both stores regardless of which column the SQL targeted), which hid this bug from tests.

## Scope of data loss today

481 entities have been running with incorrect `relatedEntries` in PG. YAML-driven pipelines mask the bug because they read directly from YAML. Any consumer reading `relatedEntries` from PG today is seeing empty/partial data. Once this lands, next full sync run restores correct data in PG; no backfill script required.

## Test plan
- [x] `pnpm crux w validate gate --scope=code` — green
- [x] `apps/wiki-server` vitest — 55/55 passing
- [x] Regression test verified to fail without the fix

Fixes QUA-519
Closes QUA-519
