### PR TITLE
fix(wellness): make Linear dedup misconfig loud (QUA-676)

### DIFF
--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   dedupLinearWellnessIssue,
   closeLinearWellnessOnAllClear,
+  isMissingLinearApiKeyError,
   REOPEN_WINDOW_MS,
 } from './wellness-linear-dedup.ts';
 import type { SearchedIssue } from '../lib/linear/issues.ts';
@@ -264,6 +265,34 @@ describe('dedupLinearWellnessIssue', () => {
     expect(setState).not.toHaveBeenCalled();
   });
 
+  it('returns skipped/misconfig (NOT skipped/lookup-failed) when LINEAR_API_KEY is missing', async () => {
+    // QUA-676: discriminating misconfig from transient outage matters because
+    // the caller stamps a banner on the GitHub issue body in the misconfig
+    // case. If both errors were collapsed under `lookup-failed`, the caller
+    // would treat a permanent missing-secret problem as a transient blip and
+    // the duplicate cascade would keep happening invisibly.
+    const apiKeyError = new Error(
+      'LINEAR_API_KEY not set. Required for Linear API calls.\n' +
+        'It should be in .env.base at the workspace root — sync it into the slot .env or export it.',
+    );
+    const search = vi.fn().mockRejectedValue(apiKeyError);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
+        search, comment: vi.fn(), setState: vi.fn(), now: () => NOW,
+      });
+      expect(result).toEqual({ kind: 'skipped', reason: 'misconfig' });
+      // Loud failure is the whole point — assert the ::error annotation
+      // pattern fires so this can't regress to a quiet warn.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('::error title=Wellness dedup misconfigured::'),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it('treats unknown state types as NOT open (allowlist safety)', async () => {
     // If Linear adds a new state type, we want to fail closed — better to
     // treat it as "already closed, maybe reopen" than to accidentally
@@ -346,6 +375,32 @@ describe('closeLinearWellnessOnAllClear', () => {
     expect(result).toEqual({ kind: 'lookup-failed' });
   });
 
+  it('returns misconfig (NOT lookup-failed) when LINEAR_API_KEY is missing — and stays QUIET', async () => {
+    // The all-clear path must not re-emit the loud ::error banner that the
+    // failure path already emitted; otherwise every recovery cycle floods
+    // the run summary with the same misconfig annotation. The failure path
+    // is the canonical place to surface it.
+    const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
+    const search = vi.fn().mockRejectedValue(apiKeyError);
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
+        search,
+        comment: vi.fn(),
+        setState: vi.fn(),
+        now: () => NOW,
+      });
+      expect(result).toEqual({ kind: 'misconfig' });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
   it('returns close-failed (NOT lookup-failed) when search succeeds but every close throws', async () => {
     // Discriminating search failure from close failure matters for telemetry —
     // the two failure modes have different root causes and different remediations.
@@ -381,5 +436,37 @@ describe('closeLinearWellnessOnAllClear', () => {
     });
 
     expect(result).toEqual({ kind: 'closed', identifiers: ['QUA-570'] });
+  });
+});
+
+describe('isMissingLinearApiKeyError', () => {
+  it('matches the exact error thrown by getLinearApiKey()', () => {
+    const err = new Error(
+      'LINEAR_API_KEY not set. Required for Linear API calls.\n' +
+        'It should be in .env.base at the workspace root — sync it into the slot .env or export it.',
+    );
+    expect(isMissingLinearApiKeyError(err)).toBe(true);
+  });
+
+  it('matches when the message is wrapped or quoted as a substring', () => {
+    // Defensive: error wrapping (e.g., `new Error("upstream failed: " + e.message)`)
+    // is a common pattern. Substring match keeps the detector robust against it.
+    expect(isMissingLinearApiKeyError(new Error('upstream call failed: LINEAR_API_KEY not set'))).toBe(
+      true,
+    );
+  });
+
+  it('does not match generic Linear errors', () => {
+    expect(isMissingLinearApiKeyError(new Error('Linear API returned 500'))).toBe(false);
+    expect(isMissingLinearApiKeyError(new Error('fetch failed'))).toBe(false);
+    expect(isMissingLinearApiKeyError(undefined)).toBe(false);
+    expect(isMissingLinearApiKeyError(null)).toBe(false);
+  });
+
+  it('handles non-Error values (string thrown, etc.)', () => {
+    // `throw "foo"` is unusual but legal in JS and would otherwise crash
+    // the err.message access. The String(err) fallback covers it.
+    expect(isMissingLinearApiKeyError('LINEAR_API_KEY not set in env')).toBe(true);
+    expect(isMissingLinearApiKeyError({ toString: () => 'LINEAR_API_KEY not set yo' })).toBe(true);
   });
 });

