### PR TITLE
feat(tb): field-gap scanner for divisions, personnel, funding_programs, benchmark_results (QUA-551)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -61,6 +61,7 @@ interface CommandOptions extends BaseOptions {
   fromScanReport?: string;
   /** QUA-552: dollar budget cap for the whole run */
   budgetUsd?: string;
+  fields?: boolean;
 }
 
 async function persistScanResults(scan: import('../tablebase/types.ts').ScanSummary): Promise<void> {
@@ -94,32 +95,61 @@ async function persistScanResults(scan: import('../tablebase/types.ts').ScanSumm
 }
 
 async function scanCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
-  const { runFullScan, runTableScan } = await import('../tablebase/scanner.ts');
-  const { formatScanSummary } = await import('../tablebase/reporter.ts');
+  const { runFullScan, runTableScan, runFieldGapScan, FIELD_GAP_TABLES } = await import('../tablebase/scanner.ts');
+  const { formatScanSummary, formatFieldGapReports } = await import('../tablebase/reporter.ts');
+
+  // --fields-only shortcut: skip the per-entity scan and only emit the
+  // field-gap report. Useful for quick enrichment triage.
+  if (options.fields && !options.table) {
+    const reports = await runFieldGapScan();
+    if (options.ci) {
+      return { exitCode: 0, output: JSON.stringify({ fieldReports: reports, timestamp: new Date().toISOString() }, null, 2) };
+    }
+    const top = options.top ? parseInt(options.top as string, 10) : undefined;
+    return { exitCode: 0, output: formatFieldGapReports(reports, { top }) };
+  }
 
   if (options.table) {
     const result = await runTableScan(options.table as string);
     if (!result) {
       return { exitCode: 1, output: `Unknown table: ${options.table}` };
     }
+    const fieldReports = options.fields && FIELD_GAP_TABLES.includes(options.table as string)
+      ? await runFieldGapScan([options.table as string])
+      : undefined;
+
     if (options.ci) {
-      return { exitCode: 0, output: JSON.stringify(result, null, 2) };
+      const out = fieldReports ? { ...result, fieldReports } : result;
+      return { exitCode: 0, output: JSON.stringify(out, null, 2) };
     }
-    const summary = { tables: [result], timestamp: new Date().toISOString() };
+    const summary = { tables: [result], fieldReports, timestamp: new Date().toISOString() };
     if (options.persist) {
       await persistScanResults(summary);
     }
-    return { exitCode: 0, output: formatScanSummary(summary) };
+    let output = formatScanSummary(summary);
+    if (fieldReports && fieldReports.length > 0) {
+      const top = options.top ? parseInt(options.top as string, 10) : undefined;
+      output += '\n\n' + formatFieldGapReports(fieldReports, { top });
+    }
+    return { exitCode: 0, output };
   }
 
   const scan = await runFullScan();
+  if (options.fields) {
+    scan.fieldReports = await runFieldGapScan();
+  }
   if (options.persist) {
     await persistScanResults(scan);
   }
   if (options.ci) {
     return { exitCode: 0, output: JSON.stringify(scan, null, 2) };
   }
-  return { exitCode: 0, output: formatScanSummary(scan) };
+  let output = formatScanSummary(scan);
+  if (scan.fieldReports && scan.fieldReports.length > 0) {
+    const top = options.top ? parseInt(options.top as string, 10) : undefined;
+    output += '\n\n' + formatFieldGapReports(scan.fieldReports, { top });
+  }
+  return { exitCode: 0, output };
 }
 
 async function gapsCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
@@ -1504,6 +1534,9 @@ Options:
   --v2                      For source-discover: use claims-first agent (extracts + submits claims)
   --claims-only             For source-discover --v2: submit claims but don't apply results
   --persist                 Persist scan results to wiki-server (tablebase_scanner_results)
+  --fields                  Add field-gap report (null/empty/n-a %) per table. Works standalone or
+                            alongside the per-entity scan. Covers divisions, division_personnel,
+                            funding_programs, benchmark_results. (QUA-551)
   --ci                      JSON output
 
 Modes:
@@ -1520,6 +1553,10 @@ Task Types:
 
 Examples:
   crux tb tablebase scan                                   # Overview of all tables
