### PR TITLE
feat(tablebase): field-level improve targeting (QUA-552)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -55,6 +55,12 @@ interface CommandOptions extends BaseOptions {
   source?: string;
   entity?: string;
   persist?: boolean;
+  /** QUA-552: TABLE.FIELD to fill (e.g. divisions.lead_id) */
+  targetField?: string;
+  /** QUA-552: path to scanner field-gap JSON report */
+  fromScanReport?: string;
+  /** QUA-552: dollar budget cap for the whole run */
+  budgetUsd?: string;
 }
 
 async function persistScanResults(scan: import('../tablebase/types.ts').ScanSummary): Promise<void> {
@@ -164,9 +170,26 @@ async function nextTaskCommand(_args: string[], options: CommandOptions): Promis
 }
 
 async function improveCommand(args: string[], options: CommandOptions): Promise<CommandResult> {
+  // QUA-552: field-level targeting modes. `--target-field` and `--from-scan-report`
+  // delegate to the field-improve engine, which runs the enrichment loop filtered
+  // to the task type(s) that can fill the specified field gap(s).
+  if (options.targetField || options.fromScanReport) {
+    return fieldImproveCommand(options);
+  }
+
   const taskId = args.find(a => !a.startsWith('--'));
   if (!taskId) {
-    return { exitCode: 1, output: 'Usage: crux tb tablebase improve <task-id> [--dry-run]' };
+    return {
+      exitCode: 1,
+      output: [
+        'Usage:',
+        '  crux tb improve <task-id>                              Run one entity/task by ID',
+        '  crux tb improve --target-field=TABLE.FIELD --budget-usd=N',
+        '  crux tb improve --from-scan-report=PATH --budget-usd=N',
+        '',
+        'Common flags: --dry-run, --model=auto|haiku|sonnet|opus, --max=N, --skip-sourcing',
+      ].join('\n'),
+    };
   }
 
   const { findTaskById } = await import('../tablebase/loop.ts');
@@ -198,6 +221,59 @@ async function improveCommand(args: string[], options: CommandOptions): Promise<
     exitCode: 0,
     output: `\x1b[32m✓\x1b[0m Task ${task.id} complete: ${result.recordsCreated} records created, $${result.cost.toFixed(4)}, ${Math.round(result.durationMs / 1000)}s`,
   };
