### PR TITLE
Enrich people FactBase entities (QUA-22 partial)

### DIFF
--- a/packages/factbase/data/fb-entities/amba-kak.yaml
+++ b/packages/factbase/data/fb-entities/amba-kak.yaml
@@ -7,5 +7,12 @@ facts:
         value: Mansfield College,
         source: https://www.wikidata.org/wiki/Q113084571,
         notes: From Wikidata Q113084571
+      },
+    {
+        id: f_ooxW6RYt3A,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Amba_Kak,
+        source: https://www.wikidata.org/wiki/Q113084571,
+        notes: From Wikidata Q113084571
       }
   ]

--- a/packages/factbase/data/fb-entities/ben-horowitz.yaml
+++ b/packages/factbase/data/fb-entities/ben-horowitz.yaml
@@ -3,8 +3,8 @@ facts:
   - id: f_GxdE4hs2i4
     property: description
     value: >-
-      Co-founder and general partner of Andreessen Horowitz (a16z).
-      Author of "The Hard Thing About Hard Things."
+      Co-founder and general partner of Andreessen Horowitz (a16z). Author of
+      "The Hard Thing About Hard Things."
     asOf: 2026-03
 
   - id: f_wufDSWqIso
@@ -22,3 +22,8 @@ facts:
     value: "Co-founder and General Partner, Andreessen Horowitz"
     asOf: 2009-07
     source: https://en.wikipedia.org/wiki/Ben_Horowitz
+  - id: f_c8qDKFF8cA
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Ben_Horowitz
+    source: https://www.wikidata.org/wiki/Q4885859
+    notes: From Wikidata Q4885859

--- a/packages/factbase/data/fb-entities/daniel-levy.yaml
+++ b/packages/factbase/data/fb-entities/daniel-levy.yaml
@@ -2,6 +2,12 @@ entity: sid_vIgoE1BeAk
 facts:
   - id: f_pVXDz5DKEl
     property: notable-for
-    value: "Co-founder of Safe Superintelligence Inc (SSI) with Ilya Sutskever and Daniel Gross"
+    value: "Co-founder of Safe Superintelligence Inc (SSI) with Ilya Sutskever and
+      Daniel Gross"
     source: https://ssi.inc
     notes: SSI co-founder; previously ML researcher
+  - id: f_NXLWypb56w
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Daniel_Levy_(businessman)
+    source: https://www.wikidata.org/wiki/Q861328
+    notes: From Wikidata Q861328

--- a/packages/factbase/data/fb-entities/dario-amodei.yaml
+++ b/packages/factbase/data/fb-entities/dario-amodei.yaml
@@ -9,11 +9,14 @@ facts:
     property: education
     value: "PhD in Biophysics, Princeton University"
     source: https://en.wikipedia.org/wiki/Dario_Amodei
-    notes: "Studied electrophysiology of neural circuits; thesis: 'Network-Scale Electrophysiology: Measuring and Understanding the Collective Behavior of Neural Circuits' (2011)"
+    notes: "Studied electrophysiology of neural circuits; thesis: 'Network-Scale
+      Electrophysiology: Measuring and Understanding the Collective Behavior of
+      Neural Circuits' (2011)"
 
   - id: f_dA4jK5lM6n
     property: notable-for
-    value: "CEO and co-founder of Anthropic; formerly VP of Research at OpenAI; leading proponent of responsible AI scaling"
+    value: "CEO and co-founder of Anthropic; formerly VP of Research at OpenAI;
+      leading proponent of responsible AI scaling"
     source: https://en.wikipedia.org/wiki/Dario_Amodei
 
   - id: f_dA7oP8qR9s
@@ -28,3 +31,8 @@ facts:
   - id: f_c85liwnyxb
     property: google-scholar
     value: "https://scholar.google.com/citations?user=0tSbNNgAAAAJ"
+  - id: f_WWpRINtcuw
+    property: website
+    value: https://darioamodei.com/
+    source: https://www.wikidata.org/wiki/Q103335665
+    notes: From Wikidata Q103335665

--- a/packages/factbase/data/fb-entities/david-krueger.yaml
+++ b/packages/factbase/data/fb-entities/david-krueger.yaml
@@ -2,7 +2,8 @@ entity: sid_ATFBoSnuqA
 facts:
   - id: f_hzaOwUZKsQ
     property: notable-for
-    value: "Cambridge professor researching AI alignment and safety; work on deceptive alignment and goal misgeneralization"
+    value: "Cambridge professor researching AI alignment and safety; work on
+      deceptive alignment and goal misgeneralization"
 
   - id: f_t6THqERYOg
     property: education
@@ -11,4 +12,8 @@ facts:
   - id: f_eywAH1NAxg
     property: website
     value: "https://www.davidscottkrueger.com"
-
+  - id: f_XHuidBzUqA
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/David_Krueger_(professor)
+    source: https://www.wikidata.org/wiki/Q126287512
+    notes: From Wikidata Q126287512

--- a/packages/factbase/data/fb-entities/david-sacks.yaml
+++ b/packages/factbase/data/fb-entities/david-sacks.yaml
@@ -2,14 +2,17 @@ entity: sid_JjyNWsA91A
 facts:
   - id: f_XwwBzQAhXg
     property: description
-    value: South African-American entrepreneur, venture capitalist, and White House AI and Crypto Czar who co-founded Craft
-      Ventures and played key roles at PayPal and Yammer. Appointed by President Trump in December 2024 to shape U.S. AI
-      and cryptocurrency policy.
+    value: South African-American entrepreneur, venture capitalist, and White House
+      AI and Crypto Czar who co-founded Craft Ventures and played key roles at
+      PayPal and Yammer. Appointed by President Trump in December 2024 to shape
+      U.S. AI and cryptocurrency policy.
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_dS7pQ3tV6x
     property: notable-for