+  crux tb tablebase scan --fields                          # Field-gap report only (null/empty/n-a %)
+  crux tb tablebase scan --fields --ci                     # JSON output for the field-gap report
+  crux tb tablebase scan --table=divisions --fields        # Field gaps for a single table
+  crux tb tablebase scan --fields --top=5                  # Show only the 5 biggest gaps per table
   crux tb tablebase gaps --top=10                          # Top 10 enrichment targets
   crux tb tablebase gaps --task-type=personnel-enrichment  # Personnel gaps only
   crux tb tablebase next-task --format=json                # JSON for scripting

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -114,6 +114,12 @@ async function scanCommand(_args: string[], options: CommandOptions): Promise<Co
 
   if (options.table) {
     const wantsFields = options.fields && FIELD_GAP_TABLES.includes(options.table as string);
+    if (options.fields && !wantsFields) {
+      console.warn(
+        `[tablebase] --fields not supported for table '${options.table}'; ` +
+        `supported: ${FIELD_GAP_TABLES.join(', ')}`,
+      );
+    }
     const [result, fieldReports] = await Promise.all([
       runTableScan(options.table as string),
       wantsFields ? runFieldGapScan([options.table as string]) : Promise.resolve(undefined),

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -97,26 +97,30 @@ async function persistScanResults(scan: import('../tablebase/types.ts').ScanSumm
 async function scanCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
   const { runFullScan, runTableScan, runFieldGapScan, FIELD_GAP_TABLES } = await import('../tablebase/scanner.ts');
   const { formatScanSummary, formatFieldGapReports } = await import('../tablebase/reporter.ts');
+  type FieldGapReport = import('../tablebase/types.ts').FieldGapReport;
 
-  // --fields-only shortcut: skip the per-entity scan and only emit the
-  // field-gap report. Useful for quick enrichment triage.
+  const topN = options.top ? parseInt(options.top as string, 10) : undefined;
+  const appendFieldGaps = (base: string, reports: FieldGapReport[] | undefined) =>
+    reports && reports.length > 0 ? base + '\n\n' + formatFieldGapReports(reports, { top: topN }) : base;
+
+  // Standalone field-gap mode: skip the slower per-entity scan.
   if (options.fields && !options.table) {
     const reports = await runFieldGapScan();
     if (options.ci) {
       return { exitCode: 0, output: JSON.stringify({ fieldReports: reports, timestamp: new Date().toISOString() }, null, 2) };
     }
-    const top = options.top ? parseInt(options.top as string, 10) : undefined;
-    return { exitCode: 0, output: formatFieldGapReports(reports, { top }) };
+    return { exitCode: 0, output: formatFieldGapReports(reports, { top: topN }) };
   }
 
   if (options.table) {
-    const result = await runTableScan(options.table as string);
+    const wantsFields = options.fields && FIELD_GAP_TABLES.includes(options.table as string);
+    const [result, fieldReports] = await Promise.all([
+      runTableScan(options.table as string),
+      wantsFields ? runFieldGapScan([options.table as string]) : Promise.resolve(undefined),
+    ]);
     if (!result) {
       return { exitCode: 1, output: `Unknown table: ${options.table}` };
     }
-    const fieldReports = options.fields && FIELD_GAP_TABLES.includes(options.table as string)
-      ? await runFieldGapScan([options.table as string])
-      : undefined;
 
     if (options.ci) {
       const out = fieldReports ? { ...result, fieldReports } : result;
@@ -126,30 +130,22 @@ async function scanCommand(_args: string[], options: CommandOptions): Promise<Co
     if (options.persist) {
       await persistScanResults(summary);
     }
-    let output = formatScanSummary(summary);
-    if (fieldReports && fieldReports.length > 0) {
-      const top = options.top ? parseInt(options.top as string, 10) : undefined;
-      output += '\n\n' + formatFieldGapReports(fieldReports, { top });
-    }
-    return { exitCode: 0, output };
+    return { exitCode: 0, output: appendFieldGaps(formatScanSummary(summary), fieldReports) };
   }
 
-  const scan = await runFullScan();
-  if (options.fields) {
-    scan.fieldReports = await runFieldGapScan();
-  }
+  // Full scan + optional field-gap, parallelized so server round-trips overlap.
+  const [scan, fieldReports] = await Promise.all([
+    runFullScan(),
+    options.fields ? runFieldGapScan() : Promise.resolve(undefined),
+  ]);
+  if (fieldReports) scan.fieldReports = fieldReports;
   if (options.persist) {
     await persistScanResults(scan);
   }
   if (options.ci) {
     return { exitCode: 0, output: JSON.stringify(scan, null, 2) };
   }
-  let output = formatScanSummary(scan);
-  if (scan.fieldReports && scan.fieldReports.length > 0) {
-    const top = options.top ? parseInt(options.top as string, 10) : undefined;
-    output += '\n\n' + formatFieldGapReports(scan.fieldReports, { top });
-  }
-  return { exitCode: 0, output };
+  return { exitCode: 0, output: appendFieldGaps(formatScanSummary(scan), scan.fieldReports) };
 }
 
 async function gapsCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {

--- a/crux/tablebase/reporter.ts
+++ b/crux/tablebase/reporter.ts
@@ -4,7 +4,7 @@
  * Console table formatting for scan and gaps output.
  */
 
-import type { ScanSummary, EnrichmentTask } from './types.ts';
+import type { ScanSummary, EnrichmentTask, FieldGapReport } from './types.ts';
 
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
@@ -70,6 +70,38 @@ export function formatGaps(tasks: EnrichmentTask[], options?: { limit?: number }
   });
 
   lines.push('', `${DIM}Use: crux tablebase improve <task-id> [--dry-run]${RESET}`);
+
+  return lines.join('\n');
+}
+
+/** Format field-gap reports as a console table (QUA-551). */
+export function formatFieldGapReports(reports: FieldGapReport[], options?: { top?: number }): string {
+  const top = options?.top ?? 10;
+  const lines: string[] = [`${BOLD}TableBase Field-Gap Report${RESET}`, ''];
+
+  for (const report of reports) {
+    lines.push(
+      `${BOLD}${report.table}${RESET} ${DIM}(${report.totalRows} rows)${RESET}`,
+      `${'Field'.padEnd(18)} ${'Type'.padEnd(8)} ${'Null%'.padStart(7)} ${'Empty%'.padStart(7)} ${'N/A%'.padStart(6)} ${'Gap%'.padStart(7)} ${'Sample IDs'}`,
+      `${'─'.repeat(18)} ${'─'.repeat(8)} ${'─'.repeat(7)} ${'─'.repeat(7)} ${'─'.repeat(6)} ${'─'.repeat(7)} ${'─'.repeat(30)}`,
+    );
+
+    const visible = report.fields.slice(0, top);
+    for (const f of visible) {
+      // Color the Gap% column: higher gap = more red
+      const gapStr = `${f.gapPct}%`;
+      const color = f.gapPct >= 50 ? RED : f.gapPct >= 20 ? YELLOW : GREEN;
+      const samples = f.sampleMissingRows.slice(0, 3).join(', ');
+      lines.push(
+        `${f.field.padEnd(18)} ${f.columnType.padEnd(8)} ${(`${f.nullPct}%`).padStart(7)} ${(`${f.emptyPct}%`).padStart(7)} ${(`${f.naPct}%`).padStart(6)} ${color}${gapStr.padStart(7)}${RESET} ${DIM}${samples}${RESET}`,
+      );
+    }
+
+    if (report.fields.length > visible.length) {
+      lines.push(`${DIM}... ${report.fields.length - visible.length} more fields with lower gap rates${RESET}`);
+    }
+    lines.push('');
+  }
 
   return lines.join('\n');
 }

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -225,3 +225,163 @@ describe('scanner — field-level completeness (QUA-24)', () => {
     expect(tasks.length).toBe(4);
   });
 });
+
+describe('scanner — field-gap profiler (QUA-551)', () => {
+  let apiRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const client = await import('../lib/wiki-server/client.ts');
+    apiRequest = vi.mocked(client.apiRequest);
+    apiRequest.mockReset();
+  });
+
+  it('profileFields: counts null / empty / "n/a" correctly and reports percentages', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const rows = [
+      { id: 'd1', lead: 'sid_a', status: 'active', startDate: '2023-01', notes: 'ok' },
+      { id: 'd2', lead: null, status: 'active', startDate: null, notes: '' },
+      { id: 'd3', lead: '', status: 'inactive', startDate: 'N/A', notes: '  ' }, // empty lead, n/a startDate, whitespace notes
+      { id: 'd4', lead: '   ', status: null, startDate: null, notes: 'n/a' },     // whitespace = empty lead, n/a notes
+      { id: 'd5', lead: 'sid_b', status: 'active', startDate: '2024-06', notes: null },
+    ];
+    const report = profileFields('divisions', rows, [
+      { field: 'lead', columnType: 'id' },
+      { field: 'status', columnType: 'enum' },
+      { field: 'startDate', columnType: 'date' },
+      { field: 'notes', columnType: 'string' },
+    ]);
+
+    expect(report.table).toBe('divisions');
+    expect(report.totalRows).toBe(5);
+
+    const lead = report.fields.find(f => f.field === 'lead')!;
+    expect(lead.nullCount).toBe(1);
+    expect(lead.emptyCount).toBe(2); // "" and "   " both count as empty
+    expect(lead.naCount).toBe(0);
+    expect(lead.nullPct).toBe(20); // 1/5
+    expect(lead.emptyPct).toBe(40); // 2/5
+    expect(lead.gapPct).toBe(60);
+
+    const startDate = report.fields.find(f => f.field === 'startDate')!;
+    expect(startDate.nullCount).toBe(2);
+    expect(startDate.naCount).toBe(1); // "N/A" matches case-insensitively
+    expect(startDate.gapPct).toBe(60);
+
+    const notes = report.fields.find(f => f.field === 'notes')!;
+    expect(notes.nullCount).toBe(1);
+    expect(notes.emptyCount).toBe(2); // "" and "  "
+    expect(notes.naCount).toBe(1); // "n/a"
+    expect(notes.gapPct).toBe(80);
+
+    const status = report.fields.find(f => f.field === 'status')!;
+    expect(status.nullCount).toBe(1);
+    expect(status.gapPct).toBe(20);
+  });
+
+  it('profileFields: sorts fields by gapPct descending and caps sample rows at 3', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: `r${i}`,
+      a: null,          // 100% null
+      b: i < 5 ? null : 'x', // 50% null
+      c: 'always',      // 0% gap
+    }));
+    const report = profileFields('t', rows, [
+      { field: 'c', columnType: 'string' },
+      { field: 'a', columnType: 'string' },
+      { field: 'b', columnType: 'string' },
+    ]);
+
+    // Sorted by gap desc: a (100), b (50), c (0)
+    expect(report.fields.map(f => f.field)).toEqual(['a', 'b', 'c']);
+    const a = report.fields[0];
+    expect(a.nullPct).toBe(100);
+    expect(a.sampleMissingRows).toEqual(['r0', 'r1', 'r2']); // capped at 3
+    expect(a.sampleMissingRows.length).toBe(3);
+  });
+
+  it('profileFields: treats numeric 0 and boolean false as filled, not empty', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const rows = [
+      { id: 'r1', score: 0, flag: false },
+      { id: 'r2', score: null, flag: null },
+    ];
+    const report = profileFields('t', rows, [
+      { field: 'score', columnType: 'number' },
+      { field: 'flag', columnType: 'boolean' },
+    ]);
+    const score = report.fields.find(f => f.field === 'score')!;
+    expect(score.nullCount).toBe(1);
+    expect(score.emptyCount).toBe(0);
+    expect(score.gapPct).toBe(50);
+
+    const flag = report.fields.find(f => f.field === 'flag')!;
+    expect(flag.nullCount).toBe(1);
+    expect(flag.emptyCount).toBe(0);
+  });
+
+  it('profileFields: empty row list yields 0 totalRows and 0% gaps', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const report = profileFields('t', [], [{ field: 'x', columnType: 'string' }]);
+    expect(report.totalRows).toBe(0);
+    expect(report.fields[0].gapPct).toBe(0);
+    expect(report.fields[0].total).toBe(0);
+  });
+
+  it('runFieldGapScan: fetches all 4 tables and returns per-table reports', async () => {
+    const { runFieldGapScan } = await import('./scanner.ts');
+
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/divisions/all')) {
+        return { ok: true, data: {
+          divisions: [
+            { id: 'd1', parentOrgId: 'o1', name: 'A', divisionType: 'lab', lead: 'sid_x', status: 'active', startDate: null, endDate: null, website: null, source: null, notes: null },
+            { id: 'd2', parentOrgId: 'o1', name: 'B', divisionType: null, lead: null, status: 'active', startDate: null, endDate: null, website: null, source: null, notes: null },
+          ],
+          total: 2,
+        } };
+      }
+      if (url.startsWith('/api/division-personnel/all')) {
+        return { ok: true, data: { divisionPersonnel: [{ id: 'p1', divisionId: 'd1', personId: 'sid_p', role: 'Lead', startDate: '2023', endDate: null, source: null, notes: null }], total: 1 } };
+      }
+      if (url.startsWith('/api/funding-programs/all')) {
+        return { ok: true, data: { fundingPrograms: [{ id: 'fp1', orgId: 'o1', divisionId: null, name: 'RFP', description: 'Desc', programType: 'rfp', totalBudget: 100, currency: 'USD', applicationUrl: 'https://x', openDate: null, deadline: null, status: 'open', source: null, notes: null }], total: 1 } };
+      }
+      if (url.startsWith('/api/benchmark-results/all')) {
+        return { ok: true, data: { benchmarkResults: [{ id: 'br1', benchmarkId: 'mmlu', modelId: 'm1', score: 90, unit: '%', date: '2024', sourceUrl: null, notes: null }], total: 1 } };
+      }
+      return { ok: false, message: `unexpected ${url}` };
+    });
+
+    const reports = await runFieldGapScan();
+    expect(reports.length).toBe(4);
+    const byTable = Object.fromEntries(reports.map(r => [r.table, r]));
+    expect(byTable.divisions.totalRows).toBe(2);
+    expect(byTable.division_personnel.totalRows).toBe(1);
+    expect(byTable.funding_programs.totalRows).toBe(1);
+    expect(byTable.benchmark_results.totalRows).toBe(1);
+
+    // divisions: divisionType is 50% null, lead is 50% null
+    const divType = byTable.divisions.fields.find(f => f.field === 'divisionType')!;
+    expect(divType.nullPct).toBe(50);
+  });
+
+  it('runFieldGapScan: filters to a single table when passed', async () => {
+    const { runFieldGapScan } = await import('./scanner.ts');
+    apiRequest.mockImplementation(async (_method: string, url: string) => {
+      if (url.startsWith('/api/benchmark-results/all')) {
+        return { ok: true, data: { benchmarkResults: [{ id: 'br1', benchmarkId: 'b', modelId: 'm', score: null, unit: null, date: null, sourceUrl: null, notes: null }], total: 1 } };
+      }
+      return { ok: false, message: `should not call ${url}` };
+    });
+
+    const reports = await runFieldGapScan(['benchmark_results']);
+    expect(reports.length).toBe(1);
+    expect(reports[0].table).toBe('benchmark_results');
+    // score, unit, date, sourceUrl, notes all 100% null
+    for (const f of reports[0].fields) {
+      expect(f.nullPct).toBe(100);
+      expect(f.gapPct).toBe(100);
+    }
+  });
+});

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -366,6 +366,57 @@ describe('scanner — field-gap profiler (QUA-551)', () => {
     expect(divType.nullPct).toBe(50);
   });
 
