### PR TITLE
data: enrich personnel for CAIS, Epoch AI, FTX Future Fund, Lightning Rod Labs; fill CHAI division lead

### DIFF
--- a/.tablebase-completed.txt
+++ b/.tablebase-completed.txt
@@ -210,3 +210,9 @@ ooMwmH7N1zOE
 aj9wMcGv24uL
 e5qLPlpJrwct
 W0YXg3c5kyIc
+6ZRuY79KNztX
+j_aBvD35SMbM
+GteUc5Rpzv5k
+_4d75pnVxN4L
+RIc1ffO4zBp-
+Ph9nCRs0GXsM

--- a/data/tablebase-manifests/2026-04-22-111553-personnel.json
+++ b/data/tablebase-manifests/2026-04-22-111553-personnel.json
@@ -1,0 +1,74 @@
+{
+  "table": "personnel",
+  "recordCount": 7,
+  "recordsRejected": 0,
+  "submittedAt": "2026-04-22T11:15:53.323Z",
+  "sourcingSummary": {
+    "withSourcing": 0,
+    "withoutSourcing": 7,
+    "verdicts": {
+      "verified": 0,
+      "contradicted": 0,
+      "unverifiable": 0,
+      "other": 0
+    }
+  },
+  "records": [
+    {
+      "id": "HF2WWVbDtY",
+      "personId": "sid_TnHMQ4cMOw",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Co-Founder and Managing Director",
+      "source": "https://en.wikipedia.org/wiki/Center_for_AI_Safety",
+      "verdict": "none"
+    },
+    {
+      "id": "16RQpr2hDQ",
+      "personId": "0HayjjEXVX",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Executive Director, CAIS Action Fund; Director of Government Relations & Public Policy",
+      "source": "https://www.legistorm.com/person/bio/80300/Venkatasatya_Varun_Krovi.html",
+      "verdict": "none"
+    },
+    {
+      "id": "nsqGvmsWQ2",
+      "personId": "sid_6QrJwedEnl",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Manager of Research & Development",
+      "source": "https://theorg.com/org/safe-ai/org-chart/steven-basart",
+      "verdict": "none"
+    },
+    {
+      "id": "bRQsqHFSpY",
+      "personId": "nXh9kROhyx",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Research Engineer",
+      "source": "https://theorg.com/org/safe-ai/org-chart/long-phan",
+      "verdict": "none"
+    },
+    {
+      "id": "7NGoW3HynB",
+      "personId": "161F1ZIdty",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Policy Lead and Senior Counsel, CAIS Action Fund",
+      "source": "https://www.legistorm.com/person/bio/567399/Brian_McGrail.html",
+      "verdict": "none"
+    },
+    {
+      "id": "ndzmFP7xOw",
+      "personId": "U2DwGy1rmN",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Project Manager",
+      "source": "https://theorg.com/org/safe-ai/org-chart/will-hodgkins",
+      "verdict": "none"
+    },
+    {
+      "id": "n9VBnn9awT",
+      "personId": "sid_SIfbuDzvcU",
+      "organizationId": "sid_y4bieqSeag",
+      "role": "Co-Founder",
+      "source": "https://andyzoujm.github.io/",
+      "verdict": "none"
+    }
+  ]
+}

--- a/data/tablebase-manifests/2026-04-22-111843-personnel.json
+++ b/data/tablebase-manifests/2026-04-22-111843-personnel.json
@@ -1,0 +1,34 @@
+{
+  "table": "personnel",
+  "recordCount": 2,
+  "recordsRejected": 0,
+  "submittedAt": "2026-04-22T11:18:43.806Z",
+  "sourcingSummary": {
+    "withSourcing": 0,
+    "withoutSourcing": 2,
+    "verdicts": {
+      "verified": 0,
+      "contradicted": 0,
+      "unverifiable": 0,
+      "other": 0
+    }
+  },
+  "records": [
+    {
+      "id": "GMha5QU7LT",
+      "personId": "sid_LWYBcu2iSQ",
+      "organizationId": "sid_JhIGCaI3Ng",
+      "role": "Team Member",
+      "source": "https://forum.effectivealtruism.org/posts/2mx6xrDrwiEKzfgks/announcing-the-future-fund-1",
+      "verdict": "none"
+    },
+    {
+      "id": "eldHexdltb",
+      "personId": "On8CZm9rk6",
+      "organizationId": "sid_JhIGCaI3Ng",
+      "role": "Adviser",
+      "source": "https://forum.effectivealtruism.org/posts/2mx6xrDrwiEKzfgks/announcing-the-future-fund-1",
+      "verdict": "none"
+    }
+  ]
+}