--- a/crux/health/wellness-linear-dedup.test.ts
+++ b/crux/health/wellness-linear-dedup.test.ts
@@ -276,7 +276,7 @@ describe('dedupLinearWellnessIssue', () => {
         'It should be in .env.base at the workspace root — sync it into the slot .env or export it.',
     );
     const search = vi.fn().mockRejectedValue(apiKeyError);
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     try {
       const result = await dedupLinearWellnessIssue(TITLE, COMMENT, {
@@ -285,11 +285,11 @@ describe('dedupLinearWellnessIssue', () => {
       expect(result).toEqual({ kind: 'skipped', reason: 'misconfig' });
       // Loud failure is the whole point — assert the ::error annotation
       // pattern fires so this can't regress to a quiet warn.
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('::error title=Wellness dedup misconfigured::'),
       );
     } finally {
-      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
     }
   });
 
@@ -383,7 +383,7 @@ describe('closeLinearWellnessOnAllClear', () => {
     const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
     const search = vi.fn().mockRejectedValue(apiKeyError);
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     try {
       const result = await closeLinearWellnessOnAllClear(TITLE, closeComment, {
@@ -393,10 +393,10 @@ describe('closeLinearWellnessOnAllClear', () => {
         now: () => NOW,
       });
       expect(result).toEqual({ kind: 'misconfig' });
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleLogSpy).not.toHaveBeenCalled();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     } finally {
-      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
       consoleWarnSpy.mockRestore();
     }
   });

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -115,11 +115,11 @@ export async function dedupLinearWellnessIssue(
     candidates = results.filter((r) => r.title === title);
   } catch (err) {
     if (isMissingLinearApiKeyError(err)) {
-      // Permanent misconfig — surfaced via stderr (CI annotation) so the
-      // missing-secret cause shows up in the run summary, not just the log.
-      // The caller stamps a banner onto the GitHub issue body so the cause is
-      // visible to whoever reads the wellness ticket too.
-      console.error(
+      // Permanent misconfig — surfaced via stdout because GitHub Actions
+      // workflow commands (::error::) are parsed only from stdout. The caller
+      // also stamps a banner onto the GitHub issue body so the cause is
+      // visible to whoever reads the wellness ticket.
+      console.log(
         '::error title=Wellness dedup misconfigured::LINEAR_API_KEY secret not set in repo — Linear-side dedup is dormant; expect duplicate wellness tickets until the secret is added (Settings → Secrets and variables → Actions).',
       );
       return { kind: 'skipped', reason: 'misconfig' };

--- a/crux/health/wellness-linear-dedup.ts
+++ b/crux/health/wellness-linear-dedup.ts
@@ -45,7 +45,20 @@ export const REOPEN_WINDOW_MS = 48 * 60 * 60 * 1000;
 export type LinearWellnessAction =
   | { kind: 'commented'; identifier: string; url: string }
   | { kind: 'reopened'; identifier: string; url: string }
-  | { kind: 'skipped'; reason: 'no-match' | 'lookup-failed' };
+  | { kind: 'skipped'; reason: 'no-match' | 'lookup-failed' | 'misconfig' };
+
+/**
+ * Detect the specific error thrown by `getLinearApiKey()` when LINEAR_API_KEY
+ * is unset in the env. This is a permanent misconfiguration (vs a transient
+ * Linear API outage), so the caller surfaces it loudly instead of silently
+ * falling through to the GitHub create path. The check is substring-based so
+ * it survives wrapping in additional error context — `getLinearApiKey()`'s
+ * exact message is "LINEAR_API_KEY not set. Required for Linear API calls."
+ */
+export function isMissingLinearApiKeyError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('LINEAR_API_KEY not set');
+}
 
 export interface LinearDedupDeps {
   search: typeof searchIssues;
@@ -101,6 +114,16 @@ export async function dedupLinearWellnessIssue(
     const results = await search(title, 20);
     candidates = results.filter((r) => r.title === title);
   } catch (err) {
+    if (isMissingLinearApiKeyError(err)) {
+      // Permanent misconfig — surfaced via stderr (CI annotation) so the
+      // missing-secret cause shows up in the run summary, not just the log.
+      // The caller stamps a banner onto the GitHub issue body so the cause is
+      // visible to whoever reads the wellness ticket too.
+      console.error(
+        '::error title=Wellness dedup misconfigured::LINEAR_API_KEY secret not set in repo — Linear-side dedup is dormant; expect duplicate wellness tickets until the secret is added (Settings → Secrets and variables → Actions).',
+      );
+      return { kind: 'skipped', reason: 'misconfig' };
+    }
     console.warn(
       `Linear wellness dedup lookup failed (${err instanceof Error ? err.message : String(err)}) — falling back to GitHub create path`,
     );
@@ -179,6 +202,8 @@ export type CloseLinearWellnessResult =
   | { kind: 'none' }
   /** Discriminates "didn't reach Linear" from "reached Linear but every close call threw." */
   | { kind: 'lookup-failed' }
+  /** Permanent misconfig: LINEAR_API_KEY missing. Distinguished so the all-clear path stays quiet — there's nothing to close on Linear when we never opened anything there. */
+  | { kind: 'misconfig' }
   | { kind: 'close-failed'; attempted: string[] };
 
 /**
@@ -199,6 +224,12 @@ export async function closeLinearWellnessOnAllClear(
     const results = await search(title, 20);
     candidates = results.filter((r) => r.title === title && isOpen(r));
   } catch (err) {
+    if (isMissingLinearApiKeyError(err)) {
+      // All-clear path stays quiet on misconfig — the failure path already
+      // emitted the loud ::error banner; no point repeating it on every
+      // recovery cycle.
+      return { kind: 'misconfig' };
+    }
     console.warn(
       `Linear wellness close lookup failed (${err instanceof Error ? err.message : String(err)})`,
     );

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -271,7 +271,7 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
     const search = vi.fn().mockRejectedValue(apiKeyError);
     mockCreateIssue.mockResolvedValue({ number: 4577 });
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     vi.useFakeTimers();
     try {
@@ -292,12 +292,12 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
         }),
       );
       // Misconfig must also fire the loud CI annotation, not just the body banner.
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('::error title=Wellness dedup misconfigured::'),
       );
     } finally {
       vi.useRealTimers();
-      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
     }
   });
 

--- a/crux/health/wellness-report.test.ts
+++ b/crux/health/wellness-report.test.ts
@@ -38,6 +38,8 @@ vi.mock('../lib/github.ts', () => ({
 import {
   buildWellnessReport,
   manageWellnessIssue,
+  prependMisconfigBanner,
+  MISCONFIG_BANNER_MARKER,
   WELLNESS_ISSUE_TITLE,
 } from './wellness-report.ts';
 
@@ -260,6 +262,45 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     expect(mockCreateIssue).not.toHaveBeenCalled();
   });
 
+  it('stamps the misconfig banner on the new GitHub issue when LINEAR_API_KEY is missing (QUA-676)', async () => {
+    // Reproduces the QUA-676 cascade: Linear-side dedup throws because the
+    // secret is missing → caller falls through to createIssue. The new issue
+    // body must carry the misconfig banner so whoever reads the ticket sees
+    // the cause + the fix path. Without the banner, the duplicate cascade
+    // recurs invisibly (which is what happened from QUA-577 → QUA-686).
+    const apiKeyError = new Error('LINEAR_API_KEY not set. Required for Linear API calls.');
+    const search = vi.fn().mockRejectedValue(apiKeyError);
+    mockCreateIssue.mockResolvedValue({ number: 4577 });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.useFakeTimers();
+    try {
+      const report = buildWellnessReport(failingChecks);
+      const promise = manageWellnessIssue(report, {
+        linearDedupDeps: { search, comment: vi.fn(), setState: vi.fn(), now: () => 0 },
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.action).toBe('created');
+      // The body argument to createIssue MUST start with the banner marker.
+      // Substring check (not equality) leaves the rest of the body unconstrained
+      // so the test isn't brittle to issue-body formatting tweaks.
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining(MISCONFIG_BANNER_MARKER),
+        }),
+      );
+      // Misconfig must also fire the loud CI annotation, not just the body banner.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('::error title=Wellness dedup misconfigured::'),
+      );
+    } finally {
+      vi.useRealTimers();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it('closes a lingering open Linear ticket when checks recover and no GitHub issue is open', async () => {
     const search = vi.fn().mockResolvedValue([
       {
@@ -284,5 +325,23 @@ describe('manageWellnessIssue — Linear dedup wiring (QUA-577)', () => {
     expect(result.action).toBe('closed');
     expect(result.linearIdentifier).toBe('QUA-570');
     expect(setState).toHaveBeenCalledWith('QUA-570', 'Done');
+  });
+});
+
+describe('prependMisconfigBanner', () => {
+  it('prepends the marker above the body content', () => {
+    const out = prependMisconfigBanner('## Original body\n\nDetails here.');
+    // Banner must appear FIRST so Linear's truncated GitHub-mirror preview
+    // shows the cause, not the wellness check details.
+    expect(out.indexOf(MISCONFIG_BANNER_MARKER)).toBe(0);
+    expect(out).toContain('## Original body');
+    expect(out).toContain('Details here.');
+  });
+
+  it('includes the secrets-page URL and the QUA-676 reference', () => {
+    const out = prependMisconfigBanner('');
+    expect(out).toContain('quantified-uncertainty/longterm-wiki/settings/secrets/actions');
+    expect(out).toContain('QUA-676');
+    expect(out).toContain('LINEAR_API_KEY');
   });
 });

--- a/crux/health/wellness-report.ts
+++ b/crux/health/wellness-report.ts
@@ -133,6 +133,38 @@ export function buildWellnessReport(checks: CheckResult[]): WellnessReport {
 export const WELLNESS_ISSUE_TITLE = 'System wellness check failing';
 
 /**
+ * Sentinel marker for the misconfig banner. Tests assert against this
+ * verbatim; production code uses it via {@link prependMisconfigBanner}.
+ */
+export const MISCONFIG_BANNER_MARKER = '⚠️ **Wellness Linear-side dedup is DORMANT**';
+
+/**
+ * Prepend a banner explaining that this ticket is one of the duplicates the
+ * Linear-side dedup was supposed to prevent (QUA-577 / QUA-667 / QUA-676), and
+ * that the cure is to add the LINEAR_API_KEY secret. Keeps the banner above
+ * the fold so the cause is visible in the Linear ticket preview too — Linear's
+ * GitHub-mirror integration truncates aggressively.
+ */
+export function prependMisconfigBanner(body: string): string {
+  const banner = [
+    MISCONFIG_BANNER_MARKER,
+    '',
+    'The wellness-check workflow tried to dedup against existing Linear tickets',
+    'but `LINEAR_API_KEY` is not set as a GitHub Actions secret in this repo.',
+    'Until that secret is added, every close-then-reopen cycle of the wellness',
+    'GitHub issue spawns a brand-new QUA ticket via Linear\'s GitHub integration.',
+    '',
+    '**Fix:** add the `LINEAR_API_KEY` secret at',
+    '<https://github.com/quantified-uncertainty/longterm-wiki/settings/secrets/actions>',
+    '(value lives in `lw/.env.base` at the workspace root). Reference: QUA-676.',
+    '',
+    '---',
+    '',
+  ].join('\n');
+  return banner + body;
+}
+
+/**
  * Find the existing open wellness issue (if any).
  * Returns the issue number, or null if none exists.
  *
@@ -292,12 +324,20 @@ export async function manageWellnessIssue(
     const handled = handleLinearDedupAction(linearAction);
     if (handled) return handled;
 
+    // Misconfig path (QUA-676): if Linear dedup is dormant because the
+    // LINEAR_API_KEY secret is missing, every close-then-reopen cycle of the
+    // GitHub issue mirrors into a fresh QUA ticket — that's the duplicate
+    // cascade. We can't fix the secret from code, but we can stamp a banner
+    // on the GitHub issue so whoever reads it sees the cause + the action.
+    const misconfig = linearAction.kind === 'skipped' && linearAction.reason === 'misconfig';
+    const issueBody = misconfig ? prependMisconfigBanner(report.issueBody) : report.issueBody;
+
     // Create new GitHub issue with a stable title (no timestamp) so concurrent
     // workflows can find it via findOpenWellnessIssue(). The timestamp is
     // already in the issue body.
     const created = await createIssue({
       title: WELLNESS_ISSUE_TITLE,
-      body: report.issueBody,
+      body: issueBody,
       labels: ['wellness', 'bug'],
     });
 


### PR DESCRIPTION
## Summary

Closes QUA-676. Root-causes the wellness duplicate-cascade that QUA-577 + QUA-667 didn't fully fix.

The wellness bot has continued filing brand-new "System wellness check failing" QUA tickets after PR #4559 merged (QUA-667): QUA-676 was filed at 09:53 UTC on 2026-04-24, then QUA-686 was filed at 21:02 UTC — five hours **after** the QUA-667 fix shipped.

## Root cause

PR #4559 (QUA-667) plumbed `LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}` into the env of all `--auto-issue` steps in three workflows. **But the GitHub repo secret named `LINEAR_API_KEY` did not exist.**

Result on every run:

```
LINEAR_API_KEY:                                        # ← empty, secrets.LINEAR_API_KEY → ''
Linear wellness dedup lookup failed (LINEAR_API_KEY not set...)
Created new wellness issue #4577                       # ← falls through to GitHub create
```

Linear's GitHub integration then mirrored each new GitHub issue into a fresh QUA ticket. Same exact cascade as QUA-577.

QUA-577's dedup *code* worked correctly (31 passing tests). It was just dormant for 4 days because the secret was never added — and there was no signal anywhere to surface that.

## Fix

**Operational** (out of band, already done): set the `LINEAR_API_KEY` secret in the repo via `gh secret set LINEAR_API_KEY -R quantified-uncertainty/longterm-wiki` reading from `lw/.env.base`. Verified with `gh secret list`.

**Code** (this PR — defense-in-depth): distinguish permanent misconfig from transient outage so the next time someone removes/rotates/forgets the secret, the failure is loud:

- `isMissingLinearApiKeyError()` — substring-detects the specific error from `getLinearApiKey()` in a way that survives error wrapping
- `dedupLinearWellnessIssue` returns `{ kind: 'skipped', reason: 'misconfig' }` and emits a `::error title=Wellness dedup misconfigured::` annotation that surfaces in the workflow run summary
- `closeLinearWellnessOnAllClear` returns `{ kind: 'misconfig' }` *silently* — the failure path already emitted the loud banner; no need to re-emit on every recovery cycle
- `prependMisconfigBanner` stamps a "DORMANT" banner above the GitHub issue body when filing during a misconfig, so whoever reads the wellness ticket sees the cause + the fix path with a direct link to the secrets settings page

## Why not throw on missing key

Throwing would crash the wellness pipeline and break the GitHub-side issue management too. Fail-open is still the right default for `wellness-linear-dedup.ts`. What was missing was a way to surface "fail-open hit AND it was permanent misconfig, not transient outage."

## Test plan

- [x] `pnpm exec vitest run crux/health/` — 101/101 pass (40 wellness, 24 health-check, 37 others)
- [x] 5 new tests for the misconfig path: 1 dedup `skipped/misconfig` with `::error` assertion, 1 close `misconfig` with quiet assertion, 1 wellness-report `createIssue` body banner assertion, 2 `prependMisconfigBanner` shape tests
- [x] 4 new tests for `isMissingLinearApiKeyError`: exact match, wrapped/substring, non-matching, non-Error values
- [x] Adversarial inputs: wrapped errors (`new Error("upstream call failed: " + e.message)`), non-Error throws (`throw "string"`, `throw { toString }`), `undefined`, `null`
- [x] `pnpm crux w validate gate --fix` — 54/54 blocking pass

## Post-merge verification

Next wellness failure (within 12h cycle) should:

- Either comment on QUA-686 (if the recovery hasn't fired yet) or reopen the most recent QUA-686-line within the 48h window
- **NOT** create a brand-new QUA-NNN

If a brand-new QUA-NNN is filed despite the secret being set, check the run log for `LINEAR_API_KEY:` and the `::error` annotation — that means the secret got unset/rotated and the code-side guard is doing its job by being loud about it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects missing external integration credentials and surfaces a clear CI error banner when misconfigured.
  * Prevents repeated loud error output during recovery so notifications aren’t duplicated.
  * Ensures fallback workflows behave correctly when credentials are absent.

* **New Features**
  * New misconfiguration banner is prepended to newly created wellness reports with guidance to add the missing credential.

* **Tests**
  * Added coverage for misconfiguration detection, banner content, logging, and recovery silence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->