### PR TITLE
chore: remove 39 unused default exports (audit Tier 1 cleanup)

### DIFF
--- a/apps/web/src/components/wiki/References.tsx
+++ b/apps/web/src/components/wiki/References.tsx
@@ -311,5 +311,3 @@ export function References({
     </section>
   );
 }
-
-export default References;

--- a/apps/web/src/components/wiki/ResourceLink.tsx
+++ b/apps/web/src/components/wiki/ResourceLink.tsx
@@ -179,4 +179,3 @@ export function ResourceLink({
 }
 
 export { ResourceLink as R };
-export default ResourceLink;

--- a/apps/web/src/components/wiki/ResourceTags.tsx
+++ b/apps/web/src/components/wiki/ResourceTags.tsx
@@ -57,5 +57,3 @@ export function ResourceTags({
     </span>
   );
 }
-
-export default ResourceTags;

--- a/crux/lib/rules/broken-links.ts
+++ b/crux/lib/rules/broken-links.ts
@@ -93,5 +93,3 @@ export const brokenLinksRule = createRule({
     return issues;
   },
 });
-
-export default brokenLinksRule;

--- a/crux/lib/rules/comparison-operators.ts
+++ b/crux/lib/rules/comparison-operators.ts
@@ -65,5 +65,3 @@ export const comparisonOperatorsRule = createRule({
     return issues;
   },
 });
-
-export default comparisonOperatorsRule;

--- a/crux/lib/rules/component-imports.ts
+++ b/crux/lib/rules/component-imports.ts
@@ -186,5 +186,3 @@ export const componentImportsRule = createRule({
     return null;
   },
 });
-
-export default componentImportsRule;

--- a/crux/lib/rules/component-refs.ts
+++ b/crux/lib/rules/component-refs.ts
@@ -263,5 +263,3 @@ export const componentRefsRule = createRule({
     return issues;
   },
 });
-
-export default componentRefsRule;

--- a/crux/lib/rules/consecutive-bold-labels.ts
+++ b/crux/lib/rules/consecutive-bold-labels.ts
@@ -71,5 +71,3 @@ export const consecutiveBoldLabelsRule = createRule({
     return issues;
   },
 });
-
-export default consecutiveBoldLabelsRule;

--- a/crux/lib/rules/datainfobox-entity-match.ts
+++ b/crux/lib/rules/datainfobox-entity-match.ts
@@ -65,5 +65,3 @@ export const datainfoboxEntityMatchRule = createRule({
     return issues;
   },
 });
-
-export default datainfoboxEntityMatchRule;

--- a/crux/lib/rules/dollar-signs.ts
+++ b/crux/lib/rules/dollar-signs.ts
@@ -224,5 +224,3 @@ export const dollarSignsRule = createRule({
     return issues;
   },
 });
-
-export default dollarSignsRule;

--- a/crux/lib/rules/entitylink-ids.ts
+++ b/crux/lib/rules/entitylink-ids.ts
@@ -204,5 +204,3 @@ export const entityLinkIdsRule = createRule({
     return issues;
   },
 });
-
-export default entityLinkIdsRule;

--- a/crux/lib/rules/estimate-boxes.ts
+++ b/crux/lib/rules/estimate-boxes.ts
@@ -52,5 +52,3 @@ export const estimateBoxesRule = createRule({
     return issues;
   },
 });
-
-export default estimateBoxesRule;

--- a/crux/lib/rules/external-links.ts
+++ b/crux/lib/rules/external-links.ts
@@ -350,5 +350,3 @@ export const externalLinksRule = createRule({
     return issues;
   },
 });
-
-export default externalLinksRule;

--- a/crux/lib/rules/factbase-refs.ts
+++ b/crux/lib/rules/factbase-refs.ts
@@ -289,5 +289,3 @@ export const kbfRefsRule = createRule({
     return issues;
   },
 });
-
-export default kbfRefsRule;

--- a/crux/lib/rules/factbase-subcategory-coverage.ts
+++ b/crux/lib/rules/factbase-subcategory-coverage.ts
@@ -102,5 +102,3 @@ export const kbSubcategoryCoverageRule = {
     return issues;
   },
 };
