### PR TITLE
QUA-600: Extract swap_fk_target() PL/pgSQL helper for FK-target migrations

### DIFF
--- a/.claude/rules/database-migrations.md
+++ b/.claude/rules/database-migrations.md
@@ -146,6 +146,55 @@ END $$;
 
 > **Note on batching**: `COMMIT` is not allowed inside a `DO` block. Each `DO` execution runs as a single transaction. For true inter-batch commits, run the batch SQL in a shell loop (e.g. `while psql ... -c "UPDATE ... LIMIT 10000 ..." | grep -q "10000 rows"`) or use a stored procedure with `CALL` in PostgreSQL 14+.
 
+## Swapping an FK target column — use `swap_fk_target()`
+
+When a migration needs to swap a child table's FK from `parent(from_col)` to `parent(to_col)` (e.g. `resources.id` → `resources.stable_id`, or any future type-ID consolidation), **call the `swap_fk_target()` procedure** (migration 0199 / QUA-600) instead of hand-writing the four-step DROP/UPDATE/orphan-check/ADD template.
+
+```sql
+CALL swap_fk_target(
+  child_table  => 'resource_papers',
+  child_col    => 'resource_id',
+  parent_table => 'resources',
+  from_col     => 'id',
+  to_col       => 'stable_id',
+  on_delete    => 'CASCADE'
+  -- use_not_valid       => false   -- true for tables > ~100k rows
+  -- new_constraint_name => NULL    -- default: <child>_<col>_<parent>_<to>_fk
+);
+```
+
+The helper owns the invariants that drifted across the 12 QUA-549 Phase B migrations:
+
+- **Orphan check uses `NOT EXISTS` against the parent table**, never a format heuristic like `NOT LIKE 'sid_%'`. This is the exact defect PR #4460 shipped with (and #4466 fixed post-merge).
+- **Backfill UPDATE guards against overwriting to NULL** when `parent.to_col IS NULL` — missed by #4460 as well.
+- **Old constraint enumeration via `information_schema`**, not hardcoded names. Works regardless of whether the old FK has the Drizzle-generated name or PostgreSQL's default `<table>_<col>_fkey`.
+- **Idempotent on replay** — safe to re-run; a second call is a no-op because no old FKs match, no rows need rewriting, and the new constraint already exists.
+
+Canonical source: `apps/wiki-server/drizzle/helpers/swap_fk_target.sql`. Install migration: `apps/wiki-server/drizzle/0199_install_swap_fk_target.sql`. Integration tests: `apps/wiki-server/src/__tests__/swap-fk-target-integration.test.ts`.
+
+### When to pass `use_not_valid => true`
+
+Follow the same decision rule as the `ADD CONSTRAINT ... NOT VALID` pattern above. For **small tables** (<~100k rows) leave it `false` — a plain `ADD CONSTRAINT` scans the table under ACCESS EXCLUSIVE in milliseconds.
+
+For **mid-size tables** pass `true`. The procedure splits into `ADD CONSTRAINT ... NOT VALID` + `VALIDATE CONSTRAINT`, which reduces the risk of a long validation scan hitting the 60s `lock_timeout` if something else is holding the table.
+
+For **very large tables** (>1M rows, e.g. anything comparable to `hallucination_risk_snapshots` from the QUA-302 incident), do **not** use the helper's combined `use_not_valid` path — it still runs both statements inside a single Drizzle transaction, so the ACCESS EXCLUSIVE lock is held through VALIDATE. Instead:
+
+1. Migration A: hand-write `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID;`
+2. Migration B (or manual script): hand-write `ALTER TABLE ... VALIDATE CONSTRAINT ...;`
+
+So the lock releases between them. The helper still owns the FK discovery, backfill, and orphan check; just inline its pre-existing-FK drop + backfill + orphan check into Migration A before the bare `ADD CONSTRAINT ... NOT VALID`.
+
+### When NOT to use the helper
+
+- **Column renames** — if you're also renaming `child_col` at the same time, the helper can't do that; do the rename in a separate ALTER first, then call the helper.
+- **Changing `ON DELETE` policy without swapping the target** — no parent column swap, no helper; just `DROP CONSTRAINT` + `ADD CONSTRAINT` directly.
+- **Non-FK constraints** (CHECK, UNIQUE) — the helper is only for foreign-key target swaps.
+
+### Rule of thumb
+
+For FK target swaps in this codebase, the hand-rolled template is now a footgun — the helper exists precisely because the template shipped a copy-paste defect 12 times. Call it. If the helper is missing a feature you need, extend it in a follow-up PR rather than bypassing it.
+
 ## Deploy flow for DDL migrations
 
 1. Merge PR with the no-op migration — deploy succeeds without DDL contention
@@ -165,6 +214,7 @@ END $$;
 |------|---------|
 | `apps/wiki-server/src/db.ts` | Connection pools + migration runner |
 | `apps/wiki-server/drizzle/` | Drizzle migration SQL files |
+| `apps/wiki-server/drizzle/helpers/` | PL/pgSQL helper source files (`swap_fk_target.sql`, …) — canonical copies; actual installs live in numbered migrations |
 | `apps/wiki-server/scripts/` | Manual migration scripts (applied via psql) |
 | `apps/wiki-server/drizzle.config.ts` | Drizzle Kit config |
 | `.github/workflows/wiki-server-docker.yml` | Deploy pipeline with smoke test |

