### PR TITLE
fix(improve): add source-coverage gate to research phase (QUA-315)

### DIFF
--- a/crux/authoring/page-improver/index.test.ts
+++ b/crux/authoring/page-improver/index.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the page-improver CLI entry point.
+ *
+ * Currently covers the --min-sources flag parser, which exists to prevent
+ * the silent-degradation failure mode QUA-315 introduced — passing
+ * parseInt('foo') (= NaN) through to the gate would silently disable it
+ * because `NaN > 0` is false.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseMinSources } from './index.ts';
+
+describe('parseMinSources', () => {
+  it('returns undefined when the flag is omitted', () => {
+    expect(parseMinSources(undefined)).toBeUndefined();
+  });
+
+  it('parses a valid positive integer', () => {
+    expect(parseMinSources('5')).toBe(5);
+  });
+
+  it('parses 0 as a valid value (gate-disable signal)', () => {
+    expect(parseMinSources('0')).toBe(0);
+  });
+
+  it('parses a numeric value passed as a number (defensive — argparser produces strings but kwargs caller may not)', () => {
+    expect(parseMinSources(3)).toBe(3);
+  });
+
+  it('throws on a non-numeric string (would otherwise become NaN and silently disable the gate)', () => {
+    expect(() => parseMinSources('foo')).toThrow(/non-negative integer/);
+  });
+
+  it('throws on a negative integer (would silently disable the gate)', () => {
+    expect(() => parseMinSources('-1')).toThrow(/non-negative integer/);
+  });
+
+  it('throws on the empty string', () => {
+    expect(() => parseMinSources('')).toThrow(/non-negative integer/);
+  });
+
+  it('throws on Infinity', () => {
+    expect(() => parseMinSources('Infinity')).toThrow(/non-negative integer/);
+  });
+
+  it('echoes the bad value in the error message for debuggability', () => {
+    expect(() => parseMinSources('foo')).toThrow(/got: foo/);
+  });
+});

--- a/crux/authoring/page-improver/index.test.ts
+++ b/crux/authoring/page-improver/index.test.ts
@@ -1,15 +1,9 @@
-/**
- * Tests for the page-improver CLI entry point.
- *
- * Currently covers the --min-sources flag parser, which exists to prevent
- * the silent-degradation failure mode QUA-315 introduced — passing
- * parseInt('foo') (= NaN) through to the gate would silently disable it
- * because `NaN > 0` is false.
- */
-
 import { describe, it, expect } from 'vitest';
 import { parseMinSources } from './index.ts';
 
