### PR TITLE
Fix tablebase enrichment manifest format — preserve temporal/lead fields (QUA-672)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -17,6 +17,7 @@
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
 import type { TaskType } from '../tablebase/types.ts';
 import { TASK_TYPES, toSlug } from '../tablebase/types.ts';
+import { summarizeRecordForManifest } from '../tablebase/manifest-record.ts';
 
 // Consolidated orphan domain imports
 import { commands as backfillGranteeIdsCommands } from './backfill-grantee-ids.ts';
@@ -503,22 +504,9 @@ async function submitCommand(args: string[], options: CommandOptions): Promise<C
         }).length,
       },
     },
-    records: recordsToSubmit.map((r: Record<string, unknown>) => {
-      const summary: Record<string, unknown> = { id: r.id };
-      if (r.personId) summary.personId = r.personId;
-      if (r.organizationId) summary.organizationId = r.organizationId;
-      if (r.role) summary.role = r.role;
-      if (r.name || r.title) summary.name = r.name || r.title;
-      if (r.source) summary.source = r.source;
-      if (r.sourcing) {
-        const v = r.sourcing as Record<string, unknown>;
-        summary.verdict = v.verdict;
-        summary.evidence = v.evidence;
-      } else {
-        summary.verdict = 'none';
-      }
-      return summary;
-    }),
+    records: recordsToSubmit.map((r: Record<string, unknown>) =>
+      summarizeRecordForManifest(r),
+    ),
   };
 
   await fsPromises.writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n');

