### PR TITLE
fix(sourcing): coerce sid_ to NULL in verdict display columns (QUA-661)

### DIFF
--- a/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
+++ b/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
@@ -20,6 +20,11 @@
 
 BEGIN;
 
+-- Use $DATABASE_MIGRATION_URL (unlimited statement_timeout) — the app pool
+-- has a 30s cap. If the script is run against $DATABASE_URL by mistake, drop
+-- the per-statement timeout for this transaction so the backfill completes.
+SET LOCAL statement_timeout = 0;
+
 -- ---------------------------------------------------------------------------
 -- Diagnostic: show count of leaked rows before the fix
 -- ---------------------------------------------------------------------------

--- a/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
+++ b/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
@@ -1,0 +1,87 @@
+-- backfill-sid-display-names-in-verdicts.sql (QUA-661)
+--
+-- Null out raw stableId (`sid_...`) values that leaked into
+-- `source_check_verdicts.display_name` / `entity_display_name`.
+--
+-- Display-name columns must hold human-readable names or NULL — never a raw
+-- `sid_`. When a sid_ lands here, the UI renders the opaque id verbatim and
+-- QUA-650's retro-scan can't evaluate subject-identity because its fallback
+-- claim label becomes the sid_ itself.
+--
+-- The PR that added this script (QUA-661) also introduced server-side
+-- coercion in POST /api/sourcing/verdicts that rejects `sid_` values before
+-- they land, so this is a one-shot cleanup for historical rows. Re-running
+-- the script is a no-op once rows are cleaned.
+--
+-- Idempotent. Safe to run multiple times.
+--
+-- Usage:
+--   psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Diagnostic: show count of leaked rows before the fix
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  display_name_leaks integer;
+  entity_display_name_leaks integer;
+BEGIN
+  SELECT COUNT(*) INTO display_name_leaks
+  FROM source_check_verdicts
+  WHERE display_name LIKE 'sid\_%' ESCAPE '\';
+
+  SELECT COUNT(*) INTO entity_display_name_leaks
+  FROM source_check_verdicts
+  WHERE entity_display_name LIKE 'sid\_%' ESCAPE '\';
+
+  RAISE NOTICE '=== Pre-fix State ===';
+  RAISE NOTICE 'Rows with sid_ in display_name: %', display_name_leaks;
+  RAISE NOTICE 'Rows with sid_ in entity_display_name: %', entity_display_name_leaks;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Clear leaked sid_ values from display_name
+-- ---------------------------------------------------------------------------
+-- LIKE 'sid\_%' ESCAPE '\' matches any value starting with the literal
+-- characters `sid_` (the underscore is escaped so it's treated literally,
+-- not as a single-char wildcard).
+
+UPDATE source_check_verdicts
+SET display_name = NULL,
+    updated_at = now()
+WHERE display_name LIKE 'sid\_%' ESCAPE '\';
+
+-- ---------------------------------------------------------------------------
+-- Clear leaked sid_ values from entity_display_name
+-- ---------------------------------------------------------------------------
+
+UPDATE source_check_verdicts
+SET entity_display_name = NULL,
+    updated_at = now()
+WHERE entity_display_name LIKE 'sid\_%' ESCAPE '\';
+
+-- ---------------------------------------------------------------------------
+-- Verify zero leaked rows remain
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  remaining integer;
+BEGIN
+  SELECT COUNT(*) INTO remaining
+  FROM source_check_verdicts
+  WHERE display_name LIKE 'sid\_%' ESCAPE '\'
+     OR entity_display_name LIKE 'sid\_%' ESCAPE '\';
+
+  RAISE NOTICE '=== Post-fix State ===';
+  RAISE NOTICE 'Remaining leaked rows: %', remaining;
+
+  IF remaining > 0 THEN
+    RAISE EXCEPTION 'Backfill failed: % rows still have sid_ values', remaining;
+  END IF;
+END $$;
+
+COMMIT;

--- a/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
+++ b/apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql
@@ -24,6 +24,9 @@ BEGIN;
 -- Diagnostic: show count of leaked rows before the fix
 -- ---------------------------------------------------------------------------
 
+-- Matches the server-side isSid() contract: anything starting with `sid_`.
+-- Use starts_with() (PG 11+) instead of LIKE with escape — cleaner, no
+-- dependency on standard_conforming_strings, and identical semantics to isSid.
 DO $$
 DECLARE
   display_name_leaks integer;
@@ -31,11 +34,11 @@ DECLARE
 BEGIN
   SELECT COUNT(*) INTO display_name_leaks
   FROM source_check_verdicts
-  WHERE display_name LIKE 'sid\_%' ESCAPE '\';
+  WHERE starts_with(display_name, 'sid_');
 
   SELECT COUNT(*) INTO entity_display_name_leaks
   FROM source_check_verdicts