+// parseMinSources must throw rather than silently coerce — bad input becoming NaN
+// would silently disable the gate (`NaN > 0` is false), which is exactly the
+// silent-degradation failure mode QUA-315 exists to prevent.
 describe('parseMinSources', () => {
   it('returns undefined when the flag is omitted', () => {
     expect(parseMinSources(undefined)).toBeUndefined();
@@ -23,15 +17,15 @@ describe('parseMinSources', () => {
     expect(parseMinSources('0')).toBe(0);
   });
 
-  it('parses a numeric value passed as a number (defensive — argparser produces strings but kwargs caller may not)', () => {
+  it('parses a numeric value passed as a number', () => {
     expect(parseMinSources(3)).toBe(3);
   });
 
-  it('throws on a non-numeric string (would otherwise become NaN and silently disable the gate)', () => {
+  it('throws on a non-numeric string', () => {
     expect(() => parseMinSources('foo')).toThrow(/non-negative integer/);
   });
 
-  it('throws on a negative integer (would silently disable the gate)', () => {
+  it('throws on a negative integer', () => {
     expect(() => parseMinSources('-1')).toThrow(/non-negative integer/);
   });
 

--- a/crux/authoring/page-improver/index.ts
+++ b/crux/authoring/page-improver/index.ts
@@ -281,6 +281,13 @@ Examples:
       console.error(`Orchestrator v2 supports tiers: polish, standard, deep (got: ${tierStr})`);
       process.exit(1);
     }
+    // The source gate (QUA-315) lives in the v1 researchPhase. The v2
+    // orchestrator uses a tool-driven research path that doesn't go through
+    // researchPhase, so silently ignoring the flag would be a UX trap.
+    if (opts['min-sources'] !== undefined || opts['skip-source-gate'] === true) {
+      console.error('Error: --min-sources / --skip-source-gate are not supported with --engine=v2 (the v2 orchestrator uses a different research path). File a follow-up if you need this. (QUA-315)');
+      process.exit(1);
+    }
     await runOrchestratorPipeline(pageId, {
       tier: v2Tier as 'polish' | 'standard' | 'deep',
       directions: (opts.directions as string) || '',
@@ -309,11 +316,39 @@ Examples:
       gapAnalysis: opts['gap-analysis'] === true ? true : undefined,
       apiDirect: opts['api-direct'] === true ? true : undefined,
       skipSourceGate: opts['skip-source-gate'] === true ? true : undefined,
-      minSources: opts['min-sources'] !== undefined
-        ? parseInt(opts['min-sources'] as string, 10)
-        : undefined,
+      minSources: parseMinSourcesOrExit(opts['min-sources']),
     });
   }
+}
+
+/** main()-side wrapper that converts parseMinSources() throws into process.exit(1). */
+function parseMinSourcesOrExit(raw: unknown): number | undefined {
+  try {
+    return parseMinSources(raw);
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Parse and validate the `--min-sources` CLI flag.
+ *
+ * Returns undefined when the flag is omitted (caller falls through to the
+ * tier-aware default). Throws on a malformed value — passing NaN through
+ * to the gate would silently disable it (because `NaN > 0` is false),
+ * exactly the silent-degradation mode QUA-315 exists to prevent.
+ *
+ * Exported for testing; main() wraps the throw in a clean process.exit(1).
+ */
+export function parseMinSources(raw: unknown): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`--min-sources requires a non-negative integer (got: ${String(raw)})`);
+  }
+  return parsed;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/crux/authoring/page-improver/index.ts
+++ b/crux/authoring/page-improver/index.ts
@@ -119,6 +119,9 @@ Options:
   --skip-citation-gate            Allow --apply even when citation audit fails (default: gate ON)
   --skip-citation-audit           Skip the post-improve citation audit phase
   --citation-audit-model <model>  Override LLM model for per-citation checking
+  --skip-source-gate              Allow improve to proceed when research lands few usable sources
+  --min-sources N                 Min usable sources from research before improve runs
+                                  (default: standard=1, deep=3; 0 disables) (QUA-315)
   --no-save-artifacts             Skip saving intermediate artifacts to wiki-server DB
   --gap-analysis                  Run claims gap analysis: inject missing verified facts as structured directions
   --openrouter                    Route all Claude calls through OpenRouter (when Anthropic credits depleted)
@@ -305,6 +308,10 @@ Examples:
       saveArtifacts: opts['no-save-artifacts'] === true ? false : undefined,
       gapAnalysis: opts['gap-analysis'] === true ? true : undefined,
       apiDirect: opts['api-direct'] === true ? true : undefined,
+      skipSourceGate: opts['skip-source-gate'] === true ? true : undefined,
+      minSources: opts['min-sources'] !== undefined
+        ? parseInt(opts['min-sources'] as string, 10)
+        : undefined,
     });
   }
 }

--- a/crux/authoring/page-improver/index.ts
+++ b/crux/authoring/page-improver/index.ts
@@ -315,14 +315,14 @@ Examples:
       saveArtifacts: opts['no-save-artifacts'] === true ? false : undefined,
       gapAnalysis: opts['gap-analysis'] === true ? true : undefined,
       apiDirect: opts['api-direct'] === true ? true : undefined,
-      skipSourceGate: opts['skip-source-gate'] === true ? true : undefined,
-      minSources: parseMinSourcesOrExit(opts['min-sources']),
+      // --skip-source-gate is sugar for setting the minimum to 0.
+      minSources: opts['skip-source-gate'] === true ? 0 : tryParseMinSources(opts['min-sources']),
     });
   }
 }
 
