### PR TITLE
feat(QUA-632): /api/enrichment/propose defensive enrichment gate

### DIFF
--- a/apps/wiki-server/drizzle/0202_qua_632_enrichment_targets.sql
+++ b/apps/wiki-server/drizzle/0202_qua_632_enrichment_targets.sql
@@ -1,0 +1,29 @@
+-- QUA-632 Phase 1: enrichment_targets table.
+--
+-- Stores estimated denominators — per (entity_id, record_type) — so coverage
+-- bursts can track progress toward a percentage goal (e.g. "70% of Anthropic
+-- personnel rows").  `basis` explains how `estimated_total` was derived
+-- (headcount heuristic, LinkedIn employee count, press release, etc.) so the
+-- estimate stays falsifiable.
+--
+-- Companion to 0203_qua_632_enrichment_runs.sql and the /api/enrichment/propose
+-- endpoint.
+
+CREATE TABLE IF NOT EXISTS "enrichment_targets" (
+  "id" bigserial PRIMARY KEY,
+  "entity_id" text NOT NULL,
+  "record_type" text NOT NULL,
+  "estimated_total" integer NOT NULL,
+  "target_pct" real NOT NULL DEFAULT 0.70,
+  "estimated_at" timestamptz NOT NULL DEFAULT NOW(),
+  "basis" text,
+  "confidence" text,
+  "created_at" timestamptz NOT NULL DEFAULT NOW(),
+  "updated_at" timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_enrichment_targets_entity_record"
+  ON "enrichment_targets" ("entity_id", "record_type");
+
+CREATE INDEX IF NOT EXISTS "idx_enrichment_targets_record_type"
+  ON "enrichment_targets" ("record_type");

--- a/apps/wiki-server/drizzle/0203_qua_632_enrichment_runs.sql
+++ b/apps/wiki-server/drizzle/0203_qua_632_enrichment_runs.sql
@@ -1,0 +1,42 @@
+-- QUA-632 Phase 1: enrichment_runs ledger.
+--
+-- One row per defensive-enrichment burst.  /api/enrichment/propose updates
+-- this ledger as proposes arrive, so we can see tier breakdown, cost, and
+-- verdict distribution per run without joining evidence rows.
+--
+-- `id` is caller-supplied (e.g. a short slug like "anthropic-personnel-t1-2026-04-20")
+-- so the same run can be resumed across sessions.
+
+CREATE TABLE IF NOT EXISTS "enrichment_runs" (
+  "id" text PRIMARY KEY CHECK (char_length("id") > 0 AND char_length("id") <= 128),
+  "label" text,
+  "record_type" text,
+  "entity_id" text,
+  "tier" text,
+  "started_at" timestamptz NOT NULL DEFAULT NOW(),
+  "finished_at" timestamptz,
+  "proposes_total" integer NOT NULL DEFAULT 0,
+  "proposes_accepted" integer NOT NULL DEFAULT 0,
+  "proposes_rejected" integer NOT NULL DEFAULT 0,
+  "accepted_t1" integer NOT NULL DEFAULT 0,
+  "accepted_t2" integer NOT NULL DEFAULT 0,
+  "accepted_t3" integer NOT NULL DEFAULT 0,
+  "verdict_confirmed" integer NOT NULL DEFAULT 0,
+  "verdict_contradicted" integer NOT NULL DEFAULT 0,
+  "verdict_outdated" integer NOT NULL DEFAULT 0,
+  "verdict_partial" integer NOT NULL DEFAULT 0,
+  "verdict_unverifiable" integer NOT NULL DEFAULT 0,
+  "cost_usd" real NOT NULL DEFAULT 0,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT NOW(),
+  "updated_at" timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_enrichment_runs_record_type"
+  ON "enrichment_runs" ("record_type");
+
+CREATE INDEX IF NOT EXISTS "idx_enrichment_runs_entity"
+  ON "enrichment_runs" ("entity_id");
+
+CREATE INDEX IF NOT EXISTS "idx_enrichment_runs_started_at"
+  ON "enrichment_runs" ("started_at" DESC);

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1415,6 +1415,20 @@
       "when": 1786521600000,
       "tag": "0201_qua_576_resources_stableid_notnull",
       "breakpoints": true
+    },
+    {
+      "idx": 202,
+      "version": "7",
+      "when": 1786608000000,
+      "tag": "0202_qua_632_enrichment_targets",
+      "breakpoints": true
+    },
+    {
+      "idx": 203,
+      "version": "7",
+      "when": 1786608000001,
+      "tag": "0203_qua_632_enrichment_runs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
+++ b/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
@@ -1,0 +1,650 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import {
+  mockDbModule,
+  postJson,
+  type SqlDispatcher,
+} from "./test-utils";
+
+// ── Mock the inner grants sync route so we don't drag in the full sync pipeline ──
+//
+// The grants Hono sub-app is imported by enrichment.ts at module load, so we
+// replace it with a tiny stub that records every POST it receives and returns
+// a configurable response.  That lets us assert both (a) exactly what the
+// propose endpoint forwards (row + sourcing) and (b) how the endpoint
+// translates downstream failures into rejection reasons.
+
+interface CapturedInnerCall {
+  path: string;
+  body: unknown;
+}
+
+const captured: CapturedInnerCall[] = [];
+let innerResponseStatus = 200;
+let innerResponseBody: Record<string, unknown> = {
+  upserted: 1,
+  verdictsWritten: 1,
+  claimsLinked: 0,
+};
+
+vi.mock("../routes/tablebase/grants.js", () => {
+  const stub = new Hono().post("/sync", async (c) => {
+    const bodyText = await c.req.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      body = bodyText;
+    }
+    captured.push({ path: new URL(c.req.url).pathname, body });
+    return c.json(innerResponseBody, innerResponseStatus as 200 | 400 | 500);
+  });
+  return { grantsRoute: stub };
+});
+
+// ── DB mock — enrichment_runs logging is the only server-side DB call.
+// Tests that care about the logRunResult SQL assert on `dbQueries`.
+const dbQueries: Array<{ query: string; params: unknown[] }> = [];
+const dbDispatcher: SqlDispatcher = (query, params) => {
+  dbQueries.push({ query, params });
+  return [];
+};
+vi.mock("../db.js", () => mockDbModule(dbDispatcher));
+
+// Import the route AFTER mocks are registered.
+const { enrichmentRoute } = await import("../routes/enrichment/enrichment.js");
+const { computeSourcingForTier } = await import("../routes/enrichment/enrichment.js");
+const { checkT1Authority } = await import("../routes/enrichment/t1-allowlist.js");
+const { isHomepageUrl } = await import("../routes/enrichment/homepage-detector.js");
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/api/enrichment", enrichmentRoute);
+  return app;
+}
+
+function resetState() {
+  captured.length = 0;
+  dbQueries.length = 0;
+  innerResponseStatus = 200;
+  innerResponseBody = { upserted: 1, verdictsWritten: 1, claimsLinked: 0 };
+}
+
+// A valid grant row shape acceptable to the real sync schema.
+const VALID_GRANT_ROW = {
+  id: "grt1234567", // 10 chars
+  organizationId: "ea-funds",
+  name: "Example Grant to Anthropic 2024",
+  amount: 50000,
+  currency: "USD",
+  date: "2024-06-15",
+};
+
+// A ~500-char chunk of source content we can slice verbatim quotes from.
+const LONG_SOURCE_CONTENT =
+  "Anthropic received a $50,000 grant from the EA Animal Welfare Fund in June 2024 to support research into AI model safety evaluations and alignment techniques. The grant will fund additional personnel and compute resources over a six-month period, with public progress reports due at the halfway mark.";
+const VERBATIM_QUOTE_50 =
+  "Anthropic received a $50,000 grant from the EA Animal"; // 50 chars, verbatim substring
+
+// ─────────────────────────────────────────────────────────────────────
+// T1 allowlist — pure logic tests
+// ─────────────────────────────────────────────────────────────────────
+
+describe("checkT1Authority", () => {
+  it("matches EA Funds URL for grants", () => {
+    const res = checkT1Authority(
+      "https://funds.effectivealtruism.org/grants",
+      "grants",
+      null,
+    );
+    expect(res.matched).toBe(true);
+    if (res.matched) {
+      expect(res.source.id).toBe("ea-funds");
+    }
+  });
+
+  it("does NOT match EA Funds URL for personnel", () => {
+    const res = checkT1Authority(
+      "https://funds.effectivealtruism.org/grants",
+      "personnel",
+      null,
+    );
+    expect(res.matched).toBe(false);
+  });
+
+  it("does NOT match an unrelated URL for grants", () => {
+    const res = checkT1Authority(
+      "https://example.com/grants",
+      "grants",
+      null,
+    );
+    expect(res.matched).toBe(false);
+  });
+
+  it("matches OpenAlex for personnel but not grants", () => {
+    const pers = checkT1Authority(
+      "https://api.openalex.org/works/W12345",
+      "personnel",
+      null,
+    );
+    expect(pers.matched).toBe(true);
+    if (pers.matched) expect(pers.source.id).toBe("openalex");
+
+    const grant = checkT1Authority(
+      "https://api.openalex.org/works/W12345",
+      "grants",
+      null,
+    );
+    expect(grant.matched).toBe(false);
+  });
+
+  it("matches Wikidata URL for personnel", () => {
+    const res = checkT1Authority(
+      "https://www.wikidata.org/wiki/Q42",
+      "personnel",
+      null,
+    );
+    expect(res.matched).toBe(true);
+  });
+
+  it("rejects an empty sourceUrl", () => {
+    const res = checkT1Authority("", "grants", null);
+    expect(res.matched).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Homepage detector — pure logic tests
+// ─────────────────────────────────────────────────────────────────────
+
+describe("isHomepageUrl", () => {
+  it.each([
+    ["https://example.com/", true],
+    ["https://example.com", true],
+    ["https://example.com/home", true],
+    ["https://example.com/about", true],
+    ["https://example.com/about-us", true],
+    ["https://example.com/about/team", false], // sub-path under about is OK
+    ["https://example.com/contact", true],
+    ["https://example.com/blog/post-123", false],
+    ["https://example.com/research/ai-safety-paper", false],
+    ["not-a-url", false],
+  ])("%s → %s", (url, expected) => {
+    expect(isHomepageUrl(url)).toBe(expected);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// computeSourcingForTier — pure function, no IO
+// ─────────────────────────────────────────────────────────────────────
+
+describe("computeSourcingForTier (T1)", () => {
+  it("accepts a matching T1 source and produces confirmed verdict", () => {
+    const res = computeSourcingForTier(
+      {
+        tier: "T1",
+        recordType: "grants",
+        row: VALID_GRANT_ROW,
+        sourceUrl: "https://funds.effectivealtruism.org/grants/123",
+        sourceContentHash: "abc123",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(true);
+    if (res.accepted) {
+      expect(res.sourcing.verdict).toBe("confirmed");
+      expect(res.sourcing.confidence).toBe(1);
+      expect(res.sourcing.checkedBy).toBe("t1-ea-funds");
+      expect(res.sourcing.evidence).toContain("abc123");
+    }
+  });
+
+  it("rejects a T1 request whose source is not on the allowlist", () => {
+    const res = computeSourcingForTier(
+      {
+        tier: "T1",
+        recordType: "grants",
+        row: VALID_GRANT_ROW,
+        sourceUrl: "https://blog.example.com/i-know-about-grants",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toMatch(/No T1 authority matches/);
+    }
+  });
+});
+
+describe("computeSourcingForTier (T2)", () => {
+  const baseReq = {
+    tier: "T2" as const,
+    recordType: "grants" as const,
+    row: VALID_GRANT_ROW,
+    sourceUrl: "https://anthropic.com/news/ea-funds-grant",
+  };
+
+  it("accepts with confirmed verdict + long verbatim quote", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "confirmed",
+        quotedText: VERBATIM_QUOTE_50,
+        checkerModel: "claude-haiku-4-5-20251001",
+        sourceContent: LONG_SOURCE_CONTENT,
+        confidence: 0.95,
+      },
+      null,
+    );
+    expect(res.accepted).toBe(true);
+    if (res.accepted) {
+      expect(res.sourcing.verdict).toBe("confirmed");
+      expect(res.sourcing.evidence).toContain(VERBATIM_QUOTE_50);
+      expect(res.sourcing.confidence).toBe(0.95);
+      expect(res.sourcing.checkedBy).toBe("claude-haiku-4-5-20251001");
+    }
+  });
+
+  it("rejects verdict=partial (strict gate — only confirmed)", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "partial",
+        quotedText: VERBATIM_QUOTE_50,
+        checkerModel: "claude-haiku-4-5-20251001",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toContain("partial");
+      expect(res.rejectionReason).toMatch(/only "confirmed"/);
+    }
+  });
+
+  it("rejects verdict=contradicted", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "contradicted",
+        quotedText: VERBATIM_QUOTE_50,
+        checkerModel: "claude-haiku-4-5-20251001",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+  });
+
+  it("rejects quotedText shorter than MIN_QUOTE_CHARS", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "confirmed",
+        quotedText: "short quote",
+        checkerModel: "claude-haiku-4-5-20251001",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toMatch(/quotedText too short/);
+    }
+  });
+
+  it("rejects when quotedText is not a verbatim substring of sourceContent", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "confirmed",
+        quotedText:
+          "This quote is long enough but does not appear anywhere in the provided source content at all.",
+        checkerModel: "claude-haiku-4-5-20251001",
+        sourceContent: LONG_SOURCE_CONTENT,
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toMatch(/verbatim substring/);
+    }
+  });
+
+  it("skips the verbatim check when sourceContent is omitted (trust-caller mode)", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "confirmed",
+        quotedText:
+          "A sufficiently long quote that the caller claims is verbatim even though we cannot check.",
+        checkerModel: "claude-haiku-4-5-20251001",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(true);
+  });
+
+  it("rejects when verdict/quotedText/checkerModel are missing", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toMatch(/required field/);
+      expect(res.rejectionReason).toMatch(/verdict/);
+      expect(res.rejectionReason).toMatch(/quotedText/);
+      expect(res.rejectionReason).toMatch(/checkerModel/);
+    }
+  });
+
+  it("tolerates whitespace differences between quote and source", () => {
+    const spacedQuote = "Anthropic  received   a  $50,000 grant  from  the EA  Animal";
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        verdict: "confirmed",
+        quotedText: spacedQuote,
+        checkerModel: "claude-haiku-4-5-20251001",
+        sourceContent: LONG_SOURCE_CONTENT,
+      },
+      null,
+    );
+    expect(res.accepted).toBe(true);
+  });
+});
+
+describe("computeSourcingForTier (T3)", () => {
+  const baseReq = {
+    tier: "T3" as const,
+    recordType: "grants" as const,
+    row: VALID_GRANT_ROW,
+    verdict: "confirmed" as const,
+    quotedText: VERBATIM_QUOTE_50,
+    checkerModel: "claude-haiku-4-5-20251001",
+    sourceContent: LONG_SOURCE_CONTENT,
+  };
+
+  it("rejects homepage URLs", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        sourceUrl: "https://example.com/",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+    if (!res.accepted) {
+      expect(res.rejectionReason).toMatch(/homepage/);
+    }
+  });
+
+  it("rejects shallow /about URLs", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        sourceUrl: "https://example.com/about",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(false);
+  });
+
+  it("accepts a specific sub-page URL", () => {
+    const res = computeSourcingForTier(
+      {
+        ...baseReq,
+        sourceUrl: "https://example.com/blog/ea-funds-grant-announcement",
+      },
+      null,
+    );
+    expect(res.accepted).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Endpoint integration tests (with mocked inner grants route)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/enrichment/propose", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  it("accepts a valid T1 request and forwards the row with sourcing to the grants sync", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/anthropic-2024",
+      sourceContentHash: "sha256:abc",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+    expect(body.tier).toBe("T1");
+    expect(body.verdict).toBe("confirmed");
+    expect(body.recordId).toBe("grt1234567");
+
+    // The inner route should have been called exactly once with our row + sourcing.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe("/sync");
+    const innerBody = captured[0].body as {
+      items: Array<Record<string, unknown> & {
+        sourcing: { verdict: string; checkedBy: string };
+      }>;
+    };
+    expect(innerBody.items).toHaveLength(1);
+    expect(innerBody.items[0].id).toBe("grt1234567");
+    expect(innerBody.items[0].source).toBe(
+      "https://funds.effectivealtruism.org/grants/anthropic-2024",
+    );
+    expect(innerBody.items[0].sourcing.verdict).toBe("confirmed");
+    expect(innerBody.items[0].sourcing.checkedBy).toBe("t1-ea-funds");
+  });
+
+  it("rejects a T1 request whose source is not on the allowlist (no inner call made)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://random.example.com/some-page",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.status).toBe("rejected");
+    expect(body.rejectionReason).toMatch(/No T1 authority matches/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("accepts a T2 request when verdict=confirmed + verbatim quote", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T2",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://anthropic.com/news/ea-grant-2024",
+      verdict: "confirmed",
+      confidence: 0.92,
+      quotedText: VERBATIM_QUOTE_50,
+      reasoning: "Quote confirms the grant amount and recipient.",
+      sourceContent: LONG_SOURCE_CONTENT,
+      checkerModel: "claude-haiku-4-5-20251001",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+    expect(body.verdict).toBe("confirmed");
+    expect(body.confidence).toBe(0.92);
+    expect(captured).toHaveLength(1);
+  });
+
+  it("rejects T2 verdict=partial at the strict gate", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T2",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://anthropic.com/news/ea-grant-2024",
+      verdict: "partial",
+      quotedText: VERBATIM_QUOTE_50,
+      checkerModel: "claude-haiku-4-5-20251001",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.rejectionReason).toContain("partial");
+    expect(captured).toHaveLength(0);
+  });
+
+  it("rejects T3 homepage URLs even with valid verdict + quote", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T3",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://example.com/",
+      verdict: "confirmed",
+      quotedText: VERBATIM_QUOTE_50,
+      sourceContent: LONG_SOURCE_CONTENT,
+      checkerModel: "claude-haiku-4-5-20251001",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.rejectionReason).toMatch(/homepage/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("returns 400 when the downstream sync handler fails", async () => {
+    innerResponseStatus = 400;
+    innerResponseBody = {
+      error: "validation_error",
+      message: "organizationId not found in entities",
+    };
+
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/abc",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.status).toBe("rejected");
+    expect(body.rejectionReason).toMatch(/organizationId not found in entities/);
+    expect(body.innerStatus).toBe(400);
+    expect(captured).toHaveLength(1); // gate passed, forwarded once, downstream rejected
+  });
+
+  it("rejects a request with unknown recordType (schema check)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "personnel", // not in SUPPORTED_RECORD_TYPES for Phase 1
+      row: { id: "x" },
+      sourceUrl: "https://api.openalex.org/works/W1",
+    });
+    expect(res.status).toBe(400);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("rejects a malformed request body", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T4", // invalid tier
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/x",
+    });
+    expect(res.status).toBe(400);
+    expect(captured).toHaveLength(0);
+  });
+
+  // Phase 1 does not support per-field verdicts — writeInlineVerdicts hardcodes
+  // `field_name = NULL`.  Accepting a non-null `fieldName` would gate T1
+  // field-restriction correctly but then write a row-level verdict anyway.
+  it("rejects non-null fieldName (Phase 1 per-field verdicts not supported)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/abc",
+      fieldName: "amount",
+    });
+    expect(res.status).toBe(400);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("accepts an explicit null fieldName (whole-record verdict)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/abc",
+      fieldName: null,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  // Covers that the `runId` path actually hits the DB — the SQL shape is how
+  // the dashboard builds per-run roll-ups.  A regression that drops the UPSERT
+  // would silently under-count in /internal/* dashboards.
+  it("writes the enrichment_runs UPSERT when runId is supplied", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/abc",
+      runId: "anthropic-personnel-t1-2026-04-20",
+    });
+    expect(res.status).toBe(200);
+
+    const runQueries = dbQueries.filter((q) =>
+      q.query.includes("enrichment_runs"),
+    );
+    expect(runQueries.length).toBe(1);
+    expect(runQueries[0].query).toContain("INSERT INTO enrichment_runs");
+    expect(runQueries[0].query).toContain("ON CONFLICT (id) DO UPDATE");
+    expect(runQueries[0].query).toContain("verdict_confirmed");
+    expect(runQueries[0].query).toContain("verdict_outdated");
+    // The runId is passed as a bound param (index 0 in the SQL).
+    expect(runQueries[0].params).toContain("anthropic-personnel-t1-2026-04-20");
+  });
+
+  it("skips enrichment_runs UPSERT when runId is omitted", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://funds.effectivealtruism.org/grants/abc",
+    });
+    expect(res.status).toBe(200);
+    const runQueries = dbQueries.filter((q) =>
+      q.query.includes("enrichment_runs"),
+    );
+    expect(runQueries.length).toBe(0);
+  });
+
+  it("still increments enrichment_runs counters on tier-gate rejection", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "grants",
+      row: VALID_GRANT_ROW,
+      sourceUrl: "https://random.example.com/not-allowlisted",
+      runId: "run-that-should-count-rejections",
+    });
+    expect(res.status).toBe(400);
+    const runQueries = dbQueries.filter((q) =>
+      q.query.includes("enrichment_runs"),
+    );
+    expect(runQueries.length).toBe(1);
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -26,6 +26,9 @@ import { urlSuggestionsRoute } from "./routes/sourcing/url-suggestions.js";
 // Claims-first sourcing system (#3253)
 import { claimsRoute } from "./routes/claims/claims.js";
 