-    value: "White House AI and Crypto Czar under Trump administration; co-founder of Craft Ventures; PayPal Mafia member and former COO; founded Yammer (sold to Microsoft for $1.2B)"
+    value: "White House AI and Crypto Czar under Trump administration; co-founder of
+      Craft Ventures; PayPal Mafia member and former COO; founded Yammer (sold
+      to Microsoft for $1.2B)"
     asOf: 2026-03
     source: https://en.wikipedia.org/wiki/David_Sacks
     notes: Enriched from wiki page
@@ -22,6 +25,12 @@ facts:
 
   - id: f_dSdX2bC5eD
     property: education
-    value: "B.A. in Economics, Stanford University (1994); J.D., University of Chicago Law School (1998)"
+    value: "B.A. in Economics, Stanford University (1994); J.D., University of
+      Chicago Law School (1998)"
     source: https://en.wikipedia.org/wiki/David_Sacks
     notes: Enriched from wiki page
+  - id: f_v1lg2dzSfw
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/David_Sacks
+    source: https://www.wikidata.org/wiki/Q5238174
+    notes: From Wikidata Q5238174

--- a/packages/factbase/data/fb-entities/dustin-moskovitz.yaml
+++ b/packages/factbase/data/fb-entities/dustin-moskovitz.yaml
@@ -39,3 +39,8 @@ facts:
     value: Harvard University; Vanguard High School
     source: https://www.wikidata.org/wiki/Q370217
     notes: From Wikidata Q370217
+  - id: f_7ZwsPlUQ6A
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Dustin_Moskovitz
+    source: https://www.wikidata.org/wiki/Q370217
+    notes: From Wikidata Q370217

--- a/packages/factbase/data/fb-entities/eli-lifland.yaml
+++ b/packages/factbase/data/fb-entities/eli-lifland.yaml
@@ -2,17 +2,25 @@ entity: sid_wjtZjN8acQ
 facts:
   - id: f_MGt6wCbGFA
     property: description
-    value: "AI researcher, forecaster, and entrepreneur specializing in AGI timelines forecasting, scenario planning, and AI
-      governance. Ranks #1 on the RAND Forecasting Initiative all-time leaderboard and co-authored the influential AI
-      2027 scenario forecast."
+    value: "AI researcher, forecaster, and entrepreneur specializing in AGI
+      timelines forecasting, scenario planning, and AI governance. Ranks #1 on
+      the RAND Forecasting Initiative all-time leaderboard and co-authored the
+      influential AI 2027 scenario forecast."
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_eL6tN2pQ1v
     property: notable-for
-    value: "Ranked #1 on RAND Forecasting Initiative all-time leaderboard; co-authored AI 2027 scenario forecast; co-leads Samotsvety forecasting team; co-founded AI Futures Project"
+    value: "Ranked #1 on RAND Forecasting Initiative all-time leaderboard;
+      co-authored AI 2027 scenario forecast; co-leads Samotsvety forecasting
+      team; co-founded AI Futures Project"
     asOf: 2026-03
     notes: Enriched from wiki page
   - id: f_eLcY8fL6kA
     property: education
     value: "Computer science and economics degrees, University of Virginia"
     notes: Enriched from wiki page
+  - id: f_FhVj6PJZfg
+    property: website
+    value: https://www.elilifland.com/
+    source: https://www.wikidata.org/wiki/Q135134339
+    notes: From Wikidata Q135134339

--- a/packages/factbase/data/fb-entities/eliezer-yudkowsky.yaml
+++ b/packages/factbase/data/fb-entities/eliezer-yudkowsky.yaml
@@ -10,11 +10,14 @@ facts:
     property: education
     value: "Self-taught; no formal university education"
     source: https://en.wikipedia.org/wiki/Eliezer_Yudkowsky
-    notes: "Autodidact; dropped out of school at age 12; taught himself AI and mathematics"
+    notes: "Autodidact; dropped out of school at age 12; taught himself AI and
+      mathematics"
 
   - id: f_eY4fG5hI6j
     property: notable-for
-    value: "Founder of MIRI; pioneer of AI alignment as a field; author of 'The Sequences' on rationality; author of Harry Potter and the Methods of Rationality; prominent AI doomer"
+    value: "Founder of MIRI; pioneer of AI alignment as a field; author of 'The
+      Sequences' on rationality; author of Harry Potter and the Methods of
+      Rationality; prominent AI doomer"
     source: https://en.wikipedia.org/wiki/Eliezer_Yudkowsky
 
   - id: f_eY7kL8mN9o
@@ -29,3 +32,8 @@ facts:
   - id: f_tcr35bkwp1
     property: website
     value: "https://www.yudkowsky.net"
+  - id: f_MkyGgUzPuQ
+    property: website
+    value: https://www.yudkowsky.net/
+    source: https://www.wikidata.org/wiki/Q704195
+    notes: From Wikidata Q704195

--- a/packages/factbase/data/fb-entities/elon-musk.yaml
+++ b/packages/factbase/data/fb-entities/elon-musk.yaml
@@ -7,20 +7,23 @@ facts:
 
   - id: f_eM1aB2cD3e
     property: education
-    value: "BS in Economics and BS in Physics, University of Pennsylvania; briefly attended Stanford PhD program (dropped out after 2 days)"
+    value: "BS in Economics and BS in Physics, University of Pennsylvania; briefly
+      attended Stanford PhD program (dropped out after 2 days)"
     source: https://en.wikipedia.org/wiki/Elon_Musk
 
   - id: f_eM4fG5hI6j
     property: notable-for
-    value: "CEO of Tesla and SpaceX; founder of xAI; co-founder of OpenAI; owner of X/Twitter; one of the wealthiest people in history"
+    value: "CEO of Tesla and SpaceX; founder of xAI; co-founder of OpenAI; owner of
+      X/Twitter; one of the wealthiest people in history"
     source: https://en.wikipedia.org/wiki/Elon_Musk
 
   - id: f_eM7kL8mN9o
     property: net-worth
-    value: 650e9
+    value: 6.5e+11
     asOf: 2026-03
     source: https://www.bloomberg.com/billionaires/
