### PR TITLE
QUA-567 Phase B.4: swap entity_resources.resource_id FK to resources.stable_id

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -907,8 +907,8 @@ function getOrgResourcesFromLinks(
   const RESEARCH_PUB_TYPES = new Set(["preprint_server", "academic_journal", "think_tank", "academic"]);
 
   // Authored resources → split into publications vs announcements by publication type.
-  // QUA-567 Phase B.4: rids from entity_resources are sid_ (resources.stable_id)
-  // after the FK swap; resolveResource() handles both legacy hex16 and sid_.
+  // resolveResource() handles both legacy hex16 and sid_ keyspace — links.authored
+  // values were hex16 before QUA-567 and are sid_ after.
   for (const rid of links.authored) {
     const r = resolveResource(rid);
     if (!r) continue;

--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -25,7 +25,7 @@ import {
   isOrganization,
   isPerson,
   isAiModel,
-  getResourceById,
+  resolveResource,
   getResourceCredibility,
   getResourcePublication,
   getPagesForResource,
@@ -906,9 +906,11 @@ function getOrgResourcesFromLinks(
   const aboutOrg: OrgResourceRow[] = [];
   const RESEARCH_PUB_TYPES = new Set(["preprint_server", "academic_journal", "think_tank", "academic"]);
 
-  // Authored resources → split into publications vs announcements by publication type
+  // Authored resources → split into publications vs announcements by publication type.
+  // QUA-567 Phase B.4: rids from entity_resources are sid_ (resources.stable_id)
+  // after the FK swap; resolveResource() handles both legacy hex16 and sid_.
   for (const rid of links.authored) {
-    const r = getResourceById(rid);
+    const r = resolveResource(rid);
     if (!r) continue;
     const row = normalizeRow(r, orgName);
     if (!row) continue;
@@ -926,7 +928,7 @@ function getOrgResourcesFromLinks(
   // Subject resources (not also authored) → press/coverage
   for (const rid of links.subject) {
     if (authoredSet.has(rid)) continue;
-    const r = getResourceById(rid);
+    const r = resolveResource(rid);
     if (!r) continue;
     const row = normalizeRow(r, orgName);
     if (!row) continue;

--- a/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
@@ -1,0 +1,50 @@
+-- QUA-567 Phase B.4: swap entity_resources.resource_id FK reference from
+-- resources.id → resources.stable_id.
+--
+-- This ticket is one of the 17-table migration from QUA-549 Phase B. Pattern
+-- follows QUA-564 (migration 0187) — in-place / Option B: column name stays
+-- `resource_id`, only the FK reference target changes, and the values are
+-- rewritten in-place from hex16 → sid_.
+--
+-- Prod state at time of authoring (2026-04-17, via direct query):
+--   - 4,182 rows in entity_resources, all hex16 format
+--   - 0 sid_ rows, 0 nulls, 0 orphans (every resource_id has a matching resource)
+--   - resources.stable_id is 100% populated (22,976/22,976)
+--
+-- The corresponding things_search MV JOIN fix ships in migration 0189.
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Drop old FK. Defensive IF EXISTS covers both the Drizzle-generated name
+-- and the postgres default (<table>_<column>_fkey). Only one will exist in
+-- any given environment.
+-- ────────────────────────────────────────────────────────────────────────
+ALTER TABLE "entity_resources" DROP CONSTRAINT IF EXISTS "entity_resources_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "entity_resources" DROP CONSTRAINT IF EXISTS "entity_resources_resource_id_fkey";--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Backfill: rewrite hex16 resource_id values to the corresponding sid_
+-- value via JOIN on resources. Guarded by NOT LIKE 'sid_%' so re-runs and
+-- environments that are already migrated are no-ops. 4,182 rows in prod;
+-- an indexed JOIN UPDATE completes well under statement_timeout.
+-- ────────────────────────────────────────────────────────────────────────
+UPDATE "entity_resources" er
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE er.resource_id = r.id
+  AND er.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Add new FK pointing at resources.stable_id. Preserves the existing
+-- CASCADE semantics. Idempotent so the migration can re-run safely.
+-- ────────────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'entity_resources_resource_id_resources_stable_id_fk'
+      AND table_name = 'entity_resources'
+  ) THEN
+    ALTER TABLE "entity_resources"
+      ADD CONSTRAINT "entity_resources_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
@@ -34,6 +34,25 @@ WHERE er.resource_id = r.id
   AND er.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
 
 -- ────────────────────────────────────────────────────────────────────────
+-- Fail-fast orphan check. After the backfill, every resource_id should be
+-- in sid_ form. If any remain non-sid_ it means the resources table is
+-- missing rows (orphan), and the subsequent ADD CONSTRAINT would fail
+-- with an opaque FK-violation message. Raising here produces an
+-- actionable error ("N orphan rows remain — resources table is missing
+-- entries for these resource_ids") instead.
+-- ────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  orphan_count INT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count FROM entity_resources
+  WHERE resource_id NOT LIKE 'sid_%';
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-567 migration halted: % orphan row(s) remain in entity_resources.resource_id after backfill. No matching resources.id was found. Fix by inserting missing resource rows or deleting orphans before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
 -- Add new FK pointing at resources.stable_id. Preserves the existing
 -- CASCADE semantics. Idempotent so the migration can re-run safely.
 -- ────────────────────────────────────────────────────────────────────────

--- a/apps/wiki-server/drizzle/0190_qua_567_rebuild_things_search_mv.sql
+++ b/apps/wiki-server/drizzle/0190_qua_567_rebuild_things_search_mv.sql
@@ -1,0 +1,597 @@
+-- QUA-567 Phase B.4: rebuild things_search MV so the entity-resource branch
+-- JOINs resources on stable_id instead of id.
+--
+-- Migration 0188 just rewrote entity_resources.resource_id from hex16 to
+-- sid_ and swapped the FK target to resources.stable_id. The MV created in
+-- 0181 still JOINs `res.id = er.resource_id` (line 291 in the original
+-- file), which won't match anymore — all 4,182 entity-resource rows in
+-- the MV would lose their resolved title/url on the next REFRESH (which
+-- the groundskeeper runs hourly).
+--
+-- Postgres has no CREATE OR REPLACE MATERIALIZED VIEW, so the whole
+-- definition has to be re-emitted. The body below is copied verbatim from
+-- 0181_create_things_search_mv.sql with a single substantive change on
+-- the entity-resource branch (search for "QUA-567" in this file). Keep in
+-- sync with any other MV edits — this file should be the current canonical
+-- definition until the next rebuild.
+--
+-- DROP + CREATE + REFRESH + CREATE INDEX runs inside the Drizzle migration
+-- transaction; external readers see either the old or the new MV snapshot,
+-- never an empty intermediate state. Total runtime in prod is expected to
+-- be ~30–60s (40,815 rows, 78 MB; 0181's initial refresh completed in
+-- similar time per docs/benchmarks/qua-506/).
+
+-- Idempotent re-run: drop any previous definition first.
+DROP MATERIALIZED VIEW IF EXISTS things_search;
+
+CREATE MATERIALIZED VIEW things_search AS
+SELECT
+  base.id,
+  base.thing_type,
+  base.title,
+  base.parent_thing_id,
+  base.source_table,
+  base.source_id,
+  base.entity_type,
+  base.description,
+  base.source_url,
+  base.wiki_id,
+  base.parent_title,
+  base.created_at,
+  base.updated_at,
+  base.synced_at,
+  (
+    setweight(to_tsvector('english', coalesce(base.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(base.parent_title, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(base.description, '')), 'C') ||
+    setweight(to_tsvector('english',
+      coalesce(replace(base.thing_type, '-', ' '), '') || ' ' ||
+      coalesce(replace(base.entity_type, '-', ' '), '')
+    ), 'D')
+  ) AS search_vector
+FROM (
+
+  -- 1. entity (from entities)
+  SELECT
+    e.stable_id::text   AS id,
+    'entity'::text      AS thing_type,
+    e.title             AS title,
+    NULL::text          AS parent_thing_id,
+    'entities'::text    AS source_table,
+    e.id::text          AS source_id,
+    e.entity_type       AS entity_type,
+    e.description       AS description,
+    e.website           AS source_url,
+    e.wiki_id           AS wiki_id,
+    NULL::text          AS parent_title,
+    e.created_at        AS created_at,
+    e.updated_at        AS updated_at,
+    e.synced_at         AS synced_at
+  FROM entities e
+
+  UNION ALL
+
+  -- 2. fact (from facts LEFT JOIN entities)
+  -- things.id convention: `factThingKey(entity_id, fact_id)` =
+  -- `encodeURIComponent(entity_id) || ':' || encodeURIComponent(fact_id)`.
+  -- Both columns are URL-safe (verified against prod 2026-04-15: 0 rows
+  -- with non-url-safe chars in either column), so the `||` concatenation
+  -- equals the TypeScript helper for all rows.
+  SELECT
+    (f.entity_id || ':' || f.fact_id)                      AS id,
+    'fact'::text                                           AS thing_type,
+    (COALESCE(f.label, f.measure, 'fact') || ' — ' ||
+      COALESCE(e.title, f.entity_id))                      AS title,
+    f.entity_id                                            AS parent_thing_id,
+    'facts'::text                                          AS source_table,
+    f.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    CASE
+      WHEN f.value IS NOT NULL
+        THEN COALESCE(f.label, f.measure, 'fact') || ': ' || f.value
+      WHEN f.numeric IS NOT NULL
+        THEN COALESCE(f.label, f.measure, 'fact') || ': ' || f.numeric::text
+      ELSE NULL
+    END                                                    AS description,
+    f.source                                               AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(e.title, f.entity_id)                         AS parent_title,
+    f.created_at                                           AS created_at,
+    f.updated_at                                           AS updated_at,
+    f.synced_at                                            AS synced_at
+  FROM facts f
+  LEFT JOIN entities e ON e.stable_id = f.entity_id
+
+  UNION ALL
+
+  -- 3. grant (from grants LEFT JOIN entities x4 — org/grantee, sid_ + slug)
+  -- `grants.organization_id` and `grants.grantee_id` can hold either a
+  -- stable_id OR a slug (entities.id). `resolveEntityTitles` accepts both
+  -- forms at write-time via an `IN (…) OR stable_id IN (…)` — mirror that
+  -- here with parallel LEFT JOINs so the MV renders resolved titles even
+  -- for slug-form FKs. Prevents raw slugs leaking into the 825 grant
+  -- `parent_title` rows that use slug org IDs today.
+  SELECT
+    g.id::text                                             AS id,
+    'grant'::text                                          AS thing_type,
+    g.name                                                 AS title,
+    g.organization_id                                      AS parent_thing_id,
+    'grants'::text                                         AS source_table,
+    g.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    NULLIF(
+      CONCAT_WS(', ',
+        CASE
+          WHEN g.grantee_id IS NOT NULL
+            THEN 'to ' || COALESCE(ge_sid.title, ge_slug.title, g.grantee_id)
+          ELSE NULL
+        END,
+        CASE
+          WHEN g.amount IS NOT NULL
+            THEN COALESCE(g.currency, 'USD') || ' ' || g.amount::text
+          ELSE NULL
+        END,
+        g.date
+      ),
+      ''
+    )                                                      AS description,
+    g.source                                               AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(oe_sid.title, oe_slug.title, g.organization_id) AS parent_title,
+    g.created_at                                           AS created_at,
+    g.updated_at                                           AS updated_at,
+    g.synced_at                                            AS synced_at
+  FROM grants g
+  LEFT JOIN entities oe_sid  ON oe_sid.stable_id  = g.organization_id
+  LEFT JOIN entities oe_slug ON oe_slug.id        = g.organization_id
+  LEFT JOIN entities ge_sid  ON ge_sid.stable_id  = g.grantee_id
+  LEFT JOIN entities ge_slug ON ge_slug.id        = g.grantee_id
+
+  UNION ALL
+
+  -- 4. personnel (from personnel LEFT JOIN entities x3)
+  -- Person name fallback mirrors the TS `cleanPersonId` helper (strip
+  -- `new:` prefix). Organization resolution accepts both sid_ and slug
+  -- forms to cover the 39 personnel rows with slug org IDs.
+  SELECT
+    p.id::text                                             AS id,
+    'personnel'::text                                      AS thing_type,
+    (
+      COALESCE(
+        pe.title,
+        p.person_display_name,
+        CASE
+          WHEN p.person_id LIKE 'new:%'
+            THEN substring(p.person_id from 5)
+          ELSE p.person_id
+        END
+      ) || ' — ' || p.role ||
+      ' at ' || COALESCE(oe_sid.title, oe_slug.title, p.organization_id)
+    )                                                      AS title,
+    NULL::text                                             AS parent_thing_id,
+    'personnel'::text                                      AS source_table,
+    p.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    p.source                                               AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(oe_sid.title, oe_slug.title, p.organization_id) AS parent_title,
+    p.created_at                                           AS created_at,
+    p.updated_at                                           AS updated_at,
+    p.synced_at                                            AS synced_at
+  FROM personnel p
+  LEFT JOIN entities pe      ON pe.stable_id      = p.person_entity_id
+  LEFT JOIN entities oe_sid  ON oe_sid.stable_id  = p.organization_id
+  LEFT JOIN entities oe_slug ON oe_slug.id        = p.organization_id
+
+  UNION ALL
+
+  -- 5. resource (from resources)
+  -- things.id convention: `COALESCE(r.stable_id, r.id)`. Resources table
+  -- has a mix of sid_-prefixed stable_ids (new rows) and legacy hex16 ids
+  -- (old rows, ~78% of rows as of 2026-04-15). The sync handler in
+  -- wikibase/resources.ts writes `r.stableId || r.id` as things.id.
+  SELECT
+    COALESCE(r.stable_id, r.id::text)                      AS id,
+    'resource'::text                                       AS thing_type,
+    COALESCE(r.title, r.url)                               AS title,
+    NULL::text                                             AS parent_thing_id,
+    'resources'::text                                      AS source_table,
+    r.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    r.summary                                              AS description,
+    r.url                                                  AS source_url,
+    NULL::text                                             AS wiki_id,
+    NULL::text                                             AS parent_title,
+    r.created_at                                           AS created_at,
+    r.updated_at                                           AS updated_at,
+    NULL::timestamptz                                      AS synced_at
+  FROM resources r
+
+  UNION ALL
+
+  -- 6. equity-position (from equity_positions LEFT JOIN entities x4)
+  -- Both holder_id and company_id can hold sid_ or slug — 11 of 13 rows
+  -- currently use slug form. Parallel sid_/slug joins so titles resolve.
+  SELECT
+    ep.id::text                                            AS id,
+    'equity-position'::text                                AS thing_type,
+    (
+      COALESCE(he_sid.title, he_slug.title, ep.holder_id) || ' stake in ' ||
+      COALESCE(ce_sid.title, ce_slug.title, ep.company_id)
+    )                                                      AS title,
+    ep.company_id                                          AS parent_thing_id,
+    'equity_positions'::text                               AS source_table,
+    ep.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    ep.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(ce_sid.title, ce_slug.title, ep.company_id)   AS parent_title,
+    ep.created_at                                          AS created_at,
+    ep.updated_at                                          AS updated_at,
+    ep.synced_at                                           AS synced_at
+  FROM equity_positions ep
+  LEFT JOIN entities he_sid  ON he_sid.stable_id  = ep.holder_id
+  LEFT JOIN entities he_slug ON he_slug.id        = ep.holder_id
+  LEFT JOIN entities ce_sid  ON ce_sid.stable_id  = ep.company_id
+  LEFT JOIN entities ce_slug ON ce_slug.id        = ep.company_id
+
+  UNION ALL
+
+  -- 7. political-race (from political_races)
+  SELECT
+    pr.id::text                                            AS id,
+    'political-race'::text                                 AS thing_type,
+    pr.name                                                AS title,
+    NULL::text                                             AS parent_thing_id,
+    'political_races'::text                                AS source_table,
+    pr.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    pr.ai_angle                                            AS description,
+    pr.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    pr.state                                               AS parent_title,
+    pr.created_at                                          AS created_at,
+    pr.updated_at                                          AS updated_at,
+    pr.synced_at                                           AS synced_at
+  FROM political_races pr
+
+  UNION ALL
+
+  -- 8. race-candidate (from race_candidates LEFT JOIN political_races)
+  SELECT
+    rc.id::text                                            AS id,
+    'race-candidate'::text                                 AS thing_type,
+    rc.candidate_display_name                              AS title,
+    rc.race_id                                             AS parent_thing_id,
+    'race_candidates'::text                                AS source_table,
+    rc.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    rc.ai_stance                                           AS description,
+    rc.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    pr2.name                                               AS parent_title,
+    rc.created_at                                          AS created_at,
+    rc.updated_at                                          AS updated_at,
+    rc.synced_at                                           AS synced_at
+  FROM race_candidates rc
+  LEFT JOIN political_races pr2 ON pr2.id = rc.race_id
+
+  UNION ALL
+
+  -- 9. entity-resource (from entity_resources LEFT JOIN entities + resources)
+  -- things.id convention: `'er:' || entity_id || ':' || resource_id`
+  -- (see tablebase/entity-resources.ts:180). entity-resources are not
+  -- currently written to things by the sync handler; MV rows exist only
+  -- here. `/api/things/:id` falls back to things_search so click-through
+  -- from search works.
+  --
+  -- QUA-567 Phase B.4: resources JOIN is on res.stable_id now (was res.id
+  -- in 0181). entity_resources.resource_id was backfilled hex16 → sid_ by
+  -- migration 0188, and the FK target was swapped to resources.stable_id.
+  SELECT
+    ('er:' || er.entity_id || ':' || er.resource_id)       AS id,
+    'entity-resource'::text                                AS thing_type,
+    COALESCE(res.title, res.url, er.resource_id)           AS title,
+    er.entity_id                                           AS parent_thing_id,
+    'entity_resources'::text                               AS source_table,
+    er.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    CASE
+      WHEN er.authored_by_entity THEN 'authored'
+      WHEN er.is_subject THEN 'about'
+      ELSE 'linked'
+    END                                                    AS description,
+    res.url                                                AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(ee.title, er.entity_id)                       AS parent_title,
+    er.created_at                                          AS created_at,
+    NULL::timestamptz                                      AS updated_at,
+    NULL::timestamptz                                      AS synced_at
+  FROM entity_resources er
+  LEFT JOIN entities ee ON ee.stable_id = er.entity_id
+  LEFT JOIN resources res ON res.stable_id = er.resource_id
+
+  UNION ALL
+
+  -- 10. entity-assessment (from entity_assessments LEFT JOIN entities)
+  SELECT
+    ea.id::text                                            AS id,
+    'entity-assessment'::text                              AS thing_type,
+    (ea.dimension || ': ' || ea.rating)                    AS title,
+    ea.entity_id                                           AS parent_thing_id,
+    'entity_assessments'::text                             AS source_table,
+    ea.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    ea.evidence                                            AS description,
+    ea.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(ae.title, ea.entity_id)                       AS parent_title,
+    ea.created_at                                          AS created_at,
+    ea.updated_at                                          AS updated_at,
+    ea.synced_at                                           AS synced_at
+  FROM entity_assessments ea
+  LEFT JOIN entities ae ON ae.stable_id = ea.entity_id
+
+  UNION ALL
+
+  -- 11. research-area (from research_areas)
+  SELECT
+    ra.id::text                                            AS id,
+    'research-area'::text                                  AS thing_type,
+    ra.title                                               AS title,
+    NULL::text                                             AS parent_thing_id,
+    'research_areas'::text                                 AS source_table,
+    ra.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    ra.description                                         AS description,
+    ra.source                                              AS source_url,
+    ra.wiki_id                                             AS wiki_id,
+    NULL::text                                             AS parent_title,
+    ra.created_at                                          AS created_at,
+    ra.updated_at                                          AS updated_at,
+    ra.synced_at                                           AS synced_at
+  FROM research_areas ra
+
+  UNION ALL
+
+  -- 12. investment (from investments LEFT JOIN entities x4, sid + slug)
+  SELECT
+    i.id::text                                             AS id,
+    'investment'::text                                     AS thing_type,
+    (
+      COALESCE(ie_sid.title, ie_slug.title, i.investor_id) || ' → ' ||
+      COALESCE(ce_sid.title, ce_slug.title, i.company_id) ||
+      COALESCE(' (' || i.round_name || ')', '')
+    )                                                      AS title,
+    i.company_id                                           AS parent_thing_id,
+    'investments'::text                                    AS source_table,
+    i.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    i.source                                               AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(ce_sid.title, ce_slug.title, i.company_id)    AS parent_title,
+    i.created_at                                           AS created_at,
+    i.updated_at                                           AS updated_at,
+    i.synced_at                                            AS synced_at
+  FROM investments i
+  LEFT JOIN entities ie_sid  ON ie_sid.stable_id  = i.investor_id
+  LEFT JOIN entities ie_slug ON ie_slug.id        = i.investor_id
+  LEFT JOIN entities ce_sid  ON ce_sid.stable_id  = i.company_id
+  LEFT JOIN entities ce_slug ON ce_slug.id        = i.company_id
+
+  UNION ALL
+
+  -- 13. policy-stakeholder (from policy_stakeholders LEFT JOIN entities)
+  SELECT
+    ps.id::text                                            AS id,
+    'policy-stakeholder'::text                             AS thing_type,
+    (
+      ps.stakeholder_display_name || ' on ' ||
+      COALESCE(pe2.title, ps.policy_entity_id)
+    )                                                      AS title,
+    ps.policy_entity_id                                    AS parent_thing_id,
+    'policy_stakeholders'::text                            AS source_table,
+    ps.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    ps.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(pe2.title, ps.policy_entity_id)               AS parent_title,
+    ps.created_at                                          AS created_at,
+    ps.updated_at                                          AS updated_at,
+    ps.synced_at                                           AS synced_at
+  FROM policy_stakeholders ps
+  LEFT JOIN entities pe2 ON pe2.stable_id = ps.policy_entity_id
+
+  UNION ALL
+
+  -- 14. benchmark-result (from benchmark_results LEFT JOIN entities + benchmarks)
+  SELECT
+    br.id::text                                            AS id,
+    'benchmark-result'::text                               AS thing_type,
+    (
+      COALESCE(me.title, br.model_id) || ' on ' ||
+      COALESCE(bm.name, br.benchmark_id) || ': ' || br.score::text
+    )                                                      AS title,
+    br.benchmark_id                                        AS parent_thing_id,
+    'benchmark_results'::text                              AS source_table,
+    br.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    br.source_url                                          AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(bm.name, br.benchmark_id)                     AS parent_title,
+    br.created_at                                          AS created_at,
+    br.updated_at                                          AS updated_at,
+    br.synced_at                                           AS synced_at
+  FROM benchmark_results br
+  LEFT JOIN entities me ON me.stable_id = br.model_id
+  LEFT JOIN benchmarks bm ON bm.id = br.benchmark_id
+
+  UNION ALL
+
+  -- 15. benchmark (from benchmarks)
+  SELECT
+    b.id::text                                             AS id,
+    'benchmark'::text                                      AS thing_type,
+    b.name                                                 AS title,
+    NULL::text                                             AS parent_thing_id,
+    'benchmarks'::text                                     AS source_table,
+    b.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    b.description                                          AS description,
+    b.website                                              AS source_url,
+    b.slug                                                 AS wiki_id,
+    NULL::text                                             AS parent_title,
+    b.created_at                                           AS created_at,
+    b.updated_at                                           AS updated_at,
+    b.synced_at                                            AS synced_at
+  FROM benchmarks b
+
+  UNION ALL
+
+  -- 16. entity-event (from entity_events LEFT JOIN entities)
+  SELECT
+    ev.id::text                                            AS id,
+    'entity-event'::text                                   AS thing_type,
+    -- Guard against NULL propagation: if ev.date is null the whole
+    -- concat is null, which violates the MV's (unenforced) NOT NULL
+    -- intent on title. Fall back to the bare event title.
+    (ev.title || COALESCE(' (' || ev.date || ')', ''))      AS title,
+    ev.entity_id                                           AS parent_thing_id,
+    'entity_events'::text                                  AS source_table,
+    ev.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    ev.description                                         AS description,
+    ev.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(eve.title, ev.entity_id)                      AS parent_title,
+    ev.created_at                                          AS created_at,
+    ev.updated_at                                          AS updated_at,
+    ev.synced_at                                           AS synced_at
+  FROM entity_events ev
+  LEFT JOIN entities eve ON eve.stable_id = ev.entity_id
+
+  UNION ALL
+
+  -- 17. division (from divisions LEFT JOIN entities)
+  SELECT
+    d.id::text                                             AS id,
+    'division'::text                                       AS thing_type,
+    d.name                                                 AS title,
+    d.parent_org_id                                        AS parent_thing_id,
+    'divisions'::text                                      AS source_table,
+    d.id::text                                             AS source_id,
+    NULL::text                                             AS entity_type,
+    d.division_type                                        AS description,
+    d.website                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(de.title, d.parent_org_id)                    AS parent_title,
+    d.created_at                                           AS created_at,
+    d.updated_at                                           AS updated_at,
+    d.synced_at                                            AS synced_at
+  FROM divisions d
+  LEFT JOIN entities de ON de.stable_id = d.parent_org_id
+
+  UNION ALL
+
+  -- 18. funding-round (from funding_rounds LEFT JOIN entities)
+  SELECT
+    fr.id::text                                            AS id,
+    'funding-round'::text                                  AS thing_type,
+    (fr.name || COALESCE(' (' || fr.date || ')', ''))      AS title,
+    fr.company_id                                          AS parent_thing_id,
+    'funding_rounds'::text                                 AS source_table,
+    fr.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    fr.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(fce.title, fr.company_display_name, fr.company_id) AS parent_title,
+    fr.created_at                                          AS created_at,
+    fr.updated_at                                          AS updated_at,
+    fr.synced_at                                           AS synced_at
+  FROM funding_rounds fr
+  LEFT JOIN entities fce ON fce.stable_id = fr.company_id
+
+  UNION ALL
+
+  -- 19. funding-program (from funding_programs LEFT JOIN entities)
+  SELECT
+    fp.id::text                                            AS id,
+    'funding-program'::text                                AS thing_type,
+    fp.name                                                AS title,
+    fp.org_id                                              AS parent_thing_id,
+    'funding_programs'::text                               AS source_table,
+    fp.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    fp.description                                         AS description,
+    fp.application_url                                     AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(fpe.title, fp.org_id)                         AS parent_title,
+    fp.created_at                                          AS created_at,
+    fp.updated_at                                          AS updated_at,
+    fp.synced_at                                           AS synced_at
+  FROM funding_programs fp
+  LEFT JOIN entities fpe ON fpe.stable_id = fp.org_id
+
+  UNION ALL
+
+  -- 20. division-personnel (from division_personnel LEFT JOIN entities)
+  SELECT
+    dp.id::text                                            AS id,
+    'division-personnel'::text                             AS thing_type,
+    (COALESCE(dpe.title, dp.person_display_name, dp.person_id) || ' — ' || dp.role) AS title,
+    dp.division_id                                         AS parent_thing_id,
+    'division_personnel'::text                             AS source_table,
+    dp.id::text                                            AS source_id,
+    NULL::text                                             AS entity_type,
+    NULL::text                                             AS description,
+    dp.source                                              AS source_url,
+    NULL::text                                             AS wiki_id,
+    NULL::text                                             AS parent_title,
+    dp.created_at                                          AS created_at,
+    dp.updated_at                                          AS updated_at,
+    dp.synced_at                                           AS synced_at
+  FROM division_personnel dp
+  LEFT JOIN entities dpe ON dpe.stable_id = dp.person_id
+
+  UNION ALL
+
+  -- 21. publication (from publications LEFT JOIN entities)
+  SELECT
+    pub.id::text                                           AS id,
+    'publication'::text                                    AS thing_type,
+    pub.title                                              AS title,
+    pub.entity_id                                          AS parent_thing_id,
+    'publications'::text                                   AS source_table,
+    pub.id::text                                           AS source_id,
+    NULL::text                                             AS entity_type,
+    NULLIF(CONCAT_WS(', ', pub.authors, pub.venue, pub.published_date), '') AS description,
+    pub.url                                                AS source_url,
+    NULL::text                                             AS wiki_id,
+    COALESCE(pue.title, pub.entity_display_name, pub.entity_id) AS parent_title,
+    pub.created_at                                         AS created_at,
+    pub.updated_at                                         AS updated_at,
+    pub.synced_at                                          AS synced_at
+  FROM publications pub
+  LEFT JOIN entities pue ON pue.stable_id = pub.entity_id
+
+) AS base
+WITH NO DATA;
+
+-- First refresh must be non-concurrent (MV is empty).
+REFRESH MATERIALIZED VIEW things_search;
+
+-- things_search_pkey is required for REFRESH CONCURRENTLY.
+CREATE UNIQUE INDEX things_search_pkey          ON things_search (id);
+CREATE INDEX        things_search_gin           ON things_search USING GIN (search_vector);
+CREATE INDEX        things_search_type_idx      ON things_search (thing_type);
+CREATE INDEX        things_search_parent_idx    ON things_search (parent_thing_id);
+CREATE INDEX        things_search_entity_type_idx ON things_search (entity_type);
+CREATE INDEX        things_search_updated_idx   ON things_search (updated_at);
+
+ANALYZE things_search;

--- a/apps/wiki-server/drizzle/0190_qua_567_rebuild_things_search_mv.sql
+++ b/apps/wiki-server/drizzle/0190_qua_567_rebuild_things_search_mv.sql
@@ -21,6 +21,15 @@
 -- be ~30–60s (40,815 rows, 78 MB; 0181's initial refresh completed in
 -- similar time per docs/benchmarks/qua-506/).
 
+-- Raise lock_timeout for the DROP step: the default migration client
+-- uses 60s (apps/wiki-server/src/db.ts), which is too tight if the
+-- hourly groundskeeper REFRESH holds AccessShareLock when this
+-- migration runs. 180s matches the /api/things-search/refresh
+-- endpoint's statement_timeout (see things-search-refresh.ts:34) so
+-- a worst-case in-flight REFRESH completes before we abort. QUA-302
+-- postmortem is the reference case for this failure shape.
+SET LOCAL lock_timeout = '180000';
+
 -- Idempotent re-run: drop any previous definition first.
 DROP MATERIALIZED VIEW IF EXISTS things_search;
 

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1324,6 +1324,20 @@
       "when": 1785830400000,
       "tag": "0188_qua_565_phase_b2_tiny_fk_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 189,
+      "version": "7",
+      "when": 1785916800000,
+      "tag": "0189_qua_567_entity_resources_fk_swap",
+      "breakpoints": true
+    },
+    {
+      "idx": 190,
+      "version": "7",
+      "when": 1785916800001,
+      "tag": "0190_qua_567_rebuild_things_search_mv",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/entity-profile-descriptions.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile-descriptions.ts
@@ -91,7 +91,7 @@ export const COLUMN_DESCRIPTIONS: Record<string, Record<string, string>> = {
   },
   entity_resources: {
     entity_id: "FK to entities.stable_id",
-    resource_id: "FK to resources.id",
+    resource_id: "FK to resources.stable_id",
     authored_by_entity: "Whether the entity authored/published this resource",
     is_subject: "Whether the resource is about this entity",
     inference_source:

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -156,16 +156,13 @@ const entityResourcesApp = new Hono()
         // map (resourceId → title + entityId → title). The composer uses
         // one lookup map; the keyspaces don't collide because resourceIds
         // and entityIds use different prefixes.
-        //
-        // QUA-567 Phase B.4: resourceIds are resources.stable_id (sid_)
-        // since migration 0188 swapped the FK target. Look up by
-        // resources.stableId and key the combined title map on stable_id
-        // so lookups from the composer (which sees r.resourceId) match.
-        const resourceRows = await tx
-          .select({ stableId: resources.stableId, title: resources.title, url: resources.url })
-          .from(resources)
-          .where(inArray(resources.stableId, resourceIds));
-        const entityTitleMap = await resolveEntityTitles(tx, entityIds);
+        const [resourceRows, entityTitleMap] = await Promise.all([
+          tx
+            .select({ stableId: resources.stableId, title: resources.title, url: resources.url })
+            .from(resources)
+            .where(inArray(resources.stableId, resourceIds)),
+          resolveEntityTitles(tx, entityIds),
+        ]);
         const combinedTitleMap = new Map<string, string>([
           ...resourceRows
             .filter((r): r is { stableId: string; title: string | null; url: string } => r.stableId !== null)

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -156,15 +156,22 @@ const entityResourcesApp = new Hono()
         // map (resourceId → title + entityId → title). The composer uses
         // one lookup map; the keyspaces don't collide because resourceIds
         // and entityIds use different prefixes.
+        //
+        // QUA-567 Phase B.4: resourceIds are resources.stable_id (sid_)
+        // since migration 0188 swapped the FK target. Look up by
+        // resources.stableId and key the combined title map on stable_id
+        // so lookups from the composer (which sees r.resourceId) match.
         const resourceRows = await tx
-          .select({ id: resources.id, title: resources.title, url: resources.url })
+          .select({ stableId: resources.stableId, title: resources.title, url: resources.url })
           .from(resources)
-          .where(inArray(resources.id, resourceIds));
+          .where(inArray(resources.stableId, resourceIds));
         const entityTitleMap = await resolveEntityTitles(tx, entityIds);
         const combinedTitleMap = new Map<string, string>([
-          ...resourceRows.map(
-            (r) => [r.id, r.title ?? r.url ?? r.id] as [string, string],
-          ),
+          ...resourceRows
+            .filter((r): r is { stableId: string; title: string | null; url: string } => r.stableId !== null)
+            .map(
+              (r) => [r.stableId, r.title ?? r.url ?? r.stableId] as [string, string],
+            ),
           ...entityTitleMap.entries(),
         ]);
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2859,9 +2859,13 @@ export const entityResources = pgTable(
     entityId: text("entity_id")
       .notNull()
       .references(() => entities.stableId, { onDelete: "cascade" }),
+    // QUA-567 Phase B.4: resource_id references resources.stable_id (not
+    // resources.id). Column name kept as `resource_id` for minimal code
+    // churn — the value is now a `sid_`-prefixed stable_id, not a legacy
+    // hex16. See QUA-549 for context.
     resourceId: text("resource_id")
       .notNull()
-      .references(() => resources.id, { onDelete: "cascade" }),
+      .references(() => resources.stableId, { onDelete: "cascade" }),
     authoredByEntity: boolean("authored_by_entity").notNull().default(false),
     isSubject: boolean("is_subject").notNull().default(false),
     inferenceSource: text("inference_source"),

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
+import { isSid } from "@longterm-wiki/id-utils";
 import type { CommandResult } from "../lib/command-types.ts";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import {
@@ -56,11 +57,11 @@ interface DatabaseJson {
   pageResources?: Record<string, string[]>;
 }
 
+// entity_resources.resource_id references resources.stable_id (not the
+// legacy hex16 resources.id) — all seed passes below emit stable_ids.
 interface MinimalResource {
   id: string;
   url?: string;
-  // QUA-567 Phase B.4: resources.stable_id is the canonical FK target for
-  // entity_resources.resource_id. Populated NOT NULL on prod as of QUA-536.
   stable_id?: string;
 }
 
@@ -126,14 +127,7 @@ function loadResources(): MinimalResource[] {
 }
 
 
-/**
- * Build normalized-URL → resource stable_id map from resources.json.
- *
- * QUA-567 Phase B.4: returns stable_ids so entity_resources.resource_id
- * (which now references resources.stable_id) gets the right FK value.
- * Resources without a stable_id are skipped (should be zero on prod per
- * Phase A / QUA-536, but the check makes local dev robust).
- */
+/** Normalized-URL → resource stable_id map from resources.json. */
 function buildUrlToResourceId(): Map<string, string> {
   const resources = loadResources();
   const map = new Map<string, string>();
@@ -145,10 +139,7 @@ function buildUrlToResourceId(): Map<string, string> {
   return map;
 }
 
-/**
- * Build hex16 (resources.id) → stable_id map for translating legacy IDs
- * that appear in database.json::pageResources. See seedFromWikiCitations.
- */
+/** Legacy hex16 → stable_id map, for translating pageResources entries. */
 function buildHexIdToStableId(): Map<string, string> {
   const resources = loadResources();
   const map = new Map<string, string>();
@@ -220,9 +211,6 @@ async function seedFromPublisher(
       const pubEntityId = r.publisherEntityId;
       if (!pubEntityId) continue;
 
-      // QUA-567 Phase B.4: entity_resources.resource_id now references
-      // resources.stable_id. Skip resources that somehow lack stable_id
-      // (should be zero on prod per Phase A / QUA-536).
       if (!r.stableId) continue;
 
       items.push({
@@ -256,9 +244,6 @@ function seedFromWikiCitations(
 ): { items: EntityResourceSyncItem[]; skipped: number } {
   const slugToStableId = loadSlugToStableId();
   const pageResources = loadPageResources();
-  // QUA-567 Phase B.4: pageResources contains hex16 resource IDs (the
-  // resources.id column). entity_resources.resource_id now references
-  // resources.stable_id, so translate via this lookup before emitting.
   const hexToStableId = buildHexIdToStableId();
   const items: EntityResourceSyncItem[] = [];
   let skipped = 0;
@@ -274,10 +259,9 @@ function seedFromWikiCitations(
     }
 
     for (const resourceId of resourceIds) {
-      // Accept both forms. In steady state pageResources still emits
-      // hex16 (build-data.mjs), but also accept sid_-prefixed IDs so the
-      // pipeline survives format churn during the Phase B rollout.
-      const translated = resourceId.startsWith("sid_")
+      // pageResources may contain either hex16 (legacy build-data.mjs
+      // output) or sid_-prefixed IDs, depending on when it was built.
+      const translated = isSid(resourceId)
         ? resourceId
         : hexToStableId.get(resourceId);
       if (!translated) {
@@ -406,9 +390,6 @@ async function seedFromAuthorEntityIds(
 
       const rawAuthorIds = (r as Record<string, unknown>).authorEntityIds;
       if (!Array.isArray(rawAuthorIds) || rawAuthorIds.length === 0) continue;
-
-      // QUA-567 Phase B.4: entity_resources.resource_id now references
-      // resources.stable_id (see migration 0188).
       if (!r.stableId) continue;
 
       // Filter to strings only and deduplicate per resource

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -18,7 +18,6 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
-import { isSid } from "@longterm-wiki/id-utils";
 import type { CommandResult } from "../lib/command-types.ts";
 import { PROJECT_ROOT } from "../lib/content-types.ts";
 import {
@@ -261,7 +260,7 @@ function seedFromWikiCitations(
     for (const resourceId of resourceIds) {
       // pageResources may contain either hex16 (legacy build-data.mjs
       // output) or sid_-prefixed IDs, depending on when it was built.
-      const translated = isSid(resourceId)
+      const translated = resourceId.startsWith("sid_")
         ? resourceId
         : hexToStableId.get(resourceId);
       if (!translated) {

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -59,6 +59,9 @@ interface DatabaseJson {
 interface MinimalResource {
   id: string;
   url?: string;
+  // QUA-567 Phase B.4: resources.stable_id is the canonical FK target for
+  // entity_resources.resource_id. Populated NOT NULL on prod as of QUA-536.
+  stable_id?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,14 +127,34 @@ function loadResources(): MinimalResource[] {
 
 
 /**
- * Build normalized-URL → resource ID map from resources.json.
+ * Build normalized-URL → resource stable_id map from resources.json.
+ *
+ * QUA-567 Phase B.4: returns stable_ids so entity_resources.resource_id
+ * (which now references resources.stable_id) gets the right FK value.
+ * Resources without a stable_id are skipped (should be zero on prod per
+ * Phase A / QUA-536, but the check makes local dev robust).
  */
 function buildUrlToResourceId(): Map<string, string> {
   const resources = loadResources();
   const map = new Map<string, string>();
   for (const r of resources) {
-    if (r.url) {
-      map.set(normalizeUrlForDedup(r.url), r.id);
+    if (r.url && r.stable_id) {
+      map.set(normalizeUrlForDedup(r.url), r.stable_id);
+    }
+  }
+  return map;
+}
+
+/**
+ * Build hex16 (resources.id) → stable_id map for translating legacy IDs
+ * that appear in database.json::pageResources. See seedFromWikiCitations.
+ */
+function buildHexIdToStableId(): Map<string, string> {
+  const resources = loadResources();
+  const map = new Map<string, string>();
+  for (const r of resources) {
+    if (r.stable_id) {
+      map.set(r.id, r.stable_id);
     }
   }
   return map;
@@ -197,9 +220,14 @@ async function seedFromPublisher(
       const pubEntityId = r.publisherEntityId;
       if (!pubEntityId) continue;
 
+      // QUA-567 Phase B.4: entity_resources.resource_id now references
+      // resources.stable_id. Skip resources that somehow lack stable_id
+      // (should be zero on prod per Phase A / QUA-536).
+      if (!r.stableId) continue;
+
       items.push({
         entityId: pubEntityId,
-        resourceId: r.id,
+        resourceId: r.stableId,
         authoredByEntity: true,
         isSubject: false,
         inferenceSource: "publisher_entity_id",
@@ -207,7 +235,7 @@ async function seedFromPublisher(
 
       if (options.verbose) {
         console.log(
-          `  authored: ${pubEntityId} → ${r.id} (${r.title?.slice(0, 60)})`,
+          `  authored: ${pubEntityId} → ${r.stableId} (${r.title?.slice(0, 60)})`,
         );
       }
     }
@@ -228,6 +256,10 @@ function seedFromWikiCitations(
 ): { items: EntityResourceSyncItem[]; skipped: number } {
   const slugToStableId = loadSlugToStableId();
   const pageResources = loadPageResources();
+  // QUA-567 Phase B.4: pageResources contains hex16 resource IDs (the
+  // resources.id column). entity_resources.resource_id now references
+  // resources.stable_id, so translate via this lookup before emitting.
+  const hexToStableId = buildHexIdToStableId();
   const items: EntityResourceSyncItem[] = [];
   let skipped = 0;
 
@@ -242,9 +274,24 @@ function seedFromWikiCitations(
     }
 
     for (const resourceId of resourceIds) {
+      // Accept both forms. In steady state pageResources still emits
+      // hex16 (build-data.mjs), but also accept sid_-prefixed IDs so the
+      // pipeline survives format churn during the Phase B rollout.
+      const translated = resourceId.startsWith("sid_")
+        ? resourceId
+        : hexToStableId.get(resourceId);
+      if (!translated) {
+        skipped++;
+        if (options.verbose) {
+          console.log(
+            `  skip: no stable_id for resource "${resourceId}" on page "${slug}"`,
+          );
+        }
+        continue;
+      }
       items.push({
         entityId: stableId,
-        resourceId,
+        resourceId: translated,
         authoredByEntity: false,
         isSubject: true,
         inferenceSource: "wiki_citation",
@@ -360,6 +407,10 @@ async function seedFromAuthorEntityIds(
       const rawAuthorIds = (r as Record<string, unknown>).authorEntityIds;
       if (!Array.isArray(rawAuthorIds) || rawAuthorIds.length === 0) continue;
 
+      // QUA-567 Phase B.4: entity_resources.resource_id now references
+      // resources.stable_id (see migration 0188).
+      if (!r.stableId) continue;
+
       // Filter to strings only and deduplicate per resource
       const seen = new Set<string>();
       for (const raw of rawAuthorIds) {
@@ -369,14 +420,14 @@ async function seedFromAuthorEntityIds(
 
         items.push({
           entityId: raw,
-          resourceId: r.id,
+          resourceId: r.stableId,
           authoredByEntity: true,
           isSubject: false,
           inferenceSource: "author_entity_ids",
         });
 
         if (options.verbose) {
-          console.log(`  authored: ${raw} → ${r.id} (${r.title?.slice(0, 60)})`);
+          console.log(`  authored: ${raw} → ${r.stableId} (${r.title?.slice(0, 60)})`);
         }
       }
     }


### PR DESCRIPTION
## Summary

Phase B.4 of [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) — migrates `entity_resources.resource_id` from referencing `resources.id` (legacy hex16) to `resources.stable_id` (canonical `sid_`). 4,182 rows, all currently hex16, are rewritten in-place to sid_.

Fixes QUA-567.

Follows the in-place / Option B pattern established by QUA-564 (PR #4456): column name stays `resource_id`; only the FK target and the values change.

## Prod state verified before authoring (2026-04-17)

| Metric | Value |
| -- | -- |
| entity_resources rows | 4,182 |
| sid_ rows | 0 |
| hex16 rows | 4,182 |
| nulls | 0 |
| orphans (no matching resources.id) | 0 |
| resources.stable_id populated | 22,976 / 22,976 (100%) |
| things_search MV rows | 40,815 (78 MB) |
| entity-resource rows in things_search | 4,182 |

Phase A (QUA-536) is fully landed — backfill is a simple indexed JOIN update.

## What changed

**Migrations**:

- `0188_qua_567_entity_resources_fk_swap.sql` — drop old FK (defensive IF EXISTS on both the Drizzle-generated name and the postgres default), UPDATE backfill hex16 → sid_, orphan fail-fast RAISE, add new FK with preserved CASCADE.
- `0189_qua_567_rebuild_things_search_mv.sql` — DROP + CREATE + REFRESH + INDEX the `things_search` MV with the entity-resource branch JOINing on `res.stable_id` instead of `res.id`. Postgres has no CREATE OR REPLACE MV, so the whole body is copied from `0181_create_things_search_mv.sql` with one substantive change (marked "QUA-567" in the entity-resource branch comment). `SET LOCAL lock_timeout = '180000'` at the top so a concurrent hourly groundskeeper REFRESH doesn't trip the default 60s lock_timeout (QUA-302 postmortem pattern).

**Schema / routes**:

- `apps/wiki-server/src/schema.ts` — `entityResources.resourceId.references()` now points at `resources.stableId`.
- `apps/wiki-server/src/routes/tablebase/entity-resources.ts` — postUpsert hook JOINs `resources.stableId` instead of `resources.id`, and runs the resource-title and entity-title lookups in parallel via `Promise.all`.
- `apps/wiki-server/src/routes/tablebase/entity-profile-descriptions.ts` — doc comment update.

**Consumer**:

- `apps/web/src/app/organizations/[slug]/org-data.ts` — `getResourceById` → `resolveResource` so `entityResourceLinks` values continue to resolve whether they're legacy hex16 (in cached `database.json` from before a rebuild) or sid_ (after).

**Seed command**:

- `crux/commands/entity-resources.ts` — all four seed passes now emit `r.stable_id` as the `resourceId`. Added a hex16 → stable_id translation for `pageResources` (which still contains hex16 from `build-data.mjs`). Skip-with-count behavior preserved.

## Why the MV rebuild is inline (not a manual migration)

If we split the MV rebuild out of the Drizzle migration, the next hourly groundskeeper REFRESH (running the *old* MV definition with `res.id = er.resource_id`) would regress all 4,182 entity-resource rows' titles to raw sid_ values until an operator ran the manual SQL. The inline approach with `lock_timeout = 180000` is tighter operationally.

## Review / hostile-review findings

`/agent-review-pr` spawned a hostile reviewer; key findings addressed before ship:

- **HIGH**: MV rebuild could hit the default 60s `lock_timeout` if groundskeeper REFRESH is in flight → added `SET LOCAL lock_timeout = '180000'`.
- **MEDIUM**: FK swap could fail opaquely on orphan rows → added a fail-fast `RAISE EXCEPTION` with an actionable message after the backfill.
- **MEDIUM (moot)**: `r.title ?? r.url ?? r.stableId` could display sid_ if both title and url were null — `resources.url` is `.notNull()` in the schema, so this branch is unreachable.

## Migration-number collision notes

- `0187` is claimed by PR #4456 (QUA-564 template). This PR uses `0188`, `0189`.
- Journal `idx` gap at 187 is documented; validate-drizzle-journal passes.
- If sibling PRs (QUA-565, QUA-568) land between #4456 and this PR, the loser rebases and bumps.

## Test plan

- [x] `pnpm test` (1248 wiki-server + 1612 web) — all pass
- [x] `pnpm build` — 103s, clean
- [x] `pnpm crux w validate gate` — 45/45 checks pass (2 advisory, 4 triage-skipped)
- [x] `npx tsc --noEmit` in apps/web, apps/wiki-server — clean
- [x] Prod row-count + orphan audit documented above
- [x] Narrow-patch detector: no matches
- [x] Hostile-reviewer subagent: 8 findings, 2 HIGH fixed, 1 moot, rest dismissed
- [x] `/simplify` pass: 3 concrete fixes (Promise.all, comment trim, isSid attempt)
- [ ] Post-merge: verify 0188 + 0189 apply cleanly and wiki-server reports `healthy`
- [ ] Post-merge: verify things_search MV has resolved titles (not sid_) for entity-resource rows


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0188 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `migration` Verify migration 0189 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` Confirm entity_resources FK points at resources.stable_id — `psql "$DATABASE_URL" -c "\d entity_resources" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE CASCADE`
- [ ] `manual` Spot-check resource_id values are sid_'s post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM entity_resources LIMIT 3;"`, expect all start with `sid_`
- [ ] `manual` Confirm the things_search MV was rebuilt with resolved titles (not sid_ leaks) — `psql "$DATABASE_URL" -c "SELECT COUNT(*) FILTER (WHERE title LIKE 'sid_%') AS sid_titles, COUNT(*) AS total FROM things_search WHERE thing_type='entity-resource';"`, expect `sid_titles=0 total=4182`
- [ ] `manual` Verify hourly groundskeeper things-search-refresh is still succeeding post-deploy — check `/internal/groundskeeper-runs` for a green `things-search-refresh` entry within ~90 minutes
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Updates**
  * Migrated resource identification system to use stable identifiers, ensuring consistent reference handling for resource links and authored content.
  * Rebuilt materialized view indexes to support both legacy and new resource identification formats.

* **Performance Improvements**
  * Optimized resource resolution processes with improved lookup efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->