### PR TITLE
fix(worker): resolve @longterm-wiki/url-utils in Docker image (QUA-605)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,11 +5,17 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /deps
-# Workspace packages referenced as file:./packages/* from docker/worker/package.json
+# Workspace packages referenced as file:./packages/<pkg> from docker/worker/package.json
 # must be present before `pnpm install` resolves them. Without this, the install
 # succeeds but @longterm-wiki/* imports from crux hit ERR_MODULE_NOT_FOUND at
 # runtime (QUA-605; same class as QUA-598).
-COPY packages/ ./packages/
+#
+# Copy only the packages actually declared as file: deps in worker/package.json —
+# broad `COPY packages/ ./packages/` would also pull in packages/factbase/data/*.yaml
+# (2+ MB of content that churns on every factbase sync), invalidating the
+# `pnpm install --prod` layer cache on unrelated FactBase edits. Add a line below
+# for each @longterm-wiki/* dep added to docker/worker/package.json.
+COPY packages/url-utils/ ./packages/url-utils/
 COPY docker/worker/package.json ./
 RUN pnpm install --prod
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,6 +5,11 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /deps
+# Workspace packages referenced as file:./packages/* from docker/worker/package.json
+# must be present before `pnpm install` resolves them. Without this, the install
+# succeeds but @longterm-wiki/* imports from crux hit ERR_MODULE_NOT_FOUND at
+# runtime (QUA-605; same class as QUA-598).
+COPY packages/ ./packages/
 COPY docker/worker/package.json ./
 RUN pnpm install --prod
 
@@ -48,7 +53,9 @@ RUN echo 'export const X = 1;' > /tmp/test.ts && \
 # Copy crux source (worker + all transitive imports)
 COPY crux/ ./crux/
 
-# Copy shared packages (factbase, id-utils) — crux has runtime imports from these
+# Keep packages/ available for crux scripts that read packages/factbase/data/*.yaml
+# by filesystem path (separate from workspace package resolution, which is handled
+# via node_modules above).
 COPY packages/ ./packages/
 
 # NOTE: No apps/wiki-server/ files needed — all imports are type-only (erased by tsx)

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -20,6 +20,25 @@ import {
   extractWorkspaceImports,
 } from './validate-workspace-dep-coverage.ts';
 
