### PR TITLE
feat(QUA-650): retro-scan confirmed source-check verdicts for subject mismatches

### DIFF
--- a/crux/commands/sourcing-retro-scan-subjects.test.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.test.ts
@@ -24,6 +24,7 @@ vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
   storeVerdict: (...args: unknown[]) => mockStoreVerdict(...args),
   getEvidenceByRecords: (...args: unknown[]) => mockGetEvidenceByRecords(...args),
   evidenceRecordKey: (rt: string, rid: string) => `${rt}|${rid}`,
+  MAX_EVIDENCE_BY_RECORDS: 1000,
 }));
 
 const mockCallLlm = vi.fn();
@@ -278,6 +279,24 @@ describe('classifyEvidence', () => {
     expect(res.size).toBe(0);
     expect(mockGetEvidenceByRecords).not.toHaveBeenCalled();
   });
+
+  it('chunks requests larger than MAX_EVIDENCE_BY_RECORDS (1000)', async () => {
+    // 2500 verdicts → 3 chunks (1000, 1000, 500).
+    const bigList = Array.from({ length: 2500 }, (_, i) =>
+      makeVerdict({ recordId: `f_${i}` }),
+    );
+    mockGetEvidenceByRecords.mockResolvedValue({
+      ok: true,
+      data: { evidenceByKey: {} },
+    });
+    const res = await classifyEvidence(bigList as never);
+    expect(res.size).toBe(0);
+    expect(mockGetEvidenceByRecords).toHaveBeenCalledTimes(3);
+    const callArgLengths = mockGetEvidenceByRecords.mock.calls.map(
+      (c) => (c[0] as Array<unknown>).length,
+    );
+    expect(callArgLengths).toEqual([1000, 1000, 500]);
+  });
 });
 
 describe('applyDowngrade', () => {
@@ -331,6 +350,34 @@ describe('applyDowngrade', () => {
       ),
     ).rejects.toThrow(/db down/);
     expect(mockStoreSourcingEvidence).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes newlines and quotes in the mismatch prefix (parseability)', async () => {
+    mockStoreVerdict.mockResolvedValueOnce({ ok: true, data: { ok: true } });
+    mockStoreSourcingEvidence.mockResolvedValueOnce(undefined);
+
+    // LLM hands us a source_subject with newlines and a stray quote — naïve
+    // interpolation would break any regex trying to extract the retro-scan
+    // marker from the reasoning field later.
+    await applyDowngrade(
+      makeVerdict() as never,
+      {
+        source_subject: 'Microsoft AI\n(subsidiary "A")\n— ref Q125891217',
+        subjects_match: false,
+        confidence: 0.9,
+        reasoning: 'r',
+      },
+      'Microsoft Corporation',
+      'https://u',
+    );
+    const body = mockStoreVerdict.mock.calls[0][0] as Record<string, unknown>;
+    const reasoning = String(body.reasoning);
+    // No raw newlines inside the bracketed prefix
+    const prefix = reasoning.split(']')[0] + ']';
+    expect(prefix).not.toContain('\n');
+    // Double-quotes replaced with single quotes so the literal delimiters stay unambiguous
+    expect(prefix).not.toMatch(/"[A-Za-z]+\s*"[A-Za-z]+/);
+    expect(prefix).toContain("Microsoft AI (subsidiary 'A')");
   });
 
   it('does not throw when evidence write fails (best-effort audit row)', async () => {

--- a/crux/commands/sourcing-retro-scan-subjects.test.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Tests for sourcing-retro-scan-subjects (QUA-650).
+ *
+ * Focus:
+ *   - prompt construction (subject-identity only, no value re-verification)
+ *   - LLM response parsing (schema validation, malformed input)
+ *   - classifyEvidence (deterministic skip logic)
+ *   - applyDowngrade (verdict + reasoning prefix + needsRecheck + evidence row)
+ *   - end-to-end dry-run path (no LLM call)
+ *   - end-to-end apply path (mismatch triggers downgrade)
+ *
+ * Uses mocks so no real wiki-server / LLM calls occur.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync, existsSync, unlinkSync } from 'node:fs';
+
+const mockListVerdicts = vi.fn();
+const mockStoreVerdict = vi.fn();
+const mockGetEvidenceByRecords = vi.fn();
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
+  listVerdicts: (...args: unknown[]) => mockListVerdicts(...args),
+  storeVerdict: (...args: unknown[]) => mockStoreVerdict(...args),
+  getEvidenceByRecords: (...args: unknown[]) => mockGetEvidenceByRecords(...args),
+  evidenceRecordKey: (rt: string, rid: string) => `${rt}|${rid}`,
+}));
+
+const mockCallLlm = vi.fn();
+vi.mock('../lib/llm.ts', async () => {
+  const actual = await vi.importActual<typeof import('../lib/llm.ts')>('../lib/llm.ts');
+  return {
+    ...actual,
+    createLlmClient: vi.fn(() => ({})),
+    callLlm: (...args: unknown[]) => mockCallLlm(...args),
+  };
+});
+
+const mockFetchSourceContent = vi.fn();
+const mockStoreSourcingEvidence = vi.fn();
+vi.mock('../lib/sourcing/index.ts', async () => {
+  const actual = await vi.importActual<typeof import('../lib/sourcing/index.ts')>(
+    '../lib/sourcing/index.ts',
+  );
+  return {
+    ...actual,
+    fetchSourceContent: (...args: unknown[]) => mockFetchSourceContent(...args),
+    storeSourcingEvidence: (...args: unknown[]) => mockStoreSourcingEvidence(...args),
+  };
+});
+
+import {
+  commands,
+  buildSubjectIdentityPrompt,
+  callSubjectIdentityCheck,
+  classifyEvidence,
+  applyDowngrade,
+  SubjectCheckSchema,
+} from './sourcing-retro-scan-subjects.ts';
+
+const retroScan = commands.default;
+
+function makeVerdict(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    recordType: 'fact',
+    recordId: 'f_QYAnAj3qg6',
+    fieldName: null,
+    entityId: 'microsoft',
+    displayName: 'Microsoft CEO fact',
+    entityDisplayName: 'Microsoft Corporation',
+    verdict: 'confirmed',
+    confidence: 0.95,
+    reasoning: 'Source directly states that Mustafa Süleyman is CEO of Microsoft AI.',
+    sourcesChecked: 1,
+    needsRecheck: false,
+    nextCheckDue: '2026-07-16',
+    lastComputedAt: '2026-04-16',
+    createdAt: '2026-04-10',
+    updatedAt: '2026-04-16',
+    ...overrides,
+  };
+}
+
+function makeEvidence(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    recordType: 'fact',
+    recordId: 'f_QYAnAj3qg6',
+    sourceUrl: 'https://www.wikidata.org/wiki/Q125891217',
+    checkerModel: 'claude-haiku-4-5-20251001',
+    verdict: 'confirmed',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Unit tests ───────────────────────────────────────────────────────
+
+describe('buildSubjectIdentityPrompt', () => {
+  it('includes the claim subject, source URL, and truncated source content', () => {
+    const prompt = buildSubjectIdentityPrompt({
+      claimSubjectLabel: 'Microsoft Corporation',
+      recordType: 'fact',
+      fieldName: null,
+      recordLabel: 'ceo = Mustafa Süleyman',
+      sourceUrl: 'https://wikidata.org/wiki/Q125891217',
+      sourceContent: 'A'.repeat(20_000),
+      previousReasoning: 'Old reasoning',
+      maxContentChars: 1000,
+    });
+    expect(prompt).toContain('Microsoft Corporation');
+    expect(prompt).toContain('https://wikidata.org/wiki/Q125891217');
+    expect(prompt).toContain('"subjects_match": true | false');
+    expect(prompt).toContain('Old reasoning');
+    // Source content was truncated to 1000
+    const aRun = prompt.match(/A{1000,}/);
+    expect(aRun?.[0].length).toBeLessThanOrEqual(1000);
+  });
+
+  it('escapes XML-special chars in interpolated fields (prompt injection defense)', () => {
+    const prompt = buildSubjectIdentityPrompt({
+      claimSubjectLabel: 'Evil <script>alert("x")</script>',
+      recordType: 'fact',
+      fieldName: 'ceo & cfo',
+      recordLabel: 'mal <bogus> label',
+      sourceUrl: 'https://example.com',
+      sourceContent: '<malicious>injection</malicious>',
+      previousReasoning: 'Prior <eval>',
+      maxContentChars: 1000,
+    });
+    expect(prompt).not.toContain('<script>alert');
+    expect(prompt).toContain('&lt;script&gt;');
+    expect(prompt).toContain('&lt;malicious&gt;');
+    expect(prompt).toContain('ceo &amp; cfo');
+  });
+
+  it('omits previous reasoning block when none is supplied', () => {
+    const prompt = buildSubjectIdentityPrompt({
+      claimSubjectLabel: 'X',
+      recordType: 'fact',
+      fieldName: null,
+      recordLabel: 'r',
+      sourceUrl: 'https://u',
+      sourceContent: 'c',
+      previousReasoning: null,
+      maxContentChars: 500,
+    });
+    expect(prompt).toContain('(none recorded)');
+  });
+});
+
+describe('SubjectCheckSchema', () => {
+  it('parses a valid LLM response', () => {
+    const parsed = SubjectCheckSchema.safeParse({
+      source_subject: 'Microsoft AI',
+      subjects_match: false,
+      confidence: 0.9,
+      reasoning: 'Source is about Microsoft AI subsidiary.',
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.subjects_match).toBe(false);
+      expect(parsed.data.source_subject).toBe('Microsoft AI');
+    }
+  });
+
+  it('rejects a response missing subjects_match (required)', () => {
+    const parsed = SubjectCheckSchema.safeParse({
+      source_subject: 'Foo',
+      confidence: 0.5,
+      reasoning: '',
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('defaults optional fields when absent', () => {
+    const parsed = SubjectCheckSchema.safeParse({ subjects_match: true });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.source_subject).toBe('');
+      expect(parsed.data.confidence).toBe(0.5);
+      expect(parsed.data.reasoning).toBe('');
+    }
+  });
+});
+
+describe('callSubjectIdentityCheck', () => {
+  it('returns ok on a well-formed JSON response', async () => {
+    mockCallLlm.mockResolvedValueOnce({
+      text: '{"source_subject":"Microsoft AI","subjects_match":false,"confidence":0.95,"reasoning":"Source is Microsoft AI, not Microsoft Corp."}',
+    });
+    const res = await callSubjectIdentityCheck({} as never, 'prompt', 'label');
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.data.subjects_match).toBe(false);
+      expect(res.data.source_subject).toBe('Microsoft AI');
+    }
+  });
+
+  it('returns an error when LLM throws', async () => {
+    mockCallLlm.mockRejectedValueOnce(new Error('Anthropic 500'));
+    const res = await callSubjectIdentityCheck({} as never, 'prompt', 'label');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('LLM call failed');
+      expect(res.error).toContain('Anthropic 500');
+    }
+  });
+
+  it('returns an error when the response fails schema validation', async () => {
+    mockCallLlm.mockResolvedValueOnce({ text: '{"source_subject":"X"}' }); // missing subjects_match
+    const res = await callSubjectIdentityCheck({} as never, 'prompt', 'label');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('failed validation');
+  });
+});
+
+describe('classifyEvidence', () => {
+  it('marks rows whose every evidence is from a deterministic checker as skip', async () => {
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        evidenceByKey: {
+          'fact|f_detA': [
+            makeEvidence({ checkerModel: 'wikidata-api' }),
+            makeEvidence({ checkerModel: 'deterministic-row-match' }),
+          ],
+          'fact|f_llmA': [makeEvidence({ checkerModel: 'claude-haiku-4-5-20251001' })],
+        },
+      },
+    });
+    const res = await classifyEvidence([
+      makeVerdict({ recordId: 'f_detA' }) as never,
+      makeVerdict({ recordId: 'f_llmA' }) as never,
+    ]);
+    expect(res.get('fact|f_detA')).toEqual({ skip: 'deterministic' });
+    expect(res.get('fact|f_llmA')).toEqual({ sourceUrl: 'https://www.wikidata.org/wiki/Q125891217' });
+  });
+
+  it('omits records with no evidence entirely (caller treats as skip:no-source-url)', async () => {
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: { evidenceByKey: {} },
+    });
+    const res = await classifyEvidence([makeVerdict() as never]);
+    expect(res.size).toBe(0);
+  });
+
+  it('prefers the most recent non-deterministic evidence when both exist', async () => {
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        evidenceByKey: {
+          'fact|f_mixed': [
+            makeEvidence({ checkerModel: 'wikidata-api', sourceUrl: 'https://wd/deterministic' }),
+            makeEvidence({ checkerModel: 'claude-haiku-4-5-20251001', sourceUrl: 'https://llm/source' }),
+          ],
+        },
+      },
+    });
+    const res = await classifyEvidence([makeVerdict({ recordId: 'f_mixed' }) as never]);
+    // Picks the first non-deterministic row — the LLM-sourced URL, since
+    // the wikidata-api row is filtered out as deterministic. That's the
+    // target we want: the row with the subject-identity defect potential.
+    expect(res.get('fact|f_mixed')).toEqual({ sourceUrl: 'https://llm/source' });
+  });
+
+  it('throws on batch evidence fetch failure (fail-loud, per QUA-331 rationale)', async () => {
+    mockGetEvidenceByRecords.mockResolvedValueOnce({ ok: false, message: 'boom' });
+    await expect(classifyEvidence([makeVerdict() as never])).rejects.toThrow(/boom/);
+  });
+
+  it('returns empty map without API call when verdict list is empty', async () => {
+    const res = await classifyEvidence([]);
+    expect(res.size).toBe(0);
+    expect(mockGetEvidenceByRecords).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyDowngrade', () => {
+  it('persists verdict=partial + needsRecheck=true + prefixed reasoning', async () => {
+    mockStoreVerdict.mockResolvedValueOnce({ ok: true, data: { ok: true } });
+    mockStoreSourcingEvidence.mockResolvedValueOnce(undefined);
+
+    const verdict = makeVerdict();
+    await applyDowngrade(
+      verdict as never,
+      {
+        source_subject: 'Microsoft AI',
+        subjects_match: false,
+        confidence: 0.9,
+        reasoning: 'Wikidata page is Microsoft AI (Q125891217), not Microsoft Corp (Q2283).',
+      },
+      'Microsoft Corporation',
+      'https://www.wikidata.org/wiki/Q125891217',
+    );
+
+    expect(mockStoreVerdict).toHaveBeenCalledOnce();
+    const body = mockStoreVerdict.mock.calls[0][0] as Record<string, unknown>;
+    expect(body.verdict).toBe('partial');
+    expect(body.needsRecheck).toBe(true);
+    expect(body.recordType).toBe('fact');
+    expect(body.recordId).toBe('f_QYAnAj3qg6');
+    expect(body.entityId).toBe('microsoft');
+    expect(body.displayName).toBe('Microsoft CEO fact');
+    expect(body.entityDisplayName).toBe('Microsoft Corporation');
+    expect(body.sourcesChecked).toBe(1);
+    expect(String(body.reasoning)).toMatch(/^\[retro-scan QUA-650: subject-mismatch/);
+    expect(String(body.reasoning)).toContain('Microsoft AI');
+    // Original reasoning preserved after the prefix
+    expect(String(body.reasoning)).toContain('Mustafa Süleyman');
+
+    expect(mockStoreSourcingEvidence).toHaveBeenCalledOnce();
+    const evBody = mockStoreSourcingEvidence.mock.calls[0][0] as Record<string, unknown>;
+    expect(evBody.checkerModel).toBe('qua650-retro-scan-subject-identity');
+    expect(evBody.verdict).toBe('partial');
+    expect(evBody.extractedValue).toContain('Microsoft AI');
+  });
+
+  it('throws when the verdict-upsert API reports !ok', async () => {
+    mockStoreVerdict.mockResolvedValueOnce({ ok: false, error: 'db down' });
+    await expect(
+      applyDowngrade(
+        makeVerdict() as never,
+        { source_subject: 's', subjects_match: false, confidence: 0.5, reasoning: 'r' },
+        'Claim',
+        'https://u',
+      ),
+    ).rejects.toThrow(/db down/);
+    expect(mockStoreSourcingEvidence).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when evidence write fails (best-effort audit row)', async () => {
+    mockStoreVerdict.mockResolvedValueOnce({ ok: true, data: { ok: true } });
+    mockStoreSourcingEvidence.mockRejectedValueOnce(new Error('evidence table down'));
+
+    await expect(
+      applyDowngrade(
+        makeVerdict() as never,
+        { source_subject: 's', subjects_match: false, confidence: 0.5, reasoning: 'r' },
+        'Claim',
+        'https://u',
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ── End-to-end (command invocation) ─────────────────────────────────
+
+describe('retroScan command', () => {
+  const tempReports: string[] = [];
+  afterEach(() => {
+    for (const p of tempReports) {
+      if (existsSync(p)) unlinkSync(p);
+    }
+    tempReports.length = 0;
+  });
+
+  it('dry-run returns a preview without calling the LLM', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 9578 },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: { evidenceByKey: { 'fact|f_QYAnAj3qg6': [makeEvidence()] } },
+    });
+
+    const result = await retroScan([], { limit: '1', 'dry-run': true, ci: true } as never);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.totalMatching).toBe(9578);
+    expect(parsed.wouldCheck).toBe(1);
+    expect(mockCallLlm).not.toHaveBeenCalled();
+  });
+
+  it('--apply path downgrades a mismatched confirmed verdict', async () => {
+    const reportPath = `/tmp/qua650-test-${Date.now()}.jsonl`;
+    tempReports.push(reportPath);
+
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 1 },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: { evidenceByKey: { 'fact|f_QYAnAj3qg6': [makeEvidence()] } },
+    });
+    mockFetchSourceContent.mockResolvedValueOnce({
+      content: 'Microsoft AI is led by Mustafa Süleyman as of March 2024.',
+    });
+    mockCallLlm.mockResolvedValueOnce({
+      text: '{"source_subject":"Microsoft AI","subjects_match":false,"confidence":0.95,"reasoning":"Source is about Microsoft AI, not Microsoft Corp."}',
+    });
+    mockStoreVerdict.mockResolvedValueOnce({ ok: true, data: { ok: true } });
+    mockStoreSourcingEvidence.mockResolvedValueOnce(undefined);
+
+    const result = await retroScan([], {
+      limit: '1',
+      apply: true,
+      concurrency: '1',
+      report: reportPath,
+      ci: true,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.mismatches).toBe(1);
+    expect(parsed.summary.downgraded).toBe(1);
+    expect(parsed.summary.errors).toBe(0);
+
+    expect(mockStoreVerdict).toHaveBeenCalledOnce();
+    const body = mockStoreVerdict.mock.calls[0][0] as Record<string, unknown>;
+    expect(body.verdict).toBe('partial');
+    expect(body.needsRecheck).toBe(true);
+
+    // JSONL report written
+    expect(existsSync(reportPath)).toBe(true);
+    const lines = readFileSync(reportPath, 'utf-8').split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(3); // header + outcome + trailer
+    const header = JSON.parse(lines[0]);
+    expect(header.kind).toBe('qua650-retro-scan-header');
+    const trailer = JSON.parse(lines[lines.length - 1]);
+    expect(trailer.kind).toBe('qua650-retro-scan-trailer');
+    expect(trailer.summary.downgraded).toBe(1);
+  });
+
+  it('--scan-only runs LLM but does not persist downgrades', async () => {
+    const reportPath = `/tmp/qua650-test-scan-only-${Date.now()}.jsonl`;
+    tempReports.push(reportPath);
+
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 1 },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: { evidenceByKey: { 'fact|f_QYAnAj3qg6': [makeEvidence()] } },
+    });
+    mockFetchSourceContent.mockResolvedValueOnce({ content: 'Microsoft AI content' });
+    mockCallLlm.mockResolvedValueOnce({
+      text: '{"source_subject":"Microsoft AI","subjects_match":false,"confidence":0.9,"reasoning":"r"}',
+    });
+
+    const result = await retroScan([], {
+      limit: '1',
+      'scan-only': true,
+      concurrency: '1',
+      report: reportPath,
+      ci: true,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.mismatches).toBe(1);
+    expect(parsed.summary.downgraded).toBe(0);
+    // CRITICAL: no writes in scan-only mode even when mismatches found.
+    expect(mockStoreVerdict).not.toHaveBeenCalled();
+    expect(mockStoreSourcingEvidence).not.toHaveBeenCalled();
+  });
+
+  it('leaves matching subjects alone (no downgrade)', async () => {
+    const reportPath = `/tmp/qua650-test-match-${Date.now()}.jsonl`;
+    tempReports.push(reportPath);
+
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 1 },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: { evidenceByKey: { 'fact|f_QYAnAj3qg6': [makeEvidence()] } },
+    });
+    mockFetchSourceContent.mockResolvedValueOnce({ content: 'Microsoft Corp is a software company.' });
+    mockCallLlm.mockResolvedValueOnce({
+      text: '{"source_subject":"Microsoft Corporation","subjects_match":true,"confidence":0.92,"reasoning":"Page is about MSFT."}',
+    });
+
+    const result = await retroScan([], {
+      limit: '1',
+      apply: true,
+      concurrency: '1',
+      report: reportPath,
+      ci: true,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.matches).toBe(1);
+    expect(parsed.summary.mismatches).toBe(0);
+    expect(parsed.summary.downgraded).toBe(0);
+    expect(mockStoreVerdict).not.toHaveBeenCalled();
+  });
+
+  it('skips rows whose only claim subject is a raw sid_ (display-name leak, QUA-407)', async () => {
+    const reportPath = `/tmp/qua650-test-sid-${Date.now()}.jsonl`;
+    tempReports.push(reportPath);
+
+    // entityDisplayName / displayName both fall back to entityId, which is a raw sid_.
+    // The LLM would always say "mismatch" ("X is an opaque id") if we ran this — so
+    // we must skip to avoid false-downgrading verdicts whose only defect is the
+    // stale *_display_name cache.
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          makeVerdict({
+            recordId: 'f_sid_leak',
+            entityId: 'sid_GLXKjYAEKw',
+            displayName: null,
+            entityDisplayName: null,
+          }),
+        ],
+        total: 1,
+      },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        evidenceByKey: {
+          'fact|f_sid_leak': [makeEvidence({ checkerModel: 'claude-haiku-4-5-20251001' })],
+        },
+      },
+    });
+
+    const result = await retroScan([], {
+      limit: '1',
+      apply: true,
+      concurrency: '1',
+      report: reportPath,
+      ci: true,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.skipped).toBe(1);
+    expect(parsed.summary.scanned).toBe(0);
+    expect(mockFetchSourceContent).not.toHaveBeenCalled();
+    expect(mockCallLlm).not.toHaveBeenCalled();
+    expect(mockStoreVerdict).not.toHaveBeenCalled();
+  });
+
+  it('skips deterministic-checker rows without fetching source or calling LLM', async () => {
+    const reportPath = `/tmp/qua650-test-det-${Date.now()}.jsonl`;
+    tempReports.push(reportPath);
+
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ recordId: 'f_det' })], total: 1 },
+    });
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        evidenceByKey: {
+          'fact|f_det': [makeEvidence({ checkerModel: 'wikidata-api' })],
+        },
+      },
+    });
+
+    const result = await retroScan([], {
+      limit: '1',
+      apply: true,
+      concurrency: '1',
+      report: reportPath,
+      ci: true,
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.skipped).toBe(1);
+    expect(parsed.summary.scanned).toBe(0);
+    expect(mockFetchSourceContent).not.toHaveBeenCalled();
+    expect(mockCallLlm).not.toHaveBeenCalled();
+    expect(mockStoreVerdict).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid --limit / --budget / --max-content', async () => {
+    const tests: Array<[Record<string, unknown>, string]> = [
+      [{ limit: '0' }, '--limit'],
+      [{ limit: 'abc' }, '--limit'],
+      [{ offset: '-1' }, '--offset'],
+      [{ budget: '0' }, '--budget'],
+      [{ 'max-content': '100' }, '--max-content'],
+    ];
+    for (const [opts, needle] of tests) {
+      const result = await retroScan([], { apply: true, ...opts } as never);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain(needle);
+    }
+  });
+
+  it('caps effective limit by --budget (cost control)', async () => {
+    // budget=$0.003 → max 1 call at $0.003/check
+    mockListVerdicts.mockResolvedValueOnce({ ok: true, data: { verdicts: [], total: 0 } });
+
+    await retroScan([], { limit: '100', budget: '0.003', 'dry-run': true, ci: true } as never);
+    // listVerdicts should have been called with limit <= 1 on the first page
+    const firstCall = mockListVerdicts.mock.calls[0][0] as Record<string, unknown>;
+    expect(firstCall.limit).toBeLessThanOrEqual(1);
+  });
+});