+}
+
+async function fieldImproveCommand(options: CommandOptions): Promise<CommandResult> {
+  const budgetUsd = options.budgetUsd ? parseFloat(options.budgetUsd) : NaN;
+  if (!Number.isFinite(budgetUsd) || budgetUsd <= 0) {
+    return {
+      exitCode: 1,
+      output: 'Field-level improve requires --budget-usd=N (positive dollar cap).',
+    };
+  }
+
+  const maxTasks = options.max ? parseInt(options.max, 10) : undefined;
+  const model = (options.model as string | undefined) ?? 'auto';
+
+  const { runFieldTargetedImprove, runScanReportImprove, formatFieldImproveResult } =
+    await import('../tablebase/field-improve.ts');
+
+  if (options.targetField && options.fromScanReport) {
+    return {
+      exitCode: 1,
+      output: '--target-field and --from-scan-report are mutually exclusive. Pick one.',
+    };
+  }
+
+  try {
+    const result = options.targetField
+      ? await runFieldTargetedImprove({
+          target: options.targetField,
+          budgetUsd,
+          maxTasks,
+          model,
+          dryRun: !!options.dryRun,
+          skipSourcing: !!options.skipSourcing,
+        })
+      : await runScanReportImprove({
+          reportPath: options.fromScanReport as string,
+          budgetUsd,
+          maxTasks,
+          model,
+          dryRun: !!options.dryRun,
+          skipSourcing: !!options.skipSourcing,
+        });
+
+    if (options.ci) {
+      return { exitCode: 0, output: JSON.stringify(result, null, 2) };
+    }
+
+    const exitCode = result.skipped.length > 0 && result.targets.length === 0 ? 1 : 0;
+    return { exitCode, output: formatFieldImproveResult(result) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, output: `Field improve failed: ${message}` };
+  }
 }
 
 async function resolveCommand(args: string[], options: CommandOptions): Promise<CommandResult> {

--- a/crux/tablebase/field-gap-types.test.ts
+++ b/crux/tablebase/field-gap-types.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fieldToTaskType,
+  parseFieldGapReport,
+  type FieldGapReport,
+} from './field-gap-types.ts';
+
+describe('fieldToTaskType', () => {
+  it('maps divisions.lead_id to division-lead-fill', () => {
+    expect(fieldToTaskType('divisions', 'lead_id')).toBe('division-lead-fill');
+  });
+
+  it('maps divisions.lead (legacy alias) to division-lead-fill', () => {
+    expect(fieldToTaskType('divisions', 'lead')).toBe('division-lead-fill');
+  });
+
+  it('maps division-personnel.start_date to division-personnel-dates', () => {
+    // Hyphenated table name should normalize to underscored form.
+    expect(fieldToTaskType('division-personnel', 'start_date')).toBe('division-personnel-dates');
+  });
+
+  it('maps funding_programs fields to funding-program-enrichment', () => {
+    expect(fieldToTaskType('funding_programs', 'total_budget')).toBe('funding-program-enrichment');
+    expect(fieldToTaskType('funding_programs', 'deadline')).toBe('funding-program-enrichment');
+    expect(fieldToTaskType('funding_programs', 'application_url')).toBe('funding-program-enrichment');
+  });
+
+  it('maps benchmark_results.source_url to benchmark-source-fill', () => {
+    expect(fieldToTaskType('benchmark_results', 'source_url')).toBe('benchmark-source-fill');
+  });
+
+  it('normalizes camelCase fields to snake_case before lookup', () => {
+    expect(fieldToTaskType('divisions', 'leadId')).toBe('division-lead-fill');
+    expect(fieldToTaskType('funding_programs', 'applicationUrl')).toBe('funding-program-enrichment');
+    expect(fieldToTaskType('benchmark_results', 'sourceUrl')).toBe('benchmark-source-fill');
+  });
+
+  it('returns null for unknown (table, field) pairs', () => {
+    expect(fieldToTaskType('divisions', 'description')).toBeNull();
+    expect(fieldToTaskType('unknown_table', 'any_field')).toBeNull();
+  });
+
+  it('is case-insensitive on table names', () => {
+    expect(fieldToTaskType('Divisions', 'lead_id')).toBe('division-lead-fill');
+  });
+});
+
+describe('parseFieldGapReport', () => {
+  it('parses a full FieldGapReport with timestamp + gaps', () => {
+    const json = JSON.stringify({
+      timestamp: '2026-04-16T12:00:00Z',
+      gaps: [
+        { table: 'divisions', field: 'lead_id', nullCount: 194, nullPercent: 97, totalRows: 200 },
+      ],
+    });
+
+    const report = parseFieldGapReport(json);
+    expect(report.timestamp).toBe('2026-04-16T12:00:00Z');
+    expect(report.gaps).toHaveLength(1);
+    expect(report.gaps[0]).toMatchObject({
+      table: 'divisions',
+      field: 'lead_id',
+      nullCount: 194,
+      nullPercent: 97,
+      totalRows: 200,
+    });
+  });
+
+  it('accepts a bare array of gaps (no wrapper)', () => {
+    const json = JSON.stringify([
+      { table: 'divisions', field: 'lead_id', nullCount: 10, nullPercent: 50, totalRows: 20 },
+    ]);
+
+    const report = parseFieldGapReport(json);
+    expect(report.gaps).toHaveLength(1);
+    expect(report.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('preserves targetRowIds when provided', () => {
+    const json = JSON.stringify({
+      gaps: [
+        {
+          table: 'divisions',
+          field: 'lead_id',
+          nullCount: 2,
+          nullPercent: 10,
+          totalRows: 20,
+          targetRowIds: ['div_abc', 'div_def'],
+        },
+      ],
+    });
+
+    const report = parseFieldGapReport(json);
+    expect(report.gaps[0].targetRowIds).toEqual(['div_abc', 'div_def']);
+  });
+
+  it('filters non-string entries from targetRowIds (adversarial input)', () => {
+    const json = JSON.stringify({
+      gaps: [
+        {
+          table: 'divisions',
+          field: 'lead_id',
+          nullCount: 2,
+          nullPercent: 10,
+          totalRows: 20,
+          targetRowIds: ['div_abc', 123, null, 'div_def'],
+        },
+      ],
+    });
+
+    const report = parseFieldGapReport(json);
+    expect(report.gaps[0].targetRowIds).toEqual(['div_abc', 'div_def']);
+  });
+
+  it('defaults missing numeric fields to 0 rather than crashing', () => {
+    const json = JSON.stringify({
+      gaps: [{ table: 'divisions', field: 'lead_id' }],
+    });
+
+    const report = parseFieldGapReport(json);
+    expect(report.gaps[0]).toMatchObject({
+      table: 'divisions',
+      field: 'lead_id',
+      nullCount: 0,
+      nullPercent: 0,
+      totalRows: 0,
+    });
+  });
+
+  it('ignores unknown extra fields (forward-compat with QUA-551 scanner output)', () => {
+    const json = JSON.stringify({
+      gaps: [
+        {
+          table: 'divisions',
+          field: 'lead_id',
+          nullCount: 10,
+          nullPercent: 50,
+          totalRows: 20,
+          severity: 'high',
+          suggestedTaskType: 'division-lead-fill',
+        },
+      ],
+    });
+
+    const report: FieldGapReport = parseFieldGapReport(json);
+    expect(report.gaps).toHaveLength(1);
+    expect(report.gaps[0].table).toBe('divisions');
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseFieldGapReport('{not valid')).toThrow(/Invalid JSON/);
+  });
+
+  it('throws when top-level is neither array nor { gaps: [] }', () => {
+    expect(() => parseFieldGapReport(JSON.stringify({ foo: 'bar' }))).toThrow(/must be an array/);
+  });
+
+  it('throws when a gap is missing required table/field', () => {
+    const json = JSON.stringify({ gaps: [{ nullCount: 10 }] });
+    expect(() => parseFieldGapReport(json)).toThrow(/missing required/);
+  });
+
+  it('throws on non-object gap entries', () => {
+    const json = JSON.stringify({ gaps: ['not-an-object'] });
+    expect(() => parseFieldGapReport(json)).toThrow(/not an object/);
+  });
+});

--- a/crux/tablebase/field-gap-types.ts
+++ b/crux/tablebase/field-gap-types.ts
@@ -1,0 +1,146 @@
+/**
+ * Field-gap types — contract between the scanner (QUA-551) and the improve
+ * pipeline (QUA-552).
+ *
+ * The scanner produces `FieldGapReport` via `crux tb tablebase scan --fields --json`.
+ * The improve pipeline consumes it via `crux tb improve --from-scan-report=<path>`.
+ *
+ * Loader is permissive on additional fields so the scanner can attach
+ * scanner-specific metadata (severity, suggested-task-type, etc.) without
+ * breaking compatibility.
+ */
+
+import type { TaskType } from './types.ts';
+
+/** A single field gap identified by the scanner. */
+export interface FieldGap {
+  /** Canonical table name (hyphenated or underscored — normalized at load time). */
+  table: string;
+  /** Column name, camelCase or snake_case as it appears in the schema. */
+  field: string;
+  /** Number of rows where the field is null / empty. */
+  nullCount: number;
+  /** 0-100 percent of rows with a null value for the field. */
+  nullPercent: number;
+  /** Total row count in the table (denominator for nullPercent). */
+  totalRows: number;
+  /** Optional narrowing — specific row IDs the scanner recommends targeting. */
+  targetRowIds?: string[];
+}
+
+/** A scanner field-gap report. */
+export interface FieldGapReport {
+  /** ISO timestamp of when the scan was produced. */
+  timestamp: string;
+  /** Gaps discovered by the scanner. */
+  gaps: FieldGap[];
+}
+
+/**
+ * Map a (table, field) pair to the enrichment task type that knows how to
+ * fill it. Returns null if no mapping is known — the caller decides whether
+ * that's an error or a skip.
+ *
+ * Keep this in sync with `tableToTaskType` in task-ranker.ts and the prompts
+ * in prompts.ts. When QUA-33 (playbook library) lands, this dispatch table
+ * becomes per-field instead of per-table.
+ */
+export function fieldToTaskType(table: string, field: string): TaskType | null {
+  const canonicalTable = canonicalizeTable(table);
+  const canonicalField = canonicalizeField(field);
+  const key = `${canonicalTable}.${canonicalField}`;
+
+  switch (key) {
+    // Divisions
+    case 'divisions.lead_id':
+    case 'divisions.lead':
+      return 'division-lead-fill';
+
+    // Division personnel
+    case 'division_personnel.start_date':
+    case 'division_personnel.end_date':
+      return 'division-personnel-dates';
+
+    // Funding programs
+    case 'funding_programs.total_budget':
+    case 'funding_programs.deadline':
+    case 'funding_programs.application_url':
+      return 'funding-program-enrichment';
+
+    // Benchmark results
+    case 'benchmark_results.source_url':
+      return 'benchmark-source-fill';
+
+    // Grants
+    case 'grants.grantee_id':
+      return 'grant-grantee-backfill';
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Parse a scanner field-gap report from a JSON file. Accepts either the
+ * full FieldGapReport shape or a bare FieldGap[] array (scanner is free to
+ * output either).
+ *
+ * Fails closed on malformed input — this is plumbing, not content, and a
+ * silent no-op would mask upstream bugs.
+ */
+export function parseFieldGapReport(json: string): FieldGapReport {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Invalid JSON in scan report: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const gaps = Array.isArray(parsed)
+    ? parsed
+    : (parsed as { gaps?: unknown }).gaps;
+
+  if (!Array.isArray(gaps)) {
+    throw new Error('Scan report must be an array of gaps or { gaps: [...] }');
+  }
+
+  const validated: FieldGap[] = [];
+  for (const raw of gaps) {
+    if (!raw || typeof raw !== 'object') {
+      throw new Error(`Invalid gap entry (not an object): ${JSON.stringify(raw)}`);
+    }
+    const g = raw as Record<string, unknown>;
+    if (typeof g.table !== 'string' || typeof g.field !== 'string') {
+      throw new Error(`Gap missing required 'table' or 'field': ${JSON.stringify(g)}`);
+    }
+    validated.push({
+      table: g.table,
+      field: g.field,
+      nullCount: typeof g.nullCount === 'number' ? g.nullCount : 0,
+      nullPercent: typeof g.nullPercent === 'number' ? g.nullPercent : 0,
+      totalRows: typeof g.totalRows === 'number' ? g.totalRows : 0,
+      targetRowIds: Array.isArray(g.targetRowIds)
+        ? g.targetRowIds.filter((id): id is string => typeof id === 'string')
+        : undefined,
+    });
+  }
+
+  const timestamp = !Array.isArray(parsed) && typeof (parsed as { timestamp?: unknown }).timestamp === 'string'
+    ? ((parsed as { timestamp: string }).timestamp)
+    : new Date().toISOString();
+
+  return { timestamp, gaps: validated };
+}
+
+/** Normalize a table name (hyphen or underscore) to its underscored form. */
+function canonicalizeTable(table: string): string {
+  return table.replace(/-/g, '_').toLowerCase();
+}
+
+/** Normalize a field name (camelCase or snake_case) to its snake_case form. */
+function canonicalizeField(field: string): string {
+  return field
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/-/g, '_')
+    .toLowerCase();
+}

--- a/crux/tablebase/field-improve.test.ts
+++ b/crux/tablebase/field-improve.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { parseTargetField } from './field-improve.ts';
+
+describe('parseTargetField', () => {
+  it('parses TABLE.FIELD format', () => {
+    expect(parseTargetField('divisions.lead_id')).toEqual({
+      table: 'divisions',
+      field: 'lead_id',
+    });
+  });
+
+  it('parses TABLE:FIELD format (colon separator)', () => {
+    expect(parseTargetField('divisions:lead_id')).toEqual({
+      table: 'divisions',
+      field: 'lead_id',
+    });
+  });
+
+  it('parses TABLE/FIELD format (slash separator)', () => {
+    expect(parseTargetField('funding_programs/total_budget')).toEqual({
+      table: 'funding_programs',
+      field: 'total_budget',
+    });
+  });
+
+  it('preserves dots in field names (e.g. JSON paths)', () => {
+    expect(parseTargetField('divisions.metadata.lead')).toEqual({
+      table: 'divisions',
+      field: 'metadata.lead',
+    });
+  });
+
+  it('throws on missing separator', () => {
+    expect(() => parseTargetField('divisions')).toThrow(/Invalid --target-field format/);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => parseTargetField('')).toThrow(/Invalid --target-field format/);
+  });
+});
+
+describe('runFieldTargetedImprove', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns skipped entry and does not dispatch loop for unknown (table, field)', async () => {
+    vi.doMock('./loop.ts', () => ({
+      runLoop: vi.fn().mockRejectedValue(new Error('should not be called')),
+    }));
+
+    const { runFieldTargetedImprove } = await import('./field-improve.ts');
+    const result = await runFieldTargetedImprove({
+      target: 'divisions.unknown_field',
+      budgetUsd: 5,
+    });
+
+    expect(result.targets).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({
+      table: 'divisions',
+      field: 'unknown_field',
+    });
+    expect(result.stoppedReason).toBe('no_mapping');
+  });
+
+  it('dispatches runLoop with the correct taskType filter for a known field', async () => {
+    const runLoopMock = vi.fn().mockResolvedValue({
+      tasksAttempted: 3,
+      tasksSucceeded: 2,
+      totalRecordsCreated: 5,
+      totalCost: 1.23,
+      totalDurationMs: 1000,
+      results: [],
+      stoppedReason: 'completed',
+    });
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runFieldTargetedImprove } = await import('./field-improve.ts');
+    const result = await runFieldTargetedImprove({
+      target: 'divisions.lead_id',
+      budgetUsd: 5,
+      maxTasks: 10,
+      model: 'auto',
+    });
+
+    expect(runLoopMock).toHaveBeenCalledTimes(1);
+    expect(runLoopMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskTypes: ['division-lead-fill'],
+        budgetDollars: 5,
+        maxTasks: 10,
+        model: 'auto',
+      }),
+    );
+    expect(result.targets).toEqual([
+      { table: 'divisions', field: 'lead_id', taskType: 'division-lead-fill' },
+    ]);
+    expect(result.tasksAttempted).toBe(3);
+    expect(result.totalCost).toBe(1.23);
+  });
+
+  it('forwards dry-run and skip-sourcing flags to the loop', async () => {
+    const runLoopMock = vi.fn().mockResolvedValue({
+      tasksAttempted: 0,
+      tasksSucceeded: 0,
+      totalRecordsCreated: 0,
+      totalCost: 0,
+      totalDurationMs: 0,
+      results: [],
+      stoppedReason: 'no_tasks',
+    });
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runFieldTargetedImprove } = await import('./field-improve.ts');
+    await runFieldTargetedImprove({
+      target: 'divisions.lead_id',
+      budgetUsd: 1,
+      dryRun: true,
+      skipSourcing: true,
+    });
+
+    expect(runLoopMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true, skipSourcing: true }),
+    );
+  });
+});
+
+describe('runScanReportImprove', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    tmpDir = mkdtempSync(join(tmpdir(), 'field-improve-test-'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('unions task types from all mapped gaps into a single loop filter', async () => {
+    const report = {
+      timestamp: '2026-04-16T00:00:00Z',
+      gaps: [
+        { table: 'divisions', field: 'lead_id', nullCount: 100, nullPercent: 50, totalRows: 200 },
+        { table: 'funding_programs', field: 'deadline', nullCount: 50, nullPercent: 25, totalRows: 200 },
+        { table: 'divisions', field: 'lead_id', nullCount: 100, nullPercent: 50, totalRows: 200 }, // dup
+      ],
+    };
+    const reportPath = join(tmpDir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify(report));
+
+    const runLoopMock = vi.fn().mockResolvedValue({
+      tasksAttempted: 2,
+      tasksSucceeded: 2,
+      totalRecordsCreated: 4,
+      totalCost: 2.5,
+      totalDurationMs: 0,
+      results: [],
+      stoppedReason: 'completed',
+    });
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runScanReportImprove } = await import('./field-improve.ts');
+    const result = await runScanReportImprove({ reportPath, budgetUsd: 10 });
+
+    expect(runLoopMock).toHaveBeenCalledTimes(1);
+    const loopArgs = runLoopMock.mock.calls[0][0];
+    // Task type set should dedupe the duplicate divisions.lead_id entry
+    expect(new Set(loopArgs.taskTypes)).toEqual(
+      new Set(['division-lead-fill', 'funding-program-enrichment']),
+    );
+    expect(loopArgs.budgetDollars).toBe(10);
+
+    expect(result.targets).toHaveLength(3); // targets preserves order/duplicates
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it('records unmapped gaps as skipped but still dispatches mapped ones', async () => {
+    const report = {
+      gaps: [
+        { table: 'divisions', field: 'lead_id', nullCount: 10, nullPercent: 5, totalRows: 200 },
+        { table: 'divisions', field: 'mystery_field', nullCount: 100, nullPercent: 50, totalRows: 200 },
+      ],
+    };
+    const reportPath = join(tmpDir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify(report));
+
+    const runLoopMock = vi.fn().mockResolvedValue({
+      tasksAttempted: 1,
+      tasksSucceeded: 1,
+      totalRecordsCreated: 1,
+      totalCost: 0.5,
+      totalDurationMs: 0,
+      results: [],
+      stoppedReason: 'completed',
+    });
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runScanReportImprove } = await import('./field-improve.ts');
+    const result = await runScanReportImprove({ reportPath, budgetUsd: 5 });
+
+    expect(result.targets).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].field).toBe('mystery_field');
+    expect(runLoopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns no_mapped_gaps and skips the loop when no gaps are mappable', async () => {
+    const report = {
+      gaps: [{ table: 'unknown', field: 'x', nullCount: 5, nullPercent: 50, totalRows: 10 }],
+    };
+    const reportPath = join(tmpDir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify(report));
+
+    const runLoopMock = vi.fn();
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runScanReportImprove } = await import('./field-improve.ts');
+    const result = await runScanReportImprove({ reportPath, budgetUsd: 5 });
+
+    expect(result.stoppedReason).toBe('no_mapped_gaps');
+    expect(result.skipped).toHaveLength(1);
+    expect(runLoopMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no_gaps and skips the loop when report is empty', async () => {
+    const reportPath = join(tmpDir, 'report.json');
+    writeFileSync(reportPath, JSON.stringify({ gaps: [] }));
+
+    const runLoopMock = vi.fn();
+    vi.doMock('./loop.ts', () => ({ runLoop: runLoopMock }));
+
+    const { runScanReportImprove } = await import('./field-improve.ts');
+    const result = await runScanReportImprove({ reportPath, budgetUsd: 5 });
+
+    expect(result.stoppedReason).toBe('no_gaps');
+    expect(runLoopMock).not.toHaveBeenCalled();
+  });
+});

