### PR TITLE
fix(entity-matrix): use tinyglobby instead of Node 22-only fs.globSync

### DIFF
--- a/crux/entity-matrix/scanner.ts
+++ b/crux/entity-matrix/scanner.ts
@@ -6,8 +6,17 @@
  * analysis, and (optionally) API queries.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync, globSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join, basename } from "path";
+import { globSync as tinyGlobSync } from "tinyglobby";
+
+// fs.globSync requires Node 22+, but this repo pins Node 20 (.nvmrc, engines).
+// @types/node@22 masks the mismatch at compile time, so the failure was silent
+// until sync:data logged "Entity matrix generation failed" at runtime. Wrap
+// tinyglobby with absolute:true so absolute patterns in → absolute paths out,
+// matching fs.globSync behavior at the original call sites.
+const globSync = (pattern: string | readonly string[]): string[] =>
+  tinyGlobSync(pattern, { absolute: true });
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import { ENTITY_TYPES, DIMENSIONS, DIMENSION_GROUPS, scoreDimension } from "./config.ts";
 import { apiRequest, type ApiResult } from "../lib/wiki-server/client.ts";

--- a/crux/entity-matrix/scanner.ts
+++ b/crux/entity-matrix/scanner.ts
@@ -9,14 +9,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join, basename } from "path";
 import { globSync as tinyGlobSync } from "tinyglobby";
-
-// fs.globSync requires Node 22+, but this repo pins Node 20 (.nvmrc, engines).
-// @types/node@22 masks the mismatch at compile time, so the failure was silent
-// until sync:data logged "Entity matrix generation failed" at runtime. Wrap
-// tinyglobby with absolute:true so absolute patterns in → absolute paths out,
-// matching fs.globSync behavior at the original call sites.
-const globSync = (pattern: string | readonly string[]): string[] =>
-  tinyGlobSync(pattern, { absolute: true });
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import { ENTITY_TYPES, DIMENSIONS, DIMENSION_GROUPS, scoreDimension } from "./config.ts";
 import { apiRequest, type ApiResult } from "../lib/wiki-server/client.ts";
@@ -26,6 +18,12 @@ import type {
   EntityTypeRow,
   MatrixSnapshot,
 } from "./types.ts";
+
+// fs.globSync is Node 22+; this repo pins Node 20. @types/node@22 masks the
+// mismatch at compile time. absolute:true preserves the absolute-path semantics
+// the call sites below rely on for readFileSync.
+const globSync = (pattern: string | readonly string[]): string[] =>
+  tinyGlobSync(pattern, { absolute: true });
 
 // ============================================================================
 // PATH CONSTANTS

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "remark-mdx": "^3.1.0",
     "remark-mdx-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
+    "tinyglobby": "^0.2.16",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "unified": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      tinyglobby:
+        specifier: ^0.2.16
+        version: 0.2.16
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -4674,6 +4677,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -5230,6 +5237,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.0.3:
@@ -9375,6 +9386,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fflate@0.8.2: {}
 
   file-uri-to-path@1.0.0:
@@ -10614,6 +10629,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -11367,6 +11384,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.0.3: {}
 
   tldts-core@7.0.27: {}
@@ -11570,7 +11592,7 @@ snapshots:
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.59.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.10
       fsevents: 2.3.3
@@ -11597,7 +11619,7 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.0.3
       vite: 7.3.1(@types/node@22.19.10)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
## Summary

`crux/entity-matrix/scanner.ts` imports `globSync` from `fs`, which is a Node 22+ API. The repo pins Node 20 (`.nvmrc`, `engines.node`). `@types/node@22` masks the mismatch at compile time, so the failure has been silent at runtime since the scanner landed (commit d0c224079, 2026-03-14): every `sync:data` logs `⚠ Entity matrix generation failed` and skips the matrix output.

Swap to `tinyglobby`'s `globSync` (already a transitive dep; added as a direct devDep for clarity). Wrap with `absolute: true` so the existing absolute-pattern call sites continue to return absolute paths — preserving behavior for downstream `readFileSync`, `basename`, and length-counting consumers.

## Key changes

- `crux/entity-matrix/scanner.ts`: replace `fs.globSync` import with `tinyglobby.globSync`; wrap in a tiny local helper that forces `absolute: true`
- `package.json` / `pnpm-lock.yaml`: add `tinyglobby` as a direct devDependency

## Test plan

- [x] `pnpm sync:data` now emits `entity-matrix: 35 types × 32 dims → entity-matrix.json (50% overall)` and writes a 105 KB snapshot — previously errored and skipped
- [x] `pnpm crux w validate gate` — 50 checks pass, no new advisories
- [x] `pnpm test:crux` — 6598 tests pass, 26 skipped (baseline)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors (25 baseline, none in scanner.ts)
- [x] `/agent-review-pr` — hostile-review subagent: no findings ≥ 60 confidence; one stylistic nit fixed

Fixes QUA-563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the project's file-globbing implementation to improve compatibility and maintain absolute path behavior for file reads.
  * Added a development dependency to enhance file pattern matching during scans and build-time tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->