-    notes: "Fluctuates significantly with Tesla stock price; Bloomberg Billionaires Index estimate as of March 2026"
+    notes: "Fluctuates significantly with Tesla stock price; Bloomberg Billionaires
+      Index estimate as of March 2026"
 
   - id: f_SxwgL1y46Q
     property: social-media
@@ -35,4 +38,10 @@ facts:
 
   - id: f_K7bEkeGkVA
     property: description
-    value: "Damages sought in Musk v. OpenAI expanded lawsuit (Aug 2024): $134.5B (racketeering claims)"
+    value: "Damages sought in Musk v. OpenAI expanded lawsuit (Aug 2024): $134.5B
+      (racketeering claims)"
+  - id: f_xjFfRmaBmA
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Elon_Musk
+    source: https://www.wikidata.org/wiki/Q317521
+    notes: From Wikidata Q317521

--- a/packages/factbase/data/fb-entities/gary-marcus.yaml
+++ b/packages/factbase/data/fb-entities/gary-marcus.yaml
@@ -19,7 +19,9 @@ facts:
     notes: From Wikidata Q3348133
   - id: f_gM6tN2pQ8v
     property: notable-for
-    value: "Prominent AI critic skeptical of deep learning as path to AGI; advocate for hybrid neurosymbolic AI approaches; author of Rebooting AI and Kluge; founder of Geometric Intelligence (acquired by Uber)"
+    value: "Prominent AI critic skeptical of deep learning as path to AGI; advocate
+      for hybrid neurosymbolic AI approaches; author of Rebooting AI and Kluge;
+      founder of Geometric Intelligence (acquired by Uber)"
     asOf: 2026-03
     source: https://en.wikipedia.org/wiki/Gary_Marcus
     notes: Enriched from public information
@@ -32,6 +34,17 @@ facts:
 
   - id: f_gMcY8fL5kA
     property: education
-    value: "Ph.D. in Brain and Cognitive Sciences, MIT (1993); B.A. from Hampshire College"
+    value: "Ph.D. in Brain and Cognitive Sciences, MIT (1993); B.A. from Hampshire
+      College"
     source: https://en.wikipedia.org/wiki/Gary_Marcus
     notes: Enriched from public information; studied under Steven Pinker at MIT
+  - id: f_ivxFescpwg
+    property: website
+    value: http://garymarcus.com/
+    source: https://www.wikidata.org/wiki/Q3348133
+    notes: From Wikidata Q3348133
+  - id: f_yclMHMrZag
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Gary_Marcus
+    source: https://www.wikidata.org/wiki/Q3348133
+    notes: From Wikidata Q3348133

--- a/packages/factbase/data/fb-entities/geoffrey-hinton.yaml
+++ b/packages/factbase/data/fb-entities/geoffrey-hinton.yaml
@@ -3,17 +3,21 @@ facts:
   - id: f_xrorsSWSXw
     property: born-year
     value: 1947
-    notes: "Born December 6, 1947 in London; Nobel Prize in Physics 2024 for foundational work on artificial neural networks"
+    notes: "Born December 6, 1947 in London; Nobel Prize in Physics 2024 for
+      foundational work on artificial neural networks"
 
   - id: f_gH1aB2cD3e
     property: education
-    value: "PhD in Artificial Intelligence, University of Edinburgh (1978); BA in Experimental Psychology, Cambridge University"
+    value: "PhD in Artificial Intelligence, University of Edinburgh (1978); BA in
+      Experimental Psychology, Cambridge University"
     source: https://en.wikipedia.org/wiki/Geoffrey_Hinton
     notes: "Also held postdoctoral positions at Sussex and UCSD"
 
   - id: f_gH4fG5hI6j
     property: notable-for
-    value: "Godfather of deep learning; pioneer of backpropagation, Boltzmann machines, and deep neural networks; Nobel Prize in Physics 2024; Turing Award 2018"
+    value: "Godfather of deep learning; pioneer of backpropagation, Boltzmann
+      machines, and deep neural networks; Nobel Prize in Physics 2024; Turing
+      Award 2018"
     source: https://en.wikipedia.org/wiki/Geoffrey_Hinton
 
   - id: f_gH7kL8mN9o
@@ -32,3 +36,8 @@ facts:
   - id: f_dx6qemfhow
     property: website
     value: "https://www.cs.toronto.edu/~hinton/"
+  - id: f_HtSld5WzPw
+    property: website
+    value: https://www.cs.toronto.edu/~hinton
+    source: https://www.wikidata.org/wiki/Q92894
+    notes: From Wikidata Q92894

--- a/packages/factbase/data/fb-entities/greg-brockman.yaml
+++ b/packages/factbase/data/fb-entities/greg-brockman.yaml
@@ -11,3 +11,13 @@ facts:
       School; University of North Dakota
     source: https://www.wikidata.org/wiki/Q100604534
     notes: From Wikidata Q100604534
+  - id: f_kurARWjFmw
+    property: website
+    value: https://gregbrockman.com/
+    source: https://www.wikidata.org/wiki/Q100604534
+    notes: From Wikidata Q100604534
+  - id: f_rFCRDTN24g
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Greg_Brockman
+    source: https://www.wikidata.org/wiki/Q100604534
+    notes: From Wikidata Q100604534

--- a/packages/factbase/data/fb-entities/gwern.yaml
+++ b/packages/factbase/data/fb-entities/gwern.yaml
@@ -2,14 +2,24 @@ entity: sid_25eyvY39Bw
 facts:
   - id: f_vHXRymjxzA
     property: description
-    value: Comprehensive biographical profile of pseudonymous researcher Gwern Branwen, documenting his early advocacy of AI
-      scaling laws (predicting AGI by 2030), extensive self-experimentation work, and influence within rationalist/EA
-      communities. While well-sourced with 47 citations, the page functions as r
+    value: Comprehensive biographical profile of pseudonymous researcher Gwern
+      Branwen, documenting his early advocacy of AI scaling laws (predicting AGI
+      by 2030), extensive self-experimentation work, and influence within
+      rationalist/EA communities. While well-sourced with 47 citations, the page
+      functions as r
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_gw6tN2pQ9v
     property: notable-for
