### PR TITLE
QUA-536 Phase A: populate NULL resources.stable_id + NOT NULL

### DIFF
--- a/apps/wiki-server/drizzle/0184_qua_536_populate_resources_stable_id.sql
+++ b/apps/wiki-server/drizzle/0184_qua_536_populate_resources_stable_id.sql
@@ -1,0 +1,19 @@
+-- QUA-536 Phase A: populate NULL `resources.stable_id` + NOT NULL constraint.
+--
+-- This Drizzle entry is a no-op because the actual work is a multi-step
+-- transactional script that drops and re-adds FK constraints on `things.id`,
+-- generates random `sid_`-prefixed stable_ids for ~17,764 rows, and updates
+-- ~22,251 `things.id` values to match. It must be applied manually during
+-- the deploy:
+--
+--   psql "$DATABASE_MIGRATION_URL" -v ON_ERROR_STOP=1 \
+--     -f apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
+--
+-- The script is self-verifying (pre-conditions abort on mismatch; post-
+-- conditions confirm zero NULL rows, no bare10, format compliance, no
+-- stale things rows). See the script header for full details.
+--
+-- Unblocks QUA-492 Phase 1 closeout (CHECK constraints on resources.stable_id).
+-- Phase B (migrate 17 FK tables from resources.id → resources.stable_id) is
+-- tracked in QUA-549 and blocks on this migration.
+SELECT 1;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1289,6 +1289,13 @@
       "when": 1785312000000,
       "tag": "0183_qua_525_numeric_and_temporal_checks",
       "breakpoints": true
