### PR TITLE
QUA-341: consolidate 7 normalizeUrl helpers into @longterm-wiki/url-utils

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -23,6 +23,7 @@ const nextConfig: NextConfig = {
     "@quri/ui",
     "@longterm-wiki/factbase",
     "@longterm-wiki/id-utils",
+    "@longterm-wiki/url-utils",
   ],
   // Allow more time for static page generation in resource-constrained
   // environments (CI, cloud dev). Dashboard pages embedded via MDX make

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@dagrejs/dagre": "^1.1.8",
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/url-utils": "workspace:*",
     "@quri/squiggle-components": "^0.10.0",
     "@quri/squiggle-lang": "^0.10.0",
     "@radix-ui/react-collapsible": "^1.1.11",

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -28,7 +28,7 @@ import { computeRedundancy } from './lib/redundancy.mjs';
 import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
 import { generateLLMFiles } from './generate-llm-files.mjs';
 import { buildUrlToResourceMap, urlKey as resourceUrlKey } from './lib/unconverted-links.mjs';
-import { normalizeUrl as normalizeUrlCanonical } from '@longterm-wiki/url-utils';
+import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';
 import { generateMdxFromYaml } from './lib/mdx-generator.mjs';
 import { computeStats } from './lib/statistics.mjs';
 import { transformEntities } from './lib/entity-transform.mjs';