+function makeScratchDir(): string {
+  const root = join(
+    os.tmpdir(),
+    `workspace-dep-coverage-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+/**
+ * Default worker-check paths for app-focused tests: point at guaranteed-missing
+ * locations so the worker scan is a no-op and doesn't pull in the real repo's
+ * docker/worker manifest.
+ */
+const NO_WORKER = {
+  workerPkgJson: '/nonexistent-worker-pkg-json',
+  workerSourceDir: '/nonexistent-crux-dir',
+};
+
 interface AppFixture {
   name: string;
   dependencies?: Record<string, string>;
@@ -98,7 +117,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(false);
     expect(result.errors).toBe(1);
     expect(result.apps).toHaveLength(1);
@@ -121,7 +140,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.errors).toBe(0);
     expect(result.apps[0].used).toEqual(
@@ -145,7 +164,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.errors).toBe(0);
     expect(result.apps[0].missing).toEqual([]);
@@ -167,7 +186,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.apps[0].used).toEqual(new Set(['@longterm-wiki/factbase']));
   });
@@ -184,7 +203,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(false);
     expect(result.apps[0].missing).toEqual(['@longterm-wiki/url-utils']);
   });
@@ -202,7 +221,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(false);
     expect(result.errors).toBe(1);
 
@@ -226,7 +245,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.errors).toBe(0);
     expect(result.warnings).toBe(1);
@@ -254,7 +273,7 @@ describe('validate-workspace-dep-coverage', () => {
       `import { x } from '@longterm-wiki/url-utils';\n`
     );
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.apps[0].used.size).toBe(0);
   });
@@ -272,7 +291,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     // No real imports → passes, no missing entries.
     expect(result.passed).toBe(true);
     expect(result.apps[0].used.size).toBe(0);
@@ -283,14 +302,17 @@ describe('validate-workspace-dep-coverage', () => {
       { name: 'stub-app' },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
     expect(result.apps).toHaveLength(1);
     expect(result.apps[0].used.size).toBe(0);
   });
 
   it('returns passed=true when the apps directory does not exist', () => {
-    const result = runCheck({ appsDir: join(os.tmpdir(), `nonexistent-${Date.now()}`) });
+    const result = runCheck({
+      appsDir: join(os.tmpdir(), `nonexistent-${Date.now()}`),
+      ...NO_WORKER,
+    });
     expect(result.passed).toBe(true);
     expect(result.apps).toEqual([]);
   });
@@ -306,7 +328,7 @@ describe('validate-workspace-dep-coverage', () => {
       },
     ]);
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(false);
     // Sorted alphabetically in the output.
     expect(result.apps[0].missing).toEqual([
@@ -327,12 +349,138 @@ describe('validate-workspace-dep-coverage', () => {
     ]);
 
     const warnings: string[] = [];
-    const result = runCheck({ appsDir: scratch, onWarn: (msg) => warnings.push(msg) });
+    const result = runCheck({
+      appsDir: scratch,
+      ...NO_WORKER,
+      onWarn: (msg) => warnings.push(msg),
+    });
 
     expect(warnings.length).toBeGreaterThan(0);
     expect(warnings[0]).toMatch(/Malformed package.json/);
     // With no declared deps, the import is still flagged as missing.
     expect(result.passed).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------
+  // Worker manifest tests — docker/worker/package.json vs crux/ imports.
+  // QUA-605: the worker image copies all of crux/ wholesale, so imports
+  // there must be declared in docker/worker/package.json (which is NOT a
+  // pnpm workspace member).
+  // ---------------------------------------------------------------------
+
+  it('flags undeclared workspace imports from the worker source tree', () => {
+    scratch = makeScratchDir();
+    // Empty apps dir (points to a missing location, which the validator treats
+    // as a no-op).
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'package.json'),
+      JSON.stringify({ name: 'worker', dependencies: {} })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'url.ts'),
+      `import { normalizeUrl } from '@longterm-wiki/url-utils';\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: join(workerDir, 'package.json'),
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(false);
+    const worker = result.apps.find((a) => a.app === 'docker/worker');
+    expect(worker).toBeDefined();
+    expect(worker?.missing).toEqual(['@longterm-wiki/url-utils']);
+  });
+
+  it('passes when worker manifest declares every crux-imported workspace pkg', () => {
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'package.json'),
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+        },
+      })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'url.ts'),
+      `import { normalizeUrl } from '@longterm-wiki/url-utils';\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: join(workerDir, 'package.json'),
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(true);
+    const worker = result.apps.find((a) => a.app === 'docker/worker');
+    expect(worker?.missing).toEqual([]);
+    expect(worker?.used).toEqual(new Set(['@longterm-wiki/url-utils']));
+  });
+
+  it('excludes crux test files from the worker scan', () => {
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'package.json'),
+      JSON.stringify({ name: 'worker', dependencies: {} })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    mkdirSync(join(cruxDir, 'lib', '__tests__'), { recursive: true });
+    // Test file imports url-utils — should NOT trigger a violation, since
+    // tests don't run in the worker image.
+    writeFileSync(
+      join(cruxDir, 'lib', 'url.test.ts'),
+      `import { normalizeUrl } from '@longterm-wiki/url-utils';\n`
+    );
+    writeFileSync(
+      join(cruxDir, 'lib', '__tests__', 'another.ts'),
+      `import { isSid } from '@longterm-wiki/id-utils';\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: join(workerDir, 'package.json'),
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(true);
+    const worker = result.apps.find((a) => a.app === 'docker/worker');
+    expect(worker?.used.size).toBe(0);
+  });
+
+  it('skips the worker check entirely when the manifest is missing', () => {
+    scratch = makeScratchDir();
+    const result = runCheck({
+      appsDir: join(scratch, 'apps-missing'),
+      workerPkgJson: join(scratch, 'worker-missing', 'package.json'),
+      workerSourceDir: join(scratch, 'crux-missing'),
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.apps.find((a) => a.app === 'docker/worker')).toBeUndefined();
   });
 
   it('skips symlinks without following them (no recursion loop)', () => {
@@ -357,7 +505,7 @@ describe('validate-workspace-dep-coverage', () => {
       return;
     }
 
-    const result = runCheck({ appsDir: scratch });
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     expect(result.passed).toBe(true);
   });
 });

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 
@@ -21,12 +21,7 @@ import {
 } from './validate-workspace-dep-coverage.ts';
 
 function makeScratchDir(): string {
-  const root = join(
-    os.tmpdir(),
-    `workspace-dep-coverage-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  );
-  mkdirSync(root, { recursive: true });
-  return root;
+  return mkdtempSync(join(os.tmpdir(), 'workspace-dep-coverage-'));
 }
 
 /**
@@ -52,11 +47,7 @@ interface AppFixture {
 }
 
 function makeAppsDir(fixtures: AppFixture[]): string {
-  const root = join(
-    os.tmpdir(),
-    `workspace-dep-coverage-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  );
-  mkdirSync(root, { recursive: true });
+  const root = makeScratchDir();
   for (const app of fixtures) {
     const appDir = join(root, app.name);
     mkdirSync(appDir, { recursive: true });
@@ -501,7 +492,7 @@ describe('validate-workspace-dep-coverage', () => {
     const worker = result.apps.find((a) => a.app === 'docker/worker');
     expect(worker?.manifestPath).toBe('docker/worker/package.json');
     expect(worker?.depSuggestion('@longterm-wiki/url-utils')).toBe(
-      '"file:./packages/url-utils"'
+      'file:./packages/url-utils'
     );
   });
 
@@ -516,7 +507,7 @@ describe('validate-workspace-dep-coverage', () => {
     const result = runCheck({ appsDir: scratch, ...NO_WORKER });
     const app = result.apps[0];
     expect(app.manifestPath).toBe('apps/my-app/package.json');
-    expect(app.depSuggestion('@longterm-wiki/url-utils')).toBe('"workspace:*"');
+    expect(app.depSuggestion('@longterm-wiki/url-utils')).toBe('workspace:*');
   });
 
   it('excludes *.spec.ts, *.test-d.ts, and tests/ directories from worker scan', () => {

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -471,6 +471,93 @@ describe('validate-workspace-dep-coverage', () => {
     expect(worker?.used.size).toBe(0);
   });
 
+  it('worker report uses docker/worker manifest path + file: protocol suggestion', () => {
+    // Regression guard for the misleading "add to apps/docker/worker/package.json
+    // with workspace:*" error that would lead a future contributor into
+    // reproducing QUA-605 all over again.
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'package.json'),
+      JSON.stringify({ name: 'worker', dependencies: {} })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'url.ts'),
+      `import { normalizeUrl } from '@longterm-wiki/url-utils';\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: join(workerDir, 'package.json'),
+      workerSourceDir: cruxDir,
+    });
+
+    const worker = result.apps.find((a) => a.app === 'docker/worker');
+    expect(worker?.manifestPath).toBe('docker/worker/package.json');
+    expect(worker?.depSuggestion('@longterm-wiki/url-utils')).toBe(
+      '"file:./packages/url-utils"'
+    );
+  });
+
+  it('app report uses apps/<name>/package.json path + workspace:* suggestion', () => {
+    scratch = makeAppsDir([
+      {
+        name: 'my-app',
+        files: { 'src/a.ts': `import { x } from '@longterm-wiki/url-utils';` },
+      },
+    ]);
+
+    const result = runCheck({ appsDir: scratch, ...NO_WORKER });
+    const app = result.apps[0];
+    expect(app.manifestPath).toBe('apps/my-app/package.json');
+    expect(app.depSuggestion('@longterm-wiki/url-utils')).toBe('"workspace:*"');
+  });
+
+  it('excludes *.spec.ts, *.test-d.ts, and tests/ directories from worker scan', () => {
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, 'package.json'),
+      JSON.stringify({ name: 'worker', dependencies: {} })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    mkdirSync(join(cruxDir, 'tests'), { recursive: true });
+    // All three should be excluded:
+    writeFileSync(
+      join(cruxDir, 'lib', 'x.spec.ts'),
+      `import { a } from '@longterm-wiki/url-utils';\n`
+    );
+    writeFileSync(
+      join(cruxDir, 'lib', 'y.test-d.ts'),
+      `import { b } from '@longterm-wiki/id-utils';\n`
+    );
+    writeFileSync(
+      join(cruxDir, 'tests', 'z.ts'),
+      `import { c } from '@longterm-wiki/factbase';\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: join(workerDir, 'package.json'),
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(true);
+    const worker = result.apps.find((a) => a.app === 'docker/worker');
+    expect(worker?.used.size).toBe(0);
+  });
+
   it('skips the worker check entirely when the manifest is missing', () => {
     scratch = makeScratchDir();
     const result = runCheck({

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -53,7 +53,7 @@
  * commented-out *import statement* (e.g. `// import { x } from '@longterm-wiki/EXAMPLE'`)
  * is still flagged — treating that as a real import is intentional since
  * commented-out code should be removed, not left behind. (Note: EXAMPLE is
- * uppercase so this doctring itself doesn't match the regex below, which
+ * uppercase so this docstring itself doesn't match the regex below, which
  * restricts package names to lowercase per npm naming rules.)
  *
  * Why "any section" and not just `dependencies`: the Dockerfiles in this
@@ -101,6 +101,11 @@ interface AppCoverage {
   declared: Set<string>;   // @longterm-wiki/X packages declared in any dep section
   missing: string[];       // used but not declared anywhere (blocking)
   unused: string[];        // declared but not used (warning)
+  /** Repo-relative path to the package.json that must be edited to fix a violation. */
+  manifestPath: string;
+  /** Dep string to suggest for a missing import. Apps use `workspace:*`; the
+   *  standalone worker manifest uses `file:./packages/<pkg>`. */
+  depSuggestion: (pkg: string) => string;
 }
 
 interface CheckOptions {
@@ -122,10 +127,15 @@ interface CheckResult {
 }
 
 interface ListOptions {
-  /** Skip __tests__ directories and *.test.* files. Used for crux scanning where
-   *  test imports shouldn't require deps in the worker image. */
+  /** Skip test directories (`__tests__/`, `tests/`) and test files (`*.test.*`,
+   *  `*.spec.*`, `*.test-d.*`). Used for crux scanning where test imports
+   *  shouldn't require deps in the worker image. */
   excludeTests?: boolean;
 }
+
+// Matches `foo.test.ts`, `foo.spec.ts`, `foo.test-d.ts` and their .js/.mjs/.jsx
+// siblings. Single source of truth so tests and the scanner agree.
+const TEST_FILE_RE = /\.(test|spec)(-d)?\.[a-z]+$/;
 
 function listSourceFiles(
   dir: string,
@@ -143,14 +153,14 @@ function listSourceFiles(
   for (const dirent of entries) {
     const name = dirent.name;
     if (name === 'node_modules' || name.startsWith('.')) continue;
-    if (options.excludeTests && name === '__tests__') continue;
+    if (options.excludeTests && (name === '__tests__' || name === 'tests')) continue;
     const full = join(dir, name);
     if (dirent.isDirectory()) {
       listSourceFiles(full, out, options);
     } else if (dirent.isFile()) {
       const dot = name.lastIndexOf('.');
       if (dot !== -1 && SOURCE_EXTENSIONS.has(name.slice(dot))) {
-        if (options.excludeTests && /\.test\.[a-z]+$/.test(name)) continue;
+        if (options.excludeTests && TEST_FILE_RE.test(name)) continue;
         out.push(full);
       }
     }
@@ -201,6 +211,33 @@ function readDeclaredDeps(
   return declared;
 }
 
+function scanImports(files: string[]): Set<string> {
+  const used = new Set<string>();
+  for (const file of files) {
+    let content: string;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.includes(WORKSPACE_PREFIX)) continue;
+    for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
+  }
+  return used;
+}
+
+function buildCoverage(
+  label: string,
+  manifestPath: string,
+  depSuggestion: (pkg: string) => string,
+  used: Set<string>,
+  declared: Set<string>,
+): AppCoverage {
+  const missing = [...used].filter((p) => !declared.has(p)).sort();
+  const unused = [...declared].filter((p) => !used.has(p)).sort();
+  return { app: label, used, declared, missing, unused, manifestPath, depSuggestion };
+}
+
 function analyzeApp(
   appDir: string,
   appName: string,
@@ -215,60 +252,42 @@ function analyzeApp(
     listSourceFiles(join(appDir, sub), files);
   }
 
-  const used = new Set<string>();
-  for (const file of files) {
-    let content: string;
-    try {
-      content = readFileSync(file, 'utf-8');
-    } catch {
-      continue;
-    }
-    if (!content.includes(WORKSPACE_PREFIX)) continue;
-    for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
-  }
-
-  const declared = readDeclaredDeps(pkgJson, onWarn);
-
-  const missing = [...used].filter((p) => !declared.has(p)).sort();
-  const unused = [...declared].filter((p) => !used.has(p)).sort();
-
-  return { app: appName, used, declared, missing, unused };
+  return buildCoverage(
+    appName,
+    `apps/${appName}/package.json`,
+    () => '"workspace:*"',
+    scanImports(files),
+    readDeclaredDeps(pkgJson, onWarn),
+  );
 }
 
 /**
  * Scan a source directory recursively and compare its `@longterm-wiki/*` imports
  * against an external package.json (i.e. one that is NOT the parent of the source
  * directory). Used for the worker image: `crux/` is scanned, but the manifest
- * that must declare the deps lives at `docker/worker/package.json`.
+ * that must declare the deps lives at `docker/worker/package.json` (a standalone,
+ * non-workspace manifest — so missing deps are suggested as `file:./packages/<pkg>`
+ * rather than `workspace:*`).
  */
 function analyzeExternalManifest(
   sourceDir: string,
   pkgJsonPath: string,
   label: string,
+  manifestPath: string,
+  depSuggestion: (pkg: string) => string,
   onWarn?: (message: string) => void,
 ): AppCoverage | null {
   if (!existsSync(pkgJsonPath)) return null;
   if (!existsSync(sourceDir)) return null;
 
   const files = listSourceFiles(sourceDir, [], { excludeTests: true });
-  const used = new Set<string>();
-  for (const file of files) {
-    let content: string;
-    try {
-      content = readFileSync(file, 'utf-8');
-    } catch {
-      continue;
-    }
-    if (!content.includes(WORKSPACE_PREFIX)) continue;
-    for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
-  }
-
-  const declared = readDeclaredDeps(pkgJsonPath, onWarn);
-
-  const missing = [...used].filter((p) => !declared.has(p)).sort();
-  const unused = [...declared].filter((p) => !used.has(p)).sort();
-
-  return { app: label, used, declared, missing, unused };
+  return buildCoverage(
+    label,
+    manifestPath,
+    depSuggestion,
+    scanImports(files),
+    readDeclaredDeps(pkgJsonPath, onWarn),
+  );
 }
 
 export function runCheck(options: CheckOptions = {}): CheckResult {
@@ -299,11 +318,16 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
   }
 
   // Worker image: crux/ source is copied wholesale, so its imports must be
-  // declared in docker/worker/package.json.
+  // declared in docker/worker/package.json. The worker is NOT a pnpm workspace
+  // member (the whole reason QUA-605 existed), so missing-dep suggestions use
+  // the `file:./packages/<pkg>` protocol that the Dockerfile wires up, not
+  // `workspace:*`.
   const workerReport = analyzeExternalManifest(
     workerSourceDir,
     workerPkgJson,
     'docker/worker',
+    'docker/worker/package.json',
+    (pkg) => `"file:./packages/${pkg.slice(WORKSPACE_PREFIX.length)}"`,
     onWarn,
   );
   if (workerReport) apps.push(workerReport);
@@ -328,10 +352,10 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
         console.log(`  ${c.red}${pkg}${c.reset}`);
       }
       console.log(
-        `${c.dim}  Fix: add to apps/${app.app}/package.json dependencies:${c.reset}`
+        `${c.dim}  Fix: add to ${app.manifestPath} dependencies:${c.reset}`
       );
       for (const pkg of app.missing) {
-        console.log(`${c.dim}    "${pkg}": "workspace:*"${c.reset}`);
+        console.log(`${c.dim}    "${pkg}": ${app.depSuggestion(pkg)}${c.reset}`);
       }
     }
 

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -73,7 +73,7 @@
  */
 
 import { readdirSync, readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
@@ -81,6 +81,7 @@ import { getColors } from '../lib/output.ts';
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 const SCAN_SUBDIRS = ['src', 'scripts'] as const;
 const WORKSPACE_PREFIX = '@longterm-wiki/';
+const WORKER_MANIFEST_PATH = 'docker/worker/package.json';
 const DEP_SECTIONS = [
   'dependencies',
   'devDependencies',
@@ -103,7 +104,8 @@ interface AppCoverage {
   unused: string[];        // declared but not used (warning)
   /** Repo-relative path to the package.json that must be edited to fix a violation. */
   manifestPath: string;
-  /** Dep string to suggest for a missing import. Apps use `workspace:*`; the
+  /** Bare dep-spec to suggest for a missing import (without surrounding JSON
+   *  quotes — those are added at print time). Apps use `workspace:*`; the
    *  standalone worker manifest uses `file:./packages/<pkg>`. */
   depSuggestion: (pkg: string) => string;
 }
@@ -255,26 +257,22 @@ function analyzeApp(
   return buildCoverage(
     appName,
     `apps/${appName}/package.json`,
-    () => '"workspace:*"',
+    () => 'workspace:*',
     scanImports(files),
     readDeclaredDeps(pkgJson, onWarn),
   );
 }
 
 /**
- * Scan a source directory recursively and compare its `@longterm-wiki/*` imports
- * against an external package.json (i.e. one that is NOT the parent of the source
- * directory). Used for the worker image: `crux/` is scanned, but the manifest
- * that must declare the deps lives at `docker/worker/package.json` (a standalone,
- * non-workspace manifest — so missing deps are suggested as `file:./packages/<pkg>`
- * rather than `workspace:*`).
+ * Scan `crux/` and compare its `@longterm-wiki/*` imports against
+ * `docker/worker/package.json`. The worker manifest is NOT a pnpm workspace
+ * member (the reason QUA-605 existed), so missing-dep suggestions use the
+ * `file:./packages/<pkg>` protocol that the Dockerfile wires up, not
+ * `workspace:*`.
  */
-function analyzeExternalManifest(
+function analyzeWorkerManifest(
   sourceDir: string,
   pkgJsonPath: string,
-  label: string,
-  manifestPath: string,
-  depSuggestion: (pkg: string) => string,
   onWarn?: (message: string) => void,
 ): AppCoverage | null {
   if (!existsSync(pkgJsonPath)) return null;
@@ -282,9 +280,9 @@ function analyzeExternalManifest(
 
   const files = listSourceFiles(sourceDir, [], { excludeTests: true });
   return buildCoverage(
-    label,
-    manifestPath,
-    depSuggestion,
+    dirname(WORKER_MANIFEST_PATH),  // "docker/worker"
+    WORKER_MANIFEST_PATH,
+    (pkg) => `file:./packages/${pkg.slice(WORKSPACE_PREFIX.length)}`,
     scanImports(files),
     readDeclaredDeps(pkgJsonPath, onWarn),
   );
@@ -294,7 +292,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
   const c = getColors();
   const appsDir = options.appsDir ?? join(PROJECT_ROOT, 'apps');
   const workerPkgJson =
-    options.workerPkgJson ?? join(PROJECT_ROOT, 'docker/worker/package.json');
+    options.workerPkgJson ?? join(PROJECT_ROOT, WORKER_MANIFEST_PATH);
   const workerSourceDir = options.workerSourceDir ?? join(PROJECT_ROOT, 'crux');
   const onWarn = options.onWarn ?? ((msg) => console.log(`${c.yellow}${msg}${c.reset}`));
 
@@ -317,19 +315,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     if (report) apps.push(report);
   }
 
-  // Worker image: crux/ source is copied wholesale, so its imports must be
-  // declared in docker/worker/package.json. The worker is NOT a pnpm workspace
-  // member (the whole reason QUA-605 existed), so missing-dep suggestions use
-  // the `file:./packages/<pkg>` protocol that the Dockerfile wires up, not
-  // `workspace:*`.
-  const workerReport = analyzeExternalManifest(
-    workerSourceDir,
-    workerPkgJson,
-    'docker/worker',
-    'docker/worker/package.json',
-    (pkg) => `"file:./packages/${pkg.slice(WORKSPACE_PREFIX.length)}"`,
-    onWarn,
-  );
+  const workerReport = analyzeWorkerManifest(workerSourceDir, workerPkgJson, onWarn);
   if (workerReport) apps.push(workerReport);
 
   let errors = 0;
@@ -355,7 +341,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
         `${c.dim}  Fix: add to ${app.manifestPath} dependencies:${c.reset}`
       );
       for (const pkg of app.missing) {
-        console.log(`${c.dim}    "${pkg}": ${app.depSuggestion(pkg)}${c.reset}`);
+        console.log(`${c.dim}    "${pkg}": "${app.depSuggestion(pkg)}"${c.reset}`);
       }
     }
 

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -5,6 +5,10 @@
  * `apps/<name>/src/` or `apps/<name>/scripts/` is declared in that app's
  * `package.json` (in any dependency section).
  *
+ * Also validates the worker Docker image: every `@longterm-wiki/*` package
+ * imported from `crux/` (which `Dockerfile.worker` copies wholesale into the
+ * image) must be declared in `docker/worker/package.json`.
+ *
  * ## Why this exists
  *
  * pnpm's workspace hoisting makes undeclared workspace imports work locally
@@ -14,13 +18,16 @@
  * import will pass every local and CI check, then fail at runtime inside the
  * Docker container with `ERR_MODULE_NOT_FOUND`.
  *
- * This bug class has recurred three times (see QUA-598):
+ * This bug class has recurred four times:
  *   - `@longterm-wiki/id-utils` (earliest incident, referenced in QUA-449)
  *   - `@longterm-wiki/factbase` (2026-04-14, QUA-449)
- *   - `@longterm-wiki/url-utils` (2026-04-18, QUA-598)
+ *   - `@longterm-wiki/url-utils` in wiki-server (2026-04-18, QUA-598)
+ *   - `@longterm-wiki/url-utils` in the worker image (2026-04-19, QUA-605) —
+ *     missed by the earlier validator because it only covered apps/*, not
+ *     the standalone worker manifest at `docker/worker/package.json`.
  *
  * Each previous occurrence was fixed instance-by-instance. This validator is
- * the systemic fix — a blocking gate check so the 4th recurrence is impossible.
+ * the systemic fix — a blocking gate check so the 5th recurrence is impossible.
  *
  * ## What it checks
  *
@@ -32,13 +39,22 @@
  *      optionalDependencies).
  *   3. Fail if any used package is not declared in any section.
  *
+ * For `docker/worker/package.json` (standalone, not a workspace member):
+ *   1. Scan `crux/` recursively (excluding `*.test.*` and `__tests__/`) for
+ *      any `@longterm-wiki/<pkg>` import. The worker Dockerfile copies all of
+ *      `crux/` into the image, so any import reachable via lazy handler load
+ *      needs the dep declared.
+ *   2. Same declared-vs-used comparison as apps.
+ *
  * Imports in scope: quote-anchored `from '@longterm-wiki/X'`, `import('…')`,
  * and `require('…')` — plus subpath imports like `@longterm-wiki/factbase/types`
  * (the package name is the first path segment). The quote anchor prevents
  * false positives from bare mentions in comments or docstrings. Note: a
- * commented-out *import statement* (e.g. `// import { x } from '@longterm-wiki/foo'`)
+ * commented-out *import statement* (e.g. `// import { x } from '@longterm-wiki/EXAMPLE'`)
  * is still flagged — treating that as a real import is intentional since
- * commented-out code should be removed, not left behind.
+ * commented-out code should be removed, not left behind. (Note: EXAMPLE is
+ * uppercase so this doctring itself doesn't match the regex below, which
+ * restricts package names to lowercase per npm naming rules.)
  *
  * Why "any section" and not just `dependencies`: the Dockerfiles in this
  * repo install with `pnpm install --filter <app>...` (no `--prod`), so
@@ -89,6 +105,11 @@ interface AppCoverage {
 
 interface CheckOptions {
   appsDir?: string;
+  /** Path to the worker's standalone package.json. Defaults to
+   *  `<repo>/docker/worker/package.json`. */
+  workerPkgJson?: string;
+  /** Source tree to scan for the worker manifest check. Defaults to `<repo>/crux`. */
+  workerSourceDir?: string;
   /** Optional warning sink so tests can assert on parse errors. */
   onWarn?: (message: string) => void;
 }
@@ -100,7 +121,17 @@ interface CheckResult {
   apps: AppCoverage[];
 }
 
-function listSourceFiles(dir: string, out: string[] = []): string[] {
+interface ListOptions {
+  /** Skip __tests__ directories and *.test.* files. Used for crux scanning where
+   *  test imports shouldn't require deps in the worker image. */
+  excludeTests?: boolean;
+}
+
+function listSourceFiles(
+  dir: string,
+  out: string[] = [],
+  options: ListOptions = {},
+): string[] {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -112,12 +143,14 @@ function listSourceFiles(dir: string, out: string[] = []): string[] {
   for (const dirent of entries) {
     const name = dirent.name;
     if (name === 'node_modules' || name.startsWith('.')) continue;
+    if (options.excludeTests && name === '__tests__') continue;
     const full = join(dir, name);
     if (dirent.isDirectory()) {
-      listSourceFiles(full, out);
+      listSourceFiles(full, out, options);
     } else if (dirent.isFile()) {
       const dot = name.lastIndexOf('.');
       if (dot !== -1 && SOURCE_EXTENSIONS.has(name.slice(dot))) {
+        if (options.excludeTests && /\.test\.[a-z]+$/.test(name)) continue;
         out.push(full);
       }
     }
@@ -202,23 +235,61 @@ function analyzeApp(
   return { app: appName, used, declared, missing, unused };
 }
 
+/**
+ * Scan a source directory recursively and compare its `@longterm-wiki/*` imports
+ * against an external package.json (i.e. one that is NOT the parent of the source
+ * directory). Used for the worker image: `crux/` is scanned, but the manifest
+ * that must declare the deps lives at `docker/worker/package.json`.
+ */
+function analyzeExternalManifest(
+  sourceDir: string,
+  pkgJsonPath: string,
+  label: string,
+  onWarn?: (message: string) => void,
+): AppCoverage | null {
+  if (!existsSync(pkgJsonPath)) return null;
+  if (!existsSync(sourceDir)) return null;
+
+  const files = listSourceFiles(sourceDir, [], { excludeTests: true });
+  const used = new Set<string>();
+  for (const file of files) {
+    let content: string;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.includes(WORKSPACE_PREFIX)) continue;
+    for (const pkg of extractWorkspaceImports(content)) used.add(pkg);
+  }
+
+  const declared = readDeclaredDeps(pkgJsonPath, onWarn);
+
+  const missing = [...used].filter((p) => !declared.has(p)).sort();
+  const unused = [...declared].filter((p) => !used.has(p)).sort();
+
+  return { app: label, used, declared, missing, unused };
+}
+
 export function runCheck(options: CheckOptions = {}): CheckResult {
   const c = getColors();
   const appsDir = options.appsDir ?? join(PROJECT_ROOT, 'apps');
+  const workerPkgJson =
+    options.workerPkgJson ?? join(PROJECT_ROOT, 'docker/worker/package.json');
+  const workerSourceDir = options.workerSourceDir ?? join(PROJECT_ROOT, 'crux');
   const onWarn = options.onWarn ?? ((msg) => console.log(`${c.yellow}${msg}${c.reset}`));
 
   console.log(
     `${c.blue}Checking workspace dependency coverage in ${appsDir}...${c.reset}\n`
   );
 
-  let appNames: string[];
+  let appNames: string[] = [];
   try {
     appNames = readdirSync(appsDir, { withFileTypes: true })
       .filter((dirent) => dirent.isDirectory())
       .map((dirent) => dirent.name);
   } catch {
-    console.log(`${c.dim}Skipping: ${appsDir} not found${c.reset}`);
-    return { passed: true, errors: 0, warnings: 0, apps: [] };
+    console.log(`${c.dim}Skipping apps: ${appsDir} not found${c.reset}`);
   }
 
   const apps: AppCoverage[] = [];
@@ -226,6 +297,16 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     const report = analyzeApp(join(appsDir, name), name, onWarn);
     if (report) apps.push(report);
   }
+
+  // Worker image: crux/ source is copied wholesale, so its imports must be
+  // declared in docker/worker/package.json.
+  const workerReport = analyzeExternalManifest(
+    workerSourceDir,
+    workerPkgJson,
+    'docker/worker',
+    onWarn,
+  );
+  if (workerReport) apps.push(workerReport);
 
   let errors = 0;
   let warnings = 0;
@@ -277,7 +358,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
       `${c.dim}Undeclared imports pass locally (pnpm hoists) but fail at runtime with ERR_MODULE_NOT_FOUND.${c.reset}`
     );
     console.log(
-      `${c.dim}See QUA-598 for the most recent incident of this class.${c.reset}`
+      `${c.dim}See QUA-598 (wiki-server) and QUA-605 (worker image) for prior incidents of this class.${c.reset}`
     );
   } else {
     console.log(

--- a/docker/worker/package.json
+++ b/docker/worker/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
+    "@longterm-wiki/url-utils": "file:./packages/url-utils",
     "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary

- `resource-ingest` jobs have been failing with `ERR_MODULE_NOT_FOUND: Cannot find package '@longterm-wiki/url-utils'` at runtime in the worker image (10 failures in the first 24h after detection, still recurring as of the latest comment). Root cause: `docker/worker/package.json` is a standalone (non-workspace) manifest that doesn't declare `@longterm-wiki/url-utils`. Commit `1f1de7a01` added `COPY packages/ ./packages/` to the image thinking that fixed it, but that COPY alone doesn't link the packages into `node_modules` — Node resolution still fails.
- **Immediate fix**: declare `@longterm-wiki/url-utils` as `file:./packages/url-utils` in `docker/worker/package.json` and copy `packages/url-utils/` into `/deps` before `pnpm install` so the `file:` reference resolves. pnpm then creates the correct `node_modules/@longterm-wiki/url-utils` symlink. Verified locally by simulating the full image build + `import('./crux/lib/search/resource-lookup.ts')`.
- **Systemic fix**: extend `validate-workspace-dep-coverage.ts` (from QUA-598) to also scan `crux/` against `docker/worker/package.json`. Previously the validator only covered `apps/*/`, so the worker manifest was an uncovered gap. A 5th recurrence of this bug class is now a blocking gate failure with the correct suggested fix (`file:./packages/<pkg>`, not `workspace:*`).

## Implementation notes

- Narrow stage-1 COPY: `COPY packages/url-utils/ ./packages/url-utils/` instead of `COPY packages/ ./packages/` — the broad copy would invalidate the pnpm install layer cache on every FactBase YAML edit (2+ MB of unrelated content).
- Only `url-utils` is imported by crux runtime code; `id-utils` and `factbase` are only imported from `crux/validate/*` and aren't reachable from the worker. The validator is the defense — it'll force-declare them the moment a real crux import appears.
- Validator cleanups from `/agent-review-pr` and `/simplify`: fixed a misleading error message (`Fix: add to apps/docker/worker/package.json workspace:*` → correct path + `file:./packages/<pkg>`), refactored to share a `scanImports`/`buildCoverage` helper, broadened `excludeTests` to cover `tests/`, `*.spec.*`, `*.test-d.*`, extracted `WORKER_MANIFEST_PATH` constant.

## Test plan

- [x] `npx tsx crux/validate/validate-workspace-dep-coverage.ts` — validator passes cleanly against the current repo (5/5 app+worker entries OK).
- [x] 25 validator unit tests (22 original + 3 new worker-specific, 0 regressions).
- [x] Simulated docker build locally (copy packages/url-utils + docker/worker/package.json into /deps, `pnpm install --prod`, copy node_modules, `import('./crux/lib/search/resource-lookup.ts')`) — resource-lookup loads with all expected exports.
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate gate --fix` — 52/52 gate checks passed.
- [ ] Post-merge: verify the next scheduled `resource-ingest` run succeeds (was failing every few minutes prior to this PR).

## Deploy Checklist

<!-- deploy-tasks:v1 -->
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly (`Dockerfile.worker`)
- [ ] `manual` After merge, confirm a fresh `resource-ingest` job succeeds against prod — `WIKI_SERVER_ENV=prod pnpm crux jobs list --type=resource-ingest --limit=5` should show at least one `succeeded` row after the new worker image rolls out
<!-- /deploy-tasks:v1 -->

Closes QUA-605
Fixes #4484
