### PR TITLE
coord: 4 systemic improvements from coord-session retrospective

### DIFF
--- a/.claude/hooks/block-raw-gh-pr.sh
+++ b/.claude/hooks/block-raw-gh-pr.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
-# Block raw `gh pr create` — agents must use `crux gh pr create` which auto-injects
-# Linear issue references (Fixes QUA-NNN) into the PR body.
-# Without this, PRs miss the Linear linkage and issues don't auto-close on merge.
+# PreToolUse hook: blocks raw `gh pr create` — agents must use
+# `crux gh pr create`, which auto-injects Linear references (Fixes QUA-NNN)
+# into the PR body so issues auto-close on merge.
+#
+# Reads the official stdin JSON protocol (every other hook in this dir does
+# the same). The previous CLAUDE_TOOL_INPUT env-var pattern was unreliable
+# in past Claude Code versions and silently no-op'd; flagged by CodeRabbit
+# on PR #4576.
 
-COMMAND="${CLAUDE_TOOL_INPUT:-}"
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" != "Bash" ] && exit 0
 
-# Match `gh pr create` but not `crux gh pr create` or `pnpm crux gh pr create`
-if echo "$COMMAND" | grep -qE '^\s*gh\s+pr\s+create'; then
-  echo "BLOCKED: Use \`pnpm crux gh pr create\` instead of raw \`gh pr create\`."
-  echo "The crux wrapper auto-injects Linear issue references (Fixes QUA-NNN) so issues auto-close on PR merge."
-  exit 1
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Match `gh pr create` but not `crux gh pr create` or `pnpm crux gh pr create`.
+if echo "$COMMAND" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create\b'; then
+  echo "BLOCKED: Use \`pnpm crux gh pr create\` instead of raw \`gh pr create\`." >&2
+  echo "The crux wrapper auto-injects Linear issue references (Fixes QUA-NNN) so issues auto-close on PR merge." >&2
+  exit 2
 fi

--- a/.claude/hooks/require-stage-approved.sh
+++ b/.claude/hooks/require-stage-approved.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Block `gh pr merge ...` calls when the target PR lacks the `stage:approved`
+# label OR has unresolved Major/Critical CodeRabbit review comments.
+# Mirrors PR-patrol's own enqueue-eligibility logic; prevents a coord
+# session from shipping un-reviewed work as happened on 2026-04-22 (11
+# Major findings landed on main because `gh pr merge --auto` was called
+# without checking either gate).
+#
+# Override (use sparingly, document why):
+#   ALLOW_UNAPPROVED_MERGE=1 gh pr merge <N> ...
+#
+# Exit codes: 0 = allow, 2 = block (Claude reads stderr).
+
+COMMAND="${CLAUDE_TOOL_INPUT:-}"
+REPO="quantified-uncertainty/longterm-wiki"
+
+# Match `gh pr merge ...` standalone or via pnpm/npx, but NOT in pipes/quotes
+# where it might be discussed (e.g. echo "gh pr merge ...").
+# Pattern: optional `pnpm `/`npx ` prefix, then `gh pr merge`, with whitespace boundary.
+if ! echo "$COMMAND" | grep -qE '(^|[;&|]|^\s*)(pnpm\s+|npx\s+)?gh\s+pr\s+merge\b'; then
+  exit 0
+fi
+
+# Override escape hatch — used when the user explicitly authorizes.
+if [[ "${ALLOW_UNAPPROVED_MERGE:-}" == "1" ]]; then
+  echo "[require-stage-approved] Override: ALLOW_UNAPPROVED_MERGE=1 — skipping label/review checks." >&2
+  exit 0
+fi
+
+# Extract the PR number. Accept these forms:
+#   gh pr merge 1234 [...]
+#   gh pr merge https://github.com/owner/repo/pull/1234
+#   gh pr merge --auto         (no number → current branch PR; we'll query it)
+PR=""
+PR=$(echo "$COMMAND" | grep -oE 'gh\s+pr\s+merge\s+[^[:space:]]*[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' | head -1)
+if [[ -z "$PR" ]]; then
+  PR=$(echo "$COMMAND" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
+fi
+if [[ -z "$PR" ]]; then
+  # No explicit PR — try the current branch's PR via gh.
+  PR=$(gh pr view --repo "$REPO" --json number --jq .number 2>/dev/null)
+fi
+
+if [[ -z "$PR" ]]; then
+  # Couldn't determine PR; let it through and let gh report its own error.
+  exit 0
+fi
+
+# Query labels + bot review threads in one call.
+META=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name]' 2>/dev/null)
+if [[ -z "$META" ]]; then
+  echo "[require-stage-approved] Could not fetch PR #$PR metadata — letting through." >&2
+  exit 0
+fi
+
+# Check 1: stage:approved label.
+if ! echo "$META" | grep -q '"stage:approved"'; then
+  echo "BLOCKED: PR #$PR is missing the \`stage:approved\` label." >&2
+  echo "" >&2
+  echo "Coord sessions must not merge PRs without explicit human approval (the" >&2
+  echo "label is set by the user, not by agents). PR-patrol follows the same rule." >&2
+  echo "" >&2
+  echo "Current labels: $META" >&2
+  echo "" >&2
+  echo "If the user explicitly told you to merge this PR anyway, override with:" >&2
+  echo "  ALLOW_UNAPPROVED_MERGE=1 gh pr merge $PR ..." >&2
+  echo "" >&2
+  echo "See: \$CLAUDE_PROJECT_DIR/.claude/memory/feedback_pr_merge_authority.md" >&2
+  exit 2
+fi
+
+# Check 2: open CodeRabbit Major / Potential issue review comments.
+# The list endpoint returns inline review comments (not PR-level comments).
+CR_MAJOR=$(gh api "repos/$REPO/pulls/$PR/comments" --jq \
+  '[.[] | select(.user.login == "coderabbitai[bot]") | select(.body | test("Major|Critical|Potential issue"))] | length' \
+  2>/dev/null)
+
+if [[ -n "$CR_MAJOR" && "$CR_MAJOR" -gt 0 ]]; then
+  echo "BLOCKED: PR #$PR has $CR_MAJOR unresolved CodeRabbit Major/Critical/Potential-issue findings." >&2
+  echo "" >&2
+  echo "Either address them (push fix commits, then re-merge) or, if they've" >&2
+  echo "been verified as already-handled / out-of-scope and the user has" >&2
+  echo "approved shipping anyway, override with:" >&2
+  echo "  ALLOW_UNAPPROVED_MERGE=1 gh pr merge $PR ..." >&2
+  echo "" >&2
+  echo "Inspect findings: gh api repos/$REPO/pulls/$PR/comments | jq '.[] | select(.user.login == \"coderabbitai[bot]\")'" >&2
+  exit 2
+fi
+
+# Both checks pass.
+exit 0

--- a/.claude/hooks/require-stage-approved.sh
+++ b/.claude/hooks/require-stage-approved.sh
@@ -1,91 +1,19 @@
 #!/usr/bin/env bash
