### PR TITLE
Add Resource Pipeline Dashboard (E2492) — QUA-61

### DIFF
--- a/apps/web/src/app/internal/resource-pipeline-dashboard/__tests__/parse-params.test.ts
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/__tests__/parse-params.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { parseParams } from "../resource-pipeline-content";
+
+describe("parseParams", () => {
+  it("returns defaults (sinceDays=7, fetchStatus=null) for empty input", () => {
+    expect(parseParams({})).toEqual({ sinceDays: 7, fetchStatus: null });
+  });
+
+  it("accepts valid sinceDays values", () => {
+    expect(parseParams({ sinceDays: "1" }).sinceDays).toBe(1);
+    expect(parseParams({ sinceDays: "30" }).sinceDays).toBe(30);
+    expect(parseParams({ sinceDays: "90" }).sinceDays).toBe(90);
+  });
+
+  it("rejects invalid sinceDays and falls back to default", () => {
+    expect(parseParams({ sinceDays: "999" }).sinceDays).toBe(7);
+    expect(parseParams({ sinceDays: "-1" }).sinceDays).toBe(7);
+    expect(parseParams({ sinceDays: "abc" }).sinceDays).toBe(7);
+    expect(parseParams({ sinceDays: "" }).sinceDays).toBe(7);
+  });
+
+  it("accepts valid fetchStatus values", () => {
+    expect(parseParams({ fetchStatus: "ok" }).fetchStatus).toBe("ok");
+    expect(parseParams({ fetchStatus: "paywall" }).fetchStatus).toBe("paywall");
+    expect(parseParams({ fetchStatus: "soft_404" }).fetchStatus).toBe("soft_404");
+  });
+
+  it("rejects unknown fetchStatus values", () => {
+    expect(parseParams({ fetchStatus: "bogus" }).fetchStatus).toBeNull();
+    expect(parseParams({ fetchStatus: "" }).fetchStatus).toBeNull();
+    // SQL-injection-shaped string: rejected by the enum check.
+    expect(parseParams({ fetchStatus: "ok'; DROP TABLE--" }).fetchStatus).toBeNull();
+  });
+
+  it("uses the first value when sinceDays/fetchStatus is an array", () => {
+    expect(parseParams({ sinceDays: ["30", "1"] }).sinceDays).toBe(30);
+    expect(parseParams({ fetchStatus: ["ok", "dead"] }).fetchStatus).toBe("ok");
+  });
+
+  it("handles undefined values gracefully", () => {
+    expect(parseParams({ sinceDays: undefined, fetchStatus: undefined })).toEqual({
+      sinceDays: 7,
+      fetchStatus: null,
+    });
+  });
+
+  it("combines sinceDays and fetchStatus independently", () => {
+    expect(parseParams({ sinceDays: "30", fetchStatus: "paywall" })).toEqual({
+      sinceDays: 30,
+      fetchStatus: "paywall",
+    });
+  });
+});

--- a/apps/web/src/app/internal/resource-pipeline-dashboard/page.tsx
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { ResourcePipelineContent } from "./resource-pipeline-content";
+
+export const metadata: Metadata = {
+  title: "Resource Pipeline — Internal",
+  description:
+    "Per-resource fetch outcomes, citation_content fill rate, and stuck-pipeline diagnostics.",
+};
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function ResourcePipelinePage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  return (
+    <article className="prose dark:prose-invert max-w-none px-6 py-8">
+      <h1>Resource Pipeline</h1>
+      <ResourcePipelineContent searchParams={params} />
+    </article>
+  );
+}

