### PR TITLE
fix(health): exclude auto-update.yml from staleness alerts (QUA-607)

### DIFF
--- a/.claude/rules/auto-update-system.md
+++ b/.claude/rules/auto-update-system.md
@@ -4,5 +4,5 @@ News-driven automatic wiki updates. Full CLI reference: `pnpm crux w auto-update
 
 - Implementation: `crux/auto-update/`
 - Source config: `data/auto-update/sources.yaml`
-- Scheduled runner: `.github/workflows/auto-update.yml` (daily 06:00 UTC, `workflow_dispatch` supported)
+- Runner: `.github/workflows/auto-update.yml` — **scheduled cron is disabled** (PR #2592, 2026-03-17). The workflow is invoked only via `workflow_dispatch` (manually from the Actions tab) or by running `pnpm crux auto-update run` locally. The wellness check excludes this workflow from staleness alerts. See QUA-31 for the open product question of whether to re-enable scheduled runs.
 - Dashboards: `/internal/auto-update-runs/` and `/internal/auto-update-news/`

--- a/.claude/rules/auto-update-system.md
+++ b/.claude/rules/auto-update-system.md
@@ -4,5 +4,5 @@ News-driven automatic wiki updates. Full CLI reference: `pnpm crux w auto-update
 
 - Implementation: `crux/auto-update/`
 - Source config: `data/auto-update/sources.yaml`
