### PR TITLE
fix(entity-profile): resolve SIDs in Related Entries section

### DIFF
--- a/apps/web/e2e/no-raw-ids.spec.ts
+++ b/apps/web/e2e/no-raw-ids.spec.ts
@@ -306,6 +306,39 @@ test.describe("Project & event pages — no raw IDs", () => {
 });
 
 /**
+ * Expand any collapsed sections inside main.
+ * EntityProfileViewer collapses Related Entries, Entity Properties, Custom
+ * Fields, and table sections by default; their contents must be in the DOM
+ * for the raw-ID scan to see them.
+ *
+ * Matches `aria-expanded="false"` buttons (post-rollout) AND buttons whose
+ * text begins with a known collapsible section name (pre-rollout / defense
+ * against HTML missing aria attributes).
+ */
+async function expandCollapsedSections(page: Page) {
+  // Click by aria attribute (post-rollout canonical path)
+  const ariaCollapsed = page.locator("main button[aria-expanded='false']");
+  const ariaCount = await ariaCollapsed.count();
+  for (let i = 0; i < ariaCount; i++) {
+    const btn = ariaCollapsed.nth(i);
+    if (await btn.isVisible()) await btn.click();
+  }
+
+  // Fallback: click by title text (catches pre-rollout HTML without aria).
+  const titles = ["Related Entries", "Entity Properties", "Custom Fields"];
+  for (const title of titles) {
+    const btn = page.locator(`main button:has-text("${title}")`).first();
+    if ((await btn.count()) > 0 && (await btn.isVisible())) {
+      // Only click if not already expanded (detect via visible ChevronDown vs ChevronRight:
+      // simpler — just click; a second click would collapse, so gate on aria if set)
+      const aria = await btn.getAttribute("aria-expanded");
+      if (aria !== "true") await btn.click();
+    }
+  }
+  await page.waitForTimeout(200);
+}
+
+/**
  * Helper for pages that require wiki-server data.
  *
  * Separates page loading (which may fail without wiki-server) from ID
@@ -323,8 +356,13 @@ async function assertNoRawIdsRequiresServer(page: Page, url: string, withTabs = 
   // Page loaded — assertions must NOT be swallowed
   if (withTabs) {
     const { text, tabCount } = await collectTextAcrossTabs(page);
-    checkTextForRawIds(text, url, `across ${tabCount} tabs`);
+    // Also expand collapsed sections within the current tab and re-scan —
+    // catches raw IDs hidden inside collapsed Related Entries / metadata.
+    await expandCollapsedSections(page);
+    const expandedText = await getMainText(page);
+    checkTextForRawIds(text + "\n" + expandedText, url, `across ${tabCount} tabs`);
   } else {
+    await expandCollapsedSections(page);
     const text = await getMainText(page);
     checkTextForRawIds(text, url);
   }

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -940,7 +940,13 @@ function EmptyState({ onSearch }: { onSearch: (q: string) => void }) {
 // ── Entity JSONB data sections ────────────────────────────────────────────
 
 /** Render structured entity data from JSONB columns (metadata, customFields, etc.) */
