### PR TITLE
refactor(crux): migrate GITHUB_TOKEN callers to shared MISSING_TOKEN_SUMMARY constant (QUA-511)

### DIFF
--- a/crux/authoring/orchestrator/tools/github-lookup.ts
+++ b/crux/authoring/orchestrator/tools/github-lookup.ts
@@ -7,6 +7,7 @@
  */
 
 import { createGitHubProvider } from '../../../lib/search/providers/github-search.ts';
+import { MISSING_TOKEN_SUMMARY } from '../../../lib/github.ts';
 import type { ToolRegistration } from './types.ts';
 
 export const tool: ToolRegistration = {
@@ -39,7 +40,7 @@ export const tool: ToolRegistration = {
 
     const provider = createGitHubProvider();
     if (!provider.isAvailable()) {
-      return JSON.stringify({ error: 'GITHUB_TOKEN not set — cannot access GitHub API' });
+      return JSON.stringify({ error: `${MISSING_TOKEN_SUMMARY} — cannot access GitHub API` });
     }
 
     try {

--- a/crux/health/checks/ci-main-health.ts
+++ b/crux/health/checks/ci-main-health.ts
@@ -18,7 +18,14 @@
  */
 
 import type { CheckResult } from '../health-check.ts';
-import { githubApi, REPO } from '../../lib/github.ts';
+import {
+  githubApi,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_HELP_MESSAGE,
+  MISSING_TOKEN_SUMMARY,
+  REPO,
+} from '../../lib/github.ts';
 
 interface WorkflowRun {
   id: number;
@@ -52,13 +59,18 @@ export async function checkCiMainHealth(): Promise<CheckResult> {
   const name = 'CI main branch';
   const detail: string[] = [];
 
-  if (!process.env.GITHUB_TOKEN) {
-    return {
-      name,
-      ok: false,
-      summary: 'GITHUB_TOKEN not set',
-      detail: ['Set GITHUB_TOKEN to enable CI main branch health checks'],
-    };
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      return {
+        name,
+        ok: false,
+        summary: MISSING_TOKEN_SUMMARY,
+        detail: [MISSING_TOKEN_HELP_MESSAGE],
+      };
+    }
+    throw e;
   }
 
   const now = Date.now();

--- a/crux/health/checks/pr-quality.ts
+++ b/crux/health/checks/pr-quality.ts
@@ -11,7 +11,14 @@
  */
 
 import type { CheckResult } from '../health-check.ts';
-import { githubApi, REPO } from '../../lib/github.ts';
+import {
+  githubApi,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_HELP_MESSAGE,
+  MISSING_TOKEN_SUMMARY,
+  REPO,
+} from '../../lib/github.ts';
 import { LABELS, ANY_WORKING_LABELS } from '../../lib/labels.ts';
 
 interface PullRequest {
@@ -48,13 +55,18 @@ export async function checkPrQuality(options?: {
   const failures: string[] = [];
   const cleanupStaleLabels = options?.cleanupStaleLabels ?? false;
 
-  if (!process.env.GITHUB_TOKEN) {
-    return {
-      name,
-      ok: false,
-      summary: 'GITHUB_TOKEN not set',
-      detail: ['Set GITHUB_TOKEN to enable PR/issue quality checks'],
-    };
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      return {
+        name,
+        ok: false,
+        summary: MISSING_TOKEN_SUMMARY,
+        detail: [MISSING_TOKEN_HELP_MESSAGE],
+      };
+    }
+    throw e;
   }
 
   // ── Pull request quality checks ──────────────────────────────────────

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -35,7 +35,14 @@
  */
 
 import { getColors } from '../lib/output.ts';
-import { githubApi, REPO } from '../lib/github.ts';
+import {
+  githubApi,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_HELP_MESSAGE,
+  MISSING_TOKEN_SUMMARY,
+  REPO,
+} from '../lib/github.ts';
 import { getServerUrl, getApiKey } from '../lib/wiki-server/client.ts';
 import { checkJobQueue } from './checks/job-queue.ts';
 import { checkPrQuality } from './checks/pr-quality.ts';
@@ -490,8 +497,13 @@ export async function checkActions(): Promise<CheckResult> {
   const detail: string[] = [];
   const failures: string[] = [];
 
-  if (!process.env.GITHUB_TOKEN) {
-    return { name, ok: false, summary: 'GITHUB_TOKEN not set', detail: ['Set GITHUB_TOKEN to enable workflow health checks'] };
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      return { name, ok: false, summary: MISSING_TOKEN_SUMMARY, detail: [MISSING_TOKEN_HELP_MESSAGE] };
+    }
+    throw e;
   }
 
   const workflowFiles = [
@@ -584,13 +596,18 @@ export async function checkActions(): Promise<CheckResult> {
 export async function checkWikiServerDeploy(): Promise<CheckResult> {
   const name = 'Wiki-server deploy';
 
-  if (!process.env.GITHUB_TOKEN) {
-    return {
-      name,
-      ok: false,
-      summary: 'GITHUB_TOKEN not set',
-      detail: ['Set GITHUB_TOKEN to enable deploy health checks'],
-    };
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      return {
+        name,
+        ok: false,
+        summary: MISSING_TOKEN_SUMMARY,
+        detail: [MISSING_TOKEN_HELP_MESSAGE],
+      };
+    }
+    throw e;
   }
 
   const health = await checkDeployHealth();

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -19,6 +19,9 @@ import {
   closeIssue,
   createIssue,
   ensureLabel,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_SUMMARY,
 } from '../lib/github.ts';
 import type { GitHubIssue } from '../lib/github.ts';
 
@@ -199,9 +202,14 @@ export async function manageWellnessIssue(
   report: WellnessReport,
   options: { runUrl?: string } = {},
 ): Promise<{ action: 'created' | 'updated' | 'closed' | 'none'; issueNumber?: number }> {
-  if (!process.env.GITHUB_TOKEN) {
-    console.warn('GITHUB_TOKEN not set — skipping wellness issue management');
-    return { action: 'none' };
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      console.warn(`${MISSING_TOKEN_SUMMARY} — skipping wellness issue management`);
+      return { action: 'none' };
+    }
+    throw e;
   }
 
   const existingIssue = await findOpenWellnessIssue();

--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -4,6 +4,7 @@ import {
   isMissingTokenError,
   MissingTokenError,
   MISSING_TOKEN_HELP_MESSAGE,
+  MISSING_TOKEN_SUMMARY,
 } from './github.ts';
 
 // Use `vi.stubEnv()` instead of mutating `process.env` directly. This is
@@ -72,6 +73,16 @@ describe('MissingTokenError', () => {
   it('uses the shared MISSING_TOKEN_HELP_MESSAGE', () => {
     const err = new MissingTokenError();
     expect(err.message).toBe(MISSING_TOKEN_HELP_MESSAGE);
+  });
+
+  it('MISSING_TOKEN_HELP_MESSAGE is derived from MISSING_TOKEN_SUMMARY so they cannot drift', () => {
+    // Regression for QUA-511: the ~8 display call sites (health-check summaries,
+    // pr-patrol error logs, etc.) read MISSING_TOKEN_SUMMARY for short labels
+    // and MISSING_TOKEN_HELP_MESSAGE for full help text. If the full message
+    // ever stops starting with the summary, users see inconsistent labeling
+    // between summary and detail views.
+    expect(MISSING_TOKEN_HELP_MESSAGE.startsWith(MISSING_TOKEN_SUMMARY)).toBe(true);
+    expect(MISSING_TOKEN_SUMMARY).toBe('GITHUB_TOKEN not set');
   });
 
   it('extends Error so stack traces work', () => {

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -18,13 +18,20 @@
 export const REPO = 'quantified-uncertainty/longterm-wiki';
 
 /**
+ * Short one-liner for display summaries ("GITHUB_TOKEN not set"). Kept in one
+ * place so the ~7 display call sites (health-check / pr-quality / ci-main-health
+ * summaries, wellness-report warning, github-lookup error, pr-patrol index
+ * errors, pr-patrol parallel error log) don't drift from each other.
+ */
+export const MISSING_TOKEN_SUMMARY = 'GITHUB_TOKEN not set';
+
+/**
  * Canonical help message for every code path that wants to tell the user
- * how to set `GITHUB_TOKEN`. Kept in one place so the 7+ display call sites
- * (health-check summaries, wellness-report, pr-quality, ci-main-health,
- * github-lookup, pr-patrol index/parallel) don't drift from each other.
+ * how to set `GITHUB_TOKEN`. Derived from `MISSING_TOKEN_SUMMARY` so the short
+ * and long forms cannot drift.
  */
 export const MISSING_TOKEN_HELP_MESSAGE =
-  'GITHUB_TOKEN not set. Required for GitHub API calls.\n' +
+  `${MISSING_TOKEN_SUMMARY}. Required for GitHub API calls.\n` +
   'Set it with: export GITHUB_TOKEN=<your-token>';
 
 /**

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -20,7 +20,7 @@
 
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { isMissingTokenError } from '../lib/github.ts';
+import { isMissingTokenError, MISSING_TOKEN_SUMMARY } from '../lib/github.ts';
 import { healthScan as realHealthScan, type HealthScanResult, type HealthIssue } from './health-scan.ts';
 import { appendJsonl, JSONL_FILE, STATE_DIR, ensureDirs, cl, log as realLog } from './state.ts';
 
@@ -238,21 +238,21 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
   // (b) the env changed between daemon startup and the first scan.
   if (!env.GITHUB_TOKEN) {
     log(
-      `${cl.red}✗ GITHUB_TOKEN not set — health gate cannot scan GitHub. ` +
+      `${cl.red}✗ ${MISSING_TOKEN_SUMMARY} — health gate cannot scan GitHub. ` +
         `Halting patrol until token is set.${cl.reset}`,
     );
     writeEvent({
       type: 'health_gate_missing_token',
       timestamp: now.toISOString(),
-      reason: 'GITHUB_TOKEN not set in environment',
+      reason: `${MISSING_TOKEN_SUMMARY} in environment`,
     });
     // Reset the consecutive-error counter: this is a config fault, not a
     // streak, and leaving it high would poison the next real scan attempt.
     cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
     return {
       proceed: false,
-      reason: 'GITHUB_TOKEN not set in environment',
-      result: syntheticScanFailureResult('GITHUB_TOKEN not set'),
+      reason: `${MISSING_TOKEN_SUMMARY} in environment`,
+      result: syntheticScanFailureResult(MISSING_TOKEN_SUMMARY),
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: false,
@@ -289,7 +289,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       );
       return {
         proceed: false,
-        reason: 'GITHUB_TOKEN not set in environment',
+        reason: `${MISSING_TOKEN_SUMMARY} in environment`,
         result: syntheticScanFailureResult(message),
         emittedIssues: [],
         suppressedIssues: [],

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -19,7 +19,13 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
-import { githubApi, REPO } from '../lib/github.ts';
+import {
+  githubApi,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_SUMMARY,
+  REPO,
+} from '../lib/github.ts';
 import { gitSafe } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
@@ -262,8 +268,14 @@ function preflightChecks(config: PatrolConfig): string[] {
     }
   }
 
-  if (!process.env.GITHUB_TOKEN) {
-    errors.push('GITHUB_TOKEN not set');
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      errors.push(MISSING_TOKEN_SUMMARY);
+    } else {
+      throw e;
+    }
   }
 
   return errors;

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -15,7 +15,12 @@ import { execSync } from 'child_process';
 import { tryRebaseAndVerify } from './rebase-verify.ts';
 import { gitIn, gitSafe, gitSafeIn } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';
-import { REPO } from '../lib/github.ts';
+import {
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_SUMMARY,
+  REPO,
+} from '../lib/github.ts';
 import type { PatrolConfig, ScoredPr, FixOutcome } from './types.ts';
 import {
   appendJsonl,
@@ -731,9 +736,14 @@ export async function runParallelDaemon(config: ParallelConfig): Promise<void> {
   log(`  mode=${config.once ? 'single pass' : config.dryRun ? 'dry run' : 'continuous'}`);
   log(`  JSONL: ${JSONL_FILE}`);
 
-  if (!process.env.GITHUB_TOKEN) {
-    log(`${cl.red}ERROR: GITHUB_TOKEN not set${cl.reset}`);
-    process.exit(1);
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      log(`${cl.red}ERROR: ${MISSING_TOKEN_SUMMARY}${cl.reset}`);
+      process.exit(1);
+    }
+    throw e;
   }
 
   // Signal handlers for graceful shutdown


### PR DESCRIPTION
## Summary

Ships the follow-up cleanup identified in the `/agent-review-pr` pass on QUA-482's PR #4372: every call site that rendered a hard-coded `'GITHUB_TOKEN not set'` variant now reads from a shared constant in `crux/lib/github.ts`, so short summary labels and long help text can't drift.

## Changes

### `crux/lib/github.ts`

- New export `MISSING_TOKEN_SUMMARY = 'GITHUB_TOKEN not set'` — the one-liner used in summary columns.
- `MISSING_TOKEN_HELP_MESSAGE` is now derived from `MISSING_TOKEN_SUMMARY` so the two forms can't diverge.

### 8 call sites migrated

| File | What changed |
|------|--------------|
| `crux/health/health-check.ts` | 2 sites (`checkActions`, `checkWikiServerDeploy`) — now use `getGitHubToken()` + `isMissingTokenError()` pattern, and `MISSING_TOKEN_{SUMMARY,HELP_MESSAGE}` for display. |
| `crux/health/wellness-report.ts` | `manageWellnessIssue` — same pattern. |
| `crux/health/checks/pr-quality.ts` | `checkPrQuality` — same pattern. |
| `crux/health/checks/ci-main-health.ts` | `checkCiMainHealth` — same pattern. |
| `crux/authoring/orchestrator/tools/github-lookup.ts` | Imports `MISSING_TOKEN_SUMMARY` for the tool-error payload (provider already handles token presence). |
| `crux/pr-patrol/index.ts` | Bare env check → `getGitHubToken()` + `isMissingTokenError()`. |
| `crux/pr-patrol/parallel.ts` | Bare env check in daemon startup → same pattern. |
| `crux/pr-patrol/health-gate.ts` | Not in the original ticket's 7-site list, but same pattern in 2 sites; migrated to prevent drift. |

### Regression test

`crux/lib/github.test.ts` now asserts `MISSING_TOKEN_HELP_MESSAGE.startsWith(MISSING_TOKEN_SUMMARY)`, so a future refactor that breaks the summary↔help-text consistency trips the test.

## Verification

- `npx vitest run crux/lib/github.test.ts crux/pr-patrol crux/health` — 482/482 tests pass, including the new assertion.
- `cd apps/wiki-server && npx tsc --noEmit` — clean.
- Manual grep confirms no remaining hardcoded `'GITHUB_TOKEN not set'` strings in `crux/` outside tests, fixtures, or the docstring on the constant itself.

## Test plan

- [x] Regression test for `MISSING_TOKEN_SUMMARY` ↔ `MISSING_TOKEN_HELP_MESSAGE` consistency
- [x] All existing `crux/pr-patrol/health-gate.test.ts` tests (28) still pass — uses `.includes('GITHUB_TOKEN not set')` which matches `MISSING_TOKEN_SUMMARY` exactly
- [ ] CI green

Fixes QUA-511
