### PR TITLE
fix(wellness): plumb LINEAR_API_KEY into wellness check workflows (QUA-667)

### DIFF
--- a/.github/workflows/ci-pr-health.yml
+++ b/.github/workflows/ci-pr-health.yml
@@ -54,10 +54,15 @@ jobs:
         run: pnpm crux health check --check=actions --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # QUA-667: required for Linear-side dedup (see crux/health/wellness-linear-dedup.ts).
+          # Without this the dedup silently falls back to GitHub create, which Linear's
+          # GitHub integration mirrors into a brand-new QUA ticket each run.
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
       - name: Job queue health
         run: pnpm crux health check --check=job-queue --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
@@ -67,3 +72,4 @@ jobs:
         run: pnpm crux health check --check=pr-quality --report --auto-issue --cleanup-labels
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/.github/workflows/frontend-data-health.yml
+++ b/.github/workflows/frontend-data-health.yml
@@ -46,11 +46,16 @@ jobs:
         run: pnpm crux health check --check=frontend --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # QUA-667: required for Linear-side dedup (see crux/health/wellness-linear-dedup.ts).
+          # Without this the dedup silently falls back to GitHub create, which Linear's
+          # GitHub integration mirrors into a brand-new QUA ticket each run.
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           WIKI_PUBLIC_URL: ${{ secrets.WIKI_PUBLIC_URL }}
       - name: Data freshness
         run: pnpm crux health check --check=freshness --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.

--- a/.github/workflows/server-api-health.yml
+++ b/.github/workflows/server-api-health.yml
@@ -46,6 +46,10 @@ jobs:
         run: pnpm crux health check --check=server --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # QUA-667: required for Linear-side dedup (see crux/health/wellness-linear-dedup.ts).
+          # Without this the dedup silently falls back to GitHub create, which Linear's
+          # GitHub integration mirrors into a brand-new QUA ticket each run.
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.
@@ -55,6 +59,7 @@ jobs:
         run: pnpm crux health check --check=api --report --auto-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LONGTERMWIKI_SERVER_URL: ${{ secrets.LONGTERMWIKI_SERVER_URL }}
           LONGTERMWIKI_SERVER_API_KEY: ${{ secrets.LONGTERMWIKI_SERVER_API_KEY }}
           # QUA-583: crux health defaults to WIKI_SERVER_ENV=prod, which reads PROD_* vars.


### PR DESCRIPTION
## Summary

Closes QUA-667. Fixes the QUA-577 dedup regression.

The wellness bot is still filing a brand-new "System wellness check failing" QUA ticket every time a failure recurs — 9 new tickets since QUA-577 merged on 2026-04-20 (QUA-582, 586, 590, 606, 610, 611, 663, 664, 667).

## Root cause

PR #4501 (QUA-577) added Linear-side dedup in `crux/health/wellness-linear-dedup.ts`. The dedup code is correct and well-tested (31 passing tests). But **none of the three wellness workflow files — `server-api-health.yml`, `frontend-data-health.yml`, `ci-pr-health.yml` — pass `LINEAR_API_KEY` to the env of the `--auto-issue` steps**.

Result:
1. Wellness check fails → `findOpenWellnessIssue()` finds no open GitHub issue (previous one auto-closed when the check recovered).
2. `dedupLinearWellnessIssue()` calls `searchIssues()` → `getLinearApiKey()` throws `"LINEAR_API_KEY not set"`.
3. The module's `try/catch` logs a warning ("Linear wellness dedup lookup failed ... falling back to GitHub create path") and returns `{ kind: 'skipped', reason: 'lookup-failed' }`.
4. `manageWellnessIssue` falls through to `createIssue()` → Linear's GitHub integration mirrors it into a fresh QUA ticket.

The dedup shipped dormant and has been dormant since 2026-04-20. Every closed QUA-xxx in the cascade carries the `"synced to a corresponding GitHub issue"` comment that proves Linear-side dedup was skipped.

## Fix

Add `LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}` to all seven `--auto-issue` steps across the three workflow files. The secret is already configured in the repo (`flagship-curate.yml` uses the same reference).

## Not in scope

- Closing the 9 duplicate QUA tickets — left for a follow-up hygiene pass (same pattern as the QUA-577 cleanup).
- Making `dedupLinearWellnessIssue` distinguish "Linear is down" from "API key not set" with a more prominent error — a nice-to-have but the root problem here is that the env var was never plumbed, which is now fixed.

## Test plan

- [x] `pnpm exec vitest run crux/health/wellness-linear-dedup.test.ts crux/health/wellness-report.test.ts` — 31/31 pass
- [x] YAML parses cleanly (`yaml.safe_load` against all three files)
- [x] `npx tsc --noEmit` passes after clean `.next` (gate TS failure was stale `.next/types` referencing since-removed verification/source-check routes, unrelated)

## Post-merge verification

When the next wellness failure fires after this merges, it should either:
- Comment on the most recent closed QUA wellness ticket within 48h and reopen it to Backlog, OR
- Comment on any currently-open QUA wellness ticket.

NOT create a brand-new QUA-NNN.


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `ci` Modified workflow "ci pr health" — verify it runs successfully after merge — `gh run list --workflow="ci-pr-health.yml" --limit=1 --json status,conclusion`
- [ ] `ci` Modified workflow "frontend data health" — verify it runs successfully after merge — `gh run list --workflow="frontend-data-health.yml" --limit=1 --json status,conclusion`
- [ ] `ci` Modified workflow "server api health" — verify it runs successfully after merge — `gh run list --workflow="server-api-health.yml" --limit=1 --json status,conclusion`
<!-- /deploy-tasks -->