### PR TITLE
feat(schema): migrate resource_content_versions.resource_id to resources.stable_id (QUA-549 pilot)

### DIFF
--- a/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
@@ -1,0 +1,64 @@
+-- QUA-549 Phase B: migrate resource_content_versions.resource_id from
+-- referencing resources.id (legacy hex16) to resources.stable_id (canonical
+-- `sid_<10>`).
+--
+-- Part of Phase B (QUA-549) of the resources-FK migration plan designed in
+-- QUA-498. Pilot table for the pattern; depends on Phase A (QUA-536) having
+-- populated resources.stable_id NOT NULL + duplicate-free.
+--
+-- Pre-flight (prod, 2026-04-16):
+--   52 rows with non-null resource_id, 0 orphans.
+--   Existing FK: resource_content_versions_resource_id_resources_id_fk
+--     ON DELETE SET NULL (matches schema.ts).
+--   Preserve the SET NULL policy on the new FK — Phase B is not the place
+--   to change delete semantics (per QUA-549 non-goals).
+--
+-- Reverse migration (if needed):
+--   ALTER TABLE resource_content_versions
+--     DROP CONSTRAINT resource_content_versions_resource_id_resources_stable_id_fk;
+--   UPDATE resource_content_versions rcv
+--     SET resource_id = r.id
+--     FROM resources r
+--     WHERE rcv.resource_id = r.stable_id;
+--   ALTER TABLE resource_content_versions
+--     ADD CONSTRAINT resource_content_versions_resource_id_resources_id_fk
+--     FOREIGN KEY (resource_id) REFERENCES resources(id)
+--     ON DELETE SET NULL;
+
+-- Step 1: drop the existing FK on resources.id.
+ALTER TABLE resource_content_versions
+  DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_resources_id_fk;
+
+-- Step 2: rewrite resource_id values from hex16 → sid_<10> via JOIN.
+-- Rows where resource_id IS NULL are untouched. Rows whose resource_id is
+-- already a sid_<10> (shouldn't exist today, but defensive) are left alone
+-- because the JOIN misses them.
+UPDATE resource_content_versions rcv
+SET resource_id = r.stable_id
+FROM resources r
+WHERE rcv.resource_id = r.id;
+
+-- Step 3: verify no non-null resource_id values remain that don't match a
+-- resources.stable_id. The pre-flight enumeration (QUA-549) found 0 orphans,
+-- but fail fast rather than silently nulling or letting ADD CONSTRAINT reject.
+DO $$
+DECLARE
+  orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*)
+  INTO orphan_count
+  FROM resource_content_versions rcv
+  WHERE rcv.resource_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM resources r WHERE r.stable_id = rcv.resource_id
+    );
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-549 migration aborted: % resource_content_versions row(s) have a resource_id that maps to neither resources.id nor resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;
+
+-- Step 4: add the new FK on resources.stable_id, preserving SET NULL.
+ALTER TABLE resource_content_versions
+  ADD CONSTRAINT resource_content_versions_resource_id_resources_stable_id_fk
+  FOREIGN KEY (resource_id) REFERENCES resources(stable_id)
+  ON DELETE SET NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1303,6 +1303,13 @@
       "when": 1785398400001,
       "tag": "0185_backfill_agent_sessions_date",
       "breakpoints": true
