### PR TITLE
refactor(verdicts): remove STRICT_VERDICTS env-var override (QUA-448)

### DIFF
--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   fetchJsonWithRetry,
   fetchRecordVerdicts,
-  isStrictVerdictsMode,
   setFullBuildMode,
 } from '../wiki-server-data.mjs';
 
@@ -161,56 +160,10 @@ describe('fetchJsonWithRetry', () => {
   });
 });
 
-describe('isStrictVerdictsMode', () => {
-  const originalEnv = { ...process.env };
-
-  beforeEach(() => {
-    delete process.env.STRICT_VERDICTS;
-    delete process.env.CI;
-    setFullBuildMode(false);
-  });
-
-  afterEach(() => {
-    // Restore only the two env vars we touch (don't clobber vitest/node state).
-    process.env.CI = originalEnv.CI;
-    if (originalEnv.STRICT_VERDICTS !== undefined) {
-      process.env.STRICT_VERDICTS = originalEnv.STRICT_VERDICTS;
-    }
-    setFullBuildMode(false);
-  });
-
-  it('is non-strict in local dev (no CI, no full build, no override)', () => {
-    expect(isStrictVerdictsMode()).toBe(false);
-  });
-
-  it('is strict when CI=true', () => {
-    process.env.CI = 'true';
-    expect(isStrictVerdictsMode()).toBe(true);
-  });
-
-  it('is NON-strict in full-build mode alone (agent gates run full-build locally without prod creds)', () => {
-    // Regression: the original predicate also fired on fullBuildMode=true,
-    // which made the pre-push gate throw whenever localhost:3112 was down —
-    // agents routinely run the gate without a local wiki-server. Only
-    // `CI=true` (which carries prod credentials) should flip to strict.
-    setFullBuildMode(true);
-    expect(isStrictVerdictsMode()).toBe(false);
-  });
-
-  it('STRICT_VERDICTS=0 overrides CI strictness (escape hatch)', () => {
-    process.env.CI = 'true';
-    process.env.STRICT_VERDICTS = '0';
-    expect(isStrictVerdictsMode()).toBe(false);
-  });
-
-  it('STRICT_VERDICTS=1 forces strict even in local dev', () => {
-    process.env.STRICT_VERDICTS = '1';
-    expect(isStrictVerdictsMode()).toBe(true);
-  });
-});
-
-describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
+describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-var override)', () => {
   const originalServerUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const originalCi = process.env.CI;
+  const originalStrict = process.env.STRICT_VERDICTS;
   const noSleep = async () => {};
 
   beforeEach(() => {
@@ -225,6 +178,16 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
       process.env.LONGTERMWIKI_SERVER_URL = originalServerUrl;
     } else {
       delete process.env.LONGTERMWIKI_SERVER_URL;
+    }
+    if (originalCi !== undefined) {
+      process.env.CI = originalCi;
+    } else {
+      delete process.env.CI;
+    }
+    if (originalStrict !== undefined) {
+      process.env.STRICT_VERDICTS = originalStrict;
+    } else {
+      delete process.env.STRICT_VERDICTS;
     }
     setFullBuildMode(false);
   });
@@ -263,8 +226,8 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
     expect(result['grant:g1:amount']?.verdict).toBe('partial');
   });
 
-  it('in STRICT mode: throws when a page fails after all retries', async () => {
-    process.env.STRICT_VERDICTS = '1';
+  it('in CI=true: throws when a page fails after all retries', async () => {
+    process.env.CI = 'true';
     const { fetcher } = makeQueueFetcher([
       mockResponse({ ok: false, status: 503 }),
       mockResponse({ ok: false, status: 503 }),
@@ -272,11 +235,13 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
     ]);
     await expect(
       fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep }),
-    ).rejects.toThrow(/record-verdicts.*strict mode/i);
+    ).rejects.toThrow(/record-verdicts.*refusing to ship/i);
   });
 
