### PR TITLE
feat(sourcing): crux sourcing-apply-suggestions — consume approved URL suggestions (QUA-591)

### DIFF
--- a/apps/wiki-server/drizzle/0200_qua_591_url_suggestion_applied_status.sql
+++ b/apps/wiki-server/drizzle/0200_qua_591_url_suggestion_applied_status.sql
@@ -1,0 +1,17 @@
+-- QUA-591: allow `applied` status on sourcing_url_suggestions.
+--
+-- The sourcing-apply-suggestions command consumes rows with
+-- status='approved'/'auto_verified', swaps the URL on the evidence row,
+-- re-runs verification, and marks the suggestion as 'applied' so re-runs
+-- of the command are naturally idempotent.
+--
+-- The table has O(thousands) of rows, so plain ADD CONSTRAINT is fine —
+-- the NOT VALID + VALIDATE pattern is only needed for large tables.
+
+DO $$ BEGIN
+  ALTER TABLE "sourcing_url_suggestions"
+    DROP CONSTRAINT IF EXISTS chk_sus_status;
+  ALTER TABLE "sourcing_url_suggestions"
+    ADD CONSTRAINT chk_sus_status
+    CHECK (status IN ('pending', 'approved', 'rejected', 'auto_verified', 'applied'));
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1401,6 +1401,13 @@
       "when": 1786348800000,
       "tag": "0199_install_swap_fk_target",
       "breakpoints": true
