### PR TITLE
fix(sourcing): remove 15 leftover getSourcingHref() 404 calls (QUA-540)

### DIFF
--- a/apps/web/src/app/ai-models/ai-models-table.tsx
+++ b/apps/web/src/app/ai-models/ai-models-table.tsx
@@ -8,7 +8,6 @@ import { PaginationControls } from "@/components/directory/PaginationControls";
 import { DEVELOPER_COLORS, SAFETY_LEVEL_COLORS, formatContext } from "./ai-model-constants";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface AiModelRow {
   id: string;
@@ -412,7 +411,8 @@ export function AiModelsTable({ rows }: { rows: AiModelRow[] }) {
                       wikiId: row.wikiId,
                     })}
                     verdict={row.verdictString}
-                    sourcingHref={row.verdictString ? getSourcingHref("ai-model", row.id) : undefined}
+                    // QUA-540: ai-model has no sourcing verdicts → href would 404.
+                    sourcingHref={undefined}
                   />
                 </td>
               </tr>

--- a/apps/web/src/app/approaches/approaches-table.tsx
+++ b/apps/web/src/app/approaches/approaches-table.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface ApproachRow {
   id: string;
@@ -143,7 +142,8 @@ export function ApproachesTable({ rows }: { rows: ApproachRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeGenericCoverage({ description: row.description, tags: row.tags, wikiId: row.wikiId })}
                     verdict={row.verdictString}
-                    sourcingHref={row.verdictString ? getSourcingHref("approach", row.id) : undefined}
+                    // QUA-540: approach has no sourcing verdicts → href would 404.
+                    sourcingHref={undefined}
                   />
                 </td>
 

--- a/apps/web/src/app/benchmarks/benchmarks-table.tsx
+++ b/apps/web/src/app/benchmarks/benchmarks-table.tsx
@@ -6,7 +6,6 @@ import { compareByValue, type SortDir } from "@/lib/sort-utils";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeBenchmarkCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface BenchmarkRow {
   id: string;
@@ -235,7 +234,8 @@ export function BenchmarksTable({ rows }: { rows: BenchmarkRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeBenchmarkCoverage(row)}
                     verdict={row.verdictString}
-                    sourcingHref={row.verdictString ? getSourcingHref("benchmark", row.id) : undefined}
+                    // QUA-540: benchmark has no sourcing verdicts → href would 404.
+                    sourcingHref={undefined}
                   />
                 </td>
               </tr>

--- a/apps/web/src/app/events/events-table.tsx
+++ b/apps/web/src/app/events/events-table.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeGenericCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface EventRow {
   id: string;
@@ -174,7 +173,8 @@ export function EventsTable({ rows }: { rows: EventRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeGenericCoverage({ description: row.description, tags: row.tags, wikiId: row.wikiId, filledFieldCount: (row.status ? 1 : 0) })}
                     verdict={row.verdictString}
-                    sourcingHref={row.verdictString ? getSourcingHref("event", row.id) : undefined}
+                    // QUA-540: event has no sourcing verdicts → href would 404.
+                    sourcingHref={undefined}
                   />
                 </td>
 

--- a/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
@@ -7,7 +7,6 @@ import { getEntityHref } from "@/data/entity-nav";
 
 import { formatCompactNumber } from "@/lib/format-compact";
 import { formatKBDate } from "@/components/wiki/factbase/format";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
 import { SectionHeader, Badge } from "./org-shared";
@@ -217,7 +216,8 @@ export function AiModelsSection({
                         wikiId: model.wikiId,
                       })}
                       verdict={modelVerdict}
-                      sourcingHref={getSourcingHref("model-release", model.id)}
+                      // QUA-540: model-release has no sourcing verdicts → /sourcing/model-release/:id 404s.
+                      sourcingHref={undefined}
                     />
                   </td>
                 </tr>

--- a/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
+++ b/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
@@ -297,7 +297,8 @@ export function ProductsSection({
                         filledFieldCount: (field(prod, "status") ? 1 : 0) + (field(prod, "website") ? 1 : 0),
                       })}
                       verdict={prodVerdict}
-                      sourcingHref={getSourcingHref("product", String(prod.key))}
+                      // QUA-540: product has no sourcing verdicts → /sourcing/product/:id 404s.
+                      sourcingHref={undefined}
                     />
                   </td>
                 </tr>
@@ -393,7 +394,8 @@ export function SafetyMilestonesSection({
                         filledFieldCount: (field(ms, "date") ? 1 : 0) + (field(ms, "source") ? 1 : 0),
                       })}
                       verdict={msVerdict}
-                      sourcingHref={getSourcingHref("safety-milestone", String(ms.key))}
+                      // QUA-540: safety-milestone has no sourcing verdicts → /sourcing/safety-milestone/:id 404s.
+                      sourcingHref={undefined}
                     />
                   </td>
                 </tr>
@@ -497,7 +499,8 @@ export function StrategicPartnershipsSection({
                         filledFieldCount: (field(sp, "date") ? 1 : 0) + (field(sp, "partner") ? 1 : 0),
                       })}
                       verdict={spVerdict}
-                      sourcingHref={getSourcingHref("strategic-partnership", String(sp.key))}
+                      // QUA-540: strategic-partnership has no sourcing verdicts → /sourcing/strategic-partnership/:id 404s.
+                      sourcingHref={undefined}
                     />
                   </td>
                 </tr>

--- a/apps/web/src/app/organizations/[slug]/market-data-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/market-data-section.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/wiki-server";
 import { formatCompactCurrency } from "@/lib/format-compact";
 
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 import { SectionHeader } from "./org-shared";
@@ -187,7 +186,8 @@ function SecondaryMarketSection({
                       status={recordVerdictToStatus(verdict)}
                       originalVerdict={verdict}
                       size="md"
-                      href={getSourcingHref("secondary-market-price", String(p.id))}
+                      // QUA-540: secondary-market-price has no sourcing verdicts → /sourcing 404s.
+                      href={undefined}
                     />
                   </td>
                 </tr>
@@ -324,7 +324,8 @@ function PredictionMarketSection({
                         status={recordVerdictToStatus(verdict)}
                         originalVerdict={verdict}
                         size="md"
-                        href={getSourcingHref("prediction-question", String(q.id))}
+                        // QUA-540: prediction-question has no sourcing verdicts → /sourcing 404s.
+                        href={undefined}
                       />
                     </td>
                   </tr>
@@ -386,7 +387,8 @@ function QuestionRow({ question: q }: { question: RpcPredictionQuestion }) {
           status={recordVerdictToStatus(verdict)}
           originalVerdict={verdict}
           size="md"
-          href={getSourcingHref("prediction-question", String(q.id))}
+          // QUA-540: prediction-question has no sourcing verdicts → /sourcing 404s.
+          href={undefined}
         />
       </td>
     </tr>

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { getTypedEntityById, getTypedEntityByStableId, getTypedEntities, isOrgan
 
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { isSid } from "@/lib/stable-id";
 import {
   getKBLatest,
@@ -686,7 +685,8 @@ export default async function OrgProfilePage({
                           status={recordVerdictToStatus(projectVerdict)}
                           originalVerdict={projectVerdict}
                           size="md"
-                          href={getSourcingHref("project", p.id)}
+                          // QUA-540: project has no sourcing verdicts → /sourcing/project/:id 404s.
+                          href={undefined}
                         />
                       </td>
                     </tr>

--- a/apps/web/src/app/projects/projects-table.tsx
+++ b/apps/web/src/app/projects/projects-table.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { SortHeader } from "@/components/directory/SortHeader";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeProjectCoverage } from "@/components/coverage/coverage-score";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface ProjectRow {
   id: string;
@@ -149,7 +148,8 @@ export function ProjectsTable({ rows }: { rows: ProjectRow[] }) {
                   <RecordStatusDots
                     coverageScore={computeProjectCoverage(row)}
                     verdict={row.verdictString}
-                    sourcingHref={row.verdictString ? getSourcingHref("project", row.id) : undefined}
+                    // QUA-540: project has no sourcing verdicts → href would 404.
+                    sourcingHref={undefined}
                   />
                 </td>
 

--- a/apps/web/src/app/races/races-table.tsx
+++ b/apps/web/src/app/races/races-table.tsx
@@ -11,7 +11,6 @@ import {
 } from "./races-constants";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
-import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 
 export interface RaceRow {
   id: string;
@@ -209,7 +208,8 @@ export function RacesTable({ rows }: { rows: RaceRow[] }) {
                       status={recordVerdictToStatus(race.verdictString)}
                       originalVerdict={race.verdictString}
                       size="md"
-                      href={getSourcingHref("race", String(race.id))}
+                      // QUA-540: race has no sourcing verdicts → /sourcing/race/:id 404s.
+                      href={undefined}
                     />
                   </td>
                 </tr>
@@ -295,7 +295,8 @@ export function RacesTable({ rows }: { rows: RaceRow[] }) {
                                     status={recordVerdictToStatus(c.verdictString)}
                                     originalVerdict={c.verdictString}
                                     size="md"
-                                    href={getSourcingHref("race-candidate", String(c.id))}
+                                    // QUA-540: race-candidate has no sourcing verdicts → /sourcing 404s.
+                                    href={undefined}
                                   />
                                 </td>
                               </tr>


### PR DESCRIPTION
## Summary

QUA-211 (PR #4174) removed `getRecordVerdict()` calls for 23 record types with zero verdicts in prod, but left the matching `getSourcingHref()` calls on the same files. Dots still rendered as "unchecked" AND still linked to `/sourcing/:type/:id` — which calls `notFound()` (QUA-420) for any type not in `RECORD_TYPE_TO_TABLE`.

## Changes

**10 un-gated calls** (replace with `undefined`):
- `organizations/[slug]/page.tsx` — `project`
- `organizations/[slug]/ai-models-section.tsx` — `model-release`
- `organizations/[slug]/main-content-sections.tsx` — `product`, `safety-milestone`, `strategic-partnership`
- `organizations/[slug]/market-data-section.tsx` — `secondary-market-price`, 2× `prediction-question`
- `races/races-table.tsx` — `race`, `race-candidate`

**5 gated calls** in directory tables (simplify to `undefined`, drop unused import):
- `ai-models/ai-models-table.tsx` — `ai-model`
- `approaches/approaches-table.tsx` — `approach`
- `benchmarks/benchmarks-table.tsx` — `benchmark`
- `events/events-table.tsx` — `event`
- `projects/projects-table.tsx` — `project`

All other `getSourcingHref()` callers use types that ARE in `RECORD_TYPE_TO_TABLE` (grant, personnel, funding-round, investment, policy-stakeholder, division, funding-program) — those show the "unchecked" empty-state page for records without verdicts rather than 404ing.

## Test plan

- [x] `npx tsc --noEmit` (apps/web) passes — no new type errors, no unused-import warnings
- [x] Existing `src/app/sourcing/__tests__/sourcing-href.test.ts` (11 tests) still passes — helper unchanged
- [x] Grep confirms 0 remaining `getSourcingHref("<no-verdict-type>"` calls for the 20 QUA-211 types

Fixes QUA-540
