### PR TITLE
Extend sourcing-suggest-urls to partial verdicts (QUA-587)

### DIFF
--- a/crux/commands/sourcing-suggest-urls.test.ts
+++ b/crux/commands/sourcing-suggest-urls.test.ts
@@ -29,8 +29,15 @@ vi.mock('../lib/sourcing/suggest-urls.ts', () => ({
 }));
 
 import { commands } from './sourcing-suggest-urls.ts';
+import { suggestUrls } from '../lib/sourcing/suggest-urls.ts';
 
 const suggest = commands.default;
+const mockSuggestUrls = vi.mocked(suggestUrls);
+
+// Typed helper so tests don't pass options through an `as never` escape hatch.
+// Accepts any subset of the command's option flags.
+type TestOpts = Record<string, string | boolean | undefined>;
+const run = (opts: TestOpts) => suggest([], opts as Parameters<typeof suggest>[1]);
 
 function makeVerdict(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
   return {
@@ -72,7 +79,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('rejects unknown verdict values before any API calls', async () => {
-    const result = await suggest([], { verdict: 'typo', 'dry-run': true } as never);
+    const result = await run({ verdict: 'typo', 'dry-run': true });
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain('Invalid --verdict');
     expect(mockListVerdicts).not.toHaveBeenCalled();
@@ -81,9 +88,12 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('rejects allowed-elsewhere verdicts that URL-replacement does not address', async () => {
-    for (const verdict of ['confirmed', 'contradicted', 'outdated']) {
+    // Includes `unchecked` — which is a legitimate verdict elsewhere but
+    // doesn't make sense here (no verdict yet to remediate). Listed
+    // explicitly so a future widening of the allowlist has to update the test.
+    for (const verdict of ['confirmed', 'contradicted', 'outdated', 'unchecked']) {
       mockListVerdicts.mockClear();
-      const result = await suggest([], { verdict, 'dry-run': true } as never);
+      const result = await run({ verdict, 'dry-run': true });
       expect(result.exitCode).toBe(1);
       expect(result.output).toMatch(/Invalid --verdict/);
       expect(result.output).toContain('unverifiable');
@@ -98,7 +108,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       ok: true,
       data: { verdicts: [makeVerdict({ verdict: 'unverifiable' })], total: 1 },
     });
-    const result = await suggest([], { 'dry-run': true } as never);
+    const result = await run({ 'dry-run': true });
     expect(result.exitCode).toBe(0);
     expect(mockListVerdicts).toHaveBeenCalledTimes(1);
     expect(mockListVerdicts).toHaveBeenCalledWith(
@@ -112,7 +122,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       ok: true,
       data: { verdicts: [makeVerdict()], total: 1 },
     });
-    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    const result = await run({ verdict: 'partial', 'dry-run': true });
     expect(result.exitCode).toBe(0);
     expect(mockListVerdicts).toHaveBeenCalledTimes(1);
     expect(mockListVerdicts).toHaveBeenCalledWith(
@@ -126,7 +136,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       ok: true,
       data: { verdicts: [], total: 0 },
     });
-    const result = await suggest([], { verdict: 'PARTIAL', 'dry-run': true } as never);
+    const result = await run({ verdict: 'PARTIAL', 'dry-run': true });
     expect(result.exitCode).toBe(0);
     expect(mockListVerdicts).toHaveBeenCalledWith(
       expect.objectContaining({ verdict: 'partial' }),
@@ -139,7 +149,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       ok: true,
       data: { verdicts: [], total: 0 },
     });
-    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    const result = await run({ verdict: 'partial', 'dry-run': true });
     expect(result.exitCode).toBe(0);
     expect(result.output).toMatch(/No partial verdicts matched/i);
   });
@@ -150,7 +160,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       message: 'boom',
       error: { code: 'HTTP_500' },
     });
-    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    const result = await run({ verdict: 'partial', 'dry-run': true });
     expect(result.exitCode).toBe(1);
     expect(result.output).toMatch(/Failed to list partial verdicts/i);
     expect(result.output).toContain('boom');
@@ -162,15 +172,55 @@ describe('sourcing-suggest-urls --verdict', () => {
       ok: true,
       data: { verdicts: [], total: 0 },
     });
