### PR TITLE
fix(wiki-server): replace z.coerce.boolean() with strict qBool parser (QUA-651)

### DIFF
--- a/apps/wiki-server/src/__tests__/publications-filters.test.ts
+++ b/apps/wiki-server/src/__tests__/publications-filters.test.ts
@@ -272,6 +272,72 @@ describe("publications GET /all — filters are applied in SQL (QUA-622)", () =>
     expect(body.total).toBe(1);
   });
 
+  it("flagshipOnly=false returns all publications (QUA-651 regression)", async () => {
+    // Before QUA-651: the schema used `z.coerce.boolean()`, which coerces the
+    // literal string "false" to true. So ?flagshipOnly=false silently
+    // filtered to flagship-only — the opposite of what the caller typed.
+    // With qBool this is now a hard false and all rows should come through.
+    for (let i = 0; i < 3; i++) {
+      publicationsStore.push(
+        makePub({ id: `nonflagsh${i}`, is_flagship: false }),
+      );
+    }
+    for (let i = 0; i < 2; i++) {
+      publicationsStore.push(
+        makePub({ id: `flagship-${i}`, is_flagship: true }),
+      );
+    }
+
+    const { publicationsRoute } = await import(
+      "../routes/tablebase/publications.js"
+    );
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request(
+      "/api/publications/all?flagshipOnly=false&limit=100",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      publications: DrizzlePubRow[];
+      total: number;
+    };
+    expect(body.publications).toHaveLength(5);
+    expect(body.total).toBe(5);
+
+    // Double-check: the route skipped the is_flagship WHERE predicate entirely
+    // (flagshipOnly=false means "no filter"), matching the `if (flagshipOnly)`
+    // gate in publications.ts. Pre-fix it would have emitted is_flagship=true.
+    const countQuery = dispatchedQueries.find(
+      (d) => d.query.toLowerCase().includes("count(")
+        && d.query.toLowerCase().includes('"publications"'),
+    );
+    expect(countQuery?.query.toLowerCase()).not.toMatch(/is_flagship/);
+  });
+
+  it("rejects flagshipOnly=FALSE (case-sensitive) with a 400 (QUA-651)", async () => {
+    const { publicationsRoute } = await import(
+      "../routes/tablebase/publications.js"
+    );
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request(
+      "/api/publications/all?flagshipOnly=FALSE",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects flagshipOnly=1 with a 400 (QUA-651)", async () => {
+    const { publicationsRoute } = await import(
+      "../routes/tablebase/publications.js"
+    );
+    const app = new Hono().route("/api/publications", publicationsRoute);
+
+    const res = await app.request(
+      "/api/publications/all?flagshipOnly=1",
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("passes no WHERE (filter columns absent) when no filters are supplied", async () => {
     publicationsStore.push(makePub({ id: "p1" }));
     publicationsStore.push(makePub({ id: "p2", is_flagship: true }));

--- a/apps/wiki-server/src/__tests__/q-bool.test.ts
+++ b/apps/wiki-server/src/__tests__/q-bool.test.ts
@@ -51,4 +51,15 @@ describe("qBool", () => {
     expect(() => Schema.parse({ flag: "FALSE" })).toThrow(z.ZodError);
     expect(() => Schema.parse({ flag: "1" })).toThrow(z.ZodError);
   });
+
+  it("composes with .default('true') and .default('false')", () => {
+    // .default applies the default to the Zod *input* (pre-transform), so
+    // .default("true") → transform sees "true" → returns true. Pin this
+    // subtlety since a caller might plausibly write qBool.default("false").
+    const A = z.object({ flag: qBool.default("true") });
+    const B = z.object({ flag: qBool.default("false") });
+    expect(A.parse({})).toEqual({ flag: true });
+    expect(B.parse({})).toEqual({ flag: false });
+    expect(A.parse({ flag: "false" })).toEqual({ flag: false });
+  });
 });

--- a/apps/wiki-server/src/__tests__/q-bool.test.ts
+++ b/apps/wiki-server/src/__tests__/q-bool.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { qBool } from "../routes/shared/utils.js";
+
+// QUA-651: `z.coerce.boolean()` silently coerces every non-empty string
+// (including `"false"`) to `true`. `qBool` is the safe replacement — these
+// tests lock in the adversarial cases that `z.coerce.boolean()` would get
+// wrong, and confirm the strict rejection behaviour for anything else.
+
+describe("qBool", () => {
+  it('parses "true" → true', () => {
+    expect(qBool.parse("true")).toBe(true);
+  });
+
+  it('parses "false" → false (the z.coerce.boolean() footgun)', () => {
+    // z.coerce.boolean().parse("false") would incorrectly return true here.
+    expect(qBool.parse("false")).toBe(false);
+  });
+
+  it.each([
+    "True",
+    "FALSE",
+    "1",
+    "0",
+    "yes",
+    "no",
+    "",
+    " true",
+    "true ",
+    "TRUE",
+  ])('rejects ambiguous input %j with a validation error', (input) => {
+    expect(() => qBool.parse(input)).toThrow(z.ZodError);
+  });
+
+  it.each([undefined, null, 0, 1, true, false, {}, []])(
+    'rejects non-string input %j',
+    (input) => {
+      expect(() => qBool.parse(input)).toThrow(z.ZodError);
+    },
+  );
+
+  it("is optional-composable — omitted query param yields undefined", () => {
+    const Schema = z.object({ flag: qBool.optional() });
+    expect(Schema.parse({})).toEqual({ flag: undefined });
+    expect(Schema.parse({ flag: "true" })).toEqual({ flag: true });
+    expect(Schema.parse({ flag: "false" })).toEqual({ flag: false });
+  });
+
+  it("rejects invalid values even when wrapped with .optional()", () => {
+    const Schema = z.object({ flag: qBool.optional() });
+    expect(() => Schema.parse({ flag: "FALSE" })).toThrow(z.ZodError);
+    expect(() => Schema.parse({ flag: "1" })).toThrow(z.ZodError);
+  });
+});

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -24,6 +24,27 @@ export function clampedLimit(maxLimit: number, defaultLimit: number) {
 }
 
 /**
+ * Parse a boolean query-string value.
+ *
+ * Use this instead of `z.coerce.boolean()` for query-string params.
+ * `z.coerce.boolean()` runs the value through `Boolean(...)`, so any non-empty
+ * string — including the literal `"false"` — coerces to `true`. That means
+ * `?flag=false` silently reads as `true`, the opposite of what the caller
+ * typed (QUA-651).
+ *
+ * Accepts only the literal strings `"true"` and `"false"`. Any other value
+ * (including `"0"`, `"1"`, `"yes"`, `""`) fails validation with a 400, so
+ * silently-wrong boolean filters become impossible.
+ *
+ * Wrap with `.optional()` when the flag is not required:
+ *
+ *   const Query = z.object({ flagshipOnly: qBool.optional() });
+ */
+export const qBool = z
+  .enum(["true", "false"])
+  .transform((v) => v === "true");
+
+/**
  * Create a PaginationQuery schema with configurable limits.
  * Each route can call this with its own defaults while sharing the base shape.
  * Values above maxLimit are clamped (not rejected) so clients requesting larger

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -40,6 +40,7 @@ import {
   validationError,
   invalidJsonError,
   escapeIlike,
+  qBool,
 } from "../shared/utils.js";
 import {
   SOURCING_EXEMPT_TYPES,
@@ -177,10 +178,7 @@ const VerdictsQuery = z.object({
   record_type: z.string().max(50).optional(),
   verdict: z.string().max(50).optional(),
   entity_id: z.string().max(200).optional(),
-  needs_recheck: z
-    .enum(["true", "false"])
-    .transform((v) => v === "true")
-    .optional(),
+  needs_recheck: qBool.optional(),
   q: z.string().max(500).optional(),
   limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),

--- a/apps/wiki-server/src/routes/tablebase/platform-accounts.ts
+++ b/apps/wiki-server/src/routes/tablebase/platform-accounts.ts
@@ -15,6 +15,7 @@ import { platformAccounts } from "../../schema.js";
 import {
   zv,
   paginationQuery,
+  qBool,
 } from "../shared/utils.js";
 import { logger } from "../../logger.js";
 import { createSyncHandler } from "./sync-factory.js";
@@ -42,10 +43,7 @@ const SyncItemSchema = z.object({
 
 const AllQuery = paginationQuery({ maxLimit: 1000, defaultLimit: 200 }).extend({
   platform: z.string().max(100).optional(),
-  unlinked: z
-    .enum(["true", "false"])
-    .optional()
-    .transform((v) => v === "true"),
+  unlinked: qBool.optional(),
 });
 
 const platformAccountsApp = new Hono()

--- a/apps/wiki-server/src/routes/tablebase/prediction-markets.ts
+++ b/apps/wiki-server/src/routes/tablebase/prediction-markets.ts
@@ -14,6 +14,7 @@ import {
   invalidJsonError,
   zv,
   clampedLimit,
+  qBool,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -48,10 +49,7 @@ const QuestionsQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   category: z.string().optional(),
-  isResolved: z
-    .enum(["true", "false"])
-    .transform((v) => v === "true")
-    .optional(),
+  isResolved: qBool.optional(),
 });
 
 const ByEntityQuery = z.object({
@@ -59,10 +57,7 @@ const ByEntityQuery = z.object({
   offset: z.coerce.number().int().min(0).default(0),
   platform: z.string().optional(),
   category: z.string().optional(),
-  isResolved: z
-    .enum(["true", "false"])
-    .transform((v) => v === "true")
-    .optional(),
+  isResolved: qBool.optional(),
 });
 
 const TimeseriesQuery = z.object({

--- a/apps/wiki-server/src/routes/tablebase/publications.ts
+++ b/apps/wiki-server/src/routes/tablebase/publications.ts
@@ -6,6 +6,7 @@ import { publications } from "../../schema.js";
 import {
   zv,
   clampedLimit,
+  qBool,
 } from "../shared/utils.js";
 import {
   resolveEntityId,
@@ -52,14 +53,14 @@ const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
   publicationType: z.enum(VALID_PUBLICATION_TYPES).optional(),
-  flagshipOnly: z.coerce.boolean().optional(),
+  flagshipOnly: qBool.optional(),
 });
 
 const ByEntityQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   publicationType: z.enum(VALID_PUBLICATION_TYPES).optional(),
-  flagshipOnly: z.coerce.boolean().optional(),
+  flagshipOnly: qBool.optional(),
 });
 
 const SyncItemSchema = z.object({

--- a/apps/wiki-server/src/routes/tablebase/website-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/website-sources.ts
@@ -17,6 +17,7 @@ import {
   paginationQuery,
   zv,
   clampedLimit,
+  qBool,
 } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
@@ -45,10 +46,7 @@ const VALID_PAGE_ROLES = [
 const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 200),
   offset: z.coerce.number().int().min(0).default(0),
-  enabled: z
-    .enum(["true", "false"])
-    .optional()
-    .transform((v) => (v === undefined ? undefined : v === "true")),
+  enabled: qBool.optional(),
 });
 
 const ByEntityQuery = z.object({


### PR DESCRIPTION
## Summary

`z.coerce.boolean()` runs the value through JavaScript's `Boolean(...)`, so any non-empty string — including the literal string `"false"` — coerces to `true`. This means `?flagshipOnly=false` silently filters to flagship-only, the opposite of what the caller typed.

- Add `qBool` helper in `apps/wiki-server/src/routes/shared/utils.ts` that accepts only the literal strings `"true"` / `"false"` (case-sensitive) and rejects every other value with a 400. Silently-wrong boolean filters become impossible.
- Migrate all 7 call sites across 5 route files (`publications`, `prediction-markets`, `platform-accounts`, `website-sources`, `sourcing`) from `z.coerce.boolean()` or the hand-rolled `z.enum(["true","false"]).transform(...)` copy to `qBool`. Per `.claude/rules/implementation-quality.md` §"Pattern fixes must be global", fixing these in a single PR prevents the pattern regressing into new routes.

## RPC type change (intentional)

Under `z.coerce.boolean()`, the Zod input type was effectively `unknown`, so RPC callers could pass `query: { flagshipOnly: true }` (native bool). Under `qBool`, the input type tightens to `"true" | "false"` — RPC callers must pass strings. No existing caller in `apps/web`, `crux`, or `packages/` passes these boolean query params today, so this is not a breaking change in practice.

## Out of scope

- `apps/wiki-server/src/routes/tablebase/entities.ts:153` — `z.enum(["true","false"]).default("false")` keeps string-typed comparison semantics (`includeStubs === "true"`), not a drop-in replacement.
- `hallucination-risk.ts` / `citations.ts` — accept `"1"`/`"0"` variants; need a separate decision on whether to tighten.
- `sourcing-enforcement.ts` / `entity-resources.ts` — hand-rolled `c.req.query(...) === "true"` checks, structural refactor.

## Test plan

- [x] Unit tests (`q-bool.test.ts`, 22 cases) — happy path, the `"false"` footgun, `"FALSE"` / `"1"` / `"yes"` / `""` / `" true"` rejections, non-string rejection, `.optional()` composition, `.default("true"|"false")` composition.
- [x] Endpoint regression tests (`publications-filters.test.ts`) — `?flagshipOnly=false` returns all publications; `?flagshipOnly=FALSE` and `?flagshipOnly=1` return 400.
- [x] Full wiki-server test suite: 1378 tests pass.
- [x] `pnpm crux w validate gate --fix` green (47 checks, 2 pre-existing advisory warnings unrelated).
- [x] TypeScript clean on `apps/web` and `apps/wiki-server`.
- [x] Hostile reviewer sweep (`/agent-review-pr`) found and fixed the 5-file pattern-sweep miss; `.default` test pinned.

Closes QUA-651