-# Block `gh pr merge ...` calls when the target PR lacks the `stage:approved`
-# label OR has unresolved Major/Critical CodeRabbit review comments.
-# Mirrors PR-patrol's own enqueue-eligibility logic; prevents a coord
-# session from shipping un-reviewed work as happened on 2026-04-22 (11
-# Major findings landed on main because `gh pr merge --auto` was called
-# without checking either gate).
+# PreToolUse hook: gate `gh pr merge ...` on `stage:approved` label and
+# zero unresolved CodeRabbit Major/Critical/Potential-issue review threads.
+# All logic lives in TypeScript (testable, typed); this is a thin wrapper
+# that reads the official stdin JSON protocol and forwards the command.
 #
-# Override (use sparingly, document why):
-#   ALLOW_UNAPPROVED_MERGE=1 gh pr merge <N> ...
+# Override: ALLOW_UNAPPROVED_MERGE=1 gh pr merge <N> ...
 #
-# Exit codes: 0 = allow, 2 = block (Claude reads stderr).
+# Exit codes: 0 = allow, 2 = block (stderr → Claude as the reason).
 
-COMMAND="${CLAUDE_TOOL_INPUT:-}"
-REPO="quantified-uncertainty/longterm-wiki"
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$TOOL_NAME" != "Bash" ] && exit 0
 
-# Match `gh pr merge ...` standalone or via pnpm/npx, but NOT in pipes/quotes
-# where it might be discussed (e.g. echo "gh pr merge ...").
-# Pattern: optional `pnpm `/`npx ` prefix, then `gh pr merge`, with whitespace boundary.
-if ! echo "$COMMAND" | grep -qE '(^|[;&|]|^\s*)(pnpm\s+|npx\s+)?gh\s+pr\s+merge\b'; then
-  exit 0
-fi
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
 
-# Override escape hatch — used when the user explicitly authorizes.
-if [[ "${ALLOW_UNAPPROVED_MERGE:-}" == "1" ]]; then
-  echo "[require-stage-approved] Override: ALLOW_UNAPPROVED_MERGE=1 — skipping label/review checks." >&2
-  exit 0
-fi
-
-# Extract the PR number. Accept these forms:
-#   gh pr merge 1234 [...]
-#   gh pr merge https://github.com/owner/repo/pull/1234
-#   gh pr merge --auto         (no number → current branch PR; we'll query it)
-PR=""
-PR=$(echo "$COMMAND" | grep -oE 'gh\s+pr\s+merge\s+[^[:space:]]*[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' | head -1)
-if [[ -z "$PR" ]]; then
-  PR=$(echo "$COMMAND" | grep -oE 'pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
-fi
-if [[ -z "$PR" ]]; then
-  # No explicit PR — try the current branch's PR via gh.
-  PR=$(gh pr view --repo "$REPO" --json number --jq .number 2>/dev/null)
-fi
-
-if [[ -z "$PR" ]]; then
-  # Couldn't determine PR; let it through and let gh report its own error.
-  exit 0
-fi
-
-# Query labels + bot review threads in one call.
-META=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name]' 2>/dev/null)
-if [[ -z "$META" ]]; then
-  echo "[require-stage-approved] Could not fetch PR #$PR metadata — letting through." >&2
-  exit 0
-fi
-
-# Check 1: stage:approved label.
-if ! echo "$META" | grep -q '"stage:approved"'; then
-  echo "BLOCKED: PR #$PR is missing the \`stage:approved\` label." >&2
-  echo "" >&2
-  echo "Coord sessions must not merge PRs without explicit human approval (the" >&2
-  echo "label is set by the user, not by agents). PR-patrol follows the same rule." >&2
-  echo "" >&2
-  echo "Current labels: $META" >&2
-  echo "" >&2
-  echo "If the user explicitly told you to merge this PR anyway, override with:" >&2
-  echo "  ALLOW_UNAPPROVED_MERGE=1 gh pr merge $PR ..." >&2
-  echo "" >&2
-  echo "See: \$CLAUDE_PROJECT_DIR/.claude/memory/feedback_pr_merge_authority.md" >&2
-  exit 2
-fi
-
-# Check 2: open CodeRabbit Major / Potential issue review comments.
-# The list endpoint returns inline review comments (not PR-level comments).
-CR_MAJOR=$(gh api "repos/$REPO/pulls/$PR/comments" --jq \
-  '[.[] | select(.user.login == "coderabbitai[bot]") | select(.body | test("Major|Critical|Potential issue"))] | length' \
-  2>/dev/null)
-
-if [[ -n "$CR_MAJOR" && "$CR_MAJOR" -gt 0 ]]; then
-  echo "BLOCKED: PR #$PR has $CR_MAJOR unresolved CodeRabbit Major/Critical/Potential-issue findings." >&2
-  echo "" >&2
-  echo "Either address them (push fix commits, then re-merge) or, if they've" >&2
-  echo "been verified as already-handled / out-of-scope and the user has" >&2
-  echo "approved shipping anyway, override with:" >&2
-  echo "  ALLOW_UNAPPROVED_MERGE=1 gh pr merge $PR ..." >&2
-  echo "" >&2
-  echo "Inspect findings: gh api repos/$REPO/pulls/$PR/comments | jq '.[] | select(.user.login == \"coderabbitai[bot]\")'" >&2
-  exit 2
-fi
-
-# Both checks pass.
-exit 0
+exec env COMMAND="$COMMAND" npx --yes tsx \
+  "$CLAUDE_PROJECT_DIR/crux/scripts/check-pr-merge-eligible.ts"

--- a/.claude/rules/pr-review-guidelines.md
+++ b/.claude/rules/pr-review-guidelines.md
@@ -34,6 +34,28 @@ Closes #533
 Closes #538
 ```
 
+## CodeRabbit "Addressed in commit X" markers — DO NOT TRUST
+
+CodeRabbit sometimes appends `✅ Addressed in commit <sha>` to its review threads when it thinks a follow-up commit fixed the finding. Empirically these markers are **unreliable** in two ways:
+
+1. **The referenced SHA may not exist.** Saw `✅ Addressed in commit 3d5cbbe` on PR #4538 (ford-foundation, protect-democracy duplicate-fact findings) and `✅ Addressed in commits 760b1ba to 2ce2219` on PR #4482 (swap-fk-target findings). `git show` returned `unknown revision` for both. CodeRabbit was confidently citing phantom commits.
+2. **Even when the SHA exists, the relevant code may not actually reflect the fix.** PR #4482 finding 3 (information_schema joins missing schema) was marked addressed but the joins still matched on `constraint_name` only — the partial WHERE-clause hardening that did land was unrelated and didn't address the original concern.
+
+**Always verify** before treating a finding as resolved:
+
+```bash
+# 1. Confirm the cited commit exists
+git show <sha> --stat
+
+# 2. Grep the current file for the bug pattern the finding flagged
+grep -n "<bad-pattern>" <path>
+
+# 3. If both are clean, the finding is genuinely addressed.
+#    Otherwise treat it as an outstanding finding regardless of the marker.
+```
+
+This applies whether you're reviewing a teammate's PR, addressing comments on your own PR, or deciding whether to merge — the marker has no authority on its own.
+
 ## Ending a session
 
 Every session should end with one of:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,6 +72,11 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-raw-gh-pr.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/require-stage-approved.sh\"",
+            "timeout": 15
           }
         ]
       }

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -165,7 +165,7 @@ cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && pnpm crux sys audits lis
 PR patrol doesn't currently log dollar cost (see QUA-324 — follow-up to add `cost_usd` to `runs.jsonl`). As a proxy until that lands, count `pr_result` entries in the last 24h from `~/.cache/pr-patrol/runs.jsonl`. **Also surface the daemon's age** — long-running daemons (>2 days) are running stale code and miss every patrol fix that has merged since they started. Empirically the daemon dies silently on credit-balance issues + races, so users need a visible signal (this skill is the only place it surfaces).
 
 ```bash
