### PR TITLE
wire tablebase loop to /api/enrichment/propose (QUA-655)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -43,6 +43,8 @@ interface CommandOptions extends BaseOptions {
   /** Required when --skipEntityValidation is set. */
   skipEntityValidationReason?: string;
   skipSourcing?: boolean;
+  /** QUA-655: route supported record types through `/api/enrichment/propose` */
+  viaPropose?: boolean;
   fix?: boolean;
   apply?: boolean;
   max?: string;
@@ -1123,6 +1125,7 @@ async function loopCommand(_args: string[], options: CommandOptions): Promise<Co
     entityTypes,
     model,
     skipSourcing: !!options.skipSourcing,
+    viaPropose: !!options.viaPropose,
   });
 
   if (options.ci) {
@@ -1577,6 +1580,8 @@ Options:
   --model=<name>            LLM model: haiku, sonnet, opus, or auto (tier by task type)
   --records-file=<path>     JSON file for submit command
   --skip-sourcing       Skip sourcing before submit (for testing)
+  --via-propose             Route supported record types (grants, Phase 1) through
+                            /api/enrichment/propose instead of direct /sync (QUA-655)
   --apply                   For source-discover: also link discovered resources to records
   --v2                      For source-discover: use claims-first agent (extracts + submits claims)
   --claims-only             For source-discover --v2: submit claims but don't apply results
@@ -1615,6 +1620,7 @@ Examples:
   crux tb tablebase loop --max=3 --budget=10               # 3-task loop with $10 cap
   crux tb tablebase loop --model=auto --max=20             # Auto-tier: haiku for simple, sonnet for complex
   crux tb tablebase loop --model=haiku --task-type=benchmark-result-fill  # All-haiku for benchmarks
+  crux tb tablebase loop --via-propose --task-type=grant-grantee-backfill  # Route grants through /propose (QUA-655)
   crux tb tablebase sourcing-records --table=personnel --source=deterministic  # Fast structural checks
   crux tb tablebase sourcing-records --table=personnel --source=batch --limit=100  # LLM check 100 records
   crux tb tablebase sourcing-records --table=personnel --source=all   # Full sourcing

--- a/crux/lib/wiki-server/enrichment.ts
+++ b/crux/lib/wiki-server/enrichment.ts
@@ -1,0 +1,117 @@
+/**
+ * Enrichment API — wiki-server client module (QUA-655).
+ *
+ * Typed RPC client for `POST /api/enrichment/propose` — the defensive
+ * enrichment gate shipped in QUA-632 Phase 1 (PR #4527). Used by the
+ * tablebase loop (`crux tb tablebase loop --via-propose`) to route writes
+ * through the server-validated tier gate instead of direct `/sync` calls.
+ *
+ * Response types are inferred from the Hono RPC route type via
+ * `InferResponseType<>`, matching the pattern in sibling files
+ * (`benchmark-results.ts`, `sourcing-client.ts`, etc.).
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { EnrichmentRoute } from '../../../apps/wiki-server/src/routes/enrichment/enrichment.ts';
+import { checkT1Authority } from '../../../apps/wiki-server/src/routes/enrichment/t1-allowlist.ts';
+
+// ---------------------------------------------------------------------------
+// Types — inferred from the Hono RPC route
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<EnrichmentRoute>>;
+
+/** Response body when `/propose` accepts a record (HTTP 200). */
+export type ProposeAcceptedResponse = InferResponseType<
+  RpcClient['propose']['$post'],
+  200
+>;
+
+/** Response body when `/propose` rejects (HTTP 400). */
+export type ProposeRejectedResponse = InferResponseType<
+  RpcClient['propose']['$post'],
+  400
+>;
+
+/** Record types the endpoint currently accepts. Keep in sync with
+ *  `SUPPORTED_RECORD_TYPES` in `apps/wiki-server/src/routes/enrichment/enrichment.ts`. */
+export type SupportedRecordType =
+  | 'grants'
+  | 'personnel'
+  | 'funding-rounds'
+  | 'benchmark-results';
+
+export type EnrichmentTier = 'T1' | 'T2' | 'T3';
+
+// ---------------------------------------------------------------------------
+// Request payload
+// ---------------------------------------------------------------------------
+
+/**
+ * Body of `POST /api/enrichment/propose`. Shape matches the server's
+ * `ProposeRequestSchema`. Kept as a plain interface rather than re-exported
+ * from the Zod schema so crux can build requests without pulling in Zod
+ * at runtime.
+ */
+export interface ProposeRequest {
+  tier: EnrichmentTier;
+  recordType: SupportedRecordType;
+  /** The record payload (shape validated by the per-type sync handler). */
+  row: Record<string, unknown>;
+  sourceUrl: string;
+  sourceContentHash?: string;
+
+  // T2/T3 fields (ignored for T1)
+  verdict?: 'confirmed' | 'contradicted' | 'outdated' | 'partial' | 'unverifiable';
+  confidence?: number;
+  quotedText?: string;
+  reasoning?: string;
+  sourceContent?: string;
+  checkerModel?: string;
+
+  runId?: string;
+  /** Phase-1 endpoint rejects non-null `fieldName`. Always send null/undefined. */
+  fieldName?: null;
+}
+
+// ---------------------------------------------------------------------------
+// API function
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit one record through the enrichment gate.
+ *
+ * Returns `{ ok: true, data }` with `status: "accepted"` on HTTP 200, or
+ * `{ ok: false, error: "bad_request", message }` when the gate rejects.
+ * Callers should surface the rejection reason verbatim to the agent so it
+ * can learn which sources/verdicts are accepted.
+ */
+export function proposeEnrichment(
+  body: ProposeRequest,
+): Promise<ApiResult<ProposeAcceptedResponse>> {
+  return apiRequest<ProposeAcceptedResponse>(
+    'POST',
+    '/api/enrichment/propose',
+    body,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// T1 client-side check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether `(sourceUrl, recordType)` is on the T1 authority allowlist.
+ *
+ * Re-exports `checkT1Authority` from the server-side module so the caller
+ * can make a local routing decision (T1 → `/propose`, else T3 or fall back)
+ * without a round-trip. The server performs its own check — this is purely
+ * an optimization. If the pattern list drifts, the server is authoritative.
+ */
+export function isT1UrlAuthoritative(
+  sourceUrl: string,
+  recordType: SupportedRecordType,
+): boolean {
+  return checkT1Authority(sourceUrl, recordType, null).matched;
+}

--- a/crux/tablebase/agent.ts
+++ b/crux/tablebase/agent.ts
@@ -20,6 +20,11 @@ export interface AgentRunOptions {
   skipSourcing?: boolean;
   /** For source-discovery: also link discovered resources to records */
   apply?: boolean;
+  /**
+   * QUA-655: route supported record types through `POST /api/enrichment/propose`
+   * (tier-aware defensive gate) instead of the direct `/sync` endpoint.
+   */
+  viaPropose?: boolean;
 }
 
 /**
@@ -30,7 +35,13 @@ export async function runEnrichmentAgent(
   task: EnrichmentTask,
   options: AgentRunOptions = {},
 ): Promise<TaskResult> {
-  const { dryRun = false, model = MODELS.sonnet, skipSourcing = false, apply = false } = options;
+  const {
+    dryRun = false,
+    model = MODELS.sonnet,
+    skipSourcing = false,
+    apply = false,
+    viaPropose = false,
+  } = options;
   const startTime = Date.now();
   const tracker = new CostTracker();
 
@@ -38,7 +49,7 @@ export async function runEnrichmentAgent(
   const systemPrompt = getSystemPrompt(task);
   const userPrompt = getUserPrompt(task);
   const { tools: regularTools, serverTools } = getToolDefinitions({ taskType: task.taskType, apply });
-  const toolHandlers = buildToolHandlers(task, dryRun, { skipSourcing, apply });
+  const toolHandlers = buildToolHandlers(task, dryRun, { skipSourcing, apply, viaPropose });
 
   let totalRecordsCreated = 0;
 

--- a/crux/tablebase/loop.ts
+++ b/crux/tablebase/loop.ts
@@ -88,6 +88,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
         dryRun: options.dryRun,
         model,
         skipSourcing: options.skipSourcing,
+        viaPropose: options.viaPropose,
       });
       results.push(result);
       totalCost += result.cost;

--- a/crux/tablebase/tools-via-propose.test.ts
+++ b/crux/tablebase/tools-via-propose.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for QUA-655: routing submit_records through `POST /api/enrichment/propose`.
+ *
+ * The handler under test is `submit_records` from `buildToolHandlers`. When
+ * the caller passes `{ viaPropose: true }` and the record's table is in
+ * `VIA_PROPOSE_TABLES` (grants only, Phase 1), each record is classified
+ * T1 or skipped client-side, then POSTed to `/api/enrichment/propose`.
+ *
+ * We mock the underlying `apiRequest` transport and assert on path shapes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the wiki-server client before importing the module under test
+vi.mock('../lib/wiki-server/client.ts', () => ({
+  apiRequest: vi.fn(),
+}));
+
+import type { EnrichmentTask } from './types.ts';
+
+const grantBackfillTask: EnrichmentTask = {
+  id: 'grant-grantee-backfill:some-org',
+  taskType: 'grant-grantee-backfill',
+  entityId: 'ea-funds',
+  entityName: 'EA Funds',
+  entityType: 'organization',
+  table: 'grants',
+  impactScore: 10,
+  reasons: [],
+  existingRecordCount: 5,
+};
+
+/**
+ * An EA Funds URL — on the T1 allowlist for grants.
+ * (See apps/wiki-server/src/routes/enrichment/t1-allowlist.ts.)
+ */
+const T1_URL = 'https://funds.effectivealtruism.org/grants/some-grant';
+
+/**
+ * A random news URL — NOT on the T1 allowlist for grants.
+ */
+const NON_T1_URL = 'https://example.com/news/some-article';
+
+describe('submit_records via /api/enrichment/propose', () => {
+  let apiRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const client = await import('../lib/wiki-server/client.ts');
+    apiRequest = vi.mocked(client.apiRequest);
+    apiRequest.mockReset();
+  });
+
+  it('routes grants records with a T1 source URL through /propose', async () => {
+    // Propose endpoint accepts the record
+    apiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        status: 'accepted',
+        tier: 'T1',
+        recordId: 'abc1234567',
+        verdict: 'confirmed',
+        confidence: 1.0,
+        checkerModel: 't1-ea-funds',
+        innerStatus: 200,
+      },
+    });
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'abc1234567',
+          organizationId: 'ea-funds',
+          name: 'Test Grant',
+          source: T1_URL,
+          amount: 50000,
+        },
+      ],
+    });
+
+    expect(result).toContain('1/1 accepted');
+    expect(apiRequest).toHaveBeenCalledTimes(1);
+    const [method, path, body] = apiRequest.mock.calls[0];
+    expect(method).toBe('POST');
+    expect(path).toBe('/api/enrichment/propose');
+    // `organizationId` is normalized to a stableId by the existing
+    // entity-matcher path before the record reaches /propose — just assert
+    // that the row carries the id + name + source-url we set, with a
+    // non-empty organizationId resolved in some form.
+    expect(body).toMatchObject({
+      tier: 'T1',
+      recordType: 'grants',
+      sourceUrl: T1_URL,
+      row: expect.objectContaining({
+        id: 'abc1234567',
+        name: 'Test Grant',
+      }),
+    });
+    const bodyTyped = body as { row: Record<string, unknown> };
+    expect(typeof bodyTyped.row.organizationId).toBe('string');
+    expect((bodyTyped.row.organizationId as string).length).toBeGreaterThan(0);
+  });
+
+  it('skips records whose source URL is not on the T1 allowlist', async () => {
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'nont1aaaab',
+          organizationId: 'ea-funds',
+          name: 'Untrusted Grant',
+          source: NON_T1_URL,
+          amount: 25000,
+        },
+      ],
+    });
+
+    // The record should NOT trigger any /propose call — it's skipped client-side
+    expect(apiRequest).not.toHaveBeenCalled();
+    expect(result).toContain('0/1 accepted');
+    expect(result).toContain('source not on T1 authority allowlist');
+    expect(result).toContain('nont1aaaab');
+  });
+
+  it('reports a mix of accepted and skipped records', async () => {
+    // First (T1) record accepted; second (non-T1) skipped before any network call
+    apiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        status: 'accepted',
+        tier: 'T1',
+        recordId: 't1aaaaaaaa',
+        verdict: 'confirmed',
+        confidence: 1.0,
+        checkerModel: 't1-ea-funds',
+        innerStatus: 200,
+      },
+    });
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 't1aaaaaaaa',
+          organizationId: 'ea-funds',
+          name: 'Authoritative Grant',
+          source: T1_URL,
+        },
+        {
+          id: 'nont1bbbbb',
+          organizationId: 'ea-funds',
+          name: 'Unverified Grant',
+          source: NON_T1_URL,
+        },
+      ],
+    });
+
+    expect(apiRequest).toHaveBeenCalledTimes(1);
+    expect(result).toContain('1/2 accepted');
+    expect(result).toContain('1 record(s) skipped');
+  });
+
+  it('surfaces rejections from /propose verbatim', async () => {
+    apiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: 'bad_request',
+      message: '400: sync/grants: id: Number must be exactly 10 characters',
+    });
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'bad-id', // Not 10 chars — downstream sync will reject
+          organizationId: 'ea-funds',
+          name: 'Malformed Grant',
+          source: T1_URL,
+        },
+      ],
+    });
+
+    expect(result).toContain('0/1 accepted');
+    expect(result).toContain('1 record(s) rejected');
+    expect(result).toContain('bad_request');
+    expect(result).toContain('Number must be exactly 10 characters');
+  });
+
+  it('does not route non-grants tables through /propose in Phase 1', async () => {
+    // The personnel dedup read call — returns no existing rows so the record flows through
+    apiRequest.mockImplementationOnce(async () => ({
+      ok: true,
+      data: { personnel: [] },
+    }));
+    // The direct personnel /sync call
+    apiRequest.mockImplementationOnce(async () => ({
+      ok: true,
+      data: { upserted: 1 },
+    }));
+
+    const personnelTask: EnrichmentTask = {
+      ...grantBackfillTask,
+      taskType: 'personnel-enrichment',
+      table: 'personnel',
+    };
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(personnelTask, false, {
+      skipSourcing: true,
+      viaPropose: true, // enabled, but personnel is not in VIA_PROPOSE_TABLES
+    });
+
+    const result = await handlers.submit_records({
+      table: 'personnel',
+      records: [
+        {
+          id: 'persabcdef',
+          role: 'CEO',
+          roleType: 'key-person',
+          source: T1_URL,
+        },
+      ],
+    });
+
+    // Both calls go to the direct sync path — no /propose
+    const paths = apiRequest.mock.calls.map((c) => c[1]);
+    expect(paths.some((p: string) => p === '/api/enrichment/propose')).toBe(false);
+    expect(paths.some((p: string) => p.startsWith('/api/personnel'))).toBe(true);
+    expect(result).toContain('Successfully submitted');
+  });
+
+  it('strips the attached `sourcing` field before POSTing to /propose', async () => {
+    // /propose owns verdict construction — a pre-attached sourcing blob would
+    // collide with the server's own field and must be scrubbed client-side.
+    apiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        status: 'accepted',
+        tier: 'T1',
+        recordId: 'cleanaaaaa',
+        verdict: 'confirmed',
+        confidence: 1.0,
+        checkerModel: 't1-ea-funds',
+        innerStatus: 200,
+      },
+    });
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'cleanaaaaa',
+          organizationId: 'ea-funds',
+          name: 'Pre-Sourced Grant',
+          source: T1_URL,
+          // Simulate a sourcing blob that might have been attached earlier
+          sourcing: { verdict: 'confirmed', confidence: 0.9, reasoning: 'stale' },
+        },
+      ],
+    });
+
+    const body = apiRequest.mock.calls[0][2] as Record<string, unknown>;
+    expect(body.row).not.toHaveProperty('sourcing');
+  });
+
+  it('records without source URL are rejected before hitting /propose', async () => {
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: true,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'nosrcaaaab',
+          organizationId: 'ea-funds',
+          name: 'Sourceless Grant',
+        },
+      ],
+    });
+
+    // Caller-side guard hits first — before the via-propose path
+    expect(apiRequest).not.toHaveBeenCalled();
+    expect(result).toContain('missing');
+  });
+
+  it('legacy path (viaPropose=false) still hits direct grants sync endpoint', async () => {
+    // The direct grants sync (batch-update-grantee)
+    apiRequest.mockResolvedValueOnce({
+      ok: true,
+      data: { updated: 1 },
+    });
+
+    const { buildToolHandlers } = await import('./tools.ts');
+    const handlers = buildToolHandlers(grantBackfillTask, false, {
+      skipSourcing: true,
+      viaPropose: false,
+    });
+
+    const result = await handlers.submit_records({
+      table: 'grants',
+      records: [
+        {
+          id: 'legacyaaaa',
+          organizationId: 'ea-funds',
+          name: 'Legacy-Path Grant',
+          source: T1_URL,
+        },
+      ],
+    });
+
+    expect(apiRequest).toHaveBeenCalledTimes(1);
+    const [, path] = apiRequest.mock.calls[0];
+    expect(path).toMatch(/^\/api\/grants\/batch-update-grantee/);
+    expect(path).not.toContain('/propose');
+    expect(result).toContain('Successfully submitted');
+  });
+});

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -11,6 +11,11 @@ import { resolve } from 'path';
 import { apiRequest } from '../lib/wiki-server/client.ts';
 import { proposeClaims, getClaimStatus } from '../lib/wiki-server/claims.ts';
 import { getVerdictsByEntity } from '../lib/wiki-server/sourcing.ts';
