### PR TITLE
fix(sourcing): catch JSON parse errors per-item in batch result processing

### DIFF
--- a/crux/lib/sourcing/orchestrator.ts
+++ b/crux/lib/sourcing/orchestrator.ts
@@ -495,7 +495,17 @@ async function runBatchExecution(
       }
 
       // Parse LLM response with shared Zod schema (same validation as real-time path)
-      const raw = parseJsonResponse(text);
+      let raw: unknown;
+      try {
+        raw = parseJsonResponse(text);
+      } catch (e) {
+        summary.errors++;
+        summary.failures.push({
+          itemId: item.id, kind: item.kind, description: item.description,
+          error: `JSON parse failed: ${e instanceof Error ? e.message : String(e)}`,
+        });
+        continue;
+      }
       const parsed = LlmResponseSchema.safeParse(raw);
       if (!parsed.success) {
         summary.errors++;


### PR DESCRIPTION
## Summary
- `parseJsonResponse()` in the batch result processing loop was unhandled — one malformed LLM response crashed the entire batch run, losing all remaining items in the chunk and preventing subsequent chunks
- Discovered during the QUA-548 one-shot source-check backfill: chunk 1 (500 items) succeeded, then the result-processing crash prevented chunk 2 (290 items) from ever running
- Fix: wrap in try-catch per-item (same pattern as the Zod validation 3 lines below), record as a per-item error, continue processing

## Test plan
- [x] Ran 282-item batch after fix: 281 verified, 1 JSON parse error caught gracefully, process completed
- [x] No type errors introduced (`npx tsc --noEmit`)

Fixes a crash found during QUA-548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch execution robustness by enhancing error handling for parsing failures. The system now logs individual item errors and continues processing remaining items instead of aborting the entire batch operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->