### PR TITLE
fix(divisions): wire lead field through import-divisions + populate CHAI

### DIFF
--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -26,6 +26,8 @@ interface DivisionDef {
   parentOrgId: string;
   name: string;
   divisionType: "fund" | "team" | "department" | "lab" | "program-area";
+  /** Person stableId or display name. Optional — most divisions are run by a team. */
+  lead?: string;
   status: "active" | "inactive" | "dissolved";
   startDate?: string;
   endDate?: string;
@@ -553,6 +555,7 @@ const DIVISIONS: DivisionDef[] = [
     parentOrgId: ORG_IDS.CHAI,
     name: "CHAI Research",
     divisionType: "lab",
+    lead: "Stuart Russell",
     status: "active",
     source: "https://humancompatible.ai/research",
     notes:
@@ -748,6 +751,7 @@ interface SyncDivision {
   parentOrgId: string;
   name: string;
   divisionType: string;
+  lead: string | null;
   status: string | null;
   startDate: string | null;
   endDate: string | null;
@@ -761,6 +765,7 @@ function toSyncDivision(def: DivisionDef): SyncDivision {
     parentOrgId: def.parentOrgId,
     name: def.name,
     divisionType: def.divisionType,
+    lead: def.lead ?? null,
     status: def.status,
     startDate: def.startDate ?? null,
     endDate: def.endDate ?? null,


### PR DESCRIPTION
## Summary

Follow-up to PR #4543 (merged). Addresses CodeRabbit's finding that the CHAI Research division was shipped without a `lead` field despite the commit objective being "fill division lead field with Stuart Russell". Root cause: the `DivisionDef` interface and `toSyncDivision()` mapper in `crux/commands/import-divisions.ts` didn't expose the `lead` column, even though `divisions.lead` exists in the PG schema and `SyncDivisionItemSchema` accepts it.

Changes:

- Add `lead?: string` to the `DivisionDef` interface
- Add `lead: string | null` to the local `SyncDivision` shape
- Forward `lead: def.lead ?? null` in `toSyncDivision()`
- Set `lead: "Stuart Russell"` on the CHAI Research entry

After merge, `pnpm crux tb import-divisions sync` will populate the `lead` column on the canonical CHAI Research record (`Ine7nH1yZD`).

## Operational follow-up — NOT in this PR

The 2026-04-22 enrichment manifest shows TWO CHAI Research records: `Ine7nH1yZD` (current) and `Ine7_H1yZD` (stale). They share idSeed `div|chai|research` — the duplicate is an artifact of the `generateId` `_` → `n` replacement transition. Cleanup requires deleting the stale `Ine7_H1yZD` row (operational `crux tb delete` or manual SQL), not a code change.

## Test plan

- [x] TypeScript checks pass for the touched file (pre-existing TS errors elsewhere unaffected)
- [x] Re-running `pnpm crux tb import-divisions sync --dry-run` after merge will preview a single update on `Ine7nH1yZD` setting `lead = "Stuart Russell"`