-PATROL_PID=$(pgrep -f "crux\s+(gh\s+)?pr-patrol\s+(run|parallel)" | head -1)
+PATROL_PID=$(pgrep -f "crux[[:space:]]+(gh[[:space:]]+)?pr-patrol[[:space:]]+(run|parallel)" | head -1)
 if [ -n "$PATROL_PID" ]; then
   # Daemon age in days (compare lstart timestamp to now). BSD `ps -p PID -o lstart=`
   # returns e.g. "Tue Apr 22 09:26:17 2026". macOS-only; on Linux use --etime.
@@ -219,7 +219,7 @@ echo "Restart patrol now? (Re-runs the Section 1c block — kill old daemon + st
 
 Restart steps (use only on user confirmation, OR automatically if `--auto-restart-stale` is passed):
 ```bash
-pkill -f "crux\s+(gh\s+)?pr-patrol\s+(run|parallel)" 2>/dev/null
+pkill -f "crux[[:space:]]+(gh[[:space:]]+)?pr-patrol[[:space:]]+(run|parallel)" 2>/dev/null
 sleep 2
 cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
   export GITHUB_TOKEN=$(gh auth token) && \
@@ -229,7 +229,7 @@ disown
 
 **6b. Print the summary block:**
 
-```
+```text
 === Admin session ready ===
 Date:        2026-04-10
 Background:  rename-loop ✓ | ws-refresh ✓ | <PATROL_STATUS from 6a>

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -160,13 +160,28 @@ cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && pnpm crux sys audits lis
 
 ### Section 6: Print orientation summary
 
-**6a. Compute PR patrol 24h activity.** PR patrol doesn't currently log dollar cost (see QUA-324 — follow-up to add `cost_usd` to `runs.jsonl`). As a proxy until that lands, count `pr_result` entries in the last 24h from `~/.cache/pr-patrol/runs.jsonl`:
+**6a. Compute PR patrol status — alive, age, 24h activity.**
+
+PR patrol doesn't currently log dollar cost (see QUA-324 — follow-up to add `cost_usd` to `runs.jsonl`). As a proxy until that lands, count `pr_result` entries in the last 24h from `~/.cache/pr-patrol/runs.jsonl`. **Also surface the daemon's age** — long-running daemons (>2 days) are running stale code and miss every patrol fix that has merged since they started. Empirically the daemon dies silently on credit-balance issues + races, so users need a visible signal (this skill is the only place it surfaces).
 
 ```bash
