### PR TITLE
QUA-568 Phase B.5: swap source_check_evidence FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0191_qua_568_sce_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0191_qua_568_sce_resource_id_to_stable_id.sql
@@ -43,13 +43,45 @@
 --     ON DELETE SET NULL;
 
 -- Step 1: drop the existing FK on resources.id.
--- IF EXISTS silences on re-runs. Both possible names are handled because
--- the phase1-sourcing-rename-rollback.sql history shows the constraint
--- may previously have been named `sourcing_evidence_resource_id_fkey`.
+-- Three possible names are handled because this table's constraint history is
+-- non-trivial — migration 0127 created it as `verification_evidence` with inline
+-- REFERENCES (auto-naming `verification_evidence_resource_id_fkey`), 0131
+-- renamed the TABLE to `source_check_evidence` but NOT its constraints (see
+-- docs/audits/qua-303-sourcing-rename-audit.md:48), and Drizzle may have
+-- subsequently normalized to a canonical name during introspection. All three
+-- IF EXISTS DROPs are idempotent no-ops when the name doesn't match; at least
+-- one is guaranteed to hit the actual name.
 ALTER TABLE source_check_evidence
   DROP CONSTRAINT IF EXISTS source_check_evidence_resource_id_resources_id_fk;
 ALTER TABLE source_check_evidence
   DROP CONSTRAINT IF EXISTS source_check_evidence_resource_id_fkey;
+ALTER TABLE source_check_evidence
+  DROP CONSTRAINT IF EXISTS verification_evidence_resource_id_fkey;
+
+-- Defensive sanity check: after the three DROPs, no FK on resource_id should
+-- remain pointing at resources.id. If one does, the pg_constraint name drifted
+-- beyond the three legacy variants we know about — fail loudly before the
+-- UPDATE violates it, rather than letting the migration half-apply.
+DO $$
+DECLARE
+  remaining_fk TEXT;
+BEGIN
+  SELECT conname INTO remaining_fk
+  FROM pg_constraint
+  WHERE conrelid = 'source_check_evidence'::regclass
+    AND contype = 'f'
+    AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+                       WHERE attrelid = 'source_check_evidence'::regclass
+                         AND attname = 'resource_id')]
+    AND confrelid = 'resources'::regclass
+    AND confkey = ARRAY[(SELECT attnum FROM pg_attribute
+                        WHERE attrelid = 'resources'::regclass
+                          AND attname = 'id')]
+  LIMIT 1;
+  IF remaining_fk IS NOT NULL THEN
+    RAISE EXCEPTION 'QUA-568 migration aborted: unexpected FK constraint "%" still points source_check_evidence.resource_id at resources.id after DROP attempts. Add an explicit DROP for this name and re-run.', remaining_fk;
+  END IF;
+END $$;
 
 -- Step 2: rewrite resource_id values from hex16 / `kb-<hex16>` → sid_<10>
 -- via JOIN on resources. Rows where resource_id IS NULL are untouched.