--- a/crux/commands/sourcing-retro-scan-subjects.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.ts
@@ -1,0 +1,850 @@
+/**
+ * Source-Check Retro-Scan: Subject-Identity Mismatch (QUA-650)
+ *
+ * Re-examines every existing `confirmed` verdict in `source_check_verdicts`
+ * through a lightweight LLM check that only asks: "does the source's primary
+ * subject match the claim's subject?" Any row flagged as a mismatch is
+ * downgraded to `partial` and marked `needsRecheck=true`, queuing it for a
+ * full re-verification via `crux sourcing-recheck`.
+ *
+ * Follow-up to QUA-648, which fixed the prompt/response shape so future
+ * sourcing checks can't false-confirm on subject-identity mismatches (e.g.
+ * "Microsoft CEO" sourced from a "Microsoft AI" Wikidata page). Existing
+ * confirmed rows were written before that fix — this command catches them.
+ *
+ * Usage:
+ *   crux sourcing-retro-scan-subjects --dry-run        Preview what would be checked
+ *   crux sourcing-retro-scan-subjects --limit=50       Sample 50 rows (with LLM)
+ *   crux sourcing-retro-scan-subjects --apply          Actually persist downgrades
+ *   crux sourcing-retro-scan-subjects --apply --budget=35 --record-type=personnel
+ *
+ * Writes a JSONL report to the path given by `--report=` (default:
+ * `/tmp/qua650-retro-scan-<timestamp>.jsonl`) so batch runs can be audited
+ * and resumed post-hoc.
+ */
+
+import { writeFileSync, appendFileSync } from 'node:fs';
+import { z } from 'zod';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import {
+  listVerdicts,
+  storeVerdict as storeVerdictRpc,
+  getEvidenceByRecords,
+  evidenceRecordKey,
+  type VerdictListEntry,
+} from '../lib/wiki-server/sourcing-client.ts';
+import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
+import { parseJsonResponse } from '../lib/anthropic.ts';
+import {
+  fetchSourceContent,
+  storeSourcingEvidence,
+} from '../lib/sourcing/index.ts';
+import { escapeXml } from '../lib/prompt-utils.ts';
+import {
+  clampSourcingConcurrency,
+  DEFAULT_SOURCING_CONCURRENCY,
+} from '../lib/sourcing/concurrency.ts';
+import type { SourcingVerdict, RecordType } from '../../apps/wiki-server/src/api-types.ts';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const LOG_PREFIX = '[retro-scan-subjects]';
+
+/** Checker-model strings that are deterministic (QID / OpenAlex / dead-link / ...).
+ *  Deterministic matches cannot have the subject-identity defect — their "match"
+ *  is an exact ID compare, not an LLM judgement — so we skip them to save cost
+ *  and avoid false-flag downgrades. */
+const DETERMINISTIC_CHECKER_MODELS = new Set([
+  'wikidata-api',
+  'deterministic-row-match',
+  'dead-link-detector',
+  'relevance-gate',
+  'openalex-matcher',
+]);
+
+/** Mirrors `isSid()` from `@longterm-wiki/id-utils` without the package dep.
+ *  A stableId is `sid_` + exactly 10 alphanumeric chars. We use this to skip
+ *  rows whose resolved "claim subject" is a raw stableId — the LLM can't
+ *  judge subject-identity against an opaque id (it would always say "no match")
+ *  and those rows are affected by a different bug (display-name cache leak,
+ *  QUA-407). */
+const SID_RE = /^sid_[A-Za-z0-9]{10}$/;
+
+/** Haiku is cheap but the response shape is small; 200 tokens is plenty. */
+const MAX_RESPONSE_TOKENS = 250;
+
+/** Keep the source-content slice small — subject-identity is usually decidable
+ *  from the first few paragraphs, and this keeps cost close to the ticket's
+ *  $0.005/call estimate. Operators can tune via `--max-content`. */
+const DEFAULT_MAX_CONTENT_CHARS = 10_000;
+
+/** Rough Haiku cost at 10K-char content + 200-token response. Used for budget
+ *  caps and dry-run estimates — not a precise meter. */
+const ESTIMATED_COST_PER_CHECK = 0.003;
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface RetroScanOptions extends BaseOptions {
+  limit?: string;
+  offset?: string;
+  budget?: string;
+  'record-type'?: string;
+  recordType?: string;
+  concurrency?: string;
+  'max-content'?: string;
+  maxContent?: string;
+  report?: string;
+  'dry-run'?: boolean;
+  dryRun?: boolean;
+  apply?: boolean;
+  'scan-only'?: boolean;
+  scanOnly?: boolean;
+  ci?: boolean;
+}
+
+/** LLM response schema for the subject-identity check. Deliberately narrow —
+ *  we are NOT re-verifying the claim value, only whether the source's subject
+ *  is the same entity as the claim's subject. */
+export const SubjectCheckSchema = z.object({
+  source_subject: z.string().default(''),
+  subjects_match: z.boolean(),
+  confidence: z.number().min(0).max(1).default(0.5),
+  reasoning: z.string().default(''),
+});
+
+export type SubjectCheckResult = z.infer<typeof SubjectCheckSchema>;
+
+interface ScanRowOutcome {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  entityId: string | null;
+  sourceUrl: string | null;
+  /** One of: 'mismatch' | 'match' | 'skip:<reason>' | 'error:<code>' */
+  status: string;
+  sourceSubject?: string;
+  claimSubject?: string;
+  confidence?: number;
+  reasoning?: string;
+  applied?: boolean;
+  errorMessage?: string;
+}
+
+interface ScanSummary {
+  totalConsidered: number;
+  scanned: number;
+  mismatches: number;
+  matches: number;
+  skipped: number;
+  /** Source-content cache misses (not_cached, fetch_error). Reported
+   *  separately from real errors because they're a known-operational state —
+   *  the resource-ingest pipeline processes these asynchronously and a later
+   *  retro-scan pass will pick them up. Does NOT fail the exit code. */
+  fetchMisses: number;
+  /** Real errors: LLM failures, downgrade-write failures. Fails exit code. */
+  errors: number;
+  downgraded: number;
+  downgradeErrors: number;
+  budgetExhausted: boolean;
+  estimatedCost: number;
+}
+
+// ── Prompt construction ──────────────────────────────────────────────
+
+/**
+ * Build a compact subject-identity prompt. Only asks whether the source's
+ * primary subject matches the claim's — NOT whether the claimed value is
+ * correct. The prompt mirrors the language of the shared
+ * `prompt-guidelines.ts::Subject-identity mismatch` rule so the LLM's
+ * judgement is consistent with the forward-going sourcing pipeline (QUA-648).
+ *
+ * All user-controlled fields (entity names, reasoning text, source content)
+ * are wrapped in XML tags and escaped with `escapeXml` to prevent prompt
+ * injection. See .claude/rules/llm-prompt-safety.md.
+ */
+export function buildSubjectIdentityPrompt(params: {
+  claimSubjectLabel: string;
+  recordType: string;
+  fieldName: string | null;
+  recordLabel: string;
+  sourceUrl: string;
+  sourceContent: string;
+  previousReasoning: string | null;
+  maxContentChars: number;
+}): string {
+  const content = params.sourceContent.slice(0, params.maxContentChars);
+  const previousReasoning = params.previousReasoning?.slice(0, 600) ?? '';
+
+  return `You are checking whether a web source is actually about the same entity that a claim is about.
+
+You are NOT being asked to verify the claim value itself. Only answer:
+is the source's primary subject the same entity as the claim's subject?
+
+Per the standing sourcing guideline (QUA-648):
+- Subsidiaries, parent companies, products, namesakes, and similarly-named-but-different organizations all count as MISMATCHES.
+- Name overlap alone is not enough (e.g. "OpenAI" confirming something about "OpenAI Japan" is a MISMATCH).
+- When in doubt, prefer MISMATCH.
+
+<claim>
+<subject>${escapeXml(params.claimSubjectLabel)}</subject>
+<record_type>${escapeXml(params.recordType)}</record_type>
+<record_label>${escapeXml(params.recordLabel)}</record_label>
+${params.fieldName ? `<field_name>${escapeXml(params.fieldName)}</field_name>\n` : ''}</claim>
+
+<source_url>${escapeXml(params.sourceUrl)}</source_url>
+
+<previous_verification_reasoning>
+${escapeXml(previousReasoning) || '(none recorded)'}
+</previous_verification_reasoning>
+
+<source_content>
+${escapeXml(content)}
+</source_content>
+
+Respond with ONLY a JSON object (no markdown fences):
+{
+  "source_subject": "Name the primary entity/subject this source is actually about (be specific — e.g. 'Microsoft AI', not just 'Microsoft'). If the source is unreadable or off-topic, say so.",
+  "subjects_match": true | false,
+  "confidence": 0.0 to 1.0,
+  "reasoning": "One or two sentences explaining your decision."
+}`;
+}
+
+// ── LLM call + parsing ───────────────────────────────────────────────
+
+/**
+ * Run the subject-identity LLM call. Returns the parsed result or an error.
+ * The caller is responsible for fetch + storage; this function is pure
+ * LLM-in / verdict-judgement-out.
+ */
+export async function callSubjectIdentityCheck(
+  client: ReturnType<typeof createLlmClient>,
+  prompt: string,
+  retryLabel: string,
+): Promise<{ ok: true; data: SubjectCheckResult } | { ok: false; error: string }> {
+  let raw: unknown;
+  try {
+    const result = await callLlm(client, prompt, {
+      model: MODELS.haiku,
+      maxTokens: MAX_RESPONSE_TOKENS,
+      temperature: 0,
+      retryLabel,
+    });
+    raw = parseJsonResponse(result.text);
+  } catch (e: unknown) {
+    return { ok: false, error: `LLM call failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  const parsed = SubjectCheckSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: `LLM response failed validation: ${parsed.error.message}` };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+// ── Evidence pre-filter ──────────────────────────────────────────────
+
+/**
+ * For a batch of verdicts, fetch the most recent evidence row per record and
+ * decide whether the row should be skipped (deterministic checker) or scanned.
+ *
+ * Returns a map keyed by `recordKey(rt, rid)` with either `{ skip: 'deterministic' }`
+ * or `{ sourceUrl }`. Records with no evidence at all end up absent from the
+ * map and are treated as "skip: no-source" by the caller.
+ */
+export async function classifyEvidence(
+  verdicts: VerdictListEntry[],
+): Promise<Map<string, { skip: 'deterministic' } | { sourceUrl: string }>> {
+  const out = new Map<string, { skip: 'deterministic' } | { sourceUrl: string }>();
+  if (verdicts.length === 0) return out;
+
+  const response = await getEvidenceByRecords(
+    verdicts.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
+    { limitPerRecord: 5 },
+  );
+  if (!response.ok) {
+    throw new Error(`Batch evidence fetch failed: ${response.message ?? 'unknown error'}`);
+  }
+
+  for (const [key, rows] of Object.entries(response.data.evidenceByKey)) {
+    // Prefer the most recent evidence row with a sourceUrl as the scan target.
+    // If *every* evidence row is from a deterministic checker, we can skip
+    // outright — those matchers check exact IDs and are immune to the
+    // subject-identity defect.
+    const withUrl = rows.filter((r) => r.sourceUrl);
+    if (withUrl.length === 0) continue;
+
+    const nonDeterministic = withUrl.find(
+      (r) => !r.checkerModel || !DETERMINISTIC_CHECKER_MODELS.has(r.checkerModel),
+    );
+    if (!nonDeterministic) {
+      out.set(key, { skip: 'deterministic' });
+      continue;
+    }
+    const sourceUrl = nonDeterministic.sourceUrl;
+    if (sourceUrl) out.set(key, { sourceUrl });
+  }
+  return out;
+}
+
+// ── Persisting a downgrade ───────────────────────────────────────────
+
+/**
+ * Apply the `confirmed → partial` + `needsRecheck=true` downgrade for a single
+ * verdict, and write an audit evidence row documenting the retro-scan finding.
+ *
+ * Preserves entityId / displayName / entityDisplayName / sourcesChecked from
+ * the prior verdict so the row doesn't lose its context. The new reasoning is
+ * prefixed with `[retro-scan QUA-650: subject-mismatch — ...]` so future
+ * operators can trace the downgrade without re-reading the JSONL report.
+ */
+export async function applyDowngrade(
+  verdict: VerdictListEntry,
+  check: SubjectCheckResult,
+  claimSubjectLabel: string,
+  sourceUrl: string,
+): Promise<void> {
+  const originalReasoning = verdict.reasoning ?? '';
+  const sourceSubject = check.source_subject.trim() || '(unnamed)';
+  const mismatchPrefix = `[retro-scan QUA-650: subject-mismatch — source is about "${sourceSubject}", claim is about "${claimSubjectLabel}"]`;
+  const newReasoning = `${mismatchPrefix} ${originalReasoning}`.slice(0, 4900);
+
+  const body: Record<string, unknown> = {
+    recordType: verdict.recordType,
+    recordId: verdict.recordId,
+    verdict: 'partial',
+    confidence: check.confidence,
+    reasoning: newReasoning,
+    sourcesChecked: verdict.sourcesChecked,
+    needsRecheck: true,
+  };
+  if (verdict.fieldName != null) body.fieldName = verdict.fieldName;
+  if (verdict.entityId != null) body.entityId = verdict.entityId;
+  if (verdict.displayName != null) body.displayName = verdict.displayName;
+  if (verdict.entityDisplayName != null) body.entityDisplayName = verdict.entityDisplayName;
+
+  const response = await storeVerdictRpc(body);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to persist downgrade for ${verdict.recordType}/${verdict.recordId}: ${response.error}`,
+    );
+  }
+
+  // Write a best-effort audit evidence row. Don't fail the downgrade if the
+  // evidence write fails — the verdict change is the important part.
+  try {
+    await storeSourcingEvidence(
+      {
+        recordType: verdict.recordType as RecordType | 'fact',
+        recordId: verdict.recordId,
+        sourceUrl,
+        verdict: 'partial' as SourcingVerdict,
+        confidence: check.confidence,
+        extractedValue: `Source subject: ${sourceSubject}`,
+        reasoning: `QUA-650 retro-scan: ${check.reasoning}`.slice(0, 4900),
+        entityId: verdict.entityId,
+        checkerModel: 'qua650-retro-scan-subject-identity',
+        fieldName: verdict.fieldName,
+      },
+      LOG_PREFIX,
+    );
+  } catch (e: unknown) {
+    console.warn(
+      `${LOG_PREFIX} Evidence write failed for ${verdict.recordType}/${verdict.recordId}: ${e instanceof Error ? e.message : String(e)} (verdict downgrade persisted)`,
+    );
+  }
+}
+
+// ── Per-row processing ───────────────────────────────────────────────
+
+/**
+ * Run the full scan on one verdict row:
+ *   - resolve sourceUrl via pre-fetched map
+ *   - fetch source content
+ *   - build + run the subject-identity prompt
+ *   - if `apply` and mismatch, persist the downgrade
+ *
+ * Always returns an outcome — never throws, so the caller's concurrency pool
+ * can continue. Errors are captured in `outcome.status` / `outcome.errorMessage`.
+ */
+async function processVerdictRow(params: {
+  verdict: VerdictListEntry;
+  classification: { skip: 'deterministic' } | { sourceUrl: string } | undefined;
+  client: ReturnType<typeof createLlmClient>;
+  maxContentChars: number;
+  apply: boolean;
+}): Promise<ScanRowOutcome> {
+  const { verdict, classification, client, maxContentChars, apply } = params;
+  const base: ScanRowOutcome = {
+    recordType: verdict.recordType,
+    recordId: verdict.recordId,
+    fieldName: verdict.fieldName,
+    entityId: verdict.entityId,
+    sourceUrl: null,
+    status: '',
+  };
+
+  if (!classification) {
+    return { ...base, status: 'skip:no-source-url' };
+  }
+  if ('skip' in classification) {
+    return { ...base, status: `skip:${classification.skip}` };
+  }
+
+  const sourceUrl = classification.sourceUrl;
+  base.sourceUrl = sourceUrl;
+
+  const claimSubjectLabel =
+    verdict.entityDisplayName ??
+    verdict.displayName ??
+    verdict.entityId ??
+    `${verdict.recordType}/${verdict.recordId}`;
+
+  // Safety guard: if the only "subject" we have is a raw stableId (sid_...),
+  // we cannot meaningfully ask the LLM "does the source subject match X?" —
+  // the LLM will always say "no, X is an opaque id". That would falsely
+  // downgrade verdicts whose only defect is a stale `*_display_name` cache
+  // (tracked by validate-sid-display / QUA-407). Skip such rows BEFORE
+  // fetching the source so we don't burn cache lookups either.
+  if (SID_RE.test(claimSubjectLabel)) {
+    return { ...base, status: 'skip:sid-display-name' };
+  }
+
+  const fetchResult = await fetchSourceContent(sourceUrl);
+  if (!fetchResult.content) {
+    return {
+      ...base,
+      status: `error:fetch:${fetchResult.errorType ?? 'unknown'}`,
+      errorMessage: fetchResult.errorMessage ?? 'Source content not cached',
+    };
+  }
+
+  const prompt = buildSubjectIdentityPrompt({
+    claimSubjectLabel,
+    recordType: verdict.recordType,
+    fieldName: verdict.fieldName,
+    recordLabel: verdict.displayName ?? verdict.recordId,
+    sourceUrl,
+    sourceContent: fetchResult.content,
+    previousReasoning: verdict.reasoning,
+    maxContentChars,
+  });
+
+  const checkResult = await callSubjectIdentityCheck(
+    client,
+    prompt,
+    `retro-scan-${verdict.recordType}-${verdict.recordId}`,
+  );
+  if (!checkResult.ok) {
+    return { ...base, status: 'error:llm', errorMessage: checkResult.error };
+  }
+
+  const check = checkResult.data;
+  const outcome: ScanRowOutcome = {
+    ...base,
+    status: check.subjects_match ? 'match' : 'mismatch',
+    sourceSubject: check.source_subject,
+    claimSubject: claimSubjectLabel,
+    confidence: check.confidence,
+    reasoning: check.reasoning,
+  };
+
+  if (!check.subjects_match && apply) {
+    try {
+      await applyDowngrade(verdict, check, claimSubjectLabel, sourceUrl);
+      outcome.applied = true;
+    } catch (e: unknown) {
+      outcome.status = 'error:downgrade';
+      outcome.errorMessage = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  return outcome;
+}
+
+// ── Pagination ───────────────────────────────────────────────────────
+
+const PAGE_SIZE = 200;
+const MAX_PAGES = 200; // Hard cap — (MAX_PAGES × PAGE_SIZE = 40,000 rows). If we
+                       // hit this, the server is returning bad pagination metadata.
+
+interface FetchOptions {
+  recordType?: string;
+  limit: number;
+  offset: number;
+}
+
+async function fetchConfirmedVerdicts(opts: FetchOptions): Promise<{
+  rows: VerdictListEntry[];
+  total: number;
+}> {
+  const collected: VerdictListEntry[] = [];
+  let serverTotal = 0;
+  let cursor = opts.offset;
+  let iterations = 0;
+  while (collected.length < opts.limit) {
+    if (iterations++ >= MAX_PAGES) {
+      throw new Error(`Pagination exceeded ${MAX_PAGES} pages — server may be returning malformed pagination metadata.`);
+    }
+    const pageSize = Math.min(PAGE_SIZE, opts.limit - collected.length);
+    const response = await listVerdicts({
+      verdict: 'confirmed',
+      recordType: opts.recordType,
+      limit: pageSize,
+      offset: cursor,
+    });
+    if (!response.ok) {
+      throw new Error(`listVerdicts failed: ${response.message}`);
+    }
+    serverTotal = response.data.total;
+    const rows = response.data.verdicts;
+    if (rows.length === 0) break;
+    collected.push(...rows);
+    cursor += rows.length;
+    if (cursor >= serverTotal) break;
+  }
+  return { rows: collected, total: serverTotal };
+}
+
+// ── Main command ─────────────────────────────────────────────────────
+
+async function retroScanCommand(
+  args: string[],
+  options: RetroScanOptions,
+): Promise<CommandResult> {
+  const scanOnly = options['scan-only'] === true || options.scanOnly === true;
+  const apply = options.apply === true && !scanOnly;
+  // Three modes:
+  //   default (no --apply, no --scan-only): fast preview; no LLM, no writes.
+  //   --scan-only:                          full LLM scan; no writes (pilot mode).
+  //   --apply:                              full LLM scan + persists downgrades.
+  const isPreview = !apply && !scanOnly;
+  const itemLimit = options.limit ? parseInt(String(options.limit), 10) : 50;
+  const offset = options.offset ? parseInt(String(options.offset), 10) : 0;
+  const budgetLimit = options.budget ? parseFloat(String(options.budget)) : 35.0;
+  const recordTypeFilter = (options['record-type'] ?? options.recordType) as string | undefined;
+  const maxContentChars = options['max-content'] || options.maxContent
+    ? parseInt(String(options['max-content'] ?? options.maxContent), 10)
+    : DEFAULT_MAX_CONTENT_CHARS;
+  const concurrency = clampSourcingConcurrency(options.concurrency ?? DEFAULT_SOURCING_CONCURRENCY);
+  const reportPath =
+    (options.report as string | undefined) ??
+    `/tmp/qua650-retro-scan-${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`;
+
+  if (!Number.isFinite(itemLimit) || itemLimit < 1) {
+    return { exitCode: 1, output: 'Invalid --limit: must be a positive integer.' };
+  }
+  if (!Number.isFinite(offset) || offset < 0) {
+    return { exitCode: 1, output: 'Invalid --offset: must be a non-negative integer.' };
+  }
+  if (!Number.isFinite(budgetLimit) || budgetLimit <= 0) {
+    return { exitCode: 1, output: 'Invalid --budget: must be a positive number.' };
+  }
+  if (!Number.isFinite(maxContentChars) || maxContentChars < 500) {
+    return { exitCode: 1, output: 'Invalid --max-content: must be an integer >= 500.' };
+  }
+
+  // Budget cap — apply after itemLimit
+  const maxByBudget = Math.floor(budgetLimit / ESTIMATED_COST_PER_CHECK);
+  const effectiveLimit = Math.min(itemLimit, maxByBudget);
+
+  const modeLabel = apply
+    ? '\x1b[31mAPPLY (will write)\x1b[0m'
+    : scanOnly
+    ? 'scan-only (LLM, no writes)'
+    : 'preview (no LLM, no writes)';
+  console.log('\x1b[1mSource-Check Retro-Scan: Subject-Identity (QUA-650)\x1b[0m');
+  console.log(`  Mode:        ${modeLabel}`);
+  console.log(`  Limit:       ${effectiveLimit}${maxByBudget < itemLimit ? ` (capped by --budget=$${budgetLimit})` : ''}`);
+  console.log(`  Offset:      ${offset}`);
+  console.log(`  Budget:      $${budgetLimit.toFixed(2)}`);
+  console.log(`  Concurrency: ${concurrency}`);
+  console.log(`  Content cap: ${maxContentChars} chars/row`);
+  if (recordTypeFilter) console.log(`  Type filter: ${recordTypeFilter}`);
+  console.log('');
+
+  // Step 1: fetch confirmed verdicts
+  let fetched: { rows: VerdictListEntry[]; total: number };
+  try {
+    fetched = await fetchConfirmedVerdicts({
+      recordType: recordTypeFilter,
+      limit: effectiveLimit,
+      offset,
+    });
+  } catch (e: unknown) {
+    return { exitCode: 1, output: `${LOG_PREFIX} ${e instanceof Error ? e.message : String(e)}` };
+  }
+  const { rows: verdicts, total: totalMatching } = fetched;
+
+  if (verdicts.length === 0) {
+    return { exitCode: 0, output: 'No confirmed verdicts found for the given filters.' };
+  }
+
+  const estimatedCost = verdicts.length * ESTIMATED_COST_PER_CHECK;
+  console.log(`Fetched ${verdicts.length} rows of ${totalMatching} confirmed (est. $${estimatedCost.toFixed(2)}).`);
+
+  // Step 2: classify evidence up-front (skip deterministic checkers)
+  let classifications: Map<string, { skip: 'deterministic' } | { sourceUrl: string }>;
+  try {
+    classifications = await classifyEvidence(verdicts);
+  } catch (e: unknown) {
+    return { exitCode: 1, output: `${LOG_PREFIX} ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  // Step 3: preview summary, or run the scan (scan-only or apply)
+  if (isPreview) {
+    return formatDryRunOutput(verdicts, classifications, totalMatching, estimatedCost, options);
+  }
+
+  // Prepare report file
+  writeFileSync(
+    reportPath,
+    JSON.stringify({
+      kind: 'qua650-retro-scan-header',
+      startedAt: new Date().toISOString(),
+      apply,
+      totalMatching,
+      fetched: verdicts.length,
+      offset,
+      recordTypeFilter: recordTypeFilter ?? null,
+      maxContentChars,
+      concurrency,
+    }) + '\n',
+  );
+
+  const client = createLlmClient();
+  const summary: ScanSummary = {
+    totalConsidered: totalMatching,
+    scanned: 0,
+    mismatches: 0,
+    matches: 0,
+    skipped: 0,
+    fetchMisses: 0,
+    errors: 0,
+    downgraded: 0,
+    downgradeErrors: 0,
+    budgetExhausted: false,
+    estimatedCost: 0,
+  };
+
+  const outcomes: ScanRowOutcome[] = [];
+
+  const processOne = async (v: VerdictListEntry): Promise<void> => {
+    const key = evidenceRecordKey(v.recordType, v.recordId);
+    const classification = classifications.get(key);
+
+    const outcome = await processVerdictRow({
+      verdict: v,
+      classification,
+      client,
+      maxContentChars,
+      apply,
+    });
+
+    outcomes.push(outcome);
+    appendFileSync(reportPath, JSON.stringify(outcome) + '\n');
+
+    if (outcome.status.startsWith('skip:')) {
+      summary.skipped++;
+    } else if (outcome.status === 'match') {
+      summary.matches++;
+      summary.scanned++;
+      summary.estimatedCost += ESTIMATED_COST_PER_CHECK;
+    } else if (outcome.status === 'mismatch') {
+      summary.mismatches++;
+      summary.scanned++;
+      summary.estimatedCost += ESTIMATED_COST_PER_CHECK;
+      if (outcome.applied) summary.downgraded++;
+    } else if (outcome.status === 'error:downgrade') {
+      summary.downgradeErrors++;
+      summary.scanned++;
+      summary.estimatedCost += ESTIMATED_COST_PER_CHECK;
+    } else if (outcome.status.startsWith('error:fetch')) {
+      // Cache miss is operational state, not a scan failure. Doesn't count
+      // toward errors (exit code) and doesn't incur LLM cost.
+      summary.fetchMisses++;
+    } else {
+      summary.errors++;
+      if (outcome.status.startsWith('error:llm')) summary.estimatedCost += ESTIMATED_COST_PER_CHECK;
+    }
+  };
+
+  console.log('');
+  console.log(`\x1b[1mScanning ${verdicts.length} rows (concurrency=${concurrency})...\x1b[0m`);
+
+  // Concurrency-limited loop (pattern borrowed from sourcing-orchestrate).
+  if (concurrency <= 1) {
+    for (const v of verdicts) {
+      if (summary.estimatedCost >= budgetLimit) {
+        summary.budgetExhausted = true;
+        break;
+      }
+      await processOne(v);
+    }
+  } else {
+    const executing = new Set<Promise<void>>();
+    for (const v of verdicts) {
+      if (summary.estimatedCost >= budgetLimit) {
+        summary.budgetExhausted = true;
+        break;
+      }
+      const p = processOne(v).finally(() => executing.delete(p));
+      executing.add(p);
+      if (executing.size >= concurrency) {
+        await Promise.race(executing);
+      }
+    }
+    await Promise.all(executing);
+  }
+
+  // Trailer
+  appendFileSync(
+    reportPath,
+    JSON.stringify({ kind: 'qua650-retro-scan-trailer', finishedAt: new Date().toISOString(), summary }) +
+      '\n',
+  );
+
+  const exitCode = summary.errors > 0 || summary.downgradeErrors > 0 ? 1 : 0;
+
+  if (options.ci) {
+    return { exitCode, output: JSON.stringify({ summary, reportPath, sampleOutcomes: outcomes.slice(0, 20) }) };
+  }
+  return { exitCode, output: formatSummaryOutput(summary, reportPath, outcomes) };
+}
+
+// ── Output formatting ────────────────────────────────────────────────
+
+function formatDryRunOutput(
+  verdicts: VerdictListEntry[],
+  classifications: Map<string, { skip: 'deterministic' } | { sourceUrl: string }>,
+  totalMatching: number,
+  estimatedCost: number,
+  options: RetroScanOptions,
+): CommandResult {
+  let withUrl = 0;
+  let deterministic = 0;
+  let noSource = 0;
+  const typeCounts = new Map<string, number>();
+  for (const v of verdicts) {
+    typeCounts.set(v.recordType, (typeCounts.get(v.recordType) ?? 0) + 1);
+    const c = classifications.get(evidenceRecordKey(v.recordType, v.recordId));
+    if (!c) noSource++;
+    else if ('skip' in c) deterministic++;
+    else withUrl++;
+  }
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({
+        totalMatching,
+        fetched: verdicts.length,
+        wouldCheck: withUrl,
+        wouldSkipDeterministic: deterministic,
+        wouldSkipNoSource: noSource,
+        estimatedCostAtFullFetch: estimatedCost,
+        byType: Object.fromEntries(typeCounts),
+      }),
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`\x1b[1mDry-run preview: ${verdicts.length} of ${totalMatching} confirmed verdicts\x1b[0m`);
+  lines.push(`  Would check (LLM):       ${withUrl}`);
+  lines.push(`  Would skip (deterministic): ${deterministic}`);
+  lines.push(`  Would skip (no source URL): ${noSource}`);
+  lines.push(`  Estimated cost (at ${verdicts.length} LLM calls): $${estimatedCost.toFixed(2)}`);
+  lines.push('');
+  lines.push('\x1b[1mBy record type:\x1b[0m');
+  for (const [type, cnt] of [...typeCounts.entries()].sort((a, b) => b[1] - a[1])) {
+    lines.push(`  ${type.padEnd(22)} ${cnt}`);
+  }
+  lines.push('');
+  lines.push('Re-run with --apply to persist downgrades. Use --limit / --offset / --budget to bound the run.');
+  return { exitCode: 0, output: lines.join('\n') };
+}
+
+function formatSummaryOutput(
+  summary: ScanSummary,
+  reportPath: string,
+  outcomes: ScanRowOutcome[],
+): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push('\x1b[1m=== Retro-Scan Summary ===\x1b[0m');
+  lines.push(`Total confirmed matching: ${summary.totalConsidered}`);
+  lines.push(`Scanned (LLM calls):      ${summary.scanned}`);
+  lines.push(`Skipped:                  ${summary.skipped}`);
+  lines.push(`Fetch cache misses:       ${summary.fetchMisses} (will re-run after ingest)`);
+  lines.push(`  Matches:                ${summary.matches}`);
+  lines.push(`  \x1b[33mMismatches:             ${summary.mismatches}\x1b[0m`);
+  lines.push(`  Downgraded:             ${summary.downgraded}`);
+  lines.push(`  Downgrade errors:       ${summary.downgradeErrors}`);
+  lines.push(`Errors:                   ${summary.errors}`);
+  lines.push(`Est. cost:                $${summary.estimatedCost.toFixed(2)}`);
+  if (summary.budgetExhausted) {
+    lines.push(`\x1b[33mBudget cap reached — re-run with --offset=N to resume.\x1b[0m`);
+  }
+  lines.push(`Report:                   ${reportPath}`);
+
+  // Show first few mismatches as a preview
+  const mismatches = outcomes.filter((o) => o.status === 'mismatch').slice(0, 10);
+  if (mismatches.length > 0) {
+    lines.push('');
+    lines.push('\x1b[1mFirst mismatches:\x1b[0m');
+    for (const o of mismatches) {
+      lines.push(`  \x1b[33m${o.recordType}/${o.recordId}\x1b[0m`);
+      lines.push(`    claim:  "${o.claimSubject}"`);
+      lines.push(`    source: "${o.sourceSubject}"`);
+      if (o.reasoning) lines.push(`    reason: ${o.reasoning.slice(0, 160)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Exports ──────────────────────────────────────────────────────────
+
+export const commands = {
+  default: retroScanCommand,
+};
+
+export function getHelp(): string {
+  return `
+Source-Check Retro-Scan: Subject-Identity (QUA-650)
+
+Re-examine existing 'confirmed' source_check_verdicts for subject-identity
+mismatches and downgrade them to 'partial' + queue for full re-verification.
+Follow-up to QUA-648.
+
+Usage:
+  crux sourcing-retro-scan-subjects [options]
+
+Options:
+  --limit=N             Max verdicts to process (default: 50)
+  --offset=N            Skip the first N matching rows (for resume) (default: 0)
+  --record-type=X       Only scan a specific record type (e.g. personnel, fact, grant)
+  --budget=N            Max USD to spend (default: 35.00, ~$0.003/row)
+  --concurrency=N       Parallel LLM calls (default: ${DEFAULT_SOURCING_CONCURRENCY}, max: 8)
+  --max-content=N       Source content truncation (default: ${DEFAULT_MAX_CONTENT_CHARS} chars)
+  --report=PATH         JSONL report path (default: /tmp/qua650-retro-scan-<ts>.jsonl)
+  --dry-run             Preview selection without running the LLM (default; alias for the preview mode)
+  --scan-only           Run the full LLM scan but do NOT persist downgrades (pilot mode)
+  --apply               Run the full LLM scan AND persist downgrades (required to write)
+  --ci                  JSON summary output for CI pipelines
+
+A row is "skipped" when:
+  - its most recent evidence is from a deterministic checker model (wikidata-api,
+    deterministic-row-match, openalex-matcher, ...) — those are immune to the
+    subject-identity defect by construction.
+  - there is no evidence row with a sourceUrl — we can't check without a source.
+
+A row is "downgraded" (with --apply) when the LLM reports subjects_match=false.
+The downgrade writes verdict='partial', needsRecheck=true, prefixes the
+reasoning with '[retro-scan QUA-650: subject-mismatch — ...]', and writes an
+audit evidence row with checkerModel='qua650-retro-scan-subject-identity'.
+
+Queue for full re-verification (after mismatches are flagged):
+  crux sourcing-recheck --verdict=partial --limit=N --budget=X
+`.trim();
+}

--- a/crux/commands/sourcing-retro-scan-subjects.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.ts
@@ -29,7 +29,7 @@ import { z } from 'zod';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
   listVerdicts,
-  storeVerdict as storeVerdictRpc,
+  storeVerdict,
   getEvidenceByRecords,
   evidenceRecordKey,
   MAX_EVIDENCE_BY_RECORDS,
@@ -83,6 +83,19 @@ const DEFAULT_MAX_CONTENT_CHARS = 10_000;
 /** Rough Haiku cost at 10K-char content + 200-token response. Used for budget
  *  caps and dry-run estimates — not a precise meter. */
 const ESTIMATED_COST_PER_CHECK = 0.003;
+
+/** Slice previous-verdict reasoning before interpolating into the prompt —
+ *  the full reasoning can be thousands of characters, and the LLM only needs
+ *  enough to orient itself. */
+const MAX_PREVIOUS_REASONING_CHARS = 600;
+
+/** Cap each label in the mismatch prefix — keeps the reasoning column within
+ *  the server's 5000-char limit and keeps the prefix machine-parseable. */
+const MAX_PREFIX_LABEL_CHARS = 120;
+
+/** `source_check_verdicts.reasoning` is varchar(5000); leave headroom for the
+ *  prefix bracket we prepend. */
+const MAX_REASONING_CHARS = 4900;
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -175,7 +188,7 @@ export function buildSubjectIdentityPrompt(params: {
   maxContentChars: number;
 }): string {
   const content = params.sourceContent.slice(0, params.maxContentChars);
-  const previousReasoning = params.previousReasoning?.slice(0, 600) ?? '';
+  const previousReasoning = params.previousReasoning?.slice(0, MAX_PREVIOUS_REASONING_CHARS) ?? '';
 
   return `You are checking whether a web source is actually about the same entity that a claim is about.
 
@@ -319,11 +332,11 @@ export async function applyDowngrade(
   // reasoning prefix — without this a newline or "quote in the LLM's
   // `source_subject` would break any regex that later tries to extract the
   // retro-scan marker from the reasoning field.
-  const sanitize = (s: string) => s.replace(/\s+/g, ' ').replace(/"/g, "'").slice(0, 120);
+  const sanitize = (s: string) => s.replace(/\s+/g, ' ').replace(/"/g, "'").slice(0, MAX_PREFIX_LABEL_CHARS);
   const sourceSubject = sanitize(check.source_subject.trim() || '(unnamed)');
   const claimSubject = sanitize(claimSubjectLabel);
   const mismatchPrefix = `[retro-scan QUA-650: subject-mismatch — source is about "${sourceSubject}", claim is about "${claimSubject}"]`;
-  const newReasoning = `${mismatchPrefix} ${originalReasoning}`.slice(0, 4900);
+  const newReasoning = `${mismatchPrefix} ${originalReasoning}`.slice(0, MAX_REASONING_CHARS);
 
   const body: Record<string, unknown> = {
     recordType: verdict.recordType,
@@ -339,7 +352,7 @@ export async function applyDowngrade(
   if (verdict.displayName != null) body.displayName = verdict.displayName;
   if (verdict.entityDisplayName != null) body.entityDisplayName = verdict.entityDisplayName;
 
-  const response = await storeVerdictRpc(body);
+  const response = await storeVerdict(body);
   if (!response.ok) {
     throw new Error(
       `Failed to persist downgrade for ${verdict.recordType}/${verdict.recordId}: ${response.error}`,
@@ -357,7 +370,7 @@ export async function applyDowngrade(
         verdict: 'partial' as SourcingVerdict,
         confidence: check.confidence,
         extractedValue: `Source subject: ${sourceSubject}`,
-        reasoning: `QUA-650 retro-scan: ${check.reasoning}`.slice(0, 4900),
+        reasoning: `QUA-650 retro-scan: ${check.reasoning}`.slice(0, MAX_REASONING_CHARS),
         entityId: verdict.entityId,
         checkerModel: 'qua650-retro-scan-subject-identity',
         fieldName: verdict.fieldName,
@@ -643,23 +656,20 @@ async function retroScanCommand(
     estimatedCost: 0,
   };
 
-  const outcomes: ScanRowOutcome[] = [];
+  // The JSONL report is the source of truth; keep only small display buffers
+  // in-memory so a 9,578-row scan doesn't accumulate ~5MB of outcome objects.
+  const sampleOutcomes: ScanRowOutcome[] = []; // first 20, for --ci output
+  const mismatchPreview: ScanRowOutcome[] = []; // first 10 mismatches, for stdout summary
+  const SAMPLE_CAP = 20;
+  const MISMATCH_PREVIEW_CAP = 10;
 
-  // Append outcomes via a WriteStream instead of appendFileSync so concurrent
-  // processOne calls don't interleave partial JSON on the same file descriptor.
-  // `createWriteStream(..., { flags: 'a' })` serializes writes through Node's
-  // internal queue, and `appendLine` chains each new line after the previous
-  // one's drain — safe up to the default highWaterMark (64K) per line.
+  // Append outcomes via a WriteStream. Node's WriteStream serializes writes
+  // through its internal queue (FIFO on a single fd), so we don't need a
+  // promise chain to guard against interleaving — just call `.write()` and
+  // `.end(callback)` flushes pending writes before the callback fires.
   const reportStream: WriteStream = createWriteStream(reportPath, { flags: 'a' });
-  let lastWrite: Promise<void> = Promise.resolve();
   const appendLine = (obj: unknown): void => {
-    const payload = JSON.stringify(obj) + '\n';
-    lastWrite = lastWrite.then(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          reportStream.write(payload, (err) => (err ? reject(err) : resolve()));
-        }),
-    );
+    reportStream.write(JSON.stringify(obj) + '\n');
   };
 
   const processOne = async (v: VerdictListEntry): Promise<void> => {
@@ -674,8 +684,11 @@ async function retroScanCommand(
       apply,
     });
 
-    outcomes.push(outcome);
     appendLine(outcome);
+    if (sampleOutcomes.length < SAMPLE_CAP) sampleOutcomes.push(outcome);
+    if (outcome.status === 'mismatch' && mismatchPreview.length < MISMATCH_PREVIEW_CAP) {
+      mismatchPreview.push(outcome);
+    }
 
     if (outcome.status.startsWith('skip:')) {
       summary.skipped++;
@@ -705,48 +718,40 @@ async function retroScanCommand(
   console.log('');
   console.log(`\x1b[1mScanning ${verdicts.length} rows (concurrency=${concurrency})...\x1b[0m`);
 
-  // Concurrency-limited loop (pattern borrowed from sourcing-orchestrate).
-  // NOTE: `budgetLimit` is a *soft* cap. The check runs between dispatches,
-  // so up to (concurrency - 1) in-flight LLM calls can push cost past the
-  // limit by roughly (concurrency - 1) × ESTIMATED_COST_PER_CHECK before
-  // the loop exits. With concurrency=5 that's ~$0.012 overshoot worst-case
-  // at the $0.003/check estimate — acceptable given we're already
-  // conservatively over-estimating per-call cost.
-  if (concurrency <= 1) {
-    for (const v of verdicts) {
-      if (summary.estimatedCost >= budgetLimit) {
-        summary.budgetExhausted = true;
-        break;
-      }
-      await processOne(v);
+  // Concurrency-limited pool (pattern borrowed from sourcing-orchestrate). The
+  // serial case (concurrency=1) is just a pool of size 1, so one loop covers
+  // both.
+  //
+  // NOTE: `budgetLimit` is a *soft* cap. The check runs before each dispatch,
+  // so up to `concurrency` in-flight LLM calls can push cost past the limit
+  // before the loop exits (the pre-dispatch check sees pre-increment cost,
+  // and each inflight call adds its ESTIMATED_COST_PER_CHECK after resolving).
+  // With concurrency=5 that's ~$0.015 overshoot worst-case at the
+  // $0.003/check estimate — acceptable given we already over-estimate per call.
+  const executing = new Set<Promise<void>>();
+  for (const v of verdicts) {
+    if (summary.estimatedCost >= budgetLimit) {
+      summary.budgetExhausted = true;
+      break;
     }
-  } else {
-    const executing = new Set<Promise<void>>();
-    for (const v of verdicts) {
-      if (summary.estimatedCost >= budgetLimit) {
-        summary.budgetExhausted = true;
-        break;
-      }
-      const p = processOne(v).finally(() => executing.delete(p));
-      executing.add(p);
-      if (executing.size >= concurrency) {
-        await Promise.race(executing);
-      }
+    const p = processOne(v).finally(() => executing.delete(p));
+    executing.add(p);
+    if (executing.size >= concurrency) {
+      await Promise.race(executing);
     }
-    await Promise.all(executing);
   }
+  await Promise.all(executing);
 
-  // Trailer — wait for the serialized write chain to drain before closing.
+  // Trailer — `stream.end(callback)` flushes all pending writes before firing.
   appendLine({ kind: 'qua650-retro-scan-trailer', finishedAt: new Date().toISOString(), summary });
-  await lastWrite;
   await new Promise<void>((resolve) => reportStream.end(resolve));
 
   const exitCode = summary.errors > 0 || summary.downgradeErrors > 0 ? 1 : 0;
 
   if (options.ci) {
-    return { exitCode, output: JSON.stringify({ summary, reportPath, sampleOutcomes: outcomes.slice(0, 20) }) };
+    return { exitCode, output: JSON.stringify({ summary, reportPath, sampleOutcomes }) };
   }
-  return { exitCode, output: formatSummaryOutput(summary, reportPath, outcomes) };
+  return { exitCode, output: formatSummaryOutput(summary, reportPath, mismatchPreview) };
 }
 
 // ── Output formatting ────────────────────────────────────────────────
@@ -804,7 +809,7 @@ function formatDryRunOutput(
 function formatSummaryOutput(
   summary: ScanSummary,
   reportPath: string,
-  outcomes: ScanRowOutcome[],
+  mismatchPreview: ScanRowOutcome[],
 ): string {
   const lines: string[] = [];
   lines.push('');
@@ -824,12 +829,10 @@ function formatSummaryOutput(
   }
   lines.push(`Report:                   ${reportPath}`);
 
-  // Show first few mismatches as a preview
-  const mismatches = outcomes.filter((o) => o.status === 'mismatch').slice(0, 10);
-  if (mismatches.length > 0) {
+  if (mismatchPreview.length > 0) {
     lines.push('');
     lines.push('\x1b[1mFirst mismatches:\x1b[0m');
-    for (const o of mismatches) {
+    for (const o of mismatchPreview) {
       lines.push(`  \x1b[33m${o.recordType}/${o.recordId}\x1b[0m`);
       lines.push(`    claim:  "${o.claimSubject}"`);
       lines.push(`    source: "${o.sourceSubject}"`);

--- a/crux/commands/sourcing-retro-scan-subjects.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.ts
@@ -23,7 +23,8 @@
  * and resumed post-hoc.
  */
 
-import { writeFileSync, appendFileSync } from 'node:fs';
+import { writeFileSync, createWriteStream } from 'node:fs';
+import type { WriteStream } from 'node:fs';
 import { z } from 'zod';
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import {
@@ -31,6 +32,7 @@ import {
   storeVerdict as storeVerdictRpc,
   getEvidenceByRecords,
   evidenceRecordKey,
+  MAX_EVIDENCE_BY_RECORDS,
   type VerdictListEntry,
 } from '../lib/wiki-server/sourcing-client.ts';
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
@@ -258,15 +260,23 @@ export async function classifyEvidence(
   const out = new Map<string, { skip: 'deterministic' } | { sourceUrl: string }>();
   if (verdicts.length === 0) return out;
 
-  const response = await getEvidenceByRecords(
-    verdicts.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
-    { limitPerRecord: 5 },
-  );
-  if (!response.ok) {
-    throw new Error(`Batch evidence fetch failed: ${response.message ?? 'unknown error'}`);
+  // Chunk the lookup to respect the server's MAX_EVIDENCE_BY_RECORDS cap.
+  // Without this, any scan of >1000 rows fails with 400 validation error
+  // from the /evidence/by-records endpoint.
+  const allEvidence: Record<string, Array<{ sourceUrl: string | null; checkerModel: string | null }>> = {};
+  for (let i = 0; i < verdicts.length; i += MAX_EVIDENCE_BY_RECORDS) {
+    const chunk = verdicts.slice(i, i + MAX_EVIDENCE_BY_RECORDS);
+    const response = await getEvidenceByRecords(
+      chunk.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
+      { limitPerRecord: 5 },
+    );
+    if (!response.ok) {
+      throw new Error(`Batch evidence fetch failed: ${response.message ?? 'unknown error'}`);
+    }
+    Object.assign(allEvidence, response.data.evidenceByKey);
   }
 
-  for (const [key, rows] of Object.entries(response.data.evidenceByKey)) {
+  for (const [key, rows] of Object.entries(allEvidence)) {
     // Prefer the most recent evidence row with a sourceUrl as the scan target.
     // If *every* evidence row is from a deterministic checker, we can skip
     // outright — those matchers check exact IDs and are immune to the
@@ -305,8 +315,14 @@ export async function applyDowngrade(
   sourceUrl: string,
 ): Promise<void> {
   const originalReasoning = verdict.reasoning ?? '';
-  const sourceSubject = check.source_subject.trim() || '(unnamed)';
-  const mismatchPrefix = `[retro-scan QUA-650: subject-mismatch — source is about "${sourceSubject}", claim is about "${claimSubjectLabel}"]`;
+  // Collapse whitespace and cap both labels before interpolating into the
+  // reasoning prefix — without this a newline or "quote in the LLM's
+  // `source_subject` would break any regex that later tries to extract the
+  // retro-scan marker from the reasoning field.
+  const sanitize = (s: string) => s.replace(/\s+/g, ' ').replace(/"/g, "'").slice(0, 120);
+  const sourceSubject = sanitize(check.source_subject.trim() || '(unnamed)');
+  const claimSubject = sanitize(claimSubjectLabel);
+  const mismatchPrefix = `[retro-scan QUA-650: subject-mismatch — source is about "${sourceSubject}", claim is about "${claimSubject}"]`;
   const newReasoning = `${mismatchPrefix} ${originalReasoning}`.slice(0, 4900);
 
   const body: Record<string, unknown> = {
@@ -629,6 +645,23 @@ async function retroScanCommand(
 
   const outcomes: ScanRowOutcome[] = [];
 
+  // Append outcomes via a WriteStream instead of appendFileSync so concurrent
+  // processOne calls don't interleave partial JSON on the same file descriptor.
+  // `createWriteStream(..., { flags: 'a' })` serializes writes through Node's
+  // internal queue, and `appendLine` chains each new line after the previous
+  // one's drain — safe up to the default highWaterMark (64K) per line.
+  const reportStream: WriteStream = createWriteStream(reportPath, { flags: 'a' });
+  let lastWrite: Promise<void> = Promise.resolve();
+  const appendLine = (obj: unknown): void => {
+    const payload = JSON.stringify(obj) + '\n';
+    lastWrite = lastWrite.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          reportStream.write(payload, (err) => (err ? reject(err) : resolve()));
+        }),
+    );
+  };
+
   const processOne = async (v: VerdictListEntry): Promise<void> => {
     const key = evidenceRecordKey(v.recordType, v.recordId);
     const classification = classifications.get(key);
@@ -642,7 +675,7 @@ async function retroScanCommand(
     });
 
     outcomes.push(outcome);
-    appendFileSync(reportPath, JSON.stringify(outcome) + '\n');
+    appendLine(outcome);
 
     if (outcome.status.startsWith('skip:')) {
       summary.skipped++;
@@ -673,6 +706,12 @@ async function retroScanCommand(
   console.log(`\x1b[1mScanning ${verdicts.length} rows (concurrency=${concurrency})...\x1b[0m`);
 
   // Concurrency-limited loop (pattern borrowed from sourcing-orchestrate).
+  // NOTE: `budgetLimit` is a *soft* cap. The check runs between dispatches,
+  // so up to (concurrency - 1) in-flight LLM calls can push cost past the
+  // limit by roughly (concurrency - 1) × ESTIMATED_COST_PER_CHECK before
+  // the loop exits. With concurrency=5 that's ~$0.012 overshoot worst-case
+  // at the $0.003/check estimate — acceptable given we're already
+  // conservatively over-estimating per-call cost.
   if (concurrency <= 1) {
     for (const v of verdicts) {
       if (summary.estimatedCost >= budgetLimit) {
@@ -697,12 +736,10 @@ async function retroScanCommand(
     await Promise.all(executing);
   }
 
-  // Trailer
-  appendFileSync(
-    reportPath,
-    JSON.stringify({ kind: 'qua650-retro-scan-trailer', finishedAt: new Date().toISOString(), summary }) +
-      '\n',
-  );
+  // Trailer — wait for the serialized write chain to drain before closing.
+  appendLine({ kind: 'qua650-retro-scan-trailer', finishedAt: new Date().toISOString(), summary });
+  await lastWrite;
+  await new Promise<void>((resolve) => reportStream.end(resolve));
 
   const exitCode = summary.errors > 0 || summary.downgradeErrors > 0 ? 1 : 0;
 

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -95,6 +95,7 @@ import * as backfillPrOutcomesCommands from './commands/backfill-pr-outcomes.ts'
 import * as factbaseMigrateEntitiesCommands from './commands/factbase-migrate-entities.ts';
 import * as verifyOrchestrateCommands from './commands/sourcing-orchestrate.ts';
 import * as sourcingRecheckCommands from './commands/sourcing-recheck.ts';
+import * as sourcingRetroScanSubjectsCommands from './commands/sourcing-retro-scan-subjects.ts';
 import * as sourcingAuditUrlsCommands from './commands/sourcing-audit-urls.ts';
 import * as sourcingBackfillHomepagesCommands from './commands/sourcing-backfill-homepages.ts';
 import * as sourcingSampleCoverageCommands from './commands/sourcing-sample-coverage.ts';
@@ -189,6 +190,7 @@ const domains = {
   verify: verifyEntityCommands,
   'verify-orchestrate': verifyOrchestrateCommands,
   'sourcing-recheck': sourcingRecheckCommands,
+  'sourcing-retro-scan-subjects': sourcingRetroScanSubjectsCommands,
   'sourcing-audit-urls': sourcingAuditUrlsCommands,
   'sourcing-backfill-homepages': sourcingBackfillHomepagesCommands,
   'sourcing-sample-coverage': sourcingSampleCoverageCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -82,6 +82,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'verify',
       'verify-orchestrate',
       'sourcing-recheck',
+      'sourcing-retro-scan-subjects',
       'sourcing-cleanup-orphans',
       'migrate-citations',
       'legislation',


### PR DESCRIPTION
## Summary

Fixes QUA-650 (follow-up to QUA-648).

Adds `crux sourcing-retro-scan-subjects`, a lightweight subject-identity-only retro-scan over existing `confirmed` source-check verdicts. QUA-648 fixed the forward-going sourcing prompt + added a programmatic `confirmed → partial` downgrade when the LLM flags a subject mismatch (e.g. "Microsoft CEO" claim confirmed from a Wikidata page about "Microsoft AI"), but the ~9,578 already-confirmed rows in prod were written before the fix. This command sweeps them.

**Per row**:
1. Pull the latest evidence for the record (batched via `/api/sourcing/evidence/by-records`, chunked at 1,000).
2. **Skip** if the most recent evidence is from a deterministic checker (`wikidata-api`, `openalex-matcher`, `dead-link-detector`, `relevance-gate`) — those match exact IDs and are immune to the subject-identity defect by construction.
3. **Skip** if the resolved claim subject is a raw `sid_...` stableId (display-name cache leak) — the LLM can't judge subject-identity against an opaque id. This guard surfaced **QUA-661** during piloting.
4. Fetch cached source content (read-only; `citation_content` cache only, no external HTTP).
5. Ask Haiku a compact prompt: "is the source's primary subject the same entity as the claim's subject?" — NOT re-verifying the claim value, ~$0.003/row.
6. On `subjects_match: false`: verdict `confirmed → partial`, set `needsRecheck=true`, prefix reasoning with `[retro-scan QUA-650: subject-mismatch — source is about "X", claim is about "Y"]`, and write an audit evidence row with `checkerModel='qua650-retro-scan-subject-identity'`.

Mismatches are queued (not resolved) — the existing `crux sourcing-recheck --verdict=partial` sweep under the QUA-648-fixed prompt is what finalizes each case.

## Modes

- **default** (no flags): preview — lists what the scan would run, no LLM, no writes.
- `--scan-only`: full LLM scan + JSONL report, **no writes** (pilot mode).
- `--apply`: full LLM scan + persist downgrades.

Controls: `--limit`, `--offset` (resume), `--budget` (soft cap, default $35), `--record-type`, `--concurrency` (default 5, max 8 via QUA-150 cap), `--max-content` (default 10K chars), `--report=PATH`, `--ci` (JSON summary).

## Live run results (this session)

Ran 88% of the backlog across two apply passes (`--apply --limit=2000` then `--apply --limit=8000 --offset=2000` stopped early at 6,429 rows). See [QUA-650 Linear comment](https://linear.app/quantifieduncertainty/issue/QUA-650) for the full summary.

Net outcome across 8,429 rows:
- **471 downgrades** written (confirmed → partial + needsRecheck=true)
- 1,380 matches left alone
- 4,337 skipped (2,960 deterministic / 1,377 sid-display-name)
- 363 fetch cache misses (will resolve as ingest pipeline catches up)
- 43 no-source-url skips
- 0 real errors

Biggest underlying-data patterns surfaced: ARIA (38 grants), Carnegie AI Program (24 personnel), Samotsvety citations, Anthropic sub-teams, Manifund grants. All 471 are now `needsRecheck=true` for the follow-up `sourcing-recheck` sweep to finalize.

## Discovered and filed

- **QUA-661** — `source_check_verdicts.{display_name,entity_display_name}` leaks raw sid_ for ~all fact rows. Blocks 1,377 sid-display-name skips from this scan. Adding these columns to `validate-sid-display.ts` would have caught it.

## Test plan

- [x] `pnpm vitest run crux/commands/sourcing-retro-scan-subjects.test.ts` — 27 tests, covering prompt construction (including `<script>alert()` prompt-injection defense), schema validation, classify-evidence skip logic, apply-downgrade path (verdict + reasoning prefix + evidence audit row), end-to-end dry-run / scan-only / apply modes, chunking > 1000 rows, budget cap, invalid-input rejection.
- [x] `pnpm build` — green.
- [x] `pnpm crux w validate gate --scope=code --fix` — 52/52, 4 pre-existing advisories.
- [x] `/agent-review-pr` — hostile reviewer flagged 1 HIGH (budget soft-cap — documented), 3 MEDIUM (prefix sanitization, concurrent JSONL writes, type assertion — fixed or accepted), 5 LOW (documented / accepted).
- [x] `/simplify` — 3 agents; findings actioned: dropped in-memory `outcomes[]` accumulator, replaced promise-chain `appendLine` with direct `stream.write` (createWriteStream already serializes), unified `concurrency<=1` branch into pool, extracted magic numbers (`MAX_PREVIOUS_REASONING_CHARS`, `MAX_PREFIX_LABEL_CHARS`, `MAX_REASONING_CHARS`).
- [x] **Live verification** against prod: 2000-row apply pass (72 downgrades), 6429-row apply pass (399 downgrades), plus three `--scan-only` and `--dry-run` sanity runs. Spot-verified one downgrade (personnel/KwBzHTCvnI) in prod: verdict=partial, needsRecheck=true, reasoning prefixed, audit evidence row written with `checkerModel='qua650-retro-scan-subject-identity'`.

## Remaining work (follow-ups)

- `crux sourcing-retro-scan-subjects --apply --offset=8429 --limit=1200` — finish the last ~12% of the confirmed pool. Cheap (~$0.30). Idempotent re-run against any already-downgraded row (it's no longer in the `confirmed` filter).
- After QUA-661 ships: re-run without the `sid-display-name` guard tripping, to sweep ~1,377 previously-skipped fact rows — including the original QUA-648 case study `f_QYAnAj3qg6`, which is currently still `confirmed` in prod and blocked from this pass by the sid leak.
- `crux sourcing-recheck --verdict=partial --limit=500` — let the QUA-648-fixed prompt finalize each of the 471 `needsRecheck=true` verdicts.

Closes QUA-650

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sourcing-retro-scan-subjects` command to scan verified sources for subject-identity mismatches and automatically remediate mismatches. Supports dry-run preview, scan-only analysis, and apply modes with configurable limits, budget caps, and concurrency controls.

* **Tests**
  * Added comprehensive test suite for the new command covering unit tests, schema validation, and end-to-end workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->