### PR TITLE
QUA-564 Phase B.1: swap publications + resource_policy_docs FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0187_qua_564_resource_fk_swap_b1.sql
+++ b/apps/wiki-server/drizzle/0187_qua_564_resource_fk_swap_b1.sql
@@ -1,0 +1,71 @@
+-- QUA-564 Phase B.1: swap publications.resource_id and resource_policy_docs.resource_id
+-- FK references from resources.id → resources.stable_id.
+--
+-- This is the template PR for QUA-549 Phase B (17-table FK migration). Only these
+-- two tables are swapped here; the other 15 ship in QUA-572/573/574/565/566/567/
+-- 568/569. See QUA-549 for the parent + full ticket list.
+--
+-- Both tables are 0 rows in prod, so no backfill is needed. The DROP+ADD CONSTRAINT
+-- is protected with IF EXISTS for both likely Drizzle-generated names and the
+-- postgres default (<table>_<column>_fkey) so this migration is idempotent.
+--
+-- Approach: in-place (Option B). Column name stays `resource_id`; only the FK
+-- reference target changes. No code churn from renaming column references.
+
+-- ────────────────────────────────────────────────────────────────────────
+-- publications.resource_id → resources.stable_id (SET NULL)
+-- ────────────────────────────────────────────────────────────────────────
+
+-- Defensive: one of these two names will match depending on how the FK was
+-- originally created. If neither matches (FK already swapped), IF EXISTS silences.
+ALTER TABLE "publications" DROP CONSTRAINT IF EXISTS "publications_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "publications" DROP CONSTRAINT IF EXISTS "publications_resource_id_fkey";--> statement-breakpoint
+
+-- Backfill: rewrite any non-null resource_id values from hex16 → sid_ via join
+-- on resources. No-op on prod (0 rows) but defensive for dev/staging/test envs.
+UPDATE "publications" p
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE p.resource_id = r.id
+  AND p.resource_id IS NOT NULL
+  AND p.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+-- Add new FK pointing at resources.stable_id, preserving SET NULL semantics.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'publications_resource_id_resources_stable_id_fk'
+      AND table_name = 'publications'
+  ) THEN
+    ALTER TABLE "publications"
+      ADD CONSTRAINT "publications_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE SET NULL;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_policy_docs.resource_id → resources.stable_id (CASCADE)
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_id is both PK and FK. Only the FK is swapped; the PK constraint is
+-- independent and stays in place.
+
+ALTER TABLE "resource_policy_docs" DROP CONSTRAINT IF EXISTS "resource_policy_docs_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "resource_policy_docs" DROP CONSTRAINT IF EXISTS "resource_policy_docs_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "resource_policy_docs" rpd
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rpd.resource_id = r.id
+  AND rpd.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'resource_policy_docs_resource_id_resources_stable_id_fk'
+      AND table_name = 'resource_policy_docs'
+  ) THEN
+    ALTER TABLE "resource_policy_docs"
+      ADD CONSTRAINT "resource_policy_docs_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/0187_qua_564_resource_fk_swap_b1.sql
+++ b/apps/wiki-server/drizzle/0187_qua_564_resource_fk_swap_b1.sql
@@ -5,9 +5,14 @@
 -- two tables are swapped here; the other 15 ship in QUA-572/573/574/565/566/567/
 -- 568/569. See QUA-549 for the parent + full ticket list.
 --
--- Both tables are 0 rows in prod, so no backfill is needed. The DROP+ADD CONSTRAINT
--- is protected with IF EXISTS for both likely Drizzle-generated names and the
--- postgres default (<table>_<column>_fkey) so this migration is idempotent.
+-- Both tables are 0 rows in prod, so no backfill is needed. The template uses
+-- patterns that scale safely to the larger Phase B tables:
+--   1. Dynamic DROP CONSTRAINT (queries information_schema for any FK on the
+--      column pointing at resources.id) — robust to constraint names we don't know.
+--   2. NOT VALID + VALIDATE CONSTRAINT pattern per .claude/rules/database-migrations.md
+--      (QUA-302/QUA-156 incident note) — minimizes ACCESS EXCLUSIVE lock time.
+--   3. r.stable_id IS NOT NULL guard on the backfill UPDATE — prevents silent
+--      NULL overwrite if any resources row is missing a stable_id.
 --
 -- Approach: in-place (Option B). Column name stays `resource_id`; only the FK
 -- reference target changes. No code churn from renaming column references.