-  WHERE entity_display_name LIKE 'sid\_%' ESCAPE '\';
+  WHERE starts_with(entity_display_name, 'sid_');
 
   RAISE NOTICE '=== Pre-fix State ===';
   RAISE NOTICE 'Rows with sid_ in display_name: %', display_name_leaks;
@@ -43,25 +46,20 @@ BEGIN
 END $$;
 
 -- ---------------------------------------------------------------------------
--- Clear leaked sid_ values from display_name
+-- Clear leaked sid_ values from display_name and entity_display_name
 -- ---------------------------------------------------------------------------
--- LIKE 'sid\_%' ESCAPE '\' matches any value starting with the literal
--- characters `sid_` (the underscore is escaped so it's treated literally,
--- not as a single-char wildcard).
+-- `updated_at` is intentionally NOT bumped: this is a display-name bookkeeping
+-- fix, not a verdict-content change. Bumping `updated_at` would make these
+-- rows appear "freshly computed" on dashboards that sort or filter by that
+-- column (stale-evidence, due-for-recheck, recent-activity).
 
 UPDATE source_check_verdicts
-SET display_name = NULL,
-    updated_at = now()
-WHERE display_name LIKE 'sid\_%' ESCAPE '\';
-
--- ---------------------------------------------------------------------------
--- Clear leaked sid_ values from entity_display_name
--- ---------------------------------------------------------------------------
+SET display_name = NULL
+WHERE starts_with(display_name, 'sid_');
 
 UPDATE source_check_verdicts
-SET entity_display_name = NULL,
-    updated_at = now()
-WHERE entity_display_name LIKE 'sid\_%' ESCAPE '\';
+SET entity_display_name = NULL
+WHERE starts_with(entity_display_name, 'sid_');
 
 -- ---------------------------------------------------------------------------
 -- Verify zero leaked rows remain
@@ -73,8 +71,8 @@ DECLARE
 BEGIN
   SELECT COUNT(*) INTO remaining
   FROM source_check_verdicts
-  WHERE display_name LIKE 'sid\_%' ESCAPE '\'
-     OR entity_display_name LIKE 'sid\_%' ESCAPE '\';
+  WHERE starts_with(display_name, 'sid_')
+     OR starts_with(entity_display_name, 'sid_');
 
   RAISE NOTICE '=== Post-fix State ===';
   RAISE NOTICE 'Remaining leaked rows: %', remaining;

--- a/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
@@ -13,11 +13,13 @@
  * the DB already has `needs_recheck: true` set).
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   shouldSkipAutoFlag,
   AUTO_FLAG_COOLDOWN_MS,
+  coerceDisplayName,
 } from "../routes/sourcing/sourcing.js";
+import { logger } from "../logger.js";
 
 // Re-parse the VerdictUpsertBody schema by importing it indirectly via a
 // known-good HTTP-level test would be ideal — but the schema is module-
@@ -110,5 +112,70 @@ describe("shouldSkipAutoFlag — cooldown helper (QUA-313)", () => {
     // diff is negative < cooldown → still skip (conservative).
     const updatedAt = new Date(now.getTime() + 60 * 1000); // 1 min in the future
     expect(shouldSkipAutoFlag(updatedAt, now)).toBe(true);
+  });
+});
+
+describe("coerceDisplayName — reject sid_ in display columns (QUA-661)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null unchanged", () => {
+    expect(coerceDisplayName(null, "displayName", "fact", "f_abc")).toBeNull();
+  });
+
+  it("passes through a human-readable name", () => {
+    expect(
+      coerceDisplayName("xAI", "entityDisplayName", "fact", "f_abc"),
+    ).toBe("xAI");
+  });
+
+  it("passes through a name that coincidentally contains 'sid' but isn't a sid_", () => {
+    expect(
+      coerceDisplayName("Consider this", "displayName", "fact", "f_abc"),
+    ).toBe("Consider this");
+    expect(
+      coerceDisplayName("sidwell-park", "displayName", "fact", "f_abc"),
+    ).toBe("sidwell-park");
+  });
+
+  it("coerces a raw stableId to null and logs a warning", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    const result = coerceDisplayName(
+      "sid_GLXKjYAEKw",
+      "entityDisplayName",
+      "fact",
+      "f_mwjUCVDWoA",
+    );
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [payload, message] = warnSpy.mock.calls[0];
+    expect(payload).toMatchObject({
+      field: "entityDisplayName",
+      value: "sid_GLXKjYAEKw",
+      recordType: "fact",
+      recordId: "f_mwjUCVDWoA",
+    });
+    expect(String(message)).toMatch(/entityDisplayName/);
+  });
+
+  it("coerces displayName sid_ to null, independent of entityDisplayName", () => {
+    vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    expect(
+      coerceDisplayName("sid_abcdefghij", "displayName", "grant", "g_1"),
+    ).toBeNull();
+  });
+
+  it("coerces ANY sid_-prefixed string (permissive — catches malformed stableIds too)", () => {
+    // isSid() only checks the prefix — we mirror that behavior so an upstream
+    // bug that writes `sid_<anything>` still gets nulled out at this layer
+    // instead of leaking into the display column.
+    vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    expect(
+      coerceDisplayName("sid_abcde", "displayName", "fact", "f_abc"),
+    ).toBeNull();
+    expect(
+      coerceDisplayName("sid_abcdefghij12345", "displayName", "fact", "f_abc"),
+    ).toBeNull();
   });
 });

