### PR TITLE
feat(tablebase): add setup-org for single-shot org onboarding

### DIFF
--- a/crux/commands/__tests__/setup-org.test.ts
+++ b/crux/commands/__tests__/setup-org.test.ts
@@ -10,9 +10,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 import {
   buildDivisionRows,
@@ -72,11 +73,6 @@ const MINIMAL_CONFIG_YAML = `
 slug: tiny-org
 name: Tiny Org
 `;
-
-function buildConfig(overrides: Partial<SetupOrgConfig> = {}): SetupOrgConfig {
-  return parseConfig(MINIMAL_CONFIG_YAML, "yaml") as SetupOrgConfig &
-    typeof overrides extends never ? SetupOrgConfig : SetupOrgConfig;
-}
 
 // ── Config validation ─────────────────────────────────────────────────
 
@@ -146,6 +142,31 @@ fundingPrograms:
 
   it("rejects malformed JSON", () => {
     expect(() => parseConfig("{not valid json", "json")).toThrow();
+  });
+
+  it("rejects relatedEntries.id that is neither sid_-prefixed nor kebab-case", () => {
+    const yaml = `
+slug: ok-slug
+name: ok
+relatedEntries:
+  - id: "Capital_Letters_And_Underscores"
+    type: person
+`;
+    expect(() => parseConfig(yaml, "yaml")).toThrow(/sid_|kebab-case/);
+  });
+
+  it("accepts relatedEntries.id in either sid_ or kebab-case form", () => {
+    const yaml = `
+slug: ok-slug
+name: ok
+relatedEntries:
+  - id: sid_AAAAAAAAAA
+    type: person
+  - id: dario-amodei
+    type: person
+`;
+    const config = parseConfig(yaml, "yaml");
+    expect(config.relatedEntries).toHaveLength(2);
   });
 });
 