--- a/apps/wiki-server/drizzle/0199_install_swap_fk_target.sql
+++ b/apps/wiki-server/drizzle/0199_install_swap_fk_target.sql
@@ -1,0 +1,183 @@
+-- QUA-600: install swap_fk_target() PL/pgSQL helper.
+--
+-- Extracted from the QUA-549 Phase B migration template (12 PRs that each
+-- repeated the same ~60-100 lines of FK-target swap boilerplate). The helper
+-- owns the orphan check, NULL guard, constraint-name enumeration, and
+-- optional NOT VALID pattern so future FK-target migrations can't reintroduce
+-- the defects that shipped in PR #4460 (QUA-567) and were fixed post-merge
+-- in #4466.
+--
+-- Source of truth for the procedure body: drizzle/helpers/swap_fk_target.sql
+-- (kept alongside this migration as a standalone reference file). Any change
+-- to the procedure must be landed via a new CREATE OR REPLACE migration;
+-- Drizzle doesn't rescan the helpers/ folder.
+--
+-- Caller docs: .claude/rules/database-migrations.md § "Swapping an FK target
+-- column".
+
+CREATE OR REPLACE PROCEDURE swap_fk_target(
+  child_table         text,
+  child_col           text,
+  parent_table        text,
+  from_col            text,
+  to_col              text,
+  on_delete           text DEFAULT 'NO ACTION',
+  use_not_valid       boolean DEFAULT false,
+  new_constraint_name text DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $proc$
+DECLARE
+  normalized_on_delete text;
+  fk_name              text;
+  constraints_dropped  int  := 0;
+  rows_updated         bigint;
+  orphan_count         bigint;
+  final_name           text;
+BEGIN
+  -- Validate on_delete against the PostgreSQL FK action allowlist.
+  -- The value is interpolated into dynamic SQL below; validating against a
+  -- fixed allowlist is what keeps this safe from injection.
+  normalized_on_delete := upper(trim(on_delete));
+  IF normalized_on_delete NOT IN
+     ('NO ACTION', 'RESTRICT', 'CASCADE', 'SET NULL', 'SET DEFAULT') THEN
+    RAISE EXCEPTION
+      'swap_fk_target: on_delete must be one of NO ACTION, RESTRICT, CASCADE, SET NULL, SET DEFAULT (got: %)',
+      on_delete;
+  END IF;
+
+  -- Compute the final constraint name. Default follows Drizzle's convention:
+  -- <child_table>_<child_col>_<parent_table>_<to_col>_fk.
+  final_name := COALESCE(
+    new_constraint_name,
+    format('%s_%s_%s_%s_fk', child_table, child_col, parent_table, to_col)
+  );
+
+  RAISE NOTICE 'swap_fk_target: %.% → %.% (ON DELETE %, NOT VALID: %, constraint: %)',
+    child_table, child_col, parent_table, to_col,
+    normalized_on_delete, use_not_valid, final_name;
+
+  -- Step 1: Drop every FK on child_table.child_col that points at
+  -- parent_table.from_col. Enumerating via information_schema means we don't
+  -- need to know the constraint's name (Drizzle's generated name and
+  -- PostgreSQL's default differ, and either can appear depending on env).
+  --
+  -- Scoped to current_schema() so the helper is safe to use in tests or any
+  -- non-public schema; for production migrations running in public, it
+  -- behaves exactly like the hand-rolled template did.
+  FOR fk_name IN
+    SELECT tc.constraint_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema    = kcu.table_schema
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_name = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_name   = ccu.constraint_name
+     AND rc.unique_constraint_schema = ccu.constraint_schema
+    WHERE tc.table_schema     = current_schema()
+      AND tc.table_name       = child_table
+      AND tc.constraint_type  = 'FOREIGN KEY'
+      AND kcu.column_name     = child_col
+      AND ccu.table_name      = parent_table
+      AND ccu.column_name     = from_col
+  LOOP
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', child_table, fk_name);
+    constraints_dropped := constraints_dropped + 1;
+    RAISE NOTICE 'swap_fk_target: dropped old FK %', fk_name;
+  END LOOP;
+  RAISE NOTICE 'swap_fk_target: % old FK constraint(s) dropped', constraints_dropped;
+
+  -- Step 2: Backfill child_col values from from_col → to_col via JOIN on the
+  -- parent table. The three guards are load-bearing:
+  --   * child_col IS NOT NULL   — leave nullable FKs' NULLs alone.
+  --   * parent.to_col IS NOT NULL — never silently overwrite a real value
+  --     with NULL if the parent happens to lack a to_col value.
+  --   * child_col != parent.to_col — skip already-migrated rows; makes this
+  --     re-runnable without counting already-correct rows as "updated".
+  EXECUTE format(
+    $fmt$
+      UPDATE %1$I c
+      SET %2$I = p.%3$I
+      FROM %4$I p
+      WHERE c.%2$I      = p.%5$I
+        AND c.%2$I IS NOT NULL
+        AND c.%2$I     <> p.%3$I
+        AND p.%3$I IS NOT NULL
+    $fmt$,
+    child_table,   -- %1$I
+    child_col,     -- %2$I
+    to_col,        -- %3$I
+    parent_table,  -- %4$I
+    from_col       -- %5$I
+  );
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RAISE NOTICE 'swap_fk_target: backfilled % row(s)', rows_updated;
+
+  -- Step 3: Orphan check. Every non-null child_col value must now map to a
+  -- parent_table.to_col value, or the ADD CONSTRAINT below will fail with an
+  -- opaque FK violation. Raise here with an actionable message instead.
+  --
+  -- Critically, this uses NOT EXISTS against the parent table — not a format
+  -- heuristic like NOT LIKE 'sid_%'. That's the defect PR #4460 shipped with
+  -- (and #4466 fixed post-merge). The template owns the correct check.
+  EXECUTE format(
+    'SELECT COUNT(*) FROM %1$I c
+      WHERE c.%2$I IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM %3$I p WHERE p.%4$I = c.%2$I)',
+    child_table, child_col, parent_table, to_col
+  ) INTO orphan_count;
+
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION
+      'swap_fk_target: % orphan row(s) remain in %.% after backfill — no matching %.% value. Fix data (insert missing rows or delete orphans) before re-running.',
+      orphan_count, child_table, child_col, parent_table, to_col;
+  END IF;
+
+  -- Step 4: Add the new FK pointing at parent_table.to_col. Wrapped in an
+  -- IF NOT EXISTS check so a manual re-apply is a no-op rather than an error.
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema    = current_schema()
+      AND constraint_name = final_name
+      AND table_name      = child_table
+  ) THEN
+    IF use_not_valid THEN
+      -- ADD CONSTRAINT NOT VALID registers the constraint as unchecked
+      -- metadata (ACCESS EXCLUSIVE for milliseconds, no row scan). Followed
+      -- by VALIDATE CONSTRAINT which only needs SHARE UPDATE EXCLUSIVE.
+      -- See .claude/rules/database-migrations.md § "ADD CONSTRAINT ... NOT
+      -- VALID + separate VALIDATE CONSTRAINT" for the when-to-use guidance
+      -- and the QUA-302/QUA-156 incident note.
+      EXECUTE format(
+        'ALTER TABLE %1$I ADD CONSTRAINT %2$I FOREIGN KEY (%3$I) REFERENCES %4$I(%5$I) ON DELETE %6$s NOT VALID',
+        child_table, final_name, child_col, parent_table, to_col, normalized_on_delete
+      );
+      RAISE NOTICE 'swap_fk_target: added constraint % (NOT VALID)', final_name;
+    ELSE
+      EXECUTE format(
+        'ALTER TABLE %1$I ADD CONSTRAINT %2$I FOREIGN KEY (%3$I) REFERENCES %4$I(%5$I) ON DELETE %6$s',
+        child_table, final_name, child_col, parent_table, to_col, normalized_on_delete
+      );
+      RAISE NOTICE 'swap_fk_target: added constraint %', final_name;
+    END IF;
+  ELSE
+    RAISE NOTICE 'swap_fk_target: constraint % already exists; skipping ADD', final_name;
+  END IF;
+
+  -- Step 5: If the constraint was added NOT VALID, validate it separately.
+  -- ALTER TABLE … VALIDATE CONSTRAINT is a no-op if the constraint is
+  -- already VALID, so this is idempotent across reruns.
+  --
+  -- Note: when this procedure runs inside a Drizzle migration (single tx),
+  -- the ACCESS EXCLUSIVE lock from step 4's ADD CONSTRAINT is still held
+  -- through the VALIDATE. For very large tables (>1M rows) where VALIDATE
+  -- is slow, the caller should split this into two migrations instead of
+  -- using use_not_valid=true — see the rule doc for the manual pattern.
+  IF use_not_valid THEN
+    EXECUTE format('ALTER TABLE %I VALIDATE CONSTRAINT %I', child_table, final_name);
+    RAISE NOTICE 'swap_fk_target: validated constraint %', final_name;
+  END IF;
+END;
+$proc$;

