### PR TITLE
hotfix(migration 0186): drop both _fk and _fkey FK names to unblock deploy

### DIFF
--- a/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
@@ -26,8 +26,16 @@
 --     ON DELETE SET NULL;
 
 -- Step 1: drop the existing FK on resources.id.
+-- Both the Drizzle-generated name (*_fk) and the postgres-default name (*_fkey)
+-- can exist in prod due to historical migration paths; drop both. This pattern
+-- was missed in the pilot and caused a deploy halt when prod had *_fkey
+-- pointing at resources(id) — the Step 2 UPDATE tripped that surviving FK.
+-- Every subsequent Phase B migration (0188, 0189, 0191, 0192, 0193, 0194, 0197)
+-- drops both names; backporting the pattern here.
 ALTER TABLE resource_content_versions
   DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_resources_id_fk;
+ALTER TABLE resource_content_versions
+  DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_fkey;
 
 -- Step 2: rewrite resource_id values from hex16 → sid_<10> via JOIN.
 -- Rows where resource_id IS NULL are untouched. Rows whose resource_id is

--- a/apps/wiki-server/src/__tests__/migration-0186-qua-549-rcv.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0186-qua-549-rcv.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql",
+);
+
+describe("migration 0186 — QUA-549 resource_content_versions FK swap", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("drops both the Drizzle-generated and postgres-default FK names", () => {
+    // Regression for the 2026-04-18 deploy halt: the pilot only dropped the
+    // Drizzle name (_fk), so prod's postgres-default name (_fkey) survived
+    // and the Step 2 UPDATE tripped it because it still pointed at
+    // resources(id). Every later Phase B migration drops both; assert 0186
+    // does too.
+    expect(sql).toMatch(
+      /DROP CONSTRAINT IF EXISTS\s+resource_content_versions_resource_id_resources_id_fk\b/,
+    );
+    expect(sql).toMatch(
+      /DROP CONSTRAINT IF EXISTS\s+resource_content_versions_resource_id_fkey\b/,
+    );
+  });
+
+  it("rewrites resource_id from hex16 to sid_ via JOIN on resources.id", () => {
+    expect(sql).toMatch(
+      /UPDATE resource_content_versions[\s\S]+SET resource_id = r\.stable_id[\s\S]+FROM resources r[\s\S]+WHERE rcv\.resource_id = r\.id/,
+    );
+  });
+
+  it("aborts on unresolved orphans via a DO block RAISE EXCEPTION", () => {
+    expect(sql).toMatch(/RAISE EXCEPTION 'QUA-549 migration aborted:/);
+  });
+
+  it("re-adds the FK targeting resources.stable_id with ON DELETE SET NULL", () => {
+    expect(sql).toMatch(
+      /ADD CONSTRAINT resource_content_versions_resource_id_resources_stable_id_fk[\s\S]+FOREIGN KEY \(resource_id\) REFERENCES resources\(stable_id\)[\s\S]+ON DELETE SET NULL/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Migration `0186_qua_549_rcv_resource_id_to_stable_id.sql` (QUA-549 pilot) only drops the Drizzle-generated FK name (`_resource_id_resources_id_fk`), but prod also carries the postgres-default name (`_resource_id_fkey`) from earlier migration history. The surviving `_fkey` still references `resources(id)`, so Step 2's `UPDATE ... SET resource_id = r.stable_id` trips FK 23503 on every row it touches:

```
PostgresError 23503: insert or update on table "resource_content_versions"
  violates foreign key constraint "resource_content_versions_resource_id_fkey"
Key (resource_id)=(sid_y5nyqbYtBN) is not present in table "resources"
```

Every subsequent Phase B migration (0188, 0189, 0191, 0192, 0193, 0194, 0197) already drops **both** names — the pilot just didn't. This PR backports the pattern to 0186.

## Prod state at time of filing

- Release PR #4488 deploy halted at ArgoCD PreSync; migration job `longterm-wiki-server-wiki-server-migration-1` hit backoff limit after 4 attempts (pod logs surfaced the exact FK above).
- Smoke test passed this time — the `@longterm-wiki/url-utils` Dockerfile fix from #4483 held.
- **Prod still healthy on the old image** (uptime ~48h, no user impact).
- Applying this patch unblocks the retry on the next release deploy.

## Why CI didn't catch it

The Test-DB-migrations CI check uses a clean Drizzle-managed schema with only the `_fk` (Drizzle) constraint name — the `_fkey` (postgres-default) is a prod-only artifact from earlier migration history. Drift between CI's minimal DB and prod's real constraint set.

## What this PR does

- Adds one extra `DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_fkey` to Step 1 of the migration (4-line SQL addition including the explanatory comment).
- Adds `apps/wiki-server/src/__tests__/migration-0186-qua-549-rcv.test.ts` — a structural test asserting the file drops both names, rewrites via the expected JOIN, raises on orphans, and re-adds the new FK with `ON DELETE SET NULL`. Mirrors the pattern used by `migration-0183-check-constraints.test.ts`.

## Follow-ups (not in this PR)

- Consider a gate validator that enforces "migrations dropping a FK on a renamed target must drop both the `_fk` and `_fkey` names". Same systemic-fix shape as QUA-598 (workspace deps). Will file as Linear follow-up.
- Orphan `sid_y5nyqbYtBN` in `resource_content_versions` — how did a `sid_` value land there before the migration ran? Non-blocking for the deploy (the orphan check in Step 3 will catch it post-UPDATE), but worth a separate ticket. Will file.

## Test plan

- [x] `npx vitest run src/__tests__/migration-0186-qua-549-rcv.test.ts` — 4/4 pass
- [x] `pnpm crux w validate gate` — 43/43 blocking checks pass (2 advisory warnings pre-existing, not related)
- [ ] Post-merge: new release PR deploy reaches ArgoCD PreSync green and migration 0186 appears in `__drizzle_migrations`
- [ ] Post-merge: confirm `resource_content_versions.resource_id` is now `sid_`-prefixed and the new FK points at `resources(stable_id)`

## Deploy Checklist

<!-- deploy-tasks:v1 -->
- [ ] ``migration`` Verify migration 0186 applied on server start (on the retry deploy) — ``psql "\$DATABASE_URL" -c "SELECT hash FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 5;"``
- [ ] ``manual`` Spot-check resource_content_versions.resource_id values are now sid_, not hex16 — ``psql "\$DATABASE_URL" -c "SELECT resource_id FROM resource_content_versions WHERE resource_id IS NOT NULL LIMIT 5;"``, expect all values start with ``sid_``
- [ ] ``manual`` Confirm the new FK is in place — ``psql "\$DATABASE_URL" -c "\d resource_content_versions" | grep stable_id_fk``
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for database migration validation, ensuring proper constraint handling and data consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->