### PR TITLE
feat(crux): add fb source-backfill command for unsourced FactBase facts

### DIFF
--- a/crux/commands/factbase-source-backfill.test.ts
+++ b/crux/commands/factbase-source-backfill.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for `crux fb source-backfill` — QUA-545.
+ *
+ * These tests exercise:
+ *   1. collectUnsourcedFacts — which facts get included/excluded under various
+ *      filter combinations (verifiable:false, editorial, --entity, --property).
+ *   2. The command wiring through `commands['source-backfill']`, with the
+ *      suggestUrls() library mocked so no external HTTP calls happen.
+ *   3. The apply path via updateFactMetaById in-memory (no real YAML writes).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseDocument } from 'yaml';
+
+// Mock suggestUrls before the command module loads so the module-level import
+// in factbase-source-backfill.ts resolves to the mock. We also mock the YAML
+// read/write helpers so --apply doesn't touch real files.
+const mockSuggestUrls = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+  candidates: [
+    { url: 'https://example.com/src', title: 'Example', snippet: null, sourceProvider: 'exa' },
+  ],
+  providersUsed: ['exa'],
+  providersSkipped: [],
+  query: 'test query',
+  costUsd: 0.0,
+}));
+
+vi.mock('../lib/sourcing/suggest-urls.ts', () => ({
+  suggestUrls: (...args: unknown[]) => mockSuggestUrls(...args),
+  GENERATOR_MODEL: 'qua-64/suggest-urls-v1',
+}));
+
+// Mock YAML file I/O so --apply tests don't mutate the working tree. We keep
+// a fake file store keyed by filepath so the read→modify→write round-trip is
+// observable.
+const fakeFiles = new Map<string, string>();
+const readEntityDocumentMock = vi.fn((filepath: string) => {
+  const content = fakeFiles.get(filepath) ?? 'facts: []\n';
+  return parseDocument(content);
+});
+const writeEntityDocumentMock = vi.fn((filepath: string, doc: { toString: () => string }) => {
+  fakeFiles.set(filepath, doc.toString());
+});
+const findEntityFilePathMock = vi.fn((slug: string) => `/fake/${slug}.yaml`);
+
+vi.mock('../lib/factbase-writer.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/factbase-writer.ts')>();
+  return {
+    ...actual,
+    readEntityDocument: (p: string) => readEntityDocumentMock(p),
+    writeEntityDocument: (p: string, d: { toString: () => string }) => writeEntityDocumentMock(p, d),
+    findEntityFilePath: (slug: string) => findEntityFilePathMock(slug),
+  };
+});
+
+import { commands, collectUnsourcedFacts, buildClaimText } from './factbase-source-backfill.ts';
+import { loadGraphFull } from '../lib/factbase-loader.ts';
+
+const backfill = commands.default;
+
+beforeEach(() => {
+  mockSuggestUrls.mockClear();
+  readEntityDocumentMock.mockClear();
+  writeEntityDocumentMock.mockClear();
+  findEntityFilePathMock.mockClear();
+  fakeFiles.clear();
+});
+
+describe('collectUnsourcedFacts', () => {
+  it('picks up facts with no source on verifiable properties', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { limit: 500 });
+    expect(out.length).toBeGreaterThan(0);
+
+    // Every returned fact must lack a source and not be an inverse fact.
+    for (const { fact } of out) {
+      expect(fact.source).toBeFalsy();
+      expect(fact.id.startsWith('inv_')).toBe(false);
+    }
+
+    // By default we skip verifiable:false properties, so none should appear.
+    for (const { fact } of out) {
+      const prop = kb.graph.getProperty(fact.propertyId);
+      expect(prop?.verifiable).not.toBe(false);
+    }
+  });
+
+  it('respects --include-non-verifiable', async () => {
+    const kb = await loadGraphFull();
+    const strict = collectUnsourcedFacts(kb, { limit: 2000 });
+    const loose = collectUnsourcedFacts(kb, { limit: 2000, includeNonVerifiable: true });
+    // Loose must include every strict fact plus at least one non-verifiable one.
+    expect(loose.length).toBeGreaterThan(strict.length);
+
+    const hasNonVerifiable = loose.some(({ fact }) => {
+      const prop = kb.graph.getProperty(fact.propertyId);
+      return prop?.verifiable === false;
+    });
+    expect(hasNonVerifiable).toBe(true);
+  });
+
+  it('skips editorial properties (description, notable-for) by default', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { limit: 2000 });
+    expect(out.some(({ fact }) => fact.propertyId === 'description')).toBe(false);
+    expect(out.some(({ fact }) => fact.propertyId === 'notable-for')).toBe(false);
+  });
+
+  it('--include-editorial surfaces description facts', async () => {
+    const kb = await loadGraphFull();
+    const withEd = collectUnsourcedFacts(kb, { limit: 2000, includeEditorial: true });
+    expect(withEd.some(({ fact }) => fact.propertyId === 'description')).toBe(true);
+  });
+
+  it('--include-property=description picks only description editorial', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, {
+      limit: 2000,
+      includeProperty: 'description',
+    });
+    expect(out.some(({ fact }) => fact.propertyId === 'description')).toBe(true);
+    // notable-for is still skipped because it wasn't in the allow list
+    expect(out.some(({ fact }) => fact.propertyId === 'notable-for')).toBe(false);
+  });
+
+  it('respects --property filter exactly', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { property: 'headcount', limit: 50 });
+    for (const { fact } of out) {
+      expect(fact.propertyId).toBe('headcount');
+    }
+  });
+
+  it('respects --entity filter', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { entity: 'anthropic', limit: 50 });
+    for (const { entity } of out) {
+      expect(entity.name.toLowerCase()).toContain('anthropic');
+    }
+  });
+
+  it('returns empty array for unknown entity (not an error)', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { entity: 'this-entity-does-not-exist', limit: 10 });
+    expect(out).toEqual([]);
+  });
+
+  it('enforces the limit cap', async () => {
+    const kb = await loadGraphFull();
+    const out = collectUnsourcedFacts(kb, { limit: 5 });
+    expect(out.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('buildClaimText', () => {
+  it('formats entity/property/value/asOf consistently', () => {
+    const entity = { id: 'e1', stableId: 'e1', name: 'Anthropic', type: 'organization' };
+    const fact = {
+      id: 'f_123',
+      subjectId: 'e1',
+      propertyId: 'headcount',
+      value: { type: 'number' as const, value: 500 },
+      asOf: '2024-06',
+    };
+    expect(buildClaimText(entity, fact, 'Headcount', '500')).toBe(
+      "Anthropic's Headcount = 500 (as of 2024-06)",
+    );
+  });
+
+  it('omits asOf when absent', () => {
+    const entity = { id: 'e1', stableId: 'e1', name: 'Anthropic', type: 'organization' };
+    const fact = {
+      id: 'f_123',
+      subjectId: 'e1',
+      propertyId: 'headcount',
+      value: { type: 'number' as const, value: 500 },
+    };
+    expect(buildClaimText(entity, fact, 'Headcount', '500')).toBe(
+      "Anthropic's Headcount = 500",
+    );
+  });
+});
+
+describe('crux fb source-backfill — dry-run (default)', () => {
+  it('reports candidates but does not call the YAML writer', async () => {
+    const result = await backfill([], {
+      entity: 'anthropic',
+      limit: '2',
+    });
+    expect(result.exitCode).toBe(0);
+    // Summary is always in the output; the header prints to stdout via log().
+    expect(result.output).toContain('=== Summary ===');
+    expect(result.output).toContain('Run with --apply');
+    expect(mockSuggestUrls).toHaveBeenCalled();
+    expect(writeEntityDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it('emits JSON in --ci mode with candidates from the mocked suggester', async () => {
+    const result = await backfill([], {
+      entity: 'anthropic',
+      limit: '2',
+      ci: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output);
+    expect(data).toHaveProperty('summary');
+    expect(data).toHaveProperty('results');
+    expect(Array.isArray(data.results)).toBe(true);
+    if (data.results.length > 0) {
+      expect(data.results[0]).toHaveProperty('factId');
+      expect(data.results[0]).toHaveProperty('candidates');
+      // The mock always returns one candidate at example.com/src
+      expect(data.results[0].candidates[0].url).toBe('https://example.com/src');
+    }
+  });
+
+  it('reports "no unsourced facts" when filters match nothing', async () => {
+    const result = await backfill([], {
+      entity: 'nonexistent-entity-xyz',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('No unsourced facts');
+  });
+
+  it('warns on invalid --limit and falls back to default', async () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    await backfill([], { entity: 'anthropic', limit: '-1' });
+    const combined = errSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(combined).toContain('ignoring --limit');
+    errSpy.mockRestore();
+  });
+});
+
+describe('crux fb source-backfill — --apply', () => {
+  it('writes the top candidate to YAML via updateFactMetaById', async () => {
+    // Seed the fake file with a pre-existing headcount fact that has NO source.
+    fakeFiles.set(
+      '/fake/anthropic.yaml',
+      `facts:\n  - id: f_FAKEEXAMPLE1\n    property: headcount\n    value:\n      type: number\n      value: 500\n    asOf: '2024-06'\n`,
+    );
+
+    // Override collectUnsourcedFacts indirectly by pointing a single entity at
+    // a real fact that exists in the KB graph. We use the real KB + real fact
+    // IDs; the file write goes into `fakeFiles`.
+    const kb = await loadGraphFull();
+    const anthropic = kb.graph.getAllEntities().find((e) => e.name === 'Anthropic');
+    expect(anthropic).toBeDefined();
+
+    // Pick one real unsourced fact for Anthropic.
+    const facts = collectUnsourcedFacts(kb, { entity: 'anthropic', limit: 1 });
+    if (facts.length === 0) {
+      // If Anthropic has no unsourced facts (shouldn't happen per enumeration
+      // but future-proof), skip gracefully.
+      return;
+    }
+    const { fact } = facts[0];
+    fakeFiles.set(
+      '/fake/anthropic.yaml',
+      `facts:\n  - id: ${fact.id}\n    property: ${fact.propertyId}\n    value: something\n`,
+    );
+
+    const result = await backfill([], {
+      entity: 'anthropic',
+      limit: '1',
+      apply: true,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Writes attempted');
+    expect(writeEntityDocumentMock).toHaveBeenCalled();
+
+    const written = fakeFiles.get('/fake/anthropic.yaml') ?? '';
+    expect(written).toContain('https://example.com/src');
+    expect(written).toContain('auto-suggested');
+  });
+
+  it('does NOT overwrite an existing source', async () => {
+    const kb = await loadGraphFull();
+    const facts = collectUnsourcedFacts(kb, { entity: 'anthropic', limit: 1 });
+    if (facts.length === 0) return;
+    const { fact } = facts[0];
+
+    // Seed the file with the same fact but WITH a pre-existing source URL.
+    // updateFactMetaById must no-op and count this as writes_skipped_existing.
+    fakeFiles.set(
+      '/fake/anthropic.yaml',
+      `facts:\n  - id: ${fact.id}\n    property: ${fact.propertyId}\n    value: something\n    source: https://pre-existing.example/\n`,
+    );
+
+    const result = await backfill([], {
+      entity: 'anthropic',
+      limit: '1',
+      apply: true,
+      ci: true,
+    });
+    expect(result.exitCode).toBe(0);
+    const data = JSON.parse(result.output);
+    expect(data.summary.writes_skipped_existing).toBeGreaterThanOrEqual(1);
+
+    const written = fakeFiles.get('/fake/anthropic.yaml') ?? '';
+    // Must still have the original URL, not the mocked suggestion.
+    expect(written).toContain('https://pre-existing.example/');
+    expect(written).not.toContain('https://example.com/src');
+  });
+});

--- a/crux/commands/factbase-source-backfill.ts
+++ b/crux/commands/factbase-source-backfill.ts
@@ -1,0 +1,566 @@
+/**
+ * FactBase Source-Backfill — QUA-545
+ *
+ * Finds FactBase facts that have no `source` URL, runs web-search against the
+ * claim, and (optionally) writes the top candidate URL back to YAML.
+ *
+ * Workflow:
+ *   1. Load the FactBase graph.
+ *   2. Collect facts where `!fact.source`, skipping:
+ *        - inverse facts (`id` starts with `inv_`)
+ *        - properties with `verifiable: false` (website, wikipedia-url, etc.)
+ *        - the `description` property by default (no single-URL source applies)
+ *      Apply --entity / --property / --limit filters.
+ *   3. Per fact: call suggestUrls(entityName, claimText, fieldName) → candidates.
+ *   4. Dry-run (default): print a per-entity report with candidates.
+ *      --apply: write top candidate to YAML and tag the fact with
+ *               notes="[auto-suggested by qua-545] <generator-model>".
+ *
+ * Safety:
+ *   - --apply never overwrites an existing source (updateFactMetaById no-ops
+ *     when `source` is already set).
+ *   - --budget caps total Perplexity spend.
+ *   - --limit caps facts processed.
+ *   - --dry-run is the default; --apply requires an explicit flag.
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { formatFactValue } from '../../packages/factbase/src/format.ts';
+import type { Entity, Fact } from '../../packages/factbase/src/types.ts';
+import { loadGraphFull, resolveEntity, KB_DATA_DIR } from '../lib/factbase-loader.ts';
+import type { LoadedKB } from '../lib/factbase-loader.ts';
+import {
+  readEntityDocument,
+  writeEntityDocument,
+  updateFactMetaById,
+  findEntityFilePath,
+} from '../lib/factbase-writer.ts';
+import { suggestUrls, GENERATOR_MODEL } from '../lib/sourcing/suggest-urls.ts';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 2000;
+const DEFAULT_BUDGET_USD = 2.0;
+const DEFAULT_MAX_CANDIDATES = 3;
+const MAX_CANDIDATES_PER_FACT = 5;
+const DEFAULT_CONCURRENCY = 5;
+
+// Properties we skip by default even without verifiable:false, because their
+// value is editorial free-text and no single source URL meaningfully supports
+// them. `description` dominates the unsourced set (~58%); the rest are
+// opinion/editorial fields. Override with --include-property=description.
+const EDITORIAL_PROPERTIES = new Set<string>([
+  'description',
+  'notable-for',
+]);
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface BackfillOptions extends BaseOptions {
+  entity?: string;
+  property?: string;
+  'include-property'?: string;
+  includeProperty?: string;
+  limit?: string;
+  budget?: string;
+  'max-candidates'?: string;
+  maxCandidates?: string;
+  apply?: boolean;
+  'dry-run'?: boolean;
+  dryRun?: boolean;
+  'include-editorial'?: boolean;
+  includeEditorial?: boolean;
+  'include-non-verifiable'?: boolean;
+  includeNonVerifiable?: boolean;
+  ci?: boolean;
+  json?: boolean;
+}
+
+interface Candidate {
+  url: string;
+  title: string;
+  snippet: string | null;
+  provider: string;
+}
+
+interface FactWithCandidates {
+  entity: Entity;
+  fact: Fact;
+  propertyName: string;
+  formattedValue: string;
+  candidates: Candidate[];
+  searchQuery: string;
+  costUsd: number;
+  providerErrors: string[];
+}
+
+interface Summary {
+  scanned: number;
+  candidatesFound: number;
+  noCandidates: number;
+  writesAttempted: number;
+  writesSucceeded: number;
+  writesSkippedExisting: number;
+  costUsd: number;
+  budgetExhausted: boolean;
+  providerErrors: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function parseBoundedInt(
+  raw: unknown,
+  fallback: number,
+  max: number,
+  flag: string,
+): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive integer)\n`);
+    return fallback;
+  }
+  return Math.min(n, max);
+}
+
+function parsePositiveFloat(raw: unknown, fallback: number, flag: string): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseFloat(String(raw));
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive number)\n`);
+    return fallback;
+  }
+  return n;
+}
+
+/**
+ * Collect facts that need a source URL. Exported for unit testing.
+ */
+export function collectUnsourcedFacts(
+  kb: LoadedKB,
+  options: {
+    entity?: string;
+    property?: string;
+    includeProperty?: string;
+    includeEditorial?: boolean;
+    includeNonVerifiable?: boolean;
+    limit?: number;
+  },
+): Array<{ entity: Entity; fact: Fact }> {
+  const graph = kb.graph;
+
+  const editorialAllowList = new Set<string>();
+  if (options.includeProperty) {
+    for (const p of options.includeProperty.split(',').map((s) => s.trim())) {
+      if (p) editorialAllowList.add(p);
+    }
+  }
+
+  const scanEntities: Entity[] = options.entity
+    ? (() => {
+        const resolved = resolveEntity(options.entity, kb);
+        return resolved ? [resolved] : [];
+      })()
+    : graph.getAllEntities();
+
+  const out: Array<{ entity: Entity; fact: Fact }> = [];
+
+  for (const entity of scanEntities) {
+    const facts = graph.getFacts(entity.id);
+    for (const fact of facts) {
+      if (fact.id.startsWith('inv_')) continue;
+      if (fact.source) continue;
+
+      if (options.property && fact.propertyId !== options.property) continue;
+
+      const property = graph.getProperty(fact.propertyId);
+
+      // Non-verifiable properties (website, wikipedia-url, etc.) don't need a
+      // source URL — skip unless the caller explicitly opts in.
+      if (property?.verifiable === false && !options.includeNonVerifiable) continue;
+
+      // Editorial free-text properties (description, notable-for) default to
+      // skipped, but --include-editorial or --include-property=<id> overrides.
+      if (
+        EDITORIAL_PROPERTIES.has(fact.propertyId) &&
+        !options.includeEditorial &&
+        !editorialAllowList.has(fact.propertyId)
+      ) {
+        continue;
+      }
+
+      out.push({ entity, fact });
+      if (options.limit && out.length >= options.limit) return out;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Build the claim-text fragment we hand to the URL suggester. Matches the
+ * shape factbase-sourcing.ts uses so the search queries are consistent.
+ */
+export function buildClaimText(
+  entity: Entity,
+  fact: Fact,
+  propertyName: string,
+  formattedValue: string,
+): string {
+  const asOfStr = fact.asOf ? ` (as of ${fact.asOf})` : '';
+  return `${entity.name}'s ${propertyName} = ${formattedValue}${asOfStr}`;
+}
+
+/**
+ * Minimal concurrency pool (copy of the one in sourcing-suggest-urls.ts —
+ * worth consolidating in a follow-up, but not part of this PR's scope).
+ */
+async function runWithConcurrency<T>(
+  concurrency: number,
+  tasks: Array<() => Promise<T>>,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, worker));
+  return results;
+}
+
+// ── Main command ────────────────────────────────────────────────────
+
+async function backfillCommand(
+  _args: string[],
+  options: BackfillOptions,
+): Promise<CommandResult> {
+  const limit = parseBoundedInt(options.limit, DEFAULT_LIMIT, MAX_LIMIT, 'limit');
+  const budget = parsePositiveFloat(options.budget, DEFAULT_BUDGET_USD, 'budget');
+  const maxCandidates = parseBoundedInt(
+    options['max-candidates'] ?? options.maxCandidates,
+    DEFAULT_MAX_CANDIDATES,
+    MAX_CANDIDATES_PER_FACT,
+    'max-candidates',
+  );
+  const apply = Boolean(options.apply);
+  const dryRun = !apply;
+  const includeEditorial = Boolean(
+    options['include-editorial'] ?? options.includeEditorial,
+  );
+  const includeNonVerifiable = Boolean(
+    options['include-non-verifiable'] ?? options.includeNonVerifiable,
+  );
+  const includeProperty =
+    (options['include-property'] as string | undefined) ??
+    (options.includeProperty as string | undefined);
+  const entityFilter = options.entity?.trim() || undefined;
+  const propertyFilter = options.property?.trim() || undefined;
+  const isJson = Boolean(options.ci || options.json);
+
+  const log = (msg: string) => { if (!isJson) console.log(msg); };
+
+  const kb = await loadGraphFull();
+  const graph = kb.graph;
+
+  const facts = collectUnsourcedFacts(kb, {
+    entity: entityFilter,
+    property: propertyFilter,
+    includeProperty,
+    includeEditorial,
+    includeNonVerifiable,
+    limit,
+  });
+
+  log(`FactBase source-backfill (QUA-545)`);
+  log(`  mode:           ${apply ? 'APPLY' : 'dry-run'}`);
+  log(`  limit:          ${limit}`);
+  log(`  budget:         $${budget.toFixed(2)}`);
+  log(`  max-candidates: ${maxCandidates}`);
+  if (entityFilter) log(`  entity:         ${entityFilter}`);
+  if (propertyFilter) log(`  property:       ${propertyFilter}`);
+  if (includeEditorial) log(`  include-editorial: yes`);
+  if (includeNonVerifiable) log(`  include-non-verifiable: yes`);
+  log(`  facts to process: ${facts.length}`);
+  log('');
+
+  if (facts.length === 0) {
+    const output = isJson
+      ? JSON.stringify({ summary: zeroSummary(), results: [] })
+      : 'No unsourced facts match the given filters.';
+    return { exitCode: 0, output };
+  }
+
+  const summary: Summary = zeroSummary();
+  const results: FactWithCandidates[] = [];
+
+  const tasks = facts.map(({ entity, fact }) => async () => {
+    summary.scanned++;
+
+    // Budget gate (pending tasks short-circuit once tripped; in-flight finish).
+    if (summary.costUsd >= budget) {
+      if (!summary.budgetExhausted) {
+        summary.budgetExhausted = true;
+        log(`Budget reached ($${summary.costUsd.toFixed(4)} >= $${budget.toFixed(2)}); stopping new work.`);
+      }
+      return;
+    }
+
+    const property = graph.getProperty(fact.propertyId);
+    const propertyName = property?.name ?? fact.propertyId;
+    const formattedValue = formatFactValue(fact, property, graph);
+    const claimText = buildClaimText(entity, fact, propertyName, formattedValue);
+
+    const res = await suggestUrls({
+      entityName: entity.name,
+      claimText,
+      fieldName: fact.propertyId,
+      existingUrl: null,
+      maxCandidates,
+    });
+    summary.costUsd += res.costUsd;
+    for (const p of res.providersSkipped) {
+      if (!p.endsWith(':no-key')) summary.providerErrors++;
+    }
+
+    const candidates: Candidate[] = res.candidates.map((c) => ({
+      url: c.url,
+      title: c.title,
+      snippet: c.snippet,
+      provider: c.sourceProvider,
+    }));
+
+    if (candidates.length > 0) summary.candidatesFound++;
+    else summary.noCandidates++;
+
+    results.push({
+      entity,
+      fact,
+      propertyName,
+      formattedValue,
+      candidates,
+      searchQuery: res.query,
+      costUsd: res.costUsd,
+      providerErrors: res.providersSkipped.filter((p) => !p.endsWith(':no-key')),
+    });
+  });
+
+  await runWithConcurrency(DEFAULT_CONCURRENCY, tasks);
+
+  if (apply && results.length > 0) {
+    applyCandidatesToYaml(results, kb, summary, log);
+  }
+
+  if (isJson) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        summary: summaryToJson(summary, apply),
+        results: results.map((r) => ({
+          entityId: r.entity.id,
+          entityName: r.entity.name,
+          factId: r.fact.id,
+          propertyId: r.fact.propertyId,
+          propertyName: r.propertyName,
+          value: r.formattedValue,
+          asOf: r.fact.asOf ?? null,
+          candidates: r.candidates,
+          searchQuery: r.searchQuery,
+          costUsd: Number(r.costUsd.toFixed(4)),
+          providerErrors: r.providerErrors,
+        })),
+      }),
+    };
+  }
+
+  return { exitCode: 0, output: formatReport(results, summary, apply) };
+}
+
+function zeroSummary(): Summary {
+  return {
+    scanned: 0,
+    candidatesFound: 0,
+    noCandidates: 0,
+    writesAttempted: 0,
+    writesSucceeded: 0,
+    writesSkippedExisting: 0,
+    costUsd: 0,
+    budgetExhausted: false,
+    providerErrors: 0,
+  };
+}
+
+function summaryToJson(s: Summary, apply: boolean) {
+  return {
+    scanned: s.scanned,
+    candidates_found: s.candidatesFound,
+    no_candidates: s.noCandidates,
+    writes_attempted: s.writesAttempted,
+    writes_succeeded: s.writesSucceeded,
+    writes_skipped_existing: s.writesSkippedExisting,
+    cost_usd: Number(s.costUsd.toFixed(4)),
+    budget_exhausted: s.budgetExhausted,
+    provider_errors: s.providerErrors,
+    apply,
+  };
+}
+
+/**
+ * Write top candidate per fact to its YAML entity file.
+ * Batched per-entity so we read+write each file at most once.
+ *
+ * Never overwrites an existing `source` — `updateFactMetaById` no-ops in that
+ * case and we count it as `writesSkippedExisting`. This protects against a
+ * race where a human added a source URL between `collectUnsourcedFacts()` and
+ * the apply phase.
+ */
+function applyCandidatesToYaml(
+  results: FactWithCandidates[],
+  kb: LoadedKB,
+  summary: Summary,
+  log: (msg: string) => void,
+): void {
+  // Group by entity id → list of (factId, url)
+  const byEntity = new Map<string, Array<{ factId: string; url: string }>>();
+  for (const r of results) {
+    if (r.candidates.length === 0) continue;
+    const top = r.candidates[0];
+    const existing = byEntity.get(r.entity.id);
+    if (existing) existing.push({ factId: r.fact.id, url: top.url });
+    else byEntity.set(r.entity.id, [{ factId: r.fact.id, url: top.url }]);
+  }
+
+  for (const [entityId, updates] of byEntity) {
+    summary.writesAttempted += updates.length;
+    const slug = kb.filenameMap.get(entityId);
+    if (!slug) {
+      log(`  [warn] no filename for entity ${entityId} — skipping ${updates.length} write(s)`);
+      continue;
+    }
+    const filepath = findEntityFilePath(slug, KB_DATA_DIR);
+    if (!filepath) {
+      log(`  [warn] YAML file not found for ${slug} — skipping ${updates.length} write(s)`);
+      continue;
+    }
+
+    try {
+      const doc = readEntityDocument(filepath);
+      let changed = 0;
+      let skippedExisting = 0;
+      let notFound = 0;
+      for (const { factId, url } of updates) {
+        const status = updateFactMetaById(doc, factId, {
+          source: url,
+          notes: `[auto-suggested by ${GENERATOR_MODEL}]`,
+        });
+        if (status === 'updated') changed++;
+        else if (status === 'skipped-existing') skippedExisting++;
+        else notFound++;
+      }
+      if (changed > 0) writeEntityDocument(filepath, doc);
+      summary.writesSucceeded += changed;
+      summary.writesSkippedExisting += skippedExisting;
+      if (notFound > 0) {
+        log(`  [warn] ${notFound} fact(s) in ${slug} not found in YAML (graph/YAML drift?)`);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log(`  [error] write failed for ${slug}: ${msg}`);
+    }
+  }
+}
+
+function formatReport(
+  results: FactWithCandidates[],
+  summary: Summary,
+  apply: boolean,
+): string {
+  const lines: string[] = [];
+
+  // Group by entity
+  const byEntity = new Map<string, FactWithCandidates[]>();
+  for (const r of results) {
+    const existing = byEntity.get(r.entity.id);
+    if (existing) existing.push(r);
+    else byEntity.set(r.entity.id, [r]);
+  }
+
+  for (const [, entries] of byEntity) {
+    const entity = entries[0].entity;
+    lines.push(`\x1b[1m${entity.name}\x1b[0m (${entity.id}) — ${entries.length} unsourced fact(s)`);
+    for (const r of entries) {
+      const asOf = r.fact.asOf ? ` [${r.fact.asOf}]` : '';
+      lines.push(`  ${r.propertyName}: ${r.formattedValue}${asOf}  (${r.fact.id})`);
+      if (r.candidates.length === 0) {
+        lines.push(`    \x1b[33m(no candidates)\x1b[0m`);
+      } else {
+        for (const c of r.candidates) {
+          lines.push(`    → ${c.url}`);
+          if (c.title) lines.push(`      ${c.title.slice(0, 100)}`);
+        }
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push('=== Summary ===');
+  lines.push(`Scanned:              ${summary.scanned}`);
+  lines.push(`Candidates found:     ${summary.candidatesFound}`);
+  lines.push(`No candidates:        ${summary.noCandidates}`);
+  if (apply) {
+    lines.push(`Writes attempted:     ${summary.writesAttempted}`);
+    lines.push(`Writes succeeded:     ${summary.writesSucceeded}`);
+    lines.push(`Skipped (had source): ${summary.writesSkippedExisting}`);
+  }
+  lines.push(`Cost:                 $${summary.costUsd.toFixed(4)}`);
+  lines.push(`Budget exhausted:     ${summary.budgetExhausted ? 'yes' : 'no'}`);
+  lines.push(`Provider errors:      ${summary.providerErrors}`);
+  lines.push('');
+  if (!apply) {
+    lines.push('\x1b[2mRun with --apply to write top candidate per fact back to YAML.\x1b[0m');
+  }
+  return lines.join('\n');
+}
+
+// ── Exports ──────────────────────────────────────────────────────────
+
+export const commands = {
+  default: backfillCommand,
+};
+
+export function getHelp(): string {
+  return `
+FactBase Source-Backfill — suggest (and optionally apply) source URLs for unsourced facts
+
+Usage:
+  crux fb source-backfill [options]
+
+Options:
+  --entity=X                 Limit to a single entity (slug, stableId, or name)
+  --property=X               Limit to a single property ID (e.g. headcount, founded-date)
+  --include-property=X,Y     Also scan editorial properties normally skipped (e.g. description, notable-for)
+  --include-editorial        Scan ALL editorial properties (description, notable-for)
+  --include-non-verifiable   Include properties with verifiable:false (website, wikipedia-url, etc.)
+  --limit=N                  Max facts to process (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
+  --budget=N                 Soft cap in USD on provider spend (default: $${DEFAULT_BUDGET_USD.toFixed(2)}).
+  --max-candidates=N         Candidates per fact (default: ${DEFAULT_MAX_CANDIDATES}, max: ${MAX_CANDIDATES_PER_FACT})
+  --apply                    Write top candidate URL back to YAML (default: dry-run)
+  --ci / --json              Machine-readable JSON output
+
+Behavior:
+  1. Loads the FactBase graph.
+  2. Collects facts with no \`source\` URL, skipping inverse facts, properties
+     with \`verifiable: false\`, and editorial free-text properties (description,
+     notable-for).
+  3. For each, runs web search (Exa + Perplexity) against the claim text.
+  4. In dry-run (default), prints a per-entity report of candidates.
+  5. With --apply, writes the TOP candidate URL to YAML and annotates the fact
+     with notes="[auto-suggested by <model>]". Never overwrites an existing source.
+
+Requires EXA_API_KEY and/or OPENROUTER_API_KEY. Missing keys degrade gracefully.
+`.trim();
+}

--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -18,6 +18,7 @@ import type { Graph } from '../../packages/factbase/src/graph.ts';
 import type { Entity, Fact, ValidationResult } from '../../packages/factbase/src/types.ts';
 import { commands as kbMigrateCommands } from './factbase-migrate.ts';
 import { sourcingCommand } from './factbase-sourcing.ts';
+import { commands as sourceBackfillCommands } from './factbase-source-backfill.ts';
 import { commands as migrateEntitiesCommands } from './factbase-migrate-entities.ts';
 import { lookupResourceByUrl, upsertResource } from '../lib/wiki-server/resources.ts';
 import { hashId, guessResourceType } from '../resource-utils.ts';
@@ -1110,6 +1111,7 @@ export const commands = {
   migrate: kbMigrateCommands.default,
   'sync-sources': syncSourcesCommand,
   'sourcing': sourcingCommand,
+  'source-backfill': sourceBackfillCommands.default,
   'add-fact': addFactCommand,
   // Consolidated from factbase-migrate-entities domain
   'migrate-entities': migrateEntitiesCommands.run,
@@ -1137,6 +1139,7 @@ Commands:
   migrate <slug>        Migrate entity from old system to KB [--dry-run] [--stub-old]
   sync-sources          Sync KB fact source URLs to wiki-server as Resources
   sourcing          Check KB facts against source URLs using LLM
+  source-backfill       Suggest source URLs for facts that have none (QUA-545) [--apply]
   migrate-entities [--dry-run]  Transform YAML files from thing: to entity: format
   migrate-entities-status       Show migration status (files in each format)
 

--- a/crux/lib/factbase-writer.ts
+++ b/crux/lib/factbase-writer.ts
@@ -124,6 +124,65 @@ export function updateFact(
 }
 
 /**
+ * Update a fact's metadata fields by fact ID. Only touches fields explicitly
+ * passed in `updates`; leaves everything else (including `value`) untouched.
+ *
+ * Return values:
+ *   'updated'          — fact found AND at least one field was written
+ *   'skipped-existing' — fact found but an existing `source` blocked the write
+ *                        (unless `overwriteExisting` is true)
+ *   'not-found'        — no fact with that id in the document
+ *
+ * Backfill callers should leave `overwriteExisting` false so a human-written
+ * source URL is never silently replaced.
+ */
+export function updateFactMetaById(
+  doc: Document,
+  factId: string,
+  updates: { source?: string; notes?: string; sourceQuote?: string },
+  options: { overwriteExisting?: boolean } = {},
+): 'updated' | 'skipped-existing' | 'not-found' {
+  const contents = doc.contents;
+  if (!isMap(contents)) return 'not-found';
+
+  const factsNode = contents.get('facts', true);
+  if (!isSeq(factsNode)) return 'not-found';
+
+  for (const item of factsNode.items) {
+    if (!isMap(item)) continue;
+    if (String(item.get('id') ?? '') !== factId) continue;
+
+    let wrote = false;
+    let skippedForSource = false;
+
+    if (updates.source !== undefined) {
+      const existing = item.get('source');
+      if (!existing || options.overwriteExisting) {
+        item.set('source', updates.source);
+        wrote = true;
+      } else {
+        skippedForSource = true;
+      }
+    }
+    if (updates.sourceQuote !== undefined) {
+      item.set('sourceQuote', updates.sourceQuote);
+      wrote = true;
+    }
+    // If we're skipping the source-write, drop the backfill-provenance note
+    // too — a note without a fresh source URL would be misleading.
+    if (updates.notes !== undefined && !skippedForSource) {
+      item.set('notes', updates.notes);
+      wrote = true;
+    }
+
+    if (wrote) return 'updated';
+    if (skippedForSource) return 'skipped-existing';
+    return 'updated';  // caller asked for nothing — treat as no-op success
+  }
+  return 'not-found';
+}
+
+/**
  * Write a YAML document back to file atomically (write to temp, rename).
  */
 export function writeEntityDocument(filepath: string, doc: Document): void {


### PR DESCRIPTION
Fixes QUA-545

## Summary

Adds `crux fb source-backfill` — a reusable command that finds FactBase facts lacking a source URL, runs the existing `suggestUrls()` web-search pipeline (Exa + Perplexity) against each claim, and optionally writes the top candidate back to YAML.

This is **Phase 1 of QUA-545** — the tool. The batch run across ~170 truly-unsourced verifiable facts, the property-tagging pass (Phase 2), and the unverifiable re-check pass (Phase 3) are separate follow-up PRs per the issue's API-spend budget.

## Behavior

```
crux fb source-backfill [options]

  --entity=X                 Limit to one entity
  --property=X               Limit to one property
  --include-property=X,Y     Also scan normally-skipped editorial properties
  --include-editorial        Include description, notable-for
  --include-non-verifiable   Include website, wikipedia-url, etc.
  --limit=N                  Max facts (default 50, max 2000)
  --budget=N                 USD cap on provider spend (default $2)
  --max-candidates=N         Candidates per fact (default 3)
  --apply                    Write top candidate back to YAML (default: dry-run)
  --ci / --json              JSON output
```

Dry-run is the default. `--apply` is opt-in; it **never overwrites an existing source** (if a human wrote one between collection and apply, the helper returns `'skipped-existing'` and the counter reflects that).

## What gets skipped by default

Enumerating the KB surfaced 610 unsourced facts. Notable breakdown:

- **357 `description` facts (58%)** — editorial free-text; no single URL "sources" them
- **50 `notable-for`** — similar pattern
- **83 already on `verifiable:false` properties** (website, wikipedia-url, etc.)
- **~170 truly web-searchable** (headcount, born-year, founded-date, education, etc.)

The command skips editorial + non-verifiable by default so the default scan targets the ~170 facts that actually benefit from auto-suggestion. Opt back in with `--include-editorial`, `--include-property=description`, or `--include-non-verifiable`.

## Safeguards

- **Dry-run is default**; `--apply` must be explicit.
- **`--apply` never overwrites an existing source** (three-state return: `'updated' | 'skipped-existing' | 'not-found'`).
- **Budget cap** short-circuits pending tasks once spend hits the threshold.
- **Auto-applied URLs get a `notes: "[auto-suggested by qua-64/suggest-urls-v1]"`** marker so humans can audit / revert.

## Files

- `crux/commands/factbase-source-backfill.ts` — new command (~410 lines)
- `crux/commands/factbase-source-backfill.test.ts` — 17 tests covering selection logic, dry-run, apply, and the "don't overwrite existing" path
- `crux/lib/factbase-writer.ts` — new `updateFactMetaById()` with three-state return
- `crux/commands/factbase.ts` — wires the subcommand into `crux fb`

## Test plan
- [x] `pnpm vitest run crux/commands/factbase-source-backfill.test.ts` — 17 tests pass
- [x] End-to-end smoke: `pnpm crux fb source-backfill --entity=anthropic --limit=2 --ci` returns real candidates from Exa
- [x] `pnpm crux w validate gate` — 51 checks pass (3 pre-existing advisory warnings, unrelated)
- [ ] Follow-up PR: run `--apply` against the full ~170-fact cohort (Phase 1 execution)

## Out of scope

- **Phase 1 batch execution** — running `--apply` across the full cohort (needs review of the selected-URL quality before writing)
- **Phase 2** — tagging more properties `verifiable:false`
- **Phase 3** — re-verifying existing `unverifiable` verdicts with new URLs
- **Phase 4** — coverage expansion to 0%-coverage entities
