### PR TITLE
feat(agents): surface Linear ID + state in sys agents status

### DIFF
--- a/crux/commands/agents.test.ts
+++ b/crux/commands/agents.test.ts
@@ -82,13 +82,12 @@ describe('collectLinearIds', () => {
       agentFixture({ id: 4, branch: 'claude/fix-239-something' }),
       agentFixture({ id: 5, branch: null }),
     ];
-    const { linearIds, uniqueIds } = collectLinearIds(agents);
+    const linearIds = collectLinearIds(agents);
     expect(linearIds.get(1)).toBe('QUA-580');
     expect(linearIds.get(2)).toBe('QUA-564');
     expect(linearIds.get(3)).toBeNull();
     expect(linearIds.get(4)).toBeNull();
     expect(linearIds.get(5)).toBeNull();
-    expect(uniqueIds.sort()).toEqual(['QUA-564', 'QUA-580']);
   });
 
   it('prefers the server-provided linearId over branch parsing', () => {
@@ -96,24 +95,14 @@ describe('collectLinearIds', () => {
       agentFixture({ id: 1, branch: 'main', linearId: 'QUA-42' }),
       agentFixture({ id: 2, branch: 'claude/qua-100-x', linearId: 'QUA-200' }),
     ];
-    const { linearIds } = collectLinearIds(agents);
+    const linearIds = collectLinearIds(agents);
     expect(linearIds.get(1)).toBe('QUA-42');
     expect(linearIds.get(2)).toBe('QUA-200');
   });
 
-  it('deduplicates repeated Linear IDs across agents', () => {
-    const agents = [
-      agentFixture({ id: 1, branch: 'claude/qua-100-a' }),
-      agentFixture({ id: 2, branch: 'claude/qua-100-b' }),
-    ];
-    const { uniqueIds } = collectLinearIds(agents);
-    expect(uniqueIds).toEqual(['QUA-100']);
-  });
-
   it('handles an empty agent list', () => {
-    const { linearIds, uniqueIds } = collectLinearIds([]);
+    const linearIds = collectLinearIds([]);
     expect(linearIds.size).toBe(0);
-    expect(uniqueIds).toEqual([]);
   });
 });
 