-    const result = await suggest([], {
+    const result = await run({
       verdict: 'partial',
       'dry-run': true,
       json: true,
-    } as never);
+    });
     expect(result.exitCode).toBe(0);
     const parsed = JSON.parse(result.output);
     expect(parsed.summary).toBeDefined();
     expect(parsed.summary.dry_run).toBe(true);
     expect(parsed.summary.scanned).toBe(0);
+  });
+
+  it('upserts candidates for --verdict=partial in the non-dry-run path', async () => {
+    // Not dry-run: proves the full pipeline (list -> evidence -> suggest
+    // -> upsert) still runs correctly once the verdict flag is threaded
+    // through. Without this, a bug where `verdict=partial` silently
+    // bypassed upsert would not be caught by the dry-run tests above.
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ recordId: 'g_a', entityId: 'anthropic' })], total: 1 },
+    });
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [
+        { url: 'https://example.com/a', title: 'A', snippet: null, relevanceScore: null, sourceProvider: 'exa' },
+      ],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'test',
+      costUsd: 0,
+    });
+    mockUpsertUrlSuggestions.mockResolvedValueOnce({
+      ok: true,
+      data: { upserted: 1 },
+    });
+
+    const result = await run({ verdict: 'partial', limit: '10' });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockSuggestUrls).toHaveBeenCalledTimes(1);
+    expect(mockUpsertUrlSuggestions).toHaveBeenCalledTimes(1);
+    const upsertArg = mockUpsertUrlSuggestions.mock.calls[0][0];
+    expect(upsertArg).toHaveLength(1);
+    expect(upsertArg[0]).toMatchObject({
+      recordType: 'grant',
+      recordId: 'g_a',
+      entityId: 'anthropic',
+      suggestedUrl: 'https://example.com/a',
+      status: 'pending',
+    });
   });
 });

--- a/crux/commands/sourcing-suggest-urls.test.ts
+++ b/crux/commands/sourcing-suggest-urls.test.ts
@@ -60,7 +60,7 @@ function makeVerdict(overrides: Partial<Record<string, unknown>> = {}): Record<s
   };
 }
 
