### PR TITLE
feat(tablebase): scan field-level gaps for QUA-24 enrichment

### DIFF
--- a/crux/tablebase/prompts.ts
+++ b/crux/tablebase/prompts.ts
@@ -123,6 +123,84 @@ ${SHARED_RULES}
 
 Use resolve_entity to find entity IDs for both companies and investors.`;
 
+    case 'division-lead-fill':
+      return `You are a research agent that identifies division leads for an organization's sub-units.
+Your job is to find the current lead (director, head, principal investigator, etc.) of each division within "${task.entityName}" that is missing one.
+
+${SHARED_RULES}
+
+## Process
+1. Use query_existing_records to list "${task.entityName}"'s divisions and see which are missing the \`lead\` field.
+2. For each missing one, web_search "[division name] [org name] director" or check the org's team/about page.
+3. Use resolve_entity to find the person's stableId. If they don't exist, use create_entity to create a person entity first.
+4. Submit an updated division record with \`lead\` set to the person's stableId (e.g. "sid_XXXX"). Do NOT submit a plain display name — that's what's already broken.
+
+## Division Update Fields
+- id: The existing division ID (from query_existing_records)
+- lead: Person stableId (from resolve_entity or create_entity) — MUST be a sid_ prefixed ID, not a name
+- source: URL where you confirmed the lead (REQUIRED)
+- notes: "Lead confirmed on [source] as of ${new Date().toISOString().slice(0, 10)}."`;
+
+    case 'division-personnel-dates':
+      return `You are a research agent that backfills start and end dates for division personnel.
+Your job is to find when each person joined (and, if applicable, left) their division at "${task.entityName}".
+
+${SHARED_RULES}
+
+## Process
+1. Use query_existing_records with table="divisions" to list "${task.entityName}"'s divisions. Note each division's id.
+2. For each division id, use query_existing_records with table="division-personnel" and entityId=<divisionId> to find rows missing startDate.
+3. For each missing row, web_search "[person name] joined [org name]" or "[person name] [division name]".
+4. Check LinkedIn, press releases, and the org's team page for appointment/departure dates.
+5. Submit an updated record with startDate (and endDate if they've left).
+
+## Date fields
+- startDate: YYYY-MM-DD or YYYY. If you can only find the year, that's better than nothing.
+- endDate: Only set if the person has left. Leave null for current roles.
+- source: URL where you confirmed the date (REQUIRED)
+- notes: If date is approximate, say so (e.g. "Approximate — confirmed in role by [date]").
+
+Prefer honesty about uncertainty over fabricated precision.`;
+
+    case 'funding-program-enrichment':
+      return `You are a research agent that fills in missing fields on funding programs.
+Your job is to find totalBudget, deadline, and applicationUrl for "${task.entityName}"'s programs that are missing them.
+
+${SHARED_RULES}
+
+## Process
+1. Use query_existing_records to list funding programs missing any of totalBudget, deadline, applicationUrl.
+2. For each, visit the program's official page (search "[org name] [program name]") to find:
+   - **totalBudget**: total funding pool in USD (e.g., "$2.5M total", "up to $10M annually")
+   - **deadline**: next application deadline (YYYY-MM-DD). For rolling programs, set status to rolling instead of a date.
+   - **applicationUrl**: direct link to the application form or program page
+3. Do NOT guess amounts or dates — if the program page doesn't list them, leave the field null and note why.
+
+## Funding Program Update Fields
+- id: The existing program ID (from query_existing_records)
+- totalBudget: Dollar amount in USD (number, not string)
+- deadline: YYYY-MM-DD, or null for rolling / closed
+- applicationUrl: Full https:// URL
+- source: URL where you confirmed these fields (REQUIRED)
+- notes: Context (e.g. "Deadline confirmed on program page; amount described as 'up to $X per grant'").`;
+
+    case 'benchmark-source-fill':
+      return `You are a research agent that finds citation URLs for existing benchmark results.
+Your job is to backfill the \`sourceUrl\` field on benchmark_results records where "${task.entityName}" was scored but no source was recorded.
+
+${SHARED_RULES}
+
+## Process
+1. Use query_existing_records to list benchmark_results for "${task.entityName}" that are missing sourceUrl.
+2. For each, web_search "[model name] [benchmark name] score" or check the model's launch blog post, technical report, or the benchmark's leaderboard page.
+3. The sourceUrl should verify the exact score value — prefer primary sources (model card, official technical report, leaderboard entry) over secondary commentary.
+4. Do NOT invent URLs. If you cannot find a source for a specific score, skip that record and note it.
+
+## Benchmark Result Update Fields
+- id: The existing benchmark_result ID (from query_existing_records)
+- sourceUrl: Full https:// URL that shows the exact score (REQUIRED — that's the point of this task)
+- notes: If the source confirms a different value than recorded, flag it in notes — do NOT silently overwrite the score.`;
+
     case 'benchmark-result-fill':
       return `You are a research agent that finds benchmark results for AI models.
 Your job is to research and add benchmark scores for "${task.entityName}".

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the wiki-server client before importing the scanner module.
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe('scanner — field-level completeness (QUA-24)', () => {
+  let apiRequest: ReturnType<typeof vi.fn>;
+
+  const orgA = { id: 'open-phil', stableId: 'sid_openphil', entityType: 'organization', title: 'Open Phil', website: 'https://openphil.org' };
+  const orgB = { id: 'anthropic', stableId: 'sid_anthropic', entityType: 'organization', title: 'Anthropic', website: 'https://anthropic.com' };
+  const modelA = { id: 'claude-4', stableId: 'sid_claude4', entityType: 'ai-model', title: 'Claude 4' };
+
+  // Minimal fake for fetchAllPaginated: returns all rows in a single page.
+  function mockEndpoint(path: string, resultKey: string, rows: unknown[]) {
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (!url.startsWith(path)) return { ok: false, message: `unexpected ${url}` };
+      // fetchAllPaginated asks for limit=200 and expects a `total`.
+      return { ok: true, data: { [resultKey]: rows, total: rows.length } };
+    });
+  }
+
+  // Route-aware mock for scanners that need multiple endpoints.
+  function mockRoutes(routes: Record<string, unknown[]>, entitiesByType?: Record<string, unknown[]>) {
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      for (const [path, rows] of Object.entries(routes)) {
+        if (url.startsWith(path)) {
+          // Infer the resultKey from the path (tests pass the full response shape elsewhere)
+          const resultKey = path.includes('/divisions/all') ? 'divisions'
+            : path.includes('/division-personnel/all') ? 'divisionPersonnel'
+            : path.includes('/funding-programs/all') ? 'fundingPrograms'
+            : path.includes('/benchmark-results/all') ? 'benchmarkResults'
+            : 'items';
+          return { ok: true, data: { [resultKey]: rows, total: rows.length } };
+        }
+      }
+      if (entitiesByType && url.startsWith('/api/entities')) {
+        const match = url.match(/entityType=([^&]+)/);
+        const type = match ? decodeURIComponent(match[1]) : '';
+        return { ok: true, data: { entities: entitiesByType[type] ?? [], total: (entitiesByType[type] ?? []).length } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+  }
+
+  beforeEach(async () => {
+    const client = await import('../lib/wiki-server/client.ts');
+    apiRequest = vi.mocked(client.apiRequest);
+    apiRequest.mockReset();
+  });
+
+  // ── scanDivisionsLead ───────────────────────────────────────────────────
+
+  it('scanDivisionsLead: computes per-org fill rate and skips inactive divisions', async () => {
+    mockEndpoint('/api/divisions/all', 'divisions', [
+      { id: 'd1', parentOrgId: 'sid_openphil', name: 'Global Health', lead: 'sid_xx', status: 'active' },
+      { id: 'd2', parentOrgId: 'sid_openphil', name: 'GCR', lead: null, status: 'active' },
+      { id: 'd3', parentOrgId: 'sid_openphil', name: 'Old Program', lead: null, status: 'dissolved' }, // skipped
+      { id: 'd4', parentOrgId: 'sid_anthropic', name: 'Research', lead: null, status: 'active' },
+      { id: 'd5', parentOrgId: 'sid_anthropic', name: 'Policy', lead: null, status: 'active' },
+    ]);
+
+    const { runTableScan } = await import('./scanner.ts');
+    // runTableScan('divisions') calls fetchEntitiesByType in-line; stub that too.
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/divisions/all')) {
+        return { ok: true, data: {
+          divisions: [
+            { id: 'd1', parentOrgId: 'sid_openphil', name: 'Global Health', lead: 'sid_xx', status: 'active' },
+            { id: 'd2', parentOrgId: 'sid_openphil', name: 'GCR', lead: null, status: 'active' },
+            { id: 'd3', parentOrgId: 'sid_openphil', name: 'Old', lead: null, status: 'dissolved' },
+            { id: 'd4', parentOrgId: 'sid_anthropic', name: 'Research', lead: null, status: 'active' },
+            { id: 'd5', parentOrgId: 'sid_anthropic', name: 'Policy', lead: null, status: 'active' },
+          ],
+          total: 5,
+        } };
+      }
+      if (url.startsWith('/api/entities')) {
+        return { ok: true, data: { entities: [orgA, orgB], total: 2 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const result = await runTableScan('divisions');
+    expect(result).toBeTruthy();
+    expect(result!.table).toBe('divisions');
+    expect(result!.profiles).toHaveLength(2);
+
+    const openphil = result!.profiles.find(p => p.entityId === 'sid_openphil')!;
+    // 1 with lead, 1 without; dissolved excluded → 1/2 = 50%
+    expect(openphil.completenessPercent).toBe(50);
+    expect(openphil.totalRecords).toBe(2);
+    expect(openphil.missingFields[0]).toContain('1 of 2 divisions missing lead');
+
+    const anthropic = result!.profiles.find(p => p.entityId === 'sid_anthropic')!;
+    expect(anthropic.completenessPercent).toBe(0);
+    expect(anthropic.missingFields[0]).toContain('2 of 2 divisions missing lead');
+  });
+
+  it('scanDivisionsLead: orgs with no divisions are excluded from profiles', async () => {
+    const { runTableScan } = await import('./scanner.ts');
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/divisions/all')) {
+        return { ok: true, data: { divisions: [], total: 0 } };
+      }
+      if (url.startsWith('/api/entities')) {
+        return { ok: true, data: { entities: [orgA, orgB], total: 2 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const result = await runTableScan('divisions');
+    expect(result!.profiles).toHaveLength(0);
+    expect(result!.avgCompleteness).toBe(100); // no profiles = nothing to enrich
+  });
+
+  // ── scanDivisionPersonnelDates ─────────────────────────────────────────
+
+  it('scanDivisionPersonnelDates: joins personnel via divisionId → parentOrgId and scores on startDate', async () => {
+    const { runTableScan } = await import('./scanner.ts');
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/divisions/all')) {
+        return { ok: true, data: {
+          divisions: [
+            { id: 'div1', parentOrgId: 'sid_openphil', name: 'GH', lead: null, status: 'active' },
+            { id: 'div2', parentOrgId: 'sid_anthropic', name: 'Research', lead: null, status: 'active' },
+          ],
+          total: 2,
+        } };
+      }
+      if (url.startsWith('/api/division-personnel/all')) {
+        return { ok: true, data: {
+          divisionPersonnel: [
+            { id: 'p1', divisionId: 'div1', personId: 'sid_a', role: 'Lead', startDate: '2023-01', endDate: null },
+            { id: 'p2', divisionId: 'div1', personId: 'sid_b', role: 'Analyst', startDate: null, endDate: null },
+            { id: 'p3', divisionId: 'div2', personId: 'sid_c', role: 'Researcher', startDate: null, endDate: null },
+            { id: 'p4', divisionId: 'div2', personId: 'sid_d', role: 'Director', startDate: null, endDate: null },
+            // Orphan row (divisionId not in divisions map) should be ignored
+            { id: 'p5', divisionId: 'ghost', personId: 'sid_e', role: 'Ghost', startDate: null, endDate: null },
+          ],
+          total: 5,
+        } };
+      }
+      if (url.startsWith('/api/entities')) {
+        return { ok: true, data: { entities: [orgA, orgB], total: 2 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const result = await runTableScan('division_personnel');
+    expect(result!.profiles).toHaveLength(2);
+    const openphil = result!.profiles.find(p => p.entityId === 'sid_openphil')!;
+    // 1 of 2 has startDate
+    expect(openphil.completenessPercent).toBe(50);
+    expect(openphil.totalRecords).toBe(2);
+
+    const anthropic = result!.profiles.find(p => p.entityId === 'sid_anthropic')!;
+    expect(anthropic.completenessPercent).toBe(0);
+    expect(anthropic.missingFields[0]).toContain('2 of 2 division personnel missing startDate');
+  });
+
+  // ── scanFundingProgramFields ───────────────────────────────────────────
+
+  it('scanFundingProgramFields: weights totalBudget always, deadline/URL only for active programs', async () => {
+    const { runTableScan } = await import('./scanner.ts');
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/funding-programs/all')) {
+        return { ok: true, data: {
+          fundingPrograms: [
+            // Active, fully filled → 3/3 slots filled
+            { id: 'fp1', orgId: 'sid_openphil', name: 'RFP1', totalBudget: 1000000, applicationUrl: 'https://x.org', deadline: '2026-06-01', status: 'open' },
+            // Active, missing deadline + url → 1/3 slots filled
+            { id: 'fp2', orgId: 'sid_openphil', name: 'RFP2', totalBudget: 500000, applicationUrl: null, deadline: null, status: 'open' },
+            // Closed, missing budget → 0/1 slots (deadline/url not scored for closed)
+            { id: 'fp3', orgId: 'sid_anthropic', name: 'Closed Grant', totalBudget: null, applicationUrl: null, deadline: null, status: 'closed' },
+          ],
+          total: 3,
+        } };
+      }
+      if (url.startsWith('/api/entities')) {
+        return { ok: true, data: { entities: [orgA, orgB], total: 2 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const result = await runTableScan('funding_programs');
+    const openphil = result!.profiles.find(p => p.entityId === 'sid_openphil')!;
+    // slots: fp1=3, fp2=3 → 6 slots; filled: fp1=3, fp2=1 → 4 filled → 67%
+    expect(openphil.completenessPercent).toBe(67);
+    expect(openphil.missingFields.some(m => m.includes('active programs missing deadline'))).toBe(true);
+    expect(openphil.missingFields.some(m => m.includes('active programs missing applicationUrl'))).toBe(true);
+
+    const anthropic = result!.profiles.find(p => p.entityId === 'sid_anthropic')!;
+    // closed program: 1 slot (budget only), 0 filled → 0%
+    expect(anthropic.completenessPercent).toBe(0);
+    expect(anthropic.missingFields[0]).toContain('1 programs missing totalBudget');
+    // deadline/url should NOT appear in missing for closed programs
+    expect(anthropic.missingFields.some(m => m.includes('missing deadline'))).toBe(false);
+  });
+
+  // ── scanBenchmarkResultSources ─────────────────────────────────────────
+
+  it('scanBenchmarkResultSources: scores per model by sourceUrl fill rate', async () => {
+    const { runTableScan } = await import('./scanner.ts');
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/benchmark-results/all')) {
+        return { ok: true, data: {
+          benchmarkResults: [
+            { id: 'br1', benchmarkId: 'mmlu', modelId: 'sid_claude4', score: 88.5, sourceUrl: 'https://anthropic.com/card' },
+            { id: 'br2', benchmarkId: 'gpqa', modelId: 'sid_claude4', score: 70, sourceUrl: null },
+            { id: 'br3', benchmarkId: 'humaneval', modelId: 'sid_claude4', score: 92, sourceUrl: '   ' }, // whitespace-only counts as missing
+          ],
+          total: 3,
+        } };
+      }
+      if (url.startsWith('/api/entities')) {
+        return { ok: true, data: { entities: [modelA], total: 1 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const result = await runTableScan('benchmark_result_sources');
+    expect(result!.profiles).toHaveLength(1);
+    const p = result!.profiles[0];
+    // 1 of 3 has a non-empty sourceUrl
+    expect(p.completenessPercent).toBe(33);
+    expect(p.missingFields[0]).toContain('2 of 3 benchmark results missing sourceUrl');
+  });
+
+  // ── ranker integration ────────────────────────────────────────────────
+
+  it('task-ranker emits the new task types for the new tables', async () => {
+    const { rankTasks } = await import('./task-ranker.ts');
+    const scan = {
+      tables: [
+        {
+          table: 'divisions', totalEntities: 1, entitiesWithRecords: 1, totalRecords: 2, avgCompleteness: 50,
+          profiles: [{ entityId: 'sid_o', entityName: 'O', entityType: 'organization', table: 'divisions', totalRecords: 2, completenessPercent: 50, missingFields: ['1 of 2 divisions missing lead'] }],
+        },
+        {
+          table: 'division_personnel', totalEntities: 1, entitiesWithRecords: 1, totalRecords: 5, avgCompleteness: 20,
+          profiles: [{ entityId: 'sid_o', entityName: 'O', entityType: 'organization', table: 'division_personnel', totalRecords: 5, completenessPercent: 20, missingFields: ['4 of 5 division personnel missing startDate'] }],
+        },
+        {
+          table: 'funding_programs', totalEntities: 1, entitiesWithRecords: 1, totalRecords: 3, avgCompleteness: 33,
+          profiles: [{ entityId: 'sid_o', entityName: 'O', entityType: 'organization', table: 'funding_programs', totalRecords: 3, completenessPercent: 33, missingFields: ['2 programs missing totalBudget'] }],
+        },
+        {
+          table: 'benchmark_result_sources', totalEntities: 1, entitiesWithRecords: 1, totalRecords: 10, avgCompleteness: 40,
+          profiles: [{ entityId: 'sid_m', entityName: 'M', entityType: 'ai-model', table: 'benchmark_result_sources', totalRecords: 10, completenessPercent: 40, missingFields: ['6 of 10 benchmark results missing sourceUrl'] }],
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    const tasks = rankTasks(scan, { excludeIds: new Set() });
+    const byType = new Set(tasks.map(t => t.taskType));
+    expect(byType.has('division-lead-fill')).toBe(true);
+    expect(byType.has('division-personnel-dates')).toBe(true);
+    expect(byType.has('funding-program-enrichment')).toBe(true);
+    expect(byType.has('benchmark-source-fill')).toBe(true);
+    expect(tasks.length).toBe(4);
+  });
+});

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -116,8 +116,45 @@ interface BenchmarkResultsAllResponse {
     benchmarkId: string;
     modelId: string;
     score: number | null;
+    sourceUrl: string | null;
   }>;
   total?: number;
+}
+
+interface DivisionsAllResponse {
+  divisions: Array<{
+    id: string;
+    parentOrgId: string;
+    name: string;
+    lead: string | null;
+    status: string | null;
+  }>;
+  total: number;
+}
+
+interface DivisionPersonnelAllResponse {
+  divisionPersonnel: Array<{
+    id: string;
+    divisionId: string;
+    personId: string;
+    role: string;
+    startDate: string | null;
+    endDate: string | null;
+  }>;
+  total: number;
+}
+
+interface FundingProgramsAllResponse {
+  fundingPrograms: Array<{
+    id: string;
+    orgId: string;
+    name: string;
+    totalBudget: number | null;
+    applicationUrl: string | null;
+    deadline: string | null;
+    status: string | null;
+  }>;
+  total: number;
 }
 
 interface StatsResponse {
@@ -428,6 +465,245 @@ async function scanBenchmarkResultsCompleteness(prefetchedModels?: EntityListRes
 }
 
 // ---------------------------------------------------------------------------
+// Field-level completeness scanners (QUA-24)
+//
+// Unlike count-based scanners above, these score entities by the fill rate of
+// specific fields within existing records. Use them to surface structural gaps
+// that the `tb tablebase improve` agent can then enrich field-by-field.
+// ---------------------------------------------------------------------------
+
+async function scanDivisionsLead(prefetchedOrgs?: EntityListResponse['entities']): Promise<TableScanResult> {
+  const allDivisions = await fetchAllPaginated<DivisionsAllResponse['divisions'][number]>(
+    '/api/divisions/all',
+    'divisions',
+  );
+
+  const orgEntities = prefetchedOrgs ?? await fetchEntitiesByType('organization');
+
+  // Group divisions by parent org. Skip inactive divisions — no point researching leads for defunct ones.
+  const byOrg = new Map<string, { total: number; withLead: number }>();
+  for (const d of allDivisions) {
+    if (d.status === 'inactive' || d.status === 'dissolved') continue;
+    const bucket = byOrg.get(d.parentOrgId) ?? { total: 0, withLead: 0 };
+    bucket.total += 1;
+    if (d.lead && d.lead.trim().length > 0) bucket.withLead += 1;
+    byOrg.set(d.parentOrgId, bucket);
+  }
+
+  const profiles: TableProfile[] = [];
+  for (const entity of orgEntities) {
+    const orgId = entity.stableId || entity.id;
+    const bucket = byOrg.get(orgId);
+    if (!bucket || bucket.total === 0) continue;
+    const completeness = Math.round((bucket.withLead / bucket.total) * 100);
+    const missing: string[] = [];
+    const gap = bucket.total - bucket.withLead;
+    if (gap > 0) missing.push(`${gap} of ${bucket.total} divisions missing lead`);
+
+    profiles.push({
+      entityId: orgId,
+      entityName: entity.title,
+      entityType: 'organization',
+      table: 'divisions',
+      totalRecords: bucket.total,
+      completenessPercent: completeness,
+      missingFields: missing,
+      website: entity.website,
+      entityImportance: lookupImportance(entity.id) ?? lookupImportance(entity.wikiId || ''),
+    });
+  }
+
+  return {
+    table: 'divisions',
+    totalEntities: profiles.length,
+    entitiesWithRecords: profiles.length,
+    totalRecords: allDivisions.length,
+    avgCompleteness: profiles.length > 0
+      ? Math.round(profiles.reduce((s, p) => s + p.completenessPercent, 0) / profiles.length)
+      : 100,
+    profiles,
+  };
+}
+
+async function scanDivisionPersonnelDates(prefetchedOrgs?: EntityListResponse['entities']): Promise<TableScanResult> {
+  const [allDivisions, allPersonnel] = await Promise.all([
+    fetchAllPaginated<DivisionsAllResponse['divisions'][number]>('/api/divisions/all', 'divisions'),
+    fetchAllPaginated<DivisionPersonnelAllResponse['divisionPersonnel'][number]>(
+      '/api/division-personnel/all',
+      'divisionPersonnel',
+    ),
+  ]);
+
+  const orgEntities = prefetchedOrgs ?? await fetchEntitiesByType('organization');
+
+  // divisionId → parentOrgId
+  const divisionToOrg = new Map<string, string>();
+  for (const d of allDivisions) divisionToOrg.set(d.id, d.parentOrgId);
+
+  // Group personnel by parent org (via their division)
+  const byOrg = new Map<string, { total: number; withStart: number; withEnd: number }>();
+  for (const p of allPersonnel) {
+    const orgId = divisionToOrg.get(p.divisionId);
+    if (!orgId) continue;
+    const bucket = byOrg.get(orgId) ?? { total: 0, withStart: 0, withEnd: 0 };
+    bucket.total += 1;
+    if (p.startDate) bucket.withStart += 1;
+    // endDate is legitimately null for current roles, so only count it if startDate is present
+    // (i.e., we expect endDate on historical personnel, indicated by role-type conventions).
+    if (p.endDate) bucket.withEnd += 1;
+    byOrg.set(orgId, bucket);
+  }
+
+  const profiles: TableProfile[] = [];
+  for (const entity of orgEntities) {
+    const orgId = entity.stableId || entity.id;
+    const bucket = byOrg.get(orgId);
+    if (!bucket || bucket.total === 0) continue;
+    // Score on startDate fill rate only — endDate is genuinely null for current roles.
+    const completeness = Math.round((bucket.withStart / bucket.total) * 100);
+    const missing: string[] = [];
+    const gap = bucket.total - bucket.withStart;
+    if (gap > 0) missing.push(`${gap} of ${bucket.total} division personnel missing startDate`);
+
+    profiles.push({
+      entityId: orgId,
+      entityName: entity.title,
+      entityType: 'organization',
+      table: 'division_personnel',
+      totalRecords: bucket.total,
+      completenessPercent: completeness,
+      missingFields: missing,
+      website: entity.website,
+      entityImportance: lookupImportance(entity.id) ?? lookupImportance(entity.wikiId || ''),
+    });
+  }
+
+  return {
+    table: 'division_personnel',
+    totalEntities: profiles.length,
+    entitiesWithRecords: profiles.length,
+    totalRecords: allPersonnel.length,
+    avgCompleteness: profiles.length > 0
+      ? Math.round(profiles.reduce((s, p) => s + p.completenessPercent, 0) / profiles.length)
+      : 100,
+    profiles,
+  };
+}
+
+async function scanFundingProgramFields(prefetchedOrgs?: EntityListResponse['entities']): Promise<TableScanResult> {
+  const allPrograms = await fetchAllPaginated<FundingProgramsAllResponse['fundingPrograms'][number]>(
+    '/api/funding-programs/all',
+    'fundingPrograms',
+  );
+
+  const orgEntities = prefetchedOrgs ?? await fetchEntitiesByType('organization');
+
+  // Group by offering org; count fill rate across the three target fields.
+  // For closed/inactive programs, deadline/applicationUrl are less actionable — skip them.
+  const byOrg = new Map<string, { total: number; slots: number; filled: number; gaps: { budget: number; deadline: number; url: number } }>();
+  for (const p of allPrograms) {
+    const isActive = p.status !== 'closed' && p.status !== 'inactive';
+    const bucket = byOrg.get(p.orgId) ?? { total: 0, slots: 0, filled: 0, gaps: { budget: 0, deadline: 0, url: 0 } };
+    bucket.total += 1;
+    // totalBudget is always expected
+    bucket.slots += 1;
+    if (p.totalBudget != null) bucket.filled += 1; else bucket.gaps.budget += 1;
+    if (isActive) {
+      bucket.slots += 2;
+      if (p.deadline) bucket.filled += 1; else bucket.gaps.deadline += 1;
+      if (p.applicationUrl) bucket.filled += 1; else bucket.gaps.url += 1;
+    }
+    byOrg.set(p.orgId, bucket);
+  }
+
+  const profiles: TableProfile[] = [];
+  for (const entity of orgEntities) {
+    const orgId = entity.stableId || entity.id;
+    const bucket = byOrg.get(orgId);
+    if (!bucket || bucket.slots === 0) continue;
+    const completeness = Math.round((bucket.filled / bucket.slots) * 100);
+    const missing: string[] = [];
+    if (bucket.gaps.budget > 0) missing.push(`${bucket.gaps.budget} programs missing totalBudget`);
+    if (bucket.gaps.deadline > 0) missing.push(`${bucket.gaps.deadline} active programs missing deadline`);
+    if (bucket.gaps.url > 0) missing.push(`${bucket.gaps.url} active programs missing applicationUrl`);
+
+    profiles.push({
+      entityId: orgId,
+      entityName: entity.title,
+      entityType: 'organization',
+      table: 'funding_programs',
+      totalRecords: bucket.total,
+      completenessPercent: completeness,
+      missingFields: missing,
+      website: entity.website,
+      entityImportance: lookupImportance(entity.id) ?? lookupImportance(entity.wikiId || ''),
+    });
+  }
+
+  return {
+    table: 'funding_programs',
+    totalEntities: profiles.length,
+    entitiesWithRecords: profiles.length,
+    totalRecords: allPrograms.length,
+    avgCompleteness: profiles.length > 0
+      ? Math.round(profiles.reduce((s, p) => s + p.completenessPercent, 0) / profiles.length)
+      : 100,
+    profiles,
+  };
+}
+
+async function scanBenchmarkResultSources(prefetchedModels?: EntityListResponse['entities']): Promise<TableScanResult> {
+  const allResults = await fetchAllPaginated<BenchmarkResultsAllResponse['benchmarkResults'][number]>(
+    '/api/benchmark-results/all',
+    'benchmarkResults',
+  );
+
+  const modelEntities = prefetchedModels ?? await fetchEntitiesByType('ai-model');
+
+  const byModel = new Map<string, { total: number; withSource: number }>();
+  for (const r of allResults) {
+    const bucket = byModel.get(r.modelId) ?? { total: 0, withSource: 0 };
+    bucket.total += 1;
+    if (r.sourceUrl && r.sourceUrl.trim().length > 0) bucket.withSource += 1;
+    byModel.set(r.modelId, bucket);
+  }
+
+  const profiles: TableProfile[] = [];
+  for (const entity of modelEntities) {
+    const modelId = entity.stableId || entity.id;
+    const bucket = byModel.get(modelId);
+    if (!bucket || bucket.total === 0) continue;
+    const completeness = Math.round((bucket.withSource / bucket.total) * 100);
+    const missing: string[] = [];
+    const gap = bucket.total - bucket.withSource;
+    if (gap > 0) missing.push(`${gap} of ${bucket.total} benchmark results missing sourceUrl`);
+
+    profiles.push({
+      entityId: modelId,
+      entityName: entity.title,
+      entityType: 'ai-model',
+      table: 'benchmark_result_sources',
+      totalRecords: bucket.total,
+      completenessPercent: completeness,
+      missingFields: missing,
+      website: entity.website,
+      entityImportance: lookupImportance(entity.id) ?? lookupImportance(entity.wikiId || ''),
+    });
+  }
+
+  return {
+    table: 'benchmark_result_sources',
+    totalEntities: profiles.length,
+    entitiesWithRecords: profiles.length,
+    totalRecords: allResults.length,
+    avgCompleteness: profiles.length > 0
+      ? Math.round(profiles.reduce((s, p) => s + p.completenessPercent, 0) / profiles.length)
+      : 100,
+    profiles,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Source quality scanner (unverifiable verdicts)
 // ---------------------------------------------------------------------------
 
@@ -547,12 +823,27 @@ export async function runFullScan(): Promise<ScanSummary> {
     fetchEntitiesByType('ai-model'),
   ]);
 
-  const [grants, personnel, fundingRounds, investments, benchmarkResults, sourceQuality] = await Promise.all([
+  const [
+    grants,
+    personnel,
+    fundingRounds,
+    investments,
+    benchmarkResults,
+    divisionsLead,
+    divisionPersonnelDates,
+    fundingProgramFields,
+    benchmarkResultSources,
+    sourceQuality,
+  ] = await Promise.all([
     scanGrantCompleteness(orgEntities),
     scanPersonnelCompleteness(orgEntities),
     scanFundingRoundsCompleteness(orgEntities),
     scanInvestmentsCompleteness(orgEntities),
     scanBenchmarkResultsCompleteness(modelEntities),
+    scanDivisionsLead(orgEntities),
+    scanDivisionPersonnelDates(orgEntities),
+    scanFundingProgramFields(orgEntities),
+    scanBenchmarkResultSources(modelEntities),
     scanSourceQuality().catch((e: unknown) => {
       // Source quality scanning is best-effort — wiki-server may not have sourcing data
       console.warn(`[tablebase] Source quality scan failed: ${e instanceof Error ? e.message : String(e)}`);
@@ -561,7 +852,18 @@ export async function runFullScan(): Promise<ScanSummary> {
   ]);
 
   return {
-    tables: [grants, personnel, fundingRounds, investments, benchmarkResults, sourceQuality],
+    tables: [
+      grants,
+      personnel,
+      fundingRounds,
+      investments,
+      benchmarkResults,
+      divisionsLead,
+      divisionPersonnelDates,
+      fundingProgramFields,
+      benchmarkResultSources,
+      sourceQuality,
+    ],
     timestamp: new Date().toISOString(),
   };
 }
@@ -573,6 +875,10 @@ export async function runTableScan(table: string): Promise<TableScanResult | nul
     case 'funding_rounds': case 'funding-rounds': return scanFundingRoundsCompleteness();
     case 'investments': return scanInvestmentsCompleteness();
     case 'benchmark_results': case 'benchmark-results': return scanBenchmarkResultsCompleteness();
+    case 'divisions': return scanDivisionsLead();
+    case 'division_personnel': case 'division-personnel': return scanDivisionPersonnelDates();
+    case 'funding_programs': case 'funding-programs': return scanFundingProgramFields();
+    case 'benchmark_result_sources': case 'benchmark-result-sources': return scanBenchmarkResultSources();
     case 'source_quality': case 'source-quality': return scanSourceQuality();
     default: return null;
   }

--- a/crux/tablebase/task-ranker.ts
+++ b/crux/tablebase/task-ranker.ts
@@ -50,6 +50,10 @@ function tableToTaskType(table: string): TaskType | null {
     case 'investments': return 'investment-linking';
     case 'benchmark_results': return 'benchmark-result-fill';
     case 'source_quality': return 'source-discovery';
+    case 'divisions': return 'division-lead-fill';
+    case 'division_personnel': return 'division-personnel-dates';
+    case 'funding_programs': return 'funding-program-enrichment';
+    case 'benchmark_result_sources': return 'benchmark-source-fill';
     default: return null;
   }
 }

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -102,7 +102,7 @@ export function getToolDefinitions(options?: { taskType?: TaskType; apply?: bool
           properties: {
             table: {
               type: 'string',
-              enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results'],
+              enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results', 'divisions', 'division-personnel', 'funding-programs'],
               description: 'The table to query',
             },
             entityId: { type: 'string', description: 'Entity ID to query records for' },
@@ -129,7 +129,7 @@ export function getToolDefinitions(options?: { taskType?: TaskType; apply?: bool
           properties: {
             table: {
               type: 'string',
-              enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results'],
+              enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results', 'divisions', 'division-personnel', 'funding-programs'],
               description: 'The table to write to',
             },
             records: {
@@ -160,7 +160,7 @@ export function getToolDefinitions(options?: { taskType?: TaskType; apply?: bool
         input_schema: {
           type: 'object',
           properties: {
-            targetTable: { type: 'string', enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results'], description: 'The table these claims will eventually populate' },
+            targetTable: { type: 'string', enum: ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results', 'divisions', 'division-personnel', 'funding-programs'], description: 'The table these claims will eventually populate' },
             claims: {
               type: 'array',
               description: 'Array of claims to verify. Each must have claimText and sourceUrl.',
@@ -533,6 +533,13 @@ async function handleSubmitRecords(
       // Grants are updated (granteeId backfill), not deduped
       deduped = records;
       break;
+    case 'divisions':
+    case 'division-personnel':
+    case 'funding-programs':
+      // Field-fill tasks (QUA-24): agent updates existing records by id.
+      // Dedup is not meaningful — sync handler upserts with COALESCE.
+      deduped = records;
+      break;
     default:
       return `Error: Unknown table "${table}"`;
   }
@@ -761,5 +768,9 @@ export function taskTypeToTable(taskType: TaskType): string {
     case 'investment-linking': return 'investments';
     case 'benchmark-result-fill': return 'benchmark-results';
     case 'source-discovery': return 'source_quality';
+    case 'division-lead-fill': return 'divisions';
+    case 'division-personnel-dates': return 'division-personnel';
+    case 'funding-program-enrichment': return 'funding-programs';
+    case 'benchmark-source-fill': return 'benchmark-results';
   }
 }

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -19,6 +19,10 @@ export const TASK_TYPES = [
   "investment-linking",
   "benchmark-result-fill",
   "source-discovery",
+  "division-lead-fill",
+  "division-personnel-dates",
+  "funding-program-enrichment",
+  "benchmark-source-fill",
 ] as const;
 
 export type TaskType = (typeof TASK_TYPES)[number];
@@ -27,9 +31,13 @@ export type TaskType = (typeof TASK_TYPES)[number];
 export const TASK_TYPE_WEIGHTS: Record<TaskType, number> = {
   "personnel-enrichment": 1.5,
   "source-discovery": 1.3,
+  "division-lead-fill": 1.3,
   "grant-grantee-backfill": 1.2,
   "funding-round-research": 1.0,
   "benchmark-result-fill": 1.0,
+  "funding-program-enrichment": 1.0,
+  "division-personnel-dates": 0.9,
+  "benchmark-source-fill": 0.9,
   "investment-linking": 0.8,
 };
 
@@ -115,4 +123,8 @@ export const TASK_TYPE_RECOMMENDED_MODEL: Record<TaskType, string> = {
   "grant-grantee-backfill": "sonnet",
   "personnel-enrichment": "sonnet",
   "source-discovery": "sonnet",
+  "division-lead-fill": "sonnet",
+  "division-personnel-dates": "haiku",
+  "funding-program-enrichment": "haiku",
+  "benchmark-source-fill": "haiku",
 };


### PR DESCRIPTION
## Summary

Plumbing for QUA-24. Extends `tb tablebase scan` / `gaps` to surface the four field-level gaps the ticket calls out, so the existing `tb tablebase improve` / `loop` pipeline can target them:

- **`divisions.lead`** (97% empty): new `division-lead-fill` task type, scanner groups by parent org and skips dissolved/inactive divisions
- **`division_personnel.startDate`**: new `division-personnel-dates` task type, joins personnel via `divisions.parentOrgId` so tasks are scoped per org (matches how `personnel-enrichment` works)
- **`funding_programs` fields** (`totalBudget` / `deadline` / `applicationUrl`): new `funding-program-enrichment` task type. `totalBudget` always scored; `deadline` / `applicationUrl` only scored for non-closed programs.
- **`benchmark_results.sourceUrl`** (~40% empty): new `benchmark-source-fill` task type, scored per AI model

Each task type has a dedicated LLM prompt, a recommended model (haiku for simple field fills, sonnet for division-lead research), and entries in the `submit_records` / `query_existing_records` / `submit_claims` tool enums.

## What this does not do

Plumbing only — surfacing gaps so the enrichment agent can target them. Actual field population happens in follow-up `tb tablebase improve` / `loop` runs.

## Test plan

- [x] 6 new unit tests in `crux/tablebase/scanner.test.ts` covering per-org fill-rate computation, dissolved-division exclusion, orphan row handling, closed-program handling, whitespace-only `sourceUrl` treated as missing, and ranker integration for all 4 new task types
- [x] `pnpm crux w validate gate --fix` → 53/53 blocking checks pass
- [x] `npx vitest run crux/tablebase/` → 93/93 pass
- [x] `npx tsc --noEmit` on `crux/` and `apps/web/` → no new errors in modified files
- [ ] Follow-up session: actually run `WIKI_SERVER_ENV=prod pnpm crux tb tablebase scan` against prod to confirm the new tables appear in the dashboard output

Fixes QUA-24