@@ -16,21 +21,51 @@
 -- publications.resource_id → resources.stable_id (SET NULL)
 -- ────────────────────────────────────────────────────────────────────────
 
--- Defensive: one of these two names will match depending on how the FK was
--- originally created. If neither matches (FK already swapped), IF EXISTS silences.
-ALTER TABLE "publications" DROP CONSTRAINT IF EXISTS "publications_resource_id_resources_id_fk";--> statement-breakpoint
-ALTER TABLE "publications" DROP CONSTRAINT IF EXISTS "publications_resource_id_fkey";--> statement-breakpoint
+-- Dynamic DROP: find any FK constraint on publications.resource_id referencing
+-- resources.id (regardless of its generated name) and drop it. Idempotent.
+DO $$
+DECLARE
+  fk_name text;
+BEGIN
+  SELECT tc.constraint_name INTO fk_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+   AND tc.table_schema = kcu.table_schema
+  JOIN information_schema.referential_constraints rc
+    ON tc.constraint_name = rc.constraint_name
+  JOIN information_schema.constraint_column_usage ccu
+    ON rc.unique_constraint_name = ccu.constraint_name
+   AND rc.unique_constraint_schema = ccu.constraint_schema
+  WHERE tc.table_name = 'publications'
+    AND tc.constraint_type = 'FOREIGN KEY'
+    AND kcu.column_name = 'resource_id'
+    AND ccu.table_name = 'resources'
+    AND ccu.column_name = 'id'
+  LIMIT 1;
+
+  IF fk_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE "publications" DROP CONSTRAINT %I', fk_name);
+  END IF;
+END $$;--> statement-breakpoint
 
 -- Backfill: rewrite any non-null resource_id values from hex16 → sid_ via join
 -- on resources. No-op on prod (0 rows) but defensive for dev/staging/test envs.
+-- The r.stable_id IS NOT NULL guard prevents silently overwriting a real link
+-- with NULL if some resources row is missing its stable_id.
 UPDATE "publications" p
 SET resource_id = r.stable_id
 FROM "resources" r
 WHERE p.resource_id = r.id
   AND p.resource_id IS NOT NULL
-  AND p.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+  AND p.resource_id NOT LIKE 'sid_%'
+  AND r.stable_id IS NOT NULL;--> statement-breakpoint
 
 -- Add new FK pointing at resources.stable_id, preserving SET NULL semantics.
+-- NOT VALID + VALIDATE CONSTRAINT pattern: adds the constraint as metadata
+-- (ACCESS EXCLUSIVE for milliseconds, no row scan) then validates separately
+-- under the lighter SHARE UPDATE EXCLUSIVE lock. No-op cost on 0-row tables
+-- but this is the template for future Phase B tables with real data.
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.table_constraints
@@ -39,9 +74,13 @@ DO $$ BEGIN
   ) THEN
     ALTER TABLE "publications"
       ADD CONSTRAINT "publications_resource_id_resources_stable_id_fk"
-      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE SET NULL;
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id")
+      ON DELETE SET NULL NOT VALID;
   END IF;
 END $$;--> statement-breakpoint
+
+ALTER TABLE "publications"
+  VALIDATE CONSTRAINT "publications_resource_id_resources_stable_id_fk";--> statement-breakpoint
 
 -- ────────────────────────────────────────────────────────────────────────
 -- resource_policy_docs.resource_id → resources.stable_id (CASCADE)
