### PR TITLE
feat(linear): ticket-sizing red-flag detection on `crux linear create` (QUA-575)

### DIFF
--- a/.claude/rules/ticket-sizing.md
+++ b/.claude/rules/ticket-sizing.md
@@ -1,0 +1,61 @@
+# Ticket Sizing — Catch Oversized Tickets at Filing Time
+
+Every oversized ticket — the kind an agent has to split mid-session — has a detectable red flag at filing time. This rule lists them, and what to do when you see one.
+
+## Why this rule exists
+
+Between 2026-04-13 and 2026-04-17, at least 5 tickets had to be split after dispatch: QUA-24 (plumbing + execution mixed), QUA-549 (17 FK tables, one PR per table was wrong — ended up as 9 sub-tickets), QUA-22 (pilot + long tail), QUA-556 (audit + implement), and others. Every late discovery cost ~30-60min of coordination overhead and a context rebuild for the next agent.
+
+All 5 had at least one of the red flags below, visible at the moment the ticket was filed.
+
+## Red flags — split before dispatch if any are present
+
+| Red flag | Why it's a problem | Example |
+|---|---|---|
+| **≥3 tables or code surfaces affected** | PR spans multiple review areas; test + CI surface explodes | QUA-549 (17 FK tables), QUA-24 (divisions + personnel + funding + benchmarks) |
+| **Mixed shapes in one ticket** | Plumbing + execution, migration + backfill, audit + implement — each shape has a different completion semantic | QUA-24 (extend scanner AND run enrichment), QUA-556 (audit AND decide AND implement) |
+| **"Phase" / "Wave" language in title or body** | Implies multi-step; each step is usually its own PR | QUA-492 "Phase 1 closeout", QUA-549 "Phase B" |
+| **Row counts >1K requiring batching** | Batch execution is budget-gated, not PR-gated; should be a separate ticket from the plumbing that enables it | QUA-545 (610 facts), QUA-536 (17,750 rows) |
+| **"and" connecting two different deliverables** | Almost always splittable at the "and" | "Scanner and improve pipeline", "Audit and fix" |
+| **Umbrella-like title** | "Bring all X to Y state", "Complete all Z", "Finish all N" | QUA-544 umbrella — intentionally, with child tickets |
+
+## What to do when you see a red flag
+
+1. **Stop before creating the ticket.** Don't file a ticket you know will need splitting.
+2. **Decompose into session-sized children.** Each child should fit one PR OR one budget-gated batch, not both.
+3. **File a parent** if the decomposition is cleaner with a parent (e.g., epic + 4 children). File children first, then parent referencing them.
+4. **If the ticket is legitimately large and atomic** (no decomposition possible), file it with `--allow-big` on `crux linear create`. This bypasses the warning but flags it for review.
+
+## Session-sized = what?
+
+A well-sized ticket fits one of these shapes:
+
+- **PR-shaped**: 1-5 files touched, acceptance criteria verifiable in ~2 hours, stated diff shape fits in one sentence.
+- **Batch-shaped**: single budget line item, single data-run acceptance (row counts, coverage %), no code changes.
+- **Design-shaped**: produces a doc or decision, ≤2 days, acceptance is "doc merged" or "decision comment posted".
+
+Anything mixing two of those shapes needs to split.
+
+## Group by code footprint, not row count
+
+The QUA-549 lesson: a migration across 17 tables can't be split by table. Tables with 1 FK reference need ~1 file of changes; tables with 12 FK references need ~12 files and more review. Group tables that touch similar code footprints into one ticket; split when the footprint diverges.
+
+## Pre-dispatch sanity check
+
+Before writing a dispatch brief for any ticket, answer in one sentence each:
+
+- "What's the PR diff shape?" — If you can't describe it in 20 words, the ticket is too big.
+- "What's the acceptance check?" — If there are two unrelated checks, the ticket is two tickets.
+- "How long will this take?" — Over ~4 hours of wall time suggests decomposition.
+
+If any answer is vague, decompose before dispatching. This is 10 minutes of coordinator time that saves 30-60 minutes of agent churn.
+
+## Relation to planning docs
+
+Plan documents under `docs/plans/` already enumerate scope by shape. When a plan calls out "Plumbing P1" or "Execution E1", those are session-sized by construction. Tickets filed from plans inherit the sizing; tickets filed ad-hoc do not — which is where this rule matters most.
+
+## See also
+
+- `.claude/rules/dispatched-agent-review.md` § Dispatcher pre-flight
+- `.claude/rules/linear-project-ownership.md` — project assignment at filing time
+- `docs/plans/` — current planning docs apply this rule implicitly

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -366,6 +366,21 @@ describe('linear create', () => {
     expect(r.output).toContain('row-count-batching');
     expect(r.output).toContain('multi-table-enumeration');
   });