+    },
+    {
+      "idx": 186,
+      "version": "7",
+      "when": 1785657600000,
+      "tag": "0186_qua_549_rcv_resource_id_to_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { mockDbModule, postJson } from "./test-utils.js";
 import type { citationQuotes, citationAccuracySnapshots, citationContent, resourceContentVersions } from "../schema.js";
+import { isSid } from "@longterm-wiki/id-utils";
 
 // ---- In-memory stores simulating Postgres tables ----
 // Store types are derived from the Drizzle schema so TypeScript catches column renames.
@@ -1496,7 +1497,10 @@ describe("Citation Server API", () => {
 
     // QUA-549 Phase B: resource_content_versions.resource_id now references
     // resources.stable_id (sid_<10>), not resources.id (hex16). Callers must
-    // pass the sid_. This test locks in that the field round-trips verbatim.
+    // pass the sid_ — the FK enforces this in prod; this test locks in that
+    // the server round-trips sid_ values verbatim and asserts the stored
+    // value is a sid_ (via isSid) so a caller-side regression back to hex16
+    // would fail the assertion even though the mock DB doesn't enforce FK.
     it("persists the caller-provided resourceId (sid_) verbatim on the content version row", async () => {
       const initialCount = contentVersionStore.length;
       await postJson(app, "/api/citations/content/upsert", {
@@ -1510,6 +1514,7 @@ describe("Citation Server API", () => {
       const latest = contentVersionStore[contentVersionStore.length - 1];
       expect(latest.url).toBe("https://example.com/with-resource");
       expect(latest.resourceId).toBe("sid_AbCdEfGhIj");
+      expect(latest.resourceId && isSid(latest.resourceId)).toBe(true);
     });
   });
 });

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -1493,5 +1493,23 @@ describe("Citation Server API", () => {
       // No version should be created (no hash, no text to compute hash from)
       expect(contentVersionStore.length).toBe(initialCount);
     });
+
+    // QUA-549 Phase B: resource_content_versions.resource_id now references
+    // resources.stable_id (sid_<10>), not resources.id (hex16). Callers must
+    // pass the sid_. This test locks in that the field round-trips verbatim.
+    it("persists the caller-provided resourceId (sid_) verbatim on the content version row", async () => {
+      const initialCount = contentVersionStore.length;
+      await postJson(app, "/api/citations/content/upsert", {
+        url: "https://example.com/with-resource",
+        resourceId: "sid_AbCdEfGhIj",
+        fetchedAt: "2025-01-01T00:00:00Z",
+        fullText: "Body for resource link",
+        contentHash: "rcvsidhash",
+      });
+      expect(contentVersionStore.length).toBe(initialCount + 1);
+      const latest = contentVersionStore[contentVersionStore.length - 1];
+      expect(latest.url).toBe("https://example.com/with-resource");
+      expect(latest.resourceId).toBe("sid_AbCdEfGhIj");
+    });
   });
 });

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -224,7 +224,7 @@ export const resourceContentVersions = pgTable(
   "resource_content_versions",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    resourceId: text("resource_id").references(() => resources.id, {
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     url: text("url").notNull(),

--- a/crux/resource-enrichment/fetch-wayback.ts
+++ b/crux/resource-enrichment/fetch-wayback.ts
@@ -126,7 +126,9 @@ export async function fetchWaybackCommand(
       try {
         await upsertCitationContent({
           url: r.url,
-          resourceId: r.id,
+          // QUA-549 Phase B: resource_content_versions.resource_id now
+          // references resources.stable_id; pass the sid_, not the hex16 id.
+          resourceId: r.stable_id ?? null,
           fetchedAt: new Date().toISOString(),
           httpStatus: 200,
           contentType: result.contentType,


### PR DESCRIPTION
## Summary

QUA-549 Phase B **pilot** — first of 17 FK tables migrated from referencing `resources.id` (legacy hex16) to `resources.stable_id` (canonical `sid_<10>`). This PR ships one table end-to-end to lock in the pattern; the remaining 16 follow in independent PRs per the ticket's 1–2 week estimate.

**Table migrated**: `resource_content_versions` (52 prod rows, `ON DELETE SET NULL`, nullable column — chosen as smallest table with a real write path and a single caller).

## Changes

- **`drizzle/0186`** — in-place FK swap following the `0083_facts_entity_id_to_stable_id.sql` precedent:
  1. `DROP CONSTRAINT IF EXISTS` (old `_resources_id_fk`)
  2. `UPDATE` to rewrite hex16 → sid_ via `JOIN resources ON rcv.resource_id = r.id`
  3. `DO` block raises if unexpected orphans appear at apply time (pre-flight enumeration found 0 orphans, but fail fast rather than silently)
  4. `ADD CONSTRAINT` pointing at `resources.stable_id`, preserving `ON DELETE SET NULL` (delete semantics are explicitly out of scope per ticket non-goals)
  5. Reverse migration documented in the file header
- **`schema.ts`** — `resourceContentVersions.resourceId` now `.references(() => resources.stableId, ...)`
- **`fetch-wayback.ts`** — the only real caller populating this column; passes `r.stable_id ?? null` (was `r.id`)
- **`citations.test.ts`** — regression test that locks in the sid_ round-trip on `/content/upsert`

## Why this is a single-table pilot, not a 17-table batch

Per QUA-549: "17 schema migrations touching ~21,631 rows across the whole citation/sourcing graph … every one needs its own rollback plan." Each table is independently shippable because the swap is scoped to one column and one (or zero) write sites. Shipping in sequence keeps PRs small, reviewable, and revertible; a 17-table batch would be unreviewable and any one bug would block the whole set.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 6670 tests pass (added 1 regression test on `/content/upsert` sid_ round-trip)
- [x] `pnpm crux w validate gate --fix` — 46 checks pass, no new advisories
- [x] `npx tsc --noEmit` across `apps/wiki-server`, `apps/web`, `crux` — no new errors (crux has pre-existing unrelated errors on `playwright-fetcher`, `political-data.test`, etc.)
- [x] `/agent-review-pr` — clean (1 review finding, fixed — Resource type uses snake_case `stable_id`, not `stableId`)
- [x] Grepped every `resource_content_versions` / `resourceContentVersions` reference; no read sites expose the column externally, no MV/view references, no build-data or client-side references.
- [x] Migration idempotency verified by construction: `DROP ... IF EXISTS`; `UPDATE` no-ops after first run because `rcv.resource_id` is now sid_ and won't match `r.id` (hex16); Drizzle's migration tracker prevents re-application in normal flow.

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0186 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` Confirm the new FK is in place on prod — `psql "$DATABASE_URL" -c "\d resource_content_versions" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE SET NULL`
- [ ] `manual` Spot-check that `resource_id` values post-migration are sid_'s, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM resource_content_versions WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_`
<!-- /deploy-tasks -->

## Follow-ups (remaining 16 tables)

Tracked by QUA-549 itself — each remaining table (listed in the ticket's pre-flight enumeration table) can reuse this migration template:

- Small/empty tables (0–150 rows): `resource_policy_docs`, `publications`, `bluesky_posts`, `proposed_claims`, `resource_tabular_sources`, `source_snapshots`, `research_area_papers`, `page_citations`, `citation_quotes`
- Mid-size (400–6k rows): `resource_papers`, `resource_forum_posts`, `resource_citations`, `entity_resources`, `source_check_evidence`

Each subsequent PR should: swap `.references()` in `schema.ts`, add a matching migration following this template, update caller(s) that populate the column, and add a regression test.

Fixes QUA-549


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal resource reference schema for improved data consistency. No changes to user-facing functionality or existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->