-function stubDryRunPrereqs() {
+function stubEmptyPrereqs() {
   // Pre-fetch of pending suggestions returns empty (no dedup skips).
   mockListUrlSuggestions.mockResolvedValue({
     ok: true,
@@ -103,7 +103,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('defaults to verdict=unverifiable when --verdict is omitted (back-compat)', async () => {
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [makeVerdict({ verdict: 'unverifiable' })], total: 1 },
@@ -117,7 +117,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('passes --verdict=partial through to listVerdicts (QUA-587)', async () => {
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [makeVerdict()], total: 1 },
@@ -131,7 +131,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('normalizes case in --verdict (PARTIAL -> partial)', async () => {
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [], total: 0 },
@@ -144,7 +144,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('empty-result message names the active verdict', async () => {
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [], total: 0 },
@@ -167,7 +167,7 @@ describe('sourcing-suggest-urls --verdict', () => {
   });
 
   it('emits JSON when --json is set (no human log lines in output)', async () => {
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [], total: 0 },
@@ -189,7 +189,7 @@ describe('sourcing-suggest-urls --verdict', () => {
     // -> upsert) still runs correctly once the verdict flag is threaded
     // through. Without this, a bug where `verdict=partial` silently
     // bypassed upsert would not be caught by the dry-run tests above.
-    stubDryRunPrereqs();
+    stubEmptyPrereqs();
     mockListVerdicts.mockResolvedValueOnce({
       ok: true,
       data: { verdicts: [makeVerdict({ recordId: 'g_a', entityId: 'anthropic' })], total: 1 },

--- a/crux/commands/sourcing-suggest-urls.test.ts
+++ b/crux/commands/sourcing-suggest-urls.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the --verdict flag added in QUA-587 — extends URL suggestion
+ * sweeps from unverifiable-only to also cover partial verdicts. Focused on
+ * the code paths that differ by flag: allowlist validation, default
+ * behaviour, and wiring through to listVerdicts + log/empty-result messages.
+ *
+ * Uses --dry-run so the search-provider layer doesn't need stubbing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockListVerdicts = vi.fn();
+const mockListUrlSuggestions = vi.fn();
+const mockGetEvidenceByRecords = vi.fn();
+const mockUpsertUrlSuggestions = vi.fn();
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
+  listVerdicts: (...args: unknown[]) => mockListVerdicts(...args),
+  listUrlSuggestions: (...args: unknown[]) => mockListUrlSuggestions(...args),
+  getEvidenceByRecords: (...args: unknown[]) => mockGetEvidenceByRecords(...args),
+  upsertUrlSuggestions: (...args: unknown[]) => mockUpsertUrlSuggestions(...args),
+  evidenceRecordKey: (rt: string, rid: string) => `${rt}|${rid}`,
+  MAX_EVIDENCE_BY_RECORDS: 1000,
+}));
+
+vi.mock('../lib/sourcing/suggest-urls.ts', () => ({
+  suggestUrls: vi.fn(),
+  GENERATOR_MODEL: 'test-generator',
+}));
+
+import { commands } from './sourcing-suggest-urls.ts';
+
+const suggest = commands.default;
+
+function makeVerdict(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    recordType: 'grant',
+    recordId: 'g_test_1',
+    fieldName: null,
+    entityId: 'anthropic',
+    displayName: 'Test grant',
+    entityDisplayName: 'Anthropic',
+    verdict: 'partial',
+    confidence: 0.6,
+    reasoning: 'Source partially confirms amount',
+    sourcesChecked: 1,
+    needsRecheck: false,
+    nextCheckDue: '2026-05-17',
+    lastComputedAt: '2026-04-16',
+    createdAt: '2026-04-01',
+    updatedAt: '2026-04-16',
+    ...overrides,
+  };
+}
+
+function stubDryRunPrereqs() {
+  // Pre-fetch of pending suggestions returns empty (no dedup skips).
+  mockListUrlSuggestions.mockResolvedValue({
+    ok: true,
+    data: { suggestions: [] },
+  });
+  // Batch evidence fetch returns no existing URLs.
+  mockGetEvidenceByRecords.mockResolvedValue({
+    ok: true,
+    data: { evidenceByKey: {} },
+  });
+}
+
+describe('sourcing-suggest-urls --verdict', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unknown verdict values before any API calls', async () => {
+    const result = await suggest([], { verdict: 'typo', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Invalid --verdict');
+    expect(mockListVerdicts).not.toHaveBeenCalled();
+    expect(mockListUrlSuggestions).not.toHaveBeenCalled();
+    expect(mockGetEvidenceByRecords).not.toHaveBeenCalled();
+  });
+
+  it('rejects allowed-elsewhere verdicts that URL-replacement does not address', async () => {
+    for (const verdict of ['confirmed', 'contradicted', 'outdated']) {
+      mockListVerdicts.mockClear();
+      const result = await suggest([], { verdict, 'dry-run': true } as never);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toMatch(/Invalid --verdict/);
+      expect(result.output).toContain('unverifiable');
+      expect(result.output).toContain('partial');
+      expect(mockListVerdicts).not.toHaveBeenCalled();
+    }
+  });
+
+  it('defaults to verdict=unverifiable when --verdict is omitted (back-compat)', async () => {
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ verdict: 'unverifiable' })], total: 1 },
+    });
+    const result = await suggest([], { 'dry-run': true } as never);
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(1);
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'unverifiable' }),
+    );
+  });
+
+  it('passes --verdict=partial through to listVerdicts (QUA-587)', async () => {
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict()], total: 1 },
+    });
+    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(1);
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'partial' }),
+    );
+  });
+
+  it('normalizes case in --verdict (PARTIAL -> partial)', async () => {
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+    const result = await suggest([], { verdict: 'PARTIAL', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ verdict: 'partial' }),
+    );
+  });
+
+  it('empty-result message names the active verdict', async () => {
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/No partial verdicts matched/i);
+  });
+
+  it('surfaces listVerdicts failures with the active verdict in the error', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: false,
+      message: 'boom',
+      error: { code: 'HTTP_500' },
+    });
+    const result = await suggest([], { verdict: 'partial', 'dry-run': true } as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/Failed to list partial verdicts/i);
+    expect(result.output).toContain('boom');
+  });
+
+  it('emits JSON when --json is set (no human log lines in output)', async () => {
+    stubDryRunPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+    const result = await suggest([], {
+      verdict: 'partial',
+      'dry-run': true,
+      json: true,
+    } as never);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary).toBeDefined();
+    expect(parsed.summary.dry_run).toBe(true);
+    expect(parsed.summary.scanned).toBe(0);
+  });
+});

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -46,8 +46,21 @@ const DEFAULT_VERDICT = 'unverifiable';
 // Only verdicts where weak source URLs are the suspected root cause.
 // `partial` added per QUA-587 — QUA-546 found re-verification was
 // ineffective for partials because the source URLs themselves are weak.
