### PR TITLE
pr-patrol: raise turn/timeout budgets; remove retry halving

### DIFF
--- a/crux/commands/pr-patrol.ts
+++ b/crux/commands/pr-patrol.ts
@@ -279,7 +279,7 @@ Branch Agent (phase 1 persistent watchdog):
 Branch Agent Options:
   --max-invocations=N  Max Claude sessions to run (default: 20)
   --timeout=N          Per-session timeout in minutes (default: 15)
-  --max-turns=N        Max turns per session (default: 30)
+  --max-turns=N        Max turns per session (default: 60)
   --ci-timeout=N       Max seconds to wait for CI (default: 900 = 15 min)
   --ci-poll=N          CI poll interval in seconds (default: 30)
   --dry-run            Show what would be done, don't fix
@@ -325,7 +325,7 @@ Stats Options:
 Daemon Options:
   --dry-run         Show what would be done, don't fix or merge
   --interval=N      Seconds between checks (default: 300)
-  --max-turns=N     Max Claude turns per fix (default: 60)
+  --max-turns=N     Max Claude turns per fix (default: 120)
   --timeout=N       Hard timeout in minutes per fix (default: 60)
   --cooldown=N      Skip recently-processed PRs for N seconds (default: 1800)
   --stale-hours=N   Hours before a PR is considered stale (default: 48)

