### PR TITLE
review(sourcing-recheck): add pagination max-iterations guard + edge-case tests

### DIFF
--- a/crux/commands/sourcing-recheck.test.ts
+++ b/crux/commands/sourcing-recheck.test.ts
@@ -155,6 +155,45 @@ describe('sourcing-recheck --verdict', () => {
     expect(mockListVerdicts).toHaveBeenCalledTimes(1);
   });
 
+  it('shrinks the final page request to remaining itemLimit (mid-page truncation)', async () => {
+    // itemLimit=250 → page 1 asks for 200, page 2 asks for 50 (not another 200).
+    const page1 = Array.from({ length: 200 }, (_, i) => makeVerdict({ recordId: `g_${i}` }));
+    const page2 = Array.from({ length: 50 }, (_, i) => makeVerdict({ recordId: `g_${200 + i}` }));
+    mockListVerdicts
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page1, total: 2000 } })
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page2, total: 2000 } });
+
+    await recheck([], {
+      verdict: 'partial',
+      limit: '250',
+      budget: '10',
+      'dry-run': true,
+    } as never);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(2);
+    expect(mockListVerdicts).toHaveBeenNthCalledWith(1, expect.objectContaining({ limit: 200, offset: 0 }));
+    expect(mockListVerdicts).toHaveBeenNthCalledWith(2, expect.objectContaining({ limit: 50, offset: 200 }));
+  });
+
+  it('aborts if pagination exceeds MAX_ITERATIONS (broken server metadata)', async () => {
+    // Simulate a broken server that returns 1 row but claims total=99999
+    // every time. Without a max-iterations guard, the command would loop
+    // until it hit --limit. With the guard, it aborts at 100 iterations.
+    mockListVerdicts.mockResolvedValue({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 99999 },
+    });
+    const result = await recheck([], {
+      verdict: 'partial',
+      limit: '100000',
+      budget: '1000',
+      'dry-run': true,
+    } as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/pagination exceeded/i);
+    // Should have bailed well before the --limit of 100000 would naturally stop it.
+    expect(mockListVerdicts.mock.calls.length).toBeLessThanOrEqual(101);
+  });
+
   it('returns a friendly message when no verdicts match', async () => {
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -342,11 +342,19 @@ async function recheckCommand(
     // a large --limit silently returns only the first 200 and subsequent
     // rows never get processed.
     const PAGE_SIZE = 200;
-    const priority = VERDICT_PRIORITY[verdictFilter] ?? 0;
+    const MAX_ITERATIONS = 100; // Hard cap on pagination loops — with PAGE_SIZE=200, this is up to 20k rows. If we hit this, something's wrong upstream (server returning stale pages, total field undefined, etc.) — better to fail loud than hang.
+    const priority = VERDICT_PRIORITY[verdictFilter];
     const collected: DueItem[] = [];
     let serverTotal = 0;
     let offset = 0;
+    let iterations = 0;
     while (collected.length < itemLimit) {
+      if (iterations++ >= MAX_ITERATIONS) {
+        return {
+          exitCode: 1,
+          output: `Pagination exceeded ${MAX_ITERATIONS} iterations — server may be returning malformed pagination metadata.`,
+        };
+      }
       const pageSize = Math.min(PAGE_SIZE, itemLimit - collected.length);
       const response = await listVerdicts({
         verdict: verdictFilter,


### PR DESCRIPTION
## Summary

Follow-up to #4462 (QUA-546) from `/agent-review-pr` findings.

- **HIGH**: `crux sourcing-recheck --verdict=X` pagination loop had no hard iteration cap. If the server ever returned malformed metadata (e.g. non-advancing pages, `total` higher than reality), the loop could only exit via `--limit`. Adds `MAX_ITERATIONS=100` — fails loud with a clear error instead of spinning.
- **Tests**: adds two new cases —
  - Mid-page truncation: `itemLimit=250` → page 1 asks for 200, page 2 asks for 50 (not another 200)
  - `MAX_ITERATIONS` abort path using a broken-server mock
- Drops a dead `?? 0` fallback on `VERDICT_PRIORITY` lookup — the filter is already validated against the set of keys.

## Test plan

- [x] `npx vitest run crux/commands/sourcing-recheck.test.ts` — 9/9 pass (was 7/7)
- [x] Prod smoke: `WIKI_SERVER_ENV=prod pnpm crux sourcing-recheck --dry-run --verdict=partial --limit=5 --ci` returns items with `priority: 50` set correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against infinite pagination loops in the sourcing-recheck command when dealing with malformed server metadata. The command now exits with an error message if pagination limits are exceeded, preventing system hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->