### PR TITLE
content(samotsvety): remove unsupported claim details — QUA-307 Phase 2 first batch

### DIFF
--- a/content/docs/knowledge-base/organizations/samotsvety.mdx
+++ b/content/docs/knowledge-base/organizations/samotsvety.mdx
@@ -73,7 +73,7 @@ The group maintains approximately 15 active members selected based on demonstrat
 
 ### AI Timelines and Risk Assessments
 
-Samotsvety's AI forecasts represent some of their most cited work, providing probabilistic timelines for transformative AI (TAI) and artificial general intelligence (AGI). Their aggregated forecasts from eight members include:[^rc-ef80]
+Samotsvety's AI forecasts represent some of their most cited work, providing probabilistic timelines for transformative AI (TAI) and artificial general intelligence (AGI). Their aggregated forecasts include:[^rc-ef80]
 
 - **28% probability of TAI by 2030**
 - **60% probability by 2050**
@@ -170,7 +170,7 @@ Forecasting AI progress encounters fundamental limits of Bayesian reasoning itse
 
 ### Prediction Market Implementation
 
-Beyond individual forecasting, Samotsvety's analysis of prediction markets identified multiple barriers to practical adoption:[^rc-8bae]
+Samotsvety's analysis suggests multiple reasons why prediction markets fail to gain adoption:[^rc-8bae]
 
 - **Underdeveloped technology** limiting market functionality
 - **Difficulty writing good and informative questions** that resolve cleanly


### PR DESCRIPTION
## Summary

QUA-307 Phase 2 — first batch of citation cleanup using the QUA-588 hardened `fix-inaccuracies` filters (merged earlier today as PR #4523).

Two contradicted-citation fixes on `samotsvety.mdx` — both unsupported detail removals verified by hand before commit.

## Context

QUA-307 Phase 2 batched apply was reverted 2026-04-18 with 75% bad-edit rate. QUA-588 added four structural filters (`remove-ref-scope`, `mdx-structure`, `context-bleed`, `span-overlap`) to catch the specific failure modes. This PR is the first end-to-end apply run with those filters in place — a conservative single-page batch to validate the filters work at apply-time, not just dry-run.

## Pages touched / run results

| Page | Flagged | Filters rejected | Applied | Kept / notes |
|---|---|---|---|---|
| samotsvety | 13 | 6 (2 `mdx-structure`, 3 `component-drop`, 1 `shrink`) | 2 | **2 applied, both clean** |
| kalshi | 15 | 6 (3 `remove-ref-scope`, 3 `shrink`) | 0 | All applies skipped (no matching originals); `[^1]` 2026-04-18 bug correctly caught by `remove-ref-scope` |
| chan-zuckerberg-initiative | 14 | 7 (1 `context-bleed`, 6 `shrink`) | 0 | `[^4]` 2026-04-18 bug caught by `context-bleed` |
| good-judgment | (proposed 10) | 2 `shrink` | 0 | No matching originals |
| hewlett-foundation | — | 5 `component-drop` | 1 | **Reverted** — semantic misplacement (see QUA-659 follow-up) |
| elicit | — | 4 (1 `component-drop`, 3 `shrink`) | 0 | No matching originals |

Net: **2 clean applied edits** across 6 pages examined. All three QUA-588-specific 2026-04-18 regressions validated as now-caught at apply-time.

## Follow-up filed

[QUA-659](https://linear.app/quantifieduncertainty/issue/QUA-659) — `fix-inaccuracies` can semantically misplace replacement content (topic-shift within a paragraph). Hit once on `hewlett-foundation` this run; 1 of 3 applied edits. Not blocking — QUA-307 proceeds with conservative per-page review until semantic filter is in place.

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` — passes (5/5 blocking checks)
- [x] Manual inspection of each applied edit in context (see samotsvety.mdx lines 76, 173)
- [x] No MDX structure breakage (no dangling bullets, no dropped EntityLinks)
- [x] `pnpm build` — passes
- [x] Follow-up ticket filed for the one semantic-misplacement case encountered

## Notes on approach

This is intentionally a **small batch** (2 edits, 1 page). The QUA-307 body references "101 patchable pages" and prior plans targeted 15+ pages in one PR. I chose conservatism because:

1. This is the first end-to-end validation that QUA-588 filters work at apply-time.
2. The samotsvety re-verification pipeline reported 13→20 flagged (local artifact — doesn't change prod counts).
3. The hewlett semantic-misplacement case confirmed filters don't catch every class of bad edit.

Suggested follow-up: once this merges and prod source-check reruns, expand the batch to 5-10 pages per PR with the same manual-inspection discipline. After QUA-659 ships, the batch size can grow further.

Refs QUA-307

Fixes QUA-307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated phrasing in knowledge base content to improve clarity and consistency in sections covering AI timelines and prediction markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->