### PR TITLE
Fix active_agents phantom buildup (QUA-584)

### DIFF
--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -232,7 +232,15 @@ Run `/agent-push-and-verify`.
 
 ## Step 9: Session close-out
 
-Clean up session artifacts and discard any unstaged changes (modified hooks, deleted markers, etc.):
+Close the session in the active-agents registry so the row leaves `status=active` (otherwise the active_agents table accumulates phantoms — see QUA-584). `/agent-end` does this in its step 6; ship needs the same call:
+
+```bash
+pnpm crux sys agents close 2>/dev/null || true
+```
+
+Best-effort: if the wiki-server is unreachable, the scheduled active-agents sweep will catch it within an hour.
+
+Then clean up session artifacts and discard any unstaged changes (modified hooks, deleted markers, etc.):
 
 ```bash
 rm -f .claude/wip-checklist.md .claude/wip-context.md

--- a/apps/groundskeeper/src/config.ts
+++ b/apps/groundskeeper/src/config.ts
@@ -35,6 +35,7 @@ export interface Config {
     githubShadowbanCheck: ShadowbanCheckConfig;
     snapshotRetention: SnapshotRetentionConfig;
     sessionSweep: TaskConfig;
+    activeAgentsSweep: TaskConfig;
     dataQualitySnapshot: TaskConfig;
     jobWorkerHealth: TaskConfig;
     autoUpdateEnqueue: AutoUpdateEnqueueConfig;
@@ -115,6 +116,16 @@ export function loadConfig(): Config {
         enabled: envBool("TASK_SESSION_SWEEP_ENABLED", true),
         schedule:
           process.env["TASK_SESSION_SWEEP_SCHEDULE"] ?? "0 */4 * * *", // every 4 hours
+      },
+      activeAgentsSweep: {
+        // QUA-584: parallel sweep for the active_agents table (live agent
+        // registry). The session-sweep task only handles agent_sessions; the
+        // active_agents table accumulated 77/81 phantom rows because no
+        // sweep was scheduled. 30 min cadence with a 60 min stale threshold
+        // means abandoned sessions are reflected in dashboards within an hour.
+        enabled: envBool("TASK_ACTIVE_AGENTS_SWEEP_ENABLED", true),
+        schedule:
+          process.env["TASK_ACTIVE_AGENTS_SWEEP_SCHEDULE"] ?? "*/30 * * * *", // every 30 min
       },
       dataQualitySnapshot: {
         enabled: envBool("TASK_DATA_QUALITY_SNAPSHOT_ENABLED", true),

--- a/apps/groundskeeper/src/incident-buffer.test.ts
+++ b/apps/groundskeeper/src/incident-buffer.test.ts
@@ -50,6 +50,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/index.ts
+++ b/apps/groundskeeper/src/index.ts
@@ -8,6 +8,7 @@ import { registerAsActiveAgent, sendHeartbeat } from "./wiki-server.js";
 import { githubShadowbanCheck } from "./tasks/github-shadowban-check.js";
 import { snapshotRetention } from "./tasks/snapshot-retention.js";
 import { sessionSweep } from "./tasks/session-sweep.js";
+import { activeAgentsSweep } from "./tasks/active-agents-sweep.js";
 import { dataQualitySnapshot } from "./tasks/data-quality-snapshot.js";
 import { jobWorkerHealth } from "./tasks/job-worker-health.js";
 import { autoUpdateEnqueue } from "./tasks/auto-update-enqueue.js";
@@ -44,6 +45,10 @@ logger.info({
     sessionSweep: {
       enabled: config.tasks.sessionSweep.enabled,
       schedule: config.tasks.sessionSweep.schedule,
+    },
+    activeAgentsSweep: {
+      enabled: config.tasks.activeAgentsSweep.enabled,
+      schedule: config.tasks.activeAgentsSweep.schedule,
     },
     dataQualitySnapshot: {
       enabled: config.tasks.dataQualitySnapshot.enabled,
@@ -120,6 +125,14 @@ registerTask(
   config.tasks.sessionSweep.schedule,
   config.tasks.sessionSweep.enabled,
   () => sessionSweep(config)
+);
+
+registerTask(
+  config,
+  "active-agents-sweep",
+  config.tasks.activeAgentsSweep.schedule,
+  config.tasks.activeAgentsSweep.enabled,
+  () => activeAgentsSweep(config)
 );
 
 registerTask(

--- a/apps/groundskeeper/src/run-tracker.test.ts
+++ b/apps/groundskeeper/src/run-tracker.test.ts
@@ -29,6 +29,7 @@ function makeConfig(runLogPath: string): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/scheduler.test.ts
+++ b/apps/groundskeeper/src/scheduler.test.ts
@@ -53,6 +53,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+import { activeAgentsSweep } from "./active-agents-sweep.js";
+import type { Config } from "../config.js";
+
+function makeConfig(): Config {
+  return {
+    githubAppId: "test",
+    githubInstallationId: "test",
+    githubAppPrivateKey: "test",
+    githubRepo: "test-owner/test-repo",
+    wikiServerUrl: "http://localhost:3000",
+    discordWebhookUrl: "http://localhost/webhook",
+    dailyRunCap: 20,
+    runLogPath: "/tmp/test-run-log.json",
+    circuitBreakerCooldownMs: 1_800_000,
+    tasks: {
+      healthCheck: { enabled: true, schedule: "*/5 * * * *" },
+      issueResponder: { enabled: false, schedule: "*/10 * * * *" },
+      githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
+      snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
+      sessionSweep: { enabled: true, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: true, schedule: "*/30 * * * *" },
+      dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
+      jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
+      autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },
+      jobFailureTriage: { enabled: false, schedule: "0 */6 * * *" },
+      tablebaseScan: { enabled: false, schedule: "0 5 * * *" },
+      e2ePostDeployWatcher: { enabled: false, schedule: "15 * * * *" },
+      thingsSearchRefresh: { enabled: false, schedule: "25 * * * *" },
+    },
+  };
+}
+
+describe("activeAgentsSweep", () => {
+  let config: Config;
+
+  beforeEach(() => {
+    config = makeConfig();
+    process.env["LONGTERMWIKI_SERVER_API_KEY"] = "test-key";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
+  });
+
+  it("returns success with 'no stale' summary when swept=0", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ swept: 0, agents: [] }),
+      }),
+    );
+
+    const result = await activeAgentsSweep(config);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("No stale");
+  });
+
+  it("calls the active-agents sweep endpoint with timeoutMinutes=60", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ swept: 0, agents: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await activeAgentsSweep(config);
+
+    const calls = fetchMock.mock.calls;
+    expect(calls[0][0]).toBe("http://localhost:3000/api/active-agents/sweep");
+    expect((calls[0][1] as RequestInit).method).toBe("POST");
+    const body = JSON.parse((calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ timeoutMinutes: 60 });
+  });
+
+  it("includes Authorization header when API key is set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ swept: 0, agents: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await activeAgentsSweep(config);
+
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers.Authorization).toBe("Bearer test-key");
+  });
+
+  it("returns failure when no API key is set", async () => {
+    delete process.env["LONGTERMWIKI_SERVER_API_KEY"];
+
+    const result = await activeAgentsSweep(config);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("failed");
+  });
+
+  it("returns failure when the sweep endpoint returns non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+      }),
+    );
+
+    const result = await activeAgentsSweep(config);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("failed");
+  });
+
+  it("returns failure when the fetch call throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+
+    const result = await activeAgentsSweep(config);
+
+    expect(result.success).toBe(false);
+    expect(result.summary).toContain("failed");
+  });
+
+  it("returns success summary with the swept count when agents are present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          swept: 3,
+          agents: [
+            { id: 1, sessionId: "claude/qua-100" },
+            { id: 2, sessionId: "claude/qua-200" },
+            { id: 3, sessionId: "claude/qua-300" },
+          ],
+        }),
+      }),
+    );
+
+    const result = await activeAgentsSweep(config);
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("Swept 3");
+  });
+});

--- a/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/active-agents-sweep.test.ts
@@ -70,7 +70,7 @@ describe("activeAgentsSweep", () => {
     expect(result.summary).toContain("No stale");
   });
 
-  it("calls the active-agents sweep endpoint with timeoutMinutes=60", async () => {
+  it("calls the active-agents sweep endpoint with timeoutMinutes=30", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ swept: 0, agents: [] }),
@@ -83,7 +83,7 @@ describe("activeAgentsSweep", () => {
     expect(calls[0][0]).toBe("http://localhost:3000/api/active-agents/sweep");
     expect((calls[0][1] as RequestInit).method).toBe("POST");
     const body = JSON.parse((calls[0][1] as RequestInit).body as string);
-    expect(body).toEqual({ timeoutMinutes: 60 });
+    expect(body).toEqual({ timeoutMinutes: 30 });
   });
 
   it("includes Authorization header when API key is set", async () => {

--- a/apps/groundskeeper/src/tasks/active-agents-sweep.ts
+++ b/apps/groundskeeper/src/tasks/active-agents-sweep.ts
@@ -1,0 +1,100 @@
+import type { Config } from "../config.js";
+import { logger as rootLogger } from "../logger.js";
+
+const logger = rootLogger.child({ task: "active-agents-sweep" });
+
+/**
+ * Minutes since last heartbeat after which an active agent is marked stale.
+ * 60 min is conservative: the heartbeat hook fires every 10 min while a session
+ * is alive, so a 60-min gap reliably means the session has ended (PR shipped,
+ * /clear'd, crashed, etc).
+ */
+const STALE_TIMEOUT_MINUTES = 60;
+
+interface SweptAgent {
+  id: number;
+  sessionId: string;
+}
+
+interface SweepResponse {
+  swept: number;
+  agents: SweptAgent[];
+}
+
+/**
+ * Call the wiki-server active-agents sweep endpoint to mark stale active agents.
+ * Returns the list of swept agents, or null on failure.
+ */
+async function callSweepEndpoint(
+  config: Config,
+  timeoutMinutes: number,
+): Promise<SweepResponse | null> {
+  const url = `${config.wikiServerUrl}/api/active-agents/sweep`;
+  const apiKey = process.env["LONGTERMWIKI_SERVER_API_KEY"];
+
+  if (!apiKey) {
+    logger.warn(
+      "LONGTERMWIKI_SERVER_API_KEY is not set — skipping sweep",
+    );
+    return null;
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ timeoutMinutes }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      logger.error({ status: res.status, body: text.slice(0, 200) }, "Sweep endpoint failed");
+      return null;
+    }
+
+    return (await res.json()) as SweepResponse;
+  } catch (err) {
+    logger.error(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Sweep request failed",
+    );
+    return null;
+  }
+}
+
+/**
+ * Active-agents sweep task (QUA-584):
+ * Marks active_agents rows stale after STALE_TIMEOUT_MINUTES of no heartbeat.
+ * The endpoint also sets completed_at = heartbeat_at so dashboards can compute
+ * accurate session durations for abandoned sessions.
+ *
+ * Companion to session-sweep (which handles the agent_sessions log table).
+ * Both must run because /agent-ship closes agent_sessions but historically
+ * left active_agents rows as phantom "active" forever.
+ *
+ * Idempotent — safe to run on any schedule.
+ */
+export async function activeAgentsSweep(
+  config: Config,
+): Promise<{ success: boolean; summary?: string }> {
+  const result = await callSweepEndpoint(config, STALE_TIMEOUT_MINUTES);
+
+  if (!result) {
+    return { success: false, summary: "Active-agents sweep endpoint call failed" };
+  }
+
+  logger.info({ swept: result.swept }, "Swept stale active agents");
+
+  if (result.swept === 0) {
+    return { success: true, summary: "No stale active agents to sweep" };
+  }
+
+  return {
+    success: true,
+    summary: `Swept ${result.swept} stale active agent(s)`,
+  };
+}

--- a/apps/groundskeeper/src/tasks/active-agents-sweep.ts
+++ b/apps/groundskeeper/src/tasks/active-agents-sweep.ts
@@ -5,11 +5,12 @@ const logger = rootLogger.child({ task: "active-agents-sweep" });
 
 /**
  * Minutes since last heartbeat after which an active agent is marked stale.
- * 60 min is conservative: the heartbeat hook fires every 10 min while a session
- * is alive, so a 60-min gap reliably means the session has ended (PR shipped,
- * /clear'd, crashed, etc).
+ * 30 min matches the wiki-server endpoint default (`active-agents.ts`
+ * STALE_TIMEOUT_MINUTES) and the dashboard ("silent for 30+ minutes"). The
+ * heartbeat hook is throttled at 10 min, so 30 min = ~3 missed heartbeats =
+ * the session has clearly ended (PR shipped, /clear'd, crashed, etc).
  */
-const STALE_TIMEOUT_MINUTES = 60;
+const STALE_TIMEOUT_MINUTES = 30;
 
 interface SweptAgent {
   id: number;

--- a/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
+++ b/apps/groundskeeper/src/tasks/e2e-post-deploy-watcher.test.ts
@@ -49,6 +49,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 30 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/health-check.test.ts
+++ b/apps/groundskeeper/src/tasks/health-check.test.ts
@@ -81,6 +81,7 @@ function makeConfig(overrides?: Partial<Config>): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/issue-responder.test.ts
+++ b/apps/groundskeeper/src/tasks/issue-responder.test.ts
@@ -98,6 +98,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
+++ b/apps/groundskeeper/src/tasks/job-failure-triage.test.ts
@@ -73,6 +73,7 @@ function makeConfig(): Config {
       },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: {

--- a/apps/groundskeeper/src/tasks/session-sweep.test.ts
+++ b/apps/groundskeeper/src/tasks/session-sweep.test.ts
@@ -36,6 +36,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 100 },
       sessionSweep: { enabled: true, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
+++ b/apps/groundskeeper/src/tasks/snapshot-retention.test.ts
@@ -40,6 +40,7 @@ function makeConfig(keep = 100): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: true, schedule: "0 3 * * *", keep },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
+++ b/apps/groundskeeper/src/tasks/tablebase-scan.test.ts
@@ -28,6 +28,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
         keep: 100,
       },
       sessionSweep: { enabled: true, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: true, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: true, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: {

--- a/apps/groundskeeper/src/tasks/things-search-refresh.test.ts
+++ b/apps/groundskeeper/src/tasks/things-search-refresh.test.ts
@@ -31,6 +31,7 @@ function makeConfig(): Config {
       githubShadowbanCheck: { enabled: false, schedule: "0 9 * * *", usernames: [] },
       snapshotRetention: { enabled: false, schedule: "0 3 * * *", keep: 30 },
       sessionSweep: { enabled: false, schedule: "0 */4 * * *" },
+      activeAgentsSweep: { enabled: false, schedule: "*/30 * * * *" },
       dataQualitySnapshot: { enabled: false, schedule: "0 6 * * *" },
       jobWorkerHealth: { enabled: false, schedule: "*/5 * * * *" },
       autoUpdateEnqueue: { enabled: false, schedule: "0 6 * * *", budget: 30, maxPages: 5 },

--- a/apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
+++ b/apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
@@ -1,25 +1,39 @@
 -- QUA-584: One-shot backfill for phantom active_agents rows.
 --
 -- Investigation 2026-04-17 found 77/81 status='active' rows had heartbeats
--- older than 60 minutes (many >7 days), because /agent-ship never closed
+-- older than 30 minutes (many >7 days), because /agent-ship never closed
 -- the active_agents row and no scheduled sweep existed for this table.
 --
--- This script marks those phantoms stale and sets completed_at to the last
--- known sign of life (heartbeat_at), matching the behavior the new sweep
--- endpoint applies going forward.
+-- This script:
+--   1. Marks phantom 'active' rows stale and sets completed_at to the last
+--      known sign of life (heartbeat_at), matching the behavior the new
+--      sweep endpoint applies going forward.
+--   2. Backfills completed_at on any historically-swept rows (status in
+--      stale/completed/errored) where completed_at is NULL — pre-PR the
+--      sweep endpoint never set this column, so older rows would leave
+--      session duration uncomputable in dashboards.
 --
--- Idempotent: re-running on already-stale rows is a no-op (WHERE filters
--- on status='active'). Safe to apply via psql against prod.
+-- Idempotent: the WHERE clauses filter on either status='active' or
+-- completed_at IS NULL, so re-running is a no-op. Safe to apply via psql.
 --
 -- Apply with:
 --   psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
 
+-- Step 1: flip phantom 'active' rows to stale with completed_at = heartbeat_at.
 UPDATE active_agents
 SET status      = 'stale',
     completed_at = heartbeat_at,
     updated_at   = NOW()
 WHERE status     = 'active'
-  AND heartbeat_at < NOW() - INTERVAL '60 minutes';
+  AND heartbeat_at < NOW() - INTERVAL '30 minutes';
+
+-- Step 2: backfill completed_at on historically-swept rows that pre-date
+-- this PR (sweep used to not populate completed_at at all).
+UPDATE active_agents
+SET completed_at = heartbeat_at,
+    updated_at   = NOW()
+WHERE status IN ('stale', 'completed', 'errored')
+  AND completed_at IS NULL;
 
 -- Verify (optional — comment out for non-interactive runs):
 SELECT

--- a/apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
+++ b/apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
@@ -1,0 +1,29 @@
+-- QUA-584: One-shot backfill for phantom active_agents rows.
+--
+-- Investigation 2026-04-17 found 77/81 status='active' rows had heartbeats
+-- older than 60 minutes (many >7 days), because /agent-ship never closed
+-- the active_agents row and no scheduled sweep existed for this table.
+--
+-- This script marks those phantoms stale and sets completed_at to the last
+-- known sign of life (heartbeat_at), matching the behavior the new sweep
+-- endpoint applies going forward.
+--
+-- Idempotent: re-running on already-stale rows is a no-op (WHERE filters
+-- on status='active'). Safe to apply via psql against prod.
+--
+-- Apply with:
+--   psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
+
+UPDATE active_agents
+SET status      = 'stale',
+    completed_at = heartbeat_at,
+    updated_at   = NOW()
+WHERE status     = 'active'
+  AND heartbeat_at < NOW() - INTERVAL '60 minutes';
+
+-- Verify (optional — comment out for non-interactive runs):
+SELECT
+  COUNT(*) FILTER (WHERE status = 'active')  AS still_active,
+  COUNT(*) FILTER (WHERE status = 'stale')   AS now_stale,
+  COUNT(*) FILTER (WHERE completed_at IS NULL AND status <> 'active') AS missing_completed_at
+FROM active_agents;

--- a/apps/wiki-server/src/__tests__/active-agents.test.ts
+++ b/apps/wiki-server/src/__tests__/active-agents.test.ts
@@ -133,11 +133,20 @@ const dispatch: SqlDispatcher = (query, params) => {
       const updatedAt = toDate(params[1]);
       // params[2] is the WHERE status value, params[3] is the cutoff
       const cutoff = toDate(params[3]);
+      // QUA-584: sweep also sets completed_at = heartbeat_at via inline SQL
+      // expression (no param). Detect it from the SET clause.
+      const setCompletedFromHeartbeat =
+        /set\s+[^]*"completed_at"\s*=\s*"active_agents"\."heartbeat_at"/i.test(
+          query,
+        );
       const updated: AgentRow[] = [];
       for (const row of store) {
         if (row.status === "active" && row.heartbeat_at < cutoff) {
           row.status = statusVal;
           row.updated_at = updatedAt;
+          if (setCompletedFromHeartbeat) {
+            row.completed_at = row.heartbeat_at;
+          }
           updated.push(row);
         }
       }
@@ -612,6 +621,26 @@ describe("Active Agents API", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.swept).toBe(0);
+    });
+
+    it("sets completed_at = heartbeat_at when marking stale (QUA-584)", async () => {
+      await postJson(app, "/api/active-agents", sampleAgent);
+      // Last heartbeat 2 hours ago — sweep with 30 min threshold should catch it
+      const lastHeartbeat = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      store[0].heartbeat_at = lastHeartbeat;
+
+      expect(store[0].completed_at).toBeNull();
+
+      const res = await postJson(app, "/api/active-agents/sweep", {
+        timeoutMinutes: 30,
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).swept).toBe(1);
+
+      // The end time of the session should be its last sign of life
+      // (heartbeat_at), not the moment the sweep ran.
+      expect(store[0].status).toBe("stale");
+      expect(store[0].completed_at).toEqual(lastHeartbeat);
     });
   });
 

--- a/apps/wiki-server/src/routes/operational/active-agents.ts
+++ b/apps/wiki-server/src/routes/operational/active-agents.ts
@@ -317,9 +317,16 @@ const activeAgentsApp = new Hono()
     const cutoff = new Date(Date.now() - timeoutMinutes * 60 * 1000);
     const db = getDrizzleDb();
 
+    // QUA-584: also set completed_at = heartbeat_at so the row carries the
+    // session's actual end time (last sign of life), not the sweep time.
+    // Dashboards can then compute session duration even for abandoned sessions.
     const stale = await db
       .update(activeAgents)
-      .set({ status: "stale", updatedAt: new Date() })
+      .set({
+        status: "stale",
+        completedAt: sql`${activeAgents.heartbeatAt}`,
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(activeAgents.status, "active"),


### PR DESCRIPTION
## Summary

Fixes phantom `active_agents` rows that never get cleaned up. Investigation 2026-04-17 found 77 of 81 rows in `active_agents` had stale heartbeats (many >7 days old). Two root causes: no scheduled sweep for the table, and `/agent-ship` never called `sys agents close` (only `/agent-end` did).

Fixes QUA-584

## What changed

- **Groundskeeper — new scheduled task.** `active-agents-sweep` runs every 30 min against `/api/active-agents/sweep`. Stale threshold is 30 min (matches the endpoint default and the dashboard wording).
- **Wiki-server sweep endpoint** now sets `completed_at = heartbeat_at` when marking rows stale. Previously the column stayed NULL, so dashboards couldn't compute session duration for abandoned sessions.
- **`/agent-ship` step 9** now calls `pnpm crux sys agents close` so shipped sessions release their row (matches `/agent-end`).
- **One-shot SQL backfill** (`qua-584-backfill-active-agents-stale.sql`) for existing phantoms, plus a second UPDATE to populate `completed_at` on any historically-swept rows where that column is NULL.

## Notes from `/agent-review-pr`

- MEDIUM: threshold inconsistency — **fixed** (aligned groundskeeper to 30 min to match endpoint/dashboard).
- MEDIUM: backfill leaving pre-existing `stale` rows with NULL `completed_at` — **fixed** (second UPDATE added).
- MEDIUM: missing `LONGTERMWIKI_SERVER_API_KEY` is reported as failure — **deferred**. Kept consistent with the existing `session-sweep` task which has the same behavior; should be fixed for both in a follow-up.
- 9 LOW findings noted but not blocking.

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm test` — all 6775 tests pass (pre-existing 2 `issue-responder` failures unrelated)
- [x] Wiki-server active-agents test suite: 35/35 pass including new `completed_at = heartbeat_at` assertion
- [x] Groundskeeper `active-agents-sweep.test.ts`: 7/7 pass (happy path, no-API-key, non-2xx, network error, swept count, Authorization header, `timeoutMinutes=30` payload)
- [x] Full gate: 44/44 blocking checks pass
- [x] Typecheck clean for `apps/web` and `apps/wiki-server`; pre-existing errors in `crux` unrelated

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `manual-migration` Run manual migration script: psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql
- [ ] `manual` Verify the active-agents sweep fires on schedule — check groundskeeper logs for a `session-sweep`-paired `active-agents-sweep` entry within the hour after deploy; `kubectl logs -n wiki deployment/groundskeeper | grep active-agents-sweep`
- [ ] `manual` Verify prod `GET /api/active-agents?status=active` count drops from ~80 to the truly-live count (expected: <15) within 30 min after the backfill script runs
<!-- /deploy-tasks -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
