### PR TITLE
feat(schema): mark resources.stable_id NOT NULL (QUA-576)

### DIFF
--- a/apps/wiki-server/drizzle/0201_qua_576_resources_stableid_notnull.sql
+++ b/apps/wiki-server/drizzle/0201_qua_576_resources_stableid_notnull.sql
@@ -1,31 +1,24 @@
--- QUA-576: reconcile schema.ts with DB state on resources.stable_id.
+-- QUA-576: reconcile schema.ts with prod DB state on resources.stable_id.
 --
--- Migration 0184 (QUA-536 Phase A) already set `resources.stable_id` NOT NULL
--- in prod via the out-of-band script at
--- apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql. The
--- drizzle snapshot never caught up because 0184 itself is a `SELECT 1;`
--- no-op on the Drizzle side.
---
--- schema.ts has now been updated to `.notNull().unique()` to match DB
--- reality. This migration is a belt-and-suspenders idempotent SET NOT NULL
--- so any environment where 0184's script was skipped (e.g., a freshly
--- bootstrapped dev DB that applied 0184 as a no-op) converges to the
--- correct state.
---
--- Guard: abort if any NULL rows still exist. If this fires, the 0184 script
--- was not run (or failed); do not silently erase the discrepancy.
+-- Migration 0184 (QUA-536 Phase A) set NOT NULL in prod via an out-of-band
+-- psql script. Drizzle never caught up because 0184 itself is SELECT 1.
+-- Idempotent on prod; catches up any dev DB that skipped the 0184 script.
+-- Aborts loudly if NULL rows still exist so the discrepancy is not masked.
+
 DO $$
-DECLARE
-  null_count bigint;
 BEGIN
-  SELECT COUNT(*) INTO null_count FROM resources WHERE stable_id IS NULL;
-  IF null_count > 0 THEN
+  IF EXISTS (SELECT 1 FROM resources WHERE stable_id IS NULL) THEN
     RAISE EXCEPTION
-      'QUA-576: % resources rows have NULL stable_id. Run apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql before applying this migration.',
-      null_count;
+      'QUA-576: resources rows with NULL stable_id exist. Run apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql first.';
+  END IF;
+
+  IF (
+    SELECT is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'resources'
+      AND column_name = 'stable_id'
+  ) = 'YES' THEN
+    ALTER TABLE "resources" ALTER COLUMN "stable_id" SET NOT NULL;
   END IF;
 END $$;
-
--- Idempotent on prod (already NOT NULL from 0184); applies the constraint
--- on any environment that somehow lacks it.
-ALTER TABLE "resources" ALTER COLUMN "stable_id" SET NOT NULL;

--- a/apps/wiki-server/drizzle/0201_qua_576_resources_stableid_notnull.sql
+++ b/apps/wiki-server/drizzle/0201_qua_576_resources_stableid_notnull.sql
@@ -1,0 +1,31 @@
+-- QUA-576: reconcile schema.ts with DB state on resources.stable_id.
+--
+-- Migration 0184 (QUA-536 Phase A) already set `resources.stable_id` NOT NULL
+-- in prod via the out-of-band script at
+-- apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql. The
+-- drizzle snapshot never caught up because 0184 itself is a `SELECT 1;`
+-- no-op on the Drizzle side.
+--
+-- schema.ts has now been updated to `.notNull().unique()` to match DB
+-- reality. This migration is a belt-and-suspenders idempotent SET NOT NULL
+-- so any environment where 0184's script was skipped (e.g., a freshly
+-- bootstrapped dev DB that applied 0184 as a no-op) converges to the
+-- correct state.
+--
+-- Guard: abort if any NULL rows still exist. If this fires, the 0184 script
+-- was not run (or failed); do not silently erase the discrepancy.
+DO $$
+DECLARE
+  null_count bigint;
+BEGIN
+  SELECT COUNT(*) INTO null_count FROM resources WHERE stable_id IS NULL;
+  IF null_count > 0 THEN
+    RAISE EXCEPTION
+      'QUA-576: % resources rows have NULL stable_id. Run apps/wiki-server/scripts/qua-536-populate-resources-stable-id.sql before applying this migration.',
+      null_count;
+  END IF;
+END $$;
+
+-- Idempotent on prod (already NOT NULL from 0184); applies the constraint
+-- on any environment that somehow lacks it.
+ALTER TABLE "resources" ALTER COLUMN "stable_id" SET NOT NULL;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1408,6 +1408,13 @@
       "when": 1786435200000,
       "tag": "0200_qua_591_url_suggestion_applied_status",
       "breakpoints": true