-    value: "Early advocate of AI scaling hypothesis predicting AGI by 2030; maintains gwern.net as comprehensive research archive on AI, psychology, and statistics; influential in rationalist and LessWrong communities; over 90,000 Wikipedia edits"
+    value: "Early advocate of AI scaling hypothesis predicting AGI by 2030;
+      maintains gwern.net as comprehensive research archive on AI, psychology,
+      and statistics; influential in rationalist and LessWrong communities; over
+      90,000 Wikipedia edits"
     asOf: 2026-03
     source: https://gwern.net
     notes: Enriched from wiki page; pseudonymous researcher, no born-year added
+  - id: f_NkRlYhhmxw
+    property: website
+    value: https://www.gwern.net/
+    source: https://www.wikidata.org/wiki/Q108133995
+    notes: From Wikidata Q108133995

--- a/packages/factbase/data/fb-entities/hannu-rajaniemi.yaml
+++ b/packages/factbase/data/fb-entities/hannu-rajaniemi.yaml
@@ -14,5 +14,12 @@ facts:
         value: University of Oulu; University of Edinburgh,
         source: https://www.wikidata.org/wiki/Q524579,
         notes: From Wikidata Q524579
+      },
+    {
+        id: f_Mg0POGyaOw,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Hannu_Rajaniemi,
+        source: https://www.wikidata.org/wiki/Q524579,
+        notes: From Wikidata Q524579
       }
   ]

--- a/packages/factbase/data/fb-entities/helen-toner.yaml
+++ b/packages/factbase/data/fb-entities/helen-toner.yaml
@@ -21,7 +21,10 @@ facts:
     notes: From Wikidata Q123475976
   - id: f_hT6tN2pQ4v
     property: notable-for
-    value: "Former OpenAI board member who voted to remove Sam Altman in November 2023; Interim Executive Director of Georgetown CSET; TIME 100 Most Influential People in AI 2024; expertise in US-China AI competition and AI governance"
+    value: "Former OpenAI board member who voted to remove Sam Altman in November
+      2023; Interim Executive Director of Georgetown CSET; TIME 100 Most
+      Influential People in AI 2024; expertise in US-China AI competition and AI
+      governance"
     asOf: 2026-03
     notes: Enriched from wiki page
   - id: f_hTcY8fL0kA
@@ -31,5 +34,16 @@ facts:
 
   - id: f_hTfB4gN2mD
     property: education
-    value: "BSc Chemical Engineering, University of Melbourne (2014); MA Security Studies, Georgetown University (2021)"
+    value: "BSc Chemical Engineering, University of Melbourne (2014); MA Security
+      Studies, Georgetown University (2021)"
     notes: Enriched from wiki page
+  - id: f_hIjXQlR0lQ
+    property: website
+    value: https://cset.georgetown.edu/staff/helen-toner/
+    source: https://www.wikidata.org/wiki/Q123475976
+    notes: From Wikidata Q123475976
+  - id: f_CXwz9m0lLw
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Helen_Toner
+    source: https://www.wikidata.org/wiki/Q123475976
+    notes: From Wikidata Q123475976

--- a/packages/factbase/data/fb-entities/ian-hogarth.yaml
+++ b/packages/factbase/data/fb-entities/ian-hogarth.yaml
@@ -2,7 +2,8 @@ entity: sid_DX4NK1gGtg
 facts:
   - id: f_fIpd1bJ2xg
     property: description
-    value: AI investor and writer; former Chair of the UK AI Safety Institute (2023-2025).
+    value: AI investor and writer; former Chair of the UK AI Safety Institute
+      (2023-2025).
     asOf: 2026-03
     notes: Stepped down as Chair in 2025
   - id: f_iH2nLw9pYr
@@ -13,5 +14,10 @@ facts:
   - id: f_Knt2LH5GjK
     property: education
     value: University of Cambridge; Beijing Language and Culture University
+    source: https://www.wikidata.org/wiki/Q14946860
+    notes: From Wikidata Q14946860
+  - id: f_SGZhfJvEAg
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Ian_Hogarth
     source: https://www.wikidata.org/wiki/Q14946860
     notes: From Wikidata Q14946860

--- a/packages/factbase/data/fb-entities/issa-rice.yaml
+++ b/packages/factbase/data/fb-entities/issa-rice.yaml
@@ -2,13 +2,22 @@ entity: sid_nuR3te3Rkw
 facts:
   - id: f_z6ueVAGyzQ
     property: description
-    value: Issa Rice is an independent researcher who has created valuable knowledge infrastructure tools like Timelines
-      Wiki and AI Watch for the EA and AI safety communities, though his work focuses on data aggregation rather than
-      original research. His contributions are primarily utilitarian reference mater
+    value: Issa Rice is an independent researcher who has created valuable knowledge
+      infrastructure tools like Timelines Wiki and AI Watch for the EA and AI
+      safety communities, though his work focuses on data aggregation rather
+      than original research. His contributions are primarily utilitarian
+      reference mater
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_iR6tN2pQ8v
     property: notable-for
-    value: "Created Timelines Wiki, AI Watch, and Org Watch for EA and AI safety communities; prolific knowledge infrastructure builder; contract researcher primarily funded by Vipul Naik"
+    value: "Created Timelines Wiki, AI Watch, and Org Watch for EA and AI safety
+      communities; prolific knowledge infrastructure builder; contract
+      researcher primarily funded by Vipul Naik"
     asOf: 2026-03
     notes: Enriched from wiki page
+  - id: f_GRKV4N3Nng
+    property: website
+    value: https://issarice.com/
+    source: https://www.wikidata.org/wiki/Q131154938
+    notes: From Wikidata Q131154938

--- a/packages/factbase/data/fb-entities/jaan-tallinn.yaml
+++ b/packages/factbase/data/fb-entities/jaan-tallinn.yaml
@@ -26,3 +26,22 @@ facts:
     value: University of Tartu; Gustav Adolf Grammar School
     source: https://www.wikidata.org/wiki/Q3156998
     notes: From Wikidata Q3156998