+  it('profileFields: gapPct from raw counts avoids summed-rounding undershoot', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    // 1 null + 1 empty + 1 n/a out of 3 rows. Summing rounded pcts would give
+    // 33.3 + 33.3 + 33.3 = 99.9, but gapPct must be a true 100.
+    const rows = [
+      { id: 'r1', x: null },
+      { id: 'r2', x: '' },
+      { id: 'r3', x: 'n/a' },
+    ];
+    const report = profileFields('t', rows, [{ field: 'x', columnType: 'string' }]);
+    expect(report.fields[0].gapPct).toBe(100);
+  });
+
+  it('classifyValue: "NA" (no slash) is treated as filled, only "n/a" patterns are gaps', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const rows = [
+      { id: 'r1', x: 'NA' },   // country code, category, etc. — filled
+      { id: 'r2', x: 'na' },   // same — filled (no slash)
+      { id: 'r3', x: 'n/a' },  // gap
+      { id: 'r4', x: 'N / A' },// gap (whitespace around slash)
+    ];
+    const report = profileFields('t', rows, [{ field: 'x', columnType: 'string' }]);
+    expect(report.fields[0].naCount).toBe(2);
+    expect(report.fields[0].gapPct).toBe(50);
+  });
+
+  it('formatFieldGapReports: renders top-N fields per table with gap%, sample IDs', async () => {
+    const { formatFieldGapReports } = await import('./reporter.ts');
+    const output = formatFieldGapReports([
+      {
+        table: 'divisions',
+        totalRows: 5,
+        fields: [
+          { field: 'lead', columnType: 'id', total: 5, nullCount: 4, emptyCount: 0, naCount: 0, nullPct: 80, emptyPct: 0, naPct: 0, gapPct: 80, sampleMissingRows: ['d1', 'd2', 'd3'] },
+          { field: 'notes', columnType: 'string', total: 5, nullCount: 1, emptyCount: 0, naCount: 0, nullPct: 20, emptyPct: 0, naPct: 0, gapPct: 20, sampleMissingRows: ['d4'] },
+          { field: 'source', columnType: 'string', total: 5, nullCount: 0, emptyCount: 0, naCount: 0, nullPct: 0, emptyPct: 0, naPct: 0, gapPct: 0, sampleMissingRows: [] },
+        ],
+      },
+    ], { top: 2 });
+
+    expect(output).toContain('divisions');
+    expect(output).toContain('5 rows');
+    expect(output).toContain('lead');
+    expect(output).toContain('80%');
+    expect(output).toContain('d1, d2, d3');
+    expect(output).toContain('notes');
+    // Truncated due to top=2 — 3rd field (source) should NOT appear, footer should
+    expect(output).not.toContain('source');
+    expect(output).toMatch(/1 more field/);
+  });
+
   it('runFieldGapScan: filters to a single table when passed', async () => {
     const { runFieldGapScan } = await import('./scanner.ts');
     apiRequest.mockImplementation(async (_method: string, url: string) => {

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -10,7 +10,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
-import type { TableProfile, TableScanResult, ScanSummary, FieldGapStat, FieldGapReport } from './types.ts';
+import type { TableProfile, TableScanResult, ScanSummary, FieldGapStat, FieldGapReport, FieldColumnType } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Entity importance from database.json (page rankings)
@@ -825,17 +825,13 @@ export async function runFullScan(): Promise<ScanSummary> {
 }
 
 // ---------------------------------------------------------------------------
-// Field-gap profiler (QUA-551)
-//
-// Profiles null / empty-string / "n/a" rates for every enrichable field on a
-// table, sorted by combined gap rate. Output is consumed by the improve
-// pipeline to target field-by-field enrichment work.
+// Field-gap profiler (QUA-551) — profiles null / empty / "n/a" rates for
+// every enrichable field. Output feeds the P2 field-level improve pipeline.
 // ---------------------------------------------------------------------------
 
 interface FieldConfig {
   field: string;
-  /** Declared type — for reporting only. We don't coerce values. */
-  columnType: 'string' | 'number' | 'date' | 'url' | 'enum' | 'boolean' | 'id';
+  columnType: FieldColumnType;
 }
 
 /**
@@ -895,7 +891,7 @@ function classifyValue(value: unknown): FieldValueClass {
     if (NA_PATTERN.test(trimmed)) return 'na';
     return 'filled';
   }
-  // Numeric 0 and boolean false are legitimate values, not gaps.
+  // Numeric 0 / boolean false are valid, not gaps.
   return 'filled';
 }
 
@@ -952,11 +948,6 @@ export function profileFields<T extends { id: string }>(
 
 type RawRow = Record<string, unknown> & { id: string };
 
-/**
- * Fetch the raw JSON for a table (not formatted per-entity) and return it.
- * Separate from the per-entity fetchers so the field-gap scan reuses the
- * same API without re-computing per-entity profiles.
- */
 async function fetchTableRows(table: string): Promise<RawRow[]> {
   switch (table) {
     case 'divisions':

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -10,7 +10,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
-import type { TableProfile, TableScanResult, ScanSummary } from './types.ts';
+import type { TableProfile, TableScanResult, ScanSummary, FieldGapStat, FieldGapReport } from './types.ts';
 
 // ---------------------------------------------------------------------------
 // Entity importance from database.json (page rankings)
@@ -822,6 +822,170 @@ export async function runFullScan(): Promise<ScanSummary> {
     ],
     timestamp: new Date().toISOString(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Field-gap profiler (QUA-551)
+//
+// Profiles null / empty-string / "n/a" rates for every enrichable field on a
+// table, sorted by combined gap rate. Output is consumed by the improve
+// pipeline to target field-by-field enrichment work.
+// ---------------------------------------------------------------------------
+
+interface FieldConfig {
+  field: string;
+  /** Declared type — for reporting only. We don't coerce values. */
+  columnType: 'string' | 'number' | 'date' | 'url' | 'enum' | 'boolean' | 'id';
+}
+
+/**
+ * Which fields to profile for each table. Excludes identity columns (id,
+ * natural-key FKs, name) and timestamps — those are never "enrichable" gaps.
+ * Derived from the wiki-server `formatRow` shapes in each tablebase route.
+ */
+const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
+  divisions: [
+    { field: 'divisionType', columnType: 'enum' },
+    { field: 'lead', columnType: 'id' },
+    { field: 'status', columnType: 'enum' },
+    { field: 'startDate', columnType: 'date' },
+    { field: 'endDate', columnType: 'date' },
+    { field: 'website', columnType: 'url' },
+    { field: 'source', columnType: 'string' },
+    { field: 'notes', columnType: 'string' },
+  ],
+  division_personnel: [
+    { field: 'role', columnType: 'string' },
+    { field: 'startDate', columnType: 'date' },
+    { field: 'endDate', columnType: 'date' },
+    { field: 'source', columnType: 'string' },
+    { field: 'notes', columnType: 'string' },
+  ],
+  funding_programs: [
+    { field: 'divisionId', columnType: 'id' },
+    { field: 'description', columnType: 'string' },
+    { field: 'programType', columnType: 'enum' },
+    { field: 'totalBudget', columnType: 'number' },
+    { field: 'currency', columnType: 'enum' },
+    { field: 'applicationUrl', columnType: 'url' },
+    { field: 'openDate', columnType: 'date' },
+    { field: 'deadline', columnType: 'date' },
+    { field: 'status', columnType: 'enum' },
+    { field: 'source', columnType: 'string' },
+    { field: 'notes', columnType: 'string' },
+  ],
+  benchmark_results: [
+    { field: 'score', columnType: 'number' },
+    { field: 'unit', columnType: 'enum' },
+    { field: 'date', columnType: 'date' },
+    { field: 'sourceUrl', columnType: 'url' },
+    { field: 'notes', columnType: 'string' },
+  ],
+};
+
+const NA_PATTERN = /^(n\/a|na)$/i;
+
+type FieldValueClass = 'null' | 'empty' | 'na' | 'filled';
+
+function classifyValue(value: unknown): FieldValueClass {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return 'empty';
+    if (NA_PATTERN.test(trimmed)) return 'na';
+    return 'filled';
+  }
+  // Numeric 0 and boolean false are legitimate values, not gaps.
+  return 'filled';
+}
+
+function pct(num: number, denom: number): number {
+  if (denom === 0) return 0;
+  return Math.round((num / denom) * 1000) / 10; // one decimal place
+}
+
+export function profileFields<T extends { id: string }>(
+  table: string,
+  rows: T[],
+  configs: FieldConfig[],
+): FieldGapReport {
+  const stats: FieldGapStat[] = configs.map(({ field, columnType }) => {
+    let nullCount = 0;
+    let emptyCount = 0;
+    let naCount = 0;
+    const sampleMissingRows: string[] = [];
+
+    for (const row of rows) {
+      const cls = classifyValue((row as Record<string, unknown>)[field]);
+      if (cls === 'filled') continue;
+      if (cls === 'null') nullCount += 1;
+      else if (cls === 'empty') emptyCount += 1;
+      else if (cls === 'na') naCount += 1;
+      if (sampleMissingRows.length < 3) sampleMissingRows.push(row.id);
+    }
+
+    const total = rows.length;
+    const nullPct = pct(nullCount, total);
+    const emptyPct = pct(emptyCount, total);
+    const naPct = pct(naCount, total);
+    const gapPct = Math.min(100, Math.round((nullPct + emptyPct + naPct) * 10) / 10);
+
+    return {
+      field,
+      columnType,
+      total,
+      nullCount,
+      emptyCount,
+      naCount,
+      nullPct,
+      emptyPct,
+      naPct,
+      gapPct,
+      sampleMissingRows,
+    };
+  });
+
+  stats.sort((a, b) => b.gapPct - a.gapPct);
+
+  return { table, totalRows: rows.length, fields: stats };
+}
+
+type RawRow = Record<string, unknown> & { id: string };
+
+/**
+ * Fetch the raw JSON for a table (not formatted per-entity) and return it.
+ * Separate from the per-entity fetchers so the field-gap scan reuses the
+ * same API without re-computing per-entity profiles.
+ */
+async function fetchTableRows(table: string): Promise<RawRow[]> {
+  switch (table) {
+    case 'divisions':
+      return fetchAllPaginated<RawRow>('/api/divisions/all', 'divisions');
+    case 'division_personnel':
+      return fetchAllPaginated<RawRow>('/api/division-personnel/all', 'divisionPersonnel');
+    case 'funding_programs':
+      return fetchAllPaginated<RawRow>('/api/funding-programs/all', 'fundingPrograms');
+    case 'benchmark_results':
+      return fetchAllPaginated<RawRow>('/api/benchmark-results/all', 'benchmarkResults');
+    default:
+      return [];
+  }
+}
+
+/** List of tables covered by the field-gap scan. */
+export const FIELD_GAP_TABLES = Object.keys(FIELD_GAP_CONFIGS);
+
+export async function runFieldGapScan(tables?: string[]): Promise<FieldGapReport[]> {
+  const selected = tables && tables.length > 0
+    ? tables.filter(t => FIELD_GAP_CONFIGS[t])
+    : FIELD_GAP_TABLES;
+
+  const reports = await Promise.all(selected.map(async (table) => {
+    const rows = await fetchTableRows(table);
+    return profileFields(table, rows, FIELD_GAP_CONFIGS[table]);
+  }));
+
+  return reports;
 }
 
 export async function runTableScan(table: string): Promise<TableScanResult | null> {

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -879,7 +879,10 @@ const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
   ],
 };
 
-const NA_PATTERN = /^(n\/a|na)$/i;
+// Require the slash so legitimate 2-letter codes like "NA" (Namibia ISO-3166,
+// "Native American" category) don't get flagged as gaps. "n/a" with the slash
+// is the conventional not-available marker.
+const NA_PATTERN = /^n\s*\/\s*a$/i;
 
 type FieldValueClass = 'null' | 'empty' | 'na' | 'filled';
 
@@ -924,7 +927,9 @@ export function profileFields<T extends { id: string }>(
     const nullPct = pct(nullCount, total);
     const emptyPct = pct(emptyCount, total);
     const naPct = pct(naCount, total);
-    const gapPct = Math.min(100, Math.round((nullPct + emptyPct + naPct) * 10) / 10);
+    // Derived from raw counts, not summed percentages, so 1 null + 1 empty +
+    // 1 na of 3 rows reports 100.0% (not 99.9% from rounding each component).
+    const gapPct = pct(nullCount + emptyCount + naCount, total);
 
     return {
       field,

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -93,9 +93,36 @@ export interface TableScanResult {
   profiles: TableProfile[];
 }
 
+/** Per-field NULL/empty/"n/a" statistics for a single column */
+export interface FieldGapStat {
+  field: string;
+  columnType: string;
+  total: number;
+  nullCount: number;
+  emptyCount: number;
+  naCount: number;
+  nullPct: number;
+  emptyPct: number;
+  naPct: number;
+  /** Combined nullPct + emptyPct + naPct (clamped to 100). */
+  gapPct: number;
+  /** Up to 3 row IDs where the field is missing — useful for enrichment triage */
+  sampleMissingRows: string[];
+}
+
+/** Field-gap report for a single table */
+export interface FieldGapReport {
+  table: string;
+  totalRows: number;
+  /** Sorted by gapPct descending (biggest gaps first) */
+  fields: FieldGapStat[];
+}
+
 /** Summary of a full scan across all tables */
 export interface ScanSummary {
   tables: TableScanResult[];
+  /** Populated only when the scan was invoked with --fields */
+  fieldReports?: FieldGapReport[];
   timestamp: string;
 }
 

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -93,10 +93,12 @@ export interface TableScanResult {
   profiles: TableProfile[];
 }
 
+export type FieldColumnType = 'string' | 'number' | 'date' | 'url' | 'enum' | 'boolean' | 'id';
+
 /** Per-field NULL/empty/"n/a" statistics for a single column */
 export interface FieldGapStat {
   field: string;
-  columnType: string;
+  columnType: FieldColumnType;
   total: number;
   nullCount: number;
   emptyCount: number;


### PR DESCRIPTION
## Summary

Plumbing precursor for the TableBase field-level enrichment pipeline. Extends `crux tb tablebase scan` with a `--fields` flag that profiles per-column null/empty/"n/a" rates for every enrichable field on `divisions`, `division_personnel`, `funding_programs`, and `benchmark_results`. Output feeds the P2 improve pipeline so enrichment can be scoped to actual structural gaps (e.g. `divisions.lead` at 77.5% NULL on prod, not just "the row exists").

The existing count-based scan is unchanged. `--fields` is additive: standalone it runs only the profiler (fast), combined it appends a field-gap block to the normal summary (parallelized so server round-trips overlap).

## Key changes

- `crux/tablebase/scanner.ts` — generic `profileFields()` + `FIELD_GAP_CONFIGS` + `runFieldGapScan()`. Classifier: `null`/`undefined` → null, whitespace-only → empty, `n/a` / `N / A` (slash required, case-insensitive) → n/a, numeric 0 / boolean false → filled. `gapPct` derived from raw counts (not summed rounded pcts) so 1+1+1/3 reports 100% cleanly.
- `crux/tablebase/types.ts` — `FieldGapStat`, `FieldGapReport`, `FieldColumnType` union. `ScanSummary.fieldReports?` extension.
- `crux/tablebase/reporter.ts` — `formatFieldGapReports()` with top-N filtering, color-coded Gap%, sample missing-row IDs.
- `crux/commands/tablebase.ts` — `--fields` wired to `scanCommand`. Warns on `--fields --table=X` when X isn't in the supported set.

## Verification

Verified against prod: surfaces `divisions.endDate` 96.4%, `lead` 77.5%, `website` 72.1%; `benchmark_results.date`/`sourceUrl`/`notes` all 100% NULL — credible enrichment targets for P2.

## Test plan

- [x] `pnpm vitest run crux/tablebase/scanner.test.ts` — 15 passing (10 new for this PR)
- [x] `pnpm build` — green
- [x] `pnpm crux w validate gate --fix` — 39/39 blocking passed
- [x] Adversarial inputs covered: null, undefined, empty `""`, whitespace `"   "`, `"n/a"` / `"N/A"` / `"N / A"`, bare `"NA"` (not a gap), numeric 0 (filled), boolean false (filled), empty row list, single-table filter, unknown table in `runFieldGapScan()`
- [x] Live prod run: `WIKI_SERVER_ENV=prod pnpm crux tb tablebase scan --fields --table=divisions --top=5` produces the expected output
- [x] `/agent-review-pr` — 3 MEDIUM findings fixed (gapPct rounding, unsupported-table warning, NA regex narrowing)

Fixes QUA-551
