### PR TITLE
QUA-572 Phase B.1b: swap bluesky_posts.resource_id FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0192_qua_572_bluesky_posts_resource_id_fk.sql
+++ b/apps/wiki-server/drizzle/0192_qua_572_bluesky_posts_resource_id_fk.sql
@@ -1,0 +1,91 @@
+-- QUA-572 Phase B.1b: migrate bluesky_posts.resource_id FK from
+-- resources.id → resources.stable_id.
+--
+-- Part of QUA-549 Phase B. Follows the in-place pattern established by
+-- 0186 (resource_content_versions), 0187 (publications + resource_policy_docs,
+-- QUA-564), 0188 (QUA-565 tiny tables), 0189 (QUA-567 entity_resources),
+-- and 0191 (QUA-568 source_check_evidence).
+--
+-- Pre-flight (prod, 2026-04-18):
+--   0 rows in bluesky_posts (zero-row table).
+--   Existing FK: bluesky_posts_resource_id_fkey
+--     (postgres default name, ON DELETE SET NULL).
+--   0 orphans trivially (0 rows).
+--
+-- Column name stays `resource_id`; only the FK reference target changes,
+-- preserving SET NULL onDelete. The backfill UPDATE below is a no-op on
+-- prod but defensive for dev/staging/test envs that may have ingested
+-- test data.
+
+-- Step 1: drop the existing FK on resources.id. Covers both the Drizzle-
+-- generated name (used by older dev databases) and the postgres default
+-- (active in prod per 2026-04-18 enumeration).
+ALTER TABLE "bluesky_posts"
+  DROP CONSTRAINT IF EXISTS "bluesky_posts_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "bluesky_posts"
+  DROP CONSTRAINT IF EXISTS "bluesky_posts_resource_id_fkey";--> statement-breakpoint
+
+-- Defensive: fail loudly if an FK on resource_id → resources.id still
+-- exists under an unexpected name (e.g. drift beyond the two variants above).
+-- Prevents the UPDATE below from running against a still-referenced column.
+DO $$
+DECLARE
+  remaining_fk TEXT;
+BEGIN
+  SELECT conname INTO remaining_fk
+  FROM pg_constraint
+  WHERE conrelid = 'bluesky_posts'::regclass
+    AND contype = 'f'
+    AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+                       WHERE attrelid = 'bluesky_posts'::regclass
+                         AND attname = 'resource_id')]
+    AND confrelid = 'resources'::regclass
+    AND confkey = ARRAY[(SELECT attnum FROM pg_attribute
+                        WHERE attrelid = 'resources'::regclass
+                          AND attname = 'id')]
+  LIMIT 1;
+  IF remaining_fk IS NOT NULL THEN
+    RAISE EXCEPTION 'QUA-572 migration aborted: unexpected FK constraint "%" still points bluesky_posts.resource_id at resources.id after DROP attempts. Add an explicit DROP for this name and re-run.', remaining_fk;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Step 2: backfill resource_id values from hex16 → sid_ via join on
+-- resources. No-op on prod (0 rows) but defensive for other envs.
+-- The r.stable_id IS NOT NULL guard prevents silently overwriting a
+-- real link with NULL if some resources row is missing its stable_id.
+UPDATE "bluesky_posts" bp
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE bp.resource_id = r.id
+  AND bp.resource_id IS NOT NULL
+  AND bp.resource_id NOT LIKE 'sid_%'
+  AND r.stable_id IS NOT NULL;--> statement-breakpoint
+
+-- Step 3: orphan check — fail fast rather than letting ADD CONSTRAINT
+-- reject with a generic FK error. Trivially passes on prod (0 rows).
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM bluesky_posts bp
+  WHERE bp.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = bp.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-572 migration aborted: % bluesky_posts row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Step 4: add the new FK pointing at resources.stable_id, preserving
+-- SET NULL. Wrapped in IF NOT EXISTS for idempotency on replay.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'bluesky_posts_resource_id_resources_stable_id_fk'
+      AND table_name = 'bluesky_posts'
+  ) THEN
+    ALTER TABLE "bluesky_posts"
+      ADD CONSTRAINT "bluesky_posts_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id")
+      ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1345,6 +1345,13 @@
       "when": 1785916800002,
       "tag": "0191_qua_568_sce_resource_id_to_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 192,
+      "version": "7",
+      "when": 1785916800003,
+      "tag": "0192_qua_572_bluesky_posts_resource_id_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/bluesky.ts
+++ b/apps/wiki-server/src/routes/tablebase/bluesky.ts
@@ -410,14 +410,17 @@ const blueskyApp = new Hono()
         .map((item) => extractEmbeddedUrl(item).url)
         .filter((u): u is string => u != null);
 
