### PR TITLE
docs: fix stale comments in tb-importers and sync-factory rule

### DIFF
--- a/.claude/rules/tablebase-sync-factory.md
+++ b/.claude/rules/tablebase-sync-factory.md
@@ -1,6 +1,6 @@
 # TableBase Sync Handler Factory
 
-The `createSyncHandler<T>()` factory in `apps/wiki-server/src/routes/tablebase/sync-factory.ts` is the canonical pattern for new TableBase POST /sync routes. Mass migration of existing routes is in progress (discussion #4088, issue #4090).
+The `createSyncHandler<T>()` factory in `apps/wiki-server/src/routes/tablebase/sync-factory.ts` is the canonical pattern for TableBase POST /sync routes. As of 2026-04, **28 routes** use the factory (migration from discussion #4088 / issue #4090 is effectively complete except for the 5 permanently-excluded routes below).
 
 ## When to use it
 
@@ -30,7 +30,7 @@ Use `pnpm crux tb scaffold <kebab-name>` (QUA-455). It generates the route file,
 
 The factory provides three escape hatches: `preValidate`, `postUpsert`, `conflictSet`. **Routes should use at most 1.** If you find yourself reaching for a second hook, that's a signal the factory isn't the right fit — hand-roll the route instead.
 
-The 3 Phase 1 pilot routes follow this rule:
+Representative examples from the 28 factory-using routes:
 
 | Route | Hook | Reason |
 |-------|------|--------|

--- a/crux/commands/tb-importers/index.ts
+++ b/crux/commands/tb-importers/index.ts
@@ -14,9 +14,9 @@
  *     - `crux tb semantic-scholar    --target=personSlug:displayName:authorId [--submit]`
  *     - `crux tb crossref            --target=doi:10.xxx/yyy[|org=slug][|person=slug] [--submit]`
  *
- * `--submit` is wired through to the propose-client; today the endpoint
- * (QUA-632) does not yet exist so submit-mode returns `pending`. Until then,
- * default behavior (dry-run) prints what would be sent.
+ * `--submit` POSTs proposals to `/api/enrichment/propose` (wired in QUA-665
+ * for personnel / funding-rounds / benchmark-results on top of QUA-632's
+ * grants endpoint). Default behavior is dry-run — prints what would be sent.
  */
 
 import { cliMain as secEdgarCliMain } from "./sec-edgar.ts";
@@ -66,6 +66,6 @@ Usage:
   crux tb crossref --target=doi:10.1145/3442188.3445922|org=anthropic [--submit]
 
 All importers default to dry-run mode (print proposals, don't POST).
-Pass --submit to attempt POST to /api/enrichment/propose (blocked on QUA-632).
+Pass --submit to POST proposals to /api/enrichment/propose.
 `;
 }


### PR DESCRIPTION
## Summary

Two trivial stale-doc fixes found during `/maintain-audit` on 2026-04-24. No logic changes — comment and rule-doc only.

1. **`crux/commands/tb-importers/index.ts`** — the module docstring and `getHelp()` output claimed `/api/enrichment/propose` "does not yet exist" and that `--submit` mode "returns `pending`". PR #4560 (QUA-665) wired the endpoint for `personnel`, `funding-rounds`, and `benchmark-results` on top of QUA-632's `grants` path. The help text now reflects current behavior.

2. **`.claude/rules/tablebase-sync-factory.md`** — claimed "3 Phase 1 pilot routes follow this rule"; 28 routes currently use `createSyncHandler` (verified via `grep -l createSyncHandler apps/wiki-server/src/routes/tablebase/`). Updated the opening paragraph and the hook-budget table heading so agents reading the rule don't assume adoption is still early.

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` — 5/5 checks pass
- [x] No logic changes — only comment and markdown edits
- [ ] CI green after push

Filed two companion Linear issues from the same audit (not part of this PR):

- [QUA-682](https://linear.app/quantifieduncertainty/issue/QUA-682) — Split `organizations/[slug]/org-data.ts` (1,822 lines) into per-record-type modules
- [QUA-683](https://linear.app/quantifieduncertainty/issue/QUA-683) — Consolidate `format-compact.ts` and `format-currency.ts` sibling formatters
