### PR TITLE
Add /data-sources/[id] detail pages (QUA-81)

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -86,6 +86,7 @@ const SIMPLE_PAGES = [
   "/wiki/E100",  // Anthropic wiki page
   "/wiki/E815",  // Anthropic Stakeholders — critical table page
   "/browse",
+  "/data-sources/ea-funds",  // Data source detail page (QUA-81)
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/data-sources/[id]/detail-utils.test.ts
+++ b/apps/web/src/app/data-sources/[id]/detail-utils.test.ts
@@ -4,7 +4,6 @@ import {
   shortHash,
   safeIsoDate,
   safeIsoDateTime,
-  isSafeHttpUrl,
 } from "./detail-utils";
 
 describe("relativeTime", () => {
@@ -77,23 +76,3 @@ describe("safeIsoDateTime", () => {
   });
 });
 
-describe("isSafeHttpUrl", () => {
-  it("accepts http/https", () => {
-    expect(isSafeHttpUrl("http://example.com")).toBe(true);
-    expect(isSafeHttpUrl("https://example.com/path?q=1")).toBe(true);
-  });
-  it("rejects javascript:/data:/file:", () => {
-    expect(isSafeHttpUrl("javascript:alert(1)")).toBe(false);
-    expect(isSafeHttpUrl("data:text/html,<script>")).toBe(false);
-    expect(isSafeHttpUrl("file:///etc/passwd")).toBe(false);
-  });
-  it("rejects non-URL strings", () => {
-    expect(isSafeHttpUrl("not a url")).toBe(false);
-    expect(isSafeHttpUrl("")).toBe(false);
-    expect(isSafeHttpUrl(null)).toBe(false);
-    expect(isSafeHttpUrl(undefined)).toBe(false);
-  });
-  it("rejects urn: scheme (used internally as placeholder)", () => {
-    expect(isSafeHttpUrl("urn:lw:tabular-source:ea-funds")).toBe(false);
-  });
-});

--- a/apps/web/src/app/data-sources/[id]/detail-utils.test.ts
+++ b/apps/web/src/app/data-sources/[id]/detail-utils.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import {
+  relativeTime,
+  shortHash,
+  safeIsoDate,
+  safeIsoDateTime,
+  isSafeHttpUrl,
+} from "./detail-utils";
+
+describe("relativeTime", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-16T12:00:00Z"));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns — for missing input", () => {
+    expect(relativeTime(null)).toBe("—");
+    expect(relativeTime(undefined)).toBe("—");
+    expect(relativeTime("")).toBe("—");
+  });
+  it("returns — for invalid date string", () => {
+    expect(relativeTime("not-a-date")).toBe("—");
+  });
+  it("returns 'just now' for future timestamps", () => {
+    expect(relativeTime("2026-04-20T00:00:00Z")).toBe("just now");
+  });
+  it("returns 'today' for under 12h old", () => {
+    expect(relativeTime("2026-04-16T06:00:00Z")).toBe("today");
+  });
+  it("returns days for week-old", () => {
+    expect(relativeTime("2026-04-11T12:00:00Z")).toBe("5d ago");
+  });
+  it("returns months for 2-month-old", () => {
+    expect(relativeTime("2026-02-16T12:00:00Z")).toBe("2mo ago");
+  });
+  it("returns years for 2-year-old", () => {
+    expect(relativeTime("2024-04-16T12:00:00Z")).toBe("2.0y ago");
+  });
+});
+
+describe("shortHash", () => {
+  it("returns — for null/empty", () => {
+    expect(shortHash(null)).toBe("—");
+    expect(shortHash(undefined)).toBe("—");
+    expect(shortHash("")).toBe("—");
+  });
+  it("returns full hash if ≤10 chars", () => {
+    expect(shortHash("abc")).toBe("abc");
+    expect(shortHash("0123456789")).toBe("0123456789");
+  });
+  it("truncates hash to first 10 chars", () => {
+    expect(shortHash("9d6695ebfab0112549c821127205014673")).toBe("9d6695ebfa");
+  });
+});
+
+describe("safeIsoDate", () => {
+  it("returns — for missing/invalid", () => {
+    expect(safeIsoDate(null)).toBe("—");
+    expect(safeIsoDate("")).toBe("—");
+    expect(safeIsoDate("not-a-date")).toBe("—");
+  });
+  it("slices valid ISO to YYYY-MM-DD", () => {
+    expect(safeIsoDate("2026-04-16T12:00:00Z")).toBe("2026-04-16");
+  });
+});
+
+describe("safeIsoDateTime", () => {
+  it("returns — for missing/invalid", () => {
+    expect(safeIsoDateTime(null)).toBe("—");
+    expect(safeIsoDateTime("not-a-date")).toBe("—");
+  });
+  it("formats ISO to 'YYYY-MM-DD HH:MM:SS'", () => {
+    expect(safeIsoDateTime("2026-04-16T12:34:56Z")).toBe("2026-04-16 12:34:56");
+  });
+});
+
+describe("isSafeHttpUrl", () => {
+  it("accepts http/https", () => {
+    expect(isSafeHttpUrl("http://example.com")).toBe(true);
+    expect(isSafeHttpUrl("https://example.com/path?q=1")).toBe(true);
+  });
+  it("rejects javascript:/data:/file:", () => {
+    expect(isSafeHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeHttpUrl("data:text/html,<script>")).toBe(false);
+    expect(isSafeHttpUrl("file:///etc/passwd")).toBe(false);
+  });
+  it("rejects non-URL strings", () => {
+    expect(isSafeHttpUrl("not a url")).toBe(false);
+    expect(isSafeHttpUrl("")).toBe(false);
+    expect(isSafeHttpUrl(null)).toBe(false);
+    expect(isSafeHttpUrl(undefined)).toBe(false);
+  });
+  it("rejects urn: scheme (used internally as placeholder)", () => {
+    expect(isSafeHttpUrl("urn:lw:tabular-source:ea-funds")).toBe(false);
+  });
+});

