### PR TITLE
feat(dispatch): crux sys dispatch wrapper (QUA-437)

### DIFF
--- a/.claude/rules/dispatched-agent-review.md
+++ b/.claude/rules/dispatched-agent-review.md
@@ -22,7 +22,22 @@ This wasn't a tooling gap — the tooling fixes in QUA-406 (PR #4300) and QUA-44
 
 ### Preferred enforcement — `crux sys dispatch`
 
-Once QUA-437 ships, `pnpm crux sys dispatch --linear=QUA-NNN --slot=N` will enforce all three pre-flight checks structurally and refuse on collision. **That wrapper is the preferred way to dispatch going forward** — it makes the rule unskippable under context pressure.
+`pnpm crux sys dispatch --linear=QUA-NNN --slot=N` (QUA-437) enforces all three pre-flight checks structurally and refuses on collision with exit code 2. **This wrapper is the preferred way to dispatch** — it makes the rule unskippable under context pressure.
+
+```bash
+# Normal dispatch — refuses on any pre-flight blocker:
+pnpm crux sys dispatch --linear=QUA-NNN --slot=7
+pnpm crux sys dispatch --linear=QUA-NNN --slot=7 --brief=../dispatch/qua-NNN.md
+
+# Dry-run (no ./ws open) to validate pre-flight before committing:
+pnpm crux sys dispatch --linear=QUA-NNN --slot=7 --dry-run
+
+# Emergency override (prior claim abandoned, prod-down, etc.):
+pnpm crux sys dispatch --linear=QUA-NNN --slot=7 \
+    --force --reason="slot a9 abandoned, PR #4296 closed, user-authorized"
+```
+
+`--force` is the only way to bypass the check. It requires `--reason="<why>"` and posts a visible `⚠ Claim forced via crux sys dispatch --force` comment on the Linear issue so forced claims stay traceable in ticket history. Every dispatch (forced or not) is audit-logged to `~/.cache/crux-dispatch/log.jsonl`.
 
 Hand-dispatch via `./ws open <N> --claude` + a hand-written brief is permitted only when the wrapper is unavailable, and in that case the coordinator is **personally** responsible for running all three checks before writing the brief.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ pnpm crux sys agent-checklist init --linear=QUA-NNN  # Init session checklist (L
 pnpm crux sys agent-checklist init --issue=N # Init session checklist (legacy GitHub)
 pnpm crux sys agent-reset                   # Show stale processes (MCP, dev servers)
 pnpm crux sys agent-reset --kill             # Kill stale processes
+pnpm crux sys dispatch --linear=QUA-NNN --slot=N  # Open a slot after pre-flight dedup checks
 
 # Cross-cutting (top-level)
 pnpm crux query search "topic"               # Full-text search

