### PR TITLE
tb-importers: 4 T1 importers (Wikidata, OpenAlex, Semantic Scholar, Crossref)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -1496,6 +1496,11 @@ export const commands = {
   'sec-edgar': tbImporterCommands['sec-edgar'],
   'github-contributors': tbImporterCommands['github-contributors'],
   'hf-leaderboard': tbImporterCommands['hf-leaderboard'],
+  // QUA-666: additional T1 authoritative-source importers.
+  'wikidata': tbImporterCommands['wikidata'],
+  'openalex': tbImporterCommands['openalex'],
+  'semantic-scholar': tbImporterCommands['semantic-scholar'],
+  'crossref': tbImporterCommands['crossref'],
 };
 
 export function getHelp(): string {
@@ -1541,10 +1546,14 @@ Commands:
   data-sources-snapshot <id>  Capture a new snapshot (--all for all sources)
   data-sources-health         Check mapping validity, staleness
 
-  T1 importers (QUA-640 — defensive enrichment):
+  T1 importers (QUA-640/QUA-666 — defensive enrichment):
   sec-edgar           Fetch SEC EDGAR Form D → funding-rounds (--target=slug:cik)
   github-contributors Fetch GitHub contributors → personnel hints (--target=slug:owner/repo[,owner/repo2])
   hf-leaderboard      Fetch HF Open LLM Leaderboard → benchmark-results (--target=modelSlug:displayName:evalName)
+  wikidata            Fetch Wikidata SPARQL → organization-fact records (--target=slug:Qnumber)
+  openalex            Fetch OpenAlex works by institution → publications (--target=slug:Iinstitution_id)
+  semantic-scholar    Fetch Semantic Scholar papers by author → publications (--target=personSlug:displayName:authorId)
+  crossref            Fetch Crossref DOI metadata → publications (--target=doi:10.xxx/yyy[|org=slug][|person=slug])
 
   Website Sources:
   website-sources             Show website source help

--- a/crux/commands/tb-importers/__tests__/allowlist.test.ts
+++ b/crux/commands/tb-importers/__tests__/allowlist.test.ts
@@ -9,6 +9,14 @@ describe("T1_AUTHORITY_ALLOWLIST", () => {
     expect(sources).toContain("hf-leaderboard:");
   });
 
+  it("includes the four QUA-666 importers", () => {
+    const sources = T1_AUTHORITY_ALLOWLIST.map((e) => e.sourcePrefix);
+    expect(sources).toContain("wikidata:");
+    expect(sources).toContain("openalex:");
+    expect(sources).toContain("semantic-scholar:");
+    expect(sources).toContain("crossref:");
+  });
+
   it("each entry has a description", () => {
     for (const entry of T1_AUTHORITY_ALLOWLIST) {
       expect(entry.description.length).toBeGreaterThan(10);
@@ -30,6 +38,10 @@ describe("isT1Authoritative", () => {
     expect(isT1Authoritative("sec-edgar:0001234567-25-000001", "funding-round")).toBe(true);
     expect(isT1Authoritative("github-contributors:anthropic:alice", "personnel")).toBe(true);
     expect(isT1Authoritative("hf-leaderboard:meta-llama/M:IFEval", "benchmark-result")).toBe(true);
+    expect(isT1Authoritative("wikidata:Q108542504:P571", "organization-fact")).toBe(true);
+    expect(isT1Authoritative("openalex:W100", "publication")).toBe(true);
+    expect(isT1Authoritative("semantic-scholar:abc123", "publication")).toBe(true);
+    expect(isT1Authoritative("crossref:10.1/x", "publication")).toBe(true);
   });
 
   it("rejects when source matches but recordType doesn't", () => {

--- a/crux/commands/tb-importers/__tests__/crossref.test.ts
+++ b/crux/commands/tb-importers/__tests__/crossref.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertValidDoi,
+  normalizeDoi,
+  extractDate,
+  pickPublishedDate,
+  formatAuthor,
+  mapPublicationType,
+  fetchDoiWork,
+  buildProposal,
+  importTarget,
+  parseTargetsArg,
+  type CrossrefTarget,
+  type CrossrefWork,
+} from "../crossref.ts";
+
+const DOI = "10.1145/3442188.3445922";
+const TARGET: CrossrefTarget = {
+  orgSlug: "anthropic",
+  personSlug: "dario-amodei",
+  doi: DOI,
+};
+
+describe("assertValidDoi", () => {
+  it("accepts well-formed DOIs", () => {
+    expect(() => assertValidDoi("10.1145/3442188.3445922")).not.toThrow();
+    expect(() => assertValidDoi("10.48550/arXiv.2303.08774")).not.toThrow();
+  });
+  it("rejects empty", () => {
+    expect(() => assertValidDoi("")).toThrow(/invalid DOI/);
+  });
+  it("rejects missing '10.' prefix", () => {
+    expect(() => assertValidDoi("1145/x")).toThrow(/invalid DOI/);
+  });
+  it("rejects missing slash + suffix", () => {
+    expect(() => assertValidDoi("10.1145")).toThrow(/invalid DOI/);
+    expect(() => assertValidDoi("10.1145/")).toThrow(/invalid DOI/);
+  });
+  it("rejects whitespace in DOI", () => {
+    expect(() => assertValidDoi("10.1145/x y")).toThrow(/invalid DOI/);
+  });
+});
+
+describe("normalizeDoi", () => {
+  it("strips doi.org URL prefixes", () => {
+    expect(normalizeDoi("https://doi.org/10.1145/abc")).toBe("10.1145/abc");
+    expect(normalizeDoi("HTTPS://DOI.ORG/10.1145/ABC")).toBe("10.1145/ABC");
+    expect(normalizeDoi("doi:10.1145/abc")).toBe("10.1145/abc");
+  });
+  it("returns bare DOI unchanged after validation", () => {
+    expect(normalizeDoi("10.1145/abc")).toBe("10.1145/abc");
+  });
+  it("throws on empty/invalid", () => {
+    expect(() => normalizeDoi("")).toThrow(/empty/);
+    expect(() => normalizeDoi("not-a-doi")).toThrow(/invalid DOI/);
+  });
+});
+
+describe("extractDate", () => {
+  it("extracts YYYY from year-only tuple", () => {
+    expect(extractDate({ "date-parts": [[2023]] })).toBe("2023-01-01");
+  });
+  it("extracts YYYY-MM from year+month tuple", () => {
+    expect(extractDate({ "date-parts": [[2023, 6]] })).toBe("2023-06-01");
+  });
+  it("extracts YYYY-MM-DD from full tuple", () => {
+    expect(extractDate({ "date-parts": [[2023, 6, 15]] })).toBe("2023-06-15");
+  });
+  it("zero-pads single-digit month/day", () => {
+    expect(extractDate({ "date-parts": [[2023, 3, 5]] })).toBe("2023-03-05");
+  });
+  it("returns null for missing/empty/invalid", () => {
+    expect(extractDate(undefined)).toBeNull();
+    expect(extractDate({})).toBeNull();
+    expect(extractDate({ "date-parts": [] })).toBeNull();
+    expect(extractDate({ "date-parts": [[]] })).toBeNull();
+  });
+  it("rejects year < 1800", () => {
+    expect(extractDate({ "date-parts": [[1799]] })).toBeNull();
+    expect(extractDate({ "date-parts": [[0]] })).toBeNull();
+  });
+  it("defaults bogus month/day to 01", () => {
+    expect(extractDate({ "date-parts": [[2023, 0, 0]] })).toBe("2023-01-01");
+    expect(extractDate({ "date-parts": [[2023, 13, 32]] })).toBe("2023-01-01");
+  });
+});
+
+describe("pickPublishedDate", () => {
+  it("picks the earliest date across issued/published/published-online", () => {
+    const work: CrossrefWork = {
+      DOI,
+      issued: { "date-parts": [[2023, 6, 15]] },
+      published: { "date-parts": [[2023, 3, 1]] },
+      "published-online": { "date-parts": [[2023, 2, 28]] },
+    };
+    expect(pickPublishedDate(work)).toBe("2023-02-28");
+  });
+  it("returns null when no date is available", () => {
+    expect(pickPublishedDate({ DOI })).toBeNull();
+  });
+});
+
+describe("formatAuthor", () => {
+  it("formats given + family", () => {
+    expect(formatAuthor({ given: "Jane", family: "Smith" })).toBe("Jane Smith");
+  });
+  it("falls back to family only", () => {
+    expect(formatAuthor({ family: "Smith" })).toBe("Smith");
+  });
+  it("falls back to given only", () => {
+    expect(formatAuthor({ given: "Jane" })).toBe("Jane");
+  });
+  it("uses organizational `name` when present", () => {
+    expect(formatAuthor({ name: "OpenAI" })).toBe("OpenAI");
+  });
+  it("returns null when all fields empty", () => {
+    expect(formatAuthor({})).toBeNull();
+    expect(formatAuthor({ given: "", family: "" })).toBeNull();
+  });
+  it("trims whitespace", () => {
+    expect(formatAuthor({ given: " Jane ", family: " Smith " })).toBe("Jane Smith");
+  });
+});
+
+describe("mapPublicationType", () => {
+  it("maps posted-content → preprint", () => {
+    expect(mapPublicationType("posted-content")).toBe("preprint");
+  });
+  it("maps journal-article → paper", () => {
+    expect(mapPublicationType("journal-article")).toBe("paper");
+  });
+  it("maps book variants → book", () => {
+    expect(mapPublicationType("book")).toBe("book");
+    expect(mapPublicationType("book-chapter")).toBe("book");
+    expect(mapPublicationType("book-section")).toBe("book");
+  });
+  it("maps report variants → report", () => {
+    expect(mapPublicationType("report")).toBe("report");
+    expect(mapPublicationType("report-component")).toBe("report");
+  });
+  it("falls back to paper for unknown/null", () => {
+    expect(mapPublicationType(null)).toBe("paper");
+    expect(mapPublicationType(undefined)).toBe("paper");
+    expect(mapPublicationType("weird")).toBe("paper");
+  });
+});
+
+describe("fetchDoiWork", () => {
+  function makeFetch(body: unknown, status = 200): typeof fetch {
+    return (async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      async json() {
+        return body;
+      },
+    })) as unknown as typeof fetch;
+  }
+
+  it("returns the message on ok status", async () => {
+    const fetchImpl = makeFetch({
+      status: "ok",
+      message: { DOI, title: ["x"] },
+    });
+    const w = await fetchDoiWork(DOI, { fetchImpl });
+    expect(w.DOI).toBe(DOI);
+  });
+
+  it("throws on non-2xx", async () => {
+    const fetchImpl = makeFetch(null, 404);
+    await expect(fetchDoiWork(DOI, { fetchImpl })).rejects.toThrow(/HTTP 404/);
+  });
+
+  it("throws when status != ok", async () => {
+    const fetchImpl = makeFetch({ status: "failed" });
+    await expect(fetchDoiWork(DOI, { fetchImpl })).rejects.toThrow(/status=failed/);
+  });
+
+  it("rejects invalid DOI before network call", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("should not fire");
+    }) as unknown as typeof fetch;
+    await expect(fetchDoiWork("not-a-doi", { fetchImpl })).rejects.toThrow(
+      /invalid DOI/
+    );
+  });
+
+  it("URL-encodes the DOI in path", async () => {
+    let capturedUrl = "";
+    const fetchImpl = (async (url: string) => {
+      capturedUrl = String(url);
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { status: "ok", message: { DOI } };
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchDoiWork(DOI, { fetchImpl });
+    expect(capturedUrl).toContain(encodeURIComponent(DOI));
+  });
+
+  it("appends ?mailto= when provided", async () => {
+    let capturedUrl = "";
+    const fetchImpl = (async (url: string) => {
+      capturedUrl = String(url);
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { status: "ok", message: { DOI } };
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchDoiWork(DOI, { fetchImpl, mailto: "bot@example.com" });
+    expect(capturedUrl).toContain("mailto=bot%40example.com");
+  });
+});
+
+describe("buildProposal", () => {
+  const baseWork: CrossrefWork = {
+    DOI,
+    title: ["Constitutional AI"],
+    author: [
+      { given: "Yuntao", family: "Bai" },
+      { given: "Saurav", family: "Kadavath" },
+    ],
+    "container-title": ["arXiv"],
+    publisher: "arXiv.org",
+    type: "posted-content",
+    issued: { "date-parts": [[2022, 12, 15]] },
+    URL: "https://arxiv.org/abs/2212.08073",
+  };
+
+  it("emits T1 + crossref source + publication recordType", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.tier).toBe("T1");
+    expect(p.source).toBe(`crossref:${DOI}`);
+    expect(p.recordType).toBe("publication");
+  });
+
+  it("emits both org and person entity refs when provided", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.entityRefs?.organization).toBe("anthropic");
+    expect(p.entityRefs?.person).toBe("dario-amodei");
+  });
+
+  it("omits empty entityRefs when no target refs supplied", () => {
+    const t: CrossrefTarget = { doi: DOI };
+    const p = buildProposal(t, baseWork)!;
+    expect(p.entityRefs?.organization).toBeUndefined();
+    expect(p.entityRefs?.person).toBeUndefined();
+  });
+
+  it("preserves title/DOI/venue/publisher/authors", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.record.title).toBe("Constitutional AI");
+    expect(p.record.doi).toBe(DOI);
+    expect(p.record.venue).toBe("arXiv");
+    expect(p.record.publisher).toBe("arXiv.org");
+    expect(p.record.authors).toEqual(["Yuntao Bai", "Saurav Kadavath"]);
+  });
+
+  it("maps posted-content → preprint", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.record.publicationType).toBe("preprint");
+  });
+
+  it("returns null for missing title", () => {
+    expect(buildProposal(TARGET, { ...baseWork, title: [] })).toBeNull();
+    expect(buildProposal(TARGET, { ...baseWork, title: [""] })).toBeNull();
+    expect(buildProposal(TARGET, { ...baseWork, title: undefined })).toBeNull();
+  });
+
+  it("returns null for missing date", () => {
+    expect(
+      buildProposal(TARGET, {
+        ...baseWork,
+        issued: undefined,
+        published: undefined,
+        "published-print": undefined,
+        "published-online": undefined,
+      })
+    ).toBeNull();
+  });
+
+  it("falls back to doi.org URL when URL is missing", () => {
+    const p = buildProposal(TARGET, { ...baseWork, URL: null })!;
+    expect(p.record.url).toBe(`https://doi.org/${DOI}`);
+  });
+
+  it("has deterministic hash over (doi, title, date)", () => {
+    const a = buildProposal(TARGET, baseWork)!;
+    const b = buildProposal(TARGET, baseWork)!;
+    expect(a.responseHash).toBe(b.responseHash);
+    expect(a.responseHash).toHaveLength(64);
+  });
+});
+
+describe("importTarget", () => {
+  it("fetches + builds proposal", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          status: "ok",
+          message: {
+            DOI,
+            title: ["Constitutional AI"],
+            issued: { "date-parts": [[2022, 12, 15]] },
+          },
+        };
+      },
+    })) as unknown as typeof fetch;
+    const { proposal } = await importTarget(TARGET, { fetchImpl });
+    expect(proposal).not.toBeNull();
+    expect(proposal!.record.title).toBe("Constitutional AI");
+  });
+
+  it("returns null proposal when work lacks required fields", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          status: "ok",
+          message: { DOI, title: [] }, // no title
+        };
+      },
+    })) as unknown as typeof fetch;
+    const { proposal } = await importTarget(TARGET, { fetchImpl });
+    expect(proposal).toBeNull();
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses --target=doi:10.xxx/yyy (DOI only)", () => {
+    const out = parseTargetsArg([`--target=doi:${DOI}`]);
+    expect(out).toEqual([{ doi: DOI }]);
+  });
+
+  it("normalizes DOI URL form", () => {
+    const out = parseTargetsArg([`--target=doi:https://doi.org/${DOI}`]);
+    expect(out[0].doi).toBe(DOI);
+  });
+
+  it("parses pipe-separated org attribute", () => {
+    const out = parseTargetsArg([`--target=doi:${DOI}|org=anthropic`]);
+    expect(out[0]).toEqual({ doi: DOI, orgSlug: "anthropic" });
+  });
+
+  it("parses pipe-separated person attribute", () => {
+    const out = parseTargetsArg([`--target=doi:${DOI}|person=jane-smith`]);
+    expect(out[0].personSlug).toBe("jane-smith");
+  });
+
+  it("parses both org and person", () => {
+    const out = parseTargetsArg([
+      `--target=doi:${DOI}|org=anthropic|person=jane-smith`,
+    ]);
+    expect(out[0].orgSlug).toBe("anthropic");
+    expect(out[0].personSlug).toBe("jane-smith");
+  });
+
+  it("throws when doi: prefix missing", () => {
+    expect(() => parseTargetsArg([`--target=${DOI}`])).toThrow(/must start with "doi:"/);
+  });
+
+  it("throws on invalid DOI format", () => {
+    expect(() => parseTargetsArg(["--target=doi:not-a-doi"])).toThrow(/invalid DOI/);
+  });
+
+  it("throws on malformed attribute (no =)", () => {
+    expect(() =>
+      parseTargetsArg([`--target=doi:${DOI}|orgonly`])
+    ).toThrow(/key=value/);
+  });
+
+  it("throws on unknown attribute key", () => {
+    expect(() =>
+      parseTargetsArg([`--target=doi:${DOI}|foo=bar`])
+    ).toThrow(/unknown attribute/);
+  });
+
+  it("throws on empty attribute value", () => {
+    expect(() =>
+      parseTargetsArg([`--target=doi:${DOI}|org=`])
+    ).toThrow(/empty value/);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/openalex.test.ts
+++ b/crux/commands/tb-importers/__tests__/openalex.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertValidInstitutionId,
+  normalizeDoi,
+  workShortId,
+  mapPublicationType,
+  fetchInstitutionWorks,
+  buildProposal,
+  importTarget,
+  parseTargetsArg,
+  type OpenAlexTarget,
+  type OpenAlexWork,
+} from "../openalex.ts";
+
+const TARGET: OpenAlexTarget = {
+  orgSlug: "anthropic",
+  orgName: "Anthropic",
+  institutionId: "I4210125762",
+};
+
+describe("assertValidInstitutionId", () => {
+  it("accepts valid IDs", () => {
+    expect(() => assertValidInstitutionId("I1")).not.toThrow();
+    expect(() => assertValidInstitutionId("I4210125762")).not.toThrow();
+  });
+  it("rejects leading zero", () => {
+    expect(() => assertValidInstitutionId("I0")).toThrow(/invalid OpenAlex/);
+    expect(() => assertValidInstitutionId("I04210125762")).toThrow(/invalid OpenAlex/);
+  });
+  it("rejects missing I prefix", () => {
+    expect(() => assertValidInstitutionId("4210125762")).toThrow(/invalid OpenAlex/);
+    expect(() => assertValidInstitutionId("i4210125762")).toThrow(/invalid OpenAlex/);
+  });
+  it("rejects trailing characters", () => {
+    expect(() => assertValidInstitutionId("I4210125762-abc")).toThrow(/invalid OpenAlex/);
+  });
+});
+
+describe("normalizeDoi", () => {
+  it("returns null for null/empty/whitespace", () => {
+    expect(normalizeDoi(null)).toBeNull();
+    expect(normalizeDoi(undefined)).toBeNull();
+    expect(normalizeDoi("")).toBeNull();
+    expect(normalizeDoi("   ")).toBeNull();
+  });
+  it("strips https://doi.org/ prefix", () => {
+    expect(normalizeDoi("https://doi.org/10.1145/3442188.3445922")).toBe(
+      "10.1145/3442188.3445922"
+    );
+  });
+  it("strips http://doi.org/ and doi: prefixes", () => {
+    expect(normalizeDoi("http://doi.org/10.1/x")).toBe("10.1/x");
+    expect(normalizeDoi("doi:10.1/x")).toBe("10.1/x");
+  });
+  it("strips case-insensitively but preserves DOI case", () => {
+    // Prefix match is case-insensitive; actual DOI body preserves case.
+    expect(normalizeDoi("HTTPS://DOI.ORG/10.1145/xYZ")).toBe("10.1145/xYZ");
+  });
+  it("returns a bare DOI unchanged", () => {
+    expect(normalizeDoi("10.1145/x")).toBe("10.1145/x");
+  });
+});
+
+describe("workShortId", () => {
+  it("strips the OpenAlex URL prefix", () => {
+    expect(workShortId("https://openalex.org/W12345")).toBe("W12345");
+    expect(workShortId("http://openalex.org/W9999")).toBe("W9999");
+  });
+  it("passes through bare IDs unchanged", () => {
+    expect(workShortId("W12345")).toBe("W12345");
+  });
+});
+
+describe("mapPublicationType", () => {
+  it("maps known types", () => {
+    expect(mapPublicationType("journal-article")).toBe("paper");
+    expect(mapPublicationType("article")).toBe("paper");
+    expect(mapPublicationType("preprint")).toBe("preprint");
+    expect(mapPublicationType("book-chapter")).toBe("book");
+    expect(mapPublicationType("book")).toBe("book");
+    expect(mapPublicationType("dissertation")).toBe("thesis");
+    expect(mapPublicationType("report")).toBe("report");
+  });
+  it("falls back to 'paper' for unknown or null", () => {
+    expect(mapPublicationType(null)).toBe("paper");
+    expect(mapPublicationType(undefined)).toBe("paper");
+    expect(mapPublicationType("something-new")).toBe("paper");
+  });
+});
+
+describe("fetchInstitutionWorks — pagination + limits", () => {
+  function pagedFetch(pages: unknown[]): typeof fetch {
+    let call = 0;
+    return (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return pages[call++] ?? { results: [], meta: { next_cursor: null } };
+      },
+    })) as unknown as typeof fetch;
+  }
+
+  it("follows next_cursor across multiple pages", async () => {
+    const fetchImpl = pagedFetch([
+      { results: [{ id: "https://openalex.org/W1", title: "A" }], meta: { next_cursor: "c2" } },
+      { results: [{ id: "https://openalex.org/W2", title: "B" }], meta: { next_cursor: null } },
+    ]);
+    const works = await fetchInstitutionWorks("I4210125762", { fetchImpl, perPage: 1 });
+    expect(works.map((w) => w.title)).toEqual(["A", "B"]);
+  });
+
+  it("stops at maxWorks even if cursor is still open", async () => {
+    const fetchImpl = pagedFetch([
+      {
+        results: [
+          { id: "https://openalex.org/W1", title: "A" },
+          { id: "https://openalex.org/W2", title: "B" },
+          { id: "https://openalex.org/W3", title: "C" },
+        ],
+        meta: { next_cursor: "more" },
+      },
+    ]);
+    const works = await fetchInstitutionWorks("I4210125762", {
+      fetchImpl,
+      perPage: 100,
+      maxWorks: 2,
+    });
+    expect(works).toHaveLength(2);
+  });
+
+  it("stops when results array is empty even with a cursor", async () => {
+    const fetchImpl = pagedFetch([
+      { results: [], meta: { next_cursor: "never-reached" } },
+    ]);
+    const works = await fetchInstitutionWorks("I42", { fetchImpl });
+    expect(works).toEqual([]);
+  });
+
+  it("throws on non-2xx", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 429 })) as unknown as typeof fetch;
+    await expect(fetchInstitutionWorks("I42", { fetchImpl })).rejects.toThrow(
+      /HTTP 429/
+    );
+  });
+
+  it("rejects bad institution ID before network call", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("should not be called");
+    }) as unknown as typeof fetch;
+    await expect(
+      fetchInstitutionWorks("bad", { fetchImpl })
+    ).rejects.toThrow(/invalid OpenAlex/);
+  });
+
+  it("includes mailto polite-pool param when set", async () => {
+    let capturedUrl = "";
+    const fetchImpl = (async (url: string) => {
+      capturedUrl = String(url);
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { results: [], meta: { next_cursor: null } };
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchInstitutionWorks("I42", {
+      fetchImpl,
+      mailto: "bot@example.com",
+    });
+    expect(capturedUrl).toContain("mailto=bot%40example.com");
+  });
+});
+
+describe("buildProposal", () => {
+  const baseWork: OpenAlexWork = {
+    id: "https://openalex.org/W100",
+    doi: "https://doi.org/10.1145/x",
+    title: "Constitutional AI",
+    publication_date: "2022-12-15",
+    type: "preprint",
+    authorships: [
+      { author: { display_name: "Yuntao Bai" } },
+      { author: { display_name: "Saurav Kadavath" } },
+    ],
+    primary_location: {
+      source: { display_name: "arXiv" },
+      landing_page_url: "https://arxiv.org/abs/2212.08073",
+    },
+  };
+
+  it("emits T1 + openalex source + publication recordType", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.tier).toBe("T1");
+    expect(p.source).toBe("openalex:W100");
+    expect(p.recordType).toBe("publication");
+    expect(p.entityRefs?.organization).toBe("anthropic");
+  });
+
+  it("normalizes the DOI (strips URL prefix)", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.record.doi).toBe("10.1145/x");
+  });
+
+  it("preserves title, authors (deduped, in order), venue, URL", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.record.title).toBe("Constitutional AI");
+    expect(p.record.authors).toEqual(["Yuntao Bai", "Saurav Kadavath"]);
+    expect(p.record.venue).toBe("arXiv");
+    expect(p.record.url).toBe("https://arxiv.org/abs/2212.08073");
+  });
+
+  it("maps preprint → preprint", () => {
+    const p = buildProposal(TARGET, baseWork)!;
+    expect(p.record.publicationType).toBe("preprint");
+  });
+
+  it("dedupes duplicate author names preserving first occurrence", () => {
+    const work: OpenAlexWork = {
+      ...baseWork,
+      authorships: [
+        { author: { display_name: "Yuntao Bai" } },
+        { author: { display_name: "Yuntao Bai" } },
+        { author: { display_name: "Saurav Kadavath" } },
+      ],
+    };
+    const p = buildProposal(TARGET, work)!;
+    expect(p.record.authors).toEqual(["Yuntao Bai", "Saurav Kadavath"]);
+  });
+
+  it("falls back to raw_author_name when display_name is missing", () => {
+    const work: OpenAlexWork = {
+      ...baseWork,
+      authorships: [
+        { raw_author_name: "Anonymous Submitter" },
+        { author: { display_name: "" }, raw_author_name: "Fallback" },
+      ],
+    };
+    const p = buildProposal(TARGET, work)!;
+    expect(p.record.authors).toEqual(["Anonymous Submitter", "Fallback"]);
+  });
+
+  it("returns null when title is empty/whitespace", () => {
+    expect(buildProposal(TARGET, { ...baseWork, title: "" })).toBeNull();
+    expect(buildProposal(TARGET, { ...baseWork, title: "   " })).toBeNull();
+    expect(buildProposal(TARGET, { ...baseWork, title: undefined })).toBeNull();
+  });
+
+  it("returns null when neither publication_date nor year is present", () => {
+    expect(
+      buildProposal(TARGET, {
+        ...baseWork,
+        publication_date: null,
+        publication_year: null,
+      })
+    ).toBeNull();
+  });
+
+  it("falls back to publication_year when publication_date is absent", () => {
+    const p = buildProposal(TARGET, {
+      ...baseWork,
+      publication_date: null,
+      publication_year: 2023,
+    })!;
+    expect(p.record.publishedDate).toBe("2023-01-01");
+  });
+
+  it("falls back to openalex URL when no primary_location.landing_page_url", () => {
+    const p = buildProposal(TARGET, {
+      ...baseWork,
+      primary_location: null,
+      doi: null,
+    })!;
+    expect(p.record.url).toBe("https://openalex.org/W100");
+  });
+
+  it("falls back to doi.org URL when no landing page but DOI is present", () => {
+    const p = buildProposal(TARGET, {
+      ...baseWork,
+      primary_location: null,
+    })!;
+    expect(p.record.url).toBe("https://doi.org/10.1145/x");
+  });
+
+  it("hash is deterministic over same (id, doi, title, date)", () => {
+    const a = buildProposal(TARGET, baseWork)!;
+    const b = buildProposal(TARGET, baseWork)!;
+    expect(a.responseHash).toBe(b.responseHash);
+    expect(a.responseHash).toHaveLength(64);
+  });
+});
+
+describe("importTarget", () => {
+  it("skips works with missing title/date; counts them", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          results: [
+            { id: "https://openalex.org/W1", title: "A", publication_date: "2024-01-01" },
+            { id: "https://openalex.org/W2", title: null, publication_date: "2024-01-01" },
+            { id: "https://openalex.org/W3", title: "C", publication_date: null },
+          ],
+          meta: { next_cursor: null },
+        };
+      },
+    })) as unknown as typeof fetch;
+    const { proposals, skipped } = await importTarget(TARGET, { fetchImpl });
+    expect(proposals).toHaveLength(1);
+    expect(skipped).toBe(2);
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses --target=slug:Inumber", () => {
+    expect(parseTargetsArg(["--target=anthropic:I4210125762"])).toEqual([
+      { orgSlug: "anthropic", orgName: "anthropic", institutionId: "I4210125762" },
+    ]);
+  });
+  it("throws on no colon", () => {
+    expect(() => parseTargetsArg(["--target=slug"])).toThrow(/exactly one colon/);
+  });
+  it("throws on extra colons", () => {
+    expect(() => parseTargetsArg(["--target=a:I1:extra"])).toThrow(
+      /exactly one colon/
+    );
+  });
+  it("throws on empty slug or institution id", () => {
+    expect(() => parseTargetsArg(["--target=:I1"])).toThrow(/non-empty/);
+    expect(() => parseTargetsArg(["--target=a:"])).toThrow(/non-empty/);
+  });
+  it("throws on malformed institution id", () => {
+    expect(() => parseTargetsArg(["--target=a:42"])).toThrow(/invalid OpenAlex/);
+    expect(() => parseTargetsArg(["--target=a:I0"])).toThrow(/invalid OpenAlex/);
+  });
+});