-/** main()-side wrapper that converts parseMinSources() throws into process.exit(1). */
-function parseMinSourcesOrExit(raw: unknown): number | undefined {
+/** main()-side helper: validate then run, exiting cleanly on a bad flag value. */
+function tryParseMinSources(raw: unknown): number | undefined {
   try {
     return parseMinSources(raw);
   } catch (err: unknown) {
@@ -340,7 +340,10 @@ function parseMinSourcesOrExit(raw: unknown): number | undefined {
  * to the gate would silently disable it (because `NaN > 0` is false),
  * exactly the silent-degradation mode QUA-315 exists to prevent.
  *
- * Exported for testing; main() wraps the throw in a clean process.exit(1).
+ * Exported for testing; main()'s tryParseMinSources() wraps the throw in
+ * a clean process.exit(1). NOTE: deliberately does NOT use parseIntOpt()
+ * from crux/lib/cli.ts — its silent NaN-to-fallback semantics is exactly
+ * the bug class this validator exists to prevent.
  */
 export function parseMinSources(raw: unknown): number | undefined {
   if (raw === undefined) return undefined;

--- a/crux/authoring/page-improver/phases/research.test.ts
+++ b/crux/authoring/page-improver/phases/research.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildSourceCache } from './research.ts';
+import { buildSourceCache, defaultMinSources, evaluateSourceGate } from './research.ts';
 import type { FetchedSource } from '../../../lib/search/source-fetcher.ts';
+import type { SourceCacheEntry } from '../../../lib/content/section-writer.ts';
+import { MIN_SOURCE_CONTENT_LENGTH } from '../../../lib/citation/citation-service.ts';
 
 function makeFetchedSource(overrides: Partial<FetchedSource> = {}): FetchedSource {
   return {
@@ -147,5 +149,186 @@ describe('buildSourceCache', () => {
 
     const cache = buildSourceCache(researchSources, fetched);
     expect(cache[0].content.length).toBe(5000);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// QUA-315: source-coverage gate
+// ──────────────────────────────────────────────────────────────────────────────
+
+function makeUsableEntry(overrides: Partial<SourceCacheEntry> = {}): SourceCacheEntry {
+  return {
+    id: 'SRC-1',
+    url: 'https://example.com/a',
+    title: 'Article',
+    facts: [],
+    // Long enough to clear MIN_SOURCE_CONTENT_LENGTH (50 chars).
+    content: 'X'.repeat(MIN_SOURCE_CONTENT_LENGTH + 10),
+    ...overrides,
+  };
+}
+
+describe('defaultMinSources', () => {
+  it('returns 1 for the standard tier', () => {
+    expect(defaultMinSources(false)).toBe(1);
+  });
+  it('returns 3 for the deep tier', () => {
+    expect(defaultMinSources(true)).toBe(3);
+  });
+});
+
+describe('evaluateSourceGate', () => {
+  it('passes when usable sources meet the threshold', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [
+        makeUsableEntry({ id: 'SRC-1', url: 'https://a' }),
+        makeUsableEntry({ id: 'SRC-2', url: 'https://b' }),
+      ],
+      totalUrls: 2,
+      llmSourceCount: 2,
+      minSources: 2,
+      skipGate: false,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.active).toBe(true);
+    expect(result.usableSources).toBe(2);
+    expect(result.cacheEntries).toBe(2);
+  });
+
+  it('fails when usable sources fall below the threshold', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [makeUsableEntry()],
+      totalUrls: 1,
+      llmSourceCount: 1,
+      minSources: 3,
+      skipGate: false,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.active).toBe(true);
+    expect(result.usableSources).toBe(1);
+    expect(result.diagnostic).toContain('1 usable source(s)');
+    expect(result.diagnostic).toContain('need at least 3');
+  });
+
+  it('fails when the cache is empty (the QUA-315 silent-failure case)', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [],
+      totalUrls: 0,
+      llmSourceCount: 0,
+      minSources: 1,
+      skipGate: false,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.usableSources).toBe(0);
+    expect(result.cacheEntries).toBe(0);
+    expect(result.diagnostic).toContain('0 usable source(s)');
+  });
+
+  it('fails when sourceCache is undefined (fetchSources threw)', () => {
+    const result = evaluateSourceGate({
+      sourceCache: undefined,
+      totalUrls: 5,
+      llmSourceCount: 5,
+      minSources: 1,
+      skipGate: false,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.usableSources).toBe(0);
+    expect(result.cacheEntries).toBe(0);
+    // Diagnostic should still reflect that the LLM returned URLs even though caching failed.
+    expect(result.diagnostic).toContain('5 sources');
+    expect(result.diagnostic).toContain('5 HTTP URL(s)');
+  });
+
+  it('does NOT count entries with empty content (paywall/dead/short)', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [
+        makeUsableEntry({ id: 'SRC-1', url: 'https://ok', content: 'X'.repeat(100) }),
+        makeUsableEntry({ id: 'SRC-2', url: 'https://paywall', content: '' }),
+        makeUsableEntry({ id: 'SRC-3', url: 'https://short', content: 'too short' }),
+      ],
+      totalUrls: 3,
+      llmSourceCount: 3,
+      minSources: 2,
+      skipGate: false,
+    });
+    expect(result.usableSources).toBe(1);
+    expect(result.cacheEntries).toBe(3);
+    expect(result.passed).toBe(false);
+  });
+
+  it('does NOT count entries without a URL', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [
+        makeUsableEntry({ id: 'SRC-1', url: '' }),
+        makeUsableEntry({ id: 'SRC-2', url: 'https://ok' }),
+      ],
+      totalUrls: 1,
+      llmSourceCount: 2,
+      minSources: 2,
+      skipGate: false,
+    });
+    expect(result.usableSources).toBe(1);
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes (gate disabled) when skipGate is true even with zero usable sources', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [],
+      totalUrls: 0,
+      llmSourceCount: 0,
+      minSources: 5,
+      skipGate: true,
+    });
+    expect(result.active).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+
+  it('passes (gate disabled) when minSources is 0', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [],
+      totalUrls: 0,
+      llmSourceCount: 0,
+      minSources: 0,
+      skipGate: false,
+    });
+    expect(result.active).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+
+  it('boundary: exactly meets the threshold (>= not >)', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [makeUsableEntry()],
+      totalUrls: 1,
+      llmSourceCount: 1,
+      minSources: 1,
+      skipGate: false,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.usableSources).toBe(1);
+  });
+
+  it('boundary: content exactly at MIN_SOURCE_CONTENT_LENGTH does NOT count (uses >, not >=)', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [makeUsableEntry({ content: 'X'.repeat(MIN_SOURCE_CONTENT_LENGTH) })],
+      totalUrls: 1,
+      llmSourceCount: 1,
+      minSources: 1,
+      skipGate: false,
+    });
+    // Matches the buildSourceCache and citation-auditor behaviour: > MIN_SOURCE_CONTENT_LENGTH.
+    expect(result.usableSources).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('diagnostic message names the chars threshold for the failure context', () => {
+    const result = evaluateSourceGate({
+      sourceCache: [],
+      totalUrls: 0,
+      llmSourceCount: 0,
+      minSources: 1,
+      skipGate: false,
+    });
+    expect(result.diagnostic).toContain(`>${MIN_SOURCE_CONTENT_LENGTH} chars`);
   });
 });