-if pgrep -f "crux gh pr-patrol run" > /dev/null; then
+PATROL_PID=$(pgrep -f "crux\s+(gh\s+)?pr-patrol\s+(run|parallel)" | head -1)
+if [ -n "$PATROL_PID" ]; then
+  # Daemon age in days (compare lstart timestamp to now). BSD `ps -p PID -o lstart=`
+  # returns e.g. "Tue Apr 22 09:26:17 2026". macOS-only; on Linux use --etime.
+  STARTED=$(ps -p "$PATROL_PID" -o lstart= 2>/dev/null | sed 's/^ *//')
+  STARTED_TS=$(date -j -f "%a %b %d %T %Y" "$STARTED" "+%s" 2>/dev/null || echo 0)
+  NOW_TS=$(date +%s)
+  if [ "$STARTED_TS" -gt 0 ]; then
+    AGE_DAYS=$(( (NOW_TS - STARTED_TS) / 86400 ))
+    AGE_NOTE=" — started ${AGE_DAYS}d ago"
+    [ "$AGE_DAYS" -ge 2 ] && AGE_NOTE="${AGE_NOTE} ⚠ STALE (running pre-${AGE_DAYS}d code; restart to pick up fixes)"
+  else
+    AGE_NOTE=""
+  fi
+
   RUNS_24H=$(awk -v cutoff="$(date -u -v-24H +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%S)" '
     /"type":"pr_result"/ {
-      # extract timestamp
       if (match($0, /"timestamp":"[^"]+"/)) {
         ts = substr($0, RSTART+13, RLENGTH-14)
         if (ts >= cutoff) count++
@@ -175,17 +190,41 @@ if pgrep -f "crux gh pr-patrol run" > /dev/null; then
     END { print count+0 }
   ' ~/.cache/pr-patrol/runs.jsonl 2>/dev/null || echo 0)
   # Warn threshold: >40 fix attempts in 24h is unusually high (normal is ~5-15).
-  # Chosen because each attempt takes ~3-10min of Claude time — 40+ suggests a
-  # runaway loop or an oscillating PR. Downgrade to raw dollars once QUA-324 lands.
+  # 40+ suggests a runaway loop or an oscillating PR. Downgrade to raw $ when QUA-324 lands.
   if [ "$RUNS_24H" -gt 40 ]; then
-    PATROL_STATUS="⚠ pr-patrol ✓ (${RUNS_24H} runs/24h — unusually high)"
+    PATROL_STATUS="⚠ pr-patrol ✓ (${RUNS_24H} runs/24h — unusually high)${AGE_NOTE}"
   else
-    PATROL_STATUS="pr-patrol ✓ (${RUNS_24H} runs/24h)"
+    PATROL_STATUS="pr-patrol ✓ (${RUNS_24H} runs/24h)${AGE_NOTE}"
+  fi
+
+  # Also flag if patrol source code has changed since the daemon started — a
+  # restart will pick up new turn-budget tunings, scoring rules, etc.
+  if [ "$STARTED_TS" -gt 0 ]; then
+    LAST_PATROL_COMMIT_TS=$(cd "$CLAUDE_PROJECT_DIR" 2>/dev/null && git log -1 --format=%ct -- crux/pr-patrol/ 2>/dev/null || echo 0)
+    if [ "$LAST_PATROL_COMMIT_TS" -gt "$STARTED_TS" ]; then
+      PATROL_STATUS="${PATROL_STATUS} | ⚠ source updated since daemon start — restart recommended"
+    fi
   fi
 else
-  PATROL_STATUS="pr-patrol –"
+  PATROL_STATUS="pr-patrol – (NOT RUNNING — restart with the Section 1c block)"
 fi
 echo "$PATROL_STATUS"
+```
+
+**If the daemon is stale (≥2d) or its source code has been updated**, offer to restart it before reporting the summary:
+
+```bash
+echo "Restart patrol now? (Re-runs the Section 1c block — kill old daemon + start fresh.)"
+```
+
+Restart steps (use only on user confirmation, OR automatically if `--auto-restart-stale` is passed):
+```bash
+pkill -f "crux\s+(gh\s+)?pr-patrol\s+(run|parallel)" 2>/dev/null
+sleep 2
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
+  export GITHUB_TOKEN=$(gh auth token) && \
+  nohup pnpm crux gh pr-patrol run > /tmp/lw-pr-patrol.log 2>&1 &
+disown
 ```
 
 **6b. Print the summary block:**
@@ -194,11 +233,14 @@ echo "$PATROL_STATUS"
 === Admin session ready ===
 Date:        2026-04-10
 Background:  rename-loop ✓ | ws-refresh ✓ | <PATROL_STATUS from 6a>
+                                              # PATROL_STATUS now includes age + stale-source warning
 Production:  healthy | uptime Xs
 Linear:      N stale In Progress | M ready P1/P2
 CI (main):   N failures in last 24h
 Slots:       N active | M idle
 ```
+
+If `PATROL_STATUS` contains `⚠ STALE` or `⚠ source updated`, surface that prominently in your first user message — those signal the patrol is running pre-fix code and needs a restart cycle.
 
 Then ask the user: "What would you like to work on?"
 
@@ -207,6 +249,7 @@ Then ask the user: "What would you like to work on?"
 - `/admin-setup` — full setup with all sections
 - `/admin-setup --no-loops` — skip starting background processes (for read-only audits)
 - `/admin-setup --quiet` — only print orientation summary, suppress section headers
+- `/admin-setup --auto-restart-stale` — restart patrol without confirmation if it's ≥2d old or its source has been updated
 
 ## Important
 

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,33 +1,55 @@
 ---
 name: worktree
-description: Create a /tmp/ worktree from the lw/main reference clone for an existing branch (or new branch from main), wire node_modules + .env symlinks, and report the path. Use whenever a coord session needs to make changes on a branch other than main — replaces the 6-step manual setup that gets repeated dozens of times per session.
+description: Create a /tmp/wt-<sha> git worktree from the lw/main reference clone for an existing branch (or new branch from origin/main), wire node_modules + .env symlinks, and report the path. Use whenever a coord session needs to make changes on a branch other than main — replaces the 6-step manual recipe that gets repeated dozens of times in long PR-fixing sessions.
 disable-model-invocation: false
 allowed-tools: Bash
 ---
 
 # /worktree — One-Shot Worktree Setup
 
-Coord sessions can't edit files on `main` (PreToolUse hook blocks it), so every PR fix needs a feature branch. The standard recipe — `git worktree add`, then 4 `ln -sf` calls for `node_modules` / `.env` — is ~6 commands and ~70 lines of context that gets repeated dozens of times in a long session. This skill collapses it to one call.
+Coord sessions can't edit files on `main` (PreToolUse hook blocks it), so every PR fix needs a feature branch. The standard recipe — `git worktree add`, then four `ln -sf` calls for `node_modules` / `.env` — gets repeated dozens of times in any long session. This skill collapses it to one call.
 
 ## Usage
 
-```
+```text
 /worktree <branch>           # check out an existing branch
 /worktree -b <new-branch>    # create new branch from origin/main
 ```
 
-`<branch>` may be either form (`claude/qua-665-foo` or `qua-665-foo` — the skill prefixes `claude/` automatically if missing).
+`<branch>` may be either form (`claude/qua-665-foo` or `qua-665-foo`); the skill prefixes `claude/` automatically when missing.
 
-## What it does
+## Implementation
 
-1. `git fetch origin <branch>` (if it exists) — silently skips if the branch is local-only.
-2. `git worktree add /tmp/wt-<short-sha> <branch>` from the `lw/main` reference clone. The `<short-sha>` is the first 6 chars of the branch's HEAD (or `new-<rand>` for `-b`), so two simultaneous fixes don't collide.
-3. Symlinks `node_modules`, `apps/web/node_modules`, `apps/wiki-server/node_modules`, and `.env` (→ `lw/.env.base`) so `pnpm` / `crux` / `vitest` work without re-installing.
-4. Prints the absolute path so the user (or follow-up bash calls) can `cd` directly.
+The skill executes `.claude/skills/worktree/worktree.sh`, passing through any args:
+
+```bash
+bash "$CLAUDE_PROJECT_DIR/.claude/skills/worktree/worktree.sh" "$@"
+```
+
+The script:
+
+1. Fetches the branch from origin (silently skips if local-only).
+2. Computes a `/tmp/wt-<short-sha>` path so two simultaneous fixes don't collide.
+3. `git worktree add` (or, on `-b`, creates the branch from `origin/main`).
+4. Symlinks `node_modules`, `apps/web/node_modules`, `apps/wiki-server/node_modules`, and `.env` (→ `lw/.env.base`) so `pnpm` / `crux` / `vitest` work without re-installing.
+5. Prints the absolute path so the user (or follow-up Bash calls) can `cd` directly.
+
+## Safety
+
+The script **refuses to reuse** an existing worktree if it has either:
+
+- uncommitted local changes (detected via `git status --porcelain`), or
+- commits ahead of `origin/<branch>` (detected via `git rev-list origin/<branch>..HEAD`).
+
+Both cases bail with an actionable message — wiping in-flight work has happened before in slot agents and the cost of a destructive reset isn't worth the convenience. To clear and start over, the user removes the worktree explicitly:
+
+```bash
+git -C /Users/ozziegooen/Documents/GitHub.nosync/lw/main worktree remove --force /tmp/wt-<sha>
+```
 
 ## Example
 
-```
+```text
 $ /worktree claude/qua-665-wire-t1-importers-to-propose
 Worktree:    /tmp/wt-ac742e
 Branch:      claude/qua-665-wire-t1-importers-to-propose (HEAD ac742e844)
@@ -35,89 +57,18 @@ Symlinked:   node_modules, apps/{web,wiki-server}/node_modules, .env
 Ready:       cd /tmp/wt-ac742e
 ```
 
-## Implementation
-
-When invoked, run:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-MAIN_CLONE="/Users/ozziegooen/Documents/GitHub.nosync/lw/main"
-ENV_FILE="/Users/ozziegooen/Documents/GitHub.nosync/lw/.env.base"
-
-# Parse args
-NEW_BRANCH=""
-BRANCH=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -b)        NEW_BRANCH="1"; shift ;;
-    --branch=*) BRANCH="${1#*=}"; shift ;;
-    *)         BRANCH="$1"; shift ;;
-  esac
-done
-
-if [[ -z "$BRANCH" ]]; then
-  echo "Usage: /worktree <branch>            (existing)" >&2
-  echo "       /worktree -b <new-branch>     (new from origin/main)" >&2
-  exit 1
-fi
-
-# Auto-prefix `claude/` if missing
-if [[ ! "$BRANCH" =~ ^(claude/|main$|production$) ]]; then
-  BRANCH="claude/$BRANCH"
-fi
-
-cd "$MAIN_CLONE"
-
-if [[ -n "$NEW_BRANCH" ]]; then
-  # Make sure origin/main is fresh, then create new branch from it
-  git fetch origin main --quiet
-  SHORT="new-$(printf '%04x' $RANDOM)"
-  WT="/tmp/wt-${SHORT}"
-  git worktree add -b "$BRANCH" "$WT" origin/main >&2
-else
-  git fetch origin "$BRANCH" --quiet 2>/dev/null || true
-  HEAD_SHA=$(git rev-parse --short=6 "origin/$BRANCH" 2>/dev/null || git rev-parse --short=6 "$BRANCH" 2>/dev/null || echo "unknown")
-  WT="/tmp/wt-${HEAD_SHA}"
-  if [[ -d "$WT" ]]; then
-    echo "Worktree already exists at $WT — reusing." >&2
-    cd "$WT"
-    git fetch origin "$BRANCH" --quiet 2>/dev/null || true
-    git reset --hard "origin/$BRANCH" >&2 2>/dev/null || true
-  else
-    git worktree add "$WT" "$BRANCH" >&2
-  fi
-fi
-
-# Symlink node_modules + env (idempotent)
-ln -sfn "$MAIN_CLONE/node_modules" "$WT/node_modules"
-mkdir -p "$WT/apps/web" "$WT/apps/wiki-server"
-ln -sfn "$MAIN_CLONE/apps/web/node_modules" "$WT/apps/web/node_modules"
-ln -sfn "$MAIN_CLONE/apps/wiki-server/node_modules" "$WT/apps/wiki-server/node_modules"
-ln -sfn "$ENV_FILE" "$WT/.env"
-
-# Report
-NEW_HEAD=$(cd "$WT" && git rev-parse --short HEAD)
-echo "Worktree:    $WT"
-echo "Branch:      $BRANCH (HEAD $NEW_HEAD)"
-echo "Symlinked:   node_modules, apps/{web,wiki-server}/node_modules, .env"
-echo "Ready:       cd $WT"
-```
-
-## Cleanup
-
-When you're done with a worktree (PR merged, abandoned, etc.):
-
-```bash
-cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main
-git worktree remove --force /tmp/wt-<short-sha>
-```
-
-The `ws refresh` loop also prunes stale worktrees automatically when their branch is merged.
-
 ## When NOT to use this
 
 - For changes to `main` itself (you can't — there's a PreToolUse hook that blocks it).
 - For large multi-file rebases where a slot agent would be more appropriate (use `./ws open <N> --claude` instead — slots have full Claude sessions).
 - For changes touching `ops/` or release flow (use `coord/` directly via the release session).
+
+## Cleanup
+
+Manual:
+
+```bash
+git -C /Users/ozziegooen/Documents/GitHub.nosync/lw/main worktree remove --force /tmp/wt-<sha>
+```
+
+Automatic: `ws refresh` prunes stale worktrees when their branch is merged.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: worktree
+description: Create a /tmp/ worktree from the lw/main reference clone for an existing branch (or new branch from main), wire node_modules + .env symlinks, and report the path. Use whenever a coord session needs to make changes on a branch other than main — replaces the 6-step manual setup that gets repeated dozens of times per session.
+disable-model-invocation: false
+allowed-tools: Bash
+---
+
+# /worktree — One-Shot Worktree Setup
+
+Coord sessions can't edit files on `main` (PreToolUse hook blocks it), so every PR fix needs a feature branch. The standard recipe — `git worktree add`, then 4 `ln -sf` calls for `node_modules` / `.env` — is ~6 commands and ~70 lines of context that gets repeated dozens of times in a long session. This skill collapses it to one call.
+
+## Usage
+
+```
+/worktree <branch>           # check out an existing branch
+/worktree -b <new-branch>    # create new branch from origin/main
+```
+
+`<branch>` may be either form (`claude/qua-665-foo` or `qua-665-foo` — the skill prefixes `claude/` automatically if missing).
+
+## What it does
+
+1. `git fetch origin <branch>` (if it exists) — silently skips if the branch is local-only.
+2. `git worktree add /tmp/wt-<short-sha> <branch>` from the `lw/main` reference clone. The `<short-sha>` is the first 6 chars of the branch's HEAD (or `new-<rand>` for `-b`), so two simultaneous fixes don't collide.
+3. Symlinks `node_modules`, `apps/web/node_modules`, `apps/wiki-server/node_modules`, and `.env` (→ `lw/.env.base`) so `pnpm` / `crux` / `vitest` work without re-installing.
+4. Prints the absolute path so the user (or follow-up bash calls) can `cd` directly.
+
+## Example
+
+```
+$ /worktree claude/qua-665-wire-t1-importers-to-propose
+Worktree:    /tmp/wt-ac742e
+Branch:      claude/qua-665-wire-t1-importers-to-propose (HEAD ac742e844)
+Symlinked:   node_modules, apps/{web,wiki-server}/node_modules, .env
+Ready:       cd /tmp/wt-ac742e
+```
+
+## Implementation
+
+When invoked, run:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAIN_CLONE="/Users/ozziegooen/Documents/GitHub.nosync/lw/main"
+ENV_FILE="/Users/ozziegooen/Documents/GitHub.nosync/lw/.env.base"
+
+# Parse args
+NEW_BRANCH=""
+BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b)        NEW_BRANCH="1"; shift ;;
+    --branch=*) BRANCH="${1#*=}"; shift ;;
+    *)         BRANCH="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$BRANCH" ]]; then
+  echo "Usage: /worktree <branch>            (existing)" >&2
+  echo "       /worktree -b <new-branch>     (new from origin/main)" >&2
+  exit 1
+fi
+
+# Auto-prefix `claude/` if missing
+if [[ ! "$BRANCH" =~ ^(claude/|main$|production$) ]]; then
+  BRANCH="claude/$BRANCH"
+fi
+
+cd "$MAIN_CLONE"
+
+if [[ -n "$NEW_BRANCH" ]]; then
+  # Make sure origin/main is fresh, then create new branch from it
+  git fetch origin main --quiet
+  SHORT="new-$(printf '%04x' $RANDOM)"
+  WT="/tmp/wt-${SHORT}"
+  git worktree add -b "$BRANCH" "$WT" origin/main >&2
+else
+  git fetch origin "$BRANCH" --quiet 2>/dev/null || true
+  HEAD_SHA=$(git rev-parse --short=6 "origin/$BRANCH" 2>/dev/null || git rev-parse --short=6 "$BRANCH" 2>/dev/null || echo "unknown")
+  WT="/tmp/wt-${HEAD_SHA}"
+  if [[ -d "$WT" ]]; then
+    echo "Worktree already exists at $WT — reusing." >&2
+    cd "$WT"
+    git fetch origin "$BRANCH" --quiet 2>/dev/null || true
+    git reset --hard "origin/$BRANCH" >&2 2>/dev/null || true
+  else
+    git worktree add "$WT" "$BRANCH" >&2
+  fi
+fi
+
+# Symlink node_modules + env (idempotent)
+ln -sfn "$MAIN_CLONE/node_modules" "$WT/node_modules"
+mkdir -p "$WT/apps/web" "$WT/apps/wiki-server"
+ln -sfn "$MAIN_CLONE/apps/web/node_modules" "$WT/apps/web/node_modules"
+ln -sfn "$MAIN_CLONE/apps/wiki-server/node_modules" "$WT/apps/wiki-server/node_modules"
+ln -sfn "$ENV_FILE" "$WT/.env"
+
+# Report
+NEW_HEAD=$(cd "$WT" && git rev-parse --short HEAD)
+echo "Worktree:    $WT"
+echo "Branch:      $BRANCH (HEAD $NEW_HEAD)"
+echo "Symlinked:   node_modules, apps/{web,wiki-server}/node_modules, .env"
+echo "Ready:       cd $WT"
+```
+
+## Cleanup
+
+When you're done with a worktree (PR merged, abandoned, etc.):
+
+```bash
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main
+git worktree remove --force /tmp/wt-<short-sha>
+```
+
+The `ws refresh` loop also prunes stale worktrees automatically when their branch is merged.
+
+## When NOT to use this
+
+- For changes to `main` itself (you can't — there's a PreToolUse hook that blocks it).
+- For large multi-file rebases where a slot agent would be more appropriate (use `./ws open <N> --claude` instead — slots have full Claude sessions).
+- For changes touching `ops/` or release flow (use `coord/` directly via the release session).

