### PR TITLE
release: 2026-04-19

### DIFF
--- a/apps/wiki-server/Dockerfile
+++ b/apps/wiki-server/Dockerfile
@@ -10,6 +10,7 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY apps/wiki-server/package.json ./apps/wiki-server/
 COPY packages/id-utils/package.json ./packages/id-utils/
 COPY packages/factbase/package.json ./packages/factbase/
+COPY packages/url-utils/package.json ./packages/url-utils/
 
 # Install wiki-server and its workspace dependencies
 RUN pnpm install --frozen-lockfile --filter wiki-server...
@@ -18,6 +19,7 @@ RUN pnpm install --frozen-lockfile --filter wiki-server...
 COPY apps/wiki-server/ ./apps/wiki-server/
 COPY packages/id-utils/ ./packages/id-utils/
 COPY packages/factbase/ ./packages/factbase/
+COPY packages/url-utils/ ./packages/url-utils/
 
 ENV NODE_ENV=production
 

--- a/apps/wiki-server/package.json
+++ b/apps/wiki-server/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@longterm-wiki/factbase": "workspace:*",
     "@longterm-wiki/id-utils": "workspace:*",
+    "@longterm-wiki/url-utils": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.4",

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -288,6 +288,18 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-598: every `@longterm-wiki/*` import from apps/*/src must be declared
+    // in that app's package.json dependencies. pnpm's hoisting lets undeclared
+    // imports work locally and in CI; the prod Docker build does not. This was
+    // the 3rd recurrence of the same class of bug (after id-utils and factbase)
+    // and is blocking to prevent a 4th.
+    id: 'workspace-dep-coverage',
+    name: 'Workspace dependency coverage (no undeclared @longterm-wiki/* imports)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-workspace-dep-coverage.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // QUA-294: enforces NOT VALID on ADD CONSTRAINT for large tables.
     // Migration 0173 caused a ~12h prod deploy stall by taking ACCESS
     // EXCLUSIVE on hallucination_risk_snapshots without NOT VALID.

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -288,11 +288,7 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
-    // QUA-598: every `@longterm-wiki/*` import from apps/*/src must be declared
-    // in that app's package.json dependencies. pnpm's hoisting lets undeclared
-    // imports work locally and in CI; the prod Docker build does not. This was
-    // the 3rd recurrence of the same class of bug (after id-utils and factbase)
-    // and is blocking to prevent a 4th.
+    // Rationale in validate-workspace-dep-coverage.ts. QUA-598.
     id: 'workspace-dep-coverage',
     name: 'Workspace dependency coverage (no undeclared @longterm-wiki/* imports)',
     command: 'npx',

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the workspace dep coverage validator.
+ *
+ * Strategy:
+ *   1. Regression test — the actual repo must pass (this is also the proof
+ *      that the "fix gaps in the same PR" step of QUA-598 was done).
+ *   2. Unit tests — build temp app trees with deliberate shapes and assert
+ *      the validator classifies them correctly (undeclared → error,
+ *      declared-unused → warning, subpath imports, type-only imports).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+
+import { runCheck } from './validate-workspace-dep-coverage.ts';
+
+interface AppFixture {
+  name: string;
+  dependencies?: Record<string, string>;
+  sources?: Record<string, string>; // relative path under src/ -> content
+}
+
+function makeAppsDir(fixtures: AppFixture[]): string {
+  const root = join(
+    os.tmpdir(),
+    `workspace-dep-coverage-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(root, { recursive: true });
+  for (const app of fixtures) {
+    const appDir = join(root, app.name);
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: app.name,
+          version: '0.0.0',
+          private: true,
+          dependencies: app.dependencies ?? {},
+        },
+        null,
+        2
+      )
+    );
+    if (app.sources) {
+      mkdirSync(join(appDir, 'src'), { recursive: true });
+      for (const [relPath, content] of Object.entries(app.sources)) {
+        const full = join(appDir, 'src', relPath);
+        mkdirSync(join(full, '..'), { recursive: true });
+        writeFileSync(full, content);
+      }
+    }
+  }
+  return root;
+}
+
+describe('validate-workspace-dep-coverage', () => {
+  let scratch: string | null = null;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = null;
+    }
+  });
+
+  it('current repo has no undeclared workspace imports', () => {
+    // Regression test: if this fails, a real undeclared import snuck into
+    // apps/*/src/ and will break the prod Docker build.
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+  });
+
+  it('fails when an app imports a workspace package that is not declared', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {},
+        sources: {
+          'index.ts':
+            `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n` +
+            `normalizeUrlForDedup('https://example.com');\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.errors).toBe(1);
+    expect(result.apps).toHaveLength(1);
+    expect(result.apps[0].missing).toEqual(['@longterm-wiki/url-utils']);
+  });
+
+  it('passes when every used workspace import is declared', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'workspace:*',
+          '@longterm-wiki/id-utils': 'workspace:*',
+        },
+        sources: {
+          'index.ts':
+            `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n` +
+            `import { isSid } from '@longterm-wiki/id-utils';\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.apps[0].used).toEqual(
+      new Set(['@longterm-wiki/url-utils', '@longterm-wiki/id-utils'])
+    );
+  });
+
+  it('strips subpaths when counting package usage', () => {
+    // `@longterm-wiki/factbase/types` is an import from `@longterm-wiki/factbase`.
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {
+          '@longterm-wiki/factbase': 'workspace:*',
+        },
+        sources: {
+          'index.ts':
+            `import type { FactSchema } from '@longterm-wiki/factbase/types';\n` +
+            `import { serialize } from '@longterm-wiki/factbase';\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.apps[0].used).toEqual(new Set(['@longterm-wiki/factbase']));
+  });
+
+  it('flags multi-app gaps independently', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'clean-app',
+        dependencies: { '@longterm-wiki/id-utils': 'workspace:*' },
+        sources: { 'a.ts': `import { isSid } from '@longterm-wiki/id-utils';` },
+      },
+      {
+        name: 'broken-app',
+        dependencies: {},
+        sources: { 'a.ts': `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';` },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.errors).toBe(1);
+
+    const clean = result.apps.find((a) => a.app === 'clean-app');
+    const broken = result.apps.find((a) => a.app === 'broken-app');
+    expect(clean?.missing).toEqual([]);
+    expect(broken?.missing).toEqual(['@longterm-wiki/url-utils']);
+  });
+
+  it('reports declared-but-unused workspace deps as a warning, not an error', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'workspace:*',
+          '@longterm-wiki/id-utils': 'workspace:*',
+        },
+        sources: {
+          'a.ts': `import { isSid } from '@longterm-wiki/id-utils';`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.warnings).toBe(1);
+    expect(result.apps[0].unused).toEqual(['@longterm-wiki/url-utils']);
+  });
+
+  it('ignores non-source files and nested node_modules', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {},
+        sources: {
+          // These files should NOT count toward the used set:
+          'README.md': `See \`@longterm-wiki/url-utils\` for docs.\n`,
+          'data.json': `{"pkg": "@longterm-wiki/url-utils"}\n`,
+        },
+      },
+    ]);
+
+    // Simulate a nested node_modules symlink-style dir — scanner must skip it
+    // even if it contains .ts files that reference workspace packages.
+    const dir = join(scratch, 'my-app', 'src', 'node_modules', 'something');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'index.ts'),
+      `import { x } from '@longterm-wiki/url-utils';\n`
+    );
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.apps[0].used.size).toBe(0);
+  });
+
+  it('handles apps with no src/ directory gracefully', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'stub-app',
+        dependencies: {},
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.apps).toHaveLength(1);
+    expect(result.apps[0].used.size).toBe(0);
+  });
+
+  it('returns passed=true when the apps directory does not exist', () => {
+    const result = runCheck({ appsDir: join(os.tmpdir(), `nonexistent-${Date.now()}`) });
+    expect(result.passed).toBe(true);
+    expect(result.apps).toEqual([]);
+  });
+
+  it('detects require() and dynamic import() forms', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: {},
+        sources: {
+          'a.cjs': `const { x } = require('@longterm-wiki/url-utils');\n`,
+          'b.ts': `const mod = await import('@longterm-wiki/id-utils');\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.apps[0].missing).toEqual(
+      ['@longterm-wiki/id-utils', '@longterm-wiki/url-utils'].sort()
+    );
+  });
+});

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -6,20 +6,30 @@
  *      that the "fix gaps in the same PR" step of QUA-598 was done).
  *   2. Unit tests — build temp app trees with deliberate shapes and assert
  *      the validator classifies them correctly (undeclared → error,
- *      declared-unused → warning, subpath imports, type-only imports).
+ *      declared-unused → warning, subpath imports, dep-section coverage,
+ *      comment/string false-positive resistance, etc.).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 
-import { runCheck } from './validate-workspace-dep-coverage.ts';
+import {
+  runCheck,
+  extractWorkspaceImports,
+} from './validate-workspace-dep-coverage.ts';
 
 interface AppFixture {
   name: string;
   dependencies?: Record<string, string>;
-  sources?: Record<string, string>; // relative path under src/ -> content
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  /** relative path under the app root (use 'src/foo.ts', 'scripts/build.mjs'). */
+  files?: Record<string, string>;
+  /** Optional raw content for package.json (overrides the JSON builder). */
+  packageJsonOverride?: string;
 }
 
 function makeAppsDir(fixtures: AppFixture[]): string {
@@ -31,23 +41,25 @@ function makeAppsDir(fixtures: AppFixture[]): string {
   for (const app of fixtures) {
     const appDir = join(root, app.name);
     mkdirSync(appDir, { recursive: true });
-    writeFileSync(
-      join(appDir, 'package.json'),
+    const pkgBody =
+      app.packageJsonOverride ??
       JSON.stringify(
         {
           name: app.name,
           version: '0.0.0',
           private: true,
           dependencies: app.dependencies ?? {},
+          devDependencies: app.devDependencies ?? {},
+          peerDependencies: app.peerDependencies ?? {},
+          optionalDependencies: app.optionalDependencies ?? {},
         },
         null,
         2
-      )
-    );
-    if (app.sources) {
-      mkdirSync(join(appDir, 'src'), { recursive: true });
-      for (const [relPath, content] of Object.entries(app.sources)) {
-        const full = join(appDir, 'src', relPath);
+      );
+    writeFileSync(join(appDir, 'package.json'), pkgBody);
+    if (app.files) {
+      for (const [relPath, content] of Object.entries(app.files)) {
+        const full = join(appDir, relPath);
         mkdirSync(join(full, '..'), { recursive: true });
         writeFileSync(full, content);
       }
@@ -68,7 +80,7 @@ describe('validate-workspace-dep-coverage', () => {
 
   it('current repo has no undeclared workspace imports', () => {
     // Regression test: if this fails, a real undeclared import snuck into
-    // apps/*/src/ and will break the prod Docker build.
+    // apps/*/src/ or scripts/ and will break the prod Docker build.
     const result = runCheck();
     expect(result.passed).toBe(true);
     expect(result.errors).toBe(0);
@@ -78,9 +90,8 @@ describe('validate-workspace-dep-coverage', () => {
     scratch = makeAppsDir([
       {
         name: 'my-app',
-        dependencies: {},
-        sources: {
-          'index.ts':
+        files: {
+          'src/index.ts':
             `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n` +
             `normalizeUrlForDedup('https://example.com');\n`,
         },
@@ -102,8 +113,8 @@ describe('validate-workspace-dep-coverage', () => {
           '@longterm-wiki/url-utils': 'workspace:*',
           '@longterm-wiki/id-utils': 'workspace:*',
         },
-        sources: {
-          'index.ts':
+        files: {
+          'src/index.ts':
             `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n` +
             `import { isSid } from '@longterm-wiki/id-utils';\n`,
         },
@@ -118,6 +129,28 @@ describe('validate-workspace-dep-coverage', () => {
     );
   });
 
+  it('accepts declaration in devDependencies, peerDependencies, or optionalDependencies', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        devDependencies: { '@longterm-wiki/id-utils': 'workspace:*' },
+        peerDependencies: { '@longterm-wiki/factbase': 'workspace:*' },
+        optionalDependencies: { '@longterm-wiki/url-utils': 'workspace:*' },
+        files: {
+          'src/a.ts':
+            `import { isSid } from '@longterm-wiki/id-utils';\n` +
+            `import { serialize } from '@longterm-wiki/factbase';\n` +
+            `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.apps[0].missing).toEqual([]);
+  });
+
   it('strips subpaths when counting package usage', () => {
     // `@longterm-wiki/factbase/types` is an import from `@longterm-wiki/factbase`.
     scratch = makeAppsDir([
@@ -126,8 +159,8 @@ describe('validate-workspace-dep-coverage', () => {
         dependencies: {
           '@longterm-wiki/factbase': 'workspace:*',
         },
-        sources: {
-          'index.ts':
+        files: {
+          'src/index.ts':
             `import type { FactSchema } from '@longterm-wiki/factbase/types';\n` +
             `import { serialize } from '@longterm-wiki/factbase';\n`,
         },
@@ -139,17 +172,33 @@ describe('validate-workspace-dep-coverage', () => {
     expect(result.apps[0].used).toEqual(new Set(['@longterm-wiki/factbase']));
   });
 
+  it('scans apps/<name>/scripts/ in addition to src/', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        // Nothing declared — imports from scripts/ must still be caught.
+        files: {
+          'scripts/build.mjs':
+            `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';\n`,
+        },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.apps[0].missing).toEqual(['@longterm-wiki/url-utils']);
+  });
+
   it('flags multi-app gaps independently', () => {
     scratch = makeAppsDir([
       {
         name: 'clean-app',
         dependencies: { '@longterm-wiki/id-utils': 'workspace:*' },
-        sources: { 'a.ts': `import { isSid } from '@longterm-wiki/id-utils';` },
+        files: { 'src/a.ts': `import { isSid } from '@longterm-wiki/id-utils';` },
       },
       {
         name: 'broken-app',
-        dependencies: {},
-        sources: { 'a.ts': `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';` },
+        files: { 'src/a.ts': `import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';` },
       },
     ]);
 
@@ -171,8 +220,8 @@ describe('validate-workspace-dep-coverage', () => {
           '@longterm-wiki/url-utils': 'workspace:*',
           '@longterm-wiki/id-utils': 'workspace:*',
         },
-        sources: {
-          'a.ts': `import { isSid } from '@longterm-wiki/id-utils';`,
+        files: {
+          'src/a.ts': `import { isSid } from '@longterm-wiki/id-utils';`,
         },
       },
     ]);
@@ -188,21 +237,20 @@ describe('validate-workspace-dep-coverage', () => {
     scratch = makeAppsDir([
       {
         name: 'my-app',
-        dependencies: {},
-        sources: {
+        files: {
           // These files should NOT count toward the used set:
-          'README.md': `See \`@longterm-wiki/url-utils\` for docs.\n`,
-          'data.json': `{"pkg": "@longterm-wiki/url-utils"}\n`,
+          'src/README.md': `See \`@longterm-wiki/url-utils\` for docs.\n`,
+          'src/data.json': `{"pkg": "@longterm-wiki/url-utils"}\n`,
         },
       },
     ]);
 
-    // Simulate a nested node_modules symlink-style dir — scanner must skip it
-    // even if it contains .ts files that reference workspace packages.
-    const dir = join(scratch, 'my-app', 'src', 'node_modules', 'something');
-    mkdirSync(dir, { recursive: true });
+    // Simulate a nested node_modules dir — scanner must skip it even if it
+    // contains .ts files that reference workspace packages.
+    const nm = join(scratch, 'my-app', 'src', 'node_modules', 'something');
+    mkdirSync(nm, { recursive: true });
     writeFileSync(
-      join(dir, 'index.ts'),
+      join(nm, 'index.ts'),
       `import { x } from '@longterm-wiki/url-utils';\n`
     );
 
@@ -211,12 +259,28 @@ describe('validate-workspace-dep-coverage', () => {
     expect(result.apps[0].used.size).toBe(0);
   });
 
-  it('handles apps with no src/ directory gracefully', () => {
+  it('does NOT false-positive on bare mentions in comments or strings', () => {
     scratch = makeAppsDir([
       {
-        name: 'stub-app',
-        dependencies: {},
+        name: 'my-app',
+        files: {
+          'src/a.ts':
+            `// See @longterm-wiki/this-does-not-exist for docs.\n` +
+            `const doc = 'visit @longterm-wiki/not-a-real-package';\n` +
+            `/* JSDoc: pulls from @longterm-wiki/also-fake */\n`,
+        },
       },
+    ]);
+
+    const result = runCheck({ appsDir: scratch });
+    // No real imports → passes, no missing entries.
+    expect(result.passed).toBe(true);
+    expect(result.apps[0].used.size).toBe(0);
+  });
+
+  it('handles apps with no src/ or scripts/ directory gracefully', () => {
+    scratch = makeAppsDir([
+      { name: 'stub-app' },
     ]);
 
     const result = runCheck({ appsDir: scratch });
@@ -235,18 +299,105 @@ describe('validate-workspace-dep-coverage', () => {
     scratch = makeAppsDir([
       {
         name: 'my-app',
-        dependencies: {},
-        sources: {
-          'a.cjs': `const { x } = require('@longterm-wiki/url-utils');\n`,
-          'b.ts': `const mod = await import('@longterm-wiki/id-utils');\n`,
+        files: {
+          'src/a.cjs': `const { x } = require('@longterm-wiki/url-utils');\n`,
+          'src/b.ts': `const mod = await import('@longterm-wiki/id-utils');\n`,
         },
       },
     ]);
 
     const result = runCheck({ appsDir: scratch });
     expect(result.passed).toBe(false);
-    expect(result.apps[0].missing).toEqual(
-      ['@longterm-wiki/id-utils', '@longterm-wiki/url-utils'].sort()
+    // Sorted alphabetically in the output.
+    expect(result.apps[0].missing).toEqual([
+      '@longterm-wiki/id-utils',
+      '@longterm-wiki/url-utils',
+    ]);
+  });
+
+  it('calls onWarn when package.json is malformed', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        packageJsonOverride: `{ "name": "my-app", "dependencies": [ broken `,
+        files: {
+          'src/a.ts': `import { x } from '@longterm-wiki/url-utils';`,
+        },
+      },
+    ]);
+
+    const warnings: string[] = [];
+    const result = runCheck({ appsDir: scratch, onWarn: (msg) => warnings.push(msg) });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toMatch(/Malformed package.json/);
+    // With no declared deps, the import is still flagged as missing.
+    expect(result.passed).toBe(false);
+  });
+
+  it('skips symlinks without following them (no recursion loop)', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        dependencies: { '@longterm-wiki/id-utils': 'workspace:*' },
+        files: {
+          'src/a.ts': `import { isSid } from '@longterm-wiki/id-utils';`,
+        },
+      },
+    ]);
+
+    // Create a symlink that would cause infinite recursion if followed.
+    try {
+      symlinkSync(
+        join(scratch, 'my-app', 'src'),
+        join(scratch, 'my-app', 'src', 'self-loop')
+      );
+    } catch {
+      // On some filesystems (e.g. CI without symlink perms) the test is a no-op.
+      return;
+    }
+
+    const result = runCheck({ appsDir: scratch });
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('extractWorkspaceImports', () => {
+  it('captures imports from import/from/require forms', () => {
+    const source = [
+      `import foo from '@longterm-wiki/a';`,
+      `import { x } from '@longterm-wiki/b';`,
+      `import('@longterm-wiki/c');`,
+      `require('@longterm-wiki/d');`,
+      `import type { T } from '@longterm-wiki/e';`,
+    ].join('\n');
+
+    expect(extractWorkspaceImports(source)).toEqual(
+      new Set([
+        '@longterm-wiki/a',
+        '@longterm-wiki/b',
+        '@longterm-wiki/c',
+        '@longterm-wiki/d',
+        '@longterm-wiki/e',
+      ])
     );
+  });
+
+  it('does not capture comment or non-quoted mentions', () => {
+    const source = [
+      `// See @longterm-wiki/foo for help`,
+      `/* @longterm-wiki/bar */`,
+      `const pkg = \`@longterm-wiki/template-literal\`;  // backtick, not single/double quote anchor`,
+    ].join('\n');
+
+    expect(extractWorkspaceImports(source)).toEqual(new Set());
+  });
+
+  it('captures subpath imports as the parent package', () => {
+    const source =
+      `import { T } from '@longterm-wiki/factbase/types';\n` +
+      `import { s } from '@longterm-wiki/factbase/serializer/v2';\n`;
+
+    expect(extractWorkspaceImports(source)).toEqual(new Set(['@longterm-wiki/factbase']));
   });
 });

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that every `@longterm-wiki/*` workspace package imported from
+ * `apps/<name>/src/` is declared in that app's `package.json` dependencies.
+ *
+ * ## Why this exists
+ *
+ * pnpm's workspace hoisting makes undeclared workspace imports work locally
+ * and in CI (because the monorepo root has all packages installed). But the
+ * prod Docker build uses `pnpm install --filter <app>...`, which only resolves
+ * declared workspace dependencies. An undeclared `@longterm-wiki/*` import
+ * will pass every local and CI check, then fail at runtime inside the Docker
+ * container with `ERR_MODULE_NOT_FOUND`.
+ *
+ * This bug class has recurred three times (see QUA-598):
+ *   - `@longterm-wiki/id-utils` (earliest incident, referenced in QUA-449)
+ *   - `@longterm-wiki/factbase` (2026-04-14, QUA-449)
+ *   - `@longterm-wiki/url-utils` (2026-04-18, QUA-598)
+ *
+ * Each previous occurrence was fixed instance-by-instance. This validator is
+ * the systemic fix — a blocking gate check so the 4th recurrence is impossible.
+ *
+ * ## What it checks
+ *
+ * For every `apps/<name>/package.json`:
+ *   1. Scan `apps/<name>/src/` recursively for any `@longterm-wiki/<pkg>` import.
+ *   2. Compare the used set against the `dependencies` block in `package.json`.
+ *   3. Fail if any used package is not declared.
+ *
+ * Imports in scope: `import ... from '@longterm-wiki/X'`, `import('…')`,
+ * `require('…')`, and subpath imports like `@longterm-wiki/factbase/types`
+ * (the package name is the first path segment).
+ *
+ * `devDependencies` is NOT accepted: the prod install graph is driven by
+ * `dependencies`, so anything a source file imports must be there.
+ *
+ * ## What it does NOT check
+ *
+ * - `apps/<name>/scripts/`, `tests/`, `e2e/` — only runtime `src/` matters.
+ * - `packages/` — workspace packages importing each other is allowed in the
+ *   monorepo graph; pnpm resolves those transitively.
+ * - Declared-but-unused packages — reported as a warning, not an error.
+ *
+ * Usage: `npx tsx crux/validate/validate-workspace-dep-coverage.ts`
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { join } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const WORKSPACE_PREFIX = '@longterm-wiki/';
+
+// Matches `@longterm-wiki/<pkg-name>`, capturing just the package name (no subpath).
+// Package names are lowercase/digits/hyphens per npm rules.
+const IMPORT_RE = /@longterm-wiki\/([a-z0-9][a-z0-9-]*)/g;
+
+interface AppCoverage {
+  app: string;
+  used: Set<string>;        // @longterm-wiki/X packages imported from src/
+  declared: Set<string>;    // @longterm-wiki/X packages in dependencies
+  missing: string[];        // used but not declared (blocking)
+  unused: string[];         // declared but not used (warning)
+}
+
+interface CheckOptions {
+  appsDir?: string;
+}
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  warnings: number;
+  apps: AppCoverage[];
+}
+
+function listSourceFiles(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (name === 'node_modules' || name.startsWith('.')) continue;
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      listSourceFiles(full, out);
+    } else if (st.isFile()) {
+      const dot = name.lastIndexOf('.');
+      if (dot !== -1 && SOURCE_EXTENSIONS.has(name.slice(dot))) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function extractWorkspaceImports(content: string): Set<string> {
+  const used = new Set<string>();
+  IMPORT_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = IMPORT_RE.exec(content)) !== null) {
+    used.add(`${WORKSPACE_PREFIX}${m[1]}`);
+  }
+  return used;
+}
+
+function readDeclaredDeps(packageJsonPath: string): Set<string> {
+  const declared = new Set<string>();
+  try {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      dependencies?: Record<string, string>;
+    };
+    for (const name of Object.keys(pkg.dependencies ?? {})) {
+      if (name.startsWith(WORKSPACE_PREFIX)) declared.add(name);
+    }
+  } catch {
+    // Unreadable package.json is surfaced as a separate error upstream if needed;
+    // returning the empty set here keeps the scan running for other apps.
+  }
+  return declared;
+}
+
+function analyzeApp(appDir: string, appName: string): AppCoverage | null {
+  const pkgJson = join(appDir, 'package.json');
+  if (!existsSync(pkgJson)) return null;
+
+  const srcDir = join(appDir, 'src');
+  const files = existsSync(srcDir) ? listSourceFiles(srcDir) : [];
+
+  const used = new Set<string>();
+  for (const file of files) {
+    let content: string;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.includes(WORKSPACE_PREFIX)) continue;
+    for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
+  }
+
+  const declared = readDeclaredDeps(pkgJson);
+
+  const missing = [...used].filter((p) => !declared.has(p)).sort();
+  const unused = [...declared].filter((p) => !used.has(p)).sort();
+
+  return { app: appName, used, declared, missing, unused };
+}
+
+export function runCheck(options: CheckOptions = {}): CheckResult {
+  const c = getColors();
+  const appsDir = options.appsDir ?? join(PROJECT_ROOT, 'apps');
+
+  console.log(
+    `${c.blue}Checking workspace dependency coverage in ${appsDir}...${c.reset}\n`
+  );
+
+  let appNames: string[];
+  try {
+    appNames = readdirSync(appsDir).filter((name) => {
+      const full = join(appsDir, name);
+      try {
+        return statSync(full).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    console.log(`${c.dim}Skipping: ${appsDir} not found${c.reset}`);
+    return { passed: true, errors: 0, warnings: 0, apps: [] };
+  }
+
+  const apps: AppCoverage[] = [];
+  for (const name of appNames.sort()) {
+    const report = analyzeApp(join(appsDir, name), name);
+    if (report) apps.push(report);
+  }
+
+  let errors = 0;
+  let warnings = 0;
+
+  for (const app of apps) {
+    if (app.missing.length === 0 && app.unused.length === 0) {
+      console.log(
+        `${c.green}${app.app}: OK${c.reset}${c.dim} (${app.used.size} used / ${app.declared.size} declared)${c.reset}`
+      );
+      continue;
+    }
+
+    if (app.missing.length > 0) {
+      errors += app.missing.length;
+      console.log(
+        `${c.red}${app.app}: ${app.missing.length} undeclared workspace import${app.missing.length > 1 ? 's' : ''}:${c.reset}`
+      );
+      for (const pkg of app.missing) {
+        console.log(`  ${c.red}${pkg}${c.reset}`);
+      }
+      console.log(
+        `${c.dim}  Fix: add to apps/${app.app}/package.json dependencies:${c.reset}`
+      );
+      for (const pkg of app.missing) {
+        console.log(`${c.dim}    "${pkg}": "workspace:*"${c.reset}`);
+      }
+    }
+
+    if (app.unused.length > 0) {
+      warnings += app.unused.length;
+      console.log(
+        `${c.yellow}${app.app}: ${app.unused.length} declared but unused workspace dep${app.unused.length > 1 ? 's' : ''} (warning):${c.reset}`
+      );
+      for (const pkg of app.unused) {
+        console.log(`  ${c.yellow}${pkg}${c.reset}`);
+      }
+    }
+  }
+
+  console.log();
+  if (errors > 0) {
+    console.log(
+      `${c.red}Found ${errors} undeclared workspace import${errors > 1 ? 's' : ''}.${c.reset}`
+    );
+    console.log(
+      `${c.dim}Prod Docker builds use \`pnpm install --filter <app>...\` which only resolves declared dependencies.${c.reset}`
+    );
+    console.log(
+      `${c.dim}Undeclared imports pass locally (pnpm hoists) but fail at runtime with ERR_MODULE_NOT_FOUND.${c.reset}`
+    );
+    console.log(
+      `${c.dim}See QUA-598 for the most recent incident of this class.${c.reset}`
+    );
+  } else {
+    console.log(
+      `${c.green}All workspace imports are declared.${c.reset}`
+    );
+  }
+
+  return {
+    passed: errors === 0,
+    errors,
+    warnings,
+    apps,
+  };
+}
+
+if (process.argv[1]?.includes('validate-workspace-dep-coverage')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -56,7 +56,7 @@
  * Usage: `npx tsx crux/validate/validate-workspace-dep-coverage.ts`
  */
 
-import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { readdirSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
@@ -101,27 +101,21 @@ interface CheckResult {
 }
 
 function listSourceFiles(dir: string, out: string[] = []): string[] {
-  let entries: string[];
+  let entries;
   try {
-    entries = readdirSync(dir);
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
     return out;
   }
-  for (const name of entries) {
+  // Dirent.isDirectory()/isFile() check the link itself (like lstat), so
+  // symbolic links are naturally skipped — no infinite recursion on loops.
+  for (const dirent of entries) {
+    const name = dirent.name;
     if (name === 'node_modules' || name.startsWith('.')) continue;
     const full = join(dir, name);
-    let st;
-    try {
-      // Using lstat avoids following symlinks (prevents infinite loops if a
-      // stray symlink points at an ancestor).
-      st = statSync(full, { throwIfNoEntry: false });
-    } catch {
-      continue;
-    }
-    if (!st) continue;
-    if (st.isDirectory()) {
+    if (dirent.isDirectory()) {
       listSourceFiles(full, out);
-    } else if (st.isFile()) {
+    } else if (dirent.isFile()) {
       const dot = name.lastIndexOf('.');
       if (dot !== -1 && SOURCE_EXTENSIONS.has(name.slice(dot))) {
         out.push(full);
@@ -184,8 +178,8 @@ function analyzeApp(
 
   const files: string[] = [];
   for (const sub of SCAN_SUBDIRS) {
-    const subPath = join(appDir, sub);
-    if (existsSync(subPath)) listSourceFiles(subPath, files);
+    // listSourceFiles silently returns [] if the subdir is missing.
+    listSourceFiles(join(appDir, sub), files);
   }
 
   const used = new Set<string>();
@@ -219,14 +213,9 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
 
   let appNames: string[];
   try {
-    appNames = readdirSync(appsDir).filter((name) => {
-      const full = join(appsDir, name);
-      try {
-        return statSync(full).isDirectory();
-      } catch {
-        return false;
-      }
-    });
+    appNames = readdirSync(appsDir, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name);
   } catch {
     console.log(`${c.dim}Skipping: ${appsDir} not found${c.reset}`);
     return { passed: true, errors: 0, warnings: 0, apps: [] };

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -2,16 +2,17 @@
 
 /**
  * Validate that every `@longterm-wiki/*` workspace package imported from
- * `apps/<name>/src/` is declared in that app's `package.json` dependencies.
+ * `apps/<name>/src/` or `apps/<name>/scripts/` is declared in that app's
+ * `package.json` (in any dependency section).
  *
  * ## Why this exists
  *
  * pnpm's workspace hoisting makes undeclared workspace imports work locally
  * and in CI (because the monorepo root has all packages installed). But the
- * prod Docker build uses `pnpm install --filter <app>...`, which only resolves
- * declared workspace dependencies. An undeclared `@longterm-wiki/*` import
- * will pass every local and CI check, then fail at runtime inside the Docker
- * container with `ERR_MODULE_NOT_FOUND`.
+ * prod Docker build uses `pnpm install --filter <app>...`, which only
+ * resolves declared workspace dependencies. An undeclared `@longterm-wiki/*`
+ * import will pass every local and CI check, then fail at runtime inside the
+ * Docker container with `ERR_MODULE_NOT_FOUND`.
  *
  * This bug class has recurred three times (see QUA-598):
  *   - `@longterm-wiki/id-utils` (earliest incident, referenced in QUA-449)
@@ -24,22 +25,32 @@
  * ## What it checks
  *
  * For every `apps/<name>/package.json`:
- *   1. Scan `apps/<name>/src/` recursively for any `@longterm-wiki/<pkg>` import.
- *   2. Compare the used set against the `dependencies` block in `package.json`.
- *   3. Fail if any used package is not declared.
+ *   1. Scan `apps/<name>/src/` AND `apps/<name>/scripts/` recursively for any
+ *      `@longterm-wiki/<pkg>` import.
+ *   2. Compare the used set against every declared-dependency section in
+ *      `package.json` (dependencies, devDependencies, peerDependencies,
+ *      optionalDependencies).
+ *   3. Fail if any used package is not declared in any section.
  *
- * Imports in scope: `import ... from '@longterm-wiki/X'`, `import('…')`,
- * `require('…')`, and subpath imports like `@longterm-wiki/factbase/types`
- * (the package name is the first path segment).
+ * Imports in scope: quote-anchored `from '@longterm-wiki/X'`, `import('…')`,
+ * and `require('…')` — plus subpath imports like `@longterm-wiki/factbase/types`
+ * (the package name is the first path segment). The quote anchor prevents
+ * false positives from bare mentions in comments or docstrings. Note: a
+ * commented-out *import statement* (e.g. `// import { x } from '@longterm-wiki/foo'`)
+ * is still flagged — treating that as a real import is intentional since
+ * commented-out code should be removed, not left behind.
  *
- * `devDependencies` is NOT accepted: the prod install graph is driven by
- * `dependencies`, so anything a source file imports must be there.
+ * Why "any section" and not just `dependencies`: the Dockerfiles in this
+ * repo install with `pnpm install --filter <app>...` (no `--prod`), so
+ * devDependencies are present in the image. The failure mode we target is
+ * "not declared anywhere", which is what makes pnpm's filter prune the
+ * package entirely.
  *
  * ## What it does NOT check
  *
- * - `apps/<name>/scripts/`, `tests/`, `e2e/` — only runtime `src/` matters.
+ * - `apps/<name>/tests/`, `e2e/` — not part of the production install graph.
  * - `packages/` — workspace packages importing each other is allowed in the
- *   monorepo graph; pnpm resolves those transitively.
+ *   monorepo graph; pnpm resolves those transitively via the root install.
  * - Declared-but-unused packages — reported as a warning, not an error.
  *
  * Usage: `npx tsx crux/validate/validate-workspace-dep-coverage.ts`
@@ -47,26 +58,39 @@
 
 import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const SCAN_SUBDIRS = ['src', 'scripts'] as const;
 const WORKSPACE_PREFIX = '@longterm-wiki/';
+const DEP_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
 
-// Matches `@longterm-wiki/<pkg-name>`, capturing just the package name (no subpath).
-// Package names are lowercase/digits/hyphens per npm rules.
-const IMPORT_RE = /@longterm-wiki\/([a-z0-9][a-z0-9-]*)/g;
+// Matches import / import() / require() for `@longterm-wiki/<pkg>` with a
+// quote anchor so stray mentions in comments ("see @longterm-wiki/foo docs")
+// don't count. Package names are lowercase/digits/hyphens (npm naming rules).
+// Captures just the first path segment, so subpath imports like
+// `@longterm-wiki/factbase/types` correctly resolve to `@longterm-wiki/factbase`.
+const IMPORT_RE = /(?:from|import|require)\s*\(?\s*['"]@longterm-wiki\/([a-z0-9][a-z0-9-]*)(?:\/[^'"]*)?['"]/g;
 
 interface AppCoverage {
   app: string;
-  used: Set<string>;        // @longterm-wiki/X packages imported from src/
-  declared: Set<string>;    // @longterm-wiki/X packages in dependencies
-  missing: string[];        // used but not declared (blocking)
-  unused: string[];         // declared but not used (warning)
+  used: Set<string>;       // @longterm-wiki/X packages imported from src/ or scripts/
+  declared: Set<string>;   // @longterm-wiki/X packages declared in any dep section
+  missing: string[];       // used but not declared anywhere (blocking)
+  unused: string[];        // declared but not used (warning)
 }
 
 interface CheckOptions {
   appsDir?: string;
+  /** Optional warning sink so tests can assert on parse errors. */
+  onWarn?: (message: string) => void;
 }
 
 interface CheckResult {
@@ -88,10 +112,13 @@ function listSourceFiles(dir: string, out: string[] = []): string[] {
     const full = join(dir, name);
     let st;
     try {
-      st = statSync(full);
+      // Using lstat avoids following symlinks (prevents infinite loops if a
+      // stray symlink points at an ancestor).
+      st = statSync(full, { throwIfNoEntry: false });
     } catch {
       continue;
     }
+    if (!st) continue;
     if (st.isDirectory()) {
       listSourceFiles(full, out);
     } else if (st.isFile()) {
@@ -104,7 +131,7 @@ function listSourceFiles(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-function extractWorkspaceImports(content: string): Set<string> {
+export function extractWorkspaceImports(content: string): Set<string> {
   const used = new Set<string>();
   IMPORT_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
@@ -114,28 +141,52 @@ function extractWorkspaceImports(content: string): Set<string> {
   return used;
 }
 
-function readDeclaredDeps(packageJsonPath: string): Set<string> {
+function readDeclaredDeps(
+  packageJsonPath: string,
+  onWarn?: (message: string) => void,
+): Set<string> {
   const declared = new Set<string>();
+  let raw: string;
   try {
-    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
-      dependencies?: Record<string, string>;
-    };
-    for (const name of Object.keys(pkg.dependencies ?? {})) {
+    raw = readFileSync(packageJsonPath, 'utf-8');
+  } catch (err) {
+    onWarn?.(
+      `Unreadable package.json at ${packageJsonPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return declared;
+  }
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    onWarn?.(
+      `Malformed package.json at ${packageJsonPath}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return declared;
+  }
+  for (const section of DEP_SECTIONS) {
+    const block = pkg[section];
+    if (!block || typeof block !== 'object') continue;
+    for (const name of Object.keys(block as Record<string, unknown>)) {
       if (name.startsWith(WORKSPACE_PREFIX)) declared.add(name);
     }
-  } catch {
-    // Unreadable package.json is surfaced as a separate error upstream if needed;
-    // returning the empty set here keeps the scan running for other apps.
   }
   return declared;
 }
 
-function analyzeApp(appDir: string, appName: string): AppCoverage | null {
+function analyzeApp(
+  appDir: string,
+  appName: string,
+  onWarn?: (message: string) => void,
+): AppCoverage | null {
   const pkgJson = join(appDir, 'package.json');
   if (!existsSync(pkgJson)) return null;
 
-  const srcDir = join(appDir, 'src');
-  const files = existsSync(srcDir) ? listSourceFiles(srcDir) : [];
+  const files: string[] = [];
+  for (const sub of SCAN_SUBDIRS) {
+    const subPath = join(appDir, sub);
+    if (existsSync(subPath)) listSourceFiles(subPath, files);
+  }
 
   const used = new Set<string>();
   for (const file of files) {
@@ -149,7 +200,7 @@ function analyzeApp(appDir: string, appName: string): AppCoverage | null {
     for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
   }
 
-  const declared = readDeclaredDeps(pkgJson);
+  const declared = readDeclaredDeps(pkgJson, onWarn);
 
   const missing = [...used].filter((p) => !declared.has(p)).sort();
   const unused = [...declared].filter((p) => !used.has(p)).sort();
@@ -160,6 +211,7 @@ function analyzeApp(appDir: string, appName: string): AppCoverage | null {
 export function runCheck(options: CheckOptions = {}): CheckResult {
   const c = getColors();
   const appsDir = options.appsDir ?? join(PROJECT_ROOT, 'apps');
+  const onWarn = options.onWarn ?? ((msg) => console.log(`${c.yellow}${msg}${c.reset}`));
 
   console.log(
     `${c.blue}Checking workspace dependency coverage in ${appsDir}...${c.reset}\n`
@@ -182,7 +234,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
 
   const apps: AppCoverage[] = [];
   for (const name of appNames.sort()) {
-    const report = analyzeApp(join(appsDir, name), name);
+    const report = analyzeApp(join(appsDir, name), name, onWarn);
     if (report) apps.push(report);
   }
 
@@ -252,7 +304,14 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
   };
 }
 
-if (process.argv[1]?.includes('validate-workspace-dep-coverage')) {
+// Entry-point guard: only run as a script when node invokes this file directly.
+// Comparing import.meta.url to process.argv[1] avoids the substring-match
+// brittleness where a sibling test file path would also trigger a side-effect run.
+const invokedDirectly =
+  import.meta.url.startsWith('file://') &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (invokedDirectly) {
   const result = runCheck();
   process.exit(result.passed ? 0 : 1);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       '@longterm-wiki/id-utils':
         specifier: workspace:*
         version: link:../../packages/id-utils
+      '@longterm-wiki/url-utils':
+        specifier: workspace:*
+        version: link:../../packages/url-utils
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)


### PR DESCRIPTION
## Release 2026-04-19

**4 commits** since last release.

> [!WARNING]
> Production has **39 commits** not on main (hotfixes or merge commits).
> Review carefully to ensure these won't be overwritten.

### Features
- feat(validate): add workspace dep coverage gate validator (QUA-598)

### Other
- simplify: use withFileTypes to skip symlinks and halve syscalls
- review: address /agent-review-pr findings

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4483)_
- [ ] `migration` Verify migration 0198 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4480)_
- [ ] `manual` Post-deploy: confirm `/internal/data-quality` still shows `facts.canonical_f` = 100% (no VALIDATE-time rejections) — visit https://www.longtermwiki.com/internal/data-quality and check the ID Format Audit panel _(from PR #4480)_
- [ ] `manual` Post-deploy: verify a fresh factbase sync still works — `WIKI_SERVER_ENV=prod pnpm crux fb sourcing --entity=anthropic --limit=1` (sanity check that the CHECK doesn't reject current writes) _(from PR #4480)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4476)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4476)_
- [ ] `migration` Verify migration 0192 registered in drizzle journal (pure no-op — `SELECT 1`; no DDL applied; no separate manual script exists). Expect the row to appear after server restart — `psql "$DATABASE_URL" -c "SELECT hash, created_at FROM drizzle.__drizzle_migrations WHERE hash LIKE '%0192%' OR created_at > NOW() - INTERVAL '1 hour' ORDER BY created_at DESC LIMIT 5;"` _(from PR #4475)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and `/health` is `healthy` — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4475)_
- [ ] `manual` Post-deploy spot-check: submit a test claim via `POST /api/claims/propose` with a legacy hex16 `resourceId`; confirm the stored `proposed_claims.resource_id` is canonical `sid_<10>`, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM proposed_claims WHERE created_at > NOW() - INTERVAL '1 hour' AND resource_id IS NOT NULL ORDER BY id DESC LIMIT 5;"`, expect `sid_`-prefixed rows. _(from PR #4475)_
- [ ] `manual` Confirm `GET /api/resources/:id/content` resolves by both hex16 and sid_ on prod — `curl -sf "$WIKI_SERVER_URL/api/resources/<any-hex16>/content" | jq .id` then `curl -sf "$WIKI_SERVER_URL/api/resources/<its-stable_id>/content" | jq .id` — both should return the same row. _(from PR #4475)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4473)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4473)_
- [ ] `manual` Spot-check citation_quotes.resource_id is now sid_ post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM citation_quotes WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_` _(from PR #4473)_
- [ ] `manual` Confirm the migration emitted 0 `skipped_null_stableid` and 0 `orphan_count` NOTICEs in deploy logs — `kubectl logs -l app=wiki-server --tail=200 | grep -i QUA-574` (expect no output, or 0 in both counters) _(from PR #4473)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4471)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4471)_
- [ ] `manual-migration` Run manual migration script: psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql _(from PR #4470)_
- [ ] `manual` Verify the active-agents sweep fires on schedule — check groundskeeper logs for a `session-sweep`-paired `active-agents-sweep` entry within the hour after deploy; `kubectl logs -n wiki deployment/groundskeeper | grep active-agents-sweep` _(from PR #4470)_
- [ ] `manual` Verify prod `GET /api/active-agents?status=active` count drops from ~80 to the truly-live count (expected: <15) within 30 min after the backfill script runs _(from PR #4470)_
- [ ] `migration` Verify migration 0188 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4468)_
- [ ] `manual` Confirm backfill flipped historical rows — `psql "$DATABASE_URL" -c "SELECT status, count(*) FROM agent_sessions GROUP BY status;"`, expect non-zero `stale` count where pre-deploy it was 0 _(from PR #4468)_
- [ ] `manual` Verify `/internal/agent-activity` shows the new "stale" count alongside completed — load https://www.longtermwiki.com/internal/agent-activity and check the summary line _(from PR #4468)_
- [ ] `manual` Verify next graceful-exit session produces status='completed' with non-null title+summary — `psql "$DATABASE_URL" -c "SELECT status, title IS NOT NULL AS has_title, summary IS NOT NULL AS has_summary, started_at FROM agent_sessions WHERE status='completed' ORDER BY started_at DESC LIMIT 5;"`, expect `has_title=t has_summary=t` on post-deploy rows _(from PR #4468)_
- [ ] `ci` Modified workflow "ci pr health" — verify it runs successfully after merge — `gh run list --workflow="ci-pr-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `ci` Modified workflow "frontend data health" — verify it runs successfully after merge — `gh run list --workflow="frontend-data-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `ci` Modified workflow "server api health" — verify it runs successfully after merge — `gh run list --workflow="server-api-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `manual` Trigger each wellness workflow directly rather than waiting for the next scheduled run — `gh workflow run ci-pr-health.yml && gh workflow run frontend-data-health.yml && gh workflow run server-api-health.yml` _(from PR #4465)_
- [ ] `manual` Verify wellness issue #4463 auto-closes after the three manually-triggered runs succeed — `gh issue view 4463 -R quantified-uncertainty/longterm-wiki` _(from PR #4465)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4461)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4461)_
- [ ] `manual` Confirm new FK is in place on prod — `psql "$DATABASE_URL" -c "\\d source_check_evidence"`, expect `source_check_evidence_resource_id_resources_stable_id_fk` line referencing `resources(stable_id) ON DELETE SET NULL` _(from PR #4461)_
- [ ] `manual` Spot-check that post-migration `resource_id` values are sid_-prefixed, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM source_check_evidence WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all start with `sid_` _(from PR #4461)_
- [ ] `manual` Visit `/organizations/anthropic` in prod and confirm verdict dots still render (verdict UI reads source_check_evidence) _(from PR #4461)_
- [ ] `migration` Verify migration 0188 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4460)_
- [ ] `migration` Verify migration 0189 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4460)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4460)_
- [ ] `manual` Confirm entity_resources FK points at resources.stable_id — `psql "$DATABASE_URL" -c "\d entity_resources" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE CASCADE` _(from PR #4460)_
- [ ] `manual` Spot-check resource_id values are sid_'s post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM entity_resources LIMIT 3;"`, expect all start with `sid_` _(from PR #4460)_
- [ ] `manual` Confirm the things_search MV was rebuilt with resolved titles (not sid_ leaks) — `psql "$DATABASE_URL" -c "SELECT COUNT(*) FILTER (WHERE title LIKE 'sid_%') AS sid_titles, COUNT(*) AS total FROM things_search WHERE thing_type='entity-resource';"`, expect `sid_titles=0 total=4182` _(from PR #4460)_
- [ ] `manual` Verify hourly groundskeeper things-search-refresh is still succeeding post-deploy — check `/internal/groundskeeper-runs` for a green `things-search-refresh` entry within ~90 minutes _(from PR #4460)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4459)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4459)_
- [ ] `migration` Verify migration 0186 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4456)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4456)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4456)_
- [ ] `route` New API route "resource-dedup" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/resource-dedup" -o /dev/null -w "%{http_code}"` _(from PR #4456)_
- [ ] `migration` Verify migration 0186 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4453)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4453)_
- [ ] `manual` Confirm the new FK is in place on prod — `psql "$DATABASE_URL" -c "\d resource_content_versions" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE SET NULL` _(from PR #4453)_
- [ ] `manual` Spot-check that `resource_id` values post-migration are sid_'s, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM resource_content_versions WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_` _(from PR #4453)_
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"` _(from PR #4436)_
<!-- /deploy-tasks -->

---
[Full diff](https://github.com/quantified-uncertainty/longterm-wiki/compare/production...main)