--- a/apps/wiki-server/drizzle/0191_qua_568_sce_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0191_qua_568_sce_resource_id_to_stable_id.sql
@@ -1,0 +1,93 @@
+-- QUA-568 Phase B.5: migrate source_check_evidence.resource_id from
+-- referencing resources.id (legacy hex16 / `kb-<hex16>`) to resources.stable_id
+-- (canonical `sid_<10>`).
+--
+-- Part of Phase B (QUA-549) of the resources-FK migration plan designed in
+-- QUA-498. This ticket is the "thorniest" of the 17 tables because the column
+-- feeds the verdict UI via /api/sourcing/* and backs source-check coverage
+-- dashboards (see QUA-568 body for the risk profile). It ships in its own PR
+-- to contain the verdict-API regression surface.
+--
+-- Follows the exact pattern established by the Phase B pilot in migration
+-- 0186_qua_549_rcv_resource_id_to_stable_id.sql (resource_content_versions).
+--
+-- Pre-flight (prod, 2026-04-17):
+--   5,337 rows with non-null resource_id (per QUA-549 audit, 2026-04-16).
+--   Sampled resource_id formats in prod: bare hex16 (e.g. 'aebe92781f2a19fb')
+--     and `kb-<hex16>` (e.g. 'kb-237cf097d225e116') — both are valid
+--     resources.id values (confirmed via GET /api/resources/<id>).
+--   0 orphans per parent-ticket audit across all 17 Phase B tables.
+--   Existing FK: source_check_evidence_resource_id_resources_id_fk
+--     ON DELETE SET NULL (matches schema.ts line 1691-1693).
+--   Preserve the SET NULL policy on the new FK — Phase B is not the place
+--   to change delete semantics (per QUA-549 non-goals).
+--
+-- No route handler JOINs `source_check_evidence.resource_id` against
+-- `resources` today — it is a pass-through column written by
+-- POST /api/sourcing/evidence and auto-resolved by
+-- crux/lib/sourcing/verdict-handler.ts::storeSourcingEvidence (via
+-- lookupResourceByUrl). That helper is updated in the same PR to read
+-- `resource.stableId` instead of `resource.id` so new evidence writes
+-- use the sid_ form.
+--
+-- Reverse migration (if needed):
+--   ALTER TABLE source_check_evidence
+--     DROP CONSTRAINT source_check_evidence_resource_id_resources_stable_id_fk;
+--   UPDATE source_check_evidence sce
+--     SET resource_id = r.id
+--     FROM resources r
+--     WHERE sce.resource_id = r.stable_id;
+--   ALTER TABLE source_check_evidence
+--     ADD CONSTRAINT source_check_evidence_resource_id_resources_id_fk
+--     FOREIGN KEY (resource_id) REFERENCES resources(id)
+--     ON DELETE SET NULL;
+
+-- Step 1: drop the existing FK on resources.id.
+-- IF EXISTS silences on re-runs. Both possible names are handled because
+-- the phase1-sourcing-rename-rollback.sql history shows the constraint
+-- may previously have been named `sourcing_evidence_resource_id_fkey`.
+ALTER TABLE source_check_evidence
+  DROP CONSTRAINT IF EXISTS source_check_evidence_resource_id_resources_id_fk;
+ALTER TABLE source_check_evidence
+  DROP CONSTRAINT IF EXISTS source_check_evidence_resource_id_fkey;
+
+-- Step 2: rewrite resource_id values from hex16 / `kb-<hex16>` → sid_<10>
+-- via JOIN on resources. Rows where resource_id IS NULL are untouched.
+-- Rows whose resource_id is already a sid_<10> (shouldn't exist today,
+-- but defensive for dev/staging replays) are left alone because the JOIN
+-- misses them.
+--
+-- Batching: at 5,337 rows this is well within statement_timeout. Parent
+-- ticket QUA-549 suggested the DO $$ LOOP batching pattern is only needed
+-- for tables > 1M rows; we follow the single-statement approach from the
+-- pilot migration 0186 (which handled 52 rows — same shape, different scale).
+UPDATE source_check_evidence sce
+SET resource_id = r.stable_id
+FROM resources r
+WHERE sce.resource_id = r.id;
+
+-- Step 3: verify no non-null resource_id values remain that don't map to a
+-- resources.stable_id. Pre-flight enumeration (QUA-549) found 0 orphans,
+-- but fail fast rather than silently letting ADD CONSTRAINT reject at
+-- migration time — that would block the whole deploy.
+DO $$
+DECLARE
+  orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*)
+  INTO orphan_count
+  FROM source_check_evidence sce
+  WHERE sce.resource_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM resources r WHERE r.stable_id = sce.resource_id
+    );
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-568 migration aborted: % source_check_evidence row(s) have a resource_id that maps to neither resources.id nor resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;
+
+-- Step 4: add the new FK on resources.stable_id, preserving SET NULL.
+ALTER TABLE source_check_evidence
+  ADD CONSTRAINT source_check_evidence_resource_id_resources_stable_id_fk
+  FOREIGN KEY (resource_id) REFERENCES resources(stable_id)
+  ON DELETE SET NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1338,6 +1338,13 @@
       "when": 1785916800001,
       "tag": "0190_qua_567_rebuild_things_search_mv",
       "breakpoints": true
+    },
+    {
+      "idx": 191,
+      "version": "7",
+      "when": 1785916800002,
+      "tag": "0191_qua_568_sce_resource_id_to_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1697,7 +1697,11 @@ export const recordSources = pgTable(
     fieldName: text("field_name"), // NULL = whole row, or specific column name
     entityId: text("entity_id"), // which entity this is about (for grouping/display)
     expectedValue: text("expected_value"), // what the record says
-    resourceId: text("resource_id").references(() => resources.id, {
+    // QUA-568 Phase B.5: references resources.stable_id (canonical sid_<10>)
+    // as of migration 0188. Previously referenced resources.id (legacy hex16).
+    // Column name stays `resource_id` to avoid churn across the Phase B series
+    // (matches the in-place pattern used by resource_content_versions in 0186).
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     sourceUrl: text("source_url"), // direct URL

--- a/crux/lib/sourcing/verdict-handler.test.ts
+++ b/crux/lib/sourcing/verdict-handler.test.ts
@@ -39,7 +39,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockStoreEvidence.mockResolvedValue({ ok: true, data: { id: 'ev-1' } as any });
   mockStoreVerdict.mockResolvedValue({ ok: true, data: { id: 'v-1' } as any });
-  mockLookupResourceByUrl.mockResolvedValue({ ok: true, data: { id: 'res-42' } as any });
+  // QUA-568 Phase B.5: source_check_evidence.resource_id now references
+  // resources.stable_id; storeSourcingEvidence writes the stableId form.
+  mockLookupResourceByUrl.mockResolvedValue({ ok: true, data: { id: 'res-42', stableId: 'sid_res42xxxx' } as any });
 });
 
 // ---------------------------------------------------------------------------
@@ -100,7 +102,7 @@ describe('storeSourcingEvidence', () => {
     expect(body.checkerModel).toBe('deterministic-row-match');
   });
 
-  it('resolves resourceId from URL when not supplied', async () => {
+  it('resolves resourceId (stable_id form) from URL when not supplied', async () => {
     await storeSourcingEvidence({
       recordType: 'grant',
       recordId: 'grant-1',
@@ -113,7 +115,10 @@ describe('storeSourcingEvidence', () => {
 
     expect(mockLookupResourceByUrl).toHaveBeenCalledWith('https://example.com/resource');
     const body = mockStoreEvidence.mock.calls[0][0];
-    expect(body.resourceId).toBe('res-42');
+    // QUA-568 Phase B.5: the helper now writes resource.data.stableId (sid_*)
+    // rather than resource.data.id (hex16) so the FK to resources.stable_id
+    // introduced by migration 0187 is satisfied.
+    expect(body.resourceId).toBe('sid_res42xxxx');
   });
 
   it('uses supplied resourceId without calling lookupResourceByUrl', async () => {

--- a/crux/lib/sourcing/verdict-handler.test.ts
+++ b/crux/lib/sourcing/verdict-handler.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
   mockStoreVerdict.mockResolvedValue({ ok: true, data: { id: 'v-1' } as any });
   // QUA-568 Phase B.5: source_check_evidence.resource_id now references
   // resources.stable_id; storeSourcingEvidence writes the stableId form.
-  mockLookupResourceByUrl.mockResolvedValue({ ok: true, data: { id: 'res-42', stableId: 'sid_res42xxxx' } as any });
+  mockLookupResourceByUrl.mockResolvedValue({ ok: true, data: { id: 'res-42', stableId: 'sid_Res42Abcde' } as any });
 });
 
 // ---------------------------------------------------------------------------
@@ -118,7 +118,31 @@ describe('storeSourcingEvidence', () => {
     // QUA-568 Phase B.5: the helper now writes resource.data.stableId (sid_*)
     // rather than resource.data.id (hex16) so the FK to resources.stable_id
     // introduced by migration 0187 is satisfied.
-    expect(body.resourceId).toBe('sid_res42xxxx');
+    expect(body.resourceId).toBe('sid_Res42Abcde');
+  });
+
+  it('falls back to NULL resourceId when lookup succeeds but stable_id is absent (QUA-568)', async () => {
+    // Prod has resources.stable_id NOT NULL (QUA-536 Phase A), but staging/test
+    // fixtures may lag. If the resource row lacks a stable_id, the new FK can't
+    // be satisfied by the legacy hex16 id — writing NULL is strictly safer than
+    // writing a value that would violate the FK.
+    mockLookupResourceByUrl.mockResolvedValueOnce({
+      ok: true,
+      data: { id: 'res-42', stableId: null } as any,
+    });
+
+    await storeSourcingEvidence({
+      recordType: 'grant',
+      recordId: 'grant-1',
+      sourceUrl: 'https://example.com/no-stableid',
+      verdict: 'supported',
+      confidence: 0.8,
+      extractedValue: '',
+      reasoning: '',
+    });
+
+    const body = mockStoreEvidence.mock.calls[0][0];
+    expect(body.resourceId).toBeNull();
   });
 
   it('uses supplied resourceId without calling lookupResourceByUrl', async () => {

--- a/crux/lib/sourcing/verdict-handler.ts
+++ b/crux/lib/sourcing/verdict-handler.ts
@@ -46,7 +46,11 @@ export async function storeSourcingEvidence(params: {
     try {
       const resource = await lookupResourceByUrl(params.sourceUrl);
       if (resource.ok) {
-        resolvedResourceId = resource.data.id;
+        // QUA-568 Phase B.5: source_check_evidence.resource_id now references
+        // resources.stable_id (sid_<10>), not resources.id (hex16). Write the
+        // stable_id here so new evidence rows satisfy the new FK (migration
+        // 0187). Older rows are back-filled by the migration's UPDATE step.
+        resolvedResourceId = resource.data.stableId;
       }
     } catch (e: unknown) {
       // Best-effort: resource lookup failure should not block evidence storage,


### PR DESCRIPTION
## Summary

QUA-568 **Phase B.5** of the QUA-549 resource-FK migration series. Migrates `source_check_evidence.resource_id` from referencing `resources.id` (legacy hex16 / `kb-<hex16>`) to `resources.stable_id` (canonical `sid_<10>`).

Parent ticket flags this as the **thorniest** of the 17 Phase B tables — it has the most rows (5,337 in prod), feeds the verdict UI via `/api/sourcing/*`, and backs the source-check coverage dashboards. Ships in its own PR to keep the verdict-API regression surface contained.

Follows the in-place pattern established by migration `0186_qua_549_rcv_resource_id_to_stable_id.sql` (Phase B pilot, merged in PR #4453): column name stays `resource_id`; only the FK target and data values flip.

Fixes QUA-568.

## What changed

### Migration: `apps/wiki-server/drizzle/0187_qua_568_sce_resource_id_to_stable_id.sql`

Five steps:

1. `DROP CONSTRAINT IF EXISTS` on **three** possible FK names. This table's constraint history is non-trivial — migration 0127 created it as `verification_evidence` (auto-named `verification_evidence_resource_id_fkey`), and 0131 renamed the **table** but NOT its constraints ([`docs/audits/qua-303-sourcing-rename-audit.md:48`](https://github.com/quantified-uncertainty/longterm-wiki/blob/main/docs/audits/qua-303-sourcing-rename-audit.md#L48)). So the migration drops `source_check_evidence_resource_id_resources_id_fk` (Drizzle convention), `source_check_evidence_resource_id_fkey` (PG auto-name, current table), and `verification_evidence_resource_id_fkey` (PG auto-name, pre-rename). At least one will match.
2. **Defensive `pg_constraint` sanity check** — raises if a 4th unknown FK name is still attached to `(resource_id → resources.id)` after the three DROPs, rather than letting Step 3's UPDATE fail at FK validation time.
3. Backfill `UPDATE sce SET resource_id = r.stable_id FROM resources r WHERE sce.resource_id = r.id`. Rewrites hex16 / `kb-<hex16>` → `sid_<10>`. 5,337 rows is comfortably within `statement_timeout`; follows the single-statement approach from the 0186 pilot rather than batched DO-loop (reserved for >1M row tables).
4. Orphan check — raises if any non-null `resource_id` doesn't map to a `resources.stable_id` (pre-flight found 0 orphans across all 17 Phase B tables per QUA-549 audit).
5. `ADD CONSTRAINT` on `resources.stable_id`, preserving `ON DELETE SET NULL` (Phase B non-goal: do not change delete semantics).

### Schema: `apps/wiki-server/src/schema.ts`

Flipped `recordSources.resourceId` from `.references(() => resources.id, ...)` to `.references(() => resources.stableId, ...)`. QUA-568 comment points at migration 0187.

### Crux caller: `crux/lib/sourcing/verdict-handler.ts`

`storeSourcingEvidence` resolves `resourceId` from a URL lookup. Updated to read `resource.data.stableId` instead of `resource.data.id` so new evidence rows satisfy the new FK. Falls back to NULL when `stableId` is absent (prod has it NOT NULL per Phase A / QUA-536; the fallback covers stale staging/test fixtures).

No server-side route changes needed: `source_check_evidence.resource_id` is a pass-through column in `POST /api/sourcing/evidence` (sourcing.ts) and is never JOINed against `resources` anywhere else.

### Tests: `crux/lib/sourcing/verdict-handler.test.ts`

- Updated the `lookupResourceByUrl` mock to include `stableId`.
- Updated the "resolves resourceId from URL" assertion to expect `sid_Res42Abcde` (proper 10-char sid).
- Added a new test for the null-stableId fallback path (asserts `body.resourceId === null` when lookup returns a resource without stableId).

23/23 tests pass in the verdict-handler suite; 101/101 in the relevant sourcing+citations suites.

## Pre-flight enumeration (prod, 2026-04-17)

Sampled via `/api/sourcing/evidence/:recordType/:recordId`:

| recordType | recordId          | resource_id                 | Format       |
|------------|-------------------|-----------------------------|--------------|
| grant      | tYKGZAznJn        | `aebe92781f2a19fb`          | hex16        |
| grant      | JcgRMKr73c        | `236572a394d569c5`          | hex16        |
| grant      | vasaRSdANN        | `null`                      | NULL         |
| fact       | f_GE2found01      | `kb-237cf097d225e116`       | `kb-<hex16>` |
| fact       | f_bWs7yJ0dPe      | `kb-c808dd961e2e3c1d`       | `kb-<hex16>` |
| fact       | f_qAmnDyPcjx      | `kb-0a3c825e304c51f7`       | `kb-<hex16>` |

Both formats are stored in `resources.id` and resolve via `GET /api/resources/<id>` — confirmed for both a raw `hex16` and a `kb-<hex16>` sample. Per QUA-549 parent audit: **0 orphans** across all 17 Phase B tables. Row count per the audit: **5,337**.

## Risks + mitigations

- **Public verdict surface** (`/organizations/:slug`, `/people/:slug`, etc.): verdict dots resolve through `source_check_evidence`, but the resolution path doesn't use `resource_id` (it reads `verdict`/`confidence`/etc.). No read-path change needed.
- **Source-check dashboards** (`/internal/entity-source-checks/`, `/internal/source-check-coverage/`): unaffected — they count verdicts, not `resource_id`.
- **Groundskeeper writes**: go through `storeSourcingEvidence` → updated in this PR to write `stableId`.
- **Rolling deploy window**: migrations run as a Helm `pre-upgrade` hook (see `ops/k8s/apps/longterm-wiki-server/templates/job-migration.yaml`), so the FK flip lands before pod rollout. Any crux invocation during the deploy window that uses pre-PR code would write hex16 → FK violation on the new FK. Mitigated by merging quickly and rebasing downstream branches.
- **Stale model detection**: `checker_model` filter unaffected (different column).

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` (verdict-handler + sourcing + citations suites) — 101 tests pass
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate gate --fix` — all 50 checks pass (4 pre-existing advisories)
- [x] `npx tsc --noEmit -p apps/wiki-server` — clean
- [x] `/agent-review-pr` — hostile subagent review found 1 CRITICAL (legacy FK name not dropped), 2 HIGH (null-stableId defense + test gap), 1 LOW (malformed mock sid_) — all fixed in review commit
- [x] Narrow-patch detector — no matches
- [x] Pre-flight prod enumeration — sampled 6 records across 2 recordTypes; confirmed both hex16 and `kb-<hex16>` formats resolve as valid `resources.id`
- [ ] Post-merge: migration 0187 applied successfully (degraded-mode health check)
- [ ] Post-merge: spot-check sourced verdict for an entity (e.g. `/organizations/anthropic`) still renders correctly


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` Confirm new FK is in place on prod — `psql "$DATABASE_URL" -c "\\d source_check_evidence"`, expect `source_check_evidence_resource_id_resources_stable_id_fk` line referencing `resources(stable_id) ON DELETE SET NULL`
- [ ] `manual` Spot-check that post-migration `resource_id` values are sid_-prefixed, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM source_check_evidence WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all start with `sid_`
- [ ] `manual` Visit `/organizations/anthropic` in prod and confirm verdict dots still render (verdict UI reads source_check_evidence)
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched evidence records to reference stable resource identifiers so stored evidence consistently links to resources by stable ID.
* **Data Migration**
  * Added a migration that rewrites existing evidence entries to use stable IDs and enforces referential integrity.
* **Tests**
  * Updated tests to expect and validate stable-ID behavior when resolving and storing resource references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->