### PR TITLE
release: 2026-04-19 #2

### DIFF
--- a/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
+++ b/apps/wiki-server/drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql
@@ -26,8 +26,16 @@
 --     ON DELETE SET NULL;
 
 -- Step 1: drop the existing FK on resources.id.
+-- Both the Drizzle-generated name (*_fk) and the postgres-default name (*_fkey)
+-- can exist in prod due to historical migration paths; drop both. This pattern
+-- was missed in the pilot and caused a deploy halt when prod had *_fkey
+-- pointing at resources(id) — the Step 2 UPDATE tripped that surviving FK.
+-- Every subsequent Phase B migration (0188, 0189, 0191, 0192, 0193, 0194, 0197)
+-- drops both names; backporting the pattern here.
 ALTER TABLE resource_content_versions
   DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_resources_id_fk;
+ALTER TABLE resource_content_versions
+  DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_fkey;
 
 -- Step 2: rewrite resource_id values from hex16 → sid_<10> via JOIN.
 -- Rows where resource_id IS NULL are untouched. Rows whose resource_id is

--- a/apps/wiki-server/src/__tests__/migration-0186-qua-549-rcv.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0186-qua-549-rcv.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0186_qua_549_rcv_resource_id_to_stable_id.sql",
+);
+
+describe("migration 0186 — QUA-549 resource_content_versions FK swap", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("drops both the Drizzle-generated and postgres-default FK names", () => {
+    // Regression for the 2026-04-18 deploy halt: the pilot only dropped the
+    // Drizzle name (_fk), so prod's postgres-default name (_fkey) survived
+    // and the Step 2 UPDATE tripped it because it still pointed at
+    // resources(id). Every later Phase B migration drops both; assert 0186
+    // does too.
+    expect(sql).toMatch(
+      /DROP CONSTRAINT IF EXISTS\s+resource_content_versions_resource_id_resources_id_fk\b/,
+    );
+    expect(sql).toMatch(
+      /DROP CONSTRAINT IF EXISTS\s+resource_content_versions_resource_id_fkey\b/,
+    );
+  });
+
+  it("rewrites resource_id from hex16 to sid_ via JOIN on resources.id", () => {
+    expect(sql).toMatch(
+      /UPDATE resource_content_versions[\s\S]+SET resource_id = r\.stable_id[\s\S]+FROM resources r[\s\S]+WHERE rcv\.resource_id = r\.id/,
+    );
+  });
+
+  it("aborts on unresolved orphans via a DO block RAISE EXCEPTION", () => {
+    expect(sql).toMatch(/RAISE EXCEPTION 'QUA-549 migration aborted:/);
+  });
+
+  it("re-adds the FK targeting resources.stable_id with ON DELETE SET NULL", () => {
+    expect(sql).toMatch(
+      /ADD CONSTRAINT resource_content_versions_resource_id_resources_stable_id_fk[\s\S]+FOREIGN KEY \(resource_id\) REFERENCES resources\(stable_id\)[\s\S]+ON DELETE SET NULL/,
+    );
+  });
+});


### PR DESCRIPTION
## Release 2026-04-19

**2 commits** since last release.

> [!WARNING]
> Production has **40 commits** not on main (hotfixes or merge commits).
> Review carefully to ensure these won't be overwritten.

