### PR TITLE
QUA-574 Phase B.2b: swap citation_quotes.resource_id FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
@@ -1,0 +1,67 @@
+-- QUA-574 Phase B.2b: swap citation_quotes.resource_id reference from
+-- resources.id → resources.stable_id.
+--
+-- Part of QUA-549 Phase B (17-table FK migration). Follows the in-place /
+-- Option B pattern established in QUA-564 (0187), QUA-565 (0188), and
+-- QUA-567 (0189): column name stays `resource_id`, the values are rewritten
+-- in-place from hex16 → sid_, and only the `.references()` target in
+-- schema.ts changes.
+--
+-- Prod state at time of authoring (2026-04-17, from QUA-574 ticket):
+--   - 109 rows in citation_quotes with a non-null resource_id
+--   - soft ref: NO FK constraint in prod (schema declares SET NULL only)
+--   - resources.stable_id is 100% populated per QUA-536
+--
+-- Non-goal per QUA-549 / QUA-574: do NOT add the missing FK constraint on
+-- citation_quotes.resource_id. Tracked separately. This migration only
+-- realigns the stored values with the new schema reference target.
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Defensive: drop any FK that may exist in dev/staging environments (prod
+-- has none). Idempotent via IF EXISTS on both the Drizzle-generated name
+-- and the postgres default (<table>_<column>_fkey). No-op in prod.
+-- ────────────────────────────────────────────────────────────────────────
+ALTER TABLE "citation_quotes" DROP CONSTRAINT IF EXISTS "citation_quotes_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "citation_quotes" DROP CONSTRAINT IF EXISTS "citation_quotes_resource_id_fkey";--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Backfill: rewrite hex16 resource_id values to the corresponding sid_
+-- value via JOIN on resources. Guarded by NOT LIKE 'sid_%' so re-runs
+-- and already-migrated environments are no-ops. The r.stable_id IS NOT
+-- NULL guard prevents silently overwriting a real link with NULL if some
+-- resources row is missing its stable_id.
+-- ────────────────────────────────────────────────────────────────────────
+UPDATE "citation_quotes" cq
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE cq.resource_id = r.id
+  AND cq.resource_id IS NOT NULL
+  AND cq.resource_id NOT LIKE 'sid_%'
+  AND r.stable_id IS NOT NULL;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- Soft-ref orphan check. After the backfill, every non-null resource_id
+-- should either already be in sid_ form or be an orphan (no matching
+-- resources row). We do NOT raise here — citation_quotes is a soft ref,
+-- so some orphans are acceptable (the schema's ON DELETE SET NULL is
+-- not enforced without a real FK). Instead, emit a NOTICE so operators
+-- can investigate post-deploy if any remain. This is a deliberate
+-- difference from the hard-FK migrations (0187/0188/0189) which must
+-- halt on orphans to avoid a failed ADD CONSTRAINT.
+-- ────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  orphan_count INT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM citation_quotes cq
+  WHERE cq.resource_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM resources r
+      WHERE r.stable_id = cq.resource_id
+    );
+  IF orphan_count > 0 THEN
+    RAISE NOTICE 'QUA-574: % citation_quotes row(s) have a resource_id with no matching resources.stable_id after backfill. Soft ref — not halting. Investigate via `SELECT id, page_id, footnote, resource_id FROM citation_quotes WHERE resource_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = citation_quotes.resource_id);`.', orphan_count;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
@@ -62,25 +62,26 @@ DECLARE
   orphan_count INT;
   skipped_null_stableid INT;
 BEGIN
-  SELECT COUNT(*) INTO orphan_count
+  -- Single scan computes both counters. `skipped_null_stableid` is the
+  -- specific subset of rows that would have been backfilled except the
+  -- matching resources row has a NULL stable_id — fixable by populating
+  -- resources.stable_id (see QUA-536), then re-running.
+  SELECT
+    COUNT(*) FILTER (
+      WHERE NOT EXISTS (
+        SELECT 1 FROM resources r WHERE r.stable_id = cq.resource_id
+      )
+    ),
+    COUNT(*) FILTER (
+      WHERE cq.resource_id NOT LIKE 'sid_%'
+        AND EXISTS (
+          SELECT 1 FROM resources r
+          WHERE r.id = cq.resource_id AND r.stable_id IS NULL
+        )
+    )
+    INTO orphan_count, skipped_null_stableid
   FROM citation_quotes cq