-  it('in NON-STRICT mode: returns partial results when a page fails', async () => {
-    // Non-strict: CI not set, STRICT_VERDICTS not set, fullBuildMode not set.
+  it('outside CI: returns partial results when a page fails (graceful degrade)', async () => {
+    // No CI, no STRICT_VERDICTS. Non-CI context returns whatever it collected
+    // before the failure, so local dev / agent gates aren't blocked by a
+    // transient wiki-server hiccup.
     const firstPage = Array.from({ length: 200 }, (_, i) => ({
       recordType: 'grant',
       recordId: `g${i}`,
@@ -290,10 +255,42 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior', () => {
       mockResponse({ ok: false, status: 503 }),
     ]);
     const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
-    // We got page 1's 200 verdicts before the failure; old behavior
-    // returned {} and discarded everything. New behavior preserves them.
     expect(Object.keys(result)).toHaveLength(200);
     expect(result['grant:g0']).toBeDefined();
+  });
+
+  it('ignores STRICT_VERDICTS=0 in CI (escape hatch removed — QUA-448)', async () => {
+    // Pre-QUA-448: STRICT_VERDICTS=0 would force non-strict even in CI,
+    // defeating the whole point of the safety check. Now the env var is
+    // a no-op; CI=true still throws.
+    process.env.CI = 'true';
+    process.env.STRICT_VERDICTS = '0';
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    await expect(
+      fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep }),
+    ).rejects.toThrow(/record-verdicts/i);
+  });
+
+  it('ignores STRICT_VERDICTS=1 outside CI (override removed — QUA-448)', async () => {
+    // Pre-QUA-448: STRICT_VERDICTS=1 could force strict locally (for testing
+    // the strict path). Removed for symmetry — no env-var override at all.
+    // Outside CI, failures degrade gracefully regardless of the env var.
+    process.env.STRICT_VERDICTS = '1';
+    const firstPage = [
+      { recordType: 'grant', recordId: 'g1', verdict: 'confirmed' },
+    ];
+    const { fetcher } = makeQueueFetcher([
+      mockResponse({ ok: true, json: { verdicts: firstPage } }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+      mockResponse({ ok: false, status: 503 }),
+    ]);
+    const result = await fetchRecordVerdicts({ fetchImpl: fetcher, sleepImpl: noSleep });
+    expect(Object.keys(result)).toHaveLength(1);
   });
 
   it('returns empty map when LONGTERMWIKI_SERVER_URL is not set', async () => {

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -166,28 +166,6 @@ export async function fetchJsonWithRetry(url, opts = {}) {
 }
 
 /**
- * Should the build FAIL (throw) on wiki-server errors, vs. degrade gracefully?
- *
- * Strict by default in CI only (`CI=true`) — CI has authenticated prod
- * credentials and a failing fetch there indicates a real regression worth
- * halting the build over. Local dev (including full-build mode run from the
- * gate) defaults to non-strict: when localhost:3112 is down or an agent slot
- * doesn't have server access, we'd rather return a partial result with a
- * loud warning than hard-fail the gate for a reason unrelated to the agent's
- * changes.
- *
- * Overrides:
- *   STRICT_VERDICTS=1  → force strict even locally (test the strict path)
- *   STRICT_VERDICTS=0  → force non-strict even in CI (emergency escape hatch)
- */
-export function isStrictVerdictsMode() {
-  const override = process.env.STRICT_VERDICTS;
-  if (override === '0') return false;
-  if (override === '1') return true;
-  return process.env.CI === 'true';
-}
-
-/**
  * Fetch latest edit dates per page from the wiki-server API.
  * Falls back to an empty map if the server is unavailable.
  */
@@ -667,18 +645,40 @@ export async function fetchResearchAreaDetails(areaIds) {
 }
 
 /**
+ * Should the build FAIL (throw) on wiki-server errors, vs. degrade gracefully?
+ *
+ * Strict in CI only (`CI=true`) — CI has authenticated prod credentials, so a
+ * failing fetch there indicates a real regression worth halting the build
+ * over. Local dev defaults to non-strict: when localhost:31xx is down or an
+ * agent slot doesn't have server access, return a partial result with a
+ * loud warning rather than hard-fail the gate for a reason unrelated to
+ * the agent's changes.
+ *
+ * QUA-448: the `STRICT_VERDICTS=0/1` env-var override used to exist here as
+ * a "panic button" to flip this decision. It has been removed — the whole
+ * point of QUA-421 (avoiding silent empty record-verdicts.json) was
+ * defeated the moment anyone set STRICT_VERDICTS=0 to silence a transient
+ * hiccup. The code smell: escape hatches become load-bearing over time.
+ * CI-based strictness is still the right heuristic; only the override is
+ * gone.
+ */
+function isStrictVerdictsMode() {
+  return process.env.CI === 'true';
+}
+
+/**
  * Fetch verification verdicts from wiki-server (unified verification system).
  * Returns a map keyed by "recordType:recordId" -> verdict info.
  *
  * QUA-421: hardened against transient HTTP errors. Each page is fetched via
  * `fetchJsonWithRetry` (3 attempts, exponential backoff). If a page ultimately
  * fails:
- *   - in strict mode (CI / full build): throw — fail the build loudly instead
- *     of shipping an empty record-verdicts.json that silently zeroes every
- *     source-check dot on the site
- *   - in non-strict mode (local dev): log a loud warning and return the
- *     partial result collected so far — still strictly better than the old
- *     behavior of returning {} and discarding everything
+ *   - in strict mode (CI): throw — fail the build loudly instead of shipping
+ *     an empty record-verdicts.json that silently zeroes every source-check
+ *     dot on the site
+ *   - outside CI: log a loud warning and return the partial result collected
+ *     so far — still strictly better than the old behavior of returning {}
+ *     and discarding everything
  */
 export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
   const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
@@ -705,21 +705,17 @@ export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
 
     if (!result.ok) {
       const partial = Object.keys(verdicts).length;
-      const reason = result.status
-        ? `${result.reason} at offset=${offset} after retries`
-        : `${result.reason} at offset=${offset} after retries`;
+      const reason = `${result.reason} at offset=${offset} after retries`;
       if (strict) {
-        // Strict: throw so the build fails loudly.
         throw new Error(
           `record-verdicts: ${reason}. ${partial} verdicts were collected ` +
             `before the failure; refusing to ship a partial/empty ` +
-            `record-verdicts.json in strict mode. Set STRICT_VERDICTS=0 to ` +
-            `force degraded behavior locally.`
+            `record-verdicts.json in CI. Fix the wiki-server regression.`
         );
       }
       logWikiServerWarning(
         'record-verdicts',
-        `${reason} — returning ${partial} partial result(s) (non-strict mode)`
+        `${reason} — returning ${partial} partial result(s) (non-CI mode)`
       );
       return verdicts;
     }


### PR DESCRIPTION
## Summary

After the 2026-04-14 soak with `STRICT_VERDICTS=1` in Vercel prod, remove the escape hatch. The env var was a panic button that could silence the QUA-421 safety check — exactly the code smell the ticket flags.

Keep CI-based strict (strict in CI, graceful degrade locally): non-CI contexts (agent slots, local dev) legitimately run full `build-data.mjs` without a reachable wiki-server, and making strict truly unconditional would block the pre-push gate in every agent slot. (Verified empirically.) CI is still strict, and CI is where regressions can actually be distinguished from local-env hiccups.

## Changes

- `wiki-server-data.mjs`: `isStrictVerdictsMode()` is now private and returns `process.env.CI === 'true'` unconditionally. No env-var override.
- Updated the thrown error message to drop the `STRICT_VERDICTS=0` hint.
- `fetch-retry.test.mjs`:
  - Removed the `isStrictVerdictsMode` describe block (5 cases) — function no longer exported.
  - Added regression tests: `STRICT_VERDICTS=0` in CI is a no-op (still throws); `STRICT_VERDICTS=1` outside CI is a no-op (still degrades).

## Operational follow-up (not in this PR)

Remove `STRICT_VERDICTS=1` from Vercel production env vars after merge. It's a no-op post-merge but removing it reduces confusion. I'll file this as an issue if one doesn't already exist.

## Test plan

- [x] `pnpm vitest run scripts/lib/__tests__/fetch-retry.test.mjs` — 17/17 passing
- [x] `pnpm crux w validate gate` — 46/46 checks pass (local agent slot with wiki-server unreachable, confirming non-CI graceful degrade still works)
- [x] `npx tsc --noEmit` — no type errors

Fixes QUA-448