--- a/apps/web/src/app/data-sources/[id]/detail-utils.ts
+++ b/apps/web/src/app/data-sources/[id]/detail-utils.ts
@@ -1,0 +1,49 @@
+/** Shared pure utilities for the data-source detail page. */
+
+/** Relative-time label like "5d ago", "2mo ago". Returns "—" for invalid/future timestamps. */
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return "—";
+  const ms = Date.now() - t;
+  if (ms < 0) return "just now";
+  const days = Math.round(ms / 86400000);
+  if (days === 0) return "today";
+  if (days === 1) return "1d ago";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${(days / 365).toFixed(1)}y ago`;
+}
+
+/** Short-hash display (first 10 chars). Returns "—" for missing/empty hashes. */
+export function shortHash(h: string | null | undefined): string {
+  if (!h) return "—";
+  return h.length > 10 ? h.slice(0, 10) : h;
+}
+
+/** Safe ISO-date slice (YYYY-MM-DD). Returns "—" for invalid/missing. */
+export function safeIsoDate(v: string | null | undefined): string {
+  if (!v) return "—";
+  const t = new Date(v).getTime();
+  if (isNaN(t)) return "—";
+  return new Date(t).toISOString().slice(0, 10);
+}
+
+/** Safe "YYYY-MM-DD HH:MM:SS" UTC format. Returns "—" for invalid/missing. */
+export function safeIsoDateTime(v: string | null | undefined): string {
+  if (!v) return "—";
+  const t = new Date(v).getTime();
+  if (isNaN(t)) return "—";
+  return new Date(t).toISOString().slice(0, 19).replace("T", " ");
+}
+
+/** Returns true only for http(s) URLs. Blocks javascript:, data:, file:, etc. */
+export function isSafeHttpUrl(url: string | null | undefined): url is string {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/app/data-sources/[id]/detail-utils.ts
+++ b/apps/web/src/app/data-sources/[id]/detail-utils.ts
@@ -1,6 +1,3 @@
-/** Shared pure utilities for the data-source detail page. */
-
-/** Relative-time label like "5d ago", "2mo ago". Returns "—" for invalid/future timestamps. */
 export function relativeTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const t = new Date(iso).getTime();
@@ -15,13 +12,11 @@ export function relativeTime(iso: string | null | undefined): string {
   return `${(days / 365).toFixed(1)}y ago`;
 }
 
-/** Short-hash display (first 10 chars). Returns "—" for missing/empty hashes. */
 export function shortHash(h: string | null | undefined): string {
   if (!h) return "—";
   return h.length > 10 ? h.slice(0, 10) : h;
 }
 
-/** Safe ISO-date slice (YYYY-MM-DD). Returns "—" for invalid/missing. */
 export function safeIsoDate(v: string | null | undefined): string {
   if (!v) return "—";
   const t = new Date(v).getTime();
@@ -29,21 +24,9 @@ export function safeIsoDate(v: string | null | undefined): string {
   return new Date(t).toISOString().slice(0, 10);
 }
 
-/** Safe "YYYY-MM-DD HH:MM:SS" UTC format. Returns "—" for invalid/missing. */
 export function safeIsoDateTime(v: string | null | undefined): string {
   if (!v) return "—";
   const t = new Date(v).getTime();
   if (isNaN(t)) return "—";
   return new Date(t).toISOString().slice(0, 19).replace("T", " ");
-}
-
-/** Returns true only for http(s) URLs. Blocks javascript:, data:, file:, etc. */
-export function isSafeHttpUrl(url: string | null | undefined): url is string {
-  if (!url) return false;
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
 }

--- a/apps/web/src/app/data-sources/[id]/page.tsx
+++ b/apps/web/src/app/data-sources/[id]/page.tsx
@@ -1,0 +1,541 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { DataSourceBanner } from "@/components/internal/DataSourceBanner";
+import { ProfileStatCard } from "@/components/directory";
+import {
+  fetchDetailed,
+  type RpcDataSourceDetailResult,
+  type RpcSnapshotListResult,
+} from "@/lib/wiki-server";
+import { resolveEntityName } from "@/lib/resolve-entity-name";
+import { computeFreshness } from "@/app/data-sources/freshness";
+import {
+  FORMAT_LABELS,
+  FORMAT_COLORS,
+  RECORD_TYPE_LABELS,
+  RECORD_TYPE_COLORS,
+} from "@/app/data-sources/data-source-labels";
+import { SnapshotsSection } from "./snapshots-section";
+
+export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const result = await fetchDetailed<RpcDataSourceDetailResult>(
+    `/api/data-sources/${encodeURIComponent(id)}`,
+    { revalidate: 300 },
+  );
+  if (!result.ok) {
+    return {
+      title: `${id} | Data Sources`,
+      description: `Metadata and snapshot history for data source ${id}.`,
+    };
+  }
+  return {
+    title: `${result.data.name} | Data Sources`,
+    description: `Metadata, column mapping, snapshot history, and connected records for the ${result.data.name} data source.`,
+  };
+}
+
+const FRESHNESS_STYLES: Record<
+  string,
+  { label: string; bg: string; text: string }
+> = {
+  fresh: {
+    label: "Fresh",
+    bg: "bg-emerald-100 dark:bg-emerald-900/40",
+    text: "text-emerald-700 dark:text-emerald-300",
+  },
+  due: {
+    label: "Due",
+    bg: "bg-amber-100 dark:bg-amber-900/40",
+    text: "text-amber-700 dark:text-amber-300",
+  },
+  overdue: {
+    label: "Overdue",
+    bg: "bg-red-100 dark:bg-red-900/40",
+    text: "text-red-700 dark:text-red-300",
+  },
+  static: {
+    label: "Static",
+    bg: "bg-gray-100 dark:bg-gray-900/40",
+    text: "text-gray-600 dark:text-gray-400",
+  },
+  unknown: {
+    label: "Unknown",
+    bg: "bg-gray-100 dark:bg-gray-900/40",
+    text: "text-gray-600 dark:text-gray-400",
+  },
+};
+
+const STATUS_STYLES: Record<string, { label: string; color: string }> = {
+  active: { label: "Active", color: "text-blue-600" },
+  archived: { label: "Archived", color: "text-muted-foreground" },
+  defunct: { label: "Defunct", color: "text-red-600" },
+};
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (isNaN(ms) || ms < 0) return iso;
+  const days = Math.round(ms / 86400000);
+  if (days === 0) return "today";
+  if (days === 1) return "1d ago";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${(days / 365).toFixed(1)}y ago`;
+}
+
+function shortHash(h: string | null): string {
+  if (!h) return "—";
+  return h.length > 10 ? h.slice(0, 10) : h;
+}
+
+function TermList({
+  items,
+}: {
+  items: Array<{ label: string; value: React.ReactNode }>;
+}) {
+  return (
+    <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 text-sm">
+      {items.map(({ label, value }) => (
+        <div key={label} className="contents">
+          <dt className="text-muted-foreground">{label}</dt>
+          <dd className="min-w-0 break-words">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground/80 mb-3">
+      {children}
+    </h2>
+  );
+}
+
+function JsonBlock({ data }: { data: unknown }) {
+  return (
+    <pre className="text-xs bg-muted/40 border border-border/60 rounded-lg p-3 overflow-x-auto max-h-72">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}
+
+export default async function DataSourceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const detailResult = await fetchDetailed<RpcDataSourceDetailResult>(
+    `/api/data-sources/${encodeURIComponent(id)}`,
+    { revalidate: 300 },
+  );
+
+  if (!detailResult.ok) {
+    if (
+      detailResult.error.type === "server-error" &&
+      detailResult.error.status === 404
+    ) {
+      notFound();
+    }
+    return (
+      <div className="max-w-[80rem] mx-auto px-6 py-8">
+        <DataSourceBanner
+          source="api"
+          apiError={
+            detailResult.error.type !== "not-configured"
+              ? detailResult.error
+              : undefined
+          }
+        />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-6 text-sm">
+          <p className="font-medium mb-1">Failed to load data source</p>
+          <p className="text-muted-foreground">
+            {detailResult.error.type === "not-configured"
+              ? "Wiki server not configured."
+              : detailResult.error.type === "connection-error"
+                ? detailResult.error.message
+                : `Server returned ${detailResult.error.status} ${detailResult.error.statusText}`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const source = detailResult.data;
+  const freshness = computeFreshness(
+    source.lastSnapshotAt,
+    source.updateFrequency,
+  );
+  const freshnessStyle =
+    FRESHNESS_STYLES[freshness] ?? FRESHNESS_STYLES.unknown;
+  const statusStyle = STATUS_STYLES[source.sourceStatus] ?? {
+    label: source.sourceStatus,
+    color: "text-muted-foreground",
+  };
+  const formatLabel = FORMAT_LABELS[source.dataFormat] ?? source.dataFormat;
+  const formatColor =
+    FORMAT_COLORS[source.dataFormat] ?? "text-muted-foreground";
+  const recordTypeLabel =
+    RECORD_TYPE_LABELS[source.recordType] ?? source.recordType;
+  const recordTypeColor =
+    RECORD_TYPE_COLORS[source.recordType] ?? "text-muted-foreground";
+
+  const publisher = source.publisherEntityId
+    ? resolveEntityName(source.publisherEntityId)
+    : null;
+
+  const snapshotsResult = await fetchDetailed<RpcSnapshotListResult>(
+    `/api/data-sources/${encodeURIComponent(id)}/snapshots?limit=20`,
+    { revalidate: 300 },
+  );
+  const snapshots = snapshotsResult.ok ? snapshotsResult.data.snapshots : [];
+  const snapshotTotal = snapshotsResult.ok ? snapshotsResult.data.total : 0;
+
+  const recordsLinkHref =
+    source.recordType === "grant" ? `/grants?dataSource=${source.id}` : null;
+
+  const statCards: Array<{
+    label: string;
+    value: string;
+    sub?: string;
+    href?: string;
+  }> = [
+    {
+      label: "Records",
+      value:
+        source.snapshotRecordCount != null
+          ? source.snapshotRecordCount.toLocaleString()
+          : "—",
+      sub:
+        source.snapshotRecordCount != null
+          ? "in latest snapshot"
+          : "no snapshot yet",
+      href: recordsLinkHref ?? undefined,
+    },
+    {
+      label: "Last Snapshot",
+      value: source.lastSnapshotAt ? relativeTime(source.lastSnapshotAt) : "—",
+      sub: source.lastSnapshotAt
+        ? new Date(source.lastSnapshotAt).toISOString().slice(0, 10)
+        : "never fetched",
+    },
+    {
+      label: "Snapshots",
+      value: snapshotTotal.toLocaleString(),
+      sub: snapshotsResult.ok ? "total stored" : "unavailable",
+    },
+    {
+      label: "Update Frequency",
+      value: source.updateFrequency ?? "—",
+      sub: source.updateFrequency ? "expected cadence" : undefined,
+    },
+  ];
+
+  const metadataItems: Array<{ label: string; value: React.ReactNode }> = [
+    { label: "Source slug", value: <code className="text-xs">{source.id}</code> },
+    {
+      label: "Format",
+      value: <span className={`font-medium ${formatColor}`}>{formatLabel}</span>,
+    },
+    {
+      label: "Record type",
+      value: (
+        <span className={`font-medium ${recordTypeColor}`}>
+          {recordTypeLabel}
+        </span>
+      ),
+    },
+    { label: "Access method", value: source.accessMethod },
+    {
+      label: "Fetch URL",
+      value: source.fetchUrl ? (
+        <a
+          href={source.fetchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-foreground hover:underline break-all"
+        >
+          {source.fetchUrl}
+        </a>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+    },
+    {
+      label: "Publisher",
+      value: publisher ? (
+        publisher.href ? (
+          <Link
+            href={publisher.href}
+            className="text-accent-foreground hover:underline"
+          >
+            {publisher.name}
+          </Link>
+        ) : (
+          publisher.name
+        )
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+    },
+    {
+      label: "Resource",
+      value: source.resourceId ? (
+        <Link
+          href={`/resources/${source.resourceId}`}
+          className="text-accent-foreground hover:underline"
+        >
+          View resource record →
+        </Link>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+    },
+    {
+      label: "Created",
+      value: (
+        <span className="tabular-nums text-muted-foreground">
+          {new Date(source.createdAt).toISOString().slice(0, 10)}
+        </span>
+      ),
+    },
+    {
+      label: "Updated",
+      value: (
+        <span className="tabular-nums text-muted-foreground">
+          {new Date(source.updatedAt).toISOString().slice(0, 10)}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <div className="max-w-[80rem] mx-auto px-6 py-8">
+      {/* Breadcrumbs */}
+      <nav className="text-xs text-muted-foreground mb-4" aria-label="Breadcrumb">
+        <Link href="/wiki/E2131" className="hover:underline">
+          Data Sources
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground/80">{source.name}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-2">
+          {source.name}
+        </h1>
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${freshnessStyle.bg} ${freshnessStyle.text}`}
+          >
+            {freshnessStyle.label}
+          </span>
+          <span className={`text-xs font-medium ${statusStyle.color}`}>
+            {statusStyle.label}
+          </span>
+          <span className="text-muted-foreground text-xs">·</span>
+          <span className={`text-xs font-medium ${formatColor}`}>
+            {formatLabel}
+          </span>
+          <span className={`text-xs font-medium ${recordTypeColor}`}>
+            {recordTypeLabel}
+          </span>
+        </div>
+        {source.fetchUrl && (
+          <p className="text-sm text-muted-foreground break-all">
+            <a
+              href={source.fetchUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+            >
+              {source.fetchUrl}
+            </a>
+          </p>
+        )}
+      </div>
+
+      <DataSourceBanner source="api" />
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
+        {statCards.map((card) => (
+          <ProfileStatCard
+            key={card.label}
+            label={card.label}
+            value={card.value}
+            sub={card.sub}
+            href={card.href}
+          />
+        ))}
+      </div>
+
+      {/* Main grid: metadata + side sections */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2 space-y-8">
+          <section>
+            <SectionHeader>Metadata</SectionHeader>
+            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+              <TermList items={metadataItems} />
+            </div>
+          </section>
+
+          {source.columnMapping &&
+            Object.keys(source.columnMapping).length > 0 && (
+              <section>
+                <SectionHeader>Column Mapping</SectionHeader>
+                <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Maps raw source columns → canonical fields used by the
+                    importer.
+                  </p>
+                  <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1.5 text-xs">
+                    {Object.entries(source.columnMapping).map(([k, v]) => (
+                      <div key={k} className="contents">
+                        <dt className="font-mono text-muted-foreground">
+                          {k}
+                        </dt>
+                        <dd className="font-mono break-all">{String(v)}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              </section>
+            )}
+
+          {source.verificationConfig && (
+            <section>
+              <SectionHeader>Verification Config</SectionHeader>
+              <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+                <p className="text-xs text-muted-foreground mb-3">
+                  Strategy and fields used by source-check to match records
+                  against this source.
+                </p>
+                <JsonBlock data={source.verificationConfig} />
+              </div>
+            </section>
+          )}
+
+          {source.sourceSchema && (
+            <section>
+              <SectionHeader>Source Schema</SectionHeader>
+              <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+                <JsonBlock data={source.sourceSchema} />
+              </div>
+            </section>
+          )}
+        </div>
+
+        <aside className="space-y-8">
+          <section>
+            <SectionHeader>Connected Records</SectionHeader>
+            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5 text-sm">
+              {recordsLinkHref ? (
+                <Link
+                  href={recordsLinkHref}
+                  className="flex items-center justify-between gap-2 text-accent-foreground hover:underline"
+                >
+                  <span>
+                    Grants from this source
+                    {source.snapshotRecordCount != null && (
+                      <span className="text-muted-foreground font-normal ml-2">
+                        ({source.snapshotRecordCount.toLocaleString()})
+                      </span>
+                    )}
+                  </span>
+                  <span className="shrink-0">→</span>
+                </Link>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  No directory filter exists for{" "}
+                  <span className="font-medium">{recordTypeLabel}</span>{" "}
+                  records yet.
+                </p>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <SectionHeader>Latest Snapshot</SectionHeader>
+            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5 text-sm">
+              {source.latestSnapshot ? (
+                <TermList
+                  items={[
+                    {
+                      label: "Fetched",
+                      value: (
+                        <span className="tabular-nums">
+                          {new Date(
+                            source.latestSnapshot.fetchedAt,
+                          ).toLocaleString()}
+                        </span>
+                      ),
+                    },
+                    {
+                      label: "Records",
+                      value:
+                        source.latestSnapshot.recordCount != null
+                          ? source.latestSnapshot.recordCount.toLocaleString()
+                          : "—",
+                    },
+                    {
+                      label: "Hash",
+                      value: (
+                        <code
+                          className="text-xs"
+                          title={source.latestSnapshot.snapshotHash}
+                        >
+                          {shortHash(source.latestSnapshot.snapshotHash)}
+                        </code>
+                      ),
+                    },
+                    {
+                      label: "Mapping",
+                      value: source.latestSnapshot.mappingValid ? (
+                        <span className="text-emerald-600">valid</span>
+                      ) : (
+                        <span className="text-red-600">invalid</span>
+                      ),
+                    },
+                    {
+                      label: "Parser",
+                      value: source.latestSnapshot.parserVersion ?? "—",
+                    },
+                  ]}
+                />
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  No snapshots recorded yet.
+                </p>
+              )}
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      {/* Snapshot history */}
+      <section className="mt-10">
+        <div className="flex items-baseline justify-between mb-3">
+          <SectionHeader>Snapshot History</SectionHeader>
+          {snapshotTotal > snapshots.length && (
+            <span className="text-xs text-muted-foreground">
+              showing {snapshots.length} of {snapshotTotal}
+            </span>
+          )}
+        </div>
+        <SnapshotsSection snapshots={snapshots} />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/data-sources/[id]/page.tsx
+++ b/apps/web/src/app/data-sources/[id]/page.tsx
@@ -17,6 +17,15 @@ import {
   RECORD_TYPE_COLORS,
 } from "@/app/data-sources/data-source-labels";
 import { SnapshotsSection } from "./snapshots-section";
+import {
+  relativeTime,
+  shortHash,
+  safeIsoDate,
+  safeIsoDateTime,
+  isSafeHttpUrl,
+} from "./detail-utils";
+
+type Freshness = ReturnType<typeof computeFreshness>;
 
 export const revalidate = 300;
 
@@ -43,7 +52,7 @@ export async function generateMetadata({
 }
 
 const FRESHNESS_STYLES: Record<
-  string,
+  Freshness,
   { label: string; bg: string; text: string }
 > = {
   fresh: {
@@ -78,22 +87,6 @@ const STATUS_STYLES: Record<string, { label: string; color: string }> = {
   archived: { label: "Archived", color: "text-muted-foreground" },
   defunct: { label: "Defunct", color: "text-red-600" },
 };
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  if (isNaN(ms) || ms < 0) return iso;
-  const days = Math.round(ms / 86400000);
-  if (days === 0) return "today";
-  if (days === 1) return "1d ago";
-  if (days < 30) return `${days}d ago`;
-  if (days < 365) return `${Math.round(days / 30)}mo ago`;
-  return `${(days / 365).toFixed(1)}y ago`;
-}
-
-function shortHash(h: string | null): string {
-  if (!h) return "—";
-  return h.length > 10 ? h.slice(0, 10) : h;
-}
 
 function TermList({
   items,
@@ -134,11 +127,18 @@ export default async function DataSourceDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const encodedId = encodeURIComponent(id);
 
-  const detailResult = await fetchDetailed<RpcDataSourceDetailResult>(
-    `/api/data-sources/${encodeURIComponent(id)}`,
-    { revalidate: 300 },
-  );
+  const [detailResult, snapshotsResult] = await Promise.all([
+    fetchDetailed<RpcDataSourceDetailResult>(
+      `/api/data-sources/${encodedId}`,
+      { revalidate: 300 },
+    ),
+    fetchDetailed<RpcSnapshotListResult>(
+      `/api/data-sources/${encodedId}/snapshots?limit=20`,
+      { revalidate: 300 },
+    ),
+  ]);
 
   if (!detailResult.ok) {
     if (
@@ -194,15 +194,16 @@ export default async function DataSourceDetailPage({
     ? resolveEntityName(source.publisherEntityId)
     : null;
 
-  const snapshotsResult = await fetchDetailed<RpcSnapshotListResult>(
-    `/api/data-sources/${encodeURIComponent(id)}/snapshots?limit=20`,
-    { revalidate: 300 },
-  );
   const snapshots = snapshotsResult.ok ? snapshotsResult.data.snapshots : [];
   const snapshotTotal = snapshotsResult.ok ? snapshotsResult.data.total : 0;
+  const snapshotsUnavailable = !snapshotsResult.ok;
 
   const recordsLinkHref =
-    source.recordType === "grant" ? `/grants?dataSource=${source.id}` : null;
+    source.recordType === "grant"
+      ? `/grants?dataSource=${encodeURIComponent(source.id)}`
+      : null;
+
+  const fetchUrlSafe = isSafeHttpUrl(source.fetchUrl) ? source.fetchUrl : null;
 
   const statCards: Array<{
     label: string;
@@ -224,15 +225,15 @@ export default async function DataSourceDetailPage({
     },
     {
       label: "Last Snapshot",
-      value: source.lastSnapshotAt ? relativeTime(source.lastSnapshotAt) : "—",
+      value: relativeTime(source.lastSnapshotAt),
       sub: source.lastSnapshotAt
-        ? new Date(source.lastSnapshotAt).toISOString().slice(0, 10)
+        ? safeIsoDate(source.lastSnapshotAt)
         : "never fetched",
     },
     {
       label: "Snapshots",
-      value: snapshotTotal.toLocaleString(),
-      sub: snapshotsResult.ok ? "total stored" : "unavailable",
+      value: snapshotsUnavailable ? "—" : snapshotTotal.toLocaleString(),
+      sub: snapshotsUnavailable ? "unavailable" : "total stored",
     },
     {
       label: "Update Frequency",
@@ -258,15 +259,22 @@ export default async function DataSourceDetailPage({
     { label: "Access method", value: source.accessMethod },
     {
       label: "Fetch URL",
-      value: source.fetchUrl ? (
+      value: fetchUrlSafe ? (
         <a
-          href={source.fetchUrl}
+          href={fetchUrlSafe}
           target="_blank"
           rel="noopener noreferrer"
           className="text-accent-foreground hover:underline break-all"
         >
-          {source.fetchUrl}
+          {fetchUrlSafe}
         </a>
+      ) : source.fetchUrl ? (
+        <span
+          className="text-muted-foreground break-all"
+          title="URL scheme is not http(s); link suppressed"
+        >
+          {source.fetchUrl}
+        </span>
       ) : (
         <span className="text-muted-foreground">—</span>
       ),
@@ -305,7 +313,7 @@ export default async function DataSourceDetailPage({
       label: "Created",
       value: (
         <span className="tabular-nums text-muted-foreground">
-          {new Date(source.createdAt).toISOString().slice(0, 10)}
+          {safeIsoDate(source.createdAt)}
         </span>
       ),
     },
@@ -313,7 +321,7 @@ export default async function DataSourceDetailPage({
       label: "Updated",
       value: (
         <span className="tabular-nums text-muted-foreground">
-          {new Date(source.updatedAt).toISOString().slice(0, 10)}
+          {safeIsoDate(source.updatedAt)}
         </span>
       ),
     },
@@ -352,15 +360,15 @@ export default async function DataSourceDetailPage({
             {recordTypeLabel}
           </span>
         </div>
-        {source.fetchUrl && (
+        {fetchUrlSafe && (
           <p className="text-sm text-muted-foreground break-all">
             <a
-              href={source.fetchUrl}
+              href={fetchUrlSafe}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:underline"
             >
-              {source.fetchUrl}
+              {fetchUrlSafe}
             </a>
           </p>
         )}
@@ -476,9 +484,7 @@ export default async function DataSourceDetailPage({
                       label: "Fetched",
                       value: (
                         <span className="tabular-nums">
-                          {new Date(
-                            source.latestSnapshot.fetchedAt,
-                          ).toLocaleString()}
+                          {safeIsoDateTime(source.latestSnapshot.fetchedAt)}
                         </span>
                       ),
                     },
@@ -534,7 +540,13 @@ export default async function DataSourceDetailPage({
             </span>
           )}
         </div>
-        <SnapshotsSection snapshots={snapshots} />
+        {snapshotsUnavailable ? (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4 text-sm text-amber-700 dark:text-amber-300">
+            Snapshot history is temporarily unavailable.
+          </div>
+        ) : (
+          <SnapshotsSection snapshots={snapshots} />
+        )}
       </section>
     </div>
   );

--- a/apps/web/src/app/data-sources/[id]/page.tsx
+++ b/apps/web/src/app/data-sources/[id]/page.tsx
@@ -1,8 +1,12 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { DataSourceBanner } from "@/components/internal/DataSourceBanner";
 import { ProfileStatCard } from "@/components/directory";
+import { Breadcrumbs } from "@/components/directory/Breadcrumbs";
+import { SafeExternalLink } from "@/components/ui/safe-external-link";
+import { isSafeUrl } from "@lib/url-utils";
 import {
   fetchDetailed,
   type RpcDataSourceDetailResult,
@@ -22,12 +26,24 @@ import {
   shortHash,
   safeIsoDate,
   safeIsoDateTime,
-  isSafeHttpUrl,
 } from "./detail-utils";
 
 type Freshness = ReturnType<typeof computeFreshness>;
+type SourceStatus = RpcDataSourceDetailResult["sourceStatus"];
 
 export const revalidate = 300;
+
+const CARD_CLASS =
+  "rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5";
+
+const MAX_JSON_BYTES = 8 * 1024;
+
+const fetchDataSource = cache((id: string) =>
+  fetchDetailed<RpcDataSourceDetailResult>(
+    `/api/data-sources/${encodeURIComponent(id)}`,
+    { revalidate: 300 },
+  ),
+);
 
 export async function generateMetadata({
   params,
@@ -35,10 +51,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  const result = await fetchDetailed<RpcDataSourceDetailResult>(
-    `/api/data-sources/${encodeURIComponent(id)}`,
-    { revalidate: 300 },
-  );
+  const result = await fetchDataSource(id);
   if (!result.ok) {
     return {
       title: `${id} | Data Sources`,
@@ -82,7 +95,7 @@ const FRESHNESS_STYLES: Record<
   },
 };
 
-const STATUS_STYLES: Record<string, { label: string; color: string }> = {
+const STATUS_STYLES: Record<SourceStatus, { label: string; color: string }> = {
   active: { label: "Active", color: "text-blue-600" },
   archived: { label: "Archived", color: "text-muted-foreground" },
   defunct: { label: "Defunct", color: "text-red-600" },
@@ -114,9 +127,16 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 }
 
 function JsonBlock({ data }: { data: unknown }) {
+  let text = JSON.stringify(data, null, 2);
+  let truncated = false;
+  if (text.length > MAX_JSON_BYTES) {
+    text = text.slice(0, MAX_JSON_BYTES);
+    truncated = true;
+  }
   return (
     <pre className="text-xs bg-muted/40 border border-border/60 rounded-lg p-3 overflow-x-auto max-h-72">
-      {JSON.stringify(data, null, 2)}
+      {text}
+      {truncated && `\n… (truncated at ${MAX_JSON_BYTES} bytes)`}
     </pre>
   );
 }
@@ -127,15 +147,11 @@ export default async function DataSourceDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const encodedId = encodeURIComponent(id);
 
   const [detailResult, snapshotsResult] = await Promise.all([
-    fetchDetailed<RpcDataSourceDetailResult>(
-      `/api/data-sources/${encodedId}`,
-      { revalidate: 300 },
-    ),
+    fetchDataSource(id),
     fetchDetailed<RpcSnapshotListResult>(
-      `/api/data-sources/${encodedId}/snapshots?limit=20`,
+      `/api/data-sources/${encodeURIComponent(id)}/snapshots?limit=20`,
       { revalidate: 300 },
     ),
   ]);
@@ -176,12 +192,8 @@ export default async function DataSourceDetailPage({
     source.lastSnapshotAt,
     source.updateFrequency,
   );
-  const freshnessStyle =
-    FRESHNESS_STYLES[freshness] ?? FRESHNESS_STYLES.unknown;
-  const statusStyle = STATUS_STYLES[source.sourceStatus] ?? {
-    label: source.sourceStatus,
-    color: "text-muted-foreground",
-  };
+  const freshnessStyle = FRESHNESS_STYLES[freshness];
+  const statusStyle = STATUS_STYLES[source.sourceStatus];
   const formatLabel = FORMAT_LABELS[source.dataFormat] ?? source.dataFormat;
   const formatColor =
     FORMAT_COLORS[source.dataFormat] ?? "text-muted-foreground";
@@ -203,7 +215,8 @@ export default async function DataSourceDetailPage({
       ? `/grants?dataSource=${encodeURIComponent(source.id)}`
       : null;
 
-  const fetchUrlSafe = isSafeHttpUrl(source.fetchUrl) ? source.fetchUrl : null;
+  const fetchUrlSafe =
+    source.fetchUrl && isSafeUrl(source.fetchUrl) ? source.fetchUrl : null;
 
   const statCards: Array<{
     label: string;
@@ -260,14 +273,12 @@ export default async function DataSourceDetailPage({
     {
       label: "Fetch URL",
       value: fetchUrlSafe ? (
-        <a
+        <SafeExternalLink
           href={fetchUrlSafe}
-          target="_blank"
-          rel="noopener noreferrer"
           className="text-accent-foreground hover:underline break-all"
         >
           {fetchUrlSafe}
-        </a>
+        </SafeExternalLink>
       ) : source.fetchUrl ? (
         <span
           className="text-muted-foreground break-all"
@@ -329,16 +340,13 @@ export default async function DataSourceDetailPage({
 
   return (
     <div className="max-w-[80rem] mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <nav className="text-xs text-muted-foreground mb-4" aria-label="Breadcrumb">
-        <Link href="/wiki/E2131" className="hover:underline">
-          Data Sources
-        </Link>
-        <span className="mx-2">/</span>
-        <span className="text-foreground/80">{source.name}</span>
-      </nav>
+      <Breadcrumbs
+        items={[
+          { label: "Data Sources", href: "/wiki/E2131" },
+          { label: source.name },
+        ]}
+      />
 
-      {/* Header */}
       <div className="mb-6">
         <h1 className="text-3xl font-extrabold tracking-tight mb-2">
           {source.name}
@@ -362,21 +370,18 @@ export default async function DataSourceDetailPage({
         </div>
         {fetchUrlSafe && (
           <p className="text-sm text-muted-foreground break-all">
-            <a
+            <SafeExternalLink
               href={fetchUrlSafe}
-              target="_blank"
-              rel="noopener noreferrer"
               className="hover:underline"
             >
               {fetchUrlSafe}
-            </a>
+            </SafeExternalLink>
           </p>
         )}
       </div>
 
       <DataSourceBanner source="api" />
 
-      {/* Stat cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8">
         {statCards.map((card) => (
           <ProfileStatCard
@@ -389,12 +394,11 @@ export default async function DataSourceDetailPage({
         ))}
       </div>
 
-      {/* Main grid: metadata + side sections */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2 space-y-8">
           <section>
             <SectionHeader>Metadata</SectionHeader>
-            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+            <div className={CARD_CLASS}>
               <TermList items={metadataItems} />
             </div>
           </section>
@@ -403,7 +407,7 @@ export default async function DataSourceDetailPage({
             Object.keys(source.columnMapping).length > 0 && (
               <section>
                 <SectionHeader>Column Mapping</SectionHeader>
-                <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+                <div className={CARD_CLASS}>
                   <p className="text-xs text-muted-foreground mb-3">
                     Maps raw source columns → canonical fields used by the
                     importer.
@@ -425,7 +429,7 @@ export default async function DataSourceDetailPage({
           {source.verificationConfig && (
             <section>
               <SectionHeader>Verification Config</SectionHeader>
-              <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+              <div className={CARD_CLASS}>
                 <p className="text-xs text-muted-foreground mb-3">
                   Strategy and fields used by source-check to match records
                   against this source.
@@ -438,7 +442,7 @@ export default async function DataSourceDetailPage({
           {source.sourceSchema && (
             <section>
               <SectionHeader>Source Schema</SectionHeader>
-              <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5">
+              <div className={CARD_CLASS}>
                 <JsonBlock data={source.sourceSchema} />
               </div>
             </section>
@@ -448,7 +452,7 @@ export default async function DataSourceDetailPage({
         <aside className="space-y-8">
           <section>
             <SectionHeader>Connected Records</SectionHeader>
-            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5 text-sm">
+            <div className={`${CARD_CLASS} text-sm`}>
               {recordsLinkHref ? (
                 <Link
                   href={recordsLinkHref}
@@ -476,7 +480,7 @@ export default async function DataSourceDetailPage({
 
           <section>
             <SectionHeader>Latest Snapshot</SectionHeader>
-            <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-5 text-sm">
+            <div className={`${CARD_CLASS} text-sm`}>
               {source.latestSnapshot ? (
                 <TermList
                   items={[
@@ -530,7 +534,6 @@ export default async function DataSourceDetailPage({
         </aside>
       </div>
 
-      {/* Snapshot history */}
       <section className="mt-10">
         <div className="flex items-baseline justify-between mb-3">
           <SectionHeader>Snapshot History</SectionHeader>

--- a/apps/web/src/app/data-sources/[id]/snapshots-section.tsx
+++ b/apps/web/src/app/data-sources/[id]/snapshots-section.tsx
@@ -1,11 +1,7 @@
 import type { RpcSnapshotListResult } from "@/lib/wiki-server";
+import { shortHash, safeIsoDateTime } from "./detail-utils";
 
 type Snapshot = RpcSnapshotListResult["snapshots"][number];
-
-function shortHash(h: string | null): string {
-  if (!h) return "—";
-  return h.length > 10 ? h.slice(0, 10) : h;
-}
 
 export function SnapshotsSection({ snapshots }: { snapshots: Snapshot[] }) {
   if (snapshots.length === 0) {
@@ -38,7 +34,7 @@ export function SnapshotsSection({ snapshots }: { snapshots: Snapshot[] }) {
               }
             >
               <td className="px-4 py-2 tabular-nums whitespace-nowrap">
-                {new Date(s.fetchedAt).toISOString().slice(0, 19).replace("T", " ")}
+                {safeIsoDateTime(s.fetchedAt)}
               </td>
               <td className="px-4 py-2 tabular-nums text-right">
                 {s.recordCount != null ? s.recordCount.toLocaleString() : "—"}

--- a/apps/web/src/app/data-sources/[id]/snapshots-section.tsx
+++ b/apps/web/src/app/data-sources/[id]/snapshots-section.tsx
@@ -1,0 +1,70 @@
+import type { RpcSnapshotListResult } from "@/lib/wiki-server";
+
+type Snapshot = RpcSnapshotListResult["snapshots"][number];
+
+function shortHash(h: string | null): string {
+  if (!h) return "—";
+  return h.length > 10 ? h.slice(0, 10) : h;
+}
+
+export function SnapshotsSection({ snapshots }: { snapshots: Snapshot[] }) {
+  if (snapshots.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 p-6 text-sm text-muted-foreground text-center">
+        No snapshots recorded for this data source yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase tracking-wider text-muted-foreground bg-muted/30">
+          <tr>
+            <th className="text-left font-medium px-4 py-2">Fetched</th>
+            <th className="text-right font-medium px-4 py-2">Records</th>
+            <th className="text-left font-medium px-4 py-2">Hash</th>
+            <th className="text-left font-medium px-4 py-2">Mapping</th>
+            <th className="text-left font-medium px-4 py-2">Parser</th>
+            <th className="text-left font-medium px-4 py-2">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {snapshots.map((s, i) => (
+            <tr
+              key={s.id}
+              className={
+                i % 2 === 0 ? "bg-transparent" : "bg-muted/10"
+              }
+            >
+              <td className="px-4 py-2 tabular-nums whitespace-nowrap">
+                {new Date(s.fetchedAt).toISOString().slice(0, 19).replace("T", " ")}
+              </td>
+              <td className="px-4 py-2 tabular-nums text-right">
+                {s.recordCount != null ? s.recordCount.toLocaleString() : "—"}
+              </td>
+              <td className="px-4 py-2">
+                <code className="text-xs" title={s.snapshotHash}>
+                  {shortHash(s.snapshotHash)}
+                </code>
+              </td>
+              <td className="px-4 py-2 text-xs">
+                {s.mappingValid ? (
+                  <span className="text-emerald-600">valid</span>
+                ) : (
+                  <span className="text-red-600">invalid</span>
+                )}
+              </td>
+              <td className="px-4 py-2 text-xs text-muted-foreground">
+                {s.parserVersion ?? "—"}
+              </td>
+              <td className="px-4 py-2 text-xs text-muted-foreground max-w-[320px] truncate" title={s.notes ?? undefined}>
+                {s.notes ?? "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/data-sources/data-sources-table.tsx
+++ b/apps/web/src/app/data-sources/data-sources-table.tsx
@@ -105,13 +105,10 @@ const columns: ColumnDef<DataSourceRow>[] = [
       <SortableHeader column={column}>Name</SortableHeader>
     ),
     cell: ({ row }) => {
-      const { name, resourceId } = row.original;
-      if (!resourceId) {
-        return <span className="text-sm font-medium">{name}</span>;
-      }
+      const { id, name } = row.original;
       return (
         <Link
-          href={`/resources/${resourceId}`}
+          href={`/data-sources/${id}`}
           className="text-sm font-medium text-accent-foreground hover:underline"
         >
           {name}


### PR DESCRIPTION
## Summary

Dedicated detail pages at `/data-sources/[id]` for each data source (ea-funds, sff, manifund, aria, acx-grants, coefficient-giving, ford-foundation, …). Closes the gap from QUA-81: users can now see the full picture for a single source — metadata, column mapping, verification config, latest snapshot, and snapshot history — instead of only a row in the E2131 table.

## Key changes

- **New dynamic route** `apps/web/src/app/data-sources/[id]/page.tsx` — server-rendered, ISR 300s.
  - Header with freshness/status/format/record-type badges
  - 4 stat cards: Records (in latest snapshot, linked to `/grants?dataSource=[id]` when applicable), Last Snapshot (relative + ISO date), Snapshots (total count), Update Frequency
  - Metadata card: source slug, fetch URL, publisher entity link, resource link, timestamps
  - Column Mapping card (raw → canonical)
  - Verification Config card (strategy + match/fuzzy/exact fields) with 8KB cap
  - Source Schema card (JSON, capped)
  - Connected Records sidebar (links to `/grants?dataSource=[id]`)
  - Latest Snapshot sidebar (fetched, records, hash, mapping-valid, parser)
  - Snapshot History table (latest 20, showing "X of N" when more exist)
- **New snapshots section** `apps/web/src/app/data-sources/[id]/snapshots-section.tsx`
- **Pure utilities + tests** in `apps/web/src/app/data-sources/[id]/detail-utils.ts` with 14 vitest cases (relativeTime, shortHash, safeIsoDate, safeIsoDateTime)
- **Table link update**: the E2131 dashboard table's Name column now links to `/data-sources/[id]` (was `/resources/[resourceId]`; the resource link is still available from the detail page's Metadata section)
- **Render-audit coverage**: `/data-sources/ea-funds` added to `e2e/render-audit.spec.ts`

## Design notes

- **Not using `EntityProfileShell`** — data sources live in `resource_tabular_sources`, not the `entities` table; they have no `numericId` or sourcing rollup. Custom layout mirrors the dashboard's visual language.
- **Reuses shared helpers**: `isSafeUrl` (lib/url-utils), `SafeExternalLink` (components/ui), `Breadcrumbs` (components/directory), `ProfileStatCard` (components/directory), `DataSourceBanner` (components/internal), `computeFreshness` (app/data-sources/freshness), `FORMAT_*` / `RECORD_TYPE_*` maps (app/data-sources/data-source-labels).
- **Only grants have a `dataSourceId` FK today** — the Connected Records sidebar currently links only for `recordType === "grant"`. Other record types (personnel, investment, publication, mixed) render an informative fallback. A future PR can extend this when those FKs land.
- **Detail fetch deduplicated** with `React.cache` so `generateMetadata` and the page share one fetch.

## Test plan

- [x] `pnpm build` — includes `ƒ /data-sources/[id]` in the route manifest
- [x] `pnpm test` — 91 files, 1598 tests (14 new cases)
- [x] `pnpm crux w validate gate --fix` — 51 blocking checks pass
- [x] Playwright smoke test against prod data (4 real slugs: ea-funds, aria, acx-grants, coefficient-giving) — all HTTP 200, no console errors
- [x] 404 path — unknown slug returns `notFound()`
- [x] Adversarial slugs — special chars, path traversal, null bytes all return clean 404 (or normalize safely)
- [x] `fetchUrl` with `javascript:`/`data:`/`urn:` schemes is rendered as plain text (not as an `<a href>`)
- [ ] Post-merge: visit `https://www.longtermwiki.com/data-sources/ea-funds` after deploy to confirm prod renders

Fixes QUA-81