--- a/crux/commands/agents.test.ts
+++ b/crux/commands/agents.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for `crux sys agents` Linear-ID extraction (QUA-580).
+ *
+ * Mocks the wiki-server client + Linear state cache so the status command
+ * can be exercised without a live server or Linear API.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  listActiveAgentsMock,
+  getIssueStatesMock,
+  isServerAvailableMock,
+} = vi.hoisted(() => ({
+  listActiveAgentsMock: vi.fn(),
+  getIssueStatesMock: vi.fn(),
+  isServerAvailableMock: vi.fn(),
+}));
+
+vi.mock('../lib/wiki-server/active-agents.ts', () => ({
+  listActiveAgents: listActiveAgentsMock,
+  registerAgent: vi.fn(),
+  updateAgent: vi.fn(),
+  heartbeat: vi.fn(),
+  sweepStaleAgents: vi.fn(),
+}));
+
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  isServerAvailable: isServerAvailableMock,
+  apiRequest: vi.fn(),
+}));
+
+vi.mock('../lib/wiki-server/agent-sessions.ts', () => ({
+  sweepStaleSessions: vi.fn(),
+  getAgentSessionByBranch: vi.fn(),
+  updateAgentSession: vi.fn(),
+}));
+
+vi.mock('../lib/wiki-server/agent-session-events.ts', () => ({
+  appendEvent: vi.fn(),
+}));
+
+vi.mock('../lib/linear/issue-states-cache.ts', () => ({
+  getIssueStates: getIssueStatesMock,
+}));
+
+import { commands, collectLinearIds } from './agents.ts';
+import type { ActiveAgentEntry } from '../lib/wiki-server/active-agents.ts';
+
+function agentFixture(overrides: Partial<ActiveAgentEntry> = {}): ActiveAgentEntry {
+  return {
+    id: 1,
+    sessionId: 'session-1',
+    sessionName: 'brave-pine',
+    branch: 'claude/qua-580-surface-linear-state',
+    task: 'do QUA-580',
+    status: 'active',
+    startedAt: '2026-04-17T00:00:00Z',
+    heartbeatAt: '2026-04-17T00:01:00Z',
+    issueNumber: null,
+    prNumber: null,
+    model: null,
+    currentStep: null,
+    filesTouched: null,
+    worktree: null,
+    completedAt: null,
+    metadata: null,
+    createdAt: '2026-04-17T00:00:00Z',
+    updatedAt: '2026-04-17T00:00:00Z',
+    linearId: null,
+    slotNumber: null,
+    ...overrides,
+  } as ActiveAgentEntry;
+}
+
+describe('collectLinearIds', () => {
+  it('extracts Linear IDs from agent branches', () => {
+    const agents = [
+      agentFixture({ id: 1, branch: 'claude/qua-580-description' }),
+      agentFixture({ id: 2, branch: 'claude/qua-564-phase-b1' }),
+      agentFixture({ id: 3, branch: 'main' }),
+      agentFixture({ id: 4, branch: 'claude/fix-239-something' }),
+      agentFixture({ id: 5, branch: null }),
+    ];
+    const { linearIds, uniqueIds } = collectLinearIds(agents);
+    expect(linearIds.get(1)).toBe('QUA-580');
+    expect(linearIds.get(2)).toBe('QUA-564');
+    expect(linearIds.get(3)).toBeNull();
+    expect(linearIds.get(4)).toBeNull();
+    expect(linearIds.get(5)).toBeNull();
+    expect(uniqueIds.sort()).toEqual(['QUA-564', 'QUA-580']);
+  });
+
+  it('prefers the server-provided linearId over branch parsing', () => {
+    const agents = [
+      agentFixture({ id: 1, branch: 'main', linearId: 'QUA-42' }),
+      agentFixture({ id: 2, branch: 'claude/qua-100-x', linearId: 'QUA-200' }),
+    ];
+    const { linearIds } = collectLinearIds(agents);
+    expect(linearIds.get(1)).toBe('QUA-42');
+    expect(linearIds.get(2)).toBe('QUA-200');
+  });
+
+  it('deduplicates repeated Linear IDs across agents', () => {
+    const agents = [
+      agentFixture({ id: 1, branch: 'claude/qua-100-a' }),
+      agentFixture({ id: 2, branch: 'claude/qua-100-b' }),
+    ];
+    const { uniqueIds } = collectLinearIds(agents);
+    expect(uniqueIds).toEqual(['QUA-100']);
+  });
+
+  it('handles an empty agent list', () => {
+    const { linearIds, uniqueIds } = collectLinearIds([]);
+    expect(linearIds.size).toBe(0);
+    expect(uniqueIds).toEqual([]);
+  });
+});
+
+describe('status command (agents)', () => {
+  beforeEach(() => {
+    listActiveAgentsMock.mockReset();
+    getIssueStatesMock.mockReset();
+    isServerAvailableMock.mockReset();
+    isServerAvailableMock.mockResolvedValue(true);
+  });
+
+  it('emits a "Linear:" line with state when a branch maps to a ticket', async () => {
+    listActiveAgentsMock.mockResolvedValue({
+      ok: true,
+      data: {
+        agents: [agentFixture({ id: 1, branch: 'claude/qua-580-surface-linear-state' })],
+        conflicts: [],
+        directoryConflicts: [],
+      },
+    });
+    getIssueStatesMock.mockResolvedValue(new Map([['QUA-580', 'In Progress']]));
+
+    const result = await commands.status([], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('QUA-580');
+    expect(result.output).toContain('In Progress');
+    expect(getIssueStatesMock).toHaveBeenCalledWith(['QUA-580']);
+  });
+
+  it('shows "—" when an agent branch has no Linear ID', async () => {
+    listActiveAgentsMock.mockResolvedValue({
+      ok: true,
+      data: {
+        agents: [agentFixture({ id: 1, branch: 'main' })],
+        conflicts: [],
+        directoryConflicts: [],
+      },
+    });
+    getIssueStatesMock.mockResolvedValue(new Map());
+
+    const result = await commands.status([], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('Linear: —');
+  });
+
+  it('shows the Linear ID with "—" state when Linear returns no match', async () => {
+    listActiveAgentsMock.mockResolvedValue({
+      ok: true,
+      data: {
+        agents: [agentFixture({ id: 1, branch: 'claude/qua-999-missing' })],
+        conflicts: [],
+        directoryConflicts: [],
+      },
+    });
+    getIssueStatesMock.mockResolvedValue(new Map([['QUA-999', null]]));
+
+    const result = await commands.status([], {});
+    expect(result.output).toContain('QUA-999');
+    expect(result.output).toMatch(/Linear:[^\n]*QUA-999[^\n]*—/);
+  });
+
+  it('includes linearId and linearState in --json output', async () => {
+    listActiveAgentsMock.mockResolvedValue({
+      ok: true,
+      data: {
+        agents: [
+          agentFixture({ id: 1, branch: 'claude/qua-580-test' }),
+          agentFixture({ id: 2, branch: 'main' }),
+        ],
+        conflicts: [],
+        directoryConflicts: [],
+      },
+    });
+    getIssueStatesMock.mockResolvedValue(new Map([['QUA-580', 'In Progress']]));
+
+    const result = await commands.status([], { json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.agents[0].linearId).toBe('QUA-580');
+    expect(parsed.agents[0].linearState).toBe('In Progress');
+    expect(parsed.agents[1].linearId).toBeNull();
+    expect(parsed.agents[1].linearState).toBeNull();
+  });
+
+  it('returns exit 1 when the wiki-server is unavailable', async () => {
+    isServerAvailableMock.mockResolvedValueOnce(false);
+    const result = await commands.status([], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/not reachable/i);
+    expect(getIssueStatesMock).not.toHaveBeenCalled();
+  });
+});

--- a/crux/commands/agents.ts
+++ b/crux/commands/agents.ts
@@ -29,6 +29,8 @@ import {
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { sweepStaleSessions, getAgentSessionByBranch, updateAgentSession } from '../lib/wiki-server/agent-sessions.ts';
 import { appendEvent } from '../lib/wiki-server/agent-session-events.ts';
+import { parseLinearId } from '../lib/linear/parse-id.ts';
+import { getIssueStates } from '../lib/linear/issue-states-cache.ts';
 
 interface CommandOptions extends BaseOptions {
   task?: string;
@@ -51,7 +53,16 @@ interface CommandOptions extends BaseOptions {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatAgent(a: ActiveAgentEntry, colors: ReturnType<typeof createLogger>['colors']): string {
+interface AgentAnnotation {
+  linearId: string | null;
+  linearState: string | null;
+}
+
+function formatAgent(
+  a: ActiveAgentEntry,
+  colors: ReturnType<typeof createLogger>['colors'],
+  annotation: AgentAnnotation = { linearId: null, linearState: null },
+): string {
   const statusColors: Record<string, string> = {
     active: colors.green,
     completed: colors.dim,
@@ -68,6 +79,9 @@ function formatAgent(a: ActiveAgentEntry, colors: ReturnType<typeof createLogger
 
   const name = a.sessionName ? ` ${colors.cyan}${a.sessionName}${colors.reset}` : '';
   const worktreeInfo = a.worktree ? `    Dir: ${colors.dim}${a.worktree}${colors.reset}` : '';
+  const linearLine = annotation.linearId
+    ? `    Linear: ${colors.cyan}${annotation.linearId}${colors.reset} ${annotation.linearState ?? '—'}`
+    : '    Linear: —';
 
   return [
     `  ${colors.bold}#${a.id}${colors.reset}${name} ${statusColor}[${a.status}]${colors.reset}${issue}${pr}`,
@@ -75,10 +89,36 @@ function formatAgent(a: ActiveAgentEntry, colors: ReturnType<typeof createLogger
     a.branch ? `    Branch: ${colors.dim}${a.branch}${colors.reset}` : '',
     worktreeInfo,
     a.model ? `    Model: ${a.model}` : '',
+    linearLine,
     `    Started: ${started}  Heartbeat: ${heartbeat}`,
     step,
     files,
   ].filter(Boolean).join('\n');
+}
+
+/**
+ * Build the `identifier → state` map for all agents whose branch contains
+ * a Linear ticket reference. Returns two maps:
+ *   - `linearIds`: agent-id → Linear identifier (or null)
+ *   - `states`: Linear identifier → state name (or null if Linear doesn't know)
+ *
+ * Exported for tests.
+ */
+export function collectLinearIds(
+  agents: readonly ActiveAgentEntry[],
+): { linearIds: Map<number, string | null>; uniqueIds: string[] } {
+  const linearIds = new Map<number, string | null>();
+  const unique = new Set<string>();
+  for (const agent of agents) {
+    // Prefer the server-provided Linear ID (populated from the authoritative
+    // agent_sessions row during `crux linear start`); fall back to parsing
+    // the branch name for agents that registered without a session (e.g.
+    // job workers, ad-hoc registrations).
+    const id = agent.linearId ?? parseLinearId(agent.branch);
+    linearIds.set(agent.id, id);
+    if (id) unique.add(id);
+  }
+  return { linearIds, uniqueIds: Array.from(unique) };
 }
 
 async function checkServer(): Promise<CommandResult | null> {
@@ -165,11 +205,22 @@ async function statusCommand(
     return { exitCode: 1, output: `Error: ${result.message}` };
   }
 
-  if (options.json) {
-    return { exitCode: 0, output: JSON.stringify(result.data, null, 2) };
-  }
-
   const { agents, conflicts, directoryConflicts } = result.data;
+
+  const { linearIds, uniqueIds } = collectLinearIds(agents);
+  const states = await getIssueStates(uniqueIds);
+
+  if (options.json) {
+    const enriched = {
+      ...result.data,
+      agents: agents.map((a) => {
+        const linearId = linearIds.get(a.id) ?? null;
+        const linearState = linearId ? states.get(linearId) ?? null : null;
+        return { ...a, linearId, linearState };
+      }),
+    };
+    return { exitCode: 0, output: JSON.stringify(enriched, null, 2) };
+  }
 
   if (agents.length === 0) {
     return { exitCode: 0, output: `No ${statusFilter} agents found.` };
@@ -177,7 +228,9 @@ async function statusCommand(
 
   let output = `${log.colors.bold}Active Agents (${agents.length})${log.colors.reset}\n\n`;
   for (const agent of agents) {
-    output += formatAgent(agent, log.colors) + '\n\n';
+    const linearId = linearIds.get(agent.id) ?? null;
+    const linearState = linearId ? states.get(linearId) ?? null : null;
+    output += formatAgent(agent, log.colors, { linearId, linearState }) + '\n\n';
   }
 
   if (conflicts.length > 0) {

--- a/crux/commands/agents.ts
+++ b/crux/commands/agents.ts
@@ -97,28 +97,22 @@ function formatAgent(
 }
 
 /**
- * Build the `identifier → state` map for all agents whose branch contains
- * a Linear ticket reference. Returns two maps:
- *   - `linearIds`: agent-id → Linear identifier (or null)
- *   - `states`: Linear identifier → state name (or null if Linear doesn't know)
+ * Map each agent's id to its Linear ticket identifier (or `null` if none
+ * is detectable). Prefers the server-provided `linearId` from the
+ * authoritative `agent_sessions` row over branch-name parsing, so that
+ * agents registered without a session (job workers, ad-hoc registrations)
+ * still get a best-effort match from the branch.
  *
  * Exported for tests.
  */
 export function collectLinearIds(
   agents: readonly ActiveAgentEntry[],
-): { linearIds: Map<number, string | null>; uniqueIds: string[] } {
+): Map<number, string | null> {
   const linearIds = new Map<number, string | null>();
-  const unique = new Set<string>();
   for (const agent of agents) {
-    // Prefer the server-provided Linear ID (populated from the authoritative
-    // agent_sessions row during `crux linear start`); fall back to parsing
-    // the branch name for agents that registered without a session (e.g.
-    // job workers, ad-hoc registrations).
-    const id = agent.linearId ?? parseLinearId(agent.branch);
-    linearIds.set(agent.id, id);
-    if (id) unique.add(id);
+    linearIds.set(agent.id, agent.linearId ?? parseLinearId(agent.branch));
   }
-  return { linearIds, uniqueIds: Array.from(unique) };
+  return linearIds;
 }
 
 async function checkServer(): Promise<CommandResult | null> {
@@ -207,17 +201,22 @@ async function statusCommand(
 
   const { agents, conflicts, directoryConflicts } = result.data;
 
-  const { linearIds, uniqueIds } = collectLinearIds(agents);
+  const linearIds = collectLinearIds(agents);
+  const uniqueIds = [...new Set([...linearIds.values()].filter((id): id is string => id !== null))];
   const states = await getIssueStates(uniqueIds);
+
+  const annotationFor = (agent: ActiveAgentEntry): AgentAnnotation => {
+    const linearId = linearIds.get(agent.id) ?? null;
+    return {
+      linearId,
+      linearState: linearId ? states.get(linearId) ?? null : null,
+    };
+  };
 
   if (options.json) {
     const enriched = {
       ...result.data,
-      agents: agents.map((a) => {
-        const linearId = linearIds.get(a.id) ?? null;
-        const linearState = linearId ? states.get(linearId) ?? null : null;
-        return { ...a, linearId, linearState };
-      }),
+      agents: agents.map((a) => ({ ...a, ...annotationFor(a) })),
     };
     return { exitCode: 0, output: JSON.stringify(enriched, null, 2) };
   }
@@ -228,9 +227,7 @@ async function statusCommand(
 
   let output = `${log.colors.bold}Active Agents (${agents.length})${log.colors.reset}\n\n`;
   for (const agent of agents) {
-    const linearId = linearIds.get(agent.id) ?? null;
-    const linearState = linearId ? states.get(linearId) ?? null : null;
-    output += formatAgent(agent, log.colors, { linearId, linearState }) + '\n\n';
+    output += formatAgent(agent, log.colors, annotationFor(agent)) + '\n\n';
   }
 
   if (conflicts.length > 0) {

--- a/crux/lib/linear/issue-states-cache.test.ts
+++ b/crux/lib/linear/issue-states-cache.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the Linear issue-state cache used by `crux sys agents status`.
+ * Verifies: (1) cache hits within the 60s TTL skip the API, (2) stale
+ * entries are refetched, (3) API failures fail open without throwing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const { linearGraphQLMock } = vi.hoisted(() => ({
+  linearGraphQLMock: vi.fn(),
+}));
+
+vi.mock('./client.ts', () => ({
+  linearGraphQL: linearGraphQLMock,
+  linearIssueUrl: (id: string) => `https://linear.app/test/issue/${id}`,
+}));
+
+// Reroute the cache file into a temporary directory for each test so that
+// the developer's real `~/.cache/crux-linear/` is never touched.
+let tempCacheDir: string;
+let tempCacheFile: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: () => tempCacheDir,
+  };
+});
+
+describe('getIssueStates', () => {
+  beforeEach(() => {
+    tempCacheDir = mkdtempSync(join(tmpdir(), 'crux-linear-test-'));
+    tempCacheFile = join(tempCacheDir, '.cache', 'crux-linear', 'issue-states.json');
+    linearGraphQLMock.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(tempCacheDir, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('returns an empty map for no identifiers without hitting the API', async () => {
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates([]);
+    expect(result.size).toBe(0);
+    expect(linearGraphQLMock).not.toHaveBeenCalled();
+  });
+
+  it('batch-fetches states and caches them to disk', async () => {
+    linearGraphQLMock.mockResolvedValueOnce({
+      i_QUA_1: { identifier: 'QUA-1', state: { name: 'In Progress' } },
+      i_QUA_2: { identifier: 'QUA-2', state: { name: 'Done' } },
+    });
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-1', 'QUA-2'], 1_000_000);
+    expect(result.get('QUA-1')).toBe('In Progress');
+    expect(result.get('QUA-2')).toBe('Done');
+    expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
+    // One GraphQL call, both aliases inside.
+    const [query] = linearGraphQLMock.mock.calls[0];
+    expect(query).toContain('i_QUA_1: issue(id: "QUA-1")');
+    expect(query).toContain('i_QUA_2: issue(id: "QUA-2")');
+    // Cache file was persisted.
+    expect(existsSync(tempCacheFile)).toBe(true);
+    const cached = JSON.parse(readFileSync(tempCacheFile, 'utf-8'));
+    expect(cached['QUA-1']).toMatchObject({ state: 'In Progress', fetchedAt: 1_000_000 });
+  });
+
+  it('serves from cache within the 60s TTL without hitting the API', async () => {
+    // Seed cache file with a fresh entry.
+    mkdirSync(join(tempCacheDir, '.cache', 'crux-linear'), { recursive: true });
+    writeFileSync(
+      tempCacheFile,
+      JSON.stringify({ 'QUA-7': { state: 'Todo', fetchedAt: 1_000_000 } }),
+    );
+    const mod = await import('./issue-states-cache.ts');
+    // 30s later — still within TTL.
+    const result = await mod.getIssueStates(['QUA-7'], 1_030_000);
+    expect(result.get('QUA-7')).toBe('Todo');
+    expect(linearGraphQLMock).not.toHaveBeenCalled();
+  });
+
+  it('refetches stale entries past the 60s TTL', async () => {
+    mkdirSync(join(tempCacheDir, '.cache', 'crux-linear'), { recursive: true });
+    writeFileSync(
+      tempCacheFile,
+      JSON.stringify({ 'QUA-7': { state: 'Todo', fetchedAt: 1_000_000 } }),
+    );
+    linearGraphQLMock.mockResolvedValueOnce({
+      i_QUA_7: { identifier: 'QUA-7', state: { name: 'In Progress' } },
+    });
+    const mod = await import('./issue-states-cache.ts');
+    // 61s later — past TTL.
+    const result = await mod.getIssueStates(['QUA-7'], 1_061_000);
+    expect(result.get('QUA-7')).toBe('In Progress');
+    expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open and returns cached values when the API throws', async () => {
+    mkdirSync(join(tempCacheDir, '.cache', 'crux-linear'), { recursive: true });
+    writeFileSync(
+      tempCacheFile,
+      JSON.stringify({ 'QUA-1': { state: 'Done', fetchedAt: 1_000_000 } }),
+    );
+    linearGraphQLMock.mockRejectedValueOnce(new Error('Linear unreachable'));
+    const mod = await import('./issue-states-cache.ts');
+    // QUA-1 is fresh (from cache), QUA-2 needs fetching (API fails).
+    const result = await mod.getIssueStates(['QUA-1', 'QUA-2'], 1_030_000);
+    expect(result.get('QUA-1')).toBe('Done');
+    expect(result.has('QUA-2')).toBe(false);
+  });
+
+  it('deduplicates identifiers before fetching', async () => {
+    linearGraphQLMock.mockResolvedValueOnce({
+      i_QUA_5: { identifier: 'QUA-5', state: { name: 'In Review' } },
+    });
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-5', 'QUA-5', 'QUA-5'], 1_000_000);
+    expect(result.get('QUA-5')).toBe('In Review');
+    expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
+    const [query] = linearGraphQLMock.mock.calls[0];
+    // Aliased issue query appears exactly once.
+    expect((query.match(/i_QUA_5: issue/g) ?? []).length).toBe(1);
+  });
+
+  it('records null state when Linear returns no match for an identifier', async () => {
+    linearGraphQLMock.mockResolvedValueOnce({
+      i_QUA_9: null,
+    });
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-9'], 1_000_000);
+    expect(result.get('QUA-9')).toBeNull();
+  });
+});

--- a/crux/lib/linear/issue-states-cache.test.ts
+++ b/crux/lib/linear/issue-states-cache.test.ts
@@ -31,16 +31,24 @@ vi.mock('os', async () => {
   };
 });
 
+const originalApiKey = process.env.LINEAR_API_KEY;
+
 describe('getIssueStates', () => {
   beforeEach(() => {
     tempCacheDir = mkdtempSync(join(tmpdir(), 'crux-linear-test-'));
     tempCacheFile = join(tempCacheDir, '.cache', 'crux-linear', 'issue-states.json');
     linearGraphQLMock.mockReset();
+    process.env.LINEAR_API_KEY = 'test-key';
   });
 
   afterEach(() => {
     rmSync(tempCacheDir, { recursive: true, force: true });
     vi.resetModules();
+    if (originalApiKey === undefined) {
+      delete process.env.LINEAR_API_KEY;
+    } else {
+      process.env.LINEAR_API_KEY = originalApiKey;
+    }
   });
 
   it('returns an empty map for no identifiers without hitting the API', async () => {
@@ -134,5 +142,20 @@ describe('getIssueStates', () => {
     const mod = await import('./issue-states-cache.ts');
     const result = await mod.getIssueStates(['QUA-9'], 1_000_000);
     expect(result.get('QUA-9')).toBeNull();
+  });
+
+  it('skips the fetch entirely when LINEAR_API_KEY is missing', async () => {
+    delete process.env.LINEAR_API_KEY;
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-1'], 1_000_000);
+    expect(result.has('QUA-1')).toBe(false);
+    expect(linearGraphQLMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses to interpolate malformed Linear IDs into the query', async () => {
+    const mod = await import('./issue-states-cache.ts');
+    await expect(
+      mod.fetchIssueStatesBatch(['QUA-1; DROP TABLE issues'] as string[]),
+    ).rejects.toThrow(/malformed Linear ID/);
   });
 });

--- a/crux/lib/linear/issue-states-cache.test.ts
+++ b/crux/lib/linear/issue-states-cache.test.ts
@@ -60,22 +60,31 @@ describe('getIssueStates', () => {
 
   it('batch-fetches states and caches them to disk', async () => {
     linearGraphQLMock.mockResolvedValueOnce({
-      i_QUA_1: { identifier: 'QUA-1', state: { name: 'In Progress' } },
-      i_QUA_2: { identifier: 'QUA-2', state: { name: 'Done' } },
+      i0: { identifier: 'QUA-1', state: { name: 'In Progress' } },
+      i1: { identifier: 'QUA-2', state: { name: 'Done' } },
     });
     const mod = await import('./issue-states-cache.ts');
     const result = await mod.getIssueStates(['QUA-1', 'QUA-2'], 1_000_000);
     expect(result.get('QUA-1')).toBe('In Progress');
     expect(result.get('QUA-2')).toBe('Done');
     expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
-    // One GraphQL call, both aliases inside.
     const [query] = linearGraphQLMock.mock.calls[0];
-    expect(query).toContain('i_QUA_1: issue(id: "QUA-1")');
-    expect(query).toContain('i_QUA_2: issue(id: "QUA-2")');
-    // Cache file was persisted.
+    expect(query).toContain('i0: issue(id: "QUA-1")');
+    expect(query).toContain('i1: issue(id: "QUA-2")');
     expect(existsSync(tempCacheFile)).toBe(true);
     const cached = JSON.parse(readFileSync(tempCacheFile, 'utf-8'));
     expect(cached['QUA-1']).toMatchObject({ state: 'In Progress', fetchedAt: 1_000_000 });
+  });
+
+  it('maps results by response identifier field (not by alias position)', async () => {
+    linearGraphQLMock.mockResolvedValueOnce({
+      i0: { identifier: 'QUA-2', state: { name: 'Done' } },
+      i1: { identifier: 'QUA-1', state: { name: 'In Progress' } },
+    });
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-1', 'QUA-2'], 1_000_000);
+    expect(result.get('QUA-1')).toBe('In Progress');
+    expect(result.get('QUA-2')).toBe('Done');
   });
 
   it('serves from cache within the 60s TTL without hitting the API', async () => {
@@ -99,12 +108,26 @@ describe('getIssueStates', () => {
       JSON.stringify({ 'QUA-7': { state: 'Todo', fetchedAt: 1_000_000 } }),
     );
     linearGraphQLMock.mockResolvedValueOnce({
-      i_QUA_7: { identifier: 'QUA-7', state: { name: 'In Progress' } },
+      i0: { identifier: 'QUA-7', state: { name: 'In Progress' } },
     });
     const mod = await import('./issue-states-cache.ts');
-    // 61s later — past TTL.
     const result = await mod.getIssueStates(['QUA-7'], 1_061_000);
     expect(result.get('QUA-7')).toBe('In Progress');
+    expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops entries with a malformed state field when reading cache', async () => {
+    mkdirSync(join(tempCacheDir, '.cache', 'crux-linear'), { recursive: true });
+    writeFileSync(
+      tempCacheFile,
+      JSON.stringify({ 'QUA-1': { state: { bad: 'object' }, fetchedAt: 1_000_000 } }),
+    );
+    linearGraphQLMock.mockResolvedValueOnce({
+      i0: { identifier: 'QUA-1', state: { name: 'Done' } },
+    });
+    const mod = await import('./issue-states-cache.ts');
+    const result = await mod.getIssueStates(['QUA-1'], 1_030_000);
+    expect(result.get('QUA-1')).toBe('Done');
     expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
   });
 
@@ -124,20 +147,19 @@ describe('getIssueStates', () => {
 
   it('deduplicates identifiers before fetching', async () => {
     linearGraphQLMock.mockResolvedValueOnce({
-      i_QUA_5: { identifier: 'QUA-5', state: { name: 'In Review' } },
+      i0: { identifier: 'QUA-5', state: { name: 'In Review' } },
     });
     const mod = await import('./issue-states-cache.ts');
     const result = await mod.getIssueStates(['QUA-5', 'QUA-5', 'QUA-5'], 1_000_000);
     expect(result.get('QUA-5')).toBe('In Review');
     expect(linearGraphQLMock).toHaveBeenCalledTimes(1);
     const [query] = linearGraphQLMock.mock.calls[0];
-    // Aliased issue query appears exactly once.
-    expect((query.match(/i_QUA_5: issue/g) ?? []).length).toBe(1);
+    expect((query.match(/issue\(id: "QUA-5"\)/g) ?? []).length).toBe(1);
   });
 
   it('records null state when Linear returns no match for an identifier', async () => {
     linearGraphQLMock.mockResolvedValueOnce({
-      i_QUA_9: null,
+      i0: null,
     });
     const mod = await import('./issue-states-cache.ts');
     const result = await mod.getIssueStates(['QUA-9'], 1_000_000);

--- a/crux/lib/linear/issue-states-cache.ts
+++ b/crux/lib/linear/issue-states-cache.ts
@@ -1,0 +1,142 @@
+/**
+ * Linear issue state cache — QUA-580
+ *
+ * Bulk-fetches the workflow state of N Linear issues in a single GraphQL
+ * query (via aliased fields) and caches results to disk with a 60s TTL so
+ * repeated `crux sys agents status` invocations don't hit Linear every time.
+ *
+ * Failure modes are all fail-open: missing LINEAR_API_KEY, network error,
+ * corrupt cache file — we return whatever states we have and let callers
+ * render `—` for the rest. The status command is cosmetic; it should never
+ * fail because Linear is unreachable.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { linearGraphQL } from './client.ts';
+
+export const CACHE_DIR = join(homedir(), '.cache', 'crux-linear');
+export const CACHE_FILE = join(CACHE_DIR, 'issue-states.json');
+export const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  state: string | null;
+  fetchedAt: number;
+}
+
+type CacheShape = Record<string, CacheEntry>;
+
+function readCache(now: number = Date.now()): CacheShape {
+  if (!existsSync(CACHE_FILE)) return {};
+  try {
+    const raw = readFileSync(CACHE_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as CacheShape;
+    // Drop obviously-stale entries on read to keep the file small.
+    const fresh: CacheShape = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (
+        v &&
+        typeof v === 'object' &&
+        typeof v.fetchedAt === 'number' &&
+        now - v.fetchedAt < CACHE_TTL_MS * 10
+      ) {
+        fresh[k] = v;
+      }
+    }
+    return fresh;
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(cache: CacheShape): void {
+  try {
+    if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2), 'utf-8');
+  } catch {
+    // Best-effort: cache write failures shouldn't break the caller.
+  }
+}
+
+function aliasFor(identifier: string): string {
+  // GraphQL aliases must match /[_A-Za-z][_0-9A-Za-z]*/.
+  return 'i_' + identifier.replace(/[^A-Za-z0-9]/g, '_');
+}
+
+interface BatchIssueResult {
+  identifier: string;
+  state: { name: string } | null;
+}
+
+/**
+ * Fetch workflow states for many Linear issues in a single round-trip using
+ * GraphQL aliases. Exported for unit tests; most callers should use
+ * `getIssueStates` which adds disk caching.
+ */
+export async function fetchIssueStatesBatch(
+  identifiers: string[],
+): Promise<Map<string, string | null>> {
+  const result = new Map<string, string | null>();
+  if (identifiers.length === 0) return result;
+
+  const parts = identifiers.map(
+    (id) =>
+      `${aliasFor(id)}: issue(id: "${id}") { identifier state { name } }`,
+  );
+  const query = `query BatchIssueStates { ${parts.join(' ')} }`;
+
+  const data = await linearGraphQL<Record<string, BatchIssueResult | null>>(query);
+  for (const id of identifiers) {
+    const row = data[aliasFor(id)];
+    result.set(id, row?.state?.name ?? null);
+  }
+  return result;
+}
+
+/**
+ * Return a Map of identifier → state name for the given Linear IDs.
+ *
+ * Uses a 60s disk cache keyed per identifier. Missing entries (or entries
+ * older than 60s) are fetched in one batched GraphQL query. Identifiers
+ * with no state in Linear map to `null`.
+ *
+ * On any failure (no API key, network error, malformed response) the
+ * returned map simply omits the affected IDs — callers should render `—`
+ * when a key is missing.
+ */
+export async function getIssueStates(
+  identifiers: string[],
+  now: number = Date.now(),
+): Promise<Map<string, string | null>> {
+  const unique = Array.from(new Set(identifiers.filter(Boolean)));
+  const result = new Map<string, string | null>();
+  if (unique.length === 0) return result;
+
+  const cache = readCache(now);
+  const toFetch: string[] = [];
+  for (const id of unique) {
+    const entry = cache[id];
+    if (entry && now - entry.fetchedAt < CACHE_TTL_MS) {
+      result.set(id, entry.state);
+    } else {
+      toFetch.push(id);
+    }
+  }
+
+  if (toFetch.length === 0) return result;
+
+  try {
+    const fetched = await fetchIssueStatesBatch(toFetch);
+    for (const [id, state] of fetched) {
+      result.set(id, state);
+      cache[id] = { state, fetchedAt: now };
+    }
+    writeCache(cache);
+  } catch {
+    // Fail open — return whatever we got from cache. Callers render `—`
+    // for the identifiers we couldn't fetch.
+  }
+
+  return result;
+}

--- a/crux/lib/linear/issue-states-cache.ts
+++ b/crux/lib/linear/issue-states-cache.ts
@@ -11,7 +11,7 @@
  * fail because Linear is unreachable.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { linearGraphQL } from './client.ts';
@@ -49,7 +49,8 @@ function readCache(now: number = Date.now()): CacheShape {
       v &&
       typeof v === 'object' &&
       typeof v.fetchedAt === 'number' &&
-      now - v.fetchedAt < CACHE_TTL_MS * 10
+      (typeof v.state === 'string' || v.state === null) &&
+      now - v.fetchedAt < CACHE_TTL_MS
     ) {
       fresh[k] = v;
     }
@@ -58,17 +59,17 @@ function readCache(now: number = Date.now()): CacheShape {
 }
 
 function writeCache(cache: CacheShape): void {
+  // Write-then-rename: on POSIX, rename is atomic, so a concurrent reader
+  // never sees a half-written file and concurrent writers don't corrupt
+  // each other. Two `crux sys agents status` processes racing is common.
+  const tmp = `${CACHE_FILE}.${process.pid}.${Date.now()}`;
   try {
     mkdirSync(CACHE_DIR, { recursive: true });
-    writeFileSync(CACHE_FILE, JSON.stringify(cache), 'utf-8');
+    writeFileSync(tmp, JSON.stringify(cache), 'utf-8');
+    renameSync(tmp, CACHE_FILE);
   } catch {
-    // Best-effort: cache write failures shouldn't break the caller.
+    try { unlinkSync(tmp); } catch { /* no temp file to clean up */ }
   }
-}
-
-function aliasFor(identifier: string): string {
-  // GraphQL aliases must match /[_A-Za-z][_0-9A-Za-z]*/.
-  return 'i_' + identifier.replace(/[^A-Za-z0-9]/g, '_');
 }
 
 interface BatchIssueResult {
@@ -77,9 +78,14 @@ interface BatchIssueResult {
 }
 
 /**
- * Fetch workflow states for many Linear issues in a single round-trip using
- * GraphQL aliases. Exported for unit tests; most callers should use
- * `getIssueStates` which adds disk caching.
+ * Fetch workflow states for many Linear issues in a single round-trip.
+ *
+ * Each issue gets a positional alias (`i0`, `i1`, ...) that depends only on
+ * the caller-provided order, so two distinct identifiers can never collide
+ * onto the same alias. Results are mapped back by the `identifier` field
+ * Linear returns in each response row, not by the alias, so the mapping
+ * remains correct even if Linear reorders the response. Exported for unit
+ * tests; most callers should use `getIssueStates` which adds disk caching.
  */
 export async function fetchIssueStatesBatch(
   identifiers: string[],
@@ -94,15 +100,19 @@ export async function fetchIssueStatesBatch(
   }
 
   const parts = identifiers.map(
-    (id) =>
-      `${aliasFor(id)}: issue(id: "${id}") { identifier state { name } }`,
+    (id, idx) => `i${idx}: issue(id: "${id}") { identifier state { name } }`,
   );
   const query = `query BatchIssueStates { ${parts.join(' ')} }`;
 
   const data = await linearGraphQL<Record<string, BatchIssueResult | null>>(query);
-  for (const id of identifiers) {
-    const row = data[aliasFor(id)];
-    result.set(id, row?.state?.name ?? null);
+  // Seed every requested identifier with `null` so callers can distinguish
+  // "Linear didn't return this" from "we never asked"; then overwrite with
+  // actual state names from whichever rows Linear did return.
+  for (const id of identifiers) result.set(id, null);
+  for (const row of Object.values(data)) {
+    if (row?.identifier && result.has(row.identifier)) {
+      result.set(row.identifier, row.state?.name ?? null);
+    }
   }
   return result;
 }
@@ -150,9 +160,15 @@ export async function getIssueStates(
       cache[id] = { state, fetchedAt: now };
     }
     writeCache(cache);
-  } catch {
-    // Fail open — return whatever we got from cache. Callers render `—`
-    // for the identifiers we couldn't fetch.
+  } catch (e) {
+    // Fail open — callers render `—` for identifiers we couldn't fetch.
+    // Log at debug level so `LINEAR_DEBUG=1` or equivalent surfaces the
+    // reason (unreachable API, bad key, edge-cache HTML) without flooding
+    // normal status output.
+    if (process.env.LINEAR_DEBUG) {
+      // eslint-disable-next-line no-console
+      console.warn(`[linear] issue-states fetch failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   return result;

--- a/crux/lib/linear/issue-states-cache.ts
+++ b/crux/lib/linear/issue-states-cache.ts
@@ -11,10 +11,19 @@
  * fail because Linear is unreachable.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { linearGraphQL } from './client.ts';
+
+/**
+ * Linear issue identifiers follow the `TEAM-NNN` shape (uppercase team key,
+ * hyphen, digits). We interpolate the ID directly into the batched GraphQL
+ * query string (there's no variable form for aliased fields), so validate
+ * the shape before trusting it. Belt-and-braces: parseLinearId already
+ * constrains the shape, but a broken caller shouldn't be able to inject.
+ */
+const LINEAR_ID_RE = /^[A-Z][A-Z0-9]*-\d+$/;
 
 export const CACHE_DIR = join(homedir(), '.cache', 'crux-linear');
 export const CACHE_FILE = join(CACHE_DIR, 'issue-states.json');
@@ -28,32 +37,30 @@ interface CacheEntry {
 type CacheShape = Record<string, CacheEntry>;
 
 function readCache(now: number = Date.now()): CacheShape {
-  if (!existsSync(CACHE_FILE)) return {};
+  let parsed: CacheShape;
   try {
-    const raw = readFileSync(CACHE_FILE, 'utf-8');
-    const parsed = JSON.parse(raw) as CacheShape;
-    // Drop obviously-stale entries on read to keep the file small.
-    const fresh: CacheShape = {};
-    for (const [k, v] of Object.entries(parsed)) {
-      if (
-        v &&
-        typeof v === 'object' &&
-        typeof v.fetchedAt === 'number' &&
-        now - v.fetchedAt < CACHE_TTL_MS * 10
-      ) {
-        fresh[k] = v;
-      }
-    }
-    return fresh;
+    parsed = JSON.parse(readFileSync(CACHE_FILE, 'utf-8')) as CacheShape;
   } catch {
     return {};
   }
+  const fresh: CacheShape = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (
+      v &&
+      typeof v === 'object' &&
+      typeof v.fetchedAt === 'number' &&
+      now - v.fetchedAt < CACHE_TTL_MS * 10
+    ) {
+      fresh[k] = v;
+    }
+  }
+  return fresh;
 }
 
 function writeCache(cache: CacheShape): void {
   try {
-    if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true });
-    writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2), 'utf-8');
+    mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(CACHE_FILE, JSON.stringify(cache), 'utf-8');
   } catch {
     // Best-effort: cache write failures shouldn't break the caller.
   }
@@ -79,6 +86,12 @@ export async function fetchIssueStatesBatch(
 ): Promise<Map<string, string | null>> {
   const result = new Map<string, string | null>();
   if (identifiers.length === 0) return result;
+
+  for (const id of identifiers) {
+    if (!LINEAR_ID_RE.test(id)) {
+      throw new Error(`Refusing to fetch malformed Linear ID: ${JSON.stringify(id)}`);
+    }
+  }
 
   const parts = identifiers.map(
     (id) =>
@@ -125,6 +138,10 @@ export async function getIssueStates(
   }
 
   if (toFetch.length === 0) return result;
+
+  // Skip the network call when there's no API key — linearGraphQL would
+  // throw, but we'd still pay for a wasted fetch setup + 15s timeout.
+  if (!process.env.LINEAR_API_KEY) return result;
 
   try {
     const fetched = await fetchIssueStatesBatch(toFetch);


### PR DESCRIPTION
## Summary

Shows each agent's Linear ticket identifier and current workflow state alongside the branch in `pnpm crux sys agents status`, so coordinators can scan active work without eyeball-parsing `claude/qua-NNN-*` strings.

```
#1593 grand-snow-slim-bay [active]
  Session on claude/qua-567-entity-resources-fk-migration
  Branch: claude/qua-567-entity-resources-fk-migration
  Linear: QUA-567 In Review        <- new
  Started: 4/17/2026, 2:43:49 PM  Heartbeat: 4:01:04 PM
```

Agents whose branch has no detectable Linear ID show `Linear: -`.

## Key changes

- **`crux/lib/linear/issue-states-cache.ts`** (new): batch-fetches Linear workflow states via a single aliased GraphQL query and caches them to disk at `~/.cache/crux-linear/issue-states.json` with a 60s TTL. Positional aliases (`i0`, `i1`, ...) are collision-proof; responses are mapped back by the `identifier` field Linear returns in each row. Writes are atomic (temp file + rename) to survive concurrent `status` invocations. Fails open on missing `LINEAR_API_KEY`, corrupt cache, or API errors.
- **`crux/commands/agents.ts`**: adds a `Linear:` line to the human output and `linearId`/`linearState` fields to `--json`. Prefers the server-provided `linearId` from `agent_sessions` (authoritative, populated by `crux linear start`) over branch-name parsing (fallback for agents without a session row - job workers, ad-hoc registrations).

## Notes for callers of `sys agents status --json`

Each agent row now has two new fields:

- `linearId: string | null` - e.g. `"QUA-580"` or `null`
- `linearState: string | null` - e.g. `"In Progress"` or `null` when Linear didn't return a state or the API wasn't reached

Existing fields are unchanged.

## Optional env var

`LINEAR_DEBUG` - set to any truthy value to get a diagnostic log when a Linear fetch fails. Unset (the default) keeps the command silent. No production deploy action required.

## Test plan

- [x] 19 unit tests (8 for `collectLinearIds` + status command, 11 for the cache - TTL, refetch, fail-open, dedup, malformed-ID rejection, alias-order independence, malformed-state pruning, API-key short-circuit)
- [x] End-to-end: `WIKI_SERVER_ENV=prod pnpm crux sys agents status` renders Linear state for 38/50 active agents; JSON output verified
- [x] Type check clean for `crux/tsconfig.json`
- [x] Gate passes (44 checks, 3 pre-existing advisory warnings)
- [x] Hostile-reviewer subagent: 2 HIGH + several MEDIUM findings - all fixed (alias collision, silent catch, concurrent-writer race, over-long stale retention, malformed-state smuggling)

Fixes QUA-580


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [x] `manual` LINEAR_DEBUG is an optional diagnostic flag — the code path uses `if (process.env.LINEAR_DEBUG)` and behaves correctly when unset (default: silent). No production env change needed. Auto-detector flagged this as a new env var; confirming it does not need to be set.
<!-- /deploy-tasks -->
