### PR TITLE
feat(data): add burst-targets.yaml — top 50 AI safety orgs seed list (QUA-639)

### DIFF
--- a/data/burst-targets.yaml
+++ b/data/burst-targets.yaml
@@ -86,7 +86,7 @@ targets:
 
   # Core technical AI safety research organizations.
   - slug: miri
-    name: Machine Intelligence Research Institute
+    name: MIRI
     importance_rank: 9
     estimated_size_tier: small
   - slug: redwood-research
@@ -98,7 +98,7 @@ targets:
     importance_rank: 11
     estimated_size_tier: small
   - slug: metr
-    name: METR (Model Evaluation & Threat Research)
+    name: METR
     importance_rank: 12
     estimated_size_tier: small
   - slug: far-ai
@@ -136,15 +136,15 @@ targets:
 
   # Academic AI safety centers and pipeline programs.
   - slug: chai
-    name: Center for Human-Compatible AI (CHAI)
+    name: CHAI
     importance_rank: 21
     estimated_size_tier: small
   - slug: govai
-    name: Centre for the Governance of AI
+    name: GovAI
     importance_rank: 22
     estimated_size_tier: small
   - slug: mats
-    name: ML Alignment & Theory Scholars (MATS)
+    name: MATS
     importance_rank: 23
     estimated_size_tier: small
   - slug: apart-research
@@ -152,7 +152,7 @@ targets:
     importance_rank: 24
     estimated_size_tier: small
   - slug: cser
-    name: Centre for the Study of Existential Risk (CSER)
+    name: CSER
     importance_rank: 25
     estimated_size_tier: small
 
@@ -208,7 +208,7 @@ targets:
 
   # Policy / advocacy / standards.
   - slug: cset
-    name: Center for Security and Emerging Technology (CSET)
+    name: CSET
     importance_rank: 37
     estimated_size_tier: medium
   - slug: fli

--- a/data/burst-targets.yaml
+++ b/data/burst-targets.yaml
@@ -10,17 +10,34 @@
 #   slug                  string  — matches data/entities/organizations.yaml id
 #   name                  string  — display name
 #   importance_rank       int     — 1-50 ordinal (1 = highest coverage priority).
-#                                   Rough; Ozzie-validated. Frontier labs > technical safety research >
-#                                   academic > government AISIs > policy/advocacy > field-building/funders.
-#   estimated_size_tier   enum    — coarse personnel bucket used to calibrate denominator estimation:
+#                                   Methodology: subjective coverage-value ordering as of 2026-Q2,
+#                                   weighting frontier-AI-risk relevance + active output. Clusters
+#                                   (in order): frontier labs (1-8) > technical safety research
+#                                   (9-20) > academic (21-25) > government AISIs (26-36, excl. 29)
+#                                   > policy/advocacy (29 + 37-43) > field-building/funders (44-50).
+#                                   Rough; Ozzie-validated per QUA-639 exit criteria. Expect this to
+#                                   shift after validation — the rank is a starting point, not a ruling.
+#   estimated_size_tier   enum    — coarse whole-org personnel bucket used to calibrate denominator
+#                                   estimation:
 #                                     tiny   (<10 staff)
 #                                     small  (10-50)
 #                                     medium (50-200)
 #                                     large  (200-1000)
 #                                     huge   (1000+)
 #                                   These are wiki-author intuitions, not facts; QUA-634 overwrites with
-#                                   researched estimates. Present here so the denominator command has a
-#                                   sanity-check signal and so orgs below a size floor can be fast-pathed.
+#                                   researched estimates. For multi-focus orgs (e.g. Open Philanthropy,
+#                                   Meta AI as FAIR scope) the tier is whole-org not AI-safety-specific;
+#                                   the denominator command is expected to narrow it.
+#
+# Known tradeoffs baked into this seed list:
+#   - Government AISIs (11 of 50) are over-represented relative to output — several were
+#     announced in 2024-25 with minimal confirmed staffing (Singapore, Canada, India, Australia,
+#     Korea, France). They're included for ecosystem-completeness; burst consumers should expect
+#     thin per-org denominators from these rows.
+#   - `nist-ai` is intentionally excluded — `us-aisi` is its `parentOrg` child and the safety-
+#     focused subset, so including both would double-count personnel/publications.
+#   - `pause-ai` (sid_woL5lkqLpg) is chosen over the duplicate `pauseai` (sid_qtXe9VykMz) row;
+#     the registry-side dedup is tracked separately.
 #
 # Source lists that fed this seed:
 #   - 80,000 Hours AI safety careers list
