### PR TITLE
feat(entities): add GET /api/entities/export bulk endpoint (QUA-522)

### DIFF
--- a/apps/wiki-server/src/__tests__/entities.test.ts
+++ b/apps/wiki-server/src/__tests__/entities.test.ts
@@ -643,28 +643,28 @@ describe("Entities API", () => {
   // ---- Export ----
 
   describe("GET /api/entities/export", () => {
-    it("returns full entity shape for all entities", async () => {
+    it("returns full entity shape including JSONB fields with values", async () => {
       await seedEntity(app, "anthropic", "Anthropic", {
         entityType: "organization",
         description: "AI safety company",
-      });
-      await seedEntity(app, "deceptive-alignment", "Deceptive Alignment", {
-        entityType: "risk",
+        tags: ["ai", "safety"],
+        customFields: [{ label: "hq", value: "San Francisco" }],
+        metadata: { founded: "2021" },
       });
 
       const res = await app.request("/api/entities/export");
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.total).toBe(2);
-      expect(body.returned).toBe(2);
-      expect(body.entities).toHaveLength(2);
-      // Full shape: metadata, relatedEntries, customFields present
-      const anthropic = body.entities.find((e: { id: string }) => e.id === "anthropic");
-      expect(anthropic).toBeDefined();
-      expect(anthropic).toHaveProperty("metadata");
-      expect(anthropic).toHaveProperty("relatedEntries");
-      expect(anthropic).toHaveProperty("customFields");
-      expect(anthropic.description).toBe("AI safety company");
+      expect(body.entities).toHaveLength(1);
+      const entity = body.entities[0];
+      expect(entity.id).toBe("anthropic");
+      expect(entity.description).toBe("AI safety company");
+      expect(entity.tags).toEqual(["ai", "safety"]);
+      expect(entity.customFields).toEqual([{ label: "hq", value: "San Francisco" }]);
+      expect(entity.metadata).toMatchObject({ founded: "2021" });
+      expect(entity).toHaveProperty("syncedAt");
+      expect(entity).toHaveProperty("createdAt");
+      expect(entity).toHaveProperty("updatedAt");
     });
 
     it("filters by entityType", async () => {
@@ -699,6 +699,16 @@ describe("Entities API", () => {
       // Ordered by id ascending → offset=1 skips "a-ent"
       expect(body.entities[0].id).toBe("b-ent");
       expect(body.entities[1].id).toBe("c-ent");
+    });
+
+    it("accepts valid ISO-8601 updatedSince", async () => {
+      const res = await app.request(
+        `/api/entities/export?updatedSince=${new Date().toISOString()}`
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty("entities");
+      expect(body).toHaveProperty("total");
     });
 
     it("rejects invalid updatedSince", async () => {

--- a/apps/wiki-server/src/__tests__/entities.test.ts
+++ b/apps/wiki-server/src/__tests__/entities.test.ts
@@ -640,6 +640,100 @@ describe("Entities API", () => {
     });
   });
 
+  // ---- Export ----
+
+  describe("GET /api/entities/export", () => {
+    it("returns full entity shape for all entities", async () => {
+      await seedEntity(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+        description: "AI safety company",
+      });
+      await seedEntity(app, "deceptive-alignment", "Deceptive Alignment", {
+        entityType: "risk",
+      });
+
+      const res = await app.request("/api/entities/export");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(2);
+      expect(body.returned).toBe(2);
+      expect(body.entities).toHaveLength(2);
+      // Full shape: metadata, relatedEntries, customFields present
+      const anthropic = body.entities.find((e: { id: string }) => e.id === "anthropic");
+      expect(anthropic).toBeDefined();
+      expect(anthropic).toHaveProperty("metadata");
+      expect(anthropic).toHaveProperty("relatedEntries");
+      expect(anthropic).toHaveProperty("customFields");
+      expect(anthropic.description).toBe("AI safety company");
+    });
+
+    it("filters by entityType", async () => {
+      await seedEntity(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+      });
+      await seedEntity(app, "deceptive-alignment", "Deceptive Alignment", {
+        entityType: "risk",
+      });
+
+      const res = await app.request("/api/entities/export?entityType=organization");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(1);
+      expect(body.entities).toHaveLength(1);
+      expect(body.entities[0].id).toBe("anthropic");
+    });
+
+    it("supports pagination via limit and offset", async () => {
+      await seedEntity(app, "a-ent", "A");
+      await seedEntity(app, "b-ent", "B");
+      await seedEntity(app, "c-ent", "C");
+
+      const res = await app.request("/api/entities/export?limit=2&offset=1");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(3);
+      expect(body.returned).toBe(2);
+      expect(body.limit).toBe(2);
+      expect(body.offset).toBe(1);
+      expect(body.entities).toHaveLength(2);
+      // Ordered by id ascending → offset=1 skips "a-ent"
+      expect(body.entities[0].id).toBe("b-ent");
+      expect(body.entities[1].id).toBe("c-ent");
+    });
+
+    it("rejects invalid updatedSince", async () => {
+      const res = await app.request("/api/entities/export?updatedSince=not-a-date");
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects limit above the export cap", async () => {
+      const res = await app.request("/api/entities/export?limit=999999");
+      expect(res.status).toBe(400);
+    });
+
+    it("does not collide with GET /:id for the literal 'export' slug", async () => {
+      // Regression: route ordering must define /export before /:id, otherwise
+      // /export would match /:id with id="export" and return 404.
+      const res = await app.request("/api/entities/export");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty("entities");
+      expect(body).toHaveProperty("total");
+    });
+
+    it("returns an empty result with total 0 when no entities match", async () => {
+      await seedEntity(app, "anthropic", "Anthropic", {
+        entityType: "organization",
+      });
+      const res = await app.request("/api/entities/export?entityType=risk");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(0);
+      expect(body.returned).toBe(0);
+      expect(body.entities).toEqual([]);
+    });
+  });
+
   // ---- Sync with JSONB fields ----
 
   describe("JSONB fields", () => {

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and, count, asc, sql, ilike, or, inArray, notInArray } from "drizzle-orm";
+import { eq, and, count, asc, sql, ilike, or, inArray, notInArray, gte } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { logger } from "../../logger.js";
@@ -52,6 +52,14 @@ import {
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 500;
+
+/**
+ * Maximum rows returned by GET /export in a single response.
+ * Mirrors EXPORT_MAX_LIMIT in routes/factbase/facts.ts. Callers that need
+ * more than this should paginate via `limit` + `offset` until `total` is
+ * exhausted.
+ */
+const EXPORT_MAX_LIMIT = 5000;
 
 /** Maximum number of entities returned by the /directory endpoint. */
 const DIRECTORY_MAX_ENTITIES = 2000;
@@ -807,6 +815,78 @@ const entitiesApp = new Hono()
 
     return c.json({ entities: items, total: items.length });
   })
+
+  // ---- GET /export ----
+  // Returns the full entity shape (including metadata, relatedEntries,
+  // customFields) for all entities in one response. Used by the PG-backed
+  // build pipeline (apps/web/scripts/build-data-from-pg.mjs) to replace the
+  // ~2,800 per-entity fetches it used to do via GET /:id.
+  //
+  // Mirrors the GET /api/facts/export pattern.
+  //
+  // Supports optional filters:
+  //   - entityType=<type>          Only entities of this type
+  //   - updatedSince=<ISO-8601>    Only entities updated at or after this time
+  //
+  // Supports pagination via `limit` (max EXPORT_MAX_LIMIT) and `offset`.
+  // Callers that need the full dataset should paginate until `returned` < limit
+  // or `offset + returned` >= `total`.
+  .get(
+    "/export",
+    zv(
+      "query",
+      z.object({
+        entityType: z.string().max(100).optional(),
+        updatedSince: z.string().datetime().optional(),
+        limit: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(EXPORT_MAX_LIMIT)
+          .default(EXPORT_MAX_LIMIT),
+        offset: z.coerce.number().int().min(0).default(0),
+      })
+    ),
+    async (c) => {
+      const { entityType, updatedSince, limit, offset } = c.req.valid("query");
+      const db = getDrizzleDb();
+
+      const conditions: SQL[] = [];
+      if (entityType) conditions.push(eq(entities.entityType, entityType));
+      if (updatedSince) {
+        conditions.push(gte(entities.updatedAt, new Date(updatedSince)));
+      }
+
+      const whereClause =
+        conditions.length === 0
+          ? undefined
+          : conditions.length === 1
+            ? conditions[0]
+            : and(...conditions);
+
+      const rows = await db
+        .select()
+        .from(entities)
+        .where(whereClause)
+        .orderBy(asc(entities.id))
+        .limit(limit)
+        .offset(offset);
+
+      const countResult = await db
+        .select({ count: count() })
+        .from(entities)
+        .where(whereClause);
+      const total = countResult[0].count;
+
+      return c.json({
+        entities: rows.map(formatEntity),
+        total,
+        returned: rows.length,
+        limit,
+        offset,
+      });
+    }
+  )
 
   // ---- GET /:id ----
 

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -55,9 +55,9 @@ const MAX_PAGE_SIZE = 500;
 
 /**
  * Maximum rows returned by GET /export in a single response.
- * Mirrors EXPORT_MAX_LIMIT in routes/factbase/facts.ts. Callers that need
- * more than this should paginate via `limit` + `offset` until `total` is
- * exhausted.
+ * Lower than facts.ts (50,000) because entities carry heavy JSONB columns
+ * (metadata, relatedEntries, customFields). Callers that need more should
+ * paginate via `limit` + `offset` until `total` is exhausted.
  */
 const EXPORT_MAX_LIMIT = 5000;
 

--- a/crux/lib/wiki-server/entities.ts
+++ b/crux/lib/wiki-server/entities.ts
@@ -35,6 +35,9 @@ export type EntitySearchResult = InferResponseType<RpcClient['search']['$get'], 
 /** Response type for GET /api/entities/stats (inferred from server). */
 export type EntityStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
 
+/** Response type for GET /api/entities/export (inferred from server). */
+export type EntityExportResult = InferResponseType<RpcClient['export']['$get'], 200>;
+
 // ---------------------------------------------------------------------------
 // Types — input (derived from server Zod schemas)
 // ---------------------------------------------------------------------------
@@ -122,4 +125,30 @@ export async function searchEntities(
 
 export async function getEntityStats(): Promise<ApiResult<EntityStatsResult>> {
   return apiRequest<EntityStatsResult>('GET', '/api/entities/stats');
+}
+
+/**
+ * Bulk export entities with their full shape (metadata, relatedEntries,
+ * customFields). Used by the PG-backed build pipeline to replace the
+ * per-entity `GET /:id` fetch pattern.
+ *
+ * Pass `limit` + `offset` to paginate; the server caps `limit` at its
+ * EXPORT_MAX_LIMIT (see routes/tablebase/entities.ts).
+ */
+export async function exportEntities(
+  opts: {
+    limit?: number;
+    offset?: number;
+    entityType?: string;
+    updatedSince?: string;
+  } = {},
+): Promise<ApiResult<EntityExportResult>> {
+  const params = new URLSearchParams();
+  if (opts.limit != null) params.set('limit', String(opts.limit));
+  if (opts.offset != null) params.set('offset', String(opts.offset));
+  if (opts.entityType) params.set('entityType', opts.entityType);
+  if (opts.updatedSince) params.set('updatedSince', opts.updatedSince);
+  const qs = params.toString();
+  const path = `/api/entities/export${qs ? `?${qs}` : ''}`;
+  return apiRequest<EntityExportResult>('GET', path);
 }


### PR DESCRIPTION
## Summary

Adds a bulk-export endpoint at `GET /api/entities/export` that returns the full entity shape (including `metadata`, `relatedEntries`, `customFields`) in a single paginated response. Replaces the ~2,800 per-entity fetch pattern used by `apps/web/scripts/build-data-from-pg.mjs`.

Mirrors the existing `GET /api/facts/export` pattern.

Fixes QUA-522

## Key changes

- `apps/wiki-server/src/routes/tablebase/entities.ts` — new `GET /export` handler, registered before `/:id` to avoid route collision with the literal slug `"export"`. Supports `entityType` and `updatedSince` query filters plus `limit`/`offset` pagination (capped at 5,000 — lower than facts.ts because entities carry heavy JSONB columns).
- `crux/lib/wiki-server/entities.ts` — adds `exportEntities()` client helper and `EntityExportResult` response type (inferred from the route via Hono RPC).
- `apps/wiki-server/src/__tests__/entities.test.ts` — 7 new tests covering: full-shape round-trip (tags, customFields, metadata), `entityType` filter, pagination, `updatedSince` validation, limit cap, route-ordering regression, and empty-result case.

## Test plan

- [x] Unit tests for the route (`pnpm vitest run src/__tests__/entities.test.ts` — 63 pass)
- [x] Route ordering regression test (`/export` doesn't collide with `/:id`)
- [x] JSONB round-trip test with specific field values
- [x] Zod validation covers bad `updatedSince` and oversized `limit`
- [x] Gate check passes (`pnpm crux w validate gate --fix` — 53 checks)
- [x] `pnpm build` exits 0
- [x] TypeScript type check passes for `wiki-server` and `crux`

## Perf note

The acceptance criterion asks for <5s on 2,800 entities against prod. Once this is deployed, `build-data-from-pg.mjs` should be updated to call `exportEntities()` once (with pagination) instead of the current per-slug fetch loop. That update is left to the Phase 3 cutover PR per the ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Entity Export API**: Added new entity export endpoint with optional filtering by entity type and modification date
* **Pagination Support**: Configurable limit (maximum 5,000 rows) and offset parameters for export results
* **Date Filtering**: ISO-8601 format validation for date-based filters with appropriate error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->