--- a/apps/wiki-server/drizzle/0199_install_swap_fk_target.sql
+++ b/apps/wiki-server/drizzle/0199_install_swap_fk_target.sql
@@ -53,6 +53,15 @@ BEGIN
     format('%s_%s_%s_%s_fk', child_table, child_col, parent_table, to_col)
   );
 
+  -- PG silently truncates identifiers past 63 bytes (NAMEDATALEN-1). Truncation
+  -- desyncs the EXISTS idempotency check below from the stored constraint name,
+  -- so fail loudly with an actionable message instead.
+  IF octet_length(final_name) > current_setting('max_identifier_length')::int THEN
+    RAISE EXCEPTION
+      'swap_fk_target: generated constraint name "%" is % bytes, exceeds PostgreSQL max_identifier_length (% bytes). Pass new_constraint_name explicitly.',
+      final_name, octet_length(final_name), current_setting('max_identifier_length');
+  END IF;
+
   RAISE NOTICE 'swap_fk_target: %.% → %.% (ON DELETE %, NOT VALID: %, constraint: %)',
     child_table, child_col, parent_table, to_col,
     normalized_on_delete, use_not_valid, final_name;
@@ -69,17 +78,20 @@ BEGIN
     SELECT tc.constraint_name
     FROM information_schema.table_constraints tc
     JOIN information_schema.key_column_usage kcu
-      ON tc.constraint_name = kcu.constraint_name
-     AND tc.table_schema    = kcu.table_schema
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+     AND tc.table_schema      = kcu.table_schema
     JOIN information_schema.referential_constraints rc
-      ON tc.constraint_name = rc.constraint_name
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
     JOIN information_schema.constraint_column_usage ccu
-      ON rc.unique_constraint_name   = ccu.constraint_name
-     AND rc.unique_constraint_schema = ccu.constraint_schema
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
     WHERE tc.table_schema     = current_schema()
       AND tc.table_name       = child_table
       AND tc.constraint_type  = 'FOREIGN KEY'
       AND kcu.column_name     = child_col
+      AND ccu.table_schema    = current_schema()
       AND ccu.table_name      = parent_table
       AND ccu.column_name     = from_col
   LOOP
@@ -137,11 +149,69 @@ BEGIN
 
   -- Step 4: Add the new FK pointing at parent_table.to_col. Wrapped in an
   -- IF NOT EXISTS check so a manual re-apply is a no-op rather than an error.
+  -- The check verifies the existing constraint is (a) a FOREIGN KEY, (b) on
+  -- child_col, and (c) references parent_table.to_col — matching on name alone
+  -- would silently skip ADD if a same-named CHECK/UNIQUE or stale mis-pointing
+  -- FK occupied the name. On collision, raise rather than skip.
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type  <> 'FOREIGN KEY'
+  ) THEN
+    RAISE EXCEPTION
+      'swap_fk_target: constraint "%" already exists on %.% but is not a FOREIGN KEY — refusing to replace it. Rename or drop the existing constraint first.',
+      final_name, current_schema(), child_table;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type   = 'FOREIGN KEY'
+      AND kcu.column_name      = child_col
+      AND ccu.table_schema     = current_schema()
+      AND ccu.table_name       = parent_table
+      AND ccu.column_name     <> to_col
+  ) THEN
+    RAISE EXCEPTION
+      'swap_fk_target: FK "%" on %.% already exists but references a different column than %.% — refusing to skip ADD. Drop or rename the existing FK first.',
+      final_name, current_schema(), child_table, parent_table, to_col;
+  END IF;
+
   IF NOT EXISTS (
-    SELECT 1 FROM information_schema.table_constraints
-    WHERE table_schema    = current_schema()
-      AND constraint_name = final_name
-      AND table_name      = child_table
+    SELECT 1 FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type   = 'FOREIGN KEY'
+      AND kcu.column_name      = child_col
+      AND ccu.table_schema     = current_schema()
+      AND ccu.table_name       = parent_table
+      AND ccu.column_name      = to_col
   ) THEN
     IF use_not_valid THEN
       -- ADD CONSTRAINT NOT VALID registers the constraint as unchecked

--- a/apps/wiki-server/drizzle/helpers/swap_fk_target.sql
+++ b/apps/wiki-server/drizzle/helpers/swap_fk_target.sql
@@ -100,6 +100,15 @@ BEGIN
     format('%s_%s_%s_%s_fk', child_table, child_col, parent_table, to_col)
   );
 
+  -- PG silently truncates identifiers past 63 bytes (NAMEDATALEN-1). Truncation
+  -- desyncs the EXISTS idempotency check below from the stored constraint name,
+  -- so fail loudly with an actionable message instead.
+  IF octet_length(final_name) > current_setting('max_identifier_length')::int THEN
+    RAISE EXCEPTION
+      'swap_fk_target: generated constraint name "%" is % bytes, exceeds PostgreSQL max_identifier_length (% bytes). Pass new_constraint_name explicitly.',
+      final_name, octet_length(final_name), current_setting('max_identifier_length');
+  END IF;
+
   RAISE NOTICE 'swap_fk_target: %.% → %.% (ON DELETE %, NOT VALID: %, constraint: %)',
     child_table, child_col, parent_table, to_col,
     normalized_on_delete, use_not_valid, final_name;
@@ -116,17 +125,20 @@ BEGIN
     SELECT tc.constraint_name
     FROM information_schema.table_constraints tc
     JOIN information_schema.key_column_usage kcu
-      ON tc.constraint_name = kcu.constraint_name
-     AND tc.table_schema    = kcu.table_schema
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+     AND tc.table_schema      = kcu.table_schema
     JOIN information_schema.referential_constraints rc
-      ON tc.constraint_name = rc.constraint_name
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
     JOIN information_schema.constraint_column_usage ccu
-      ON rc.unique_constraint_name   = ccu.constraint_name
-     AND rc.unique_constraint_schema = ccu.constraint_schema
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
     WHERE tc.table_schema     = current_schema()
       AND tc.table_name       = child_table
       AND tc.constraint_type  = 'FOREIGN KEY'
       AND kcu.column_name     = child_col
+      AND ccu.table_schema    = current_schema()
       AND ccu.table_name      = parent_table
       AND ccu.column_name     = from_col
   LOOP
@@ -184,11 +196,69 @@ BEGIN
 
   -- Step 4: Add the new FK pointing at parent_table.to_col. Wrapped in an
   -- IF NOT EXISTS check so a manual re-apply is a no-op rather than an error.
