### PR TITLE
feat(organizations): grouped-by-type landing view with descriptions

### DIFF
--- a/apps/web/src/app/organizations/org-sort.test.ts
+++ b/apps/web/src/app/organizations/org-sort.test.ts
@@ -9,6 +9,7 @@ function makeRow(overrides: Partial<OrgRow> = {}): OrgRow {
     id: "o1",
     slug: "org-1",
     name: "Acme Corp",
+    description: null,
     wikiId: null,
     orgType: null,
     wikiPageId: null,

--- a/apps/web/src/app/organizations/organizations-grouped.test.ts
+++ b/apps/web/src/app/organizations/organizations-grouped.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { bucketOrgs, splitFeatured } from "./organizations-grouped";
+import type { OrgRow } from "./organizations-table";
+
+function org(partial: Partial<OrgRow> & Pick<OrgRow, "id" | "name">): OrgRow {
+  return {
+    slug: partial.id,
+    description: null,
+    wikiId: null,
+    orgType: null,
+    wikiPageId: null,
+    revenue: null,
+    revenueNum: null,
+    revenueDate: null,
+    valuation: null,
+    valuationNum: null,
+    valuationDate: null,
+    headcount: null,
+    headcountDate: null,
+    totalFunding: null,
+    totalFundingNum: null,
+    foundedDate: null,
+    peopleCount: null,
+    completionScore: 1,
+    verdictString: null,
+    searchText: "",
+    ...partial,
+  };
+}
+
+// Minimal column shape that matches what splitFeatured needs.
+const HEADCOUNT_COL = {
+  key: "headcount",
+  label: "Headcount",
+  render: (r: OrgRow) => r.headcount,
+  has: (r: OrgRow) => r.headcount != null,
+};
+const VALUATION_COL = {
+  key: "valuation",
+  label: "Valuation",
+  render: (r: OrgRow) => r.valuationNum,
+  has: (r: OrgRow) => r.valuationNum != null,
+};
+const FOUNDED_COL = {
+  key: "founded",
+  label: "Founded",
+  render: (r: OrgRow) => r.foundedDate,
+  has: (r: OrgRow) => Boolean(r.foundedDate),
+};
+const cols = [HEADCOUNT_COL, VALUATION_COL, FOUNDED_COL];
+
+describe("bucketOrgs", () => {
+  it("groups rows by orgType", () => {
+    const rows = [
+      org({ id: "a", name: "Anthropic", orgType: "frontier-lab" }),
+      org({ id: "b", name: "OpenAI", orgType: "frontier-lab" }),
+      org({ id: "c", name: "OP", orgType: "funder" }),
+    ];
+    const map = bucketOrgs(rows);
+    expect(map.get("frontier-lab")?.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(map.get("funder")?.map((r) => r.id)).toEqual(["c"]);
+  });
+
+  it("folds unknown / 'other' orgTypes into the generic catchall", () => {
+    const rows = [
+      org({ id: "x", name: "X", orgType: "weird-new-type" }),
+      org({ id: "y", name: "Y", orgType: null }),
+      org({ id: "z", name: "Z", orgType: "other" }),
+    ];
+    const map = bucketOrgs(rows);
+    expect(map.has("weird-new-type")).toBe(false);
+    expect(map.get("generic")?.map((r) => r.id).sort()).toEqual(["x", "y", "z"]);
+  });
+});
+
+describe("splitFeatured", () => {
+  it("ranks orgs with rendered-column data above orgs without it", () => {
+    const rows = [
+      org({ id: "rich", name: "Rich", headcount: 100, valuationNum: 1e9, foundedDate: "2020" }),
+      org({ id: "thin", name: "Thin" }), // no rendered cells
+      org({ id: "ok", name: "Ok", headcount: 10 }),
+    ];
+    const { featured, trailing } = splitFeatured(rows, cols);
+    // Rich (3 cells) > Ok (1 cell) > Thin (0 cells)
+    expect(featured.map((r) => r.id)).toEqual(["rich", "ok"]);
+    expect(trailing.map((r) => r.id)).toEqual(["thin"]);
+  });
+
+  it("treats description as a partial signal (boost over a totally empty row)", () => {
+    const rows = [
+      org({ id: "desc", name: "Desc", description: "We do alignment research." }),
+      org({ id: "blank", name: "Blank" }),
+    ];
+    const { featured, trailing } = splitFeatured(rows, cols);
+    expect(featured.map((r) => r.id)).toEqual(["desc"]);
+    expect(trailing.map((r) => r.id)).toEqual(["blank"]);
+  });
+
+  it("falls back to top 4 when nothing has rendered data", () => {
+    const rows = [
+      org({ id: "a", name: "Aardvark", completionScore: 1 }),
+      org({ id: "b", name: "Beaver", completionScore: 2 }),
+      org({ id: "c", name: "Coyote", completionScore: 1 }),
+      org({ id: "d", name: "Dingo", completionScore: 2 }),
+      org({ id: "e", name: "Elk", completionScore: 1 }),
+    ];
+    const { featured, trailing } = splitFeatured(rows, cols);
+    expect(featured).toHaveLength(4);
+    // Top 4 by completionScore (then name)
+    expect(featured[0].completionScore).toBe(2);
+    expect(trailing).toHaveLength(1);
+  });
+
+  it("caps featured at 10 and ties break by completionScore then name", () => {
+    const rows = Array.from({ length: 15 }, (_, i) =>
+      org({
+        id: `o${i}`,
+        name: `O${i.toString().padStart(2, "0")}`,
+        headcount: 10,
+        valuationNum: 1e9,
+        foundedDate: "2020",
+        completionScore: 4,
+      }),
+    );
+    const { featured, trailing } = splitFeatured(rows, cols);
+    expect(featured).toHaveLength(10);
+    expect(trailing).toHaveLength(5);
+    // Names alphabetical when scores tie
+    expect(featured.map((r) => r.id).slice(0, 3)).toEqual(["o0", "o1", "o2"]);
+  });
+
+  it("handles empty input", () => {
+    const { featured, trailing } = splitFeatured([], cols);
+    expect(featured).toEqual([]);
+    expect(trailing).toEqual([]);
+  });
+
+  it("handles single-org input", () => {
+    const rows = [org({ id: "only", name: "Only", headcount: 5 })];
+    const { featured, trailing } = splitFeatured(rows, cols);
+    expect(featured.map((r) => r.id)).toEqual(["only"]);
+    expect(trailing).toEqual([]);
+  });
+});

--- a/apps/web/src/app/organizations/organizations-grouped.tsx
+++ b/apps/web/src/app/organizations/organizations-grouped.tsx
@@ -135,6 +135,10 @@ const FALLBACK_TYPE = "generic";
 
 const MAX_FEATURED = 10;
 const MAX_TRAILING_NAMES = 8;
+/** Weight of the description field in featured-row ranking, relative to a
+ *  rendered numeric cell. Tuned so a description is enough on its own to
+ *  beat a totally blank stub but ranks below any row with hard data. */
+const DESCRIPTION_SIGNAL_WEIGHT = 0.5;
 
 // ── Featured ranking ────────────────────────────────────────────────────
 
@@ -144,7 +148,9 @@ function rowSignalCount(row: OrgRow, columns: ColumnDef[]): number {
   for (const col of columns) {
     if (col.has(row)) n++;
   }
-  if (row.description && row.description.trim().length > 0) n += 0.5;
+  if (row.description && row.description.trim().length > 0) {
+    n += DESCRIPTION_SIGNAL_WEIGHT;
+  }
   return n;
 }
 

--- a/apps/web/src/app/organizations/organizations-grouped.tsx
+++ b/apps/web/src/app/organizations/organizations-grouped.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type { OrgRow } from "./organizations-table";
+import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
+import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
+import { stripMdxEscapes } from "@/lib/inline-markdown";
+
+// ── Column definitions (universal — uses fields available in OrgRow) ─────
+
+interface ColumnDef {
+  key: string;
+  label: string;
+  /** Returns formatted display value, or null when the underlying field is empty. */
+  render: (row: OrgRow) => ReactNode | null;
+  /** Returns true when this row has data in this column. Drives signal counting. */
+  has: (row: OrgRow) => boolean;
+}
+
+const COLUMN_DEFS: Record<string, ColumnDef> = {
+  valuation: {
+    key: "valuation",
+    label: "Valuation",
+    render: (r) => (r.valuationNum != null ? formatCompactCurrency(r.valuationNum) : null),
+    has: (r) => r.valuationNum != null,
+  },
+  totalFunding: {
+    key: "totalFunding",
+    label: "Total Funding",
+    render: (r) => (r.totalFundingNum != null ? formatCompactCurrency(r.totalFundingNum) : null),
+    has: (r) => r.totalFundingNum != null,
+  },
+  revenue: {
+    key: "revenue",
+    label: "Revenue",
+    render: (r) => (r.revenueNum != null ? formatCompactCurrency(r.revenueNum) : null),
+    has: (r) => r.revenueNum != null,
+  },
+  headcount: {
+    key: "headcount",
+    label: "Headcount",
+    render: (r) => (r.headcount != null ? formatCompactNumber(r.headcount) : null),
+    has: (r) => r.headcount != null,
+  },
+  founded: {
+    key: "founded",
+    label: "Founded",
+    render: (r) => (r.foundedDate ? r.foundedDate.split("-")[0] : null),
+    has: (r) => Boolean(r.foundedDate),
+  },
+};
+
+// ── Group definitions ───────────────────────────────────────────────────
+
+interface GroupDef {
+  orgType: string;
+  label: string;
+  chipLabel: string;
+  /** One-line "what is this group and why does it matter" copy. */
+  description: string;
+  /** Tailwind bg color for the small accent dot in the section header. */
+  dotClass: string;
+  columns: string[];
+}
+
+export const GROUPS: GroupDef[] = [
+  {
+    orgType: "frontier-lab",
+    label: "Frontier AI Labs",
+    chipLabel: "Frontier Labs",
+    description:
+      "Companies training the largest general-purpose AI systems. Their compute scale, model releases, and safety posture set the pace of capability progress.",
+    dotClass: "bg-rose-400",
+    columns: ["valuation", "headcount", "totalFunding"],
+  },
+  {
+    orgType: "funder",
+    label: "Funders & Grantmakers",
+    chipLabel: "Funders",
+    description:
+      "Foundations, philanthropies, and grant programs financing AI safety work — from individual researchers to lab buildouts.",
+    dotClass: "bg-amber-400",
+    columns: ["totalFunding", "headcount", "founded"],
+  },
+  {
+    orgType: "safety-org",
+    label: "Safety & Alignment Orgs",
+    chipLabel: "Safety",
+    description:
+      "Independent organizations doing technical safety, evals, interpretability, or alignment research outside the major labs.",
+    dotClass: "bg-emerald-400",
+    columns: ["headcount", "totalFunding", "founded"],
+  },
+  {
+    orgType: "academic",
+    label: "Academic Groups",
+    chipLabel: "Academic",
+    description:
+      "University labs, centres, and research groups producing publications and training the next generation of safety researchers.",
+    dotClass: "bg-indigo-400",
+    columns: ["headcount", "founded", "totalFunding"],
+  },
+  {
+    orgType: "government",
+    label: "Government & Policy",
+    chipLabel: "Government",
+    description:
+      "Government bodies, AI safety institutes, and policy organizations shaping the regulatory and standards environment.",
+    dotClass: "bg-sky-400",
+    columns: ["headcount", "totalFunding", "founded"],
+  },
+  {
+    orgType: "startup",
+    label: "Startups",
+    chipLabel: "Startups",
+    description:
+      "Early-stage companies building tools, infrastructure, and applications across the AI safety stack.",
+    dotClass: "bg-purple-400",
+    columns: ["valuation", "headcount", "founded"],
+  },
+  {
+    orgType: "generic",
+    label: "Other Organizations",
+    chipLabel: "Other",
+    description:
+      "Other organizations tracked in the knowledge base — companies, nonprofits, and groups adjacent to AI safety.",
+    dotClass: "bg-gray-400",
+    columns: ["headcount", "totalFunding", "founded"],
+  },
+];
+
+const KNOWN_TYPES = new Set(GROUPS.map((g) => g.orgType));
+const FALLBACK_TYPE = "generic";
+
+const MAX_FEATURED = 10;
+const MAX_TRAILING_NAMES = 8;
+
+// ── Featured ranking ────────────────────────────────────────────────────
+
+/** Counts data signals visible in this group's row layout (rendered cells + description). */
+function rowSignalCount(row: OrgRow, columns: ColumnDef[]): number {
+  let n = 0;
+  for (const col of columns) {
+    if (col.has(row)) n++;
+  }
+  if (row.description && row.description.trim().length > 0) n += 0.5;
+  return n;
+}
+
+function compareForFeatured(
+  a: OrgRow,
+  b: OrgRow,
+  columns: ColumnDef[],
+): number {
+  const aSig = rowSignalCount(a, columns);
+  const bSig = rowSignalCount(b, columns);
+  if (bSig !== aSig) return bSig - aSig;
+  if (b.completionScore !== a.completionScore) {
+    return b.completionScore - a.completionScore;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+export function splitFeatured(
+  orgs: OrgRow[],
+  columns: ColumnDef[],
+): { featured: OrgRow[]; trailing: OrgRow[] } {
+  const sorted = [...orgs].sort((a, b) => compareForFeatured(a, b, columns));
+  // Anything with at least *some* signal (a rendered cell or a description)
+  // is eligible to be featured. Totally blank stubs sink to the trailing list.
+  const wellOrganized = sorted.filter(
+    (o) => rowSignalCount(o, columns) > 0,
+  );
+  const featured = wellOrganized.slice(0, MAX_FEATURED);
+  // If absolutely nothing has any data, surface a small handful so the section
+  // isn't blank — the section header's coverage badges signal this honestly.
+  const finalFeatured =
+    featured.length > 0 ? featured : sorted.slice(0, Math.min(4, sorted.length));
+  const featuredIds = new Set(finalFeatured.map((o) => o.id));
+  const trailing = sorted.filter((o) => !featuredIds.has(o.id));
+  return { featured: finalFeatured, trailing };
+}
+
+// ── Bucketing ───────────────────────────────────────────────────────────
+
+export function bucketOrgs(rows: OrgRow[]): Map<string, OrgRow[]> {
+  const byType = new Map<string, OrgRow[]>();
+  for (const row of rows) {
+    const t =
+      row.orgType && KNOWN_TYPES.has(row.orgType) ? row.orgType : FALLBACK_TYPE;
+    const arr = byType.get(t) ?? [];
+    arr.push(row);
+    byType.set(t, arr);
+  }
+  return byType;
+}
+
+// ── Components ──────────────────────────────────────────────────────────
+
+export interface OrganizationsGroupedProps {
+  rows: OrgRow[];
+  /** Called when the user clicks "view all" in a section's trailing footer. */
+  onViewAll?: (orgType: string) => void;
+}
+
+export function OrganizationsGrouped({ rows, onViewAll }: OrganizationsGroupedProps) {
+  const byType = bucketOrgs(rows);
+
+  return (
+    <div className="space-y-6">
+      {GROUPS.map((group) => {
+        const orgs = byType.get(group.orgType);
+        if (!orgs || orgs.length === 0) return null;
+        return (
+          <OrgGroupSection
+            key={group.orgType}
+            group={group}
+            orgs={orgs}
+            onViewAll={onViewAll}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function OrgGroupSection({
+  group,
+  orgs,
+  onViewAll,
+}: {
+  group: GroupDef;
+  orgs: OrgRow[];
+  onViewAll?: (orgType: string) => void;
+}) {
+  const columns = group.columns
+    .map((c) => COLUMN_DEFS[c])
+    .filter((c): c is ColumnDef => Boolean(c));
+  const { featured, trailing } = splitFeatured(orgs, columns);
+
+  return (
+    <section
+      id={`group-${group.orgType}`}
+      aria-labelledby={`group-${group.orgType}-h`}
+      className="scroll-mt-32"
+    >
+      {/* Slim single-row header: title block + description (truncated) + coverage + view-all */}
+      <header className="rounded-t-xl border border-border bg-muted/30 px-4 py-1.5 flex items-center gap-x-3 min-h-[34px]">
+        {/* Title cluster — never shrinks, never wraps */}
+        <div className="flex items-baseline gap-2 flex-none whitespace-nowrap">
+          <span
+            className={`inline-block w-2 h-2 rounded-full translate-y-[1px] ${group.dotClass}`}
+            aria-hidden="true"
+          />
+          <h2
+            id={`group-${group.orgType}-h`}
+            className="text-sm font-semibold tracking-tight text-foreground"
+          >
+            {group.label}
+          </h2>
+          <span className="text-[11px] text-muted-foreground/80 tabular-nums">
+            {orgs.length} · {featured.length} featured
+          </span>
+        </div>
+        {/* Description — fills remaining space, truncates to one line */}
+        <p className="text-xs text-muted-foreground/80 truncate flex-1 min-w-0 leading-snug hidden md:block">
+          {group.description}
+        </p>
+        {/* View-all link */}
+        {onViewAll && trailing.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onViewAll(group.orgType)}
+            className="text-[11px] text-primary hover:underline underline-offset-2 whitespace-nowrap flex-none"
+          >
+            View all {orgs.length} →
+          </button>
+        )}
+      </header>
+
+      {/* Featured rows */}
+      <ul className="rounded-b-xl border border-t-0 border-border bg-card divide-y divide-border/40 overflow-hidden">
+        {featured.map((row) => (
+          <FeaturedRow key={row.id} row={row} columns={columns} />
+        ))}
+      </ul>
+
+      {/* Trailing list */}
+      {trailing.length > 0 && (
+        <TrailingList
+          trailing={trailing}
+          orgType={group.orgType}
+          onViewAll={onViewAll}
+        />
+      )}
+    </section>
+  );
+}
+
+function FeaturedRow({
+  row,
+  columns,
+}: {
+  row: OrgRow;
+  columns: ColumnDef[];
+}) {
+  return (
+    <li className="grid grid-cols-[minmax(260px,2.6fr)_repeat(3,minmax(80px,0.8fr))_auto] items-start gap-x-4 gap-y-1 px-4 py-3 hover:bg-muted/20 transition-colors">
+      {/* Name + description */}
+      <div className="min-w-0">
+        <Link
+          href={`/organizations/${row.slug ?? row.id}`}
+          className="font-medium text-foreground hover:text-primary transition-colors"
+        >
+          {row.name}
+        </Link>
+        {row.description && (
+          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2 leading-snug">
+            {stripMdxEscapes(row.description)}
+          </p>
+        )}
+      </div>
+      {/* Per-type columns (always 3) */}
+      {[0, 1, 2].map((i) => {
+        const col = columns[i];
+        if (!col) return <div key={i} aria-hidden="true" />;
+        const value = col.render(row);
+        return (
+          <div key={col.key}>
+            <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-0.5">
+              {col.label}
+            </div>
+            {value != null ? (
+              <div className="font-semibold tabular-nums text-sm">{value}</div>
+            ) : (
+              <div className="text-muted-foreground/40 text-sm">{"\u2014"}</div>
+            )}
+          </div>
+        );
+      })}
+      {/* Coverage dots */}
+      <div className="ml-2 pt-0.5">
+        <RecordStatusDots
+          coverageScore={row.completionScore}
+          verdict={row.verdictString}
+        />
+      </div>
+    </li>
+  );
+}
+
+function TrailingList({
+  trailing,
+  orgType,
+  onViewAll,
+}: {
+  trailing: OrgRow[];
+  orgType: string;
+  onViewAll?: (orgType: string) => void;
+}) {
+  const visibleNames = trailing.slice(0, MAX_TRAILING_NAMES);
+  const remaining = trailing.length - visibleNames.length;
+
+  return (
+    <div className="mt-2 px-5 py-2 text-xs text-muted-foreground/90 leading-relaxed">
+      <span className="text-muted-foreground/60 mr-2">Also:</span>
+      {visibleNames.map((row, i) => (
+        <span key={row.id}>
+          <Link
+            href={`/organizations/${row.slug ?? row.id}`}
+            className="hover:text-primary transition-colors hover:underline underline-offset-2"
+          >
+            {row.name}
+          </Link>
+          {i < visibleNames.length - 1 ? ", " : ""}
+        </span>
+      ))}
+      {remaining > 0 && onViewAll ? (
+        <>
+          {" "}
+          <button
+            type="button"
+            onClick={() => onViewAll(orgType)}
+            className="text-primary hover:underline underline-offset-2"
+          >
+            …and {remaining} more →
+          </button>
+        </>
+      ) : remaining > 0 ? (
+        <span className="italic"> …and {remaining} more</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -679,9 +679,24 @@ export function OrganizationsTable({
                       colSpan={activeColCount}
                       className="py-8 text-center text-muted-foreground text-sm"
                     >
-                      {search
-                        ? "No organizations match your search."
-                        : "No organizations found."}
+                      <div>
+                        {search || typeFilter !== "all" || statFilter !== "all"
+                          ? "No organizations match the current filters."
+                          : "No organizations found."}
+                      </div>
+                      {(search || typeFilter !== "all" || statFilter !== "all") && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            handleSearch("");
+                            urlSetFilter("type", "all");
+                            urlSetFilter("stat", "all");
+                          }}
+                          className="mt-2 text-xs text-primary hover:underline underline-offset-2"
+                        >
+                          Clear filters
+                        </button>
+                      )}
                     </td>
                   </tr>
                 )}

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -16,11 +16,14 @@ import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
 import { useServerTable } from "@/hooks/use-server-table";
 import { formatCompactCurrency, formatCompactNumber as formatCompactNum } from "@/lib/format-compact";
+import { stripMdxEscapes } from "@/lib/inline-markdown";
 
 export interface OrgRow {
   id: string;
   slug: string | null;
   name: string;
+  /** One-line description (from YAML or wiki-server) — used in grouped view. */
+  description: string | null;
   wikiId: string | null;
   orgType: string | null;
   wikiPageId: string | null;
@@ -130,6 +133,7 @@ function transformOrgsResponse(json: unknown): { rows: OrgRow[]; total: number }
       id: org.id,
       slug: org.id,
       name: org.title,
+      description: org.description ?? null,
       wikiId: org.wikiId,
       orgType: null, // Will be enriched client-side from orgTypeMap
       wikiPageId: org.wikiId,
@@ -160,6 +164,7 @@ export function OrganizationsTable({
   stats,
   serverEnabled = false,
   orgTypeMap,
+  hideHeader = false,
 }: {
   rows: OrgRow[];
   stats?: OrgStatDef[];
@@ -167,6 +172,8 @@ export function OrganizationsTable({
   serverEnabled?: boolean;
   /** Maps entity id -> orgType for enriching server results (orgType is not in the DB) */
   orgTypeMap?: Record<string, string>;
+  /** When true, hides the table's own search input + type chips (caller renders them above). */
+  hideHeader?: boolean;
 }) {
   const serverMode = serverEnabled;
 
@@ -443,26 +450,28 @@ export function OrganizationsTable({
       )}
 
       {/* Filters */}
-      <div role="search" className="flex flex-col sm:flex-row gap-3 mb-5">
-        <input
-          type="text"
-          placeholder="Search name, type, people, funding programs, description..."
-          aria-label="Search organizations"
-          value={search}
-          onChange={(e) => handleSearch(e.target.value)}
-          className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-96"
-        />
-        <FilterChips
-          items={orgTypes.map((t) => ({
-            key: t,
-            label: ORG_TYPE_LABELS[t] ?? t,
-            count: typeCounts[t] ?? 0,
-          }))}
-          selected={typeFilter}
-          onSelect={(key) => urlSetFilter("type", key)}
-          allCount={typeCounts.all}
-        />
-      </div>
+      {!hideHeader && (
+        <div role="search" className="flex flex-col sm:flex-row gap-3 mb-5">
+          <input
+            type="text"
+            placeholder="Search name, type, people, funding programs, description..."
+            aria-label="Search organizations"
+            value={search}
+            onChange={(e) => handleSearch(e.target.value)}
+            className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full sm:w-96"
+          />
+          <FilterChips
+            items={orgTypes.map((t) => ({
+              key: t,
+              label: ORG_TYPE_LABELS[t] ?? t,
+              count: typeCounts[t] ?? 0,
+            }))}
+            selected={typeFilter}
+            onSelect={(key) => urlSetFilter("type", key)}
+            allCount={typeCounts.all}
+          />
+        </div>
+      )}
 
       {/* Results count + column picker */}
       <div className="flex items-center gap-3 mb-3">
@@ -550,26 +559,33 @@ export function OrganizationsTable({
                     key={row.id}
                     className={`hover:bg-muted/20 transition-colors ${isLoading ? "opacity-50" : ""}`}
                   >
-                    {/* Name */}
-                    <td className="py-2.5 px-3">
-                      {row.slug ? (
-                        <Link
-                          href={`/organizations/${row.slug}`}
-                          className="font-medium text-foreground hover:text-primary transition-colors"
-                        >
-                          {row.name}
-                        </Link>
-                      ) : (
-                        <span className="font-medium text-foreground">{row.name}</span>
-                      )}
-                      {row.wikiPageId && (
-                        <Link
-                          href={`/wiki/${row.wikiPageId}`}
-                          className="ml-2 text-xs text-muted-foreground hover:text-primary transition-colors"
-                          title="Wiki page"
-                        >
-                          wiki
-                        </Link>
+                    {/* Name + description */}
+                    <td className="py-2.5 px-3 max-w-[28rem]">
+                      <div className="flex items-baseline gap-2">
+                        {row.slug ? (
+                          <Link
+                            href={`/organizations/${row.slug}`}
+                            className="font-medium text-foreground hover:text-primary transition-colors"
+                          >
+                            {row.name}
+                          </Link>
+                        ) : (
+                          <span className="font-medium text-foreground">{row.name}</span>
+                        )}
+                        {row.wikiPageId && (
+                          <Link
+                            href={`/wiki/${row.wikiPageId}`}
+                            className="text-xs text-muted-foreground hover:text-primary transition-colors"
+                            title="Wiki page"
+                          >
+                            wiki
+                          </Link>
+                        )}
+                      </div>
+                      {row.description && (
+                        <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2 leading-snug">
+                          {stripMdxEscapes(row.description)}
+                        </p>
                       )}
                     </td>
 

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -403,10 +403,12 @@ export function OrganizationsTable({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [showColumnPicker]);
+  // peopleCount is intentionally NOT exposed: the API doesn't return it and
+  // the local FactBase data is too sparse to be useful. Re-add when there's
+  // a server-side rollup of personnel/career counts per org.
   type OptionalColumnKey = "peopleCount" | "completionScore";
   const OPTIONAL_COLUMNS: { key: OptionalColumnKey; label: string }[] = [
     { key: "completionScore", label: "Coverage" },
-    { key: "peopleCount", label: "People Tracked" },
   ];
   const [visibleColumns, setVisibleColumns] = useState<Set<OptionalColumnKey>>(
     () => new Set(["completionScore"]),

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -7,6 +7,10 @@ import { useDirectoryUrl } from "@/hooks/use-directory-url";
 
 type ViewMode = "groups" | "table";
 
+/** Window after a chip click during which a 2nd click on the same chip
+ *  promotes from "scroll-to-section" to "expand as filtered table view". */
+const CHIP_REPEAT_WINDOW_MS = 8000;
+
 export function OrganizationsView({
   rows,
   stats,
@@ -78,7 +82,8 @@ export function OrganizationsView({
       if (view === "groups") {
         const now = Date.now();
         const isRepeat =
-          lastChipRef.current.key === key && now - lastChipRef.current.at < 8000;
+          lastChipRef.current.key === key &&
+          now - lastChipRef.current.at < CHIP_REPEAT_WINDOW_MS;
         lastChipRef.current = { key, at: now };
 
         const sectionEl = document.getElementById(`group-${key}`);
@@ -166,10 +171,20 @@ export function OrganizationsView({
             aria-label="Organization view"
             className="inline-flex rounded-lg border border-border bg-card p-0.5 text-xs"
           >
-            <ViewTab active={view === "groups"} onClick={() => handleViewToggle("groups")}>
+            <ViewTab
+              active={view === "groups"}
+              onClick={() => handleViewToggle("groups")}
+              controls="orgs-panel-groups"
+              id="orgs-tab-groups"
+            >
               By category
             </ViewTab>
-            <ViewTab active={view === "table"} onClick={() => handleViewToggle("table")}>
+            <ViewTab
+              active={view === "table"}
+              onClick={() => handleViewToggle("table")}
+              controls="orgs-panel-table"
+              id="orgs-tab-table"
+            >
               Table view
             </ViewTab>
           </div>
@@ -182,15 +197,19 @@ export function OrganizationsView({
       </div>
 
       {view === "groups" ? (
-        <OrganizationsGrouped rows={rows} onViewAll={handleViewAll} />
+        <div role="tabpanel" id="orgs-panel-groups" aria-labelledby="orgs-tab-groups">
+          <OrganizationsGrouped rows={rows} onViewAll={handleViewAll} />
+        </div>
       ) : (
-        <OrganizationsTable
-          rows={rows}
-          stats={stats}
-          serverEnabled={serverEnabled}
-          orgTypeMap={orgTypeMap}
-          hideHeader
-        />
+        <div role="tabpanel" id="orgs-panel-table" aria-labelledby="orgs-tab-table">
+          <OrganizationsTable
+            rows={rows}
+            stats={stats}
+            serverEnabled={serverEnabled}
+            orgTypeMap={orgTypeMap}
+            hideHeader
+          />
+        </div>
       )}
     </div>
   );
@@ -229,16 +248,23 @@ function ChipButton({
 function ViewTab({
   active,
   onClick,
+  controls,
+  id,
   children,
 }: {
   active: boolean;
   onClick: () => void;
+  controls: string;
+  id: string;
   children: React.ReactNode;
 }) {
   return (
     <button
       role="tab"
+      id={id}
       aria-selected={active}
+      aria-controls={controls}
+      tabIndex={active ? 0 : -1}
       type="button"
       onClick={onClick}
       className={`px-3 py-1 rounded-md transition-colors ${

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -226,21 +226,28 @@ function ChipButton({
   selected: boolean;
   onClick: () => void;
 }) {
+  // Build a screen-reader label so chips read as "Funders, 55 organizations"
+  // rather than "Funders 55" run together.
+  const ariaLabel =
+    count != null ? `${label}, ${count} organization${count === 1 ? "" : "s"}` : label;
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={selected}
+      aria-label={ariaLabel}
       className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
         selected
           ? "bg-primary/10 border-primary/30 text-primary font-semibold"
           : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
       }`}
     >
-      {label}
-      {count != null && (
-        <span className="ml-1 text-[10px] opacity-60">{count}</span>
-      )}
+      <span aria-hidden="true">
+        {label}
+        {count != null && (
+          <span className="ml-1 text-[10px] opacity-60">{count}</span>
+        )}
+      </span>
     </button>
   );
 }
@@ -263,7 +270,10 @@ function ViewTab({
       role="tab"
       id={id}
       aria-selected={active}
-      aria-controls={controls}
+      // Only the selected tab references its panel — the inactive panel isn't
+      // in the DOM (we don't want to mount both views at once), so dangling
+      // aria-controls on the inactive tab would point at a non-existent ID.
+      aria-controls={active ? controls : undefined}
       tabIndex={active ? 0 : -1}
       type="button"
       onClick={onClick}

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -72,9 +72,7 @@ export function OrganizationsView({
     [typeCounts],
   );
 
-  // Track the last chip the user clicked so we can detect a repeat click
-  // (works even if the header is offscreen because the alreadyAtTop heuristic
-  // becomes unreliable mid-scroll).
+  // Last chip + timestamp — drives the "click again to expand as table" UX.
   const lastChipRef = useRef<{ key: string; at: number }>({ key: "", at: 0 });
 
   const handleChipClick = useCallback(

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -36,6 +36,20 @@ export function OrganizationsView({
   const lastExplicitViewRef = useRef<ViewMode>(initialView);
   const [searchOpenedTable, setSearchOpenedTable] = useState(false);
   const prevSearchRef = useRef(search);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Cmd/Ctrl+K focuses search.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   useEffect(() => {
     const wasEmpty = prevSearchRef.current.trim() === "";
@@ -136,14 +150,43 @@ export function OrganizationsView({
           scrolling through long sections. */}
       <div className="sticky top-0 z-30 -mx-6 px-6 pt-2 pb-3 mb-5 bg-background/85 backdrop-blur-md border-b border-border/40">
         <div role="search" className="flex flex-col lg:flex-row gap-3 mb-2.5">
-          <input
-            type="text"
-            placeholder="Search name, type, people, funding programs, description..."
-            aria-label="Search organizations"
-            value={search}
-            onChange={(e) => url.setSearch(e.target.value)}
-            className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full lg:w-96"
-          />
+          <div className="relative w-full lg:w-96">
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search name, type, people, funding programs, description..."
+              aria-label="Search organizations"
+              value={search}
+              onChange={(e) => url.setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && search) {
+                  e.preventDefault();
+                  url.setSearch("");
+                }
+              }}
+              className="px-3 py-2 pr-16 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full"
+            />
+            {search ? (
+              <button
+                type="button"
+                onClick={() => {
+                  url.setSearch("");
+                  searchInputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 px-1.5 py-0.5 text-xs text-muted-foreground/70 hover:text-foreground hover:bg-muted rounded transition-colors"
+              >
+                ✕
+              </button>
+            ) : (
+              <kbd
+                aria-hidden="true"
+                className="absolute right-2 top-1/2 -translate-y-1/2 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground/60 border border-border/60 rounded bg-muted/40 pointer-events-none"
+              >
+                ⌘K
+              </kbd>
+            )}
+          </div>
           <div className="flex flex-wrap gap-1.5">
             <ChipButton
               label="All"

--- a/apps/web/src/app/organizations/organizations-view.tsx
+++ b/apps/web/src/app/organizations/organizations-view.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { OrganizationsTable, type OrgRow, type OrgStatDef } from "./organizations-table";
+import { OrganizationsGrouped, GROUPS } from "./organizations-grouped";
+import { useDirectoryUrl } from "@/hooks/use-directory-url";
+
+type ViewMode = "groups" | "table";
+
+export function OrganizationsView({
+  rows,
+  stats,
+  serverEnabled = false,
+  orgTypeMap,
+}: {
+  rows: OrgRow[];
+  stats?: OrgStatDef[];
+  serverEnabled?: boolean;
+  orgTypeMap?: Record<string, string>;
+}) {
+  const url = useDirectoryUrl({
+    defaultSort: { field: "name", dir: "asc" },
+    filters: ["type", "stat"],
+  });
+  const search = url.search;
+  const typeFilter = url.filters.type ?? "all";
+
+  // Initial view: ?type=<x> on cold load means user wants the filtered table.
+  const initialView: ViewMode = typeFilter !== "all" ? "table" : "groups";
+  const [view, setView] = useState<ViewMode>(initialView);
+
+  const lastExplicitViewRef = useRef<ViewMode>(initialView);
+  const [searchOpenedTable, setSearchOpenedTable] = useState(false);
+  const prevSearchRef = useRef(search);
+
+  useEffect(() => {
+    const wasEmpty = prevSearchRef.current.trim() === "";
+    const isEmpty = search.trim() === "";
+
+    if (!isEmpty && wasEmpty && view === "groups") {
+      setSearchOpenedTable(true);
+      setView("table");
+    } else if (isEmpty && !wasEmpty && searchOpenedTable) {
+      setView(lastExplicitViewRef.current);
+      setSearchOpenedTable(false);
+    }
+    prevSearchRef.current = search;
+  }, [search, view, searchOpenedTable]);
+
+  // Counts per orgType (rolled up to the same buckets the grouped view uses).
+  const typeCounts = useMemo(() => {
+    const knownTypes = new Set(GROUPS.map((g) => g.orgType));
+    const counts: Record<string, number> = { all: rows.length };
+    for (const r of rows) {
+      const t = r.orgType && knownTypes.has(r.orgType) ? r.orgType : "generic";
+      counts[t] = (counts[t] ?? 0) + 1;
+    }
+    return counts;
+  }, [rows]);
+
+  const chipItems = useMemo(
+    () =>
+      GROUPS.filter((g) => (typeCounts[g.orgType] ?? 0) > 0).map((g) => ({
+        key: g.orgType,
+        label: g.chipLabel,
+        count: typeCounts[g.orgType] ?? 0,
+      })),
+    [typeCounts],
+  );
+
+  // Track the last chip the user clicked so we can detect a repeat click
+  // (works even if the header is offscreen because the alreadyAtTop heuristic
+  // becomes unreliable mid-scroll).
+  const lastChipRef = useRef<{ key: string; at: number }>({ key: "", at: 0 });
+
+  const handleChipClick = useCallback(
+    (key: string) => {
+      if (view === "groups") {
+        const now = Date.now();
+        const isRepeat =
+          lastChipRef.current.key === key && now - lastChipRef.current.at < 8000;
+        lastChipRef.current = { key, at: now };
+
+        const sectionEl = document.getElementById(`group-${key}`);
+
+        if (isRepeat) {
+          // Second tap on same chip → escalate to filtered table view.
+          url.setFilter("type", key);
+          setView("table");
+          lastExplicitViewRef.current = "table";
+          return;
+        }
+        if (sectionEl) {
+          sectionEl.scrollIntoView({ behavior: "smooth", block: "start" });
+          return;
+        }
+      }
+      url.setFilter("type", key);
+    },
+    [url, view],
+  );
+
+  const handleAllClick = useCallback(() => {
+    url.setFilter("type", "all");
+    if (view === "groups") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [url, view]);
+
+  const handleViewAll = useCallback(
+    (orgType: string) => {
+      url.setFilter("type", orgType);
+      setView("table");
+      lastExplicitViewRef.current = "table";
+    },
+    [url],
+  );
+
+  const handleViewToggle = useCallback(
+    (next: ViewMode) => {
+      setView(next);
+      lastExplicitViewRef.current = next;
+      if (next === "groups" && typeFilter !== "all") {
+        url.setFilter("type", "all");
+      }
+    },
+    [url, typeFilter],
+  );
+
+  return (
+    <div>
+      {/* Sticky header: search + chips + view toggle stay reachable while
+          scrolling through long sections. */}
+      <div className="sticky top-0 z-30 -mx-6 px-6 pt-2 pb-3 mb-5 bg-background/85 backdrop-blur-md border-b border-border/40">
+        <div role="search" className="flex flex-col lg:flex-row gap-3 mb-2.5">
+          <input
+            type="text"
+            placeholder="Search name, type, people, funding programs, description..."
+            aria-label="Search organizations"
+            value={search}
+            onChange={(e) => url.setSearch(e.target.value)}
+            className="px-3 py-2 text-sm rounded-lg border border-border bg-card placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 w-full lg:w-96"
+          />
+          <div className="flex flex-wrap gap-1.5">
+            <ChipButton
+              label="All"
+              count={typeCounts.all}
+              selected={typeFilter === "all"}
+              onClick={handleAllClick}
+            />
+            {chipItems.map((item) => (
+              <ChipButton
+                key={item.key}
+                label={item.label}
+                count={item.count}
+                selected={typeFilter === item.key}
+                onClick={() => handleChipClick(item.key)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <div
+            role="tablist"
+            aria-label="Organization view"
+            className="inline-flex rounded-lg border border-border bg-card p-0.5 text-xs"
+          >
+            <ViewTab active={view === "groups"} onClick={() => handleViewToggle("groups")}>
+              By category
+            </ViewTab>
+            <ViewTab active={view === "table"} onClick={() => handleViewToggle("table")}>
+              Table view
+            </ViewTab>
+          </div>
+          {view === "groups" && typeFilter === "all" && (
+            <span className="text-[11px] text-muted-foreground/70 hidden md:inline">
+              Tip: click a category chip again to see its full list
+            </span>
+          )}
+        </div>
+      </div>
+
+      {view === "groups" ? (
+        <OrganizationsGrouped rows={rows} onViewAll={handleViewAll} />
+      ) : (
+        <OrganizationsTable
+          rows={rows}
+          stats={stats}
+          serverEnabled={serverEnabled}
+          orgTypeMap={orgTypeMap}
+          hideHeader
+        />
+      )}
+    </div>
+  );
+}
+
+function ChipButton({
+  label,
+  count,
+  selected,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+        selected
+          ? "bg-primary/10 border-primary/30 text-primary font-semibold"
+          : "border-border/60 bg-card hover:bg-muted/50 text-muted-foreground"
+      }`}
+    >
+      {label}
+      {count != null && (
+        <span className="ml-1 text-[10px] opacity-60">{count}</span>
+      )}
+    </button>
+  );
+}
+
+function ViewTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-md transition-colors ${
+        active
+          ? "bg-primary/10 text-foreground font-medium"
+          : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -203,7 +203,7 @@ async function loadFromApi(
 
       foundedDate: org.foundedDate,
 
-      peopleCount: null, // Not available from API
+      peopleCount: null, // Not available from API; column hidden in picker.
       completionScore: computeOrgCoverage(org),
       verdictString: null, // entity has no sourcing verdicts yet; needs server-side roll-up (QUA-136)
 
@@ -255,7 +255,7 @@ async function loadFromApi(
 
       foundedDate,
 
-      peopleCount: null,
+      peopleCount: null, // Not available from API; column hidden in picker.
       completionScore: computeOrgCoverage({ foundedDate }),
       verdictString: null, // entity has no sourcing verdicts yet; needs server-side roll-up (QUA-136)
 
@@ -385,7 +385,8 @@ function buildStats(rows: OrgRow[]): OrgStatDef[] {
 // ── Page component ───────────────────────────────────────────────────────
 
 export default async function OrganizationsPage() {
-  // Always build orgTypeMap from local data — orgType is not in the wiki-server DB
+  // Always build orgTypeMap and people-count map from local data — neither is in
+  // the wiki-server DB, so both server- and local-mode rows resolve them locally.
   const allEntities = getTypedEntities();
   const orgs = allEntities.filter(isOrganization).filter((e) => !e.deprecated);
   const orgTypeMap: Record<string, string> = {};

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -5,7 +5,8 @@ import { getTypedEntities, isOrganization, getPageById, getTypedEntityById, type
 import { resolveOrgBySlug } from "@/app/organizations/org-utils";
 import { formatKBFactValue } from "@/components/wiki/factbase/format";
 import type { Fact, Property } from "@longterm-wiki/factbase";
-import { OrganizationsTable, type OrgRow, type OrgStatDef } from "@/app/organizations/organizations-table";
+import type { OrgRow, OrgStatDef } from "@/app/organizations/organizations-table";
+import { OrganizationsView } from "@/app/organizations/organizations-view";
 import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
 import { DataSourceBanner } from "@components/internal/DataSourceBanner";
 import { computeOrgCoverage } from "@/components/coverage/coverage-score";
@@ -181,6 +182,7 @@ async function loadFromApi(
       id: org.id,
       slug: org.id,
       name: org.title,
+      description: org.description ?? null,
       wikiId: org.wikiId,
       orgType,
       wikiPageId: org.wikiId,
@@ -232,6 +234,7 @@ async function loadFromApi(
       id: org.id,
       slug: org.id,
       name: org.title,
+      description: org.description ?? null,
       wikiId: org.wikiId ?? null,
       orgType,
       wikiPageId: org.wikiId && getPageById(org.id) ? org.wikiId : null,
@@ -316,6 +319,7 @@ function loadFromLocal(): OrgPageData {
       id: org.id,
       slug: org.id,
       name: org.title,
+      description: org.description ?? null,
       wikiId: org.wikiId ?? null,
       orgType: org.orgType ?? null,
       wikiPageId: org.wikiId && getPageById(org.id) ? org.wikiId : null,
@@ -411,7 +415,7 @@ export default async function OrganizationsPage() {
       <DataSourceBanner source={source} apiError={apiError} />
 
       <Suspense fallback={<div>Loading...</div>}>
-        <OrganizationsTable
+        <OrganizationsView
           rows={data.rows}
           stats={data.stats}
           serverEnabled={data.serverEnabled}

--- a/apps/web/src/components/internal/DataSourceBanner.tsx
+++ b/apps/web/src/components/internal/DataSourceBanner.tsx
@@ -6,13 +6,8 @@ interface DataSourceBannerProps {
 }
 
 export function DataSourceBanner({ source, apiError }: DataSourceBannerProps) {
-  if (source === "api") {
-    return (
-      <p className="text-xs text-emerald-600 dark:text-emerald-400 mb-4">
-        Live data from wiki-server
-      </p>
-    );
-  }
+  // Success case is the expected default — no need to announce it.
+  if (source === "api") return null;
 
   if (!apiError || apiError.type === "not-configured") {
     return (


### PR DESCRIPTION
## Summary

Replaces the flat `/organizations` directory with a grouped-by-type landing
view that surfaces the most-data-rich orgs first within each type, while
keeping the original sortable table accessible via a tab toggle.

## What changed

### Grouped landing view (`organizations-grouped.tsx`)
- 7 sections by `orgType`: Frontier Labs, Funders, Safety, Academic,
  Government, Startups, Other.
- Slim 34px section header: small accent dot + title + count + one-line
  description (truncated) + view-all link.
- Per-type column sets (Frontier shows valuation/headcount/funding;
  Funders show funding/headcount/founded; etc.).
- "Featured" rows ranked by data density: weights rendered cells (1 each)
  + description (0.5). Totally blank stubs sink to the trailing list.
- Trailing "Also: A, B, C, …and N more →" line links to the filtered
  table view.

### Unified header (`organizations-view.tsx`)
- Sticky search input + chip filter + view toggle so chips remain
  reachable while scrolling sections.
- Search auto-switches to Table view; clearing restores prior view.
- Chip 1st-click in groups view scrolls to that section; 2nd click
  within 8s escalates to filtered table view.
- "View all N →" / "…and N more →" buttons jump to Table view filtered
  by that orgType.
- WAI-ARIA tab semantics: `aria-controls`/`aria-labelledby` between
  active tab and panel; inactive tab drops the dangling reference.
  Chip buttons expose "Funders, 55 organizations" via `aria-label`.

### Search ergonomics
- ⌘K / Ctrl+K from anywhere on the page focuses the search input.
- Esc clears the input when it has text.
- A small ✕ button appears inside the input when populated.
- A subtle `⌘K` kbd hint sits in the input when empty.

### Table view changes
- New description column rendered under each org name with
  `stripMdxEscapes()` so `\$` / `\<` etc. don't leak into output.
- "No organizations found" empty state now offers a "Clear filters"
  button when any of search / type / stat filters are active.
- Removed the broken "People Tracked" column from the column picker —
  the data was null in API mode and only ~5/500 orgs had it locally.
  Re-add when there's a server-side personnel-count rollup.
- New `hideHeader` prop so the table doesn't double-render search/chips
  when nested under the wrapper.

### Other UX cleanup
- Shared `DataSourceBanner` no longer announces "Live data from
  wiki-server" in the success case (the expected default). Error and
  not-configured states still show. Affects every page using the banner.

### Data plumbing
- `OrgRow` gains a `description` field. Both API and local data paths
  in `page.tsx` populate it. The wiki-server already returned
  `description`; this just pipes it through.

## Test plan

- [x] `pnpm test` — 1620 tests pass (172 in organizations module)
- [x] `pnpm build` — clean
- [x] `pnpm crux w validate gate` — 52/52 checks pass
- [x] 7 new unit tests cover `bucketOrgs` + `splitFeatured`
- [x] Adversarial: `?q=<script>alert(1)</script>` renders safely
- [x] No `\$` / `\<` leaks in 70 grouped + 48 table descriptions
- [x] Mobile (390px): no horizontal overflow
- [x] ⌘K / Esc / clear button verified via Playwright
- [x] Verified against prod wiki-server data via Playwright

## Notes on what was deliberately out of scope

Three follow-up areas surfaced during review but weren't tackled here:

1. **Better tag system.** `orgType` is single-bucket today (an org can
   only be one of frontier-lab/funder/safety-org/academic/government/
   startup/generic). A multi-tag system (orgType + focusAreas[] +
   businessModel) would unlock filters like "research orgs working on
   evals" without inflating the type enum.
2. **Section-level data-coverage indicators.** Current featured ranking
   is honest (blank rows sink) but a per-section "we have funding for
   6 of 10 frontier labs" rollup would orient the reader on data depth
   per group. A first pass was implemented and removed at user request
   to keep the header slim — could return as a popover.
3. **Server-side per-org personnel count.** The "People Tracked" column
   needs a bulk endpoint (current per-org calls aren't viable for 500+
   rows) before it can be re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)