### PR TITLE
QUA-566 Phase B.3: swap papers/posts/citations FK to resources.stable_id

### DIFF
--- a/apps/wiki-server/drizzle/0197_qua_566_phase_b3_papers_posts_citations.sql
+++ b/apps/wiki-server/drizzle/0197_qua_566_phase_b3_papers_posts_citations.sql
@@ -1,0 +1,142 @@
+-- QUA-566 Phase B.3: swap papers/forum-posts/citations FK tables from
+-- resources.id → resources.stable_id.
+--
+-- Part of QUA-549 Phase B. Follows the in-place pattern established by
+-- QUA-549 (0186), QUA-564 Phase B.1 (0187), QUA-565 Phase B.2 (0188),
+-- QUA-567 Phase B.4 (0189-0190), QUA-568 Phase B.5 (0191).
+--
+-- Scope (prod row counts enumerated 2026-04-18 via /api/resources/all-details
+-- + /api/resources/citations/all + /api/resources/stats):
+--   resource_papers       —   431 rows, 100% hex16 — FK ON DELETE CASCADE
+--   resource_forum_posts  — 5,267 rows, 100% hex16 — FK ON DELETE CASCADE
+--   resource_citations    — 5,962 rows (4,526 distinct resource_ids), 100%
+--                           hex16 — FK ON DELETE CASCADE
+--
+-- Pre-flight: 0 orphans against resources.id; resources.stable_id coverage
+-- 22,976/22,976 (100%, per QUA-536 Phase A).
+--
+-- Column name stays `resource_id` on all three tables; only the FK reference
+-- target and the stored value change. Same minimal-churn approach as B.1/B.2.
+--
+-- Existing FK constraint naming: Drizzle-generated
+-- `<table>_<col>_<target_table>_<target_col>_fk` (present in this repo's
+-- development databases) and the postgres default `<table>_<col>_fkey` (not
+-- known to exist for these 3 tables but dropped defensively for dev/staging
+-- parity with earlier phases).
+
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_papers.resource_id → resources.stable_id (CASCADE)
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_id is the PK on this table (one row per resource). Only the FK
+-- changes here; the PK constraint is independent and stays in place.
+
+ALTER TABLE "resource_papers" DROP CONSTRAINT IF EXISTS "resource_papers_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "resource_papers" DROP CONSTRAINT IF EXISTS "resource_papers_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "resource_papers" rp
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rp.resource_id = r.id
+  AND rp.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+-- Fail loudly (with a clear message) rather than letting ADD CONSTRAINT
+-- reject with a generic FK error. Pre-flight found 0 orphans 2026-04-18.
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM resource_papers t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-566 migration aborted: % resource_papers row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'resource_papers_resource_id_resources_stable_id_fk'
+      AND table_name = 'resource_papers'
+  ) THEN
+    ALTER TABLE "resource_papers"
+      ADD CONSTRAINT "resource_papers_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_forum_posts.resource_id → resources.stable_id (CASCADE)
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_id is the PK on this table.
+
+ALTER TABLE "resource_forum_posts" DROP CONSTRAINT IF EXISTS "resource_forum_posts_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "resource_forum_posts" DROP CONSTRAINT IF EXISTS "resource_forum_posts_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "resource_forum_posts" rfp
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rfp.resource_id = r.id
+  AND rfp.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM resource_forum_posts t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-566 migration aborted: % resource_forum_posts row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'resource_forum_posts_resource_id_resources_stable_id_fk'
+      AND table_name = 'resource_forum_posts'
+  ) THEN
+    ALTER TABLE "resource_forum_posts"
+      ADD CONSTRAINT "resource_forum_posts_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- ────────────────────────────────────────────────────────────────────────
+-- resource_citations.resource_id → resources.stable_id (CASCADE)
+-- ────────────────────────────────────────────────────────────────────────
+-- (resource_id, page_id) is the composite PK on this table.
+
+ALTER TABLE "resource_citations" DROP CONSTRAINT IF EXISTS "resource_citations_resource_id_resources_id_fk";--> statement-breakpoint
+ALTER TABLE "resource_citations" DROP CONSTRAINT IF EXISTS "resource_citations_resource_id_fkey";--> statement-breakpoint
+
+UPDATE "resource_citations" rc
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rc.resource_id = r.id
+  AND rc.resource_id NOT LIKE 'sid_%';--> statement-breakpoint
+
+DO $$
+DECLARE orphan_count BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM resource_citations t
+  WHERE t.resource_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM resources r WHERE r.stable_id = t.resource_id);
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'QUA-566 migration aborted: % resource_citations row(s) have a resource_id that does not map to any resources.stable_id. Investigate before re-running.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'resource_citations_resource_id_resources_stable_id_fk'
+      AND table_name = 'resource_citations'
+  ) THEN
+    ALTER TABLE "resource_citations"
+      ADD CONSTRAINT "resource_citations_resource_id_resources_stable_id_fk"
+      FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+  END IF;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1380,6 +1380,13 @@
       "when": 1786089600001,
       "tag": "0196_qua_573_pc_resource_id_to_stable_id",
       "breakpoints": true