+  -- The check verifies the existing constraint is (a) a FOREIGN KEY, (b) on
+  -- child_col, and (c) references parent_table.to_col — matching on name alone
+  -- would silently skip ADD if a same-named CHECK/UNIQUE or stale mis-pointing
+  -- FK occupied the name. On collision, raise rather than skip.
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type  <> 'FOREIGN KEY'
+  ) THEN
+    RAISE EXCEPTION
+      'swap_fk_target: constraint "%" already exists on %.% but is not a FOREIGN KEY — refusing to replace it. Rename or drop the existing constraint first.',
+      final_name, current_schema(), child_table;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type   = 'FOREIGN KEY'
+      AND kcu.column_name      = child_col
+      AND ccu.table_schema     = current_schema()
+      AND ccu.table_name       = parent_table
+      AND ccu.column_name     <> to_col
+  ) THEN
+    RAISE EXCEPTION
+      'swap_fk_target: FK "%" on %.% already exists but references a different column than %.% — refusing to skip ADD. Drop or rename the existing FK first.',
+      final_name, current_schema(), child_table, parent_table, to_col;
+  END IF;
+
   IF NOT EXISTS (
-    SELECT 1 FROM information_schema.table_constraints
-    WHERE table_schema    = current_schema()
-      AND constraint_name = final_name
-      AND table_name      = child_table
+    SELECT 1 FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_schema = kcu.constraint_schema
+     AND tc.constraint_name   = kcu.constraint_name
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_schema = rc.constraint_schema
+     AND tc.constraint_name   = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_schema = ccu.constraint_schema
+     AND rc.unique_constraint_name   = ccu.constraint_name
+    WHERE tc.constraint_schema = current_schema()
+      AND tc.constraint_name   = final_name
+      AND tc.table_schema      = current_schema()
+      AND tc.table_name        = child_table
+      AND tc.constraint_type   = 'FOREIGN KEY'
+      AND kcu.column_name      = child_col
+      AND ccu.table_schema     = current_schema()
+      AND ccu.table_name       = parent_table
+      AND ccu.column_name      = to_col
   ) THEN
     IF use_not_valid THEN
       -- ADD CONSTRAINT NOT VALID registers the constraint as unchecked

