### PR TITLE
Wire T1 importers to /api/enrichment/propose (QUA-665)

### DIFF
--- a/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
+++ b/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
@@ -6,15 +6,18 @@ import {
   type SqlDispatcher,
 } from "./test-utils";
 
-// ── Mock the inner grants sync route so we don't drag in the full sync pipeline ──
+// ── Mock the inner sync routes so we don't drag in the full sync pipeline ──
 //
-// The grants Hono sub-app is imported by enrichment.ts at module load, so we
-// replace it with a tiny stub that records every POST it receives and returns
+// The sync sub-apps are imported by enrichment.ts at module load, so we
+// replace them with tiny stubs that record every POST they receive and return
 // a configurable response.  That lets us assert both (a) exactly what the
-// propose endpoint forwards (row + sourcing) and (b) how the endpoint
-// translates downstream failures into rejection reasons.
+// propose endpoint forwards to each record-type's sync handler (row +
+// sourcing) and (b) how the endpoint translates downstream failures into
+// rejection reasons.
 
 interface CapturedInnerCall {
+  /** Which record-type's sync stub captured this call. */
+  route: "grants" | "personnel" | "funding-rounds" | "benchmark-results";
   path: string;
   body: unknown;
 }
@@ -27,8 +30,8 @@ let innerResponseBody: Record<string, unknown> = {
   claimsLinked: 0,
 };
 
-vi.mock("../routes/tablebase/grants.js", () => {
-  const stub = new Hono().post("/sync", async (c) => {
+function makeStub(route: CapturedInnerCall["route"]) {
+  return new Hono().post("/sync", async (c) => {
     const bodyText = await c.req.text();
     let body: unknown;
     try {
@@ -36,11 +39,17 @@ vi.mock("../routes/tablebase/grants.js", () => {
     } catch {
       body = bodyText;
     }
-    captured.push({ path: new URL(c.req.url).pathname, body });
+    captured.push({ route, path: new URL(c.req.url).pathname, body });
     return c.json(innerResponseBody, innerResponseStatus as 200 | 400 | 500);
   });
-  return { grantsRoute: stub };
-});
+}
+
+vi.mock("../routes/tablebase/grants.js", () => ({ grantsRoute: makeStub("grants") }));
+vi.mock("../routes/tablebase/personnel.js", () => ({ personnelRoute: makeStub("personnel") }));
+vi.mock("../routes/tablebase/funding-rounds.js", () => ({ fundingRoundsRoute: makeStub("funding-rounds") }));
+vi.mock("../routes/tablebase/benchmark-results.js", () => ({
+  benchmarkResultsRoute: makeStub("benchmark-results"),
+}));
 
 // ── DB mock — enrichment_runs logging is the only server-side DB call.
 // Tests that care about the logRunResult SQL assert on `dbQueries`.
@@ -543,7 +552,10 @@ describe("POST /api/enrichment/propose", () => {
     const app = buildApp();
     const res = await postJson(app, "/api/enrichment/propose", {
       tier: "T1",
-      recordType: "personnel", // not in SUPPORTED_RECORD_TYPES for Phase 1
+      // "publications" is a future record type named in the T1 allowlist
+      // (openalex) but not yet wired into RECORD_TYPE_ROUTES — the Zod
+      // SUPPORTED_RECORD_TYPES enum rejects it before any routing happens.
+      recordType: "publications",
       row: { id: "x" },
       sourceUrl: "https://api.openalex.org/works/W1",
     });
@@ -646,5 +658,148 @@ describe("POST /api/enrichment/propose", () => {
       q.query.includes("enrichment_runs"),
     );
     expect(runQueries.length).toBe(1);
+  });
+
+  // ── QUA-665: Phase 1.5 — new record types wired in ──────────────────────
+
+  it("routes funding-rounds T1 requests to the funding-rounds sync subapp", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "funding-rounds",
+      row: {
+        id: "fr01234567",
+        companyId: "anthropic",
+        name: "Form D filing 2024-05-30",
+      },
+      sourceUrl:
+        "https://www.sec.gov/Archives/edgar/data/1828101/000182810124000001/primary_doc.xml",
+      sourceContentHash: "sha256:abc",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+    expect(body.recordId).toBe("fr01234567");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].route).toBe("funding-rounds");
+    const innerBody = captured[0].body as { items: Array<{
+      id: string; companyId: string; source: string;
+      sourcing: { verdict: string; checkedBy: string };
+    }> };
+    expect(innerBody.items[0].companyId).toBe("anthropic");
+    // funding-rounds uses `source` for the URL (not `sourceUrl`).
+    expect(innerBody.items[0].source).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1828101/000182810124000001/primary_doc.xml",
+    );
+    expect(innerBody.items[0].sourcing.checkedBy).toBe("t1-sec-edgar");
+  });
+
+  it("routes personnel T1 requests to the personnel sync subapp", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "personnel",
+      row: {
+        id: "per0123456",
+        personId: "alice",
+        organizationId: "anthropic",
+        role: "contributor",
+        roleType: "career",
+      },
+      sourceUrl: "https://github.com/alice",
+      sourceContentHash: "sha256:def",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].route).toBe("personnel");
+    const innerBody = captured[0].body as { items: Array<{
+      id: string; personId: string; organizationId: string;
+      source: string; sourcing: { verdict: string; checkedBy: string };
+    }> };
+    expect(innerBody.items[0].personId).toBe("alice");
+    expect(innerBody.items[0].organizationId).toBe("anthropic");
+    expect(innerBody.items[0].sourcing.checkedBy).toBe("t1-github-user");
+  });
+
+  it("routes benchmark-results T1 requests to the benchmark-results sync subapp", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "benchmark-results",
+      row: {
+        id: "br01234567",
+        benchmarkId: "ifeval",
+        modelId: "claude-3-5-sonnet",
+        score: 75.2,
+        unit: "%",
+      },
+      sourceUrl:
+        "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard?row=claude-3-5-sonnet",
+      sourceContentHash: "sha256:xyz",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("accepted");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].route).toBe("benchmark-results");
+    const innerBody = captured[0].body as { items: Array<{
+      id: string; benchmarkId: string; modelId: string; score: number;
+      sourceUrl: string; source?: unknown;
+      sourcing: { verdict: string; checkedBy: string };
+    }> };
+    // benchmark-results uses `sourceUrl` (not `source`) for the URL field.
+    expect(innerBody.items[0].sourceUrl).toContain(
+      "huggingface.co/spaces/open-llm-leaderboard",
+    );
+    // The opposite field is scrubbed so callers can't smuggle a divergent URL.
+    expect(innerBody.items[0].source).toBeUndefined();
+    expect(innerBody.items[0].sourcing.checkedBy).toBe("t1-hf-leaderboard");
+  });
+
+  it("rejects a funding-rounds T1 request when the source is not on the allowlist", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "funding-rounds",
+      row: {
+        id: "fr01234567",
+        companyId: "anthropic",
+        name: "x",
+      },
+      sourceUrl: "https://crunchbase.com/company/anthropic",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.rejectionReason).toMatch(/No T1 authority matches/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("overwrites a caller-supplied 'source' with the gate-validated sourceUrl even on non-grants routes", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "funding-rounds",
+      row: {
+        id: "fr01234567",
+        companyId: "anthropic",
+        name: "x",
+        // Caller tries to smuggle a different source URL in the row.
+        source: "https://attacker.example.com/fake-form-d",
+      },
+      sourceUrl:
+        "https://www.sec.gov/Archives/edgar/data/1/abc/primary_doc.xml",
+    });
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    const innerBody = captured[0].body as { items: Array<{ source: string }> };
+    // The gate-validated URL wins; the smuggled one is dropped.
+    expect(innerBody.items[0].source).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1/abc/primary_doc.xml",
+    );
   });
 });

--- a/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
+++ b/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
@@ -690,7 +690,7 @@ describe("POST /api/enrichment/propose", () => {
     expect(runQueries.length).toBe(1);
   });
 