--- a/crux/tablebase/manifest-record.test.ts
+++ b/crux/tablebase/manifest-record.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeRecordForManifest } from './manifest-record.ts';
+
+describe('summarizeRecordForManifest (QUA-672)', () => {
+  it('preserves temporal fields on personnel records (the original bug)', () => {
+    const r = {
+      id: 'abc1234567',
+      personId: 'p_xyz',
+      organizationId: 'sid_org',
+      role: 'President of Global Affairs',
+      roleType: 'key-person',
+      startDate: '2024-05',
+      endDate: '2025-01',
+      isFounder: false,
+      source: 'https://example.com',
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.startDate).toBe('2024-05');
+    expect(summary.endDate).toBe('2025-01');
+    expect(summary.roleType).toBe('key-person');
+    expect(summary.isFounder).toBe(false);
+    expect(summary.role).toBe('President of Global Affairs');
+  });
+
+  it('preserves division-specific fields (lead, divisionType, status, dates)', () => {
+    const r = {
+      id: 'div1234567',
+      parentOrgId: 'sid_org',
+      name: 'Safety Team',
+      divisionType: 'team',
+      lead: 'Jane Doe',
+      status: 'active',
+      startDate: '2023-06',
+      endDate: null,
+      source: 'https://example.com',
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.lead).toBe('Jane Doe');
+    expect(summary.divisionType).toBe('team');
+    expect(summary.status).toBe('active');
+    expect(summary.startDate).toBe('2023-06');
+    expect(summary.endDate).toBeUndefined(); // null was dropped
+  });
+
+  it('drops null and undefined fields', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      personId: 'p_xyz',
+      role: 'CEO',
+      endDate: null,
+      background: undefined,
+      isFounder: false, // false is NOT null/undefined → kept
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.endDate).toBeUndefined();
+    expect('endDate' in summary).toBe(false);
+    expect(summary.background).toBeUndefined();
+    expect('background' in summary).toBe(false);
+    expect(summary.isFounder).toBe(false);
+  });
+
+  it('truncates long freetext fields with an indicator', () => {
+    const longText = 'x'.repeat(500);
+    const r = {
+      id: 'a1b2c3d4e5',
+      role: 'CEO',
+      notes: longText,
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(typeof summary.notes).toBe('string');
+    expect((summary.notes as string).length).toBeLessThan(500);
+    expect(summary.notes).toContain('… [truncated, 200 more chars]');
+  });
+
+  it('does not truncate freetext fields under 300 chars', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      notes: 'short note',
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.notes).toBe('short note');
+  });
+
+  it('hoists sourcing.verdict and sourcing.evidence to top level', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      role: 'CEO',
+      sourcing: {
+        verdict: 'confirmed',
+        evidence: 'Confirmed by official press release',
+        confidence: 0.95,
+        sourceContentHash: 'abcdef',
+        checkedAt: '2026-04-24T00:00:00Z',
+      },
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.verdict).toBe('confirmed');
+    expect(summary.evidence).toBe('Confirmed by official press release');
+    expect(summary.confidence).toBe(0.95);
+    // The inner sourcing object should NOT be in the summary
+    expect(summary.sourcing).toBeUndefined();
+  });
+
+  it('truncates long evidence strings', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      sourcing: {
+        verdict: 'confirmed',
+        evidence: 'y'.repeat(500),
+      },
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect((summary.evidence as string).length).toBeLessThan(500);
+    expect(summary.evidence).toContain('… [truncated');
+  });
+
+  it("emits verdict: 'none' when no sourcing object is present", () => {
+    const r = { id: 'a1b2c3d4e5', role: 'Engineer' };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.verdict).toBe('none');
+  });
+
+  it('drops claimIds (internal IDs, not human-useful)', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      role: 'CEO',
+      claimIds: [101, 102, 103],
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.claimIds).toBeUndefined();
+  });
+
+  it('handles empty record gracefully', () => {
+    const summary = summarizeRecordForManifest({});
+    expect(summary).toEqual({ verdict: 'none' });
+  });
+
+  it('does not truncate non-string freetext fields (e.g. object notes)', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      notes: { structured: 'data' }, // pathological — should pass through unchanged
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.notes).toEqual({ structured: 'data' });
+  });
+
+  it('preserves both startDate and endDate when both are populated (regression for #4550 false-positive)', () => {
+    // Reproduces the exact CodeRabbit false-positive class on Nick Clegg / GPAI records.
+    const r = {
+      id: 'JhM3kFxq71',
+      personId: 'sid_clegg',
+      organizationId: 'sid_meta',
+      role: 'President of Global Affairs',
+      roleType: 'key-person',
+      startDate: '2024-05',
+      endDate: '2025-01',
+      isFounder: false,
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary).toMatchObject({
+      startDate: '2024-05',
+      endDate: '2025-01',
+    });
+  });
+
+  it('handles sourcing without evidence (verdict-only)', () => {
+    const r = {
+      id: 'a1b2c3d4e5',
+      sourcing: { verdict: 'unverifiable' },
+    };
+    const summary = summarizeRecordForManifest(r);
+    expect(summary.verdict).toBe('unverifiable');
+    expect('evidence' in summary).toBe(false);
+  });
+});

--- a/crux/tablebase/manifest-record.ts
+++ b/crux/tablebase/manifest-record.ts
@@ -1,66 +1,44 @@
 /**
- * Manifest record summarization (QUA-672).
+ * Build the per-record summary written to `data/tablebase-manifests/*.json`.
  *
- * Takes a record submitted to a `/sync` endpoint and returns a
- * human-readable summary for `data/tablebase-manifests/*.json`.
- *
- * Design rationale: the manifest is the audit trail reviewers see in PRs.
- * Earlier versions only kept a hand-picked allowlist of fields (id, role,
- * source, verdict) which omitted temporal fields like startDate/endDate
- * and triggered CodeRabbit "missing endDate" false-positives even when the
- * actual data on prod was correct. We now spread the full record, with
- * two transformations:
- *
- *   1. Long freetext fields are truncated so the manifest stays diff-able.
- *   2. The inline `sourcing` object is hoisted: verdict + evidence + confidence
- *      become top-level fields so reviewers don't have to drill in.
- *
- * Fields stored as null/undefined are dropped to keep manifests compact.
+ * Spreads every non-null field of the submitted record so reviewers can see
+ * temporal/lead/status fields directly, truncates a few bloat-prone freetext
+ * columns, and hoists `sourcing.{verdict,evidence,confidence}` to the top
+ * level. See QUA-672 for context.
  */
 