-
-export default kbSubcategoryCoverageRule;

--- a/crux/lib/rules/fake-urls.ts
+++ b/crux/lib/rules/fake-urls.ts
@@ -116,5 +116,3 @@ export const fakeUrlsRule = createRule({
     return issues;
   },
 });
-
-export default fakeUrlsRule;

--- a/crux/lib/rules/footnote-integrity.ts
+++ b/crux/lib/rules/footnote-integrity.ts
@@ -118,5 +118,3 @@ export const footnoteIntegrityRule = {
     return issues;
   },
 };
-
-export default footnoteIntegrityRule;

--- a/crux/lib/rules/hardcoded-calculations.ts
+++ b/crux/lib/rules/hardcoded-calculations.ts
@@ -100,5 +100,3 @@ export const hardcodedCalculationsRule = createRule({
     });
   },
 });
-
-export default hardcodedCalculationsRule;

--- a/crux/lib/rules/index.ts
+++ b/crux/lib/rules/index.ts
@@ -18,5 +18,3 @@ export * from './catalog.ts';
 // the named exports. `catalog.ts` re-exports rules and ONLY rules; any non-rule
 // export added there would break this cast.
 export const allRules: Rule[] = Object.values(catalog) as Rule[];
-
-export default allRules;

--- a/crux/lib/rules/internal-links.ts
+++ b/crux/lib/rules/internal-links.ts
@@ -140,5 +140,3 @@ export const internalLinksRule = createRule({
     return issues;
   },
 });
-
-export default internalLinksRule;

--- a/crux/lib/rules/jsx-in-md.ts
+++ b/crux/lib/rules/jsx-in-md.ts
@@ -73,5 +73,3 @@ export const jsxInMdRule = createRule({
     return issues;
   },
 });
-
-export default jsxInMdRule;

--- a/crux/lib/rules/markdown-lists.ts
+++ b/crux/lib/rules/markdown-lists.ts
@@ -76,5 +76,3 @@ export const markdownListsRule = createRule({
     return issues;
   },
 });
-
-export default markdownListsRule;

--- a/crux/lib/rules/no-deprecated-components.ts
+++ b/crux/lib/rules/no-deprecated-components.ts
@@ -67,5 +67,3 @@ export const noDeprecatedComponentsRule = createRule({
     return issues;
   },
 });
-
-export default noDeprecatedComponentsRule;

--- a/crux/lib/rules/no-exec-sync.ts
+++ b/crux/lib/rules/no-exec-sync.ts
@@ -77,5 +77,3 @@ export const noExecSyncRule = createRule({
     return issues;
   },
 });
-
-export default noExecSyncRule;

--- a/crux/lib/rules/numbered-footnotes.ts
+++ b/crux/lib/rules/numbered-footnotes.ts
@@ -86,5 +86,3 @@ export const numberedFootnotesRule = {
     return issues;
   },
 };
-
-export default numberedFootnotesRule;

--- a/crux/lib/rules/orphaned-footnotes.ts
+++ b/crux/lib/rules/orphaned-footnotes.ts
@@ -136,5 +136,3 @@ export const orphanedFootnotesRule = createRule({
     return issues;
   },
 });
-
-export default orphanedFootnotesRule;

--- a/crux/lib/rules/outdated-names.ts
+++ b/crux/lib/rules/outdated-names.ts
@@ -142,5 +142,3 @@ export const outdatedNamesRule = createRule({
     return issues;
   },
 });
-
-export default outdatedNamesRule;

--- a/crux/lib/rules/person-org-affiliation.ts
+++ b/crux/lib/rules/person-org-affiliation.ts
@@ -133,5 +133,3 @@ export const personOrgAffiliationRule = createRule({
     return issues;
   },
 });
-
-export default personOrgAffiliationRule;

--- a/crux/lib/rules/pipeline-artifacts.ts
+++ b/crux/lib/rules/pipeline-artifacts.ts
@@ -127,5 +127,3 @@ export const pipelineArtifactsRule = {
     return issues;
   },
 };
-
-export default pipelineArtifactsRule;

