### PR TITLE
fix(ProfileTabs): prevent React #418 on multi-tab profile pages (QUA-656)

### DIFF
--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -253,6 +253,12 @@ function TabsContentList({ tabs, layout }: { tabs: ProfileTab[]; layout: "horizo
 
 // ─── Layout wrappers ────────────────────────────────────────────────────
 
+// QUA-656: Both Fallback and Inner call these with `onChange` set, so the
+// rendered `<Tabs>` always uses controlled props (`value` + `onValueChange`).
+// Keeping the wire shape identical between the two Suspense states is what
+// lets the Suspense transition avoid tripping React #418 during ISR cache
+// boundaries — the only thing that changes across the transition is the
+// handler identity, not the DOM structure.
 function HorizontalLayout({
   tabs,
   activeTab,
@@ -262,23 +268,16 @@ function HorizontalLayout({
 }: {
   tabs: ProfileTab[];
   activeTab: string;
-  onChange?: (value: string) => void;
+  onChange: (value: string) => void;
   ariaLabel?: string;
   notice?: React.ReactNode;
 }) {
-  const content = (
-    <>
+  return (
+    <Tabs value={activeTab} onValueChange={onChange}>
       <HorizontalTabsList tabs={tabs} ariaLabel={ariaLabel} />
       {notice}
       <TabsContentList tabs={tabs} layout="horizontal" />
-    </>
-  );
-  return onChange ? (
-    <Tabs value={activeTab} onValueChange={onChange}>
-      {content}
     </Tabs>
-  ) : (
-    <Tabs defaultValue={activeTab}>{content}</Tabs>
   );
 }
 
@@ -292,34 +291,27 @@ function VerticalLayout({
 }: {
   tabs: ProfileTab[];
   activeTab: string;
-  onChange?: (value: string) => void;
+  onChange: (value: string) => void;
   ariaLabel?: string;
   groups?: ProfileTabGroup[];
   notice?: React.ReactNode;
 }) {
-  const content = (
-    <div className="grid grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] gap-x-10 gap-y-6">
-      <div className="md:sticky md:top-4 md:self-start">
-        <VerticalTabsNav tabs={tabs} groups={groups} ariaLabel={ariaLabel} />
-      </div>
-      <div className="min-w-0">
-        {notice}
-        <TabsContentList tabs={tabs} layout="vertical" />
-      </div>
-    </div>
-  );
-  return onChange ? (
+  return (
     <Tabs
       value={activeTab}
       onValueChange={onChange}
       orientation="vertical"
       className="flex-col gap-0"
     >
-      {content}
-    </Tabs>
-  ) : (
-    <Tabs defaultValue={activeTab} orientation="vertical" className="flex-col gap-0">
-      {content}
+      <div className="grid grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] gap-x-10 gap-y-6">
+        <div className="md:sticky md:top-4 md:self-start">
+          <VerticalTabsNav tabs={tabs} groups={groups} ariaLabel={ariaLabel} />
+        </div>
+        <div className="min-w-0">
+          {notice}
+          <TabsContentList tabs={tabs} layout="vertical" />
+        </div>
+      </div>
     </Tabs>
   );
 }
@@ -344,7 +336,17 @@ function UnknownTabNotice({
   );
 }
 
-function ProfileTabsBody({
+// Shared helper: pick the tab that both Fallback and Inner should start with.
+// Keeping this in one place means the two Suspense states can never diverge
+// on "which tab is active on first paint".
+function pickDefaultTab(tabs: ProfileTab[]): ProfileTab {
+  const selectable = tabs.filter((t) => !t.href);
+  return selectable[0] ?? tabs[0];
+}
+
+function noop() {}
+
+function ProfileTabsInner({
   tabs,
   ariaLabel,
   layout,
@@ -359,28 +361,29 @@ function ProfileTabsBody({
   const pathname = usePathname();
   const router = useRouter();
 
-  // Link tabs (with href) aren't Radix tabs — they navigate on click. Pick
-  // the first non-link tab as the default active id.
-  const selectableTabs = tabs.filter((t) => !t.href);
-  const defaultTab = selectableTabs[0] ?? tabs[0];
+  const defaultTab = pickDefaultTab(tabs);
   const defaultTabId = defaultTab.id;
+  const selectableTabs = tabs.filter((t) => !t.href);
 
-  // QUA-656: Initial render always uses defaultTabId on both server and
-  // client so the two render trees match exactly. URL-param sync happens
-  // post-hydration in the effect below. A prior Suspense-based design
-  // (QUA-463 for single-tab, this for multi-tab) was vulnerable to React
-  // #418 element-type mismatches during ISR cache boundaries, where the
-  // streamed HTML and RSC payload could come from different renders.
+  // QUA-656: Inner starts with the same default tab the Fallback renders,
+  // and reconciles with `?tab=` in a post-hydration effect. Prior design
+  // derived activeTab from searchParams synchronously, which — combined
+  // with the Fallback rendering `defaultValue` (uncontrolled) vs Inner's
+  // `value` (controlled) — produced structurally different Radix trees
+  // across the Suspense transition. During Vercel ISR cache boundaries,
+  // HTML and RSC could come from different renders and mis-match on
+  // hydration (React #418, args[]=HTML element-type mismatch).
   const [activeTab, setActiveTab] = useState<string>(defaultTabId);
   const [unknownTabRequested, setUnknownTabRequested] = useState<string | null>(null);
 
-  // Stable key of selectable tab ids so the effect only re-runs when the set
-  // of tabs actually changes, not on every render (tabs prop is a new array
-  // from the parent on each render).
+  // `searchParams` object identity changes every parent render; depend on
+  // the resolved `tab` value instead so the effect only fires when the URL
+  // actually changes. `selectableIdsKey` likewise guards against new array
+  // identity on every render.
+  const tabParam = searchParams.get("tab");
   const selectableIdsKey = selectableTabs.map((t) => t.id).join("|");
 
   useEffect(() => {
-    const tabParam = searchParams.get("tab");
     if (!tabParam) {
       setActiveTab(defaultTabId);
       setUnknownTabRequested(null);
@@ -394,7 +397,7 @@ function ProfileTabsBody({
       setActiveTab(defaultTabId);
       setUnknownTabRequested(tabParam);
     }
-  }, [searchParams, defaultTabId, selectableIdsKey]);
+  }, [tabParam, defaultTabId, selectableIdsKey]);
 
   function handleTabChange(value: string) {
     if (value === defaultTabId) {
@@ -428,6 +431,41 @@ function ProfileTabsBody({
   );
 }
 
+function ProfileTabsFallback({
+  tabs,
+  ariaLabel,
+  layout,
+  groups,
+}: {
+  tabs: ProfileTab[];
+  ariaLabel?: string;
+  layout: "horizontal" | "vertical";
+  groups?: ProfileTabGroup[];
+}) {
+  // QUA-656: Fallback renders the SAME controlled <Tabs value={...}
+  // onValueChange={...}> tree Inner starts with — only the handler identity
+  // differs. That way when Suspense swaps Fallback → Inner after the
+  // searchParams hook resolves, the DOM doesn't restructure and React
+  // doesn't have to reconcile incompatible tab-root configurations.
+  const defaultTabId = pickDefaultTab(tabs).id;
+  return layout === "vertical" ? (
+    <VerticalLayout
+      tabs={tabs}
+      activeTab={defaultTabId}
+      onChange={noop}
+      ariaLabel={ariaLabel}
+      groups={groups}
+    />
+  ) : (
+    <HorizontalLayout
+      tabs={tabs}
+      activeTab={defaultTabId}
+      onChange={noop}
+      ariaLabel={ariaLabel}
+    />
+  );
+}
+
 /**
  * Reusable tabbed layout for profile pages (organizations, people, etc.).
  * - Filters out tabs where `count === 0`
@@ -438,15 +476,28 @@ function ProfileTabsBody({
 export function ProfileTabs({ tabs, ariaLabel, layout = "horizontal", groups }: ProfileTabsProps) {
   const visibleTabs = tabs.filter((t) => t.count !== 0);
   if (visibleTabs.length === 0) return null;
+  // Single-tab short-circuit — matches QUA-463 hydration fix: skip Suspense
+  // so server and client agree on a plain fragment.
   if (visibleTabs.length === 1) {
     return <>{visibleTabs[0].content}</>;
   }
   return (
-    <ProfileTabsBody
-      tabs={visibleTabs}
-      ariaLabel={ariaLabel}
-      layout={layout}
-      groups={groups}
-    />
+    <Suspense
+      fallback={
+        <ProfileTabsFallback
+          tabs={visibleTabs}
+          ariaLabel={ariaLabel}
+          layout={layout}
+          groups={groups}
+        />
+      }
+    >
+      <ProfileTabsInner
+        tabs={visibleTabs}
+        ariaLabel={ariaLabel}
+        layout={layout}
+        groups={groups}
+      />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -344,7 +344,7 @@ function UnknownTabNotice({
   );
 }
 
-function ProfileTabsInner({
+function ProfileTabsBody({
   tabs,
   ariaLabel,
   layout,
@@ -364,10 +364,37 @@ function ProfileTabsInner({
   const selectableTabs = tabs.filter((t) => !t.href);
   const defaultTab = selectableTabs[0] ?? tabs[0];
   const defaultTabId = defaultTab.id;
-  const tabParam = searchParams.get("tab");
-  const hasTabMatch = tabParam ? selectableTabs.some((t) => t.id === tabParam) : false;
-  const activeTab = hasTabMatch ? (tabParam as string) : defaultTabId;
-  const unknownTabRequested = tabParam && !hasTabMatch ? tabParam : null;
+
+  // QUA-656: Initial render always uses defaultTabId on both server and
+  // client so the two render trees match exactly. URL-param sync happens
+  // post-hydration in the effect below. A prior Suspense-based design
+  // (QUA-463 for single-tab, this for multi-tab) was vulnerable to React
+  // #418 element-type mismatches during ISR cache boundaries, where the
+  // streamed HTML and RSC payload could come from different renders.
+  const [activeTab, setActiveTab] = useState<string>(defaultTabId);
+  const [unknownTabRequested, setUnknownTabRequested] = useState<string | null>(null);
+
+  // Stable key of selectable tab ids so the effect only re-runs when the set
+  // of tabs actually changes, not on every render (tabs prop is a new array
+  // from the parent on each render).
+  const selectableIdsKey = selectableTabs.map((t) => t.id).join("|");
+
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (!tabParam) {
+      setActiveTab(defaultTabId);
+      setUnknownTabRequested(null);
+      return;
+    }
+    const ids = selectableIdsKey.split("|");
+    if (ids.includes(tabParam)) {
+      setActiveTab(tabParam);
+      setUnknownTabRequested(null);
+    } else {
+      setActiveTab(defaultTabId);
+      setUnknownTabRequested(tabParam);
+    }
+  }, [searchParams, defaultTabId, selectableIdsKey]);
 
   function handleTabChange(value: string) {
     if (value === defaultTabId) {
@@ -401,26 +428,6 @@ function ProfileTabsInner({
   );
 }
 
-function ProfileTabsFallback({
-  tabs,
-  ariaLabel,
-  layout,
-  groups,
-}: {
-  tabs: ProfileTab[];
-  ariaLabel?: string;
-  layout: "horizontal" | "vertical";
-  groups?: ProfileTabGroup[];
-}) {
-  const selectable = tabs.filter((t) => !t.href);
-  const activeTab = selectable[0]?.id ?? tabs[0].id;
-  return layout === "vertical" ? (
-    <VerticalLayout tabs={tabs} activeTab={activeTab} ariaLabel={ariaLabel} groups={groups} />
-  ) : (
-    <HorizontalLayout tabs={tabs} activeTab={activeTab} ariaLabel={ariaLabel} />
-  );
-}
-
 /**
  * Reusable tabbed layout for profile pages (organizations, people, etc.).
  * - Filters out tabs where `count === 0`
@@ -431,28 +438,15 @@ function ProfileTabsFallback({
 export function ProfileTabs({ tabs, ariaLabel, layout = "horizontal", groups }: ProfileTabsProps) {
   const visibleTabs = tabs.filter((t) => t.count !== 0);
   if (visibleTabs.length === 0) return null;
-  // Single-tab short-circuit — matches QUA-463 hydration fix: skip Suspense so
-  // server and client agree on a plain fragment.
   if (visibleTabs.length === 1) {
     return <>{visibleTabs[0].content}</>;
   }
   return (
-    <Suspense
-      fallback={
-        <ProfileTabsFallback
-          tabs={visibleTabs}
-          ariaLabel={ariaLabel}
-          layout={layout}
-          groups={groups}
-        />
-      }
-    >
-      <ProfileTabsInner
-        tabs={visibleTabs}
-        ariaLabel={ariaLabel}
-        layout={layout}
-        groups={groups}
-      />
-    </Suspense>
+    <ProfileTabsBody
+      tabs={visibleTabs}
+      ariaLabel={ariaLabel}
+      layout={layout}
+      groups={groups}
+    />
   );
 }

--- a/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
+++ b/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
@@ -261,5 +261,24 @@ describe("ProfileTabs", () => {
       // Overview content renders (it's the first non-link tab = default).
       expect(screen.getByTestId("overview")).toBeTruthy();
     });
+
+    it("post-hydration effect activates a known ?tab= param", () => {
+      mockState.search = "tab=facts";
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div>overview</div>),
+            tab("facts", "Facts", <div data-testid="facts-content">facts</div>),
+          ]}
+        />,
+      );
+      // jsdom runs effects synchronously on render, so by the time this
+      // assertion runs the useEffect has applied the URL param and Facts is
+      // active.
+      const activeTab = screen.getByRole("tab", { selected: true });
+      expect(activeTab.textContent).toMatch(/Facts/);
+      // Active panel is Facts'.
+      expect(screen.getByTestId("facts-content")).toBeTruthy();
+    });
   });
 });

--- a/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
+++ b/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
@@ -242,4 +242,24 @@ describe("ProfileTabs", () => {
       expect(screen.queryByRole("status")).toBeNull();
     });
   });
+
+  describe("QUA-656: hydration safety", () => {
+    // SSR path: the server renders the component without access to URL search
+    // params; the initial render on BOTH server and client must pick the first
+    // selectable tab so the two trees match exactly. URL-based selection is
+    // applied via useEffect after hydration.
+    it("first visible tab is a link — default is the first non-link tab", () => {
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("wiki", "Wiki", null, undefined, { href: "/wiki/E1" }),
+            tab("overview", "Overview", <div data-testid="overview">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      // Overview content renders (it's the first non-link tab = default).
+      expect(screen.getByTestId("overview")).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Multi-tab organization / person / AI-model / etc. profile pages were intermittently tripping React error [#418](https://react.dev/errors/418) (`args[]=HTML` — element-type hydration mismatch) on post-deploy e2e tests. Different orgs failed on each run (`controlai`, `futuresearch`, `goodfire`, `us-aisi`, `xai`, `polymarket`), and the rate was too low to reproduce locally after ~1000 prod fetches, pointing at Vercel ISR cache-boundary behaviour: pre-rendered HTML and the RSC payload can come from different renders during revalidation.

**Root cause.** `ProfileTabs` wrapped its body in a `<Suspense>` boundary so `useSearchParams()` could read the URL at SSR time. The Suspense fallback rendered `<Tabs defaultValue={X}>` (uncontrolled) while the inner rendered `<Tabs value={X} onValueChange={…}>` (controlled) — structurally different Radix trees. When a race between the pre-rendered HTML cache and the RSC cache served HTML from one render and RSC from the other, React couldn't reconcile the two tab-root configurations and threw #418.

**Fix.** Keep the Suspense boundary (it's required to preserve static generation of `/organizations/[slug]`, `/people/[slug]`, `/ai-models/[slug]`, etc. — dropping it fails `pnpm build` with `missing-suspense-with-csr-bailout`), but make the fallback and inner render byte-identical initial trees:

- Both Layout wrappers always render controlled `<Tabs value=… onValueChange=…>`; the fallback passes a `noop` handler instead of branching on `onChange ? controlled : uncontrolled`.
- New `pickDefaultTab()` helper guarantees fallback and inner agree on which tab is active on first paint.
- Inner initialises `useState(defaultTabId)` and reconciles with `?tab=` in a post-hydration `useEffect`. The effect depends on the resolved `tab` string, not the `searchParams` object reference (which changes every parent render).
- Single-tab short-circuit from QUA-463 is preserved.

After the change, a cache-boundary race where HTML and RSC come from different renders is harmless: both renders produce the same tree.

## Test plan

- [x] `pnpm test` — 7405 pass (14 unit tests on `ProfileTabs`, one new one that asserts `?tab=facts` activates the Facts tab after hydration)
- [x] `pnpm build` — succeeds, `/organizations/[slug]` et al. remain SSG-prerendered (previous no-Suspense attempt failed here with `useSearchParams() should be wrapped in a suspense boundary at page "/ai-models/[slug]"`)
- [x] `pnpm crux w validate gate --fix` — 54/54 pass
- [x] Playwright dev-server smoke on the six orgs originally listed in the issue (`xai`, `controlai`, `futuresearch`, `goodfire`, `us-aisi`, `polymarket`) — all render with no page errors
- [x] Verified SSR HTML for `/organizations/xai` and `/organizations/xai?tab=facts` is byte-identical at first paint (both show `Overview` active); the client effect switches to `Facts` after mount

## Notes for reviewers

- The `?tab=X` URL still flashes the default tab for one paint before the effect syncs — this matches the old behaviour (Fallback always rendered the default tab too, and the Suspense transition briefly swapped it). Not a regression.
- This extends QUA-463's philosophy from single-tab orgs to multi-tab orgs: both sides of the Suspense boundary have to agree on the initial tree.

Fixes QUA-656
