### PR TITLE
fix(wiki): stop leaking raw sid_ ids in R/FBF fallbacks (QUA-657)

### DIFF
--- a/apps/web/src/components/wiki/FBF.tsx
+++ b/apps/web/src/components/wiki/FBF.tsx
@@ -68,6 +68,12 @@ export function FBF({
 
   // Error state: red badge for missing fact
   if (!fact) {
+    // Never render the raw entity id in visible text — `entity` may be a
+    // stableId like `sid_xxx` which leaks into user-facing pages (QUA-657).
+    // Prefer author-provided children, else the human property name, else
+    // the raw property key (which is not a stableId).
+    const propertyName = prop?.name ?? property;
+    const fallback = children ?? `[missing: ${propertyName}]`;
     return (
       <span
         className={cn(
@@ -76,7 +82,7 @@ export function FBF({
         )}
         title={`Missing FactBase fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
       >
-        {children || `[missing: ${entity}.${property}]`}
+        {fallback}
       </span>
     );
   }

--- a/apps/web/src/components/wiki/ResourceLink.tsx
+++ b/apps/web/src/components/wiki/ResourceLink.tsx
@@ -33,9 +33,13 @@ export function ResourceLink({
   const resource = resolveResource(id);
 
   if (!resource) {
+    // Never render the raw id in visible text — it leaks stableIds like
+    // `sid_xxx` into user-facing pages (QUA-657). Fall back to the
+    // author-provided label/children, or a generic placeholder.
+    const fallback = children ?? label ?? "missing resource";
     return (
       <span className={cn("text-destructive italic", className)} title={`Resource not found: ${id}`}>
-        [{id}]
+        {fallback}
       </span>
     );
   }

--- a/apps/web/src/components/wiki/__tests__/FBF.test.tsx
+++ b/apps/web/src/components/wiki/__tests__/FBF.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+/**
+ * FBF tests — QUA-657 regression guard.
+ *
+ * The missing-fact fallback must never render the raw entity id in visible
+ * text — `entity` may be a stableId like `sid_xxx` which leaks into
+ * user-facing pages.
+ */
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock data-layer imports before importing the component
+vi.mock("@data/factbase", () => ({
+  getKBFacts: vi.fn(() => []),
+  getKBLatest: vi.fn(() => undefined),
+  getKBProperty: vi.fn((id: string) => {
+    const properties: Record<string, { name: string }> = {
+      revenue: { name: "Revenue" },
+    };
+    return properties[id];
+  }),
+}));
+
+vi.mock("@/components/sourcing/FactSourcingDot", () => ({
+  FactSourcingDot: () => null,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import { FBF } from "@/components/wiki/FBF";
+
+describe("FBF — missing fact fallback (QUA-657)", () => {
+  it("renders children as fallback text when fact is missing", () => {
+    render(
+      <FBF entity="sid_mK9pX3rQ7n" property="revenue">
+        $4 billion
+      </FBF>,
+    );
+    expect(screen.getByText("$4 billion")).toBeDefined();
+    expect(screen.queryByText(/sid_mK9pX3rQ7n/)).toBeNull();
+  });
+
+  it("renders property name (not stableId) as fallback when no children", () => {
+    render(<FBF entity="sid_mK9pX3rQ7n" property="revenue" />);
+    expect(screen.getByText("[missing: Revenue]")).toBeDefined();
+    expect(screen.queryByText(/sid_mK9pX3rQ7n/)).toBeNull();
+    expect(screen.queryByText(/\[missing: sid_/)).toBeNull();
+  });
+
+  it("falls back to raw property key when no registered property", () => {
+    render(<FBF entity="sid_mK9pX3rQ7n" property="coding-market-share" />);
+    expect(screen.getByText("[missing: coding-market-share]")).toBeDefined();
+    expect(screen.queryByText(/sid_mK9pX3rQ7n/)).toBeNull();
+  });
+
+  it("preserves entity+property in title attribute for dev debugging", () => {
+    const { container } = render(
+      <FBF entity="sid_mK9pX3rQ7n" property="revenue" />,
+    );
+    const span = container.querySelector("span[title]");
+    expect(span?.getAttribute("title")).toBe(
+      "Missing FactBase fact: sid_mK9pX3rQ7n.revenue",
+    );
+  });
+});

--- a/apps/web/src/components/wiki/__tests__/ResourceLink.test.tsx
+++ b/apps/web/src/components/wiki/__tests__/ResourceLink.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+/**
+ * ResourceLink tests — QUA-657 regression guard.
+ *
+ * The not-found fallback must NEVER render the raw id in visible text.
+ * Rendering `[{id}]` leaks stableIds like `sid_xxx` into user-facing pages
+ * and breaks the no-raw-ids e2e test.
+ */
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock data-layer imports before importing the component
+vi.mock("@data", () => ({
+  resolveResource: vi.fn(() => undefined),
+  getResourceCredibility: vi.fn(() => null),
+  getResourcePublication: vi.fn(() => null),
+}));
+
+import { ResourceLink } from "@/components/wiki/ResourceLink";
+
+describe("ResourceLink — missing resource fallback (QUA-657)", () => {
+  it("renders children as fallback text when resource is not found", () => {
+    render(
+      <ResourceLink id="sid_missingResource">
+        Scalable agent alignment via reward modeling
+      </ResourceLink>,
+    );
+    expect(
+      screen.getByText("Scalable agent alignment via reward modeling"),
+    ).toBeDefined();
+    expect(screen.queryByText(/sid_missingResource/)).toBeNull();
+    expect(screen.queryByText(/\[sid_/)).toBeNull();
+  });
+
+  it("renders label prop as fallback when resource is not found and no children", () => {
+    render(<ResourceLink id="sid_missingResource" label="Alignment Research Center" />);
+    expect(screen.getByText("Alignment Research Center")).toBeDefined();
+    expect(screen.queryByText(/sid_missingResource/)).toBeNull();
+  });
+
+  it("renders generic placeholder when resource missing and no children or label", () => {
+    render(<ResourceLink id="sid_missingResource" />);
+    expect(screen.getByText("missing resource")).toBeDefined();
+    expect(screen.queryByText(/sid_missingResource/)).toBeNull();
+    expect(screen.queryByText(/\[sid_/)).toBeNull();
+  });
+
+  it("preserves the full id in title attribute for dev debugging", () => {
+    const { container } = render(
+      <ResourceLink id="sid_missingResource">some label</ResourceLink>,
+    );
+    const span = container.querySelector("span[title]");
+    expect(span?.getAttribute("title")).toBe("Resource not found: sid_missingResource");
+  });
+
+  it("does not leak hex-format legacy ids either", () => {
+    render(
+      <ResourceLink id="deadbeef1234abcd">Legacy Resource</ResourceLink>,
+    );
+    expect(screen.getByText("Legacy Resource")).toBeDefined();
+    expect(screen.queryByText(/deadbeef1234abcd/)).toBeNull();
+  });
+});

--- a/apps/web/src/components/wiki/factbase/FBFactValue.tsx
+++ b/apps/web/src/components/wiki/factbase/FBFactValue.tsx
@@ -49,6 +49,11 @@ export function FBFactValue({
   }
 
   if (!fact) {
+    // Never render the raw entity id in visible text — `entity` may be a
+    // stableId like `sid_xxx` which leaks into user-facing pages (QUA-657).
+    // Use the human property name if available, else the raw property key
+    // (which is not a stableId).
+    const propertyName = prop?.name ?? property;
     return (
       <span
         className={cn(
@@ -57,7 +62,7 @@ export function FBFactValue({
         )}
         title={`Missing FactBase fact: ${entity}.${property}${asOf ? ` (${asOf})` : ""}`}
       >
-        [missing: {entity}.{property}]
+        [missing: {propertyName}]
       </span>
     );
   }


### PR DESCRIPTION
## Summary

- The `<R>`, `<FBF>`, and `<FBFactValue>` MDX components rendered raw stableIds in their "missing" fallback paths, leaking `sid_xxx` into user-facing text — notably the 2026-04-23 inline-wiki-tab regression on `/organizations/{anthropic,deepmind,arc,conjecture,uk-aisi}` caught by `e2e/no-raw-ids.spec.ts`.
- Commit 25b691862 patched one exposure path by reverting the Wiki tab to a link-tab. This PR closes the root cause across all MDX render sites.
- Fallbacks now prefer author-provided `children`/`label`, else a property name or a generic placeholder — never the raw id. The full id still lands in `title=` for dev debugging (not in `innerText`).

## Changes

- `apps/web/src/components/wiki/ResourceLink.tsx` — missing resource renders `children ?? label ?? "missing resource"` instead of `[{id}]`.
- `apps/web/src/components/wiki/FBF.tsx` — missing fact renders `children ?? \`[missing: ${propertyName}]\`` (property name from `getKBProperty(property)?.name`, else the raw property key).
- `apps/web/src/components/wiki/factbase/FBFactValue.tsx` — same fix, no children prop available.
- Regression tests for both components covering missing-resource, missing-fact, unknown-property, and `sid_` + hex-format id shapes.

## Test plan

- [x] `npx vitest run src/components/wiki` — 139 tests pass
- [x] Typecheck clean (`npx tsc --noEmit -p apps/web/tsconfig.json`)
- [x] Gate passes (`pnpm crux w validate gate --scope=content`)
- [ ] `e2e/no-raw-ids.spec.ts` still green in CI

Fixes QUA-657