@@ -145,17 +162,21 @@ targets:
     importance_rank: 26
     estimated_size_tier: medium
   - slug: us-aisi
-    name: US AI Safety Institute
+    name: US AI Safety Institute / CAISI
     importance_rank: 27
     estimated_size_tier: small
   - slug: eu-ai-office
     name: European AI Office
     importance_rank: 28
     estimated_size_tier: medium
-  - slug: nist-ai
-    name: NIST AI (NIST AI Safety Institute)
+  # IAPS sits in the AISI/policy cluster despite being a private think tank — it's the
+  # DC-based policy-research counterpart to the government institutes. `nist-ai` was
+  # dropped here because `us-aisi` (ranked 27 above) is its parentOrg child, so both
+  # would double-count the same personnel/publications in QUA-634 denominators.
+  - slug: iaps
+    name: Institute for AI Policy and Strategy
     importance_rank: 29
-    estimated_size_tier: medium
+    estimated_size_tier: small
   - slug: japan-aisi
     name: Japan AI Safety Institute
     importance_rank: 30

--- a/data/burst-targets.yaml
+++ b/data/burst-targets.yaml
@@ -1,0 +1,246 @@
+# Burst Targets — Top 50 AI Safety Organizations
+#
+# Anchors the tiered defensive enrichment burst (QUA-637). Downstream consumers:
+#   - QUA-634: denominator estimation pass (per-org × record_type totals)
+#   - QUA-641: T1 saturation run across the same 50 orgs
+#   - QUA-642: T2 website corpus extraction pipeline
+#   - QUA-643: T3 subscription burst + per-org acceptance reopener
+#
+# Schema
+#   slug                  string  — matches data/entities/organizations.yaml id
+#   name                  string  — display name
+#   importance_rank       int     — 1-50 ordinal (1 = highest coverage priority).
+#                                   Rough; Ozzie-validated. Frontier labs > technical safety research >
+#                                   academic > government AISIs > policy/advocacy > field-building/funders.
+#   estimated_size_tier   enum    — coarse personnel bucket used to calibrate denominator estimation:
+#                                     tiny   (<10 staff)
+#                                     small  (10-50)
+#                                     medium (50-200)
+#                                     large  (200-1000)
+#                                     huge   (1000+)
+#                                   These are wiki-author intuitions, not facts; QUA-634 overwrites with
+#                                   researched estimates. Present here so the denominator command has a
+#                                   sanity-check signal and so orgs below a size floor can be fast-pathed.
+#
+# Source lists that fed this seed:
+#   - 80,000 Hours AI safety careers list
+#   - AlignmentForum-adjacent orgs
+#   - AIS Funding Map
+#   - EA Forum AI safety tag
+#   - Existing data/entities/organizations.yaml rows tagged `ai-safety`
+#
+# Every slug below corresponds to an existing TableBase entity row (id + stableId
+# already allocated in data/entities/organizations.yaml).
+
+targets:
+  # Frontier AI labs — highest-leverage coverage targets.
+  - slug: anthropic
+    name: Anthropic
+    importance_rank: 1
+    estimated_size_tier: huge
+  - slug: openai
+    name: OpenAI
+    importance_rank: 2
+    estimated_size_tier: huge
+  - slug: deepmind
+    name: Google DeepMind
+    importance_rank: 3
+    estimated_size_tier: huge
+  - slug: meta-ai
+    name: Meta AI
+    importance_rank: 4
+    estimated_size_tier: huge
+  - slug: xai
+    name: xAI
+    importance_rank: 5
+    estimated_size_tier: large
+  - slug: mistral-ai
+    name: Mistral AI
+    importance_rank: 6
+    estimated_size_tier: medium
+  - slug: deepseek
+    name: DeepSeek
+    importance_rank: 7
+    estimated_size_tier: medium
+  - slug: ssi
+    name: Safe Superintelligence Inc.
+    importance_rank: 8
+    estimated_size_tier: small
+
+  # Core technical AI safety research organizations.
+  - slug: miri
+    name: Machine Intelligence Research Institute
+    importance_rank: 9
+    estimated_size_tier: small
+  - slug: redwood-research
+    name: Redwood Research
+    importance_rank: 10
+    estimated_size_tier: small
+  - slug: apollo-research
+    name: Apollo Research
+    importance_rank: 11
+    estimated_size_tier: small
+  - slug: metr
+    name: METR (Model Evaluation & Threat Research)
+    importance_rank: 12
+    estimated_size_tier: small
+  - slug: far-ai
+    name: FAR AI
+    importance_rank: 13
+    estimated_size_tier: small
+  - slug: arc
+    name: Alignment Research Center
+    importance_rank: 14
+    estimated_size_tier: tiny
+  - slug: cais
+    name: Center for AI Safety
+    importance_rank: 15
+    estimated_size_tier: small
+  - slug: conjecture
+    name: Conjecture
+    importance_rank: 16
+    estimated_size_tier: small
+  - slug: palisade-research
+    name: Palisade Research
+    importance_rank: 17
+    estimated_size_tier: tiny
+  - slug: goodfire
+    name: Goodfire
+    importance_rank: 18
+    estimated_size_tier: small
+  - slug: elicit
+    name: Elicit
+    importance_rank: 19
+    estimated_size_tier: medium
+  - slug: epoch-ai
+    name: Epoch AI
+    importance_rank: 20
+    estimated_size_tier: small
+
+  # Academic AI safety centers and pipeline programs.
+  - slug: chai
+    name: Center for Human-Compatible AI (CHAI)
+    importance_rank: 21
+    estimated_size_tier: small
+  - slug: govai
+    name: Centre for the Governance of AI
+    importance_rank: 22
+    estimated_size_tier: small
+  - slug: mats
+    name: ML Alignment & Theory Scholars (MATS)
+    importance_rank: 23
+    estimated_size_tier: small
+  - slug: apart-research
+    name: Apart Research
+    importance_rank: 24
+    estimated_size_tier: small
+  - slug: cser
+    name: Centre for the Study of Existential Risk (CSER)
+    importance_rank: 25
+    estimated_size_tier: small
+
+  # Government AI Safety Institutes and NIST AI.
+  - slug: uk-aisi
+    name: UK AI Safety Institute
+    importance_rank: 26
+    estimated_size_tier: medium
+  - slug: us-aisi
+    name: US AI Safety Institute
+    importance_rank: 27
+    estimated_size_tier: small
+  - slug: eu-ai-office
+    name: European AI Office
+    importance_rank: 28
+    estimated_size_tier: medium
+  - slug: nist-ai
+    name: NIST AI (NIST AI Safety Institute)
+    importance_rank: 29
+    estimated_size_tier: medium
+  - slug: japan-aisi
+    name: Japan AI Safety Institute
+    importance_rank: 30
+    estimated_size_tier: small
+  - slug: singapore-aisi
+    name: Singapore AI Safety Institute
+    importance_rank: 31
+    estimated_size_tier: tiny
+  - slug: canada-aisi
+    name: Canadian AI Safety Institute
+    importance_rank: 32
+    estimated_size_tier: tiny
+  - slug: south-korea-aisi
+    name: Korea AI Safety Institute
+    importance_rank: 33
+    estimated_size_tier: tiny
+  - slug: france-inesia
+    name: INESIA (France)
+    importance_rank: 34
+    estimated_size_tier: tiny
+  - slug: australia-aisi
+    name: Australia AI Safety Institute
+    importance_rank: 35
+    estimated_size_tier: tiny
+  - slug: india-aisi
+    name: India AI Safety Institute
+    importance_rank: 36
+    estimated_size_tier: tiny
+
+  # Policy / advocacy / standards.
+  - slug: cset
+    name: Center for Security and Emerging Technology (CSET)
+    importance_rank: 37
+    estimated_size_tier: medium
+  - slug: fli
+    name: Future of Life Institute
+    importance_rank: 38
+    estimated_size_tier: small
+  - slug: centre-for-long-term-resilience
+    name: Centre for Long-Term Resilience
+    importance_rank: 39
+    estimated_size_tier: small
+  - slug: frontier-model-forum
+    name: Frontier Model Forum
+    importance_rank: 40
+    estimated_size_tier: tiny
+  - slug: controlai
+    name: ControlAI
+    importance_rank: 41
+    estimated_size_tier: tiny
+  - slug: pause-ai
+    name: PauseAI
+    importance_rank: 42
+    estimated_size_tier: small
+  - slug: saferai
+    name: SaferAI
+    importance_rank: 43
+    estimated_size_tier: tiny
+
+  # Field-building, infrastructure, and major funders.
+  - slug: horizon-institute
+    name: Horizon Institute for Public Service
+    importance_rank: 44
+    estimated_size_tier: small
+  - slug: bluedot-impact
+    name: BlueDot Impact
+    importance_rank: 45
+    estimated_size_tier: small
+  - slug: lightcone-infrastructure
+    name: Lightcone Infrastructure
+    importance_rank: 46
+    estimated_size_tier: tiny
+  - slug: 80000-hours
+    name: 80,000 Hours
+    importance_rank: 47
+    estimated_size_tier: medium
+  - slug: open-philanthropy
+    name: Open Philanthropy
+    importance_rank: 48
+    estimated_size_tier: medium
+  - slug: center-on-long-term-risk
+    name: Center on Long-Term Risk
+    importance_rank: 49
+    estimated_size_tier: tiny
+  - slug: pivotal-research
+    name: Pivotal Research
+    importance_rank: 50
+    estimated_size_tier: tiny