+  - id: f_EZnSjqqhyA
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Jaan_Tallinn
+    source: https://www.wikidata.org/wiki/Q3156998
+    notes: From Wikidata Q3156998
+  - id: f_ysJDGkAo2Q
+    property: notable-for
+    value: Co-founder of Skype (2003); co-founder of Centre for the Study of
+      Existential Risk (CSER, 2012) and Future of Life Institute (FLI, 2014);
+      primary funder of Survival and Flourishing Fund (SFF) and Lightspeed
+      Grants; major philanthropic donor to AI safety research
+    asOf: 2026-04
+    source: https://en.wikipedia.org/wiki/Jaan_Tallinn
+  - id: f_UWG1ka4xug
+    property: role
+    value: Founder and philanthropist; primary funder of SFF (Survival and
+      Flourishing Fund) and Lightspeed Grants
+    asOf: 2026-04
+    source: https://en.wikipedia.org/wiki/Jaan_Tallinn

--- a/packages/factbase/data/fb-entities/jack-clark.yaml
+++ b/packages/factbase/data/fb-entities/jack-clark.yaml
@@ -6,5 +6,15 @@ facts:
 
   - id: f_y6ELYGnAGQ
     property: notable-for
-    value: "Co-founder of Anthropic; former Policy Director at OpenAI; creator of the Import AI newsletter; AI policy advocate"
-
+    value: "Co-founder of Anthropic; former Policy Director at OpenAI; creator of
+      the Import AI newsletter; AI policy advocate"
+  - id: f_ImsORphD5g
+    property: website
+    value: https://jack-clark.net/
+    source: https://www.wikidata.org/wiki/Q135111322
+    notes: From Wikidata Q135111322
+  - id: f_jDL9bXdqCQ
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Jack_Clark_(AI_policy_expert)
+    source: https://www.wikidata.org/wiki/Q135111322
+    notes: From Wikidata Q135111322

--- a/packages/factbase/data/fb-entities/jan-leike.yaml
+++ b/packages/factbase/data/fb-entities/jan-leike.yaml
@@ -4,14 +4,40 @@ facts:
     property: education
     value: "PhD in Machine Learning, Australian National University"
     source: https://jan.leike.name/
-    notes: "PhD supervised by Marcus Hutter; research on universal reinforcement learning"
+    notes: "PhD supervised by Marcus Hutter; research on universal reinforcement
+      learning"
 
   - id: f_jL4fG5hI6j
     property: notable-for
-    value: "VP of Alignment Science at Anthropic; former co-lead of OpenAI Superalignment team; prominent advocate for AI safety resource allocation"
+    value: "VP of Alignment Science at Anthropic; former co-lead of OpenAI
+      Superalignment team; prominent advocate for AI safety resource allocation"
     source: https://en.wikipedia.org/wiki/Jan_Leike
 
   - id: f_jL7kL8mN9o
     property: social-media
     value: "@janleike"
     source: https://x.com/janleike
+  - id: f_yn1d2BADOw
+    property: website
+    value: https://jan.leike.name/
+    source: https://www.wikidata.org/wiki/Q123130693
+    notes: From Wikidata Q123130693
+  - id: f_DifUNoifXg
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Jan_Leike
+    source: https://www.wikidata.org/wiki/Q123130693
+    notes: From Wikidata Q123130693
+  - id: f_qdvJAWaYJg
+    property: description
+    value: German AI safety researcher; VP of Alignment Science at Anthropic since
+      2024 after leaving OpenAI, where he co-led the Superalignment team with
+      Ilya Sutskever. His research focuses on scalable oversight, recursive
+      reward modeling, and AI alignment. Prominent public voice on AI safety
+      resource allocation.
+    asOf: 2026-04
+    source: https://en.wikipedia.org/wiki/Jan_Leike
+  - id: f_9hQAFolmjQ
+    property: role
+    value: VP of Alignment Science, Anthropic
+    asOf: 2024-05
+    source: https://jan.leike.name/

--- a/packages/factbase/data/fb-entities/jared-kaplan.yaml
+++ b/packages/factbase/data/fb-entities/jared-kaplan.yaml
@@ -2,9 +2,14 @@ entity: sid_x16GL4gP2A
 facts:
   - id: f_clGvV7hzcA
     property: notable-for
-    value: "Co-founder of Anthropic; Johns Hopkins physics professor; co-author of neural scaling laws research"
+    value: "Co-founder of Anthropic; Johns Hopkins physics professor; co-author of
+      neural scaling laws research"
 
   - id: f_h7OOErJfYQ
     property: education
     value: "PhD in Physics, Stanford University"
-
+  - id: f_e2w29wsIKg
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Jared_Kaplan
+    source: https://www.wikidata.org/wiki/Q102649624
+    notes: From Wikidata Q102649624

--- a/packages/factbase/data/fb-entities/jennifer-pahlka.yaml
+++ b/packages/factbase/data/fb-entities/jennifer-pahlka.yaml
@@ -14,5 +14,12 @@ facts:
         value: Yale University,
         source: https://www.wikidata.org/wiki/Q6178697,
         notes: From Wikidata Q6178697
+      },
+    {
+        id: f_vTdhGZzbxA,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Jennifer_Pahlka,
+        source: https://www.wikidata.org/wiki/Q6178697,
+        notes: From Wikidata Q6178697
       }
   ]

--- a/packages/factbase/data/fb-entities/jeremie-harris.yaml
+++ b/packages/factbase/data/fb-entities/jeremie-harris.yaml
@@ -1,2 +1,11 @@
 entity: sid_aJOiUj35UA
-facts: []
+facts:
+  [
+    {
+        id: f_33pVcNKFEg,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Jeremie_Harris,
+        source: https://www.wikidata.org/wiki/Q47658458,
+        notes: From Wikidata Q47658458
+      }
+  ]