@@ -49,14 +88,40 @@ END $$;--> statement-breakpoint
 -- resource_id is both PK and FK. Only the FK is swapped; the PK constraint is
 -- independent and stays in place.
 
-ALTER TABLE "resource_policy_docs" DROP CONSTRAINT IF EXISTS "resource_policy_docs_resource_id_resources_id_fk";--> statement-breakpoint
-ALTER TABLE "resource_policy_docs" DROP CONSTRAINT IF EXISTS "resource_policy_docs_resource_id_fkey";--> statement-breakpoint
+DO $$
+DECLARE
+  fk_name text;
+BEGIN
+  SELECT tc.constraint_name INTO fk_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+   AND tc.table_schema = kcu.table_schema
+  JOIN information_schema.referential_constraints rc
+    ON tc.constraint_name = rc.constraint_name
+  JOIN information_schema.constraint_column_usage ccu
+    ON rc.unique_constraint_name = ccu.constraint_name
+   AND rc.unique_constraint_schema = ccu.constraint_schema
+  WHERE tc.table_name = 'resource_policy_docs'
+    AND tc.constraint_type = 'FOREIGN KEY'
+    AND kcu.column_name = 'resource_id'
+    AND ccu.table_name = 'resources'
+    AND ccu.column_name = 'id'
+  LIMIT 1;
 
+  IF fk_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE "resource_policy_docs" DROP CONSTRAINT %I', fk_name);
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Backfill with stable_id-non-null guard (critical here because resource_id is
+-- the PK; silently overwriting to NULL would fail PK or create a duplicate).
 UPDATE "resource_policy_docs" rpd
 SET resource_id = r.stable_id
 FROM "resources" r
 WHERE rpd.resource_id = r.id
-  AND rpd.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+  AND rpd.resource_id NOT LIKE 'sid_%'
+  AND r.stable_id IS NOT NULL;--> statement-breakpoint
 
 DO $$ BEGIN
   IF NOT EXISTS (
@@ -66,6 +131,10 @@ DO $$ BEGIN
   ) THEN
     ALTER TABLE "resource_policy_docs"
       ADD CONSTRAINT "resource_policy_docs_resource_id_resources_stable_id_fk"
-      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id")
+      ON DELETE CASCADE NOT VALID;
   END IF;
-END $$;
+END $$;--> statement-breakpoint
+
+ALTER TABLE "resource_policy_docs"
+  VALIDATE CONSTRAINT "resource_policy_docs_resource_id_resources_stable_id_fk";

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1310,6 +1310,13 @@
       "when": 1785657600000,
       "tag": "0186_qua_549_rcv_resource_id_to_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 187,
+      "version": "7",
+      "when": 1785744000000,
+      "tag": "0187_qua_564_resource_fk_swap_b1",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/publications.ts
+++ b/apps/wiki-server/src/routes/tablebase/publications.ts
@@ -66,6 +66,11 @@ const SyncItemSchema = z.object({
   id: z.string().length(10),
   entityId: z.string().min(1).max(200),
   entityDisplayName: z.string().max(500).nullable().optional(),
+  // QUA-564 Phase B.1: publications.resource_id now FKs to resources.stable_id.
+  // Callers must pass sid_-prefixed stable_ids, not legacy hex16 resources.id
+  // values. No translation layer here — no current caller populates this field
+  // (data/publications.yaml has zero resourceId entries). A future caller that
+  // provides hex16 will hit a clear FK violation at insert time.
   resourceId: z.string().max(200).nullable().optional(),
   title: z.string().min(1).max(2000),
   authors: z.string().max(5000).nullable().optional(),

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -1596,11 +1596,16 @@ const resourcesApp = new Hono()
       return notFoundError(c, `Resource not found: ${id}`);
     }
 
-    // Fetch sub-table data in parallel
+    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId now references resources.stable_id,
+    // so the lookup must use stable_id (not the hex16 `id` URL param). Other sub-tables
+    // still use resources.id until their respective Phase B tickets land.
+    // resources.stable_id is NOT NULL in prod per QUA-536; the `?? id` fallback is only
+    // defensive for test fixtures that may omit it (will return zero rows harmlessly).
+    const stableId = rows[0].stableId ?? id;
     const [paperRows, forumRows, policyRows, citations] = await Promise.all([
       db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, id)).limit(1),
       db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, id)).limit(1),
