### PR TITLE
QUA-413: `crux sys sessions list` for cross-session observability

### DIFF
--- a/.claude/rules/agent-session-workflow.md
+++ b/.claude/rules/agent-session-workflow.md
@@ -35,6 +35,28 @@ If an open PR already targets the same failure, do NOT create a competing branch
 
 This prevents the duplicate-work pattern where multiple agents independently race to fix the same trivial CI break, wasting CI runs and creating abandoned PRs (e.g., 7 competing PRs for a single 5-line test fix on 2026-04-03).
 
+### Checking for active sessions before starting
+
+Before beginning non-trivial work — especially before dispatching an agent to another slot — check which Claude Code sessions are already in flight. `crux sys sessions list` (QUA-413) is the canonical way to see this:
+
+```bash
+WIKI_SERVER_ENV=prod pnpm crux sys sessions list                   # active sessions across all slots
+WIKI_SERVER_ENV=prod pnpm crux sys sessions list --all             # include completed history
+WIKI_SERVER_ENV=prod pnpm crux sys sessions list --linear=QUA-NNN  # "is anyone working on QUA-NNN?"
+WIKI_SERVER_ENV=prod pnpm crux sys sessions list --slot=9          # what's slot a9 doing?
+WIKI_SERVER_ENV=prod pnpm crux sys sessions list --json            # machine-readable for scripting
+```
+
+The command reads the PG `agent_sessions` table (authoritative: who registered via `agent-checklist init`) and cross-references it with local `claude` processes found via `ps` + `lsof`. Output uses five liveness states:
+
+- `●` **live** — heartbeat within the last 2 minutes (session actively running)
+- `◐` **recent** — heartbeat within the last 30 minutes (probably active)
+- `◯` **stale** — `status='active'` in DB but heartbeat >30 min old (session probably crashed without calling `/agent-end` or the sweep)
+- `!` **ghost** — live `claude` process with no matching active DB row (session is running code without registering — it skipped `agent-checklist init`)
+- `✓` **done** — `status='completed'` (shown only with `--all`)
+
+Prefer this over `./ws list`: `./ws list` shows slot git state (branch, dirty, PR) and does NOT cross-reference with live processes or the `agent_sessions` table, so a slot with an active Claude session on a feature branch can appear as `main, no PR` when init was run before the branch was created — exactly the QUA-406 failure mode.
+
 ## Step 1: Session Start — BEFORE taking any action
 
 Run `/agent-init` as the very first thing — before reading files, running commands, or writing any code. "Before writing code" is not sufficient; quick fixes and file reads count too. If you start without this, you will forget it entirely.

--- a/.claude/rules/dispatched-agent-review.md
+++ b/.claude/rules/dispatched-agent-review.md
@@ -10,7 +10,7 @@ Before writing a dispatch brief for any Linear-tracked ticket, the coordinator M
 
 1. **Linear state** — Run `pnpm crux linear view QUA-NNN`. Confirm the issue is **not already In Progress with a recent (<24h) start comment from a different session**. Recent start comments mean a slot already picked this up.
 2. **Open PRs** — Run `gh pr list -R quantified-uncertainty/longterm-wiki --search "QUA-NNN in:body" --state all --json number,state,headRefName`. Confirm **no open PR references the ticket**. A closed-unmerged PR is usually fine (investigate the close reason); an open PR almost always means another session is iterating on it.
-3. **Active slots** — Run `./ws list` (or `pnpm crux sys sessions list` once QUA-413 ships). Confirm **no other slot is currently on a `claude/qua-NNN-*` branch** or has an uncommitted working tree that suggests it's on the same ticket.
+3. **Active slots** — Run `WIKI_SERVER_ENV=prod pnpm crux sys sessions list --linear=QUA-NNN` (QUA-413) to see every registered session working on the ticket, cross-referenced with live `claude` processes. Fall back to `./ws list` only if the wiki-server is unreachable. Confirm **no other slot is currently on a `claude/qua-NNN-*` branch**, has a ghost Claude process, or an uncommitted working tree that suggests it's on the same ticket.
 
 **If any check surfaces an existing claim, abort the dispatch.** Either (a) investigate the existing session first and confirm it's abandoned/stuck before taking over with `--force`, or (b) comment on the existing PR instead of opening a new one, or (c) wait for the in-flight session to ship.
 