-  WHERE cq.resource_id IS NOT NULL
-    AND NOT EXISTS (
-      SELECT 1
-      FROM resources r
-      WHERE r.stable_id = cq.resource_id
-    );
-
-  -- Count hex16 rows still present whose resources row exists but has
-  -- NULL stable_id — these are the UPDATE's `r.stable_id IS NOT NULL`
-  -- guard skips. They overlap with `orphan_count` but have a specific
-  -- fixable cause (populate resources.stable_id, then re-run).
-  SELECT COUNT(*) INTO skipped_null_stableid
-  FROM citation_quotes cq
-  JOIN resources r ON r.id = cq.resource_id
-  WHERE cq.resource_id IS NOT NULL
-    AND cq.resource_id NOT LIKE 'sid_%'
-    AND r.stable_id IS NULL;
+  WHERE cq.resource_id IS NOT NULL;
 
   IF skipped_null_stableid > 0 THEN
     RAISE NOTICE 'QUA-574: % citation_quotes row(s) could not be backfilled because the matching resources row has a NULL stable_id. Populate resources.stable_id for those rows (see QUA-536) and re-run this migration to complete.', skipped_null_stableid;

--- a/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
+++ b/apps/wiki-server/drizzle/0194_qua_574_citation_quotes_fk_swap.sql
@@ -40,18 +40,27 @@ WHERE cq.resource_id = r.id
   AND r.stable_id IS NOT NULL;--> statement-breakpoint
 
 -- ────────────────────────────────────────────────────────────────────────
--- Soft-ref orphan check. After the backfill, every non-null resource_id
--- should either already be in sid_ form or be an orphan (no matching
--- resources row). We do NOT raise here — citation_quotes is a soft ref,
--- so some orphans are acceptable (the schema's ON DELETE SET NULL is
--- not enforced without a real FK). Instead, emit a NOTICE so operators
--- can investigate post-deploy if any remain. This is a deliberate
--- difference from the hard-FK migrations (0187/0188/0189) which must
--- halt on orphans to avoid a failed ADD CONSTRAINT.
+-- Soft-ref orphan check + diagnostics. After the backfill, every non-null
+-- resource_id should either already be in sid_ form or be an orphan
+-- (no matching resources row). We do NOT raise here — citation_quotes is
+-- a soft ref, so some orphans are acceptable (the schema's ON DELETE
+-- SET NULL is not enforced without a real FK). Instead, emit NOTICEs so
+-- operators can investigate post-deploy. This is a deliberate difference
+-- from the hard-FK migrations (0187/0188/0189) which must halt on
+-- orphans to avoid a failed ADD CONSTRAINT.
+--
+-- Two distinct diagnostic counters:
+--   (a) total post-backfill orphans — any non-null resource_id with no
+--       matching resources.stable_id. Expected to be 0 in prod.
+--   (b) rows that could not be backfilled because the matching resources
+--       row had NULL stable_id. Expected to be 0 per QUA-536 (100%
+--       populated), but called out separately so the root cause is
+--       visible if either category turns up.
 -- ────────────────────────────────────────────────────────────────────────
 DO $$
 DECLARE
   orphan_count INT;
+  skipped_null_stableid INT;
 BEGIN
   SELECT COUNT(*) INTO orphan_count
   FROM citation_quotes cq
@@ -61,6 +70,22 @@ BEGIN
       FROM resources r
       WHERE r.stable_id = cq.resource_id
     );