+    },
+    {
+      "idx": 184,
+      "version": "7",
+      "when": 1785398400000,
+      "tag": "0184_qua_536_populate_resources_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
+++ b/apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
@@ -160,8 +160,13 @@ END $$;
 
 -- ---------------------------------------------------------------------------
 -- 4. Populate NULL `resources.stable_id` with `sid_` + 10 random alphanumeric
---    characters. Alphabet matches the TS `generateId()` in
---    `packages/factbase/src/ids.ts:45` (A-Z, a-z, 0-9 — 62 chars).
+--    characters. Output matches the downstream invariant
+--    `^sid_[A-Za-z0-9]{10}$` that the TS `generateId()` in
+--    `packages/factbase/src/ids.ts:45` also produces. The distributions are
+--    NOT identical — TS starts from base64url then replaces '-'/'_' with
+--    lowercase-only, while this PG function samples uniformly from the
+--    full 62-char alphabet — but both are valid sids for all validators
+--    downstream.
 --
 --    The generator is a VOLATILE PL/pgSQL function so that `UPDATE` evaluates
 --    it once per row. A naive scalar subquery in SET would be folded to a
@@ -170,8 +175,9 @@ END $$;
 --    Collision handling: with 62^10 ≈ 8.4×10^17 possibilities and ~22,893
 --    total resource rows after this migration, birthday-paradox collision
 --    probability is ~10^-10. We still wrap the UPDATE in an EXCEPTION /
---    retry loop so a spurious collision re-generates affected rows rather
---    than aborting the whole transaction.
+--    retry loop — on `unique_violation`, the whole UPDATE rolls back and
+--    we re-generate stable_ids for ALL remaining NULL rows (not just the
+--    colliding subset, which PG doesn't expose). Bounded to 5 attempts.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION pg_temp.qua536_sid_gen() RETURNS text AS $$
@@ -306,12 +312,19 @@ BEGIN
     RAISE EXCEPTION 'QUA-536: % duplicate stable_id values after step 4', dup_count;
   END IF;
 
+  -- Two pathologies to catch:
+  -- (a) things rows with source_table='resources' whose id doesn't match the
+  --     matching resource's stable_id (the main thing we just aligned)
+  -- (b) orphan things rows with source_table='resources' whose source_id
+  --     doesn't correspond to any resources row — these would be missed by
+  --     the JOIN version below, so check with LEFT JOIN + IS NULL.
   SELECT count(*) INTO stale_things
   FROM things t
-  JOIN resources r ON r.id = t.source_id
-  WHERE t.source_table = 'resources' AND t.id <> r.stable_id;
+  LEFT JOIN resources r ON r.id = t.source_id
+  WHERE t.source_table = 'resources'
+    AND (r.id IS NULL OR t.id <> r.stable_id);
   IF stale_things <> 0 THEN
-    RAISE EXCEPTION 'QUA-536: % things rows still mismatch resources.stable_id after step 5',
+    RAISE EXCEPTION 'QUA-536: % things rows still mismatch or orphan resources.stable_id after step 5',
       stale_things;
   END IF;
 
@@ -352,7 +365,21 @@ DO $$
 DECLARE
   attempt int := 0;
   max_attempts int := 10;
+  late_null_count int;
 BEGIN
+  -- Between the main-txn COMMIT and this step, a concurrent writer could
+  -- theoretically INSERT a new resource row with NULL stable_id via any
+  -- INSERT path the application did not cover. All application-level INSERT
+  -- paths were audited and now always provide a stable_id (see
+  -- qua-536-migration.test.ts "INSERT path stable_id defaulting" suite), but
+  -- this guard gives a clear error if a miss was made — better than SET NOT
+  -- NULL failing halfway with a cryptic message.
+  SELECT count(*) INTO late_null_count FROM resources WHERE stable_id IS NULL;
+  IF late_null_count > 0 THEN
+    RAISE EXCEPTION 'QUA-536: % NULL stable_id rows appeared between main-txn COMMIT and SET NOT NULL — a concurrent writer is using an INSERT path that does not set stable_id. Investigate writers before retry.',
+      late_null_count;
+  END IF;
+
   LOOP
     attempt := attempt + 1;
     BEGIN

--- a/apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
+++ b/apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
@@ -1,0 +1,382 @@
+-- QUA-536 Phase A: populate NULL `resources.stable_id` + NOT NULL constraint.
+--
+-- Context: see Linear QUA-536 and the rescope comment for the enumeration
+-- audit. Pre-flight (2026-04-16) counted ~17,764 rows where `stable_id IS NULL`
+-- and ~4,769 rows where `resources.stable_id` is populated but `things.id` is
+-- still the stale hex16 `resources.id` (pre-existing drift from before QUA-503).
+-- This migration fixes both: it populates every NULL stable_id with a new
+-- `sid_<10>` and aligns every `things.id` for `source_table='resources'` to
+-- match the resource's canonical stable_id.
+--
+-- Usage (from a release session):
+--   psql "$DATABASE_MIGRATION_URL" -v ON_ERROR_STOP=1 \
+--     -f apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
+--
+-- Pre-conditions verified by the script:
+--   1. At least one NULL `resources.stable_id` row exists (else migration
+--      already applied or pre-flight snapshot is stale).
+--   2. Zero `^[A-Za-z0-9]{10}$` bare10 stable_ids (QUA-503 / migration 0182
+--      cleared these). If this fires, a bare10 row reappeared since QUA-503
+--      — halt and file a ticket.
+--   3. The test-probe row (`id='test-resource-probe'`) is present as expected.
+--
+-- Post-conditions verified at the end:
+--   1. Zero `resources.stable_id IS NULL` rows.
+--   2. Every `resources.stable_id` matches `^sid_[A-Za-z0-9]{10}$`.
+--   3. No duplicate `stable_id` values.
+--   4. Zero `things` rows where `source_table='resources'` AND `id != r.stable_id`.
+--
+-- DDL on `things`: this script drops and re-adds the FKs that reference
+-- `things.id`, matching the pattern from QUA-503 (migration 0182). PostgreSQL
+-- does not support PK updates when referenced rows exist and the FKs are not
+-- `ON UPDATE CASCADE`. We drop + UPDATE + re-add as `ON DELETE SET NULL`
+-- (matching the committed schema). The re-add uses `NOT VALID` + a separate
+-- `VALIDATE CONSTRAINT` so the AccessExclusive lock is held for milliseconds,
+-- not the time it takes to scan the `things` table — avoiding the QUA-302 /
+-- QUA-156 outage pattern where a long DDL deadlocked with the `things_search`
+-- MV refresh.
+--
+-- The `things_search` MV refresh runs outside the main transaction (after
+-- `COMMIT`) so the SELECT locks the refresh acquires on every base table do
+-- not compound with any other DDL contention.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '60s';
+SET LOCAL statement_timeout = '0';
+
+-- ---------------------------------------------------------------------------
+-- 1. Pre-conditions.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  null_count int;
+  bare10_count int;
+  test_row_count int;
+BEGIN
+  SELECT count(*) INTO null_count FROM resources WHERE stable_id IS NULL;
+
+  SELECT count(*) INTO bare10_count
+  FROM resources
+  WHERE stable_id ~ '^[A-Za-z0-9]{10}$' AND stable_id !~ '^sid_';
+
+  SELECT count(*) INTO test_row_count
+  FROM resources
+  WHERE id = 'test-resource-probe';
+
+  IF null_count = 0 THEN
+    RAISE EXCEPTION 'QUA-536: no NULL resources.stable_id rows — migration already applied, or pre-flight snapshot is stale. Aborting to avoid silent no-op.';
+  END IF;
+
+  IF bare10_count > 0 THEN
+    RAISE EXCEPTION 'QUA-536: % bare10 rows reappeared in resources.stable_id — QUA-503 cleared these. Investigate before proceeding.',
+      bare10_count;
+  END IF;
+
+  RAISE NOTICE 'QUA-536: pre-conditions OK — % NULL rows to populate; test-probe row present: %',
+    null_count, (test_row_count > 0);
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Delete the test-probe row (and its `things` row, if any).
+--    The row (`id='test-resource-probe'`, `stable_id='probe-test-001'`) was
+--    left over from an earlier manual test and has a non-canonical stable_id
+--    format. It would fail the post-condition format check if left in place,
+--    and it would also fail QUA-492's eventual CHECK constraint.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM things
+WHERE source_table = 'resources' AND source_id = 'test-resource-probe';
+
+DELETE FROM resources
+WHERE id = 'test-resource-probe' AND stable_id = 'probe-test-001';
+
+-- ---------------------------------------------------------------------------
+-- 3. Drop FKs on `things.id` so the PK UPDATE in step 5 can proceed.
+--
+--    Discovered dynamically via `pg_constraint` (same pattern as migration
+--    0182). Recorded in a temp table so step 6 can re-add them symmetrically.
+-- ---------------------------------------------------------------------------
+
+CREATE TEMP TABLE qua536_dropped_fks (
+  table_name text NOT NULL,
+  constraint_name text NOT NULL,
+  fk_column text NOT NULL
+) ON COMMIT DROP;
+
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT
+      t.relname AS table_name,
+      c.conname AS constraint_name,
+      a.attname AS fk_column
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attnum = c.conkey[1]
+    WHERE c.contype = 'f'
+      AND c.confrelid = 'things'::regclass
+      AND array_length(c.conkey, 1) = 1
+  LOOP
+    INSERT INTO qua536_dropped_fks (table_name, constraint_name, fk_column)
+    VALUES (rec.table_name, rec.constraint_name, rec.fk_column);
+    RAISE NOTICE 'QUA-536: dropping FK %.% (% -> things.id)',
+      rec.table_name, rec.constraint_name, rec.fk_column;
+    EXECUTE format(
+      'ALTER TABLE %I DROP CONSTRAINT %I',
+      rec.table_name,
+      rec.constraint_name
+    );
+  END LOOP;
+  IF NOT EXISTS (SELECT 1 FROM qua536_dropped_fks) THEN
+    RAISE EXCEPTION 'QUA-536: expected at least one FK referencing things.id but found none — schema drift?';
+  END IF;
+END $$;
+
+-- Assert the dropped set matches what step 5/6 know how to handle. Any new FK
+-- on `things.id` would need its own UPDATE in step 5 below, so fire loudly if
+-- one appears.
+DO $$
+DECLARE
+  unexpected int;
+BEGIN
+  SELECT count(*) INTO unexpected
+  FROM qua536_dropped_fks
+  WHERE (table_name, fk_column) NOT IN (
+    ('things',         'parent_thing_id'),
+    ('qa_page_checks', 'thing_id')
+  );
+  IF unexpected > 0 THEN
+    RAISE EXCEPTION
+      'QUA-536: % unexpected FK column(s) reference things.id; add UPDATEs for them in step 5 and update this assertion',
+      unexpected;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Populate NULL `resources.stable_id` with `sid_` + 10 random alphanumeric
+--    characters. Alphabet matches the TS `generateId()` in
+--    `packages/factbase/src/ids.ts:45` (A-Z, a-z, 0-9 — 62 chars).
+--
+--    The generator is a VOLATILE PL/pgSQL function so that `UPDATE` evaluates
+--    it once per row. A naive scalar subquery in SET would be folded to a
+--    single value by the planner and assign every row the same id.
+--
+--    Collision handling: with 62^10 ≈ 8.4×10^17 possibilities and ~22,893
+--    total resource rows after this migration, birthday-paradox collision
+--    probability is ~10^-10. We still wrap the UPDATE in an EXCEPTION /
+--    retry loop so a spurious collision re-generates affected rows rather
+--    than aborting the whole transaction.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pg_temp.qua536_sid_gen() RETURNS text AS $$
+DECLARE
+  alphabet text := 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  result text := '';
+  i int;
+BEGIN
+  FOR i IN 1..10 LOOP
+    result := result || substr(alphabet, 1 + floor(random() * 62)::int, 1);
+  END LOOP;
+  RETURN 'sid_' || result;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+DO $$
+DECLARE
+  attempt int := 0;
+  max_attempts int := 5;
+  remaining int;
+BEGIN
+  LOOP
+    attempt := attempt + 1;
+    BEGIN
+      UPDATE resources
+      SET stable_id = pg_temp.qua536_sid_gen()
+      WHERE stable_id IS NULL;
+
+      SELECT count(*) INTO remaining FROM resources WHERE stable_id IS NULL;
+      IF remaining = 0 THEN
+        RAISE NOTICE 'QUA-536: populated stable_ids in % attempt(s)', attempt;
+        EXIT;
+      END IF;
+      RAISE EXCEPTION 'QUA-536: UPDATE succeeded but % NULL rows remain — concurrent writer?',
+        remaining;
+    EXCEPTION WHEN unique_violation THEN
+      IF attempt >= max_attempts THEN
+        RAISE EXCEPTION 'QUA-536: exceeded % attempts due to stable_id unique_violation — collision rate far higher than expected',
+          max_attempts;
+      END IF;
+      RAISE NOTICE 'QUA-536: unique_violation on attempt %, retrying', attempt;
+    END;
+  END LOOP;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Align `things` rows to the canonical stable_id.
+--
+--    Two kinds of stale rows get corrected here:
+--    (a) rows for resources that were just populated in step 4 (~17,482)
+--    (b) pre-existing stale rows (~4,769) where resources.stable_id was
+--        already populated but things.id was never re-synced after QUA-503.
+--
+--    Per pre-flight, `parent_thing_id` self-refs and `qa_page_checks.thing_id`
+--    have ZERO rows pointing at resource things today — the UPDATEs below are
+--    defensive: they fire only if rows appear between pre-flight and apply.
+--    Including them means a schema drift or a concurrent insert cannot leave
+--    a dangling reference after this migration.
+-- ---------------------------------------------------------------------------
+
+UPDATE things t
+   SET id = r.stable_id,
+       updated_at = now(),
+       synced_at  = now()
+  FROM resources r
+ WHERE t.source_table = 'resources'
+   AND t.source_id = r.id
+   AND t.id <> r.stable_id;
+
+UPDATE things t
+   SET parent_thing_id = r.stable_id
+  FROM resources r
+ WHERE t.parent_thing_id = r.id;
+
+UPDATE qa_page_checks q
+   SET thing_id = r.stable_id
+  FROM resources r
+ WHERE q.thing_id = r.id;
+
+-- ---------------------------------------------------------------------------
+-- 6. Re-add FKs in NOT VALID mode, matching the original ON DELETE SET NULL
+--    semantics. Static DDL because the assertion in step 3 guarantees the
+--    dropped set matches these two (table, column) pairs and both are
+--    `ON DELETE SET NULL` in the committed schema. VALIDATE CONSTRAINT runs
+--    outside the transaction (step 9) under SHARE UPDATE EXCLUSIVE so
+--    concurrent reads/writes against `things` proceed normally.
+--
+--    Constraint names use the Drizzle convention (`*_things_id_fk`) so future
+--    `drizzle-kit generate` runs don't emit spurious renames.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE things
+  ADD CONSTRAINT things_parent_thing_id_things_id_fk
+  FOREIGN KEY (parent_thing_id) REFERENCES things(id) ON DELETE SET NULL
+  NOT VALID;
+
+ALTER TABLE qa_page_checks
+  ADD CONSTRAINT qa_page_checks_thing_id_things_id_fk
+  FOREIGN KEY (thing_id) REFERENCES things(id) ON DELETE SET NULL
+  NOT VALID;
+
+-- ---------------------------------------------------------------------------
+-- 7. Post-condition checks.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  remaining_null int;
+  bad_format int;
+  dup_count int;
+  stale_things int;
+BEGIN
+  SELECT count(*) INTO remaining_null FROM resources WHERE stable_id IS NULL;
+  IF remaining_null <> 0 THEN
+    RAISE EXCEPTION 'QUA-536: % NULL resources.stable_id rows remain after step 4', remaining_null;
+  END IF;
+
+  SELECT count(*) INTO bad_format
+  FROM resources
+  WHERE stable_id !~ '^sid_[A-Za-z0-9]{10}$';
+  IF bad_format <> 0 THEN
+    RAISE EXCEPTION 'QUA-536: % rows have non-canonical stable_id format after step 4',
+      bad_format;
+  END IF;
+
+  SELECT count(*) INTO dup_count
+  FROM (
+    SELECT stable_id FROM resources
+    GROUP BY stable_id HAVING count(*) > 1
+  ) d;
+  IF dup_count <> 0 THEN
+    RAISE EXCEPTION 'QUA-536: % duplicate stable_id values after step 4', dup_count;
+  END IF;
+
+  SELECT count(*) INTO stale_things
+  FROM things t
+  JOIN resources r ON r.id = t.source_id
+  WHERE t.source_table = 'resources' AND t.id <> r.stable_id;
+  IF stale_things <> 0 THEN
+    RAISE EXCEPTION 'QUA-536: % things rows still mismatch resources.stable_id after step 5',
+      stale_things;
+  END IF;
+
+  RAISE NOTICE 'QUA-536: post-condition checks passed';
+END $$;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- 8. Validate the FKs we re-added in NOT VALID mode. Runs OUTSIDE the main
+--    transaction under SHARE UPDATE EXCLUSIVE so concurrent reads and writes
+--    against `things` proceed normally during the validation scan.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE things VALIDATE CONSTRAINT things_parent_thing_id_things_id_fk;
+ALTER TABLE qa_page_checks VALIDATE CONSTRAINT qa_page_checks_thing_id_things_id_fk;
+
+-- ---------------------------------------------------------------------------
+-- 9. Add NOT NULL constraint on resources.stable_id.
+--
+--    DONE OUTSIDE the main transaction. Inside the main transaction it would
+--    deadlock with a concurrent reader/writer on `resources` — the UPDATE in
+--    step 4 acquires row locks, a concurrent UPDATE/DELETE on one of those
+--    rows would then wait on our xact, and a subsequent `SET NOT NULL` in our
+--    xact (wanting AccessExclusiveLock) would circular-block on that waiter.
+--
+--    By splitting AFTER COMMIT, the row locks from step 4 are released first;
+--    `SET NOT NULL` then only contends with live readers/writers briefly.
+--    The explicit `lock_timeout` + retry loop bounds any contention: each
+--    attempt gives up after 5s and retries with 1s backoff, so a short-lived
+--    concurrent reader does not abort the whole migration.
+--
+--    PG ≥ 12: scan cost is catalog-only when no explicit CHECK exists, but PG
+--    still needs AccessExclusive briefly. 22,893 rows is fast.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  attempt int := 0;
+  max_attempts int := 10;
+BEGIN
+  LOOP
+    attempt := attempt + 1;
+    BEGIN
+      SET LOCAL lock_timeout = '5s';
+      ALTER TABLE resources ALTER COLUMN stable_id SET NOT NULL;
+      RAISE NOTICE 'QUA-536: SET NOT NULL on resources.stable_id succeeded in attempt %', attempt;
+      EXIT;
+    EXCEPTION WHEN lock_not_available THEN
+      IF attempt >= max_attempts THEN
+        RAISE EXCEPTION 'QUA-536: SET NOT NULL on resources.stable_id could not acquire AccessExclusiveLock after % attempts — retry during a low-traffic window',
+          max_attempts;
+      END IF;
+      RAISE NOTICE 'QUA-536: lock_timeout on attempt %, retrying in 1s', attempt;
+      PERFORM pg_sleep(1);
+    END;
+  END LOOP;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 10. Refresh the `things_search` materialized view so search stays in sync.
+--     Outside the main transaction so the SELECT locks the refresh acquires
+--     on every base table do not compound with any other DDL contention.
+--     REFRESH MATERIALIZED VIEW CONCURRENTLY requires a UNIQUE INDEX on the
+--     MV (created by migration 0181).
+-- ---------------------------------------------------------------------------
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY things_search;

--- a/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
@@ -53,13 +53,13 @@ describe("QUA-536 Phase A migration structure", () => {
     );
   });
 
-  it("Drizzle journal includes entry 0184", () => {
+  it("Drizzle journal includes a 0184_qua_536 entry with matching idx", () => {
     const journal = JSON.parse(readFileSync(JOURNAL, "utf-8"));
     const entry = journal.entries.find(
       (e: { tag: string }) => e.tag === "0184_qua_536_populate_resources_stable_id",
     );
     expect(entry).toBeDefined();
-    expect(entry.idx).toBe(183);
+    expect(entry.idx).toBe(184);
   });
 
   describe("manual script", () => {

--- a/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
@@ -191,4 +191,66 @@ describe("QUA-536 Phase A migration structure", () => {
       expect(refreshIdx).toBeGreaterThan(commitIdx);
     });
   });
+
+  describe("INSERT path stable_id defaulting (regression guards)", () => {
+    // After NOT NULL lands on resources.stable_id, every INSERT into resources
+    // must provide a stable_id value or the INSERT fails. These guards pin
+    // that invariant to the files that insert resources, so a future refactor
+    // reverting to `stableId: d.stableId ?? null` fires here instead of in
+    // prod at apply time.
+    const RESOURCES_ROUTE_PATH = join(
+      __dirname,
+      "..",
+      "routes",
+      "wikibase",
+      "resources.ts",
+    );
+    const DATA_SOURCES_PATH = join(
+      __dirname,
+      "..",
+      "routes",
+      "tablebase",
+      "data-sources.ts",
+    );
+    const resourcesRoute = readFileSync(RESOURCES_ROUTE_PATH, "utf-8");
+    const dataSources = readFileSync(DATA_SOURCES_PATH, "utf-8");
+
+    it("resourceValues() generates stable_id if caller didn't provide", () => {
+      // Not `?? null` — that's the pre-QUA-536 bug. Must be `?? generateId()`.
+      expect(resourcesRoute).toMatch(/stableId:\s*d\.stableId\s*\?\?\s*generateId\(\)/);
+      expect(resourcesRoute).not.toMatch(/stableId:\s*d\.stableId\s*\?\?\s*null\b/);
+    });
+
+    it("/suggest raw SQL INSERT includes stable_id column", () => {
+      // The raw SQL INSERT used to be `(id, url, type, created_at, updated_at)`.
+      // Post-QUA-536 it must include stable_id.
+      expect(resourcesRoute).toMatch(
+        /INSERT INTO resources\s*\([^)]*stable_id[^)]*\)\s*\n\s*SELECT \* FROM unnest/,
+      );
+      // And the unnest must include the stable_ids array
+      expect(resourcesRoute).toMatch(/\$\{stableIds\}::text\[\]/);
+    });
+
+    it("resources.ts imports generateId from @longterm-wiki/factbase", () => {
+      expect(resourcesRoute).toMatch(
+        /import \{ generateId \} from ["']@longterm-wiki\/factbase["']/,
+      );
+    });
+
+    it("data-sources.ts tabular resource insert provides stable_id", () => {
+      // The data-sources /tabular endpoint creates a resource row. Before
+      // QUA-536 it omitted stable_id, relying on the nullable column.
+      const insertBlock = dataSources.match(
+        /\.insert\(resources\)[\s\S]*?\.returning\([^)]*\);/,
+      );
+      expect(insertBlock).not.toBeNull();
+      expect(insertBlock![0]).toMatch(/stableId:\s*generateId\(\)/);
+    });
+
+    it("data-sources.ts imports generateId from @longterm-wiki/factbase", () => {
+      expect(dataSources).toMatch(
+        /import \{ generateId \} from ["']@longterm-wiki\/factbase["']/,
+      );
+    });
+  });
 });

