### PR TITLE
fix(agent-sessions): populate date on sweep + fallback to started_at

### DIFF
--- a/apps/wiki-server/drizzle/0185_backfill_agent_sessions_date.sql
+++ b/apps/wiki-server/drizzle/0185_backfill_agent_sessions_date.sql
@@ -1,0 +1,13 @@
+-- Backfill `agent_sessions.date` from `started_at` for rows where it's null.
+--
+-- Context: `date` is supposed to be populated by `crux sys session-finalize`
+-- (async SessionEnd hook), but the hook is unreliable — it runs async with a
+-- 30s timeout and fails silently. The groundskeeper sweep then marks those
+-- sessions `completed` without touching `date`, so rows end up with
+-- status=completed, date=null, and drop out of every date-filtered query
+-- (retrospective, /internal/page-changes).
+--
+-- This UPDATE is idempotent and bounded (only a few hundred rows in prod).
+UPDATE agent_sessions
+   SET date = started_at::date
+ WHERE date IS NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1296,6 +1296,13 @@
       "when": 1785398400000,
       "tag": "0184_qua_536_populate_resources_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 185,
+      "version": "7",
+      "when": 1785398400001,
+      "tag": "0185_backfill_agent_sessions_date",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -449,11 +449,16 @@ const agentSessionsApp = new Hono()
     // (async SessionEnd hook) and frequently doesn't run; without this fallback,
     // swept rows end up with status=completed but date=null and drop out of any
     // date-filtered query (retrospective, /internal/page-changes, etc).
+    // Note: unlike the PATCH handler, this sweep does NOT require title/summary
+    // before setting status='completed'. Swept rows may therefore have
+    // title=null / summary=null. Downstream consumers of status='completed' must
+    // tolerate nulls in those fields (the retrospective tool already does).
+    const now = new Date();
     const stale = await db.update(agentSessions)
       .set({
         status: "completed",
-        completedAt: new Date(),
-        updatedAt: new Date(),
+        completedAt: now,
+        updatedAt: now,
         date: sql`COALESCE(${agentSessions.date}, ${agentSessions.startedAt}::date)`,
       })
       .where(and(eq(agentSessions.status, "active"), lt(agentSessions.updatedAt, cutoff)))

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -445,8 +445,17 @@ const agentSessionsApp = new Hono()
     const timeoutHours = Math.max(1, Math.min(Number.isFinite(raw) ? raw : 2, 720));
     const cutoff = new Date(Date.now() - timeoutHours * 60 * 60 * 1000);
     const db = getDrizzleDb();
+    // Backfill `date` from `started_at` when null — session-finalize is best-effort
+    // (async SessionEnd hook) and frequently doesn't run; without this fallback,
+    // swept rows end up with status=completed but date=null and drop out of any
+    // date-filtered query (retrospective, /internal/page-changes, etc).
     const stale = await db.update(agentSessions)
-      .set({ status: "completed", completedAt: new Date(), updatedAt: new Date() })
+      .set({
+        status: "completed",
+        completedAt: new Date(),
+        updatedAt: new Date(),
+        date: sql`COALESCE(${agentSessions.date}, ${agentSessions.startedAt}::date)`,
+      })
       .where(and(eq(agentSessions.status, "active"), lt(agentSessions.updatedAt, cutoff)))
       .returning({ id: agentSessions.id, branch: agentSessions.branch, issueNumber: agentSessions.issueNumber });
     logger.info({ swept: stale.length, cutoff: cutoff.toISOString() }, "Sweep: marked stale sessions as completed");