--- a/crux/commands/sessions.test.ts
+++ b/crux/commands/sessions.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the `crux sys sessions list` command handler. The merge/format
+ * logic is unit-tested separately in `crux/lib/session/sessions-list.test.ts`
+ * and `crux/lib/session/claude-processes.test.ts`; this file covers the
+ * command-layer glue: option validation, the server-unavailable degradation
+ * path, scan-failure warnings, and JSON output shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock wiki-server deps up-front (vi.mock is hoisted above imports).
+const { listAgentSessionsMock, isServerAvailableMock, findClaudeProcessesMock } = vi.hoisted(() => ({
+  listAgentSessionsMock: vi.fn<(...a: unknown[]) => Promise<unknown>>(),
+  isServerAvailableMock: vi.fn<() => Promise<boolean>>(async () => true),
+  findClaudeProcessesMock: vi.fn<() => {
+    processes: Array<{ pid: number; cwd: string; slot: number | null }>;
+    scanFailed: boolean;
+    scanError: string;
+  }>(() => ({ processes: [], scanFailed: false, scanError: '' })),
+}));
+
+vi.mock('../lib/wiki-server/agent-sessions.ts', () => ({
+  listAgentSessions: listAgentSessionsMock,
+}));
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  isServerAvailable: isServerAvailableMock,
+}));
+vi.mock('../lib/session/claude-processes.ts', () => ({
+  findClaudeProcesses: findClaudeProcessesMock,
+}));
+
+// Stub fs so the unrelated `write` command's module-level imports don't blow up.
+vi.mock('fs', () => ({
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+}));
+
+// Stub the wiki-server sync import used by `write`, unrelated to `list`.
+vi.mock('../wiki-server/sync-session.ts', () => ({
+  syncSessionFile: vi.fn(async () => true),
+}));
+
+vi.mock('../lib/session/session-checklist.ts', () => ({
+  currentBranch: vi.fn(() => 'main'),
+}));
+
+// Strip ANSI escapes so assertions don't have to encode color codes.
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+import { commands } from './sessions.ts';
+
+const list = commands.list;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isServerAvailableMock.mockResolvedValue(true);
+  listAgentSessionsMock.mockResolvedValue({ ok: true, data: { sessions: [] } });
+  findClaudeProcessesMock.mockReturnValue({ processes: [], scanFailed: false, scanError: '' });
+});
+
+describe('list command — option validation', () => {
+  it('rejects non-numeric --slot with exit code 2', async () => {
+    const r = await list([], { slot: 'abc' });
+    expect(r.exitCode).toBe(2);
+    expect(stripAnsi(r.output)).toContain('--slot must be a non-negative integer');
+  });
+
+  it('rejects negative --slot with exit code 2', async () => {
+    const r = await list([], { slot: '-1' });
+    expect(r.exitCode).toBe(2);
+  });
+
+  it('accepts numeric --slot', async () => {
+    const r = await list([], { slot: '9' });
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe('list command — server unavailable degradation', () => {
+  it('does not hard-fail when server is unreachable; shows warning + scan-only results', async () => {
+    isServerAvailableMock.mockResolvedValue(false);
+    findClaudeProcessesMock.mockReturnValue({
+      processes: [{ pid: 42, cwd: '/lw/a9', slot: 9 }],
+      scanFailed: false,
+      scanError: '',
+    });
+    const r = await list([], {});
+    expect(r.exitCode).toBe(0);
+    const out = stripAnsi(r.output);
+    expect(out).toContain('wiki-server unreachable');
+    expect(out).toContain('a9'); // ghost still surfaces
+  });
+
+  it('does not call listAgentSessions when server is unreachable', async () => {
+    isServerAvailableMock.mockResolvedValue(false);
+    await list([], {});
+    expect(listAgentSessionsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('list command — scan failure warning', () => {
+  it('emits a warning banner when the process scan fails', async () => {
+    findClaudeProcessesMock.mockReturnValue({
+      processes: [],
+      scanFailed: true,
+      scanError: 'lsof failed: permission denied',
+    });
+    const r = await list([], {});
+    expect(r.exitCode).toBe(0);
+    const out = stripAnsi(r.output);
+    expect(out).toContain('process scan failed');
+    expect(out).toContain('permission denied');
+    expect(out).toContain('Ghost detection disabled');
+  });
+});
+
+describe('list command — JSON output', () => {
+  it('returns a plain array when there are no warnings', async () => {
+    const r = await list([], { json: true });
+    const parsed = JSON.parse(r.output);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it('wraps output in {warnings, sessions} when warnings exist', async () => {
+    findClaudeProcessesMock.mockReturnValue({
+      processes: [],
+      scanFailed: true,
+      scanError: 'x',
+    });
+    const r = await list([], { json: true });
+    const parsed = JSON.parse(r.output);
+    expect(parsed).toHaveProperty('warnings');
+    expect(parsed).toHaveProperty('sessions');
+    expect(Array.isArray(parsed.warnings)).toBe(true);
+    expect(parsed.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('list command — limit clamping', () => {
+  it('clamps --limit to 500 max', async () => {
+    await list([], { limit: '1000' });
+    expect(listAgentSessionsMock).toHaveBeenCalledWith(500);
+  });
+
+  it('defaults to 200 for invalid --limit', async () => {
+    await list([], { limit: 'abc' });
+    expect(listAgentSessionsMock).toHaveBeenCalledWith(200);
+  });
+
+  it('defaults to 200 for negative --limit', async () => {
+    await list([], { limit: '-5' });
+    expect(listAgentSessionsMock).toHaveBeenCalledWith(200);
+  });
+
+  it('floors fractional --limit', async () => {
+    await list([], { limit: '3.7' });
+    expect(listAgentSessionsMock).toHaveBeenCalledWith(3);
+  });
+});

--- a/crux/commands/sessions.test.ts
+++ b/crux/commands/sessions.test.ts
@@ -14,9 +14,8 @@ const { listAgentSessionsMock, isServerAvailableMock, findClaudeProcessesMock } 
   isServerAvailableMock: vi.fn<() => Promise<boolean>>(async () => true),
   findClaudeProcessesMock: vi.fn<() => {
     processes: Array<{ pid: number; cwd: string; slot: number | null }>;
-    scanFailed: boolean;
-    scanError: string;
-  }>(() => ({ processes: [], scanFailed: false, scanError: '' })),
+    scanError: string | null;
+  }>(() => ({ processes: [], scanError: null })),
 }));
 
 vi.mock('../lib/wiki-server/agent-sessions.ts', () => ({
@@ -59,7 +58,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   isServerAvailableMock.mockResolvedValue(true);
   listAgentSessionsMock.mockResolvedValue({ ok: true, data: { sessions: [] } });
-  findClaudeProcessesMock.mockReturnValue({ processes: [], scanFailed: false, scanError: '' });
+  findClaudeProcessesMock.mockReturnValue({ processes: [], scanError: null });
 });
 
 describe('list command — option validation', () => {
@@ -81,24 +80,32 @@ describe('list command — option validation', () => {
 });
 
 describe('list command — server unavailable degradation', () => {
-  it('does not hard-fail when server is unreachable; shows warning + scan-only results', async () => {
-    isServerAvailableMock.mockResolvedValue(false);
+  it('does not hard-fail when DB returns unavailable; shows warning + scan-only results', async () => {
+    listAgentSessionsMock.mockResolvedValue({
+      ok: false,
+      error: 'unavailable',
+      message: 'connection refused',
+    });
     findClaudeProcessesMock.mockReturnValue({
       processes: [{ pid: 42, cwd: '/lw/a9', slot: 9 }],
-      scanFailed: false,
-      scanError: '',
+      scanError: null,
     });
     const r = await list([], {});
     expect(r.exitCode).toBe(0);
     const out = stripAnsi(r.output);
     expect(out).toContain('wiki-server unreachable');
-    expect(out).toContain('a9'); // ghost still surfaces
+    expect(out).toContain('a9');
   });
 
-  it('does not call listAgentSessions when server is unreachable', async () => {
-    isServerAvailableMock.mockResolvedValue(false);
-    await list([], {});
-    expect(listAgentSessionsMock).not.toHaveBeenCalled();
+  it('reports non-unavailable DB errors with the error kind', async () => {
+    listAgentSessionsMock.mockResolvedValue({
+      ok: false,
+      error: 'server_error',
+      message: '500 Internal Server Error',
+    });
+    const r = await list([], {});
+    expect(r.exitCode).toBe(0);
+    expect(stripAnsi(r.output)).toContain('DB fetch failed (server_error)');
   });
 });
 
@@ -106,7 +113,6 @@ describe('list command — scan failure warning', () => {
   it('emits a warning banner when the process scan fails', async () => {
     findClaudeProcessesMock.mockReturnValue({
       processes: [],
-      scanFailed: true,
       scanError: 'lsof failed: permission denied',
     });
     const r = await list([], {});
@@ -119,45 +125,41 @@ describe('list command — scan failure warning', () => {
 });
 
 describe('list command — JSON output', () => {
-  it('returns a plain array when there are no warnings', async () => {
-    const r = await list([], { json: true });
-    const parsed = JSON.parse(r.output);
-    expect(Array.isArray(parsed)).toBe(true);
-  });
-
-  it('wraps output in {warnings, sessions} when warnings exist', async () => {
-    findClaudeProcessesMock.mockReturnValue({
-      processes: [],
-      scanFailed: true,
-      scanError: 'x',
-    });
+  it('always wraps output in {warnings, sessions} — consistent shape', async () => {
     const r = await list([], { json: true });
     const parsed = JSON.parse(r.output);
     expect(parsed).toHaveProperty('warnings');
     expect(parsed).toHaveProperty('sessions');
     expect(Array.isArray(parsed.warnings)).toBe(true);
+    expect(Array.isArray(parsed.sessions)).toBe(true);
+    expect(parsed.warnings).toEqual([]); // empty when no issues
+  });
+
+  it('populates warnings when scan or DB fails', async () => {
+    findClaudeProcessesMock.mockReturnValue({
+      processes: [],
+      scanError: 'x',
+    });
+    const r = await list([], { json: true });
+    const parsed = JSON.parse(r.output);
     expect(parsed.warnings.length).toBeGreaterThan(0);
   });
 });
 
-describe('list command — limit clamping', () => {
+describe('list command — limit validation', () => {
   it('clamps --limit to 500 max', async () => {
     await list([], { limit: '1000' });
     expect(listAgentSessionsMock).toHaveBeenCalledWith(500);
   });
 
-  it('defaults to 200 for invalid --limit', async () => {
-    await list([], { limit: 'abc' });
-    expect(listAgentSessionsMock).toHaveBeenCalledWith(200);
+  it('rejects non-integer --limit with exit 2 (matches --slot behavior)', async () => {
+    const r = await list([], { limit: 'abc' });
+    expect(r.exitCode).toBe(2);
+    expect(stripAnsi(r.output)).toContain('--limit must be a non-negative integer');
   });
 
-  it('defaults to 200 for negative --limit', async () => {
-    await list([], { limit: '-5' });
-    expect(listAgentSessionsMock).toHaveBeenCalledWith(200);
-  });
-
-  it('floors fractional --limit', async () => {
-    await list([], { limit: '3.7' });
-    expect(listAgentSessionsMock).toHaveBeenCalledWith(3);
+  it('rejects negative --limit with exit 2', async () => {
+    const r = await list([], { limit: '-5' });
+    expect(r.exitCode).toBe(2);
   });
 });

--- a/crux/commands/sessions.ts
+++ b/crux/commands/sessions.ts
@@ -243,6 +243,14 @@ function livenessColor(liveness: Liveness, c: ReturnType<typeof createLogger>['c
       return c.red;
     case 'done':
       return c.dim;
+    default: {
+      // Exhaustiveness: if a new Liveness variant is added, TS errors here
+      // and a runtime fallback keeps the output legible instead of emitting
+      // `undefined` as an ANSI escape prefix.
+      const _exhaustive: never = liveness;
+      void _exhaustive;
+      return c.reset;
+    }
   }
 }
 
@@ -286,44 +294,67 @@ function renderTable(
   return out;
 }
 
+/** Parse `--slot=N` with explicit error on malformed input. */
+function parseSlotOption(raw: unknown): { ok: true; slot: number | undefined } | { ok: false; error: string } {
+  if (raw === undefined) return { ok: true, slot: undefined };
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) {
+    return { ok: false, error: `--slot must be a non-negative integer, got: ${String(raw)}` };
+  }
+  return { ok: true, slot: n };
+}
+
 async function list(_args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const log = createLogger(options.ci as boolean | undefined);
   const c = log.colors;
 
-  const available = await isServerAvailable();
-  if (!available) {
-    return {
-      exitCode: 1,
-      output:
-        `${c.red}Error: wiki-server is not reachable.${c.reset}\n` +
-        `  In agent slots, set WIKI_SERVER_ENV=prod to query the production DB:\n` +
-        `  ${c.cyan}WIKI_SERVER_ENV=prod pnpm crux sys sessions list${c.reset}\n`,
-    };
+  // Validate --slot early so a typo like --slot=abc surfaces immediately
+  // instead of silently returning an unfiltered table.
+  const slotOpt = parseSlotOption(options.slot);
+  if (!slotOpt.ok) {
+    return { exitCode: 2, output: `${c.red}Error: ${slotOpt.error}${c.reset}\n` };
   }
 
+  // Fetch DB sessions (may fail if wiki-server is unreachable) and scan local
+  // processes in parallel. Failure of either is degraded-but-still-useful:
+  // DB-only data or scan-only data both give the coordinator partial signal.
+  const serverUp = await isServerAvailable();
   const limit = Number(options.limit ?? 200);
-  const result = await listAgentSessions(Number.isFinite(limit) && limit > 0 ? Math.min(limit, 500) : 200);
-  if (!result.ok) {
-    return { exitCode: 1, output: `${c.red}Error fetching sessions: ${result.message}${c.reset}\n` };
+  const boundedLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 500) : 200;
+  const dbPromise = serverUp ? listAgentSessions(boundedLimit) : null;
+  const scan = findClaudeProcesses();
+  const dbResult = dbPromise ? await dbPromise : null;
+
+  const sessions = dbResult?.ok ? dbResult.data.sessions : [];
+  const warnings: string[] = [];
+  if (!serverUp) {
+    warnings.push(
+      'wiki-server unreachable — showing local Claude processes only (no DB session data). ' +
+        'In agent slots, set WIKI_SERVER_ENV=prod.',
+    );
+  } else if (dbResult && !dbResult.ok) {
+    warnings.push(`DB fetch failed: ${dbResult.message}. Showing local process data only.`);
+  }
+  if (scan.scanFailed) {
+    warnings.push(
+      `process scan failed (${scan.scanError}). Ghost detection disabled — a live session without a DB row won't be visible.`,
+    );
   }
 
-  const liveMinutes = options.liveMinutes !== undefined ? Number(options.liveMinutes) : 2;
-  const staleMinutes = options.fresh !== undefined ? Number(options.fresh) : 30;
+  const liveMinutes = options.liveMinutes !== undefined ? Number(options.liveMinutes) : undefined;
+  const staleMinutes = options.fresh !== undefined ? Number(options.fresh) : undefined;
 
-  const processes = findClaudeProcesses();
-
-  const merged = mergeSessions(result.data.sessions, processes, {
-    liveMinutes: Number.isFinite(liveMinutes) && liveMinutes > 0 ? liveMinutes : 2,
-    staleMinutes: Number.isFinite(staleMinutes) && staleMinutes > 0 ? staleMinutes : 30,
+  const merged = mergeSessions(sessions, scan.processes, {
+    liveMinutes,
+    staleMinutes,
   });
 
   const filterLinear = typeof options.linear === 'string' ? options.linear : undefined;
-  const filterSlot = options.slot !== undefined ? Number(options.slot) : undefined;
 
   const filtered = filterSessions(merged, {
     includeCompleted: Boolean(options.all),
     linearId: filterLinear,
-    slot: Number.isFinite(filterSlot) ? (filterSlot as number) : undefined,
+    slot: slotOpt.slot,
   });
 
   const sorted = sortSessions(filtered);
@@ -333,7 +364,8 @@ async function list(_args: string[], options: Record<string, unknown>): Promise<
     const jsonRows = sorted.map((r) => ({
       slot: r.session?.slotNumber ?? r.process?.slot ?? null,
       pid: r.process?.pid ?? null,
-      cwd: r.process?.cwd ?? r.session?.worktree ?? null,
+      cwd: r.process?.cwd ?? null,
+      worktree: r.session?.worktree ?? null,
       branch: r.session?.branch ?? null,
       linearId: r.session?.linearId ?? null,
       prUrl: r.session?.prUrl ?? null,
@@ -346,11 +378,17 @@ async function list(_args: string[], options: Record<string, unknown>): Promise<
       startedAt: r.session?.startedAt ?? null,
       sessionId: r.session?.id ?? null,
     }));
-    return { exitCode: 0, output: JSON.stringify(jsonRows, null, 2) + '\n' };
+    const payload = warnings.length > 0
+      ? { warnings, sessions: jsonRows }
+      : jsonRows;
+    return { exitCode: 0, output: JSON.stringify(payload, null, 2) + '\n' };
   }
 
   const header = `${c.bold}Agent Sessions${c.reset} ${c.dim}(${sorted.length} row${sorted.length === 1 ? '' : 's'}${Boolean(options.all) ? '' : ', active only'})${c.reset}\n\n`;
-  return { exitCode: 0, output: header + renderTable(sorted, c) };
+  const warningBanner = warnings.length > 0
+    ? warnings.map((w) => `  ${c.yellow}⚠ ${w}${c.reset}`).join('\n') + '\n\n'
+    : '';
+  return { exitCode: 0, output: warningBanner + header + renderTable(sorted, c) };
 }
 
 // ---------------------------------------------------------------------------
@@ -396,5 +434,6 @@ Examples:
   pnpm crux sys sessions list --slot=9 --json
   pnpm crux sys sessions write "Fix citation parser bug"
   pnpm crux sys sessions write "Add dark mode" --model=claude-sonnet-4-6 --duration="~45min"
+  pnpm crux sys sessions write "Update AI timelines page" --pages=ai-timelines,ai-forecasting --sync
 `.trim();
 }

--- a/crux/commands/sessions.ts
+++ b/crux/commands/sessions.ts
@@ -7,6 +7,10 @@
  *   crux sys sessions write "Session title"               Write a session log YAML
  *   crux sys sessions write --title="Session title"       Alternative flag form
  *   crux sys sessions write "Title" --sync                Write + sync to wiki-server
+ *   crux sys sessions list                                List active sessions across all slots
+ *   crux sys sessions list --all                          Include completed sessions
+ *   crux sys sessions list --linear=QUA-NNN               Filter by Linear ID
+ *   crux sys sessions list --slot=7                       Filter by slot number
  */
 
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
@@ -16,6 +20,16 @@ import { currentBranch } from '../lib/session/session-checklist.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { syncSessionFile } from '../wiki-server/sync-session.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
+import { listAgentSessions } from '../lib/wiki-server/agent-sessions.ts';
+import { findClaudeProcesses } from '../lib/session/claude-processes.ts';
+import {
+  mergeSessions,
+  filterSessions,
+  sortSessions,
+  toDisplayRow,
+  type MergedSession,
+  type Liveness,
+} from '../lib/session/sessions-list.ts';
 import type { CommandResult } from '../lib/cli.ts';
 
 const SESSIONS_DIR = join(PROJECT_ROOT, '.claude/sessions');
@@ -206,21 +220,166 @@ async function write(args: string[], options: Record<string, unknown>): Promise<
 }
 
 // ---------------------------------------------------------------------------
+// list command — cross-session observability (QUA-413)
+// ---------------------------------------------------------------------------
+
+const LIVENESS_BADGE: Record<Liveness, string> = {
+  live: '●',
+  recent: '◐',
+  stale: '◯',
+  ghost: '!',
+  done: '✓',
+};
+
+function livenessColor(liveness: Liveness, c: ReturnType<typeof createLogger>['colors']): string {
+  switch (liveness) {
+    case 'live':
+      return c.green;
+    case 'recent':
+      return c.cyan;
+    case 'stale':
+      return c.yellow;
+    case 'ghost':
+      return c.red;
+    case 'done':
+      return c.dim;
+  }
+}
+
+function renderTable(
+  rows: MergedSession[],
+  colors: ReturnType<typeof createLogger>['colors'],
+): string {
+  if (rows.length === 0) {
+    return `${colors.dim}No sessions match the filter.${colors.reset}\n`;
+  }
+
+  const display = rows.map(toDisplayRow);
+
+  const widths = {
+    badge: 2,
+    slot: Math.max(4, ...display.map((d) => d.slot.length)),
+    pid: Math.max(5, ...display.map((d) => d.pid.length)),
+    branch: Math.max(6, ...display.map((d) => d.branch.length)),
+    linear: Math.max(7, ...display.map((d) => d.linear.length)),
+    pr: Math.max(4, ...display.map((d) => d.pr.length)),
+    age: Math.max(3, ...display.map((d) => d.age.length)),
+    task: Math.max(4, ...display.map((d) => d.task.length)),
+  };
+
+  const pad = (s: string, w: number) => s.padEnd(w);
+
+  let out = '';
+  // Header
+  out += `  ${pad('', widths.badge)} ${pad('Slot', widths.slot)} ${pad('PID', widths.pid)} ${pad('Branch', widths.branch)} ${pad('Linear', widths.linear)} ${pad('PR', widths.pr)} ${pad('Age', widths.age)} ${pad('Task', widths.task)}\n`;
+  out += `  ${'─'.repeat(widths.badge)} ${'─'.repeat(widths.slot)} ${'─'.repeat(widths.pid)} ${'─'.repeat(widths.branch)} ${'─'.repeat(widths.linear)} ${'─'.repeat(widths.pr)} ${'─'.repeat(widths.age)} ${'─'.repeat(widths.task)}\n`;
+
+  for (const d of display) {
+    const col = livenessColor(d.liveness, colors);
+    const badge = LIVENESS_BADGE[d.liveness];
+    const line = `  ${col}${pad(badge, widths.badge)}${colors.reset} ${pad(d.slot, widths.slot)} ${colors.dim}${pad(d.pid, widths.pid)}${colors.reset} ${pad(d.branch, widths.branch)} ${pad(d.linear, widths.linear)} ${pad(d.pr, widths.pr)} ${pad(d.age, widths.age)} ${pad(d.task, widths.task)}`;
+    out += `${line}\n`;
+  }
+
+  // Legend
+  out += `\n${colors.dim}  ${colors.green}●${colors.dim} live (<2m)   ${colors.cyan}◐${colors.dim} recent (<30m)   ${colors.yellow}◯${colors.dim} stale   ${colors.red}!${colors.dim} ghost (untracked)   ${colors.dim}✓${colors.dim} done${colors.reset}\n`;
+  return out;
+}
+
+async function list(_args: string[], options: Record<string, unknown>): Promise<CommandResult> {
+  const log = createLogger(options.ci as boolean | undefined);
+  const c = log.colors;
+
+  const available = await isServerAvailable();
+  if (!available) {
+    return {
+      exitCode: 1,
+      output:
+        `${c.red}Error: wiki-server is not reachable.${c.reset}\n` +
+        `  In agent slots, set WIKI_SERVER_ENV=prod to query the production DB:\n` +
+        `  ${c.cyan}WIKI_SERVER_ENV=prod pnpm crux sys sessions list${c.reset}\n`,
+    };
+  }
+
+  const limit = Number(options.limit ?? 200);
+  const result = await listAgentSessions(Number.isFinite(limit) && limit > 0 ? Math.min(limit, 500) : 200);
+  if (!result.ok) {
+    return { exitCode: 1, output: `${c.red}Error fetching sessions: ${result.message}${c.reset}\n` };
+  }
+
+  const liveMinutes = options.liveMinutes !== undefined ? Number(options.liveMinutes) : 2;
+  const staleMinutes = options.fresh !== undefined ? Number(options.fresh) : 30;
+
+  const processes = findClaudeProcesses();
+
+  const merged = mergeSessions(result.data.sessions, processes, {
+    liveMinutes: Number.isFinite(liveMinutes) && liveMinutes > 0 ? liveMinutes : 2,
+    staleMinutes: Number.isFinite(staleMinutes) && staleMinutes > 0 ? staleMinutes : 30,
+  });
+
+  const filterLinear = typeof options.linear === 'string' ? options.linear : undefined;
+  const filterSlot = options.slot !== undefined ? Number(options.slot) : undefined;
+
+  const filtered = filterSessions(merged, {
+    includeCompleted: Boolean(options.all),
+    linearId: filterLinear,
+    slot: Number.isFinite(filterSlot) ? (filterSlot as number) : undefined,
+  });
+
+  const sorted = sortSessions(filtered);
+
+  if (options.json) {
+    // Shape the JSON output with explicit fields a coordinator might script against.
+    const jsonRows = sorted.map((r) => ({
+      slot: r.session?.slotNumber ?? r.process?.slot ?? null,
+      pid: r.process?.pid ?? null,
+      cwd: r.process?.cwd ?? r.session?.worktree ?? null,
+      branch: r.session?.branch ?? null,
+      linearId: r.session?.linearId ?? null,
+      prUrl: r.session?.prUrl ?? null,
+      task: r.session?.task ?? null,
+      status: r.session?.status ?? null,
+      liveness: r.liveness,
+      ageMinutes: r.ageMinutes,
+      heartbeatAt: r.session?.heartbeatAt ?? null,
+      updatedAt: r.session?.updatedAt ?? null,
+      startedAt: r.session?.startedAt ?? null,
+      sessionId: r.session?.id ?? null,
+    }));
+    return { exitCode: 0, output: JSON.stringify(jsonRows, null, 2) + '\n' };
+  }
+
+  const header = `${c.bold}Agent Sessions${c.reset} ${c.dim}(${sorted.length} row${sorted.length === 1 ? '' : 's'}${Boolean(options.all) ? '' : ', active only'})${c.reset}\n\n`;
+  return { exitCode: 0, output: header + renderTable(sorted, c) };
+}
+
+// ---------------------------------------------------------------------------
 // Domain entry point (required by crux.mjs dispatch)
 // ---------------------------------------------------------------------------
 
 export const commands = {
   write,
+  list,
 };
 
 export function getHelp(): string {
   return `
-Sessions Domain — Create and manage agent session log YAML files
+Sessions Domain — Agent sessions: list active, write session logs
 
 Commands:
+  list [options]            List active agent sessions across all slots (QUA-413)
   write <title> [options]   Scaffold a session YAML in .claude/sessions/
 
-Options:
+List options:
+  --all                     Include completed sessions (default: active only)
+  --linear=QUA-NNN          Filter by Linear ID
+  --slot=N                  Filter by slot number
+  --fresh=N                 Staleness cutoff in minutes (default: 30)
+  --live-minutes=N          "Live" threshold in minutes (default: 2)
+  --limit=N                 Max DB rows to fetch (default: 200, cap 500)
+  --json                    Machine-readable JSON output
+
+Write options:
   --title=<text>            Session title (alternative to positional arg)
   --summary=<text>          Short summary of what was done
   --model=<name>            Model used (e.g. claude-sonnet-4-6)
@@ -232,8 +391,10 @@ Options:
   --output=<path>           Custom output path (default: .claude/sessions/<date>_<branch>.yaml)
 
 Examples:
+  pnpm crux sys sessions list
+  pnpm crux sys sessions list --all --linear=QUA-413
+  pnpm crux sys sessions list --slot=9 --json
   pnpm crux sys sessions write "Fix citation parser bug"
   pnpm crux sys sessions write "Add dark mode" --model=claude-sonnet-4-6 --duration="~45min"
-  pnpm crux sys sessions write "Update AI timelines page" --pages=ai-timelines,ai-forecasting --sync
 `.trim();
 }

--- a/crux/commands/sessions.ts
+++ b/crux/commands/sessions.ts
@@ -15,12 +15,14 @@
 
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { createLogger } from '../lib/output.ts';
+import { createLogger, type Colors } from '../lib/output.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { syncSessionFile } from '../wiki-server/sync-session.ts';
 import { isServerAvailable } from '../lib/wiki-server/client.ts';
 import { listAgentSessions } from '../lib/wiki-server/agent-sessions.ts';
+// NOTE: isServerAvailable is used by `write`; `list` relies on listAgentSessions'
+// structured unavailable-error path to avoid an extra round-trip.
 import { findClaudeProcesses } from '../lib/session/claude-processes.ts';
 import {
   mergeSessions,
@@ -231,7 +233,7 @@ const LIVENESS_BADGE: Record<Liveness, string> = {
   done: '✓',
 };
 
-function livenessColor(liveness: Liveness, c: ReturnType<typeof createLogger>['colors']): string {
+function livenessColor(liveness: Liveness, c: Colors): string {
   switch (liveness) {
     case 'live':
       return c.green;
@@ -256,7 +258,7 @@ function livenessColor(liveness: Liveness, c: ReturnType<typeof createLogger>['c
 
 function renderTable(
   rows: MergedSession[],
-  colors: ReturnType<typeof createLogger>['colors'],
+  colors: Colors,
 ): string {
   if (rows.length === 0) {
     return `${colors.dim}No sessions match the filter.${colors.reset}\n`;
@@ -294,73 +296,77 @@ function renderTable(
   return out;
 }
 
-/** Parse `--slot=N` with explicit error on malformed input. */
-function parseSlotOption(raw: unknown): { ok: true; slot: number | undefined } | { ok: false; error: string } {
-  if (raw === undefined) return { ok: true, slot: undefined };
+/** Parse a non-negative integer option. Returns error string on malformed input. */
+function parseIntOption(
+  raw: unknown,
+  name: string,
+): { ok: true; value: number | undefined } | { ok: false; error: string } {
+  if (raw === undefined) return { ok: true, value: undefined };
   const n = Number(raw);
   if (!Number.isInteger(n) || n < 0) {
-    return { ok: false, error: `--slot must be a non-negative integer, got: ${String(raw)}` };
+    return { ok: false, error: `${name} must be a non-negative integer, got: ${String(raw)}` };
   }
-  return { ok: true, slot: n };
+  return { ok: true, value: n };
 }
 
 async function list(_args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const log = createLogger(options.ci as boolean | undefined);
   const c = log.colors;
 
-  // Validate --slot early so a typo like --slot=abc surfaces immediately
-  // instead of silently returning an unfiltered table.
-  const slotOpt = parseSlotOption(options.slot);
-  if (!slotOpt.ok) {
-    return { exitCode: 2, output: `${c.red}Error: ${slotOpt.error}${c.reset}\n` };
-  }
+  // Validate numeric options up front so typos like --slot=abc or --limit=xyz
+  // surface as errors instead of silently coercing to defaults or NaN.
+  const slotOpt = parseIntOption(options.slot, '--slot');
+  if (!slotOpt.ok) return { exitCode: 2, output: `${c.red}Error: ${slotOpt.error}${c.reset}\n` };
 
-  // Fetch DB sessions (may fail if wiki-server is unreachable) and scan local
-  // processes in parallel. Failure of either is degraded-but-still-useful:
-  // DB-only data or scan-only data both give the coordinator partial signal.
-  const serverUp = await isServerAvailable();
-  const limit = Number(options.limit ?? 200);
-  const boundedLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 500) : 200;
-  const dbPromise = serverUp ? listAgentSessions(boundedLimit) : null;
+  const limitOpt = parseIntOption(options.limit, '--limit');
+  if (!limitOpt.ok) return { exitCode: 2, output: `${c.red}Error: ${limitOpt.error}${c.reset}\n` };
+  const limit = Math.min(limitOpt.value ?? 200, 500);
+
+  // DB fetch and process scan kick off together. listAgentSessions returns
+  // `{ok:false, error:'unavailable'}` on network failure, so no pre-probe is
+  // needed — the discriminated error is enough to emit the right warning.
+  // (The scan is execSync-based and blocks the event loop, so "parallel" is
+  // aspirational; see follow-up for execFile conversion.)
+  const dbPromise = listAgentSessions(limit);
   const scan = findClaudeProcesses();
-  const dbResult = dbPromise ? await dbPromise : null;
+  const dbResult = await dbPromise;
 
-  const sessions = dbResult?.ok ? dbResult.data.sessions : [];
+  const sessions = dbResult.ok ? dbResult.data.sessions : [];
   const warnings: string[] = [];
-  if (!serverUp) {
-    warnings.push(
-      'wiki-server unreachable — showing local Claude processes only (no DB session data). ' +
-        'In agent slots, set WIKI_SERVER_ENV=prod.',
-    );
-  } else if (dbResult && !dbResult.ok) {
-    warnings.push(`DB fetch failed: ${dbResult.message}. Showing local process data only.`);
+  if (!dbResult.ok) {
+    if (dbResult.error === 'unavailable') {
+      warnings.push(
+        'wiki-server unreachable — showing local Claude processes only (no DB session data). ' +
+          'In agent slots, set WIKI_SERVER_ENV=prod.',
+      );
+    } else {
+      warnings.push(`DB fetch failed (${dbResult.error}): ${dbResult.message}. Showing local process data only.`);
+    }
   }
-  if (scan.scanFailed) {
+  if (scan.scanError !== null) {
     warnings.push(
       `process scan failed (${scan.scanError}). Ghost detection disabled — a live session without a DB row won't be visible.`,
     );
   }
 
   const liveMinutes = options.liveMinutes !== undefined ? Number(options.liveMinutes) : undefined;
-  const staleMinutes = options.fresh !== undefined ? Number(options.fresh) : undefined;
+  const staleMinutes = options.staleMinutes !== undefined ? Number(options.staleMinutes) : undefined;
 
-  const merged = mergeSessions(sessions, scan.processes, {
-    liveMinutes,
-    staleMinutes,
-  });
+  const merged = mergeSessions(sessions, scan.processes, { liveMinutes, staleMinutes });
 
+  const includeCompleted = Boolean(options.all);
   const filterLinear = typeof options.linear === 'string' ? options.linear : undefined;
 
   const filtered = filterSessions(merged, {
-    includeCompleted: Boolean(options.all),
+    includeCompleted,
     linearId: filterLinear,
-    slot: slotOpt.slot,
+    slot: slotOpt.value,
   });
 
   const sorted = sortSessions(filtered);
 
   if (options.json) {
-    // Shape the JSON output with explicit fields a coordinator might script against.
+    // Consistent shape so scripts don't have to branch on warnings presence.
     const jsonRows = sorted.map((r) => ({
       slot: r.session?.slotNumber ?? r.process?.slot ?? null,
       pid: r.process?.pid ?? null,
@@ -378,13 +384,13 @@ async function list(_args: string[], options: Record<string, unknown>): Promise<
       startedAt: r.session?.startedAt ?? null,
       sessionId: r.session?.id ?? null,
     }));
-    const payload = warnings.length > 0
-      ? { warnings, sessions: jsonRows }
-      : jsonRows;
-    return { exitCode: 0, output: JSON.stringify(payload, null, 2) + '\n' };
+    return {
+      exitCode: 0,
+      output: JSON.stringify({ warnings, sessions: jsonRows }, null, 2) + '\n',
+    };
   }
 
-  const header = `${c.bold}Agent Sessions${c.reset} ${c.dim}(${sorted.length} row${sorted.length === 1 ? '' : 's'}${Boolean(options.all) ? '' : ', active only'})${c.reset}\n\n`;
+  const header = `${c.bold}Agent Sessions${c.reset} ${c.dim}(${sorted.length} row${sorted.length === 1 ? '' : 's'}${includeCompleted ? '' : ', active only'})${c.reset}\n\n`;
   const warningBanner = warnings.length > 0
     ? warnings.map((w) => `  ${c.yellow}⚠ ${w}${c.reset}`).join('\n') + '\n\n'
     : '';
@@ -412,8 +418,8 @@ List options:
   --all                     Include completed sessions (default: active only)
   --linear=QUA-NNN          Filter by Linear ID
   --slot=N                  Filter by slot number
-  --fresh=N                 Staleness cutoff in minutes (default: 30)
-  --live-minutes=N          "Live" threshold in minutes (default: 2)
+  --stale-minutes=N         Staleness cutoff (default: 30)
+  --live-minutes=N          "Live" threshold (default: 2)
   --limit=N                 Max DB rows to fetch (default: 200, cap 500)
   --json                    Machine-readable JSON output
 

--- a/crux/lib/session/claude-processes.test.ts
+++ b/crux/lib/session/claude-processes.test.ts
@@ -119,44 +119,52 @@ describe('findClaudeProcesses — integration (mocked shell)', () => {
       if (cmd.startsWith('lsof ')) return lsof;
       throw new Error(`unexpected: ${cmd}`);
     };
-    expect(findClaudeProcesses({ execCmd })).toEqual([
+    const result = findClaudeProcesses({ execCmd });
+    expect(result.scanFailed).toBe(false);
+    expect(result.processes).toEqual([
       { pid: 95223, cwd: '/Users/dev/lw/a9', slot: 9 },
     ]);
   });
 
-  it('returns [] when no Claude processes found (skips lsof entirely)', () => {
+  it('returns empty scan-succeeded result when no Claude processes found (skips lsof entirely)', () => {
     const calls: string[] = [];
     const execCmd = (cmd: string) => {
       calls.push(cmd);
       if (cmd.startsWith('ps ')) return '  1 /sbin/launchd\n';
       throw new Error('lsof should not be called');
     };
-    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+    const result = findClaudeProcesses({ execCmd });
+    expect(result).toEqual({ processes: [], scanFailed: false, scanError: '' });
     expect(calls).toHaveLength(1); // only ps, never lsof
   });
 
-  it('returns [] when ps fails', () => {
+  it('marks scanFailed=true when ps fails', () => {
     const execCmd = (cmd: string) => {
       if (cmd.startsWith('ps ')) throw new Error('ps: command not found');
       throw new Error('unreachable');
     };
-    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+    const result = findClaudeProcesses({ execCmd });
+    expect(result.scanFailed).toBe(true);
+    expect(result.scanError).toContain('ps failed');
+    expect(result.processes).toEqual([]);
   });
 
-  it('returns [] when lsof fails after ps succeeds (no partial results)', () => {
+  it('marks scanFailed=true when lsof fails after ps succeeds (no partial results)', () => {
     const execCmd = (cmd: string) => {
       if (cmd.startsWith('ps ')) return '  1 claude\n';
       throw new Error('lsof: permission denied');
     };
-    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+    const result = findClaudeProcesses({ execCmd });
+    expect(result.scanFailed).toBe(true);
+    expect(result.scanError).toContain('lsof failed');
+    expect(result.processes).toEqual([]);
   });
 
   it('marks cwd outside slot dirs with slot=null', () => {
     const ps = '  1 claude\n';
     const lsof = 'p1\nfcwd\nn/tmp\n';
     const execCmd = (cmd: string) => (cmd.startsWith('ps ') ? ps : lsof);
-    expect(findClaudeProcesses({ execCmd })).toEqual([
-      { pid: 1, cwd: '/tmp', slot: null },
-    ]);
+    const result = findClaudeProcesses({ execCmd });
+    expect(result.processes).toEqual([{ pid: 1, cwd: '/tmp', slot: null }]);
   });
 });

--- a/crux/lib/session/claude-processes.test.ts
+++ b/crux/lib/session/claude-processes.test.ts
@@ -28,10 +28,13 @@ describe('slotFromPath', () => {
     expect(slotFromPath('/Users/dev/alpha/src')).toBeNull();
   });
 
-  it('returns the innermost slot when nested (takes the first a<N> walking leaf→root)', () => {
-    // Unusual but defensible behavior: the first a<N> segment in path order
-    // is typically the outermost slot directory.
-    expect(slotFromPath('/Users/dev/a5/nested/a9/src')).toBe(5);
+  it('returns the innermost slot when nested (walks leaf→root)', () => {
+    // Matches session-context.ts::findSlotFromAncestors: if a process is
+    // running deep inside a slot directory, the slot closest to the cwd
+    // wins. Rare in practice (no one nests slots).
+    expect(slotFromPath('/Users/dev/a5/nested/a9/src')).toBe(9);
+    expect(slotFromPath('/Users/dev/lw/a9')).toBe(9);
+    expect(slotFromPath('/Users/dev/lw/a9/apps/web')).toBe(9);
   });
 });
 

--- a/crux/lib/session/claude-processes.test.ts
+++ b/crux/lib/session/claude-processes.test.ts
@@ -4,39 +4,13 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  slotFromPath,
   findClaudePids,
   parseLsofFpn,
   findClaudeProcesses,
 } from './claude-processes.ts';
 
-describe('slotFromPath', () => {
-  it('extracts slot number from a typical slot path', () => {
-    expect(slotFromPath('/Users/dev/lw/a9')).toBe(9);
-    expect(slotFromPath('/Users/dev/lw/a15/apps/web')).toBe(15);
-  });
-
-  it('returns null when no a<N> ancestor exists', () => {
-    expect(slotFromPath('/tmp/foo')).toBeNull();
-    expect(slotFromPath('/')).toBeNull();
-    expect(slotFromPath('')).toBeNull();
-  });
-
-  it('rejects non-slot a-prefixed directories', () => {
-    // "apps" or "alpha" shouldn't match — only bare a<digits>
-    expect(slotFromPath('/Users/dev/apps/web')).toBeNull();
-    expect(slotFromPath('/Users/dev/alpha/src')).toBeNull();
-  });
-
-  it('returns the innermost slot when nested (walks leaf→root)', () => {
-    // Matches session-context.ts::findSlotFromAncestors: if a process is
-    // running deep inside a slot directory, the slot closest to the cwd
-    // wins. Rare in practice (no one nests slots).
-    expect(slotFromPath('/Users/dev/a5/nested/a9/src')).toBe(9);
-    expect(slotFromPath('/Users/dev/lw/a9')).toBe(9);
-    expect(slotFromPath('/Users/dev/lw/a9/apps/web')).toBe(9);
-  });
-});
+// Slot resolution is tested in session-context.test.ts —
+// claude-processes.ts reuses findSlotFromAncestors from there.
 
 describe('findClaudePids', () => {
   it('matches Claude Code installed binary path', () => {
@@ -120,13 +94,13 @@ describe('findClaudeProcesses — integration (mocked shell)', () => {
       throw new Error(`unexpected: ${cmd}`);
     };
     const result = findClaudeProcesses({ execCmd });
-    expect(result.scanFailed).toBe(false);
+    expect(result.scanError).toBeNull();
     expect(result.processes).toEqual([
       { pid: 95223, cwd: '/Users/dev/lw/a9', slot: 9 },
     ]);
   });
 
-  it('returns empty scan-succeeded result when no Claude processes found (skips lsof entirely)', () => {
+  it('returns empty success when no Claude processes found (skips lsof entirely)', () => {
     const calls: string[] = [];
     const execCmd = (cmd: string) => {
       calls.push(cmd);
@@ -134,28 +108,26 @@ describe('findClaudeProcesses — integration (mocked shell)', () => {
       throw new Error('lsof should not be called');
     };
     const result = findClaudeProcesses({ execCmd });
-    expect(result).toEqual({ processes: [], scanFailed: false, scanError: '' });
-    expect(calls).toHaveLength(1); // only ps, never lsof
+    expect(result).toEqual({ processes: [], scanError: null });
+    expect(calls).toHaveLength(1);
   });
 
-  it('marks scanFailed=true when ps fails', () => {
+  it('reports scanError when ps fails', () => {
     const execCmd = (cmd: string) => {
       if (cmd.startsWith('ps ')) throw new Error('ps: command not found');
       throw new Error('unreachable');
     };
     const result = findClaudeProcesses({ execCmd });
-    expect(result.scanFailed).toBe(true);
     expect(result.scanError).toContain('ps failed');
     expect(result.processes).toEqual([]);
   });
 
-  it('marks scanFailed=true when lsof fails after ps succeeds (no partial results)', () => {
+  it('reports scanError when lsof fails after ps succeeds (no partial results)', () => {
     const execCmd = (cmd: string) => {
       if (cmd.startsWith('ps ')) return '  1 claude\n';
       throw new Error('lsof: permission denied');
     };
     const result = findClaudeProcesses({ execCmd });
-    expect(result.scanFailed).toBe(true);
     expect(result.scanError).toContain('lsof failed');
     expect(result.processes).toEqual([]);
   });

--- a/crux/lib/session/claude-processes.test.ts
+++ b/crux/lib/session/claude-processes.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the Claude Code process scanner (QUA-413).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  slotFromPath,
+  findClaudePids,
+  parseLsofFpn,
+  findClaudeProcesses,
+} from './claude-processes.ts';
+
+describe('slotFromPath', () => {
+  it('extracts slot number from a typical slot path', () => {
+    expect(slotFromPath('/Users/dev/lw/a9')).toBe(9);
+    expect(slotFromPath('/Users/dev/lw/a15/apps/web')).toBe(15);
+  });
+
+  it('returns null when no a<N> ancestor exists', () => {
+    expect(slotFromPath('/tmp/foo')).toBeNull();
+    expect(slotFromPath('/')).toBeNull();
+    expect(slotFromPath('')).toBeNull();
+  });
+
+  it('rejects non-slot a-prefixed directories', () => {
+    // "apps" or "alpha" shouldn't match — only bare a<digits>
+    expect(slotFromPath('/Users/dev/apps/web')).toBeNull();
+    expect(slotFromPath('/Users/dev/alpha/src')).toBeNull();
+  });
+
+  it('returns the innermost slot when nested (takes the first a<N> walking leaf→root)', () => {
+    // Unusual but defensible behavior: the first a<N> segment in path order
+    // is typically the outermost slot directory.
+    expect(slotFromPath('/Users/dev/a5/nested/a9/src')).toBe(5);
+  });
+});
+
+describe('findClaudePids', () => {
+  it('matches Claude Code installed binary path', () => {
+    const ps = `
+   95223 /Users/dev/.local/share/claude/versions/2.1.112
+   12345 node /path/to/something
+    `.trim();
+    expect(findClaudePids(ps)).toEqual([95223]);
+  });
+
+  it('matches bare `claude` wrapper invocation', () => {
+    const ps = `
+   54321 claude
+   55555 claude --help
+    `.trim();
+    expect(findClaudePids(ps)).toEqual([54321, 55555]);
+  });
+
+  it('excludes the scanner pipeline itself (ps, grep, lsof)', () => {
+    const ps = `
+   1000 ps -eo pid=,args=
+   1001 grep claude
+   1002 lsof -a -p 1000 -d cwd
+   1003 claude
+    `.trim();
+    expect(findClaudePids(ps)).toEqual([1003]);
+  });
+
+  it('ignores unrelated processes mentioning "claude" in paths', () => {
+    const ps = `
+   2000 /usr/bin/node /Users/dev/some/file-about-claude.js
+   2001 /bin/cat /tmp/claude-notes.txt
+    `.trim();
+    // These don't match CLAUDE_PROCESS_RE because the word "claude" isn't
+    // preceded by whitespace-start followed by nothing-or-whitespace. They'd
+    // only match if args were literally "claude" or contained `/share/claude/versions/`.
+    expect(findClaudePids(ps)).toEqual([]);
+  });
+
+  it('ignores blank lines and malformed rows', () => {
+    const ps = '\n\n   \n12345\nno-pid-here\n';
+    expect(findClaudePids(ps)).toEqual([]);
+  });
+});
+
+describe('parseLsofFpn', () => {
+  it('parses multi-process output with p/n tags', () => {
+    const raw = 'p95223\nfcwd\nn/Users/dev/lw/a9\np38772\nfcwd\nn/Users/dev/lw/a4\n';
+    expect(parseLsofFpn(raw)).toEqual([
+      { pid: 95223, cwd: '/Users/dev/lw/a9' },
+      { pid: 38772, cwd: '/Users/dev/lw/a4' },
+    ]);
+  });
+
+  it('ignores the fcwd fd-tag line between pid and name', () => {
+    // The fcwd line (f<type>) is present in real output; we skip it silently
+    // because the parser only acts on p/n tags.
+    const raw = 'p1\nf cwd\nn/a\n';
+    expect(parseLsofFpn(raw)).toEqual([{ pid: 1, cwd: '/a' }]);
+  });
+
+  it('returns [] on empty or malformed input', () => {
+    expect(parseLsofFpn('')).toEqual([]);
+    expect(parseLsofFpn('garbage\nno tags here\n')).toEqual([]);
+    expect(parseLsofFpn('nMissingPid\n')).toEqual([]);
+  });
+
+  it('skips invalid pids', () => {
+    const raw = 'pNotANumber\nn/foo\np0\nn/bar\np123\nn/baz\n';
+    expect(parseLsofFpn(raw)).toEqual([{ pid: 123, cwd: '/baz' }]);
+  });
+});
+
+describe('findClaudeProcesses — integration (mocked shell)', () => {
+  it('combines ps + lsof to produce ClaudeProcess[]', () => {
+    const ps = '  95223 /Users/dev/.local/share/claude/versions/2.1.112\n';
+    const lsof = 'p95223\nfcwd\nn/Users/dev/lw/a9\n';
+    const execCmd = (cmd: string) => {
+      if (cmd.startsWith('ps ')) return ps;
+      if (cmd.startsWith('lsof ')) return lsof;
+      throw new Error(`unexpected: ${cmd}`);
+    };
+    expect(findClaudeProcesses({ execCmd })).toEqual([
+      { pid: 95223, cwd: '/Users/dev/lw/a9', slot: 9 },
+    ]);
+  });
+
+  it('returns [] when no Claude processes found (skips lsof entirely)', () => {
+    const calls: string[] = [];
+    const execCmd = (cmd: string) => {
+      calls.push(cmd);
+      if (cmd.startsWith('ps ')) return '  1 /sbin/launchd\n';
+      throw new Error('lsof should not be called');
+    };
+    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+    expect(calls).toHaveLength(1); // only ps, never lsof
+  });
+
+  it('returns [] when ps fails', () => {
+    const execCmd = (cmd: string) => {
+      if (cmd.startsWith('ps ')) throw new Error('ps: command not found');
+      throw new Error('unreachable');
+    };
+    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+  });
+
+  it('returns [] when lsof fails after ps succeeds (no partial results)', () => {
+    const execCmd = (cmd: string) => {
+      if (cmd.startsWith('ps ')) return '  1 claude\n';
+      throw new Error('lsof: permission denied');
+    };
+    expect(findClaudeProcesses({ execCmd })).toEqual([]);
+  });
+
+  it('marks cwd outside slot dirs with slot=null', () => {
+    const ps = '  1 claude\n';
+    const lsof = 'p1\nfcwd\nn/tmp\n';
+    const execCmd = (cmd: string) => (cmd.startsWith('ps ') ? ps : lsof);
+    expect(findClaudeProcesses({ execCmd })).toEqual([
+      { pid: 1, cwd: '/tmp', slot: null },
+    ]);
+  });
+});

--- a/crux/lib/session/claude-processes.ts
+++ b/crux/lib/session/claude-processes.ts
@@ -22,6 +22,7 @@
  */
 
 import { execSync } from 'child_process';
+import { findSlotFromAncestors } from './session-context.ts';
 
 export interface ClaudeProcess {
   pid: number;
@@ -32,23 +33,6 @@ export interface ClaudeProcess {
 
 export interface ProcessScanDeps {
   execCmd?: (cmd: string) => string;
-}
-
-/**
- * Walk the path segments leaf→root looking for an `a<N>` directory basename.
- * Returns the slot number or null. Matches `findSlotFromAncestors` in
- * session-context.ts so both agree on the (rare) nested-slot edge case.
- */
-export function slotFromPath(path: string): number | null {
-  const parts = path.split('/').filter(Boolean);
-  for (let i = parts.length - 1; i >= 0; i--) {
-    const m = parts[i].match(/^a(\d+)$/);
-    if (m) {
-      const n = Number.parseInt(m[1], 10);
-      if (Number.isSafeInteger(n)) return n;
-    }
-  }
-  return null;
 }
 
 /**
@@ -104,21 +88,19 @@ export function parseLsofFpn(raw: string): Array<{ pid: number; cwd: string }> {
 export interface ProcessScanResult {
   processes: ClaudeProcess[];
   /**
-   * True when the scan could not complete (ps/lsof missing, timeout, permission
-   * denied). Callers must distinguish this from "no processes found" because
-   * a silent scan failure would give a coordinator a false "no ghosts" signal
-   * — exactly the QUA-413 failure mode this command is meant to prevent.
+   * Null when the scan ran successfully (with 0+ processes found). Non-null
+   * when the scan could not complete (ps/lsof missing, timeout, permission
+   * denied). Callers must distinguish this from "no processes found" — a
+   * silent scan failure would give a coordinator a false "no ghosts" signal,
+   * exactly the QUA-413 failure mode this command is meant to prevent.
    */
-  scanFailed: boolean;
-  /** Short reason string for user-facing display. Empty when scanFailed=false. */
-  scanError: string;
+  scanError: string | null;
 }
 
 /**
  * List all running Claude Code processes and their working directories.
- * Returns `{ processes: [], scanFailed: true }` when the scan itself couldn't
- * run (ps/lsof missing, timeout). Returns `{ processes: [], scanFailed: false }`
- * when the scan ran but found nothing.
+ * On failure returns `{ processes: [], scanError: '<reason>' }`. On success
+ * with nothing found, returns `{ processes: [], scanError: null }`.
  */
 export function findClaudeProcesses(deps: ProcessScanDeps = {}): ProcessScanResult {
   const exec =
@@ -135,11 +117,11 @@ export function findClaudeProcesses(deps: ProcessScanDeps = {}): ProcessScanResu
   try {
     psOut = exec('ps -eo pid=,args=');
   } catch (e) {
-    return { processes: [], scanFailed: true, scanError: `ps failed: ${errMsg(e)}` };
+    return { processes: [], scanError: `ps failed: ${errMsg(e)}` };
   }
   const pids = findClaudePids(psOut);
   if (pids.length === 0) {
-    return { processes: [], scanFailed: false, scanError: '' };
+    return { processes: [], scanError: null };
   }
 
   // Step 2: lsof for CWD. Must use `-a` to AND the `-p` and `-d` filters on
@@ -149,13 +131,12 @@ export function findClaudeProcesses(deps: ProcessScanDeps = {}): ProcessScanResu
   try {
     lsofOut = exec(`lsof -a -p ${pids.join(',')} -d cwd -Fpn`);
   } catch (e) {
-    return { processes: [], scanFailed: true, scanError: `lsof failed: ${errMsg(e)}` };
+    return { processes: [], scanError: `lsof failed: ${errMsg(e)}` };
   }
   const pairs = parseLsofFpn(lsofOut);
   return {
-    processes: pairs.map(({ pid, cwd }) => ({ pid, cwd, slot: slotFromPath(cwd) })),
-    scanFailed: false,
-    scanError: '',
+    processes: pairs.map(({ pid, cwd }) => ({ pid, cwd, slot: findSlotFromAncestors(cwd) })),
+    scanError: null,
   };
 }
 

--- a/crux/lib/session/claude-processes.ts
+++ b/crux/lib/session/claude-processes.ts
@@ -101,13 +101,26 @@ export function parseLsofFpn(raw: string): Array<{ pid: number; cwd: string }> {
   return out;
 }
 
+export interface ProcessScanResult {
+  processes: ClaudeProcess[];
+  /**
+   * True when the scan could not complete (ps/lsof missing, timeout, permission
+   * denied). Callers must distinguish this from "no processes found" because
+   * a silent scan failure would give a coordinator a false "no ghosts" signal
+   * — exactly the QUA-413 failure mode this command is meant to prevent.
+   */
+  scanFailed: boolean;
+  /** Short reason string for user-facing display. Empty when scanFailed=false. */
+  scanError: string;
+}
+
 /**
  * List all running Claude Code processes and their working directories.
- * Returns [] on any failure (ps missing, lsof missing, permission denied,
- * or no matching processes). Best-effort — the command degrades gracefully
- * to DB-only data.
+ * Returns `{ processes: [], scanFailed: true }` when the scan itself couldn't
+ * run (ps/lsof missing, timeout). Returns `{ processes: [], scanFailed: false }`
+ * when the scan ran but found nothing.
  */
-export function findClaudeProcesses(deps: ProcessScanDeps = {}): ClaudeProcess[] {
+export function findClaudeProcesses(deps: ProcessScanDeps = {}): ProcessScanResult {
   const exec =
     deps.execCmd ??
     ((cmd: string) =>
@@ -121,11 +134,13 @@ export function findClaudeProcesses(deps: ProcessScanDeps = {}): ClaudeProcess[]
   let psOut = '';
   try {
     psOut = exec('ps -eo pid=,args=');
-  } catch {
-    return [];
+  } catch (e) {
+    return { processes: [], scanFailed: true, scanError: `ps failed: ${errMsg(e)}` };
   }
   const pids = findClaudePids(psOut);
-  if (pids.length === 0) return [];
+  if (pids.length === 0) {
+    return { processes: [], scanFailed: false, scanError: '' };
+  }
 
   // Step 2: lsof for CWD. Must use `-a` to AND the `-p` and `-d` filters on
   // macOS — without it, lsof ORs the filters and returns every process.
@@ -133,9 +148,18 @@ export function findClaudeProcesses(deps: ProcessScanDeps = {}): ClaudeProcess[]
   let lsofOut = '';
   try {
     lsofOut = exec(`lsof -a -p ${pids.join(',')} -d cwd -Fpn`);
-  } catch {
-    return [];
+  } catch (e) {
+    return { processes: [], scanFailed: true, scanError: `lsof failed: ${errMsg(e)}` };
   }
   const pairs = parseLsofFpn(lsofOut);
-  return pairs.map(({ pid, cwd }) => ({ pid, cwd, slot: slotFromPath(cwd) }));
+  return {
+    processes: pairs.map(({ pid, cwd }) => ({ pid, cwd, slot: slotFromPath(cwd) })),
+    scanFailed: false,
+    scanError: '',
+  };
+}
+
+function errMsg(e: unknown): string {
+  if (e instanceof Error) return e.message.slice(0, 200);
+  return String(e).slice(0, 200);
 }

--- a/crux/lib/session/claude-processes.ts
+++ b/crux/lib/session/claude-processes.ts
@@ -1,0 +1,141 @@
+/**
+ * Claude Code process scanner — live cross-reference for `crux sys sessions list`.
+ *
+ * The PG `agent_sessions` table is the authoritative source of truth for who's
+ * working on what, but it trusts sessions to register themselves via
+ * `agent-checklist init`. A crashed or never-init'd Claude Code process leaves
+ * no DB trace. This module scans the local `ps` table for Claude Code
+ * processes and resolves their CWD via `lsof` so `sessions list` can flag:
+ *
+ *   - DB rows without a matching live process  (stale/dead)
+ *   - Live processes without a DB row           (untracked — init was skipped)
+ *
+ * Two-step scan because `lsof -c claude` does not match Claude Code on macOS:
+ * the installer delivers a versioned native binary at
+ * `~/.local/share/claude/versions/<version>` and the process's command name
+ * is the version string ("2.1.112"), not "claude". We identify Claude Code
+ * processes by their args containing `/share/claude/versions/` (installed
+ * binary path) OR by a bare `claude` args line (the wrapper script).
+ *
+ * Darwin and Linux are supported. Fails open (returns []) on any error — the
+ * command must still be useful without live data.
+ */
+
+import { execSync } from 'child_process';
+
+export interface ClaudeProcess {
+  pid: number;
+  cwd: string;
+  /** Slot number (a<N>) derived from the cwd ancestor walk, or null. */
+  slot: number | null;
+}
+
+export interface ProcessScanDeps {
+  execCmd?: (cmd: string) => string;
+}
+
+/**
+ * Walk the path segments looking for an `a<N>` directory basename. Returns
+ * the slot number or null. Mirrors `findSlotFromAncestors` in session-context.ts
+ * but operates on an arbitrary path string rather than `process.cwd()`.
+ */
+export function slotFromPath(path: string): number | null {
+  const parts = path.split('/').filter(Boolean);
+  for (const part of parts) {
+    const m = part.match(/^a(\d+)$/);
+    if (m) {
+      const n = Number.parseInt(m[1], 10);
+      if (Number.isSafeInteger(n)) return n;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pattern for a Claude Code process in `ps` args output. Matches either:
+ *   - the installed binary path (`.../share/claude/versions/<version>`)
+ *   - a bare `claude` wrapper invocation (the CLI symlink)
+ *
+ * Deliberately strict: `grep claude`, `tsc claude.ts`, and other tools
+ * mentioning the word in arguments must not match. `\bclaude\b` inside a
+ * longer grep arg line is caught by the `/share/claude/versions/` clause
+ * only when the binary path is literally present.
+ */
+const CLAUDE_PROCESS_RE =
+  /(?:\/share\/claude\/versions\/|(?:^|\s)claude(?:\s|$))/;
+
+/** Extract PIDs from `ps -eo pid=,args=` output that look like Claude Code. */
+export function findClaudePids(psOutput: string): number[] {
+  const pids: number[] = [];
+  for (const line of psOutput.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const m = trimmed.match(/^(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const pid = Number.parseInt(m[1], 10);
+    const args = m[2];
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+    // Self-exclusion: don't match `ps` or its pipeline itself.
+    if (/^(ps|grep|lsof)\b/.test(args)) continue;
+    if (CLAUDE_PROCESS_RE.test(args)) pids.push(pid);
+  }
+  return pids;
+}
+
+/** Parse `lsof -a -p <pids> -d cwd -Fpn` output into {pid, cwd} pairs. */
+export function parseLsofFpn(raw: string): Array<{ pid: number; cwd: string }> {
+  const out: Array<{ pid: number; cwd: string }> = [];
+  let pid: number | null = null;
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    const tag = line[0];
+    const rest = line.slice(1);
+    if (tag === 'p') {
+      const n = Number.parseInt(rest, 10);
+      pid = Number.isSafeInteger(n) && n > 0 ? n : null;
+    } else if (tag === 'n' && pid !== null) {
+      out.push({ pid, cwd: rest });
+      pid = null;
+    }
+  }
+  return out;
+}
+
+/**
+ * List all running Claude Code processes and their working directories.
+ * Returns [] on any failure (ps missing, lsof missing, permission denied,
+ * or no matching processes). Best-effort — the command degrades gracefully
+ * to DB-only data.
+ */
+export function findClaudeProcesses(deps: ProcessScanDeps = {}): ClaudeProcess[] {
+  const exec =
+    deps.execCmd ??
+    ((cmd: string) =>
+      execSync(cmd, {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      }));
+
+  // Step 1: ps to find candidate PIDs.
+  let psOut = '';
+  try {
+    psOut = exec('ps -eo pid=,args=');
+  } catch {
+    return [];
+  }
+  const pids = findClaudePids(psOut);
+  if (pids.length === 0) return [];
+
+  // Step 2: lsof for CWD. Must use `-a` to AND the `-p` and `-d` filters on
+  // macOS — without it, lsof ORs the filters and returns every process.
+  // Comma-separated PID list is supported on both Darwin and Linux.
+  let lsofOut = '';
+  try {
+    lsofOut = exec(`lsof -a -p ${pids.join(',')} -d cwd -Fpn`);
+  } catch {
+    return [];
+  }
+  const pairs = parseLsofFpn(lsofOut);
+  return pairs.map(({ pid, cwd }) => ({ pid, cwd, slot: slotFromPath(cwd) }));
+}

--- a/crux/lib/session/claude-processes.ts
+++ b/crux/lib/session/claude-processes.ts
@@ -35,14 +35,14 @@ export interface ProcessScanDeps {
 }
 
 /**
- * Walk the path segments looking for an `a<N>` directory basename. Returns
- * the slot number or null. Mirrors `findSlotFromAncestors` in session-context.ts
- * but operates on an arbitrary path string rather than `process.cwd()`.
+ * Walk the path segments leaf→root looking for an `a<N>` directory basename.
+ * Returns the slot number or null. Matches `findSlotFromAncestors` in
+ * session-context.ts so both agree on the (rare) nested-slot edge case.
  */
 export function slotFromPath(path: string): number | null {
   const parts = path.split('/').filter(Boolean);
-  for (const part of parts) {
-    const m = part.match(/^a(\d+)$/);
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const m = parts[i].match(/^a(\d+)$/);
     if (m) {
       const n = Number.parseInt(m[1], 10);
       if (Number.isSafeInteger(n)) return n;

--- a/crux/lib/session/session-context.ts
+++ b/crux/lib/session/session-context.ts
@@ -66,7 +66,7 @@ function readIntFile(
  * subdirectories of their slot (apps/web, crux, etc.) — without this walk,
  * the slot field would silently go missing from start comments.
  */
-function findSlotFromAncestors(cwd: string): number | null {
+export function findSlotFromAncestors(cwd: string): number | null {
   let current = cwd;
   for (let i = 0; i < 10; i++) {
     const match = basename(current).match(/^a(\d+)$/);

--- a/crux/lib/session/sessions-list.test.ts
+++ b/crux/lib/session/sessions-list.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for the cross-session observability merge/filter/format logic
+ * underneath `crux sys sessions list` (QUA-413).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  mergeSessions,
+  filterSessions,
+  sortSessions,
+  toDisplayRow,
+  formatAge,
+  formatPr,
+  truncate,
+  type MergedSession,
+} from './sessions-list.ts';
+import type { AgentSessionListResponse } from '../wiki-server/agent-sessions.ts';
+import type { ClaudeProcess } from './claude-processes.ts';
+
+type DbSession = AgentSessionListResponse['sessions'][number];
+
+const NOW = new Date('2026-04-18T20:30:00Z').getTime();
+
+function mkSession(partial: Partial<DbSession>): DbSession {
+  // Build a minimal row with the columns our code actually reads. Other
+  // fields are present in the real response but unused here — we cast so
+  // the test helpers don't need to enumerate every nullable column.
+  return {
+    id: 1,
+    branch: 'main',
+    task: 'do the thing',
+    sessionType: 'infrastructure',
+    issueNumber: null,
+    linearId: null,
+    slotNumber: null,
+    worktree: null,
+    prUrl: null,
+    prOutcome: null,
+    fixesPrUrl: null,
+    checklistMd: '',
+    status: 'active',
+    startedAt: new Date(NOW - 60 * 60_000).toISOString(),
+    completedAt: null,
+    createdAt: new Date(NOW - 60 * 60_000).toISOString(),
+    updatedAt: new Date(NOW - 1 * 60_000).toISOString(),
+    heartbeatAt: new Date(NOW - 1 * 60_000).toISOString(),
+    date: null,
+    title: null,
+    summary: null,
+    model: null,
+    duration: null,
+    durationMinutes: null,
+    cost: null,
+    costCents: null,
+    checksYaml: null,
+    issuesJson: null,
+    learningsJson: null,
+    recommendationsJson: null,
+    reviewed: null,
+    ...partial,
+  } as DbSession;
+}
+
+describe('mergeSessions — liveness classification', () => {
+  it('classifies heartbeat <2min as live', () => {
+    const s = mkSession({
+      id: 1,
+      slotNumber: 9,
+      heartbeatAt: new Date(NOW - 30_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('live');
+  });
+
+  it('classifies heartbeat between 2 and 30 min as recent', () => {
+    const s = mkSession({
+      id: 1,
+      heartbeatAt: new Date(NOW - 10 * 60_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('recent');
+  });
+
+  it('classifies active rows with heartbeat >30min as stale', () => {
+    const s = mkSession({
+      id: 1,
+      status: 'active',
+      heartbeatAt: new Date(NOW - 60 * 60_000).toISOString(),
+      updatedAt: new Date(NOW - 60 * 60_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('stale');
+  });
+
+  it('classifies completed rows as done regardless of heartbeat freshness', () => {
+    const s = mkSession({
+      id: 1,
+      status: 'completed',
+      heartbeatAt: new Date(NOW - 30_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('done');
+  });
+
+  it('falls back to updatedAt when heartbeatAt is null', () => {
+    const s = mkSession({
+      id: 1,
+      heartbeatAt: null,
+      updatedAt: new Date(NOW - 30_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('live');
+  });
+
+  it('classifies rows with no timestamp at all as stale', () => {
+    const s = mkSession({
+      id: 1,
+      heartbeatAt: null,
+      updatedAt: null as unknown as string,
+    });
+    const [row] = mergeSessions([s], [], { now: NOW });
+    expect(row.liveness).toBe('stale');
+    expect(row.ageMinutes).toBeNull();
+  });
+
+  it('respects custom liveMinutes and staleMinutes thresholds', () => {
+    const s = mkSession({
+      id: 1,
+      heartbeatAt: new Date(NOW - 5 * 60_000).toISOString(),
+    });
+    const [row] = mergeSessions([s], [], {
+      now: NOW,
+      liveMinutes: 10,
+      staleMinutes: 20,
+    });
+    expect(row.liveness).toBe('live'); // 5 min ago is within a 10-min live window
+  });
+});
+
+describe('mergeSessions — process correlation', () => {
+  it('matches a live claude process to a DB session by slot number', () => {
+    const s = mkSession({ id: 1, slotNumber: 9 });
+    const p: ClaudeProcess = { pid: 95223, cwd: '/lw/a9', slot: 9 };
+    const [row] = mergeSessions([s], [p], { now: NOW });
+    expect(row.process).toEqual(p);
+  });
+
+  it('emits a ghost row when a live claude process has no DB session', () => {
+    const p: ClaudeProcess = { pid: 42, cwd: '/lw/a15', slot: 15 };
+    const rows = mergeSessions([], [p], { now: NOW });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].liveness).toBe('ghost');
+    expect(rows[0].session).toBeNull();
+    expect(rows[0].process).toBe(p);
+  });
+
+  it('does NOT emit a ghost when the process slot matches an active DB session', () => {
+    const s = mkSession({ id: 1, slotNumber: 9 });
+    const p: ClaudeProcess = { pid: 42, cwd: '/lw/a9', slot: 9 };
+    const rows = mergeSessions([s], [p], { now: NOW });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].session?.id).toBe(1);
+    expect(rows[0].process).toEqual(p);
+  });
+
+  it('ignores processes with null slot for ghost detection', () => {
+    const p: ClaudeProcess = { pid: 42, cwd: '/tmp', slot: null };
+    const rows = mergeSessions([], [p], { now: NOW });
+    expect(rows).toEqual([]);
+  });
+
+  it('handles multiple processes in the same slot by binding the first', () => {
+    const s = mkSession({ id: 1, slotNumber: 9 });
+    const p1: ClaudeProcess = { pid: 10, cwd: '/lw/a9', slot: 9 };
+    const p2: ClaudeProcess = { pid: 20, cwd: '/lw/a9', slot: 9 };
+    const rows = mergeSessions([s], [p1, p2], { now: NOW });
+    // First process wins; second is dropped silently (rare edge case —
+    // Claude Code normally keeps one live process per slot).
+    expect(rows).toHaveLength(1);
+    expect(rows[0].process?.pid).toBe(10);
+  });
+});
+
+describe('filterSessions', () => {
+  const sessions: MergedSession[] = [
+    {
+      session: mkSession({ id: 1, slotNumber: 9, linearId: 'QUA-413' }),
+      process: null,
+      liveness: 'recent',
+      ageMinutes: 5,
+    },
+    {
+      session: mkSession({ id: 2, slotNumber: 10, linearId: 'QUA-500' }),
+      process: null,
+      liveness: 'done',
+      ageMinutes: 60,
+    },
+    {
+      session: null,
+      process: { pid: 1, cwd: '/lw/a11', slot: 11 },
+      liveness: 'ghost',
+      ageMinutes: null,
+    },
+  ];
+
+  it('drops completed sessions by default', () => {
+    const r = filterSessions(sessions, {});
+    expect(r.map((s) => s.session?.id ?? 'ghost')).toEqual([1, 'ghost']);
+  });
+
+  it('keeps completed sessions when includeCompleted=true', () => {
+    const r = filterSessions(sessions, { includeCompleted: true });
+    expect(r).toHaveLength(3);
+  });
+
+  it('filters by linear id (case-insensitive)', () => {
+    const r = filterSessions(sessions, { linearId: 'qua-413', includeCompleted: true });
+    expect(r).toHaveLength(1);
+    expect(r[0].session?.id).toBe(1);
+  });
+
+  it('filters by slot (matches either session or process slot)', () => {
+    expect(filterSessions(sessions, { slot: 9, includeCompleted: true })).toHaveLength(1);
+    expect(filterSessions(sessions, { slot: 11, includeCompleted: true })).toHaveLength(1); // ghost
+    expect(filterSessions(sessions, { slot: 99, includeCompleted: true })).toHaveLength(0);
+  });
+});
+
+describe('sortSessions — liveness bucket ordering', () => {
+  it('sorts live < recent < stale < ghost < done', () => {
+    const rows: MergedSession[] = [
+      { session: mkSession({ id: 1 }), process: null, liveness: 'done', ageMinutes: 1 },
+      { session: mkSession({ id: 2 }), process: null, liveness: 'live', ageMinutes: 1 },
+      { session: mkSession({ id: 3 }), process: null, liveness: 'stale', ageMinutes: 1 },
+      { session: null, process: { pid: 1, cwd: '/a1', slot: 1 }, liveness: 'ghost', ageMinutes: null },
+      { session: mkSession({ id: 4 }), process: null, liveness: 'recent', ageMinutes: 1 },
+    ];
+    const sorted = sortSessions(rows);
+    expect(sorted.map((r) => r.liveness)).toEqual(['live', 'recent', 'stale', 'ghost', 'done']);
+  });
+
+  it('sorts within a bucket by recency (newest first)', () => {
+    const older = mkSession({
+      id: 1,
+      heartbeatAt: new Date(NOW - 5 * 60_000).toISOString(),
+    });
+    const newer = mkSession({
+      id: 2,
+      heartbeatAt: new Date(NOW - 1 * 60_000).toISOString(),
+    });
+    const sorted = sortSessions([
+      { session: older, process: null, liveness: 'recent', ageMinutes: 5 },
+      { session: newer, process: null, liveness: 'recent', ageMinutes: 1 },
+    ]);
+    expect(sorted.map((r) => r.session?.id)).toEqual([2, 1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+describe('formatAge', () => {
+  it('returns — for null', () => {
+    expect(formatAge(null)).toBe('—');
+  });
+  it('shows <1m for sub-minute ages', () => {
+    expect(formatAge(0.5)).toBe('<1m');
+  });
+  it('rounds minutes under 60', () => {
+    expect(formatAge(5.4)).toBe('5m');
+    expect(formatAge(59)).toBe('59m');
+  });
+  it('uses hours between 1h and 24h', () => {
+    expect(formatAge(60)).toBe('1.0h');
+    expect(formatAge(120)).toBe('2.0h');
+  });
+  it('uses days >=24h', () => {
+    expect(formatAge(60 * 24)).toBe('1.0d');
+    expect(formatAge(60 * 24 * 7)).toBe('7.0d');
+  });
+});
+
+describe('formatPr', () => {
+  it('extracts PR number from a GitHub URL', () => {
+    expect(formatPr('https://github.com/owner/repo/pull/1234')).toBe('#1234');
+    expect(formatPr('https://github.com/owner/repo/pull/1234?foo=bar')).toBe('#1234');
+  });
+  it('handles a bare number', () => {
+    expect(formatPr('4296')).toBe('#4296');
+  });
+  it('truncates unrecognized PR strings', () => {
+    const long = 'not-a-pr-url-but-very-long-string';
+    expect(formatPr(long)).toBe('not-a-pr-url-b…');
+  });
+  it('returns — for null/undefined', () => {
+    expect(formatPr(null)).toBe('—');
+    expect(formatPr(undefined)).toBe('—');
+  });
+});
+
+describe('truncate', () => {
+  it('does not truncate strings at or under width', () => {
+    expect(truncate('hello', 5)).toBe('hello');
+    expect(truncate('hi', 5)).toBe('hi');
+  });
+  it('adds ellipsis when over width', () => {
+    expect(truncate('hello world', 8)).toBe('hello w…');
+  });
+  it('returns — for null/undefined', () => {
+    expect(truncate(null, 5)).toBe('—');
+    expect(truncate(undefined, 5)).toBe('—');
+  });
+});
+
+describe('toDisplayRow', () => {
+  it('renders a DB session into display columns', () => {
+    const row = toDisplayRow({
+      session: mkSession({
+        id: 1,
+        slotNumber: 9,
+        branch: 'claude/qua-413-sessions-list',
+        linearId: 'QUA-413',
+        prUrl: 'https://github.com/owner/repo/pull/4296',
+        task: 'Build cross-session observability',
+        status: 'active',
+      }),
+      process: { pid: 42, cwd: '/lw/a9', slot: 9 },
+      liveness: 'live',
+      ageMinutes: 1,
+    });
+    expect(row).toMatchObject({
+      slot: 'a9',
+      branch: 'claude/qua-413-sessions-list',
+      linear: 'QUA-413',
+      pr: '#4296',
+      age: '1m',
+      status: 'active',
+      liveness: 'live',
+      pid: '42',
+    });
+  });
+
+  it('renders a ghost row with — for DB-only fields', () => {
+    const row = toDisplayRow({
+      session: null,
+      process: { pid: 7, cwd: '/lw/a11', slot: 11 },
+      liveness: 'ghost',
+      ageMinutes: null,
+    });
+    expect(row).toMatchObject({
+      slot: 'a11',
+      branch: '—',
+      linear: '—',
+      pr: '—',
+      age: '—',
+      status: 'ghost',
+      liveness: 'ghost',
+      pid: '7',
+    });
+    expect(row.task).toContain('ghost');
+  });
+});

--- a/crux/lib/session/sessions-list.test.ts
+++ b/crux/lib/session/sessions-list.test.ts
@@ -169,15 +169,37 @@ describe('mergeSessions — process correlation', () => {
     expect(rows).toEqual([]);
   });
 
-  it('handles multiple processes in the same slot by binding the first', () => {
+  it('handles multiple processes in the same slot: first binds to session, rest become ghosts', () => {
     const s = mkSession({ id: 1, slotNumber: 9 });
     const p1: ClaudeProcess = { pid: 10, cwd: '/lw/a9', slot: 9 };
     const p2: ClaudeProcess = { pid: 20, cwd: '/lw/a9', slot: 9 };
     const rows = mergeSessions([s], [p1, p2], { now: NOW });
-    // First process wins; second is dropped silently (rare edge case —
-    // Claude Code normally keeps one live process per slot).
-    expect(rows).toHaveLength(1);
+    // p1 binds to the session; p2 surfaces as a ghost so the
+    // "is anyone else using this slot?" signal isn't lost.
+    expect(rows).toHaveLength(2);
+    expect(rows[0].session?.id).toBe(1);
     expect(rows[0].process?.pid).toBe(10);
+    expect(rows[1].session).toBeNull();
+    expect(rows[1].liveness).toBe('ghost');
+    expect(rows[1].process?.pid).toBe(20);
+  });
+});
+
+describe('mergeSessions — defensive option validation', () => {
+  it('falls back to default liveMinutes on NaN / negative / zero input', () => {
+    const s = mkSession({
+      id: 1,
+      heartbeatAt: new Date(NOW - 30_000).toISOString(), // 30s ago → live (<2m)
+    });
+    for (const bad of [NaN, -5, 0, Infinity as unknown as number]) {
+      const [row] = mergeSessions([s], [], {
+        now: NOW,
+        liveMinutes: bad,
+      });
+      // Without NaN-guarding, `age < NaN` is false and liveness would be "stale".
+      // With the guard, default (2m) is used and age=30s classifies as live.
+      expect(row.liveness).toBe('live');
+    }
   });
 });
 

--- a/crux/lib/session/sessions-list.test.ts
+++ b/crux/lib/session/sessions-list.test.ts
@@ -293,6 +293,11 @@ describe('formatAge', () => {
     expect(formatAge(5.4)).toBe('5m');
     expect(formatAge(59)).toBe('59m');
   });
+  it('promotes 59.5m to the hours bucket (no "60m" wraparound)', () => {
+    // 59.5 rounds to 60, which would display as "60m" without the fix.
+    // Now it correctly falls through to the hours branch.
+    expect(formatAge(59.5)).toBe('1.0h');
+  });
   it('uses hours between 1h and 24h', () => {
     expect(formatAge(60)).toBe('1.0h');
     expect(formatAge(120)).toBe('2.0h');

--- a/crux/lib/session/sessions-list.ts
+++ b/crux/lib/session/sessions-list.ts
@@ -1,0 +1,233 @@
+/**
+ * `crux sys sessions list` — fetch, correlate, and format active agent sessions.
+ *
+ * Data sources:
+ *   - PG `agent_sessions` via wiki-server (authoritative: who registered)
+ *   - Local `claude` processes via lsof (best-effort: who's actually running)
+ *
+ * The merge surfaces three states a coordinator cares about:
+ *   - LIVE:  DB row with fresh heartbeat AND matching ps process in slot cwd
+ *   - STALE: DB row with old heartbeat (>fresh window), still status='active'
+ *            — session probably crashed without calling /agent-end or sweep
+ *   - GHOST: live claude process whose cwd's slot has no active DB row
+ *            — session started work without `agent-checklist init`
+ *
+ * This file is pure data-shaping so the command handler stays thin and the
+ * merge/format logic is unit-testable without a running wiki-server.
+ */
+
+import type { AgentSessionListResponse } from '../wiki-server/agent-sessions.ts';
+import type { ClaudeProcess } from './claude-processes.ts';
+
+type DbSession = AgentSessionListResponse['sessions'][number];
+
+export type Liveness = 'live' | 'recent' | 'stale' | 'done' | 'ghost';
+
+export interface MergedSession {
+  /** DB row. null for GHOST rows where only a live process exists. */
+  session: DbSession | null;
+  /** Matching live claude process (by slot). null if none found. */
+  process: ClaudeProcess | null;
+  liveness: Liveness;
+  ageMinutes: number | null;
+}
+
+export interface MergeOptions {
+  /** Now, for deterministic tests. Defaults to Date.now(). */
+  now?: number;
+  /** Heartbeat freshness for "live" bucket. Default 2 min. */
+  liveMinutes?: number;
+  /** Staleness cutoff: active rows older than this are STALE. Default 30 min. */
+  staleMinutes?: number;
+}
+
+/** Parse an ISO timestamp into epoch ms. Returns null for null/invalid input. */
+function parseTs(ts: string | Date | null | undefined): number | null {
+  if (!ts) return null;
+  const d = typeof ts === 'string' ? new Date(ts) : ts;
+  const n = d.getTime();
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Pick the best liveness signal: prefer dedicated heartbeatAt, fall back to
+ * updatedAt. Older sessions predate heartbeatAt and rely on updatedAt alone.
+ */
+function lastSignal(s: DbSession): number | null {
+  return parseTs(s.heartbeatAt) ?? parseTs(s.updatedAt);
+}
+
+/**
+ * Merge DB session rows with live claude processes.
+ *
+ * A row is matched to a process by slot number (both must be non-null and
+ * equal). This correctly handles the common case of one session per slot.
+ * Multiple processes in the same slot are unusual but not impossible (stuck
+ * subagent, crashed parent); we take the first match and surface the rest
+ * as implicit GHOSTs? — no, simpler: we emit one row per DB session plus
+ * one GHOST row per live process with no matching DB session.
+ */
+export function mergeSessions(
+  sessions: DbSession[],
+  processes: ClaudeProcess[],
+  opts: MergeOptions = {},
+): MergedSession[] {
+  const now = opts.now ?? Date.now();
+  const liveMs = (opts.liveMinutes ?? 2) * 60_000;
+  const staleMs = (opts.staleMinutes ?? 30) * 60_000;
+
+  // Build slot → process lookup. If multiple processes share a slot, keep
+  // the first; extras become GHOSTs below.
+  const processBySlot = new Map<number, ClaudeProcess>();
+  const consumed = new Set<number>();
+  for (const p of processes) {
+    if (p.slot !== null && !processBySlot.has(p.slot)) {
+      processBySlot.set(p.slot, p);
+    }
+  }
+
+  const rows: MergedSession[] = [];
+
+  for (const s of sessions) {
+    const sig = lastSignal(s);
+    const age = sig === null ? null : now - sig;
+    const ageMin = age === null ? null : age / 60_000;
+
+    let proc: ClaudeProcess | null = null;
+    if (s.slotNumber !== null && processBySlot.has(s.slotNumber)) {
+      proc = processBySlot.get(s.slotNumber) ?? null;
+      consumed.add(s.slotNumber);
+    }
+
+    let liveness: Liveness;
+    if (s.status === 'completed') {
+      liveness = 'done';
+    } else if (age !== null && age <= liveMs) {
+      liveness = 'live';
+    } else if (age !== null && age <= staleMs) {
+      liveness = 'recent';
+    } else {
+      liveness = 'stale';
+    }
+
+    rows.push({ session: s, process: proc, liveness, ageMinutes: ageMin });
+  }
+
+  // GHOSTs: live processes whose slot has no matching active DB row. These
+  // are the most alarming category — a session is running without having
+  // registered via agent-checklist init.
+  for (const p of processes) {
+    if (p.slot === null || consumed.has(p.slot)) continue;
+    rows.push({ session: null, process: p, liveness: 'ghost', ageMinutes: null });
+  }
+
+  return rows;
+}
+
+export interface FilterOptions {
+  /** If false (default), drop 'done' rows. */
+  includeCompleted?: boolean;
+  /** Only show rows for this linear ID (e.g. "QUA-413"). */
+  linearId?: string;
+  /** Only show rows for this slot number. */
+  slot?: number;
+}
+
+export function filterSessions(rows: MergedSession[], opts: FilterOptions): MergedSession[] {
+  const linearId = opts.linearId?.toUpperCase();
+  return rows.filter((r) => {
+    if (!opts.includeCompleted && r.liveness === 'done') return false;
+    if (linearId) {
+      const rowLinear = r.session?.linearId?.toUpperCase() ?? null;
+      if (rowLinear !== linearId) return false;
+    }
+    if (opts.slot !== undefined) {
+      const rowSlot = r.session?.slotNumber ?? r.process?.slot ?? null;
+      if (rowSlot !== opts.slot) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Sort for display: LIVE first, then RECENT, STALE, GHOST, DONE. Within a
+ * bucket, newer sessions first.
+ */
+const LIVENESS_ORDER: Record<Liveness, number> = {
+  live: 0,
+  recent: 1,
+  stale: 2,
+  ghost: 3,
+  done: 4,
+};
+
+export function sortSessions(rows: MergedSession[]): MergedSession[] {
+  return [...rows].sort((a, b) => {
+    const o = LIVENESS_ORDER[a.liveness] - LIVENESS_ORDER[b.liveness];
+    if (o !== 0) return o;
+    // Newer first. Missing signal sorts last within the bucket.
+    const aSig = a.session ? lastSignal(a.session) : null;
+    const bSig = b.session ? lastSignal(b.session) : null;
+    if (aSig === null && bSig === null) return 0;
+    if (aSig === null) return 1;
+    if (bSig === null) return -1;
+    return bSig - aSig;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+export function truncate(s: string | null | undefined, width: number): string {
+  if (!s) return '—';
+  if (s.length <= width) return s;
+  return s.slice(0, width - 1) + '…';
+}
+
+export function formatAge(minutes: number | null): string {
+  if (minutes === null) return '—';
+  if (minutes < 1) return '<1m';
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  const h = minutes / 60;
+  if (h < 24) return `${h.toFixed(1)}h`;
+  const d = h / 24;
+  return `${d.toFixed(1)}d`;
+}
+
+export function formatPr(prUrl: string | null | undefined): string {
+  if (!prUrl) return '—';
+  // Match /pull/N at the end of a GitHub URL
+  const m = prUrl.match(/\/pull\/(\d+)(?:$|\?|#|\/)/);
+  if (m) return `#${m[1]}`;
+  // Bare number
+  if (/^\d+$/.test(prUrl)) return `#${prUrl}`;
+  // Give up and truncate
+  return truncate(prUrl, 15);
+}
+
+export interface DisplayRow {
+  slot: string;
+  branch: string;
+  linear: string;
+  pr: string;
+  task: string;
+  age: string;
+  status: string;
+  liveness: Liveness;
+  pid: string;
+}
+
+export function toDisplayRow(r: MergedSession): DisplayRow {
+  const s = r.session;
+  const slotNum = s?.slotNumber ?? r.process?.slot ?? null;
+  const slot = slotNum === null ? '—' : `a${slotNum}`;
+  const branch = truncate(s?.branch ?? '—', 40);
+  const linear = s?.linearId ?? '—';
+  const pr = formatPr(s?.prUrl);
+  const task = truncate(s?.task ?? '(ghost claude process — not registered)', 40);
+  const age = formatAge(r.ageMinutes);
+  const status = s?.status ?? 'ghost';
+  const pid = r.process ? String(r.process.pid) : '—';
+  return { slot, branch, linear, pr, task, age, status, liveness: r.liveness, pid };
+}

--- a/crux/lib/session/sessions-list.ts
+++ b/crux/lib/session/sessions-list.ts
@@ -58,14 +58,23 @@ function lastSignal(s: DbSession): number | null {
 }
 
 /**
+ * Coerce a user-provided option to a positive number, falling back to
+ * `fallback` for NaN, negatives, and zero. Defended inside `mergeSessions`
+ * so non-CLI callers (dashboards, scripts) can't accidentally classify
+ * every row as stale by passing in a bad value.
+ */
+function positiveOr(n: number | undefined, fallback: number): number {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+/**
  * Merge DB session rows with live claude processes.
  *
  * A row is matched to a process by slot number (both must be non-null and
- * equal). This correctly handles the common case of one session per slot.
- * Multiple processes in the same slot are unusual but not impossible (stuck
- * subagent, crashed parent); we take the first match and surface the rest
- * as implicit GHOSTs? — no, simpler: we emit one row per DB session plus
- * one GHOST row per live process with no matching DB session.
+ * equal). Extra processes in the same slot (rare — a stuck subagent or
+ * crashed-parent scenario) are emitted as separate ghost rows so the
+ * "is anyone else using this slot?" signal isn't silently lost.
  */
 export function mergeSessions(
   sessions: DbSession[],
@@ -73,17 +82,18 @@ export function mergeSessions(
   opts: MergeOptions = {},
 ): MergedSession[] {
   const now = opts.now ?? Date.now();
-  const liveMs = (opts.liveMinutes ?? 2) * 60_000;
-  const staleMs = (opts.staleMinutes ?? 30) * 60_000;
+  const liveMs = positiveOr(opts.liveMinutes, 2) * 60_000;
+  const staleMs = positiveOr(opts.staleMinutes, 30) * 60_000;
 
-  // Build slot → process lookup. If multiple processes share a slot, keep
-  // the first; extras become GHOSTs below.
-  const processBySlot = new Map<number, ClaudeProcess>();
-  const consumed = new Set<number>();
+  // Track which (slot, pid) pairs get bound to a DB session. Anything left
+  // over becomes a ghost row.
+  const bound = new Set<number>(); // pids bound to a DB session
+  const processBySlot = new Map<number, ClaudeProcess[]>();
   for (const p of processes) {
-    if (p.slot !== null && !processBySlot.has(p.slot)) {
-      processBySlot.set(p.slot, p);
-    }
+    if (p.slot === null) continue;
+    const list = processBySlot.get(p.slot) ?? [];
+    list.push(p);
+    processBySlot.set(p.slot, list);
   }
 
   const rows: MergedSession[] = [];
@@ -94,17 +104,22 @@ export function mergeSessions(
     const ageMin = age === null ? null : age / 60_000;
 
     let proc: ClaudeProcess | null = null;
-    if (s.slotNumber !== null && processBySlot.has(s.slotNumber)) {
-      proc = processBySlot.get(s.slotNumber) ?? null;
-      consumed.add(s.slotNumber);
+    if (s.slotNumber !== null) {
+      const candidates = processBySlot.get(s.slotNumber) ?? [];
+      // Bind the first unbound process in this slot to the session.
+      const picked = candidates.find((p) => !bound.has(p.pid));
+      if (picked) {
+        proc = picked;
+        bound.add(picked.pid);
+      }
     }
 
     let liveness: Liveness;
     if (s.status === 'completed') {
       liveness = 'done';
-    } else if (age !== null && age <= liveMs) {
+    } else if (age !== null && age < liveMs) {
       liveness = 'live';
-    } else if (age !== null && age <= staleMs) {
+    } else if (age !== null && age < staleMs) {
       liveness = 'recent';
     } else {
       liveness = 'stale';
@@ -113,11 +128,11 @@ export function mergeSessions(
     rows.push({ session: s, process: proc, liveness, ageMinutes: ageMin });
   }
 
-  // GHOSTs: live processes whose slot has no matching active DB row. These
-  // are the most alarming category — a session is running without having
-  // registered via agent-checklist init.
+  // GHOSTs: every process not bound to a DB session. This includes both
+  // slots that have no DB row at all AND slots with extra processes beyond
+  // the first (e.g. a stuck subagent).
   for (const p of processes) {
-    if (p.slot === null || consumed.has(p.slot)) continue;
+    if (p.slot === null || bound.has(p.pid)) continue;
     rows.push({ session: null, process: p, liveness: 'ghost', ageMinutes: null });
   }
 

--- a/crux/lib/session/sessions-list.ts
+++ b/crux/lib/session/sessions-list.ts
@@ -203,7 +203,9 @@ export function truncate(s: string | null | undefined, width: number): string {
 export function formatAge(minutes: number | null): string {
   if (minutes === null) return '—';
   if (minutes < 1) return '<1m';
-  if (minutes < 60) return `${Math.round(minutes)}m`;
+  // Round before checking the boundary so 59.5m renders as 1.0h, not 60m.
+  const m = Math.round(minutes);
+  if (m < 60) return `${m}m`;
   const h = minutes / 60;
   if (h < 24) return `${h.toFixed(1)}h`;
   const d = h / 24;


### PR DESCRIPTION
## Summary

Adds `crux sys sessions list` — the canonical way to see which Claude Code sessions are running across all agent slots. Closes the root cause of QUA-406 (duplicate work on QUA-397): coordinator sessions had no way to cross-reference the `agent_sessions` PG table with live `claude` processes, so a slot mid-work on a feature branch could look idle in `./ws list` when init was run before the branch was created.

## Key changes

- **New command** `crux sys sessions list` — pulls from `GET /api/agent-sessions` and cross-references with local `claude` processes via `ps` + `lsof`. Supports `--all` / `--linear=QUA-NNN` / `--slot=N` / `--live-minutes=N` / `--stale-minutes=N` / `--json` / `--limit=N`.
- **Five liveness states**: `live` (heartbeat <2m), `recent` (<30m), `stale` (active DB row with old heartbeat — session probably crashed), `ghost` (live claude process with no DB row — init was skipped), `done` (completed, with `--all`).
- **Graceful degradation**: if the wiki-server is unreachable, the command shows scan-only output with a warning banner. If the local scan fails (missing `lsof`, permission denied), the table still shows DB rows with a banner naming the failure so coordinators can't be fooled by a false "no ghosts" signal.
- **Pure library code** (`crux/lib/session/sessions-list.ts`, `crux/lib/session/claude-processes.ts`) separate from CLI glue, so the merge/filter/sort logic has 34 unit tests and the process scanner has 14.
- **Docs**: `.claude/rules/agent-session-workflow.md` adds a "Checking for active sessions" section pointing at this command; `.claude/rules/dispatched-agent-review.md` uses it for the dispatcher pre-flight "active slots" check.

## Test plan

- [x] `npx vitest run crux/lib/session/ crux/commands/sessions.test.ts` — 157 tests pass
- [x] `pnpm crux w validate gate --scope=code --fix` — all 46 checks pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean on changed files
- [x] CLI smoke: `WIKI_SERVER_ENV=prod pnpm crux sys sessions list` renders table with ghost detection
- [x] CLI smoke: `pnpm crux sys sessions list` (server-down) degrades to scan-only with warning banner
- [x] CLI smoke: `pnpm crux sys sessions list --slot=abc` exits 2 with error (parity with `--limit=abc`)
- [x] CLI smoke: `pnpm crux sys sessions list --json` returns consistent `{warnings, sessions}` shape

## Follow-ups filed

- QUA-593 — narrow-column projection on `GET /api/agent-sessions` (~10 MB → ~50 KB wire payload)
- QUA-595 — convert `findClaudeProcesses` from `execSync` to async `execFile` so scan runs genuinely parallel with DB fetch

Fixes QUA-413