+
+  it('emits structured JSON on red-flag refusal when --json is set', async () => {
+    const r = await commands.create(['Phase 2: closeout'], {
+      ci: true,
+      json: true,
+    });
+    expect(r.exitCode).toBe(2);
+    // Output must be valid JSON — no ANSI color codes, no warning text.
+    const parsed = JSON.parse(r.output);
+    expect(parsed.error).toBe('ticket-sizing-red-flag');
+    expect(Array.isArray(parsed.flags)).toBe(true);
+    expect(parsed.flags[0].kind).toBe('phase-or-wave');
+    expect(parsed.hint).toContain('--allow-big');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -307,6 +307,65 @@ describe('linear create', () => {
       projectId: 'project-uuid',
     });
   });
+
+  // ── Ticket-sizing red flags (QUA-575) ────────────────────────────────────
+
+  it('refuses creation with exit=2 when title contains red-flag tokens', async () => {
+    const r = await commands.create(['Phase 2: closeout'], { ci: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('phase-or-wave');
+    expect(r.output).toContain('--allow-big');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses creation when description contains red-flag tokens', async () => {
+    const r = await commands.create(['Update tooling'], {
+      ci: true,
+      description: 'We need to migrate 5,000 facts into the new schema.',
+    });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('row-count-batching');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('does not warn on ordinary tickets', async () => {
+    const r = await commands.create(['Fix typo in README'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).not.toContain('red flag');
+    expect(createIssueMock).toHaveBeenCalled();
+  });
+
+  it('proceeds when --allow-big is set despite red flags', async () => {
+    // Capture stderr so the test environment doesn't print the warning.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const r = await commands.create(
+        ['Phase 2: migrate 5,000 rows across `foo`, `bar`, `baz`'],
+        { ci: true, allowBig: true },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(createIssueMock).toHaveBeenCalled();
+      // Warning was printed to stderr (not stdout) so --json consumers don't see it.
+      expect(stderrSpy).toHaveBeenCalled();
+      const stderrContent = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(stderrContent).toContain('phase-or-wave');
+      expect(stderrContent).toContain('row-count-batching');
+      expect(stderrContent).toContain('multi-table-enumeration');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('detects all three flags from the canonical example', async () => {
+    const r = await commands.create(
+      ['Phase 2: migrate 5,000 rows across `foo`, `bar`, `baz`'],
+      { ci: true },
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('phase-or-wave');
+    expect(r.output).toContain('row-count-batching');
+    expect(r.output).toContain('multi-table-enumeration');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -427,6 +427,43 @@ async function parse(args: string[], options: CommandOptions): Promise<CommandRe
   return { output: `${id}\n`, exitCode: 0 };
 }
 
+/**
+ * Run the ticket-sizing red-flag check used by `crux linear create`. Returns
+ * a refusal `CommandResult` (exit 2) when a flag fires without `--allow-big`,
+ * or `null` when the caller may proceed. With `--json`, the refusal is a
+ * structured payload so pipes into `jq` don't choke on the human warning.
+ *
+ * Side effect: when `--allow-big` is set and flags fired, prints the warning
+ * to stderr so the bypass stays visible in session logs.
+ */
+function checkRedFlagsOrRefuse(
+  title: string,
+  description: string,
+  options: CommandOptions,
+  c: ReturnType<typeof createLogger>['colors'],
+): CommandResult | null {
+  const flags = detectRedFlags(title, description);
+  if (flags.length === 0) return null;
+
+  const warning = formatRedFlagsWarning(flags);
+  if (options.allowBig) {
+    process.stderr.write(warning);
+    return null;
+  }
+  if (options.json) {
+    return {
+      output:
+        JSON.stringify(
+          { error: 'ticket-sizing-red-flag', flags, hint: 'Re-run with --allow-big to bypass.' },
+          null,
+          2,
+        ) + '\n',
+      exitCode: 2,
+    };
+  }
+  return { output: `${c.yellow}${warning}${c.reset}`, exitCode: 2 };
+}
+
 async function create(args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(options.ci);
   const c = log.colors;
@@ -443,38 +480,9 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   const descFromFile = readBodyFlag(options.descriptionFile);
   const description = descFromFile ?? options.description ?? '';
 
-  // Ticket-sizing red-flag detection (QUA-575). Refuses to create a ticket
-  // whose title/body contains patterns that empirically predict mid-session
-  // splits unless the caller passes --allow-big. See
-  // .claude/rules/ticket-sizing.md.
-  const flags = detectRedFlags(title, description);
-  if (flags.length > 0) {
-    const warning = formatRedFlagsWarning(flags);
-    if (!options.allowBig) {
-      // Refuse with exit 2 (distinct from 1 = other errors). Caller may
-      // re-run with --allow-big to bypass when the ticket is legitimately
-      // large and atomic. With --json, emit a structured error payload so
-      // pipes-into-jq don't choke on the human-readable warning.
-      if (options.json) {
-        return {
-          output:
-            JSON.stringify(
-              { error: 'ticket-sizing-red-flag', flags, hint: 'Re-run with --allow-big to bypass.' },
-              null,
-              2,
-            ) + '\n',
-          exitCode: 2,
-        };
-      }
-      return {
-        output: `${c.yellow}${warning}${c.reset}`,
-        exitCode: 2,
-      };
-    }
-    // --allow-big set: print the warning to stderr so it's visible in the
-    // session log without polluting --json stdout, and proceed to create.
-    process.stderr.write(warning);
-  }
+  // QUA-575: refuse on ticket-sizing red flags unless --allow-big is set.
+  const sizingRefusal = checkRedFlagsOrRefuse(title, description, options, c);
+  if (sizingRefusal) return sizingRefusal;
 
   // Parse priority (Linear: 1=urgent, 2=high, 3=medium, 4=low)
   let priority: number | undefined;

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -50,6 +50,7 @@ import {
   type OpenPrMatch,
   type RecentStartClaim,
 } from '../lib/linear/dedup.ts';
+import { detectRedFlags, formatRedFlagsWarning } from '../lib/linear/sizing-red-flags.ts';
 import { currentBranch } from '../lib/session/session-checklist.ts';
 import { buildStartCommentBody, getSessionContext } from '../lib/session/session-context.ts';
 import { execSync } from 'child_process';
@@ -78,6 +79,11 @@ interface CommandOptions extends BaseOptions {
   // already ran the pre-check and shouldn't pay for it again (and
   // shouldn't mark the comment as forced). Not exposed on the CLI.
   skipDedupCheck?: boolean;
+  // Bypass ticket-sizing red-flag check on `crux linear create`. Without
+  // this, oversized-ticket patterns (Phase/Wave language, row-count
+  // batching, mixed shapes, multi-table enumeration) refuse the create.
+  // See QUA-575 + .claude/rules/ticket-sizing.md.
+  allowBig?: boolean;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -436,6 +442,27 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   // Resolve description from flag or file
   const descFromFile = readBodyFlag(options.descriptionFile);
   const description = descFromFile ?? options.description ?? '';
+
+  // Ticket-sizing red-flag detection (QUA-575). Refuses to create a ticket
+  // whose title/body contains patterns that empirically predict mid-session
+  // splits unless the caller passes --allow-big. See
+  // .claude/rules/ticket-sizing.md.
+  const flags = detectRedFlags(title, description);
+  if (flags.length > 0) {
+    const warning = formatRedFlagsWarning(flags);
+    if (!options.allowBig) {
+      // Refuse with exit 2 (distinct from 1 = other errors). Caller may
+      // re-run with --allow-big to bypass when the ticket is legitimately
+      // large and atomic.
+      return {
+        output: `${c.yellow}${warning}${c.reset}`,
+        exitCode: 2,
+      };
+    }
+    // --allow-big set: print the warning to stderr so it's visible in the
+    // session log without polluting --json output, and proceed to create.
+    process.stderr.write(warning);
+  }
 
   // Parse priority (Linear: 1=urgent, 2=high, 3=medium, 4=low)
   let priority: number | undefined;
@@ -1022,6 +1049,7 @@ Options (create):
   --priority=N               Priority: 1=urgent, 2=high, 3=medium, 4=low (default: none)
   --parent=QUA-NNN           Parent issue (sets the child link to an epic)
   --project=<name|uuid>      Project (UUID or case-insensitive exact name)
+  --allow-big                Bypass the ticket-sizing red-flag check (see .claude/rules/ticket-sizing.md)
 
 Options (comment):
   --body-file=<path>  Comment body from file (safe for multiline / escaped content)

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -453,14 +453,26 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     if (!options.allowBig) {
       // Refuse with exit 2 (distinct from 1 = other errors). Caller may
       // re-run with --allow-big to bypass when the ticket is legitimately
-      // large and atomic.
+      // large and atomic. With --json, emit a structured error payload so
+      // pipes-into-jq don't choke on the human-readable warning.
+      if (options.json) {
+        return {
+          output:
+            JSON.stringify(
+              { error: 'ticket-sizing-red-flag', flags, hint: 'Re-run with --allow-big to bypass.' },
+              null,
+              2,
+            ) + '\n',
+          exitCode: 2,
+        };
+      }
       return {
         output: `${c.yellow}${warning}${c.reset}`,
         exitCode: 2,
       };
     }
     // --allow-big set: print the warning to stderr so it's visible in the
-    // session log without polluting --json output, and proceed to create.
+    // session log without polluting --json stdout, and proceed to create.
     process.stderr.write(warning);
   }
 

--- a/crux/lib/linear/__tests__/sizing-red-flags.test.ts
+++ b/crux/lib/linear/__tests__/sizing-red-flags.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { detectRedFlags, formatRedFlagsWarning } from '../sizing-red-flags.ts';
+
+describe('detectRedFlags', () => {
+  describe('zero flags', () => {
+    it('returns no flags for a small bug-fix title', () => {
+      expect(detectRedFlags('Fix typo in README', '')).toEqual([]);
+    });
+
+    it('returns no flags when neither title nor description match', () => {
+      expect(
+        detectRedFlags(
+          'Repair broken tooltip on entity page',
+          'The tooltip vanishes when the user hovers over the avatar.',
+        ),
+      ).toEqual([]);
+    });
+
+    it('does not fire on a single backticked identifier', () => {
+      expect(detectRedFlags('Refactor `foo`', '')).toEqual([]);
+    });
+
+    it('does not fire on two backticked identifiers (under threshold)', () => {
+      expect(detectRedFlags('Refactor `foo` and `bar`', '')).toEqual([]);
+    });
+  });
+
+  describe('phase-or-wave', () => {
+    it('fires on "Phase 2" in title', () => {
+      const flags = detectRedFlags('Phase 2: closeout', '');
+      expect(flags).toHaveLength(1);
+      expect(flags[0].kind).toBe('phase-or-wave');
+      expect(flags[0].match.toLowerCase()).toBe('phase 2');
+    });
+
+    it('fires on "Wave B" in body', () => {
+      const flags = detectRedFlags('Roll out integrations', 'Wave B: enable for tier-2 customers.');
+      expect(flags).toHaveLength(1);
+      expect(flags[0].kind).toBe('phase-or-wave');
+    });
+
+    it('fires on "Phase 1A" (mixed digits + letters)', () => {
+      const flags = detectRedFlags('Phase 1A migration', '');
+      expect(flags[0].kind).toBe('phase-or-wave');
+    });
+
+    it('is case-insensitive', () => {
+      expect(detectRedFlags('PHASE 3 rollout', '')[0]?.kind).toBe('phase-or-wave');
+      expect(detectRedFlags('phase 3 rollout', '')[0]?.kind).toBe('phase-or-wave');
+    });
+
+    it('does not fire on the bare word "phase" without a number', () => {
+      expect(detectRedFlags('Phase out the old endpoint', '')).toEqual([]);
+    });
+
+    it('only emits one entry per kind even on repeated matches', () => {
+      const flags = detectRedFlags('Phase 1 and Phase 2', 'Wave A and Phase 3');
+      expect(flags.filter((f) => f.kind === 'phase-or-wave')).toHaveLength(1);
+    });
+  });
+
+  describe('row-count-batching', () => {
+    it('fires on "migrate 5,000"', () => {
+      const flags = detectRedFlags('Migrate 5,000 rows', '');
+      expect(flags[0].kind).toBe('row-count-batching');
+      expect(flags[0].match.toLowerCase()).toBe('migrate 5,000');
+    });
+
+    it('fires on "backfill 100"', () => {
+      expect(detectRedFlags('', 'We need to backfill 100 records')[0]?.kind).toBe('row-count-batching');
+    });
+
+    it('fires on "populate 10,000"', () => {
+      expect(detectRedFlags('Populate 10,000 facts', '')[0]?.kind).toBe('row-count-batching');
+    });
+
+    it('fires on "rewrite 250"', () => {
+      expect(detectRedFlags('Rewrite 250 prompts', '')[0]?.kind).toBe('row-count-batching');
+    });
+
+    it('does not fire on "migrate" without a number', () => {
+      expect(detectRedFlags('Migrate the auth middleware', '')).toEqual([]);
+    });
+
+    it('does not fire on "migration" (token boundary)', () => {
+      expect(detectRedFlags('Migration system overhaul 5000', '')).toEqual([]);
+    });
+  });
+
+  describe('mixed-shapes', () => {
+    it('fires on "audit and"', () => {
+      const flags = detectRedFlags('Audit and fix tier-1 entities', '');
+      expect(flags[0].kind).toBe('mixed-shapes');
+    });
+
+    it('fires on "design and"', () => {
+      const flags = detectRedFlags('Design and ship the new resolver', '')[0];
+      expect(flags?.kind).toBe('mixed-shapes');
+    });
+
+    it('does not fire on bare "audit" without "and"', () => {
+      expect(detectRedFlags('Audit the validation gate', '')).toEqual([]);
+    });
+  });
+
+  describe('multi-table-enumeration', () => {
+    it('fires on three backticked identifiers separated by commas', () => {
+      const flags = detectRedFlags('Update `foo`, `bar`, `baz`', '');
+      expect(flags[0].kind).toBe('multi-table-enumeration');
+    });
+
+    it('fires on five backticked identifiers', () => {
+      const flags = detectRedFlags('Touch `a`, `b`, `c`, `d`, `e`', '');
+      expect(flags[0].kind).toBe('multi-table-enumeration');
+    });
+
+    it('handles snake_case identifiers', () => {
+      const flags = detectRedFlags('', 'Migrate `entity_resources`, `resource_papers`, `entity_facts`');
+      expect(flags[0]?.kind).toBe('multi-table-enumeration');
+    });
+
+    it('does not fire on two backticked identifiers', () => {
+      expect(detectRedFlags('Update `foo`, `bar`', '')).toEqual([]);
+    });
+
+    it('handles whitespace variation around commas', () => {
+      expect(
+        detectRedFlags('`a` ,  `b`  ,`c`', '')[0]?.kind,
+      ).toBe('multi-table-enumeration');
+    });
+  });
+
+  describe('multi-flag scenarios', () => {
+    it('fires three flags on the canonical example from the ticket', () => {
+      // From QUA-575: "Phase 2: migrate 5,000 rows across `foo`, `bar`, `baz`"
+      // Expected: 3 red flags (phase-or-wave, row-count-batching, multi-table-enumeration).
+      const flags = detectRedFlags(
+        'Phase 2: migrate 5,000 rows across `foo`, `bar`, `baz`',
+        '',
+      );
+      const kinds = flags.map((f) => f.kind).sort();
+      expect(kinds).toEqual(
+        ['multi-table-enumeration', 'phase-or-wave', 'row-count-batching'].sort(),
+      );
+    });
+
+    it('combines flags from title and description', () => {
+      const flags = detectRedFlags(
+        'Phase 1 cleanup',
+        'Audit and fix the resolver across `a`, `b`, `c`',
+      );
+      const kinds = new Set(flags.map((f) => f.kind));
+      expect(kinds).toContain('phase-or-wave');
+      expect(kinds).toContain('mixed-shapes');
+      expect(kinds).toContain('multi-table-enumeration');
+    });
+
+    it('returns at most one flag per kind even when multiple match', () => {
+      const flags = detectRedFlags(
+        'Phase 1 and Phase 2 design and audit and review',
+        'migrate 100 then backfill 200',
+      );
+      const kindCounts = new Map<string, number>();
+      for (const f of flags) {
+        kindCounts.set(f.kind, (kindCounts.get(f.kind) ?? 0) + 1);
+      }
+      for (const count of kindCounts.values()) {
+        expect(count).toBe(1);
+      }
+    });
+  });
+});
+
+describe('formatRedFlagsWarning', () => {
+  it('returns empty string for no flags', () => {
+    expect(formatRedFlagsWarning([])).toBe('');
+  });
+
+  it('mentions the rule file path so the user can read more', () => {
+    const flags = detectRedFlags('Phase 2', '');
+    const out = formatRedFlagsWarning(flags);
+    expect(out).toContain('.claude/rules/ticket-sizing.md');
+  });
+
+  it('mentions the --allow-big escape hatch', () => {
+    const flags = detectRedFlags('Phase 2', '');
+    const out = formatRedFlagsWarning(flags);
+    expect(out).toContain('--allow-big');
+  });
+
+  it('lists each detected kind', () => {
+    const flags = detectRedFlags('Phase 2: migrate 5,000 rows', '');
+    const out = formatRedFlagsWarning(flags);
+    expect(out).toContain('phase-or-wave');
+    expect(out).toContain('row-count-batching');
+  });
+});

--- a/crux/lib/linear/sizing-red-flags.ts
+++ b/crux/lib/linear/sizing-red-flags.ts
@@ -12,6 +12,8 @@
  * it past filing.
  */
 
+import { formatCount } from '../output.ts';
+
 export type RedFlagKind =
   | 'phase-or-wave'
   | 'row-count-batching'
@@ -35,42 +37,30 @@ interface Detector {
 const DETECTORS: Detector[] = [
   {
     kind: 'phase-or-wave',
-    // \b(phase|wave) [0-9ABC]+\b — "Phase 2", "Phase 1A", "Wave B".
-    // Implies multi-step work; each step is usually its own PR.
-    pattern: /\b(phase|wave) [0-9ABC]+\b/gi,
+    pattern: /\b(phase|wave) [0-9ABC]+\b/i,
     reason:
       'Phase/Wave language implies multi-step work — each step is usually its own ticket.',
   },
   {
-    kind: 'row-count-batching',
-    // \b(migrate|backfill|populate|rewrite) [0-9,]+\b — "migrate 5,000".
-    // Batch execution is budget-gated, not PR-gated; should be a separate
-    // ticket from the plumbing that enables it.
     // Anchor on a leading digit so degenerate inputs like "migrate ,5" or
-    // "migrate ,," can't match. The trailing characters allow comma-grouping
-    // (e.g. "5,000").
-    pattern: /\b(migrate|backfill|populate|rewrite) [0-9][0-9,]*\b/gi,
+    // "migrate ,," can't match. Trailing chars allow comma-grouping ("5,000").
+    kind: 'row-count-batching',
+    pattern: /\b(migrate|backfill|populate|rewrite) [0-9][0-9,]*\b/i,
     reason:
       'Row-count batching mixes PR-shaped plumbing with budget-gated execution — file as separate tickets.',
   },
   {
     kind: 'mixed-shapes',
-    // \b(audit and|design and)\b — "Audit and fix", "Design and ship".
-    // Mixed shapes (audit+implement, design+execute) have different
-    // completion semantics and should split.
-    pattern: /\b(audit and|design and)\b/gi,
+    pattern: /\b(audit and|design and)\b/i,
     reason:
       'Mixed shapes (audit+implement, design+execute) have different completion semantics — split at the "and".',
   },
   {
+    // ≥3 backtick-delimited identifiers separated by commas. The trailing
+    // {2,} on the second-and-onward groups means we need at least three
+    // total identifiers to fire.
     kind: 'multi-table-enumeration',
-    // ≥3 backtick-delimited identifiers separated by commas:
-    //   `foo`, `bar`, `baz`           — fires
-    //   `foo`, `bar`                  — does not fire (only 2)
-    // Each backticked identifier is a typical surface for tables, modules,
-    // or files. Three+ enumerated surfaces means the PR will span multiple
-    // review areas.
-    pattern: /`[A-Za-z_][A-Za-z0-9_]*`(?:\s*,\s*`[A-Za-z_][A-Za-z0-9_]*`){2,}/g,
+    pattern: /`[A-Za-z_][A-Za-z0-9_]*`(?:\s*,\s*`[A-Za-z_][A-Za-z0-9_]*`){2,}/,
     reason:
       '≥3 enumerated code surfaces in one ticket — PR will span multiple review areas; group by code footprint and split.',
   },
@@ -87,12 +77,8 @@ export function detectRedFlags(title: string, description: string): RedFlag[] {
   const haystack = [title, description].filter(Boolean).join('\n');
   const out: RedFlag[] = [];
   for (const det of DETECTORS) {
-    // Reset state — `g` flag patterns are stateful per regex instance.
-    det.pattern.lastIndex = 0;
     const m = det.pattern.exec(haystack);
-    if (m) {
-      out.push({ kind: det.kind, match: m[0], reason: det.reason });
-    }
+    if (m) out.push({ kind: det.kind, match: m[0], reason: det.reason });
   }
   return out;
 }
@@ -104,7 +90,7 @@ export function detectRedFlags(title: string, description: string): RedFlag[] {
  */
 export function formatRedFlagsWarning(flags: RedFlag[]): string {
   if (flags.length === 0) return '';
-  let out = `⚠ Ticket-sizing red flag${flags.length === 1 ? '' : 's'} detected (${flags.length}):\n`;
+  let out = `⚠ Ticket-sizing ${formatCount(flags.length, 'red flag')} detected:\n`;
   for (const f of flags) {
     out += `  • [${f.kind}] matched "${f.match}"\n`;
     out += `    ${f.reason}\n`;

--- a/crux/lib/linear/sizing-red-flags.ts
+++ b/crux/lib/linear/sizing-red-flags.ts
@@ -1,0 +1,118 @@
+/**
+ * Ticket-sizing red-flag detector.
+ *
+ * Scans a candidate ticket title + description for patterns that empirically
+ * predict a ticket will need to be split mid-session. See
+ * `.claude/rules/ticket-sizing.md` for the rule that motivates each pattern
+ * and QUA-575 for the originating incidents.
+ *
+ * The detector is intentionally regex-based and conservative — false positives
+ * are escapable via `--allow-big` on `crux linear create`, and the cost of a
+ * spurious warning is much lower than the cost of an oversized ticket making
+ * it past filing.
+ */
+
+export type RedFlagKind =
+  | 'phase-or-wave'
+  | 'row-count-batching'
+  | 'mixed-shapes'
+  | 'multi-table-enumeration';
+
+export interface RedFlag {
+  kind: RedFlagKind;
+  /** The exact substring of the input that fired the rule. */
+  match: string;
+  /** Human-readable explanation, including a pointer to the rule file. */
+  reason: string;
+}
+
+interface Detector {
+  kind: RedFlagKind;
+  pattern: RegExp;
+  reason: string;
+}
+
+const DETECTORS: Detector[] = [
+  {
+    kind: 'phase-or-wave',
+    // \b(phase|wave) [0-9ABC]+\b — "Phase 2", "Phase 1A", "Wave B".
+    // Implies multi-step work; each step is usually its own PR.
+    pattern: /\b(phase|wave) [0-9ABC]+\b/gi,
+    reason:
+      'Phase/Wave language implies multi-step work — each step is usually its own ticket.',
+  },
+  {
+    kind: 'row-count-batching',
+    // \b(migrate|backfill|populate|rewrite) [0-9,]+\b — "migrate 5,000".
+    // Batch execution is budget-gated, not PR-gated; should be a separate
+    // ticket from the plumbing that enables it.
+    pattern: /\b(migrate|backfill|populate|rewrite) [0-9,]+\b/gi,
+    reason:
+      'Row-count batching mixes PR-shaped plumbing with budget-gated execution — file as separate tickets.',
+  },
+  {
+    kind: 'mixed-shapes',
+    // \b(audit and|design and)\b — "Audit and fix", "Design and ship".
+    // Mixed shapes (audit+implement, design+execute) have different
+    // completion semantics and should split.
+    pattern: /\b(audit and|design and)\b/gi,
+    reason:
+      'Mixed shapes (audit+implement, design+execute) have different completion semantics — split at the "and".',
+  },
+  {
+    kind: 'multi-table-enumeration',
+    // ≥3 backtick-delimited identifiers separated by commas:
+    //   `foo`, `bar`, `baz`           — fires
+    //   `foo`, `bar`                  — does not fire (only 2)
+    // Each backticked identifier is a typical surface for tables, modules,
+    // or files. Three+ enumerated surfaces means the PR will span multiple
+    // review areas.
+    pattern: /`[A-Za-z_][A-Za-z0-9_]*`(?:\s*,\s*`[A-Za-z_][A-Za-z0-9_]*`){2,}/g,
+    reason:
+      '≥3 enumerated code surfaces in one ticket — PR will span multiple review areas; group by code footprint and split.',
+  },
+];
+
+/**
+ * Detect ticket-sizing red flags in a title + description.
+ *
+ * Returns one entry per kind of flag fired (deduplicated by `kind` so a
+ * description that says "Phase 1" and "Phase 2" doesn't generate two
+ * `phase-or-wave` warnings). Within a kind, `match` is the first occurrence.
+ */
+export function detectRedFlags(title: string, description: string): RedFlag[] {
+  const haystack = [title, description].filter(Boolean).join('\n');
+  const out: RedFlag[] = [];
+  for (const det of DETECTORS) {
+    // Reset state — `g` flag patterns are stateful per regex instance.
+    det.pattern.lastIndex = 0;
+    const m = det.pattern.exec(haystack);
+    if (m) {
+      out.push({ kind: det.kind, match: m[0], reason: det.reason });
+    }
+  }
+  return out;
+}
+
+/**
+ * Format detected red flags as a human-readable warning block. Caller chooses
+ * stdout vs stderr; this function returns a plain string with no ANSI codes
+ * so it's safe for both.
+ */
+export function formatRedFlagsWarning(flags: RedFlag[]): string {
+  if (flags.length === 0) return '';
+  let out = `⚠ Ticket-sizing red flag${flags.length === 1 ? '' : 's'} detected (${flags.length}):\n`;
+  for (const f of flags) {
+    out += `  • [${f.kind}] matched "${f.match}"\n`;
+    out += `    ${f.reason}\n`;
+  }
+  out += '\n';
+  out += 'Why this matters: oversized tickets get split mid-session, costing\n';
+  out += '~30-60min of coordination overhead each time. See\n';
+  out += '.claude/rules/ticket-sizing.md for the full rule and decomposition\n';
+  out += 'guidance.\n';
+  out += '\n';
+  out += 'To proceed anyway (the ticket is legitimately large and atomic),\n';
+  out += 're-run with --allow-big.\n';
+  return out;
+}

--- a/crux/lib/linear/sizing-red-flags.ts
+++ b/crux/lib/linear/sizing-red-flags.ts
@@ -46,7 +46,10 @@ const DETECTORS: Detector[] = [
     // \b(migrate|backfill|populate|rewrite) [0-9,]+\b — "migrate 5,000".
     // Batch execution is budget-gated, not PR-gated; should be a separate
     // ticket from the plumbing that enables it.
-    pattern: /\b(migrate|backfill|populate|rewrite) [0-9,]+\b/gi,
+    // Anchor on a leading digit so degenerate inputs like "migrate ,5" or
+    // "migrate ,," can't match. The trailing characters allow comma-grouping
+    // (e.g. "5,000").
+    pattern: /\b(migrate|backfill|populate|rewrite) [0-9][0-9,]*\b/gi,
     reason:
       'Row-count batching mixes PR-shaped plumbing with budget-gated execution — file as separate tickets.',
   },


### PR DESCRIPTION
## Summary

Adds red-flag detection to `crux linear create` so oversized tickets get caught at filing time instead of mid-session. Companion rule file documents the patterns and decomposition workflow.

- **Detector** (`crux/lib/linear/sizing-red-flags.ts`): scans title + description for four patterns:
  - **phase-or-wave** — `\b(phase|wave) [0-9ABC]+\b` (multi-step language)
  - **row-count-batching** — `\b(migrate|backfill|populate|rewrite) [0-9][0-9,]*\b` (batch execution mixed with PR plumbing)
  - **mixed-shapes** — `\b(audit and|design and)\b` (different completion semantics)
  - **multi-table-enumeration** — ≥3 backticked identifiers separated by commas
- **`crux linear create`** refuses with exit=2 when any flag fires, unless `--allow-big` is set. With `--json`, the refusal is a structured `{error, flags, hint}` payload so jq consumers don't choke on the human warning. With `--allow-big`, the warning prints to stderr and creation proceeds.
- **`.claude/rules/ticket-sizing.md`** — decomposition guidance, session-shape definitions, pre-dispatch sanity checks. Auto-loaded into Claude Code sessions.

## Test plan

- [x] 31 detector unit tests (zero flags, each kind, multi-flag scenarios, token-boundary edges)
- [x] 6 `crux linear create` tests (refuse, --allow-big stderr, --json structured output, ordinary tickets unchanged)
- [x] Live CLI verified: refuse with exit 2, JSON refusal payload parses, `--allow-big` proceeds (test ticket QUA-695 created and closed during verification)
- [x] Gate: 52 checks passed
- [x] Build: passes
- [x] Reviewer flagged JSON-contract bug (warning text on stdout when --json); fixed in follow-up commit
- [x] /simplify pass: extracted `checkRedFlagsOrRefuse` helper, dropped redundant `g` regex flags, used `formatCount` for pluralization

Closes QUA-575
