### PR TITLE
QUA-638: swap Anthropic T&S division source URL to /transparency

### DIFF
--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -441,9 +441,9 @@ const DIVISIONS: DivisionDef[] = [
     name: "Trust and Safety",
     divisionType: "team",
     status: "active",
-    source: "https://www.anthropic.com/legal/aup",
+    source: "https://www.anthropic.com/transparency",
     notes:
-      "Non-research operational team responsible for usage-policy enforcement and user safety; reachable at usersafety@anthropic.com per Anthropic's Acceptable Use Policy.",
+      "Non-research operational team (publicly referred to as the \"Safeguards team\" in Anthropic's transparency reporting and Usage Policy) responsible for usage-policy enforcement, detection/monitoring, and user safety; reachable at usersafety@anthropic.com per Anthropic's Acceptable Use Policy.",
   },
   {
     idSeed: "div|anthropic|ai-welfare",


### PR DESCRIPTION
## Summary

- Swap `Trust and Safety` division source URL from `https://www.anthropic.com/legal/aup` (JS-rendered, `resource-ingest` stalls at `not_cached`) to `https://www.anthropic.com/transparency` (statically-rendered, same kind of anthropic.com page that the other 6 confirmed research-team divisions already use).
- Update notes to link the record name `Trust and Safety` with Anthropic's current public terminology `Safeguards team` (the transparency page explicitly mentions "Our Safeguards team") so the LLM source-checker can match the record to the page content.

**Option 2** from the ticket. Option 1 (fixing JS-rendered ingest at the infra layer) stays scoped to QUA-95. Option 3 (renaming to `Safeguards`) is blocked by the existing `Policy and Safeguards` division, which would collide.

## Why this unblocks the verdict

- Before: 7 of 8 Anthropic divisions confirmed; T&S stuck at `unchecked`/`unverifiable` because the AUP page never ingests.
- After: `/transparency` is a 66 KB statically-renderable page that loads cleanly from the same ingest pipeline already proven to work for `/research`. The phrase "Our Safeguards team created test questions" appears in the extracted HTML text, so the source-checker should verify against the updated notes.

## Follow-up (manual, post-merge)

1. `pnpm crux tb import-divisions sync` — push the new source URL to prod.
2. `pnpm crux tb flagship-curate --entity=anthropic --table=division --skip-research` — re-verify the Trust and Safety record.

If the verdict still doesn't become `confirmed` (e.g. the LLM considers the transparency page off-topic), we iterate on URL choice; but the ingest stall itself should be gone.

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` (all blocking checks passed)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in `import-divisions.ts`
- [x] `grep -r "legal/aup" .` — no other references
- [ ] Post-merge: run the 2 follow-up commands above and confirm T&S moves from `unchecked`/`unverifiable` to `confirmed` (or at least `partial`, i.e. ingest no longer stalls)

## Acceptance criteria (from QUA-638)

- [x] Trust and Safety division no longer has a stuck ingest source URL
- [x] Choice is documented (Option 2 chosen over 1/3/4 with reasons)
- [x] Division ID is unchanged (deterministic `idSeed` preserved → stableId stable → no data migration)

Fixes QUA-638


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal division reference information and documentation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->