### PR TITLE
feat(agent-end): bundle slot reset + fix id-client test env hermeticity

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -1,13 +1,15 @@
 ---
-description: End the current session — log it, update issues, clean up. No shipping required.
+description: End the current session — log it, update issues, clean up, reset slot back to main. No shipping required.
 effort: low
 ---
 
-# Agent End — Close Out a Session
+# Agent End — Close Out a Session and Reset the Slot
 
-Lightweight session close. Use this when the session is done but you don't need to ship a PR.
+Session close + slot reset, bundled. Use this when the session is done but you don't need to ship a PR.
 
-For sessions that DO ship code, use `/agent-ship` instead (it calls `/agent-end` internally after shipping).
+This runs what used to be `/agent-end` followed by `/agent-reset`: logs the session, updates Linear/GitHub, kills the dev server, cleans artifacts, closes the DB-level agent, resets the branch to clean `main`, and renames the tmux window. After it finishes, run `/clear` then `/rename` to finish the slot handoff (those are built-ins and can't be invoked from a skill).
+
+For sessions that DO ship code, use `/agent-ship` instead (it has its own inline close-out).
 
 ## When to use `/agent-end` vs `/agent-ship`
 
@@ -126,12 +128,60 @@ git checkout -- .claude/simplify-done 2>/dev/null || rm -f .claude/simplify-done
 git checkout -- .claude/hooks/ 2>/dev/null || true
 ```
 
-## Step 6: Session summary
+## Step 6: Close session in DB (agents-level)
+
+Broader than the checklist-level close in Step 1 — marks the active agent as completed and logs the close event:
+
+```bash
+pnpm crux sys agents close 2>/dev/null || true
+```
+
+Best-effort: if the wiki-server is down, continue.
+
+## Step 7: Reset slot to clean main
+
+Bundles what `/agent-reset` used to do. **Safety first**: show the user what's about to be discarded, and pause if anything is uncommitted or unpushed.
+
+```bash
+BRANCH=$(git branch --show-current)
+echo "Current branch: $BRANCH"
+git status --porcelain
+git log --oneline "@{u}..HEAD" 2>/dev/null || echo "(no upstream to compare)"
+```
+
+If there are uncommitted changes or unpushed commits on a non-main branch, **ask the user before proceeding**. They may want to commit/push first. If the PR has already merged or the user confirms, continue.
+
+Discard local changes and switch to main:
+
+```bash
+git checkout -- .
+git clean -fd --exclude=.agent-slot --exclude=.envrc --exclude=.env
+
+if [ "$BRANCH" != "main" ]; then
+  AGENT_RESET=1 git checkout main
+  git pull --ff-only origin main || git reset --hard origin/main
+  git branch -D "$BRANCH" 2>/dev/null || true
+fi
+```
+
+Rename the tmux window back to the idle slot name (e.g. `A4`):
+
+```bash
+SLOT=$(cat .agent-slot 2>/dev/null | tr -d '[:space:]')
+if [ -n "$SLOT" ] && [ -n "$TMUX" ]; then
+  tmux rename-window "A${SLOT}"
+fi
+```
+
+## Step 8: Session summary + next steps
 
 Output a brief summary:
-- Branch name
+- Branch that was ended (and whether it was deleted)
 - What was done (1-2 sentences)
 - PR URL (if any)
 - Whether the checklist was completed
+- Final state: on `main`, clean
 
-That's it. The slot is now ready for the next session (or run `crux sys agent-reset --kill` for a full reset including pulling main).
+Then tell the user:
+
+> **Next:** run `/clear` to wipe context, then `/rename` to clear the Claude Code session name. (Both are built-ins and can't be invoked from a skill.)

--- a/apps/web/scripts/lib/__tests__/id-client.test.mjs
+++ b/apps/web/scripts/lib/__tests__/id-client.test.mjs
@@ -9,10 +9,14 @@ beforeEach(() => {
   savedEnv = {
     LONGTERMWIKI_SERVER_URL: process.env.LONGTERMWIKI_SERVER_URL,
     LONGTERMWIKI_SERVER_API_KEY: process.env.LONGTERMWIKI_SERVER_API_KEY,
+    WIKI_SERVER_ENV: process.env.WIKI_SERVER_ENV,
   };
-  // Default: no server configured
+  // Default: no server configured, and no PROD_ prefix routing.
+  // WIKI_SERVER_ENV=prod would make getEnv() read PROD_LONGTERMWIKI_SERVER_URL,
+  // which tests never set — unset it so tests are hermetic regardless of shell env.
   delete process.env.LONGTERMWIKI_SERVER_URL;
   delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  delete process.env.WIKI_SERVER_ENV;
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

- **`/agent-end` now bundles `/agent-reset`**: adds DB-level agent close, git reset to clean `main`, branch delete, and tmux window rename. Collapses the end-of-slot flow from 4 actions (`/agent-end`, `/agent-reset`, `/clear`, `/rename`) to 3 (`/agent-end`, `/clear`, `/rename`). `/clear` and `/rename` stay manual because they're Claude Code built-ins.
- **`id-client.test.mjs` now hermetic against `WIKI_SERVER_ENV`**: `beforeEach` saves and deletes `WIKI_SERVER_ENV` so tests pass whether or not the invoking shell has `WIKI_SERVER_ENV=prod` set. Previously, running `pnpm test` with `WIKI_SERVER_ENV=prod` exported caused 8 failures because `getEnv()` routed to `PROD_LONGTERMWIKI_SERVER_URL`, which the tests never set. The prefix logic landed in d4a3a9c08 but the tests were never updated — main CI is green because GitHub Actions doesn't export the var.

## Why together

Hit the test bug while pushing the agent-end change from an agent slot (slots can't run a local wiki-server, so `WIKI_SERVER_ENV=prod` is required for the gate's `build-data` to find PG-native resources — which then propagated into `pnpm test` and broke the id-client tests). The fix is one-line and preventing future slot pushes from hitting the same snag is worth coupling.

## Test plan

- [x] `pnpm --filter longterm-next test -- scripts/lib/__tests__/id-client.test.mjs` passes under both `WIKI_SERVER_ENV=prod` and unset
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate gate` passes (gate + tests + content)
- [ ] CI green
- [ ] Run `/agent-end` on a test slot and confirm it resets branch + renames tmux window

## Standalone `/agent-reset` skill

Left intact — still useful for reset-without-end flows.