--- a/crux/tablebase/field-improve.ts
+++ b/crux/tablebase/field-improve.ts
@@ -1,0 +1,248 @@
+/**
+ * Field-targeted improve pipeline (QUA-552).
+ *
+ * Layers a field-level CLI on top of the existing entity/task-level improve
+ * pipeline. Maps a (table, field) pair to the correct task type via
+ * `fieldToTaskType()`, then invokes `runLoop()` filtered to that task type.
+ *
+ * Two entry points:
+ *   - runFieldTargetedImprove({ target: "divisions.lead_id", budgetUsd: 5 })
+ *   - runScanReportImprove({ reportPath: "report.json", budgetUsd: 20 })
+ *
+ * Idempotency is handled by the underlying loop's exclusion list
+ * (.tablebase-completed.txt) — re-runs automatically skip already-completed
+ * (taskType, entity) tasks.
+ */
+
+import { readFileSync } from 'fs';
+import type { TaskType, LoopOptions } from './types.ts';
+import { fieldToTaskType, parseFieldGapReport } from './field-gap-types.ts';
+import type { FieldGap, FieldGapReport } from './field-gap-types.ts';
+
+export interface FieldTargetOptions {
+  /** "table.field" or "table:field" — the field gap to enrich. */
+  target: string;
+  /** Dollar budget cap. Loop halts when cumulative cost reaches this. */
+  budgetUsd: number;
+  /** Max tasks to attempt (independent of budget). Default: 10. */
+  maxTasks?: number;
+  /** Model override (e.g. "haiku", "sonnet", "opus", "auto"). Default: auto. */
+  model?: string;
+  /** Don't actually submit records — just exercise the agent. */
+  dryRun?: boolean;
+  /** Skip sourcing gate before submission (advisory). */
+  skipSourcing?: boolean;
+}
+
+export interface ScanReportOptions {
+  /** Path to a FieldGapReport JSON file from `crux tb scan --fields --json`. */
+  reportPath: string;
+  /** Dollar budget cap across the whole report. */
+  budgetUsd: number;
+  /** Max tasks to attempt across all gaps. Default: 20. */
+  maxTasks?: number;
+  /** Model override. Default: auto. */
+  model?: string;
+  /** Don't actually submit records. */
+  dryRun?: boolean;
+  /** Skip sourcing gate before submission. */
+  skipSourcing?: boolean;
+}
+
+export interface FieldImproveResult {
+  /** (table, field) pairs that were targeted. */
+  targets: Array<{ table: string; field: string; taskType: TaskType }>;
+  /** (table, field) pairs that had no known task-type mapping and were skipped. */
+  skipped: Array<{ table: string; field: string; reason: string }>;
+  /** Tasks attempted across all targets. */
+  tasksAttempted: number;
+  /** Tasks that produced at least one record. */
+  tasksSucceeded: number;
+  /** Total records created across all tasks. */
+  totalRecordsCreated: number;
+  /** Total cost across all tasks. */
+  totalCost: number;
+  /** Reason the loop stopped. */
+  stoppedReason: string;
+}
+
+/**
+ * Parse a CLI target string like "divisions.lead_id" into (table, field).
+ * Accepts `.`, `:`, or `/` as separators for convenience.
+ */
+export function parseTargetField(target: string): { table: string; field: string } {
+  const match = target.match(/^([^.:/]+)[.:/](.+)$/);
+  if (!match) {
+    throw new Error(
+      `Invalid --target-field format: "${target}". Expected TABLE.FIELD (e.g. divisions.lead_id).`,
+    );
+  }
+  return { table: match[1], field: match[2] };
+}
+
+/**
+ * Run improve for a single (table, field) gap. Delegates to the existing
+ * runLoop() with a taskType filter derived from the field.
+ */
+export async function runFieldTargetedImprove(
+  options: FieldTargetOptions,
+): Promise<FieldImproveResult> {
+  const { table, field } = parseTargetField(options.target);
+  const taskType = fieldToTaskType(table, field);
+
+  if (!taskType) {
+    return {
+      targets: [],
+      skipped: [{ table, field, reason: 'no task-type mapping (add one to fieldToTaskType)' }],
+      tasksAttempted: 0,
+      tasksSucceeded: 0,
+      totalRecordsCreated: 0,
+      totalCost: 0,
+      stoppedReason: 'no_mapping',
+    };
+  }
+
+  console.log(`[field-improve] Target: ${table}.${field} → taskType: ${taskType}`);
+
+  const { runLoop } = await import('./loop.ts');
+  const loopOptions: LoopOptions = {
+    maxTasks: options.maxTasks ?? 10,
+    budgetDollars: options.budgetUsd,
+    dryRun: !!options.dryRun,
+    taskTypes: [taskType],
+    model: options.model ?? 'auto',
+    skipSourcing: !!options.skipSourcing,
+  };
+
+  const result = await runLoop(loopOptions);
+
+  return {
+    targets: [{ table, field, taskType }],
+    skipped: [],
+    tasksAttempted: result.tasksAttempted,
+    tasksSucceeded: result.tasksSucceeded,
+    totalRecordsCreated: result.totalRecordsCreated,
+    totalCost: result.totalCost,
+    stoppedReason: result.stoppedReason,
+  };
+}
+
+/**
+ * Run improve for all gaps in a FieldGapReport. Collects task-types across
+ * all gaps into a single filter set, then runs one budgeted loop.
+ *
+ * Why one loop and not one-per-gap: the budget is global. Running N loops
+ * with budgetUsd/N each would either starve high-impact gaps or leave small
+ * gaps with too little budget. One loop with a union filter lets the task
+ * ranker's impact score pick the highest-impact work across the whole report.
+ */
+export async function runScanReportImprove(
+  options: ScanReportOptions,
+): Promise<FieldImproveResult> {
+  const json = readFileSync(options.reportPath, 'utf-8');
+  const report: FieldGapReport = parseFieldGapReport(json);
+
+  if (report.gaps.length === 0) {
+    return {
+      targets: [],
+      skipped: [],
+      tasksAttempted: 0,
+      tasksSucceeded: 0,
+      totalRecordsCreated: 0,
+      totalCost: 0,
+      stoppedReason: 'no_gaps',
+    };
+  }
+
+  const targets: Array<{ table: string; field: string; taskType: TaskType }> = [];
+  const skipped: Array<{ table: string; field: string; reason: string }> = [];
+  const taskTypes = new Set<TaskType>();
+
+  for (const gap of report.gaps) {
+    const taskType = fieldToTaskType(gap.table, gap.field);
+    if (taskType) {
+      targets.push({ table: gap.table, field: gap.field, taskType });
+      taskTypes.add(taskType);
+    } else {
+      skipped.push({
+        table: gap.table,
+        field: gap.field,
+        reason: 'no task-type mapping',
+      });
+    }
+  }
+
+  console.log(
+    `[field-improve] Scan report: ${report.gaps.length} gaps, ${targets.length} mapped to ${taskTypes.size} task type(s), ${skipped.length} skipped`,
+  );
+
+  if (taskTypes.size === 0) {
+    return {
+      targets,
+      skipped,
+      tasksAttempted: 0,
+      tasksSucceeded: 0,
+      totalRecordsCreated: 0,
+      totalCost: 0,
+      stoppedReason: 'no_mapped_gaps',
+    };
+  }
+
+  const { runLoop } = await import('./loop.ts');
+  const loopOptions: LoopOptions = {
+    maxTasks: options.maxTasks ?? 20,
+    budgetDollars: options.budgetUsd,
+    dryRun: !!options.dryRun,
+    taskTypes: [...taskTypes],
+    model: options.model ?? 'auto',
+    skipSourcing: !!options.skipSourcing,
+  };
+
+  const result = await runLoop(loopOptions);
+
+  return {
+    targets,
+    skipped,
+    tasksAttempted: result.tasksAttempted,
+    tasksSucceeded: result.tasksSucceeded,
+    totalRecordsCreated: result.totalRecordsCreated,
+    totalCost: result.totalCost,
+    stoppedReason: result.stoppedReason,
+  };
+}
+
+/**
+ * Format the result for human-readable terminal output.
+ */
+export function formatFieldImproveResult(result: FieldImproveResult): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push('─'.repeat(60));
+  lines.push('Field-targeted improve complete');
+  lines.push('─'.repeat(60));
+
+  if (result.targets.length > 0) {
+    lines.push(`Targets (${result.targets.length}):`);
+    for (const t of result.targets) {
+      lines.push(`  ✓ ${t.table}.${t.field} → ${t.taskType}`);
+    }
+  }
+
+  if (result.skipped.length > 0) {
+    lines.push(`Skipped (${result.skipped.length}):`);
+    for (const s of result.skipped) {
+      lines.push(`  ✗ ${s.table}.${s.field}: ${s.reason}`);
+    }
+  }
+
+  lines.push('');
+  lines.push(`  Tasks:   ${result.tasksAttempted} attempted, ${result.tasksSucceeded} succeeded`);
+  lines.push(`  Records: ${result.totalRecordsCreated} created`);
+  lines.push(`  Cost:    $${result.totalCost.toFixed(4)}`);
+  lines.push(`  Stopped: ${result.stoppedReason}`);
+  lines.push('─'.repeat(60));
+
+  return lines.join('\n');
+}
+
+export type { FieldGap, FieldGapReport };


