### PR TITLE
review(QUA-650): address CodeRabbit findings on retro-scan

### DIFF
--- a/crux/commands/sourcing-retro-scan-subjects.test.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.test.ts
@@ -250,7 +250,11 @@ describe('classifyEvidence', () => {
     expect(res.size).toBe(0);
   });
 
-  it('prefers the most recent non-deterministic evidence when both exist', async () => {
+  it('skips when the latest evidence row is deterministic (even if older LLM rows exist)', async () => {
+    // Per CodeRabbit review on PR #4539: classify by the *latest* evidence row,
+    // not the latest non-deterministic one. A verdict that was re-confirmed by
+    // a deterministic checker should not be downgraded by stale LLM evidence
+    // sitting underneath it. Order: index 0 = most recent.
     mockGetEvidenceByRecords.mockResolvedValueOnce({
       ok: true,
       data: {
@@ -263,9 +267,25 @@ describe('classifyEvidence', () => {
       },
     });
     const res = await classifyEvidence([makeVerdict({ recordId: 'f_mixed' }) as never]);
-    // Picks the first non-deterministic row — the LLM-sourced URL, since
-    // the wikidata-api row is filtered out as deterministic. That's the
-    // target we want: the row with the subject-identity defect potential.
+    expect(res.get('fact|f_mixed')).toEqual({ skip: 'deterministic' });
+  });
+
+  it('scans by the latest evidence row when it is non-deterministic (older deterministic row ignored)', async () => {
+    // Companion to the previous test: latest is the LLM row (index 0), so
+    // we scan with the LLM URL — the older deterministic row underneath does
+    // not factor in.
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        evidenceByKey: {
+          'fact|f_mixed': [
+            makeEvidence({ checkerModel: 'claude-haiku-4-5-20251001', sourceUrl: 'https://llm/source' }),
+            makeEvidence({ checkerModel: 'wikidata-api', sourceUrl: 'https://wd/deterministic' }),
+          ],
+        },
+      },
+    });
+    const res = await classifyEvidence([makeVerdict({ recordId: 'f_mixed' }) as never]);
     expect(res.get('fact|f_mixed')).toEqual({ sourceUrl: 'https://llm/source' });
   });
 
@@ -422,6 +442,26 @@ describe('retroScan command', () => {
     expect(parsed.totalMatching).toBe(9578);
     expect(parsed.wouldCheck).toBe(1);
     expect(mockCallLlm).not.toHaveBeenCalled();
+  });
+
+  it('rejects --dry-run combined with --apply (CodeRabbit review on PR #4539)', async () => {
+    const result = await retroScan(
+      [],
+      { 'dry-run': true, apply: true, ci: true } as never,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/--dry-run cannot be combined/);
+    expect(mockCallLlm).not.toHaveBeenCalled();
+    expect(mockStoreVerdict).not.toHaveBeenCalled();
+  });
+
+  it('rejects --dry-run combined with --scan-only', async () => {
+    const result = await retroScan(
+      [],
+      { 'dry-run': true, 'scan-only': true, ci: true } as never,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/--dry-run cannot be combined/);
   });
 
   it('--apply path downgrades a mismatched confirmed verdict', async () => {

--- a/crux/commands/sourcing-retro-scan-subjects.ts
+++ b/crux/commands/sourcing-retro-scan-subjects.ts
@@ -290,21 +290,24 @@ export async function classifyEvidence(
   }
 
   for (const [key, rows] of Object.entries(allEvidence)) {
-    // Prefer the most recent evidence row with a sourceUrl as the scan target.
-    // If *every* evidence row is from a deterministic checker, we can skip
-    // outright — those matchers check exact IDs and are immune to the
-    // subject-identity defect.
+    // Classify by the *latest* evidence row that has a sourceUrl. If that
+    // row is from a deterministic checker (exact-ID match), the verdict is
+    // immune to the subject-identity defect — skip. Previously we picked
+    // the latest *non-deterministic* row, which let stale LLM evidence
+    // downgrade verdicts that were since re-confirmed by a deterministic
+    // checker. (CodeRabbit review on PR #4539.)
     const withUrl = rows.filter((r) => r.sourceUrl);
     if (withUrl.length === 0) continue;
 
-    const nonDeterministic = withUrl.find(
-      (r) => !r.checkerModel || !DETERMINISTIC_CHECKER_MODELS.has(r.checkerModel),
-    );
-    if (!nonDeterministic) {
+    const latestWithUrl = withUrl[0];
+    if (
+      latestWithUrl.checkerModel &&
+      DETERMINISTIC_CHECKER_MODELS.has(latestWithUrl.checkerModel)
+    ) {
       out.set(key, { skip: 'deterministic' });
       continue;
     }
-    const sourceUrl = nonDeterministic.sourceUrl;
+    const sourceUrl = latestWithUrl.sourceUrl;
     if (sourceUrl) out.set(key, { sourceUrl });
   }
   return out;
@@ -542,12 +545,25 @@ async function retroScanCommand(
   options: RetroScanOptions,
 ): Promise<CommandResult> {
   const scanOnly = options['scan-only'] === true || options.scanOnly === true;
-  const apply = options.apply === true && !scanOnly;
-  // Three modes:
-  //   default (no --apply, no --scan-only): fast preview; no LLM, no writes.
-  //   --scan-only:                          full LLM scan; no writes (pilot mode).
-  //   --apply:                              full LLM scan + persists downgrades.
-  const isPreview = !apply && !scanOnly;
+  const dryRun = options['dry-run'] === true || options.dryRun === true;
+
+  // --dry-run is documented as preview-only; reject combinations that would
+  // otherwise silently bypass it (e.g., `--dry-run --apply` would have
+  // persisted writes). CodeRabbit review on PR #4539.
+  if (dryRun && (scanOnly || options.apply === true)) {
+    return {
+      exitCode: 1,
+      output: 'Invalid mode: --dry-run cannot be combined with --scan-only or --apply.',
+    };
+  }
+
+  const apply = options.apply === true && !scanOnly && !dryRun;
+  // Four modes (mutually exclusive):
+  //   default (no flags):     fast preview; no LLM, no writes.
+  //   --dry-run:               same as default — explicit preview.
+  //   --scan-only:             full LLM scan; no writes (pilot mode).
+  //   --apply:                 full LLM scan + persists downgrades.
+  const isPreview = dryRun || (!apply && !scanOnly);
   const itemLimit = options.limit ? parseInt(String(options.limit), 10) : 50;
   const offset = options.offset ? parseInt(String(options.offset), 10) : 0;
   const budgetLimit = options.budget ? parseFloat(String(options.budget)) : 35.0;


### PR DESCRIPTION
## Summary

Follow-up to PR #4539 (merged). Addresses 2 Major CodeRabbit findings that landed unresolved on main:

1. **classifyEvidence picked latest non-deterministic row instead of latest row.** A verdict re-confirmed by a deterministic exact-ID checker could still be downgraded by stale LLM evidence underneath it. Now classifies by the latest sourceUrl-bearing row; skip if it's deterministic.
2. **`--dry-run` was ignored.** `--dry-run --apply` would silently persist downgrades. Now reject conflicting flag combinations and OR `dryRun` into `isPreview`.

Tests updated: replaced the old "prefers most recent non-deterministic" test (which asserted the buggy behavior) with two tests for the new policy. Added two regression tests for the `--dry-run` rejection. All 30 tests in `sourcing-retro-scan-subjects.test.ts` pass.

## Test plan

- [x] `npx vitest run crux/commands/sourcing-retro-scan-subjects.test.ts` — 30/30 pass

Fixes QUA-650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit `--dry-run` mode support.

* **Bug Fixes**
  * Fixed evidence selection logic to use the latest evidence row containing a source URL.
  * Added validation to prevent incompatible flag combinations; `--dry-run` now cannot be used with `--apply` or `--scan-only`, returning an error instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->