### PR TITLE
fix(QUA-620): FactBase facts use currency: not unit: (silent loader drop)

### DIFF
--- a/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
+++ b/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
@@ -216,10 +216,6 @@ describe("formatKBFactValue additional coverage", () => {
   });
 
   it("uses fact.currency to override property unit for monetary values (QUA-620)", () => {
-    // Regression: Ada Lovelace Institute's total-funding fact is stored as
-    // 5e6 GBP. The `total-funding` property defaults to unit USD with prefix
-    // "$". Without the currency override, the overview rendered "$5 million".
-    // With currency: "GBP", it must render with the pound sign.
     const fact: Fact = {
       id: "f_Hw1vL6tN9c",
       subjectId: "sid_BgSnHHzV6g",

--- a/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
+++ b/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
@@ -214,4 +214,25 @@ describe("formatKBFactValue additional coverage", () => {
     const fact = makeFact("weird", { type: "custom" as never, value: { a: 1 } } as never);
     expect(formatKBFactValue(fact)).toBe('{"a":1}');
   });
+
+  it("uses fact.currency to override property unit for monetary values (QUA-620)", () => {
+    // Regression: Ada Lovelace Institute's total-funding fact is stored as
+    // 5e6 GBP. The `total-funding` property defaults to unit USD with prefix
+    // "$". Without the currency override, the overview rendered "$5 million".
+    // With currency: "GBP", it must render with the pound sign.
+    const fact: Fact = {
+      id: "f_Hw1vL6tN9c",
+      subjectId: "sid_BgSnHHzV6g",
+      propertyId: "total-funding",
+      value: { type: "number", value: 5_000_000 },
+      currency: "GBP",
+    };
+    const result = formatKBFactValue(fact, "USD", {
+      divisor: 1e9,
+      prefix: "$",
+      suffix: "B",
+    });
+    expect(result).toContain("£");
+    expect(result).not.toContain("$");
+  });
 });

--- a/crux/validate/validate-factbase-fact-unit-field.test.ts
+++ b/crux/validate/validate-factbase-fact-unit-field.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+
+import { checkContent } from "./validate-factbase-fact-unit-field.ts";
+
+describe("validate-factbase-fact-unit-field", () => {
+  it("flags a top-level `unit:` field on a fact (indent 4)", () => {
+    const yaml = [
+      "entity: sid_abc123",
+      "facts:",
+      "  - id: f_foo",
+      "    property: total-funding",
+      "    value: 5e+6",
+      "    unit: GBP",
+      "    asOf: 2018-01",
+      "",
+    ].join("\n");
+
+    const violations = checkContent(yaml);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].line).toBe(6);
+    expect(violations[0].suggestion).toContain("currency: GBP");
+  });
+
+  it("does not flag `currency:` at fact top-level", () => {
+    const yaml = [
+      "entity: sid_abc123",
+      "facts:",
+      "  - id: f_foo",
+      "    property: total-funding",
+      "    value: 5e+6",
+      "    currency: GBP",
+      "",
+    ].join("\n");
+
+    expect(checkContent(yaml)).toHaveLength(0);
+  });
+
+  it("does not flag `unit:` inside a structured value block (indent 6+)", () => {
+    const yaml = [
+      "entity: sid_abc123",
+      "facts:",
+      "  - id: f_foo",
+      "    property: total-funding",
+      "    value:",
+      "      type: number",
+      "      value: 5e+6",
+      "      unit: GBP",
+      "",
+    ].join("\n");
+
+    expect(checkContent(yaml)).toHaveLength(0);
+  });
+
+  it("flags multiple violations and reports each line", () => {
+    const yaml = [
+      "facts:",
+      "  - id: f_1",
+      "    property: revenue",
+      "    unit: EUR",
+      "  - id: f_2",
+      "    property: valuation",
+      "    unit: JPY",
+      "",
+    ].join("\n");
+
+    const violations = checkContent(yaml);
+    expect(violations).toHaveLength(2);
+    expect(violations[0].line).toBe(4);
+    expect(violations[0].suggestion).toContain("currency: EUR");
+    expect(violations[1].line).toBe(7);
+    expect(violations[1].suggestion).toContain("currency: JPY");
+  });
+
+  it("flags percent/count units too (even when non-monetary) because the loader drops them the same way", () => {
+    const yaml = [
+      "facts:",
+      "  - id: f_1",
+      "    property: market-share",
+      "    value: 64",
+      "    unit: percent",
+      "",
+    ].join("\n");
+
+    const violations = checkContent(yaml);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].text).toContain("unit: percent");
+  });
+
+  it("returns no violations for a well-formed facts file", () => {
+    const yaml = [
+      "entity: sid_abc123",
+      "facts:",
+      "  - id: f_1",
+      "    property: founded-date",
+      "    value: '2018'",
+      "  - id: f_2",
+      "    property: total-funding",
+      "    value: 5e+6",
+      "    currency: GBP",
+      "    usdEquivalent: 6700000",
+      "",
+    ].join("\n");
+
+    expect(checkContent(yaml)).toHaveLength(0);
+  });
+});

--- a/crux/validate/validate-factbase-fact-unit-field.test.ts
+++ b/crux/validate/validate-factbase-fact-unit-field.test.ts
@@ -86,6 +86,41 @@ describe("validate-factbase-fact-unit-field", () => {
     expect(violations[0].text).toContain("unit: percent");
   });
 