--- a/packages/factbase/data/fb-entities/jimmy-ba.yaml
+++ b/packages/factbase/data/fb-entities/jimmy-ba.yaml
@@ -3,3 +3,9 @@ thing:
   stableId: sid_AdQS3o56n7
   type: person
   name: "Jimmy Ba"
+facts:
+  - id: f_WzDlkBJ44Q
+    property: website
+    value: https://jimmylba.github.io/
+    source: https://www.wikidata.org/wiki/Q50380592
+    notes: From Wikidata Q50380592

--- a/packages/factbase/data/fb-entities/joe-biden.yaml
+++ b/packages/factbase/data/fb-entities/joe-biden.yaml
@@ -8,10 +8,17 @@ facts:
 
   - id: f_Ix3mkuMr35
     property: notable-for
-    value: "46th President of the United States (2021-2025); signed Executive Order 14110 on Safe, Secure, and Trustworthy AI (October 2023), the most comprehensive federal AI policy action at the time"
+    value: "46th President of the United States (2021-2025); signed Executive Order
+      14110 on Safe, Secure, and Trustworthy AI (October 2023), the most
+      comprehensive federal AI policy action at the time"
     source: https://en.wikipedia.org/wiki/Joe_Biden
     notes: "EO 14110 was later revoked by the Trump administration in January 2025"
 
   - id: f_QLtye0VpIp
     property: wikipedia-url
     value: "https://en.wikipedia.org/wiki/Joe_Biden"
+  - id: f_02wv3I18Rw
+    property: website
+    value: https://joebiden.com/es/inicio
+    source: https://www.wikidata.org/wiki/Q6279
+    notes: From Wikidata Q6279

--- a/packages/factbase/data/fb-entities/joelle-pineau.yaml
+++ b/packages/factbase/data/fb-entities/joelle-pineau.yaml
@@ -3,3 +3,14 @@ thing:
   stableId: sid_he0I2G8Q4g
   type: person
   name: "Joëlle Pineau"
+facts:
+  - id: f_ru9KtelDmQ
+    property: website
+    value: http://www.cs.mcgill.ca/~jpineau/
+    source: https://www.wikidata.org/wiki/Q44741969
+    notes: From Wikidata Q44741969
+  - id: f_KBUgua6uPQ
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Jo%C3%ABlle_Pineau
+    source: https://www.wikidata.org/wiki/Q44741969
+    notes: From Wikidata Q44741969

--- a/packages/factbase/data/fb-entities/john-etchemendy.yaml
+++ b/packages/factbase/data/fb-entities/john-etchemendy.yaml
@@ -1,2 +1,18 @@
 entity: sid_rhgfPZYXTw
-facts: []
+facts:
+  [
+    {
+        id: f_Nq6nRKegAg,
+        property: website,
+        value: https://profiles.stanford.edu/john-etchemendy,
+        source: https://www.wikidata.org/wiki/Q6231954,
+        notes: From Wikidata Q6231954
+      },
+    {
+        id: f_pmWH4UXg8Q,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/John_Etchemendy,
+        source: https://www.wikidata.org/wiki/Q6231954,
+        notes: From Wikidata Q6231954
+      }
+  ]

--- a/packages/factbase/data/fb-entities/john-schulman.yaml
+++ b/packages/factbase/data/fb-entities/john-schulman.yaml
@@ -7,5 +7,19 @@ facts:
         value: "University of California, Berkeley; California Institute of Technology",
         source: https://www.wikidata.org/wiki/Q103236782,
         notes: From Wikidata Q103236782
+      },
+    {
+        id: f_Ho2oLmylvg,
+        property: website,
+        value: http://joschu.net/,
+        source: https://www.wikidata.org/wiki/Q103236782,
+        notes: From Wikidata Q103236782
+      },
+    {
+        id: f_3CcnwesK2w,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/John_Schulman,
+        source: https://www.wikidata.org/wiki/Q103236782,
+        notes: From Wikidata Q103236782
       }
   ]

--- a/packages/factbase/data/fb-entities/kate-crawford.yaml
+++ b/packages/factbase/data/fb-entities/kate-crawford.yaml
@@ -14,5 +14,19 @@ facts:
         value: University of Sydney,
         source: https://www.wikidata.org/wiki/Q6375450,
         notes: From Wikidata Q6375450
+      },
+    {
+        id: f_ayiBY3bl0w,
+        property: website,
+        value: http://www.katecrawford.net/,
+        source: https://www.wikidata.org/wiki/Q6375450,
+        notes: From Wikidata Q6375450
+      },
+    {
+        id: f_k466qtfZcg,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Kate_Crawford,
+        source: https://www.wikidata.org/wiki/Q6375450,
+        notes: From Wikidata Q6375450
       }
   ]

--- a/packages/factbase/data/fb-entities/marc-andreessen.yaml
+++ b/packages/factbase/data/fb-entities/marc-andreessen.yaml
@@ -19,7 +19,9 @@ facts:
     notes: From Wikidata Q62882
   - id: f_mA6tN2pQ7v
     property: notable-for
-    value: "Co-created Mosaic web browser (1993); founded Netscape (sold to AOL for $4.2B); co-founded Andreessen Horowitz managing $90B+ in venture capital; techno-optimist AI advocate opposing safety regulation"
+    value: "Co-created Mosaic web browser (1993); founded Netscape (sold to AOL for
+      $4.2B); co-founded Andreessen Horowitz managing $90B+ in venture capital;
+      techno-optimist AI advocate opposing safety regulation"
     asOf: 2026-03
     source: https://en.wikipedia.org/wiki/Marc_Andreessen
     notes: Enriched from wiki page
@@ -43,19 +45,22 @@ facts:
     source: https://a16z.com/the-techno-optimist-manifesto/
     notes: >-
       Published October 2023. Critiques EA, longtermism, and AI safety
-      regulation. Lists effective altruism and deceleration/safety
-      movements among ideologies opposed to techno-optimism.
+      regulation. Lists effective altruism and deceleration/safety movements
+      among ideologies opposed to techno-optimism.
 
   - id: f_mAeW9qM2xC
     property: political-positioning
     value: >-