-  // ── QUA-665: Phase 1.5 — new record types wired in ──────────────────────
+  // ── Per-record-type routing: personnel / funding-rounds / benchmark-results ──
 
   it("routes funding-rounds T1 requests to the funding-rounds sync subapp", async () => {
     const app = buildApp();

--- a/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
+++ b/apps/wiki-server/src/__tests__/enrichment-propose.test.ts
@@ -160,6 +160,36 @@ describe("checkT1Authority", () => {
     const res = checkT1Authority("", "grants", null);
     expect(res.matched).toBe(false);
   });
+
+  it("matches github.com user-profile URLs for personnel", () => {
+    const res = checkT1Authority(
+      "https://github.com/octocat",
+      "personnel",
+      null,
+    );
+    expect(res.matched).toBe(true);
+    if (res.matched) expect(res.source.id).toBe("github-user");
+  });
+
+  it("rejects github.com reserved paths as personnel authority", () => {
+    for (const reserved of [
+      "https://github.com/settings",
+      "https://github.com/marketplace",
+      "https://github.com/orgs",
+      "https://github.com/about",
+      "https://github.com/pulls",
+      "https://github.com/issues",
+      "https://github.com/search",
+      "https://github.com/explore",
+      "https://github.com/notifications",
+      "https://github.com/login",
+      "https://github.com/features",
+      "https://github.com/pricing",
+    ]) {
+      const res = checkT1Authority(reserved, "personnel", null);
+      expect(res.matched).toBe(false);
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────
@@ -800,6 +830,58 @@ describe("POST /api/enrichment/propose", () => {
     // The gate-validated URL wins; the smuggled one is dropped.
     expect(innerBody.items[0].source).toBe(
       "https://www.sec.gov/Archives/edgar/data/1/abc/primary_doc.xml",
+    );
+  });
+
+  it("scrubs a smuggled 'sourceUrl' from a funding-rounds row (opposite-field smuggle)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "funding-rounds",
+      row: {
+        id: "fr01234567",
+        companyId: "anthropic",
+        name: "x",
+        // funding-rounds uses `source`; a caller smuggling `sourceUrl` into
+        // the row is dropped so it can't round-trip through an unused column.
+        sourceUrl: "https://attacker.example.com/smuggled",
+      },
+      sourceUrl:
+        "https://www.sec.gov/Archives/edgar/data/1/abc/primary_doc.xml",
+    });
+    expect(res.status).toBe(200);
+    const innerBody = captured[0].body as {
+      items: Array<{ source: string; sourceUrl?: unknown }>;
+    };
+    expect(innerBody.items[0].sourceUrl).toBeUndefined();
+    expect(innerBody.items[0].source).toBe(
+      "https://www.sec.gov/Archives/edgar/data/1/abc/primary_doc.xml",
+    );
+  });
+
+  it("scrubs a smuggled 'source' from a benchmark-results row (opposite-field smuggle)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/enrichment/propose", {
+      tier: "T1",
+      recordType: "benchmark-results",
+      row: {
+        id: "br01234567",
+        benchmarkId: "ifeval",
+        modelId: "claude-3-5-sonnet",
+        score: 75.2,
+        // benchmark-results uses `sourceUrl`; smuggled `source` is dropped.
+        source: "https://attacker.example.com/smuggled",
+      },
+      sourceUrl:
+        "https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard?row=x",
+    });
+    expect(res.status).toBe(200);
+    const innerBody = captured[0].body as {
+      items: Array<{ sourceUrl: string; source?: unknown }>;
+    };
+    expect(innerBody.items[0].source).toBeUndefined();
+    expect(innerBody.items[0].sourceUrl).toContain(
+      "huggingface.co/spaces/open-llm-leaderboard",
     );
   });
 });

--- a/apps/wiki-server/src/routes/enrichment/enrichment.ts
+++ b/apps/wiki-server/src/routes/enrichment/enrichment.ts
@@ -32,6 +32,9 @@ import { logger } from "../../logger.js";
 import { parseJsonBody, validationError, invalidJsonError } from "../shared/utils.js";
 import type { InlineSourcing } from "../tablebase/sourcing-schema.js";
 import { grantsRoute } from "../tablebase/grants.js";
+import { personnelRoute } from "../tablebase/personnel.js";
+import { fundingRoundsRoute } from "../tablebase/funding-rounds.js";
+import { benchmarkResultsRoute } from "../tablebase/benchmark-results.js";
 import { checkT1Authority } from "./t1-allowlist.js";
 import { isHomepageUrl } from "./homepage-detector.js";
 
@@ -51,11 +54,24 @@ const MAX_SOURCE_CONTENT_CHARS = 200_000;
 // ── Supported record types ──────────────────────────────────────────────
 
 /**
- * Phase 1 ships grants as the initial supported record type (T1 = EA Funds
- * CSV, T2/T3 = open web).  Adding more record types = (a) import the sync
- * subapp, (b) append it here, (c) extend T1 allowlist entries that name it.
+ * Phase 1 shipped only `grants`. Phase 1.5 (QUA-665) extends this to the three
+ * T1 importers shipped in QUA-640 (sec-edgar → funding-rounds,
+ * github-contributors → personnel, hf-leaderboard → benchmark-results).
+ *
+ * Adding more record types = (a) import the sync subapp, (b) append the
+ * recordType to `SUPPORTED_RECORD_TYPES`, (c) add a `RECORD_TYPE_ROUTES`
+ * entry, (d) extend `t1-allowlist.ts` entries that name it (or add new ones).
+ *
+ * Record-type names MUST match the sync-route mount names in
+ * `apps/wiki-server/src/routes/tablebase/mount-registry.ts` so the value
+ * readers / dashboards / import pipelines all use the same string.
  */
-const SUPPORTED_RECORD_TYPES = ["grants"] as const;
+const SUPPORTED_RECORD_TYPES = [
+  "grants",
+  "personnel",
+  "funding-rounds",
+  "benchmark-results",
+] as const;
 type SupportedRecordType = (typeof SUPPORTED_RECORD_TYPES)[number];
 
 interface RecordTypeRoute {
@@ -64,10 +80,35 @@ interface RecordTypeRoute {
   subApp: { fetch: (req: Request) => Response | Promise<Response> };
   /** Path within the sub-app that accepts the sync POST. */
   syncPath: string;
+  /**
+   * Name of the row field that carries the evidence URL.  Different sync
+   * schemas use different column names:
+   *   - grants / funding-rounds / personnel: `source`
+   *   - benchmark-results: `sourceUrl`
+   * The propose endpoint overwrites this field with `req.sourceUrl` to keep
+   * the gate-validated URL canonical; callers mustn't smuggle a different
+   * one in the row payload.
+   */
+  sourceUrlField: "source" | "sourceUrl";
 }
 
 const RECORD_TYPE_ROUTES: Record<SupportedRecordType, RecordTypeRoute> = {
-  grants: { subApp: grantsRoute, syncPath: "/sync" },
+  grants: { subApp: grantsRoute, syncPath: "/sync", sourceUrlField: "source" },
+  personnel: {
+    subApp: personnelRoute,
+    syncPath: "/sync",
+    sourceUrlField: "source",
+  },
+  "funding-rounds": {
+    subApp: fundingRoundsRoute,
+    syncPath: "/sync",
+    sourceUrlField: "source",
+  },
+  "benchmark-results": {
+    subApp: benchmarkResultsRoute,
+    syncPath: "/sync",
+    sourceUrlField: "sourceUrl",
+  },
 };
 
 // ── Request schema ──────────────────────────────────────────────────────
@@ -169,12 +210,18 @@ const enrichmentApp = new Hono()
     }
 
     // ── Delegate to the sync handler with sourcing attached ──────────
+    // The record-type's sync schema names its source-URL field either
+    // `source` (grants, funding-rounds, personnel) or `sourceUrl`
+    // (benchmark-results).  Overriding is intentional: the gate validated
+    // this exact URL, callers mustn't smuggle a different one in the row
+    // payload.  The opposite field (if present) is also scrubbed so a caller
+    // can't round-trip one through the unused column on a per-record-type
+    // schema that strips extras silently.
+    const { source: _src, sourceUrl: _srcUrl, ...rowWithoutSourceFields } =
+      req.row as Record<string, unknown>;
     const itemWithSourcing = {
-      ...req.row,
-      // Grants' sync schema uses `source` (URL).  Overriding is intentional:
-      // the gate validated this exact URL, callers mustn't smuggle a different
-      // one in the row payload.
-      source: req.sourceUrl,
+      ...rowWithoutSourceFields,
+      [route.sourceUrlField]: req.sourceUrl,
       sourcing: gate.sourcing,
     };
 