+    },
+    {
+      "idx": 200,
+      "version": "7",
+      "when": 1786435200000,
+      "tag": "0200_qua_591_url_suggestion_applied_status",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/sourcing/url-suggestions.ts
+++ b/apps/wiki-server/src/routes/sourcing/url-suggestions.ts
@@ -30,13 +30,15 @@ const MAX_BATCH = 200;
 
 /**
  * Allowed lifecycle states for a URL suggestion.
- * Also mirrored in migration 0176's CHECK constraint — keep in sync.
+ * Mirrored in the PG CHECK constraint — migrations 0176 (initial set) and
+ * 0198 (added 'applied'). Keep in sync.
  */
 export const VALID_SUGGESTION_STATUSES = [
   "pending",
   "approved",
   "rejected",
   "auto_verified",
+  "applied",
 ] as const;
 export type SuggestionStatus = (typeof VALID_SUGGESTION_STATUSES)[number];
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1815,7 +1815,7 @@ export const sourcingUrlSuggestions = pgTable(
     relevanceScore: real("relevance_score"), // 0..1, provider-supplied or heuristic
     sourceProvider: text("source_provider").notNull(), // exa | perplexity | scry | manual
     generatorModel: text("generator_model"),
-    /** pending | approved | rejected | auto_verified */
+    /** pending | approved | rejected | auto_verified | applied */
     status: text("status").notNull().default("pending"),
     reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
     reviewedBy: text("reviewed_by"), // agent session id or user handle
@@ -1834,7 +1834,7 @@ export const sourcingUrlSuggestions = pgTable(
     index("idx_sus_created").on(table.createdAt),
     // Unique (record_type, record_id, COALESCE(field_name, ''), suggested_url)
     // declared in migration SQL since COALESCE cannot be expressed in Drizzle .on().
-    // CHECK (status IN ('pending','approved','rejected','auto_verified')) likewise in migration.
+    // CHECK (status IN ('pending','approved','rejected','auto_verified','applied')) likewise in migration.
   ]
 );
 

--- a/crux/commands/sourcing-apply-suggestions.test.ts
+++ b/crux/commands/sourcing-apply-suggestions.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Tests for sourcing-apply-suggestions (QUA-591).
+ *
+ * Uses --dry-run where possible so the LLM layer doesn't need stubbing, and
+ * stubs the sourcing helpers (fetchSourceContent, callLlmForSourcing, etc.)
+ * for the live-path tests. Follows the same mocking pattern as
+ * sourcing-recheck.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockListUrlSuggestions = vi.fn();
+const mockUpdateUrlSuggestionStatus = vi.fn();
+const mockStoreVerdictRpc = vi.fn();
+const mockGetVerdictByRecord = vi.fn();
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
+  listUrlSuggestions: (...args: unknown[]) => mockListUrlSuggestions(...args),
+  updateUrlSuggestionStatus: (...args: unknown[]) => mockUpdateUrlSuggestionStatus(...args),
+  storeVerdict: (...args: unknown[]) => mockStoreVerdictRpc(...args),
+  getVerdictByRecord: (...args: unknown[]) => mockGetVerdictByRecord(...args),
+}));
+
+const mockFetchSourceContent = vi.fn();
+const mockCallLlmForSourcing = vi.fn();
+const mockStoreSourcingEvidence = vi.fn();
+
+vi.mock('../lib/sourcing/index.ts', () => ({
+  fetchSourceContent: (...args: unknown[]) => mockFetchSourceContent(...args),
+  callLlmForSourcing: (...args: unknown[]) => mockCallLlmForSourcing(...args),
+  storeSourcingEvidence: (...args: unknown[]) => mockStoreSourcingEvidence(...args),
+  storeAggregateVerdict: vi.fn(),
+  SOURCE_CHECK_CONSTANTS: {
+    ESTIMATED_COST_PER_VERIFICATION: 0.01,
+    PROMPT_CONTENT_LENGTH: 30_000,
+  },
+}));
+
+vi.mock('../lib/llm.ts', () => ({
+  createLlmClient: vi.fn(() => ({})),
+  callLlm: vi.fn(),
+}));
+
+import { commands } from './sourcing-apply-suggestions.ts';
+
+const apply = commands.default;
+
+function makeSuggestion(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: 42,
+    recordType: 'grant',
+    recordId: 'g_test_1',
+    fieldName: null,
+    entityId: 'anthropic',
+    suggestedUrl: 'https://example.com/new-source',
+    title: 'New Source',
+    snippet: null,
+    sourceProvider: 'exa',
+    status: 'approved',
+    ...overrides,
+  };
+}
+
+describe('sourcing-apply-suggestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('option validation', () => {
+    it('rejects an unknown --status value', async () => {
+      const result = await apply([], { status: 'aproved', 'dry-run': true } as never);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Invalid --status');
+      expect(mockListUrlSuggestions).not.toHaveBeenCalled();
+    });
+
+    it('accepts multiple comma-separated statuses', async () => {
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: true,
+        data: { suggestions: [], returned: 0 },
+      });
+      const result = await apply([], {
+        status: 'approved,auto_verified',
+        'dry-run': true,
+      } as never);
+      // Both statuses queried — 2 calls total
+      expect(result.exitCode).toBe(0);
+      expect(mockListUrlSuggestions).toHaveBeenCalledTimes(2);
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'approved' }),
+      );
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'auto_verified' }),
+      );
+    });
+
+    it('defaults to approved + auto_verified when --status omitted', async () => {
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: true,
+        data: { suggestions: [], returned: 0 },
+      });
+      await apply([], { 'dry-run': true } as never);
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'approved' }),
+      );
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'auto_verified' }),
+      );
+    });
+
+    it('passes --type through as recordType filter', async () => {
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: true,
+        data: { suggestions: [], returned: 0 },
+      });
+      await apply([], {
+        status: 'approved',
+        type: 'grant',
+        'dry-run': true,
+      } as never);
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ recordType: 'grant', status: 'approved' }),
+      );
+    });
+  });
+
+  describe('empty-result handling', () => {
+    it('returns a friendly message when no suggestions match', async () => {
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: true,
+        data: { suggestions: [], returned: 0 },
+      });
+      const result = await apply([], {
+        status: 'approved',
+        'dry-run': true,
+      } as never);
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toMatch(/No suggestions found/i);
+    });
+
+    it('surfaces listUrlSuggestions failures as exit=1', async () => {
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: false,
+        message: 'boom',
+        error: { code: 'HTTP_500' },
+      });
+      const result = await apply([], { 'dry-run': true } as never);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('boom');
+    });
+  });
+
+  describe('pagination', () => {
+    it('paginates when the first page is full', async () => {
+      const page1 = Array.from({ length: 200 }, (_, i) =>
+        makeSuggestion({ id: i + 1, recordId: `g_${i}` }),
+      );
+      const page2 = Array.from({ length: 50 }, (_, i) =>
+        makeSuggestion({ id: 201 + i, recordId: `g_${200 + i}` }),
+      );
+      mockListUrlSuggestions
+        // first status: approved → 2 pages
+        .mockResolvedValueOnce({ ok: true, data: { suggestions: page1, returned: 200 } })
+        .mockResolvedValueOnce({ ok: true, data: { suggestions: page2, returned: 50 } })
+        // second status: auto_verified → empty
+        .mockResolvedValueOnce({ ok: true, data: { suggestions: [], returned: 0 } });
+
+      const result = await apply([], { limit: '500', 'dry-run': true } as never);
+      expect(result.exitCode).toBe(0);
+      // 2 pages for approved, 1 for auto_verified, total 3 calls
+      expect(mockListUrlSuggestions).toHaveBeenCalledTimes(3);
+      expect(mockListUrlSuggestions).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ status: 'approved', offset: 0 }),
+      );
+      expect(mockListUrlSuggestions).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ status: 'approved', offset: 200 }),
+      );
+    });
+
+    it('stops once itemLimit is satisfied', async () => {
+      // Even with a full page of 200 and more behind it, itemLimit=100 stops early.
+      const page = Array.from({ length: 100 }, (_, i) => makeSuggestion({ id: i + 1 }));
+      mockListUrlSuggestions.mockResolvedValue({
+        ok: true,
+        data: { suggestions: page, returned: 100 },
+      });
+      await apply([], {
+        status: 'approved',
+        limit: '100',
+        'dry-run': true,
+      } as never);
+      expect(mockListUrlSuggestions).toHaveBeenCalledTimes(1);
+      expect(mockListUrlSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 100, offset: 0 }),
+      );
+    });
+  });
+
+  describe('live apply path', () => {
+    beforeEach(() => {
+      // Default: LLM verifies as confirmed.
+      mockGetVerdictByRecord.mockResolvedValue({
+        ok: true,
+        data: { verdicts: [{ verdict: 'unverifiable', fieldName: null }] },
+      });
+      mockCallLlmForSourcing.mockResolvedValue({
+        verdict: 'confirmed',
+        confidence: 0.9,
+        extractedValue: 'The company confirmed 500 employees in 2024',
+        reasoning: 'Direct match on the claim',
+      });
+      mockStoreSourcingEvidence.mockResolvedValue(undefined);
+      mockStoreVerdictRpc.mockResolvedValue({ ok: true, data: {} });
+      mockUpdateUrlSuggestionStatus.mockResolvedValue({ ok: true, data: { ok: true, id: 42 } });
+    });
+
+    it('fetches → LLMs → stores evidence+verdict → marks applied, on success', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({
+        content: 'Anthropic has 500 employees as of 2024.',
+      });
+
+      const result = await apply([], {} as never);
+      expect(result.exitCode).toBe(0);
+
+      // Evidence stored with the NEW URL
+      expect(mockStoreSourcingEvidence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceUrl: 'https://example.com/new-source',
+          verdict: 'confirmed',
+        }),
+        expect.any(String),
+      );
+
+      // Aggregate verdict stored with the new verdict
+      expect(mockStoreVerdictRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recordType: 'grant',
+          recordId: 'g_test_1',
+          verdict: 'confirmed',
+        }),
+      );
+
+      // Suggestion marked as applied
+      expect(mockUpdateUrlSuggestionStatus).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ status: 'applied' }),
+      );
+
+      expect(result.output).toMatch(/unverifiable.*confirmed/);
+    });
+
+    it('counts non-transition applies (e.g. still-unverifiable) as applied, not changed', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({ content: 'Off-topic text.' });
+      mockCallLlmForSourcing.mockResolvedValueOnce({
+        verdict: 'unverifiable',
+        confidence: 0.3,
+        extractedValue: '',
+        reasoning: 'Source does not cover this claim',
+      });
+
+      const result = await apply([], {} as never);
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toMatch(/Applied:\s+1/);
+      expect(result.output).toMatch(/Changed verdicts:\s+0/);
+      // Suggestion still marked applied — we tried, it just didn't help.
+      expect(mockUpdateUrlSuggestionStatus).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ status: 'applied' }),
+      );
+    });
+
+    it('surfaces awaiting-ingest fetch failures without calling LLM or marking applied', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({
+        content: null,
+        errorType: 'not_cached',
+        errorMessage: 'not in cache',
+        ingestEnqueued: true,
+      });
+
+      const result = await apply([], {} as never);
+      // awaiting-ingest contributes to errors and non-zero exit — the sweep
+      // isn't fully converged yet.
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toMatch(/awaiting resource-ingest/i);
+      expect(mockCallLlmForSourcing).not.toHaveBeenCalled();
+      expect(mockStoreSourcingEvidence).not.toHaveBeenCalled();
+      expect(mockUpdateUrlSuggestionStatus).not.toHaveBeenCalled();
+    });
+
+    it('treats dead_link fetch failures as errors (no LLM, no apply)', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({
+        content: null,
+        errorType: 'dead_link',
+        errorMessage: 'HTTP 404',
+        httpStatus: 404,
+      });
+
+      const result = await apply([], {} as never);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('HTTP 404');
+      expect(mockCallLlmForSourcing).not.toHaveBeenCalled();
+      expect(mockUpdateUrlSuggestionStatus).not.toHaveBeenCalled();
+    });
+
+    it('propagates fieldName and entityId through to verdict body', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: {
+            suggestions: [
+              makeSuggestion({ fieldName: 'amount_usd', entityId: 'sid_abc' }),
+            ],
+            returned: 1,
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({ content: 'text' });
+
+      await apply([], {} as never);
+
+      expect(mockStoreVerdictRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fieldName: 'amount_usd',
+          entityId: 'sid_abc',
+        }),
+      );
+      expect(mockStoreSourcingEvidence).toHaveBeenCalledWith(
+        expect.objectContaining({ fieldName: 'amount_usd', entityId: 'sid_abc' }),
+        expect.any(String),
+      );
+    });
+
+    it('does NOT mark applied when verdict storage fails (so next run retries)', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValueOnce({ content: 'text' });
+      mockStoreVerdictRpc.mockResolvedValueOnce({
+        ok: false,
+        message: 'constraint violation',
+        error: 'constraint violation',
+      });
+
+      const result = await apply([], {} as never);
+      expect(result.exitCode).toBe(1);
+      expect(mockUpdateUrlSuggestionStatus).not.toHaveBeenCalled();
+    });
+
+    it('continues past a status-patch failure but reports non-zero exit', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: {
+            suggestions: [
+              makeSuggestion(),
+              makeSuggestion({ id: 43, recordId: 'g_test_2' }),
+            ],
+            returned: 2,
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockFetchSourceContent.mockResolvedValue({ content: 'text' });
+      mockUpdateUrlSuggestionStatus
+        .mockResolvedValueOnce({ ok: false, message: 'patch failed' })
+        .mockResolvedValueOnce({ ok: true, data: { ok: true, id: 43 } });
+
+      const result = await apply([], {} as never);
+      // Applied both but one patch failed → non-zero exit
+      expect(result.exitCode).toBe(1);
+      expect(mockStoreVerdictRpc).toHaveBeenCalledTimes(2);
+      expect(mockUpdateUrlSuggestionStatus).toHaveBeenCalledTimes(2);
+      expect(result.output).toMatch(/applied but not marked/i);
+    });
+
+    it('records the correct previous verdict from getVerdictByRecord', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      // Prior verdict is 'partial' (not the default 'unverifiable')
+      mockGetVerdictByRecord.mockResolvedValueOnce({
+        ok: true,
+        data: { verdicts: [{ verdict: 'partial', fieldName: null }] },
+      });
+      mockFetchSourceContent.mockResolvedValueOnce({ content: 'text' });
+
+      const result = await apply([], {} as never);
+      expect(result.output).toMatch(/partial.*confirmed/);
+    });
+
+    it('uses the field-matching prior verdict when multiple exist', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: {
+            suggestions: [makeSuggestion({ fieldName: 'amount_usd' })],
+            returned: 1,
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockGetVerdictByRecord.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          verdicts: [
+            { verdict: 'confirmed', fieldName: 'date' },
+            { verdict: 'partial', fieldName: 'amount_usd' },
+          ],
+        },
+      });
+      mockFetchSourceContent.mockResolvedValueOnce({ content: 'text' });
+
+      const result = await apply([], {} as never);
+      // Should pick 'partial' (the amount_usd one), not 'confirmed' (first row)
+      expect(result.output).toMatch(/partial.*confirmed/);
+    });
+  });
+
+  describe('budget cap', () => {
+    it('caps applies by --budget before invoking fetch', async () => {
+      const suggestions = Array.from({ length: 10 }, (_, i) =>
+        makeSuggestion({ id: i + 1, recordId: `g_${i}` }),
+      );
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions, returned: 10 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      // $0.03 / $0.01 per = 3 applies max
+      const result = await apply([], {
+        budget: '0.03',
+        'dry-run': true,
+      } as never);
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toMatch(/3 of 10/);
+    });
+
+    it('honors --budget in live execution too', async () => {
+      const suggestions = Array.from({ length: 5 }, (_, i) =>
+        makeSuggestion({ id: i + 1, recordId: `g_${i}` }),
+      );
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions, returned: 5 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      mockGetVerdictByRecord.mockResolvedValue({
+        ok: true,
+        data: { verdicts: [{ verdict: 'unverifiable', fieldName: null }] },
+      });
+      mockFetchSourceContent.mockResolvedValue({ content: 'text' });
+      mockCallLlmForSourcing.mockResolvedValue({
+        verdict: 'confirmed',
+        confidence: 0.9,
+        extractedValue: '',
+        reasoning: '',
+      });
+      mockStoreSourcingEvidence.mockResolvedValue(undefined);
+      mockStoreVerdictRpc.mockResolvedValue({ ok: true, data: {} });
+      mockUpdateUrlSuggestionStatus.mockResolvedValue({ ok: true, data: { ok: true, id: 1 } });
+
+      // $0.02 / $0.01 = 2 applies
+      await apply([], { budget: '0.02' } as never);
+      expect(mockFetchSourceContent).toHaveBeenCalledTimes(2);
+      expect(mockCallLlmForSourcing).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('JSON output', () => {
+    it('emits machine-readable JSON on --ci', async () => {
+      mockListUrlSuggestions
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [makeSuggestion()], returned: 1 },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: { suggestions: [], returned: 0 },
+        });
+      const result = await apply([], { ci: true, 'dry-run': true } as never);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.output);
+      expect(parsed).toMatchObject({
+        totalCandidates: 1,
+        selected: 1,
+        estimatedCost: expect.any(Number),
+        items: expect.any(Array),
+      });
+      expect(parsed.items[0]).toMatchObject({
+        id: 42,
+        recordType: 'grant',
+        suggestedUrl: 'https://example.com/new-source',
+      });
+    });
+  });
+});

