### PR TITLE
feat(wellness): Linear-side dedup before filing new tickets

### DIFF
--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -161,7 +161,10 @@ describe('dedupLinearWellnessIssue', () => {
     expect(setState).not.toHaveBeenCalled();
   });
 
-  it('fails open when commenting on an open match throws', async () => {
+  it('returns commented (NOT skipped) when commenting on an open match throws — prevents duplicate on open path', async () => {
+    // The open ticket exists; its existence is the dedup signal. A failed
+    // comment must NOT cascade into a GitHub create — that would mirror
+    // into a second Linear ticket and reintroduce the duplicate cascade.
     const search = vi.fn().mockResolvedValue([
       makeIssue({ identifier: 'QUA-570', state: { name: 'In Progress', type: 'started' } }),
     ]);
@@ -172,7 +175,11 @@ describe('dedupLinearWellnessIssue', () => {
       search, comment, setState, now: () => NOW,
     });
 
-    expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
+    expect(result).toEqual({
+      kind: 'commented',
+      identifier: 'QUA-570',
+      url: expect.any(String),
+    });
     expect(setState).not.toHaveBeenCalled();
   });
 

--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -5,12 +5,15 @@
  * a match, the caller MUST NOT create a new GitHub issue (which would
  * spawn another Linear duplicate). These tests exercise every branch:
  *
- *   - open match      → comment, no create
- *   - recent closed   → reopen + comment, no create
- *   - stale closed    → fall through to create
- *   - no match        → fall through to create
- *   - lookup error    → fall through (fail-open)
- *   - comment error   → fall through (fail-open)
+ *   - open match                 → comment, no create
+ *   - recent closed              → reopen + comment, no create
+ *   - recent closed + comment err → still "reopened" (critical — no fall-through)
+ *   - stale closed               → fall through to create
+ *   - no match                   → fall through to create
+ *   - lookup error               → fall through (fail-open)
+ *   - comment error (open path)  → fall through (fail-open)
+ *   - reopen error               → fall through (fail-open)
+ *   - unknown state type         → treated as closed (allowlist safety)
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -47,10 +50,10 @@ describe('dedupLinearWellnessIssue', () => {
       makeIssue({ identifier: 'QUA-555', state: { name: 'Backlog', type: 'backlog' } }),
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Backlog' });
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({
@@ -59,7 +62,7 @@ describe('dedupLinearWellnessIssue', () => {
       url: expect.any(String),
     });
     expect(comment).toHaveBeenCalledWith('QUA-555', COMMENT);
-    expect(reopen).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
   });
 
   it('filters out rows whose title does not exactly match', async () => {
@@ -70,10 +73,10 @@ describe('dedupLinearWellnessIssue', () => {
       makeIssue({ identifier: 'QUA-999', title: 'System wellness check flaky' }),
     ]);
     const comment = vi.fn();
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
@@ -96,10 +99,10 @@ describe('dedupLinearWellnessIssue', () => {
       }),
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Backlog' });
+    const setState = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Backlog' });
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({
@@ -107,7 +110,7 @@ describe('dedupLinearWellnessIssue', () => {
       identifier: 'QUA-570',
       url: expect.any(String),
     });
-    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Backlog');
+    expect(setState).toHaveBeenCalledWith('QUA-570', 'Backlog');
     expect(comment).toHaveBeenCalledWith('QUA-570', COMMENT);
   });
 
@@ -121,24 +124,24 @@ describe('dedupLinearWellnessIssue', () => {
       }),
     ]);
     const comment = vi.fn();
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
-    expect(reopen).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
     expect(comment).not.toHaveBeenCalled();
   });
 
   it('returns no-match when search returns an empty list', async () => {
     const search = vi.fn().mockResolvedValue([]);
     const comment = vi.fn();
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
@@ -147,15 +150,15 @@ describe('dedupLinearWellnessIssue', () => {
   it('fails open when the Linear search throws', async () => {
     const search = vi.fn().mockRejectedValue(new Error('Linear GraphQL timed out'));
     const comment = vi.fn();
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
     expect(comment).not.toHaveBeenCalled();
-    expect(reopen).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
   });
 
   it('fails open when commenting on an open match throws', async () => {
@@ -163,14 +166,14 @@ describe('dedupLinearWellnessIssue', () => {
       makeIssue({ identifier: 'QUA-570', state: { name: 'In Progress', type: 'started' } }),
     ]);
     const comment = vi.fn().mockRejectedValue(new Error('Linear 5xx'));
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
-    expect(reopen).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
   });
 
   it('fails open when the reopen state transition throws', async () => {
@@ -183,13 +186,43 @@ describe('dedupLinearWellnessIssue', () => {
       }),
     ]);
     const comment = vi.fn();
-    const reopen = vi.fn().mockRejectedValue(new Error('state update refused'));
+    const setState = vi.fn().mockRejectedValue(new Error('state update refused'));
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
+    expect(comment).not.toHaveBeenCalled();
+  });
+
+  it('returns reopened (NOT skipped) when reopen succeeds but comment throws — prevents the QUA-577 duplicate', async () => {
+    // CRITICAL: if this returns `skipped/lookup-failed`, the caller in
+    // wellness-report.ts falls through to createIssue, Linear's GitHub
+    // integration mirrors that into ANOTHER Linear ticket, and we end up
+    // with the reopened ticket PLUS a new duplicate — exactly the 8-in-57h
+    // failure mode this entire module exists to prevent.
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-570',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: oneHourAgo,
+      }),
+    ]);
+    const comment = vi.fn().mockRejectedValue(new Error('Linear 500 on comment'));
+    const setState = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Backlog' });
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, setState, now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      kind: 'reopened',
+      identifier: 'QUA-570',
+      url: expect.any(String),
+    });
+    expect(setState).toHaveBeenCalledWith('QUA-570', 'Backlog');
   });
 
   it('prefers the open match even when a recent closed match also exists', async () => {
@@ -210,10 +243,10 @@ describe('dedupLinearWellnessIssue', () => {
       }),
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({
@@ -221,7 +254,34 @@ describe('dedupLinearWellnessIssue', () => {
       identifier: 'QUA-400',
       url: expect.any(String),
     });
-    expect(reopen).not.toHaveBeenCalled();
+    expect(setState).not.toHaveBeenCalled();
+  });
+
+  it('treats unknown state types as NOT open (allowlist safety)', async () => {
+    // If Linear adds a new state type, we want to fail closed — better to
+    // treat it as "already closed, maybe reopen" than to accidentally
+    // comment on a ticket in an unknown state as if it were open.
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-999',
+        state: { name: 'Weird', type: 'some-future-type' },
+        updatedAt: oneHourAgo,
+      }),
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const setState = vi.fn().mockResolvedValue({ identifier: 'QUA-999', state: 'Backlog' });
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, setState, now: () => NOW,
+    });
+
+    // Unknown type is not open, so the code takes the closed-branch path:
+    // setState('Backlog') runs before comment. If the allowlist regressed
+    // to a denylist, the comment-only open-branch would fire instead and
+    // setState would never be called.
+    expect(result.kind).toBe('reopened');
+    expect(setState).toHaveBeenCalledWith('QUA-999', 'Backlog');
   });
 });
 
