### PR TITLE
QUA-679: extract shared YAML-sync helpers (DRY events + assessments)

### DIFF
--- a/crux/wiki-server/sync-entity-assessments.ts
+++ b/crux/wiki-server/sync-entity-assessments.ts
@@ -31,14 +31,19 @@
  *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
  */
 
-import { readFileSync, readdirSync, existsSync } from "fs";
+import { readFileSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
-import { parseCliArgs } from "../lib/cli.ts";
-import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
 import { contentHash } from "../../packages/factbase/src/ids.ts";
-import { waitForHealthy, batchSync } from "./sync-common.ts";
+import { batchSync } from "./sync-common.ts";
+import {
+  asString,
+  asOptionalString,
+  assertPlainObject,
+  loadYamlDir,
+  runSyncMain,
+} from "./sync-yaml-helpers.ts";
 
 const PROJECT_ROOT = join(import.meta.dirname!, "../..");
 const ASSESSMENTS_DIR = join(PROJECT_ROOT, "data/entity-assessments");
@@ -66,16 +71,6 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const DIMENSION_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 // --- Types ---
-
-interface RawAssessment {
-  dimension?: unknown;
-  rating?: unknown;
-  evidence?: unknown;
-  assessor?: unknown;
-  assessedAt?: unknown;
-  source?: unknown;
-  notes?: unknown;
-}
 
 interface RawAssessmentsFile {
   entityId?: unknown;
@@ -111,21 +106,6 @@ export function assessmentIdFor(
   return contentHash(["entity-assessment", entityId, dimension, assessor]);
 }
 
-function asString(v: unknown, field: string, file: string): string {
-  if (typeof v !== "string" || v.trim() === "") {
-    throw new Error(`${file}: '${field}' must be a non-empty string`);
-  }
-  return v;
-}
-
-function asOptionalString(v: unknown, field: string, file: string): string | null {
-  if (v === undefined || v === null || v === "") return null;
-  if (typeof v !== "string") {
-    throw new Error(`${file}: '${field}' must be a string when present`);
-  }
-  return v;
-}
-
 /**
  * Load and validate one entity-assessments YAML file.
  * Throws on malformed input — sync should fail-closed rather than silently skip.
@@ -152,10 +132,8 @@ export function loadAssessmentsFile(filePath: string): SyncEntityAssessment[] {
   for (let i = 0; i < parsed.assessments.length; i++) {
     const where = `${filePath} assessments[${i}]`;
     const rawItem = parsed.assessments[i];
-    if (!rawItem || typeof rawItem !== "object" || Array.isArray(rawItem)) {
-      throw new Error(`${where}: must be an object`);
-    }
-    const a = rawItem as RawAssessment;
+    assertPlainObject(rawItem, where);
+    const a = rawItem;
 
     const dimension = asString(a.dimension, "dimension", where);
     if (!DIMENSION_RE.test(dimension)) {
@@ -221,34 +199,14 @@ export function loadAllAssessments(dir: string = ASSESSMENTS_DIR): {
   assessments: SyncEntityAssessment[];
   files: string[];
 } {
-  if (!existsSync(dir)) {
-    return { assessments: [], files: [] };
-  }
-  const files = readdirSync(dir)
-    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
-    .sort();
-
-  const all: SyncEntityAssessment[] = [];
-  for (const f of files) {
-    const assessments = loadAssessmentsFile(join(dir, f));
-    all.push(...assessments);
-  }
-
-  // Detect duplicate IDs across files — would surface as a silent overwrite
-  // server-side, so catch it here with the offending pair named.
-  const seen = new Map<string, SyncEntityAssessment>();
-  for (const a of all) {
-    const prev = seen.get(a.id);
-    if (prev) {
-      throw new Error(
-        `Duplicate assessment ID ${a.id} from (${prev.entityId}, ${prev.dimension}, ${prev.assessor}) and ` +
-          `(${a.entityId}, ${a.dimension}, ${a.assessor}). Adjust dimension or assessor to disambiguate.`,
-      );
-    }
-    seen.set(a.id, a);
-  }
-
-  return { assessments: all, files };
+  const { items, files } = loadYamlDir<SyncEntityAssessment>({
+    dir,
+    loadFile: loadAssessmentsFile,
+    kindLabel: "assessment",
+    describe: (a) => `${a.entityId}, ${a.dimension}, ${a.assessor}`,
+    dedupHint: "Adjust dimension or assessor to disambiguate.",
+  });
+  return { assessments: items, files };
 }
 
 // --- Sync ---
@@ -276,78 +234,19 @@ export async function syncEntityAssessments(
 // --- Main ---
 
 async function main() {
-  const args = parseCliArgs(process.argv.slice(2));
-  const dryRun = args["dry-run"] === true;
-  const batchSize = Number(args["batch-size"]) || DEFAULT_BATCH_SIZE;
-
-  const serverUrl = getServerUrl();
-  const apiKey = getApiKey();
-
-  if (!serverUrl) {
-    console.error(
-      "Error: LONGTERMWIKI_SERVER_URL environment variable is required",
-    );
-    process.exit(1);
-  }
-  if (!apiKey) {
-    console.error(
-      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required",
-    );
-    process.exit(1);
-  }
-
-  console.log(`Reading entity assessments from: ${ASSESSMENTS_DIR}`);
-  const { assessments, files } = loadAllAssessments();
-  console.log(`  Found ${files.length} files, ${assessments.length} assessments`);
-
-  if (assessments.length === 0) {
-    console.log("Nothing to sync.");
-    return;
-  }
-
-  // Per-entity counts for visibility
-  const byEntity = new Map<string, number>();
-  for (const a of assessments) {
-    byEntity.set(a.entityId, (byEntity.get(a.entityId) ?? 0) + 1);
-  }
-  for (const [entityId, count] of [...byEntity.entries()].sort()) {
-    console.log(`  ${entityId}: ${count} assessments`);
-  }
-
-  if (dryRun) {
-    console.log("\n[dry-run] Would sync these assessments (showing first 10):");
-    for (const a of assessments.slice(0, 10)) {
-      console.log(
-        `  ${a.entityId} [${a.assessor}] ${a.dimension}: ${a.rating.slice(0, 60)}${a.rating.length > 60 ? "…" : ""}`,
-      );
-    }
-    if (assessments.length > 10) {
-      console.log(`  ... and ${assessments.length - 10} more`);
-    }
-    return;
-  }
-
-  console.log("\nChecking server health...");
-  const healthy = await waitForHealthy(serverUrl);
-  if (!healthy) {
-    console.error(
-      `Error: Server at ${serverUrl} is not healthy. Aborting sync.`,
-    );
-    process.exit(1);
-  }
-
-  console.log(
-    `\nSyncing ${assessments.length} entity assessments (batch size: ${batchSize})...`,
-  );
-  const result = await syncEntityAssessments(serverUrl, assessments, batchSize);
-
-  console.log(`\nSync complete:`);
-  console.log(`  Upserted: ${result.upserted}`);
-  if (result.errors > 0) {
-    console.log(`  Errors:   ${result.errors}`);
-    console.error(`\nSync failed with ${result.errors} assessment errors.`);
-    process.exit(1);
-  }
+  await runSyncMain<SyncEntityAssessment>({
+    dir: ASSESSMENTS_DIR,
+    label: "entity assessments",
+    loadAll: (d) => {
+      const { assessments, files } = loadAllAssessments(d);
+      return { items: assessments, files };
+    },
+    getEntityId: (a) => a.entityId,
+    formatDryRun: (a) =>
+      `${a.entityId} [${a.assessor}] ${a.dimension}: ${a.rating.slice(0, 60)}${a.rating.length > 60 ? "…" : ""}`,
+    sync: syncEntityAssessments,
+    defaultBatchSize: DEFAULT_BATCH_SIZE,
+  });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/crux/wiki-server/sync-entity-events.test.ts
+++ b/crux/wiki-server/sync-entity-events.test.ts
@@ -189,6 +189,22 @@ events: "oops"
     expect(() => loadEventsFile(f)).toThrow(/object/);
   });
 
+  it("rejects null/primitive items in the events array", () => {
+    // Regression for pre-existing bug: the events loader used to cast the
+    // raw item to RawEvent without a runtime shape check, so a null or
+    // primitive array entry would crash later with a bare TypeError.
+    const f = writeFile(
+      "t.yaml",
+      `
+entityId: sid_abc1234567
+events:
+  - null
+  - { date: "2020", title: OK, eventType: founding }
+`,
+    );
+    expect(() => loadEventsFile(f)).toThrow(/events\[0\].*must be an object/);
+  });
+
   it("includes the file path in error messages", () => {
     const f = writeFile(
       "broken.yaml",

--- a/crux/wiki-server/sync-entity-events.ts
+++ b/crux/wiki-server/sync-entity-events.ts
@@ -29,14 +29,19 @@
  *   LONGTERMWIKI_SERVER_API_KEY - Bearer token for authentication
  */
 
-import { readFileSync, readdirSync, existsSync } from "fs";
+import { readFileSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
-import { parseCliArgs } from "../lib/cli.ts";
-import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
 import { contentHash } from "../../packages/factbase/src/ids.ts";
-import { waitForHealthy, batchSync } from "./sync-common.ts";
+import { batchSync } from "./sync-common.ts";
+import {
+  asString,
+  asOptionalString,
+  assertPlainObject,
+  loadYamlDir,
+  runSyncMain,
+} from "./sync-yaml-helpers.ts";
 
 const PROJECT_ROOT = join(import.meta.dirname!, "../..");
 const EVENTS_DIR = join(PROJECT_ROOT, "data/entity-events");
@@ -67,16 +72,6 @@ type EventType = (typeof VALID_EVENT_TYPES)[number];
 type Significance = (typeof VALID_SIGNIFICANCE)[number];
 
 // --- Types ---
-
-interface RawEvent {
-  date?: unknown;
-  title?: unknown;
-  eventType?: unknown;
-  significance?: unknown;
-  description?: unknown;
-  source?: unknown;
-  notes?: unknown;
-}
 
 interface RawEventsFile {
   entityId?: unknown;
@@ -111,21 +106,6 @@ export function eventIdFor(entityId: string, date: string, title: string): strin
 
 const DATE_RE = /^\d{4}(-\d{2}(-\d{2})?)?$/;
 
-function asString(v: unknown, field: string, file: string): string {
-  if (typeof v !== "string" || v.trim() === "") {
-    throw new Error(`${file}: '${field}' must be a non-empty string`);
-  }
-  return v;
-}
-
-function asOptionalString(v: unknown, field: string, file: string): string | null {
-  if (v === undefined || v === null || v === "") return null;
-  if (typeof v !== "string") {
-    throw new Error(`${file}: '${field}' must be a string when present`);
-  }
-  return v;
-}
-
 /**
  * Load and validate one entity-events YAML file.
  * Throws on malformed input — sync should fail-closed rather than silently skip.
@@ -150,8 +130,10 @@ export function loadEventsFile(filePath: string): SyncEntityEvent[] {
 
   const out: SyncEntityEvent[] = [];
   for (let i = 0; i < parsed.events.length; i++) {
-    const ev = parsed.events[i] as RawEvent;
     const where = `${filePath} events[${i}]`;
+    const rawItem = parsed.events[i];
+    assertPlainObject(rawItem, where);
+    const ev = rawItem;
 
     const date = asString(ev.date, "date", where);
     if (!DATE_RE.test(date)) {
@@ -204,34 +186,14 @@ export function loadAllEvents(dir: string = EVENTS_DIR): {
   events: SyncEntityEvent[];
   files: string[];
 } {
-  if (!existsSync(dir)) {
-    return { events: [], files: [] };
-  }
-  const files = readdirSync(dir)
-    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
-    .sort();
-
-  const all: SyncEntityEvent[] = [];
-  for (const f of files) {
-    const events = loadEventsFile(join(dir, f));
-    all.push(...events);
-  }
-
-  // Detect duplicate IDs across files — would surface as a silent overwrite
-  // server-side, so catch it here with the offending pair named.
-  const seen = new Map<string, SyncEntityEvent>();
-  for (const ev of all) {
-    const prev = seen.get(ev.id);
-    if (prev) {
-      throw new Error(
-        `Duplicate event ID ${ev.id} from (${prev.entityId}, ${prev.date}, "${prev.title}") and ` +
-          `(${ev.entityId}, ${ev.date}, "${ev.title}"). Adjust one title to disambiguate.`,
-      );
-    }
-    seen.set(ev.id, ev);
-  }
-
-  return { events: all, files };
+  const { items, files } = loadYamlDir<SyncEntityEvent>({
+    dir,
+    loadFile: loadEventsFile,
+    kindLabel: "event",
+    describe: (ev) => `${ev.entityId}, ${ev.date}, "${ev.title}"`,
+    dedupHint: "Adjust one title to disambiguate.",
+  });
+  return { events: items, files };
 }
 
 // --- Sync ---
@@ -259,78 +221,19 @@ export async function syncEntityEvents(
 // --- Main ---
 
 async function main() {
-  const args = parseCliArgs(process.argv.slice(2));
-  const dryRun = args["dry-run"] === true;
-  const batchSize = Number(args["batch-size"]) || DEFAULT_BATCH_SIZE;
-
-  const serverUrl = getServerUrl();
-  const apiKey = getApiKey();
-
-  if (!serverUrl) {
-    console.error(
-      "Error: LONGTERMWIKI_SERVER_URL environment variable is required",
-    );
-    process.exit(1);
-  }
-  if (!apiKey) {
-    console.error(
-      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required",
-    );
-    process.exit(1);
-  }
-
-  console.log(`Reading entity events from: ${EVENTS_DIR}`);
-  const { events, files } = loadAllEvents();
-  console.log(`  Found ${files.length} files, ${events.length} events`);
-
-  if (events.length === 0) {
-    console.log("Nothing to sync.");
-    return;
-  }
-
-  // Per-entity counts for visibility
-  const byEntity = new Map<string, number>();
-  for (const ev of events) {
-    byEntity.set(ev.entityId, (byEntity.get(ev.entityId) ?? 0) + 1);
-  }
-  for (const [entityId, count] of [...byEntity.entries()].sort()) {
-    console.log(`  ${entityId}: ${count} events`);
-  }
-
-  if (dryRun) {
-    console.log("\n[dry-run] Would sync these events (showing first 10):");
-    for (const ev of events.slice(0, 10)) {
-      console.log(
-        `  ${ev.entityId} ${ev.date} [${ev.eventType}] ${ev.title}`,
-      );
-    }
-    if (events.length > 10) {
-      console.log(`  ... and ${events.length - 10} more`);
-    }
-    return;
-  }
-
-  console.log("\nChecking server health...");
-  const healthy = await waitForHealthy(serverUrl);
-  if (!healthy) {
-    console.error(
-      `Error: Server at ${serverUrl} is not healthy. Aborting sync.`,
-    );
-    process.exit(1);
-  }
-
-  console.log(
-    `\nSyncing ${events.length} entity events (batch size: ${batchSize})...`,
-  );
-  const result = await syncEntityEvents(serverUrl, events, batchSize);
-
-  console.log(`\nSync complete:`);
-  console.log(`  Upserted: ${result.upserted}`);
-  if (result.errors > 0) {
-    console.log(`  Errors:   ${result.errors}`);
-    console.error(`\nSync failed with ${result.errors} event errors.`);
-    process.exit(1);
-  }
+  await runSyncMain<SyncEntityEvent>({
+    dir: EVENTS_DIR,
+    label: "entity events",
+    loadAll: (d) => {
+      const { events, files } = loadAllEvents(d);
+      return { items: events, files };
+    },
+    getEntityId: (ev) => ev.entityId,
+    formatDryRun: (ev) =>
+      `${ev.entityId} ${ev.date} [${ev.eventType}] ${ev.title}`,
+    sync: syncEntityEvents,
+    defaultBatchSize: DEFAULT_BATCH_SIZE,
+  });
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/crux/wiki-server/sync-yaml-helpers.test.ts
+++ b/crux/wiki-server/sync-yaml-helpers.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  asString,
+  asOptionalString,
+  assertPlainObject,
+  loadYamlDir,
+} from "./sync-yaml-helpers.ts";
+
+describe("asString", () => {
+  it("returns the string when valid", () => {
+    expect(asString("hello", "field", "file.yaml")).toBe("hello");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => asString("", "name", "file.yaml")).toThrow(/name.*non-empty/);
+  });
+
+  it("throws on whitespace-only string", () => {
+    expect(() => asString("   ", "name", "file.yaml")).toThrow(/name.*non-empty/);
+  });
+
+  it("throws on non-string types", () => {
+    expect(() => asString(42, "num", "file.yaml")).toThrow(/num.*non-empty/);
+    expect(() => asString(null, "n", "file.yaml")).toThrow();
+    expect(() => asString(undefined, "n", "file.yaml")).toThrow();
+    expect(() => asString({}, "n", "file.yaml")).toThrow();
+  });
+
+  it("includes file and field in error", () => {
+    expect(() => asString(null, "dimension", "orgs/anthropic.yaml")).toThrow(
+      /orgs\/anthropic\.yaml.*dimension/,
+    );
+  });
+});
+
+describe("asOptionalString", () => {
+  it("returns the string when valid", () => {
+    expect(asOptionalString("hello", "field", "file.yaml")).toBe("hello");
+  });
+
+  it("returns null for undefined, null, empty string", () => {
+    expect(asOptionalString(undefined, "n", "f")).toBeNull();
+    expect(asOptionalString(null, "n", "f")).toBeNull();
+    expect(asOptionalString("", "n", "f")).toBeNull();
+  });
+
+  it("throws on non-string non-nullish values", () => {
+    expect(() => asOptionalString(42, "num", "f.yaml")).toThrow(/num.*string/);
+    expect(() => asOptionalString({}, "obj", "f.yaml")).toThrow(/obj.*string/);
+    expect(() => asOptionalString([], "arr", "f.yaml")).toThrow(/arr.*string/);
+  });
+
+  it("accepts whitespace-only as a valid present string (differs from asString)", () => {
+    // This is the existing contract — optional passthrough doesn't trim,
+    // so "   " is a present-but-meaningless string. Callers validate shape
+    // separately if they care.
+    expect(asOptionalString("  ", "n", "f")).toBe("  ");
+  });
+});
+
+describe("assertPlainObject", () => {
+  it("passes for plain objects", () => {
+    expect(() => assertPlainObject({}, "where")).not.toThrow();
+    expect(() => assertPlainObject({ a: 1 }, "where")).not.toThrow();
+  });
+
+  it("throws for null", () => {
+    expect(() => assertPlainObject(null, "items[0]")).toThrow(
+      /items\[0\].*must be an object/,
+    );
+  });
+
+  it("throws for undefined", () => {
+    expect(() => assertPlainObject(undefined, "items[0]")).toThrow(
+      /must be an object/,
+    );
+  });
+
+  it("throws for arrays", () => {
+    expect(() => assertPlainObject([], "items[0]")).toThrow(/must be an object/);
+    expect(() => assertPlainObject([1, 2], "items[0]")).toThrow(
+      /must be an object/,
+    );
+  });
+
+  it("throws for primitives", () => {
+    expect(() => assertPlainObject("hello", "where")).toThrow();
+    expect(() => assertPlainObject(42, "where")).toThrow();
+    expect(() => assertPlainObject(true, "where")).toThrow();
+  });
+
+  it("narrows the type for typescript callers", () => {
+    const v: unknown = { foo: "bar" };
+    assertPlainObject(v, "where");
+    // v is now Record<string, unknown>; this line would be a type error
+    // if the assertion didn't narrow.
+    expect(v.foo).toBe("bar");
+  });
+});
+
+describe("loadYamlDir", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "yaml-dir-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeFile(name: string, contents: string): void {
+    writeFileSync(join(tmp, name), contents);
+  }
+
+  interface Item {
+    id: string;
+    entityId: string;
+    label: string;
+  }
+
+  const trivialLoader = (filePath: string): Item[] => {
+    const raw = filePath.split("/").pop() ?? "";
+    const base = raw.replace(/\.(yaml|yml)$/, "");
+    return [
+      {
+        id: `id-${base}`,
+        entityId: `entity-${base}`,
+        label: base,
+      },
+    ];
+  };
+
+  it("returns empty for a missing directory", () => {
+    const result = loadYamlDir<Item>({
+      dir: join(tmp, "nope"),
+      loadFile: trivialLoader,
+      kindLabel: "item",
+      describe: (i) => i.id,
+    });
+    expect(result.items).toEqual([]);
+    expect(result.files).toEqual([]);
+  });
+
+  it("lists yaml and yml files sorted, ignoring others", () => {
+    writeFile("b.yaml", "");
+    writeFile("a.yaml", "");
+    writeFile("c.yml", "");
+    writeFile("notes.md", "");
+    writeFile("README.txt", "");
+
+    const result = loadYamlDir<Item>({
+      dir: tmp,
+      loadFile: trivialLoader,
+      kindLabel: "item",
+      describe: (i) => i.id,
+    });
+    expect(result.files).toEqual(["a.yaml", "b.yaml", "c.yml"]);
+    expect(result.items.map((i) => i.label)).toEqual(["a", "b", "c"]);
+  });
+
+  it("throws a descriptive error on cross-file duplicate IDs", () => {
+    writeFile("first.yaml", "");
+    writeFile("second.yaml", "");
+
+    const loadFile = (filePath: string): Item[] => {
+      const base = filePath.endsWith("first.yaml") ? "first" : "second";
+      return [
+        {
+          id: "dup",
+          entityId: `entity-${base}`,
+          label: base,
+        },
+      ];
+    };
+
+    expect(() =>
+      loadYamlDir<Item>({
+        dir: tmp,
+        loadFile,
+        kindLabel: "thing",
+        describe: (i) => `${i.entityId}/${i.label}`,
+        dedupHint: "Change the label to disambiguate.",
+      }),
+    ).toThrow(
+      /Duplicate thing ID dup from \(entity-first\/first\) and \(entity-second\/second\)\. Change the label to disambiguate\./,
+    );
+  });
+
+  it("propagates errors thrown by loadFile unchanged", () => {
+    writeFile("broken.yaml", "");
+    const loadFile = (filePath: string): Item[] => {
+      throw new Error(`boom: ${filePath}`);
+    };
+    expect(() =>
+      loadYamlDir<Item>({
+        dir: tmp,
+        loadFile,
+        kindLabel: "x",
+        describe: () => "",
+      }),
+    ).toThrow(/boom:.*broken\.yaml/);
+  });
+
+  it("uses the default dedup hint when none is provided", () => {
+    writeFile("a.yaml", "");
+    writeFile("b.yaml", "");
+    const loadFile = (): Item[] => [
+      { id: "dup", entityId: "e", label: "x" },
+    ];
+    expect(() =>
+      loadYamlDir<Item>({
+        dir: tmp,
+        loadFile,
+        kindLabel: "item",
+        describe: (i) => i.id,
+      }),
+    ).toThrow(/Adjust one field to disambiguate\./);
+  });
+
+  it("aggregates items across files and preserves load order", () => {
+    writeFile("a.yaml", "");
+    writeFile("b.yaml", "");
+    const loadFile = (filePath: string): Item[] => {
+      if (filePath.endsWith("a.yaml")) {
+        return [
+          { id: "a1", entityId: "e1", label: "a1" },
+          { id: "a2", entityId: "e1", label: "a2" },
+        ];
+      }
+      return [{ id: "b1", entityId: "e2", label: "b1" }];
+    };
+
+    const result = loadYamlDir<Item>({
+      dir: tmp,
+      loadFile,
+      kindLabel: "item",
+      describe: (i) => i.id,
+    });
+    expect(result.items.map((i) => i.id)).toEqual(["a1", "a2", "b1"]);
+    expect(result.files).toEqual(["a.yaml", "b.yaml"]);
+  });
+});

--- a/crux/wiki-server/sync-yaml-helpers.ts
+++ b/crux/wiki-server/sync-yaml-helpers.ts
@@ -1,0 +1,242 @@
+/**
+ * Shared helpers for YAML-per-entity sync scripts.
+ *
+ * Used by sync-entity-events.ts and sync-entity-assessments.ts (and any
+ * future script with the same shape: one YAML file per entity containing
+ * an array of structured child records, synced via a deterministic-ID
+ * upsert endpoint).
+ *
+ * Contents:
+ *   - asString / asOptionalString — field-level YAML validators
+ *   - assertPlainObject            — null/primitive guard for array items
+ *   - loadYamlDir                  — dir walk + cross-file duplicate-ID detection
+ *   - runSyncMain                  — CLI scaffolding (env check, dry-run, health, report)
+ */
+
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { parseCliArgs } from "../lib/cli.ts";
+import { getServerUrl, getApiKey } from "../lib/wiki-server/client.ts";
+import { waitForHealthy } from "./sync-common.ts";
+
+// --- Field-level validators ---
+
+export function asString(v: unknown, field: string, file: string): string {
+  if (typeof v !== "string" || v.trim() === "") {
+    throw new Error(`${file}: '${field}' must be a non-empty string`);
+  }
+  return v;
+}
+
+export function asOptionalString(
+  v: unknown,
+  field: string,
+  file: string,
+): string | null {
+  if (v === undefined || v === null || v === "") return null;
+  if (typeof v !== "string") {
+    throw new Error(`${file}: '${field}' must be a string when present`);
+  }
+  return v;
+}
+
+/**
+ * Ensure a value is a plain object (not null, array, or primitive). Throws
+ * with a location-prefixed error if the shape is wrong. Use this on each
+ * element of a parsed YAML array before treating it as a record.
+ */
+export function assertPlainObject(
+  v: unknown,
+  where: string,
+): asserts v is Record<string, unknown> {
+  if (!v || typeof v !== "object" || Array.isArray(v)) {
+    throw new Error(`${where}: must be an object`);
+  }
+}
+
+// --- Directory loading + cross-file dup detection ---
+
+export interface LoadYamlDirOptions<T extends { id: string }> {
+  /** Absolute path to the directory of YAML files. */
+  dir: string;
+  /** Loader for a single file — throws on validation errors. */
+  loadFile: (filePath: string) => T[];
+  /**
+   * Short noun describing a single item — used in the duplicate-ID error
+   * message: `Duplicate ${kindLabel} ID <id> from (...) and (...).`
+   */
+  kindLabel: string;
+  /** Formats an item's natural-key tuple for the duplicate-ID error. */
+  describe: (item: T) => string;
+  /**
+   * Hint appended to duplicate-ID errors telling the author which field to
+   * change. Default: "Adjust one field to disambiguate."
+   */
+  dedupHint?: string;
+}
+
+/**
+ * Walk a directory, load every *.yaml / *.yml with `loadFile`, flatten the
+ * results, and throw on any duplicate item IDs across files. Returns an
+ * empty result when the directory does not exist.
+ *
+ * Exists so sync-entity-events and sync-entity-assessments don't each
+ * hand-roll the same dir walk + dup-detection loop.
+ */
+export function loadYamlDir<T extends { id: string }>(
+  options: LoadYamlDirOptions<T>,
+): { items: T[]; files: string[] } {
+  const {
+    dir,
+    loadFile,
+    kindLabel,
+    describe,
+    dedupHint = "Adjust one field to disambiguate.",
+  } = options;
+
+  if (!existsSync(dir)) {
+    return { items: [], files: [] };
+  }
+
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+
+  const all: T[] = [];
+  for (const f of files) {
+    all.push(...loadFile(join(dir, f)));
+  }
+
+  const seen = new Map<string, T>();
+  for (const item of all) {
+    const prev = seen.get(item.id);
+    if (prev) {
+      throw new Error(
+        `Duplicate ${kindLabel} ID ${item.id} from (${describe(prev)}) and ` +
+          `(${describe(item)}). ${dedupHint}`,
+      );
+    }
+    seen.set(item.id, item);
+  }
+
+  return { items: all, files };
+}
+
+// --- Main / CLI scaffolding ---
+
+export interface RunSyncMainOptions<T> {
+  /** Directory containing the YAML files (printed in the banner). */
+  dir: string;
+  /** Plural human label, e.g. "entity events". Used in log messages. */
+  label: string;
+  /** Loads every item from `dir`. */
+  loadAll: (dir: string) => { items: T[]; files: string[] };
+  /** Extracts the entity ID for the per-entity count summary. */
+  getEntityId: (item: T) => string;
+  /** Formats one item as a single-line dry-run preview. */
+  formatDryRun: (item: T) => string;
+  /**
+   * Runs the actual sync against the server. Must return a summary with
+   * `upserted` and `errors` counts. Typically wraps `batchSync`.
+   */
+  sync: (
+    serverUrl: string,
+    items: T[],
+    batchSize: number,
+  ) => Promise<{ upserted: number; errors: number }>;
+  /** Default batch size when --batch-size is not passed. */
+  defaultBatchSize?: number;
+}
+
+/**
+ * Run a sync script end-to-end: parse CLI, check env vars, load YAML,
+ * print per-entity counts, handle --dry-run, health-check, call sync,
+ * print a final report, and `process.exit(1)` on batch errors.
+ *
+ * Extracted from sync-entity-events.ts and sync-entity-assessments.ts —
+ * each now passes its loader + sync function + formatters here.
+ */
+export async function runSyncMain<T>(
+  options: RunSyncMainOptions<T>,
+): Promise<void> {
+  const {
+    dir,
+    label,
+    loadAll,
+    getEntityId,
+    formatDryRun,
+    sync,
+    defaultBatchSize = 100,
+  } = options;
+
+  const args = parseCliArgs(process.argv.slice(2));
+  const dryRun = args["dry-run"] === true;
+  const batchSize = Number(args["batch-size"]) || defaultBatchSize;
+
+  const serverUrl = getServerUrl();
+  const apiKey = getApiKey();
+
+  if (!serverUrl) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_URL environment variable is required",
+    );
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error(
+      "Error: LONGTERMWIKI_SERVER_API_KEY environment variable is required",
+    );
+    process.exit(1);
+  }
+
+  console.log(`Reading ${label} from: ${dir}`);
+  const { items, files } = loadAll(dir);
+  console.log(`  Found ${files.length} files, ${items.length} ${label}`);
+
+  if (items.length === 0) {
+    console.log("Nothing to sync.");
+    return;
+  }
+
+  const byEntity = new Map<string, number>();
+  for (const item of items) {
+    const eid = getEntityId(item);
+    byEntity.set(eid, (byEntity.get(eid) ?? 0) + 1);
+  }
+  for (const [entityId, count] of [...byEntity.entries()].sort()) {
+    console.log(`  ${entityId}: ${count} ${label}`);
+  }
+
+  if (dryRun) {
+    console.log(`\n[dry-run] Would sync these ${label} (showing first 10):`);
+    for (const item of items.slice(0, 10)) {
+      console.log(`  ${formatDryRun(item)}`);
+    }
+    if (items.length > 10) {
+      console.log(`  ... and ${items.length - 10} more`);
+    }
+    return;
+  }
+
+  console.log("\nChecking server health...");
+  const healthy = await waitForHealthy(serverUrl);
+  if (!healthy) {
+    console.error(
+      `Error: Server at ${serverUrl} is not healthy. Aborting sync.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nSyncing ${items.length} ${label} (batch size: ${batchSize})...`,
+  );
+  const result = await sync(serverUrl, items, batchSize);
+
+  console.log(`\nSync complete:`);
+  console.log(`  Upserted: ${result.upserted}`);
+  if (result.errors > 0) {
+    console.log(`  Errors:   ${result.errors}`);
+    console.error(`\nSync failed with ${result.errors} ${label} errors.`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

Factors ~120 lines of scaffolding common to `sync-entity-events.ts` and `sync-entity-assessments.ts` into a new `crux/wiki-server/sync-yaml-helpers.ts`, per the QUA-679 proposal.

**Stacked on PR #4568** (QUA-27 — entity-assessments) because that PR introduces the second sync script being DRY'd. Base branch is set to `claude/qua-27-entity-assessments-extractor`; GitHub will re-target to `main` automatically once PR #4568 merges.

## What's extracted

- `asString(v, field, file)` / `asOptionalString(v, field, file)` — field-level YAML validators
- `assertPlainObject(v, where)` — null/primitive guard for array items, TypeScript-narrowing via `asserts`
- `loadYamlDir<T extends { id: string }>({ dir, loadFile, kindLabel, describe, dedupHint? })` — dir walk + cross-file duplicate-ID detection
- `runSyncMain<T>({ dir, label, loadAll, getEntityId, formatDryRun, sync, defaultBatchSize? })` — CLI scaffolding (env-var check, `--dry-run`, `--batch-size`, per-entity count summary, health check, final report, `process.exit(1)` on errors)

Each sync script now supplies its loader + sync wrapper + one-line formatters and delegates the rest.

## Pre-existing bug fix

The QUA-27 review flagged two pre-existing issues in `sync-entity-events.ts` that weren't back-ported. This PR fixes one of them:

- **Null/primitive items in the `events` array** crashed with a bare `TypeError` because the loader blindly cast `parsed.events[i]` to `RawEvent`. Now guarded by `assertPlainObject`, matching the assessments loader. Regression test added in `sync-entity-events.test.ts` ("rejects null/primitive items in the events array").

## Public API — unchanged

Both loaders keep identical signatures, identical error messages, and identical duplicate-detection semantics. All 49 existing loader tests pass without modification:

- `loadEventsFile`, `loadAllEvents`, `eventIdFor`, `VALID_EVENT_TYPES`, `VALID_SIGNIFICANCE`
- `loadAssessmentsFile`, `loadAllAssessments`, `assessmentIdFor`, `VALID_ASSESSORS`
- `syncEntityEvents`, `syncEntityAssessments` (thin `batchSync` wrappers — kept for programmatic callers)

Duplicate-ID error messages are byte-identical (helper composes `kindLabel` + `describe()` + `dedupHint` back to the same string shape).

## Net diff

```
 crux/wiki-server/sync-entity-assessments.ts   165 +----------
 crux/wiki-server/sync-entity-events.test.ts    16 +
 crux/wiki-server/sync-entity-events.ts        163 +----------
 crux/wiki-server/sync-yaml-helpers.test.ts    219 ++++++++ (new)
 crux/wiki-server/sync-yaml-helpers.ts         240 ++++++++ (new)
```

## Test plan

- [x] `pnpm vitest run crux/wiki-server/sync-yaml-helpers.test.ts crux/wiki-server/sync-entity-events.test.ts crux/wiki-server/sync-entity-assessments.test.ts` — **70 passed** (21 new helper tests, 24 events, 25 assessments)
- [x] `pnpm test -- crux/wiki-server` — **293 passed**, 26 skipped
- [x] `pnpm crux w validate gate --fix` — **51/51 blocking checks pass** (3 pre-existing advisory warnings)
- [x] `pnpm build` — passes
- [x] Typecheck on changed files clean (`tsc --noEmit -p crux/tsconfig.json` errors are all pre-existing in unrelated files: `political-data.test.ts`, `propose-client.ts`, `playwright-fetcher.ts`, etc.)

## Follow-ups deferred

- The second pre-existing events bug mentioned in the QUA-27 review: within-file duplicate `(entityId, date, title)` detection. Not fixed here because events' server-side natural key is on the derived `id` only, so the cross-file dup check (which runs after flattening) already catches it — adding a within-file check would only give a clearer error message. Leaving as-is for now; file a separate ticket if the error-message clarity matters.

Closes QUA-679