-      db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, id)).limit(1),
+      db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, stableId)).limit(1),
       // JOIN wiki_pages to recover slug from integer page ID
       db.select({ pageId: wikiPages.slug })
         .from(resourceCitations)
@@ -1718,14 +1723,21 @@ const resourcesApp = new Hono()
 
     const db = getDrizzleDb();
 
-    const resRows = await db.select({ id: resources.id }).from(resources).where(eq(resources.id, id)).limit(1);
+    // QUA-564 Phase B.1: pull stable_id for the resource_policy_docs FK (which now
+    // references resources.stable_id). URL param `id` remains the hex16 resources.id.
+    const resRows = await db
+      .select({ id: resources.id, stableId: resources.stableId })
+      .from(resources)
+      .where(eq(resources.id, id))
+      .limit(1);
     if (resRows.length === 0) return notFoundError(c, `Resource not found: ${id}`);
+    const stableId = resRows[0].stableId ?? id;
 
     try {
       await db
         .insert(resourcePolicyDocs)
         .values({
-          resourceId: id,
+          resourceId: stableId,
           ...data,
           updatedAt: new Date(),
         })
@@ -1836,10 +1848,29 @@ const resourcesApp = new Hono()
           results.forumPosts = batchData.forumPosts.length;
         }
 
-        // Bulk upsert policy docs in one query
+        // Bulk upsert policy docs in one query.
+        // QUA-564 Phase B.1: resource_policy_docs.resource_id now references
+        // resources.stable_id. Client batch items may supply either hex16 (resources.id)
+        // or sid_ (resources.stable_id); translate hex → sid before insert.
         if (batchData.policyDocs && batchData.policyDocs.length > 0) {
+          const inputIds = batchData.policyDocs
+            .map((item) => item.resourceId)
+            .filter((v): v is string => !!v);
+          const resourceRows = inputIds.length
+            ? await tx
+                .select({ id: resources.id, stableId: resources.stableId })
+                .from(resources)
+                .where(inArray(resources.id, inputIds))
+            : [];
+          const hexToStableId = new Map(
+            resourceRows
+              .filter((r): r is { id: string; stableId: string } => !!r.stableId)
+              .map((r) => [r.id, r.stableId])
+          );
           const policyVals = batchData.policyDocs.map((item) => ({
-            resourceId: item.resourceId,
+            // If the input is already a sid_ (or any non-hex that doesn't match),
+            // keep it as-is; the FK will catch genuinely invalid values at insert time.
+            resourceId: hexToStableId.get(item.resourceId) ?? item.resourceId,
             documentType: item.documentType ?? null,
             jurisdictionEntityId: item.jurisdictionEntityId ?? null,
             agencyEntityId: item.agencyEntityId ?? null,
@@ -1904,15 +1935,20 @@ const resourcesApp = new Hono()
 
     const ids = rows.map((r) => r.id);
     const idList = sql.join(ids.map((id) => sql`${id}`), sql`, `);
+    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId references resources.stable_id,
+    // so build a parallel stable-id list for the policy-docs IN query. Falls back to
+    // the hex id for resources with null stable_id (shouldn't happen post-QUA-536).
+    const stableIds = rows.map((r) => r.stableId ?? r.id);
+    const stableIdList = sql.join(stableIds.map((sid) => sql`${sid}`), sql`, `);
 
     // Fetch all sub-table rows for this page of resources in parallel
     const [paperRows, forumRows, policyRows] = await Promise.all([
       db.select().from(resourcePapers).where(sql`${resourcePapers.resourceId} IN (${idList})`),
       db.select().from(resourceForumPosts).where(sql`${resourceForumPosts.resourceId} IN (${idList})`),
-      db.select().from(resourcePolicyDocs).where(sql`${resourcePolicyDocs.resourceId} IN (${idList})`),
+      db.select().from(resourcePolicyDocs).where(sql`${resourcePolicyDocs.resourceId} IN (${stableIdList})`),
     ]);
 
-    // Index by resourceId
+    // Index by resourceId. policyIndex keys are stable_ids; the others are hex16 ids.
     const paperIndex = new Map(paperRows.map((r) => [r.resourceId, r]));
     const forumIndex = new Map(forumRows.map((r) => [r.resourceId, r]));
     const policyIndex = new Map(policyRows.map((r) => [r.resourceId, r]));
@@ -1920,12 +1956,15 @@ const resourcesApp = new Hono()
     const countResult = await db.select({ count: count() }).from(resources).where(conditions);
 
     return c.json({
-      resources: rows.map((r) => ({
-        ...formatResource(r),
-        paper: paperIndex.has(r.id) ? formatPaper(paperIndex.get(r.id)!) : null,
-        forumPost: forumIndex.has(r.id) ? formatForumPost(forumIndex.get(r.id)!) : null,
-        policyDoc: policyIndex.has(r.id) ? formatPolicyDoc(policyIndex.get(r.id)!) : null,
-      })),
+      resources: rows.map((r) => {
+        const policyKey = r.stableId ?? r.id;
+        return {
+          ...formatResource(r),
+          paper: paperIndex.has(r.id) ? formatPaper(paperIndex.get(r.id)!) : null,
+          forumPost: forumIndex.has(r.id) ? formatForumPost(forumIndex.get(r.id)!) : null,
+          policyDoc: policyIndex.has(policyKey) ? formatPolicyDoc(policyIndex.get(policyKey)!) : null,
+        };
+      }),
       total: countResult[0].count,
       limit,
       offset,
@@ -1948,6 +1987,8 @@ const resourcesApp = new Hono()
       return notFoundError(c, `Resource not found: ${id}`);
     }
 
+    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId references resources.stable_id now.
+    const stableId = rows[0].stableId ?? id;
     // Also fetch citations, sub-table data, and tabular source metadata
     const [citations, paperRows, forumRows, policyRows, tabularRows] = await Promise.all([
       db.select({ pageId: wikiPages.slug })
@@ -1956,7 +1997,7 @@ const resourcesApp = new Hono()
         .where(eq(resourceCitations.resourceId, id)),
       db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, id)).limit(1),
       db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, id)).limit(1),
-      db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, id)).limit(1),
+      db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, stableId)).limit(1),
       db.select().from(resourceTabularSources).where(eq(resourceTabularSources.resourceId, id)).limit(1),
     ]);
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -779,9 +779,12 @@ export const resourceForumPosts = pgTable("resource_forum_posts", {
 
 /** Type-specific metadata for policy/government documents (~100-300 resources). */
 export const resourcePolicyDocs = pgTable("resource_policy_docs", {
+  // QUA-564 Phase B.1: resource_id references resources.stable_id (not resources.id).
+  // Column name kept as `resource_id` for minimal code churn — the value is now a
+  // `sid_`-prefixed stable_id, not a legacy hex16. See QUA-549 for context.
   resourceId: text("resource_id")
     .primaryKey()
-    .references(() => resources.id, { onDelete: "cascade" }),
+    .references(() => resources.stableId, { onDelete: "cascade" }),
   documentType: text("document_type"),
   jurisdictionEntityId: text("jurisdiction_entity_id"),
   agencyEntityId: text("agency_entity_id"),
@@ -2529,8 +2532,11 @@ export const publications = pgTable(
       .references(() => entities.stableId, { onDelete: "cascade" }),
     /** Display name fallback */
     entityDisplayName: text("entity_display_name"),
-    /** Optional FK to resources table for citation tracking */
-    resourceId: text("resource_id").references(() => resources.id, {
+    /**
+     * Optional FK to resources table for citation tracking.
+     * QUA-564 Phase B.1: references resources.stable_id (column name unchanged).
+     */
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     title: text("title").notNull(),


### PR DESCRIPTION
## Summary

Template PR for [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) Phase B (17-table FK migration from `resources.id` to `resources.stable_id`). Migrates the two lowest-risk tables to establish the in-place pattern; the remaining 15 tables land in QUA-565, QUA-566, QUA-567, QUA-568, QUA-569, QUA-572, QUA-573, QUA-574.

Fixes QUA-564.

## What changed

Two tables: `publications` (schema-only — no code reads/writes the column) and `resource_policy_docs` (5 callsites in `resources.ts`). Both are 0 rows in prod.

**Approach: Option B / in-place.** Column name stays `resource_id` on both tables; only `.references()` target in schema.ts changes from `resources.id` → `resources.stableId`. Matches the existing `entity_resources.entity_id → entities.stable_id` pattern. Avoids code churn from renaming columns to `resource_stable_id` across the 17 Phase B tickets.

- **`apps/wiki-server/drizzle/0186_qua_564_resource_fk_swap_b1.sql`** (new): drops old FK constraints (idempotent via `IF EXISTS` on two possible names — the Drizzle-generated `<table>_<col>_<target_table>_<target_col>_fk` and the postgres default `<table>_<col>_fkey`). Backfills any non-null `resource_id` values from hex16 → sid_ via JOIN on resources (no-op on prod; defensive for dev/staging/test). Adds new FK referencing `resources.stable_id`, preserving the existing onDelete semantics (`publications`: SET NULL; `resource_policy_docs`: CASCADE).
- **`apps/wiki-server/src/schema.ts`**: two `.references()` edits with comments pointing at QUA-564.
- **`apps/wiki-server/src/routes/wikibase/resources.ts`**: 5 callsite updates:
  - `GET /:id/details`: look up `rows[0].stableId` for policy_docs sub-table query
  - `POST /:id/policy-doc`: translate incoming hex16 → stable_id before insert
  - `POST /batch-details`: batch-translate `policyDocs[].resourceId` via resources lookup map (handles mixed hex16 / sid_ input gracefully)
  - `GET /all-details`: build parallel `stableIds` list for `IN (...)` query, index `policyIndex` by stable_id
  - `GET /:id`: use `stableId ?? id` for policy_docs sub-table fetch

## Risk profile

Low. Both tables have 0 prod rows. Other sub-tables in the same file (`resource_papers`, `resource_forum_posts`, `resource_citations`, `resource_tabular_sources`) still use `resources.id`; each will be swapped in its own Phase B sub-ticket.

## Deploy Checklist

- [ ] After merge, migration `0186_qua_564_resource_fk_swap_b1` runs automatically at wiki-server startup. Verify degraded-mode health is not triggered.
- [ ] Smoke-check: `GET /api/resources/<hex16-id>/details` still returns sub-table data correctly (policy docs should now resolve via stable_id).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `pnpm build` completes successfully
- [x] `pnpm test` (wiki-server `resources.test.ts`, 38 tests): all pass
- [x] `pnpm crux w validate gate --scope=content --fix`: all 5 checks pass (after refreshing stale local resources-snapshot.json)
- [ ] Post-merge: degraded-mode check on wiki-server logs
- [ ] Post-merge: sample `GET /api/resources/<id>/details` for a policy doc resource (if any exist in prod — currently 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal resource reference system to improve data consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0186 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New API route "resource-dedup" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/resource-dedup" -o /dev/null -w "%{http_code}"`
<!-- /deploy-tasks -->