### PR TITLE
QUA-640: T1 importers — SEC EDGAR, GitHub contributors, HF Leaderboard

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -30,6 +30,7 @@ import { commands as dataSourcesCommands } from './data-sources.ts';
 import { commands as websiteSourcesCommands } from './website-sources.ts';
 import { commands as scaffoldCommands } from './tablebase-scaffold.ts';
 import { commands as setupOrgCommands } from './setup-org.ts';
+import { commands as tbImporterCommands } from './tb-importers/index.ts';
 
 interface CommandOptions extends BaseOptions {
   top?: string;
@@ -1491,6 +1492,10 @@ export const commands = {
   // QUA-455: scaffold a new tablebase entity type.
   scaffold: scaffoldCommands.scaffold,
   'setup-org': setupOrgCommands.default,
+  // QUA-640: T1 authoritative-source importers.
+  'sec-edgar': tbImporterCommands['sec-edgar'],
+  'github-contributors': tbImporterCommands['github-contributors'],
+  'hf-leaderboard': tbImporterCommands['hf-leaderboard'],
 };
 
 export function getHelp(): string {
@@ -1535,6 +1540,11 @@ Commands:
   data-sources-show <id>      Show details + snapshot history
   data-sources-snapshot <id>  Capture a new snapshot (--all for all sources)
   data-sources-health         Check mapping validity, staleness
+
+  T1 importers (QUA-640 — defensive enrichment):
+  sec-edgar           Fetch SEC EDGAR Form D → funding-rounds (--target=slug:cik)
+  github-contributors Fetch GitHub contributors → personnel hints (--target=slug:owner/repo[,owner/repo2])
+  hf-leaderboard      Fetch HF Open LLM Leaderboard → benchmark-results (--target=modelSlug:displayName:evalName)
 
   Website Sources:
   website-sources             Show website source help

--- a/crux/commands/tb-importers/__tests__/allowlist.test.ts
+++ b/crux/commands/tb-importers/__tests__/allowlist.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { isT1Authoritative, T1_AUTHORITY_ALLOWLIST } from "../allowlist.ts";
+
+describe("T1_AUTHORITY_ALLOWLIST", () => {
+  it("includes the three QUA-640 importers", () => {
+    const sources = T1_AUTHORITY_ALLOWLIST.map((e) => e.sourcePrefix);
+    expect(sources).toContain("sec-edgar:");
+    expect(sources).toContain("github-contributors:");
+    expect(sources).toContain("hf-leaderboard:");
+  });
+
+  it("each entry has a description", () => {
+    for (const entry of T1_AUTHORITY_ALLOWLIST) {
+      expect(entry.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("no duplicate (sourcePrefix, recordType) tuples", () => {
+    const keys = new Set<string>();
+    for (const entry of T1_AUTHORITY_ALLOWLIST) {
+      const key = `${entry.sourcePrefix}|${entry.recordType}`;
+      expect(keys.has(key)).toBe(false);
+      keys.add(key);
+    }
+  });
+});
+
+describe("isT1Authoritative", () => {
+  it("accepts on prefix match + recordType match", () => {
+    expect(isT1Authoritative("sec-edgar:0001234567-25-000001", "funding-round")).toBe(true);
+    expect(isT1Authoritative("github-contributors:anthropic:alice", "personnel")).toBe(true);
+    expect(isT1Authoritative("hf-leaderboard:meta-llama/M:IFEval", "benchmark-result")).toBe(true);
+  });
+
+  it("rejects when source matches but recordType doesn't", () => {
+    expect(isT1Authoritative("sec-edgar:abc", "personnel")).toBe(false);
+    expect(isT1Authoritative("github-contributors:x:y", "funding-round")).toBe(false);
+  });
+
+  it("rejects when recordType matches but source doesn't", () => {
+    expect(isT1Authoritative("crunchbase:abc", "funding-round")).toBe(false);
+    expect(isT1Authoritative("twitter:somebody", "personnel")).toBe(false);
+  });
+
+  it("rejects exact-match-without-prefix-colon", () => {
+    // Source needs the colon so that "sec-edgar-fake:abc" doesn't slip past
+    expect(isT1Authoritative("sec-edgar-fake:abc", "funding-round")).toBe(false);
+  });
+
+  it("rejects empty source", () => {
+    expect(isT1Authoritative("", "funding-round")).toBe(false);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/github-contributors.test.ts
+++ b/crux/commands/tb-importers/__tests__/github-contributors.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import {
+  fetchRepoContributors,
+  aggregateContributors,
+  buildProposals,
+  importTarget,
+  parseTargetsArg,
+  type GhContributor,
+  type GhContributorsTarget,
+} from "../github-contributors.ts";
+
+const TARGET: GhContributorsTarget = {
+  orgSlug: "anthropic",
+  orgName: "Anthropic",
+  repos: ["anthropics/anthropic-sdk-python", "anthropics/courses"],
+  minCommits: 5,
+};
+
+function makeFetch(byUrl: Record<string, { status: number; body: unknown }>): typeof fetch {
+  return (async (url: string) => {
+    const match = byUrl[url];
+    if (!match) {
+      return { ok: false, status: 404, async json() { return {}; } };
+    }
+    return {
+      ok: match.status >= 200 && match.status < 300,
+      status: match.status,
+      async json() {
+        return match.body;
+      },
+    };
+  }) as unknown as typeof fetch;
+}
+
+const SAMPLE_USERS: GhContributor[] = [
+  { login: "alice", id: 1, contributions: 50, type: "User", html_url: "https://github.com/alice" },
+  { login: "bob", id: 2, contributions: 10, type: "User", html_url: "https://github.com/bob" },
+  { login: "carol", id: 3, contributions: 3, type: "User", html_url: "https://github.com/carol" }, // below min
+  { login: "dependabot[bot]", id: 4, contributions: 200, type: "Bot", html_url: "https://github.com/dependabot" },
+  { login: "an-org", id: 5, contributions: 100, type: "Organization", html_url: "https://github.com/an-org" },
+];
+
+describe("fetchRepoContributors", () => {
+  it("filters out Bots and Organizations", async () => {
+    const fetchImpl = makeFetch({
+      "https://api.github.com/repos/anthropics/anthropic-sdk-python/contributors?per_page=100": {
+        status: 200,
+        body: SAMPLE_USERS,
+      },
+    });
+    const out = await fetchRepoContributors("anthropics/anthropic-sdk-python", { fetchImpl });
+    expect(out.map((u) => u.login)).toEqual(["alice", "bob", "carol"]);
+  });
+
+  it("throws on bad owner/repo format", async () => {
+    await expect(fetchRepoContributors("invalid", {})).rejects.toThrow(/owner\/repo/);
+  });
+
+  it("throws on non-2xx HTTP", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 403 })) as unknown as typeof fetch;
+    await expect(
+      fetchRepoContributors("a/b", { fetchImpl })
+    ).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("sends Authorization when githubToken provided", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      const headers = (init?.headers as Record<string, string>) ?? {};
+      captured = headers.Authorization ?? "";
+      return { ok: true, status: 200, async json() { return []; } };
+    }) as unknown as typeof fetch;
+    await fetchRepoContributors("a/b", { fetchImpl, githubToken: "secret123" });
+    expect(captured).toBe("Bearer secret123");
+  });
+
+  it("does not send Authorization when no token", async () => {
+    let captured: string | undefined;
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      const headers = (init?.headers as Record<string, string>) ?? {};
+      captured = headers.Authorization;
+      return { ok: true, status: 200, async json() { return []; } };
+    }) as unknown as typeof fetch;
+    await fetchRepoContributors("a/b", { fetchImpl });
+    expect(captured).toBeUndefined();
+  });
+});
+
+describe("aggregateContributors", () => {
+  it("sums contributions across repos and applies threshold", () => {
+    const perRepo = {
+      "a/r1": [
+        { login: "alice", id: 1, contributions: 4, type: "User" as const, html_url: "url1" },
+        { login: "bob", id: 2, contributions: 2, type: "User" as const, html_url: "url2" },
+      ],
+      "a/r2": [
+        { login: "alice", id: 1, contributions: 3, type: "User" as const, html_url: "url1" },
+        { login: "carol", id: 3, contributions: 5, type: "User" as const, html_url: "url3" },
+      ],
+    };
+    const out = aggregateContributors(perRepo, 5);
+    expect(out.map((c) => c.login)).toEqual(["alice", "carol"]);
+    expect(out[0].totalContributions).toBe(7);
+    expect(out[0].perRepo).toEqual({ "a/r1": 4, "a/r2": 3 });
+  });
+
+  it("orders by totalContributions descending", () => {
+    const perRepo = {
+      "a/r": [
+        { login: "low", id: 1, contributions: 5, type: "User" as const, html_url: "u" },
+        { login: "high", id: 2, contributions: 100, type: "User" as const, html_url: "u" },
+        { login: "mid", id: 3, contributions: 50, type: "User" as const, html_url: "u" },
+      ],
+    };
+    const out = aggregateContributors(perRepo, 5);
+    expect(out.map((c) => c.login)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("returns empty when nothing meets the threshold", () => {
+    const perRepo = {
+      "a/r": [{ login: "x", id: 1, contributions: 1, type: "User" as const, html_url: "u" }],
+    };
+    expect(aggregateContributors(perRepo, 5)).toEqual([]);
+  });
+
+  it("handles empty per-repo map", () => {
+    expect(aggregateContributors({}, 1)).toEqual([]);
+  });
+});
+
+describe("buildProposals", () => {
+  it("emits T1 + github-contributors source", () => {
+    const proposals = buildProposals(TARGET, [
+      {
+        login: "alice",
+        totalContributions: 50,
+        perRepo: { "anthropics/anthropic-sdk-python": 50 },
+        htmlUrl: "https://github.com/alice",
+      },
+    ]);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].tier).toBe("T1");
+    expect(proposals[0].source).toBe("github-contributors:anthropic:alice");
+    expect(proposals[0].recordType).toBe("personnel");
+  });
+
+  it("uses role=contributor / roleType=career (T1 seeding only)", () => {
+    const [p] = buildProposals(TARGET, [
+      { login: "alice", totalContributions: 50, perRepo: {}, htmlUrl: "u" },
+    ]);
+    expect(p.record.role).toBe("contributor");
+    expect(p.record.roleType).toBe("career");
+    expect(p.record.isFounder).toBe(false);
+  });
+
+  it("hashes the canonical record deterministically", () => {
+    const a1 = buildProposals(TARGET, [
+      { login: "x", totalContributions: 5, perRepo: { "r": 5 }, htmlUrl: "u" },
+    ])[0];
+    const a2 = buildProposals(TARGET, [
+      { login: "x", totalContributions: 5, perRepo: { "r": 5 }, htmlUrl: "u" },
+    ])[0];
+    expect(a1.responseHash).toBe(a2.responseHash);
+  });
+
+  it("hash differs when commit counts differ", () => {
+    const a = buildProposals(TARGET, [
+      { login: "x", totalContributions: 5, perRepo: { "r": 5 }, htmlUrl: "u" },
+    ])[0];
+    const b = buildProposals(TARGET, [
+      { login: "x", totalContributions: 6, perRepo: { "r": 6 }, htmlUrl: "u" },
+    ])[0];
+    expect(a.responseHash).not.toBe(b.responseHash);
+  });
+
+  it("entityRefs carry org slug + person login for resolver", () => {
+    const [p] = buildProposals(TARGET, [
+      { login: "alice", totalContributions: 5, perRepo: {}, htmlUrl: "u" },
+    ]);
+    expect(p.entityRefs).toEqual({ organization: "anthropic", person: "alice" });
+  });
+});
+
+describe("importTarget", () => {
+  it("aggregates across repos and emits proposals above threshold", async () => {
+    const fetchImpl = makeFetch({
+      "https://api.github.com/repos/anthropics/anthropic-sdk-python/contributors?per_page=100": {
+        status: 200,
+        body: [
+          { login: "alice", id: 1, contributions: 8, type: "User", html_url: "u1" },
+          { login: "carol", id: 3, contributions: 2, type: "User", html_url: "u3" },
+        ],
+      },
+      "https://api.github.com/repos/anthropics/courses/contributors?per_page=100": {
+        status: 200,
+        body: [
+          { login: "alice", id: 1, contributions: 3, type: "User", html_url: "u1" },
+          { login: "carol", id: 3, contributions: 4, type: "User", html_url: "u3" },
+        ],
+      },
+    });
+    const out = await importTarget(TARGET, { fetchImpl });
+    // alice: 11 (>=5), carol: 6 (>=5)
+    expect(out.map((p) => (p.record.personDisplayName as string))).toEqual([
+      "alice",
+      "carol",
+    ]);
+  });
+
+  it("skips broken repos and returns proposals from the others", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (String(url).includes("anthropic-sdk-python")) {
+        return { ok: false, status: 500, async json() { return {}; } };
+      }
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return [{ login: "alice", id: 1, contributions: 100, type: "User", html_url: "u" }];
+        },
+      };
+    }) as unknown as typeof fetch;
+    const out = await importTarget(TARGET, { fetchImpl });
+    expect(out).toHaveLength(1);
+    expect((out[0].record.personDisplayName as string)).toBe("alice");
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses single repo", () => {
+    expect(parseTargetsArg(["--target=anthropic:anthropics/sdk"])).toEqual([
+      { orgSlug: "anthropic", orgName: "anthropic", repos: ["anthropics/sdk"] },
+    ]);
+  });
+  it("parses multiple repos comma-separated", () => {
+    const out = parseTargetsArg(["--target=anthropic:anthropics/a,anthropics/b"]);
+    expect(out[0].repos).toEqual(["anthropics/a", "anthropics/b"]);
+  });
+  it("throws when repo is missing the slash", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:badrepo"])).toThrow(/owner\/repo/);
+  });
+  it("throws when repos list is empty", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:"])).toThrow();
+  });
+  it("throws when colon is missing", () => {
+    expect(() => parseTargetsArg(["--target=anthropic"])).toThrow(/slug:owner\/repo/);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/github-contributors.test.ts
+++ b/crux/commands/tb-importers/__tests__/github-contributors.test.ts
@@ -52,8 +52,19 @@ describe("fetchRepoContributors", () => {
     expect(out.map((u) => u.login)).toEqual(["alice", "bob", "carol"]);
   });
 
-  it("throws on bad owner/repo format", async () => {
+  it("throws on bad owner/repo format (missing slash)", async () => {
     await expect(fetchRepoContributors("invalid", {})).rejects.toThrow(/owner\/repo/);
+  });
+
+  it("rejects path-traversal in owner/repo (SSRF guard)", async () => {
+    // Multi-slash → caught by the parts.length check
+    await expect(fetchRepoContributors("../etc/passwd", {})).rejects.toThrow(/owner\/repo/);
+    // Encoded bytes → caught by the char allowlist
+    await expect(fetchRepoContributors("foo/%2e%2e", {})).rejects.toThrow(/A-Za-z0-9._-/);
+    // ".." as a name → caught by the explicit deny list
+    await expect(fetchRepoContributors("foo/..", {})).rejects.toThrow(/traversal/);
+    // Bad chars → caught by the char allowlist
+    await expect(fetchRepoContributors("a/b@evil.com", {})).rejects.toThrow();
   });
 
   it("throws on non-2xx HTTP", async () => {
@@ -61,6 +72,15 @@ describe("fetchRepoContributors", () => {
     await expect(
       fetchRepoContributors("a/b", { fetchImpl })
     ).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("throws when API returns a non-array", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() { return { error: "rate limited" }; },
+    })) as unknown as typeof fetch;
+    await expect(fetchRepoContributors("a/b", { fetchImpl })).rejects.toThrow(/not an array/);
   });
 
   it("sends Authorization when githubToken provided", async () => {
@@ -126,6 +146,21 @@ describe("aggregateContributors", () => {
   it("handles empty per-repo map", () => {
     expect(aggregateContributors({}, 1)).toEqual([]);
   });
+
+  it("handles a login appearing twice in the SAME repo (defensive — preserves invariant)", () => {
+    const perRepo = {
+      "a/r": [
+        { login: "alice", id: 1, contributions: 3, type: "User" as const, html_url: "u" },
+        { login: "alice", id: 1, contributions: 4, type: "User" as const, html_url: "u" },
+      ],
+    };
+    const [agg] = aggregateContributors(perRepo, 5);
+    // totalContributions === sum(perRepo.values()) invariant must hold
+    expect(agg.totalContributions).toBe(7);
+    expect(agg.perRepo).toEqual({ "a/r": 7 });
+    const sumOfPerRepo = Object.values(agg.perRepo).reduce((s, v) => s + v, 0);
+    expect(sumOfPerRepo).toBe(agg.totalContributions);
+  });
 });
 
 describe("buildProposals", () => {
@@ -151,6 +186,15 @@ describe("buildProposals", () => {
     expect(p.record.role).toBe("contributor");
     expect(p.record.roleType).toBe("career");
     expect(p.record.isFounder).toBe(false);
+  });
+
+  it("personDisplayName is null (avoids raw machine ID display)", () => {
+    const [p] = buildProposals(TARGET, [
+      { login: "alice", totalContributions: 50, perRepo: {}, htmlUrl: "u" },
+    ]);
+    expect(p.record.personDisplayName).toBeNull();
+    // login is preserved in notes for downstream resolution
+    expect(String(p.record.notes)).toContain("alice");
   });
 
   it("hashes the canonical record deterministically", () => {
@@ -182,7 +226,7 @@ describe("buildProposals", () => {
 });
 
 describe("importTarget", () => {
-  it("aggregates across repos and emits proposals above threshold", async () => {
+  it("aggregates across repos and emits proposals above threshold; returns failure count", async () => {
     const fetchImpl = makeFetch({
       "https://api.github.com/repos/anthropics/anthropic-sdk-python/contributors?per_page=100": {
         status: 200,
@@ -199,15 +243,13 @@ describe("importTarget", () => {
         ],
       },
     });
-    const out = await importTarget(TARGET, { fetchImpl });
+    const { proposals, failures } = await importTarget(TARGET, { fetchImpl });
     // alice: 11 (>=5), carol: 6 (>=5)
-    expect(out.map((p) => (p.record.personDisplayName as string))).toEqual([
-      "alice",
-      "carol",
-    ]);
+    expect(proposals.map((p) => p.entityRefs?.person)).toEqual(["alice", "carol"]);
+    expect(failures).toBe(0);
   });
 
-  it("skips broken repos and returns proposals from the others", async () => {
+  it("skips broken repos and returns failures count", async () => {
     const fetchImpl = (async (url: string) => {
       if (String(url).includes("anthropic-sdk-python")) {
         return { ok: false, status: 500, async json() { return {}; } };
@@ -220,9 +262,10 @@ describe("importTarget", () => {
         },
       };
     }) as unknown as typeof fetch;
-    const out = await importTarget(TARGET, { fetchImpl });
-    expect(out).toHaveLength(1);
-    expect((out[0].record.personDisplayName as string)).toBe("alice");
+    const { proposals, failures } = await importTarget(TARGET, { fetchImpl });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].entityRefs?.person).toBe("alice");
+    expect(failures).toBe(1);
   });
 });
 
@@ -236,13 +279,31 @@ describe("parseTargetsArg", () => {
     const out = parseTargetsArg(["--target=anthropic:anthropics/a,anthropics/b"]);
     expect(out[0].repos).toEqual(["anthropics/a", "anthropics/b"]);
   });
-  it("throws when repo is missing the slash", () => {
+  it("throws when a repo is missing the slash", () => {
     expect(() => parseTargetsArg(["--target=anthropic:badrepo"])).toThrow(/owner\/repo/);
   });
-  it("throws when repos list is empty", () => {
+  it("throws when the repos list contains an empty entry (a/b,,a/c)", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:a/b,,a/c"])).toThrow(/empty entries/);
+  });
+  it("throws on leading or trailing comma", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:,a/b"])).toThrow(/empty entries/);
+    expect(() => parseTargetsArg(["--target=anthropic:a/b,"])).toThrow(/empty entries/);
+  });
+  it("throws when repos list is empty (just colon)", () => {
     expect(() => parseTargetsArg(["--target=anthropic:"])).toThrow();
+  });
+  it("throws when a repo has bad chars (path traversal / encoded bytes)", () => {
+    // ".." as a name → caught by deny list
+    expect(() => parseTargetsArg(["--target=anthropic:foo/..,bar/baz"])).toThrow(
+      /traversal/
+    );
+    // Encoded bytes → caught by char allowlist
+    expect(() => parseTargetsArg(["--target=anthropic:foo/%2e%2e"])).toThrow(/A-Za-z0-9._-/);
   });
   it("throws when colon is missing", () => {
     expect(() => parseTargetsArg(["--target=anthropic"])).toThrow(/slug:owner\/repo/);
+  });
+  it("throws on empty slug", () => {
+    expect(() => parseTargetsArg(["--target=:a/b"])).toThrow(/non-empty/);
   });
 });

--- a/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
+++ b/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
@@ -130,10 +130,6 @@ describe("lookupRow", () => {
   it("returns null when not found", () => {
     expect(lookupRow({ byEvalName: new Map(), byFullname: new Map() }, "missing")).toBeNull();
   });
-  it("accepts a bare Map (legacy convenience)", () => {
-    const m = new Map([["a", { eval_name: "a" }]]);
-    expect(lookupRow(m, "a")?.eval_name).toBe("a");
-  });
 });
 
 describe("validateScore", () => {

--- a/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
+++ b/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
@@ -6,6 +6,7 @@ import {
   buildProposals,
   importTargets,
   parseTargetsArg,
+  validateScore,
   DEFAULT_BENCHMARK_COLUMNS,
   type HfLeaderboardRow,
   type HfLeaderboardTarget,
@@ -58,14 +59,23 @@ describe("fetchLeaderboardSnapshot", () => {
       { rows: Array.from({ length: 50 }, (_, i) => ({ row: { eval_name: `m${100 + i}`, IFEval: i } })) },
     ]);
     const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100 });
-    expect(snap.size).toBe(150);
+    expect(snap.byEvalName.size).toBe(150);
+  });
+
+  it("builds the fullname index in addition to eval_name", async () => {
+    const fetchImpl = pageFetch([
+      { rows: [{ row: { eval_name: "x", fullname: "long/name" } }] },
+    ]);
+    const snap = await fetchLeaderboardSnapshot({ fetchImpl });
+    expect(snap.byEvalName.has("x")).toBe(true);
+    expect(snap.byFullname.has("long/name")).toBe(true);
   });
 
   it("stops at maxRows even if pages keep coming", async () => {
     const fullPage = { rows: Array.from({ length: 100 }, (_, i) => ({ row: { eval_name: `m${i}`, IFEval: i } })) };
     const fetchImpl = pageFetch([fullPage, fullPage, fullPage]);
     const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100, maxRows: 100 });
-    expect(snap.size).toBe(100);
+    expect(snap.byEvalName.size).toBe(100);
   });
 
   it("clamps pageSize to 100 (datasets-server limit)", async () => {
@@ -88,27 +98,72 @@ describe("fetchLeaderboardSnapshot", () => {
       { rows: [{ row: { eval_name: "good" } }, { row: {} as HfLeaderboardRow }] },
     ]);
     const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100 });
-    expect(snap.size).toBe(1);
+    expect(snap.byEvalName.size).toBe(1);
+  });
+
+  it("tolerates malformed rows wrapper (no .rows field)", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() { return {}; },
+    })) as unknown as typeof fetch;
+    const snap = await fetchLeaderboardSnapshot({ fetchImpl });
+    expect(snap.byEvalName.size).toBe(0);
   });
 });
 
 describe("lookupRow", () => {
-  it("returns direct hit by eval_name", () => {
-    const snap = new Map([["a", { eval_name: "a" }]]);
+  it("returns direct hit by eval_name from a snapshot", () => {
+    const snap = {
+      byEvalName: new Map([["a", { eval_name: "a" }]]),
+      byFullname: new Map(),
+    };
     expect(lookupRow(snap, "a")?.eval_name).toBe("a");
   });
-  it("falls back to fullname scan", () => {
-    const snap = new Map([["x", { eval_name: "x", fullname: "long-name" }]]);
+  it("falls back to fullname index (O(1), not scan)", () => {
+    const snap = {
+      byEvalName: new Map(),
+      byFullname: new Map([["long-name", { eval_name: "x", fullname: "long-name" }]]),
+    };
     expect(lookupRow(snap, "long-name")?.eval_name).toBe("x");
   });
   it("returns null when not found", () => {
-    expect(lookupRow(new Map(), "missing")).toBeNull();
+    expect(lookupRow({ byEvalName: new Map(), byFullname: new Map() }, "missing")).toBeNull();
+  });
+  it("accepts a bare Map (legacy convenience)", () => {
+    const m = new Map([["a", { eval_name: "a" }]]);
+    expect(lookupRow(m, "a")?.eval_name).toBe("a");
+  });
+});
+
+describe("validateScore", () => {
+  it("accepts 0", () => {
+    expect(validateScore(0, "%")).toBeNull();
+  });
+  it("accepts boundary score 100 with unit=%", () => {
+    expect(validateScore(100, "%")).toBeNull();
+  });
+  it("rejects negative", () => {
+    expect(validateScore(-1, "%")).toMatch(/negative/);
+  });
+  it("rejects > 100 with unit=%", () => {
+    expect(validateScore(150, "%")).toMatch(/> 100/);
+  });
+  it("accepts > 100 with non-percent unit", () => {
+    expect(validateScore(150, "score")).toBeNull();
+  });
+  it("rejects NaN and Infinity", () => {
+    expect(validateScore(NaN, "%")).toMatch(/finite/);
+    expect(validateScore(Infinity, "%")).toMatch(/finite/);
   });
 });
 
 describe("buildProposals", () => {
   it("emits one proposal per (target, benchmark) intersection that has a numeric score", () => {
-    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const snap = {
+      byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]),
+      byFullname: new Map(),
+    };
     const { proposals, misses } = buildProposals([TARGET], snap);
     expect(misses).toHaveLength(0);
     expect(proposals).toHaveLength(DEFAULT_BENCHMARK_COLUMNS.length);
@@ -117,35 +172,64 @@ describe("buildProposals", () => {
   });
 
   it("records a miss when target eval_name is absent", () => {
-    const snap = new Map<string, HfLeaderboardRow>();
+    const snap = { byEvalName: new Map(), byFullname: new Map() };
     const { proposals, misses } = buildProposals([TARGET], snap);
     expect(proposals).toEqual([]);
     expect(misses).toHaveLength(1);
     expect(misses[0].reason).toContain("not in snapshot");
   });
 
-  it("skips benchmark columns with non-numeric scores", () => {
+  it("emits a proposal when score is exactly 0 (not treated as missing)", () => {
+    const row: HfLeaderboardRow = { eval_name: TARGET.evalName, IFEval: 0 };
+    const snap = { byEvalName: new Map([[TARGET.evalName, row]]), byFullname: new Map() };
+    const { proposals } = buildProposals([TARGET], snap);
+    const ifeval = proposals.find((p) => p.source.endsWith(":IFEval"));
+    expect(ifeval).toBeDefined();
+    expect(ifeval?.record.score).toBe(0);
+  });
+
+  it("rejects a proposal when score is negative (records as miss)", () => {
+    const row: HfLeaderboardRow = { eval_name: TARGET.evalName, IFEval: -1 };
+    const snap = { byEvalName: new Map([[TARGET.evalName, row]]), byFullname: new Map() };
+    const { proposals, misses } = buildProposals([TARGET], snap);
+    expect(proposals.find((p) => p.source.endsWith(":IFEval"))).toBeUndefined();
+    expect(misses.find((m) => m.reason.includes("IFEval"))).toBeDefined();
+  });
+
+  it("rejects > 100 scores with unit=% (records as miss)", () => {
+    const row: HfLeaderboardRow = { eval_name: TARGET.evalName, IFEval: 150 };
+    const snap = { byEvalName: new Map([[TARGET.evalName, row]]), byFullname: new Map() };
+    const { proposals, misses } = buildProposals([TARGET], snap);
+    expect(proposals).toHaveLength(0);
+    expect(misses.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("skips columns with non-numeric / NaN scores without recording miss", () => {
     const partialRow: HfLeaderboardRow = {
       eval_name: TARGET.evalName,
       IFEval: 80,
       BBH: undefined,
-      GPQA: NaN, // exercise the runtime guard for non-finite (NaN is a number type)
+      GPQA: NaN,
     };
-    const snap = new Map([[TARGET.evalName, partialRow]]);
-    const { proposals } = buildProposals([TARGET], snap);
+    const snap = { byEvalName: new Map([[TARGET.evalName, partialRow]]), byFullname: new Map() };
+    const { proposals, misses } = buildProposals([TARGET], snap);
+    // Only IFEval should produce a proposal.
     expect(proposals).toHaveLength(1);
     expect(proposals[0].source).toBe(`hf-leaderboard:${TARGET.evalName}:IFEval`);
+    // BBH=undefined → skipped silently. GPQA=NaN → recorded as miss.
+    expect(misses.find((m) => m.reason.includes("GPQA"))).toBeDefined();
+    expect(misses.find((m) => m.reason.includes("BBH"))).toBeUndefined();
   });
 
   it("hashes deterministically per (target, column, score)", () => {
-    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const snap = { byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]), byFullname: new Map() };
     const a = buildProposals([TARGET], snap).proposals;
     const b = buildProposals([TARGET], snap).proposals;
     a.forEach((p, i) => expect(p.responseHash).toBe(b[i].responseHash));
   });
 
   it("entityRefs carries model + benchmark slugs for resolution", () => {
-    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const snap = { byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]), byFullname: new Map() };
     const { proposals } = buildProposals([TARGET], snap);
     const ifeval = proposals.find((p) => p.source.endsWith(":IFEval"));
     expect(ifeval?.entityRefs?.model).toBe("meta-llama-3-70b-instruct");
@@ -153,18 +237,24 @@ describe("buildProposals", () => {
   });
 
   it("uses the provided scoredAt date", () => {
-    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const snap = { byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]), byFullname: new Map() };
     const { proposals } = buildProposals([TARGET], snap, { scoredAt: "2026-04-19" });
     expect(proposals[0].record.date).toBe("2026-04-19");
   });
 
   it("respects custom benchmarkColumns mapping", () => {
-    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const snap = { byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]), byFullname: new Map() };
     const { proposals } = buildProposals([TARGET], snap, {
-      benchmarkColumns: [{ column: "BBH", benchmarkId: "bbh", benchmarkSlug: "bbh", unit: "%" }],
+      benchmarkColumns: [{ column: "BBH", benchmarkSlug: "bbh", unit: "%" }],
     });
     expect(proposals).toHaveLength(1);
     expect(proposals[0].source).toBe(`hf-leaderboard:${TARGET.evalName}:BBH`);
+  });
+
+  it("includes modelDisplayName in notes for evidence", () => {
+    const snap = { byEvalName: new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]), byFullname: new Map() };
+    const { proposals } = buildProposals([TARGET], snap);
+    expect(String(proposals[0].record.notes)).toContain(TARGET.modelDisplayName);
   });
 });
 

--- a/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
+++ b/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRowsUrl,
+  fetchLeaderboardSnapshot,
+  lookupRow,
+  buildProposals,
+  importTargets,
+  parseTargetsArg,
+  DEFAULT_BENCHMARK_COLUMNS,
+  type HfLeaderboardRow,
+  type HfLeaderboardTarget,
+} from "../hf-leaderboard.ts";
+
+const TARGET: HfLeaderboardTarget = {
+  modelSlug: "meta-llama-3-70b-instruct",
+  modelDisplayName: "Meta-Llama-3-70B-Instruct",
+  evalName: "meta-llama/Meta-Llama-3-70B-Instruct",
+};
+
+const SAMPLE_ROW: HfLeaderboardRow = {
+  eval_name: "meta-llama/Meta-Llama-3-70B-Instruct",
+  IFEval: 80.5,
+  BBH: 50.1,
+  "MATH Lvl 5": 23.4,
+  GPQA: 11.0,
+  MUSR: 17.3,
+  "MMLU-PRO": 41.2,
+};
+
+function pageFetch(pages: Array<{ status?: number; rows: Array<{ row: HfLeaderboardRow }> }>): typeof fetch {
+  let i = 0;
+  return (async () => {
+    const page = pages[i++] ?? { rows: [] };
+    return {
+      ok: (page.status ?? 200) >= 200 && (page.status ?? 200) < 300,
+      status: page.status ?? 200,
+      async json() {
+        return { rows: page.rows };
+      },
+    };
+  }) as unknown as typeof fetch;
+}
+
+describe("buildRowsUrl", () => {
+  it("constructs a valid datasets-server URL", () => {
+    const url = buildRowsUrl(0, 100);
+    expect(url).toContain("dataset=open-llm-leaderboard%2Fcontents");
+    expect(url).toContain("offset=0");
+    expect(url).toContain("length=100");
+    expect(url).toContain("split=train");
+  });
+});
+
+describe("fetchLeaderboardSnapshot", () => {
+  it("paginates until a short page", async () => {
+    const fetchImpl = pageFetch([
+      { rows: Array.from({ length: 100 }, (_, i) => ({ row: { eval_name: `m${i}`, IFEval: i } })) },
+      { rows: Array.from({ length: 50 }, (_, i) => ({ row: { eval_name: `m${100 + i}`, IFEval: i } })) },
+    ]);
+    const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100 });
+    expect(snap.size).toBe(150);
+  });
+
+  it("stops at maxRows even if pages keep coming", async () => {
+    const fullPage = { rows: Array.from({ length: 100 }, (_, i) => ({ row: { eval_name: `m${i}`, IFEval: i } })) };
+    const fetchImpl = pageFetch([fullPage, fullPage, fullPage]);
+    const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100, maxRows: 100 });
+    expect(snap.size).toBe(100);
+  });
+
+  it("clamps pageSize to 100 (datasets-server limit)", async () => {
+    const captured: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      captured.push(String(url));
+      return { ok: true, status: 200, async json() { return { rows: [] }; } };
+    }) as unknown as typeof fetch;
+    await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 500 });
+    expect(captured[0]).toContain("length=100");
+  });
+
+  it("throws on non-2xx", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 503 })) as unknown as typeof fetch;
+    await expect(fetchLeaderboardSnapshot({ fetchImpl })).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("ignores rows missing eval_name", async () => {
+    const fetchImpl = pageFetch([
+      { rows: [{ row: { eval_name: "good" } }, { row: {} as HfLeaderboardRow }] },
+    ]);
+    const snap = await fetchLeaderboardSnapshot({ fetchImpl, pageSize: 100 });
+    expect(snap.size).toBe(1);
+  });
+});
+
+describe("lookupRow", () => {
+  it("returns direct hit by eval_name", () => {
+    const snap = new Map([["a", { eval_name: "a" }]]);
+    expect(lookupRow(snap, "a")?.eval_name).toBe("a");
+  });
+  it("falls back to fullname scan", () => {
+    const snap = new Map([["x", { eval_name: "x", fullname: "long-name" }]]);
+    expect(lookupRow(snap, "long-name")?.eval_name).toBe("x");
+  });
+  it("returns null when not found", () => {
+    expect(lookupRow(new Map(), "missing")).toBeNull();
+  });
+});
+
+describe("buildProposals", () => {
+  it("emits one proposal per (target, benchmark) intersection that has a numeric score", () => {
+    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const { proposals, misses } = buildProposals([TARGET], snap);
+    expect(misses).toHaveLength(0);
+    expect(proposals).toHaveLength(DEFAULT_BENCHMARK_COLUMNS.length);
+    expect(proposals.every((p) => p.tier === "T1")).toBe(true);
+    expect(proposals.every((p) => p.recordType === "benchmark-result")).toBe(true);
+  });
+
+  it("records a miss when target eval_name is absent", () => {
+    const snap = new Map<string, HfLeaderboardRow>();
+    const { proposals, misses } = buildProposals([TARGET], snap);
+    expect(proposals).toEqual([]);
+    expect(misses).toHaveLength(1);
+    expect(misses[0].reason).toContain("not in snapshot");
+  });
+
+  it("skips benchmark columns with non-numeric scores", () => {
+    const partialRow: HfLeaderboardRow = {
+      eval_name: TARGET.evalName,
+      IFEval: 80,
+      BBH: undefined,
+      GPQA: NaN, // exercise the runtime guard for non-finite (NaN is a number type)
+    };
+    const snap = new Map([[TARGET.evalName, partialRow]]);
+    const { proposals } = buildProposals([TARGET], snap);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].source).toBe(`hf-leaderboard:${TARGET.evalName}:IFEval`);
+  });
+
+  it("hashes deterministically per (target, column, score)", () => {
+    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const a = buildProposals([TARGET], snap).proposals;
+    const b = buildProposals([TARGET], snap).proposals;
+    a.forEach((p, i) => expect(p.responseHash).toBe(b[i].responseHash));
+  });
+
+  it("entityRefs carries model + benchmark slugs for resolution", () => {
+    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const { proposals } = buildProposals([TARGET], snap);
+    const ifeval = proposals.find((p) => p.source.endsWith(":IFEval"));
+    expect(ifeval?.entityRefs?.model).toBe("meta-llama-3-70b-instruct");
+    expect(ifeval?.entityRefs?.benchmark).toBe("ifeval");
+  });
+
+  it("uses the provided scoredAt date", () => {
+    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const { proposals } = buildProposals([TARGET], snap, { scoredAt: "2026-04-19" });
+    expect(proposals[0].record.date).toBe("2026-04-19");
+  });
+
+  it("respects custom benchmarkColumns mapping", () => {
+    const snap = new Map([[SAMPLE_ROW.eval_name, SAMPLE_ROW]]);
+    const { proposals } = buildProposals([TARGET], snap, {
+      benchmarkColumns: [{ column: "BBH", benchmarkId: "bbh", benchmarkSlug: "bbh", unit: "%" }],
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].source).toBe(`hf-leaderboard:${TARGET.evalName}:BBH`);
+  });
+});
+
+describe("importTargets", () => {
+  it("end-to-end fetches + builds proposals", async () => {
+    const fetchImpl = pageFetch([
+      { rows: [{ row: SAMPLE_ROW }] },
+    ]);
+    const { proposals, misses } = await importTargets([TARGET], { fetchImpl, pageSize: 100 });
+    expect(misses).toHaveLength(0);
+    expect(proposals.length).toBe(DEFAULT_BENCHMARK_COLUMNS.length);
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses single target with three segments", () => {
+    expect(parseTargetsArg(["--target=slug:Display:eval/name"])).toEqual([
+      { modelSlug: "slug", modelDisplayName: "Display", evalName: "eval/name" },
+    ]);
+  });
+
+  it("preserves colons in evalName beyond the second", () => {
+    const out = parseTargetsArg(["--target=s:D:org/model:variant"]);
+    expect(out[0].evalName).toBe("org/model:variant");
+  });
+
+  it("throws on missing segments", () => {
+    expect(() => parseTargetsArg(["--target=slug"])).toThrow(/modelSlug:displayName:evalName/);
+    expect(() => parseTargetsArg(["--target=slug:onlyone"])).toThrow(
+      /modelSlug:displayName:evalName/
+    );
+  });
+
+  it("throws on empty segment", () => {
+    expect(() => parseTargetsArg(["--target=:Display:eval"])).toThrow(/empty segment/);
+    expect(() => parseTargetsArg(["--target=slug::eval"])).toThrow(/empty segment/);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/http-utils.test.ts
+++ b/crux/commands/tb-importers/__tests__/http-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHeaderValue, getUserAgent, USER_AGENT } from "../http-utils.ts";
+
+describe("sanitizeHeaderValue", () => {
+  it("strips CR and LF from header values", () => {
+    expect(sanitizeHeaderValue("hello\r\nX-Evil: yes")).toBe("helloX-Evil: yes");
+    expect(sanitizeHeaderValue("a\nb\rc")).toBe("abc");
+  });
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeHeaderValue("  ua  ")).toBe("ua");
+  });
+});
+
+describe("getUserAgent", () => {
+  it("returns default when no override", () => {
+    expect(getUserAgent({})).toBe(USER_AGENT);
+  });
+  it("returns sanitized override when provided", () => {
+    expect(getUserAgent({ userAgent: "test/1.0\r\nX: y" })).toBe("test/1.0X: y");
+  });
+});
+
+describe("USER_AGENT", () => {
+  it("uses the org bot email, not personal", () => {
+    expect(USER_AGENT).toContain("bot@quantifieduncertainty.org");
+    expect(USER_AGENT).not.toContain("ozzie@");
+  });
+});