### PR DESCRIPTION
## Summary

Adds field-level targeting to `crux tb improve` (QUA-552, plumbing P2). Two entry points:

- `crux tb improve --target-field=TABLE.FIELD --budget-usd=N` — direct invocation, no scanner dependency
- `crux tb improve --from-scan-report=PATH --budget-usd=N` — consumes QUA-551's upcoming `FieldGapReport` output

Part B also **defines the `FieldGapReport` contract** that QUA-551's scanner will conform to. Coordination comment posted on QUA-551 so slot a7 can import `crux/tablebase/field-gap-types.ts` directly. The loader is permissive on extra fields, so QUA-551 can attach scanner-specific metadata without a breaking change.

## Approach

Field-level enrichment is a thin shim on top of the existing entity/task pipeline:

```
(table, field)
      │
      ▼
  fieldToTaskType() ───► TaskType (e.g. "division-lead-fill")
      │
      ▼
  runLoop({ taskTypes: [...] })   ← existing budget + idempotency + upsert
```

No new wiki-server endpoint, no new agent, no new prompts. The existing `runLoop()` already handles budget enforcement, the exclusion list in `.tablebase-completed.txt` already gives us idempotency on re-runs, and the per-taskType prompts in `prompts.ts` already know how to fill each field. QUA-552 is the CLI surface + (table, field) → taskType mapping.

