### PR TITLE
feat(crux): add --parent and --project flags to linear create

### DIFF
--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -13,6 +13,7 @@ const {
   updateIssueStateMock,
   commentOnIssueMock,
   searchIssuesMock,
+  createIssueMock,
   fetchRemoteWorkflowStatesMock,
   listProjectsMock,
   getProjectMock,
@@ -26,6 +27,7 @@ const {
   updateIssueStateMock: vi.fn(),
   commentOnIssueMock: vi.fn(),
   searchIssuesMock: vi.fn(),
+  createIssueMock: vi.fn(),
   fetchRemoteWorkflowStatesMock: vi.fn(),
   listProjectsMock: vi.fn(),
   getProjectMock: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock('../../lib/linear/issues.ts', () => ({
   updateIssueState: updateIssueStateMock,
   commentOnIssue: commentOnIssueMock,
   searchIssues: searchIssuesMock,
+  createIssue: createIssueMock,
 }));
 
 vi.mock('../../lib/linear/projects.ts', () => ({
@@ -204,6 +207,105 @@ describe('linear search', () => {
     expect(r.output).toContain('QUA-1');
     expect(r.output).toContain('A title');
     expect(r.output).toContain('high'); // priority 2 = high
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('linear create', () => {
+  const createdIssue = {
+    identifier: 'QUA-999',
+    url: 'https://linear.app/quantifieduncertainty/issue/QUA-999',
+  };
+
+  beforeEach(() => {
+    createIssueMock.mockResolvedValue(createdIssue);
+  });
+
+  it('prints usage when no title is given', async () => {
+    const r = await commands.create([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('creates an issue with just a title', async () => {
+    const r = await commands.create(['My', 'ticket'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(createIssueMock).toHaveBeenCalledWith({
+      title: 'My ticket',
+      description: '',
+      priority: undefined,
+      parentId: undefined,
+      projectId: undefined,
+    });
+    expect(r.output).toContain('QUA-999');
+  });
+
+  it('resolves --parent QUA-NNN to the parent UUID', async () => {
+    getIssueMock.mockResolvedValueOnce({ ...mockIssue, id: 'parent-uuid', title: 'Epic' });
+    const r = await commands.create(['Child ticket'], { ci: true, parent: 'QUA-184' });
+    expect(r.exitCode).toBe(0);
+    expect(getIssueMock).toHaveBeenCalledWith('QUA-184');
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ parentId: 'parent-uuid' }),
+    );
+    expect(r.output).toContain('parent:');
+    expect(r.output).toContain('QUA-184');
+  });
+
+  it('fails cleanly when --parent issue does not exist', async () => {
+    getIssueMock.mockResolvedValueOnce(null);
+    const r = await commands.create(['Child'], { ci: true, parent: 'QUA-9999' });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Parent issue not found');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves --project name to the project UUID', async () => {
+    getProjectMock.mockResolvedValueOnce({
+      id: 'project-uuid',
+      name: 'Data Model Unwind',
+    });
+    const r = await commands.create(['Ticket'], {
+      ci: true,
+      project: 'Data Model Unwind',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(getProjectMock).toHaveBeenCalledWith('Data Model Unwind');
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'project-uuid' }),
+    );
+    expect(r.output).toContain('project:');
+    expect(r.output).toContain('Data Model Unwind');
+  });
+
+  it('fails cleanly when --project does not exist', async () => {
+    getProjectMock.mockResolvedValueOnce(null);
+    const r = await commands.create(['Ticket'], { ci: true, project: 'Nonexistent' });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Project not found');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('combines --parent, --project, and --priority in one call', async () => {
+    getIssueMock.mockResolvedValueOnce({ ...mockIssue, id: 'parent-uuid', title: 'Epic' });
+    getProjectMock.mockResolvedValueOnce({ id: 'project-uuid', name: 'Proj' });
+    const r = await commands.create(['Ticket'], {
+      ci: true,
+      parent: 'QUA-408',
+      project: 'Proj',
+      priority: '2',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(createIssueMock).toHaveBeenCalledWith({
+      title: 'Ticket',
+      description: '',
+      priority: 2,
+      parentId: 'parent-uuid',
+      projectId: 'project-uuid',
+    });
   });
 });
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -64,6 +64,8 @@ interface CommandOptions extends BaseOptions {
   description?: string;
   descriptionFile?: string;
   priority?: string;
+  parent?: string;
+  project?: string;
   content?: string;
   contentFile?: string;
   name?: string;
@@ -426,7 +428,7 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   const title = args.filter((a) => !a.startsWith('--')).join(' ').trim();
   if (!title) {
     return {
-      output: `${c.red}Usage: crux linear create "Issue title" [--description="..."] [--description-file=<path>] [--priority=1-4]${c.reset}\n`,
+      output: `${c.red}Usage: crux linear create "Issue title" [--description="..."] [--description-file=<path>] [--priority=1-4] [--parent=QUA-NNN] [--project=<name|uuid>]${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -447,7 +449,37 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     }
   }
 
-  const result = await createIssue({ title, description, priority });
+  // Resolve parent issue (QUA-NNN → internal UUID)
+  let parentId: string | undefined;
+  let parentLabel: string | undefined;
+  if (options.parent) {
+    const parent = await getIssue(options.parent);
+    if (!parent) {
+      return {
+        output: `${c.red}Parent issue not found: ${options.parent}${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+    parentId = parent.id;
+    parentLabel = `${parent.identifier} — ${parent.title}`;
+  }
+
+  // Resolve project (UUID or case-insensitive exact name)
+  let projectId: string | undefined;
+  let projectLabel: string | undefined;
+  if (options.project) {
+    const project = await getProject(options.project);
+    if (!project) {
+      return {
+        output: `${c.red}Project not found: ${options.project}${c.reset}\n  Run ${c.cyan}crux linear project list${c.reset} to see available projects.\n`,
+        exitCode: 1,
+      };
+    }
+    projectId = project.id;
+    projectLabel = project.name;
+  }
+
+  const result = await createIssue({ title, description, priority, parentId, projectId });
 
   if (options.json) {
     return { output: JSON.stringify(result, null, 2) + '\n', exitCode: 0 };
@@ -455,6 +487,8 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
 
   let out = '';
   out += `${c.green}✓${c.reset} Created ${c.cyan}${result.identifier}${c.reset} — ${title}\n`;
+  if (parentLabel) out += `  ${c.dim}parent:${c.reset}  ${parentLabel}\n`;
+  if (projectLabel) out += `  ${c.dim}project:${c.reset} ${projectLabel}\n`;
   out += `  ${result.url}\n`;
   return { output: out, exitCode: 0 };
 }
@@ -986,6 +1020,8 @@ Options (create):
   --description=<text>       Issue description (inline)
   --description-file=<path>  Issue description from file (safe for multiline)
   --priority=N               Priority: 1=urgent, 2=high, 3=medium, 4=low (default: none)
+  --parent=QUA-NNN           Parent issue (sets the child link to an epic)
+  --project=<name|uuid>      Project (UUID or case-insensitive exact name)
 
 Options (comment):
   --body-file=<path>  Comment body from file (safe for multiline / escaped content)
@@ -1017,6 +1053,7 @@ Options (project update):
 Examples:
   crux linear create "Broken login page" --description="The login form crashes on submit"
   crux linear create "Add retry logic" --description-file=/tmp/desc.md --priority=3
+  crux linear create "Migrate X" --parent=QUA-408 --project="Data Model Unwind" --priority=2
   crux linear view QUA-184
   crux linear search "agent checklist"
   crux linear start QUA-184


### PR DESCRIPTION
## Summary

`crux linear create` only accepted title/description/priority — the lib-level `createIssue()` already supported `parentId`/`projectId` but the CLI wrapper never exposed them. Agents filing new tickets off an epic had to set parent and project in the Linear UI afterward; easy to miss, which is how QUA-536 (created earlier today) ended up orphaned from QUA-408 / Data Model Unwind.

### Changes

- `--parent=QUA-NNN` — resolves the identifier via `getIssue()` and passes the internal UUID as `parentId`.
- `--project=<name|uuid>` — resolves via `getProject()` (UUID or exact case-insensitive name match) and passes as `projectId`.
- Both fail cleanly (non-zero exit, no issue created) when the parent/project doesn't exist. The success output now shows `parent:` and `project:` summary lines when set.
- `--help`, Usage string, and the Examples section updated.

### Tests

7 new tests in `crux/commands/__tests__/linear.test.ts`:
- title-only path still works
- `--parent` happy path + missing-parent error
- `--project` happy path + missing-project error
- combined `--parent` + `--project` + `--priority` passes all three through

All 60 `linear.test.ts` tests pass; full Linear test surface (203 tests across 8 files) green.

## Test plan

- [x] All 203 Linear unit tests pass locally (`pnpm test -- crux/commands/__tests__/linear.test.ts crux/lib/linear`)
- [x] `pnpm crux linear create --help` shows the new flags and example
- [x] `pnpm crux linear create` (no title) prints the updated Usage string
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `crux linear create` command with `--parent` option to link new issues to parent issues
  * Added `--project` option to assign created issues to specific projects
  * Added validation with informative error messages for invalid parent issue or project references

* **Tests**
  * Added comprehensive test coverage for new parent and project linking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->