### PR TITLE
QUA-573 Phase B.1c: swap proposed_claims.resource_id FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0196_qua_573_pc_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0196_qua_573_pc_resource_id_to_stable_id.sql
@@ -1,0 +1,31 @@
+-- QUA-573 Phase B.1c: migrate proposed_claims.resource_id from referencing
+-- resources.id (legacy hex16) to resources.stable_id (canonical sid_<10>).
+--
+-- Part of Phase B (QUA-549) of the resources-FK migration plan designed in
+-- QUA-498. Split out of the original QUA-564 Phase B.1 after discovering the
+-- claims surface touches ~10 callsites across wiki-server + crux.
+--
+-- proposed_claims is a SOFT-REF table: the schema declares
+-- `.references(() => resources.id, { onDelete: "set null" })` but no FK
+-- constraint was ever created in prod (verified 2026-04-17 per QUA-573 body).
+-- That means:
+--   * No FK to drop.
+--   * No FK to add (Phase B non-goal per QUA-549: "do NOT add missing FK
+--     constraints on proposed_claims — separate ticket").
+--   * No orphan scan needed — a soft-ref has no enforcement.
+--
+-- All semantic changes in QUA-573 are schema.ts + application-code:
+--   * schema.ts flips `.references(() => resources.stableId, ...)` so future
+--     Drizzle introspection shows the canonical relationship.
+--   * POST /api/claims/propose now accepts incoming resource_id in either
+--     format (hex16 legacy or sid_ canonical) and translates to stable_id
+--     before insert. See apps/wiki-server/src/routes/claims/claims.ts.
+--   * GET /api/resources/:id/content now accepts either format so the
+--     claim-sourcing job handler can call it with the stored sid_.
+--
+-- This migration is a no-op to keep the Drizzle journal in sync with the
+-- schema.ts edit. Drizzle-kit will not emit a migration for a pure
+-- .references() target change on a column that already exists, so we author
+-- this file by hand and register it in meta/_journal.json.
+
+SELECT 1;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1373,6 +1373,13 @@
       "when": 1786089600000,
       "tag": "0195_qua_221_backfill_stale_agent_sessions",
       "breakpoints": true
+    },
+    {
+      "idx": 196,
+      "version": "7",
+      "when": 1786089600001,
+      "tag": "0196_qua_573_pc_resource_id_to_stable_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/claims-redteam.test.ts
+++ b/apps/wiki-server/src/__tests__/claims-redteam.test.ts
@@ -193,11 +193,12 @@ function resetStores() {
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
+  // QUA-573: propose resolves hex16 OR sid_ to stable_id before insert.
   if (q.includes("from resources") && q.includes("where")) {
-    if (Array.isArray(params[0])) {
-      return (params[0] as string[]).map((id) => ({ id }));
-    }
-    return params.map((p) => ({ id: p }));
+    const ids = Array.isArray(params[0]) ? (params[0] as string[]) : params.filter((p) => typeof p === "string") as string[];
+    const ids2 = Array.isArray(params[1]) ? (params[1] as string[]) : [];
+    const all = [...new Set([...ids, ...ids2])];
+    return all.map((id) => ({ id, stable_id: id }));
   }
 
   if (q.includes("insert into") && q.includes("proposed_claims")) {

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -204,16 +204,18 @@ let claimStore: Array<{
   verification_job_id: number | null;
 }>;
 let jobStore: Array<{ id: number; type: string; params: unknown }>;
-// QUA-573: per-test override mapping input resource_id → stable_id for the
-// resources-lookup dispatcher. An entry with a null value simulates "not found".
-let resourceLookupOverride: Map<string, string | null> | null = null;
+// QUA-573: per-test fixtures for the resources-lookup dispatcher.
+//   resourceRows: rows that exist in the "resources" table (id, stable_id). The
+//     dispatcher matches the query's `id = ANY($1) OR stable_id = ANY($2)` shape.
+//   null stable_id simulates a row with no canonical stable_id assigned.
+let resourceRows: Array<{ id: string; stable_id: string | null }> | null = null;
 
 function resetStores() {
   claimStore = [];
   jobStore = [];
   nextClaimId = 1;
   nextJobId = 1;
-  resourceLookupOverride = null;
+  resourceRows = null;
 }
 
 function dispatch(query: string, params: unknown[]): unknown[] {
@@ -221,30 +223,17 @@ function dispatch(query: string, params: unknown[]): unknown[] {
 
   // ---- SELECT resources WHERE id = ANY(...) OR stable_id = ANY(...) ----
   // QUA-573: propose resolves hex16 OR sid_ to stable_id before insert.
-  // Any input ID starting with "missing:" simulates an unknown resource.
-  // `resourceLookupOverride` lets individual tests inject a hex16 → sid_ mapping
-  // to verify the translation path.
+  // When `resourceRows` is set, match inputs against its id/stable_id columns
+  // (mirrors real PG behavior). Otherwise fall back to identity mapping for
+  // legacy tests that only care about the insert path.
   if (q.includes("from resources") && q.includes("where")) {
     const ids = Array.isArray(params[0]) ? (params[0] as string[]) : params.filter((p) => typeof p === "string") as string[];
     const ids2 = Array.isArray(params[1]) ? (params[1] as string[]) : [];
-    const all = [...new Set([...ids, ...ids2])];
-    const rows: Array<{ id: string; stable_id: string | null }> = [];
-    for (const input of all) {
-      if (input.startsWith("missing:")) continue;
-      if (resourceLookupOverride) {
-        const mapped = resourceLookupOverride.get(input);
-        if (mapped === undefined) continue; // treat as not-found
-        if (mapped === null) {
-          rows.push({ id: input, stable_id: null });
-        } else {
-          // Emit the canonical row keyed by the hex16 id so the resolver maps both.
-          rows.push({ id: input.startsWith("sid_") ? input : input, stable_id: mapped });
-        }
-      } else {
-        rows.push({ id: input, stable_id: input });
-      }
+    const all = [...new Set([...ids, ...ids2])].filter((id) => !id.startsWith("missing:"));
+    if (resourceRows) {
+      return resourceRows.filter((r) => all.includes(r.id) || (r.stable_id !== null && all.includes(r.stable_id)));
     }
-    return rows;
+    return all.map((id) => ({ id, stable_id: id }));
   }
 
   // ---- INSERT INTO proposed_claims (batch via unnest) ----
@@ -489,7 +478,7 @@ describe("Claims API — POST /api/claims/propose", () => {
   // request; persist the resolved stable_id.
   describe("QUA-573: resource_id ↔ stable_id translation", () => {
     it("translates incoming hex16 resource_id to stable_id before insert", async () => {
-      resourceLookupOverride = new Map([["aebe92781f2a19fb", "sid_AbCd012345"]]);
+      resourceRows = [{ id: "aebe92781f2a19fb", stable_id: "sid_AbCd012345" }];
       const res = await postJson(app, "/api/claims/propose", {
         entityId: "test-entity",
         targetTable: "facts",
@@ -504,7 +493,8 @@ describe("Claims API — POST /api/claims/propose", () => {
     });
 
     it("accepts incoming sid_ resource_id and stores it unchanged", async () => {
-      resourceLookupOverride = new Map([["sid_AbCd012345", "sid_AbCd012345"]]);
+      // Row's hex16 id is DIFFERENT from input; the resolver must match via stable_id.
+      resourceRows = [{ id: "aebe92781f2a19fb", stable_id: "sid_AbCd012345" }];
       const res = await postJson(app, "/api/claims/propose", {
         entityId: "test-entity",
         targetTable: "facts",
@@ -516,8 +506,25 @@ describe("Claims API — POST /api/claims/propose", () => {
       expect(claimStore[0].resource_id).toBe("sid_AbCd012345");
     });
 
+    it("dedupes when the same resource is referenced by both hex16 and sid_ in one batch", async () => {
+      resourceRows = [{ id: "aebe92781f2a19fb", stable_id: "sid_AbCd012345" }];
+      const res = await postJson(app, "/api/claims/propose", {
+        entityId: "test-entity",
+        targetTable: "facts",
+        claims: [
+          { claimText: "c1", sourceUrl: "https://a.com", resourceId: "aebe92781f2a19fb" },
+          { claimText: "c2", sourceUrl: "https://b.com", resourceId: "sid_AbCd012345" },
+        ],
+      });
+      expect(res.status).toBe(201);
+      expect(claimStore).toHaveLength(2);
+      // Both rows must resolve to the same canonical stable_id.
+      expect(claimStore[0].resource_id).toBe("sid_AbCd012345");
+      expect(claimStore[1].resource_id).toBe("sid_AbCd012345");
+    });
+
     it("rejects a resource_id that matches neither id nor stable_id", async () => {
-      // The dispatcher mock returns an empty set for any ID prefixed `missing:`.
+      // The dispatcher returns no row for inputs prefixed "missing:".
       const res = await postJson(app, "/api/claims/propose", {
         entityId: "test-entity",
         targetTable: "facts",
@@ -532,7 +539,7 @@ describe("Claims API — POST /api/claims/propose", () => {
     });
 
     it("rejects a resource_id whose stable_id is null", async () => {
-      resourceLookupOverride = new Map([["orphan-hex16", null]]);
+      resourceRows = [{ id: "orphan-hex16", stable_id: null }];
       const res = await postJson(app, "/api/claims/propose", {
         entityId: "test-entity",
         targetTable: "facts",

--- a/apps/wiki-server/src/__tests__/claims.test.ts
+++ b/apps/wiki-server/src/__tests__/claims.test.ts
@@ -204,24 +204,47 @@ let claimStore: Array<{
   verification_job_id: number | null;
 }>;
 let jobStore: Array<{ id: number; type: string; params: unknown }>;
+// QUA-573: per-test override mapping input resource_id → stable_id for the
+// resources-lookup dispatcher. An entry with a null value simulates "not found".
+let resourceLookupOverride: Map<string, string | null> | null = null;
 
 function resetStores() {
   claimStore = [];
   jobStore = [];
   nextClaimId = 1;
   nextJobId = 1;
+  resourceLookupOverride = null;
 }
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
 
-  // ---- SELECT resources WHERE id = ANY(...) (resource validation) ----
+  // ---- SELECT resources WHERE id = ANY(...) OR stable_id = ANY(...) ----
+  // QUA-573: propose resolves hex16 OR sid_ to stable_id before insert.
+  // Any input ID starting with "missing:" simulates an unknown resource.
+  // `resourceLookupOverride` lets individual tests inject a hex16 → sid_ mapping
+  // to verify the translation path.
   if (q.includes("from resources") && q.includes("where")) {
-    // Return all requested IDs as existing (pass validation)
-    if (Array.isArray(params[0])) {
-      return (params[0] as string[]).map((id) => ({ id }));
+    const ids = Array.isArray(params[0]) ? (params[0] as string[]) : params.filter((p) => typeof p === "string") as string[];
+    const ids2 = Array.isArray(params[1]) ? (params[1] as string[]) : [];
+    const all = [...new Set([...ids, ...ids2])];
+    const rows: Array<{ id: string; stable_id: string | null }> = [];
+    for (const input of all) {
+      if (input.startsWith("missing:")) continue;
+      if (resourceLookupOverride) {
+        const mapped = resourceLookupOverride.get(input);
+        if (mapped === undefined) continue; // treat as not-found
+        if (mapped === null) {
+          rows.push({ id: input, stable_id: null });
+        } else {
+          // Emit the canonical row keyed by the hex16 id so the resolver maps both.
+          rows.push({ id: input.startsWith("sid_") ? input : input, stable_id: mapped });
+        }
+      } else {
+        rows.push({ id: input, stable_id: input });
+      }
     }
-    return params.map((p) => ({ id: p }));
+    return rows;
   }
 
   // ---- INSERT INTO proposed_claims (batch via unnest) ----
@@ -459,6 +482,68 @@ describe("Claims API — POST /api/claims/propose", () => {
     // NOT jobCount * SECONDS_PER_CLAIM (3 * 3 = 9)
     expect(body.estimatedSourcingTime).toBe(4 * SECONDS_PER_CLAIM_ESTIMATE);
     expect(body.estimatedSourcingTime).not.toBe(body.jobCount * SECONDS_PER_CLAIM_ESTIMATE);
+  });
+
+  // QUA-573 Phase B.1c: proposed_claims.resource_id references resources.stable_id.
+  // Accept either resources.id (legacy hex16) or stable_id (canonical sid_) in the
+  // request; persist the resolved stable_id.
+  describe("QUA-573: resource_id ↔ stable_id translation", () => {
+    it("translates incoming hex16 resource_id to stable_id before insert", async () => {
+      resourceLookupOverride = new Map([["aebe92781f2a19fb", "sid_AbCd012345"]]);
+      const res = await postJson(app, "/api/claims/propose", {
+        entityId: "test-entity",
+        targetTable: "facts",
+        claims: [
+          { claimText: "c", sourceUrl: "https://a.com", resourceId: "aebe92781f2a19fb" },
+        ],
+      });
+      expect(res.status).toBe(201);
+      // The stored value must be the canonical stable_id, NOT the hex16 input.
+      expect(claimStore).toHaveLength(1);
+      expect(claimStore[0].resource_id).toBe("sid_AbCd012345");
+    });
+
+    it("accepts incoming sid_ resource_id and stores it unchanged", async () => {
+      resourceLookupOverride = new Map([["sid_AbCd012345", "sid_AbCd012345"]]);
+      const res = await postJson(app, "/api/claims/propose", {
+        entityId: "test-entity",
+        targetTable: "facts",
+        claims: [
+          { claimText: "c", sourceUrl: "https://a.com", resourceId: "sid_AbCd012345" },
+        ],
+      });
+      expect(res.status).toBe(201);
+      expect(claimStore[0].resource_id).toBe("sid_AbCd012345");
+    });
+
+    it("rejects a resource_id that matches neither id nor stable_id", async () => {
+      // The dispatcher mock returns an empty set for any ID prefixed `missing:`.
+      const res = await postJson(app, "/api/claims/propose", {
+        entityId: "test-entity",
+        targetTable: "facts",
+        claims: [
+          { claimText: "c", sourceUrl: "https://a.com", resourceId: "missing:foo" },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toMatch(/Resource IDs not found/);
+      expect(body.message).toMatch(/missing:foo/);
+    });
+
+    it("rejects a resource_id whose stable_id is null", async () => {
+      resourceLookupOverride = new Map([["orphan-hex16", null]]);
+      const res = await postJson(app, "/api/claims/propose", {
+        entityId: "test-entity",
+        targetTable: "facts",
+        claims: [
+          { claimText: "c", sourceUrl: "https://a.com", resourceId: "orphan-hex16" },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.message).toMatch(/Resource IDs not found/);
+    });
   });
 
   it("returns 201 with correct structure for a basic propose request", async () => {

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -304,6 +304,18 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       }
       return [];
     }
+    // ---- SELECT ... FROM resources WHERE id = $1 OR stable_id = $2 ----
+    // QUA-573: /:id/content now accepts either hex16 id or canonical sid_.
+    if (whereClause.includes('"id"') && whereClause.includes('"stable_id"')) {
+      const id = params[0] as string;
+      const stableId = (params[1] ?? params[0]) as string;
+      const byId = resourceStore.get(id);
+      if (byId) return [byId];
+      for (const r of resourceStore.values()) {
+        if (r.stable_id === stableId) return [r];
+      }
+      return [];
+    }
     // ---- SELECT ... FROM resources WHERE id = $1 ----
     if (whereClause.includes('"id"')) {
       const id = params[0] as string;
@@ -720,6 +732,39 @@ describe("Resources API", () => {
 
     it("returns 404 for unknown ID", async () => {
       const res = await app.request("/api/resources/nonexistent");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // QUA-573: /:id/content accepts either hex16 resources.id or canonical sid_.
+  describe("GET /api/resources/:id/content", () => {
+    it("resolves by hex16 id (legacy)", async () => {
+      await postJson(app, "/api/resources", {
+        ...sampleResource,
+        id: "abc123def456",
+        stableId: "sid_AbCd012345",
+      });
+      const res = await app.request("/api/resources/abc123def456/content");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.id).toBe("abc123def456");
+    });
+
+    it("resolves by stable_id (canonical sid_)", async () => {
+      await postJson(app, "/api/resources", {
+        ...sampleResource,
+        id: "abc123def456",
+        stableId: "sid_AbCd012345",
+      });
+      const res = await app.request("/api/resources/sid_AbCd012345/content");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Server responds with the hex16 primary key regardless of lookup form.
+      expect(body.id).toBe("abc123def456");
+    });
+
+    it("returns 404 for unknown id", async () => {
+      const res = await app.request("/api/resources/sid_NoSuchOne0/content");
       expect(res.status).toBe(404);
     });
   });

--- a/apps/wiki-server/src/routes/claims/claims.ts
+++ b/apps/wiki-server/src/routes/claims/claims.ts
@@ -212,7 +212,17 @@ const claimsApp = new Hono()
           ${claims.map((cl) => cl.targetField ?? null)}::text[],
           ${claims.map((cl) => cl.proposedValue ?? null)}::text[],
           ${claims.map((cl) => cl.proposedData ? JSON.stringify(cl.proposedData) : null)}::jsonb[],
-          ${claims.map((cl) => (cl.resourceId ? (resolvedMap.get(cl.resourceId) ?? cl.resourceId) : null))}::text[],
+          ${claims.map((cl) => {
+            if (!cl.resourceId) return null;
+            const stableId = resolvedMap.get(cl.resourceId);
+            if (!stableId) {
+              // Unreachable: validation above rejects any resourceId not in the map.
+              // Throw rather than silently persist an untranslated hex16, which would
+              // violate the QUA-573 canonical-stable_id invariant.
+              throw new Error(`resolvedMap missing entry for ${cl.resourceId} after validation`);
+            }
+            return stableId;
+          })}::text[],
           ${claims.map((cl) => cl.sourceUrl)}::text[],
           ${claims.map((cl) => cl.agentEvidence ?? null)}::text[],
           ${claims.map(() => "pending")}::text[],

--- a/apps/wiki-server/src/routes/claims/claims.ts
+++ b/apps/wiki-server/src/routes/claims/claims.ts
@@ -159,20 +159,32 @@ const claimsApp = new Hono()
       "proposing claims for sourcing",
     );
 
-    // 1. Validate resource references exist (if provided)
-    const resourceIds = [
+    // 1. Validate resource references exist (if provided) and resolve to stable_id.
+    // QUA-573 Phase B.1c: proposed_claims.resource_id now references
+    // resources.stable_id, but callers (source-discover-agent via /api/resources/suggest)
+    // still pass the legacy hex16 resources.id. Accept either and translate to
+    // stable_id before insert so new rows land in the canonical form.
+    const inputResourceIds = [
       ...new Set(claims.map((cl) => cl.resourceId).filter(Boolean) as string[]),
     ];
-    if (resourceIds.length > 0) {
-      const existing = await sql<{ id: string }[]>`
-        SELECT id FROM resources WHERE id = ANY(${resourceIds})
+    const resolvedMap = new Map<string, string>();
+    if (inputResourceIds.length > 0) {
+      const existing = await sql<{ id: string; stable_id: string | null }[]>`
+        SELECT id, stable_id FROM resources
+        WHERE id = ANY(${inputResourceIds}) OR stable_id = ANY(${inputResourceIds})
       `;
-      const existingSet = new Set(existing.map((r) => r.id));
-      const missing = resourceIds.filter((id) => !existingSet.has(id));
+      for (const r of existing) {
+        if (r.stable_id) {
+          // Map both forms to the canonical stable_id.
+          resolvedMap.set(r.id, r.stable_id);
+          resolvedMap.set(r.stable_id, r.stable_id);
+        }
+      }
+      const missing = inputResourceIds.filter((id) => !resolvedMap.has(id));
       if (missing.length > 0) {
         return validationError(
           c,
-          `Resource IDs not found: ${missing.join(", ")}`,
+          `Resource IDs not found (or missing stable_id): ${missing.join(", ")}`,
         );
       }
     }
@@ -200,7 +212,7 @@ const claimsApp = new Hono()
           ${claims.map((cl) => cl.targetField ?? null)}::text[],
           ${claims.map((cl) => cl.proposedValue ?? null)}::text[],
           ${claims.map((cl) => cl.proposedData ? JSON.stringify(cl.proposedData) : null)}::jsonb[],
-          ${claims.map((cl) => cl.resourceId ?? null)}::text[],
+          ${claims.map((cl) => (cl.resourceId ? (resolvedMap.get(cl.resourceId) ?? cl.resourceId) : null))}::text[],
           ${claims.map((cl) => cl.sourceUrl)}::text[],
           ${claims.map((cl) => cl.agentEvidence ?? null)}::text[],
           ${claims.map(() => "pending")}::text[],

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -4,6 +4,7 @@ import { buildPrefixTsquery } from "../../search-utils.js";
 import { logger } from "../../logger.js";
 import {
   eq,
+  or,
   count,
   sql,
   desc,
@@ -1435,10 +1436,14 @@ const resourcesApp = new Hono()
     const id = c.req.param("id");
     const db = getDrizzleDb();
 
+    // QUA-573: accept either resources.id (legacy hex16) or resources.stable_id
+    // (canonical sid_<10>). The claim-sourcing job handler looks up content via
+    // whatever value was stored in proposed_claims.resource_id, which is now
+    // stable_id. Other callers still pass hex16 — both must resolve.
     const rows = await db
       .select()
       .from(resources)
-      .where(eq(resources.id, id))
+      .where(or(eq(resources.id, id), eq(resources.stableId, id)))
       .limit(1);
 
     if (rows.length === 0) {

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -3705,7 +3705,10 @@ export const proposedClaims = pgTable(
     proposedData: jsonb("proposed_data"),
 
     // Source evidence (from research agent)
-    resourceId: text("resource_id").references(() => resources.id, { onDelete: "set null" }),
+    // QUA-573 Phase B.1c: references resources.stable_id (canonical sid_<10>).
+    // Soft-ref in prod (no DB-level FK constraint); onDelete preserved from the
+    // Drizzle declaration. See QUA-549 for parent migration context.
+    resourceId: text("resource_id").references(() => resources.stableId, { onDelete: "set null" }),
     sourceUrl: text("source_url").notNull(),
     agentEvidence: text("agent_evidence"),
 


### PR DESCRIPTION
## Summary

QUA-573 Phase B.1c of the [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) resource-FK migration series. Migrates `proposed_claims.resource_id` from referencing `resources.id` (legacy hex16) to `resources.stable_id` (canonical `sid_<10>`).

Unlike prior phases (QUA-564, QUA-565, QUA-567, QUA-568), `proposed_claims` is a **soft-ref** table — the schema declares `.references(() => resources.id, { onDelete: "set null" })` but no FK constraint was ever created in prod. Migration 0192 is a pure no-op (`SELECT 1`) for journal consistency. Per QUA-549 non-goals, no DB-level FK is added.

Fixes QUA-573.

## What changed

### Schema: `apps/wiki-server/src/schema.ts`

Flipped `proposedClaims.resourceId.references()` from `resources.id` → `resources.stableId`. Preserves `onDelete: "set null"`.

### Migration: `apps/wiki-server/drizzle/0192_qua_573_pc_resource_id_to_stable_id.sql`

No-op (`SELECT 1;`). No FK to drop, no FK to add, no backfill. Full rationale inline.

### Route: `apps/wiki-server/src/routes/claims/claims.ts` — POST /api/claims/propose

Accept incoming `resourceId` in **either** format (legacy hex16 or canonical `sid_`) and resolve to `stable_id` before insert. Callers like `source-discover-agent` still receive hex16 from `/api/resources/suggest`; translating server-side contains scope. Inputs that resolve to neither `id` nor `stable_id` are rejected with 400. The insert path now throws if the resolver map lacks an entry (defense-in-depth — otherwise untranslated hex16 could leak into a sid_-only column).

### Route: `apps/wiki-server/src/routes/wikibase/resources.ts` — GET /api/resources/:id/content

Accepts either `resources.id` or `resources.stable_id` via `or(eq(resources.id, id), eq(resources.stableId, id))`. The claim-sourcing job handler stores `stable_id` in `proposed_claims.resource_id` and passes that to `/content` — both forms must resolve.

### Tests

- `claims.test.ts`: 5 new tests for the QUA-573 translation path (hex16 → sid_, sid_ passthrough, mixed hex16+sid_ in one batch, unknown id rejection, null stable_id rejection).
- `claims-redteam.test.ts`: mock dispatcher updated to handle the new `WHERE id = ANY OR stable_id = ANY` query shape.
- `resources.test.ts`: 3 new tests for `/content` (resolves by hex16, resolves by sid_, 404 on unknown).

## Prod state check (2026-04-18)

Data-quality snapshot shows `proposed_claims` currently has 185 rows (ticket claimed 0 as of 2026-04-17). No FK constraint exists and no JOIN uses `resource_id`, so mixed hex16/sid_ values in existing rows are tolerated. New rows inserted post-merge land in canonical `sid_` form.

## Non-goals (inherited from QUA-549)

- Do NOT add the missing FK constraint on `proposed_claims.resource_id` (tracked separately).
- Do NOT drop `resources.id`.
- Do NOT combine with CHECK constraints.

## Risks

- **Soft-ref silent drift**: validated by the new resolver throw + pre-insert SELECT — a hex16 that can't be translated fails fast (400).
- **Claims-first in-flight work**: the PR is additive at the API boundary (accepts old + new forms), so existing callers keep working during rollout.

## Test plan

- [x] `pnpm typecheck` (wiki-server) — clean
- [x] `pnpm build` — passes
- [x] `pnpm test` — 1256/1256 wiki-server, 6778/6778 crux-side
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate gate --fix` — 48/48 pass (3 pre-existing advisories)
- [x] `/agent-review-pr` — hostile subagent found 2 MEDIUM + 6 LOW; 4 fixed in review commit, rest accepted with rationale
- [x] Narrow-patch detector — no matches
- [ ] Post-merge: migration 0192 applied on server start (degraded-mode health check)
- [ ] Post-merge: spot-check that a new claim with a hex16 `resourceId` is stored as `sid_` in `proposed_claims.resource_id`


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0192 registered in drizzle journal (pure no-op — `SELECT 1`; no DDL applied; no separate manual script exists). Expect the row to appear after server restart — `psql "$DATABASE_URL" -c "SELECT hash, created_at FROM drizzle.__drizzle_migrations WHERE hash LIKE '%0192%' OR created_at > NOW() - INTERVAL '1 hour' ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and `/health` is `healthy` — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` Post-deploy spot-check: submit a test claim via `POST /api/claims/propose` with a legacy hex16 `resourceId`; confirm the stored `proposed_claims.resource_id` is canonical `sid_<10>`, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM proposed_claims WHERE created_at > NOW() - INTERVAL '1 hour' AND resource_id IS NOT NULL ORDER BY id DESC LIMIT 5;"`, expect `sid_`-prefixed rows.
- [ ] `manual` Confirm `GET /api/resources/:id/content` resolves by both hex16 and sid_ on prod — `curl -sf "$WIKI_SERVER_URL/api/resources/<any-hex16>/content" | jq .id` then `curl -sf "$WIKI_SERVER_URL/api/resources/<its-stable_id>/content" | jq .id` — both should return the same row.
<!-- /deploy-tasks -->
