### PR TITLE
fix(QUA-675): linkify URLs in entity db cells so embedded digits don't leak

### DIFF
--- a/apps/web/src/app/internal/entity-profile/__tests__/linkify-text.test.tsx
+++ b/apps/web/src/app/internal/entity-profile/__tests__/linkify-text.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { linkifyText } from "../linkify-text";
+
+function flatten(node: ReactNode): { text: string; hrefs: string[] } {
+  const hrefs: string[] = [];
+  let text = "";
+  const visit = (n: ReactNode) => {
+    if (n == null || typeof n === "boolean") return;
+    if (typeof n === "string" || typeof n === "number") {
+      text += String(n);
+      return;
+    }
+    if (Array.isArray(n)) {
+      n.forEach(visit);
+      return;
+    }
+    if (isValidElement(n)) {
+      const el = n as ReactElement<{ href?: string; children?: ReactNode }>;
+      if (el.props.href) hrefs.push(el.props.href);
+      text += "[link]";
+      if (el.props.children) visit(el.props.children);
+      text += "[/link]";
+    }
+  };
+  visit(node);
+  return { text, hrefs };
+}
+
+describe("linkifyText", () => {
+  it("returns the input string unchanged when there are no URLs", () => {
+    expect(linkifyText("just some text")).toBe("just some text");
+    expect(linkifyText("")).toBe("");
+  });
+
+  it("linkifies a URL embedded in prose and keeps the digits out of innerText", () => {
+    const input =
+      "[Navigating Transformative AI] https://web.archive.org/web/20240601000000/https://openphilanthropy.org/grants/openai-general-support/";
+    const { text, hrefs } = flatten(linkifyText(input));
+    // The 14-digit timestamp must not leak as visible text.
+    expect(text).not.toMatch(/20240601000000/);
+    // The URL text is replaced by its hostname.
+    expect(text).toContain("web.archive.org");
+    // The href still contains the original URL.
+    expect(hrefs[0]).toContain("20240601000000");
+  });
+
+  it("links multiple URLs in one string", () => {
+    const { hrefs } = flatten(
+      linkifyText("see https://example.com/a and https://foo.bar/b for details"),
+    );
+    expect(hrefs).toHaveLength(2);
+    expect(hrefs[0]).toBe("https://example.com/a");
+    expect(hrefs[1]).toBe("https://foo.bar/b");
+  });
+
+  it("trims trailing sentence punctuation from the URL", () => {
+    const { hrefs } = flatten(linkifyText("go to https://example.com/page."));
+    expect(hrefs[0]).toBe("https://example.com/page");
+  });
+
+  it("leaves digits in non-URL text alone", () => {
+    const { text } = flatten(linkifyText("Internal Revenue: 1700000000"));
+    expect(text).toBe("Internal Revenue: 1700000000");
+  });
+});

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -32,6 +32,7 @@ import {
   isLegacyResourceId,
 } from "./sanitize-raw-ids";
 import { formatFactValueString } from "./format-cell-value";
+import { linkifyText } from "./linkify-text";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -302,14 +303,14 @@ function tryParseNumeric(value: unknown): number | null {
 
 // ── Expandable text ───────────────────────────────────────────────────────
 
-function ExpandableText({ text }: { text: string }) {
+function ExpandableText({ children }: { children: React.ReactNode }) {
   const [expanded, setExpanded] = useState(false);
   return (
     <div>
       <span
         className={`text-[11px] whitespace-pre-wrap break-words ${expanded ? "" : "line-clamp-2"}`}
       >
-        {text}
+        {children}
       </span>
       <button
         onClick={() => setExpanded(!expanded)}
@@ -502,10 +503,10 @@ function CellValue({
         }
       } catch { /* not JSON, fall through */ }
     }
-    return <ExpandableText text={sanitizeRawIds(str)} />;
+    return <ExpandableText>{linkifyText(sanitizeRawIds(str))}</ExpandableText>;
   }
 
-  return <span className="text-[11px]">{sanitizeRawIds(str)}</span>;
+  return <span className="text-[11px]">{linkifyText(sanitizeRawIds(str))}</span>;
 }
 
 function JsonValue({ value }: { value: unknown }) {

--- a/apps/web/src/app/internal/entity-profile/linkify-text.tsx
+++ b/apps/web/src/app/internal/entity-profile/linkify-text.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+// URL matcher: http(s) scheme, any non-whitespace/bracket/quote char, minus a
+// final punctuation char that's more likely sentence-terminal than URL.
+// Used to linkify embedded URLs so raw digits inside them (e.g. web.archive.org
+// timestamps) don't leak into innerText. QUA-675.
+const URL_RE = /https?:\/\/[^\s<>"')]+[^\s<>"').,;:!?]/g;
+
+export function linkifyText(text: string): React.ReactNode {
+  if (!text.includes("http")) return text;
+  const parts: React.ReactNode[] = [];
+  let lastIdx = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    const start = m.index ?? 0;
+    if (start > lastIdx) parts.push(text.slice(lastIdx, start));
+    const url = m[0];
+    let domain: string | null = null;
+    try {
+      domain = new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+      /* malformed URL — render full text as fallback */
+    }
+    parts.push(
+      <a
+        key={start}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 dark:text-blue-400 hover:underline break-all"
+        title={url}
+      >
+        {domain ?? url}
+      </a>,
+    );
+    lastIdx = start + url.length;
+  }
+  if (parts.length === 0) return text;
+  if (lastIdx < text.length) parts.push(text.slice(lastIdx));
+  return parts;
+}


### PR DESCRIPTION
## Summary

Render audit failed on `/organizations/openai` because the grants
`notes` column rendered text like `[title] https://web.archive.org/web/20240601000000/...`
as plain text. `innerText` then exposed the 14-digit archive timestamp
as a bare digit run and tripped the "raw large numbers" anti-pattern
check.

The existing URL branch in `CellValue` only handles values that are
entirely a URL. Embedded URLs in prose fell through to ExpandableText
or plain-span rendering, which put the URL content directly into
`innerText`.

## Changes

- New `linkify-text.tsx` helper: walks URL matches in a string and
  replaces each with a clickable `<a>` that shows only the hostname.
  Digits inside URLs live in `href`/`title`, never in `innerText`.
- `CellValue` long-text and short-text fallback branches now pass
  output through `linkifyText`.
- `ExpandableText` switched from `text: string` prop to `children`
  to accept the linkified node tree.
- Fast-path (`text.includes("http")`) keeps cost ~0 for URL-free cells.
- Bonus: URLs in description/notes columns are now clickable — they
  weren't before.

Note: two of the three originally failing tests (`/organizations/meta-ai`
and `/organizations/google-deepmind` on the Database tab) were separate
Value-column raw-number leaks that QUA-673 already fixed in main; those
will pass once Vercel rolls out the latest deploy. This PR closes out
the third — the URL-in-notes case — which QUA-673 did not cover.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (7405 tests)
- [x] `pnpm crux w validate gate` passes
- [x] New unit test in `__tests__/linkify-text.test.tsx` covers: no-URL passthrough, embedded URL linkification, multiple URLs, trailing-punctuation trimming, non-URL digits preserved
- [x] `e2e/render-audit.spec.ts` Database-tab checks pass locally for `/organizations/openai|meta-ai|google-deepmind`
- [x] Adversarial: web.archive.org URL with 14-digit timestamp embedded in prose

Closes QUA-675
