### PR TITLE
feat(tb): field-gap scanner for YAML entity catalogs (QUA-571)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -124,10 +124,7 @@ async function scanCommand(_args: string[], options: CommandOptions): Promise<Co
       );
     }
 
-    // YAML catalogs (concepts, risks, capabilities) have no per-entity PG
-    // scan — field-gap is the only meaningful scan for them. Skip runTableScan
-    // (which would return null and fail out) and emit the field-gap report
-    // directly. QUA-571.
+    // YAML catalogs only support --fields (no per-entity PG scan).
     if (isYamlCatalog) {
       if (!wantsFields) {
         return {

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -96,7 +96,7 @@ async function persistScanResults(scan: import('../tablebase/types.ts').ScanSumm
 }
 
 async function scanCommand(_args: string[], options: CommandOptions): Promise<CommandResult> {
-  const { runFullScan, runTableScan, runFieldGapScan, FIELD_GAP_TABLES } = await import('../tablebase/scanner.ts');
+  const { runFullScan, runTableScan, runFieldGapScan, FIELD_GAP_TABLES, YAML_CATALOG_TABLES } = await import('../tablebase/scanner.ts');
   const { formatScanSummary, formatFieldGapReports } = await import('../tablebase/reporter.ts');
   type FieldGapReport = import('../tablebase/types.ts').FieldGapReport;
 
@@ -114,19 +114,40 @@ async function scanCommand(_args: string[], options: CommandOptions): Promise<Co
   }
 
   if (options.table) {
-    const wantsFields = options.fields && FIELD_GAP_TABLES.includes(options.table as string);
+    const tableName = options.table as string;
+    const isYamlCatalog = YAML_CATALOG_TABLES.includes(tableName);
+    const wantsFields = options.fields && FIELD_GAP_TABLES.includes(tableName);
     if (options.fields && !wantsFields) {
       console.warn(
-        `[tablebase] --fields not supported for table '${options.table}'; ` +
+        `[tablebase] --fields not supported for table '${tableName}'; ` +
         `supported: ${FIELD_GAP_TABLES.join(', ')}`,
       );
     }
+
+    // YAML catalogs (concepts, risks, capabilities) have no per-entity PG
+    // scan — field-gap is the only meaningful scan for them. Skip runTableScan
+    // (which would return null and fail out) and emit the field-gap report
+    // directly. QUA-571.
+    if (isYamlCatalog) {
+      if (!wantsFields) {
+        return {
+          exitCode: 1,
+          output: `YAML catalog '${tableName}' supports --fields only. Re-run with --fields.`,
+        };
+      }
+      const fieldReports = await runFieldGapScan([tableName]);
+      if (options.ci) {
+        return { exitCode: 0, output: JSON.stringify({ fieldReports, timestamp: new Date().toISOString() }, null, 2) };
+      }
+      return { exitCode: 0, output: formatFieldGapReports(fieldReports, { top: topN }) };
+    }
+
     const [result, fieldReports] = await Promise.all([
-      runTableScan(options.table as string),
-      wantsFields ? runFieldGapScan([options.table as string]) : Promise.resolve(undefined),
+      runTableScan(tableName),
+      wantsFields ? runFieldGapScan([tableName]) : Promise.resolve(undefined),
     ]);
     if (!result) {
-      return { exitCode: 1, output: `Unknown table: ${options.table}` };
+      return { exitCode: 1, output: `Unknown table: ${tableName}` };
     }
 
     if (options.ci) {

--- a/crux/tablebase/__fixtures__/yaml-catalog-corrupt.yaml
+++ b/crux/tablebase/__fixtures__/yaml-catalog-corrupt.yaml
@@ -1,0 +1,6 @@
+# Intentionally malformed YAML used by scanner.test.ts to exercise the
+# loadYamlCatalogRows parse-error branch. Do not "fix" the syntax here.
+- id: unterminated-flow-list
+  broken: [one, two, three
+- id: another-entry
+  title: never reached

--- a/crux/tablebase/__fixtures__/yaml-catalog-mixed.yaml
+++ b/crux/tablebase/__fixtures__/yaml-catalog-mixed.yaml
@@ -1,0 +1,12 @@
+# Mixed-validity catalog entries. Used by scanner.test.ts to confirm
+# loadYamlCatalogRows keeps only entries whose `id` is a non-empty string.
+- id: valid-a
+  title: A
+- title: missing-id
+- id: 42
+  title: numeric-id
+- not-an-object
+- id: ''
+  title: empty-id
+- id: valid-b
+  title: B

--- a/crux/tablebase/__fixtures__/yaml-catalog-object.yaml
+++ b/crux/tablebase/__fixtures__/yaml-catalog-object.yaml
@@ -1,0 +1,4 @@
+# Top-level is a map rather than a list. Used by scanner.test.ts to
+# exercise the loadYamlCatalogRows "expected top-level list" branch.
+some: object
+not: a-list

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -474,7 +474,40 @@ describe('scanner — YAML entity catalog support (QUA-571)', () => {
     warnSpy.mockRestore();
   });
 
-  it('runFieldGapScan: profiles concepts.yaml, flags sources as a 100% gap', async () => {
+  it('loadYamlCatalogRows: returns [] (with warning) on malformed YAML', async () => {
+    const { loadYamlCatalogRows } = await import('./scanner.ts');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = loadYamlCatalogRows('crux/tablebase/__fixtures__/yaml-catalog-corrupt.yaml');
+    expect(rows).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to parse'));
+    warnSpy.mockRestore();
+  });
+
+  it('loadYamlCatalogRows: returns [] (with warning) when top-level is not a list', async () => {
+    const { loadYamlCatalogRows } = await import('./scanner.ts');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = loadYamlCatalogRows('crux/tablebase/__fixtures__/yaml-catalog-object.yaml');
+    expect(rows).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('expected top-level list'));
+    warnSpy.mockRestore();
+  });
+
+  it('loadYamlCatalogRows: skips entries without a non-empty string id', async () => {
+    const { loadYamlCatalogRows } = await import('./scanner.ts');
+    const rows = loadYamlCatalogRows('crux/tablebase/__fixtures__/yaml-catalog-mixed.yaml');
+    // Fixture has 6 entries: valid-a, missing-id, numeric-id (42), not-an-object,
+    // empty-id (''), valid-b. Only valid-a and valid-b survive.
+    expect(rows.map((r) => r.id)).toEqual(['valid-a', 'valid-b']);
+  });
+
+  it('runFieldGapScan: profiles concepts.yaml and returns the expected field shape', async () => {
+    // Integration-style: reads the real data/entities/concepts.yaml so the
+    // test also exercises the YAML parse + loadYamlCatalogRows path end-to-end.
+    // Deliberately avoids absolute % assertions (e.g. "sources is 100% gap")
+    // because the follow-up PR (QUA-571 Phase 2) populates `sources` and the
+    // test should stay green as enrichment happens — it's profiling behavior,
+    // not gap state. Exact-value assertions are covered by the fixture-based
+    // profileFields test below.
     const { runFieldGapScan } = await import('./scanner.ts');
     const reports = await runFieldGapScan(['concepts']);
     expect(reports.length).toBe(1);
@@ -485,15 +518,17 @@ describe('scanner — YAML entity catalog support (QUA-571)', () => {
     const sources = report.fields.find((f) => f.field === 'sources');
     expect(sources).toBeDefined();
     expect(sources!.columnType).toBe('list');
-    // No YAML entity currently populates `sources`, so every row is a null gap.
-    expect(sources!.gapPct).toBe(100);
-    expect(sources!.nullPct).toBe(100);
+    // Must have at least some rows profiled — a 0-row report would mean the
+    // YAML loader silently returned [].
+    expect(sources!.total).toBe(report.totalRows);
 
     const rel = report.fields.find((f) => f.field === 'relatedEntries');
     expect(rel).toBeDefined();
-    // Partial coverage — don't hardcode the exact %, but require > 0 and < 100.
-    expect(rel!.gapPct).toBeGreaterThan(0);
-    expect(rel!.gapPct).toBeLessThan(100);
+    expect(rel!.columnType).toBe('list');
+
+    const desc = report.fields.find((f) => f.field === 'description');
+    expect(desc).toBeDefined();
+    expect(desc!.columnType).toBe('string');
   });
 
   it('profileFields: classifies empty arrays as "empty", populated arrays as "filled"', async () => {

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -354,7 +354,7 @@ describe('scanner — field-gap profiler (QUA-551)', () => {
     });
 
     const reports = await runFieldGapScan();
-    // 4 PG tables (QUA-551) + 3 YAML catalogs (QUA-571) = 7 reports.
+    // 4 PG tables + 3 YAML catalogs = 7 reports.
     expect(reports.length).toBe(7);
     const byTable = Object.fromEntries(reports.map(r => [r.table, r]));
     expect(byTable.divisions.totalRows).toBe(2);

--- a/crux/tablebase/scanner.test.ts
+++ b/crux/tablebase/scanner.test.ts
@@ -354,7 +354,8 @@ describe('scanner — field-gap profiler (QUA-551)', () => {
     });
 
     const reports = await runFieldGapScan();
-    expect(reports.length).toBe(4);
+    // 4 PG tables (QUA-551) + 3 YAML catalogs (QUA-571) = 7 reports.
+    expect(reports.length).toBe(7);
     const byTable = Object.fromEntries(reports.map(r => [r.table, r]));
     expect(byTable.divisions.totalRows).toBe(2);
     expect(byTable.division_personnel.totalRows).toBe(1);
@@ -434,5 +435,81 @@ describe('scanner — field-gap profiler (QUA-551)', () => {
       expect(f.nullPct).toBe(100);
       expect(f.gapPct).toBe(100);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QUA-571: YAML entity catalog support (concepts, risks, capabilities)
+// ---------------------------------------------------------------------------
+
+describe('scanner — YAML entity catalog support (QUA-571)', () => {
+  it('YAML_CATALOG_TABLES exposes the supported catalog names', async () => {
+    const { YAML_CATALOG_TABLES } = await import('./scanner.ts');
+    expect(YAML_CATALOG_TABLES).toEqual(expect.arrayContaining(['concepts', 'risks', 'capabilities']));
+  });
+
+  it('YAML catalog tables are merged into FIELD_GAP_TABLES so runFieldGapScan picks them up', async () => {
+    const { FIELD_GAP_TABLES } = await import('./scanner.ts');
+    expect(FIELD_GAP_TABLES).toEqual(expect.arrayContaining(['concepts', 'risks', 'capabilities']));
+    // Legacy PG tables still present — merge, not replace.
+    expect(FIELD_GAP_TABLES).toEqual(expect.arrayContaining(['divisions', 'funding_programs']));
+  });
+
+  it('loadYamlCatalogRows: returns rows with an `id` field, skips entries without one', async () => {
+    const { loadYamlCatalogRows } = await import('./scanner.ts');
+    const rows = loadYamlCatalogRows('data/entities/concepts.yaml');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(typeof row.id).toBe('string');
+      expect(row.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('loadYamlCatalogRows: returns [] (with warning) when the file is missing', async () => {
+    const { loadYamlCatalogRows } = await import('./scanner.ts');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = loadYamlCatalogRows('data/entities/does-not-exist.yaml');
+    expect(rows).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('YAML catalog file not found'));
+    warnSpy.mockRestore();
+  });
+
+  it('runFieldGapScan: profiles concepts.yaml, flags sources as a 100% gap', async () => {
+    const { runFieldGapScan } = await import('./scanner.ts');
+    const reports = await runFieldGapScan(['concepts']);
+    expect(reports.length).toBe(1);
+    const report = reports[0];
+    expect(report.table).toBe('concepts');
+    expect(report.totalRows).toBeGreaterThan(0);
+
+    const sources = report.fields.find((f) => f.field === 'sources');
+    expect(sources).toBeDefined();
+    expect(sources!.columnType).toBe('list');
+    // No YAML entity currently populates `sources`, so every row is a null gap.
+    expect(sources!.gapPct).toBe(100);
+    expect(sources!.nullPct).toBe(100);
+
+    const rel = report.fields.find((f) => f.field === 'relatedEntries');
+    expect(rel).toBeDefined();
+    // Partial coverage — don't hardcode the exact %, but require > 0 and < 100.
+    expect(rel!.gapPct).toBeGreaterThan(0);
+    expect(rel!.gapPct).toBeLessThan(100);
+  });
+
+  it('profileFields: classifies empty arrays as "empty", populated arrays as "filled"', async () => {
+    const { profileFields } = await import('./scanner.ts');
+    const rows = [
+      { id: 'a', sources: [] },
+      { id: 'b', sources: [{ url: 'https://example.com' }] },
+      { id: 'c', sources: null },
+      { id: 'd' }, // undefined
+    ];
+    const report = profileFields('test', rows, [{ field: 'sources', columnType: 'list' }]);
+    const sources = report.fields[0];
+    expect(sources.total).toBe(4);
+    expect(sources.nullCount).toBe(2); // null + undefined
+    expect(sources.emptyCount).toBe(1); // []
+    // 1 of 4 is filled → gap = 75%.
+    expect(sources.gapPct).toBe(75);
   });
 });

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import type { TableProfile, TableScanResult, ScanSummary, FieldGapStat, FieldGapReport, FieldColumnType } from './types.ts';
@@ -879,6 +880,54 @@ const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
   ],
 };
 
+// ---------------------------------------------------------------------------
+// YAML entity catalogs (concepts, risks, capabilities, ...)
+//
+// Unlike the PG-backed tables above, these live in data/entities/*.yaml and
+// are loaded directly from disk. The field-gap scan treats each row the same
+// way regardless of source. Added by QUA-571 to unblock the YAML-catalog
+// enrichment thread (QUA-23, and analogous risk/capability tickets).
+// ---------------------------------------------------------------------------
+
+interface YamlCatalogConfig {
+  /** Path relative to PROJECT_ROOT. */
+  file: string;
+  fields: FieldConfig[];
+}
+
+const YAML_CATALOG_CONFIGS: Record<string, YamlCatalogConfig> = {
+  concepts: {
+    file: 'data/entities/concepts.yaml',
+    fields: [
+      { field: 'sources', columnType: 'list' },
+      { field: 'relatedEntries', columnType: 'list' },
+      { field: 'description', columnType: 'string' },
+    ],
+  },
+  risks: {
+    file: 'data/entities/risks.yaml',
+    fields: [
+      { field: 'sources', columnType: 'list' },
+      { field: 'relatedEntries', columnType: 'list' },
+      { field: 'description', columnType: 'string' },
+    ],
+  },
+  capabilities: {
+    file: 'data/entities/capabilities.yaml',
+    fields: [
+      { field: 'sources', columnType: 'list' },
+      { field: 'relatedEntries', columnType: 'list' },
+      { field: 'description', columnType: 'string' },
+    ],
+  },
+};
+
+export const YAML_CATALOG_TABLES = Object.keys(YAML_CATALOG_CONFIGS);
+
+for (const [name, config] of Object.entries(YAML_CATALOG_CONFIGS)) {
+  FIELD_GAP_CONFIGS[name] = config.fields;
+}
+
 // Require the slash so legitimate 2-letter codes like "NA" (Namibia ISO-3166,
 // "Native American" category) don't get flagged as gaps. "n/a" with the slash
 // is the conventional not-available marker.
@@ -893,6 +942,9 @@ function classifyValue(value: unknown): FieldValueClass {
     if (trimmed.length === 0) return 'empty';
     if (NA_PATTERN.test(trimmed)) return 'na';
     return 'filled';
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? 'empty' : 'filled';
   }
   // Numeric 0 / boolean false are valid, not gaps.
   return 'filled';
@@ -954,6 +1006,10 @@ export function profileFields<T extends { id: string }>(
 type RawRow = Record<string, unknown> & { id: string };
 
 async function fetchTableRows(table: string): Promise<RawRow[]> {
+  const yamlConfig = YAML_CATALOG_CONFIGS[table];
+  if (yamlConfig) {
+    return loadYamlCatalogRows(yamlConfig.file);
+  }
   switch (table) {
     case 'divisions':
       return fetchAllPaginated<RawRow>('/api/divisions/all', 'divisions');
@@ -966,6 +1022,40 @@ async function fetchTableRows(table: string): Promise<RawRow[]> {
     default:
       return [];
   }
+}
+
+/**
+ * Load rows from a YAML entity catalog file (e.g. data/entities/concepts.yaml).
+ * Returns [] with a warning if the file is missing or malformed so a broken
+ * YAML file can't silently break the whole scan. Rows missing an `id` are
+ * skipped — profileFields<T extends { id: string }> requires one.
+ */
+export function loadYamlCatalogRows(relativePath: string): RawRow[] {
+  const fullPath = join(PROJECT_ROOT, relativePath);
+  if (!existsSync(fullPath)) {
+    console.warn(`[tablebase scanner] YAML catalog file not found: ${relativePath}`);
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(readFileSync(fullPath, 'utf-8'));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[tablebase scanner] failed to parse ${relativePath}: ${msg}`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    console.warn(`[tablebase scanner] expected top-level list in ${relativePath}, got ${typeof parsed}`);
+    return [];
+  }
+  const rows: RawRow[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id !== 'string' || id.length === 0) continue;
+    rows.push({ ...(entry as Record<string, unknown>), id });
+  }
+  return rows;
 }
 
 /** List of tables covered by the field-gap scan. */

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -881,14 +881,7 @@ const PG_FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
   ],
 };
 
-// ---------------------------------------------------------------------------
-// YAML entity catalogs (concepts, risks, capabilities, ...)
-//
-// Unlike the PG-backed tables above, these live in data/entities/*.yaml and
-// are loaded directly from disk. The field-gap scan treats each row the same
-// way regardless of source. Added by QUA-571 to unblock the YAML-catalog
-// enrichment thread (QUA-23, and analogous risk/capability tickets).
-// ---------------------------------------------------------------------------
+// YAML entity catalogs — loaded from data/entities/*.yaml (no PG backing).
 
 interface YamlCatalogConfig {
   /** Path relative to PROJECT_ROOT. */
@@ -896,41 +889,22 @@ interface YamlCatalogConfig {
   fields: FieldConfig[];
 }
 
+// Shape-universal fields present on every entity YAML — will gain new fields
+// for all catalogs simultaneously, so extracted rather than repeated per-type.
+const YAML_CATALOG_DEFAULT_FIELDS: FieldConfig[] = [
+  { field: 'sources', columnType: 'list' },
+  { field: 'relatedEntries', columnType: 'list' },
+  { field: 'description', columnType: 'string' },
+];
+
 const YAML_CATALOG_CONFIGS: Record<string, YamlCatalogConfig> = {
-  concepts: {
-    file: 'data/entities/concepts.yaml',
-    fields: [
-      { field: 'sources', columnType: 'list' },
-      { field: 'relatedEntries', columnType: 'list' },
-      { field: 'description', columnType: 'string' },
-    ],
-  },
-  risks: {
-    file: 'data/entities/risks.yaml',
-    fields: [
-      { field: 'sources', columnType: 'list' },
-      { field: 'relatedEntries', columnType: 'list' },
-      { field: 'description', columnType: 'string' },
-    ],
-  },
-  capabilities: {
-    file: 'data/entities/capabilities.yaml',
-    fields: [
-      { field: 'sources', columnType: 'list' },
-      { field: 'relatedEntries', columnType: 'list' },
-      { field: 'description', columnType: 'string' },
-    ],
-  },
+  concepts:     { file: 'data/entities/concepts.yaml',     fields: YAML_CATALOG_DEFAULT_FIELDS },
+  risks:        { file: 'data/entities/risks.yaml',        fields: YAML_CATALOG_DEFAULT_FIELDS },
+  capabilities: { file: 'data/entities/capabilities.yaml', fields: YAML_CATALOG_DEFAULT_FIELDS },
 };
 
 export const YAML_CATALOG_TABLES = Object.keys(YAML_CATALOG_CONFIGS);
 
-/**
- * Unified field-gap config map — PG tables + YAML catalogs. Assembled once
- * here, so `FIELD_GAP_TABLES` below sees the full set. No runtime mutation;
- * the resulting object shape is a function of the two config declarations
- * above, nothing more.
- */
 const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
   ...PG_FIELD_GAP_CONFIGS,
   ...Object.fromEntries(
@@ -1036,22 +1010,23 @@ async function fetchTableRows(table: string): Promise<RawRow[]> {
 
 /**
  * Load rows from a YAML entity catalog file (e.g. data/entities/concepts.yaml).
- * Returns [] with a warning if the file is missing or malformed so a broken
- * YAML file can't silently break the whole scan. Rows missing an `id` are
- * skipped — profileFields<T extends { id: string }> requires one.
+ * Returns [] with a warning on any failure (missing, malformed, wrong shape)
+ * so a broken file can't silently break the whole scan. Rows without a
+ * non-empty string `id` are skipped — profileFields<T extends { id: string }>
+ * requires one.
  */
 export function loadYamlCatalogRows(relativePath: string): RawRow[] {
   const fullPath = join(PROJECT_ROOT, relativePath);
-  if (!existsSync(fullPath)) {
-    console.warn(`[tablebase scanner] YAML catalog file not found: ${relativePath}`);
-    return [];
-  }
   let parsed: unknown;
   try {
     parsed = parseYaml(readFileSync(fullPath, 'utf-8'));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[tablebase scanner] failed to parse ${relativePath}: ${msg}`);
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      console.warn(`[tablebase scanner] YAML catalog file not found: ${relativePath}`);
+    } else {
+      console.warn(`[tablebase scanner] failed to parse ${relativePath}: ${msg}`);
+    }
     return [];
   }
   if (!Array.isArray(parsed)) {

--- a/crux/tablebase/scanner.ts
+++ b/crux/tablebase/scanner.ts
@@ -836,11 +836,12 @@ interface FieldConfig {
 }
 
 /**
- * Which fields to profile for each table. Excludes identity columns (id,
- * natural-key FKs, name) and timestamps — those are never "enrichable" gaps.
- * Derived from the wiki-server `formatRow` shapes in each tablebase route.
+ * Which fields to profile for each PG-backed table. Excludes identity columns
+ * (id, natural-key FKs, name) and timestamps — those are never "enrichable"
+ * gaps. Derived from the wiki-server `formatRow` shapes in each tablebase
+ * route.
  */
-const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
+const PG_FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
   divisions: [
     { field: 'divisionType', columnType: 'enum' },
     { field: 'lead', columnType: 'id' },
@@ -924,9 +925,18 @@ const YAML_CATALOG_CONFIGS: Record<string, YamlCatalogConfig> = {
 
 export const YAML_CATALOG_TABLES = Object.keys(YAML_CATALOG_CONFIGS);
 
-for (const [name, config] of Object.entries(YAML_CATALOG_CONFIGS)) {
-  FIELD_GAP_CONFIGS[name] = config.fields;
-}
+/**
+ * Unified field-gap config map — PG tables + YAML catalogs. Assembled once
+ * here, so `FIELD_GAP_TABLES` below sees the full set. No runtime mutation;
+ * the resulting object shape is a function of the two config declarations
+ * above, nothing more.
+ */
+const FIELD_GAP_CONFIGS: Record<string, FieldConfig[]> = {
+  ...PG_FIELD_GAP_CONFIGS,
+  ...Object.fromEntries(
+    Object.entries(YAML_CATALOG_CONFIGS).map(([name, config]) => [name, config.fields]),
+  ),
+};
 
 // Require the slash so legitimate 2-letter codes like "NA" (Namibia ISO-3166,
 // "Native American" category) don't get flagged as gaps. "n/a" with the slash
@@ -1053,6 +1063,8 @@ export function loadYamlCatalogRows(relativePath: string): RawRow[] {
     if (!entry || typeof entry !== 'object') continue;
     const id = (entry as { id?: unknown }).id;
     if (typeof id !== 'string' || id.length === 0) continue;
+    // `id` shorthand goes last so the narrowed string wins over the
+    // unknown-typed `id` from the spread.
     rows.push({ ...(entry as Record<string, unknown>), id });
   }
   return rows;

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -93,7 +93,7 @@ export interface TableScanResult {
   profiles: TableProfile[];
 }
 
-export type FieldColumnType = 'string' | 'number' | 'date' | 'url' | 'enum' | 'boolean' | 'id';
+export type FieldColumnType = 'string' | 'number' | 'date' | 'url' | 'enum' | 'boolean' | 'id' | 'list';
 
 /** Per-field NULL/empty/"n/a" statistics for a single column */
 export interface FieldGapStat {


### PR DESCRIPTION
## Summary

Extends `crux tb tablebase scan --fields` to cover three YAML entity catalogs — `concepts`, `risks`, `capabilities` — so field-gap profiling works uniformly across PG tables and YAML entity sources.

## Why

QUA-551 + QUA-552 landed field-gap plumbing for PG-backed tables only (`divisions`, `division_personnel`, `funding_programs`, `benchmark_results`). YAML catalogs in `data/entities/*.yaml` were the other half of the enrichment thread (QUA-23 concepts; analogous risk/capability tickets). Before this PR, `scan --fields --table=concepts` errored out: `--fields not supported for table 'concepts'`.

This is **Phase 1 of 2** — scanner visibility only. Phase 2 (write path for `improve --target-field` + concept research playbook) follows in a separate PR so the LLM→YAML write mechanism is reviewable on its own merits.

## What changed

- **`crux/tablebase/types.ts`** — add `'list'` to `FieldColumnType`.
- **`crux/tablebase/scanner.ts`**
  - `YAML_CATALOG_CONFIGS` registers concepts/risks/capabilities with a shared `YAML_CATALOG_DEFAULT_FIELDS` list (`sources`, `relatedEntries`, `description`).
  - `FIELD_GAP_CONFIGS` is now assembled as a single spread of `PG_FIELD_GAP_CONFIGS` + YAML configs — no runtime mutation.
  - New `loadYamlCatalogRows(relativePath)` — fail-soft reader that returns `[]` with a warning on missing / malformed / wrong-shape files, skips entries without a non-empty string `id`. One catch handles both ENOENT and parse errors (no TOCTOU existsSync check).
  - `classifyValue()` now treats `[]` as `'empty'` and populated arrays as `'filled'` (previously all non-string non-null values got classified as `'filled'`, which misclassified `sources: []`).
- **`crux/commands/tablebase.ts`** — new branch for YAML catalogs in the `--table=X --fields` path. Skips `runTableScan()` (PG-only) and emits the field-gap report directly. `--table=X` without `--fields` on a YAML catalog returns a clear error.

## Ground-truth baseline (context for Phase 2)

```
concepts     (58 rows):  sources 100% gap, relatedEntries 43.1% gap
risks        (67 rows):  sources 100% gap, relatedEntries 28.4% gap
capabilities (24 rows):  sources 100% gap, relatedEntries 54.2% gap
```

The QUA-23 ticket body's claim that "9.4% of concepts have sources (5/53)" was stale as of 2026-04-17 — across all three catalogs, **zero** entities populate `sources` today. Phase 2 is where that changes.

## Test plan

- [x] `pnpm vitest run crux/tablebase/` — 142/142 pass (includes 8 new scanner tests)
- [x] `pnpm test` — 6735 pass, 26 skipped
- [x] `pnpm build` — exits 0
- [x] `pnpm crux w validate gate --no-cache` — 42/42 blocking checks pass (2 pre-existing advisory warnings)
- [x] CLI smoke: `scan --fields --table=concepts` / `--table=risks` / `--table=capabilities` / `--fields` (full) / `--ci` JSON output
- [x] CLI error paths: `--table=concepts` without `--fields` → clear error; `--table=unknown` → unknown-table error
- [x] Reviewed via `/agent-review-pr` — 3 MEDIUM findings addressed (module-level mutation, data-coupled test, missing parse-error/non-array test coverage)
- [x] Simplified via `/simplify` — DRY default-fields, trim change-narration comments, drop TOCTOU existsSync

## Follow-up

Phase 2 PR (to be filed after merge) extends `crux tb tablebase improve` to accept `--target-field=concepts.sources` etc., adds a concept research playbook (QUA-33 pattern), and adds a surgical YAML writer that preserves formatting (precedent: `crux/commands/backfill-yaml-stable-ids.ts`). Once that ships, QUA-23 becomes truly execution-only.

Fixes QUA-571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
