### PR TITLE
fix(data-sources): restore sourcing-lint baseline (unstick main CI)

### DIFF
--- a/apps/web/src/app/data-sources/[id]/page.tsx
+++ b/apps/web/src/app/data-sources/[id]/page.tsx
@@ -431,7 +431,7 @@ export default async function DataSourceDetailPage({
               <SectionHeader>Verification Config</SectionHeader>
               <div className={CARD_CLASS}>
                 <p className="text-xs text-muted-foreground mb-3">
-                  Strategy and fields used by source-check to match records
+                  Strategy and fields used by sourcing to match records
                   against this source.
                 </p>
                 <JsonBlock data={source.verificationConfig} />


### PR DESCRIPTION
## Summary

PR #4442 (QUA-81 data-sources detail pages) introduced a new user-facing
helper string on \`/data-sources/[id]\` that used \`source-check\` prose.
That pushed the sourcing-lint-guard total from 1 → 2 and tripped the
ratchet's baseline regression test (\`validate-sourcing-lint-guard.test.ts\`,
the \`runCheck passes on the current codebase\` case), which turned main CI
and release PR #4439 red.

Fix: rename the one prose occurrence to \`sourcing\`. Baseline (1) holds;
no code paths changed.

## Test plan
- [x] \`GITHUB_REF=refs/heads/main npx tsx crux/validate/validate-sourcing-lint-guard.ts\` → "At baseline (1 references across 1487 files)"
- [x] Pre-push gate: all 41 checks passed
- [ ] CI green on this PR
- [ ] Main CI green after merge
- [ ] Release PR #4439 green after this lands on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description text in the "Verification Config" section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->