### PR TITLE
de-emphasize claims pipeline widget on org data pages

### DIFF
--- a/apps/web/src/app/organizations/[slug]/data/org-data-body.tsx
+++ b/apps/web/src/app/organizations/[slug]/data/org-data-body.tsx
@@ -3,10 +3,6 @@ import { EntityDbPage } from "@/components/directory/EntityDbPage";
 import { DataViewTabs } from "@/components/directory/DataViewTabs";
 import { ClaimsPipelineSummary } from "@/components/entity/claims-pipeline-summary";
 
-/**
- * Body content for the organization data page.
- * Renders the Claims Pipeline summary + Structured Facts / Database Records tabs.
- */
 export function OrgDataBody({ slug }: { slug: string }) {
   const structuredContent = <FactBaseEntityBody entityId={slug} skipVerdicts />;
   const databaseContent = (
@@ -20,11 +16,11 @@ export function OrgDataBody({ slug }: { slug: string }) {
 
   return (
     <div className="space-y-6">
-      <ClaimsPipelineSummary entityId={slug} />
       <DataViewTabs
         structuredContent={structuredContent}
         databaseContent={databaseContent}
       />
+      <ClaimsPipelineSummary entityId={slug} />
     </div>
   );
 }

--- a/apps/web/src/components/entity/claims-pipeline-summary.tsx
+++ b/apps/web/src/components/entity/claims-pipeline-summary.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { ArrowRight, Loader2, ExternalLink } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { ExternalLink } from "lucide-react";
 
 interface PipelineData {
   entityId: string;
@@ -20,142 +19,39 @@ interface PipelineData {
   }>;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  verified: "bg-emerald-500",
-  contradicted: "bg-red-500",
-  unverifiable: "bg-gray-400",
-  pending: "bg-blue-400",
-  verifying: "bg-amber-400",
-  expired: "bg-orange-400",
-};
-
-function StatusBar({ claims }: { claims: Array<{ status: string }> }) {
-  if (claims.length === 0) return null;
-
-  const counts: Record<string, number> = {};
-  for (const c of claims) {
-    counts[c.status] = (counts[c.status] ?? 0) + 1;
-  }
-
-  return (
-    <div className="flex h-2 rounded-full overflow-hidden w-full" title="Claim status distribution">
-      {Object.entries(counts).map(([status, count]) => (
-        <div
-          key={status}
-          className={cn("h-full", STATUS_COLORS[status] ?? "bg-gray-300")}
-          style={{ width: `${(count / claims.length) * 100}%` }}
-          title={`${status}: ${count}`}
-        />
-      ))}
-    </div>
-  );
-}
-
-function PipelineStep({ label, value, sub }: { label: string; value: number; sub?: string }) {
-  return (
-    <div className="flex flex-col items-center text-center min-w-[80px]">
-      <div className="text-2xl font-bold tabular-nums">{value}</div>
-      <div className="text-xs text-muted-foreground font-medium">{label}</div>
-      {sub && <div className="text-[10px] text-muted-foreground">{sub}</div>}
-    </div>
-  );
-}
-
-function PipelineArrow() {
-  return (
-    <div className="flex items-center px-2 text-muted-foreground">
-      <ArrowRight className="h-4 w-4" />
-    </div>
-  );
-}
-
 export function ClaimsPipelineSummary({ entityId }: { entityId: string }) {
   const [data, setData] = useState<PipelineData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
       try {
         const res = await fetch(`/api/claims-by-entity-proxy?entity_id=${encodeURIComponent(entityId)}&limit=200`);
-        if (!res.ok) {
-          if (res.status === 503) {
-            // Wiki server not configured — don't show error
-            setData(null);
-            return;
-          }
-          throw new Error(`HTTP ${res.status}`);
-        }
+        if (!res.ok) return;
         setData(await res.json());
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      } finally {
-        setIsLoading(false);
+      } catch {
+        // silent — this is a muted footer badge
       }
     })();
   }, [entityId]);
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" /> Loading pipeline data...
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-xs text-muted-foreground py-2">
-        Claims pipeline unavailable
-      </div>
-    );
-  }
-
-  if (!data || data.total === 0) {
-    return null; // Don't render anything if no claims
-  }
+  if (!data || data.total === 0) return null;
 
   const uniqueSources = new Set(data.claims.map((c) => c.resourceId ?? c.sourceUrl)).size;
   const verified = data.claims.filter((c) => c.status === "verified").length;
   const linkedRecords = new Set(data.recordLinks.map((r) => `${r.recordType}:${r.recordId}`)).size;
 
   return (
-    <div className="rounded-lg border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold">Claims Pipeline</h3>
-        <a
-          href="/wiki/E2200"
-          className="text-xs text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
-        >
-          Source Checks <ExternalLink className="h-3 w-3" />
-        </a>
-      </div>
-
-      {/* Pipeline flow */}
-      <div className="flex items-center justify-center gap-1">
-        <PipelineStep label="Sources" value={uniqueSources} />
-        <PipelineArrow />
-        <PipelineStep label="Claims" value={data.total} sub={`${verified} verified`} />
-        <PipelineArrow />
-        <PipelineStep label="Records" value={linkedRecords} sub="linked" />
-      </div>
-
-      {/* Status bar */}
-      <StatusBar claims={data.claims} />
-
-      {/* Legend */}
-      <div className="flex flex-wrap gap-x-3 gap-y-1 justify-center">
-        {Object.entries(STATUS_COLORS).map(([status, color]) => {
-          const count = data.claims.filter((c) => c.status === status).length;
-          if (count === 0) return null;
-          return (
-            <div key={status} className="flex items-center gap-1 text-[10px] text-muted-foreground">
-              <div className={cn("h-2 w-2 rounded-full", color)} />
-              {status} ({count})
-            </div>
-          );
-        })}
-      </div>
+    <div className="text-xs text-muted-foreground py-2 border-t flex flex-wrap items-center gap-x-2">
+      <span className="font-medium">Source-check proposals:</span>
+      <span>
+        {data.total} from {uniqueSources} source{uniqueSources === 1 ? "" : "s"} · {verified} verified · {linkedRecords} linked to records
+      </span>
+      <a
+        href="/wiki/E2200"
+        className="text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
+      >
+        Source Checks <ExternalLink className="h-3 w-3" />
+      </a>
     </div>
   );
 }