@@ -268,15 +268,6 @@ function warnIfSnapshotStale(snapshotPath) {
 // Link graph functions (computeBacklinks, scanContentEntityLinks, buildTagIndex,
 // computeRelatedGraph, collectLinkSignals) extracted to ./lib/link-graph.mjs
 
-/**
- * Normalize a URL for fuzzy matching between resource URLs and citation URLs.
- * Wraps the canonical normalizer with the dedup preset (stripProtocol +
- * lowercasePath). Both writer and reader use this so symmetric normalization
- * preserves the legacy behavior.
- */
-function normalizeUrlForMatch(str) {
-  return normalizeUrlCanonical(str, { stripProtocol: true, lowercasePath: true });
-}
 
 /**
  * Cross-reference KB fact source URLs with citation quotes to produce
@@ -306,7 +297,7 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
       const verdict = q.accuracyVerdict || (q.quoteVerified ? 'verified' : null);
       if (!verdict) continue;
 
-      const normalizedUrl = normalizeUrlForMatch(q.url);
+      const normalizedUrl = normalizeUrlForDedup(q.url);
       const existing = urlToVerdict.get(normalizedUrl);
       // Use most recent verdict (by checkedAt/updatedAt) or just overwrite
       // since citation quotes are ordered by recency in the bundle.
@@ -334,7 +325,7 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
       // Only match URL sources
       if (!url.startsWith('http://') && !url.startsWith('https://')) continue;
 
-      const normalizedSource = normalizeUrlForMatch(url);
+      const normalizedSource = normalizeUrlForDedup(url);
       const entry = urlToVerdict.get(normalizedSource);
       if (entry) {
         verification[fact.id] = entry.verdict;
@@ -353,7 +344,7 @@ function buildKBFactVerification(kb, citationQuotesBundle) {
  *   - resourceUrlToFactIds: normalizedUrl → factId[] (for resource detail pages)
  *   - factIdToResourceId: factId → resourceId (for fact detail pages)
  *
- * Uses normalizeUrlForMatch() for consistent URL normalization.
+ * Uses normalizeUrlForDedup() for consistent URL normalization.
  *
  * @param {object} kb - Serialized KB data (from build-data)
  * @param {Array<{id: string, url?: string, stable_id?: string}>} resources
@@ -370,7 +361,7 @@ function buildResourceFactLinks(kb, resources) {
   let resourceUrlCount = 0;
   for (const r of resources) {
     if (!r.url) continue;
-    const normalized = normalizeUrlForMatch(r.url);
+    const normalized = normalizeUrlForDedup(r.url);
     urlToResourceId.set(normalized, r.id);
     resourceUrlCount++;
   }
@@ -393,7 +384,7 @@ function buildResourceFactLinks(kb, resources) {
       if (!url.startsWith('http://') && !url.startsWith('https://')) continue;
       totalFactsWithUrls++;
 
-      const normalizedSource = normalizeUrlForMatch(url);
+      const normalizedSource = normalizeUrlForDedup(url);
       const resourceId = urlToResourceId.get(normalizedSource);
       if (resourceId) {
         // Add to resourceUrl → factIds map (keyed by resource ID for lookup)
@@ -948,8 +939,7 @@ async function main() {
         }
       }
 
-      // Source 3: URL matching from markdown links (canonical-key lookup;
-      // urlToId is built from urlToResource, which is canonical-keyed too).
+      // Source 3: URL matching from markdown links
       const linkRe = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
       while ((m = linkRe.exec(page.rawContent)) !== null) {
         const url = m[2];

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -27,7 +27,8 @@ import { filterBulkImportDates } from './lib/git-date-utils.mjs';
 import { computeRedundancy } from './lib/redundancy.mjs';
 import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
 import { generateLLMFiles } from './generate-llm-files.mjs';
-import { buildUrlToResourceMap } from './lib/unconverted-links.mjs';
+import { buildUrlToResourceMap, urlKey as resourceUrlKey } from './lib/unconverted-links.mjs';
+import { normalizeUrl as normalizeUrlCanonical } from '@longterm-wiki/url-utils';
 import { generateMdxFromYaml } from './lib/mdx-generator.mjs';
 import { computeStats } from './lib/statistics.mjs';
 import { transformEntities } from './lib/entity-transform.mjs';
@@ -269,20 +270,12 @@ function warnIfSnapshotStale(snapshotPath) {
 
 /**
  * Normalize a URL for fuzzy matching between resource URLs and citation URLs.
- * Strips protocol, www. prefix, trailing slashes, and hash fragments. Preserves
- * query string. Mirrors the logic in resource-utils.ts (cannot import .ts in .mjs).
+ * Wraps the canonical normalizer with the dedup preset (stripProtocol +
+ * lowercasePath). Both writer and reader use this so symmetric normalization
+ * preserves the legacy behavior.
  */
 function normalizeUrlForMatch(str) {
-  try {
-    const url = new URL(str);
-    url.hostname = url.hostname.replace(/^www\./, '');
-    url.hash = '';
-    return (
-      url.host + url.pathname.replace(/\/+$/, '') + url.search
-    ).toLowerCase();
-  } catch {
-    return str.replace(/\/+$/, '').toLowerCase();
-  }
+  return normalizeUrlCanonical(str, { stripProtocol: true, lowercasePath: true });
 }
 
 /**
@@ -750,7 +743,7 @@ async function main() {
   // Build URL → resource map for unconverted link detection
   const resources = database.resources || [];
   const urlToResource = buildUrlToResourceMap(resources);
-  console.log(`  urlToResource: ${urlToResource.size} URL variations mapped`);
+  console.log(`  urlToResource: ${urlToResource.size} canonical URL keys mapped`);
 
   // Fetch edit log dates, earliest edit log dates, and citation stats from
   // wiki-server (parallel). Also build git-based date maps (synchronous, fast).
@@ -955,11 +948,12 @@ async function main() {
         }
       }
 
-      // Source 3: URL matching from markdown links
+      // Source 3: URL matching from markdown links (canonical-key lookup;
+      // urlToId is built from urlToResource, which is canonical-keyed too).
       const linkRe = /(?<!!)\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
       while ((m = linkRe.exec(page.rawContent)) !== null) {
         const url = m[2];
-        const id = urlToId.get(url) ?? urlToId.get(url.replace(/\/$/, '')) ?? urlToId.get(url.replace(/\/$/, '') + '/');
+        const id = urlToId.get(resourceUrlKey(url));
         if (id && !seen.has(id) && validIds.has(id)) { seen.add(id); mergedIds.push(id); }
       }
 

--- a/apps/web/scripts/lib/unconverted-links.mjs
+++ b/apps/web/scripts/lib/unconverted-links.mjs
@@ -7,24 +7,11 @@
  * Extracted from build-data.mjs for modularity.
  */
 
-import { normalizeUrl } from "@longterm-wiki/url-utils";
-
-/** Canonical lookup key for a resource URL — protocol+slash agnostic. */
-export function urlKey(url) {
-  return normalizeUrl(url, { stripProtocol: true });
-}
-
-/**
- * Build URL → resource map from resources
- */
-export function buildUrlToResourceMap(resources) {
-  const urlToResource = new Map();
-  for (const r of resources) {
-    if (!r.url) continue;
-    urlToResource.set(urlKey(r.url), r);
-  }
-  return urlToResource;
-}
+// Re-export the canonical resource-URL helpers from crux so this module and
+// build-data.mjs share a single source of truth (build-data.mjs runs under
+// tsx/esm, so importing .ts is fine).
+import { resourceUrlKey, buildUrlToResourceMap, lookupResourceByUrl } from "../../../../crux/resource-utils.ts";
+export { resourceUrlKey as urlKey, buildUrlToResourceMap, lookupResourceByUrl };
 
 /**
  * Extract markdown links from content (not images, not internal, not <R> components)
@@ -51,7 +38,7 @@ export function findUnconvertedLinks(content, urlToResource) {
   const unconverted = [];
 
   for (const link of links) {
-    const resource = urlToResource.get(urlKey(link.url));
+    const resource = lookupResourceByUrl(urlToResource, link.url);
     if (resource) {
       unconverted.push({
         text: link.text,

--- a/apps/web/scripts/lib/unconverted-links.mjs
+++ b/apps/web/scripts/lib/unconverted-links.mjs
@@ -7,33 +7,11 @@
  * Extracted from build-data.mjs for modularity.
  */
 
-/**
- * Normalize URL to handle variations (trailing slashes, www prefix, http/https)
- */
-function normalizeUrl(url) {
-  const variations = new Set();
-  try {
-    const parsed = new URL(url);
-    const base = parsed.href.replace(/\/$/, '');
-    variations.add(base);
-    variations.add(base + '/');
+import { normalizeUrl } from "@longterm-wiki/url-utils";
 
-    // Without www
-    if (parsed.hostname.startsWith('www.')) {
-      const noWww = base.replace('://www.', '://');
-      variations.add(noWww);
-      variations.add(noWww + '/');
-    }
-    // With www
-    if (!parsed.hostname.startsWith('www.')) {
-      const withWww = base.replace('://', '://www.');
-      variations.add(withWww);
-      variations.add(withWww + '/');
-    }
-  } catch {
-    variations.add(url);
-  }
-  return Array.from(variations);
+/** Canonical lookup key for a resource URL — protocol+slash agnostic. */
+function urlKey(url) {
+  return normalizeUrl(url, { stripProtocol: true });
 }
 
 /**
@@ -43,10 +21,7 @@ export function buildUrlToResourceMap(resources) {
   const urlToResource = new Map();
   for (const r of resources) {
     if (!r.url) continue;
-    const normalizedUrls = normalizeUrl(r.url);
-    for (const url of normalizedUrls) {
-      urlToResource.set(url, r);
-    }
+    urlToResource.set(urlKey(r.url), r);
   }
   return urlToResource;
 }
@@ -76,7 +51,7 @@ export function findUnconvertedLinks(content, urlToResource) {
   const unconverted = [];
 
   for (const link of links) {
-    const resource = urlToResource.get(link.url) || urlToResource.get(link.url.replace(/\/$/, ''));
+    const resource = urlToResource.get(urlKey(link.url));
     if (resource) {
       unconverted.push({
         text: link.text,

--- a/apps/web/scripts/lib/unconverted-links.mjs
+++ b/apps/web/scripts/lib/unconverted-links.mjs
@@ -10,7 +10,7 @@
 import { normalizeUrl } from "@longterm-wiki/url-utils";
 
 /** Canonical lookup key for a resource URL — protocol+slash agnostic. */
-function urlKey(url) {
+export function urlKey(url) {
   return normalizeUrl(url, { stripProtocol: true });
 }
 

--- a/apps/web/src/components/wiki/resource-utils.ts
+++ b/apps/web/src/components/wiki/resource-utils.ts
@@ -1,6 +1,6 @@
 /** Shared constants and helpers for resource rendering components */
 
-import { normalizeUrl as canonicalNormalizeUrl } from "@longterm-wiki/url-utils";
+import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
 import {
   CITATION_VERDICT_KEYS,
   type CitationVerdictKey,
@@ -9,22 +9,18 @@ import {
   CITATION_VERDICT_SEVERITY,
 } from "@/components/shared/verdict-styles";
 
+/**
+ * Re-export the canonical dedup-mode normalizer under the historical
+ * `normalizeUrl` name expected by ReferenceCitationDot/Details.
+ */
+export { normalizeUrlForDedup as normalizeUrl };
+
 // Re-export citation verdict constants under their original names for backward compatibility
 export const VERDICT_KEYS = CITATION_VERDICT_KEYS;
 export type VerdictKey = CitationVerdictKey;
 export const VERDICT_SEVERITY = CITATION_VERDICT_SEVERITY;
 export const VERDICT_COLORS = CITATION_VERDICT_COLORS;
 export const VERDICT_STYLES = CITATION_VERDICT_STYLES;
-
-/**
- * Normalize a URL for fuzzy matching between resource URLs and citation URLs.
- * Uses the canonical normalizer (`@longterm-wiki/url-utils`) with the dedup
- * preset (stripProtocol + lowercasePath) so http/https/www variants compare
- * equal and case-insensitive paths dedup correctly.
- */
-export function normalizeUrl(raw: string): string {
-  return canonicalNormalizeUrl(raw, { stripProtocol: true, lowercasePath: true });
-}
 
 /** Maximum claims to display before showing "+N more" */
 export const MAX_CLAIMS_SHOWN = 8;

--- a/apps/web/src/components/wiki/resource-utils.ts
+++ b/apps/web/src/components/wiki/resource-utils.ts
@@ -1,5 +1,6 @@
 /** Shared constants and helpers for resource rendering components */
 
+import { normalizeUrl as canonicalNormalizeUrl } from "@longterm-wiki/url-utils";
 import {
   CITATION_VERDICT_KEYS,
   type CitationVerdictKey,
@@ -17,22 +18,12 @@ export const VERDICT_STYLES = CITATION_VERDICT_STYLES;
 
 /**
  * Normalize a URL for fuzzy matching between resource URLs and citation URLs.
- * - Strips protocol and `www.` prefix
- * - Removes trailing slashes
- * - Preserves query string, drops hash fragment
- * - Case-insensitive
+ * Uses the canonical normalizer (`@longterm-wiki/url-utils`) with the dedup
+ * preset (stripProtocol + lowercasePath) so http/https/www variants compare
+ * equal and case-insensitive paths dedup correctly.
  */
 export function normalizeUrl(raw: string): string {
-  try {
-    const u = new URL(raw);
-    return (
-      u.host.replace(/^www\./, "") +
-      u.pathname.replace(/\/+$/, "") +
-      u.search
-    ).toLowerCase();
-  } catch {
-    return raw.replace(/\/+$/, "").toLowerCase();
-  }
+  return canonicalNormalizeUrl(raw, { stripProtocol: true, lowercasePath: true });
 }
 
 /** Maximum claims to display before showing "+N more" */

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       "@data": path.resolve(__dirname, "./src/data/index.ts"),
       "@lib": path.resolve(__dirname, "./src/lib"),
       "@longterm-wiki/id-utils": path.resolve(__dirname, "../../packages/id-utils/src/index.ts"),
+      "@longterm-wiki/url-utils": path.resolve(__dirname, "../../packages/url-utils/src/index.ts"),
       "@wiki-server/api-response-types": path.resolve(__dirname, "../wiki-server/src/api-response-types.ts"),
       "@wiki-server/api-types": path.resolve(__dirname, "../wiki-server/src/api-types.ts"),
       "@wiki-server/facts-route": path.resolve(__dirname, "../wiki-server/src/routes/factbase/facts.ts"),

--- a/crux/citations/register-resources.ts
+++ b/crux/citations/register-resources.ts
@@ -15,7 +15,7 @@ import { readFileSync } from 'fs';
 import { basename } from 'path';
 import { parseCliArgs } from '../lib/cli.ts';
 import { getColors } from '../lib/output.ts';
-import { hashId, guessResourceType, buildUrlToResourceMap } from '../resource-utils.ts';
+import { hashId, guessResourceType, buildUrlToResourceMap, lookupResourceByUrl } from '../resource-utils.ts';
 import { loadResources, saveResources } from '../resource-io.ts';
 import { parseFootnoteSources } from '../lib/footnote-parser.ts';
 import { getCitationContentByUrl } from '../lib/wiki-server/citations.ts';
@@ -113,12 +113,8 @@ async function main() {
         continue;
       }
 
-      // Check if URL is already in our lookup (with normalization)
-      const hasEntry = urlToResource.has(source.url) ||
-        urlToResource.has(source.url.replace(/\/$/, '')) ||
-        urlToResource.has(source.url.replace(/\/$/, '') + '/');
-
-      if (hasEntry) {
+      // Check if URL is already registered (canonical-key lookup).
+      if (lookupResourceByUrl(urlToResource, source.url)) {
         alreadyRegistered++;
         continue;
       }

--- a/crux/citations/register-resources.ts
+++ b/crux/citations/register-resources.ts
@@ -113,7 +113,6 @@ async function main() {
         continue;
       }
 
-      // Check if URL is already registered (canonical-key lookup).
       if (lookupResourceByUrl(urlToResource, source.url)) {
         alreadyRegistered++;
         continue;

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -17,6 +17,7 @@
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
+import { normalizeUrl } from "@longterm-wiki/url-utils";
 import type { CommandResult } from "../lib/command-types.ts";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import {
@@ -122,20 +123,13 @@ function loadResources(): MinimalResource[] {
 }
 
 /**
- * Normalize a URL for fuzzy matching. Strips protocol, www prefix, trailing
- * slashes, and hash fragments. Preserves query string. Lowercases.
+ * Normalize a URL for fuzzy matching. Wraps the canonical normalizer with the
+ * dedup preset (stripProtocol + lowercasePath). Both writer and reader of
+ * `urlToResourceId` go through this helper, so the symmetric normalization
+ * preserves the legacy behavior.
  */
 function normalizeUrlForMatch(str: string): string {
-  try {
-    const url = new URL(str);
-    url.hostname = url.hostname.replace(/^www\./, "");
-    url.hash = "";
-    return (
-      url.host + url.pathname.replace(/\/+$/, "") + url.search
-    ).toLowerCase();
-  } catch {
-    return str.replace(/\/+$/, "").toLowerCase();
-  }
+  return normalizeUrl(str, { stripProtocol: true, lowercasePath: true });
 }
 
 /**

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -17,7 +17,7 @@
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
-import { normalizeUrl } from "@longterm-wiki/url-utils";
+import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
 import type { CommandResult } from "../lib/command-types.ts";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import {
@@ -122,15 +122,6 @@ function loadResources(): MinimalResource[] {
   return _cachedResources;
 }
 
-/**
- * Normalize a URL for fuzzy matching. Wraps the canonical normalizer with the
- * dedup preset (stripProtocol + lowercasePath). Both writer and reader of
- * `urlToResourceId` go through this helper, so the symmetric normalization
- * preserves the legacy behavior.
- */
-function normalizeUrlForMatch(str: string): string {
-  return normalizeUrl(str, { stripProtocol: true, lowercasePath: true });
-}
 
 /**
  * Build normalized-URL → resource ID map from resources.json.
@@ -140,7 +131,7 @@ function buildUrlToResourceId(): Map<string, string> {
   const map = new Map<string, string>();
   for (const r of resources) {
     if (r.url) {
-      map.set(normalizeUrlForMatch(r.url), r.id);
+      map.set(normalizeUrlForDedup(r.url), r.id);
     }
   }
   return map;
@@ -311,7 +302,7 @@ function seedFromLiterature(
       }
 
       // Resolve link URL to resource ID
-      const normalizedUrl = normalizeUrlForMatch(paper.link);
+      const normalizedUrl = normalizeUrlForDedup(paper.link);
       const resourceId = urlToResourceId.get(normalizedUrl);
       if (!resourceId) {
         skippedUrlNotFound++;

--- a/crux/lib/__tests__/footnote-parser.test.ts
+++ b/crux/lib/__tests__/footnote-parser.test.ts
@@ -131,14 +131,28 @@ Claims about Kalshi.[^1] More claims.[^2] Even more.[^3]
     expect(sourceB!.footnoteNumbers).toEqual([3]);
   });
 
-  it("matches URLs to resource IDs when provided", () => {
+  it("matches URLs to resource IDs when provided (canonical keys, QUA-341)", () => {
     const content = `
 [^1]: [Example](https://example.com/page)
 `;
+    // The map must be keyed by canonical URL (run through
+    // normalizeUrl(url, { stripProtocol: true })) — see parseFootnoteSources docs.
     const urlToResourceId = new Map([
-      ["https://example.com/page", "abc123"],
+      ["example.com/page", "abc123"],
     ]);
     const result = parseFootnoteSources(content, urlToResourceId);
+    expect(result.sources[0].resourceId).toBe("abc123");
+  });
+
+  it("matches resource IDs across http/https/www variants (QUA-341)", () => {
+    const content = `
+[^1]: [A](http://example.com/page)
+[^2]: [B](https://www.example.com/page/)
+`;
+    const urlToResourceId = new Map([["example.com/page", "abc123"]]);
+    const result = parseFootnoteSources(content, urlToResourceId);
+    // Both footnotes dedup to the same source and both should resolve to abc123.
+    expect(result.sources).toHaveLength(1);
     expect(result.sources[0].resourceId).toBe("abc123");
   });
 

--- a/crux/lib/__tests__/resource-utils.test.ts
+++ b/crux/lib/__tests__/resource-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  resourceUrlKey,
+  buildUrlToResourceMap,
+  lookupResourceByUrl,
+} from "../../resource-utils.ts";
+import type { Resource } from "../../resource-types.ts";
+
+const r = (id: string, url: string): Resource => ({
+  id,
+  url,
+  title: id,
+  type: "web",
+});
+
+describe("resourceUrlKey (QUA-341)", () => {
+  it("produces the same key for http and https variants", () => {
+    expect(resourceUrlKey("http://example.com/page")).toBe(
+      resourceUrlKey("https://example.com/page"),
+    );
+  });
+
+  it("produces the same key for www and bare-host variants", () => {
+    expect(resourceUrlKey("https://www.example.com/page")).toBe(
+      resourceUrlKey("https://example.com/page"),
+    );
+  });
+
+  it("produces the same key for trailing-slash and bare variants", () => {
+    expect(resourceUrlKey("https://example.com/page/")).toBe(
+      resourceUrlKey("https://example.com/page"),
+    );
+  });
+
+  it("differentiates different paths", () => {
+    expect(resourceUrlKey("https://example.com/a")).not.toBe(
+      resourceUrlKey("https://example.com/b"),
+    );
+  });
+
+  it("strips tracking parameters", () => {
+    expect(resourceUrlKey("https://example.com/page?utm_source=x")).toBe(
+      resourceUrlKey("https://example.com/page"),
+    );
+  });
+});
+
+describe("buildUrlToResourceMap + lookupResourceByUrl (QUA-341)", () => {
+  it("looks up a resource regardless of URL surface form", () => {
+    const map = buildUrlToResourceMap([
+      r("R1", "https://example.com/foo"),
+      r("R2", "https://other.org/bar"),
+    ]);
+
+    expect(lookupResourceByUrl(map, "https://example.com/foo")?.id).toBe("R1");
+    expect(lookupResourceByUrl(map, "http://example.com/foo")?.id).toBe("R1");
+    expect(lookupResourceByUrl(map, "https://www.example.com/foo")?.id).toBe("R1");
+    expect(lookupResourceByUrl(map, "https://example.com/foo/")?.id).toBe("R1");
+    expect(lookupResourceByUrl(map, "https://example.com/foo?utm_source=x")?.id).toBe("R1");
+  });
+
+  it("returns undefined for unknown URLs", () => {
+    const map = buildUrlToResourceMap([r("R1", "https://example.com/foo")]);
+    expect(lookupResourceByUrl(map, "https://nope.com/foo")).toBeUndefined();
+  });
+
+  it("skips resources with no URL", () => {
+    const map = buildUrlToResourceMap([
+      { id: "R1", url: "", title: "no url", type: "web" } as Resource,
+      r("R2", "https://example.com/page"),
+    ]);
+    expect(map.size).toBe(1);
+    expect(lookupResourceByUrl(map, "https://example.com/page")?.id).toBe("R2");
+  });
+
+  it("writes one canonical key per resource (not 4 variants like the old generator)", () => {
+    const map = buildUrlToResourceMap([
+      r("R1", "https://www.example.com/foo/"),
+    ]);
+    expect(map.size).toBe(1);
+  });
+});

--- a/crux/lib/footnote-parser.ts
+++ b/crux/lib/footnote-parser.ts
@@ -75,14 +75,17 @@ function cleanUrl(url: string): string {
 }
 
 /**
- * Normalize a URL for deduplication: strips protocol, www, trailing slashes,
- * and lowercases. This groups footnotes that reference the same source.
+ * Normalize a URL for deduplication: strips protocol, www, fragment, trailing
+ * slashes, and tracking parameters; lowercases host and path. Groups footnotes
+ * that reference the same source.
  *
- * Wraps `@longterm-wiki/url-utils::normalizeUrl` with the dedup option set
- * (stripProtocol + lowercasePath). Preserves all query params (no tracking
- * filter) so footnotes that differ only in tracking suffix dedup correctly,
- * the same as before — note: the canonical helper does strip tracking by
- * default, which actually improves dedup quality here.
+ * Wraps `@longterm-wiki/url-utils::normalizeUrl` with `stripProtocol +
+ * lowercasePath`. Note: the canonical helper strips tracking parameters
+ * (utm_*, fbclid, gclid, ...) by default — a slight semantic widening
+ * vs. the pre-QUA-341 implementation, which kept all query params. This
+ * makes footnote dedup more aggressive (two URLs differing only in utm_*
+ * now collapse). Pass `keepTracking: true` to recover the old behavior if
+ * a regression appears.
  */
 export function normalizeUrlForDedup(url: string): string {
   return normalizeUrl(url, { stripProtocol: true, lowercasePath: true });
@@ -186,7 +189,9 @@ function extractTitleFromText(text: string): string | null {
  * Parse footnotes and group them by unique source URL.
  *
  * @param content - Raw MDX content
- * @param urlToResourceId - Optional map of URL → resource ID for matching
+ * @param urlToResourceId - Optional map of URL → resource ID for matching.
+ *   Keys must be canonical URLs (run through `normalizeUrl(url, { stripProtocol: true })`).
+ *   The lookup normalizes the footnote URL the same way before checking.
  */
 export function parseFootnoteSources(
   content: string,
@@ -206,14 +211,11 @@ export function parseFootnoteSources(
     if (!sourceMap.has(normUrl)) {
       urlNormToCanonical.set(normUrl, fn.url);
 
-      // Try to find matching resource
+      // Try to find matching resource — normalize the lookup URL the same way
+      // resource maps are built (canonical key, protocol-agnostic).
       let resourceId: string | null = null;
       if (urlToResourceId) {
-        resourceId =
-          urlToResourceId.get(fn.url) ??
-          urlToResourceId.get(fn.url.replace(/\/$/, "")) ??
-          urlToResourceId.get(fn.url.replace(/\/$/, "") + "/") ??
-          null;
+        resourceId = urlToResourceId.get(normalizeUrl(fn.url, { stripProtocol: true })) ?? null;
       }
 
       sourceMap.set(normUrl, {

--- a/crux/lib/footnote-parser.ts
+++ b/crux/lib/footnote-parser.ts
@@ -7,6 +7,8 @@
  *   - crux citations for citation management
  */
 
+import { normalizeUrl } from "@longterm-wiki/url-utils";
+
 export interface ParsedFootnote {
   /** Footnote number (e.g. 1, 2, 3) */
   number: number;
@@ -75,18 +77,15 @@ function cleanUrl(url: string): string {
 /**
  * Normalize a URL for deduplication: strips protocol, www, trailing slashes,
  * and lowercases. This groups footnotes that reference the same source.
+ *
+ * Wraps `@longterm-wiki/url-utils::normalizeUrl` with the dedup option set
+ * (stripProtocol + lowercasePath). Preserves all query params (no tracking
+ * filter) so footnotes that differ only in tracking suffix dedup correctly,
+ * the same as before — note: the canonical helper does strip tracking by
+ * default, which actually improves dedup quality here.
  */
 export function normalizeUrlForDedup(url: string): string {
-  try {
-    const u = new URL(url);
-    return (
-      u.host.replace(/^www\./, "") +
-      u.pathname.replace(/\/+$/, "") +
-      u.search
-    ).toLowerCase();
-  } catch {
-    return url.replace(/\/+$/, "").toLowerCase();
-  }
+  return normalizeUrl(url, { stripProtocol: true, lowercasePath: true });
 }
 
 /**

--- a/crux/lib/footnote-parser.ts
+++ b/crux/lib/footnote-parser.ts
@@ -7,7 +7,11 @@
  *   - crux citations for citation management
  */
 
-import { normalizeUrl } from "@longterm-wiki/url-utils";
+import { normalizeUrl, normalizeUrlForDedup } from "@longterm-wiki/url-utils";
+
+// Re-export the canonical dedup helper for back-compat with existing
+// `import { normalizeUrlForDedup } from '../footnote-parser.ts'` callers.
+export { normalizeUrlForDedup };
 
 export interface ParsedFootnote {
   /** Footnote number (e.g. 1, 2, 3) */
@@ -72,23 +76,6 @@ function extractUrlFromFootnote(text: string): { url: string | null; title: stri
  */
 function cleanUrl(url: string): string {
   return url.replace(/[.),:;]+$/, "");
-}
-
-/**
- * Normalize a URL for deduplication: strips protocol, www, fragment, trailing
- * slashes, and tracking parameters; lowercases host and path. Groups footnotes
- * that reference the same source.
- *
- * Wraps `@longterm-wiki/url-utils::normalizeUrl` with `stripProtocol +
- * lowercasePath`. Note: the canonical helper strips tracking parameters
- * (utm_*, fbclid, gclid, ...) by default — a slight semantic widening
- * vs. the pre-QUA-341 implementation, which kept all query params. This
- * makes footnote dedup more aggressive (two URLs differing only in utm_*
- * now collapse). Pass `keepTracking: true` to recover the old behavior if
- * a regression appears.
- */
-export function normalizeUrlForDedup(url: string): string {
-  return normalizeUrl(url, { stripProtocol: true, lowercasePath: true });
 }
 
 /**

--- a/crux/lib/search/resource-lookup.test.ts
+++ b/crux/lib/search/resource-lookup.test.ts
@@ -82,6 +82,25 @@ describe('resource-lookup', () => {
     it('returns null for an unknown URL', () => {
       expect(getResourceByUrl('https://unknown.com/page')).toBeNull();
     });
+
+    it('treats http and https as equivalent (QUA-341)', () => {
+      // The pre-QUA-341 implementation forced https://; the new canonical
+      // helper strips the protocol entirely. Both produce the same key.
+      const r = getResourceByUrl('http://example.com/paper-one');
+      expect(r).not.toBeNull();
+      expect(r!.id).toBe('abc123def456');
+    });
+
+    it('returns the same resource regardless of query-param order (QUA-341)', () => {
+      // sortParams: true gives deterministic keys.
+      // Note: example.com/paper-one in mock data has no query params, so test
+      // the mock URL with synthetic params won't actually match anything new.
+      // What we verify is the URL parser treats these inputs equivalently.
+      // The resource above has no query params, so a query-bearing URL won't
+      // match it — assert that "no match" on either ordering, equally:
+      expect(getResourceByUrl('https://example.com/paper-one?b=2&a=1')).toBeNull();
+      expect(getResourceByUrl('https://example.com/paper-one?a=1&b=2')).toBeNull();
+    });
   });
 
   describe('resolveResource', () => {

--- a/crux/lib/search/resource-lookup.test.ts
+++ b/crux/lib/search/resource-lookup.test.ts
@@ -83,23 +83,10 @@ describe('resource-lookup', () => {
       expect(getResourceByUrl('https://unknown.com/page')).toBeNull();
     });
 
-    it('treats http and https as equivalent (QUA-341)', () => {
-      // The pre-QUA-341 implementation forced https://; the new canonical
-      // helper strips the protocol entirely. Both produce the same key.
+    it('treats http and https as equivalent', () => {
       const r = getResourceByUrl('http://example.com/paper-one');
       expect(r).not.toBeNull();
       expect(r!.id).toBe('abc123def456');
-    });
-
-    it('returns the same resource regardless of query-param order (QUA-341)', () => {
-      // sortParams: true gives deterministic keys.
-      // Note: example.com/paper-one in mock data has no query params, so test
-      // the mock URL with synthetic params won't actually match anything new.
-      // What we verify is the URL parser treats these inputs equivalently.
-      // The resource above has no query params, so a query-bearing URL won't
-      // match it — assert that "no match" on either ordering, equally:
-      expect(getResourceByUrl('https://example.com/paper-one?b=2&a=1')).toBeNull();
-      expect(getResourceByUrl('https://example.com/paper-one?a=1&b=2')).toBeNull();
     });
   });
 

--- a/crux/lib/search/resource-lookup.ts
+++ b/crux/lib/search/resource-lookup.ts
@@ -7,6 +7,7 @@
  * Read path: loads resources from snapshot (sync) or PG (async via initFromPG).
  */
 
+import { normalizeUrl } from "@longterm-wiki/url-utils";
 import type { Resource } from '../../resource-types.ts';
 import { loadResources, loadResourcesPGFirst } from '../../resource-io.ts';
 
@@ -36,32 +37,11 @@ let cachedByStableId: Map<string, Resource> | null = null;
 let cachedByUrl: Map<string, Resource> | null = null;
 
 function normalizeUrlKey(url: string): string {
-  try {
-    const parsed = new URL(url);
-    // Normalize protocol: http → https
-    parsed.protocol = 'https:';
-    // Remove www. prefix
-    parsed.hostname = parsed.hostname.replace(/^www\./, '');
-    // Remove fragment
-    parsed.hash = '';
-    // Remove UTM tracking parameters and sort remaining params
-    const params = new URLSearchParams(parsed.search);
-    const keysToDelete: string[] = [];
-    for (const key of params.keys()) {
-      if (key.startsWith('utm_')) {
-        keysToDelete.push(key);
-      }
-    }
-    for (const key of keysToDelete) {
-      params.delete(key);
-    }
-    params.sort();
-    parsed.search = params.toString();
-    // Remove trailing slash
-    return parsed.href.replace(/\/$/, '');
-  } catch {
-    return url;
-  }
+  // Use the canonical normalizer with the lookup-key preset:
+  // stripProtocol makes http and https hash to the same key (the previous
+  // implementation forced https, which is equivalent), and sortParams
+  // gives deterministic keys regardless of param order.
+  return normalizeUrl(url, { stripProtocol: true, sortParams: true });
 }
 
 function ensureLoaded(): void {

--- a/crux/lib/search/resource-lookup.ts
+++ b/crux/lib/search/resource-lookup.ts
@@ -76,11 +76,10 @@ function buildIndexes(resources: Resource[]): void {
       cachedByStableId.set(resource.stable_id, resource);
     }
 
-    // Index by normalized URL (with and without trailing slash, www variants)
+    // Index by canonical URL key (the canonical helper already strips
+    // trailing slash, www, and tracking params — one entry covers all variants).
     if (resource.url) {
-      const norm = normalizeUrlKey(resource.url);
-      cachedByUrl.set(norm, resource);
-      cachedByUrl.set(norm + '/', resource);
+      cachedByUrl.set(normalizeUrlKey(resource.url), resource);
     }
   }
 }
@@ -114,11 +113,10 @@ export function getResourceById(id: string): Resource | null {
   return cachedById!.get(id) ?? null;
 }
 
-/** Look up a resource by URL (normalized, tolerant of trailing slashes and www). */
+/** Look up a resource by URL (canonical-key normalization, tolerant of www/protocol/slash variants). */
 export function getResourceByUrl(url: string): Resource | null {
   ensureLoaded();
-  const norm = normalizeUrlKey(url);
-  return cachedByUrl!.get(norm) ?? cachedByUrl!.get(norm + '/') ?? null;
+  return cachedByUrl!.get(normalizeUrlKey(url)) ?? null;
 }
 
 /**

--- a/crux/lib/sourcing/fuzzy-match.test.ts
+++ b/crux/lib/sourcing/fuzzy-match.test.ts
@@ -162,6 +162,33 @@ describe('urlMatches', () => {
   it('preserves path differences', () => {
     expect(urlMatches('https://anthropic.com/about', 'https://anthropic.com/team')).toBe(false);
   });
+
+  it('treats URLs that differ only in tracking params as matching (QUA-341)', () => {
+    // The canonical helper strips utm_/fbclid/etc. by default; this is a
+    // semantic widening vs. the pre-QUA-341 implementation, made explicit
+    // here as a regression guard.
+    expect(
+      urlMatches(
+        'https://anthropic.com/post?utm_source=twitter',
+        'https://anthropic.com/post',
+      ),
+    ).toBe(true);
+  });
+
+  it('treats URLs that differ only in fragment as matching (QUA-341)', () => {
+    // The pre-QUA-341 implementation would have returned false here because
+    // fragments were never stripped. Asserting the new behavior so any future
+    // revert needs to be explicit.
+    expect(
+      urlMatches('https://anthropic.com/post#section-1', 'https://anthropic.com/post'),
+    ).toBe(true);
+  });
+
+  it('treats malformed URLs case-insensitively in the fallback path', () => {
+    // Both inputs fail URL parsing, so they go through the
+    // trim+strip-trailing-slash+lowercase fallback. Old impl did not lowercase.
+    expect(urlMatches('NOT-A-URL', 'not-a-url')).toBe(true);
+  });
 });
 
 describe('parseAmount', () => {

--- a/crux/lib/sourcing/fuzzy-match.ts
+++ b/crux/lib/sourcing/fuzzy-match.ts
@@ -7,6 +7,8 @@
  * Part of Phase 3: Data Source Resources (Discussion #3567).
  */
 
+import { normalizeUrl } from "@longterm-wiki/url-utils";
+
 /**
  * Normalize an organization name for comparison.
  * Strips common suffixes, lowercases, normalizes Unicode, collapses whitespace.
@@ -110,18 +112,11 @@ function normalizeDateString(d: string): string {
 }
 
 /**
- * Check if two URLs match after normalization.
- * Strips trailing `/`, normalizes http<->https, strips `www.` prefix.
+ * Check if two URLs match after protocol-agnostic normalization.
+ * Uses the canonical normalizer (strip protocol, www, trailing slash, tracking).
  */
 export function urlMatches(a: string, b: string): boolean {
-  function normalizeUrl(url: string): string {
-    return url
-      .trim()
-      .replace(/^https?:\/\//, '')    // strip protocol
-      .replace(/^www\./, '')           // strip www.
-      .replace(/\/+$/, '');            // strip trailing slashes
-  }
-  return normalizeUrl(a) === normalizeUrl(b);
+  return normalizeUrl(a, { stripProtocol: true }) === normalizeUrl(b, { stripProtocol: true });
 }
 
 /**

--- a/crux/lib/sourcing/url-quality.ts
+++ b/crux/lib/sourcing/url-quality.ts
@@ -12,7 +12,12 @@
  *
  * Phase 2 of QUA-113 / Discussion #4221. Extracted from inline implementation
  * in `crux/commands/sourcing-audit-urls.ts` (Phase 1, PR #4222).
+ *
+ * URL normalization helpers (`normalizeUrlForJoin`, `extractHost`) moved to
+ * `@longterm-wiki/url-utils` in QUA-341 — re-exported here for compat.
  */
+
+export { normalizeUrl as normalizeUrlForJoin, extractHost } from "@longterm-wiki/url-utils";
 
 // ── Module constants ──
 
@@ -21,10 +26,6 @@ export const FLAG_THRESHOLD = 0.7;
 
 /** Confidence threshold to skip LLM classify-step (write directly to PG). */
 export const FAST_PATH_THRESHOLD = 0.8;
-
-/** Query parameters that indicate tracking, not data content. */
-const TRACKING_PREFIXES = ['utm_', 'mc_', 'oly_'];
-const TRACKING_EXACT = new Set(['fbclid', 'gclid', 'yclid', 'msclkid', '_ga']);
 
 /** Query parameters that indicate specific content (force non-homepage classification). */
 const DATA_PARAM_KEYS = new Set(['id', 'v', 'q', 'search', 'article', 'item', 'page', 'post']);
@@ -143,52 +144,3 @@ export function classifyByUrl(raw: string): UrlClassification {
   return { purpose: null, confidence: 0.4, reasons: [`depth:1:${path}`] };
 }
 
-/**
- * Canonical URL form for comparing/grouping evidence URLs and resource URLs.
- * Strips: trailing slash, www., fragment, default ports, common tracking
- * params (utm_*, fbclid, gclid). Lowercases host.
- *
- * NOT a replacement for the 9 existing URL normalizers in the codebase —
- * those serve different semantics. This one is for audit-join + domain grouping.
- */
-export function normalizeUrlForJoin(raw: string): string {
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return raw.trim().toLowerCase();
-  }
-
-  let host = url.hostname.toLowerCase();
-  if (host.startsWith('www.')) host = host.slice(4);
-
-  const portSuffix =
-    (url.port === '' || (url.protocol === 'http:' && url.port === '80') ||
-      (url.protocol === 'https:' && url.port === '443'))
-      ? ''
-      : `:${url.port}`;
-
-  const filteredParams = new URLSearchParams();
-  for (const [k, v] of url.searchParams.entries()) {
-    const keyLower = k.toLowerCase();
-    if (TRACKING_EXACT.has(keyLower)) continue;
-    if (TRACKING_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
-    filteredParams.append(k, v);
-  }
-  const qs = filteredParams.toString();
-
-  const path = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
-
-  return `${url.protocol}//${host}${portSuffix}${path}${qs ? '?' + qs : ''}`;
-}
-
-/** Extract just the host portion, normalized, for domain grouping. */
-export function extractHost(raw: string): string {
-  try {
-    let host = new URL(raw).hostname.toLowerCase();
-    if (host.startsWith('www.')) host = host.slice(4);
-    return host;
-  } catch {
-    return '(invalid-url)';
-  }
-}

--- a/crux/resource-manager.ts
+++ b/crux/resource-manager.ts
@@ -130,7 +130,7 @@ function cmdShow(opts: ParsedOpts): void {
   const needsResource: typeof links = [];
 
   for (const link of links) {
-    const resource = urlMap.get(link.url) || urlMap.get(link.url.replace(/\/$/, ''));
+    const resource = lookupResourceByUrl(urlMap, link.url);
     if (resource) {
       convertible.push({ ...link, resource });
     } else {
@@ -286,8 +286,8 @@ async function cmdCreate(opts: ParsedOpts): Promise<void> {
   const resources = loadResources();
   const urlMap = buildUrlToResourceMap(resources);
 
-  // Check if already exists
-  const existing = urlMap.get(url) || urlMap.get(url.replace(/\/$/, ''));
+  // Check if already exists (canonical-key lookup)
+  const existing = lookupResourceByUrl(urlMap, url);
   if (existing) {
     console.log(`Resource already exists: ${existing.id}`);
     console.log(`  Title: ${existing.title}`);

--- a/crux/resource-manager.ts
+++ b/crux/resource-manager.ts
@@ -33,7 +33,7 @@ import { findMdxFiles } from './lib/file-utils.ts';
 
 import type { Resource, ParsedOpts, Conversion } from './resource-types.ts';
 import { loadResources, loadResourcesPGFirst, saveResources, loadPages, loadPublications } from './resource-io.ts';
-import { hashId, normalizeUrl, buildUrlToResourceMap, extractMarkdownLinks, findFileByName, guessResourceType } from './resource-utils.ts';
+import { hashId, resourceUrlKey, lookupResourceByUrl, buildUrlToResourceMap, extractMarkdownLinks, findFileByName, guessResourceType } from './resource-utils.ts';
 import { cmdMetadata } from './resource-metadata.ts';
 import { cmdValidate } from './resource-validator.ts';
 import { cmdRefreshTitles } from './resource-refresh-titles.ts';
@@ -191,7 +191,7 @@ async function cmdProcess(opts: ParsedOpts): Promise<void> {
   const newResources: Resource[] = [];
 
   for (const link of links) {
-    let resource = urlMap.get(link.url) || urlMap.get(link.url.replace(/\/$/, ''));
+    let resource = lookupResourceByUrl(urlMap, link.url);
 
     if (!resource && !skipCreate) {
       // Create new resource
@@ -205,10 +205,7 @@ async function cmdProcess(opts: ParsedOpts): Promise<void> {
       };
       newResources.push(resource);
       resources.push(resource);
-      // Update map for any duplicate URLs
-      for (const url of normalizeUrl(link.url)) {
-        urlMap.set(url, resource);
-      }
+      urlMap.set(resourceUrlKey(link.url), resource);
     }
 
     if (resource) {

--- a/crux/resource-manager.ts
+++ b/crux/resource-manager.ts
@@ -286,7 +286,6 @@ async function cmdCreate(opts: ParsedOpts): Promise<void> {
   const resources = loadResources();
   const urlMap = buildUrlToResourceMap(resources);
 
-  // Check if already exists (canonical-key lookup)
   const existing = lookupResourceByUrl(urlMap, url);
   if (existing) {
     console.log(`Resource already exists: ${existing.id}`);

--- a/crux/resource-utils.ts
+++ b/crux/resource-utils.ts
@@ -6,6 +6,7 @@
 
 import { basename } from 'path';
 import { createHash, randomBytes } from 'crypto';
+import { normalizeUrl } from "@longterm-wiki/url-utils";
 import { CONTENT_DIR_ABS as CONTENT_DIR } from './lib/content-types.ts';
 import { findMdxFiles } from './lib/file-utils.ts';
 import type { Resource, MarkdownLink } from './resource-types.ts';
@@ -19,40 +20,29 @@ export function generateFactId(): string {
   return randomBytes(4).toString('hex');
 }
 
-export function normalizeUrl(url: string): string[] {
-  const variations = new Set<string>();
-  try {
-    const parsed = new URL(url);
-    const base = parsed.href.replace(/\/$/, '');
-    variations.add(base);
-    variations.add(base + '/');
-    // Without www
-    if (parsed.hostname.startsWith('www.')) {
-      const noWww = base.replace('://www.', '://');
-      variations.add(noWww);
-      variations.add(noWww + '/');
-    }
-    // With www
-    if (!parsed.hostname.startsWith('www.')) {
-      const withWww = base.replace('://', '://www.');
-      variations.add(withWww);
-      variations.add(withWww + '/');
-    }
-  } catch (_err: unknown) {
-    variations.add(url);
-  }
-  return Array.from(variations);
+/**
+ * Canonical lookup key for a resource URL: protocol-agnostic and trailing-slash
+ * agnostic. Use this for both writing to and reading from a URL → resource map.
+ */
+export function resourceUrlKey(url: string): string {
+  return normalizeUrl(url, { stripProtocol: true });
 }
 
 export function buildUrlToResourceMap(resources: Resource[]): Map<string, Resource> {
   const map = new Map<string, Resource>();
   for (const r of resources) {
     if (!r.url) continue;
-    for (const url of normalizeUrl(r.url)) {
-      map.set(url, r);
-    }
+    map.set(resourceUrlKey(r.url), r);
   }
   return map;
+}
+
+/** Look up a resource by URL using the canonical key normalization. */
+export function lookupResourceByUrl(
+  map: Map<string, Resource>,
+  url: string,
+): Resource | undefined {
+  return map.get(resourceUrlKey(url));
 }
 
 export function extractMarkdownLinks(content: string): MarkdownLink[] {

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -315,6 +315,15 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'url-normalize',
+    name: 'URL normalization helpers consolidated (QUA-341)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-url-normalize.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: prevents new local normalizeUrl helpers from re-fragmenting
+    // the canonical helper in @longterm-wiki/url-utils.
+  },
+  {
     id: 'sourcing-lint-guard',
     name: 'Sourcing rename ratchet (legacy terminology counts only fall)',
     command: 'npx',

--- a/crux/validate/validate-url-normalize.test.ts
+++ b/crux/validate/validate-url-normalize.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { runCheck } from "./validate-url-normalize.ts";
+
+describe("validate-url-normalize (QUA-341)", () => {
+  it("passes on the current codebase (no stray URL normalizers)", () => {
+    // Regression guard: any new file that defines its own `normalizeUrl`,
+    // `normalizeUrlForJoin`, `normalizeUrlForDedup`, `normalizeUrlKey`, or
+    // `urlMatches` outside the canonical package and ALLOWLIST will fail this.
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+  });
+});

--- a/crux/validate/validate-url-normalize.ts
+++ b/crux/validate/validate-url-normalize.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that URL-normalization functions live only in @longterm-wiki/url-utils.
+ *
+ * QUA-341 consolidated 7 different `normalizeUrl`-style helpers (each with subtly
+ * different semantics) into a single canonical helper in the url-utils package.
+ * This validator prevents regression — it scans crux/, apps/web/src/, and
+ * apps/web/scripts/ for new local definitions of `normalizeUrl`,
+ * `normalizeUrlForJoin`, `normalizeUrlForDedup`, `normalizeUrlKey`, or
+ * `urlMatches` outside the canonical package and an explicit allowlist of
+ * thin wrappers/re-exports.
+ *
+ * Usage: npx tsx crux/validate/validate-url-normalize.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+
+/** Directories to scan (relative to PROJECT_ROOT) */
+const SCAN_DIRS = [
+  "crux",
+  "apps/web/src",
+  "apps/web/scripts",
+  "apps/wiki-server/src",
+  "apps/groundskeeper/src",
+];
+
+/** Files allowed to define their own URL normalizer (re-exports + thin wrappers). */
+const ALLOWLIST = new Set<string>([
+  // Canonical helper itself.
+  "packages/url-utils/src/index.ts",
+  // Backward-compat re-export of the canonical helper under the old name.
+  "crux/lib/sourcing/url-quality.ts",
+  // Thin wrappers that delegate to the canonical helper with preset options.
+  // These wrap to preserve a domain-specific call signature; they do not
+  // re-implement normalization. If you remove the wrapper, remove this entry.
+  "crux/lib/footnote-parser.ts",
+  "crux/lib/search/resource-lookup.ts",
+  "crux/lib/sourcing/fuzzy-match.ts",
+  "apps/web/src/components/wiki/resource-utils.ts",
+  "crux/resource-utils.ts",
+  "apps/web/scripts/lib/unconverted-links.mjs",
+]);
+
+/** Function names that this validator considers URL-normalizers. */
+const BANNED_NAMES = [
+  "normalizeUrl",
+  "normalizeUrlForJoin",
+  "normalizeUrlForDedup",
+  "normalizeUrlKey",
+  "urlMatches",
+];
+
+/** Match `function NAME(`, `const NAME = (`, `const NAME = function(`. */
+const FUNCTION_DEF_PATTERN = new RegExp(
+  `\\b(?:function|const|let|var)\\s+(${BANNED_NAMES.join("|")})\\b`,
+);
+
+/** Match `(...): NAME` (returning) — not what we want. The above pattern catches definitions. */
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  symbol: string;
+}
+
+function collectFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  function walk(current: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        if (
+          entry === "node_modules" ||
+          entry === ".next" ||
+          entry === "dist" ||
+          entry === "coverage" ||
+          entry === "__tests__"
+        ) {
+          continue;
+        }
+        walk(fullPath);
+      } else if (
+        (entry.endsWith(".ts") || entry.endsWith(".tsx") || entry.endsWith(".mjs")) &&
+        !entry.endsWith(".test.ts") &&
+        !entry.endsWith(".test.tsx") &&
+        !entry.endsWith(".test.mjs") &&
+        !entry.endsWith(".d.ts")
+      ) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+function checkFile(filePath: string): Violation[] {
+  const relPath = relative(PROJECT_ROOT, filePath);
+  if (ALLOWLIST.has(relPath)) return [];
+
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    // Skip commented-out lines and JSDoc.
+    if (
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("*") ||
+      trimmed.startsWith("/*")
+    ) {
+      continue;
+    }
+
+    const match = trimmed.match(FUNCTION_DEF_PATTERN);
+    if (match) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        text: trimmed,
+        symbol: match[1],
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: Violation[] } {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking for stray URL-normalization helpers (QUA-341)...${c.reset}\n`,
+  );
+
+  const allFiles: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    const absDir = join(PROJECT_ROOT, dir);
+    const files = collectFiles(absDir);
+    allFiles.push(...files);
+  }
+
+  if (allFiles.length === 0) {
+    console.log(`${c.dim}No files found to check${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: Violation[] = [];
+  for (const file of allFiles) {
+    allViolations.push(...checkFile(file));
+  }
+
+  if (allViolations.length === 0) {
+    console.log(
+      `${c.green}No stray URL normalizers found (${allFiles.length} files checked)${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${allViolations.length} stray URL normalizer definition(s):${c.reset}\n`,
+    );
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset} — defines ${v.symbol}`);
+      console.log(`    ${c.dim}${v.text}${c.reset}`);
+    }
+    console.log();
+    console.log(
+      `  ${c.dim}Fix: import { normalizeUrl } from "@longterm-wiki/url-utils" and pass options as needed.${c.reset}`,
+    );
+    console.log(
+      `  ${c.dim}     If a thin wrapper is genuinely needed, add the file path to the ALLOWLIST in this validator.${c.reset}`,
+    );
+  }
+
+  return {
+    passed: allViolations.length === 0,
+    errors: allViolations.length,
+    violations: allViolations,
+  };
+}
+
+if (process.argv[1]?.includes("validate-url-normalize")) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-url-normalize.ts
+++ b/crux/validate/validate-url-normalize.ts
@@ -28,25 +28,15 @@ const SCAN_DIRS = [
   "apps/groundskeeper/src",
 ];
 
-/** Files allowed to define their own URL normalizer (re-exports + thin wrappers). */
+/** Files allowed to define their own URL normalizer (canonical + thin wrappers). */
 const ALLOWLIST = new Set<string>([
   // Canonical helper itself.
   "packages/url-utils/src/index.ts",
-  // Backward-compat re-export of the canonical helper under the old name.
-  "crux/lib/sourcing/url-quality.ts",
-  // Thin wrappers that delegate to the canonical helper with preset options.
-  // These wrap to preserve a domain-specific call signature; they do not
-  // re-implement normalization. If you remove the wrapper, remove this entry.
-  "crux/lib/footnote-parser.ts",
-  "crux/lib/search/resource-lookup.ts",
-  "crux/lib/sourcing/fuzzy-match.ts",
-  "apps/web/src/components/wiki/resource-utils.ts",
-  "crux/resource-utils.ts",
-  "apps/web/scripts/lib/unconverted-links.mjs",
-  // Per-command thin wrappers that delegate to the canonical helper with
-  // dedup preset, kept locally so call-sites stay readable.
-  "crux/commands/entity-resources.ts",
-  "apps/web/scripts/build-data.mjs",
+  // Two remaining thin wrappers that change call signature (return string vs
+  // boolean), not just option presets. If you remove either, drop the entry.
+  "crux/lib/search/resource-lookup.ts", // normalizeUrlKey — bounds the cache key
+  "crux/lib/sourcing/fuzzy-match.ts", // urlMatches — boolean comparator
+  "crux/resource-utils.ts", // resourceUrlKey — typed for Resource maps
 ]);
 
 /** Function names that this validator considers URL-normalizers. */
@@ -54,6 +44,7 @@ const BANNED_NAMES = [
   "normalizeUrl",
   "normalizeUrlForJoin",
   "normalizeUrlForDedup",
+  "normalizeUrlForLookup",
   "normalizeUrlForMatch",
   "normalizeUrlKey",
   "urlMatches",

--- a/crux/validate/validate-url-normalize.ts
+++ b/crux/validate/validate-url-normalize.ts
@@ -43,6 +43,10 @@ const ALLOWLIST = new Set<string>([
   "apps/web/src/components/wiki/resource-utils.ts",
   "crux/resource-utils.ts",
   "apps/web/scripts/lib/unconverted-links.mjs",
+  // Per-command thin wrappers that delegate to the canonical helper with
+  // dedup preset, kept locally so call-sites stay readable.
+  "crux/commands/entity-resources.ts",
+  "apps/web/scripts/build-data.mjs",
 ]);
 
 /** Function names that this validator considers URL-normalizers. */
@@ -50,16 +54,15 @@ const BANNED_NAMES = [
   "normalizeUrl",
   "normalizeUrlForJoin",
   "normalizeUrlForDedup",
+  "normalizeUrlForMatch",
   "normalizeUrlKey",
   "urlMatches",
 ];
 
-/** Match `function NAME(`, `const NAME = (`, `const NAME = function(`. */
+/** Match `function NAME(`, `const NAME = ...`, `let NAME = ...`, `var NAME = ...`. */
 const FUNCTION_DEF_PATTERN = new RegExp(
   `\\b(?:function|const|let|var)\\s+(${BANNED_NAMES.join("|")})\\b`,
 );
-
-/** Match `(...): NAME` (returning) — not what we want. The above pattern catches definitions. */
 
 interface Violation {
   file: string;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@aws-sdk/client-s3": "^3.1013.0",
+    "@longterm-wiki/url-utils": "workspace:*",
     "@radix-ui/react-popover": "^1.1.15",
     "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",

--- a/packages/url-utils/package.json
+++ b/packages/url-utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@longterm-wiki/url-utils",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/url-utils/src/index.ts
+++ b/packages/url-utils/src/index.ts
@@ -91,6 +91,29 @@ export function normalizeUrl(raw: string, opts: NormalizeUrlOptions = {}): strin
   return `${scheme}${host}${portSuffix}${path}${qs ? "?" + qs : ""}`;
 }
 
+/**
+ * Canonical URL key for protocol-agnostic dedup / lookup. Strips protocol,
+ * www, fragment, trailing slash, and tracking params. Lowercases the path.
+ *
+ * Two URLs that differ only in scheme, www-prefix, trailing slash, fragment,
+ * tracking params, or path case all collapse to the same key.
+ */
+export function normalizeUrlForDedup(raw: string): string {
+  return normalizeUrl(raw, { stripProtocol: true, lowercasePath: true });
+}
+
+/**
+ * Canonical URL key for resource lookups. Strips protocol, www, fragment,
+ * trailing slash, and tracking params. Sorts query parameters alphabetically
+ * so two URLs with the same params in different order produce the same key.
+ *
+ * Use this when both writer and reader normalize through the same function
+ * (i.e., for in-memory resource Maps and the resource-lookup cache).
+ */
+export function normalizeUrlForLookup(raw: string): string {
+  return normalizeUrl(raw, { stripProtocol: true, sortParams: true });
+}
+
 /** Extract just the host portion, normalized (lowercased, www-stripped). */
 export function extractHost(raw: string): string {
   try {

--- a/packages/url-utils/src/index.ts
+++ b/packages/url-utils/src/index.ts
@@ -1,0 +1,91 @@
+/**
+ * @longterm-wiki/url-utils — Canonical URL normalization for the longterm-wiki system.
+ *
+ * One helper, options when needed. Replaces the historical sprawl of seven
+ * `normalizeUrl`-style functions across crux/, apps/web/, and scripts/, each
+ * with subtly different semantics (QUA-341).
+ *
+ * Default semantics: strip tracking params, fragment, www, trailing slash;
+ * lowercase host; preserve protocol and case-sensitive path.
+ *
+ * Use options for the legitimate variations:
+ *   - `stripProtocol`  — for protocol-agnostic comparison
+ *   - `lowercasePath`  — for case-insensitive dedup
+ *   - `sortParams`     — for deterministic lookup keys
+ *   - `keepTracking`   — for footnote-style dedup that wants the raw query
+ */
+
+const TRACKING_PREFIXES = ["utm_", "mc_", "oly_"];
+const TRACKING_EXACT = new Set(["fbclid", "gclid", "yclid", "msclkid", "_ga"]);
+
+export interface NormalizeUrlOptions {
+  /** Drop the `http://` / `https://` scheme entirely. Default: false. */
+  stripProtocol?: boolean;
+  /** Lowercase the path component (lossy but useful for case-insensitive dedup). Default: false. */
+  lowercasePath?: boolean;
+  /** Sort remaining query parameters alphabetically. Default: false. */
+  sortParams?: boolean;
+  /** Keep tracking parameters (utm_*, fbclid, ...). Default: false (strip them). */
+  keepTracking?: boolean;
+}
+
+/**
+ * Normalize a URL into a stable comparison/lookup key.
+ *
+ * Always: lowercases host, strips `www.` prefix, strips fragment, strips
+ * trailing slash, strips default ports (`:80` for http, `:443` for https),
+ * removes tracking parameters (utm_*, fbclid, gclid, ...) unless
+ * `keepTracking` is set.
+ *
+ * Falls back to a trimmed-lowercased version of the input if it can't be
+ * parsed as a URL — this keeps fuzzy lookups working on malformed inputs.
+ */
+export function normalizeUrl(raw: string, opts: NormalizeUrlOptions = {}): string {
+  const { stripProtocol, lowercasePath, sortParams, keepTracking } = opts;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return raw.trim().replace(/\/+$/, "").toLowerCase();
+  }
+
+  let host = url.hostname.toLowerCase();
+  if (host.startsWith("www.")) host = host.slice(4);
+
+  const portSuffix =
+    url.port === "" ||
+    (url.protocol === "http:" && url.port === "80") ||
+    (url.protocol === "https:" && url.port === "443")
+      ? ""
+      : `:${url.port}`;
+
+  const params = new URLSearchParams();
+  for (const [k, v] of url.searchParams.entries()) {
+    if (!keepTracking) {
+      const keyLower = k.toLowerCase();
+      if (TRACKING_EXACT.has(keyLower)) continue;
+      if (TRACKING_PREFIXES.some((p) => keyLower.startsWith(p))) continue;
+    }
+    params.append(k, v);
+  }
+  if (sortParams) params.sort();
+  const qs = params.toString();
+
+  let path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+  if (lowercasePath) path = path.toLowerCase();
+
+  const scheme = stripProtocol ? "" : `${url.protocol}//`;
+  return `${scheme}${host}${portSuffix}${path}${qs ? "?" + qs : ""}`;
+}
+
+/** Extract just the host portion, normalized (lowercased, www-stripped). */
+export function extractHost(raw: string): string {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    if (host.startsWith("www.")) host = host.slice(4);
+    return host;
+  } catch {
+    return "(invalid-url)";
+  }
+}

--- a/packages/url-utils/src/index.ts
+++ b/packages/url-utils/src/index.ts
@@ -39,6 +39,12 @@ export interface NormalizeUrlOptions {
  *
  * Falls back to a trimmed-lowercased version of the input if it can't be
  * parsed as a URL — this keeps fuzzy lookups working on malformed inputs.
+ *
+ * Non-`http(s):` schemes (e.g., `mailto:`, `javascript:`, `file:`) are passed
+ * through the fallback path. This avoids the open-redirect risk where
+ * `stripProtocol: true` would collapse `javascript:foo` and `https://foo` to
+ * the same key — callers that route normalized output to a redirect / link
+ * rewriter cannot accidentally cross schemes.
  */
 export function normalizeUrl(raw: string, opts: NormalizeUrlOptions = {}): string {
   const { stripProtocol, lowercasePath, sortParams, keepTracking } = opts;
@@ -47,6 +53,12 @@ export function normalizeUrl(raw: string, opts: NormalizeUrlOptions = {}): strin
   try {
     url = new URL(raw);
   } catch {
+    return raw.trim().replace(/\/+$/, "").toLowerCase();
+  }
+
+  // Reject non-http(s) schemes via the fallback path so they cannot collide
+  // with http(s) URLs under stripProtocol: true.
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
     return raw.trim().replace(/\/+$/, "").toLowerCase();
   }
 

--- a/packages/url-utils/tests/index.test.ts
+++ b/packages/url-utils/tests/index.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl, extractHost } from "../src/index.js";
+
+describe("normalizeUrl — defaults", () => {
+  it("strips trailing slash", () => {
+    expect(normalizeUrl("https://example.com/foo/")).toBe("https://example.com/foo");
+    expect(normalizeUrl("https://example.com/foo")).toBe("https://example.com/foo");
+  });
+
+  it("normalizes root path to empty (no trailing slash)", () => {
+    expect(normalizeUrl("https://example.com/")).toBe("https://example.com");
+    expect(normalizeUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("strips www prefix", () => {
+    expect(normalizeUrl("https://www.example.com/foo")).toBe("https://example.com/foo");
+  });
+
+  it("lowercases host but preserves path case", () => {
+    expect(normalizeUrl("https://EXAMPLE.com/FooBar")).toBe("https://example.com/FooBar");
+  });
+
+  it("strips fragment", () => {
+    expect(normalizeUrl("https://example.com/foo#section")).toBe("https://example.com/foo");
+  });
+
+  it("strips tracking parameters", () => {
+    expect(normalizeUrl("https://example.com/?utm_source=x&utm_campaign=y")).toBe("https://example.com");
+    expect(normalizeUrl("https://example.com/foo?fbclid=x&id=42")).toBe("https://example.com/foo?id=42");
+    expect(normalizeUrl("https://example.com/?gclid=abc&msclkid=xyz")).toBe("https://example.com");
+    expect(normalizeUrl("https://example.com/?_ga=foo&yclid=bar")).toBe("https://example.com");
+  });
+
+  it("preserves data params", () => {
+    expect(normalizeUrl("https://example.com/search?q=foo&page=2")).toBe(
+      "https://example.com/search?q=foo&page=2",
+    );
+  });
+
+  it("strips default ports", () => {
+    expect(normalizeUrl("https://example.com:443/foo")).toBe("https://example.com/foo");
+    expect(normalizeUrl("http://example.com:80/foo")).toBe("http://example.com/foo");
+    expect(normalizeUrl("https://example.com:8443/foo")).toBe("https://example.com:8443/foo");
+  });
+
+  it("falls back to lowercased trimmed input on parse failure", () => {
+    expect(normalizeUrl("not a url")).toBe("not a url");
+    expect(normalizeUrl("  GARBAGE  ")).toBe("garbage");
+    expect(normalizeUrl("foo/")).toBe("foo");
+  });
+
+  it("handles empty input gracefully", () => {
+    expect(normalizeUrl("")).toBe("");
+  });
+});
+
+describe("normalizeUrl — stripProtocol", () => {
+  it("drops scheme entirely", () => {
+    expect(normalizeUrl("https://example.com/foo", { stripProtocol: true })).toBe("example.com/foo");
+    expect(normalizeUrl("http://example.com/foo", { stripProtocol: true })).toBe("example.com/foo");
+  });
+
+  it("treats http and https as equal", () => {
+    const a = normalizeUrl("https://anthropic.com", { stripProtocol: true });
+    const b = normalizeUrl("http://anthropic.com", { stripProtocol: true });
+    expect(a).toBe(b);
+  });
+
+  it("treats www and non-www as equal", () => {
+    const a = normalizeUrl("https://www.anthropic.com", { stripProtocol: true });
+    const b = normalizeUrl("https://anthropic.com", { stripProtocol: true });
+    expect(a).toBe(b);
+  });
+
+  it("treats trailing-slash and bare as equal", () => {
+    const a = normalizeUrl("https://anthropic.com/", { stripProtocol: true });
+    const b = normalizeUrl("https://anthropic.com", { stripProtocol: true });
+    expect(a).toBe(b);
+  });
+});
+
+describe("normalizeUrl — lowercasePath", () => {
+  it("lowercases the path component", () => {
+    expect(normalizeUrl("https://EXAMPLE.com/FooBar", { lowercasePath: true })).toBe(
+      "https://example.com/foobar",
+    );
+  });
+
+  it("does not lowercase query values", () => {
+    expect(normalizeUrl("https://example.com/p?q=Foo", { lowercasePath: true })).toBe(
+      "https://example.com/p?q=Foo",
+    );
+  });
+});
+
+describe("normalizeUrl — sortParams", () => {
+  it("sorts remaining params alphabetically", () => {
+    expect(normalizeUrl("https://example.com/?z=1&a=2&m=3", { sortParams: true })).toBe(
+      "https://example.com?a=2&m=3&z=1",
+    );
+  });
+
+  it("sorts after stripping tracking", () => {
+    expect(
+      normalizeUrl("https://example.com/?utm_source=x&z=1&a=2", { sortParams: true }),
+    ).toBe("https://example.com?a=2&z=1");
+  });
+});
+
+describe("normalizeUrl — keepTracking", () => {
+  it("preserves tracking params when requested", () => {
+    expect(normalizeUrl("https://example.com/?utm_source=x", { keepTracking: true })).toBe(
+      "https://example.com?utm_source=x",
+    );
+  });
+});
+
+describe("normalizeUrl — composed options", () => {
+  it("dedup mode (stripProtocol + lowercasePath)", () => {
+    const a = normalizeUrl("https://www.Example.com/PAGE/", {
+      stripProtocol: true,
+      lowercasePath: true,
+    });
+    const b = normalizeUrl("http://example.com/page", {
+      stripProtocol: true,
+      lowercasePath: true,
+    });
+    expect(a).toBe(b);
+    expect(a).toBe("example.com/page");
+  });
+
+  it("lookup-key mode (sortParams)", () => {
+    const a = normalizeUrl("https://example.com/p?b=2&a=1", { sortParams: true });
+    const b = normalizeUrl("https://example.com/p?a=1&b=2", { sortParams: true });
+    expect(a).toBe(b);
+  });
+});
+
+describe("normalizeUrl — adversarial inputs", () => {
+  it("handles URL with only fragment", () => {
+    expect(normalizeUrl("https://example.com/#")).toBe("https://example.com");
+  });
+
+  it("handles URL with only query", () => {
+    expect(normalizeUrl("https://example.com/?")).toBe("https://example.com");
+  });
+
+  it("handles repeated trailing slashes", () => {
+    expect(normalizeUrl("https://example.com/foo///")).toBe("https://example.com/foo");
+  });
+
+  it("handles uppercase protocol", () => {
+    // URL parser already lowercases the protocol — that's just how it works.
+    expect(normalizeUrl("HTTPS://example.com/foo")).toBe("https://example.com/foo");
+  });
+
+  it("preserves non-default ports", () => {
+    expect(normalizeUrl("https://example.com:8443/foo")).toBe("https://example.com:8443/foo");
+  });
+
+  it("handles non-http schemes by passing through host", () => {
+    // ftp://, mailto:, etc. — URL parses but our normalization assumes http(s).
+    // We don't crash; we produce a stable output.
+    const result = normalizeUrl("ftp://example.com/file");
+    expect(result).toContain("example.com");
+  });
+});
+
+describe("extractHost", () => {
+  it("returns lowercased, www-stripped host", () => {
+    expect(extractHost("https://www.Example.com/foo")).toBe("example.com");
+    expect(extractHost("http://api.example.com:8080/")).toBe("api.example.com");
+  });
+
+  it("returns sentinel on invalid input", () => {
+    expect(extractHost("not a url")).toBe("(invalid-url)");
+    expect(extractHost("")).toBe("(invalid-url)");
+  });
+});

--- a/packages/url-utils/tests/index.test.ts
+++ b/packages/url-utils/tests/index.test.ts
@@ -158,11 +158,20 @@ describe("normalizeUrl — adversarial inputs", () => {
     expect(normalizeUrl("https://example.com:8443/foo")).toBe("https://example.com:8443/foo");
   });
 
-  it("handles non-http schemes by passing through host", () => {
-    // ftp://, mailto:, etc. — URL parses but our normalization assumes http(s).
-    // We don't crash; we produce a stable output.
-    const result = normalizeUrl("ftp://example.com/file");
-    expect(result).toContain("example.com");
+  it("routes non-http(s) schemes through the fallback (no scheme collision)", () => {
+    // ftp://, mailto:, javascript: — passed through unchanged via fallback so
+    // they cannot accidentally collide with http(s) URLs under stripProtocol.
+    expect(normalizeUrl("ftp://example.com/file")).toBe("ftp://example.com/file");
+    expect(normalizeUrl("mailto:foo@bar.com")).toBe("mailto:foo@bar.com");
+    expect(normalizeUrl("javascript:alert(1)")).toBe("javascript:alert(1)");
+  });
+
+  it("never collapses non-http(s) and http(s) schemes under stripProtocol", () => {
+    // Critical safety property: even with stripProtocol, javascript:foo and
+    // https://foo must NOT produce the same key.
+    const evil = normalizeUrl("javascript:alert", { stripProtocol: true });
+    const safe = normalizeUrl("https://alert", { stripProtocol: true });
+    expect(evil).not.toBe(safe);
   });
 });
 

--- a/packages/url-utils/tsconfig.json
+++ b/packages/url-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1013.0
         version: 3.1013.0
+      '@longterm-wiki/url-utils':
+        specifier: workspace:*
+        version: link:packages/url-utils
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -179,6 +182,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/url-utils':
+        specifier: workspace:*
+        version: link:../../packages/url-utils
       '@quri/squiggle-components':
         specifier: ^0.10.0
         version: 0.10.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -394,6 +400,15 @@ importers:
         version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/id-utils:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.0.18(@types/node@22.19.10)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/url-utils:
     devDependencies:
       typescript:
         specifier: ^5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - "apps/groundskeeper"
   - "packages/factbase"
   - "packages/id-utils"
+  - "packages/url-utils"


### PR DESCRIPTION
## Summary

Consolidates 7 separate `normalizeUrl`-style helpers across `crux/`, `apps/web/`, and `apps/web/scripts/` into a single canonical helper in a new workspace package `@longterm-wiki/url-utils` with named presets (`normalizeUrlForDedup`, `normalizeUrlForLookup`). Adds a blocking gate validator that rejects new local definitions outside an explicit allowlist of thin wrappers.

## Background

Per the [Resources Infrastructure plan](https://linear.app/quantifieduncertainty/issue/QUA-341) rescope, this is critical-path P1 — must land before V1/V2 (data-source detail pages) so those pages don't render duplicate resources under different normalized URLs. Also blocks the dedup job (plan gap P5).

## What changed

- **New package** `packages/url-utils/` with one canonical `normalizeUrl(url, opts?)` plus two named presets
- **Migrated 7 helpers** to wrap or directly call the canonical helper:
  - `crux/lib/sourcing/url-quality.ts::normalizeUrlForJoin` → re-export
  - `crux/lib/sourcing/fuzzy-match.ts::urlMatches` → wraps canonical
  - `crux/lib/footnote-parser.ts::normalizeUrlForDedup` → re-export
  - `crux/lib/search/resource-lookup.ts::normalizeUrlKey` → wraps canonical
  - `apps/web/src/components/wiki/resource-utils.ts::normalizeUrl` → re-export
  - `crux/resource-utils.ts::normalizeUrl` (variant generator) → replaced with `resourceUrlKey` + `lookupResourceByUrl` (normalize-on-both-sides instead of writing 4 keys per resource)
  - `apps/web/scripts/lib/unconverted-links.mjs` → re-exports from `crux/resource-utils.ts`
- **Inlined two `normalizeUrlForMatch` wrappers** found by review (not in original 7 — added once detected)
- **Added blocking gate validator** `crux/validate/validate-url-normalize.ts` — `BANNED_NAMES` includes all 7 historical names; ALLOWLIST has 4 entries (canonical + 3 wrappers that change call signature)
- **Open-redirect hardening**: canonical helper now routes non-`http(s):` schemes through the fallback so `javascript:foo` cannot collide with `https://foo` under `stripProtocol`

## Bug caught by review (would have shipped without the hostile-reviewer pass)

The first commit broke 4 lookup-map call-sites that called `Map.get(rawUrl)` against a now-canonical-keyed map. The most serious would have silently broken the production `pageResources` index in `build-data.mjs` (markdown link → resource ID matching). Three other call-sites in `register-resources.ts`, `resource-manager.ts`, and `parseFootnoteSources` had the same shape. All fixed in commit `c619dfd`.

## Test plan

- [x] `pnpm test` (apps/web) — 1584/1584 pass
- [x] `pnpm test:crux` — 6508/6508 pass (added 14 new tests: resource-utils ×8, urlMatches ×3, getResourceByUrl ×1, non-http safety ×2)
- [x] `pnpm test` in `packages/url-utils` — 30/30 pass covering each option combination + adversarial inputs (`mailto:`, `javascript:`, `ftp:`, scheme collision under stripProtocol)
- [x] `pnpm crux w validate gate --fix` — all 46 checks pass
- [x] `pnpm build` (apps/web) — 2192 pages prerender
- [x] `pnpm sync:data:content` — pipeline runs end-to-end without crashes
- [x] `npx tsx crux/validate/validate-url-normalize.ts` standalone — 0 violations across 1528 files

## Related

- QUA-332 / PR #4239 — first consumer consolidated (`suggest-urls.ts`)
- QUA-312 — original `normalizeUrlForJoin` extraction
- QUA-560 — pre-existing flake discovered en route: `id-client.test.mjs` fails when `WIKI_SERVER_ENV=prod` is exported (filed separately, not addressed here)

Fixes QUA-341


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"`
<!-- /deploy-tasks -->