### PR TITLE
fix: entity profile polish — unknown-tab banner, chrome, facts, AI table (QUA-668, QUA-669, QUA-670, QUA-671)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -28,6 +28,21 @@ const nextConfig: NextConfig = {
   // server resources during concurrent static generation.
   staticPageGenerationTimeout: 300,
 
+  // Rewrites to rescue legacy URLs. `afterFiles` mode runs only when a
+  // filesystem route didn't match, so `/factbase/entity`, `/factbase/facts`,
+  // etc. still take precedence over the single-segment catch.
+  async rewrites() {
+    return {
+      afterFiles: [
+        // Legacy /factbase/<entity> URL used before the split into /factbase/entity/*.
+        // QUA-670: previously 404'd; rewrite to the canonical factbase-entity page.
+        { source: "/factbase/:slug", destination: "/factbase/entity/:slug" },
+      ],
+      beforeFiles: [],
+      fallback: [],
+    };
+  },
+
   async redirects() {
     return [
       // Vanity URL: /about → wiki page E755

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -106,6 +106,20 @@
   color: var(--muted-foreground);
 }
 
+/* Keyboard focus ring. The shared `focus:outline-none` on Tailwind's button
+   reset strips the default ring; Radix's `focus-visible` state isn't styled
+   by the tab classes, so we paint it here. (QUA-670) */
+.profile-tab-vertical:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--background),
+              0 0 0 4px oklch(from var(--ring) l c h / 0.8);
+}
+.profile-tab-vertical[data-state="active"]:focus-visible {
+  box-shadow: 0 0 0 1px oklch(from var(--border) l c h / 0.8),
+              0 0 0 3px var(--background),
+              0 0 0 5px oklch(from var(--ring) l c h / 0.8);
+}
+
 /* ============================================================================
    PAGE META (last updated + GitHub link)
    ============================================================================ */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -57,16 +57,19 @@ export default function RootLayout({
         {/* Top nav bar */}
         <header className="sticky top-0 z-40 border-b border-border bg-card">
           <div className="flex items-center max-w-full">
-            <Link href="/" className="w-64 shrink-0 px-4 py-3 text-lg font-bold no-underline text-foreground max-md:w-auto">
+            {/* Wordmark: w-64 only at lg+ (1024px) where the desktop nav can fit
+                alongside it. Below lg, shrink to `w-auto` so the wordmark + hamburger
+                don't collide (QUA-670). */}
+            <Link href="/" className="lg:w-64 shrink-0 px-4 py-3 text-lg font-bold no-underline text-foreground">
               Longterm Wiki
             </Link>
             <nav aria-label="Main navigation" className="flex-1 flex items-center justify-end gap-4 px-6 py-3 min-w-0">
-              <div className="hidden md:flex items-center gap-4">
+              <div className="hidden lg:flex items-center gap-4">
                 <DesktopNav />
               </div>
               <Link
                 href="/feed.xml"
-                className="hidden md:inline text-muted-foreground no-underline hover:text-foreground transition-colors"
+                className="hidden lg:inline text-muted-foreground no-underline hover:text-foreground transition-colors"
                 title="Atom feed"
                 target="_blank"
               >

--- a/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
@@ -47,7 +47,9 @@ const FEATURED_BENCHMARKS = [
 /** Pick top N benchmark scores, preferring featured benchmarks. */
 function pickTopBenchmarks(
   benchmarks: BenchmarkScore[],
-  maxCount = 3,
+  // QUA-669: 3 benchmarks per row wrapped onto 3 lines when names were long;
+  // 2 keeps the column height consistent across the table.
+  maxCount = 2,
 ): BenchmarkScore[] {
   if (benchmarks.length === 0) return [];
 
@@ -194,13 +196,24 @@ export function AiModelsSection({
                           {topBenchmarks.map((b) => (
                             <span
                               key={b.name}
-                              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted/50 text-[10px] text-muted-foreground"
+                              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted/50 text-[10px] text-muted-foreground max-w-[14rem]"
                               title={`${b.name}: ${b.score}${b.unit ? ` ${b.unit}` : ""}`}
                             >
-                              <span className="font-medium text-foreground/80">{b.name}</span>
-                              <span className="tabular-nums">{b.score}{b.unit === "%" ? "%" : ""}</span>
+                              <span className="font-medium text-foreground/80 truncate">{b.name}</span>
+                              <span className="tabular-nums shrink-0">{b.score}{b.unit === "%" ? "%" : ""}</span>
                             </span>
                           ))}
+                          {benchmarks && benchmarks.length > topBenchmarks.length && (
+                            <span
+                              className="inline-flex items-center px-1.5 py-0.5 rounded bg-transparent text-[10px] text-muted-foreground/60"
+                              title={benchmarks
+                                .slice(topBenchmarks.length)
+                                .map((b) => `${b.name}: ${b.score}${b.unit ? ` ${b.unit}` : ""}`)
+                                .join("\n")}
+                            >
+                              +{benchmarks.length - topBenchmarks.length}
+                            </span>
+                          )}
                         </div>
                       ) : null}
                     </td>

--- a/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
@@ -203,17 +203,22 @@ export function AiModelsSection({
                               <span className="tabular-nums shrink-0">{b.score}{b.unit === "%" ? "%" : ""}</span>
                             </span>
                           ))}
-                          {benchmarks && benchmarks.length > topBenchmarks.length && (
-                            <span
-                              className="inline-flex items-center px-1.5 py-0.5 rounded bg-transparent text-[10px] text-muted-foreground/60"
-                              title={benchmarks
-                                .slice(topBenchmarks.length)
-                                .map((b) => `${b.name}: ${b.score}${b.unit ? ` ${b.unit}` : ""}`)
-                                .join("\n")}
-                            >
-                              +{benchmarks.length - topBenchmarks.length}
-                            </span>
-                          )}
+                          {(() => {
+                            if (!benchmarks) return null;
+                            const shown = new Set(topBenchmarks.map((b) => b.name));
+                            const remaining = benchmarks.filter((b) => !shown.has(b.name));
+                            if (remaining.length === 0) return null;
+                            return (
+                              <span
+                                className="inline-flex items-center px-1.5 py-0.5 rounded bg-transparent text-[10px] text-muted-foreground/60"
+                                title={remaining
+                                  .map((b) => `${b.name}: ${b.score}${b.unit ? ` ${b.unit}` : ""}`)
+                                  .join("\n")}
+                              >
+                                +{remaining.length}
+                              </span>
+                            );
+                          })()}
                         </div>
                       ) : null}
                     </td>

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -337,7 +337,7 @@ export default async function OrgProfilePage({
     label: "Facts",
     group: "data",
     icon: <ListTree className={ICON_CLASS} />,
-    content: <FactBaseEntityBody entityId={entity.id} skipVerdicts />,
+    content: <FactBaseEntityBody entityId={entity.id} skipVerdicts skipHeroStats />,
   });
 
   // ── Database Records tab (embedded EntityProfileViewer) ──

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -38,7 +38,7 @@ export function MobileNav() {
   }, [open]);
 
   return (
-    <div ref={menuRef} className="md:hidden relative">
+    <div ref={menuRef} className="lg:hidden relative">
       <button
         type="button"
         onClick={() => setOpen(!open)}

--- a/apps/web/src/components/coverage/CoverageDots.tsx
+++ b/apps/web/src/components/coverage/CoverageDots.tsx
@@ -13,7 +13,7 @@ interface CoverageDotsProps {
   label?: string;
   /** Tooltip text (shown on hover) */
   tooltip?: string;
-  /** Circle size: sm = 7px (table rows), md = 9px (cards/headers) */
+  /** Circle size: sm = 6px (table rows), md = 11px (cards/headers, QUA-670) */
   size?: "sm" | "md";
   className?: string;
 }
@@ -27,7 +27,7 @@ export function CoverageDots({
 }: CoverageDotsProps) {
   const clampedScore = Math.max(1, Math.min(4, Math.round(score)));
   const pct = clampedScore * 25; // 25%, 50%, 75%, 100%
-  const dim = size === "md" ? 7 : 6;
+  const dim = size === "md" ? 11 : 6;
   const ariaLabel = label ?? `Coverage: ${pct}%`;
 
   return (

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -258,15 +258,18 @@ function HorizontalLayout({
   activeTab,
   onChange,
   ariaLabel,
+  notice,
 }: {
   tabs: ProfileTab[];
   activeTab: string;
   onChange?: (value: string) => void;
   ariaLabel?: string;
+  notice?: React.ReactNode;
 }) {
   const content = (
     <>
       <HorizontalTabsList tabs={tabs} ariaLabel={ariaLabel} />
+      {notice}
       <TabsContentList tabs={tabs} layout="horizontal" />
     </>
   );
@@ -285,12 +288,14 @@ function VerticalLayout({
   onChange,
   ariaLabel,
   groups,
+  notice,
 }: {
   tabs: ProfileTab[];
   activeTab: string;
   onChange?: (value: string) => void;
   ariaLabel?: string;
   groups?: ProfileTabGroup[];
+  notice?: React.ReactNode;
 }) {
   const content = (
     <div className="grid grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] gap-x-10 gap-y-6">
@@ -298,6 +303,7 @@ function VerticalLayout({
         <VerticalTabsNav tabs={tabs} groups={groups} ariaLabel={ariaLabel} />
       </div>
       <div className="min-w-0">
+        {notice}
         <TabsContentList tabs={tabs} layout="vertical" />
       </div>
     </div>
@@ -320,6 +326,24 @@ function VerticalLayout({
 
 // ─── Public component with URL-sync + Suspense fallback ────────────────
 
+function UnknownTabNotice({
+  requested,
+  fallback,
+}: {
+  requested: string;
+  fallback: string;
+}) {
+  return (
+    <div
+      role="status"
+      className="mb-4 rounded-md border border-amber-300/60 bg-amber-50/50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-200"
+    >
+      No <span className="font-mono">{requested}</span> data for this entity — showing{" "}
+      <span className="font-medium">{fallback}</span> instead.
+    </div>
+  );
+}
+
 function ProfileTabsInner({
   tabs,
   ariaLabel,
@@ -338,10 +362,12 @@ function ProfileTabsInner({
   // Link tabs (with href) aren't Radix tabs — they navigate on click. Pick
   // the first non-link tab as the default active id.
   const selectableTabs = tabs.filter((t) => !t.href);
-  const defaultTabId = selectableTabs[0]?.id ?? tabs[0].id;
+  const defaultTab = selectableTabs[0] ?? tabs[0];
+  const defaultTabId = defaultTab.id;
   const tabParam = searchParams.get("tab");
-  const activeTab =
-    tabParam && selectableTabs.some((t) => t.id === tabParam) ? tabParam : defaultTabId;
+  const hasTabMatch = tabParam ? selectableTabs.some((t) => t.id === tabParam) : false;
+  const activeTab = hasTabMatch ? (tabParam as string) : defaultTabId;
+  const unknownTabRequested = tabParam && !hasTabMatch ? tabParam : null;
 
   function handleTabChange(value: string) {
     if (value === defaultTabId) {
@@ -351,6 +377,10 @@ function ProfileTabsInner({
     }
   }
 
+  const notice = unknownTabRequested ? (
+    <UnknownTabNotice requested={unknownTabRequested} fallback={defaultTab.label} />
+  ) : null;
+
   return layout === "vertical" ? (
     <VerticalLayout
       tabs={tabs}
@@ -358,6 +388,7 @@ function ProfileTabsInner({
       onChange={handleTabChange}
       ariaLabel={ariaLabel}
       groups={groups}
+      notice={notice}
     />
   ) : (
     <HorizontalLayout
@@ -365,6 +396,7 @@ function ProfileTabsInner({
       activeTab={activeTab}
       onChange={handleTabChange}
       ariaLabel={ariaLabel}
+      notice={notice}
     />
   );
 }

--- a/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
+++ b/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
-/** ProfileTabs — verifies the single-tab short-circuit path (QUA-463). */
+/** ProfileTabs — single-tab short-circuit (QUA-463) and URL-sync (QUA-668). */
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+
+// Per-test mutable state so we can drive the mocked router/searchParams.
+const mockState = {
+  search: "",
+  replace: vi.fn() as ReturnType<typeof vi.fn>,
+};
 
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => new URLSearchParams(mockState.search),
   usePathname: () => "/organizations/x",
-  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useRouter: () => ({ replace: mockState.replace, push: vi.fn() }),
 }));
 
 import {
@@ -15,6 +21,11 @@ import {
   type ProfileTab,
   type ProfileTabGroup,
 } from "@components/directory/ProfileTabs";
+
+beforeEach(() => {
+  mockState.search = "";
+  mockState.replace = vi.fn();
+});
 
 function tab(
   id: string,
@@ -157,6 +168,78 @@ describe("ProfileTabs", () => {
       // fallback header using its id.
       expect(screen.getByText("extra")).toBeTruthy();
       expect(screen.getByText("About")).toBeTruthy();
+    });
+  });
+
+  describe("URL sync + scroll preservation (QUA-668)", () => {
+    function clickTab(el: HTMLElement) {
+      // Radix Tabs listens for mouseDown (pointer events) on the trigger; jsdom
+      // + fireEvent.click alone doesn't always route through Radix's handler.
+      fireEvent.mouseDown(el);
+      fireEvent.click(el);
+    }
+
+    it("calls router.replace with scroll:false when a non-default tab is clicked", () => {
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      clickTab(screen.getByRole("tab", { name: /Facts/ }));
+      expect(mockState.replace).toHaveBeenCalledWith(
+        "/organizations/x?tab=facts",
+        { scroll: false },
+      );
+    });
+
+    it("strips ?tab= from URL when the default tab is clicked", () => {
+      mockState.search = "tab=facts";
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      clickTab(screen.getByRole("tab", { name: /Overview/ }));
+      expect(mockState.replace).toHaveBeenCalledWith("/organizations/x", {
+        scroll: false,
+      });
+    });
+
+    it("shows a banner and falls back to the default tab when ?tab= names an unknown tab", () => {
+      mockState.search = "tab=shareholders";
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      // Banner names the requested tab + the fallback target.
+      const banner = screen.getByRole("status");
+      expect(banner.textContent).toMatch(/shareholders/);
+      expect(banner.textContent).toMatch(/Overview/);
+      // Default tab's content is shown.
+      expect(screen.getByTestId("overview-content")).toBeTruthy();
+    });
+
+    it("does NOT show the banner when ?tab= matches a known tab", () => {
+      mockState.search = "tab=facts";
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      expect(screen.queryByRole("status")).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/factbase/FactBaseEntityBody.tsx
+++ b/apps/web/src/components/factbase/FactBaseEntityBody.tsx
@@ -107,9 +107,16 @@ interface FactBaseEntityBodyProps {
   entityId: string;
   /** Skip fetching verdicts from wiki-server (for embedding in directory pages that use local data only). */
   skipVerdicts?: boolean;
+  /**
+   * Hide the hero stat-cards row. Use when the parent already renders the same
+   * KPIs (e.g. the Overview tab in the organization profile shows the same
+   * revenue/valuation/headcount cards, so rendering them again in the Facts
+   * tab is pure duplication — QUA-671).
+   */
+  skipHeroStats?: boolean;
 }
 
-export async function FactBaseEntityBody({ entityId, skipVerdicts }: FactBaseEntityBodyProps) {
+export async function FactBaseEntityBody({ entityId, skipVerdicts, skipHeroStats }: FactBaseEntityBodyProps) {
   const entity = getKBEntity(entityId);
   if (!entity) {
     return (
@@ -174,8 +181,8 @@ export async function FactBaseEntityBody({ entityId, skipVerdicts }: FactBaseEnt
         </div>
       )}
 
-      {/* Hero Stat Cards */}
-      {heroProps.length > 0 && (
+      {/* Hero Stat Cards — suppressed when the parent already renders them (QUA-671). */}
+      {heroProps.length > 0 && !skipHeroStats && (
         <section className="mb-8">
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-3">
             {heroProps.map((propId) => (
@@ -292,31 +299,34 @@ export async function FactBaseEntityBody({ entityId, skipVerdicts }: FactBaseEnt
           Internal Metadata
         </summary>
         <div className="mt-2 border border-border/50 rounded-lg overflow-hidden">
+          {/* Each row has an explicit " : " separator in page text so a non-CSS reader
+              (Playwright page.textContent, screen reader linear walk) still sees
+              "ID: sid_..." instead of a label/value concatenation (QUA-671). */}
           <table className="w-full text-xs">
             <tbody className="divide-y divide-border/50">
               <tr>
-                <td className="py-1.5 px-3 font-medium text-muted-foreground w-[8rem] bg-muted/20">ID</td>
+                <td className="py-1.5 px-3 font-medium text-muted-foreground w-[8rem] bg-muted/20">ID:{" "}</td>
                 <td className="py-1.5 px-3 font-mono">{entity.id}</td>
               </tr>
               {entity.stableId && (
                 <tr>
-                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Stable ID</td>
+                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Stable ID:{" "}</td>
                   <td className="py-1.5 px-3 font-mono">{entity.stableId}</td>
                 </tr>
               )}
               {entity.wikiId && (
                 <tr>
-                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Wiki ID</td>
+                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Wiki ID:{" "}</td>
                   <td className="py-1.5 px-3 font-mono">{entity.wikiId}</td>
                 </tr>
               )}
               <tr>
-                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Type</td>
+                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Type:{" "}</td>
                 <td className="py-1.5 px-3">{entity.type}</td>
               </tr>
               {entity.parent && (
                 <tr>
-                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Parent</td>
+                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Parent:{" "}</td>
                   <td className="py-1.5 px-3">
                     <Link href={`/factbase/entity/${entity.parent}`} className="text-blue-600 hover:underline dark:text-blue-400">
                       {getKBEntity(entity.parent)?.name ?? entity.parent}
@@ -325,11 +335,11 @@ export async function FactBaseEntityBody({ entityId, skipVerdicts }: FactBaseEnt
                 </tr>
               )}
               <tr>
-                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">YAML Source</td>
+                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">YAML Source:{" "}</td>
                 <td className="py-1.5 px-3 font-mono">packages/factbase/data/fb-entities/{entityId}.yaml</td>
               </tr>
               <tr>
-                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Facts</td>
+                <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Facts:{" "}</td>
                 <td className="py-1.5 px-3">
                   {structuredFacts.length} structured
                   {allFacts.length !== structuredFacts.length && ` (${allFacts.length} total)`}
@@ -337,7 +347,7 @@ export async function FactBaseEntityBody({ entityId, skipVerdicts }: FactBaseEnt
               </tr>
               {totalItems > 0 && (
                 <tr>
-                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Records</td>
+                  <td className="py-1.5 px-3 font-medium text-muted-foreground bg-muted/20">Records:{" "}</td>
                   <td className="py-1.5 px-3">
                     {totalItems} in {totalCollections} collection{totalCollections !== 1 ? "s" : ""}
                   </td>

--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -115,6 +115,39 @@ export function CategoryFactSection({
           const property = getKBProperty(propertyId);
           const latestFact = facts[0];
 
+          const isMultiPoint = facts.length > 1;
+
+          // Single-point facts: render a plain row that links to the fact
+          // detail page. Skip the `<details>` chrome + 4-column sub-table —
+          // it's pure noise for 1-row data (QUA-671).
+          if (!isMultiPoint) {
+            return (
+              <div
+                key={propertyId}
+                id={propertyId}
+                className="scroll-mt-16 flex items-center gap-4 px-4 py-3 text-sm hover:bg-muted/20 transition-colors"
+              >
+                <span className="inline-flex items-center gap-1.5 font-semibold min-w-[10rem] text-foreground/90">
+                  <FactSourcingDot factId={latestFact.id} sourceUrl={latestFact.source} size="sm" />
+                  {property?.name ?? propertyId}
+                </span>
+                <span className="flex-1 text-muted-foreground truncate font-mono text-[13px]">
+                  <FactValueDisplay fact={latestFact} property={property} />
+                </span>
+                <span className="text-muted-foreground/60 text-xs whitespace-nowrap">
+                  {formatKBDate(latestFact.asOf)}
+                </span>
+                <Link
+                  href={`/factbase/fact/${latestFact.id}`}
+                  className="text-blue-600 hover:underline dark:text-blue-400 text-xs whitespace-nowrap"
+                  title={latestFact.id}
+                >
+                  view &rarr;
+                </Link>
+              </div>
+            );
+          }
+
           return (
             <details key={propertyId} id={propertyId} className="group scroll-mt-16">
               <summary className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-muted/30 text-sm select-none transition-colors">
@@ -128,11 +161,9 @@ export function CategoryFactSection({
                 <span className="text-muted-foreground/60 text-xs whitespace-nowrap">
                   {formatKBDate(latestFact.asOf)}
                 </span>
-                {facts.length > 1 && (
-                  <span className="text-[10px] font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground whitespace-nowrap">
-                    {facts.length} pts
-                  </span>
-                )}
+                <span className="text-[10px] font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground whitespace-nowrap">
+                  {facts.length} pts
+                </span>
                 <span className="text-muted-foreground/50 text-xs group-open:rotate-90 transition-transform">
                   &#9654;
                 </span>
@@ -152,7 +183,9 @@ export function CategoryFactSection({
                     <tr className="text-xs text-muted-foreground border-b border-border">
                       <th className="text-left py-1 pr-3 font-medium">As Of</th>
                       <th className="text-left py-1 pr-3 font-medium">Value</th>
-                      <th className="text-left py-1 pr-3 font-medium">Fact ID</th>
+                      {/* "Fact ID" header dropped (QUA-671) — the cell shows "view →",
+                          not an ID, so the label was misleading. */}
+                      <th className="text-left py-1 pr-3 font-medium w-12 sr-only">Link</th>
                       <th className="text-left py-1 font-medium w-5"></th>
                     </tr>
                   </thead>

--- a/apps/web/src/components/sourcing/SourcingDot.tsx
+++ b/apps/web/src/components/sourcing/SourcingDot.tsx
@@ -33,7 +33,7 @@ interface SourcingDotProps {
   error?: string | null;
   /** Optional: original verdict string for additional context */
   originalVerdict?: string | null;
-  /** Dot size: sm = 6px (inline), md = 8px (table cell) */
+  /** Dot size: sm = 6px (inline/table), md = 10px (cards/headers, QUA-670) */
   size?: "sm" | "md";
   /** Link to sourcing detail page. When provided, the element becomes clickable. */
   href?: string;
@@ -95,7 +95,7 @@ export function SourcingDot({
   className = "",
 }: SourcingDotProps) {
   const config = SOURCE_CHECK_STATUS_CONFIG[status];
-  const dotSize = size === "md" ? "w-[7px] h-[7px]" : "w-1.5 h-1.5";
+  const dotSize = size === "md" ? "w-[10px] h-[10px]" : "w-1.5 h-1.5";
   const tooltip = buildTooltip({
     status,
     lastChecked,
@@ -108,6 +108,8 @@ export function SourcingDot({
     <span
       className={`inline-flex items-center shrink-0 ${className}`}
       title={tooltip}
+      role="img"
+      aria-label={`Sourcing: ${config.label}`}
     >
       <span
         className={`inline-block ${dotSize} rounded-full shrink-0 ${config.dotColor} ${config.borderColor}`}


### PR DESCRIPTION
## Summary

Closes four UI polish follow-ups from the organization profile redesign (PR #4553), all observed on `/organizations/anthropic`.

## QUA-668 — entity profile tabs

- URL sync + scroll preservation were already shipped in #4553; add regression tests that click a tab and assert `router.replace('/organizations/x?tab=facts', { scroll: false })`.
- New: when `?tab=` names an unknown tab, render a small amber `role="status"` banner (e.g. "No shareholders data for this entity — showing Overview instead.") above the content, instead of silently falling back. Banner slot plumbed through both horizontal and vertical layouts.

## QUA-669 — AI Models table

- Phantom `<table hidden>` + mid-width overflow: not reproducible on prod at any viewport (1 table, 0 hidden; parent already `overflow-x-auto`). Already fixed by the #4553 refactor.
- Benchmarks column: cap to top 2 (was 3) so row heights don't diverge when some models have many benchmarks and others have one. Long names truncate inside a `max-w-[14rem]` pill; trailing "+N" chip summarizes dropped benchmarks with a `title` tooltip listing them.
- Sort/filter deferred as a larger follow-up feature.

## QUA-670 — chrome polish

- Header nav collapse breakpoint moved from `md` (768px) to `lg` (1024px): below 1024 the wordmark shrinks to `w-auto` and the hamburger is used; at ≥1024 the full desktop nav + wordmark render. Fixes wordmark/nav overlap at 768–1023px.
- Keyboard focus ring on vertical profile tabs — Tailwind's `focus-visible:ring-*` variants weren't compiling against the custom CSS rule, so paint the ring directly in `globals.css`.
- `CoverageDots` and `SourcingDot` `size="md"` bumped from 7px → 11px / 10px. `SourcingDot` gains `role="img"` + `aria-label="Sourcing: <label>"` so screen readers can decode it.
- `/factbase/<slug>` no longer 404s: rewrite (afterFiles) routes it to `/factbase/entity/<slug>`, which already handles every entity type.
- Wiki-tab findings #4 (detached "Open full wiki page ↗") and #5 (no h1) are N/A since the Wiki tab is now a link-tab navigating to `/wiki/E<N>` rather than rendering inline.

## QUA-671 — Facts tab cleanup

- New `skipHeroStats` prop on `FactBaseEntityBody`; the org page's Facts tab passes it so Revenue/Valuation/Headcount/etc. KPI cards don't duplicate the ones Overview already renders.
- Single-point facts render as a plain row (property name + value + date + `view →` link) instead of a `<details>` wrapping a 4-column sub-table — 1-row "tables" were pure noise.
- Multi-point fact tables drop the misleading "Fact ID" column header (the cell shows `view →`, not an ID); kept as `sr-only`.
- Internal Metadata key cells now end with `": "` so a non-CSS text reader (Playwright `textContent`, screen-reader linear walk) sees `"ID: sid_..."` instead of `"IDsid_..."`.

## Test plan

- [x] `pnpm test` on touched components — 87 pass (ProfileTabs gains 4 new tests for URL sync + scroll preservation + unknown-tab banner)
- [x] `pnpm build` — succeeds, all 2203+ static paths regenerate
- [x] `npx tsc --noEmit` in `apps/web` — clean
- [x] `pnpm crux w validate gate --fix` — 54/54 pass (4 pre-existing advisory warnings unchanged)
- [x] Playwright dev-server check on `/organizations/anthropic`:
  - URL syncs on tab click (`?tab=facts`)
  - Unknown-tab banner renders for `?tab=nonsense`
  - Hamburger visible at 900px, desktop nav hidden
  - `/factbase/anthropic` 200 OK
  - Products tab has 1 table / 0 hidden
  - Facts tab no longer duplicates "as of" KPI cards

Fixes QUA-668
Fixes QUA-669
Fixes QUA-670
Fixes QUA-671

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for legacy factbase URLs that previously returned 404 errors
  * Unknown tab selections now display a helpful notice

* **Improvements**
  * Enhanced benchmark display with better overflow handling and compact indicators
  * Optimized single-point fact presentation for improved readability
  * Refined responsive layout alignment across screen sizes
  * Strengthened keyboard navigation with visible focus indicators on tabs
  * Increased visibility of coverage and sourcing dots
  * Improved accessibility with better labels for visual indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->