### PR TITLE
feat(dashboards): migrate sourcing-coverage to Pattern A (QUA-359)

### DIFF
--- a/apps/web/src/app/internal/sourcing-coverage/page.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/page.tsx
@@ -1,18 +1,5 @@
-import type { Metadata } from "next";
-import { SourcingCoverageContent } from "./sourcing-coverage-content";
+import { redirect } from "next/navigation";
 
-export const metadata: Metadata = {
-  title: "Source Check Coverage",
-  description:
-    "Data quality and coverage across all record types — sourcing verdicts, entity counts, and accuracy rates.",
-  robots: { index: false },
-};
-
-export default function SourcingCoveragePage() {
-  return (
-    <article className="container mx-auto max-w-6xl px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">Source Check Coverage</h1>
-      <SourcingCoverageContent />
-    </article>
-  );
+export default function SourcingCoverageRedirect() {
+  redirect("/wiki/E2486");
 }

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -76,6 +76,7 @@ import { PeopleCoverageContent } from "@/app/internal/people-coverage/people-cov
 import { AgentActivityContent } from "@/app/internal/agent-activity/agent-activity-content";
 import { EntityProfileContent } from "@/app/internal/entity-profile/entity-profile-content";
 import { EntitySourcingContent } from "@/app/internal/entity-sourcing/entity-sourcing-content";
+import { SourcingCoverageContent } from "@/app/internal/sourcing-coverage/sourcing-coverage-content";
 import { DataQualityContent } from "@/app/internal/data-quality/data-quality-content";
 import { TalentFlowsContent } from "@/app/internal/talent-flows/talent-flows-content";
 import { JobsDashboardContent } from "@/app/internal/jobs/jobs-content";
@@ -240,6 +241,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   AgentActivityContent,
   EntityProfileContent,
   EntitySourcingContent,
+  SourcingCoverageContent,
   DataQualityContent,
   TalentFlowsContent,
   JobsDashboardContent,

--- a/apps/web/src/lib/__tests__/wiki-nav.test.ts
+++ b/apps/web/src/lib/__tests__/wiki-nav.test.ts
@@ -431,9 +431,6 @@ describe("internal sidebar completeness (real data)", () => {
       if (!entry.isDirectory()) continue;
       // Skip the catch-all route (handles MDX pages)
       if (entry.name.startsWith("[[")) continue;
-      // Skip pages not yet migrated to Pattern A (no entity ID allocated)
-      if (entry.name === "sourcing-coverage") continue; // #3634
-
       const pagePath = path.join(APP_INTERNAL_DIR, entry.name, "page.tsx");
       if (fs.existsSync(pagePath)) {
         // Skip pages that are just redirects (migrated to MDX stubs or consolidated)

--- a/content/docs/internal/sourcing-coverage-dashboard.mdx
+++ b/content/docs/internal/sourcing-coverage-dashboard.mdx
@@ -1,0 +1,13 @@
+---
+wikiId: E2486
+title: "Source Check Coverage"
+description: "Data quality and coverage across all record types — sourcing verdicts, entity counts, and accuracy rates."
+subcategory: dashboards
+contentFormat: dashboard
+hideSidebar: true
+lastEdited: "2026-04-16"
+---
+
+Per-record-type coverage and verdict breakdown across the unified sourcing system. Shows which record types have been source-checked, which are exempt (data ingested from canonical APIs), and the verdict distribution. Compare to `/internal/entity-sourcing` for per-entity claim-level drilldowns.
+
+<SourcingCoverageContent />

--- a/content/docs/internal/verification-sourcing-hub.mdx
+++ b/content/docs/internal/verification-sourcing-hub.mdx
@@ -30,7 +30,7 @@ A page says "Anthropic raised \$4B in 2024" and you want to know whether that's 
 | [Citation Accuracy](/internal/citation-accuracy-dashboard) | Per-citation accuracy scores from claim-vs-source LLM checks |
 | [Citation Content](/internal/citation-content-dashboard) | Citation metadata: title/content availability, broken URLs |
 | [Hallucination Risk](/internal/hallucination-risk-dashboard) | Per-page and wiki-wide risk scores |
-| [Source Check Coverage](/internal/sourcing-coverage) | Coverage by record type and entity type |
+| [Source Check Coverage](/internal/sourcing-coverage-dashboard) | Coverage by record type and entity type |
 
 ## CLI playbook
 


### PR DESCRIPTION
## Summary
- Last non-compliant internal dashboard migrated to Pattern A (MDX wiki page shell)
- Allocates entity E2486 for `sourcing-coverage-dashboard`
- Removes `// Skip pages not yet migrated to Pattern A` exemption from the wiki-nav test

## Changes
- `apps/web/src/app/internal/sourcing-coverage/page.tsx` — replaced body with `redirect("/wiki/E2486")`
- `content/docs/internal/sourcing-coverage-dashboard.mdx` — new wiki page stub rendering `<SourcingCoverageContent />`
- `apps/web/src/components/mdx-components.tsx` — register `SourcingCoverageContent`
- `content/docs/internal/verification-sourcing-hub.mdx` — point link at `/internal/sourcing-coverage-dashboard`
- `apps/web/src/lib/__tests__/wiki-nav.test.ts` — remove sourcing-coverage exemption block (issue #3634 resolved by this PR)

The existing content component already lacked `<article>`, `<h1>`, and a `metadata` export, so no component changes were needed.

## Test plan
- [x] `pnpm build-data:content` succeeds (757 → 758 pages, new MDX picked up)
- [x] Full gate passes (44 checks including Next.js build)
- [x] `apps/web/src/lib/__tests__/wiki-nav.test.ts` passes (27 tests) — the migration exemption is gone and the test now asserts the directory is either in the sidebar or redirects
- [x] TypeScript clean across wiki-server and apps/web

After merge, `/internal/sourcing-coverage` continues to work (redirect), and `/internal/sourcing-coverage-dashboard` (via catch-all) also resolves.

Fixes QUA-359