--- a/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * QUA-536 Phase A migration — structural tests.
+ *
+ * These assert the shape of the manual migration script and its Drizzle
+ * no-op pair. The actual DDL behavior is covered by the dry-run harness at
+ * `apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql`
+ * itself (pre- and post-conditions), which is exercised when the operator
+ * applies the migration via psql with `ON_ERROR_STOP=1`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = join(__filename, "..");
+
+const DRIZZLE_NOOP = join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "0184_qua_536_populate_resources_stable_id.sql",
+);
+const MANUAL_SCRIPT = join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "qua-536-populate-resources-stable-id.sql",
+);
+const JOURNAL = join(__dirname, "..", "..", "drizzle", "meta", "_journal.json");
+
+describe("QUA-536 Phase A migration structure", () => {
+  const drizzleContent = readFileSync(DRIZZLE_NOOP, "utf-8");
+  const manualContent = readFileSync(MANUAL_SCRIPT, "utf-8");
+
+  it("Drizzle migration is a SELECT 1 no-op", () => {
+    // Drizzle migrator applies every .sql file in the folder. Since the real
+    // work happens in the manual script, the Drizzle entry must not do any
+    // DDL on its own — lest concurrent readers hit a partial state on
+    // autodeploy.
+    expect(drizzleContent.replace(/--.*$/gm, "").trim()).toBe("SELECT 1;");
+  });
+
+  it("Drizzle migration points at the manual script path", () => {
+    // The whole point of the no-op pattern is that the comment tells the
+    // operator where the actual work lives. Don't rename the manual script
+    // without updating this comment.
+    expect(drizzleContent).toContain(
+      "apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql",
+    );
+  });
+
+  it("Drizzle journal includes entry 0184", () => {
+    const journal = JSON.parse(readFileSync(JOURNAL, "utf-8"));
+    const entry = journal.entries.find(
+      (e: { tag: string }) => e.tag === "0184_qua_536_populate_resources_stable_id",
+    );
+    expect(entry).toBeDefined();
+    expect(entry.idx).toBe(183);
+  });
+
+  describe("manual script", () => {
+    it("has a BEGIN and a matching COMMIT", () => {
+      const beginCount = (manualContent.match(/^BEGIN;/gm) ?? []).length;
+      const commitCount = (manualContent.match(/^COMMIT;/gm) ?? []).length;
+      expect(beginCount).toBe(1);
+      expect(commitCount).toBe(1);
+    });
+
+    it("sets lock_timeout and statement_timeout inside the main txn", () => {
+      // Any long migration that doesn't bound lock_timeout risks blocking
+      // prod traffic for the full statement_timeout. `SET LOCAL` keeps the
+      // override scoped to this transaction.
+      expect(manualContent).toMatch(/SET LOCAL lock_timeout = '60s'/);
+      expect(manualContent).toMatch(/SET LOCAL statement_timeout = '0'/);
+    });
+
+    it("asserts NULL rows exist before running", () => {
+      // Without this, a re-run on already-populated state would silently
+      // succeed instead of failing loudly.
+      expect(manualContent).toMatch(/no NULL resources\.stable_id rows/);
+    });
+
+    it("asserts zero bare10 rows before running", () => {
+      // QUA-503 cleared bare10. If any reappeared, halt and investigate
+      // before we potentially mask the drift.
+      expect(manualContent).toMatch(/bare10 rows reappeared/);
+    });
+
+    it("deletes the test-resource-probe row", () => {
+      expect(manualContent).toMatch(/DELETE FROM resources\s+WHERE id = 'test-resource-probe'/);
+      expect(manualContent).toMatch(
+        /DELETE FROM things\s+WHERE source_table = 'resources' AND source_id = 'test-resource-probe'/,
+      );
+    });
+
+    it("uses a VOLATILE PL/pgSQL function for sid generation", () => {
+      // A scalar subquery would be folded once by the planner and assign
+      // every row the same stable_id. The dry-run on 2026-04-16 caught this
+      // exact bug; the VOLATILE function fixes it.
+      expect(manualContent).toMatch(/qua536_sid_gen/);
+      expect(manualContent).toMatch(/LANGUAGE plpgsql VOLATILE/);
+    });
+
+    it("sid generator alphabet matches TS generateId()", () => {
+      // `packages/factbase/src/ids.ts:45::generateId()` produces
+      // "sid_" + 10 chars from A-Z a-z 0-9 (base64url with '-'/'_' replaced).
+      // Any drift here would break the downstream invariant that all
+      // sid_-prefixed ids match `^sid_[A-Za-z0-9]{10}$`.
+      expect(manualContent).toMatch(
+        /'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'/,
+      );
+    });
+
+    it("handles unique_violation with a bounded retry loop", () => {
+      // Birthday-paradox collision probability is ~10^-10. If we somehow
+      // hit five spurious collisions in a row, that indicates a deeper
+      // problem — abort and surface rather than infinite-loop.
+      expect(manualContent).toMatch(/EXCEPTION WHEN unique_violation THEN/);
+      expect(manualContent).toMatch(/max_attempts int := 5/);
+    });
+
+    it("drops FKs on things.id dynamically and asserts the expected set", () => {
+      expect(manualContent).toMatch(/qua536_dropped_fks/);
+      expect(manualContent).toMatch(/c\.confrelid = 'things'::regclass/);
+      expect(manualContent).toMatch(
+        /\('things',\s+'parent_thing_id'\),\s+\('qa_page_checks', 'thing_id'\)/,
+      );
+    });
+
+    it("aligns things.id, things.parent_thing_id, and qa_page_checks.thing_id", () => {
+      // Per pre-flight audit: the parent_thing_id and qa_page_checks UPDATEs
+      // are defensive (0 rows today), but mandatory so a late-arriving row
+      // cannot leak a dangling reference past the re-added FK.
+      expect(manualContent).toMatch(/UPDATE things t\s+SET id = r\.stable_id/);
+      expect(manualContent).toMatch(/UPDATE things t\s+SET parent_thing_id = r\.stable_id/);
+      expect(manualContent).toMatch(/UPDATE qa_page_checks q\s+SET thing_id = r\.stable_id/);
+    });
+
+    it("re-adds FKs NOT VALID matching the Drizzle constraint names", () => {
+      // The committed Drizzle schema uses these exact names. Mismatched
+      // names would leave drizzle-kit generate emitting bogus renames on
+      // the next schema export.
+      expect(manualContent).toMatch(
+        /ADD CONSTRAINT things_parent_thing_id_things_id_fk[\s\S]*NOT VALID/,
+      );
+      expect(manualContent).toMatch(
+        /ADD CONSTRAINT qa_page_checks_thing_id_things_id_fk[\s\S]*NOT VALID/,
+      );
+    });
+
+    it("verifies zero NULL, correct format, no duplicates, no stale things before COMMIT", () => {
+      expect(manualContent).toMatch(/NULL resources\.stable_id rows remain/);
+      expect(manualContent).toMatch(/non-canonical stable_id format/);
+      expect(manualContent).toMatch(/duplicate stable_id values/);
+      expect(manualContent).toMatch(/things rows still mismatch resources\.stable_id/);
+    });
+
+    it("runs SET NOT NULL OUTSIDE the main transaction with lock_timeout retry", () => {
+      // Inside the main txn, SET NOT NULL deadlocked with concurrent
+      // writers on resources (dry-run 2026-04-16). Moving it outside the
+      // main txn releases row locks from step 4 before attempting the
+      // AccessExclusiveLock, and the retry loop bounds contention.
+      const commitIdx = manualContent.indexOf("\nCOMMIT;");
+      const setNotNullIdx = manualContent.indexOf("SET NOT NULL");
+      expect(commitIdx).toBeGreaterThan(-1);
+      expect(setNotNullIdx).toBeGreaterThan(commitIdx);
+      expect(manualContent).toMatch(/EXCEPTION WHEN lock_not_available THEN/);
+    });
+
+    it("runs VALIDATE CONSTRAINT outside the main transaction", () => {
+      const commitIdx = manualContent.indexOf("\nCOMMIT;");
+      const validateThingsIdx = manualContent.indexOf(
+        "ALTER TABLE things VALIDATE CONSTRAINT",
+      );
+      const validateQaIdx = manualContent.indexOf(
+        "ALTER TABLE qa_page_checks VALIDATE CONSTRAINT",
+      );
+      expect(validateThingsIdx).toBeGreaterThan(commitIdx);
+      expect(validateQaIdx).toBeGreaterThan(commitIdx);
+    });
+
+    it("refreshes things_search CONCURRENTLY after commit", () => {
+      const commitIdx = manualContent.indexOf("\nCOMMIT;");
+      const refreshIdx = manualContent.indexOf(
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY things_search",
+      );
+      expect(refreshIdx).toBeGreaterThan(commitIdx);
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-536-migration.test.ts
@@ -156,7 +156,28 @@ describe("QUA-536 Phase A migration structure", () => {
       expect(manualContent).toMatch(/NULL resources\.stable_id rows remain/);
       expect(manualContent).toMatch(/non-canonical stable_id format/);
       expect(manualContent).toMatch(/duplicate stable_id values/);
-      expect(manualContent).toMatch(/things rows still mismatch resources\.stable_id/);
+      expect(manualContent).toMatch(/things rows still mismatch or orphan resources\.stable_id/);
+    });
+
+    it("re-checks NULL count between COMMIT and SET NOT NULL (race-window guard)", () => {
+      // Between main-txn COMMIT and SET NOT NULL, a concurrent writer with
+      // an un-fixed INSERT path could insert a NULL stable_id. Without this
+      // guard, SET NOT NULL would fail with a cryptic "null value in column"
+      // after the main txn committed irreversibly. The guard catches it
+      // early with an actionable message pointing at the root cause.
+      expect(manualContent).toMatch(/late_null_count/);
+      expect(manualContent).toMatch(
+        /NULL stable_id rows appeared between main-txn COMMIT and SET NOT NULL/,
+      );
+      // Guard must come BEFORE the ALTER TABLE statement (otherwise it's
+      // not a guard, just a post-hoc message).
+      const guardIdx = manualContent.indexOf("late_null_count");
+      const alterIdx = manualContent.indexOf(
+        "ALTER TABLE resources ALTER COLUMN stable_id SET NOT NULL",
+      );
+      expect(guardIdx).toBeGreaterThan(-1);
+      expect(alterIdx).toBeGreaterThan(-1);
+      expect(guardIdx).toBeLessThan(alterIdx);
     });
 
     it("runs SET NOT NULL OUTSIDE the main transaction with lock_timeout retry", () => {

--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -17,6 +17,7 @@ import { sourceSnapshots, resources, resourceTabularSources } from "../../schema
 import { paginationQuery, zv, notFoundError } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { generateId } from "@longterm-wiki/factbase";
 
 // ---- Zod schemas ----
 
@@ -249,6 +250,9 @@ const dataSourcesApp = new Hono()
           type: "dataset",
           resourceSubtype: "tabular_source",
           publisherEntityId: body.publisherEntityId ?? null,
+          // QUA-536: NOT NULL on resources.stable_id means this INSERT must
+          // provide one. ON CONFLICT (url) keeps the existing stable_id.
+          stableId: generateId(),
         })
         .onConflictDoUpdate({
           target: resources.url,

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -187,7 +187,7 @@ function resourceValues(d: ResourceInput) {
     fetchedAt: d.fetchedAt ? new Date(d.fetchedAt) : null,
     contentHash: d.contentHash ?? null,
     // QUA-536: always generate a stableId if one isn't provided. The NOT NULL
-    // constraint on resources.stable_id (added in migration 0183) means
+    // constraint on resources.stable_id (added in migration 0184) means
     // INSERTs without stable_id fail. On ON CONFLICT (UPDATE) paths, the
     // COALESCE below preserves the existing stable_id, so a generated one on
     // update is harmless (never written).

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -66,6 +66,7 @@ registerComposer<ResourceComposerRow>("resource", (row) => ({
   parentTitle: null,
 }));
 import { urlVariants } from "../shared/url-variants.js";
+import { generateId } from "@longterm-wiki/factbase";
 import { createHash, randomBytes } from "crypto";
 
 // ---- Raw SQL row types ----
@@ -185,7 +186,12 @@ function resourceValues(d: ResourceInput) {
     credibilityOverride: d.credibilityOverride ?? null,
     fetchedAt: d.fetchedAt ? new Date(d.fetchedAt) : null,
     contentHash: d.contentHash ?? null,
-    stableId: d.stableId ?? null,
+    // QUA-536: always generate a stableId if one isn't provided. The NOT NULL
+    // constraint on resources.stable_id (added in migration 0183) means
+    // INSERTs without stable_id fail. On ON CONFLICT (UPDATE) paths, the
+    // COALESCE below preserves the existing stable_id, so a generated one on
+    // update is harmless (never written).
+    stableId: d.stableId ?? generateId(),
     archiveUrl: d.archiveUrl ?? null,
     stance: d.stance ?? null,
     contextNote: d.contextNote ?? null,
@@ -716,11 +722,15 @@ const resourcesApp = new Hono()
     const toCreate = uniqueUrls.filter((u) => !urlToResource.has(u));
     if (toCreate.length > 0) {
       const ids = toCreate.map((u) => hashId(u));
+      // QUA-536: mint a stableId per row. The NOT NULL constraint on
+      // resources.stable_id means this raw INSERT must provide one. On
+      // CONFLICT (url) paths the existing row keeps its stable_id.
+      const stableIds = toCreate.map(() => generateId());
       // DO UPDATE SET updated_at = now() forces RETURNING to include conflicting rows
       const created = await rawDb<ResourceWithContent[]>`
-        INSERT INTO resources (id, url, type, created_at, updated_at)
-        SELECT * FROM unnest(${ids}::text[], ${toCreate}::text[])
-          AS t(id, url),
+        INSERT INTO resources (id, url, stable_id, type, created_at, updated_at)
+        SELECT * FROM unnest(${ids}::text[], ${toCreate}::text[], ${stableIds}::text[])
+          AS t(id, url, stable_id),
           LATERAL (SELECT 'web'::text AS type, now() AS created_at, now() AS updated_at) defaults
         ON CONFLICT (url) DO UPDATE SET updated_at = now()
         RETURNING id, url, title, null::timestamptz AS fetched_at, false AS has_content


### PR DESCRIPTION
## Summary

Phase A of [QUA-536](https://linear.app/quantifieduncertainty/issue/QUA-536): populate ~17,764 NULL `resources.stable_id` rows with canonical `sid_<10>` format, align ~22,251 stale `things.id` values, add `NOT NULL` constraint, and update 3 resource-INSERT paths to generate a `stable_id` server-side. Unblocks [QUA-492](https://linear.app/quantifieduncertainty/issue/QUA-492)'s CHECK constraint on `resources.stable_id` and completes Phase 1 of [QUA-408](https://linear.app/quantifieduncertainty/issue/QUA-408) on the resources side.

**Phase B** (migrate 17 FK tables from `resources.id` → `resources.stable_id`) is split out as [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) and blocks on this migration.

## What changed

**Migration**
- `apps/wiki-server/drizzle/0184_qua_536_populate_resources_stable_id.sql` — no-op Drizzle migration (records in journal, points at manual script; same pattern as migration 0182 for QUA-503).
- `apps/wiki-server/drizzle/meta/_journal.json` — `0184` entry.
- `apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql` — the actual migration (self-verifying; pre- and post-conditions; operator applies via psql).

**Code changes (required by NOT NULL)**
- `apps/wiki-server/src/routes/wikibase/resources.ts` — `resourceValues()` now does `stableId: d.stableId ?? generateId()` (was `?? null`). The `/suggest` endpoint's raw SQL INSERT now includes a `stable_id` column and mints one per row via `toCreate.map(() => generateId())`.
- `apps/wiki-server/src/routes/tablebase/data-sources.ts` — tabular-source insert now passes `stableId: generateId()`.

These three fixes are required because, without them, the first request to any of those three endpoints after the migration lands would fail with a NOT NULL violation. Prod would break. I found this during paranoid local testing against a Dockerized Postgres using the actual Drizzle migrator, which let me observe the NOT NULL enforcement path live.

**Tests**
- `apps/wiki-server/src/__tests__/qua-536-migration.test.ts` — 23 structural assertions: shape of the manual SQL, journal entry, VOLATILE generator, `SET NOT NULL` outside the main txn, sid alphabet matches `generateId()`, plus 5 regression guards that pin the INSERT-path fixes (catch a future revert to `?? null`).

## Why the work split

The [original ticket body](https://linear.app/quantifieduncertainty/issue/QUA-536) treated Phase A and Phase B as one ship. Pre-flight enumeration (posted as a [rescope comment](https://linear.app/quantifieduncertainty/issue/QUA-536) on QUA-536, 2026-04-16) found several deltas from the ticket body: the 17 FK list had 3 renamed tables, 2 missing FKs, 1 duplicate FK, 5 wrong `onDelete` values, and a test row with a non-canonical `stable_id`. Phase A is a focused UPDATE + NOT NULL + 3 INSERT-path fixes that can land today; Phase B is 17 separate schema migrations touching ~21,631 rows and deserves its own test plan.

## Verification

### Dry-run against prod (rollback)

Full migration applied in a transaction that rolled back. Results:

| Metric | Pre | Post (in-txn) |
|---|---|---|
| `resources.stable_id IS NULL` | 17,764 | **0** |
| `resources.stable_id LIKE 'sid_%'` | 5,128 | **22,892** |
| Stale things rows (`things.id = resources.id`) | 22,251 | **0** |
| Bad stable_id format | 0 | **0** |
| `resources.stable_id` nullable | YES | **NO** |
| Both `things` FKs convalidated | — | **true** |

### Against a local Postgres with realistic fixtures

Ran against a dockerized PG 15 with Drizzle migrations applied, using a fixture matching prod shape (17,764 NULL + 5,128 sid_ + test-probe + 22,251 stale things rows). **Migration completed in 943ms; all invariants held: 0 NULL, 0 bad format, 22,892 distinct sids, 0 stale things, NOT NULL set, both FKs validated.**

Adversarial / edge-case tests also pass:
- Idempotent re-apply (pre-condition rejects cleanly)
- Migration without the test-probe row
- NOT NULL enforcement against post-migration INSERTs without stable_id
- Things_search MV refresh works (UNIQUE index from 0181 present)
- Generator produces 5,000 distinct values with 0 collisions
- kb-hex16 resource IDs (`kb-0076b3c1fc94703d`-style) handled
- Concurrent NULL-stable-id INSERT during the migration txn → either caught by step-4 UPDATE or rejected by post-NOT-NULL constraint; end state always consistent
- Pre-condition failure leaves state 100% unchanged
- All 3 fixed INSERT paths successfully produce valid `sid_`-prefixed stable_ids

### Bugs caught during the paranoid test pass (before prod)

1. **Subquery stability**: a scalar subquery in the UPDATE was folded once by the planner — every row got the same stable_id. Fixed with a `VOLATILE` PL/pgSQL function `pg_temp.qua536_sid_gen()`.
2. **Deadlock**: `SET NOT NULL` inside the main txn deadlocked with concurrent writers on `resources` (our UPDATE's row locks + their AccessShareLock blocking our requested AccessExclusive). Fixed by moving `SET NOT NULL` after COMMIT with bounded `lock_timeout` retry loop.
3. **Broken INSERT paths (THE BIG ONE)**: local test revealed that `resources.ts resourceValues()` used `?? null` for stableId; `/suggest` raw SQL INSERT didn't mention stable_id; `data-sources.ts` tabular INSERT didn't provide it. Any one of the three would have broken prod post-deploy. Fixed all three.

### Unit tests

- 23 structural tests in `qua-536-migration.test.ts`: passing
- 56 tests in `resources.test.ts` (touching the modified endpoints): passing
- Full wiki-server suite (1,217 tests): passing

## Deploy Checklist

- [ ] Run manual migration script: `psql "$DATABASE_MIGRATION_URL" -v ON_ERROR_STOP=1 -f apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql`
- [ ] Verify `SELECT count(*) FROM resources WHERE stable_id IS NULL` returns 0
- [ ] Verify `SELECT count(*) FROM things t JOIN resources r ON r.id=t.source_id WHERE t.source_table='resources' AND t.id != r.stable_id` returns 0
- [ ] Verify `is_nullable='NO'` for `resources.stable_id` in information_schema
- [ ] (auto) Drizzle migration `0184` recorded in `__drizzle_migrations` table — no DDL, manual script must be applied separately
- [ ] (auto) Wiki-server deploy picks up the 3 fixed INSERT paths before the manual script runs

**Recommended order:**
1. Merge PR → wiki-server redeploys with the 3 INSERT-path fixes (all new resources now get a stable_id; backward-compatible because the column is still nullable at this point)
2. Apply the manual SQL script during a low-traffic window (rewrites 17,764 rows, aligns things, SET NOT NULL)
3. If `SET NOT NULL` fails with `lock_not_available` after 10 retries, retry during lower traffic (unlikely — script acquires lock in <50ms normally)

## Test plan

- [x] Local end-to-end against realistic fixture (22k resources, 22k things rows) — passes in ~1s
- [x] Adversarial edge cases — all pass
- [x] Idempotent re-apply — pre-condition rejects cleanly
- [x] Post-NOT-NULL INSERTs through all 3 fixed paths — succeed with valid sids
- [x] Wiki-server test suite (1,217 tests) — passing
- [ ] After merge + deploy, apply manual script, verify prod post-conditions listed above
- [ ] Verify `/search` and `/resources/<id>` still work post-deploy (things_search MV refreshed automatically at end of script)

## Non-goals (not in this PR, by design)

- **No change to `resources.id`** — the hex16/kb-hex16 column stays permanently as a secondary identifier. `/api/resources/:id` resolves by `resources.id` and 14 hardcoded ids in `grants-data-source.ts` depend on it.
- **No FK migration** — Phase B (QUA-549) handles the 17 `resource_id` → `resource_stable_id` rewrites.
- **No CHECK constraint** on `resources.stable_id` format — that lands in QUA-492 after Phase B.
- **No change to archive tables** (`_archived_claim_sources`, `_archived_statement_citations`).

Fixes QUA-536

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Migration 0184 is a no-op — verify manual migration script was applied separately — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `manual-migration` Run manual migration script: psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql
- [ ] `manual` Post-apply: confirm `SELECT count(*) FROM resources WHERE stable_id IS NULL` returns 0, and `information_schema.columns.is_nullable='NO'` for `resources.stable_id`
- [ ] `manual` Post-apply: confirm `SELECT count(*) FROM things t JOIN resources r ON r.id=t.source_id WHERE t.source_table='resources' AND t.id != r.stable_id` returns 0 (no stale things rows)
- [ ] `manual` Verify the 3 fixed INSERT paths still work end-to-end by exercising each once on prod: POST /api/resources (upsertResource), POST /api/resources/suggest with a URL that isn't already in resources, and creating a new data-source tabular row. Each should succeed and produce a `sid_`-prefixed stable_id — `curl -sf https://wiki-server.k8s.quantifieduncertainty.org/health | jq`
- [ ] `manual` Verify things_search MV is healthy post-apply (script auto-refreshes it, but confirm): check `/internal/data-quality` for the things_search staleness panel showing green within ~15 minutes of apply
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Migration**
  * Added database migration to populate and enforce stable ID constraints for resources.

* **Application Updates**
  * Updated resource creation endpoints to automatically generate stable IDs when not provided by the caller.

* **Tests**
  * Added comprehensive test suite to validate migration execution and application code compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
