### PR TITLE
fix(QUA-673): format raw large numbers on org Database tab

### DIFF
--- a/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  PURE_NUMERIC_STRING_RE,
+  formatFactValueString,
+  sanitizeRawLargeNumbers,
+} from "../format-cell-value";
+
+describe("PURE_NUMERIC_STRING_RE", () => {
+  it("accepts plain integers and decimals", () => {
+    expect(PURE_NUMERIC_STRING_RE.test("1700000000")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("0.63")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("-0.5")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test(".5")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("0")).toBe(true);
+  });
+
+  it("accepts scientific notation", () => {
+    expect(PURE_NUMERIC_STRING_RE.test("1e+9")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("7e10")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("2.0097e+11")).toBe(true);
+    expect(PURE_NUMERIC_STRING_RE.test("-1.5E-3")).toBe(true);
+  });
+
+  it("rejects non-numeric fact values that also appear in the facts.value column", () => {
+    expect(PURE_NUMERIC_STRING_RE.test("Menlo Park, CA")).toBe(false);
+    expect(PURE_NUMERIC_STRING_RE.test("sid_cMbVUVK29Q")).toBe(false);
+    expect(PURE_NUMERIC_STRING_RE.test("0.015–0.025")).toBe(false); // en-dash range
+    expect(PURE_NUMERIC_STRING_RE.test("1,700,000,000")).toBe(false); // pre-formatted
+    expect(PURE_NUMERIC_STRING_RE.test("$1.7B")).toBe(false);
+    expect(PURE_NUMERIC_STRING_RE.test("https://ai.meta.com/")).toBe(false);
+    expect(PURE_NUMERIC_STRING_RE.test("2024-05")).toBe(false);
+  });
+});
+
+describe("formatFactValueString (QUA-673)", () => {
+  it("formats large numeric strings with USD prefix", () => {
+    expect(formatFactValueString("1700000000", "USD")).toBe("$1.7B");
+  });
+
+  it("formats large numeric strings without a currency", () => {
+    // Intent: the call site can still disambiguate via `row.currency`, but when
+    // it's absent we fall back to the unit-less compact number so `user-count`
+    // facts (e.g. 1e9 active users) don't render as `$1B`.
+    expect(formatFactValueString("1000000000", null)).toBe("1B");
+    expect(formatFactValueString("70000000000", undefined)).toBe("70B");
+  });
+
+  it("formats scientific notation strings", () => {
+    expect(formatFactValueString("7e+10", "USD")).toBe("$70B");
+    // formatCompactCurrency rounds to 0 decimals once abs >= 10 of the unit,
+    // so 164.5B compacts to "$165B" (not "$164.5B"). The important contract
+    // for QUA-673 is that no 10+ digit run remains.
+    expect(formatFactValueString("1.645e+11", "USD")).toBe("$165B");
+  });
+
+  it("returns null for values < 1000 so small numbers render raw (no distortion)", () => {
+    expect(formatFactValueString("63", null)).toBeNull();
+    expect(formatFactValueString("999", null)).toBeNull();
+    expect(formatFactValueString("-500", null)).toBeNull();
+  });
+
+  it("formats values >= 1000 as compact (below the render-audit threshold but still worth compacting)", () => {
+    expect(formatFactValueString("1500", null)).toBe("1.5K");
+    // formatCompactNumber rounds to 0 decimals once abs >= 10 of the unit.
+    expect(formatFactValueString("78800", null)).toBe("79K");
+  });
+
+  it("returns null for non-numeric fact values", () => {
+    expect(formatFactValueString("Menlo Park, CA", null)).toBeNull();
+    expect(formatFactValueString("sid_abc", null)).toBeNull();
+    expect(formatFactValueString("0.015–0.025", null)).toBeNull();
+    expect(formatFactValueString("", null)).toBeNull();
+    expect(formatFactValueString("   ", null)).toBeNull();
+  });
+
+  it("respects GBP currency", () => {
+    expect(formatFactValueString("1325000000", "GBP")).toBe("£1.3B");
+  });
+
+  it("output never contains a bare 10+ digit run (the render-audit regex)", () => {
+    const meta = [
+      "1000000000",
+      "69000000000",
+      "125000000000",
+      "70000000000",
+      "164500000000",
+      "200970000000",
+      "27000000000",
+    ];
+    const bigDigitRegex = /(?<![a-zA-Z_])\d{10,}(?![a-zA-Z])/;
+    for (const v of meta) {
+      expect(formatFactValueString(v, "USD"), `USD ${v}`).not.toMatch(bigDigitRegex);
+      expect(formatFactValueString(v, null), `plain ${v}`).not.toMatch(bigDigitRegex);
+    }
+  });
+});
+
+describe("sanitizeRawLargeNumbers (QUA-673)", () => {
+  it("rewrites a bare 10+ digit run inside a label: value description", () => {
+    // formatCompactNumber rounds to 1-decimal precision only below 10 of a
+    // unit; 1.96B rounds to "2B", 1.7B stays "1.7B".
+    expect(sanitizeRawLargeNumbers("Internal Revenue: 1700000000")).toBe(
+      "Internal Revenue: 1.7B",
+    );
+    expect(sanitizeRawLargeNumbers("Internal Revenue: 1960000000")).toBe(
+      "Internal Revenue: 2B",
+    );
+  });
+
+  it("rewrites multiple runs in one string", () => {
+    expect(
+      sanitizeRawLargeNumbers("Parent Revenue: 164500000000; capex: 69000000000"),
+    ).toBe("Parent Revenue: 165B; capex: 69B");
+  });
+
+  it("leaves sub-1000 numeric runs alone (phone-like codes that happen to be short)", () => {
+    expect(sanitizeRawLargeNumbers("Code: 2024-05-23")).toBe("Code: 2024-05-23");
+  });
+
+  it("leaves numbers embedded inside alphanumeric tokens untouched (ids, hashes)", () => {
+    // A stableId-looking token or commit hash must not be rewritten — only
+    // runs that are already "bare" in the surrounding text.
+    const hash = "abc1234567890def"; // 10 digits but embedded in alphanum
+    expect(sanitizeRawLargeNumbers(hash)).toBe(hash);
+  });
+
+  it("leaves shorter digit runs alone", () => {
+    // 9-digit runs are below the render-audit regex threshold and sometimes
+    // legitimate (phone numbers, smaller identifiers). Keep untouched.
+    expect(sanitizeRawLargeNumbers("Revenue: 123456789")).toBe(
+      "Revenue: 123456789",
+    );
+  });
+
+  it("is idempotent on an already-formatted description", () => {
+    const formatted = "Internal Revenue: $1.7B";
+    expect(sanitizeRawLargeNumbers(formatted)).toBe(formatted);
+  });
+
+  it("eliminates every run the render-audit regex flags", () => {
+    const raw =
+      "Internal Revenue: 1700000000. Parent Revenue: 164500000000. Users: 1000000000.";
+    const out = sanitizeRawLargeNumbers(raw);
+    expect(out).not.toMatch(/(?<![a-zA-Z_])\d{10,}(?![a-zA-Z])/);
+  });
+});

