### PR TITLE
feat(E815): migrate Anthropic pledge/EA facts to FactBase + cell-level sourcing dots

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -186,9 +186,25 @@ test.describe("Render audit — critical data tables", () => {
       // a unique footer string; a second "Dario Amodei" row exists in the
       // markdown-rendered Founder Donation Pledges table below.
       const stakeholderTable = page.locator("table").filter({ hasText: "Totals (pledged stakeholders)" });
-      const dariorowText = (await stakeholderTable.locator("tr", { hasText: "Dario Amodei" }).first().textContent()) ?? "";
+      const dariorow = stakeholderTable.locator("tr", { hasText: "Dario Amodei" }).first();
+      const dariorowText = (await dariorow.textContent()) ?? "";
       expect(dariorowText, "Dario Amodei row should show 'Co-founder' category").toContain("Co-founder");
       expect(dariorowText, "Dario Amodei row should not be all em-dashes in editorial columns").toMatch(/80%/);
+
+      // Cell-level sourcing dots: three per populated row — stake (record),
+      // pledge (fact), ea-alignment (fact). Links go to /sourcing/...
+      // pages; their presence is the regression signal.
+      const dariohrefs = await dariorow
+        .locator('a[href^="/sourcing/"]')
+        .evaluateAll((els) => els.map((e) => e.getAttribute("href") ?? ""));
+      expect(
+        dariohrefs.some((h) => h.startsWith("/sourcing/equity_positions/")),
+        `Dario row should have an equity_positions sourcing link (got: ${dariohrefs.join(", ")})`,
+      ).toBe(true);
+      expect(
+        dariohrefs.filter((h) => h.startsWith("/sourcing/fact/")).length,
+        `Dario row should have 2 fact sourcing links (pledge + ea align). hrefs: ${dariohrefs.join(", ")}`,
+      ).toBe(2);
     }
   });
 });

--- a/apps/web/src/components/wiki/AnthropicStakeholdersTable.tsx
+++ b/apps/web/src/components/wiki/AnthropicStakeholdersTable.tsx
@@ -1,48 +1,22 @@
 /**
  * AnthropicStakeholdersTable — server wrapper
  *
- * Reads equity stakes from PG (via KB records at build time) and overlays
- * editorial estimates for pledge rates, EA alignment, and categories.
- * These editorial fields have no PG table — they are analytical opinions,
- * not structured data.
+ * Reads equity stakes from PG (via KB records at build time) and per-
+ * stakeholder editorial estimates (pledge rate, EA alignment probability)
+ * from FactBase. Each per-row editorial value is backed by a real
+ * `Fact` with its own fact ID, which drives a cell-level sourcing dot.
+ * Categories remain a hardcoded editorial lookup — they're short labels,
+ * not claims that benefit from an explicit sourcing check.
  */
 
-import { getKBLatest, getKBRecords, getFactBaseEntity, resolveFactBaseSlug } from "@data/factbase";
-import { getTypedEntityById, getPageById, getEntityHref, resolveId } from "@/data";
+import { getKBLatest, getKBRecords, getFactBaseEntity, resolveFactBaseSlug, getFactBaseFactSourcing } from "@data/factbase";
+import { getTypedEntityById, getPageById, getEntityHref, resolveId, getRecordVerdict } from "@/data";
 import { AnthropicStakeholdersTableClient, type EntityPreview, type Stakeholder } from "@components/wiki/AnthropicStakeholdersTableClient";
+import type { Fact } from "@longterm-wiki/factbase";
 