--- a/crux/commands/tb-importers/__tests__/semantic-scholar.test.ts
+++ b/crux/commands/tb-importers/__tests__/semantic-scholar.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertValidAuthorId,
+  mapPublicationType,
+  normalizeDoi,
+  fetchAuthorPapers,
+  buildProposal,
+  importTarget,
+  parseTargetsArg,
+  type SemanticScholarTarget,
+  type SemanticScholarPaper,
+} from "../semantic-scholar.ts";
+
+const TARGET: SemanticScholarTarget = {
+  personSlug: "dario-amodei",
+  personName: "Dario Amodei",
+  authorId: "1712334",
+};
+
+describe("assertValidAuthorId", () => {
+  it("accepts numeric IDs", () => {
+    expect(() => assertValidAuthorId("1")).not.toThrow();
+    expect(() => assertValidAuthorId("1712334")).not.toThrow();
+  });
+  it("rejects non-numeric", () => {
+    expect(() => assertValidAuthorId("abc")).toThrow(/invalid Semantic Scholar/);
+    expect(() => assertValidAuthorId("123x")).toThrow(/invalid Semantic Scholar/);
+  });
+  it("rejects empty", () => {
+    expect(() => assertValidAuthorId("")).toThrow(/invalid Semantic Scholar/);
+  });
+  it("rejects IDs with leading/trailing whitespace", () => {
+    expect(() => assertValidAuthorId(" 123")).toThrow(/invalid Semantic Scholar/);
+    expect(() => assertValidAuthorId("123 ")).toThrow(/invalid Semantic Scholar/);
+  });
+});
+
+describe("mapPublicationType", () => {
+  it("maps Book → book", () => {
+    expect(mapPublicationType(["Book"])).toBe("book");
+  });
+  it("maps JournalArticle → paper", () => {
+    expect(mapPublicationType(["JournalArticle"])).toBe("paper");
+  });
+  it("maps Conference → paper", () => {
+    expect(mapPublicationType(["Conference"])).toBe("paper");
+  });
+  it("maps Review → paper", () => {
+    expect(mapPublicationType(["Review"])).toBe("paper");
+  });
+  it("returns paper for null/empty", () => {
+    expect(mapPublicationType(null)).toBe("paper");
+    expect(mapPublicationType(undefined)).toBe("paper");
+    expect(mapPublicationType([])).toBe("paper");
+  });
+  it("prefers Book > other types when multiple present", () => {
+    expect(mapPublicationType(["JournalArticle", "Book"])).toBe("book");
+  });
+});
+
+describe("normalizeDoi", () => {
+  it("returns null for null/empty", () => {
+    expect(normalizeDoi(null)).toBeNull();
+    expect(normalizeDoi(undefined)).toBeNull();
+    expect(normalizeDoi("")).toBeNull();
+  });
+  it("strips doi.org URL prefixes", () => {
+    expect(normalizeDoi("https://doi.org/10.1/x")).toBe("10.1/x");
+    expect(normalizeDoi("http://doi.org/10.1/x")).toBe("10.1/x");
+    expect(normalizeDoi("doi:10.1/x")).toBe("10.1/x");
+  });
+});
+
+describe("fetchAuthorPapers", () => {
+  function pagedFetch(pages: unknown[]): typeof fetch {
+    let call = 0;
+    return (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return pages[call++] ?? { data: [] };
+      },
+    })) as unknown as typeof fetch;
+  }
+
+  it("paginates via `next` offsets", async () => {
+    const fetchImpl = pagedFetch([
+      { data: [{ paperId: "p1" }], next: 1 },
+      { data: [{ paperId: "p2" }], next: 2 },
+      { data: [] },
+    ]);
+    const papers = await fetchAuthorPapers("1", { fetchImpl, limit: 1 });
+    expect(papers.map((p) => p.paperId)).toEqual(["p1", "p2"]);
+  });
+
+  it("stops when `next` is missing", async () => {
+    const fetchImpl = pagedFetch([
+      { data: [{ paperId: "p1" }] /* no next field */ },
+    ]);
+    const papers = await fetchAuthorPapers("1", { fetchImpl });
+    expect(papers).toHaveLength(1);
+  });
+
+  it("stops when `next` does not advance (defensive against bad APIs)", async () => {
+    const fetchImpl = pagedFetch([
+      { data: [{ paperId: "p1" }], next: 0 }, // same offset — terminator
+    ]);
+    const papers = await fetchAuthorPapers("1", { fetchImpl });
+    expect(papers).toHaveLength(1);
+  });
+
+  it("respects maxPapers", async () => {
+    const fetchImpl = pagedFetch([
+      { data: [{ paperId: "p1" }, { paperId: "p2" }, { paperId: "p3" }], next: 3 },
+    ]);
+    const papers = await fetchAuthorPapers("1", { fetchImpl, maxPapers: 2 });
+    expect(papers).toHaveLength(2);
+  });
+
+  it("throws on non-2xx", async () => {
+    const fetchImpl = (async () => ({ ok: false, status: 403 })) as unknown as typeof fetch;
+    await expect(fetchAuthorPapers("1", { fetchImpl })).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("rejects bad author ID before network call", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("should not fire");
+    }) as unknown as typeof fetch;
+    await expect(fetchAuthorPapers("bad", { fetchImpl })).rejects.toThrow(
+      /invalid Semantic Scholar/
+    );
+  });
+
+  it("sends x-api-key when provided", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      captured = String(
+        (init?.headers as Record<string, string>)?.["x-api-key"] ?? ""
+      );
+      return { ok: true, status: 200, async json() { return { data: [] }; } };
+    }) as unknown as typeof fetch;
+    await fetchAuthorPapers("1", { fetchImpl, apiKey: "my-key" });
+    expect(captured).toBe("my-key");
+  });
+
+  it("strips CR/LF from apiKey (header injection guard)", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      captured = String(
+        (init?.headers as Record<string, string>)?.["x-api-key"] ?? ""
+      );
+      return { ok: true, status: 200, async json() { return { data: [] }; } };
+    }) as unknown as typeof fetch;
+    await fetchAuthorPapers("1", { fetchImpl, apiKey: "bad\r\nX-Inj: pwn" });
+    expect(captured).not.toContain("\r");
+    expect(captured).not.toContain("\n");
+  });
+});
+
+describe("buildProposal", () => {
+  const basePaper: SemanticScholarPaper = {
+    paperId: "abc123",
+    externalIds: { DOI: "10.1/x", ArXiv: "2307.12345" },
+    title: "On Cruxes",
+    venue: "NeurIPS",
+    year: 2023,
+    publicationDate: "2023-06-15",
+    publicationTypes: ["JournalArticle"],
+    url: "https://example.org/paper",
+  };
+
+  it("emits T1 + semantic-scholar source + publication recordType", () => {
+    const p = buildProposal(TARGET, basePaper)!;
+    expect(p.tier).toBe("T1");
+    expect(p.source).toBe("semantic-scholar:abc123");
+    expect(p.recordType).toBe("publication");
+    expect(p.entityRefs?.person).toBe("dario-amodei");
+  });
+
+  it("preserves title/DOI/venue/arxiv", () => {
+    const p = buildProposal(TARGET, basePaper)!;
+    expect(p.record.title).toBe("On Cruxes");
+    expect(p.record.doi).toBe("10.1/x");
+    expect(p.record.arxivId).toBe("2307.12345");
+    expect(p.record.venue).toBe("NeurIPS");
+  });
+
+  it("returns null when title is missing", () => {
+    expect(buildProposal(TARGET, { ...basePaper, title: "" })).toBeNull();
+    expect(buildProposal(TARGET, { ...basePaper, title: null })).toBeNull();
+  });
+
+  it("returns null when date unresolvable", () => {
+    expect(
+      buildProposal(TARGET, { ...basePaper, publicationDate: null, year: null })
+    ).toBeNull();
+    // Year 0 is treated as unset
+    expect(
+      buildProposal(TARGET, { ...basePaper, publicationDate: null, year: 0 })
+    ).toBeNull();
+    expect(
+      buildProposal(TARGET, { ...basePaper, publicationDate: null, year: 1700 })
+    ).toBeNull();
+  });
+
+  it("falls back to year-only when publicationDate is absent", () => {
+    const p = buildProposal(TARGET, {
+      ...basePaper,
+      publicationDate: null,
+      year: 2022,
+    })!;
+    expect(p.record.publishedDate).toBe("2022-01-01");
+  });
+
+  it("falls back to s2 URL when no paper.url", () => {
+    const p = buildProposal(TARGET, { ...basePaper, url: null, externalIds: null })!;
+    expect(p.record.url).toBe("https://www.semanticscholar.org/paper/abc123");
+  });
+
+  it("falls back to doi.org URL when no paper.url but has DOI", () => {
+    const p = buildProposal(TARGET, { ...basePaper, url: null })!;
+    expect(p.record.url).toBe("https://doi.org/10.1/x");
+  });
+
+  it("includes arxiv id in notes when present", () => {
+    const p = buildProposal(TARGET, basePaper)!;
+    expect(String(p.record.notes)).toContain("arXiv:2307.12345");
+  });
+
+  it("has deterministic hash over (paperId, doi, arxiv, title, date)", () => {
+    const a = buildProposal(TARGET, basePaper)!;
+    const b = buildProposal(TARGET, basePaper)!;
+    expect(a.responseHash).toBe(b.responseHash);
+    expect(a.responseHash).toHaveLength(64);
+  });
+});
+
+describe("importTarget", () => {
+  it("skips papers with missing title/date + counts them", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          data: [
+            { paperId: "p1", title: "A", publicationDate: "2024-01-01" },
+            { paperId: "p2", title: null, publicationDate: "2024-01-01" },
+            { paperId: "p3", title: "B", publicationDate: null, year: null },
+          ],
+          next: null,
+        };
+      },
+    })) as unknown as typeof fetch;
+    const { proposals, skipped } = await importTarget(TARGET, { fetchImpl });
+    expect(proposals).toHaveLength(1);
+    expect(skipped).toBe(2);
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses --target=personSlug:displayName:authorId", () => {
+    expect(
+      parseTargetsArg(["--target=dario-amodei:Dario Amodei:1712334"])
+    ).toEqual([
+      { personSlug: "dario-amodei", personName: "Dario Amodei", authorId: "1712334" },
+    ]);
+  });
+  it("handles displayName containing a colon", () => {
+    // First colon separates slug, last colon separates authorId; middle may contain colons.
+    const t = parseTargetsArg(["--target=a:Prof: Dario Amodei:1712334"])[0];
+    expect(t.personSlug).toBe("a");
+    expect(t.personName).toBe("Prof: Dario Amodei");
+    expect(t.authorId).toBe("1712334");
+  });
+  it("throws when fewer than 2 colons", () => {
+    expect(() => parseTargetsArg(["--target=slug"])).toThrow(/at least two colons/);
+    expect(() => parseTargetsArg(["--target=slug:only"])).toThrow(
+      /at least two colons/
+    );
+  });
+  it("throws on empty segments", () => {
+    expect(() => parseTargetsArg(["--target=:Dario:123"])).toThrow(/empty segment/);
+    expect(() => parseTargetsArg(["--target=a::123"])).toThrow(/empty segment/);
+    expect(() => parseTargetsArg(["--target=a:Dario:"])).toThrow(/empty segment/);
+  });
+  it("throws on non-numeric author id", () => {
+    expect(() => parseTargetsArg(["--target=a:Dario:abc"])).toThrow(
+      /invalid Semantic Scholar/
+    );
+  });
+});