@@ -416,7 +437,6 @@ describe("planFiles", () => {
     try {
       const entityPath = join(tmp, "data/entities/tiny-org.yaml");
       // Pre-create the file.
-      const { mkdirSync } = require("node:fs");
       mkdirSync(join(tmp, "data/entities"), { recursive: true });
       writeFileSync(entityPath, "- id: tiny-org\n");
 
@@ -516,8 +536,8 @@ describe("runSetupOrg (dry-run)", () => {
     expect(mock.syncFundingPrograms.getCalls()).toBe(0);
     expect(mock.written).toHaveLength(0);
     expect(report.applied).toBe(false);
-    expect(report.wikiId).toBe("<would-allocate>");
-    expect(report.stableId).toBe("sid_PREVIEW00");
+    expect(report.wikiId).toBe("<would-allocate-wiki-id>");
+    expect(report.stableId).toBe("<would-allocate-stable-id>");
     // Counts are still computed for the preview.
     expect(report.divisions.count).toBe(2);
     expect(report.fundingPrograms.count).toBe(1);
@@ -536,7 +556,7 @@ describe("runSetupOrg (dry-run)", () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps({ getId: "fail" });
     const report = await runSetupOrg(config, false, deps);
-    expect(report.wikiId).toBe("<would-allocate>");
+    expect(report.wikiId).toBe("<would-allocate-wiki-id>");
     expect(report.steps[0]!.status).toBe("skipped");
     expect(report.steps[0]!.detail).toContain("lookup failed");
   });
@@ -586,24 +606,109 @@ describe("runSetupOrg (--apply)", () => {
     expect(mock.written).toHaveLength(0);
   });
 
-  it("reports failed sync-entity-pg without aborting subsequent sync steps", async () => {
-    // Only entity sync fails — divisions/programs should still be attempted
-    // so the user sees the full picture, not "fail-fast on first error".
+  it("reports failed sync-entity-pg AND skips downstream syncs to avoid orphans", async () => {
+    // When entity sync fails, divisions/programs reference an org that
+    // doesn't exist in PG — writing them anyway produces orphan rows.
+    // The orchestrator must skip downstream syncs and report why.
     const config = parseConfig(FULL_CONFIG_YAML, "yaml");
-    const { deps, mock } = makeDeps({}, mkdtempSync(join(tmpdir(), "setup-org-fail-")));
-    let entitySyncCalls = 0;
-    deps.syncEntities = async () => {
-      entitySyncCalls++;
-      return { ok: false, message: "boom" };
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-fail-"));
+    try {
+      const { deps, mock } = makeDeps({}, tmp);
+      let entitySyncCalls = 0;
+      deps.syncEntities = async () => {
+        entitySyncCalls++;
+        return { ok: false, message: "boom" };
+      };
+      const report = await runSetupOrg(config, true, deps);
+      expect(entitySyncCalls).toBe(1);
+      // Downstream syncs skipped, NOT attempted.
+      expect(mock.syncDivisions.getCalls()).toBe(0);
+      expect(mock.syncFundingPrograms.getCalls()).toBe(0);
+      const divisionsStep = report.steps.find((s) => s.step === "sync-divisions");
+      expect(divisionsStep?.status).toBe("skipped");
+      expect(divisionsStep?.detail).toContain("orphan");
+      const programsStep = report.steps.find((s) => s.step === "sync-funding-programs");
+      expect(programsStep?.status).toBe("skipped");
+      const entityStep = report.steps.find((s) => s.step === "sync-entity-pg");
+      expect(entityStep?.status).toBe("failed");
+      expect(entityStep?.detail).toContain("boom");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to overwrite existing YAML without --force", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-overwrite-"));
+    try {
+      // Pre-create the entity YAML to simulate existing content.
+      const entityPath = join(tmp, "data/entities/tiny-org.yaml");
+      mkdirSync(dirname(entityPath), { recursive: true });
+      writeFileSync(entityPath, "- id: tiny-org\n  hand-curated: yes\n");
+
+      const { deps, mock } = makeDeps({}, tmp);
+      const report = await runSetupOrg(config, { apply: true }, deps);
+
+      const writeStep = report.steps.find((s) => s.step === "write-entity-yaml");
+      expect(writeStep?.status).toBe("failed");
+      expect(writeStep?.detail).toContain("--force");
+      // No PG calls happened.
+      expect(mock.syncEntities.getCalls()).toBe(0);
+      // Hand-curated content NOT clobbered.
+      expect(readFileSync(entityPath, "utf-8")).toContain("hand-curated: yes");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("overwrites existing YAML when --force is set", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-force-"));
+    try {
+      const entityPath = join(tmp, "data/entities/tiny-org.yaml");
+      mkdirSync(dirname(entityPath), { recursive: true });
+      writeFileSync(entityPath, "- id: tiny-org\n  hand-curated: yes\n");
+
+      const { deps, mock } = makeDeps({}, tmp);
+      const report = await runSetupOrg(config, { apply: true, force: true }, deps);
+
+      expect(report.steps.find((s) => s.step === "write-entity-yaml")?.status).toBe("ok");
+      expect(mock.syncEntities.getCalls()).toBe(1);
+      // File was actually written.
+      expect(mock.written.find((w) => w.path === entityPath)).toBeTruthy();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("converts thrown writeFile errors into failed step results (not unhandled exceptions)", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps, mock } = makeDeps();
+    deps.writeFile = () => {
+      throw new Error("ENOSPC: no space left on device");
     };
-    const report = await runSetupOrg(config, true, deps);
-    expect(entitySyncCalls).toBe(1);
-    // Subsequent sync* calls still ran.
-    expect(mock.syncDivisions.getCalls()).toBe(1);
-    expect(mock.syncFundingPrograms.getCalls()).toBe(1);
-    const entityStep = report.steps.find((s) => s.step === "sync-entity-pg");
-    expect(entityStep?.status).toBe("failed");
-    expect(entityStep?.detail).toContain("boom");
+    const report = await runSetupOrg(config, { apply: true }, deps);
+    const writeStep = report.steps.find((s) => s.step === "write-entity-yaml");
+    expect(writeStep?.status).toBe("failed");
+    expect(writeStep?.detail).toContain("ENOSPC");
+    // PG sync skipped because file write failed first.
+    expect(mock.syncEntities.getCalls()).toBe(0);
+    // The follow-up section warns about the abort.
+    expect(report.followUp.some((f) => f.includes("PG sync skipped"))).toBe(true);
+  });
+
+  it("skips download files but still surfaces both file-write attempts", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps();
+    let writeCount = 0;
+    deps.writeFile = () => {
+      writeCount++;
+      throw new Error("EACCES");
+    };
+    const report = await runSetupOrg(config, { apply: true }, deps);
+    // Both write attempts run before we abort downstream — user sees full picture.
+    expect(writeCount).toBe(2);
+    expect(report.steps.filter((s) => s.status === "failed")).toHaveLength(2);
   });
 });
 
@@ -627,8 +732,6 @@ describe("apply mode writes valid YAML to disk", () => {
         syncFundingPrograms: async () => ({ ok: true as const, data: { upserted: 1 } }),
         writeFile: (path, contents) => {
           // Persist for round-trip check.
-          const { mkdirSync } = require("node:fs");
-          const { dirname } = require("node:path");
           mkdirSync(dirname(path), { recursive: true });
           writeFileSync(path, contents, "utf-8");
           written.push({ path, contents });
@@ -639,8 +742,7 @@ describe("apply mode writes valid YAML to disk", () => {
       expect(written).toHaveLength(2);
       const entityPath = join(tmp, "data/entities/aria.yaml");
       expect(existsSync(entityPath)).toBe(true);
-      const { parse } = require("yaml");
-      const parsed = parse(readFileSync(entityPath, "utf-8"));
+      const parsed = parseYaml(readFileSync(entityPath, "utf-8"));
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed[0]).toMatchObject({
         id: "aria",
@@ -652,6 +754,40 @@ describe("apply mode writes valid YAML to disk", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ── Shell injection defense ──────────────────────────────────────────
+
+describe("follow-up suggestions are shell-safe", () => {
+  it("escapes embedded $(...) and backticks in config.name", async () => {
+    const yaml = `
+slug: ok-slug
+name: "$(rm -rf ~) and \`echo pwned\`"
+`;
+    const config = parseConfig(yaml, "yaml");
+    const { deps } = makeDeps();
+    const report = await runSetupOrg(config, false, deps);
+    // The follow-up suggestion uses single-quotes which prevent shell
+    // expansion. The literal $(...)/backticks should appear verbatim
+    // inside single quotes, not as an active shell construct.
+    const wikiCreate = report.followUp.find((f) => f.includes("crux w create"));
+    expect(wikiCreate).toBeDefined();
+    expect(wikiCreate).toContain("'$(rm -rf ~) and `echo pwned`'");
+    // No double-quote wrapper that would allow $() expansion.
+    expect(wikiCreate).not.toContain('"$(rm');
+  });
+
+  it("escapes embedded single quotes via the standard '\\\\'' trick", async () => {
+    const yaml = `
+slug: ok-slug
+name: "Bob's R&D Lab"
+`;
+    const config = parseConfig(yaml, "yaml");
+    const { deps } = makeDeps();
+    const report = await runSetupOrg(config, false, deps);
+    const wikiCreate = report.followUp.find((f) => f.includes("crux w create"));
+    expect(wikiCreate).toContain("'Bob'\\''s R&D Lab'");
   });
 });
 
@@ -678,5 +814,3 @@ describe("formatReport", () => {
   });
 });
 
-// Suppress "buildConfig is unused" lint by referencing it once.
-void buildConfig;

--- a/crux/commands/__tests__/setup-org.test.ts
+++ b/crux/commands/__tests__/setup-org.test.ts
@@ -1,13 +1,4 @@
-/**
- * Tests for `crux tb setup-org` (QUA-35).
- *
- * Covers:
- *   - Config validation (Zod schema)
- *   - Pure builders (entity record, FactBase doc, division/program rows)
- *   - Snippet formatters
- *   - The orchestrator's dry-run vs --apply behavior, with mocked wiki-server clients
- *   - File-write planning (no real I/O — temp dir only)
- */
+// Tests for `crux tb setup-org`.
 
 import { describe, it, expect } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -530,7 +521,7 @@ describe("runSetupOrg (dry-run)", () => {
   it("never calls allocateId or sync* in dry-run", async () => {
     const config = parseConfig(FULL_CONFIG_YAML, "yaml");
     const { deps, mock } = makeDeps({ getId: "missing" });
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     expect(mock.syncEntities.getCalls()).toBe(0);
     expect(mock.syncDivisions.getCalls()).toBe(0);
     expect(mock.syncFundingPrograms.getCalls()).toBe(0);
@@ -539,15 +530,15 @@ describe("runSetupOrg (dry-run)", () => {
     expect(report.wikiId).toBe("<would-allocate-wiki-id>");
     expect(report.stableId).toBe("<would-allocate-stable-id>");
     // Counts are still computed for the preview.
-    expect(report.divisions.count).toBe(2);
-    expect(report.fundingPrograms.count).toBe(1);
+    expect(report.divisions.ids.length).toBe(2);
+    expect(report.fundingPrograms.ids.length).toBe(1);
     expect(report.factbaseFacts).toBe(1);
   });
 
   it("uses the existing ID when the slug is already allocated", async () => {
     const config = parseConfig(FULL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps({ getId: "found" });
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     expect(report.wikiId).toBe("E999");
     expect(report.stableId).toBe("sid_EXISTING01");
   });
@@ -555,7 +546,7 @@ describe("runSetupOrg (dry-run)", () => {
   it("falls back to placeholders when wiki-server is unreachable", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps({ getId: "fail" });
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     expect(report.wikiId).toBe("<would-allocate-wiki-id>");
     expect(report.steps[0]!.status).toBe("skipped");
     expect(report.steps[0]!.detail).toContain("lookup failed");
@@ -564,7 +555,7 @@ describe("runSetupOrg (dry-run)", () => {
   it("includes follow-up steps for divisions and programs", async () => {
     const config = parseConfig(FULL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps();
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     expect(report.followUp.some((f) => f.includes("import-divisions.ts"))).toBe(true);
     expect(report.followUp.some((f) => f.includes("import-funding-programs.ts"))).toBe(true);
     expect(report.followUp.some((f) => f.includes("crux w create"))).toBe(true);
@@ -579,7 +570,7 @@ describe("runSetupOrg (--apply)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "setup-org-apply-"));
     try {
       const { deps, mock } = makeDeps({}, tmp);
-      const report = await runSetupOrg(config, true, deps);
+      const report = await runSetupOrg(config, { apply: true }, deps);
       expect(report.applied).toBe(true);
       expect(report.wikiId).toBe("E1234");
       expect(report.stableId).toBe("sid_NEW0000000");
@@ -600,7 +591,7 @@ describe("runSetupOrg (--apply)", () => {
   it("returns with failed allocate-id and does not call any sync*", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps, mock } = makeDeps({ allocate: false });
-    const report = await runSetupOrg(config, true, deps);
+    const report = await runSetupOrg(config, { apply: true }, deps);
     expect(report.steps[0]!.status).toBe("failed");
     expect(mock.syncEntities.getCalls()).toBe(0);
     expect(mock.written).toHaveLength(0);
@@ -619,7 +610,7 @@ describe("runSetupOrg (--apply)", () => {
         entitySyncCalls++;
         return { ok: false, message: "boom" };
       };
-      const report = await runSetupOrg(config, true, deps);
+      const report = await runSetupOrg(config, { apply: true }, deps);
       expect(entitySyncCalls).toBe(1);
       // Downstream syncs skipped, NOT attempted.
       expect(mock.syncDivisions.getCalls()).toBe(0);
@@ -738,7 +729,7 @@ describe("apply mode writes valid YAML to disk", () => {
         },
         log: () => {},
       };
-      await runSetupOrg(config, true, deps);
+      await runSetupOrg(config, { apply: true }, deps);
       expect(written).toHaveLength(2);
       const entityPath = join(tmp, "data/entities/aria.yaml");
       expect(existsSync(entityPath)).toBe(true);
@@ -767,7 +758,7 @@ name: "$(rm -rf ~) and \`echo pwned\`"
 `;
     const config = parseConfig(yaml, "yaml");
     const { deps } = makeDeps();
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     // The follow-up suggestion uses single-quotes which prevent shell
     // expansion. The literal $(...)/backticks should appear verbatim
     // inside single quotes, not as an active shell construct.
@@ -785,7 +776,7 @@ name: "Bob's R&D Lab"
 `;
     const config = parseConfig(yaml, "yaml");
     const { deps } = makeDeps();
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     const wikiCreate = report.followUp.find((f) => f.includes("crux w create"));
     expect(wikiCreate).toContain("'Bob'\\''s R&D Lab'");
   });
@@ -797,7 +788,7 @@ describe("formatReport", () => {
   it("includes step status glyphs and the (re-run with --apply) hint in dry-run", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps();
-    const report = await runSetupOrg(config, false, deps);
+    const report = await runSetupOrg(config, { apply: false }, deps);
     const text = formatReport(report);
     expect(text).toContain("Dry run (preview)");
     expect(text).toContain("re-run with --apply");
@@ -807,7 +798,7 @@ describe("formatReport", () => {
   it("omits the (re-run with --apply) hint when applied", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps({}, mkdtempSync(join(tmpdir(), "setup-org-fmt-")));
-    const report = await runSetupOrg(config, true, deps);
+    const report = await runSetupOrg(config, { apply: true }, deps);
     const text = formatReport(report);
     expect(text).toContain("Applied");
     expect(text).not.toContain("re-run with --apply");

--- a/crux/commands/__tests__/setup-org.test.ts
+++ b/crux/commands/__tests__/setup-org.test.ts
@@ -1,0 +1,682 @@
+/**
+ * Tests for `crux tb setup-org` (QUA-35).
+ *
+ * Covers:
+ *   - Config validation (Zod schema)
+ *   - Pure builders (entity record, FactBase doc, division/program rows)
+ *   - Snippet formatters
+ *   - The orchestrator's dry-run vs --apply behavior, with mocked wiki-server clients
+ *   - File-write planning (no real I/O — temp dir only)
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildDivisionRows,
+  buildEntityRecord,
+  buildFactBaseDoc,
+  buildFundingProgramRows,
+  formatDivisionsSnippet,
+  formatFundingProgramsSnippet,
+  formatReport,
+  parseConfig,
+  planFiles,
+  runSetupOrg,
+  type SetupOrgConfig,
+} from "../setup-org.ts";
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const FULL_CONFIG_YAML = `
+slug: aria
+name: Advanced Research and Innovation Agency
+type: organization
+aliases:
+  - ARIA
+website: https://aria.org.uk
+description: UK government R&D funding agency
+orgType: government-agency
+tags:
+  - funder
+  - government
+relatedEntries:
+  - id: sid_xxxxxxxxxx
+    type: person
+    relationship: leads-to
+divisions:
+  - name: Programmable Plants
+    divisionType: program-area
+    status: active
+    source: https://aria.org.uk/programmes/programmable-plants
+  - name: Loneliness
+    divisionType: program-area
+    status: active
+fundingPrograms:
+  - name: Programmable Plants RFP
+    programType: rfp
+    status: open
+    totalBudget: 60000000
+    currency: GBP
+    deadline: Rolling
+    divisionSlug: programmable-plants
+facts:
+  - property: founded-date
+    value: "2023"
+    source: https://aria.org.uk/about
+`;
+
+const MINIMAL_CONFIG_YAML = `
+slug: tiny-org
+name: Tiny Org
+`;
+
+function buildConfig(overrides: Partial<SetupOrgConfig> = {}): SetupOrgConfig {
+  return parseConfig(MINIMAL_CONFIG_YAML, "yaml") as SetupOrgConfig &
+    typeof overrides extends never ? SetupOrgConfig : SetupOrgConfig;
+}
+
+// ── Config validation ─────────────────────────────────────────────────
+
+describe("parseConfig", () => {
+  it("accepts a full YAML config", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    expect(config.slug).toBe("aria");
+    expect(config.name).toBe("Advanced Research and Innovation Agency");
+    expect(config.aliases).toEqual(["ARIA"]);
+    expect(config.divisions).toHaveLength(2);
+    expect(config.fundingPrograms).toHaveLength(1);
+    expect(config.facts).toHaveLength(1);
+  });
+
+  it("accepts a minimal YAML config", () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    expect(config.slug).toBe("tiny-org");
+    expect(config.type).toBe("organization"); // default
+    expect(config.divisions).toBeUndefined();
+  });
+
+  it("accepts a JSON config", () => {
+    const config = parseConfig('{"slug":"json-org","name":"JSON Org"}', "json");
+    expect(config.slug).toBe("json-org");
+    expect(config.name).toBe("JSON Org");
+  });
+
+  it("rejects uppercase slug", () => {
+    expect(() => parseConfig('{"slug":"BAD_UPPER","name":"x"}', "json")).toThrow(/kebab-case/);
+  });
+
+  it("rejects empty name", () => {
+    expect(() => parseConfig('{"slug":"x-y","name":""}', "json")).toThrow();
+  });
+
+  it("rejects missing slug", () => {
+    expect(() => parseConfig('{"name":"x"}', "json")).toThrow();
+  });
+
+  it("rejects unknown divisionType enum", () => {
+    const yaml = `
+slug: ok-slug
+name: ok
+divisions:
+  - name: Bad Type
+    divisionType: not-a-real-type
+    status: active
+`;
+    expect(() => parseConfig(yaml, "yaml")).toThrow();
+  });
+
+  it("rejects unknown program status enum", () => {
+    const yaml = `
+slug: ok-slug
+name: ok
+fundingPrograms:
+  - name: Bad
+    programType: rfp
+    status: maybe
+`;
+    expect(() => parseConfig(yaml, "yaml")).toThrow();
+  });
+
+  it("rejects non-object root", () => {
+    expect(() => parseConfig('"just-a-string"', "json")).toThrow(/object/);
+  });
+
+  it("rejects malformed JSON", () => {
+    expect(() => parseConfig("{not valid json", "json")).toThrow();
+  });
+});
+
+// ── Pure builders ──────────────────────────────────────────────────────
+
+describe("buildEntityRecord", () => {
+  it("includes only fields present in the config", () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const record = buildEntityRecord(config, { wikiId: "E1", stableId: "sid_AAAAAAAAAA" });
+    expect(record.id).toBe("tiny-org");
+    expect(record.wikiId).toBe("E1");
+    expect(record.stableId).toBe("sid_AAAAAAAAAA");
+    expect(record.title).toBe("Tiny Org");
+    expect(record.aliases).toBeUndefined();
+    expect(record.website).toBeUndefined();
+    expect(record.relatedEntries).toBeUndefined();
+  });
+
+  it("propagates aliases, website, description, tags, orgType, relatedEntries", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const record = buildEntityRecord(config, { wikiId: "E42", stableId: "sid_BBBBBBBBBB" });
+    expect(record.orgType).toBe("government-agency");
+    expect(record.aliases).toEqual(["ARIA"]);
+    expect(record.website).toBe("https://aria.org.uk");
+    expect(record.description).toBe("UK government R&D funding agency");
+    expect(record.tags).toEqual(["funder", "government"]);
+    expect(record.relatedEntries).toEqual([
+      { id: "sid_xxxxxxxxxx", type: "person", relationship: "leads-to" },
+    ]);
+  });
+
+  it("strips undefined relationship from relatedEntries", () => {
+    const config = parseConfig(
+      `slug: x-y\nname: X\nrelatedEntries:\n  - id: sid_AAAAAAAAAA\n    type: person\n`,
+      "yaml",
+    );
+    const record = buildEntityRecord(config, { wikiId: "E1", stableId: "sid_BBBBBBBBBB" });
+    expect(record.relatedEntries).toEqual([{ id: "sid_AAAAAAAAAA", type: "person" }]);
+    expect(record.relatedEntries?.[0]).not.toHaveProperty("relationship");
+  });
+});
+
+describe("buildFactBaseDoc", () => {
+  it("returns entity stub with empty facts when no facts provided", () => {
+    const doc = buildFactBaseDoc("sid_zzzzzzzzzz", undefined);
+    expect(doc.entity).toBe("sid_zzzzzzzzzz");
+    expect(doc.facts).toEqual([]);
+  });
+
+  it("emits deterministic fact IDs based on stableId+property+asOf", () => {
+    const docA = buildFactBaseDoc("sid_zzzzzzzzzz", [
+      { property: "founded-date", value: "2023" },
+    ]);
+    const docB = buildFactBaseDoc("sid_zzzzzzzzzz", [
+      { property: "founded-date", value: "2023" },
+    ]);
+    expect(docA.facts[0]!.id).toBe(docB.facts[0]!.id);
+    expect(docA.facts[0]!.id).toMatch(/^f_[A-Za-z0-9]{10}$/);
+  });
+
+  it("differentiates facts with different asOf values", () => {
+    const doc = buildFactBaseDoc("sid_zzzzzzzzzz", [
+      { property: "revenue", value: 100, asOf: "2024" },
+      { property: "revenue", value: 200, asOf: "2025" },
+    ]);
+    expect(doc.facts[0]!.id).not.toBe(doc.facts[1]!.id);
+  });
+
+  it("includes optional fields only when set", () => {
+    const doc = buildFactBaseDoc("sid_zzzzzzzzzz", [
+      { property: "headquarters", value: "London", source: "https://example.org" },
+    ]);
+    expect(doc.facts[0]).toMatchObject({
+      property: "headquarters",
+      value: "London",
+      source: "https://example.org",
+    });
+    expect(doc.facts[0]).not.toHaveProperty("notes");
+    expect(doc.facts[0]).not.toHaveProperty("asOf");
+  });
+});
+
+describe("buildDivisionRows", () => {
+  it("returns empty array when no divisions in config", () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    expect(buildDivisionRows(config, "sid_AAAAAAAAAA")).toEqual([]);
+  });
+
+  it("derives slug from name when not provided", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const rows = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    expect(rows[0]!.idSeed).toBe("div|aria|programmable-plants");
+    expect(rows[1]!.idSeed).toBe("div|aria|loneliness");
+  });
+
+  it("emits a 10-char alphanumeric id matching the idSeed convention", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const rows = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    for (const row of rows) {
+      expect(row.id).toMatch(/^[A-Za-z0-9]{10}$/);
+      expect(row.parentOrgId).toBe("sid_AAAAAAAAAA");
+    }
+  });
+
+  it("rejects duplicate division slugs in the same config", () => {
+    const yaml = `
+slug: x-y
+name: X
+divisions:
+  - name: Same Name
+    divisionType: lab
+    status: active
+  - name: Same-Name
+    divisionType: lab
+    status: active
+`;
+    const config = parseConfig(yaml, "yaml");
+    expect(() => buildDivisionRows(config, "sid_AAAAAAAAAA")).toThrow(/duplicate/);
+  });
+});
+
+describe("buildFundingProgramRows", () => {
+  it("links a program to a division by divisionSlug", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const divisions = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    const programs = buildFundingProgramRows(config, "sid_AAAAAAAAAA", divisions);
+    expect(programs).toHaveLength(1);
+    expect(programs[0]!.divisionId).toBe(divisions[0]!.id);
+    expect(programs[0]!.divisionIdSeed).toBe("div|aria|programmable-plants");
+  });
+
+  it("throws when divisionSlug references a missing division", () => {
+    const yaml = `
+slug: x-y
+name: X
+fundingPrograms:
+  - name: Orphan
+    programType: rfp
+    status: open
+    divisionSlug: missing-division
+`;
+    const config = parseConfig(yaml, "yaml");
+    expect(() => buildFundingProgramRows(config, "sid_AAAAAAAAAA", [])).toThrow(/missing-division/);
+  });
+
+  it("leaves divisionId null when the program omits divisionSlug", () => {
+    const yaml = `
+slug: x-y
+name: X
+fundingPrograms:
+  - name: Standalone
+    programType: prize
+    status: closed
+`;
+    const config = parseConfig(yaml, "yaml");
+    const rows = buildFundingProgramRows(config, "sid_AAAAAAAAAA", []);
+    expect(rows[0]!.divisionId).toBeNull();
+    expect(rows[0]!.divisionIdSeed).toBeNull();
+  });
+
+  it("rejects duplicate program slugs", () => {
+    const yaml = `
+slug: x-y
+name: X
+fundingPrograms:
+  - name: Same
+    programType: rfp
+    status: open
+  - name: Same
+    programType: prize
+    status: closed
+`;
+    const config = parseConfig(yaml, "yaml");
+    expect(() => buildFundingProgramRows(config, "sid_AAAAAAAAAA", [])).toThrow(/duplicate/);
+  });
+});
+
+// ── Snippet formatters ────────────────────────────────────────────────
+
+describe("formatDivisionsSnippet", () => {
+  it("returns empty string when no rows", () => {
+    expect(formatDivisionsSnippet([], "any")).toBe("");
+  });
+
+  it("emits valid TypeScript object literals with all fields quoted", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const rows = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    const snippet = formatDivisionsSnippet(rows, "aria");
+    expect(snippet).toContain('// ---- aria ----');
+    expect(snippet).toContain('idSeed: "div|aria|programmable-plants"');
+    expect(snippet).toContain('parentOrgId: "sid_AAAAAAAAAA"');
+    expect(snippet).toContain('divisionType: "program-area"');
+    expect(snippet).toContain('status: "active"');
+  });
+
+  it("omits null/undefined optional fields rather than emitting `null`", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const rows = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    const lonelinessSnippet = formatDivisionsSnippet([rows[1]!], "aria");
+    expect(lonelinessSnippet).not.toContain("startDate");
+    expect(lonelinessSnippet).not.toContain("source:");
+    expect(lonelinessSnippet).not.toContain("null");
+  });
+});
+
+describe("formatFundingProgramsSnippet", () => {
+  it("emits valid TypeScript object literals including divisionIdSeed", () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const divisions = buildDivisionRows(config, "sid_AAAAAAAAAA");
+    const programs = buildFundingProgramRows(config, "sid_AAAAAAAAAA", divisions);
+    const snippet = formatFundingProgramsSnippet(programs, "aria");
+    expect(snippet).toContain('idSeed: "prog|aria|programmable-plants-rfp"');
+    expect(snippet).toContain('divisionIdSeed: "div|aria|programmable-plants"');
+    expect(snippet).toContain("totalBudget: 60000000");
+    expect(snippet).toContain('currency: "GBP"');
+  });
+
+  it("omits divisionIdSeed when program is unlinked", () => {
+    const yaml = `
+slug: x-y
+name: X
+fundingPrograms:
+  - name: Standalone Prize
+    programType: prize
+    status: closed
+`;
+    const config = parseConfig(yaml, "yaml");
+    const programs = buildFundingProgramRows(config, "sid_AAAAAAAAAA", []);
+    const snippet = formatFundingProgramsSnippet(programs, "x-y");
+    expect(snippet).not.toContain("divisionIdSeed");
+  });
+});
+
+// ── File planner ──────────────────────────────────────────────────────
+
+describe("planFiles", () => {
+  it("computes the YAML paths and contents under the given repo root", () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const record = buildEntityRecord(config, { wikiId: "E1", stableId: "sid_AAAAAAAAAA" });
+    const factbase = buildFactBaseDoc("sid_AAAAAAAAAA", undefined);
+
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-plan-"));
+    try {
+      const plan = planFiles(tmp, config, record, factbase);
+      expect(plan.entityYamlPath).toBe(join(tmp, "data/entities/tiny-org.yaml"));
+      expect(plan.factbaseYamlPath).toBe(
+        join(tmp, "packages/factbase/data/fb-entities/tiny-org.yaml"),
+      );
+      expect(plan.entityYamlExists).toBe(false);
+      expect(plan.factbaseYamlExists).toBe(false);
+      // Entity YAML is a single-element list, not a map.
+      expect(plan.entityYamlContents).toMatch(/^- id: tiny-org/m);
+      expect(plan.entityYamlContents).toContain("stableId: sid_AAAAAAAAAA");
+      expect(plan.entityYamlContents).toContain("wikiId: E1");
+      // FactBase YAML has the entity stub even with empty facts.
+      expect(plan.factbaseYamlContents).toMatch(/^entity: sid_AAAAAAAAAA/m);
+      expect(plan.factbaseYamlContents).toMatch(/facts: \[\]/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("flags existing files as willOverwrite", () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const record = buildEntityRecord(config, { wikiId: "E1", stableId: "sid_AAAAAAAAAA" });
+    const factbase = buildFactBaseDoc("sid_AAAAAAAAAA", undefined);
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-plan-"));
+    try {
+      const entityPath = join(tmp, "data/entities/tiny-org.yaml");
+      // Pre-create the file.
+      const { mkdirSync } = require("node:fs");
+      mkdirSync(join(tmp, "data/entities"), { recursive: true });
+      writeFileSync(entityPath, "- id: tiny-org\n");
+
+      const plan = planFiles(tmp, config, record, factbase);
+      expect(plan.entityYamlExists).toBe(true);
+      expect(plan.factbaseYamlExists).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Orchestrator ──────────────────────────────────────────────────────
+
+interface MockDeps {
+  getIdBySlug: ReturnType<typeof makeMockGetId>;
+  allocateId: ReturnType<typeof makeMockAllocate>;
+  syncEntities: ReturnType<typeof makeMockSync>;
+  syncDivisions: ReturnType<typeof makeMockSync>;
+  syncFundingPrograms: ReturnType<typeof makeMockSync>;
+  written: Array<{ path: string; contents: string }>;
+}
+
+function makeMockGetId(behavior: "found" | "missing" | "fail") {
+  return async (_slug: string) => {
+    if (behavior === "fail") {
+      return { ok: false as const, message: "wiki-server unreachable" };
+    }
+    if (behavior === "missing") {
+      return { ok: true as const, data: null };
+    }
+    return { ok: true as const, data: { wikiId: "E999", stableId: "sid_EXISTING01" } };
+  };
+}
+
+function makeMockAllocate(succeed: boolean) {
+  return async (_slug: string) => {
+    if (!succeed) return { ok: false as const, message: "allocate failed" };
+    return { ok: true as const, data: { wikiId: "E1234", stableId: "sid_NEW0000000" } };
+  };
+}
+
+function makeMockSync(succeed: boolean) {
+  let calls = 0;
+  const fn = async (_items: unknown) => {
+    calls++;
+    if (!succeed) return { ok: false as const, message: "sync failed" };
+    return { ok: true as const, data: { upserted: 1 } };
+  };
+  return Object.assign(fn, { getCalls: () => calls });
+}
+
+function makeDeps(
+  overrides: {
+    getId?: "found" | "missing" | "fail";
+    allocate?: boolean;
+    sync?: boolean;
+  } = {},
+  repoRoot = "/tmp/fake-root",
+): { deps: Parameters<typeof runSetupOrg>[2]; mock: MockDeps } {
+  const written: MockDeps["written"] = [];
+  const getIdBySlug = makeMockGetId(overrides.getId ?? "missing");
+  const allocateId = makeMockAllocate(overrides.allocate ?? true);
+  const syncEntities = makeMockSync(overrides.sync ?? true);
+  const syncDivisions = makeMockSync(overrides.sync ?? true);
+  const syncFundingPrograms = makeMockSync(overrides.sync ?? true);
+  const deps: Parameters<typeof runSetupOrg>[2] = {
+    repoRoot,
+    getIdBySlug,
+    allocateId,
+    syncEntities,
+    syncDivisions,
+    syncFundingPrograms,
+    writeFile: (path, contents) => written.push({ path, contents }),
+    log: () => {},
+  };
+  return {
+    deps,
+    mock: {
+      getIdBySlug,
+      allocateId,
+      syncEntities,
+      syncDivisions,
+      syncFundingPrograms,
+      written,
+    },
+  };
+}
+
+describe("runSetupOrg (dry-run)", () => {
+  it("never calls allocateId or sync* in dry-run", async () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const { deps, mock } = makeDeps({ getId: "missing" });
+    const report = await runSetupOrg(config, false, deps);
+    expect(mock.syncEntities.getCalls()).toBe(0);
+    expect(mock.syncDivisions.getCalls()).toBe(0);
+    expect(mock.syncFundingPrograms.getCalls()).toBe(0);
+    expect(mock.written).toHaveLength(0);
+    expect(report.applied).toBe(false);
+    expect(report.wikiId).toBe("<would-allocate>");
+    expect(report.stableId).toBe("sid_PREVIEW00");
+    // Counts are still computed for the preview.
+    expect(report.divisions.count).toBe(2);
+    expect(report.fundingPrograms.count).toBe(1);
+    expect(report.factbaseFacts).toBe(1);
+  });
+
+  it("uses the existing ID when the slug is already allocated", async () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps({ getId: "found" });
+    const report = await runSetupOrg(config, false, deps);
+    expect(report.wikiId).toBe("E999");
+    expect(report.stableId).toBe("sid_EXISTING01");
+  });
+
+  it("falls back to placeholders when wiki-server is unreachable", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps({ getId: "fail" });
+    const report = await runSetupOrg(config, false, deps);
+    expect(report.wikiId).toBe("<would-allocate>");
+    expect(report.steps[0]!.status).toBe("skipped");
+    expect(report.steps[0]!.detail).toContain("lookup failed");
+  });
+
+  it("includes follow-up steps for divisions and programs", async () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps();
+    const report = await runSetupOrg(config, false, deps);
+    expect(report.followUp.some((f) => f.includes("import-divisions.ts"))).toBe(true);
+    expect(report.followUp.some((f) => f.includes("import-funding-programs.ts"))).toBe(true);
+    expect(report.followUp.some((f) => f.includes("crux w create"))).toBe(true);
+    expect(report.divisionsSnippet).toBeTruthy();
+    expect(report.fundingProgramsSnippet).toBeTruthy();
+  });
+});
+
+describe("runSetupOrg (--apply)", () => {
+  it("calls allocateId, writes both YAML files, and syncs entity+divisions+programs", async () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-apply-"));
+    try {
+      const { deps, mock } = makeDeps({}, tmp);
+      const report = await runSetupOrg(config, true, deps);
+      expect(report.applied).toBe(true);
+      expect(report.wikiId).toBe("E1234");
+      expect(report.stableId).toBe("sid_NEW0000000");
+      expect(mock.syncEntities.getCalls()).toBe(1);
+      expect(mock.syncDivisions.getCalls()).toBe(1);
+      expect(mock.syncFundingPrograms.getCalls()).toBe(1);
+      expect(mock.written.map((w) => w.path)).toEqual([
+        join(tmp, "data/entities/aria.yaml"),
+        join(tmp, "packages/factbase/data/fb-entities/aria.yaml"),
+      ]);
+      // No failed steps.
+      expect(report.steps.filter((s) => s.status === "failed")).toHaveLength(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns with failed allocate-id and does not call any sync*", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps, mock } = makeDeps({ allocate: false });
+    const report = await runSetupOrg(config, true, deps);
+    expect(report.steps[0]!.status).toBe("failed");
+    expect(mock.syncEntities.getCalls()).toBe(0);
+    expect(mock.written).toHaveLength(0);
+  });
+
+  it("reports failed sync-entity-pg without aborting subsequent sync steps", async () => {
+    // Only entity sync fails — divisions/programs should still be attempted
+    // so the user sees the full picture, not "fail-fast on first error".
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const { deps, mock } = makeDeps({}, mkdtempSync(join(tmpdir(), "setup-org-fail-")));
+    let entitySyncCalls = 0;
+    deps.syncEntities = async () => {
+      entitySyncCalls++;
+      return { ok: false, message: "boom" };
+    };
+    const report = await runSetupOrg(config, true, deps);
+    expect(entitySyncCalls).toBe(1);
+    // Subsequent sync* calls still ran.
+    expect(mock.syncDivisions.getCalls()).toBe(1);
+    expect(mock.syncFundingPrograms.getCalls()).toBe(1);
+    const entityStep = report.steps.find((s) => s.step === "sync-entity-pg");
+    expect(entityStep?.status).toBe("failed");
+    expect(entityStep?.detail).toContain("boom");
+  });
+});
+
+// ── End-to-end file write ────────────────────────────────────────────
+
+describe("apply mode writes valid YAML to disk", () => {
+  it("entity YAML round-trips through yaml.parse", async () => {
+    const config = parseConfig(FULL_CONFIG_YAML, "yaml");
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-rt-"));
+    try {
+      const written: Array<{ path: string; contents: string }> = [];
+      const deps: Parameters<typeof runSetupOrg>[2] = {
+        repoRoot: tmp,
+        getIdBySlug: async () => ({ ok: true as const, data: null }),
+        allocateId: async () => ({
+          ok: true as const,
+          data: { wikiId: "E1234", stableId: "sid_NEW0000000" },
+        }),
+        syncEntities: async () => ({ ok: true as const, data: { upserted: 1 } }),
+        syncDivisions: async () => ({ ok: true as const, data: { upserted: 2 } }),
+        syncFundingPrograms: async () => ({ ok: true as const, data: { upserted: 1 } }),
+        writeFile: (path, contents) => {
+          // Persist for round-trip check.
+          const { mkdirSync } = require("node:fs");
+          const { dirname } = require("node:path");
+          mkdirSync(dirname(path), { recursive: true });
+          writeFileSync(path, contents, "utf-8");
+          written.push({ path, contents });
+        },
+        log: () => {},
+      };
+      await runSetupOrg(config, true, deps);
+      expect(written).toHaveLength(2);
+      const entityPath = join(tmp, "data/entities/aria.yaml");
+      expect(existsSync(entityPath)).toBe(true);
+      const { parse } = require("yaml");
+      const parsed = parse(readFileSync(entityPath, "utf-8"));
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0]).toMatchObject({
+        id: "aria",
+        wikiId: "E1234",
+        stableId: "sid_NEW0000000",
+        type: "organization",
+        title: "Advanced Research and Innovation Agency",
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Format report ─────────────────────────────────────────────────────
+
+describe("formatReport", () => {
+  it("includes step status glyphs and the (re-run with --apply) hint in dry-run", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps();
+    const report = await runSetupOrg(config, false, deps);
+    const text = formatReport(report);
+    expect(text).toContain("Dry run (preview)");
+    expect(text).toContain("re-run with --apply");
+    expect(text).toContain("tiny-org");
+  });
+
+  it("omits the (re-run with --apply) hint when applied", async () => {
+    const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
+    const { deps } = makeDeps({}, mkdtempSync(join(tmpdir(), "setup-org-fmt-")));
+    const report = await runSetupOrg(config, true, deps);
+    const text = formatReport(report);
+    expect(text).toContain("Applied");
+    expect(text).not.toContain("re-run with --apply");
+  });
+});
+
+// Suppress "buildConfig is unused" lint by referencing it once.
+void buildConfig;

--- a/crux/commands/__tests__/setup-org.test.ts
+++ b/crux/commands/__tests__/setup-org.test.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 
 import {
+  adaptIdLookup,
   buildDivisionRows,
   buildEntityRecord,
   buildFactBaseDoc,
@@ -688,7 +689,7 @@ describe("runSetupOrg (--apply)", () => {
     expect(report.followUp.some((f) => f.includes("PG sync skipped"))).toBe(true);
   });
 
-  it("skips download files but still surfaces both file-write attempts", async () => {
+  it("skips PG sync but still surfaces both file-write attempts when both writes fail", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
     const { deps } = makeDeps();
     let writeCount = 0;
@@ -797,11 +798,73 @@ describe("formatReport", () => {
 
   it("omits the (re-run with --apply) hint when applied", async () => {
     const config = parseConfig(MINIMAL_CONFIG_YAML, "yaml");
-    const { deps } = makeDeps({}, mkdtempSync(join(tmpdir(), "setup-org-fmt-")));
-    const report = await runSetupOrg(config, { apply: true }, deps);
-    const text = formatReport(report);
-    expect(text).toContain("Applied");
-    expect(text).not.toContain("re-run with --apply");
+    const tmp = mkdtempSync(join(tmpdir(), "setup-org-fmt-"));
+    try {
+      const { deps } = makeDeps({}, tmp);
+      const report = await runSetupOrg(config, { apply: true }, deps);
+      const text = formatReport(report);
+      expect(text).toContain("Applied");
+      expect(text).not.toContain("re-run with --apply");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 
+
+
+describe("adaptIdLookup", () => {
+  it("returns null when slug is not allocated (404 from wiki-server)", () => {
+    // The wiki-server HTTP client coerces 4xx to error: "bad_request" with the
+    // status code at the start of the message. "Slug not allocated" should be
+    // a successful lookup with no data — not a propagated failure.
+    const r = adaptIdLookup({
+      ok: false,
+      error: "bad_request",
+      message: "404: slug not allocated",
+    });
+    expect(r).toEqual({ ok: true, data: null });
+  });
+
+  it("propagates other bad_request errors as failures", () => {
+    // 400/422/429 are real errors and must surface, not get silently mapped to
+    // "not allocated". The narrow regex on "^404[:\\s]" in adaptIdLookup is
+    // what guards this distinction.
+    const r = adaptIdLookup({
+      ok: false,
+      error: "bad_request",
+      message: "400: invalid slug",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toBe("bad_request: 400: invalid slug");
+  });
+
+  it("propagates non-bad_request errors as failures", () => {
+    const r = adaptIdLookup({
+      ok: false,
+      error: "network",
+      message: "ECONNREFUSED",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toBe("network: ECONNREFUSED");
+  });
+
+  it("returns null when the row exists but has no stableId", () => {
+    const r = adaptIdLookup({
+      ok: true,
+      data: { wikiId: "E42", stableId: null },
+    });
+    expect(r).toEqual({ ok: true, data: null });
+  });
+
+  it("returns ids when both wikiId and stableId are present", () => {
+    const r = adaptIdLookup({
+      ok: true,
+      data: { wikiId: "E42", stableId: "sid_AbCdEfGhIj" },
+    });
+    expect(r).toEqual({
+      ok: true,
+      data: { wikiId: "E42", stableId: "sid_AbCdEfGhIj" },
+    });
+  });
+});

--- a/crux/commands/setup-org.ts
+++ b/crux/commands/setup-org.ts
@@ -1,0 +1,1008 @@
+/**
+ * `crux tb setup-org` — single-shot organization onboarding (QUA-35).
+ *
+ * Replaces the manual ~15-step entity onboarding flow with one command:
+ *   1. Allocate wiki ID (E-number + sid_ stableId) via wiki-server
+ *   2. Write the FactBase entity stub at packages/factbase/data/fb-entities/<slug>.yaml
+ *   3. Write the YAML entity file at data/entities/<slug>.yaml
+ *   4. Sync entity to PG (entities table)
+ *   5. Sync optional divisions to PG (divisions table)
+ *   6. Sync optional funding programs to PG (funding_programs table)
+ *   7. Emit a verification report listing what was created and what manual
+ *      follow-ups remain (wiki page authoring, personnel discovery, grants,
+ *      and snippets to make divisions/programs persistent in the
+ *      `import-divisions.ts` / `import-funding-programs.ts` constants files).
+ *
+ * Default mode is dry-run/preview — writes only happen when `--apply` is set.
+ *
+ * Usage:
+ *   crux tb setup-org --config=path/to/aria.yaml
+ *   crux tb setup-org --config=path/to/aria.yaml --apply
+ *   crux tb setup-org --config=- --apply              # JSON config from stdin
+ *   crux tb setup-org --config=path/to/aria.yaml --ci # JSON output
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { z } from "zod";
+
+import type {
+  CommandOptions as BaseOptions,
+  CommandResult,
+} from "../lib/command-types.ts";
+import { generateId } from "../lib/grant-import/id.ts";
+import { toSlug } from "../tablebase/types.ts";
+
+// ── Config schema ───────────────────────────────────────────────────────
+
+const RelatedEntrySchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  relationship: z.string().optional(),
+});
+
+const DivisionInputSchema = z.object({
+  name: z.string().min(1),
+  slug: z.string().min(1).optional(),
+  divisionType: z.enum(["fund", "team", "department", "lab", "program-area"]),
+  status: z.enum(["active", "inactive", "dissolved"]),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  source: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+const FundingProgramInputSchema = z.object({
+  name: z.string().min(1),
+  slug: z.string().min(1).optional(),
+  description: z.string().optional(),
+  programType: z.enum([
+    "rfp",
+    "grant-round",
+    "fellowship",
+    "prize",
+    "solicitation",
+    "call",
+  ]),
+  status: z.enum(["open", "closed", "awarded"]),
+  totalBudget: z.number().nonnegative().optional(),
+  currency: z.string().optional(),
+  source: z.string().optional(),
+  notes: z.string().optional(),
+  deadline: z.string().max(20).optional(),
+  applicationUrl: z.string().optional(),
+  openDate: z.string().optional(),
+  /** Slug of one of the divisions in this config — links the program to that division. */
+  divisionSlug: z.string().optional(),
+});
+
+const FactInputSchema = z.object({
+  property: z.string().min(1),
+  value: z.union([z.string(), z.number()]),
+  asOf: z.string().optional(),
+  source: z.string().optional(),
+  notes: z.string().optional(),
+  unit: z.string().optional(),
+  currency: z.string().optional(),
+});
+
+const SetupOrgConfigSchema = z.object({
+  slug: z
+    .string()
+    .min(2)
+    .max(100)
+    .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, "slug must be kebab-case"),
+  name: z.string().min(1).max(500),
+  type: z.string().min(1).default("organization"),
+  aliases: z.array(z.string().min(1)).optional(),
+  website: z.string().optional(),
+  description: z.string().optional(),
+  orgType: z.string().optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  relatedEntries: z.array(RelatedEntrySchema).optional(),
+  divisions: z.array(DivisionInputSchema).optional(),
+  fundingPrograms: z.array(FundingProgramInputSchema).optional(),
+  facts: z.array(FactInputSchema).optional(),
+});
+
+export type SetupOrgConfig = z.infer<typeof SetupOrgConfigSchema>;
+export type DivisionInput = z.infer<typeof DivisionInputSchema>;
+export type FundingProgramInput = z.infer<typeof FundingProgramInputSchema>;
+export type FactInput = z.infer<typeof FactInputSchema>;
+
+// ── Pure builders ───────────────────────────────────────────────────────
+
+/**
+ * Parse + validate a config from a YAML or JSON string.
+ * Returns the parsed config or throws a ZodError / SyntaxError.
+ */
+export function parseConfig(raw: string, format: "yaml" | "json" = "yaml"): SetupOrgConfig {
+  const data = format === "json" ? JSON.parse(raw) : parseYaml(raw);
+  if (data === null || typeof data !== "object") {
+    throw new Error("config must be a YAML/JSON object");
+  }
+  return SetupOrgConfigSchema.parse(data);
+}
+
+export interface EntityRecord {
+  id: string;
+  stableId: string;
+  wikiId: string;
+  type: string;
+  orgType?: string;
+  title: string;
+  aliases?: string[];
+  website?: string;
+  description?: string;
+  tags?: string[];
+  relatedEntries?: Array<{
+    id: string;
+    type: string;
+    relationship?: string;
+  }>;
+}
+
+/**
+ * Build the YAML entity record (the object that lives inside data/entities/<slug>.yaml).
+ * Fields are ordered to match the convention in existing entity files.
+ */
+export function buildEntityRecord(
+  config: SetupOrgConfig,
+  ids: { wikiId: string; stableId: string },
+): EntityRecord {
+  const record: EntityRecord = {
+    id: config.slug,
+    stableId: ids.stableId,
+    wikiId: ids.wikiId,
+    type: config.type,
+    title: config.name,
+  };
+  if (config.orgType) record.orgType = config.orgType;
+  if (config.aliases?.length) record.aliases = [...config.aliases];
+  if (config.website) record.website = config.website;
+  if (config.description) record.description = config.description;
+  if (config.tags?.length) record.tags = [...config.tags];
+  if (config.relatedEntries?.length) {
+    record.relatedEntries = config.relatedEntries.map((r) => {
+      const out: { id: string; type: string; relationship?: string } = {
+        id: r.id,
+        type: r.type,
+      };
+      if (r.relationship) out.relationship = r.relationship;
+      return out;
+    });
+  }
+  return record;
+}
+
+interface FactBaseFact {
+  id: string;
+  property: string;
+  value: string | number;
+  asOf?: string;
+  unit?: string;
+  currency?: string;
+  source?: string;
+  notes?: string;
+}
+
+export interface FactBaseEntityDoc {
+  entity: string;
+  facts: FactBaseFact[];
+}
+
+/**
+ * Build the FactBase YAML document (entity stub + initial facts).
+ * Facts get deterministic IDs based on the entity stableId + property + asOf
+ * so re-running the command on the same config produces the same fact IDs.
+ */
+export function buildFactBaseDoc(
+  stableId: string,
+  facts: FactInput[] | undefined,
+): FactBaseEntityDoc {
+  const factRows: FactBaseFact[] = (facts ?? []).map((f) => {
+    const seed = `${stableId}|${f.property}|${f.asOf ?? ""}`;
+    const factId = `f_${generateId(seed)}`;
+    const out: FactBaseFact = { id: factId, property: f.property, value: f.value };
+    if (f.asOf) out.asOf = f.asOf;
+    if (f.unit) out.unit = f.unit;
+    if (f.currency) out.currency = f.currency;
+    if (f.source) out.source = f.source;
+    if (f.notes) out.notes = f.notes;
+    return out;
+  });
+  return { entity: stableId, facts: factRows };
+}
+
+export interface DivisionRow {
+  id: string;
+  idSeed: string;
+  parentOrgId: string;
+  name: string;
+  divisionType: string;
+  status: string;
+  startDate: string | null;
+  endDate: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+/**
+ * Build the rows that get sent to /api/divisions/sync.
+ * Each idSeed follows the `div|<orgSlug>|<divisionSlug>` convention used
+ * throughout import-divisions.ts so the IDs collide cleanly if the same
+ * division is later added to that constants file.
+ */
+export function buildDivisionRows(
+  config: SetupOrgConfig,
+  parentOrgId: string,
+): DivisionRow[] {
+  const rows: DivisionRow[] = [];
+  const seenIds = new Set<string>();
+  const seenSlugs = new Set<string>();
+  for (const d of config.divisions ?? []) {
+    const slug = d.slug ?? toSlug(d.name);
+    if (seenSlugs.has(slug)) {
+      throw new Error(`duplicate division slug: ${slug}`);
+    }
+    seenSlugs.add(slug);
+    const idSeed = `div|${config.slug}|${slug}`;
+    const id = generateId(idSeed);
+    if (seenIds.has(id)) {
+      // Should be impossible given seenSlugs but guard against generateId collision.
+      throw new Error(`division id collision for seed: ${idSeed}`);
+    }
+    seenIds.add(id);
+    rows.push({
+      id,
+      idSeed,
+      parentOrgId,
+      name: d.name,
+      divisionType: d.divisionType,
+      status: d.status,
+      startDate: d.startDate ?? null,
+      endDate: d.endDate ?? null,
+      source: d.source ?? null,
+      notes: d.notes ?? null,
+    });
+  }
+  return rows;
+}
+
+export interface FundingProgramRow {
+  id: string;
+  idSeed: string;
+  orgId: string;
+  divisionId: string | null;
+  divisionIdSeed: string | null;
+  name: string;
+  description: string | null;
+  programType: string;
+  totalBudget: number | null;
+  currency: string | null;
+  status: string;
+  source: string | null;
+  notes: string | null;
+  deadline: string | null;
+  applicationUrl: string | null;
+  openDate: string | null;
+}
+
+/**
+ * Build the rows that get sent to /api/funding-programs/sync.
+ * If a program references a divisionSlug, it must match a division in the
+ * same config — otherwise we throw rather than silently linking to nothing.
+ */
+export function buildFundingProgramRows(
+  config: SetupOrgConfig,
+  orgStableId: string,
+  divisionRows: DivisionRow[],
+): FundingProgramRow[] {
+  const divisionIdBySlug = new Map<string, { id: string; idSeed: string }>();
+  for (const d of config.divisions ?? []) {
+    const slug = d.slug ?? toSlug(d.name);
+    const row = divisionRows.find((r) => r.idSeed.endsWith(`|${slug}`));
+    if (row) divisionIdBySlug.set(slug, { id: row.id, idSeed: row.idSeed });
+  }
+
+  const rows: FundingProgramRow[] = [];
+  const seenSlugs = new Set<string>();
+  for (const p of config.fundingPrograms ?? []) {
+    const slug = p.slug ?? toSlug(p.name);
+    if (seenSlugs.has(slug)) {
+      throw new Error(`duplicate funding-program slug: ${slug}`);
+    }
+    seenSlugs.add(slug);
+
+    let divisionId: string | null = null;
+    let divisionIdSeed: string | null = null;
+    if (p.divisionSlug) {
+      const linked = divisionIdBySlug.get(p.divisionSlug);
+      if (!linked) {
+        throw new Error(
+          `funding program "${p.name}" references unknown division slug "${p.divisionSlug}"`,
+        );
+      }
+      divisionId = linked.id;
+      divisionIdSeed = linked.idSeed;
+    }
+
+    const idSeed = `prog|${config.slug}|${slug}`;
+    const id = generateId(idSeed);
+    rows.push({
+      id,
+      idSeed,
+      orgId: orgStableId,
+      divisionId,
+      divisionIdSeed,
+      name: p.name,
+      description: p.description ?? null,
+      programType: p.programType,
+      totalBudget: p.totalBudget ?? null,
+      currency: p.currency ?? null,
+      status: p.status,
+      source: p.source ?? null,
+      notes: p.notes ?? null,
+      deadline: p.deadline ?? null,
+      applicationUrl: p.applicationUrl ?? null,
+      openDate: p.openDate ?? null,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Pretty-print a TypeScript snippet the user can paste into
+ * crux/commands/import-divisions.ts to make synced divisions
+ * persistent across `import-divisions sync` runs.
+ */
+export function formatDivisionsSnippet(rows: DivisionRow[], orgSlug: string): string {
+  if (rows.length === 0) return "";
+  const lines: string[] = [];
+  lines.push(`  // ---- ${orgSlug} ----`);
+  for (const r of rows) {
+    lines.push(`  {`);
+    lines.push(`    idSeed: ${JSON.stringify(r.idSeed)},`);
+    lines.push(`    parentOrgId: ${JSON.stringify(r.parentOrgId)},`);
+    lines.push(`    name: ${JSON.stringify(r.name)},`);
+    lines.push(`    divisionType: ${JSON.stringify(r.divisionType)},`);
+    lines.push(`    status: ${JSON.stringify(r.status)},`);
+    if (r.startDate) lines.push(`    startDate: ${JSON.stringify(r.startDate)},`);
+    if (r.endDate) lines.push(`    endDate: ${JSON.stringify(r.endDate)},`);
+    if (r.source) lines.push(`    source: ${JSON.stringify(r.source)},`);
+    if (r.notes) lines.push(`    notes: ${JSON.stringify(r.notes)},`);
+    lines.push(`  },`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Pretty-print a TypeScript snippet for crux/commands/import-funding-programs.ts.
+ */
+export function formatFundingProgramsSnippet(
+  rows: FundingProgramRow[],
+  orgSlug: string,
+): string {
+  if (rows.length === 0) return "";
+  const lines: string[] = [];
+  lines.push(`  // ---- ${orgSlug} ----`);
+  for (const r of rows) {
+    lines.push(`  {`);
+    lines.push(`    idSeed: ${JSON.stringify(r.idSeed)},`);
+    lines.push(`    orgId: ${JSON.stringify(r.orgId)},`);
+    if (r.divisionIdSeed) {
+      lines.push(`    divisionIdSeed: ${JSON.stringify(r.divisionIdSeed)},`);
+    }
+    lines.push(`    name: ${JSON.stringify(r.name)},`);
+    if (r.description) lines.push(`    description: ${JSON.stringify(r.description)},`);
+    lines.push(`    programType: ${JSON.stringify(r.programType)},`);
+    if (r.totalBudget != null) lines.push(`    totalBudget: ${r.totalBudget},`);
+    if (r.currency) lines.push(`    currency: ${JSON.stringify(r.currency)},`);
+    lines.push(`    status: ${JSON.stringify(r.status)},`);
+    if (r.source) lines.push(`    source: ${JSON.stringify(r.source)},`);
+    if (r.notes) lines.push(`    notes: ${JSON.stringify(r.notes)},`);
+    if (r.deadline) lines.push(`    deadline: ${JSON.stringify(r.deadline)},`);
+    if (r.applicationUrl) lines.push(`    applicationUrl: ${JSON.stringify(r.applicationUrl)},`);
+    if (r.openDate) lines.push(`    openDate: ${JSON.stringify(r.openDate)},`);
+    lines.push(`  },`);
+  }
+  return lines.join("\n");
+}
+
+// ── File I/O helpers ────────────────────────────────────────────────────
+
+export interface FilePlan {
+  entityYamlPath: string;
+  entityYamlContents: string;
+  entityYamlExists: boolean;
+  factbaseYamlPath: string;
+  factbaseYamlContents: string;
+  factbaseYamlExists: boolean;
+}
+
+/**
+ * Compute the full file-write plan without touching disk.
+ * `repoRoot` lets tests point at a temp directory.
+ */
+export function planFiles(
+  repoRoot: string,
+  config: SetupOrgConfig,
+  record: EntityRecord,
+  factbaseDoc: FactBaseEntityDoc,
+): FilePlan {
+  const entityYamlPath = join(repoRoot, "data/entities", `${config.slug}.yaml`);
+  const factbaseYamlPath = join(
+    repoRoot,
+    "packages/factbase/data/fb-entities",
+    `${config.slug}.yaml`,
+  );
+
+  // Entity YAML is a single-element list — `loadYamlDir` merges all files in
+  // the directory, so a one-entry file behaves the same as appending to
+  // organizations.yaml without the risk of corrupting an existing multi-entry file.
+  const entityYamlContents = stringifyYaml([record], { lineWidth: 0 });
+
+  // FactBase YAML is one-file-per-entity. Empty-facts case still emits the
+  // `facts: []` key to keep the schema consistent.
+  const factbaseYamlContents = stringifyYaml(factbaseDoc, { lineWidth: 0 });
+
+  return {
+    entityYamlPath,
+    entityYamlContents,
+    entityYamlExists: existsSync(entityYamlPath),
+    factbaseYamlPath,
+    factbaseYamlContents,
+    factbaseYamlExists: existsSync(factbaseYamlPath),
+  };
+}
+
+function writeFileEnsuringDir(path: string, contents: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, contents, "utf-8");
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────────
+
+interface SetupOrgOptions extends BaseOptions {
+  config?: string;
+  apply?: boolean;
+  ci?: boolean;
+  json?: boolean;
+}
+
+interface StepResult {
+  step: string;
+  status: "ok" | "skipped" | "failed";
+  detail?: string;
+}
+
+interface Report {
+  slug: string;
+  name: string;
+  wikiId: string | null;
+  stableId: string | null;
+  applied: boolean;
+  steps: StepResult[];
+  divisions: { count: number; ids: string[] };
+  fundingPrograms: { count: number; ids: string[] };
+  factbaseFacts: number;
+  files: { path: string; willOverwrite: boolean }[];
+  followUp: string[];
+  divisionsSnippet?: string;
+  fundingProgramsSnippet?: string;
+}
+
+function readConfigSource(
+  configFlag: string,
+  cwd: string,
+  stdinReader: () => string,
+): { raw: string; format: "yaml" | "json" } {
+  if (configFlag === "-") {
+    return { raw: stdinReader(), format: "json" };
+  }
+  const path = isAbsolute(configFlag) ? configFlag : resolve(cwd, configFlag);
+  if (!existsSync(path)) {
+    throw new Error(`config file not found: ${path}`);
+  }
+  const raw = readFileSync(path, "utf-8");
+  const format = path.endsWith(".json") ? "json" : "yaml";
+  return { raw, format };
+}
+
+function readStdinSync(): string {
+  // fd 0 = stdin; readFileSync returns a string when an encoding is given.
+  return readFileSync(0, "utf-8");
+}
+
+interface OrchestratorDeps {
+  repoRoot: string;
+  /**
+   * Look up an existing wiki ID for a slug. Returns null for `not found`,
+   * which means the dry-run preview shows `<would allocate>` instead of
+   * provisioning a new ID against prod.
+   */
+  getIdBySlug: (
+    slug: string,
+  ) => Promise<{ ok: true; data: { wikiId: string; stableId: string } | null } | { ok: false; message: string }>;
+  /** Allocate a new wiki ID. Only called in --apply mode. */
+  allocateId: (
+    slug: string,
+    description?: string,
+  ) => Promise<{ ok: true; data: { wikiId: string; stableId: string } } | { ok: false; message: string }>;
+  syncEntities: (
+    items: Array<Record<string, unknown>>,
+  ) => Promise<{ ok: true; data: { upserted: number } } | { ok: false; message: string }>;
+  syncDivisions: (
+    items: Array<Record<string, unknown>>,
+  ) => Promise<{ ok: true; data: unknown } | { ok: false; message: string }>;
+  syncFundingPrograms: (
+    items: ReadonlyArray<unknown>,
+  ) => Promise<{ ok: true; data: unknown } | { ok: false; message: string }>;
+  writeFile: (path: string, contents: string) => void;
+  log: (line: string) => void;
+}
+
+/** Placeholder shown for IDs we haven't allocated yet (dry-run on a new slug). */
+const PLACEHOLDER_WIKI_ID = "<would-allocate>";
+const PLACEHOLDER_STABLE_ID = "sid_PREVIEW00";
+
+/**
+ * Pure orchestration entry point — exported for unit tests so they can
+ * inject mock wiki-server clients and a temp file system.
+ */
+export async function runSetupOrg(
+  config: SetupOrgConfig,
+  apply: boolean,
+  deps: OrchestratorDeps,
+): Promise<Report> {
+  const steps: StepResult[] = [];
+  const report: Report = {
+    slug: config.slug,
+    name: config.name,
+    wikiId: null,
+    stableId: null,
+    applied: apply,
+    steps,
+    divisions: { count: 0, ids: [] },
+    fundingPrograms: { count: 0, ids: [] },
+    factbaseFacts: 0,
+    files: [],
+    followUp: [],
+  };
+
+  // 1. Resolve wiki ID. In --apply mode we POST to /allocate (idempotent).
+  // In dry-run mode we only GET — never provision a new entity_ids row, so
+  // previewing a brand-new slug doesn't pollute the prod allocation table.
+  let wikiId: string;
+  let stableId: string;
+  if (apply) {
+    deps.log(`Allocating wiki ID for ${config.slug}…`);
+    const idResult = await deps.allocateId(config.slug, config.name);
+    if (!idResult.ok) {
+      steps.push({ step: "allocate-id", status: "failed", detail: idResult.message });
+      return report;
+    }
+    wikiId = idResult.data.wikiId;
+    stableId = idResult.data.stableId;
+    steps.push({
+      step: "allocate-id",
+      status: "ok",
+      detail: `${wikiId} / ${stableId}`,
+    });
+  } else {
+    deps.log(`Looking up wiki ID for ${config.slug}…`);
+    const lookup = await deps.getIdBySlug(config.slug);
+    if (!lookup.ok) {
+      // Wiki-server unreachable: still preview with placeholders rather than fail.
+      wikiId = PLACEHOLDER_WIKI_ID;
+      stableId = PLACEHOLDER_STABLE_ID;
+      steps.push({
+        step: "allocate-id",
+        status: "skipped",
+        detail: `dry-run; lookup failed (${lookup.message})`,
+      });
+    } else if (lookup.data) {
+      wikiId = lookup.data.wikiId;
+      stableId = lookup.data.stableId;
+      steps.push({
+        step: "allocate-id",
+        status: "skipped",
+        detail: `dry-run; existing ${wikiId} / ${stableId}`,
+      });
+    } else {
+      wikiId = PLACEHOLDER_WIKI_ID;
+      stableId = PLACEHOLDER_STABLE_ID;
+      steps.push({
+        step: "allocate-id",
+        status: "skipped",
+        detail: "dry-run; would allocate new ID",
+      });
+    }
+  }
+  report.wikiId = wikiId;
+  report.stableId = stableId;
+
+  // 2. Build records from config + allocated IDs.
+  const entityRecord = buildEntityRecord(config, { wikiId, stableId });
+  const factbaseDoc = buildFactBaseDoc(stableId, config.facts);
+  report.factbaseFacts = factbaseDoc.facts.length;
+
+  const divisionRows = buildDivisionRows(config, stableId);
+  const programRows = buildFundingProgramRows(config, stableId, divisionRows);
+  report.divisions.count = divisionRows.length;
+  report.divisions.ids = divisionRows.map((r) => r.id);
+  report.fundingPrograms.count = programRows.length;
+  report.fundingPrograms.ids = programRows.map((r) => r.id);
+
+  // 3. Plan file writes.
+  const filePlan = planFiles(deps.repoRoot, config, entityRecord, factbaseDoc);
+  report.files = [
+    { path: filePlan.entityYamlPath, willOverwrite: filePlan.entityYamlExists },
+    { path: filePlan.factbaseYamlPath, willOverwrite: filePlan.factbaseYamlExists },
+  ];
+
+  if (apply) {
+    deps.writeFile(filePlan.entityYamlPath, filePlan.entityYamlContents);
+    steps.push({
+      step: "write-entity-yaml",
+      status: "ok",
+      detail: filePlan.entityYamlPath,
+    });
+    deps.writeFile(filePlan.factbaseYamlPath, filePlan.factbaseYamlContents);
+    steps.push({
+      step: "write-factbase-yaml",
+      status: "ok",
+      detail: filePlan.factbaseYamlPath,
+    });
+  } else {
+    steps.push({ step: "write-entity-yaml", status: "skipped", detail: "dry-run" });
+    steps.push({ step: "write-factbase-yaml", status: "skipped", detail: "dry-run" });
+  }
+
+  // 4. Sync entity to PG.
+  if (apply) {
+    const entityForSync: Record<string, unknown> = {
+      id: entityRecord.id,
+      stableId: entityRecord.stableId,
+      wikiId: entityRecord.wikiId,
+      entityType: entityRecord.type,
+      title: entityRecord.title,
+    };
+    if (entityRecord.description) entityForSync.description = entityRecord.description;
+    if (entityRecord.website) entityForSync.website = entityRecord.website;
+    if (entityRecord.tags?.length) entityForSync.tags = entityRecord.tags;
+    if (entityRecord.relatedEntries?.length) {
+      entityForSync.relatedEntries = entityRecord.relatedEntries;
+    }
+    const syncResult = await deps.syncEntities([entityForSync]);
+    steps.push({
+      step: "sync-entity-pg",
+      status: syncResult.ok ? "ok" : "failed",
+      detail: syncResult.ok
+        ? `upserted ${syncResult.data.upserted}`
+        : syncResult.message,
+    });
+  } else {
+    steps.push({ step: "sync-entity-pg", status: "skipped", detail: "dry-run" });
+  }
+
+  // 5. Divisions.
+  if (divisionRows.length > 0) {
+    if (apply) {
+      const items = divisionRows.map((r) => ({
+        id: r.id,
+        parentOrgId: r.parentOrgId,
+        name: r.name,
+        divisionType: r.divisionType,
+        status: r.status,
+        startDate: r.startDate,
+        endDate: r.endDate,
+        source: r.source,
+        notes: r.notes,
+      }));
+      const result = await deps.syncDivisions(items);
+      steps.push({
+        step: "sync-divisions",
+        status: result.ok ? "ok" : "failed",
+        detail: result.ok ? `${divisionRows.length} divisions` : result.message,
+      });
+    } else {
+      steps.push({
+        step: "sync-divisions",
+        status: "skipped",
+        detail: `dry-run (${divisionRows.length} divisions)`,
+      });
+    }
+    report.divisionsSnippet = formatDivisionsSnippet(divisionRows, config.slug);
+  }
+
+  // 6. Funding programs.
+  if (programRows.length > 0) {
+    if (apply) {
+      const items = programRows.map((r) => ({
+        id: r.id,
+        orgId: r.orgId,
+        divisionId: r.divisionId,
+        name: r.name,
+        description: r.description,
+        programType: r.programType,
+        totalBudget: r.totalBudget,
+        currency: r.currency,
+        status: r.status,
+        source: r.source,
+        notes: r.notes,
+        deadline: r.deadline,
+        applicationUrl: r.applicationUrl,
+        openDate: r.openDate,
+      }));
+      const result = await deps.syncFundingPrograms(items);
+      steps.push({
+        step: "sync-funding-programs",
+        status: result.ok ? "ok" : "failed",
+        detail: result.ok ? `${programRows.length} programs` : result.message,
+      });
+    } else {
+      steps.push({
+        step: "sync-funding-programs",
+        status: "skipped",
+        detail: `dry-run (${programRows.length} programs)`,
+      });
+    }
+    report.fundingProgramsSnippet = formatFundingProgramsSnippet(programRows, config.slug);
+  }
+
+  // 7. Follow-ups (always shown — these aren't automated).
+  report.followUp.push(
+    `Create the wiki page: WIKI_SERVER_ENV=prod pnpm crux w create ${JSON.stringify(config.name)} --tier=standard`,
+  );
+  report.followUp.push(
+    `Discover related personnel: WIKI_SERVER_ENV=prod pnpm crux tb people discover`,
+  );
+  if (divisionRows.length > 0) {
+    report.followUp.push(
+      `Persist divisions: paste the snippet above into the DIVISIONS array in crux/commands/import-divisions.ts so subsequent \`import-divisions sync\` runs keep them.`,
+    );
+  }
+  if (programRows.length > 0) {
+    report.followUp.push(
+      `Persist funding programs: paste the snippet above into the PROGRAMS array in crux/commands/import-funding-programs.ts.`,
+    );
+  }
+  report.followUp.push(
+    `Verify in PG: WIKI_SERVER_ENV=prod pnpm crux query search ${JSON.stringify(config.name)}`,
+  );
+
+  return report;
+}
+
+// ── CLI formatting ──────────────────────────────────────────────────────
+
+const BOLD = "\x1b[1m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+function statusGlyph(status: StepResult["status"]): string {
+  if (status === "ok") return `${GREEN}✓${RESET}`;
+  if (status === "failed") return `${RED}✗${RESET}`;
+  return `${DIM}⊘${RESET}`;
+}
+
+export function formatReport(report: Report): string {
+  const lines: string[] = [];
+  const header = report.applied ? "Applied" : "Dry run (preview)";
+  lines.push(`${BOLD}=== Setup Org: ${report.name} (${header}) ===${RESET}`);
+  lines.push(`  slug:     ${report.slug}`);
+  if (report.wikiId) lines.push(`  wikiId:   ${report.wikiId}`);
+  if (report.stableId) lines.push(`  stableId: ${report.stableId}`);
+  lines.push("");
+
+  lines.push(`${BOLD}Steps:${RESET}`);
+  for (const s of report.steps) {
+    const detail = s.detail ? `  ${DIM}${s.detail}${RESET}` : "";
+    lines.push(`  ${statusGlyph(s.status)} ${s.step}${detail}`);
+  }
+  lines.push("");
+
+  lines.push(`${BOLD}Created:${RESET}`);
+  lines.push(`  Entity:           ${report.applied ? "yes" : "would create"}`);
+  lines.push(`  FactBase facts:   ${report.factbaseFacts}`);
+  lines.push(`  Divisions:        ${report.divisions.count}`);
+  lines.push(`  Funding programs: ${report.fundingPrograms.count}`);
+  lines.push("");
+
+  if (report.files.length > 0) {
+    lines.push(`${BOLD}Files:${RESET}`);
+    for (const f of report.files) {
+      const note = f.willOverwrite ? `${DIM}(overwrites existing)${RESET}` : "";
+      lines.push(`  ${f.path} ${note}`.trimEnd());
+    }
+    lines.push("");
+  }
+
+  if (report.divisionsSnippet) {
+    lines.push(`${BOLD}Snippet for crux/commands/import-divisions.ts (DIVISIONS array):${RESET}`);
+    lines.push(report.divisionsSnippet);
+    lines.push("");
+  }
+
+  if (report.fundingProgramsSnippet) {
+    lines.push(`${BOLD}Snippet for crux/commands/import-funding-programs.ts (PROGRAMS array):${RESET}`);
+    lines.push(report.fundingProgramsSnippet);
+    lines.push("");
+  }
+
+  if (report.followUp.length > 0) {
+    lines.push(`${BOLD}Follow-up steps:${RESET}`);
+    for (const f of report.followUp) {
+      lines.push(`  • ${f}`);
+    }
+    lines.push("");
+  }
+
+  if (!report.applied) {
+    lines.push(`${DIM}(re-run with --apply to write files and sync to PG)${RESET}`);
+  }
+
+  return lines.join("\n");
+}
+
+function reportExitCode(report: Report): number {
+  return report.steps.some((s) => s.status === "failed") ? 1 : 0;
+}
+
+// ── Command entry ───────────────────────────────────────────────────────
+
+async function setupOrgCommand(
+  _args: string[],
+  options: SetupOrgOptions,
+): Promise<CommandResult> {
+  if (!options.config) {
+    return {
+      exitCode: 1,
+      output:
+        "Usage: crux tb setup-org --config=<path-to-yaml-or-json> [--apply] [--ci]\n" +
+        "       crux tb setup-org --config=- --apply   # JSON config from stdin",
+    };
+  }
+
+  let config: SetupOrgConfig;
+  try {
+    const { raw, format } = readConfigSource(
+      options.config,
+      process.cwd(),
+      readStdinSync,
+    );
+    config = parseConfig(raw, format);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, output: `Config error: ${message}` };
+  }
+
+  const repoRoot = process.cwd();
+  const apply = !!options.apply;
+
+  const { allocateId, getIdBySlug } = await import("../lib/wiki-server/ids.ts");
+  const { syncEntities } = await import("../lib/wiki-server/entities.ts");
+  const { syncDivisions } = await import("../lib/wiki-server/divisions.ts");
+  const { syncFundingPrograms } = await import("../lib/wiki-server/funding-programs.ts");
+
+  const deps: OrchestratorDeps = {
+    repoRoot,
+    getIdBySlug: async (slug) => {
+      const r = await getIdBySlug(slug);
+      if (!r.ok) {
+        // 404 is the expected "not allocated yet" case — return null, not an error.
+        if (r.error === "bad_request") return { ok: true, data: null };
+        return { ok: false, message: r.message };
+      }
+      if (!r.data.stableId) return { ok: true, data: null };
+      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
+    },
+    allocateId: async (slug, description) => {
+      const r = await allocateId(slug, description);
+      if (!r.ok) return { ok: false, message: r.message };
+      if (!r.data.stableId) {
+        return { ok: false, message: `wiki-server returned no stableId for slug "${slug}"` };
+      }
+      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
+    },
+    syncEntities: async (items) => {
+      const r = await syncEntities(
+        items as unknown as Parameters<typeof syncEntities>[0],
+      );
+      if (!r.ok) return { ok: false, message: r.message };
+      return { ok: true, data: { upserted: r.data.upserted } };
+    },
+    syncDivisions: async (items) => {
+      const r = await syncDivisions(items);
+      if (!r.ok) return { ok: false, message: r.message };
+      return { ok: true, data: r.data };
+    },
+    syncFundingPrograms: async (items) => {
+      const r = await syncFundingPrograms(items);
+      if (!r.ok) return { ok: false, message: r.message };
+      return { ok: true, data: r.data };
+    },
+    writeFile: writeFileEnsuringDir,
+    log: (line) => {
+      if (!options.ci && !options.json) console.error(line);
+    },
+  };
+
+  const report = await runSetupOrg(config, apply, deps);
+  const exitCode = reportExitCode(report);
+
+  if (options.ci || options.json) {
+    return { exitCode, output: JSON.stringify(report, null, 2) };
+  }
+  return { exitCode, output: formatReport(report) };
+}
+
+export const commands: Record<
+  string,
+  (args: string[], options: BaseOptions) => Promise<CommandResult>
+> = {
+  default: setupOrgCommand,
+};
+
+export function getHelp(): string {
+  return `
+${BOLD}setup-org${RESET} — Single-shot organization onboarding (QUA-35)
+
+Replaces the manual ~15-step onboarding flow with one config file:
+  • Allocates wiki ID (E-number + sid_ stableId)
+  • Writes the YAML entity at data/entities/<slug>.yaml
+  • Writes the FactBase entity at packages/factbase/data/fb-entities/<slug>.yaml
+  • Syncs entity, divisions, and funding programs to wiki-server PG
+  • Outputs a verification report and snippets for the persistent constants files
+
+${BOLD}Usage:${RESET}
+  crux tb setup-org --config=path/to/aria.yaml          # Dry run (preview)
+  crux tb setup-org --config=path/to/aria.yaml --apply  # Actually write + sync
+  crux tb setup-org --config=- --apply                  # JSON config from stdin
+  crux tb setup-org --config=path/to/aria.yaml --ci     # JSON output
+
+${BOLD}Config schema (YAML):${RESET}
+  slug: aria                              # required, kebab-case
+  name: Advanced Research and Innovation Agency  # required
+  type: organization                      # default: organization
+  aliases: [ARIA]
+  website: https://aria.org.uk
+  description: ...
+  orgType: government-agency
+  tags: [funder, government]
+  relatedEntries:
+    - id: sid_xxx
+      type: person
+      relationship: leads-to
+  divisions:
+    - name: Programmable Plants
+      divisionType: program-area          # fund | team | department | lab | program-area
+      status: active                      # active | inactive | dissolved
+      source: ...
+  fundingPrograms:
+    - name: Programmable Plants Programme
+      programType: rfp                    # rfp | grant-round | fellowship | prize | solicitation | call
+      status: open                        # open | closed | awarded
+      totalBudget: 60000000
+      currency: GBP
+      deadline: Rolling
+      divisionSlug: programmable-plants   # links to one of the divisions above
+  facts:
+    - property: founded-date
+      value: "2023"
+      source: https://aria.org.uk/about
+
+${BOLD}Apply requires WIKI_SERVER_ENV=prod from agent slots:${RESET}
+  WIKI_SERVER_ENV=prod pnpm crux tb setup-org --config=aria.yaml --apply
+
+${BOLD}Out of scope (run separately afterwards):${RESET}
+  • Wiki page authoring → pnpm crux w create "<name>" --tier=standard
+  • Personnel discovery → pnpm crux tb people discover
+  • Grant ingestion     → pnpm crux tb import-grants sync
+`;
+}

--- a/crux/commands/setup-org.ts
+++ b/crux/commands/setup-org.ts
@@ -720,6 +720,11 @@ export async function runSetupOrg(
     if (entityRecord.relatedEntries?.length) {
       entityForSync.relatedEntries = entityRecord.relatedEntries;
     }
+    // Non-base fields (aliases, orgType) ride along in metadata so PG mirrors YAML.
+    const metadata: Record<string, unknown> = {};
+    if (entityRecord.orgType) metadata.orgType = entityRecord.orgType;
+    if (entityRecord.aliases?.length) metadata.aliases = entityRecord.aliases;
+    if (Object.keys(metadata).length > 0) entityForSync.metadata = metadata;
     const syncResult = await deps.syncEntities([entityForSync]);
     entitySyncOk = syncResult.ok;
     steps.push({
@@ -768,7 +773,10 @@ export async function runSetupOrg(
         detail: `dry-run (${divisionRows.length} divisions)`,
       });
     }
-    report.divisionsSnippet = formatDivisionsSnippet(divisionRows, config.slug);
+    const divisionsSnippet = formatDivisionsSnippet(divisionRows, config.slug);
+    report.divisionsSnippet = stableId === PLACEHOLDER_STABLE_ID
+      ? `  // NOTE: dry-run preview — replace "${PLACEHOLDER_STABLE_ID}" with the real stable ID before pasting.\n${divisionsSnippet}`
+      : divisionsSnippet;
   }
 
   // 6. Funding programs. Same skip-on-entity-failure rule as divisions.
@@ -809,7 +817,10 @@ export async function runSetupOrg(
         detail: `dry-run (${programRows.length} programs)`,
       });
     }
-    report.fundingProgramsSnippet = formatFundingProgramsSnippet(programRows, config.slug);
+    const programsSnippet = formatFundingProgramsSnippet(programRows, config.slug);
+    report.fundingProgramsSnippet = stableId === PLACEHOLDER_STABLE_ID
+      ? `  // NOTE: dry-run preview — replace "${PLACEHOLDER_STABLE_ID}" with the real stable ID before pasting.\n${programsSnippet}`
+      : programsSnippet;
   }
 
   // 7. Follow-ups (always shown — these aren't automated).
@@ -924,23 +935,32 @@ function adaptApiResult<T>(r: ApiCallResult<T>): Result<T> {
   return r.ok ? { ok: true, data: r.data } : { ok: false, message: `${r.error}: ${r.message}` };
 }
 
+/**
+ * Adapt the raw wiki-server `getIdBySlug` response into the orchestrator's
+ * lookup shape. The wiki-server returns 404 for "slug not allocated" — a
+ * valid lookup result, not an error. The HTTP client coerces all 4xx to
+ * `bad_request`, so we narrow on the "404" message prefix to avoid
+ * swallowing real 400/422/429.
+ *
+ * Exported for unit testing.
+ */
+export function adaptIdLookup(
+  r: ApiCallResult<{ wikiId: string; stableId: string | null }>,
+): Result<Ids | null> {
+  if (!r.ok) {
+    if (r.error === "bad_request" && /^404[:\s]/.test(r.message)) {
+      return { ok: true, data: null };
+    }
+    return { ok: false, message: `${r.error}: ${r.message}` };
+  }
+  if (!r.data.stableId) return { ok: true, data: null };
+  return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
+}
+
 export function buildLiveDeps(repoRoot: string, ciOrJson: boolean): OrchestratorDeps {
   return {
     repoRoot,
-    getIdBySlug: async (slug) => {
-      const r = await getIdBySlug(slug);
-      if (!r.ok) {
-        // wiki-server returns 404 for "slug not allocated" — a valid lookup
-        // result, not an error. The client coerces all 4xx to `bad_request`,
-        // so narrow on the message prefix to avoid swallowing real 400/422/429.
-        if (r.error === "bad_request" && /^404[:\s]/.test(r.message)) {
-          return { ok: true, data: null };
-        }
-        return { ok: false, message: `${r.error}: ${r.message}` };
-      }
-      if (!r.data.stableId) return { ok: true, data: null };
-      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
-    },
+    getIdBySlug: async (slug) => adaptIdLookup(await getIdBySlug(slug)),
     allocateId: async (slug, description) => {
       const r = await allocateId(slug, description);
       if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };

--- a/crux/commands/setup-org.ts
+++ b/crux/commands/setup-org.ts
@@ -1,28 +1,16 @@
 /**
- * `crux tb setup-org` — single-shot organization onboarding (QUA-35).
+ * `crux tb setup-org` — single-shot organization onboarding.
  *
- * Replaces the manual ~15-step entity onboarding flow with one command:
- *   1. Allocate wiki ID (E-number + sid_ stableId) via wiki-server
- *   2. Write the FactBase entity stub at packages/factbase/data/fb-entities/<slug>.yaml
- *   3. Write the YAML entity file at data/entities/<slug>.yaml
- *   4. Sync entity to PG (entities table)
- *   5. Sync optional divisions to PG (divisions table)
- *   6. Sync optional funding programs to PG (funding_programs table)
- *   7. Emit a verification report listing what was created and what manual
- *      follow-ups remain (wiki page authoring, personnel discovery, grants,
- *      and snippets to make divisions/programs persistent in the
- *      `import-divisions.ts` / `import-funding-programs.ts` constants files).
+ * Reads a YAML/JSON config and orchestrates wiki ID allocation, FactBase
+ * entity stub, YAML entity file, and PG sync of entity/divisions/programs.
+ * Emits a verification report and copy-pastable snippets for the persistent
+ * constants files in import-divisions.ts / import-funding-programs.ts.
  *
- * Default mode is dry-run/preview — writes only happen when `--apply` is set.
- *
- * Usage:
- *   crux tb setup-org --config=path/to/aria.yaml
- *   crux tb setup-org --config=path/to/aria.yaml --apply
- *   crux tb setup-org --config=- --apply              # JSON config from stdin
- *   crux tb setup-org --config=path/to/aria.yaml --ci # JSON output
+ * Default mode is dry-run; `--apply` writes files and syncs to PG.
+ * See `getHelp()` for full Usage and config schema.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
@@ -32,31 +20,45 @@ import type {
   CommandResult,
 } from "../lib/command-types.ts";
 import { generateId } from "../lib/grant-import/id.ts";
+import { generateContentFactId } from "../../packages/factbase/src/ids.ts";
 import { toSlug } from "../tablebase/types.ts";
+import { getColors } from "../lib/output.ts";
 import { allocateId, getIdBySlug } from "../lib/wiki-server/ids.ts";
 import { syncEntities } from "../lib/wiki-server/entities.ts";
 import { syncDivisions } from "../lib/wiki-server/divisions.ts";
 import { syncFundingPrograms } from "../lib/wiki-server/funding-programs.ts";
 
-// ── Constants ──────────────────────────────────────────────────────────
-
 const MAX_NAME_LENGTH = 500;
-const SID_FORMAT_RE = /^sid_[A-Za-z0-9]{10}$/;
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+// Mirrors isSid() from @longterm-wiki/id-utils. crux/tsconfig has no path
+// mapping for that package, so use the local regex (same form as
+// validate-rendered-sid.ts and validate-factbase-stableid.ts).
+const SID_RE = /^sid_[A-Za-z0-9]{10}$/;
+
+// Step names — referenced by tests, kept as a typed const so a typo on either
+// side fails at compile time instead of silently mismatching.
+const STEP = {
+  ALLOCATE: "allocate-id",
+  WRITE_ENTITY: "write-entity-yaml",
+  WRITE_FACTBASE: "write-factbase-yaml",
+  SYNC_ENTITY: "sync-entity-pg",
+  SYNC_DIVISIONS: "sync-divisions",
+  SYNC_PROGRAMS: "sync-funding-programs",
+} as const;
+type StepName = (typeof STEP)[keyof typeof STEP];
 
 // ── Config schema ───────────────────────────────────────────────────────
 
-// relatedEntries point to other entities. Per .claude/rules/id-system.md the
-// canonical ref is a sid_ prefixed stableId. Slugs are also accepted today
-// (see entities/organizations.yaml), so we permit either form.
+// Per .claude/rules/id-system.md, refs are sid_-prefixed stableIds. Slugs
+// are also accepted today (organizations.yaml uses both), so allow either.
 const RelatedEntrySchema = z.object({
   id: z
     .string()
     .min(1)
     .max(300)
-    .refine(
-      (s) => SID_FORMAT_RE.test(s) || /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(s),
-      { message: "id must be a sid_-prefixed stableId or a kebab-case slug" },
-    ),
+    .refine((s) => SID_RE.test(s) || SLUG_RE.test(s), {
+      message: "id must be a sid_-prefixed stableId or a kebab-case slug",
+    }),
   type: z.string().min(1),
   relationship: z.string().optional(),
 });
@@ -111,7 +113,7 @@ const SetupOrgConfigSchema = z.object({
     .string()
     .min(2)
     .max(100)
-    .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, "slug must be kebab-case"),
+    .regex(SLUG_RE, "slug must be kebab-case"),
   name: z.string().min(1).max(MAX_NAME_LENGTH),
   type: z.string().min(1).default("organization"),
   aliases: z.array(z.string().min(1)).optional(),
@@ -132,10 +134,6 @@ export type FactInput = z.infer<typeof FactInputSchema>;
 
 // ── Pure builders ───────────────────────────────────────────────────────
 
-/**
- * Parse + validate a config from a YAML or JSON string.
- * Returns the parsed config or throws a ZodError / SyntaxError.
- */
 export function parseConfig(raw: string, format: "yaml" | "json" = "yaml"): SetupOrgConfig {
   const data = format === "json" ? JSON.parse(raw) : parseYaml(raw);
   if (data === null || typeof data !== "object") {
@@ -162,10 +160,7 @@ export interface EntityRecord {
   }>;
 }
 
-/**
- * Build the YAML entity record (the object that lives inside data/entities/<slug>.yaml).
- * Fields are ordered to match the convention in existing entity files.
- */
+// Field order matches the convention in existing data/entities/*.yaml files.
 export function buildEntityRecord(
   config: SetupOrgConfig,
   ids: { wikiId: string; stableId: string },
@@ -211,19 +206,20 @@ export interface FactBaseEntityDoc {
   facts: FactBaseFact[];
 }
 
-/**
- * Build the FactBase YAML document (entity stub + initial facts).
- * Facts get deterministic IDs based on the entity stableId + property + asOf
- * so re-running the command on the same config produces the same fact IDs.
- */
+// Re-running setup-org with the same config must produce the same fact IDs,
+// otherwise PG sync sees them as new rows. `generateContentFactId` is the
+// canonical helper for this — its seed includes the value, which prevents
+// two facts with the same (property, asOf) but different values from colliding.
 export function buildFactBaseDoc(
   stableId: string,
   facts: FactInput[] | undefined,
 ): FactBaseEntityDoc {
   const factRows: FactBaseFact[] = (facts ?? []).map((f) => {
-    const seed = `${stableId}|${f.property}|${f.asOf ?? ""}`;
-    const factId = `f_${generateId(seed)}`;
-    const out: FactBaseFact = { id: factId, property: f.property, value: f.value };
+    const out: FactBaseFact = {
+      id: generateContentFactId(stableId, f.property, f.value, f.asOf),
+      property: f.property,
+      value: f.value,
+    };
     if (f.asOf) out.asOf = f.asOf;
     if (f.unit) out.unit = f.unit;
     if (f.currency) out.currency = f.currency;
@@ -247,18 +243,14 @@ export interface DivisionRow {
   notes: string | null;
 }
 
-/**
- * Build the rows that get sent to /api/divisions/sync.
- * Each idSeed follows the `div|<orgSlug>|<divisionSlug>` convention used
- * throughout import-divisions.ts so the IDs collide cleanly if the same
- * division is later added to that constants file.
- */
+// idSeed follows the `div|<orgSlug>|<divisionSlug>` convention used throughout
+// import-divisions.ts so the IDs collide cleanly if the same division is later
+// pasted into that constants file via the snippet.
 export function buildDivisionRows(
   config: SetupOrgConfig,
   parentOrgId: string,
 ): DivisionRow[] {
   const rows: DivisionRow[] = [];
-  const seenIds = new Set<string>();
   const seenSlugs = new Set<string>();
   for (const d of config.divisions ?? []) {
     const slug = d.slug ?? toSlug(d.name);
@@ -268,11 +260,6 @@ export function buildDivisionRows(
     seenSlugs.add(slug);
     const idSeed = `div|${config.slug}|${slug}`;
     const id = generateId(idSeed);
-    if (seenIds.has(id)) {
-      // Should be impossible given seenSlugs but guard against generateId collision.
-      throw new Error(`division id collision for seed: ${idSeed}`);
-    }
-    seenIds.add(id);
     rows.push({
       id,
       idSeed,
@@ -308,19 +295,14 @@ export interface FundingProgramRow {
   openDate: string | null;
 }
 
-/**
- * Build the rows that get sent to /api/funding-programs/sync.
- * If a program references a divisionSlug, it must match a division in the
- * same config — otherwise we throw rather than silently linking to nothing.
- */
+// A program's divisionSlug must match a division in the same config —
+// silently leaving it unlinked would produce orphan programs in PG.
 export function buildFundingProgramRows(
   config: SetupOrgConfig,
   orgStableId: string,
   divisionRows: DivisionRow[],
 ): FundingProgramRow[] {
-  // Index divisions by their slug so program → division lookup is O(1).
-  // `config.divisions` and `divisionRows` are built in the same order from
-  // the same source, so we can zip them positionally.
+  // Zip positionally: config.divisions and divisionRows are in the same order.
   const divisionIdBySlug = new Map<string, { id: string; idSeed: string }>();
   (config.divisions ?? []).forEach((d, i) => {
     const slug = d.slug ?? toSlug(d.name);
@@ -374,11 +356,6 @@ export function buildFundingProgramRows(
   return rows;
 }
 
-/**
- * Pretty-print a TypeScript snippet the user can paste into
- * crux/commands/import-divisions.ts to make synced divisions
- * persistent across `import-divisions sync` runs.
- */
 export function formatDivisionsSnippet(rows: DivisionRow[], orgSlug: string): string {
   if (rows.length === 0) return "";
   const lines: string[] = [];
@@ -399,9 +376,6 @@ export function formatDivisionsSnippet(rows: DivisionRow[], orgSlug: string): st
   return lines.join("\n");
 }
 
-/**
- * Pretty-print a TypeScript snippet for crux/commands/import-funding-programs.ts.
- */
 export function formatFundingProgramsSnippet(
   rows: FundingProgramRow[],
   orgSlug: string,
@@ -443,10 +417,7 @@ export interface FilePlan {
   factbaseYamlExists: boolean;
 }
 
-/**
- * Compute the full file-write plan without touching disk.
- * `repoRoot` lets tests point at a temp directory.
- */
+// repoRoot lets tests point at a temp directory.
 export function planFiles(
   repoRoot: string,
   config: SetupOrgConfig,
@@ -480,8 +451,8 @@ export function planFiles(
 }
 
 function writeFileEnsuringDir(path: string, contents: string): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // mkdirSync with recursive:true is idempotent — no existsSync guard needed.
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, contents, "utf-8");
 }
 
@@ -496,7 +467,7 @@ interface SetupOrgOptions extends BaseOptions {
 }
 
 interface StepResult {
-  step: string;
+  step: StepName;
   status: "ok" | "skipped" | "failed";
   detail?: string;
 }
@@ -508,8 +479,8 @@ interface Report {
   stableId: string | null;
   applied: boolean;
   steps: StepResult[];
-  divisions: { count: number; ids: string[] };
-  fundingPrograms: { count: number; ids: string[] };
+  divisions: { ids: string[] };
+  fundingPrograms: { ids: string[] };
   factbaseFacts: number;
   files: { path: string; willOverwrite: boolean }[];
   followUp: string[];
@@ -547,48 +518,34 @@ function readStdinSync(): string {
   return readFileSync(0, "utf-8");
 }
 
+type Result<T> =
+  | { ok: true; data: T }
+  | { ok: false; message: string };
+
+interface Ids {
+  wikiId: string;
+  stableId: string;
+}
+
 interface OrchestratorDeps {
   repoRoot: string;
-  /**
-   * Look up an existing wiki ID for a slug. Returns null for `not found`,
-   * which means the dry-run preview shows `<would allocate>` instead of
-   * provisioning a new ID against prod.
-   */
-  getIdBySlug: (
-    slug: string,
-  ) => Promise<{ ok: true; data: { wikiId: string; stableId: string } | null } | { ok: false; message: string }>;
-  /** Allocate a new wiki ID. Only called in --apply mode. */
-  allocateId: (
-    slug: string,
-    description?: string,
-  ) => Promise<{ ok: true; data: { wikiId: string; stableId: string } } | { ok: false; message: string }>;
-  syncEntities: (
-    items: Array<Record<string, unknown>>,
-  ) => Promise<{ ok: true; data: { upserted: number } } | { ok: false; message: string }>;
-  syncDivisions: (
-    items: Array<Record<string, unknown>>,
-  ) => Promise<{ ok: true; data: unknown } | { ok: false; message: string }>;
-  syncFundingPrograms: (
-    items: ReadonlyArray<unknown>,
-  ) => Promise<{ ok: true; data: unknown } | { ok: false; message: string }>;
+  getIdBySlug: (slug: string) => Promise<Result<Ids | null>>;
+  allocateId: (slug: string, description?: string) => Promise<Result<Ids>>;
+  syncEntities: (items: ReadonlyArray<Record<string, unknown>>) => Promise<Result<{ upserted: number }>>;
+  syncDivisions: (items: ReadonlyArray<Record<string, unknown>>) => Promise<Result<unknown>>;
+  syncFundingPrograms: (items: ReadonlyArray<Record<string, unknown>>) => Promise<Result<unknown>>;
   writeFile: (path: string, contents: string) => void;
   log: (line: string) => void;
 }
 
-/**
- * Placeholders shown for IDs we haven't allocated yet (dry-run on a new slug).
- * Both deliberately fail SID/wikiId validators so any tool downstream of the
- * dry-run report (e.g. a script consuming the JSON output) crashes loudly
- * instead of treating them as real allocated IDs.
- */
+// Placeholders deliberately fail the SID / wikiId validators so a script
+// that consumes the dry-run JSON crashes loudly instead of acting on them.
 const PLACEHOLDER_WIKI_ID = "<would-allocate-wiki-id>";
 const PLACEHOLDER_STABLE_ID = "<would-allocate-stable-id>";
 
-/**
- * Quote a string for safe pasting into a Bash command. Wraps in single quotes
- * and escapes any embedded `'`. Defends against `name = "$(rm -rf ~)"`-style
- * shell-injection in the verification report's copy-pastable follow-up steps.
- */
+// Single-quote wrap with `'\''` escape — prevents $(...)/backtick interpolation
+// in copy-pastable follow-up commands when the user-provided name contains
+// shell metacharacters.
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
@@ -599,21 +556,13 @@ export interface RunSetupOrgOptions {
   force?: boolean;
 }
 
-/**
- * Pure orchestration entry point — exported for unit tests so they can
- * inject mock wiki-server clients and a temp file system.
- */
 export async function runSetupOrg(
   config: SetupOrgConfig,
-  optionsOrApply: boolean | RunSetupOrgOptions,
+  options: RunSetupOrgOptions,
   deps: OrchestratorDeps,
 ): Promise<Report> {
-  const opts: RunSetupOrgOptions =
-    typeof optionsOrApply === "boolean"
-      ? { apply: optionsOrApply }
-      : optionsOrApply;
-  const apply = opts.apply;
-  const force = !!opts.force;
+  const apply = options.apply;
+  const force = !!options.force;
   const steps: StepResult[] = [];
   const report: Report = {
     slug: config.slug,
@@ -622,8 +571,8 @@ export async function runSetupOrg(
     stableId: null,
     applied: apply,
     steps,
-    divisions: { count: 0, ids: [] },
-    fundingPrograms: { count: 0, ids: [] },
+    divisions: { ids: [] },
+    fundingPrograms: { ids: [] },
     factbaseFacts: 0,
     files: [],
     followUp: [],
@@ -638,13 +587,13 @@ export async function runSetupOrg(
     deps.log(`Allocating wiki ID for ${config.slug}…`);
     const idResult = await deps.allocateId(config.slug, config.name);
     if (!idResult.ok) {
-      steps.push({ step: "allocate-id", status: "failed", detail: idResult.message });
+      steps.push({ step: STEP.ALLOCATE, status: "failed", detail: idResult.message });
       return report;
     }
     wikiId = idResult.data.wikiId;
     stableId = idResult.data.stableId;
     steps.push({
-      step: "allocate-id",
+      step: STEP.ALLOCATE,
       status: "ok",
       detail: `${wikiId} / ${stableId}`,
     });
@@ -656,7 +605,7 @@ export async function runSetupOrg(
       wikiId = PLACEHOLDER_WIKI_ID;
       stableId = PLACEHOLDER_STABLE_ID;
       steps.push({
-        step: "allocate-id",
+        step: STEP.ALLOCATE,
         status: "skipped",
         detail: `dry-run; lookup failed (${lookup.message})`,
       });
@@ -664,7 +613,7 @@ export async function runSetupOrg(
       wikiId = lookup.data.wikiId;
       stableId = lookup.data.stableId;
       steps.push({
-        step: "allocate-id",
+        step: STEP.ALLOCATE,
         status: "skipped",
         detail: `dry-run; existing ${wikiId} / ${stableId}`,
       });
@@ -672,7 +621,7 @@ export async function runSetupOrg(
       wikiId = PLACEHOLDER_WIKI_ID;
       stableId = PLACEHOLDER_STABLE_ID;
       steps.push({
-        step: "allocate-id",
+        step: STEP.ALLOCATE,
         status: "skipped",
         detail: "dry-run; would allocate new ID",
       });
@@ -688,9 +637,7 @@ export async function runSetupOrg(
 
   const divisionRows = buildDivisionRows(config, stableId);
   const programRows = buildFundingProgramRows(config, stableId, divisionRows);
-  report.divisions.count = divisionRows.length;
   report.divisions.ids = divisionRows.map((r) => r.id);
-  report.fundingPrograms.count = programRows.length;
   report.fundingPrograms.ids = programRows.map((r) => r.id);
 
   // 3. Plan file writes.
@@ -712,7 +659,7 @@ export async function runSetupOrg(
         .filter(Boolean)
         .join(", ");
       steps.push({
-        step: "write-entity-yaml",
+        step: STEP.WRITE_ENTITY,
         status: "failed",
         detail: `refusing to overwrite existing file(s) without --force: ${which}`,
       });
@@ -720,7 +667,7 @@ export async function runSetupOrg(
     }
 
     const writeStep = (
-      stepName: string,
+      stepName: StepName,
       path: string,
       contents: string,
     ): boolean => {
@@ -735,12 +682,12 @@ export async function runSetupOrg(
       }
     };
     const entityWritten = writeStep(
-      "write-entity-yaml",
+      STEP.WRITE_ENTITY,
       filePlan.entityYamlPath,
       filePlan.entityYamlContents,
     );
     const factbaseWritten = writeStep(
-      "write-factbase-yaml",
+      STEP.WRITE_FACTBASE,
       filePlan.factbaseYamlPath,
       filePlan.factbaseYamlContents,
     );
@@ -753,8 +700,8 @@ export async function runSetupOrg(
       return report;
     }
   } else {
-    steps.push({ step: "write-entity-yaml", status: "skipped", detail: "dry-run" });
-    steps.push({ step: "write-factbase-yaml", status: "skipped", detail: "dry-run" });
+    steps.push({ step: STEP.WRITE_ENTITY, status: "skipped", detail: "dry-run" });
+    steps.push({ step: STEP.WRITE_FACTBASE, status: "skipped", detail: "dry-run" });
   }
 
   // 4. Sync entity to PG.
@@ -776,14 +723,14 @@ export async function runSetupOrg(
     const syncResult = await deps.syncEntities([entityForSync]);
     entitySyncOk = syncResult.ok;
     steps.push({
-      step: "sync-entity-pg",
+      step: STEP.SYNC_ENTITY,
       status: syncResult.ok ? "ok" : "failed",
       detail: syncResult.ok
         ? `upserted ${syncResult.data.upserted}`
         : syncResult.message,
     });
   } else {
-    steps.push({ step: "sync-entity-pg", status: "skipped", detail: "dry-run" });
+    steps.push({ step: STEP.SYNC_ENTITY, status: "skipped", detail: "dry-run" });
   }
 
   // 5. Divisions. Skipped if entity sync failed — divisions reference the
@@ -792,7 +739,7 @@ export async function runSetupOrg(
   if (divisionRows.length > 0) {
     if (apply && !entitySyncOk) {
       steps.push({
-        step: "sync-divisions",
+        step: STEP.SYNC_DIVISIONS,
         status: "skipped",
         detail: "skipped because sync-entity-pg failed (would create orphans)",
       });
@@ -810,13 +757,13 @@ export async function runSetupOrg(
       }));
       const result = await deps.syncDivisions(items);
       steps.push({
-        step: "sync-divisions",
+        step: STEP.SYNC_DIVISIONS,
         status: result.ok ? "ok" : "failed",
         detail: result.ok ? `${divisionRows.length} divisions` : result.message,
       });
     } else {
       steps.push({
-        step: "sync-divisions",
+        step: STEP.SYNC_DIVISIONS,
         status: "skipped",
         detail: `dry-run (${divisionRows.length} divisions)`,
       });
@@ -828,7 +775,7 @@ export async function runSetupOrg(
   if (programRows.length > 0) {
     if (apply && !entitySyncOk) {
       steps.push({
-        step: "sync-funding-programs",
+        step: STEP.SYNC_PROGRAMS,
         status: "skipped",
         detail: "skipped because sync-entity-pg failed (would create orphans)",
       });
@@ -851,13 +798,13 @@ export async function runSetupOrg(
       }));
       const result = await deps.syncFundingPrograms(items);
       steps.push({
-        step: "sync-funding-programs",
+        step: STEP.SYNC_PROGRAMS,
         status: result.ok ? "ok" : "failed",
         detail: result.ok ? `${programRows.length} programs` : result.message,
       });
     } else {
       steps.push({
-        step: "sync-funding-programs",
+        step: STEP.SYNC_PROGRAMS,
         status: "skipped",
         detail: `dry-run (${programRows.length} programs)`,
       });
@@ -895,64 +842,61 @@ export async function runSetupOrg(
 
 // ── CLI formatting ──────────────────────────────────────────────────────
 
-const BOLD = "\x1b[1m";
-const GREEN = "\x1b[32m";
-const RED = "\x1b[31m";
-const DIM = "\x1b[2m";
-const RESET = "\x1b[0m";
-
-function statusGlyph(status: StepResult["status"]): string {
-  if (status === "ok") return `${GREEN}✓${RESET}`;
-  if (status === "failed") return `${RED}✗${RESET}`;
-  return `${DIM}⊘${RESET}`;
+function statusGlyph(status: StepResult["status"], c: ReturnType<typeof getColors>): string {
+  if (status === "ok") return `${c.green}✓${c.reset}`;
+  if (status === "failed") return `${c.red}✗${c.reset}`;
+  return `${c.dim}⊘${c.reset}`;
 }
 
 export function formatReport(report: Report): string {
+  // getColors() honors both --ci flag and CI=true env var, so output is
+  // automatically ANSI-stripped under any CI invocation.
+  const c = getColors();
   const lines: string[] = [];
   const header = report.applied ? "Applied" : "Dry run (preview)";
-  lines.push(`${BOLD}=== Setup Org: ${report.name} (${header}) ===${RESET}`);
+  lines.push(`${c.bold}=== Setup Org: ${report.name} (${header}) ===${c.reset}`);
   lines.push(`  slug:     ${report.slug}`);
   if (report.wikiId) lines.push(`  wikiId:   ${report.wikiId}`);
   if (report.stableId) lines.push(`  stableId: ${report.stableId}`);
   lines.push("");
 
-  lines.push(`${BOLD}Steps:${RESET}`);
+  lines.push(`${c.bold}Steps:${c.reset}`);
   for (const s of report.steps) {
-    const detail = s.detail ? `  ${DIM}${s.detail}${RESET}` : "";
-    lines.push(`  ${statusGlyph(s.status)} ${s.step}${detail}`);
+    const detail = s.detail ? `  ${c.dim}${s.detail}${c.reset}` : "";
+    lines.push(`  ${statusGlyph(s.status, c)} ${s.step}${detail}`);
   }
   lines.push("");
 
-  lines.push(`${BOLD}Created:${RESET}`);
+  lines.push(`${c.bold}Created:${c.reset}`);
   lines.push(`  Entity:           ${report.applied ? "yes" : "would create"}`);
   lines.push(`  FactBase facts:   ${report.factbaseFacts}`);
-  lines.push(`  Divisions:        ${report.divisions.count}`);
-  lines.push(`  Funding programs: ${report.fundingPrograms.count}`);
+  lines.push(`  Divisions:        ${report.divisions.ids.length}`);
+  lines.push(`  Funding programs: ${report.fundingPrograms.ids.length}`);
   lines.push("");
 
   if (report.files.length > 0) {
-    lines.push(`${BOLD}Files:${RESET}`);
+    lines.push(`${c.bold}Files:${c.reset}`);
     for (const f of report.files) {
-      const note = f.willOverwrite ? `${DIM}(overwrites existing)${RESET}` : "";
+      const note = f.willOverwrite ? `${c.dim}(overwrites existing)${c.reset}` : "";
       lines.push(`  ${f.path} ${note}`.trimEnd());
     }
     lines.push("");
   }
 
   if (report.divisionsSnippet) {
-    lines.push(`${BOLD}Snippet for crux/commands/import-divisions.ts (DIVISIONS array):${RESET}`);
+    lines.push(`${c.bold}Snippet for crux/commands/import-divisions.ts (DIVISIONS array):${c.reset}`);
     lines.push(report.divisionsSnippet);
     lines.push("");
   }
 
   if (report.fundingProgramsSnippet) {
-    lines.push(`${BOLD}Snippet for crux/commands/import-funding-programs.ts (PROGRAMS array):${RESET}`);
+    lines.push(`${c.bold}Snippet for crux/commands/import-funding-programs.ts (PROGRAMS array):${c.reset}`);
     lines.push(report.fundingProgramsSnippet);
     lines.push("");
   }
 
   if (report.followUp.length > 0) {
-    lines.push(`${BOLD}Follow-up steps:${RESET}`);
+    lines.push(`${c.bold}Follow-up steps:${c.reset}`);
     for (const f of report.followUp) {
       lines.push(`  • ${f}`);
     }
@@ -960,7 +904,7 @@ export function formatReport(report: Report): string {
   }
 
   if (!report.applied) {
-    lines.push(`${DIM}(re-run with --apply to write files and sync to PG)${RESET}`);
+    lines.push(`${c.dim}(re-run with --apply to write files and sync to PG)${c.reset}`);
   }
 
   return lines.join("\n");
@@ -972,24 +916,23 @@ function reportExitCode(report: Report): number {
 
 // ── Command entry ───────────────────────────────────────────────────────
 
-/**
- * Build the OrchestratorDeps wrapper around the real wiki-server clients.
- * Exported so tests can hit `setupOrgCommand` end-to-end with a stubbed
- * `apiRequest` (or assert on the wrapper's error mapping in isolation).
- */
-export function buildLiveDeps(
-  repoRoot: string,
-  ciOrJson: boolean,
-): OrchestratorDeps {
+type ApiCallResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; message: string };
+
+function adaptApiResult<T>(r: ApiCallResult<T>): Result<T> {
+  return r.ok ? { ok: true, data: r.data } : { ok: false, message: `${r.error}: ${r.message}` };
+}
+
+export function buildLiveDeps(repoRoot: string, ciOrJson: boolean): OrchestratorDeps {
   return {
     repoRoot,
     getIdBySlug: async (slug) => {
       const r = await getIdBySlug(slug);
       if (!r.ok) {
-        // The wiki-server returns 404 for "slug not allocated" — that's a
-        // valid lookup result, not an error. The client classifies all 4xx
-        // as `bad_request`, so we narrow on the message prefix to avoid
-        // swallowing real validation errors (400, 422, 429, ...).
+        // wiki-server returns 404 for "slug not allocated" — a valid lookup
+        // result, not an error. The client coerces all 4xx to `bad_request`,
+        // so narrow on the message prefix to avoid swallowing real 400/422/429.
         if (r.error === "bad_request" && /^404[:\s]/.test(r.message)) {
           return { ok: true, data: null };
         }
@@ -1007,22 +950,12 @@ export function buildLiveDeps(
       return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
     },
     syncEntities: async (items) => {
-      const r = await syncEntities(
-        items as unknown as Parameters<typeof syncEntities>[0],
-      );
+      const r = await syncEntities(items as Parameters<typeof syncEntities>[0]);
       if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
       return { ok: true, data: { upserted: r.data.upserted } };
     },
-    syncDivisions: async (items) => {
-      const r = await syncDivisions(items);
-      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
-      return { ok: true, data: r.data };
-    },
-    syncFundingPrograms: async (items) => {
-      const r = await syncFundingPrograms(items);
-      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
-      return { ok: true, data: r.data };
-    },
+    syncDivisions: async (items) => adaptApiResult(await syncDivisions([...items])),
+    syncFundingPrograms: async (items) => adaptApiResult(await syncFundingPrograms([...items])),
     writeFile: writeFileEnsuringDir,
     log: (line) => {
       if (!ciOrJson) console.error(line);
@@ -1078,8 +1011,9 @@ export const commands: Record<
 };
 
 export function getHelp(): string {
+  const c = getColors();
   return `
-${BOLD}setup-org${RESET} — Single-shot organization onboarding (QUA-35)
+${c.bold}setup-org${c.reset} — Single-shot organization onboarding
 
 Replaces the manual ~15-step onboarding flow with one config file:
   • Allocates wiki ID (E-number + sid_ stableId)
@@ -1088,14 +1022,14 @@ Replaces the manual ~15-step onboarding flow with one config file:
   • Syncs entity, divisions, and funding programs to wiki-server PG
   • Outputs a verification report and snippets for the persistent constants files
 
-${BOLD}Usage:${RESET}
+${c.bold}Usage:${c.reset}
   crux tb setup-org --config=path/to/aria.yaml           # Dry run (preview)
   crux tb setup-org --config=path/to/aria.yaml --apply   # Actually write + sync
   crux tb setup-org --config=path/to/aria.yaml --apply --force   # Allow YAML overwrite
   crux tb setup-org --config=- --apply                   # JSON config from stdin
   crux tb setup-org --config=path/to/aria.yaml --ci      # JSON output
 
-${BOLD}Config schema (YAML):${RESET}
+${c.bold}Config schema (YAML):${c.reset}
   slug: aria                              # required, kebab-case
   name: Advanced Research and Innovation Agency  # required
   type: organization                      # default: organization
@@ -1126,10 +1060,10 @@ ${BOLD}Config schema (YAML):${RESET}
       value: "2023"
       source: https://aria.org.uk/about
 
-${BOLD}From an agent slot, prefix with WIKI_SERVER_ENV=prod:${RESET}
+${c.bold}From an agent slot, prefix with WIKI_SERVER_ENV=prod:${c.reset}
   WIKI_SERVER_ENV=prod pnpm crux tb setup-org --config=aria.yaml --apply
 
-${BOLD}Out of scope (run separately afterwards):${RESET}
+${c.bold}Out of scope (run separately afterwards):${c.reset}
   • Wiki page authoring → pnpm crux w create "<name>" --tier=standard
   • Personnel discovery → pnpm crux tb people discover
   • Grant ingestion     → pnpm crux tb import-grants sync

--- a/crux/commands/setup-org.ts
+++ b/crux/commands/setup-org.ts
@@ -33,11 +33,30 @@ import type {
 } from "../lib/command-types.ts";
 import { generateId } from "../lib/grant-import/id.ts";
 import { toSlug } from "../tablebase/types.ts";
+import { allocateId, getIdBySlug } from "../lib/wiki-server/ids.ts";
+import { syncEntities } from "../lib/wiki-server/entities.ts";
+import { syncDivisions } from "../lib/wiki-server/divisions.ts";
+import { syncFundingPrograms } from "../lib/wiki-server/funding-programs.ts";
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const MAX_NAME_LENGTH = 500;
+const SID_FORMAT_RE = /^sid_[A-Za-z0-9]{10}$/;
 
 // ── Config schema ───────────────────────────────────────────────────────
 
+// relatedEntries point to other entities. Per .claude/rules/id-system.md the
+// canonical ref is a sid_ prefixed stableId. Slugs are also accepted today
+// (see entities/organizations.yaml), so we permit either form.
 const RelatedEntrySchema = z.object({
-  id: z.string().min(1),
+  id: z
+    .string()
+    .min(1)
+    .max(300)
+    .refine(
+      (s) => SID_FORMAT_RE.test(s) || /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(s),
+      { message: "id must be a sid_-prefixed stableId or a kebab-case slug" },
+    ),
   type: z.string().min(1),
   relationship: z.string().optional(),
 });
@@ -93,7 +112,7 @@ const SetupOrgConfigSchema = z.object({
     .min(2)
     .max(100)
     .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, "slug must be kebab-case"),
-  name: z.string().min(1).max(500),
+  name: z.string().min(1).max(MAX_NAME_LENGTH),
   type: z.string().min(1).default("organization"),
   aliases: z.array(z.string().min(1)).optional(),
   website: z.string().optional(),
@@ -299,12 +318,15 @@ export function buildFundingProgramRows(
   orgStableId: string,
   divisionRows: DivisionRow[],
 ): FundingProgramRow[] {
+  // Index divisions by their slug so program → division lookup is O(1).
+  // `config.divisions` and `divisionRows` are built in the same order from
+  // the same source, so we can zip them positionally.
   const divisionIdBySlug = new Map<string, { id: string; idSeed: string }>();
-  for (const d of config.divisions ?? []) {
+  (config.divisions ?? []).forEach((d, i) => {
     const slug = d.slug ?? toSlug(d.name);
-    const row = divisionRows.find((r) => r.idSeed.endsWith(`|${slug}`));
+    const row = divisionRows[i];
     if (row) divisionIdBySlug.set(slug, { id: row.id, idSeed: row.idSeed });
-  }
+  });
 
   const rows: FundingProgramRow[] = [];
   const seenSlugs = new Set<string>();
@@ -469,7 +491,8 @@ interface SetupOrgOptions extends BaseOptions {
   config?: string;
   apply?: boolean;
   ci?: boolean;
-  json?: boolean;
+  /** Allow overwriting existing YAML / FactBase files. Otherwise the command refuses. */
+  force?: boolean;
 }
 
 interface StepResult {
@@ -512,6 +535,14 @@ function readConfigSource(
 }
 
 function readStdinSync(): string {
+  // Refuse to block on stdin when there's no piped input — otherwise the
+  // user just sees a hung command. A fresh terminal sends no EOF, so we'd
+  // either block forever (Linux) or get EAGAIN (macOS).
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "--config=- expects JSON on stdin, but stdin is a TTY. Pipe input or pass a file path.",
+    );
+  }
   // fd 0 = stdin; readFileSync returns a string when an encoding is given.
   return readFileSync(0, "utf-8");
 }
@@ -544,9 +575,29 @@ interface OrchestratorDeps {
   log: (line: string) => void;
 }
 
-/** Placeholder shown for IDs we haven't allocated yet (dry-run on a new slug). */
-const PLACEHOLDER_WIKI_ID = "<would-allocate>";
-const PLACEHOLDER_STABLE_ID = "sid_PREVIEW00";
+/**
+ * Placeholders shown for IDs we haven't allocated yet (dry-run on a new slug).
+ * Both deliberately fail SID/wikiId validators so any tool downstream of the
+ * dry-run report (e.g. a script consuming the JSON output) crashes loudly
+ * instead of treating them as real allocated IDs.
+ */
+const PLACEHOLDER_WIKI_ID = "<would-allocate-wiki-id>";
+const PLACEHOLDER_STABLE_ID = "<would-allocate-stable-id>";
+
+/**
+ * Quote a string for safe pasting into a Bash command. Wraps in single quotes
+ * and escapes any embedded `'`. Defends against `name = "$(rm -rf ~)"`-style
+ * shell-injection in the verification report's copy-pastable follow-up steps.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+export interface RunSetupOrgOptions {
+  apply: boolean;
+  /** Allow overwriting existing YAML / FactBase files. */
+  force?: boolean;
+}
 
 /**
  * Pure orchestration entry point — exported for unit tests so they can
@@ -554,9 +605,15 @@ const PLACEHOLDER_STABLE_ID = "sid_PREVIEW00";
  */
 export async function runSetupOrg(
   config: SetupOrgConfig,
-  apply: boolean,
+  optionsOrApply: boolean | RunSetupOrgOptions,
   deps: OrchestratorDeps,
 ): Promise<Report> {
+  const opts: RunSetupOrgOptions =
+    typeof optionsOrApply === "boolean"
+      ? { apply: optionsOrApply }
+      : optionsOrApply;
+  const apply = opts.apply;
+  const force = !!opts.force;
   const steps: StepResult[] = [];
   const report: Report = {
     slug: config.slug,
@@ -644,24 +701,64 @@ export async function runSetupOrg(
   ];
 
   if (apply) {
-    deps.writeFile(filePlan.entityYamlPath, filePlan.entityYamlContents);
-    steps.push({
-      step: "write-entity-yaml",
-      status: "ok",
-      detail: filePlan.entityYamlPath,
-    });
-    deps.writeFile(filePlan.factbaseYamlPath, filePlan.factbaseYamlContents);
-    steps.push({
-      step: "write-factbase-yaml",
-      status: "ok",
-      detail: filePlan.factbaseYamlPath,
-    });
+    // Refuse to clobber existing files unless --force. Hand-curated YAML in
+    // data/entities/ or packages/factbase/data/fb-entities/ is high-value
+    // content that must not be silently overwritten.
+    if ((filePlan.entityYamlExists || filePlan.factbaseYamlExists) && !force) {
+      const which = [
+        filePlan.entityYamlExists ? filePlan.entityYamlPath : null,
+        filePlan.factbaseYamlExists ? filePlan.factbaseYamlPath : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      steps.push({
+        step: "write-entity-yaml",
+        status: "failed",
+        detail: `refusing to overwrite existing file(s) without --force: ${which}`,
+      });
+      return report;
+    }
+
+    const writeStep = (
+      stepName: string,
+      path: string,
+      contents: string,
+    ): boolean => {
+      try {
+        deps.writeFile(path, contents);
+        steps.push({ step: stepName, status: "ok", detail: path });
+        return true;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        steps.push({ step: stepName, status: "failed", detail: `${path}: ${message}` });
+        return false;
+      }
+    };
+    const entityWritten = writeStep(
+      "write-entity-yaml",
+      filePlan.entityYamlPath,
+      filePlan.entityYamlContents,
+    );
+    const factbaseWritten = writeStep(
+      "write-factbase-yaml",
+      filePlan.factbaseYamlPath,
+      filePlan.factbaseYamlContents,
+    );
+    // If either YAML write failed, abort downstream PG syncs to avoid a
+    // partial-state where PG has rows the YAML doesn't, or vice versa.
+    if (!entityWritten || !factbaseWritten) {
+      report.followUp.push(
+        `File write failed — PG sync skipped to avoid YAML/PG drift. Fix the underlying I/O error and re-run.`,
+      );
+      return report;
+    }
   } else {
     steps.push({ step: "write-entity-yaml", status: "skipped", detail: "dry-run" });
     steps.push({ step: "write-factbase-yaml", status: "skipped", detail: "dry-run" });
   }
 
   // 4. Sync entity to PG.
+  let entitySyncOk = !apply; // dry-run treats "skipped" as not-failed.
   if (apply) {
     const entityForSync: Record<string, unknown> = {
       id: entityRecord.id,
@@ -677,6 +774,7 @@ export async function runSetupOrg(
       entityForSync.relatedEntries = entityRecord.relatedEntries;
     }
     const syncResult = await deps.syncEntities([entityForSync]);
+    entitySyncOk = syncResult.ok;
     steps.push({
       step: "sync-entity-pg",
       status: syncResult.ok ? "ok" : "failed",
@@ -688,9 +786,17 @@ export async function runSetupOrg(
     steps.push({ step: "sync-entity-pg", status: "skipped", detail: "dry-run" });
   }
 
-  // 5. Divisions.
+  // 5. Divisions. Skipped if entity sync failed — divisions reference the
+  // org's stableId, so writing them when the parent isn't in PG produces
+  // orphans that would have to be cleaned up manually.
   if (divisionRows.length > 0) {
-    if (apply) {
+    if (apply && !entitySyncOk) {
+      steps.push({
+        step: "sync-divisions",
+        status: "skipped",
+        detail: "skipped because sync-entity-pg failed (would create orphans)",
+      });
+    } else if (apply) {
       const items = divisionRows.map((r) => ({
         id: r.id,
         parentOrgId: r.parentOrgId,
@@ -718,9 +824,15 @@ export async function runSetupOrg(
     report.divisionsSnippet = formatDivisionsSnippet(divisionRows, config.slug);
   }
 
-  // 6. Funding programs.
+  // 6. Funding programs. Same skip-on-entity-failure rule as divisions.
   if (programRows.length > 0) {
-    if (apply) {
+    if (apply && !entitySyncOk) {
+      steps.push({
+        step: "sync-funding-programs",
+        status: "skipped",
+        detail: "skipped because sync-entity-pg failed (would create orphans)",
+      });
+    } else if (apply) {
       const items = programRows.map((r) => ({
         id: r.id,
         orgId: r.orgId,
@@ -754,11 +866,14 @@ export async function runSetupOrg(
   }
 
   // 7. Follow-ups (always shown — these aren't automated).
+  // Use shellQuote so arbitrary chars in config.name (`$(...)`, backticks,
+  // semicolons) can't smuggle commands into a copy-pasted suggestion.
+  const quotedName = shellQuote(config.name);
   report.followUp.push(
-    `Create the wiki page: WIKI_SERVER_ENV=prod pnpm crux w create ${JSON.stringify(config.name)} --tier=standard`,
+    `Create the wiki page: pnpm crux w create ${quotedName} --tier=standard`,
   );
   report.followUp.push(
-    `Discover related personnel: WIKI_SERVER_ENV=prod pnpm crux tb people discover`,
+    `Discover related personnel: pnpm crux tb people discover`,
   );
   if (divisionRows.length > 0) {
     report.followUp.push(
@@ -770,8 +885,9 @@ export async function runSetupOrg(
       `Persist funding programs: paste the snippet above into the PROGRAMS array in crux/commands/import-funding-programs.ts.`,
     );
   }
+  report.followUp.push(`Verify in PG: pnpm crux query search ${quotedName}`);
   report.followUp.push(
-    `Verify in PG: WIKI_SERVER_ENV=prod pnpm crux query search ${JSON.stringify(config.name)}`,
+    `(prefix any of the above with WIKI_SERVER_ENV=prod when running from an agent slot)`,
   );
 
   return report;
@@ -856,6 +972,64 @@ function reportExitCode(report: Report): number {
 
 // ── Command entry ───────────────────────────────────────────────────────
 
+/**
+ * Build the OrchestratorDeps wrapper around the real wiki-server clients.
+ * Exported so tests can hit `setupOrgCommand` end-to-end with a stubbed
+ * `apiRequest` (or assert on the wrapper's error mapping in isolation).
+ */
+export function buildLiveDeps(
+  repoRoot: string,
+  ciOrJson: boolean,
+): OrchestratorDeps {
+  return {
+    repoRoot,
+    getIdBySlug: async (slug) => {
+      const r = await getIdBySlug(slug);
+      if (!r.ok) {
+        // The wiki-server returns 404 for "slug not allocated" — that's a
+        // valid lookup result, not an error. The client classifies all 4xx
+        // as `bad_request`, so we narrow on the message prefix to avoid
+        // swallowing real validation errors (400, 422, 429, ...).
+        if (r.error === "bad_request" && /^404[:\s]/.test(r.message)) {
+          return { ok: true, data: null };
+        }
+        return { ok: false, message: `${r.error}: ${r.message}` };
+      }
+      if (!r.data.stableId) return { ok: true, data: null };
+      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
+    },
+    allocateId: async (slug, description) => {
+      const r = await allocateId(slug, description);
+      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
+      if (!r.data.stableId) {
+        return { ok: false, message: `wiki-server returned no stableId for slug "${slug}"` };
+      }
+      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
+    },
+    syncEntities: async (items) => {
+      const r = await syncEntities(
+        items as unknown as Parameters<typeof syncEntities>[0],
+      );
+      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
+      return { ok: true, data: { upserted: r.data.upserted } };
+    },
+    syncDivisions: async (items) => {
+      const r = await syncDivisions(items);
+      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
+      return { ok: true, data: r.data };
+    },
+    syncFundingPrograms: async (items) => {
+      const r = await syncFundingPrograms(items);
+      if (!r.ok) return { ok: false, message: `${r.error}: ${r.message}` };
+      return { ok: true, data: r.data };
+    },
+    writeFile: writeFileEnsuringDir,
+    log: (line) => {
+      if (!ciOrJson) console.error(line);
+    },
+  };
+}
+
 async function setupOrgCommand(
   _args: string[],
   options: SetupOrgOptions,
@@ -864,7 +1038,7 @@ async function setupOrgCommand(
     return {
       exitCode: 1,
       output:
-        "Usage: crux tb setup-org --config=<path-to-yaml-or-json> [--apply] [--ci]\n" +
+        "Usage: crux tb setup-org --config=<path-to-yaml-or-json> [--apply] [--force] [--ci]\n" +
         "       crux tb setup-org --config=- --apply   # JSON config from stdin",
     };
   }
@@ -882,61 +1056,15 @@ async function setupOrgCommand(
     return { exitCode: 1, output: `Config error: ${message}` };
   }
 
-  const repoRoot = process.cwd();
-  const apply = !!options.apply;
-
-  const { allocateId, getIdBySlug } = await import("../lib/wiki-server/ids.ts");
-  const { syncEntities } = await import("../lib/wiki-server/entities.ts");
-  const { syncDivisions } = await import("../lib/wiki-server/divisions.ts");
-  const { syncFundingPrograms } = await import("../lib/wiki-server/funding-programs.ts");
-
-  const deps: OrchestratorDeps = {
-    repoRoot,
-    getIdBySlug: async (slug) => {
-      const r = await getIdBySlug(slug);
-      if (!r.ok) {
-        // 404 is the expected "not allocated yet" case — return null, not an error.
-        if (r.error === "bad_request") return { ok: true, data: null };
-        return { ok: false, message: r.message };
-      }
-      if (!r.data.stableId) return { ok: true, data: null };
-      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
-    },
-    allocateId: async (slug, description) => {
-      const r = await allocateId(slug, description);
-      if (!r.ok) return { ok: false, message: r.message };
-      if (!r.data.stableId) {
-        return { ok: false, message: `wiki-server returned no stableId for slug "${slug}"` };
-      }
-      return { ok: true, data: { wikiId: r.data.wikiId, stableId: r.data.stableId } };
-    },
-    syncEntities: async (items) => {
-      const r = await syncEntities(
-        items as unknown as Parameters<typeof syncEntities>[0],
-      );
-      if (!r.ok) return { ok: false, message: r.message };
-      return { ok: true, data: { upserted: r.data.upserted } };
-    },
-    syncDivisions: async (items) => {
-      const r = await syncDivisions(items);
-      if (!r.ok) return { ok: false, message: r.message };
-      return { ok: true, data: r.data };
-    },
-    syncFundingPrograms: async (items) => {
-      const r = await syncFundingPrograms(items);
-      if (!r.ok) return { ok: false, message: r.message };
-      return { ok: true, data: r.data };
-    },
-    writeFile: writeFileEnsuringDir,
-    log: (line) => {
-      if (!options.ci && !options.json) console.error(line);
-    },
-  };
-
-  const report = await runSetupOrg(config, apply, deps);
+  const deps = buildLiveDeps(process.cwd(), !!options.ci);
+  const report = await runSetupOrg(
+    config,
+    { apply: !!options.apply, force: !!options.force },
+    deps,
+  );
   const exitCode = reportExitCode(report);
 
-  if (options.ci || options.json) {
+  if (options.ci) {
     return { exitCode, output: JSON.stringify(report, null, 2) };
   }
   return { exitCode, output: formatReport(report) };
@@ -961,10 +1089,11 @@ Replaces the manual ~15-step onboarding flow with one config file:
   • Outputs a verification report and snippets for the persistent constants files
 
 ${BOLD}Usage:${RESET}
-  crux tb setup-org --config=path/to/aria.yaml          # Dry run (preview)
-  crux tb setup-org --config=path/to/aria.yaml --apply  # Actually write + sync
-  crux tb setup-org --config=- --apply                  # JSON config from stdin
-  crux tb setup-org --config=path/to/aria.yaml --ci     # JSON output
+  crux tb setup-org --config=path/to/aria.yaml           # Dry run (preview)
+  crux tb setup-org --config=path/to/aria.yaml --apply   # Actually write + sync
+  crux tb setup-org --config=path/to/aria.yaml --apply --force   # Allow YAML overwrite
+  crux tb setup-org --config=- --apply                   # JSON config from stdin
+  crux tb setup-org --config=path/to/aria.yaml --ci      # JSON output
 
 ${BOLD}Config schema (YAML):${RESET}
   slug: aria                              # required, kebab-case
@@ -997,7 +1126,7 @@ ${BOLD}Config schema (YAML):${RESET}
       value: "2023"
       source: https://aria.org.uk/about
 
-${BOLD}Apply requires WIKI_SERVER_ENV=prod from agent slots:${RESET}
+${BOLD}From an agent slot, prefix with WIKI_SERVER_ENV=prod:${RESET}
   WIKI_SERVER_ENV=prod pnpm crux tb setup-org --config=aria.yaml --apply
 
 ${BOLD}Out of scope (run separately afterwards):${RESET}

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -29,6 +29,7 @@ import { commands as importFundingProgramsCommands } from './import-funding-prog
 import { commands as dataSourcesCommands } from './data-sources.ts';
 import { commands as websiteSourcesCommands } from './website-sources.ts';
 import { commands as scaffoldCommands } from './tablebase-scaffold.ts';
+import { commands as setupOrgCommands } from './setup-org.ts';
 
 interface CommandOptions extends BaseOptions {
   top?: string;
@@ -1465,6 +1466,8 @@ export const commands = {
   'website-sources-fetch': websiteSourcesCommands.fetch,
   // QUA-455: scaffold a new tablebase entity type.
   scaffold: scaffoldCommands.scaffold,
+  // QUA-35: single-shot organization onboarding.
+  'setup-org': setupOrgCommands.default,
 };
 
 export function getHelp(): string {
@@ -1552,6 +1555,10 @@ Task Types:
   investment-linking         Add investment records
   benchmark-result-fill      Add benchmark scores for AI models
   source-discovery           Find better sources for unverifiable records
+
+Onboarding:
+  setup-org --config=<path>   Single-shot org onboarding: ID + entity YAML + FactBase + PG sync.
+                              Default is dry-run; pass --apply to write. See setup-org --help for full help.
 
 Examples:
   crux tb tablebase scan                                   # Overview of all tables

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -1466,7 +1466,6 @@ export const commands = {
   'website-sources-fetch': websiteSourcesCommands.fetch,
   // QUA-455: scaffold a new tablebase entity type.
   scaffold: scaffoldCommands.scaffold,
-  // QUA-35: single-shot organization onboarding.
   'setup-org': setupOrgCommands.default,
 };
 


### PR DESCRIPTION
## Summary

Adds `pnpm crux tb setup-org --config=<path>` — a single orchestration command that replaces the manual ~15-step organization onboarding flow described in QUA-35.

A YAML/JSON config drives:
- Wiki ID allocation (E-number + `sid_` stableId) via wiki-server
- New `data/entities/<slug>.yaml` (single-entry file — `loadYamlDir` merges per-file)
- New `packages/factbase/data/fb-entities/<slug>.yaml` with optional initial facts (deterministic IDs via `generateContentFactId`)
- PG sync of the entity, divisions, and funding programs
- Verification report with copy-pastable TS snippets to paste into `import-divisions.ts` / `import-funding-programs.ts` for persistence

Default mode is dry-run (lookup-only — no `entity_ids` row provisioned for new slugs); `--apply` writes files and syncs to PG. `--force` is required to overwrite existing hand-curated YAML.

## Out of scope (covered by follow-up commands the verification report links to)

- Wiki page authoring → `pnpm crux w create "<name>" --tier=standard`
- Personnel discovery → `pnpm crux tb people discover`
- Grant ingestion → `pnpm crux tb import-grants sync`

## Key behaviors

- **Dry-run is side-effect-free** — only `getIdBySlug` (GET), never `allocateId` (POST). Brand-new slugs preview as `<would-allocate-wiki-id>` placeholders that fail validators if downstream tools consume the JSON output.
- **Failed `sync-entity-pg` aborts downstream syncs** — divisions/programs reference the org's stableId; writing them when the parent isn't in PG would create orphans.
- **Refuses to overwrite existing YAML without `--force`** — `data/entities/` and `packages/factbase/data/fb-entities/` are high-value hand-curated content.
- **Shell-safe follow-up suggestions** — `config.name` is single-quote-escaped via `'\''` to defend against `$(...)`/backtick injection in copy-pasted commands.
- **Bad-request handling** — narrows on `404[:\s]` in the message (the wiki-server returns 404 for "slug not allocated"), so genuine 400/422/429 surface as failed steps.

## Test plan

- [x] 50/50 unit tests pass (`crux/commands/__tests__/setup-org.test.ts`) — covers config validation, pure builders, snippet formatters, file planner, dry-run vs apply orchestrator, --force behavior, ENOSPC handling, abort-on-entity-sync-failure, shell-injection defense.
- [x] Smoke-tested against prod wiki-server: dry-run on existing slug shows allocated IDs; dry-run on new slug shows `<would-allocate>` placeholders (no PG write).
- [x] Validation gate passes (43/43 blocking checks).
- [x] Typecheck clean for crux + apps/web + apps/wiki-server.
- [ ] Reviewer: try the command end-to-end on a fictional slug with `--apply` against staging or prod.

Closes QUA-35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `setup-org` command for streamlined organization onboarding via YAML/JSON configuration.
  * Supports dry-run mode (default) to preview changes and `--apply` mode to persist them.
  * Includes `--force` flag to overwrite existing outputs and `--ci` flag for JSON output.
  * Handles ID allocation, database syncing, and generates follow-up steps with code snippets.

* **Tests**
  * Comprehensive test suite covering end-to-end functionality and helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->