-// ── Editorial data (keyed by holderId slug) ─────────────────────────────────
-// These are subjective editorial assessments, not structured data.
-// Pledge rates = fraction of equity pledged to charity.
-// EA alignment = estimated probability donations go to EA-aligned causes.
-// Categories describe the stakeholder's relationship to Anthropic.
-
-const PLEDGE_RATES: Record<string, [number, number]> = {
-  "dario-amodei":             [0.8,  0.8],
-  "daniela-amodei":           [0.8,  0.8],
-  "chris-olah":               [0.8,  0.8],
-  "jack-clark":               [0.8,  0.8],
-  "tom-brown":                [0.8,  0.8],
-  "jared-kaplan":             [0.8,  0.8],
-  "sam-mccandlish":           [0.8,  0.8],
-  "jaan-tallinn":             [0.9,  0.9],
-  "dustin-moskovitz":         [0.95, 0.95],
-  "employee-equity-pool":     [0.25, 0.5],
-};
-
-const EA_ALIGNMENT: Record<string, [number, number]> = {
-  "dario-amodei":             [0.8,  0.9],
-  "daniela-amodei":           [0.8,  0.9],
-  "chris-olah":               [0.4,  0.6],
-  "jack-clark":               [0.3,  0.5],
-  "tom-brown":                [0.15, 0.3],
-  "jared-kaplan":             [0.15, 0.3],
-  "sam-mccandlish":           [0.15, 0.3],
-  "jaan-tallinn":             [0.9,  0.95],
-  "dustin-moskovitz":         [0.9,  0.95],
-  "employee-equity-pool":     [0.4,  0.7],
-};
-
+// ── Editorial categories (slug → role label) ────────────────────────────────
+// Short descriptive labels for each stakeholder's relationship to Anthropic.
+// These are display strings, not claims — no sourcing.
 const CATEGORIES: Record<string, string> = {
   "dario-amodei":             "Co-founder, CEO",
   "daniela-amodei":           "Co-founder, President",
@@ -59,12 +33,27 @@ const CATEGORIES: Record<string, string> = {
   "series-g-institutional":   "Institutional",
 };
 
+// ── Employee-equity-pool fallback ───────────────────────────────────────────
+// The employee pool is a conceptual aggregate, not a stakeholder entity, so
+// it has no FactBase entity to hang per-row facts off. Keep its pledge/EA
+// estimates hardcoded; they surface with an editorial (not-sourced) dot.
+const EMPLOYEE_POOL_PLEDGE: [number, number] = [0.25, 0.5];
+const EMPLOYEE_POOL_EA_ALIGN: [number, number] = [0.4, 0.7];
+
 /** Extract [min, max] from a KB field that may be a number, [min, max] array, or missing. */
 function parseRange(field: unknown): [number, number] | null {
   if (typeof field === "number") return [field, field];
   if (Array.isArray(field) && field.length === 2 && typeof field[0] === "number" && typeof field[1] === "number") {
     return [field[0], field[1]];
   }
+  return null;
+}
+
+/** Extract [min, max] from a FactBase Fact whose value is a number or a range. */
+function factToRange(fact: Fact | undefined): [number, number] | null {
+  if (!fact) return null;
+  if (fact.value.type === "number") return [fact.value.value, fact.value.value];
+  if (fact.value.type === "range") return [fact.value.low, fact.value.high];
   return null;
 }
 
@@ -122,32 +111,32 @@ export async function AnthropicStakeholdersTable() {
   // Build entity previews for holders that have wiki pages
   const entityPreviews: Record<string, EntityPreview> = {};
   for (const rec of equityRecords) {
-    const holderSlug = rec.fields.holder;
-    if (typeof holderSlug !== "string") continue;
-    const entity = getTypedEntityById(holderSlug);
-    const page = getPageById(holderSlug);
+    const holderRef = rec.fields.holder;
+    if (typeof holderRef !== "string") continue;
+    const entity = getTypedEntityById(holderRef);
+    const page = getPageById(holderRef);
     if (!entity) continue;
-    const href = getEntityHref(holderSlug, entity.entityType);
+    const href = getEntityHref(holderRef, entity.entityType);
     const preview: EntityPreview = {
-      title: entity.title || holderSlug,
+      title: entity.title || holderRef,
       type: entity.entityType,
       description: page?.description || entity.description,
       href,
     };
     entityPreviews[href] = preview;
     // Also index by wiki page ID URL so /wiki/E123 stakeholder links resolve
-    const tbEnt = getTypedEntityById(holderSlug);
-    if (tbEnt?.wikiId) {
-      entityPreviews[`/wiki/${tbEnt.wikiId}`] = preview;
+    if (entity.wikiId) {
+      entityPreviews[`/wiki/${entity.wikiId}`] = preview;
     }
   }
 
-  // Transform equity records into stakeholder rows, overlaying editorial data
+  // Transform equity records into stakeholder rows. Per-row editorial values
+  // (pledge, EA alignment) come from FactBase facts on the stakeholder's
+  // entity; each fact's id drives a cell-level sourcing dot.
   const stakeholders: Stakeholder[] = equityRecords.map((record) => {
     // record.fields.holder may be either a slug ("dario-amodei") or a stableId
-    // ("sid_ENl8sgChDQ") depending on FK resolution state. Editorial lookups
-    // below (PLEDGE_RATES, EA_ALIGNMENT, CATEGORIES) are keyed by slug, so
-    // resolve to the slug form up-front.
+    // ("sid_ENl8sgChDQ") depending on FK resolution state. Normalize to slug
+    // up-front so editorial lookups (CATEGORIES) and FactBase lookups line up.
     const holderRef = typeof record.fields.holder === "string" ? record.fields.holder : record.key;
     const holderSlug = resolveId(holderRef);
     const name = resolveHolderName(holderSlug);
@@ -157,13 +146,40 @@ export async function AnthropicStakeholdersTable() {
 
     const category = CATEGORIES[holderSlug] ?? "Investor";
 
-    const pledge = PLEDGE_RATES[holderSlug];
-    const pledgeMin = pledge ? pledge[0] : 0;
-    const pledgeMax = pledge ? pledge[1] : 0;
+    // Look up per-stakeholder FactBase facts. Employee pool has no FB entity,
+    // so fall back to the hardcoded aggregate estimate and surface no dot.
+    const pledgeFact = getKBLatest(holderSlug, "equity-pledge-fraction");
+    const eaAlignFact = getKBLatest(holderSlug, "ea-alignment-estimate");
 
-    const ea = EA_ALIGNMENT[holderSlug];
-    const eaAlignMin = ea ? ea[0] : 0;
-    const eaAlignMax = ea ? ea[1] : 0;
+    let pledgeMin = 0;
+    let pledgeMax = 0;
+    let eaAlignMin = 0;
+    let eaAlignMax = 0;
+    const isEmployeePool = holderSlug === "employee-equity-pool";
+
+    const pledgeRange = factToRange(pledgeFact);
+    if (pledgeRange) {
+      [pledgeMin, pledgeMax] = pledgeRange;
+    } else if (isEmployeePool) {
+      [pledgeMin, pledgeMax] = EMPLOYEE_POOL_PLEDGE;
+    }
+
+    const eaRange = factToRange(eaAlignFact);
+    if (eaRange) {
+      [eaAlignMin, eaAlignMax] = eaRange;
+    } else if (isEmployeePool) {
+      [eaAlignMin, eaAlignMax] = EMPLOYEE_POOL_EA_ALIGN;
+    }
+
+    // Resolve sourcing state for each cell. `null` means no verdict available
+    // (renders as the default "not run" dot); `undefined` means there isn't
+    // even a fact to check (editorial-only — the client renders a distinct
+    // marker instead of a dot).
+    const stakeVerdict = getRecordVerdict("equity_positions", record.key)?.verdict ?? null;
+    const pledgeFactId = pledgeFact?.id;
+    const pledgeVerdict = pledgeFactId ? getFactBaseFactSourcing(pledgeFactId) ?? null : null;
+    const eaAlignFactId = eaAlignFact?.id;
+    const eaAlignVerdict = eaAlignFactId ? getFactBaseFactSourcing(eaAlignFactId) ?? null : null;
 
     // Build link from entity slug
     let link: string | undefined;
@@ -186,8 +202,24 @@ export async function AnthropicStakeholdersTable() {
     const notes = typeof record.fields.notes === "string" ? record.fields.notes : undefined;
 
     return {
-      name, category, stakeMin, stakeMax, pledgeMin, pledgeMax,
-      eaAlignMin, eaAlignMax, link, notes, includeInTotal,
+      name,
+      category,
+      stakeMin,
+      stakeMax,
+      pledgeMin,
+      pledgeMax,
+      eaAlignMin,
+      eaAlignMax,
+      link,
+      notes,
+      includeInTotal,
+      // Sourcing metadata — consumed by the client to render cell-level dots
+      equityRecordKey: record.key,
+      stakeVerdict,
+      pledgeFactId,
+      pledgeVerdict,
+      eaAlignFactId,
+      eaAlignVerdict,
     };
   });
 

--- a/apps/web/src/components/wiki/AnthropicStakeholdersTable.tsx
+++ b/apps/web/src/components/wiki/AnthropicStakeholdersTable.tsx
@@ -171,15 +171,18 @@ export async function AnthropicStakeholdersTable() {
       [eaAlignMin, eaAlignMax] = EMPLOYEE_POOL_EA_ALIGN;
     }
 
-    // Resolve sourcing state for each cell. `null` means no verdict available
-    // (renders as the default "not run" dot); `undefined` means there isn't
-    // even a fact to check (editorial-only — the client renders a distinct
-    // marker instead of a dot).
-    const stakeVerdict = getRecordVerdict("equity_positions", record.key)?.verdict ?? null;
-    const pledgeFactId = pledgeFact?.id;
-    const pledgeVerdict = pledgeFactId ? getFactBaseFactSourcing(pledgeFactId) ?? null : null;
-    const eaAlignFactId = eaAlignFact?.id;
-    const eaAlignVerdict = eaAlignFactId ? getFactBaseFactSourcing(eaAlignFactId) ?? null : null;
+    // `verdict: null` = fact/record exists but unchecked (neutral dot).
+    // `source: undefined` = no fact at all (no dot — purely editorial cell).
+    const stakeSource = {
+      id: record.key,
+      verdict: getRecordVerdict("equity_positions", record.key)?.verdict ?? null,
+    };
+    const pledgeSource = pledgeFact
+      ? { id: pledgeFact.id, verdict: getFactBaseFactSourcing(pledgeFact.id) ?? null }
+      : undefined;
+    const eaAlignSource = eaAlignFact
+      ? { id: eaAlignFact.id, verdict: getFactBaseFactSourcing(eaAlignFact.id) ?? null }
+      : undefined;
 
     // Build link from entity slug
     let link: string | undefined;
@@ -213,13 +216,9 @@ export async function AnthropicStakeholdersTable() {
       link,
       notes,
       includeInTotal,
-      // Sourcing metadata — consumed by the client to render cell-level dots
-      equityRecordKey: record.key,
-      stakeVerdict,
-      pledgeFactId,
-      pledgeVerdict,
-      eaAlignFactId,
-      eaAlignVerdict,
+      stakeSource,
+      pledgeSource,
+      eaAlignSource,
     };
   });
 

--- a/apps/web/src/components/wiki/AnthropicStakeholdersTableClient.tsx
+++ b/apps/web/src/components/wiki/AnthropicStakeholdersTableClient.tsx
@@ -18,6 +18,11 @@ import {
   Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { SourcingDot } from "@/components/sourcing/SourcingDot";
+import {
+  factbaseVerdictToStatus,
+  recordVerdictToStatus,
+} from "@/components/sourcing/sourcing-status";
 import { cn } from "@/lib/utils";
 
 // ─── Exported types (used by server wrapper) ─────────────────────────────────
@@ -57,6 +62,54 @@ export interface Stakeholder {
   link?: string;
   notes?: string;
   includeInTotal?: boolean;
+  // Sourcing metadata — resolved server-side; the client just renders dots.
+  // `null` = fact/record exists but is unchecked. `undefined` = no underlying
+  // fact, so the cell's value is purely editorial (no dot rendered).
+  equityRecordKey: string;
+  stakeVerdict: string | null;
+  pledgeFactId?: string;
+  pledgeVerdict: string | null;
+  eaAlignFactId?: string;
+  eaAlignVerdict: string | null;
+}
+
+// ─── Cell-level sourcing dot helpers ─────────────────────────────────────────
+
+function StakeSourcingDot({
+  recordKey,
+  verdict,
+}: {
+  recordKey: string;
+  verdict: string | null;
+}) {
+  return (
+    <SourcingDot
+      status={recordVerdictToStatus(verdict)}
+      originalVerdict={verdict}
+      size="sm"
+      href={`/sourcing/equity_positions/${encodeURIComponent(recordKey)}`}
+      className="ml-1"
+    />
+  );
+}
+
+function FactCellSourcingDot({
+  factId,
+  verdict,
+}: {
+  factId?: string;
+  verdict: string | null;
+}) {
+  if (!factId) return null;
+  return (
+    <SourcingDot
+      status={factbaseVerdictToStatus(verdict)}
+      originalVerdict={verdict}
+      size="sm"
+      href={`/sourcing/fact/${encodeURIComponent(factId)}`}
+      className="ml-1"
+    />
+  );
 }
 
 // ─── Formatting helpers ───────────────────────────────────────────────────────
@@ -334,11 +387,14 @@ export function AnthropicStakeholdersTableClient({
 
                   {show("stake") && (
                     <TableCell className="text-right text-sm tabular-nums">
-                      {stakeKnown ? (
-                        fmtStake(s.stakeMin, s.stakeMax)
-                      ) : (
-                        <span className="text-muted-foreground italic text-xs">Undisclosed</span>
-                      )}
+                      <span className="inline-flex items-center justify-end gap-1">
+                        {stakeKnown ? (
+                          fmtStake(s.stakeMin, s.stakeMax)
+                        ) : (
+                          <span className="text-muted-foreground italic text-xs">Undisclosed</span>
+                        )}
+                        <StakeSourcingDot recordKey={s.equityRecordKey} verdict={s.stakeVerdict} />
+                      </span>
                     </TableCell>
                   )}
 
@@ -354,23 +410,29 @@ export function AnthropicStakeholdersTableClient({
 
                   {show("pledge") && (
                     <TableCell className="text-right text-sm tabular-nums">
-                      {hasPledge ? (
-                        fmtPledge(s.pledgeMin, s.pledgeMax)
-                      ) : (
-                        <span className="text-muted-foreground">&mdash;</span>
-                      )}
+                      <span className="inline-flex items-center justify-end gap-1">
+                        {hasPledge ? (
+                          fmtPledge(s.pledgeMin, s.pledgeMax)
+                        ) : (
+                          <span className="text-muted-foreground">&mdash;</span>
+                        )}
+                        <FactCellSourcingDot factId={s.pledgeFactId} verdict={s.pledgeVerdict} />
+                      </span>
                     </TableCell>
                   )}
 
                   {show("eaAlign") && (
                     <TableCell className="text-right">
-                      {s.eaAlignMax > 0 ? (
-                        <Badge variant="outline" className={cn("text-[10px] whitespace-nowrap", eaCls)}>
-                          {fmtEaAlign(s.eaAlignMin, s.eaAlignMax)}&nbsp;&middot;&nbsp;{eaLabel}
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground text-sm">&mdash;</span>
-                      )}
+                      <span className="inline-flex items-center justify-end gap-1">
+                        {s.eaAlignMax > 0 ? (
+                          <Badge variant="outline" className={cn("text-[10px] whitespace-nowrap", eaCls)}>
+                            {fmtEaAlign(s.eaAlignMin, s.eaAlignMax)}&nbsp;&middot;&nbsp;{eaLabel}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">&mdash;</span>
+                        )}
+                        <FactCellSourcingDot factId={s.eaAlignFactId} verdict={s.eaAlignVerdict} />
+                      </span>
                     </TableCell>
                   )}
 

--- a/apps/web/src/components/wiki/AnthropicStakeholdersTableClient.tsx
+++ b/apps/web/src/components/wiki/AnthropicStakeholdersTableClient.tsx
@@ -50,6 +50,15 @@ const COLUMN_CONFIG: Array<{ key: ColKey; shortLabel: string; defaultVisible: bo
 
 // ─── Stakeholder data ─────────────────────────────────────────────────────────
 
+/**
+ * Cell-level sourcing handle.
+ *
+ * `undefined` on a Stakeholder field = no underlying fact/record, so the cell
+ * is purely editorial and renders no dot. `verdict: null` = fact exists but
+ * hasn't been checked yet (neutral "not checked" dot).
+ */
+export type StakeholderSource = { id: string; verdict: string | null };
+
 export interface Stakeholder {
   name: string;
   category: string;
@@ -62,52 +71,31 @@ export interface Stakeholder {
   link?: string;
   notes?: string;
   includeInTotal?: boolean;
-  // Sourcing metadata — resolved server-side; the client just renders dots.
-  // `null` = fact/record exists but is unchecked. `undefined` = no underlying
-  // fact, so the cell's value is purely editorial (no dot rendered).
-  equityRecordKey: string;
-  stakeVerdict: string | null;
-  pledgeFactId?: string;
-  pledgeVerdict: string | null;
-  eaAlignFactId?: string;
-  eaAlignVerdict: string | null;
+  stakeSource: StakeholderSource;
+  pledgeSource?: StakeholderSource;
+  eaAlignSource?: StakeholderSource;
 }
 
-// ─── Cell-level sourcing dot helpers ─────────────────────────────────────────
-
-function StakeSourcingDot({
-  recordKey,
-  verdict,
+function CellDot({
+  source,
+  kind,
 }: {
-  recordKey: string;
-  verdict: string | null;
+  source?: StakeholderSource;
+  kind: "record" | "fact";
 }) {
+  if (!source) return null;
+  const status = kind === "record"
+    ? recordVerdictToStatus(source.verdict)
+    : factbaseVerdictToStatus(source.verdict);
+  const href = kind === "record"
+    ? `/sourcing/equity_positions/${encodeURIComponent(source.id)}`
+    : `/sourcing/fact/${encodeURIComponent(source.id)}`;
   return (
     <SourcingDot
-      status={recordVerdictToStatus(verdict)}
-      originalVerdict={verdict}
+      status={status}
+      originalVerdict={source.verdict}
       size="sm"
-      href={`/sourcing/equity_positions/${encodeURIComponent(recordKey)}`}
-      className="ml-1"
-    />
-  );
-}
-
-function FactCellSourcingDot({
-  factId,
-  verdict,
-}: {
-  factId?: string;
-  verdict: string | null;
-}) {
-  if (!factId) return null;
-  return (
-    <SourcingDot
-      status={factbaseVerdictToStatus(verdict)}
-      originalVerdict={verdict}
-      size="sm"
-      href={`/sourcing/fact/${encodeURIComponent(factId)}`}
-      className="ml-1"
+      href={href}
     />
   );
 }
@@ -393,7 +381,7 @@ export function AnthropicStakeholdersTableClient({
                         ) : (
                           <span className="text-muted-foreground italic text-xs">Undisclosed</span>
                         )}
-                        <StakeSourcingDot recordKey={s.equityRecordKey} verdict={s.stakeVerdict} />
+                        <CellDot source={s.stakeSource} kind="record" />
                       </span>
                     </TableCell>
                   )}
@@ -416,7 +404,7 @@ export function AnthropicStakeholdersTableClient({
                         ) : (
                           <span className="text-muted-foreground">&mdash;</span>
                         )}
-                        <FactCellSourcingDot factId={s.pledgeFactId} verdict={s.pledgeVerdict} />
+                        <CellDot source={s.pledgeSource} kind="fact" />
                       </span>
                     </TableCell>
                   )}
@@ -431,7 +419,7 @@ export function AnthropicStakeholdersTableClient({
                         ) : (
                           <span className="text-muted-foreground text-sm">&mdash;</span>
                         )}
-                        <FactCellSourcingDot factId={s.eaAlignFactId} verdict={s.eaAlignVerdict} />
+                        <CellDot source={s.eaAlignSource} kind="fact" />
                       </span>
                     </TableCell>
                   )}

--- a/packages/factbase/data/fb-entities/chris-olah.yaml
+++ b/packages/factbase/data/fb-entities/chris-olah.yaml
@@ -39,3 +39,19 @@ facts:
     value: https://en.wikipedia.org/wiki/Chris_Olah
     source: https://www.wikidata.org/wiki/Q50358648
     notes: From Wikidata Q50358648
+
+  - id: f_LqILfwvg64
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_oxVU2XTpRV
+    property: ea-alignment-estimate
+    value: [0.4, 0.6]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Interpretability pioneer; participated in EA events;
+      safety-focused work closely aligned with EA priorities but less explicit
+      commitment to EA cause-area giving than Dario/Daniela. Moderate confidence."

--- a/packages/factbase/data/fb-entities/daniela-amodei.yaml
+++ b/packages/factbase/data/fb-entities/daniela-amodei.yaml
@@ -21,3 +21,18 @@ facts:
     value: https://en.wikipedia.org/wiki/Daniela_Amodei
     source: https://www.wikidata.org/wiki/Q119721378
     notes: From Wikidata Q119721378
+
+  - id: f_tQiNLmRZIL
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_vgq29V8MAr
+    property: ea-alignment-estimate
+    value: [0.8, 0.9]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Daniela is married to Holden Karnofsky (GiveWell
+      co-founder, now at Anthropic); strong documented EA community ties."

--- a/packages/factbase/data/fb-entities/dario-amodei.yaml
+++ b/packages/factbase/data/fb-entities/dario-amodei.yaml
@@ -36,3 +36,20 @@ facts:
     value: https://darioamodei.com/
     source: https://www.wikidata.org/wiki/Q103335665
     notes: From Wikidata Q103335665
+
+  - id: f_Z9bwckKwAI
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_606Pwh7C4Q
+    property: ea-alignment-estimate
+    value: [0.8, 0.9]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Dario is a Giving What We Can signatory with
+      documented EA community ties and an early GiveWell supporter; former
+      roommate of Holden Karnofsky. High confidence that donations flow to
+      EA-aligned causes."

--- a/packages/factbase/data/fb-entities/dustin-moskovitz.yaml
+++ b/packages/factbase/data/fb-entities/dustin-moskovitz.yaml
@@ -44,3 +44,21 @@ facts:
     value: https://en.wikipedia.org/wiki/Dustin_Moskovitz
     source: https://www.wikidata.org/wiki/Q370217
     notes: From Wikidata Q370217
+
+  - id: f_StcA4XMBiR
+    property: equity-pledge-fraction
+    value: 0.95
+    asOf: "2026-04"
+    source: https://givingpledge.org/pledger?pledgerId=177
+    notes: "Estimate based on Giving Pledge commitment (Moskovitz and Cari Tuna,
+      2010) plus $500M of Anthropic equity already moved to Good Ventures
+      nonprofit vehicle in Nov 2025. Track record: $4B+ lifetime giving through
+      Good Ventures / Open Philanthropy."
+
+  - id: f_cE6rp57HY8
+    property: ea-alignment-estimate
+    value: [0.9, 0.95]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Co-founder of Good Ventures; Open Philanthropy is
+      the single largest EA-aligned grantmaker. Very high confidence that
+      donations flow to EA-aligned causes."

--- a/packages/factbase/data/fb-entities/jaan-tallinn.yaml
+++ b/packages/factbase/data/fb-entities/jaan-tallinn.yaml
@@ -45,3 +45,21 @@ facts:
       Flourishing Fund) and Lightspeed Grants
     asOf: 2026-04
     source: https://en.wikipedia.org/wiki/Jaan_Tallinn
+
+  - id: f_WqT0yED9QY
+    property: equity-pledge-fraction
+    value: 0.9
+    asOf: "2026-04"
+    source: https://www.lesswrong.com/posts/8ojWtREJjKmyvWdDb/jaan-tallinn-s-2024-philanthropy-overview
+    notes: "Estimate based on documented giving track record — $150M+ lifetime
+      AI safety giving, primary funder of SFF and Lightspeed Grants,
+      co-founded CSER and FLI. Not a formal legal pledge."
+
+  - id: f_oVtgXAR5e5
+    property: ea-alignment-estimate
+    value: [0.9, 0.95]
+    asOf: "2026-04"
+    source: https://www.lesswrong.com/posts/8ojWtREJjKmyvWdDb/jaan-tallinn-s-2024-philanthropy-overview
+    notes: "Editorial estimate. Long documented EA/longtermist community ties;
+      funds EA-aligned orgs (SFF, Lightspeed, CSER, FLI); very high confidence
+      of EA-aligned giving."

--- a/packages/factbase/data/fb-entities/jack-clark.yaml
+++ b/packages/factbase/data/fb-entities/jack-clark.yaml
@@ -18,3 +18,19 @@ facts:
     value: https://en.wikipedia.org/wiki/Jack_Clark_(AI_policy_expert)
     source: https://www.wikidata.org/wiki/Q135111322
     notes: From Wikidata Q135111322
+
+  - id: f_sf0mYpKKLs
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_1LrZ2LnRkC
+    property: ea-alignment-estimate
+    value: [0.3, 0.5]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Responsible-AI advocate with EA-adjacent framing;
+      founded Import AI newsletter; less documented EA cause-area alignment than
+      founders with explicit EA community ties."

--- a/packages/factbase/data/fb-entities/jared-kaplan.yaml
+++ b/packages/factbase/data/fb-entities/jared-kaplan.yaml
@@ -13,3 +13,19 @@ facts:
     value: https://en.wikipedia.org/wiki/Jared_Kaplan
     source: https://www.wikidata.org/wiki/Q102649624
     notes: From Wikidata Q102649624
+
+  - id: f_ceQMMKR9xw
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_FoEx38QdKF
+    property: ea-alignment-estimate
+    value: [0.15, 0.3]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Scaling laws pioneer and safety-motivated
+      co-founder; no documented EA pledge or EA Forum activity. Low confidence
+      of EA-aligned cause-area giving."

--- a/packages/factbase/data/fb-entities/sam-mccandlish.yaml
+++ b/packages/factbase/data/fb-entities/sam-mccandlish.yaml
@@ -9,3 +9,19 @@ facts:
     value: Stanford University
     source: https://www.wikidata.org/wiki/Q105285886
     notes: From Wikidata Q105285886
+
+  - id: f_8MTYhQ6jZo
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_ZVloKY5FkQ
+    property: ea-alignment-estimate
+    value: [0.15, 0.3]
+    asOf: "2026-04"
+    notes: "Editorial estimate. Alignment researcher; no publicly documented EA
+      pledge or EA community ties. Low confidence of EA-aligned cause-area
+      giving."

--- a/packages/factbase/data/fb-entities/tom-brown.yaml
+++ b/packages/factbase/data/fb-entities/tom-brown.yaml
@@ -1,2 +1,17 @@
 entity: sid_4CY8YJCrM7
-facts: []
+facts:
+  - id: f_wBLSiXE6AQ
+    property: equity-pledge-fraction
+    value: 0.8
+    asOf: "2026-01"
+    source: https://fortune.com/2026/01/27/anthropic-billionaire-cofounders-ceo-dario-amodei-giving-away-80-percent-of-wealth-fighting-inequality-ai-revolution/
+    notes: "All seven Anthropic co-founders pledged to donate 80% of their equity
+      per Fortune's January 2026 reporting. Pledge is not legally binding."
+
+  - id: f_oENaxzRk0e
+    property: ea-alignment-estimate
+    value: [0.15, 0.3]
+    asOf: "2026-04"
+    notes: "Editorial estimate. GPT-3 lead author who chose Anthropic's safety
+      mission over other options; no documented EA pledge or EA Forum activity.
+      Low confidence of EA-aligned cause-area giving."

--- a/packages/factbase/data/properties.yaml
+++ b/packages/factbase/data/properties.yaml
@@ -489,6 +489,30 @@ properties:
       prefix: "$"
       suffix: "B"
 
+  equity-pledge-fraction:
+    name: Equity Pledge Fraction
+    description: "Fraction (0–1) of equity holdings pledged to charitable giving. 0.8 = pledged 80% to charity."
+    dataType: number
+    category: financial
+    temporal: true
+    verifiable: false
+    appliesTo: [person, organization]
+    display:
+      divisor: 0.01
+      suffix: "%"
+
+  ea-alignment-estimate:
+    name: EA Alignment Estimate
+    description: "Editorial estimate (0–1) of the probability that donations from this stakeholder flow to Effective Altruism-aligned causes. Subjective; not a factual claim."
+    dataType: number
+    category: philanthropy
+    temporal: true
+    verifiable: false
+    appliesTo: [person, organization]
+    display:
+      divisor: 0.01
+      suffix: "%"
+
   # ── Nonprofit Financial ───────────────────────────────────────
 
   annual-expenses:


### PR DESCRIPTION
## Summary

The *Anthropic Stakeholders* table embedded two editorial estimates per row — fraction of equity pledged to charity and EA-alignment probability — as hardcoded `Record<slug, [number, number]>` objects in the component source. Readers had no way to tell which figures were traceable and which were editorial guesses, and editing a number required a code change.

This PR migrates both to FactBase facts and adds cell-level sourcing dots so readers can see at a glance which numbers have been source-checked:

- **`equity-pledge-fraction`** and **`ea-alignment-estimate`** added to `packages/factbase/data/properties.yaml` (fraction 0–1, rendered as %, `verifiable: false`).
- **18 new facts** across 9 stakeholder entities (7 founders + Tallinn + Moskovitz). Founders cite Fortune's Jan-2026 pledge announcement; Tallinn cites LessWrong 2024 philanthropy overview; Moskovitz cites the Giving Pledge. EA-alignment values are explicitly editorial with reasoning in notes.
- Employee Equity Pool stays hardcoded — it's a conceptual aggregate with no backing entity. Amazon/Google/Series G have no pledge data and continue to render em-dashes.

**Cell-level sourcing dots** (three per populated row):
- **Est. Stake** → record-level dot keyed to the `equity_positions` row. Links to `/sourcing/equity_positions/<key>`.
- **Pledge %** → fact-level dot keyed to the pledge Fact ID. Links to `/sourcing/fact/<id>`.
- **EA Align %** → fact-level dot keyed to the EA-alignment Fact ID.

Cells without a backing fact (Employee Pool's hardcoded values, rows with no pledge data) render no dot — the absence is the signal that the value is editorial-only. Cells with facts but no verdict show the neutral "not checked" white dot with a tooltip and link to the sourcing detail page.

Follow-on to #4503 (the hardcoded-slug bug fix). See earlier design discussion for why row-level dots weren't the right shape here — the columns carry genuinely different provenance classes.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — 6975 tests pass
- [x] `pnpm crux w validate gate --scope=content` — all gate checks pass
- [x] `WIKI_SERVER_ENV=prod pnpm crux fb validate` — 9 pre-existing errors (none from this PR), my 18 facts validate cleanly
- [x] `npx tsc --noEmit` — clean across apps/web
- [x] `pnpm crux fb show dario-amodei` — shows `Equity Pledge Fraction 80% (2026-01)` and `EA Alignment Estimate 80%–90% (2026-04)`
- [x] Strengthened `e2e/render-audit.spec.ts` E815 test — asserts 3 sourcing links per Dario row: one `/sourcing/equity_positions/...` and two `/sourcing/fact/...`
- [x] Visually verified all 13 stakeholder rows in a local dev browser — founders render with `Co-founder` categories + correct pledge/EA values + 3 dots each; employee pool / amazon / google render with 1 stake dot and editorial values without dots

## Deploy Checklist

- [ ] `manual` Verify the `Sync Entities & Facts` workflow ran on merge and synced the 18 new facts to prod PG. The workflow auto-triggers on push to `main` for `packages/factbase/data/fb-entities/**` paths. Check the Actions tab for a successful run; then `curl -sf https://wiki-server.k8s.quantifieduncertainty.org/api/facts/export | jq '.facts."sid_zR4nW8xB2f" | map(select(.propertyId=="equity-pledge-fraction"))'` should return one fact with `value.value: 0.8`.
- [ ] `manual` After the next site deploy picks up the new component code, visit https://www.longtermwiki.com/wiki/E815 and confirm each founder row shows 3 sourcing dots (stake/pledge/ea-align) and correct Category + Pledge % + EA Align values. Until the facts sync completes, pledge/ea columns will em-dash for stakeholders whose facts haven't landed in PG yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stakeholder table now displays sourcing indicators for equity pledge and EA alignment data, making information provenance transparent.

* **Tests**
  * Enhanced test coverage for stakeholder table rendering and sourcing dot validation.

* **Chores**
  * Updated stakeholder data with equity pledge fractions and EA alignment estimates across multiple individuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->