### PR DESCRIPTION
## Summary

Phase 2 prereq for QUA-637 (coverage-expansion burst). Adds `data/burst-targets.yaml` — the top 50 AI safety orgs that anchor denominator estimation (QUA-634), T1 saturation (QUA-641), T2 website corpus extraction (QUA-642), and T3 subscription burst (QUA-643).

## What's in the seed list

50 orgs with schema `{ slug, name, importance_rank, estimated_size_tier }`:

- **8 frontier labs** (Anthropic, OpenAI, DeepMind, xAI, Meta AI, Mistral, DeepSeek, SSI)
- **12 technical safety research orgs** (MIRI, Redwood, Apollo, METR, FAR AI, ARC, CAIS, Conjecture, Palisade, Goodfire, Elicit, Epoch AI)
- **5 academic safety centers** (CHAI, GovAI, MATS, Apart Research, CSER)
- **10 government AISIs + 1 policy think tank** (UK AISI, US AISI/CAISI, EU AI Office, IAPS, Japan/Singapore/Canada/Korea/France/Australia/India AISIs)
- **7 policy/advocacy** (CSET, FLI, CLTR, Frontier Model Forum, ControlAI, PauseAI, SaferAI)
- **7 field-building / funders** (Horizon Institute, BlueDot, Lightcone, 80k Hours, Open Philanthropy, Center on Long-Term Risk, Pivotal Research)

