### PR TITLE
review(QUA-28): address CodeRabbit findings on IRS 990 import

### DIFF
--- a/crux/commands/factbase-import-990.test.ts
+++ b/crux/commands/factbase-import-990.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { extractFinancialFacts } from './factbase-import-990.ts';
+
+function makeFiling(over: Partial<{
+  tax_prd: number;
+  tax_prd_yr: number;
+  formtype: number;
+  totrevenue: number;
+  totfuncexpns: number;
+  totassetsend: number;
+  totliabend: number;
+  totnetassetend: number;
+  ein: number;
+}> = {}) {
+  return {
+    tax_prd: 201712,
+    tax_prd_yr: 2017,
+    formtype: 0,
+    totrevenue: 1000,
+    totfuncexpns: 800,
+    totassetsend: 5000,
+    totliabend: 0,
+    totnetassetend: 5000,
+    ein: 123456789,
+    ...over,
+  };
+}
+
+function makeOrg(filings: ReturnType<typeof makeFiling>[]) {
+  return {
+    organization: {
+      ein: 123456789,
+      name: 'Test Org',
+      city: 'Test',
+      state: 'CA',
+      sort_name: 'Test',
+    },
+    filings_with_data: filings,
+    filings_without_data: [],
+  } as never;
+}
+
+describe('extractFinancialFacts', () => {
+  it('emits revenue / annual-expenses / net-assets for a single filing', () => {
+    const facts = extractFinancialFacts('e1', makeOrg([makeFiling()]));
+    expect(facts.map((f) => f.property).sort()).toEqual([
+      'annual-expenses',
+      'net-assets',
+      'revenue',
+    ]);
+  });
+
+  it('CodeRabbit review on PR #4538: deduplicates filings with identical (tax_prd_yr, tax_prd)', () => {
+    // Two filings for the same period — without dedup, both produce
+    // facts with the same (property, asOf) key. Both would be written,
+    // polluting the time series. Keep first occurrence.
+    const facts = extractFinancialFacts(
+      'e1',
+      makeOrg([
+        makeFiling({ tax_prd_yr: 2017, tax_prd: 201712, totrevenue: 100 }),
+        makeFiling({ tax_prd_yr: 2017, tax_prd: 201712, totrevenue: 999 }),
+      ]),
+    );
+    const revenueFacts = facts.filter((f) => f.property === 'revenue');
+    expect(revenueFacts).toHaveLength(1);
+    expect(revenueFacts[0].value).toBe(100);
+    expect(revenueFacts[0].asOf).toBe('2017');
+  });
+
+  it('keeps both filings when same year but different periods (legitimate dual filings)', () => {
+    // Two filings for same year but different periods (e.g. fiscal-year
+    // transition: short period + full year). Disambiguated via YYYY-MM asOf.
+    const facts = extractFinancialFacts(
+      'e1',
+      makeOrg([
+        makeFiling({ tax_prd_yr: 2017, tax_prd: 201706, totrevenue: 100 }),
+        makeFiling({ tax_prd_yr: 2017, tax_prd: 201712, totrevenue: 200 }),
+      ]),
+    );
+    const revenueFacts = facts.filter((f) => f.property === 'revenue');
+    expect(revenueFacts).toHaveLength(2);
+    expect(revenueFacts.map((f) => f.asOf).sort()).toEqual(['2017-06', '2017-12']);
+  });
+
+  it('skips totrevenue=0 but keeps annual-expenses=0 and net-assets=0', () => {
+    const facts = extractFinancialFacts(
+      'e1',
+      makeOrg([makeFiling({ totrevenue: 0, totfuncexpns: 0, totnetassetend: 0 })]),
+    );
+    // CodeRabbit review on PR #4538: annual-expenses=0 is meaningful (e.g.
+    // newly-formed foundations that haven't started spending yet), so emit
+    // it with an explanatory note rather than skipping. totrevenue=0 still
+    // skipped (an org with no revenue isn't worth tracking).
+    expect(facts.map((f) => f.property).sort()).toEqual([
+      'annual-expenses',
+      'net-assets',
+    ]);
+    const expensesFact = facts.find((f) => f.property === 'annual-expenses');
+    expect(expensesFact?.value).toBe(0);
+    expect(expensesFact?.notes).toMatch(/no operational spending/);
+  });
+});

