### PR TITLE
fix(wiki-server): cap unbounded queries across 5 routes (QUA-623)

### DIFF
--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -1867,6 +1867,12 @@ export async function fetchEntityResourceLinks() {
     }
     const data = await resp.json();
     const items = data.items || [];
+    if (data.truncated) {
+      logWikiServerWarning(
+        'entityResourceLinks',
+        `export truncated at ${data.limit ?? items.length} rows — raise EXPORT_LIMIT in entity-resources.ts or add cursor pagination`,
+      );
+    }
 
     // Group by entityId
     const grouped = {};

--- a/apps/wiki-server/src/__tests__/integrity.test.ts
+++ b/apps/wiki-server/src/__tests__/integrity.test.ts
@@ -1,0 +1,102 @@
+/**
+ * QUA-623: the integrity endpoint ran 7 `SELECT DISTINCT ... WHERE NOT EXISTS`
+ * scans without LIMIT. A data-integrity regression could return a huge
+ * `missing_refs` array and OOM the response. We cap each check at
+ * MAX_MISSING_REFS and set a `truncated` flag when the cap is hit.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type SqlDispatcher, mockDbModule } from "./test-utils";
+
+/** Rows the mocked `db.execute` should return for each check. */
+let rowsByTable: Record<string, { ref: string }[]>;
+
+function resetRows() {
+  rowsByTable = {};
+}
+
+const dispatch: SqlDispatcher = (query, _params) => {
+  // Each checkDangling call composes `<original-query> LIMIT $N`. We route
+  // the query to the right synthetic result set by looking at the first
+  // recognizable table name inside it.
+  if (query.includes("FROM facts")) return rowsByTable.facts ?? [];
+  if (query.includes("FROM summaries")) return rowsByTable.summaries ?? [];
+  if (query.includes("FROM citation_quotes") && query.includes("page_id"))
+    return rowsByTable.citation_quotes_page ?? [];
+  if (query.includes("FROM citation_quotes") && query.includes("resource_id"))
+    return rowsByTable.citation_quotes_resource ?? [];
+  if (query.includes("FROM edit_logs")) return rowsByTable.edit_logs ?? [];
+  if (query.includes("FROM entities ent")) return rowsByTable.related_entries ?? [];
+  if (query.includes("FROM resource_citations")) return rowsByTable.resource_citations ?? [];
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { integrityRoute } = await import("../routes/operational/integrity.js");
+
+describe("Integrity endpoint — QUA-623 unbounded query cap", () => {
+  beforeEach(() => {
+    resetRows();
+  });
+
+  it("reports `status: clean` when all tables are consistent", async () => {
+    // All empty → clean.
+    const res = await integrityRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      issues: unknown[];
+      summary: { tables_checked: number; issues_found: number };
+    };
+    expect(body.status).toBe("clean");
+    expect(body.issues).toEqual([]);
+    expect(body.summary.tables_checked).toBe(7);
+    expect(body.summary.issues_found).toBe(0);
+  });
+
+  it("reports each dangling ref with `truncated: false` when below the cap", async () => {
+    rowsByTable.facts = [{ ref: "orphan-1" }, { ref: "orphan-2" }];
+    rowsByTable.summaries = [{ ref: "s-orphan" }];
+    const res = await integrityRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      issues: {
+        table: string;
+        missing_refs: string[];
+        count: number;
+        truncated: boolean;
+      }[];
+    };
+    expect(body.status).toBe("issues_found");
+    const facts = body.issues.find((i) => i.table === "facts");
+    expect(facts).toBeDefined();
+    expect(facts!.missing_refs).toEqual(["orphan-1", "orphan-2"]);
+    expect(facts!.count).toBe(2);
+    expect(facts!.truncated).toBe(false);
+  });
+
+  it("sets `truncated: true` and caps `missing_refs` when an issue exceeds MAX_MISSING_REFS", async () => {
+    // MAX_MISSING_REFS is 1000. Return 1001 rows so the +1 sentinel fires.
+    rowsByTable.facts = Array.from({ length: 1001 }, (_, i) => ({
+      ref: `orphan-${i}`,
+    }));
+    const res = await integrityRoute.request("/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      issues: {
+        table: string;
+        missing_refs: string[];
+        count: number;
+        truncated: boolean;
+      }[];
+    };
+    const facts = body.issues.find((i) => i.table === "facts");
+    expect(facts).toBeDefined();
+    expect(facts!.truncated).toBe(true);
+    // Capped back to MAX_MISSING_REFS (1000); the +1 sentinel row is dropped.
+    expect(facts!.missing_refs.length).toBe(1000);
+    expect(facts!.count).toBe(1000);
+  });
+});

