### PR TITLE
feat(schema): QUA-492 CHECK constraint on facts.fact_id canonical format

### DIFF
--- a/apps/wiki-server/drizzle/0198_qua_492_facts_fact_id_check.sql
+++ b/apps/wiki-server/drizzle/0198_qua_492_facts_fact_id_check.sql
@@ -14,36 +14,60 @@
 -- ## Prod enumeration (2026-04-18, per .claude/rules/database-migrations.md
 --   § "Adding CHECK constraints on enum columns")
 --
--- /internal/data-quality snapshot #20 (2026-04-18T06:00:01Z):
+-- Strict-regex enumeration via /api/facts/export (pulls every fact_id
+-- directly from PG, tests each against the constraint regex):
 --
---   facts.fact_id distribution (total 2274):
---     canonical_f    (^f_[A-Za-z0-9]{8,}$):  2274 (100%)
---     legacy_hex8    (^[0-9a-f]{8}$):           0
---     legacy_alnum10 (^[A-Za-z0-9]{10}$):       0
---     legacy_hex16   (^[0-9a-f]{16}$):          0
---     other:                                    0
+--   Total rows:                                  2274
+--   Length distribution:                         {"12": 2274}  (f_ + 10 chars)
+--   Strict violations (!~ '^f_[A-Za-z0-9]{10}$'):   0
 --
