### PR TITLE
fix(workflows): add PROD_LONGTERMWIKI_SERVER_URL to wellness workflows

### DIFF
--- a/.github/workflows/ci-pr-health.yml
+++ b/.github/workflows/ci-pr-health.yml
@@ -60,6 +60,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       - name: PR & issue quality
         run: pnpm crux health check --check=pr-quality --report --auto-issue --cleanup-labels
         env:

--- a/.github/workflows/frontend-data-health.yml
+++ b/.github/workflows/frontend-data-health.yml
@@ -53,3 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}

--- a/.github/workflows/server-api-health.yml
+++ b/.github/workflows/server-api-health.yml
@@ -48,9 +48,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
       - name: API smoke tests
         run: pnpm crux health check --check=api --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
+          # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
+          PROD_LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
+          PROD_LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}


### PR DESCRIPTION
## Summary

Three scheduled wellness-check workflows (`server-api-health.yml`, `frontend-data-health.yml`, `ci-pr-health.yml`) have been failing twice daily with `LONGTERMWIKI_SERVER_URL not set`.

Root cause: `crux health check` defaults to `WIKI_SERVER_ENV=prod`, so `getServerUrl()` / `getApiKey()` read `PROD_LONGTERMWIKI_SERVER_URL` / `PROD_LONGTERMWIKI_SERVER_API_KEY`. The three workflows only exported the unprefixed variants, so the env lookup failed and the wellness-issue updater looped on `exit 1` (driving the permanent open issue #4463).

Fix: add `PROD_LONGTERMWIKI_SERVER_URL` + `PROD_LONGTERMWIKI_SERVER_API_KEY` to every step in these three workflows that calls `pnpm crux health check` against the wiki-server.

Mirrors the QUA-396 fix applied earlier to `sourcing-recheck.yml`.

## Files changed

- `.github/workflows/server-api-health.yml` — both steps (`Server health`, `API smoke tests`)
- `.github/workflows/frontend-data-health.yml` — `Data freshness` only (the `Frontend availability` step only needs `WIKI_PUBLIC_URL`)
- `.github/workflows/ci-pr-health.yml` — `Job queue health` only (the other two steps only need `GITHUB_TOKEN`)

## Test plan

- [x] YAML parses in all three files, `jobs.check.steps` structure intact
- [x] Every step that references `LONGTERMWIKI_SERVER_URL` now also references `PROD_LONGTERMWIKI_SERVER_URL` (and same for API key) — verified via `js-yaml` scan
- [x] Gate passes (`pnpm crux w validate gate --fix`)
- [ ] After merge: manually trigger each workflow via `workflow_dispatch` and confirm the data-freshness / job-queue / server-health steps pass
- [ ] After merge: confirm wellness issue #4463 auto-closes on the next green run

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `ci` Modified workflow "ci pr health" — verify it runs successfully after merge — `gh run list --workflow="ci-pr-health.yml" --limit=1 --json status,conclusion`
- [ ] `ci` Modified workflow "frontend data health" — verify it runs successfully after merge — `gh run list --workflow="frontend-data-health.yml" --limit=1 --json status,conclusion`
- [ ] `ci` Modified workflow "server api health" — verify it runs successfully after merge — `gh run list --workflow="server-api-health.yml" --limit=1 --json status,conclusion`
- [ ] `manual` Trigger each wellness workflow directly rather than waiting for the next scheduled run — `gh workflow run ci-pr-health.yml && gh workflow run frontend-data-health.yml && gh workflow run server-api-health.yml`
- [ ] `manual` Verify wellness issue #4463 auto-closes after the three manually-triggered runs succeed — `gh issue view 4463 -R quantified-uncertainty/longterm-wiki`
<!-- /deploy-tasks -->

Fixes QUA-583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD health check workflows with additional environment variable configurations to support production server connectivity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->