+  it("catches case typos (Unit/UNIT/units) the loader also silently drops", () => {
+    const yaml = [
+      "facts:",
+      "  - id: f_1",
+      "    property: revenue",
+      "    Unit: EUR",
+      "  - id: f_2",
+      "    property: revenue",
+      "    UNIT: JPY",
+      "  - id: f_3",
+      "    property: revenue",
+      "    units: CAD",
+      "",
+    ].join("\n");
+
+    const violations = checkContent(yaml);
+    expect(violations).toHaveLength(3);
+    expect(violations[0].suggestion).toContain("currency: EUR");
+    expect(violations[1].suggestion).toContain("currency: JPY");
+    expect(violations[2].suggestion).toContain("currency: CAD");
+  });
+
+  it("does not flag `unit:` appearing inside a YAML comment (# marker precedes)", () => {
+    const yaml = [
+      "facts:",
+      "  - id: f_1",
+      "    property: revenue",
+      "    # unit: GBP (old, replaced by currency below)",
+      "    currency: GBP",
+      "",
+    ].join("\n");
+
+    expect(checkContent(yaml)).toHaveLength(0);
+  });
+
   it("returns no violations for a well-formed facts file", () => {
     const yaml = [
       "entity: sid_abc123",

--- a/crux/validate/validate-factbase-fact-unit-field.ts
+++ b/crux/validate/validate-factbase-fact-unit-field.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * Validate that FactBase fact entries don't use a top-level `unit:` field.
- *
- * The Fact schema (packages/factbase/src/types.ts) declares `currency` for
- * ISO 4217 overrides. The loader (packages/factbase/src/loader.ts::parseFact)
- * only reads `currency` — a top-level `unit:` on a fact is silently dropped,
- * and the property-level unit default applies. This looks like the author
- * set a currency, but the rendered value uses the property's default symbol
- * (usually $), producing wrong output like "$5 million" for a £5M fact.
- *
- * Incident: QUA-620. Ada Lovelace Institute's total-funding fact had
- * `unit: GBP`; the overview rendered "$5 million" while the /data page's
- * funding round (correctly stored) rendered "£5M / $6.7M".
- *
- * Fix: use `currency: GBP` (or `currency: EUR` etc.) at the fact top-level.
- *
- * Usage: npx tsx crux/validate/validate-factbase-fact-unit-field.ts
+ * Reject `unit:` (and case/plural typos) at a FactBase fact top-level.
+ * The loader only reads `currency:` for ISO 4217 overrides; `unit:` is
+ * silently dropped and the property default takes over — which produced
+ * QUA-620 ("$5 million" for a £5M fact).
  */
 
 import { readFileSync, readdirSync } from "fs";
@@ -29,17 +17,10 @@ const FB_ENTITIES_DIR = join(
   "packages/factbase/data/fb-entities",
 );
 
-// Fact top-level fields live at YAML indent depth 4 (2-space indent):
-//   facts:
-//     - id: f_x
-//       property: p
-//       unit: GBP      <- depth 4 (4 spaces)
-//       value: ...
-// A `unit:` inside a structured value block would be deeper (6+ spaces).
-//
-// Case-insensitive on the key name so typos like `Unit:`, `UNIT:`, and
-// plural `units:` also surface — the loader drops all of them silently.
-const FACT_TOP_LEVEL_UNIT_RE = /^ {4}(unit|Unit|UNIT|units):\s*(\S.*?)\s*$/;
+// Fact top-level = 4-space indent; a `unit:` inside a value block would be 6+.
+// Case-insensitive + optional plural so typos (`Unit:`, `UNIT:`, `units:`) — which
+// the loader also silently drops — surface here.
+const FACT_TOP_LEVEL_UNIT_RE = /^ {4}(units?):\s*(\S.*?)\s*$/i;
 
 export interface Violation {
   file: string;

--- a/crux/validate/validate-factbase-fact-unit-field.ts
+++ b/crux/validate/validate-factbase-fact-unit-field.ts
@@ -36,7 +36,10 @@ const FB_ENTITIES_DIR = join(
 //       unit: GBP      <- depth 4 (4 spaces)
 //       value: ...
 // A `unit:` inside a structured value block would be deeper (6+ spaces).
-const FACT_TOP_LEVEL_UNIT_RE = /^ {4}unit:\s*(\S.*?)\s*$/;
+//
+// Case-insensitive on the key name so typos like `Unit:`, `UNIT:`, and
+// plural `units:` also surface — the loader drops all of them silently.
+const FACT_TOP_LEVEL_UNIT_RE = /^ {4}(unit|Unit|UNIT|units):\s*(\S.*?)\s*$/;
 
 export interface Violation {
   file: string;
@@ -60,12 +63,13 @@ export function checkContent(
     const line = lines[i];
     const match = FACT_TOP_LEVEL_UNIT_RE.exec(line);
     if (!match) continue;
-    const rawValue = match[1];
+    const key = match[1];
+    const rawValue = match[2];
     violations.push({
       file: filePath,
       line: i + 1,
       text: line,
-      suggestion: `Replace \`unit: ${rawValue}\` with \`currency: ${rawValue}\` (or remove if redundant with property default).`,
+      suggestion: `Replace \`${key}: ${rawValue}\` with \`currency: ${rawValue}\` (or remove if redundant with property default).`,
     });
   }
 

--- a/crux/validate/validate-factbase-fact-unit-field.ts
+++ b/crux/validate/validate-factbase-fact-unit-field.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that FactBase fact entries don't use a top-level `unit:` field.
+ *
+ * The Fact schema (packages/factbase/src/types.ts) declares `currency` for
+ * ISO 4217 overrides. The loader (packages/factbase/src/loader.ts::parseFact)
+ * only reads `currency` — a top-level `unit:` on a fact is silently dropped,
+ * and the property-level unit default applies. This looks like the author
+ * set a currency, but the rendered value uses the property's default symbol
+ * (usually $), producing wrong output like "$5 million" for a £5M fact.
+ *
+ * Incident: QUA-620. Ada Lovelace Institute's total-funding fact had
+ * `unit: GBP`; the overview rendered "$5 million" while the /data page's
+ * funding round (correctly stored) rendered "£5M / $6.7M".
+ *
+ * Fix: use `currency: GBP` (or `currency: EUR` etc.) at the fact top-level.
+ *
+ * Usage: npx tsx crux/validate/validate-factbase-fact-unit-field.ts
+ */
+
+import { readFileSync, readdirSync } from "fs";
+import { join, relative } from "path";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+
+const FB_ENTITIES_DIR = join(
+  PROJECT_ROOT,
+  "packages/factbase/data/fb-entities",
+);
+
+// Fact top-level fields live at YAML indent depth 4 (2-space indent):
+//   facts:
+//     - id: f_x
+//       property: p
+//       unit: GBP      <- depth 4 (4 spaces)
+//       value: ...
+// A `unit:` inside a structured value block would be deeper (6+ spaces).
+const FACT_TOP_LEVEL_UNIT_RE = /^ {4}unit:\s*(\S.*?)\s*$/;
+
+export interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  suggestion: string;
+}
+
+/**
+ * Scan YAML content for `unit:` at fact top-level (indent depth 4).
+ * Exported for direct testing.
+ */
+export function checkContent(
+  content: string,
+  filePath = "<inline>",
+): Violation[] {
+  const lines = content.split("\n");
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const match = FACT_TOP_LEVEL_UNIT_RE.exec(line);
+    if (!match) continue;
+    const rawValue = match[1];
+    violations.push({
+      file: filePath,
+      line: i + 1,
+      text: line,
+      suggestion: `Replace \`unit: ${rawValue}\` with \`currency: ${rawValue}\` (or remove if redundant with property default).`,
+    });
+  }
+
+  return violations;
+}
+
+function checkFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, "utf-8");
+  const relPath = relative(PROJECT_ROOT, filePath);
+  return checkContent(content, relPath);
+}
+
+export function runCheck(): {
+  passed: boolean;
+  errors: number;
+  violations: Violation[];
+} {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking for dropped \`unit:\` fields at FactBase fact top-level...${c.reset}\n`,
+  );
+
+  let files: string[];
+  try {
+    files = readdirSync(FB_ENTITIES_DIR)
+      .filter((f) => f.endsWith(".yaml"))
+      .map((f) => join(FB_ENTITIES_DIR, f));
+  } catch {
+    console.log(`${c.dim}fb-entities directory not found: ${FB_ENTITIES_DIR}${c.reset}`);
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  const allViolations: Violation[] = [];
+  for (const file of files) {
+    allViolations.push(...checkFile(file));
+  }
+
+  if (allViolations.length === 0) {
+    console.log(
+      `${c.green}No stray \`unit:\` fields found (${files.length} files checked)${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${allViolations.length} stray \`unit:\` field(s) that the loader will silently drop:${c.reset}\n`,
+    );
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}`);
+      console.log(`    ${c.dim}${v.text}${c.reset}`);
+      console.log(`    ${c.dim}Fix: ${v.suggestion}${c.reset}\n`);
+    }
+    console.log(
+      `${c.dim}Background: facts use \`currency\` for ISO 4217 overrides; \`unit\` is only valid on Property definitions in properties.yaml. See QUA-620.${c.reset}`,
+    );
+  }
+
+  return {
+    passed: allViolations.length === 0,
+    errors: allViolations.length,
+    violations: allViolations,
+  };
+}
+
+if (process.argv[1]?.includes("validate-factbase-fact-unit-field")) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -390,6 +390,15 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'factbase-fact-unit-field',
+    name: 'FactBase facts use `currency:` not `unit:` (loader drops stray unit fields)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-factbase-fact-unit-field.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: `unit:` at a fact top-level is silently dropped by the loader,
+    // causing currency symbol mismatches (QUA-620: £5M fact rendered as $5M).
+  },
+  {
     id: 'dot-position',
     name: 'Dot indicator position (SourcingDot / RecordStatusDots not in first column)',
     command: 'npx',

--- a/packages/factbase/data/fb-entities/access-now.yaml
+++ b/packages/factbase/data/fb-entities/access-now.yaml
@@ -14,7 +14,7 @@ facts:
   - id: f_0gN2dWSxYB
     property: annual-revenue
     value: "15000000"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://en.wikipedia.org/wiki/Access_Now
     notes: "Approximate figure from Wikipedia. Superseded by FY 2024 Form 990 data (f_YY42DsWj0s) showing $16.15M."
@@ -36,7 +36,7 @@ facts:
   - id: f_YY42DsWj0s
     property: annual-revenue
     value: "16152454"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/270597430
     notes: "FY 2024 Form 990 (EIN 27-0597430). Total expenses $15,120,599. Net assets $8,112,583. Contributions made up 99%+ of revenue."

--- a/packages/factbase/data/fb-entities/aclu.yaml
+++ b/packages/factbase/data/fb-entities/aclu.yaml
@@ -9,7 +9,7 @@ facts:
   - id: f_2puku4DVng
     property: annual-revenue
     value: "307000000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://projects.propublica.org/nonprofits/organizations/136213516
     notes: "ACLU Foundation revenue ~$307M (FY ending March 2025). Separate

--- a/packages/factbase/data/fb-entities/ada-lovelace-institute.yaml
+++ b/packages/factbase/data/fb-entities/ada-lovelace-institute.yaml
@@ -17,8 +17,6 @@ facts:
     value: 5e+6
     currency: GBP
     usdEquivalent: 6700000
-    exchangeRate: 1.34
-    exchangeRateDate: 2018-03
     asOf: 2018-01
     source: https://www.nuffieldfoundation.org/news/the-nuffield-foundation-announces-new-5-million-ada-lovelace-institute
     notes: "Nuffield Foundation committed GBP 5 million over five years to establish the institute (~USD 6.7M at 2018 exchange rates)."

--- a/packages/factbase/data/fb-entities/ada-lovelace-institute.yaml
+++ b/packages/factbase/data/fb-entities/ada-lovelace-institute.yaml
@@ -15,10 +15,13 @@ facts:
   - id: f_Hw1vL6tN9c
     property: total-funding
     value: 5e+6
-    unit: GBP
+    currency: GBP
+    usdEquivalent: 6700000
+    exchangeRate: 1.34
+    exchangeRateDate: 2018-03
     asOf: 2018-01
     source: https://www.nuffieldfoundation.org/news/the-nuffield-foundation-announces-new-5-million-ada-lovelace-institute
-    notes: "Nuffield Foundation committed GBP 5 million over five years to establish the institute (~USD 6.5M at 2018 exchange rates)."
+    notes: "Nuffield Foundation committed GBP 5 million over five years to establish the institute (~USD 6.7M at 2018 exchange rates)."
 
   - id: f_Jy4cJ7mQ3d
     property: legal-structure

--- a/packages/factbase/data/fb-entities/ai-now-institute.yaml
+++ b/packages/factbase/data/fb-entities/ai-now-institute.yaml
@@ -130,7 +130,7 @@ facts:
   - id: f_vYiIVBXPH0
     property: grant-received
     value: "2000000"
-    unit: USD
+    currency: USD
     asOf: 2026-02
     source: https://www.macfound.org/press/press-releases/10-million-to-advance-ai-by-and-for-people
     notes: "MacArthur Foundation $2M grant announced Feb 12, 2026, part of $10M Humanity AI initiative for national security and AI"

--- a/packages/factbase/data/fb-entities/ai-policy-institute.yaml
+++ b/packages/factbase/data/fb-entities/ai-policy-institute.yaml
@@ -25,7 +25,7 @@ facts:
   - id: f_vZve8M0opl
     property: grant-received
     value: "1635000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://survivalandflourishing.fund/2025/recommendations
     notes: "SFF 2025 grant: $1,635,000 for general support"
@@ -33,7 +33,7 @@ facts:
   - id: f_BTIfaFnsU8
     property: grant-received
     value: "142000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://survivalandflourishing.fund/2024/recommendations
     notes: "SFF 2024 grant: $142,000 for general support"

--- a/packages/factbase/data/fb-entities/algorithmwatch.yaml
+++ b/packages/factbase/data/fb-entities/algorithmwatch.yaml
@@ -20,7 +20,7 @@ facts:
   - id: f_lGRSYGn2Xw
     property: annual-revenue
     value: "1200000"
-    unit: EUR
+    currency: EUR
     asOf: 2022
     source: https://algorithmwatch.org/en/transparency/
     notes: "2022: grants EUR 1.12M + donations EUR 60K + other EUR 17K. Major funders: Alfred Landecker Foundation, BMBF, BMUV, Deutsche Postcode Lotterie"

--- a/packages/factbase/data/fb-entities/americans-for-responsible-innovation.yaml
+++ b/packages/factbase/data/fb-entities/americans-for-responsible-innovation.yaml
@@ -33,7 +33,7 @@ facts:
   - id: f_sVDGE7x4Yu
     property: lobbying-spend
     value: "1080000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://lda.senate.gov/filings/public/filing/search/?client=Americans+for+Responsible+Innovation
     notes: "Total 2024 federal lobbying ~$1.08M (in-house $700K + external firms $380K). Verified from Senate LDA filings."
@@ -41,7 +41,7 @@ facts:
   - id: f_aFSIs1oXPv
     property: lobbying-spend
     value: "2110000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://lda.senate.gov/filings/public/filing/search/?client=Americans+for+Responsible+Innovation
     notes: "Total 2025 federal lobbying ~$2.11M. Largest pro-safety AI lobbying spender. Verified from Senate LDA."
@@ -49,7 +49,7 @@ facts:
   - id: f_fT7iaHWSgm
     property: pac-fundraising
     value: "91661"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.opensecrets.org/political-action-committees-pacs/americans-for-responsible-innovation/C00873356/summary/2024
     notes: "Hybrid PAC raised $91,661; contributed $60,300 to federal candidates"

--- a/packages/factbase/data/fb-entities/asml.yaml
+++ b/packages/factbase/data/fb-entities/asml.yaml
@@ -98,7 +98,6 @@ facts:
   - id: f_kFj7TBgRuP
     property: euv-market-share
     value: 100
-    unit: percent
     asOf: 2024-12
     source: https://en.wikipedia.org/wiki/ASML_Holding
     notes: "ASML is the sole supplier of EUV lithography machines globally; no competitor"
@@ -106,7 +105,7 @@ facts:
   - id: f_l2QMMMF9BM
     property: euv-system-price
     value: 380000000
-    unit: USD
+    currency: USD
     asOf: 2024-12
     source: https://en.wikipedia.org/wiki/ASML_Holding
     notes: "High-NA EUV systems cost approximately $380M each; standard EUV ~$150-200M"

--- a/packages/factbase/data/fb-entities/brennan-center.yaml
+++ b/packages/factbase/data/fb-entities/brennan-center.yaml
@@ -9,7 +9,7 @@ facts:
   - id: f_ZLxIVY8SBQ
     property: annual-revenue
     value: "57900000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://en.wikipedia.org/wiki/Brennan_Center_for_Justice
     notes: "Approximately $57.9M (FY 2023-2024). ProPublica URL 404; figure confirmed via Wikipedia."

--- a/packages/factbase/data/fb-entities/brookings-ai.yaml
+++ b/packages/factbase/data/fb-entities/brookings-ai.yaml
@@ -53,7 +53,7 @@ facts:
   - id: f_Cq7BVOPP2O
     property: revenue
     value: "100000000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://en.wikipedia.org/wiki/Brookings_Institution
     notes: "Approximate annual operating expenses for the full Brookings Institution (~$100M)"

--- a/packages/factbase/data/fb-entities/cais-action-fund.yaml
+++ b/packages/factbase/data/fb-entities/cais-action-fund.yaml
@@ -21,7 +21,7 @@ facts:
   - id: f_kWG7y5ECDN
     property: lobbying-spend
     value: "490000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.opensecrets.org/federal-lobbying/clients/summary?cycle=2024&id=D000110584
     notes: "Total 2024 federal lobbying ~$490K (in-house $270K + Akin Gump $160K + Michael Best $60K). Verified from Senate LDA filings."
@@ -29,7 +29,7 @@ facts:
   - id: f_84KoWjirDP
     property: lobbying-spend
     value: "420000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://lda.senate.gov/filings/public/filing/search/?client=Center+for+AI+Safety+Action+Fund
     notes: "Total 2025 federal lobbying ~$420K (in-house $310K + Michael Best $110K). Verified from Senate LDA."

--- a/packages/factbase/data/fb-entities/cais.yaml
+++ b/packages/factbase/data/fb-entities/cais.yaml
@@ -64,7 +64,7 @@ facts:
   - id: f_rYN3krk6tQ
     property: revenue
     value: "6660060"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990. EIN: 88-1751310. First year of operations."
@@ -72,7 +72,7 @@ facts:
   - id: f_UgwULHbsZr
     property: revenue
     value: "16089191"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990"
@@ -80,7 +80,7 @@ facts:
   - id: f_HC5iejEJyY
     property: revenue
     value: "10235085"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990. EIN: 88-1751310."
@@ -88,7 +88,7 @@ facts:
   - id: f_2gFP8riiGw
     property: annual-expenses
     value: "816760"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990. First year of operations; low expenses relative to revenue."
@@ -96,7 +96,7 @@ facts:
   - id: f_YgMeE4EFsw
     property: annual-expenses
     value: "8134449"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990. Significant increase as organization scaled up."
@@ -104,14 +104,14 @@ facts:
   - id: f_DrCHRnYm9V
     property: annual-expenses
     value: "7163607"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/881751310
 
   - id: f_iKgkztnKMQ
     property: grant-received
     value: "5160000"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://www.openphilanthropy.org/grants/center-for-ai-safety-general-support/
     notes: "Open Philanthropy general support grant to CAIS, 2022"
@@ -119,7 +119,7 @@ facts:
   - id: f_JKwyv80ODu
     property: grant-received
     value: "5460000"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://www.openphilanthropy.org/grants/center-for-ai-safety-general-support-2023/
     notes: "Open Philanthropy general support grant to CAIS, 2023. Total OP funding to CAIS across 2022-2023 was ~$10.6M per donations tracker."
@@ -127,7 +127,7 @@ facts:
   - id: f_2o7SVDOLcV
     property: grant-received
     value: "2767000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://survivalandflourishing.fund/2024/recommendations
     notes: "SFF 2024: $1,146K to CAIS Inc + $1,621K to CAIS Action Fund = $2,767K total"
@@ -135,7 +135,7 @@ facts:
   - id: f_IFDN4UddCw
     property: grant-received
     value: "1061000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://survivalandflourishing.fund/2025/recommendations
     notes: "SFF 2025: $289K to CAIS Inc + $772K to CAIS Action Fund = $1,061K total"
@@ -169,7 +169,7 @@ facts:
   - id: f_BnRfdZYOjA
     property: net-assets
     value: "5843300"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990. End of first year."
@@ -177,7 +177,7 @@ facts:
   - id: f_Wh3ZWtew6g
     property: net-assets
     value: "8538240"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990."
@@ -185,7 +185,7 @@ facts:
   - id: f_DldXXRYERQ
     property: net-assets
     value: "11609718"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/881751310
     notes: "From IRS Form 990."

--- a/packages/factbase/data/fb-entities/carnegie-endowment.yaml
+++ b/packages/factbase/data/fb-entities/carnegie-endowment.yaml
@@ -14,7 +14,7 @@ facts:
   - id: f_ry7EKNUU3Y
     property: annual-revenue
     value: "57574887"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://projects.propublica.org/nonprofits/organizations/130552040
     notes: "FY ending June 2025. Total assets $602M."

--- a/packages/factbase/data/fb-entities/center-for-ai-policy.yaml
+++ b/packages/factbase/data/fb-entities/center-for-ai-policy.yaml
@@ -33,7 +33,7 @@ facts:
   - id: f_gXQzCR6lTO
     property: lobbying-spend
     value: "281964"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.opensecrets.org/orgs/center-for-ai-policy/summary?id=D000110490
     notes: "2024 in-house federal lobbying. Lobbyists: Jason Green-Lowe, Jakub Stanger Kraus, Martin Spitzer. Verified from Senate LDA."
@@ -41,7 +41,7 @@ facts:
   - id: f_6YetHpmHhR
     property: grant-received
     value: "288000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://survivalandflourishing.fund/2024/recommendations
     notes: "SFF 2024 grant for general support"

--- a/packages/factbase/data/fb-entities/center-for-democracy-and-technology.yaml
+++ b/packages/factbase/data/fb-entities/center-for-democracy-and-technology.yaml
@@ -15,7 +15,7 @@ facts:
   - id: f_bPJsTpgjnP
     property: annual-revenue
     value: "11300000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/521905358
     notes: "Revenue $11.3M. Expenses $8.77M. Assets $21.3M. Revenue: 56% foundations, 24% corporations, 10% events."

--- a/packages/factbase/data/fb-entities/center-for-humane-technology.yaml
+++ b/packages/factbase/data/fb-entities/center-for-humane-technology.yaml
@@ -14,7 +14,7 @@ facts:
   - id: f_cs4sXkLptL
     property: annual-revenue
     value: "1800000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://www.humanetech.com
     notes: "Approximately $1.8M annual revenue"
@@ -35,7 +35,7 @@ facts:
   - id: f_D5bcDZJL8W
     property: lobbying-spend
     value: "320000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://lda.senate.gov/filings/public/filing/search/?client=Center+for+Humane+Technology
     notes: "Federal lobbying via Holland & Knight LLP: $80K/quarter consistently
@@ -44,7 +44,7 @@ facts:
   - id: f_Wf8azn6DG2
     property: lobbying-spend
     value: "320000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://lda.senate.gov/filings/public/filing/search/?client=Center+for+Humane+Technology
     notes: "Same $80K/quarter pattern through Holland & Knight"
@@ -52,7 +52,7 @@ facts:
   - id: f_cFUKtV2tG7
     property: grant-received
     value: "468000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://survivalandflourishing.fund/2025/recommendations
     notes: "SFF 2025 grant for general support"
@@ -67,7 +67,7 @@ facts:
   - id: f_hEE9D2RAKl
     property: annual-revenue
     value: "3580000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.humanetech.com
     notes: "Most recent 990: revenue $3.58M, expenses $6.33M, net assets $6.01M,

--- a/packages/factbase/data/fb-entities/collective-intelligence-project.yaml
+++ b/packages/factbase/data/fb-entities/collective-intelligence-project.yaml
@@ -47,7 +47,7 @@ facts:
   - id: f_Hn1VyhLA0a
     property: annual-revenue
     value: "1908186"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/920327339
     notes: "Nearly all revenue from contributions ($1.91M). Total assets $2.47M. Net income $1.64M. Operates exclusively through philanthropic donations."

--- a/packages/factbase/data/fb-entities/cset.yaml
+++ b/packages/factbase/data/fb-entities/cset.yaml
@@ -11,7 +11,7 @@ facts:
   - id: f_bhVFcp5tGp
     property: cumulative-funding
     value: "100000000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://cset.georgetown.edu/article/new-grant-agreement-boosts-cset-funding-to-more-than-100-million-over-five-years/
     notes: "Total Open Philanthropy/Coefficient Giving funding >$100M over 5 years (founding $55M 2019 + $42M renewal 2021 + additional grants)"
@@ -73,7 +73,7 @@ facts:
   - id: f_QGx6d8Eut1
     property: grant-received
     value: "5000000"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://cset.georgetown.edu/article/the-hewlett-foundation-awards-cset-an-additional-3-million-to-continue-cyber-and-ai-research/
     notes: "Hewlett Foundation CyberAI grants totaling $5M ($2M in 2019, $3M renewal in 2022)"

--- a/packages/factbase/data/fb-entities/epic-privacy.yaml
+++ b/packages/factbase/data/fb-entities/epic-privacy.yaml
@@ -35,7 +35,7 @@ facts:
   - id: f_9UHngbbF1G
     property: annual-revenue
     value: "3029134"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/522225921
     notes: "FY 2024 Form 990 (EIN 52-2225921). Total expenses $3,368,137. Net assets $4,215,708. Revenue peaked at $3.8M in 2023."

--- a/packages/factbase/data/fb-entities/fli.yaml
+++ b/packages/factbase/data/fb-entities/fli.yaml
@@ -22,21 +22,21 @@ facts:
   - id: f_de9hyXzJ2M
     property: grant-given
     value: "25025000"
-    unit: USD
+    currency: USD
     asOf: !date 2022-12
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Initial capitalization of Future of Life Foundation (FLF)
   - id: f_I1oSDd9OAz
     property: grant-given
     value: "15700000"
-    unit: USD
+    currency: USD
     asOf: !date 2023
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional grant to FLF in 2023
   - id: f_ngxodh3SNe
     property: grant-given
     value: "18100000"
-    unit: USD
+    currency: USD
     asOf: !date 2024
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional grant to FLF in 2024
@@ -44,7 +44,7 @@ facts:
   - id: f_vm1oBsIh14
     property: lobbying-spend
     value: "310000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.opensecrets.org/federal-lobbying/clients/summary?cycle=2025&id=D000087562
     notes: "US federal lobbying via Dentons: $310K in 2024. Verified from Senate LDA filings."
@@ -52,7 +52,7 @@ facts:
   - id: f_h4e6LBhlmR
     property: lobbying-spend
     value: "360000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://lda.senate.gov/filings/public/filing/search/?client=Future+of+Life+Institute
     notes: "US federal lobbying via Dentons: $360K in 2025 ($90K/quarter). Verified from Senate LDA."
@@ -60,7 +60,7 @@ facts:
   - id: f_LA81LD1WDK
     property: lobbying-spend
     value: "446619"
-    unit: EUR
+    currency: EUR
     asOf: 2024
     source: https://www.lobbyfacts.eu/datacard/future-of-life-institute?rid=787064543128-10
     notes: "EU advocacy spend EUR 446,619 (includes staff + Dentons Global Advisors). 2.5 FTE, 5 lobbyists, 3 EP accreditation passes."
@@ -93,7 +93,7 @@ facts:
   - id: f_s83tI9sEe6
     property: grant-received
     value: "10000000"
-    unit: USD
+    currency: USD
     asOf: 2015
     source: https://en.wikipedia.org/wiki/Future_of_Life_Institute
     notes: "Elon Musk donated $10M to FLI in January 2015 to fund research grants on AI safety"
@@ -101,7 +101,7 @@ facts:
   - id: f_2PAHN0Iwku
     property: grant-received
     value: "665800000"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://en.wikipedia.org/wiki/Future_of_Life_Institute
     notes: "Vitalik Buterin donated $665.8M in SHIB tokens to FLI in May 2021. Buterin confirmed ~$500M was actually cashed out (March 2026). Majority transferred to a donor-advised fund."
@@ -115,7 +115,7 @@ facts:
   - id: f_Gz4uyRC44r
     property: revenue
     value: "549531672"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990. Spike from Vitalik Buterin SHIB token donation."
@@ -123,7 +123,7 @@ facts:
   - id: f_J3dYwWWqrw
     property: revenue
     value: "4717340"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990"
@@ -131,7 +131,7 @@ facts:
   - id: f_feRFvTG4CX
     property: revenue
     value: "21273381"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990. Only $85K in new donor contributions; rest from endowment."
@@ -139,7 +139,7 @@ facts:
   - id: f_aEq32QQklw
     property: annual-expenses
     value: "16065773"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990"
@@ -147,7 +147,7 @@ facts:
   - id: f_s2O048D4tQ
     property: annual-expenses
     value: "16317712"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990"
@@ -155,7 +155,7 @@ facts:
   - id: f_A8f0X4bXW4
     property: annual-expenses
     value: "17399051"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "Breakdown: Grants 49%, Personnel 20%, Contractors 13%, Media 11%, Events 5%, Other 2%"
@@ -170,7 +170,7 @@ facts:
   - id: f_Gz4uyRC44r
     property: one-time-donation
     value: "549531672"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/471052538
     notes: "From IRS Form 990. Vitalik Buterin SHIB token donation — one-time windfall,

--- a/packages/factbase/data/fb-entities/ford-foundation.yaml
+++ b/packages/factbase/data/fb-entities/ford-foundation.yaml
@@ -13,14 +13,14 @@ facts:
   - id: f_6sfr123pxM
     property: total-assets
     value: "17480000000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/131684331
 
   - id: f_nrz9SeHOD7
     property: annual-revenue
     value: "1150000000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/131684331
     notes: "92.8% from investment sales, 6.9% dividends. Total expenses $1.04B. Charitable disbursements ~$1.05B."
@@ -28,7 +28,7 @@ facts:
   - id: f_wnEwWXmN3A
     property: annual-grantmaking
     value: "840000000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.fordfoundation.org/work/our-grants/
     notes: "$4.2B in grants over past 5 years (~$840M/year average). ~1,400 grants/year worldwide."

--- a/packages/factbase/data/fb-entities/foresight-institute.yaml
+++ b/packages/factbase/data/fb-entities/foresight-institute.yaml
@@ -29,7 +29,7 @@ facts:
   - id: f_qM9MOhiX3V
     property: total-assets
     value: "8900000"
-    unit: USD
+    currency: USD
     asOf: "2024"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990 filing (fiscal year ending Dec 2024, filed Nov 2025). EIN: 77-0119168."
@@ -37,7 +37,7 @@ facts:
   - id: f_h0OSCecsVg
     property: annual-expenses
     value: "1050000"
-    unit: USD
+    currency: USD
     asOf: "2021"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990"
@@ -45,7 +45,7 @@ facts:
   - id: f_PwmzuTbNLQ
     property: annual-expenses
     value: "1970000"
-    unit: USD
+    currency: USD
     asOf: "2022"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990"
@@ -53,7 +53,7 @@ facts:
   - id: f_Kfhwhz9Iow
     property: annual-expenses
     value: "2620000"
-    unit: USD
+    currency: USD
     asOf: "2023"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990"
@@ -61,7 +61,7 @@ facts:
   - id: f_3oG8SogVOI
     property: annual-expenses
     value: "3750000"
-    unit: USD
+    currency: USD
     asOf: "2024"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "Total functional expenses from Form 990 (fiscal year ending Dec 2024, filed Nov 2025)"
@@ -135,7 +135,7 @@ facts:
   - id: f_StP6Vh4wkV
     property: total-funding
     value: "290000"
-    unit: USD
+    currency: USD
     asOf: "2023"
     source: https://futureoflife.org/grant/foresight-institute-existential-hope/
     notes: "Grant from Future of Life Institute for Existential Hope and Tech Tree Programs, published October 2023"
@@ -143,7 +143,7 @@ facts:
   - id: f_A3gqqlkvOg
     property: revenue
     value: "1601000"
-    unit: USD
+    currency: USD
     asOf: "2021"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990. Growth year as organization expanded into AI safety."
@@ -151,7 +151,7 @@ facts:
   - id: f_TSbd1JsuHw
     property: revenue
     value: "2400000"
-    unit: USD
+    currency: USD
     asOf: "2022"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990"
@@ -159,7 +159,7 @@ facts:
   - id: f_wYlShSVHlQ
     property: revenue
     value: "3560000"
-    unit: USD
+    currency: USD
     asOf: "2023"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990"
@@ -167,7 +167,7 @@ facts:
   - id: f_l8DspNqJJw
     property: revenue
     value: "9360000"
-    unit: USD
+    currency: USD
     asOf: "2024"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "From IRS Form 990. Significant growth year — nearly tripled from 2023."
@@ -175,7 +175,7 @@ facts:
   - id: f_7mh2tQkFnF
     property: program-service-revenue
     value: "575642"
-    unit: USD
+    currency: USD
     asOf: "2024"
     source: https://projects.propublica.org/nonprofits/organizations/770119168
     notes: "Program service revenue from Form 990 (subset of total revenue)"

--- a/packages/factbase/data/fb-entities/freedom-house.yaml
+++ b/packages/factbase/data/fb-entities/freedom-house.yaml
@@ -48,7 +48,7 @@ facts:
   - id: f_RysUmFd7UE
     property: annual-revenue
     value: "90305550"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/131656647
     notes: "FY ending June 2024 (EIN 13-1656647). Total expenses $88,758,068. Contributions $89,972,151 (99.6% of revenue). Previous year (FY 2023) revenue was $93.5M."

--- a/packages/factbase/data/fb-entities/future-of-life-foundation.yaml
+++ b/packages/factbase/data/fb-entities/future-of-life-foundation.yaml
@@ -20,7 +20,7 @@ facts:
   - id: f_jQSLOnndmf
     property: funding-received
     value: "25025000"
-    unit: USD
+    currency: USD
     asOf: !date 2022
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Initial capitalization from FLI in December 2022
@@ -28,7 +28,7 @@ facts:
   - id: f_wljvq2YnMl
     property: funding-received
     value: "15700000"
-    unit: USD
+    currency: USD
     asOf: !date 2023
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional FLI grant in 2023
@@ -36,7 +36,7 @@ facts:
   - id: f_0SFSw7BkHs
     property: funding-received
     value: "18100000"
-    unit: USD
+    currency: USD
     asOf: !date 2024
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: Additional FLI grant in 2024
@@ -61,7 +61,7 @@ facts:
   - id: f_sP4q9hNagi
     property: grant-given
     value: "800000"
-    unit: USD
+    currency: USD
     asOf: !date 2025-04
     source: https://www.wiseancestors.org/discover/wise-ancestors-receives-grant-from-future-of-life-foundation-supporting-the-growth-of-its-highly-collaborative-decentralized-conservation-genomics-platform
     notes: Grant to Wise Ancestors for conservation genomics platform growth
@@ -69,7 +69,7 @@ facts:
   - id: f_bfOERZO5RV
     property: grant-given
     value: "1275000"
-    unit: USD
+    currency: USD
     asOf: !date 2025-07
     notes: >-
       Estimated cost of AI for Human Reasoning Fellowship: 30 fellows x

--- a/packages/factbase/data/fb-entities/govai.yaml
+++ b/packages/factbase/data/fb-entities/govai.yaml
@@ -31,7 +31,7 @@ facts:
   - id: f_ZGICR7QweU
     property: grant-received
     value: "2800000"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://www.openphilanthropy.org/grants/centre-for-the-governance-of-ai-general-support-2/
     notes: "Open Philanthropy general support grant, 2023. Original URL now redirects to coefficientgiving.org."
@@ -39,7 +39,7 @@ facts:
   - id: f_scQniXpfbB
     property: grant-received
     value: "2500000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.openphilanthropy.org/grants/govai-general-support-2024/
     notes: "Open Philanthropy general support grant, 2024"
@@ -47,7 +47,7 @@ facts:
   - id: f_MSACv166LQ
     property: grant-received
     value: "2995207"
-    unit: USD
+    currency: USD
     asOf: 2025-02
     source: https://www.openphilanthropy.org/grants/govai-general-support-february-2025/
     notes: "Open Philanthropy general support grant, February 2025"
@@ -55,7 +55,7 @@ facts:
   - id: f_jrvBLfs2yz
     property: grant-received
     value: "756000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://survivalandflourishing.fund/2025/recommendations
     notes: "SFF 2025 grant for general support"
@@ -161,7 +161,7 @@ facts:
   - id: f_FkWciW5Lpa
     property: total-funding
     value: "13300000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://www.openphilanthropy.org/grants/?q=govai
     notes: "Total identified Open Philanthropy/Coefficient Giving funding ~$13.3M+ across multiple grants 2020-2025"
@@ -169,7 +169,7 @@ facts:
   - id: f_N5d3TF1C6Q
     property: revenue
     value: "5748996"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/994000294
     notes: "From IRS Form 990 for the US entity (Centre for the Governance of AI Inc, EIN 99-4000294). First year of US filing; tax-exempt since September 2024. Nearly all revenue ($5.73M) from contributions."
@@ -177,7 +177,7 @@ facts:
   - id: f_vBDNosn0YQ
     property: annual-expenses
     value: "919661"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/994000294
     notes: "From IRS Form 990 for the US entity only. The UK entity (Companies House #15883729) has separate finances. Total organizational spending is significantly higher."

--- a/packages/factbase/data/fb-entities/humanity-ai-coalition.yaml
+++ b/packages/factbase/data/fb-entities/humanity-ai-coalition.yaml
@@ -9,7 +9,7 @@ facts:
   - id: f_eQxEIIrI9c
     property: total-funding
     value: "500000000"
-    unit: USD
+    currency: USD
     asOf: 2025-10
     source: https://www.macfound.org/press/press-releases/humanity-ai-commits-500-million-to-build-a-people-centered-future-for-ai
     notes: "$500M over 5 years"

--- a/packages/factbase/data/fb-entities/iaps.yaml
+++ b/packages/factbase/data/fb-entities/iaps.yaml
@@ -63,7 +63,7 @@ facts:
   - id: f_3J9UcxjgVg
     property: grant-received
     value: "572000"
-    unit: USD
+    currency: USD
     asOf: 2025
     source: https://survivalandflourishing.fund/2025/recommendations
     notes: "SFF 2025 grant"
@@ -71,7 +71,7 @@ facts:
   - id: f_VYPdIhqTQR
     property: grant-received
     value: "183000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://survivalandflourishing.fund/2024/recommendations
     notes: "SFF 2024 grant"

--- a/packages/factbase/data/fb-entities/legal-priorities-project.yaml
+++ b/packages/factbase/data/fb-entities/legal-priorities-project.yaml
@@ -14,7 +14,7 @@ facts:
   - id: f_9Z978lvcwS
     property: annual-revenue
     value: "7852814"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/851024198
     notes: "Major jump from $963K (2023) to $7.85M (2024). Assets $6.05M."
@@ -50,7 +50,7 @@ facts:
   - id: f_ltwPScsmD4
     property: annual-revenue
     value: "1100000"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://forum.effectivealtruism.org/posts/xen7oLdHwoHDTG4hR/legal-priorities-project-annual-report-2022
     notes: "~$1.1M spent in 2022. Raised ~$1.3M. 14 grant applications since inception (10 fully granted, 3 partly)."

--- a/packages/factbase/data/fb-entities/mozilla-foundation.yaml
+++ b/packages/factbase/data/fb-entities/mozilla-foundation.yaml
@@ -13,7 +13,7 @@ facts:
   - id: f_GGxu3k9sNa
     property: annual-revenue
     value: "37200000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/200097189
     notes: "Foundation only. Revenue: $37.2M (Major sources: license fees from Mozilla Corp and contributions). Assets: $123.3M."

--- a/packages/factbase/data/fb-entities/niskanen-center.yaml
+++ b/packages/factbase/data/fb-entities/niskanen-center.yaml
@@ -14,7 +14,7 @@ facts:
   - id: f_i2u0fBwEOh
     property: annual-revenue
     value: "9958495"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/455308952
     notes: "Total assets $12M. Net assets $9.7M."
@@ -69,7 +69,7 @@ facts:
   - id: f_LKjEZFHThm
     property: annual-revenue
     value: "7075571"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://en.wikipedia.org/wiki/Niskanen_Center
     notes: "Revenue $7.1M, expenses $7.6M"

--- a/packages/factbase/data/fb-entities/nvidia.yaml
+++ b/packages/factbase/data/fb-entities/nvidia.yaml
@@ -120,7 +120,7 @@ facts:
   - id: f_MF4yOqWUTI
     property: quarterly-data-center-revenue
     value: 6.23e+10
-    unit: USD
+    currency: USD
     asOf: 2026-01
     source: https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2026
     notes: "FY2026 Q4 data center revenue of $62.3B; record quarterly segment revenue"

--- a/packages/factbase/data/fb-entities/pauseai.yaml
+++ b/packages/factbase/data/fb-entities/pauseai.yaml
@@ -37,7 +37,7 @@ facts:
   - id: f_0qD6Fk7FbN
     property: total-funding
     value: 715000
-    unit: EUR
+    currency: EUR
     asOf: 2025-12
     source: https://pauseai.info/funding
     notes: "Largest donors: Future of Life Institute (EUR 423K), Greg Colbourn (EUR 95K), Conjointly (EUR 83K), Lightspeed Grants (EUR 46K combined), SFF (EUR 9.5K)"
@@ -75,7 +75,7 @@ facts:
   - id: f_DSEdfJN0mL
     property: annual-revenue
     value: "288319"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/990899650
     notes: "PauseAI US (501(c)(3), EIN 99-0899650, San Francisco, CA). Separate from Dutch PauseAI Global Stichting, which reports donor totals of EUR 715K through 2025-12."

--- a/packages/factbase/data/fb-entities/rand-ai.yaml
+++ b/packages/factbase/data/fb-entities/rand-ai.yaml
@@ -58,7 +58,7 @@ facts:
   - id: f_lMgspCVlPG
     property: cumulative-funding
     value: "34500000"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://www.openphilanthropy.org/grants/rand-corporation-emerging-technology-initiatives-2024/
     notes: "Total Open Philanthropy AI-related funding ~$34.5M across 6 grants (2020-2024)"

--- a/packages/factbase/data/fb-entities/redwood-research.yaml
+++ b/packages/factbase/data/fb-entities/redwood-research.yaml
@@ -32,7 +32,7 @@ facts:
   - id: f_djeGq9dqSA
     property: revenue
     value: "13904248"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990. First year of operations."
@@ -40,7 +40,7 @@ facts:
   - id: f_NRg485oCJw
     property: revenue
     value: "12049894"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -48,7 +48,7 @@ facts:
   - id: f_2Renvd6yYg
     property: revenue
     value: "10036347"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -56,7 +56,7 @@ facts:
   - id: f_6L6LOTW5Hw
     property: revenue
     value: "22060"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990. Dramatic revenue decline; organization drawing down reserves."
@@ -64,7 +64,7 @@ facts:
   - id: f_zUSEWyPxrA
     property: annual-expenses
     value: "2341569"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990. First year; ramping up operations."
@@ -72,7 +72,7 @@ facts:
   - id: f_C7KMno2g6Q
     property: annual-expenses
     value: "12759191"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -80,7 +80,7 @@ facts:
   - id: f_Zi6S0NWlVg
     property: annual-expenses
     value: "12590834"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -88,7 +88,7 @@ facts:
   - id: f_kBjzUvpoiw
     property: annual-expenses
     value: "2922498"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990. Significant reduction in spending."
@@ -110,7 +110,7 @@ facts:
   - id: f_fuHk3Y2qpQ
     property: net-assets
     value: "11562679"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -118,7 +118,7 @@ facts:
   - id: f_eUlrCHH4uQ
     property: net-assets
     value: "10853382"
-    unit: USD
+    currency: USD
     asOf: 2022
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -126,7 +126,7 @@ facts:
   - id: f_4DFAHutX6Q
     property: net-assets
     value: "8298895"
-    unit: USD
+    currency: USD
     asOf: 2023
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990"
@@ -134,7 +134,7 @@ facts:
   - id: f_6uYJTha67A
     property: net-assets
     value: "6497522"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/871702255
     notes: "From IRS Form 990. Declining reserves."

--- a/packages/factbase/data/fb-entities/semiconductor-industry-association.yaml
+++ b/packages/factbase/data/fb-entities/semiconductor-industry-association.yaml
@@ -4,7 +4,7 @@ facts:
   - id: f_Ks42xuxIfv
     property: global-semiconductor-revenue
     value: 5.27e+11
-    unit: USD
+    currency: USD
     asOf: 2023-12
     source: https://www.semiconductors.org/global-semiconductor-sales-increase-19-in-2024/
     notes: "Global semiconductor revenue $527B in 2023; decline from 2022 peak"
@@ -12,7 +12,7 @@ facts:
   - id: f_puGJTXLsW9
     property: global-semiconductor-revenue
     value: 6.27e+11
-    unit: USD
+    currency: USD
     asOf: 2024-12
     source: https://www.semiconductors.org/global-semiconductor-sales-increase-19-in-2024/
     notes: "Global semiconductor revenue ~$627B in 2024; 19% YoY growth"
@@ -20,7 +20,7 @@ facts:
   - id: f_QxwvXepiT6
     property: global-semiconductor-revenue
     value: 9.10e+11
-    unit: USD
+    currency: USD
     asOf: 2026-12
     source: https://www.deloitte.com/global/en/Industries/tmt/analysis/semiconductor-industry-outlook.html
     notes: "Projected $910B by 2026; driven by AI chip demand"
@@ -29,7 +29,7 @@ facts:
   - id: f_qvrs0X6RLc
     property: chips-act-total-funding
     value: 5.27e+10
-    unit: USD
+    currency: USD
     asOf: 2022-08
     source: https://en.wikipedia.org/wiki/CHIPS_and_Science_Act
     notes: "$52.7B in CHIPS Act funding for semiconductor manufacturing and R&D"
@@ -37,7 +37,7 @@ facts:
   - id: f_dLU4O4AnWM
     property: chips-act-private-investment
     value: 6.30e+11
-    unit: USD
+    currency: USD
     asOf: 2025-12
     source: https://www.semiconductors.org/
     notes: "Over $630B in private investment catalyzed by CHIPS Act"
@@ -45,7 +45,7 @@ facts:
   - id: f_OMqgmk6JJg
     property: chips-act-rd-allocation
     value: 1.10e+10
-    unit: USD
+    currency: USD
     asOf: 2022-08
     source: https://en.wikipedia.org/wiki/CHIPS_and_Science_Act
     notes: "$11B allocated for R&D, including $3.5B for defense 'secure enclave'"
@@ -54,7 +54,6 @@ facts:
   - id: f_vd9fZ6f61O
     property: estimated-chip-diversion
     value: 140000
-    unit: chips
     asOf: 2024-12
     source: https://www.cnas.org/publications/reports/countering-ai-chip-smuggling-has-become-a-national-security-priority
     notes: "CNAS median estimate of ~140,000 chips diverted to China in 2024, representing 6-10% of China's AI compute"
@@ -63,7 +62,7 @@ facts:
   - id: f_RrOoSNtMaR
     property: hyperscaler-ai-capex
     value: 6.50e+11
-    unit: USD
+    currency: USD
     asOf: 2025-12
     source: https://www.reuters.com/technology/
     notes: "Combined projected CapEx of Google, Amazon, Microsoft, and Meta for AI infrastructure build-out"

--- a/packages/factbase/data/fb-entities/sk-hynix.yaml
+++ b/packages/factbase/data/fb-entities/sk-hynix.yaml
@@ -87,7 +87,6 @@ facts:
   - id: f_YVrPBFl9Tf
     property: hbm-market-share
     value: 53
-    unit: percent
     asOf: 2024-12
     source: https://www.trendforce.com/
     notes: "SK Hynix holds ~53% of HBM market; Samsung ~38%, Micron ~9%"

--- a/packages/factbase/data/fb-entities/tech-oversight-project.yaml
+++ b/packages/factbase/data/fb-entities/tech-oversight-project.yaml
@@ -20,7 +20,7 @@ facts:
   - id: f_nIIQPufNjQ
     property: annual-revenue
     value: "910105"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/874209086
     notes: "FY 2024 Form 990 filed Oct 30, 2025. Total expenses $889,146. Net assets $264,299."

--- a/packages/factbase/data/fb-entities/the-future-society.yaml
+++ b/packages/factbase/data/fb-entities/the-future-society.yaml
@@ -15,7 +15,7 @@ facts:
   - id: f_63hZuAt6Uv
     property: annual-revenue
     value: "3406697"
-    unit: USD
+    currency: USD
     asOf: 2024
     source: https://projects.propublica.org/nonprofits/organizations/813568099
     notes: "Revenue $3.4M, expenses $1.9M, assets $3.7M. EIN: 81-3568099. Growing: was $755K in 2021."
@@ -80,7 +80,7 @@ facts:
   - id: f_SALPS8hrDy
     property: annual-revenue
     value: "755388"
-    unit: USD
+    currency: USD
     asOf: 2021
     source: https://www.influencewatch.org/non-profit/the-future-society/
     notes: "Revenue $755K, expenses $725K, assets $385K in 2021. Grew significantly to $3.4M by 2024."

--- a/packages/factbase/data/fb-entities/tsmc.yaml
+++ b/packages/factbase/data/fb-entities/tsmc.yaml
@@ -110,7 +110,6 @@ facts:
   - id: f_wIySb9OLoI
     property: foundry-market-share
     value: 64
-    unit: percent
     asOf: 2024-12
     source: https://www.counterpointresearch.com/insight/global-semiconductor-foundry-market-share
     notes: "TSMC holds ~64% of global semiconductor foundry revenue"
@@ -118,7 +117,6 @@ facts:
   - id: f_Lro8d6qLqd
     property: advanced-node-market-share
     value: 92
-    unit: percent
     asOf: 2024-12
     source: https://www.counterpointresearch.com/insight/global-semiconductor-foundry-market-share
     notes: "TSMC fabricates >90% of chips at sub-7nm nodes"


### PR DESCRIPTION
## Summary

Ada Lovelace Institute's overview showed "**$5 million**" for total funding while the `/data` page correctly showed "**£5M / $6.7M**" from the Nuffield Foundation funding round. The two pages disagreed because the FactBase YAML stored `unit: GBP` on the total-funding fact — and **the loader at `packages/factbase/src/loader.ts::parseFact` only reads `currency:`**, so `unit:` was silently dropped. The property-level default (USD, `$` prefix) then applied.

Same latent bug affected 3 more orgs (AlgorithmWatch, FLI, PauseAI — all EUR) and ~33 USD entries that were cosmetically wrong but masked by the USD default.

## Key changes

- **Data sweep** (37 files, 118 lines): renamed `unit: <ISO>` → `currency: <ISO>` at fact top-level across all affected orgs. Also deleted 5 redundant `unit: percent/chips` entries (properties already declare these).
- **Ada Lovelace fact**: added `usdEquivalent: 6700000` to match the $6.7M the funding round already shows. Note updated from "~USD 6.5M" to "~USD 6.7M" for consistency.
- **New blocking gate check** `validate-factbase-fact-unit-field.ts` — scans fb-entities YAML for `unit:` (and case typos `Unit:`, `UNIT:`, `units:`) at fact top-level. Prevents the class of bug from regressing.
- **Regression test** in `apps/web/src/components/wiki/factbase/__tests__/format.test.ts` pinning the QUA-620 scenario: a fact with `currency: GBP` must render with `£`, not `$`, even when the property's default unit is USD.

## Verification

- Overview `/organizations/ada-lovelace-institute` Total Funding stat card now renders "**£5 million** (as of Jan 2018)" — confirmed via curl against local dev server on port 3014.
- `/data` page agrees.
- 54/54 gate checks pass (4 pre-existing advisory warnings unrelated to this PR).
- New validator finds 0 violations across 539 fb-entities files.

## Test plan

- [x] Ada Lovelace overview shows "£5 million" (was "$5 million")
- [x] Ada Lovelace /data page total-funding shows "£5 million"
- [x] Other non-USD orgs (AlgorithmWatch, FLI, PauseAI) now have `currency:` field in built data
- [x] New validator blocks in the gate (checked via gate-level rerun)
- [x] Regression test pins GBP-override behavior
- [x] `pnpm build` passes
- [x] Full gate passes (`pnpm crux w validate gate --fix`)

Fixes QUA-620