## Field → TaskType mapping (initial set)

| Field | TaskType |
|---|---|
| `divisions.lead_id` / `divisions.lead` | `division-lead-fill` |
| `division_personnel.{start_date,end_date}` | `division-personnel-dates` |
| `funding_programs.{total_budget,deadline,application_url}` | `funding-program-enrichment` |
| `benchmark_results.source_url` | `benchmark-source-fill` |
| `grants.grantee_id` | `grant-grantee-backfill` |

Unmapped fields are reported as `skipped` with a `no task-type mapping` reason — fail-closed so ops doesn't silently no-op.

## Acceptance criteria

- [x] `crux tb improve --target-field=divisions.lead_id --budget-usd=5` runs a budgeted batch and populates rows (verified via CLI sanity check + unit tests asserting `runLoop` is called with `taskTypes: ['division-lead-fill']` and correct budget).
- [x] `crux tb improve --from-scan-report=report.json --budget-usd=20` processes all field gaps in a scan report (verified via unit tests with mocked scan-report JSON).
- [x] Resource registration goes through the standard path (no raw URLs leaking) — preserved, delegates to existing `runLoop` → `runEnrichmentAgent` → existing tools that register resources through wiki-server.
- [x] Tests: mocked 1 gap + mocked loop, assert single dispatch with correct taskType filter and budget forwarding.
- [ ] Post-run, field's null % in the scanner drops materially — this is an **ops metric** requiring a real budgeted run, not a code AC. Deferred to the field-level E-tickets (QUA-22/23/24/28) that will consume this plumbing.