--- a/crux/authoring/page-improver/phases/research.test.ts
+++ b/crux/authoring/page-improver/phases/research.test.ts
@@ -187,7 +187,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 2,
       llmSourceCount: 2,
       minSources: 2,
-      skipGate: false,
     });
     expect(result.passed).toBe(true);
     expect(result.active).toBe(true);
@@ -201,7 +200,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 1,
       llmSourceCount: 1,
       minSources: 3,
-      skipGate: false,
     });
     expect(result.passed).toBe(false);
     expect(result.active).toBe(true);
@@ -216,7 +214,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 0,
       llmSourceCount: 0,
       minSources: 1,
-      skipGate: false,
     });
     expect(result.passed).toBe(false);
     expect(result.usableSources).toBe(0);
@@ -230,7 +227,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 5,
       llmSourceCount: 5,
       minSources: 1,
-      skipGate: false,
     });
     expect(result.passed).toBe(false);
     expect(result.usableSources).toBe(0);
@@ -250,7 +246,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 3,
       llmSourceCount: 3,
       minSources: 2,
-      skipGate: false,
     });
     expect(result.usableSources).toBe(1);
     expect(result.cacheEntries).toBe(3);
@@ -266,31 +261,17 @@ describe('evaluateSourceGate', () => {
       totalUrls: 1,
       llmSourceCount: 2,
       minSources: 2,
-      skipGate: false,
     });
     expect(result.usableSources).toBe(1);
     expect(result.passed).toBe(false);
   });
 
-  it('passes (gate disabled) when skipGate is true even with zero usable sources', () => {
-    const result = evaluateSourceGate({
-      sourceCache: [],
-      totalUrls: 0,
-      llmSourceCount: 0,
-      minSources: 5,
-      skipGate: true,
-    });
-    expect(result.active).toBe(false);
-    expect(result.passed).toBe(true);
-  });
-
-  it('passes (gate disabled) when minSources is 0', () => {
+  it('passes (gate disabled) when minSources is 0 — the canonical disable signal (--skip-source-gate maps to this)', () => {
     const result = evaluateSourceGate({
       sourceCache: [],
       totalUrls: 0,
       llmSourceCount: 0,
       minSources: 0,
-      skipGate: false,
     });
     expect(result.active).toBe(false);
     expect(result.passed).toBe(true);
@@ -302,7 +283,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 1,
       llmSourceCount: 1,
       minSources: 1,
-      skipGate: false,
     });
     expect(result.passed).toBe(true);
     expect(result.usableSources).toBe(1);
@@ -314,7 +294,6 @@ describe('evaluateSourceGate', () => {
       totalUrls: 1,
       llmSourceCount: 1,
       minSources: 1,
-      skipGate: false,
     });
     // Matches the buildSourceCache and citation-auditor behaviour: > MIN_SOURCE_CONTENT_LENGTH.
     expect(result.usableSources).toBe(0);
@@ -327,8 +306,9 @@ describe('evaluateSourceGate', () => {
       totalUrls: 0,
       llmSourceCount: 0,
       minSources: 1,
-      skipGate: false,
     });
     expect(result.diagnostic).toContain(`>${MIN_SOURCE_CONTENT_LENGTH} chars`);
+    // Threshold is also exposed on the report so callers can format their own log lines without re-importing the constant.
+    expect(result.contentThreshold).toBe(MIN_SOURCE_CONTENT_LENGTH);
   });
 });

--- a/crux/authoring/page-improver/phases/research.ts
+++ b/crux/authoring/page-improver/phases/research.ts
@@ -58,12 +58,80 @@ export function buildSourceCache(
   return cache;
 }
 
