### PR TITLE
feat(validate): enforce Dockerfile.worker COPY matches file: deps (QUA-654)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,9 +16,8 @@ WORKDIR /deps
 # `pnpm install --prod` layer cache on unrelated FactBase edits. Add a line below
 # for each @longterm-wiki/* dep added to docker/worker/package.json.
 #
-# Missing-COPY is enforced by crux/validate/validate-workspace-dep-coverage.ts
-# (QUA-654) — the gate will fail if you add a file: dep without the matching
-# COPY line, so this is no longer a silent gotcha.
+# Missing-COPY is enforced by crux/validate/validate-workspace-dep-coverage.ts —
+# the gate fails if a file: dep is added without the matching COPY line.
 COPY packages/url-utils/ ./packages/url-utils/
 COPY docker/worker/package.json ./
 RUN pnpm install --prod

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -15,6 +15,10 @@ WORKDIR /deps
 # (2+ MB of content that churns on every factbase sync), invalidating the
 # `pnpm install --prod` layer cache on unrelated FactBase edits. Add a line below
 # for each @longterm-wiki/* dep added to docker/worker/package.json.
+#
+# Missing-COPY is enforced by crux/validate/validate-workspace-dep-coverage.ts
+# (QUA-654) — the gate will fail if you add a file: dep without the matching
+# COPY line, so this is no longer a silent gotcha.
 COPY packages/url-utils/ ./packages/url-utils/
 COPY docker/worker/package.json ./
 RUN pnpm install --prod

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -31,6 +31,7 @@ function makeScratchDir(): string {
  */
 const NO_WORKER = {
   workerPkgJson: '/nonexistent-worker-pkg-json',
+  workerDockerfile: '/nonexistent-worker-dockerfile',
   workerSourceDir: '/nonexistent-crux-dir',
 };
 
@@ -559,6 +560,306 @@ describe('validate-workspace-dep-coverage', () => {
 
     expect(result.passed).toBe(true);
     expect(result.apps.find((a) => a.app === 'docker/worker')).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------
+  // Dockerfile COPY tests — every file:./packages/<pkg> dep in the worker
+  // manifest must have a matching `COPY packages/<pkg>/` line in
+  // Dockerfile.worker, or `pnpm install --prod` fails at image build.
+  // QUA-654: the second half of the QUA-605 invariant.
+  // ---------------------------------------------------------------------
+
+  it('flags file: deps without a matching COPY line in Dockerfile.worker', () => {
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+          '@longterm-wiki/forgotten': 'file:./packages/forgotten',
+        },
+      })
+    );
+
+    // Crux imports are fine — this test isolates the COPY-line check.
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'a.ts'),
+      `import { x } from '@longterm-wiki/url-utils';\n` +
+        `import { y } from '@longterm-wiki/forgotten';\n`
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY packages/url-utils/ ./packages/url-utils/\n` +
+        // NOTE: forgotten/ COPY is missing on purpose.
+        `COPY docker/worker/package.json ./\n` +
+        `RUN pnpm install --prod\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.dockerCopy).toBeDefined();
+    expect(result.dockerCopy!.missingCopy).toEqual(['forgotten']);
+    expect(result.dockerCopy!.fileDeps).toEqual(new Set(['url-utils', 'forgotten']));
+    expect(result.dockerCopy!.copied).toEqual(new Set(['url-utils']));
+    expect(result.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it('passes when every worker file: dep has a matching COPY line', () => {
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+        },
+      })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'a.ts'),
+      `import { x } from '@longterm-wiki/url-utils';\n`
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY packages/url-utils/ ./packages/url-utils/\n` +
+        `COPY docker/worker/package.json ./\n` +
+        `RUN pnpm install --prod\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.dockerCopy!.missingCopy).toEqual([]);
+  });
+
+  it('ignores workspace:* deps — only file: deps need a COPY line', () => {
+    // Sanity: the Dockerfile COPY check should not fire for `workspace:*`
+    // or `^1.0.0` deps, since those resolve via pnpm's workspace or npm
+    // registry and don't need a local packages/<pkg>/ directory.
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+          // workspace:* and version-range deps should be ignored by the COPY check.
+          '@longterm-wiki/hoisted': 'workspace:*',
+          'zod': '^3.25.0',
+        },
+      })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(join(cruxDir, 'lib'), { recursive: true });
+    writeFileSync(
+      join(cruxDir, 'lib', 'a.ts'),
+      `import { x } from '@longterm-wiki/url-utils';\n` +
+        `import { y } from '@longterm-wiki/hoisted';\n`
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY packages/url-utils/ ./packages/url-utils/\n` +
+        `RUN pnpm install --prod\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.dockerCopy!.fileDeps).toEqual(new Set(['url-utils']));
+    expect(result.dockerCopy!.missingCopy).toEqual([]);
+  });
+
+  it('accepts COPY lines with --from/--chown flags before the path', () => {
+    // Some Dockerfiles use `COPY --chown=user:group packages/foo/ ./packages/foo/`.
+    // The parser must tolerate flag args before the source path.
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+        },
+      })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(cruxDir, { recursive: true });
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY --chown=node:node packages/url-utils/ ./packages/url-utils/\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.dockerCopy!.copied).toEqual(new Set(['url-utils']));
+  });
+
+  it('does not count COPY lines in comments', () => {
+    // A commented-out COPY line must not satisfy the coverage check —
+    // otherwise a reviewer commenting out a line to debug would silently
+    // re-introduce the QUA-605 failure mode.
+    scratch = makeScratchDir();
+    const emptyApps = join(scratch, 'apps-missing');
+
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+        },
+      })
+    );
+
+    const cruxDir = join(scratch, 'crux');
+    mkdirSync(cruxDir, { recursive: true });
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `# COPY packages/url-utils/ ./packages/url-utils/\n`
+    );
+
+    const result = runCheck({
+      appsDir: emptyApps,
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: cruxDir,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.dockerCopy!.missingCopy).toEqual(['url-utils']);
+  });
+
+  it('skips the Dockerfile check entirely when the Dockerfile is missing', () => {
+    scratch = makeScratchDir();
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+        },
+      })
+    );
+
+    const result = runCheck({
+      appsDir: join(scratch, 'apps-missing'),
+      workerPkgJson: workerPkg,
+      workerDockerfile: join(scratch, 'Dockerfile.missing'),
+      workerSourceDir: join(scratch, 'crux-missing'),
+    });
+
+    // No Dockerfile means no coverage report — don't generate false errors.
+    expect(result.dockerCopy).toBeUndefined();
+    expect(result.errors).toBe(0);
+  });
+
+  it('warns when a @longterm-wiki/foo file: dep points to packages/bar', () => {
+    // The file: path should match the package basename. A mismatch is a
+    // configuration error; flag it via onWarn so it surfaces instead of
+    // silently slipping past the COPY check.
+    scratch = makeScratchDir();
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/wrong-name',
+        },
+      })
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY packages/wrong-name/ ./packages/wrong-name/\n`
+    );
+
+    const warnings: string[] = [];
+    const result = runCheck({
+      appsDir: join(scratch, 'apps-missing'),
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: join(scratch, 'crux-missing'),
+      onWarn: (m) => warnings.push(m),
+    });
+
+    expect(warnings.some((w) => /wrong-name/.test(w) && /url-utils/.test(w))).toBe(true);
+    // The package basename, not the file-path suffix, is what drives coverage —
+    // so missingCopy lists "url-utils" (declared basename) not "wrong-name".
+    expect(result.dockerCopy!.fileDeps).toEqual(new Set(['url-utils']));
   });
 
   it('skips symlinks without following them (no recursion loop)', () => {

--- a/crux/validate/validate-workspace-dep-coverage.test.ts
+++ b/crux/validate/validate-workspace-dep-coverage.test.ts
@@ -822,10 +822,13 @@ describe('validate-workspace-dep-coverage', () => {
     expect(result.errors).toBe(0);
   });
 
-  it('warns when a @longterm-wiki/foo file: dep points to packages/bar', () => {
+  it('warns when a @longterm-wiki/foo file: dep points to packages/bar, tracks the file path', () => {
     // The file: path should match the package basename. A mismatch is a
-    // configuration error; flag it via onWarn so it surfaces instead of
-    // silently slipping past the COPY check.
+    // configuration error; we warn via onWarn AND track coverage by the
+    // file-path basename (what pnpm actually resolves against), not the
+    // declared name. Tracking by declared name would print a misleading
+    // "add COPY packages/<declared>" suggestion when the Dockerfile is
+    // actually already correct for what the file: path points at.
     scratch = makeScratchDir();
     const workerDir = join(scratch, 'worker');
     mkdirSync(workerDir, { recursive: true });
@@ -857,9 +860,80 @@ describe('validate-workspace-dep-coverage', () => {
     });
 
     expect(warnings.some((w) => /wrong-name/.test(w) && /url-utils/.test(w))).toBe(true);
-    // The package basename, not the file-path suffix, is what drives coverage —
-    // so missingCopy lists "url-utils" (declared basename) not "wrong-name".
-    expect(result.dockerCopy!.fileDeps).toEqual(new Set(['url-utils']));
+    // Coverage tracks the file-path basename (what pnpm needs), so the
+    // Dockerfile's `COPY packages/wrong-name/` correctly satisfies the dep.
+    expect(result.dockerCopy!.fileDeps).toEqual(new Set(['wrong-name']));
+    expect(result.dockerCopy!.missingCopy).toEqual([]);
+  });
+
+  it('ignores file: deps that do not point into packages/', () => {
+    // `file:./some-other-dir` is valid pnpm syntax but not something this
+    // validator handles — it's outside the packages/ tree so the COPY
+    // invariant doesn't apply. Must not match FILE_DEP_RE.
+    scratch = makeScratchDir();
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/weird': 'file:./some-other-dir',
+          '@longterm-wiki/bare': 'file:bare-sibling',
+        },
+      })
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(dockerfile, `FROM node:20-slim AS deps\n`);
+
+    const result = runCheck({
+      appsDir: join(scratch, 'apps-missing'),
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: join(scratch, 'crux-missing'),
+    });
+
+    expect(result.dockerCopy!.fileDeps).toEqual(new Set());
+    expect(result.dockerCopy!.missingCopy).toEqual([]);
+  });
+
+  it('accepts valueless BuildKit flags (--link, --parents) before the COPY source', () => {
+    // `COPY --link packages/foo/ ./packages/foo/` is recommended for cache
+    // optimization. The parser must accept flags with AND without `=value`.
+    scratch = makeScratchDir();
+    const workerDir = join(scratch, 'worker');
+    mkdirSync(workerDir, { recursive: true });
+    const workerPkg = join(workerDir, 'package.json');
+    writeFileSync(
+      workerPkg,
+      JSON.stringify({
+        name: 'worker',
+        dependencies: {
+          '@longterm-wiki/url-utils': 'file:./packages/url-utils',
+          '@longterm-wiki/other': 'file:./packages/other',
+        },
+      })
+    );
+
+    const dockerfile = join(scratch, 'Dockerfile.worker');
+    writeFileSync(
+      dockerfile,
+      `FROM node:20-slim AS deps\n` +
+        `COPY --link packages/url-utils/ ./packages/url-utils/\n` +
+        `COPY --link --chown=node:node packages/other/ ./packages/other/\n`
+    );
+
+    const result = runCheck({
+      appsDir: join(scratch, 'apps-missing'),
+      workerPkgJson: workerPkg,
+      workerDockerfile: dockerfile,
+      workerSourceDir: join(scratch, 'crux-missing'),
+    });
+
+    expect(result.dockerCopy!.copied).toEqual(new Set(['url-utils', 'other']));
+    expect(result.dockerCopy!.missingCopy).toEqual([]);
   });
 
   it('skips symlinks without following them (no recursion loop)', () => {

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -19,23 +19,9 @@
  * prod Docker build uses `pnpm install --filter <app>...`, which only
  * resolves declared workspace dependencies. An undeclared `@longterm-wiki/*`
  * import will pass every local and CI check, then fail at runtime inside the
- * Docker container with `ERR_MODULE_NOT_FOUND`.
- *
- * This bug class has recurred five times:
- *   - `@longterm-wiki/id-utils` (earliest incident, referenced in QUA-449)
- *   - `@longterm-wiki/factbase` (2026-04-14, QUA-449)
- *   - `@longterm-wiki/url-utils` in wiki-server (2026-04-18, QUA-598)
- *   - `@longterm-wiki/url-utils` in the worker image (2026-04-19, QUA-605) —
- *     missed by the earlier validator because it only covered apps/*, not
- *     the standalone worker manifest at `docker/worker/package.json`.
- *   - Worker Dockerfile COPY gap (2026-04-20, QUA-654) — QUA-605's fix added
- *     the dep to the manifest but left the matching `COPY packages/<pkg>/`
- *     line in Dockerfile.worker as a manual step. Adding a new `file:` dep
- *     without the COPY line would break the image build (stage-1 pnpm
- *     install can't resolve a `file:` path whose source isn't staged).
- *
- * Each previous occurrence was fixed instance-by-instance. This validator is
- * the systemic fix — a blocking gate check so the 6th recurrence is impossible.
+ * Docker container with `ERR_MODULE_NOT_FOUND`. The same class of bug recurs
+ * one file: dep at a time without a systemic check (see QUA-449 / QUA-598 /
+ * QUA-605 / QUA-654 for instance history).
  *
  * ## What it checks
  *
@@ -54,11 +40,11 @@
  *      needs the dep declared.
  *   2. Same declared-vs-used comparison as apps.
  *
- * For `Dockerfile.worker` (QUA-654):
+ * For `Dockerfile.worker`:
  *   1. For every `@longterm-wiki/<pkg>` dep in docker/worker/package.json
  *      with a `file:./packages/<pkg>` spec, verify the Dockerfile has a
- *      matching `COPY packages/<pkg>/` line.
- *   2. Only file: deps require a COPY — workspace:* / version deps resolve
+ *      matching `COPY packages/<pkg>/` line before `pnpm install --prod`.
+ *   2. Only file: deps require a COPY — `workspace:*` / version deps resolve
  *      via pnpm and don't need staging.
  *
  * Imports in scope: quote-anchored `from '@longterm-wiki/X'`, `import('…')`,
@@ -140,17 +126,15 @@ interface AppCoverage {
 }
 
 /**
- * Dockerfile COPY coverage for the worker image. Populated when checking the
- * worker: every `file:./packages/<pkg>` dep in docker/worker/package.json must
- * have a matching `COPY packages/<pkg>/` line in Dockerfile.worker, or
- * `pnpm install --prod` fails at image build because the file: path doesn't
- * resolve. This is the second half of the QUA-605 invariant — the manifest
- * declares the dep, the Dockerfile must actually stage the source tree.
+ * Dockerfile COPY coverage for the worker image. Every `file:./packages/<pkg>`
+ * dep in docker/worker/package.json must have a matching `COPY packages/<pkg>/`
+ * line in Dockerfile.worker, or `pnpm install --prod` fails at image build
+ * because the file: path doesn't resolve.
  */
 interface DockerCopyCoverage {
   dockerfilePath: string;     // repo-relative; the file to edit to fix violations
   manifestPath: string;       // repo-relative; where the file: deps came from
-  fileDeps: Set<string>;      // package basenames (e.g. "url-utils") declared as file: deps
+  fileDeps: Set<string>;      // package basenames declared as file: deps
   copied: Set<string>;        // package basenames with a `COPY packages/<pkg>/` line
   missingCopy: string[];      // declared as file: but no COPY line (blocking)
 }
