### PR TITLE
fix(qua-567): address bot review comments post-merge — orphan check, sid_ validation, comment

### DIFF
--- a/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0189_qua_567_entity_resources_fk_swap.sql
@@ -11,7 +11,7 @@
 --   - 0 sid_ rows, 0 nulls, 0 orphans (every resource_id has a matching resource)
 --   - resources.stable_id is 100% populated (22,976/22,976)
 --
--- The corresponding things_search MV JOIN fix ships in migration 0189.
+-- The corresponding things_search MV JOIN fix ships in migration 0190.
 
 -- ────────────────────────────────────────────────────────────────────────
 -- Drop old FK. Defensive IF EXISTS covers both the Drizzle-generated name
@@ -31,7 +31,8 @@ UPDATE "entity_resources" er
 SET resource_id = r.stable_id
 FROM "resources" r
 WHERE er.resource_id = r.id
-  AND er.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+  AND er.resource_id NOT LIKE 'sid_%'
+  AND r.stable_id IS NOT NULL;--> statement-breakpoint
 
 -- ────────────────────────────────────────────────────────────────────────
 -- Fail-fast orphan check. After the backfill, every resource_id should be
@@ -45,10 +46,15 @@ DO $$
 DECLARE
   orphan_count INT;
 BEGIN
-  SELECT COUNT(*) INTO orphan_count FROM entity_resources
-  WHERE resource_id NOT LIKE 'sid_%';
+  SELECT COUNT(*) INTO orphan_count
+  FROM entity_resources er
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM resources r
+    WHERE r.stable_id = er.resource_id
+  );
   IF orphan_count > 0 THEN
-    RAISE EXCEPTION 'QUA-567 migration halted: % orphan row(s) remain in entity_resources.resource_id after backfill. No matching resources.id was found. Fix by inserting missing resource rows or deleting orphans before re-running.', orphan_count;
+    RAISE EXCEPTION 'QUA-567 migration halted: % orphan row(s) remain in entity_resources.resource_id after backfill. No matching resources.stable_id was found. Fix by inserting missing resource rows or deleting orphans before re-running.', orphan_count;
   END IF;
 END $$;--> statement-breakpoint
 

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -154,8 +154,8 @@ const entityResourcesApp = new Hono()
 
         // Resolve resource titles and entity titles into a single combined
         // map (resourceId → title + entityId → title). The composer uses
-        // one lookup map; the keyspaces don't collide because resourceIds
-        // and entityIds use different prefixes.
+        // one lookup map; after QUA-567 both keys are stable IDs, so this
+        // relies on stable IDs being globally unique across these tables.
         const [resourceRows, entityTitleMap] = await Promise.all([
           tx
             .select({ stableId: resources.stableId, title: resources.title, url: resources.url })

--- a/crux/commands/entity-resources.ts
+++ b/crux/commands/entity-resources.ts
@@ -244,6 +244,7 @@ function seedFromWikiCitations(
   const slugToStableId = loadSlugToStableId();
   const pageResources = loadPageResources();
   const hexToStableId = buildHexIdToStableId();
+  const knownStableIds = new Set(hexToStableId.values());
   const items: EntityResourceSyncItem[] = [];
   let skipped = 0;
 
@@ -260,8 +261,12 @@ function seedFromWikiCitations(
     for (const resourceId of resourceIds) {
       // pageResources may contain either hex16 (legacy build-data.mjs
       // output) or sid_-prefixed IDs, depending on when it was built.
+      // For sid_ values, validate against knownStableIds to catch stale
+      // or invalid IDs that no longer exist in the resources table.
       const translated = resourceId.startsWith("sid_")
-        ? resourceId
+        ? knownStableIds.has(resourceId)
+          ? resourceId
+          : undefined
         : hexToStableId.get(resourceId);
       if (!translated) {
         skipped++;


### PR DESCRIPTION
## Summary

Follow-up to PR #4460 (QUA-567 Phase B.4) addressing 3 bot review comments that were identified after the PR merged.

- **Fix 1 (Important):** Replace the fail-fast orphan check's `NOT LIKE 'sid_%'` heuristic with a `NOT EXISTS` subquery that checks the actual FK target. A row with a valid-looking `sid_` that has no matching `resources.stable_id` would previously bypass the error and fail later with an opaque FK-violation. Also adds `AND r.stable_id IS NOT NULL` guard to the UPDATE backfill, and fixes the error message to say "No matching resources.stable_id was found". Fixes comment reference 0189→0190.
- **Fix 2 (Nitpick):** Update stale comment in `entity-resources.ts` — after QUA-567, both resourceIds and entityIds are stable IDs, not "different prefixes".
- **Fix 3 (Major, outside diff):** In `crux/commands/entity-resources.ts::seedFromWikiCitations`, validate `sid_`-prefixed resource IDs against a `knownStableIds` set derived from `hexToStableId.values()`. Previously, a `sid_` value that appeared in pageResources data but didn't exist in the resources table would pass through unvalidated and fail at the server sync endpoint.

Note: Migration 0189 is already applied in prod, so the SQL changes are for correctness in test environments and documentation clarity.

## Test plan

- [ ] Gate checks pass (verified locally — all 42 blocking checks pass)
- [ ] `crux/commands/entity-resources.ts` now correctly skips stale/invalid `sid_` resource IDs rather than passing them through to the sync endpoint

Closes #4460 review comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)