+    },
+    {
+      "idx": 197,
+      "version": "7",
+      "when": 1786176000000,
+      "tag": "0197_qua_566_phase_b3_papers_posts_citations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/integration.test.ts
+++ b/apps/wiki-server/src/__tests__/integration.test.ts
@@ -122,8 +122,10 @@ describeWithDb("Integration: Drizzle migrations", () => {
     expect(fkNames).toContain("session_pages_session_id_sessions_id_fk");
     // FK from auto_update_results.run_id → auto_update_runs.id (migration 0008)
     expect(fkNames).toContain("auto_update_results_run_id_auto_update_runs_id_fk");
-    // FK from resource_citations.resource_id → resources.id (migration 0009)
-    expect(fkNames).toContain("resource_citations_resource_id_resources_id_fk");
+    // FK from resource_citations.resource_id → resources.stable_id
+    // (migration 0009 created the original FK to resources.id; QUA-566 Phase B.3
+    // migration 0192 swapped it to resources.stable_id).
+    expect(fkNames).toContain("resource_citations_resource_id_resources_stable_id_fk");
   });
 
   it("is idempotent — running migrate() again succeeds", async () => {

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -353,14 +353,25 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return filtered.slice(offset, offset + limit);
   }
 
-  // ---- /suggest: SELECT resource_id, count(*) FROM resource_citations WHERE resource_id = ANY(...) ----
+  // ---- /suggest: SELECT r.id, count(*) FROM resource_citations rc
+  //                 JOIN resources r ON rc.resource_id = r.stable_id
+  //                 WHERE r.id = ANY(...) GROUP BY r.id ----
+  // QUA-566 Phase B.3: resource_citations.resource_id references resources.stable_id.
+  // The prod query JOINs resources and surfaces r.id (hex16) so downstream map-by-hex16
+  // lookups keep working. The mock walks resourceStore to resolve the hex16 key into
+  // the stable_id, then counts citationStore rows whose resource_id matches that stable_id.
   if (q.includes("resource_citations") && q.includes("group by") && q.includes("any($)")) {
     const resourceIds = params[0] as string[];
     const counts: Record<string, number> = {};
-    for (const c of citationStore) {
-      if (resourceIds.includes(c.resource_id)) {
-        counts[c.resource_id] = (counts[c.resource_id] || 0) + 1;
+    for (const resourceId of resourceIds) {
+      const r = resourceStore.get(resourceId);
+      const stableId = r?.stable_id as string | null | undefined;
+      if (!stableId) continue;
+      let n = 0;
+      for (const c of citationStore) {
+        if (c.resource_id === stableId) n++;
       }
+      if (n > 0) counts[resourceId] = n;
     }
     return Object.entries(counts).map(([resource_id, cnt]) => ({
       resource_id,
@@ -1049,9 +1060,12 @@ describe("Resources API", () => {
     });
 
     it("sets job priority based on citation count", async () => {
-      // Pre-populate a resource with known ID and citations
+      // Pre-populate a resource with known ID, stable_id, and citations.
+      // QUA-566 Phase B.3: resource_citations.resource_id is now the resource's
+      // stable_id, so push to citationStore keyed on stable_id.
       resourceStore.set("cited-res", {
         id: "cited-res",
+        stable_id: "sid_cited-res",
         url: "https://example.com/cited",
         title: null,
         fetched_at: null,
@@ -1062,7 +1076,7 @@ describe("Resources API", () => {
       const pageIds = ["page-1", "page-2", "page-3", "page-4"];
       for (const slug of pageIds) {
         citationStore.push({
-          resource_id: "cited-res",
+          resource_id: "sid_cited-res",
           page_slug: slug,
           page_id: getIntIdForSlug(slug),
           created_at: new Date(),
@@ -1086,8 +1100,10 @@ describe("Resources API", () => {
 
     it("caps priority at 100", async () => {
       // Pre-populate resource with 25 citations → priority = min(100, 25 * 5) = 100
+      // QUA-566 Phase B.3: citations keyed by stable_id post-migration.
       resourceStore.set("popular-res", {
         id: "popular-res",
+        stable_id: "sid_popular-res",
         url: "https://example.com/popular",
         title: null,
         fetched_at: null,
@@ -1096,7 +1112,7 @@ describe("Resources API", () => {
 
       for (let i = 0; i < 25; i++) {
         citationStore.push({
-          resource_id: "popular-res",
+          resource_id: "sid_popular-res",
           page_slug: `page-${i}`,
           page_id: getIntIdForSlug(`page-${i}`),
           created_at: new Date(),

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -210,12 +210,21 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   }
 
   // ---- SELECT ... FROM resource_citations INNER JOIN resources (by-page) ----
+  // QUA-566 Phase B.3: resource_citations.resource_id now references
+  // resources.stable_id, so the join is on stable_id, not id.
   if (q.includes("resource_citations") && q.includes("inner join") && q.includes('"resources"')) {
     const intId = params[0] as number;
     const results: Record<string, unknown>[] = [];
     for (const c of citationStore) {
       if (c.page_id === intId) {
-        const r = resourceStore.get(c.resource_id);
+        // Look up by stable_id (the new join key)
+        let r: Record<string, unknown> | undefined;
+        for (const res of resourceStore.values()) {
+          if (res.stable_id === c.resource_id) {
+            r = res;
+            break;
+          }
+        }
         if (r) {
           results.push({
             id: r.id,

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -625,10 +625,9 @@ const researchAreasApp = new Hono()
 
     // Use raw SQL for the complex join + insert.
     // QUA-565 Phase B.2: research_area_papers.resource_id references
-    // resources.stable_id, so we SELECT r.stable_id (not r.id). The
-    // upstream JOIN (resource_citations.resource_id = r.id) is unchanged —
-    // resource_citations.resource_id still references resources.id until
-    // its own Phase B ticket lands.
+    // resources.stable_id, so we SELECT r.stable_id (not r.id).
+    // QUA-566 Phase B.3: resource_citations.resource_id also now references
+    // resources.stable_id, so the upstream JOIN is on r.stable_id as well.
     const result = await db.execute(sql`
       INSERT INTO research_area_papers (research_area_id, resource_id, title, url, authors, published_date, sort_order)
       SELECT
@@ -644,7 +643,7 @@ const researchAreasApp = new Hono()
       FROM research_areas ra
       JOIN wiki_pages wp ON ra.wiki_id = wp.wiki_id AND ra.wiki_id IS NOT NULL
       JOIN resource_citations rc ON rc.page_id = wp.id
-      JOIN resources r ON rc.resource_id = r.id
+      JOIN resources r ON rc.resource_id = r.stable_id
       WHERE r.url IS NOT NULL
       ON CONFLICT (research_area_id, url) WHERE url IS NOT NULL DO NOTHING
     `);

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -282,6 +282,7 @@ async function upsertResource(
       id: resources.id,
       url: resources.url,
       title: resources.title,
+      stableId: resources.stableId,
     });
 
   const result = firstOrThrow(rows, `resource upsert ${d.id}`);
@@ -298,8 +299,16 @@ async function upsertResource(
     `);
   }
 
-  // Upsert citations (cited_by)
+  // Upsert citations (cited_by).
+  // QUA-566 Phase B.3: resource_citations.resource_id references
+  // resources.stable_id, so delete/insert using the persisted stable_id
+  // (not the hex16 request id).
   if (d.citedBy && d.citedBy.length > 0) {
+    if (!result.stableId) {
+      throw new Error(
+        `resource ${d.id} has no stable_id — cannot write resource_citations (QUA-536 invariant violated)`
+      );
+    }
     // Resolve slugs to integer IDs before touching existing rows
     const citedByIntIdMap = options?.intIdMap ?? await resolvePageIntIds(db, d.citedBy);
     const unresolvedPageIds = d.citedBy.filter((pageId) => !citedByIntIdMap.has(pageId));
@@ -311,9 +320,9 @@ async function upsertResource(
     // Delete existing citations for this resource, then re-insert
     await db
       .delete(resourceCitations)
-      .where(eq(resourceCitations.resourceId, d.id));
+      .where(eq(resourceCitations.resourceId, result.stableId));
     const citationValues = d.citedBy.map((slug) => ({
-      resourceId: d.id,
+      resourceId: result.stableId as string,
       pageId: citedByIntIdMap.get(slug) as number,
     }));
     await db
@@ -556,14 +565,22 @@ const resourcesApp = new Hono()
 
         results = upsertedRows.map((r) => ({ id: r.id, url: r.url }));
 
-        // Bulk replace citations: delete all old citations for batch resources, then insert new ones
-        const resourceIdsWithCitations = items
+        // Bulk replace citations: delete all old citations for batch resources, then insert new ones.
+        // QUA-566 Phase B.3: resource_citations.resource_id references resources.stable_id.
+        // Map each request item's hex16 id → stable_id via the persisted rows (already in
+        // upsertedRows.stableId from the RETURNING clause).
+        const hexToStableId = new Map<string, string>();
+        for (const row of upsertedRows) {
+          if (row.stableId) hexToStableId.set(row.id, row.stableId);
+        }
+        const resourceStableIdsWithCitations = items
           .filter((d) => d.citedBy && d.citedBy.length > 0)
-          .map((d) => d.id);
-        if (resourceIdsWithCitations.length > 0) {
+          .map((d) => hexToStableId.get(d.id))
+          .filter((sid): sid is string => !!sid);
+        if (resourceStableIdsWithCitations.length > 0) {
           await tx
             .delete(resourceCitations)
-            .where(inArray(resourceCitations.resourceId, resourceIdsWithCitations));
+            .where(inArray(resourceCitations.resourceId, resourceStableIdsWithCitations));
 
           const allCitations: Array<{
             resourceId: string;
@@ -571,11 +588,13 @@ const resourcesApp = new Hono()
           }> = [];
           for (const item of items) {
             if (item.citedBy && item.citedBy.length > 0) {
+              const stableId = hexToStableId.get(item.id);
+              if (!stableId) continue;
               for (const slug of item.citedBy) {
                 const intId = intIdMap.get(slug);
                 if (intId != null) {
                   allCitations.push({
-                    resourceId: item.id,
+                    resourceId: stableId,
                     pageId: intId,
                   });
                 }
@@ -801,17 +820,22 @@ const resourcesApp = new Hono()
     if (toIngest.length > 0) {
       batchId = generateBatchId();
 
-      // Fetch citation counts for priority calculation
+      // Fetch citation counts for priority calculation.
+      // QUA-566 Phase B.3: resource_citations.resource_id now references
+      // resources.stable_id, but `toIngest[].resourceId` is still hex16
+      // (from `urlToResource.get(url).id`). JOIN and return the hex16 id
+      // so downstream `citationCountMap.get(item.resourceId)` still works.
       const resourceIds = toIngest.map((r) => r.resourceId);
       interface CitationCountRow {
         resource_id: string;
         cnt: string;
       }
       const citationCounts = await rawDb<CitationCountRow[]>`
-        SELECT resource_id, count(*)::text AS cnt
-        FROM resource_citations
-        WHERE resource_id = ANY(${resourceIds})
-        GROUP BY resource_id
+        SELECT r.id AS resource_id, count(*)::text AS cnt
+        FROM resource_citations rc
+        JOIN resources r ON rc.resource_id = r.stable_id
+        WHERE r.id = ANY(${resourceIds})
+        GROUP BY r.id
       `;
       const citationCountMap = new Map<string, number>();
       for (const row of citationCounts) {
@@ -1048,7 +1072,7 @@ const resourcesApp = new Hono()
     ] = await Promise.all([
       rawDb<CountRow[]>`
         SELECT count(*) AS c FROM resources r
-        LEFT JOIN resource_citations rc ON rc.resource_id = r.id
+        LEFT JOIN resource_citations rc ON rc.resource_id = r.stable_id
         WHERE rc.resource_id IS NULL
       `,
       rawDb<CountRow[]>`
@@ -1330,7 +1354,8 @@ const resourcesApp = new Hono()
         stance: resources.stance,
       })
       .from(resourceCitations)
-      .innerJoin(resources, eq(resourceCitations.resourceId, resources.id))
+      // QUA-566 Phase B.3: resource_citations.resource_id → resources.stable_id
+      .innerJoin(resources, eq(resourceCitations.resourceId, resources.stableId))
       .where(eq(resourceCitations.pageId, intId))
       .orderBy(resourceCitations.createdAt)
       .limit(500);
@@ -1479,13 +1504,18 @@ const resourcesApp = new Hono()
   .get("/citations/all", async (c) => {
     const HARD_LIMIT = 50000;
     const db = getDrizzleDb();
-    // JOIN wiki_pages to recover slug from integer page ID
+    // JOIN wiki_pages to recover slug from integer page ID.
+    // QUA-566 Phase B.3: resource_citations.resource_id references
+    // resources.stable_id, but API consumers (snapshot-resources, resource-io,
+    // the web build) key the result by resources.id (hex16). JOIN resources
+    // and surface r.id so the response contract is preserved.
     const rows = await db
       .select({
-        resourceId: resourceCitations.resourceId,
+        resourceId: resources.id,
         pageId: wikiPages.slug,
       })
       .from(resourceCitations)
+      .innerJoin(resources, eq(resourceCitations.resourceId, resources.stableId))
       .leftJoin(wikiPages, eq(wikiPages.id, resourceCitations.pageId))
       .limit(HARD_LIMIT + 1);
 
@@ -1601,21 +1631,19 @@ const resourcesApp = new Hono()
       return notFoundError(c, `Resource not found: ${id}`);
     }
 
-    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId now references resources.stable_id,
-    // so the lookup must use stable_id (not the hex16 `id` URL param). Other sub-tables
-    // still use resources.id until their respective Phase B tickets land.
+    // QUA-564 B.1 / QUA-566 B.3: all five sub-tables now reference resources.stable_id.
     // resources.stable_id is NOT NULL in prod per QUA-536; the `?? id` fallback is only
     // defensive for test fixtures that may omit it (will return zero rows harmlessly).
     const stableId = rows[0].stableId ?? id;
     const [paperRows, forumRows, policyRows, citations] = await Promise.all([
-      db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, id)).limit(1),
-      db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, id)).limit(1),
+      db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, stableId)).limit(1),
+      db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, stableId)).limit(1),
       db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, stableId)).limit(1),
       // JOIN wiki_pages to recover slug from integer page ID
       db.select({ pageId: wikiPages.slug })
         .from(resourceCitations)
         .leftJoin(wikiPages, eq(wikiPages.id, resourceCitations.pageId))
-        .where(eq(resourceCitations.resourceId, id)),
+        .where(eq(resourceCitations.resourceId, stableId)),
     ]);
 
     return c.json({
@@ -1635,15 +1663,25 @@ const resourcesApp = new Hono()
 
     const db = getDrizzleDb();
 
-    // Verify resource exists
-    const resRows = await db.select({ id: resources.id }).from(resources).where(eq(resources.id, id)).limit(1);
+    // Verify resource exists and fetch its stable_id.
+    // QUA-566 Phase B.3: resource_papers.resource_id references resources.stable_id;
+    // the URL param is still hex16 for API-contract stability.
+    const resRows = await db
+      .select({ id: resources.id, stableId: resources.stableId })
+      .from(resources)
+      .where(eq(resources.id, id))
+      .limit(1);
     if (resRows.length === 0) return notFoundError(c, `Resource not found: ${id}`);
+    const resourceStableId = resRows[0].stableId;
+    if (!resourceStableId) {
+      return dbError(c, "paper upsert", new Error(`resource ${id} has no stable_id`), { resourceId: id });
+    }
 
     try {
       await db
         .insert(resourcePapers)
         .values({
-          resourceId: id,
+          resourceId: resourceStableId,
           ...data,
           categories: data.categories ?? null,
           updatedAt: new Date(),
@@ -1681,14 +1719,24 @@ const resourcesApp = new Hono()
 
     const db = getDrizzleDb();
 
-    const resRows = await db.select({ id: resources.id }).from(resources).where(eq(resources.id, id)).limit(1);
+    // QUA-566 Phase B.3: resource_forum_posts.resource_id references
+    // resources.stable_id; URL param is still hex16.
+    const resRows = await db
+      .select({ id: resources.id, stableId: resources.stableId })
+      .from(resources)
+      .where(eq(resources.id, id))
+      .limit(1);
     if (resRows.length === 0) return notFoundError(c, `Resource not found: ${id}`);
+    const resourceStableId = resRows[0].stableId;
+    if (!resourceStableId) {
+      return dbError(c, "forum-post upsert", new Error(`resource ${id} has no stable_id`), { resourceId: id });
+    }
 
     try {
       await db
         .insert(resourceForumPosts)
         .values({
-          resourceId: id,
+          resourceId: resourceStableId,
           ...data,
           forumTags: data.forumTags ?? null,
           updatedAt: new Date(),
@@ -1775,12 +1823,35 @@ const resourcesApp = new Hono()
     const db = getDrizzleDb();
     const results = { papers: 0, forumPosts: 0, policyDocs: 0 };
 
+    // QUA-564 B.1 / QUA-566 B.3: all three sub-tables' resource_id references
+    // resources.stable_id. Client batch items may supply hex16 (resources.id)
+    // or sid_ (resources.stable_id); build one hex → sid_ map up front and use
+    // it to translate across all three sub-types.
+    const allInputIds = new Set<string>();
+    for (const it of batchData.papers ?? []) if (it.resourceId) allInputIds.add(it.resourceId);
+    for (const it of batchData.forumPosts ?? []) if (it.resourceId) allInputIds.add(it.resourceId);
+    for (const it of batchData.policyDocs ?? []) if (it.resourceId) allInputIds.add(it.resourceId);
+    const hexToStableId = new Map<string, string>();
+    if (allInputIds.size > 0) {
+      const resourceRows = await db
+        .select({ id: resources.id, stableId: resources.stableId })
+        .from(resources)
+        .where(inArray(resources.id, [...allInputIds]));
+      for (const r of resourceRows) {
+        if (r.stableId) hexToStableId.set(r.id, r.stableId);
+      }
+    }
+    // If the input is already sid_ (or anything not in the map), pass through;
+    // the FK will catch genuinely invalid values at insert time.
+    const resolveResourceId = (input: string): string =>
+      hexToStableId.get(input) ?? input;
+
     try {
       await db.transaction(async (tx) => {
         // Bulk upsert papers in one query
         if (batchData.papers && batchData.papers.length > 0) {
           const paperVals = batchData.papers.map((item) => ({
-            resourceId: item.resourceId,
+            resourceId: resolveResourceId(item.resourceId),
             arxivId: item.arxivId ?? null,
             doi: item.doi ?? null,
             semanticScholarId: item.semanticScholarId ?? null,
@@ -1816,7 +1887,7 @@ const resourcesApp = new Hono()
         // Bulk upsert forum posts in one query
         if (batchData.forumPosts && batchData.forumPosts.length > 0) {
           const forumVals = batchData.forumPosts.map((item) => ({
-            resourceId: item.resourceId,
+            resourceId: resolveResourceId(item.resourceId),
             forum: item.forum,
             forumPostId: item.forumPostId ?? null,
             forumSlug: item.forumSlug ?? null,
@@ -1854,28 +1925,12 @@ const resourcesApp = new Hono()
         }
 
         // Bulk upsert policy docs in one query.
-        // QUA-564 Phase B.1: resource_policy_docs.resource_id now references
-        // resources.stable_id. Client batch items may supply either hex16 (resources.id)
-        // or sid_ (resources.stable_id); translate hex → sid before insert.
+        // QUA-564 Phase B.1 / QUA-566 Phase B.3: resource_id references
+        // resources.stable_id; the shared resolveResourceId() above translates
+        // hex16 → sid_ for any client still passing legacy hex ids.
         if (batchData.policyDocs && batchData.policyDocs.length > 0) {
-          const inputIds = batchData.policyDocs
-            .map((item) => item.resourceId)
-            .filter((v): v is string => !!v);
-          const resourceRows = inputIds.length
-            ? await tx
-                .select({ id: resources.id, stableId: resources.stableId })
-                .from(resources)
-                .where(inArray(resources.id, inputIds))
-            : [];
-          const hexToStableId = new Map(
-            resourceRows
-              .filter((r): r is { id: string; stableId: string } => !!r.stableId)
-              .map((r) => [r.id, r.stableId])
-          );
           const policyVals = batchData.policyDocs.map((item) => ({
-            // If the input is already a sid_ (or any non-hex that doesn't match),
-            // keep it as-is; the FK will catch genuinely invalid values at insert time.
-            resourceId: hexToStableId.get(item.resourceId) ?? item.resourceId,
+            resourceId: resolveResourceId(item.resourceId),
             documentType: item.documentType ?? null,
             jurisdictionEntityId: item.jurisdictionEntityId ?? null,
             agencyEntityId: item.agencyEntityId ?? null,
@@ -1938,22 +1993,20 @@ const resourcesApp = new Hono()
       return c.json({ resources: [], total: countResult[0].count, limit, offset });
     }
 
-    const ids = rows.map((r) => r.id);
-    const idList = sql.join(ids.map((id) => sql`${id}`), sql`, `);
-    // QUA-564 Phase B.1: resourcePolicyDocs.resourceId references resources.stable_id,
-    // so build a parallel stable-id list for the policy-docs IN query. Falls back to
-    // the hex id for resources with null stable_id (shouldn't happen post-QUA-536).
+    // QUA-564 B.1 / QUA-566 B.3: all five sub-tables now reference resources.stable_id,
+    // so we IN-query them all by stable_id. Falls back to the hex id for resources with
+    // null stable_id (shouldn't happen post-QUA-536).
     const stableIds = rows.map((r) => r.stableId ?? r.id);
     const stableIdList = sql.join(stableIds.map((sid) => sql`${sid}`), sql`, `);
 
     // Fetch all sub-table rows for this page of resources in parallel
     const [paperRows, forumRows, policyRows] = await Promise.all([
-      db.select().from(resourcePapers).where(sql`${resourcePapers.resourceId} IN (${idList})`),
-      db.select().from(resourceForumPosts).where(sql`${resourceForumPosts.resourceId} IN (${idList})`),
+      db.select().from(resourcePapers).where(sql`${resourcePapers.resourceId} IN (${stableIdList})`),
+      db.select().from(resourceForumPosts).where(sql`${resourceForumPosts.resourceId} IN (${stableIdList})`),
       db.select().from(resourcePolicyDocs).where(sql`${resourcePolicyDocs.resourceId} IN (${stableIdList})`),
     ]);
 
-    // Index by resourceId. policyIndex keys are stable_ids; the others are hex16 ids.
+    // All three sub-tables are now keyed by stable_id.
     const paperIndex = new Map(paperRows.map((r) => [r.resourceId, r]));
     const forumIndex = new Map(forumRows.map((r) => [r.resourceId, r]));
     const policyIndex = new Map(policyRows.map((r) => [r.resourceId, r]));
@@ -1962,12 +2015,12 @@ const resourcesApp = new Hono()
 
     return c.json({
       resources: rows.map((r) => {
-        const policyKey = r.stableId ?? r.id;
+        const key = r.stableId ?? r.id;
         return {
           ...formatResource(r),
-          paper: paperIndex.has(r.id) ? formatPaper(paperIndex.get(r.id)!) : null,
-          forumPost: forumIndex.has(r.id) ? formatForumPost(forumIndex.get(r.id)!) : null,
-          policyDoc: policyIndex.has(policyKey) ? formatPolicyDoc(policyIndex.get(policyKey)!) : null,
+          paper: paperIndex.has(key) ? formatPaper(paperIndex.get(key)!) : null,
+          forumPost: forumIndex.has(key) ? formatForumPost(forumIndex.get(key)!) : null,
+          policyDoc: policyIndex.has(key) ? formatPolicyDoc(policyIndex.get(key)!) : null,
         };
       }),
       total: countResult[0].count,
@@ -1992,17 +2045,17 @@ const resourcesApp = new Hono()
       return notFoundError(c, `Resource not found: ${id}`);
     }
 
-    // QUA-564 B.1: resourcePolicyDocs.resourceId → resources.stable_id.
-    // QUA-565 B.2: resourceTabularSources.resourceId → resources.stable_id.
+    // QUA-564 B.1 / QUA-565 B.2 / QUA-566 B.3: all five sub-tables reference
+    // resources.stable_id.
     const stableId = rows[0].stableId ?? id;
     // Also fetch citations, sub-table data, and tabular source metadata
     const [citations, paperRows, forumRows, policyRows, tabularRows] = await Promise.all([
       db.select({ pageId: wikiPages.slug })
         .from(resourceCitations)
         .leftJoin(wikiPages, eq(wikiPages.id, resourceCitations.pageId))
-        .where(eq(resourceCitations.resourceId, id)),
-      db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, id)).limit(1),
-      db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, id)).limit(1),
+        .where(eq(resourceCitations.resourceId, stableId)),
+      db.select().from(resourcePapers).where(eq(resourcePapers.resourceId, stableId)).limit(1),
+      db.select().from(resourceForumPosts).where(eq(resourceForumPosts.resourceId, stableId)).limit(1),
       db.select().from(resourcePolicyDocs).where(eq(resourcePolicyDocs.resourceId, stableId)).limit(1),
       db.select().from(resourceTabularSources).where(eq(resourceTabularSources.resourceId, stableId)).limit(1),
     ]);

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -717,9 +717,12 @@ export const resources = pgTable(
 export const resourceCitations = pgTable(
   "resource_citations",
   {
+    // QUA-566 Phase B.3: resource_id references resources.stable_id (not resources.id).
+    // Column name kept as `resource_id` for minimal code churn — the value is now a
+    // `sid_`-prefixed stable_id, not a legacy hex16. See QUA-549 for context.
     resourceId: text("resource_id")
       .notNull()
-      .references(() => resources.id, { onDelete: "cascade" }),
+      .references(() => resources.stableId, { onDelete: "cascade" }),
     pageId: integer("page_id")
       .notNull()
       .references(() => wikiPages.id),
@@ -737,9 +740,11 @@ export const resourceCitations = pgTable(
 
 /** Type-specific metadata for academic papers (~800-2,000 resources). */
 export const resourcePapers = pgTable("resource_papers", {
+  // QUA-566 Phase B.3: resource_id references resources.stable_id (not resources.id).
+  // Column name kept as `resource_id` for minimal code churn.
   resourceId: text("resource_id")
     .primaryKey()
-    .references(() => resources.id, { onDelete: "cascade" }),
+    .references(() => resources.stableId, { onDelete: "cascade" }),
   arxivId: text("arxiv_id"),
   doi: text("doi"),
   semanticScholarId: text("semantic_scholar_id"),
@@ -760,9 +765,11 @@ export const resourcePapers = pgTable("resource_papers", {
 
 /** Type-specific metadata for forum posts (~400-1,200 resources). */
 export const resourceForumPosts = pgTable("resource_forum_posts", {
+  // QUA-566 Phase B.3: resource_id references resources.stable_id (not resources.id).
+  // Column name kept as `resource_id` for minimal code churn.
   resourceId: text("resource_id")
     .primaryKey()
-    .references(() => resources.id, { onDelete: "cascade" }),
+    .references(() => resources.stableId, { onDelete: "cascade" }),
   forum: text("forum").notNull(),
   forumPostId: text("forum_post_id"),
   forumSlug: text("forum_slug"),


### PR DESCRIPTION
## Summary

Phase B.3 of [QUA-549](https://linear.app/quantifieduncertainty/issue/QUA-549) — migrates the 3 medium citation/papers FK tables from referencing `resources.id` (legacy hex16) to `resources.stable_id` (canonical `sid_`). Total ~11,660 rows rewritten in-place to `sid_`.

Fixes QUA-566.

Follows the in-place / Option B pattern established by QUA-564 (#4456), QUA-565 (#4459), QUA-567 (#4460), QUA-568 (#4461). Column names stay `resource_id`; only the FK target and stored values change.

## Prod state verified before authoring (2026-04-18)

| Table | Rows | Format | Orphans (vs `resources.id`) | `onDelete` |
| -- | -- | -- | -- | -- |
| `resource_papers` | 431 | 100% hex16 | 0 | CASCADE |
| `resource_forum_posts` | 5,267 | 100% hex16 | 0 | CASCADE |
| `resource_citations` | 5,962 | 100% hex16 | 0 | CASCADE |

- Distinct resource_ids in `resource_citations`: 4,526
- `resources.stable_id` coverage: 22,976 / 22,976 (100%, per QUA-536 Phase A)

Every row maps cleanly hex16 → sid_ via the `resources` JOIN.

## What changed

**Migration** — `apps/wiki-server/drizzle/0192_qua_566_phase_b3_papers_posts_citations.sql` (new)
One transactional migration covering all 3 tables (they share CASCADE `onDelete` and live in the same citation/papers code path). Per table: `DROP CONSTRAINT IF EXISTS` (both the Drizzle-generated `<table>_<col>_resources_id_fk` and the postgres-default `<table>_<col>_fkey`), `UPDATE ... SET resource_id = r.stable_id FROM resources r WHERE ...`, a `DO $$ RAISE EXCEPTION` orphan guard, then `ADD CONSTRAINT IF NOT EXISTS ... REFERENCES resources(stable_id) ON DELETE CASCADE`. Same idempotent-on-rerun pattern as 0188.

**Schema** — `apps/wiki-server/src/schema.ts`
`resourceCitations.resourceId`, `resourcePapers.resourceId`, and `resourceForumPosts.resourceId` all flip `.references(() => resources.id)` → `.references(() => resources.stableId)`.

**Callsite sweep** — `apps/wiki-server/src/routes/wikibase/resources.ts`
- `upsertResource` (single): adds `stableId` to the `.returning()` clause and writes citations with the persisted `stable_id`. Throws on the impossible `!stableId` case.
- Batch upsert: builds one `hexToStableId` map from `upsertedRows` and uses it for citation delete+insert.
- `/suggest` citation count: raw SQL JOINs `resources` on `stable_id` and returns `r.id` so the downstream priority map keyed by hex16 keeps working.
- Orphaned-resources count: LEFT JOIN switches to `rc.resource_id = r.stable_id`.
- `GET /:pageId/resources`: Drizzle `innerJoin` switches to `resources.stableId`.
- **`GET /citations/all`**: adds `INNER JOIN resources` and surfaces `resources.id` (hex16) so the API contract is preserved for the three downstream consumers (`apps/web/scripts/lib/wiki-server-data.mjs`, `crux/resource-io.ts`, `crux/wiki-server/snapshot-resources.ts`, all of which key citations by hex16 `r.id`).
- `GET /:id`, `GET /:id/details`: all five sub-tables (papers / forum / policy / tabular / citations) now look up by `stableId`.
- `POST /:id/paper`, `POST /:id/forum-post`: verify + fetch `stable_id` once, pass to the upsert.
- `POST /batch-details`: hoisted the policyDocs hex→sid translation into a single up-front fetch + shared `resolveResourceId()` helper applied to all three sub-types.

**Other callsites**
- `apps/wiki-server/src/routes/tablebase/research-areas.ts`: `backfill-papers-from-citations` SQL switches `JOIN resources r ON rc.resource_id = r.id` to `rc.resource_id = r.stable_id`.

**Tests**
- `apps/wiki-server/src/__tests__/integration.test.ts`: FK constraint-name assertion updated to the new `resource_citations_resource_id_resources_stable_id_fk` form.
- `apps/wiki-server/src/__tests__/resources.test.ts`: two mock JOIN branches (by-page, /suggest citation count) updated to reflect the new join key; `cited-res` and `popular-res` fixtures seeded with `stable_id` and `citationStore.resource_id` keyed on them.

## Out-of-scope, filed as follow-up

- **QUA-589** — `resource-dedup.loadResourceFks` filters `information_schema.ccu.column_name = 'id'`, so the 3 tables (plus every other migrated Phase B table) silently drop off the dedup sweep. CASCADE `onDelete` still cleans them when a dup resource is deleted; only the UPDATE-to-canonical path is affected. Deferred here in line with Phases B.1/B.2/B.4/B.5, tracked explicitly in QUA-589.

## Risk profile

Low-medium. 11,660 rows total across 3 small tables, all mapping cleanly to populated `resources.stable_id`. The migration is transactional and idempotent; the pre-flight `RAISE EXCEPTION` block fails loudly on any orphan rather than letting `ADD CONSTRAINT` error generically. No MV refreshes target these tables, so QUA-302 `NOT VALID` pattern is unnecessary. The one user-facing risk — a regression in the `/citations/all` response shape breaking three downstream consumers — was caught at design time and preserved via the `INNER JOIN resources` surfacing `r.id`.

## Test plan

- [x] `npx tsc --noEmit` — apps/wiki-server + apps/web both clean
- [x] `pnpm test` — wiki-server (1,248 tests) + apps/web (1,612 tests) all pass
- [x] `pnpm build` — clean
- [x] `pnpm crux w validate gate` — all 46 blocking checks pass (3 advisory warnings, 4 triage-skipped)
- [x] Prod orphan enumeration documented above (0 orphans across all 3 tables, 100% stable_id coverage)
- [x] `/agent-review-pr` hostile-review pass: one MEDIUM test-mock-fidelity finding fixed (second commit); one MEDIUM dedup-degradation filed as QUA-589
- [ ] Post-merge: verify 0192 applies cleanly on wiki-server startup (Deploy Checklist)
- [ ] Post-merge: sample `GET /api/resources/<hex16>/details` for a resource with citations + a resource with paper metadata — both should still render correctly


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->