Every slug resolves to an existing row in `data/entities/organizations.yaml` with an allocated `stableId` — no new entity allocation required.

## Decisions baked in (documented in preamble)

- **`nist-ai` excluded**: it's `us-aisi`'s `parentOrg` and including both would double-count personnel/publications in QUA-634 denominators. `us-aisi` (the safety-focused subset) is kept at rank 27; `iaps` fills rank 29 as the policy-research counterpart.
- **`us-aisi` named "US AI Safety Institute / CAISI"** to reflect the June 2025 rename to Center for AI Standards and Innovation.
- **`pause-ai` (E553) chosen over duplicate `pauseai` (E2101)** — registry-side dedup tracked in [QUA-652](https://linear.app/quantifieduncertainty/issue/QUA-652).
- **Ranking methodology** is documented in the preamble. Order is subjective; expect Ozzie-side validation per the ticket's exit criteria.

## Validation performed

- All 50 slugs resolve to `data/entities/organizations.yaml` with `stableId` populated.
- Ranks 1–50 contiguous, no duplicate slugs or names.
- `estimated_size_tier` ∈ `{tiny, small, medium, large, huge}`.
- `pnpm crux w validate gate --scope=content` passes (13 rules, including YAML schema + temporal invariants).

## Review / simplification

- `/agent-review-pr` ran a hostile-reviewer subagent. 3 HIGH findings (NIST/USAISI double-count, stale CAISI name, pause-ai dupe) fixed in commit `review(qua-639): replace nist-ai with iaps...`; 1 Linear ticket filed (QUA-652).
- `/simplify` pass normalized display names to ecosystem-canonical short forms (MIRI, METR, CHAI, GovAI, MATS, CSER, CSET).

## Test plan

- [x] YAML parses and has exactly 50 records
- [x] Every slug resolves to an `organizations.yaml` row with `stableId`
- [x] Ranks 1–50 contiguous, no duplicates
- [x] All tier values valid
- [x] `pnpm crux w validate gate --scope=content` green
- [ ] **Ozzie-side review**: validate/prune before QUA-634 denominator estimation runs (ticket exit criteria)

Fixes QUA-639.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dataset containing detailed information on 50 organizations with unique identifiers, names, importance rankings (1–50 scale), and organizational size classifications (tiny to huge). This configuration supports enhanced data enrichment and processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->