### PR TITLE
fix(validate): tolerate legacy manifest shapes in sourcing-coverage (QUA-401)

### DIFF
--- a/crux/validate/validate-sourcing-coverage.test.ts
+++ b/crux/validate/validate-sourcing-coverage.test.ts
@@ -210,6 +210,48 @@ describe('validate-sourcing-coverage', () => {
     expect(result.output).toContain('grants');
   });
 
+  it('accepts legacy verificationSummary shape from pre-2026-04-07 manifests (QUA-401)', () => {
+    // Pre-rename manifests stored the same data under `verificationSummary` with
+    // `withVerification`/`withoutVerification` keys. Must not emit a fatal error.
+    createManifest('test-legacy-verificationSummary.json', {
+      table: 'investments',
+      recordCount: 2,
+      submittedAt: '2026-04-03T00:00:00Z',
+      verificationSummary: {
+        withVerification: 2,
+        withoutVerification: 0,
+        verdicts: { verified: 2, contradicted: 0, unverifiable: 0, other: 0 },
+      },
+      records: [],
+    });
+
+    const result = runValidator('--enforcement=advisory');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).not.toContain('missing sourcingSummary');
+    expect(result.output).toContain('All TableBase submissions have sourcing');
+  });
+
+  it('does not crash on legacy manifests missing the verdicts field (QUA-401)', () => {
+    // Legacy manifests (pre-2026-04) omit sourcingSummary.verdicts.
+    // The validator must treat missing as zero rather than throwing TypeError.
+    createManifest('test-legacy-no-verdicts.json', {
+      table: 'investments',
+      recordCount: 3,
+      submittedAt: '2026-03-01T00:00:00Z',
+      sourcingSummary: {
+        withSourcing: 3,
+        withoutSourcing: 0,
+        // NOTE: no `verdicts` field — matches pre-2026-04 manifest shape
+      },
+      records: [],
+    });
+
+    const result = runValidator('--enforcement=soft');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('All TableBase submissions have sourcing');
+    expect(result.output).not.toContain('Cannot read properties of undefined');
+  });
+
   it('allows personnel manifests when all records have sourcing', () => {
     createManifest('test-hard-ok.json', {
       table: 'personnel',

--- a/crux/validate/validate-sourcing-coverage.ts
+++ b/crux/validate/validate-sourcing-coverage.ts
@@ -50,7 +50,8 @@ const enforcement: 'advisory' | 'soft' | 'hard' = (
 interface SourcingSummary {
   withSourcing: number;
   withoutSourcing: number;
-  verdicts: {
+  // Optional because legacy manifests (pre-2026-04) lack this field.
+  verdicts?: {
     verified: number;
     contradicted: number;
     unverifiable: number;
@@ -62,8 +63,30 @@ interface Manifest {
   table: string;
   recordCount: number;
   submittedAt: string;
-  sourcingSummary: SourcingSummary;
+  sourcingSummary?: SourcingSummary;
+  // Legacy (pre-2026-04-07): field was renamed from verificationSummary.
+  verificationSummary?: {
+    withVerification?: number;
+    withoutVerification?: number;
+    verdicts?: SourcingSummary['verdicts'];
+  };
   records: Array<Record<string, unknown>>;
+}
+
+/**
+ * Normalize legacy manifests: pre-2026-04-07 manifests stored the same data
+ * under `verificationSummary` with `withVerification`/`withoutVerification`
+ * keys. Treat them as equivalent to today's `sourcingSummary` shape.
+ */
+function normalizeSummary(manifest: Manifest): SourcingSummary | undefined {
+  if (manifest.sourcingSummary) return manifest.sourcingSummary;
+  const legacy = manifest.verificationSummary;
+  if (!legacy) return undefined;
+  return {
+    withSourcing: legacy.withVerification ?? 0,
+    withoutSourcing: legacy.withoutVerification ?? 0,
+    verdicts: legacy.verdicts,
+  };
 }
 
 function main() {
@@ -94,7 +117,8 @@ function main() {
       continue;
     }
 
-    const { table, recordCount, sourcingSummary } = manifest;
+    const { table, recordCount } = manifest;
+    const sourcingSummary = normalizeSummary(manifest);
 
     if (!sourcingSummary || typeof recordCount !== 'number') {
       fatalErrors.push(`${file}: missing sourcingSummary or recordCount`);
@@ -114,9 +138,12 @@ function main() {
       }
     }
 
-    if (sourcingSummary.verdicts.contradicted > 0) {
+    // Legacy manifests (pre-2026-04) lack the `verdicts` field.
+    // Treat missing as zero rather than crashing.
+    const contradicted = sourcingSummary.verdicts?.contradicted ?? 0;
+    if (contradicted > 0) {
       warnings.push(
-        `${file}: ${sourcingSummary.verdicts.contradicted} ${table} records have CONTRADICTED verdicts`
+        `${file}: ${contradicted} ${table} records have CONTRADICTED verdicts`
       );
     }
   }


### PR DESCRIPTION
## Summary

Fix two shape-drift failures in `validate-sourcing-coverage.ts`:

1. **TypeError on undefined verdicts** (the originally-reported crash): `2026-04-12-far-ai-personnel.json` has `sourcingSummary` but no `verdicts` subfield (it uses `forceSkipSourceCheck`). Line 117 now uses `verdicts?.contradicted ?? 0`.

2. **Legacy `verificationSummary` name**: ~18 pre-2026-04-07 manifests use the old field name (renamed in commit 5f6788d6d). Previously these produced `"missing sourcingSummary or recordCount"` fatal errors that blocked exit. Now normalized to `SourcingSummary` shape via a small helper.

The `sourcing-coverage` gate step is `advisory: true` so the crash didn't actually block CI, but it produced noise and a stack trace on every gate run. With both shapes normalized, the validator now cleanly processes all 48 existing manifests.

## Test plan

- [x] `pnpm vitest run crux/validate/validate-sourcing-coverage.test.ts` — 11/11 passing (2 new regression tests)
- [x] `npx tsx crux/validate/validate-sourcing-coverage.ts --enforcement=advisory` runs to completion against real manifests (no TypeError, no fatal errors on legacy shapes)
- [x] No new TypeScript errors introduced

Fixes QUA-401
