### PR TITLE
feat(research): per-type research playbooks (QUA-33)

### DIFF
--- a/crux/authoring/page-improver/phases/analyze.ts
+++ b/crux/authoring/page-improver/phases/analyze.ts
@@ -13,6 +13,7 @@ import { runAgent } from '../api.ts';
 import { parseJsonFromLlm } from './json-parsing.ts';
 import { resolveTemplate, formatTemplateForPrompt } from '../../../lib/content/page-templates.ts';
 import { getPageType } from '../../../lib/page-analysis.ts';
+import { loadPlaybook, formatPlaybookForPrompt } from '../../../lib/research-playbooks.ts';
 
 export async function analyzePhase(page: PageData, directions: string, options: PipelineOptions): Promise<AnalysisResult> {
   log('analyze', 'Starting analysis');
@@ -29,6 +30,17 @@ export async function analyzePhase(page: PageData, directions: string, options: 
   const templateSection = template
     ? `\n## Template Requirements\nThis page should follow the **${template.name}** template. When analyzing gaps, check whether required sections are present.\n\n${formatTemplateForPrompt(template)}\n`
     : '';
+
+  // Per-type research playbook (QUA-33): inject source recommendations and
+  // standard data points so researchNeeded topics are playbook-aware. Pulled
+  // from the page's entityType (e.g. "organization", "person").
+  const playbook = loadPlaybook(page.entityType);
+  const playbookSection = playbook
+    ? `\n## Research Playbook for \`${playbook.entityType}\`\nUse this playbook to decide which research topics to propose. Favor facts from the standard checklist that are missing from the page, and prefer sources listed here over ad-hoc web search.\n\n${formatPlaybookForPrompt(playbook)}\n`
+    : '';
+  if (playbook) {
+    log('analyze', `Loaded research playbook for entityType="${playbook.entityType}"`);
+  }
 
   const prompt = `Analyze this wiki page for improvement opportunities.
 
@@ -47,7 +59,7 @@ ${directions || 'No specific directions provided - do a general quality improvem
 ${currentContent}
 \`\`\`
 
-${templateSection}## Analysis Required
+${templateSection}${playbookSection}## Analysis Required
 
 Analyze the page and output a JSON object with:
 

--- a/crux/authoring/page-improver/phases/research.ts
+++ b/crux/authoring/page-improver/phases/research.ts
@@ -15,6 +15,7 @@ import type { PageData, AnalysisResult, ResearchResult, PipelineOptions } from '
 import { log, writeTemp } from '../utils.ts';
 import { runAgent } from '../api.ts';
 import { parseAndValidate, ResearchResultSchema } from './json-parsing.ts';
+import { loadPlaybook, formatPlaybookForPrompt } from '../../../lib/research-playbooks.ts';
 
 /**
  * Convert research sources + fetched content into SourceCacheEntry[] for
@@ -138,11 +139,22 @@ export async function researchPhase(page: PageData, analysis: AnalysisResult, op
     return { sources: [] };
   }
 
+  // Per-type research playbook (QUA-33): inject source recommendations so the
+  // research agent prefers authoritative primary sources (SEC, institutional
+  // profiles) over generic web search results.
+  const playbook = loadPlaybook(page.entityType);
+  const playbookSection = playbook
+    ? `\n## Research Playbook for \`${playbook.entityType}\`\nPrefer these sources over generic web search where applicable, and be wary of the listed pitfalls.\n\n${formatPlaybookForPrompt(playbook)}\n`
+    : '';
+  if (playbook) {
+    log('research', `Loaded research playbook for entityType="${playbook.entityType}"`);
+  }
+
   const prompt = `Research the following topics to improve a wiki page about "${page.title}".
 
 ## Topics to Research
 ${topics.map((t, i) => `${i + 1}. ${t}`).join('\n')}
-
+${playbookSection}
 ## Research Instructions
 
 For each topic:

--- a/crux/commands/context.ts
+++ b/crux/commands/context.ts
@@ -46,6 +46,7 @@ import { githubApi, REPO } from '../lib/github.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { type CommandResult, parseIntOpt } from '../lib/cli.ts';
 import { buildKbContextForPage } from '../lib/factbase-context.ts';
+import { loadPlaybook, formatPlaybookMarkdown } from '../lib/research-playbooks.ts';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -470,6 +471,12 @@ async function forEntity(
     };
   }
 
+  const e = entityResult.data;
+
+  // Per-type research playbook (QUA-33): guidance on which sources to use,
+  // standard facts to gather, and common pitfalls for this entity type.
+  const playbook = loadPlaybook(e.entityType);
+
   // --json / --ci: return structured data as JSON (to stdout)
   if (options.json) {
     const jsonData = {
@@ -478,14 +485,19 @@ async function forEntity(
       entity: entityResult.data,
       facts: factsResult.ok ? factsResult.data : null,
       pages: pageSearchResult.ok ? pageSearchResult.data : null,
+      playbook,
     };
     return { output: JSON.stringify(jsonData, null, 2), exitCode: 0 };
   }
 
-  const e = entityResult.data;
   let bundle = mdHeader(`Entity: ${e.title}`, 'for-entity', [entityId]);
   bundle += entityBlock(e);
   bundle += '---\n\n';
+
+  if (playbook) {
+    bundle += formatPlaybookMarkdown(playbook);
+    bundle += '---\n\n';
+  }
 
   if (factsResult.ok && factsResult.data.facts.length > 0) {
     bundle += factsBlock(factsResult.data.facts);
@@ -546,6 +558,7 @@ async function forEntity(
   const summary = [
     `${c.green}✓${c.reset} Context bundle written to ${c.cyan}${outputPath}${c.reset}`,
     `  Entity: ${e.title} (${entityId}) [${e.entityType}]`,
+    playbook ? `  Research playbook: ${playbook.entityType} (${playbook.sources.length} sources)` : '',
     factsResult.ok ? `  Facts: ${factsResult.data.facts.length}` : '',
     kbContext ? `  KB structured facts: included` : '',
     pageSearchResult.ok ? `  Pages mentioning entity: ${pageSearchResult.data.results.length}` : '',

--- a/crux/lib/__tests__/research-playbooks.test.ts
+++ b/crux/lib/__tests__/research-playbooks.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  canonicalizeEntityType,
+  loadPlaybook,
+  listPlaybookTypes,
+  formatPlaybookMarkdown,
+  formatPlaybookForPrompt,
+  PLAYBOOKS_DIR,
+  type ResearchPlaybook,
+} from '../research-playbooks.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_YAML = `
+entityType: organization
+description: Test playbook for orgs.
+checklist:
+  - Founding year
+  - Headcount
+sources:
+  - name: Crunchbase
+    reliability: medium
+    covers: [funding, investors]
+    pitfalls:
+      - Headcount is stale
+  - name: SEC EDGAR
+    reliability: very-high
+    covers: [financials]
+    applies_when: publicly traded
+common_pitfalls:
+  - Conflating parent and subsidiary
+research_order:
+  - Start with official site
+  - Cross-reference aggregators
+`;
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'playbooks-test-'));
+}
+
+function writePlaybook(dir: string, name: string, content: string): void {
+  fs.writeFileSync(path.join(dir, `${name}.yaml`), content, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// canonicalizeEntityType
+// ---------------------------------------------------------------------------
+
+describe('canonicalizeEntityType', () => {
+  it('returns null for empty / whitespace / null / undefined input', () => {
+    expect(canonicalizeEntityType(null)).toBeNull();
+    expect(canonicalizeEntityType(undefined)).toBeNull();
+    expect(canonicalizeEntityType('')).toBeNull();
+    expect(canonicalizeEntityType('   ')).toBeNull();
+  });
+
+  it('passes through canonical types unchanged', () => {
+    expect(canonicalizeEntityType('organization')).toBe('organization');
+    expect(canonicalizeEntityType('person')).toBe('person');
+    expect(canonicalizeEntityType('ai-model')).toBe('ai-model');
+  });
+
+  it('resolves common aliases to canonical form', () => {
+    expect(canonicalizeEntityType('researcher')).toBe('person');
+    expect(canonicalizeEntityType('lab')).toBe('organization');
+    expect(canonicalizeEntityType('lab-frontier')).toBe('organization');
+    expect(canonicalizeEntityType('funder')).toBe('organization');
+  });
+
+  it('trims surrounding whitespace before lookup', () => {
+    expect(canonicalizeEntityType('  person  ')).toBe('person');
+    expect(canonicalizeEntityType('  researcher  ')).toBe('person');
+  });
+
+  it('returns the unknown type unchanged when it is not an alias', () => {
+    // Unknown types pass through so callers can detect "no playbook" via loadPlaybook.
+    expect(canonicalizeEntityType('widget')).toBe('widget');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPlaybook
+// ---------------------------------------------------------------------------
+
+describe('loadPlaybook', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the playbook file does not exist', () => {
+    expect(loadPlaybook('organization', { dir: tmpDir })).toBeNull();
+  });
+
+  it('returns null for empty or nullish entity types', () => {
+    expect(loadPlaybook(null, { dir: tmpDir })).toBeNull();
+    expect(loadPlaybook(undefined, { dir: tmpDir })).toBeNull();
+    expect(loadPlaybook('', { dir: tmpDir })).toBeNull();
+  });
+
+  it('loads and validates a well-formed playbook', () => {
+    writePlaybook(tmpDir, 'organization', VALID_YAML);
+    const pb = loadPlaybook('organization', { dir: tmpDir });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('organization');
+    expect(pb!.checklist).toEqual(['Founding year', 'Headcount']);
+    expect(pb!.sources).toHaveLength(2);
+    expect(pb!.sources[0].name).toBe('Crunchbase');
+    expect(pb!.sources[0].reliability).toBe('medium');
+    expect(pb!.sources[0].covers).toEqual(['funding', 'investors']);
+    expect(pb!.sources[1].applies_when).toBe('publicly traded');
+    expect(pb!.common_pitfalls).toEqual(['Conflating parent and subsidiary']);
+    expect(pb!.research_order).toHaveLength(2);
+  });
+
+  it('defaults common_pitfalls and research_order to empty arrays when missing', () => {
+    writePlaybook(
+      tmpDir,
+      'minimal',
+      `
+entityType: minimal
+description: Minimal playbook.
+checklist: [One fact]
+sources:
+  - name: Some source
+    reliability: high
+    covers: [everything]
+`,
+    );
+    const pb = loadPlaybook('minimal', { dir: tmpDir });
+    expect(pb).not.toBeNull();
+    expect(pb!.common_pitfalls).toEqual([]);
+    expect(pb!.research_order).toEqual([]);
+  });
+
+  it('canonicalizes aliases before lookup (researcher → person)', () => {
+    writePlaybook(tmpDir, 'person', VALID_YAML.replace('organization', 'person'));
+    const pb = loadPlaybook('researcher', { dir: tmpDir });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('person');
+  });
+
+  it('canonicalizes aliases before lookup (lab-frontier → organization)', () => {
+    writePlaybook(tmpDir, 'organization', VALID_YAML);
+    const pb = loadPlaybook('lab-frontier', { dir: tmpDir });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('organization');
+  });
+
+  it('returns null for malformed YAML (syntax error) without throwing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writePlaybook(tmpDir, 'organization', '::: not valid yaml :::\n  - oops');
+    const pb = loadPlaybook('organization', { dir: tmpDir });
+    expect(pb).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when YAML is valid but violates the schema', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writePlaybook(
+      tmpDir,
+      'organization',
+      `
+entityType: organization
+description: Missing required fields.
+`,
+    );
+    const pb = loadPlaybook('organization', { dir: tmpDir });
+    expect(pb).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('rejects a source with an invalid reliability value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writePlaybook(
+      tmpDir,
+      'organization',
+      `
+entityType: organization
+description: Test.
+checklist: [X]
+sources:
+  - name: Bad source
+    reliability: mediocre
+    covers: [foo]
+`,
+    );
+    expect(loadPlaybook('organization', { dir: tmpDir })).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('rejects a playbook with empty checklist or sources arrays', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writePlaybook(
+      tmpDir,
+      'organization',
+      `
+entityType: organization
+description: Empty lists.
+checklist: []
+sources: []
+`,
+    );
+    expect(loadPlaybook('organization', { dir: tmpDir })).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it('warns when file entityType disagrees with the resolved canonical key but still loads', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // File is named organization.yaml but declares a different entityType.
+    writePlaybook(tmpDir, 'organization', VALID_YAML.replace('entityType: organization', 'entityType: project'));
+    const pb = loadPlaybook('organization', { dir: tmpDir });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('project');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('entityType mismatch'));
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPlaybookTypes
+// ---------------------------------------------------------------------------
+
+describe('listPlaybookTypes', () => {
+  it('returns [] for a non-existent directory', () => {
+    const tmpDir = path.join(os.tmpdir(), `definitely-missing-${Date.now()}`);
+    expect(listPlaybookTypes({ dir: tmpDir })).toEqual([]);
+  });
+
+  it('returns the canonical names of all .yaml files, sorted', () => {
+    const tmpDir = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'organization.yaml'), '');
+      fs.writeFileSync(path.join(tmpDir, 'person.yaml'), '');
+      fs.writeFileSync(path.join(tmpDir, 'README.md'), ''); // filtered out
+      fs.writeFileSync(path.join(tmpDir, 'ai-model.yaml'), '');
+      expect(listPlaybookTypes({ dir: tmpDir })).toEqual(['ai-model', 'organization', 'person']);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const SAMPLE_PLAYBOOK: ResearchPlaybook = {
+  entityType: 'organization',
+  description: 'Sample description.',
+  checklist: ['Founding year', 'Total funding'],
+  sources: [
+    {
+      name: 'Crunchbase',
+      reliability: 'medium',
+      covers: ['funding', 'investors'],
+      pitfalls: ['Headcount is stale'],
+    },
+    {
+      name: 'SEC EDGAR',
+      reliability: 'very-high',
+      covers: ['financials'],
+      applies_when: 'publicly traded',
+    },
+  ],
+  common_pitfalls: ['Parent vs subsidiary confusion'],
+  research_order: ['Step 1', 'Step 2'],
+};
+
+describe('formatPlaybookMarkdown', () => {
+  it('renders all sections present in the playbook', () => {
+    const md = formatPlaybookMarkdown(SAMPLE_PLAYBOOK);
+    expect(md).toContain('## Research Playbook: organization');
+    expect(md).toContain('Sample description.');
+    expect(md).toContain('### Standard Checklist');
+    expect(md).toContain('- Founding year');
+    expect(md).toContain('### Recommended Sources');
+    expect(md).toContain('| Crunchbase | medium |');
+    expect(md).toContain('Headcount is stale');
+    expect(md).toContain('_when_: publicly traded');
+    expect(md).toContain('### Recommended Research Order');
+    expect(md).toContain('1. Step 1');
+    expect(md).toContain('### Common Pitfalls');
+    expect(md).toContain('- Parent vs subsidiary confusion');
+  });
+
+  it('omits optional sections when arrays are empty', () => {
+    const md = formatPlaybookMarkdown({
+      ...SAMPLE_PLAYBOOK,
+      common_pitfalls: [],
+      research_order: [],
+    });
+    expect(md).not.toContain('Recommended Research Order');
+    expect(md).not.toContain('Common Pitfalls');
+  });
+
+  it('escapes pipe characters in table cells', () => {
+    const md = formatPlaybookMarkdown({
+      ...SAMPLE_PLAYBOOK,
+      sources: [
+        {
+          name: 'Weird | Source',
+          reliability: 'high',
+          covers: ['a | b'],
+        },
+      ],
+    });
+    expect(md).toContain('Weird \\| Source');
+    expect(md).toContain('a \\| b');
+  });
+});
+
+describe('formatPlaybookForPrompt', () => {
+  it('includes all core sections in compact form', () => {
+    const prompt = formatPlaybookForPrompt(SAMPLE_PLAYBOOK);
+    expect(prompt).toContain('# Research Playbook: organization');
+    expect(prompt).toContain('Sample description.');
+    expect(prompt).toContain('## Standard data points to gather');
+    expect(prompt).toContain('- Founding year');
+    expect(prompt).toContain('## Recommended sources (in priority order)');
+    expect(prompt).toContain('**Crunchbase** (medium)');
+    expect(prompt).toContain('**SEC EDGAR** (very-high)');
+    expect(prompt).toContain('[publicly traded]');
+    expect(prompt).toContain('pitfall: Headcount is stale');
+    expect(prompt).toContain('## Recommended research order');
+    expect(prompt).toContain('1. Step 1');
+    expect(prompt).toContain('## Common pitfalls to avoid');
+  });
+
+  it('is shorter than the markdown variant for the same input', () => {
+    const prompt = formatPlaybookForPrompt(SAMPLE_PLAYBOOK);
+    const md = formatPlaybookMarkdown(SAMPLE_PLAYBOOK);
+    // Prompt form skips the table scaffolding, so it should be noticeably shorter.
+    expect(prompt.length).toBeLessThan(md.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: the real repo playbooks must parse cleanly
+// ---------------------------------------------------------------------------
+
+describe('checked-in playbooks', () => {
+  it('organization.yaml loads and has the expected shape', () => {
+    const pb = loadPlaybook('organization', { dir: PLAYBOOKS_DIR });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('organization');
+    expect(pb!.sources.length).toBeGreaterThan(0);
+    expect(pb!.checklist.length).toBeGreaterThan(0);
+  });
+
+  it('person.yaml loads and has the expected shape', () => {
+    const pb = loadPlaybook('person', { dir: PLAYBOOKS_DIR });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('person');
+    expect(pb!.sources.length).toBeGreaterThan(0);
+    expect(pb!.checklist.length).toBeGreaterThan(0);
+  });
+
+  it('researcher alias resolves to person via loadPlaybook', () => {
+    const pb = loadPlaybook('researcher', { dir: PLAYBOOKS_DIR });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('person');
+  });
+
+  it('lab-frontier alias resolves to organization via loadPlaybook', () => {
+    const pb = loadPlaybook('lab-frontier', { dir: PLAYBOOKS_DIR });
+    expect(pb).not.toBeNull();
+    expect(pb!.entityType).toBe('organization');
+  });
+});

--- a/crux/lib/__tests__/research-playbooks.test.ts
+++ b/crux/lib/__tests__/research-playbooks.test.ts
@@ -81,6 +81,16 @@ describe('canonicalizeEntityType', () => {
     // Unknown types pass through so callers can detect "no playbook" via loadPlaybook.
     expect(canonicalizeEntityType('widget')).toBe('widget');
   });
+
+  it('rejects path-traversal and unsafe filesystem characters', () => {
+    expect(canonicalizeEntityType('../etc/passwd')).toBeNull();
+    expect(canonicalizeEntityType('../../foo')).toBeNull();
+    expect(canonicalizeEntityType('foo/bar')).toBeNull();
+    expect(canonicalizeEntityType('.hidden')).toBeNull();
+    expect(canonicalizeEntityType('foo\\bar')).toBeNull();
+    expect(canonicalizeEntityType('Organization')).toBeNull(); // uppercase rejected
+    expect(canonicalizeEntityType('foo bar')).toBeNull();      // space rejected
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/lib/research-playbooks.ts
+++ b/crux/lib/research-playbooks.ts
@@ -1,0 +1,222 @@
+/**
+ * Research Playbooks
+ *
+ * Per-type guidance for entity research. Each playbook (e.g.
+ * `data/research-playbooks/organization.yaml`) codifies generic research
+ * recipes — recommended sources, reliability ratings, common pitfalls,
+ * standard data points — so agents don't rediscover the same knowledge
+ * every session.
+ *
+ * Consumed by:
+ *   - `crux context for-entity` (injects playbook into the context bundle)
+ *   - `crux content improve` analyze phase (injects playbook into the LLM
+ *     prompt so generated researchNeeded topics are playbook-aware)
+ *
+ * See QUA-33 and discussion in PR #2997.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { z } from 'zod';
+import { parse as parseYaml } from 'yaml';
+import { PROJECT_ROOT } from './content-types.ts';
+import { ENTITY_TYPE_ALIASES } from '../../apps/web/src/data/entity-type-names.ts';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const Reliability = z.enum(['very-high', 'high', 'medium', 'low']);
+export type Reliability = z.infer<typeof Reliability>;
+
+export const PlaybookSourceSchema = z.object({
+  name: z.string().min(1),
+  reliability: Reliability,
+  covers: z.array(z.string().min(1)).min(1),
+  url_pattern: z.string().optional(),
+  applies_when: z.string().optional(),
+  pitfalls: z.array(z.string().min(1)).optional(),
+});
+export type PlaybookSource = z.infer<typeof PlaybookSourceSchema>;
+
+export const ResearchPlaybookSchema = z.object({
+  entityType: z.string().min(1),
+  description: z.string().min(1),
+  sources: z.array(PlaybookSourceSchema).min(1),
+  checklist: z.array(z.string().min(1)).min(1),
+  common_pitfalls: z.array(z.string().min(1)).default([]),
+  research_order: z.array(z.string().min(1)).default([]),
+});
+export type ResearchPlaybook = z.infer<typeof ResearchPlaybookSchema>;
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export const PLAYBOOKS_DIR = path.join(PROJECT_ROOT, 'data/research-playbooks');
+
+/**
+ * Normalize an entity type string to its canonical form.
+ * Handles aliases like "researcher" → "person", "lab-frontier" → "organization".
+ * Returns null for empty input.
+ */
+export function canonicalizeEntityType(entityType: string | null | undefined): string | null {
+  if (!entityType) return null;
+  const trimmed = entityType.trim();
+  if (!trimmed) return null;
+  return ENTITY_TYPE_ALIASES[trimmed] ?? trimmed;
+}
+
+/**
+ * Load the research playbook for the given entity type, canonicalizing aliases.
+ * Returns null if no playbook exists or the file is malformed.
+ *
+ * Validation errors are logged to stderr but do not throw — a broken playbook
+ * should not break the pipeline; it should just be ignored.
+ */
+export function loadPlaybook(
+  entityType: string | null | undefined,
+  opts: { dir?: string } = {},
+): ResearchPlaybook | null {
+  const canonical = canonicalizeEntityType(entityType);
+  if (!canonical) return null;
+  const dir = opts.dir ?? PLAYBOOKS_DIR;
+  const filePath = path.join(dir, `${canonical}.yaml`);
+  if (!existsSync(filePath)) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[research-playbooks] Failed to read ${filePath}: ${msg}`);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[research-playbooks] Malformed YAML in ${filePath}: ${msg}`);
+    return null;
+  }
+
+  const validated = ResearchPlaybookSchema.safeParse(parsed);
+  if (!validated.success) {
+    console.warn(
+      `[research-playbooks] Schema validation failed for ${filePath}: ${validated.error.message}`,
+    );
+    return null;
+  }
+
+  if (validated.data.entityType !== canonical) {
+    console.warn(
+      `[research-playbooks] entityType mismatch in ${filePath}: ` +
+        `file declares "${validated.data.entityType}" but resolves to "${canonical}"`,
+    );
+  }
+
+  return validated.data;
+}
+
+/**
+ * List all entity types that have a playbook (reading from disk).
+ * Returns canonical entity type names.
+ */
+export function listPlaybookTypes(opts: { dir?: string } = {}): string[] {
+  const dir = opts.dir ?? PLAYBOOKS_DIR;
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.yaml'))
+    .map((f) => f.replace(/\.yaml$/, ''))
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a playbook as a markdown section for the context bundle
+ * (`.claude/wip-context.md`). Designed to be scannable by a human agent.
+ */
+export function formatPlaybookMarkdown(playbook: ResearchPlaybook): string {
+  let md = `## Research Playbook: ${playbook.entityType}\n\n`;
+  md += `${playbook.description}\n\n`;
+
+  md += `### Standard Checklist\n\n`;
+  for (const item of playbook.checklist) md += `- ${item}\n`;
+  md += '\n';
+
+  md += `### Recommended Sources\n\n`;
+  md += '| Source | Reliability | Covers | Notes |\n';
+  md += '|--------|-------------|--------|-------|\n';
+  for (const s of playbook.sources) {
+    const covers = s.covers.join(', ');
+    const notes: string[] = [];
+    if (s.applies_when) notes.push(`_when_: ${s.applies_when}`);
+    if (s.pitfalls && s.pitfalls.length > 0) notes.push(`⚠ ${s.pitfalls[0]}`);
+    md += `| ${escapeCell(s.name)} | ${s.reliability} | ${escapeCell(covers)} | ${escapeCell(notes.join('; '))} |\n`;
+  }
+  md += '\n';
+
+  if (playbook.research_order.length > 0) {
+    md += `### Recommended Research Order\n\n`;
+    playbook.research_order.forEach((step, i) => {
+      md += `${i + 1}. ${step}\n`;
+    });
+    md += '\n';
+  }
+
+  if (playbook.common_pitfalls.length > 0) {
+    md += `### Common Pitfalls\n\n`;
+    for (const p of playbook.common_pitfalls) md += `- ${p}\n`;
+    md += '\n';
+  }
+
+  return md;
+}
+
+/**
+ * Format a playbook as a compact prompt section for LLM consumption.
+ * Intentionally more terse than the markdown variant to conserve tokens.
+ */
+export function formatPlaybookForPrompt(playbook: ResearchPlaybook): string {
+  const lines: string[] = [];
+  lines.push(`# Research Playbook: ${playbook.entityType}`);
+  lines.push('');
+  lines.push(playbook.description);
+  lines.push('');
+
+  lines.push('## Standard data points to gather');
+  for (const item of playbook.checklist) lines.push(`- ${item}`);
+  lines.push('');
+
+  lines.push('## Recommended sources (in priority order)');
+  for (const s of playbook.sources) {
+    const coversStr = s.covers.join(', ');
+    const when = s.applies_when ? ` [${s.applies_when}]` : '';
+    lines.push(`- **${s.name}** (${s.reliability}) — covers: ${coversStr}${when}`);
+    for (const p of s.pitfalls ?? []) lines.push(`  - pitfall: ${p}`);
+  }
+  lines.push('');
+
+  if (playbook.research_order.length > 0) {
+    lines.push('## Recommended research order');
+    playbook.research_order.forEach((step, i) => lines.push(`${i + 1}. ${step}`));
+    lines.push('');
+  }
+
+  if (playbook.common_pitfalls.length > 0) {
+    lines.push('## Common pitfalls to avoid');
+    for (const p of playbook.common_pitfalls) lines.push(`- ${p}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function escapeCell(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}

--- a/crux/lib/research-playbooks.ts
+++ b/crux/lib/research-playbooks.ts
@@ -55,16 +55,23 @@ export type ResearchPlaybook = z.infer<typeof ResearchPlaybookSchema>;
 
 export const PLAYBOOKS_DIR = path.join(PROJECT_ROOT, 'data/research-playbooks');
 
+// Path-safe entity type: lowercase alphanumerics + hyphens only. Used as a
+// filesystem guard against path traversal via crafted entityType values.
+const SAFE_ENTITY_TYPE_RE = /^[a-z0-9][a-z0-9-]*$/;
+
 /**
  * Normalize an entity type string to its canonical form.
  * Handles aliases like "researcher" → "person", "lab-frontier" → "organization".
- * Returns null for empty input.
+ * Returns null for empty input or any value that isn't path-safe (prevents
+ * filename traversal in loadPlaybook).
  */
 export function canonicalizeEntityType(entityType: string | null | undefined): string | null {
   if (!entityType) return null;
   const trimmed = entityType.trim();
   if (!trimmed) return null;
-  return ENTITY_TYPE_ALIASES[trimmed] ?? trimmed;
+  const canonical = ENTITY_TYPE_ALIASES[trimmed] ?? trimmed;
+  if (!SAFE_ENTITY_TYPE_RE.test(canonical)) return null;
+  return canonical;
 }
 
 /**

--- a/data/research-playbooks/organization.yaml
+++ b/data/research-playbooks/organization.yaml
@@ -1,0 +1,103 @@
+# Research playbook for organizations (companies, labs, nonprofits, academic groups).
+# Consumed by `crux context for-entity` and the `crux content improve` analyze phase.
+# See QUA-33.
+
+entityType: organization
+
+description: >
+  Organizations encompass AI labs (frontier and academic), nonprofits, funders,
+  government bodies, and commercial companies. Facts drift quickly — headcounts
+  change, orgs restructure, funding rounds add layers. Prefer primary sources
+  (org website, SEC, regulatory filings) over aggregators, and always record
+  "as of" dates.
+
+checklist:
+  - "Founding year and location"
+  - "Legal structure (for-profit, nonprofit, academic, government, public benefit)"
+  - "Current headcount (approximate, with as-of date)"
+  - "Total funding or budget (most recent disclosed figure)"
+  - "Most recent funding round (date, amount, lead investor) if applicable"
+  - "Key leadership: CEO/ED, CTO, founders, board members"
+  - "Parent organization or major subsidiaries"
+  - "Mission or primary research focus"
+  - "Major products, services, or research outputs"
+  - "Geographic footprint (primary office(s), remote stance)"
+  - "Recent material news within the last 12 months"
+
+sources:
+  - name: "Official organization website (/about, /team, /research, /careers)"
+    reliability: high
+    covers: [mission, leadership, legal-structure, primary-focus, office-locations]
+    pitfalls:
+      - "Forward-looking and promotional tone — extract facts, not framing"
+      - "Stale for orgs in transition (recent restructures may not be reflected)"
+  - name: "Crunchbase"
+    url_pattern: "crunchbase.com/organization/{slug}"
+    reliability: medium
+    covers: [funding-rounds, investors, founding-year, acquisitions]
+    pitfalls:
+      - "Free tier hides most funding round detail; paid tier or cached Google result often needed"
+      - "Headcount estimates are scraped and frequently stale"
+      - "Merger/acquisition history can lag by months"
+  - name: "SEC EDGAR (10-K, S-1, 8-K)"
+    url_pattern: "sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={ticker-or-cik}"
+    reliability: very-high
+    covers: [financials, executive-compensation, risk-factors, funding-rounds, material-events]
+    applies_when: "Organization is US-publicly-traded or filed an S-1/S-4"
+    pitfalls:
+      - "Only covers public companies and certain regulated filers"
+      - "Fiscal year may differ from calendar year"
+  - name: "LinkedIn company page"
+    url_pattern: "linkedin.com/company/{slug}"
+    reliability: low
+    covers: [headcount-estimate, industry-classification, office-locations]
+    pitfalls:
+      - "Employee counts are inflated — includes alumni, consultants, and loosely-affiliated contractors"
+      - "Some organizations maintain multiple pages; pick the one linked from the official site"
+      - "Industry classifications are too coarse to be useful"
+  - name: "PitchBook / CB Insights"
+    reliability: high
+    covers: [funding-rounds, valuation, investors, competitive-positioning]
+    applies_when: "Organization is venture-funded or private-equity-backed"
+    pitfalls:
+      - "Paywalled — often inaccessible without institutional access"
+      - "Valuations are self-reported and can lag by quarters"
+  - name: "Companies House (UK) / equivalent national registries"
+    reliability: very-high
+    covers: [legal-structure, directors, registered-address, filings-history]
+    applies_when: "Organization is registered in a jurisdiction with public company registries (UK, EU, etc.)"
+  - name: "Charity Navigator / GuideStar / nonprofit IRS 990"
+    reliability: high
+    covers: [revenue, expenses, executive-compensation, program-spending, major-donors]
+    applies_when: "Organization is a US 501(c)(3) or comparable nonprofit"
+    pitfalls:
+      - "990s lag by 12-18 months from the reporting year"
+  - name: "Wikipedia"
+    reliability: medium
+    covers: [history, leadership, general-overview]
+    pitfalls:
+      - "Quality varies wildly; verify the cited primary sources rather than trusting the article"
+      - "Can lag recent events by weeks to months"
+  - name: "Recent news (org blog, press releases, tech press)"
+    reliability: medium
+    covers: [recent-announcements, product-launches, funding-announcements, personnel-changes]
+    pitfalls:
+      - "Press releases are promotional; cross-check numbers with primary sources"
+      - "Anonymous leaks or rumor-mill coverage should be treated as speculation until confirmed"
+
+research_order:
+  - "Start with the official site — establish the org's self-description and current leadership"
+  - "Check SEC EDGAR or the relevant national registry for hard financial facts"
+  - "Cross-reference Crunchbase / PitchBook for funding history and investors"
+  - "Verify current leadership on LinkedIn with their role timestamps"
+  - "Scan recent news (last 12 months) for material changes not yet on the official site"
+  - "For nonprofits: pull the most recent 990 for revenue and program spending"
+
+common_pitfalls:
+  - "Conflating parent/subsidiary — e.g., DeepMind vs Google/Alphabet, OpenAI vs OpenAI Global LLC vs the nonprofit"
+  - "Out-of-date headcount after layoffs, hiring sprees, or reorgs — always attach an as-of date"
+  - "Conflating research output with commercial output (papers vs products)"
+  - "Ignoring org restructures: name changes, spin-offs, or mergers may mean your source is describing a no-longer-extant entity"
+  - "Double-counting funding (e.g., counting announced and disbursed rounds separately, or including credits-in-kind as cash)"
+  - "Self-reported mission statements are not neutral — cite them as such, not as fact"
+  - "For international orgs, not checking the local registry (company data is often more authoritative there than US aggregators)"

--- a/data/research-playbooks/person.yaml
+++ b/data/research-playbooks/person.yaml
@@ -1,0 +1,98 @@
+# Research playbook for people (researchers, executives, policymakers, notable figures).
+# Consumed by `crux context for-entity` and the `crux content improve` analyze phase.
+# See QUA-33.
+
+entityType: person
+
+description: >
+  People entities span academic researchers, lab employees, executives, board
+  members, policymakers, and notable public commentators. Prefer primary
+  sources (personal website, institutional profile, first-author papers) over
+  aggregators (LinkedIn, Wikipedia). Always distinguish current role from past
+  roles, and record the "as of" date for any employment claim.
+
+checklist:
+  - "Current role and primary affiliation (with as-of date)"
+  - "Prior roles relevant to AI safety / policy / research (with dates)"
+  - "Highest degree and institution (PhD, Masters, etc.)"
+  - "Primary research area or domain of expertise"
+  - "Most-cited publications or public writing"
+  - "Public stances on key topics (p-doom, timelines, policy proposals) with source"
+  - "Public profiles and handles (personal site, Twitter/X, GitHub, Google Scholar)"
+  - "Organizational affiliations beyond primary (board seats, advisory roles, fellowships)"
+
+sources:
+  - name: "Personal website or blog"
+    reliability: high
+    covers: [current-role, cv, writing, stances]
+    pitfalls:
+      - "May be stale (not updated after role change) — check most-recent post date"
+      - "Often self-curated; omissions are common (e.g., past roles at defunct orgs)"
+  - name: "Institutional profile (university, lab, or company /team page)"
+    reliability: high
+    covers: [current-role, title, affiliation, research-interests]
+    pitfalls:
+      - "Confirms current employment but often lacks start date"
+      - "May not be updated immediately after departures"
+  - name: "Google Scholar"
+    url_pattern: "scholar.google.com/citations?user={id}"
+    reliability: high
+    covers: [publications, citation-counts, h-index, research-areas]
+    pitfalls:
+      - "Author disambiguation is imperfect — verify by cross-checking paper titles"
+      - "Citation counts change; always record the as-of date"
+  - name: "ORCID / arXiv author page"
+    reliability: very-high
+    covers: [publications, co-authors, research-timeline]
+    pitfalls:
+      - "Requires the person to have registered an ORCID (many do not)"
+  - name: "LinkedIn profile"
+    url_pattern: "linkedin.com/in/{slug}"
+    reliability: medium
+    covers: [employment-history, dates, education, endorsements]
+    pitfalls:
+      - "Self-reported; can exaggerate seniority or overlap tenures"
+      - "Private profiles are not accessible without login"
+      - "Role end dates often omitted — current role inferred only"
+  - name: "Twitter/X profile and posts"
+    reliability: low
+    covers: [public-stances, recent-activity, current-affiliation-in-bio]
+    pitfalls:
+      - "Hot takes and drafts are often walked back — don't cite single tweets as policy positions"
+      - "Bios drift out of date; verify affiliation elsewhere"
+      - "Quote-tweets and dunks are not position statements"
+  - name: "Wikipedia"
+    reliability: medium
+    covers: [biography, career-highlights, notable-positions]
+    pitfalls:
+      - "Only available for a small fraction of researchers"
+      - "Quality varies; verify cited primary sources"
+  - name: "Podcast transcripts, long-form interviews"
+    reliability: medium
+    covers: [stances, reasoning, biographical-detail]
+    pitfalls:
+      - "Verbal statements are less precise than written ones — quote carefully"
+      - "Hosts may misframe; verify against the person's own writing"
+  - name: "Conference bios and keynote announcements"
+    reliability: medium
+    covers: [current-role, short-bio, recent-speaking-topics]
+    pitfalls:
+      - "Bios are promotional; shorter than reality"
+
+research_order:
+  - "Start with the personal site to anchor the current narrative"
+  - "Confirm current affiliation via the institutional /team page"
+  - "Pull Google Scholar for publication record and research focus"
+  - "Cross-reference LinkedIn for employment history dates"
+  - "Check recent writing (blog, Twitter, podcasts) for public stances and drift"
+  - "For public figures: look for a Wikipedia page but verify its primary sources"
+
+common_pitfalls:
+  - "Conflating past and current roles — use dated phrasing like \"at X from 2019–2022\" or \"currently at Y (as of 2024)\""
+  - "Treating a one-off tweet or interview comment as a durable public stance"
+  - "Confusing same-named researchers (e.g., multiple \"J. Smith\"s in the same field) — disambiguate with institution or co-authors"
+  - "Attributing views to someone based only on retweets or affiliations — only quote their own words"
+  - "Ignoring pseudonymous or private researchers who prefer not to have a public profile"
+  - "Inflating titles: \"Research Scientist\" and \"Senior Research Scientist\" are different; check the institutional directory"
+  - "Assuming LinkedIn headcounts or seniority match institutional reality"
+  - "For researchers who have left a field, don't cite their current AI views from a pre-AI career stage"


### PR DESCRIPTION
## Summary

Introduces **per-type research playbooks** that codify generic research recipes — recommended sources, reliability ratings, common pitfalls, standard data points — so agents researching an entity don't rediscover the same knowledge every session.

Closes QUA-33. See also the discussion in PR #2997 that motivated this.

## What ships

- **`crux/lib/research-playbooks.ts`** — Zod-validated YAML loader. Canonicalizes entity-type aliases via `ENTITY_TYPE_ALIASES` (so `researcher` → `person`, `lab-frontier` → `organization`). Returns `null` on malformed YAML, schema violations, or missing files — warnings are logged to stderr but never throw.
- **`data/research-playbooks/organization.yaml`** and **`person.yaml`** — the two initial playbooks. 9 sources each, ~10-item standard checklist, 7–8 common pitfalls, and a recommended research order.
- **`crux context for-entity`** — injects the playbook into the generated markdown bundle and the `--json` payload.
- **Page-improver analyze + research phases** — inject the playbook into the LLM prompt so generated `researchNeeded` topics favor checklist items, and the research agent prefers authoritative primary sources over generic web search.

## Safety

- `canonicalizeEntityType` rejects any value that isn't `[a-z0-9-]+` before joining it into a filesystem path, preventing path traversal via a crafted entity type.
- Malformed/invalid playbooks degrade gracefully — the pipeline continues without a playbook rather than failing.

## Acceptance criteria

- [x] YAML schema for research playbooks defined
- [x] At least organization and person playbooks created
- [x] `crux context for-entity` loads the playbook for the entity type
- [x] Improve pipeline consults playbook during research phase

## Test plan

- [x] 28 unit tests for the loader: happy path, malformed YAML, schema violations, alias resolution, path-traversal, entityType mismatch, missing directory, formatters
- [x] 46 existing context-command tests still pass
- [x] All 137 page-improver tests still pass
- [x] Live verification: `WIKI_SERVER_ENV=prod pnpm crux context for-entity anthropic` → "Research playbook: organization (9 sources)"
- [x] Live verification: `... for-entity geoffrey-hinton` → "Research playbook: person (9 sources)"
- [x] Live verification: `... for-entity gpt-4` (no playbook for `ai-model`) → no playbook line, graceful fallback
- [x] `pnpm build` exits 0
- [x] `pnpm crux w validate gate` passes (all 45 checks)

## Notes for future work

- Additional playbooks (`ai-model`, `policy`, `project`, `research-area`, `benchmark`) are natural follow-ups.
- A `pnpm crux sys playbooks list` command could expose `listPlaybookTypes()` for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