-// `contradicted` / `outdated` / `confirmed` are excluded: their URLs are
-// relevant, just disagreeing or aging, so URL replacement isn't the fix.
+// Deliberately excluded:
+//   - `confirmed`: the source works; no reason to replace it.
+//   - `contradicted`: the source disagrees substantively; replacing the
+//     URL would mask the disagreement. Route through crux sourcing-recheck
+//     instead.
+//   - `outdated`: handled via the recheck path (crux sourcing-recheck
+//     --verdict=outdated re-fetches the same URL looking for updates),
+//     not URL replacement. Staleness is a value-refresh problem, not a
+//     URL-quality problem. If this turns out to be wrong in practice we
+//     can widen the allowlist — the ticket (QUA-587) explicitly scopes
+//     this change to unverifiable + partial.
+//   - `unchecked`: no verdict yet to remediate.
+// NOTE: sourcing-recheck.ts uses a broader allowlist (all 5 real verdicts)
+// because its semantics differ — it reruns the LLM against current
+// evidence, which is valid for any verdict type.
 const ALLOWED_SUGGEST_VERDICTS = new Set(['unverifiable', 'partial']);
 
 interface SuggestOptions extends BaseOptions {
@@ -235,7 +248,7 @@ async function suggestCommand(
   if (!ALLOWED_SUGGEST_VERDICTS.has(verdictFilter)) {
     return {
       exitCode: 1,
-      output: `Invalid --verdict "${options.verdict}". Must be one of: ${[...ALLOWED_SUGGEST_VERDICTS].join(', ')}`,
+      output: `Invalid --verdict "${verdictFilter}". Must be one of: ${[...ALLOWED_SUGGEST_VERDICTS].sort().join(', ')}`,
     };
   }
   const dryRun = Boolean(options['dry-run'] ?? options.dryRun);
@@ -435,7 +448,7 @@ Usage:
 
 Options:
   --verdict=X            Verdict type to sweep (default: ${DEFAULT_VERDICT}).
-                         Allowed: ${[...ALLOWED_SUGGEST_VERDICTS].join(', ')}.
+                         Allowed: ${[...ALLOWED_SUGGEST_VERDICTS].sort().join(', ')}.
   --limit=N              Max verdicts to scan (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
   --budget=N             Soft cap in USD on search-provider spend (default: $${DEFAULT_BUDGET_USD.toFixed(2)}).
                          Checked before each record — a single in-flight call can overshoot.

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -31,6 +31,7 @@ import {
   upsertUrlSuggestions,
 } from '../lib/wiki-server/sourcing-client.ts';
 import { suggestUrls, GENERATOR_MODEL } from '../lib/sourcing/suggest-urls.ts';
+import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 1000;
@@ -42,7 +43,7 @@ const PREFETCH_MAX = 2000;
 const UPSERT_CHUNK = 100;
 const DEFAULT_CONCURRENCY = 5;
 
-const DEFAULT_VERDICT = 'unverifiable';
+const DEFAULT_VERDICT: SourcingVerdict = 'unverifiable';
 // Only verdicts where weak source URLs are the suspected root cause.
 // `partial` added per QUA-587 — QUA-546 found re-verification was
 // ineffective for partials because the source URLs themselves are weak.
@@ -61,7 +62,16 @@ const DEFAULT_VERDICT = 'unverifiable';
 // NOTE: sourcing-recheck.ts uses a broader allowlist (all 5 real verdicts)
 // because its semantics differ — it reruns the LLM against current
 // evidence, which is valid for any verdict type.
-const ALLOWED_SUGGEST_VERDICTS = new Set(['unverifiable', 'partial']);
+// Outer type is Set<string> so .has() accepts raw user input; members are
+// typed SourcingVerdict so TS catches a typo or invalid verdict here.
+const ALLOWED_SUGGEST_VERDICTS: ReadonlySet<string> = new Set<SourcingVerdict>([
+  'unverifiable',
+  'partial',
+]);
+// Guard drift between DEFAULT_VERDICT and the allowlist.
+if (!ALLOWED_SUGGEST_VERDICTS.has(DEFAULT_VERDICT)) {
+  throw new Error(`DEFAULT_VERDICT "${DEFAULT_VERDICT}" is not in ALLOWED_SUGGEST_VERDICTS`);
+}
 
 interface SuggestOptions extends BaseOptions {
   limit?: string;

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -1,12 +1,12 @@
 /**
- * Sourcing Suggest URLs — QUA-64
+ * Sourcing Suggest URLs — QUA-64 (QUA-587: extended to partial verdicts)
  *
- * For records whose sourcing verdict is `unverifiable`, run web search for
- * the claim + entity name and store 1-3 candidate URLs for human review or
- * auto-recheck.
+ * For records whose sourcing verdict is `unverifiable` (default) or `partial`,
+ * run web search for the claim + entity name and store 1-3 candidate URLs for
+ * human review or auto-recheck.
  *
  * Workflow:
- *   1. List verdicts with verdict='unverifiable' (optional --type/--entity filter).
+ *   1. List verdicts with verdict=<flag> (optional --type/--entity filter).
  *   2. For each, pull one evidence row to learn the existing URL (so we skip it).
  *   3. Generate candidates via crux/lib/sourcing/suggest-urls.ts
  *   4. Batch-upsert to /api/sourcing/url-suggestions.
@@ -42,11 +42,20 @@ const PREFETCH_MAX = 2000;
 const UPSERT_CHUNK = 100;
 const DEFAULT_CONCURRENCY = 5;
 
+const DEFAULT_VERDICT = 'unverifiable';
+// Only verdicts where weak source URLs are the suspected root cause.
+// `partial` added per QUA-587 — QUA-546 found re-verification was
+// ineffective for partials because the source URLs themselves are weak.
+// `contradicted` / `outdated` / `confirmed` are excluded: their URLs are
+// relevant, just disagreeing or aging, so URL replacement isn't the fix.
+const ALLOWED_SUGGEST_VERDICTS = new Set(['unverifiable', 'partial']);
+
 interface SuggestOptions extends BaseOptions {
   limit?: string;
   budget?: string;
   type?: string;
   entity?: string;
+  verdict?: string;
   'max-candidates'?: string;
   maxCandidates?: string;
   'dry-run'?: boolean;
@@ -222,6 +231,13 @@ async function suggestCommand(
   );
   const recordTypeFilter = options.type?.trim() || undefined;
   const entityFilter = options.entity?.trim() || undefined;
+  const verdictFilter = (options.verdict?.trim() || DEFAULT_VERDICT).toLowerCase();
+  if (!ALLOWED_SUGGEST_VERDICTS.has(verdictFilter)) {
+    return {
+      exitCode: 1,
+      output: `Invalid --verdict "${options.verdict}". Must be one of: ${[...ALLOWED_SUGGEST_VERDICTS].join(', ')}`,
+    };
+  }
   const dryRun = Boolean(options['dry-run'] ?? options.dryRun);
   const skipExisting = options['skip-existing'] ?? options.skipExisting ?? true;
   const isJson = Boolean(options.json || options.ci);
@@ -229,6 +245,7 @@ async function suggestCommand(
   const log = (msg: string) => { if (!isJson) console.log(msg); };
 
   log(`Sourcing Suggest URLs (QUA-64)`);
+  log(`  verdict:        ${verdictFilter}`);
   log(`  limit:          ${limit}`);
   log(`  budget:         $${budgetCap.toFixed(2)}`);
   log(`  max-candidates: ${maxCandidates}`);
@@ -240,14 +257,14 @@ async function suggestCommand(
   const summary = makeSummary();
 
   const verdictsResult = await listVerdicts({
-    verdict: 'unverifiable',
+    verdict: verdictFilter,
     recordType: recordTypeFilter,
     limit,
   });
   if (!verdictsResult.ok) {
     return {
       exitCode: 1,
-      output: `Failed to list unverifiable verdicts: ${verdictsResult.message ?? 'unknown error'}`,
+      output: `Failed to list ${verdictFilter} verdicts: ${verdictsResult.message ?? 'unknown error'}`,
     };
   }
 
@@ -259,12 +276,12 @@ async function suggestCommand(
       )
     : verdictsResult.data.verdicts;
 
-  log(`Fetched ${verdictRows.length} unverifiable verdict(s).`);
+  log(`Fetched ${verdictRows.length} ${verdictFilter} verdict(s).`);
 
   if (verdictRows.length === 0) {
     const output = isJson
       ? JSON.stringify({ summary: summaryToJson(summary, dryRun) })
-      : 'No unverifiable verdicts matched.';
+      : `No ${verdictFilter} verdicts matched.`;
     return { exitCode: 0, output };
   }
 
@@ -411,13 +428,15 @@ export const commands = {
 
 export function getHelp(): string {
   return `
-Sourcing Suggest URLs — auto-suggest better source URLs for unverifiable verdicts
+Sourcing Suggest URLs — auto-suggest better source URLs for weak-URL verdicts
 
 Usage:
   crux sourcing-suggest-urls [options]
 
 Options:
-  --limit=N              Max unverifiable verdicts to scan (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
+  --verdict=X            Verdict type to sweep (default: ${DEFAULT_VERDICT}).
+                         Allowed: ${[...ALLOWED_SUGGEST_VERDICTS].join(', ')}.
+  --limit=N              Max verdicts to scan (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
   --budget=N             Soft cap in USD on search-provider spend (default: $${DEFAULT_BUDGET_USD.toFixed(2)}).
                          Checked before each record — a single in-flight call can overshoot.
   --type=X               Filter by record type (e.g., fact, grant, personnel)
@@ -428,7 +447,7 @@ Options:
   --json / --ci          Machine-readable JSON output
 
 Workflow:
-  1. Lists verdicts with verdict='unverifiable' from /api/sourcing/verdicts.
+  1. Lists verdicts with verdict=<--verdict> from /api/sourcing/verdicts.
   2. Runs web search (Exa + Perplexity) for the claim + entity name.
   3. Batch-upserts candidates to /api/sourcing/url-suggestions for human review
      or auto-recheck. Human decisions (approved/rejected) are preserved on re-runs.


### PR DESCRIPTION
## Summary
Follow-up to QUA-546. Bulk re-verification of `partial` sourcing verdicts was shown to be ineffective — the source URLs themselves are genuinely weak, not the LLM prompt. This extends `crux sourcing-suggest-urls` (previously `unverifiable`-only) to also sweep `partial` verdicts via `--verdict=partial`.

- Add `--verdict=X` flag with allowlist validation. Default `unverifiable`; `partial` is the only other accepted value — `contradicted` / `outdated` / `confirmed` / `unchecked` are deliberately excluded (URL replacement isn't the remedy; see the allowlist comment for per-verdict rationale).
- Allowlist members are typed `SourcingVerdict` so TS catches a typo; runtime guard asserts `DEFAULT_VERDICT` is a member.
- Log lines, error messages, and help text name the active verdict.
- New test file mirrors the `sourcing-recheck.test.ts` pattern: allowlist rejection (incl. `confirmed/contradicted/outdated/unchecked`), default back-compat, case normalization, empty-result message, error surfacing, JSON output, and one non-dry-run test proving the full `listVerdicts → suggestUrls → upsert` pipeline still runs for `--verdict=partial`.

Fixes QUA-587

## Test plan
- [x] `pnpm vitest run crux/commands/sourcing-suggest-urls.test.ts` — 9/9 pass
- [x] Adjacent suites unchanged: `crux/lib/sourcing/suggest-urls.test.ts` (12/12), `crux/commands/sourcing-recheck.test.ts` (9/9)
- [x] `pnpm crux w validate gate --fix` — 54/54 pass (3 pre-existing advisory warnings)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in changed files
- [x] `pnpm crux sourcing-suggest-urls --help` — renders, allowlist sorted
- [x] `/agent-review-pr` — 2 MEDIUM + 4 LOW fixed or documented
- [x] `/simplify` — typing + drift-guard + helper rename
- [ ] Sweep on prod (not in this PR): `WIKI_SERVER_ENV=prod pnpm crux sourcing-suggest-urls --verdict=partial --limit=50 --dry-run` then real run against the ~2,165 partial verdicts at an est. \~$11 budget, per QUA-587