-      Publicly supported Republican candidates and endorsed Trump
-      circa 2023-2024. This positioning, combined with the Techno-Optimist
-      Manifesto, increased tensions between a16z and EA/AI safety
-      communities.
+      Publicly supported Republican candidates and endorsed Trump circa
+      2023-2024. This positioning, combined with the Techno-Optimist Manifesto,
+      increased tensions between a16z and EA/AI safety communities.
     asOf: 2024-01
     source: https://en.wikipedia.org/wiki/Marc_Andreessen
     notes: >-
-      The a16z/EA conflict involves both political affiliation differences
-      and substantive disagreement on AI development pace and safety
-      regulation.
+      The a16z/EA conflict involves both political affiliation differences and
+      substantive disagreement on AI development pace and safety regulation.
+  - id: f_KrTmj3K5bQ
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Marc_Andreessen
+    source: https://www.wikidata.org/wiki/Q62882
+    notes: From Wikidata Q62882

--- a/packages/factbase/data/fb-entities/meredith-whittaker.yaml
+++ b/packages/factbase/data/fb-entities/meredith-whittaker.yaml
@@ -6,12 +6,21 @@ facts:
         property: born-year,
         value: 1982,
         source: https://en.wikipedia.org/wiki/Meredith_Whittaker,
-        notes: "Born 1982; Wikidata Q55433882 listed only '20th century'. Established AI researcher (Google 2006-2018), Signal Foundation president since 2022."
+        notes: "Born 1982; Wikidata Q55433882 listed only '20th century'. Established AI
+          researcher (Google 2006-2018), Signal Foundation president since
+          2022."
       },
     {
         id: f_8NQqe4ohuH,
         property: education,
         value: "University of California, Berkeley College of Engineering",
+        source: https://www.wikidata.org/wiki/Q55433882,
+        notes: From Wikidata Q55433882
+      },
+    {
+        id: f_QChNq2Yn1Q,
+        property: wikipedia-url,
+        value: https://en.wikipedia.org/wiki/Meredith_Whittaker,
         source: https://www.wikidata.org/wiki/Q55433882,
         notes: From Wikidata Q55433882
       }

--- a/packages/factbase/data/fb-entities/mike-krieger.yaml
+++ b/packages/factbase/data/fb-entities/mike-krieger.yaml
@@ -3,3 +3,9 @@ thing:
   stableId: sid_FNwvoeGSpW
   type: person
   name: "Mike Krieger"
+facts:
+  - id: f_lf2E9LgcSg
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Mike_Krieger
+    source: https://www.wikidata.org/wiki/Q10329947
+    notes: From Wikidata Q10329947

--- a/packages/factbase/data/fb-entities/nick-beckstead.yaml
+++ b/packages/factbase/data/fb-entities/nick-beckstead.yaml
@@ -2,13 +2,17 @@ entity: sid_licWPlOJMg
 facts:
   - id: f_NwIcIbqfqQ
     property: description
-    value: Nick Beckstead is a philosopher and philanthropist who completed his PhD at Rutgers University in 2013 with a
-      dissertation arguing for the overwhelming importance of shaping the far future—one of the first rigorous academic
-      defenses of longtermism. He served as a program officer at Open Philanthropy, where he managed a substantial
-      longtermism portfolio focusing on existential risk reduction and global catastrophic risk. He later became a
-      founding team member of the FTX Future Fund before its collapse in November 2022 when FTX filed for bankruptcy. He
-      subsequently founded the Secure AI Project, a policy advocacy organization focused on legislative requirements for
-      AI safety protocols and whistleblower protections.
+    value: Nick Beckstead is a philosopher and philanthropist who completed his PhD
+      at Rutgers University in 2013 with a dissertation arguing for the
+      overwhelming importance of shaping the far future—one of the first
+      rigorous academic defenses of longtermism. He served as a program officer
+      at Open Philanthropy, where he managed a substantial longtermism portfolio
+      focusing on existential risk reduction and global catastrophic risk. He
+      later became a founding team member of the FTX Future Fund before its
+      collapse in November 2022 when FTX filed for bankruptcy. He subsequently
+      founded the Secure AI Project, a policy advocacy organization focused on
+      legislative requirements for AI safety protocols and whistleblower
+      protections.
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_9EOQ53N4Gg
@@ -16,6 +20,25 @@ facts:
     value: https://www.nickbeckstead.com/
   - id: f_nB2nLw9pYr
     property: notable-for
-    value: "Longtermism, existential risk, FTX Future Fund leadership, Secure AI Project"
+    value: "Longtermism, existential risk, FTX Future Fund leadership, Secure AI
+      Project"
     asOf: "2026-03"
     notes: "Migrated from entity customFields"
+  - id: f_t0mBxqD8qA
+    property: education
+    value: PhD Philosophy, Rutgers University (2013); dissertation 'On the
+      Overwhelming Importance of Shaping the Far Future'
+    asOf: "2013"
+    source: https://philpapers.org/rec/BECOTO-3
+  - id: f_Dlo6H5eUNQ
+    property: role
+    value: Founder, Secure AI Project (AI safety policy advocacy organization)
+    asOf: "2024"
+    source: https://secureaiproject.org/
+  - id: f_ylO6QcJMfw
+    property: notable-for
+    value: PhD dissertation defending longtermism; former Open Philanthropy program
+      officer (longtermism portfolio); founding team, FTX Future Fund (2022);
+      founder, Secure AI Project
+    asOf: 2026-04
+    source: https://www.nickbeckstead.com/

--- a/packages/factbase/data/fb-entities/pushmeet-kohli.yaml
+++ b/packages/factbase/data/fb-entities/pushmeet-kohli.yaml
@@ -3,3 +3,14 @@ thing:
   stableId: sid_6T8nglIbo6
   type: person
   name: "Pushmeet Kohli"
+facts:
+  - id: f_uygVBbfzrA
+    property: website
+    value: https://research.google/people/105667
+    source: https://www.wikidata.org/wiki/Q21061678
+    notes: From Wikidata Q21061678
+  - id: f_fE4XcBPhfw
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Pushmeet_Kohli
+    source: https://www.wikidata.org/wiki/Q21061678
+    notes: From Wikidata Q21061678

