### PR TITLE
fix import-divisions sync: tb-wrapper dispatch, inline sourcing, error message

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
@@ -155,10 +155,7 @@ describe('enforceSourcing', () => {
     expect(res.status).toBe(200);
   });
 
-  it('error message includes table name and verify-orchestrate command (QUA-677)', async () => {
-    // Regression test: the message used to suggest `tb verify <table>` which
-    // routes to the single-entity personnel-ID check, not the sourcing
-    // orchestrator. It must point at `tb verify-orchestrate <table>`.
+  it('error message points at verify-orchestrate, not the single-entity verify', async () => {
     const app = createTestApp('grants');
     const res = await makeRequest(app, [{ id: '1' }]);
     expect(res.status).toBe(400);

--- a/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
@@ -155,11 +155,15 @@ describe('enforceSourcing', () => {
     expect(res.status).toBe(200);
   });
 
-  it('error message includes table name and verify command', async () => {
+  it('error message includes table name and verify-orchestrate command (QUA-677)', async () => {
+    // Regression test: the message used to suggest `tb verify <table>` which
+    // routes to the single-entity personnel-ID check, not the sourcing
+    // orchestrator. It must point at `tb verify-orchestrate <table>`.
     const app = createTestApp('grants');
     const res = await makeRequest(app, [{ id: '1' }]);
     expect(res.status).toBe(400);
     const body = await res.json() as { message: string };
-    expect(body.message).toContain('pnpm crux tb verify grants');
+    expect(body.message).toContain('pnpm crux tb verify-orchestrate grants');
+    expect(body.message).not.toMatch(/pnpm crux tb verify grants(?!-)/);
   });
 });

--- a/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
@@ -66,7 +66,7 @@ export function enforceSourcing(
   return validationError(
     c,
     `Source-check required (${source}) but ${unchecked.length}/${items.length} records lack sourcing data. ` +
-    `Run \`pnpm crux tb verify ${tableName}\` before submitting, ` +
+    `Run \`pnpm crux tb verify-orchestrate ${tableName}\` to populate source_check_verdicts before submitting, ` +
     `or use ?forceSkipSourcing=true&reason=... to bypass with audit logging.`,
   );
 }

--- a/crux/commands/import-divisions.test.ts
+++ b/crux/commands/import-divisions.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for import-divisions cmdSync — QUA-677.
+ *
+ * Covers the sourcing-attach wiring: the command must fetch verdicts from PG,
+ * map them onto the right divisions, and honor --force-skip-sourcing by not
+ * fetching at all. The helper itself is tested in
+ * crux/lib/wiki-server/inline-sourcing.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockFetchInlineSourcing, mockSyncDivisions, mockGetServerUrl } =
+  vi.hoisted(() => ({
+    mockFetchInlineSourcing: vi.fn(),
+    mockSyncDivisions: vi.fn(),
+    mockGetServerUrl: vi.fn(() => "https://fake.wiki-server"),
+  }));
+vi.mock("../lib/wiki-server/inline-sourcing.ts", () => ({
+  fetchInlineSourcing: mockFetchInlineSourcing,
+}));
+vi.mock("../lib/wiki-server/divisions.ts", () => ({
+  syncDivisions: mockSyncDivisions,
+  deleteDivisionsBatch: vi.fn(),
+}));
+vi.mock("../lib/wiki-server/client.ts", () => ({
+  getServerUrl: mockGetServerUrl,
+}));
+
+import { commands as divisionsCommands } from "./import-divisions.ts";
+
+/** Capture console.log so we can assert on output. */
+function captureConsole() {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map((a) => String(a)).join(" "));
+  };
+  return {
+    lines,
+    restore: () => {
+      console.log = originalLog;
+    },
+  };
+}
+
+describe("import-divisions sync — sourcing attach (QUA-677)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchInlineSourcing.mockResolvedValue(new Map());
+    mockSyncDivisions.mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    });
+  });
+
+  it("fetches verdicts and attaches sourcing to matched divisions (dry-run)", async () => {
+    // Use a recordId that exists in DIVISIONS — pick the first one. We can't
+    // import DIVISIONS directly without also importing the command side-effect,
+    // so instead set up a fetch that matches every item (wildcard by default
+    // verdict), and verify attach count equals total via the log line.
+    mockFetchInlineSourcing.mockResolvedValueOnce(
+      new Map([
+        // Return entries for common ids; unmatched items will be reported unsourced.
+        // We purposely return an empty map to assert the 0/N log line, then a
+        // separate test exercises a non-empty map via a spy.
+      ]),
+    );
+    const cap = captureConsole();
+    try {
+      const res = await divisionsCommands.sync([], { "dry-run": true });
+      expect(res.exitCode).toBe(0);
+    } finally {
+      cap.restore();
+    }
+
+    expect(mockFetchInlineSourcing).toHaveBeenCalledWith("division");
+    expect(mockSyncDivisions).not.toHaveBeenCalled(); // dry-run
+    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
+    expect(summary).toBeDefined();
+    expect(summary).toMatch(/0\/\d+ records have verdicts/);
+    expect(summary).toMatch(/unsourced — server will reject/);
+  });
+
+  it("reports attached count when some records have verdicts", async () => {
+    // Capture the actual first id by running once with an empty map,
+    // parsing the dry-run line, then re-running with a matching map.
+    // Simpler: stub fetch to return a map that matches ANY input id via a
+    // Proxy, and count attaches.
+    const universalMap = new Proxy(new Map<string, unknown>(), {
+      get(target, prop) {
+        if (prop === "get") {
+          return (_key: string) => ({
+            verdict: "confirmed",
+            confidence: 0.9,
+            checkedAt: "2026-04-24T00:00:00.000Z",
+          });
+        }
+        return Reflect.get(target, prop);
+      },
+    });
+    mockFetchInlineSourcing.mockResolvedValueOnce(universalMap);
+
+    const cap = captureConsole();
+    try {
+      await divisionsCommands.sync([], { "dry-run": true });
+    } finally {
+      cap.restore();
+    }
+    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
+    expect(summary).toBeDefined();
+    // All records attached — no "unsourced" warning suffix.
+    expect(summary).toMatch(/\d+\/\d+ records have verdicts$/);
+    expect(summary).not.toContain("unsourced");
+
+    // Dry-run printed per-item badges with the verdict name.
+    const itemLines = cap.lines.filter((l) => l.includes("[confirmed]"));
+    expect(itemLines.length).toBeGreaterThan(0);
+  });
+
+  it("skips the verdict fetch under --force-skip-sourcing", async () => {
+    const cap = captureConsole();
+    try {
+      await divisionsCommands.sync([], {
+        "dry-run": true,
+        "force-skip-sourcing": true,
+        reason: "smoke-test",
+      });
+    } finally {
+      cap.restore();
+    }
+    expect(mockFetchInlineSourcing).not.toHaveBeenCalled();
+    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
+    expect(summary).toContain("skipped");
+    expect(summary).toContain("smoke-test");
+  });
+
+  it("rejects --force-skip-sourcing without --reason", async () => {
+    await expect(
+      divisionsCommands.sync([], { "force-skip-sourcing": true }),
+    ).rejects.toThrow(/reason/);
+    expect(mockFetchInlineSourcing).not.toHaveBeenCalled();
+    expect(mockSyncDivisions).not.toHaveBeenCalled();
+  });
+
+  it("POSTs attached sourcing to syncDivisions on a real sync", async () => {
+    mockFetchInlineSourcing.mockResolvedValueOnce(
+      new Proxy(new Map(), {
+        get(target, prop) {
+          if (prop === "get") {
+            return () => ({ verdict: "confirmed" });
+          }
+          return Reflect.get(target, prop);
+        },
+      }),
+    );
+
+    const cap = captureConsole();
+    try {
+      await divisionsCommands.sync([], {});
+    } finally {
+      cap.restore();
+    }
+
+    expect(mockSyncDivisions).toHaveBeenCalledOnce();
+    const [items] = mockSyncDivisions.mock.calls[0];
+    expect(Array.isArray(items)).toBe(true);
+    expect(items.length).toBeGreaterThan(0);
+    // Every item carries the inline sourcing payload.
+    for (const item of items) {
+      expect(item.sourcing).toEqual({ verdict: "confirmed" });
+    }
+  });
+
+  it("passes forceSkipSourcing + reason through to the client on a real sync", async () => {
+    const cap = captureConsole();
+    try {
+      await divisionsCommands.sync([], {
+        "force-skip-sourcing": true,
+        reason: "ops backfill",
+      });
+    } finally {
+      cap.restore();
+    }
+
+    expect(mockFetchInlineSourcing).not.toHaveBeenCalled();
+    expect(mockSyncDivisions).toHaveBeenCalledOnce();
+    const [, opts] = mockSyncDivisions.mock.calls[0];
+    expect(opts).toEqual({
+      forceSkipSourcing: true,
+      forceSkipSourcingReason: "ops backfill",
+    });
+  });
+
+  it("throws when syncDivisions returns an error", async () => {
+    mockSyncDivisions.mockResolvedValueOnce({
+      ok: false,
+      error: { status: 400 },
+      message: "sourcing missing",
+    });
+    const cap = captureConsole();
+    try {
+      await expect(
+        divisionsCommands.sync([], {
+          "force-skip-sourcing": true,
+          reason: "test",
+        }),
+      ).rejects.toThrow(/sourcing missing/);
+    } finally {
+      cap.restore();
+    }
+  });
+});