--- a/apps/wiki-server/drizzle/helpers/swap_fk_target.sql
+++ b/apps/wiki-server/drizzle/helpers/swap_fk_target.sql
@@ -1,0 +1,230 @@
+-- swap_fk_target() — canonical PL/pgSQL helper for swapping an FK's target column.
+--
+-- Source of truth for the procedure definition. The install migration
+-- (0199_install_swap_fk_target.sql) embeds this body verbatim. Any change
+-- here must be accompanied by a new migration that CREATE OR REPLACEs the
+-- procedure — Drizzle doesn't rescan this file.
+--
+-- ## Background
+--
+-- QUA-549 Phase B (migrations 0186, 0187–0194, 0196, 0197) swapped 17 FK
+-- columns from resources.id (legacy hex16) to resources.stable_id (canonical
+-- sid_<10>). Every migration repeated ~60-100 lines of the same template:
+--
+--   1. DROP CONSTRAINT IF EXISTS <drizzle_name> + <pg_default_name>
+--   2. UPDATE child SET col = parent.to_col FROM parent WHERE col = from_col
+--      + NOT LIKE 'sid_%' heuristic + parent.to_col IS NOT NULL guard
+--   3. DO $$ IF EXISTS (SELECT … orphans) THEN RAISE EXCEPTION END $$
+--   4. ADD CONSTRAINT … REFERENCES parent(to_col) ON DELETE <mode>
+--      (sometimes with NOT VALID + VALIDATE CONSTRAINT split)
+--
+-- The consistency review found:
+--   * PR #4460 (QUA-567) shipped with two defects (wrong orphan heuristic,
+--     missing null guard) that had to be fixed post-merge in #4466. Later
+--     PRs absorbed the fix by copy-paste, not by template.
+--   * NOT VALID usage drifted (some PRs used it, some didn't, no written rule).
+--   * Some PRs used hardcoded constraint names, others enumerated via pg_*.
+--
+-- This procedure owns the safe pattern so future FK-target migrations can't
+-- reintroduce those defects. Usage:
+--
+--   CALL swap_fk_target(
+--     child_table  => 'resource_papers',
+--     child_col    => 'resource_id',
+--     parent_table => 'resources',
+--     from_col     => 'id',
+--     to_col       => 'stable_id',
+--     on_delete    => 'CASCADE'
+--   );
+--
+-- See .claude/rules/database-migrations.md § "Swapping an FK target column"
+-- for the decision rules and the when-to-use-NOT-VALID guidance.
+--
+-- ## What the procedure does
+--
+-- 1. Validates on_delete against the PostgreSQL FK action allowlist.
+-- 2. Computes the new constraint name (or uses `new_constraint_name` override).
+-- 3. Enumerates every FK on `child_table.child_col` that points at
+--    `parent_table.from_col` via information_schema (robust to rename drift)
+--    and drops each one.
+-- 4. Backfills `child.child_col = parent.to_col` via JOIN, with the guards
+--    baked in: `child_col IS NOT NULL`, `child_col != parent.to_col`, and
+--    `parent.to_col IS NOT NULL`. Emits the row count via RAISE NOTICE.
+-- 5. Runs a NOT EXISTS orphan check and raises a descriptive exception if
+--    any rows remain that don't map to a parent.to_col value.
+-- 6. Adds the new FK constraint. If `use_not_valid=true`, splits into
+--    ADD CONSTRAINT … NOT VALID + separate VALIDATE CONSTRAINT.
+--
+-- ## Idempotency
+--
+-- Safe to run twice. On the second call: step 3 finds no old FKs to drop
+-- (or only finds new ones, which don't match the from_col predicate),
+-- step 4 updates 0 rows, step 5 finds 0 orphans, and step 6 is a no-op
+-- because the constraint already exists.
+
+CREATE OR REPLACE PROCEDURE swap_fk_target(
+  child_table         text,
+  child_col           text,
+  parent_table        text,
+  from_col            text,
+  to_col              text,
+  on_delete           text DEFAULT 'NO ACTION',
+  use_not_valid       boolean DEFAULT false,
+  new_constraint_name text DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $proc$
+DECLARE
+  normalized_on_delete text;
+  fk_name              text;
+  constraints_dropped  int  := 0;
+  rows_updated         bigint;
+  orphan_count         bigint;
+  final_name           text;
+BEGIN
+  -- Validate on_delete against the PostgreSQL FK action allowlist.
+  -- The value is interpolated into dynamic SQL below; validating against a
+  -- fixed allowlist is what keeps this safe from injection.
+  normalized_on_delete := upper(trim(on_delete));
+  IF normalized_on_delete NOT IN
+     ('NO ACTION', 'RESTRICT', 'CASCADE', 'SET NULL', 'SET DEFAULT') THEN
+    RAISE EXCEPTION
+      'swap_fk_target: on_delete must be one of NO ACTION, RESTRICT, CASCADE, SET NULL, SET DEFAULT (got: %)',
+      on_delete;
+  END IF;
+
+  -- Compute the final constraint name. Default follows Drizzle's convention:
+  -- <child_table>_<child_col>_<parent_table>_<to_col>_fk.
+  final_name := COALESCE(
+    new_constraint_name,
+    format('%s_%s_%s_%s_fk', child_table, child_col, parent_table, to_col)
+  );
+
+  RAISE NOTICE 'swap_fk_target: %.% → %.% (ON DELETE %, NOT VALID: %, constraint: %)',
+    child_table, child_col, parent_table, to_col,
+    normalized_on_delete, use_not_valid, final_name;
+
+  -- Step 1: Drop every FK on child_table.child_col that points at
+  -- parent_table.from_col. Enumerating via information_schema means we don't
+  -- need to know the constraint's name (Drizzle's generated name and
+  -- PostgreSQL's default differ, and either can appear depending on env).
+  --
+  -- Scoped to current_schema() so the helper is safe to use in tests or any
+  -- non-public schema; for production migrations running in public, it
+  -- behaves exactly like the hand-rolled template did.
+  FOR fk_name IN
+    SELECT tc.constraint_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema    = kcu.table_schema
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_name = rc.constraint_name
+    JOIN information_schema.constraint_column_usage ccu
+      ON rc.unique_constraint_name   = ccu.constraint_name
+     AND rc.unique_constraint_schema = ccu.constraint_schema
+    WHERE tc.table_schema     = current_schema()
+      AND tc.table_name       = child_table
+      AND tc.constraint_type  = 'FOREIGN KEY'
+      AND kcu.column_name     = child_col
+      AND ccu.table_name      = parent_table
+      AND ccu.column_name     = from_col
+  LOOP
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', child_table, fk_name);
+    constraints_dropped := constraints_dropped + 1;
+    RAISE NOTICE 'swap_fk_target: dropped old FK %', fk_name;
+  END LOOP;
+  RAISE NOTICE 'swap_fk_target: % old FK constraint(s) dropped', constraints_dropped;
+
+  -- Step 2: Backfill child_col values from from_col → to_col via JOIN on the
+  -- parent table. The three guards are load-bearing:
+  --   * child_col IS NOT NULL   — leave nullable FKs' NULLs alone.
+  --   * parent.to_col IS NOT NULL — never silently overwrite a real value
+  --     with NULL if the parent happens to lack a to_col value.
+  --   * child_col != parent.to_col — skip already-migrated rows; makes this
+  --     re-runnable without counting already-correct rows as "updated".
+  EXECUTE format(
+    $fmt$
+      UPDATE %1$I c
+      SET %2$I = p.%3$I
+      FROM %4$I p
+      WHERE c.%2$I      = p.%5$I
+        AND c.%2$I IS NOT NULL
+        AND c.%2$I     <> p.%3$I
+        AND p.%3$I IS NOT NULL
+    $fmt$,
+    child_table,   -- %1$I
+    child_col,     -- %2$I
+    to_col,        -- %3$I
+    parent_table,  -- %4$I
+    from_col       -- %5$I
+  );
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RAISE NOTICE 'swap_fk_target: backfilled % row(s)', rows_updated;
+
+  -- Step 3: Orphan check. Every non-null child_col value must now map to a
+  -- parent_table.to_col value, or the ADD CONSTRAINT below will fail with an
+  -- opaque FK violation. Raise here with an actionable message instead.
+  --
+  -- Critically, this uses NOT EXISTS against the parent table — not a format
+  -- heuristic like NOT LIKE 'sid_%'. That's the defect PR #4460 shipped with
+  -- (and #4466 fixed post-merge). The template owns the correct check.
+  EXECUTE format(
+    'SELECT COUNT(*) FROM %1$I c
+      WHERE c.%2$I IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM %3$I p WHERE p.%4$I = c.%2$I)',
+    child_table, child_col, parent_table, to_col
+  ) INTO orphan_count;
+
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION
+      'swap_fk_target: % orphan row(s) remain in %.% after backfill — no matching %.% value. Fix data (insert missing rows or delete orphans) before re-running.',
+      orphan_count, child_table, child_col, parent_table, to_col;
+  END IF;
+
+  -- Step 4: Add the new FK pointing at parent_table.to_col. Wrapped in an
+  -- IF NOT EXISTS check so a manual re-apply is a no-op rather than an error.
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema    = current_schema()
+      AND constraint_name = final_name
+      AND table_name      = child_table
+  ) THEN
+    IF use_not_valid THEN
+      -- ADD CONSTRAINT NOT VALID registers the constraint as unchecked
+      -- metadata (ACCESS EXCLUSIVE for milliseconds, no row scan). Followed
+      -- by VALIDATE CONSTRAINT which only needs SHARE UPDATE EXCLUSIVE.
+      -- See .claude/rules/database-migrations.md § "ADD CONSTRAINT ... NOT
+      -- VALID + separate VALIDATE CONSTRAINT" for the when-to-use guidance
+      -- and the QUA-302/QUA-156 incident note.
+      EXECUTE format(
+        'ALTER TABLE %1$I ADD CONSTRAINT %2$I FOREIGN KEY (%3$I) REFERENCES %4$I(%5$I) ON DELETE %6$s NOT VALID',
+        child_table, final_name, child_col, parent_table, to_col, normalized_on_delete
+      );
+      RAISE NOTICE 'swap_fk_target: added constraint % (NOT VALID)', final_name;
+    ELSE
+      EXECUTE format(
+        'ALTER TABLE %1$I ADD CONSTRAINT %2$I FOREIGN KEY (%3$I) REFERENCES %4$I(%5$I) ON DELETE %6$s',
+        child_table, final_name, child_col, parent_table, to_col, normalized_on_delete
+      );
+      RAISE NOTICE 'swap_fk_target: added constraint %', final_name;
+    END IF;
+  ELSE
+    RAISE NOTICE 'swap_fk_target: constraint % already exists; skipping ADD', final_name;
+  END IF;
+
+  -- Step 5: If the constraint was added NOT VALID, validate it separately.
+  -- ALTER TABLE … VALIDATE CONSTRAINT is a no-op if the constraint is
+  -- already VALID, so this is idempotent across reruns.
+  --
+  -- Note: when this procedure runs inside a Drizzle migration (single tx),
+  -- the ACCESS EXCLUSIVE lock from step 4's ADD CONSTRAINT is still held
+  -- through the VALIDATE. For very large tables (>1M rows) where VALIDATE
+  -- is slow, the caller should split this into two migrations instead of
+  -- using use_not_valid=true — see the rule doc for the manual pattern.
+  IF use_not_valid THEN
+    EXECUTE format('ALTER TABLE %I VALIDATE CONSTRAINT %I', child_table, final_name);
+    RAISE NOTICE 'swap_fk_target: validated constraint %', final_name;
+  END IF;
+END;
+$proc$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1394,6 +1394,13 @@
       "when": 1786262400000,
       "tag": "0198_qua_492_facts_fact_id_check",
       "breakpoints": true
+    },
+    {
+      "idx": 199,
+      "version": "7",
+      "when": 1786348800000,
+      "tag": "0199_install_swap_fk_target",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/swap-fk-target-drift.test.ts
+++ b/apps/wiki-server/src/__tests__/swap-fk-target-drift.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Drift check — swap_fk_target() procedure body is defined in two places:
+ *
+ *   drizzle/helpers/swap_fk_target.sql  (canonical reference copy)
+ *   drizzle/0199_install_swap_fk_target.sql  (Drizzle install migration)
+ *
+ * The procedure body MUST be identical between the two. Drizzle doesn't
+ * rescan the helpers/ folder, so the install migration is what actually
+ * runs; the helpers/ copy exists so developers have a single-file reference
+ * with the preamble comments and canonical version in one place.
+ *
+ * If you're updating the procedure, update both files in the same commit.
+ * Better: create a new `NNNN_update_swap_fk_target.sql` migration with the
+ * new body and update helpers/ to match — Drizzle's journal ensures the
+ * new version is applied to every env.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const drizzleDir = path.resolve(__dirname, "../../drizzle");
+
+/** Extract the CREATE OR REPLACE PROCEDURE block from a .sql file. */
+function extractProcedureBody(filePath: string): string {
+  const content = readFileSync(filePath, "utf8");
+  const start = content.indexOf("CREATE OR REPLACE PROCEDURE swap_fk_target");
+  if (start < 0) {
+    throw new Error(`Procedure declaration not found in ${filePath}`);
+  }
+  // The body ends at the closing `$proc$;` dollar-quoted tag.
+  const endMarker = "$proc$;";
+  const end = content.indexOf(endMarker, start);
+  if (end < 0) {
+    throw new Error(`Procedure terminator not found in ${filePath}`);
+  }
+  return content.slice(start, end + endMarker.length).trim();
+}
+
+describe("swap_fk_target helper + install migration parity", () => {
+  it("procedure body is identical in helpers/swap_fk_target.sql and 0199_install_swap_fk_target.sql", () => {
+    const helper = extractProcedureBody(
+      path.join(drizzleDir, "helpers/swap_fk_target.sql"),
+    );
+    const install = extractProcedureBody(
+      path.join(drizzleDir, "0199_install_swap_fk_target.sql"),
+    );
+    // Assert byte-identical. If someone changes one without the other, this
+    // fails with the full diff in the error output.
+    expect(install).toBe(helper);
+  });
+});

--- a/apps/wiki-server/src/__tests__/swap-fk-target-integration.test.ts
+++ b/apps/wiki-server/src/__tests__/swap-fk-target-integration.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Integration tests — swap_fk_target() PL/pgSQL helper from QUA-600
+ * (migration 0199).
+ *
+ * These tests require DATABASE_URL to be set. They are skipped otherwise.
+ * Run with: pnpm test:integration (or `pnpm test` with DATABASE_URL set).
+ *
+ * We create a dedicated test schema (`swap_fk_target_test`) with throwaway
+ * parent/child tables so the tests don't touch anything in the real public
+ * schema. Each test resets the tables.
+ *
+ * What we verify here are the invariants the helper promises to the migration
+ * template, not general PG behavior. The defects the helper exists to prevent
+ * (PR #4460 / #4466) are the primary test targets:
+ *   - Orphan check is NOT EXISTS against the parent, not a format heuristic.
+ *   - UPDATE doesn't overwrite a real FK with NULL when parent.to_col is NULL.
+ *   - Replay is a no-op.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import postgres from "postgres";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+
+const SCHEMA = "swap_fk_target_test";
+
+describeWithDb("swap_fk_target() (migration 0199 / QUA-600)", () => {
+  let sqlConn: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    sqlConn = postgres(DATABASE_URL!, { max: 2 });
+
+    // Sanity-check the procedure exists in the DB we're talking to. If this
+    // assertion fails, the DB wasn't migrated up to 0199 — bail early with a
+    // useful error rather than letting every test fail opaquely.
+    const procExists = await sqlConn<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE p.proname = 'swap_fk_target' AND n.nspname = 'public'
+      ) AS exists
+    `;
+    if (!procExists[0]?.exists) {
+      throw new Error(
+        "swap_fk_target procedure not installed — run migrations up to 0199 before this test.",
+      );
+    }
+
+    // Clean slate every run.
+    await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await sqlConn.unsafe(`CREATE SCHEMA ${SCHEMA}`);
+  });
+
+  afterAll(async () => {
+    await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await sqlConn.end();
+  });
+
+  /**
+   * Reset to the canonical two-table fixture used by most tests:
+   *   parent(id text PK, stable_id text UNIQUE)  -- id = legacy, stable_id = canonical
+   *   child(id serial PK, parent_id text FK → parent(id) ON DELETE <policy>)
+   *
+   * Tests set up their own rows after calling this.
+   */
+  async function resetFixture(onDelete = "CASCADE") {
+    await sqlConn.unsafe(`SET search_path TO ${SCHEMA}, public`);
+    await sqlConn.unsafe(`DROP TABLE IF EXISTS ${SCHEMA}.child CASCADE`);
+    await sqlConn.unsafe(`DROP TABLE IF EXISTS ${SCHEMA}.parent CASCADE`);
+    await sqlConn.unsafe(`
+      CREATE TABLE ${SCHEMA}.parent (
+        id text PRIMARY KEY,
+        stable_id text UNIQUE
+      )
+    `);
+    await sqlConn.unsafe(`
+      CREATE TABLE ${SCHEMA}.child (
+        id serial PRIMARY KEY,
+        parent_id text REFERENCES ${SCHEMA}.parent(id) ON DELETE ${onDelete}
+      )
+    `);
+  }
+
+  async function callHelper(opts: {
+    onDelete?: string;
+    useNotValid?: boolean;
+    newConstraintName?: string;
+  } = {}) {
+    const { onDelete = "CASCADE", useNotValid = false, newConstraintName = null } = opts;
+    // Procedures are invoked via CALL; parameter order matters because
+    // postgres.js doesn't support the `=>` named-args syntax via tagged
+    // templates, so we pass positionally.
+    await sqlConn.unsafe(
+      `CALL swap_fk_target($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        "child",
+        "parent_id",
+        "parent",
+        "id",
+        "stable_id",
+        onDelete,
+        useNotValid,
+        newConstraintName,
+      ],
+    );
+  }
+
+  beforeEach(async () => {
+    // Scope every test to the isolated schema so CALL … against 'child' /
+    // 'parent' resolves to the fixture tables, not the production ones.
+    await sqlConn.unsafe(`SET search_path TO ${SCHEMA}, public`);
+  });
+
+  it("rewrites child.parent_id from parent.id → parent.stable_id and swaps the FK", async () => {
+    await resetFixture("CASCADE");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES
+        ('legacy-a', 'sid_AAAAAAAAAA'),
+        ('legacy-b', 'sid_BBBBBBBBBB')
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a'), ('legacy-b'), ('legacy-a')
+    `);
+
+    await callHelper({ onDelete: "CASCADE" });
+
+    const rows = await sqlConn<{ parent_id: string }[]>`
+      SELECT parent_id FROM ${sqlConn(SCHEMA)}.child ORDER BY id
+    `;
+    expect(rows.map((r) => r.parent_id)).toEqual([
+      "sid_AAAAAAAAAA",
+      "sid_BBBBBBBBBB",
+      "sid_AAAAAAAAAA",
+    ]);
+
+    const fks = await sqlConn<{ constraint_name: string; delete_rule: string }[]>`
+      SELECT tc.constraint_name, rc.delete_rule
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.referential_constraints rc
+        ON tc.constraint_name = rc.constraint_name
+      WHERE tc.table_schema = ${SCHEMA}
+        AND tc.table_name = 'child'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `;
+    expect(fks.length).toBe(1);
+    expect(fks[0]?.constraint_name).toBe("child_parent_id_parent_stable_id_fk");
+    expect(fks[0]?.delete_rule).toBe("CASCADE");
+  });
+
+  it("raises with an actionable message on orphaned rows (the #4466 defect)", async () => {
+    await resetFixture("SET NULL");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    // Insert an orphan: parent_id value that doesn't match any parent.id and
+    // won't map to any parent.stable_id after backfill. This is exactly the
+    // shape the NOT EXISTS orphan check catches — a NOT LIKE 'sid_%' heuristic
+    // would not, because 'ghost' isn't sid_-prefixed either.
+    //
+    // We have to bypass the existing FK to insert the orphan, so drop the FK
+    // first. The helper will rediscover there's no FK, skip step 1, try to
+    // add the new one, and trip the orphan check.
+    await sqlConn.unsafe(`
+      ALTER TABLE ${SCHEMA}.child DROP CONSTRAINT child_parent_id_fkey
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a'), ('ghost')
+    `);
+
+    await expect(callHelper({ onDelete: "SET NULL" })).rejects.toThrow(
+      /orphan row\(s\) remain.*ghost|orphan row\(s\) remain/i,
+    );
+
+    // FK should NOT have been added — orphan check is a hard stop.
+    const fks = await sqlConn<{ constraint_name: string }[]>`
+      SELECT constraint_name FROM information_schema.table_constraints
+      WHERE table_schema = ${SCHEMA} AND table_name = 'child' AND constraint_type = 'FOREIGN KEY'
+    `;
+    expect(fks.length).toBe(0);
+  });
+
+  it("does not overwrite a child row to NULL when parent.stable_id is NULL (the #4466 null-guard defect)", async () => {
+    // Scenario: parent row exists, but its stable_id is NULL (Phase A
+    // backfill missed it). A naïve UPDATE without the NULL guard would
+    // rewrite child.parent_id = NULL and then the orphan check or the
+    // subsequent ADD CONSTRAINT would still pass (NULL isn't an orphan).
+    // Silent corruption. The NULL guard in the UPDATE leaves the row alone,
+    // the orphan check trips on legacy-a, CALL raises, and the whole
+    // transaction rolls back.
+    //
+    // We assert on two things: (a) the procedure raises on orphans, and
+    // (b) the child row with the NULL-parent.to_col is NOT NULL after the
+    // rollback — the operator can see the real data and fix the parent row.
+    await resetFixture("SET NULL");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES
+        ('legacy-a', NULL),
+        ('legacy-b', 'sid_BBBBBBBBBB')
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a'), ('legacy-b')
+    `);
+
+    await expect(callHelper({ onDelete: "SET NULL" })).rejects.toThrow(/orphan row/i);
+
+    // The CALL is one transaction and the RAISE rolls it back, so both
+    // child rows are observed in their pre-call state. Critically, the
+    // 'legacy-a' row is 'legacy-a' — NOT NULL. A defective helper without
+    // the parent.to_col IS NOT NULL guard on the UPDATE would have set
+    // this to NULL before the orphan check, and the NULL wouldn't have
+    // rolled back cleanly if the ADD CONSTRAINT had succeeded.
+    const rows = await sqlConn<{ parent_id: string | null }[]>`
+      SELECT parent_id FROM ${sqlConn(SCHEMA)}.child ORDER BY id
+    `;
+    expect(rows[0]?.parent_id).toBe("legacy-a");
+    expect(rows[0]?.parent_id).not.toBeNull();
+    expect(rows[1]?.parent_id).toBe("legacy-b");
+  });
+
+  it("is idempotent on replay (second call is a no-op)", async () => {
+    await resetFixture("CASCADE");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a'), ('legacy-a')
+    `);
+
+    await callHelper({ onDelete: "CASCADE" });
+    // Second call must not throw, must not drop the new FK, must not rewrite.
+    await callHelper({ onDelete: "CASCADE" });
+
+    const rows = await sqlConn<{ parent_id: string }[]>`
+      SELECT parent_id FROM ${sqlConn(SCHEMA)}.child ORDER BY id
+    `;
+    expect(rows.map((r) => r.parent_id)).toEqual(["sid_AAAAAAAAAA", "sid_AAAAAAAAAA"]);
+
+    const fks = await sqlConn<{ constraint_name: string }[]>`
+      SELECT constraint_name FROM information_schema.table_constraints
+      WHERE table_schema = ${SCHEMA} AND table_name = 'child' AND constraint_type = 'FOREIGN KEY'
+    `;
+    expect(fks.length).toBe(1);
+    expect(fks[0]?.constraint_name).toBe("child_parent_id_parent_stable_id_fk");
+  });
+
+  it("leaves NULL parent_id values untouched (nullable FK support)", async () => {
+    await resetFixture("SET NULL");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a'), (NULL), (NULL)
+    `);
+
+    await callHelper({ onDelete: "SET NULL" });
+
+    const rows = await sqlConn<{ parent_id: string | null }[]>`
+      SELECT parent_id FROM ${sqlConn(SCHEMA)}.child ORDER BY id
+    `;
+    expect(rows.map((r) => r.parent_id)).toEqual(["sid_AAAAAAAAAA", null, null]);
+  });
+
+  it("use_not_valid=true adds the constraint as NOT VALID then VALIDATEs it", async () => {
+    await resetFixture("CASCADE");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a')
+    `);
+
+    await callHelper({ onDelete: "CASCADE", useNotValid: true });
+
+    // After VALIDATE CONSTRAINT, pg_constraint.convalidated = true.
+    // We query pg_constraint (not information_schema, which doesn't expose
+    // the NOT VALID flag) on the new FK name.
+    const constraints = await sqlConn<{ convalidated: boolean }[]>`
+      SELECT c.convalidated
+      FROM pg_constraint c
+      JOIN pg_class t ON t.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE c.conname = 'child_parent_id_parent_stable_id_fk'
+        AND t.relname = 'child'
+        AND n.nspname = ${SCHEMA}
+    `;
+    expect(constraints.length).toBe(1);
+    expect(constraints[0]?.convalidated).toBe(true);
+  });
+
+  it("rejects unknown on_delete values before touching the table", async () => {
+    await resetFixture("CASCADE");
+    await expect(
+      sqlConn.unsafe(
+        `CALL swap_fk_target($1, $2, $3, $4, $5, $6, $7, $8)`,
+        ["child", "parent_id", "parent", "id", "stable_id", "EXPLODE", false, null],
+      ),
+    ).rejects.toThrow(/on_delete must be one of/i);
+  });
+
+  it("drops multiple old FK constraints on the same column (enumerated via pg_catalog)", async () => {
+    // Some tables carry both the Drizzle-generated FK name and a leftover
+    // postgres-default fkey from an earlier schema. The helper should drop
+    // both, not require the caller to know their names.
+    await resetFixture("CASCADE");
+    // Add a second FK on parent_id pointing at parent.id.
+    await sqlConn.unsafe(`
+      ALTER TABLE ${SCHEMA}.child
+      ADD CONSTRAINT child_parent_id_secondary_fk
+      FOREIGN KEY (parent_id) REFERENCES ${SCHEMA}.parent(id) ON DELETE CASCADE
+    `);
+
+    const before = await sqlConn<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM information_schema.referential_constraints rc
+      JOIN information_schema.table_constraints tc ON tc.constraint_name = rc.constraint_name
+      WHERE tc.table_schema = ${SCHEMA} AND tc.table_name = 'child'
+    `;
+    expect(Number(before[0]?.count ?? 0)).toBe(2);
+
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    await sqlConn.unsafe(`INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a')`);
+
+    await callHelper({ onDelete: "CASCADE" });
+
+    const after = await sqlConn<{ constraint_name: string }[]>`
+      SELECT tc.constraint_name
+      FROM information_schema.table_constraints tc
+      WHERE tc.table_schema = ${SCHEMA}
+        AND tc.table_name = 'child'
+        AND tc.constraint_type = 'FOREIGN KEY'
+    `;
+    expect(after.map((r) => r.constraint_name)).toEqual([
+      "child_parent_id_parent_stable_id_fk",
+    ]);
+  });
+
+  it("honors a custom new_constraint_name override", async () => {
+    await resetFixture("CASCADE");
+    await sqlConn.unsafe(`
+      INSERT INTO ${SCHEMA}.parent (id, stable_id) VALUES ('legacy-a', 'sid_AAAAAAAAAA')
+    `);
+    await sqlConn.unsafe(`INSERT INTO ${SCHEMA}.child (parent_id) VALUES ('legacy-a')`);
+
+    await callHelper({ onDelete: "CASCADE", newConstraintName: "custom_fk_name" });
+
+    const fks = await sqlConn<{ constraint_name: string }[]>`
+      SELECT constraint_name FROM information_schema.table_constraints
+      WHERE table_schema = ${SCHEMA} AND table_name = 'child' AND constraint_type = 'FOREIGN KEY'
+    `;
+    expect(fks.map((r) => r.constraint_name)).toEqual(["custom_fk_name"]);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts a PL/pgSQL `swap_fk_target()` procedure that owns the safe pattern for swapping an FK's target column (e.g. `resources.id` → `resources.stable_id`). The 12 QUA-549 Phase B migrations repeated the same ~60-100 line template — PR #4460 shipped with two defects (orphan check used a `NOT LIKE 'sid_%'` heuristic instead of `NOT EXISTS`; backfill UPDATE missed the `parent.to_col IS NOT NULL` guard) that were fixed post-merge in #4466 and then absorbed by copy-paste rather than template.

Usage:

```sql
CALL swap_fk_target(
  child_table  => 'resource_papers',
  child_col    => 'resource_id',
  parent_table => 'resources',
  from_col     => 'id',
  to_col       => 'stable_id',
  on_delete    => 'CASCADE'
  -- use_not_valid => true  for tables > ~100k rows
);
```

The procedure:
- Enumerates old FKs on `child_col` via `information_schema` (robust to Drizzle-vs-pg-default name drift) and drops each one.
- Backfills with guards baked in: `child_col IS NOT NULL`, `child_col != parent.to_col` (skip already-migrated rows), `parent.to_col IS NOT NULL` (never silently overwrite to NULL).
- Runs a `NOT EXISTS` orphan check and raises with an actionable message if any remain — the #4466 defect becomes structurally impossible.
- Optionally splits `ADD CONSTRAINT … NOT VALID` + `VALIDATE CONSTRAINT` when `use_not_valid=true`.
- Is idempotent on replay (safe to run twice).

## Files

- `apps/wiki-server/drizzle/helpers/swap_fk_target.sql` — canonical reference copy
- `apps/wiki-server/drizzle/0199_install_swap_fk_target.sql` — Drizzle install migration
- `apps/wiki-server/src/__tests__/swap-fk-target-integration.test.ts` — 9 integration tests (happy path, `#4466` orphan-check defect, `#4466` NULL-guard defect, idempotency on replay, nullable FKs, `use_not_valid` VALIDATE path, invalid `on_delete`, multi-FK drop, custom constraint name)
- `apps/wiki-server/src/__tests__/swap-fk-target-drift.test.ts` — asserts the procedure body is byte-identical between helper + install migration
- `.claude/rules/database-migrations.md` — new **"Swapping an FK target column"** section

## Scope

Per the ticket's *"pick the next real use case, don't force one"* clause, **no real FK-target migration is piggybacked on this PR** — all 17 QUA-549 Phase B tables already migrated, and `facts.fact_id` has no FKs pointing at it (checked `schema.ts`). Coverage comes from the 9-case integration test suite that exercises the procedure end-to-end on a scratch schema against a real Postgres. Next real caller will be the first one this helper earns.

## Acceptance criteria

- [x] `swap_fk_target()` PL/pgSQL function in `apps/wiki-server/drizzle/helpers/`
- [x] One new FK migration uses the helper (skipped per *"don't force one"* — no real pending swap; integration tests cover the behaviors)
- [x] `.claude/rules/database-migrations.md` updated with **"Swapping an FK target column"** section
- [x] Idempotent on replay (explicit test)

## Test plan

- [x] 46/46 gate checks pass locally
- [x] `pnpm build` passes
- [x] `pnpm --filter wiki-server test` — 1276 pass, 55 skipped (including integration suites that need `DATABASE_URL`)
- [x] Integration tests pass locally against Postgres 16 (9/9)
- [x] Migration 0199 applies cleanly on a fresh DB (verified locally)
- [ ] CI migrations job green on PR
- [ ] CI tests green on PR

## Deploy Checklist

- [ ] Verify migration 0199 applied on server start

## Related

- Parent: QUA-408 (epic)
- Origin: QUA-549 Phase B (12 migrations 0186–0197) + retrospective
- Defect reference: PR #4460 / #4466
- NOT VALID pattern: QUA-302 / QUA-156 incident note in `database-migrations.md`

Fixes QUA-600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced database migration documentation with standardized operational procedures and deployment best practices for different database scenarios.

* **Tests**
  * Added comprehensive integration and validation tests ensuring database migration reliability, error handling, and consistency across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->