+
+  -- Count hex16 rows still present whose resources row exists but has
+  -- NULL stable_id — these are the UPDATE's `r.stable_id IS NOT NULL`
+  -- guard skips. They overlap with `orphan_count` but have a specific
+  -- fixable cause (populate resources.stable_id, then re-run).
+  SELECT COUNT(*) INTO skipped_null_stableid
+  FROM citation_quotes cq
+  JOIN resources r ON r.id = cq.resource_id
+  WHERE cq.resource_id IS NOT NULL
+    AND cq.resource_id NOT LIKE 'sid_%'
+    AND r.stable_id IS NULL;
+
+  IF skipped_null_stableid > 0 THEN
+    RAISE NOTICE 'QUA-574: % citation_quotes row(s) could not be backfilled because the matching resources row has a NULL stable_id. Populate resources.stable_id for those rows (see QUA-536) and re-run this migration to complete.', skipped_null_stableid;
+  END IF;
+
   IF orphan_count > 0 THEN
     RAISE NOTICE 'QUA-574: % citation_quotes row(s) have a resource_id with no matching resources.stable_id after backfill. Soft ref — not halting. Investigate via `SELECT id, page_id, footnote, resource_id FROM citation_quotes WHERE resource_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = citation_quotes.resource_id);`.', orphan_count;
   END IF;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1359,6 +1359,13 @@
       "when": 1786003200000,
       "tag": "0193_qua_569_page_citations_resource_id_to_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 194,
+      "version": "7",
+      "when": 1786003200001,
+      "tag": "0194_qua_574_citation_quotes_fk_swap",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -24,6 +24,9 @@ let quotesStore: Map<string, QuoteRow>; // key: `${pageSlug}:${footnote}`
 let contentStore: Map<string, ContentRow>; // key: url
 let snapshotStore: Array<SnapshotRow>;
 let contentVersionStore: Array<ContentVersionRow>;
+// QUA-574: capture dispatched SQL so tests can assert on the column used
+// for ref-check lookups (e.g. `resources.stable_id` vs `resources.id`).
+let dispatchedQueries: string[] = [];
 
 let nextSlugIntId = 1000;
 const slugIntIdMap = new Map<string, number>();
@@ -54,6 +57,7 @@ function resetStores() {
   contentVersionStore = [];
   nextSlugIntId = 1000;
   slugIntIdMap.clear();
+  dispatchedQueries = [];
 }
 
 function quoteKey(pageId: string, footnote: number) {
@@ -128,6 +132,7 @@ function contentToSqlRow(r: ContentRow): Record<string, unknown> {
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
+  dispatchedQueries.push(q);
   // Debug: uncomment to see SQL patterns
   // if (q.includes("resource_content_versions")) console.log("DISPATCH rcv:", JSON.stringify({ q: q.slice(0, 300), params }));
 
@@ -847,6 +852,35 @@ describe("Citation Server API", () => {
       expect(body.quotes).toHaveLength(1);
       expect(body.quotes[0].resourceId).toBe("sid_AbCdEfGhIj");
       expect(isSid(body.quotes[0].resourceId)).toBe(true);
+    });
+
+    // QUA-574 regression lock: verify the resource ref-check uses the
+    // `resources.stable_id` column, not `resources.id`. Without this, a
+    // naïve mock that accepts anything in the IN list passes both column
+    // choices — so the round-trip test above can't detect a regression
+    // that points `.references()` back at `resources.id`.
+    it("looks up resource refs against resources.stable_id (not resources.id)", async () => {
+      await postJson(app, "/api/citations/quotes/upsert", {
+        pageId: "col-check-page",
+        footnote: 1,
+        claimText: "Claim",
+        url: "https://example.com/col-check",
+        resourceId: "sid_ColumnXyz",
+      });
+
+      // The ref-check issues: SELECT "resources"."stable_id" AS "id"
+      //                       FROM "resources"
+      //                       WHERE "resources"."stable_id" IN (...)
+      const resourceLookups = dispatchedQueries.filter(
+        (q) => q.includes('from "resources"') && q.includes(" in ")
+      );
+      expect(resourceLookups.length).toBeGreaterThan(0);
+      for (const q of resourceLookups) {
+        expect(q).toContain('"resources"."stable_id"');
+        // If the schema ever regresses to resources.id, this assertion fails
+        // before the round-trip assertion ever runs.
+        expect(q).not.toMatch(/"resources"\."id"\s+in\s/);
+      }
     });
   });
 

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -826,6 +826,28 @@ describe("Citation Server API", () => {
       const body = await res.json();
       expect(body.error).toBe("invalid_json");
     });
