### PR TITLE
Enrich 3 governance FactBase files with revenue/employee data (QUA-38)

### DIFF
--- a/packages/factbase/data/fb-entities/encode-justice.yaml
+++ b/packages/factbase/data/fb-entities/encode-justice.yaml
@@ -62,3 +62,10 @@ facts:
     property: country
     value: "United States"
     source: https://www.influencewatch.org/non-profit/encode-justice/
+
+  - id: f_BdJM5BZNra
+    property: financial-disclosure
+    value: "No independent IRS Form 990 filings. Encode Justice operates as a fiscal project of Future Incubator (a program of March On / Future Coalition) and does not file its own financial reports. Revenue and employee figures are not publicly disclosed."
+    asOf: 2026-04
+    source: https://www.influencewatch.org/non-profit/encode-justice/
+    notes: "ProPublica Nonprofit Explorer returns no record for 'Encode Justice'. Fiscal sponsorship confirmed by InfluenceWatch profile."

--- a/packages/factbase/data/fb-entities/pauseai.yaml
+++ b/packages/factbase/data/fb-entities/pauseai.yaml
@@ -64,3 +64,18 @@ facts:
     property: country
     value: "Netherlands"
     source: https://pauseai.info/legal
+
+  - id: f_mlKtecLXeW
+    property: employee-count
+    value: "22"
+    asOf: 2026-04
+    source: https://pauseai.info/people
+    notes: "Named team: 3 executive (CEO, Organizing Director, Communications Director), 15 national/chapter leaders, and 3 global board members. Mix of paid staff and volunteer leaders; org does not publicly break down paid vs. volunteer counts. Operational teams (Operations, Onboarding, Communications) also include additional unpaid volunteers."
+
+  - id: f_DSEdfJN0mL
+    property: annual-revenue
+    value: "288319"
+    unit: USD
+    asOf: 2024
+    source: https://projects.propublica.org/nonprofits/organizations/990899650
+    notes: "PauseAI US (501(c)(3), EIN 99-0899650, San Francisco, CA). Separate from Dutch PauseAI Global Stichting, which reports donor totals of EUR 715K through 2025-12."

--- a/packages/factbase/data/fb-entities/the-future-society.yaml
+++ b/packages/factbase/data/fb-entities/the-future-society.yaml
@@ -80,3 +80,10 @@ facts:
     asOf: 2021
     source: https://www.influencewatch.org/non-profit/the-future-society/
     notes: "Revenue $755K, expenses $725K, assets $385K in 2021. Grew significantly to $3.4M by 2024."
+
+  - id: f_aJtJdBOXQU
+    property: employee-count
+    value: "19"
+    asOf: 2026-04
+    source: https://thefuturesociety.org/our-team/
+    notes: "Team page lists 15 staff (2 leadership, 2 directors, 4 senior associates, 4 associates, 1 analyst, 2 operations) plus 4 advisors/former leadership (founder & former chair, senior advisor, volunteer chair for AI and the Rule of Law, special assistant). Staff distributed across North America, Europe, and Africa per org description."


### PR DESCRIPTION
## Summary

Closes **QUA-38** — Deep FactBase enrichment for 7 sparse governance org files.

All 7 target files already held 11-13 facts each with source URLs from prior enrichment in PR #3473. This PR fills the remaining gaps against the "Revenue and employee data added where available" acceptance criterion:

| File | Added |
|------|-------|
| `pauseai.yaml` | `employee-count: 22` (named team) + `annual-revenue: $288,319 USD, 2024` (PauseAI US 501(c)(3), EIN 99-0899650) |
| `the-future-society.yaml` | `employee-count: 19` (15 staff + 4 advisors per `/our-team/`) |
| `encode-justice.yaml` | `financial-disclosure` fact documenting that Encode Justice is a fiscal project of Future Incubator with no independent IRS 990 — data genuinely unavailable |

## Acceptance criteria status

- [x] Each file has 6+ verified facts (all 7 files now at 11-14 facts)
- [x] Revenue and employee data added where available (see table above; Encode Justice has a documented "not available" fact)
- [x] All facts include source URLs

## Verification

- All sources re-fetched live: PauseAI `/people`, The Future Society `/our-team/`, ProPublica 990 for PauseAI US, InfluenceWatch profile for Encode Justice.
- `pnpm crux w validate gate --fix` → **46/46 checks pass**.
- No new warnings or errors on the target files per `validate-factbase-schema`.

## Test plan

- [x] Gate check passes locally
- [ ] CI green on push
- [ ] Built `database.json` / `factbase-data.json` render the new facts on the three org profile pages

Fixes QUA-38