+      // QUA-572: resource_id FK now points at resources.stable_id, so we
+      // store the sid_ form. Resources whose stable_id is null are skipped —
+      // the FK would reject them anyway.
       const urlToResourceId = new Map<string, string>();
       if (embeddedUrls.length > 0) {
         const matchedResources = await db
-          .select({ id: resources.id, url: resources.url })
+          .select({ stableId: resources.stableId, url: resources.url })
           .from(resources)
           .where(inArray(resources.url, embeddedUrls));
         for (const r of matchedResources) {
-          urlToResourceId.set(r.url, r.id);
+          if (r.stableId) urlToResourceId.set(r.url, r.stableId);
         }
       }
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3478,8 +3478,10 @@ export const blueskyPosts = pgTable(
     embeddedTitle: text("embedded_title"),
     /** URI of the post this is replying to */
     replyToUri: text("reply_to_uri"),
-    /** FK to resources — links this post to a known resource by embedded URL */
-    resourceId: text("resource_id").references(() => resources.id, {
+    /** FK to resources.stable_id — links this post to a known resource by embedded URL.
+     *  QUA-572 Phase B.1b: swapped from resources.id → resources.stableId (in-place;
+     *  column name kept as `resource_id`). See migration 0192. */
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     /** Entity stableIds this post is about */


### PR DESCRIPTION
## Summary

Phase B.1b of [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) (17-table FK migration from `resources.id` → `resources.stable_id`). Swaps `bluesky_posts.resource_id` to reference `resources.stable_id` in-place.

Fixes QUA-572.

## Table in scope

| Table | Prod rows | Existing FK | onDelete |
|-------|-----------|------------|---------|
| `bluesky_posts` | **0** | `bluesky_posts_resource_id_fkey` → `resources.id` | `SET NULL` (preserved) |

Enumerated on prod 2026-04-18: 0 rows, 0 non-null `resource_id`, 0 orphans.

## What changed

1. **`apps/wiki-server/drizzle/0192_qua_572_bluesky_posts_resource_id_fk.sql`** (new). Four steps, each idempotent:
   - Drop existing FK by both possible names (`bluesky_posts_resource_id_resources_id_fk` from Drizzle + `bluesky_posts_resource_id_fkey` postgres default).
   - Defensive `pg_constraint` guard: RAISE EXCEPTION if an unexpected FK name still points `resource_id → resources.id`. Prevents half-apply on name drift.
   - Backfill `UPDATE` that rewrites hex16 `resource_id` → `sid_` via JOIN on `resources.stable_id`, with the `stable_id IS NOT NULL` guard per Phase B template. No-op on prod (0 rows), defensive for dev/staging.
   - Orphan check, then `ADD CONSTRAINT` preserving `ON DELETE SET NULL`.
2. **`apps/wiki-server/src/schema.ts`**: `blueskyPosts.resourceId.references(() => resources.id)` → `resources.stableId`. Column name kept (in-place / Option B).
3. **`apps/wiki-server/src/routes/tablebase/bluesky.ts`**: when building the `urlToResourceId` map from `resources`, select `stable_id` instead of `id` and skip resources without a `stable_id` (FK would reject them anyway).
4. **`apps/wiki-server/drizzle/meta/_journal.json`**: new entry for 0192.

Follows the same in-place template established by 0187 (QUA-564), 0188 (QUA-565), 0189 (QUA-567), 0191 (QUA-568). NOT VALID + VALIDATE CONSTRAINT is unnecessary here because the table has 0 rows (the lock-contention risk that motivated the pattern on `hallucination_risk_snapshots` / QUA-302 can't exist on 0 rows).

## Risk profile

Low. 0 rows in prod. Single write-path (the bluesky sync job) already rewritten to produce `sid_` values that satisfy the new FK. No readers JOIN on this column.

## Test plan

- [x] `npx tsc --noEmit` (wiki-server + web): passes
- [x] `pnpm build`: passes
- [x] `pnpm test` in `apps/wiki-server/`: 1248 pass / 46 skipped (pre-existing)
- [x] `pnpm crux w validate gate --fix`: all 50 gate checks pass (3 pre-existing advisory warnings)
- [ ] Post-merge: migration 0192 applies at wiki-server startup; health endpoint returns `healthy` not `degraded`
- [ ] Post-merge: next bluesky sync run writes `sid_`-prefixed `resource_id` values (if any URLs match resources with stable_ids)

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->