+
+    // QUA-574 Phase B.2b: citation_quotes.resource_id now references
+    // resources.stable_id (sid_<10>), not resources.id (hex16). Callers must
+    // pass the sid_ form. The FK enforces this in prod; this test locks in
+    // that the server round-trips sid_ values verbatim.
+    it("persists the caller-provided resourceId (sid_) verbatim on the citation quote row", async () => {
+      const res = await postJson(app, "/api/citations/quotes/upsert", {
+        pageId: "sid-test-page",
+        footnote: 1,
+        claimText: "Claim with sid_ resource",
+        url: "https://example.com/sid-test",
+        resourceId: "sid_AbCdEfGhIj",
+      });
+      expect(res.status).toBe(200);
+
+      const getRes = await app.request("/api/citations/quotes?page_id=sid-test-page");
+      expect(getRes.status).toBe(200);
+      const body = await getRes.json();
+      expect(body.quotes).toHaveLength(1);
+      expect(body.quotes[0].resourceId).toBe("sid_AbCdEfGhIj");
+      expect(isSid(body.quotes[0].resourceId)).toBe(true);
+    });
   });
 
   // ---- Batch Upsert ----
@@ -851,6 +873,41 @@ describe("Citation Server API", () => {
         items: [],
       });
       expect(res.status).toBe(400);
+    });
+
+    // QUA-574 Phase B.2b: verify the batch endpoint also round-trips sid_
+    // values verbatim on the resource_id column.
+    it("persists caller-provided resourceId (sid_) verbatim across a batch", async () => {
+      const res = await postJson(app, "/api/citations/quotes/upsert-batch", {
+        items: [
+          {
+            pageId: "batch-sid-page",
+            footnote: 1,
+            claimText: "Claim A",
+            url: "https://example.com/a",
+            resourceId: "sid_BatchOneAb",
+          },
+          {
+            pageId: "batch-sid-page",
+            footnote: 2,
+            claimText: "Claim B",
+            url: "https://example.com/b",
+            resourceId: "sid_BatchTwoCd",
+          },
+        ],
+      });
+      expect(res.status).toBe(200);
+
+      const getRes = await app.request("/api/citations/quotes?page_id=batch-sid-page");
+      expect(getRes.status).toBe(200);
+      const body = await getRes.json();
+      expect(body.quotes).toHaveLength(2);
+      const byFootnote = new Map(body.quotes.map((q: { footnote: number; resourceId: string | null }) => [q.footnote, q.resourceId]));
+      expect(byFootnote.get(1)).toBe("sid_BatchOneAb");
+      expect(byFootnote.get(2)).toBe("sid_BatchTwoCd");
+      for (const rid of byFootnote.values()) {
+        expect(rid && isSid(rid as string)).toBe(true);
+      }
     });
   });
 

--- a/apps/wiki-server/src/__tests__/citations.test.ts
+++ b/apps/wiki-server/src/__tests__/citations.test.ts
@@ -909,8 +909,6 @@ describe("Citation Server API", () => {
       expect(res.status).toBe(400);
     });
 