-const TRUNCATE_FIELDS = ['notes', 'background', 'description'] as const;
+const TRUNCATE_FIELDS = new Set(['notes', 'background', 'description']);
 const TRUNCATE_AT = 300;
 
-function truncateIfLong(value: unknown): unknown {
-  if (typeof value !== 'string') return value;
-  if (value.length <= TRUNCATE_AT) return value;
-  return `${value.slice(0, TRUNCATE_AT)}… [truncated, ${value.length - TRUNCATE_AT} more chars]`;
+function truncate(s: string): string {
+  if (s.length <= TRUNCATE_AT) return s;
+  return `${s.slice(0, TRUNCATE_AT)}… [truncated, ${s.length - TRUNCATE_AT} more chars]`;
 }
 
-/**
- * Build the manifest summary for a single submitted record.
- *
- * Always emits `id` first and `verdict` last (or 'none' when no sourcing
- * was attached) for stable diffs.
- */
+function truncateIfString(value: unknown): unknown {
+  return typeof value === 'string' ? truncate(value) : value;
+}
+
 export function summarizeRecordForManifest(
   r: Record<string, unknown>,
 ): Record<string, unknown> {
   const summary: Record<string, unknown> = {};
 
-  // 1. Spread non-null/undefined record fields, with truncation for bloat-prone freetext.
-  //    Skip `sourcing` and `claimIds` here — they're handled separately.
   for (const [key, value] of Object.entries(r)) {
     if (key === 'sourcing' || key === 'claimIds') continue;
     if (value === null || value === undefined) continue;
-    if ((TRUNCATE_FIELDS as readonly string[]).includes(key)) {
-      summary[key] = truncateIfLong(value);
-    } else {
-      summary[key] = value;
-    }
+    summary[key] = TRUNCATE_FIELDS.has(key) ? truncateIfString(value) : value;
   }
 
-  // 2. Hoist sourcing fields. Trim evidence the same way as freetext.
-  if (r.sourcing && typeof r.sourcing === 'object') {
-    const v = r.sourcing as Record<string, unknown>;
-    summary.verdict = v.verdict;
-    if (v.evidence !== undefined && v.evidence !== null) {
-      summary.evidence = truncateIfLong(v.evidence);
-    }
-    if (typeof v.confidence === 'number') {
-      summary.confidence = v.confidence;
-    }
+  const sourcing = r.sourcing;
+  if (sourcing && typeof sourcing === 'object') {
+    const s = sourcing as Record<string, unknown>;
+    summary.verdict = s.verdict;
+    if (typeof s.evidence === 'string') summary.evidence = truncate(s.evidence);
+    if (typeof s.confidence === 'number') summary.confidence = s.confidence;
   } else {
+    // Backward-compat: existing manifests use 'none' for absent sourcing;
+    // validate-sourcing-coverage and PR reviewers both rely on this sentinel.
     summary.verdict = 'none';
   }
 

--- a/crux/tablebase/manifest-record.ts
+++ b/crux/tablebase/manifest-record.ts
@@ -1,0 +1,68 @@
+/**
+ * Manifest record summarization (QUA-672).
+ *
+ * Takes a record submitted to a `/sync` endpoint and returns a
+ * human-readable summary for `data/tablebase-manifests/*.json`.
+ *
+ * Design rationale: the manifest is the audit trail reviewers see in PRs.
+ * Earlier versions only kept a hand-picked allowlist of fields (id, role,
+ * source, verdict) which omitted temporal fields like startDate/endDate
+ * and triggered CodeRabbit "missing endDate" false-positives even when the
+ * actual data on prod was correct. We now spread the full record, with
+ * two transformations:
+ *
+ *   1. Long freetext fields are truncated so the manifest stays diff-able.
+ *   2. The inline `sourcing` object is hoisted: verdict + evidence + confidence
+ *      become top-level fields so reviewers don't have to drill in.
+ *
+ * Fields stored as null/undefined are dropped to keep manifests compact.
+ */
+
+const TRUNCATE_FIELDS = ['notes', 'background', 'description'] as const;
+const TRUNCATE_AT = 300;
+
+function truncateIfLong(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  if (value.length <= TRUNCATE_AT) return value;
+  return `${value.slice(0, TRUNCATE_AT)}… [truncated, ${value.length - TRUNCATE_AT} more chars]`;
+}
+
+/**
+ * Build the manifest summary for a single submitted record.
+ *
+ * Always emits `id` first and `verdict` last (or 'none' when no sourcing
+ * was attached) for stable diffs.
+ */
+export function summarizeRecordForManifest(
+  r: Record<string, unknown>,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+
+  // 1. Spread non-null/undefined record fields, with truncation for bloat-prone freetext.
+  //    Skip `sourcing` and `claimIds` here — they're handled separately.
+  for (const [key, value] of Object.entries(r)) {
+    if (key === 'sourcing' || key === 'claimIds') continue;
+    if (value === null || value === undefined) continue;
+    if ((TRUNCATE_FIELDS as readonly string[]).includes(key)) {
+      summary[key] = truncateIfLong(value);
+    } else {
+      summary[key] = value;
+    }
+  }
+
+  // 2. Hoist sourcing fields. Trim evidence the same way as freetext.
+  if (r.sourcing && typeof r.sourcing === 'object') {
+    const v = r.sourcing as Record<string, unknown>;
+    summary.verdict = v.verdict;
+    if (v.evidence !== undefined && v.evidence !== null) {
+      summary.evidence = truncateIfLong(v.evidence);
+    }
+    if (typeof v.confidence === 'number') {
+      summary.confidence = v.confidence;
+    }
+  } else {
+    summary.verdict = 'none';
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## Summary

The tablebase enrichment manifest writer (`crux/commands/tablebase.ts`) was emitting a hand-picked allowlist of fields per record (`id`, `personId`, `organizationId`, `role`, `source`, `verdict`) and silently dropping everything else. CodeRabbit flagged "missing endDate" on PR #4550 (Nick Clegg + 4 GPAI records) when those fields were actually populated correctly on prod — they were just invisible in the manifest.

Replace the allowlist with a generic spread that:
- includes every non-null/undefined field from the submitted record
- truncates 3 known-bloaty freetext fields (`notes`, `background`, `description`) at 300 chars
- hoists `sourcing.{verdict, evidence, confidence}` to the top level
- drops `claimIds` (internal numeric IDs, not human-useful)
- emits `verdict: 'none'` when no sourcing was attached (preserves backward-compat with `validate-sourcing-coverage`)

Extracted into `crux/tablebase/manifest-record.ts` with 13 unit tests.

## Acceptance criteria (from QUA-672)

- [x] Manifest format includes `startDate` / `endDate` for personnel records
- [x] Manifest format includes `lead`, `divisionType`, `status`, `startDate`, `endDate` for divisions
- [x] PR-review smoke test: regression test in `manifest-record.test.ts` reproduces the exact Nick Clegg / GPAI false-positive class
- [ ] No CodeRabbit false-positives on the next enrichment PR for the same class (verifies on next merge)

## Test plan

- [x] `npx vitest run tablebase/manifest-record.test.ts` — 13 tests pass
- [x] `pnpm test` — all 1411 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm crux w validate gate --fix` — all 54 checks pass
- [x] `/agent-review-pr` ran — no findings, build/types/gate green
- [x] `/simplify` ran — applied: `Set` lookup, narrowed `truncate` signature, trimmed comments

## Followup filed

- QUA-678 — consolidate ~25 `truncate()` / `truncateText()` helpers across `crux/` (deferred from /simplify)

Closes QUA-672