--- a/apps/web/src/app/internal/resource-pipeline-dashboard/resource-list-table.tsx
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/resource-list-table.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, SortableHeader } from "@/components/ui/data-table";
+import { formatAge } from "@lib/format";
+import type { RpcResourcePipelineRow } from "@lib/wiki-server";
+
+const FETCH_STATUS_COLOR: Record<string, string> = {
+  ok: "text-emerald-600",
+  paywall: "text-amber-600",
+  dead: "text-red-600",
+  soft_404: "text-red-600",
+  not_found: "text-red-600",
+  timeout: "text-orange-600",
+  unreachable: "text-orange-600",
+  error: "text-red-600",
+};
+
+const ENRICHMENT_STATUS_COLOR: Record<string, string> = {
+  reviewed: "text-emerald-600",
+  enriched: "text-emerald-600",
+  classified: "text-blue-600",
+  fetched: "text-yellow-600",
+  pending: "text-muted-foreground",
+};
+
+const columns: ColumnDef<RpcResourcePipelineRow>[] = [
+  {
+    accessorKey: "title",
+    header: "Title",
+    cell: ({ row }) => {
+      const title = row.original.title || "(no title)";
+      return (
+        <span className="text-xs truncate max-w-[320px] block" title={title}>
+          {title}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "url",
+    header: "URL",
+    cell: ({ row }) => (
+      <a
+        href={row.original.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-blue-600 hover:underline truncate max-w-[280px] block"
+        title={row.original.url}
+      >
+        {row.original.url}
+      </a>
+    ),
+  },
+  {
+    accessorKey: "fetchStatus",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Fetch</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const status = row.original.fetchStatus ?? "unknown";
+      const color = FETCH_STATUS_COLOR[status] ?? "text-muted-foreground";
+      return <span className={`text-xs font-mono ${color}`}>{status}</span>;
+    },
+  },
+  {
+    accessorKey: "enrichmentStatus",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Enrichment</SortableHeader>
+    ),
+    cell: ({ row }) => {
+      const status = row.original.enrichmentStatus ?? "none";
+      const color =
+        ENRICHMENT_STATUS_COLOR[status] ?? "text-muted-foreground/60";
+      return <span className={`text-xs font-mono ${color}`}>{status}</span>;
+    },
+  },
+  {
+    accessorKey: "lastFetchedAt",
+    header: ({ column }) => (
+      <SortableHeader column={column}>Last fetched</SortableHeader>
+    ),
+    cell: ({ row }) => (
+      <span className="text-xs tabular-nums text-muted-foreground whitespace-nowrap">
+        {formatAge(row.original.lastFetchedAt)}
+      </span>
+    ),
+  },
+];
+
+export function ResourceListTable({ data }: { data: RpcResourcePipelineRow[] }) {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      searchPlaceholder="Search by title or URL..."
+      defaultSorting={[{ id: "lastFetchedAt", desc: true }]}
+    />
+  );
+}