-    // QUA-574 Phase B.2b: verify the batch endpoint also round-trips sid_
-    // values verbatim on the resource_id column.
     it("persists caller-provided resourceId (sid_) verbatim across a batch", async () => {
       const res = await postJson(app, "/api/citations/quotes/upsert-batch", {
         items: [

--- a/apps/wiki-server/src/routes/operational/integrity.ts
+++ b/apps/wiki-server/src/routes/operational/integrity.ts
@@ -65,10 +65,11 @@ const integrityApp = new Hono()
         "page_id",
         "wiki_pages"
       ),
-      // 5. citation_quotes.resource_id → resources
+      // 5. citation_quotes.resource_id → resources.stable_id
+      // QUA-574 Phase B.2b: resource_id now references resources.stable_id (not resources.id).
       checkDangling(
         db,
-        sql`SELECT DISTINCT cq.resource_id AS ref FROM citation_quotes cq WHERE cq.resource_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.id = cq.resource_id)`,
+        sql`SELECT DISTINCT cq.resource_id AS ref FROM citation_quotes cq WHERE cq.resource_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = cq.resource_id)`,
         "citation_quotes",
         "resource_id",
         "resources"

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -370,9 +370,11 @@ const citationsApp = new Hono()
       return validationError(c, `Referenced page not found: ${missingPages.join(", ")}`);
     }
 
-    // Validate resource reference (optional)
+    // Validate resource reference (optional).
+    // QUA-574 Phase B.2b: citation_quotes.resource_id now references
+    // resources.stable_id (sid_<10>), not resources.id (hex16).
     if (parsed.resourceId) {
-      const missingRes = await checkRefsExist(db, resources, resources.id, [parsed.resourceId]);
+      const missingRes = await checkRefsExist(db, resources, resources.stableId, [parsed.resourceId]);
       if (missingRes.length > 0) {
         return validationError(c, `Referenced resource not found: ${missingRes.join(", ")}`);
       }
@@ -411,12 +413,14 @@ const citationsApp = new Hono()
       );
     }
 
-    // Validate resource references (optional field)
+    // Validate resource references (optional field).
+    // QUA-574 Phase B.2b: citation_quotes.resource_id now references
+    // resources.stable_id (sid_<10>), not resources.id (hex16).
     const resourceIds = [
       ...new Set(items.map((d) => d.resourceId).filter((r): r is string => r != null)),
     ];
     if (resourceIds.length > 0) {
-      const missingResources = await checkRefsExist(db, resources, resources.id, resourceIds);
+      const missingResources = await checkRefsExist(db, resources, resources.stableId, resourceIds);
       if (missingResources.length > 0) {
         return validationError(
           c,

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -52,7 +52,12 @@ export const citationQuotes = pgTable(
       .references(() => wikiPages.id),
     footnote: integer("footnote").notNull(),
     url: text("url"),
-    resourceId: text("resource_id").references(() => resources.id, {
+    // QUA-574 Phase B.2b: resource_id references resources.stable_id (not resources.id).
+    // Column name kept as `resource_id` for minimal code churn — the value is now a
+    // `sid_`-prefixed stable_id, not a legacy hex16. See QUA-549 for context.
+    // Soft ref: schema declares SET NULL, but no FK constraint exists in prod — adding
+    // the FK is tracked separately (non-goal of QUA-574).
+    resourceId: text("resource_id").references(() => resources.stableId, {
       onDelete: "set null",
     }),
     claimText: text("claim_text").notNull(),

--- a/crux/citations/backfill-resource-ids.ts
+++ b/crux/citations/backfill-resource-ids.ts
@@ -50,8 +50,8 @@ async function main() {
 
   let matched = 0;
   let unmatched = 0;
-
   let skippedNoStableId = 0;
+
   for (const quote of candidates) {
     const resource = getResourceByUrl(quote.url!);
     if (resource) {

--- a/crux/citations/backfill-resource-ids.ts
+++ b/crux/citations/backfill-resource-ids.ts
@@ -58,14 +58,14 @@ async function main() {
       // QUA-574 Phase B.2b: citation_quotes.resource_id now references
       // resources.stable_id. Skip resources without a stable_id rather than
       // writing a legacy hex16 value that would fail wiki-server validation.
-      if (!resource.stableId) {
+      if (!resource.stable_id) {
         skippedNoStableId++;
         continue;
       }
       matched++;
       if (dryRun) {
         console.log(
-          `  ${c.green}MATCH${c.reset} [${quote.pageId}:^${quote.footnote}] → ${resource.stableId} (${resource.title || resource.url})`,
+          `  ${c.green}MATCH${c.reset} [${quote.pageId}:^${quote.footnote}] → ${resource.stable_id} (${resource.title || resource.url})`,
         );
       } else {
         // Re-upsert with the resource_id populated (stable_id form)
@@ -73,7 +73,7 @@ async function main() {
           pageId: String(quote.pageId),
           footnote: quote.footnote,
           url: quote.url,
-          resourceId: resource.stableId,
+          resourceId: resource.stable_id,
           claimText: quote.claimText,
           claimContext: quote.claimContext ?? null,
           sourceQuote: quote.sourceQuote ?? null,

--- a/crux/citations/backfill-resource-ids.ts
+++ b/crux/citations/backfill-resource-ids.ts
@@ -51,21 +51,29 @@ async function main() {
   let matched = 0;
   let unmatched = 0;
 
+  let skippedNoStableId = 0;
   for (const quote of candidates) {
     const resource = getResourceByUrl(quote.url!);
     if (resource) {
+      // QUA-574 Phase B.2b: citation_quotes.resource_id now references
+      // resources.stable_id. Skip resources without a stable_id rather than
+      // writing a legacy hex16 value that would fail wiki-server validation.
+      if (!resource.stableId) {
+        skippedNoStableId++;
+        continue;
+      }
       matched++;
       if (dryRun) {
         console.log(
-          `  ${c.green}MATCH${c.reset} [${quote.pageId}:^${quote.footnote}] → ${resource.id} (${resource.title || resource.url})`,
+          `  ${c.green}MATCH${c.reset} [${quote.pageId}:^${quote.footnote}] → ${resource.stableId} (${resource.title || resource.url})`,
         );
       } else {
-        // Re-upsert with the resource_id populated
+        // Re-upsert with the resource_id populated (stable_id form)
         await upsertCitationQuote({
           pageId: String(quote.pageId),
           footnote: quote.footnote,
           url: quote.url,
-          resourceId: resource.id,
+          resourceId: resource.stableId,
           claimText: quote.claimText,
           claimContext: quote.claimContext ?? null,
           sourceQuote: quote.sourceQuote ?? null,
@@ -86,6 +94,9 @@ async function main() {
   console.log(`\n${c.bold}Results:${c.reset}`);
   console.log(`  ${c.green}Matched:${c.reset}   ${matched}`);
   console.log(`  ${c.dim}Unmatched:${c.reset} ${unmatched}`);
+  if (skippedNoStableId > 0) {
+    console.log(`  ${c.yellow}Skipped (no stable_id):${c.reset} ${skippedNoStableId}`);
+  }
   if (dryRun) {
     console.log(`\n  ${c.yellow}Dry run — no changes written.${c.reset}`);
   } else {

--- a/crux/citations/extract-quotes.ts
+++ b/crux/citations/extract-quotes.ts
@@ -205,9 +205,15 @@ export async function extractQuotesForPage(
 
       // Resolve resource_id from URL.
       // QUA-574 Phase B.2b: citation_quotes.resource_id references resources.stable_id,
-      // so write the sid_ value. Resources without a stable_id are left unlinked.
+      // so write the sid_ value. Resources without a stable_id are left unlinked —
+      // warn so the data-quality drift is visible rather than silent.
       const resource = cit.url ? getResourceByUrl(cit.url) : null;
-      const resourceId = resource?.stableId ?? null;
+      if (resource && !resource.stable_id) {
+        console.warn(
+          `  WARN: resource "${resource.id}" (${cit.url}) has no stable_id — citation quote will be unlinked. Populate resources.stable_id to fix.`,
+        );
+      }
+      const resourceId = resource?.stable_id ?? null;
 
       // Store in wiki-server DB
       await upsertCitationQuote({
@@ -261,7 +267,7 @@ export async function extractQuotesForPage(
         pageId,
         footnote: numericFootnote,
         url: cit.url || null,
-        resourceId: errResource?.stableId ?? null,
+        resourceId: errResource?.stable_id ?? null,
         claimText,
         claimContext: cit.claimContext,
         sourceTitle,

--- a/crux/citations/extract-quotes.ts
+++ b/crux/citations/extract-quotes.ts
@@ -203,9 +203,11 @@ export async function extractQuotesForPage(
         }
       }
 
-      // Resolve resource_id from URL
+      // Resolve resource_id from URL.
+      // QUA-574 Phase B.2b: citation_quotes.resource_id references resources.stable_id,
+      // so write the sid_ value. Resources without a stable_id are left unlinked.
       const resource = cit.url ? getResourceByUrl(cit.url) : null;
-      const resourceId = resource?.id ?? null;
+      const resourceId = resource?.stableId ?? null;
 
       // Store in wiki-server DB
       await upsertCitationQuote({
@@ -252,13 +254,14 @@ export async function extractQuotesForPage(
         console.log(` ERROR: ${msg.slice(0, 80)}`);
       }
 
-      // Still store the claim even if extraction failed
+      // Still store the claim even if extraction failed.
+      // QUA-574: write stable_id (not hex id) for the resource_id column.
       const errResource = cit.url ? getResourceByUrl(cit.url) : null;
       await upsertCitationQuote({
         pageId,
         footnote: numericFootnote,
         url: cit.url || null,
-        resourceId: errResource?.id ?? null,
+        resourceId: errResource?.stableId ?? null,
         claimText,
         claimContext: cit.claimContext,
         sourceTitle,


### PR DESCRIPTION
## Summary

Phase B.2b of [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549): swaps `citation_quotes.resource_id` reference from `resources.id` (hex16) → `resources.stable_id` (sid_). Follows the in-place / Option B pattern established by QUA-564 (#4456), QUA-565, and QUA-567 — column name stays `resource_id`, only the `.references()` target and stored values change.

Fixes QUA-574.

## What changed

- **`apps/wiki-server/src/schema.ts`**: `citationQuotes.resourceId` now `.references(() => resources.stableId, { onDelete: "set null" })`. Soft-ref — prod has no FK constraint (schema declares SET NULL only); adding the FK is a non-goal per QUA-574 and tracked separately.
- **Migration `0192_qua_574_citation_quotes_fk_swap.sql`**: defensive FK DROP (idempotent for dev/staging), in-place backfill (109 rows in prod), and a single-scan diagnostic block that emits two distinct NOTICEs:
  - `skipped_null_stableid` — rows where the matching `resources.stable_id` is NULL (fixable via QUA-536).
  - `orphan_count` — total rows with no matching `resources.stable_id` after backfill.
  Uses `RAISE NOTICE` (not `EXCEPTION`) since citation_quotes is a soft ref — ON DELETE SET NULL is unenforced without a real FK. Idempotent via `NOT LIKE 'sid_%'` guard on UPDATE.
- **`apps/wiki-server/src/routes/wikibase/citations.ts`**: `checkRefsExist` on `POST /quotes/upsert` + `POST /quotes/upsert-batch` now targets `resources.stableId`.
- **`apps/wiki-server/src/routes/operational/integrity.ts`**: dangling-ref scan joins on `r.stable_id` instead of `r.id`.
- **`crux/citations/extract-quotes.ts`** + **`crux/citations/backfill-resource-ids.ts`**: write `resource.stable_id` (not `resource.id`). `backfill-resource-ids` skips resources without a `stable_id` and reports the skipped count; `extract-quotes` emits a warning so silent NULL writes are visible.
- **Tests (`citations.test.ts`)**:
  - Round-trip test: single + batch upsert persist `sid_` values verbatim.
  - **Regression-lock test**: captures dispatched SQL and asserts the ref-check targets `"resources"."stable_id"` (not `"resources"."id"`). Verified by temporarily reverting — the test fails as expected.

## Risk profile

Low. 109 rows to backfill, soft-ref semantics preserved, no FK additions, migration halts only on NOTICE (no EXCEPTION paths that could block deploy). Route behavior changes but mock tests + column-check regression lock confirm the swap. Citation UI components (`ReferenceContext`, `CitationOverlay`, footnote tooltips) pass `resourceId` through as opaque strings — no join against `resources.id` to update on the frontend.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 6778 tests pass (3 new tests: sid_ round-trip single, sid_ round-trip batch, column-regression lock)
- [x] `pnpm crux w validate gate --fix` — all 44 gate checks pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean (caught a pre-fix `stableId` vs `stable_id` typo during review, now resolved)
- [x] Column-regression test verified to fail when schema is reverted to `resources.id`
- [ ] Post-deploy: inspect deploy logs for `QUA-574: N citation_quotes row(s) could not be backfilled` NOTICE — expected 0 per QUA-536.

## Review & simplify

- `/agent-review-pr` found 2 CRITICAL bugs (camelCase `stableId` across 5 call sites in 2 files — would have shipped silent NULL writes since `typecheck-crux` is advisory) and 1 HIGH test-gap. All fixed.
- `/simplify` consolidated the migration's two `COUNT(*)` scans into one `FILTER` query, tidied a narrative test comment, and grouped the loop counters.


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` Spot-check citation_quotes.resource_id is now sid_ post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM citation_quotes WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_`
- [ ] `manual` Confirm the migration emitted 0 `skipped_null_stableid` and 0 `orphan_count` NOTICEs in deploy logs — `kubectl logs -l app=wiki-server --tail=200 | grep -i QUA-574` (expect no output, or 0 in both counters)
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Citation quotes now reference resources using stable identifiers instead of internal IDs, improving data consistency and integrity across the system.

* **Tests**
  * Added comprehensive test coverage for citation resource reference validation and batch upsert operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->