### PR TITLE
hotfix(lint): rename remaining source-check strings in import-divisions (unblocks #4506)

### DIFF
--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -373,7 +373,7 @@ const DIVISIONS: DivisionDef[] = [
   // ---- Anthropic ----
   // Team names and descriptions sourced from https://www.anthropic.com/research
   // which lists the public research teams. Division records use the exact public
-  // team names so source-check verification succeeds.
+  // team names so sourcing verification succeeds.
   {
     idSeed: "div|anthropic|alignment-science",
     parentOrgId: ORG_IDS.ANTHROPIC,
@@ -951,7 +951,7 @@ Commands:
   list                                    Show all known divisions (default)
   sync                                    Sync divisions to wiki-server Postgres
   sync --dry-run                          Preview what would be synced without writing
-  sync --force-skip-sourcing --reason=X   Bypass source-check enforcement (audit logged)
+  sync --force-skip-sourcing --reason=X   Bypass sourcing enforcement (audit logged)
   delete-orphans --id=X,Y,Z               Delete removed division records (with things cleanup)
   delete-orphans --id=X --dry-run         Preview a delete
 


### PR DESCRIPTION
## Summary

PR #4508 (QUA-542) landed 2 hyphenated `source-check` strings in `crux/commands/import-divisions.ts` — a source comment and a CLI `--help` entry. These pushed the `validate-sourcing-lint-guard` ratchet from `1 → 3`, failing CI on release PR #4506 and blocking today's deploy.

Rename both to `sourcing` per QUA-102 / QUA-237 (the project-wide rename doc). Zero behavior change — both are dev-facing strings.

## Before / after

```diff
- // team names so source-check verification succeeds.
+ // team names so sourcing verification succeeds.

- sync --force-skip-sourcing --reason=X   Bypass source-check enforcement (audit logged)
+ sync --force-skip-sourcing --reason=X   Bypass sourcing enforcement (audit logged)
```

## Verification

```
$ npx tsx crux/validate/validate-sourcing-lint-guard.ts
Checking sourcing lint guard...
At baseline (1 references across 1503 files)
```

The remaining 1 reference is the Drizzle `sourceCheckedAt` column, frozen per QUA-303 until the DB column rename lands.

## Why not bump the baseline

Per `.claude/rules/patrol-health-gate.md` § "If you're writing code to silence a CI signal, stop" — bumping the baseline would be a symptom patch. The new refs are fresh additions today, trivially renamable to the canonical term, with no behavior change. That's the intended resolution path per QUA-102.

## Unblocks

- Release PR #4506 ("release: 2026-04-20") — CI will go green once this merges + main is updated in the release head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined help text for the sourcing enforcement bypass feature to improve terminology consistency with command naming.
  * Updated inline documentation describing team name requirements for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->