+/**
+ * Default minimum usable sources required by the research-phase gate.
+ * Tuned to catch the QUA-315 failure mode (0/4 successful improves on
+ * placeholder-heavy pages) without blocking legitimate edge cases.
+ *   - standard: 1 (any usable source — light bar)
+ *   - deep:    3 (the deep tier's whole purpose is multi-source grounding)
+ */
+export function defaultMinSources(deep: boolean): number {
+  return deep ? 3 : 1;
+}
+
+export interface SourceGateInput {
+  /** Source-cache entries built from the LLM's returned URLs + fetcher output. */
+  sourceCache: SourceCacheEntry[] | undefined;
+  /** Number of HTTP URLs the LLM agent returned (for the diagnostic message). */
+  totalUrls: number;
+  /** Number of LLM-returned source records (for the diagnostic message). */
+  llmSourceCount: number;
+  /** Tier-aware minimum (already resolved from options.minSources / defaults). */
+  minSources: number;
+  /** When true, the gate is bypassed (treated as PASS). */
+  skipGate: boolean;
+}
+
+export interface SourceGateReport {
+  /** True if the gate passed (or was disabled). */
+  passed: boolean;
+  /** True if the gate is active (not bypassed and minSources > 0). */
+  active: boolean;
+  /** Count of usable cache entries (>MIN_SOURCE_CONTENT_LENGTH chars of content). */
+  usableSources: number;
+  /** Number of cache entries (regardless of usability). */
+  cacheEntries: number;
+  /** Diagnostic message to pair with the throw / log. */
+  diagnostic: string;
+}
+
+/**
+ * Pure gate evaluation for the research phase. Decides whether the
+ * downstream improve phase should be allowed to run based on how many
+ * fetched sources actually carry usable content.
+ *
+ * Extracted from researchPhase so it can be unit-tested without mocking
+ * the LLM agent or the network. (QUA-315)
+ */
+export function evaluateSourceGate(input: SourceGateInput): SourceGateReport {
+  const { sourceCache, totalUrls, llmSourceCount, minSources, skipGate } = input;
+  const cacheEntries = sourceCache?.length || 0;
+  const usableSources = (sourceCache || []).filter(
+    e => e.url && e.content && e.content.length > MIN_SOURCE_CONTENT_LENGTH,
+  ).length;
+  const active = !skipGate && minSources > 0;
+  const passed = !active || usableSources >= minSources;
+
+  const diagnostic =
+    `Got ${usableSources} usable source(s); need at least ${minSources}. ` +
+    `Diagnostics: LLM agent returned ${llmSourceCount} sources with ${totalUrls} HTTP URL(s); ` +
+    `${cacheEntries} were cached, ${usableSources} had usable content ` +
+    `(>${MIN_SOURCE_CONTENT_LENGTH} chars).`;
+
+  return { passed, active, usableSources, cacheEntries, diagnostic };
+}
+
 export async function researchPhase(page: PageData, analysis: AnalysisResult, options: PipelineOptions): Promise<ResearchResult> {
   log('research', 'Starting research');
 
   const topics: string[] = analysis.researchNeeded || [];
   if (topics.length === 0) {
-    log('research', 'No research topics identified, skipping');
+    // Analysis decided no research is needed. This is sometimes legitimate
+    // (high-quality page with style-only gaps) but also a known silent-
+    // failure mode where the analyzer under-detects citation gaps. We
+    // surface it as a warning so reviewers see it in the log; the source
+    // gate does not fire because no fetch was attempted.
+    log('research', '⚠ No research topics identified by analysis — skipping research. If the page has placeholder citations, this is a misjudgment; consider re-running with --tier=deep or filing a follow-up.');
     return { sources: [] };
   }
 
@@ -186,6 +254,43 @@ Output ONLY valid JSON at the end.`;
       const error = err instanceof Error ? err : new Error(String(err));
       log('research', `  ⚠ Source fetching failed: ${error.message} — continuing without source cache`);
     }
+  }
+
+  // ── Source-coverage gate (QUA-315) ───────────────────────────────────────
+  // Count usable sources: cache entries whose fetched content cleared the
+  // MIN_SOURCE_CONTENT_LENGTH threshold. URLs returned by the LLM but not
+  // fetched, or fetched but paywalled/dead/empty, do NOT count — synthesis
+  // can't cite them and would otherwise emit placeholder footnotes.
+  const minSources = options.minSources ?? defaultMinSources(options.deep === true);
+  const gate = evaluateSourceGate({
+    sourceCache: research.sourceCache,
+    totalUrls: urls.length,
+    llmSourceCount: research.sources?.length || 0,
+    minSources,
+    skipGate: options.skipSourceGate === true,
+  });
+
+  log('research',
+    `Source coverage report: ${research.sources?.length || 0} LLM sources, ${urls.length} URL(s) returned, ` +
+    `${gate.cacheEntries} cache entries, ${gate.usableSources} usable (>${MIN_SOURCE_CONTENT_LENGTH} chars).`,
+  );
+  if (gate.active) {
+    log('research',
+      `Source gate: minSources=${minSources}, ${gate.passed ? 'PASS' : 'FAIL'} ` +
+      `(use --skip-source-gate to bypass).`,
+    );
+  } else {
+    log('research', 'Source gate: disabled (--skip-source-gate or minSources=0)');
+  }
+
+  if (!gate.passed) {
+    throw new Error(
+      `research: source-coverage gate failed for "${page.title}" (page ${page.id}). ` +
+      `${gate.diagnostic} ` +
+      `Aborting before improve to avoid synthesizing placeholder citations. ` +
+      `Use --skip-source-gate to override, --min-sources=N to lower the threshold, ` +
+      `or investigate why the research agent (Perplexity/SCRY/web_search) returned no usable URLs for this topic. (QUA-315)`,
+    );
   }
 
   return research;

--- a/crux/authoring/page-improver/phases/research.ts
+++ b/crux/authoring/page-improver/phases/research.ts
@@ -76,21 +76,24 @@ export interface SourceGateInput {
   totalUrls: number;
   /** Number of LLM-returned source records (for the diagnostic message). */
   llmSourceCount: number;
-  /** Tier-aware minimum (already resolved from options.minSources / defaults). */
+  /**
+   * Tier-aware minimum (already resolved from options.minSources / defaults).
+   * Set to 0 to disable the gate.
+   */
   minSources: number;
-  /** When true, the gate is bypassed (treated as PASS). */
-  skipGate: boolean;
 }
 
 export interface SourceGateReport {
   /** True if the gate passed (or was disabled). */
   passed: boolean;
-  /** True if the gate is active (not bypassed and minSources > 0). */
+  /** True if the gate is enforcing (minSources > 0). */
   active: boolean;
-  /** Count of usable cache entries (>MIN_SOURCE_CONTENT_LENGTH chars of content). */
+  /** Count of usable cache entries (above the content-length threshold). */
   usableSources: number;
   /** Number of cache entries (regardless of usability). */
   cacheEntries: number;
+  /** Content-length threshold below which an entry doesn't count as usable. */
+  contentThreshold: number;
   /** Diagnostic message to pair with the throw / log. */
   diagnostic: string;
 }
@@ -104,12 +107,12 @@ export interface SourceGateReport {
  * the LLM agent or the network. (QUA-315)
  */
 export function evaluateSourceGate(input: SourceGateInput): SourceGateReport {
-  const { sourceCache, totalUrls, llmSourceCount, minSources, skipGate } = input;
+  const { sourceCache, totalUrls, llmSourceCount, minSources } = input;
   const cacheEntries = sourceCache?.length || 0;
   const usableSources = (sourceCache || []).filter(
     e => e.url && e.content && e.content.length > MIN_SOURCE_CONTENT_LENGTH,
   ).length;
-  const active = !skipGate && minSources > 0;
+  const active = minSources > 0;
   const passed = !active || usableSources >= minSources;
 
   const diagnostic =
@@ -118,7 +121,7 @@ export function evaluateSourceGate(input: SourceGateInput): SourceGateReport {
     `${cacheEntries} were cached, ${usableSources} had usable content ` +
     `(>${MIN_SOURCE_CONTENT_LENGTH} chars).`;
 
-  return { passed, active, usableSources, cacheEntries, diagnostic };
+  return { passed, active, usableSources, cacheEntries, contentThreshold: MIN_SOURCE_CONTENT_LENGTH, diagnostic };
 }
 
 export async function researchPhase(page: PageData, analysis: AnalysisResult, options: PipelineOptions): Promise<ResearchResult> {
@@ -256,31 +259,25 @@ Output ONLY valid JSON at the end.`;
     }
   }
 
