### PR TITLE
QUA-565 Phase B.2: swap 3 tiny FK tables to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0188_qua_565_phase_b2_tiny_fk_tables.sql
+++ b/apps/wiki-server/drizzle/0188_qua_565_phase_b2_tiny_fk_tables.sql
@@ -1,0 +1,146 @@
+-- QUA-565 Phase B.2: swap 3 tiny tables from resources.id → resources.stable_id.
+--
+-- Part of QUA-549 Phase B. Follows the in-place pattern established by
+-- QUA-549 (0186, resource_content_versions) and QUA-564 (Phase B.1,
+-- publications + resource_policy_docs).
+--
+-- Scope (prod row counts, enumerated 2026-04-17):
+--   resource_tabular_sources — 14 rows, all hex16 — FK ON DELETE CASCADE
+--   source_snapshots         — 14 rows, all hex16 — FK ON DELETE SET NULL
+--   research_area_papers     — 73 rows, all hex16 — FK ON DELETE SET NULL
+--
+-- Pre-flight: 84 distinct resource_ids across the 3 tables all resolve to
+-- a resources row with a populated stable_id; 0 orphans.
+--
+-- Scope note: citation_quotes was in the original ticket scope but was
+-- deferred to its own Phase B.6 ticket due to a larger 12-file code surface.
+-- resource_content_versions also originally appeared in this phase but was
+-- shipped early as the QUA-549 pilot (migration 0186).
+--
+-- Column name stays `resource_id` on all three tables; only the FK reference
+-- target and the stored value change. Same minimal-churn approach as B.1.
+--
+-- Existing FK constraint names (enumerated from prod pg_constraint 2026-04-17):
+--   research_area_papers_resource_id_fkey     (postgres default)
+--   resource_tabular_sources_resource_id_fkey (postgres default)
+--   source_snapshots_resource_id_fkey         (postgres default)
+-- The DROP CONSTRAINT IF EXISTS below also covers the Drizzle-generated
+-- `<table>_<col>_<target_table>_<target_col>_fk` name, so this migration
+-- works against older dev/staging databases that used that convention.
+
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_tabular_sources.resource_id → resources.stable_id (CASCADE)
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_id is both PK and FK on this table. Only the FK changes here;
+-- the PK constraint is independent and stays in place.
+
+ALTER TABLE "resource_tabular_sources" DROP CONSTRAINT IF EXISTS "resource_tabular_sources_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "resource_tabular_sources" DROP CONSTRAINT IF EXISTS "resource_tabular_sources_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "resource_tabular_sources" rts
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rts.resource_id = r.id
+  AND rts.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+-- Fail loudly (with a clear message) rather than letting ADD CONSTRAINT
+-- reject with a generic FK error. Pre-flight found 0 orphans 2026-04-17.
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM resource_tabular_sources t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-565 migration aborted: % resource_tabular_sources row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'resource_tabular_sources_resource_id_resources_stable_id_fk'
+      AND table_name = 'resource_tabular_sources'
+  ) THEN
+    ALTER TABLE "resource_tabular_sources"
+      ADD CONSTRAINT "resource_tabular_sources_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- source_snapshots.resource_id → resources.stable_id (SET NULL)
+-- ────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "source_snapshots" DROP CONSTRAINT IF EXISTS "source_snapshots_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "source_snapshots" DROP CONSTRAINT IF EXISTS "source_snapshots_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "source_snapshots" ss
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE ss.resource_id = r.id
+  AND ss.resource_id IS NOT NULL
+  AND ss.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM source_snapshots t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-565 migration aborted: % source_snapshots row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'source_snapshots_resource_id_resources_stable_id_fk'
+      AND table_name = 'source_snapshots'
+  ) THEN
+    ALTER TABLE "source_snapshots"
+      ADD CONSTRAINT "source_snapshots_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE SET NULL;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- research_area_papers.resource_id → resources.stable_id (SET NULL)
+-- ────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE "research_area_papers" DROP CONSTRAINT IF EXISTS "research_area_papers_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "research_area_papers" DROP CONSTRAINT IF EXISTS "research_area_papers_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "research_area_papers" rap
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rap.resource_id = r.id
+  AND rap.resource_id IS NOT NULL
+  AND rap.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM research_area_papers t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-565 migration aborted: % research_area_papers row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'research_area_papers_resource_id_resources_stable_id_fk'
+      AND table_name = 'research_area_papers'
+  ) THEN
+    ALTER TABLE "research_area_papers"
+      ADD CONSTRAINT "research_area_papers_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1317,6 +1317,13 @@
       "when": 1785744000000,
       "tag": "0187_qua_564_resource_fk_swap_b1",
       "breakpoints": true
