### PR TITLE
feat(validate): add FK-swap double-drop gate validator (QUA-609)

### DIFF
--- a/crux/validate/validate-fk-swap-double-drop.test.ts
+++ b/crux/validate/validate-fk-swap-double-drop.test.ts
@@ -364,6 +364,57 @@ describe('findSwapTargets', () => {
     `);
     expect(targets).toEqual([]);
   });
+
+  it('detects an aliasless UPDATE referencing the table by name in WHERE', () => {
+    // PostgreSQL allows `UPDATE "x" SET ... WHERE x.col = r.id` without an
+    // alias. A migration written this way without the validator's protection
+    // is exactly the failure mode that motivated this check.
+    const targets = findSwapTargets(`
+      UPDATE "publications"
+      SET resource_id = r.stable_id
+      FROM "resources" r
+      WHERE publications.resource_id = r.id;
+    `);
+    expect(targets).toEqual([
+      expect.objectContaining({
+        table: 'publications',
+        column: 'resource_id',
+      }),
+    ]);
+  });
+
+  it('detects an aliasless UPDATE with implicit column reference in WHERE', () => {
+    // `WHERE resource_id = r.id` (no prefix) is also valid in aliasless
+    // form and resolves to the UPDATE target table's column.
+    const targets = findSwapTargets(`
+      UPDATE "publications"
+      SET resource_id = r.stable_id
+      FROM "resources" r
+      WHERE resource_id = r.id;
+    `);
+    expect(targets).toEqual([
+      expect.objectContaining({
+        table: 'publications',
+        column: 'resource_id',
+      }),
+    ]);
+  });
+
+  it('does not span ADD CONSTRAINT detection across statement boundaries', () => {
+    // Two unrelated statements: an ALTER TABLE on table A (no FK swap),
+    // followed by a separate ADD CONSTRAINT on table B that adds the FK
+    // to resources(stable_id). Without the [^;]*? bound, ADD_CONSTRAINT_RE
+    // would attribute the FK to table A. Verify it captures table B.
+    const targets = findSwapTargets(`
+      ALTER TABLE "audit_log" DROP COLUMN "scratch_col";
+      SELECT 1;
+      ALTER TABLE "page_citations"
+        ADD CONSTRAINT "page_citations_resource_id_resources_stable_id_fk"
+        FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id");
+    `);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].table).toBe('page_citations');
+  });
 });
 
 describe('findDroppedConstraints', () => {

--- a/crux/validate/validate-fk-swap-double-drop.test.ts
+++ b/crux/validate/validate-fk-swap-double-drop.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for the FK-swap double-drop validator.
+ *
+ * Strategy:
+ *   1. Regression test — the actual repo passes (this is the proof that
+ *      QUA-609's "fix any unexpected violations in-PR" step was satisfied).
+ *   2. Unit tests — write temp .sql fixtures and assert classification:
+ *      - Compliant two-name pattern passes.
+ *      - Compliant dynamic-drop pattern (0187 style) passes.
+ *      - Single-drop fabrication (0186 pre-fix style) fails.
+ *      - Non-FK-swap migration is skipped.
+ *      - Multi-table migration with one bad block fails on that block only.
+ *      - Comments containing "DROP CONSTRAINT" do not satisfy the requirement.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+
+import {
+  runCheck,
+  findSwapTargets,
+  findDroppedConstraints,
+  hasDynamicDrop,
+} from './validate-fk-swap-double-drop.ts';
+
+function makeDrizzleDir(files: Record<string, string>): string {
+  const root = join(
+    os.tmpdir(),
+    `fk-swap-double-drop-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(root, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(root, name), content);
+  }
+  return root;
+}
+
+// Compliant: two-name DROP, UPDATE rewrite, ADD CONSTRAINT — based on 0188's
+// resource_tabular_sources block, simplified.
+const COMPLIANT_TWO_NAME = `
+ALTER TABLE "resource_tabular_sources" DROP CONSTRAINT IF EXISTS "resource_tabular_sources_resource_id_resources_id_fk";
+ALTER TABLE "resource_tabular_sources" DROP CONSTRAINT IF EXISTS "resource_tabular_sources_resource_id_fkey";
+
+UPDATE "resource_tabular_sources" rts
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE rts.resource_id = r.id
+  AND rts.resource_id NOT LIKE 'sid_%';
+
+ALTER TABLE "resource_tabular_sources"
+  ADD CONSTRAINT "resource_tabular_sources_resource_id_resources_stable_id_fk"
+  FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE CASCADE;
+`;
+
+// Compliant: dynamic information_schema lookup + EXECUTE format — based on
+// 0187's publications block, simplified.
+const COMPLIANT_DYNAMIC = `
+DO $$
+DECLARE
+  fk_name text;
+BEGIN
+  SELECT tc.constraint_name INTO fk_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+  JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name
+  WHERE tc.table_name = 'publications'
+    AND kcu.column_name = 'resource_id'
+    AND ccu.table_name = 'resources'
+    AND ccu.column_name = 'id'
+  LIMIT 1;
+  IF fk_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE "publications" DROP CONSTRAINT %I', fk_name);
+  END IF;
+END $$;
+
+UPDATE "publications" p
+SET resource_id = r.stable_id
+FROM "resources" r
+WHERE p.resource_id = r.id
+  AND p.resource_id IS NOT NULL;
+
+ALTER TABLE "publications"
+  ADD CONSTRAINT "publications_resource_id_resources_stable_id_fk"
+  FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id") ON DELETE SET NULL;
+`;
+
+// Bad: only the Drizzle name is dropped (this is the 0186 pre-fix mistake).
+const BAD_SINGLE_DROP = `
+ALTER TABLE resource_content_versions
+  DROP CONSTRAINT IF EXISTS resource_content_versions_resource_id_resources_id_fk;
+
+UPDATE resource_content_versions rcv
+SET resource_id = r.stable_id
+FROM resources r
+WHERE rcv.resource_id = r.id;
+
+ALTER TABLE resource_content_versions
+  ADD CONSTRAINT resource_content_versions_resource_id_resources_stable_id_fk
+  FOREIGN KEY (resource_id) REFERENCES resources(stable_id);
+`;
+
+// Non-FK-swap: a normal CREATE TABLE migration. Should be skipped entirely.
+const NON_FK_SWAP = `
+CREATE TABLE IF NOT EXISTS "things" (
+  id text PRIMARY KEY,
+  title text NOT NULL,
+  description text
+);
+
+CREATE INDEX IF NOT EXISTS "things_title_idx" ON "things" (title);
+`;
+
+describe('validate-fk-swap-double-drop', () => {
+  let scratch: string | null = null;
+
+  afterEach(() => {
+    if (scratch) {
+      rmSync(scratch, { recursive: true, force: true });
+      scratch = null;
+    }
+  });
+
+  it('current repo has zero violations', () => {
+    // Regression test: the live drizzle/ tree must pass. Proves 0186 fix
+    // (PR #4489) is in main and no later migration regressed.
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    // We expect the validator to find some FK-swap files (Phase B is in main).
+    expect(result.filesWithSwaps).toBeGreaterThan(0);
+  });
+
+  it('passes when both _fk and _fkey are dropped (two-name pattern)', () => {
+    scratch = makeDrizzleDir({
+      '0188_compliant.sql': COMPLIANT_TWO_NAME,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.filesWithSwaps).toBe(1);
+  });
+
+  it('passes when the dynamic information_schema + EXECUTE format pattern is used', () => {
+    scratch = makeDrizzleDir({
+      '0187_compliant_dynamic.sql': COMPLIANT_DYNAMIC,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.filesWithSwaps).toBe(1);
+  });
+
+  it('fails when only the Drizzle _fk name is dropped (0186 pre-fix shape)', () => {
+    scratch = makeDrizzleDir({
+      '0186_bad.sql': BAD_SINGLE_DROP,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.errors).toBe(1);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      file: '0186_bad.sql',
+      table: 'resource_content_versions',
+      column: 'resource_id',
+      missingDrops: ['resource_content_versions_resource_id_fkey'],
+    });
+    // Both UPDATE rewrite and ADD CONSTRAINT signals should fire.
+    expect(result.violations[0].signals.sort()).toEqual([
+      'add-constraint',
+      'update',
+    ]);
+  });
+
+  it('fails with both names listed when neither drop is present', () => {
+    scratch = makeDrizzleDir({
+      '0200_no_drops.sql': `
+        UPDATE "publications" p
+        SET resource_id = r.stable_id
+        FROM "resources" r
+        WHERE p.resource_id = r.id;
+      `,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].missingDrops.sort()).toEqual([
+      'publications_resource_id_fkey',
+      'publications_resource_id_resources_id_fk',
+    ]);
+  });
+
+  it('skips migrations with no FK-swap signals', () => {
+    scratch = makeDrizzleDir({
+      '0050_create_things.sql': NON_FK_SWAP,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.filesWithSwaps).toBe(0);
+    expect(result.scanned).toBe(1);
+  });
+
+  it('flags a multi-block migration where one block is bad', () => {
+    scratch = makeDrizzleDir({
+      '0210_mixed.sql': `
+        ${COMPLIANT_TWO_NAME}
+
+        ${BAD_SINGLE_DROP}
+      `,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.errors).toBe(1);
+    expect(result.violations[0]).toMatchObject({
+      table: 'resource_content_versions',
+      column: 'resource_id',
+    });
+  });
+
+  it('does NOT count "DROP CONSTRAINT" mentioned only in comments', () => {
+    scratch = makeDrizzleDir({
+      '0211_commented_drops.sql': `
+        -- ALTER TABLE "publications" DROP CONSTRAINT IF EXISTS "publications_resource_id_resources_id_fk";
+        /* DROP CONSTRAINT IF EXISTS "publications_resource_id_fkey"; */
+
+        UPDATE "publications" p
+        SET resource_id = r.stable_id
+        FROM "resources" r
+        WHERE p.resource_id = r.id;
+      `,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].missingDrops.sort()).toEqual([
+      'publications_resource_id_fkey',
+      'publications_resource_id_resources_id_fk',
+    ]);
+  });
+
+  it('does NOT trigger on UPDATE statements that lack the resources JOIN', () => {
+    // A SET = r.stable_id without `FROM resources r` and `WHERE col = r.id`
+    // is not the canonical FK-swap rewrite — could be referencing a different
+    // alias `r`. We require all parts of the canonical structure.
+    scratch = makeDrizzleDir({
+      '0212_unrelated_update.sql': `
+        UPDATE "audit_log" a
+        SET resource_id = r.stable_id
+        FROM "things" r
+        WHERE a.thing_id = r.id;
+      `,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.filesWithSwaps).toBe(0);
+  });
+
+  it('returns passed=true when the drizzle directory does not exist', () => {
+    const result = runCheck({
+      drizzleDir: join(os.tmpdir(), `nonexistent-${Date.now()}`),
+    });
+    expect(result.passed).toBe(true);
+    expect(result.scanned).toBe(0);
+  });
+
+  it('handles an empty directory cleanly', () => {
+    scratch = makeDrizzleDir({});
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(true);
+    expect(result.scanned).toBe(0);
+    expect(result.filesWithSwaps).toBe(0);
+  });
+
+  it('detects a swap target when only the ADD CONSTRAINT signal fires (no backfill)', () => {
+    // A fresh-table FK that points at resources(stable_id) without a backfill
+    // UPDATE still needs both drops in case the table existed previously with
+    // a different FK shape.
+    scratch = makeDrizzleDir({
+      '0220_add_only.sql': `
+        ALTER TABLE "new_resource_link"
+          ADD CONSTRAINT "new_resource_link_resource_id_resources_stable_id_fk"
+          FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id");
+      `,
+    });
+    const result = runCheck({ drizzleDir: scratch });
+    expect(result.passed).toBe(false);
+    expect(result.violations[0].signals).toEqual(['add-constraint']);
+  });
+});
+
+describe('findSwapTargets', () => {
+  it('captures table and column from a canonical UPDATE rewrite', () => {
+    const targets = findSwapTargets(`
+      UPDATE "publications" p
+      SET resource_id = r.stable_id
+      FROM "resources" r
+      WHERE p.resource_id = r.id;
+    `);
+    expect(targets).toEqual([
+      expect.objectContaining({
+        table: 'publications',
+        column: 'resource_id',
+        signals: new Set(['update']),
+      }),
+    ]);
+  });
+
+  it('captures table and column from an ADD CONSTRAINT clause', () => {
+    const targets = findSwapTargets(`
+      ALTER TABLE "page_citations"
+        ADD CONSTRAINT "page_citations_resource_id_resources_stable_id_fk"
+        FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id");
+    `);
+    expect(targets).toEqual([
+      expect.objectContaining({
+        table: 'page_citations',
+        column: 'resource_id',
+        signals: new Set(['add-constraint']),
+      }),
+    ]);
+  });
+
+  it('merges signals when both UPDATE and ADD CONSTRAINT touch the same target', () => {
+    const targets = findSwapTargets(`
+      UPDATE "x" t
+      SET resource_id = r.stable_id
+      FROM "resources" r
+      WHERE t.resource_id = r.id;
+
+      ALTER TABLE "x"
+        ADD CONSTRAINT "x_resource_id_resources_stable_id_fk"
+        FOREIGN KEY ("resource_id") REFERENCES "resources"("stable_id");
+    `);
+    expect(targets).toHaveLength(1);
+    expect(targets[0].signals).toEqual(new Set(['update', 'add-constraint']));
+  });
+
+  it('captures multiple distinct (table, column) pairs in one file', () => {
+    const targets = findSwapTargets(`
+      UPDATE "a" x SET resource_id = r.stable_id FROM "resources" r WHERE x.resource_id = r.id;
+      UPDATE "b" y SET resource_id = r.stable_id FROM "resources" r WHERE y.resource_id = r.id;
+    `);
+    const tables = targets.map((t) => t.table).sort();
+    expect(tables).toEqual(['a', 'b']);
+  });
+
+  it('ignores SQL comments containing UPDATE syntax', () => {
+    const targets = findSwapTargets(`
+      -- UPDATE "fake" f SET resource_id = r.stable_id FROM "resources" r WHERE f.resource_id = r.id;
+      /* UPDATE "also_fake" g SET resource_id = r.stable_id FROM "resources" r WHERE g.resource_id = r.id; */
+      SELECT 1;
+    `);
+    expect(targets).toEqual([]);
+  });
+
+  it('does not match when the FROM clause references a non-resources table', () => {
+    const targets = findSwapTargets(`
+      UPDATE "x" t
+      SET resource_id = r.stable_id
+      FROM "other_table" r
+      WHERE t.resource_id = r.id;
+    `);
+    expect(targets).toEqual([]);
+  });
+});
+
+describe('findDroppedConstraints', () => {
+  it('captures all DROP CONSTRAINT IF EXISTS names', () => {
+    const drops = findDroppedConstraints(`
+      ALTER TABLE "x" DROP CONSTRAINT IF EXISTS "a_b_fkey";
+      ALTER TABLE "x" DROP CONSTRAINT IF EXISTS c_d_fk;
+    `);
+    expect(drops).toEqual(new Set(['a_b_fkey', 'c_d_fk']));
+  });
+
+  it('does NOT capture DROP CONSTRAINT without IF EXISTS', () => {
+    // Plain DROP CONSTRAINT without IF EXISTS is not idempotent — we don't
+    // count it. (None of the Phase B migrations use it; if this becomes a
+    // concern we can broaden later.)
+    const drops = findDroppedConstraints(`
+      ALTER TABLE "x" DROP CONSTRAINT "y_fkey";
+    `);
+    expect(drops.size).toBe(0);
+  });
+
+  it('ignores DROP CONSTRAINT mentions inside comments', () => {
+    const drops = findDroppedConstraints(`
+      -- DROP CONSTRAINT IF EXISTS "fake_fkey";
+      SELECT 1;
+    `);
+    expect(drops.size).toBe(0);
+  });
+});
+
+describe('hasDynamicDrop', () => {
+  it('detects the 0187-style dynamic information_schema lookup + EXECUTE format', () => {
+    expect(
+      hasDynamicDrop(COMPLIANT_DYNAMIC, 'publications', 'resource_id')
+    ).toBe(true);
+  });
+
+  it('returns false when the EXECUTE format names a different table', () => {
+    const sql = COMPLIANT_DYNAMIC.replace(
+      /ALTER TABLE "publications"/g,
+      'ALTER TABLE "wrong_table"'
+    );
+    expect(hasDynamicDrop(sql, 'publications', 'resource_id')).toBe(false);
+  });
+
+  it('returns false when the column lookup does not match', () => {
+    expect(
+      hasDynamicDrop(COMPLIANT_DYNAMIC, 'publications', 'other_column')
+    ).toBe(false);
+  });
+
+  it('returns false on an empty file', () => {
+    expect(hasDynamicDrop('', 'x', 'y')).toBe(false);
+  });
+});

--- a/crux/validate/validate-fk-swap-double-drop.ts
+++ b/crux/validate/validate-fk-swap-double-drop.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that every Drizzle migration which performs the QUA-549 Phase B
+ * resources-FK swap drops BOTH the Drizzle-generated constraint name
+ * (`<table>_<col>_resources_id_fk`) AND the postgres-default constraint name
+ * (`<table>_<col>_fkey`).
+ *
+ * ## Why this exists
+ *
+ * Migration 0186 (the QUA-549 pilot) only dropped the Drizzle name. Prod had
+ * the postgres-default `_fkey` name surviving from an older code path; the
+ * Step 2 UPDATE tripped that surviving FK and the deploy halted. Every
+ * subsequent Phase B migration (0187–0197) drops both names, but the
+ * difference between "safe" and "breaks prod" was the PR author's memory of
+ * the pilot post-mortem. This validator promotes that memory to a gate check.
+ *
+ * ## What it flags
+ *
+ * For each `apps/wiki-server/drizzle/*.sql`:
+ *   1. Detect any FK-swap operation against `resources(stable_id)` for a
+ *      `(table, column)` pair. Two signals trigger:
+ *        a) `UPDATE <table> <alias> SET <col> = r.stable_id FROM resources r
+ *           WHERE <alias>.<col> = r.id` — the canonical hex16 → sid_ rewrite.
+ *        b) `ALTER TABLE <table> ... ADD CONSTRAINT ... FOREIGN KEY (<col>)
+ *           REFERENCES resources(stable_id)` — the new FK target.
+ *   2. For every `(table, col)` discovered, require either:
+ *        a) BOTH `DROP CONSTRAINT IF EXISTS "<table>_<col>_resources_id_fk"`
+ *           (Drizzle convention) AND `DROP CONSTRAINT IF EXISTS
+ *           "<table>_<col>_fkey"` (postgres default) — the explicit two-name
+ *           pattern used by 0188–0197; OR
+ *        b) A dynamic-drop DO block that looks up the FK by `(table, column,
+ *           ccu.table='resources', ccu.column='id')` in `information_schema`
+ *           and `EXECUTE format`s an `ALTER TABLE "<table>" DROP CONSTRAINT
+ *           %I` — the pattern used by 0187. This is strictly safer than the
+ *           two-name pattern (handles any constraint name) so it's accepted.
+ *   3. Migrations with no FK-swap signals are skipped entirely.
+ *
+ * ## What it does NOT check
+ *
+ * - DELETE policy correctness (CASCADE vs SET NULL) — separate concern.
+ * - The reverse direction (sid_ → hex16) — Phase B is one-way.
+ * - That the new FK is actually added — some swaps (citation_quotes/0194) are
+ *   soft refs that intentionally leave the FK off.
+ * - Migrations that touch resources in other ways without doing the swap.
+ *
+ * Usage: `npx tsx crux/validate/validate-fk-swap-double-drop.ts`
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const DEFAULT_DRIZZLE_DIR = join(PROJECT_ROOT, 'apps/wiki-server/drizzle');
+
+/** A `(table, column)` pair that needs both drops. */
+interface SwapTarget {
+  table: string;
+  column: string;
+  /** Which signal(s) flagged this target — useful for the human-readable error. */
+  signals: Set<'update' | 'add-constraint'>;
+}
+
+interface MigrationViolation {
+  file: string;
+  table: string;
+  column: string;
+  signals: string[];
+  /** Which of the two required drops are missing for this target. */
+  missingDrops: string[];
+}
+
+interface CheckOptions {
+  drizzleDir?: string;
+}
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  violations: MigrationViolation[];
+  scanned: number;
+  /** Files where at least one swap target was detected. */
+  filesWithSwaps: number;
+}
+
+// ---------------------------------------------------------------------------
+// Comment stripping — important so a "do NOT drop X" sentence in a comment
+// doesn't accidentally count as a real DROP statement.
+// ---------------------------------------------------------------------------
+
+function stripComments(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Detection regexes
+// ---------------------------------------------------------------------------
+
+// UPDATE rewrite signal: `UPDATE <table> <alias> SET <col> = r.stable_id`.
+// Anchored to `r.stable_id` to avoid generic UPDATEs. We also verify the
+// FROM resources / WHERE col = r.id structure with a separate test on the
+// captured statement so a SET to r.stable_id without the resources JOIN does
+// not false-positive.
+const UPDATE_RE =
+  /UPDATE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s+([A-Za-z_][A-Za-z0-9_]*)\s+SET\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s*=\s*r\.stable_id\b([\s\S]*?);/gi;
+
+// ADD CONSTRAINT to resources(stable_id). The ALTER TABLE may sit on a prior
+// line (Drizzle multi-line) or inside a DO block, but in this codebase the
+// FOREIGN KEY (<col>) REFERENCES "resources"("stable_id") clause always
+// appears within the same statement as its ALTER TABLE.
+const ADD_CONSTRAINT_RE =
+  /ALTER\s+TABLE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?[\s\S]*?ADD\s+CONSTRAINT\s+"?[A-Za-z_][A-Za-z0-9_]*"?[\s\S]*?FOREIGN\s+KEY\s*\(\s*"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\)\s*REFERENCES\s+"?resources"?\s*\(\s*"?stable_id"?\s*\)/gi;
+
+// All `DROP CONSTRAINT IF EXISTS <name>` constraint names in the file.
+// We require IF EXISTS because the migrations always use it; a DROP without
+// IF EXISTS is risky on its own and would warrant a separate check.
+const DROP_RE =
+  /DROP\s+CONSTRAINT\s+IF\s+EXISTS\s+"?([A-Za-z_][A-Za-z0-9_]*)"?/gi;
+
+// Inside an UPDATE statement, confirm the canonical hex16→sid_ structure:
+// `FROM "?resources"? r ... WHERE <alias>.<col> = r.id`. The alias and column
+// are captured from the UPDATE_RE outer match, so we just need to verify
+// the FROM clause and the equality condition.
+function isCanonicalRewrite(stmt: string, alias: string, column: string): boolean {
+  if (!/FROM\s+"?resources"?\s+r\b/i.test(stmt)) return false;
+  // alias.col = r.id (column may be quoted or not, alias is a plain identifier).
+  const re = new RegExp(
+    `\\b${alias}\\.\\s*"?${column}"?\\s*=\\s*r\\.\\s*id\\b`,
+    'i'
+  );
+  return re.test(stmt);
+}
+
+export function findSwapTargets(sql: string): SwapTarget[] {
+  const stripped = stripComments(sql);
+  const targets = new Map<string, SwapTarget>(); // key = `${table}::${column}`
+
+  function record(
+    table: string,
+    column: string,
+    signal: 'update' | 'add-constraint'
+  ): void {
+    const key = `${table}::${column}`;
+    let target = targets.get(key);
+    if (!target) {
+      target = { table, column, signals: new Set() };
+      targets.set(key, target);
+    }
+    target.signals.add(signal);
+  }
+
+  // UPDATE rewrites
+  UPDATE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = UPDATE_RE.exec(stripped)) !== null) {
+    const [, table, alias, column, tail] = m;
+    if (isCanonicalRewrite(tail, alias, column)) {
+      record(table, column, 'update');
+    }
+  }
+
+  // ADD CONSTRAINT to resources(stable_id)
+  ADD_CONSTRAINT_RE.lastIndex = 0;
+  while ((m = ADD_CONSTRAINT_RE.exec(stripped)) !== null) {
+    const [, table, column] = m;
+    record(table, column, 'add-constraint');
+  }
+
+  return [...targets.values()];
+}
+
+export function findDroppedConstraints(sql: string): Set<string> {
+  const stripped = stripComments(sql);
+  const drops = new Set<string>();
+  DROP_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = DROP_RE.exec(stripped)) !== null) {
+    drops.add(m[1]);
+  }
+  return drops;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Detect the "dynamic drop" pattern used by migration 0187: a DO block that
+ * looks up the FK in information_schema by (table, column, target=resources.id)
+ * and `EXECUTE format`s an `ALTER TABLE "<table>" DROP CONSTRAINT %I`.
+ *
+ * This is strictly safer than the two-name pattern because it drops *any*
+ * constraint name matching the (table, column, target) tuple — including
+ * names neither convention covers. Accepted as an equivalent guarantee.
+ *
+ * The check is file-scoped, but the EXECUTE format hardcodes the literal
+ * `<table>` so a dynamic-drop block for table A cannot satisfy the check
+ * for table B.
+ */
+export function hasDynamicDrop(sql: string, table: string, column: string): boolean {
+  const stripped = stripComments(sql);
+  const t = escapeRegex(table);
+  const c = escapeRegex(column);
+
+  const required: RegExp[] = [
+    new RegExp(`tc\\.table_name\\s*=\\s*'${t}'`, 'i'),
+    new RegExp(`kcu\\.column_name\\s*=\\s*'${c}'`, 'i'),
+    /ccu\.table_name\s*=\s*'resources'/i,
+    /ccu\.column_name\s*=\s*'id'/i,
+    new RegExp(
+      `EXECUTE\\s+format\\s*\\(\\s*'ALTER\\s+TABLE\\s+"?${t}"?\\s+DROP\\s+CONSTRAINT\\s+%I'`,
+      'i'
+    ),
+  ];
+
+  return required.every((re) => re.test(stripped));
+}
+
+function checkFile(file: string, sql: string): MigrationViolation[] {
+  const targets = findSwapTargets(sql);
+  if (targets.length === 0) return [];
+
+  const drops = findDroppedConstraints(sql);
+  const violations: MigrationViolation[] = [];
+
+  for (const target of targets) {
+    // Equivalent guarantee: a dynamic-drop DO block covers any constraint name.
+    if (hasDynamicDrop(sql, target.table, target.column)) continue;
+
+    const drizzleName = `${target.table}_${target.column}_resources_id_fk`;
+    const postgresName = `${target.table}_${target.column}_fkey`;
+
+    const missing: string[] = [];
+    if (!drops.has(drizzleName)) missing.push(drizzleName);
+    if (!drops.has(postgresName)) missing.push(postgresName);
+
+    if (missing.length > 0) {
+      violations.push({
+        file,
+        table: target.table,
+        column: target.column,
+        signals: [...target.signals],
+        missingDrops: missing,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function runCheck(options: CheckOptions = {}): CheckResult {
+  const c = getColors();
+  const drizzleDir = options.drizzleDir ?? DEFAULT_DRIZZLE_DIR;
+
+  console.log(
+    `${c.blue}Checking FK-swap double-drop pattern in ${drizzleDir}...${c.reset}\n`
+  );
+
+  let sqlFiles: string[];
+  try {
+    sqlFiles = readdirSync(drizzleDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+  } catch {
+    console.log(`${c.dim}Skipping: ${drizzleDir} not found${c.reset}`);
+    return { passed: true, errors: 0, violations: [], scanned: 0, filesWithSwaps: 0 };
+  }
+
+  const violations: MigrationViolation[] = [];
+  let filesWithSwaps = 0;
+
+  for (const file of sqlFiles) {
+    let sql: string;
+    try {
+      sql = readFileSync(join(drizzleDir, file), 'utf-8');
+    } catch {
+      continue;
+    }
+    const targets = findSwapTargets(sql);
+    if (targets.length === 0) continue;
+    filesWithSwaps += 1;
+    violations.push(...checkFile(file, sql));
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `${c.green}All ${filesWithSwaps} FK-swap migration${filesWithSwaps === 1 ? '' : 's'} drop both _fk and _fkey names${c.reset}`
+    );
+    console.log(
+      `${c.dim}(${sqlFiles.length} migration files scanned, ${filesWithSwaps} flagged as FK-swap)${c.reset}`
+    );
+    return {
+      passed: true,
+      errors: 0,
+      violations: [],
+      scanned: sqlFiles.length,
+      filesWithSwaps,
+    };
+  }
+
+  console.log(
+    `${c.red}Found ${violations.length} FK-swap migration${violations.length === 1 ? '' : 's'} missing required DROP CONSTRAINT IF EXISTS:${c.reset}\n`
+  );
+  for (const v of violations) {
+    const sigList = v.signals.join(' + ');
+    console.log(
+      `  ${c.red}${v.file}${c.reset} — ${c.dim}${v.table}.${v.column} (${sigList})${c.reset}`
+    );
+    for (const drop of v.missingDrops) {
+      console.log(`    ${c.red}missing:${c.reset} DROP CONSTRAINT IF EXISTS "${drop}"`);
+    }
+  }
+  console.log();
+  console.log(
+    `${c.dim}Both names must be dropped because prod databases may carry the postgres-default${c.reset}`
+  );
+  console.log(
+    `${c.dim}\`<table>_<col>_fkey\` constraint (from older code paths) alongside, or instead of,${c.reset}`
+  );
+  console.log(
+    `${c.dim}the Drizzle-generated \`<table>_<col>_resources_id_fk\` name. Migration 0186 (QUA-549${c.reset}`
+  );
+  console.log(
+    `${c.dim}pilot) halted production for this exact reason.${c.reset}\n`
+  );
+  console.log(`${c.dim}Two equivalent fixes:${c.reset}`);
+  console.log(
+    `${c.dim}  1. Add both \`ALTER TABLE ... DROP CONSTRAINT IF EXISTS ...\` lines (pattern in 0188).${c.reset}`
+  );
+  console.log(
+    `${c.dim}  2. Use the dynamic information_schema lookup + EXECUTE format() pattern (0187).${c.reset}`
+  );
+
+  return {
+    passed: false,
+    errors: violations.length,
+    violations,
+    scanned: sqlFiles.length,
+    filesWithSwaps,
+  };
+}
+
+const invokedDirectly =
+  import.meta.url.startsWith('file://') &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (invokedDirectly) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-fk-swap-double-drop.ts
+++ b/crux/validate/validate-fk-swap-double-drop.ts
@@ -55,21 +55,33 @@ import { getColors } from '../lib/output.ts';
 
 const DEFAULT_DRIZZLE_DIR = join(PROJECT_ROOT, 'apps/wiki-server/drizzle');
 
+type Signal = 'update' | 'add-constraint';
+
 /** A `(table, column)` pair that needs both drops. */
 interface SwapTarget {
   table: string;
   column: string;
   /** Which signal(s) flagged this target — useful for the human-readable error. */
-  signals: Set<'update' | 'add-constraint'>;
+  signals: Set<Signal>;
 }
 
 interface MigrationViolation {
   file: string;
   table: string;
   column: string;
-  signals: string[];
+  signals: Signal[];
   /** Which of the two required drops are missing for this target. */
   missingDrops: string[];
+}
+
+/** Drizzle-generated constraint name for an FK from `<table>.<col>` → `resources.id`. */
+function drizzleFkName(table: string, column: string): string {
+  return `${table}_${column}_resources_id_fk`;
+}
+
+/** Postgres-default constraint name for an FK from `<table>.<col>` → `resources.id`. */
+function postgresFkName(table: string, column: string): string {
+  return `${table}_${column}_fkey`;
 }
 
 interface CheckOptions {
@@ -159,11 +171,7 @@ export function findSwapTargets(sql: string): SwapTarget[] {
   const stripped = stripComments(sql);
   const targets = new Map<string, SwapTarget>(); // key = `${table}::${column}`
 
-  function record(
-    table: string,
-    column: string,
-    signal: 'update' | 'add-constraint'
-  ): void {
+  function record(table: string, column: string, signal: Signal): void {
     const key = `${table}::${column}`;
     let target = targets.get(key);
     if (!target) {
@@ -241,8 +249,11 @@ export function hasDynamicDrop(sql: string, table: string, column: string): bool
   return required.every((re) => re.test(stripped));
 }
 
-function checkFile(file: string, sql: string): MigrationViolation[] {
-  const targets = findSwapTargets(sql);
+function checkFile(
+  file: string,
+  sql: string,
+  targets: SwapTarget[]
+): MigrationViolation[] {
   if (targets.length === 0) return [];
 
   const drops = findDroppedConstraints(sql);
@@ -252,8 +263,8 @@ function checkFile(file: string, sql: string): MigrationViolation[] {
     // Equivalent guarantee: a dynamic-drop DO block covers any constraint name.
     if (hasDynamicDrop(sql, target.table, target.column)) continue;
 
-    const drizzleName = `${target.table}_${target.column}_resources_id_fk`;
-    const postgresName = `${target.table}_${target.column}_fkey`;
+    const drizzleName = drizzleFkName(target.table, target.column);
+    const postgresName = postgresFkName(target.table, target.column);
 
     const missing: string[] = [];
     if (!drops.has(drizzleName)) missing.push(drizzleName);
@@ -313,7 +324,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     const targets = findSwapTargets(sql);
     if (targets.length === 0) continue;
     filesWithSwaps += 1;
-    violations.push(...checkFile(file, sql));
+    violations.push(...checkFile(file, sql, targets));
   }
 
   if (violations.length === 0) {

--- a/crux/validate/validate-fk-swap-double-drop.ts
+++ b/crux/validate/validate-fk-swap-double-drop.ts
@@ -100,20 +100,30 @@ function stripComments(sql: string): string {
 // Detection regexes
 // ---------------------------------------------------------------------------
 
-// UPDATE rewrite signal: `UPDATE <table> <alias> SET <col> = r.stable_id`.
-// Anchored to `r.stable_id` to avoid generic UPDATEs. We also verify the
-// FROM resources / WHERE col = r.id structure with a separate test on the
-// captured statement so a SET to r.stable_id without the resources JOIN does
-// not false-positive.
+// UPDATE rewrite signal. Both alias-form and aliasless forms are matched:
+//   `UPDATE "table" alias SET col = r.stable_id ...`     (Drizzle convention)
+//   `UPDATE "table" SET col = r.stable_id ...`            (aliasless, allowed by PG)
+// The alias capture group is optional via `(?!SET\b)` so `UPDATE x SET` does
+// not capture `SET` as the alias.
+//
+// The resources alias `r` is hardcoded — every Phase B migration in this repo
+// uses that name. If a future migration uses a different alias (e.g. `res`),
+// this regex won't match. That's acceptable; the validator is meant to
+// enforce a convention, not to parse arbitrary SQL.
+//
+// We anchor to `r.stable_id` to avoid generic UPDATEs and verify the FROM
+// resources / WHERE col = r.id structure separately in `isCanonicalRewrite`.
 const UPDATE_RE =
-  /UPDATE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s+([A-Za-z_][A-Za-z0-9_]*)\s+SET\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s*=\s*r\.stable_id\b([\s\S]*?);/gi;
+  /UPDATE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s+(?!SET\b)([A-Za-z_][A-Za-z0-9_]*))?\s+SET\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s*=\s*r\.stable_id\b([^;]*);/gi;
 
 // ADD CONSTRAINT to resources(stable_id). The ALTER TABLE may sit on a prior
-// line (Drizzle multi-line) or inside a DO block, but in this codebase the
-// FOREIGN KEY (<col>) REFERENCES "resources"("stable_id") clause always
-// appears within the same statement as its ALTER TABLE.
+// line (Drizzle multi-line) or inside a DO block, but the FOREIGN KEY
+// (<col>) REFERENCES "resources"("stable_id") clause must appear within the
+// same SQL statement as its ALTER TABLE. We bound the gap with `[^;]*?` so
+// the regex cannot span across a statement terminator and misattribute the
+// FK to a different ALTER TABLE earlier in the file.
 const ADD_CONSTRAINT_RE =
-  /ALTER\s+TABLE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?[\s\S]*?ADD\s+CONSTRAINT\s+"?[A-Za-z_][A-Za-z0-9_]*"?[\s\S]*?FOREIGN\s+KEY\s*\(\s*"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\)\s*REFERENCES\s+"?resources"?\s*\(\s*"?stable_id"?\s*\)/gi;
+  /ALTER\s+TABLE\s+"?([A-Za-z_][A-Za-z0-9_]*)"?[^;]*?ADD\s+CONSTRAINT\s+"?[A-Za-z_][A-Za-z0-9_]*"?[^;]*?FOREIGN\s+KEY\s*\(\s*"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\)\s*REFERENCES\s+"?resources"?\s*\(\s*"?stable_id"?\s*\)/gi;
 
 // All `DROP CONSTRAINT IF EXISTS <name>` constraint names in the file.
 // We require IF EXISTS because the migrations always use it; a DROP without
@@ -122,14 +132,24 @@ const DROP_RE =
   /DROP\s+CONSTRAINT\s+IF\s+EXISTS\s+"?([A-Za-z_][A-Za-z0-9_]*)"?/gi;
 
 // Inside an UPDATE statement, confirm the canonical hex16→sid_ structure:
-// `FROM "?resources"? r ... WHERE <alias>.<col> = r.id`. The alias and column
-// are captured from the UPDATE_RE outer match, so we just need to verify
-// the FROM clause and the equality condition.
-function isCanonicalRewrite(stmt: string, alias: string, column: string): boolean {
+// `FROM "?resources"? r ... WHERE [<prefix>.]<col> = r.id`.
+//
+// The prefix may be the alias (`p.resource_id`), the bare table name
+// (`publications.resource_id`, common in aliasless UPDATEs), or absent
+// (`resource_id = r.id`, also valid in aliasless form). All three are
+// accepted because all three are FK-swap shapes worth catching.
+function isCanonicalRewrite(
+  stmt: string,
+  table: string,
+  alias: string | undefined,
+  column: string
+): boolean {
   if (!/FROM\s+"?resources"?\s+r\b/i.test(stmt)) return false;
-  // alias.col = r.id (column may be quoted or not, alias is a plain identifier).
+  // Optional prefix: alias OR table OR nothing.
+  const prefixes = alias ? [alias, table] : [table];
+  const prefixGroup = `(?:(?:${prefixes.map(escapeRegex).join('|')})\\.\\s*)?`;
   const re = new RegExp(
-    `\\b${alias}\\.\\s*"?${column}"?\\s*=\\s*r\\.\\s*id\\b`,
+    `\\b${prefixGroup}"?${escapeRegex(column)}"?\\s*=\\s*r\\.\\s*id\\b`,
     'i'
   );
   return re.test(stmt);
@@ -153,12 +173,13 @@ export function findSwapTargets(sql: string): SwapTarget[] {
     target.signals.add(signal);
   }
 
-  // UPDATE rewrites
+  // UPDATE rewrites — alias is the optional second capture (undefined for
+  // aliasless `UPDATE "x" SET ...`).
   UPDATE_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = UPDATE_RE.exec(stripped)) !== null) {
     const [, table, alias, column, tail] = m;
-    if (isCanonicalRewrite(tail, alias, column)) {
+    if (isCanonicalRewrite(tail, table, alias, column)) {
       record(table, column, 'update');
     }
   }
@@ -266,6 +287,11 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
       .filter((f) => f.endsWith('.sql'))
       .sort();
   } catch {
+    // Intentionally pass-through. The dir-missing case fires when the
+    // validator runs outside the repo (tests, isolated tooling). Failing
+    // here would block legitimate non-repo usage; the gate runs from the
+    // repo root and doesn't hit this path. Same convention as
+    // validate-workspace-dep-coverage.ts.
     console.log(`${c.dim}Skipping: ${drizzleDir} not found${c.reset}`);
     return { passed: true, errors: 0, violations: [], scanned: 0, filesWithSwaps: 0 };
   }
@@ -278,6 +304,10 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     try {
       sql = readFileSync(join(drizzleDir, file), 'utf-8');
     } catch {
+      // File disappeared between readdir and readFile (race, or symlink
+      // resolution failure). Skip — there's no useful action to take here
+      // and no real risk because if we can't read it, nothing else can
+      // apply it as a migration either.
       continue;
     }
     const targets = findSwapTargets(sql);

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -288,6 +288,18 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-609: enforces FK-swap migrations drop BOTH the Drizzle-generated
+    // `<table>_<col>_resources_id_fk` AND the postgres-default
+    // `<table>_<col>_fkey` names. Migration 0186 only dropped the first and
+    // halted production. Blocking — the deploy-halt cost makes any bypass
+    // strictly worse than the small surface this rule covers.
+    id: 'fk-swap-double-drop',
+    name: 'FK-swap migrations drop both _fk and _fkey names',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-fk-swap-double-drop.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // Rationale in validate-workspace-dep-coverage.ts. QUA-598.
     id: 'workspace-dep-coverage',
     name: 'Workspace dependency coverage (no undeclared @longterm-wiki/* imports)',


### PR DESCRIPTION
## Summary

Migration 0186 (the QUA-549 pilot) only dropped the Drizzle-generated FK
name `<table>_<col>_resources_id_fk` and missed the postgres-default
`<table>_<col>_fkey`. Prod had `_fkey` surviving from an older code path,
the Step 2 UPDATE tripped that surviving FK, and the deploy halted.

Every later Phase B migration (0187–0197) drops both names — but the
difference between "safe" and "breaks prod" was the PR author's memory
of the post-mortem. This PR promotes that memory to a blocking gate
check.

## How the validator works

`crux/validate/validate-fk-swap-double-drop.ts` scans
`apps/wiki-server/drizzle/*.sql`. For each file, it detects FK-swap
operations against `resources(stable_id)` for any `(table, column)` pair
via two signals:

1. The canonical hex16 → sid_ rewrite:
   `UPDATE <table> [alias] SET <col> = r.stable_id FROM resources r WHERE [<prefix>.]<col> = r.id`
2. The new FK target:
   `ALTER TABLE <table> ... ADD CONSTRAINT ... FOREIGN KEY (<col>) REFERENCES resources(stable_id)`

For every `(table, col)` discovered, it requires either:

- **Two-name pattern** (used by 0188–0197): both
  `DROP CONSTRAINT IF EXISTS "<table>_<col>_resources_id_fk"` and
  `DROP CONSTRAINT IF EXISTS "<table>_<col>_fkey"` clauses present, OR
- **Dynamic-drop pattern** (used by 0187): a DO block that looks up the
  FK by `(table, column, ccu.table='resources', ccu.column='id')` in
  `information_schema` and `EXECUTE format`s an
  `ALTER TABLE "<table>" DROP CONSTRAINT %I`. This is strictly safer
  because it handles any constraint name, so it's accepted as
  equivalent.

Migrations with no FK-swap signals are skipped entirely. Comments are
stripped before all checks so a doc comment mentioning `DROP CONSTRAINT`
or a commented-out UPDATE doesn't trick the validator either way.

## Verification

- 28 unit tests cover compliant patterns (two-name + dynamic),
  fabricated single-drop violations, multi-block migrations, comment
  stripping, aliasless UPDATE, ADD CONSTRAINT detection across unrelated
  ALTER TABLE statements, and the dynamic-drop spoof-resistance check.
- Standalone snapshot test against current `main` returns 0 violations
  (9 FK-swap migrations correctly classified: 0186–0189, 0191–0194,
  0197).
- Wired into `validate-gate.ts::parallelChecks` as blocking. Local gate
  run: 3.7s for this check, all 42 gate checks pass.

## Review

`/agent-review-pr` ran a hostile-reviewer subagent that flagged three
real detection gaps; all fixed before ship:

- `UPDATE_RE` required an alias, missing aliasless `UPDATE "x" SET ...`
  forms (the exact deploy-halt class the validator should catch).
- `ADD_CONSTRAINT_RE` used `[\s\S]*?` between `ALTER TABLE` and
  `ADD CONSTRAINT`, allowing the regex to span across `;` and
  misattribute the FK to an unrelated earlier ALTER TABLE.
- Two silent `catch {}` blocks lacked the explanatory comments required
  by `.claude/rules/error-handling.md`.

`/simplify` then deduplicated the `findSwapTargets` call (was running
twice per FK-swap file) and extracted a `Signal` type alias plus
`drizzleFkName()` / `postgresFkName()` helpers.

## Test plan

- [x] 28 unit tests pass (`npx vitest run validate/validate-fk-swap-double-drop.test.ts`)
- [x] Validator standalone returns 0 violations on main (`npx tsx crux/validate/validate-fk-swap-double-drop.ts`)
- [x] Full gate passes (`pnpm crux w validate gate --fix --no-cache`)
- [x] TypeScript clean (`npx tsc --noEmit -p crux/tsconfig.json` shows no errors in new files)
- [x] Adversarial fuzzing: empty file, huge file, comment-spoofed DROPs, false-positive UPDATE on non-resources column — all handled correctly
- [ ] CI green on push

Closes QUA-609.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FK-swap double-drop validator ensuring database migrations properly drop constraints when rewriting foreign key columns.
  * Recognizes two acceptable constraint drop patterns: explicit `DROP CONSTRAINT` statements or dynamic `information_schema` lookups.
  * Reports detailed violations listing missing constraint drops and affected migration targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->