-  // ── Source-coverage gate (QUA-315) ───────────────────────────────────────
-  // Count usable sources: cache entries whose fetched content cleared the
-  // MIN_SOURCE_CONTENT_LENGTH threshold. URLs returned by the LLM but not
-  // fetched, or fetched but paywalled/dead/empty, do NOT count — synthesis
-  // can't cite them and would otherwise emit placeholder footnotes.
+  // Source-coverage gate (QUA-315): abort before the expensive improve pass
+  // when too few real sources landed. Otherwise synthesis hallucinates
+  // placeholder `[^N]: Research data on X` footnotes.
   const minSources = options.minSources ?? defaultMinSources(options.deep === true);
   const gate = evaluateSourceGate({
     sourceCache: research.sourceCache,
     totalUrls: urls.length,
     llmSourceCount: research.sources?.length || 0,
     minSources,
-    skipGate: options.skipSourceGate === true,
   });
 
   log('research',
     `Source coverage report: ${research.sources?.length || 0} LLM sources, ${urls.length} URL(s) returned, ` +
-    `${gate.cacheEntries} cache entries, ${gate.usableSources} usable (>${MIN_SOURCE_CONTENT_LENGTH} chars).`,
+    `${gate.cacheEntries} cache entries, ${gate.usableSources} usable (>${gate.contentThreshold} chars).`,
   );
   if (gate.active) {
-    log('research',
-      `Source gate: minSources=${minSources}, ${gate.passed ? 'PASS' : 'FAIL'} ` +
-      `(use --skip-source-gate to bypass).`,
-    );
+    log('research', `Source gate: minSources=${minSources}, ${gate.passed ? 'PASS' : 'FAIL'} (use --skip-source-gate to bypass).`);
   } else {
-    log('research', 'Source gate: disabled (--skip-source-gate or minSources=0)');
+    log('research', 'Source gate: disabled (minSources=0)');
   }
 
   if (!gate.passed) {

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -162,6 +162,26 @@ export interface PipelineOptions {
    * CLI mode bills via Claude Code subscription; API-direct bills via ANTHROPIC_API_KEY.
    */
   apiDirect?: boolean;
+  /**
+   * Minimum number of usable fetched sources required from the research
+   * phase. If fewer are landed, the pipeline aborts before improve runs
+   * (avoiding a wasted ~$15-25 improve pass that would produce placeholder
+   * citations). A "usable" source is one whose URL fetched successfully and
+   * returned more than MIN_SOURCE_CONTENT_LENGTH chars of content.
+   *
+   * Defaults: 1 for standard tier, 3 for research-deep. Set to 0 (or pass
+   * skipSourceGate) to disable. (QUA-315)
+   */
+  minSources?: number;
+  /**
+   * When true, skip the research-phase source-coverage gate. The improve
+   * pipeline will proceed even if no real URLs were fetched.
+   *
+   * Default: false (gate ON). The gate exists because synthesis on empty
+   * research produces placeholder footnotes that look cited but aren't —
+   * the same failure mode as QUA-290 in the create pipeline. (QUA-315)
+   */
+  skipSourceGate?: boolean;
 }
 
 // Re-export AuditResult so callers importing from types.ts get it too

--- a/crux/authoring/page-improver/types.ts
+++ b/crux/authoring/page-improver/types.ts
@@ -167,21 +167,12 @@ export interface PipelineOptions {
    * phase. If fewer are landed, the pipeline aborts before improve runs
    * (avoiding a wasted ~$15-25 improve pass that would produce placeholder
    * citations). A "usable" source is one whose URL fetched successfully and
-   * returned more than MIN_SOURCE_CONTENT_LENGTH chars of content.
+   * returned content above the citation-auditor's content-length threshold.
    *
-   * Defaults: 1 for standard tier, 3 for research-deep. Set to 0 (or pass
-   * skipSourceGate) to disable. (QUA-315)
+   * Defaults: 1 for standard tier, 3 for research-deep. Set to 0 to disable
+   * the gate entirely (the CLI's --skip-source-gate flag does this). (QUA-315)
    */
   minSources?: number;
-  /**
-   * When true, skip the research-phase source-coverage gate. The improve
-   * pipeline will proceed even if no real URLs were fetched.
-   *
-   * Default: false (gate ON). The gate exists because synthesis on empty
-   * research produces placeholder footnotes that look cited but aren't —
-   * the same failure mode as QUA-290 in the create pipeline. (QUA-315)
-   */
-  skipSourceGate?: boolean;
 }
 
 // Re-export AuditResult so callers importing from types.ts get it too

--- a/crux/commands/content.ts
+++ b/crux/commands/content.ts
@@ -14,7 +14,7 @@ const SCRIPTS: Record<string, ScriptConfig> = {
   improve: {
     script: 'authoring/page-improver/index.ts',
     description: 'Improve an existing page with AI assistance',
-    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'dry-run', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log', 'skip-enrich', 'section-level', 'engine', 'citation-gate', 'skip-citation-gate', 'skip-citation-audit', 'citation-audit-model', 'batch', 'batch-file', 'batch-budget', 'page-timeout', 'resume', 'report-file', 'no-save-artifacts', 'output', 'limit', 'openrouter', 'gap-analysis', 'api-direct'],
+    passthrough: ['ci', 'tier', 'directions', 'dryRun', 'dry-run', 'apply', 'grade', 'no-grade', 'triage', 'skip-session-log', 'skip-enrich', 'section-level', 'engine', 'citation-gate', 'skip-citation-gate', 'skip-citation-audit', 'citation-audit-model', 'batch', 'batch-file', 'batch-budget', 'page-timeout', 'resume', 'report-file', 'no-save-artifacts', 'output', 'limit', 'openrouter', 'gap-analysis', 'api-direct', 'skip-source-gate', 'min-sources'],
     positional: true,
   },
   iterate: {
@@ -106,6 +106,8 @@ Options:
   --skip-citation-gate  Allow --apply even if citation audit fails (default: gate ON) (improve)
   --skip-citation-audit  Skip citation audit phase (improve)
   --citation-audit-model Override LLM model for citation checking (improve)
+  --skip-source-gate    Allow improve to proceed when research lands few usable sources (improve)
+  --min-sources=N       Min usable research sources before improve runs; default standard=1 deep=3 (improve)
   --batch=id1,id2     Batch mode: comma-separated page IDs (improve, requires --engine=v2)
   --batch-file=f.txt  Batch mode: file with page IDs (improve, requires --engine=v2)
   --batch-budget=N    Stop batch when cumulative cost exceeds $N (improve)


### PR DESCRIPTION
## Summary

The improve pipeline's research phase silently degraded when source fetching failed: when the LLM agent returned 0 URLs, all fetches failed, or `fetchSources` threw, the phase returned an empty source cache and the downstream improve LLM hallucinated placeholder `[^N]: Research data on X` footnotes. This is the same failure class as [QUA-290](https://linear.app/quantifieduncertainty/issue/QUA-290) in the create pipeline (already fixed in PR #4267 via `crux/authoring/creator/source-fetching.ts`), and is the immediate cause of QUA-315: in a serial run over 4 placeholder-heavy pages, only 1/4 succeeded after ~2h and ~$100 of compute.

This adds a fail-fast gate at the end of `researchPhase` that aborts before improve runs. A "usable" source is one whose fetched content cleared `MIN_SOURCE_CONTENT_LENGTH` (50 chars). Defaults are tier-aware: `standard=1`, `deep=3` (the issue suggested 5; chose 3 as more conservative). Override with `--min-sources=N` or bypass with `--skip-source-gate`.

Every run now emits a `Source coverage report` log line for visibility — silent failures become loud failures.

## Key changes

- **`crux/authoring/page-improver/phases/research.ts`** — new `evaluateSourceGate()` (pure, unit-testable) + `defaultMinSources()`; gate enforcement at end of `researchPhase`. Made the "no research topics" case emit a warning instead of silent skip.
- **`crux/authoring/page-improver/types.ts`** — added `minSources?: number` to `PipelineOptions` (set to 0 to disable; `--skip-source-gate` is sugar for this).
- **`crux/authoring/page-improver/index.ts`** — wired `--min-sources=N` and `--skip-source-gate` flags. `parseMinSources()` validator throws on NaN/negative values (does NOT silently coerce — that would defeat the gate's purpose).
- **`crux/commands/content.ts`** — flag passthrough + help text.
- **`crux/authoring/page-improver/phases/research.test.ts`** + **`index.test.ts`** — 20 new unit tests covering gate boundary conditions, paywall/dead/empty entries, NaN/negative input rejection.

## Behavior change for callers

- **Manual `pnpm crux w improve <page> --tier=deep`**: now fails fast with a descriptive error instead of producing $25 of placeholder citations.
- **Auto-update batch (`crux/auto-update/batch-improve.ts`)**: pages where research lands fewer than the threshold sources will now be marked `failed` instead of silently shipping placeholder footnotes. This is the intended behavior — it makes the existing silent-failure mode visible. No code change to batch-improve was needed (its existing try/catch surfaces the failure to the orchestrator's failure log).
- **Orchestrator v2 (`--engine=v2`)**: rejects `--min-sources` / `--skip-source-gate` with a clear error pointing at the v1 path. The v2 orchestrator uses a different research path (tool-driven) and the gate doesn't apply identically. Filing a follow-up if v2 needs equivalent guarding is a separate concern.

## Out of scope (filed/noted)

- **`<R>` end-to-end refactor** (per QUA-290 follow-up comment): the existing pipeline already post-converts `[^N]` → `[^rc-XXXX]` via `convert-new-footnotes.ts`. Threading works correctly when fed real URLs; this fix prevents the no-URL cascade. A larger refactor having the LLM emit `<R>` directly is a separate ticket.
- **Adversarial-loop targeted research** (deep tier): doesn't go through `fetchSources()`, only does additional LLM research that gets merged. The primary failure mode (QUA-315) is the *initial* research phase coming back empty.
- **Analyzer-undercount**: when `analysis.researchNeeded` is empty, no fetch is attempted and the gate doesn't fire (now warned in the log). If the analyzer misjudges a placeholder-heavy page as needing no research, the fix belongs in the analyze phase. Worth a follow-up if observed.

## Test plan

- [x] `pnpm test` — 6593 tests pass (was 6593, +20 new)
- [x] `pnpm build` — exits 0
- [x] `pnpm crux w validate gate --fix` — all 50 gate checks pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — zero new errors in touched files
- [x] CLI smoke tests: `--min-sources=foo` → rejected, `--min-sources=-1` → rejected, `--engine=v2 --skip-source-gate` → rejected
- [x] `--help` text renders new flags
- [ ] Production verification: re-run `pnpm crux w improve openai-board-and-foundation-dynamics --tier=deep --apply` (one of the QUA-315 failed pages) — expect either real citations land OR a clear error pointing at low source coverage. Either is success vs. the current silent placeholder mode.

## Review

- `/agent-review-pr` ran (adaptive). Hostile reviewer found 2 HIGH issues — both fixed in commit 734c57c9: parseInt NaN guard and v2+gate combo rejection. 9 follow-up tests added.
- `/simplify` ran. Collapsed `skipSourceGate` field into `minSources: 0` (canonical disable signal) — net -35 lines from review state.

Closes QUA-315