--- a/crux/lib/rules/placeholder-text.ts
+++ b/crux/lib/rules/placeholder-text.ts
@@ -157,5 +157,3 @@ export const placeholderTextRule = createRule({
     return issues;
   },
 });
-
-export default placeholderTextRule;

--- a/crux/lib/rules/placeholders.ts
+++ b/crux/lib/rules/placeholders.ts
@@ -84,5 +84,3 @@ export const placeholdersRule = createRule({
     return issues;
   },
 });
-
-export default placeholdersRule;

--- a/crux/lib/rules/prefer-entitylink.ts
+++ b/crux/lib/rules/prefer-entitylink.ts
@@ -149,5 +149,3 @@ export const preferEntityLinkRule = createRule({
     return issues;
   },
 });
-
-export default preferEntityLinkRule;

--- a/crux/lib/rules/probability-consistency.ts
+++ b/crux/lib/rules/probability-consistency.ts
@@ -246,5 +246,3 @@ export const probabilityConsistencyRule = createRule({
     return issues;
   },
 });
-
-export default probabilityConsistencyRule;

--- a/crux/lib/rules/resource-ref-integrity.ts
+++ b/crux/lib/rules/resource-ref-integrity.ts
@@ -78,5 +78,3 @@ export const resourceRefIntegrityRule = createRule({
     return issues;
   },
 });
-
-export default resourceRefIntegrityRule;

--- a/crux/lib/rules/squiggle-quality.ts
+++ b/crux/lib/rules/squiggle-quality.ts
@@ -176,5 +176,3 @@ export const squiggleQualityRule = createRule({
     return issues;
   },
 });
-
-export default squiggleQualityRule;

--- a/crux/lib/rules/table-headers.ts
+++ b/crux/lib/rules/table-headers.ts
@@ -182,5 +182,3 @@ export const tableHeadersRule = createRule({
     return issues;
   },
 });
-
-export default tableHeadersRule;

--- a/crux/lib/rules/terminology-variants.ts
+++ b/crux/lib/rules/terminology-variants.ts
@@ -106,5 +106,3 @@ export const terminologyVariantsRule = createRule({
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
-
-export default terminologyVariantsRule;

--- a/crux/lib/rules/tilde-dollar.ts
+++ b/crux/lib/rules/tilde-dollar.ts
@@ -98,5 +98,3 @@ export const tildeDollarRule = createRule({
     return issues;
   },
 });
-
-export default tildeDollarRule;

--- a/crux/lib/rules/url-safety.ts
+++ b/crux/lib/rules/url-safety.ts
@@ -96,5 +96,3 @@ export const urlSafetyRule = createRule({
     return issues;
   },
 });
-
-export default urlSafetyRule;


### PR DESCRIPTION
## Summary

Mechanical sweep removing **39 unused `export default` statements** flagged by the 2026-04-19 codebase audit (Tier 1 quick win). Zero importers anywhere in the codebase consumed any of these defaults — every consumer uses named imports.

- `crux/lib/rules/*.ts` (36 files): each rule file ended with `export default <ruleName>;`. All 36 consumers (`validate-unified.ts`, `grading/steps.ts`, `page-improver/phases/validate.ts`, `orchestrator/tools/validate-content.ts`) use `import { <ruleName>, allRules } from '.../rules/index.ts'`.
- `crux/lib/rules/index.ts`: `export default allRules;` — same story.
- `apps/web/src/components/wiki/{References,ResourceLink,ResourceTags}.tsx`: consumed via named imports in `mdx-components.tsx`. The `as R` re-export on `ResourceLink` is preserved (it's used).

Audit report: see the `/maintain-audit` output dated 2026-04-19; this addresses the "unused `default` exports flagged by knip" item.

## Test plan

- [x] Verified zero default-import consumers via grep before sweep
- [x] `apps/web` typecheck: clean
- [x] `crux w validate gate --scope=content`: 5/5 passed
- [x] No tests reference the removed identifiers (the 16 vitest failures on `factbase-resolve-entity` and `FactValueDisplay` exist on `main` independently — they're about database.json mocking, not these changes)
- [ ] CI green