+// Defensive enrichment gate (QUA-632 Phase 1)
+import { enrichmentRoute } from "./routes/enrichment/enrichment.js";
+
 // FactBase routes — structured triples with temporal data
 import { factsRoute } from "./routes/factbase/facts.js";
 
@@ -208,6 +211,9 @@ export function createApp() {
 
   // Claims-first sourcing (#3253)
   app.route("/api/claims", claimsRoute);
+
+  // Defensive enrichment gate (QUA-632 Phase 1)
+  app.route("/api/enrichment", enrichmentRoute);
 
   // WikiBase assessments (not in the TableBase registry — separate concern)
   app.route("/api/assessments", assessmentsRoute);

--- a/apps/wiki-server/src/routes/enrichment/enrichment.ts
+++ b/apps/wiki-server/src/routes/enrichment/enrichment.ts
@@ -1,0 +1,430 @@
+/**
+ * QUA-632 Phase 1 — `POST /api/enrichment/propose`.
+ *
+ * Defensive enrichment gate.  Produces a server-validated sourcing verdict
+ * from the tier rules and delegates the row write to the existing sync-handler
+ * pipeline, which atomically writes (row + evidence + verdict) inside a
+ * single transaction via `writeInlineVerdicts`.
+ *
+ *   tier     gate                                       verdict source
+ *   ─────    ────────────────────────────────────────   ────────────────────
+ *   T1       sourceUrl must match T1 authority          `confirmed`  (fixed)
+ *   T2       caller-supplied verdict, strict gate       caller's verdict-LLM
+ *   T3       T2 rules + reject homepage URLs            caller's verdict-LLM
+ *
+ * Atomicity scope: the (row + evidence + verdict) triple is atomic inside
+ * the sync handler's tx.  The best-effort `enrichment_runs` ledger update
+ * that follows is intentionally outside that tx (it must never block a
+ * successful write).  If propose crashes after the inner sync succeeded
+ * but before the ledger row lands, the row is safely written and the
+ * ledger counter is under-counted — never over-counted.
+ *
+ * Strict gate = only `verdict === "confirmed"` is accepted (QUA-635
+ * calibration: Haiku at 0 % false-confirm with confirmed-only rule).
+ * `partial` etc. must be routed to a separate triage queue by the caller.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { logger } from "../../logger.js";
+import { parseJsonBody, validationError, invalidJsonError } from "../shared/utils.js";
+import type { InlineSourcing } from "../tablebase/sourcing-schema.js";
+import { grantsRoute } from "../tablebase/grants.js";
+import { checkT1Authority } from "./t1-allowlist.js";
+import { isHomepageUrl } from "./homepage-detector.js";
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+/** Strict-gate accepted verdicts.  Keep in sync with QUA-635 calibration. */
+const ACCEPTED_VERDICTS = new Set(["confirmed"]);
+
+/** Minimum length of a T2/T3 verbatim quote.  Calibration showed shorter
+ *  quotes correlate with paraphrase and hallucination. */
+const MIN_QUOTE_CHARS = 40;
+
+/** Maximum size of inlined source content the caller can ship for verbatim
+ *  quote-verification (≈200 kB).  Caller is expected to pre-trim. */
+const MAX_SOURCE_CONTENT_CHARS = 200_000;
+
+// ── Supported record types ──────────────────────────────────────────────
+
+/**
+ * Phase 1 ships grants as the initial supported record type (T1 = EA Funds
+ * CSV, T2/T3 = open web).  Adding more record types = (a) import the sync
+ * subapp, (b) append it here, (c) extend T1 allowlist entries that name it.
+ */
+const SUPPORTED_RECORD_TYPES = ["grants"] as const;
+type SupportedRecordType = (typeof SUPPORTED_RECORD_TYPES)[number];
+
+interface RecordTypeRoute {
+  /** The sync handler's Hono sub-app.  Hono's `fetch` can return either
+   *  `Response` or `Promise<Response>`, so we type it loosely here. */
+  subApp: { fetch: (req: Request) => Response | Promise<Response> };
+  /** Path within the sub-app that accepts the sync POST. */
+  syncPath: string;
+}
+
+const RECORD_TYPE_ROUTES: Record<SupportedRecordType, RecordTypeRoute> = {
+  grants: { subApp: grantsRoute, syncPath: "/sync" },
+};
+
+// ── Request schema ──────────────────────────────────────────────────────
+
+const VERDICT_VALUES = [
+  "confirmed",
+  "contradicted",
+  "outdated",
+  "partial",
+  "unverifiable",
+] as const;
+
+const ProposeRequestSchema = z
+  .object({
+    tier: z.enum(["T1", "T2", "T3"]),
+    recordType: z.enum(SUPPORTED_RECORD_TYPES),
+    /** The record payload (shape per recordType — validated by the sync
+     *  handler's own Zod schema).  Must include the record's `id`. */
+    row: z.record(z.unknown()),
+    sourceUrl: z.string().url().max(2000),
+    /** Optional hash of the API response / page content — recorded in
+     *  evidence for replayability. */
+    sourceContentHash: z.string().max(100).optional(),
+
+    // ─── T2 / T3 inputs (required for those tiers; ignored for T1) ───
+    /** The verdict the caller's verdict-LLM produced.  Only "confirmed" is
+     *  accepted by the gate; others are rejected for the caller to triage. */
+    verdict: z.enum(VERDICT_VALUES).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    /** Verbatim quote from the source content supporting the claim.
+     *  Must be a substring of `sourceContent` when that is provided. */
+    quotedText: z.string().max(5000).optional(),
+    reasoning: z.string().max(5000).optional(),
+    /** Source content for verbatim-quote verification.  If omitted the
+     *  verbatim check is skipped (trust-the-caller mode). */
+    sourceContent: z.string().max(MAX_SOURCE_CONTENT_CHARS).optional(),
+    /** Model used by the verdict-LLM.  Recorded as evidence.checker_model. */
+    checkerModel: z.string().max(200).optional(),
+
+    // ─── Optional metadata ────
+    runId: z.string().max(64).optional(),
+    /**
+     * Per-field verdicts are NOT supported in Phase 1.  `writeInlineVerdicts`
+     * hardcodes `field_name = NULL`, so accepting a non-null `fieldName` here
+     * would gate the T1 field-restriction correctly but then write a
+     * row-level verdict anyway — a silent correctness bug.  Reject explicitly
+     * until Phase 2 extends `InlineSourcing` + the sync pipeline to carry
+     * field_name through.
+     *
+     * Schema-side: accept `null` and `undefined` only.  The runtime gate
+     * below double-checks this.
+     */
+    fieldName: z.null().optional(),
+  })
+  .strict();
+
+type ProposeRequest = z.infer<typeof ProposeRequestSchema>;
+
+// ── Route ───────────────────────────────────────────────────────────────
+
+const enrichmentApp = new Hono()
+  .post("/propose", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = ProposeRequestSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+    const req = parsed.data;
+
+    const fieldName = req.fieldName ?? null;
+    const route = RECORD_TYPE_ROUTES[req.recordType];
+
+    // ── Tier gate ────────────────────────────────────────────────────
+    const gate = computeSourcingForTier(req, fieldName);
+    if (!gate.accepted) {
+      await logRunResult({
+        runId: req.runId,
+        tier: req.tier,
+        accepted: false,
+        rejectionReason: gate.rejectionReason,
+      });
+      logger.info(
+        {
+          recordType: req.recordType,
+          tier: req.tier,
+          rejectionReason: gate.rejectionReason,
+        },
+        "enrichment.propose: rejected at tier gate",
+      );
+      return c.json(
+        {
+          status: "rejected" as const,
+          tier: req.tier,
+          rejectionReason: gate.rejectionReason,
+          verdict: null,
+        },
+        400,
+      );
+    }
+
+    // ── Delegate to the sync handler with sourcing attached ──────────
+    const itemWithSourcing = {
+      ...req.row,
+      // Grants' sync schema uses `source` (URL).  Overriding is intentional:
+      // the gate validated this exact URL, callers mustn't smuggle a different
+      // one in the row payload.
+      source: req.sourceUrl,
+      sourcing: gate.sourcing,
+    };
+
+    // Intentionally no query string on the inner request: the sync
+    // handler's `requireSourcing` / `forceSkipSourcing` / `skipEntityValidation`
+    // escape hatches must NOT be reachable through /propose — the whole point
+    // of the gate is to enforce sourcing + entity refs uniformly.
+    const innerReq = new Request(`http://wiki-server-internal${route.syncPath}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ items: [itemWithSourcing] }),
+    });
+
+    const innerRes = await Promise.resolve(route.subApp.fetch(innerReq));
+    const innerText = await innerRes.text();
+    let innerBody: Record<string, unknown>;
+    try {
+      innerBody = JSON.parse(innerText);
+    } catch {
+      innerBody = { raw: innerText };
+    }
+
+    if (innerRes.status >= 400) {
+      const reason =
+        typeof innerBody.message === "string"
+          ? `sync/${req.recordType}: ${innerBody.message}`
+          : `sync/${req.recordType}: HTTP ${innerRes.status}`;
+      await logRunResult({
+        runId: req.runId,
+        tier: req.tier,
+        accepted: false,
+        rejectionReason: reason.slice(0, 500),
+      });
+      logger.warn(
+        {
+          recordType: req.recordType,
+          tier: req.tier,
+          innerStatus: innerRes.status,
+          innerBody,
+        },
+        "enrichment.propose: downstream sync rejected",
+      );
+      return c.json(
+        {
+          status: "rejected" as const,
+          tier: req.tier,
+          rejectionReason: reason.slice(0, 500),
+          verdict: null,
+          innerStatus: innerRes.status,
+        },
+        400,
+      );
+    }
+
+    const recordId =
+      typeof req.row.id === "string" && req.row.id.length > 0 ? req.row.id : null;
+
+    await logRunResult({
+      runId: req.runId,
+      tier: req.tier,
+      accepted: true,
+      verdict: gate.sourcing.verdict,
+    });
+
+    return c.json({
+      status: "accepted" as const,
+      tier: req.tier,
+      recordId,
+      verdict: gate.sourcing.verdict,
+      confidence: gate.sourcing.confidence ?? null,
+      checkerModel: gate.sourcing.checkedBy ?? null,
+      innerStatus: innerRes.status,
+    });
+  });
+
+// ── Internals ────────────────────────────────────────────────────────────
+
+type GateResult =
+  | { accepted: true; sourcing: InlineSourcing }
+  | { accepted: false; rejectionReason: string };
+
+/**
+ * Tier-gate decision.  Pure function (no IO) — easy to unit-test.
+ */
+export function computeSourcingForTier(
+  req: ProposeRequest,
+  fieldName: string | null,
+): GateResult {
+  if (req.tier === "T1") {
+    const match = checkT1Authority(req.sourceUrl, req.recordType, fieldName);
+    if (!match.matched) {
+      return { accepted: false, rejectionReason: match.reason };
+    }
+    const s = match.source;
+    const evidenceSummary = req.sourceContentHash
+      ? `[T1: ${s.name}] response-hash=${req.sourceContentHash}`
+      : `[T1: ${s.name}]`;
+    return {
+      accepted: true,
+      sourcing: {
+        verdict: "confirmed",
+        confidence: 1.0,
+        evidence: evidenceSummary,
+        sourceContentHash: req.sourceContentHash,
+        checkedBy: `t1-${s.id}`,
+        checkedAt: new Date().toISOString(),
+      },
+    };
+  }
+
+  // T2 or T3 — caller-supplied verdict path.
+  const missing: string[] = [];
+  if (!req.verdict) missing.push("verdict");
+  if (!req.quotedText) missing.push("quotedText");
+  if (!req.checkerModel) missing.push("checkerModel");
+  if (missing.length > 0) {
+    return {
+      accepted: false,
+      rejectionReason: `${req.tier}: required field(s) missing: ${missing.join(", ")}`,
+    };
+  }
+  // Type-guard now that we've checked.
+  const verdict = req.verdict!;
+  const quotedText = req.quotedText!;
+  const checkerModel = req.checkerModel!;
+
+  if (!ACCEPTED_VERDICTS.has(verdict)) {
+    return {
+      accepted: false,
+      rejectionReason: `${req.tier}: verdict="${verdict}" rejected — only "confirmed" is accepted by the defensive gate (route partials/contradicted to triage queue)`,
+    };
+  }
+
+  if (quotedText.length < MIN_QUOTE_CHARS) {
+    return {
+      accepted: false,
+      rejectionReason: `${req.tier}: quotedText too short (${quotedText.length} chars, min ${MIN_QUOTE_CHARS})`,
+    };
+  }
+
+  if (req.sourceContent && !sourceContainsQuote(req.sourceContent, quotedText)) {
+    return {
+      accepted: false,
+      rejectionReason: `${req.tier}: quotedText is not a verbatim substring of sourceContent`,
+    };
+  }
+
+  if (req.tier === "T3" && isHomepageUrl(req.sourceUrl)) {
+    return {
+      accepted: false,
+      rejectionReason: `T3: sourceUrl is a homepage — pick a specific sub-page`,
+    };
+  }
+
+  const evidenceBlob = req.reasoning
+    ? `${quotedText}\n---\n${req.reasoning}`.slice(0, 5000)
+    : quotedText.slice(0, 5000);
+
+  return {
+    accepted: true,
+    sourcing: {
+      verdict: "confirmed",
+      confidence: req.confidence ?? 0.9,
+      evidence: evidenceBlob,
+      sourceContentHash: req.sourceContentHash,
+      checkedBy: checkerModel,
+      checkedAt: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Whitespace-tolerant, case-insensitive substring check.  The verdict-LLM
+ * preserves case reasonably well but collapses whitespace, so a naive strict
+ * substring check rejects too many real quotes.
+ */
+function sourceContainsQuote(source: string, quote: string): boolean {
+  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
+  return norm(source).includes(norm(quote));
+}
+
+/**
+ * Best-effort counter update on `enrichment_runs`.  Never throws — a failure
+ * to log counters must not block the propose call.  Rows are auto-created on
+ * first hit (INSERT … ON CONFLICT DO UPDATE).
+ */
+interface LogRunArgs {
+  runId: string | undefined;
+  tier: "T1" | "T2" | "T3";
+  accepted: boolean;
+  rejectionReason?: string;
+  verdict?: string;
+}
+
+async function logRunResult(args: LogRunArgs): Promise<void> {
+  if (!args.runId) return;
+
+  // Precompute tier + verdict counter values so the SQL stays flat.
+  // `tier` and `started_at` on the base row are advisory — they reflect the
+  // FIRST writer's value and are intentionally not bumped in the UPDATE SET.
+  const a = args.accepted ? 1 : 0;
+  const r = args.accepted ? 0 : 1;
+  const t1 = args.accepted && args.tier === "T1" ? 1 : 0;
+  const t2 = args.accepted && args.tier === "T2" ? 1 : 0;
+  const t3 = args.accepted && args.tier === "T3" ? 1 : 0;
+  const vCo = args.accepted && args.verdict === "confirmed" ? 1 : 0;
+  const vCn = args.accepted && args.verdict === "contradicted" ? 1 : 0;
+  const vOu = args.accepted && args.verdict === "outdated" ? 1 : 0;
+  const vPa = args.accepted && args.verdict === "partial" ? 1 : 0;
+  const vUn = args.accepted && args.verdict === "unverifiable" ? 1 : 0;
+
+  try {
+    const db = getDrizzleDb();
+    await db.execute(sql`
+      INSERT INTO enrichment_runs (
+        id, tier, started_at,
+        proposes_total, proposes_accepted, proposes_rejected,
+        accepted_t1, accepted_t2, accepted_t3,
+        verdict_confirmed, verdict_contradicted, verdict_outdated, verdict_partial, verdict_unverifiable
+      )
+      VALUES (
+        ${args.runId}, ${args.tier}, NOW(),
+        1, ${a}, ${r},
+        ${t1}, ${t2}, ${t3},
+        ${vCo}, ${vCn}, ${vOu}, ${vPa}, ${vUn}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        proposes_total = enrichment_runs.proposes_total + 1,
+        proposes_accepted = enrichment_runs.proposes_accepted + EXCLUDED.proposes_accepted,
+        proposes_rejected = enrichment_runs.proposes_rejected + EXCLUDED.proposes_rejected,
+        accepted_t1 = enrichment_runs.accepted_t1 + EXCLUDED.accepted_t1,
+        accepted_t2 = enrichment_runs.accepted_t2 + EXCLUDED.accepted_t2,
+        accepted_t3 = enrichment_runs.accepted_t3 + EXCLUDED.accepted_t3,
+        verdict_confirmed = enrichment_runs.verdict_confirmed + EXCLUDED.verdict_confirmed,
+        verdict_contradicted = enrichment_runs.verdict_contradicted + EXCLUDED.verdict_contradicted,
+        verdict_outdated = enrichment_runs.verdict_outdated + EXCLUDED.verdict_outdated,
+        verdict_partial = enrichment_runs.verdict_partial + EXCLUDED.verdict_partial,
+        verdict_unverifiable = enrichment_runs.verdict_unverifiable + EXCLUDED.verdict_unverifiable,
+        updated_at = NOW()
+    `);
+  } catch (e: unknown) {
+    logger.warn(
+      {
+        err: e instanceof Error ? e.message : String(e),
+        runId: args.runId,
+      },
+      "enrichment.propose: enrichment_runs counter update failed — continuing",
+    );
+  }
+}
+
+export const enrichmentRoute = enrichmentApp;
+export type EnrichmentRoute = typeof enrichmentApp;

--- a/apps/wiki-server/src/routes/enrichment/homepage-detector.ts
+++ b/apps/wiki-server/src/routes/enrichment/homepage-detector.ts
@@ -1,0 +1,51 @@
+/**
+ * QUA-632 Phase 1 — T3 homepage rejection.
+ *
+ * T3 is "open web with stricter rejection".  The canonical failure mode the
+ * rule targets: a record's `source` is set to the org's homepage, the LLM
+ * reads the front page, and returns `unverifiable 0.9` because the page
+ * mentions the entity in passing but doesn't specifically confirm the claim.
+ *
+ * We reject homepage-like URLs at the gate so T3 callers must supply a
+ * specific sub-page (press release, blog post, docs page, etc.).
+ */
+
+const HOMEPAGE_PATHS = new Set([
+  "",
+  "/",
+  "/index",
+  "/index.html",
+  "/index.htm",
+  "/home",
+]);
+
+const SHALLOW_LANDING_PATHS = new Set([
+  "/about",
+  "/about-us",
+  "/aboutus",
+  "/contact",
+  "/contact-us",
+  "/contactus",
+]);
+
+export function isHomepageUrl(rawUrl: string): boolean {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) return false;
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  const path = normalisePath(url.pathname);
+  if (HOMEPAGE_PATHS.has(path)) return true;
+  if (SHALLOW_LANDING_PATHS.has(path)) return true;
+  return false;
+}
+
+function normalisePath(raw: string): string {
+  // Strip trailing slashes except the root itself.
+  let p = raw.toLowerCase();
+  if (p.length > 1) p = p.replace(/\/+$/, "");
+  return p;
+}

--- a/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
+++ b/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
@@ -1,0 +1,131 @@
+/**
+ * QUA-632 Phase 1 — T1 Authority Allowlist.
+ *
+ * A T1 source is a deterministic, authoritative data source where the act of
+ * matching the URL + record-type is itself the verification.  No verdict-LLM
+ * call is made: the source's authority *is* the verdict.
+ *
+ * Adding an entry below is a declaration that: for rows of this `recordType`
+ * (optionally a specific `fieldName`), a URL matching this pattern IS
+ * confirmation.  Add sparingly and only after auditing the source.
+ *
+ * Each entry has a stable `id` that is recorded in
+ * `source_check_evidence.checker_model` as `t1-<id>` so T1-written rows are
+ * auditable and re-runnable.
+ */
+
+export interface T1Source {
+  /** Stable identifier used in evidence.checker_model (`t1-<id>`). */
+  id: string;
+  /** Human-readable label used in audit reasoning. */
+  name: string;
+  /** Regex matched against the full source URL. */
+  urlPattern: RegExp;
+  /**
+   * Record types this source is authoritative for.  A request with a
+   * recordType not in this list falls through to the next entry (and
+   * ultimately to rejection).
+   */
+  recordTypes: string[];
+  /**
+   * Optional per-field restriction.  When set for a recordType, the request's
+   * `fieldName` must be null OR one of the listed field names to match.
+   * When unset, the source is row-level authoritative for the whole record.
+   */
+  fields?: Record<string, string[]>;
+}
+
+/**
+ * The allowlist.  Ordered from most-specific to least-specific; first match
+ * wins.  The current list seeds the six T1 sources named in the QUA-637
+ * umbrella; Phase 1 only exercises the subset that has sync-route support
+ * registered in `enrichment.ts`.
+ */
+export const T1_ALLOWLIST: T1Source[] = [
+  {
+    id: "ea-funds",
+    name: "EA Funds",
+    // Covers the grants listing pages + direct CSV downloads.
+    urlPattern: /^https:\/\/funds\.effectivealtruism\.org\//i,
+    recordTypes: ["grants"],
+  },
+  {
+    id: "coefficient-giving",
+    name: "Coefficient Giving (fka Open Philanthropy) — grant database",
+    urlPattern: /^https:\/\/(www\.)?coefficientgiving\.org\/grants(\/|$)/i,
+    recordTypes: ["grants"],
+  },
+  {
+    id: "openalex",
+    name: "OpenAlex API",
+    urlPattern: /^https:\/\/api\.openalex\.org\//i,
+    recordTypes: ["personnel", "publications"],
+  },
+  {
+    id: "wikidata",
+    name: "Wikidata",
+    urlPattern: /^https:\/\/www\.wikidata\.org\/wiki\/Q\d+/i,
+    recordTypes: ["personnel", "organization"],
+  },
+  {
+    id: "sec-edgar",
+    name: "SEC EDGAR",
+    urlPattern: /^https:\/\/(www\.)?sec\.gov\/(cgi-bin\/browse-edgar|Archives\/edgar)\//i,
+    recordTypes: ["funding-rounds", "organization"],
+  },
+  {
+    id: "hf-leaderboard",
+    name: "Hugging Face Leaderboard",
+    urlPattern: /^https:\/\/huggingface\.co\/spaces\/[^/]+\/[^/]*leaderboard/i,
+    recordTypes: ["benchmarks"],
+  },
+  {
+    id: "github-api",
+    name: "GitHub API",
+    urlPattern: /^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/(contributors|collaborators)/i,
+    recordTypes: ["personnel"],
+  },
+];
+
+export type T1MatchResult =
+  | { matched: true; source: T1Source }
+  | { matched: false; reason: string };
+
+/**
+ * Check whether `(sourceUrl, recordType, fieldName?)` is on the T1 allowlist.
+ * Returns the matched source on success or a human-readable reason on miss.
+ *
+ * `fieldName` = null means "row-level" / "whole record"; only sources without a
+ * `fields[recordType]` restriction match that case.
+ */
+export function checkT1Authority(
+  sourceUrl: string,
+  recordType: string,
+  fieldName: string | null,
+): T1MatchResult {
+  if (typeof sourceUrl !== "string" || sourceUrl.length === 0) {
+    return { matched: false, reason: "sourceUrl is empty" };
+  }
+
+  for (const source of T1_ALLOWLIST) {
+    if (!source.urlPattern.test(sourceUrl)) continue;
+    if (!source.recordTypes.includes(recordType)) continue;
+
+    const fieldRestriction = source.fields?.[recordType];
+    if (fieldRestriction) {
+      if (fieldName === null) continue;
+      if (!fieldRestriction.includes(fieldName)) continue;
+    }
+
+    return { matched: true, source };
+  }
+
+  return {
+    matched: false,
+    reason: `No T1 authority matches (url=${truncate(sourceUrl, 120)}, recordType=${recordType}, fieldName=${fieldName ?? "<row>"})`,
+  };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + "…";
+}

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -4089,3 +4089,65 @@ export const tablebaseScannerResults = pgTable(
     uniqueIndex("uq_scanner_results_natural_key").on(table.scanRunId, table.recordType, table.entityId),
   ],
 );
+
+// ────────────────────────────────────────────────────────────────────────────
+// QUA-632 Phase 1: defensive enrichment tables.
+//
+// `enrichment_targets` — estimated denominators per (entity, record_type)
+// so bursts can track progress toward coverage goals.
+// `enrichment_runs`    — ledger of a single burst operation, updated as
+// /api/enrichment/propose requests arrive.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const enrichmentTargets = pgTable(
+  "enrichment_targets",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    entityId: text("entity_id").notNull(),
+    recordType: text("record_type").notNull(),
+    estimatedTotal: integer("estimated_total").notNull(),
+    targetPct: real("target_pct").notNull().default(0.7),
+    estimatedAt: timestamp("estimated_at", { withTimezone: true }).notNull().defaultNow(),
+    basis: text("basis"),
+    confidence: text("confidence"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_enrichment_targets_entity_record").on(table.entityId, table.recordType),
+    index("idx_enrichment_targets_record_type").on(table.recordType),
+  ],
+);
+
+export const enrichmentRuns = pgTable(
+  "enrichment_runs",
+  {
+    id: text("id").primaryKey(),
+    label: text("label"),
+    recordType: text("record_type"),
+    entityId: text("entity_id"),
+    tier: text("tier"),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+    proposesTotal: integer("proposes_total").notNull().default(0),
+    proposesAccepted: integer("proposes_accepted").notNull().default(0),
+    proposesRejected: integer("proposes_rejected").notNull().default(0),
+    acceptedT1: integer("accepted_t1").notNull().default(0),
+    acceptedT2: integer("accepted_t2").notNull().default(0),
+    acceptedT3: integer("accepted_t3").notNull().default(0),
+    verdictConfirmed: integer("verdict_confirmed").notNull().default(0),
+    verdictContradicted: integer("verdict_contradicted").notNull().default(0),
+    verdictOutdated: integer("verdict_outdated").notNull().default(0),
+    verdictPartial: integer("verdict_partial").notNull().default(0),
+    verdictUnverifiable: integer("verdict_unverifiable").notNull().default(0),
+    costUsd: real("cost_usd").notNull().default(0),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_enrichment_runs_record_type").on(table.recordType),
+    index("idx_enrichment_runs_entity").on(table.entityId),
+    index("idx_enrichment_runs_started_at").on(sql`${table.startedAt} DESC`),
+  ],
+);


### PR DESCRIPTION
## Summary

Phase 1 of the [QUA-637](https://linear.app/quantifieduncertainty/issue/QUA-637) coverage-expansion umbrella. Ships the server-side tier-aware gate that enforces "no row without (evidence + verdict)" at a single chokepoint, plus the backing ledger tables.

The gate design is driven by [PR #4518](https://github.com/quantified-uncertainty/longterm-wiki/pull/4518) (QUA-635 verdict-LLM calibration): Haiku 4.5 is 0 % false-confirm at a **strict `verdict === "confirmed"` rule** with ~92 % recall. This PR encodes that rule at the server boundary so future callers can't accidentally weaken it.

## What lands

- **Migrations 0202 / 0203** (note: 0201 was taken by QUA-576; the QUA-632 spec's slot numbers shift by one):
  - `enrichment_targets` — estimated denominators per `(entity_id, record_type)` with a `basis` field so the estimate stays falsifiable. Used by coverage bursts to track progress.
  - `enrichment_runs` — per-burst ledger: proposes_total/accepted/rejected, tier breakdown, verdict distribution, cost. `id` is caller-supplied so a burst can resume across sessions. Has a `CHECK (char_length(id) <= 128)` for defense-in-depth.
- **`POST /api/enrichment/propose`** (`apps/wiki-server/src/routes/enrichment/enrichment.ts`):
  - **T1** — `sourceUrl` must match the T1 authority allowlist for the `(recordType, fieldName)` pair. On match, server produces `sourcing = {verdict: "confirmed", confidence: 1.0, checkedBy: "t1-<source-id>", ...}` — no verdict-LLM call.
  - **T2** — caller supplies `{verdict, quotedText, confidence, checkerModel}`; server enforces `verdict === "confirmed"`, minimum quote length (40 chars), and — when `sourceContent` is supplied — whitespace-tolerant verbatim substring check.
  - **T3** — T2 rules + reject homepage-like URLs (`/`, `/about`, `/contact`, etc.) to prevent the "homepage as source" failure mode from QUA-426 / QUA-648.
  - **Atomic (row + evidence + verdict)** is delegated to the existing grants sync sub-app via an in-process Hono `.fetch()` call. The sync handler's `writeInlineVerdicts` is already transactional; `/propose` does not duplicate the pipeline. Query-string escape hatches (`requireSourcing`, `forceSkipSourcing`, `skipEntityValidation`) are deliberately NOT plumbed through — the whole point of the gate is to enforce these uniformly.
  - Phase 1 supports `grants` as the initial record type; other record types are a one-entry extension to the in-file `RECORD_TYPE_ROUTES` registry once their sync handlers expose a stable route.
- **T1 allowlist** (`t1-allowlist.ts`) seeded with 7 sources: EA Funds, Coefficient Giving, OpenAlex, Wikidata, SEC EDGAR, Hugging Face Leaderboard, GitHub API. Each entry names the record types it's authoritative for.
- **Homepage detector** (`homepage-detector.ts`) — small pure module matching `/`, `/index`, `/home`, `/about`, `/contact` variants; lower-cased path comparison.
- **42 tests** (`apps/wiki-server/src/__tests__/enrichment-propose.test.ts`): T1 allowlist unit tests, homepage-detector table-driven cases, `computeSourcingForTier` pure-function cases (T1/T2/T3 accept + reject variants including `verdict=partial`, short quote, non-verbatim quote, whitespace tolerance), endpoint integration tests with the inner grants route mocked (capturing the forwarded row + sourcing), and ledger UPSERT SQL-capture tests.

## Deferred to follow-up

- **`crux tb tablebase loop` refactor to call `/propose`** (the last bullet of the QUA-632 deliverable). The refactor is an agent-tool change in `crux/tablebase/` that is cleaner to ship independently once this gate is merged and deployed. Filing as a follow-up Linear ticket so the endpoint's first caller lands with full context. No code ships today that exercises `/propose` against prod — the endpoint is available for the follow-up to wire up.
- **Per-field verdicts**: `writeInlineVerdicts` hardcodes `field_name = NULL`. Phase 1 therefore rejects non-null `fieldName` on `/propose` rather than silently writing a row-level verdict. Phase 2 will extend `InlineSourcing` + the sync pipeline to carry `field_name` through.

## Test plan

- [x] `pnpm crux w validate gate --fix` — 53/53 blocking checks pass (3 pre-existing advisory)
- [x] `pnpm build` — clean
- [x] `pnpm --filter "./apps/wiki-server" test` — 1337 passed / 55 skipped (was 1332/55 before; +5 from new tier-gate branches)
- [x] `pnpm --filter "./apps/wiki-server" test -- enrichment-propose` — 42/42
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean

## Observed this session

- **Migration slot shift**: QUA-632 spec called for 0201/0202; slot 0201 was already occupied by the merged QUA-576 `resources_stableid_notnull` migration. Using **0202 / 0203** instead. No cross-referencing tickets to update — QUA-632 itself still points at the right thing.
- **PR #4520 (QUA-634/639) references QUA-632** in its PR body as context. No real claim collision; `crux sys agent-checklist init` flagged it as a dedup hit, verified as a false positive (PR is for QUA-634 / QUA-639), forced past with explicit reason.
- **Verdict-LLM stays caller-side (crux), not server-side**. Wiki-server has no LLM infrastructure today; adding it for Phase 1 would be a separate, larger change. The strict-confirmed gate + verbatim quote check + homepage rejection give the same integrity guarantee whether the LLM runs on server or client. When `sourceContent` is supplied, the verbatim check actually verifies the caller's quote against the source — strong defense against a dishonest caller even without server-side LLM.

## Deploy Checklist

- [ ] Post-deploy: verify migration 0202 applied (`\d enrichment_targets`)
- [ ] Post-deploy: verify migration 0203 applied (`\d enrichment_runs`)
- [ ] Post-deploy: `GET /api/enrichment/propose` reachable (expect 405 / 404 because it's POST-only — just confirm the route exists under auth)
- [ ] Post-deploy: sanity-check /internal/data-quality or /health for schema-drift after Drizzle runs both migrations

Fixes QUA-632