--- a/.claude/skills/worktree/worktree.sh
+++ b/.claude/skills/worktree/worktree.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# /worktree implementation. Creates a /tmp/wt-<sha> git worktree from the
+# lw/main reference clone, wires node_modules + .env symlinks, and reports
+# the path. Safe to re-invoke (refuses to wipe dirty/divergent worktrees).
+#
+# See SKILL.md for argument forms and exit semantics.
+
+set -euo pipefail
+
+MAIN_CLONE="${LW_MAIN_CLONE:-/Users/ozziegooen/Documents/GitHub.nosync/lw/main}"
+ENV_FILE="${LW_ENV_BASE:-/Users/ozziegooen/Documents/GitHub.nosync/lw/.env.base}"
+
+# ── arg parse ────────────────────────────────────────────────────────────
+NEW_BRANCH=0
+BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -b)         NEW_BRANCH=1; shift ;;
+    --branch=*) BRANCH="${1#*=}"; shift ;;
+    -h|--help)
+      echo "Usage: worktree.sh <branch>           (existing branch)"
+      echo "       worktree.sh -b <new-branch>    (new from origin/main)"
+      exit 0
+      ;;
+    *)          BRANCH="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$BRANCH" ]]; then
+  echo "Usage: worktree.sh <branch>            (existing)" >&2
+  echo "       worktree.sh -b <new-branch>     (new from origin/main)" >&2
+  exit 1
+fi
+
+# Auto-prefix `claude/` if missing (so `worktree qua-665-foo` works).
+if [[ ! "$BRANCH" =~ ^(claude/|main$|production$) ]]; then
+  BRANCH="claude/$BRANCH"
+fi
+
+cd "$MAIN_CLONE"
+
+# ── new branch path ──────────────────────────────────────────────────────
+if (( NEW_BRANCH )); then
+  if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "Branch '$BRANCH' already exists locally. Re-invoke without -b to reuse it." >&2
+    exit 1
+  fi
+  git fetch origin main --quiet
+  WT="/tmp/wt-new-$(printf '%04x' "$RANDOM")"
+  git worktree add -b "$BRANCH" "$WT" origin/main >&2
+else
+  # ── existing branch path ───────────────────────────────────────────────
+  git fetch origin "$BRANCH" --quiet 2>/dev/null || true
+  HEAD_SHA=$(git rev-parse --short=6 "origin/$BRANCH" 2>/dev/null \
+            || git rev-parse --short=6 "$BRANCH" 2>/dev/null \
+            || echo "unknown")
+  WT="/tmp/wt-${HEAD_SHA}"
+
+  if [[ -d "$WT" ]]; then
+    # Reuse: refuse to clobber uncommitted or unpushed work.
+    pushd "$WT" >/dev/null
+    if [[ -n "$(git status --porcelain)" ]]; then
+      echo "Worktree already at $WT but has uncommitted changes — refusing to reuse." >&2
+      echo "Either:" >&2
+      echo "  - commit/discard those changes there, then re-run, or" >&2
+      echo "  - remove the worktree:  git -C $MAIN_CLONE worktree remove --force $WT" >&2
+      exit 1
+    fi
+    if [[ -n "$(git rev-list "origin/$BRANCH..HEAD" 2>/dev/null)" ]]; then
+      echo "Worktree at $WT has commits ahead of origin/$BRANCH — refusing to reuse." >&2
+      echo "Push them first, or remove the worktree if they're unwanted." >&2
+      exit 1
+    fi
+    git fetch origin "$BRANCH" --quiet 2>/dev/null || true
+    git reset --hard "origin/$BRANCH" >&2
+    popd >/dev/null
+    REUSED=" (reused & fast-forwarded)"
+  else
+    git worktree add "$WT" "$BRANCH" >&2
+    REUSED=""
+  fi
+fi
+
+# ── symlink node_modules + env (idempotent) ──────────────────────────────
+ln -sfn "$MAIN_CLONE/node_modules" "$WT/node_modules"
+mkdir -p "$WT/apps/web" "$WT/apps/wiki-server"
+ln -sfn "$MAIN_CLONE/apps/web/node_modules" "$WT/apps/web/node_modules"
+ln -sfn "$MAIN_CLONE/apps/wiki-server/node_modules" "$WT/apps/wiki-server/node_modules"
+ln -sfn "$ENV_FILE" "$WT/.env"
+
+# ── report ───────────────────────────────────────────────────────────────
+NEW_HEAD=$(git -C "$WT" rev-parse --short HEAD)
+echo "Worktree:    ${WT}${REUSED:-}"
+echo "Branch:      $BRANCH (HEAD $NEW_HEAD)"
+echo "Symlinked:   node_modules, apps/{web,wiki-server}/node_modules, .env"
+echo "Ready:       cd $WT"