--- a/apps/wiki-server/src/routes/enrichment/enrichment.ts
+++ b/apps/wiki-server/src/routes/enrichment/enrichment.ts
@@ -54,17 +54,14 @@ const MAX_SOURCE_CONTENT_CHARS = 200_000;
 // ── Supported record types ──────────────────────────────────────────────
 
 /**
- * Phase 1 shipped only `grants`. Phase 1.5 (QUA-665) extends this to the three
- * T1 importers shipped in QUA-640 (sec-edgar → funding-rounds,
- * github-contributors → personnel, hf-leaderboard → benchmark-results).
+ * Adding a new supported record type requires: (a) importing the sync subapp,
+ * (b) appending the name to `SUPPORTED_RECORD_TYPES`, (c) adding a
+ * `RECORD_TYPE_ROUTES` entry with the correct `sourceUrlField`, (d) extending
+ * `t1-allowlist.ts` entries that name it.
  *
- * Adding more record types = (a) import the sync subapp, (b) append the
- * recordType to `SUPPORTED_RECORD_TYPES`, (c) add a `RECORD_TYPE_ROUTES`
- * entry, (d) extend `t1-allowlist.ts` entries that name it (or add new ones).
- *
- * Record-type names MUST match the sync-route mount names in
- * `apps/wiki-server/src/routes/tablebase/mount-registry.ts` so the value
- * readers / dashboards / import pipelines all use the same string.
+ * Names MUST match the sync-route mount names in
+ * `apps/wiki-server/src/routes/tablebase/mount-registry.ts` so readers,
+ * dashboards, and import pipelines all use the same string.
  */
 const SUPPORTED_RECORD_TYPES = [
   "grants",

--- a/apps/wiki-server/src/routes/enrichment/enrichment.ts
+++ b/apps/wiki-server/src/routes/enrichment/enrichment.ts
@@ -218,7 +218,7 @@ const enrichmentApp = new Hono()
     // can't round-trip one through the unused column on a per-record-type
     // schema that strips extras silently.
     const { source: _src, sourceUrl: _srcUrl, ...rowWithoutSourceFields } =
-      req.row as Record<string, unknown>;
+      req.row;
     const itemWithSourcing = {
       ...rowWithoutSourceFields,
       [route.sourceUrlField]: req.sourceUrl,

--- a/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
+++ b/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
@@ -93,9 +93,17 @@ export const T1_ALLOWLIST: T1Source[] = [
     // Public GitHub URLs surfaced by the github-contributors importer (T1).
     // The contributors API hits `api.github.com` above; the per-user profile
     // URLs written into `proposal.sourceUrl` live under github.com itself.
+    //
+    // Pattern excludes GitHub's reserved single-segment paths (settings,
+    // marketplace, orgs, etc.) — those aren't user profiles and must never
+    // be accepted as authoritative sources for personnel records.  The
+    // downstream github-contributors importer also independently knows the
+    // URL is a real user profile because it was surfaced by the contributors
+    // API, but this allowlist is meant to be an independent gate.
     id: "github-user",
     name: "GitHub user profile (via contributors importer)",
-    urlPattern: /^https:\/\/github\.com\/[^/]+\/?$/i,
+    urlPattern:
+      /^https:\/\/github\.com\/(?!(settings|marketplace|orgs|about|pulls|issues|explore|topics|trending|notifications|new|login|signup|join|search|sponsors|features|pricing|customer-stories|security|enterprise|team|collections|codespaces|dashboard|blog|help|site|contact)(\/|$))[A-Za-z0-9][A-Za-z0-9-]{0,38}\/?$/i,
     recordTypes: ["personnel"],
   },
 ];

--- a/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
+++ b/apps/wiki-server/src/routes/enrichment/t1-allowlist.ts
@@ -76,13 +76,26 @@ export const T1_ALLOWLIST: T1Source[] = [
   {
     id: "hf-leaderboard",
     name: "Hugging Face Leaderboard",
+    // Leaderboard "row" query-string URLs are also accepted — the datasets-server
+    // deep-links use ?row=<evalName> (see hf-leaderboard importer).
     urlPattern: /^https:\/\/huggingface\.co\/spaces\/[^/]+\/[^/]*leaderboard/i,
-    recordTypes: ["benchmarks"],
+    // Maps to the `benchmark-results` sync route (auto-eval scores), not the
+    // `benchmarks` definition table.
+    recordTypes: ["benchmark-results"],
   },
   {
     id: "github-api",
     name: "GitHub API",
     urlPattern: /^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+\/(contributors|collaborators)/i,
+    recordTypes: ["personnel"],
+  },
+  {
+    // Public GitHub URLs surfaced by the github-contributors importer (T1).
+    // The contributors API hits `api.github.com` above; the per-user profile
+    // URLs written into `proposal.sourceUrl` live under github.com itself.
+    id: "github-user",
+    name: "GitHub user profile (via contributors importer)",
+    urlPattern: /^https:\/\/github\.com\/[^/]+\/?$/i,
     recordTypes: ["personnel"],
   },
 ];

--- a/crux/commands/tb-importers/__tests__/allowlist.test.ts
+++ b/crux/commands/tb-importers/__tests__/allowlist.test.ts
@@ -35,9 +35,9 @@ describe("T1_AUTHORITY_ALLOWLIST", () => {
 
 describe("isT1Authoritative", () => {
   it("accepts on prefix match + recordType match", () => {
-    expect(isT1Authoritative("sec-edgar:0001234567-25-000001", "funding-round")).toBe(true);
+    expect(isT1Authoritative("sec-edgar:0001234567-25-000001", "funding-rounds")).toBe(true);
     expect(isT1Authoritative("github-contributors:anthropic:alice", "personnel")).toBe(true);
-    expect(isT1Authoritative("hf-leaderboard:meta-llama/M:IFEval", "benchmark-result")).toBe(true);
+    expect(isT1Authoritative("hf-leaderboard:meta-llama/M:IFEval", "benchmark-results")).toBe(true);
     expect(isT1Authoritative("wikidata:Q108542504:P571", "organization-fact")).toBe(true);
     expect(isT1Authoritative("openalex:W100", "publication")).toBe(true);
     expect(isT1Authoritative("semantic-scholar:abc123", "publication")).toBe(true);
@@ -46,20 +46,20 @@ describe("isT1Authoritative", () => {
 
   it("rejects when source matches but recordType doesn't", () => {
     expect(isT1Authoritative("sec-edgar:abc", "personnel")).toBe(false);
-    expect(isT1Authoritative("github-contributors:x:y", "funding-round")).toBe(false);
+    expect(isT1Authoritative("github-contributors:x:y", "funding-rounds")).toBe(false);
   });
 
   it("rejects when recordType matches but source doesn't", () => {
-    expect(isT1Authoritative("crunchbase:abc", "funding-round")).toBe(false);
+    expect(isT1Authoritative("crunchbase:abc", "funding-rounds")).toBe(false);
     expect(isT1Authoritative("twitter:somebody", "personnel")).toBe(false);
   });
 
   it("rejects exact-match-without-prefix-colon", () => {
     // Source needs the colon so that "sec-edgar-fake:abc" doesn't slip past
-    expect(isT1Authoritative("sec-edgar-fake:abc", "funding-round")).toBe(false);
+    expect(isT1Authoritative("sec-edgar-fake:abc", "funding-rounds")).toBe(false);
   });
 
   it("rejects empty source", () => {
-    expect(isT1Authoritative("", "funding-round")).toBe(false);
+    expect(isT1Authoritative("", "funding-rounds")).toBe(false);
   });
 });

--- a/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
+++ b/crux/commands/tb-importers/__tests__/hf-leaderboard.test.ts
@@ -164,7 +164,7 @@ describe("buildProposals", () => {
     expect(misses).toHaveLength(0);
     expect(proposals).toHaveLength(DEFAULT_BENCHMARK_COLUMNS.length);
     expect(proposals.every((p) => p.tier === "T1")).toBe(true);
-    expect(proposals.every((p) => p.recordType === "benchmark-result")).toBe(true);
+    expect(proposals.every((p) => p.recordType === "benchmark-results")).toBe(true);
   });
 
   it("records a miss when target eval_name is absent", () => {

--- a/crux/commands/tb-importers/__tests__/propose-client.test.ts
+++ b/crux/commands/tb-importers/__tests__/propose-client.test.ts
@@ -183,6 +183,7 @@ describe("submitProposal (submit=true) — network path", () => {
   const origEnvUrl = process.env.LONGTERMWIKI_SERVER_URL;
   const origEnvProdUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
   const origEnvKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+  const origWikiEnv = process.env.WIKI_SERVER_ENV;
 
   beforeEach(() => {
     fetchMock.mockReset();
@@ -194,15 +195,17 @@ describe("submitProposal (submit=true) — network path", () => {
     process.env.LONGTERMWIKI_SERVER_API_KEY = "test-key";
   });
 
+  function restoreEnv(key: string, orig: string | undefined): void {
+    if (orig === undefined) delete process.env[key];
+    else process.env[key] = orig;
+  }
+
   afterEach(() => {
     globalThis.fetch = origFetch;
-    delete process.env.WIKI_SERVER_ENV;
-    if (origEnvUrl === undefined) delete process.env.LONGTERMWIKI_SERVER_URL;
-    else process.env.LONGTERMWIKI_SERVER_URL = origEnvUrl;
-    if (origEnvProdUrl === undefined) delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
-    else process.env.PROD_LONGTERMWIKI_SERVER_URL = origEnvProdUrl;
-    if (origEnvKey === undefined) delete process.env.LONGTERMWIKI_SERVER_API_KEY;
-    else process.env.LONGTERMWIKI_SERVER_API_KEY = origEnvKey;
+    restoreEnv("WIKI_SERVER_ENV", origWikiEnv);
+    restoreEnv("LONGTERMWIKI_SERVER_URL", origEnvUrl);
+    restoreEnv("PROD_LONGTERMWIKI_SERVER_URL", origEnvProdUrl);
+    restoreEnv("LONGTERMWIKI_SERVER_API_KEY", origEnvKey);
   });
 
   function mockResponse(status: number, body: unknown): void {

--- a/crux/commands/tb-importers/__tests__/propose-client.test.ts
+++ b/crux/commands/tb-importers/__tests__/propose-client.test.ts
@@ -1,18 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   validateProposal,
   submitProposal,
   submitBatch,
+  deriveRecordId,
+  buildProposeRequest,
 } from "../propose-client.ts";
 import type { EnrichmentProposal } from "../types.ts";
+
+const HEX64 =
+  "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
 const VALID: EnrichmentProposal = {
   tier: "T1",
   source: "sec-edgar:0001234567-25-000001",
   sourceUrl: "https://www.sec.gov/Archives/x.xml",
-  responseHash: "abc123",
-  recordType: "funding-round",
+  responseHash: HEX64,
+  recordType: "funding-rounds",
   record: { name: "Series A" },
+  entityRefs: { organization: "anthropic" },
 };
 
 describe("validateProposal", () => {
@@ -21,20 +27,28 @@ describe("validateProposal", () => {
   });
 
   it("rejects non-T1 tiers", () => {
-    expect(validateProposal({ ...VALID, tier: "T2" })).toMatch(/T1 importers must emit tier=T1/);
+    expect(validateProposal({ ...VALID, tier: "T2" })).toMatch(
+      /T1 importers must emit tier=T1/
+    );
   });
 
   it("rejects missing source/url/hash", () => {
-    expect(validateProposal({ ...VALID, source: "" })).toMatch(/missing required/);
-    expect(validateProposal({ ...VALID, sourceUrl: "" })).toMatch(/missing required/);
-    expect(validateProposal({ ...VALID, responseHash: "" })).toMatch(/missing required/);
+    expect(validateProposal({ ...VALID, source: "" })).toMatch(
+      /missing required/
+    );
+    expect(validateProposal({ ...VALID, sourceUrl: "" })).toMatch(
+      /missing required/
+    );
+    expect(validateProposal({ ...VALID, responseHash: "" })).toMatch(
+      /missing required/
+    );
   });
 
   it("rejects (source, recordType) not on the T1 allowlist", () => {
     const proposal: EnrichmentProposal = {
       ...VALID,
       source: "wikipedia:anthropic",
-      recordType: "funding-round",
+      recordType: "funding-rounds",
     };
     expect(validateProposal(proposal)).toMatch(/not on T1 authority allowlist/);
   });
@@ -46,6 +60,95 @@ describe("validateProposal", () => {
       recordType: "personnel",
     };
     expect(validateProposal(proposal)).toMatch(/not on T1 authority allowlist/);
+  });
+});
+
+describe("deriveRecordId", () => {
+  it("returns the first 10 chars of a hex response hash", () => {
+    expect(deriveRecordId(HEX64)).toBe("abcdef0123");
+  });
+
+  it("rejects a non-hex hash", () => {
+    expect(() => deriveRecordId("not-a-hash")).toThrow(/hex/);
+  });
+
+  it("rejects a hash shorter than 10 chars", () => {
+    expect(() => deriveRecordId("abc")).toThrow(/hex/);
+  });
+
+  it("is deterministic — same hash → same id", () => {
+    expect(deriveRecordId(HEX64)).toBe(deriveRecordId(HEX64));
+  });
+});
+
+describe("buildProposeRequest", () => {
+  it("mints id from responseHash[:10] and preserves tier/recordType/sourceUrl", () => {
+    const req = buildProposeRequest(VALID);
+    expect(req.tier).toBe("T1");
+    expect(req.recordType).toBe("funding-rounds");
+    expect(req.sourceUrl).toBe(VALID.sourceUrl);
+    expect(req.sourceContentHash).toBe(VALID.responseHash);
+    expect(req.row.id).toBe("abcdef0123");
+  });
+
+  it("maps entityRefs.organization → row.companyId for funding-rounds", () => {
+    const req = buildProposeRequest(VALID);
+    expect(req.row.companyId).toBe("anthropic");
+  });
+
+  it("maps entityRefs to personId + organizationId for personnel", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      source: "github-contributors:anthropic:alice",
+      recordType: "personnel",
+      record: { role: "contributor", roleType: "career" },
+      entityRefs: { organization: "anthropic", person: "alice" },
+    };
+    const req = buildProposeRequest(proposal);
+    expect(req.row.organizationId).toBe("anthropic");
+    expect(req.row.personId).toBe("alice");
+  });
+
+  it("maps entityRefs to modelId + benchmarkId for benchmark-results", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      source: "hf-leaderboard:claude-3-5-sonnet:IFEval",
+      recordType: "benchmark-results",
+      record: { score: 75.2, unit: "%" },
+      entityRefs: { model: "claude-3-5-sonnet", benchmark: "ifeval" },
+    };
+    const req = buildProposeRequest(proposal);
+    expect(req.row.modelId).toBe("claude-3-5-sonnet");
+    expect(req.row.benchmarkId).toBe("ifeval");
+  });
+
+  it("does not overwrite existing FK columns in the record", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      record: { name: "Series A", companyId: "pre-filled-id" },
+      entityRefs: { organization: "anthropic" },
+    };
+    const req = buildProposeRequest(proposal);
+    expect(req.row.companyId).toBe("pre-filled-id");
+  });
+
+  it("forces row.id from the derived hash, overwriting any id in the record", () => {
+    const proposal: EnrichmentProposal = {
+      ...VALID,
+      record: { name: "Series A", id: "caller-picked-id" },
+    };
+    const req = buildProposeRequest(proposal);
+    expect(req.row.id).toBe("abcdef0123");
+  });
+
+  it("includes runId when provided", () => {
+    const req = buildProposeRequest(VALID, { runId: "run-123" });
+    expect(req.runId).toBe("run-123");
+  });
+
+  it("omits runId when not provided", () => {
+    const req = buildProposeRequest(VALID);
+    expect("runId" in req).toBe(false);
   });
 });
 
@@ -62,12 +165,6 @@ describe("submitProposal", () => {
     expect(r.reason).toBe("dry-run");
   });
 
-  it("returns pending with QUA-632 reason when --submit and endpoint not yet built", async () => {
-    const r = await submitProposal(VALID, { submit: true });
-    expect(r.status).toBe("pending");
-    expect(r.reason).toMatch(/QUA-632/);
-  });
-
   it("skipAllowlistCheck bypasses validation", async () => {
     const proposal: EnrichmentProposal = {
       ...VALID,
@@ -79,12 +176,103 @@ describe("submitProposal", () => {
   });
 });
 
+describe("submitProposal (submit=true) — network path", () => {
+  // Mock global fetch to intercept the POST without requiring a real server.
+  const fetchMock = vi.fn();
+  const origFetch = globalThis.fetch;
+  const origEnvUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const origEnvProdUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  const origEnvKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    // Force the local prefix so WIKI_SERVER_ENV auto-detection in a slot
+    // doesn't flip us to the prod prefix during the test.
+    process.env.WIKI_SERVER_ENV = "local";
+    process.env.LONGTERMWIKI_SERVER_URL = "http://test.invalid";
+    process.env.LONGTERMWIKI_SERVER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    delete process.env.WIKI_SERVER_ENV;
+    if (origEnvUrl === undefined) delete process.env.LONGTERMWIKI_SERVER_URL;
+    else process.env.LONGTERMWIKI_SERVER_URL = origEnvUrl;
+    if (origEnvProdUrl === undefined) delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    else process.env.PROD_LONGTERMWIKI_SERVER_URL = origEnvProdUrl;
+    if (origEnvKey === undefined) delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    else process.env.LONGTERMWIKI_SERVER_API_KEY = origEnvKey;
+  });
+
+  function mockResponse(status: number, body: unknown): void {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(body), { status })
+    );
+  }
+
+  it("POSTs the translated payload to /api/enrichment/propose", async () => {
+    mockResponse(200, {
+      status: "accepted",
+      tier: "T1",
+      recordId: "abcdef0123",
+      verdict: "confirmed",
+    });
+    const r = await submitProposal(VALID, { submit: true });
+    expect(r.status).toBe("accepted");
+    expect(r.recordId).toBe("abcdef0123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toBe("http://test.invalid/api/enrichment/propose");
+    const init = call[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.tier).toBe("T1");
+    expect(body.recordType).toBe("funding-rounds");
+    expect(body.sourceUrl).toBe(VALID.sourceUrl);
+    expect(body.sourceContentHash).toBe(VALID.responseHash);
+    expect(body.row.id).toBe("abcdef0123");
+    expect(body.row.companyId).toBe("anthropic");
+  });
+
+  it("maps server 'rejected' response to ProposeResult.rejected with the reason", async () => {
+    mockResponse(400, {
+      status: "rejected",
+      tier: "T1",
+      rejectionReason: "No T1 authority matches",
+    });
+    const r = await submitProposal(VALID, { submit: true });
+    expect(r.status).toBe("rejected");
+    expect(r.reason).toMatch(/No T1 authority matches/);
+  });
+
+  it("falls back to pending on transport failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const r = await submitProposal(VALID, { submit: true });
+    expect(r.status).toBe("pending");
+    expect(r.reason).toMatch(/unavailable/);
+  });
+
+  it("includes runId in the POST body when provided", async () => {
+    mockResponse(200, { status: "accepted", tier: "T1", recordId: "abcdef0123" });
+    await submitProposal(VALID, { submit: true, runId: "import-2026-04-23" });
+    const body = JSON.parse(
+      fetchMock.mock.calls[0][1].body as string
+    );
+    expect(body.runId).toBe("import-2026-04-23");
+  });
+});
+
 describe("submitBatch", () => {
   it("returns one result per input, preserving order", async () => {
     const proposals: EnrichmentProposal[] = [
       VALID,
       { ...VALID, tier: "T3" },
-      { ...VALID, source: "github-contributors:anthropic:alice", recordType: "personnel" },
+      {
+        ...VALID,
+        source: "github-contributors:anthropic:alice",
+        recordType: "personnel",
+      },
     ];
     const results = await submitBatch(proposals);
     expect(results).toHaveLength(3);

--- a/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
+++ b/crux/commands/tb-importers/__tests__/sec-edgar.test.ts
@@ -317,7 +317,7 @@ describe("buildProposal", () => {
     accessionNoDashes: "000182810124000001",
   };
 
-  it("emits T1 + sec-edgar source + funding-round recordType", () => {
+  it("emits T1 + sec-edgar source + funding-rounds recordType", () => {
     const extract = parseFormDXml(SAMPLE_XML);
     const p = buildProposal(
       TARGET,
@@ -328,7 +328,7 @@ describe("buildProposal", () => {
     );
     expect(p.tier).toBe("T1");
     expect(p.source).toBe("sec-edgar:0001828101-24-000001");
-    expect(p.recordType).toBe("funding-round");
+    expect(p.recordType).toBe("funding-rounds");
     expect(p.entityRefs?.organization).toBe("anthropic");
   });
 

--- a/crux/commands/tb-importers/allowlist.ts
+++ b/crux/commands/tb-importers/allowlist.ts
@@ -38,7 +38,7 @@ export interface T1AuthorityEntry {
 export const T1_AUTHORITY_ALLOWLIST: readonly T1AuthorityEntry[] = [
   {
     sourcePrefix: T1_SOURCE_PREFIXES.secEdgar,
-    recordType: "funding-round",
+    recordType: "funding-rounds",
     description:
       "SEC EDGAR Form D filings (regulatory filings of US private offerings).",
   },
@@ -50,7 +50,7 @@ export const T1_AUTHORITY_ALLOWLIST: readonly T1AuthorityEntry[] = [
   },
   {
     sourcePrefix: T1_SOURCE_PREFIXES.hfLeaderboard,
-    recordType: "benchmark-result",
+    recordType: "benchmark-results",
     description:
       "HuggingFace Open LLM Leaderboard (deterministic auto-eval pipeline).",
   },

--- a/crux/commands/tb-importers/hf-leaderboard.ts
+++ b/crux/commands/tb-importers/hf-leaderboard.ts
@@ -237,7 +237,7 @@ export function buildProposals(
         source: `${T1_SOURCE_PREFIXES.hfLeaderboard}${t.evalName}:${col.column}`,
         sourceUrl: `https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard?row=${encodeURIComponent(t.evalName)}`,
         responseHash,
-        recordType: "benchmark-result",
+        recordType: "benchmark-results",
         record: {
           score: raw,
           unit: col.unit,

--- a/crux/commands/tb-importers/propose-client.ts
+++ b/crux/commands/tb-importers/propose-client.ts
@@ -1,20 +1,16 @@
 /**
- * Client for `POST /api/enrichment/propose` (QUA-632 / QUA-665).
+ * Client for `POST /api/enrichment/propose`.
  *
  * Translates an importer-emitted `EnrichmentProposal` into the
  * `ProposeRequestSchema` shape the endpoint expects, then POSTs it and
  * classifies the response.
  *
- * Translation responsibilities (the importer's job ends at
- * `{record, entityRefs, sourceUrl, responseHash}`):
- *   - Mint a deterministic 10-char `row.id` from the responseHash so repeat
- *     submissions upsert the same record.
- *   - Merge `entityRefs.{organization,person,model,benchmark}` into the row as
- *     the FK column names the sync schema expects (`companyId`, `personId`,
- *     `organizationId`, `modelId`, `benchmarkId`). Sync handlers accept
- *     slugs here and resolve them to stableIds via `resolveEntityFKs`.
+ * Translation steps (see `buildProposeRequest`):
+ *   - Derive a deterministic 10-char `row.id` from `responseHash[:10]`.
+ *   - Merge `entityRefs` into the sync schema's FK column names per
+ *     `ENTITY_REF_FK_MAP`. Sync handlers resolve slugs to stableIds
+ *     downstream via `resolveEntityFKs`.
  *   - Rename `responseHash` → `sourceContentHash` (the endpoint's name).
- *   - Preserve the wire-format `tier` and `recordType`.
  */
 
 import { apiRequest } from "../../lib/wiki-server/client.ts";
@@ -35,20 +31,18 @@ export interface ProposeClientOptions {
 }
 
 /**
- * Server-side `POST /api/enrichment/propose` response shape. Duplicated here
- * rather than imported from wiki-server because crux is a separate package
- * that doesn't depend on `apps/wiki-server/*`. The matching server-side type
- * is inferred by Hono RPC from `enrichment.ts` — if the two drift, the
- * endpoint integration test (enrichment-propose.test.ts) will fail.
+ * Accepted response from `/api/enrichment/propose` — duplicated here rather
+ * than imported from wiki-server because crux is a separate package. Rejections
+ * always return HTTP 400, so on the success (HTTP 200) path `status` is always
+ * `"accepted"`.
  */
-interface ProposeEndpointResponse {
-  status: "accepted" | "rejected";
+interface AcceptedProposeResponse {
+  status: "accepted";
   tier: "T1" | "T2" | "T3";
   recordId?: string | null;
   verdict?: string | null;
   confidence?: number | null;
   checkerModel?: string | null;
-  rejectionReason?: string;
 }
 
 /**
@@ -89,40 +83,25 @@ export function deriveRecordId(responseHash: string): string {
 }
 
 /**
- * Map `entityRefs.{organization,person,model,benchmark}` into the sync-schema
- * FK column names the target record type expects. Unmapped entityRefs are
- * dropped silently — the sync handler will reject missing required FKs via
- * its own schema validation, which produces a clearer error message than
- * any client-side check would.
+ * Maps each record type to the `(entityRef key → row FK column)` pairs the
+ * corresponding sync schema expects. Single source of truth for the FK
+ * contract — the docstring on `EnrichmentProposal.entityRefs` in `types.ts`
+ * should match this table exactly.
  */
-function mergeEntityRefs(
-  recordType: EnrichmentRecordType,
-  record: Record<string, unknown>,
-  entityRefs: EnrichmentProposal["entityRefs"] | undefined
-): Record<string, unknown> {
-  if (!entityRefs) return record;
-  const row = { ...record };
-  if (recordType === "funding-rounds") {
-    if (entityRefs.organization != null && row.companyId == null) {
-      row.companyId = entityRefs.organization;
-    }
-  } else if (recordType === "personnel") {
-    if (entityRefs.organization != null && row.organizationId == null) {
-      row.organizationId = entityRefs.organization;
-    }
-    if (entityRefs.person != null && row.personId == null) {
-      row.personId = entityRefs.person;
-    }
-  } else if (recordType === "benchmark-results") {
-    if (entityRefs.model != null && row.modelId == null) {
-      row.modelId = entityRefs.model;
-    }
-    if (entityRefs.benchmark != null && row.benchmarkId == null) {
-      row.benchmarkId = entityRefs.benchmark;
-    }
-  }
-  return row;
-}
+const ENTITY_REF_FK_MAP: Record<
+  EnrichmentRecordType,
+  ReadonlyArray<[keyof NonNullable<EnrichmentProposal["entityRefs"]>, string]>
+> = {
+  "funding-rounds": [["organization", "companyId"]],
+  personnel: [
+    ["organization", "organizationId"],
+    ["person", "personId"],
+  ],
+  "benchmark-results": [
+    ["model", "modelId"],
+    ["benchmark", "benchmarkId"],
+  ],
+};
 
 /**
  * Build the `/api/enrichment/propose` request body from a proposal.
@@ -140,11 +119,19 @@ export function buildProposeRequest(
   sourceContentHash: string;
   runId?: string;
 } {
-  const id = deriveRecordId(p.responseHash);
-  const withFks = mergeEntityRefs(p.recordType, p.record, p.entityRefs);
-  // Any explicit id in the record is overwritten with the deterministic
-  // derived id so the same responseHash always upserts to the same row.
-  const row: Record<string, unknown> = { ...withFks, id };
+  // One spread, then in-place mutation: FK columns pulled from entityRefs
+  // (without overwriting values already in the record), and an id derived
+  // from responseHash so the same response always upserts to the same row.
+  const row: Record<string, unknown> = { ...p.record };
+  if (p.entityRefs) {
+    for (const [refKey, rowKey] of ENTITY_REF_FK_MAP[p.recordType]) {
+      const refValue = p.entityRefs[refKey];
+      if (refValue != null && row[rowKey] == null) {
+        row[rowKey] = refValue;
+      }
+    }
+  }
+  row.id = deriveRecordId(p.responseHash);
   return {
     tier: p.tier,
     recordType: p.recordType,
@@ -188,15 +175,15 @@ async function submitToServer(
     return { proposal: p, status: "rejected", reason: `client error: ${msg}` };
   }
 
-  const res = await apiRequest<ProposeEndpointResponse>(
+  const res = await apiRequest<AcceptedProposeResponse>(
     "POST",
     "/api/enrichment/propose",
     body
   );
 
   if (!res.ok) {
-    // Bad-request responses still return a JSON body with `rejectionReason`
-    // on the server side; apiRequest drops that body into `res.message`.
+    // Rejections always return HTTP 400 with a `rejectionReason` body;
+    // apiRequest collapses that into `res.message`.
     return {
       proposal: p,
       status: res.error === "bad_request" ? "rejected" : "pending",
@@ -204,18 +191,10 @@ async function submitToServer(
     };
   }
 
-  if (res.data.status === "accepted") {
-    return {
-      proposal: p,
-      status: "accepted",
-      recordId: res.data.recordId ?? undefined,
-    };
-  }
-
   return {
     proposal: p,
-    status: "rejected",
-    reason: res.data.rejectionReason ?? "server rejected without a reason",
+    status: "accepted",
+    recordId: res.data.recordId ?? undefined,
   };
 }
 

--- a/crux/commands/tb-importers/propose-client.ts
+++ b/crux/commands/tb-importers/propose-client.ts
@@ -1,25 +1,55 @@
 /**
- * Client for `POST /api/enrichment/propose` (QUA-632).
+ * Client for `POST /api/enrichment/propose` (QUA-632 / QUA-665).
  *
- * QUA-632 is in flight in another session — until that endpoint lands, this
- * client is a stub. `submitProposal()` validates the proposal against the T1
- * allowlist and either:
- *   - dry-run mode (default): logs the proposal as JSON, returns `pending`
- *   - --submit mode: would POST to the endpoint when it exists; today returns
- *     `pending` with a "endpoint not yet built (QUA-632)" reason
+ * Translates an importer-emitted `EnrichmentProposal` into the
+ * `ProposeRequestSchema` shape the endpoint expects, then POSTs it and
+ * classifies the response.
  *
- * The wire format (`EnrichmentProposal` from ./types.ts) is the contract.
- * When QUA-632 lands, only the `submitToServer()` body needs to change.
+ * Translation responsibilities (the importer's job ends at
+ * `{record, entityRefs, sourceUrl, responseHash}`):
+ *   - Mint a deterministic 10-char `row.id` from the responseHash so repeat
+ *     submissions upsert the same record.
+ *   - Merge `entityRefs.{organization,person,model,benchmark}` into the row as
+ *     the FK column names the sync schema expects (`companyId`, `personId`,
+ *     `organizationId`, `modelId`, `benchmarkId`). Sync handlers accept
+ *     slugs here and resolve them to stableIds via `resolveEntityFKs`.
+ *   - Rename `responseHash` → `sourceContentHash` (the endpoint's name).
+ *   - Preserve the wire-format `tier` and `recordType`.
  */
 
+import { apiRequest } from "../../lib/wiki-server/client.ts";
 import { isT1Authoritative } from "./allowlist.ts";
-import type { EnrichmentProposal, ProposeResult } from "./types.ts";
+import type {
+  EnrichmentProposal,
+  EnrichmentRecordType,
+  ProposeResult,
+} from "./types.ts";
 
 export interface ProposeClientOptions {
-  /** When true, attempt to POST to /api/enrichment/propose. Default false. */
+  /** When true, actually POST to /api/enrichment/propose. Default false. */
   submit?: boolean;
-  /** When true, skip the T1 allowlist check (for testing). */
+  /** When true, skip the client-side T1 allowlist check (for testing). */
   skipAllowlistCheck?: boolean;
+  /** Optional runId to correlate this submission with an `enrichment_runs` row. */
+  runId?: string;
+}
+
+/**
+ * Server-side `POST /api/enrichment/propose` response shape. Duplicated here
+ * rather than imported from wiki-server because crux is a separate package
+ * that doesn't depend on `apps/wiki-server/*`. The matching server-side type
+ * is inferred by Hono RPC from `enrichment.ts` — if the two drift, the
+ * endpoint integration test (enrichment-propose.test.ts) will fail.
+ */
+interface ProposeEndpointResponse {
+  status: "accepted" | "rejected";
+  tier: "T1" | "T2" | "T3";
+  recordId?: string | null;
+  verdict?: string | null;
+  confidence?: number | null;
+  checkerModel?: string | null;
+  innerStatus?: number;
+  rejectionReason?: string;
 }
 
 /**
@@ -40,9 +70,96 @@ export function validateProposal(p: EnrichmentProposal): string | null {
 }
 
 /**
- * Submit a single proposal. Returns the result.
+ * Derive a deterministic 10-char record id from a proposal's responseHash.
  *
- * Today (pre-QUA-632) this never reaches the network — see top-of-file note.
+ * responseHash is a 64-char hex SHA-256. Taking the first 10 chars gives
+ * us a deterministic, 10-char-alphanumeric ID that all three sync schemas
+ * accept (`id: z.string().length(10)` for funding-rounds/benchmark-results;
+ * `/^[A-Za-z0-9_-]{10}$/` for personnel). Collisions are negligible at
+ * O(10^6) records (birthday bound ~2^20 entries before 50% collision).
+ */
+export function deriveRecordId(responseHash: string): string {
+  if (!/^[A-Fa-f0-9]{10,}$/.test(responseHash)) {
+    throw new Error(
+      `responseHash must be hex with ≥10 chars, got "${responseHash.slice(0, 16)}${
+        responseHash.length > 16 ? "..." : ""
+      }"`
+    );
+  }
+  return responseHash.slice(0, 10);
+}
+
+/**
+ * Map `entityRefs.{organization,person,model,benchmark}` into the sync-schema
+ * FK column names the target record type expects. Unmapped entityRefs are
+ * dropped silently — the sync handler will reject missing required FKs via
+ * its own schema validation, which produces a clearer error message than
+ * any client-side check would.
+ */
+function mergeEntityRefs(
+  recordType: EnrichmentRecordType,
+  record: Record<string, unknown>,
+  entityRefs: EnrichmentProposal["entityRefs"] | undefined
+): Record<string, unknown> {
+  if (!entityRefs) return record;
+  const row = { ...record };
+  if (recordType === "funding-rounds") {
+    if (entityRefs.organization != null && row.companyId == null) {
+      row.companyId = entityRefs.organization;
+    }
+  } else if (recordType === "personnel") {
+    if (entityRefs.organization != null && row.organizationId == null) {
+      row.organizationId = entityRefs.organization;
+    }
+    if (entityRefs.person != null && row.personId == null) {
+      row.personId = entityRefs.person;
+    }
+  } else if (recordType === "benchmark-results") {
+    if (entityRefs.model != null && row.modelId == null) {
+      row.modelId = entityRefs.model;
+    }
+    if (entityRefs.benchmark != null && row.benchmarkId == null) {
+      row.benchmarkId = entityRefs.benchmark;
+    }
+  }
+  return row;
+}
+
+/**
+ * Build the `/api/enrichment/propose` request body from a proposal.
+ *
+ * Exported for tests; the typical path is to go through `submitProposal`.
+ */
+export function buildProposeRequest(
+  p: EnrichmentProposal,
+  opts: { runId?: string } = {}
+): {
+  tier: "T1" | "T2" | "T3";
+  recordType: EnrichmentRecordType;
+  row: Record<string, unknown>;
+  sourceUrl: string;
+  sourceContentHash: string;
+  runId?: string;
+} {
+  const id = deriveRecordId(p.responseHash);
+  const withFks = mergeEntityRefs(p.recordType, p.record, p.entityRefs);
+  // Strip null personDisplayName (github-contributors emits null on purpose
+  // to fail-safe the display-name validator) so Zod's `.nullable()` optional
+  // keeps the null; any explicit id in the record is overwritten with the
+  // deterministic derived id so the same responseHash always upserts.
+  const row: Record<string, unknown> = { ...withFks, id };
+  return {
+    tier: p.tier,
+    recordType: p.recordType,
+    row,
+    sourceUrl: p.sourceUrl,
+    sourceContentHash: p.responseHash,
+    ...(opts.runId ? { runId: opts.runId } : {}),
+  };
+}
+
+/**
+ * Submit a single proposal. Returns the result.
  */
 export async function submitProposal(
   p: EnrichmentProposal,
@@ -59,21 +176,49 @@ export async function submitProposal(
     return { proposal: p, status: "pending", reason: "dry-run" };
   }
 
-  return submitToServer(p);
+  return submitToServer(p, opts);
 }
 
-/**
- * The actual network call. Stub until QUA-632 ships.
- *
- * When QUA-632 lands, replace the body with:
- *   const res = await apiRequest<ProposeResult>("/api/enrichment/propose", { method: "POST", body: p });
- *   return res;
- */
-async function submitToServer(p: EnrichmentProposal): Promise<ProposeResult> {
+async function submitToServer(
+  p: EnrichmentProposal,
+  opts: ProposeClientOptions
+): Promise<ProposeResult> {
+  let body: ReturnType<typeof buildProposeRequest>;
+  try {
+    body = buildProposeRequest(p, { runId: opts.runId });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { proposal: p, status: "rejected", reason: `client error: ${msg}` };
+  }
+
+  const res = await apiRequest<ProposeEndpointResponse>(
+    "POST",
+    "/api/enrichment/propose",
+    body
+  );
+
+  if (!res.ok) {
+    // Bad-request responses still return a JSON body with `rejectionReason`
+    // on the server side; apiRequest drops that body into `res.message`.
+    return {
+      proposal: p,
+      status: res.error === "bad_request" ? "rejected" : "pending",
+      reason: `${res.error}: ${res.message}`,
+    };
+  }
+
+  if (res.data.status === "accepted") {
+    return {
+      proposal: p,
+      status: "accepted",
+      recordId: res.data.recordId ?? undefined,
+    };
+  }
+
   return {
     proposal: p,
-    status: "pending",
-    reason: "endpoint /api/enrichment/propose not yet built (blocked on QUA-632)",
+    status: "rejected",
+    reason: res.data.rejectionReason ?? "server rejected without a reason",
   };
 }
 

--- a/crux/commands/tb-importers/propose-client.ts
+++ b/crux/commands/tb-importers/propose-client.ts
@@ -48,7 +48,6 @@ interface ProposeEndpointResponse {
   verdict?: string | null;
   confidence?: number | null;
   checkerModel?: string | null;
-  innerStatus?: number;
   rejectionReason?: string;
 }
 
@@ -143,10 +142,8 @@ export function buildProposeRequest(
 } {
   const id = deriveRecordId(p.responseHash);
   const withFks = mergeEntityRefs(p.recordType, p.record, p.entityRefs);
-  // Strip null personDisplayName (github-contributors emits null on purpose
-  // to fail-safe the display-name validator) so Zod's `.nullable()` optional
-  // keeps the null; any explicit id in the record is overwritten with the
-  // deterministic derived id so the same responseHash always upserts.
+  // Any explicit id in the record is overwritten with the deterministic
+  // derived id so the same responseHash always upserts to the same row.
   const row: Record<string, unknown> = { ...withFks, id };
   return {
     tier: p.tier,

--- a/crux/commands/tb-importers/sec-edgar.ts
+++ b/crux/commands/tb-importers/sec-edgar.ts
@@ -257,7 +257,7 @@ export function buildProposal(
     source: `${T1_SOURCE_PREFIXES.secEdgar}${filing.accessionNumber}`,
     sourceUrl,
     responseHash,
-    recordType: "funding-round",
+    recordType: "funding-rounds",
     record: {
       // Form D doesn't tell us the round name directly — use filing date as fallback.
       name: `Form D filing ${filing.filingDate}`,

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -1,19 +1,14 @@
 /**
- * Shared types for T1 importers (QUA-640, wired in QUA-665).
- *
- * Each importer fetches from an authoritative source, extracts deterministic
- * records, and emits `EnrichmentProposal` payloads that are POSTed to
- * `POST /api/enrichment/propose` (QUA-632) with `tier=T1`.
- *
- * The propose-client translates these proposals into the endpoint's
- * `ProposeRequestSchema` (see `propose-client.ts::buildProposeRequest`).
+ * Shared types for T1 importers. Each importer fetches from an authoritative
+ * source, extracts deterministic records, and emits `EnrichmentProposal`
+ * payloads that are POSTed to `POST /api/enrichment/propose` with `tier=T1`.
+ * See `propose-client.ts::buildProposeRequest` for the wire translation.
  */
 
-/** Tier model from QUA-637 umbrella. */
 export type EnrichmentTier = "T1" | "T2" | "T3";
 
 /**
- * Record types this PR's importers produce. Values MUST match the sync-route
+ * Record types the T1 importers produce. Values MUST match the sync-route
  * mount names (plural kebab-case) in
  * `apps/wiki-server/src/routes/tablebase/mount-registry.ts` — the propose
  * endpoint dispatches on these strings, and dashboards read them verbatim.

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -1,12 +1,12 @@
 /**
- * Shared types for T1 importers (QUA-640).
+ * Shared types for T1 importers (QUA-640, wired in QUA-665).
  *
  * Each importer fetches from an authoritative source, extracts deterministic
- * records, and emits `EnrichmentProposal` payloads that will be POSTed to
+ * records, and emits `EnrichmentProposal` payloads that are POSTed to
  * `POST /api/enrichment/propose` (QUA-632) with `tier=T1`.
  *
- * Until QUA-632 lands, the propose-client is a stub that writes JSON to disk
- * for inspection — the contract here is the wire format.
+ * The propose-client translates these proposals into the endpoint's
+ * `ProposeRequestSchema` (see `propose-client.ts::buildProposeRequest`).
  */
 
 /** Tier model from QUA-637 umbrella. */
@@ -39,42 +39,49 @@ export interface EnrichmentProposal {
   source: string;
   /** URL the data was fetched from — written to the evidence row. */
   sourceUrl: string;
-  /** SHA-256 hex of the canonical fetched payload — written to evidence. */
+  /**
+   * SHA-256 hex of the canonical fetched payload — written to evidence.
+   * MUST be pure lowercase hex (no `sha256:` prefix) because the
+   * propose-client derives `row.id` from `responseHash[:10]` and that
+   * derivation expects hex-only input.
+   */
   responseHash: string;
   /** Target tablebase record type. */
   recordType: EnrichmentRecordType;
   /**
    * The record fields. Shape depends on `recordType`.
    *
-   * NOTE: this is the *enrichment proposal*, not a fully-formed PG row.
-   * The propose endpoint (QUA-632) is responsible for:
-   *   - Minting the record `id` (10-char primary key)
-   *   - Resolving `entityRefs` into entity stableIds (FK columns)
-   *   - Populating any required fields the importer doesn't know
+   * The importer emits deterministic, source-derived fields:
+   *   - funding-rounds:     name, date, raised, instrument, source, notes,
+   *                         companyDisplayName
+   *   - personnel:          role, roleType, personDisplayName, orgDisplayName,
+   *                         source, notes, isFounder
+   *   - benchmark-results:  score, unit, date, sourceUrl, notes
+   *   - publication:        title, doi, publishedDate, venue, authors,
+   *                         publicationType, url, notes
+   *   - organization-fact:  property, value, valueType, source, notes
    *
-   * The importer's job is to emit deterministic, source-derived fields:
-   *   - funding-round: name, date, raised, instrument, source, notes,
-   *     companyDisplayName
-   *   - personnel:     role, roleType, personDisplayName, orgDisplayName,
-   *     source, notes, isFounder
-   *   - benchmark-result: score, unit, date, sourceUrl, notes
-   *   - publication:    title, doi, publishedDate, venue, authors,
-   *     publicationType, url, notes
-   *   - organization-fact: property, value, valueType, source, notes
+   * `propose-client.ts::buildProposeRequest` mints the 10-char `row.id` from
+   * `responseHash[:10]` and merges `entityRefs` into the correct FK column
+   * names before POSTing. Downstream entity-FK resolution (slug → stableId)
+   * happens in each sync handler's `resolveEntityFKs` step.
    */
   record: Record<string, unknown>;
   /**
-   * Optional foreign-key resolution hints. When present, the propose endpoint
-   * will resolve display names to entity stableIds before writing the row.
+   * Optional foreign-key resolution hints. `buildProposeRequest` maps these
+   * to the sync schema's FK columns:
+   *   - funding-rounds:     organization → companyId
+   *   - personnel:          organization → organizationId, person → personId
+   *   - benchmark-results:  model → modelId, benchmark → benchmarkId
    */
   entityRefs?: {
     /** Slug or display name of the org the record belongs to. */
     organization?: string;
     /** Slug or display name of the person (personnel only). */
     person?: string;
-    /** Slug or display name of the AI model (benchmark-result only). */
+    /** Slug or display name of the AI model (benchmark-results only). */
     model?: string;
-    /** Benchmark id (benchmark-result only). */
+    /** Benchmark id (benchmark-results only). */
     benchmark?: string;
   };
 }

--- a/crux/commands/tb-importers/types.ts
+++ b/crux/commands/tb-importers/types.ts
@@ -12,11 +12,16 @@
 /** Tier model from QUA-637 umbrella. */
 export type EnrichmentTier = "T1" | "T2" | "T3";
 
-/** Record types this PR's importers produce. The full set lives in QUA-632. */
+/**
+ * Record types this PR's importers produce. Values MUST match the sync-route
+ * mount names (plural kebab-case) in
+ * `apps/wiki-server/src/routes/tablebase/mount-registry.ts` — the propose
+ * endpoint dispatches on these strings, and dashboards read them verbatim.
+ */
 export type EnrichmentRecordType =
-  | "funding-round"
+  | "funding-rounds"
   | "personnel"
-  | "benchmark-result"
+  | "benchmark-results"
   | "publication"
   | "organization-fact";
 


### PR DESCRIPTION
## Summary

- Extend `/api/enrichment/propose` from `grants`-only to also accept `personnel`, `funding-rounds`, and `benchmark-results`, with a per-record-type `sourceUrlField` so the gate-validated URL lands on the correct column (benchmark-results uses `sourceUrl`, the others use `source`).
- Scrub both `source` and `sourceUrl` from the caller row before setting the validated URL so callers can't smuggle a divergent URL through the unused column.
- Tighten the `github-user` T1 allowlist entry to exclude GitHub's reserved paths (`/settings`, `/marketplace`, `/orgs`, `/login`, etc.) so they can't pass as authoritative personnel sources. Rename the hf-leaderboard T1 entry from `benchmarks` → `benchmark-results` (the actual target table).
- Wire `propose-client.ts::submitToServer` to actually POST to the endpoint. Add `buildProposeRequest` that translates `EnrichmentProposal` → endpoint payload: derives a deterministic 10-char `row.id` from `responseHash[:10]` so reruns upsert the same row, merges `entityRefs` into the sync schema's FK columns via a central `ENTITY_REF_FK_MAP`, and renames `responseHash` → `sourceContentHash`.
- Rename client-side record types from singular (`funding-round`, `benchmark-result`) to plural kebab-case (`funding-rounds`, `benchmark-results`) to match the sync-route mount names.

Phase 1.5 follow-up to #4527 (QUA-632) and #4529 (QUA-640).

## Test plan

- [x] `pnpm test src/__tests__/enrichment-propose.test.ts` (wiki-server) — 51 tests pass; covers new per-record-type forwarding, URL-field scrubbing (including opposite-field smuggle), `github-user` reserved-path denylist (12 reserved segments).
- [x] `pnpm test:crux crux/commands/tb-importers` — 147 tests pass; covers `buildProposeRequest` FK mapping for all 3 record types, `deriveRecordId` determinism, real-network POST via mocked fetch, plural-rename propagation.
- [x] `pnpm crux w validate gate --fix` — 54/54 gate checks pass.
- [x] `pnpm build` — exits 0.
- [x] `npx tsc --noEmit` on wiki-server and crux — clean.

Fixes QUA-665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub user profile URLs now authorized as trusted sources for personnel record enrichment
  * Enrichment system expanded to support benchmark results and funding rounds record types
  * Extended T1 allowlist coverage with new trusted source authorizations

* **Bug Fixes**
  * Enhanced URL field validation and mapping across enrichment record types
  * Improved payload handling to prevent URL field circumvention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->