--- YAML source enumeration (packages/factbase/data/fb-entities/*.yaml,
--- 2131 fact IDs): 100% match `^f_[A-Za-z0-9]{10}$` exactly — 12 chars total.
+-- Sanity cross-check via /internal/data-quality snapshot #20
+-- (2026-04-18T06:00:01Z), looser `{8,}` regex: 2274/2274 in canonical_f bucket.
+-- YAML source (packages/factbase/data/fb-entities/*.yaml, 2131 IDs): 100%
+-- match `^f_[A-Za-z0-9]{10}$`.
 --
 -- The generator (generateFactId() in packages/factbase/src/ids.ts) always
--- produces exactly 10 chars after the `f_` prefix. The data-quality audit
--- regex uses `{8,}` only to catch drift; this migration enforces the
--- strict `{10}` form that matches what the generator actually emits.
+-- produces exactly 10 chars after the `f_` prefix. The strict `{10}` regex
+-- matches what the generator emits; VALIDATE CONSTRAINT is confirmed safe.
 --
--- ## Safety
+-- ## Lock profile + materialized-view dependency
 --
--- facts is small (2274 rows). No materialized view depends on it (verified
--- by grep for "MATERIALIZED VIEW.*facts" under apps/wiki-server/). Lock
--- contention risk is negligible.
+-- facts is small (2274 rows). `ADD CONSTRAINT ... NOT VALID` needs ACCESS
+-- EXCLUSIVE; `VALIDATE CONSTRAINT` needs SHARE UPDATE EXCLUSIVE.
 --
--- The NOT VALID + VALIDATE CONSTRAINT split is not strictly necessary at
--- this size but is used for consistency with the pattern in
--- .claude/rules/database-migrations.md § "`ADD CONSTRAINT ... NOT VALID` +
--- separate `VALIDATE CONSTRAINT`" and to be future-proof as the table grows.
+-- The `things_search` materialized view (defined by migration 0190) reads
+-- `FROM facts f` and is REFRESH'd (CONCURRENTLY) by the hourly job at
+-- apps/wiki-server/src/routes/operational/things-search-refresh.ts with a
+-- 180s statement_timeout. A REFRESH holds ACCESS SHARE on `facts`, which
+-- conflicts with the ACCESS EXCLUSIVE that `ADD CONSTRAINT` acquires. The
+-- migration client's default `lock_timeout` is 60s — not enough to survive
+-- colliding with a long-running REFRESH. Same failure shape as QUA-302.
+--
+-- Mitigations:
+--   1. `SET LOCAL lock_timeout = '180000'` (below) extends the wait to
+--      match the REFRESH's statement_timeout.
+--   2. facts is small enough that NOT VALID is milliseconds once the lock
+--      is acquired, so the "wait-then-succeed" path is the common case.
+--
+-- ## Transaction semantics
+--
+-- Drizzle wraps each migration SQL file in a single transaction. That means
+-- both ADD CONSTRAINT (NOT VALID) and VALIDATE CONSTRAINT run inside the
+-- same transaction and the ACCESS EXCLUSIVE lock is held through VALIDATE.
+-- For a 2274-row table this is inconsequential (validation is sub-second).
+-- If `facts` grows large enough that VALIDATE becomes slow, this migration
+-- should be split into two files (0193a NOT VALID, 0193b VALIDATE) so the
+-- locks release between them. This is tracked in .claude/rules/database-migrations.md
+-- § "ADD CONSTRAINT ... NOT VALID + separate VALIDATE CONSTRAINT".
 --
 -- ADD CONSTRAINT is wrapped in a DO block with duplicate_object EXCEPTION
--- handling so the migration is idempotent — safe to re-run if interrupted.
+-- handling so a manual re-apply (outside Drizzle) is a no-op instead of an
+-- error. Drizzle itself tracks applied migrations in __drizzle_migrations
+-- and won't re-run this file on startup.
+
+-- Extend lock wait to tolerate an in-progress things_search REFRESH (180s
+-- statement_timeout there). SET LOCAL only lasts for this transaction.
+SET LOCAL lock_timeout = '180000';
 
 -- 1. Register the CHECK constraint as unchecked metadata.
 --    Acquires ACCESS EXCLUSIVE for milliseconds; no row scan.
@@ -56,5 +80,6 @@ END $$;
 
 -- 2. Validate against existing rows.
 --    Only needs SHARE UPDATE EXCLUSIVE — concurrent SELECT/INSERT/UPDATE
---    are allowed.
+--    are allowed (other than the ACCESS EXCLUSIVE already held from step 1
+--    inside this transaction; see "Transaction semantics" above).
 ALTER TABLE "facts" VALIDATE CONSTRAINT chk_facts_fact_id_format;

--- a/apps/wiki-server/drizzle/0198_qua_492_facts_fact_id_check.sql
+++ b/apps/wiki-server/drizzle/0198_qua_492_facts_fact_id_check.sql
@@ -1,0 +1,60 @@
+-- QUA-492 (QUA-408 Phase 1 closeout, facts half): CHECK constraint on
+-- facts.fact_id to enforce canonical `f_<10-char alnum>` format.
+--
+-- The 248-ID migration to canonical format landed 2026-04-03 (commit
+-- b52551357) and was completed by QUA-497 (merged 2026-04-16, PR #4375)
+-- which migrated the last 776 bare10 IDs. This migration locks the door:
+-- non-canonical rows can no longer be inserted or updated.
+--
+-- Resources-side CHECK constraints (resources.stable_id,
+-- entity_resources.resource_id, resources.id) remain blocked on QUA-549
+-- Phase B completion and are intentionally out of scope here, per the
+-- 2026-04-16 rescope comment on QUA-492.
+--
+-- ## Prod enumeration (2026-04-18, per .claude/rules/database-migrations.md
+--   § "Adding CHECK constraints on enum columns")
+--
+-- /internal/data-quality snapshot #20 (2026-04-18T06:00:01Z):
+--
+--   facts.fact_id distribution (total 2274):
+--     canonical_f    (^f_[A-Za-z0-9]{8,}$):  2274 (100%)
+--     legacy_hex8    (^[0-9a-f]{8}$):           0
+--     legacy_alnum10 (^[A-Za-z0-9]{10}$):       0
+--     legacy_hex16   (^[0-9a-f]{16}$):          0
+--     other:                                    0
+--
+-- YAML source enumeration (packages/factbase/data/fb-entities/*.yaml,
+-- 2131 fact IDs): 100% match `^f_[A-Za-z0-9]{10}$` exactly — 12 chars total.
+--
+-- The generator (generateFactId() in packages/factbase/src/ids.ts) always
+-- produces exactly 10 chars after the `f_` prefix. The data-quality audit
+-- regex uses `{8,}` only to catch drift; this migration enforces the
+-- strict `{10}` form that matches what the generator actually emits.
+--
+-- ## Safety
+--
+-- facts is small (2274 rows). No materialized view depends on it (verified
+-- by grep for "MATERIALIZED VIEW.*facts" under apps/wiki-server/). Lock
+-- contention risk is negligible.
+--
+-- The NOT VALID + VALIDATE CONSTRAINT split is not strictly necessary at
+-- this size but is used for consistency with the pattern in
+-- .claude/rules/database-migrations.md § "`ADD CONSTRAINT ... NOT VALID` +
+-- separate `VALIDATE CONSTRAINT`" and to be future-proof as the table grows.
+--
+-- ADD CONSTRAINT is wrapped in a DO block with duplicate_object EXCEPTION
+-- handling so the migration is idempotent — safe to re-run if interrupted.
+
+-- 1. Register the CHECK constraint as unchecked metadata.
+--    Acquires ACCESS EXCLUSIVE for milliseconds; no row scan.
+DO $$ BEGIN
+  ALTER TABLE "facts"
+    ADD CONSTRAINT chk_facts_fact_id_format
+    CHECK (fact_id ~ '^f_[A-Za-z0-9]{10}$') NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 2. Validate against existing rows.
+--    Only needs SHARE UPDATE EXCLUSIVE — concurrent SELECT/INSERT/UPDATE
+--    are allowed.
+ALTER TABLE "facts" VALIDATE CONSTRAINT chk_facts_fact_id_format;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1387,6 +1387,13 @@
       "when": 1786176000000,
       "tag": "0197_qua_566_phase_b3_papers_posts_citations",
       "breakpoints": true
+    },
+    {
+      "idx": 198,
+      "version": "7",
+      "when": 1786262400000,
+      "tag": "0198_qua_492_facts_fact_id_check",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/migration-0198-facts-fact-id-check.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0198-facts-fact-id-check.test.ts
@@ -44,10 +44,62 @@ describe("migration 0198 — QUA-492 facts.fact_id CHECK constraint", () => {
   });
 
   it("wraps ADD CONSTRAINT in a duplicate_object EXCEPTION handler (idempotent)", () => {
-    // DO $$ ... EXCEPTION WHEN duplicate_object ... END $$ makes the
-    // migration safe to re-run if interrupted partway through.
+    // DO $$ ... EXCEPTION WHEN duplicate_object ... END $$ makes a manual
+    // re-apply (outside Drizzle) a no-op. Drizzle itself tracks applied
+    // migrations and won't re-run this file.
     expect(sql).toMatch(
       /DO\s*\$\$[\s\S]*?ADD\s+CONSTRAINT\s+chk_facts_fact_id_format[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object[\s\S]*?END\s*\$\$/,
     );
+  });
+
+  it("sets lock_timeout to tolerate in-progress things_search REFRESH", () => {
+    // The things_search MV REFRESH (hourly job, 180s statement_timeout)
+    // holds ACCESS SHARE on facts. Without an extended lock_timeout the
+    // migration would fail at the default 60s. See migration 0190 +
+    // routes/operational/things-search-refresh.ts and the QUA-302 postmortem.
+    expect(sql).toMatch(/SET\s+LOCAL\s+lock_timeout\s*=\s*'180000'/);
+  });
+});
+
+describe("facts.fact_id CHECK regex semantics (behavior)", () => {
+  // PG regex operator `~` uses POSIX syntax, but [A-Za-z0-9]{10} is
+  // portable across POSIX and ECMAScript. Testing in JS gives us
+  // defense-in-depth without a live PG.
+  const CHECK_RE = /^f_[A-Za-z0-9]{10}$/;
+
+  it("accepts the canonical generateFactId() output shape", () => {
+    expect(CHECK_RE.test("f_a3Kf2rZ9mQ")).toBe(true); // mixed case + digit
+    expect(CHECK_RE.test("f_1234567890")).toBe(true); // all digits
+    expect(CHECK_RE.test("f_abcdefghij")).toBe(true); // all lowercase
+    expect(CHECK_RE.test("f_ABCDEFGHIJ")).toBe(true); // all uppercase
+  });
+
+  it("rejects non-canonical shapes that used to be in prod", () => {
+    expect(CHECK_RE.test("00mxokmZmg")).toBe(false); // bare 10-char legacy
+    expect(CHECK_RE.test("abcdef12")).toBe(false); // 8-char hex legacy
+    expect(CHECK_RE.test("abcdef1234567890")).toBe(false); // 16-char hex
+    expect(CHECK_RE.test("kb-abcdef1234567890")).toBe(false); // kb-prefixed
+  });
+
+  it("rejects length mismatches (off-by-one guards)", () => {
+    expect(CHECK_RE.test("f_abc123456")).toBe(false); // 9 chars after f_
+    expect(CHECK_RE.test("f_abcd12345")).toBe(false); // 10 chars but only 10 total
+    expect(CHECK_RE.test("f_abcdefghij1")).toBe(false); // 11 chars after f_
+  });
+
+  it("rejects wrong prefix / no prefix / empty", () => {
+    expect(CHECK_RE.test("sid_abc1234567")).toBe(false); // sid_ not f_
+    expect(CHECK_RE.test("f-abc1234567")).toBe(false); // hyphen not underscore
+    expect(CHECK_RE.test("F_abc1234567")).toBe(false); // uppercase prefix
+    expect(CHECK_RE.test("")).toBe(false);
+  });
+
+  it("rejects non-alphanumeric chars (excludes what base64url would leak)", () => {
+    // base64url can emit `-` or `_`; generateFactId() replaces them but
+    // verify the constraint would reject if the replacement ever broke.
+    expect(CHECK_RE.test("f_abc-defghi")).toBe(false); // hyphen
+    expect(CHECK_RE.test("f_abc_defghi")).toBe(false); // underscore
+    expect(CHECK_RE.test("f_abc defghi")).toBe(false); // space
+    expect(CHECK_RE.test("f_abcdefghi!")).toBe(false); // punctuation
   });
 });

--- a/apps/wiki-server/src/__tests__/migration-0198-facts-fact-id-check.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0198-facts-fact-id-check.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0198_qua_492_facts_fact_id_check.sql",
+);
+
+/**
+ * Schema-drift test: asserts the migration SQL contains the expected
+ * CHECK constraint. It does NOT verify PG-level rejection (PG enforces
+ * the constraint automatically once applied).
+ */
+describe("migration 0198 — QUA-492 facts.fact_id CHECK constraint", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("declares ADD CONSTRAINT chk_facts_fact_id_format on facts", () => {
+    expect(sql).toMatch(/ALTER\s+TABLE\s+"facts"/);
+    expect(sql).toMatch(/ADD\s+CONSTRAINT\s+chk_facts_fact_id_format\b/);
+  });
+
+  it("uses the canonical ^f_[A-Za-z0-9]{10}$ regex", () => {
+    // The strict {10} form matches generateFactId() output exactly.
+    // {8,} is only used by /internal/data-quality drift detection.
+    expect(sql).toMatch(
+      /CHECK\s*\(\s*fact_id\s*~\s*'\^f_\[A-Za-z0-9\]\{10\}\$'\s*\)/,
+    );
+  });
+
+  it("uses NOT VALID + VALIDATE CONSTRAINT (avoids long ACCESS EXCLUSIVE lock)", () => {
+    // Per .claude/rules/database-migrations.md: split DDL into metadata
+    // registration (NOT VALID, fast) and validation (VALIDATE CONSTRAINT,
+    // non-blocking) to avoid holding ACCESS EXCLUSIVE during a full row scan.
+    expect(sql).toMatch(
+      /ADD\s+CONSTRAINT\s+chk_facts_fact_id_format[\s\S]*?NOT\s+VALID/,
+    );
+    expect(sql).toMatch(
+      /VALIDATE\s+CONSTRAINT\s+chk_facts_fact_id_format\b/,
+    );
+  });
+
+  it("wraps ADD CONSTRAINT in a duplicate_object EXCEPTION handler (idempotent)", () => {
+    // DO $$ ... EXCEPTION WHEN duplicate_object ... END $$ makes the
+    // migration safe to re-run if interrupted partway through.
+    expect(sql).toMatch(
+      /DO\s*\$\$[\s\S]*?ADD\s+CONSTRAINT\s+chk_facts_fact_id_format[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object[\s\S]*?END\s*\$\$/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Lock the facts half of QUA-408 Phase 1: add a CHECK constraint on `facts.fact_id` enforcing the canonical `^f_[A-Za-z0-9]{10}$` format. Non-canonical rows can no longer be inserted or updated at the PG layer.

**Scope is narrow by design.** Resources-side CHECKs remain blocked on open QUA-549 Phase B sub-tickets and are out of scope per the [2026-04-16 rescope comment](https://linear.app/quantifieduncertainty/issue/QUA-492) on QUA-492. This PR ships the Facts half.

## Why now

- QUA-497 (PR #4375, merged 2026-04-16) migrated the last 776 legacy bare10 fact IDs. Prod is now 100% canonical.
- Two earlier attempts at QUA-492 halted because the premise was wrong — prod wasn't canonical. It is now.

## Prod enumeration (per `.claude/rules/database-migrations.md`)

Strict-regex check via `/api/facts/export` (every fact_id pulled from PG and tested against the constraint regex):

| Check | Count |
|---|---|
| Total rows | 2274 |
| Length distribution | `{"12": 2274}` (f_ + 10 chars) |
| **Strict `^f_[A-Za-z0-9]{10}$` violations** | **0** |

Sanity cross-check via `/internal/data-quality` snapshot #20 (2026-04-18): 2274/2274 in canonical_f bucket.
YAML source (`packages/factbase/data/fb-entities/*.yaml`, 2131 IDs): 100% match strict regex.

## Key design choices

- **Strict `{10}` regex** matches what `generateFactId()` actually emits. Data-quality audit uses looser `{8,}` only for drift detection.
- **`SET LOCAL lock_timeout = '180000'`** — `things_search` MV (migration 0190) reads `FROM facts` and is REFRESH'd hourly with a 180s statement_timeout. The REFRESH holds ACCESS SHARE, conflicting with the ACCESS EXCLUSIVE that `ADD CONSTRAINT` needs. This mitigates the QUA-302 failure shape.
- **`NOT VALID` + `VALIDATE CONSTRAINT`** for pattern consistency, even though the table is tiny. Migration comment documents that Drizzle wraps both in one transaction, so locks release at commit — when `facts` grows large enough for this to matter, the migration should be split into two files.
- **Legacy detection cleanup deferred.** `sanitize-raw-ids.ts` still handles resource IDs (blocked) and render-time embedded IDs. Safer to split as a follow-up once both CHECKs land.

## Test plan

- [x] Unit tests — 10 assertions (4 schema-drift + 6 regex behavior): canonical shape accepted, legacy shapes rejected, off-by-one guarded, wrong prefix rejected, non-alphanumeric rejected
- [x] `pnpm test` — 6778 tests pass
- [x] `pnpm build` — clean (2189 pages)
- [x] `pnpm crux w validate gate --fix` — 48/48 passes
- [x] `validate-drizzle-journal.ts` — new migration prefix unique, journal entry well-formed
- [x] Prod live-enumeration — 2274/2274 match strict regex (zero violations)
- [ ] Post-deploy: verify migration 0198 applied on server start (auto-detected by `crux gh deploy-tasks`)
- [ ] Post-deploy: `/internal/data-quality` continues to show facts.canonical_f = 100%

Closes QUA-492


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0198 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `manual` Post-deploy: confirm `/internal/data-quality` still shows `facts.canonical_f` = 100% (no VALIDATE-time rejections) — visit https://www.longtermwiki.com/internal/data-quality and check the ID Format Audit panel
- [ ] `manual` Post-deploy: verify a fresh factbase sync still works — `WIKI_SERVER_ENV=prod pnpm crux fb sourcing --entity=anthropic --limit=1` (sanity check that the CHECK doesn't reject current writes)
<!-- /deploy-tasks -->