--- a/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-content.tsx
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-content.tsx
@@ -1,0 +1,277 @@
+import {
+  fetchDetailed,
+  withApiFallback,
+  type RpcResourcePipelineResult,
+  type FetchResult,
+} from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { ResourcePipelineFilters } from "./resource-pipeline-filters";
+import { ResourceListTable } from "./resource-list-table";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export const FETCH_STATUS_VALUES = [
+  "ok",
+  "dead",
+  "soft_404",
+  "not_found",
+  "timeout",
+  "unreachable",
+  "paywall",
+  "error",
+] as const;
+export type FetchStatusValue = (typeof FETCH_STATUS_VALUES)[number];
+
+export const SINCE_DAYS_OPTIONS = [1, 7, 30, 90] as const;
+export type SinceDaysValue = (typeof SINCE_DAYS_OPTIONS)[number];
+
+export interface PipelineParams {
+  sinceDays: SinceDaysValue;
+  fetchStatus: FetchStatusValue | null;
+}
+
+export function parseParams(searchParams: Record<string, string | string[] | undefined>): PipelineParams {
+  const rawDays = Array.isArray(searchParams.sinceDays)
+    ? searchParams.sinceDays[0]
+    : searchParams.sinceDays;
+  const parsedDays = rawDays ? Number(rawDays) : NaN;
+  const sinceDays: SinceDaysValue =
+    SINCE_DAYS_OPTIONS.find((d) => d === parsedDays) ?? 7;
+
+  const rawStatus = Array.isArray(searchParams.fetchStatus)
+    ? searchParams.fetchStatus[0]
+    : searchParams.fetchStatus;
+  const fetchStatus =
+    rawStatus && FETCH_STATUS_VALUES.includes(rawStatus as FetchStatusValue)
+      ? (rawStatus as FetchStatusValue)
+      : null;
+
+  return { sinceDays, fetchStatus };
+}
+
+// ── Data loading ─────────────────────────────────────────────────────────
+
+async function loadFromApi(
+  params: PipelineParams
+): Promise<FetchResult<RpcResourcePipelineResult>> {
+  const qs = new URLSearchParams({ sinceDays: String(params.sinceDays) });
+  if (params.fetchStatus) qs.set("fetchStatus", params.fetchStatus);
+  return await fetchDetailed<RpcResourcePipelineResult>(
+    `/api/resources/pipeline?${qs.toString()}`,
+    { revalidate: 60 }
+  );
+}
+
+function emptyData(params: PipelineParams): RpcResourcePipelineResult {
+  return {
+    sinceDays: params.sinceDays,
+    fetchStatusFilter: params.fetchStatus,
+    totals: { inWindow: 0, all: 0 },
+    byFetchStatus: {},
+    byEnrichmentStatus: {},
+    contentFill: { withFullText: 0, withMetadataOnly: 0, uncached: 0 },
+    stuck: { total: 0, sample: [] },
+    recentFetched: [],
+  };
+}
+
+// ── Display helpers ──────────────────────────────────────────────────────
+
+const FETCH_STATUS_COLOR: Record<string, string> = {
+  ok: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+  dead: "bg-red-500/15 text-red-700 dark:text-red-400",
+  soft_404: "bg-red-500/10 text-red-700 dark:text-red-400",
+  not_found: "bg-red-500/10 text-red-700 dark:text-red-400",
+  timeout: "bg-orange-500/15 text-orange-700 dark:text-orange-400",
+  unreachable: "bg-orange-500/15 text-orange-700 dark:text-orange-400",
+  paywall: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  error: "bg-red-500/15 text-red-700 dark:text-red-400",
+  unknown: "bg-muted text-muted-foreground",
+};
+
+function StatusPill({
+  label,
+  count,
+  color,
+}: {
+  label: string;
+  count: number;
+  color: string;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-mono ${color}`}
+    >
+      <span className="font-semibold">{count.toLocaleString()}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <div className="text-xs text-muted-foreground uppercase tracking-wide">
+        {label}
+      </div>
+      <div className="text-2xl font-semibold tabular-nums mt-1">
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </div>
+      {hint && (
+        <div className="text-xs text-muted-foreground mt-1">{hint}</div>
+      )}
+    </div>
+  );
+}
+
+// ── Content component ────────────────────────────────────────────────────
+
+interface Props {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+export async function ResourcePipelineContent({ searchParams }: Props) {
+  const params = parseParams(searchParams);
+
+  const { data, source, apiError } = await withApiFallback(
+    () => loadFromApi(params),
+    () => emptyData(params)
+  );
+
+  const fetchEntries = Object.entries(data.byFetchStatus).sort(
+    (a, b) => b[1] - a[1]
+  );
+  const enrichmentEntries = Object.entries(data.byEnrichmentStatus).sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  const totalContent =
+    data.contentFill.withFullText +
+    data.contentFill.withMetadataOnly +
+    data.contentFill.uncached;
+  const fillPct =
+    totalContent > 0
+      ? ((data.contentFill.withFullText / totalContent) * 100).toFixed(1)
+      : "0";
+
+  return (
+    <>
+      <p className="text-muted-foreground">
+        Per-resource pipeline outcomes during the last{" "}
+        <span className="font-medium text-foreground">
+          {params.sinceDays} day{params.sinceDays === 1 ? "" : "s"}
+        </span>
+        . Tracks fetch reachability (ok / paywall / dead), citation_content
+        fill rate, and resources stuck mid-pipeline (fetched but not enriched).
+      </p>
+
+      <ResourcePipelineFilters
+        sinceDays={params.sinceDays}
+        fetchStatus={params.fetchStatus}
+        sinceDaysOptions={[...SINCE_DAYS_OPTIONS]}
+        fetchStatusOptions={[...FETCH_STATUS_VALUES]}
+      />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard
+          label="Fetched in window"
+          value={data.totals.inWindow}
+          hint={`${data.totals.all.toLocaleString()} resources total`}
+        />
+        <StatCard
+          label="Citation content fill"
+          value={`${fillPct}%`}
+          hint={`${data.contentFill.withFullText.toLocaleString()} with full text`}
+        />
+        <StatCard
+          label="Metadata only"
+          value={data.contentFill.withMetadataOnly}
+          hint="Title fetched, no body text"
+        />
+        <StatCard
+          label="Stuck (not enriched)"
+          value={data.stuck.total}
+          hint="Fetched, awaiting classify/enrich"
+        />
+      </div>
+
+      <h2>Fetch status distribution</h2>
+      {fetchEntries.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {fetchEntries.map(([status, count]) => (
+            <StatusPill
+              key={status}
+              label={status}
+              count={count}
+              color={FETCH_STATUS_COLOR[status] ?? "bg-muted text-muted-foreground"}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No fetches recorded in the selected window.
+        </p>
+      )}
+
+      <h2>Enrichment pipeline stage</h2>
+      {enrichmentEntries.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {enrichmentEntries.map(([status, count]) => (
+            <StatusPill
+              key={status}
+              label={status}
+              count={count}
+              color="bg-indigo-500/15 text-indigo-700 dark:text-indigo-400"
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No enrichment activity in the selected window.
+        </p>
+      )}
+
+      <h2>
+        Stuck resources{" "}
+        <span className="text-muted-foreground text-base font-normal">
+          ({data.stuck.total.toLocaleString()})
+        </span>
+      </h2>
+      <p className="text-sm text-muted-foreground">
+        Resources that have been fetched but never reached the{" "}
+        <code className="text-xs">classified</code> /{" "}
+        <code className="text-xs">enriched</code> stage. Sorted oldest first —
+        the top entries are the most stale.
+      </p>
+      {data.stuck.sample.length > 0 ? (
+        <ResourceListTable data={data.stuck.sample} />
+      ) : (
+        <p className="text-sm text-muted-foreground italic">
+          No stuck resources in the selected window.
+        </p>
+      )}
+
+      <h2>Recent fetches</h2>
+      <p className="text-sm text-muted-foreground">
+        25 most recently fetched resources matching the current filter.
+      </p>
+      {data.recentFetched.length > 0 ? (
+        <ResourceListTable data={data.recentFetched} />
+      ) : (
+        <p className="text-sm text-muted-foreground italic">
+          No fetches in the selected window.
+        </p>
+      )}
+
+      <DataSourceBanner source={source} apiError={apiError} />
+    </>
+  );
+}

--- a/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-dashboard-content.tsx
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-dashboard-content.tsx
@@ -1,0 +1,11 @@
+import { ResourcePipelineContent } from "./resource-pipeline-content";
+
+/**
+ * Wiki MDX entry point (rendered at /wiki/E2492). Renders the dashboard with
+ * default filter state (last 7 days, all fetch statuses). Filter pills inside
+ * the content link to /internal/resource-pipeline?... where searchParams are
+ * honored — see resource-pipeline/page.tsx.
+ */
+export function ResourcePipelineDashboardContent() {
+  return <ResourcePipelineContent searchParams={{}} />;
+}

--- a/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-filters.tsx
+++ b/apps/web/src/app/internal/resource-pipeline-dashboard/resource-pipeline-filters.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+
+interface Props {
+  sinceDays: number;
+  fetchStatus: string | null;
+  sinceDaysOptions: number[];
+  fetchStatusOptions: string[];
+}
+
+const BASE_PATH = "/internal/resource-pipeline-dashboard";
+
+function buildHref(params: { sinceDays?: number; fetchStatus?: string | null }) {
+  const qs = new URLSearchParams();
+  if (params.sinceDays !== undefined) qs.set("sinceDays", String(params.sinceDays));
+  if (params.fetchStatus) qs.set("fetchStatus", params.fetchStatus);
+  const qsStr = qs.toString();
+  return qsStr ? `${BASE_PATH}?${qsStr}` : BASE_PATH;
+}
+
+function FilterPill({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
+  const className = active
+    ? "bg-foreground text-background"
+    : "bg-muted text-muted-foreground hover:bg-muted/80";
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-mono transition-colors ${className}`}
+      prefetch={false}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function ResourcePipelineFilters({
+  sinceDays,
+  fetchStatus,
+  sinceDaysOptions,
+  fetchStatusOptions,
+}: Props) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4 space-y-3 not-prose">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide w-24">
+          Window
+        </span>
+        {sinceDaysOptions.map((days) => (
+          <FilterPill
+            key={days}
+            href={buildHref({ sinceDays: days, fetchStatus })}
+            label={`${days}d`}
+            active={days === sinceDays}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide w-24">
+          Fetch status
+        </span>
+        <FilterPill
+          href={buildHref({ sinceDays, fetchStatus: null })}
+          label="all"
+          active={fetchStatus === null}
+        />
+        {fetchStatusOptions.map((status) => (
+          <FilterPill
+            key={status}
+            href={buildHref({ sinceDays, fetchStatus: status })}
+            label={status}
+            active={status === fetchStatus}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -80,6 +80,7 @@ import { SourcingCoverageContent } from "@/app/internal/sourcing-coverage/sourci
 import { DataQualityContent } from "@/app/internal/data-quality/data-quality-content";
 import { TalentFlowsContent } from "@/app/internal/talent-flows/talent-flows-content";
 import { JobsDashboardContent } from "@/app/internal/jobs/jobs-content";
+import { ResourcePipelineDashboardContent } from "@/app/internal/resource-pipeline-dashboard/resource-pipeline-dashboard-content";
 import { DataSourcesContent } from "@/app/data-sources/data-sources-content";
 import { TablebaseCoverageContent } from "@/app/internal/tablebase-coverage/tablebase-coverage-content";
 import { AutomationLandscapeContent } from "@/app/internal/automation-landscape/automation-landscape-content";
@@ -245,6 +246,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   DataQualityContent,
   TalentFlowsContent,
   JobsDashboardContent,
+  ResourcePipelineDashboardContent,
   DataSourcesContent,
   TablebaseCoverageContent,
   AutomationLandscapeContent,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -281,6 +281,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Entity Profile", href: internalHref("entity-profile-dashboard") },
         { label: "People Coverage", href: internalHref("people-coverage-dashboard") },
         { label: "Data Sources", href: internalHref("data-sources-dashboard") },
+        { label: "Resource Pipeline", href: internalHref("resource-pipeline-dashboard") },
         { label: "Grants", href: internalHref("grants-dashboard") },
         { label: "Divisions", href: internalHref("divisions-dashboard") },
         { label: "Funding Programs", href: internalHref("funding-programs-dashboard") },

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -549,6 +549,12 @@ type ResourcesClient = ReturnType<typeof hc<ResourcesRoute>>;
 /** Inferred response type for GET /api/resources/:id (single resource with sub-tables) */
 export type RpcResourceDetailResult = InferResponseType<ResourcesClient[':id']['$get'], 200>;
 
+/** Inferred response type for GET /api/resources/pipeline (Resource Pipeline Dashboard) */
+export type RpcResourcePipelineResult = InferResponseType<ResourcesClient['pipeline']['$get'], 200>;
+
+/** A single stuck/recent resource row from /api/resources/pipeline */
+export type RpcResourcePipelineRow = RpcResourcePipelineResult['stuck']['sample'][number];
+
 // ============================================================================
 // Hono RPC client — Political Scores API
 // ============================================================================

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -1099,6 +1099,212 @@ const resourcesApp = new Hono()
     return c.json(result);
   })
 
+  // ---- GET /pipeline?sinceDays=N&fetchStatus=X (pipeline outcomes for dashboard) ----
+  //
+  // Returns fetch_status distribution, citation_content fill rate, stuck resource
+  // samples, and recent fetch activity. Date filter narrows to resources whose
+  // last_fetched_at falls within the window. fetchStatus filter narrows the
+  // stuck-resources sample (other counts always reflect the full sinceDays window).
+  //
+  // Powers the Resource Pipeline Dashboard (E2492).
+  .get(
+    "/pipeline",
+    zv(
+      "query",
+      z.object({
+        sinceDays: z.coerce.number().int().min(1).max(365).default(7),
+        fetchStatus: z
+          .enum([
+            "ok",
+            "dead",
+            "soft_404",
+            "not_found",
+            "timeout",
+            "unreachable",
+            "paywall",
+            "error",
+          ])
+          .optional(),
+      })
+    ),
+    async (c) => {
+      const { sinceDays, fetchStatus } = c.req.valid("query");
+      const rawDb = getDb();
+
+      // postgres.js fragment for the optional fetch_status filter — embeds
+      // safely as a parameter when present, no-op fragment when not.
+      const fetchFilter = fetchStatus
+        ? rawDb`AND r.fetch_status = ${fetchStatus}`
+        : rawDb``;
+
+      const [
+        fetchStatusRows,
+        enrichmentStatusRows,
+        windowTotalsRow,
+        contentFillRow,
+        stuckCountRow,
+        stuckSampleRows,
+        recentFetchedRows,
+      ] = await Promise.all([
+        // fetch_status distribution within the date window
+        rawDb<{ status: string | null; c: string }[]>`
+          SELECT fetch_status AS status, count(*) AS c
+          FROM resources
+          WHERE last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+          GROUP BY fetch_status
+          ORDER BY count(*) DESC
+        `,
+        // enrichment_status distribution within the date window
+        rawDb<{ status: string | null; c: string }[]>`
+          SELECT enrichment_status AS status, count(*) AS c
+          FROM resources
+          WHERE last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+          GROUP BY enrichment_status
+          ORDER BY count(*) DESC
+        `,
+        // Totals for the window
+        rawDb<{ total_in_window: string; total_all: string }[]>`
+          SELECT
+            (SELECT count(*) FROM resources
+              WHERE last_fetched_at >= NOW() - make_interval(days => ${sinceDays})) AS total_in_window,
+            (SELECT count(*) FROM resources) AS total_all
+        `,
+        // Citation content fill (limited to resources fetched in window)
+        rawDb<{
+          with_full_text: string;
+          with_metadata_only: string;
+          uncached: string;
+        }[]>`
+          SELECT
+            (SELECT count(*) FROM resources r
+              JOIN citation_content cc ON cc.resource_id = r.id
+              WHERE r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+                AND cc.full_text IS NOT NULL) AS with_full_text,
+            (SELECT count(*) FROM resources r
+              JOIN citation_content cc ON cc.resource_id = r.id
+              WHERE r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+                AND cc.full_text IS NULL AND cc.page_title IS NOT NULL) AS with_metadata_only,
+            (SELECT count(*) FROM resources r
+              LEFT JOIN citation_content cc ON cc.resource_id = r.id
+              WHERE r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+                AND cc.resource_id IS NULL) AS uncached
+        `,
+        // Stuck count: fetched but enrichment did not progress past 'fetched'
+        // (NULL, 'pending', 'fetched' = not classified/enriched/reviewed)
+        rawDb<{ c: string }[]>`
+          SELECT count(*) AS c
+          FROM resources r
+          WHERE r.fetched_at IS NOT NULL
+            AND (r.enrichment_status IS NULL
+                 OR r.enrichment_status IN ('pending', 'fetched'))
+            AND r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+            ${fetchFilter}
+        `,
+        // Stuck sample: oldest-fetched resources still not enriched
+        rawDb<{
+          id: string;
+          url: string;
+          title: string | null;
+          fetch_status: string | null;
+          enrichment_status: string | null;
+          last_fetched_at: Date;
+        }[]>`
+          SELECT id, url, title, fetch_status, enrichment_status, last_fetched_at
+          FROM resources r
+          WHERE r.fetched_at IS NOT NULL
+            AND (r.enrichment_status IS NULL
+                 OR r.enrichment_status IN ('pending', 'fetched'))
+            AND r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+            ${fetchFilter}
+          ORDER BY r.last_fetched_at ASC
+          LIMIT 25
+        `,
+        // Recent fetches: most recently fetched resources matching the filter
+        rawDb<{
+          id: string;
+          url: string;
+          title: string | null;
+          fetch_status: string | null;
+          enrichment_status: string | null;
+          last_fetched_at: Date;
+        }[]>`
+          SELECT id, url, title, fetch_status, enrichment_status, last_fetched_at
+          FROM resources r
+          WHERE r.last_fetched_at >= NOW() - make_interval(days => ${sinceDays})
+            ${fetchFilter}
+          ORDER BY r.last_fetched_at DESC
+          LIMIT 25
+        `,
+      ]);
+
+      const byFetchStatus: Record<string, number> = {};
+      for (const row of fetchStatusRows) {
+        byFetchStatus[row.status ?? "unknown"] = Number(row.c);
+      }
+
+      const byEnrichmentStatus: Record<string, number> = {};
+      for (const row of enrichmentStatusRows) {
+        byEnrichmentStatus[row.status ?? "none"] = Number(row.c);
+      }
+
+      const totalsRow = windowTotalsRow[0] ?? {
+        total_in_window: "0",
+        total_all: "0",
+      };
+      const totalInWindow = Number(totalsRow.total_in_window);
+      const totalAll = Number(totalsRow.total_all);
+
+      const fillRow = contentFillRow[0] ?? {
+        with_full_text: "0",
+        with_metadata_only: "0",
+        uncached: "0",
+      };
+      const withFullText = Number(fillRow.with_full_text);
+      const withMetadataOnly = Number(fillRow.with_metadata_only);
+      const uncached = Number(fillRow.uncached);
+
+      const formatRow = (r: {
+        id: string;
+        url: string;
+        title: string | null;
+        fetch_status: string | null;
+        enrichment_status: string | null;
+        last_fetched_at: Date;
+      }) => ({
+        id: r.id,
+        url: r.url,
+        title: r.title,
+        fetchStatus: r.fetch_status,
+        enrichmentStatus: r.enrichment_status,
+        lastFetchedAt:
+          r.last_fetched_at instanceof Date
+            ? r.last_fetched_at.toISOString()
+            : String(r.last_fetched_at),
+      });
+
+      return c.json({
+        sinceDays,
+        fetchStatusFilter: fetchStatus ?? null,
+        totals: {
+          inWindow: totalInWindow,
+          all: totalAll,
+        },
+        byFetchStatus,
+        byEnrichmentStatus,
+        contentFill: {
+          withFullText,
+          withMetadataOnly,
+          uncached,
+        },
+        stuck: {
+          total: Number(stuckCountRow[0]?.c ?? 0),
+          sample: stuckSampleRows.map(formatRow),
+        },
+        recentFetched: recentFetchedRows.map(formatRow),
+      });
+    }
+  )
+
   // ---- GET /by-page/:pageId (resources cited by a page) ----
 
   .get("/by-page/:pageId", async (c) => {

--- a/content/docs/internal/resource-pipeline-dashboard.mdx
+++ b/content/docs/internal/resource-pipeline-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2492
+title: "Resource Pipeline Dashboard"
+description: "Per-resource fetch outcomes (ok/dead/paywall/error), citation_content fill rate, and stuck-pipeline diagnostics. Filterable by fetch status and date window."
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-16"
+---
+
+<ResourcePipelineDashboardContent />


### PR DESCRIPTION
## Summary

Adds a new internal dashboard (E2492) surfacing per-resource pipeline outcomes that the Jobs Dashboard (E2120) only shows in aggregate.

**Acceptance criteria** (all met — QUA-61):
- Dashboard shows fetch_status distribution (ok/dead/paywall/error and 4 other variants)
- Shows citation_content fill rate (full text vs metadata-only vs uncached)
- Shows resources ingested but enrichment failed (the "Stuck" section)
- Filterable by status (8-value enum) and date (1/7/30/90 day window)

## What's added

- **Wiki-server endpoint:** `GET /api/resources/pipeline?sinceDays=N&fetchStatus=X` (`apps/wiki-server/src/routes/wikibase/resources.ts`). Zod-validated query params; postgres.js parameterized fragments throughout (no string concat); 7 parallel queries scoped by `last_fetched_at`.
- **Pattern A wiring:** MDX stub at `content/docs/internal/resource-pipeline-dashboard.mdx`, content components under `apps/web/src/app/internal/resource-pipeline-dashboard/`, sidebar entry in TableBase section alongside Data Sources, typed RPC client export `RpcResourcePipelineResult` via `InferResponseType<>`.
- **Tests:** 8 parse-params tests covering invalid sinceDays (999, -1, abc), unknown fetchStatus, SQL-injection-shape strings, array/undefined values.

## Design note

MDX components don't receive `searchParams`, so `/wiki/E2492` renders the dashboard with default filter (7d, all statuses). Filter pills in the dashboard navigate to `/internal/resource-pipeline-dashboard?...` (same content component, but the page accepts searchParams). Both URLs render identical content, just with different filter state.

## Test plan

- [x] `pnpm crux w validate gate --fix` — all 46 gate checks pass (3 advisory warnings, all unrelated to this PR)
- [x] `pnpm test` for `wiki-nav.test.ts`, `parse-params.test.ts`, `resources.test.ts` — all green (35 + 38 = 73 tests)
- [x] Playwright verified: default view, `?sinceDays=30&fetchStatus=ok`, invalid params (defaults gracefully), `/wiki/E2492` MDX render
- [ ] Confirm post-deploy: `/internal/resource-pipeline-dashboard` and `/wiki/E2492` render on prod
- [ ] Confirm post-deploy: sidebar shows "Resource Pipeline" under TableBase section

Fixes QUA-61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Resource Pipeline Dashboard for monitoring resource fetch outcomes and enrichment status
  * Implemented filters by fetch status and time window (1, 7, 30, or 90 days)
  * Displays pipeline statistics, content fill rates, and resource counts
  * Lists stuck and recently fetched resources with sortable, searchable tables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->