### PR TITLE
fix(flagship-curate): detect consecutive sourcing failures in inner loop (QUA-460)

### DIFF
--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -427,6 +427,91 @@ describe('flagship-curate', () => {
     });
   });
 
+  // ── Sourcing endpoint unavailable — inner loop (QUA-460) ─────────
+  describe('sourcing endpoint unavailable, inner loop (QUA-460)', () => {
+    it('aborts after 6 consecutive getVerdictsByEntity failures instead of silently reporting 0 needsCuration', async () => {
+      // Outer call succeeds (10 orgs returned)…
+      mockApiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          entities: Array.from({ length: 10 }, (_, i) => ({
+            id: `org-${i}`,
+            stableId: `sid_${i}`,
+            title: `Org ${i}`,
+            entityType: 'organization',
+          })),
+          total: 10,
+        },
+        status: 200,
+      });
+      // …but every per-entity verdict fetch fails. Pre-QUA-460, this
+      // would silently `continue` on each one, producing zero curation
+      // candidates and reporting "No entities found needing curation"
+      // even though the sourcing endpoint is down.
+      mockGetVerdictsByEntity.mockResolvedValue({
+        ok: false,
+        error: 'unavailable',
+        message: 'sourcing service 503',
+        status: 503,
+      });
+
+      const result = await commands.default([], {
+        all: true,
+        limit: '1',
+        budget: '1',
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toMatch(/Failed to fetch entities from wiki-server/);
+      expect(result.output).toMatch(/consecutive entities/i);
+      expect(result.output).toMatch(/sourcing service 503/);
+      // Must NOT silently report "no entities found".
+      expect(result.output).not.toMatch(/No entities found needing curation/);
+    });
+
+    it('tolerates up to 5 consecutive failures before aborting (threshold boundary)', async () => {
+      // 6 entities: 5 fail, then 1 succeeds with a curation candidate.
+      // The counter resets on success, so the sweep continues.
+      mockApiRequest.mockResolvedValue({
+        ok: true,
+        data: {
+          entities: Array.from({ length: 6 }, (_, i) => ({
+            id: `org-${i}`,
+            stableId: `sid_${i}`,
+            title: `Org ${i}`,
+            entityType: 'organization',
+          })),
+          total: 6,
+        },
+        status: 200,
+      });
+
+      mockGetVerdictsByEntity
+        .mockResolvedValueOnce({ ok: false, error: 'e', message: 'm', status: 503 })
+        .mockResolvedValueOnce({ ok: false, error: 'e', message: 'm', status: 503 })
+        .mockResolvedValueOnce({ ok: false, error: 'e', message: 'm', status: 503 })
+        .mockResolvedValueOnce({ ok: false, error: 'e', message: 'm', status: 503 })
+        .mockResolvedValueOnce({ ok: false, error: 'e', message: 'm', status: 503 })
+        .mockResolvedValueOnce(
+          makeVerdicts([
+            { recordType: 'personnel', recordId: 'p1', verdict: 'unchecked', displayName: 'Alice' },
+          ]),
+        );
+
+      // After 5 failures and 1 success, the sweep finds 1 entity. With
+      // dry-run, processing is lightweight and exits 0.
+      const result = await commands.default([], {
+        all: true,
+        limit: '1',
+        budget: '1',
+        'dry-run': true,
+      });
+
+      // Did NOT abort with QUA-460 consecutive-failures error.
+      expect(result.output).not.toMatch(/consecutive entities/i);
+    });
+  });
+
   // ── Credit-exhaustion handling (QUA-378) ────────────────────────────
   describe('credit exhaustion (QUA-378)', () => {
     it('aborts with exit code 2 when research throws CreditExhaustedError', async () => {

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -180,13 +180,40 @@ async function findEntitiesNeedingCuration(limit: number): Promise<FindEntitiesR
     return { ok: false, error: `${result.error}: ${result.message}` };
   }
 
-  // For each entity, check how many non-confirmed verdicts exist
+  // For each entity, check how many non-confirmed verdicts exist.
+  //
+  // QUA-460: track consecutive sourcing-endpoint failures. A single hiccup
+  // is tolerated (the entity is silently skipped and counted toward a
+  // threshold), but N consecutive failures abort the whole sweep — same
+  // pattern as the groundskeeper health-check tracker
+  // (`.claude/rules/error-handling.md`). Without this, a down sourcing
+  // endpoint would make every entity report `needsCuration: 0`, producing
+  // an empty "nothing to curate" list that the outer command can't
+  // distinguish from a legitimate "all clean" state.
+  const MAX_CONSECUTIVE_SOURCING_FAILURES = 5;
   const scored: Array<{ entity: ResolvedEntity; needsCuration: number }> = [];
+  let consecutiveSourcingFailures = 0;
+  let lastSourcingError = '';
 
   for (const e of result.data.entities) {
     const stableId = (e.stableId ?? e.stable_id ?? e.id) as string;
     const verdicts = await getVerdictsByEntity(stableId, { limit: 200 });
-    if (!verdicts.ok) continue;
+    if (!verdicts.ok) {
+      consecutiveSourcingFailures++;
+      lastSourcingError = `${verdicts.error}: ${verdicts.message}`;
+      if (consecutiveSourcingFailures > MAX_CONSECUTIVE_SOURCING_FAILURES) {
+        return {
+          ok: false,
+          error:
+            `Sourcing endpoint (getVerdictsByEntity) failed for ` +
+            `${consecutiveSourcingFailures} consecutive entities — aborting ` +
+            `instead of reporting "no entities found needing curation" with ` +
+            `incomplete data. Last error: ${lastSourcingError}`,
+        };
+      }
+      continue;
+    }
+    consecutiveSourcingFailures = 0;
 
     const needsCuration = (verdicts.data.verdicts ?? []).filter(
       (v) => NEEDS_CURATION_VERDICTS.has(v.verdict),


### PR DESCRIPTION
## Summary

Sibling of QUA-452. In `findEntitiesNeedingCuration`, the per-entity loop silently skipped on `!verdicts.ok`:

```ts
const verdicts = await getVerdictsByEntity(stableId, { limit: 200 });
if (!verdicts.ok) continue;
```

Smaller blast radius than QUA-452's outer `/api/entities` call, but same failure mode: a down sourcing endpoint makes every entity report `needsCuration: 0`, producing an empty curation list that the caller reports as "No entities found needing curation" — indistinguishable from "all clean."

## Fix

Track consecutive sourcing failures. Abort with a loud error if >5 in a row fail. Same pattern as the groundskeeper health-check tracker documented in `.claude/rules/error-handling.md`. Counter resets on any successful fetch, so transient blips are tolerated.

The outer error-handling path (added in QUA-452) already surfaces `ok: false` as exit code 1 — no caller-side changes needed.

## Test plan

- [x] New test: 6 consecutive failures → aborts with "consecutive entities" error, preserves server message, does NOT emit "No entities found needing curation"
- [x] New test: 5 failures + 1 success → sweep continues (threshold boundary)
- [x] `pnpm vitest run crux/commands/flagship-curate.test.ts` — 58/58 pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new type errors

Fixes QUA-460