### Other
- hotfix: drop both _fk and _fkey constraint names in migration 0186

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0186 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] ``manual`` Spot-check resource_content_versions.resource_id values are now sid_, not hex16 — ``psql "\$DATABASE_URL" -c "SELECT resource_id FROM resource_content_versions WHERE resource_id IS NOT NULL LIMIT 5;"``, expect all values start with ``sid_`` _(from PR #4489)_
- [ ] ``manual`` Confirm the new FK is in place — ``psql "\$DATABASE_URL" -c "\d resource_content_versions" | grep stable_id_fk`` _(from PR #4489)_
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4483)_
- [ ] `migration` Verify migration 0198 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4480)_
- [ ] `manual` Post-deploy: confirm `/internal/data-quality` still shows `facts.canonical_f` = 100% (no VALIDATE-time rejections) — visit https://www.longtermwiki.com/internal/data-quality and check the ID Format Audit panel _(from PR #4480)_
- [ ] `manual` Post-deploy: verify a fresh factbase sync still works — `WIKI_SERVER_ENV=prod pnpm crux fb sourcing --entity=anthropic --limit=1` (sanity check that the CHECK doesn't reject current writes) _(from PR #4480)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4476)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4476)_
- [ ] `migration` Verify migration 0192 registered in drizzle journal (pure no-op — `SELECT 1`; no DDL applied; no separate manual script exists). Expect the row to appear after server restart — `psql "$DATABASE_URL" -c "SELECT hash, created_at FROM drizzle.__drizzle_migrations WHERE hash LIKE '%0192%' OR created_at > NOW() - INTERVAL '1 hour' ORDER BY created_at DESC LIMIT 5;"` _(from PR #4475)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and `/health` is `healthy` — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4475)_
- [ ] `manual` Post-deploy spot-check: submit a test claim via `POST /api/claims/propose` with a legacy hex16 `resourceId`; confirm the stored `proposed_claims.resource_id` is canonical `sid_<10>`, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM proposed_claims WHERE created_at > NOW() - INTERVAL '1 hour' AND resource_id IS NOT NULL ORDER BY id DESC LIMIT 5;"`, expect `sid_`-prefixed rows. _(from PR #4475)_
- [ ] `manual` Confirm `GET /api/resources/:id/content` resolves by both hex16 and sid_ on prod — `curl -sf "$WIKI_SERVER_URL/api/resources/<any-hex16>/content" | jq .id` then `curl -sf "$WIKI_SERVER_URL/api/resources/<its-stable_id>/content" | jq .id` — both should return the same row. _(from PR #4475)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4473)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4473)_
- [ ] `manual` Spot-check citation_quotes.resource_id is now sid_ post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM citation_quotes WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_` _(from PR #4473)_
- [ ] `manual` Confirm the migration emitted 0 `skipped_null_stableid` and 0 `orphan_count` NOTICEs in deploy logs — `kubectl logs -l app=wiki-server --tail=200 | grep -i QUA-574` (expect no output, or 0 in both counters) _(from PR #4473)_
- [ ] `migration` Verify migration 0192 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4471)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4471)_
- [ ] `manual-migration` Run manual migration script: psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/qua-584-backfill-active-agents-stale.sql _(from PR #4470)_
- [ ] `manual` Verify the active-agents sweep fires on schedule — check groundskeeper logs for a `session-sweep`-paired `active-agents-sweep` entry within the hour after deploy; `kubectl logs -n wiki deployment/groundskeeper | grep active-agents-sweep` _(from PR #4470)_
- [ ] `manual` Verify prod `GET /api/active-agents?status=active` count drops from ~80 to the truly-live count (expected: <15) within 30 min after the backfill script runs _(from PR #4470)_
- [ ] `migration` Verify migration 0188 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4468)_
- [ ] `manual` Confirm backfill flipped historical rows — `psql "$DATABASE_URL" -c "SELECT status, count(*) FROM agent_sessions GROUP BY status;"`, expect non-zero `stale` count where pre-deploy it was 0 _(from PR #4468)_
- [ ] `manual` Verify `/internal/agent-activity` shows the new "stale" count alongside completed — load https://www.longtermwiki.com/internal/agent-activity and check the summary line _(from PR #4468)_
- [ ] `manual` Verify next graceful-exit session produces status='completed' with non-null title+summary — `psql "$DATABASE_URL" -c "SELECT status, title IS NOT NULL AS has_title, summary IS NOT NULL AS has_summary, started_at FROM agent_sessions WHERE status='completed' ORDER BY started_at DESC LIMIT 5;"`, expect `has_title=t has_summary=t` on post-deploy rows _(from PR #4468)_
- [ ] `ci` Modified workflow "ci pr health" — verify it runs successfully after merge — `gh run list --workflow="ci-pr-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `ci` Modified workflow "frontend data health" — verify it runs successfully after merge — `gh run list --workflow="frontend-data-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `ci` Modified workflow "server api health" — verify it runs successfully after merge — `gh run list --workflow="server-api-health.yml" --limit=1 --json status,conclusion` _(from PR #4465)_
- [ ] `manual` Trigger each wellness workflow directly rather than waiting for the next scheduled run — `gh workflow run ci-pr-health.yml && gh workflow run frontend-data-health.yml && gh workflow run server-api-health.yml` _(from PR #4465)_
- [ ] `manual` Verify wellness issue #4463 auto-closes after the three manually-triggered runs succeed — `gh issue view 4463 -R quantified-uncertainty/longterm-wiki` _(from PR #4465)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4461)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4461)_
- [ ] `manual` Confirm new FK is in place on prod — `psql "$DATABASE_URL" -c "\\d source_check_evidence"`, expect `source_check_evidence_resource_id_resources_stable_id_fk` line referencing `resources(stable_id) ON DELETE SET NULL` _(from PR #4461)_
- [ ] `manual` Spot-check that post-migration `resource_id` values are sid_-prefixed, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM source_check_evidence WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all start with `sid_` _(from PR #4461)_
- [ ] `manual` Visit `/organizations/anthropic` in prod and confirm verdict dots still render (verdict UI reads source_check_evidence) _(from PR #4461)_
- [ ] `migration` Verify migration 0188 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4460)_
- [ ] `migration` Verify migration 0189 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4460)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4460)_
- [ ] `manual` Confirm entity_resources FK points at resources.stable_id — `psql "$DATABASE_URL" -c "\d entity_resources" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE CASCADE` _(from PR #4460)_
- [ ] `manual` Spot-check resource_id values are sid_'s post-migration — `psql "$DATABASE_URL" -c "SELECT resource_id FROM entity_resources LIMIT 3;"`, expect all start with `sid_` _(from PR #4460)_
- [ ] `manual` Confirm the things_search MV was rebuilt with resolved titles (not sid_ leaks) — `psql "$DATABASE_URL" -c "SELECT COUNT(*) FILTER (WHERE title LIKE 'sid_%') AS sid_titles, COUNT(*) AS total FROM things_search WHERE thing_type='entity-resource';"`, expect `sid_titles=0 total=4182` _(from PR #4460)_
- [ ] `manual` Verify hourly groundskeeper things-search-refresh is still succeeding post-deploy — check `/internal/groundskeeper-runs` for a green `things-search-refresh` entry within ~90 minutes _(from PR #4460)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4459)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4459)_
- [ ] `migration` Verify migration 0187 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4456)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4456)_
- [ ] `route` New API route "resource-dedup" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/resource-dedup" -o /dev/null -w "%{http_code}"` _(from PR #4456)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4453)_
- [ ] `manual` Confirm the new FK is in place on prod — `psql "$DATABASE_URL" -c "\d resource_content_versions" | grep stable_id_fk`, expect one line referencing `resources(stable_id) ON DELETE SET NULL` _(from PR #4453)_
- [ ] `manual` Spot-check that `resource_id` values post-migration are sid_'s, not hex16 — `psql "$DATABASE_URL" -c "SELECT resource_id FROM resource_content_versions WHERE resource_id IS NOT NULL LIMIT 3;"`, expect all values start with `sid_` _(from PR #4453)_
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"` _(from PR #4436)_
<!-- /deploy-tasks -->

---
[Full diff](https://github.com/quantified-uncertainty/longterm-wiki/compare/production...main)