--- a/apps/web/src/components/entity/claims-pipeline-summary.tsx
+++ b/apps/web/src/components/entity/claims-pipeline-summary.tsx
@@ -23,15 +23,29 @@ export function ClaimsPipelineSummary({ entityId }: { entityId: string }) {
   const [data, setData] = useState<PipelineData | null>(null);
 
   useEffect(() => {
+    setData(null);
+    const ac = new AbortController();
     (async () => {
       try {
-        const res = await fetch(`/api/claims-by-entity-proxy?entity_id=${encodeURIComponent(entityId)}&limit=200`);
-        if (!res.ok) return;
+        const res = await fetch(
+          `/api/claims-by-entity-proxy?entity_id=${encodeURIComponent(entityId)}&limit=200`,
+          { signal: ac.signal },
+        );
+        if (!res.ok) {
+          if (res.status !== 503) {
+            // 503 = wiki-server not configured (expected in some envs).
+            // Surface other failures so regressions aren't hidden by the muted UI.
+            console.warn(`ClaimsPipelineSummary: HTTP ${res.status} for ${entityId}`);
+          }
+          return;
+        }
         setData(await res.json());
-      } catch {
-        // silent — this is a muted footer badge
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        console.warn(`ClaimsPipelineSummary fetch failed for ${entityId}:`, e);
       }
     })();
+    return () => ac.abort();
   }, [entityId]);
 
   if (!data || data.total === 0) return null;


### PR DESCRIPTION
## Summary

The "Claims Pipeline" widget on `/organizations/<slug>/data` counts rows in the `proposed_claims` table (the source-check sourcing pipeline), **not** FactBase facts or TableBase records about the entity. For most orgs this means it headlines a very small number — e.g. Anthropic: `2 sources → 3 claims → 0 records linked` — while the page actually contains dozens of facts and hundreds of structured records. That reads as "Anthropic only has 3 claims," which is misleading.

### What changes

- **Relabel** `"Claims Pipeline"` → `"Source-check proposals"`, so the number is no longer conflated with claims *about* the entity.
- **Shrink** the large pipeline diagram + status bar + colored-dot legend into a single muted footer line: `Source-check proposals: 3 from 2 sources · 1 verified · 0 linked to records · Source Checks →`.
- **Move** the widget from above the Structured Facts / Database Records tabs to **below** them, so it no longer dominates the page layout.

### Review fixes (included in this PR)

Fixes from `/agent-review-pr`:
- Non-OK HTTP responses were being silently swallowed, hiding real regressions. Now `console.warn`s for any non-503 status and any non-Abort catch.
- Stale data from a previous `entityId` could briefly render on client-side nav. Reset to `null` on effect entry.
- Added `AbortController` cleanup so a late in-flight fetch can't overwrite newer data.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm crux w validate gate --fix` — 49/49 pass (3 advisory warnings unrelated)
- [x] Type check (all three tsconfigs)
- [x] `pnpm test` — only failing tests are pre-existing resource-snapshot data-quality checks on main (unrelated)
- [ ] Visual spot-check on staging/prod after deploy: `/organizations/anthropic/data`, `/organizations/openai/data` — verify the footer shows below the tabs and the old big pipeline box is gone
