### PR TITLE
feat(QUA-660): EntityTimeline component for entity_events

### DIFF
--- a/apps/web/src/app/organizations/[slug]/org-data.ts
+++ b/apps/web/src/app/organizations/[slug]/org-data.ts
@@ -16,6 +16,8 @@ import {
   getKBRecords,
   getAllKBRecords,
   getKBFactsByProperty,
+  getEntityEvents,
+  type EntityEvent,
 } from "@/data/factbase";
 import type { Fact } from "@longterm-wiki/factbase";
 import {
@@ -1055,6 +1057,9 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
   const sortedMilestones = sortKBRecords(safetyMilestones, "date", false);
   const sortedPartnerships = sortKBRecords(strategicPartnerships, "date", false);
 
+  // Entity timeline events (PG entity_events, merged into factbase-data.json)
+  const entityEvents: EntityEvent[] = getEntityEvents(entity.id);
+
   // Sort key persons: current first, then by start date descending
   const sortedPersons = [...keyPersons].sort((a, b) => {
     const endA = a.fields.end ? 1 : 0;
@@ -1487,6 +1492,7 @@ export function loadOrgPageData(entity: OrgEntity, slug: string) {
     sortedRounds,
     sortedModels,
     sortedMilestones,
+    entityEvents,
     sortedPartnerships,
     sortedPersons,
     wikiHref,

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -33,6 +33,7 @@ import {
 import { RelatedPages } from "@/components/RelatedPages";
 import { FactBaseEntityBody } from "@/components/factbase/FactBaseEntityBody";
 import { EntityDbPage } from "@/components/directory/EntityDbPage";
+import { EntityTimeline } from "@/components/wiki/EntityTimeline";
 
 // Shared components & helpers
 import {
@@ -129,6 +130,7 @@ import {
   BookOpen,
   Database,
   ListTree,
+  Clock,
 } from "lucide-react";
 
 const ORG_TAB_GROUPS: ProfileTabGroup[] = [
@@ -473,6 +475,18 @@ export default async function OrgProfilePage({
       content: <PeopleSection people={allPeople} unresolvedCount={pgResult.unresolvedCount} />,
       group: "about",
       icon: <Users className={ICON_CLASS} />,
+    });
+  }
+
+  // ── Timeline tab (entity_events from PG, merged into factbase-data.json) ──
+  if (data.entityEvents.length > 0) {
+    tabs.push({
+      id: "timeline",
+      label: "Timeline",
+      count: data.entityEvents.length,
+      group: "about",
+      icon: <Clock className={ICON_CLASS} />,
+      content: <EntityTimeline events={data.entityEvents} />,
     });
   }
 

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -17,6 +17,7 @@ import CauseEffectGraph from "@/components/wiki/CauseEffectGraph";
 import { PageCauseEffectGraph } from "@/components/wiki/PageCauseEffectGraph";
 import { OverviewBanner } from "@/components/wiki/OverviewBanner";
 import { AnthropicStakeholdersTable } from "@/components/wiki/AnthropicStakeholdersTable";
+import { EntityTimeline } from "@/components/wiki/EntityTimeline";
 
 // FactBase components — typed facts, properties, records
 import { FBFactTable } from "@/components/wiki/factbase/FBFactTable";
@@ -181,6 +182,9 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
 
   // Anthropic-specific table
   AnthropicStakeholdersTable,
+
+  // Entity timeline — reads entity_events from factbase-data.json
+  EntityTimeline,
 
   // FactBase — typed facts, record collections, entity data
   FBFactTable,

--- a/apps/web/src/components/wiki/EntityTimeline.tsx
+++ b/apps/web/src/components/wiki/EntityTimeline.tsx
@@ -1,0 +1,240 @@
+/**
+ * EntityTimeline — Renders a timeline of events for a FactBase entity.
+ *
+ * Reads entity_events from factbase-data.json (merged in from the PG
+ * `entity_events` table at build time — see apps/web/scripts/lib/wiki-server-data.mjs).
+ *
+ * Usage in MDX:
+ *   <EntityTimeline entity="manifund" />
+ *   <EntityTimeline entity="80000-hours" sort="asc" showSignificance />
+ *   <EntityTimeline entity="redwood-research" eventType="funding" />
+ *
+ * Usage in a React tree (e.g. EntityProfileShell):
+ *   <EntityTimeline events={events} />
+ */
+
+import { getEntityEvents, type EntityEvent } from "@data/factbase";
+import { formatKBDate, isUrl, shortDomain, titleCase } from "./factbase/format";
+import { safeHref } from "@/lib/format-compact";
+
+interface EntityTimelineProps {
+  /** Slug, stableId, or wikiId of the entity. Ignored when `events` is provided. */
+  entity?: string;
+  /** Pre-fetched events (escape hatch for server components that already loaded them). */
+  events?: EntityEvent[];
+  /** Sort order. Default "asc" (oldest first — natural for a timeline). */
+  sort?: "asc" | "desc";
+  /** Filter to a specific eventType (founding, pivot, funding, etc.). */
+  eventType?: string;
+  /** Override auto-detection: force-show the Type column. */
+  showType?: boolean;
+  /** Opt in to the Significance column (hidden by default). */
+  showSignificance?: boolean;
+  /** Override auto-detection: force-show the Source column. */
+  showSource?: boolean;
+  /** Override auto-detection: force-show the Description column. */
+  showDescription?: boolean;
+  /** Cap the number of rows rendered. Undefined = show all. */
+  maxItems?: number;
+  /** Optional section heading. Renders nothing if omitted. */
+  title?: string;
+}
+
+const SIGNIFICANCE_COLORS: Record<string, string> = {
+  major:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  moderate:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  minor:
+    "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+};
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  founding:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  acquisition:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
+  pivot:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  launch:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  publication:
+    "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300",
+  policy:
+    "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-300",
+  milestone:
+    "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-300",
+  "leadership-change":
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  incident:
+    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  funding:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  dissolution:
+    "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300",
+  other: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+};
+
+/**
+ * Compare two events by date, treating missing dates as "most recent"
+ * (so they land at the bottom of an ascending sort and at the top of a
+ * descending one — consistent with how date-less records are handled
+ * elsewhere in the wiki).
+ *
+ * Dates are compared lexicographically, which is safe for the YYYY,
+ * YYYY-MM, and YYYY-MM-DD formats the entity_events schema permits.
+ */
+function compareByDate(a: EntityEvent, b: EntityEvent, ascending: boolean): number {
+  const ad = a.date;
+  const bd = b.date;
+  if (!ad && !bd) return 0;
+  if (!ad) return 1;
+  if (!bd) return -1;
+  if (ad === bd) return 0;
+  return ascending ? ad.localeCompare(bd) : bd.localeCompare(ad);
+}
+
+export function EntityTimeline({
+  entity,
+  events: providedEvents,
+  sort = "asc",
+  eventType,
+  showType,
+  showSignificance = false,
+  showSource,
+  showDescription,
+  maxItems,
+  title,
+}: EntityTimelineProps) {
+  const rawEvents =
+    providedEvents ?? (entity ? getEntityEvents(entity) : []);
+
+  const filtered = eventType
+    ? rawEvents.filter((e) => e.eventType === eventType)
+    : rawEvents;
+
+  if (filtered.length === 0) return null;
+
+  const sorted = [...filtered].sort((a, b) =>
+    compareByDate(a, b, sort === "asc"),
+  );
+
+  // Column auto-detection runs against the full sorted set, not the
+  // post-maxItems slice, so capping visible rows never hides a column
+  // whose data lives in the tail.
+  const autoHasType = sorted.some((e) => e.eventType);
+  const autoHasDescription = sorted.some((e) => e.description);
+  const autoHasSource = sorted.some((e) => e.source && isUrl(e.source));
+  const autoHasSignificance = sorted.some((e) => e.significance);
+
+  const rows = typeof maxItems === "number" ? sorted.slice(0, maxItems) : sorted;
+
+  const renderType = showType ?? autoHasType;
+  const renderDescription = showDescription ?? autoHasDescription;
+  const renderSource = showSource ?? autoHasSource;
+  const renderSignificance = showSignificance && autoHasSignificance;
+
+  return (
+    <section className="entity-timeline">
+      {title && (
+        <h3 className="text-base font-bold tracking-tight mb-3">{title}</h3>
+      )}
+      <div className="border border-border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+              <th scope="col" className="py-2 px-3 text-left font-medium whitespace-nowrap">
+                Date
+              </th>
+              <th scope="col" className="py-2 px-3 text-left font-medium">
+                Event
+              </th>
+              {renderType && (
+                <th scope="col" className="py-2 px-3 text-left font-medium">
+                  Type
+                </th>
+              )}
+              {renderSignificance && (
+                <th scope="col" className="py-2 px-3 text-left font-medium">
+                  Significance
+                </th>
+              )}
+              {renderDescription && (
+                <th scope="col" className="py-2 px-3 text-left font-medium">
+                  Description
+                </th>
+              )}
+              {renderSource && (
+                <th scope="col" className="py-2 px-3 text-left font-medium">
+                  Source
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/50">
+            {rows.map((ev) => (
+              <tr key={ev.id} className="hover:bg-muted/20 transition-colors align-top">
+                <td className="py-1.5 px-3 text-muted-foreground whitespace-nowrap">
+                  {ev.date ? formatKBDate(ev.date) : (
+                    <span className="text-muted-foreground/40">{"\u2014"}</span>
+                  )}
+                </td>
+                <td className="py-1.5 px-3 font-medium">{ev.title}</td>
+                {renderType && (
+                  <td className="py-1.5 px-3">
+                    {ev.eventType && (
+                      <span
+                        className={`inline-block px-1.5 py-0.5 rounded-full text-[11px] font-semibold ${
+                          EVENT_TYPE_COLORS[ev.eventType] ??
+                          EVENT_TYPE_COLORS.other
+                        }`}
+                      >
+                        {titleCase(ev.eventType)}
+                      </span>
+                    )}
+                  </td>
+                )}
+                {renderSignificance && (
+                  <td className="py-1.5 px-3">
+                    {ev.significance && (
+                      <span
+                        className={`inline-block px-1.5 py-0.5 rounded-full text-[11px] font-semibold ${
+                          SIGNIFICANCE_COLORS[ev.significance] ??
+                          SIGNIFICANCE_COLORS.minor
+                        }`}
+                      >
+                        {titleCase(ev.significance)}
+                      </span>
+                    )}
+                  </td>
+                )}
+                {renderDescription && (
+                  <td className="py-1.5 px-3 text-muted-foreground text-xs">
+                    {ev.description ?? (
+                      <span className="text-muted-foreground/40">{"\u2014"}</span>
+                    )}
+                  </td>
+                )}
+                {renderSource && (
+                  <td className="py-1.5 px-3">
+                    {ev.source && isUrl(ev.source) ? (
+                      <a
+                        href={safeHref(ev.source)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[11px] text-primary/70 hover:text-primary hover:underline transition-colors"
+                      >
+                        {shortDomain(ev.source)}
+                        <span className="sr-only"> (opens in new tab)</span>
+                      </a>
+                    ) : null}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/wiki/__tests__/EntityTimeline.test.tsx
+++ b/apps/web/src/components/wiki/__tests__/EntityTimeline.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+/**
+ * Tests for EntityTimeline — covers sort order, column auto-detection,
+ * filtering, empty state, and source rendering.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { EntityEvent } from "@data/factbase";
+
+const mockGetEntityEvents = vi.fn<(entityId: string) => EntityEvent[]>();
+
+vi.mock("@data/factbase", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@data/factbase")>();
+  return {
+    ...actual,
+    getEntityEvents: (id: string) => mockGetEntityEvents(id),
+  };
+});
+
+import { EntityTimeline } from "../EntityTimeline";
+
+function makeEvent(overrides: Partial<EntityEvent>): EntityEvent {
+  return {
+    id: "ev1",
+    entityId: "sid_test000001",
+    title: "Untitled event",
+    ...overrides,
+  };
+}
+
+describe("EntityTimeline", () => {
+  it("renders nothing when there are no events", () => {
+    mockGetEntityEvents.mockReturnValueOnce([]);
+    const { container } = render(<EntityTimeline entity="orphan" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when no entity and no events prop provided", () => {
+    const { container } = render(<EntityTimeline />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders rows from getEntityEvents when entity prop is given", () => {
+    mockGetEntityEvents.mockReturnValueOnce([
+      makeEvent({ id: "a", title: "Founded", date: "2020" }),
+      makeEvent({ id: "b", title: "Launched", date: "2021" }),
+    ]);
+    render(<EntityTimeline entity="example-org" />);
+    expect(mockGetEntityEvents).toHaveBeenCalledWith("example-org");
+    expect(screen.getByText("Founded")).toBeInTheDocument();
+    expect(screen.getByText("Launched")).toBeInTheDocument();
+  });
+
+  it("sorts events ascending by date by default (oldest first)", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "c", title: "Third", date: "2023" }),
+      makeEvent({ id: "a", title: "First", date: "2020" }),
+      makeEvent({ id: "b", title: "Second", date: "2021-06" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    const titles = screen.getAllByRole("row").slice(1).map(
+      (r) => r.querySelectorAll("td")[1]?.textContent,
+    );
+    expect(titles).toEqual(["First", "Second", "Third"]);
+  });
+
+  it("sorts descending when sort='desc' is passed", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "First", date: "2020" }),
+      makeEvent({ id: "c", title: "Third", date: "2023" }),
+      makeEvent({ id: "b", title: "Second", date: "2021-06" }),
+    ];
+    render(<EntityTimeline events={events} sort="desc" />);
+    const titles = screen.getAllByRole("row").slice(1).map(
+      (r) => r.querySelectorAll("td")[1]?.textContent,
+    );
+    expect(titles).toEqual(["Third", "Second", "First"]);
+  });
+
+  it("places events with missing dates at the end of ascending sort", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "c", title: "No date" }),
+      makeEvent({ id: "a", title: "Earliest", date: "2020" }),
+      makeEvent({ id: "b", title: "Later", date: "2021" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    const titles = screen.getAllByRole("row").slice(1).map(
+      (r) => r.querySelectorAll("td")[1]?.textContent,
+    );
+    expect(titles).toEqual(["Earliest", "Later", "No date"]);
+  });
+
+  it("auto-hides the Type column when no event has eventType", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ title: "Plain", date: "2020" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    expect(screen.queryByText("Type")).not.toBeInTheDocument();
+  });
+
+  it("auto-shows the Type column when any event has eventType", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "Product debut", date: "2021", eventType: "launch" }),
+      makeEvent({ id: "b", title: "Other", date: "2022" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    // Title text and type badge text don't collide
+    expect(screen.getByText("Launch")).toBeInTheDocument();
+    expect(screen.getByText("Product debut")).toBeInTheDocument();
+  });
+
+  it("hides the Significance column by default even when data is present", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ title: "X", date: "2020", significance: "major" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    expect(screen.queryByText("Significance")).not.toBeInTheDocument();
+  });
+
+  it("renders Significance column with colored badge when opt-in", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "X", date: "2020", significance: "major" }),
+      makeEvent({ id: "b", title: "Y", date: "2021", significance: "minor" }),
+    ];
+    render(<EntityTimeline events={events} showSignificance />);
+    expect(screen.getByText("Significance")).toBeInTheDocument();
+    expect(screen.getByText("Major")).toBeInTheDocument();
+    expect(screen.getByText("Minor")).toBeInTheDocument();
+  });
+
+  it("filters to a specific eventType when provided", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "Founded", date: "2020", eventType: "founding" }),
+      makeEvent({ id: "b", title: "Pivoted", date: "2022", eventType: "pivot" }),
+      makeEvent({ id: "c", title: "Funded", date: "2023", eventType: "funding" }),
+    ];
+    render(<EntityTimeline events={events} eventType="funding" />);
+    expect(screen.getByText("Funded")).toBeInTheDocument();
+    expect(screen.queryByText("Founded")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pivoted")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when eventType filter produces no matches", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ title: "Founded", date: "2020", eventType: "founding" }),
+    ];
+    const { container } = render(
+      <EntityTimeline events={events} eventType="acquisition" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("auto-detects columns from the full sorted set, not the post-maxItems slice", () => {
+    // Only the last (newest) event has a source URL. In desc sort it lands at
+    // row 0. With maxItems=2 in asc sort it would be clipped; the Source column
+    // still needs to render for the visible rows that carry that data — but
+    // conversely, source data that lives only in the *excluded* tail must
+    // still be reflected in header detection so the column renders where
+    // applicable. This test locks that the detector reads all sorted rows.
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "A", date: "2020" }),
+      makeEvent({ id: "b", title: "B", date: "2021" }),
+      makeEvent({ id: "c", title: "C", date: "2022" }),
+      makeEvent({
+        id: "d",
+        title: "D",
+        date: "2023",
+        source: "https://example.com/source",
+      }),
+    ];
+    render(<EntityTimeline events={events} maxItems={2} />);
+    expect(screen.getByText("Source")).toBeInTheDocument();
+  });
+
+  it("caps rows to maxItems (respecting the sorted order)", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ id: "a", title: "2020-event", date: "2020" }),
+      makeEvent({ id: "b", title: "2021-event", date: "2021" }),
+      makeEvent({ id: "c", title: "2022-event", date: "2022" }),
+      makeEvent({ id: "d", title: "2023-event", date: "2023" }),
+    ];
+    render(<EntityTimeline events={events} sort="desc" maxItems={2} />);
+    expect(screen.getByText("2023-event")).toBeInTheDocument();
+    expect(screen.getByText("2022-event")).toBeInTheDocument();
+    expect(screen.queryByText("2021-event")).not.toBeInTheDocument();
+    expect(screen.queryByText("2020-event")).not.toBeInTheDocument();
+  });
+
+  it("renders Source as a short-domain external link when URL is present", () => {
+    const events: EntityEvent[] = [
+      makeEvent({
+        title: "Paper",
+        date: "2024",
+        source: "https://arxiv.org/abs/2401.12345",
+      }),
+    ];
+    render(<EntityTimeline events={events} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://arxiv.org/abs/2401.12345");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveTextContent("arxiv.org");
+  });
+
+  it("hides Source column when no event has a URL source", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ title: "X", date: "2020", source: "Internal note" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    expect(screen.queryByText("Source")).not.toBeInTheDocument();
+  });
+
+  it("renders the optional title heading", () => {
+    const events: EntityEvent[] = [makeEvent({ title: "X", date: "2020" })];
+    render(<EntityTimeline events={events} title="Timeline" />);
+    expect(
+      screen.getByRole("heading", { name: "Timeline" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a heading when title prop is omitted", () => {
+    const events: EntityEvent[] = [makeEvent({ title: "X", date: "2020" })];
+    render(<EntityTimeline events={events} />);
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  it("renders an em-dash placeholder for events missing a date", () => {
+    const events: EntityEvent[] = [
+      makeEvent({ title: "Undated event" }),
+    ];
+    render(<EntityTimeline events={events} />);
+    expect(screen.getByText("\u2014")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/data/factbase.ts
+++ b/apps/web/src/data/factbase.ts
@@ -502,6 +502,70 @@ export function getAllFactBaseRecordsByCollection(collection: string): FactBaseR
   return getAllFactBaseRecords(collection);
 }
 
+// ── Entity Events (PG-sourced timeline events per entity) ──
+
+/** Allowed significance levels for an EntityEvent. */
+export type EntityEventSignificance = "major" | "moderate" | "minor";
+
+/**
+ * Structured shape of an entity_events record after parsing the underlying
+ * FactBaseRecordEntry.fields bag. Mirrors the columns on the wiki-server
+ * `entity_events` table (schema.ts:2446).
+ */
+export interface EntityEvent {
+  /** Stable record id (10-char) from the entity_events table. */
+  id: string;
+  /** Entity the event belongs to (stableId, e.g. "sid_XXXXXXXXXX"). */
+  entityId: string;
+  /** Event title. PG enforces NOT NULL; typed optional as a defensive shim. */
+  title: string;
+  /** Event date (YYYY, YYYY-MM, or YYYY-MM-DD). PG enforces NOT NULL. */
+  date?: string;
+  /** Event type tag (founding, pivot, launch, publication, etc). PG enforces NOT NULL. */
+  eventType?: string;
+  /** Optional longer description. */
+  description?: string;
+  /** Significance level (major/moderate/minor). */
+  significance?: EntityEventSignificance;
+  /** Optional URL to a primary source. */
+  source?: string;
+  /** Optional editorial notes. */
+  notes?: string;
+}
+
+function parseEntityEvent(entry: FactBaseRecordEntry): EntityEvent {
+  const f = entry.fields as Record<string, unknown>;
+  const asString = (v: unknown): string | undefined =>
+    typeof v === "string" && v.length > 0 ? v : undefined;
+  const sig = asString(f.significance);
+  return {
+    id: entry.key,
+    entityId: entry.ownerEntityId,
+    title: asString(f.title) ?? "",
+    date: asString(f.date),
+    eventType: asString(f.eventType),
+    description: asString(f.description),
+    significance:
+      sig === "major" || sig === "moderate" || sig === "minor" ? sig : undefined,
+    source: asString(f.source),
+    notes: asString(f.notes),
+  };
+}
+
+/**
+ * Get all entity_events for a given entity (slug, stableId, or wikiId).
+ * Events are returned in the order they were merged; callers that need
+ * chronological order should sort by `date` themselves.
+ */
+export function getEntityEvents(entityId: string): EntityEvent[] {
+  return getFactBaseRecords(entityId, "entity-events").map(parseEntityEvent);
+}
+
+/** Get all entity_events across all entities (used by cross-entity views). */
+export function getAllEntityEvents(): EntityEvent[] {
+  return getAllFactBaseRecords("entity-events").map(parseEntityEvent);
+}
+
 /**
  * Get all unique record collection names present in factbase-data.json.
  * Derived dynamically from the data so new collections are picked up automatically.

--- a/content/docs/knowledge-base/organizations/80000-hours.mdx
+++ b/content/docs/knowledge-base/organizations/80000-hours.mdx
@@ -63,21 +63,7 @@ The organization has prioritized AI safety as their top recommended problem area
 
 ### Timeline
 
-| Year | Event | Significance |
-|------|-------|--------------|
-| **2011** | Founded at Oxford | Benjamin Todd and William MacAskill start 80,000 Hours as a student project |
-| **2012** | First full-time staff | Organization professionalizes; begins systematic research |
-| **2012** | Co-founded EA movement | Helped establish effective altruism alongside Giving What We Can, CEA |
-| **2015** | Y Combinator acceptance | One of first nonprofits in YC; gained startup methodology and credibility |
-| **2016** | AI safety becomes top priority | Identified risks from AI as most pressing problem area |
-| **2016** | Published career guide book | *80,000 Hours: Find a fulfilling career that does good* |
-| **2017** | Podcast launch | <EntityLink id="rob-wiblin" name="rob-wiblin">Rob Wiblin</EntityLink> begins hosting The 80,000 Hours Podcast |
-| **2020** | Reached 14 FTEs | Steady organizational growth |
-| **2022** | Leadership transition | Benjamin Todd moves from CEO to President; Howie Lempel becomes CEO |
-| **2022** | Reached 25 FTEs | Organization nearly doubles in size |
-| **2024** | New CEO appointed | Niel Bowerman becomes CEO (former FHI Assistant Director) |
-| **2025** | Strategic shift to AGI | Announced focus on navigating transition to powerful AGI |
-| **2025** | Spin-out from Effective Ventures | Became independent nonprofit (April 1, 2025) |
+<EntityTimeline entity="80000-hours" />
 
 ### Founding Story
 

--- a/content/docs/knowledge-base/organizations/coefficient-giving.mdx
+++ b/content/docs/knowledge-base/organizations/coefficient-giving.mdx
@@ -62,15 +62,7 @@ In 2017, Open Philanthropy [spun off from GiveWell](https://www.openphilanthropy
 
 Coefficient Giving began supporting AI safety work in 2015, when the field was nascent and institutional support was minimal. Early grants helped establish foundational organizations including the [Machine Intelligence Research Institute](https://www.openphilanthropy.org/grants/machine-intelligence-research-institute-ai-safety-retraining-program/) (<EntityLink id="E202" name="miri">MIRI</EntityLink>), the [Center for Human-Compatible AI](https://humancompatible.ai/) at UC Berkeley, and the [Future of Humanity Institute](https://web.archive.org/web/2024/https://www.fhi.ox.ac.uk/) at Oxford. By 2023, AI safety had become Coefficient Giving's largest longtermist cause area, reflecting growing concern about advanced AI risks among the leadership team.
 
-| Year | AI Safety Milestone |
-|------|-------------------|
-| 2015 | First AI safety grants; field had ≈10 full-time researchers |
-| 2017 | Independent organization; <EntityLink id="E156" name="holden-karnofsky">Holden Karnofsky</EntityLink> publishes AI concerns |
-| 2019 | AI safety spending exceeds \$20M annually |
-| 2022 | \$150M Regranting Challenge launched (not AI-specific) |
-| 2023 | ≈\$46M AI safety spending; largest funder in the field |
-| 2024 | ≈\$50M committed; 68% to evaluations/benchmarking |
-| 2025 | Rebrand to Coefficient Giving; \$40M Technical AI Safety RFP |
+<EntityTimeline entity="coefficient-giving" />
 
 ### The November 2025 Rebrand
 

--- a/content/docs/knowledge-base/organizations/manifund.mdx
+++ b/content/docs/knowledge-base/organizations/manifund.mdx
@@ -476,22 +476,7 @@ Several Manifund-funded projects have subsequently received larger grants from <
 
 ## Timeline
 
-| Date | Event |
-|------|-------|
-| **Dec 2021** | Manifold Markets founded by Austin Chen, Stephen Grugett, James Grugett |
-| **2022** | Manifold receives \$500K from FTX Future Fund for charity prediction markets |
-| **2022** | Manifund incorporated as separate 501(c)(3) |
-| **Late 2022** | Scott Alexander approaches team about running ACX Grants via impact certificates |
-| **2022** | Rachel Weinberg joins; builds manifund.org in two weeks |
-| **May 2023** | Anonymous donor "D" provides \$1.5M for regranting program |
-| **2023** | Manifund launches with ≈12 regrantors (\$50K-400K budgets each) |
-| **Sep 2023** | First Manifest conference (250 attendees, Berkeley) |
-| **2023** | \$2.06M distributed (\$2.012M grants + \$45K impact certificates) |
-| **Q1 2024** | Impact certificate experiments conclude with mixed results |
-| **Jun 2024** | Manifest 2024 (600 attendees) |
-| **2024** | ACX Grants 2024 includes impact market for 50+ proposals |
-| **2025** | \$2.25M raised for 10 regrantors |
-| **Jan 2025** | ACX Grants 2025 funds 42 of 654 applications |
+<EntityTimeline entity="manifund" />
 
 ## Sources and Citations
 

--- a/content/docs/knowledge-base/organizations/redwood-research.mdx
+++ b/content/docs/knowledge-base/organizations/redwood-research.mdx
@@ -34,15 +34,7 @@ The organization takes a "prosaic alignment" approach, explicitly aiming to alig
 
 ### Timeline
 
-| Date | Event | Source |
-|------|-------|--------|
-| Sep 2021 | Tax-exempt status granted; 10 staff assembled | [ProPublica](https://projects.propublica.org/nonprofits/organizations/871702255) |
-| Dec 2021 | MLAB bootcamp launches (40 participants) | [Buck's blog](https://blog.redwoodresearch.org/p/the-inaugural-redwood-research-podcast) |
-| 2022 | Adversarial robustness research; acknowledged as unsuccessful | [Buck's blog](https://blog.redwoodresearch.org/p/the-inaugural-redwood-research-podcast) |
-| 2022-2023 | Causal scrubbing methodology developed | [LessWrong](https://www.lesswrong.com/posts/JvZhhzycHu2Yd57RN/causal-scrubbing-a-method-for-rigorously-testing) |
-| 2023 | REMIX interpretability program runs | [EA Forum](https://forum.effectivealtruism.org/posts/MGbdhjgd2v6cg3vjv/apply-to-the-redwood-research-mechanistic-interpretability) |
-| 2024 | <EntityLink id="E46" name="buck-shlegeris">Buck Shlegeris</EntityLink> becomes CEO; AI Control ICML oral | [ProPublica](https://projects.propublica.org/nonprofits/organizations/871702255) |
-| Dec 2024 | Alignment faking paper with Anthropic | [Anthropic](https://www.anthropic.com/research/alignment-faking) |
+<EntityTimeline entity="redwood-research" />
 
 ### Founding and Early Growth (2021)
 


### PR DESCRIPTION
## Summary

- Adds `<EntityTimeline>` — a server React component that renders `entity_events` from `factbase-data.json` (populated by the PG `entity_events` table at build time in QUA-26).
- Registers the component in `mdx-components.tsx` and replaces the four hand-written inline timeline tables in `manifund`, `80000-hours`, `redwood-research`, and `coefficient-giving` with `<EntityTimeline entity="<slug>" />`.
- Adds a new "Timeline" tab (Clock icon, `about` group) to `/organizations/[slug]` profile pages that renders whenever the org has events.

## Component design

- Two call modes:
  - `<EntityTimeline entity="slug" />` — looks up events via `getEntityEvents(entityId)`.
  - `<EntityTimeline events={events} />` — accepts pre-fetched events (used by profile pages that already loaded their data in `loadOrgPageData`).
- Default sort: ascending (oldest first) — matches the four existing hand-written timelines that this PR replaces.
- Column auto-detection (Type, Description, Source) runs against the full sorted set, not the post-`maxItems` slice, so capping visible rows can't hide a column whose data lives in the tail.
- `Significance` is opt-in (`showSignificance`) because most timelines don't need it; kept available for future use.
- Returns `null` when there are no events — same graceful-degradation pattern as `SafetyMilestonesSection` and other PG-sourced sections.

## Scope trade-offs

- **Coefficient Giving table scope widened**: the old MDX "AI Safety Milestone" table had 7 AI-safety-only rows (2015-2025); PG has 10 events (2011-2025) spanning full org history. The replacement shows all 10 in the `Growth and AI Safety Focus` subsection; the adjacent `Origins (2011-2017)` prose subsection remains as narrative context.
- **Redwood inline EntityLink removed**: the 2024 row in the old redwood table embedded `<EntityLink id="E46">Buck Shlegeris</EntityLink>`. PG stores the description as plain text, so that inline link is lost on migration. Acceptable per QUA-660's framing; future enrichment can reintroduce links if needed.
- **80K Hours `Significance` column**: the old column was narrative prose. In PG that same content is now in the `description` field (Event column stays titular, Description column carries the narrative). The enum-valued `significance` field (major/moderate/minor) is extra metadata not shown by default.
- **Graceful degradation in local dev**: without prod wiki-server access at build time, `entity_events` never land in `factbase-data.json`, so the replaced `## Timeline` sections render only their heading. This matches how `personnel`, `grants`, `divisions`, and other PG-sourced sections behave today. No CI impact — CI builds against prod wiki-server.

## Test plan

- [x] 19 unit tests in `EntityTimeline.test.tsx` cover sort order (asc/desc + missing-date tie-break), column auto-detection (including post-`maxItems` edge case), `eventType` filtering, `maxItems` cap, source URL rendering, empty state, and `title` prop. Full vitest suite: 1647/1647 passing.
- [x] `npx tsc --noEmit` clean from `apps/web/`; `pnpm --filter longterm-next build` succeeds; `pnpm crux w validate gate --fix` — 54/54 gate checks pass.
- [x] Playwright `render-audit.spec.ts` — 28/28 pass against the built server. Manual Playwright check against `/wiki/E547` (manifund), `/wiki/E510` (80000-hours), `/wiki/E557` (redwood-research), `/wiki/E521` (coefficient-giving) confirms each renders the component with the expected row counts (14 / 13 / 7 / 10) and correct auto-detected columns (Date, Event, Type badge, Description, Source short-domain link where data exists).

Closes QUA-660