--- a/crux/commands/__tests__/dispatch.test.ts
+++ b/crux/commands/__tests__/dispatch.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Tests for `crux sys dispatch` — QUA-437.
+ *
+ * Covers the three pre-flight signals (Linear claim, open PR, target
+ * slot) and the --force / --dry-run / --reason combinations. All
+ * external surfaces (Linear, GitHub, tmux, git) are mocked via
+ * dependency injection rather than vi.mock so the tests stay close to
+ * the handler's real code paths.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dispatchDefault, buildForceClaimComment } from '../dispatch.ts';
+import type { DispatchDeps } from '../dispatch.ts';
+import type { PreflightResult, SlotStateCheck } from '../../lib/dispatch/preflight.ts';
+import type { DispatchLogEntry } from '../../lib/dispatch/audit-log.ts';
+
+/**
+ * vi.fn() infers tighter signatures from 2-arg lambdas than DispatchDeps
+ * wants (4 params for runPreflight, 1 param for getIssue). Typing the
+ * override bag as Record<string, unknown> and casting at the spread site
+ * keeps tests terse without weakening the production type.
+ */
+type TestDispatchOverrides = Record<string, unknown>;
+
+function cleanSlot(slotDir = '/lw/a7'): SlotStateCheck {
+  return { slotDir, exists: true, branch: 'main', clean: true, detail: '' };
+}
+
+function makeDeps(overrides: TestDispatchOverrides = {}): {
+  deps: DispatchDeps;
+  spies: {
+    openSlot: ReturnType<typeof vi.fn>;
+    appendDispatchLog: ReturnType<typeof vi.fn>;
+    commentOnIssue: ReturnType<typeof vi.fn>;
+    getIssue: ReturnType<typeof vi.fn>;
+    runPreflight: ReturnType<typeof vi.fn>;
+  };
+} {
+  const openSlot = vi.fn(() => ({ ok: true }));
+  const appendDispatchLog = vi.fn();
+  const commentOnIssue = vi.fn(async () => {});
+  const getIssue = vi.fn(async () => ({
+    id: 'uuid-437',
+    identifier: 'QUA-437',
+    title: 'Test',
+    description: null,
+    priority: 2,
+    url: 'https://linear.app/quantifieduncertainty/issue/QUA-437',
+    state: { id: 's', name: 'In Progress', type: 'started' },
+    team: { id: 't', key: 'QUA' },
+    parent: null,
+    project: null,
+    labels: { nodes: [] },
+    children: { nodes: [] },
+  }));
+  const runPreflight = vi.fn(
+    async (_id: string, slotDir: string): Promise<PreflightResult> => ({
+      linearClaims: [],
+      openPrs: [],
+      slot: cleanSlot(slotDir),
+      ok: true,
+      blockers: [],
+    }),
+  );
+
+  const deps = {
+    getIssue,
+    commentOnIssue,
+    getSessionContext: () => ({
+      slot: 10,
+      branch: 'claude/qua-437-sys-dispatch-wrapper',
+      host: 'test-host',
+      agentId: null,
+    }),
+    runPreflight,
+    appendDispatchLog,
+    openSlot,
+    resolveLwDir: () => '/lw',
+    ...overrides,
+  } as unknown as DispatchDeps;
+  return {
+    deps,
+    spies: { openSlot, appendDispatchLog, commentOnIssue, getIssue, runPreflight },
+  };
+}
+
+beforeEach(() => {
+  // Ensure TMUX check in the open branch doesn't flake between tests.
+  process.env.TMUX = 'test-tmux';
+});
+
+describe('crux sys dispatch — argument validation', () => {
+  it('errors when --linear is missing', async () => {
+    const { deps } = makeDeps();
+    const r = await dispatchDefault([], { slot: '7', ci: true }, deps);
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage: crux sys dispatch');
+  });
+
+  it('errors when --slot is missing', async () => {
+    const { deps } = makeDeps();
+    const r = await dispatchDefault([], { linear: 'QUA-437', ci: true }, deps);
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('--slot=<N> is required');
+  });
+
+  it('errors when --slot is not a positive integer', async () => {
+    const { deps } = makeDeps();
+    const r = await dispatchDefault([], { linear: 'QUA-437', slot: 'abc', ci: true }, deps);
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('positive integer');
+  });
+
+  it('errors when --force is set without --reason', async () => {
+    const { deps } = makeDeps();
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', force: true, ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('requires --reason');
+  });
+
+  it('errors when the Linear issue is not found', async () => {
+    const { deps } = makeDeps({ getIssue: vi.fn(async () => null) });
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-99999', slot: '7', dryRun: true, ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not found');
+  });
+});
+
+describe('crux sys dispatch — pre-flight blocking', () => {
+  it('refuses with exit 2 when a Linear claim exists', async () => {
+    const { deps, spies } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [
+          {
+            body: '🤖 Claude Code starting work\n**Slot:** a9\n**Branch:** `claude/qua-437-other`',
+            createdAt: '2026-04-17T10:00:00Z',
+            branch: 'claude/qua-437-other',
+            slot: 'a9',
+          },
+        ],
+        openPrs: [],
+        slot: cleanSlot(),
+        ok: false,
+        blockers: ['linear-claim'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', dryRun: true, ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('Pre-flight blocked');
+    expect(r.output).toContain('Active Linear claim');
+    expect(r.output).toContain('a9');
+    expect(spies.openSlot).not.toHaveBeenCalled();
+    expect(spies.appendDispatchLog).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'refused', blockers: ['linear-claim'] }),
+    );
+  });
+
+  it('refuses when an open PR references the ticket', async () => {
+    const { deps, spies } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [],
+        openPrs: [
+          {
+            number: 4297,
+            title: 'QUA-397: fix things',
+            url: 'https://github.com/quantified-uncertainty/longterm-wiki/pull/4297',
+          },
+        ],
+        slot: cleanSlot(),
+        ok: false,
+        blockers: ['open-pr'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-397', slot: '7', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('Open PR');
+    expect(r.output).toContain('#4297');
+    expect(spies.openSlot).not.toHaveBeenCalled();
+  });
+
+  it('refuses when target slot is on a feature branch', async () => {
+    const { deps } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [],
+        openPrs: [],
+        slot: {
+          slotDir: '/lw/a7',
+          exists: true,
+          branch: 'claude/qua-111-foo',
+          clean: false,
+          detail: "on branch 'claude/qua-111-foo' (expected 'main')",
+        },
+        ok: false,
+        blockers: ['slot-off-main'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('Target slot');
+    expect(r.output).toContain("'claude/qua-111-foo'");
+  });
+
+  it('refuses when target slot does not exist', async () => {
+    const { deps } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [],
+        openPrs: [],
+        slot: {
+          slotDir: '/lw/a99',
+          exists: false,
+          branch: '',
+          clean: false,
+          detail: 'slot directory does not exist',
+        },
+        ok: false,
+        blockers: ['slot-missing'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '99', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('does not exist');
+  });
+});
+
+describe('crux sys dispatch — --force override', () => {
+  it('dispatches past a Linear claim with --force + --reason', async () => {
+    const { deps, spies } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [
+          {
+            body: '🤖 Claude Code starting work\n**Slot:** a9',
+            createdAt: '2026-04-17T10:00:00Z',
+            branch: null,
+            slot: 'a9',
+          },
+        ],
+        openPrs: [],
+        slot: cleanSlot(),
+        ok: false,
+        blockers: ['linear-claim'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      {
+        linear: 'QUA-437',
+        slot: '7',
+        force: true,
+        reason: 'slot a9 abandoned, confirmed with user',
+        ci: true,
+      },
+      deps,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('Forced past pre-flight');
+    expect(spies.openSlot).toHaveBeenCalledWith(7, '/lw');
+    expect(spies.commentOnIssue).toHaveBeenCalledTimes(1);
+    const commentBody = spies.commentOnIssue.mock.calls[0][1];
+    expect(commentBody).toContain('⚠ Claim forced via');
+    expect(commentBody).toContain('slot a9 abandoned, confirmed with user');
+    expect(spies.appendDispatchLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'forced',
+        force: true,
+        forceReason: 'slot a9 abandoned, confirmed with user',
+      }),
+    );
+  });
+
+  it('does not post a Linear comment in dry-run even when --force is set', async () => {
+    const { deps, spies } = makeDeps({
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [
+          { body: 'x', createdAt: '2026-04-17T10:00:00Z', branch: null, slot: 'a9' },
+        ],
+        openPrs: [],
+        slot: cleanSlot(),
+        ok: false,
+        blockers: ['linear-claim'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      {
+        linear: 'QUA-437',
+        slot: '7',
+        force: true,
+        reason: 'checking',
+        dryRun: true,
+        ci: true,
+      },
+      deps,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(spies.commentOnIssue).not.toHaveBeenCalled();
+    expect(spies.openSlot).not.toHaveBeenCalled();
+    expect(spies.appendDispatchLog).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'dry-run', force: true }),
+    );
+  });
+
+  it('proceeds when Linear comment posting fails (best-effort)', async () => {
+    const { deps, spies } = makeDeps({
+      commentOnIssue: vi.fn(async () => {
+        throw new Error('Linear down');
+      }),
+      runPreflight: vi.fn(async (_id: string, _dir: string) => ({
+        linearClaims: [
+          { body: 'x', createdAt: '2026-04-17T10:00:00Z', branch: null, slot: 'a9' },
+        ],
+        openPrs: [],
+        slot: cleanSlot(),
+        ok: false,
+        blockers: ['linear-claim'],
+      })),
+    });
+
+    const r = await dispatchDefault(
+      [],
+      {
+        linear: 'QUA-437',
+        slot: '7',
+        force: true,
+        reason: 'API is down, prod hotfix',
+        ci: true,
+      },
+      deps,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(spies.openSlot).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('crux sys dispatch — happy path', () => {
+  it('dispatches when pre-flight passes', async () => {
+    const { deps, spies } = makeDeps();
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('Dispatched QUA-437');
+    expect(spies.openSlot).toHaveBeenCalledWith(7, '/lw');
+    expect(spies.commentOnIssue).not.toHaveBeenCalled();
+    expect(spies.appendDispatchLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'dispatched',
+        force: false,
+        blockers: [],
+      }),
+    );
+  });
+
+  it('dry-run succeeds without opening the slot', async () => {
+    const { deps, spies } = makeDeps();
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', dryRun: true, ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('Pre-flight passed');
+    expect(r.output).toContain('dry-run');
+    expect(spies.openSlot).not.toHaveBeenCalled();
+    expect(spies.appendDispatchLog).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'dry-run' }),
+    );
+  });
+
+  it('errors when not in a tmux session (not a dry-run)', async () => {
+    const { deps, spies } = makeDeps();
+    delete process.env.TMUX;
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not inside a tmux session');
+    expect(spies.openSlot).not.toHaveBeenCalled();
+  });
+
+  it('propagates ./ws open failures as exit 1', async () => {
+    const { deps, spies } = makeDeps({
+      openSlot: vi.fn(() => ({ ok: false, error: 'tmux refused' })),
+    });
+    const r = await dispatchDefault(
+      [],
+      { linear: 'QUA-437', slot: '7', ci: true },
+      deps,
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('tmux refused');
+    // We still log the attempt so operators can see the open failed.
+    const logged: DispatchLogEntry = spies.appendDispatchLog.mock.calls[0][0];
+    expect(logged.blockers).toContain('open-failed');
+  });
+});
+
+describe('buildForceClaimComment', () => {
+  it('includes slot + reason + reconciliation guidance', () => {
+    const body = buildForceClaimComment({
+      dispatcherSlot: 10,
+      dispatcherBranch: 'claude/qua-437-wrap',
+      targetSlot: 7,
+      reason: 'prior session abandoned, tmux dead',
+    });
+    expect(body).toContain('⚠ Claim forced via');
+    expect(body).toContain('slot a10');
+    expect(body).toContain('slot a7');
+    expect(body).toContain('prior session abandoned, tmux dead');
+    expect(body).toContain('agent-checklist init --force');
+  });
+
+  it('falls back to branch tag when dispatcher slot is null', () => {
+    const body = buildForceClaimComment({
+      dispatcherSlot: null,
+      dispatcherBranch: 'main',
+      targetSlot: 3,
+      reason: 'r',
+    });
+    // Dispatcher is identified by branch, not slot
+    expect(body).toContain('from branch `main`');
+    expect(body).not.toMatch(/from slot a\d/);
+    // Target slot still renders as "slot a<N>"
+    expect(body).toContain('slot a3');
+  });
+});

--- a/crux/commands/dispatch.ts
+++ b/crux/commands/dispatch.ts
@@ -25,7 +25,7 @@
  *   2  pre-flight collision (matches `crux linear start` exit code)
  */
 
-import { execSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 

--- a/crux/commands/dispatch.ts
+++ b/crux/commands/dispatch.ts
@@ -1,0 +1,440 @@
+/**
+ * `crux sys dispatch` — QUA-437
+ *
+ * Structural wrapper around `./ws open <N> --claude` that enforces the
+ * dispatch pre-flight checks (`.claude/rules/dispatched-agent-review.md`
+ * § "Dispatcher pre-flight") before opening a slot. Designed to make
+ * the checks unskippable under context pressure — the coordinator
+ * cannot hand-roll their way around a wrapper that exits non-zero on
+ * collision.
+ *
+ * Motivating incident: QUA-406 — a coordinator session filed QUA-397,
+ * then dispatched slot a16 to fix it three hours later without noticing
+ * slot a9 had already shipped a PR. Two shipping PRs, ~$100 of
+ * duplicated work. The root cause wasn't tooling (the signals existed)
+ * — it was that the coordinator had all the information and didn't
+ * use it under load. A CLI wrapper that refuses on collision closes
+ * that behavioral gap.
+ *
+ * Usage:
+ *   crux sys dispatch --linear=QUA-NNN --slot=N [--brief=<path>] [--force --reason="..."] [--dry-run]
+ *
+ * Exit codes:
+ *   0  dispatched (or dry-run succeeded)
+ *   1  argument / environment error
+ *   2  pre-flight collision (matches `crux linear start` exit code)
+ */
+
+import { execSync, spawnSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import { createLogger, type Logger } from '../lib/output.ts';
+import { parseLinearId } from '../lib/linear/parse-id.ts';
+import { getIssue, commentOnIssue } from '../lib/linear/issues.ts';
+import { getSessionContext } from '../lib/session/session-context.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { runPreflight, type PreflightResult } from '../lib/dispatch/preflight.ts';
+import { appendDispatchLog } from '../lib/dispatch/audit-log.ts';
+
+interface CommandOptions extends BaseOptions {
+  linear?: string;
+  slot?: string;
+  brief?: string;
+  force?: boolean;
+  reason?: string;
+  dryRun?: boolean;
+  json?: boolean;
+  ci?: boolean;
+}
+
+export interface DispatchDeps {
+  /** Override for tests — defaults to the real Linear issue helper. */
+  getIssue?: typeof getIssue;
+  /** Override for tests — defaults to the real comment helper. No-op swallowed on failure. */
+  commentOnIssue?: typeof commentOnIssue;
+  /** Override for tests — defaults to `getSessionContext()`. */
+  getSessionContext?: typeof getSessionContext;
+  /** Override for tests — defaults to `runPreflight`. */
+  runPreflight?: typeof runPreflight;
+  /** Override for tests — defaults to `appendDispatchLog`. */
+  appendDispatchLog?: typeof appendDispatchLog;
+  /** Override for tests — defaults to shelling out to `./ws open <N> --claude`. */
+  openSlot?: (slot: number, lwDir: string) => { ok: boolean; error?: string };
+  /** Override for tests — defaults to `process.cwd()` / path joins from PROJECT_ROOT. */
+  resolveLwDir?: () => string;
+}
+
+/**
+ * Resolve the `lw/` workspace root by walking up from PROJECT_ROOT.
+ * Matches the heuristic in `agent-workspace.ts::getLwDir` — if PROJECT_ROOT
+ * looks like an agent slot (`a<N>`) or `main` under a `lw/` directory,
+ * return the parent; otherwise assume lw/ is a sibling.
+ */
+export function resolveLwDir(): string {
+  const parent = dirname(PROJECT_ROOT);
+  const dirName = PROJECT_ROOT.split('/').pop() ?? '';
+  if (/^(a\d+|main|coord)$/.test(dirName) && parent.endsWith('/lw')) return parent;
+  return join(parent, 'lw');
+}
+
+/**
+ * Open the target slot with `./ws open <N> --claude`. Uses the `./ws`
+ * script rather than invoking `pnpm crux agent-workspace open` directly
+ * because `./ws` knows the absolute lw/ directory layout and tmux hook
+ * overlay logic. Requires `$TMUX` to be set (same precondition the
+ * underlying `open` handler already enforces).
+ */
+function openSlotViaWs(slot: number, lwDir: string): { ok: boolean; error?: string } {
+  const wsScript = join(lwDir, 'ws');
+  if (!existsSync(wsScript)) {
+    return { ok: false, error: `Workspace script not found at ${wsScript}` };
+  }
+  const res = spawnSync(wsScript, ['open', String(slot), '--claude'], {
+    cwd: lwDir,
+    stdio: 'inherit',
+    encoding: 'utf-8',
+  });
+  if (res.status === 0) return { ok: true };
+  return { ok: false, error: `./ws open ${slot} --claude exited with status ${res.status ?? 'unknown'}` };
+}
+
+export const FORCE_COMMENT_PREAMBLE = '⚠ Claim forced via `crux sys dispatch --force`';
+
+export function buildForceClaimComment(params: {
+  dispatcherSlot: number | null;
+  dispatcherBranch: string;
+  targetSlot: number;
+  reason: string;
+}): string {
+  const dispatcherTag = params.dispatcherSlot !== null
+    ? `slot a${params.dispatcherSlot}`
+    : `branch \`${params.dispatcherBranch}\``;
+  return [
+    `${FORCE_COMMENT_PREAMBLE} from ${dispatcherTag}.`,
+    `Dispatching to slot a${params.targetSlot}.`,
+    '',
+    `**Reason:** ${params.reason}`,
+    '',
+    'The dispatched session will run `agent-checklist init --force` and should reconcile ' +
+      'with any prior claimant (close the competing PR, coordinate the handoff, or ' +
+      'document the abandonment in this ticket).',
+  ].join('\n');
+}
+
+export function buildDispatchBriefCopy(params: {
+  linearId: string;
+  targetSlot: number;
+  dispatcherBranch: string;
+  briefBody: string;
+}): string {
+  return [
+    `<!-- Dispatched via \`crux sys dispatch\` on ${new Date().toISOString()}`,
+    `     Linear:   ${params.linearId}`,
+    `     Slot:     a${params.targetSlot}`,
+    `     Dispatcher branch: ${params.dispatcherBranch}`,
+    '-->',
+    '',
+    params.briefBody.trimEnd(),
+    '',
+  ].join('\n');
+}
+
+/**
+ * Stage the dispatch brief inside the target slot so the opened Claude
+ * session can `cat .claude/dispatch-brief.md` on its first turn.
+ *
+ * Returns the absolute path on success, null if no `--brief` was passed,
+ * or an error string if the brief file is missing / unreadable.
+ */
+function stageBrief(
+  briefPath: string | undefined,
+  linearId: string,
+  targetSlot: number,
+  targetSlotDir: string,
+  dispatcherBranch: string,
+): { path: string } | { error: string } | null {
+  if (!briefPath) return null;
+  let briefBody: string;
+  try {
+    briefBody = readFileSync(briefPath, 'utf-8');
+  } catch (e) {
+    return { error: `Could not read brief at ${briefPath}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  if (!briefBody.trim()) {
+    return { error: `Brief file ${briefPath} is empty` };
+  }
+
+  const dest = join(targetSlotDir, '.claude', 'dispatch-brief.md');
+  try {
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(
+      dest,
+      buildDispatchBriefCopy({ linearId, targetSlot, dispatcherBranch, briefBody }),
+    );
+    return { path: dest };
+  } catch (e) {
+    return { error: `Could not write staged brief to ${dest}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+function parseSlotNumber(raw: string | undefined): number | { error: string } {
+  if (!raw) return { error: '--slot=<N> is required' };
+  if (!/^\d+$/.test(raw)) return { error: `--slot must be a positive integer (got: ${raw})` };
+  const n = Number.parseInt(raw, 10);
+  if (n < 1) return { error: '--slot must be >= 1' };
+  return n;
+}
+
+function formatPreflightBlockers(pf: PreflightResult, c: Logger['colors']): string {
+  let out = '';
+  if (pf.linearClaims.length > 0) {
+    const label = pf.linearClaims.length === 1 ? 'Active Linear claim' : `${pf.linearClaims.length} active Linear claims`;
+    out += `  ${c.bold}${label}${c.reset} (from a different slot, <24h):\n`;
+    for (const claim of pf.linearClaims) {
+      const firstLine = claim.body.split('\n').find((l) => l.trim().length > 0) ?? '';
+      const tag =
+        `slot=${claim.slot ?? '?'} ` +
+        `branch=${claim.branch ?? '?'} ` +
+        `at=${claim.createdAt}`;
+      out += `    ${c.dim}${tag}${c.reset}\n`;
+      out += `    ${firstLine.slice(0, 120)}\n`;
+    }
+    out += '\n';
+  }
+  if (pf.openPrs.length > 0) {
+    const label = pf.openPrs.length === 1 ? 'Open PR' : `${pf.openPrs.length} open PRs`;
+    out += `  ${c.bold}${label}${c.reset} referencing this ticket:\n`;
+    for (const pr of pf.openPrs) {
+      out += `    ${c.cyan}#${pr.number}${c.reset} ${pr.title}\n`;
+      out += `    ${c.dim}${pr.url}${c.reset}\n`;
+    }
+    out += '\n';
+  }
+  if (!pf.slot.exists) {
+    out += `  ${c.bold}Target slot${c.reset}: directory does not exist (${pf.slot.slotDir})\n\n`;
+  } else if (pf.slot.branch !== 'main' || !pf.slot.clean) {
+    out += `  ${c.bold}Target slot${c.reset}: ${pf.slot.detail || 'not in a reusable state'}\n`;
+    out += `    ${c.dim}${pf.slot.slotDir}${c.reset}\n\n`;
+  }
+  return out;
+}
+
+async function dispatchDefault(
+  args: string[],
+  options: CommandOptions,
+  deps: DispatchDeps = {},
+): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  // ── 1. Parse + validate arguments ──────────────────────────────────────
+  const linearRaw = typeof options.linear === 'string' ? options.linear : args[0];
+  const linearId = parseLinearId(linearRaw);
+  if (!linearId) {
+    return {
+      output:
+        `${c.red}Usage: crux sys dispatch --linear=QUA-NNN --slot=N ` +
+        `[--brief=<path>] [--force --reason="..."] [--dry-run]${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const slotResult = parseSlotNumber(options.slot);
+  if (typeof slotResult !== 'number') {
+    return { output: `${c.red}Error: ${slotResult.error}${c.reset}\n`, exitCode: 1 };
+  }
+  const targetSlot = slotResult;
+
+  if (options.force && !options.reason) {
+    return {
+      output:
+        `${c.red}Error: --force requires --reason="<why>".${c.reset}\n` +
+        `  Forced claims leave an audit trail in the Linear ticket; without a reason the ` +
+        `claim looks arbitrary to reviewers reading the ticket later.\n`,
+      exitCode: 1,
+    };
+  }
+
+  // ── 2. Resolve workspace + target slot paths ───────────────────────────
+  const lwDir = (deps.resolveLwDir ?? resolveLwDir)();
+  const targetSlotDir = join(lwDir, `a${targetSlot}`);
+
+  // ── 3. Fetch issue (confirms it exists + gives us the URL for output) ──
+  const issueFn = deps.getIssue ?? getIssue;
+  const issue = await issueFn(linearId).catch(() => null);
+  if (!issue) {
+    return {
+      output: `${c.red}Linear issue ${linearId} not found (or Linear API unreachable)${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  // ── 4. Run pre-flight checks (three signals in parallel) ───────────────
+  const ctx = (deps.getSessionContext ?? getSessionContext)();
+  const runPf = deps.runPreflight ?? runPreflight;
+  const preflight = await runPf(linearId, targetSlotDir, ctx);
+
+  const logEntryBase = {
+    linearId,
+    slot: targetSlot,
+    force: !!options.force,
+    forceReason: options.reason ?? null,
+    dispatcherSlot: ctx.slot,
+    dispatcherBranch: ctx.branch,
+    pid: process.pid,
+    blockers: [...preflight.blockers].sort(),
+    briefPath: options.brief ?? null,
+  };
+  const auditLog = deps.appendDispatchLog ?? appendDispatchLog;
+
+  // ── 5. On collision without --force: refuse with exit code 2 ───────────
+  if (!preflight.ok && !options.force) {
+    auditLog({ ...logEntryBase, outcome: 'refused' });
+    let out = `${c.red}✗ Pre-flight blocked dispatch of ${linearId} to slot a${targetSlot}.${c.reset}\n\n`;
+    out += formatPreflightBlockers(preflight, c);
+    out += `  ${c.yellow}Investigate before dispatching.${c.reset} Either continue the in-flight session, ` +
+      `comment on the open PR instead of opening a new one, or — if you're certain the prior claim is ` +
+      `abandoned — re-run with:\n`;
+    out += `    ${c.bold}crux sys dispatch --linear=${linearId} --slot=${targetSlot} --force --reason="<why>"${c.reset}\n\n`;
+    out += `  Issue: ${issue.url}\n`;
+    return { output: out, exitCode: 2 };
+  }
+
+  // ── 6. Stage the dispatch brief (if provided) ──────────────────────────
+  const brief = stageBrief(
+    options.brief,
+    linearId,
+    targetSlot,
+    targetSlotDir,
+    ctx.branch,
+  );
+  if (brief && 'error' in brief) {
+    return { output: `${c.red}Error: ${brief.error}${c.reset}\n`, exitCode: 1 };
+  }
+  const briefStagedPath = brief && 'path' in brief ? brief.path : null;
+
+  // ── 7. On --force: post a reconciliation comment to Linear ─────────────
+  // Best-effort: if the comment fails, we still dispatch — the audit log
+  // captures the force event either way. Failing to post a comment should
+  // not block an emergency dispatch.
+  if (options.force && !options.dryRun) {
+    const commentFn = deps.commentOnIssue ?? commentOnIssue;
+    const body = buildForceClaimComment({
+      dispatcherSlot: ctx.slot,
+      dispatcherBranch: ctx.branch,
+      targetSlot,
+      reason: options.reason ?? '(no reason given)',
+    });
+    try {
+      await commentFn(linearId, body);
+    } catch {
+      // Swallow; we'll note it in the CLI output below.
+    }
+  }
+
+  // ── 8. Dry-run short-circuit ───────────────────────────────────────────
+  if (options.dryRun) {
+    auditLog({ ...logEntryBase, outcome: 'dry-run' });
+    let out = '';
+    out += `${c.green}✓${c.reset} Pre-flight ${preflight.ok ? 'passed' : c.yellow + 'would be forced' + c.reset}`;
+    out += ` for ${c.cyan}${linearId}${c.reset} → slot a${targetSlot}\n`;
+    out += `  ${c.dim}(dry-run — did not open ./ws)${c.reset}\n`;
+    if (briefStagedPath) out += `  Brief staged: ${c.cyan}${briefStagedPath}${c.reset}\n`;
+    out += `  Issue: ${issue.url}\n`;
+    return { output: out, exitCode: 0 };
+  }
+
+  // ── 9. Open the slot ───────────────────────────────────────────────────
+  if (!process.env.TMUX) {
+    return {
+      output:
+        `${c.red}Error: not inside a tmux session — cannot invoke ./ws open.${c.reset}\n` +
+        `  Start a tmux session first, or use --dry-run to validate pre-flight without opening a slot.\n`,
+      exitCode: 1,
+    };
+  }
+  const opener = deps.openSlot ?? openSlotViaWs;
+  const openResult = opener(targetSlot, lwDir);
+  if (!openResult.ok) {
+    auditLog({ ...logEntryBase, outcome: 'refused', blockers: [...logEntryBase.blockers, 'open-failed'].sort() });
+    return {
+      output: `${c.red}Error opening slot a${targetSlot}: ${openResult.error ?? 'unknown'}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  auditLog({ ...logEntryBase, outcome: options.force ? 'forced' : 'dispatched' });
+
+  // ── 10. Success output ─────────────────────────────────────────────────
+  let out = '';
+  out += `${c.green}✓${c.reset} Dispatched ${c.cyan}${linearId}${c.reset} → slot a${targetSlot}\n`;
+  if (options.force) {
+    out += `  ${c.yellow}⚠ Forced past pre-flight${c.reset} — reason: ${options.reason}\n`;
+    out += `  ${c.dim}Reconciliation comment posted on ${linearId}${c.reset}\n`;
+  }
+  if (briefStagedPath) {
+    out += `  Brief:   ${c.cyan}${briefStagedPath}${c.reset}\n`;
+    out += `  ${c.dim}In the new session: cat .claude/dispatch-brief.md${c.reset}\n`;
+  }
+  out += `  Issue:   ${issue.url}\n`;
+  out += `  Audit:   ${c.dim}~/.cache/crux-dispatch/log.jsonl${c.reset}\n`;
+  return { output: out, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export { dispatchDefault };
+
+export const commands: Record<string, (args: string[], options: CommandOptions) => Promise<CommandResult>> = {
+  default: (args, options) => dispatchDefault(args, options),
+};
+
+export function getHelp(): string {
+  return `
+# Dispatch — Open an agent slot after the three dispatch pre-flight checks (QUA-437)
+
+Usage:
+  crux sys dispatch --linear=QUA-NNN --slot=N [options]
+
+Arguments:
+  --linear=QUA-NNN    Required. The Linear issue the dispatched session should work on.
+  --slot=N            Required. Target agent slot (lw/a<N>). Must exist, be on main, and clean.
+
+Pre-flight checks (all block the dispatch unless --force):
+  1. Linear state     — no active claim from a different session in the last 24h
+                        (consults PG agent_sessions first, then Linear start comments).
+  2. Open PRs         — no open PR in the wiki repo mentions this Linear ID.
+  3. Target slot      — lw/a<N> exists, git branch is 'main', working tree clean,
+                        no un-pushed commits.
+
+Options:
+  --brief=<path>      Copy a dispatch brief into lw/a<N>/.claude/dispatch-brief.md so the
+                      new Claude session can 'cat' it on its first turn.
+  --force             Override pre-flight blockers. Requires --reason.
+  --reason="<why>"    Required when --force is set. Posted as a Linear comment AND written
+                      to the audit log. Forced claims stay visible in the ticket timeline.
+  --dry-run           Run pre-flight + report, but do not open the slot. Useful in tests
+                      and for coordinators who want to verify cleanliness before committing.
+  --json              Emit machine-readable output (not yet implemented for this command).
+  --ci                Disable colors / interactive formatting.
+
+Exit codes:
+  0    Dispatched (or dry-run succeeded).
+  1    Argument / environment error (bad flags, no tmux, Linear unreachable).
+  2    Pre-flight collision — another session already claims this ticket. Rerun with
+       --force --reason=... if the prior claim is genuinely abandoned.
+
+Examples:
+  crux sys dispatch --linear=QUA-440 --slot=7
+  crux sys dispatch --linear=QUA-440 --slot=7 --brief=../dispatch/qua-440.md
+  crux sys dispatch --linear=QUA-397 --slot=7 --force --reason="slot a9 abandoned, PR #4296 closed"
+  crux sys dispatch --linear=QUA-440 --slot=7 --dry-run
+
+See .claude/rules/dispatched-agent-review.md § "Dispatcher pre-flight" for the full rule
+this wrapper enforces, and QUA-406 / QUA-437 for the incident history that motivated it.
+`;
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -126,6 +126,7 @@ import * as docsCommands from './commands/docs.ts';
 import * as linearCommands from './commands/linear.ts';
 import * as flagshipCurateCommands from './commands/flagship-curate.ts';
 import * as sessionFinalizeCommands from './commands/session-finalize.ts';
+import * as dispatchCommands from './commands/dispatch.ts';
 
 const domains = {
   validate: validateCommands,
@@ -216,6 +217,7 @@ const domains = {
   linear: linearCommands,
   'flagship-curate': flagshipCurateCommands,
   'session-finalize': sessionFinalizeCommands,
+  dispatch: dispatchCommands,
 };
 
 const shortcutMap = buildShortcutMap();

--- a/crux/lib/dispatch/audit-log.test.ts
+++ b/crux/lib/dispatch/audit-log.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the dispatch audit-log writer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { appendDispatchLog } from './audit-log.ts';
+
+function tmpFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dispatch-log-'));
+  return join(dir, 'log.jsonl');
+}
+
+describe('appendDispatchLog', () => {
+  it('writes one JSON line per entry and creates parent dirs', () => {
+    const file = join(mkdtempSync(join(tmpdir(), 'dispatch-log-')), 'nested', 'log.jsonl');
+    appendDispatchLog(
+      {
+        linearId: 'QUA-437',
+        slot: 7,
+        outcome: 'dispatched',
+        force: false,
+        forceReason: null,
+        dispatcherSlot: 10,
+        dispatcherBranch: 'claude/qua-437',
+        pid: 12345,
+        blockers: [],
+        briefPath: null,
+      },
+      { file, now: () => '2026-04-17T12:00:00Z' },
+    );
+    expect(existsSync(file)).toBe(true);
+    const parsed = JSON.parse(readFileSync(file, 'utf-8').trim());
+    expect(parsed.linearId).toBe('QUA-437');
+    expect(parsed.outcome).toBe('dispatched');
+    expect(parsed.timestamp).toBe('2026-04-17T12:00:00Z');
+    rmSync(file, { recursive: false, force: true });
+  });
+
+  it('appends without clobbering prior entries', () => {
+    const file = tmpFile();
+    const base = {
+      slot: 7,
+      force: false,
+      forceReason: null,
+      dispatcherSlot: 10,
+      dispatcherBranch: 'claude/x',
+      pid: 1,
+      blockers: [] as string[],
+      briefPath: null,
+    };
+    appendDispatchLog({ ...base, linearId: 'QUA-1', outcome: 'dispatched' }, { file });
+    appendDispatchLog({ ...base, linearId: 'QUA-2', outcome: 'refused', blockers: ['open-pr'] }, { file });
+    const lines = readFileSync(file, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).linearId).toBe('QUA-1');
+    expect(JSON.parse(lines[1]).linearId).toBe('QUA-2');
+    expect(JSON.parse(lines[1]).blockers).toEqual(['open-pr']);
+  });
+
+  it('does not throw when the destination is unwritable', () => {
+    // Point at a path where the parent cannot be created. On macOS,
+    // mkdirSync under /dev/null/x throws EEXIST/ENOTDIR — we just need
+    // any path that will blow up inside the try block.
+    expect(() =>
+      appendDispatchLog(
+        {
+          linearId: 'QUA-1',
+          slot: 1,
+          outcome: 'refused',
+          force: false,
+          forceReason: null,
+          dispatcherSlot: null,
+          dispatcherBranch: 'main',
+          pid: 1,
+          blockers: [],
+          briefPath: null,
+        },
+        { file: '/dev/null/unwritable/log.jsonl' },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/crux/lib/dispatch/audit-log.ts
+++ b/crux/lib/dispatch/audit-log.ts
@@ -1,0 +1,76 @@
+/**
+ * Dispatch audit log — QUA-437
+ *
+ * Appends one JSONL line per `crux sys dispatch` invocation to
+ * `~/.cache/crux-dispatch/log.jsonl`, so cross-session "who dispatched
+ * what, when, and under what circumstances" is queryable without
+ * spelunking through Linear comments or tmux history.
+ *
+ * Fields intentionally sparse — enough to reconstruct a timeline and
+ * identify forced claims, without duplicating content already in Linear
+ * or the PR body. The `force` + `forceReason` fields are the primary
+ * reason this log exists: `--force` claims must be traceable even when
+ * the Linear comment is deleted or the ticket is closed.
+ *
+ * Never crashes the dispatch on write failure — best-effort, like
+ * `pr-patrol/state.ts::appendJsonl`.
+ */
+
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+
+export const DISPATCH_LOG_DIR = join(homedir(), '.cache', 'crux-dispatch');
+export const DISPATCH_LOG_FILE = join(DISPATCH_LOG_DIR, 'log.jsonl');
+
+export type DispatchOutcome = 'dispatched' | 'refused' | 'forced' | 'dry-run';
+
+export interface DispatchLogEntry {
+  /** Linear issue identifier, e.g. "QUA-437". */
+  linearId: string;
+  /** Target slot number (the slot we opened, not the dispatcher's slot). */
+  slot: number;
+  /**
+   * What happened. `refused` = pre-flight blocked and no `--force`.
+   * `forced` = pre-flight blocked but operator overrode. `dry-run` =
+   * pre-flight passed (or was forced past) but `--dry-run` skipped the
+   * actual `./ws open`. `dispatched` = slot was opened.
+   */
+  outcome: DispatchOutcome;
+  /** True iff `--force` was passed. Redundant with `outcome` for `refused`, but useful for filtering. */
+  force: boolean;
+  /** Reason string passed with `--force`. Required by the CLI when `--force` is set. */
+  forceReason: string | null;
+  /** Dispatcher's session context — `slot` field can be null when running outside a slot dir. */
+  dispatcherSlot: number | null;
+  dispatcherBranch: string;
+  /** Process pid, for cross-referencing with tmux scrollback. */
+  pid: number;
+  /** Sorted list of pre-flight blocker tags (empty when pre-flight passed). */
+  blockers: string[];
+  /** Optional path to the dispatch brief if `--brief=<path>` was passed. */
+  briefPath: string | null;
+}
+
+/**
+ * Append an entry to the audit log. Silently swallows filesystem errors
+ * — the dispatch command's job is to open a slot, not to guarantee
+ * logging. A missing log line is recoverable; a failed dispatch because
+ * `~/.cache` was read-only is not.
+ */
+export function appendDispatchLog(
+  entry: DispatchLogEntry,
+  opts: { file?: string; now?: () => string } = {},
+): void {
+  const file = opts.file ?? DISPATCH_LOG_FILE;
+  const timestamp = (opts.now ?? (() => new Date().toISOString()))();
+
+  try {
+    const dir = dirname(file);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const line = JSON.stringify({ timestamp, ...entry }) + '\n';
+    appendFileSync(file, line);
+  } catch {
+    // Best-effort; dispatch should not fail because the log is unwritable.
+  }
+}

--- a/crux/lib/dispatch/preflight.test.ts
+++ b/crux/lib/dispatch/preflight.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the dispatch pre-flight orchestration layer (QUA-437).
+ *
+ * `runSlotState` is covered by the real filesystem in a temp dir so we
+ * exercise actual git behavior rather than mock out the shell. The
+ * orchestrator `runPreflight` is tested with injected fakes for each
+ * of its three signals.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { runPreflight, runSlotState } from './preflight.ts';
+import type { SessionContext } from '../session/session-context.ts';
+
+function initRepoOnMain(dir: string): void {
+  execSync('git init -b main', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.email test@example.com', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.name Test', { cwd: dir, stdio: 'ignore' });
+  writeFileSync(join(dir, 'README.md'), 'hi\n');
+  execSync('git add README.md && git commit -m init', { cwd: dir, stdio: 'ignore' });
+}
+
+const baseCtx: SessionContext = {
+  slot: 10,
+  branch: 'claude/qua-437',
+  host: 'h',
+  agentId: null,
+};
+
+describe('runSlotState', () => {
+  it('reports non-existent dir as exists=false', () => {
+    const state = runSlotState('/nonexistent/path/deep/a99');
+    expect(state.exists).toBe(false);
+    expect(state.clean).toBe(false);
+    expect(state.detail).toContain('does not exist');
+  });
+
+  it('reports clean + on main when repo is untouched', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ws-a-'));
+    try {
+      initRepoOnMain(dir);
+      const state = runSlotState(dir);
+      expect(state.exists).toBe(true);
+      expect(state.branch).toBe('main');
+      expect(state.clean).toBe(true);
+      expect(state.detail).toBe('');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('flags uncommitted changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ws-b-'));
+    try {
+      initRepoOnMain(dir);
+      writeFileSync(join(dir, 'scratch.txt'), 'dirty\n');
+      const state = runSlotState(dir);
+      expect(state.branch).toBe('main');
+      expect(state.clean).toBe(false);
+      expect(state.detail).toContain('uncommitted');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('flags being off main', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ws-c-'));
+    try {
+      initRepoOnMain(dir);
+      execSync('git checkout -b claude/side', { cwd: dir, stdio: 'ignore' });
+      const state = runSlotState(dir);
+      expect(state.branch).toBe('claude/side');
+      expect(state.clean).toBe(true); // tree is clean; branch is wrong
+      expect(state.detail).toContain("on branch 'claude/side'");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not flag unpushed as unclean when no upstream exists', () => {
+    // Common case: a brand-new slot clone whose local `main` has never
+    // been pushed to a remote — the `@{u}` rev parse fails, which we
+    // treat as "no upstream, skip the un-pushed check."
+    const dir = mkdtempSync(join(tmpdir(), 'ws-d-'));
+    try {
+      initRepoOnMain(dir);
+      const state = runSlotState(dir);
+      expect(state.clean).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runPreflight', () => {
+  const okSlot = {
+    slotDir: '/lw/a7',
+    exists: true,
+    branch: 'main',
+    clean: true,
+    detail: '',
+  };
+
+  it('returns ok when all three signals pass', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [],
+      findOpenPrsMentioningLinearId: async () => [],
+      inspectSlot: () => okSlot,
+    });
+    expect(pf.ok).toBe(true);
+    expect(pf.blockers).toEqual([]);
+  });
+
+  it('reports linear-claim blocker', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [
+        {
+          body: '🤖 Claude Code starting work',
+          createdAt: '2026-04-17T10:00:00Z',
+          branch: null,
+          slot: 'a9',
+        },
+      ],
+      findOpenPrsMentioningLinearId: async () => [],
+      inspectSlot: () => okSlot,
+    });
+    expect(pf.ok).toBe(false);
+    expect(pf.blockers).toContain('linear-claim');
+  });
+
+  it('reports open-pr blocker independently of linear-claim', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [],
+      findOpenPrsMentioningLinearId: async () => [
+        { number: 1, title: 't', url: 'u' },
+      ],
+      inspectSlot: () => okSlot,
+    });
+    expect(pf.blockers).toEqual(['open-pr']);
+  });
+
+  it('reports slot-off-main when branch is wrong', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [],
+      findOpenPrsMentioningLinearId: async () => [],
+      inspectSlot: () => ({
+        ...okSlot,
+        branch: 'claude/other',
+        detail: "on branch 'claude/other'",
+      }),
+    });
+    expect(pf.blockers).toContain('slot-off-main');
+  });
+
+  it('reports slot-dirty when on main but dirty', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [],
+      findOpenPrsMentioningLinearId: async () => [],
+      inspectSlot: () => ({
+        ...okSlot,
+        clean: false,
+        detail: 'uncommitted changes: M scratch',
+      }),
+    });
+    expect(pf.blockers).toContain('slot-dirty');
+  });
+
+  it('combines multiple blockers', async () => {
+    const pf = await runPreflight('QUA-437', '/lw/a7', baseCtx, {
+      findActiveClaimsByOthers: async () => [
+        { body: 'x', createdAt: '2026-04-17T10:00:00Z', branch: null, slot: 'a9' },
+      ],
+      findOpenPrsMentioningLinearId: async () => [
+        { number: 1, title: 't', url: 'u' },
+      ],
+      inspectSlot: () => ({ ...okSlot, clean: false, detail: 'dirty' }),
+    });
+    expect(pf.blockers).toContain('linear-claim');
+    expect(pf.blockers).toContain('open-pr');
+    expect(pf.blockers).toContain('slot-dirty');
+  });
+});

--- a/crux/lib/dispatch/preflight.ts
+++ b/crux/lib/dispatch/preflight.ts
@@ -1,0 +1,160 @@
+/**
+ * Dispatch pre-flight checks — QUA-437
+ *
+ * `crux sys dispatch` runs three structural checks before opening a slot,
+ * so coordinators can't dispatch a duplicate claim under context pressure
+ * (QUA-406 incident, where a coordinator dispatched slot a16 to fix
+ * QUA-397 three hours after another session had already shipped a PR).
+ *
+ * Checks (all fail the dispatch unless `--force`):
+ *
+ *   1. Linear state — reuses `findActiveClaimsByOthers()` from
+ *      `crux/lib/linear/dedup.ts`. Consults PG `agent_sessions` first,
+ *      falls back to Linear start comments.
+ *   2. Open PRs — reuses `findOpenPrsMentioningLinearId()`. Catches
+ *      abandoned branches that PG / Linear have forgotten.
+ *   3. Target slot — checks `lw/a<N>` exists, is on `main`, has a clean
+ *      working tree, and has no un-pushed commits. A dirty / off-main
+ *      slot would clobber in-progress work when the dispatched session
+ *      creates its feature branch.
+ *
+ * Separated from the CLI handler so the logic is testable without
+ * mocking argument parsing or tmux invocation.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+
+import {
+  findActiveClaimsByOthers,
+  findOpenPrsMentioningLinearId,
+  type OpenPrMatch,
+  type RecentStartClaim,
+} from '../linear/dedup.ts';
+import type { SessionContext } from '../session/session-context.ts';
+
+export interface SlotStateCheck {
+  /** Resolved absolute path to `lw/a<N>`. */
+  slotDir: string;
+  /** True when the slot directory exists on disk. */
+  exists: boolean;
+  /** `git branch --show-current` output (empty when detached / missing repo). */
+  branch: string;
+  /**
+   * True when `git status --porcelain` is empty AND no un-pushed commits sit
+   * on the current branch. A dispatch into a dirty slot risks clobbering
+   * in-progress work when the new session runs `git checkout -b` or `main`
+   * sync, so we treat both kinds of un-pushed state as the same class of
+   * "not safe to reuse."
+   */
+  clean: boolean;
+  /** Human-readable reason when `clean` is false or `branch !== 'main'`. */
+  detail: string;
+}
+
+export interface PreflightResult {
+  linearClaims: RecentStartClaim[];
+  openPrs: OpenPrMatch[];
+  slot: SlotStateCheck;
+  /** True iff every check passed with no collisions. */
+  ok: boolean;
+  /** Short category tags, stable across CLI / JSON outputs. */
+  blockers: Array<'linear-claim' | 'open-pr' | 'slot-missing' | 'slot-dirty' | 'slot-off-main'>;
+}
+
+export interface PreflightDeps {
+  /** Override for tests — defaults to the real dedup helper. */
+  findActiveClaimsByOthers?: typeof findActiveClaimsByOthers;
+  /** Override for tests — defaults to the real GitHub-search helper. */
+  findOpenPrsMentioningLinearId?: typeof findOpenPrsMentioningLinearId;
+  /** Override for tests — defaults to `runSlotState`. */
+  inspectSlot?: (slotDir: string) => SlotStateCheck;
+}
+
+/**
+ * Inspect a slot directory with the same read-only git commands `./ws list`
+ * uses. `-C <slotDir>` avoids `cd`-ing into the slot (slot-isolation rule):
+ * we're reading state, not modifying anything. Short timeouts keep a hung
+ * or NFS-stalled slot from wedging the dispatcher.
+ */
+export function runSlotState(slotDir: string): SlotStateCheck {
+  if (!existsSync(slotDir)) {
+    return { slotDir, exists: false, branch: '', clean: false, detail: 'slot directory does not exist' };
+  }
+  const branch = safeGit(slotDir, ['branch', '--show-current']);
+  const porcelain = safeGit(slotDir, ['status', '--porcelain']);
+  // `@{u}` resolves to the upstream branch — missing when the branch has no
+  // upstream (the slot is on a local-only branch or a fresh checkout). We
+  // treat "no upstream" as clean since the local-only branch case is already
+  // flagged by the off-main check.
+  const unpushed = safeGit(slotDir, ['log', '@{u}..HEAD', '--oneline']);
+  const dirty = porcelain.length > 0;
+  const hasUnpushed = unpushed.length > 0;
+  const clean = !dirty && !hasUnpushed;
+
+  let detail = '';
+  if (!branch) detail = 'detached HEAD';
+  else if (branch !== 'main') detail = `on branch '${branch}' (expected 'main')`;
+  else if (dirty) {
+    const firstLines = porcelain.split('\n').slice(0, 3).join('; ');
+    detail = `uncommitted changes: ${firstLines}`;
+  } else if (hasUnpushed) {
+    const firstLines = unpushed.split('\n').slice(0, 3).join('; ');
+    detail = `unpushed commits: ${firstLines}`;
+  }
+
+  return { slotDir, exists: true, branch, clean, detail };
+}
+
+function safeGit(cwd: string, args: string[]): string {
+  try {
+    return execSync(`git ${args.join(' ')}`, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    // Treat all git failures as "no output." The detail string elsewhere
+    // already captures the likely cause (missing dir, detached HEAD, etc.).
+    return '';
+  }
+}
+
+/**
+ * Run all three pre-flight checks in parallel where possible, collect
+ * results, and compute a single `ok` flag + list of blocker tags.
+ * Callers decide whether to refuse (default) or proceed past blockers
+ * (via `--force`).
+ */
+export async function runPreflight(
+  linearId: string,
+  slotDir: string,
+  ctx: SessionContext,
+  deps: PreflightDeps = {},
+): Promise<PreflightResult> {
+  const claimsFn = deps.findActiveClaimsByOthers ?? findActiveClaimsByOthers;
+  const prsFn = deps.findOpenPrsMentioningLinearId ?? findOpenPrsMentioningLinearId;
+  const slotFn = deps.inspectSlot ?? runSlotState;
+
+  const [linearClaims, openPrs, slot] = await Promise.all([
+    claimsFn(linearId, ctx),
+    prsFn(linearId),
+    Promise.resolve(slotFn(slotDir)),
+  ]);
+
+  const blockers: PreflightResult['blockers'] = [];
+  if (linearClaims.length > 0) blockers.push('linear-claim');
+  if (openPrs.length > 0) blockers.push('open-pr');
+  if (!slot.exists) blockers.push('slot-missing');
+  else if (slot.branch !== 'main') blockers.push('slot-off-main');
+  else if (!slot.clean) blockers.push('slot-dirty');
+
+  return {
+    linearClaims,
+    openPrs,
+    slot,
+    ok: blockers.length === 0,
+    blockers,
+  };
+}

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -128,6 +128,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'usage-patterns',
       'session-finalize',
       'docs',
+      'dispatch',
     ],
   },
   linear: {


### PR DESCRIPTION
## Summary

Adds `pnpm crux sys dispatch --linear=QUA-NNN --slot=N` — a structural wrapper around `./ws open <N> --claude` that enforces the three dispatcher pre-flight checks in `.claude/rules/dispatched-agent-review.md` § "Dispatcher pre-flight":

1. **Linear state** — no active claim from a different session in the last 24h (consults PG `agent_sessions` first, then Linear start comments via the existing `findActiveClaimsByOthers` helper).
2. **Open PRs** — no open PR in the wiki repo mentions the Linear ID (via `findOpenPrsMentioningLinearId`).
3. **Target slot** — `lw/a<N>` exists, branch is `main`, working tree is clean, no un-pushed commits.

Refuses on collision with exit code 2 (matching `crux linear start` for consistency). `--force --reason="<why>"` overrides — forced claims post a visible `⚠ Claim forced via crux sys dispatch --force` comment on the Linear issue so they stay traceable in ticket history, and every dispatch is audit-logged to `~/.cache/crux-dispatch/log.jsonl`.

**Why a wrapper (not just docs)**: QUA-406 incident — a coordinator session filed QUA-397, then dispatched slot a16 to fix it three hours later without noticing slot a9 had already shipped a PR. Two shipping PRs, ~$100 of duplicated work. The signals existed; the coordinator just didn't check under context pressure. A CLI that exits non-zero on collision closes the behavioral gap.

## Acceptance criteria (from QUA-437)

- ✅ `crux sys dispatch --linear=QUA-NNN --slot=N` exists and exits non-zero on any of: (a) recent-start comment from different session, (b) open PR referencing the Linear ID, (c) target slot is dirty or non-main.
- ✅ `--force` override works and writes a loud marker to both the dispatch audit log AND the Linear start comment so forced claims are visible in ticket history.
- ✅ `.claude/rules/dispatched-agent-review.md` updated to point at the now-existing command (the "Once QUA-437 ships…" paragraph is replaced with usage examples).
- ✅ Tests: pre-flight blocker combinations (Linear claim, open PR, dirty slot, missing slot, off-main), --force path (with + without Linear outage), --dry-run, tmux guard, `./ws open` failure propagation. 32 tests across `dispatch.test.ts`, `preflight.test.ts`, `audit-log.test.ts`.
- ⚠ `--json` is reserved on the CLI but not yet implemented (would duplicate the exit-code + human-readable output without an immediate caller; can add on demand).

## Key files

- `crux/commands/dispatch.ts` — CLI handler (argument parsing, pre-flight orchestration, `--force` Linear comment, `./ws open` invocation).
- `crux/lib/dispatch/preflight.ts` — `runPreflight()` orchestrator + `runSlotState()` read-only slot inspector. Separated for testability.
- `crux/lib/dispatch/audit-log.ts` — JSONL writer for `~/.cache/crux-dispatch/log.jsonl`. Fail-closed on write errors.
- `crux/crux.mjs` + `crux/lib/groups.ts` — register `dispatch` as a `sys` group domain.
- `.claude/rules/dispatched-agent-review.md` — rule doc update.
- `CLAUDE.md` — quickref entry.

## Test plan

- [x] `pnpm test` — 6761 passing, 26 skipped (pre-existing skips), no new failures
- [x] `pnpm crux w validate gate --fix` — all 46 checks pass (2 pre-existing advisory warnings)
- [x] `pnpm install --frozen-lockfile` — lockfile up to date
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `pnpm crux sys dispatch --help` — help renders
- [x] Manual dry-run against `QUA-440` targeting a dirty slot — correctly refuses with exit 2 and prints the off-branch detail
- [ ] Merge-gated: one round of usage in production (any next dispatched ticket)

Fixes QUA-437
