### PR TITLE
fix(ratchet): unstick main — rename source-check→sourcing in build-corpus comment

### DIFF
--- a/crux/calibration/build-corpus.ts
+++ b/crux/calibration/build-corpus.ts
@@ -1,7 +1,7 @@
 /**
  * Calibration Corpus Builder (QUA-635)
  *
- * Samples confirmed source-check verdicts from prod, pulls the matching
+ * Samples confirmed sourcing verdicts from prod, pulls the matching
  * records + evidence + cached source content, and emits a calibration
  * corpus JSON file that the calibration runner can replay against
  * different LLM models.


### PR DESCRIPTION
## Summary

Unstick main CI — the `validate-sourcing-lint-guard` ratchet is tripping because PR #4518 (QUA-635 calibration) introduced a new `source-check verdicts` comment in `crux/calibration/build-corpus.ts`, pushing the hyphenated count 0 → 1 (baseline is frozen at 1 total, pinned to the lone `sourceCheckedAt` column binding — see `.sourcing-baseline.json`).

Single-word fix: `source-check verdicts` → `sourcing verdicts`. Ratchet passes locally.

## Test plan

- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` — passes ("At baseline (1 references across 1506 files)")

Fixes the main CI red streak that started 2026-04-20T16:36 (3 consecutive failing commits). Health gate on patrol will lift once this merges.
