### PR TITLE
test(wiki-server): QUA-604 consolidate resources.test.ts mocks

### DIFF
--- a/.claude/rules/implementation-quality.md
+++ b/.claude/rules/implementation-quality.md
@@ -15,7 +15,7 @@ Applies to sessions that write or modify code (not content-only MDX/YAML edits).
 - Test with adversarial inputs: empty strings, null/undefined, boundary values (0, -1, MAX_INT), malformed data, very large inputs.
 - No trivial assertions (`typeof result === 'object'`). Assert on specific values and shapes that would catch regressions.
 - **Test skip discipline**: No `it.skip()` without a linked GitHub issue number. Unskip in the same PR that fixes the underlying bug.
-- **Mock fidelity**: Test mocks for the same DB table must share a single in-memory store. Don't create parallel mock stores (e.g., separate `suggestResourceStore`) for different endpoints that hit the same table.
+- **Mock fidelity**: Test mocks for the same DB table must share a single in-memory store. Don't create parallel mock stores (e.g., separate `suggestResourceStore`) for different endpoints that hit the same table. When a table pair is accessed from many mock branches, extract a typed store helper — `apps/wiki-server/src/__tests__/_helpers/resources-store.ts` (QUA-604) is the canonical pattern: one class encapsulates `resources` + `resource_citations` with `seedResource` / `seedCitation` for tests and `setResource` / `insertCitation` / `joinCitationsByPage` for the dispatcher.
 
 **Bug fixes — TDD workflow:**
 1. Write a failing test that reproduces the bug FIRST