--- a/crux/commands/sourcing-apply-suggestions.ts
+++ b/crux/commands/sourcing-apply-suggestions.ts
@@ -1,0 +1,733 @@
+/**
+ * Source-Check Apply Suggestions — QUA-591
+ *
+ * Consume `approved` and `auto_verified` URL suggestions from the queue,
+ * swap the evidence-row URL, re-run verification, and update the aggregate
+ * verdict. Marks successful applies as status='applied' so re-runs are
+ * naturally idempotent.
+ *
+ * Pipeline per suggestion:
+ *   1. Fetch source content from the suggested URL (cache + Wayback fallback).
+ *      - On cache miss, `fetchSourceContent` auto-enqueues a resource-ingest
+ *        job; a second pass hours later will find the content cached. First
+ *        passes of a sweep will therefore mostly leave suggestions alone —
+ *        this is expected, not an error.
+ *   2. LLM-verify the claim against the new content (same prompt as recheck).
+ *   3. Store a new evidence row for the new URL.
+ *   4. Store the aggregate verdict (replaces the prior `unverifiable`).
+ *   5. PATCH the suggestion status to 'applied'.
+ *
+ * Usage:
+ *   crux sourcing-apply-suggestions --dry-run                     Preview
+ *   crux sourcing-apply-suggestions --limit=50 --budget=0.5       Apply up to 50
+ *   crux sourcing-apply-suggestions --status=approved             Only human-approved
+ *   crux sourcing-apply-suggestions --type=grant                   Filter by record type
+ */
+
+import type {
+  CommandOptions as BaseOptions,
+  CommandResult,
+} from '../lib/command-types.ts';
+import {
+  listUrlSuggestions,
+  updateUrlSuggestionStatus,
+  storeVerdict as storeVerdictRpc,
+  getVerdictByRecord,
+} from '../lib/wiki-server/sourcing-client.ts';
+import {
+  VALID_SUGGESTION_STATUSES,
+  type SuggestionStatus,
+} from '../../apps/wiki-server/src/routes/sourcing/url-suggestions.ts';
+import { createLlmClient } from '../lib/llm.ts';
+import {
+  fetchSourceContent,
+  callLlmForSourcing,
+  storeSourcingEvidence,
+  SOURCE_CHECK_CONSTANTS,
+} from '../lib/sourcing/index.ts';
+import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const { ESTIMATED_COST_PER_VERIFICATION } = SOURCE_CHECK_CONSTANTS;
+
+const LOG_PREFIX = '[apply]';
+
+const DEFAULT_STATUSES: SuggestionStatus[] = ['approved', 'auto_verified'];
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 2000;
+const DEFAULT_BUDGET_USD = 0.50;
+const PAGE_SIZE = 200;
+/** Hard cap on pagination loops — see sourcing-recheck.ts for rationale. */
+const MAX_PAGINATION_ITERATIONS = 100;
+
+/** Next-check-due intervals by verdict (in days) — mirrors sourcing-recheck. */
+const RECHECK_INTERVALS: Record<string, number> = {
+  confirmed: 90,
+  contradicted: 7,
+  outdated: 14,
+  partial: 30,
+  unverifiable: 60,
+};
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface ApplyOptions extends BaseOptions {
+  status?: string;
+  type?: string;
+  limit?: string;
+  budget?: string;
+  'dry-run'?: boolean;
+  dryRun?: boolean;
+  ci?: boolean;
+  json?: boolean;
+}
+
+interface PendingSuggestion {
+  id: number;
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  entityId: string | null;
+  suggestedUrl: string;
+  title: string | null;
+  snippet: string | null;
+  sourceProvider: string;
+  status: SuggestionStatus;
+}
+
+interface ApplyResult {
+  id: number;
+  recordType: string;
+  recordId: string;
+  suggestedUrl: string;
+  previousVerdict: string;
+  newVerdict: string;
+  confidence: number;
+  changed: boolean;
+}
+
+interface ApplyError {
+  id: number;
+  recordType: string;
+  recordId: string;
+  suggestedUrl: string;
+  error: string;
+  /** True when the URL isn't cached yet but an ingest job was enqueued —
+   *  the operator can re-run in a few hours without further action. */
+  awaitingIngest: boolean;
+}
+
+interface ApplySummary {
+  totalCandidates: number;
+  processed: number;
+  applied: number;
+  changed: number;
+  errors: number;
+  awaitingIngest: number;
+  statusPatchErrors: number;
+  estimatedCost: number;
+  verdictTransitions: Array<{ from: string; to: string; count: number }>;
+  results: ApplyResult[];
+  failures: ApplyError[];
+}
+
+// ── Option parsing ───────────────────────────────────────────────────
+
+function parseBoundedInt(
+  raw: unknown,
+  fallback: number,
+  max: number,
+  flag: string,
+): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive integer)\n`);
+    return fallback;
+  }
+  return Math.min(n, max);
+}
+
+function parsePositiveFloat(raw: unknown, fallback: number, flag: string): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseFloat(String(raw));
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive number)\n`);
+    return fallback;
+  }
+  return n;
+}
+
+/**
+ * Parse a comma-separated status filter. Validates each value against the
+ * server-side enum. Invalid values cause the command to error out instead of
+ * silently dropping — a typo like `--status=aproved` should not make the
+ * command run on an empty set and report success.
+ */
+function parseStatusFilter(raw: unknown): SuggestionStatus[] | { error: string } {
+  if (raw === undefined || raw === null || raw === '') {
+    return [...DEFAULT_STATUSES];
+  }
+  const parts = String(raw)
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (parts.length === 0) return [...DEFAULT_STATUSES];
+  const allowed = new Set<string>(VALID_SUGGESTION_STATUSES);
+  const out: SuggestionStatus[] = [];
+  for (const p of parts) {
+    if (!allowed.has(p)) {
+      return { error: `Invalid --status "${p}". Must be one of: ${[...allowed].join(', ')}` };
+    }
+    out.push(p as SuggestionStatus);
+  }
+  return out;
+}
+
+// ── Candidate fetching ───────────────────────────────────────────────
+
+/**
+ * Fetch suggestions from the queue for each requested status, up to `limit`
+ * total across all statuses. Paginates server-side (the server caps pages at
+ * 200) and bails with a clear error if the server returns a malformed total.
+ */
+async function fetchCandidates(
+  statuses: SuggestionStatus[],
+  typeFilter: string | undefined,
+  limit: number,
+): Promise<{ candidates: PendingSuggestion[]; totalMatching: number } | { error: string }> {
+  const collected: PendingSuggestion[] = [];
+  let totalMatching = 0;
+
+  for (const status of statuses) {
+    if (collected.length >= limit) break;
+
+    let offset = 0;
+    let iterations = 0;
+    while (collected.length < limit) {
+      if (iterations++ >= MAX_PAGINATION_ITERATIONS) {
+        return {
+          error: `Pagination exceeded ${MAX_PAGINATION_ITERATIONS} iterations for status=${status} — server may be returning malformed pagination metadata.`,
+        };
+      }
+
+      const pageSize = Math.min(PAGE_SIZE, limit - collected.length);
+      const response = await listUrlSuggestions({
+        recordType: typeFilter,
+        status,
+        limit: pageSize,
+        offset,
+      });
+      if (!response.ok) {
+        return { error: `Failed to list url-suggestions (status=${status}): ${response.message}` };
+      }
+
+      const rows = response.data.suggestions ?? [];
+      // The list endpoint returns `returned` (page size) not a total count.
+      // Accumulate as we go so the summary isn't a lie.
+      totalMatching += rows.length;
+      if (rows.length === 0) break;
+
+      for (const r of rows) {
+        collected.push({
+          id: r.id,
+          recordType: r.recordType,
+          recordId: r.recordId,
+          fieldName: r.fieldName ?? null,
+          entityId: r.entityId ?? null,
+          suggestedUrl: r.suggestedUrl,
+          title: r.title ?? null,
+          snippet: r.snippet ?? null,
+          sourceProvider: r.sourceProvider,
+          status: r.status as SuggestionStatus,
+        });
+      }
+      offset += rows.length;
+      if (rows.length < pageSize) break;
+    }
+  }
+
+  return { candidates: collected.slice(0, limit), totalMatching };
+}
+
+// ── LLM verification ─────────────────────────────────────────────────
+
+/**
+ * Prompt modeled on sourcing-recheck. Does NOT include the prior verdict's
+ * reasoning on purpose — we're verifying against a *new* URL, and the prior
+ * reasoning was about the old URL. Including it would bias the model toward
+ * the prior verdict ("confirm unverifiable because the old reasoning said so")
+ * when we want a fresh read.
+ */
+function buildApplyPrompt(
+  candidate: PendingSuggestion,
+  sourceText: string,
+): string {
+  return `You are a fact-checker evaluating whether a newly-proposed source URL supports a previously-unverifiable record.
+
+Record type: ${candidate.recordType}
+Record ID: ${candidate.recordId}
+${candidate.fieldName ? `Field: ${candidate.fieldName}` : ''}
+${candidate.entityId ? `Entity: ${candidate.entityId}` : ''}
+
+Suggested source URL: ${candidate.suggestedUrl}
+${candidate.title ? `Source title: ${candidate.title}` : ''}
+
+Source text (excerpt):
+---
+${sourceText.slice(0, SOURCE_CHECK_CONSTANTS.PROMPT_CONTENT_LENGTH)}
+---
+
+Evaluate whether this source supports the record:
+- "confirmed": The source explicitly states the record's data.
+- "partial": The source confirms some but not all fields.
+- "contradicted": The source explicitly states a different value.
+- "unverifiable": The source does not address the claim, or is off-topic.
+- "outdated": The source confirms a historically-correct-but-now-stale value.
+
+Respond with ONLY a JSON object (no markdown code fences):
+{
+  "verdict": "confirmed|contradicted|unverifiable|outdated|partial",
+  "confidence": 0.0 to 1.0,
+  "extracted_value": "What the source says about this record (quote or paraphrase)",
+  "reasoning": "Brief explanation of your verdict"
+}`;
+}
+
+function computeNextCheckDue(verdict: string): string {
+  const days = RECHECK_INTERVALS[verdict] ?? 60;
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString();
+}
+
+// ── Per-candidate apply ──────────────────────────────────────────────
+
+async function applyOne(
+  candidate: PendingSuggestion,
+  client: ReturnType<typeof createLlmClient>,
+): Promise<ApplyResult | ApplyError> {
+  // Step 1: fetch the suggested URL's content.
+  const fetchResult = await fetchSourceContent(
+    candidate.suggestedUrl,
+    undefined,
+    LOG_PREFIX,
+  );
+  if (!fetchResult.content) {
+    const awaitingIngest =
+      fetchResult.errorType === 'not_cached' && Boolean(fetchResult.ingestEnqueued);
+    return {
+      id: candidate.id,
+      recordType: candidate.recordType,
+      recordId: candidate.recordId,
+      suggestedUrl: candidate.suggestedUrl,
+      error: fetchResult.errorMessage ?? 'Could not fetch source content',
+      awaitingIngest,
+    };
+  }
+
+  // Step 2: look up the current verdict so we can report the transition.
+  let previousVerdict = 'unverifiable';
+  try {
+    const priorResp = await getVerdictByRecord(candidate.recordType, candidate.recordId);
+    if (priorResp.ok) {
+      const verdicts = priorResp.data.verdicts ?? [];
+      // Prefer the row matching our fieldName (null == null or both strings).
+      const match = verdicts.find(
+        (v) => (v.fieldName ?? null) === (candidate.fieldName ?? null),
+      ) ?? verdicts[0];
+      if (match) previousVerdict = match.verdict;
+    }
+  } catch (e: unknown) {
+    // Non-fatal — we'll report previousVerdict as 'unverifiable' (our best guess)
+    console.warn(
+      `${LOG_PREFIX} Could not fetch prior verdict for ${candidate.recordType}/${candidate.recordId}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  // Step 3: LLM.
+  let llmResult;
+  try {
+    const prompt = buildApplyPrompt(candidate, fetchResult.content);
+    llmResult = await callLlmForSourcing(
+      client,
+      prompt,
+      `apply-${candidate.recordType}-${candidate.recordId}`,
+    );
+  } catch (e: unknown) {
+    return {
+      id: candidate.id,
+      recordType: candidate.recordType,
+      recordId: candidate.recordId,
+      suggestedUrl: candidate.suggestedUrl,
+      error: `LLM call failed: ${e instanceof Error ? e.message : String(e)}`,
+      awaitingIngest: false,
+    };
+  }
+
+  const newVerdict = llmResult.verdict as SourcingVerdict;
+  const changed = newVerdict !== previousVerdict;
+
+  // Step 4: persist evidence + aggregate verdict.
+  try {
+    await storeSourcingEvidence(
+      {
+        recordType: candidate.recordType as Parameters<typeof storeSourcingEvidence>[0]['recordType'],
+        recordId: candidate.recordId,
+        sourceUrl: candidate.suggestedUrl,
+        verdict: newVerdict,
+        confidence: llmResult.confidence,
+        extractedValue: llmResult.extractedValue ?? '',
+        reasoning: `Apply URL suggestion #${candidate.id}. ${llmResult.reasoning ?? ''}`,
+        entityId: candidate.entityId,
+        fieldName: candidate.fieldName,
+      },
+      LOG_PREFIX,
+    );
+  } catch (e: unknown) {
+    return {
+      id: candidate.id,
+      recordType: candidate.recordType,
+      recordId: candidate.recordId,
+      suggestedUrl: candidate.suggestedUrl,
+      error: `Evidence storage failed: ${e instanceof Error ? e.message : String(e)}`,
+      awaitingIngest: false,
+    };
+  }
+
+  const verdictBody: Record<string, unknown> = {
+    recordType: candidate.recordType,
+    recordId: candidate.recordId,
+    verdict: newVerdict,
+    confidence: llmResult.confidence,
+    reasoning: `Applied URL suggestion #${candidate.id}. Prior: ${previousVerdict}. ${changed ? 'Changed.' : 'Unchanged.'}`,
+    sourcesChecked: 1,
+    nextCheckDue: computeNextCheckDue(newVerdict),
+  };
+  // Carry fieldName through when present so we don't accidentally demote
+  // a field-level verdict into a row-level one (sourcing-recheck.ts has the
+  // same risk but we do it right here).
+  if (candidate.fieldName != null) verdictBody.fieldName = candidate.fieldName;
+  if (candidate.entityId != null) verdictBody.entityId = candidate.entityId;
+
+  const verdictResp = await storeVerdictRpc(verdictBody);
+  if (!verdictResp.ok) {
+    return {
+      id: candidate.id,
+      recordType: candidate.recordType,
+      recordId: candidate.recordId,
+      suggestedUrl: candidate.suggestedUrl,
+      error: `Verdict storage failed: ${verdictResp.error ?? verdictResp.message ?? 'unknown'}`,
+      awaitingIngest: false,
+    };
+  }
+
+  return {
+    id: candidate.id,
+    recordType: candidate.recordType,
+    recordId: candidate.recordId,
+    suggestedUrl: candidate.suggestedUrl,
+    previousVerdict,
+    newVerdict,
+    confidence: llmResult.confidence,
+    changed,
+  };
+}
+
+// ── Main command ─────────────────────────────────────────────────────
+
+async function applyCommand(
+  _args: string[],
+  options: ApplyOptions,
+): Promise<CommandResult> {
+  const isDryRun = options['dry-run'] || options.dryRun;
+  const statusParse = parseStatusFilter(options.status);
+  if ('error' in statusParse) {
+    return { exitCode: 1, output: statusParse.error };
+  }
+  const statuses = statusParse;
+  const typeFilter = options.type as string | undefined;
+  const limit = parseBoundedInt(options.limit, DEFAULT_LIMIT, MAX_LIMIT, 'limit');
+  const budget = parsePositiveFloat(options.budget, DEFAULT_BUDGET_USD, 'budget');
+
+  console.log('\x1b[1mSource-Check Apply Suggestions\x1b[0m');
+  console.log(`Statuses: ${statuses.join(', ')}${typeFilter ? ` | type=${typeFilter}` : ''}`);
+  console.log('');
+
+  // ── Step 1: fetch candidates ──
+  console.log('Fetching candidate suggestions...');
+  const candidatesResult = await fetchCandidates(statuses, typeFilter, limit);
+  if ('error' in candidatesResult) {
+    return { exitCode: 1, output: candidatesResult.error };
+  }
+  const { candidates } = candidatesResult;
+
+  if (candidates.length === 0) {
+    return {
+      exitCode: 0,
+      output: `No suggestions found with status in {${statuses.join(', ')}}${typeFilter ? ` and recordType=${typeFilter}` : ''}.`,
+    };
+  }
+
+  console.log(`  Found ${candidates.length} candidate(s) (limit=${limit})`);
+
+  // ── Step 2: budget cap ──
+  const maxByBudget = Math.floor(budget / ESTIMATED_COST_PER_VERIFICATION);
+  const toApply = candidates.slice(0, maxByBudget);
+  const estimatedCost = toApply.length * ESTIMATED_COST_PER_VERIFICATION;
+
+  if (maxByBudget < candidates.length) {
+    console.log(`  Budget \$${budget.toFixed(2)} caps at ${maxByBudget} apply(s) (est. cost \$${estimatedCost.toFixed(2)})`);
+  }
+
+  // ── Step 3: dry run ──
+  if (isDryRun) {
+    return formatDryRunOutput(toApply, candidates.length, estimatedCost, options);
+  }
+
+  // ── Live execution ──
+  const client = createLlmClient();
+  const summary: ApplySummary = {
+    totalCandidates: candidates.length,
+    processed: 0,
+    applied: 0,
+    changed: 0,
+    errors: 0,
+    awaitingIngest: 0,
+    statusPatchErrors: 0,
+    estimatedCost,
+    verdictTransitions: [],
+    results: [],
+    failures: [],
+  };
+  const transitionCounts = new Map<string, number>();
+
+  console.log(`\n\x1b[1mApplying ${toApply.length} suggestions (est. \$${estimatedCost.toFixed(2)})...\x1b[0m\n`);
+
+  for (let i = 0; i < toApply.length; i++) {
+    const candidate = toApply[i];
+    const label = `${candidate.recordType}/${candidate.recordId}`.slice(0, 60);
+    const urlShort = candidate.suggestedUrl.length > 80
+      ? candidate.suggestedUrl.slice(0, 77) + '...'
+      : candidate.suggestedUrl;
+    console.log(`  [${i + 1}/${toApply.length}] ${label} → ${urlShort}`);
+
+    summary.processed++;
+    const result = await applyOne(candidate, client);
+
+    if ('error' in result) {
+      summary.errors++;
+      if (result.awaitingIngest) summary.awaitingIngest++;
+      summary.failures.push(result);
+      const prefix = result.awaitingIngest ? '    \x1b[33mAWAITING INGEST' : '    \x1b[31mERROR';
+      console.log(`${prefix}: ${result.error}\x1b[0m`);
+      continue;
+    }
+
+    summary.applied++;
+    summary.results.push(result);
+
+    if (result.changed) summary.changed++;
+    const transitionKey = `${result.previousVerdict}→${result.newVerdict}`;
+    transitionCounts.set(transitionKey, (transitionCounts.get(transitionKey) ?? 0) + 1);
+
+    const color = result.newVerdict === 'confirmed' ? '\x1b[32m'
+      : result.newVerdict === 'contradicted' ? '\x1b[31m'
+      : '\x1b[33m';
+    const changeMarker = result.changed ? ' [CHANGED]' : '';
+    console.log(`    ${color}${result.previousVerdict} → ${result.newVerdict}\x1b[0m (confidence: ${(result.confidence * 100).toFixed(0)}%)${changeMarker}`);
+
+    // Mark the suggestion as applied. A status-patch failure must not drop
+    // the apply — the evidence and verdict are already stored, so next run
+    // would just re-do the LLM. We log but continue.
+    try {
+      const patchResp = await updateUrlSuggestionStatus(candidate.id, {
+        status: 'applied',
+        reviewedBy: 'sourcing-apply-suggestions',
+      });
+      if (!patchResp.ok) {
+        summary.statusPatchErrors++;
+        console.warn(`    \x1b[33mFailed to mark suggestion ${candidate.id} as applied: ${patchResp.message ?? 'unknown'}\x1b[0m`);
+      }
+    } catch (e: unknown) {
+      summary.statusPatchErrors++;
+      console.warn(`    \x1b[33mFailed to mark suggestion ${candidate.id} as applied: ${e instanceof Error ? e.message : String(e)}\x1b[0m`);
+    }
+  }
+
+  // Roll up transitions.
+  summary.verdictTransitions = [...transitionCounts.entries()]
+    .map(([key, count]) => {
+      const [from, to] = key.split('→');
+      return { from, to, count };
+    })
+    .sort((a, b) => b.count - a.count);
+
+  // ── Exit code ──
+  // Non-zero on any error so CI / scripts catch partial failure. Note: the
+  // `awaiting ingest` path is NOT an error in the usual sense — it just means
+  // the second pass hasn't been run yet — but it contributes to `errors`
+  // because the caller should know the sweep isn't fully converged.
+  const exitCode = summary.errors > 0 || summary.statusPatchErrors > 0 ? 1 : 0;
+
+  if (options.ci || options.json) {
+    return { exitCode, output: JSON.stringify(summary) };
+  }
+  return { exitCode, output: formatSummaryOutput(summary) };
+}
+
+// ── Output formatting ────────────────────────────────────────────────
+
+function formatDryRunOutput(
+  items: PendingSuggestion[],
+  totalCandidates: number,
+  estimatedCost: number,
+  options: ApplyOptions,
+): CommandResult {
+  if (options.ci || options.json) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        totalCandidates,
+        selected: items.length,
+        estimatedCost,
+        items: items.map((i) => ({
+          id: i.id,
+          recordType: i.recordType,
+          recordId: i.recordId,
+          fieldName: i.fieldName,
+          suggestedUrl: i.suggestedUrl,
+          sourceProvider: i.sourceProvider,
+          status: i.status,
+        })),
+      }),
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`\x1b[1mDry run: ${items.length} of ${totalCandidates} suggestions would be applied\x1b[0m`);
+  lines.push(`Estimated cost: \$${estimatedCost.toFixed(2)}`);
+  lines.push('');
+
+  const byType = new Map<string, number>();
+  for (const item of items) {
+    byType.set(item.recordType, (byType.get(item.recordType) ?? 0) + 1);
+  }
+  lines.push('\x1b[1mBy record type:\x1b[0m');
+  for (const [type, cnt] of [...byType.entries()].sort((a, b) => b[1] - a[1])) {
+    lines.push(`  ${type.padEnd(20)} ${cnt}`);
+  }
+  lines.push('');
+
+  const byProvider = new Map<string, number>();
+  for (const item of items) {
+    byProvider.set(item.sourceProvider, (byProvider.get(item.sourceProvider) ?? 0) + 1);
+  }
+  lines.push('\x1b[1mBy source provider:\x1b[0m');
+  for (const [provider, cnt] of [...byProvider.entries()].sort((a, b) => b[1] - a[1])) {
+    lines.push(`  ${provider.padEnd(15)} ${cnt}`);
+  }
+  lines.push('');
+
+  const header = `${'ID'.padEnd(8)} ${'Type'.padEnd(16)} ${'Record'.padEnd(30)} ${'Status'.padEnd(14)} URL`;
+  lines.push(`\x1b[1m${header}\x1b[0m`);
+  lines.push('-'.repeat(120));
+  for (const item of items.slice(0, 30)) {
+    const rid = item.recordId.length > 28 ? item.recordId.slice(0, 27) + '...' : item.recordId;
+    const url = item.suggestedUrl.length > 50 ? item.suggestedUrl.slice(0, 47) + '...' : item.suggestedUrl;
+    lines.push(
+      `${String(item.id).padEnd(8)} ${item.recordType.padEnd(16)} ${rid.padEnd(30)} ${item.status.padEnd(14)} ${url}`,
+    );
+  }
+  if (items.length > 30) {
+    lines.push(`  ... and ${items.length - 30} more`);
+  }
+
+  lines.push('');
+  lines.push('Use without --dry-run to apply (calls LLM against each suggested URL).');
+
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+function formatSummaryOutput(summary: ApplySummary): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push('\x1b[1m=== Apply-Suggestions Summary ===\x1b[0m');
+  lines.push(`Candidates:        ${summary.totalCandidates}`);
+  lines.push(`Processed:         ${summary.processed}`);
+  lines.push(`Applied:           ${summary.applied}`);
+  lines.push(`Changed verdicts:  ${summary.changed}`);
+  lines.push(`Errors:            ${summary.errors}`);
+  if (summary.awaitingIngest > 0) {
+    lines.push(`  \x1b[33m(${summary.awaitingIngest} awaiting resource-ingest — re-run in a few hours)\x1b[0m`);
+  }
+  if (summary.statusPatchErrors > 0) {
+    lines.push(`  \x1b[33m${summary.statusPatchErrors} suggestion(s) applied but not marked as 'applied' — next run will re-apply\x1b[0m`);
+  }
+  lines.push(`Est. cost:         \$${summary.estimatedCost.toFixed(2)}`);
+  lines.push('');
+
+  if (summary.verdictTransitions.length > 0) {
+    lines.push('\x1b[1mVerdict transitions:\x1b[0m');
+    for (const t of summary.verdictTransitions) {
+      const color = t.to === 'confirmed' ? '\x1b[32m'
+        : t.to === 'contradicted' ? '\x1b[31m'
+        : '\x1b[33m';
+      lines.push(`  ${t.from.padEnd(15)} → ${color}${t.to.padEnd(15)}\x1b[0m ${t.count}`);
+    }
+    lines.push('');
+  }
+
+  if (summary.failures.length > 0) {
+    lines.push(`\x1b[31mErrors (${summary.failures.length}):\x1b[0m`);
+    for (const f of summary.failures.slice(0, 10)) {
+      const tag = f.awaitingIngest ? '[awaiting-ingest] ' : '';
+      lines.push(`  ${tag}${f.recordType}/${f.recordId}: ${f.error}`);
+    }
+    if (summary.failures.length > 10) {
+      lines.push(`  ... and ${summary.failures.length - 10} more`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Exports ──────────────────────────────────────────────────────────
+
+export const commands = {
+  default: applyCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check Apply Suggestions — consume approved URL suggestions
+
+Usage:
+  crux sourcing-apply-suggestions [options]
+
+Options:
+  --status=X,Y        Comma-separated statuses to consume (default: approved,auto_verified).
+                      Valid: ${VALID_SUGGESTION_STATUSES.join(' | ')}
+  --type=X            Filter by record type (e.g., grant, personnel, fact)
+  --limit=N           Max suggestions to apply (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
+  --budget=N          Max dollars to spend on LLM rechecks (default: \$${DEFAULT_BUDGET_USD.toFixed(2)},
+                      est. ~\$${ESTIMATED_COST_PER_VERIFICATION.toFixed(2)}/apply)
+  --dry-run           Preview what would be applied without fetching or LLM calls
+  --ci / --json       Machine-readable JSON output
+
+What it does:
+  For each suggestion in {status, status, …}:
+    1. Fetch source content from the suggested URL (cache + Wayback fallback).
+    2. LLM-verify the claim against the new content.
+    3. Store a new evidence row + update the aggregate verdict.
+    4. Mark the suggestion as 'applied' so re-runs are idempotent.
+
+  Brand-new suggestion URLs will usually miss the cache on the first pass.
+  fetchSourceContent auto-enqueues a resource-ingest job in that case and the
+  suggestion stays in its original status — re-run the command after the
+  ingest worker catches up (usually minutes to a few hours).
+
+Requires WIKI_SERVER_ENV=prod in agent slots (no local wiki-server).
+`.trim();
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -99,6 +99,7 @@ import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
 import * as sourcingBackfillHomepagesCommands from './commands/sourcing-backfill-homepages.ts';
 import * as sourcingSampleCoverageCommands from './commands/sourcing-sample-coverage.ts';
 import * as sourcingSuggestUrlsCommands from './commands/sourcing-suggest-urls.ts';
+import * as sourcingApplySuggestionsCommands from './commands/sourcing-apply-suggestions.ts';
 import * as sourcingCleanupOrphansCommands from './commands/sourcing-cleanup-orphans.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
@@ -192,6 +193,7 @@ const domains = {
   'sourcing-backfill-homepages': sourcingBackfillHomepagesCommands,
   'sourcing-sample-coverage': sourcingSampleCoverageCommands,
   'sourcing-suggest-urls': sourcingSuggestUrlsCommands,
+  'sourcing-apply-suggestions': sourcingApplySuggestionsCommands,
   'sourcing-cleanup-orphans': sourcingCleanupOrphansCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -221,6 +221,23 @@ export async function listUrlSuggestions(
   );
 }
 
+/**
+ * Update a single URL suggestion's status (approve / reject / mark applied).
+ * Thin PATCH wrapper over /api/sourcing/url-suggestions/:id. Used by
+ * sourcing-apply-suggestions (QUA-591) to mark 'applied' after a successful
+ * URL swap + recheck.
+ */
+export async function updateUrlSuggestionStatus(
+  id: number,
+  body: { status: SuggestionStatus; reviewedBy?: string; notes?: string | null },
+): Promise<ApiResult<{ ok: boolean; id: number }>> {
+  return apiRequest<{ ok: boolean; id: number }>(
+    'PATCH',
+    `/api/sourcing/url-suggestions/${id}`,
+    body,
+  );
+}
+
 /** Get records due for re-check. */
 export async function getDueForRecheck(
   options?: { recordType?: string; limit?: number },


### PR DESCRIPTION
## Summary

Adds the missing consumer for the `sourcing_url_suggestions` queue. The `sourcing-suggest-urls` pipeline has been write-only — it generated candidate URLs for unverifiable verdicts but nothing ever consumed `approved` / `auto_verified` rows, so suggestions sat in the queue forever and verdicts stayed `unverifiable`.

New command:

```
crux sourcing-apply-suggestions [--status=approved,auto_verified]
                                [--type=X] [--limit=N] [--budget=N]
                                [--dry-run]
```

Per suggestion it:
1. Fetches source content from the suggested URL (cache + Wayback fallback, same path as recheck).
2. LLM-verifies the claim against the new content.
3. Stores a new evidence row + updates the aggregate verdict.
4. Marks the suggestion as `applied` so re-runs are naturally idempotent.

Brand-new URLs typically miss the citation_content cache on first pass — `fetchSourceContent` auto-enqueues a resource-ingest job and we surface this as `awaiting-ingest` (non-zero exit so sweeps know they aren't converged). Operator re-runs hours later once the worker catches up.

## Part of QUA-547 split

QUA-547 (reduce 748 unverifiable verdicts to <200) split into:

- **QUA-591** (this PR) — build the apply-suggestions consumer
- QUA-592 — add LLM auto-approval to `sourcing-suggest-urls`
- QUA-594 — run the end-to-end sweep end-to-end
- QUA-596 — triage remainders

Split comment: https://linear.app/quantifieduncertainty/issue/QUA-547

## Follow-up filed

Noticed `sourcing-recheck.ts:291-299` drops `fieldName` when storing the aggregate verdict — latent bug that demotes field-level verdicts into row-level ones. Filed as QUA-597. The new apply-suggestions command passes `fieldName` through correctly from the start.

## Test plan

- [x] `pnpm vitest run crux/commands/sourcing-apply-suggestions.test.ts` — 20 tests pass (option validation, pagination, happy path, field-match prior verdict, awaiting-ingest, dead-link, verdict storage failure, status-patch failure, budget cap, CI JSON output)
- [x] `pnpm crux w validate gate --fix` — 46 gate checks pass (2 advisory warnings unrelated to this change)
- [x] Smoke-tested `WIKI_SERVER_ENV=prod pnpm crux sourcing-apply-suggestions --dry-run --status=pending --limit=5` — correctly fetches real pending suggestions from prod and renders the dry-run table

## Deploy checklist

- [ ] Verify migration 0195 applied on server start — adds `applied` to `sourcing_url_suggestions.status` CHECK constraint (small table, ~thousands of rows, plain DROP + ADD is safe)
- [ ] Drizzle schema changed — verify wiki-server redeployed and schema is in sync

Fixes QUA-591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new CLI command to automatically apply URL suggestions with LLM-powered verification, content fetching, and evidence storage.
  * Added `applied` status for URL suggestions to track processed items.

* **Tests**
  * Added comprehensive test suite for the sourcing-apply-suggestions command covering pagination, verification workflows, and status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->