--- a/data/tablebase-manifests/2026-04-22-112209-personnel.json
+++ b/data/tablebase-manifests/2026-04-22-112209-personnel.json
@@ -1,0 +1,74 @@
+{
+  "table": "personnel",
+  "recordCount": 7,
+  "recordsRejected": 0,
+  "submittedAt": "2026-04-22T11:22:09.150Z",
+  "sourcingSummary": {
+    "withSourcing": 0,
+    "withoutSourcing": 7,
+    "verdicts": {
+      "verified": 0,
+      "contradicted": 0,
+      "unverifiable": 0,
+      "other": 0
+    }
+  },
+  "records": [
+    {
+      "id": "ga5eGCLhRc",
+      "personId": "X8fIcIkNAM",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Associate Director",
+      "source": "https://theorg.com/org/epoch-ai/org-chart/tamay-besiroglu",
+      "verdict": "none"
+    },
+    {
+      "id": "HA1AZdb5ks",
+      "personId": "x4f4umLvlc",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Staff Researcher",
+      "source": "https://theorg.com/org/epoch-ai/org-chart/ben-cottier",
+      "verdict": "none"
+    },
+    {
+      "id": "ptNC7C0wtT",
+      "personId": "OyBuH33ede",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Staff Researcher",
+      "source": "https://theorg.com/org/epoch-ai/org-chart/anson-ho",
+      "verdict": "none"
+    },
+    {
+      "id": "Jy9kwflR2b",
+      "personId": "JOslnVZbUg",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Staff Researcher",
+      "source": "https://theorg.com/org/epoch-ai/org-chart/pablo-villalobos",
+      "verdict": "none"
+    },
+    {
+      "id": "kxkAgMVSOY",
+      "personId": "h54nvRR8LG",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Senior Researcher",
+      "source": "https://theorg.com/org/epoch-ai/org-chart/david-owen",
+      "verdict": "none"
+    },
+    {
+      "id": "K787BTlPcZ",
+      "personId": "F9tO9Hn9Aq",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Researcher",
+      "source": "https://epochai.substack.com/p/ai-progress-is-about-to-speed-up",
+      "verdict": "none"
+    },
+    {
+      "id": "Py0Gujbc9K",
+      "personId": "sid_1XMO6wYcZn",
+      "organizationId": "sid_cBPkzcVBBQ",
+      "role": "Research Fellow",
+      "source": "https://www.matsprogram.org/stream/hobbhahn",
+      "verdict": "none"
+    }
+  ]
+}

--- a/data/tablebase-manifests/2026-04-22-112435-personnel.json
+++ b/data/tablebase-manifests/2026-04-22-112435-personnel.json
@@ -1,0 +1,34 @@
+{
+  "table": "personnel",
+  "recordCount": 2,
+  "recordsRejected": 0,
+  "submittedAt": "2026-04-22T11:24:35.142Z",
+  "sourcingSummary": {
+    "withSourcing": 0,
+    "withoutSourcing": 2,
+    "verdicts": {
+      "verified": 0,
+      "contradicted": 0,
+      "unverifiable": 0,
+      "other": 0
+    }
+  },
+  "records": [
+    {
+      "id": "TiO9BuSzHu",
+      "personId": "FdTb1WYzAO",
+      "organizationId": "sid_4804DX6Zbg",
+      "role": "Senior Software Engineer",
+      "source": "https://www.linkedin.com/in/bartolomej/",
+      "verdict": "none"
+    },
+    {
+      "id": "3SYukaOMwM",
+      "personId": "Novx54IkuJ",
+      "organizationId": "sid_4804DX6Zbg",
+      "role": "Machine Learning Engineer",
+      "source": "https://www.linkedin.com/in/pwilczewski/",
+      "verdict": "none"
+    }
+  ]
+}

--- a/data/tablebase-manifests/2026-04-22-112608-divisions.json
+++ b/data/tablebase-manifests/2026-04-22-112608-divisions.json
@@ -1,0 +1,30 @@
+{
+  "table": "divisions",
+  "recordCount": 2,
+  "recordsRejected": 0,
+  "submittedAt": "2026-04-22T11:26:08.806Z",
+  "sourcingSummary": {
+    "withSourcing": 0,
+    "withoutSourcing": 2,
+    "verdicts": {
+      "verified": 0,
+      "contradicted": 0,
+      "unverifiable": 0,
+      "other": 0
+    }
+  },
+  "records": [
+    {
+      "id": "Ine7nH1yZD",
+      "name": "CHAI Research",
+      "source": "https://humancompatible.ai/people",
+      "verdict": "none"
+    },
+    {
+      "id": "Ine7_H1yZD",
+      "name": "CHAI Research",
+      "source": "https://humancompatible.ai/people",
+      "verdict": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

TableBase enrichment run adding 18 personnel records and 2 division lead updates across 5 organizations:

- **CAIS (Center for AI Safety)**: 7 new staff — Oliver Zhang (Co-Founder/Managing Director), Varun Krovi (Executive Director CAIS Action Fund), Steven Basart (Manager R&D, since May 2022), Long Phan (Research Engineer), Brian McGrail (Policy Lead, since Feb 2025), Will Hodgkins (Project Manager, since June 2023), Andy Zou (Co-Founder)
- **FTX Future Fund**: 2 additional team members — Avital Balwit and William MacAskill (both Feb–Nov 2022)
- **Epoch AI**: 7 researchers — Tamay Besiroglu (Assoc. Director, left 2025), Ben Cottier, Anson Ho, Pablo Villalobos, David Owen (Senior Researcher), Ege Erdil (left March 2025), Marius Hobbhahn (part-time fellow June 2022–April 2023)
- **Lightning Rod Labs**: 2 engineers — Bartolomej Kozorog (Senior SWE), Paul Wilczewski (ML Engineer)
- **CHAI**: filled `lead` field on CHAI Research divisions with Stuart Russell's stableId

All records have source URLs. Submitted with `--skip-sourcing` due to missing `ANTHROPIC_BILLING_KEY`; sourcing verdicts can be run separately via `pnpm crux tb verify-records`.

## Test plan

- [ ] Records appear in wiki-server for each organization
- [ ] No gate failures introduced (only manifest JSON files added)

https://claude.ai/code/session_01P9B1SvQZe39Vvqv3x3GWL7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated table data manifests for personnel and divisions with new records and metadata entries.
  * Extended completion tracking list with six new identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->