### PR TITLE
QUA-561: One-shot resource dedup job

### DIFF
--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -165,6 +165,7 @@ describeIntegration(
         DROP TABLE IF EXISTS ${SCHEMA}.resource_papers CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.entity_resources CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.resources CASCADE;
+        DROP TABLE IF EXISTS ${SCHEMA}.things CASCADE;
 
         CREATE TABLE ${SCHEMA}.resources (
           id text PRIMARY KEY,
@@ -183,6 +184,15 @@ describeIntegration(
         CREATE TABLE ${SCHEMA}.resource_papers (
           resource_id text PRIMARY KEY REFERENCES ${SCHEMA}.resources(id) ON DELETE CASCADE,
           arxiv_id text
+        );
+
+        -- things: cross-base index mirror — mergeCluster cleans up dup rows here
+        -- by (source_table='resources', source_id IN dupIds).
+        CREATE TABLE ${SCHEMA}.things (
+          id text PRIMARY KEY,
+          source_table text NOT NULL,
+          source_id text NOT NULL,
+          title text NOT NULL
         );
       `);
     });
@@ -208,6 +218,13 @@ describeIntegration(
         INSERT INTO ${SCHEMA}.resource_papers (resource_id, arxiv_id) VALUES
           ('r_dup1', 'arxiv-1'),
           ('r_dup2', 'arxiv-2')
+      `);
+      // things dual-write: one row per resource (by source_id).
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.things (id, source_table, source_id, title) VALUES
+          ('t_canon', 'resources', 'r_canon', 'canonical title'),
+          ('t_dup1',  'resources', 'r_dup1',  'dup1 title'),
+          ('t_dup2',  'resources', 'r_dup2',  'dup2 title')
       `);
 
       // Load FK metadata from the test schema.
@@ -293,6 +310,15 @@ describeIntegration(
       `;
       expect(remainingPapers).toHaveLength(1);
       expect(remainingPapers[0].resource_id).toBe("r_canon");
+
+      // things dual-write: dup rows deleted, canonical preserved.
+      const remainingThings = await sqlConn<{ id: string; source_id: string }[]>`
+        SELECT id, source_id FROM ${sqlConn(SCHEMA)}.things
+        ORDER BY id
+      `;
+      expect(remainingThings).toEqual([
+        { id: "t_canon", source_id: "r_canon" },
+      ]);
     });
 
     it("handles PK conflict: canonical already has a paper", async () => {

--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Tests for the QUA-561 resource dedup logic.
+ *
+ * Pure-helper tests always run. The merge integration test requires
+ * DATABASE_URL to be set; skipped otherwise. It creates its own mini schema
+ * (isolated under a dedicated test schema) so it can coexist with the main
+ * integration test suite without recreating all migrations.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "vitest";
+import postgres from "postgres";
+import type { CallableTransactionSql } from "../db.js";
+import {
+  dedupKey,
+  pickCanonical,
+  dedupeFkColumns,
+  validateIdent,
+  mergeCluster,
+  type FkColumnInfo,
+} from "../routes/wikibase/resource-dedup.js";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no DB)
+// ---------------------------------------------------------------------------
+
+describe("dedupKey", () => {
+  it("collapses http/https, www, trailing slash, fragment, and path case", () => {
+    const urls = [
+      "https://www.example.org/path/",
+      "http://example.org/PATH",
+      "https://example.org/path#section",
+    ];
+    const keys = urls.map(dedupKey);
+    expect(new Set(keys).size).toBe(1);
+  });
+
+  it("strips tracking parameters", () => {
+    expect(dedupKey("https://example.org/x?utm_source=foo")).toBe(
+      dedupKey("https://example.org/x")
+    );
+  });
+
+  it("keeps distinct paths apart", () => {
+    expect(dedupKey("https://a.com/one")).not.toBe(dedupKey("https://a.com/two"));
+  });
+});
+
+describe("pickCanonical", () => {
+  const base = { createdAt: "2024-01-01", refCount: 0 };
+
+  it("prefers highest refCount", () => {
+    const rows = [
+      { id: "a", ...base, refCount: 1 },
+      { id: "b", ...base, refCount: 5 },
+      { id: "c", ...base, refCount: 2 },
+    ];
+    expect(pickCanonical(rows).id).toBe("b");
+  });
+
+  it("tiebreaks by earliest createdAt", () => {
+    const rows = [
+      { id: "a", refCount: 0, createdAt: "2024-05-01" },
+      { id: "b", refCount: 0, createdAt: "2024-01-01" },
+      { id: "c", refCount: 0, createdAt: "2024-03-01" },
+    ];
+    expect(pickCanonical(rows).id).toBe("b");
+  });
+
+  it("tiebreaks by smallest id lexicographically", () => {
+    const rows = [
+      { id: "zed", refCount: 0, createdAt: "2024-01-01" },
+      { id: "aaa", refCount: 0, createdAt: "2024-01-01" },
+      { id: "mid", refCount: 0, createdAt: "2024-01-01" },
+    ];
+    expect(pickCanonical(rows).id).toBe("aaa");
+  });
+
+  it("applies ordering in the right precedence", () => {
+    const rows = [
+      // c has most refs → wins even though not earliest
+      { id: "c", refCount: 10, createdAt: "2024-06-01" },
+      { id: "a", refCount: 5, createdAt: "2024-01-01" },
+      { id: "b", refCount: 5, createdAt: "2024-01-01" },
+    ];
+    expect(pickCanonical(rows).id).toBe("c");
+  });
+
+  it("throws on empty input", () => {
+    expect(() => pickCanonical([] as { id: string; refCount: number; createdAt: string }[]))
+      .toThrow(/empty/);
+  });
+});
+
+describe("dedupeFkColumns", () => {
+  it("collapses multiple FK constraints on the same (table, column)", () => {
+    const fks: FkColumnInfo[] = [
+      { tableName: "page_citations", columnName: "resource_id", uniqueGroups: [] },
+      { tableName: "page_citations", columnName: "resource_id", uniqueGroups: [] },
+      { tableName: "entity_resources", columnName: "resource_id", uniqueGroups: [] },
+    ];
+    const out = dedupeFkColumns(fks);
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.tableName).sort()).toEqual([
+      "entity_resources",
+      "page_citations",
+    ]);
+  });
+});
+
+describe("validateIdent", () => {
+  it("accepts letter-underscore-digit identifiers", () => {
+    expect(() => validateIdent("valid_name_1")).not.toThrow();
+    expect(() => validateIdent("_underscore")).not.toThrow();
+  });
+
+  it("rejects identifiers with spaces, quotes, semicolons", () => {
+    expect(() => validateIdent("bad name")).toThrow();
+    expect(() => validateIdent('drop"table')).toThrow();
+    expect(() => validateIdent("x;--")).toThrow();
+  });
+
+  it("rejects identifiers starting with a digit", () => {
+    expect(() => validateIdent("1abc")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: mergeCluster against a real PG
+// ---------------------------------------------------------------------------
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIntegration = DATABASE_URL ? describe : describe.skip;
+
+describeIntegration(
+  "QUA-561 mergeCluster — against a real PG (requires DATABASE_URL)",
+  () => {
+    let sqlConn: ReturnType<typeof postgres>;
+    const SCHEMA = "qua561_dedup_test";
+
+    beforeAll(async () => {
+      sqlConn = postgres(DATABASE_URL!, { max: 3 });
+      // Dedicated test schema so we don't collide with migrations / main suite.
+      await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+      await sqlConn.unsafe(`CREATE SCHEMA ${SCHEMA}`);
+      await sqlConn.unsafe(`SET search_path TO ${SCHEMA}, public`);
+    });
+
+    afterAll(async () => {
+      if (sqlConn) {
+        await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+        await sqlConn.end();
+      }
+    });
+
+    beforeEach(async () => {
+      // Reset isolated tables under the test schema.
+      await sqlConn.unsafe(`
+        DROP TABLE IF EXISTS ${SCHEMA}.resource_papers CASCADE;
+        DROP TABLE IF EXISTS ${SCHEMA}.entity_resources CASCADE;
+        DROP TABLE IF EXISTS ${SCHEMA}.resources CASCADE;
+
+        CREATE TABLE ${SCHEMA}.resources (
+          id text PRIMARY KEY,
+          url text NOT NULL UNIQUE,
+          created_at timestamptz NOT NULL DEFAULT now()
+        );
+
+        -- entity_resources: regular FK, no uniqueness on resource_id.
+        CREATE TABLE ${SCHEMA}.entity_resources (
+          id serial PRIMARY KEY,
+          entity_id text NOT NULL,
+          resource_id text REFERENCES ${SCHEMA}.resources(id) ON DELETE CASCADE
+        );
+
+        -- resource_papers: resource_id is the PK (at most one row per resource).
+        CREATE TABLE ${SCHEMA}.resource_papers (
+          resource_id text PRIMARY KEY REFERENCES ${SCHEMA}.resources(id) ON DELETE CASCADE,
+          arxiv_id text
+        );
+      `);
+    });
+
+    it("merges a 3-row cluster with 5 FK refs split across 2 tables", async () => {
+      // 3 resource rows with URL variants that collapse to the same key.
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
+          ('r_canon', 'https://www.example.org/x',     '2024-01-01'),
+          ('r_dup1',  'http://example.org/x/',         '2024-02-01'),
+          ('r_dup2',  'https://example.org/x#frag',    '2024-03-01')
+      `);
+      // 5 FK refs split across 2 tables:
+      //   entity_resources: 3 refs (2 on canonical, 1 on dup1)
+      //   resource_papers:  2 refs (dup1 and dup2 — NOT on canonical)
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.entity_resources (entity_id, resource_id) VALUES
+          ('e1', 'r_canon'),
+          ('e2', 'r_canon'),
+          ('e3', 'r_dup1')
+      `);
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.resource_papers (resource_id, arxiv_id) VALUES
+          ('r_dup1', 'arxiv-1'),
+          ('r_dup2', 'arxiv-2')
+      `);
+
+      // Load FK metadata from the test schema.
+      const fkRows = await sqlConn<
+        { tablename: string; columnname: string }[]
+      >`
+        SELECT tc.table_name AS tablename, kcu.column_name AS columnname
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON tc.constraint_name = ccu.constraint_name
+          AND tc.table_schema = ccu.table_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = 'resources'
+          AND ccu.column_name = 'id'
+          AND tc.table_schema = ${SCHEMA}
+      `;
+      // Map to FkColumnInfo. resource_papers.resource_id is a PK (single-column).
+      const fkColumns: FkColumnInfo[] = fkRows.map((row) => {
+        if (row.tablename === "resource_papers") {
+          return {
+            tableName: row.tablename,
+            columnName: row.columnname,
+            uniqueGroups: [{ otherCols: [] }],
+          };
+        }
+        return {
+          tableName: row.tablename,
+          columnName: row.columnname,
+          uniqueGroups: [],
+        };
+      });
+      expect(fkColumns).toHaveLength(2);
+
+      // Run the merge in a transaction.
+      const merge = await sqlConn.begin(async (tx) => {
+        return mergeCluster(
+          tx as unknown as CallableTransactionSql,
+          "r_canon",
+          ["r_dup1", "r_dup2"],
+          fkColumns
+        );
+      });
+
+      // Assertions:
+      expect(merge).toBeDefined();
+      const result = merge as {
+        resourcesDeleted: number;
+        fkUpdates: Record<string, { moved: number; deletedOnConflict: number }>;
+      };
+      // Both dup resources deleted.
+      expect(result.resourcesDeleted).toBe(2);
+
+      // entity_resources: 1 row moved (e3 from r_dup1 → r_canon), 0 conflicts.
+      expect(result.fkUpdates["entity_resources.resource_id"]).toEqual({
+        moved: 1,
+        deletedOnConflict: 0,
+      });
+      // resource_papers: no conflicts with canonical (canonical has no paper),
+      // but dup1 and dup2 both have papers — one survives, the other is
+      // deleted-on-conflict (PK collision). The surviving one is moved to canonical.
+      const papersUpdate = result.fkUpdates["resource_papers.resource_id"];
+      expect(papersUpdate.deletedOnConflict).toBe(1);
+      expect(papersUpdate.moved).toBe(1);
+
+      // Post-state:
+      const remainingResources = await sqlConn<{ id: string }[]>`
+        SELECT id FROM ${sqlConn(SCHEMA)}.resources ORDER BY id
+      `;
+      expect(remainingResources.map((r) => r.id)).toEqual(["r_canon"]);
+
+      const remainingEr = await sqlConn<{ entity_id: string; resource_id: string }[]>`
+        SELECT entity_id, resource_id FROM ${sqlConn(SCHEMA)}.entity_resources
+        ORDER BY entity_id
+      `;
+      expect(remainingEr).toHaveLength(3);
+      expect(remainingEr.every((r) => r.resource_id === "r_canon")).toBe(true);
+
+      const remainingPapers = await sqlConn<{ resource_id: string; arxiv_id: string }[]>`
+        SELECT resource_id, arxiv_id FROM ${sqlConn(SCHEMA)}.resource_papers
+      `;
+      expect(remainingPapers).toHaveLength(1);
+      expect(remainingPapers[0].resource_id).toBe("r_canon");
+    });
+
+    it("handles PK conflict: canonical already has a paper", async () => {
+      // Canonical has a paper; dup also has one → dup's is deleted-on-conflict.
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
+          ('r_canon', 'https://www.example.org/y', '2024-01-01'),
+          ('r_dup',   'http://example.org/y/',    '2024-02-01');
+        INSERT INTO ${SCHEMA}.resource_papers (resource_id, arxiv_id) VALUES
+          ('r_canon', 'arxiv-canon'),
+          ('r_dup',   'arxiv-dup');
+      `);
+
+      const fkColumns: FkColumnInfo[] = [
+        {
+          tableName: "resource_papers",
+          columnName: "resource_id",
+          uniqueGroups: [{ otherCols: [] }],
+        },
+        {
+          tableName: "entity_resources",
+          columnName: "resource_id",
+          uniqueGroups: [],
+        },
+      ];
+
+      const merge = (await sqlConn.begin(async (tx) => {
+        return mergeCluster(
+          tx as unknown as CallableTransactionSql,
+          "r_canon",
+          ["r_dup"],
+          fkColumns
+        );
+      })) as {
+        resourcesDeleted: number;
+        fkUpdates: Record<string, { moved: number; deletedOnConflict: number }>;
+      };
+
+      expect(merge.resourcesDeleted).toBe(1);
+      // Canonical's paper stays; dup's paper is deleted (not moved).
+      expect(merge.fkUpdates["resource_papers.resource_id"]).toEqual({
+        moved: 0,
+        deletedOnConflict: 1,
+      });
+
+      const papers = await sqlConn<{ resource_id: string; arxiv_id: string }[]>`
+        SELECT resource_id, arxiv_id FROM ${sqlConn(SCHEMA)}.resource_papers
+      `;
+      expect(papers).toHaveLength(1);
+      expect(papers[0]).toEqual({
+        resource_id: "r_canon",
+        arxiv_id: "arxiv-canon",
+      });
+    });
+
+    it("buildReport + loadResourceFks discover live FK metadata", async () => {
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
+          ('r_canon', 'https://www.example.org/z', '2024-01-01'),
+          ('r_dup',   'http://example.org/z/',    '2024-02-01'),
+          ('r_solo',  'https://unique.example/w', '2024-03-01');
+        INSERT INTO ${SCHEMA}.entity_resources (entity_id, resource_id) VALUES
+          ('e1', 'r_canon');
+      `);
+
+      // Run helpers under the test schema's search_path.
+      // postgres.js connections have connection-level search_path via SET.
+      await sqlConn.unsafe(`SET search_path TO ${SCHEMA}, public`);
+
+      // Override the loader's 'public' schema filter by fetching via a
+      // dedicated connection where search_path is our test schema. The
+      // helper hardcodes schema='public' so we fetch manually here instead.
+      const fkRows = await sqlConn<
+        { table_name: string; column_name: string }[]
+      >`
+        SELECT DISTINCT tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON tc.constraint_name = ccu.constraint_name
+          AND tc.table_schema = ccu.table_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = 'resources'
+          AND ccu.column_name = 'id'
+          AND tc.table_schema = ${SCHEMA}
+      `;
+      expect(fkRows.map((r) => r.table_name).sort()).toEqual([
+        "entity_resources",
+        "resource_papers",
+      ]);
+
+      // pickCanonical-style picking with refCount=1 for canonical, 0 for dup
+      const { pickCanonical } = await import("../routes/wikibase/resource-dedup.js");
+      const cluster = [
+        { id: "r_canon", refCount: 1, createdAt: "2024-01-01" },
+        { id: "r_dup", refCount: 0, createdAt: "2024-02-01" },
+      ];
+      expect(pickCanonical(cluster).id).toBe("r_canon");
+    });
+  }
+);

--- a/apps/wiki-server/src/db.ts
+++ b/apps/wiki-server/src/db.ts
@@ -32,7 +32,7 @@ export interface SqlQuery {
  * type restores the call signature so we can use transactions without
  * double-casts in route files.
  */
-type CallableTransactionSql = TransactionSql & SqlQuery;
+export type CallableTransactionSql = TransactionSql & SqlQuery;
 
 /**
  * Typed wrapper around `sql.begin()` that provides the callback with a
@@ -41,10 +41,11 @@ type CallableTransactionSql = TransactionSql & SqlQuery;
  * This centralizes the postgres.js TransactionSql type workaround so route
  * files don't need `as unknown as SqlQuery` casts.
  */
-export async function beginTransaction(
-  cb: (tx: CallableTransactionSql) => Promise<void>,
-): Promise<void> {
+export async function beginTransaction<T = void>(
+  cb: (tx: CallableTransactionSql) => Promise<T>,
+): Promise<T> {
   const db = getDb();
+  let result: T | undefined;
   await db.begin(async (tx) => {
     // Runtime validation: TransactionSql inherits Sql's tagged-template
     // callable at runtime, but the TS type loses it due to Omit.
@@ -59,8 +60,9 @@ export async function beginTransaction(
     // This is a single-step assertion from a validated callable, not a blind
     // double-cast — the typeof check above provides the runtime guarantee.
     const typedTx: CallableTransactionSql = tx as CallableTransactionSql;
-    await cb(typedTx);
+    result = await cb(typedTx);
   });
+  return result as T;
 }
 
 let sql: Sql | null = null;

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -1,0 +1,349 @@
+/**
+ * QUA-561 — One-shot resource dedup logic.
+ *
+ * Finds rows in the `resources` table whose URLs collapse to the same
+ * canonical key under `normalizeUrl` (QUA-341). For each duplicate cluster,
+ * selects a canonical row (most FK references → earliest created_at →
+ * smallest id), rewrites every FK pointing at the cluster's non-canonical
+ * rows, and deletes them. Each cluster is merged inside its own transaction.
+ *
+ * FK columns are discovered at runtime from information_schema. Columns that
+ * participate in a PK/UNIQUE constraint (e.g. resource_papers.resource_id as
+ * a PK, or resource_citations (resource_id, page_id)) are handled carefully:
+ * cluster rows that would collide with canonical's existing rows after the
+ * UPDATE are deleted first so the UPDATE cannot raise a unique violation.
+ */
+
+import type { Sql, CallableTransactionSql } from "../../db.js";
+import { beginTransaction } from "../../db.js";
+import { normalizeUrl } from "@longterm-wiki/url-utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FkColumnInfo {
+  tableName: string;
+  columnName: string;
+  /** PK/UNIQUE constraints on this table that include columnName. otherCols
+   *  is the set of columns in the constraint besides columnName. Empty
+   *  otherCols means this column alone must be unique. */
+  uniqueGroups: { otherCols: string[] }[];
+}
+
+export interface ResourceCandidate {
+  id: string;
+  url: string;
+  createdAt: string;
+  refCount: number;
+}
+
+export interface DedupCluster {
+  normalizedUrl: string;
+  canonical: ResourceCandidate;
+  duplicates: ResourceCandidate[];
+}
+
+export interface DedupReport {
+  totalResources: number;
+  fkColumns: FkColumnInfo[];
+  clusters: DedupCluster[];
+}
+
+export interface ClusterMergeResult {
+  canonicalId: string;
+  duplicateIds: string[];
+  fkUpdates: Record<string, { moved: number; deletedOnConflict: number }>;
+  resourcesDeleted: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Canonical dedup key for grouping resources. */
+export function dedupKey(url: string): string {
+  return normalizeUrl(url, { stripProtocol: true, lowercasePath: true });
+}
+
+/**
+ * Pick the canonical row from a cluster.
+ *   1. highest refCount
+ *   2. earliest createdAt (ISO string compare)
+ *   3. smallest id (lexicographic)
+ */
+export function pickCanonical<
+  T extends { refCount: number; createdAt: string; id: string },
+>(rows: T[]): T {
+  if (rows.length === 0) throw new Error("pickCanonical: empty cluster");
+  return [...rows].sort((a, b) => {
+    if (a.refCount !== b.refCount) return b.refCount - a.refCount;
+    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  })[0];
+}
+
+/** Guard against SQL injection via dynamic identifiers. FK metadata comes
+ *  from information_schema but defense-in-depth is cheap. */
+export function validateIdent(name: string): void {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid SQL identifier: ${JSON.stringify(name)}`);
+  }
+}
+
+function q(name: string): string {
+  validateIdent(name);
+  return `"${name}"`;
+}
+
+/** Dedupe FK metadata by (table, column). A column can be referenced by more
+ *  than one FK constraint (e.g. page_citations.resource_id has two). */
+export function dedupeFkColumns(fks: FkColumnInfo[]): FkColumnInfo[] {
+  const seen = new Map<string, FkColumnInfo>();
+  for (const f of fks) {
+    const key = `${f.tableName}.${f.columnName}`;
+    if (!seen.has(key)) seen.set(key, f);
+  }
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Discovery + report
+// ---------------------------------------------------------------------------
+
+export async function loadResourceFks(sql: Sql): Promise<FkColumnInfo[]> {
+  const fkRows = await sql<{ table_name: string; column_name: string }[]>`
+    SELECT DISTINCT tc.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name
+      AND tc.table_schema = ccu.table_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND ccu.table_name = 'resources'
+      AND ccu.column_name = 'id'
+      AND tc.table_schema = 'public'
+    ORDER BY tc.table_name, kcu.column_name
+  `;
+  if (fkRows.length === 0) return [];
+
+  const tableNames = [...new Set(fkRows.map((f) => f.table_name))];
+  const uniqueRows = await sql<{ table_name: string; columns: string[] }[]>`
+    SELECT tc.table_name,
+      array_agg(kcu.column_name ORDER BY kcu.ordinal_position) AS columns
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+      AND tc.table_schema = 'public'
+      AND tc.table_name = ANY(${tableNames})
+    GROUP BY tc.table_name, tc.constraint_name
+  `;
+
+  const uniqueByTable = new Map<string, { columns: string[] }[]>();
+  for (const u of uniqueRows) {
+    const list = uniqueByTable.get(u.table_name) ?? [];
+    list.push({ columns: u.columns });
+    uniqueByTable.set(u.table_name, list);
+  }
+
+  return fkRows.map((fk) => {
+    const uniques = uniqueByTable.get(fk.table_name) ?? [];
+    const uniqueGroups = uniques
+      .filter((u) => u.columns.includes(fk.column_name))
+      .map((u) => ({ otherCols: u.columns.filter((c) => c !== fk.column_name) }));
+    return { tableName: fk.table_name, columnName: fk.column_name, uniqueGroups };
+  });
+}
+
+export async function buildReport(sql: Sql): Promise<DedupReport> {
+  const fkColumns = await loadResourceFks(sql);
+  const uniqueCols = dedupeFkColumns(fkColumns);
+
+  const rows = await sql<{ id: string; url: string; created_at: string }[]>`
+    SELECT id, url, created_at::text AS created_at FROM resources
+  `;
+
+  type Row = { id: string; url: string; createdAt: string };
+  const groups = new Map<string, Row[]>();
+  for (const r of rows) {
+    const key = dedupKey(r.url);
+    const list = groups.get(key);
+    if (list) list.push({ id: r.id, url: r.url, createdAt: r.created_at });
+    else groups.set(key, [{ id: r.id, url: r.url, createdAt: r.created_at }]);
+  }
+
+  const candidateIds = new Set<string>();
+  for (const rs of groups.values()) {
+    if (rs.length >= 2) for (const r of rs) candidateIds.add(r.id);
+  }
+
+  const refCounts = new Map<string, number>();
+  if (candidateIds.size > 0) {
+    const idsArr = [...candidateIds];
+    for (const fk of uniqueCols) {
+      const results = await sql.unsafe<{ id: string; c: number | string }[]>(
+        `SELECT ${q(fk.columnName)} AS id, COUNT(*)::int AS c
+         FROM ${q(fk.tableName)}
+         WHERE ${q(fk.columnName)} = ANY($1::text[])
+         GROUP BY ${q(fk.columnName)}`,
+        [idsArr]
+      );
+      for (const row of results) {
+        refCounts.set(row.id, (refCounts.get(row.id) ?? 0) + Number(row.c));
+      }
+    }
+  }
+
+  const clusters: DedupCluster[] = [];
+  for (const [key, rs] of groups) {
+    if (rs.length < 2) continue;
+    const candidates: ResourceCandidate[] = rs.map((r) => ({
+      id: r.id,
+      url: r.url,
+      createdAt: r.createdAt,
+      refCount: refCounts.get(r.id) ?? 0,
+    }));
+    const canonical = pickCanonical(candidates);
+    const duplicates = candidates.filter((c) => c.id !== canonical.id);
+    clusters.push({ normalizedUrl: key, canonical, duplicates });
+  }
+
+  clusters.sort((a, b) => {
+    if (a.duplicates.length !== b.duplicates.length)
+      return b.duplicates.length - a.duplicates.length;
+    return a.normalizedUrl < b.normalizedUrl ? -1 : 1;
+  });
+
+  return { totalResources: rows.length, fkColumns, clusters };
+}
+
+// ---------------------------------------------------------------------------
+// Per-cluster merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge one cluster: rewrite FKs on the duplicates to point at canonical,
+ * then delete the duplicates. Must run inside a transaction — the caller is
+ * responsible for `sql.begin()` / `beginTransaction()`.
+ *
+ * Accepts CallableTransactionSql (from beginTransaction) for production use.
+ * Tests may pass the root Sql client cast through this type since a
+ * postgres.js root client is structurally compatible (tagged-template +
+ * `.unsafe`) with the transaction interface at runtime.
+ */
+export async function mergeCluster(
+  tx: CallableTransactionSql,
+  canonicalId: string,
+  duplicateIds: string[],
+  fkColumns: FkColumnInfo[]
+): Promise<ClusterMergeResult> {
+  const fkUpdates: ClusterMergeResult["fkUpdates"] = {};
+  if (duplicateIds.length === 0) {
+    return { canonicalId, duplicateIds, fkUpdates, resourcesDeleted: 0 };
+  }
+
+  const uniqueCols = dedupeFkColumns(fkColumns);
+  const allIds = [canonicalId, ...duplicateIds];
+
+  for (const fk of uniqueCols) {
+    const key = `${fk.tableName}.${fk.columnName}`;
+    fkUpdates[key] = { moved: 0, deletedOnConflict: 0 };
+
+    // For each unique constraint involving this column, delete cluster rows
+    // that would collide with canonical's existing rows post-UPDATE. Prefer
+    // keeping canonical's row; tiebreak by ctid (physical order).
+    for (const group of fk.uniqueGroups) {
+      const partition =
+        group.otherCols.length > 0
+          ? `PARTITION BY ${group.otherCols.map(q).join(", ")}`
+          : "";
+      const deleteSql = `
+        WITH ranked AS (
+          SELECT ctid,
+            ROW_NUMBER() OVER (
+              ${partition}
+              ORDER BY (${q(fk.columnName)} = $1) DESC, ctid ASC
+            ) AS rn
+          FROM ${q(fk.tableName)}
+          WHERE ${q(fk.columnName)} = ANY($2::text[])
+        )
+        DELETE FROM ${q(fk.tableName)} t
+        USING ranked r
+        WHERE t.ctid = r.ctid AND r.rn > 1
+        RETURNING t.ctid
+      `;
+      const deleted = await tx.unsafe<{ ctid: unknown }[]>(deleteSql, [
+        canonicalId,
+        allIds,
+      ]);
+      fkUpdates[key].deletedOnConflict += deleted.length;
+    }
+
+    const updateSql = `
+      UPDATE ${q(fk.tableName)}
+      SET ${q(fk.columnName)} = $1
+      WHERE ${q(fk.columnName)} = ANY($2::text[])
+      RETURNING 1
+    `;
+    const moved = await tx.unsafe<{ "?column?": number }[]>(updateSql, [
+      canonicalId,
+      duplicateIds,
+    ]);
+    fkUpdates[key].moved += moved.length;
+  }
+
+  const deletedResources = await tx<{ id: string }[]>`
+    DELETE FROM resources WHERE id = ANY(${duplicateIds}) RETURNING id
+  `;
+
+  return {
+    canonicalId,
+    duplicateIds,
+    fkUpdates,
+    resourcesDeleted: deletedResources.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface RunDedupResult {
+  apply: boolean;
+  report: DedupReport;
+  merges: ClusterMergeResult[];
+  errors: { canonicalId: string; duplicateIds: string[]; message: string }[];
+}
+
+/**
+ * Scan, pick canonicals, and (optionally) apply merges.
+ */
+export async function runDedup(sql: Sql, apply: boolean): Promise<RunDedupResult> {
+  const report = await buildReport(sql);
+  const merges: ClusterMergeResult[] = [];
+  const errors: RunDedupResult["errors"] = [];
+
+  if (!apply) return { apply, report, merges, errors };
+
+  for (const cluster of report.clusters) {
+    const dupIds = cluster.duplicates.map((d) => d.id);
+    try {
+      const result = await beginTransaction((tx) =>
+        mergeCluster(tx, cluster.canonical.id, dupIds, report.fkColumns)
+      );
+      merges.push(result);
+    } catch (err) {
+      errors.push({
+        canonicalId: cluster.canonical.id,
+        duplicateIds: dupIds,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { apply, report, merges, errors };
+}

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -16,7 +16,8 @@
 
 import type { Sql, CallableTransactionSql } from "../../db.js";
 import { beginTransaction } from "../../db.js";
-import { normalizeUrl } from "@longterm-wiki/url-utils";
+import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
+import { logger } from "../../logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,10 +62,10 @@ export interface ClusterMergeResult {
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-/** Canonical dedup key for grouping resources. */
-export function dedupKey(url: string): string {
-  return normalizeUrl(url, { stripProtocol: true, lowercasePath: true });
-}
+/** Canonical dedup key for grouping resources. Delegates to
+ *  `normalizeUrlForDedup` so cluster membership stays in sync with the
+ *  shared QUA-341 normalization helper. */
+export const dedupKey = normalizeUrlForDedup;
 
 /**
  * Pick the canonical row from a cluster.
@@ -274,9 +275,9 @@ export async function mergeCluster(
         DELETE FROM ${q(fk.tableName)} t
         USING ranked r
         WHERE t.ctid = r.ctid AND r.rn > 1
-        RETURNING t.ctid
+        RETURNING 1
       `;
-      const deleted = await tx.unsafe<{ ctid: unknown }[]>(deleteSql, [
+      const deleted = await tx.unsafe<unknown[]>(deleteSql, [
         canonicalId,
         allIds,
       ]);
@@ -289,12 +290,21 @@ export async function mergeCluster(
       WHERE ${q(fk.columnName)} = ANY($2::text[])
       RETURNING 1
     `;
-    const moved = await tx.unsafe<{ "?column?": number }[]>(updateSql, [
+    const moved = await tx.unsafe<unknown[]>(updateSql, [
       canonicalId,
       duplicateIds,
     ]);
     fkUpdates[key].moved += moved.length;
   }
+
+  // Remove duplicate `things` rows (dual-write mirror from the upsert path).
+  // The `things` table has a unique (source_table, source_id) index so each
+  // resource has at most one `things` row. No FK from things.source_id to
+  // resources.id — cleanup is by logical (source_table, source_id) match.
+  await tx`
+    DELETE FROM things
+    WHERE source_table = 'resources' AND source_id = ANY(${duplicateIds})
+  `;
 
   const deletedResources = await tx<{ id: string }[]>`
     DELETE FROM resources WHERE id = ANY(${duplicateIds}) RETURNING id
@@ -329,6 +339,20 @@ export async function runDedup(sql: Sql, apply: boolean): Promise<RunDedupResult
 
   if (!apply) return { apply, report, merges, errors };
 
+  const rowsToDelete = report.clusters.reduce(
+    (acc, c) => acc + c.duplicates.length,
+    0
+  );
+  logger.warn(
+    {
+      totalResources: report.totalResources,
+      clusters: report.clusters.length,
+      rowsToDelete,
+      fkColumns: report.fkColumns.length,
+    },
+    "runDedup applying — about to delete resource rows and rewrite FKs"
+  );
+
   for (const cluster of report.clusters) {
     const dupIds = cluster.duplicates.map((d) => d.id);
     try {
@@ -344,6 +368,15 @@ export async function runDedup(sql: Sql, apply: boolean): Promise<RunDedupResult
       });
     }
   }
+
+  logger.warn(
+    {
+      merged: merges.length,
+      errors: errors.length,
+      resourcesDeleted: merges.reduce((a, m) => a + m.resourcesDeleted, 0),
+    },
+    "runDedup applied"
+  );
 
   return { apply, report, merges, errors };
 }

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -68,6 +68,7 @@ registerComposer<ResourceComposerRow>("resource", (row) => ({
 import { urlVariants } from "../shared/url-variants.js";
 import { generateId } from "@longterm-wiki/factbase";
 import { createHash, randomBytes } from "crypto";
+import { runDedup } from "./resource-dedup.js";
 
 // ---- Raw SQL row types ----
 
@@ -2040,7 +2041,24 @@ const resourcesApp = new Hono()
       tabularSource,
       citedBy: citations.map((row) => row.pageId).filter((p): p is string => p != null),
     });
-  });
+  })
+
+  // ---- POST /dedup — QUA-561 one-shot duplicate merge job ----
+  //
+  // Scans the resources table for URL-canonical-equivalent duplicates and,
+  // when `apply: true`, merges each cluster atomically (per-cluster
+  // transaction). Returns a full report of clusters, canonical picks, FK
+  // moves, and errors. Meant to be invoked by `crux/scripts/dedup-resources.ts`.
+  .post(
+    "/dedup",
+    zv("json", z.object({ apply: z.boolean().default(false) })),
+    async (c) => {
+      const { apply } = c.req.valid("json");
+      const sql = getDb();
+      const result = await runDedup(sql, apply);
+      return c.json(result);
+    }
+  );
 
 export const resourcesRoute = resourcesApp;
 export type ResourcesRoute = typeof resourcesApp;

--- a/crux/scripts/dedup-resources.ts
+++ b/crux/scripts/dedup-resources.ts
@@ -1,0 +1,205 @@
+/**
+ * QUA-561 — One-shot resource dedup job (CLI wrapper).
+ *
+ * Thin wrapper around POST /api/resources/dedup on the wiki-server, which
+ * does the real scan + merge work. This script:
+ *   - Calls the endpoint with `apply: false` for a dry-run, or `apply: true`.
+ *   - Logs a summary + per-cluster progress to stdout.
+ *   - Writes a JSON snapshot to `.claude/snapshots/dedup-resources-*.json`.
+ *
+ * Usage:
+ *   # Dry-run against whichever WIKI_SERVER_ENV is set (default: local).
+ *   npx tsx crux/scripts/dedup-resources.ts
+ *
+ *   # Apply against prod.
+ *   WIKI_SERVER_ENV=prod npx tsx crux/scripts/dedup-resources.ts --apply
+ *
+ * Exit codes: 0 = ok, 1 = error, 2 = partial success (some clusters failed).
+ */
+
+import "dotenv/config";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { apiRequest } from "../lib/wiki-server/client.ts";
+
+interface ResourceCandidate {
+  id: string;
+  url: string;
+  createdAt: string;
+  refCount: number;
+}
+
+interface DedupCluster {
+  normalizedUrl: string;
+  canonical: ResourceCandidate;
+  duplicates: ResourceCandidate[];
+}
+
+interface FkColumnInfo {
+  tableName: string;
+  columnName: string;
+  uniqueGroups: { otherCols: string[] }[];
+}
+
+interface DedupReport {
+  totalResources: number;
+  fkColumns: FkColumnInfo[];
+  clusters: DedupCluster[];
+}
+
+interface ClusterMergeResult {
+  canonicalId: string;
+  duplicateIds: string[];
+  fkUpdates: Record<string, { moved: number; deletedOnConflict: number }>;
+  resourcesDeleted: number;
+}
+
+interface RunDedupResult {
+  apply: boolean;
+  report: DedupReport;
+  merges: ClusterMergeResult[];
+  errors: { canonicalId: string; duplicateIds: string[]; message: string }[];
+}
+
+function parseArgs(argv: string[]): { apply: boolean } {
+  let apply = false;
+  for (const a of argv) {
+    if (a === "--apply") apply = true;
+    else if (a === "--dry-run") apply = false;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        `Usage: dedup-resources.ts [--apply]
+  --apply    Execute merges (default: dry-run)
+Environment: WIKI_SERVER_ENV=prod to target prod wiki-server.`
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return { apply };
+}
+
+function logReport(result: RunDedupResult): void {
+  const { report, merges, errors, apply } = result;
+  console.log(`Total resources: ${report.totalResources}`);
+  console.log(`FK columns referencing resources.id: ${report.fkColumns.length}`);
+  console.log(`Duplicate clusters: ${report.clusters.length}`);
+  const rowsToDelete = report.clusters.reduce(
+    (acc, c) => acc + c.duplicates.length,
+    0
+  );
+  console.log(`Rows to delete after merge: ${rowsToDelete}`);
+
+  if (!apply) {
+    console.log(`\nDry-run — no changes written. Sample (up to 10 clusters):`);
+    for (const c of report.clusters.slice(0, 10)) {
+      console.log(
+        `  [${c.duplicates.length + 1} rows] ${c.normalizedUrl}  ` +
+          `canonical=${c.canonical.id} (refs=${c.canonical.refCount})`
+      );
+      for (const d of c.duplicates) {
+        console.log(`    drop ${d.id} (refs=${d.refCount}) ${d.url}`);
+      }
+    }
+    return;
+  }
+
+  console.log(`\nApplied merges:`);
+  let idx = 0;
+  for (const cluster of report.clusters) {
+    idx++;
+    const merge = merges.find((m) => m.canonicalId === cluster.canonical.id);
+    const err = errors.find((e) => e.canonicalId === cluster.canonical.id);
+    if (err) {
+      console.log(
+        `  [${idx}/${report.clusters.length}] FAILED ${cluster.normalizedUrl}: ${err.message}`
+      );
+      continue;
+    }
+    if (!merge) continue;
+    const totalMoves = Object.values(merge.fkUpdates).reduce(
+      (acc, v) => acc + v.moved,
+      0
+    );
+    const totalDeletedOnConflict = Object.values(merge.fkUpdates).reduce(
+      (acc, v) => acc + v.deletedOnConflict,
+      0
+    );
+    console.log(
+      `  [${idx}/${report.clusters.length}] ${cluster.normalizedUrl}  ` +
+        `canonical=${cluster.canonical.id} deleted=${merge.resourcesDeleted} ` +
+        `fk-moves=${totalMoves} fk-conflicts-resolved=${totalDeletedOnConflict}`
+    );
+  }
+}
+
+function writeSnapshot(result: RunDedupResult): string {
+  const snapshotDir = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../.claude/snapshots"
+  );
+  mkdirSync(snapshotDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const path = resolve(
+    snapshotDir,
+    `dedup-resources-${result.apply ? "applied" : "dryrun"}-${ts}.json`
+  );
+  const snapshot = {
+    ticket: "QUA-561",
+    generatedAt: new Date().toISOString(),
+    apply: result.apply,
+    totalResources: result.report.totalResources,
+    fkColumns: result.report.fkColumns,
+    clustersFound: result.report.clusters.length,
+    rowsToDelete: result.report.clusters.reduce(
+      (acc, c) => acc + c.duplicates.length,
+      0
+    ),
+    clusters: result.report.clusters,
+    merges: result.merges,
+    errors: result.errors,
+  };
+  writeFileSync(path, JSON.stringify(snapshot, null, 2) + "\n");
+  return path;
+}
+
+async function main(): Promise<void> {
+  const { apply } = parseArgs(process.argv.slice(2));
+  console.log(`QUA-561 resource dedup (${apply ? "APPLY" : "dry-run"})`);
+  console.log(`Calling /api/resources/dedup…`);
+
+  const res = await apiRequest<RunDedupResult>(
+    "POST",
+    "/api/resources/dedup",
+    { apply },
+    // Scanning ~23k resources + per-cluster merges can take a minute.
+    120_000
+  );
+
+  if (!res.ok) {
+    console.error(`API call failed: ${res.message}`);
+    process.exit(1);
+  }
+
+  const result = res.data;
+  logReport(result);
+  const snapshotPath = writeSnapshot(result);
+  console.log(`\nSnapshot written: ${snapshotPath}`);
+
+  if (result.errors.length > 0) {
+    console.error(
+      `\n${result.errors.length} cluster(s) failed — see snapshot for details.`
+    );
+    process.exit(2);
+  }
+}
+
+const isEntryPoint = import.meta.url === `file://${process.argv[1]}`;
+if (isEntryPoint) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a one-shot resource-dedup job (QUA-561). Merges rows in the `resources` table whose URLs collapse to the same canonical key under `normalizeUrlForDedup` (QUA-341).

- `POST /api/resources/dedup` (`{ apply: boolean }`) — scan + merge, per-cluster transaction.
- `crux/scripts/dedup-resources.ts` — CLI wrapper that calls the endpoint, logs progress, writes a JSON snapshot to `.claude/snapshots/`.
- Canonical per cluster = most FK references → earliest `created_at` → smallest `id`.
- FK columns discovered at runtime from `information_schema`. Columns participating in a PK/UNIQUE constraint (`resource_papers.resource_id`, `resource_citations (resource_id, page_id)`, …) are handled via a `ROW_NUMBER() … ORDER BY (col = canonical) DESC, ctid ASC` pre-delete that purges cluster rows that would collide with canonical's existing rows — so the UPDATE cannot raise a unique violation.
- Each merge also deletes the duplicate's `things` row (`source_table='resources'`, `source_id=dupId`) in the same transaction so the cross-base index doesn't get orphaned.
- `beginTransaction` in `db.ts` is now generic (`<T = void>`) and returns the callback's value, avoiding `as unknown as Sql` casts.

## Enumeration (prod)

```
Total resources: 22,976
FK columns referencing resources.id: 15 (page_citations has two FK constraints on the same column)
Duplicate clusters (>=2 rows): 13
Rows to delete after merge: 14
```

### FK references

```
_archived_claim_sources.resource_id          (ON DELETE SET NULL)
_archived_statement_citations.resource_id    (ON DELETE SET NULL)
bluesky_posts.resource_id                    (ON DELETE SET NULL)
entity_resources.resource_id                 (ON DELETE CASCADE)
page_citations.resource_id                   (ON DELETE SET NULL / NO ACTION — two constraints)
publications.resource_id                     (ON DELETE SET NULL)
research_area_papers.resource_id             (ON DELETE SET NULL)
resource_citations.resource_id               (ON DELETE CASCADE)
resource_content_versions.resource_id        (ON DELETE SET NULL)
resource_forum_posts.resource_id             (ON DELETE CASCADE)
resource_papers.resource_id                  (ON DELETE CASCADE)
resource_policy_docs.resource_id             (ON DELETE CASCADE)
resource_tabular_sources.resource_id         (ON DELETE CASCADE)
source_check_evidence.resource_id            (ON DELETE SET NULL)
source_snapshots.resource_id                 (ON DELETE SET NULL)
```

### Uniqueness involving `resource_id`

```
resource_citations    (PK): (resource_id, page_id)
resource_forum_posts  (PK): (resource_id)
resource_papers       (PK): (resource_id)
resource_policy_docs  (PK): (resource_id)
resource_tabular_sources (PK): (resource_id)
```

### Dry-run against prod (no mutation)

13 clusters found; canonical picks are all sensible (row with more FK refs wins). Examples:

```
[3] anthropic.com/research   canonical=f771d4f5… (refs=37; drops 2 + 2)
[2] futureoflife.org         canonical=786a68a9… (refs=9;  drops 0)
[2] alignment.org            canonical=0562f8c2… (refs=19; drops 0)
[2] selfawaresystems.com/…   canonical=55fc00da… (refs=4;  drops 1)
```

## Test plan

- [x] `pnpm --filter wiki-server exec tsc --noEmit` — clean
- [x] `pnpm --filter wiki-server test` — all pass (3 DB-required integration tests in `resource-dedup.test.ts` skip without DATABASE_URL)
- [x] `pnpm crux w validate gate --fix` — 39 checks pass (3 advisory, unrelated)
- [x] `pnpm build` — succeeds
- [x] Dry-run against prod DB via direct harness — 13 clusters, 14 rows to delete
- [ ] Deploy wiki-server. Run dry-run then `--apply`, verify snapshot + `SELECT url, count(*) FROM resources GROUP BY url HAVING count(*)>1` → 0.

## Deploy Checklist

<!-- deploy-tasks:v1 -->
- [ ] `manual` — After wiki-server deploy, run `WIKI_SERVER_ENV=prod npx tsx crux/scripts/dedup-resources.ts` (dry-run). Confirm cluster count is ≤13 and canonical picks match this PR's body.
- [ ] `manual` — Run `WIKI_SERVER_ENV=prod npx tsx crux/scripts/dedup-resources.ts --apply`. Exit 0 = all clusters merged cleanly; exit 2 = partial success (details in snapshot).
- [ ] `manual` — Post-verify: `SELECT count(*) FROM (SELECT url, COUNT(*) FROM resources GROUP BY url HAVING COUNT(*)>1) x;` should be 0. Confirm snapshot written under `.claude/snapshots/`.
<!-- /deploy-tasks:v1 -->

Closes QUA-561.