--- a/packages/factbase/data/fb-entities/reid-hoffman.yaml
+++ b/packages/factbase/data/fb-entities/reid-hoffman.yaml
@@ -3,9 +3,9 @@ facts:
   - id: f_3sWzLPJYzt
     property: description
     value: >-
-      Co-founder of LinkedIn and partner at Greylock Partners. One of the
-      most prominent tech donors focused on democracy and political stability.
-      Board member at Microsoft.
+      Co-founder of LinkedIn and partner at Greylock Partners. One of the most
+      prominent tech donors focused on democracy and political stability. Board
+      member at Microsoft.
     asOf: 2026-03
 
   - id: f_NOQQbpFdyH
@@ -15,14 +15,25 @@ facts:
 
   - id: f_mI1D9F9YjL
     property: education
-    value: "B.S. Symbolic Systems, Stanford; M.St. Philosophy, Oxford (Marshall Scholar)"
+    value: "B.S. Symbolic Systems, Stanford; M.St. Philosophy, Oxford (Marshall
+      Scholar)"
     source: https://en.wikipedia.org/wiki/Reid_Hoffman
 
   - id: f_kBEnmPVUDD
     property: notable-for
     value: >-
       Co-founded LinkedIn (2002, acquired by Microsoft for $26.2B in 2016);
-      early PayPal executive; Greylock Partners board partner; major
-      Democratic donor and democracy-focused philanthropist.
+      early PayPal executive; Greylock Partners board partner; major Democratic
+      donor and democracy-focused philanthropist.
     asOf: 2026-03
     source: https://en.wikipedia.org/wiki/Reid_Hoffman
+  - id: f_qquhh05S1g
+    property: website
+    value: http://reidhoffman.org/
+    source: https://www.wikidata.org/wiki/Q211098
+    notes: From Wikidata Q211098
+  - id: f_MEk07SCScg
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Reid_Hoffman
+    source: https://www.wikidata.org/wiki/Q211098
+    notes: From Wikidata Q211098

--- a/packages/factbase/data/fb-entities/robin-hanson.yaml
+++ b/packages/factbase/data/fb-entities/robin-hanson.yaml
@@ -45,3 +45,8 @@ facts:
     value: https://en.wikipedia.org/wiki/Robin_Hanson
     source: https://www.wikidata.org/wiki/Q2159779
     notes: From Wikidata Q2159779 (economist, not the swimmer Q106923078)
+  - id: f_vdJuI5cYqw
+    property: wikipedia-url
+    value: https://en.wikipedia.org/wiki/Robin_Hanson_(swimmer)
+    source: https://www.wikidata.org/wiki/Q106923078
+    notes: From Wikidata Q106923078

--- a/packages/factbase/data/fb-entities/sarah-myers-west.yaml
+++ b/packages/factbase/data/fb-entities/sarah-myers-west.yaml
@@ -1,2 +1,11 @@
 entity: sid_lCvbYl5SE0
-facts: []
+facts:
+  [
+    {
+        id: f_d4txBqGCxw,
+        property: website,
+        value: https://www.sarahmyerswest.com/,
+        source: https://www.wikidata.org/wiki/Q126364614,
+        notes: From Wikidata Q126364614
+      }
+  ]

--- a/packages/factbase/data/fb-entities/vipul-naik.yaml
+++ b/packages/factbase/data/fb-entities/vipul-naik.yaml
@@ -44,4 +44,10 @@ facts:
     property: website
     value: https://vipulnaik.com/
     source: https://www.wikidata.org/wiki/Q102535772
-    notes: "Personal website; Wikidata lists this as official site (start Dec 2013). Old CMI page (cmi.ac.in/~vipul/) is outdated."
+    notes: "Personal website; Wikidata lists this as official site (start Dec 2013).
+      Old CMI page (cmi.ac.in/~vipul/) is outdated."
+  - id: f_0OaBG9NAbQ
+    property: website
+    value: http://www.cmi.ac.in/~vipul/
+    source: https://www.wikidata.org/wiki/Q102535772
+    notes: From Wikidata Q102535772


### PR DESCRIPTION
## Summary

Focused pilot on QUA-22 (enrich people entity data):

- **Wikidata enrich across all 114 person entities** via `crux fb wikidata-enrich --type=person` — added 49 new facts across 38 entities (wikipedia-url, website, born-year, education where Wikidata had matches). 7 stubs de-stubbed.
- **Hand-enriched 3 thin priority targets** with sourced facts:
  - Nick Beckstead: 3 → 6 facts (education, role, notable-for)
  - Jaan Tallinn: 5 → 8 facts (notable-for, role)
  - Jan Leike: 3 → 7 facts (description, role)
- Will MacAskill and Max Tegmark already had 8 facts each; Wikidata added no new facts for them.

Coverage delta: 90 → 97 person entities with facts (7 de-stubbed, 17 stubs remain).

## Scope note

QUA-22 calls for enrichment of 80+ sparse entries. This PR ships a pilot — full coverage of the remaining ~17 stubs + ~20 thin entries is tracked in **QUA-553** (follow-up filed this session).

Intentionally avoiding `Fixes QUA-22` to prevent auto-close; the parent ticket should remain open until QUA-553 lands.

## Test plan

- [x] `pnpm crux fb validate --errors-only` — 9 pre-existing errors unrelated to this PR (string-valued `founded-by` / `employed-by` refs on other entities)
- [x] `pnpm crux w validate gate --fix` — all 53 gate checks pass
- [x] `pnpm build-data:content` — 0 YAML parse errors, 2026 entities loaded
- [x] Priority target coverage verified via `crux fb coverage --type=person`

## Deferred

- Remaining ~37 sparse people entries → QUA-553
- `crux fb wikidata-enrich` has no person-specific SPARQL properties (P569, P19, P108, etc.) — adding them would raise automated yield significantly. Noted in QUA-553 body.