+import {
+  proposeEnrichment,
+  isT1UrlAuthoritative,
+  type SupportedRecordType,
+} from '../lib/wiki-server/enrichment.ts';
 import { suggestResources } from '../lib/search/suggest-resources.ts';
 import { generateId } from '../lib/grant-import/id.ts';
 import { generateSid, isAnySid, isSid, stripSid, SID_PREFIX } from '../../packages/id-utils/src/index.ts';
@@ -24,6 +29,17 @@ import {
   dedupInvestments,
   dedupBenchmarkResults,
 } from './dedup.ts';
+
+/**
+ * Tables the `--via-propose` path supports in Phase 1 (QUA-655).
+ *
+ * Only `grants` is wired for now. The endpoint accepts all four types in
+ * `SUPPORTED_RECORD_TYPES` (grants, personnel, funding-rounds,
+ * benchmark-results), but the loop's enrichment prompts don't all produce
+ * records that satisfy the /propose tier gate today — extend this list
+ * record-type by record-type as each one proves out. See QUA-655 item 4.
+ */
+const VIA_PROPOSE_TABLES: ReadonlySet<SupportedRecordType> = new Set(['grants']);
 
 // ---------------------------------------------------------------------------
 // Tool definitions (passed to Claude API)
@@ -424,6 +440,7 @@ async function handleSubmitRecords(
   task: EnrichmentTask,
   dryRun: boolean,
   skipSourcing: boolean = false,
+  viaPropose: boolean = false,
 ): Promise<string> {
   const table = input.table as string;
   const records = input.records as Array<Record<string, unknown>>;
@@ -580,6 +597,19 @@ async function handleSubmitRecords(
     return `[DRY RUN] Would submit ${deduped.length} records to ${table} (${records.length - deduped.length} duplicates filtered):\n${JSON.stringify(deduped, null, 2)}`;
   }
 
+  // QUA-655: route supported record types through POST /api/enrichment/propose
+  // instead of the direct sync endpoint. Each record is gated server-side by
+  // the tier allowlist and written atomically with (row + evidence + verdict).
+  if (viaPropose && VIA_PROPOSE_TABLES.has(table as SupportedRecordType)) {
+    const dupCount = records.length - deduped.length;
+    return submitRecordsViaPropose(
+      table as SupportedRecordType,
+      recordsToSubmit,
+      dupCount,
+      sourcingSummary,
+    );
+  }
+
   const syncConfig = getTableConfig(table);
   if (!syncConfig) return `Error: Unknown table "${table}"`;
 
@@ -606,6 +636,94 @@ async function handleSubmitRecords(
   const count = result.data.upserted ?? result.data.updated ?? recordsToSubmit.length;
   const dupCount = records.length - deduped.length;
   return `Successfully submitted ${count} records to ${table} (${dupCount} duplicates filtered)${sourcingSummary}.`;
+}
+
+/**
+ * Submit records one-at-a-time through `POST /api/enrichment/propose`.
+ *
+ * Each record is classified T1 (URL on the allowlist) or skipped with a
+ * clear message. T2/T3 paths require a caller-supplied verdict-LLM output
+ * (`quotedText`, `checkerModel`, `reasoning`) which the loop agent does not
+ * produce today — those records are deliberately left out of scope for
+ * Phase 1 so that a non-T1 source is a signal to the agent, not a silent
+ * fall-back to the direct sync path.
+ *
+ * Returns a human-readable summary for the agent's tool-result channel.
+ */
+async function submitRecordsViaPropose(
+  recordType: SupportedRecordType,
+  records: Array<Record<string, unknown>>,
+  dupCount: number,
+  sourcingSummary: string,
+): Promise<string> {
+  let acceptedCount = 0;
+  const rejected: Array<{ id: string; reason: string }> = [];
+  const skippedNonT1: Array<{ id: string; sourceUrl: string }> = [];
+
+  for (const record of records) {
+    const recordId = typeof record.id === 'string' ? record.id : '?';
+    const sourceUrl =
+      (record.source as string | undefined) ??
+      (record.sourceUrl as string | undefined);
+
+    if (!sourceUrl) {
+      rejected.push({ id: recordId, reason: 'missing source URL' });
+      continue;
+    }
+
+    // Phase 1: T1-only. Non-T1 sources are surfaced to the agent instead of
+    // silently dropping into the direct sync path — the point of the gate is
+    // to pressure the agent toward authoritative sources.
+    if (!isT1UrlAuthoritative(sourceUrl, recordType)) {
+      skippedNonT1.push({ id: recordId, sourceUrl });
+      continue;
+    }
+
+    // Strip fields the /propose endpoint rejects or manages itself. `sourcing`
+    // was attached by pre-submit-sourcing for the legacy path; /propose owns
+    // verdict construction.
+    const { sourcing: _sourcing, ...rowForPropose } = record;
+
+    const res = await proposeEnrichment({
+      tier: 'T1',
+      recordType,
+      row: rowForPropose,
+      sourceUrl,
+    });
+
+    if (!res.ok) {
+      rejected.push({ id: recordId, reason: `${res.error}: ${res.message}` });
+      continue;
+    }
+
+    acceptedCount++;
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `Via /api/enrichment/propose: ${acceptedCount}/${records.length} accepted (${dupCount} duplicates filtered)${sourcingSummary}.`,
+  );
+  if (skippedNonT1.length > 0) {
+    lines.push(
+      `  ${skippedNonT1.length} record(s) skipped — source not on T1 authority allowlist (Phase 1 via-propose accepts T1 only):`,
+    );
+    for (const s of skippedNonT1.slice(0, 5)) {
+      lines.push(`    - ${s.id}: ${s.sourceUrl}`);
+    }
+    if (skippedNonT1.length > 5) {
+      lines.push(`    ...and ${skippedNonT1.length - 5} more`);
+    }
+  }
+  if (rejected.length > 0) {
+    lines.push(`  ${rejected.length} record(s) rejected by /propose:`);
+    for (const r of rejected.slice(0, 5)) {
+      lines.push(`    - ${r.id}: ${r.reason}`);
+    }
+    if (rejected.length > 5) {
+      lines.push(`    ...and ${rejected.length - 5} more`);
+    }
+  }
+  return lines.join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -736,9 +854,10 @@ async function handleLinkSource(
 export function buildToolHandlers(
   task: EnrichmentTask,
   dryRun: boolean,
-  options: { skipSourcing?: boolean; apply?: boolean } = {},
+  options: { skipSourcing?: boolean; apply?: boolean; viaPropose?: boolean } = {},
 ): Record<string, (input: Record<string, unknown>) => Promise<string>> {
   const skipSourcing = options.skipSourcing ?? false;
+  const viaPropose = options.viaPropose ?? false;
   const isSourceDiscovery = task.taskType === 'source-discovery';
 
   const handlers: Record<string, (input: Record<string, unknown>) => Promise<string>> = {
@@ -748,7 +867,7 @@ export function buildToolHandlers(
     create_entity: async (input) => dryRun
       ? `[DRY RUN] Would create ${input.entityType} entity: "${input.name}"`
       : handleCreateEntity(input),
-    submit_records: async (input) => handleSubmitRecords(input, task, dryRun, skipSourcing),
+    submit_records: async (input) => handleSubmitRecords(input, task, dryRun, skipSourcing, viaPropose),
     submit_claims: async (input) => dryRun
       ? `[DRY RUN] Would submit ${(input.claims as unknown[])?.length ?? 0} claims for ${input.targetTable}`
       : handleSubmitClaims(input, task),

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -139,6 +139,13 @@ export interface LoopOptions {
   model?: string;
   /** Skip sourcing before submitting records */
   skipSourcing?: boolean;
+  /**
+   * QUA-655: route supported record types through
+   * `POST /api/enrichment/propose` (tier-aware defensive gate) instead of the
+   * direct `/sync` endpoint. Phase 1 supports grants only; non-T1 sources are
+   * surfaced to the agent instead of silently falling back.
+   */
+  viaPropose?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a `--via-propose` flag to `crux tb tablebase loop`. When set, the `submit_records` tool routes **grants** records through the tier-aware defensive gate shipped in [QUA-632 Phase 1](https://linear.app/quantifieduncertainty/issue/QUA-632) / PR #4527 instead of the direct `/api/grants/batch-update-grantee` sync endpoint.

Closes the loop-refactor piece of [QUA-632](https://linear.app/quantifieduncertainty/issue/QUA-632)'s original deliverable, which was deferred to [QUA-655](https://linear.app/quantifieduncertainty/issue/QUA-655) because it's an agent-tool change that shipped more cleanly on its own PR once the endpoint was merged and deployed.

## Scope (Phase 1)

- **Grants only.** Personnel, funding-rounds, and benchmark-results are already in the endpoint's `SUPPORTED_RECORD_TYPES` but are deliberately **not** in `VIA_PROPOSE_TABLES` yet. They'll be added one-by-one as each proves out (QUA-655 item 4).
- **T1-only.** Records whose `source` URL matches the T1 authority allowlist (EA Funds, Coefficient Giving for grants) POST to `/api/enrichment/propose` with `tier=T1`. The server writes the row + evidence + `confirmed` verdict atomically.
- **Non-T1 sources are surfaced to the agent**, not silently fallen back to direct sync. The tool result names each skipped source with "Phase 1 via-propose accepts T1 only" — the point of the gate is to pressure the agent toward authoritative sources.
- **T2/T3 verdict-LLM integration is out of scope here.** Those paths require the caller to supply `quotedText` (verbatim), `checkerModel`, and `reasoning`, which the loop agent doesn't produce today. That's a follow-up.

## Files

- `crux/lib/wiki-server/enrichment.ts` (new) — typed RPC client using `InferResponseType<EnrichmentRoute>`, mirroring the sibling pattern in `benchmark-results.ts` / `sourcing-client.ts`. Also re-exports the server-side `checkT1Authority` as `isT1UrlAuthoritative` for client-side routing.
- `crux/tablebase/tools.ts` — `handleSubmitRecords` accepts `viaPropose`; when on AND table ∈ `VIA_PROPOSE_TABLES`, dispatches to `submitRecordsViaPropose` which iterates records, classifies each T1 or skipped, and POSTs to `/propose`.
- `crux/tablebase/{agent,loop,types}.ts` — thread `viaPropose` through `LoopOptions` → `AgentRunOptions` → `buildToolHandlers`.
- `crux/commands/tablebase.ts` — `--via-propose` CLI flag and help entry.
- `crux/tablebase/tools-via-propose.test.ts` (new) — 8 tests.

## Test plan

- [x] `pnpm vitest run crux/tablebase/tools-via-propose.test.ts` — 8 tests pass (T1 routing, non-T1 skip, mixed batches, /propose rejections, non-grants tables still use direct sync, `sourcing` field stripped, missing-source guard, legacy path preservation).
- [x] `pnpm vitest run crux/tablebase/` — all 150 tablebase tests pass.
- [x] `pnpm vitest run apps/wiki-server/src/__tests__/enrichment-propose.test.ts` — all 51 server-side tests still pass.
- [x] `pnpm crux w validate gate --fix` — 54/54 gate checks pass.
- [x] `pnpm build` — Next.js build compiles.
- [ ] **Manual exit criterion** (QUA-655 item 3): run `crux tb tablebase loop --via-propose --task-type=grant-grantee-backfill` against a scratch target and confirm ≥10 test rows land with `source_check_verdicts` rows attached inline (no `unchecked` aggregate verdicts). Deferred to post-merge.

Fixes QUA-655