--- a/crux/scripts/check-pr-merge-eligible.test.ts
+++ b/crux/scripts/check-pr-merge-eligible.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPrNumber,
+  hasStageApproved,
+  unresolvedMajorBotCount,
+} from "./check-pr-merge-eligible.ts";
+
+describe("extractPrNumber", () => {
+  it("recognises plain `gh pr merge 1234`", () => {
+    expect(extractPrNumber("gh pr merge 1234")).toBe(1234);
+  });
+
+  it("recognises flags before the number", () => {
+    expect(extractPrNumber("gh pr merge --auto --squash 1234")).toBe(1234);
+    expect(extractPrNumber("gh pr merge -R owner/repo 4576")).toBe(4576);
+  });
+
+  it("recognises owner/repo#1234 form", () => {
+    expect(
+      extractPrNumber("gh pr merge quantified-uncertainty/longterm-wiki#4576"),
+    ).toBe(4576);
+  });
+
+  it("recognises a github.com pull URL", () => {
+    expect(
+      extractPrNumber(
+        "gh pr merge https://github.com/quantified-uncertainty/longterm-wiki/pull/4576",
+      ),
+    ).toBe(4576);
+  });
+
+  it("recognises pnpm/npx prefixes", () => {
+    expect(extractPrNumber("pnpm gh pr merge 100")).toBe(100);
+  });
+
+  it("returns null when only a branch selector is given", () => {
+    expect(extractPrNumber("gh pr merge my-feature-branch --auto")).toBeNull();
+  });
+
+  it("returns null when the command is unrelated", () => {
+    expect(extractPrNumber("gh pr view 1234")).toBeNull();
+    expect(extractPrNumber("echo hello")).toBeNull();
+  });
+});
+
+describe("hasStageApproved", () => {
+  it("true when stage:approved is in the labels", () => {
+    expect(
+      hasStageApproved({
+        labels: { nodes: [{ name: "bug" }, { name: "stage:approved" }] },
+        reviewThreads: { nodes: [] },
+      }),
+    ).toBe(true);
+  });
+
+  it("false when stage:approved is missing", () => {
+    expect(
+      hasStageApproved({
+        labels: { nodes: [{ name: "bug" }, { name: "pr-patrol:working" }] },
+        reviewThreads: { nodes: [] },
+      }),
+    ).toBe(false);
+  });
+
+  it("false on an empty label set", () => {
+    expect(
+      hasStageApproved({
+        labels: { nodes: [] },
+        reviewThreads: { nodes: [] },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("unresolvedMajorBotCount", () => {
+  const thread = (
+    isResolved: boolean,
+    body: string,
+    login = "coderabbitai",
+  ) => ({
+    isResolved,
+    comments: { nodes: [{ author: { login }, body }] },
+  });
+
+  it("counts unresolved Major/Critical/Potential-issue threads", () => {
+    expect(
+      unresolvedMajorBotCount({
+        labels: { nodes: [] },
+        reviewThreads: {
+          nodes: [
+            thread(false, "Potential issue | 🟠 Major\nfoo"),
+            thread(false, "Critical: do this"),
+            thread(false, "Just a Minor nit"),
+          ],
+        },
+      }),
+    ).toBe(2);
+  });
+
+  it("ignores resolved threads even if they match severity", () => {
+    expect(
+      unresolvedMajorBotCount({
+        labels: { nodes: [] },
+        reviewThreads: {
+          nodes: [thread(true, "Major: do this"), thread(false, "Major: fix")],
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it("ignores non-CodeRabbit authors", () => {
+    expect(
+      unresolvedMajorBotCount({
+        labels: { nodes: [] },
+        reviewThreads: {
+          nodes: [thread(false, "Critical: foo", "github-actions")],
+        },
+      }),
+    ).toBe(0);
+  });
+
+  it("handles author=null gracefully", () => {
+    expect(
+      unresolvedMajorBotCount({
+        labels: { nodes: [] },
+        reviewThreads: {
+          nodes: [
+            {
+              isResolved: false,
+              comments: { nodes: [{ author: null, body: "Major: x" }] },
+            },
+          ],
+        },
+      }),
+    ).toBe(0);
+  });
+
+  it("returns 0 when there are no threads", () => {
+    expect(
+      unresolvedMajorBotCount({
+        labels: { nodes: [] },
+        reviewThreads: { nodes: [] },
+      }),
+    ).toBe(0);
+  });
+});

--- a/crux/scripts/check-pr-merge-eligible.ts
+++ b/crux/scripts/check-pr-merge-eligible.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse hook helper — invoked by `.claude/hooks/require-stage-approved.sh`
+ * to decide whether a `gh pr merge ...` Bash call should proceed.
+ *
+ * Exit codes:
+ *   0 = allow the tool call (or not applicable to this hook)
+ *   2 = block; stderr is shown to Claude as the reason
+ *
+ * Two gates:
+ *   1. PR has the `stage:approved` label.
+ *   2. PR has zero unresolved CodeRabbit Major / Critical / Potential-issue
+ *      review threads. We use GitHub's GraphQL `reviewThreads` (it exposes
+ *      `isResolved`); the REST `/pulls/:n/comments` endpoint doesn't, so a
+ *      previous bash-only version blocked even after threads were resolved.
+ *
+ * Override: `ALLOW_UNAPPROVED_MERGE=1 gh pr merge ...`
+ *
+ * The Bash command is passed in via the `COMMAND` env var (set by the hook
+ * wrapper from stdin JSON `tool_input.command`). We use env, not argv, to
+ * avoid shell quoting fragility on commands containing pipes / quotes.
+ *
+ * Fail-open on transport errors (missing token, GraphQL down, etc.) — the
+ * hook is a guardrail, not a security boundary; if we can't query, we let
+ * `gh pr merge` itself report any errors.
+ */
+
+import {
+  githubGraphQL,
+  REPO,
+  isMissingTokenError,
+} from "../lib/github.ts";
+
+interface PrData {
+  labels: { nodes: { name: string }[] };
+  reviewThreads: {
+    nodes: {
+      isResolved: boolean;
+      comments: { nodes: { author: { login: string } | null; body: string }[] };
+    }[];
+  };
+}
+
+const SEVERITY_RE = /Major|Critical|Potential issue/;
+const STAGE_APPROVED = "stage:approved";
+
+/**
+ * Detect whether the command is a `gh pr merge` invocation we should gate.
+ * Allows pnpm/npx prefix and accepts `gh pr merge` as the leading meaningful
+ * token (or after a `;`/`&&`/`||` separator). Conservatively avoids blocking
+ * commands that *mention* `gh pr merge` in a string literal — those are rare
+ * and the false-positive cost (blocking) is higher than the false-negative
+ * cost (one un-gated merge slips through).
+ */
+function isMergeCommand(command: string): boolean {
+  return /(^|[;&|]\s*)(?:pnpm\s+|npx\s+)?gh\s+pr\s+merge\b/.test(command);
+}
+
+/**
+ * Pull the target PR number out of a `gh pr merge` invocation. Recognised:
+ *   - `gh pr merge 1234`
+ *   - `gh pr merge --auto 1234`
+ *   - `gh pr merge owner/repo#1234`
+ *   - `gh pr merge https://github.com/owner/repo/pull/1234`
+ *
+ * Returns null if no PR can be inferred from the command itself; the caller
+ * may then fall back to `gh pr view` for the current branch.
+ */
+export function extractPrNumber(command: string): number | null {
+  // Pull URL — most specific, check first.
+  const urlMatch = /github\.com\/[\w.-]+\/[\w.-]+\/pull\/(\d+)/.exec(command);
+  if (urlMatch) return Number(urlMatch[1]);
+
+  // owner/repo#1234 form (e.g. `gh pr merge quri/lw#4576`)
+  const hashed = /\bgh\s+pr\s+merge\b[^\n]*?\b\S+#(\d+)\b/.exec(command);
+  if (hashed) return Number(hashed[1]);
+
+  // Generic: take the FIRST standalone integer token after `gh pr merge`.
+  // This tolerates flag/value pairs like `gh pr merge -R owner/repo 4576`
+  // or `--auto` / `--squash` interleaving with the PR number.
+  const merge = /\bgh\s+pr\s+merge\b/.exec(command);
+  if (!merge) return null;
+  const tail = command.slice(merge.index + merge[0].length);
+  for (const tok of tail.split(/\s+/)) {
+    if (/^\d+$/.test(tok)) return Number(tok);
+  }
+
+  return null;
+}
+
+export function hasStageApproved(pr: PrData): boolean {
+  return pr.labels.nodes.some((l) => l.name === STAGE_APPROVED);
+}
+
+export function unresolvedMajorBotCount(pr: PrData): number {
+  let count = 0;
+  for (const thread of pr.reviewThreads.nodes) {
+    if (thread.isResolved) continue;
+    const first = thread.comments.nodes[0];
+    if (!first) continue;
+    if (first.author?.login !== "coderabbitai") continue;
+    if (SEVERITY_RE.test(first.body)) count += 1;
+  }
+  return count;
+}
+
+async function loadPr(prNumber: number): Promise<PrData> {
+  const [owner, name] = REPO.split("/");
+  const data = await githubGraphQL<{
+    repository: { pullRequest: PrData };
+  }>(
+    `query($owner:String!,$name:String!,$pr:Int!) {
+       repository(owner:$owner, name:$name) {
+         pullRequest(number:$pr) {
+           labels(first:50) { nodes { name } }
+           reviewThreads(first:100) {
+             nodes {
+               isResolved
+               comments(first:1) {
+                 nodes { author { login } body }
+               }
+             }
+           }
+         }
+       }
+     }`,
+    { owner, name, pr: prNumber },
+  );
+  return data.repository.pullRequest;
+}
+
+function block(message: string): never {
+  process.stderr.write(message);
+  if (!message.endsWith("\n")) process.stderr.write("\n");
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const command = process.env.COMMAND ?? "";
+  if (!command || !isMergeCommand(command)) {
+    process.exit(0);
+  }
+
+  if (process.env.ALLOW_UNAPPROVED_MERGE === "1") {
+    process.stderr.write(
+      "[require-stage-approved] Override: ALLOW_UNAPPROVED_MERGE=1 — skipping label/review checks.\n",
+    );
+    process.exit(0);
+  }
+
+  const prNumber = extractPrNumber(command);
+  if (prNumber == null) {
+    // Couldn't infer the PR from the command. Conservative fail-open — the
+    // user could be running `gh pr merge` interactively for a branch that
+    // doesn't have a number on the cmdline; let `gh` resolve and report.
+    process.exit(0);
+  }
+
+  let pr: PrData;
+  try {
+    pr = await loadPr(prNumber);
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      process.stderr.write(
+        "[require-stage-approved] No GITHUB_TOKEN — letting through.\n",
+      );
+      process.exit(0);
+    }
+    process.stderr.write(
+      `[require-stage-approved] Could not fetch PR #${prNumber} metadata — letting through. (${e instanceof Error ? e.message : String(e)})\n`,
+    );
+    process.exit(0);
+  }
+
+  if (!hasStageApproved(pr)) {
+    block(
+      `BLOCKED: PR #${prNumber} is missing the \`${STAGE_APPROVED}\` label.\n\n` +
+        `Coord sessions must not merge PRs without explicit human approval (the\n` +
+        `label is set by the user, not by agents). PR-patrol follows the same rule.\n\n` +
+        `Current labels: [${pr.labels.nodes.map((l) => l.name).join(", ")}]\n\n` +
+        `If the user explicitly told you to merge this PR anyway, override with:\n` +
+        `  ALLOW_UNAPPROVED_MERGE=1 gh pr merge ${prNumber} ...\n\n` +
+        `See: $CLAUDE_PROJECT_DIR/.claude/memory/feedback_pr_merge_authority.md`,
+    );
+  }
+
+  const unresolved = unresolvedMajorBotCount(pr);
+  if (unresolved > 0) {
+    block(
+      `BLOCKED: PR #${prNumber} has ${unresolved} unresolved CodeRabbit Major/Critical/Potential-issue review thread(s).\n\n` +
+        `Either address them (push fix commits, then re-merge) or — if they've\n` +
+        `been verified as already-handled / out-of-scope and the user has\n` +
+        `approved shipping anyway — override with:\n` +
+        `  ALLOW_UNAPPROVED_MERGE=1 gh pr merge ${prNumber} ...\n\n` +
+        `Inspect threads in the PR's "Conversation" tab; resolved threads don't count.`,
+    );
+  }
+
+  process.exit(0);
+}
+
+// Only run main() when invoked as a script (not when imported for testing).
+// `import.meta.url === ...` works under tsx/Node ESM; we detect via process.argv[1].
+const isMainScript =
+  typeof process.argv[1] === "string" &&
+  process.argv[1].endsWith("check-pr-merge-eligible.ts");
+
+if (isMainScript) {
+  main().catch((e) => {
+    process.stderr.write(
+      `[require-stage-approved] Unexpected error — letting through: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+    process.exit(0);
+  });
+}


### PR DESCRIPTION
## Summary

After a long-running coord session shipped 11 unresolved CodeRabbit Major findings to main and ran patrol on 4-day-old stale code without anyone noticing, four systemic fixes — each targeting a class of incident seen multiple times in the session.

## Changes

### 1. `.claude/hooks/require-stage-approved.sh` (new)
PreToolUse hook on Bash that blocks `gh pr merge ...` calls when the target PR lacks the `stage:approved` label OR has unresolved CodeRabbit Major/Critical/Potential-issue review threads. Override with `ALLOW_UNAPPROVED_MERGE=1`. Wired into `settings.json` under `PreToolUse → Bash`.

The `feedback_pr_merge_authority.md` memory rule already documents this — but memory is advisory. The hook is harness-enforced and survives the prompt-engineering failure mode where the agent forgets the rule mid-batch.

Smoke-tested locally: blocks unapproved merge with helpful message, passes through non-merge commands silently, honors the override env.

### 2. `.claude/skills/admin-setup/SKILL.md` — Section 6a
Patrol daemon status now reports:
- Start time + ⚠ STALE warning when ≥2 days old
- ⚠ source-updated warning when `crux/pr-patrol/` has commits newer than the daemon

Both surfaced in the orientation summary line so they can't be missed. Empirically the daemon dies silently on credit-balance / API failures and runs old code for days. Added `--auto-restart-stale` arg.

### 3. `.claude/skills/worktree/SKILL.md` (new)
One-shot `/worktree <branch>` skill that creates a `/tmp/wt-<sha>` worktree from the `lw/main` reference clone, wires the four `node_modules` + `.env` symlinks, and prints the path. Replaces the 6-step recipe that gets repeated dozens of times in any long PR-fixing session. Auto-prefixes `claude/` for branch names; supports `-b` for new branches from `origin/main`.

### 4. `.claude/rules/pr-review-guidelines.md` — new section
"CodeRabbit `✅ Addressed in commit X` markers — DO NOT TRUST". Documents two real cases this session (PR #4538 and PR #4482 both cited phantom SHAs), and prescribes the verify-before-trust workflow. Covers both non-existent SHAs and existent-but-irrelevant SHAs.

## Test plan

- [x] Hook smoke test: `CLAUDE_TOOL_INPUT='gh pr merge 4555 --auto'` blocks (exit 2). `CLAUDE_TOOL_INPUT='gh pr view 4555'` passes (exit 0). `ALLOW_UNAPPROVED_MERGE=1` overrides to exit 0.
- [x] settings.json validates as JSON
- [x] Skill files use the `disable-model-invocation: false` frontmatter for `/worktree` so the user can invoke it; admin-setup unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/worktree` command for creating temporary Git worktrees with branch support.
  * PR merges now require `stage:approved` label verification before proceeding.

* **Documentation**
  * Enhanced PR review guidelines with required CodeRabbit comment verification procedures.
  * Improved admin-setup daemon status monitoring with stale warnings and source update detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->