--- a/apps/wiki-server/src/__tests__/_helpers/resources-store.ts
+++ b/apps/wiki-server/src/__tests__/_helpers/resources-store.ts
@@ -1,0 +1,279 @@
+/**
+ * Shared in-memory store for `resources` + `resource_citations` test mocks.
+ *
+ * Prod invariants this mirrors (QUA-566 Phase B.3):
+ *   - Every row in `resources` has a `stable_id` (sid_) — NOT NULL since migration 0184.
+ *   - `resource_citations.resource_id` FKs to `resources.stable_id` (not `resources.id`).
+ *
+ * Tests that need to seed a resource without caring about stable_id get one auto-derived
+ * (`sid_${id}`). Tests that need a specific stable_id pass it explicitly.
+ *
+ * See QUA-604 for why this exists — prior to consolidation, resources.test.ts kept a raw
+ * `Map<string, Row>` keyed on hex16 `id` plus a separate `Citation[]` array, and each
+ * Phase B PR that touched the mocks had to patch 2-5 dispatcher branches by hand,
+ * repeatedly missing spots.
+ */
+
+export interface ResourceRow {
+  id: string;
+  stable_id: string;
+  url: string;
+  title?: string | null;
+  type?: string | null;
+  summary?: string | null;
+  review?: string | null;
+  abstract?: string | null;
+  key_points?: unknown;
+  publication_id?: string | null;
+  authors?: unknown;
+  published_date?: string | null;
+  tags?: unknown;
+  local_filename?: string | null;
+  credibility_override?: number | null;
+  fetched_at?: Date | null;
+  content_hash?: string | null;
+  enrichment_status?: string | null;
+  has_content?: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+  [key: string]: unknown;
+}
+
+export interface Citation {
+  resource_id: string;
+  page_slug: string;
+  page_id: number;
+  created_at: Date;
+}
+
+export type ResourceSeed = Partial<ResourceRow> & { id: string; url: string };
+
+export class ResourcesStore {
+  private byId = new Map<string, ResourceRow>();
+  private byStableId = new Map<string, ResourceRow>();
+  private citations: Citation[] = [];
+  private slugToIntId = new Map<string, number>();
+  private nextIntId = 1000;
+
+  reset(): void {
+    this.byId.clear();
+    this.byStableId.clear();
+    this.citations = [];
+    this.slugToIntId.clear();
+    this.nextIntId = 1000;
+  }
+
+  /**
+   * Seed a resource from a test. `stable_id` auto-derived as `sid_${id}` if omitted —
+   * sufficient for tests that don't exercise citation joins. Tests that DO care about
+   * a specific stable_id should pass it explicitly.
+   */
+  seedResource(seed: ResourceSeed): ResourceRow {
+    const stable_id = seed.stable_id ?? `sid_${seed.id}`;
+    const now = new Date();
+    const row: ResourceRow = {
+      ...seed,
+      id: seed.id,
+      stable_id,
+      url: seed.url,
+      title: seed.title ?? null,
+      fetched_at: seed.fetched_at ?? null,
+      has_content: seed.has_content ?? false,
+      created_at: seed.created_at ?? now,
+      updated_at: seed.updated_at ?? now,
+    };
+    this.setResource(row);
+    return row;
+  }
+
+  /** Low-level set — used by INSERT dispatch. Maintains both id and stable_id indices. */
+  setResource(row: ResourceRow): void {
+    const existing = this.byId.get(row.id);
+    if (existing && existing.stable_id !== row.stable_id) {
+      this.byStableId.delete(existing.stable_id);
+    }
+    this.byId.set(row.id, row);
+    this.byStableId.set(row.stable_id, row);
+  }
+
+  getById(id: string): ResourceRow | undefined {
+    return this.byId.get(id);
+  }
+
+  getByStableId(stableId: string): ResourceRow | undefined {
+    return this.byStableId.get(stableId);
+  }
+
+  /** Resolve identifier that may be either hex16 id or sid_. */
+  resolveResource(identifier: string): ResourceRow | undefined {
+    return this.byId.get(identifier) ?? this.byStableId.get(identifier);
+  }
+
+  getByUrl(url: string): ResourceRow | undefined {
+    for (const r of this.byId.values()) {
+      if (r.url === url) return r;
+    }
+    return undefined;
+  }
+
+  allResources(): ResourceRow[] {
+    return Array.from(this.byId.values());
+  }
+
+  resourceCount(): number {
+    return this.byId.size;
+  }
+
+  countByType(type: string): number {
+    let n = 0;
+    for (const r of this.byId.values()) if (r.type === type) n++;
+    return n;
+  }
+
+  groupByType(): Array<{ type: string; count: number }> {
+    const counts: Record<string, number> = {};
+    for (const r of this.byId.values()) {
+      const t = (r.type as string) ?? "unknown";
+      counts[t] = (counts[t] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  clearResources(): void {
+    this.byId.clear();
+    this.byStableId.clear();
+  }
+
+  // ---- citations ----
+
+  /**
+   * Seed a citation from a test. The `resourceIdentifier` may be either hex16 id or sid_ —
+   * the store resolves to the canonical `stable_id` internally. Throws if the referenced
+   * resource hasn't been seeded (mirrors the FK constraint in prod).
+   */
+  seedCitation(input: { resourceIdentifier: string; pageSlug: string }): Citation {
+    const resource = this.resolveResource(input.resourceIdentifier);
+    if (!resource) {
+      throw new Error(
+        `seedCitation: no resource with id/stable_id "${input.resourceIdentifier}". ` +
+          `Call seedResource first.`,
+      );
+    }
+    return this.insertCitation(resource.stable_id, input.pageSlug);
+  }
+
+  /** Low-level citation insert used by INSERT dispatch. Expects a resolved stable_id. */
+  insertCitation(stableId: string, pageSlug: string): Citation {
+    const page_id = this.getOrAllocatePageId(pageSlug);
+    const existing = this.citations.find(
+      (c) => c.resource_id === stableId && c.page_id === page_id,
+    );
+    if (existing) return existing;
+    const citation: Citation = {
+      resource_id: stableId,
+      page_slug: pageSlug,
+      page_id,
+      created_at: new Date(),
+    };
+    this.citations.push(citation);
+    return citation;
+  }
+
+  /** Low-level citation insert by page_id (for dispatch paths that already have the int id). */
+  insertCitationByPageId(stableId: string, pageId: number): Citation {
+    const slug = this.slugFromPageId(pageId) ?? `page-${pageId}`;
+    const existing = this.citations.find(
+      (c) => c.resource_id === stableId && c.page_id === pageId,
+    );
+    if (existing) return existing;
+    const citation: Citation = {
+      resource_id: stableId,
+      page_slug: slug,
+      page_id: pageId,
+      created_at: new Date(),
+    };
+    this.citations.push(citation);
+    return citation;
+  }
+
+  deleteCitationsForResource(stableId: string): void {
+    this.citations = this.citations.filter((c) => c.resource_id !== stableId);
+  }
+
+  getCitationsForResource(stableId: string): Citation[] {
+    return this.citations.filter((c) => c.resource_id === stableId);
+  }
+
+  allCitations(): readonly Citation[] {
+    return this.citations;
+  }
+
+  citationCount(): number {
+    return this.citations.length;
+  }
+
+  uniquePageCount(): number {
+    return new Set(this.citations.map((c) => c.page_id)).size;
+  }
+
+  clearCitations(): void {
+    this.citations = [];
+  }
+
+  /** INNER JOIN resource_citations × resources on stable_id, filtered by page_id. */
+  joinCitationsByPage(pageId: number): ResourceRow[] {
+    const rows: ResourceRow[] = [];
+    for (const c of this.citations) {
+      if (c.page_id === pageId) {
+        const r = this.byStableId.get(c.resource_id);
+        if (r) rows.push(r);
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * For a set of hex16 ids, return citation counts keyed on the input hex16 id
+   * (prod surfaces `r.id` from the JOIN so downstream map-by-hex16 lookups work).
+   */
+  citationCountsByHexIds(hexIds: string[]): Array<{ resource_id: string; cnt: string }> {
+    const counts: Record<string, number> = {};
+    for (const hexId of hexIds) {
+      const r = this.byId.get(hexId);
+      if (!r?.stable_id) continue;
+      const n = this.citations.filter((c) => c.resource_id === r.stable_id).length;
+      if (n > 0) counts[hexId] = n;
+    }
+    return Object.entries(counts).map(([resource_id, cnt]) => ({
+      resource_id,
+      cnt: String(cnt),
+    }));
+  }
+
+  // ---- page slug <-> int id ----
+
+  /** Allocating lookup — mirrors prod where every page slug has a `wiki_pages` row. */
+  getOrAllocatePageId(slug: string): number {
+    let id = this.slugToIntId.get(slug);
+    if (id === undefined) {
+      id = this.nextIntId++;
+      this.slugToIntId.set(slug, id);
+    }
+    return id;
+  }
+
+  slugFromPageId(pageId: number | null): string | null {
+    if (pageId === null) return null;
+    for (const [slug, id] of this.slugToIntId.entries()) {
+      if (id === pageId) return slug;
+    }
+    return null;
+  }
+}
+
+/** Factory — tests call this in beforeEach or once at module scope and call reset() in beforeEach. */
+export function makeResourcesStore(): ResourcesStore {
+  return new ResourcesStore();
+}

--- a/apps/wiki-server/src/__tests__/_helpers/resources-store.ts
+++ b/apps/wiki-server/src/__tests__/_helpers/resources-store.ts
@@ -5,14 +5,16 @@
  *   - Every row in `resources` has a `stable_id` (sid_) — NOT NULL since migration 0184.
  *   - `resource_citations.resource_id` FKs to `resources.stable_id` (not `resources.id`).
  *
- * Tests that need to seed a resource without caring about stable_id get one auto-derived
- * (`sid_${id}`). Tests that need a specific stable_id pass it explicitly.
+ * Tests that don't care about a specific stable_id get one auto-derived as
+ * `sid_${id}`. Tests that exercise the sid_ path pass one explicitly.
  *
  * See QUA-604 for why this exists — prior to consolidation, resources.test.ts kept a raw
  * `Map<string, Row>` keyed on hex16 `id` plus a separate `Citation[]` array, and each
  * Phase B PR that touched the mocks had to patch 2-5 dispatcher branches by hand,
  * repeatedly missing spots.
  */
+
+import { SID_PREFIX } from "@longterm-wiki/id-utils";
 
 export interface ResourceRow {
   id: string;
@@ -36,23 +38,23 @@ export interface ResourceRow {
   has_content?: boolean;
   created_at?: Date;
   updated_at?: Date;
-  [key: string]: unknown;
 }
 
-export interface Citation {
+interface Citation {
   resource_id: string;
   page_slug: string;
   page_id: number;
   created_at: Date;
 }
 
-export type ResourceSeed = Partial<ResourceRow> & { id: string; url: string };
+type ResourceSeed = Partial<ResourceRow> & { id: string; url: string };
 
 export class ResourcesStore {
   private byId = new Map<string, ResourceRow>();
   private byStableId = new Map<string, ResourceRow>();
   private citations: Citation[] = [];
   private slugToIntId = new Map<string, number>();
+  private intIdToSlug = new Map<number, string>();
   private nextIntId = 1000;
 
   reset(): void {
@@ -60,6 +62,7 @@ export class ResourcesStore {
     this.byStableId.clear();
     this.citations = [];
     this.slugToIntId.clear();
+    this.intIdToSlug.clear();
     this.nextIntId = 1000;
   }
 
@@ -69,7 +72,7 @@ export class ResourcesStore {
    * a specific stable_id should pass it explicitly.
    */
   seedResource(seed: ResourceSeed): ResourceRow {
-    const stable_id = seed.stable_id ?? `sid_${seed.id}`;
+    const stable_id = seed.stable_id ?? `${SID_PREFIX}${seed.id}`;
     const now = new Date();
     const row: ResourceRow = {
       ...seed,
@@ -86,7 +89,7 @@ export class ResourcesStore {
     return row;
   }
 
-  /** Low-level set — used by INSERT dispatch. Maintains both id and stable_id indices. */
+  /** Low-level set used by INSERT dispatch. Maintains both id and stable_id indices. */
   setResource(row: ResourceRow): void {
     const existing = this.byId.get(row.id);
     if (existing && existing.stable_id !== row.stable_id) {
@@ -104,7 +107,7 @@ export class ResourcesStore {
     return this.byStableId.get(stableId);
   }
 
-  /** Resolve identifier that may be either hex16 id or sid_. */
+  /** Resolve an identifier that may be either hex16 `id` or `sid_` stable_id. */
   resolveResource(identifier: string): ResourceRow | undefined {
     return this.byId.get(identifier) ?? this.byStableId.get(identifier);
   }
@@ -133,7 +136,7 @@ export class ResourcesStore {
   groupByType(): Array<{ type: string; count: number }> {
     const counts: Record<string, number> = {};
     for (const r of this.byId.values()) {
-      const t = (r.type as string) ?? "unknown";
+      const t = r.type ?? "unknown";
       counts[t] = (counts[t] || 0) + 1;
     }
     return Object.entries(counts)
@@ -141,6 +144,7 @@ export class ResourcesStore {
       .sort((a, b) => b.count - a.count);
   }
 
+  /** TRUNCATE resources only; does not touch citations (matches the literal TRUNCATE SQL). */
   clearResources(): void {
     this.byId.clear();
     this.byStableId.clear();
@@ -161,36 +165,18 @@ export class ResourcesStore {
           `Call seedResource first.`,
       );
     }
-    return this.insertCitation(resource.stable_id, input.pageSlug);
+    return this.insertCitationByPageId(resource.stable_id, this.getOrAllocatePageId(input.pageSlug));
   }
 
-  /** Low-level citation insert used by INSERT dispatch. Expects a resolved stable_id. */
-  insertCitation(stableId: string, pageSlug: string): Citation {
-    const page_id = this.getOrAllocatePageId(pageSlug);
-    const existing = this.citations.find(
-      (c) => c.resource_id === stableId && c.page_id === page_id,
-    );
-    if (existing) return existing;
-    const citation: Citation = {
-      resource_id: stableId,
-      page_slug: pageSlug,
-      page_id,
-      created_at: new Date(),
-    };
-    this.citations.push(citation);
-    return citation;
-  }
-
-  /** Low-level citation insert by page_id (for dispatch paths that already have the int id). */
+  /** Low-level citation insert used by INSERT dispatch; callers provide a resolved stable_id + page_id. */
   insertCitationByPageId(stableId: string, pageId: number): Citation {
-    const slug = this.slugFromPageId(pageId) ?? `page-${pageId}`;
     const existing = this.citations.find(
       (c) => c.resource_id === stableId && c.page_id === pageId,
     );
     if (existing) return existing;
     const citation: Citation = {
       resource_id: stableId,
-      page_slug: slug,
+      page_slug: this.intIdToSlug.get(pageId) ?? `page-${pageId}`,
       page_id: pageId,
       created_at: new Date(),
     };
@@ -206,6 +192,7 @@ export class ResourcesStore {
     return this.citations.filter((c) => c.resource_id === stableId);
   }
 
+  /** Read-only view; `readonly` is compile-time only, so tests should not mutate. */
   allCitations(): readonly Citation[] {
     return this.citations;
   }
@@ -235,21 +222,23 @@ export class ResourcesStore {
   }
 
   /**
-   * For a set of hex16 ids, return citation counts keyed on the input hex16 id
-   * (prod surfaces `r.id` from the JOIN so downstream map-by-hex16 lookups work).
+   * For a set of hex16 ids, return citation counts keyed on the input hex16 id.
+   * Prod surfaces `r.id` from the JOIN so downstream map-by-hex16 lookups keep working —
+   * the `cnt: string` shape mirrors the raw SQL result.
    */
   citationCountsByHexIds(hexIds: string[]): Array<{ resource_id: string; cnt: string }> {
-    const counts: Record<string, number> = {};
+    const countByStable: Record<string, number> = {};
+    for (const c of this.citations) {
+      countByStable[c.resource_id] = (countByStable[c.resource_id] || 0) + 1;
+    }
+    const results: Array<{ resource_id: string; cnt: string }> = [];
     for (const hexId of hexIds) {
       const r = this.byId.get(hexId);
       if (!r?.stable_id) continue;
-      const n = this.citations.filter((c) => c.resource_id === r.stable_id).length;
-      if (n > 0) counts[hexId] = n;
+      const n = countByStable[r.stable_id] ?? 0;
+      if (n > 0) results.push({ resource_id: hexId, cnt: String(n) });
     }
-    return Object.entries(counts).map(([resource_id, cnt]) => ({
-      resource_id,
-      cnt: String(cnt),
-    }));
+    return results;
   }
 
   // ---- page slug <-> int id ----
@@ -260,20 +249,13 @@ export class ResourcesStore {
     if (id === undefined) {
       id = this.nextIntId++;
       this.slugToIntId.set(slug, id);
+      this.intIdToSlug.set(id, slug);
     }
     return id;
   }
 
   slugFromPageId(pageId: number | null): string | null {
     if (pageId === null) return null;
-    for (const [slug, id] of this.slugToIntId.entries()) {
-      if (id === pageId) return slug;
-    }
-    return null;
+    return this.intIdToSlug.get(pageId) ?? null;
   }
-}
-
-/** Factory — tests call this in beforeEach or once at module scope and call reset() in beforeEach. */
-export function makeResourcesStore(): ResourcesStore {
-  return new ResourcesStore();
 }

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
+import { SID_PREFIX } from "@longterm-wiki/id-utils";
 import { mockDbModule, postJson } from "./test-utils.js";
-import { makeResourcesStore, type ResourceRow } from "./_helpers/resources-store.js";
+import { ResourcesStore, type ResourceRow } from "./_helpers/resources-store.js";
 
 // ---- In-memory stores ----
 //
@@ -9,7 +10,7 @@ import { makeResourcesStore, type ResourceRow } from "./_helpers/resources-store
 // for the rationale (QUA-604). Jobs are a separate table with no cross-cutting mock pattern,
 // so they stay inline.
 
-const store = makeResourcesStore();
+const store = new ResourcesStore();
 let jobStore: Map<number, Record<string, unknown>>;
 let nextJobId = 1;
 
@@ -114,7 +115,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         fetched_at: (params[o + 14] as Date | null) ?? existing?.fetched_at ?? null,
         content_hash: (params[o + 15] as string | null) ?? existing?.content_hash ?? null,
         // stableId is generate-once: preserve existing, only set if row didn't have one
-        stable_id: existing?.stable_id ?? (params[o + 16] as string) ?? `sid_${id}`,
+        stable_id: existing?.stable_id ?? (params[o + 16] as string) ?? `${SID_PREFIX}${id}`,
         created_at: existing?.created_at ?? now,
         updated_at: now,
       };
@@ -219,7 +220,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       const row: ResourceRow = {
         id: ids[i],
         url: urls[i],
-        stable_id: stableIds[i] ?? `sid_${ids[i]}`,
+        stable_id: stableIds[i] ?? `${SID_PREFIX}${ids[i]}`,
         title: null,
         fetched_at: null,
         has_content: false,

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { mockDbModule, postJson } from "./test-utils.js";
+import { makeResourcesStore, type ResourceRow } from "./_helpers/resources-store.js";
 
 // ---- In-memory stores ----
+//
+// `store` unifies mocks for `resources` + `resource_citations`. See _helpers/resources-store.ts
+// for the rationale (QUA-604). Jobs are a separate table with no cross-cutting mock pattern,
+// so they stay inline.
 
-let resourceStore: Map<string, Record<string, unknown>>;
-let citationStore: Array<{ resource_id: string; page_slug: string; page_id: number; created_at: Date }>;
+const store = makeResourcesStore();
 let jobStore: Map<number, Record<string, unknown>>;
 let nextJobId = 1;
 
@@ -15,47 +19,27 @@ let nextJobId = 1;
 // Since the mock doesn't model citation_content, we check:
 //   1. An explicit has_content field (set directly by suggest tests), OR
 //   2. content_hash being non-null (proxy for content having been fetched)
-function toSuggestShape(row: Record<string, unknown>): { id: string; url: string; title: string | null; fetched_at: Date | null; has_content: boolean } {
+function toSuggestShape(row: ResourceRow): {
+  id: string;
+  url: string;
+  title: string | null;
+  fetched_at: Date | null;
+  has_content: boolean;
+} {
   return {
-    id: row.id as string,
-    url: row.url as string,
-    title: (row.title as string | null) ?? null,
-    fetched_at: (row.fetched_at as Date | null) ?? null,
-    has_content: row.has_content === true || (row.content_hash != null && row.content_hash !== ""),
+    id: row.id,
+    url: row.url,
+    title: row.title ?? null,
+    fetched_at: row.fetched_at ?? null,
+    has_content:
+      row.has_content === true || (row.content_hash != null && row.content_hash !== ""),
   };
 }
 
-let nextSlugIntId = 1000;
-const slugIntIdMap = new Map<string, number>();
-
-function getIntIdForSlug(slug: string): number {
-  if (!slugIntIdMap.has(slug)) {
-    slugIntIdMap.set(slug, nextSlugIntId++);
-  }
-  return slugIntIdMap.get(slug)!;
-}
-
-/** Non-allocating lookup — returns undefined for slugs not yet in the map. */
-function lookupIntIdForSlug(slug: string): number | undefined {
-  return slugIntIdMap.get(slug);
-}
-
-/** Reverse-lookup: recover slug from integer ID. */
-function slugFromIntId(intId: number | null): string | null {
-  if (intId === null) return null;
-  for (const [slug, id] of slugIntIdMap.entries()) {
-    if (id === intId) return slug;
-  }
-  return null;
-}
-
 function resetStores() {
-  resourceStore = new Map();
-  citationStore = [];
+  store.reset();
   jobStore = new Map();
   nextJobId = 1;
-  nextSlugIntId = 1000;
-  slugIntIdMap.clear();
 }
 
 function dispatch(query: string, params: unknown[]): unknown[] {
@@ -73,7 +57,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   // Must use 'from "wiki_pages"' to avoid matching JOIN queries that also reference wiki_pages.
   if (q.includes('from "wiki_pages"') && q.includes("where") && q.includes("slug") && !q.includes("as id")) {
     // Allocating on first use mirrors production where all page slugs have wiki_pages rows.
-    return params.map((p) => ({ id: getIntIdForSlug(String(p)), slug: p }));
+    return params.map((p) => ({ id: store.getOrAllocatePageId(String(p)), slug: p }));
   }
 
   // ---- ref-check: SELECT id FROM wiki_pages WHERE id IN (...) ----
@@ -83,11 +67,11 @@ function dispatch(query: string, params: unknown[]): unknown[] {
 
   // ---- TRUNCATE ----
   if (q.includes("truncate") && q.includes("resource_citations")) {
-    citationStore = [];
+    store.clearCitations();
     return [];
   }
   if (q.includes("truncate") && q.includes("resources")) {
-    resourceStore = new Map();
+    store.clearResources();
     return [];
   }
 
@@ -103,37 +87,38 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     const now = new Date();
     const COLS = 27; // Number of columns in resourceValues()
     const numRows = Math.max(1, Math.floor(params.length / COLS));
-    const results: Record<string, unknown>[] = [];
+    const results: ResourceRow[] = [];
 
     for (let r = 0; r < numRows; r++) {
       const o = r * COLS;
       const id = params[o] as string;
-      const existing = resourceStore.get(id);
+      const existing = store.getById(id);
 
-      const row: Record<string, unknown> = {
+      const row: ResourceRow = {
         id,
-        url: params[o + 1],
+        url: params[o + 1] as string,
         // COALESCE(incoming, existing): non-null incoming overwrites; null preserves existing.
-        title: params[o + 2] ?? existing?.title ?? null,
-        type: params[o + 3] ?? existing?.type ?? null,
-        summary: params[o + 4] ?? existing?.summary ?? null,
-        review: params[o + 5] ?? existing?.review ?? null,
-        abstract: params[o + 6] ?? existing?.abstract ?? null,
+        title: (params[o + 2] as string | null) ?? existing?.title ?? null,
+        type: (params[o + 3] as string | null) ?? existing?.type ?? null,
+        summary: (params[o + 4] as string | null) ?? existing?.summary ?? null,
+        review: (params[o + 5] as string | null) ?? existing?.review ?? null,
+        abstract: (params[o + 6] as string | null) ?? existing?.abstract ?? null,
         key_points: params[o + 7] ?? existing?.key_points ?? null,
-        publication_id: params[o + 8] ?? existing?.publication_id ?? null,
+        publication_id: (params[o + 8] as string | null) ?? existing?.publication_id ?? null,
         authors: params[o + 9] ?? existing?.authors ?? null,
-        published_date: params[o + 10] ?? existing?.published_date ?? null,
+        published_date: (params[o + 10] as string | null) ?? existing?.published_date ?? null,
         tags: params[o + 11] ?? existing?.tags ?? null,
-        local_filename: params[o + 12] ?? existing?.local_filename ?? null,
-        credibility_override: params[o + 13] ?? existing?.credibility_override ?? null,
-        fetched_at: params[o + 14] ?? existing?.fetched_at ?? null,
-        content_hash: params[o + 15] ?? existing?.content_hash ?? null,
+        local_filename: (params[o + 12] as string | null) ?? existing?.local_filename ?? null,
+        credibility_override:
+          (params[o + 13] as number | null) ?? existing?.credibility_override ?? null,
+        fetched_at: (params[o + 14] as Date | null) ?? existing?.fetched_at ?? null,
+        content_hash: (params[o + 15] as string | null) ?? existing?.content_hash ?? null,
         // stableId is generate-once: preserve existing, only set if row didn't have one
-        stable_id: existing?.stable_id ?? params[o + 16] ?? null,
+        stable_id: existing?.stable_id ?? (params[o + 16] as string) ?? `sid_${id}`,
         created_at: existing?.created_at ?? now,
         updated_at: now,
       };
-      resourceStore.set(id, row);
+      store.setResource(row);
       results.push(row);
     }
     return results;
@@ -143,110 +128,67 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   if (q.includes("delete") && q.includes("resource_citations") && q.includes("where")) {
     // Supports both single-row (= $1) and bulk (IN ($1, $2, ...)) deletes
     for (const p of params) {
-      const resourceId = p as string;
-      citationStore = citationStore.filter((c) => c.resource_id !== resourceId);
+      store.deleteCitationsForResource(p as string);
     }
     return [];
   }
 
   // ---- INSERT INTO resource_citations (supports multi-row) ----
-  // Params: resource_id, page_id (integer)
+  // Params: resource_id (stable_id, post-QUA-566), page_id (integer)
   if (q.includes("insert into") && q.includes("resource_citations")) {
-    const COLS = 2; // resource_id, page_id
+    const COLS = 2;
     const numRows = params.length / COLS;
     for (let i = 0; i < numRows; i++) {
       const o = i * COLS;
-      const resourceId = params[o] as string;
-      const pageId = params[o + 1] as number;
-      const slug = slugFromIntId(pageId) ?? `page-${pageId}`;
-      const exists = citationStore.some(
-        (c) => c.resource_id === resourceId && c.page_id === pageId
-      );
-      if (!exists) {
-        citationStore.push({
-          resource_id: resourceId,
-          page_slug: slug,
-          page_id: pageId,
-          created_at: new Date(),
-        });
-      }
+      store.insertCitationByPageId(params[o] as string, params[o + 1] as number);
     }
     return [];
   }
 
   // ---- SELECT count(distinct page_id) FROM resource_citations ----
   if (q.includes("count(distinct") && q.includes("resource_citations")) {
-    const uniquePages = new Set(citationStore.map((c) => c.page_id));
-    return [{ page_id: uniquePages.size }];
+    return [{ page_id: store.uniquePageCount() }];
   }
 
   // ---- SELECT count(*) FROM resource_citations (not GROUP BY) ----
   if (q.includes("count(*)") && q.includes("resource_citations") && !q.includes("group by")) {
-    return [{ count: citationStore.length }];
+    return [{ count: store.citationCount() }];
   }
 
   // ---- SELECT count(*) FROM resources with GROUP BY type ----
   if (q.includes("count(*)") && q.includes('"resources"') && q.includes("group by")) {
-    const counts: Record<string, number> = {};
-    for (const r of resourceStore.values()) {
-      const t = (r.type as string) ?? "unknown";
-      counts[t] = (counts[t] || 0) + 1;
-    }
-    return Object.entries(counts)
-      .map(([type, count]) => ({ type, count }))
-      .sort((a, b) => b.count - a.count);
+    return store.groupByType();
   }
 
   // ---- SELECT count(*) FROM resources (no GROUP BY, with optional WHERE) ----
   if (q.includes("count(*)") && q.includes('"resources"') && !q.includes("group by")) {
     if (q.includes("where") && params.length > 0) {
-      let count = 0;
-      for (const r of resourceStore.values()) {
-        if (r.type === params[0]) count++;
-      }
-      return [{ count }];
+      return [{ count: store.countByType(params[0] as string) }];
     }
-    return [{ count: resourceStore.size }];
+    return [{ count: store.resourceCount() }];
   }
 
   // ---- SELECT ... FROM resource_citations INNER JOIN resources (by-page) ----
-  // QUA-566 Phase B.3: resource_citations.resource_id now references
-  // resources.stable_id, so the join is on stable_id, not id.
+  // QUA-566 Phase B.3: resource_citations.resource_id references resources.stable_id.
   if (q.includes("resource_citations") && q.includes("inner join") && q.includes('"resources"')) {
     const intId = params[0] as number;
-    const results: Record<string, unknown>[] = [];
-    for (const c of citationStore) {
-      if (c.page_id === intId) {
-        // Look up by stable_id (the new join key)
-        let r: Record<string, unknown> | undefined;
-        for (const res of resourceStore.values()) {
-          if (res.stable_id === c.resource_id) {
-            r = res;
-            break;
-          }
-        }
-        if (r) {
-          results.push({
-            id: r.id,
-            url: r.url,
-            title: r.title,
-            type: r.type,
-            publication_id: r.publication_id,
-            authors: r.authors,
-            published_date: r.published_date,
-          });
-        }
-      }
-    }
-    return results;
+    return store.joinCitationsByPage(intId).map((r) => ({
+      id: r.id,
+      url: r.url,
+      title: r.title,
+      type: r.type,
+      publication_id: r.publication_id,
+      authors: r.authors,
+      published_date: r.published_date,
+    }));
   }
 
   // ---- SELECT wiki_pages.slug FROM resource_citations LEFT JOIN wiki_pages WHERE resource_id = $1 ----
   // Returns slug via LEFT JOIN wiki_pages
   if (q.includes("resource_citations") && q.includes("where") && !q.includes("delete") && !q.includes("count")) {
     const resourceId = params[0] as string;
-    return citationStore
-      .filter((c) => c.resource_id === resourceId)
+    return store
+      .getCitationsForResource(resourceId)
       .map((c) => ({ slug: c.page_slug })); // wiki_pages.slug
   }
 
@@ -255,8 +197,8 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   if (q.includes("from resources") && q.includes("citation_content") && q.includes("any($)")) {
     const urlList = params[0] as string[];
     const results: Record<string, unknown>[] = [];
-    for (const row of resourceStore.values()) {
-      if (urlList.includes(row.url as string)) {
+    for (const row of store.allResources()) {
+      if (urlList.includes(row.url)) {
         results.push(toSuggestShape(row));
       }
     }
@@ -266,14 +208,32 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   }
 
   // ---- /suggest: INSERT INTO resources ... unnest ... RETURNING (bulk create for new URLs) ----
+  // Prod SQL passes three unnest arrays: ids, urls, stable_ids (QUA-536).
   if (q.includes("insert into resources") && q.includes("unnest")) {
     const ids = params[0] as string[];
     const urls = params[1] as string[];
+    const stableIds = (params[2] as string[] | undefined) ?? [];
+    const now = new Date();
     const results: Record<string, unknown>[] = [];
     for (let i = 0; i < ids.length; i++) {
-      const row: Record<string, unknown> = { id: ids[i], url: urls[i], title: null, fetched_at: null, has_content: false, created_at: new Date(), updated_at: new Date() };
-      resourceStore.set(ids[i], row);
-      results.push({ id: ids[i], url: urls[i], title: null, fetched_at: null, has_content: false });
+      const row: ResourceRow = {
+        id: ids[i],
+        url: urls[i],
+        stable_id: stableIds[i] ?? `sid_${ids[i]}`,
+        title: null,
+        fetched_at: null,
+        has_content: false,
+        created_at: now,
+        updated_at: now,
+      };
+      store.setResource(row);
+      results.push({
+        id: row.id,
+        url: row.url,
+        title: null,
+        fetched_at: null,
+        has_content: false,
+      });
     }
     return results;
   }
@@ -282,20 +242,24 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   // Tagged template: params = [prefixQuery, prefixQuery, limit] (interpolated values in order)
   // unsafe(): params = [prefixQuery, limit]
   if ((q.includes("to_tsquery") || q.includes("plainto_tsquery")) && q.includes("resources")) {
-    const rawQuery = (params[0] as string);
+    const rawQuery = params[0] as string;
     // Strip :* suffixes and & operators to get plain search words
     const searchTerm = rawQuery.replace(/:\*/g, "").replace(/\s*&\s*/g, " ").trim().toLowerCase();
     // The limit is always the last param (a number); earlier params are query strings.
     const lastParam = params[params.length - 1];
-    const limit = (typeof lastParam === "number" ? lastParam : 20);
+    const limit = typeof lastParam === "number" ? lastParam : 20;
     const results: Record<string, unknown>[] = [];
-    for (const r of resourceStore.values()) {
+    for (const r of store.allResources()) {
       const title = ((r.title as string) || "").toLowerCase();
       const summary = ((r.summary as string) || "").toLowerCase();
       const abstract = ((r.abstract as string) || "").toLowerCase();
       const review = ((r.review as string) || "").toLowerCase();
-      if (title.includes(searchTerm) || summary.includes(searchTerm) ||
-          abstract.includes(searchTerm) || review.includes(searchTerm)) {
+      if (
+        title.includes(searchTerm) ||
+        summary.includes(searchTerm) ||
+        abstract.includes(searchTerm) ||
+        review.includes(searchTerm)
+      ) {
         results.push({ ...r, rank: 1.0 });
       }
     }
@@ -308,36 +272,30 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     const whereClause = q.split("where")[1] || "";
     if (whereClause.includes('"url"')) {
       const url = params[0] as string;
-      for (const r of resourceStore.values()) {
-        if (r.url === url) return [r];
-      }
-      return [];
+      const r = store.getByUrl(url);
+      return r ? [r] : [];
     }
     // ---- SELECT ... FROM resources WHERE id = $1 OR stable_id = $2 ----
     // QUA-573: /:id/content now accepts either hex16 id or canonical sid_.
     if (whereClause.includes('"id"') && whereClause.includes('"stable_id"')) {
       const id = params[0] as string;
       const stableId = (params[1] ?? params[0]) as string;
-      const byId = resourceStore.get(id);
+      const byId = store.getById(id);
       if (byId) return [byId];
-      for (const r of resourceStore.values()) {
-        if (r.stable_id === stableId) return [r];
-      }
-      return [];
+      const byStable = store.getByStableId(stableId);
+      return byStable ? [byStable] : [];
     }
     // ---- SELECT ... FROM resources WHERE id = $1 ----
     if (whereClause.includes('"id"')) {
       const id = params[0] as string;
-      const r = resourceStore.get(id);
+      const r = store.getById(id);
       return r ? [r] : [];
     }
   }
 
   // ---- SELECT ... FROM resources ORDER BY (paginated all) ----
   if (q.includes('"resources"') && q.includes("order by") && q.includes("limit")) {
-    const allRows = Array.from(resourceStore.values()).sort((a, b) =>
-      (a.id as string).localeCompare(b.id as string)
-    );
+    const allRows = store.allResources().sort((a, b) => a.id.localeCompare(b.id));
 
     // Filter by type if there's a WHERE clause
     let filtered = allRows;
@@ -357,26 +315,9 @@ function dispatch(query: string, params: unknown[]): unknown[] {
   //                 JOIN resources r ON rc.resource_id = r.stable_id
   //                 WHERE r.id = ANY(...) GROUP BY r.id ----
   // QUA-566 Phase B.3: resource_citations.resource_id references resources.stable_id.
-  // The prod query JOINs resources and surfaces r.id (hex16) so downstream map-by-hex16
-  // lookups keep working. The mock walks resourceStore to resolve the hex16 key into
-  // the stable_id, then counts citationStore rows whose resource_id matches that stable_id.
+  // Prod surfaces r.id (hex16) so downstream map-by-hex16 lookups keep working.
   if (q.includes("resource_citations") && q.includes("group by") && q.includes("any($)")) {
-    const resourceIds = params[0] as string[];
-    const counts: Record<string, number> = {};
-    for (const resourceId of resourceIds) {
-      const r = resourceStore.get(resourceId);
-      const stableId = r?.stable_id as string | null | undefined;
-      if (!stableId) continue;
-      let n = 0;
-      for (const c of citationStore) {
-        if (c.resource_id === stableId) n++;
-      }
-      if (n > 0) counts[resourceId] = n;
-    }
-    return Object.entries(counts).map(([resource_id, cnt]) => ({
-      resource_id,
-      cnt: String(cnt),
-    }));
+    return store.citationCountsByHexIds(params[0] as string[]);
   }
 
   // ---- INSERT INTO jobs ... ON CONFLICT ... RETURNING id ----
@@ -443,7 +384,7 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       if (dk && dk.startsWith(prefix)) {
         const jobParams = job.params as { resourceId?: string; url?: string } | null;
         const resourceId = jobParams?.resourceId ?? null;
-        const resource = resourceId ? resourceStore.get(resourceId) : null;
+        const resource = resourceId ? store.getById(resourceId) : null;
         results.push({
           job_id: job.id,
           job_status: job.status,
@@ -529,14 +470,14 @@ describe("Resources API", () => {
         citedBy: ["page-a", "page-b"],
       });
       expect(res.status).toBe(201);
-      expect(citationStore).toHaveLength(2);
-      expect(citationStore[0].page_slug).toBe("page-a");
+      expect(store.citationCount()).toBe(2);
+      expect(store.allCitations()[0].page_slug).toBe("page-a");
     });
 
     it("updates existing resource on upsert (same id, different data)", async () => {
       // First insert
       await postJson(app, "/api/resources", sampleResource);
-      expect(resourceStore.get("abc123def456")?.title).toBe(
+      expect(store.getById("abc123def456")?.title).toBe(
         "AI Alignment: A Comprehensive Survey"
       );
 
@@ -546,7 +487,7 @@ describe("Resources API", () => {
         title: "Updated Title",
       });
       expect(res.status).toBe(201);
-      expect(resourceStore.get("abc123def456")?.title).toBe("Updated Title");
+      expect(store.getById("abc123def456")?.title).toBe("Updated Title");
     });
 
     it("preserves existing enriched fields when upserting bare resource (COALESCE)", async () => {
@@ -561,7 +502,7 @@ describe("Resources API", () => {
         publishedDate: "2025-01-15",
         tags: ["alignment", "survey"],
       });
-      const enriched = resourceStore.get("abc123def456");
+      const enriched = store.getById("abc123def456");
       expect(enriched?.summary).toBe("A comprehensive survey of AI alignment approaches.");
 
       // Upsert with bare resource (only id + url) — should NOT wipe enriched fields
@@ -571,7 +512,7 @@ describe("Resources API", () => {
       });
       expect(res.status).toBe(201);
 
-      const afterBare = resourceStore.get("abc123def456");
+      const afterBare = store.getById("abc123def456");
       // Enriched text fields should be preserved (COALESCE(null, existing) = existing)
       expect(afterBare?.summary).toBe("A comprehensive survey of AI alignment approaches.");
       expect(afterBare?.review).toBe("Excellent overview of the field.");
@@ -598,7 +539,7 @@ describe("Resources API", () => {
       });
       expect(res.status).toBe(201);
 
-      const updated = resourceStore.get("abc123def456");
+      const updated = store.getById("abc123def456");
       expect(updated?.summary).toBe("Updated summary");
     });
   });
@@ -812,7 +753,7 @@ describe("Resources API", () => {
   describe("POST /api/resources/suggest — variant collision handling", () => {
     it("resolves both URLs when they are www-variants of each other and one exists in DB", async () => {
       // Pre-populate: the DB has the www version stored
-      resourceStore.set("existing-res-1", {
+      store.seedResource({
         id: "existing-res-1",
         url: "https://www.example.com",
         title: "Example Site",
@@ -845,7 +786,7 @@ describe("Resources API", () => {
 
     it("resolves both URLs when DB has the non-www version stored", async () => {
       // Pre-populate: the DB has the non-www version stored
-      resourceStore.set("existing-res-2", {
+      store.seedResource({
         id: "existing-res-2",
         url: "https://example.com",
         title: "Example Site",
@@ -875,14 +816,14 @@ describe("Resources API", () => {
 
     it("prefers exact URL match over variant match when both exist in DB", async () => {
       // DB has both www and non-www as separate resources
-      resourceStore.set("res-no-www", {
+      store.seedResource({
         id: "res-no-www",
         url: "https://example.com",
         title: "No WWW Version",
         fetched_at: new Date(),
         has_content: true,
       });
-      resourceStore.set("res-with-www", {
+      store.seedResource({
         id: "res-with-www",
         url: "https://www.example.com",
         title: "WWW Version",
@@ -907,7 +848,7 @@ describe("Resources API", () => {
 
     it("creates new resource only for genuinely unknown URLs", async () => {
       // DB has one URL; submit it along with a truly new URL
-      resourceStore.set("known-res", {
+      store.seedResource({
         id: "known-res",
         url: "https://known.com",
         title: "Known Resource",
@@ -934,7 +875,7 @@ describe("Resources API", () => {
 
     it("handles trailing slash variants correctly", async () => {
       // DB stores URL with trailing slash
-      resourceStore.set("slash-res", {
+      store.seedResource({
         id: "slash-res",
         url: "https://example.com/page/",
         title: "Page With Slash",
@@ -954,7 +895,7 @@ describe("Resources API", () => {
     });
 
     it("deduplicates identical input URLs", async () => {
-      resourceStore.set("dedup-res", {
+      store.seedResource({
         id: "dedup-res",
         url: "https://example.com",
         title: "Dedup Test",
@@ -1006,7 +947,7 @@ describe("Resources API", () => {
 
     it("does not create jobs for fresh resources", async () => {
       // Pre-populate with a fresh resource
-      resourceStore.set("fresh-res", {
+      store.seedResource({
         id: "fresh-res",
         url: "https://example.com/fresh",
         title: "Fresh Resource",
@@ -1030,7 +971,7 @@ describe("Resources API", () => {
 
     it("returns batchId only for non-fresh resources in a mixed batch", async () => {
       // One fresh, one missing
-      resourceStore.set("fresh-mixed", {
+      store.seedResource({
         id: "fresh-mixed",
         url: "https://example.com/existing",
         title: "Existing Resource",
@@ -1060,10 +1001,8 @@ describe("Resources API", () => {
     });
 
     it("sets job priority based on citation count", async () => {
-      // Pre-populate a resource with known ID, stable_id, and citations.
-      // QUA-566 Phase B.3: resource_citations.resource_id is now the resource's
-      // stable_id, so push to citationStore keyed on stable_id.
-      resourceStore.set("cited-res", {
+      // Seed a resource with an explicit stable_id; citations key on that stable_id.
+      store.seedResource({
         id: "cited-res",
         stable_id: "sid_cited-res",
         url: "https://example.com/cited",
@@ -1072,15 +1011,9 @@ describe("Resources API", () => {
         has_content: false,
       });
 
-      // Add citations: 4 pages cite this resource → priority = min(100, 4 * 5) = 20
-      const pageIds = ["page-1", "page-2", "page-3", "page-4"];
-      for (const slug of pageIds) {
-        citationStore.push({
-          resource_id: "sid_cited-res",
-          page_slug: slug,
-          page_id: getIntIdForSlug(slug),
-          created_at: new Date(),
-        });
+      // 4 pages cite this resource → priority = min(100, 4 * 5) = 20
+      for (const slug of ["page-1", "page-2", "page-3", "page-4"]) {
+        store.seedCitation({ resourceIdentifier: "cited-res", pageSlug: slug });
       }
 
       const res = await postJson(app, "/api/resources/suggest", {
@@ -1099,9 +1032,8 @@ describe("Resources API", () => {
     });
 
     it("caps priority at 100", async () => {
-      // Pre-populate resource with 25 citations → priority = min(100, 25 * 5) = 100
-      // QUA-566 Phase B.3: citations keyed by stable_id post-migration.
-      resourceStore.set("popular-res", {
+      // 25 citations → priority = min(100, 25 * 5) = 100
+      store.seedResource({
         id: "popular-res",
         stable_id: "sid_popular-res",
         url: "https://example.com/popular",
@@ -1111,12 +1043,7 @@ describe("Resources API", () => {
       });
 
       for (let i = 0; i < 25; i++) {
-        citationStore.push({
-          resource_id: "sid_popular-res",
-          page_slug: `page-${i}`,
-          page_id: getIntIdForSlug(`page-${i}`),
-          created_at: new Date(),
-        });
+        store.seedCitation({ resourceIdentifier: "popular-res", pageSlug: `page-${i}` });
       }
 
       const res = await postJson(app, "/api/resources/suggest", {
@@ -1210,8 +1137,9 @@ describe("Resources API", () => {
       // Simulate completion: mark job complete and add enrichment to resource
       const jobId = Array.from(jobStore.keys())[0];
       jobStore.get(jobId)!.status = "completed";
-      resourceStore.get(resourceId)!.enrichment_status = "enriched";
-      resourceStore.get(resourceId)!.summary = "This is an enriched summary";
+      const enrichedRow = store.getById(resourceId)!;
+      enrichedRow.enrichment_status = "enriched";
+      enrichedRow.summary = "This is an enriched summary";
 
       const statusRes = await app.request(`/api/resources/suggest/status/${batchId}`);
       const statusBody = await statusRes.json();


### PR DESCRIPTION
## Summary

Consolidates the two parallel in-memory mock stores in
`apps/wiki-server/src/__tests__/resources.test.ts` (raw `Map` on hex16 id +
`Citation[]` on sid_) into a single typed `ResourcesStore` helper at
`apps/wiki-server/src/__tests__/_helpers/resources-store.ts`.

Addresses the "parallel mock stores" anti-pattern called out in
`.claude/rules/implementation-quality.md` § Mock fidelity. Each Phase B PR that
touched the mocks (QUA-566, QUA-567, QUA-569, QUA-574) had to patch 2–5
dispatcher branches by hand; some updates missed spots and were caught only
downstream. One consolidated store makes the invariant (citation keys are
stable_id, resource keys are hex16) impossible to forget.

## Key changes

- **New**: `ResourcesStore` class with `seedResource` / `seedCitation` for tests
  and `setResource` / `insertCitationByPageId` / `joinCitationsByPage` /
  `citationCountsByHexIds` for the dispatcher. Stable_id is the canonical
  citation key; `resolveResource()` accepts either hex16 id or sid_.
- **Auto-derivation**: if a test seeds a resource without `stable_id`, the
  store synthesizes `sid_${id}` via the `SID_PREFIX` constant from
  `@longterm-wiki/id-utils`. Tests that exercise the sid_ path pass an explicit
  `stable_id`.
- **Latent drift fixed**: prod `/suggest` unnest SQL passes three arrays
  (ids, urls, stable_ids, per QUA-536) but the mock only read the first two.
  The mock now reads `params[2]` as the stable_id array.
- **Behavior note**: the INSERT dispatch's default `stable_id` changed from
  `null` to `sid_${id}` when no existing row and no param-provided value.
  Brings the mock closer to prod (which always mints a stableId); no test
  depends on the null.
- **Docs**: `implementation-quality.md` § Mock fidelity now points at the
  helper as the canonical pattern.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/resources.test.ts` — 41/41 pass
- [x] Full wiki-server suite — 1276/1276 pass, 46 skipped (pre-existing)
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `pnpm build` (apps/web) — clean
- [x] `pnpm crux w validate gate` — 44/44 checks pass
- [x] Grep confirms no other test file maintains a parallel
  `citationStore` / `resourcesStore`

Fixes QUA-604