@@ -235,16 +295,20 @@ describe('closeLinearWellnessOnAllClear', () => {
       makeIssue({ identifier: 'QUA-571', state: { name: 'In Progress', type: 'started' } }),
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Done' });
+    const setState = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Done' });
 
     const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
-      search, comment, reopen, now: () => NOW,
+      search, comment, setState, now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'closed', identifiers: ['QUA-570', 'QUA-571'] });
-    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Done');
-    expect(reopen).toHaveBeenCalledWith('QUA-571', 'Done');
-    expect(reopen).not.toHaveBeenCalledWith('QUA-555', expect.anything());
+    expect(setState).toHaveBeenCalledWith('QUA-570', 'Done');
+    expect(setState).toHaveBeenCalledWith('QUA-571', 'Done');
+    expect(setState).not.toHaveBeenCalledWith('QUA-555', expect.anything());
+    // Comment must fire only for the open tickets, not the already-closed one.
+    expect(comment).toHaveBeenCalledWith('QUA-570', closeComment);
+    expect(comment).toHaveBeenCalledWith('QUA-571', closeComment);
+    expect(comment).not.toHaveBeenCalledWith('QUA-555', expect.anything());
   });
 
   it('returns none when there are no open matches', async () => {
@@ -255,7 +319,7 @@ describe('closeLinearWellnessOnAllClear', () => {
     const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
       search,
       comment: vi.fn(),
-      reopen: vi.fn(),
+      setState: vi.fn(),
       now: () => NOW,
     });
 
@@ -268,10 +332,47 @@ describe('closeLinearWellnessOnAllClear', () => {
     const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
       search,
       comment: vi.fn(),
-      reopen: vi.fn(),
+      setState: vi.fn(),
       now: () => NOW,
     });
 
     expect(result).toEqual({ kind: 'lookup-failed' });
+  });
+
+  it('returns close-failed (NOT lookup-failed) when search succeeds but every close throws', async () => {
+    // Discriminating search failure from close failure matters for telemetry —
+    // the two failure modes have different root causes and different remediations.
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-570', state: { name: 'Backlog', type: 'backlog' } }),
+      makeIssue({ identifier: 'QUA-571', state: { name: 'In Progress', type: 'started' } }),
+    ]);
+    const comment = vi.fn().mockRejectedValue(new Error('comment 500'));
+    const setState = vi.fn();
+
+    const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+      search, comment, setState, now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      kind: 'close-failed',
+      attempted: ['QUA-570', 'QUA-571'],
+    });
+  });
+
+  it('returns closed with partial success when some closes throw', async () => {
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-570', state: { name: 'Backlog', type: 'backlog' } }),
+      makeIssue({ identifier: 'QUA-571', state: { name: 'In Progress', type: 'started' } }),
+    ]);
+    const comment = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('second one failed'));
+    const setState = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Done' });
+
+    const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+      search, comment, setState, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'closed', identifiers: ['QUA-570'] });
   });
 });

--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for crux/health/wellness-linear-dedup.ts
+ *
+ * The dedup path is the critical piece of QUA-577 — if the search returns
+ * a match, the caller MUST NOT create a new GitHub issue (which would
+ * spawn another Linear duplicate). These tests exercise every branch:
+ *
+ *   - open match      → comment, no create
+ *   - recent closed   → reopen + comment, no create
+ *   - stale closed    → fall through to create
+ *   - no match        → fall through to create
+ *   - lookup error    → fall through (fail-open)
+ *   - comment error   → fall through (fail-open)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  dedupLinearWellnessIssue,
+  closeLinearWellnessOnAllClear,
+  REOPEN_WINDOW_MS,
+} from './wellness-linear-dedup.ts';
+import type { SearchedIssue } from '../lib/linear/issues.ts';
+
+const TITLE = 'System wellness check failing';
+const COMMENT = 'Wellness check failing again at 2026-04-19 20:00 UTC.';
+
+// Fixed reference point for deterministic "now" in tests
+const NOW = Date.parse('2026-04-19T20:00:00.000Z');
+
+function makeIssue(overrides: Partial<SearchedIssue> = {}): SearchedIssue {
+  return {
+    identifier: 'QUA-500',
+    title: TITLE,
+    priority: 0,
+    state: { name: 'Backlog', type: 'backlog' },
+    url: 'https://linear.app/quantifieduncertainty/issue/QUA-500',
+    createdAt: new Date(NOW - 3_600_000).toISOString(),
+    updatedAt: new Date(NOW - 3_600_000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('dedupLinearWellnessIssue', () => {
+  it('comments on the oldest open match and returns commented', async () => {
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-570', state: { name: 'Backlog', type: 'backlog' } }),
+      makeIssue({ identifier: 'QUA-555', state: { name: 'Backlog', type: 'backlog' } }),
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Backlog' });
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      kind: 'commented',
+      identifier: 'QUA-555',
+      url: expect.any(String),
+    });
+    expect(comment).toHaveBeenCalledWith('QUA-555', COMMENT);
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
+  it('filters out rows whose title does not exactly match', async () => {
+    // Linear search is token-based, so a query for "System wellness check
+    // failing" can return near-misses like "System wellness check flaky".
+    // Those must NOT be treated as matches.
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-999', title: 'System wellness check flaky' }),
+    ]);
+    const comment = vi.fn();
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
+    expect(comment).not.toHaveBeenCalled();
+  });
+
+  it('reopens the most recently closed match when inside the reopen window', async () => {
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    const tenHoursAgo = new Date(NOW - 10 * 60 * 60 * 1000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-555',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: tenHoursAgo,
+      }),
+      makeIssue({
+        identifier: 'QUA-570',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: oneHourAgo,
+      }),
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Backlog' });
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      kind: 'reopened',
+      identifier: 'QUA-570',
+      url: expect.any(String),
+    });
+    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Backlog');
+    expect(comment).toHaveBeenCalledWith('QUA-570', COMMENT);
+  });
+
+  it('skips reopening when the newest closed match is outside the reopen window', async () => {
+    const outsideWindow = new Date(NOW - REOPEN_WINDOW_MS - 60_000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-400',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: outsideWindow,
+      }),
+    ]);
+    const comment = vi.fn();
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
+    expect(reopen).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
+  });
+
+  it('returns no-match when search returns an empty list', async () => {
+    const search = vi.fn().mockResolvedValue([]);
+    const comment = vi.fn();
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'no-match' });
+  });
+
+  it('fails open when the Linear search throws', async () => {
+    const search = vi.fn().mockRejectedValue(new Error('Linear GraphQL timed out'));
+    const comment = vi.fn();
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
+    expect(comment).not.toHaveBeenCalled();
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
+  it('fails open when commenting on an open match throws', async () => {
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-570', state: { name: 'In Progress', type: 'started' } }),
+    ]);
+    const comment = vi.fn().mockRejectedValue(new Error('Linear 5xx'));
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the reopen state transition throws', async () => {
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-570',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: oneHourAgo,
+      }),
+    ]);
+    const comment = vi.fn();
+    const reopen = vi.fn().mockRejectedValue(new Error('state update refused'));
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'lookup-failed' });
+  });
+
+  it('prefers the open match even when a recent closed match also exists', async () => {
+    // Regression: an old, open ticket in Backlog should win over a freshly
+    // closed one — Linear's dedup ordering must match GitHub's "keep the
+    // original" convention (oldest open) or the two systems diverge on
+    // which ticket is canonical.
+    const oneHourAgo = new Date(NOW - 60 * 60 * 1000).toISOString();
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({
+        identifier: 'QUA-400',
+        state: { name: 'Backlog', type: 'backlog' },
+      }),
+      makeIssue({
+        identifier: 'QUA-555',
+        state: { name: 'Done', type: 'completed' },
+        updatedAt: oneHourAgo,
+      }),
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn();
+
+    const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({
+      kind: 'commented',
+      identifier: 'QUA-400',
+      url: expect.any(String),
+    });
+    expect(reopen).not.toHaveBeenCalled();
+  });
+});
+
+describe('closeLinearWellnessOnAllClear', () => {
+  const closeComment = 'All wellness checks passed at 2026-04-19 20:00 UTC. Auto-closing.';
+
+  it('closes every open match and returns their identifiers', async () => {
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-570', state: { name: 'Backlog', type: 'backlog' } }),
+      makeIssue({ identifier: 'QUA-555', state: { name: 'Done', type: 'completed' } }),
+      makeIssue({ identifier: 'QUA-571', state: { name: 'In Progress', type: 'started' } }),
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn().mockResolvedValue({ identifier: 'x', state: 'Done' });
+
+    const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+      search, comment, reopen, now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'closed', identifiers: ['QUA-570', 'QUA-571'] });
+    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Done');
+    expect(reopen).toHaveBeenCalledWith('QUA-571', 'Done');
+    expect(reopen).not.toHaveBeenCalledWith('QUA-555', expect.anything());
+  });
+
+  it('returns none when there are no open matches', async () => {
+    const search = vi.fn().mockResolvedValue([
+      makeIssue({ identifier: 'QUA-555', state: { name: 'Done', type: 'completed' } }),
+    ]);
+
+    const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+      search,
+      comment: vi.fn(),
+      reopen: vi.fn(),
+      now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'none' });
+  });
+
+  it('returns lookup-failed when the search throws', async () => {
+    const search = vi.fn().mockRejectedValue(new Error('Linear down'));
+
+    const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+      search,
+      comment: vi.fn(),
+      reopen: vi.fn(),
+      now: () => NOW,
+    });
+
+    expect(result).toEqual({ kind: 'lookup-failed' });
+  });
+});

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -16,6 +16,13 @@
  * All lookups are fail-open: Linear outages/timeouts never block the
  * wellness pipeline. A brief warning is logged and the caller proceeds
  * with the normal GitHub path.