--- a/crux/commands/factbase-import-990.ts
+++ b/crux/commands/factbase-import-990.ts
@@ -143,7 +143,7 @@ async function fetchOrganization(ein: string): Promise<ProPublicaOrg> {
 
 // ── Fact extraction ───────────────────────────────────────────────────
 
-function extractFinancialFacts(
+export function extractFinancialFacts(
   _entityId: string,
   org: ProPublicaOrg,
 ): FinancialFact[] {
@@ -151,16 +151,34 @@ function extractFinancialFacts(
   const sourceUrl = `${PROPUBLICA_PAGE_BASE}/${ein}`;
   const facts: FinancialFact[] = [];
 
+  // Deduplicate filings by (tax_prd_yr, tax_prd) — ProPublica occasionally
+  // returns multiple filings for the same tax period (e.g. amended return
+  // filed twice, or a duplicate API record). Without this dedup, two filings
+  // with identical period produce identical asOf values and emit duplicate
+  // (property, asOf) facts that both get written, polluting the FactBase
+  // time series. (CodeRabbit review on PR #4538 — the bug shipped duplicate
+  // 2012 facts to ford-foundation.yaml and 2017 facts to protect-democracy.yaml.)
+  // Keep the first occurrence per (year, period) — order from ProPublica is
+  // newest-first, so the most recent revision wins ties.
+  const seenPeriod = new Set<string>();
+  const dedupedFilings: typeof org.filings_with_data = [];
+  for (const f of org.filings_with_data) {
+    const periodKey = `${f.tax_prd_yr}::${f.tax_prd}`;
+    if (seenPeriod.has(periodKey)) continue;
+    seenPeriod.add(periodKey);
+    dedupedFilings.push(f);
+  }
+
   // Detect years with multiple filings (e.g. amended returns, fiscal-year
   // transitions). For single-filing years, keep the simpler `YYYY` asOf to
   // match existing data conventions; for multi-filing years, disambiguate
   // with `YYYY-MM` derived from `tax_prd` so each filing gets a unique key.
   const yearCounts = new Map<number, number>();
-  for (const f of org.filings_with_data) {
+  for (const f of dedupedFilings) {
     yearCounts.set(f.tax_prd_yr, (yearCounts.get(f.tax_prd_yr) ?? 0) + 1);
   }
 
-  for (const filing of org.filings_with_data) {
+  for (const filing of dedupedFilings) {
     const einFormatted = formatEin(ein);
     const year = String(filing.tax_prd_yr);
     const asOf = (yearCounts.get(filing.tax_prd_yr) ?? 1) > 1
@@ -181,14 +199,20 @@ function extractFinancialFacts(
       });
     }
 
-    // Expenses
-    if (filing.totfuncexpns != null && filing.totfuncexpns !== 0) {
+    // Expenses — emit even when 0 (e.g., newly-formed foundations that
+    // received funds but haven't spent them yet). Skipping 0 caused
+    // future-of-life-foundation 2022 to ship without an annual-expenses
+    // fact while neighbours had it (CodeRabbit review on PR #4538).
+    if (filing.totfuncexpns != null) {
+      const expenseNote = filing.totfuncexpns === 0
+        ? `From IRS Form 990 (EIN ${einFormatted}). Total functional expenses for ${periodNote} reported as $0 (no operational spending in this period).`
+        : `From IRS Form 990 (EIN ${einFormatted}). Total functional expenses for ${periodNote}.`;
       facts.push({
         property: 'annual-expenses',
         value: filing.totfuncexpns,
         asOf,
         source: sourceUrl,
-        notes: `From IRS Form 990 (EIN ${einFormatted}). Total functional expenses for ${periodNote}.`,
+        notes: expenseNote,
       });
     }
 

--- a/packages/factbase/data/fb-entities/council-on-strategic-risks.yaml
+++ b/packages/factbase/data/fb-entities/council-on-strategic-risks.yaml
@@ -4,9 +4,7 @@ facts:
     property: description
     value: The Council on Strategic Risks is a DC-based nonprofit founded in 2017
       that focuses on climate-security intersections, strategic weapons, and
-      ecological risks through three research centers. While the organization
-      claims nonpartisan status, its left-leaning funding sources and critical
-      stance toward
+      ecological risks through three research centers.
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_MqvJ2jFa3g

--- a/packages/factbase/data/fb-entities/future-of-life-foundation.yaml
+++ b/packages/factbase/data/fb-entities/future-of-life-foundation.yaml
@@ -93,6 +93,16 @@ facts:
     asOf: "2022"
     source: https://projects.propublica.org/nonprofits/organizations/880926067
     notes: From IRS Form 990 (EIN 88-0926067). Total revenue for tax year 2022.
+  - id: f_5VMZfaUaXj
+    property: annual-expenses
+    value: 0
+    asOf: "2022"
+    source: https://projects.propublica.org/nonprofits/organizations/880926067
+    notes: From IRS Form 990 (EIN 88-0926067). Total functional expenses for tax
+      year 2022 reported as $0 — FLF was newly formed and held its initial
+      $25M revenue without operational spending in its first reporting year
+      (revenue and end-of-year net assets match exactly). Backfilled per
+      CodeRabbit review on PR #4538.
   - id: f_suNgCCT3JQ
     property: net-assets
     value: 25035877

--- a/packages/factbase/data/fb-entities/securebio.yaml
+++ b/packages/factbase/data/fb-entities/securebio.yaml
@@ -6,7 +6,7 @@ facts:
       protect against catastrophic pandemics, including AI-enabled biological
       threats, through wastewater surveillance (Nucleic Acid Observatory) and AI
       capability evaluations (Virology Capabilities Test). Co-founded by Kevin
-      Esvelt, wh
+      Esvelt.
     asOf: 2026-03
     notes: Migrated from old entity system
   - id: f_xwrWbUvMXQ


### PR DESCRIPTION
## Summary

Follow-up to PR #4538 (merged). Addresses 6 CodeRabbit findings; 4 needed code changes, 2 were already resolved in the YAML data.

### Code changes

1. **(Major) factbase-import-990.ts:171 — Dedup filings with identical `(tax_prd_yr, tax_prd)`.** When ProPublica returns multiple filings for the same period (amended return filed twice, duplicate API record), both produce identical `asOf` values and emit duplicate `(property, asOf)` facts that both get written, polluting the FactBase time series. Added a filing-level dedup at the head of `extractFinancialFacts()` keeping the first occurrence per `(year, period)`.

2. **(Major) future-of-life-foundation.yaml:102 — Missing `annual-expenses` for 2022.** Root cause: the extractor skipped `totfuncexpns=0`, but for newly-formed foundations (FLF received $25M in 2022 and held it as net assets without spending), 0 is meaningful. Updated the extractor to emit `annual-expenses=0` with an explanatory note when the value is zero, and manually backfilled the missing FLF 2022 fact.

3. **(Minor) council-on-strategic-risks.yaml:9 — Description ended mid-sentence at "critical stance toward".** Trimmed to the previous complete clause.

4. **(Minor) securebio.yaml:9 — Description ended mid-word at "wh".** Replaced with "Co-founded by Kevin Esvelt." per CodeRabbit's suggestion.

### Already addressed in shipped data

CodeRabbit added "✅ Addressed in commit 3d5cbbe" markers to two findings (ford-foundation 2012, protect-democracy 2017), but `3d5cbbe` is a phantom commit — it doesn't exist in the repo. Fortunately, checking the actual files shows the data was already disambiguated:

- ford-foundation.yaml — 2012 facts use `asOf "2012-12"` (short-period) vs `"2012-09"` (full year) with explanatory notes.
- protect-democracy.yaml — 2017 facts use `"2017-12"` vs `"2017-06"` with full-year vs short-period notes.

The dedup fix in (1) prevents this class of bug from recurring on future imports.

## Test plan

- [x] `npx vitest run crux/commands/factbase-import-990.test.ts` — 4/4 pass (new test file)
- [x] `pnpm crux fb show future-of-life-foundation` shows "Annual Expenses $0M (2022)" alongside the existing revenue and net-assets facts

Fixes QUA-28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced financial data deduplication to prevent duplicate time-series entries from identical filing periods
  * Improved expense reporting to include zero-value expenses with explanatory notes

* **Bug Fixes**
  * Corrected organizational descriptions and removed inaccurate qualifiers
  * Fixed incomplete text in entity descriptions

* **Tests**
  * Added comprehensive test coverage for financial fact extraction logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->