### PR TITLE
QUA-26: extract org timeline events to entity_events table

### DIFF
--- a/crux/commands/wiki-server.ts
+++ b/crux/commands/wiki-server.ts
@@ -48,6 +48,11 @@ const SCRIPTS = {
     description: 'Sync page assessments (quality, importance, ratings) to wiki-server',
     passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
   },
+  'sync-entity-events': {
+    script: 'wiki-server/sync-entity-events.ts',
+    description: 'Sync data/entity-events/*.yaml (org timelines) to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
   'sync-coverage-scans': {
     script: 'wiki-server/sync-coverage-scans.ts',
     description: 'Compute entity coverage scores and sync to wiki-server',
@@ -99,6 +104,7 @@ Examples:
   crux sys wiki-server sync-session .claude/sessions/2026-02-21_my-branch.yaml
   crux sys wiki-server sync-sessions           Sync all session logs
   crux sys wiki-server sync-auto-update-runs   Sync all auto-update runs
+  crux sys wiki-server sync-entity-events      Sync org timelines from data/entity-events/
   crux sys wiki-server snapshot-resources      Export PG resources to snapshot JSON
 `;
 }

--- a/crux/wiki-server/sync-entity-events.test.ts
+++ b/crux/wiki-server/sync-entity-events.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  loadEventsFile,
+  loadAllEvents,
+  eventIdFor,
+  VALID_EVENT_TYPES,
+  VALID_SIGNIFICANCE,
+} from "./sync-entity-events.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "entity-events-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(tmp, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe("eventIdFor", () => {
+  it("produces a deterministic 10-char ID", () => {
+    const id = eventIdFor("sid_abc1234567", "2020-12", "Founded");
+    expect(id).toHaveLength(10);
+    expect(eventIdFor("sid_abc1234567", "2020-12", "Founded")).toBe(id);
+  });
+
+  it("produces different IDs for different inputs", () => {
+    const a = eventIdFor("sid_abc1234567", "2020-12", "Founded");
+    const b = eventIdFor("sid_abc1234567", "2020-12", "Acquired");
+    const c = eventIdFor("sid_xyz9876543", "2020-12", "Founded");
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it("differentiates date variants", () => {
+    expect(eventIdFor("sid_abc1234567", "2020", "X")).not.toBe(
+      eventIdFor("sid_abc1234567", "2020-12", "X"),
+    );
+  });
+});
+
+describe("loadEventsFile", () => {
+  const validYaml = `
+entityId: sid_abc1234567
+entityDisplayName: Test Org
+events:
+  - date: "2020-12"
+    title: Founded
+    eventType: founding
+    significance: major
+    description: Test event
+    source: https://example.com
+  - date: "2021"
+    title: Series A
+    eventType: funding
+`;
+
+  it("parses a valid file", () => {
+    const f = writeFile("test.yaml", validYaml);
+    const events = loadEventsFile(f);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      entityId: "sid_abc1234567",
+      entityDisplayName: "Test Org",
+      date: "2020-12",
+      title: "Founded",
+      eventType: "founding",
+      significance: "major",
+      description: "Test event",
+      source: "https://example.com",
+      notes: null,
+    });
+    expect(events[0].id).toHaveLength(10);
+  });
+
+  it("defaults significance/description/source/notes to null when absent", () => {
+    const f = writeFile("t.yaml", validYaml);
+    const events = loadEventsFile(f);
+    expect(events[1].significance).toBeNull();
+    expect(events[1].description).toBeNull();
+    expect(events[1].source).toBeNull();
+    expect(events[1].notes).toBeNull();
+  });
+
+  it("produces deterministic IDs across calls", () => {
+    const f = writeFile("t.yaml", validYaml);
+    const a = loadEventsFile(f);
+    const b = loadEventsFile(f);
+    expect(a[0].id).toBe(b[0].id);
+    expect(a[1].id).toBe(b[1].id);
+  });
+
+  it("accepts YYYY, YYYY-MM, and YYYY-MM-DD dates", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: A, eventType: founding }
+  - { date: "2020-12", title: B, eventType: founding }
+  - { date: "2020-12-15", title: C, eventType: founding }
+`,
+    );
+    const events = loadEventsFile(f);
+    expect(events.map((e) => e.date)).toEqual(["2020", "2020-12", "2020-12-15"]);
+  });
+
+  it("rejects invalid date formats", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "Dec 2020", title: X, eventType: founding }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/date.*YYYY/);
+  });
+
+  it("rejects unknown event types", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: X, eventType: bogus }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/eventType/);
+  });
+
+  it("rejects unknown significance levels", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: X, eventType: founding, significance: huge }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/significance/);
+  });
+
+  it("rejects empty title", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: "", eventType: founding }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/title/);
+  });
+
+  it("rejects missing entityId", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+events:
+  - { date: "2020", title: X, eventType: founding }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/entityId/);
+  });
+
+  it("rejects events that is not an array", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events: "oops"
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/events.*array/);
+  });
+
+  it("rejects non-object top-level YAML", () => {
+    const f = writeFile("t.yaml", `- foo`);
+    expect(() => loadEventsFile(f)).toThrow(/object/);
+  });
+
+  it("includes the file path in error messages", () => {
+    const f = writeFile(
+      "broken.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - { date: "X", title: X, eventType: founding }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/broken\.yaml/);
+  });
+
+  it("accepts every documented event type", () => {
+    for (const t of VALID_EVENT_TYPES) {
+      const f = writeFile(
+        `${t}.yaml`,
+        `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: T, eventType: ${t} }
+`,
+      );
+      expect(loadEventsFile(f)[0].eventType).toBe(t);
+    }
+  });
+
+  it("accepts every documented significance level", () => {
+    for (const s of VALID_SIGNIFICANCE) {
+      const f = writeFile(
+        `${s}.yaml`,
+        `
+entityId: sid_abc1234567
+events:
+  - { date: "2020", title: T, eventType: founding, significance: ${s} }
+`,
+      );
+      expect(loadEventsFile(f)[0].significance).toBe(s);
+    }
+  });
+});
+
+describe("loadAllEvents", () => {
+  it("returns empty when directory does not exist", () => {
+    const result = loadAllEvents(join(tmp, "missing"));
+    expect(result.events).toEqual([]);
+    expect(result.files).toEqual([]);
+  });
+
+  it("aggregates events across multiple files", () => {
+    writeFile(
+      "a.yaml",
+      `
+entityId: sid_aaaaaaa111
+events:
+  - { date: "2020", title: A1, eventType: founding }
+  - { date: "2021", title: A2, eventType: launch }
+`,
+    );
+    writeFile(
+      "b.yaml",
+      `
+entityId: sid_bbbbbbb222
+events:
+  - { date: "2020", title: B1, eventType: founding }
+`,
+    );
+    const result = loadAllEvents(tmp);
+    expect(result.files).toEqual(["a.yaml", "b.yaml"]);
+    expect(result.events).toHaveLength(3);
+    expect(result.events.map((e) => e.entityId).sort()).toEqual([
+      "sid_aaaaaaa111",
+      "sid_aaaaaaa111",
+      "sid_bbbbbbb222",
+    ]);
+  });
+
+  it("ignores non-yaml files", () => {
+    writeFile("notes.md", "hello");
+    writeFile(
+      "c.yaml",
+      `
+entityId: sid_ccccccc333
+events:
+  - { date: "2020", title: C1, eventType: founding }
+`,
+    );
+    const result = loadAllEvents(tmp);
+    expect(result.files).toEqual(["c.yaml"]);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it("throws on duplicate IDs across files", () => {
+    writeFile(
+      "a.yaml",
+      `
+entityId: sid_dupdupdup1
+events:
+  - { date: "2020", title: Same, eventType: founding }
+`,
+    );
+    writeFile(
+      "b.yaml",
+      `
+entityId: sid_dupdupdup1
+events:
+  - { date: "2020", title: Same, eventType: founding }
+`,
+    );
+    expect(() => loadAllEvents(tmp)).toThrow(/Duplicate event ID/);
+  });
+
+  it("propagates per-file validation errors", () => {
+    writeFile(
+      "bad.yaml",
+      `
+entityId: sid_eeeeeeee44
+events:
+  - { date: "no", title: X, eventType: founding }
+`,
+    );
+    expect(() => loadAllEvents(tmp)).toThrow(/bad\.yaml/);
+  });
+
+  it("loads .yml as well as .yaml", () => {
+    writeFile(
+      "x.yml",
+      `
+entityId: sid_yyyyyyy777
+events:
+  - { date: "2020", title: Y1, eventType: founding }
+`,
+    );
+    const result = loadAllEvents(tmp);
+    expect(result.files).toEqual(["x.yml"]);
+    expect(result.events).toHaveLength(1);
+  });
+});

--- a/crux/wiki-server/sync-entity-events.ts
+++ b/crux/wiki-server/sync-entity-events.ts
@@ -1,0 +1,341 @@
+/**
+ * Wiki Server Entity Events Sync
+ *
+ * Reads data/entity-events/*.yaml and syncs to /api/entity-events/sync.
+ *
+ * Each YAML file represents one entity's timeline:
+ *
+ *   entityId: sid_xxxxxxxxxx              # FK to entities.stable_id
+ *   entityDisplayName: "Anthropic"        # optional fallback display name
+ *   events:
+ *     - date: "2020-12"                   # YYYY, YYYY-MM, or YYYY-MM-DD
+ *       title: "Founded by ex-OpenAI"
+ *       eventType: founding               # see VALID_EVENT_TYPES below
+ *       significance: major               # major | moderate | minor (optional)
+ *       description: "..."                # optional
+ *       source: "https://..."             # optional URL
+ *       notes: "..."                      # optional
+ *
+ * Item IDs are derived deterministically from (entityId, date, title) so the
+ * sync is idempotent: re-running with the same YAML upserts the same rows.
+ *
+ * Usage:
+ *   pnpm crux sys wiki-server sync-entity-events
+ *   pnpm crux sys wiki-server sync-entity-events --dry-run
+ *   pnpm crux sys wiki-server sync-entity-events --batch-size=50
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL     - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
+import { contentHash } from "../../packages/factbase/src/ids.ts";
+import { waitForHealthy, batchSync } from "./sync-common.ts";
+
+const PROJECT_ROOT = join(import.meta.dirname!, "../..");
+const EVENTS_DIR = join(PROJECT_ROOT, "data/entity-events");
+
+const DEFAULT_BATCH_SIZE = 100;
+
+// Mirror of VALID_EVENT_TYPES / VALID_SIGNIFICANCE in
+// apps/wiki-server/src/routes/tablebase/entity-events.ts.
+// Keep in sync with that route's Zod schema.
+export const VALID_EVENT_TYPES = [
+  "founding",
+  "acquisition",
+  "pivot",
+  "launch",
+  "publication",
+  "policy",
+  "milestone",
+  "leadership-change",
+  "incident",
+  "funding",
+  "dissolution",
+  "other",
+] as const;
+
+export const VALID_SIGNIFICANCE = ["major", "moderate", "minor"] as const;
+
+type EventType = (typeof VALID_EVENT_TYPES)[number];
+type Significance = (typeof VALID_SIGNIFICANCE)[number];
+
+// --- Types ---
+
+interface RawEvent {
+  date?: unknown;
+  title?: unknown;
+  eventType?: unknown;
+  significance?: unknown;
+  description?: unknown;
+  source?: unknown;
+  notes?: unknown;
+}
+
+interface RawEventsFile {
+  entityId?: unknown;
+  entityDisplayName?: unknown;
+  events?: unknown;
+}
+
+export interface SyncEntityEvent {
+  id: string;
+  entityId: string;
+  entityDisplayName: string | null;
+  date: string;
+  title: string;
+  description: string | null;
+  eventType: EventType;
+  significance: Significance | null;
+  source: string | null;
+  notes: string | null;
+}
+
+// --- Loader ---
+
+/**
+ * Generate a deterministic 10-char ID from (entityId, date, title).
+ * Re-running the sync with the same YAML produces the same IDs, so the
+ * upsert is idempotent. Editing the title produces a new row — the old
+ * row remains until cleaned up via /delete-batch.
+ */
+export function eventIdFor(entityId: string, date: string, title: string): string {
+  return contentHash(["entity-event", entityId, date, title]);
+}
+
+const DATE_RE = /^\d{4}(-\d{2}(-\d{2})?)?$/;
+
+function asString(v: unknown, field: string, file: string): string {
+  if (typeof v !== "string" || v.trim() === "") {
+    throw new Error(`${file}: '${field}' must be a non-empty string`);
+  }
+  return v;
+}
+
+function asOptionalString(v: unknown, field: string, file: string): string | null {
+  if (v === undefined || v === null || v === "") return null;
+  if (typeof v !== "string") {
+    throw new Error(`${file}: '${field}' must be a string when present`);
+  }
+  return v;
+}
+
+/**
+ * Load and validate one entity-events YAML file.
+ * Throws on malformed input — sync should fail-closed rather than silently skip.
+ */
+export function loadEventsFile(filePath: string): SyncEntityEvent[] {
+  const raw = readFileSync(filePath, "utf-8");
+  const parsed = parseYaml(raw) as RawEventsFile | null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${filePath}: top-level YAML must be an object`);
+  }
+
+  const entityId = asString(parsed.entityId, "entityId", filePath);
+  const entityDisplayName = asOptionalString(
+    parsed.entityDisplayName,
+    "entityDisplayName",
+    filePath,
+  );
+
+  if (!Array.isArray(parsed.events)) {
+    throw new Error(`${filePath}: 'events' must be an array`);
+  }
+
+  const out: SyncEntityEvent[] = [];
+  for (let i = 0; i < parsed.events.length; i++) {
+    const ev = parsed.events[i] as RawEvent;
+    const where = `${filePath} events[${i}]`;
+
+    const date = asString(ev.date, "date", where);
+    if (!DATE_RE.test(date)) {
+      throw new Error(
+        `${where}: 'date' must be YYYY, YYYY-MM, or YYYY-MM-DD (got "${date}")`,
+      );
+    }
+
+    const title = asString(ev.title, "title", where);
+    const eventType = asString(ev.eventType, "eventType", where) as EventType;
+    if (!(VALID_EVENT_TYPES as readonly string[]).includes(eventType)) {
+      throw new Error(
+        `${where}: 'eventType' must be one of ${VALID_EVENT_TYPES.join("|")} (got "${eventType}")`,
+      );
+    }
+
+    let significance: Significance | null = null;
+    if (ev.significance !== undefined && ev.significance !== null && ev.significance !== "") {
+      const sig = asString(ev.significance, "significance", where) as Significance;
+      if (!(VALID_SIGNIFICANCE as readonly string[]).includes(sig)) {
+        throw new Error(
+          `${where}: 'significance' must be one of ${VALID_SIGNIFICANCE.join("|")} (got "${sig}")`,
+        );
+      }
+      significance = sig;
+    }
+
+    out.push({
+      id: eventIdFor(entityId, date, title),
+      entityId,
+      entityDisplayName,
+      date,
+      title,
+      description: asOptionalString(ev.description, "description", where),
+      eventType,
+      significance,
+      source: asOptionalString(ev.source, "source", where),
+      notes: asOptionalString(ev.notes, "notes", where),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Load all *.yaml files from data/entity-events/ and return the flattened
+ * event list. Returns an empty array if the directory does not exist.
+ */
+export function loadAllEvents(dir: string = EVENTS_DIR): {
+  events: SyncEntityEvent[];
+  files: string[];
+} {
+  if (!existsSync(dir)) {
+    return { events: [], files: [] };
+  }
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+
+  const all: SyncEntityEvent[] = [];
+  for (const f of files) {
+    const events = loadEventsFile(join(dir, f));
+    all.push(...events);
+  }
+
+  // Detect duplicate IDs across files — would surface as a silent overwrite
+  // server-side, so catch it here with the offending pair named.
+  const seen = new Map<string, SyncEntityEvent>();
+  for (const ev of all) {
+    const prev = seen.get(ev.id);
+    if (prev) {
+      throw new Error(
+        `Duplicate event ID ${ev.id} from (${prev.entityId}, ${prev.date}, "${prev.title}") and ` +
+          `(${ev.entityId}, ${ev.date}, "${ev.title}"). Adjust one title to disambiguate.`,
+      );
+    }
+    seen.set(ev.id, ev);
+  }
+
+  return { events: all, files };
+}
+
+// --- Sync ---
+
+export async function syncEntityEvents(
+  serverUrl: string,
+  events: SyncEntityEvent[],
+  batchSize: number,
+  options: { _sleep?: (ms: number) => Promise<void> } = {},
+): Promise<{ upserted: number; errors: number }> {
+  const result = await batchSync(
+    `${serverUrl}/api/entity-events/sync`,
+    events,
+    batchSize,
+    {
+      bodyKey: "items",
+      responseCountKey: "upserted",
+      itemLabel: "entity events",
+      _sleep: options._sleep,
+    },
+  );
+  return { upserted: result.count, errors: result.errors };
+}
+
+// --- Main ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || DEFAULT_BATCH_SIZE;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_URL environment variable is required",
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required",
+    );
+    process.exit(1);
+  }
+
+  console.log(`Reading entity events from: ${EVENTS_DIR}`);
+  const { events, files } = loadAllEvents();
+  console.log(`  Found ${files.length} files, ${events.length} events`);
+
+  if (events.length === 0) {
+    console.log("Nothing to sync.");
+    return;
+  }
+
+  // Per-entity counts for visibility
+  const byEntity = new Map<string, number>();
+  for (const ev of events) {
+    byEntity.set(ev.entityId, (byEntity.get(ev.entityId) ?? 0) + 1);
+  }
+  for (const [entityId, count] of [...byEntity.entries()].sort()) {
+    console.log(`  ${entityId}: ${count} events`);
+  }
+
+  if (dryRun) {
+    console.log("\n[dry-run] Would sync these events (showing first 10):");
+    for (const ev of events.slice(0, 10)) {
+      console.log(
+        `  ${ev.entityId} ${ev.date} [${ev.eventType}] ${ev.title}`,
+      );
+    }
+    if (events.length > 10) {
+      console.log(`  ... and ${events.length - 10} more`);
+    }
+    return;
+  }
+
+  console.log("\nChecking server health...");
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nSyncing ${events.length} entity events (batch size: ${batchSize})...`,
+  );
+  const result = await syncEntityEvents(serverUrl, events, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Upserted: ${result.upserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:   ${result.errors}`);
+    console.error(`\nSync failed with ${result.errors} event errors.`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("Entity events sync failed:", err);
+    process.exit(1);
+  });
+}

--- a/data/entity-events/80000-hours.yaml
+++ b/data/entity-events/80000-hours.yaml
@@ -1,0 +1,82 @@
+# Entity events for 80,000 Hours (E510)
+# Source: content/docs/knowledge-base/organizations/80000-hours.mdx (### Timeline section)
+entityId: sid_hvg9ecR3nA
+entityDisplayName: 80,000 Hours
+events:
+  - date: "2011"
+    title: Founded at Oxford by Benjamin Todd and William MacAskill
+    eventType: founding
+    significance: major
+    description: Started as a student project; helped establish effective altruism alongside Giving What We Can and CEA.
+
+  - date: "2012"
+    title: First full-time staff hired
+    eventType: milestone
+    significance: moderate
+    description: Organization professionalizes; begins systematic research.
+
+  - date: "2012"
+    title: Co-founded EA movement
+    eventType: milestone
+    significance: major
+    description: Helped establish effective altruism alongside Giving What We Can and CEA.
+
+  - date: "2015"
+    title: Y Combinator acceptance
+    eventType: milestone
+    significance: major
+    description: One of the first nonprofits in YC; gained startup methodology and credibility.
+
+  - date: "2016"
+    title: AI safety becomes top priority
+    eventType: pivot
+    significance: major
+    description: Identified risks from AI as the most pressing problem area.
+
+  - date: "2016"
+    title: Published career guide book
+    eventType: publication
+    significance: moderate
+    description: "80,000 Hours: Find a fulfilling career that does good."
+
+  - date: "2017"
+    title: Podcast launch
+    eventType: launch
+    significance: moderate
+    description: Rob Wiblin begins hosting The 80,000 Hours Podcast.
+
+  - date: "2020"
+    title: Reached 14 FTEs
+    eventType: milestone
+    significance: minor
+    description: Steady organizational growth.
+
+  - date: "2022"
+    title: Leadership transition — Howie Lempel becomes CEO
+    eventType: leadership-change
+    significance: major
+    description: Benjamin Todd moves from CEO to President; Howie Lempel becomes CEO.
+
+  - date: "2022"
+    title: Reached 25 FTEs
+    eventType: milestone
+    significance: moderate
+    description: Organization nearly doubles in size.
+
+  - date: "2024"
+    title: Niel Bowerman appointed CEO
+    eventType: leadership-change
+    significance: major
+    description: Former FHI Assistant Director takes over as CEO.
+
+  - date: "2025"
+    title: Strategic shift to AGI focus announced
+    eventType: pivot
+    significance: major
+    description: Announced focus on navigating transition to powerful AGI.
+
+  - date: "2025-04-01"
+    title: Spin-out from Effective Ventures
+    eventType: pivot
+    significance: major
+    description: Became an independent nonprofit (April 1, 2025).

--- a/data/entity-events/anthropic.yaml
+++ b/data/entity-events/anthropic.yaml
@@ -1,0 +1,49 @@
+# Entity events for Anthropic (E22)
+# Source: content/docs/knowledge-base/organizations/anthropic.mdx (## History section)
+entityId: sid_mK9pX3rQ7n
+entityDisplayName: Anthropic
+events:
+  - date: "2020-12"
+    title: Founded by 7 ex-OpenAI researchers
+    eventType: founding
+    significance: major
+    description: Dario Amodei (CEO), Daniela Amodei (President), Chris Olah, Tom Brown, Jack Clark, Jared Kaplan, and Sam McCandlish departed OpenAI over disagreement about scaling vs. alignment priorities.
+
+  - date: "2021"
+    title: Series A led by Jaan Tallinn at $550M pre-money valuation
+    eventType: funding
+    significance: major
+    description: Skype co-founder Jaan Tallinn reportedly led the Series A. Dustin Moskovitz also participated in seed and Series A rounds.
+
+  - date: "2022"
+    title: FTX invests ~$500M
+    eventType: funding
+    significance: major
+    description: FTX reportedly invested approximately $500M in Anthropic in 2022 according to multiple news accounts.
+
+  - date: "2024-12"
+    title: Run-rate revenue ~$1B
+    eventType: milestone
+    significance: major
+    description: Beginning-of-2025 run-rate revenue figure reported as approximately $1B.
+
+  - date: "2025-07"
+    title: Annualized revenue $4B
+    eventType: milestone
+    significance: major
+
+  - date: "2025-12"
+    title: Run-rate revenue exceeds $9B
+    eventType: milestone
+    significance: major
+
+  - date: "2026-02"
+    title: Run-rate revenue reaches $14B
+    eventType: milestone
+    significance: major
+
+  - date: "2026-03"
+    title: Run-rate revenue reaches ~$19B
+    eventType: milestone
+    significance: major
+    description: Reportedly targeting $20-26B annualized revenue for 2026, with bull-case projections reaching up to $70B by 2028.

--- a/data/entity-events/arc.yaml
+++ b/data/entity-events/arc.yaml
@@ -1,0 +1,45 @@
+# Entity events for Alignment Research Center / ARC (E25)
+# Source: content/docs/knowledge-base/organizations/arc.mdx
+entityId: sid_QsXVXtQ0zE
+entityDisplayName: Alignment Research Center
+events:
+  - date: "2021"
+    title: Founded by Paul Christiano
+    eventType: founding
+    significance: major
+    description: Founded by Paul Christiano after his departure from OpenAI; nonprofit AI safety research organization focused on theoretical alignment.
+
+  - date: "2022"
+    title: ARC Evals incubated; Beth Barnes hired to lead it
+    eventType: launch
+    significance: major
+    description: Began incubating ARC Evals — exploratory work on independent evaluations of frontier AI models. Completed evaluations of GPT-4 (with OpenAI) and Claude (with Anthropic).
+
+  - date: "2022"
+    title: Open Philanthropy grant ($265K)
+    eventType: funding
+    significance: moderate
+    description: Documented grant from Coefficient Giving (then Open Philanthropy).
+
+  - date: "2022"
+    title: Returned $1.25M FTX Foundation grant after FTX bankruptcy
+    eventType: funding
+    significance: major
+
+  - date: "2023-09-19"
+    title: ARC Evals spin-out announced
+    eventType: pivot
+    significance: major
+    description: Growth in ARC Evals' size prompted formalization of separation.
+
+  - date: "2023-12-04"
+    title: ARC Evals formally renamed METR
+    eventType: pivot
+    significance: major
+    description: Model Evaluation & Threat Research; independent 501(c)(3) nonprofit led by Beth Barnes.
+
+  - date: "2024-04"
+    title: Christiano appointed Head of AI Safety at US AISI
+    eventType: leadership-change
+    significance: major
+    description: Personal appointment at NIST rather than an institutional contract with ARC.

--- a/data/entity-events/cais.yaml
+++ b/data/entity-events/cais.yaml
@@ -1,0 +1,41 @@
+# Entity events for Center for AI Safety / CAIS (E47)
+# Source: content/docs/knowledge-base/organizations/cais.mdx
+entityId: sid_y4bieqSeag
+entityDisplayName: Center for AI Safety
+events:
+  - date: "2022"
+    title: Founded by Dan Hendrycks and Oliver Zhang
+    eventType: founding
+    significance: major
+    description: Nonprofit research organization (EIN 88-1751310) focused on technical AI safety research, field-building, and public communication.
+
+  - date: "2022"
+    title: '"Unsolved Problems in ML Safety" published'
+    eventType: publication
+    significance: major
+    description: Taxonomy of open technical challenges in machine learning safety, intended partly as a research agenda for the field.
+
+  - date: "2023"
+    title: Representation Engineering paper published
+    eventType: publication
+    significance: major
+    description: Methods for reading and steering model internal representations.
+
+  - date: "2023"
+    title: MACHIAVELLI benchmark released
+    eventType: publication
+    significance: moderate
+    description: Benchmark for evaluating goal-directed and deceptive behavior in AI systems.
+
+  - date: "2023-05"
+    title: Statement on AI Risk released
+    eventType: milestone
+    significance: major
+    description: One-sentence statement on AI extinction risk attracted signatures from over 350 AI researchers and industry figures, including Turing Award recipients (Hinton, Bengio, Russell) and CEOs of major AI labs (Altman, Amodei, Hassabis).
+
+  - date: "2024"
+    title: Reported revenue of $10.2M (FY2024)
+    eventType: milestone
+    significance: moderate
+    description: Cumulative funding reaches ~$33M since founding ($6.7M in 2022, $16.1M in 2023, $10.2M in 2024).
+    source: https://projects.propublica.org/nonprofits/organizations/881751310

--- a/data/entity-events/coefficient-giving.yaml
+++ b/data/entity-events/coefficient-giving.yaml
@@ -1,0 +1,62 @@
+# Entity events for Coefficient Giving (E521, formerly Open Philanthropy)
+# Source: content/docs/knowledge-base/organizations/coefficient-giving.mdx
+entityId: sid_ULjDXpSLCI
+entityDisplayName: Coefficient Giving
+events:
+  - date: "2011"
+    title: GiveWell begins advising Good Ventures
+    eventType: founding
+    significance: major
+    description: GiveWell, founded by Holden Karnofsky and Elie Hassenfeld, begins advising Good Ventures (established by Dustin Moskovitz and Cari Tuna) on how to deploy philanthropic capital effectively.
+
+  - date: "2014"
+    title: Open Philanthropy formalized as project within GiveWell
+    eventType: milestone
+    significance: major
+    description: The advising relationship formalizes into "Open Philanthropy" as a distinct project, focused on identifying high-impact giving opportunities across a broader range of cause areas than GiveWell's traditional global health focus.
+
+  - date: "2015"
+    title: First AI safety grants
+    eventType: milestone
+    significance: major
+    description: Began supporting AI safety work in 2015, when the field had ~10 full-time researchers and institutional support was minimal. Early grants helped establish MIRI, CHAI, and the Future of Humanity Institute.
+
+  - date: "2017"
+    title: Spun off from GiveWell as independent LLC
+    eventType: pivot
+    significance: major
+    description: Holden Karnofsky publishes detailed AI concerns; the spinoff enables Open Philanthropy to pursue its own strategic priorities while GiveWell continues focusing on evidence-backed global health interventions.
+    source: https://www.openphilanthropy.org/research/open-philanthropy-is-now-an-independent-organization/
+
+  - date: "2019"
+    title: AI safety spending exceeds $20M annually
+    eventType: milestone
+    significance: moderate
+
+  - date: "2022"
+    title: $150M Regranting Challenge launched (not AI-specific)
+    eventType: launch
+    significance: moderate
+
+  - date: "2023"
+    title: ~$46M AI safety spending; largest funder in the field
+    eventType: milestone
+    significance: major
+    description: AI safety becomes Open Philanthropy's largest longtermist cause area.
+
+  - date: "2024"
+    title: ~$50M AI safety committed; 68% to evaluations/benchmarking
+    eventType: milestone
+    significance: moderate
+
+  - date: "2025"
+    title: $40M Technical AI Safety RFP
+    eventType: funding
+    significance: major
+
+  - date: "2025-11-18"
+    title: Rebrand from Open Philanthropy to Coefficient Giving
+    eventType: pivot
+    significance: major
+    description: Multi-donor expansion (over $100M directed from non-Good-Ventures donors in 2024); brand clarity to disambiguate from OpenAI and Open Society Foundations; structural reorganization into 13 distinct funds.
+    source: https://coefficientgiving.org/research/open-philanthropy-is-now-coefficient-giving/

--- a/data/entity-events/deepmind.yaml
+++ b/data/entity-events/deepmind.yaml
@@ -1,0 +1,88 @@
+# Entity events for Google DeepMind (E98)
+# Source: content/docs/knowledge-base/organizations/deepmind.mdx
+entityId: sid_A4XoubikkQ
+entityDisplayName: Google DeepMind
+events:
+  - date: "2010"
+    title: DeepMind founded in London
+    eventType: founding
+    significance: major
+    description: Founded by Demis Hassabis, Shane Legg, and Mustafa Suleyman with the mission to "solve intelligence, then use that to solve everything else."
+
+  - date: "2014"
+    title: Acquired by Google
+    eventType: acquisition
+    significance: major
+    description: Acquisition structured to preserve DeepMind's autonomy — separate brand, ethics board for AGI oversight, open research publication, and UK headquarters.
+
+  - date: "2016-03"
+    title: AlphaGo defeats Lee Sedol 4-1
+    eventType: milestone
+    significance: major
+    description: 200M+ viewers; demonstrated strategic AI; "Move 37" exemplified unexpected AI strategy.
+
+  - date: "2017"
+    title: AlphaGo Zero defeats AlphaGo 100-0 via self-play
+    eventType: milestone
+    significance: major
+    description: Learning without human data.
+
+  - date: "2017"
+    title: AlphaZero generalizes to chess and shogi
+    eventType: milestone
+    significance: major
+    description: Domain-general strategic reasoning.
+
+  - date: "2018"
+    title: AlphaFold wins CASP13
+    eventType: milestone
+    significance: major
+    description: First place in protein-prediction competition; proof of concept for AI in structural biology.
+
+  - date: "2020"
+    title: AlphaFold 2 reaches ~90% accuracy at CASP14
+    eventType: milestone
+    significance: major
+    description: Addressed a 50-year grand challenge in protein folding.
+
+  - date: "2021"
+    title: AlphaFold protein database release
+    eventType: launch
+    significance: major
+    description: 200M+ protein structures freely available; accelerated global research.
+
+  - date: "2022"
+    title: Sparrow dialogue agent published
+    eventType: publication
+    significance: moderate
+    description: Applied RLHF and rule-based reward modeling with debate-style methods toward scalable oversight.
+
+  - date: "2023-04"
+    title: Merger with Google Brain ends DeepMind's independent governance
+    eventType: pivot
+    significance: major
+    description: Driven by ChatGPT competitive pressure, resource efficiency, product integration, and talent retention.
+
+  - date: "2023-12"
+    title: Gemini 1.0 launched
+    eventType: launch
+    significance: major
+    description: Multimodal from the ground up; claimed GPT-4 parity or superiority.
+
+  - date: "2024-02"
+    title: Gemini 1.5 launched
+    eventType: launch
+    significance: moderate
+    description: 2M-token context window; long-context leadership.
+
+  - date: "2024"
+    title: Nobel Prize in Chemistry awarded
+    eventType: milestone
+    significance: major
+    description: Awarded to Demis Hassabis and John Jumper of DeepMind (shared with David Baker of University of Washington for independent protein-design work) for AlphaFold.
+
+  - date: "2024-12"
+    title: Gemini 2.0 launched
+    eventType: launch
+    significance: moderate
+    description: Enhanced agentic capabilities; integrated across Google products.

--- a/data/entity-events/manifund.yaml
+++ b/data/entity-events/manifund.yaml
@@ -1,0 +1,76 @@
+# Entity events for Manifund (E547)
+# Source: content/docs/knowledge-base/organizations/manifund.mdx (## Timeline section)
+entityId: sid_fFVOuFZCRf
+entityDisplayName: Manifund
+events:
+  - date: "2021-12"
+    title: Manifold Markets founded
+    eventType: founding
+    significance: major
+    description: Founded by Austin Chen, Stephen Grugett, and James Grugett.
+    source: https://manifund.org
+
+  - date: "2022"
+    title: Receives $500K from FTX Future Fund for charity prediction markets
+    eventType: funding
+    significance: moderate
+
+  - date: "2022"
+    title: Manifund incorporated as separate 501(c)(3)
+    eventType: milestone
+    significance: major
+
+  - date: "2022"
+    title: Scott Alexander approaches team about ACX Grants via impact certificates
+    eventType: milestone
+    significance: moderate
+
+  - date: "2022"
+    title: Rachel Weinberg joins; builds manifund.org in two weeks
+    eventType: milestone
+    significance: moderate
+
+  - date: "2023-05"
+    title: Anonymous donor "D" provides $1.5M for regranting program
+    eventType: funding
+    significance: major
+
+  - date: "2023"
+    title: Manifund launches with ~12 regrantors ($50K-400K budgets each)
+    eventType: launch
+    significance: major
+
+  - date: "2023-09"
+    title: First Manifest conference (250 attendees, Berkeley)
+    eventType: milestone
+    significance: moderate
+
+  - date: "2023"
+    title: $2.06M distributed ($2.012M grants + $45K impact certificates)
+    eventType: milestone
+    significance: moderate
+
+  - date: "2024-01"
+    title: Impact certificate experiments conclude with mixed results
+    eventType: milestone
+    significance: moderate
+
+  - date: "2024-06"
+    title: Manifest 2024 (600 attendees)
+    eventType: milestone
+    significance: moderate
+
+  - date: "2024"
+    title: ACX Grants 2024 includes impact market for 50+ proposals
+    eventType: milestone
+    significance: moderate
+
+  - date: "2025"
+    title: $2.25M raised for 10 regrantors
+    eventType: funding
+    significance: moderate
+
+  - date: "2025-01"
+    title: ACX Grants 2025 funds 42 of 654 applications
+    eventType: milestone
+    significance: moderate

--- a/data/entity-events/miri.yaml
+++ b/data/entity-events/miri.yaml
@@ -1,0 +1,62 @@
+# Entity events for MIRI / Machine Intelligence Research Institute (E202)
+# Source: content/docs/knowledge-base/organizations/miri.mdx (## History section)
+entityId: sid_puAffUjWSS
+entityDisplayName: Machine Intelligence Research Institute
+events:
+  - date: "2000"
+    title: Singularity Institute for Artificial Intelligence founded
+    eventType: founding
+    significance: major
+    description: Founded by Eliezer Yudkowsky with the original (paradoxical) mission of accelerating AI development.
+    source: https://en.wikipedia.org/wiki/Machine_Intelligence_Research_Institute
+
+  - date: "2005"
+    title: Reorientation toward AI safety
+    eventType: pivot
+    significance: major
+    description: Yudkowsky's concerns about superintelligent AI risks prompted a fundamental reorientation toward AI safety. Organization also relocated from Atlanta to Silicon Valley that year.
+
+  - date: "2006"
+    title: First Singularity Summit
+    eventType: launch
+    significance: moderate
+    description: Annual summit organized in cooperation with Stanford University, with funding from Peter Thiel.
+
+  - date: "2012-12"
+    title: Sold name, web domain, and Singularity Summit to Singularity University
+    eventType: pivot
+    significance: major
+    description: Marked the end of the public-outreach phase.
+
+  - date: "2013-01"
+    title: Renamed to Machine Intelligence Research Institute
+    eventType: pivot
+    significance: major
+
+  - date: "2019-02"
+    title: Open Philanthropy two-year general support grant ($2.65M)
+    eventType: funding
+    significance: moderate
+    description: Provided $2,652,500 over two years; OP support grew from $1.4M (2018) to $2.31M (2019).
+    source: https://www.openphilanthropy.org/grants/machine-intelligence-research-institute-general-support-2019/
+
+  - date: "2020-04"
+    title: Largest single Open Philanthropy grant — $7.7M
+    eventType: funding
+    significance: major
+    description: $6.24M from main OP funders + $1.46M from BitMEX co-founder Ben Delo. At this peak, OP provided ~60% of MIRI's predicted budgets for 2020-2021.
+    source: https://www.openphilanthropy.org/grants/machine-intelligence-research-institute-general-support-2019/
+
+  - date: "2021-05"
+    title: $4.3M Ethereum donation from Vitalik Buterin
+    eventType: funding
+    significance: major
+    description: Contributed to a revenue spike to $25.6M in 2021.
+    source: https://intelligence.org/2021/05/13/two-major-donations/
+
+  - date: "2024"
+    title: Strategic pivot away from alignment research
+    eventType: pivot
+    significance: major
+    description: 2024 announcement; current focus on attempting to halt development of increasingly general AI models via discussions with policymakers about extreme risks.
+    source: https://intelligence.org/2024/01/04/miri-2024-mission-and-strategy-update/

--- a/data/entity-events/openai.yaml
+++ b/data/entity-events/openai.yaml
@@ -1,0 +1,76 @@
+# Entity events for OpenAI (E218)
+# Source: content/docs/knowledge-base/organizations/openai.mdx
+entityId: sid_1LcLlMGLbw
+entityDisplayName: OpenAI
+events:
+  - date: "2015"
+    title: Founded as non-profit with ~$1B founder commitment
+    eventType: founding
+    significance: major
+    description: Founding mission "AGI benefits all humanity"; "open by default" research publishing, "safety over competitive advantage."
+
+  - date: "2018"
+    title: GPT-1 released (117M parameters)
+    eventType: launch
+    significance: moderate
+    description: First transformer language model from OpenAI; established the architecture.
+
+  - date: "2019"
+    title: GPT-2 released (1.5B parameters)
+    eventType: launch
+    significance: major
+    description: Initially withheld due to misuse concerns; demonstrated growing capability of large language models.
+
+  - date: "2019"
+    title: Restructured to capped-profit LLC
+    eventType: pivot
+    significance: major
+    description: Created OpenAI LP capped-profit subsidiary to raise commercial capital while preserving the non-profit parent.
+
+  - date: "2020"
+    title: GPT-3 released (175B parameters)
+    eventType: launch
+    significance: major
+    description: Few-shot learning breakthrough that sparked the modern scaling race.
+
+  - date: "2022-11"
+    title: ChatGPT launched
+    eventType: launch
+    significance: major
+    description: InstructGPT/ChatGPT (GPT-3.5 + RLHF) drove mainstream AI adoption; established RLHF as a standard alignment technique.
+
+  - date: "2023-03"
+    title: GPT-4 released
+    eventType: launch
+    significance: major
+    description: Undisclosed multimodal model; human-level performance on many tasks; dangerous capabilities acknowledged.
+
+  - date: "2023-11"
+    title: Board crisis and Sam Altman ouster/return
+    eventType: leadership-change
+    significance: major
+    description: Brief removal of Sam Altman by the non-profit board, followed by his return; restructured board with commercial representation.
+
+  - date: "2024"
+    title: o1 reasoning model released
+    eventType: launch
+    significance: major
+    description: Advanced chain-of-thought; mathematical/scientific reasoning advances; raised hidden reasoning and deception risks.
+
+  - date: "2024"
+    title: o3 preview released
+    eventType: launch
+    significance: moderate
+    description: Next-generation reasoning model; near-frontier performance on some tasks.
+
+  - date: "2025"
+    title: o3-mini released
+    eventType: launch
+    significance: moderate
+    description: Efficient reasoning model; broader reasoning availability.
+
+  - date: "2025"
+    title: Converted to Public Benefit Corporation
+    eventType: pivot
+    significance: major
+    description: Converted from capped-profit LLC; cumulative funding reaches $59.9B (including $11B+ Microsoft and a $40B SoftBank round).

--- a/data/entity-events/redwood-research.yaml
+++ b/data/entity-events/redwood-research.yaml
@@ -1,0 +1,52 @@
+# Entity events for Redwood Research (E557)
+# Source: content/docs/knowledge-base/organizations/redwood-research.mdx (### Timeline + History sections)
+entityId: sid_dwMzc9WzPa
+entityDisplayName: Redwood Research
+events:
+  - date: "2021-09"
+    title: Tax-exempt status granted; 10 staff assembled
+    eventType: founding
+    significance: major
+    source: https://projects.propublica.org/nonprofits/organizations/871702255
+
+  - date: "2021-12"
+    title: MLAB bootcamp launches
+    eventType: launch
+    significance: moderate
+    description: Inaugural ML for Alignment Bootcamp with 40 participants; 3-week intensive teaching attendees to build BERT/GPT-2 from scratch.
+    source: https://blog.redwoodresearch.org/p/the-inaugural-redwood-research-podcast
+
+  - date: "2022"
+    title: Adversarial robustness research project
+    eventType: milestone
+    significance: minor
+    description: Initial adversarial training project; later acknowledged by leadership as unsuccessful.
+    source: https://blog.redwoodresearch.org/p/the-inaugural-redwood-research-podcast
+
+  - date: "2022"
+    title: Causal scrubbing methodology developed
+    eventType: publication
+    significance: moderate
+    description: Developed across 2022-2023; method for rigorously testing mechanistic interpretability claims.
+    source: https://www.lesswrong.com/posts/JvZhhzycHu2Yd57RN/causal-scrubbing-a-method-for-rigorously-testing
+
+  - date: "2023"
+    title: REMIX interpretability program runs
+    eventType: launch
+    significance: moderate
+    description: Mechanistic interpretability training program for ~10-15 junior researchers.
+    source: https://forum.effectivealtruism.org/posts/MGbdhjgd2v6cg3vjv/apply-to-the-redwood-research-mechanistic-interpretability
+
+  - date: "2024"
+    title: Buck Shlegeris becomes CEO; AI Control ICML oral
+    eventType: leadership-change
+    significance: major
+    description: Buck Shlegeris transitions from CTO to CEO and Director; Ryan Greenblatt serves as Chief Scientist. AI Control work accepted as an ICML oral.
+    source: https://projects.propublica.org/nonprofits/organizations/871702255
+
+  - date: "2024-12"
+    title: Alignment faking paper with Anthropic
+    eventType: publication
+    significance: major
+    description: Landmark collaboration with Anthropic on alignment faking research.
+    source: https://www.anthropic.com/research/alignment-faking


### PR DESCRIPTION
## Summary

Populates the `entity_events` PG table (created in PR #2915 but empty since) with **100 timeline events across the top 10 AI safety / AI lab orgs**:

| Org | Events |
|---|--:|
| Anthropic | 8 |
| OpenAI | 12 |
| DeepMind | 14 |
| MIRI | 9 |
| ARC | 7 |
| Manifund | 14 |
| Coefficient Giving | 10 |
| 80,000 Hours | 13 |
| CAIS | 6 |
| Redwood Research | 7 |
| **Total** | **100** |

Events extracted from the History/Timeline sections of each org's wiki page (mix of explicit timeline tables and prose history).

## What's added

- **`data/entity-events/<slug>.yaml`** — one file per org, source of truth. Each event has `date`, `title`, `eventType`, optional `significance`, `description`, `source`, `notes`.
- **`crux/wiki-server/sync-entity-events.ts`** — loader + sync orchestrator using the shared `batchSync` helper.
- **`crux/wiki-server/sync-entity-events.test.ts`** — 23 tests covering loader validation (date format, enum membership, missing fields), deterministic ID generation, duplicate detection across files, and aggregation.
- **`crux sys wiki-server sync-entity-events`** — registered command. Supports `--dry-run` and `--batch-size=N`.

Item IDs are derived deterministically from `(entityId, date, title)` via `contentHash`, so the sync is idempotent — re-running upserts the same rows.

## Acceptance criteria (QUA-26)

- [x] `entity_events` populated for 10+ orgs
- [ ] Timeline data removed from wiki MDX — **deferred to QUA-660** (depends on a render component; removing now would regress user-visible info on wiki pages)
- [x] Data accessible via `/api/entity-events/by-entity/:id` — verified against prod for slug, stableId, and numericId resolution

## Test plan

- [x] `pnpm test` — 7,183 passed locally
- [x] `pnpm crux w validate gate --fix` — 54/54 gate checks pass
- [x] Synced 100 events against prod wiki-server; `/api/entity-events/stats` returns 100
- [x] Per-entity API spot-checks against prod (slug `manifund`, stableId `sid_fFVOuFZCRf`) return correct events ordered by date desc

Closes QUA-26
Follow-up: QUA-660