+ *
+ * Trade-off documented: a sustained Linear outage (where `searchIssues`
+ * always throws) defeats the dedup and lets every wellness run create a
+ * new GitHub issue → new Linear mirror. The alternative is to block
+ * wellness reporting entirely during a Linear outage, which is strictly
+ * worse — GitHub outages would also halt reporting even though the
+ * wellness-check data is still valuable. Accept the occasional burst.
  */
 
 import {
@@ -34,6 +41,15 @@ import {
  */
 export const REOPEN_WINDOW_MS = 48 * 60 * 60 * 1000;
 
+/**
+ * Linear workflow-state `type` values that represent an actively-tracked
+ * (non-terminal) ticket. Use an allowlist rather than a denylist so any
+ * unknown/future state type (`triage`, custom types, etc.) fails safe as
+ * "don't treat as open" — accidentally commenting on a terminal ticket
+ * is worse than letting one slip through and file a fresh one.
+ */
+const OPEN_STATE_TYPES = new Set(['backlog', 'unstarted', 'started', 'triage']);
+
 export type LinearWellnessAction =
   | { kind: 'commented'; identifier: string; url: string }
   | { kind: 'reopened'; identifier: string; url: string }
@@ -42,14 +58,19 @@ export type LinearWellnessAction =
 export interface LinearDedupDeps {
   search: typeof searchIssues;
   comment: typeof commentOnIssue;
-  reopen: typeof updateIssueState;
+  /**
+   * Underlying state transition. Named after the generic `updateIssueState`
+   * it wraps rather than "reopen" or "close" because this module uses it
+   * for both transitions (Backlog on reopen, Done on all-clear close).
+   */
+  setState: typeof updateIssueState;
   now: () => number;
 }
 
 const DEFAULT_DEPS: LinearDedupDeps = {
   search: searchIssues,
   comment: commentOnIssue,
-  reopen: updateIssueState,
+  setState: updateIssueState,
   now: Date.now,
 };
 
@@ -59,7 +80,11 @@ function parseQuaNumber(identifier: string): number {
 }
 
 function isOpen(issue: SearchedIssue): boolean {
-  return issue.state.type !== 'completed' && issue.state.type !== 'canceled';
+  return OPEN_STATE_TYPES.has(issue.state.type);
+}
+
+function issueTimestampMs(issue: SearchedIssue): number {
+  return new Date(issue.updatedAt ?? issue.createdAt).getTime();
 }
 
 /**
@@ -76,7 +101,7 @@ export async function dedupLinearWellnessIssue(
   commentBody: string,
   deps: Partial<LinearDedupDeps> = {},
 ): Promise<LinearWellnessAction> {
-  const { search, comment, reopen, now } = { ...DEFAULT_DEPS, ...deps };
+  const { search, comment, setState, now } = { ...DEFAULT_DEPS, ...deps };
 
   let candidates: SearchedIssue[];
   try {
@@ -115,13 +140,14 @@ export async function dedupLinearWellnessIssue(
   // No open ticket. Check whether the most recently closed match is still
   // inside the reopen window; if so, reopen + comment rather than filing a
   // brand-new ticket (the failure mode this whole module exists to fix).
-  const closed = [...candidates].sort(
-    (a, b) =>
-      new Date(b.updatedAt ?? b.createdAt).getTime() -
-      new Date(a.updatedAt ?? a.createdAt).getTime(),
-  );
-  const mostRecent = closed[0];
-  const mostRecentTs = new Date(mostRecent.updatedAt ?? mostRecent.createdAt).getTime();
+  // Sort only the CLOSED candidates (the early-return above guarantees
+  // `open` is empty here, but an explicit filter keeps intent local to the
+  // block in case the guard is ever refactored).
+  const closedCandidates = candidates
+    .filter((c) => !isOpen(c))
+    .sort((a, b) => issueTimestampMs(b) - issueTimestampMs(a));
+  const mostRecent = closedCandidates[0];
+  const mostRecentTs = issueTimestampMs(mostRecent);
 
   if (!Number.isFinite(mostRecentTs) || now() - mostRecentTs > REOPEN_WINDOW_MS) {
     console.log(
@@ -130,22 +156,37 @@ export async function dedupLinearWellnessIssue(
     return { kind: 'skipped', reason: 'no-match' };
   }
 
+  // Reopen first. Once the state transition lands, the ticket IS canonically
+  // the target of the recurrence — even if the follow-up comment fails, we
+  // must NOT fall through to the GitHub create path (that's the exact
+  // duplicate-creation bug QUA-577 fixes). The comment is best-effort
+  // decoration; the state transition is the dedup action.
   try {
-    await reopen(mostRecent.identifier, 'Backlog');
-    await comment(mostRecent.identifier, commentBody);
+    await setState(mostRecent.identifier, 'Backlog');
   } catch (err) {
     console.warn(
       `Linear reopen of ${mostRecent.identifier} failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
     );
     return { kind: 'skipped', reason: 'lookup-failed' };
   }
+  // Reopen succeeded — the rest is cosmetic. A comment failure here MUST NOT
+  // propagate as `skipped` (see the test in wellness-linear-dedup.test.ts
+  // titled "returns reopened (NOT skipped) when reopen succeeds but comment
+  // throws").
+  await comment(mostRecent.identifier, commentBody).catch((err) => {
+    console.warn(
+      `Linear comment on reopened ${mostRecent.identifier} failed (${err instanceof Error ? err.message : String(err)}); ticket is already reopened, skipping GitHub create`,
+    );
+  });
   return { kind: 'reopened', identifier: mostRecent.identifier, url: mostRecent.url };
 }
 
 export type CloseLinearWellnessResult =
   | { kind: 'closed'; identifiers: string[] }
   | { kind: 'none' }
-  | { kind: 'lookup-failed' };
+  /** Discriminates "didn't reach Linear" from "reached Linear but every close call threw." */
+  | { kind: 'lookup-failed' }
+  | { kind: 'close-failed'; attempted: string[] };
 
 /**
  * Close any open Linear wellness tickets when the check recovers. Needed
@@ -158,7 +199,7 @@ export async function closeLinearWellnessOnAllClear(
   commentBody: string,
   deps: Partial<LinearDedupDeps> = {},
 ): Promise<CloseLinearWellnessResult> {
-  const { search, comment, reopen } = { ...DEFAULT_DEPS, ...deps };
+  const { search, comment, setState } = { ...DEFAULT_DEPS, ...deps };
 
   let candidates: SearchedIssue[];
   try {
@@ -174,12 +215,12 @@ export async function closeLinearWellnessOnAllClear(
   if (candidates.length === 0) return { kind: 'none' };
 
   const closed: string[] = [];
+  const attempted: string[] = [];
   for (const issue of candidates) {
+    attempted.push(issue.identifier);
     try {
       await comment(issue.identifier, commentBody);
-      // `updateIssueState` is shared with the reopen path — same call,
-      // different target state.
-      await reopen(issue.identifier, 'Done');
+      await setState(issue.identifier, 'Done');
       closed.push(issue.identifier);
     } catch (err) {
       console.warn(
@@ -187,5 +228,6 @@ export async function closeLinearWellnessOnAllClear(
       );
     }
   }
-  return closed.length > 0 ? { kind: 'closed', identifiers: closed } : { kind: 'lookup-failed' };
+  if (closed.length > 0) return { kind: 'closed', identifiers: closed };
+  return { kind: 'close-failed', attempted };
 }

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -31,6 +31,7 @@ import {
   updateIssueState,
   type SearchedIssue,
 } from '../lib/linear/issues.ts';
+import { isOpenStateType } from '../lib/linear/workflow-states.ts';
 
 /**
  * Window for treating a closed Linear wellness ticket as "still recent
@@ -40,15 +41,6 @@ import {
  * reopens tickets that have genuinely been triaged away.
  */
 export const REOPEN_WINDOW_MS = 48 * 60 * 60 * 1000;
-
-/**
- * Linear workflow-state `type` values that represent an actively-tracked
- * (non-terminal) ticket. Use an allowlist rather than a denylist so any
- * unknown/future state type (`triage`, custom types, etc.) fails safe as
- * "don't treat as open" — accidentally commenting on a terminal ticket
- * is worse than letting one slip through and file a fresh one.
- */
-const OPEN_STATE_TYPES = new Set(['backlog', 'unstarted', 'started', 'triage']);
 
 export type LinearWellnessAction =
   | { kind: 'commented'; identifier: string; url: string }
@@ -80,7 +72,7 @@ function parseQuaNumber(identifier: string): number {
 }
 
 function isOpen(issue: SearchedIssue): boolean {
-  return OPEN_STATE_TYPES.has(issue.state.type);
+  return isOpenStateType(issue.state.type);
 }
 
 function issueTimestampMs(issue: SearchedIssue): number {
@@ -126,14 +118,15 @@ export async function dedupLinearWellnessIssue(
   if (open.length > 0) {
     open.sort((a, b) => parseQuaNumber(a.identifier) - parseQuaNumber(b.identifier));
     const target = open[0];
-    try {
-      await comment(target.identifier, commentBody);
-    } catch (err) {
+    // The open ticket's EXISTENCE is the dedup signal; the comment is
+    // cosmetic decoration. A comment failure must NOT fall through to the
+    // GitHub create path — that would mirror into a second Linear ticket
+    // and reintroduce the duplicate-cascade this module prevents.
+    await comment(target.identifier, commentBody).catch((err) => {
       console.warn(
-        `Linear comment on ${target.identifier} failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
+        `Linear comment on ${target.identifier} failed (${err instanceof Error ? err.message : String(err)}); ticket is already open, skipping GitHub create`,
       );
-      return { kind: 'skipped', reason: 'lookup-failed' };
-    }
+    });
     return { kind: 'commented', identifier: target.identifier, url: target.url };
   }
 
@@ -214,20 +207,23 @@ export async function closeLinearWellnessOnAllClear(
 
   if (candidates.length === 0) return { kind: 'none' };
 
-  const closed: string[] = [];
-  const attempted: string[] = [];
-  for (const issue of candidates) {
-    attempted.push(issue.identifier);
-    try {
+  // Close in parallel. Typically 0–3 candidates; Linear API calls are
+  // independent. Promise.allSettled preserves partial-success semantics
+  // without tangling the sequential-loop error plumbing.
+  const results = await Promise.allSettled(
+    candidates.map(async (issue) => {
       await comment(issue.identifier, commentBody);
       await setState(issue.identifier, 'Done');
-      closed.push(issue.identifier);
-    } catch (err) {
-      console.warn(
-        `Failed to close Linear ${issue.identifier}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
+      return issue.identifier;
+    }),
+  );
+  const closed = results.flatMap((r, i) => {
+    if (r.status === 'fulfilled') return [r.value];
+    console.warn(
+      `Failed to close Linear ${candidates[i].identifier}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+    );
+    return [];
+  });
   if (closed.length > 0) return { kind: 'closed', identifiers: closed };
-  return { kind: 'close-failed', attempted };
+  return { kind: 'close-failed', attempted: candidates.map((c) => c.identifier) };
 }

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -1,0 +1,191 @@
+/**
+ * Linear-side dedup for wellness-check auto-filing (QUA-577).
+ *
+ * The GitHub-side dedup in `wellness-report.ts` already prevents stacking
+ * open GitHub issues by label. Linear's GitHub integration, however, creates
+ * a brand-new Linear ticket every time a new GitHub issue is filed — even
+ * when a previous Linear ticket is still open or was closed only hours ago.
+ * Result: 8+ near-identical Linear tickets accumulate per week.
+ *
+ * This module checks Linear *before* the GitHub issue is created:
+ *   - If an open Linear ticket matches, comment on it and skip GitHub creation.
+ *   - If the most recent match was closed inside `REOPEN_WINDOW_MS`,
+ *     reopen it to Backlog and comment.
+ *   - Otherwise, fall through to the normal GitHub create path.
+ *
+ * All lookups are fail-open: Linear outages/timeouts never block the
+ * wellness pipeline. A brief warning is logged and the caller proceeds
+ * with the normal GitHub path.
+ */
+
+import {
+  searchIssues,
+  commentOnIssue,
+  updateIssueState,
+  type SearchedIssue,
+} from '../lib/linear/issues.ts';
+
+/**
+ * Window for treating a closed Linear wellness ticket as "still recent
+ * enough to reopen instead of filing a new one." Tuned to comfortably
+ * cover the ~12h gap between consecutive wellness failures — anything
+ * shorter lets the duplicate-cascade pattern back in; anything longer
+ * reopens tickets that have genuinely been triaged away.
+ */
+export const REOPEN_WINDOW_MS = 48 * 60 * 60 * 1000;
+
+export type LinearWellnessAction =
+  | { kind: 'commented'; identifier: string; url: string }
+  | { kind: 'reopened'; identifier: string; url: string }
+  | { kind: 'skipped'; reason: 'no-match' | 'lookup-failed' };
+
+export interface LinearDedupDeps {
+  search: typeof searchIssues;
+  comment: typeof commentOnIssue;
+  reopen: typeof updateIssueState;
+  now: () => number;
+}
+
+const DEFAULT_DEPS: LinearDedupDeps = {
+  search: searchIssues,
+  comment: commentOnIssue,
+  reopen: updateIssueState,
+  now: Date.now,
+};
+
+function parseQuaNumber(identifier: string): number {
+  const m = identifier.match(/^QUA-(\d+)$/);
+  return m ? Number(m[1]) : 0;
+}
+
+function isOpen(issue: SearchedIssue): boolean {
+  return issue.state.type !== 'completed' && issue.state.type !== 'canceled';
+}
+
+/**
+ * Look for existing Linear wellness tickets and take the appropriate
+ * deduplication action. Returns what was done; the caller decides whether
+ * to proceed with its own filing path.
+ *
+ * @param title        The exact Linear issue title to match.
+ * @param commentBody  The message to post on a match (recurrence timestamp + run link).
+ * @param deps         Optional dependency overrides for tests.
+ */
+export async function dedupLinearWellnessIssue(
+  title: string,
+  commentBody: string,
+  deps: Partial<LinearDedupDeps> = {},
+): Promise<LinearWellnessAction> {
+  const { search, comment, reopen, now } = { ...DEFAULT_DEPS, ...deps };
+
+  let candidates: SearchedIssue[];
+  try {
+    // Linear's search is token-based; filter to exact title matches after.
+    const results = await search(title, 20);
+    candidates = results.filter((r) => r.title === title);
+  } catch (err) {
+    console.warn(
+      `Linear wellness dedup lookup failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
+    );
+    return { kind: 'skipped', reason: 'lookup-failed' };
+  }
+
+  if (candidates.length === 0) {
+    return { kind: 'skipped', reason: 'no-match' };
+  }
+
+  // Prefer the oldest open ticket (lowest QUA number) — matches the GitHub
+  // "keep the original, close the rest" convention so both systems converge
+  // on the same canonical ticket.
+  const open = candidates.filter(isOpen);
+  if (open.length > 0) {
+    open.sort((a, b) => parseQuaNumber(a.identifier) - parseQuaNumber(b.identifier));
+    const target = open[0];
+    try {
+      await comment(target.identifier, commentBody);
+    } catch (err) {
+      console.warn(
+        `Linear comment on ${target.identifier} failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
+      );
+      return { kind: 'skipped', reason: 'lookup-failed' };
+    }
+    return { kind: 'commented', identifier: target.identifier, url: target.url };
+  }
+
+  // No open ticket. Check whether the most recently closed match is still
+  // inside the reopen window; if so, reopen + comment rather than filing a
+  // brand-new ticket (the failure mode this whole module exists to fix).
+  const closed = [...candidates].sort(
+    (a, b) =>
+      new Date(b.updatedAt ?? b.createdAt).getTime() -
+      new Date(a.updatedAt ?? a.createdAt).getTime(),
+  );
+  const mostRecent = closed[0];
+  const mostRecentTs = new Date(mostRecent.updatedAt ?? mostRecent.createdAt).getTime();
+
+  if (!Number.isFinite(mostRecentTs) || now() - mostRecentTs > REOPEN_WINDOW_MS) {
+    console.log(
+      `Linear wellness dedup: most recent closed match (${mostRecent.identifier}) is outside the ${REOPEN_WINDOW_MS / 3_600_000}h reopen window — filing new ticket`,
+    );
+    return { kind: 'skipped', reason: 'no-match' };
+  }
+
+  try {
+    await reopen(mostRecent.identifier, 'Backlog');
+    await comment(mostRecent.identifier, commentBody);
+  } catch (err) {
+    console.warn(
+      `Linear reopen of ${mostRecent.identifier} failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
+    );
+    return { kind: 'skipped', reason: 'lookup-failed' };
+  }
+  return { kind: 'reopened', identifier: mostRecent.identifier, url: mostRecent.url };
+}
+
+export type CloseLinearWellnessResult =
+  | { kind: 'closed'; identifiers: string[] }
+  | { kind: 'none' }
+  | { kind: 'lookup-failed' };
+
+/**
+ * Close any open Linear wellness tickets when the check recovers. Needed
+ * because the failure path may comment on a Linear ticket WITHOUT creating
+ * a GitHub issue — so the GitHub-mirror close logic would never fire and
+ * Linear would be left holding a hanging open ticket.
+ */
+export async function closeLinearWellnessOnAllClear(
+  title: string,
+  commentBody: string,
+  deps: Partial<LinearDedupDeps> = {},
+): Promise<CloseLinearWellnessResult> {
+  const { search, comment, reopen } = { ...DEFAULT_DEPS, ...deps };
+
+  let candidates: SearchedIssue[];
+  try {
+    const results = await search(title, 20);
+    candidates = results.filter((r) => r.title === title && isOpen(r));
+  } catch (err) {
+    console.warn(
+      `Linear wellness close lookup failed (${err instanceof Error ? err.message : String(err)})`,
+    );
+    return { kind: 'lookup-failed' };
+  }
+
+  if (candidates.length === 0) return { kind: 'none' };
+
+  const closed: string[] = [];
+  for (const issue of candidates) {
+    try {
+      await comment(issue.identifier, commentBody);
+      // `updateIssueState` is shared with the reopen path — same call,
+      // different target state.
+      await reopen(issue.identifier, 'Done');
+      closed.push(issue.identifier);
+    } catch (err) {
+      console.warn(
+        `Failed to close Linear ${issue.identifier}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return closed.length > 0 ? { kind: 'closed', identifiers: closed } : { kind: 'lookup-failed' };
+}

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -8,9 +8,38 @@
  *   - Issue body has full detail sections
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CheckResult } from './health-check.ts';
-import { buildWellnessReport, WELLNESS_ISSUE_TITLE } from './wellness-report.ts';
+
+// Mock GitHub so manageWellnessIssue tests don't touch the network. Keep the
+// hoist-safe pattern from the rest of the codebase — the mocks are set up
+// before the module under test is imported.
+const mockListIssuesByLabel = vi.fn();
+const mockListRecentOpenIssues = vi.fn();
+const mockCreateIssueComment = vi.fn();
+const mockCloseIssue = vi.fn();
+const mockCreateIssue = vi.fn();
+const mockEnsureLabel = vi.fn();
+const mockGetGitHubToken = vi.fn();
+
+vi.mock('../lib/github.ts', () => ({
+  REPO: 'quantified-uncertainty/longterm-wiki',
+  listIssuesByLabel: (...args: unknown[]) => mockListIssuesByLabel(...args),
+  listRecentOpenIssues: (...args: unknown[]) => mockListRecentOpenIssues(...args),
+  createIssueComment: (...args: unknown[]) => mockCreateIssueComment(...args),
+  closeIssue: (...args: unknown[]) => mockCloseIssue(...args),
+  createIssue: (...args: unknown[]) => mockCreateIssue(...args),
+  ensureLabel: (...args: unknown[]) => mockEnsureLabel(...args),
+  getGitHubToken: (...args: unknown[]) => mockGetGitHubToken(...args),
+  isMissingTokenError: () => false,
+  MISSING_TOKEN_SUMMARY: 'GITHUB_TOKEN not set',
+}));
+
+import {
+  buildWellnessReport,
+  manageWellnessIssue,
+  WELLNESS_ISSUE_TITLE,
+} from './wellness-report.ts';
 
 function makeCheck(overrides: Partial<CheckResult> = {}): CheckResult {
   return {
@@ -146,5 +175,114 @@ describe('WELLNESS_ISSUE_TITLE', () => {
     // runs can find each other's issues and avoid duplicates.
     expect(WELLNESS_ISSUE_TITLE).toBe('System wellness check failing');
     expect(WELLNESS_ISSUE_TITLE).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
+  const failingChecks = [makeCheck({ ok: false, summary: 'Data freshness failed' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGitHubToken.mockReturnValue('fake-token');
+    mockEnsureLabel.mockResolvedValue(undefined);
+    mockListIssuesByLabel.mockResolvedValue([]);
+    mockListRecentOpenIssues.mockResolvedValue([]);
+  });
+
+  it('skips GitHub create when Linear search returns an open match', async () => {
+    const search = vi.fn().mockResolvedValue([
+      {
+        identifier: 'QUA-570',
+        title: WELLNESS_ISSUE_TITLE,
+        priority: 0,
+        state: { name: 'Backlog', type: 'backlog' },
+        url: 'https://linear.app/q/issue/QUA-570',
+        createdAt: '2026-04-19T09:00:00.000Z',
+        updatedAt: '2026-04-19T09:00:00.000Z',
+      },
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn();
+
+    const report = buildWellnessReport(failingChecks);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: { search, comment, reopen, now: () => Date.parse('2026-04-19T20:00:00.000Z') },
+    });
+
+    expect(result.action).toBe('linear-commented');
+    expect(result.linearIdentifier).toBe('QUA-570');
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+    expect(comment).toHaveBeenCalledWith('QUA-570', expect.stringContaining('failing again'));
+  });
+
+  it('falls through to GitHub create when Linear has no match', async () => {
+    const search = vi.fn().mockResolvedValue([]);
+    mockCreateIssue.mockResolvedValue({ number: 9999 });
+
+    // `deduplicateWellnessIssues` uses fake timers to skip the 2s concurrent-
+    // create settle delay in tests. Advance the single pending timer as soon
+    // as it's registered so the create path returns without sleeping.
+    vi.useFakeTimers();
+    try {
+      const report = buildWellnessReport(failingChecks);
+      const promise = manageWellnessIssue(report, {
+        linearDedupDeps: { search, comment: vi.fn(), reopen: vi.fn(), now: () => 0 },
+      });
+      // Let microtasks run, advance the 2s settle timer, then await.
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.action).toBe('created');
+      expect(result.issueNumber).toBe(9999);
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: WELLNESS_ISSUE_TITLE,
+          labels: ['wellness', 'bug'],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not call the Linear dedup path when an open GitHub issue already exists', async () => {
+    mockListIssuesByLabel.mockResolvedValue([{ number: 100, title: WELLNESS_ISSUE_TITLE }]);
+    const search = vi.fn();
+
+    const report = buildWellnessReport(failingChecks);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: { search, comment: vi.fn(), reopen: vi.fn(), now: () => 0 },
+    });
+
+    expect(result.action).toBe('updated');
+    expect(result.issueNumber).toBe(100);
+    expect(search).not.toHaveBeenCalled();
+    expect(mockCreateIssue).not.toHaveBeenCalled();
+  });
+
+  it('closes a lingering open Linear ticket when checks recover and no GitHub issue is open', async () => {
+    const search = vi.fn().mockResolvedValue([
+      {
+        identifier: 'QUA-570',
+        title: WELLNESS_ISSUE_TITLE,
+        priority: 0,
+        state: { name: 'Backlog', type: 'backlog' },
+        url: 'u',
+        createdAt: '2026-04-19T09:00:00.000Z',
+        updatedAt: '2026-04-19T09:00:00.000Z',
+      },
+    ]);
+    const comment = vi.fn().mockResolvedValue(undefined);
+    const reopen = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Done' });
+
+    const passing = [makeCheck({ ok: true })];
+    const report = buildWellnessReport(passing);
+    const result = await manageWellnessIssue(report, {
+      linearDedupDeps: { search, comment, reopen, now: () => 0 },
+    });
+
+    expect(result.action).toBe('closed');
+    expect(result.linearIdentifier).toBe('QUA-570');
+    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Done');
   });
 });

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -202,11 +202,11 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
       },
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn();
+    const setState = vi.fn();
 
     const report = buildWellnessReport(failingChecks);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment, reopen, now: () => Date.parse('2026-04-19T20:00:00.000Z') },
+      linearDedupDeps: { search, comment, setState, now: () => Date.parse('2026-04-19T20:00:00.000Z') },
     });
 
     expect(result.action).toBe('linear-commented');
@@ -226,7 +226,7 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     try {
       const report = buildWellnessReport(failingChecks);
       const promise = manageWellnessIssue(report, {
-        linearDedupDeps: { search, comment: vi.fn(), reopen: vi.fn(), now: () => 0 },
+        linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
       });
       // Let microtasks run, advance the 2s settle timer, then await.
       await vi.runAllTimersAsync();
@@ -251,7 +251,7 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
 
     const report = buildWellnessReport(failingChecks);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment: vi.fn(), reopen: vi.fn(), now: () => 0 },
+      linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
     });
 
     expect(result.action).toBe('updated');
@@ -273,16 +273,16 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
       },
     ]);
     const comment = vi.fn().mockResolvedValue(undefined);
-    const reopen = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Done' });
+    const setState = vi.fn().mockResolvedValue({ identifier: 'QUA-570', state: 'Done' });
 
     const passing = [makeCheck({ ok: true })];
     const report = buildWellnessReport(passing);
     const result = await manageWellnessIssue(report, {
-      linearDedupDeps: { search, comment, reopen, now: () => 0 },
+      linearDedupDeps: { search, comment, setState, now: () => 0 },
     });
 
     expect(result.action).toBe('closed');
     expect(result.linearIdentifier).toBe('QUA-570');
-    expect(reopen).toHaveBeenCalledWith('QUA-570', 'Done');
+    expect(setState).toHaveBeenCalledWith('QUA-570', 'Done');
   });
 });

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -24,6 +24,12 @@ import {
   MISSING_TOKEN_SUMMARY,
 } from '../lib/github.ts';
 import type { GitHubIssue } from '../lib/github.ts';
+import {
+  dedupLinearWellnessIssue,
+  closeLinearWellnessOnAllClear,
+  type LinearDedupDeps,
+  type LinearWellnessAction,
+} from './wellness-linear-dedup.ts';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -198,10 +204,50 @@ async function ensureWellnessLabel(): Promise<void> {
   await ensureLabel('wellness', 'e4e669', 'Periodic wellness check failures');
 }
 
+/**
+ * Translate a `LinearWellnessAction` into a short-circuit result for
+ * `manageWellnessIssue`, or return null when the caller should continue
+ * to the GitHub create path.
+ */
+function handleLinearDedupAction(
+  action: LinearWellnessAction,
+): WellnessIssueResult | null {
+  switch (action.kind) {
+    case 'commented':
+      console.log(`Commented on existing Linear wellness issue ${action.identifier}`);
+      return { action: 'linear-commented', linearIdentifier: action.identifier };
+    case 'reopened':
+      console.log(`Reopened recent Linear wellness issue ${action.identifier}`);
+      return { action: 'linear-reopened', linearIdentifier: action.identifier };
+    case 'skipped':
+      return null;
+  }
+}
+
+export type WellnessIssueAction =
+  | 'created'
+  | 'updated'
+  | 'closed'
+  | 'none'
+  | 'linear-commented'
+  | 'linear-reopened';
+
+export interface WellnessIssueResult {
+  action: WellnessIssueAction;
+  issueNumber?: number;
+  linearIdentifier?: string;
+}
+
+export interface ManageWellnessOptions {
+  runUrl?: string;
+  /** Inject overrides for the Linear-side dedup path (used in tests). */
+  linearDedupDeps?: Partial<LinearDedupDeps>;
+}
+
 export async function manageWellnessIssue(
   report: WellnessReport,
-  options: { runUrl?: string } = {},
-): Promise<{ action: 'created' | 'updated' | 'closed' | 'none'; issueNumber?: number }> {
+  options: ManageWellnessOptions = {},
+): Promise<WellnessIssueResult> {
   try {
     getGitHubToken();
   } catch (e) {
@@ -229,22 +275,37 @@ export async function manageWellnessIssue(
 
       console.log(`Updated existing wellness issue #${existingIssue}`);
       return { action: 'updated', issueNumber: existingIssue };
-    } else {
-      // Create new issue with a stable title (no timestamp) so concurrent
-      // workflows can find it via findOpenWellnessIssue(). The timestamp
-      // is already in the issue body.
-      const created = await createIssue({
-        title: WELLNESS_ISSUE_TITLE,
-        body: report.issueBody,
-        labels: ['wellness', 'bug'],
-      });
-
-      // Best-effort dedup: close any duplicates from concurrent workflows
-      await deduplicateWellnessIssues();
-
-      console.log(`Created new wellness issue #${created.number}`);
-      return { action: 'created', issueNumber: created.number };
     }
+
+    // No open GitHub issue. Before filing a new one (which Linear's GitHub
+    // integration would mirror into a brand-new Linear ticket), check Linear
+    // directly for an existing open or recently-closed wellness ticket.
+    // See QUA-577 for the 8-duplicate-tickets incident this prevents.
+    const linearComment = runUrl
+      ? `Wellness check failing again at ${report.timestamp}. See [run](${runUrl}) for details.`
+      : `Wellness check failing again at ${report.timestamp}.`;
+    const linearAction = await dedupLinearWellnessIssue(
+      WELLNESS_ISSUE_TITLE,
+      linearComment,
+      options.linearDedupDeps,
+    );
+    const handled = handleLinearDedupAction(linearAction);
+    if (handled) return handled;
+
+    // Create new GitHub issue with a stable title (no timestamp) so concurrent
+    // workflows can find it via findOpenWellnessIssue(). The timestamp is
+    // already in the issue body.
+    const created = await createIssue({
+      title: WELLNESS_ISSUE_TITLE,
+      body: report.issueBody,
+      labels: ['wellness', 'bug'],
+    });
+
+    // Best-effort dedup: close any duplicates from concurrent workflows
+    await deduplicateWellnessIssues();
+
+    console.log(`Created new wellness issue #${created.number}`);
+    return { action: 'created', issueNumber: created.number };
   } else {
     // ── All clear case ─────────────────────────────────────────────────
     if (existingIssue) {
@@ -258,9 +319,23 @@ export async function manageWellnessIssue(
 
       console.log(`Closed resolved wellness issue #${existingIssue}`);
       return { action: 'closed', issueNumber: existingIssue };
-    } else {
-      console.log('All checks passed. No open wellness issue to close.');
-      return { action: 'none' };
     }
+
+    // No open GitHub issue, but there may be an open Linear ticket that
+    // we commented on during a prior failure (without creating GitHub).
+    // Close it so Linear doesn't hold a hanging open ticket.
+    const linearCloseResult = await closeLinearWellnessOnAllClear(
+      WELLNESS_ISSUE_TITLE,
+      `All wellness checks passed at ${report.timestamp}. Auto-closing.`,
+      options.linearDedupDeps,
+    );
+    if (linearCloseResult.kind === 'closed') {
+      const ids = linearCloseResult.identifiers.join(', ');
+      console.log(`Closed Linear wellness ticket(s): ${ids}`);
+      return { action: 'closed', linearIdentifier: linearCloseResult.identifiers[0] };
+    }
+
+    console.log('All checks passed. No open wellness issue to close.');
+    return { action: 'none' };
   }
 }

--- a/crux/lib/linear/__tests__/issues.test.ts
+++ b/crux/lib/linear/__tests__/issues.test.ts
@@ -375,6 +375,8 @@ describe('issues.ts — transport helpers', () => {
                   priority: 2,
                   state: { name: 'Backlog', type: 'backlog' },
                   url: 'u1',
+                  createdAt: '2026-04-01T00:00:00.000Z',
+                  updatedAt: '2026-04-01T00:00:00.000Z',
                 },
                 {
                   identifier: 'QUA-2',
@@ -382,6 +384,8 @@ describe('issues.ts — transport helpers', () => {
                   priority: 3,
                   state: { name: 'Todo', type: 'unstarted' },
                   url: 'u2',
+                  createdAt: '2026-04-02T00:00:00.000Z',
+                  updatedAt: '2026-04-02T00:00:00.000Z',
                 },
               ],
             },

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -15,6 +15,7 @@ import {
   type LinearChildrenResult,
   type LinearTriageIssue,
 } from './issues.ts';
+import { isOpenStateType } from './workflow-states.ts';
 
 export type AuditBucket =
   | 'active'
@@ -50,7 +51,6 @@ interface GhSearchResponse {
 }
 
 export const STALE_DAYS = 7;
-const RESOLVED_STATE_TYPES = new Set(['completed', 'canceled']);
 
 /**
  * Label that opts an issue out of `audit --fix` auto-closure regardless of PR
@@ -218,9 +218,7 @@ export function classifyEntry(
 ): AuditEntry {
   const { openPRs, mergedPRs } = classifyPRs(items);
   const children = childrenResult.nodes;
-  const unresolvedChildren = children.filter(
-    (c) => !RESOLVED_STATE_TYPES.has(c.state.type),
-  );
+  const unresolvedChildren = children.filter((c) => isOpenStateType(c.state.type));
   const daysInactive = daysSince(issue.updatedAt);
 
   let bucket: AuditBucket;

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -219,6 +219,8 @@ export interface SearchedIssue {
   priority: number;
   state: { name: string; type: string };
   url: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /**
@@ -241,6 +243,8 @@ export async function searchIssues(
           priority
           state { name type }
           url
+          createdAt
+          updatedAt
         }
       }
     }`,

--- a/crux/lib/linear/workflow-states.ts
+++ b/crux/lib/linear/workflow-states.ts
@@ -50,6 +50,20 @@ export function getWorkflowStateId(name: WorkflowStateName): string {
   return id;
 }
 
+/**
+ * Linear state `type` values that represent an active (non-terminal) ticket.
+ * Allowlist so unknown/future state types fail safe as "not open" — better to
+ * re-file a ticket than to accidentally comment on something terminal-looking.
+ *
+ * Callers across the codebase (wellness dedup, audit auto-close, etc.) must
+ * agree on what "open" means or their decisions diverge on edge cases.
+ */
+export const OPEN_STATE_TYPES = new Set(['triage', 'backlog', 'unstarted', 'started']);
+
+export function isOpenStateType(type: string): boolean {
+  return OPEN_STATE_TYPES.has(type);
+}
+
 export interface RemoteWorkflowState {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Adds Linear-side dedup to the wellness-check auto-filing path so recurring failures no longer spawn a new Linear ticket every time the check flaps.

Closes QUA-577. Fixes QUA-577.

## The bug

The wellness-check workflow filed **8 separate Linear tickets** in 57 hours, all titled "System wellness check failing." Each one had `integrationSourceType: "github"` and was attached to a fresh GitHub issue — so the chain is:

1. Wellness check fails → GitHub issue created (correctly deduped against open GitHub issues by label).
2. Check recovers → GitHub issue closed → Linear's GitHub integration mirrors the close to Done.
3. Check fails again later → GitHub dedup finds no *open* issue (because step 2 closed it) → new GitHub issue created → Linear's integration creates **another** ticket.

Repeat 8 times.

## The fix

In `manageWellnessIssue` — after the GitHub-by-label lookup returns null, but *before* `createIssue` — search Linear for tickets whose title exactly matches `"System wellness check failing"`:

- **Open match (`triage` / `backlog` / `unstarted` / `started`)**: comment on the oldest open one. Skip GitHub create.
- **Closed match inside the 48h reopen window**: setState → `Backlog`, comment. Skip GitHub create.
- **Otherwise (no match, or only stale closed matches)**: fall through to the existing GitHub create path.

The all-clear path also got a sibling: `closeLinearWellnessOnAllClear` closes any lingering Linear ticket that was commented-on without a GitHub mirror, so Linear doesn't accumulate open wellness tickets over time.

All Linear calls are **fail-open**: any lookup/comment/reopen/close failure logs a warning and falls through to the GitHub path. The exception is the commit-point where the state transition has already landed — at that point the Linear ticket IS the dedup target, and a comment failure must NOT fall through to GitHub create (that's the exact bug this PR prevents). Both the reopen-then-comment path and the open-then-comment path handle this correctly.

## Key changes

- `crux/health/wellness-linear-dedup.ts` (new) — the dedup module. Two exported functions (`dedupLinearWellnessIssue`, `closeLinearWellnessOnAllClear`) + a DI-shaped `LinearDedupDeps` for tests.
- `crux/health/wellness-report.ts` — `manageWellnessIssue` now calls into the dedup module on the failure-and-no-GitHub-match branch, and the all-clear-and-no-GitHub-match branch.
- `crux/lib/linear/issues.ts` — `SearchedIssue` gained `createdAt` + `updatedAt` so the staleness check has timestamps to work with.
- `crux/lib/linear/workflow-states.ts` — new shared `OPEN_STATE_TYPES` allowlist + `isOpenStateType(type)`; `crux/lib/linear/audit.ts` migrated from a denylist (`RESOLVED_STATE_TYPES`) to this shared allowlist so both callers agree on edge cases.

## Test plan

- [x] `pnpm exec vitest run crux/health/wellness-linear-dedup.test.ts` — 16 tests covering every branch (open match, closed inside window, closed outside window, no match, lookup error, open-comment error, setState error, reopen-then-comment partial failure, unknown state type, close batch, close-failed vs lookup-failed, partial close)
- [x] `pnpm exec vitest run crux/health/wellness-report.test.ts` — 15 tests including 4 new `manageWellnessIssue` wiring tests (skips GitHub on Linear match; falls through on no match; doesn't call Linear when GitHub match exists; closes lingering Linear on all-clear)
- [x] `pnpm exec vitest run crux/lib/linear/__tests__/` — all 202 Linear-related tests pass, including the 35 audit tests affected by the denylist → allowlist migration
- [x] `pnpm build` — passes
- [x] `pnpm crux w validate gate --fix` — 42 checks pass
- [x] `/agent-review-pr` — hostile reviewer caught one CRITICAL (reopen-then-comment-fail duplicate) + two HIGH issues; all fixed
- [x] `/simplify` — three parallel reviewers caught one HIGH (open-then-comment-fail duplicate — same bug shape on the other branch) + three MEDIUM improvements; all fixed

## Historical cleanup

The 7 duplicate Done tickets (QUA-512, 513, 517, 518, 533, 555) and the currently-open QUA-570 are left for a separate hygiene pass, as the ticket suggests. This PR prevents the cascade from continuing.
