### PR TITLE
fix(factbase): tag 5 estimate-only properties as non-verifiable (QUA-541)

### DIFF
--- a/packages/factbase/data/properties.yaml
+++ b/packages/factbase/data/properties.yaml
@@ -398,6 +398,7 @@ properties:
     unit: employees
     category: safety
     temporal: true
+    verifiable: false  # Estimate; no published source
     appliesTo: [organization]
 
   interpretability-team-size:
@@ -407,6 +408,7 @@ properties:
     unit: employees
     category: safety
     temporal: true
+    verifiable: false  # Estimate; no published source
     appliesTo: [organization]
 
   # ── Additional Financial ──────────────────────────────────────
@@ -431,6 +433,7 @@ properties:
     unit: percent
     category: financial
     temporal: true
+    verifiable: false  # Estimate; no published source
     appliesTo: [organization]
     display:
       suffix: "%"
@@ -442,6 +445,7 @@ properties:
     unit: percent
     category: financial
     temporal: true
+    verifiable: false  # Estimate; no published source
     appliesTo: [organization]
     display:
       suffix: "%"
@@ -544,6 +548,7 @@ properties:
     unit: percent
     category: safety
     temporal: true
+    verifiable: false  # Estimate; no published source
     appliesTo: [organization]
     display:
       suffix: "%"


### PR DESCRIPTION
## Summary
- Adds `verifiable: false` to 5 FactBase property definitions that are inherently estimates without published sources
- Extends the QUA-247 pattern (which tagged `secondary-market-valuation` and `equity-stake-percent`)
- Properties will now be skipped by the source-checker instead of inflating the "unverifiable" count

## Properties tagged
- `safety-staffing-ratio`
- `interpretability-team-size`
- `safety-researcher-count`
- `retention-rate`
- `customer-concentration`

## Mechanism
`crux/lib/sourcing/item-collectors.ts:195` already skips properties where `property?.verifiable === false`, so no code changes needed.

## Test plan
- [x] Content gate passes
- [x] `pnpm build-data:content` succeeds (2026 entities, 757 pages)
- [x] `pnpm crux fb source-backfill --dry-run` runs without touching tagged properties
- [x] Full gate passes (41 checks)

Fixes QUA-541