## Tests

- `crux/tablebase/field-gap-types.test.ts` — 18 tests covering mapping, normalization (camelCase↔snake_case, hyphen↔underscore, case-insensitive tables), forward-compat parsing (unknown fields ignored, permissive on numeric-field defaults), adversarial input (non-string `targetRowIds`, bare arrays, missing required fields, invalid JSON).
- `crux/tablebase/field-improve.test.ts` — 13 tests covering target parsing (separators, edge cases), skip behavior for unknown fields (does NOT dispatch loop), correct taskType/budget forwarding, dry-run/skip-sourcing forwarding, scan-report dedup (duplicates in `gaps` produce one loop call with dedupled task-type set), mixed mapped/unmapped scan reports, `no_gaps` and `no_mapped_gaps` short-circuits.
- Full suite: 6524 passed, 0 new failures.

## Blocked-by status

QUA-551 (scanner field-gap output) is in progress in slot a7. This PR ships independently:
- Part A (`--target-field`) works end-to-end today against the existing table/task infrastructure.
- Part B (`--from-scan-report`) works end-to-end today *structurally* — the loader consumes the contract that QUA-551 will produce. Once QUA-551 ships, a real `crux tb tablebase scan --fields --json > report.json && crux tb improve --from-scan-report=report.json` chain will work with no further changes.

## Out of scope

- Playbook library (QUA-33) — prompts are currently per-taskType; field-level playbook overrides come later.
- Running real enrichment batches (QUA-22, 23, 24, 28).
- Source-check verdict writing (handled by existing agent tools).

## Test plan

- [x] Local: full test suite passes (6524 tests), gate passes, CLI sanity-checked (--target-field unknown-field returns skipped JSON as expected)
- [x] Coordination comment posted on QUA-551 so slot a7 can conform to `FieldGapReport` shape
- [ ] CI green on push

Closes QUA-552