@@ -230,11 +214,21 @@ export function extractWorkspaceImports(content: string): Set<string> {
   return used;
 }
 
-function readDeclaredDeps(
+interface WorkspaceDepEntry {
+  name: string;   // full `@longterm-wiki/<pkg>` dep name
+  spec: string;   // dep spec value (e.g. `workspace:*` or `file:./packages/<pkg>`)
+}
+
+/**
+ * Parse `@longterm-wiki/*` dep entries from a package.json, across every
+ * declared-dependency section. Returns `[]` on read or JSON parse failure
+ * (after warning via `onWarn`). Shared by `readDeclaredDeps` (apps) and
+ * `readFileDeps` (worker manifest).
+ */
+function readWorkspaceDepEntries(
   packageJsonPath: string,
   onWarn?: (message: string) => void,
-): Set<string> {
-  const declared = new Set<string>();
+): WorkspaceDepEntry[] {
   let raw: string;
   try {
     raw = readFileSync(packageJsonPath, 'utf-8');
@@ -242,7 +236,7 @@ function readDeclaredDeps(
     onWarn?.(
       `Unreadable package.json at ${packageJsonPath}: ${err instanceof Error ? err.message : String(err)}`
     );
-    return declared;
+    return [];
   }
   let pkg: Record<string, unknown>;
   try {
@@ -251,16 +245,26 @@ function readDeclaredDeps(
     onWarn?.(
       `Malformed package.json at ${packageJsonPath}: ${err instanceof Error ? err.message : String(err)}`
     );
-    return declared;
+    return [];
   }
+  const entries: WorkspaceDepEntry[] = [];
   for (const section of DEP_SECTIONS) {
     const block = pkg[section];
     if (!block || typeof block !== 'object') continue;
-    for (const name of Object.keys(block as Record<string, unknown>)) {
-      if (name.startsWith(WORKSPACE_PREFIX)) declared.add(name);
+    for (const [name, spec] of Object.entries(block as Record<string, unknown>)) {
+      if (!name.startsWith(WORKSPACE_PREFIX)) continue;
+      if (typeof spec !== 'string') continue;
+      entries.push({ name, spec });
     }
   }
-  return declared;
+  return entries;
+}
+
+function readDeclaredDeps(
+  packageJsonPath: string,
+  onWarn?: (message: string) => void,
+): Set<string> {
+  return new Set(readWorkspaceDepEntries(packageJsonPath, onWarn).map((e) => e.name));
 }
 
 function scanImports(files: string[]): Set<string> {
@@ -314,53 +318,31 @@ function analyzeApp(
 }
 
 /**
- * Extract the `<pkg>` names from `file:./packages/<pkg>` dep specs in the
- * worker package.json. Only `@longterm-wiki/*` deps are in scope — other
- * `file:` deps would point outside the packages/ tree and aren't our concern.
+ * Extract `file:./packages/<pkg>` basenames from worker package.json entries.
+ * Tracks by file-path basename (what pnpm resolves against), not the declared
+ * `@longterm-wiki/<name>` — so a mismatch like
+ * `"@longterm-wiki/foo": "file:./packages/bar"` adds `bar` to the set (and
+ * emits a warning). Tracking by declared name would produce a misleading
+ * "add COPY packages/foo/" suggestion when the Dockerfile's `COPY
+ * packages/bar/` is actually correct.
  */
-function readFileDeps(
+function extractFileDeps(
+  entries: WorkspaceDepEntry[],
   packageJsonPath: string,
   onWarn?: (message: string) => void,
 ): Set<string> {
   const fileDeps = new Set<string>();
-  let raw: string;
-  try {
-    raw = readFileSync(packageJsonPath, 'utf-8');
-  } catch {
-    // readDeclaredDeps already warns on the same file; stay silent here to avoid dupes.
-    return fileDeps;
-  }
-  let pkg: Record<string, unknown>;
-  try {
-    pkg = JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    return fileDeps;
-  }
-  for (const section of DEP_SECTIONS) {
-    const block = pkg[section];
-    if (!block || typeof block !== 'object') continue;
-    for (const [name, spec] of Object.entries(block as Record<string, unknown>)) {
-      if (!name.startsWith(WORKSPACE_PREFIX)) continue;
-      if (typeof spec !== 'string') continue;
-      const match = FILE_DEP_RE.exec(spec);
-      if (!match) continue;
-      const pkgBasename = match[1];
-      const declaredBasename = name.slice(WORKSPACE_PREFIX.length);
-      // Sanity: the dep spec's packages/<pkg> path should match the package
-      // basename. A mismatch (`"@longterm-wiki/foo": "file:./packages/bar"`)
-      // would be a developer error; flag it so the mismatch is visible.
-      if (pkgBasename !== declaredBasename) {
-        onWarn?.(
-          `${packageJsonPath}: dep "${name}" points to packages/${pkgBasename} but the package name implies packages/${declaredBasename}`
-        );
-      }
-      // Track by file-path basename, not declared name — pnpm resolves the
-      // `file:` spec by path, so the Dockerfile must COPY what the path
-      // points at, not what the dep is named. Tracking by declared name
-      // would produce an incorrect "add COPY packages/<declared>" suggestion
-      // in the mismatch case above.
-      fileDeps.add(pkgBasename);
+  for (const { name, spec } of entries) {
+    const match = FILE_DEP_RE.exec(spec);
+    if (!match) continue;
+    const pkgBasename = match[1];
+    const declaredBasename = name.slice(WORKSPACE_PREFIX.length);
+    if (pkgBasename !== declaredBasename) {
+      onWarn?.(
+        `${packageJsonPath}: dep "${name}" points to packages/${pkgBasename} but the package name implies packages/${declaredBasename}`
+      );
     }
+    fileDeps.add(pkgBasename);
   }
   return fileDeps;
 }
@@ -396,24 +378,13 @@ function readDockerfileCopiedPackages(
  * Dockerfile has `COPY packages/<pkg>/`. Without the COPY line, pnpm's
  * `file:` resolution fails at image build with "ENOENT: no such file or
  * directory, scandir '/deps/packages/<pkg>'".
- *
- * This closes the second half of the QUA-605 invariant. The existing
- * analyzeWorkerManifest catches "crux imports `@longterm-wiki/foo` but
- * package.json doesn't declare it"; this catches "package.json declares
- * file:./packages/foo but the Dockerfile doesn't stage the source."
  */
 function analyzeWorkerDockerfile(
-  pkgJsonPath: string,
+  fileDeps: Set<string>,
   dockerfilePath: string,
-  onWarn?: (message: string) => void,
-): DockerCopyCoverage | null {
-  if (!existsSync(pkgJsonPath)) return null;
-  if (!existsSync(dockerfilePath)) return null;
-
-  const fileDeps = readFileDeps(pkgJsonPath, onWarn);
+): DockerCopyCoverage {
   const copied = readDockerfileCopiedPackages(dockerfilePath);
   const missingCopy = [...fileDeps].filter((p) => !copied.has(p)).sort();
-
   return {
     dockerfilePath: WORKER_DOCKERFILE_PATH,
     manifestPath: WORKER_MANIFEST_PATH,
@@ -426,25 +397,20 @@ function analyzeWorkerDockerfile(
 /**
  * Scan `crux/` and compare its `@longterm-wiki/*` imports against
  * `docker/worker/package.json`. The worker manifest is NOT a pnpm workspace
- * member (the reason QUA-605 existed), so missing-dep suggestions use the
- * `file:./packages/<pkg>` protocol that the Dockerfile wires up, not
- * `workspace:*`.
+ * member, so missing-dep suggestions use the `file:./packages/<pkg>` protocol
+ * that the Dockerfile wires up, not `workspace:*`.
  */
 function analyzeWorkerManifest(
   sourceDir: string,
-  pkgJsonPath: string,
-  onWarn?: (message: string) => void,
-): AppCoverage | null {
-  if (!existsSync(pkgJsonPath)) return null;
-  if (!existsSync(sourceDir)) return null;
-
+  declared: Set<string>,
+): AppCoverage {
   const files = listSourceFiles(sourceDir, [], { excludeTests: true });
   return buildCoverage(
     dirname(WORKER_MANIFEST_PATH),  // "docker/worker"
     WORKER_MANIFEST_PATH,
     (pkg) => `file:./packages/${pkg.slice(WORKSPACE_PREFIX.length)}`,
     scanImports(files),
-    readDeclaredDeps(pkgJsonPath, onWarn),
+    declared,
   );
 }
 
@@ -477,14 +443,27 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     if (report) apps.push(report);
   }
 
-  const workerReport = analyzeWorkerManifest(workerSourceDir, workerPkgJson, onWarn);
-  if (workerReport) apps.push(workerReport);
+  // Parse the worker manifest once, then feed the entries into both the
+  // manifest-coverage check (crux imports vs declared deps) and the
+  // Dockerfile COPY check (file: deps vs COPY lines).
+  const workerEntries = existsSync(workerPkgJson)
+    ? readWorkspaceDepEntries(workerPkgJson, onWarn)
+    : null;
 
-  const dockerCopy = analyzeWorkerDockerfile(
-    workerPkgJson,
-    workerDockerfile,
-    onWarn,
-  );
+  let dockerCopy: DockerCopyCoverage | undefined;
+  if (workerEntries !== null) {
+    if (existsSync(workerSourceDir)) {
+      apps.push(
+        analyzeWorkerManifest(workerSourceDir, new Set(workerEntries.map((e) => e.name))),
+      );
+    }
+    if (existsSync(workerDockerfile)) {
+      dockerCopy = analyzeWorkerDockerfile(
+        extractFileDeps(workerEntries, workerPkgJson, onWarn),
+        workerDockerfile,
+      );
+    }
+  }
 
   let errors = 0;
   let warnings = 0;
@@ -561,7 +540,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
       `${c.dim}Missing worker COPY lines cause \`pnpm install --prod\` to fail during image build when the file:./packages/<pkg> dep can't resolve.${c.reset}`
     );
     console.log(
-      `${c.dim}See QUA-598 (wiki-server), QUA-605 (worker image), and QUA-654 (worker Dockerfile COPY gap) for prior incidents.${c.reset}`
+      `${c.dim}See QUA-449 / QUA-598 / QUA-605 / QUA-654 for prior incidents of this class.${c.reset}`
     );
   } else {
     console.log(
@@ -574,7 +553,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     errors,
     warnings,
     apps,
-    dockerCopy: dockerCopy ?? undefined,
+    dockerCopy,
   };
 }
 

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -7,7 +7,10 @@
  *
  * Also validates the worker Docker image: every `@longterm-wiki/*` package
  * imported from `crux/` (which `Dockerfile.worker` copies wholesale into the
- * image) must be declared in `docker/worker/package.json`.
+ * image) must be declared in `docker/worker/package.json`, AND every
+ * `file:./packages/<pkg>` dep in that manifest must have a matching
+ * `COPY packages/<pkg>/` line in `Dockerfile.worker` before
+ * `pnpm install --prod`.
  *
  * ## Why this exists
  *
@@ -18,16 +21,21 @@
  * import will pass every local and CI check, then fail at runtime inside the
  * Docker container with `ERR_MODULE_NOT_FOUND`.
  *
- * This bug class has recurred four times:
+ * This bug class has recurred five times:
  *   - `@longterm-wiki/id-utils` (earliest incident, referenced in QUA-449)
  *   - `@longterm-wiki/factbase` (2026-04-14, QUA-449)
  *   - `@longterm-wiki/url-utils` in wiki-server (2026-04-18, QUA-598)
  *   - `@longterm-wiki/url-utils` in the worker image (2026-04-19, QUA-605) —
  *     missed by the earlier validator because it only covered apps/*, not
  *     the standalone worker manifest at `docker/worker/package.json`.
+ *   - Worker Dockerfile COPY gap (2026-04-20, QUA-654) — QUA-605's fix added
+ *     the dep to the manifest but left the matching `COPY packages/<pkg>/`
+ *     line in Dockerfile.worker as a manual step. Adding a new `file:` dep
+ *     without the COPY line would break the image build (stage-1 pnpm
+ *     install can't resolve a `file:` path whose source isn't staged).
  *
  * Each previous occurrence was fixed instance-by-instance. This validator is
- * the systemic fix — a blocking gate check so the 5th recurrence is impossible.
+ * the systemic fix — a blocking gate check so the 6th recurrence is impossible.
  *
  * ## What it checks
  *
@@ -45,6 +53,13 @@
  *      `crux/` into the image, so any import reachable via lazy handler load
  *      needs the dep declared.
  *   2. Same declared-vs-used comparison as apps.
+ *
+ * For `Dockerfile.worker` (QUA-654):
+ *   1. For every `@longterm-wiki/<pkg>` dep in docker/worker/package.json
+ *      with a `file:./packages/<pkg>` spec, verify the Dockerfile has a
+ *      matching `COPY packages/<pkg>/` line.
+ *   2. Only file: deps require a COPY — workspace:* / version deps resolve
+ *      via pnpm and don't need staging.
  *
  * Imports in scope: quote-anchored `from '@longterm-wiki/X'`, `import('…')`,
  * and `require('…')` — plus subpath imports like `@longterm-wiki/factbase/types`
@@ -82,12 +97,23 @@ const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
 const SCAN_SUBDIRS = ['src', 'scripts'] as const;
 const WORKSPACE_PREFIX = '@longterm-wiki/';
 const WORKER_MANIFEST_PATH = 'docker/worker/package.json';
+const WORKER_DOCKERFILE_PATH = 'Dockerfile.worker';
 const DEP_SECTIONS = [
   'dependencies',
   'devDependencies',
   'peerDependencies',
   'optionalDependencies',
 ] as const;
+
+// Matches `file:./packages/<pkg>` or `file:packages/<pkg>` dep specs in the
+// worker package.json. The Dockerfile must copy each referenced package into
+// /deps before `pnpm install --prod` or the install fails.
+const FILE_DEP_RE = /^file:\.?\/?(?:packages\/)?([a-z0-9][a-z0-9-]*)\/?$/;
+
+// Matches `COPY packages/<pkg>/` lines in the Dockerfile. The trailing slash on
+// `<pkg>/` is required so `COPY packages/foo-bar/` doesn't shadow `packages/foo/`.
+// Runs line-by-line to skip `#`-commented lines.
+const DOCKERFILE_COPY_RE = /^\s*COPY\s+(?:--[a-z-]+=\S+\s+)*packages\/([a-z0-9][a-z0-9-]*)\//;
 
 // Matches import / import() / require() for `@longterm-wiki/<pkg>` with a
 // quote anchor so stray mentions in comments ("see @longterm-wiki/foo docs")
@@ -110,11 +136,29 @@ interface AppCoverage {
   depSuggestion: (pkg: string) => string;
 }
 
+/**
+ * Dockerfile COPY coverage for the worker image. Populated when checking the
+ * worker: every `file:./packages/<pkg>` dep in docker/worker/package.json must
+ * have a matching `COPY packages/<pkg>/` line in Dockerfile.worker, or
+ * `pnpm install --prod` fails at image build because the file: path doesn't
+ * resolve. This is the second half of the QUA-605 invariant — the manifest
+ * declares the dep, the Dockerfile must actually stage the source tree.
+ */
+interface DockerCopyCoverage {
+  dockerfilePath: string;     // repo-relative; the file to edit to fix violations
+  manifestPath: string;       // repo-relative; where the file: deps came from
+  fileDeps: Set<string>;      // package basenames (e.g. "url-utils") declared as file: deps
+  copied: Set<string>;        // package basenames with a `COPY packages/<pkg>/` line
+  missingCopy: string[];      // declared as file: but no COPY line (blocking)
+}
+
 interface CheckOptions {
   appsDir?: string;
   /** Path to the worker's standalone package.json. Defaults to
    *  `<repo>/docker/worker/package.json`. */
   workerPkgJson?: string;
+  /** Path to the worker Dockerfile. Defaults to `<repo>/Dockerfile.worker`. */
+  workerDockerfile?: string;
   /** Source tree to scan for the worker manifest check. Defaults to `<repo>/crux`. */
   workerSourceDir?: string;
   /** Optional warning sink so tests can assert on parse errors. */
@@ -126,6 +170,9 @@ interface CheckResult {
   errors: number;
   warnings: number;
   apps: AppCoverage[];
+  /** Worker Dockerfile COPY coverage. Only present when both the manifest and
+   *  Dockerfile exist. */
+  dockerCopy?: DockerCopyCoverage;
 }
 
 interface ListOptions {
@@ -264,6 +311,112 @@ function analyzeApp(
 }
 
 /**
+ * Extract the `<pkg>` names from `file:./packages/<pkg>` dep specs in the
+ * worker package.json. Only `@longterm-wiki/*` deps are in scope — other
+ * `file:` deps would point outside the packages/ tree and aren't our concern.
+ */
+function readFileDeps(
+  packageJsonPath: string,
+  onWarn?: (message: string) => void,
+): Set<string> {
+  const fileDeps = new Set<string>();
+  let raw: string;
+  try {
+    raw = readFileSync(packageJsonPath, 'utf-8');
+  } catch {
+    // readDeclaredDeps already warns on the same file; stay silent here to avoid dupes.
+    return fileDeps;
+  }
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return fileDeps;
+  }
+  for (const section of DEP_SECTIONS) {
+    const block = pkg[section];
+    if (!block || typeof block !== 'object') continue;
+    for (const [name, spec] of Object.entries(block as Record<string, unknown>)) {
+      if (!name.startsWith(WORKSPACE_PREFIX)) continue;
+      if (typeof spec !== 'string') continue;
+      const match = FILE_DEP_RE.exec(spec);
+      if (!match) continue;
+      const pkgBasename = match[1];
+      const declaredBasename = name.slice(WORKSPACE_PREFIX.length);
+      // Sanity: the dep spec's packages/<pkg> path should match the package
+      // basename. A mismatch (`"@longterm-wiki/foo": "file:./packages/bar"`)
+      // would be a developer error; flag it so the mismatch can't silently
+      // bypass the COPY check.
+      if (pkgBasename !== declaredBasename) {
+        onWarn?.(
+          `${packageJsonPath}: dep "${name}" points to packages/${pkgBasename} but the package name implies packages/${declaredBasename}`
+        );
+      }
+      fileDeps.add(declaredBasename);
+    }
+  }
+  return fileDeps;
+}
+
+/**
+ * Parse `Dockerfile.worker` and return the set of `<pkg>` names with a
+ * `COPY packages/<pkg>/` line. Comments (lines starting with `#`) are skipped.
+ * Continuation lines (`\\` at end of line) are not handled — a COPY that
+ * straddles a backslash-continuation is exotic enough that the author should
+ * prefer one COPY per line for the image cache anyway.
+ */
+function readDockerfileCopiedPackages(
+  dockerfilePath: string,
+): Set<string> {
+  const copied = new Set<string>();
+  let content: string;
+  try {
+    content = readFileSync(dockerfilePath, 'utf-8');
+  } catch {
+    return copied;
+  }
+  for (const line of content.split('\n')) {
+    if (line.trimStart().startsWith('#')) continue;
+    const match = DOCKERFILE_COPY_RE.exec(line);
+    if (match) copied.add(match[1]);
+  }
+  return copied;
+}
+
+/**
+ * Build the worker Dockerfile COPY coverage report. For every
+ * `file:./packages/<pkg>` dep in docker/worker/package.json, verify the
+ * Dockerfile has `COPY packages/<pkg>/`. Without the COPY line, pnpm's
+ * `file:` resolution fails at image build with "ENOENT: no such file or
+ * directory, scandir '/deps/packages/<pkg>'".
+ *
+ * This closes the second half of the QUA-605 invariant. The existing
+ * analyzeWorkerManifest catches "crux imports `@longterm-wiki/foo` but
+ * package.json doesn't declare it"; this catches "package.json declares
+ * file:./packages/foo but the Dockerfile doesn't stage the source."
+ */
+function analyzeWorkerDockerfile(
+  pkgJsonPath: string,
+  dockerfilePath: string,
+  onWarn?: (message: string) => void,
+): DockerCopyCoverage | null {
+  if (!existsSync(pkgJsonPath)) return null;
+  if (!existsSync(dockerfilePath)) return null;
+
+  const fileDeps = readFileDeps(pkgJsonPath, onWarn);
+  const copied = readDockerfileCopiedPackages(dockerfilePath);
+  const missingCopy = [...fileDeps].filter((p) => !copied.has(p)).sort();
+
+  return {
+    dockerfilePath: WORKER_DOCKERFILE_PATH,
+    manifestPath: WORKER_MANIFEST_PATH,
+    fileDeps,
+    copied,
+    missingCopy,
+  };
+}
+
+/**
  * Scan `crux/` and compare its `@longterm-wiki/*` imports against
  * `docker/worker/package.json`. The worker manifest is NOT a pnpm workspace
  * member (the reason QUA-605 existed), so missing-dep suggestions use the
@@ -293,6 +446,8 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
   const appsDir = options.appsDir ?? join(PROJECT_ROOT, 'apps');
   const workerPkgJson =
     options.workerPkgJson ?? join(PROJECT_ROOT, WORKER_MANIFEST_PATH);
+  const workerDockerfile =
+    options.workerDockerfile ?? join(PROJECT_ROOT, WORKER_DOCKERFILE_PATH);
   const workerSourceDir = options.workerSourceDir ?? join(PROJECT_ROOT, 'crux');
   const onWarn = options.onWarn ?? ((msg) => console.log(`${c.yellow}${msg}${c.reset}`));
 
@@ -317,6 +472,12 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
 
   const workerReport = analyzeWorkerManifest(workerSourceDir, workerPkgJson, onWarn);
   if (workerReport) apps.push(workerReport);
+
+  const dockerCopy = analyzeWorkerDockerfile(
+    workerPkgJson,
+    workerDockerfile,
+    onWarn,
+  );
 
   let errors = 0;
   let warnings = 0;
@@ -356,10 +517,32 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     }
   }
 
+  if (dockerCopy) {
+    if (dockerCopy.missingCopy.length === 0) {
+      console.log(
+        `${c.green}${dockerCopy.dockerfilePath}: OK${c.reset}${c.dim} (${dockerCopy.fileDeps.size} file: dep${dockerCopy.fileDeps.size === 1 ? '' : 's'} / ${dockerCopy.copied.size} copied)${c.reset}`
+      );
+    } else {
+      errors += dockerCopy.missingCopy.length;
+      console.log(
+        `${c.red}${dockerCopy.dockerfilePath}: ${dockerCopy.missingCopy.length} file: dep${dockerCopy.missingCopy.length > 1 ? 's' : ''} without a matching COPY line:${c.reset}`
+      );
+      for (const pkg of dockerCopy.missingCopy) {
+        console.log(`  ${c.red}packages/${pkg}${c.reset}`);
+      }
+      console.log(
+        `${c.dim}  Fix: add before \`pnpm install --prod\` in ${dockerCopy.dockerfilePath}:${c.reset}`
+      );
+      for (const pkg of dockerCopy.missingCopy) {
+        console.log(`${c.dim}    COPY packages/${pkg}/ ./packages/${pkg}/${c.reset}`);
+      }
+    }
+  }
+
   console.log();
   if (errors > 0) {
     console.log(
-      `${c.red}Found ${errors} undeclared workspace import${errors > 1 ? 's' : ''}.${c.reset}`
+      `${c.red}Found ${errors} workspace dep coverage error${errors > 1 ? 's' : ''}.${c.reset}`
     );
     console.log(
       `${c.dim}Prod Docker builds use \`pnpm install --filter <app>...\` which only resolves declared dependencies.${c.reset}`
@@ -368,11 +551,14 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
       `${c.dim}Undeclared imports pass locally (pnpm hoists) but fail at runtime with ERR_MODULE_NOT_FOUND.${c.reset}`
     );
     console.log(
-      `${c.dim}See QUA-598 (wiki-server) and QUA-605 (worker image) for prior incidents of this class.${c.reset}`
+      `${c.dim}Missing worker COPY lines cause \`pnpm install --prod\` to fail during image build when the file:./packages/<pkg> dep can't resolve.${c.reset}`
+    );
+    console.log(
+      `${c.dim}See QUA-598 (wiki-server), QUA-605 (worker image), and QUA-654 (worker Dockerfile COPY gap) for prior incidents.${c.reset}`
     );
   } else {
     console.log(
-      `${c.green}All workspace imports are declared.${c.reset}`
+      `${c.green}All workspace imports are declared and all worker file: deps are copied.${c.reset}`
     );
   }
 
@@ -381,6 +567,7 @@ export function runCheck(options: CheckOptions = {}): CheckResult {
     errors,
     warnings,
     apps,
+    dockerCopy: dockerCopy ?? undefined,
   };
 }
 

--- a/crux/validate/validate-workspace-dep-coverage.ts
+++ b/crux/validate/validate-workspace-dep-coverage.ts
@@ -106,14 +106,17 @@ const DEP_SECTIONS = [
 ] as const;
 
 // Matches `file:./packages/<pkg>` or `file:packages/<pkg>` dep specs in the
-// worker package.json. The Dockerfile must copy each referenced package into
-// /deps before `pnpm install --prod` or the install fails.
-const FILE_DEP_RE = /^file:\.?\/?(?:packages\/)?([a-z0-9][a-z0-9-]*)\/?$/;
+// worker package.json. The `packages/` segment is required — a `file:` dep
+// outside the packages/ tree wouldn't need a `COPY packages/` line at all
+// and is not something this validator is meant to cover.
+const FILE_DEP_RE = /^file:\.?\/?packages\/([a-z0-9][a-z0-9-]*)\/?$/;
 
 // Matches `COPY packages/<pkg>/` lines in the Dockerfile. The trailing slash on
 // `<pkg>/` is required so `COPY packages/foo-bar/` doesn't shadow `packages/foo/`.
+// Flag tokens before the source path may or may not take a value — `--chown=x`
+// takes one, `--link` / `--parents` (BuildKit) don't.
 // Runs line-by-line to skip `#`-commented lines.
-const DOCKERFILE_COPY_RE = /^\s*COPY\s+(?:--[a-z-]+=\S+\s+)*packages\/([a-z0-9][a-z0-9-]*)\//;
+const DOCKERFILE_COPY_RE = /^\s*COPY\s+(?:--[a-z-]+(?:=\S+)?\s+)*packages\/([a-z0-9][a-z0-9-]*)\//;
 
 // Matches import / import() / require() for `@longterm-wiki/<pkg>` with a
 // quote anchor so stray mentions in comments ("see @longterm-wiki/foo docs")
@@ -345,14 +348,18 @@ function readFileDeps(
       const declaredBasename = name.slice(WORKSPACE_PREFIX.length);
       // Sanity: the dep spec's packages/<pkg> path should match the package
       // basename. A mismatch (`"@longterm-wiki/foo": "file:./packages/bar"`)
-      // would be a developer error; flag it so the mismatch can't silently
-      // bypass the COPY check.
+      // would be a developer error; flag it so the mismatch is visible.
       if (pkgBasename !== declaredBasename) {
         onWarn?.(
           `${packageJsonPath}: dep "${name}" points to packages/${pkgBasename} but the package name implies packages/${declaredBasename}`
         );
       }
-      fileDeps.add(declaredBasename);
+      // Track by file-path basename, not declared name — pnpm resolves the
+      // `file:` spec by path, so the Dockerfile must COPY what the path
+      // points at, not what the dep is named. Tracking by declared name
+      // would produce an incorrect "add COPY packages/<declared>" suggestion
+      // in the mismatch case above.
+      fileDeps.add(pkgBasename);
     }
   }
   return fileDeps;


### PR DESCRIPTION
## Summary

- **Immediate bug** was fixed by PR #4502 (merged 2026-04-20 00:26 UTC, worker image redeployed 03:36 UTC). Last `url-utils` failure was at 02:12:58 UTC — no failures since.
- **Systemic gap addressed by this PR**: QUA-605 declared `@longterm-wiki/url-utils` as a `file:./packages/url-utils` dep in `docker/worker/package.json` but left the matching `COPY packages/url-utils/` line in `Dockerfile.worker` as a manual step. A future contributor adding a new `file:` dep without the COPY would break the image build at stage-1 `pnpm install --prod` because the `file:` path wouldn't resolve.
- Extend `validate-workspace-dep-coverage.ts` to also parse `Dockerfile.worker` and flag any `file:./packages/<pkg>` dep whose matching `COPY packages/<pkg>/` line is missing. The existing `workspace-dep-coverage` gate entry now covers this, blocking.

## Implementation notes

- New `analyzeWorkerDockerfile()` + `readFileDeps()` + `readDockerfileCopiedPackages()`. Scoped: only `@longterm-wiki/*` deps with `file:./packages/<pkg>` specs are in coverage; `workspace:*` and version-range deps are ignored (they resolve via pnpm and don't need a COPY line).
- `DOCKERFILE_COPY_RE` handles both `--chown=x`-style flags (with `=`) and BuildKit valueless flags (`--link`, `--parents`). Trailing `/` on `packages/<pkg>/` prevents `foo-bar/` from shadowing `foo/`. Comment lines (`# COPY …`) don't satisfy coverage.
- `FILE_DEP_RE` requires the spec to point into `packages/` — `file:./some-other-dir` won't match (and shouldn't, since it's outside our coverage).
- Mismatch case (`"@longterm-wiki/url-utils": "file:./packages/wrong-name"`): coverage tracks the **file-path basename** (what pnpm resolves against), not the declared name. Additionally emits a warning so the mismatch is visible.
- Updated `Dockerfile.worker` comment to point at the automated check so future contributors know the COPY invariant is enforced.

## Test plan

- [x] `npx vitest run crux/validate/validate-workspace-dep-coverage.test.ts` — **34 tests pass** (25 original + 9 new for the Dockerfile COPY check)
- [x] `npx tsx crux/validate/validate-workspace-dep-coverage.ts` — validator passes on current repo (1 file: dep / 1 copied)
- [x] Red-teamed 9 adversarial Dockerfile patterns: empty, prefix-shadow, case-mismatch, ADD vs COPY, catch-all `COPY . ./`, nested dest paths, TAB indent, multi-source COPY, BuildKit `--link` flag — all handled correctly
- [x] Proved the validator catches the real failure mode: stubbed out the existing `COPY packages/url-utils/` line locally → validator flagged it with the correct fix suggestion
- [x] `/agent-review-pr` — 2 HIGH + 1 MEDIUM findings fixed in a follow-up commit
- [x] `pnpm build` succeeds
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 content checks pass
- [ ] Post-merge: next scheduled worker deploy succeeds with the new Dockerfile comment

Fixes QUA-654


## Deploy Checklist
<!-- deploy-tasks:v1 -->
> _Deploy tasks checked off retroactively on 2026-04-24 — all tasks were executed live during their original deploy; leaving unchecked caused carryover into later release PR bodies (QUA-658)._
- [x] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Validation**
  * Build validation now checks that workspace file-dependencies referenced for the worker have matching Docker COPY entries and reports clearer, actionable errors when missing.

* **Tests**
  * Added comprehensive unit tests covering Docker COPY coverage, flag variants, commented lines, ignored dep types, and missing-Dockerfile behavior.

* **Documentation**
  * Added clarifying inline Dockerfile comments explaining dependency-to-COPY expectations and failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