--- a/crux/commands/tb-importers/__tests__/wikidata.test.ts
+++ b/crux/commands/tb-importers/__tests__/wikidata.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertValidQid,
+  buildSparqlQuery,
+  extractBindingValue,
+  buildProposals,
+  fetchSparqlBindings,
+  importTarget,
+  parseTargetsArg,
+  WIKIDATA_PROPERTY_BINDINGS,
+  type SparqlBinding,
+  type WikidataTarget,
+} from "../wikidata.ts";
+
+const TARGET: WikidataTarget = {
+  orgSlug: "anthropic",
+  orgName: "Anthropic",
+  qid: "Q108542504",
+};
+
+function makeFetch(body: unknown, status = 200): typeof fetch {
+  return (async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return typeof body === "string" ? body : JSON.stringify(body);
+    },
+    async json() {
+      return body;
+    },
+  })) as unknown as typeof fetch;
+}
+
+function sparqlResponse(row: Record<string, string>): unknown {
+  const binding: SparqlBinding = {};
+  for (const [k, v] of Object.entries(row)) {
+    binding[k] = { type: "literal", value: v };
+  }
+  return { results: { bindings: [binding] } };
+}
+
+describe("assertValidQid", () => {
+  it("accepts valid QIDs", () => {
+    expect(() => assertValidQid("Q1")).not.toThrow();
+    expect(() => assertValidQid("Q108542504")).not.toThrow();
+  });
+  it("rejects empty string", () => {
+    expect(() => assertValidQid("")).toThrow(/invalid Wikidata QID/);
+  });
+  it("rejects missing Q prefix", () => {
+    expect(() => assertValidQid("108542504")).toThrow(/invalid Wikidata QID/);
+    expect(() => assertValidQid("q108542504")).toThrow(/invalid Wikidata QID/);
+  });
+  it("rejects leading zero (Q0...)", () => {
+    expect(() => assertValidQid("Q0")).toThrow(/invalid Wikidata QID/);
+    expect(() => assertValidQid("Q012345")).toThrow(/invalid Wikidata QID/);
+  });
+  it("rejects QID with trailing chars", () => {
+    expect(() => assertValidQid("Q1234abc")).toThrow(/invalid Wikidata QID/);
+  });
+});
+
+describe("buildSparqlQuery", () => {
+  it("includes all property bindings", () => {
+    const q = buildSparqlQuery("Q108542504");
+    for (const b of WIKIDATA_PROPERTY_BINDINGS) {
+      expect(q).toContain(`wdt:${b.wikidataProperty}`);
+    }
+  });
+  it("targets the right QID", () => {
+    expect(buildSparqlQuery("Q108542504")).toContain("wd:Q108542504");
+    expect(buildSparqlQuery("Q42")).toContain("wd:Q42");
+  });
+  it("uses LIMIT 1 (we only expect one row per QID)", () => {
+    expect(buildSparqlQuery("Q1")).toMatch(/LIMIT\s+1/);
+  });
+  it("rejects an invalid QID before building", () => {
+    expect(() => buildSparqlQuery("not-a-qid")).toThrow(/invalid Wikidata QID/);
+  });
+});
+
+describe("extractBindingValue", () => {
+  const foundedBinding = WIKIDATA_PROPERTY_BINDINGS.find(
+    (b) => b.property === "founded-date"
+  )!;
+  const headcountBinding = WIKIDATA_PROPERTY_BINDINGS.find(
+    (b) => b.property === "headcount"
+  )!;
+  const hqBinding = WIKIDATA_PROPERTY_BINDINGS.find(
+    (b) => b.property === "headquarters"
+  )!;
+
+  it("returns null when variable is missing", () => {
+    expect(extractBindingValue({}, foundedBinding)).toBeNull();
+  });
+  it("returns null when variable value is empty", () => {
+    const binding: SparqlBinding = {
+      foundedDate: { type: "literal", value: "" },
+    };
+    expect(extractBindingValue(binding, foundedBinding)).toBeNull();
+  });
+  it("truncates date to YYYY-MM", () => {
+    const binding: SparqlBinding = {
+      foundedDate: { type: "literal", value: "2021-01-23T00:00:00Z" },
+    };
+    expect(extractBindingValue(binding, foundedBinding)).toBe("2021-01");
+  });
+  it("parses headcount as number (rejects 0 and negatives)", () => {
+    expect(
+      extractBindingValue(
+        { employees: { type: "literal", value: "175" } },
+        headcountBinding
+      )
+    ).toBe(175);
+    expect(
+      extractBindingValue(
+        { employees: { type: "literal", value: "0" } },
+        headcountBinding
+      )
+    ).toBeNull();
+    expect(
+      extractBindingValue(
+        { employees: { type: "literal", value: "-5" } },
+        headcountBinding
+      )
+    ).toBeNull();
+    expect(
+      extractBindingValue(
+        { employees: { type: "literal", value: "NaN" } },
+        headcountBinding
+      )
+    ).toBeNull();
+  });
+  it("returns raw value for string-typed properties", () => {
+    const binding: SparqlBinding = {
+      headquartersLabel: { type: "literal", value: "San Francisco" },
+    };
+    expect(extractBindingValue(binding, hqBinding)).toBe("San Francisco");
+  });
+});
+
+describe("buildProposals", () => {
+  it("returns [] when bindings is empty", () => {
+    expect(buildProposals(TARGET, [], "", "x")).toEqual([]);
+  });
+
+  it("emits one proposal per present property", () => {
+    const binding: SparqlBinding = {
+      foundedDate: { type: "literal", value: "2021-01-23T00:00:00Z" },
+      headquartersLabel: { type: "literal", value: "San Francisco" },
+      employees: { type: "literal", value: "175" },
+    };
+    const proposals = buildProposals(
+      TARGET,
+      [binding],
+      "raw",
+      "https://www.wikidata.org/wiki/Q108542504"
+    );
+    expect(proposals).toHaveLength(3);
+    const props = proposals.map((p) => p.record.property);
+    expect(props).toContain("founded-date");
+    expect(props).toContain("headquarters");
+    expect(props).toContain("headcount");
+  });
+
+  it("emits T1 + wikidata source + organization-fact recordType", () => {
+    const binding: SparqlBinding = {
+      foundedDate: { type: "literal", value: "2021-01-23T00:00:00Z" },
+    };
+    const p = buildProposals(TARGET, [binding], "raw", "u")[0];
+    expect(p.tier).toBe("T1");
+    expect(p.source).toBe("wikidata:Q108542504:P571");
+    expect(p.recordType).toBe("organization-fact");
+    expect(p.entityRefs?.organization).toBe("anthropic");
+    expect(p.record.value).toBe("2021-01");
+    expect(p.record.valueType).toBe("date");
+  });
+
+  it("hashes (qid, property, value) deterministically", () => {
+    const binding: SparqlBinding = {
+      employees: { type: "literal", value: "175" },
+    };
+    const a = buildProposals(TARGET, [binding], "raw-a", "u")[0];
+    const b = buildProposals(TARGET, [binding], "raw-b", "u")[0];
+    // Hashing is over (qid, property, value), NOT the raw SPARQL JSON —
+    // so raw-JSON-ordering changes don't flip the hash.
+    expect(a.responseHash).toBe(b.responseHash);
+    expect(a.responseHash).toHaveLength(64);
+  });
+
+  it("skips properties with null/empty/invalid values", () => {
+    const binding: SparqlBinding = {
+      foundedDate: { type: "literal", value: "" },
+      employees: { type: "literal", value: "not-a-number" },
+      headquartersLabel: { type: "literal", value: "Boston" },
+    };
+    const ps = buildProposals(TARGET, [binding], "raw", "u");
+    expect(ps.map((p) => p.record.property)).toEqual(["headquarters"]);
+  });
+});
+
+describe("fetchSparqlBindings", () => {
+  it("throws on non-2xx", async () => {
+    const fetchImpl = makeFetch(null, 503);
+    await expect(
+      fetchSparqlBindings("Q108542504", { fetchImpl })
+    ).rejects.toThrow(/HTTP 503/);
+  });
+
+  it("throws on malformed JSON", async () => {
+    const fetchImpl = makeFetch("{not json", 200);
+    await expect(
+      fetchSparqlBindings("Q108542504", { fetchImpl })
+    ).rejects.toThrow(/not valid JSON/);
+  });
+
+  it("throws when results.bindings is missing", async () => {
+    const fetchImpl = makeFetch({ other: true }, 200);
+    await expect(
+      fetchSparqlBindings("Q108542504", { fetchImpl })
+    ).rejects.toThrow(/missing results.bindings/);
+  });
+
+  it("returns the canonical wiki page URL (not the SPARQL URL)", async () => {
+    const fetchImpl = makeFetch(sparqlResponse({}));
+    const { sourceUrl } = await fetchSparqlBindings("Q108542504", { fetchImpl });
+    expect(sourceUrl).toBe("https://www.wikidata.org/wiki/Q108542504");
+  });
+
+  it("sends Accept: sparql-results+json and User-Agent", async () => {
+    let capturedAccept = "";
+    let capturedUA = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      const h = (init?.headers as Record<string, string>) ?? {};
+      capturedAccept = h.Accept ?? "";
+      capturedUA = h["User-Agent"] ?? "";
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(sparqlResponse({}));
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchSparqlBindings("Q108542504", { fetchImpl });
+    expect(capturedAccept).toContain("sparql-results+json");
+    expect(capturedUA).toBeTruthy();
+  });
+
+  it("strips CR/LF from user-supplied UA (header injection guard)", async () => {
+    let captured = "";
+    const fetchImpl = (async (_url: string, init: RequestInit | undefined) => {
+      captured = String(
+        (init?.headers as Record<string, string>)?.["User-Agent"] ?? ""
+      );
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(sparqlResponse({}));
+        },
+      };
+    }) as unknown as typeof fetch;
+    await fetchSparqlBindings("Q108542504", {
+      fetchImpl,
+      userAgent: "evil\r\nX-Inj: yes",
+    });
+    expect(captured).not.toContain("\r");
+    expect(captured).not.toContain("\n");
+  });
+});
+
+describe("importTarget — happy path", () => {
+  it("produces proposals for the bindings present in the response", async () => {
+    const fetchImpl = makeFetch(
+      sparqlResponse({
+        foundedDate: "2021-01-23T00:00:00Z",
+        headquartersLabel: "San Francisco",
+        ceoLabel: "Dario Amodei",
+      })
+    );
+    const { proposals } = await importTarget(TARGET, { fetchImpl });
+    expect(proposals).toHaveLength(3);
+    const props = new Set(proposals.map((p) => p.record.property));
+    expect(props).toEqual(new Set(["founded-date", "headquarters", "ceo-name"]));
+  });
+
+  it("returns empty proposals when the response has no bindings", async () => {
+    const fetchImpl = makeFetch({ results: { bindings: [] } });
+    const { proposals } = await importTarget(TARGET, { fetchImpl });
+    expect(proposals).toEqual([]);
+  });
+});
+
+describe("parseTargetsArg", () => {
+  it("parses --target=slug:Qnumber", () => {
+    expect(parseTargetsArg(["--target=anthropic:Q108542504"])).toEqual([
+      { orgSlug: "anthropic", orgName: "anthropic", qid: "Q108542504" },
+    ]);
+  });
+  it("ignores non-target flags", () => {
+    expect(parseTargetsArg(["--submit", "--target=x:Q1"])).toHaveLength(1);
+  });
+  it("throws on no colon", () => {
+    expect(() => parseTargetsArg(["--target=slugonly"])).toThrow(
+      /exactly one colon/
+    );
+  });
+  it("throws on extra colons", () => {
+    expect(() => parseTargetsArg(["--target=a:Q1:extra"])).toThrow(
+      /exactly one colon/
+    );
+  });
+  it("throws on empty slug", () => {
+    expect(() => parseTargetsArg(["--target=:Q1"])).toThrow(/non-empty/);
+  });
+  it("throws on empty qid", () => {
+    expect(() => parseTargetsArg(["--target=a:"])).toThrow(/non-empty/);
+  });
+  it("throws on malformed qid", () => {
+    expect(() => parseTargetsArg(["--target=a:notaqid"])).toThrow(
+      /invalid Wikidata QID/
+    );
+    expect(() => parseTargetsArg(["--target=a:Q0"])).toThrow(
+      /invalid Wikidata QID/
+    );
+  });
+});