+    },
+    {
+      "idx": 188,
+      "version": "7",
+      "when": 1785830400000,
+      "tag": "0188_qua_565_phase_b2_tiny_fk_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -113,7 +113,12 @@ function formatFromNewTables(
     accessMethod: rts.accessMethod,
     recordType: rts.recordType,
     fetchUrl: res.url.startsWith("urn:") ? null : res.url,
-    resourceId: rts.resourceId,
+    // QUA-565 Phase B.2: we return res.id (the hex16 resources.id), NOT
+    // rts.resourceId (which is now a sid_). The web UI links to
+    // `/resources/${resourceId}` and /api/resources/:id still expects
+    // hex16. Keeping the response contract on hex16 avoids a UI regression
+    // until resources.id itself is retired in a later Phase B.*.
+    resourceId: res.id,
     publisherEntityId: res.publisherEntityId,
     updateFrequency: rts.updateFrequency,
     columnMapping: rts.columnMapping,
@@ -136,14 +141,16 @@ const dataSourcesApp = new Hono()
   .get("/", async (c) => {
     const db = getDrizzleDb();
 
-    // Join new tables for the base data
+    // Join new tables for the base data.
+    // QUA-565 Phase B.2: resourceTabularSources.resourceId references
+    // resources.stable_id, so the JOIN target is resources.stableId.
     const rows = await db
       .select({
         res: resources,
         rts: resourceTabularSources,
       })
       .from(resourceTabularSources)
-      .innerJoin(resources, eq(resources.id, resourceTabularSources.resourceId))
+      .innerJoin(resources, eq(resources.stableId, resourceTabularSources.resourceId))
       .orderBy(resources.title);
 
     // Compute snapshot metadata for each source.
@@ -164,14 +171,15 @@ const dataSourcesApp = new Hono()
     const db = getDrizzleDb();
     const id = c.req.param("id");
 
-    // Look up by sourceSlug (same as old data_sources.id)
+    // Look up by sourceSlug (same as old data_sources.id).
+    // QUA-565 Phase B.2: JOIN on resources.stable_id — see GET / above.
     const [row] = await db
       .select({
         res: resources,
         rts: resourceTabularSources,
       })
       .from(resourceTabularSources)
-      .innerJoin(resources, eq(resources.id, resourceTabularSources.resourceId))
+      .innerJoin(resources, eq(resources.stableId, resourceTabularSources.resourceId))
       .where(eq(resourceTabularSources.sourceSlug, id));
 
     if (!row) return notFoundError(c, "Data source not found");
@@ -237,6 +245,11 @@ const dataSourcesApp = new Hono()
     const url = body.fetchUrl ?? `urn:lw:tabular-source:${body.id}`;
     const resId = hashId(url);
     let actualResId = resId;
+    // QUA-565 Phase B.2: resource_tabular_sources.resource_id now references
+    // resources.stable_id, so we need the stable_id (not the hex16 id) when
+    // writing into that table. The API response keeps `resourceId` as the
+    // hex16 id to preserve the existing contract.
+    let actualStableId = "";
 
     await db.transaction(async (tx) => {
       // Upsert resource row. ON CONFLICT on URL handles the case where
@@ -263,16 +276,27 @@ const dataSourcesApp = new Hono()
             updatedAt: new Date(),
           },
         })
-        .returning({ id: resources.id });
+        .returning({ id: resources.id, stableId: resources.stableId });
 
       actualResId = upsertedResource.id;
+      // Post-QUA-536, resources.stable_id is NOT NULL at the DB level (even
+      // though the Drizzle schema type still allows null). The INSERT above
+      // always provides a generateId() value; ON CONFLICT preserves an
+      // existing one. A null here would indicate a pre-QUA-536 row slipping
+      // through, which shouldn't happen but is worth catching loudly.
+      if (!upsertedResource.stableId) {
+        throw new Error(
+          `resources.stable_id unexpectedly null for id=${actualResId} (url=${url})`
+        );
+      }
+      actualStableId = upsertedResource.stableId;
 
       // Upsert resource_tabular_sources. Conflict on sourceSlug (not resourceId)
       // so that changing a source's URL correctly updates the resourceId.
       await tx
         .insert(resourceTabularSources)
         .values({
-          resourceId: actualResId,
+          resourceId: actualStableId,
           sourceSlug: body.id,
           dataFormat: body.dataFormat,
           accessMethod: body.accessMethod,
@@ -286,7 +310,7 @@ const dataSourcesApp = new Hono()
         .onConflictDoUpdate({
           target: resourceTabularSources.sourceSlug,
           set: {
-            resourceId: actualResId,
+            resourceId: actualStableId,
             dataFormat: body.dataFormat,
             accessMethod: body.accessMethod,
             recordType: body.recordType,

--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -113,11 +113,8 @@ function formatFromNewTables(
     accessMethod: rts.accessMethod,
     recordType: rts.recordType,
     fetchUrl: res.url.startsWith("urn:") ? null : res.url,
-    // QUA-565 Phase B.2: we return res.id (the hex16 resources.id), NOT
-    // rts.resourceId (which is now a sid_). The web UI links to
-    // `/resources/${resourceId}` and /api/resources/:id still expects
-    // hex16. Keeping the response contract on hex16 avoids a UI regression
-    // until resources.id itself is retired in a later Phase B.*.
+    // QUA-565 Phase B.2: intentionally res.id (hex16), not rts.resourceId
+    // (now sid_). The UI links to /resources/:id, which still expects hex16.
     resourceId: res.id,
     publisherEntityId: res.publisherEntityId,
     updateFrequency: rts.updateFrequency,
@@ -141,9 +138,7 @@ const dataSourcesApp = new Hono()
   .get("/", async (c) => {
     const db = getDrizzleDb();
 
-    // Join new tables for the base data.
-    // QUA-565 Phase B.2: resourceTabularSources.resourceId references
-    // resources.stable_id, so the JOIN target is resources.stableId.
+    // QUA-565 Phase B.2: JOIN on resources.stable_id (the new FK target).
     const rows = await db
       .select({
         res: resources,
@@ -171,8 +166,7 @@ const dataSourcesApp = new Hono()
     const db = getDrizzleDb();
     const id = c.req.param("id");
 
-    // Look up by sourceSlug (same as old data_sources.id).
-    // QUA-565 Phase B.2: JOIN on resources.stable_id — see GET / above.
+    // Look up by sourceSlug. QUA-565 Phase B.2: JOIN on resources.stable_id.
     const [row] = await db
       .select({
         res: resources,
@@ -246,9 +240,8 @@ const dataSourcesApp = new Hono()
     const resId = hashId(url);
     let actualResId = resId;
     // QUA-565 Phase B.2: resource_tabular_sources.resource_id now references
-    // resources.stable_id, so we need the stable_id (not the hex16 id) when
-    // writing into that table. The API response keeps `resourceId` as the
-    // hex16 id to preserve the existing contract.
+    // resources.stable_id, so we write stable_id here. The API response still
+    // returns hex16 in `resourceId` to preserve the existing contract.
     let actualStableId = "";
 
     await db.transaction(async (tx) => {
@@ -279,11 +272,8 @@ const dataSourcesApp = new Hono()
         .returning({ id: resources.id, stableId: resources.stableId });
 
       actualResId = upsertedResource.id;
-      // Post-QUA-536, resources.stable_id is NOT NULL at the DB level (even
-      // though the Drizzle schema type still allows null). The INSERT above
-      // always provides a generateId() value; ON CONFLICT preserves an
-      // existing one. A null here would indicate a pre-QUA-536 row slipping
-      // through, which shouldn't happen but is worth catching loudly.
+      // resources.stable_id is NOT NULL post-QUA-536; throw loudly if a
+      // pre-migration row somehow slipped through rather than silently writing ''.
       if (!upsertedResource.stableId) {
         throw new Error(
           `resources.stable_id unexpectedly null for id=${actualResId} (url=${url})`

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, sql, and } from "drizzle-orm";
+import { eq, count, sql, and, inArray } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import {
@@ -36,6 +36,7 @@ import {
   researchAreaEvaluations,
   researchAreaScores,
   evaluationDimensions,
+  resources,
 } from "../../schema.js";
 
 // ---- Constants ----
@@ -523,6 +524,25 @@ const researchAreasApp = new Hono()
       byArea.set(item.researchAreaId, existing);
     }
 
+    // QUA-565 Phase B.2: research_area_papers.resource_id now references
+    // resources.stable_id. Translate any incoming hex16 values → sid_ via
+    // a single lookup before the transaction. Items whose resourceId is
+    // already a sid_ (or doesn't match any resources.id) pass through
+    // unchanged; the FK enforces validity at insert time.
+    const inputResourceIds = items
+      .map((item) => item.resourceId)
+      .filter((v): v is string => !!v);
+    const hexToStableId = new Map<string, string>();
+    if (inputResourceIds.length > 0) {
+      const resourceRows = await db
+        .select({ id: resources.id, stableId: resources.stableId })
+        .from(resources)
+        .where(inArray(resources.id, inputResourceIds));
+      for (const r of resourceRows) {
+        if (r.stableId) hexToStableId.set(r.id, r.stableId);
+      }
+    }
+
     await db.transaction(async (tx) => {
       // Delete existing papers for each area being synced, then bulk insert fresh
       for (const [areaId, areaItems] of byArea) {
@@ -533,7 +553,9 @@ const researchAreasApp = new Hono()
         await tx.insert(researchAreaPapers).values(
           areaItems.map((item) => ({
             researchAreaId: item.researchAreaId,
-            resourceId: item.resourceId ?? null,
+            resourceId: item.resourceId
+              ? hexToStableId.get(item.resourceId) ?? item.resourceId
+              : null,
             title: item.title,
             url: item.url ?? null,
             authors: item.authors ?? null,
@@ -601,12 +623,17 @@ const researchAreasApp = new Hono()
   .post("/backfill-papers-from-citations", async (c) => {
     const db = getDrizzleDb();
 
-    // Use raw SQL for the complex join + insert
+    // Use raw SQL for the complex join + insert.
+    // QUA-565 Phase B.2: research_area_papers.resource_id references
+    // resources.stable_id, so we SELECT r.stable_id (not r.id). The
+    // upstream JOIN (resource_citations.resource_id = r.id) is unchanged —
+    // resource_citations.resource_id still references resources.id until
+    // its own Phase B ticket lands.
     const result = await db.execute(sql`
       INSERT INTO research_area_papers (research_area_id, resource_id, title, url, authors, published_date, sort_order)
       SELECT
         ra.id,
-        r.id,
+        r.stable_id,
         COALESCE(r.title, 'Untitled'),
         r.url,
         CASE WHEN r.authors IS NOT NULL

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -1987,7 +1987,8 @@ const resourcesApp = new Hono()
       return notFoundError(c, `Resource not found: ${id}`);
     }
 
-    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId references resources.stable_id now.
+    // QUA-564 B.1: resourcePolicyDocs.resourceId → resources.stable_id.
+    // QUA-565 B.2: resourceTabularSources.resourceId → resources.stable_id.
     const stableId = rows[0].stableId ?? id;
     // Also fetch citations, sub-table data, and tabular source metadata
     const [citations, paperRows, forumRows, policyRows, tabularRows] = await Promise.all([
@@ -1998,7 +1999,7 @@ const resourcesApp = new Hono()
       db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, id)).limit(1),
       db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, id)).limit(1),
       db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, stableId)).limit(1),
-      db.select().from(resourceTabularSources).where(eq(resourceTabularSources.resourceId, id)).limit(1),
+      db.select().from(resourceTabularSources).where(eq(resourceTabularSources.resourceId, stableId)).limit(1),
     ]);
 
     // If tabular source, fetch latest snapshot metadata + preview

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -819,9 +819,12 @@ export const resourcePolicyDocs = pgTable("resource_policy_docs", {
  * Part of: Unify Data Sources into Resources (Discussion #3567, PR 2/5).
  */
 export const resourceTabularSources = pgTable("resource_tabular_sources", {
+  // QUA-565 Phase B.2: resource_id references resources.stable_id (not resources.id).
+  // Column name kept as `resource_id` for minimal churn — the value is now a
+  // `sid_`-prefixed stable_id, not a legacy hex16. See QUA-549 for context.
   resourceId: text("resource_id")
     .primaryKey()
-    .references(() => resources.id, { onDelete: "cascade" }),
+    .references(() => resources.stableId, { onDelete: "cascade" }),
   /** Human-readable slug (was data_sources.id, e.g. 'coefficient-giving') */
   sourceSlug: text("source_slug").notNull().unique(),
   /** csv | html_table | json_api | spreadsheet */
@@ -868,8 +871,11 @@ export const sourceSnapshots = pgTable("source_snapshots", {
   /** Human-readable slug referencing resource_tabular_sources.source_slug */
   sourceSlug: text("source_slug").notNull()
     .references(() => resourceTabularSources.sourceSlug, { onDelete: "cascade" }),
-  /** Resource ID from unified resources table */
-  resourceId: text("resource_id").references(() => resources.id, { onDelete: "set null" }),
+  /**
+   * Resource ID from unified resources table.
+   * QUA-565 Phase B.2: references resources.stable_id (column name unchanged).
+   */
+  resourceId: text("resource_id").references(() => resources.stableId, { onDelete: "set null" }),
   snapshotHash: text("snapshot_hash").notNull(),
   recordCount: integer("record_count"),
   /** Raw CSV/HTML/JSON text — the ground truth. Parsed on-demand. */
@@ -2791,7 +2797,8 @@ export const researchAreaPapers = pgTable(
     researchAreaId: text("research_area_id")
       .notNull()
       .references(() => researchAreas.id, { onDelete: "cascade" }),
-    resourceId: text("resource_id").references(() => resources.id, {
+    // QUA-565 Phase B.2: resource_id references resources.stable_id (not resources.id).
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     title: text("title").notNull(),


### PR DESCRIPTION
## Summary

Part of [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) Phase B. Migrates three tiny FK tables from referencing `resources.id` (legacy hex16) to `resources.stable_id` (canonical `sid_<10>`) in place. Same minimal-churn pattern as Phase B.1 (#4456): column names stay `resource_id`; only the FK target and stored value change.

Fixes QUA-565.

## Tables in scope

Prod row counts enumerated 2026-04-17:

| Table | Rows | `onDelete` |
| -- | -- | -- |
| `resource_tabular_sources` | 14 | CASCADE |
| `source_snapshots` | 14 | SET NULL |
| `research_area_papers` | 73 | SET NULL |

Pre-flight: 84 distinct referenced ids, **0 orphans**. All existing FK constraints are the postgres-default `<table>_<col>_fkey`.

### Scope note — 3 tables, not 5

The original ticket listed 5 tables. Two are resolved out-of-band:
- `resource_content_versions` shipped early via the QUA-549 pilot (migration 0186).
- `citation_quotes` was rescoped into Phase B.6 because it has a 12-file code surface across web components.

## What changed

- `apps/wiki-server/drizzle/0187_qua_565_phase_b2_tiny_fk_tables.sql` (new) — idempotent migration. `DROP CONSTRAINT IF EXISTS` covers both the Drizzle-generated and postgres-default names; `UPDATE` backfills hex16 → sid_ via JOIN; a `DO $$ ... RAISE EXCEPTION` block fails loudly (with a readable message) if any orphan would slip past the pre-flight; `ADD CONSTRAINT` guarded by `IF NOT EXISTS` for re-run safety. Same transactional-rollback safety as 0186.
- `apps/wiki-server/src/schema.ts` — three `.references()` targets flipped to `resources.stableId`.
- `apps/wiki-server/src/routes/tablebase/data-sources.ts` — JOINs now on `resources.stableId`; `POST /sync` writes stable_id into `resource_tabular_sources`; **the API response intentionally returns `resourceId: res.id` (hex16) to keep the `/resources/${resourceId}` UI link working** until `resources.id` itself is retired in a later phase. Throws on unexpected null `stable_id` rather than silently writing an empty string.
- `apps/wiki-server/src/routes/tablebase/research-areas.ts` — `POST /sync-papers` translates any incoming hex16 → sid_ via a single bulk lookup; `POST /backfill-papers-from-citations` raw SQL now `SELECT r.stable_id`.
- `apps/wiki-server/src/routes/wikibase/resources.ts` — `GET /api/resources/:id` resolves `resource_tabular_sources` via the resource's `stable_id`.

## Risk profile

Low-medium. 101 total rows across the 3 tables, all mapping cleanly to a populated `resources.stable_id`. The migration is transactional; a stuck migration would leave the constraint in its prior state. The one user-visible risk was a `/resources/:sid_xxx` 404 on data-source detail pages — avoided by keeping the API response contract on hex16 (reviewed and fixed during `/agent-review-pr`).

## Follow-ups (intentionally deferred)

- The `hexToStableId` Map pattern now appears in two files (here + PR #4456). If the remaining Phase B tickets repeat it, extract a `buildResourceHexToStableIdMap` helper under `apps/wiki-server/src/routes/shared/`. Not blocking here.
- The `stableId ?? id` fallback at `wikibase/resources.ts` matches the B.1 template; can be removed once QUA-549 Phase B completes and we trust the `NOT NULL` invariant codified in QUA-536.

## Test plan

- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json`: clean
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`: clean
- [x] `pnpm build`: succeeds
- [x] `pnpm test` (wiki-server, 1248 tests): all pass
- [x] `pnpm crux w validate gate`: all 44 blocking checks pass
- [x] `/agent-review-pr`: hostile-reviewer subagent ran; CRITICAL UI-link regression caught and fixed; orphan-check block added to match 0186's pattern
- [x] `/simplify`: comment blocks tightened
- [ ] Post-merge: verify 0187 applies cleanly on wiki-server startup (see Deploy Checklist)
- [ ] Post-merge: `GET /api/data-sources` returns hex16 `resourceId`; `/data-sources/<slug>` page "View resource record →" link still navigates correctly


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

Internal database restructuring to improve data consistency and referential integrity across system components.

* **Chores**
  * Database migration to optimize internal data relationships and consistency
  * Updated system components to align with restructured data mappings
  * Enhanced validation and referential integrity checks
  * Improved handling of dependent record management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->