--- a/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   PURE_NUMERIC_STRING_RE,
   formatFactValueString,
-  sanitizeRawLargeNumbers,
 } from "../format-cell-value";
+import { sanitizeRawLargeNumbers } from "@/lib/format-compact";
 
 describe("PURE_NUMERIC_STRING_RE", () => {
   it("accepts plain integers and decimals", () => {
@@ -135,6 +135,22 @@ describe("sanitizeRawLargeNumbers (QUA-673)", () => {
   it("is idempotent on an already-formatted description", () => {
     const formatted = "Internal Revenue: $1.7B";
     expect(sanitizeRawLargeNumbers(formatted)).toBe(formatted);
+  });
+
+  it("does not corrupt decimals that happen to contain a 10+ digit tail", () => {
+    // Regression: an earlier regex fired on "1700000000.5" because the
+    // trailing "." was not in the negative look-ahead, producing "1.7B.5".
+    expect(sanitizeRawLargeNumbers("1700000000.5")).toBe("1700000000.5");
+    expect(sanitizeRawLargeNumbers("Version 2.1700000000")).toBe("Version 2.1700000000");
+    expect(sanitizeRawLargeNumbers("ratio 0.1700000000")).toBe("ratio 0.1700000000");
+  });
+
+  it("still rewrites currency-prefixed amounts and negatives", () => {
+    // $ / space / start-of-string boundary should still allow a match.
+    expect(sanitizeRawLargeNumbers("Total $1700000000")).toBe("Total $1.7B");
+    // Negative values: the `-` is outside the captured digit run, so the
+    // replacement happens and the sign is preserved in the surrounding text.
+    expect(sanitizeRawLargeNumbers("Losses -1700000000")).toBe("Losses -1.7B");
   });
 
   it("eliminates every run the render-audit regex flags", () => {

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -27,6 +27,10 @@ import {
   isOpaqueLegacyFactId,
   isLegacyResourceId,
 } from "./sanitize-raw-ids";
+import {
+  formatFactValueString,
+  sanitizeRawLargeNumbers,
+} from "./format-cell-value";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -433,6 +437,22 @@ function CellValue({
     }
   }
 
+  // Facts `value` column holds the serialized fact value as text (e.g.
+  // "70000000000" for a number fact, "Menlo Park, CA" for a text fact,
+  // "[sid_...]" for refs). Format pure-numeric strings so the Database tab
+  // never renders a bare 10+ digit run alongside the (already-formatted)
+  // sibling `numeric` cell. Regression of QUA-82, tracked as QUA-673.
+  if (columnName === "value" && typeof value === "string") {
+    const formatted = formatFactValueString(value, (row?.currency as string) ?? null);
+    if (formatted !== null) {
+      return (
+        <span className="text-[11px] tabular-nums font-medium whitespace-nowrap" title={value}>
+          {formatted}
+        </span>
+      );
+    }
+  }
+
   // Generic number values (real/doublePrecision columns arrive as typeof number)
   if (typeof value === "number" && isFinite(value)) {
     const formatted = Math.abs(value) >= 1000
@@ -463,7 +483,15 @@ function CellValue({
     );
   }
 
-  const str = String(value);
+  let str = String(value);
+
+  // `things.description` is composed server-side and — for rows synced before
+  // QUA-673 — may still embed a raw numeric literal (e.g. "Internal Revenue:
+  // 1700000000"). Rewrite bare 10+ digit runs to their compact form so the
+  // Database tab shows "$1.7B" without requiring a full facts re-sync.
+  if (columnName === "description" && typeof value === "string") {
+    str = sanitizeRawLargeNumbers(str);
+  }
 
   // Long text -> expandable with line-clamp
   if (str.length > 80) {

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -438,11 +438,9 @@ function CellValue({
     }
   }
 
-  // Facts `value` column holds the serialized fact value as text (e.g.
-  // "70000000000" for a number fact, "Menlo Park, CA" for a text fact,
-  // "[sid_...]" for refs). Format pure-numeric strings so the Database tab
-  // never renders a bare 10+ digit run alongside the (already-formatted)
-  // sibling `numeric` cell. Regression of QUA-82, tracked as QUA-673.
+  // Facts `value` is a text column that stringifies number facts to
+  // "70000000000" and similar. Format pure-numeric entries so the Database
+  // tab never renders a bare 10+ digit run.
   if (columnName === "value" && typeof value === "string") {
     const formatted = formatFactValueString(value, (row?.currency as string) ?? null);
     if (formatted !== null) {
@@ -486,10 +484,9 @@ function CellValue({
 
   let str = String(value);
 
-  // `things.description` is composed server-side and — for rows synced before
-  // QUA-673 — may still embed a raw numeric literal (e.g. "Internal Revenue:
-  // 1700000000"). Rewrite bare 10+ digit runs to their compact form so the
-  // Database tab shows "$1.7B" without requiring a full facts re-sync.
+  // Older composed things.description rows embed raw numeric literals
+  // (e.g. "Internal Revenue: 1700000000"). Rewrite at render time so the
+  // Database tab heals without a full facts re-sync.
   if (columnName === "description" && typeof value === "string") {
     str = sanitizeRawLargeNumbers(str);
   }

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -18,7 +18,11 @@ import * as HoverCard from "@radix-ui/react-hover-card";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 
-import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
+import {
+  formatCompactCurrency,
+  formatCompactNumber,
+  sanitizeRawLargeNumbers,
+} from "@/lib/format-compact";
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { isEntityRefColumn } from "./entity-ref-columns";
 import {
@@ -27,10 +31,7 @@ import {
   isOpaqueLegacyFactId,
   isLegacyResourceId,
 } from "./sanitize-raw-ids";
-import {
-  formatFactValueString,
-  sanitizeRawLargeNumbers,
-} from "./format-cell-value";
+import { formatFactValueString } from "./format-cell-value";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/internal/entity-profile/format-cell-value.ts
+++ b/apps/web/src/app/internal/entity-profile/format-cell-value.ts
@@ -1,41 +1,18 @@
-/**
- * Pure helpers for formatting cell values in the entity profile viewer's
- * Database tab. Extracted from entity-profile-viewer.tsx so they can be
- * unit-tested without pulling in the full client React tree.
- *
- * The render-audit e2e regression in QUA-673 caught two distinct paths where
- * bare 10+ digit numbers leaked onto `/organizations/:slug` (Database tab):
- *
- *   1. The `facts.value` column — a text column storing the serialized fact
- *      value. Numeric facts stringify to e.g. "70000000000"; the existing
- *      CellValue branches only formatted known currency columns.
- *   2. The `things.description` column — composed server-side. For rows
- *      synced before the composer fix, the stored description still contains
- *      the raw numeric literal (e.g. "Internal Revenue: 1700000000"). We
- *      rewrite these at render time so the Database tab heals without a
- *      full facts re-sync.
- */
-
 import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
 
-/**
- * Pure numeric string (optionally signed, decimal, or in scientific
- * notation). Used to gate numeric coercion in the `value` cell renderer.
- */
+/** Pure numeric literal: optionally signed, decimal, or scientific notation. */
 export const PURE_NUMERIC_STRING_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
 
 /**
- * If `value` (from the `facts.value` column) is a pure-numeric string whose
- * magnitude is ≥ 1000, return its compact-formatted form. Otherwise return
- * null so the caller falls through to the generic string renderer.
- *
- * When `currency` is provided (from the sibling `facts.currency` column) the
- * output includes the currency symbol (`"$1.7B"`, `"£1.3B"`).
+ * If `value` is a pure-numeric string with magnitude ≥ 1000, return the
+ * compact-formatted form; otherwise return null so the caller falls through
+ * to its generic string renderer. The magnitude floor keeps small counts
+ * (63 market-share, 1500 headcount) rendering as-is without distortion.
  */
 export function formatFactValueString(value: string, currency?: string | null): string | null {
   const trimmed = value.trim();
   if (!trimmed || !PURE_NUMERIC_STRING_RE.test(trimmed)) return null;
   const n = Number(trimmed);
-  if (!isFinite(n) || Math.abs(n) < 1000) return null;
+  if (!Number.isFinite(n) || Math.abs(n) < 1000) return null;
   return currency ? formatCompactCurrency(n, currency) : formatCompactNumber(n);
 }

--- a/apps/web/src/app/internal/entity-profile/format-cell-value.ts
+++ b/apps/web/src/app/internal/entity-profile/format-cell-value.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for formatting cell values in the entity profile viewer's
+ * Database tab. Extracted from entity-profile-viewer.tsx so they can be
+ * unit-tested without pulling in the full client React tree.
+ *
+ * The render-audit e2e regression in QUA-673 caught two distinct paths where
+ * bare 10+ digit numbers leaked onto `/organizations/:slug` (Database tab):
+ *
+ *   1. The `facts.value` column — a text column storing the serialized fact
+ *      value. Numeric facts stringify to e.g. "70000000000"; the existing
+ *      CellValue branches only formatted known currency columns.
+ *   2. The `things.description` column — composed server-side. For rows
+ *      synced before the composer fix, the stored description still contains
+ *      the raw numeric literal (e.g. "Internal Revenue: 1700000000"). We
+ *      rewrite these at render time so the Database tab heals without a
+ *      full facts re-sync.
+ */
+
+import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
+
+/**
+ * Pure numeric string (optionally signed, decimal, or in scientific
+ * notation). Used to gate numeric coercion in the `value` cell renderer.
+ */
+export const PURE_NUMERIC_STRING_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+
+/**
+ * Replace any bare 10+ digit run inside a display string with its compact
+ * form (e.g. `"Internal Revenue: 1700000000"` → `"Internal Revenue: 1.7B"`).
+ *
+ * Skips runs that are embedded in word/number-adjacent context (e.g. a hash
+ * like `abc1234567890def` stays untouched) and leaves small magnitudes alone
+ * so ordinal / count strings aren't mangled.
+ */
+export function sanitizeRawLargeNumbers(s: string): string {
+  return s.replace(/(?<![a-zA-Z_\d])(\d{10,})(?![a-zA-Z\d])/g, (m) => {
+    const n = Number(m);
+    if (!isFinite(n) || Math.abs(n) < 1000) return m;
+    return formatCompactNumber(n);
+  });
+}
+
+/**
+ * If `value` (from the `facts.value` column) is a pure-numeric string whose
+ * magnitude is ≥ 1000, return its compact-formatted form. Otherwise return
+ * null so the caller falls through to the generic string renderer.
+ *
+ * When `currency` is provided (from the sibling `facts.currency` column) the
+ * output includes the currency symbol (`"$1.7B"`, `"£1.3B"`).
+ */
+export function formatFactValueString(value: string, currency?: string | null): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || !PURE_NUMERIC_STRING_RE.test(trimmed)) return null;
+  const n = Number(trimmed);
+  if (!isFinite(n) || Math.abs(n) < 1000) return null;
+  return currency ? formatCompactCurrency(n, currency) : formatCompactNumber(n);
+}

--- a/apps/web/src/app/internal/entity-profile/format-cell-value.ts
+++ b/apps/web/src/app/internal/entity-profile/format-cell-value.ts
@@ -25,22 +25,6 @@ import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact
 export const PURE_NUMERIC_STRING_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
 
 /**
- * Replace any bare 10+ digit run inside a display string with its compact
- * form (e.g. `"Internal Revenue: 1700000000"` → `"Internal Revenue: 1.7B"`).
- *
- * Skips runs that are embedded in word/number-adjacent context (e.g. a hash
- * like `abc1234567890def` stays untouched) and leaves small magnitudes alone
- * so ordinal / count strings aren't mangled.
- */
-export function sanitizeRawLargeNumbers(s: string): string {
-  return s.replace(/(?<![a-zA-Z_\d])(\d{10,})(?![a-zA-Z\d])/g, (m) => {
-    const n = Number(m);
-    if (!isFinite(n) || Math.abs(n) < 1000) return m;
-    return formatCompactNumber(n);
-  });
-}
-
-/**
  * If `value` (from the `facts.value` column) is a pure-numeric string whose
  * magnitude is ≥ 1000, return its compact-formatted form. Otherwise return
  * null so the caller falls through to the generic string renderer.

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -366,9 +366,8 @@ export default async function ThingDetailPage({ params }: PageProps) {
   }
 
   if (thing.description) {
-    // Some fact things synced before QUA-673 still embed raw numeric
-    // literals (e.g. "Internal Revenue: 1700000000"). Rewrite at render
-    // time so the detail page heals without a facts re-sync.
+    // Older composed fact descriptions embed raw numeric literals
+    // (e.g. "Internal Revenue: 1700000000"); rewrite at render time.
     const sanitized = sanitizeRawLargeNumbers(thing.description);
     metadataRows.push({
       label: "Description",

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { Breadcrumbs } from "@/components/directory/Breadcrumbs";
 import { fetchDetailed } from "@/lib/wiki-server";
 import type { RpcSourcingDetailResult } from "@/lib/wiki-server";
+import { sanitizeRawLargeNumbers } from "@/lib/format-compact";
 import {
   VerdictBadge,
   formatRecordType,
@@ -365,13 +366,17 @@ export default async function ThingDetailPage({ params }: PageProps) {
   }
 
   if (thing.description) {
+    // Some fact things synced before QUA-673 still embed raw numeric
+    // literals (e.g. "Internal Revenue: 1700000000"). Rewrite at render
+    // time so the detail page heals without a facts re-sync.
+    const sanitized = sanitizeRawLargeNumbers(thing.description);
     metadataRows.push({
       label: "Description",
       value: (
         <span className="text-sm">
-          {thing.description.length > 300
-            ? thing.description.slice(0, 300) + "\u2026"
-            : thing.description}
+          {sanitized.length > 300
+            ? sanitized.slice(0, 300) + "\u2026"
+            : sanitized}
         </span>
       ),
     });

--- a/apps/web/src/components/SearchDialog.tsx
+++ b/apps/web/src/components/SearchDialog.tsx
@@ -523,8 +523,6 @@ export function SearchDialog() {
  */
 function HighlightedSnippet({ result }: { result: SearchResult }) {
   const { description: rawDescription, match, terms, snippet } = result;
-  // sanitizeRawLargeNumbers heals un-resynced things.description rows that
-  // still embed raw fact values (QUA-673 defense in depth).
   const description = rawDescription
     ? sanitizeRawLargeNumbers(stripMdxEscapes(rawDescription))
     : rawDescription;

--- a/apps/web/src/components/SearchDialog.tsx
+++ b/apps/web/src/components/SearchDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@lib/search";
 import { ENTITY_TYPES, ENTITY_GROUPS } from "@data/entity-ontology";
 import { stripMdxEscapes } from "@lib/inline-markdown";
+import { sanitizeRawLargeNumbers } from "@lib/format-compact";
 
 // ---------------------------------------------------------------------------
 // Directory route mapping — entity types with dedicated directory pages
@@ -447,7 +448,7 @@ export function SearchDialog() {
                         )}
                         {t.description && (
                           <div className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
-                            {t.description}
+                            {sanitizeRawLargeNumbers(t.description)}
                           </div>
                         )}
                       </div>
@@ -522,7 +523,11 @@ export function SearchDialog() {
  */
 function HighlightedSnippet({ result }: { result: SearchResult }) {
   const { description: rawDescription, match, terms, snippet } = result;
-  const description = rawDescription ? stripMdxEscapes(rawDescription) : rawDescription;
+  // sanitizeRawLargeNumbers heals un-resynced things.description rows that
+  // still embed raw fact values (QUA-673 defense in depth).
+  const description = rawDescription
+    ? sanitizeRawLargeNumbers(stripMdxEscapes(rawDescription))
+    : rawDescription;
 
   // Prefer server-generated snippet with <mark> tags from ts_headline()
   if (snippet && snippet.includes("<mark>")) {

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -70,34 +70,24 @@ export function formatCompactNumber(n: number | null | undefined): string {
 }
 
 /**
- * Replace any bare 10+ digit run inside a display string with its compact
- * form (e.g. `"Internal Revenue: 1700000000"` → `"Internal Revenue: 1.7B"`).
+ * Rewrite bare 10+ digit runs inside a display string as compact numbers
+ * (`"Revenue: 1700000000"` → `"Revenue: 1.7B"`).
  *
- * Defense-in-depth for text fields (primarily `things.description`) that
- * were composed server-side before the composer started formatting numeric
- * fact values in QUA-673. The composer now formats at write time, so
- * freshly-synced rows never need this — but older rows still embed raw
- * literals and this helper heals them at render time until the next full
- * facts re-sync.
- *
- * Boundaries are tuned for mid-string decimal safety:
- *   - Negative look-behind blocks runs preceded by a letter, digit,
- *     underscore, or dot — so `"abc1234567890def"`, `"1.7000000000"`, and
- *     `"Version 2.1700000000"` are left alone.
- *   - Negative look-ahead blocks runs followed by a letter or digit AND
- *     also by `.<digit>` (the decimal fraction case) — so `"1700000000.5"`
- *     stays intact, but `"1700000000. "` (period ending a sentence)
- *     still matches.
- *   - Digits preceded by `-`, `$`, `:`, or whitespace still match so
- *     signed / currency-prefixed amounts and `Label: number` strings
- *     format as expected.
+ * Boundaries are tuned so embedded digit runs stay untouched:
+ *   - Look-behind blocks letters, digits, underscores, and `.` so hashes
+ *     (`abc1234567890def`) and decimals (`0.1700000000`, `2.1700000000`)
+ *     are skipped.
+ *   - Look-ahead blocks letters, digits, and `.<digit>` so decimals like
+ *     `"1700000000.5"` stay intact while a sentence-ending `"1700000000. "`
+ *     still matches. `-`, `$`, `:`, and whitespace stay unblocked so
+ *     signed / currency-prefixed / `Label: N` strings format as expected.
  */
 export function sanitizeRawLargeNumbers(s: string): string {
   return s.replace(
-    /(?<![a-zA-Z_\d.])(\d{10,})(?![a-zA-Z\d])(?!\.\d)/g,
+    /(?<![a-zA-Z_\d.])(\d{10,})(?![a-zA-Z\d]|\.\d)/g,
     (m) => {
       const n = Number(m);
-      if (!isFinite(n) || Math.abs(n) < 1000) return m;
+      if (!Number.isFinite(n) || Math.abs(n) < 1000) return m;
       return formatCompactNumber(n);
     },
   );

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -69,6 +69,40 @@ export function formatCompactNumber(n: number | null | undefined): string {
   return n.toLocaleString();
 }
 
+/**
+ * Replace any bare 10+ digit run inside a display string with its compact
+ * form (e.g. `"Internal Revenue: 1700000000"` → `"Internal Revenue: 1.7B"`).
+ *
+ * Defense-in-depth for text fields (primarily `things.description`) that
+ * were composed server-side before the composer started formatting numeric
+ * fact values in QUA-673. The composer now formats at write time, so
+ * freshly-synced rows never need this — but older rows still embed raw
+ * literals and this helper heals them at render time until the next full
+ * facts re-sync.
+ *
+ * Boundaries are tuned for mid-string decimal safety:
+ *   - Negative look-behind blocks runs preceded by a letter, digit,
+ *     underscore, or dot — so `"abc1234567890def"`, `"1.7000000000"`, and
+ *     `"Version 2.1700000000"` are left alone.
+ *   - Negative look-ahead blocks runs followed by a letter or digit AND
+ *     also by `.<digit>` (the decimal fraction case) — so `"1700000000.5"`
+ *     stays intact, but `"1700000000. "` (period ending a sentence)
+ *     still matches.
+ *   - Digits preceded by `-`, `$`, `:`, or whitespace still match so
+ *     signed / currency-prefixed amounts and `Label: number` strings
+ *     format as expected.
+ */
+export function sanitizeRawLargeNumbers(s: string): string {
+  return s.replace(
+    /(?<![a-zA-Z_\d.])(\d{10,})(?![a-zA-Z\d])(?!\.\d)/g,
+    (m) => {
+      const n = Number(m);
+      if (!isFinite(n) || Math.abs(n) < 1000) return m;
+      return formatCompactNumber(n);
+    },
+  );
+}
+
 /** Return href only if it is a safe HTTP(S) URL; otherwise "#". Prevents XSS via javascript: URIs. */
 export function safeHref(url: string): string {
   return /^https?:\/\//i.test(url) ? url : "#";

--- a/apps/wiki-server/src/__tests__/facts-composer.test.ts
+++ b/apps/wiki-server/src/__tests__/facts-composer.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression coverage for the facts composer (QUA-673).
+ *
+ * The fact composer builds `things.title`, `things.description`, and
+ * `things.parent_title` from a `facts` row. Raw numeric values leaking into
+ * description was the regression of QUA-82 that surfaced as unformatted 10+
+ * digit numbers on `/organizations/:slug` Database tab (render-audit e2e).
+ *
+ * The composer is registered at module load as a side effect of importing
+ * the facts route.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { composeThing, hasComposer } from "../routes/shared/compose-thing.js";
+
+import "../routes/factbase/facts.js";
+
+interface FactRow {
+  factId: string;
+  entityId: string;
+  label?: string | null;
+  measure?: string | null;
+  value?: string | null;
+  numeric?: string | number | null;
+  currency?: string | null;
+}
+
+const ENTITY_STABLE_ID = "sid_deepmind001";
+
+function compose(row: FactRow) {
+  const titleMap = new Map<string, string>([[ENTITY_STABLE_ID, "Google DeepMind"]]);
+  return composeThing<FactRow>("fact", row, titleMap);
+}
+
+describe("facts composer (QUA-673)", () => {
+  beforeAll(() => {
+    expect(hasComposer("fact")).toBe(true);
+  });
+
+  it("formats a USD revenue fact compactly", () => {
+    const result = compose({
+      factId: "f_abc",
+      entityId: ENTITY_STABLE_ID,
+      label: "Internal Revenue",
+      measure: "internal-revenue",
+      value: "1700000000",
+      numeric: 1700000000,
+      currency: "USD",
+    });
+    expect(result.description).toBe("Internal Revenue: $1.7B");
+    expect(result.description).not.toMatch(/\d{10,}/);
+  });
+
+  it("formats a non-currency numeric fact compactly", () => {
+    const result = compose({
+      factId: "f_users",
+      entityId: ENTITY_STABLE_ID,
+      label: "User Count",
+      measure: "user-count",
+      value: "1000000000",
+      numeric: 1000000000,
+      currency: null,
+    });
+    expect(result.description).toBe("User Count: 1B");
+    expect(result.description).not.toMatch(/\d{10,}/);
+  });
+
+  it("formats a scientific-notation numeric string", () => {
+    const result = compose({
+      factId: "f_losses",
+      entityId: ENTITY_STABLE_ID,
+      label: "Cumulative Losses",
+      measure: "cumulative-losses",
+      value: "7e+10",
+      numeric: 7e10,
+      currency: "USD",
+    });
+    expect(result.description).toBe("Cumulative Losses: $70B");
+  });
+
+  it("uses GBP symbol when currency is GBP", () => {
+    const result = compose({
+      factId: "f_gbp",
+      entityId: ENTITY_STABLE_ID,
+      label: "Turnover",
+      measure: "turnover",
+      value: "1325000000",
+      numeric: 1325000000,
+      currency: "GBP",
+    });
+    expect(result.description).toBe("Turnover: £1.3B");
+  });
+
+  it("preserves non-numeric text values verbatim", () => {
+    const result = compose({
+      factId: "f_hq",
+      entityId: ENTITY_STABLE_ID,
+      label: "Headquarters",
+      measure: "headquarters",
+      value: "Menlo Park, CA",
+      numeric: null,
+      currency: null,
+    });
+    expect(result.description).toBe("Headquarters: Menlo Park, CA");
+  });
+
+  it("preserves a ref-typed value (sid_...) verbatim", () => {
+    const result = compose({
+      factId: "f_founder",
+      entityId: ENTITY_STABLE_ID,
+      label: "Founder",
+      measure: "founded-by",
+      value: "sid_cMbVUVK29Q",
+      numeric: null,
+      currency: null,
+    });
+    expect(result.description).toBe("Founder: sid_cMbVUVK29Q");
+  });
+
+  it("preserves a range value verbatim (en-dash breaks the numeric regex)", () => {
+    const result = compose({
+      factId: "f_range",
+      entityId: ENTITY_STABLE_ID,
+      label: "Stake",
+      measure: "stake",
+      value: "0.015–0.025",
+      numeric: null,
+      currency: null,
+    });
+    expect(result.description).toBe("Stake: 0.015–0.025");
+  });
+
+  it("falls back to numeric column when value is null", () => {
+    const result = compose({
+      factId: "f_fallback",
+      entityId: ENTITY_STABLE_ID,
+      label: "Headcount",
+      measure: "headcount",
+      value: null,
+      numeric: 78800,
+      currency: null,
+    });
+    expect(result.description).toBe("Headcount: 78.8K");
+  });
+
+  it("leaves small numbers as-is (no suffix, no 10+ digit run risk)", () => {
+    const result = compose({
+      factId: "f_small",
+      entityId: ENTITY_STABLE_ID,
+      label: "Market Share",
+      measure: "market-share",
+      value: "63",
+      numeric: 63,
+      currency: null,
+    });
+    expect(result.description).toBe("Market Share: 63");
+  });
+
+  it("returns null description when both value and numeric are missing", () => {
+    const result = compose({
+      factId: "f_empty",
+      entityId: ENTITY_STABLE_ID,
+      label: "Unknown",
+      measure: null,
+      value: null,
+      numeric: null,
+      currency: null,
+    });
+    expect(result.description).toBeNull();
+  });
+
+  it("never leaks a 10+ digit run for any of the meta-ai regression values", () => {
+    // The render-audit e2e flagged these exact values on /organizations/meta-ai.
+    const cases: Array<[string, number]> = [
+      ["1000000000", 1e9],
+      ["69000000000", 6.9e10],
+      ["125000000000", 1.25e11],
+      ["70000000000", 7e10],
+      ["164500000000", 1.645e11],
+      ["200970000000", 2.0097e11],
+      ["27000000000", 2.7e10],
+      ["630000000", 6.3e8],
+    ];
+    for (const [valueStr, numeric] of cases) {
+      const result = compose({
+        factId: "f_case",
+        entityId: ENTITY_STABLE_ID,
+        label: "Revenue",
+        measure: "revenue",
+        value: valueStr,
+        numeric,
+        currency: "USD",
+      });
+      expect(
+        result.description,
+        `description must not contain a 10+ digit run for value=${valueStr}: ${result.description}`,
+      ).not.toMatch(/(?<![a-zA-Z_])\d{10,}(?![a-zA-Z])/);
+    }
+  });
+});

--- a/apps/wiki-server/src/__tests__/facts-composer.test.ts
+++ b/apps/wiki-server/src/__tests__/facts-composer.test.ts
@@ -140,7 +140,8 @@ describe("facts composer (QUA-673)", () => {
       numeric: 78800,
       currency: null,
     });
-    expect(result.description).toBe("Headcount: 78.8K");
+    // Precision matches client format-compact.ts: >= 10 of unit drops decimals.
+    expect(result.description).toBe("Headcount: 79K");
   });
 
   it("leaves small numbers as-is (no suffix, no 10+ digit run risk)", () => {

--- a/apps/wiki-server/src/__tests__/format-currency.test.ts
+++ b/apps/wiki-server/src/__tests__/format-currency.test.ts
@@ -98,13 +98,15 @@ describe('formatCompactAmount (QUA-673)', () => {
   });
 
   it('compacts sub-billion values', () => {
-    expect(formatCompactAmount(78_800, null)).toBe('78.8K');
+    // Precision matches client format-compact.ts: >= 10 of unit drops decimals.
+    expect(formatCompactAmount(78_800, null)).toBe('79K');
     expect(formatCompactAmount(6_300_000, null)).toBe('6.3M');
   });
 
   it('accepts scientific notation strings', () => {
     expect(formatCompactAmount('7e+10', 'USD')).toBe('$70B');
-    expect(formatCompactAmount('1.645e+11', 'USD')).toBe('$164.5B');
+    // Precision matches client's format-compact.ts: >= 10 of unit drops decimals.
+    expect(formatCompactAmount('1.645e+11', 'USD')).toBe('$165B');
   });
 
   it('accepts plain numeric strings', () => {

--- a/apps/wiki-server/src/__tests__/format-currency.test.ts
+++ b/apps/wiki-server/src/__tests__/format-currency.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMoney } from '../routes/shared/format-currency.js';
+import { formatMoney, formatCompactAmount } from '../routes/shared/format-currency.js';
 
 describe('formatMoney', () => {
   it('formats USD with $ symbol', () => {
@@ -73,5 +73,76 @@ describe('formatMoney', () => {
     const result = formatMoney(1000, 'TOOLONG');
     expect(result).not.toBeNull();
     expect(result).toContain('1,000');
+  });
+});
+
+describe('formatCompactAmount (QUA-673)', () => {
+  it('compacts billions with USD prefix', () => {
+    expect(formatCompactAmount(1_700_000_000, 'USD')).toBe('$1.7B');
+  });
+
+  it('compacts tens of billions', () => {
+    expect(formatCompactAmount(70_000_000_000, 'USD')).toBe('$70B');
+  });
+
+  it('compacts hundreds of billions', () => {
+    expect(formatCompactAmount(125_000_000_000, 'USD')).toBe('$125B');
+  });
+
+  it('compacts GBP with £ prefix', () => {
+    expect(formatCompactAmount(1_325_000_000, 'GBP')).toBe('£1.3B');
+  });
+
+  it('compacts without a currency prefix when currency is null', () => {
+    expect(formatCompactAmount(1_000_000_000, null)).toBe('1B');
+  });
+
+  it('compacts sub-billion values', () => {
+    expect(formatCompactAmount(78_800, null)).toBe('78.8K');
+    expect(formatCompactAmount(6_300_000, null)).toBe('6.3M');
+  });
+
+  it('accepts scientific notation strings', () => {
+    expect(formatCompactAmount('7e+10', 'USD')).toBe('$70B');
+    expect(formatCompactAmount('1.645e+11', 'USD')).toBe('$164.5B');
+  });
+
+  it('accepts plain numeric strings', () => {
+    expect(formatCompactAmount('1700000000', 'USD')).toBe('$1.7B');
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(formatCompactAmount('Menlo Park, CA', null)).toBeNull();
+    expect(formatCompactAmount('1,700,000,000', null)).toBeNull();
+    expect(formatCompactAmount('0.015–0.025', null)).toBeNull();
+    expect(formatCompactAmount('sid_abc', null)).toBeNull();
+  });
+
+  it('returns null for null / undefined / NaN / Infinity', () => {
+    expect(formatCompactAmount(null, 'USD')).toBeNull();
+    expect(formatCompactAmount(undefined, 'USD')).toBeNull();
+    expect(formatCompactAmount(Number.NaN, 'USD')).toBeNull();
+    expect(formatCompactAmount(Number.POSITIVE_INFINITY, 'USD')).toBeNull();
+  });
+
+  it('handles zero', () => {
+    expect(formatCompactAmount(0, 'USD')).toBe('$0');
+    expect(formatCompactAmount(0, null)).toBe('0');
+  });
+
+  it('handles negative values', () => {
+    // Intl keeps the minus sign before the currency symbol.
+    const neg = formatCompactAmount(-1_700_000_000, 'USD');
+    expect(neg).toBe('-$1.7B');
+  });
+
+  it('output never contains a bare 10+ digit run', () => {
+    // Contract: this function must not produce raw large-digit strings that
+    // would fail the render-audit regex in e2e/render-audit.spec.ts.
+    const inputs = [1_000_000_000, 7e10, 1.25e11, 1.645e11, 2.0097e11, 70_000_000_000];
+    for (const n of inputs) {
+      const got = formatCompactAmount(n, 'USD');
+      expect(got, `compact form of ${n}`).not.toMatch(/(?<![a-zA-Z_])\d{10,}(?![a-zA-Z])/);
+    }
   });
 });

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -68,13 +68,10 @@ interface FactComposerRow {
 }
 
 /**
- * Render a fact's value for `things.description`.
- *
- * Prefers `row.value` (the serialized human-facing string, which captures
- * ranges, refs, booleans, etc.) but falls back to `row.numeric` when value
- * is missing. Pure numeric values are rendered compactly with a grouping
- * separator or SI suffix so large magnitudes never appear as bare 10+ digit
- * runs (regression of QUA-82, tracked as QUA-673).
+ * Render a fact value for `things.description`. Prefers `row.value` (the
+ * serialized human-facing string, which preserves ranges, refs, booleans,
+ * etc.) and falls back to `row.numeric`. Numeric values are compacted so
+ * large magnitudes never appear as bare 10+ digit runs in user-visible text.
  */
 function renderFactDescriptionValue(row: FactComposerRow): string | null {
   if (row.value != null && row.value.length > 0) {

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -16,6 +16,7 @@ import {
 import { SyncFactsBatchSchema } from "../../api-types.js";
 import { upsertThingsInTx, resolveEntityTitles } from "../shared/thing-sync.js";
 import { registerComposer, composeThing } from "../shared/compose-thing.js";
+import { formatCompactAmount } from "../shared/format-currency.js";
 import { formatFactLabel } from "@longterm-wiki/factbase";
 import { logger } from "../../logger.js";
 
@@ -63,6 +64,28 @@ interface FactComposerRow {
   measure?: string | null;
   value?: string | null;
   numeric?: string | number | null;
+  currency?: string | null;
+}
+
+/**
+ * Render a fact's value for `things.description`.
+ *
+ * Prefers `row.value` (the serialized human-facing string, which captures
+ * ranges, refs, booleans, etc.) but falls back to `row.numeric` when value
+ * is missing. Pure numeric values are rendered compactly with a grouping
+ * separator or SI suffix so large magnitudes never appear as bare 10+ digit
+ * runs (regression of QUA-82, tracked as QUA-673).
+ */
+function renderFactDescriptionValue(row: FactComposerRow): string | null {
+  if (row.value != null && row.value.length > 0) {
+    const compact = formatCompactAmount(row.value, row.currency ?? null);
+    return compact ?? row.value;
+  }
+  if (row.numeric != null) {
+    const compact = formatCompactAmount(row.numeric, row.currency ?? null);
+    return compact ?? String(row.numeric);
+  }
+  return null;
 }
 
 registerComposer<FactComposerRow>("fact", (row, titleMap) => {
@@ -71,11 +94,8 @@ registerComposer<FactComposerRow>("fact", (row, titleMap) => {
     label: row.label,
     measure: row.measure,
   });
-  const description = row.value
-    ? `${factLabel}: ${row.value}`
-    : row.numeric != null
-      ? `${factLabel}: ${row.numeric}`
-      : null;
+  const displayValue = renderFactDescriptionValue(row);
+  const description = displayValue != null ? `${factLabel}: ${displayValue}` : null;
   return {
     title: `${factLabel} — ${entityName}`,
     description,

--- a/apps/wiki-server/src/routes/shared/format-currency.ts
+++ b/apps/wiki-server/src/routes/shared/format-currency.ts
@@ -34,17 +34,42 @@ export function formatMoney(
 const PURE_NUMERIC_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
 
 /**
- * Format an amount compactly for display in things.description where
- * readability matters more than precision (e.g. "$1.7B", "70B", "£1.3B").
- *
- * Values below 1,000 are rendered with grouping separators (e.g. "$500") so
- * the output never contains a bare 10+ digit run — critical for the e2e
- * render-audit regression that caught raw numbers like "1700000000" leaking
- * into fact thing descriptions (QUA-673).
- *
- * Accepts number, pure-numeric string ("7e+10", "1700000000", "-0.5"), or
- * nullish. Returns null for nullish / non-finite / non-numeric inputs so the
- * caller can fall back to the raw text.
+ * Bounded cache of `Intl.NumberFormat` instances keyed by the (currency,
+ * fractionDigits) tuple. A batch fact sync composes hundreds of rows back
+ * to back; allocating a new formatter per row dominates the compose cost.
+ * Currencies are few (USD/EUR/GBP/…) and fractionDigits is 0 or 1, so the
+ * cache stays under ~20 entries.
+ */
+const FORMATTER_CACHE = new Map<string, Intl.NumberFormat>();
+
+function getCompactFormatter(
+  currency: string | null,
+  fractionDigits: number,
+): Intl.NumberFormat {
+  const key = `${currency ?? ""}|${fractionDigits}`;
+  const cached = FORMATTER_CACHE.get(key);
+  if (cached) return cached;
+  const opts: Intl.NumberFormatOptions = {
+    notation: "compact",
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: 0,
+  };
+  if (currency) {
+    opts.style = "currency";
+    opts.currency = currency;
+  }
+  const formatter = new Intl.NumberFormat("en-US", opts);
+  FORMATTER_CACHE.set(key, formatter);
+  return formatter;
+}
+
+/**
+ * Compact-format an amount for display in things.description
+ * (e.g. `"$1.7B"`, `"70B"`, `"£1.3B"`). Accepts number, pure-numeric
+ * string (`"7e+10"`, `"1700000000"`, `"-0.5"`), or nullish — returns null
+ * for nullish / non-finite / non-numeric so the caller can fall back to
+ * the raw text. Output never contains a bare 10+ digit run (every scale
+ * branch uses a grouping separator or SI suffix).
  */
 export function formatCompactAmount(
   amount: number | string | null | undefined,
@@ -61,12 +86,10 @@ export function formatCompactAmount(
   }
   if (!Number.isFinite(n)) return null;
 
-  // Match the client's format-compact.ts precision rules so a fact's
-  // server-composed `things.description` and its client-rendered sibling
-  // cells render with the same compactness: below 10 of a unit → keep
-  // 1 decimal ("$1.7B"), at or above 10 of a unit → drop decimals
-  // ("$70B", "$165B"). Without this Intl always keeps 1 decimal, so the
-  // Database tab would show "$164.5B" next to "165B" for the same value.
+  // Precision mirrors apps/web/src/lib/format-compact.ts: below 10 of a
+  // unit keep 1 decimal ("$1.7B"); at or above, drop decimals ("$70B").
+  // Without this rule Intl always keeps 1 decimal, and the Database tab
+  // would show server "$164.5B" next to client "165B" for the same value.
   const abs = Math.abs(n);
   let scaleAbs: number;
   if (abs >= 1e12) scaleAbs = abs / 1e12;
@@ -77,17 +100,8 @@ export function formatCompactAmount(
   const fractionDigits = scaleAbs < 10 && abs >= 1e3 ? 1 : 0;
 
   const code = currency ? currency.toUpperCase() : null;
-  const opts: Intl.NumberFormatOptions = {
-    notation: "compact",
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: 0,
-  };
-  if (code) {
-    opts.style = "currency";
-    opts.currency = code;
-  }
   try {
-    return new Intl.NumberFormat("en-US", opts).format(n);
+    return getCompactFormatter(code, fractionDigits).format(n);
   } catch {
     // Malformed currency code — fall back to grouped decimal so no bare
     // run of 10+ digits leaks to callers that use this for display.

--- a/apps/wiki-server/src/routes/shared/format-currency.ts
+++ b/apps/wiki-server/src/routes/shared/format-currency.ts
@@ -61,12 +61,25 @@ export function formatCompactAmount(
   }
   if (!Number.isFinite(n)) return null;
 
+  // Match the client's format-compact.ts precision rules so a fact's
+  // server-composed `things.description` and its client-rendered sibling
+  // cells render with the same compactness: below 10 of a unit → keep
+  // 1 decimal ("$1.7B"), at or above 10 of a unit → drop decimals
+  // ("$70B", "$165B"). Without this Intl always keeps 1 decimal, so the
+  // Database tab would show "$164.5B" next to "165B" for the same value.
+  const abs = Math.abs(n);
+  let scaleAbs: number;
+  if (abs >= 1e12) scaleAbs = abs / 1e12;
+  else if (abs >= 1e9) scaleAbs = abs / 1e9;
+  else if (abs >= 1e6) scaleAbs = abs / 1e6;
+  else if (abs >= 1e3) scaleAbs = abs / 1e3;
+  else scaleAbs = abs;
+  const fractionDigits = scaleAbs < 10 && abs >= 1e3 ? 1 : 0;
+
   const code = currency ? currency.toUpperCase() : null;
   const opts: Intl.NumberFormatOptions = {
     notation: "compact",
-    // Together these give us "1.7B" (kept) but "70B" / "125B" / "$0" (no
-    // trailing ".0"). Without minimumFractionDigits: 0 Intl renders "$70.0B".
-    maximumFractionDigits: 1,
+    maximumFractionDigits: fractionDigits,
     minimumFractionDigits: 0,
   };
   if (code) {

--- a/apps/wiki-server/src/routes/shared/format-currency.ts
+++ b/apps/wiki-server/src/routes/shared/format-currency.ts
@@ -29,3 +29,55 @@ export function formatMoney(
     return n.toLocaleString("en-US");
   }
 }
+
+/** Regex matching a pure numeric string (optionally signed, decimal, or in scientific notation). */
+const PURE_NUMERIC_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+
+/**
+ * Format an amount compactly for display in things.description where
+ * readability matters more than precision (e.g. "$1.7B", "70B", "£1.3B").
+ *
+ * Values below 1,000 are rendered with grouping separators (e.g. "$500") so
+ * the output never contains a bare 10+ digit run — critical for the e2e
+ * render-audit regression that caught raw numbers like "1700000000" leaking
+ * into fact thing descriptions (QUA-673).
+ *
+ * Accepts number, pure-numeric string ("7e+10", "1700000000", "-0.5"), or
+ * nullish. Returns null for nullish / non-finite / non-numeric inputs so the
+ * caller can fall back to the raw text.
+ */
+export function formatCompactAmount(
+  amount: number | string | null | undefined,
+  currency?: string | null
+): string | null {
+  if (amount == null) return null;
+  let n: number;
+  if (typeof amount === "number") {
+    n = amount;
+  } else {
+    const trimmed = amount.trim();
+    if (!PURE_NUMERIC_RE.test(trimmed)) return null;
+    n = Number(trimmed);
+  }
+  if (!Number.isFinite(n)) return null;
+
+  const code = currency ? currency.toUpperCase() : null;
+  const opts: Intl.NumberFormatOptions = {
+    notation: "compact",
+    // Together these give us "1.7B" (kept) but "70B" / "125B" / "$0" (no
+    // trailing ".0"). Without minimumFractionDigits: 0 Intl renders "$70.0B".
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 0,
+  };
+  if (code) {
+    opts.style = "currency";
+    opts.currency = code;
+  }
+  try {
+    return new Intl.NumberFormat("en-US", opts).format(n);
+  } catch {
+    // Malformed currency code — fall back to grouped decimal so no bare
+    // run of 10+ digits leaks to callers that use this for display.
+    return n.toLocaleString("en-US");
+  }
+}


### PR DESCRIPTION
## Summary

Regression of QUA-82. Release #4554 promoted the Database tab to a first-class tab on `/organizations/:slug`, which began exercising the embedded `EntityProfileViewer` through the `render-audit` e2e. The audit flagged raw 10+ digit numbers like `1700000000` on `/organizations/google-deepmind` and 14 values on `/organizations/meta-ai`.

Two fix paths, one PR:

- **Render-side (Database tab, `/things/[id]`, SearchDialog)**: extract `sanitizeRawLargeNumbers` into `apps/web/src/lib/format-compact.ts` and apply everywhere `things.description` surfaces. Also add a new `formatFactValueString` branch in `CellValue` so the `facts.value` text column formats pure-numeric strings (e.g. `"70000000000"` → `"$70B"`) honoring the sibling `currency` column.
- **Composer-side (`apps/wiki-server/src/routes/factbase/facts.ts`)**: the fact composer now runs `row.value` / `row.numeric` through a new `formatCompactAmount` helper before building `things.description`, so freshly-synced rows land formatted. The new helper's precision rule matches `apps/web/src/lib/format-compact.ts` so server-composed and client-rendered siblings agree (no more `$164.5B` next to `165B`). Intl formatters are cached per `(currency, fractionDigits)` tuple to avoid per-row allocation during batch sync.

No facts re-sync is required — the render-side sanitizer heals older stored descriptions at render time. New writes pick up the composer fix automatically.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 1649 web tests + 1402 wiki-server tests
- [x] `pnpm crux w validate gate --fix` — all 52 blocking checks pass
- [x] Unit tests for `formatCompactAmount`, `sanitizeRawLargeNumbers`, `formatFactValueString` (regex boundary cases: decimal tails, currency prefix, negatives, hashes; exact meta-ai regression values)
- [x] Unit tests for the fact composer (USD / GBP / non-currency / scientific notation / non-numeric / range / ref / null fallback)
- [x] Playwright render-audit against local dev server (prod data, slot a4 @ :3014) — `anthropic`, `openai`, `google-deepmind`, `meta-ai`, `microsoft` all pass; previously failing google-deepmind now green
- [ ] Post-merge: re-run `render-audit.spec.ts` against prod after deploy

Fixes QUA-673