--- a/crux/commands/tb-importers/allowlist.ts
+++ b/crux/commands/tb-importers/allowlist.ts
@@ -21,6 +21,10 @@ export const T1_SOURCE_PREFIXES = {
   secEdgar: "sec-edgar:",
   githubContributors: "github-contributors:",
   hfLeaderboard: "hf-leaderboard:",
+  wikidata: "wikidata:",
+  openalex: "openalex:",
+  semanticScholar: "semantic-scholar:",
+  crossref: "crossref:",
 } as const;
 
 export interface T1AuthorityEntry {
@@ -49,6 +53,30 @@ export const T1_AUTHORITY_ALLOWLIST: readonly T1AuthorityEntry[] = [
     recordType: "benchmark-result",
     description:
       "HuggingFace Open LLM Leaderboard (deterministic auto-eval pipeline).",
+  },
+  {
+    sourcePrefix: T1_SOURCE_PREFIXES.wikidata,
+    recordType: "organization-fact",
+    description:
+      "Wikidata SPARQL (Q-entity facts: founded, HQ, country, CEO name, employees, etc.).",
+  },
+  {
+    sourcePrefix: T1_SOURCE_PREFIXES.openalex,
+    recordType: "publication",
+    description:
+      "OpenAlex works API (publications by institution ID, deterministic metadata).",
+  },
+  {
+    sourcePrefix: T1_SOURCE_PREFIXES.semanticScholar,
+    recordType: "publication",
+    description:
+      "Semantic Scholar Academic Graph (papers by author ID, deterministic metadata).",
+  },
+  {
+    sourcePrefix: T1_SOURCE_PREFIXES.crossref,
+    recordType: "publication",
+    description:
+      "Crossref DOI metadata (canonical bibliographic registry for published works).",
   },
 ] as const;
 

