### PR TITLE
fix(web): org slug redirects cover sub-routes (QUA-538)

### DIFF
--- a/apps/web/e2e/org-slug-redirects.spec.ts
+++ b/apps/web/e2e/org-slug-redirects.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Organization slug redirect regression tests (QUA-538).
+ *
+ * When org slugs are renamed in data/entities/organizations.yaml, the old slug
+ * must redirect to the canonical one on BOTH the top-level route
+ * (/organizations/:slug) and every sub-route (/data, /grants/*, /divisions/*).
+ *
+ * Redirects are configured in apps/web/next.config.ts. Each alias needs both
+ * an exact-match entry AND a `:path*` wildcard entry so sub-routes redirect
+ * too — otherwise /organizations/google-deepmind returns 308 but
+ * /organizations/google-deepmind/data returns 404.
+ *
+ * Adding a new rename? Add both an exact and a wildcard entry to next.config.ts
+ * and append a case below.
+ */
+
+type RedirectCase = {
+  from: string;
+  to: string;
+};
+
+const ORG_REDIRECTS: RedirectCase[] = [
+  { from: "google-deepmind", to: "deepmind" },
+  { from: "meta", to: "meta-ai" },
+  { from: "future-of-life-institute", to: "fli" },
+  { from: "centre-for-effective-altruism", to: "cea" },
+];
+
+const SUB_ROUTES = ["", "/data", "/data?tab=database"];
+
+test.describe("Organization slug redirects", () => {
+  for (const { from, to } of ORG_REDIRECTS) {
+    for (const sub of SUB_ROUTES) {
+      test(`/organizations/${from}${sub} redirects to /organizations/${to}${sub}`, async ({
+        request,
+        baseURL,
+      }) => {
+        // Fetch without following redirects so we can assert the 3xx status +
+        // Location header directly — no need to render the destination page
+        // (which can be slow to compile in dev).
+        const res = await request.get(`/organizations/${from}${sub}`, {
+          maxRedirects: 0,
+        });
+
+        const status = res.status();
+        const location = res.headers()["location"] ?? "";
+
+        expect(status, `Expected 3xx redirect for /organizations/${from}${sub}, got ${status}`).toBeGreaterThanOrEqual(300);
+        expect(status).toBeLessThan(400);
+
+        // Location may be absolute or relative; parse to compare pathname +
+        // query regardless of scheme/host. Query string MUST be preserved
+        // across the redirect — dropping ?tab=database would lose state.
+        const resolved = new URL(location, baseURL ?? "http://localhost");
+        const [subPath, subQuery = ""] = sub.split("?");
+        expect(resolved.pathname).toBe(`/organizations/${to}${subPath}`);
+        expect(resolved.search).toBe(subQuery ? `?${subQuery}` : "");
+      });
+    }
+  }
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -242,10 +242,27 @@ const nextConfig: NextConfig = {
         destination: "/publications/deepmind",
         permanent: true,
       },
-      // Organization alternate-name redirects
+      // Organization alternate-name redirects — each slug needs both an exact
+      // entry and a `:path*` wildcard so sub-routes like /data, /grants/:id,
+      // and /divisions/:slug redirect too. See QUA-538.
       {
         source: "/organizations/google-deepmind",
         destination: "/organizations/deepmind",
+        permanent: true,
+      },
+      {
+        source: "/organizations/google-deepmind/:path*",
+        destination: "/organizations/deepmind/:path*",
+        permanent: true,
+      },
+      {
+        source: "/organizations/meta",
+        destination: "/organizations/meta-ai",
+        permanent: true,
+      },
+      {
+        source: "/organizations/meta/:path*",
+        destination: "/organizations/meta-ai/:path*",
         permanent: true,
       },
       {
@@ -254,8 +271,18 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/organizations/future-of-life-institute/:path*",
+        destination: "/organizations/fli/:path*",
+        permanent: true,
+      },
+      {
         source: "/organizations/centre-for-effective-altruism",
         destination: "/organizations/cea",
+        permanent: true,
+      },
+      {
+        source: "/organizations/centre-for-effective-altruism/:path*",
+        destination: "/organizations/cea/:path*",
         permanent: true,
       },
       // Research area intuitive-slug redirects (#3486)


### PR DESCRIPTION
## Summary

Fixes broken redirects for renamed org slugs. After recent data-model-unwind merges, `/organizations/meta` 404'd (should have redirected to `/organizations/meta-ai`) and `/organizations/google-deepmind/data` 404'd even though `/organizations/google-deepmind` itself already redirected.

Root cause: `apps/web/next.config.ts` had exact-match entries but no `:path*` wildcard counterparts, so sub-routes (`/data`, `/grants/*`, `/divisions/*`) didn't redirect.

## Changes

- `apps/web/next.config.ts`: add `:path*` wildcard entries for every org alternate-name redirect (google-deepmind, future-of-life-institute, centre-for-effective-altruism) and add the missing `meta → meta-ai` pair (both exact + wildcard).
- `apps/web/e2e/org-slug-redirects.spec.ts`: new regression spec. Asserts 12 cases (4 renames × 3 sub-routes) return 3xx with the correct Location pathname **and** preserved query string (`?tab=database`).

## Verification

Locally against dev (port 3017), all 12 tests pass in 622ms. Against prod they currently fail on the missing redirects — which is exactly the bug this PR fixes.

## Test plan

- [x] All 12 new e2e tests pass locally
- [x] `pnpm build` green
- [x] `pnpm test` green (6638 passed)
- [x] Gate green (53 checks)
- [ ] After deploy: prod test suite passes for all 12 redirect cases

Fixes QUA-538
