### PR TITLE
feat(sourcing-recheck): add --verdict flag for targeted re-verification sweeps

### DIFF
--- a/crux/commands/sourcing-recheck.test.ts
+++ b/crux/commands/sourcing-recheck.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the --verdict flag added in QUA-546 — force-recheck of specific
+ * verdict types (bypassing the due-date filter). Focused on the code path
+ * that differs from the default due-for-recheck flow: input validation,
+ * which API is called, pagination, and empty-result handling.
+ *
+ * Uses --dry-run so the LLM layer doesn't need stubbing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockListVerdicts = vi.fn();
+const mockGetDueForRecheck = vi.fn();
+const mockGetEvidenceByRecords = vi.fn();
+const mockStoreVerdict = vi.fn();
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
+  listVerdicts: (...args: unknown[]) => mockListVerdicts(...args),
+  getDueForRecheck: (...args: unknown[]) => mockGetDueForRecheck(...args),
+  getEvidenceByRecords: (...args: unknown[]) => mockGetEvidenceByRecords(...args),
+  storeVerdict: (...args: unknown[]) => mockStoreVerdict(...args),
+  evidenceRecordKey: (rt: string, rid: string) => `${rt}|${rid}`,
+}));
+
+vi.mock('../lib/llm.ts', () => ({
+  createLlmClient: vi.fn(() => ({})),
+  callLlm: vi.fn(),
+}));
+
+vi.mock('../lib/sourcing/index.ts', () => ({
+  fetchSourceContent: vi.fn(),
+  callLlmForSourcing: vi.fn(),
+  storeSourcingEvidence: vi.fn(),
+  storeAggregateVerdict: vi.fn(),
+  SOURCE_CHECK_CONSTANTS: {
+    ESTIMATED_COST_PER_VERIFICATION: 0.01,
+    PROMPT_CONTENT_LENGTH: 50000,
+  },
+}));
+
+import { commands } from './sourcing-recheck.ts';
+
+const recheck = commands.default;
+
+function makeVerdict(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    recordType: 'grant',
+    recordId: 'g_test_1',
+    fieldName: null,
+    entityId: 'anthropic',
+    displayName: 'Test grant',
+    entityDisplayName: 'Anthropic',
+    verdict: 'partial',
+    confidence: 0.6,
+    reasoning: 'Source partially confirms amount',
+    sourcesChecked: 1,
+    needsRecheck: false,
+    nextCheckDue: '2026-05-17',
+    lastComputedAt: '2026-04-16',
+    createdAt: '2026-04-01',
+    updatedAt: '2026-04-16',
+    ...overrides,
+  };
+}
+
+describe('sourcing-recheck --verdict', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unknown verdict values', async () => {
+    const result = await recheck([], { verdict: 'typo', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Invalid --verdict');
+    expect(mockListVerdicts).not.toHaveBeenCalled();
+    expect(mockGetDueForRecheck).not.toHaveBeenCalled();
+  });
+
+  it('calls listVerdicts (not getDueForRecheck) when --verdict is set', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 1 },
+    });
+    const result = await recheck([], {
+      verdict: 'partial',
+      limit: '5',
+      budget: '1',
+      'dry-run': true,
+    } as never);
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(1);
+    expect(mockListVerdicts).toHaveBeenCalledWith({
+      verdict: 'partial',
+      recordType: undefined,
+      limit: 5,
+      offset: 0,
+    });
+    expect(mockGetDueForRecheck).not.toHaveBeenCalled();
+    expect(result.output).toContain('partial');
+  });
+
+  it('passes --type through to listVerdicts as recordType', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ recordType: 'personnel' })], total: 1 },
+    });
+    await recheck([], {
+      verdict: 'partial',
+      type: 'personnel',
+      limit: '10',
+      'dry-run': true,
+    } as never);
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ recordType: 'personnel', verdict: 'partial' }),
+    );
+  });
+
+  it('paginates when server total exceeds the 200-row per-page cap', async () => {
+    // Simulate 350 matching rows. With a 200-row page size, the command
+    // should make two calls: offset=0 (200 rows) and offset=200 (150 rows).
+    const page1 = Array.from({ length: 200 }, (_, i) =>
+      makeVerdict({ recordId: `g_${i}` }),
+    );
+    const page2 = Array.from({ length: 150 }, (_, i) =>
+      makeVerdict({ recordId: `g_${200 + i}` }),
+    );
+    mockListVerdicts
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page1, total: 350 } })
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page2, total: 350 } });
+
+    const result = await recheck([], {
+      verdict: 'partial',
+      limit: '500',
+      budget: '10',
+      'dry-run': true,
+    } as never);
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(2);
+    expect(mockListVerdicts).toHaveBeenNthCalledWith(1, expect.objectContaining({ offset: 0, limit: 200 }));
+    expect(mockListVerdicts).toHaveBeenNthCalledWith(2, expect.objectContaining({ offset: 200, limit: 200 }));
+  });
+
+  it('stops paginating once itemLimit is satisfied', async () => {
+    const page1 = Array.from({ length: 200 }, (_, i) => makeVerdict({ recordId: `g_${i}` }));
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: page1, total: 2000 },
+    });
+    await recheck([], {
+      verdict: 'partial',
+      limit: '200',
+      budget: '10',
+      'dry-run': true,
+    } as never);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a friendly message when no verdicts match', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+    const result = await recheck([], {
+      verdict: 'contradicted',
+      'dry-run': true,
+    } as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/No verdicts matched/i);
+  });
+
+  it('surfaces listVerdicts failures as exit=1', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: false,
+      message: 'boom',
+      error: { code: 'HTTP_500' },
+    });
+    const result = await recheck([], {
+      verdict: 'partial',
+      'dry-run': true,
+    } as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('boom');
+  });
+});

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -15,6 +15,7 @@ import type { CommandOptions as BaseOptions, CommandResult } from '../lib/comman
 import {
   storeVerdict as storeVerdictRpc,
   getDueForRecheck,
+  listVerdicts,
   getEvidenceByRecords,
   evidenceRecordKey,
 } from '../lib/wiki-server/sourcing-client.ts';