--- a/crux/pr-patrol/branch-agent.ts
+++ b/crux/pr-patrol/branch-agent.ts
@@ -52,7 +52,7 @@ export function buildBranchAgentConfig(
   return {
     repo: (process.env.PR_PATROL_REPO as string) ?? 'quantified-uncertainty/longterm-wiki',
     intervalSeconds: 60, // Unused in branch-agent, but required by PatrolConfig
-    maxTurns: parseIntOpt(options.maxTurns ?? process.env.PR_PATROL_MAX_TURNS, 30),
+    maxTurns: parseIntOpt(options.maxTurns ?? process.env.PR_PATROL_MAX_TURNS, 60),
     cooldownSeconds: 0, // Branch-agent doesn't use global cooldowns
     staleHours: 48,
     model: (options.model as string) ?? process.env.PR_PATROL_MODEL ?? 'sonnet',

--- a/crux/pr-patrol/index.test.ts
+++ b/crux/pr-patrol/index.test.ts
@@ -504,34 +504,34 @@ describe('computeBudget', () => {
     expect(budget.timeoutMinutes).toBe(3);
   });
 
-  it('gives small budget for missing-testplan only', () => {
+  it('gives budget for missing-testplan', () => {
     const budget = computeBudget(['missing-testplan']);
-    expect(budget.maxTurns).toBe(8);
-    expect(budget.timeoutMinutes).toBe(5);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(15);
   });
 
   it('gives medium budget for ci-failure', () => {
     const budget = computeBudget(['ci-failure']);
-    expect(budget.maxTurns).toBe(50);
-    expect(budget.timeoutMinutes).toBe(45);
+    expect(budget.maxTurns).toBe(100);
+    expect(budget.timeoutMinutes).toBe(60);
   });
 
-  it('gives reduced budget for conflict (#3776)', () => {
+  it('gives budget for conflict', () => {
     const budget = computeBudget(['conflict']);
-    expect(budget.maxTurns).toBe(30);
-    expect(budget.timeoutMinutes).toBe(20);
+    expect(budget.maxTurns).toBe(60);
+    expect(budget.timeoutMinutes).toBe(30);
   });
 
   it('uses highest budget when multiple issues present', () => {
     const budget = computeBudget(['missing-issue-ref', 'ci-failure']);
-    expect(budget.maxTurns).toBe(50);
-    expect(budget.timeoutMinutes).toBe(45);
+    expect(budget.maxTurns).toBe(100);
+    expect(budget.timeoutMinutes).toBe(60);
   });
 
   it('conflict dominates when mixed with smaller issues', () => {
     const budget = computeBudget(['missing-testplan', 'conflict', 'missing-issue-ref']);
-    expect(budget.maxTurns).toBe(30);
-    expect(budget.timeoutMinutes).toBe(20);
+    expect(budget.maxTurns).toBe(60);
+    expect(budget.timeoutMinutes).toBe(30);
   });
 });
 

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -184,7 +184,7 @@ export function buildConfig(
     ),
     maxTurns: parseIntOpt(
       options.maxTurns ?? process.env.PR_PATROL_MAX_TURNS,
-      60,
+      120,
     ),
     cooldownSeconds: parseIntOpt(
       options.cooldown ?? process.env.PR_PATROL_COOLDOWN,

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -375,8 +375,8 @@ async function fixPrInWorktree(
           const rebasePrompt = `Rebase the current branch onto origin/main. Resolve any merge conflicts. Then force-push with: git push --force-with-lease. Do NOT fix CI issues, do NOT address code review comments — ONLY resolve the merge conflicts and push.`;
           const rebaseResult2 = await spawnClaude(rebasePrompt, {
             ...config,
-            maxTurns: 30,
-            timeoutMinutes: 15,
+            maxTurns: 60,
+            timeoutMinutes: 30,
           }, { cwd: worktreePath });
           const elapsedS = Math.floor((Date.now() - startTime) / 1000);
           const claudeOutcome: FixOutcome = rebaseResult2.exitCode === 0 && !rebaseResult2.hitMaxTurns ? 'fixed' : 'error';
@@ -792,7 +792,7 @@ export function buildParallelConfig(
     ),
     maxTurns: parseIntOpt(
       options.maxTurns ?? process.env.PR_PATROL_MAX_TURNS,
-      60,
+      120,
     ),
     cooldownSeconds: parseIntOpt(
       options.cooldown ?? process.env.PR_PATROL_COOLDOWN,

--- a/crux/pr-patrol/scoring.test.ts
+++ b/crux/pr-patrol/scoring.test.ts
@@ -112,64 +112,64 @@ describe('computeBudget', () => {
     expect(budget.timeoutMinutes).toBe(3);
   });
 
-  it('gives small budget for missing-testplan only', () => {
+  it('gives budget for missing-testplan', () => {
     const budget = computeBudget(['missing-testplan']);
-    expect(budget.maxTurns).toBe(8);
-    expect(budget.timeoutMinutes).toBe(5);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(15);
   });
 
   it('gives medium budget for ci-failure', () => {
     const budget = computeBudget(['ci-failure']);
-    expect(budget.maxTurns).toBe(50);
-    expect(budget.timeoutMinutes).toBe(45);
+    expect(budget.maxTurns).toBe(100);
+    expect(budget.timeoutMinutes).toBe(60);
   });
 
-  it('gives reduced budget for conflict (#3776)', () => {
+  it('gives budget for conflict', () => {
     const budget = computeBudget(['conflict']);
-    expect(budget.maxTurns).toBe(30);
-    expect(budget.timeoutMinutes).toBe(20);
+    expect(budget.maxTurns).toBe(60);
+    expect(budget.timeoutMinutes).toBe(30);
   });
 
   it('uses highest budget when multiple issues present', () => {
     const budget = computeBudget(['missing-issue-ref', 'ci-failure']);
-    expect(budget.maxTurns).toBe(50);
-    expect(budget.timeoutMinutes).toBe(45);
+    expect(budget.maxTurns).toBe(100);
+    expect(budget.timeoutMinutes).toBe(60);
   });
 
   it('conflict dominates when mixed with smaller issues', () => {
     const budget = computeBudget(['missing-testplan', 'conflict', 'missing-issue-ref']);
-    expect(budget.maxTurns).toBe(30);
+    expect(budget.maxTurns).toBe(60);
+    expect(budget.timeoutMinutes).toBe(30);
+  });
+
+  it('gives budget for bot-review-major', () => {
+    const budget = computeBudget(['bot-review-major']);
+    expect(budget.maxTurns).toBe(60);
     expect(budget.timeoutMinutes).toBe(20);
   });
 
-  it('gives small budget for bot-review-major (#3827)', () => {
-    const budget = computeBudget(['bot-review-major']);
-    expect(budget.maxTurns).toBe(10);
-    expect(budget.timeoutMinutes).toBe(5);
-  });
-
-  it('gives small budget for bot-review-nitpick', () => {
+  it('gives budget for bot-review-nitpick', () => {
     const budget = computeBudget(['bot-review-nitpick']);
-    expect(budget.maxTurns).toBe(8);
-    expect(budget.timeoutMinutes).toBe(5);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(15);
   });
 
   it('gives stale budget', () => {
     const budget = computeBudget(['stale']);
-    expect(budget.maxTurns).toBe(10);
-    expect(budget.timeoutMinutes).toBe(5);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(15);
   });
 
   it('gives merge-blocked budget', () => {
     const budget = computeBudget(['merge-blocked']);
-    expect(budget.maxTurns).toBe(10);
-    expect(budget.timeoutMinutes).toBe(5);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(15);
   });
 
   it('gives self-authored-feedback budget', () => {
     const budget = computeBudget(['self-authored-feedback']);
-    expect(budget.maxTurns).toBe(20);
-    expect(budget.timeoutMinutes).toBe(15);
+    expect(budget.maxTurns).toBe(60);
+    expect(budget.timeoutMinutes).toBe(25);
   });
 
   it('gives tiny safety-net budget for stuck — stuck PRs are intercepted before Claude dispatch (QUA-286)', () => {
@@ -186,60 +186,46 @@ describe('computeBudget', () => {
 // ── getRetryBudgetMultiplier ─────────────────────────────────────────────────
 
 describe('getRetryBudgetMultiplier', () => {
-  it('returns 1.0 on first attempt (no prior failures)', () => {
+  it('returns 1.0 on first attempt', () => {
     expect(getRetryBudgetMultiplier(0)).toBe(1.0);
   });
 
-  it('returns 0.5 on second attempt (1 prior failure)', () => {
-    expect(getRetryBudgetMultiplier(1)).toBe(0.5);
-  });
-
-  it('returns 0.5 on third attempt (2 prior failures)', () => {
-    expect(getRetryBudgetMultiplier(2)).toBe(0.5);
+  it('returns 1.0 on retry (no halving)', () => {
+    // Halving on retry was defeatist: if the first full-budget attempt couldn't
+    // finish, a half-budget one won't either. All attempts now get full budget.
+    expect(getRetryBudgetMultiplier(1)).toBe(1.0);
+    expect(getRetryBudgetMultiplier(2)).toBe(1.0);
+    expect(getRetryBudgetMultiplier(10)).toBe(1.0);
   });
 });
 
 // ── computeEffectiveBudget ──────────────────────────────────────────────────
 
 describe('computeEffectiveBudget', () => {
-  it('returns full budget on first attempt', () => {
-    const budget = computeEffectiveBudget(['ci-failure'], 60, 60, 0);
-    expect(budget.maxTurns).toBe(50); // ci-failure base is 50, config cap 60
-    expect(budget.timeoutMinutes).toBe(45); // ci-failure base is 45, config cap 60
+  it('returns full budget on first attempt (capped by config)', () => {
+    const budget = computeEffectiveBudget(['ci-failure'], 80, 60, 0);
+    expect(budget.maxTurns).toBe(80); // ci-failure base 100, capped at config 80
+    expect(budget.timeoutMinutes).toBe(60); // ci-failure base 60, config cap 60
   });
 
-  it('returns half budget on retry', () => {
-    const budget = computeEffectiveBudget(['ci-failure'], 60, 60, 1);
-    expect(budget.maxTurns).toBe(25); // ceil(50 * 0.5)
-    expect(budget.timeoutMinutes).toBe(23); // ceil(45 * 0.5)
+  it('returns full budget on retry (no halving)', () => {
+    const budget = computeEffectiveBudget(['ci-failure'], 80, 60, 1);
+    expect(budget.maxTurns).toBe(80);
+    expect(budget.timeoutMinutes).toBe(60);
   });
 
-  it('applies config cap before multiplier', () => {
-    // Config caps at 30 turns / 20 min, ci-failure base is 50/45
-    const first = computeEffectiveBudget(['ci-failure'], 30, 20, 0);
-    expect(first.maxTurns).toBe(30);
-    expect(first.timeoutMinutes).toBe(20);
-
-    const retry = computeEffectiveBudget(['ci-failure'], 30, 20, 1);
-    expect(retry.maxTurns).toBe(15); // ceil(30 * 0.5)
-    expect(retry.timeoutMinutes).toBe(10); // ceil(20 * 0.5)
+  it('applies config cap', () => {
+    // Config caps at 30 turns / 20 min, ci-failure base is 100/60 — cap wins.
+    const budget = computeEffectiveBudget(['ci-failure'], 30, 20, 0);
+    expect(budget.maxTurns).toBe(30);
+    expect(budget.timeoutMinutes).toBe(20);
   });
 
-  it('uses Math.ceil so budget never rounds down to 0', () => {
-    // missing-issue-ref has 5 turns / 3 min — half should be 3 / 2, not 2 / 1
-    const budget = computeEffectiveBudget(['missing-issue-ref'], 60, 60, 1);
-    expect(budget.maxTurns).toBe(3); // ceil(5 * 0.5) = 3
-    expect(budget.timeoutMinutes).toBe(2); // ceil(3 * 0.5) = 2
-  });
-
-  it('conflict issue gets 30 turns on first attempt, 15 on retry (#3776)', () => {
-    const first = computeEffectiveBudget(['conflict'], 60, 60, 0);
-    expect(first.maxTurns).toBe(30);
-    expect(first.timeoutMinutes).toBe(20);
-
-    const retry = computeEffectiveBudget(['conflict'], 60, 60, 1);
-    expect(retry.maxTurns).toBe(15);
-    expect(retry.timeoutMinutes).toBe(10);
+  it('retry budget matches first-attempt budget (no reduction)', () => {
+    const first = computeEffectiveBudget(['conflict'], 120, 60, 0);
+    const retry = computeEffectiveBudget(['conflict'], 120, 60, 1);
+    expect(retry.maxTurns).toBe(first.maxTurns);
+    expect(retry.timeoutMinutes).toBe(first.timeoutMinutes);
   });
 });
 

--- a/crux/pr-patrol/scoring.ts
+++ b/crux/pr-patrol/scoring.ts
@@ -83,22 +83,20 @@ export interface IssueBudget {
 // Note: missing-issue-ref is an advisory-only issue (see ADVISORY_ISSUES in types.ts)
 // and is filtered out before reaching the budget system, so it's not listed here.
 const ISSUE_BUDGETS: Partial<Record<PrIssueType, IssueBudget>> = {
-  // Reduced from 60/60 — 60+ turns is counterproductive (#3776). Most conflicts
-  // resolve in <20 turns; beyond that, the agent is likely stuck in a loop.
-  conflict:            { maxTurns: 30, timeoutMinutes: 20 },
-  'ci-failure':        { maxTurns: 50, timeoutMinutes: 45 },
-  // Reduced from 15/10 — large CodeRabbit reviews are systematically unfixable
-  // by patrol (#3827). Give enough turns to try, but fail fast.
-  'bot-review-major':  { maxTurns: 10, timeoutMinutes: 5 },
-  stale:               { maxTurns: 10, timeoutMinutes: 5 },
-  'missing-testplan':  { maxTurns: 8,  timeoutMinutes: 5 },
-  'bot-review-nitpick':{ maxTurns: 8,  timeoutMinutes: 5 },
-  // Merge-blocked usually requires adding a label, clearing a review request,
-  // or coordinating with a maintainer — lightweight work, not code changes.
-  'merge-blocked':     { maxTurns: 10, timeoutMinutes: 5 },
-  // Self-authored feedback requires reading the maintainer comment and
-  // addressing it; keep modest but non-trivial budget.
-  'self-authored-feedback': { maxTurns: 20, timeoutMinutes: 15 },
+  // Raised across the board — empirically, Claude Code eventually fixes the
+  // vast majority of patrol-eligible issues when given enough turns. Prior
+  // caps (conflict 30/20, bot-review-major 10/5, merge-blocked 10/5) were
+  // calibrated to "fail fast" on a hypothesis of systematic unfixability
+  // that did not hold up — the dominant abandon outcome was hitting the cap,
+  // not genuine dead-ends. Give bigger budgets and let Claude finish.
+  conflict:            { maxTurns: 60, timeoutMinutes: 30 },
+  'ci-failure':        { maxTurns: 100, timeoutMinutes: 60 },
+  'bot-review-major':  { maxTurns: 60, timeoutMinutes: 20 },
+  stale:               { maxTurns: 30, timeoutMinutes: 15 },
+  'missing-testplan':  { maxTurns: 30, timeoutMinutes: 15 },
+  'bot-review-nitpick':{ maxTurns: 30, timeoutMinutes: 15 },
+  'merge-blocked':     { maxTurns: 30, timeoutMinutes: 15 },
+  'self-authored-feedback': { maxTurns: 60, timeoutMinutes: 25 },
   // Stuck-cycle PRs are routed to escalation (no Claude dispatch), so the
   // budget here is a safety net for the rare case they reach fixPr() without
   // being intercepted. Keep it tiny so a misconfig doesn't burn compute.
@@ -120,11 +118,13 @@ export function computeBudget(issues: PrIssueType[]): IssueBudget {
 
 /**
  * Compute the retry budget multiplier based on the number of previous failures.
- * First attempt gets full budget (1.0), subsequent attempts get half (0.5).
- * This prevents wasting compute on PRs where the full budget already failed.
+ * All attempts get the full budget — halving on retry meant attempt 2 was
+ * almost guaranteed to fail on any PR that needed non-trivial work, wasting
+ * both the attempt and the signal. If the first full-budget attempt couldn't
+ * finish, a half-budget one won't either.
  */
-export function getRetryBudgetMultiplier(failCount: number): number {
-  return failCount === 0 ? 1.0 : 0.5;
+export function getRetryBudgetMultiplier(_failCount: number): number {
+  return 1.0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Raise per-issue turn/timeout budgets and remove the retry-halving multiplier, after observing the dominant PR patrol abandon outcome is **hitting the cap mid-fix**, not genuine dead-ends. Prior budgets were calibrated on a \"systematically unfixable\" hypothesis (see #3776 and #3827 comments) that did not hold up empirically.

## Budget changes

| Issue | Old turns | New turns | Old timeout | New timeout |
|-------|----------:|----------:|------------:|------------:|
| conflict | 30 | **60** | 20 min | **30 min** |
| ci-failure | 50 | **100** | 45 min | **60 min** |
| bot-review-major | 10 | **60** | 5 min | **20 min** |
| bot-review-nitpick | 8 | **30** | 5 min | **15 min** |
| merge-blocked | 10 | **30** | 5 min | **15 min** |
| self-authored-feedback | 20 | **60** | 15 min | **25 min** |
| stale | 10 | **30** | 5 min | **15 min** |
| missing-testplan | 8 | **30** | 5 min | **15 min** |
| stuck | 3 (unchanged — intercepted before dispatch) |

Global caps:
- `configMaxTurns` daemon/parallel default: 60 → **120**
- Branch-agent default: 30 → **60**
- Parallel conflict-retry rebase block: 30/15 → **60/30**

## Retry multiplier removed

`getRetryBudgetMultiplier` now returns `1.0` always. Halving on retry meant attempt 2 was almost guaranteed to fail on any PR that needed non-trivial work — if a full-budget first attempt couldn't finish, a half-budget one won't either. `parallel.ts` already passed `failCount: 0` to skip this reduction, so this change aligns `execution.ts` with the parallel path's existing behavior.

## Motivation

From \`~/.cache/pr-patrol/runs.jsonl\` in the last 24h:
- Lifetime outcome mix: 186 fixed / **165 max-turns** / 168 error / 40 timeout
- Recent pattern: #4400, #4422, #4434, #4441 all abandoned with \`max-turns, elapsed_s ≤ 200s\` — agents were still actively working, not stuck
- \`bot-review-major\` + \`self-authored-feedback\` combined budget of 20/15 was hit repeatedly on CodeRabbit-heavy PRs

## Test plan

- [x] \`pnpm vitest run crux/pr-patrol/\` — all 408 tests pass
- [x] \`scoring.test.ts\` updated: 36/36 pass (new budget values + no-halving retry assertions)
- [x] \`index.test.ts\` duplicate computeBudget block updated: 58/58 pass
- [ ] Reviewer: verify daemon picks up the new budgets after restart