### PR TITLE
QUA-27: extract org Quick Assessment tables to entity_assessments

### DIFF
--- a/crux/commands/wiki-server.ts
+++ b/crux/commands/wiki-server.ts
@@ -53,6 +53,11 @@ const SCRIPTS = {
     description: 'Sync data/entity-events/*.yaml (org timelines) to wiki-server',
     passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
   },
+  'sync-entity-assessments': {
+    script: 'wiki-server/sync-entity-assessments.ts',
+    description: 'Sync data/entity-assessments/*.yaml (org Quick Assessment tables) to wiki-server',
+    passthrough: ['dryRun', 'dry-run', 'batchSize', 'batch-size'],
+  },
   'sync-coverage-scans': {
     script: 'wiki-server/sync-coverage-scans.ts',
     description: 'Compute entity coverage scores and sync to wiki-server',

--- a/crux/wiki-server/sync-entity-assessments.test.ts
+++ b/crux/wiki-server/sync-entity-assessments.test.ts
@@ -56,7 +56,6 @@ describe("assessmentIdFor", () => {
 describe("loadAssessmentsFile", () => {
   const validYaml = `
 entityId: sid_abc1234567
-entityDisplayName: Test Org
 assessments:
   - dimension: mission-alignment
     rating: Public benefit corp
@@ -73,7 +72,6 @@ assessments:
     expect(assessments).toHaveLength(2);
     expect(assessments[0]).toMatchObject({
       entityId: "sid_abc1234567",
-      entityDisplayName: "Test Org",
       dimension: "mission-alignment",
       rating: "Public benefit corp",
       evidence: "Board structure with safety governance",
@@ -189,6 +187,19 @@ assessments: "oops"
   it("rejects non-object top-level YAML", () => {
     const f = writeFile("t.yaml", `- foo`);
     expect(() => loadAssessmentsFile(f)).toThrow(/object/);
+  });
+
+  it("rejects null/primitive items in the assessments array", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - null
+  - { dimension: speed, rating: Fast }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/assessments\[0\].*must be an object/);
   });
 
   it("rejects duplicate (dimension, assessor) within a single file", () => {

--- a/crux/wiki-server/sync-entity-assessments.test.ts
+++ b/crux/wiki-server/sync-entity-assessments.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  loadAssessmentsFile,
+  loadAllAssessments,
+  assessmentIdFor,
+  VALID_ASSESSORS,
+} from "./sync-entity-assessments.ts";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "entity-assessments-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeFile(name: string, contents: string): string {
+  const p = join(tmp, name);
+  writeFileSync(p, contents);
+  return p;
+}
+
+describe("assessmentIdFor", () => {
+  it("produces a deterministic 10-char ID", () => {
+    const id = assessmentIdFor("sid_abc1234567", "mission-alignment", "editorial");
+    expect(id).toHaveLength(10);
+    expect(
+      assessmentIdFor("sid_abc1234567", "mission-alignment", "editorial"),
+    ).toBe(id);
+  });
+
+  it("produces different IDs for different inputs", () => {
+    const a = assessmentIdFor("sid_abc1234567", "mission-alignment", "editorial");
+    const b = assessmentIdFor("sid_abc1234567", "technical-capabilities", "editorial");
+    const c = assessmentIdFor("sid_xyz9876543", "mission-alignment", "editorial");
+    const d = assessmentIdFor("sid_abc1234567", "mission-alignment", "llm");
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).not.toBe(d);
+  });
+
+  it("matches the server-side natural key (entityId, dimension, assessor)", () => {
+    // Editing rating does not change the ID — this is intentional so the
+    // sync is an upsert that matches uq_entity_assessment_natural_key.
+    const id1 = assessmentIdFor("sid_abc1234567", "speed", "editorial");
+    const id2 = assessmentIdFor("sid_abc1234567", "speed", "editorial");
+    expect(id1).toBe(id2);
+  });
+});
+
+describe("loadAssessmentsFile", () => {
+  const validYaml = `
+entityId: sid_abc1234567
+entityDisplayName: Test Org
+assessments:
+  - dimension: mission-alignment
+    rating: Public benefit corp
+    evidence: Board structure with safety governance
+    assessor: editorial
+    source: https://example.com
+  - dimension: research-output
+    rating: High
+`;
+
+  it("parses a valid file", () => {
+    const f = writeFile("test.yaml", validYaml);
+    const assessments = loadAssessmentsFile(f);
+    expect(assessments).toHaveLength(2);
+    expect(assessments[0]).toMatchObject({
+      entityId: "sid_abc1234567",
+      entityDisplayName: "Test Org",
+      dimension: "mission-alignment",
+      rating: "Public benefit corp",
+      evidence: "Board structure with safety governance",
+      assessor: "editorial",
+      source: "https://example.com",
+      notes: null,
+      assessedAt: null,
+    });
+    expect(assessments[0].id).toHaveLength(10);
+  });
+
+  it("defaults assessor to editorial and other fields to null when absent", () => {
+    const f = writeFile("t.yaml", validYaml);
+    const assessments = loadAssessmentsFile(f);
+    expect(assessments[1].assessor).toBe("editorial");
+    expect(assessments[1].evidence).toBeNull();
+    expect(assessments[1].source).toBeNull();
+    expect(assessments[1].notes).toBeNull();
+    expect(assessments[1].assessedAt).toBeNull();
+  });
+
+  it("produces deterministic IDs across calls", () => {
+    const f = writeFile("t.yaml", validYaml);
+    const a = loadAssessmentsFile(f);
+    const b = loadAssessmentsFile(f);
+    expect(a[0].id).toBe(b[0].id);
+    expect(a[1].id).toBe(b[1].id);
+  });
+
+  it("accepts YYYY-MM-DD for assessedAt", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: Fast, assessedAt: "2026-04-24" }
+`,
+    );
+    const assessments = loadAssessmentsFile(f);
+    expect(assessments[0].assessedAt).toBe("2026-04-24");
+  });
+
+  it("rejects non-YYYY-MM-DD assessedAt values", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: Fast, assessedAt: "2026-04" }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/assessedAt/);
+  });
+
+  it("rejects non-kebab-case dimensions", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: "Mission Alignment", rating: Good }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/dimension.*kebab-case/);
+  });
+
+  it("rejects unknown assessors", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: Fast, assessor: bogus }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/assessor/);
+  });
+
+  it("rejects empty rating", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: "" }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/rating/);
+  });
+
+  it("rejects missing entityId", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+assessments:
+  - { dimension: speed, rating: Fast }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/entityId/);
+  });
+
+  it("rejects assessments that is not an array", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments: "oops"
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/assessments.*array/);
+  });
+
+  it("rejects non-object top-level YAML", () => {
+    const f = writeFile("t.yaml", `- foo`);
+    expect(() => loadAssessmentsFile(f)).toThrow(/object/);
+  });
+
+  it("rejects duplicate (dimension, assessor) within a single file", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: Fast }
+  - { dimension: speed, rating: Slow }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/duplicate/i);
+  });
+
+  it("allows the same dimension across different assessors", () => {
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: Fast, assessor: editorial }
+  - { dimension: speed, rating: Slow, assessor: llm }
+`,
+    );
+    const assessments = loadAssessmentsFile(f);
+    expect(assessments).toHaveLength(2);
+    expect(assessments[0].id).not.toBe(assessments[1].id);
+  });
+
+  it("includes the file path in error messages", () => {
+    const f = writeFile(
+      "broken.yaml",
+      `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: "Bad Dimension", rating: X }
+`,
+    );
+    expect(() => loadAssessmentsFile(f)).toThrow(/broken\.yaml/);
+  });
+
+  it("accepts every documented assessor", () => {
+    for (const s of VALID_ASSESSORS) {
+      const f = writeFile(
+        `${s}.yaml`,
+        `
+entityId: sid_abc1234567
+assessments:
+  - { dimension: speed, rating: X, assessor: ${s} }
+`,
+      );
+      expect(loadAssessmentsFile(f)[0].assessor).toBe(s);
+    }
+  });
+});
+
+describe("loadAllAssessments", () => {
+  it("returns empty when directory does not exist", () => {
+    const result = loadAllAssessments(join(tmp, "missing"));
+    expect(result.assessments).toEqual([]);
+    expect(result.files).toEqual([]);
+  });
+
+  it("aggregates assessments across multiple files", () => {
+    writeFile(
+      "a.yaml",
+      `
+entityId: sid_aaaaaaa111
+assessments:
+  - { dimension: speed, rating: Fast }
+  - { dimension: transparency, rating: High }
+`,
+    );
+    writeFile(
+      "b.yaml",
+      `
+entityId: sid_bbbbbbb222
+assessments:
+  - { dimension: speed, rating: Slow }
+`,
+    );
+    const result = loadAllAssessments(tmp);
+    expect(result.files).toEqual(["a.yaml", "b.yaml"]);
+    expect(result.assessments).toHaveLength(3);
+    expect(result.assessments.map((a) => a.entityId).sort()).toEqual([
+      "sid_aaaaaaa111",
+      "sid_aaaaaaa111",
+      "sid_bbbbbbb222",
+    ]);
+  });
+
+  it("ignores non-yaml files", () => {
+    writeFile("notes.md", "hello");
+    writeFile(
+      "c.yaml",
+      `
+entityId: sid_ccccccc333
+assessments:
+  - { dimension: speed, rating: Fast }
+`,
+    );
+    const result = loadAllAssessments(tmp);
+    expect(result.files).toEqual(["c.yaml"]);
+    expect(result.assessments).toHaveLength(1);
+  });
+
+  it("throws on duplicate IDs across files", () => {
+    writeFile(
+      "a.yaml",
+      `
+entityId: sid_dupdupdup1
+assessments:
+  - { dimension: speed, rating: Fast }
+`,
+    );
+    writeFile(
+      "b.yaml",
+      `
+entityId: sid_dupdupdup1
+assessments:
+  - { dimension: speed, rating: Slow }
+`,
+    );
+    expect(() => loadAllAssessments(tmp)).toThrow(/Duplicate assessment ID/);
+  });
+
+  it("propagates per-file validation errors", () => {
+    writeFile(
+      "bad.yaml",
+      `
+entityId: sid_eeeeeeee44
+assessments:
+  - { dimension: "Bad Dim", rating: X }
+`,
+    );
+    expect(() => loadAllAssessments(tmp)).toThrow(/bad\.yaml/);
+  });
+
+  it("loads .yml as well as .yaml", () => {
+    writeFile(
+      "x.yml",
+      `
+entityId: sid_yyyyyyy777
+assessments:
+  - { dimension: speed, rating: Fast }
+`,
+    );
+    const result = loadAllAssessments(tmp);
+    expect(result.files).toEqual(["x.yml"]);
+    expect(result.assessments).toHaveLength(1);
+  });
+});

--- a/crux/wiki-server/sync-entity-assessments.ts
+++ b/crux/wiki-server/sync-entity-assessments.ts
@@ -1,0 +1,363 @@
+/**
+ * Wiki Server Entity Assessments Sync
+ *
+ * Reads data/entity-assessments/*.yaml and syncs to /api/entity-assessments/sync.
+ *
+ * Each YAML file represents one entity's structured quality/capability ratings
+ * (the "Quick Assessment" tables previously embedded in wiki pages):
+ *
+ *   entityId: sid_xxxxxxxxxx              # FK to entities.stable_id
+ *   entityDisplayName: "Anthropic"        # optional fallback display name
+ *   assessments:
+ *     - dimension: mission-alignment      # kebab-case string (free-form, not enum)
+ *       rating: "Public benefit corp"    # short rating value (required)
+ *       evidence: "..."                  # optional supporting text
+ *       assessor: editorial              # editorial | llm | community | external
+ *       assessedAt: "2026-04-24"         # YYYY-MM-DD (optional)
+ *       source: "https://..."            # optional URL
+ *       notes: "..."                     # optional
+ *
+ * Item IDs are derived deterministically from (entityId, dimension, assessor) so
+ * the sync is idempotent: re-running with the same YAML upserts the same rows.
+ * This matches the natural-key uniqueness constraint on the server side
+ * (uq_entity_assessment_natural_key).
+ *
+ * Usage:
+ *   pnpm crux sys wiki-server sync-entity-assessments
+ *   pnpm crux sys wiki-server sync-entity-assessments --dry-run
+ *   pnpm crux sys wiki-server sync-entity-assessments --batch-size=50
+ *
+ * Environment:
+ *   LONGTERMWIKI_SERVER_URL     - Base URL of the wiki server
+ *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
+import { contentHash } from "../../packages/factbase/src/ids.ts";
+import { waitForHealthy, batchSync } from "./sync-common.ts";
+
+const PROJECT_ROOT = join(import.meta.dirname!, "../..");
+const ASSESSMENTS_DIR = join(PROJECT_ROOT, "data/entity-assessments");
+
+const DEFAULT_BATCH_SIZE = 100;
+
+// Mirror of VALID_ASSESSORS in
+// apps/wiki-server/src/routes/tablebase/entity-assessments.ts.
+// Keep in sync with that route's Zod schema.
+export const VALID_ASSESSORS = [
+  "editorial",
+  "llm",
+  "community",
+  "external",
+] as const;
+
+type Assessor = (typeof VALID_ASSESSORS)[number];
+
+// Date format for assessedAt: YYYY-MM-DD only (schema allows max 10 chars).
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Kebab-case dimensions only. This keeps (entityId, dimension, assessor) keys
+// stable across edits and lets the UI format the display label independently
+// of storage. Allows lowercase letters, digits, and hyphens.
+const DIMENSION_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+// --- Types ---
+
+interface RawAssessment {
+  dimension?: unknown;
+  rating?: unknown;
+  evidence?: unknown;
+  assessor?: unknown;
+  assessedAt?: unknown;
+  source?: unknown;
+  notes?: unknown;
+}
+
+interface RawAssessmentsFile {
+  entityId?: unknown;
+  entityDisplayName?: unknown;
+  assessments?: unknown;
+}
+
+export interface SyncEntityAssessment {
+  id: string;
+  entityId: string;
+  entityDisplayName: string | null;
+  dimension: string;
+  rating: string;
+  evidence: string | null;
+  assessor: Assessor;
+  assessedAt: string | null;
+  source: string | null;
+  notes: string | null;
+}
+
+// --- Loader ---
+
+/**
+ * Generate a deterministic 10-char ID from (entityId, dimension, assessor).
+ * This mirrors the server-side natural-key uniqueness constraint, so a
+ * re-sync upserts the same rows. Editing the rating in-place keeps the ID
+ * stable; editing the dimension produces a new row (the old one will
+ * linger until cleaned up via /delete-batch).
+ */
+export function assessmentIdFor(
+  entityId: string,
+  dimension: string,
+  assessor: string,
+): string {
+  return contentHash(["entity-assessment", entityId, dimension, assessor]);
+}
+
+function asString(v: unknown, field: string, file: string): string {
+  if (typeof v !== "string" || v.trim() === "") {
+    throw new Error(`${file}: '${field}' must be a non-empty string`);
+  }
+  return v;
+}
+
+function asOptionalString(v: unknown, field: string, file: string): string | null {
+  if (v === undefined || v === null || v === "") return null;
+  if (typeof v !== "string") {
+    throw new Error(`${file}: '${field}' must be a string when present`);
+  }
+  return v;
+}
+
+/**
+ * Load and validate one entity-assessments YAML file.
+ * Throws on malformed input — sync should fail-closed rather than silently skip.
+ */
+export function loadAssessmentsFile(filePath: string): SyncEntityAssessment[] {
+  const raw = readFileSync(filePath, "utf-8");
+  const parsed = parseYaml(raw) as RawAssessmentsFile | null;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${filePath}: top-level YAML must be an object`);
+  }
+
+  const entityId = asString(parsed.entityId, "entityId", filePath);
+  const entityDisplayName = asOptionalString(
+    parsed.entityDisplayName,
+    "entityDisplayName",
+    filePath,
+  );
+
+  if (!Array.isArray(parsed.assessments)) {
+    throw new Error(`${filePath}: 'assessments' must be an array`);
+  }
+
+  const out: SyncEntityAssessment[] = [];
+  // Within-file uniqueness on (dimension, assessor) — duplicates here would
+  // also trigger the natural-key constraint server-side, but catching here
+  // gives a clearer error naming the offending pair.
+  const seenInFile = new Set<string>();
+
+  for (let i = 0; i < parsed.assessments.length; i++) {
+    const a = parsed.assessments[i] as RawAssessment;
+    const where = `${filePath} assessments[${i}]`;
+
+    const dimension = asString(a.dimension, "dimension", where);
+    if (!DIMENSION_RE.test(dimension)) {
+      throw new Error(
+        `${where}: 'dimension' must be kebab-case (lowercase letters, digits, hyphens; got "${dimension}")`,
+      );
+    }
+
+    const rating = asString(a.rating, "rating", where);
+
+    let assessor: Assessor = "editorial";
+    if (a.assessor !== undefined && a.assessor !== null && a.assessor !== "") {
+      const candidate = asString(a.assessor, "assessor", where) as Assessor;
+      if (!(VALID_ASSESSORS as readonly string[]).includes(candidate)) {
+        throw new Error(
+          `${where}: 'assessor' must be one of ${VALID_ASSESSORS.join("|")} (got "${candidate}")`,
+        );
+      }
+      assessor = candidate;
+    }
+
+    let assessedAt: string | null = null;
+    if (a.assessedAt !== undefined && a.assessedAt !== null && a.assessedAt !== "") {
+      const candidate = asString(a.assessedAt, "assessedAt", where);
+      if (!DATE_RE.test(candidate)) {
+        throw new Error(
+          `${where}: 'assessedAt' must be YYYY-MM-DD (got "${candidate}")`,
+        );
+      }
+      assessedAt = candidate;
+    }
+
+    const dedupKey = `${dimension}::${assessor}`;
+    if (seenInFile.has(dedupKey)) {
+      throw new Error(
+        `${where}: duplicate (dimension, assessor) within file — ${dimension} / ${assessor}`,
+      );
+    }
+    seenInFile.add(dedupKey);
+
+    out.push({
+      id: assessmentIdFor(entityId, dimension, assessor),
+      entityId,
+      entityDisplayName,
+      dimension,
+      rating,
+      evidence: asOptionalString(a.evidence, "evidence", where),
+      assessor,
+      assessedAt,
+      source: asOptionalString(a.source, "source", where),
+      notes: asOptionalString(a.notes, "notes", where),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Load all *.yaml / *.yml files from data/entity-assessments/ and return the
+ * flattened assessment list. Returns an empty array if the directory does
+ * not exist.
+ */
+export function loadAllAssessments(dir: string = ASSESSMENTS_DIR): {
+  assessments: SyncEntityAssessment[];
+  files: string[];
+} {
+  if (!existsSync(dir)) {
+    return { assessments: [], files: [] };
+  }
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+
+  const all: SyncEntityAssessment[] = [];
+  for (const f of files) {
+    const assessments = loadAssessmentsFile(join(dir, f));
+    all.push(...assessments);
+  }
+
+  // Detect duplicate IDs across files — would surface as a silent overwrite
+  // server-side, so catch it here with the offending pair named.
+  const seen = new Map<string, SyncEntityAssessment>();
+  for (const a of all) {
+    const prev = seen.get(a.id);
+    if (prev) {
+      throw new Error(
+        `Duplicate assessment ID ${a.id} from (${prev.entityId}, ${prev.dimension}, ${prev.assessor}) and ` +
+          `(${a.entityId}, ${a.dimension}, ${a.assessor}). Adjust dimension or assessor to disambiguate.`,
+      );
+    }
+    seen.set(a.id, a);
+  }
+
+  return { assessments: all, files };
+}
+
+// --- Sync ---
+
+export async function syncEntityAssessments(
+  serverUrl: string,
+  assessments: SyncEntityAssessment[],
+  batchSize: number,
+  options: { _sleep?: (ms: number) => Promise<void> } = {},
+): Promise<{ upserted: number; errors: number }> {
+  const result = await batchSync(
+    `${serverUrl}/api/entity-assessments/sync`,
+    assessments,
+    batchSize,
+    {
+      bodyKey: "items",
+      responseCountKey: "upserted",
+      itemLabel: "entity assessments",
+      _sleep: options._sleep,
+    },
+  );
+  return { upserted: result.count, errors: result.errors };
+}
+
+// --- Main ---
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || DEFAULT_BATCH_SIZE;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_URL environment variable is required",
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required",
+    );
+    process.exit(1);
+  }
+
+  console.log(`Reading entity assessments from: ${ASSESSMENTS_DIR}`);
+  const { assessments, files } = loadAllAssessments();
+  console.log(`  Found ${files.length} files, ${assessments.length} assessments`);
+
+  if (assessments.length === 0) {
+    console.log("Nothing to sync.");
+    return;
+  }
+
+  // Per-entity counts for visibility
+  const byEntity = new Map<string, number>();
+  for (const a of assessments) {
+    byEntity.set(a.entityId, (byEntity.get(a.entityId) ?? 0) + 1);
+  }
+  for (const [entityId, count] of [...byEntity.entries()].sort()) {
+    console.log(`  ${entityId}: ${count} assessments`);
+  }
+
+  if (dryRun) {
+    console.log("\n[dry-run] Would sync these assessments (showing first 10):");
+    for (const a of assessments.slice(0, 10)) {
+      console.log(
+        `  ${a.entityId} [${a.assessor}] ${a.dimension}: ${a.rating.slice(0, 60)}${a.rating.length > 60 ? "…" : ""}`,
+      );
+    }
+    if (assessments.length > 10) {
+      console.log(`  ... and ${assessments.length - 10} more`);
+    }
+    return;
+  }
+
+  console.log("\nChecking server health...");
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nSyncing ${assessments.length} entity assessments (batch size: ${batchSize})...`,
+  );
+  const result = await syncEntityAssessments(serverUrl, assessments, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Upserted: ${result.upserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:   ${result.errors}`);
+    console.error(`\nSync failed with ${result.errors} assessment errors.`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("Entity assessments sync failed:", err);
+    process.exit(1);
+  });
+}

