### PR TITLE
resource-dedup: broaden FK discovery to stable_id (QUA-589)

### DIFF
--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -249,10 +249,9 @@ describeIntegration(
     });
 
     beforeEach(async () => {
-      // Reset isolated tables under the test schema. QUA-589: resources now
-      // has a UNIQUE stable_id column (Phase A QUA-536 made it NOT NULL +
-      // UNIQUE in prod) so FKs can target either id or stable_id. The
-      // mixed-target test case below exercises both forms in one cluster.
+      // Reset isolated tables under the test schema. resources.stable_id
+      // is NOT NULL UNIQUE in prod (Phase A); the mixed-target test below
+      // exercises FKs to both id and stable_id forms.
       await sqlConn.unsafe(`
         DROP TABLE IF EXISTS ${SCHEMA}.resource_papers CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.entity_resources CASCADE;

--- a/apps/wiki-server/src/__tests__/resource-dedup.test.ts
+++ b/apps/wiki-server/src/__tests__/resource-dedup.test.ts
@@ -103,11 +103,11 @@ describe("pickCanonical", () => {
 });
 
 describe("dedupeFkColumns", () => {
-  it("collapses multiple FK constraints on the same (table, column)", () => {
+  it("collapses multiple FK constraints on the same (table, column, target)", () => {
     const fks: FkColumnInfo[] = [
-      { tableName: "page_citations", columnName: "resource_id", uniqueGroups: [] },
-      { tableName: "page_citations", columnName: "resource_id", uniqueGroups: [] },
-      { tableName: "entity_resources", columnName: "resource_id", uniqueGroups: [] },
+      { tableName: "page_citations", columnName: "resource_id", targetColumn: "id", uniqueGroups: [] },
+      { tableName: "page_citations", columnName: "resource_id", targetColumn: "id", uniqueGroups: [] },
+      { tableName: "entity_resources", columnName: "resource_id", targetColumn: "stable_id", uniqueGroups: [] },
     ];
     const out = dedupeFkColumns(fks);
     expect(out).toHaveLength(2);
@@ -115,6 +115,19 @@ describe("dedupeFkColumns", () => {
       "entity_resources",
       "page_citations",
     ]);
+  });
+
+  it("keeps two FKs on the same (table, column) when they target different resources columns", () => {
+    // Defensive: the degenerate case where one column has FKs to BOTH
+    // resources.id and resources.stable_id. Both must survive so the merge
+    // rewrites the value under whichever interpretation holds.
+    const fks: FkColumnInfo[] = [
+      { tableName: "weird_table", columnName: "resource_id", targetColumn: "id", uniqueGroups: [] },
+      { tableName: "weird_table", columnName: "resource_id", targetColumn: "stable_id", uniqueGroups: [] },
+    ];
+    const out = dedupeFkColumns(fks);
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.targetColumn).sort()).toEqual(["id", "stable_id"]);
   });
 });
 
@@ -236,30 +249,44 @@ describeIntegration(
     });
 
     beforeEach(async () => {
-      // Reset isolated tables under the test schema.
+      // Reset isolated tables under the test schema. QUA-589: resources now
+      // has a UNIQUE stable_id column (Phase A QUA-536 made it NOT NULL +
+      // UNIQUE in prod) so FKs can target either id or stable_id. The
+      // mixed-target test case below exercises both forms in one cluster.
       await sqlConn.unsafe(`
         DROP TABLE IF EXISTS ${SCHEMA}.resource_papers CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.entity_resources CASCADE;
+        DROP TABLE IF EXISTS ${SCHEMA}.publications CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.resources CASCADE;
         DROP TABLE IF EXISTS ${SCHEMA}.things CASCADE;
 
         CREATE TABLE ${SCHEMA}.resources (
           id text PRIMARY KEY,
+          stable_id text NOT NULL UNIQUE,
           url text NOT NULL UNIQUE,
           created_at timestamptz NOT NULL DEFAULT now()
         );
 
-        -- entity_resources: regular FK, no uniqueness on resource_id.
+        -- entity_resources: regular FK on resources.id (legacy form).
         CREATE TABLE ${SCHEMA}.entity_resources (
           id serial PRIMARY KEY,
           entity_id text NOT NULL,
           resource_id text REFERENCES ${SCHEMA}.resources(id) ON DELETE CASCADE
         );
 
-        -- resource_papers: resource_id is the PK (at most one row per resource).
+        -- resource_papers: resource_id is the PK and references resources.id (legacy).
         CREATE TABLE ${SCHEMA}.resource_papers (
           resource_id text PRIMARY KEY REFERENCES ${SCHEMA}.resources(id) ON DELETE CASCADE,
           arxiv_id text
+        );
+
+        -- publications: QUA-549 Phase B.1 — FK targets resources.stable_id.
+        -- resource_id is unique (one publication per resource) so the merge
+        -- has to also handle the deduped-on-conflict path for stable_id FKs.
+        CREATE TABLE ${SCHEMA}.publications (
+          id serial PRIMARY KEY,
+          resource_id text UNIQUE REFERENCES ${SCHEMA}.resources(stable_id) ON DELETE SET NULL,
+          title text
         );
 
         -- things: cross-base index mirror — mergeCluster cleans up dup rows here
@@ -276,10 +303,10 @@ describeIntegration(
     it("merges a 3-row cluster with 5 FK refs split across 2 tables", async () => {
       // 3 resource rows with URL variants that collapse to the same key.
       await sqlConn.unsafe(`
-        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
-          ('r_canon', 'https://www.example.org/x',     '2024-01-01'),
-          ('r_dup1',  'http://example.org/x/',         '2024-02-01'),
-          ('r_dup2',  'https://example.org/x#frag',    '2024-03-01')
+        INSERT INTO ${SCHEMA}.resources (id, stable_id, url, created_at) VALUES
+          ('r_canon', 'sid_canon01', 'https://www.example.org/x',     '2024-01-01'),
+          ('r_dup1',  'sid_dup101',  'http://example.org/x/',         '2024-02-01'),
+          ('r_dup2',  'sid_dup201',  'https://example.org/x#frag',    '2024-03-01')
       `);
       // 5 FK refs split across 2 tables:
       //   entity_resources: 3 refs (2 on canonical, 1 on dup1)
@@ -321,17 +348,20 @@ describeIntegration(
           AND tc.table_schema = ${SCHEMA}
       `;
       // Map to FkColumnInfo. resource_papers.resource_id is a PK (single-column).
+      // Both FKs in this test target resources.id (legacy, pre-Phase B).
       const fkColumns: FkColumnInfo[] = fkRows.map((row) => {
         if (row.tablename === "resource_papers") {
           return {
             tableName: row.tablename,
             columnName: row.columnname,
+            targetColumn: "id",
             uniqueGroups: [{ otherCols: [] }],
           };
         }
         return {
           tableName: row.tablename,
           columnName: row.columnname,
+          targetColumn: "id",
           uniqueGroups: [],
         };
       });
@@ -400,9 +430,9 @@ describeIntegration(
     it("handles PK conflict: canonical already has a paper", async () => {
       // Canonical has a paper; dup also has one → dup's is deleted-on-conflict.
       await sqlConn.unsafe(`
-        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
-          ('r_canon', 'https://www.example.org/y', '2024-01-01'),
-          ('r_dup',   'http://example.org/y/',    '2024-02-01');
+        INSERT INTO ${SCHEMA}.resources (id, stable_id, url, created_at) VALUES
+          ('r_canon', 'sid_pk_canon', 'https://www.example.org/y', '2024-01-01'),
+          ('r_dup',   'sid_pk_dup',   'http://example.org/y/',    '2024-02-01');
         INSERT INTO ${SCHEMA}.resource_papers (resource_id, arxiv_id) VALUES
           ('r_canon', 'arxiv-canon'),
           ('r_dup',   'arxiv-dup');
@@ -412,11 +442,13 @@ describeIntegration(
         {
           tableName: "resource_papers",
           columnName: "resource_id",
+          targetColumn: "id",
           uniqueGroups: [{ otherCols: [] }],
         },
         {
           tableName: "entity_resources",
           columnName: "resource_id",
+          targetColumn: "id",
           uniqueGroups: [],
         },
       ];
@@ -450,27 +482,23 @@ describeIntegration(
       });
     });
 
-    it("buildReport + loadResourceFks discover live FK metadata", async () => {
+    it("buildReport + loadResourceFks discover live FK metadata across both id and stable_id targets", async () => {
       await sqlConn.unsafe(`
-        INSERT INTO ${SCHEMA}.resources (id, url, created_at) VALUES
-          ('r_canon', 'https://www.example.org/z', '2024-01-01'),
-          ('r_dup',   'http://example.org/z/',    '2024-02-01'),
-          ('r_solo',  'https://unique.example/w', '2024-03-01');
+        INSERT INTO ${SCHEMA}.resources (id, stable_id, url, created_at) VALUES
+          ('r_canon', 'sid_meta_canon', 'https://www.example.org/z', '2024-01-01'),
+          ('r_dup',   'sid_meta_dup',   'http://example.org/z/',    '2024-02-01'),
+          ('r_solo',  'sid_meta_solo',  'https://unique.example/w', '2024-03-01');
         INSERT INTO ${SCHEMA}.entity_resources (entity_id, resource_id) VALUES
           ('e1', 'r_canon');
       `);
 
-      // Run helpers under the test schema's search_path.
-      // postgres.js connections have connection-level search_path via SET.
-      await sqlConn.unsafe(`SET search_path TO ${SCHEMA}, public`);
-
-      // Override the loader's 'public' schema filter by fetching via a
-      // dedicated connection where search_path is our test schema. The
-      // helper hardcodes schema='public' so we fetch manually here instead.
+      // QUA-589: discovery must surface BOTH id-targeting and stable_id-
+      // targeting FKs. Query exactly the helper's logic but scoped to the
+      // test schema (loadResourceFks itself hardcodes schema='public').
       const fkRows = await sqlConn<
-        { table_name: string; column_name: string }[]
+        { table_name: string; column_name: string; target_column: string }[]
       >`
-        SELECT DISTINCT tc.table_name, kcu.column_name
+        SELECT DISTINCT tc.table_name, kcu.column_name, ccu.column_name AS target_column
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
           ON tc.constraint_name = kcu.constraint_name
@@ -480,12 +508,16 @@ describeIntegration(
           AND tc.table_schema = ccu.table_schema
         WHERE tc.constraint_type = 'FOREIGN KEY'
           AND ccu.table_name = 'resources'
-          AND ccu.column_name = 'id'
+          AND ccu.column_name IN ('id', 'stable_id')
           AND tc.table_schema = ${SCHEMA}
       `;
-      expect(fkRows.map((r) => r.table_name).sort()).toEqual([
-        "entity_resources",
-        "resource_papers",
+      const summary = fkRows
+        .map((r) => `${r.table_name}.${r.column_name}->${r.target_column}`)
+        .sort();
+      expect(summary).toEqual([
+        "entity_resources.resource_id->id",
+        "publications.resource_id->stable_id",
+        "resource_papers.resource_id->id",
       ]);
 
       // pickCanonical-style picking with refCount=1 for canonical, 0 for dup
@@ -495,6 +527,141 @@ describeIntegration(
         { id: "r_dup", refCount: 0, createdAt: "2024-02-01" },
       ];
       expect(pickCanonical(cluster).id).toBe("r_canon");
+    });
+
+    it("merges a cluster with FKs targeting both resources.id AND resources.stable_id (QUA-589)", async () => {
+      // QUA-589: post-Phase B, FKs target either resources.id (legacy) OR
+      // resources.stable_id (migrated). The merge must rewrite each FK using
+      // the right value type. This test asserts:
+      //   1. Legacy id-targeting FK (entity_resources) is rewritten id→id.
+      //   2. Phase B stable_id-targeting FK with a UNIQUE constraint
+      //      (publications) gets the deduped-on-conflict path AND the moved
+      //      row's value translated to canonical's stable_id.
+      await sqlConn.unsafe(`
+        INSERT INTO ${SCHEMA}.resources (id, stable_id, url, created_at) VALUES
+          ('r_canon', 'sid_mix_canon', 'https://www.example.org/m',  '2024-01-01'),
+          ('r_dup1',  'sid_mix_dup1',  'http://example.org/m/',      '2024-02-01'),
+          ('r_dup2',  'sid_mix_dup2',  'https://example.org/m#frag', '2024-03-01');
+
+        -- entity_resources (FK → resources.id, no uniqueness): 3 refs
+        --   1 on canonical, 1 on dup1, 1 on dup2 — all should land on canonical.
+        INSERT INTO ${SCHEMA}.entity_resources (entity_id, resource_id) VALUES
+          ('e1', 'r_canon'),
+          ('e2', 'r_dup1'),
+          ('e3', 'r_dup2');
+
+        -- publications (FK → resources.stable_id, UNIQUE on resource_id):
+        --   canonical has none; dup1 and dup2 each have one. The merge should
+        --   keep one (move it onto canonical's stable_id) and conflict-delete
+        --   the other.
+        INSERT INTO ${SCHEMA}.publications (resource_id, title) VALUES
+          ('sid_mix_dup1', 'paper-from-dup1'),
+          ('sid_mix_dup2', 'paper-from-dup2');
+
+        INSERT INTO ${SCHEMA}.things (id, source_table, source_id, title) VALUES
+          ('t_canon', 'resources', 'r_canon', 'canon'),
+          ('t_dup1',  'resources', 'r_dup1',  'dup1'),
+          ('t_dup2',  'resources', 'r_dup2',  'dup2');
+      `);
+
+      const fkColumns: FkColumnInfo[] = [
+        {
+          tableName: "entity_resources",
+          columnName: "resource_id",
+          targetColumn: "id",
+          uniqueGroups: [],
+        },
+        {
+          tableName: "publications",
+          columnName: "resource_id",
+          targetColumn: "stable_id",
+          // UNIQUE constraint on resource_id alone → otherCols is empty.
+          uniqueGroups: [{ otherCols: [] }],
+        },
+      ];
+
+      const merge = (await sqlConn.begin(async (tx) => {
+        return mergeCluster(
+          tx as unknown as CallableTransactionSql,
+          "r_canon",
+          ["r_dup1", "r_dup2"],
+          fkColumns,
+        );
+      })) as {
+        resourcesDeleted: number;
+        fkUpdates: Record<string, { moved: number; deletedOnConflict: number }>;
+      };
+
+      expect(merge.resourcesDeleted).toBe(2);
+
+      // entity_resources: 2 rows moved (e2, e3 onto r_canon), 0 conflicts.
+      expect(merge.fkUpdates["entity_resources.resource_id"]).toEqual({
+        moved: 2,
+        deletedOnConflict: 0,
+      });
+
+      // publications: dup1/dup2 each have a row (UNIQUE) → one survives + is
+      // rewritten to sid_mix_canon, the other is conflict-deleted.
+      expect(merge.fkUpdates["publications.resource_id"]).toEqual({
+        moved: 1,
+        deletedOnConflict: 1,
+      });
+
+      // Post-state: only canonical resource remains.
+      const remainingResources = await sqlConn<{ id: string }[]>`
+        SELECT id FROM ${sqlConn(SCHEMA)}.resources ORDER BY id
+      `;
+      expect(remainingResources.map((r) => r.id)).toEqual(["r_canon"]);
+
+      // entity_resources: all 3 rows now point at r_canon (id form).
+      const remainingEr = await sqlConn<{ entity_id: string; resource_id: string }[]>`
+        SELECT entity_id, resource_id FROM ${sqlConn(SCHEMA)}.entity_resources
+        ORDER BY entity_id
+      `;
+      expect(remainingEr).toHaveLength(3);
+      expect(remainingEr.every((r) => r.resource_id === "r_canon")).toBe(true);
+
+      // publications: 1 surviving row, rewritten to canonical's stable_id.
+      const remainingPubs = await sqlConn<{ resource_id: string; title: string }[]>`
+        SELECT resource_id, title FROM ${sqlConn(SCHEMA)}.publications
+      `;
+      expect(remainingPubs).toHaveLength(1);
+      expect(remainingPubs[0].resource_id).toBe("sid_mix_canon");
+      // The surviving title is whichever ctid won — both are valid.
+      expect(["paper-from-dup1", "paper-from-dup2"]).toContain(remainingPubs[0].title);
+    });
+
+    it("throws if a clustered resource has NULL stable_id and any FK targets stable_id (QUA-589)", async () => {
+      // Defensive: a duplicate with NULL stable_id can't be rewritten by the
+      // stable_id-targeting FK path. mergeCluster should refuse rather than
+      // silently leaving orphan child rows.
+      await sqlConn.unsafe(`
+        ALTER TABLE ${SCHEMA}.resources DROP CONSTRAINT resources_stable_id_key;
+        ALTER TABLE ${SCHEMA}.resources ALTER COLUMN stable_id DROP NOT NULL;
+        INSERT INTO ${SCHEMA}.resources (id, stable_id, url, created_at) VALUES
+          ('r_canon', 'sid_null_canon', 'https://www.example.org/n', '2024-01-01'),
+          ('r_dup',   NULL,             'http://example.org/n/',     '2024-02-01');
+      `);
+
+      const fkColumns: FkColumnInfo[] = [
+        {
+          tableName: "publications",
+          columnName: "resource_id",
+          targetColumn: "stable_id",
+          uniqueGroups: [{ otherCols: [] }],
+        },
+      ];
+
+      await expect(
+        sqlConn.begin(async (tx) => {
+          return mergeCluster(
+            tx as unknown as CallableTransactionSql,
+            "r_canon",
+            ["r_dup"],
+            fkColumns,
+          );
+        }),
+      ).rejects.toThrow(/NULL stable_id/);
     });
   }
 );

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -232,19 +232,33 @@ export async function buildReport(
   // QUA-623: cap with a +1 sentinel so the caller can tell the scan was
   // partial. Dedup apply=true should refuse to run on a truncated report —
   // clusters past the cutoff would silently survive.
-  const rows = await sql<{ id: string; url: string; created_at: string }[]>`
-    SELECT id, url, created_at::text AS created_at FROM resources
+  // QUA-589: pull `stable_id` in the same scan so the FK refCount loop
+  // below can translate id↔stable_id without a second round-trip.
+  const rows = await sql<
+    { id: string; stable_id: string | null; url: string; created_at: string }[]
+  >`
+    SELECT id, stable_id, url, created_at::text AS created_at FROM resources
     LIMIT ${scanCap + 1}
   `;
   const { items: scanned, truncated } = applyTruncation(rows, scanCap);
 
   type Row = { id: string; url: string; createdAt: string };
   const groups = new Map<string, Row[]>();
+  // QUA-589: id↔stable_id translation maps. NULL stable_id rows are
+  // silently absent — they can't be referenced by any stable_id-targeting
+  // FK (the FK requires a target value), so their refCount under those
+  // FKs is genuinely 0. Phase A (QUA-536) made stable_id NOT NULL in prod.
+  const idToStable = new Map<string, string>();
+  const stableToId = new Map<string, string>();
   for (const r of scanned) {
     const key = dedupKey(r.url);
     const list = groups.get(key);
     if (list) list.push({ id: r.id, url: r.url, createdAt: r.created_at });
     else groups.set(key, [{ id: r.id, url: r.url, createdAt: r.created_at }]);
+    if (r.stable_id) {
+      idToStable.set(r.id, r.stable_id);
+      stableToId.set(r.stable_id, r.id);
+    }
   }
 
   const candidateIds = new Set<string>();
@@ -255,33 +269,6 @@ export async function buildReport(
   const refCounts = new Map<string, number>();
   if (candidateIds.size > 0) {
     const idsArr = [...candidateIds];
-
-    // QUA-589: FKs may target either resources.id or resources.stable_id.
-    // For stable_id-targeting FKs we have to translate the id-keyed
-    // candidateIds into their stable_id values before querying, then
-    // translate the matched FK values back to id when accumulating refCount
-    // (the refCount map is keyed by resources.id throughout).
-    //
-    // NULL stable_id in the cluster: silently filtered out below. This is
-    // correct — a resource row with NULL stable_id cannot be referenced by
-    // any stable_id-targeting FK (the FK constraint requires a target
-    // value), so its refCount under those FKs is genuinely 0. Phase A
-    // (QUA-536) made resources.stable_id NOT NULL in prod, so this filter
-    // is dead in prod and only fires in dev/test.
-    const needsStable = uniqueCols.some((f) => f.targetColumn === "stable_id");
-    const idToStable = new Map<string, string>();
-    const stableToId = new Map<string, string>();
-    if (needsStable) {
-      const mapRows = await sql<{ id: string; stable_id: string | null }[]>`
-        SELECT id, stable_id FROM resources WHERE id = ANY(${idsArr})
-      `;
-      for (const r of mapRows) {
-        if (r.stable_id) {
-          idToStable.set(r.id, r.stable_id);
-          stableToId.set(r.stable_id, r.id);
-        }
-      }
-    }
 
     for (const fk of uniqueCols) {
       const isStable = fk.targetColumn === "stable_id";

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -261,6 +261,13 @@ export async function buildReport(
     // candidateIds into their stable_id values before querying, then
     // translate the matched FK values back to id when accumulating refCount
     // (the refCount map is keyed by resources.id throughout).
+    //
+    // NULL stable_id in the cluster: silently filtered out below. This is
+    // correct — a resource row with NULL stable_id cannot be referenced by
+    // any stable_id-targeting FK (the FK constraint requires a target
+    // value), so its refCount under those FKs is genuinely 0. Phase A
+    // (QUA-536) made resources.stable_id NOT NULL in prod, so this filter
+    // is dead in prod and only fires in dev/test.
     const needsStable = uniqueCols.some((f) => f.targetColumn === "stable_id");
     const idToStable = new Map<string, string>();
     const stableToId = new Map<string, string>();
@@ -379,6 +386,13 @@ export async function mergeCluster(
   }
 
   for (const fk of uniqueCols) {
+    // fkUpdates is keyed by (table, column), not by (table, column, target).
+    // In the rare degenerate case where a single column has FKs to BOTH
+    // resources.id AND resources.stable_id (dedupeFkColumns triple-key
+    // keeps both FK entries so each gets its own UPDATE/DELETE pass), the
+    // counters here aggregate across the two passes. Aggregation is the
+    // right report semantics — "we moved N rows on column X" is the user-
+    // facing question, regardless of which FK constraint enforced it.
     const key = `${fk.tableName}.${fk.columnName}`;
     fkUpdates[key] = fkUpdates[key] ?? { moved: 0, deletedOnConflict: 0 };
 

--- a/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
+++ b/apps/wiki-server/src/routes/wikibase/resource-dedup.ts
@@ -27,6 +27,10 @@ import { applyTruncation } from "../shared/utils.js";
 export interface FkColumnInfo {
   tableName: string;
   columnName: string;
+  /** Which column on `resources` this FK targets. QUA-549 Phase B has
+   *  swapped most FKs from `id` to `stable_id`; the dedup flow tracks both
+   *  forms (QUA-589) so per-FK rewrites use the right value type. */
+  targetColumn: "id" | "stable_id";
   /** PK/UNIQUE constraints on this table that include columnName. otherCols
    *  is the set of columns in the constraint besides columnName. Empty
    *  otherCols means this column alone must be unique. */
@@ -125,14 +129,18 @@ function q(name: string): string {
   return `"${name}"`;
 }
 
-/** Dedupe FK metadata by (table, column). A column CAN be referenced by more
- *  than one FK constraint in Postgres; we keep this helper defensively even
- *  after QUA-569 reconciled the last known duplicate (page_citations.resource_id
- *  was the historical case — migration 0193 dropped its duplicate pair). */
+/** Dedupe FK metadata by (table, column, targetColumn). A column CAN be
+ *  referenced by more than one FK constraint in Postgres; we keep this helper
+ *  defensively even after QUA-569 reconciled the last known duplicate
+ *  (page_citations.resource_id was the historical case — migration 0193
+ *  dropped its duplicate pair). The targetColumn part of the key is defensive
+ *  for the unusual case where a single (table, column) has FKs pointing at
+ *  both resources.id and resources.stable_id simultaneously — keep both so
+ *  the merge rewrites whichever values are actually stored. */
 export function dedupeFkColumns(fks: FkColumnInfo[]): FkColumnInfo[] {
   const seen = new Map<string, FkColumnInfo>();
   for (const f of fks) {
-    const key = `${f.tableName}.${f.columnName}`;
+    const key = `${f.tableName}.${f.columnName}:${f.targetColumn}`;
     if (!seen.has(key)) seen.set(key, f);
   }
   return [...seen.values()];
@@ -143,8 +151,17 @@ export function dedupeFkColumns(fks: FkColumnInfo[]): FkColumnInfo[] {
 // ---------------------------------------------------------------------------
 
 export async function loadResourceFks(sql: Sql): Promise<FkColumnInfo[]> {
-  const fkRows = await sql<{ table_name: string; column_name: string }[]>`
-    SELECT DISTINCT tc.table_name, kcu.column_name
+  // QUA-589: include both resources.id and resources.stable_id as valid FK
+  // targets. QUA-549 Phase B has swapped most FKs from id → stable_id;
+  // restricting discovery to id silently dropped migrated tables off the
+  // dedup sweep (CASCADE still cleaned them on resource delete, but the
+  // FK-rewrite-to-canonical path no longer fired).
+  const fkRows = await sql<{
+    table_name: string;
+    column_name: string;
+    target_column: string;
+  }[]>`
+    SELECT DISTINCT tc.table_name, kcu.column_name, ccu.column_name AS target_column
     FROM information_schema.table_constraints tc
     JOIN information_schema.key_column_usage kcu
       ON tc.constraint_name = kcu.constraint_name
@@ -154,9 +171,9 @@ export async function loadResourceFks(sql: Sql): Promise<FkColumnInfo[]> {
       AND tc.table_schema = ccu.table_schema
     WHERE tc.constraint_type = 'FOREIGN KEY'
       AND ccu.table_name = 'resources'
-      AND ccu.column_name = 'id'
+      AND ccu.column_name IN ('id', 'stable_id')
       AND tc.table_schema = 'public'
-    ORDER BY tc.table_name, kcu.column_name
+    ORDER BY tc.table_name, kcu.column_name, ccu.column_name
   `;
   if (fkRows.length === 0) return [];
 
@@ -186,7 +203,21 @@ export async function loadResourceFks(sql: Sql): Promise<FkColumnInfo[]> {
     const uniqueGroups = uniques
       .filter((u) => u.columns.includes(fk.column_name))
       .map((u) => ({ otherCols: u.columns.filter((c) => c !== fk.column_name) }));
-    return { tableName: fk.table_name, columnName: fk.column_name, uniqueGroups };
+    if (fk.target_column !== "id" && fk.target_column !== "stable_id") {
+      // Defensive: the SQL filter restricts to ('id', 'stable_id'), so this
+      // branch is unreachable. Throw rather than silently mis-categorize a
+      // future FK target we haven't taught mergeCluster how to translate.
+      throw new Error(
+        `loadResourceFks: unexpected FK target resources.${fk.target_column} ` +
+          `on ${fk.table_name}.${fk.column_name}`,
+      );
+    }
+    return {
+      tableName: fk.table_name,
+      columnName: fk.column_name,
+      targetColumn: fk.target_column,
+      uniqueGroups,
+    };
   });
 }
 
@@ -224,16 +255,50 @@ export async function buildReport(
   const refCounts = new Map<string, number>();
   if (candidateIds.size > 0) {
     const idsArr = [...candidateIds];
+
+    // QUA-589: FKs may target either resources.id or resources.stable_id.
+    // For stable_id-targeting FKs we have to translate the id-keyed
+    // candidateIds into their stable_id values before querying, then
+    // translate the matched FK values back to id when accumulating refCount
+    // (the refCount map is keyed by resources.id throughout).
+    const needsStable = uniqueCols.some((f) => f.targetColumn === "stable_id");
+    const idToStable = new Map<string, string>();
+    const stableToId = new Map<string, string>();
+    if (needsStable) {
+      const mapRows = await sql<{ id: string; stable_id: string | null }[]>`
+        SELECT id, stable_id FROM resources WHERE id = ANY(${idsArr})
+      `;
+      for (const r of mapRows) {
+        if (r.stable_id) {
+          idToStable.set(r.id, r.stable_id);
+          stableToId.set(r.stable_id, r.id);
+        }
+      }
+    }
+
     for (const fk of uniqueCols) {
+      const isStable = fk.targetColumn === "stable_id";
+      const valueSet = isStable
+        ? idsArr
+            .map((id) => idToStable.get(id))
+            .filter((v): v is string => v !== undefined)
+        : idsArr;
+      if (valueSet.length === 0) continue;
+
       const results = await sql.unsafe<{ id: string; c: number | string }[]>(
         `SELECT ${q(fk.columnName)} AS id, COUNT(*)::int AS c
          FROM ${q(fk.tableName)}
          WHERE ${q(fk.columnName)} = ANY($1::text[])
          GROUP BY ${q(fk.columnName)}`,
-        [idsArr]
+        [valueSet]
       );
       for (const row of results) {
-        refCounts.set(row.id, (refCounts.get(row.id) ?? 0) + Number(row.c));
+        const resourceId = isStable ? stableToId.get(row.id) : row.id;
+        if (!resourceId) continue;
+        refCounts.set(
+          resourceId,
+          (refCounts.get(resourceId) ?? 0) + Number(row.c)
+        );
       }
     }
   }
@@ -289,9 +354,42 @@ export async function mergeCluster(
   const uniqueCols = dedupeFkColumns(fkColumns);
   const allIds = [canonicalId, ...duplicateIds];
 
+  // QUA-589: Phase B FKs target resources.stable_id, not resources.id.
+  // Pre-resolve (id → stable_id) for the cluster so per-FK SQL can use the
+  // right value type. Fail loudly if any clustered resource is missing a
+  // stable_id — silently skipping a stable_id-targeting FK would leave
+  // orphan child rows pointing at the about-to-be-deleted duplicate.
+  const needsStable = uniqueCols.some((f) => f.targetColumn === "stable_id");
+  const idToStable = new Map<string, string>();
+  if (needsStable) {
+    const mapRows = await tx<{ id: string; stable_id: string | null }[]>`
+      SELECT id, stable_id FROM resources WHERE id = ANY(${allIds})
+    `;
+    for (const r of mapRows) {
+      if (r.stable_id) idToStable.set(r.id, r.stable_id);
+    }
+    const missing = allIds.filter((id) => !idToStable.has(id));
+    if (missing.length > 0) {
+      throw new Error(
+        `mergeCluster: ${missing.length} clustered resource(s) have NULL stable_id ` +
+          `(${missing.join(", ")}); cannot rewrite stable_id-targeting FKs. ` +
+          `Backfill resources.stable_id (see migration 0184_qua_536) before retrying.`,
+      );
+    }
+  }
+
   for (const fk of uniqueCols) {
     const key = `${fk.tableName}.${fk.columnName}`;
-    fkUpdates[key] = { moved: 0, deletedOnConflict: 0 };
+    fkUpdates[key] = fkUpdates[key] ?? { moved: 0, deletedOnConflict: 0 };
+
+    const isStable = fk.targetColumn === "stable_id";
+    const canonValue = isStable ? idToStable.get(canonicalId)! : canonicalId;
+    const allValues = isStable
+      ? allIds.map((id) => idToStable.get(id)!)
+      : allIds;
+    const dupValues = isStable
+      ? duplicateIds.map((id) => idToStable.get(id)!)
+      : duplicateIds;
 
     // For each unique constraint involving this column, delete cluster rows
     // that would collide with canonical's existing rows post-UPDATE. Prefer
@@ -317,8 +415,8 @@ export async function mergeCluster(
         RETURNING 1
       `;
       const deleted = await tx.unsafe<unknown[]>(deleteSql, [
-        canonicalId,
-        allIds,
+        canonValue,
+        allValues,
       ]);
       fkUpdates[key].deletedOnConflict += deleted.length;
     }
@@ -330,8 +428,8 @@ export async function mergeCluster(
       RETURNING 1
     `;
     const moved = await tx.unsafe<unknown[]>(updateSql, [
-      canonicalId,
-      duplicateIds,
+      canonValue,
+      dupValues,
     ]);
     fkUpdates[key].moved += moved.length;
   }

--- a/crux/scripts/dedup-resources.ts
+++ b/crux/scripts/dedup-resources.ts
@@ -39,6 +39,9 @@ interface DedupCluster {
 interface FkColumnInfo {
   tableName: string;
   columnName: string;
+  /** QUA-589: which resources column this FK targets — `id` (legacy hex16)
+   *  or `stable_id` (canonical sid_, post-Phase B). */
+  targetColumn: "id" | "stable_id";
   uniqueGroups: { otherCols: string[] }[];
 }
 
@@ -93,7 +96,15 @@ function logReport(result: RunDedupResult): void {
     );
   }
   console.log(`Total resources: ${report.totalResources}`);
-  console.log(`FK columns referencing resources.id: ${report.fkColumns.length}`);
+  // QUA-589: discovery includes both resources.id and resources.stable_id targets.
+  const idFks = report.fkColumns.filter((f) => f.targetColumn === "id").length;
+  const stableFks = report.fkColumns.filter(
+    (f) => f.targetColumn === "stable_id",
+  ).length;
+  console.log(
+    `FK columns referencing resources: ${report.fkColumns.length} (` +
+      `${idFks} → resources.id, ${stableFks} → resources.stable_id)`,
+  );
   console.log(`Duplicate clusters: ${report.clusters.length}`);
   const rowsToDelete = report.clusters.reduce(
     (acc, c) => acc + c.duplicates.length,


### PR DESCRIPTION
## Summary

`apps/wiki-server/src/routes/wikibase/resource-dedup.ts` (QUA-561 dedup) only saw FKs targeting `resources.id`. Phase B (QUA-549) has migrated 17 tables to reference `resources.stable_id`; each one silently dropped off the dedup sweep — CASCADE still cleaned them on resource delete, but the UPDATE-to-canonical path stopped firing for those tables.

This PR teaches the dedup flow that an FK can target either `resources.id` (legacy) or `resources.stable_id` (post-Phase-B). Both forms are supported simultaneously, so this is independent of when the remaining Phase B tables migrate.

### Key changes
- **`loadResourceFks`** now matches `ccu.column_name IN ('id', 'stable_id')` and records `targetColumn` per FK so callers know which value type to write.
- **`mergeCluster`** pre-resolves `(id → stable_id)` for the cluster once (only when at least one FK targets `stable_id`) and uses the right value per FK pass. Throws if any clustered resource has NULL `stable_id` — Phase A (QUA-536) made `stable_id` NOT NULL in prod, so this only fires in misconfigured environments.
- **`buildReport`** pulls `stable_id` in the same `resources` scan it was already running and translates id↔stable_id during the FK refCount loop. No second round-trip.
- **`dedupeFkColumns`** keys on `(table, column, target)` so the rare degenerate case of one column with FKs to both `resources.id` and `resources.stable_id` keeps both entries (each gets its own UPDATE/DELETE pass).
- **`fkUpdates`** is keyed by `(table, column)` and aggregates across the two passes when the degenerate case fires — this is the right report semantics.
- CLI script (`crux/scripts/dedup-resources.ts`) now prints "FK columns referencing resources: N (X → resources.id, Y → resources.stable_id)".

Backward-compatible: `needsStable` is false on pre-Phase-B databases, all stable_id paths short-circuit.

### Test coverage
- New unit test for `dedupeFkColumns` keeping both entries when targets differ.
- New integration test exercising a 3-resource cluster with FKs to both `id` (entity_resources) and `stable_id` with UNIQUE (publications) — asserts moved + deletedOnConflict counters and final row state.
- New integration test for the NULL-stable_id throw path.
- Existing integration tests updated to populate `stable_id` and pass `targetColumn` on `FkColumnInfo`.

## Test plan
- [x] `pnpm --filter wiki-server test resource-dedup` — 17 unit tests pass (5 integration tests skip without `DATABASE_URL`)
- [x] Full wiki-server suite — 1422 tests pass
- [x] `pnpm crux w validate gate --fix` — 47 checks pass
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `/agent-review-pr` — 4 medium findings addressed (3 documented as deliberate invariants, 1 fixed via simplification)
- [x] `/simplify` — folded `stable_id` into the existing scan; -14 lines, one fewer round-trip per dedup run

Fixes QUA-589