+    },
+    {
+      "idx": 201,
+      "version": "7",
+      "when": 1786521600000,
+      "tag": "0201_qua_576_resources_stableid_notnull",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
@@ -28,27 +28,19 @@ const JOURNAL = join(__dirname, "..", "..", "drizzle", "meta", "_journal.json");
 describe("QUA-576 resources.stable_id schema/DB alignment", () => {
   const schema = readFileSync(SCHEMA_PATH, "utf-8");
 
-  it("resources.stableId is declared .notNull().unique()", () => {
-    // Find the `resources` table declaration and its stable_id column.
+  it("resources.stableId is declared notNull and unique (in any order)", () => {
     const resourcesBlock = schema.match(
       /export const resources = pgTable\(\s*"resources",\s*\{[\s\S]*?\n\s*\}\s*,/,
     );
     expect(resourcesBlock).not.toBeNull();
-    // Must include notNull() before unique() on the stable_id column.
-    expect(resourcesBlock![0]).toMatch(
-      /stableId:\s*text\("stable_id"\)\.notNull\(\)\.unique\(\)/,
-    );
-    // Guard against accidental regression to the nullable form.
-    expect(resourcesBlock![0]).not.toMatch(
-      /stableId:\s*text\("stable_id"\)\.unique\(\)(?!\.notNull)/,
-    );
+    const col = resourcesBlock![0].match(/stableId:\s*text\("stable_id"\)[^,\n]*/);
+    expect(col).not.toBeNull();
+    expect(col![0]).toContain(".notNull()");
+    expect(col![0]).toContain(".unique()");
   });
 
   it("reconcile migration 0201 guards against NULL stable_id rows", () => {
     const sql = readFileSync(RECONCILE_MIGRATION, "utf-8");
-    // The migration must run an abort-on-NULL check before SET NOT NULL so
-    // an environment where 0184's manual script was skipped produces a
-    // loud error rather than a silent constraint violation mid-ALTER.
     expect(sql).toMatch(/stable_id IS NULL/);
     expect(sql).toMatch(/RAISE EXCEPTION/);
     expect(sql).toMatch(

--- a/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
@@ -9,13 +9,13 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getTableColumns } from "drizzle-orm";
+import { resources } from "../schema.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = join(__filename, "..");
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const SCHEMA_PATH = join(__dirname, "..", "schema.ts");
 const RECONCILE_MIGRATION = join(
   __dirname,
   "..",
@@ -26,17 +26,10 @@ const RECONCILE_MIGRATION = join(
 const JOURNAL = join(__dirname, "..", "..", "drizzle", "meta", "_journal.json");
 
 describe("QUA-576 resources.stable_id schema/DB alignment", () => {
-  const schema = readFileSync(SCHEMA_PATH, "utf-8");
-
-  it("resources.stableId is declared notNull and unique (in any order)", () => {
-    const resourcesBlock = schema.match(
-      /export const resources = pgTable\(\s*"resources",\s*\{[\s\S]*?\n\s*\}\s*,/,
-    );
-    expect(resourcesBlock).not.toBeNull();
-    const col = resourcesBlock![0].match(/stableId:\s*text\("stable_id"\)[^,\n]*/);
-    expect(col).not.toBeNull();
-    expect(col![0]).toContain(".notNull()");
-    expect(col![0]).toContain(".unique()");
+  it("resources.stableId column is NOT NULL and UNIQUE", () => {
+    const { stableId } = getTableColumns(resources);
+    expect(stableId.notNull).toBe(true);
+    expect(stableId.isUnique).toBe(true);
   });
 
   it("reconcile migration 0201 guards against NULL stable_id rows", () => {

--- a/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
+++ b/apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts
@@ -1,0 +1,67 @@
+/**
+ * QUA-576: schema.ts must model resources.stable_id as NOT NULL to match
+ * DB state established by migration 0184 (QUA-536 Phase A).
+ *
+ * If this test fails, schema.ts has drifted back to the pre-QUA-576 state
+ * where downstream callers default to unreachable `?? null` paths. See the
+ * ticket for the allow-list of "still load-bearing" defensive fallbacks.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = join(__filename, "..");
+
+const SCHEMA_PATH = join(__dirname, "..", "schema.ts");
+const RECONCILE_MIGRATION = join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "0201_qua_576_resources_stableid_notnull.sql",
+);
+const JOURNAL = join(__dirname, "..", "..", "drizzle", "meta", "_journal.json");
+
+describe("QUA-576 resources.stable_id schema/DB alignment", () => {
+  const schema = readFileSync(SCHEMA_PATH, "utf-8");
+
+  it("resources.stableId is declared .notNull().unique()", () => {
+    // Find the `resources` table declaration and its stable_id column.
+    const resourcesBlock = schema.match(
+      /export const resources = pgTable\(\s*"resources",\s*\{[\s\S]*?\n\s*\}\s*,/,
+    );
+    expect(resourcesBlock).not.toBeNull();
+    // Must include notNull() before unique() on the stable_id column.
+    expect(resourcesBlock![0]).toMatch(
+      /stableId:\s*text\("stable_id"\)\.notNull\(\)\.unique\(\)/,
+    );
+    // Guard against accidental regression to the nullable form.
+    expect(resourcesBlock![0]).not.toMatch(
+      /stableId:\s*text\("stable_id"\)\.unique\(\)(?!\.notNull)/,
+    );
+  });
+
+  it("reconcile migration 0201 guards against NULL stable_id rows", () => {
+    const sql = readFileSync(RECONCILE_MIGRATION, "utf-8");
+    // The migration must run an abort-on-NULL check before SET NOT NULL so
+    // an environment where 0184's manual script was skipped produces a
+    // loud error rather than a silent constraint violation mid-ALTER.
+    expect(sql).toMatch(/stable_id IS NULL/);
+    expect(sql).toMatch(/RAISE EXCEPTION/);
+    expect(sql).toMatch(
+      /ALTER TABLE "resources" ALTER COLUMN "stable_id" SET NOT NULL/,
+    );
+  });
+
+  it("drizzle journal includes the 0201 reconcile entry", () => {
+    const journal = JSON.parse(readFileSync(JOURNAL, "utf-8"));
+    const entry = journal.entries.find(
+      (e: { tag: string }) => e.tag === "0201_qua_576_resources_stableid_notnull",
+    );
+    expect(entry).toBeDefined();
+    expect(entry.idx).toBe(201);
+  });
+});

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -654,8 +654,6 @@ export const resources = pgTable(
     credibilityOverride: real("credibility_override"),
     fetchedAt: timestamp("fetched_at", { withTimezone: true }),
     contentHash: text("content_hash"),
-    // QUA-576: .notNull() matches DB state (migration 0184 set column NOT NULL).
-    // Prevents schema drift that allowed unreachable `?? null` paths in callers.
     stableId: text("stable_id").notNull().unique(),
     /** HTTP reachability of the resource URL.
      *  Values: ok | dead | soft_404 | not_found | timeout | unreachable | paywall | error.

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -654,7 +654,9 @@ export const resources = pgTable(
     credibilityOverride: real("credibility_override"),
     fetchedAt: timestamp("fetched_at", { withTimezone: true }),
     contentHash: text("content_hash"),
-    stableId: text("stable_id").unique(),
+    // QUA-576: .notNull() matches DB state (migration 0184 set column NOT NULL).
+    // Prevents schema drift that allowed unreachable `?? null` paths in callers.
+    stableId: text("stable_id").notNull().unique(),
     /** HTTP reachability of the resource URL.
      *  Values: ok | dead | soft_404 | not_found | timeout | unreachable | paywall | error.
      *  Written by resource-ingest and source-fetcher after each fetch attempt.


### PR DESCRIPTION
## Summary

Fixes QUA-576 — reconciles `apps/wiki-server/src/schema.ts` with the
DB state established by migration 0184 (QUA-536 Phase A), which
populated `resources.stable_id` and set it NOT NULL via an out-of-band
psql script. The Drizzle schema had lagged, allowing downstream
callers to default to `?? null` paths that were structurally
unreachable in prod.

This is the last residual item blocking the QUA-549 coordinator
ticket from closing.

## Changes

- `apps/wiki-server/src/schema.ts` — `stableId: text("stable_id").unique()` → `.notNull().unique()`
- `apps/wiki-server/drizzle/0201_qua_576_resources_stableid_notnull.sql` — reconcile migration: aborts if any NULL rows remain, then idempotent `SET NOT NULL` (skipped when `information_schema` already reports NOT NULL, avoiding a full-table ACCESS EXCLUSIVE scan on prod)
- `apps/wiki-server/src/__tests__/qua-576-schema-drift.test.ts` — pins the invariant via `getTableColumns(resources).stableId.{notNull,isUnique}` so a future revert of schema.ts fails here rather than at the first NULL-write attempt

## Audit performed

**Writes** (every INSERT into `resources`):
- `apps/wiki-server/src/routes/wikibase/resources.ts::resourceValues()` — `stableId: d.stableId ?? generateId()`
- `apps/wiki-server/src/routes/wikibase/resources.ts::/suggest` raw SQL — explicitly passes `stable_id` in the unnest
- `apps/wiki-server/src/routes/tablebase/data-sources.ts` — `stableId: generateId()` on the tabular-source insert
- `apps/wiki-server/scripts/0160_migrate_tabular_sources.sql` — historical one-shot, already applied

**Reads** with `?? id` / `?? undefined` / `if (row.stableId)` fallbacks:
All sites are now structurally unreachable per the new schema, but left in
place — their existing comments already note "defensive for test fixtures /
shouldn't happen post-QUA-536" and they do not impose a runtime cost beyond
a cheap truthy check. No behavioral change needed.

## Test plan

- [x] `pnpm exec tsc --noEmit` on `apps/wiki-server`, `apps/web`, `crux` — clean (crux pre-existing baseline unchanged)
- [x] `pnpm test` — 6926 passing / 26 skipped
- [x] `pnpm exec vitest run apps/wiki-server` — 1295 passing, including QUA-576 + QUA-536 regression suites
- [x] `pnpm crux w validate gate --fix` — 52 blocking checks pass (3 pre-existing advisories)
- [x] `/agent-review-pr` adaptive review — hostile reviewer flagged 5 items, 1 fixed (drizzle introspection test), 4 dismissed after investigation

## Deploy Checklist

<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0201 applied on server start — `kubectl logs -l app=wiki-server | grep '0201_qua_576'`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync
<!-- /deploy-tasks:v1 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced mandatory uniqueness and non-null constraints on resource identifiers to strengthen data integrity. Includes validation checks to detect and prevent issues with existing data before applying schema changes.

* **Tests**
  * Added test suite to validate schema constraints, migration logic, and data integrity requirements are properly enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->