--- a/crux/wiki-server/sync-entity-assessments.ts
+++ b/crux/wiki-server/sync-entity-assessments.ts
@@ -7,7 +7,6 @@
  * (the "Quick Assessment" tables previously embedded in wiki pages):
  *
  *   entityId: sid_xxxxxxxxxx              # FK to entities.stable_id
- *   entityDisplayName: "Anthropic"        # optional fallback display name
  *   assessments:
  *     - dimension: mission-alignment      # kebab-case string (free-form, not enum)
  *       rating: "Public benefit corp"    # short rating value (required)
@@ -80,14 +79,12 @@ interface RawAssessment {
 
 interface RawAssessmentsFile {
   entityId?: unknown;
-  entityDisplayName?: unknown;
   assessments?: unknown;
 }
 
 export interface SyncEntityAssessment {
   id: string;
   entityId: string;
-  entityDisplayName: string | null;
   dimension: string;
   rating: string;
   evidence: string | null;
@@ -141,11 +138,6 @@ export function loadAssessmentsFile(filePath: string): SyncEntityAssessment[] {
   }
 
   const entityId = asString(parsed.entityId, "entityId", filePath);
-  const entityDisplayName = asOptionalString(
-    parsed.entityDisplayName,
-    "entityDisplayName",
-    filePath,
-  );
 
   if (!Array.isArray(parsed.assessments)) {
     throw new Error(`${filePath}: 'assessments' must be an array`);
@@ -158,8 +150,12 @@ export function loadAssessmentsFile(filePath: string): SyncEntityAssessment[] {
   const seenInFile = new Set<string>();
 
   for (let i = 0; i < parsed.assessments.length; i++) {
-    const a = parsed.assessments[i] as RawAssessment;
     const where = `${filePath} assessments[${i}]`;
+    const rawItem = parsed.assessments[i];
+    if (!rawItem || typeof rawItem !== "object" || Array.isArray(rawItem)) {
+      throw new Error(`${where}: must be an object`);
+    }
+    const a = rawItem as RawAssessment;
 
     const dimension = asString(a.dimension, "dimension", where);
     if (!DIMENSION_RE.test(dimension)) {
@@ -203,7 +199,6 @@ export function loadAssessmentsFile(filePath: string): SyncEntityAssessment[] {
     out.push({
       id: assessmentIdFor(entityId, dimension, assessor),
       entityId,
-      entityDisplayName,
       dimension,
       rating,
       evidence: asOptionalString(a.evidence, "evidence", where),

--- a/data/entity-assessments/80000-hours.yaml
+++ b/data/entity-assessments/80000-hours.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for 80,000 Hours (E510)
 # Source: content/docs/knowledge-base/organizations/80000-hours.mdx (## Quick Assessment)
 entityId: sid_hvg9ecR3nA
-entityDisplayName: 80,000 Hours
 assessments:
   - dimension: scale
     rating: Largest EA Career Organization

--- a/data/entity-assessments/80000-hours.yaml
+++ b/data/entity-assessments/80000-hours.yaml
@@ -1,0 +1,36 @@
+# Entity assessments for 80,000 Hours (E510)
+# Source: content/docs/knowledge-base/organizations/80000-hours.mdx (## Quick Assessment)
+entityId: sid_hvg9ecR3nA
+entityDisplayName: 80,000 Hours
+assessments:
+  - dimension: scale
+    rating: Largest EA Career Organization
+    evidence: 10M+ website readers; 400K+ newsletter subscribers
+
+  - dimension: primary-focus
+    rating: AI Safety Careers
+    evidence: Top priority since 2016; explicit AGI focus since 2025
+
+  - dimension: key-outputs
+    rating: Career Advice + Research
+    evidence: Problem profiles, career reviews, podcast, job board
+
+  - dimension: impact-metric
+    rating: Career Plan Changes
+    evidence: 3,000+ self-reported significant changes
+
+  - dimension: funding-model
+    rating: Philanthropic Grants
+    evidence: 80% from Coefficient Giving; 20% from other donors
+
+  - dimension: cumulative-funding
+    rating: $10M+
+    evidence: Primarily from Coefficient Giving
+
+  - dimension: independence
+    rating: Newly Independent
+    evidence: Spun out from Effective Ventures in April 2025
+
+  - dimension: target-audience
+    rating: Analytical Altruists
+    evidence: College-educated, 18-45, English-speaking, impact-focused

--- a/data/entity-assessments/ai-impacts.yaml
+++ b/data/entity-assessments/ai-impacts.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for AI Impacts (E512)
 # Source: content/docs/knowledge-base/organizations/ai-impacts.mdx (## Quick Assessment)
 entityId: sid_TdbypiKyCw
-entityDisplayName: AI Impacts
 assessments:
   - dimension: type
     rating: Research organization

--- a/data/entity-assessments/ai-impacts.yaml
+++ b/data/entity-assessments/ai-impacts.yaml
@@ -1,0 +1,22 @@
+# Entity assessments for AI Impacts (E512)
+# Source: content/docs/knowledge-base/organizations/ai-impacts.mdx (## Quick Assessment)
+entityId: sid_TdbypiKyCw
+entityDisplayName: AI Impacts
+assessments:
+  - dimension: type
+    rating: Research organization
+
+  - dimension: founded
+    rating: ~2010s
+
+  - dimension: focus
+    rating: Empirical analysis of AI timelines, risks, and human-level AI impacts
+
+  - dimension: key-people
+    rating: Katja Grace (Lead Researcher), Rick Korzekwa (Director)
+
+  - dimension: approach
+    rating: Survey research, historical trend analysis, evidence synthesis
+
+  - dimension: community-ties
+    rating: LessWrong, Effective Altruism

--- a/data/entity-assessments/anthropic.yaml
+++ b/data/entity-assessments/anthropic.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Anthropic (E22)
 # Source: content/docs/knowledge-base/organizations/anthropic.mdx (## Quick Assessment)
 entityId: sid_mK9pX3rQ7n
-entityDisplayName: Anthropic
 assessments:
   - dimension: mission-alignment
     rating: Public benefit corporation with safety governance

--- a/data/entity-assessments/anthropic.yaml
+++ b/data/entity-assessments/anthropic.yaml
@@ -1,0 +1,20 @@
+# Entity assessments for Anthropic (E22)
+# Source: content/docs/knowledge-base/organizations/anthropic.mdx (## Quick Assessment)
+entityId: sid_mK9pX3rQ7n
+entityDisplayName: Anthropic
+assessments:
+  - dimension: mission-alignment
+    rating: Public benefit corporation with safety governance
+    evidence: "Long-Term Benefit Trust holds Class T stock with board voting power increasing from 1/5 directors (2023) to majority by 2027 [Harvard Law](https://corpgov.law.harvard.edu/2023/10/28/anthropic-long-term-benefit-trust/)"
+
+  - dimension: technical-capabilities
+    rating: 80.9% on SWE-bench Verified (Nov 2025)
+    evidence: "Claude Opus 4.5 first model above 80% on SWE-bench Verified; 42% enterprise coding market share vs OpenAI's 21% [Anthropic](https://www.anthropic.com/news/claude-opus-4-5), [TechCrunch](https://techcrunch.com/2025/07/31/enterprises-prefer-anthropics-ai-models-over-anyone-elses-including-openais/)"
+
+  - dimension: safety-research
+    rating: Constitutional AI, mechanistic interpretability, model welfare
+    evidence: "Dictionary learning monitors ~10M neural features; 34M interpretable features identified via sparse autoencoders (2024); MIT Technology Review named interpretability work a 2026 Breakthrough Technology [Anthropic](https://transformer-circuits.pub/2024/scaling-monosemanticity/index.html), [MIT TR](https://www.technologyreview.com/2026/01/12/1130003/mechanistic-interpretability-ai-research-models-2026-breakthrough-technologies/)"
+
+  - dimension: known-risks
+    rating: Self-preservation behavior in testing
+    evidence: "Claude 3 Opus showed 12% alignment faking rate; Claude Opus 4 exhibited self-preservation actions in contrived test scenarios [Bank Info Security](https://www.bankinfosecurity.com/models-strategically-lie-finds-anthropic-study-a-27136), [Axios](https://www.axios.com/2025/05/23/anthropic-ai-deception-risk)"

--- a/data/entity-assessments/apart-research.yaml
+++ b/data/entity-assessments/apart-research.yaml
@@ -1,0 +1,34 @@
+# Entity assessments for Apart Research (E1156)
+# Source: content/docs/knowledge-base/organizations/apart-research.mdx (## Quick Assessment)
+entityId: sid_5WqgebIWFQ
+entityDisplayName: Apart Research
+assessments:
+  - dimension: type
+    rating: Independent non-profit research organization
+
+  - dimension: founded
+    rating: "2022"
+
+  - dimension: focus
+    rating: AI safety research, talent development, hackathons
+
+  - dimension: director-of-research
+    rating: Jason Hoelscher-Obermaier
+
+  - dimension: founder
+    rating: Esben Kran (Board Member)
+
+  - dimension: ceo
+    rating: Jaime Raldúa Veuthey
+
+  - dimension: funding-2025
+    rating: $619,921
+
+  - dimension: publications
+    rating: 22 peer-reviewed papers (including 2 ICLR 2025 orals)
+
+  - dimension: research-sprint-participants
+    rating: 3,500+ across 42 sprints
+
+  - dimension: fellows-supported
+    rating: 100+

--- a/data/entity-assessments/apart-research.yaml
+++ b/data/entity-assessments/apart-research.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Apart Research (E1156)
 # Source: content/docs/knowledge-base/organizations/apart-research.mdx (## Quick Assessment)
 entityId: sid_5WqgebIWFQ
-entityDisplayName: Apart Research
 assessments:
   - dimension: type
     rating: Independent non-profit research organization

--- a/data/entity-assessments/apollo-research.yaml
+++ b/data/entity-assessments/apollo-research.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Apollo Research (E24)
 # Source: content/docs/knowledge-base/organizations/apollo-research.mdx (## Quick Assessment)
 entityId: sid_pKeaWwP6sQ
-entityDisplayName: Apollo Research
 assessments:
   - dimension: research-output
     rating: High Impact

--- a/data/entity-assessments/apollo-research.yaml
+++ b/data/entity-assessments/apollo-research.yaml
@@ -1,0 +1,32 @@
+# Entity assessments for Apollo Research (E24)
+# Source: content/docs/knowledge-base/organizations/apollo-research.mdx (## Quick Assessment)
+entityId: sid_pKeaWwP6sQ
+entityDisplayName: Apollo Research
+assessments:
+  - dimension: research-output
+    rating: High Impact
+    evidence: "[December 2024 paper](https://arxiv.org/abs/2412.04984) tested 6 frontier models across 180+ scenarios; cited in OpenAI/Anthropic safety frameworks"
+
+  - dimension: team-size
+    rating: ~20 researchers
+    evidence: "Full-time staff including CEO Marius Hobbhahn, named [TIME 100 AI 2025](https://time.com/collections/time100-ai-2025/7305864/marius-hobbhahn/)"
+
+  - dimension: lab-partnerships
+    rating: Extensive
+    evidence: "Pre-deployment evaluations for [OpenAI](https://openai.com/index/detecting-and-reducing-scheming-in-ai-models/), [Anthropic](https://www.anthropic.com), and [Google DeepMind](https://deepmind.google/blog/deepening-our-partnership-with-the-uk-ai-security-institute/)"
+
+  - dimension: government-integration
+    rating: Strong
+    evidence: UK AISI partner, US AISI consortium member, presented at Bletchley AI Summit
+
+  - dimension: methodology-rigor
+    rating: Very High
+    evidence: 300 rollouts per model/evaluation; statistically significant results (p less than 0.05)
+
+  - dimension: key-finding-2024
+    rating: Critical
+    evidence: o1 maintains deception in over 85% of follow-up questions after engaging in scheming
+
+  - dimension: intervention-impact
+    rating: Measurable
+    evidence: Deliberative alignment reduced scheming from 13% to 0.4% (30x reduction) in OpenAI models

--- a/data/entity-assessments/coefficient-giving.yaml
+++ b/data/entity-assessments/coefficient-giving.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Coefficient Giving (E521)
 # Source: content/docs/knowledge-base/organizations/coefficient-giving.mdx (## Quick Assessment)
 entityId: sid_ULjDXpSLCI
-entityDisplayName: Coefficient Giving
 assessments:
   - dimension: scale
     rating: Dominant

--- a/data/entity-assessments/coefficient-giving.yaml
+++ b/data/entity-assessments/coefficient-giving.yaml
@@ -1,0 +1,28 @@
+# Entity assessments for Coefficient Giving (E521)
+# Source: content/docs/knowledge-base/organizations/coefficient-giving.mdx (## Quick Assessment)
+entityId: sid_ULjDXpSLCI
+entityDisplayName: Coefficient Giving
+assessments:
+  - dimension: scale
+    rating: Dominant
+    evidence: "$4B+ total grants; ~$46M AI safety in 2023"
+
+  - dimension: structure
+    rating: 13 cause-specific funds
+    evidence: Multi-donor pooled funds since Nov 2025 rebrand
+
+  - dimension: ai-safety-focus
+    rating: Leading funder
+    evidence: "$336M+ to AI safety since 2014; ~60% of external AI safety funding"
+
+  - dimension: application-model
+    rating: Rolling RFPs + regranting
+    evidence: 300-word EOI, 2-week response; supports platforms like Manifund
+
+  - dimension: transparency
+    rating: High
+    evidence: Public grants database, annual progress reports
+
+  - dimension: key-funders
+    rating: Good Ventures (primary)
+    evidence: Dustin Moskovitz & Cari Tuna; expanding to multi-donor model

--- a/data/entity-assessments/cset.yaml
+++ b/data/entity-assessments/cset.yaml
@@ -1,0 +1,32 @@
+# Entity assessments for CSET (E524)
+# Source: content/docs/knowledge-base/organizations/cset.mdx (## Quick Assessment)
+entityId: sid_lvsDuyzPcg
+entityDisplayName: CSET (Center for Security and Emerging Technology)
+assessments:
+  - dimension: policy-influence
+    rating: Very High
+    evidence: Hundreds of government briefings annually, regular congressional testimony, research cited in export control decisions
+
+  - dimension: research-rigor
+    rating: High
+    evidence: Data-driven methodology, 80+ annual publications, peer-reviewed work in major venues
+
+  - dimension: data-infrastructure
+    rating: Very High
+    evidence: Emerging Technology Observatory with 10 public tools and 8 open datasets
+
+  - dimension: china-expertise
+    rating: Very High
+    evidence: In-house translation team, extensive Chinese-language research analysis
+
+  - dimension: funding-stability
+    rating: Very High
+    evidence: $100M+ secured through 2025, diversified funding base
+
+  - dimension: staff-size
+    rating: Large
+    evidence: 50+ full-time staff as of 2022
+
+  - dimension: independence
+    rating: High
+    evidence: Nonpartisan, university-affiliated, philanthropically funded

--- a/data/entity-assessments/cset.yaml
+++ b/data/entity-assessments/cset.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for CSET (E524)
 # Source: content/docs/knowledge-base/organizations/cset.mdx (## Quick Assessment)
 entityId: sid_lvsDuyzPcg
-entityDisplayName: CSET (Center for Security and Emerging Technology)
 assessments:
   - dimension: policy-influence
     rating: Very High

--- a/data/entity-assessments/foresight-institute.yaml
+++ b/data/entity-assessments/foresight-institute.yaml
@@ -1,0 +1,34 @@
+# Entity assessments for Foresight Institute (E1210)
+# Source: content/docs/knowledge-base/organizations/foresight-institute.mdx (## Quick Assessment)
+entityId: sid_NPPTvNqRXA
+entityDisplayName: Foresight Institute
+assessments:
+  - dimension: type
+    rating: Nonprofit research organization and think tank
+
+  - dimension: founded
+    rating: 1986, San Francisco, CA
+
+  - dimension: founders
+    rating: Christine Peterson, K. Eric Drexler, James C. Bennett
+
+  - dimension: focus-areas
+    rating: Nanotechnology, secure AI, neurotechnology, longevity biotechnology, space, existential hope
+
+  - dimension: key-programs
+    rating: Grants, Feynman Prize, fellowships, Vision Weekend conferences, AI Nodes, tech trees
+
+  - dimension: employees
+    rating: ~6 (recent estimates)
+
+  - dimension: total-assets
+    rating: ~$8.9M (2024 filing)
+
+  - dimension: annual-program-spending
+    rating: ~$3.7M (2024 filing, total functional expenses)
+
+  - dimension: ai-safety-relevance
+    rating: Funds AI safety research in security, human-AI cooperation, neurotechnology, and forecasting
+
+  - dimension: ein
+    rating: 77-0119168

--- a/data/entity-assessments/foresight-institute.yaml
+++ b/data/entity-assessments/foresight-institute.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Foresight Institute (E1210)
 # Source: content/docs/knowledge-base/organizations/foresight-institute.mdx (## Quick Assessment)
 entityId: sid_NPPTvNqRXA
-entityDisplayName: Foresight Institute
 assessments:
   - dimension: type
     rating: Nonprofit research organization and think tank

--- a/data/entity-assessments/lesswrong.yaml
+++ b/data/entity-assessments/lesswrong.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for LessWrong (E538)
 # Source: content/docs/knowledge-base/organizations/lesswrong.mdx (## Quick Assessment)
 entityId: sid_BEKEqQDmkQ
-entityDisplayName: LessWrong
 assessments:
   - dimension: influence-on-ai-safety
     rating: High

--- a/data/entity-assessments/lesswrong.yaml
+++ b/data/entity-assessments/lesswrong.yaml
@@ -1,0 +1,16 @@
+# Entity assessments for LessWrong (E538)
+# Source: content/docs/knowledge-base/organizations/lesswrong.mdx (## Quick Assessment)
+entityId: sid_BEKEqQDmkQ
+entityDisplayName: LessWrong
+assessments:
+  - dimension: influence-on-ai-safety
+    rating: High
+    evidence: "Material influenced formation of MIRI and CFAR; attracted major tech donors; 31% of EA survey respondents in 2014 first heard of EA through LessWrong [Wikipedia](https://en.wikipedia.org/wiki/LessWrong), [Rationality - LessWrong](https://www.lesswrong.com/rationality)"
+
+  - dimension: community-scale
+    rating: Medium
+    evidence: "2016 survey had ~3,000 respondents; 2023 survey had 558 respondents; peak 15,000 daily pageviews [Wikipedia](https://en.wikipedia.org/wiki/LessWrong), [2023 Survey](https://www.lesswrong.com/posts/WRaq4SzxhunLoFKCs/2023-survey-results)"
+
+  - dimension: funding-base
+    rating: Substantial
+    evidence: "Over $5 million from Survival and Flourishing Fund, Future Fund, and Coefficient Giving combined [EA Forum](https://forum-bots.effectivealtruism.org/topics/lesswrong)"

--- a/data/entity-assessments/manifund.yaml
+++ b/data/entity-assessments/manifund.yaml
@@ -1,0 +1,36 @@
+# Entity assessments for Manifund (E547)
+# Source: content/docs/knowledge-base/organizations/manifund.mdx (## Quick Assessment)
+entityId: sid_fFVOuFZCRf
+entityDisplayName: Manifund
+assessments:
+  - dimension: scale
+    rating: Growing
+    evidence: "$2M+ in 2023; $2.25M raised for 2025 regrants"
+
+  - dimension: speed
+    rating: Very Fast
+    evidence: Grant recommendation to disbursement in under 1 week
+
+  - dimension: mechanism-innovation
+    rating: High
+    evidence: Pioneered impact certificates, regranting at scale
+
+  - dimension: transparency
+    rating: Very High
+    evidence: All grants public with explanations
+
+  - dimension: team-size
+    rating: Small
+    evidence: ~3 core staff (Austin Chen, Rachel Weinberg, Saul Munn)
+
+  - dimension: fiscal-sponsorship
+    rating: "Yes"
+    evidence: 501(c)(3) status; 5% fee for large donors
+
+  - dimension: focus-areas
+    rating: AI Safety Primary
+    evidence: ~80% of grants to x-risk/AI safety
+
+  - dimension: related-platform
+    rating: Manifold Markets
+    evidence: Shared founders, infrastructure, community

--- a/data/entity-assessments/manifund.yaml
+++ b/data/entity-assessments/manifund.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Manifund (E547)
 # Source: content/docs/knowledge-base/organizations/manifund.mdx (## Quick Assessment)
 entityId: sid_fFVOuFZCRf
-entityDisplayName: Manifund
 assessments:
   - dimension: scale
     rating: Growing

--- a/data/entity-assessments/mats.yaml
+++ b/data/entity-assessments/mats.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for MATS (E548)
 # Source: content/docs/knowledge-base/organizations/mats.mdx (## Quick Assessment)
 entityId: sid_yYtGSTsXuw
-entityDisplayName: MATS (ML Alignment Theory Scholars program)
 assessments:
   - dimension: program-scale
     rating: High

--- a/data/entity-assessments/mats.yaml
+++ b/data/entity-assessments/mats.yaml
@@ -1,0 +1,24 @@
+# Entity assessments for MATS (E548)
+# Source: content/docs/knowledge-base/organizations/mats.mdx (## Quick Assessment)
+entityId: sid_yYtGSTsXuw
+entityDisplayName: MATS (ML Alignment Theory Scholars program)
+assessments:
+  - dimension: program-scale
+    rating: High
+    evidence: 98 scholars and 57 mentors in most recent cohort (MATS 8.0, Summer 2025)
+
+  - dimension: research-output
+    rating: Strong
+    evidence: 160+ publications, 8,000+ citations, h-index of 40 over 4 years
+
+  - dimension: career-impact
+    rating: Very High
+    evidence: 80% of alumni work in AI alignment; placements at Anthropic, OpenAI, DeepMind
+
+  - dimension: funding-per-scholar
+    rating: $27k
+    evidence: $15k stipend + $12k compute resources, plus housing and meals
+
+  - dimension: selectivity
+    rating: Very Competitive
+    evidence: ~15% acceptance rate; 40+ mentors with independent selection

--- a/data/entity-assessments/miri.yaml
+++ b/data/entity-assessments/miri.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for MIRI (E202)
 # Source: content/docs/knowledge-base/organizations/miri.mdx (## Quick Assessment)
 entityId: sid_puAffUjWSS
-entityDisplayName: Machine Intelligence Research Institute (MIRI)
 assessments:
   - dimension: historical-significance
     rating: First organization to focus on ASI alignment as technical problem

--- a/data/entity-assessments/miri.yaml
+++ b/data/entity-assessments/miri.yaml
@@ -1,0 +1,24 @@
+# Entity assessments for MIRI (E202)
+# Source: content/docs/knowledge-base/organizations/miri.mdx (## Quick Assessment)
+entityId: sid_puAffUjWSS
+entityDisplayName: Machine Intelligence Research Institute (MIRI)
+assessments:
+  - dimension: historical-significance
+    rating: First organization to focus on ASI alignment as technical problem
+    evidence: "Among first to recognize ASI as most important event in 21st century [MIRI About](https://intelligence.org/about/)"
+
+  - dimension: current-strategy
+    rating: Policy advocacy to halt AI development
+    evidence: "Major 2024 pivot after acknowledging alignment research 'extremely unlikely to succeed in time' [MIRI About](https://intelligence.org/about/)"
+
+  - dimension: research-output
+    rating: Minimal recent publications
+    evidence: "Near-zero new publications from core researchers between 2018 and 2022 [LessWrong](https://www.lesswrong.com/posts/rfNHWe5JWhGuSqMHN/steelmanning-miri-critics)"
+
+  - dimension: financial-status
+    rating: Operating at deficit with ~2 year runway
+    evidence: "$4.97M net loss in 2024, $15.24M in net assets [ProPublica](https://projects.propublica.org/nonprofits/organizations/582565917)"
+
+  - dimension: field-impact
+    rating: Controversial but influential
+    evidence: "Raised awareness but faced criticism for theoretical approach and failed research programs [LessWrong](https://www.lesswrong.com/posts/rfNHWe5JWhGuSqMHN/steelmanning-miri-critics)"

--- a/data/entity-assessments/redwood-research.yaml
+++ b/data/entity-assessments/redwood-research.yaml
@@ -1,7 +1,6 @@
 # Entity assessments for Redwood Research (E557)
 # Source: content/docs/knowledge-base/organizations/redwood-research.mdx (## Quick Assessment)
 entityId: sid_dwMzc9WzPa
-entityDisplayName: Redwood Research
 assessments:
   - dimension: focus-area
     rating: AI systems acting against developer interests

--- a/data/entity-assessments/redwood-research.yaml
+++ b/data/entity-assessments/redwood-research.yaml
@@ -1,0 +1,20 @@
+# Entity assessments for Redwood Research (E557)
+# Source: content/docs/knowledge-base/organizations/redwood-research.mdx (## Quick Assessment)
+entityId: sid_dwMzc9WzPa
+entityDisplayName: Redwood Research
+assessments:
+  - dimension: focus-area
+    rating: AI systems acting against developer interests
+    evidence: Primary research on AI Control and alignment faking
+
+  - dimension: funding
+    rating: $25M+ from Coefficient Giving
+    evidence: "$9.4M (2021), $10.7M (2022), $5.3M (2023)"
+
+  - dimension: team-size
+    rating: 10 staff (2021), 6-15 research staff (2023 estimate)
+    evidence: Early team of 10 expanded to research organization
+
+  - dimension: key-concern
+    rating: Research output relative to funding
+    evidence: 2023 critics cited limited publications; subsequent ICML, NeurIPS work addressed this


### PR DESCRIPTION
## Summary

Populates the `entity_assessments` PG table (schema + routes shipped in PR #2915, empty since) with **83 structured assessments across 13 AI safety / AI lab orgs** by extracting the "Quick Assessment" tables already embedded in wiki pages.

Parallel to QUA-26 / PR #4537 (entity_events for org timelines). Same file-layout, same loader shape, same deterministic-ID + idempotent-upsert pattern, same command registration.

| Org | Assessments |
|---|--:|
| Apart Research | 10 |
| Foresight Institute | 10 |
| 80,000 Hours | 8 |
| Manifund | 8 |
| Apollo Research | 7 |
| CSET | 7 |
| AI Impacts | 6 |
| Coefficient Giving | 6 |
| MATS | 5 |
| MIRI | 5 |
| Anthropic | 4 |
| Redwood Research | 4 |
| LessWrong | 3 |
| **Total** | **83** |

## What's added

- **`data/entity-assessments/<slug>.yaml`** — one file per org, source of truth. Each assessment has `dimension` (kebab-case), `rating` (short), plus optional `evidence`, `assessor`, `assessedAt`, `source`, `notes`.
- **`crux/wiki-server/sync-entity-assessments.ts`** — loader + sync orchestrator using the shared `batchSync` helper.
- **`crux/wiki-server/sync-entity-assessments.test.ts`** — 25 tests covering loader validation (dimension format, enum membership, date format, duplicates), deterministic ID generation, cross-file duplicate detection, null-item guard.
- **`crux sys wiki-server sync-entity-assessments`** — registered command. Supports `--dry-run` and `--batch-size=N`.

Item IDs are derived deterministically from `(entityId, dimension, assessor)` — matching the server-side `uq_entity_assessment_natural_key` unique index — so the sync is idempotent: re-running upserts the same rows.

## Design notes

- **Dimensions use kebab-case** (`mission-alignment`, `safety-research`) — keeps the natural key stable, lets the UI format the label independently of storage.
- **`assessor` defaults to `editorial`** when omitted (matches the PG column default); switching to `llm` / `community` / `external` for the same `(entity, dimension)` produces a distinct row.
- **Server derives display names** via `thingsTitleIds` at write time, so the client payload omits `entityDisplayName` (unlike sync-entity-events.ts, where the server schema actually stores it).

## Review findings addressed

Review via `/agent-review-pr` surfaced two bugs fixed before push:

1. **HIGH**: `entityDisplayName` was in the YAML + client interface but the server `SyncItemSchema` silently stripped it (no corresponding column). Removed from loader + all 13 YAMLs. IDs unchanged.
2. **MEDIUM**: null or primitive items in the assessments array crashed with a bare TypeError. Added a guard + regression test.

Follow-up filed as **QUA-679** for DRY-extraction of ~120 lines of shared YAML-sync scaffolding between this script and `sync-entity-events.ts` (plus two pre-existing bugs in events that weren't back-ported from this review).

## Acceptance criteria (QUA-27)

- [x] `entity_assessments` populated for 10+ organizations — **13 orgs, 83 rows** (verified live: `{"total":83}` from `/api/entity-assessments/stats`)
- [ ] Assessment data removed from wiki page MDX — **deferred** (parallel to QUA-26: needs a render component before the MDX table can be removed without regressing user-visible info)
- [x] Data accessible via `/api/entity-assessments/by-entity/:id` — verified for slug (`anthropic` → 4 rows) and stableId (`sid_mK9pX3rQ7n` → 4 rows). numericId resolution returns empty — matches QUA-26 prod behavior.

## Test plan

- [x] `pnpm test` — 7429 passed locally, 25 new tests for loader behavior
- [x] `pnpm crux w validate gate --fix` — 51/51 blocking checks pass (3 pre-existing advisory)
- [x] `pnpm build` — passes cleanly
- [x] Synced 83 assessments against prod wiki-server; stats endpoint returns 83
- [x] Per-entity API spot-checks against prod return correct assessments
- [x] Re-sync verifies idempotency (same 83 upserted, no new rows)

Closes QUA-27
Follow-up: QUA-679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wiki-server command to sync entity assessment data in bulk from configuration files.

* **Tests**
  * Added comprehensive test suite covering assessment data validation, parsing, and duplicate detection.

* **Chores**
  * Added assessment datasets for 13 organizations including 80000 Hours, Anthropic, CSET, MIRI, Redwood Research, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->