-function EntityDataSections({ entity }: { entity: Record<string, unknown> }) {
+function EntityDataSections({
+  entity,
+  displayNames,
+}: {
+  entity: Record<string, unknown>;
+  displayNames?: Record<string, DisplayNameEntry>;
+}) {
   const metadata = (entity.metadata && typeof entity.metadata === "object" && !Array.isArray(entity.metadata))
     ? entity.metadata as Record<string, unknown>
     : null;
@@ -979,16 +985,96 @@ function EntityDataSections({ entity }: { entity: Record<string, unknown> }) {
         />
       )}
 
-      {/* Related entries */}
+      {/* Related entries — SID ids resolve to human names via displayNames. */}
       {relatedEntries && relatedEntries.length > 0 && (
-        <CollapsibleTableSection
-          title="Related Entries"
-          description="Cross-references to other entities"
-          headers={["Entity ID", "Type", "Relationship"]}
-          rows={relatedEntries.map((r) => [r.id, r.type, r.relationship ?? ""])}
-        />
+        <RelatedEntriesSection entries={relatedEntries} displayNames={displayNames} />
       )}
 
+    </div>
+  );
+}
+
+/** Related-entries table — resolves sid_ ids through the displayNames map. */
+function RelatedEntriesSection({
+  entries,
+  displayNames,
+}: {
+  entries: Array<{ id: string; type: string; relationship?: string }>;
+  displayNames?: Record<string, DisplayNameEntry>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-muted/30 transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <span className="text-sm font-medium">Related Entries</span>
+        <span className="text-[11px] font-mono text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded">
+          {entries.length}
+        </span>
+        <span className="text-[11px] text-muted-foreground/60 ml-auto">Cross-references to other entities</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-border/30 overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="bg-muted/20">
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground text-[11px]">Entity</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground text-[11px]">Type</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground text-[11px]">Relationship</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((r, i) => {
+                const resolved = isAnySid(r.id) ? displayNames?.[r.id] : undefined;
+                return (
+                  <tr key={i} className="border-t border-border/20">
+                    <td className="px-3 py-1.5 text-foreground/80 max-w-xs truncate">
+                      {resolved ? (
+                        <EntityRefHoverCard entry={resolved} stableId={r.id}>
+                          <Link
+                            href={entityHref(resolved)}
+                            className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
+                          >
+                            {resolved.title}
+                          </Link>
+                        </EntityRefHoverCard>
+                      ) : isAnySid(r.id) ? (
+                        <Link
+                          href={`/wiki/E1929?entity=${encodeURIComponent(r.id)}`}
+                          className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline font-mono text-[11px]"
+                          title="View entity DB profile"
+                        >
+                          {r.id}
+                          <ExternalLink className="h-2.5 w-2.5 opacity-40" />
+                        </Link>
+                      ) : (
+                        <Link
+                          href={`/wiki/E1929?entity=${encodeURIComponent(r.id)}`}
+                          className="text-blue-600 dark:text-blue-400 hover:underline text-xs"
+                        >
+                          {r.id}
+                        </Link>
+                      )}
+                    </td>
+                    <td className="px-3 py-1.5 text-foreground/80 max-w-xs truncate">{r.type}</td>
+                    <td className="px-3 py-1.5 text-foreground/80 max-w-xs truncate">
+                      {r.relationship || <span className="text-muted-foreground/20">&mdash;</span>}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -1011,6 +1097,7 @@ function CollapsibleJsonSection({
     <div className="rounded-lg border border-border/50 overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
         className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-muted/30 transition-colors"
       >
         {expanded ? (
@@ -1076,6 +1163,7 @@ function CollapsibleTableSection({
     <div className="rounded-lg border border-border/50 overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
         className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-muted/30 transition-colors"
       >
         {expanded ? (
@@ -1325,7 +1413,7 @@ export function EntityProfileViewer({
           </div>
 
           {/* Entity JSONB fields (metadata, customFields, relatedEntries) */}
-          <EntityDataSections entity={data.entity} />
+          <EntityDataSections entity={data.entity} displayNames={data.displayNames} />
 
           <div className="space-y-2">
             {SECTION_GROUPS.map((group) => {

--- a/apps/wiki-server/src/routes/tablebase/entity-profile.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile.ts
@@ -422,6 +422,21 @@ const entityProfileApp = new Hono()
       }
     }
 
+    // Also include entity.relatedEntries[].id — these are displayed in the
+    // EntityDataSections block and were previously rendered as raw sid_
+    // strings because they never entered the displayName batch.
+    const relatedEntries = (entityRow as Record<string, unknown>).relatedEntries;
+    if (Array.isArray(relatedEntries)) {
+      for (const entry of relatedEntries) {
+        if (entry && typeof entry === "object") {
+          const id = (entry as Record<string, unknown>).id;
+          if (typeof id === "string" && isAnySid(id)) {
+            entityRefIds.add(id);
+          }
+        }
+      }
+    }
+
     // Batch-resolve stableIds to display names
     const displayNames: Record<string, { title: string; slug: string; entityType: string }> = {};
     if (entityRefIds.size > 0) {


### PR DESCRIPTION
## Summary

- Raw `sid_XXXXXXXXXX` values were visible on `/organizations/<slug>/data?tab=database` in the "Related Entries" section. The block rendered `relatedEntries[].id` as plain text while the rest of `EntityProfileViewer` resolves SIDs through a `displayNames` map.
- Server-side, related-entries SIDs were never included in the `displayName` batch fetch, so even a resolution-capable client wouldn't have the names.
- Adds a Playwright regression check: `no-raw-ids.spec.ts` now expands collapsed sections before scanning, so the existing `/organizations/*/data` coverage catches this class of bug. Verified against prod — the test fails with 10 raw SIDs today.

## Scope

- `apps/wiki-server/src/routes/tablebase/entity-profile.ts`: include `entity.relatedEntries[].id` SIDs in the displayName batch.
- `apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx`: dedicated `RelatedEntriesSection` that renders resolved names + hover card, with a `/wiki/E1929?entity=<sid>` link fallback for unresolved SIDs. `aria-expanded` added to the three collapsibles in this file so tests can open them.
- `apps/web/e2e/no-raw-ids.spec.ts`: `expandCollapsedSections` helper clicks both `aria-expanded="false"` buttons and known title-text buttons; invoked inside `assertNoRawIdsRequiresServer`.

## Out of scope

The "Resource ID = —" column (all 140 rows em-dashes) shown in the second screenshot is **intentional muting** of 16-char legacy hex IDs per QUA-397/407 `isLegacyResourceId`. Fixing it productively means either finishing the QUA-407 migration to `sid_` resource IDs (~5,002 bare10 legacy rows remaining per QUA-503) or joining resource titles into the response. Filed as a follow-up consideration, not touched here.

## Test plan

- [x] `pnpm crux w validate gate --fix` — 50 checks pass
- [x] `pnpm --filter longterm-next build` — clean
- [x] `npx tsc -p apps/web/tsconfig.json --noEmit` + wiki-server — clean
- [x] `pnpm --filter longterm-next test run` — 19 passed
- [x] `pnpm --filter wiki-server test run` — 45 passed
- [x] Playwright against prod before fix: confirms test catches 10 raw SIDs in `/organizations/anthropic/data?tab=database`
- [ ] Post-deploy: Playwright against prod after fix should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