--- a/crux/lib/maintain/session-logs.test.ts
+++ b/crux/lib/maintain/session-logs.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the wiki-server client BEFORE importing session-logs
+vi.mock('../wiki-server/agent-sessions.ts', () => ({
+  listAgentSessions: vi.fn(),
+}));
+
+import { loadSessionLogsSince } from './session-logs.ts';
+import { listAgentSessions } from '../wiki-server/agent-sessions.ts';
+
+const mockListAgentSessions = vi.mocked(listAgentSessions);
+
+function apiOk<T>(data: T) {
+  return { ok: true as const, data };
+}
+
+describe('loadSessionLogsSince', () => {
+  beforeEach(() => {
+    mockListAgentSessions.mockReset();
+  });
+
+  it('falls back to startedAt when date is null', async () => {
+    mockListAgentSessions.mockResolvedValue(
+      apiOk({
+        sessions: [
+          {
+            id: 1, branch: 'claude/foo', date: null,
+            startedAt: '2026-04-16T12:00:00.000Z',
+            title: 'A', summary: 'S',
+            issuesJson: null, learningsJson: null,
+          },
+        ] as any,
+      }) as any
+    );
+
+    const entries = await loadSessionLogsSince('2026-04-09');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-04-16');
+    expect(entries[0].branch).toBe('claude/foo');
+  });
+
+  it('prefers explicit date over startedAt when both are present', async () => {
+    mockListAgentSessions.mockResolvedValue(
+      apiOk({
+        sessions: [
+          {
+            id: 1, branch: 'claude/foo',
+            date: '2026-04-15',
+            startedAt: '2026-04-16T12:00:00.000Z',
+            title: 'A', summary: 'S',
+            issuesJson: null, learningsJson: null,
+          },
+        ] as any,
+      }) as any
+    );
+
+    const entries = await loadSessionLogsSince('2026-04-09');
+    expect(entries[0].date).toBe('2026-04-15');
+  });
+
+  it('drops rows before the since threshold regardless of which field is used', async () => {
+    mockListAgentSessions.mockResolvedValue(
+      apiOk({
+        sessions: [
+          {
+            id: 1, branch: 'claude/old', date: null,
+            startedAt: '2026-03-15T12:00:00.000Z',
+            title: null, summary: null,
+            issuesJson: null, learningsJson: null,
+          },
+          {
+            id: 2, branch: 'claude/recent', date: null,
+            startedAt: '2026-04-16T12:00:00.000Z',
+            title: null, summary: null,
+            issuesJson: null, learningsJson: null,
+          },
+        ] as any,
+      }) as any
+    );
+
+    const entries = await loadSessionLogsSince('2026-04-09');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].branch).toBe('claude/recent');
+  });
+
+  it('drops rows where both date and startedAt are null', async () => {
+    mockListAgentSessions.mockResolvedValue(
+      apiOk({
+        sessions: [
+          {
+            id: 1, branch: 'claude/broken',
+            date: null, startedAt: null,
+            title: null, summary: null,
+            issuesJson: null, learningsJson: null,
+          },
+        ] as any,
+      }) as any
+    );
+
+    const entries = await loadSessionLogsSince('2026-04-09');
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/crux/lib/maintain/session-logs.ts
+++ b/crux/lib/maintain/session-logs.ts
@@ -73,7 +73,10 @@ export async function loadSessionLogsSince(since: string): Promise<SessionLogEnt
     if (result.ok) {
       const entries: SessionLogEntry[] = [];
       for (const row of result.data.sessions) {
-        const sessionDate = row.date?.slice(0, 10);
+        // Prefer explicit session date, fall back to started_at.
+        // The sweep endpoint and crashed sessions leave `date` null; without this
+        // fallback the retrospective tool reports 0 sessions despite hundreds being present.
+        const sessionDate = row.date?.slice(0, 10) ?? row.startedAt?.slice(0, 10);
         if (!sessionDate || sessionDate < since) continue;
 
         const issues = parseJsonArray(row.issuesJson);


### PR DESCRIPTION
## Summary

Fixes the `Session Logs: 0` gap in `crux sys maintain review-prs` (flagged in the 2026-04-16 retrospective). Root cause: `agent_sessions.date` was NULL for every row — the sweep endpoint was bypassing the PATCH handler's title/summary guard and leaving `date` unset, and `loadSessionLogsSince()` drops any row with a null date.

## What changed

- **A**: `loadSessionLogsSince()` falls back to `row.startedAt?.slice(0, 10)` when `row.date` is null. Un-breaks the retrospective tool immediately.
- **B**: Sweep endpoint (`/api/agent-sessions/sweep`) now sets `date = COALESCE(date, started_at::date)` alongside `status='completed'`. Prevents future rows from having the same gap.
- **C**: Migration 0185 backfills NULL `date` rows from `started_at::date`. Makes historical sessions queryable.

## Why the underlying gap exists (documented in commit message for future archaeology)

`date` is supposed to be populated by `crux sys session-finalize`, called from the `SessionEnd` hook. The hook is `async: true` with a 30s timeout and fails silently on most error paths. When the hook doesn't run, the groundskeeper `sessionSweep` task (4h cadence) marks sessions `completed` via a raw `db.update()` that bypasses the PATCH endpoint's `title`/`summary` guard.

A follow-up worth filing (not done in this PR): make `session-finalize` synchronous or invoke it explicitly from `/agent-ship` and `/agent-end` instead of relying on the async SessionEnd hook.

## Verification

Before:
```
pnpm crux sys maintain review-prs --since=$(date -v-3d +%Y-%m-%d)
Merged PRs: 98
Session Logs: 0
```

After (in this branch, running against prod):
```
Session Logs: 9
```

## Test plan
- [x] Unit tests for `loadSessionLogsSince` fallback (4 cases: null date w/ startedAt, both fields, since-threshold, both null) — `crux/lib/maintain/session-logs.test.ts`
- [x] Existing 51 `agent-sessions.test.ts` tests pass unchanged
- [x] Full `pnpm test` passes (6602 tests)
- [x] Typecheck clean in modified files
- [x] Gate check passes
- [x] Verified end-to-end against prod: retrospective tool now surfaces sessions

## Deploy Checklist
- [ ] Verify migration 0185 applied on server start (post-deploy, automated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured agent session dates are properly populated with fallback to session start times when dates are missing.
  * Corrected historical session records by backfilling missing date information.

* **Tests**
  * Added comprehensive test coverage for session log date handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->