### PR TITLE
fix(QUA-648): source-check flags subject-identity mismatches

### DIFF
--- a/crux/commands/__tests__/sourcing-orchestrate.test.ts
+++ b/crux/commands/__tests__/sourcing-orchestrate.test.ts
@@ -20,7 +20,9 @@ describe('LlmResponseSchema', () => {
         reasoning: 'The source states the funding amount is $2.5 billion.',
       };
       const result = LlmResponseSchema.parse(input);
-      expect(result).toEqual(input);
+      // QUA-648: `source_subject` defaults to '' and `subject_matches_claim`
+      // is optional, so the parsed shape has them alongside the input.
+      expect(result).toEqual({ ...input, source_subject: '' });
     });
 
     it('parses boundary confidence values', () => {
@@ -81,11 +83,14 @@ describe('LlmResponseSchema', () => {
 
     it('defaults all fields when given an empty object', () => {
       const result = LlmResponseSchema.parse({});
+      // QUA-648: `source_subject` has a default; `subject_matches_claim` is
+      // optional and stays undefined (so it's dropped by `toEqual`).
       expect(result).toEqual({
         verdict: 'unverifiable',
         confidence: 0.5,
         extracted_value: '',
         reasoning: '',
+        source_subject: '',
       });
     });
   });

--- a/crux/commands/sourcing-apply-suggestions.ts
+++ b/crux/commands/sourcing-apply-suggestions.ts
@@ -45,6 +45,7 @@ import {
   storeSourcingEvidence,
   SOURCE_CHECK_CONSTANTS,
 } from '../lib/sourcing/index.ts';
+import { SOURCE_CHECK_RESPONSE_FORMAT } from '../lib/sourcing/prompt-guidelines.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -286,13 +287,7 @@ Evaluate whether this source supports the record:
 - "unverifiable": The source does not address the claim, or is off-topic.
 - "outdated": The source confirms a historically-correct-but-now-stale value.
 
-Respond with ONLY a JSON object (no markdown code fences):
-{
-  "verdict": "confirmed|contradicted|unverifiable|outdated|partial",
-  "confidence": 0.0 to 1.0,
-  "extracted_value": "What the source says about this record (quote or paraphrase)",
-  "reasoning": "Brief explanation of your verdict"
-}`;
+${SOURCE_CHECK_RESPONSE_FORMAT}`;
 }
 
 function computeNextCheckDue(verdict: string): string {

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -27,6 +27,7 @@ import {
   storeAggregateVerdict,
   SOURCE_CHECK_CONSTANTS,
 } from '../lib/sourcing/index.ts';
+import { SOURCE_CHECK_RESPONSE_FORMAT } from '../lib/sourcing/prompt-guidelines.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 import { extractQid } from '../lib/sourcing/wikidata-matcher.ts';
 
@@ -181,13 +182,9 @@ Consider:
 - If the source partially matches, mark as "partial"
 - If the source no longer addresses this data point, mark as "unverifiable"
 
-Respond with ONLY a JSON object (no markdown code fences):
-{
-  "verdict": "confirmed|contradicted|unverifiable|outdated|partial",
-  "confidence": 0.0 to 1.0,
-  "extracted_value": "What the source says about this record (quote or paraphrase)",
-  "reasoning": "Brief explanation of your verdict and whether it changed from the previous check"
-}`;
+${SOURCE_CHECK_RESPONSE_FORMAT}
+
+In addition to the guidance above, since this is a re-check, the \`reasoning\` field should briefly note whether the verdict changed from the previous check.`;
 }
 
 /**

--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -193,13 +193,8 @@ ${sourceText.slice(0, PROMPT_CONTENT_LENGTH)}
 ---
 
 Does the source text contain information about this entity? If so, does it confirm or contradict what we know?
-Respond with ONLY a JSON object (no markdown code fences):
-{
-  "verdict": "confirmed|contradicted|unverifiable|outdated|partial",
-  "confidence": 0.0 to 1.0,
-  "extracted_value": "Key facts the source mentions about this entity",
-  "reasoning": "Brief explanation of your verdict"
-}`;
+
+${SOURCE_CHECK_RESPONSE_FORMAT}`;
 }
 
 // ── Deterministic matching ──────────────────────────────────────────

--- a/crux/lib/sourcing/llm-checker.test.ts
+++ b/crux/lib/sourcing/llm-checker.test.ts
@@ -1,8 +1,20 @@
 /**
  * Tests for llm-checker.ts
  */
-import { describe, it, expect } from 'vitest';
-import { validateVerdict } from './llm-checker.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock callLlm BEFORE importing the module under test so the import binding
+// resolves to the mock. Also stub `getApiKey` to avoid env dependency.
+const mockCallLlm = vi.fn();
+vi.mock('../llm.ts', async () => {
+  const actual = await vi.importActual<typeof import('../llm.ts')>('../llm.ts');
+  return {
+    ...actual,
+    callLlm: (...args: unknown[]) => mockCallLlm(...args),
+  };
+});
+
+import { callLlmForSourcing, validateVerdict } from './llm-checker.ts';
 
 describe('validateVerdict', () => {
   it('returns valid verdicts unchanged', () => {
@@ -24,5 +36,143 @@ describe('validateVerdict', () => {
   it('returns "unverifiable" for empty/whitespace strings', () => {
     expect(validateVerdict('')).toBe('unverifiable');
     expect(validateVerdict(' ')).toBe('unverifiable');
+  });
+});
+
+// QUA-648: subject-identity downgrade.
+// The LLM is instructed to return `subject_matches_claim: false` when the
+// source is about a materially different entity (e.g., Microsoft AI when the
+// claim is about Microsoft Corp). If the LLM also returns `confirmed`, the
+// checker downgrades to `partial` and annotates the reasoning.
+describe('callLlmForSourcing — subject-identity downgrade (QUA-648)', () => {
+  const fakeClient = {} as Parameters<typeof callLlmForSourcing>[0];
+
+  beforeEach(() => {
+    mockCallLlm.mockReset();
+  });
+
+  function llmReturns(body: Record<string, unknown>) {
+    mockCallLlm.mockResolvedValue({ text: JSON.stringify(body) });
+  }
+
+  it('downgrades confirmed → partial when subject_matches_claim is false', async () => {
+    llmReturns({
+      verdict: 'confirmed',
+      confidence: 0.95,
+      extracted_value: 'CEO of Microsoft AI is Mustafa Süleyman',
+      reasoning: 'Source confirms the CEO value.',
+      source_subject: 'Microsoft AI',
+      subject_matches_claim: false,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('partial');
+    expect(result.sourceSubject).toBe('Microsoft AI');
+    expect(result.subjectMatchesClaim).toBe(false);
+    expect(result.reasoning).toContain('[subject-mismatch');
+    expect(result.reasoning).toContain('Microsoft AI');
+    expect(result.reasoning).toContain('Source confirms the CEO value.');
+  });
+
+  it('preserves confirmed when subject_matches_claim is true', async () => {
+    llmReturns({
+      verdict: 'confirmed',
+      confidence: 0.95,
+      extracted_value: 'CEO: Sam Altman',
+      reasoning: 'Matches.',
+      source_subject: 'OpenAI',
+      subject_matches_claim: true,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('confirmed');
+    expect(result.subjectMatchesClaim).toBe(true);
+    expect(result.reasoning).not.toContain('[subject-mismatch');
+  });
+
+  it('preserves confirmed when subject_matches_claim is absent (backward compat)', async () => {
+    llmReturns({
+      verdict: 'confirmed',
+      confidence: 0.95,
+      extracted_value: 'x',
+      reasoning: 'Matches.',
+      // subject_matches_claim omitted — older prompts don't request it
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('confirmed');
+    expect(result.subjectMatchesClaim).toBeUndefined();
+    expect(result.reasoning).not.toContain('[subject-mismatch');
+  });
+
+  it('does NOT downgrade non-confirmed verdicts on subject mismatch', async () => {
+    // `partial` should stay `partial` — the rule only forbids false-confirms.
+    llmReturns({
+      verdict: 'partial',
+      confidence: 0.8,
+      extracted_value: 'x',
+      reasoning: 'Partial match.',
+      source_subject: 'Microsoft AI',
+      subject_matches_claim: false,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('partial');
+    // Reasoning is not re-annotated — the downgrade fires only when we
+    // actually rewrite the verdict.
+    expect(result.reasoning).toBe('Partial match.');
+  });
+
+  it('does NOT downgrade unverifiable on subject mismatch', async () => {
+    llmReturns({
+      verdict: 'unverifiable',
+      confidence: 0.5,
+      extracted_value: '',
+      reasoning: 'Cannot verify.',
+      source_subject: 'Microsoft AI',
+      subject_matches_claim: false,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('unverifiable');
+  });
+
+  it('annotates reasoning even when source_subject is empty', async () => {
+    llmReturns({
+      verdict: 'confirmed',
+      confidence: 0.9,
+      extracted_value: 'x',
+      reasoning: 'Matches.',
+      source_subject: '',
+      subject_matches_claim: false,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('partial');
+    expect(result.reasoning).toContain('[subject-mismatch');
+    expect(result.reasoning).toContain('Matches.');
+  });
+
+  it('passes source_subject through when no downgrade is needed', async () => {
+    llmReturns({
+      verdict: 'partial',
+      confidence: 0.7,
+      extracted_value: 'x',
+      reasoning: 'Partial.',
+      source_subject: 'OpenAI',
+      subject_matches_claim: true,
+    });
+
+    const result = await callLlmForSourcing(fakeClient, 'prompt', 'label');
+
+    expect(result.verdict).toBe('partial');
+    expect(result.sourceSubject).toBe('OpenAI');
+    expect(result.subjectMatchesClaim).toBe(true);
   });
 });

--- a/crux/lib/sourcing/llm-checker.ts
+++ b/crux/lib/sourcing/llm-checker.ts
@@ -20,6 +20,10 @@ export const LlmResponseSchema = z.object({
   confidence: z.number().min(0).max(1).default(0.5),
   extracted_value: z.string().default(''),
   reasoning: z.string().default(''),
+  // QUA-648: the LLM names the source's actual subject and flags if it diverges from the claim.
+  // Both fields are optional for backward compat — pre-QUA-648 prompts don't request them.
+  source_subject: z.string().default(''),
+  subject_matches_claim: z.boolean().optional(),
 });
 
 /**
@@ -54,15 +58,37 @@ export async function callLlmForSourcing(
     };
   }
 
-  const verdict = (VALID_SOURCE_CHECK_VERDICTS as readonly string[]).includes(parsed.data.verdict)
+  let verdict = (VALID_SOURCE_CHECK_VERDICTS as readonly string[]).includes(parsed.data.verdict)
     ? parsed.data.verdict
     : 'unverifiable';
+  let reasoning = parsed.data.reasoning;
+
+  // QUA-648: defense-in-depth downgrade. The prompt instructs the LLM to
+  // return `subject_matches_claim: false` when the source is about a
+  // materially different entity than the claim (e.g. Microsoft AI vs.
+  // Microsoft), in which case `confirmed` must be downgraded to `partial`.
+  // The prompt also forbids the combination, but the LLM has shipped
+  // `confirmed` + mismatch anyway (see QUA-648 case study), so we enforce
+  // the rule here too. The downgrade is only applied to `confirmed` — if
+  // the LLM already chose `partial`/`unverifiable`/etc., the verdict stands.
+  if (
+    parsed.data.subject_matches_claim === false &&
+    verdict === 'confirmed'
+  ) {
+    verdict = 'partial';
+    const mismatchNote = parsed.data.source_subject
+      ? `[subject-mismatch: source is about "${parsed.data.source_subject}", not the claim's subject] `
+      : '[subject-mismatch: LLM flagged source subject as different from claim subject] ';
+    reasoning = `${mismatchNote}${reasoning}`;
+  }
 
   return {
     verdict,
     confidence: parsed.data.confidence,
     extractedValue: parsed.data.extracted_value,
-    reasoning: parsed.data.reasoning,
+    reasoning,
+    sourceSubject: parsed.data.source_subject || undefined,
+    subjectMatchesClaim: parsed.data.subject_matches_claim,
   };
 }
 

--- a/crux/lib/sourcing/prompt-guidelines.ts
+++ b/crux/lib/sourcing/prompt-guidelines.ts
@@ -18,6 +18,7 @@ export const SOURCE_CHECK_FALSE_POSITIVE_GUIDELINES = `IMPORTANT — avoid these
 - **Temporal mismatch**: Only compare values from the same time period. If the claim is "as of 2024" but the source discusses 2025 projections (or vice versa), that is "unverifiable" or "outdated", NOT contradicted.
 - **Source has been updated since claim was made**: If the claim has an \`asOf\` date older than the source's current data, and the source no longer shows the historical figure, that is "outdated" (source has newer information) — NOT "contradicted". Example: claim is "revenue = $0.1B as of 2023" but source now shows "$19B as of 2026". This is outdated — the source was updated, not the claim was wrong.
 - **Wrong source relevance**: The source must actually discuss the specific claim. If the source is about entity X's own page but the claim is about a person's prior employment at entity Y, the source cannot contradict that — it's "unverifiable".
+- **Subject-identity mismatch**: Before deciding on the predicate, identify the *subject* of the source. If the source is about a materially different entity than the claim — a subsidiary (e.g. "Microsoft AI" vs. "Microsoft"), a parent, a product line, a namesake, or a similarly-named-but-different organization — the verdict is at most "partial", NEVER "confirmed", even if the predicate matches. Name overlap is not enough: "OpenAI" confirming something about "OpenAI Japan" is a subject mismatch. Set \`subject_matches_claim: false\` and \`source_subject\` to what the source is actually about so this is auditable.
 - **Approximate values**: A claimed value within 10% of the source value is "partial" or "confirmed", not "contradicted". Only use "contradicted" when values clearly conflict (e.g., source says 500, claim says 2000).
 - **Rounded display values**: The claim may show a rounded display format (e.g., "$1.2B") with an exact stored value in parentheses (e.g., "exact stored value: 1,234,000,000 (i.e. ~1.23 billion)"). ALWAYS compare against the exact stored value, not the rounded display. The rounded display loses precision: "$1.2B" is the display version of "$1,234,000,000". If the source says "$1.234 billion" or "$1,234,000,000" and we display "$1.2B", that is "confirmed", NOT contradicted.
 - **Numeric format equivalence**: All of these represent the same value and should be treated as equivalent: "$1.234B", "$1.234 billion", "$1,234,000,000", "1234000000", "1.234e9". Differences in notation (compact vs. full, abbreviation vs. word, with vs. without commas) are NEVER contradictions.
@@ -50,6 +51,10 @@ export const SOURCE_CHECK_RESPONSE_FORMAT = `Respond with ONLY a JSON object (no
 {
   "verdict": "confirmed|contradicted|unverifiable|outdated|partial",
   "confidence": 0.0 to 1.0,
+  "source_subject": "Identify the primary entity/subject the source is actually about (e.g. 'Microsoft AI', 'Anthropic PBC', 'Geoffrey Hinton'). Be specific — do not just echo the claim's entity name.",
+  "subject_matches_claim": true,
   "extracted_value": "What the source actually says about this data point (quote or paraphrase)",
-  "reasoning": "Brief explanation of your verdict"
-}`;
+  "reasoning": "Brief explanation of your verdict. If subject_matches_claim is false, start by naming the mismatch (e.g. 'Source is about Microsoft AI, claim is about Microsoft Corp')."
+}
+
+Set \`subject_matches_claim: false\` whenever the source's primary subject is not the same entity the claim is about (subsidiaries, parents, products, namesakes all count as mismatches). When subjects don't match, the verdict may NOT be "confirmed" — use "partial" or "unverifiable" instead.`;

--- a/crux/lib/sourcing/types.ts
+++ b/crux/lib/sourcing/types.ts
@@ -25,6 +25,19 @@ export interface LlmSourcingResult {
   confidence: number;
   extractedValue: string;
   reasoning: string;
+  /**
+   * QUA-648: the primary entity/subject the source is actually about, as
+   * identified by the LLM. When this diverges from the claim's entity,
+   * `callLlmForSourcing` downgrades `confirmed` verdicts to `partial`.
+   */
+  sourceSubject?: string;
+  /**
+   * QUA-648: whether the LLM thinks the source's subject is the same
+   * entity the claim is about. `false` triggers the programmatic
+   * downgrade. `undefined` means the LLM didn't return the field
+   * (pre-QUA-648 prompts, or a malformed response).
+   */
+  subjectMatchesClaim?: boolean;
 }
 
 /** Category of a wiki page sourcing item */


### PR DESCRIPTION
## Summary

Fixes QUA-648.

Source-check was returning `confirmed` when the source's *subject* materially differed from the claim's entity (e.g., a Microsoft CEO fact sourced from a Microsoft AI Wikidata page). The LLM correctly noted the mismatch in its reasoning but the verdict still shipped as `confirmed @ 0.95`.

The fix is two-pronged and centralized so every source-check path picks it up:

1. **Prompt update** (`crux/lib/sourcing/prompt-guidelines.ts`): new "Subject-identity mismatch" guideline + two new required response fields — `source_subject` (what the source is actually about) and `subject_matches_claim` (boolean).
2. **Programmatic downgrade** (`crux/lib/sourcing/llm-checker.ts`): `callLlmForSourcing` now rewrites `confirmed → partial` with a `[subject-mismatch: source is about "X"]` reasoning prefix when the LLM sets `subject_matches_claim: false`. Defense-in-depth: the prompt also forbids the combination, but the LLM has shipped it anyway (QUA-648 case study), so we enforce it in code too. Only `confirmed` is affected — existing `partial`/`unverifiable`/etc. stand.

Also consolidated 3 ad-hoc inline response-format blocks (entity-check, recheck, apply-suggestions) onto the shared constant so the fix is universal.

Retro rescan of existing `confirmed` verdicts is out of scope — filed as **QUA-650**.

## Test plan

- [x] New unit tests in `crux/lib/sourcing/llm-checker.test.ts` — 7 cases covering the downgrade path, backward compat (absent field), non-`confirmed` verdict preservation (`partial`/`unverifiable` unchanged on mismatch), and the empty-`source_subject` annotation fallback.
- [x] Updated stale assertions in `crux/commands/__tests__/sourcing-orchestrate.test.ts` for the new default fields on `LlmResponseSchema`.
- [x] `pnpm test` — 6991 tests pass.
- [x] `pnpm crux w validate gate --fix` — all 53 gate checks pass (3 pre-existing advisories).
- [x] `npx tsc --noEmit -p crux/tsconfig.json` on touched files — clean (ambient baseline errors elsewhere are pre-existing).