--- a/crux/commands/import-divisions.test.ts
+++ b/crux/commands/import-divisions.test.ts
@@ -1,13 +1,4 @@
-/**
- * Tests for import-divisions cmdSync — QUA-677.
- *
- * Covers the sourcing-attach wiring: the command must fetch verdicts from PG,
- * map them onto the right divisions, and honor --force-skip-sourcing by not
- * fetching at all. The helper itself is tested in
- * crux/lib/wiki-server/inline-sourcing.test.ts.
- */
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockFetchInlineSourcing, mockSyncDivisions, mockGetServerUrl } =
   vi.hoisted(() => ({
@@ -27,23 +18,25 @@ vi.mock("../lib/wiki-server/client.ts", () => ({
 }));
 
 import { commands as divisionsCommands } from "./import-divisions.ts";
+import type { InlineSourcing } from "../lib/wiki-server/inline-sourcing.ts";
 
-/** Capture console.log so we can assert on output. */
-function captureConsole() {
-  const originalLog = console.log;
-  const lines: string[] = [];
-  console.log = (...args: unknown[]) => {
-    lines.push(args.map((a) => String(a)).join(" "));
-  };
-  return {
-    lines,
-    restore: () => {
-      console.log = originalLog;
+/**
+ * Returns a Map whose `.get(anyId)` always yields the same sourcing object.
+ * Avoids having to enumerate DIVISIONS (imported lazily by the command) just
+ * to seed a keyed map.
+ */
+function universalMap(sourcing: InlineSourcing): Map<string, InlineSourcing> {
+  return new Proxy(new Map<string, InlineSourcing>(), {
+    get(target, prop) {
+      if (prop === "get") return () => sourcing;
+      return Reflect.get(target, prop);
     },
-  };
+  }) as Map<string, InlineSourcing>;
 }
 
-describe("import-divisions sync — sourcing attach (QUA-677)", () => {
+describe("import-divisions sync — sourcing attach", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchInlineSourcing.mockResolvedValue(new Map());
@@ -51,85 +44,53 @@ describe("import-divisions sync — sourcing attach (QUA-677)", () => {
       ok: true,
       data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
     });
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
-  it("fetches verdicts and attaches sourcing to matched divisions (dry-run)", async () => {
-    // Use a recordId that exists in DIVISIONS — pick the first one. We can't
-    // import DIVISIONS directly without also importing the command side-effect,
-    // so instead set up a fetch that matches every item (wildcard by default
-    // verdict), and verify attach count equals total via the log line.
-    mockFetchInlineSourcing.mockResolvedValueOnce(
-      new Map([
-        // Return entries for common ids; unmatched items will be reported unsourced.
-        // We purposely return an empty map to assert the 0/N log line, then a
-        // separate test exercises a non-empty map via a spy.
-      ]),
-    );
-    const cap = captureConsole();
-    try {
-      const res = await divisionsCommands.sync([], { "dry-run": true });
-      expect(res.exitCode).toBe(0);
-    } finally {
-      cap.restore();
-    }
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
 
+  function logged(): string[] {
+    return logSpy.mock.calls.map((args: unknown[]) =>
+      args.map((a) => String(a)).join(" "),
+    );
+  }
+
+  it("fetches verdicts and reports 0/N sourced when no verdicts exist", async () => {
+    const res = await divisionsCommands.sync([], { "dry-run": true });
+    expect(res.exitCode).toBe(0);
     expect(mockFetchInlineSourcing).toHaveBeenCalledWith("division");
-    expect(mockSyncDivisions).not.toHaveBeenCalled(); // dry-run
-    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
-    expect(summary).toBeDefined();
+    expect(mockSyncDivisions).not.toHaveBeenCalled();
+    const summary = logged().find((l) => l.includes("Sourcing:"));
     expect(summary).toMatch(/0\/\d+ records have verdicts/);
     expect(summary).toMatch(/unsourced — server will reject/);
   });
 
-  it("reports attached count when some records have verdicts", async () => {
-    // Capture the actual first id by running once with an empty map,
-    // parsing the dry-run line, then re-running with a matching map.
-    // Simpler: stub fetch to return a map that matches ANY input id via a
-    // Proxy, and count attaches.
-    const universalMap = new Proxy(new Map<string, unknown>(), {
-      get(target, prop) {
-        if (prop === "get") {
-          return (_key: string) => ({
-            verdict: "confirmed",
-            confidence: 0.9,
-            checkedAt: "2026-04-24T00:00:00.000Z",
-          });
-        }
-        return Reflect.get(target, prop);
-      },
-    });
-    mockFetchInlineSourcing.mockResolvedValueOnce(universalMap);
+  it("reports attached count when records have verdicts", async () => {
+    mockFetchInlineSourcing.mockResolvedValueOnce(
+      universalMap({
+        verdict: "confirmed",
+        confidence: 0.9,
+        checkedAt: "2026-04-24T00:00:00.000Z",
+      }),
+    );
+    await divisionsCommands.sync([], { "dry-run": true });
 
-    const cap = captureConsole();
-    try {
-      await divisionsCommands.sync([], { "dry-run": true });
-    } finally {
-      cap.restore();
-    }
-    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
-    expect(summary).toBeDefined();
-    // All records attached — no "unsourced" warning suffix.
+    const summary = logged().find((l) => l.includes("Sourcing:"));
     expect(summary).toMatch(/\d+\/\d+ records have verdicts$/);
     expect(summary).not.toContain("unsourced");
-
-    // Dry-run printed per-item badges with the verdict name.
-    const itemLines = cap.lines.filter((l) => l.includes("[confirmed]"));
-    expect(itemLines.length).toBeGreaterThan(0);
+    expect(logged().some((l) => l.includes("[confirmed]"))).toBe(true);
   });
 
   it("skips the verdict fetch under --force-skip-sourcing", async () => {
-    const cap = captureConsole();
-    try {
-      await divisionsCommands.sync([], {
-        "dry-run": true,
-        "force-skip-sourcing": true,
-        reason: "smoke-test",
-      });
-    } finally {
-      cap.restore();
-    }
+    await divisionsCommands.sync([], {
+      "dry-run": true,
+      "force-skip-sourcing": true,
+      reason: "smoke-test",
+    });
     expect(mockFetchInlineSourcing).not.toHaveBeenCalled();
-    const summary = cap.lines.find((l) => l.includes("Sourcing:"));
+    const summary = logged().find((l) => l.includes("Sourcing:"));
     expect(summary).toContain("skipped");
     expect(summary).toContain("smoke-test");
   });
@@ -144,43 +105,24 @@ describe("import-divisions sync — sourcing attach (QUA-677)", () => {
 
   it("POSTs attached sourcing to syncDivisions on a real sync", async () => {
     mockFetchInlineSourcing.mockResolvedValueOnce(
-      new Proxy(new Map(), {
-        get(target, prop) {
-          if (prop === "get") {
-            return () => ({ verdict: "confirmed" });
-          }
-          return Reflect.get(target, prop);
-        },
-      }),
+      universalMap({ verdict: "confirmed" }),
     );
-
-    const cap = captureConsole();
-    try {
-      await divisionsCommands.sync([], {});
-    } finally {
-      cap.restore();
-    }
+    await divisionsCommands.sync([], {});
 
     expect(mockSyncDivisions).toHaveBeenCalledOnce();
     const [items] = mockSyncDivisions.mock.calls[0];
     expect(Array.isArray(items)).toBe(true);
     expect(items.length).toBeGreaterThan(0);
-    // Every item carries the inline sourcing payload.
     for (const item of items) {
       expect(item.sourcing).toEqual({ verdict: "confirmed" });
     }
   });
 
   it("passes forceSkipSourcing + reason through to the client on a real sync", async () => {
-    const cap = captureConsole();
-    try {
-      await divisionsCommands.sync([], {
-        "force-skip-sourcing": true,
-        reason: "ops backfill",
-      });
-    } finally {
-      cap.restore();
-    }
+    await divisionsCommands.sync([], {
+      "force-skip-sourcing": true,
+      reason: "ops backfill",
+    });
 
     expect(mockFetchInlineSourcing).not.toHaveBeenCalled();
     expect(mockSyncDivisions).toHaveBeenCalledOnce();
@@ -197,16 +139,11 @@ describe("import-divisions sync — sourcing attach (QUA-677)", () => {
       error: { status: 400 },
       message: "sourcing missing",
     });
-    const cap = captureConsole();
-    try {
-      await expect(
-        divisionsCommands.sync([], {
-          "force-skip-sourcing": true,
-          reason: "test",
-        }),
-      ).rejects.toThrow(/sourcing missing/);
-    } finally {
-      cap.restore();
-    }
+    await expect(
+      divisionsCommands.sync([], {
+        "force-skip-sourcing": true,
+        reason: "test",
+      }),
+    ).rejects.toThrow(/sourcing missing/);
   });
 });

--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -15,6 +15,7 @@ import { generateId } from "../lib/grant-import/id.ts";
 import { getServerUrl } from "../lib/wiki-server/client.ts";
 import { deleteDivisionsBatch, syncDivisions } from "../lib/wiki-server/divisions.ts";
 import { ORG_IDS } from "../lib/grant-import/constants.ts";
+import { fetchInlineSourcing, type InlineSourcing } from "../lib/wiki-server/inline-sourcing.ts";
 
 // ---------------------------------------------------------------------------
 // Division type (matches wiki-server SyncDivisionItemSchema)
@@ -757,6 +758,7 @@ interface SyncDivision {
   endDate: string | null;
   source: string | null;
   notes: string | null;
+  sourcing?: InlineSourcing;
 }
 
 function toSyncDivision(def: DivisionDef): SyncDivision {
@@ -841,12 +843,43 @@ async function cmdSync(
     );
   }
 
+  // Attach inline sourcing from source_check_verdicts, unless explicitly
+  // bypassed. The server requires sourcing for divisions (SOURCE_CHECK_REQUIRED
+  // in apps/wiki-server/src/routes/shared/sourcing-enforcement.ts); items
+  // without a verdict row are sent bare and the server rejects the batch with
+  // a count of unsourced records, pointing to `verify-orchestrate divisions`.
+  let attached = 0;
+  if (!options?.forceSkipSourcing) {
+    const sourcingByRecordId = await fetchInlineSourcing("division");
+    for (const item of items) {
+      const sourcing = sourcingByRecordId.get(item.id);
+      if (sourcing) {
+        item.sourcing = sourcing;
+        attached++;
+      }
+    }
+  }
+
   console.log(`\nSyncing ${items.length} divisions to ${serverUrl}...`);
+  if (!options?.forceSkipSourcing) {
+    const unsourced = items.length - attached;
+    console.log(
+      `  Sourcing: ${attached}/${items.length} records have verdicts` +
+        (unsourced > 0
+          ? ` (${unsourced} unsourced — server will reject unless you run \`pnpm crux tb verify-orchestrate divisions\` first)`
+          : ""),
+    );
+  } else {
+    console.log(
+      `  Sourcing: skipped (--force-skip-sourcing, reason: ${options?.forceSkipSourcingReason ?? "unspecified"})`,
+    );
+  }
 
   if (dryRun) {
     console.log("  (dry run -- no data written)");
     for (const d of items) {
-      console.log(`  ${d.id}  ${d.name} [${d.divisionType}]`);
+      const badge = d.sourcing ? `[${d.sourcing.verdict}]` : "[unsourced]";
+      console.log(`  ${d.id}  ${d.name} [${d.divisionType}] ${badge}`);
     }
     return;
   }

--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -843,15 +843,8 @@ async function cmdSync(
     );
   }
 
-  // Attach inline sourcing from source_check_verdicts, unless explicitly
-  // bypassed. The server requires sourcing for divisions (SOURCE_CHECK_REQUIRED
-  // in apps/wiki-server/src/routes/shared/sourcing-enforcement.ts); items
-  // without a verdict row are sent bare and the server rejects the batch with
-  // a count of unsourced records, pointing to `verify-orchestrate divisions`.
-  //
-  // The fetch runs even under --dry-run: the whole point of dry-run here is
-  // to preview what the server would accept, which includes which records
-  // already have verdicts ([confirmed] badge) vs. which don't ([unsourced]).
+  // Server requires inline sourcing for divisions; missing verdicts show as
+  // [unsourced] badges so dry-run surfaces the problem before the real sync.
   const forceSkipSourcing = !!options?.forceSkipSourcing;
   let attached = 0;
   if (!forceSkipSourcing) {

--- a/crux/commands/import-divisions.ts
+++ b/crux/commands/import-divisions.ts
@@ -848,8 +848,13 @@ async function cmdSync(
   // in apps/wiki-server/src/routes/shared/sourcing-enforcement.ts); items
   // without a verdict row are sent bare and the server rejects the batch with
   // a count of unsourced records, pointing to `verify-orchestrate divisions`.
+  //
+  // The fetch runs even under --dry-run: the whole point of dry-run here is
+  // to preview what the server would accept, which includes which records
+  // already have verdicts ([confirmed] badge) vs. which don't ([unsourced]).
+  const forceSkipSourcing = !!options?.forceSkipSourcing;
   let attached = 0;
-  if (!options?.forceSkipSourcing) {
+  if (!forceSkipSourcing) {
     const sourcingByRecordId = await fetchInlineSourcing("division");
     for (const item of items) {
       const sourcing = sourcingByRecordId.get(item.id);
@@ -861,18 +866,16 @@ async function cmdSync(
   }
 
   console.log(`\nSyncing ${items.length} divisions to ${serverUrl}...`);
-  if (!options?.forceSkipSourcing) {
-    const unsourced = items.length - attached;
-    console.log(
-      `  Sourcing: ${attached}/${items.length} records have verdicts` +
-        (unsourced > 0
-          ? ` (${unsourced} unsourced — server will reject unless you run \`pnpm crux tb verify-orchestrate divisions\` first)`
-          : ""),
-    );
-  } else {
+  if (forceSkipSourcing) {
     console.log(
       `  Sourcing: skipped (--force-skip-sourcing, reason: ${options?.forceSkipSourcingReason ?? "unspecified"})`,
     );
+  } else {
+    const unsourced = items.length - attached;
+    const warning = unsourced > 0
+      ? ` (${unsourced} unsourced — server will reject unless you run \`pnpm crux tb verify-orchestrate divisions\` first)`
+      : "";
+    console.log(`  Sourcing: ${attached}/${items.length} records have verdicts${warning}`);
   }
 
   if (dryRun) {

--- a/crux/lib/groups.test.ts
+++ b/crux/lib/groups.test.ts
@@ -222,11 +222,7 @@ describe('resolveGroupRouting', () => {
     expect(r).toEqual({ groupName: 'gh', domain: 'issues', command: 'search', argsStart: 2 });
   });
 
-  it('routes tb import-divisions as its own domain (QUA-677)', () => {
-    // Regression test: `pnpm crux tb import-divisions sync` used to route
-    // via the flattened path to `tablebase.import-divisions` (the .default
-    // list command) with `sync` swallowed as a positional arg. Now it
-    // routes to the import-divisions domain with sync as the command.
+  it('routes tb <subdomain> <cmd> to the subdomain, not the tablebase flattened command', () => {
     const hasCommand = (domain: string, cmd: string) => {
       const cmds: Record<string, string[]> = {
         tablebase: ['import-divisions', 'import-divisions-sync'],
@@ -242,7 +238,7 @@ describe('resolveGroupRouting', () => {
     });
   });
 
-  it('routes tb import-divisions (no command) to the domain default', () => {
+  it('routes tb <subdomain> (no command) to the subdomain default', () => {
     const r = resolveGroupRouting(['tb', 'import-divisions'], shortcuts, () => false);
     expect(r).toEqual({
       groupName: 'tablebase',
@@ -252,7 +248,7 @@ describe('resolveGroupRouting', () => {
     });
   });
 
-  it('routes tb data-sources subcommand to the domain', () => {
+  it('routes tb data-sources subcommand to the subdomain', () => {
     const r = resolveGroupRouting(['tb', 'data-sources', 'list'], shortcuts, () => false);
     expect(r).toEqual({
       groupName: 'tablebase',
@@ -262,9 +258,7 @@ describe('resolveGroupRouting', () => {
     });
   });
 
-  it('keeps flattened import-divisions-sync alias routing to tablebase', () => {
-    // `crux tb import-divisions-sync` should still find the flat command
-    // on the tablebase domain (used by scripts, docs, muscle memory).
+  it('keeps flattened dash-form aliases routing to tablebase', () => {
     const hasCommand = (domain: string, cmd: string) => {
       return domain === 'tablebase' && cmd === 'import-divisions-sync';
     };

--- a/crux/lib/groups.test.ts
+++ b/crux/lib/groups.test.ts
@@ -221,4 +221,59 @@ describe('resolveGroupRouting', () => {
     const r = resolveGroupRouting(['gh', 'search', 'topic'], shortcuts, mockHasCommand);
     expect(r).toEqual({ groupName: 'gh', domain: 'issues', command: 'search', argsStart: 2 });
   });
+
+  it('routes tb import-divisions as its own domain (QUA-677)', () => {
+    // Regression test: `pnpm crux tb import-divisions sync` used to route
+    // via the flattened path to `tablebase.import-divisions` (the .default
+    // list command) with `sync` swallowed as a positional arg. Now it
+    // routes to the import-divisions domain with sync as the command.
+    const hasCommand = (domain: string, cmd: string) => {
+      const cmds: Record<string, string[]> = {
+        tablebase: ['import-divisions', 'import-divisions-sync'],
+      };
+      return cmds[domain]?.includes(cmd) ?? false;
+    };
+    const r = resolveGroupRouting(['tb', 'import-divisions', 'sync'], shortcuts, hasCommand);
+    expect(r).toEqual({
+      groupName: 'tablebase',
+      domain: 'import-divisions',
+      command: 'sync',
+      argsStart: 3,
+    });
+  });
+
+  it('routes tb import-divisions (no command) to the domain default', () => {
+    const r = resolveGroupRouting(['tb', 'import-divisions'], shortcuts, () => false);
+    expect(r).toEqual({
+      groupName: 'tablebase',
+      domain: 'import-divisions',
+      command: null,
+      argsStart: 3,
+    });
+  });
+
+  it('routes tb data-sources subcommand to the domain', () => {
+    const r = resolveGroupRouting(['tb', 'data-sources', 'list'], shortcuts, () => false);
+    expect(r).toEqual({
+      groupName: 'tablebase',
+      domain: 'data-sources',
+      command: 'list',
+      argsStart: 3,
+    });
+  });
+
+  it('keeps flattened import-divisions-sync alias routing to tablebase', () => {
+    // `crux tb import-divisions-sync` should still find the flat command
+    // on the tablebase domain (used by scripts, docs, muscle memory).
+    const hasCommand = (domain: string, cmd: string) => {
+      return domain === 'tablebase' && cmd === 'import-divisions-sync';
+    };
+    const r = resolveGroupRouting(['tb', 'import-divisions-sync'], shortcuts, hasCommand);
+    expect(r).toEqual({
+      groupName: 'tablebase',
+      domain: 'tablebase',
+      command: 'import-divisions-sync',
+      argsStart: 2,
+    });
+  });
 });

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -91,12 +91,10 @@ export const GROUPS: Record<string, GroupDef> = {
       'political',
       'benchmarks',
       'flagship-curate',
-      // QUA-677: treat import/data-source domains with multiple subcommands
-      // as proper sub-domains so `crux tb <domain> <sub>` dispatches to the
-      // subcommand instead of silently running `.default` with `<sub>` as a
-      // swallowed positional arg. The flattened dash-form aliases
-      // (`import-divisions-sync`, etc.) in tablebase.commands keep working
-      // via the flattened path.
+      // Domains with multiple subcommands — list them so `tb <domain> <sub>`
+      // dispatches to the subcommand rather than the domain default. Flat
+      // dash-form aliases (`import-divisions-sync`, etc.) still resolve via
+      // the flattened path.
       'import-grants',
       'import-divisions',
       'import-funding-programs',

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -91,6 +91,17 @@ export const GROUPS: Record<string, GroupDef> = {
       'political',
       'benchmarks',
       'flagship-curate',
+      // QUA-677: treat import/data-source domains with multiple subcommands
+      // as proper sub-domains so `crux tb <domain> <sub>` dispatches to the
+      // subcommand instead of silently running `.default` with `<sub>` as a
+      // swallowed positional arg. The flattened dash-form aliases
+      // (`import-divisions-sync`, etc.) in tablebase.commands keep working
+      // via the flattened path.
+      'import-grants',
+      'import-divisions',
+      'import-funding-programs',
+      'data-sources',
+      'website-sources',
     ],
     flattened: ['tablebase'],
   },

--- a/crux/lib/wiki-server/inline-sourcing.test.ts
+++ b/crux/lib/wiki-server/inline-sourcing.test.ts
@@ -221,4 +221,51 @@ describe("fetchInlineSourcing", () => {
       });
     await expect(fetchInlineSourcing("division")).rejects.toThrow(/offset=200/);
   });
+
+  it("falls back to error code when message is missing (no 'undefined' in text)", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: false,
+      error: "server_error",
+      message: undefined,
+    });
+    let thrown: Error | null = null;
+    try {
+      await fetchInlineSourcing("division");
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).toMatch(/server_error/);
+    expect(thrown!.message).not.toMatch(/undefined/);
+  });
+
+  it("truncates evidence longer than 5000 chars with a visible marker", async () => {
+    const longReasoning = "a".repeat(6000);
+    mockListVerdicts.mockResolvedValue({
+      ok: true,
+      data: {
+        verdicts: [verdict({ recordId: "a", reasoning: longReasoning })],
+        total: 1,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    const evidence = map.get("a")?.evidence ?? "";
+    expect(evidence.length).toBeLessThanOrEqual(5000);
+    expect(evidence.endsWith("… [truncated]")).toBe(true);
+    // And the non-truncated prefix is preserved.
+    expect(evidence.startsWith("aaa")).toBe(true);
+  });
+
+  it("leaves evidence at exactly 5000 chars untouched (boundary)", async () => {
+    const exact = "b".repeat(5000);
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [verdict({ recordId: "a", reasoning: exact })],
+        total: 1,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    expect(map.get("a")?.evidence).toBe(exact);
+  });
 });

--- a/crux/lib/wiki-server/inline-sourcing.test.ts
+++ b/crux/lib/wiki-server/inline-sourcing.test.ts
@@ -1,14 +1,3 @@
-/**
- * Tests for fetchInlineSourcing — QUA-677.
- *
- * Verifies that:
- *   - whole-row verdicts are mapped by recordId
- *   - per-field verdicts (fieldName !== null) are skipped
- *   - `unchecked` and other non-attachable verdict values are skipped
- *   - pagination continues until a short page is returned
- *   - non-ok API responses throw
- */
-
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { mockListVerdicts } = vi.hoisted(() => ({

--- a/crux/lib/wiki-server/inline-sourcing.test.ts
+++ b/crux/lib/wiki-server/inline-sourcing.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for fetchInlineSourcing — QUA-677.
+ *
+ * Verifies that:
+ *   - whole-row verdicts are mapped by recordId
+ *   - per-field verdicts (fieldName !== null) are skipped
+ *   - `unchecked` and other non-attachable verdict values are skipped
+ *   - pagination continues until a short page is returned
+ *   - non-ok API responses throw
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockListVerdicts } = vi.hoisted(() => ({
+  mockListVerdicts: vi.fn(),
+}));
+vi.mock("./sourcing-client.ts", () => ({
+  listVerdicts: mockListVerdicts,
+}));
+
+import { fetchInlineSourcing } from "./inline-sourcing.ts";
+
+type Verdict = {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  entityId: string | null;
+  displayName: string | null;
+  entityDisplayName: string | null;
+  verdict: string;
+  confidence: number | null;
+  reasoning: string | null;
+  sourcesChecked: number;
+  needsRecheck: boolean;
+  nextCheckDue: string | null;
+  lastComputedAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function verdict(overrides: Partial<Verdict> = {}): Verdict {
+  return {
+    recordType: "division",
+    recordId: "r1",
+    fieldName: null,
+    entityId: null,
+    displayName: null,
+    entityDisplayName: null,
+    verdict: "confirmed",
+    confidence: 0.9,
+    reasoning: "Verified against primary source",
+    sourcesChecked: 1,
+    needsRecheck: false,
+    nextCheckDue: null,
+    lastComputedAt: "2026-04-24T00:00:00.000Z",
+    createdAt: "2026-04-24T00:00:00.000Z",
+    updatedAt: "2026-04-24T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("fetchInlineSourcing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps whole-row verdicts by recordId", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          verdict({ recordId: "a", verdict: "confirmed" }),
+          verdict({ recordId: "b", verdict: "contradicted" }),
+        ],
+        total: 2,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    expect(map.size).toBe(2);
+    expect(map.get("a")?.verdict).toBe("confirmed");
+    expect(map.get("b")?.verdict).toBe("contradicted");
+  });
+
+  it("skips per-field verdicts (fieldName !== null)", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          verdict({ recordId: "a", fieldName: null }),
+          verdict({ recordId: "b", fieldName: "lead" }),
+        ],
+        total: 2,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    expect(map.has("a")).toBe(true);
+    expect(map.has("b")).toBe(false);
+  });
+
+  it("skips unchecked and other non-attachable verdicts", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          verdict({ recordId: "a", verdict: "unchecked" }),
+          verdict({ recordId: "b", verdict: "confirmed" }),
+          verdict({ recordId: "c", verdict: "bogus" }),
+        ],
+        total: 3,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    expect(map.has("a")).toBe(false);
+    expect(map.has("b")).toBe(true);
+    expect(map.has("c")).toBe(false);
+  });
+
+  it("populates confidence, checkedAt, and evidence from the row", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          verdict({
+            recordId: "a",
+            verdict: "partial",
+            confidence: 0.6,
+            reasoning: "Partial evidence found.",
+            lastComputedAt: "2026-04-24T12:00:00.000Z",
+          }),
+        ],
+        total: 1,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    const s = map.get("a");
+    expect(s).toEqual({
+      verdict: "partial",
+      confidence: 0.6,
+      evidence: "Partial evidence found.",
+      checkedAt: "2026-04-24T12:00:00.000Z",
+    });
+  });
+
+  it("omits optional fields when the row has null values", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        verdicts: [
+          verdict({
+            recordId: "a",
+            confidence: null,
+            reasoning: null,
+          }),
+        ],
+        total: 1,
+      },
+    });
+    const map = await fetchInlineSourcing("division");
+    const s = map.get("a")!;
+    expect(s.verdict).toBe("confirmed");
+    expect(s).not.toHaveProperty("confidence");
+    expect(s).not.toHaveProperty("evidence");
+  });
+
+  it("paginates until a short page is returned", async () => {
+    // Full page of 200 → request another page → empty page ends pagination
+    const fullPage = Array.from({ length: 200 }, (_, i) =>
+      verdict({ recordId: `a${i}` }),
+    );
+    mockListVerdicts
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: fullPage, total: 201 } })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: { verdicts: [verdict({ recordId: "final" })], total: 201 },
+      });
+    const map = await fetchInlineSourcing("division");
+    expect(map.size).toBe(201);
+    expect(map.has("final")).toBe(true);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(2);
+    expect(mockListVerdicts.mock.calls[0][0]).toEqual({
+      recordType: "division",
+      limit: 200,
+      offset: 0,
+    });
+    expect(mockListVerdicts.mock.calls[1][0]).toEqual({
+      recordType: "division",
+      limit: 200,
+      offset: 200,
+    });
+  });
+
+  it("stops pagination on a short page without an extra request", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [verdict({ recordId: "only" })], total: 1 },
+    });
+    const map = await fetchInlineSourcing("division");
+    expect(map.size).toBe(1);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the API returns an error", async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: false,
+      error: { status: 500, code: "server_error" },
+      message: "boom",
+    });
+    await expect(fetchInlineSourcing("division")).rejects.toThrow(/boom/);
+  });
+
+  it("includes the offset in error messages so mid-pagination failures are debuggable", async () => {
+    const fullPage = Array.from({ length: 200 }, (_, i) =>
+      verdict({ recordId: `x${i}` }),
+    );
+    mockListVerdicts
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: fullPage, total: 400 } })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { status: 503 },
+        message: "unavailable",
+      });
+    await expect(fetchInlineSourcing("division")).rejects.toThrow(/offset=200/);
+  });
+});

--- a/crux/lib/wiki-server/inline-sourcing.ts
+++ b/crux/lib/wiki-server/inline-sourcing.ts
@@ -1,0 +1,93 @@
+/**
+ * Inline sourcing attach helper — fetches `source_check_verdicts` rows for a
+ * given record type and returns a map of recordId → InlineSourcing payload
+ * suitable for attaching to TableBase `/sync` request items.
+ *
+ * Usage (in crux importers):
+ *   const byRecordId = await fetchInlineSourcing('division');
+ *   for (const item of items) {
+ *     const s = byRecordId.get(item.id);
+ *     if (s) item.sourcing = s;
+ *   }
+ *
+ * Why this exists: server tables listed in `SOURCE_CHECK_REQUIRED`
+ * (see apps/wiki-server/src/routes/shared/sourcing-enforcement.ts) reject
+ * sync payloads whose items do not carry an inline `sourcing` field. The
+ * canonical verdict rows already live in PG after
+ * `pnpm crux tb verify-orchestrate <table>`, so importers can read them
+ * back at sync time instead of requiring every record author to curate
+ * verdicts by hand. See QUA-677.
+ */
+
+import { listVerdicts } from "./sourcing-client.ts";
+
+/** Must match apps/wiki-server/src/routes/tablebase/sourcing-schema.ts */
+export interface InlineSourcing {
+  verdict: "confirmed" | "contradicted" | "outdated" | "partial" | "unverifiable";
+  evidence?: string;
+  confidence?: number;
+  sourceContentHash?: string;
+  checkedAt?: string;
+  checkedBy?: string;
+}
+
+/** Verdicts that aren't accepted by InlineSourcingSchema (skipped when attaching). */
+const ATTACHABLE_VERDICTS = new Set([
+  "confirmed",
+  "contradicted",
+  "outdated",
+  "partial",
+  "unverifiable",
+]);
+
+/** Must not exceed the server's MAX_PAGE_SIZE for the verdicts endpoint. */
+const PAGE_SIZE = 200;
+
+/**
+ * Fetch whole-row verdicts (`fieldName === null`) for a given record_type and
+ * return a map of recordId → InlineSourcing. Paginates through the verdicts
+ * endpoint so tables with >200 verdicts are covered.
+ *
+ * Rows with `verdict='unchecked'` are skipped — InlineSourcingSchema rejects
+ * that value, and attaching it would trip the server's enforcement check
+ * anyway. Per-field verdicts (`fieldName !== null`) are also skipped because
+ * inline sourcing on sync payloads is whole-row.
+ */
+export async function fetchInlineSourcing(
+  recordType: string,
+): Promise<Map<string, InlineSourcing>> {
+  const map = new Map<string, InlineSourcing>();
+  let offset = 0;
+
+  while (true) {
+    const res = await listVerdicts({
+      recordType,
+      limit: PAGE_SIZE,
+      offset,
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch ${recordType} verdicts (offset=${offset}): ${res.message}`,
+      );
+    }
+
+    for (const v of res.data.verdicts) {
+      if (v.fieldName != null) continue;
+      if (!ATTACHABLE_VERDICTS.has(v.verdict)) continue;
+
+      const sourcing: InlineSourcing = {
+        verdict: v.verdict as InlineSourcing["verdict"],
+      };
+      if (v.confidence != null) sourcing.confidence = v.confidence;
+      if (v.lastComputedAt) sourcing.checkedAt = v.lastComputedAt;
+      if (v.reasoning) sourcing.evidence = v.reasoning.slice(0, 5000);
+
+      map.set(v.recordId, sourcing);
+    }
+
+    if (res.data.verdicts.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  return map;
+}

--- a/crux/lib/wiki-server/inline-sourcing.ts
+++ b/crux/lib/wiki-server/inline-sourcing.ts
@@ -1,40 +1,14 @@
 /**
- * Inline sourcing attach helper — fetches `source_check_verdicts` rows for a
- * given record type and returns a map of recordId → InlineSourcing payload
- * suitable for attaching to TableBase `/sync` request items.
- *
- * Usage (in crux importers):
- *   const byRecordId = await fetchInlineSourcing('division');
- *   for (const item of items) {
- *     const s = byRecordId.get(item.id);
- *     if (s) item.sourcing = s;
- *   }
- *
- * Why this exists: server tables listed in `SOURCE_CHECK_REQUIRED`
- * (see apps/wiki-server/src/routes/shared/sourcing-enforcement.ts) reject
- * sync payloads whose items do not carry an inline `sourcing` field. The
- * canonical verdict rows already live in PG after
- * `pnpm crux tb verify-orchestrate <table>`, so importers can read them
- * back at sync time instead of requiring every record author to curate
- * verdicts by hand. See QUA-677.
+ * Fetch whole-row source_check_verdicts for attaching as inline sourcing on
+ * TableBase /sync payloads. See sourcing-enforcement.ts — server tables listed
+ * in SOURCE_CHECK_REQUIRED reject sync items without a `sourcing` field.
  */
 
+import type { InlineSourcing } from "../../../apps/wiki-server/src/routes/tablebase/sourcing-schema.ts";
 import { listVerdicts } from "./sourcing-client.ts";
 
-/** Must match apps/wiki-server/src/routes/tablebase/sourcing-schema.ts */
-export interface InlineSourcing {
-  verdict: "confirmed" | "contradicted" | "outdated" | "partial" | "unverifiable";
-  evidence?: string;
-  confidence?: number;
-  sourceContentHash?: string;
-  checkedAt?: string;
-  checkedBy?: string;
-}
+export type { InlineSourcing };
 
-/**
- * Verdict values accepted by InlineSourcingSchema. Kept as a typed Set so the
- * `has` check narrows the verdict string to the enum without a type assertion.
- */
 const ATTACHABLE_VERDICTS = new Set<InlineSourcing["verdict"]>([
   "confirmed",
   "contradicted",
@@ -43,29 +17,18 @@ const ATTACHABLE_VERDICTS = new Set<InlineSourcing["verdict"]>([
   "unverifiable",
 ]);
 
-/**
- * Must not exceed the server's MAX_PAGE_SIZE for the verdicts endpoint (200),
- * defined in apps/wiki-server/src/routes/sourcing/sourcing.ts.
- */
+/** Matches server MAX_PAGE_SIZE in apps/wiki-server/src/routes/sourcing/sourcing.ts. */
 const PAGE_SIZE = 200;
 
-/**
- * Server-side InlineSourcingSchema caps `evidence` at 5000 chars. Mirror it
- * here so we don't ship a payload the server rejects, and so truncation is
- * visible to readers of the helper rather than happening by silent overflow.
- */
+/** Server's InlineSourcingSchema caps `evidence` at 5000 chars. */
 const EVIDENCE_MAX_LENGTH = 5000;
 const TRUNCATION_SUFFIX = "… [truncated]";
 
 /**
- * Fetch whole-row verdicts (`fieldName === null`) for a given record_type and
- * return a map of recordId → InlineSourcing. Paginates through the verdicts
- * endpoint so tables with >200 verdicts are covered.
- *
- * Rows with `verdict='unchecked'` are skipped — InlineSourcingSchema rejects
- * that value, and attaching it would trip the server's enforcement check
- * anyway. Per-field verdicts (`fieldName !== null`) are also skipped because
- * inline sourcing on sync payloads is whole-row.
+ * Fetch whole-row verdicts for a record_type and return a map of
+ * recordId → InlineSourcing. Paginates through all verdicts; skips
+ * per-field verdicts (fieldName !== null) and `unchecked` values
+ * that InlineSourcingSchema rejects.
  */
 export async function fetchInlineSourcing(
   recordType: string,
@@ -109,11 +72,6 @@ function isAttachableVerdict(v: string): v is InlineSourcing["verdict"] {
   return (ATTACHABLE_VERDICTS as Set<string>).has(v);
 }
 
-/**
- * Truncate evidence to the server's 5000-char cap, appending a visible marker
- * when truncation occurs so it's not silent. The marker eats into the budget
- * so the final string is still under the limit.
- */
 function truncateEvidence(s: string): string {
   if (s.length <= EVIDENCE_MAX_LENGTH) return s;
   const head = s.slice(0, EVIDENCE_MAX_LENGTH - TRUNCATION_SUFFIX.length);

--- a/crux/lib/wiki-server/inline-sourcing.ts
+++ b/crux/lib/wiki-server/inline-sourcing.ts
@@ -31,8 +31,11 @@ export interface InlineSourcing {
   checkedBy?: string;
 }
 
-/** Verdicts that aren't accepted by InlineSourcingSchema (skipped when attaching). */
-const ATTACHABLE_VERDICTS = new Set([
+/**
+ * Verdict values accepted by InlineSourcingSchema. Kept as a typed Set so the
+ * `has` check narrows the verdict string to the enum without a type assertion.
+ */
+const ATTACHABLE_VERDICTS = new Set<InlineSourcing["verdict"]>([
   "confirmed",
   "contradicted",
   "outdated",
@@ -40,8 +43,19 @@ const ATTACHABLE_VERDICTS = new Set([
   "unverifiable",
 ]);
 
-/** Must not exceed the server's MAX_PAGE_SIZE for the verdicts endpoint. */
+/**
+ * Must not exceed the server's MAX_PAGE_SIZE for the verdicts endpoint (200),
+ * defined in apps/wiki-server/src/routes/sourcing/sourcing.ts.
+ */
 const PAGE_SIZE = 200;
+
+/**
+ * Server-side InlineSourcingSchema caps `evidence` at 5000 chars. Mirror it
+ * here so we don't ship a payload the server rejects, and so truncation is
+ * visible to readers of the helper rather than happening by silent overflow.
+ */
+const EVIDENCE_MAX_LENGTH = 5000;
+const TRUNCATION_SUFFIX = "… [truncated]";
 
 /**
  * Fetch whole-row verdicts (`fieldName === null`) for a given record_type and
@@ -66,21 +80,20 @@ export async function fetchInlineSourcing(
       offset,
     });
     if (!res.ok) {
+      const detail = res.message || res.error || "unknown error";
       throw new Error(
-        `Failed to fetch ${recordType} verdicts (offset=${offset}): ${res.message}`,
+        `Failed to fetch ${recordType} verdicts (offset=${offset}): ${detail}`,
       );
     }
 
     for (const v of res.data.verdicts) {
       if (v.fieldName != null) continue;
-      if (!ATTACHABLE_VERDICTS.has(v.verdict)) continue;
+      if (!isAttachableVerdict(v.verdict)) continue;
 
-      const sourcing: InlineSourcing = {
-        verdict: v.verdict as InlineSourcing["verdict"],
-      };
+      const sourcing: InlineSourcing = { verdict: v.verdict };
       if (v.confidence != null) sourcing.confidence = v.confidence;
       if (v.lastComputedAt) sourcing.checkedAt = v.lastComputedAt;
-      if (v.reasoning) sourcing.evidence = v.reasoning.slice(0, 5000);
+      if (v.reasoning) sourcing.evidence = truncateEvidence(v.reasoning);
 
       map.set(v.recordId, sourcing);
     }
@@ -90,4 +103,19 @@ export async function fetchInlineSourcing(
   }
 
   return map;
+}
+
+function isAttachableVerdict(v: string): v is InlineSourcing["verdict"] {
+  return (ATTACHABLE_VERDICTS as Set<string>).has(v);
+}
+
+/**
+ * Truncate evidence to the server's 5000-char cap, appending a visible marker
+ * when truncation occurs so it's not silent. The marker eats into the budget
+ * so the final string is still under the limit.
+ */
+function truncateEvidence(s: string): string {
+  if (s.length <= EVIDENCE_MAX_LENGTH) return s;
+  const head = s.slice(0, EVIDENCE_MAX_LENGTH - TRUNCATION_SUFFIX.length);
+  return head + TRUNCATION_SUFFIX;
 }


### PR DESCRIPTION
## Summary

`pnpm crux import-divisions sync` was unusable against prod. Three bugs, all fixed here:

1. **`tb` wrapper silently no-oped.** `crux tb import-divisions sync` routed via the flattened tablebase path to `.default` (the list command) with `sync` swallowed as a positional arg. Same latent bug affected `import-grants`, `import-funding-programs`, `data-sources`, `website-sources`. Fixed by listing these as sub-domains in `tablebase.domains` so `tb <domain> <sub>` dispatches correctly.

2. **Sync payload had no inline sourcing.** Server enforcement (QUA-248 Phase 7) rejected 65/65 records. Added `crux/lib/wiki-server/inline-sourcing.ts` — a generic helper that fetches whole-row verdicts from `source_check_verdicts` and returns a `Map<recordId, InlineSourcing>`. `cmdSync` attaches them before POSTing. Type is imported from the server's `sourcing-schema.ts` (no drift risk). Records without a verdict ship bare; the server rejects with the count + next-step command.

3. **Server error message pointed at the wrong command.** `tb verify <table>` is the single-entity personnel ID check; the sourcing orchestrator is `tb verify-orchestrate <table>`. Fixed the suggestion text in `sourcing-enforcement.ts`.

## Verification

Tested all five invocation paths against prod (dry-run):
- `crux tb import-divisions` → lists 65 divisions
- `crux tb import-divisions sync --dry-run` → `Sourcing: 63/65 records have verdicts (2 unsourced)` with per-item `[confirmed]` / `[unsourced]` badges
- `crux import-divisions sync --dry-run` → same behavior via legacy path
- `crux tb import-divisions-sync --dry-run` → flat-dashed alias still routes
- `crux tb import-divisions sync --force-skip-sourcing --reason="..."` → skips fetch, logs reason

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm crux w validate gate --fix` — all 48 checks pass
- [x] `pnpm --filter wiki-server test` — sourcing-enforcement + sync-factory green
- [x] New tests: `inline-sourcing.test.ts` (12), `import-divisions.test.ts` (7), `groups.test.ts` (+4 cases). All 75 pass.
- [x] Existing regression guard in `sourcing-enforcement.test.ts` updated to assert on `verify-orchestrate` and reject a bare `verify <table>` suggestion.
- [x] Smoke-tested all 5 CLI invocation paths against prod wiki-server.

## Follow-ups (not in this PR)

- CI post-deploy hook that runs the actual sync (not just `--dry-run`) so this class of design gap is caught before the next release. Will file.
- `fetchInlineSourcing` over-fetches the whole recordType. Fine for 65 divisions; worth a target-IDs filter + parallel pagination if reused for grants (5k+) / investments. Will file.
- Shared pagination helper (`fetchAllPages`) — 9+ crux/lib/wiki-server call sites currently hand-roll offset loops.

Fixes QUA-677
