### PR TITLE
fix(QUA-681): compact-short currency in Overview stat cards

### DIFF
--- a/apps/web/src/components/directory/__tests__/FactValueDisplay.test.tsx
+++ b/apps/web/src/components/directory/__tests__/FactValueDisplay.test.tsx
@@ -44,32 +44,42 @@ function makeProperty(unit?: string, display?: Property["display"]): Property {
 
 describe("FactValueDisplay", () => {
   describe("monetary values (production data)", () => {
-    it("renders Anthropic valuation as '$61.5 billion' not '61500000000'", () => {
+    it("renders Anthropic valuation as compact '$62B' not '61500000000'", () => {
+      // 61.5 rounds to 62 because ≥10 drops decimal (QUA-681).
       const fact = makeFact({ type: "number", value: 61_500_000_000, unit: "USD" });
       const prop = makeProperty("USD");
       render(<FactValueDisplay fact={fact} property={prop} />);
-      expect(screen.getByText("$61.5 billion")).toBeInTheDocument();
+      expect(screen.getByText("$62B")).toBeInTheDocument();
     });
 
-    it("renders OpenAI valuation as '$300 billion'", () => {
+    it("renders OpenAI valuation as '$300B'", () => {
       const fact = makeFact({ type: "number", value: 300_000_000_000, unit: "USD" });
       const prop = makeProperty("USD");
       render(<FactValueDisplay fact={fact} property={prop} />);
-      expect(screen.getByText("$300 billion")).toBeInTheDocument();
+      expect(screen.getByText("$300B")).toBeInTheDocument();
     });
 
-    it("renders revenue in millions correctly", () => {
+    it("renders revenue in millions compactly", () => {
       const fact = makeFact({ type: "number", value: 850_000_000, unit: "USD" });
       const prop = makeProperty("USD");
       render(<FactValueDisplay fact={fact} property={prop} />);
-      expect(screen.getByText("$850 million")).toBeInTheDocument();
+      expect(screen.getByText("$850M")).toBeInTheDocument();
     });
 
-    it("renders total funding correctly", () => {
+    it("renders total funding compactly", () => {
       const fact = makeFact({ type: "number", value: 10_750_000_000, unit: "USD" });
       const prop = makeProperty("USD");
       render(<FactValueDisplay fact={fact} property={prop} />);
-      expect(screen.getByText("$10.8 billion")).toBeInTheDocument();
+      // 10.75 rounds to 11 because ≥10 drops decimal (QUA-681).
+      expect(screen.getByText("$11B")).toBeInTheDocument();
+    });
+
+    it("renders small revenue as compact thousands (Redwood Research bug from QUA-681)", () => {
+      // Before the fix, this rendered as "$22,060" on /organizations/redwood-research.
+      const fact = makeFact({ type: "number", value: 22_060, unit: "USD" });
+      const prop = makeProperty("USD");
+      render(<FactValueDisplay fact={fact} property={prop} />);
+      expect(screen.getByText("$22K")).toBeInTheDocument();
     });
   });
 
@@ -147,8 +157,8 @@ describe("FactValueDisplay", () => {
       const prop = makeProperty("USD");
       const { container } = render(<FactValueDisplay fact={fact} property={prop} />);
       const text = container.querySelector("span")?.textContent ?? "";
-      expect(text).toContain("$1 billion");
-      expect(text).toContain("$2 billion");
+      expect(text).toContain("$1B");
+      expect(text).toContain("$2B");
     });
   });
 
@@ -166,7 +176,7 @@ describe("FactValueDisplay", () => {
       const { container } = render(<FactValueDisplay fact={fact} property={prop} />);
       const text = container.querySelector("span")?.textContent ?? "";
       expect(text).toContain("≥");
-      expect(text).toContain("$5 billion");
+      expect(text).toContain("$5B");
     });
   });
 });

--- a/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
+++ b/apps/web/src/components/wiki/factbase/__tests__/FBCellValue.test.tsx
@@ -71,16 +71,16 @@ describe("FBCellValue", () => {
   });
 
   // ── Path 4: number with currency unit (USD) ──
-  it("formats number with USD unit as currency", () => {
+  it("formats number with USD unit as compact currency", () => {
     const fieldDef: FieldDef = { type: "number", unit: "USD", description: "" };
     render(<FBCellValue value={380_000_000_000} fieldName="valuation" fieldDef={fieldDef} />);
-    expect(screen.getByText("$380 billion")).toBeInTheDocument();
+    expect(screen.getByText("$380B")).toBeInTheDocument();
   });
 
-  it("formats smaller USD amount", () => {
+  it("formats smaller USD amount compactly", () => {
     const fieldDef: FieldDef = { type: "number", unit: "USD", description: "" };
     render(<FBCellValue value={850_000_000} fieldName="revenue" fieldDef={fieldDef} />);
-    expect(screen.getByText("$850 million")).toBeInTheDocument();
+    expect(screen.getByText("$850M")).toBeInTheDocument();
   });
 
   // ── Path 5: number with fraction field → percentage ──
@@ -107,13 +107,13 @@ describe("FBCellValue", () => {
   });
 
   // ── Path 7: array range with currency ──
-  it("formats array range with USD unit as currency range", () => {
+  it("formats array range with USD unit as compact currency range", () => {
     const fieldDef: FieldDef = { type: "number", unit: "USD", description: "" };
     const { container } = render(
       <FBCellValue value={[5_000_000, 10_000_000]} fieldName="amount" fieldDef={fieldDef} />
     );
-    expect(container.textContent).toContain("$5 million");
-    expect(container.textContent).toContain("$10 million");
+    expect(container.textContent).toContain("$5M");
+    expect(container.textContent).toContain("$10M");
   });
 
   // ── Path 8: date ──
@@ -141,14 +141,14 @@ describe("FBCellValue", () => {
     const { container } = render(
       <FBCellValue value={[5_000_000, 10_000_000]} fieldName="amount" />
     );
-    expect(container.textContent).toContain("$5 million");
-    expect(container.textContent).toContain("$10 million");
+    expect(container.textContent).toContain("$5M");
+    expect(container.textContent).toContain("$10M");
   });
 
   // ── Path 12: fallback number without schema ──
   it("formats plain number with currency hint from field name", () => {
     render(<FBCellValue value={1_000_000_000} fieldName="valuation" />);
-    expect(screen.getByText("$1 billion")).toBeInTheDocument();
+    expect(screen.getByText("$1B")).toBeInTheDocument();
   });
 
   it("formats plain number without currency hint", () => {
@@ -198,7 +198,7 @@ describe("FBCellValue", () => {
 
   it("infers USD for amount field without schema", () => {
     render(<FBCellValue value={50_000_000} fieldName="amount" />);
-    expect(screen.getByText("$50 million")).toBeInTheDocument();
+    expect(screen.getByText("$50M")).toBeInTheDocument();
   });
 
   // Drizzle numeric() columns return JS strings. These tests guard the
@@ -206,22 +206,22 @@ describe("FBCellValue", () => {
   describe("string-typed PG numeric fallback", () => {
     it("formats string-typed funding round raised as USD", () => {
       render(<FBCellValue value="8000000000" fieldName="raised" />);
-      expect(screen.getByText("$8 billion")).toBeInTheDocument();
+      expect(screen.getByText("$8B")).toBeInTheDocument();
     });
 
     it("formats string-typed valuation as USD", () => {
       render(<FBCellValue value="380000000000" fieldName="valuation" />);
-      expect(screen.getByText("$380 billion")).toBeInTheDocument();
+      expect(screen.getByText("$380B")).toBeInTheDocument();
     });
 
     it("formats camelCase raisedLow (PG column) as USD", () => {
       render(<FBCellValue value="2600000000" fieldName="raisedLow" />);
-      expect(screen.getByText("$2.6 billion")).toBeInTheDocument();
+      expect(screen.getByText("$2.6B")).toBeInTheDocument();
     });
 
-    it("formats impliedValuation as USD", () => {
+    it("formats impliedValuation as USD (≥10 drops decimal: 61.5 → 62)", () => {
       render(<FBCellValue value="61500000000" fieldName="impliedValuation" />);
-      expect(screen.getByText("$61.5 billion")).toBeInTheDocument();
+      expect(screen.getByText("$62B")).toBeInTheDocument();
     });
 
     it("formats string-typed fraction field as percentage", () => {
@@ -269,8 +269,8 @@ describe("FBCellValue", () => {
     it("formats negative string currency correctly", () => {
       // Would only occur for NAV-style fields, but the parse path handles it.
       render(<FBCellValue value="-5000000" fieldName="amount" />);
-      const el = screen.getByText(/5 million/);
-      expect(el.textContent).toMatch(/-|\$/);
+      const el = screen.getByText(/5M/);
+      expect(el.textContent).toMatch(/-\$/);
     });
   });
 });

--- a/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
+++ b/apps/web/src/components/wiki/factbase/__tests__/format.test.ts
@@ -69,14 +69,15 @@ describe("formatKBNumber edge cases", () => {
     expect(formatKBNumber(0, "USD")).toBe("$0");
   });
 
-  it("formats negative numbers with USD", () => {
+  it("formats negative numbers with USD in compact form", () => {
     const result = formatKBNumber(-500_000_000, "USD");
     expect(result).toContain("$");
-    expect(result).toContain("million");
+    expect(result).toContain("M");
+    expect(result.startsWith("-$")).toBe(true);
   });
 
-  it("formats very large number (trillion+)", () => {
-    expect(formatKBNumber(2_500_000_000_000, "USD")).toBe("$2.5 trillion");
+  it("formats very large number (trillion+) in compact form", () => {
+    expect(formatKBNumber(2_500_000_000_000, "USD")).toBe("$2.5T");
   });
 
   it("uses currency override (GBP) with display config", () => {
@@ -103,9 +104,9 @@ describe("formatKBCellValue", () => {
   });
 
   describe("with field definition", () => {
-    it("formats number with unit", () => {
+    it("formats number with unit in compact form", () => {
       const fd: FieldDef = { type: "number", unit: "USD", description: "" };
-      expect(formatKBCellValue(1_000_000_000, fd)).toBe("$1 billion");
+      expect(formatKBCellValue(1_000_000_000, fd)).toBe("$1B");
     });
 
     it("formats date string", () => {
@@ -195,13 +196,13 @@ describe("formatKBFactValue additional coverage", () => {
 
   it("formats min value with >= prefix", () => {
     const fact = makeFact("revenue", { type: "min", value: 5_000_000_000 });
-    expect(formatKBFactValue(fact, "USD")).toBe("\u2265$5 billion");
+    expect(formatKBFactValue(fact, "USD")).toBe("\u2265$5B");
   });
 
   it("formats number fact with value-level unit when property unit absent", () => {
     const fact = makeFact("some-val", { type: "number", value: 100_000_000, unit: "USD" });
     // value.unit = "USD" should be used when property unit is not provided
-    expect(formatKBFactValue(fact)).toBe("$100 million");
+    expect(formatKBFactValue(fact)).toBe("$100M");
   });
 
   it("handles unknown/default case for unrecognized value types gracefully", () => {

--- a/apps/web/src/lib/__tests__/factbase-format.test.ts
+++ b/apps/web/src/lib/__tests__/factbase-format.test.ts
@@ -15,12 +15,12 @@ import type { Fact } from "@longterm-wiki/factbase";
 
 describe("formatKBNumber", () => {
   describe("with known unit (smart formatter)", () => {
-    it("formats USD billions", () => {
-      expect(formatKBNumber(5_500_000_000, "USD")).toBe("$5.5 billion");
+    it("formats USD billions in compact short", () => {
+      expect(formatKBNumber(5_500_000_000, "USD")).toBe("$5.5B");
     });
 
-    it("formats USD millions", () => {
-      expect(formatKBNumber(850_000_000, "USD")).toBe("$850 million");
+    it("formats USD millions in compact short", () => {
+      expect(formatKBNumber(850_000_000, "USD")).toBe("$850M");
     });
 
     it("formats percent", () => {
@@ -123,7 +123,7 @@ describe("formatKBFactValue", () => {
     it("formats large USD number with unit (property found)", () => {
       // employee-tender-offer with unit: USD
       const fact = makeFact("employee-tender-offer", { type: "number", value: 5_500_000_000 });
-      expect(formatKBFactValue(fact, "USD")).toBe("$5.5 billion");
+      expect(formatKBFactValue(fact, "USD")).toBe("$5.5B");
     });
 
     it("formats large number without unit using smart magnitude fallback", () => {
@@ -145,7 +145,7 @@ describe("formatKBFactValue", () => {
 
     it("formats range with USD unit (property found)", () => {
       const fact = makeFact("revenue", { type: "range", low: 1_000_000_000, high: 2_000_000_000 });
-      expect(formatKBFactValue(fact, "USD")).toBe("$1 billion\u2013$2 billion");
+      expect(formatKBFactValue(fact, "USD")).toBe("$1B\u2013$2B");
     });
   });
 
@@ -188,12 +188,12 @@ describe("formatKBFactValue", () => {
   describe("Bug #3305: JSON-wrapped nested FactValue objects", () => {
     it("unwraps nested number from json format", () => {
       const fact = makeFact("valuation", { type: "json", value: { type: "number", value: 500_000_000_000 } });
-      expect(formatKBFactValue(fact, "USD")).toBe("$500 billion");
+      expect(formatKBFactValue(fact, "USD")).toBe("$500B");
     });
 
     it("unwraps nested number with unit from json format", () => {
       const fact = makeFact("valuation", { type: "json", value: { type: "number", value: 500_000_000_000, unit: "USD" } });
-      expect(formatKBFactValue(fact)).toBe("$500 billion");
+      expect(formatKBFactValue(fact)).toBe("$500B");
     });
 
     it("unwraps nested text from json format", () => {
@@ -221,25 +221,26 @@ describe("formatKBFactValue", () => {
     it("formats 15B without raw digits (Meta AI infra-investment)", () => {
       const fact = makeFact("infrastructure-investment", { type: "number", value: 15_000_000_000 });
       const result = formatKBFactValue(fact, "USD");
-      expect(result).toBe("$15 billion");
+      expect(result).toBe("$15B");
       expect(result).not.toMatch(/\d{10,}/);
     });
 
-    it("formats 13.5B without raw digits", () => {
+    it("formats 13.5B without raw digits (≥10 drops decimal by convention)", () => {
       const fact = makeFact("infrastructure-investment", { type: "number", value: 13_500_000_000 });
       const result = formatKBFactValue(fact, "USD");
-      expect(result).toBe("$13.5 billion");
+      expect(result).toBe("$14B");
       expect(result).not.toMatch(/\d{10,}/);
     });
 
     it("formats 380B without raw digits (Anthropic valuation)", () => {
       const fact = makeFact("valuation", { type: "number", value: 380_000_000_000 });
       const result = formatKBFactValue(fact, "USD");
-      expect(result).toBe("$380 billion");
+      expect(result).toBe("$380B");
       expect(result).not.toMatch(/\d{10,}/);
     });
 
     it("formats large number without unit and produces no raw digits", () => {
+      // Fallback (no unit) still uses long form — "201 billion" is fine here.
       const fact = makeFact("parent-revenue", { type: "number", value: 200_970_000_000 });
       const result = formatKBFactValue(fact);
       expect(result).not.toMatch(/\d{10,}/);

--- a/apps/web/src/lib/__tests__/format-value.test.ts
+++ b/apps/web/src/lib/__tests__/format-value.test.ts
@@ -8,116 +8,129 @@ import {
 
 describe("formatNumberWithUnit", () => {
   describe("USD (prefix currency)", () => {
-    it("formats sub-million values with $ prefix", () => {
+    it("formats sub-thousand values with $ prefix and locale grouping", () => {
       expect(formatNumberWithUnit(500, "USD")).toBe("$500");
     });
 
-    it("formats thousands with comma separator", () => {
-      expect(formatNumberWithUnit(1500, "USD")).toBe("$1,500");
+    it("formats thousands with K suffix", () => {
+      // $22,060 on Redwood Research's profile triggered QUA-681 — must render as $22K.
+      expect(formatNumberWithUnit(22060, "USD")).toBe("$22K");
+      expect(formatNumberWithUnit(1500, "USD")).toBe("$1.5K");
     });
 
-    it("formats millions", () => {
-      expect(formatNumberWithUnit(2.5e6, "USD")).toBe("$2.5 million");
+    it("formats millions with M suffix", () => {
+      expect(formatNumberWithUnit(2.5e6, "USD")).toBe("$2.5M");
     });
 
-    it("formats billions", () => {
-      expect(formatNumberWithUnit(30e9, "USD")).toBe("$30 billion");
+    it("formats billions with B suffix", () => {
+      expect(formatNumberWithUnit(30e9, "USD")).toBe("$30B");
     });
 
-    it("formats trillions", () => {
-      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5 trillion");
+    it("formats trillions with T suffix", () => {
+      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5T");
     });
 
     it("formats zero", () => {
       expect(formatNumberWithUnit(0, "USD")).toBe("$0");
     });
 
-    it("cleans trailing .0 from round numbers", () => {
-      expect(formatNumberWithUnit(380e9, "USD")).toBe("$380 billion");
-      expect(formatNumberWithUnit(100e6, "USD")).toBe("$100 million");
-      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1 trillion");
+    it("drops trailing .0 from round numbers", () => {
+      expect(formatNumberWithUnit(380e9, "USD")).toBe("$380B");
+      expect(formatNumberWithUnit(100e6, "USD")).toBe("$100M");
+      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1T");
     });
 
-    it("preserves meaningful decimals", () => {
-      expect(formatNumberWithUnit(2.5e9, "USD")).toBe("$2.5 billion");
-      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5 trillion");
-      expect(formatNumberWithUnit(3.7e6, "USD")).toBe("$3.7 million");
+    it("preserves meaningful decimals below 10 of a unit", () => {
+      expect(formatNumberWithUnit(2.5e9, "USD")).toBe("$2.5B");
+      expect(formatNumberWithUnit(1.5e12, "USD")).toBe("$1.5T");
+      expect(formatNumberWithUnit(3.7e6, "USD")).toBe("$3.7M");
+    });
+
+    it("drops decimals at or above 10 of a unit", () => {
+      expect(formatNumberWithUnit(19e9, "USD")).toBe("$19B");
+      expect(formatNumberWithUnit(380e9, "USD")).toBe("$380B");
     });
   });
 
   describe("negative values with prefix currency", () => {
     it("places negative sign before the currency symbol", () => {
-      expect(formatNumberWithUnit(-850e6, "USD")).toBe("-$850 million");
+      expect(formatNumberWithUnit(-850e6, "USD")).toBe("-$850M");
     });
 
     it("handles negative billions", () => {
-      expect(formatNumberWithUnit(-30e9, "USD")).toBe("-$30 billion");
+      expect(formatNumberWithUnit(-30e9, "USD")).toBe("-$30B");
     });
 
     it("handles negative trillions", () => {
-      expect(formatNumberWithUnit(-1.5e12, "USD")).toBe("-$1.5 trillion");
+      expect(formatNumberWithUnit(-1.5e12, "USD")).toBe("-$1.5T");
     });
 
-    it("handles negative sub-million values", () => {
+    it("handles negative sub-thousand values", () => {
       expect(formatNumberWithUnit(-500, "USD")).toBe("-$500");
     });
   });
 
   describe("boundary values at magnitude thresholds", () => {
-    it("formats exactly 1e6 as million", () => {
-      expect(formatNumberWithUnit(1e6, "USD")).toBe("$1 million");
+    it("formats exactly 1e6 as $1M", () => {
+      expect(formatNumberWithUnit(1e6, "USD")).toBe("$1M");
     });
 
-    it("formats exactly 1e9 as billion", () => {
-      expect(formatNumberWithUnit(1e9, "USD")).toBe("$1 billion");
+    it("formats exactly 1e9 as $1B", () => {
+      expect(formatNumberWithUnit(1e9, "USD")).toBe("$1B");
     });
 
-    it("formats exactly 1e12 as trillion", () => {
-      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1 trillion");
+    it("formats exactly 1e12 as $1T", () => {
+      expect(formatNumberWithUnit(1e12, "USD")).toBe("$1T");
     });
 
-    it("formats just below 1e6 as a plain number", () => {
-      expect(formatNumberWithUnit(999999, "USD")).toBe("$999,999");
+    it("promotes 999,999 up to $1M instead of rendering $1000K", () => {
+      expect(formatNumberWithUnit(999999, "USD")).toBe("$1M");
+    });
+
+    it("still renders values that stay under 1000 of a unit", () => {
+      expect(formatNumberWithUnit(950000, "USD")).toBe("$950K");
+      expect(formatNumberWithUnit(950e6, "USD")).toBe("$950M");
+      expect(formatNumberWithUnit(950e9, "USD")).toBe("$950B");
     });
   });
 
   describe("suffix currencies (SEK, NOK)", () => {
     it("formats SEK with suffix kr", () => {
-      expect(formatNumberWithUnit(100e6, "SEK")).toBe("100 million kr");
+      expect(formatNumberWithUnit(100e6, "SEK")).toBe("100M kr");
     });
 
     it("formats SEK billions with suffix kr", () => {
-      expect(formatNumberWithUnit(5e9, "SEK")).toBe("5 billion kr");
+      expect(formatNumberWithUnit(5e9, "SEK")).toBe("5B kr");
     });
 
     it("formats SEK trillions with suffix kr", () => {
-      expect(formatNumberWithUnit(2e12, "SEK")).toBe("2 trillion kr");
+      expect(formatNumberWithUnit(2e12, "SEK")).toBe("2T kr");
     });
 
     it("formats NOK sub-million with suffix kr", () => {
-      expect(formatNumberWithUnit(5000, "NOK")).toBe("5,000 kr");
+      expect(formatNumberWithUnit(5000, "NOK")).toBe("5K kr");
     });
 
     it("places negative sign correctly for suffix currencies", () => {
-      expect(formatNumberWithUnit(-100e6, "SEK")).toBe("-100 million kr");
+      expect(formatNumberWithUnit(-100e6, "SEK")).toBe("-100M kr");
     });
   });
 
   describe("other prefix currencies", () => {
     it("formats GBP with pound sign", () => {
-      expect(formatNumberWithUnit(100e6, "GBP")).toBe("\u00A3100 million");
+      expect(formatNumberWithUnit(100e6, "GBP")).toBe("\u00A3100M");
     });
 
     it("formats EUR with euro sign", () => {
-      expect(formatNumberWithUnit(50e9, "EUR")).toBe("\u20AC50 billion");
+      expect(formatNumberWithUnit(50e9, "EUR")).toBe("\u20AC50B");
     });
 
     it("formats JPY with yen sign", () => {
-      expect(formatNumberWithUnit(1e12, "JPY")).toBe("\u00A51 trillion");
+      expect(formatNumberWithUnit(1e12, "JPY")).toBe("\u00A51T");
     });
 
     it("formats CAD with C$ prefix", () => {
-      expect(formatNumberWithUnit(200e6, "CAD")).toBe("C$200 million");
+      expect(formatNumberWithUnit(200e6, "CAD")).toBe("C$200M");
     });
   });
 
@@ -139,20 +152,20 @@ describe("formatNumberWithUnit", () => {
     });
   });
 
-  describe("count and tokens units", () => {
+  describe("count and tokens units (long-form unchanged)", () => {
     it("formats count with comma separator", () => {
       expect(formatNumberWithUnit(1500, "count")).toBe("1,500");
     });
 
-    it("formats count millions", () => {
+    it("formats count millions in long form", () => {
       expect(formatNumberWithUnit(2.5e6, "count")).toBe("2.5 million");
     });
 
-    it("formats count billions", () => {
+    it("formats count billions in long form", () => {
       expect(formatNumberWithUnit(2.5e9, "count")).toBe("2.5 billion");
     });
 
-    it("formats count trillions", () => {
+    it("formats count trillions in long form", () => {
       expect(formatNumberWithUnit(1e12, "count")).toBe("1 trillion");
     });
 
@@ -164,7 +177,7 @@ describe("formatNumberWithUnit", () => {
 
   describe("currency override parameter", () => {
     it("overrides unit currency with explicit currency", () => {
-      expect(formatNumberWithUnit(100e6, "USD", "GBP")).toBe("\u00A3100 million");
+      expect(formatNumberWithUnit(100e6, "USD", "GBP")).toBe("\u00A3100M");
     });
 
     it("does not apply currency override when unit is percent", () => {
@@ -176,24 +189,24 @@ describe("formatNumberWithUnit", () => {
     });
 
     it("applies currency override when unit is also a currency", () => {
-      expect(formatNumberWithUnit(50e6, "USD", "EUR")).toBe("\u20AC50 million");
+      expect(formatNumberWithUnit(50e6, "USD", "EUR")).toBe("\u20AC50M");
     });
   });
 
   describe("fallback (no unit or unknown unit)", () => {
-    it("formats with no unit", () => {
+    it("formats with no unit (long form unchanged)", () => {
       expect(formatNumberWithUnit(1500)).toBe("1,500");
     });
 
-    it("formats millions with no unit", () => {
+    it("formats millions with no unit in long form", () => {
       expect(formatNumberWithUnit(5e6)).toBe("5 million");
     });
 
-    it("formats billions with no unit", () => {
+    it("formats billions with no unit in long form", () => {
       expect(formatNumberWithUnit(3e9)).toBe("3 billion");
     });
 
-    it("formats trillions with no unit", () => {
+    it("formats trillions with no unit in long form", () => {
       expect(formatNumberWithUnit(2e12)).toBe("2 trillion");
     });
 
@@ -222,15 +235,19 @@ describe("formatNumberWithUnit", () => {
 describe("formatValueRange", () => {
   describe("USD range (prefix currency)", () => {
     it("formats billion range", () => {
-      expect(formatValueRange(20e9, 26e9, "USD")).toBe("$20-$26 billion");
+      expect(formatValueRange(20e9, 26e9, "USD")).toBe("$20B-$26B");
     });
 
     it("formats million range", () => {
-      expect(formatValueRange(20e6, 30e6, "USD")).toBe("$20-$30 million");
+      expect(formatValueRange(20e6, 30e6, "USD")).toBe("$20M-$30M");
     });
 
-    it("formats sub-million range", () => {
-      expect(formatValueRange(1500, 3000, "USD")).toBe("$1,500-$3,000");
+    it("formats sub-thousand range", () => {
+      expect(formatValueRange(500, 900, "USD")).toBe("$500-$900");
+    });
+
+    it("formats thousand range", () => {
+      expect(formatValueRange(1500, 3000, "USD")).toBe("$1.5K-$3K");
     });
   });
 
@@ -250,27 +267,27 @@ describe("formatValueRange", () => {
 
   describe("suffix currency range (SEK)", () => {
     it("formats billion range with suffix", () => {
-      expect(formatValueRange(20e9, 26e9, "SEK")).toBe("20-26 billion kr");
+      expect(formatValueRange(20e9, 26e9, "SEK")).toBe("20B kr-26B kr");
     });
 
     it("formats million range with suffix", () => {
-      expect(formatValueRange(20e6, 30e6, "SEK")).toBe("20-30 million kr");
+      expect(formatValueRange(20e6, 30e6, "SEK")).toBe("20M kr-30M kr");
     });
 
-    it("formats sub-million range with suffix", () => {
-      expect(formatValueRange(1500, 3000, "SEK")).toBe("1,500-3,000 kr");
+    it("formats sub-thousand range with suffix", () => {
+      expect(formatValueRange(500, 900, "SEK")).toBe("500 kr-900 kr");
     });
   });
 
   describe("currency override in range", () => {
     it("overrides unit currency with explicit currency", () => {
       expect(formatValueRange(20e6, 30e6, "USD", "GBP")).toBe(
-        "\u00A320-\u00A330 million"
+        "\u00A320M-\u00A330M"
       );
     });
   });
 
-  describe("count/tokens range", () => {
+  describe("count/tokens range (long-form unchanged)", () => {
     it("formats million range for count", () => {
       expect(formatValueRange(20e6, 30e6, "count")).toBe("20-30 million");
     });
@@ -290,7 +307,7 @@ describe("formatValueRange", () => {
 describe("formatStructuredValue", () => {
   describe("numeric strings", () => {
     it("parses and formats a numeric string with USD unit", () => {
-      expect(formatStructuredValue("850000000", "USD")).toBe("$850 million");
+      expect(formatStructuredValue("850000000", "USD")).toBe("$850M");
     });
 
     it("parses and formats a small number", () => {
@@ -302,7 +319,7 @@ describe("formatStructuredValue", () => {
     });
 
     it("parses negative numbers", () => {
-      expect(formatStructuredValue("-500000000", "USD")).toBe("-$500 million");
+      expect(formatStructuredValue("-500000000", "USD")).toBe("-$500M");
     });
 
     it("parses decimal strings", () => {

--- a/apps/web/src/lib/format-value.ts
+++ b/apps/web/src/lib/format-value.ts
@@ -15,6 +15,48 @@ function cleanDecimal(n: number): string {
 }
 
 /**
+ * Scale a positive number into compact K/M/B/T form with the matching suffix,
+ * returning `{ formatted, scaled }` where `scaled < 10 ? one decimal : integer`.
+ *
+ * Below 1000 returns the locale-grouped number with no suffix.
+ */
+function compactScale(abs: number): { formatted: string; suffix: "" | "K" | "M" | "B" | "T" } {
+  const tiers: { min: number; divisor: number; suffix: "K" | "M" | "B" | "T" }[] = [
+    { min: 1e12, divisor: 1e12, suffix: "T" },
+    { min: 1e9, divisor: 1e9, suffix: "B" },
+    { min: 1e6, divisor: 1e6, suffix: "M" },
+    { min: 1e3, divisor: 1e3, suffix: "K" },
+  ];
+  for (let i = 0; i < tiers.length; i++) {
+    const t = tiers[i];
+    if (abs < t.min) continue;
+    const v = abs / t.divisor;
+    // < 10 of a unit keeps one decimal ("$1.5B"); at or above, drop decimals ("$30B").
+    const formatted = v < 10 ? v.toFixed(1).replace(/\.0$/, "") : v.toFixed(0);
+    // Promote: "999.999 / 1e3 -> 1000K" should become "$1M".
+    if (i > 0 && Number(formatted) >= 1000) {
+      const promoted = tiers[i - 1];
+      const pv = abs / promoted.divisor;
+      return {
+        formatted: pv < 10 ? pv.toFixed(1).replace(/\.0$/, "") : pv.toFixed(0),
+        suffix: promoted.suffix,
+      };
+    }
+    return { formatted, suffix: t.suffix };
+  }
+  return { formatted: abs.toLocaleString("en-US"), suffix: "" };
+}
+
+/** Compact-format a signed number as "-$1.5K" / "$380B" / "$500" with the given
+ *  currency symbol and position. Used for currency-tagged values. */
+function compactCurrency(n: number, sym: string, position: "prefix" | "suffix"): string {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  const { formatted, suffix } = compactScale(abs);
+  return withCurrency(sym, position, `${sign}${formatted}${suffix}`);
+}
+
+/**
  * Resolve the currency info for a given unit/currency combination.
  * Returns null if the unit is not monetary.
  */
@@ -43,10 +85,14 @@ function withCurrency(sym: string, position: "prefix" | "suffix", formatted: str
 /**
  * Format a single number into a human-readable string based on unit.
  *
+ * Currency values use compact short form so stat cards, chart captions, and
+ * inline MDX fact values all render the same way (QUA-681 / QUA-82 / QUA-673).
+ *
  * Examples:
- *   formatNumberWithUnit(850000000, "USD")              -> "$850 million"
- *   formatNumberWithUnit(100000000, "USD", "GBP")       -> "£100 million"
- *   formatNumberWithUnit(30000000000, "USD")            -> "$30 billion"
+ *   formatNumberWithUnit(850000000, "USD")              -> "$850M"
+ *   formatNumberWithUnit(100000000, "USD", "GBP")       -> "£100M"
+ *   formatNumberWithUnit(30000000000, "USD")            -> "$30B"
+ *   formatNumberWithUnit(22060, "USD")                  -> "$22K"
  *   formatNumberWithUnit(40, "percent")                 -> "40%"
  *   formatNumberWithUnit(1500, "count")                 -> "1,500"
  *   formatNumberWithUnit(200000, "tokens")              -> "200,000"
@@ -55,10 +101,7 @@ export function formatNumberWithUnit(n: number | null | undefined, unit?: string
   if (n == null) return "";
   const cur = resolveCurrencyInfo(unit, currency);
   if (cur !== null) {
-    if (Math.abs(n) >= 1e12) return withCurrency(cur.symbol, cur.position, `${cleanDecimal(n / 1e12)} trillion`);
-    if (Math.abs(n) >= 1e9) return withCurrency(cur.symbol, cur.position, `${cleanDecimal(n / 1e9)} billion`);
-    if (Math.abs(n) >= 1e6) return withCurrency(cur.symbol, cur.position, `${cleanDecimal(n / 1e6)} million`);
-    return withCurrency(cur.symbol, cur.position, n.toLocaleString("en-US"));
+    return compactCurrency(n, cur.symbol, cur.position);
   }
   if (unit === "percent") return `${cleanDecimal(n)}%`;
   if (unit === "count" || unit === "tokens") {
@@ -85,10 +128,13 @@ export function formatNumberWithUnit(n: number | null | undefined, unit?: string
 /**
  * Format a [low, high] range into a human-readable string.
  *
+ * Currency ranges use the same compact short form as `formatNumberWithUnit`
+ * so stat cards and chart captions line up.
+ *
  * Examples:
- *   formatValueRange(20e9, 26e9, "USD")            -> "$20-$26 billion"
- *   formatValueRange(20e6, 30e6, "USD", "GBP")     -> "£20-£30 million"
- *   formatValueRange(20, 30, "percent")             -> "20-30%"
+ *   formatValueRange(20e9, 26e9, "USD")            -> "$20B-$26B"
+ *   formatValueRange(20e6, 30e6, "USD", "GBP")     -> "£20M-£30M"
+ *   formatValueRange(20, 30, "percent")            -> "20-30%"
  */
 export function formatValueRange(
   lo: number,
@@ -99,18 +145,7 @@ export function formatValueRange(
   if (unit === "percent") return `${cleanDecimal(lo)}-${cleanDecimal(hi)}%`;
   const cur = resolveCurrencyInfo(unit, currency);
   if (cur !== null) {
-    const { symbol: sym, position: pos } = cur;
-    if (lo >= 1e9 && hi >= 1e9)
-      return pos === "suffix"
-        ? `${cleanDecimal(lo / 1e9)}-${cleanDecimal(hi / 1e9)} billion ${sym}`
-        : `${sym}${cleanDecimal(lo / 1e9)}-${sym}${cleanDecimal(hi / 1e9)} billion`;
-    if (lo >= 1e6 && hi >= 1e6)
-      return pos === "suffix"
-        ? `${cleanDecimal(lo / 1e6)}-${cleanDecimal(hi / 1e6)} million ${sym}`
-        : `${sym}${cleanDecimal(lo / 1e6)}-${sym}${cleanDecimal(hi / 1e6)} million`;
-    return pos === "suffix"
-      ? `${lo.toLocaleString("en-US")}-${hi.toLocaleString("en-US")} ${sym}`
-      : `${sym}${lo.toLocaleString("en-US")}-${sym}${hi.toLocaleString("en-US")}`;
+    return `${compactCurrency(lo, cur.symbol, cur.position)}-${compactCurrency(hi, cur.symbol, cur.position)}`;
   }
   if (unit === "count" || unit === "tokens") {
     if (lo >= 1e6 && hi >= 1e6)
@@ -125,7 +160,7 @@ export function formatValueRange(
  * Parses to number, formats, falls back to the raw string if not numeric.
  *
  * Examples:
- *   formatStructuredValue("850000000", "USD")   -> "$850 million"
+ *   formatStructuredValue("850000000", "USD")   -> "$850M"
  *   formatStructuredValue("San Francisco", null) -> "San Francisco"
  */
 export function formatStructuredValue(


### PR DESCRIPTION
## Summary

- Fixes inconsistent currency rendering on organization Overview stat cards
  (`$22,060` / `$19 billion` / `$380 billion`) to match the chart captions
  below them (`$22K` / `$19B` / `$380B`).
- Change is in `apps/web/src/lib/format-value.ts::formatNumberWithUnit` and
  `formatValueRange` — currency units now produce compact short form; `percent`,
  `count`, `tokens`, and no-unit fallback behavior are unchanged.
- Also adds a tier-promotion in `compactScale` so `999,999` rounds up to
  `$1M` instead of the ugly `$1000K`.

## Root cause

`FactValueDisplay` in `apps/web/src/components/directory/FactsSection.tsx:79`
flows through `formatKBFactValue` → `formatKBNumber` → `formatNumberWithUnit`.
That function used long-form labels (`"$380 billion"`) and bare `toLocaleString`
for sub-million currency (`"$22,060"`), while the chart captions below used
`formatCompactCurrency` from `lib/format-compact.ts` (`"$22K"`, `"$380B"`).
This PR aligns both paths on compact form.

## Scope

Compact short affects every caller of `formatNumberWithUnit` / `formatKBNumber`:
Overview stat cards, dot-leader fact rows, `<FBF>` / `<FBFactValue>` inline MDX
values, factbase browser, resources page facts, sourcing detail pages,
organizations directory filters, and structured claims. This is the intended
sweep — matches the direction QUA-82 / QUA-673 / QUA-620 / QUA-436 already
shipped for other currency paths.

## Verification

- All 1683 apps/web vitest tests pass (updated 5 test files, added Redwood
  `$22K` regression test).
- Full monorepo test suite: 7420 passed, 26 skipped.
- `npx tsc --noEmit` clean in apps/web.
- `pnpm build` succeeds.
- `pnpm crux w validate gate --scope=content --fix` green.
- Verified against prod data via local prod build (`next start -p 3015`):
  - `/organizations/redwood-research` stat card: `$22K` ✓
  - `/organizations/anthropic` stat cards: `$19B`, `$380B`, `$67B` ✓
  - `/organizations/anthropic/data` Database tab: still renders compactly ✓

## Test plan

- [x] `pnpm test` (apps/web) passes
- [x] `pnpm test` (workspace) passes
- [x] `pnpm build` succeeds
- [x] `pnpm crux w validate gate` passes
- [x] Local smoke: Overview stat cards match chart captions on prod data

Fixes QUA-681