-- Runner: `.github/workflows/auto-update.yml` — **scheduled cron is disabled** (PR #2592, 2026-03-17). The workflow is invoked only via `workflow_dispatch` (manually from the Actions tab) or by running `pnpm crux auto-update run` locally. The wellness check excludes this workflow from staleness alerts. See QUA-31 for the open product question of whether to re-enable scheduled runs.
+- Runner: `.github/workflows/auto-update.yml` — **scheduled cron is disabled** (PR #2592, 2026-03-17). The workflow is invoked only via `workflow_dispatch` (manually from the Actions tab) or by running `pnpm crux auto-update run` locally. Wellness checks exclude `auto-update` from staleness alerts in two places — `crux/health/health-check.ts` (workflow-staleness + freshness checks) and `crux/health/checks/job-queue.ts` (`EXCLUDED_JOB_TYPES`). If you re-enable the schedule, undo both exclusions. See QUA-31 for the open product question of whether to re-enable scheduled runs.
 - Dashboards: `/internal/auto-update-runs/` and `/internal/auto-update-news/`

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -474,9 +474,9 @@ interface WorkflowRunsResponse {
   workflow_runs: WorkflowRun[];
 }
 
-// Workflows that are inherently flaky — depends on LLMs, external URLs,
-// citation checking. For these, we check if ANY of the last 5 runs
-// succeeded rather than requiring the most recent one to succeed.
+// Workflows that are inherently flaky and may transiently fail.
+// For these, we check if ANY of the last 5 runs succeeded rather than
+// requiring the most recent one to succeed.
 // scheduled-maintenance.yml uses Claude Code which can fail transiently.
 const FLAKY_WORKFLOWS = new Set(['scheduled-maintenance.yml']);
 

--- a/crux/health/health-check.ts
+++ b/crux/health/health-check.ts
@@ -201,10 +201,7 @@ const MIN_ENTITIES = 500;
 const MIN_FACTS = 40; // Currently ~54; alert if drops dramatically
 
 // Workflow staleness thresholds (hours)
-// auto-update.yml schedule is disabled — it runs only via manual workflow_dispatch,
-// so the threshold must be generous to avoid false alarms.
 const MAX_AGE: Record<string, number> = {
-  'auto-update.yml': 720, // 30 days — schedule disabled, manual runs only (see #2982)
   'database-backup.yml': 36,
   'scheduled-maintenance.yml': 216, // 9 days
   'server-health-monitor.yml': 192, // weekly dead-man-switch (8 days)
@@ -481,7 +478,7 @@ interface WorkflowRunsResponse {
 // citation checking. For these, we check if ANY of the last 5 runs
 // succeeded rather than requiring the most recent one to succeed.
 // scheduled-maintenance.yml uses Claude Code which can fail transiently.
-const FLAKY_WORKFLOWS = new Set(['auto-update.yml', 'scheduled-maintenance.yml']);
+const FLAKY_WORKFLOWS = new Set(['scheduled-maintenance.yml']);
 
 // Workflows that only run on schedule or workflow_dispatch (not push).
 // For these, we filter out push-triggered runs which can be spurious
@@ -506,8 +503,11 @@ export async function checkActions(): Promise<CheckResult> {
     throw e;
   }
 
+  // auto-update.yml is intentionally excluded — its schedule was disabled in PR #2592
+  // and it now runs only via workflow_dispatch with no SLA. The job-queue check applies
+  // the same exclusion via EXCLUDED_JOB_TYPES (see crux/health/checks/job-queue.ts).
+  // The product question of whether to re-enable auto-update is tracked in QUA-31.
   const workflowFiles = [
-    'auto-update.yml',
     'database-backup.yml',
     'scheduled-maintenance.yml',
     'server-health-monitor.yml',
@@ -726,32 +726,9 @@ export async function checkFreshness(): Promise<CheckResult> {
     failures.push(`Pages list unavailable (${msg})`);
   }
 
-  // Most recent auto-update run — skip cleanly if endpoint returns 404 (route may not exist)
-  const runsResp = await fetchJson(`${SERVER_URL}/api/auto-update-runs?limit=1`, auth);
-  if (runsResp.status === 404) {
-    detail.push(`INFO  Auto-update runs: endpoint not available`);
-  } else if (runsResp.ok) {
-    const r = runsResp.data as Array<{ createdAt?: string; startedAt?: string }>;
-    const run = r[0];
-    const date = run?.createdAt ?? run?.startedAt;
-    if (date) {
-      const ageH = hoursAgo(date);
-      if (ageH > 48) {
-        failures.push(`Last auto-update run ${ageH}h ago (expected < 48h)`);
-        detail.push(`WARN  Last auto-update run: ${ageH}h ago`);
-      } else {
-        detail.push(`PASS  Last auto-update run: ${ageH}h ago`);
-      }
-    } else {
-      detail.push(`INFO  Last auto-update run: no runs found`);
-    }
-  } else {
-    const msg =
-      runsResp.status === 0 && runsResp.errorDetail
-        ? runsResp.errorDetail
-        : `HTTP ${runsResp.status}`;
-    detail.push(`SKIP  Auto-update runs: ${msg}`);
-  }
+  // Auto-update runs freshness check intentionally omitted — auto-update.yml schedule
+  // is disabled (PR #2592) so there is no SLA on /api/auto-update-runs. See QUA-31 for
+  // the open product question of whether to re-enable it.
 
   // Most recent agent session — response: { sessions: [...], total, limit, offset }
   const sessionsResp = await fetchJson(`${SERVER_URL}/api/sessions?limit=1`, auth);


### PR DESCRIPTION
## Summary

Fix QUA-607: the wellness check (`ci-pr-health.yml` → `crux health check --check=actions`) has been alerting on `auto-update.yml` being stale ever since PR #2592 (2026-03-17) intentionally disabled its daily cron. The 720h grace threshold rolled past on day 30, generating recurring false-positive wellness issues.

This PR removes `auto-update.yml` from both wellness staleness watchers in `crux/health/health-check.ts`, mirroring the pre-existing exclusion in `crux/health/checks/job-queue.ts::EXCLUDED_JOB_TYPES`. All three wellness checks (workflow staleness, job-queue, data-freshness) now agree.

## Diagnosis

- `auto-update.yml` cron was disabled by PR #2592 (commit 190f1106a, 2026-03-17). `workflow_dispatch` is preserved.
- No manual `workflow_dispatch` runs have happened in 33 days. Last actual run was 2026-03-17.
- Two wellness checks still expected the workflow to run within 720h, and both started failing this week:
  - `checkActions()` workflow staleness list — produced `FAIL  auto-update.yml: last run 789h ago (max 720h)`
  - `checkFreshness()` `/api/auto-update-runs?limit=1` check — would have produced `Last auto-update run ${ageH}h ago (expected < 48h)`
- `EXCLUDED_JOB_TYPES` in `crux/health/checks/job-queue.ts` already excludes `auto-update` for the same root cause (PR #2592). The other two checks just hadn't been updated to match.

## Changes

- `crux/health/health-check.ts`: removed `auto-update.yml` from `MAX_AGE`, `FLAKY_WORKFLOWS`, and the `workflowFiles` array in `checkActions()`. Removed the `/api/auto-update-runs?limit=1` block from `checkFreshness()`. Cross-referenced the `job-queue.ts::EXCLUDED_JOB_TYPES` exclusion in code comments.
- `.claude/rules/auto-update-system.md`: documented that the schedule is disabled, that wellness checks exclude this workflow in two places, and that the open product question of re-enabling lives in QUA-31.

## Out of scope

- Whether to re-enable scheduled auto-update is a separate product decision (tracked in QUA-31). This PR does not change that one way or the other — the workflow file and `workflow_dispatch` trigger are preserved.
- Content-freshness damage from 33 days of no auto-update runs. The QUA-31 backlog ticket already covers manual content refresh; this PR is the "stop the false alarm" half only.

## Test plan

- [x] Build passes (`pnpm build`).
- [x] Health module tests pass (`crux/health/` — 72/72).
- [x] Gate passes (`pnpm crux w validate gate --fix` — 47 checks, 3 advisory warnings).
- [x] Manual smoke: `WIKI_SERVER_ENV=prod pnpm crux health check --check=actions --report` → all 4 monitored workflows green (`database-backup.yml`, `scheduled-maintenance.yml`, `server-health-monitor.yml`, `ci.yml`); auto-update no longer in the list.
- [x] Manual `gh workflow run auto-update.yml -f dry_run=true -f count=1 -f budget=5` triggered run 24622713090 — confirms the workflow itself is still functional via `workflow_dispatch` (the wellness check exclusion does not break the workflow's ability to run when manually invoked).
- [x] `/agent-review-pr` ran adaptive review; 4 LOW findings; 2 fixed (stale comment, doc cross-reference), 2 dismissed as out of scope.

Fixes QUA-607


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated auto-update workflow documentation to clarify that scheduled execution is disabled; the workflow now runs only via manual trigger.

* **Chores**
  * Removed auto-update workflow from health monitoring checks to align with disabled scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->