--- a/crux/commands/tb-importers/__tests__/propose-client.test.ts
+++ b/crux/commands/tb-importers/__tests__/propose-client.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateProposal,
+  submitProposal,
+  submitBatch,
+} from "../propose-client.ts";
+import type { EnrichmentProposal } from "../types.ts";
+
+const VALID: EnrichmentProposal = {
+  tier: "T1",
+  source: "sec-edgar:0001234567-25-000001",
+  sourceUrl: "https://www.sec.gov/Archives/x.xml",
+  responseHash: "abc123",
+  recordType: "funding-round",
+  record: { name: "Series A" },
+};
+
+describe("validateProposal", () => {
+  it("returns null on a fully-valid proposal", () => {
+    expect(validateProposal(VALID)).toBeNull();
+  });
+
+  it("rejects non-T1 tiers", () => {
+    expect(validateProposal({ ...VALID, tier: "T2" })).toMatch(/T1 importers must emit tier=T1/);
+  });
+
+  it("rejects missing source/url/hash", () => {
+    expect(validateProposal({ ...VALID, source: "" })).toMatch(/missing required/);
+    expect(validateProposal({ ...VALID, sourceUrl: "" })).toMatch(/missing required/);
+    expect(validateProposal({ ...VALID, responseHash: "" })).toMatch(/missing required/);
+  });
+
+  it("rejects (source, recordType) not on the T1 allowlist", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      source: "wikipedia:anthropic",
+      recordType: "funding-round",
+    };
+    expect(validateProposal(proposal)).toMatch(/not on T1 authority allowlist/);
+  });
+
+  it("rejects mismatched (source, recordType) on the allowlist", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      source: "sec-edgar:abc",
+      recordType: "personnel",
+    };
+    expect(validateProposal(proposal)).toMatch(/not on T1 authority allowlist/);
+  });
+});
+
+describe("submitProposal", () => {
+  it("returns rejected on validation failure", async () => {
+    const r = await submitProposal({ ...VALID, tier: "T2" });
+    expect(r.status).toBe("rejected");
+    expect(r.reason).toMatch(/T1/);
+  });
+
+  it("returns pending in dry-run mode (default)", async () => {
+    const r = await submitProposal(VALID);
+    expect(r.status).toBe("pending");
+    expect(r.reason).toBe("dry-run");
+  });
+
+  it("returns pending with QUA-632 reason when --submit and endpoint not yet built", async () => {
+    const r = await submitProposal(VALID, { submit: true });
+    expect(r.status).toBe("pending");
+    expect(r.reason).toMatch(/QUA-632/);
+  });
+
+  it("skipAllowlistCheck bypasses validation", async () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      source: "wikipedia:x",
+    };
+    const r = await submitProposal(proposal, { skipAllowlistCheck: true });
+    expect(r.status).toBe("pending");
+    expect(r.reason).toBe("dry-run");
+  });
+});
+
+describe("submitBatch", () => {
+  it("returns one result per input, preserving order", async () => {
+    const proposals: EnrichmentProposal[] = [
+      VALID,
+      { ...VALID, tier: "T3" },
+      { ...VALID, source: "github-contributors:anthropic:alice", recordType: "personnel" },
+    ];
+    const results = await submitBatch(proposals);
+    expect(results).toHaveLength(3);
+    expect(results[0].status).toBe("pending");
+    expect(results[1].status).toBe("rejected");
+    expect(results[2].status).toBe("pending");
+  });
+
+  it("returns empty array for empty input", async () => {
+    expect(await submitBatch([])).toEqual([]);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
+++ b/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import {
+  padCik,
+  buildFormDUrl,
+  parseFormDXml,
+  fetchFormDFilings,
+  fetchAndParseFormD,
+  buildProposal,
+  importTarget,
+  parseTargetsArg,
+  type FormDFiling,
+  type SecEdgarTarget,
+  type SecEdgarOptions,
+} from "../sec-edgar.ts";
+
+const TARGET: SecEdgarTarget = {
+  orgSlug: "anthropic",
+  orgName: "Anthropic, PBC",
+  cik: "1828101",
+};
+
+const SAMPLE_XML = `<?xml version="1.0"?>
+<edgarSubmission>
+  <primaryIssuer>
+    <entityName>Anthropic, PBC</entityName>
+  </primaryIssuer>
+  <offeringData>
+    <offeringSalesAmounts>
+      <totalOfferingAmount>1000000000</totalOfferingAmount>
+      <totalAmountSold>750000000</totalAmountSold>
+    </offeringSalesAmounts>
+    <signatureBlock>
+      <dateOfFirstSale>2024-05-30</dateOfFirstSale>
+    </signatureBlock>
+    <totalNumberAlreadyInvested>12</totalNumberAlreadyInvested>
+  </offeringData>
+</edgarSubmission>`;
+
+describe("padCik", () => {
+  it("pads short CIKs to 10 digits", () => {
+    expect(padCik("1828101")).toBe("0001828101");
+    expect(padCik("1")).toBe("0000000001");
+  });
+  it("preserves a 10-digit CIK", () => {
+    expect(padCik("0001234567")).toBe("0001234567");
+  });
+  it("strips non-digits before padding", () => {
+    expect(padCik("CIK 1828101")).toBe("0001828101");
+    expect(padCik("0001828101 ")).toBe("0001828101");
+  });
+  it("throws on input with no digits", () => {
+    expect(() => padCik("CIK")).toThrow(/invalid CIK/);
+    expect(() => padCik("")).toThrow(/invalid CIK/);
+  });
+});
+
+describe("buildFormDUrl", () => {
+  const filing: FormDFiling = {
+    accessionNumber: "0001828101-24-000001",
+    filingDate: "2024-05-30",
+    primaryDocument: "primary_doc.xml",
+    accessionNoDashes: "000182810124000001",
+  };
+  it("uses unpadded CIK in directory segment", () => {
+    expect(buildFormDUrl("1828101", filing)).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1828101/000182810124000001/primary_doc.xml"
+    );
+  });
+  it("strips leading zeros from a padded CIK", () => {
+    expect(buildFormDUrl("0001828101", filing)).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1828101/000182810124000001/primary_doc.xml"
+    );
+  });
+});
+
+describe("parseFormDXml", () => {
+  it("extracts the headline numeric fields", () => {
+    const e = parseFormDXml(SAMPLE_XML);
+    expect(e.totalAmountSold).toBe(750_000_000);
+    expect(e.totalNumberAlreadyInvested).toBe(12);
+    expect(e.firstSaleDate).toBe("2024-05-30");
+    expect(e.issuerName).toBe("Anthropic, PBC");
+  });
+
+  it("returns null for missing fields rather than throwing", () => {
+    const e = parseFormDXml(`<edgarSubmission></edgarSubmission>`);
+    expect(e.totalAmountSold).toBeNull();
+    expect(e.totalNumberAlreadyInvested).toBeNull();
+    expect(e.firstSaleDate).toBeNull();
+    expect(e.issuerName).toBe("");
+  });
+
+  it("returns null when amount field is non-numeric", () => {
+    const xml = `<edgarSubmission><totalAmountSold>UNKNOWN</totalAmountSold></edgarSubmission>`;
+    expect(parseFormDXml(xml).totalAmountSold).toBeNull();
+  });
+
+  it("handles empty leaf elements", () => {
+    const xml = `<edgarSubmission><totalAmountSold></totalAmountSold></edgarSubmission>`;
+    expect(parseFormDXml(xml).totalAmountSold).toBeNull();
+  });
+});
+
+describe("fetchFormDFilings", () => {
+  function makeFetch(body: unknown, status = 200): typeof fetch {
+    return (async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      async json() {
+        return body;
+      },
+    })) as unknown as typeof fetch;
+  }
+
+  it("filters to Form D / Form D/A and zips parallel arrays", async () => {
+    const fetchImpl = makeFetch({
+      cik: "1828101",
+      name: "Anthropic, PBC",
+      filings: {
+        recent: {
+          accessionNumber: ["A-001", "A-002", "A-003", "A-004"],
+          form: ["D", "10-K", "D/A", "8-K"],
+          filingDate: ["2024-05-30", "2024-03-01", "2024-06-15", "2024-04-01"],
+          primaryDocument: ["d.xml", "10k.htm", "da.xml", "8k.htm"],
+        },
+      },
+    });
+
+    const out = await fetchFormDFilings("1828101", { fetchImpl });
+    expect(out).toHaveLength(2);
+    expect(out[0].accessionNumber).toBe("A-001");
+    expect(out[0].accessionNoDashes).toBe("A001");
+    expect(out[1].accessionNumber).toBe("A-003");
+  });
+
+  it("returns empty array when no Form D filings", async () => {
+    const fetchImpl = makeFetch({
+      cik: "1828101",
+      name: "Anthropic, PBC",
+      filings: {
+        recent: { accessionNumber: ["X"], form: ["8-K"], filingDate: ["2024-01-01"] },
+      },
+    });
+    const out = await fetchFormDFilings("1828101", { fetchImpl });
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty array when the recent block is missing entirely", async () => {
+    const fetchImpl = makeFetch({ cik: "1828101", name: "X" });
+    expect(await fetchFormDFilings("1828101", { fetchImpl })).toEqual([]);
+  });
+
+  it("throws on non-2xx HTTP", async () => {
+    const fetchImpl = makeFetch(null, 503);
+    await expect(fetchFormDFilings("1828101", { fetchImpl })).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("respects maxFilingsPerTarget", async () => {
+    const accs = Array.from({ length: 10 }, (_, i) => `A-${i}`);
+    const fetchImpl = makeFetch({
+      cik: "1828101",
+      filings: {
+        recent: {
+          accessionNumber: accs,
+          form: accs.map(() => "D"),
+          filingDate: accs.map(() => "2024-01-01"),
+        },
+      },
+    });
+    const out = await fetchFormDFilings("1828101", { fetchImpl, maxFilingsPerTarget: 3 });
+    expect(out).toHaveLength(3);
+  });
+
+  it("sends the configured User-Agent header", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      captured = String((init?.headers as Record<string, string>)?.["User-Agent"] ?? "");
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { cik: "x", filings: { recent: {} } };
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchFormDFilings("1828101", { fetchImpl, userAgent: "test-agent/1.0" });
+    expect(captured).toBe("test-agent/1.0");
+  });
+});
+
+describe("fetchAndParseFormD", () => {
+  it("returns extract + raw + sourceUrl", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return SAMPLE_XML;
+      },
+    })) as unknown as typeof fetch;
+    const filing: FormDFiling = {
+      accessionNumber: "A-001",
+      filingDate: "2024-05-30",
+      primaryDocument: "primary_doc.xml",
+      accessionNoDashes: "A001",
+    };
+    const r = await fetchAndParseFormD("1828101", filing, { fetchImpl });
+    expect(r.extract.totalAmountSold).toBe(750_000_000);
+    expect(r.sourceUrl).toContain("/1828101/A001/primary_doc.xml");
+    expect(r.rawXml).toBe(SAMPLE_XML);
+  });
+
+  it("throws on non-2xx", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 404 })) as unknown as typeof fetch;
+    const filing: FormDFiling = {
+      accessionNumber: "A-001",
+      filingDate: "x",
+      primaryDocument: "d.xml",
+      accessionNoDashes: "A",
+    };
+    await expect(
+      fetchAndParseFormD("1828101", filing, { fetchImpl })
+    ).rejects.toThrow(/HTTP 404/);
+  });
+});
+
+describe("buildProposal", () => {
+  const filing: FormDFiling = {
+    accessionNumber: "0001828101-24-000001",
+    filingDate: "2024-05-30",
+    primaryDocument: "primary_doc.xml",
+    accessionNoDashes: "000182810124000001",
+  };
+
+  it("emits T1 + sec-edgar source + funding-round recordType", () => {
+    const extract = parseFormDXml(SAMPLE_XML);
+    const p = buildProposal(
+      TARGET,
+      filing,
+      extract,
+      SAMPLE_XML,
+      "https://www.sec.gov/x"
+    );
+    expect(p.tier).toBe("T1");
+    expect(p.source).toBe("sec-edgar:0001828101-24-000001");
+    expect(p.recordType).toBe("funding-round");
+    expect(p.entityRefs?.organization).toBe("anthropic");
+  });
+
+  it("hashes the raw XML deterministically", () => {
+    const extract = parseFormDXml(SAMPLE_XML);
+    const a = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
+    const b = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
+    expect(a.responseHash).toBe(b.responseHash);
+    expect(a.responseHash).toHaveLength(64); // hex sha256
+  });
+
+  it("populates raised + date from the extract", () => {
+    const extract = parseFormDXml(SAMPLE_XML);
+    const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
+    expect(p.record.raised).toBe(750_000_000);
+    expect(p.record.date).toBe("2024-05-30");
+    expect(String(p.record.notes)).toContain("12 investors");
+  });
+
+  it("emits null raised when the extract lacks the field", () => {
+    const extract = parseFormDXml(`<edgarSubmission></edgarSubmission>`);
+    const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
+    expect(p.record.raised).toBeNull();
+    expect(p.record.notes).toBeNull();
+  });
+});
+
+describe("importTarget — happy path + skip-on-error", () => {
+  it("returns proposals for fetched filings and skips broken ones", async () => {
+    let callIdx = 0;
+    const fetchImpl = (async (url: string) => {
+      callIdx++;
+      if (url.includes("submissions/")) {
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              cik: "1828101",
+              filings: {
+                recent: {
+                  accessionNumber: ["A-1", "A-2"],
+                  form: ["D", "D"],
+                  filingDate: ["2024-01-01", "2024-02-01"],
+                  primaryDocument: ["primary_doc.xml", "primary_doc.xml"],
+                },
+              },
+            };
+          },
+        };
+      }
+      // Fail the second filing fetch
+      if (callIdx === 3) return { ok: false, status: 500 };
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return SAMPLE_XML;
+        },
+      };
+    }) as unknown as typeof fetch;
+    const opts: SecEdgarOptions = { fetchImpl };
+    const proposals = await importTarget(TARGET, opts);
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].source).toBe("sec-edgar:A-1");
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses --target=slug:cik", () => {
+    expect(parseTargetsArg(["--target=anthropic:1828101"])).toEqual([
+      { orgSlug: "anthropic", orgName: "anthropic", cik: "1828101" },
+    ]);
+  });
+  it("ignores other flags", () => {
+    expect(parseTargetsArg(["--submit", "--target=x:1"])).toHaveLength(1);
+  });
+  it("throws on malformed --target", () => {
+    expect(() => parseTargetsArg(["--target=missingcik"])).toThrow(/slug:cik/);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
+++ b/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
@@ -3,6 +3,7 @@ import {
   padCik,
   buildFormDUrl,
   parseFormDXml,
+  decodeXmlEntities,
   fetchFormDFilings,
   fetchAndParseFormD,
   buildProposal,
@@ -54,6 +55,29 @@ describe("padCik", () => {
   });
 });
 
+describe("decodeXmlEntities", () => {
+  it("decodes named entities", () => {
+    expect(decodeXmlEntities("AT&amp;T")).toBe("AT&T");
+    expect(decodeXmlEntities("&lt;tag&gt;")).toBe("<tag>");
+    expect(decodeXmlEntities("she said &quot;hi&quot;")).toBe('she said "hi"');
+    expect(decodeXmlEntities("don&apos;t")).toBe("don't");
+  });
+  it("decodes decimal numeric character references", () => {
+    expect(decodeXmlEntities("&#39;")).toBe("'");
+    expect(decodeXmlEntities("&#65;")).toBe("A");
+  });
+  it("decodes hex numeric character references", () => {
+    expect(decodeXmlEntities("&#x27;")).toBe("'");
+    expect(decodeXmlEntities("&#xA9;")).toBe("©");
+  });
+  it("preserves &amp;lt; → &lt; (not <)", () => {
+    expect(decodeXmlEntities("&amp;lt;")).toBe("&lt;");
+  });
+  it("leaves bare ampersands alone", () => {
+    expect(decodeXmlEntities("a & b")).toBe("a & b");
+  });
+});
+
 describe("buildFormDUrl", () => {
   const filing: FormDFiling = {
     accessionNumber: "0001828101-24-000001",
@@ -71,6 +95,9 @@ describe("buildFormDUrl", () => {
       "https://www.sec.gov/Archives/edgar/data/1828101/000182810124000001/primary_doc.xml"
     );
   });
+  it("throws on all-zero CIK rather than producing /data/0/...", () => {
+    expect(() => buildFormDUrl("0000000000", filing)).toThrow(/all zeros/);
+  });
 });
 
 describe("parseFormDXml", () => {
@@ -87,7 +114,7 @@ describe("parseFormDXml", () => {
     expect(e.totalAmountSold).toBeNull();
     expect(e.totalNumberAlreadyInvested).toBeNull();
     expect(e.firstSaleDate).toBeNull();
-    expect(e.issuerName).toBe("");
+    expect(e.issuerName).toBeNull();
   });
 
   it("returns null when amount field is non-numeric", () => {
@@ -98,6 +125,31 @@ describe("parseFormDXml", () => {
   it("handles empty leaf elements", () => {
     const xml = `<edgarSubmission><totalAmountSold></totalAmountSold></edgarSubmission>`;
     expect(parseFormDXml(xml).totalAmountSold).toBeNull();
+  });
+
+  it("handles namespace-prefixed tags (ns1:totalAmountSold)", () => {
+    const xml = `<ns1:edgarSubmission><ns1:totalAmountSold>500</ns1:totalAmountSold></ns1:edgarSubmission>`;
+    expect(parseFormDXml(xml).totalAmountSold).toBe(500);
+  });
+
+  it("handles tags with attributes (xml:lang on entityName)", () => {
+    const xml = `<edgarSubmission><entityName xml:lang="en">OpenAI</entityName></edgarSubmission>`;
+    expect(parseFormDXml(xml).issuerName).toBe("OpenAI");
+  });
+
+  it("handles namespace + attributes simultaneously", () => {
+    const xml = `<a><ns1:entityName xml:lang="en" foo="bar">Anthropic, PBC</ns1:entityName></a>`;
+    expect(parseFormDXml(xml).issuerName).toBe("Anthropic, PBC");
+  });
+
+  it("decodes XML entities inside element values", () => {
+    const xml = `<edgarSubmission><entityName>OpenAI &amp; Affiliates</entityName></edgarSubmission>`;
+    expect(parseFormDXml(xml).issuerName).toBe("OpenAI & Affiliates");
+  });
+
+  it("decodes numeric character references in values", () => {
+    const xml = `<edgarSubmission><entityName>L&#39;Or&#xE9;al</entityName></edgarSubmission>`;
+    expect(parseFormDXml(xml).issuerName).toBe("L'Oréal");
   });
 });
 
@@ -171,6 +223,23 @@ describe("fetchFormDFilings", () => {
     expect(out).toHaveLength(3);
   });
 
+  it("safely handles mismatched parallel-array lengths", async () => {
+    const fetchImpl = makeFetch({
+      cik: "1828101",
+      filings: {
+        recent: {
+          accessionNumber: ["A-1"],          // length 1
+          form: ["D", "D"],                   // length 2
+          filingDate: ["2024-01-01", "2024-02-01"], // length 2
+        },
+      },
+    });
+    // Should not crash on undefined access; takes the shortest array.
+    const out = await fetchFormDFilings("1828101", { fetchImpl });
+    expect(out).toHaveLength(1);
+    expect(out[0].accessionNumber).toBe("A-1");
+  });
+
   it("sends the configured User-Agent header", async () => {
     let captured = "";
     const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
@@ -185,6 +254,23 @@ describe("fetchFormDFilings", () => {
     }) as unknown as typeof fetch;
     await fetchFormDFilings("1828101", { fetchImpl, userAgent: "test-agent/1.0" });
     expect(captured).toBe("test-agent/1.0");
+  });
+
+  it("strips CR/LF from user-supplied User-Agent (header injection guard)", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      captured = String((init?.headers as Record<string, string>)?.["User-Agent"] ?? "");
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { cik: "x", filings: { recent: {} } };
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchFormDFilings("1828101", { fetchImpl, userAgent: "evil\r\nX-Inj: yes" });
+    expect(captured).not.toContain("\r");
+    expect(captured).not.toContain("\n");
   });
 });
 
@@ -258,24 +344,35 @@ describe("buildProposal", () => {
     const extract = parseFormDXml(SAMPLE_XML);
     const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
     expect(p.record.raised).toBe(750_000_000);
+    // Prefers extract.firstSaleDate over filing.filingDate when both are present
     expect(p.record.date).toBe("2024-05-30");
+  });
+
+  it("includes the issuer name from the XML in notes (for evidence)", () => {
+    const extract = parseFormDXml(SAMPLE_XML);
+    const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
     expect(String(p.record.notes)).toContain("12 investors");
+    expect(String(p.record.notes)).toContain("Issuer per Form D: Anthropic, PBC");
+  });
+
+  it("falls back to filing.filingDate when extract.firstSaleDate is null", () => {
+    const extract = parseFormDXml(`<edgarSubmission></edgarSubmission>`);
+    const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
+    expect(p.record.date).toBe("2024-05-30"); // from filing.filingDate
+    expect(p.record.notes).toBeNull();
   });
 
   it("emits null raised when the extract lacks the field", () => {
     const extract = parseFormDXml(`<edgarSubmission></edgarSubmission>`);
     const p = buildProposal(TARGET, filing, extract, SAMPLE_XML, "u");
     expect(p.record.raised).toBeNull();
-    expect(p.record.notes).toBeNull();
   });
 });
 
 describe("importTarget — happy path + skip-on-error", () => {
-  it("returns proposals for fetched filings and skips broken ones", async () => {
-    let callIdx = 0;
+  it("returns proposals + failures count and skips broken filings", async () => {
     const fetchImpl = (async (url: string) => {
-      callIdx++;
-      if (url.includes("submissions/")) {
+      if (String(url).includes("submissions/")) {
         return {
           ok: true,
           status: 200,
@@ -294,8 +391,10 @@ describe("importTarget — happy path + skip-on-error", () => {
           },
         };
       }
-      // Fail the second filing fetch
-      if (callIdx === 3) return { ok: false, status: 500 };
+      // Fail filing A-2 specifically (not call-counter — robust to refactor)
+      if (String(url).includes("/A2/")) {
+        return { ok: false, status: 500 };
+      }
       return {
         ok: true,
         status: 200,
@@ -305,9 +404,10 @@ describe("importTarget — happy path + skip-on-error", () => {
       };
     }) as unknown as typeof fetch;
     const opts: SecEdgarOptions = { fetchImpl };
-    const proposals = await importTarget(TARGET, opts);
+    const { proposals, failures } = await importTarget(TARGET, opts);
     expect(proposals).toHaveLength(1);
     expect(proposals[0].source).toBe("sec-edgar:A-1");
+    expect(failures).toBe(1);
   });
 });
 
@@ -320,7 +420,25 @@ describe("parseTargetsArg", () => {
   it("ignores other flags", () => {
     expect(parseTargetsArg(["--submit", "--target=x:1"])).toHaveLength(1);
   });
-  it("throws on malformed --target", () => {
-    expect(() => parseTargetsArg(["--target=missingcik"])).toThrow(/slug:cik/);
+  it("throws on malformed --target (no colon)", () => {
+    expect(() => parseTargetsArg(["--target=missingcik"])).toThrow(/exactly one colon/);
+  });
+  it("throws on extra colons (--target=slug:cik:extra)", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:1828101:extra"])).toThrow(
+      /exactly one colon/
+    );
+  });
+  it("throws on empty slug", () => {
+    expect(() => parseTargetsArg(["--target=:1828101"])).toThrow(/non-empty/);
+  });
+  it("throws on empty cik", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:"])).toThrow(/non-empty/);
+  });
+  it("throws on non-numeric cik", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:abc"])).toThrow(/1-10 digits/);
+    expect(() => parseTargetsArg(["--target=anthropic:CIK 1"])).toThrow(/1-10 digits/);
+  });
+  it("throws on too-long cik", () => {
+    expect(() => parseTargetsArg(["--target=anthropic:12345678901"])).toThrow(/1-10 digits/);
   });
 });

--- a/crux/commands/tb-importers/allowlist.ts
+++ b/crux/commands/tb-importers/allowlist.ts
@@ -5,22 +5,26 @@
  * the propose endpoint may write a `confirmed` verdict without an LLM call".
  *
  * The propose endpoint (QUA-632) is the enforcement point. This module is the
- * source of truth that both the importers and the endpoint import from.
- *
- * Adding a new entry here is a deliberate trust decision: the source must be a
- * primary, deterministic source for the record type. Examples:
- *   - SEC EDGAR Form D filings → funding-rounds (regulatory filings, structured)
- *   - GitHub contributors API → personnel (org-controlled access lists, structured)
- *   - HuggingFace Open LLM Leaderboard → benchmark-results (auto-eval pipeline output)
- *
- * Things that are NOT T1 (and would be rejected by the gate even if listed
- * here): wikipedia, blog posts, press releases, anything LLM-summarized.
+ * source of truth that both the importers and the endpoint import from —
+ * including the prefix constants themselves, so a renamed prefix can't drift
+ * out of sync between the importer's `proposal.source` and the allowlist.
  */
 
 import type { EnrichmentRecordType } from "./types.ts";
 
+/**
+ * Canonical source-prefix strings. Importers MUST construct
+ * `proposal.source` as `${T1_SOURCE_PREFIXES.X}${id}` so renames
+ * propagate to the allowlist automatically.
+ */
+export const T1_SOURCE_PREFIXES = {
+  secEdgar: "sec-edgar:",
+  githubContributors: "github-contributors:",
+  hfLeaderboard: "hf-leaderboard:",
+} as const;
+
 export interface T1AuthorityEntry {
-  /** Prefix matched against `proposal.source`. e.g. "sec-edgar:" matches "sec-edgar:0001234..." */
+  /** Prefix matched against `proposal.source`. */
   sourcePrefix: string;
   recordType: EnrichmentRecordType;
   /** Human-readable description (shown in audit logs). */
@@ -29,19 +33,19 @@ export interface T1AuthorityEntry {
 
 export const T1_AUTHORITY_ALLOWLIST: readonly T1AuthorityEntry[] = [
   {
-    sourcePrefix: "sec-edgar:",
+    sourcePrefix: T1_SOURCE_PREFIXES.secEdgar,
     recordType: "funding-round",
     description:
       "SEC EDGAR Form D filings (regulatory filings of US private offerings).",
   },
   {
-    sourcePrefix: "github-contributors:",
+    sourcePrefix: T1_SOURCE_PREFIXES.githubContributors,
     recordType: "personnel",
     description:
       "GitHub contributors API for org-owned repositories (≥N commit threshold).",
   },
   {
-    sourcePrefix: "hf-leaderboard:",
+    sourcePrefix: T1_SOURCE_PREFIXES.hfLeaderboard,
     recordType: "benchmark-result",
     description:
       "HuggingFace Open LLM Leaderboard (deterministic auto-eval pipeline).",

--- a/crux/commands/tb-importers/allowlist.ts
+++ b/crux/commands/tb-importers/allowlist.ts
@@ -1,0 +1,63 @@
+/**
+ * T1 authority allowlist (QUA-640).
+ *
+ * Maps `(source-prefix, recordType)` tuples to "this combo is authoritative —
+ * the propose endpoint may write a `confirmed` verdict without an LLM call".
+ *
+ * The propose endpoint (QUA-632) is the enforcement point. This module is the
+ * source of truth that both the importers and the endpoint import from.
+ *
+ * Adding a new entry here is a deliberate trust decision: the source must be a
+ * primary, deterministic source for the record type. Examples:
+ *   - SEC EDGAR Form D filings → funding-rounds (regulatory filings, structured)
+ *   - GitHub contributors API → personnel (org-controlled access lists, structured)
+ *   - HuggingFace Open LLM Leaderboard → benchmark-results (auto-eval pipeline output)
+ *
+ * Things that are NOT T1 (and would be rejected by the gate even if listed
+ * here): wikipedia, blog posts, press releases, anything LLM-summarized.
+ */
+
+import type { EnrichmentRecordType } from "./types.ts";
+
+export interface T1AuthorityEntry {
+  /** Prefix matched against `proposal.source`. e.g. "sec-edgar:" matches "sec-edgar:0001234..." */
+  sourcePrefix: string;
+  recordType: EnrichmentRecordType;
+  /** Human-readable description (shown in audit logs). */
+  description: string;
+}
+
+export const T1_AUTHORITY_ALLOWLIST: readonly T1AuthorityEntry[] = [
+  {
+    sourcePrefix: "sec-edgar:",
+    recordType: "funding-round",
+    description:
+      "SEC EDGAR Form D filings (regulatory filings of US private offerings).",
+  },
+  {
+    sourcePrefix: "github-contributors:",
+    recordType: "personnel",
+    description:
+      "GitHub contributors API for org-owned repositories (≥N commit threshold).",
+  },
+  {
+    sourcePrefix: "hf-leaderboard:",
+    recordType: "benchmark-result",
+    description:
+      "HuggingFace Open LLM Leaderboard (deterministic auto-eval pipeline).",
+  },
+] as const;
+
+/**
+ * Returns true if `(source, recordType)` is on the T1 allowlist.
+ * Source matching is by prefix — `sec-edgar:0001234567-25-000001` matches `sec-edgar:`.
+ */
+export function isT1Authoritative(
+  source: string,
+  recordType: EnrichmentRecordType
+): boolean {
+  return T1_AUTHORITY_ALLOWLIST.some(
+    (entry) =>
+      entry.recordType === recordType && source.startsWith(entry.sourcePrefix)
+  );
+}

--- a/crux/commands/tb-importers/github-contributors.ts
+++ b/crux/commands/tb-importers/github-contributors.ts
@@ -28,6 +28,8 @@ import {
   type ProposeClientOptions,
 } from "./propose-client.ts";
 import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
 import type { EnrichmentProposal } from "./types.ts";
 
 /**
@@ -199,7 +201,7 @@ export function buildProposals(
     const responseHash = createHash("sha256").update(canonical).digest("hex");
     return {
       tier: "T1" as const,
-      source: `github-contributors:${target.orgSlug}:${c.login}`,
+      source: `${T1_SOURCE_PREFIXES.githubContributors}${target.orgSlug}:${c.login}`,
       sourceUrl: c.htmlUrl,
       responseHash,
       recordType: "personnel" as const,
@@ -226,6 +228,11 @@ export function buildProposals(
  * Fetch + aggregate + build proposals for one target.
  * Returns the proposals AND a `failures` count for the caller; per-repo
  * errors are logged and skipped but surfaced via the count.
+ *
+ * Per-repo fetches run in parallel. GitHub's authenticated rate limit is
+ * 5000/h, so a target with 10 repos is comfortably under any cap; without
+ * a token (60/h) you're rate-limit constrained anyway and parallelism is
+ * effectively bounded by the limit.
  */
 export async function importTarget(
   target: GhContributorsTarget,
@@ -235,23 +242,27 @@ export async function importTarget(
     target.minCommits ?? opts.defaultMinCommits ?? DEFAULT_MIN_COMMITS;
   const perRepo: Record<string, GhContributor[]> = {};
   let failures = 0;
-  for (const repo of target.repos) {
-    try {
-      perRepo[repo] = await fetchRepoContributors(repo, opts);
-    } catch (e) {
-      failures++;
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[github-contributors] skipping repo ${repo}: ${msg}`);
-    }
+  const settled = await Promise.all(
+    target.repos.map(async (repo) => {
+      try {
+        return { repo, contribs: await fetchRepoContributors(repo, opts) };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.warn(`[github-contributors] skipping repo ${repo}: ${msg}`);
+        return { repo, error: msg };
+      }
+    })
+  );
+  for (const r of settled) {
+    if ("error" in r) failures++;
+    else perRepo[r.repo] = r.contribs;
   }
   const aggregated = aggregateContributors(perRepo, minCommits);
   return { proposals: buildProposals(target, aggregated), failures };
 }
 
 /** CLI entry — `crux tb github-contributors --target=anthropic:repo1,repo2`. */
-export async function cliMain(
-  args: string[]
-): Promise<{ exitCode: number; output: string }> {
+export async function cliMain(args: string[]): Promise<CommandResult> {
   const submit = args.includes("--submit");
   const targets = parseTargetsArg(args);
   if (targets.length === 0) {

--- a/crux/commands/tb-importers/github-contributors.ts
+++ b/crux/commands/tb-importers/github-contributors.ts
@@ -1,0 +1,269 @@
+/**
+ * GitHub contributors → personnel hints importer (T1, QUA-640).
+ *
+ * For AI labs with public repos (Anthropic, DeepMind, MIRI, Redwood, Apollo,
+ * FAR AI, Conjecture, EleutherAI), the GitHub contributors API gives us a
+ * deterministic list of GitHub users with ≥N commits to org-controlled repos.
+ *
+ * Important: this is a T1 SEEDING step. The contributor's role/title still
+ * needs T2 verification against the org's team page — we record the GitHub
+ * association, not the role. Per QUA-640: "personnel role/title still needs
+ * T2 verification against team pages; this is a T1 seeding step".
+ *
+ * The personnel record we write therefore uses role="contributor" and
+ * roleType="career" — explicitly distinguishing it from key-person rows.
+ *
+ * API: https://api.github.com/repos/<owner>/<repo>/contributors?per_page=100
+ *   (requires no auth for public repos; rate-limited at 60/h unauth or
+ *    5000/h with a token).
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
+
+export interface GhContributorsTarget {
+  /** Org slug from data/entities/organizations.yaml */
+  orgSlug: string;
+  /** Display name for the org */
+  orgName: string;
+  /** GitHub repos (`owner/repo`) attributed to this org */
+  repos: readonly string[];
+  /** Minimum commit count to include a contributor. Defaults to 5. */
+  minCommits?: number;
+}
+
+export interface GhContributorsOptions {
+  /** Override fetch — used by tests to inject responses */
+  fetchImpl?: typeof fetch;
+  /** Override the User-Agent */
+  userAgent?: string;
+  /** Personal access token for higher rate limits (5000/h vs 60/h unauth) */
+  githubToken?: string;
+  /** Default minimum commits floor when target lacks its own (defaults to 5) */
+  defaultMinCommits?: number;
+}
+
+/** Shape of one row in `GET /repos/{owner}/{repo}/contributors`. Partial. */
+export interface GhContributor {
+  login: string;
+  id: number;
+  contributions: number;
+  type: "User" | "Bot" | "Organization";
+  html_url: string;
+}
+
+/** Aggregated contributor across all of one org's repos. */
+export interface AggregatedContributor {
+  login: string;
+  /** Total contributions summed across the org's repos. */
+  totalContributions: number;
+  /** Per-repo breakdown for evidence. */
+  perRepo: Record<string, number>;
+  /** GitHub profile URL — first one observed. */
+  htmlUrl: string;
+}
+
+const DEFAULT_MIN_COMMITS = 5;
+
+function getFetch(opts: GhContributorsOptions): typeof fetch {
+  return opts.fetchImpl ?? globalThis.fetch;
+}
+
+function getHeaders(opts: GhContributorsOptions): Record<string, string> {
+  const h: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": opts.userAgent ?? USER_AGENT,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (opts.githubToken) {
+    h.Authorization = `Bearer ${opts.githubToken}`;
+  }
+  return h;
+}
+
+/**
+ * Fetch contributors for one repo. Returns Users only (filters Bots and
+ * Organizations) since we want human personnel.
+ */
+export async function fetchRepoContributors(
+  ownerRepo: string,
+  opts: GhContributorsOptions = {}
+): Promise<GhContributor[]> {
+  if (!ownerRepo.includes("/")) {
+    throw new Error(`expected "owner/repo", got "${ownerRepo}"`);
+  }
+  const url = `https://api.github.com/repos/${ownerRepo}/contributors?per_page=100`;
+  const resp = await getFetch(opts)(url, { headers: getHeaders(opts) });
+  if (!resp.ok) {
+    throw new Error(
+      `GitHub contributors HTTP ${resp.status} for ${ownerRepo}`
+    );
+  }
+  const rows = (await resp.json()) as GhContributor[];
+  return rows.filter((r) => r.type === "User");
+}
+
+/**
+ * Aggregate contributors across all of an org's repos and apply the
+ * minCommits threshold. Sorted descending by totalContributions.
+ */
+export function aggregateContributors(
+  perRepo: Record<string, GhContributor[]>,
+  minCommits: number
+): AggregatedContributor[] {
+  const byLogin = new Map<string, AggregatedContributor>();
+  for (const [repo, contribs] of Object.entries(perRepo)) {
+    for (const c of contribs) {
+      const existing = byLogin.get(c.login);
+      if (existing) {
+        existing.totalContributions += c.contributions;
+        existing.perRepo[repo] = c.contributions;
+      } else {
+        byLogin.set(c.login, {
+          login: c.login,
+          totalContributions: c.contributions,
+          perRepo: { [repo]: c.contributions },
+          htmlUrl: c.html_url,
+        });
+      }
+    }
+  }
+  return [...byLogin.values()]
+    .filter((c) => c.totalContributions >= minCommits)
+    .sort((a, b) => b.totalContributions - a.totalContributions);
+}
+
+/**
+ * Build one personnel proposal per contributor.
+ *
+ * The `source` is `github-contributors:<orgSlug>:<login>` — uniquely
+ * identifies the (org, person) tuple. The `responseHash` covers the
+ * canonicalized aggregated record so retries with the same data produce
+ * identical proposals.
+ */
+export function buildProposals(
+  target: GhContributorsTarget,
+  contributors: readonly AggregatedContributor[]
+): EnrichmentProposal[] {
+  return contributors.map((c) => {
+    const canonical = JSON.stringify({
+      org: target.orgSlug,
+      login: c.login,
+      perRepo: c.perRepo,
+    });
+    const responseHash = createHash("sha256").update(canonical).digest("hex");
+    return {
+      tier: "T1" as const,
+      source: `github-contributors:${target.orgSlug}:${c.login}`,
+      sourceUrl: c.htmlUrl,
+      responseHash,
+      recordType: "personnel" as const,
+      record: {
+        // T1 seeding only — role is placeholder; real title comes from T2 team-page verification.
+        role: "contributor",
+        roleType: "career",
+        // GitHub login — will need cross-reference with Wikidata/OpenAlex
+        // by a downstream step (out of scope for QUA-640). We record the
+        // login so the resolver can do that lookup.
+        personDisplayName: c.login,
+        orgDisplayName: target.orgName,
+        source: c.htmlUrl,
+        notes: `GitHub contributor: ${c.totalContributions} commits across ${Object.keys(c.perRepo).length} repo(s)`,
+        isFounder: false,
+      },
+      entityRefs: {
+        organization: target.orgSlug,
+        person: c.login,
+      },
+    };
+  });
+}
+
+/**
+ * Fetch + aggregate + build proposals for one target.
+ * Errors on individual repos are logged + skipped.
+ */
+export async function importTarget(
+  target: GhContributorsTarget,
+  opts: GhContributorsOptions = {}
+): Promise<EnrichmentProposal[]> {
+  const minCommits =
+    target.minCommits ?? opts.defaultMinCommits ?? DEFAULT_MIN_COMMITS;
+  const perRepo: Record<string, GhContributor[]> = {};
+  for (const repo of target.repos) {
+    try {
+      perRepo[repo] = await fetchRepoContributors(repo, opts);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[github-contributors] skipping repo ${repo}: ${msg}`);
+    }
+  }
+  const aggregated = aggregateContributors(perRepo, minCommits);
+  return buildProposals(target, aggregated);
+}
+
+/** CLI entry — `crux tb github-contributors --target=anthropic:repo1,repo2`. */
+export async function cliMain(
+  args: string[]
+): Promise<{ exitCode: number; output: string }> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=slug:owner/repo[,owner/repo2] (repeatable)",
+    };
+  }
+  const opts: GhContributorsOptions = {
+    githubToken: process.env.GITHUB_TOKEN,
+  };
+  const all: EnrichmentProposal[] = [];
+  for (const t of targets) {
+    console.log(
+      `[github-contributors] fetching ${t.orgSlug} (${t.repos.length} repos)...`
+    );
+    const proposals = await importTarget(t, opts);
+    console.log(`[github-contributors]   → ${proposals.length} contributors`);
+    all.push(...proposals);
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(all, clientOpts);
+  printBatchSummary(results, "github-contributors");
+  return { exitCode: 0, output: "" };
+}
+
+/**
+ * Parse `--target=slug:owner/repo,owner/repo2` flags. The repo list is
+ * comma-separated and may not contain spaces.
+ */
+export function parseTargetsArg(args: readonly string[]): GhContributorsTarget[] {
+  const out: GhContributorsTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    const colonIdx = value.indexOf(":");
+    if (colonIdx === -1) {
+      throw new Error(
+        `--target must be slug:owner/repo[,owner/repo2], got "${value}"`
+      );
+    }
+    const orgSlug = value.slice(0, colonIdx);
+    const reposCsv = value.slice(colonIdx + 1);
+    const repos = reposCsv.split(",").filter(Boolean);
+    if (repos.length === 0 || repos.some((r) => !r.includes("/"))) {
+      throw new Error(
+        `--target repos must each be "owner/repo", got "${reposCsv}"`
+      );
+    }
+    out.push({ orgSlug, orgName: orgSlug, repos });
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/github-contributors.ts
+++ b/crux/commands/tb-importers/github-contributors.ts
@@ -10,8 +10,11 @@
  * association, not the role. Per QUA-640: "personnel role/title still needs
  * T2 verification against team pages; this is a T1 seeding step".
  *
- * The personnel record we write therefore uses role="contributor" and
- * roleType="career" — explicitly distinguishing it from key-person rows.
+ * The personnel record uses role="contributor" / roleType="career", and
+ * `personDisplayName` is left null — the GitHub login is stored in `notes`
+ * because surfacing a raw login as a display name fails
+ * `validate-display-names.ts` ("no raw machine IDs in titles"). Resolution
+ * to a real name happens via downstream Wikidata/OpenAlex cross-reference.
  *
  * API: https://api.github.com/repos/<owner>/<repo>/contributors?per_page=100
  *   (requires no auth for public repos; rate-limited at 60/h unauth or
@@ -24,9 +27,15 @@ import {
   printBatchSummary,
   type ProposeClientOptions,
 } from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
 import type { EnrichmentProposal } from "./types.ts";
 
-const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
+/**
+ * GitHub owner / repo name char allowlist (no path traversal, no encoded bytes).
+ * Also rejects the literal traversal segments "." and "..".
+ */
+const GH_NAME_RE = /^[A-Za-z0-9._-]+$/;
+const GH_DENY_NAMES = new Set([".", ".."]);
 
 export interface GhContributorsTarget {
   /** Org slug from data/entities/organizations.yaml */
@@ -39,11 +48,7 @@ export interface GhContributorsTarget {
   minCommits?: number;
 }
 
-export interface GhContributorsOptions {
-  /** Override fetch — used by tests to inject responses */
-  fetchImpl?: typeof fetch;
-  /** Override the User-Agent */
-  userAgent?: string;
+export interface GhContributorsOptions extends HttpOptions {
   /** Personal access token for higher rate limits (5000/h vs 60/h unauth) */
   githubToken?: string;
   /** Default minimum commits floor when target lacks its own (defaults to 5) */
@@ -72,20 +77,41 @@ export interface AggregatedContributor {
 
 const DEFAULT_MIN_COMMITS = 5;
 
-function getFetch(opts: GhContributorsOptions): typeof fetch {
-  return opts.fetchImpl ?? globalThis.fetch;
-}
-
 function getHeaders(opts: GhContributorsOptions): Record<string, string> {
   const h: Record<string, string> = {
     Accept: "application/vnd.github+json",
-    "User-Agent": opts.userAgent ?? USER_AGENT,
+    "User-Agent": getUserAgent(opts),
     "X-GitHub-Api-Version": "2022-11-28",
   };
   if (opts.githubToken) {
     h.Authorization = `Bearer ${opts.githubToken}`;
   }
   return h;
+}
+
+/**
+ * Validate `owner/repo` against the GitHub character allowlist.
+ * Throws on path traversal (`..`), encoded bytes (`%2e`), or any character
+ * outside `[A-Za-z0-9._-]`. Defense against SSRF when `owner/repo` arrives
+ * via CLI input.
+ */
+function assertValidOwnerRepo(ownerRepo: string): { owner: string; repo: string } {
+  const parts = ownerRepo.split("/");
+  if (parts.length !== 2) {
+    throw new Error(`expected "owner/repo", got "${ownerRepo}"`);
+  }
+  const [owner, repo] = parts;
+  if (!GH_NAME_RE.test(owner) || !GH_NAME_RE.test(repo)) {
+    throw new Error(
+      `owner/repo must match /^[A-Za-z0-9._-]+$/, got "${ownerRepo}"`
+    );
+  }
+  if (GH_DENY_NAMES.has(owner) || GH_DENY_NAMES.has(repo)) {
+    throw new Error(
+      `owner/repo cannot contain traversal segments "." or "..", got "${ownerRepo}"`
+    );
+  }
+  return { owner, repo };
 }
 
 /**
@@ -96,9 +122,7 @@ export async function fetchRepoContributors(
   ownerRepo: string,
   opts: GhContributorsOptions = {}
 ): Promise<GhContributor[]> {
-  if (!ownerRepo.includes("/")) {
-    throw new Error(`expected "owner/repo", got "${ownerRepo}"`);
-  }
+  assertValidOwnerRepo(ownerRepo);
   const url = `https://api.github.com/repos/${ownerRepo}/contributors?per_page=100`;
   const resp = await getFetch(opts)(url, { headers: getHeaders(opts) });
   if (!resp.ok) {
@@ -107,12 +131,21 @@ export async function fetchRepoContributors(
     );
   }
   const rows = (await resp.json()) as GhContributor[];
-  return rows.filter((r) => r.type === "User");
+  if (!Array.isArray(rows)) {
+    throw new Error(
+      `GitHub contributors response was not an array for ${ownerRepo}`
+    );
+  }
+  return rows.filter((r) => r?.type === "User");
 }
 
 /**
  * Aggregate contributors across all of an org's repos and apply the
  * minCommits threshold. Sorted descending by totalContributions.
+ *
+ * If the same login appears more than once in the same repo (GitHub
+ * shouldn't but defensive), the per-repo count accumulates so the
+ * invariant `totalContributions === sum(perRepo.values())` holds.
  */
 export function aggregateContributors(
   perRepo: Record<string, GhContributor[]>,
@@ -124,7 +157,7 @@ export function aggregateContributors(
       const existing = byLogin.get(c.login);
       if (existing) {
         existing.totalContributions += c.contributions;
-        existing.perRepo[repo] = c.contributions;
+        existing.perRepo[repo] = (existing.perRepo[repo] ?? 0) + c.contributions;
       } else {
         byLogin.set(c.login, {
           login: c.login,
@@ -147,6 +180,11 @@ export function aggregateContributors(
  * identifies the (org, person) tuple. The `responseHash` covers the
  * canonicalized aggregated record so retries with the same data produce
  * identical proposals.
+ *
+ * `personDisplayName` is intentionally null: surfacing the GitHub login
+ * as a person's display name fails `validate-display-names.ts`
+ * ("no raw machine IDs in titles"). The login is in `notes` for
+ * downstream Wikidata/OpenAlex resolution.
  */
 export function buildProposals(
   target: GhContributorsTarget,
@@ -169,13 +207,11 @@ export function buildProposals(
         // T1 seeding only — role is placeholder; real title comes from T2 team-page verification.
         role: "contributor",
         roleType: "career",
-        // GitHub login — will need cross-reference with Wikidata/OpenAlex
-        // by a downstream step (out of scope for QUA-640). We record the
-        // login so the resolver can do that lookup.
-        personDisplayName: c.login,
+        // Display name left null on purpose; see header comment.
+        personDisplayName: null,
         orgDisplayName: target.orgName,
         source: c.htmlUrl,
-        notes: `GitHub contributor: ${c.totalContributions} commits across ${Object.keys(c.perRepo).length} repo(s)`,
+        notes: `GitHub contributor "${c.login}": ${c.totalContributions} commits across ${Object.keys(c.perRepo).length} repo(s)`,
         isFounder: false,
       },
       entityRefs: {
@@ -188,25 +224,28 @@ export function buildProposals(
 
 /**
  * Fetch + aggregate + build proposals for one target.
- * Errors on individual repos are logged + skipped.
+ * Returns the proposals AND a `failures` count for the caller; per-repo
+ * errors are logged and skipped but surfaced via the count.
  */
 export async function importTarget(
   target: GhContributorsTarget,
   opts: GhContributorsOptions = {}
-): Promise<EnrichmentProposal[]> {
+): Promise<{ proposals: EnrichmentProposal[]; failures: number }> {
   const minCommits =
     target.minCommits ?? opts.defaultMinCommits ?? DEFAULT_MIN_COMMITS;
   const perRepo: Record<string, GhContributor[]> = {};
+  let failures = 0;
   for (const repo of target.repos) {
     try {
       perRepo[repo] = await fetchRepoContributors(repo, opts);
     } catch (e) {
+      failures++;
       const msg = e instanceof Error ? e.message : String(e);
       console.warn(`[github-contributors] skipping repo ${repo}: ${msg}`);
     }
   }
   const aggregated = aggregateContributors(perRepo, minCommits);
-  return buildProposals(target, aggregated);
+  return { proposals: buildProposals(target, aggregated), failures };
 }
 
 /** CLI entry — `crux tb github-contributors --target=anthropic:repo1,repo2`. */
@@ -226,23 +265,37 @@ export async function cliMain(
     githubToken: process.env.GITHUB_TOKEN,
   };
   const all: EnrichmentProposal[] = [];
+  let totalFailures = 0;
   for (const t of targets) {
     console.log(
       `[github-contributors] fetching ${t.orgSlug} (${t.repos.length} repos)...`
     );
-    const proposals = await importTarget(t, opts);
-    console.log(`[github-contributors]   → ${proposals.length} contributors`);
-    all.push(...proposals);
+    try {
+      const { proposals, failures } = await importTarget(t, opts);
+      console.log(
+        `[github-contributors]   → ${proposals.length} contributors, ${failures} repo failures`
+      );
+      all.push(...proposals);
+      totalFailures += failures;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[github-contributors] target ${t.orgSlug} failed: ${msg}`);
+      totalFailures++;
+    }
   }
   const clientOpts: ProposeClientOptions = { submit };
   const results = await submitBatch(all, clientOpts);
   printBatchSummary(results, "github-contributors");
+  if (totalFailures > 0) {
+    console.warn(`[github-contributors] ${totalFailures} repo/target failures`);
+  }
   return { exitCode: 0, output: "" };
 }
 
 /**
  * Parse `--target=slug:owner/repo,owner/repo2` flags. The repo list is
- * comma-separated and may not contain spaces.
+ * comma-separated. Empty segments (`a/b,,a/c`) are rejected as typos.
+ * Each `owner/repo` is validated against the GitHub allowlist.
  */
 export function parseTargetsArg(args: readonly string[]): GhContributorsTarget[] {
   const out: GhContributorsTarget[] = [];
@@ -257,11 +310,17 @@ export function parseTargetsArg(args: readonly string[]): GhContributorsTarget[]
     }
     const orgSlug = value.slice(0, colonIdx);
     const reposCsv = value.slice(colonIdx + 1);
-    const repos = reposCsv.split(",").filter(Boolean);
-    if (repos.length === 0 || repos.some((r) => !r.includes("/"))) {
+    if (!orgSlug) {
+      throw new Error(`--target slug must be non-empty, got "${value}"`);
+    }
+    const repos = reposCsv.split(",");
+    if (repos.length === 0 || repos.some((r) => r.length === 0)) {
       throw new Error(
-        `--target repos must each be "owner/repo", got "${reposCsv}"`
+        `--target repos must be a comma-separated list with no empty entries, got "${reposCsv}"`
       );
+    }
+    for (const r of repos) {
+      assertValidOwnerRepo(r);
     }
     out.push({ orgSlug, orgName: orgSlug, repos });
   }

--- a/crux/commands/tb-importers/hf-leaderboard.ts
+++ b/crux/commands/tb-importers/hf-leaderboard.ts
@@ -34,6 +34,8 @@ import {
   type ProposeClientOptions,
 } from "./propose-client.ts";
 import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
 import type { EnrichmentProposal } from "./types.ts";
 
 const DATASET = "open-llm-leaderboard/contents";
@@ -168,22 +170,12 @@ export async function fetchLeaderboardSnapshot(
   return { byEvalName, byFullname };
 }
 
-/**
- * Lookup helper. O(1) on either index — eval_name first, fullname second.
- *
- * Accepts either a `LeaderboardSnapshot` or a bare `Map` for callers that
- * only build a single index (legacy convenience).
- */
+/** Lookup helper. O(1) — eval_name first, fullname second. */
 export function lookupRow(
-  snapshot: LeaderboardSnapshot | ReadonlyMap<string, HfLeaderboardRow>,
+  snapshot: LeaderboardSnapshot,
   evalName: string
 ): HfLeaderboardRow | null {
-  const isSnapshot = (s: unknown): s is LeaderboardSnapshot =>
-    typeof s === "object" && s !== null && "byEvalName" in s && "byFullname" in s;
-  if (isSnapshot(snapshot)) {
-    return snapshot.byEvalName.get(evalName) ?? snapshot.byFullname.get(evalName) ?? null;
-  }
-  return snapshot.get(evalName) ?? null;
+  return snapshot.byEvalName.get(evalName) ?? snapshot.byFullname.get(evalName) ?? null;
 }
 
 /**
@@ -206,7 +198,7 @@ export function validateScore(
  */
 export function buildProposals(
   targets: readonly HfLeaderboardTarget[],
-  snapshot: LeaderboardSnapshot | ReadonlyMap<string, HfLeaderboardRow>,
+  snapshot: LeaderboardSnapshot,
   opts: { benchmarkColumns?: readonly BenchmarkColumnMap[]; scoredAt?: string } = {}
 ): { proposals: EnrichmentProposal[]; misses: Array<{ target: HfLeaderboardTarget; reason: string }> } {
   const cols = opts.benchmarkColumns ?? DEFAULT_BENCHMARK_COLUMNS;
@@ -242,7 +234,7 @@ export function buildProposals(
       const responseHash = createHash("sha256").update(canonical).digest("hex");
       proposals.push({
         tier: "T1",
-        source: `hf-leaderboard:${t.evalName}:${col.column}`,
+        source: `${T1_SOURCE_PREFIXES.hfLeaderboard}${t.evalName}:${col.column}`,
         sourceUrl: `https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard?row=${encodeURIComponent(t.evalName)}`,
         responseHash,
         recordType: "benchmark-result",
@@ -276,9 +268,7 @@ export async function importTargets(
 }
 
 /** CLI entry — `crux tb hf-leaderboard --target=slug:displayName:evalName`. */
-export async function cliMain(
-  args: string[]
-): Promise<{ exitCode: number; output: string }> {
+export async function cliMain(args: string[]): Promise<CommandResult> {
   const submit = args.includes("--submit");
   const targets = parseTargetsArg(args);
   if (targets.length === 0) {

--- a/crux/commands/tb-importers/hf-leaderboard.ts
+++ b/crux/commands/tb-importers/hf-leaderboard.ts
@@ -1,0 +1,300 @@
+/**
+ * HuggingFace Open LLM Leaderboard → benchmark-results importer (T1, QUA-640).
+ *
+ * The leaderboard publishes auto-eval results for ~5000 LLMs across the
+ * BBH / GPQA / MUSR / MATH-Lvl 5 / IFEval / MMLU-Pro suite. The pipeline
+ * is deterministic — same model, same eval, identical score — so we treat
+ * it as T1.
+ *
+ * Data is published as a HuggingFace dataset:
+ *   https://huggingface.co/datasets/open-llm-leaderboard/contents
+ *
+ * Queryable via the datasets-server API:
+ *   GET https://datasets-server.huggingface.co/rows
+ *     ?dataset=open-llm-leaderboard%2Fcontents
+ *     &config=default&split=train
+ *     &offset=<n>&length=<n>
+ *
+ * Each row has fields: `eval_name`, `Average ⬆️`, `IFEval`, `BBH`, `MATH Lvl 5`,
+ * `GPQA`, `MUSR`, `MMLU-PRO`, model metadata, etc.
+ *
+ * We accept a curated list of (model_slug, eval_name) pairs from the caller —
+ * the leaderboard has thousands of rows; the umbrella decides which ones
+ * are wiki-worthy.
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
+const DATASET = "open-llm-leaderboard/contents";
+
+/** One leaderboard row, partial — only the fields we extract. */
+export interface HfLeaderboardRow {
+  /** Full eval name on the leaderboard, e.g. "meta-llama/Meta-Llama-3-70B-Instruct" */
+  eval_name: string;
+  /** The actual fullname is a separate field on some leaderboard versions. */
+  fullname?: string;
+  Average?: number;
+  IFEval?: number;
+  BBH?: number;
+  "MATH Lvl 5"?: number;
+  GPQA?: number;
+  MUSR?: number;
+  "MMLU-PRO"?: number;
+}
+
+/**
+ * The benchmarks we map leaderboard columns to. The leaderboard column
+ * is on the left; the benchmark id (matches `benchmarks.id` in PG) is
+ * on the right. Source-of-truth is the umbrella seed list.
+ */
+export interface BenchmarkColumnMap {
+  /** Column name as it appears in the leaderboard row. */
+  column: keyof HfLeaderboardRow;
+  /** TableBase benchmark id (10-char). */
+  benchmarkId: string;
+  /** Human-readable benchmark slug, used for entityRefs. */
+  benchmarkSlug: string;
+  /** Score unit. The leaderboard normalizes to "%". */
+  unit: string;
+}
+
+export const DEFAULT_BENCHMARK_COLUMNS: readonly BenchmarkColumnMap[] = [
+  { column: "IFEval", benchmarkId: "ifeval-inst", benchmarkSlug: "ifeval", unit: "%" },
+  { column: "BBH", benchmarkId: "bbh", benchmarkSlug: "bbh", unit: "%" },
+  { column: "MATH Lvl 5", benchmarkId: "math-lvl5", benchmarkSlug: "math-lvl-5", unit: "%" },
+  { column: "GPQA", benchmarkId: "gpqa", benchmarkSlug: "gpqa", unit: "%" },
+  { column: "MUSR", benchmarkId: "musr", benchmarkSlug: "musr", unit: "%" },
+  { column: "MMLU-PRO", benchmarkId: "mmlu-pro", benchmarkSlug: "mmlu-pro", unit: "%" },
+] as const;
+
+export interface HfLeaderboardTarget {
+  /** Wiki entity slug for this AI model (e.g., "claude-3-5-sonnet"). */
+  modelSlug: string;
+  /** Display name fallback. */
+  modelDisplayName: string;
+  /** Exact `eval_name` as it appears in the leaderboard. */
+  evalName: string;
+}
+
+export interface HfLeaderboardOptions {
+  /** Override fetch — used by tests. */
+  fetchImpl?: typeof fetch;
+  /** Override the User-Agent. */
+  userAgent?: string;
+  /** Override the column → benchmark mapping. */
+  benchmarkColumns?: readonly BenchmarkColumnMap[];
+  /** Page size for the datasets-server query (max 100). */
+  pageSize?: number;
+  /** Hard cap on rows scanned per call. Defaults to 1000. */
+  maxRows?: number;
+  /** Reference date for the snapshot, used in the benchmark-result `date` field. */
+  scoredAt?: string;
+}
+
+interface RowsResponse {
+  rows: Array<{ row: HfLeaderboardRow }>;
+}
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_MAX_ROWS = 1000;
+
+function getFetch(opts: HfLeaderboardOptions): typeof fetch {
+  return opts.fetchImpl ?? globalThis.fetch;
+}
+
+function getHeaders(opts: HfLeaderboardOptions): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "User-Agent": opts.userAgent ?? USER_AGENT,
+  };
+}
+
+/** Build the datasets-server rows URL for one page. */
+export function buildRowsUrl(offset: number, length: number): string {
+  const params = new URLSearchParams({
+    dataset: DATASET,
+    config: "default",
+    split: "train",
+    offset: String(offset),
+    length: String(length),
+  });
+  return `https://datasets-server.huggingface.co/rows?${params.toString()}`;
+}
+
+/**
+ * Page through the leaderboard, building a map keyed by `eval_name` for
+ * O(1) lookup. Stops when `maxRows` reached or when a page returns < pageSize.
+ */
+export async function fetchLeaderboardSnapshot(
+  opts: HfLeaderboardOptions = {}
+): Promise<Map<string, HfLeaderboardRow>> {
+  const pageSize = Math.min(opts.pageSize ?? DEFAULT_PAGE_SIZE, 100);
+  const maxRows = opts.maxRows ?? DEFAULT_MAX_ROWS;
+  const fetchImpl = getFetch(opts);
+  const headers = getHeaders(opts);
+  const out = new Map<string, HfLeaderboardRow>();
+  let offset = 0;
+
+  while (out.size < maxRows) {
+    const url = buildRowsUrl(offset, pageSize);
+    const resp = await fetchImpl(url, { headers });
+    if (!resp.ok) {
+      throw new Error(`HuggingFace datasets-server HTTP ${resp.status}`);
+    }
+    const data = (await resp.json()) as RowsResponse;
+    if (!data.rows || data.rows.length === 0) break;
+    for (const wrap of data.rows) {
+      const r = wrap.row;
+      if (r?.eval_name) {
+        out.set(r.eval_name, r);
+      }
+    }
+    if (data.rows.length < pageSize) break;
+    offset += pageSize;
+  }
+  return out;
+}
+
+/**
+ * Lookup helper. The leaderboard publishes both `eval_name` and `fullname`
+ * on some snapshots; if the `eval_name` lookup misses, fall back to a
+ * full scan of `fullname`.
+ */
+export function lookupRow(
+  snapshot: ReadonlyMap<string, HfLeaderboardRow>,
+  evalName: string
+): HfLeaderboardRow | null {
+  const direct = snapshot.get(evalName);
+  if (direct) return direct;
+  for (const row of snapshot.values()) {
+    if (row.fullname === evalName) return row;
+  }
+  return null;
+}
+
+/**
+ * Build proposals — one per (target, benchmark column) pair.
+ * Returns the proposals AND a list of misses (target+column) for caller logging.
+ */
+export function buildProposals(
+  targets: readonly HfLeaderboardTarget[],
+  snapshot: ReadonlyMap<string, HfLeaderboardRow>,
+  opts: { benchmarkColumns?: readonly BenchmarkColumnMap[]; scoredAt?: string } = {}
+): { proposals: EnrichmentProposal[]; misses: Array<{ target: HfLeaderboardTarget; reason: string }> } {
+  const cols = opts.benchmarkColumns ?? DEFAULT_BENCHMARK_COLUMNS;
+  const proposals: EnrichmentProposal[] = [];
+  const misses: Array<{ target: HfLeaderboardTarget; reason: string }> = [];
+  const date = opts.scoredAt ?? new Date().toISOString().slice(0, 10);
+
+  for (const t of targets) {
+    const row = lookupRow(snapshot, t.evalName);
+    if (!row) {
+      misses.push({ target: t, reason: `eval_name "${t.evalName}" not in snapshot` });
+      continue;
+    }
+    for (const col of cols) {
+      const score = row[col.column];
+      if (typeof score !== "number" || !Number.isFinite(score)) {
+        // Don't emit a proposal for a benchmark the model didn't run.
+        continue;
+      }
+      const canonical = JSON.stringify({
+        eval_name: t.evalName,
+        column: col.column,
+        score,
+      });
+      const responseHash = createHash("sha256").update(canonical).digest("hex");
+      proposals.push({
+        tier: "T1",
+        source: `hf-leaderboard:${t.evalName}:${col.column}`,
+        sourceUrl: `https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard?row=${encodeURIComponent(t.evalName)}`,
+        responseHash,
+        recordType: "benchmark-result",
+        record: {
+          score,
+          unit: col.unit,
+          date,
+          sourceUrl: "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard",
+          notes: `${col.column} score from HuggingFace Open LLM Leaderboard`,
+        },
+        entityRefs: {
+          model: t.modelSlug,
+          benchmark: col.benchmarkSlug,
+        },
+      });
+    }
+  }
+  return { proposals, misses };
+}
+
+/** End-to-end: fetch snapshot + build proposals. */
+export async function importTargets(
+  targets: readonly HfLeaderboardTarget[],
+  opts: HfLeaderboardOptions = {}
+): Promise<{ proposals: EnrichmentProposal[]; misses: Array<{ target: HfLeaderboardTarget; reason: string }> }> {
+  const snapshot = await fetchLeaderboardSnapshot(opts);
+  return buildProposals(targets, snapshot, {
+    benchmarkColumns: opts.benchmarkColumns,
+    scoredAt: opts.scoredAt,
+  });
+}
+
+/** CLI entry — `crux tb hf-leaderboard --target=slug:displayName:evalName`. */
+export async function cliMain(
+  args: string[]
+): Promise<{ exitCode: number; output: string }> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=modelSlug:displayName:evalName (repeatable)",
+    };
+  }
+  console.log(`[hf-leaderboard] fetching snapshot for ${targets.length} target(s)...`);
+  const { proposals, misses } = await importTargets(targets);
+  console.log(`[hf-leaderboard] built ${proposals.length} proposals; ${misses.length} target(s) missed`);
+  for (const m of misses.slice(0, 10)) {
+    console.log(`  - ${m.target.modelSlug}: ${m.reason}`);
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(proposals, clientOpts);
+  printBatchSummary(results, "hf-leaderboard");
+  return { exitCode: 0, output: "" };
+}
+
+/**
+ * Parse `--target=modelSlug:displayName:evalName`.
+ * `displayName` and `evalName` may contain forward slashes.
+ */
+export function parseTargetsArg(args: readonly string[]): HfLeaderboardTarget[] {
+  const out: HfLeaderboardTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    // Use the first two colons as separators — evalName may contain colons too.
+    const first = value.indexOf(":");
+    const second = first === -1 ? -1 : value.indexOf(":", first + 1);
+    if (first === -1 || second === -1) {
+      throw new Error(
+        `--target must be modelSlug:displayName:evalName, got "${value}"`
+      );
+    }
+    const modelSlug = value.slice(0, first);
+    const modelDisplayName = value.slice(first + 1, second);
+    const evalName = value.slice(second + 1);
+    if (!modelSlug || !modelDisplayName || !evalName) {
+      throw new Error(`--target has empty segment(s): "${value}"`);
+    }
+    out.push({ modelSlug, modelDisplayName, evalName });
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/hf-leaderboard.ts
+++ b/crux/commands/tb-importers/hf-leaderboard.ts
@@ -21,6 +21,10 @@
  * We accept a curated list of (model_slug, eval_name) pairs from the caller —
  * the leaderboard has thousands of rows; the umbrella decides which ones
  * are wiki-worthy.
+ *
+ * Score policy: `0` is treated as a legitimate result (some hard benchmarks
+ * have models that score 0). Negative scores are rejected as sentinels.
+ * Scores >100 (with `unit: "%"`) are also rejected as obvious data errors.
  */
 
 import { createHash } from "crypto";
@@ -29,9 +33,9 @@ import {
   printBatchSummary,
   type ProposeClientOptions,
 } from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
 import type { EnrichmentProposal } from "./types.ts";
 
-const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
 const DATASET = "open-llm-leaderboard/contents";
 
 /** One leaderboard row, partial — only the fields we extract. */
@@ -57,21 +61,19 @@ export interface HfLeaderboardRow {
 export interface BenchmarkColumnMap {
   /** Column name as it appears in the leaderboard row. */
   column: keyof HfLeaderboardRow;
-  /** TableBase benchmark id (10-char). */
-  benchmarkId: string;
-  /** Human-readable benchmark slug, used for entityRefs. */
+  /** Human-readable benchmark slug, used for entityRefs (matches `benchmarks.id` in PG). */
   benchmarkSlug: string;
   /** Score unit. The leaderboard normalizes to "%". */
   unit: string;
 }
 
 export const DEFAULT_BENCHMARK_COLUMNS: readonly BenchmarkColumnMap[] = [
-  { column: "IFEval", benchmarkId: "ifeval-inst", benchmarkSlug: "ifeval", unit: "%" },
-  { column: "BBH", benchmarkId: "bbh", benchmarkSlug: "bbh", unit: "%" },
-  { column: "MATH Lvl 5", benchmarkId: "math-lvl5", benchmarkSlug: "math-lvl-5", unit: "%" },
-  { column: "GPQA", benchmarkId: "gpqa", benchmarkSlug: "gpqa", unit: "%" },
-  { column: "MUSR", benchmarkId: "musr", benchmarkSlug: "musr", unit: "%" },
-  { column: "MMLU-PRO", benchmarkId: "mmlu-pro", benchmarkSlug: "mmlu-pro", unit: "%" },
+  { column: "IFEval", benchmarkSlug: "ifeval", unit: "%" },
+  { column: "BBH", benchmarkSlug: "bbh", unit: "%" },
+  { column: "MATH Lvl 5", benchmarkSlug: "math-lvl-5", unit: "%" },
+  { column: "GPQA", benchmarkSlug: "gpqa", unit: "%" },
+  { column: "MUSR", benchmarkSlug: "musr", unit: "%" },
+  { column: "MMLU-PRO", benchmarkSlug: "mmlu-pro", unit: "%" },
 ] as const;
 
 export interface HfLeaderboardTarget {
@@ -83,11 +85,7 @@ export interface HfLeaderboardTarget {
   evalName: string;
 }
 
-export interface HfLeaderboardOptions {
-  /** Override fetch — used by tests. */
-  fetchImpl?: typeof fetch;
-  /** Override the User-Agent. */
-  userAgent?: string;
+export interface HfLeaderboardOptions extends HttpOptions {
   /** Override the column → benchmark mapping. */
   benchmarkColumns?: readonly BenchmarkColumnMap[];
   /** Page size for the datasets-server query (max 100). */
@@ -105,15 +103,21 @@ interface RowsResponse {
 const DEFAULT_PAGE_SIZE = 100;
 const DEFAULT_MAX_ROWS = 1000;
 
-function getFetch(opts: HfLeaderboardOptions): typeof fetch {
-  return opts.fetchImpl ?? globalThis.fetch;
-}
-
 function getHeaders(opts: HfLeaderboardOptions): Record<string, string> {
   return {
     Accept: "application/json",
-    "User-Agent": opts.userAgent ?? USER_AGENT,
+    "User-Agent": getUserAgent(opts),
   };
+}
+
+/**
+ * The snapshot we return from `fetchLeaderboardSnapshot`. Holds two indices
+ * so `lookupRow` is O(1) on either eval_name or fullname (the leaderboard
+ * publishes both on some snapshots).
+ */
+export interface LeaderboardSnapshot {
+  byEvalName: ReadonlyMap<string, HfLeaderboardRow>;
+  byFullname: ReadonlyMap<string, HfLeaderboardRow>;
 }
 
 /** Build the datasets-server rows URL for one page. */
@@ -129,53 +133,70 @@ export function buildRowsUrl(offset: number, length: number): string {
 }
 
 /**
- * Page through the leaderboard, building a map keyed by `eval_name` for
- * O(1) lookup. Stops when `maxRows` reached or when a page returns < pageSize.
+ * Page through the leaderboard, building both eval_name + fullname indices.
+ * Stops when `maxRows` reached or when a page returns < pageSize.
  */
 export async function fetchLeaderboardSnapshot(
   opts: HfLeaderboardOptions = {}
-): Promise<Map<string, HfLeaderboardRow>> {
+): Promise<LeaderboardSnapshot> {
   const pageSize = Math.min(opts.pageSize ?? DEFAULT_PAGE_SIZE, 100);
   const maxRows = opts.maxRows ?? DEFAULT_MAX_ROWS;
   const fetchImpl = getFetch(opts);
   const headers = getHeaders(opts);
-  const out = new Map<string, HfLeaderboardRow>();
+  const byEvalName = new Map<string, HfLeaderboardRow>();
+  const byFullname = new Map<string, HfLeaderboardRow>();
   let offset = 0;
 
-  while (out.size < maxRows) {
+  while (byEvalName.size < maxRows) {
     const url = buildRowsUrl(offset, pageSize);
     const resp = await fetchImpl(url, { headers });
     if (!resp.ok) {
       throw new Error(`HuggingFace datasets-server HTTP ${resp.status}`);
     }
     const data = (await resp.json()) as RowsResponse;
-    if (!data.rows || data.rows.length === 0) break;
+    if (!data?.rows || data.rows.length === 0) break;
     for (const wrap of data.rows) {
-      const r = wrap.row;
+      const r = wrap?.row;
       if (r?.eval_name) {
-        out.set(r.eval_name, r);
+        byEvalName.set(r.eval_name, r);
+        if (r.fullname) byFullname.set(r.fullname, r);
       }
     }
     if (data.rows.length < pageSize) break;
     offset += pageSize;
   }
-  return out;
+  return { byEvalName, byFullname };
 }
 
 /**
- * Lookup helper. The leaderboard publishes both `eval_name` and `fullname`
- * on some snapshots; if the `eval_name` lookup misses, fall back to a
- * full scan of `fullname`.
+ * Lookup helper. O(1) on either index — eval_name first, fullname second.
+ *
+ * Accepts either a `LeaderboardSnapshot` or a bare `Map` for callers that
+ * only build a single index (legacy convenience).
  */
 export function lookupRow(
-  snapshot: ReadonlyMap<string, HfLeaderboardRow>,
+  snapshot: LeaderboardSnapshot | ReadonlyMap<string, HfLeaderboardRow>,
   evalName: string
 ): HfLeaderboardRow | null {
-  const direct = snapshot.get(evalName);
-  if (direct) return direct;
-  for (const row of snapshot.values()) {
-    if (row.fullname === evalName) return row;
+  const isSnapshot = (s: unknown): s is LeaderboardSnapshot =>
+    typeof s === "object" && s !== null && "byEvalName" in s && "byFullname" in s;
+  if (isSnapshot(snapshot)) {
+    return snapshot.byEvalName.get(evalName) ?? snapshot.byFullname.get(evalName) ?? null;
   }
+  return snapshot.get(evalName) ?? null;
+}
+
+/**
+ * Validate a score before emitting a proposal. Returns null on accept,
+ * a string reason on reject. Centralizes the score-policy decisions.
+ */
+export function validateScore(
+  score: number,
+  unit: string
+): string | null {
+  if (!Number.isFinite(score)) return "score is not finite";
+  if (score < 0) return `score ${score} is negative (sentinel rejected)`;
+  if (unit === "%" && score > 100) return `score ${score} > 100 with unit="%"`;
   return null;
 }
 
@@ -185,7 +206,7 @@ export function lookupRow(
  */
 export function buildProposals(
   targets: readonly HfLeaderboardTarget[],
-  snapshot: ReadonlyMap<string, HfLeaderboardRow>,
+  snapshot: LeaderboardSnapshot | ReadonlyMap<string, HfLeaderboardRow>,
   opts: { benchmarkColumns?: readonly BenchmarkColumnMap[]; scoredAt?: string } = {}
 ): { proposals: EnrichmentProposal[]; misses: Array<{ target: HfLeaderboardTarget; reason: string }> } {
   const cols = opts.benchmarkColumns ?? DEFAULT_BENCHMARK_COLUMNS;
@@ -200,15 +221,23 @@ export function buildProposals(
       continue;
     }
     for (const col of cols) {
-      const score = row[col.column];
-      if (typeof score !== "number" || !Number.isFinite(score)) {
+      const raw = row[col.column];
+      if (typeof raw !== "number") {
         // Don't emit a proposal for a benchmark the model didn't run.
+        continue;
+      }
+      const reject = validateScore(raw, col.unit);
+      if (reject) {
+        misses.push({
+          target: t,
+          reason: `${col.column}: ${reject}`,
+        });
         continue;
       }
       const canonical = JSON.stringify({
         eval_name: t.evalName,
         column: col.column,
-        score,
+        score: raw,
       });
       const responseHash = createHash("sha256").update(canonical).digest("hex");
       proposals.push({
@@ -218,11 +247,11 @@ export function buildProposals(
         responseHash,
         recordType: "benchmark-result",
         record: {
-          score,
+          score: raw,
           unit: col.unit,
           date,
           sourceUrl: "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard",
-          notes: `${col.column} score from HuggingFace Open LLM Leaderboard`,
+          notes: `${col.column} score from HuggingFace Open LLM Leaderboard (model: ${t.modelDisplayName})`,
         },
         entityRefs: {
           model: t.modelSlug,
@@ -261,7 +290,7 @@ export async function cliMain(
   }
   console.log(`[hf-leaderboard] fetching snapshot for ${targets.length} target(s)...`);
   const { proposals, misses } = await importTargets(targets);
-  console.log(`[hf-leaderboard] built ${proposals.length} proposals; ${misses.length} target(s) missed`);
+  console.log(`[hf-leaderboard] built ${proposals.length} proposals; ${misses.length} target+column miss(es)`);
   for (const m of misses.slice(0, 10)) {
     console.log(`  - ${m.target.modelSlug}: ${m.reason}`);
   }
@@ -273,7 +302,8 @@ export async function cliMain(
 
 /**
  * Parse `--target=modelSlug:displayName:evalName`.
- * `displayName` and `evalName` may contain forward slashes.
+ * `displayName` and `evalName` may contain forward slashes; `evalName`
+ * may contain additional colons (everything after the second colon).
  */
 export function parseTargetsArg(args: readonly string[]): HfLeaderboardTarget[] {
   const out: HfLeaderboardTarget[] = [];

--- a/crux/commands/tb-importers/http-utils.ts
+++ b/crux/commands/tb-importers/http-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared HTTP utilities for T1 importers.
+ *
+ * Extracts the previously-duplicated User-Agent constant, fetch resolver,
+ * and header builder so all three importers share one definition.
+ */
+
+/**
+ * User-Agent sent on outbound requests.
+ *
+ * SEC requires accurate identification per
+ * https://www.sec.gov/os/accessing-edgar-data — they enforce 403 on missing
+ * UA. We use the org bot address to keep personal contact info out of
+ * outbound requests + git history.
+ */
+export const USER_AGENT = "longterm-wiki <bot@quantifieduncertainty.org>";
+
+export interface HttpOptions {
+  /** Override the global fetch — used by tests to inject responses. */
+  fetchImpl?: typeof fetch;
+  /** Override the User-Agent. Stripped of CR/LF to prevent header injection. */
+  userAgent?: string;
+}
+
+export function getFetch(opts: HttpOptions): typeof fetch {
+  return opts.fetchImpl ?? globalThis.fetch;
+}
+
+/**
+ * Sanitize a header value: strip CR/LF + leading/trailing whitespace.
+ * Header injection via interpolated user values is the failure mode this
+ * guards. The User-Agent is the only header in our hot path that can be
+ * caller-overridden today; this keeps the door closed.
+ */
+export function sanitizeHeaderValue(v: string): string {
+  return v.replace(/[\r\n]/g, "").trim();
+}
+
+export function getUserAgent(opts: HttpOptions): string {
+  return sanitizeHeaderValue(opts.userAgent ?? USER_AGENT);
+}

--- a/crux/commands/tb-importers/index.ts
+++ b/crux/commands/tb-importers/index.ts
@@ -15,24 +15,14 @@ import { cliMain as secEdgarCliMain } from "./sec-edgar.ts";
 import { cliMain as ghContribCliMain } from "./github-contributors.ts";
 import { cliMain as hfLeaderboardCliMain } from "./hf-leaderboard.ts";
 
-type CommandResult = { exitCode?: number; output?: string };
-
-async function secEdgar(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
-  return secEdgarCliMain(args);
-}
-
-async function githubContributors(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
-  return ghContribCliMain(args);
-}
-
-async function hfLeaderboard(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
-  return hfLeaderboardCliMain(args);
-}
+// The crux dispatcher passes (args, options); the importers ignore options
+// (their flags are parsed from `args`), so a one-arg adapter is sufficient.
+const adapt = (fn: (args: string[]) => unknown) => (args: string[]) => fn(args);
 
 export const commands = {
-  "sec-edgar": secEdgar,
-  "github-contributors": githubContributors,
-  "hf-leaderboard": hfLeaderboard,
+  "sec-edgar": adapt(secEdgarCliMain),
+  "github-contributors": adapt(ghContribCliMain),
+  "hf-leaderboard": adapt(hfLeaderboardCliMain),
 };
 
 export function getHelp(): string {

--- a/crux/commands/tb-importers/index.ts
+++ b/crux/commands/tb-importers/index.ts
@@ -1,0 +1,55 @@
+/**
+ * T1 importer command exports (QUA-640).
+ *
+ * Wires the three importer CLIs into the tb command tree:
+ *   - `crux tb sec-edgar           --target=slug:cik [--submit]`
+ *   - `crux tb github-contributors --target=slug:owner/repo[,owner/repo2] [--submit]`
+ *   - `crux tb hf-leaderboard      --target=modelSlug:displayName:evalName [--submit]`
+ *
+ * `--submit` is wired through to the propose-client; today the endpoint
+ * (QUA-632) does not yet exist so submit-mode returns `pending`. Until then,
+ * default behavior (dry-run) prints what would be sent.
+ */
+
+import { cliMain as secEdgarCliMain } from "./sec-edgar.ts";
+import { cliMain as ghContribCliMain } from "./github-contributors.ts";
+import { cliMain as hfLeaderboardCliMain } from "./hf-leaderboard.ts";
+
+type CommandResult = { exitCode?: number; output?: string };
+
+async function secEdgar(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
+  return secEdgarCliMain(args);
+}
+
+async function githubContributors(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
+  return ghContribCliMain(args);
+}
+
+async function hfLeaderboard(args: string[], _options: Record<string, unknown>): Promise<CommandResult> {
+  return hfLeaderboardCliMain(args);
+}
+
+export const commands = {
+  "sec-edgar": secEdgar,
+  "github-contributors": githubContributors,
+  "hf-leaderboard": hfLeaderboard,
+};
+
+export function getHelp(): string {
+  return `
+T1 importers — defensive enrichment via authoritative sources (QUA-640)
+
+Commands:
+  sec-edgar              Fetch SEC EDGAR Form D filings → funding-rounds
+  github-contributors    Fetch GitHub contributors API → personnel hints
+  hf-leaderboard         Fetch HuggingFace Open LLM Leaderboard → benchmark-results
+
+Usage:
+  crux tb sec-edgar --target=anthropic:1828101 [--submit]
+  crux tb github-contributors --target=anthropic:anthropics/anthropic-sdk-python [--submit]
+  crux tb hf-leaderboard --target=llama-3-70b:Llama-3-70B:meta-llama/Llama-3-70B [--submit]
+
+All importers default to dry-run mode (print proposals, don't POST).
+Pass --submit to attempt POST to /api/enrichment/propose (blocked on QUA-632).
+`;
+}

--- a/crux/commands/tb-importers/propose-client.ts
+++ b/crux/commands/tb-importers/propose-client.ts
@@ -1,0 +1,117 @@
+/**
+ * Client for `POST /api/enrichment/propose` (QUA-632).
+ *
+ * QUA-632 is in flight in another session — until that endpoint lands, this
+ * client is a stub. `submitProposal()` validates the proposal against the T1
+ * allowlist and either:
+ *   - dry-run mode (default): logs the proposal as JSON, returns `pending`
+ *   - --submit mode: would POST to the endpoint when it exists; today returns
+ *     `pending` with a "endpoint not yet built (QUA-632)" reason
+ *
+ * The wire format (`EnrichmentProposal` from ./types.ts) is the contract.
+ * When QUA-632 lands, only the `submitToServer()` body needs to change.
+ */
+
+import { isT1Authoritative } from "./allowlist.ts";
+import type { EnrichmentProposal, ProposeResult } from "./types.ts";
+
+export interface ProposeClientOptions {
+  /** When true, attempt to POST to /api/enrichment/propose. Default false. */
+  submit?: boolean;
+  /** When true, skip the T1 allowlist check (for testing). */
+  skipAllowlistCheck?: boolean;
+}
+
+/**
+ * Validate one proposal locally before it's POSTed.
+ * Returns null on success, or a string reason on failure.
+ */
+export function validateProposal(p: EnrichmentProposal): string | null {
+  if (p.tier !== "T1") {
+    return `T1 importers must emit tier=T1, got tier=${p.tier}`;
+  }
+  if (!p.source || !p.sourceUrl || !p.responseHash) {
+    return "proposal missing required source/sourceUrl/responseHash";
+  }
+  if (!isT1Authoritative(p.source, p.recordType)) {
+    return `(source=${p.source}, recordType=${p.recordType}) not on T1 authority allowlist`;
+  }
+  return null;
+}
+
+/**
+ * Submit a single proposal. Returns the result.
+ *
+ * Today (pre-QUA-632) this never reaches the network — see top-of-file note.
+ */
+export async function submitProposal(
+  p: EnrichmentProposal,
+  opts: ProposeClientOptions = {}
+): Promise<ProposeResult> {
+  if (!opts.skipAllowlistCheck) {
+    const failure = validateProposal(p);
+    if (failure) {
+      return { proposal: p, status: "rejected", reason: failure };
+    }
+  }
+
+  if (!opts.submit) {
+    return { proposal: p, status: "pending", reason: "dry-run" };
+  }
+
+  return submitToServer(p);
+}
+
+/**
+ * The actual network call. Stub until QUA-632 ships.
+ *
+ * When QUA-632 lands, replace the body with:
+ *   const res = await apiRequest<ProposeResult>("/api/enrichment/propose", { method: "POST", body: p });
+ *   return res;
+ */
+async function submitToServer(p: EnrichmentProposal): Promise<ProposeResult> {
+  return {
+    proposal: p,
+    status: "pending",
+    reason: "endpoint /api/enrichment/propose not yet built (blocked on QUA-632)",
+  };
+}
+
+/**
+ * Submit many proposals sequentially. Returns one result per input.
+ * Sequential because we want stable ordering + cheap rate-limiting.
+ */
+export async function submitBatch(
+  proposals: readonly EnrichmentProposal[],
+  opts: ProposeClientOptions = {}
+): Promise<ProposeResult[]> {
+  const out: ProposeResult[] = [];
+  for (const p of proposals) {
+    out.push(await submitProposal(p, opts));
+  }
+  return out;
+}
+
+/**
+ * Summarize a batch result for stdout. Side-effecting on purpose.
+ */
+export function printBatchSummary(
+  results: readonly ProposeResult[],
+  importerName: string
+): void {
+  const accepted = results.filter((r) => r.status === "accepted").length;
+  const rejected = results.filter((r) => r.status === "rejected").length;
+  const pending = results.filter((r) => r.status === "pending").length;
+  console.log(
+    `[${importerName}] ${results.length} proposals: accepted=${accepted} rejected=${rejected} pending=${pending}`
+  );
+  if (rejected > 0) {
+    console.log(`[${importerName}] First 5 rejections:`);
+    results
+      .filter((r) => r.status === "rejected")
+      .slice(0, 5)
+      .forEach((r) =>
+        console.log(`  - ${r.proposal.source}: ${r.reason ?? "no reason"}`)
+      );
+  }
+}

--- a/crux/commands/tb-importers/propose-client.ts
+++ b/crux/commands/tb-importers/propose-client.ts
@@ -99,19 +99,21 @@ export function printBatchSummary(
   results: readonly ProposeResult[],
   importerName: string
 ): void {
-  const accepted = results.filter((r) => r.status === "accepted").length;
-  const rejected = results.filter((r) => r.status === "rejected").length;
-  const pending = results.filter((r) => r.status === "pending").length;
+  const rejections: ProposeResult[] = [];
+  let accepted = 0;
+  let pending = 0;
+  for (const r of results) {
+    if (r.status === "accepted") accepted++;
+    else if (r.status === "pending") pending++;
+    else if (r.status === "rejected") rejections.push(r);
+  }
   console.log(
-    `[${importerName}] ${results.length} proposals: accepted=${accepted} rejected=${rejected} pending=${pending}`
+    `[${importerName}] ${results.length} proposals: accepted=${accepted} rejected=${rejections.length} pending=${pending}`
   );
-  if (rejected > 0) {
+  if (rejections.length > 0) {
     console.log(`[${importerName}] First 5 rejections:`);
-    results
-      .filter((r) => r.status === "rejected")
-      .slice(0, 5)
-      .forEach((r) =>
-        console.log(`  - ${r.proposal.source}: ${r.reason ?? "no reason"}`)
-      );
+    for (const r of rejections.slice(0, 5)) {
+      console.log(`  - ${r.proposal.source}: ${r.reason ?? "no reason"}`);
+    }
   }
 }

--- a/crux/commands/tb-importers/sec-edgar.ts
+++ b/crux/commands/tb-importers/sec-edgar.ts
@@ -11,8 +11,12 @@
  *   (returns recent.form[] / recent.accessionNumber[] / recent.filingDate[])
  * Form D XML index: https://www.sec.gov/Archives/edgar/data/<cik>/<accession-no-dashes>/<accession-with-dashes>-index.json
  *
- * SEC requires a User-Agent identifying the requester. We send
- * "longterm-wiki <ozzie@quantifieduncertainty.org>".
+ * The XML parser is deliberately regex-based but tolerant of:
+ *   - namespace prefixes (`<ns1:totalAmountSold>`)
+ *   - element attributes (`<entityName xml:lang="en">`)
+ *   - HTML entity references (`&amp;`, `&lt;`, `&#39;`, `&#x27;`)
+ * If you encounter Form D XML this can't parse, swap in `fast-xml-parser`
+ * here — the rest of the importer is parser-agnostic.
  */
 
 import { createHash } from "crypto";
@@ -21,9 +25,8 @@ import {
   printBatchSummary,
   type ProposeClientOptions,
 } from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
 import type { EnrichmentProposal } from "./types.ts";
-
-const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
 
 export interface SecEdgarTarget {
   /** Org slug from data/entities/organizations.yaml */
@@ -34,11 +37,7 @@ export interface SecEdgarTarget {
   cik: string;
 }
 
-export interface SecEdgarOptions {
-  /** Override the global fetch — used by tests to inject responses. */
-  fetchImpl?: typeof fetch;
-  /** Override the User-Agent — keep default in production. */
-  userAgent?: string;
+export interface SecEdgarOptions extends HttpOptions {
   /** Limit on filings fetched per target (paginated APIs return many). */
   maxFilingsPerTarget?: number;
 }
@@ -72,23 +71,13 @@ export interface FormDExtract {
   totalAmountSold: number | null;
   /** Number of investors in this offering. */
   totalNumberAlreadyInvested: number | null;
-  /** Filing date (YYYY-MM-DD). */
-  filingDate: string;
   /** Issuer entity name from the Form D primary document. */
-  issuerName: string;
+  issuerName: string | null;
   /** First sale date if present (YYYY-MM-DD). */
   firstSaleDate: string | null;
 }
 
 const DEFAULT_MAX_FILINGS = 50;
-
-function getFetch(opts: SecEdgarOptions): typeof fetch {
-  return opts.fetchImpl ?? globalThis.fetch;
-}
-
-function getUserAgent(opts: SecEdgarOptions): string {
-  return opts.userAgent ?? USER_AGENT;
-}
 
 /** SEC requires CIK zero-padded to 10 digits in URL paths. */
 export function padCik(cik: string): string {
@@ -102,8 +91,9 @@ export function padCik(cik: string): string {
 /**
  * Fetch all Form D filings for one CIK from the EDGAR submissions index.
  *
- * The submissions endpoint returns parallel arrays under filings.recent —
- * we zip them, filter to Form D, and dedup.
+ * The submissions endpoint returns parallel arrays under filings.recent.
+ * If the arrays disagree on length, take the shortest to avoid undefined
+ * destructuring downstream.
  */
 export async function fetchFormDFilings(
   cik: string,
@@ -124,8 +114,14 @@ export async function fetchFormDFilings(
   }
 
   const max = opts.maxFilingsPerTarget ?? DEFAULT_MAX_FILINGS;
+  // Defensive: take the shortest parallel array to avoid out-of-bounds reads.
+  const len = Math.min(
+    recent.form.length,
+    recent.accessionNumber.length,
+    recent.filingDate.length
+  );
   const out: FormDFiling[] = [];
-  for (let i = 0; i < recent.form.length && out.length < max; i++) {
+  for (let i = 0; i < len && out.length < max; i++) {
     if (recent.form[i] !== "D" && recent.form[i] !== "D/A") continue;
     const accession = recent.accessionNumber[i];
     const filingDate = recent.filingDate[i];
@@ -143,31 +139,58 @@ export async function fetchFormDFilings(
 /**
  * Build the canonical URL for a Form D primary document XML.
  * EDGAR archive URLs use the dashed accession number for the path
- * but the un-dashed form for the directory.
+ * but a leading-zero-stripped CIK for the directory segment.
+ *
+ * If the CIK is all zeros after stripping, EDGAR has no entity at /data/0/
+ * and we throw — better to fail fast than 404 on every filing.
  */
 export function buildFormDUrl(
   cik: string,
   filing: FormDFiling
 ): string {
   const padded = padCik(cik);
-  // EDGAR strips leading zeros for the directory segment
-  const dirCik = String(parseInt(padded, 10));
+  const dirCik = padded.replace(/^0+/, "");
+  if (dirCik.length === 0) {
+    throw new Error(`CIK is all zeros after stripping: "${cik}"`);
+  }
   return `https://www.sec.gov/Archives/edgar/data/${dirCik}/${filing.accessionNoDashes}/${filing.primaryDocument}`;
 }
 
 /**
+ * Decode the small set of XML entities Form D filings use in practice.
+ * Form D doesn't carry CDATA blocks of significance in the fields we care
+ * about, so this covers `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`,
+ * `&#NN;` (decimal), and `&#xHH;` (hex).
+ */
+export function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&"); // keep last so &amp;lt; → &lt;, not <
+}
+
+/**
  * Parse a Form D XML payload. Form D has a fixed schema; we extract a small
- * fixed subset. Tag names are case-sensitive in EDGAR XML.
+ * fixed subset.
  *
- * This intentionally uses regex rather than a full XML parser — Form D
- * payloads are small and the fields we want are leaf elements with no
- * attribute interactions or nested duplicates.
+ * Tolerates: optional namespace prefix (`ns1:`), optional attributes,
+ * `&amp;` `&lt;` `&gt;` `&quot;` `&apos;` `&#N;` `&#xH;` entities.
+ *
+ * Doesn't handle: CDATA sections, nested elements with the same name,
+ * elements split across the buffer (Form D filings are single-file, small).
  */
 export function parseFormDXml(xml: string): FormDExtract {
   const text = (tag: string): string | null => {
-    const re = new RegExp(`<${tag}>([^<]*)</${tag}>`);
+    // Optional namespace prefix, optional attributes, leaf element only.
+    const re = new RegExp(
+      `<(?:[\\w-]+:)?${tag}(?:\\s[^>]*)?>([^<]*)</(?:[\\w-]+:)?${tag}>`
+    );
     const m = re.exec(xml);
-    return m ? m[1].trim() : null;
+    return m ? decodeXmlEntities(m[1].trim()) : null;
   };
   const num = (tag: string): number | null => {
     const v = text(tag);
@@ -176,12 +199,10 @@ export function parseFormDXml(xml: string): FormDExtract {
     return Number.isFinite(n) ? n : null;
   };
 
-  const filingDate = text("dateOfFirstSale") ?? text("filingDate") ?? "";
   return {
     totalAmountSold: num("totalAmountSold"),
     totalNumberAlreadyInvested: num("totalNumberAlreadyInvested"),
-    filingDate: filingDate || "",
-    issuerName: text("entityName") ?? "",
+    issuerName: text("entityName"),
     firstSaleDate: text("dateOfFirstSale"),
   };
 }
@@ -203,7 +224,15 @@ export async function fetchAndParseFormD(
   return { extract: parseFormDXml(rawXml), rawXml, sourceUrl };
 }
 
-/** Build the proposal payload from one Form D extract. */
+/**
+ * Build the proposal payload from one Form D extract.
+ *
+ * We prefer `extract.firstSaleDate` for the funding-round date when present
+ * (more precise than the filing date, which can lag the actual sale by
+ * weeks), and fall back to the filing date from the index. The issuer name
+ * from the XML is stored in `notes` for evidence — the propose endpoint can
+ * verify it matches the requested target before accepting the row.
+ */
 export function buildProposal(
   target: SecEdgarTarget,
   filing: FormDFiling,
@@ -212,6 +241,15 @@ export function buildProposal(
   sourceUrl: string
 ): EnrichmentProposal {
   const responseHash = createHash("sha256").update(rawXml).digest("hex");
+  const date = extract.firstSaleDate || filing.filingDate;
+  const investorNote = extract.totalNumberAlreadyInvested != null
+    ? `${extract.totalNumberAlreadyInvested} investors per Form D`
+    : null;
+  const issuerNote = extract.issuerName
+    ? `Issuer per Form D: ${extract.issuerName}`
+    : null;
+  const notes = [investorNote, issuerNote].filter(Boolean).join(" — ") || null;
+
   return {
     tier: "T1",
     source: `sec-edgar:${filing.accessionNumber}`,
@@ -221,15 +259,13 @@ export function buildProposal(
     record: {
       // Form D doesn't tell us the round name directly — use filing date as fallback.
       name: `Form D filing ${filing.filingDate}`,
-      date: filing.filingDate,
+      date,
       raised: extract.totalAmountSold,
       // Form D explicitly labels these as "exempt offering" — instrument unknown
       // without external context. Leave null rather than guessing.
       instrument: null,
       source: sourceUrl,
-      notes: extract.totalNumberAlreadyInvested != null
-        ? `${extract.totalNumberAlreadyInvested} investors per Form D`
-        : null,
+      notes,
       companyDisplayName: target.orgName,
     },
     entityRefs: { organization: target.orgSlug },
@@ -238,14 +274,19 @@ export function buildProposal(
 
 /**
  * End-to-end import for a single target — fetch index, fetch each Form D,
- * build proposals. Errors on individual filings are logged + skipped.
+ * build proposals.
+ *
+ * Returns both the proposals AND a `failures` count for the caller —
+ * silent partial success is dangerous for T1 importers (one target with
+ * 49/50 broken filings shouldn't look like a successful import).
  */
 export async function importTarget(
   target: SecEdgarTarget,
   opts: SecEdgarOptions = {}
-): Promise<EnrichmentProposal[]> {
+): Promise<{ proposals: EnrichmentProposal[]; failures: number }> {
   const filings = await fetchFormDFilings(target.cik, opts);
   const proposals: EnrichmentProposal[] = [];
+  let failures = 0;
   for (const filing of filings) {
     try {
       const { extract, rawXml, sourceUrl } = await fetchAndParseFormD(
@@ -257,13 +298,14 @@ export async function importTarget(
         buildProposal(target, filing, extract, rawXml, sourceUrl)
       );
     } catch (e) {
+      failures++;
       const msg = e instanceof Error ? e.message : String(e);
       console.warn(
         `[sec-edgar] skipping ${target.orgSlug} filing ${filing.accessionNumber}: ${msg}`
       );
     }
   }
-  return proposals;
+  return { proposals, failures };
 }
 
 /** CLI entry point — `crux tb sec-edgar [--submit]`. */
@@ -282,28 +324,53 @@ export async function cliMain(
   }
 
   const allProposals: EnrichmentProposal[] = [];
+  let totalFailures = 0;
   for (const t of targets) {
     console.log(`[sec-edgar] fetching ${t.orgSlug} (CIK ${t.cik})...`);
-    const proposals = await importTarget(t);
-    console.log(`[sec-edgar]   → ${proposals.length} Form D proposals`);
-    allProposals.push(...proposals);
+    try {
+      const { proposals, failures } = await importTarget(t);
+      console.log(
+        `[sec-edgar]   → ${proposals.length} proposals, ${failures} per-filing failures`
+      );
+      allProposals.push(...proposals);
+      totalFailures += failures;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[sec-edgar] target ${t.orgSlug} failed entirely: ${msg}`);
+      totalFailures++;
+    }
   }
 
   const clientOpts: ProposeClientOptions = { submit };
   const results = await submitBatch(allProposals, clientOpts);
   printBatchSummary(results, "sec-edgar");
+  if (totalFailures > 0) {
+    console.warn(`[sec-edgar] ${totalFailures} per-filing/per-target failures`);
+  }
   return { exitCode: 0, output: "" };
 }
 
-/** Parse `--target=anthropic:0001234567` flags from argv. */
+/**
+ * Parse `--target=anthropic:0001234567` flags from argv.
+ * Strict: rejects extra colons, empty parts, malformed CIK input.
+ */
 export function parseTargetsArg(args: readonly string[]): SecEdgarTarget[] {
   const out: SecEdgarTarget[] = [];
   for (const arg of args) {
     if (!arg.startsWith("--target=")) continue;
     const value = arg.slice("--target=".length);
-    const [orgSlug, cik] = value.split(":");
+    const parts = value.split(":");
+    if (parts.length !== 2) {
+      throw new Error(`--target must be slug:cik (exactly one colon), got "${value}"`);
+    }
+    const [orgSlug, cik] = parts;
     if (!orgSlug || !cik) {
-      throw new Error(`--target must be slug:cik, got "${value}"`);
+      throw new Error(`--target slug and cik must both be non-empty, got "${value}"`);
+    }
+    // Validate CIK is numeric early so that downstream URL building doesn't
+    // produce a malformed request URL.
+    if (!/^\d{1,10}$/.test(cik)) {
+      throw new Error(`--target cik must be 1-10 digits, got "${cik}"`);
     }
     out.push({ orgSlug, orgName: orgSlug, cik });
   }

--- a/crux/commands/tb-importers/sec-edgar.ts
+++ b/crux/commands/tb-importers/sec-edgar.ts
@@ -26,6 +26,8 @@ import {
   type ProposeClientOptions,
 } from "./propose-client.ts";
 import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
 import type { EnrichmentProposal } from "./types.ts";
 
 export interface SecEdgarTarget {
@@ -252,7 +254,7 @@ export function buildProposal(
 
   return {
     tier: "T1",
-    source: `sec-edgar:${filing.accessionNumber}`,
+    source: `${T1_SOURCE_PREFIXES.secEdgar}${filing.accessionNumber}`,
     sourceUrl,
     responseHash,
     recordType: "funding-round",
@@ -312,7 +314,7 @@ export async function importTarget(
 export async function cliMain(
   args: string[],
   options: { dryRun?: boolean } = {}
-): Promise<{ exitCode: number; output: string }> {
+): Promise<CommandResult> {
   const submit = args.includes("--submit") && options.dryRun !== true;
   const targets = parseTargetsArg(args);
   if (targets.length === 0) {

--- a/crux/commands/tb-importers/sec-edgar.ts
+++ b/crux/commands/tb-importers/sec-edgar.ts
@@ -1,0 +1,311 @@
+/**
+ * SEC EDGAR Form D importer (T1, QUA-640).
+ *
+ * Form D = notice of exempt offering of securities. US private offerings
+ * (Anthropic, OpenAI, Runway, Character.AI, Inflection, xAI, Cohere, etc.)
+ * file these. The data is structured XML with deterministic fields:
+ * IssuerName, FilingDate, TotalAmountSold, MinimumInvestmentAccepted, etc.
+ *
+ * Source documentation: https://www.sec.gov/forms (Form D)
+ * EDGAR submissions API: https://data.sec.gov/submissions/CIK<10-digit>.json
+ *   (returns recent.form[] / recent.accessionNumber[] / recent.filingDate[])
+ * Form D XML index: https://www.sec.gov/Archives/edgar/data/<cik>/<accession-no-dashes>/<accession-with-dashes>-index.json
+ *
+ * SEC requires a User-Agent identifying the requester. We send
+ * "longterm-wiki <ozzie@quantifieduncertainty.org>".
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+const USER_AGENT = "longterm-wiki <ozzie@quantifieduncertainty.org>";
+
+export interface SecEdgarTarget {
+  /** Org slug from data/entities/organizations.yaml */
+  orgSlug: string;
+  /** Display name for the org (used in funding_round.companyDisplayName) */
+  orgName: string;
+  /** SEC Central Index Key (CIK), zero-padded to 10 digits */
+  cik: string;
+}
+
+export interface SecEdgarOptions {
+  /** Override the global fetch — used by tests to inject responses. */
+  fetchImpl?: typeof fetch;
+  /** Override the User-Agent — keep default in production. */
+  userAgent?: string;
+  /** Limit on filings fetched per target (paginated APIs return many). */
+  maxFilingsPerTarget?: number;
+}
+
+/** Shape of `https://data.sec.gov/submissions/CIK<n>.json`. Partial — only fields we use. */
+interface SubmissionsResponse {
+  cik: string;
+  name: string;
+  filings?: {
+    recent?: {
+      accessionNumber?: string[];
+      form?: string[];
+      filingDate?: string[];
+      primaryDocument?: string[];
+    };
+  };
+}
+
+/** One Form D filing summary, after filtering & dedup of submissions response. */
+export interface FormDFiling {
+  accessionNumber: string;
+  filingDate: string;
+  primaryDocument: string;
+  /** Convenience: accession number with dashes stripped (used in URL paths). */
+  accessionNoDashes: string;
+}
+
+/** Selected fields extracted from a Form D XML payload. */
+export interface FormDExtract {
+  /** Total amount raised in this offering, in USD. */
+  totalAmountSold: number | null;
+  /** Number of investors in this offering. */
+  totalNumberAlreadyInvested: number | null;
+  /** Filing date (YYYY-MM-DD). */
+  filingDate: string;
+  /** Issuer entity name from the Form D primary document. */
+  issuerName: string;
+  /** First sale date if present (YYYY-MM-DD). */
+  firstSaleDate: string | null;
+}
+
+const DEFAULT_MAX_FILINGS = 50;
+
+function getFetch(opts: SecEdgarOptions): typeof fetch {
+  return opts.fetchImpl ?? globalThis.fetch;
+}
+
+function getUserAgent(opts: SecEdgarOptions): string {
+  return opts.userAgent ?? USER_AGENT;
+}
+
+/** SEC requires CIK zero-padded to 10 digits in URL paths. */
+export function padCik(cik: string): string {
+  const digits = cik.replace(/\D/g, "");
+  if (digits.length === 0) {
+    throw new Error(`invalid CIK: "${cik}"`);
+  }
+  return digits.padStart(10, "0");
+}
+
+/**
+ * Fetch all Form D filings for one CIK from the EDGAR submissions index.
+ *
+ * The submissions endpoint returns parallel arrays under filings.recent —
+ * we zip them, filter to Form D, and dedup.
+ */
+export async function fetchFormDFilings(
+  cik: string,
+  opts: SecEdgarOptions = {}
+): Promise<FormDFiling[]> {
+  const padded = padCik(cik);
+  const url = `https://data.sec.gov/submissions/CIK${padded}.json`;
+  const resp = await getFetch(opts)(url, {
+    headers: { "User-Agent": getUserAgent(opts), Accept: "application/json" },
+  });
+  if (!resp.ok) {
+    throw new Error(`SEC EDGAR submissions HTTP ${resp.status} for CIK ${padded}`);
+  }
+  const data = (await resp.json()) as SubmissionsResponse;
+  const recent = data.filings?.recent;
+  if (!recent?.form || !recent.accessionNumber || !recent.filingDate) {
+    return [];
+  }
+
+  const max = opts.maxFilingsPerTarget ?? DEFAULT_MAX_FILINGS;
+  const out: FormDFiling[] = [];
+  for (let i = 0; i < recent.form.length && out.length < max; i++) {
+    if (recent.form[i] !== "D" && recent.form[i] !== "D/A") continue;
+    const accession = recent.accessionNumber[i];
+    const filingDate = recent.filingDate[i];
+    const primaryDoc = recent.primaryDocument?.[i] ?? "primary_doc.xml";
+    out.push({
+      accessionNumber: accession,
+      filingDate,
+      primaryDocument: primaryDoc,
+      accessionNoDashes: accession.replace(/-/g, ""),
+    });
+  }
+  return out;
+}
+
+/**
+ * Build the canonical URL for a Form D primary document XML.
+ * EDGAR archive URLs use the dashed accession number for the path
+ * but the un-dashed form for the directory.
+ */
+export function buildFormDUrl(
+  cik: string,
+  filing: FormDFiling
+): string {
+  const padded = padCik(cik);
+  // EDGAR strips leading zeros for the directory segment
+  const dirCik = String(parseInt(padded, 10));
+  return `https://www.sec.gov/Archives/edgar/data/${dirCik}/${filing.accessionNoDashes}/${filing.primaryDocument}`;
+}
+
+/**
+ * Parse a Form D XML payload. Form D has a fixed schema; we extract a small
+ * fixed subset. Tag names are case-sensitive in EDGAR XML.
+ *
+ * This intentionally uses regex rather than a full XML parser — Form D
+ * payloads are small and the fields we want are leaf elements with no
+ * attribute interactions or nested duplicates.
+ */
+export function parseFormDXml(xml: string): FormDExtract {
+  const text = (tag: string): string | null => {
+    const re = new RegExp(`<${tag}>([^<]*)</${tag}>`);
+    const m = re.exec(xml);
+    return m ? m[1].trim() : null;
+  };
+  const num = (tag: string): number | null => {
+    const v = text(tag);
+    if (v === null || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  const filingDate = text("dateOfFirstSale") ?? text("filingDate") ?? "";
+  return {
+    totalAmountSold: num("totalAmountSold"),
+    totalNumberAlreadyInvested: num("totalNumberAlreadyInvested"),
+    filingDate: filingDate || "",
+    issuerName: text("entityName") ?? "",
+    firstSaleDate: text("dateOfFirstSale"),
+  };
+}
+
+/** Fetch + parse the Form D XML for one filing. */
+export async function fetchAndParseFormD(
+  cik: string,
+  filing: FormDFiling,
+  opts: SecEdgarOptions = {}
+): Promise<{ extract: FormDExtract; rawXml: string; sourceUrl: string }> {
+  const sourceUrl = buildFormDUrl(cik, filing);
+  const resp = await getFetch(opts)(sourceUrl, {
+    headers: { "User-Agent": getUserAgent(opts) },
+  });
+  if (!resp.ok) {
+    throw new Error(`SEC EDGAR Form D XML HTTP ${resp.status} for ${sourceUrl}`);
+  }
+  const rawXml = await resp.text();
+  return { extract: parseFormDXml(rawXml), rawXml, sourceUrl };
+}
+
+/** Build the proposal payload from one Form D extract. */
+export function buildProposal(
+  target: SecEdgarTarget,
+  filing: FormDFiling,
+  extract: FormDExtract,
+  rawXml: string,
+  sourceUrl: string
+): EnrichmentProposal {
+  const responseHash = createHash("sha256").update(rawXml).digest("hex");
+  return {
+    tier: "T1",
+    source: `sec-edgar:${filing.accessionNumber}`,
+    sourceUrl,
+    responseHash,
+    recordType: "funding-round",
+    record: {
+      // Form D doesn't tell us the round name directly — use filing date as fallback.
+      name: `Form D filing ${filing.filingDate}`,
+      date: filing.filingDate,
+      raised: extract.totalAmountSold,
+      // Form D explicitly labels these as "exempt offering" — instrument unknown
+      // without external context. Leave null rather than guessing.
+      instrument: null,
+      source: sourceUrl,
+      notes: extract.totalNumberAlreadyInvested != null
+        ? `${extract.totalNumberAlreadyInvested} investors per Form D`
+        : null,
+      companyDisplayName: target.orgName,
+    },
+    entityRefs: { organization: target.orgSlug },
+  };
+}
+
+/**
+ * End-to-end import for a single target — fetch index, fetch each Form D,
+ * build proposals. Errors on individual filings are logged + skipped.
+ */
+export async function importTarget(
+  target: SecEdgarTarget,
+  opts: SecEdgarOptions = {}
+): Promise<EnrichmentProposal[]> {
+  const filings = await fetchFormDFilings(target.cik, opts);
+  const proposals: EnrichmentProposal[] = [];
+  for (const filing of filings) {
+    try {
+      const { extract, rawXml, sourceUrl } = await fetchAndParseFormD(
+        target.cik,
+        filing,
+        opts
+      );
+      proposals.push(
+        buildProposal(target, filing, extract, rawXml, sourceUrl)
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `[sec-edgar] skipping ${target.orgSlug} filing ${filing.accessionNumber}: ${msg}`
+      );
+    }
+  }
+  return proposals;
+}
+
+/** CLI entry point — `crux tb sec-edgar [--submit]`. */
+export async function cliMain(
+  args: string[],
+  options: { dryRun?: boolean } = {}
+): Promise<{ exitCode: number; output: string }> {
+  const submit = args.includes("--submit") && options.dryRun !== true;
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=slug:cik (repeatable) or --targets-file=path.json",
+    };
+  }
+
+  const allProposals: EnrichmentProposal[] = [];
+  for (const t of targets) {
+    console.log(`[sec-edgar] fetching ${t.orgSlug} (CIK ${t.cik})...`);
+    const proposals = await importTarget(t);
+    console.log(`[sec-edgar]   → ${proposals.length} Form D proposals`);
+    allProposals.push(...proposals);
+  }
+
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(allProposals, clientOpts);
+  printBatchSummary(results, "sec-edgar");
+  return { exitCode: 0, output: "" };
+}
+
+/** Parse `--target=anthropic:0001234567` flags from argv. */
+export function parseTargetsArg(args: readonly string[]): SecEdgarTarget[] {
+  const out: SecEdgarTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    const [orgSlug, cik] = value.split(":");
+    if (!orgSlug || !cik) {
+      throw new Error(`--target must be slug:cik, got "${value}"`);
+    }
+    out.push({ orgSlug, orgName: orgSlug, cik });
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -36,7 +36,22 @@ export interface EnrichmentProposal {
   responseHash: string;
   /** Target tablebase record type. */
   recordType: EnrichmentRecordType;
-  /** The record fields. Shape depends on `recordType`. */
+  /**
+   * The record fields. Shape depends on `recordType`.
+   *
+   * NOTE: this is the *enrichment proposal*, not a fully-formed PG row.
+   * The propose endpoint (QUA-632) is responsible for:
+   *   - Minting the record `id` (10-char primary key)
+   *   - Resolving `entityRefs` into entity stableIds (FK columns)
+   *   - Populating any required fields the importer doesn't know
+   *
+   * The importer's job is to emit deterministic, source-derived fields:
+   *   - funding-round: name, date, raised, instrument, source, notes,
+   *     companyDisplayName
+   *   - personnel:     role, roleType, personDisplayName, orgDisplayName,
+   *     source, notes, isFounder
+   *   - benchmark-result: score, unit, date, sourceUrl, notes
+   */
   record: Record<string, unknown>;
   /**
    * Optional foreign-key resolution hints. When present, the propose endpoint

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared types for T1 importers (QUA-640).
+ *
+ * Each importer fetches from an authoritative source, extracts deterministic
+ * records, and emits `EnrichmentProposal` payloads that will be POSTed to
+ * `POST /api/enrichment/propose` (QUA-632) with `tier=T1`.
+ *
+ * Until QUA-632 lands, the propose-client is a stub that writes JSON to disk
+ * for inspection — the contract here is the wire format.
+ */
+
+/** Tier model from QUA-637 umbrella. */
+export type EnrichmentTier = "T1" | "T2" | "T3";
+
+/** Record types this PR's importers produce. The full set lives in QUA-632. */
+export type EnrichmentRecordType =
+  | "funding-round"
+  | "personnel"
+  | "benchmark-result";
+
+/**
+ * One record proposal. The propose endpoint validates `(source, recordType)`
+ * against the T1 authority allowlist and, if accepted, atomically writes:
+ *   - the row into the target table
+ *   - an evidence row (source URL + response hash)
+ *   - a `confirmed` verdict
+ */
+export interface EnrichmentProposal {
+  /** Tier for this proposal. T1 importers always emit "T1". */
+  tier: EnrichmentTier;
+  /** Authoritative source identifier, e.g. "sec-edgar:0001577552-25-000123". */
+  source: string;
+  /** URL the data was fetched from — written to the evidence row. */
+  sourceUrl: string;
+  /** SHA-256 hex of the canonical fetched payload — written to evidence. */
+  responseHash: string;
+  /** Target tablebase record type. */
+  recordType: EnrichmentRecordType;
+  /** The record fields. Shape depends on `recordType`. */
+  record: Record<string, unknown>;
+  /**
+   * Optional foreign-key resolution hints. When present, the propose endpoint
+   * will resolve display names to entity stableIds before writing the row.
+   */
+  entityRefs?: {
+    /** Slug or display name of the org the record belongs to. */
+    organization?: string;
+    /** Slug or display name of the person (personnel only). */
+    person?: string;
+    /** Slug or display name of the AI model (benchmark-result only). */
+    model?: string;
+    /** Benchmark id (benchmark-result only). */
+    benchmark?: string;
+  };
+}
+
+/** Result of submitting one proposal — populated by the propose endpoint. */
+export interface ProposeResult {
+  proposal: EnrichmentProposal;
+  status: "accepted" | "rejected" | "pending";
+  /** Server-side row id when accepted. */
+  recordId?: string;
+  /** Human-readable rejection reason when rejected. */
+  reason?: string;
+}


### PR DESCRIPTION
## Summary

Phase 2 of [QUA-637](https://linear.app/quantifieduncertainty/issue/QUA-637) — three new T1 (authoritative-source) importers under `crux/commands/tb-importers/`. Each fetches deterministic records from a primary source and emits `EnrichmentProposal` payloads ready for `POST /api/enrichment/propose` (the QUA-632 endpoint, in-flight).

## What's added

| Importer | Source | Record type | CLI |
|---|---|---|---|
| `sec-edgar` | SEC EDGAR Form D filings (XML) | `funding-round` | `crux tb sec-edgar --target=anthropic:1828101` |
| `github-contributors` | GitHub contributors API (JSON) | `personnel` (T1 seeding only — see below) | `crux tb github-contributors --target=anthropic:anthropics/anthropic-sdk-python` |
| `hf-leaderboard` | HuggingFace Open LLM Leaderboard datasets-server (JSON) | `benchmark-result` | `crux tb hf-leaderboard --target=llama-3-70b:Llama-3-70B:meta-llama/Llama-3-70B` |

Shared infrastructure:

- `types.ts` — `EnrichmentProposal` wire format with documented `record` field expectations per `recordType`.
- `allowlist.ts` — `T1_AUTHORITY_ALLOWLIST` + canonical `T1_SOURCE_PREFIXES` constants. The propose endpoint is the enforcement point; importers and allowlist read from the same prefix constants so renames can't drift out of sync.
- `propose-client.ts` — local validation against the allowlist + stub `submitToServer()`. Today returns `pending` because QUA-632's endpoint isn't built yet; one function-body swap when it lands.
- `http-utils.ts` — shared `USER_AGENT` (org bot email, not personal), `getFetch`, `sanitizeHeaderValue` (CR/LF strip).

## Design notes

- **GitHub contributors → personnel is a SEEDING step.** Per QUA-640: role/title still needs T2 verification against team pages. Records are written with `role="contributor"` / `roleType="career"` / `personDisplayName=null` (raw GitHub login is in `notes` for downstream Wikidata/OpenAlex resolution, not displayed).
- **HF Leaderboard score policy**: `0` is accepted (some hard benchmarks have models scoring 0 legitimately); negative or `>100` (with `unit="%"`) is rejected as sentinel/error.
- **Deterministic idempotency**: every proposal carries a SHA-256 `responseHash` over the canonical fetched payload; same input → same proposal. The propose endpoint can dedup on `(source, responseHash)`.
- **Dependency injection for testability**: each importer takes `fetchImpl?: typeof fetch` so tests inject mock responses without network calls (no `vi.mock` of `node:fetch` needed).
- **Per-target failures surfaced**: `importTarget` returns `{ proposals, failures }` so callers can detect partial success — silent partial success is dangerous for T1 importers.

## Upstream blocker (acknowledged, not blocking ship)

`/api/enrichment/propose` (QUA-632) does not yet exist; slot a10 has a ghost process working it but no PR. Rather than halt this session, the importers ship the deterministic extraction + proposal-build (the high-value work) with a stub propose-client. The `EnrichmentProposal` wire format is the contract; only `submitToServer()`'s body needs to change when QUA-632 lands.

## Test plan

- [x] 132 unit tests across 6 files (allowlist, http-utils, propose-client, sec-edgar, github-contributors, hf-leaderboard); all green.
- [x] Adversarial inputs covered:
  - SEC: malformed CIK (non-digit, all zeros, too long); namespace-prefixed XML (`ns1:`); attributed elements; XML entities (`&amp;`, `&#39;`, `&#xE9;`); mismatched parallel-array lengths; HTTP 404/500/503; CR/LF in User-Agent.
  - GitHub: path traversal (`..`, `%2e%2e`); empty repos in csv (`a/b,,a/c`); non-array response; missing/present token; logins appearing twice in same repo.
  - HF: score 0 (accepted), negative (rejected), >100% (rejected), NaN (rejected), undefined (skipped silently); empty pages; `pageSize > 100` clamping; missing `eval_name` rows; malformed `rows` wrapper.
- [x] CLI dry-run smoke test: `pnpm crux tb sec-edgar | github-contributors | hf-leaderboard` (each surfaces a clean error on missing/malformed `--target`).
- [x] Type check clean (apps/web, apps/wiki-server, crux).
- [x] `pnpm crux w validate gate --scope=content --fix` passed (5/5 checks, 153s).
- [x] `/agent-review-pr` ran (34 findings — 16 fixed, 7 documented, 11 LOW dismissed).
- [x] `/simplify` ran (5 mechanical refactors: source-prefix constants, canonical `CommandResult`, parallel per-repo fetches, dropped Map fallback, collapsed thin wrappers).

## Observed this session

- QUA-632 is in-flight in slot a10 (ghost process, no PR yet). Importers built against a stub propose-client; integration is one function-body change once QUA-632 ships → **deferred:** depends on QUA-632.
- Reviewer noted that the `EnrichmentProposal.record` field doesn't match what existing PG sync handlers require (missing `id`, `personId`, `companyId`). Documented in `types.ts` JSDoc as the propose endpoint's responsibility (mint id, resolve `entityRefs` → stableId) → **filed-into:** QUA-632 will need to implement that resolver layer; the contract here is now explicit.
- `submitBatch` does sequential POSTs per proposal — once QUA-632 ships, the endpoint should accept arrays for batch submit (one round-trip vs N) → **deferred:** flag for QUA-632 design.

Fixes QUA-640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new CLI importers for creating T1 enrichment proposals: `sec-edgar` (SEC Form D funding-round data), `github-contributors` (personnel data from GitHub repos), and `hf-leaderboard` (benchmark-result data from HuggingFace leaderboard). Each includes validation, proposal generation, and batch submission.

* **Tests**
  * Comprehensive test coverage added for all importer implementations and shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->