--- a/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
@@ -116,18 +116,23 @@ describe("shouldSkipAutoFlag — cooldown helper (QUA-313)", () => {
 });
 
 describe("coerceDisplayName — reject sid_ in display columns (QUA-661)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
   });
 
-  it("returns null unchanged", () => {
+  it("returns null unchanged and does not log", () => {
     expect(coerceDisplayName(null, "displayName", "fact", "f_abc")).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("passes through a human-readable name", () => {
+  it("passes through a human-readable name without logging", () => {
     expect(
       coerceDisplayName("xAI", "entityDisplayName", "fact", "f_abc"),
     ).toBe("xAI");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("passes through a name that coincidentally contains 'sid' but isn't a sid_", () => {
@@ -137,10 +142,10 @@ describe("coerceDisplayName — reject sid_ in display columns (QUA-661)", () =>
     expect(
       coerceDisplayName("sidwell-park", "displayName", "fact", "f_abc"),
     ).toBe("sidwell-park");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("coerces a raw stableId to null and logs a warning", () => {
-    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
     const result = coerceDisplayName(
       "sid_GLXKjYAEKw",
       "entityDisplayName",
@@ -160,22 +165,22 @@ describe("coerceDisplayName — reject sid_ in display columns (QUA-661)", () =>
   });
 
   it("coerces displayName sid_ to null, independent of entityDisplayName", () => {
-    vi.spyOn(logger, "warn").mockImplementation(() => logger);
     expect(
       coerceDisplayName("sid_abcdefghij", "displayName", "grant", "g_1"),
     ).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it("coerces ANY sid_-prefixed string (permissive — catches malformed stableIds too)", () => {
     // isSid() only checks the prefix — we mirror that behavior so an upstream
     // bug that writes `sid_<anything>` still gets nulled out at this layer
     // instead of leaking into the display column.
-    vi.spyOn(logger, "warn").mockImplementation(() => logger);
     expect(
       coerceDisplayName("sid_abcde", "displayName", "fact", "f_abc"),
     ).toBeNull();
     expect(
       coerceDisplayName("sid_abcdefghij12345", "displayName", "fact", "f_abc"),
     ).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-verdicts.test.ts
@@ -17,8 +17,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   shouldSkipAutoFlag,
   AUTO_FLAG_COOLDOWN_MS,
-  coerceDisplayName,
 } from "../routes/sourcing/sourcing.js";
+import { coerceDisplayName } from "../routes/shared/display-name-coerce.js";
 import { logger } from "../logger.js";
 
 // Re-parse the VerdictUpsertBody schema by importing it indirectly via a

--- a/apps/wiki-server/src/routes/shared/display-name-coerce.ts
+++ b/apps/wiki-server/src/routes/shared/display-name-coerce.ts
@@ -1,0 +1,36 @@
+import { isSid } from "@longterm-wiki/id-utils";
+import { logger } from "../../logger.js";
+
+/**
+ * Coerce a candidate display-name value to NULL if it's a raw stableId
+ * (anything starting with `sid_`; see `isSid` in `@longterm-wiki/id-utils`).
+ *
+ * Display-name columns on `source_check_verdicts` must hold human-readable
+ * names or NULL — a raw `sid_` leaks to UI and defeats QUA-650's retro-scans
+ * that match on subject labels.
+ *
+ * When a sid_ is dropped, logs a warning identifying the record so the
+ * offending caller can be traced. The verdict is still written, just with
+ * NULL in the display column — an honest signal of "unknown name".
+ *
+ * Used by POST /api/sourcing/verdicts (sourcing.ts) and the citation-accuracy
+ * write path (wikibase/citations.ts). Any new write site for
+ * `source_check_verdicts.display_name` / `entity_display_name` must route
+ * through this helper.
+ */
+export function coerceDisplayName(
+  value: string | null,
+  fieldName: "displayName" | "entityDisplayName",
+  recordType: string,
+  recordId: string,
+): string | null {
+  if (value == null) return null;
+  if (isSid(value)) {
+    logger.warn(
+      { field: fieldName, value, recordType, recordId },
+      `Rejected sid_ in source_check_verdicts.${fieldName} — coerced to NULL`,
+    );
+    return null;
+  }
+  return value;
+}

--- a/apps/wiki-server/src/routes/shared/index.ts
+++ b/apps/wiki-server/src/routes/shared/index.ts
@@ -25,3 +25,4 @@ export { upsertThingsInTx, resolveEntityTitles, type ThingSyncInput } from "./th
 export { resolveEntityStableId } from "./entity-resolution.js";
 export { buildSearchCondition, parseSort, paginationMeta, type PaginationMeta } from "./query-helpers.js";
 export { validateEntityRefs, findMissingEntityRefs, type EntityRefField } from "./validate-entity-refs.js";
+export { coerceDisplayName } from "./display-name-coerce.js";

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -46,6 +46,8 @@ import {
   SOURCING_EXEMPT_TYPES,
   isSourcingExempt,
 } from "../../api-types.js";
+import { isSid } from "@longterm-wiki/id-utils";
+import { logger } from "../../logger.js";
 
 // ---- Constants ----
 
@@ -74,6 +76,36 @@ export function shouldSkipAutoFlag(
 ): boolean {
   if (updatedAt == null) return false;
   return now.getTime() - updatedAt.getTime() < cooldownMs;
+}
+
+/**
+ * QUA-661: coerce a candidate display-name value to NULL if it's a raw
+ * stableId (anything starting with `sid_`; see `isSid` in
+ * `@longterm-wiki/id-utils`). Display-name columns on `source_check_verdicts`
+ * must hold human-readable names or NULL — a raw `sid_` leaks to UI and
+ * defeats QUA-650's retro-scans that match on subject labels.
+ *
+ * When we drop a sid_, we log a warning identifying the record so the
+ * offending caller can be traced. The verdict is still written, just with
+ * NULL in the display column — an honest signal of "unknown name".
+ *
+ * Exported for unit tests.
+ */
+export function coerceDisplayName(
+  value: string | null,
+  fieldName: "displayName" | "entityDisplayName",
+  recordType: string,
+  recordId: string,
+): string | null {
+  if (value == null) return null;
+  if (isSid(value)) {
+    logger.warn(
+      { field: fieldName, value, recordType, recordId },
+      `Rejected sid_ in source_check_verdicts.${fieldName} — coerced to NULL`,
+    );
+    return null;
+  }
+  return value;
 }
 
 const VALID_VERDICTS = [
@@ -1257,8 +1289,23 @@ const sourcingApp = new Hono()
     // issues across PG versions with the postgres.js driver.
     const fieldNameVal = body.fieldName ?? null;
     const entityIdVal = body.entityId ?? null;
-    const displayNameVal = body.displayName ?? null;
-    const entityDisplayNameVal = body.entityDisplayName ?? null;
+    // QUA-661: coerce raw stableIds to NULL before persisting. Display-name
+    // columns must hold human-readable names or NULL — never a raw `sid_`.
+    // Callers that pass an unresolved sid_ get a NULL here (honest signal of
+    // "unknown") plus a warn-level log so the leak is traceable back to the
+    // source code path.
+    const displayNameVal = coerceDisplayName(
+      body.displayName ?? null,
+      "displayName",
+      body.recordType,
+      body.recordId,
+    );
+    const entityDisplayNameVal = coerceDisplayName(
+      body.entityDisplayName ?? null,
+      "entityDisplayName",
+      body.recordType,
+      body.recordId,
+    );
 
     // Use Drizzle ORM insert/update instead of raw SQL to avoid driver issues
     // with bare literals and COALESCE expressions.

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -46,8 +46,7 @@ import {
   SOURCING_EXEMPT_TYPES,
   isSourcingExempt,
 } from "../../api-types.js";
-import { isSid } from "@longterm-wiki/id-utils";
-import { logger } from "../../logger.js";
+import { coerceDisplayName } from "../shared/display-name-coerce.js";
 
 // ---- Constants ----
 
@@ -76,36 +75,6 @@ export function shouldSkipAutoFlag(
 ): boolean {
   if (updatedAt == null) return false;
   return now.getTime() - updatedAt.getTime() < cooldownMs;
-}
-
-/**
- * QUA-661: coerce a candidate display-name value to NULL if it's a raw
- * stableId (anything starting with `sid_`; see `isSid` in
- * `@longterm-wiki/id-utils`). Display-name columns on `source_check_verdicts`
- * must hold human-readable names or NULL — a raw `sid_` leaks to UI and
- * defeats QUA-650's retro-scans that match on subject labels.
- *
- * When we drop a sid_, we log a warning identifying the record so the
- * offending caller can be traced. The verdict is still written, just with
- * NULL in the display column — an honest signal of "unknown name".
- *
- * Exported for unit tests.
- */
-export function coerceDisplayName(
-  value: string | null,
-  fieldName: "displayName" | "entityDisplayName",
-  recordType: string,
-  recordId: string,
-): string | null {
-  if (value == null) return null;
-  if (isSid(value)) {
-    logger.warn(
-      { field: fieldName, value, recordType, recordId },
-      `Rejected sid_ in source_check_verdicts.${fieldName} — coerced to NULL`,
-    );
-    return null;
-  }
-  return value;
 }
 
 const VALID_VERDICTS = [

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -212,6 +212,13 @@ const VerdictsQuery = z.object({
   entity_id: z.string().max(200).optional(),
   needs_recheck: qBool.optional(),
   q: z.string().max(500).optional(),
+  /**
+   * QUA-661: when true, only return rows where `display_name` or
+   * `entity_display_name` is a raw `sid_`-prefixed stableId. Used by
+   * `validate-sid-display` to avoid paginating all ~14k verdict rows
+   * on every gate run.
+   */
+  display_name_is_sid: qBool.optional(),
   limit: defaultClampedLimit,
   offset: z.coerce.number().int().min(0).default(0),
 });
@@ -594,7 +601,7 @@ const sourcingApp = new Hono()
 
   // ---- GET /verdicts ----
   .get("/verdicts", zv("query", VerdictsQuery), async (c) => {
-    const { record_type, verdict, entity_id, needs_recheck, q, limit, offset } =
+    const { record_type, verdict, entity_id, needs_recheck, q, display_name_is_sid, limit, offset } =
       c.req.valid("query");
     const db = getDrizzleDb();
 
@@ -610,6 +617,13 @@ const sourcingApp = new Hono()
     }
     if (entity_id) {
       conditions.push(eq(sourceVerdicts.entityId, entity_id));
+    }
+    if (display_name_is_sid) {
+      // Matches the isSid() contract (prefix-only). Used by validate-sid-display
+      // (QUA-661) so the gate check doesn't scan all rows just to find zero leaks.
+      conditions.push(
+        sql`(starts_with(${sourceVerdicts.displayName}, 'sid_') OR starts_with(${sourceVerdicts.entityDisplayName}, 'sid_'))`
+      );
     }
     if (q) {
       const pattern = `%${escapeIlike(q)}%`;

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -25,7 +25,7 @@ import {
 } from "../../api-types.js";
 import { logger } from "../../logger.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
-import { coerceDisplayName } from "../sourcing/sourcing.js";
+import { coerceDisplayName } from "../shared/display-name-coerce.js";
 
 // ---- Constants ----
 
@@ -140,17 +140,11 @@ async function dualWriteToSourcing(
     }
   }
 
-  // QUA-661: coerce any sid_ value to NULL before persisting. `displayName` is
-  // synthesized from pageSlug so it's safe, but `entityDisplayName` is sourced
-  // from entities.title / wikiPages.title — if that ever contains a sid_
-  // (upstream data corruption), we want to null it out here, not leak it into
-  // the UI.
-  const safeDisplayName = coerceDisplayName(
-    displayName.slice(0, 500),
-    "displayName",
-    "citation",
-    recordId,
-  );
+  // QUA-661: `entityDisplayName` is sourced from entities.title / wikiPages.title
+  // — if either ever contains a sid_ (upstream data corruption), we want to null
+  // it out here, not leak it into the UI. The local `displayName` is synthesized
+  // as `[slug] fnN: ...` so it can't be a sid_ and doesn't need coercion.
+  const safeDisplayName = displayName.slice(0, 500);
   const safeEntityDisplayName = coerceDisplayName(
     entityDisplayName?.slice(0, 500) ?? null,
     "entityDisplayName",

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -25,6 +25,7 @@ import {
 } from "../../api-types.js";
 import { logger } from "../../logger.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
+import { coerceDisplayName } from "../sourcing/sourcing.js";
 
 // ---- Constants ----
 
@@ -139,12 +140,30 @@ async function dualWriteToSourcing(
     }
   }
 
+  // QUA-661: coerce any sid_ value to NULL before persisting. `displayName` is
+  // synthesized from pageSlug so it's safe, but `entityDisplayName` is sourced
+  // from entities.title / wikiPages.title — if that ever contains a sid_
+  // (upstream data corruption), we want to null it out here, not leak it into
+  // the UI.
+  const safeDisplayName = coerceDisplayName(
+    displayName.slice(0, 500),
+    "displayName",
+    "citation",
+    recordId,
+  );
+  const safeEntityDisplayName = coerceDisplayName(
+    entityDisplayName?.slice(0, 500) ?? null,
+    "entityDisplayName",
+    "citation",
+    recordId,
+  );
+
   const verdictUpdated = await tx
     .update(sourceVerdicts)
     .set({
       entityId,
-      displayName: displayName.slice(0, 500),
-      entityDisplayName: entityDisplayName?.slice(0, 500) ?? null,
+      displayName: safeDisplayName,
+      entityDisplayName: safeEntityDisplayName,
       verdict: mappedVerdict,
       confidence: params.accuracyScore,
       reasoning: params.issues ?? `Citation accuracy: ${params.accuracyVerdict}`,
@@ -164,8 +183,8 @@ async function dualWriteToSourcing(
     try {
       await tx.insert(sourceVerdicts).values({
         recordType: "citation", recordId, fieldName: null,
-        entityId, displayName: displayName.slice(0, 500),
-        entityDisplayName: entityDisplayName?.slice(0, 500) ?? null,
+        entityId, displayName: safeDisplayName,
+        entityDisplayName: safeEntityDisplayName,
         verdict: mappedVerdict, confidence: params.accuracyScore,
         reasoning: params.issues ?? `Citation accuracy: ${params.accuracyVerdict}`,
         sourcesChecked: 1, needsRecheck: false,

--- a/crux/validate/validate-sid-display.test.ts
+++ b/crux/validate/validate-sid-display.test.ts
@@ -347,6 +347,60 @@ describe("validateAllTables", () => {
     expect(results[0].displayErrors).toHaveLength(0);
   });
 
+  it("detects sid_ leak in source_check_verdicts using composite recordIdExtractor (QUA-661)", async () => {
+    mockFetchAllRecords.mockResolvedValue([
+      {
+        // No `id` column — identity is (recordType, recordId[, fieldName])
+        recordType: "fact",
+        recordId: "f_mwjUCVDWoA",
+        fieldName: null,
+        entityId: "sid_GLXKjYAEKw",
+        displayName: "sid_GLXKjYAEKw",        // leaked
+        entityDisplayName: "sid_GLXKjYAEKw", // leaked
+        verdict: "confirmed",
+      },
+      {
+        // Clean row — both display names are human-readable
+        recordType: "fact",
+        recordId: "f_2",
+        fieldName: "position",
+        entityId: "sid_anthropic",
+        displayName: "CEO fact",
+        entityDisplayName: "Anthropic",
+        verdict: "confirmed",
+      },
+    ]);
+
+    const specs = [
+      {
+        apiPath: "/api/sourcing/verdicts",
+        responseKey: "verdicts",
+        displayFields: [
+          { displayField: "displayName" },
+          { displayField: "entityDisplayName" },
+        ],
+        idFields: [],
+        maxLimit: 200,
+        recordIdExtractor: (record: Record<string, unknown>) =>
+          `${String(record.recordType ?? "unknown")}/${String(record.recordId ?? "unknown")}${record.fieldName ? `[${String(record.fieldName)}]` : ""}`,
+      },
+    ];
+
+    const results = await validateAllTables(specs);
+    expect(results).toHaveLength(1);
+    expect(results[0].displayErrors).toHaveLength(2);
+    // Both errors reference the same composite recordId since they're on the
+    // same row.
+    expect(results[0].displayErrors[0].recordId).toBe("fact/f_mwjUCVDWoA");
+    expect(results[0].displayErrors[0].field).toBe("displayName");
+    expect(results[0].displayErrors[0].value).toBe("sid_GLXKjYAEKw");
+    expect(results[0].displayErrors[1].recordId).toBe("fact/f_mwjUCVDWoA");
+    expect(results[0].displayErrors[1].field).toBe("entityDisplayName");
+    expect(results[0].displayErrors[1].value).toBe("sid_GLXKjYAEKw");
+    // The clean row is not flagged.
+    expect(results[0].idWarnings).toHaveLength(0);
+  });
+
   it("detects both display errors and ID warnings on the same record", async () => {
     mockFetchAllRecords.mockResolvedValue([
       {

--- a/crux/validate/validate-sid-display.test.ts
+++ b/crux/validate/validate-sid-display.test.ts
@@ -347,6 +347,38 @@ describe("validateAllTables", () => {
     expect(results[0].displayErrors).toHaveLength(0);
   });
 
+  it("recordIdExtractor treats empty-string fieldName as no fieldName (QUA-661)", async () => {
+    mockFetchAllRecords.mockResolvedValue([
+      {
+        recordType: "fact",
+        recordId: "f_empty",
+        fieldName: "", // empty string — should NOT produce a [] suffix
+        displayName: "sid_LEAK",
+        verdict: "confirmed",
+      },
+    ]);
+
+    const specs = [
+      {
+        apiPath: "/api/sourcing/verdicts",
+        responseKey: "verdicts",
+        displayFields: [{ displayField: "displayName" }],
+        idFields: [],
+        maxLimit: 200,
+        recordIdExtractor: (record: Record<string, unknown>) => {
+          const base = `${String(record.recordType ?? "unknown")}/${String(record.recordId ?? "unknown")}`;
+          return record.fieldName != null && record.fieldName !== ""
+            ? `${base}[${String(record.fieldName)}]`
+            : base;
+        },
+      },
+    ];
+
+    const results = await validateAllTables(specs);
+    expect(results[0].displayErrors).toHaveLength(1);
+    expect(results[0].displayErrors[0].recordId).toBe("fact/f_empty");
+  });
+
   it("detects sid_ leak in source_check_verdicts using composite recordIdExtractor (QUA-661)", async () => {
     mockFetchAllRecords.mockResolvedValue([
       {

--- a/crux/validate/validate-sid-display.ts
+++ b/crux/validate/validate-sid-display.ts
@@ -185,7 +185,10 @@ export const TABLE_DISPLAY_SPECS: TableDisplaySpec[] = [
     // coerces sid_ to NULL on write, but this validator catches any historical
     // rows written before that protection, or future write paths that bypass
     // the POST /verdicts endpoint.
-    apiPath: "/api/sourcing/verdicts",
+    //
+    // `display_name_is_sid=true` pushes the filter to the server so we only
+    // paginate the (typically zero) leaked rows — not all ~14k verdict rows.
+    apiPath: "/api/sourcing/verdicts?display_name_is_sid=true",
     responseKey: "verdicts",
     displayFields: [
       { displayField: "displayName" },

--- a/crux/validate/validate-sid-display.ts
+++ b/crux/validate/validate-sid-display.ts
@@ -199,8 +199,12 @@ export const TABLE_DISPLAY_SPECS: TableDisplaySpec[] = [
     // it as an ID warning.
     idFields: [],
     maxLimit: 200,
-    recordIdExtractor: (record) =>
-      `${String(record.recordType ?? "unknown")}/${String(record.recordId ?? "unknown")}${record.fieldName ? `[${String(record.fieldName)}]` : ""}`,
+    recordIdExtractor: (record) => {
+      const base = `${String(record.recordType ?? "unknown")}/${String(record.recordId ?? "unknown")}`;
+      return record.fieldName != null && record.fieldName !== ""
+        ? `${base}[${String(record.fieldName)}]`
+        : base;
+    },
   },
 ];
 

--- a/crux/validate/validate-sid-display.ts
+++ b/crux/validate/validate-sid-display.ts
@@ -9,13 +9,14 @@
  * or be NULL. This validator catches cases where the enrichment pipeline
  * incorrectly stores a stableId as a display name.
  *
- * Checks all 6 tables with display name columns:
+ * Checks all 7 tables with display name columns:
  * - personnel: person_display_name, org_display_name
  * - grants: grantee_display_name, org_display_name
  * - funding_rounds: company_display_name, lead_investor_display_name
  * - investments: company_display_name, investor_display_name
  * - equity_positions: company_display_name, holder_display_name
  * - entity_events: entity_display_name
+ * - source_check_verdicts: display_name, entity_display_name (QUA-661)
  *
  * Also checks that raw ID fields (person_id, grantee_id, etc.) that contain
  * sid_-prefixed values have a resolved entity FK.
@@ -95,6 +96,12 @@ interface TableDisplaySpec {
   displayFields: DisplayFieldSpec[];
   idFields: IdFieldSpec[];
   maxLimit?: number;
+  /**
+   * Optional custom record ID extractor. Defaults to `record.id`. Used for
+   * tables like `source_check_verdicts` where the identity is a composite
+   * (recordType, recordId, fieldName) instead of a single `id` column.
+   */
+  recordIdExtractor?: (record: Record<string, unknown>) => string;
 }
 
 export const TABLE_DISPLAY_SPECS: TableDisplaySpec[] = [
@@ -173,6 +180,25 @@ export const TABLE_DISPLAY_SPECS: TableDisplaySpec[] = [
     idFields: [],
     maxLimit: 200,
   },
+  {
+    // QUA-661: catch sid_ leaks into verdict display columns. The server
+    // coerces sid_ to NULL on write, but this validator catches any historical
+    // rows written before that protection, or future write paths that bypass
+    // the POST /verdicts endpoint.
+    apiPath: "/api/sourcing/verdicts",
+    responseKey: "verdicts",
+    displayFields: [
+      { displayField: "displayName" },
+      { displayField: "entityDisplayName" },
+    ],
+    // source_check_verdicts has no resolved-FK columns — entityId is the
+    // only ID-shaped column and is meant to hold a sid_, so we don't treat
+    // it as an ID warning.
+    idFields: [],
+    maxLimit: 200,
+    recordIdExtractor: (record) =>
+      `${String(record.recordType ?? "unknown")}/${String(record.recordId ?? "unknown")}${record.fieldName ? `[${String(record.fieldName)}]` : ""}`,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -205,7 +231,9 @@ export async function validateTableDisplay(
   result.totalRecords = records.length;
 
   for (const record of records) {
-    const recordId = String(record.id ?? "unknown");
+    const recordId = spec.recordIdExtractor
+      ? spec.recordIdExtractor(record)
+      : String(record.id ?? "unknown");
 
     // Check display name columns for sid_ values — always an error
     for (const { displayField } of spec.displayFields) {


### PR DESCRIPTION
## Summary

Fixes [QUA-661](https://linear.app/quantifieduncertainty/issue/QUA-661): `source_check_verdicts.display_name` / `entity_display_name` were persisting raw `sid_...` stableIds where human-readable names belong. The UI renders the opaque id verbatim, and QUA-650's retro-scan skips affected rows because its claim-subject fallback falls all the way through to the `sid_`.

Applies defense in depth:

- **Coerce at the write boundary**: `coerceDisplayName` nulls out any `sid_`-prefixed value on the way into `source_check_verdicts`, and logs a warning naming the offending caller so the leak is traceable. Applied in POST `/api/sourcing/verdicts` and in the citation-accuracy write path (`upsertCitationVerdict`) — the two write sites that set these columns.
- **Catch historical rows**: `validate-sid-display` now covers `source_check_verdicts.display_name` / `entity_display_name`. A new `display_name_is_sid=true` filter on GET `/api/sourcing/verdicts` pushes the predicate into PG via `starts_with(...)`, so the gate check pays one round-trip in steady state instead of paginating all 14k rows.
- **Backfill existing leaks**: idempotent SQL script under `apps/wiki-server/scripts/` (deploy task auto-detected; see checklist below).

Scanned prod via the new filter at write time: **0 leaked rows across 13,851 verdicts** (the original xAI examples in the ticket had `displayName`/`entityDisplayName = NULL` with `entityId = sid_GLXKjYAEKw`, which is not a display-column leak — the retro-scan's fallback-to-entityId surfaces them regardless; unchanged by this PR).

## Key changes

- `apps/wiki-server/src/routes/sourcing/sourcing.ts` — add `coerceDisplayName` helper; apply in POST `/verdicts`; add `display_name_is_sid` filter to GET `/verdicts`.
- `apps/wiki-server/src/routes/wikibase/citations.ts` — route `upsertCitationVerdict` through `coerceDisplayName` so the citation path can't bypass the chokepoint.
- `crux/validate/validate-sid-display.ts` — add `source_check_verdicts` entry to `TABLE_DISPLAY_SPECS` with composite `recordIdExtractor`; use the new server-side filter.
- `apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql` — one-shot idempotent cleanup using `starts_with(col, 'sid_')`. Does not bump `updated_at` (pure display-name bookkeeping shouldn't look like a recomputed verdict on dashboards).

## Test plan

- [x] `coerceDisplayName` unit tests: null, human-readable, coincidental "sid" substring, canonical `sid_+10`, malformed `sid_`, verifies `logger.warn` is/isn't called as appropriate
- [x] Validator test with composite `recordIdExtractor` — leaked and clean rows
- [x] Full sourcing test suite (88 tests), citations test suite, plus validator test suite — all pass
- [x] TSC clean (wiki-server + crux)
- [x] Prod probe via new filter: 0 display-name leaks across 13,851 verdicts
- [x] `/agent-review-pr` completed — 1 HIGH finding (bypass write path in `citations.ts`) fixed before ship; 1 efficiency finding (full-table scan on every gate run) fixed via server-side filter
- [x] `/simplify` completed

<!-- deploy-tasks:v1 -->
## Deploy Checklist

- [ ] `manual` Run manual migration: `psql "$DATABASE_MIGRATION_URL" -f apps/wiki-server/scripts/backfill-sid-display-names-in-verdicts.sql` — idempotent, safe to re-run; expect `Pre-fix State` rows (display_name_leaks, entity_display_name_leaks) to log before and `Remaining leaked rows: 0` after.
- [ ] `manual` Verify the server-side coercion is live in prod: `curl -H "Authorization: Bearer $KEY" "https://wiki-server.k8s.quantifieduncertainty.org/api/sourcing/verdicts?display_name_is_sid=true&limit=5"` — expect `total: 0` once the backfill has run and new writes are coerced.
<!-- /deploy-tasks:v1 -->

Closes QUA-661.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sanitization of verdict records to prevent display of internal identifiers
  * Backfilled historical data to clean up leaked identifier values

* **Tests**
  * Added test coverage for display name sanitization logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->