--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -25,6 +25,7 @@ import {
   mergeCluster,
   buildReport,
   runDedup,
+  ScanTruncatedError,
   type FkColumnInfo,
 } from "../routes/wikibase/resource-dedup.js";
 import type { Sql } from "../db.js";
@@ -174,12 +175,15 @@ describe("runDedup — QUA-623 refuse-on-truncated guard", () => {
     expect(result.errors).toEqual([]);
   });
 
-  it("throws when apply=true and the scan was truncated", async () => {
+  it("throws ScanTruncatedError when apply=true and the scan was truncated", async () => {
     const rows = Array.from({ length: 4 }, (_, i) => ({
       id: `r${i}`,
       url: `https://x.test/${i}`,
       created_at: "2024-01-01",
     }));
+    await expect(runDedup(makeFakeSql(rows), true, { scanCap: 3 })).rejects.toBeInstanceOf(
+      ScanTruncatedError,
+    );
     await expect(runDedup(makeFakeSql(rows), true, { scanCap: 3 })).rejects.toThrow(
       /scan was truncated/,
     );

--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -23,8 +23,11 @@ import {
   dedupeFkColumns,
   validateIdent,
   mergeCluster,
+  buildReport,
+  runDedup,
   type FkColumnInfo,
 } from "../routes/wikibase/resource-dedup.js";
+import type { Sql } from "../db.js";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (no DB)
@@ -111,6 +114,75 @@ describe("dedupeFkColumns", () => {
       "entity_resources",
       "page_citations",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QUA-623: scan cap + truncation guard (no DB)
+// ---------------------------------------------------------------------------
+
+// Minimal fake Sql for buildReport / runDedup: routes tagged-template calls
+// based on their first literal chunk. Only what these tests exercise.
+function makeFakeSql(resourcesRows: { id: string; url: string; created_at: string }[]): Sql {
+  const fake = ((strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const firstChunk = strings[0] ?? "";
+    // loadResourceFks runs two information_schema queries; return empty.
+    if (firstChunk.includes("information_schema")) return [];
+    // buildReport's resources scan.
+    if (firstChunk.includes("FROM resources")) return resourcesRows;
+    return [];
+  }) as unknown as Sql;
+  return fake;
+}
+
+describe("buildReport — QUA-623 scan cap + truncation flag", () => {
+  it("sets truncated=false when rows fit within the cap", async () => {
+    const rows = [
+      { id: "a", url: "https://x.test/1", created_at: "2024-01-01" },
+      { id: "b", url: "https://x.test/2", created_at: "2024-01-02" },
+    ];
+    const report = await buildReport(makeFakeSql(rows), { scanCap: 5 });
+    expect(report.truncated).toBe(false);
+    expect(report.totalResources).toBe(2);
+  });
+
+  it("sets truncated=true when rows exceed the cap (sentinel detection)", async () => {
+    // Postgres returns (cap + 1) rows so the sentinel fires; buildReport
+    // should slice back to the cap and flip truncated on.
+    const rows = Array.from({ length: 4 }, (_, i) => ({
+      id: `r${i}`,
+      url: `https://x.test/${i}`,
+      created_at: "2024-01-01",
+    }));
+    const report = await buildReport(makeFakeSql(rows), { scanCap: 3 });
+    expect(report.truncated).toBe(true);
+    expect(report.totalResources).toBe(3);
+  });
+});
+
+describe("runDedup — QUA-623 refuse-on-truncated guard", () => {
+  it("returns the truncated report in dry-run (apply=false) without throwing", async () => {
+    const rows = Array.from({ length: 4 }, (_, i) => ({
+      id: `r${i}`,
+      url: `https://x.test/${i}`,
+      created_at: "2024-01-01",
+    }));
+    const result = await runDedup(makeFakeSql(rows), false, { scanCap: 3 });
+    expect(result.apply).toBe(false);
+    expect(result.report.truncated).toBe(true);
+    expect(result.merges).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("throws when apply=true and the scan was truncated", async () => {
+    const rows = Array.from({ length: 4 }, (_, i) => ({
+      id: `r${i}`,
+      url: `https://x.test/${i}`,
+      created_at: "2024-01-01",
+    }));
+    await expect(runDedup(makeFakeSql(rows), true, { scanCap: 3 })).rejects.toThrow(
+      /scan was truncated/,
+    );
   });
 });
 

--- a/apps/wiki-server/src/routes/operational/agent-sessions.ts
+++ b/apps/wiki-server/src/routes/operational/agent-sessions.ts
@@ -158,6 +158,9 @@ const agentSessionsApp = new Hono()
       const { freshMinutes } = c.req.valid("query");
       const cutoff = new Date(Date.now() - freshMinutes * 60_000);
       const db = getDrizzleDb();
+      // QUA-623: cap result set. The dedup check only needs a handful of
+      // active sessions per Linear ID; a huge result almost certainly means
+      // a bug in the caller or an unusually active ticket — 50 is plenty.
       const rows = await db
         .select({
           id: agentSessions.id,
@@ -173,7 +176,8 @@ const agentSessionsApp = new Hono()
           eq(agentSessions.status, "active"),
           gte(agentSessions.updatedAt, cutoff),
         ))
-        .orderBy(desc(agentSessions.updatedAt));
+        .orderBy(desc(agentSessions.updatedAt))
+        .limit(50);
       return c.json({ sessions: rows, freshMinutes });
     },
   )

--- a/apps/wiki-server/src/routes/operational/integrity.ts
+++ b/apps/wiki-server/src/routes/operational/integrity.ts
@@ -8,11 +8,21 @@ interface IntegrityIssue {
   target_table: string;
   missing_refs: string[];
   count: number;
+  truncated: boolean;
 }
+
+// QUA-623: cap each SELECT DISTINCT to prevent a data-integrity regression
+// from OOMing the response or hitting statement_timeout. If refs exceed the
+// cap, we return the capped list and set `truncated: true` — the number of
+// dangling refs is a red flag either way, the exact count can be re-queried.
+const MAX_MISSING_REFS = 1000;
 
 /**
  * Run a dangling-reference check and return an issue if any are found.
  * Returns null if the table is clean.
+ *
+ * The caller's SQL should NOT include its own LIMIT — we append one with a
+ * +1 sentinel to detect truncation.
  */
 async function checkDangling(
   db: ReturnType<typeof getDrizzleDb>,
@@ -21,14 +31,18 @@ async function checkDangling(
   column: string,
   targetTable: string
 ): Promise<IntegrityIssue | null> {
-  const rows = (await db.execute(query)) as Array<{ ref: string }>;
+  const capped = sql`${query} LIMIT ${MAX_MISSING_REFS + 1}`;
+  const rows = (await db.execute(capped)) as Array<{ ref: string }>;
   if (rows.length === 0) return null;
+  const truncated = rows.length > MAX_MISSING_REFS;
+  const refs = truncated ? rows.slice(0, MAX_MISSING_REFS) : rows;
   return {
     table,
     column,
     target_table: targetTable,
-    missing_refs: rows.map((r) => r.ref),
-    count: rows.length,
+    missing_refs: refs.map((r) => r.ref),
+    count: refs.length,
+    truncated,
   };
 }
 

--- a/apps/wiki-server/src/routes/operational/integrity.ts
+++ b/apps/wiki-server/src/routes/operational/integrity.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { sql } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
+import { applyTruncation } from "../shared/utils.js";
 
 interface IntegrityIssue {
   table: string;
@@ -34,14 +35,13 @@ async function checkDangling(
   const capped = sql`${query} LIMIT ${MAX_MISSING_REFS + 1}`;
   const rows = (await db.execute(capped)) as Array<{ ref: string }>;
   if (rows.length === 0) return null;
-  const truncated = rows.length > MAX_MISSING_REFS;
-  const refs = truncated ? rows.slice(0, MAX_MISSING_REFS) : rows;
+  const { items, truncated } = applyTruncation(rows, MAX_MISSING_REFS);
   return {
     table,
     column,
     target_table: targetTable,
-    missing_refs: refs.map((r) => r.ref),
-    count: refs.length,
+    missing_refs: items.map((r) => r.ref),
+    count: items.length,
     truncated,
   };
 }

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -48,6 +48,25 @@ export function noDuplicateIds(items: { id: string }[]) {
   return new Set(items.map((i) => i.id)).size === items.length;
 }
 
+/**
+ * Apply the "+1 sentinel → slice + flag" truncation pattern to a row set.
+ *
+ * Callers should `.limit(cap + 1)` the query so the sentinel fires cleanly
+ * when rows exceed the cap, then pass the resulting rows here. Returns the
+ * capped `items` array plus a `truncated` flag for the response body.
+ *
+ * Prefer this over hand-rolling the slice-and-flag — multiple sites across
+ * the codebase (resource-dedup, integrity, entity-resources, resources,
+ * entity-profile) do the same thing.
+ */
+export function applyTruncation<T>(
+  rows: T[],
+  cap: number,
+): { items: T[]; truncated: boolean } {
+  const truncated = rows.length > cap;
+  return { items: truncated ? rows.slice(0, cap) : rows, truncated };
+}
+
 /** Standard error codes for 400 responses. */
 export const VALIDATION_ERROR = "validation_error" as const;
 export const INVALID_JSON_ERROR = "invalid_json" as const;

--- a/apps/wiki-server/src/routes/tablebase/entity-profile.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-profile.ts
@@ -30,7 +30,7 @@ import {
 } from "../../schema.js";
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { resolveEntityStableId } from "../shared/entity-resolution.js";
-import { notFoundError } from "../shared/utils.js";
+import { notFoundError, applyTruncation } from "../shared/utils.js";
 import { COLUMN_DESCRIPTIONS } from "./entity-profile-descriptions.js";
 import { stripInternalColumns } from "../shared/strip-internal-columns.js";
 import type { PgTable } from "drizzle-orm/pg-core";
@@ -351,8 +351,7 @@ const entityProfileApp = new Hono()
       SECTIONS.map(async (section) => {
         try {
           const rows = await section.query(db, stableId, slug);
-          const truncated = rows.length > SECTION_ROW_LIMIT;
-          const capped = truncated ? rows.slice(0, SECTION_ROW_LIMIT) : rows;
+          const { items: capped, truncated } = applyTruncation(rows, SECTION_ROW_LIMIT);
           return {
             key: section.key,
             label: section.label,

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -196,7 +196,13 @@ const entityResourcesApp = new Hono()
   )
 
   // GET /api/entity-resources/export — all rows (for build pipeline)
+  // Capped to prevent unbounded scans on a growing table (QUA-623). Uses a
+  // +1 sentinel so `truncated` is false when the row count exactly equals
+  // the cap (vs. genuinely spilling past it). The build pipeline reads ~all
+  // rows; raise EXPORT_LIMIT if prod exceeds it and add cursor pagination
+  // before then.
   .get("/export", async (c) => {
+    const EXPORT_LIMIT = 200_000;
     const db = getDrizzleDb();
     const rows = await db
       .select({
@@ -205,9 +211,17 @@ const entityResourcesApp = new Hono()
         authoredByEntity: entityResources.authoredByEntity,
         isSubject: entityResources.isSubject,
       })
-      .from(entityResources);
+      .from(entityResources)
+      .limit(EXPORT_LIMIT + 1);
+    const truncated = rows.length > EXPORT_LIMIT;
+    const items = truncated ? rows.slice(0, EXPORT_LIMIT) : rows;
 
-    return c.json({ items: rows, total: rows.length });
+    return c.json({
+      items,
+      total: items.length,
+      truncated,
+      limit: EXPORT_LIMIT,
+    });
   })
 
   .post("/delete-batch", deleteBatchHandler(entityResources, "entity_resources"));

--- a/apps/wiki-server/src/routes/tablebase/entity-resources.ts
+++ b/apps/wiki-server/src/routes/tablebase/entity-resources.ts
@@ -6,6 +6,7 @@ import { entityResources, resources } from "../../schema.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { registerComposer, composeThing } from "../shared/compose-thing.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { applyTruncation } from "../shared/utils.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- QUA-470 Phase 4b-B.1: entity-resource composer ----
@@ -213,8 +214,7 @@ const entityResourcesApp = new Hono()
       })
       .from(entityResources)
       .limit(EXPORT_LIMIT + 1);
-    const truncated = rows.length > EXPORT_LIMIT;
-    const items = truncated ? rows.slice(0, EXPORT_LIMIT) : rows;
+    const { items, truncated } = applyTruncation(rows, EXPORT_LIMIT);
 
     return c.json({
       items,

--- a/apps/wiki-server/src/routes/tablebase/research-areas.ts
+++ b/apps/wiki-server/src/routes/tablebase/research-areas.ts
@@ -43,6 +43,15 @@ import {
 
 const MAX_PAGE_SIZE = 200;
 
+// QUA-623: safety caps on related-data subqueries. Hit today is small
+// (single-digit to low-hundreds per area), but `.limit()` prevents silent
+// 503s if the tables grow.
+const RELATED_DATA_CAP = 500;
+const TOP_GRANTS_CAP = 50;
+const FUNDING_BREAKDOWN_CAP = 200;
+const SCORES_LIST_CAP = 5_000;
+const EVALUATIONS_PER_AREA_CAP = 1_000;
+
 // Max possible standard deviation for a 1-10 scale (bimodal 50/50 split at extremes).
 // Used to normalize stdDev into a 0-1 "model agreement" metric.
 const MAX_SCORE_STDDEV = 4.5;
@@ -340,26 +349,31 @@ const researchAreasApp = new Hono()
       );
     }
 
-    // Fetch related data in parallel
+    // Fetch related data in parallel. Each subquery is capped (QUA-623) to
+    // prevent unbounded scans as these tables grow.
     const [orgs, papers, risks, children, topGrants, fundingByOrg] = await Promise.all([
       db
         .select()
         .from(researchAreaOrganizations)
-        .where(eq(researchAreaOrganizations.researchAreaId, id)),
+        .where(eq(researchAreaOrganizations.researchAreaId, id))
+        .limit(RELATED_DATA_CAP),
       db
         .select()
         .from(researchAreaPapers)
         .where(eq(researchAreaPapers.researchAreaId, id))
-        .orderBy(researchAreaPapers.sortOrder),
+        .orderBy(researchAreaPapers.sortOrder)
+        .limit(RELATED_DATA_CAP),
       db
         .select()
         .from(researchAreaRisks)
-        .where(eq(researchAreaRisks.researchAreaId, id)),
+        .where(eq(researchAreaRisks.researchAreaId, id))
+        .limit(RELATED_DATA_CAP),
       db
         .select()
         .from(researchAreas)
-        .where(eq(researchAreas.parentAreaId, id)),
-      // Top grants by amount (up to 50)
+        .where(eq(researchAreas.parentAreaId, id))
+        .limit(RELATED_DATA_CAP),
+      // Top grants by amount (cap: TOP_GRANTS_CAP)
       db
         .select({
           id: grants.id,
@@ -374,7 +388,7 @@ const researchAreasApp = new Hono()
         .innerJoin(grants, eq(grantResearchAreas.grantId, grants.id))
         .where(eq(grantResearchAreas.researchAreaId, id))
         .orderBy(sql`${grants.amount}::numeric DESC NULLS LAST`)
-        .limit(50),
+        .limit(TOP_GRANTS_CAP),
       // Funding breakdown by funder org
       db
         .select({
@@ -386,7 +400,8 @@ const researchAreasApp = new Hono()
         .innerJoin(grants, eq(grantResearchAreas.grantId, grants.id))
         .where(eq(grantResearchAreas.researchAreaId, id))
         .groupBy(grants.organizationId)
-        .orderBy(sql`COALESCE(SUM(${grants.amount}::numeric), 0) DESC`),
+        .orderBy(sql`COALESCE(SUM(${grants.amount}::numeric), 0) DESC`)
+        .limit(FUNDING_BREAKDOWN_CAP),
     ]);
 
     return c.json({
@@ -736,7 +751,8 @@ const researchAreasApp = new Hono()
         .select()
         .from(researchAreaScores)
         .where(conditions.length > 0 ? and(...conditions) : undefined)
-        .orderBy(researchAreaScores.researchAreaId, researchAreaScores.dimension);
+        .orderBy(researchAreaScores.researchAreaId, researchAreaScores.dimension)
+        .limit(SCORES_LIST_CAP);
 
       return c.json({
         scores: rows.map((r) => ({
@@ -765,12 +781,14 @@ const researchAreasApp = new Hono()
         .select()
         .from(researchAreaEvaluations)
         .where(eq(researchAreaEvaluations.researchAreaId, areaId))
-        .orderBy(researchAreaEvaluations.dimension, researchAreaEvaluations.evaluatedAt),
+        .orderBy(researchAreaEvaluations.dimension, researchAreaEvaluations.evaluatedAt)
+        .limit(EVALUATIONS_PER_AREA_CAP),
       db
         .select()
         .from(researchAreaScores)
         .where(eq(researchAreaScores.researchAreaId, areaId))
-        .orderBy(researchAreaScores.dimension),
+        .orderBy(researchAreaScores.dimension)
+        .limit(RELATED_DATA_CAP),
     ]);
 
     return c.json({

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -18,6 +18,7 @@ import type { Sql, CallableTransactionSql } from "../../db.js";
 import { beginTransaction } from "../../db.js";
 import { normalizeUrlForDedup } from "@longterm-wiki/url-utils";
 import { logger } from "../../logger.js";
+import { applyTruncation } from "../shared/utils.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,6 +62,22 @@ export interface DedupReport {
 // requires both a config bump and a confirmation it still completes under
 // the 30s statement_timeout.
 export const RESOURCES_SCAN_CAP = 500_000;
+
+/**
+ * Thrown from `runDedup` when `apply=true` is called on a truncated scan.
+ * HTTP handlers should catch this and translate to a 409 so CLI callers get
+ * an actionable message instead of a generic 500.
+ */
+export class ScanTruncatedError extends Error {
+  readonly scanCap: number;
+  constructor(scanCap: number) {
+    super(
+      `runDedup refused: resources scan was truncated at ${scanCap} rows; raise RESOURCES_SCAN_CAP or implement chunked scanning before applying.`,
+    );
+    this.name = "ScanTruncatedError";
+    this.scanCap = scanCap;
+  }
+}
 
 export interface ClusterMergeResult {
   canonicalId: string;
@@ -188,8 +205,7 @@ export async function buildReport(
     SELECT id, url, created_at::text AS created_at FROM resources
     LIMIT ${scanCap + 1}
   `;
-  const truncated = rows.length > scanCap;
-  const scanned = truncated ? rows.slice(0, scanCap) : rows;
+  const { items: scanned, truncated } = applyTruncation(rows, scanCap);
 
   type Row = { id: string; url: string; createdAt: string };
   const groups = new Map<string, Row[]>();
@@ -370,9 +386,7 @@ export async function runDedup(
   // Refuse apply=true when the scan was truncated. Clusters past the cutoff
   // would silently survive — raise RESOURCES_SCAN_CAP or chunk the scan.
   if (report.truncated) {
-    throw new Error(
-      `runDedup refused: resources scan was truncated at ${scanCap} rows; raise RESOURCES_SCAN_CAP or implement chunked scanning before applying.`,
-    );
+    throw new ScanTruncatedError(scanCap);
   }
 
   const rowsToDelete = report.clusters.reduce(

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -49,7 +49,18 @@ export interface DedupReport {
   totalResources: number;
   fkColumns: FkColumnInfo[];
   clusters: DedupCluster[];
+  /** True when the resources scan hit RESOURCES_SCAN_CAP — clusters beyond
+   *  the cap are invisible to this run. Raise the cap or switch to chunked
+   *  scanning before running apply=true. */
+  truncated: boolean;
 }
+
+// QUA-623: cap the full-table scan in buildReport(). resources is ~22k rows
+// today (well below this cap); the cap exists to prevent silent HTTP 503s if
+// the table grows. buildReport is an admin-only dedup tool — raising this
+// requires both a config bump and a confirmation it still completes under
+// the 30s statement_timeout.
+export const RESOURCES_SCAN_CAP = 500_000;
 
 export interface ClusterMergeResult {
   canonicalId: string;
@@ -162,17 +173,27 @@ export async function loadResourceFks(sql: Sql): Promise<FkColumnInfo[]> {
   });
 }
 
-export async function buildReport(sql: Sql): Promise<DedupReport> {
+export async function buildReport(
+  sql: Sql,
+  opts?: { scanCap?: number },
+): Promise<DedupReport> {
+  const scanCap = opts?.scanCap ?? RESOURCES_SCAN_CAP;
   const fkColumns = await loadResourceFks(sql);
   const uniqueCols = dedupeFkColumns(fkColumns);
 
+  // QUA-623: cap with a +1 sentinel so the caller can tell the scan was
+  // partial. Dedup apply=true should refuse to run on a truncated report —
+  // clusters past the cutoff would silently survive.
   const rows = await sql<{ id: string; url: string; created_at: string }[]>`
     SELECT id, url, created_at::text AS created_at FROM resources
+    LIMIT ${scanCap + 1}
   `;
+  const truncated = rows.length > scanCap;
+  const scanned = truncated ? rows.slice(0, scanCap) : rows;
 
   type Row = { id: string; url: string; createdAt: string };
   const groups = new Map<string, Row[]>();
-  for (const r of rows) {
+  for (const r of scanned) {
     const key = dedupKey(r.url);
     const list = groups.get(key);
     if (list) list.push({ id: r.id, url: r.url, createdAt: r.created_at });
@@ -221,7 +242,7 @@ export async function buildReport(sql: Sql): Promise<DedupReport> {
     return a.normalizedUrl < b.normalizedUrl ? -1 : 1;
   });
 
-  return { totalResources: rows.length, fkColumns, clusters };
+  return { totalResources: scanned.length, fkColumns, clusters, truncated };
 }
 
 // ---------------------------------------------------------------------------
@@ -334,12 +355,25 @@ export interface RunDedupResult {
 /**
  * Scan, pick canonicals, and (optionally) apply merges.
  */
-export async function runDedup(sql: Sql, apply: boolean): Promise<RunDedupResult> {
-  const report = await buildReport(sql);
+export async function runDedup(
+  sql: Sql,
+  apply: boolean,
+  opts?: { scanCap?: number },
+): Promise<RunDedupResult> {
+  const scanCap = opts?.scanCap ?? RESOURCES_SCAN_CAP;
+  const report = await buildReport(sql, { scanCap });
   const merges: ClusterMergeResult[] = [];
   const errors: RunDedupResult["errors"] = [];
 
   if (!apply) return { apply, report, merges, errors };
+
+  // Refuse apply=true when the scan was truncated. Clusters past the cutoff
+  // would silently survive — raise RESOURCES_SCAN_CAP or chunk the scan.
+  if (report.truncated) {
+    throw new Error(
+      `runDedup refused: resources scan was truncated at ${scanCap} rows; raise RESOURCES_SCAN_CAP or implement chunked scanning before applying.`,
+    );
+  }
 
   const rowsToDelete = report.clusters.reduce(
     (acc, c) => acc + c.duplicates.length,

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -34,6 +34,7 @@ import {
   paginationQuery,
   zv,
   clampedLimit,
+  applyTruncation,
 } from "../shared/utils.js";
 import {
   UpsertResourceSchema as SharedUpsertResourceSchema,
@@ -70,7 +71,7 @@ registerComposer<ResourceComposerRow>("resource", (row) => ({
 import { urlVariants } from "../shared/url-variants.js";
 import { generateId } from "@longterm-wiki/factbase";
 import { createHash, randomBytes } from "crypto";
-import { runDedup } from "./resource-dedup.js";
+import { runDedup, ScanTruncatedError } from "./resource-dedup.js";
 
 // ---- Raw SQL row types ----
 
@@ -1516,17 +1517,16 @@ const resourcesApp = new Hono()
       .leftJoin(wikiPages, eq(wikiPages.id, resourceCitations.pageId))
       .limit(HARD_LIMIT + 1);
 
-    const truncated = rows.length > HARD_LIMIT;
-    if (truncated) rows.length = HARD_LIMIT; // discard the probe row
+    const { items, truncated } = applyTruncation(rows, HARD_LIMIT);
 
     // Group by resourceId
     const index: Record<string, string[]> = {};
-    for (const row of rows) {
+    for (const row of items) {
       if (!index[row.resourceId]) index[row.resourceId] = [];
       if (row.pageId) index[row.resourceId].push(row.pageId);
     }
 
-    return c.json({ citations: index, count: rows.length, truncated });
+    return c.json({ citations: index, count: items.length, truncated });
   })
 
   // ---- PATCH /:id/fetch-status (update fetch status from source-fetcher) ----
@@ -2139,15 +2139,11 @@ const resourcesApp = new Hono()
         const result = await runDedup(sql, apply);
         return c.json(result);
       } catch (err) {
-        // runDedup throws on apply=true when the scan was truncated (QUA-623).
-        // Translate to a structured 409 so CLI callers get an actionable message
-        // instead of a generic 500.
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.includes("scan was truncated")) {
-          return c.json(
-            { error: "scan_truncated", message },
-            409,
-          );
+        // runDedup throws ScanTruncatedError when apply=true hits a truncated
+        // scan (QUA-623) — translate to a structured 409 so CLI callers get an
+        // actionable message instead of a generic 500.
+        if (err instanceof ScanTruncatedError) {
+          return c.json({ error: "scan_truncated", message: err.message }, 409);
         }
         throw err;
       }

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -2135,8 +2135,22 @@ const resourcesApp = new Hono()
     async (c) => {
       const { apply } = c.req.valid("json");
       const sql = getDb();
-      const result = await runDedup(sql, apply);
-      return c.json(result);
+      try {
+        const result = await runDedup(sql, apply);
+        return c.json(result);
+      } catch (err) {
+        // runDedup throws on apply=true when the scan was truncated (QUA-623).
+        // Translate to a structured 409 so CLI callers get an actionable message
+        // instead of a generic 500.
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("scan was truncated")) {
+          return c.json(
+            { error: "scan_truncated", message },
+            409,
+          );
+        }
+        throw err;
+      }
     }
   );
 

--- a/crux/scripts/dedup-resources.ts
+++ b/crux/scripts/dedup-resources.ts
@@ -46,6 +46,10 @@ interface DedupReport {
   totalResources: number;
   fkColumns: FkColumnInfo[];
   clusters: DedupCluster[];
+  /** QUA-623: true when the server's resources scan hit its cap. Clusters
+   *  past the cutoff are invisible to this report; --apply will be refused
+   *  server-side with a 409 until the cap is raised or the scan is chunked. */
+  truncated?: boolean;
 }
 
 interface ClusterMergeResult {
@@ -83,6 +87,11 @@ Environment: WIKI_SERVER_ENV=prod to target prod wiki-server.`
 
 function logReport(result: RunDedupResult): void {
   const { report, merges, errors, apply } = result;
+  if (report.truncated) {
+    console.warn(
+      `⚠ WARNING: resources scan was TRUNCATED — clusters past the server's cap are not in this report. --apply will be refused by the server until the cap is raised or chunked scanning lands.`,
+    );
+  }
   console.log(`Total resources: ${report.totalResources}`);
   console.log(`FK columns referencing resources.id: ${report.fkColumns.length}`);
   console.log(`Duplicate clusters: ${report.clusters.length}`);
@@ -151,6 +160,7 @@ function writeSnapshot(result: RunDedupResult): string {
     generatedAt: new Date().toISOString(),
     apply: result.apply,
     totalResources: result.report.totalResources,
+    scanTruncated: result.report.truncated ?? false,
     fkColumns: result.report.fkColumns,
     clustersFound: result.report.clusters.length,
     rowsToDelete: result.report.clusters.reduce(


### PR DESCRIPTION
## Summary

Five wiki-server route handlers returned unbounded result sets. Each works today but would hit the 30s `statement_timeout` as the underlying tables grew — the failures would have been silent HTTP 503s in prod.

## Changes

| Route | Cap applied |
|---|---|
| `entity-resources.ts` GET `/export` | 200k + `truncated` flag, +1 sentinel. Build pipeline call site now warns on truncation. |
| `research-areas.ts` GET `/:id` (5 subqueries) | `orgs`/`papers`/`risks`/`children` at 500, `fundingByOrg` at 200. `topGrants` was already 50. |
| `research-areas.ts` GET `/evaluations/scores` | 5000 |
| `research-areas.ts` GET `/evaluations/by-area/:id` | evaluations 1000, scores 500 |
| `operational/integrity.ts` GET `/` (7 checks) | Each `SELECT DISTINCT` capped at 1000 with +1 sentinel; per-check `truncated` flag in response |
| `operational/agent-sessions.ts` GET `/by-linear/:linearId` | 50 (dedup check only needs a handful) |
| `wikibase/resource-dedup.ts` `buildReport` | 500k with +1 sentinel; `runDedup(apply=true)` throws `ScanTruncatedError` on truncated scan |

## Design decisions

- Used `.limit(N)` with named module-level constants rather than `clampedLimit()` — those endpoints have no user-supplied limit param; the caps are hardcoded safety bounds, not user knobs.
- Responses that can overflow gain an optional `truncated: boolean` flag so callers can detect partial data.
- `POST /api/resources/dedup` catches `ScanTruncatedError` and returns a structured 409 `scan_truncated` instead of a generic 500 — CLI callers get an actionable message.
- The `crux/scripts/dedup-resources.ts` CLI logs a conspicuous warning + records `scanTruncated` in the snapshot so operators don't miss a partial scan.
- Extracted `applyTruncation(rows, cap)` into `apps/wiki-server/src/routes/shared/utils.ts` — the "+1 sentinel → slice + flag" pattern appeared 5 times across the wiki-server (3 new, 2 pre-existing in `resources.ts` and `entity-profile.ts`). Per `.claude/rules/implementation-quality.md` "Pattern fixes must be global", all 5 now share one implementation.
- `ScanTruncatedError` subclass replaces stringly-typed error matching in the HTTP handler.
- `buildReport` takes an optional `{ scanCap }` so tests don't need to materialize 500k rows.

## Test plan

- [x] `pnpm test` — 1302 wiki-server tests pass (55 skipped as usual)
- [x] `pnpm build` passes
- [x] `pnpm crux w validate gate --fix` — all 53 checks pass (2 advisory warnings unrelated)
- [x] New tests: 3 in `integrity.test.ts` (clean response, truncated-false, truncated-true); 6 in `resource-dedup.test.ts` (scan cap sentinel, dry-run + apply variants, `ScanTruncatedError` instanceof check)
- [x] Type check clean across `apps/web`, `apps/wiki-server`
- [x] Pre-push hook ran gate locally before push

Fixes QUA-623