@@ -50,10 +51,21 @@ interface RecheckOptions extends BaseOptions {
   budget?: string;
   limit?: string;
   type?: string;
+  verdict?: string;
   'dry-run'?: boolean;
   dryRun?: boolean;
   ci?: boolean;
 }
+
+const VERDICT_PRIORITY: Record<string, number> = {
+  contradicted: 100,
+  outdated: 80,
+  partial: 50,
+  unverifiable: 30,
+  confirmed: 10,
+};
+
+const ALLOWED_FORCE_VERDICTS = new Set(Object.keys(VERDICT_PRIORITY));
 
 interface DueItem {
   recordType: string;
@@ -303,38 +315,100 @@ async function recheckCommand(
   const budgetLimit = options.budget ? parseFloat(String(options.budget)) : 1.0;
   const itemLimit = options.limit ? parseInt(String(options.limit), 10) : 50;
   const typeFilter = options.type as string | undefined;
+  const verdictFilter = options.verdict as string | undefined;
+
+  if (verdictFilter && !ALLOWED_FORCE_VERDICTS.has(verdictFilter)) {
+    return {
+      exitCode: 1,
+      output: `Invalid --verdict "${verdictFilter}". Must be one of: ${[...ALLOWED_FORCE_VERDICTS].join(', ')}`,
+    };
+  }
 
   console.log('\x1b[1mSource-Check Recheck Scheduler\x1b[0m');
   console.log('');
 
-  // ── Step 1: Fetch items due for recheck ──
-  console.log('Fetching items due for recheck...');
+  // ── Step 1: Fetch items ──
+  // When --verdict is passed, bypass the due-date filter and pull all verdicts
+  // matching that type. Used for targeted sweeps (QUA-546) where we want to
+  // re-run the improved LLM prompt against historical verdicts regardless of
+  // whether their nextCheckDue has elapsed.
+  let items: DueItem[];
+  let total: number;
 
-  const queryParams = new URLSearchParams();
-  queryParams.set('limit', String(itemLimit));
-  if (typeFilter) {
-    queryParams.set('record_type', typeFilter);
+  if (verdictFilter) {
+    console.log(`Fetching verdicts with verdict='${verdictFilter}' (bypassing due-date filter)...`);
+    // Server clamps per-page to MAX_PAGE_SIZE (200), so paginate client-side
+    // until we have `itemLimit` items or the server runs out. Without this,
+    // a large --limit silently returns only the first 200 and subsequent
+    // rows never get processed.
+    const PAGE_SIZE = 200;
+    const priority = VERDICT_PRIORITY[verdictFilter] ?? 0;
+    const collected: DueItem[] = [];
+    let serverTotal = 0;
+    let offset = 0;
+    while (collected.length < itemLimit) {
+      const pageSize = Math.min(PAGE_SIZE, itemLimit - collected.length);
+      const response = await listVerdicts({
+        verdict: verdictFilter,
+        recordType: typeFilter,
+        limit: pageSize,
+        offset,
+      });
+      if (!response.ok) {
+        return {
+          exitCode: 1,
+          output: `Failed to list verdicts: ${response.message}`,
+        };
+      }
+      serverTotal = response.data.total;
+      const rows = response.data.verdicts;
+      if (rows.length === 0) break;
+      for (const v of rows) {
+        collected.push({
+          recordType: v.recordType,
+          recordId: v.recordId,
+          fieldName: v.fieldName,
+          entityId: v.entityId,
+          verdict: v.verdict,
+          confidence: v.confidence,
+          reasoning: v.reasoning,
+          sourcesChecked: v.sourcesChecked,
+          needsRecheck: v.needsRecheck,
+          nextCheckDue: v.nextCheckDue,
+          lastComputedAt: v.lastComputedAt,
+          createdAt: v.createdAt,
+          updatedAt: v.updatedAt,
+          priority,
+        });
+      }
+      offset += rows.length;
+      if (offset >= serverTotal) break;
+    }
+    items = collected;
+    total = serverTotal;
+  } else {
+    console.log('Fetching items due for recheck...');
+    const response = await getDueForRecheck({ recordType: typeFilter, limit: itemLimit });
+    if (!response.ok) {
+      return {
+        exitCode: 1,
+        output: `Failed to fetch items due for recheck: ${response.message}`,
+      };
+    }
+    items = response.data.items;
+    total = response.data.total;
   }
-
-  const response = await getDueForRecheck({ recordType: typeFilter, limit: itemLimit });
-
-  if (!response.ok) {
-    return {
-      exitCode: 1,
-      output: `Failed to fetch items due for recheck: ${response.message}`,
-    };
-  }
-
-  const { items, total } = response.data;
 
   if (items.length === 0) {
     return {
       exitCode: 0,
-      output: 'No items due for recheck.',
+      output: verdictFilter
+        ? `No verdicts matched verdict='${verdictFilter}'${typeFilter ? ` type='${typeFilter}'` : ''}.`
+        : 'No items due for recheck.',
     };
   }
 
-  console.log(`  Found ${items.length} items due for recheck (${total} total in queue)`);
+  console.log(`  Found ${items.length} item(s)${verdictFilter ? '' : ' due for recheck'} (${total} total matching)`);
 
   // ── Step 2: Apply budget cap ──
   const maxByBudget = Math.floor(budgetLimit / ESTIMATED_COST_PER_VERIFICATION);
@@ -592,6 +666,10 @@ Options:
   --budget=N             Max dollars to spend (default: 1.0, est. ~$0.01/item)
   --limit=N              Max number of items to recheck (default: 50)
   --type=X               Filter by record type (e.g., personnel, fact, grant)
+  --verdict=X            Force-recheck all verdicts of this kind (confirmed |
+                         contradicted | outdated | partial | unverifiable),
+                         bypassing the next_check_due window. Used for
+                         targeted prompt-improvement sweeps.
   --dry-run              Preview what would be rechecked without running LLM
   --ci                   JSON output for CI pipelines
 


### PR DESCRIPTION
## Summary

Adds `--verdict=<confirmed|contradicted|outdated|partial|unverifiable>` to `crux sourcing-recheck`. When set, pulls matching rows from `/verdicts` instead of `/due-for-recheck`, bypassing the `nextCheckDue` window. Enables targeted sweeps of a specific verdict bucket after prompt/tooling improvements, rather than waiting out the recheck interval.

Paginates client-side at 200/page to respect the server's `MAX_PAGE_SIZE` cap, so large `--limit` values don't silently truncate.

## Pilot findings (QUA-546)

Per the ticket, we ran a pilot before the full sweep to validate the conversion rate from bulk re-verification of partial verdicts:

| Bucket | Sample | Result |
|---|---|---|
| facts (100 items, $1) | partial → confirmed: **2**, stayed partial: **98** | ~2% conversion |
| grants (50 items, $0.50) | partial → **unverifiable**: **46**, stayed partial: **4**, confirmed: **0** | shifts to a different non-green bucket |

**Takeaway**: bulk re-verification alone does not hit the `<300 partial` target. Most partial verdicts have a source URL that genuinely doesn't fully confirm the claim — the LLM is consistent against the same URL. The real lever is the **URL-quality sweep** (proposed fix #2 in the ticket): extend `sourcing-suggest-urls` (currently `unverifiable`-only) to cover partial verdicts and find better sources.

This PR ships the tooling so future sweeps are possible. A follow-up will extend `sourcing-suggest-urls` to the partial bucket.

## Tests

`crux/commands/sourcing-recheck.test.ts` — 7 tests covering:
- Invalid verdict rejection
- `listVerdicts` vs `getDueForRecheck` dispatch
- `--type` passthrough
- Client-side pagination (multi-page and itemLimit cutoff)
- Empty-result messaging
- Upstream error surfacing

## Test plan

- [x] Unit tests (7 passing)
- [x] Prod dry-run smoke: `WIKI_SERVER_ENV=prod pnpm crux sourcing-recheck --verdict=partial --dry-run --limit=10` — returned 10 of 2165 matching, correct verdict filter applied
- [x] End-to-end pilot (100 fact items + 50 grant items) — verdicts stored and changes reported correctly
- [ ] CI green

Fixes QUA-546 (tooling); URL-quality sweep to be filed as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