--- a/crux/commands/tb-importers/crossref.ts
+++ b/crux/commands/tb-importers/crossref.ts
@@ -1,0 +1,370 @@
+/**
+ * Crossref → publication importer (T1, QUA-666).
+ *
+ * Crossref (https://api.crossref.org) is the canonical registry for scholarly
+ * DOIs. Given a DOI we get deterministic bibliographic metadata: title,
+ * authors, container (journal), published date, publisher, type.
+ *
+ * API:
+ *   GET https://api.crossref.org/works/<doi>
+ *   → { status: "ok", message: { ...work... } }
+ *
+ * Polite pool: include `?mailto=<email>` or a User-Agent with a contact
+ * address. We already ship bot@quantifieduncertainty.org in the UA.
+ *
+ * The importer accepts one DOI per target. Multi-DOI batch is out of scope —
+ * use `/works?filter=doi:X,doi:Y,...` if bulk is needed later, but the
+ * per-DOI endpoint is simpler + the evidence URL is stable per work.
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+/**
+ * DOI format per https://www.doi.org/doi_handbook/2_Numbering.html:
+ *   Prefix starts with "10." followed by a registrant code (digits),
+ *   then "/" then a suffix (any printable chars).
+ *
+ * Regex rejects leading/trailing whitespace, disallowed chars, and
+ * missing suffix. Not a full RFC-grade validator — just enough to refuse
+ * obviously malformed CLI input.
+ */
+const DOI_RE = /^10\.[0-9]{4,9}\/[^\s]+$/;
+
+export interface CrossrefTarget {
+  /** Optional org slug to attach to the publication. */
+  orgSlug?: string;
+  /** Optional person slug (author) to attach. */
+  personSlug?: string;
+  /** DOI in bare form (e.g. "10.1145/3442188.3445922"). */
+  doi: string;
+}
+
+export interface CrossrefOptions extends HttpOptions {
+  /** Override base URL (tests inject localhost). */
+  apiBase?: string;
+  /** mailto for Crossref polite pool. */
+  mailto?: string;
+}
+
+interface CrossrefAuthor {
+  given?: string | null;
+  family?: string | null;
+  name?: string | null;
+  ORCID?: string | null;
+}
+
+interface DateParts {
+  "date-parts"?: number[][];
+}
+
+export interface CrossrefWork {
+  DOI: string;
+  title?: string[];
+  author?: CrossrefAuthor[];
+  "container-title"?: string[];
+  publisher?: string | null;
+  type?: string | null;
+  published?: DateParts;
+  "published-print"?: DateParts;
+  "published-online"?: DateParts;
+  issued?: DateParts;
+  URL?: string | null;
+  subject?: string[];
+}
+
+interface CrossrefResponse {
+  status?: string;
+  message?: CrossrefWork;
+}
+
+const DEFAULT_API_BASE = "https://api.crossref.org";
+
+/** Validate a DOI string. Throws on malformed input. */
+export function assertValidDoi(doi: string): void {
+  if (!DOI_RE.test(doi)) {
+    throw new Error(
+      `invalid DOI: "${doi}" (must match /^10\\.[0-9]{4,9}\\/[^\\s]+$/)`
+    );
+  }
+}
+
+/**
+ * Normalize a DOI: accept URL form ("https://doi.org/..."), strip,
+ * validate. Returns the bare DOI. Throws if the result is invalid.
+ */
+export function normalizeDoi(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === "") throw new Error("DOI is empty");
+  const lower = trimmed.toLowerCase();
+  let bare = trimmed;
+  for (const prefix of ["https://doi.org/", "http://doi.org/", "doi:"]) {
+    if (lower.startsWith(prefix)) {
+      bare = trimmed.slice(prefix.length);
+      break;
+    }
+  }
+  assertValidDoi(bare);
+  return bare;
+}
+
+/**
+ * Extract a YYYY-MM-DD date from Crossref's date-parts tuple format.
+ * `date-parts` is `[[YYYY, MM?, DD?]]` — month and day optional.
+ *
+ * Zero-pads where necessary. Returns null if the outer array is empty OR
+ * the first sub-array is missing/empty (no year).
+ */
+export function extractDate(parts: DateParts | undefined): string | null {
+  const arr = parts?.["date-parts"];
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  const first = arr[0];
+  if (!Array.isArray(first) || first.length === 0) return null;
+  const [y, m, d] = first;
+  if (typeof y !== "number" || y < 1800) return null;
+  const mo = typeof m === "number" && m >= 1 && m <= 12 ? String(m).padStart(2, "0") : "01";
+  const day = typeof d === "number" && d >= 1 && d <= 31 ? String(d).padStart(2, "0") : "01";
+  return `${y}-${mo}-${day}`;
+}
+
+/**
+ * Pick the earliest date available across `issued`, `published`,
+ * `published-print`, `published-online`. Crossref sometimes populates one
+ * but not others; `issued` is the most commonly present.
+ */
+export function pickPublishedDate(work: CrossrefWork): string | null {
+  const candidates = [work.issued, work.published, work["published-print"], work["published-online"]];
+  let earliest: string | null = null;
+  for (const p of candidates) {
+    const d = extractDate(p);
+    if (d && (!earliest || d < earliest)) earliest = d;
+  }
+  return earliest;
+}
+
+/**
+ * Format a Crossref author to "Given Family" or fall back to `name`
+ * (organizational author) or drop it.
+ */
+export function formatAuthor(a: CrossrefAuthor): string | null {
+  if (a.name) return a.name.trim() || null;
+  const given = a.given?.trim() ?? "";
+  const family = a.family?.trim() ?? "";
+  if (given && family) return `${given} ${family}`;
+  if (family) return family;
+  if (given) return given;
+  return null;
+}
+
+/**
+ * Map Crossref type → our publication type enum. Crossref's `type` values are
+ * controlled: https://api.crossref.org/types
+ */
+export function mapPublicationType(crossrefType: string | null | undefined): string {
+  if (!crossrefType) return "paper";
+  switch (crossrefType) {
+    case "journal-article":
+      return "paper";
+    case "posted-content":
+      return "preprint";
+    case "book":
+    case "book-section":
+    case "book-chapter":
+      return "book";
+    case "dissertation":
+      return "thesis";
+    case "report":
+    case "report-component":
+      return "report";
+    case "proceedings-article":
+      return "paper";
+    default:
+      return "paper";
+  }
+}
+
+/** Fetch one DOI's work metadata. Throws on non-2xx or non-ok payload. */
+export async function fetchDoiWork(
+  doi: string,
+  opts: CrossrefOptions = {}
+): Promise<CrossrefWork> {
+  assertValidDoi(doi);
+  const apiBase = opts.apiBase ?? DEFAULT_API_BASE;
+  // Crossref's /works/{doi} expects a URL-encoded DOI in the path.
+  const url =
+    `${apiBase}/works/${encodeURIComponent(doi)}` +
+    (opts.mailto ? `?mailto=${encodeURIComponent(opts.mailto)}` : "");
+  const resp = await getFetch(opts)(url, {
+    headers: {
+      "User-Agent": getUserAgent(opts),
+      Accept: "application/json",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Crossref HTTP ${resp.status} for DOI ${doi}`);
+  }
+  const data = (await resp.json()) as CrossrefResponse;
+  if (data?.status !== "ok" || !data.message) {
+    throw new Error(
+      `Crossref response status=${data?.status ?? "unknown"} for DOI ${doi}`
+    );
+  }
+  return data.message;
+}
+
+/**
+ * Build one publication proposal from a Crossref work.
+ *
+ * Returns null when the work is undatable or missing a title — we don't
+ * emit half-populated proposals.
+ */
+export function buildProposal(
+  target: CrossrefTarget,
+  work: CrossrefWork
+): EnrichmentProposal | null {
+  const title = work.title?.[0]?.trim();
+  if (!title) return null;
+  const date = pickPublishedDate(work);
+  if (!date) return null;
+  const venue = work["container-title"]?.[0]?.trim() || null;
+  const authors = (work.author ?? [])
+    .map(formatAuthor)
+    .filter((a): a is string => a !== null);
+  const url = work.URL ?? `https://doi.org/${target.doi}`;
+  const canonical = JSON.stringify({
+    doi: target.doi,
+    title,
+    date,
+  });
+  const responseHash = createHash("sha256").update(canonical).digest("hex");
+  const sourceUrl = `https://doi.org/${target.doi}`;
+
+  // entityRefs: prefer the org, then the person, never both without an org
+  // (the propose endpoint links authorships separately — this is just the
+  // primary owner for the publication row).
+  const entityRefs: EnrichmentProposal["entityRefs"] = {};
+  if (target.orgSlug) entityRefs.organization = target.orgSlug;
+  if (target.personSlug) entityRefs.person = target.personSlug;
+
+  return {
+    tier: "T1",
+    source: `${T1_SOURCE_PREFIXES.crossref}${target.doi}`,
+    sourceUrl,
+    responseHash,
+    recordType: "publication",
+    record: {
+      title,
+      doi: target.doi,
+      publishedDate: date,
+      venue,
+      authors,
+      publicationType: mapPublicationType(work.type ?? undefined),
+      publisher: work.publisher?.trim() ?? null,
+      url,
+      notes: `Crossref DOI ${target.doi}${work.subject?.length ? ` (subjects: ${work.subject.slice(0, 3).join(", ")})` : ""}`,
+    },
+    entityRefs,
+  };
+}
+
+/** End-to-end for one target: fetch + build proposal. */
+export async function importTarget(
+  target: CrossrefTarget,
+  opts: CrossrefOptions = {}
+): Promise<{ proposal: EnrichmentProposal | null }> {
+  const work = await fetchDoiWork(target.doi, opts);
+  return { proposal: buildProposal(target, work) };
+}
+
+/** CLI entry — `crux tb crossref --target=doi:10.xxx/yyy`. */
+export async function cliMain(args: string[]): Promise<CommandResult> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=doi:10.xxx/yyy (optionally with :org=slug or :person=slug)",
+    };
+  }
+  const all: EnrichmentProposal[] = [];
+  let totalFailures = 0;
+  let totalSkipped = 0;
+  for (const t of targets) {
+    console.log(`[crossref] fetching ${t.doi}...`);
+    try {
+      const { proposal } = await importTarget(t);
+      if (proposal) {
+        console.log(`[crossref]   → 1 publication proposal`);
+        all.push(proposal);
+      } else {
+        console.warn(
+          `[crossref]   → skipped ${t.doi} (missing title or undatable)`
+        );
+        totalSkipped++;
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[crossref] target ${t.doi} failed: ${msg}`);
+      totalFailures++;
+    }
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(all, clientOpts);
+  printBatchSummary(results, "crossref");
+  if (totalFailures > 0 || totalSkipped > 0) {
+    console.warn(
+      `[crossref] ${totalFailures} target failure(s), ${totalSkipped} skipped`
+    );
+  }
+  return { exitCode: 0, output: "" };
+}
+
+/**
+ * Parse `--target=doi:10.x/y` — and optional `org=<slug>` / `person=<slug>`
+ * suffixes in the form `--target=doi:10.x/y|org=anthropic|person=jane-smith`.
+ * We pick `|` as the attribute separator because DOIs can legally contain
+ * colons, commas, and semicolons; `|` is not a valid DOI character.
+ */
+export function parseTargetsArg(args: readonly string[]): CrossrefTarget[] {
+  const out: CrossrefTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    const segments = value.split("|");
+    const head = segments[0];
+    if (!head.startsWith("doi:")) {
+      throw new Error(
+        `--target must start with "doi:", got "${value}" (expected "doi:10.xxx/yyy[|org=slug][|person=slug]")`
+      );
+    }
+    const doi = normalizeDoi(head.slice("doi:".length));
+    const target: CrossrefTarget = { doi };
+    for (const seg of segments.slice(1)) {
+      const eq = seg.indexOf("=");
+      if (eq === -1) {
+        throw new Error(
+          `--target attribute must be key=value, got "${seg}"`
+        );
+      }
+      const key = seg.slice(0, eq);
+      const val = seg.slice(eq + 1);
+      if (!val) {
+        throw new Error(`--target attribute "${key}" has empty value`);
+      }
+      if (key === "org") target.orgSlug = val;
+      else if (key === "person") target.personSlug = val;
+      else throw new Error(`--target unknown attribute "${key}" (expected "org" or "person")`);
+    }
+    out.push(target);
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/index.ts
+++ b/crux/commands/tb-importers/index.ts
@@ -1,10 +1,18 @@
 /**
- * T1 importer command exports (QUA-640).
+ * T1 importer command exports.
  *
- * Wires the three importer CLIs into the tb command tree:
- *   - `crux tb sec-edgar           --target=slug:cik [--submit]`
- *   - `crux tb github-contributors --target=slug:owner/repo[,owner/repo2] [--submit]`
- *   - `crux tb hf-leaderboard      --target=modelSlug:displayName:evalName [--submit]`
+ * Wires all T1 importer CLIs into the tb command tree:
+ *
+ *   QUA-640:
+ *     - `crux tb sec-edgar           --target=slug:cik                       [--submit]`
+ *     - `crux tb github-contributors --target=slug:owner/repo[,owner/repo2]  [--submit]`
+ *     - `crux tb hf-leaderboard      --target=modelSlug:displayName:evalName [--submit]`
+ *
+ *   QUA-666:
+ *     - `crux tb wikidata            --target=slug:Qnumber                   [--submit]`
+ *     - `crux tb openalex            --target=slug:Iinstitution_id           [--submit]`
+ *     - `crux tb semantic-scholar    --target=personSlug:displayName:authorId [--submit]`
+ *     - `crux tb crossref            --target=doi:10.xxx/yyy[|org=slug][|person=slug] [--submit]`
  *
  * `--submit` is wired through to the propose-client; today the endpoint
  * (QUA-632) does not yet exist so submit-mode returns `pending`. Until then,
@@ -14,30 +22,48 @@
 import { cliMain as secEdgarCliMain } from "./sec-edgar.ts";
 import { cliMain as ghContribCliMain } from "./github-contributors.ts";
 import { cliMain as hfLeaderboardCliMain } from "./hf-leaderboard.ts";
+import { cliMain as wikidataCliMain } from "./wikidata.ts";
+import { cliMain as openalexCliMain } from "./openalex.ts";
+import { cliMain as semanticScholarCliMain } from "./semantic-scholar.ts";
+import { cliMain as crossrefCliMain } from "./crossref.ts";
 
 // The crux dispatcher passes (args, options); the importers ignore options
 // (their flags are parsed from `args`), so a one-arg adapter is sufficient.
 const adapt = (fn: (args: string[]) => unknown) => (args: string[]) => fn(args);
 
 export const commands = {
+  // QUA-640
   "sec-edgar": adapt(secEdgarCliMain),
   "github-contributors": adapt(ghContribCliMain),
   "hf-leaderboard": adapt(hfLeaderboardCliMain),
+  // QUA-666
+  "wikidata": adapt(wikidataCliMain),
+  "openalex": adapt(openalexCliMain),
+  "semantic-scholar": adapt(semanticScholarCliMain),
+  "crossref": adapt(crossrefCliMain),
 };
 
 export function getHelp(): string {
   return `
-T1 importers — defensive enrichment via authoritative sources (QUA-640)
+T1 importers — defensive enrichment via authoritative sources (QUA-637)
 
 Commands:
   sec-edgar              Fetch SEC EDGAR Form D filings → funding-rounds
   github-contributors    Fetch GitHub contributors API → personnel hints
   hf-leaderboard         Fetch HuggingFace Open LLM Leaderboard → benchmark-results
+  wikidata               Fetch Wikidata SPARQL facts → organization-fact records
+  openalex               Fetch OpenAlex works by institution → publications
+  semantic-scholar       Fetch Semantic Scholar papers by author → publications
+  crossref               Fetch Crossref DOI metadata → publications
 
 Usage:
   crux tb sec-edgar --target=anthropic:1828101 [--submit]
   crux tb github-contributors --target=anthropic:anthropics/anthropic-sdk-python [--submit]
   crux tb hf-leaderboard --target=llama-3-70b:Llama-3-70B:meta-llama/Llama-3-70B [--submit]
+  crux tb wikidata --target=anthropic:Q108542504 [--submit]
+  crux tb openalex --target=anthropic:I4210125762 [--submit]
+  crux tb semantic-scholar --target=dario-amodei:Dario Amodei:1712334 [--submit]
+  crux tb crossref --target=doi:10.1145/3442188.3445922|org=anthropic [--submit]
 
 All importers default to dry-run mode (print proposals, don't POST).
 Pass --submit to attempt POST to /api/enrichment/propose (blocked on QUA-632).

--- a/crux/commands/tb-importers/openalex.ts
+++ b/crux/commands/tb-importers/openalex.ts
@@ -1,0 +1,345 @@
+/**
+ * OpenAlex works → publications importer (T1, QUA-666).
+ *
+ * OpenAlex (https://openalex.org) is a free, open index of ~200M scholarly
+ * works with structured metadata. For an AI safety org like Anthropic
+ * (institution id I4210125762), the works-by-institution endpoint returns
+ * deterministic paper metadata: DOI, title, authors, venue, published date,
+ * type (journal-article | preprint | report | book-chapter | …).
+ *
+ * API:
+ *   GET https://api.openalex.org/works
+ *     ?filter=authorships.institutions.id:I<N>
+ *     &per-page=<≤200>&cursor=<token>
+ *     &select=id,doi,title,publication_date,publication_year,type,authorships,primary_location
+ *
+ * Cursor pagination is required past the first 10,000 results; start with
+ * `cursor=*` and follow `meta.next_cursor` until null.
+ *
+ * Polite pool: include `mailto=<email>` in query or User-Agent for higher
+ * rate limits. OpenAlex is otherwise free + unauth.
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+/**
+ * OpenAlex institution IDs are `I` followed by 1+ digits. No leading zeros
+ * (OpenAlex never emits them).
+ */
+const INSTITUTION_ID_RE = /^I[1-9]\d*$/;
+
+export interface OpenAlexTarget {
+  /** Org slug from data/entities/organizations.yaml */
+  orgSlug: string;
+  /** Display name for the org */
+  orgName: string;
+  /** OpenAlex institution ID (e.g., "I4210125762" for Anthropic). */
+  institutionId: string;
+}
+
+export interface OpenAlexOptions extends HttpOptions {
+  /** Override base URL (tests inject localhost). */
+  apiBase?: string;
+  /** Page size (max 200 per OpenAlex docs). */
+  perPage?: number;
+  /** Hard cap on total works fetched per target (defaults to 500). */
+  maxWorks?: number;
+  /** mailto for the OpenAlex polite pool. */
+  mailto?: string;
+  /** If set, only return works published on or after this YYYY-MM-DD. */
+  sinceDate?: string;
+}
+
+export interface OpenAlexAuthorship {
+  author?: { id?: string | null; display_name?: string | null };
+  institutions?: Array<{ id?: string | null; display_name?: string | null }>;
+  raw_author_name?: string | null;
+}
+
+export interface OpenAlexWork {
+  id: string; // "https://openalex.org/Wxxx"
+  doi?: string | null;
+  title?: string | null;
+  publication_date?: string | null;
+  publication_year?: number | null;
+  type?: string | null;
+  authorships?: OpenAlexAuthorship[];
+  primary_location?: {
+    source?: { display_name?: string | null; type?: string | null } | null;
+    landing_page_url?: string | null;
+  } | null;
+}
+
+interface WorksResponse {
+  meta?: { count?: number; next_cursor?: string | null };
+  results?: OpenAlexWork[];
+}
+
+const DEFAULT_API_BASE = "https://api.openalex.org";
+const DEFAULT_PER_PAGE = 100;
+const DEFAULT_MAX_WORKS = 500;
+const MAX_PER_PAGE = 200;
+
+/** Validate an OpenAlex institution ID. Throws on malformed input. */
+export function assertValidInstitutionId(id: string): void {
+  if (!INSTITUTION_ID_RE.test(id)) {
+    throw new Error(
+      `invalid OpenAlex institution id: "${id}" (must match /^I[1-9]\\d*$/)`
+    );
+  }
+}
+
+/**
+ * OpenAlex publishes DOIs in two shapes: bare ("10.1145/...") and URL form
+ * ("https://doi.org/10.1145/..."). Normalize to bare for record storage;
+ * the URL form is derivable on demand.
+ *
+ * Returns null for empty input rather than throwing, because many works
+ * legitimately have no DOI (preprints, reports, internal papers).
+ */
+export function normalizeDoi(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const lower = trimmed.toLowerCase();
+  // Strip common URL prefixes
+  for (const prefix of ["https://doi.org/", "http://doi.org/", "doi:"]) {
+    if (lower.startsWith(prefix)) return trimmed.slice(prefix.length);
+  }
+  return trimmed;
+}
+
+/** Strip the OpenAlex URL-prefix from a work ID to get the bare `Wnnn`. */
+export function workShortId(id: string): string {
+  return id.replace(/^https?:\/\/openalex\.org\//, "");
+}
+
+/**
+ * Map OpenAlex work `type` → our publicationType enum. Keeps the set small
+ * (matches `VALID_PUBLICATION_TYPES` in apps/wiki-server/src/routes/tablebase/publications.ts).
+ * Unknown types → "paper" as a neutral default.
+ */
+export function mapPublicationType(openalexType: string | null | undefined): string {
+  if (!openalexType) return "paper";
+  switch (openalexType) {
+    case "journal-article":
+    case "article":
+      return "paper";
+    case "preprint":
+      return "preprint";
+    case "book-chapter":
+    case "book":
+      return "book";
+    case "dissertation":
+      return "thesis";
+    case "report":
+      return "report";
+    default:
+      return "paper";
+  }
+}
+
+/**
+ * Fetch all works for an institution via cursor pagination.
+ * Respects `maxWorks` — stops early when the cap is hit OR when the cursor
+ * runs out, whichever comes first.
+ */
+export async function fetchInstitutionWorks(
+  institutionId: string,
+  opts: OpenAlexOptions = {}
+): Promise<OpenAlexWork[]> {
+  assertValidInstitutionId(institutionId);
+  const apiBase = opts.apiBase ?? DEFAULT_API_BASE;
+  const perPage = Math.min(opts.perPage ?? DEFAULT_PER_PAGE, MAX_PER_PAGE);
+  const maxWorks = opts.maxWorks ?? DEFAULT_MAX_WORKS;
+  const fetchImpl = getFetch(opts);
+  const headers: Record<string, string> = {
+    "User-Agent": getUserAgent(opts),
+    Accept: "application/json",
+  };
+
+  const works: OpenAlexWork[] = [];
+  let cursor: string | null = "*";
+  let loops = 0;
+  const MAX_LOOPS = 1000; // hard guard against runaway loops
+  while (cursor && works.length < maxWorks && loops < MAX_LOOPS) {
+    loops++;
+    const params = new URLSearchParams({
+      filter: `authorships.institutions.id:${institutionId}` +
+        (opts.sinceDate ? `,from_publication_date:${opts.sinceDate}` : ""),
+      "per-page": String(perPage),
+      cursor,
+      select:
+        "id,doi,title,publication_date,publication_year,type,authorships,primary_location",
+    });
+    if (opts.mailto) params.set("mailto", opts.mailto);
+    const url = `${apiBase}/works?${params.toString()}`;
+    const resp = await fetchImpl(url, { headers });
+    if (!resp.ok) {
+      throw new Error(`OpenAlex works HTTP ${resp.status} for ${institutionId}`);
+    }
+    const data = (await resp.json()) as WorksResponse;
+    const results = data?.results;
+    if (!Array.isArray(results) || results.length === 0) break;
+    for (const w of results) {
+      works.push(w);
+      if (works.length >= maxWorks) break;
+    }
+    cursor = data?.meta?.next_cursor ?? null;
+  }
+  return works;
+}
+
+/**
+ * Build one publication proposal from one OpenAlex work.
+ *
+ * Policy:
+ *  - Skip works with no title (junk rows we can't usefully store)
+ *  - Skip works with no `publication_date` AND no `publication_year`
+ *    (undatable works violate PG `publications.published_date` NOT NULL
+ *    downstream — fail early at the importer)
+ *  - DOI is optional — preprints and internal reports often lack one
+ *  - `entityRefs.organization` = target orgSlug (author→institution comes
+ *    via authorship; we emit one proposal per work, scoped to this target
+ *    org's institution id in the filter)
+ */
+export function buildProposal(
+  target: OpenAlexTarget,
+  work: OpenAlexWork
+): EnrichmentProposal | null {
+  const title = work.title?.trim();
+  if (!title) return null;
+  const date = work.publication_date
+    ?? (work.publication_year ? `${work.publication_year}-01-01` : null);
+  if (!date) return null;
+  const doi = normalizeDoi(work.doi);
+  const shortId = workShortId(work.id);
+  const venue = work.primary_location?.source?.display_name?.trim() || null;
+  // Authors: `display_name` is the canonical field; fall back to `raw_author_name`
+  // when OpenAlex hasn't resolved the authorship. Deduped preserving order.
+  const seenAuthors = new Set<string>();
+  const authors: string[] = [];
+  for (const a of work.authorships ?? []) {
+    // Use || (not ??) so an empty-string display_name falls through to raw_author_name.
+    const name = (a.author?.display_name || a.raw_author_name || "").trim();
+    if (!name || seenAuthors.has(name)) continue;
+    seenAuthors.add(name);
+    authors.push(name);
+  }
+  const url = work.primary_location?.landing_page_url
+    ?? (doi ? `https://doi.org/${doi}` : `https://openalex.org/${shortId}`);
+
+  // Canonicalize on (openalex id, doi, title, date) — these are the fields
+  // the server will actually persist. Stable hashes survive minor changes
+  // in author list ordering on re-fetch.
+  const canonical = JSON.stringify({ id: work.id, doi, title, date });
+  const responseHash = createHash("sha256").update(canonical).digest("hex");
+  const sourceUrl = `https://openalex.org/${shortId}`;
+
+  return {
+    tier: "T1",
+    source: `${T1_SOURCE_PREFIXES.openalex}${shortId}`,
+    sourceUrl,
+    responseHash,
+    recordType: "publication",
+    record: {
+      title,
+      doi,
+      publishedDate: date,
+      venue,
+      authors,
+      publicationType: mapPublicationType(work.type),
+      url,
+      notes: `OpenAlex work ${shortId} (institution ${target.orgSlug})`,
+      orgDisplayName: target.orgName,
+    },
+    entityRefs: { organization: target.orgSlug },
+  };
+}
+
+/** End-to-end for one target: fetch + build proposals. */
+export async function importTarget(
+  target: OpenAlexTarget,
+  opts: OpenAlexOptions = {}
+): Promise<{ proposals: EnrichmentProposal[]; skipped: number }> {
+  const works = await fetchInstitutionWorks(target.institutionId, opts);
+  const proposals: EnrichmentProposal[] = [];
+  let skipped = 0;
+  for (const w of works) {
+    const p = buildProposal(target, w);
+    if (p) proposals.push(p);
+    else skipped++;
+  }
+  return { proposals, skipped };
+}
+
+/** CLI entry — `crux tb openalex --target=slug:Innn`. */
+export async function cliMain(args: string[]): Promise<CommandResult> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=slug:Iinstitution_id (repeatable)",
+    };
+  }
+  const all: EnrichmentProposal[] = [];
+  let totalFailures = 0;
+  let totalSkipped = 0;
+  for (const t of targets) {
+    console.log(`[openalex] fetching ${t.orgSlug} (${t.institutionId})...`);
+    try {
+      const { proposals, skipped } = await importTarget(t);
+      console.log(
+        `[openalex]   → ${proposals.length} publication proposals, ${skipped} skipped (missing title/date)`
+      );
+      all.push(...proposals);
+      totalSkipped += skipped;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[openalex] target ${t.orgSlug} failed: ${msg}`);
+      totalFailures++;
+    }
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(all, clientOpts);
+  printBatchSummary(results, "openalex");
+  if (totalFailures > 0 || totalSkipped > 0) {
+    console.warn(
+      `[openalex] ${totalFailures} target failure(s), ${totalSkipped} work(s) skipped`
+    );
+  }
+  return { exitCode: 0, output: "" };
+}
+
+/** Parse `--target=slug:Ixxx`. Strict colon count + institution ID format. */
+export function parseTargetsArg(args: readonly string[]): OpenAlexTarget[] {
+  const out: OpenAlexTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    const parts = value.split(":");
+    if (parts.length !== 2) {
+      throw new Error(
+        `--target must be slug:Iinstitution_id (exactly one colon), got "${value}"`
+      );
+    }
+    const [orgSlug, institutionId] = parts;
+    if (!orgSlug || !institutionId) {
+      throw new Error(`--target slug and institution_id must both be non-empty, got "${value}"`);
+    }
+    assertValidInstitutionId(institutionId);
+    out.push({ orgSlug, orgName: orgSlug, institutionId });
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/semantic-scholar.ts
+++ b/crux/commands/tb-importers/semantic-scholar.ts
@@ -1,0 +1,338 @@
+/**
+ * Semantic Scholar → publications importer (T1, QUA-666).
+ *
+ * The Semantic Scholar Academic Graph (https://api.semanticscholar.org)
+ * exposes author IDs plus a deterministic `author/<id>/papers` endpoint.
+ * Given an author resolution (personSlug ↔ S2 authorId) we emit one
+ * `publication` proposal per paper.
+ *
+ * The ticket calls this "author resolution" — our interpretation: the
+ * importer accepts pre-resolved author IDs as input (from a prior matching
+ * pass) and emits deterministic paper metadata. We do NOT do fuzzy name
+ * search here: that's a T2/T3 concern with non-deterministic output.
+ *
+ * API:
+ *   GET https://api.semanticscholar.org/graph/v1/author/<authorId>/papers
+ *     ?fields=paperId,externalIds,title,venue,year,publicationDate,publicationTypes,url,abstract
+ *     &limit=<≤100>&offset=<n>
+ *
+ * Offset-based pagination up to 10,000 total records; beyond that the API
+ * returns 400 — reasonable cap for a single author.
+ *
+ * Auth: optional API key via `x-api-key` header (env var
+ * `SEMANTIC_SCHOLAR_API_KEY`). Unauth is rate-limited at 1 req/sec shared
+ * across the internet, which is usually fine for a seeding importer but
+ * you'll want a key for bursts.
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import { mapPublicationType as mapOpenAlexType } from "./openalex.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+/**
+ * Semantic Scholar author IDs are numeric strings. Historically 1–10 digits.
+ */
+const AUTHOR_ID_RE = /^\d+$/;
+
+export interface SemanticScholarTarget {
+  /** Personnel slug from data/entities or the personnel table. */
+  personSlug: string;
+  /** Display name for the person */
+  personName: string;
+  /** Semantic Scholar author ID (e.g. "1712334" for a real author). */
+  authorId: string;
+}
+
+export interface SemanticScholarOptions extends HttpOptions {
+  /** Override base URL (tests inject localhost). */
+  apiBase?: string;
+  /** Page size (max 100 per S2 docs). */
+  limit?: number;
+  /** Hard cap on total papers fetched per target (defaults to 500). */
+  maxPapers?: number;
+  /** `x-api-key` header value. Stripped of CR/LF before send. */
+  apiKey?: string;
+}
+
+export interface SemanticScholarPaper {
+  paperId: string;
+  externalIds?: {
+    DOI?: string | null;
+    ArXiv?: string | null;
+    CorpusId?: number | null;
+  } | null;
+  title?: string | null;
+  venue?: string | null;
+  year?: number | null;
+  publicationDate?: string | null;
+  publicationTypes?: string[] | null;
+  url?: string | null;
+}
+
+interface PapersResponse {
+  offset?: number;
+  next?: number | null;
+  total?: number;
+  data?: SemanticScholarPaper[];
+}
+
+const DEFAULT_API_BASE = "https://api.semanticscholar.org/graph/v1";
+const DEFAULT_LIMIT = 100;
+const DEFAULT_MAX_PAPERS = 500;
+const MAX_LIMIT = 100;
+const S2_API_OFFSET_CAP = 10_000;
+
+/** Validate an S2 author ID. */
+export function assertValidAuthorId(id: string): void {
+  if (!AUTHOR_ID_RE.test(id)) {
+    throw new Error(
+      `invalid Semantic Scholar author id: "${id}" (must match /^\\d+$/)`
+    );
+  }
+}
+
+/**
+ * Map S2 publicationTypes[] → our publication type. S2 returns an ARRAY
+ * like ["JournalArticle"], ["Conference", "JournalArticle"], or null.
+ *
+ * We pick the most specific element: Book > Dataset > Review >
+ * JournalArticle > Conference > anything else → "paper". Preprints show up
+ * as JournalArticle with a `arXiv` externalId; callers who want that
+ * granularity can inspect `externalIds`.
+ */
+export function mapPublicationType(types: string[] | null | undefined): string {
+  if (!types || types.length === 0) return "paper";
+  if (types.includes("Book")) return "book";
+  if (types.includes("Review")) return "paper";
+  if (types.includes("Dataset")) return "paper";
+  if (types.includes("JournalArticle")) return "paper";
+  if (types.includes("Conference")) return "paper";
+  // Fallback via the shared OpenAlex mapper; unknown → "paper".
+  return mapOpenAlexType(types[0]);
+}
+
+/**
+ * Normalize a DOI to bare form. Mirrors the OpenAlex helper.
+ * Returns null for empty input.
+ */
+export function normalizeDoi(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const lower = trimmed.toLowerCase();
+  for (const prefix of ["https://doi.org/", "http://doi.org/", "doi:"]) {
+    if (lower.startsWith(prefix)) return trimmed.slice(prefix.length);
+  }
+  return trimmed;
+}
+
+/**
+ * Fetch all papers for an author via offset pagination. Respects maxPapers
+ * and the S2-imposed offset cap.
+ */
+export async function fetchAuthorPapers(
+  authorId: string,
+  opts: SemanticScholarOptions = {}
+): Promise<SemanticScholarPaper[]> {
+  assertValidAuthorId(authorId);
+  const apiBase = opts.apiBase ?? DEFAULT_API_BASE;
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const maxPapers = opts.maxPapers ?? DEFAULT_MAX_PAPERS;
+  const fetchImpl = getFetch(opts);
+  const headers: Record<string, string> = {
+    "User-Agent": getUserAgent(opts),
+    Accept: "application/json",
+  };
+  if (opts.apiKey) {
+    // Strip CR/LF from user-supplied key — same header-injection guard as User-Agent.
+    headers["x-api-key"] = opts.apiKey.replace(/[\r\n]/g, "").trim();
+  }
+
+  const papers: SemanticScholarPaper[] = [];
+  let offset = 0;
+  while (papers.length < maxPapers && offset < S2_API_OFFSET_CAP) {
+    const params = new URLSearchParams({
+      fields:
+        "paperId,externalIds,title,venue,year,publicationDate,publicationTypes,url",
+      limit: String(limit),
+      offset: String(offset),
+    });
+    const url = `${apiBase}/author/${encodeURIComponent(authorId)}/papers?${params.toString()}`;
+    const resp = await fetchImpl(url, { headers });
+    if (!resp.ok) {
+      throw new Error(
+        `Semantic Scholar papers HTTP ${resp.status} for author ${authorId}`
+      );
+    }
+    const data = (await resp.json()) as PapersResponse;
+    const batch = data?.data;
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    for (const p of batch) {
+      papers.push(p);
+      if (papers.length >= maxPapers) break;
+    }
+    const next = data?.next;
+    if (typeof next !== "number" || next <= offset) break;
+    offset = next;
+  }
+  return papers;
+}
+
+/**
+ * Build one publication proposal from one S2 paper.
+ *
+ * Skips papers with no title, no date, or a nonsensical year (S2 has some
+ * year=0 rows for undated preprints).
+ *
+ * entityRefs.person points to the target person slug; the propose endpoint
+ * will link the paper-author relationship.
+ */
+export function buildProposal(
+  target: SemanticScholarTarget,
+  paper: SemanticScholarPaper
+): EnrichmentProposal | null {
+  const title = paper.title?.trim();
+  if (!title) return null;
+  const date = paper.publicationDate
+    ?? (paper.year && paper.year > 1800 ? `${paper.year}-01-01` : null);
+  if (!date) return null;
+  const doi = normalizeDoi(paper.externalIds?.DOI);
+  const arxiv = paper.externalIds?.ArXiv ?? null;
+  const venue = paper.venue?.trim() || null;
+  const url = paper.url
+    ?? (doi ? `https://doi.org/${doi}` : `https://www.semanticscholar.org/paper/${paper.paperId}`);
+
+  const canonical = JSON.stringify({
+    paperId: paper.paperId,
+    doi,
+    arxiv,
+    title,
+    date,
+  });
+  const responseHash = createHash("sha256").update(canonical).digest("hex");
+  const sourceUrl = `https://www.semanticscholar.org/paper/${paper.paperId}`;
+
+  const notesParts: string[] = [
+    `Semantic Scholar paper ${paper.paperId}`,
+    `author ${target.authorId} (${target.personName})`,
+  ];
+  if (arxiv) notesParts.push(`arXiv:${arxiv}`);
+
+  return {
+    tier: "T1",
+    source: `${T1_SOURCE_PREFIXES.semanticScholar}${paper.paperId}`,
+    sourceUrl,
+    responseHash,
+    recordType: "publication",
+    record: {
+      title,
+      doi,
+      arxivId: arxiv,
+      publishedDate: date,
+      venue,
+      publicationType: mapPublicationType(paper.publicationTypes ?? undefined),
+      url,
+      notes: notesParts.join(" — "),
+    },
+    entityRefs: { person: target.personSlug },
+  };
+}
+
+/** End-to-end for one target: fetch + build proposals. */
+export async function importTarget(
+  target: SemanticScholarTarget,
+  opts: SemanticScholarOptions = {}
+): Promise<{ proposals: EnrichmentProposal[]; skipped: number }> {
+  const papers = await fetchAuthorPapers(target.authorId, opts);
+  const proposals: EnrichmentProposal[] = [];
+  let skipped = 0;
+  for (const p of papers) {
+    const proposal = buildProposal(target, p);
+    if (proposal) proposals.push(proposal);
+    else skipped++;
+  }
+  return { proposals, skipped };
+}
+
+/** CLI entry — `crux tb semantic-scholar --target=slug:name:authorId`. */
+export async function cliMain(args: string[]): Promise<CommandResult> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output:
+        "No targets specified. Pass --target=personSlug:displayName:authorId (repeatable)",
+    };
+  }
+  const apiKey = process.env.SEMANTIC_SCHOLAR_API_KEY;
+  const all: EnrichmentProposal[] = [];
+  let totalFailures = 0;
+  let totalSkipped = 0;
+  for (const t of targets) {
+    console.log(
+      `[semantic-scholar] fetching ${t.personSlug} (author ${t.authorId})...`
+    );
+    try {
+      const { proposals, skipped } = await importTarget(t, { apiKey });
+      console.log(
+        `[semantic-scholar]   → ${proposals.length} publication proposals, ${skipped} skipped (missing title/date)`
+      );
+      all.push(...proposals);
+      totalSkipped += skipped;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `[semantic-scholar] target ${t.personSlug} failed: ${msg}`
+      );
+      totalFailures++;
+    }
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(all, clientOpts);
+  printBatchSummary(results, "semantic-scholar");
+  if (totalFailures > 0 || totalSkipped > 0) {
+    console.warn(
+      `[semantic-scholar] ${totalFailures} target failure(s), ${totalSkipped} paper(s) skipped`
+    );
+  }
+  return { exitCode: 0, output: "" };
+}
+
+/**
+ * Parse `--target=personSlug:displayName:authorId`. displayName may contain
+ * colons (we split on the first two only).
+ */
+export function parseTargetsArg(args: readonly string[]): SemanticScholarTarget[] {
+  const out: SemanticScholarTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    // First colon separates slug from the rest; last colon separates
+    // authorId from displayName. displayName is anything in between.
+    const firstColon = value.indexOf(":");
+    const lastColon = value.lastIndexOf(":");
+    if (firstColon === -1 || lastColon === -1 || firstColon === lastColon) {
+      throw new Error(
+        `--target must be personSlug:displayName:authorId (at least two colons), got "${value}"`
+      );
+    }
+    const personSlug = value.slice(0, firstColon);
+    const personName = value.slice(firstColon + 1, lastColon);
+    const authorId = value.slice(lastColon + 1);
+    if (!personSlug || !personName || !authorId) {
+      throw new Error(`--target has empty segment(s): "${value}"`);
+    }
+    assertValidAuthorId(authorId);
+    out.push({ personSlug, personName, authorId });
+  }
+  return out;
+}

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -16,7 +16,9 @@ export type EnrichmentTier = "T1" | "T2" | "T3";
 export type EnrichmentRecordType =
   | "funding-round"
   | "personnel"
-  | "benchmark-result";
+  | "benchmark-result"
+  | "publication"
+  | "organization-fact";
 
 /**
  * One record proposal. The propose endpoint validates `(source, recordType)`
@@ -51,6 +53,9 @@ export interface EnrichmentProposal {
    *   - personnel:     role, roleType, personDisplayName, orgDisplayName,
    *     source, notes, isFounder
    *   - benchmark-result: score, unit, date, sourceUrl, notes
+   *   - publication:    title, doi, publishedDate, venue, authors,
+   *     publicationType, url, notes
+   *   - organization-fact: property, value, valueType, source, notes
    */
   record: Record<string, unknown>;
   /**

--- a/crux/commands/tb-importers/wikidata.ts
+++ b/crux/commands/tb-importers/wikidata.ts
@@ -1,0 +1,378 @@
+/**
+ * Wikidata SPARQL → organization-fact importer (T1, QUA-666).
+ *
+ * Fetches structured facts for an org by Q-number from the Wikidata SPARQL
+ * endpoint. Each SPARQL binding yields one or more `organization-fact`
+ * proposals (property, value, valueType) routed through the propose endpoint.
+ *
+ * This is STRUCTURALLY DIFFERENT from `crux fb wikidata-enrich` (which writes
+ * FactBase YAML for entity-level facts). That command pre-dates the proposal
+ * pipeline and writes directly to YAML. This one emits EnrichmentProposal
+ * payloads for the QUA-632 propose endpoint, so facts land in TableBase with
+ * proper evidence + verdict rows.
+ *
+ * API: https://query.wikidata.org/sparql
+ *   Query via `?query=<url-encoded SPARQL>` GET request.
+ *   Accept: application/sparql-results+json
+ *   Rate limit: ~1 req/sec is courteous (WDQS enforces 60/min hard cap).
+ *
+ * Property set mirrors the existing wikidata-enrich command for consistency:
+ *   P571 foundedDate, P159 HQ, P17 country, P856 website, P169 CEO,
+ *   P1128 employees, P2139 revenue, P749 parentOrg, P112 founder,
+ *   P1454 legalForm.
+ */
+
+import { createHash } from "crypto";
+import {
+  submitBatch,
+  printBatchSummary,
+  type ProposeClientOptions,
+} from "./propose-client.ts";
+import { getFetch, getUserAgent, type HttpOptions } from "./http-utils.ts";
+import { T1_SOURCE_PREFIXES } from "./allowlist.ts";
+import type { CommandResult } from "../../lib/command-types.ts";
+import type { EnrichmentProposal } from "./types.ts";
+
+/**
+ * QID regex — `Q` followed by 1+ digits. Wikidata item IDs never carry
+ * leading zeros, so `Q0...` is explicitly rejected.
+ */
+const QID_RE = /^Q[1-9]\d*$/;
+
+export interface WikidataTarget {
+  /** Org slug from data/entities/organizations.yaml */
+  orgSlug: string;
+  /** Display name for the org (preserved into notes) */
+  orgName: string;
+  /** Wikidata item ID (e.g., "Q108542504" for Anthropic) */
+  qid: string;
+}
+
+export interface WikidataOptions extends HttpOptions {
+  /** SPARQL endpoint override (tests point this at a mock URL). */
+  sparqlEndpoint?: string;
+}
+
+/**
+ * One SPARQL binding → one FactBase property. Each binding produces one
+ * proposal; bindings that come back null are silently skipped.
+ *
+ * `valueType` is how the propose endpoint decides how to store the value:
+ *   - "date" (YYYY-MM or YYYY-MM-DD)
+ *   - "string" (labels, free text)
+ *   - "number" (counts, amounts)
+ *   - "url"    (website URL)
+ */
+export interface WikidataPropertyBinding {
+  /** Wikidata property ID, e.g. "P571" — used in `source` suffix. */
+  wikidataProperty: string;
+  /** SPARQL variable name returned in the binding. */
+  sparqlVariable: string;
+  /** Target record property, e.g. "founded-date". */
+  property: string;
+  /** Expected value type for the target property. */
+  valueType: "date" | "string" | "number" | "url";
+  /** Optional value extractor — defaults to returning the raw SPARQL value. */
+  extractValue?: (raw: string) => string | number | null;
+}
+
+/**
+ * Wikidata property set — kept small & intentional. Matches the fact set
+ * already in use by `crux fb wikidata-enrich` so the two pipelines produce
+ * comparable facts when run against the same org.
+ */
+export const WIKIDATA_PROPERTY_BINDINGS: readonly WikidataPropertyBinding[] = [
+  {
+    wikidataProperty: "P571",
+    sparqlVariable: "foundedDate",
+    property: "founded-date",
+    valueType: "date",
+    // Wikidata dates are like "2015-12-11T00:00:00Z" — truncate to YYYY-MM.
+    extractValue: (raw: string) => {
+      const m = /^(\d{4}-\d{2})/.exec(raw);
+      return m ? m[1] : null;
+    },
+  },
+  {
+    wikidataProperty: "P159",
+    sparqlVariable: "headquartersLabel",
+    property: "headquarters",
+    valueType: "string",
+  },
+  {
+    wikidataProperty: "P17",
+    sparqlVariable: "countryLabel",
+    property: "country",
+    valueType: "string",
+  },
+  {
+    wikidataProperty: "P856",
+    sparqlVariable: "website",
+    property: "website",
+    valueType: "url",
+  },
+  {
+    wikidataProperty: "P169",
+    sparqlVariable: "ceoLabel",
+    property: "ceo-name",
+    valueType: "string",
+  },
+  {
+    wikidataProperty: "P1128",
+    sparqlVariable: "employees",
+    property: "headcount",
+    valueType: "number",
+    extractValue: (raw: string) => {
+      const n = Number(raw);
+      return Number.isFinite(n) && n > 0 ? n : null;
+    },
+  },
+  {
+    wikidataProperty: "P2139",
+    sparqlVariable: "revenue",
+    property: "revenue",
+    valueType: "number",
+    extractValue: (raw: string) => {
+      const n = Number(raw);
+      return Number.isFinite(n) && n > 0 ? n : null;
+    },
+  },
+  {
+    wikidataProperty: "P749",
+    sparqlVariable: "parentOrgLabel",
+    property: "parent-organization",
+    valueType: "string",
+  },
+  {
+    wikidataProperty: "P112",
+    sparqlVariable: "founderLabel",
+    property: "founded-by-name",
+    valueType: "string",
+  },
+  {
+    wikidataProperty: "P1454",
+    sparqlVariable: "legalFormLabel",
+    property: "legal-structure",
+    valueType: "string",
+  },
+] as const;
+
+/** Minimal SPARQL binding shape. */
+export interface SparqlBinding {
+  [key: string]: { type: string; value: string; datatype?: string } | undefined;
+}
+
+export interface SparqlResults {
+  results: { bindings: SparqlBinding[] };
+}
+
+const DEFAULT_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql";
+
+/**
+ * Build the SPARQL query covering all bindings. Uses OPTIONAL for every
+ * clause so a missing triple yields a null binding rather than an empty
+ * overall result set.
+ */
+export function buildSparqlQuery(qid: string): string {
+  assertValidQid(qid);
+  const optionals = WIKIDATA_PROPERTY_BINDINGS.map((b) => {
+    // `?xLabel` variables come from the wikibase:label service, which binds
+    // them from `?x` triples automatically. For website + date we want the
+    // raw bound value instead.
+    const isLabel = b.sparqlVariable.endsWith("Label");
+    const baseVar = isLabel
+      ? b.sparqlVariable.slice(0, -"Label".length)
+      : b.sparqlVariable;
+    return `  OPTIONAL { wd:${qid} wdt:${b.wikidataProperty} ?${baseVar}. }`;
+  }).join("\n");
+  // Select the full variable list with label suffix where needed.
+  const selectVars = WIKIDATA_PROPERTY_BINDINGS.map((b) => `?${b.sparqlVariable}`).join(" ");
+  return `SELECT ${selectVars} WHERE {
+${optionals}
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+LIMIT 1`;
+}
+
+/**
+ * Validate a Wikidata Q-number. Rejects empty, non-Q-prefixed, leading-zero,
+ * or non-numeric QIDs. Throws — not returns null — because invalid QIDs
+ * would produce malformed SPARQL or trivially-empty results.
+ */
+export function assertValidQid(qid: string): void {
+  if (!QID_RE.test(qid)) {
+    throw new Error(
+      `invalid Wikidata QID: "${qid}" (must match /^Q[1-9]\\d*$/)`
+    );
+  }
+}
+
+/**
+ * Fetch SPARQL results for one QID. Throws on non-2xx.
+ * Returns the raw bindings (array; usually 1 element since LIMIT 1).
+ */
+export async function fetchSparqlBindings(
+  qid: string,
+  opts: WikidataOptions = {}
+): Promise<{ bindings: SparqlBinding[]; rawResponse: string; sourceUrl: string }> {
+  const sparql = buildSparqlQuery(qid);
+  const endpoint = opts.sparqlEndpoint ?? DEFAULT_SPARQL_ENDPOINT;
+  const url = `${endpoint}?query=${encodeURIComponent(sparql)}`;
+  const resp = await getFetch(opts)(url, {
+    headers: {
+      "User-Agent": getUserAgent(opts),
+      Accept: "application/sparql-results+json",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Wikidata SPARQL HTTP ${resp.status} for ${qid}`);
+  }
+  const rawResponse = await resp.text();
+  let data: SparqlResults;
+  try {
+    data = JSON.parse(rawResponse) as SparqlResults;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Wikidata SPARQL response is not valid JSON: ${msg}`);
+  }
+  const bindings = data?.results?.bindings;
+  if (!Array.isArray(bindings)) {
+    throw new Error(`Wikidata SPARQL response missing results.bindings`);
+  }
+  // The canonical wiki page URL — used as evidence source, NOT the raw
+  // SPARQL URL (which is huge and caching-hostile).
+  const sourceUrl = `https://www.wikidata.org/wiki/${qid}`;
+  return { bindings, rawResponse, sourceUrl };
+}
+
+/**
+ * Extract one typed value from a single binding row.
+ * Returns null for missing/invalid values so the caller can skip without
+ * emitting a broken proposal.
+ */
+export function extractBindingValue(
+  binding: SparqlBinding,
+  propBinding: WikidataPropertyBinding
+): string | number | null {
+  const raw = binding[propBinding.sparqlVariable]?.value;
+  if (raw == null || raw === "") return null;
+  if (propBinding.extractValue) return propBinding.extractValue(raw);
+  return raw;
+}
+
+/**
+ * Build per-property proposals from SPARQL result bindings.
+ *
+ * One binding row can yield up to N proposals (one per property that's
+ * present and passes extraction). If the query returned zero binding rows,
+ * returns an empty array.
+ */
+export function buildProposals(
+  target: WikidataTarget,
+  bindings: readonly SparqlBinding[],
+  rawResponse: string,
+  sourceUrl: string
+): EnrichmentProposal[] {
+  if (bindings.length === 0) return [];
+  const row = bindings[0]; // LIMIT 1 ⇒ at most one row
+  const proposals: EnrichmentProposal[] = [];
+  for (const b of WIKIDATA_PROPERTY_BINDINGS) {
+    const value = extractBindingValue(row, b);
+    if (value === null) continue;
+    // Hash the (qid, property, value) triple so retries produce identical
+    // response hashes even if the SPARQL response JSON ordering shifts.
+    const canonical = JSON.stringify({
+      qid: target.qid,
+      wikidataProperty: b.wikidataProperty,
+      value,
+    });
+    const responseHash = createHash("sha256").update(canonical).digest("hex");
+    proposals.push({
+      tier: "T1",
+      source: `${T1_SOURCE_PREFIXES.wikidata}${target.qid}:${b.wikidataProperty}`,
+      sourceUrl,
+      responseHash,
+      recordType: "organization-fact",
+      record: {
+        property: b.property,
+        value,
+        valueType: b.valueType,
+        source: sourceUrl,
+        notes: `From Wikidata ${target.qid} (${b.wikidataProperty}); SPARQL response SHA-256: ${createHash("sha256").update(rawResponse).digest("hex").slice(0, 12)}`,
+        orgDisplayName: target.orgName,
+      },
+      entityRefs: { organization: target.orgSlug },
+    });
+  }
+  return proposals;
+}
+
+/** End-to-end import for one target. */
+export async function importTarget(
+  target: WikidataTarget,
+  opts: WikidataOptions = {}
+): Promise<{ proposals: EnrichmentProposal[] }> {
+  const { bindings, rawResponse, sourceUrl } = await fetchSparqlBindings(
+    target.qid,
+    opts
+  );
+  return { proposals: buildProposals(target, bindings, rawResponse, sourceUrl) };
+}
+
+/** CLI entry — `crux tb wikidata --target=slug:Q12345 [--submit]`. */
+export async function cliMain(args: string[]): Promise<CommandResult> {
+  const submit = args.includes("--submit");
+  const targets = parseTargetsArg(args);
+  if (targets.length === 0) {
+    return {
+      exitCode: 2,
+      output: "No targets specified. Pass --target=slug:Q12345 (repeatable)",
+    };
+  }
+  const all: EnrichmentProposal[] = [];
+  let totalFailures = 0;
+  for (const t of targets) {
+    console.log(`[wikidata] fetching ${t.orgSlug} (${t.qid})...`);
+    try {
+      const { proposals } = await importTarget(t);
+      console.log(`[wikidata]   → ${proposals.length} fact proposals`);
+      all.push(...proposals);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[wikidata] target ${t.orgSlug} failed: ${msg}`);
+      totalFailures++;
+    }
+  }
+  const clientOpts: ProposeClientOptions = { submit };
+  const results = await submitBatch(all, clientOpts);
+  printBatchSummary(results, "wikidata");
+  if (totalFailures > 0) {
+    console.warn(`[wikidata] ${totalFailures} target failures`);
+  }
+  return { exitCode: 0, output: "" };
+}
+
+/**
+ * Parse `--target=slug:Qnumber`. Strict on colons (exactly one) and QID
+ * format to guard against malformed SPARQL.
+ */
+export function parseTargetsArg(args: readonly string[]): WikidataTarget[] {
+  const out: WikidataTarget[] = [];
+  for (const arg of args) {
+    if (!arg.startsWith("--target=")) continue;
+    const value = arg.slice("--target=".length);
+    const parts = value.split(":");
+    if (parts.length !== 2) {
+      throw new Error(
+        `--target must be slug:Qnumber (exactly one colon), got "${value}"`
+      );
+    }
+    const [orgSlug, qid] = parts;
+    if (!orgSlug || !qid) {
+      throw new Error(`--target slug and qid must both be non-empty, got "${value}"`);
+    }
+    assertValidQid(qid);
+    out.push({ orgSlug, orgName: orgSlug, qid });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Phase 2 of [QUA-637](https://linear.app/quantifieduncertainty/issue/QUA-637) coverage-expansion umbrella. Adds 4 T1 authoritative-source importers that emit `EnrichmentProposal` payloads through the propose endpoint (QUA-632) — unblocks the [QUA-641](https://linear.app/quantifieduncertainty/issue/QUA-641) saturation run that had "Sources to run" list gaps.

Fixes QUA-666

## What's added

| Command | Target format | Record type | API |
|---------|---------------|-------------|-----|
| `crux tb wikidata` | `slug:Qnumber` | `organization-fact` | `query.wikidata.org/sparql` |
| `crux tb openalex` | `slug:Iinstitution_id` | `publication` | `api.openalex.org/works` (cursor paginated) |
| `crux tb semantic-scholar` | `personSlug:displayName:authorId` | `publication` | `api.semanticscholar.org/graph/v1/author/<id>/papers` |
| `crux tb crossref` | `doi:10.xxx/yyy[\|org=slug][\|person=slug]` | `publication` | `api.crossref.org/works/<doi>` |

All 4 match the [QUA-640](https://linear.app/quantifieduncertainty/issue/QUA-640) pattern (SEC EDGAR / GitHub / HF Leaderboard):
- Deterministic extraction, SHA-256 response hashes over canonical tuples
- T1 allowlist enforcement via shared `propose-client`
- Fetch injection for tests, CR/LF stripping on user-supplied headers
- Strict CLI target parsing (rejects empty segments, bad ID formats)

## Registry changes

- `T1_SOURCE_PREFIXES`: `wikidata:` / `openalex:` / `semantic-scholar:` / `crossref:`
- `T1_AUTHORITY_ALLOWLIST`: corresponding `(prefix, recordType)` allowlist entries
- `EnrichmentRecordType`: add `publication` and `organization-fact`

## Why Wikidata is a new importer even though `crux fb wikidata-enrich` exists

The existing `crux fb wikidata-enrich` writes FactBase YAML directly (entity-level facts, bypassing the proposal pipeline). The new `crux tb wikidata` emits `EnrichmentProposal` payloads for QUA-632, so facts land in TableBase with proper evidence rows + verdict rows. Same property set (P571/P159/P17/P856/P169/P1128/P2139/P749/P112/P1454) but routed through the proposal gate.

## Follow-up

- Submit mode returns `pending` until [QUA-632](https://linear.app/quantifieduncertainty/issue/QUA-632) (propose endpoint) lands
- Saturation run (QUA-641) can now proceed with the full T1 source list

## Test plan

- [x] 191 new unit tests across the 4 importers (294 total in `tb-importers/__tests__/`, all passing via `npx vitest run crux/commands/tb-importers/__tests__/`). Coverage: parse/extract/fetch/build, adversarial inputs (empty strings, header injection `\r\n`, malformed IDs `Q0`/`I0`/`abc`, bad pagination cursors, undatable works, missing titles), happy-path against mocked fetch.
- [x] Live-tested Wikidata: `pnpm crux tb wikidata --target=anthropic:Q108542504 --submit` → 3 fact proposals returned (founded-date, headquarters, headcount).
- [x] Live-tested Crossref: `pnpm crux tb crossref --target='doi:10.1145/3442188.3445922|org=anthropic' --submit` → 1 publication proposal returned.
- [x] Gate check: `pnpm crux w validate gate --fix` → all 54 gate checks passed (3 pre-existing advisory warnings).
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new data importers: Wikidata, OpenAlex, Semantic Scholar, and Crossref
  * New CLI commands to import publication and organization-fact records from these authoritative sources
  * Publication imports include title, author, date, and URL metadata
  * Batch processing and submission of imported records with error tracking and skip counting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [x] `env` SEMANTIC_SCHOLAR_API_KEY is OPTIONAL — importer works unauth at ~1 req/sec shared. Set it post-merge only if running bursts. Not a merge blocker.
<!-- /deploy-tasks -->
