### PR TITLE
QUA-442: universal PG audit log via generic trigger + SET LOCAL session attribution

### DIFF
--- a/.claude/rules/audit-log.md
+++ b/.claude/rules/audit-log.md
@@ -1,0 +1,147 @@
+# Audit Log System — Subsystem Map
+
+Universal PG audit log (QUA-442) + the older `tablebase_audit_log`. Read this
+**before** proposing a new audit-related change, adding an audit write, or
+writing a background job that mutates rows — both layers are already wired
+and the most common mistake is to bypass them.
+
+## Two layers, different purposes
+
+| Layer | Table | Populated by | Purpose |
+|---|---|---|---|
+| **Universal (QUA-442)** | `full_audit_log` | `audit_trigger_fn()` PL/pgSQL trigger on every allow-listed table | Comprehensive capture of every INSERT/UPDATE/DELETE, forever. Raw JSONB, session attribution. |
+| **Rich (legacy)** | `tablebase_audit_log` | Explicit `logAuditEntries(tx, entries)` calls (sync-factory + a few routes) | Richer per-record attribution: source URL, verdict, evidence. Only populated for sync-factory writes. |
+
+**They complement, not replace.** The universal log is the floor (anything
+that writes to PG is captured). The rich log is the ceiling (application-
+layer metadata the trigger can't see).
+
+## How attribution works end-to-end
+
+1. **Crux client** sets `process.env.CRUX_COMMAND = '<domain> <command>'` at
+   startup (`crux.mjs::main()`), and calls `primeAuditSessionId()` which
+   looks up the current agent-checklist session via
+   `getAgentSessionByBranch(currentBranch())` once and caches the result.
+2. **Crux HTTP client** (`crux/lib/wiki-server/client.ts::buildHeaders()`)
+   stamps `X-Agent-Session-Id` and `X-Agent-Tool` on every wiki-server
+   request when the values are known.
+3. **Wiki-server middleware** (`apps/wiki-server/src/middleware/audit-context.ts`)
+   reads those two headers on every `/api/*` request and stashes them on
+   `c.set('auditContext', ...)`.
+4. **`applyAuditContext(tx, c)`** is called at the top of every Drizzle
+   transaction in a route that writes data. It runs
+   `SELECT set_config('app.agent_session_id', ..., true)` and
+   `SELECT set_config('app.agent_tool', ..., true)` — both scoped to the
+   transaction (`is_local = true`), so values reset on COMMIT/ROLLBACK.
+5. **PG trigger** (`audit_trigger_fn`) fires after every INSERT/UPDATE/DELETE
+   and reads those GUCs via `current_setting('app.agent_session_id', true)`,
+   writing the attribution alongside `to_jsonb(OLD)` / `to_jsonb(NEW)`
+   into `full_audit_log`.
+
+Where the chain is most commonly broken: step 4. **Every new hand-rolled
+transaction must call `applyAuditContext(tx, c)`**. The sync-factory does
+this automatically; non-factory routes (entities, things, data-sources,
+bluesky, ids, and anything outside `tablebase/`) need an explicit call.
+
+## Allow-list — which tables get the trigger
+
+Initial v1 allow-list lives in migration
+`0204_qua_442_audit_log_universal_trigger.sql` and covers the TableBase
+domain tables plus `entities` and `facts`. Excluded for v1:
+
+- High-volume time-series: `*_snapshots`, `secondary_market_prices`
+- System/pipeline state: `agent_sessions`, `active_agents`, `jobs`,
+  `groundskeeper_runs`, `service_health_incidents`, `operations_log`
+- Audit tables themselves: `full_audit_log`, `tablebase_audit_log`
+- Derived/cache tables: `things`, `wikibase_page_similarity`,
+  `wikibase_page_assessments`, `qa_page_checks`
+- Claims pipeline (already has its own attribution): `claims`, `claim_sources`,
+  `claim_page_references`, `proposed_claims`, `claim_record_links`,
+  `statement_citations`, `statement_page_references`
+- `edit_logs`, `sessions`, `session_pages` (separate audit)
+- Scan output, enrichment runs
+
+**Expanding**: a follow-up migration that calls `CALL apply_audit_trigger('<table>')`
+for any non-listed table. The helper is idempotent.
+
+**Removing**: `CALL remove_audit_trigger('<table>')`.
+
+## `app.audit_skip` escape hatch
+
+For bulk migrations that would flood the audit log with millions of rows,
+set `app.audit_skip = 'true'` at the top of the transaction:
+
+```sql
+SET LOCAL app.audit_skip = 'true';
+UPDATE big_table SET ... WHERE ...;
+```
+
+Values accepted: `'true'`, `'on'`, `'1'`. Anything else (including unset) is
+treated as "don't skip."
+
+**When to use it**: planned bulk rewrites where the migration's git history
+IS the audit trail (e.g. Phase 4b-B `things` denormalization under QUA-408).
+
+**When NOT to use it**: anything that writes unplanned state — bug fixes,
+content edits, job workers. The trigger overhead is trivial (~5-10% per row)
+and the audit trail is valuable.
+
+## Reading the audit log
+
+```bash
+crux audit recent                                  # 50 most recent across all tables
+crux audit recent --table=personnel --limit=200    # filter by table
+crux audit recent --session=12345                  # all writes from one session
+crux audit recent --txn=98765                      # all rows in one transaction
+crux audit recent --since=2026-04-20T00:00:00Z --json
+```
+
+API: `GET /api/audit-log/recent?table=&session=&txn=&since=&limit=` returns
+`{ entries: AuditEntry[] }` with `oldRow` + `newRow` as JSONB, plus
+`sessionId`, `tool`, `txnId`, `changedAt`.
+
+## Writing directly to `tablebase_audit_log` (the rich layer)
+
+`logAuditEntries(tx, entries)` from
+`apps/wiki-server/src/routes/tablebase/audit-log.ts`. Call **inside a
+transaction** with pre-computed before/after state. Fields:
+
+- `recordType`, `recordId` (required)
+- `operation: 'insert' | 'update' | 'delete'` (required)
+- `oldData`, `newData` (newData required)
+- `sourceUrl`, `verdict`, `evidence` — richer than the trigger can provide
+- `agentSessionId` — **auto-filled from `current_setting('app.agent_session_id')`
+  when the caller doesn't pass one**, so all 4 existing callers pick up
+  session attribution for free once the middleware is wired.
+
+The sync-factory wires `auditRecordType` to call `logAuditEntries` for
+each upsert chunk. Routes NOT using the factory must call it explicitly.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `apps/wiki-server/drizzle/helpers/audit_log_trigger.sql` | Source-of-truth SQL for `audit_trigger_fn()`, `apply_audit_trigger`, `remove_audit_trigger` |
+| `apps/wiki-server/drizzle/0204_qua_442_audit_log_universal_trigger.sql` | Install + attach to allow-list |
+| `apps/wiki-server/src/middleware/audit-context.ts` | Hono middleware + `applyAuditContext` helper |
+| `apps/wiki-server/src/routes/operational/audit-log.ts` | `GET /api/audit-log/recent` |
+| `apps/wiki-server/src/routes/tablebase/audit-log.ts` | `logAuditEntries()` for the rich layer |
+| `apps/wiki-server/src/routes/tablebase/sync-factory.ts` | Calls `applyAuditContext(tx, c)` at tx start + `logAuditEntries` for opted-in routes |
+| `crux/lib/wiki-server/audit-context.ts` | Client-side session-id cache + tool name |
+| `crux/lib/wiki-server/client.ts::buildHeaders` | Stamps `X-Agent-Session-Id` / `X-Agent-Tool` |
+| `crux/commands/audit.ts` | `crux audit recent` CLI |
+
+## Common mistakes to avoid
+
+1. **Hand-rolled transaction without `applyAuditContext(tx, c)`**. The row
+   is still captured by the trigger, but `session_id` / `tool` are NULL.
+   Add a one-line call at the top of the transaction callback.
+2. **Calling `logAuditEntries(db, ...)` outside a transaction**. The GUC
+   fallback for `agentSessionId` reads `current_setting(...)` which is
+   only meaningful inside the transaction that set it. Always pass the `tx`.
+3. **Adding a new domain table without extending the allow-list**. The
+   trigger doesn't auto-attach to new tables. After the Drizzle migration
+   that creates the table, add `CALL apply_audit_trigger('<new_table>')`
+   in the same migration (or a follow-up).
+4. **Using `app.audit_skip` as a general bypass**. It's only for bulk
+   migrations; using it in application code silently loses history.

--- a/.claude/rules/database-migrations.md
+++ b/.claude/rules/database-migrations.md
@@ -195,6 +195,34 @@ So the lock releases between them. The helper still owns the FK discovery, backf
 
 For FK target swaps in this codebase, the hand-rolled template is now a footgun — the helper exists precisely because the template shipped a copy-paste defect 12 times. Call it. If the helper is missing a feature you need, extend it in a follow-up PR rather than bypassing it.
 
+## Bulk backfills — skip the universal audit trigger
+
+As of QUA-442 (migration 0204), every allow-listed domain table has an
+`AFTER INSERT OR UPDATE OR DELETE` trigger that writes to `full_audit_log`.
+A naive bulk migration — `UPDATE things SET ...` across millions of rows —
+would produce one audit row per modified row.
+
+Opt out at the top of any bulk-rewrite migration that doesn't need per-row
+audit capture (the git history of the migration IS the audit trail):
+
+```sql
+SET LOCAL app.audit_skip = 'true';
+UPDATE big_table SET x = y WHERE ...;
+```
+
+Accepted truthy values: `'true'`, `'on'`, `'1'`. `SET LOCAL` scopes this to
+the current transaction, so it never leaks into application writes.
+
+**When to use it**: planned bulk rewrites you authored and expect (e.g.,
+the QUA-408 Phase 4b-B `things` denormalization rewrites).
+
+**When NOT to use it**: application code or bug fixes — the audit trail
+catches unplanned state changes that diverge from what the migration
+intended. The per-row overhead is ~5–10% per INSERT/UPDATE and rarely
+matters outside bulk migrations.
+
+Full docs: `.claude/rules/audit-log.md`.
+
 ## Deploy flow for DDL migrations
 
 1. Merge PR with the no-op migration — deploy succeeds without DDL contention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,4 +220,5 @@ These are "mental model" maps. They list the components, endpoints, helpers, and
 - `.claude/rules/three-bases-architecture.md` — TableBase/FactBase/WikiBase naming and which layer owns what
 - `.claude/rules/id-system.md` — `numericId` vs `stableId` vs `tableId`, allocation, validation
 - `.claude/rules/validation-gate-system.md` — `crux/validate/` 80+ validators, gate wiring, blocking vs advisory
+- `.claude/rules/audit-log.md` — Universal PG audit log (QUA-442) + legacy `tablebase_audit_log`. Read before touching trigger, middleware, or bulk migrations.
 - `docs/audits/things-denormalization-audit.md` — **Historical reference** (denorm columns dropped in QUA-507 / migration 0204). Retained for pre-QUA-507 composer logic per thing_type (useful if the `things_search` MV composition ever needs to change) and for the `*_display_name` sibling pattern audit (~20 columns across 13 tables) before proposing a new cache column.

--- a/apps/wiki-server/drizzle/0210_qua_442_audit_log_universal_trigger.sql
+++ b/apps/wiki-server/drizzle/0210_qua_442_audit_log_universal_trigger.sql
@@ -9,9 +9,10 @@
 --       application-layer entries).
 --   2. `audit_trigger_fn()` plpgsql function.
 --   3. `apply_audit_trigger(text)` / `remove_audit_trigger(text)` helpers.
---   4. Attaches the trigger to an initial allow-list of TableBase domain
---       tables (~25 tables). Expansion to remaining tables is a one-line
---       follow-up migration per table.
+--   4. Attaches the trigger to an initial allow-list of 28 TableBase
+--       domain tables (including the two flagship non-factory tables,
+--       `entities` and `facts`, plus `resources`). Expansion to remaining
+--       tables is a one-line follow-up migration per table.
 --
 -- Source of truth for the procedure bodies lives at
 -- apps/wiki-server/drizzle/helpers/audit_log_trigger.sql. That file is kept
@@ -42,6 +43,11 @@ CREATE INDEX IF NOT EXISTS idx_full_audit_log_session
 
 CREATE INDEX IF NOT EXISTS idx_full_audit_log_txn
   ON full_audit_log (txn_id);
+
+-- Time-only index: unfiltered `/api/audit-log/recent` with just `since`
+-- would otherwise degrade to a seq scan once the table grows.
+CREATE INDEX IF NOT EXISTS idx_full_audit_log_changed_at
+  ON full_audit_log (changed_at DESC);
 
 -- ---- 2. Trigger function -----------------------------------------------
 CREATE OR REPLACE FUNCTION audit_trigger_fn() RETURNS trigger
@@ -121,12 +127,16 @@ END;
 $proc$;
 
 -- ---- 4. Attach to allow-list -------------------------------------------
--- Initial allow-list covers all factory-using TableBase domain tables plus
--- the two flagship non-factory ones (`entities`, `facts`). Deliberately
--- excluded for v1: high-volume time-series (*_snapshots, secondary_market_prices),
--- system/pipeline state (agent_sessions, jobs, groundskeeper_runs, ...),
--- the audit tables themselves, the derived `things` cross-base index, and
--- the claims pipeline (already has its own attribution).
+-- Initial allow-list covers all factory-using TableBase domain tables
+-- plus `entities`, `facts`, and `resources` (the three high-traffic
+-- non-factory write targets with dedicated middleware wiring added in
+-- this PR — see apps/wiki-server/src/routes/tablebase/entities.ts,
+-- .../tablebase/data-sources.ts, .../wikibase/resources.ts). Deliberately
+-- excluded for v1: high-volume time-series (*_snapshots,
+-- secondary_market_prices), system/pipeline state (agent_sessions, jobs,
+-- groundskeeper_runs, ...), the audit tables themselves, the derived
+-- `things` cross-base index, and the claims pipeline (already has its
+-- own attribution).
 --
 -- Expanding: a follow-up migration may call `apply_audit_trigger('<table>')`
 -- for any non-listed domain table.

--- a/apps/wiki-server/drizzle/0210_qua_442_audit_log_universal_trigger.sql
+++ b/apps/wiki-server/drizzle/0210_qua_442_audit_log_universal_trigger.sql
@@ -1,0 +1,171 @@
+-- QUA-442: universal PG audit log via generic trigger + SET LOCAL session
+-- attribution. Lives under epic QUA-408 (data-model unwind); coordinated
+-- to ship before Phase 4b bulk rewrites so the migration writes themselves
+-- are captured with session attribution.
+--
+-- Installs:
+--   1. `full_audit_log` table (comprehensive capture; complements the
+--       existing `tablebase_audit_log` which stays for richer
+--       application-layer entries).
+--   2. `audit_trigger_fn()` plpgsql function.
+--   3. `apply_audit_trigger(text)` / `remove_audit_trigger(text)` helpers.
+--   4. Attaches the trigger to an initial allow-list of TableBase domain
+--       tables (~25 tables). Expansion to remaining tables is a one-line
+--       follow-up migration per table.
+--
+-- Source of truth for the procedure bodies lives at
+-- apps/wiki-server/drizzle/helpers/audit_log_trigger.sql. That file is kept
+-- in sync with the CREATE OR REPLACE bodies below by convention (same
+-- pattern as 0199_install_swap_fk_target.sql).
+--
+-- Caller docs: .claude/rules/audit-log.md.
+
+-- ---- 1. Table ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS full_audit_log (
+  id               bigserial PRIMARY KEY,
+  table_name       text NOT NULL,
+  operation        text NOT NULL,
+  old_row          jsonb,
+  new_row          jsonb,
+  txn_id           bigint,
+  session_id       text,
+  tool             text,
+  application_name text,
+  changed_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_full_audit_log_table_time
+  ON full_audit_log (table_name, changed_at);
+
+CREATE INDEX IF NOT EXISTS idx_full_audit_log_session
+  ON full_audit_log (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_full_audit_log_txn
+  ON full_audit_log (txn_id);
+
+-- ---- 2. Trigger function -----------------------------------------------
+CREATE OR REPLACE FUNCTION audit_trigger_fn() RETURNS trigger
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  v_session_id       text;
+  v_tool             text;
+  v_application_name text;
+  v_skip             text;
+BEGIN
+  v_skip := current_setting('app.audit_skip', true);
+  IF v_skip = 'true' OR v_skip = 'on' OR v_skip = '1' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  v_session_id       := current_setting('app.agent_session_id', true);
+  v_tool             := current_setting('app.agent_tool', true);
+  v_application_name := current_setting('application_name', true);
+
+  IF v_session_id       = '' THEN v_session_id       := NULL; END IF;
+  IF v_tool             = '' THEN v_tool             := NULL; END IF;
+  IF v_application_name = '' THEN v_application_name := NULL; END IF;
+
+  INSERT INTO full_audit_log (
+    table_name, operation,
+    old_row, new_row, txn_id,
+    session_id, tool, application_name, changed_at
+  ) VALUES (
+    TG_TABLE_NAME, TG_OP,
+    CASE WHEN TG_OP IN ('UPDATE','DELETE') THEN to_jsonb(OLD) END,
+    CASE WHEN TG_OP IN ('INSERT','UPDATE') THEN to_jsonb(NEW) END,
+    txid_current(),
+    v_session_id, v_tool, v_application_name,
+    now()
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$fn$;
+
+-- ---- 3. Helper procedures ----------------------------------------------
+CREATE OR REPLACE PROCEDURE apply_audit_trigger(target_table text)
+LANGUAGE plpgsql AS $proc$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = current_schema()
+      AND table_name   = target_table
+      AND table_type   = 'BASE TABLE'
+  ) THEN
+    RAISE NOTICE 'apply_audit_trigger: table % not found in schema %; skipping',
+      target_table, current_schema();
+    RETURN;
+  END IF;
+
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS zz_audit_trigger ON %I',
+    target_table
+  );
+  EXECUTE format(
+    'CREATE TRIGGER zz_audit_trigger AFTER INSERT OR UPDATE OR DELETE ON %I '
+    || 'FOR EACH ROW EXECUTE FUNCTION audit_trigger_fn()',
+    target_table
+  );
+  RAISE NOTICE 'apply_audit_trigger: attached to %', target_table;
+END;
+$proc$;
+
+CREATE OR REPLACE PROCEDURE remove_audit_trigger(target_table text)
+LANGUAGE plpgsql AS $proc$
+BEGIN
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS zz_audit_trigger ON %I',
+    target_table
+  );
+END;
+$proc$;
+
+-- ---- 4. Attach to allow-list -------------------------------------------
+-- Initial allow-list covers all factory-using TableBase domain tables plus
+-- the two flagship non-factory ones (`entities`, `facts`). Deliberately
+-- excluded for v1: high-volume time-series (*_snapshots, secondary_market_prices),
+-- system/pipeline state (agent_sessions, jobs, groundskeeper_runs, ...),
+-- the audit tables themselves, the derived `things` cross-base index, and
+-- the claims pipeline (already has its own attribution).
+--
+-- Expanding: a follow-up migration may call `apply_audit_trigger('<table>')`
+-- for any non-listed domain table.
+DO $$
+DECLARE
+  t text;
+  tables text[] := ARRAY[
+    'entities',
+    'facts',
+    'personnel',
+    'grants',
+    'investments',
+    'funding_rounds',
+    'equity_positions',
+    'divisions',
+    'division_personnel',
+    'benchmarks',
+    'benchmark_results',
+    'publications',
+    'research_areas',
+    'entity_resources',
+    'entity_events',
+    'entity_assessments',
+    'funding_programs',
+    'policy_stakeholders',
+    'political_scores',
+    'political_votes',
+    'political_races',
+    'political_offices',
+    'campaign_finance',
+    'platform_accounts',
+    'prediction_market_questions',
+    'talent_flows',
+    'website_sources',
+    'resources'
+  ];
+BEGIN
+  FOREACH t IN ARRAY tables LOOP
+    CALL apply_audit_trigger(t);
+  END LOOP;
+END
+$$;

--- a/apps/wiki-server/drizzle/helpers/audit_log_trigger.sql
+++ b/apps/wiki-server/drizzle/helpers/audit_log_trigger.sql
@@ -1,0 +1,106 @@
+-- QUA-442: universal audit-log trigger function.
+--
+-- Source of truth for the procedure body. Landed via a thin install
+-- migration (see 0204_qua_442_audit_log_universal_trigger.sql); any change
+-- to the function must be re-landed via a new CREATE OR REPLACE migration
+-- because Drizzle doesn't rescan helpers/.
+--
+-- Caller docs: .claude/rules/audit-log.md and
+-- .claude/rules/database-migrations.md § "Audit-log escape hatch".
+
+-- The trigger function. Fires AFTER INSERT, UPDATE, DELETE on every table it's
+-- attached to. Writes a single row to `full_audit_log` with before/after
+-- state as JSONB plus GUC-sourced session attribution.
+--
+-- Opt-out: set `app.audit_skip = 'true'` (SET LOCAL for per-transaction,
+-- SET SESSION for the duration of a psql/Drizzle connection) to bypass the
+-- insert entirely. Used by bulk backfill migrations that would otherwise
+-- produce millions of audit rows for no investigative value.
+--
+-- Fail-open: every current_setting() uses the `missing_ok = true` second
+-- argument so the function never errors on a never-set GUC — the audit row
+-- simply records NULL session/tool/application_name. An audit-trigger that
+-- can break writes is worse than one that records fewer fields.
+CREATE OR REPLACE FUNCTION audit_trigger_fn() RETURNS trigger
+LANGUAGE plpgsql AS $fn$
+DECLARE
+  v_session_id       text;
+  v_tool             text;
+  v_application_name text;
+  v_skip             text;
+BEGIN
+  v_skip := current_setting('app.audit_skip', true);
+  IF v_skip = 'true' OR v_skip = 'on' OR v_skip = '1' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  v_session_id       := current_setting('app.agent_session_id', true);
+  v_tool             := current_setting('app.agent_tool', true);
+  v_application_name := current_setting('application_name', true);
+
+  -- Treat empty strings as NULL so filters can use IS NULL uniformly.
+  IF v_session_id       = '' THEN v_session_id       := NULL; END IF;
+  IF v_tool             = '' THEN v_tool             := NULL; END IF;
+  IF v_application_name = '' THEN v_application_name := NULL; END IF;
+
+  INSERT INTO full_audit_log (
+    table_name, operation,
+    old_row, new_row, txn_id,
+    session_id, tool, application_name, changed_at
+  ) VALUES (
+    TG_TABLE_NAME, TG_OP,
+    CASE WHEN TG_OP IN ('UPDATE','DELETE') THEN to_jsonb(OLD) END,
+    CASE WHEN TG_OP IN ('INSERT','UPDATE') THEN to_jsonb(NEW) END,
+    txid_current(),
+    v_session_id, v_tool, v_application_name,
+    now()
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$fn$;
+
+-- Attach or re-attach the audit trigger to a single table. Idempotent.
+--
+-- Uses a well-known trigger name (`zz_audit_trigger`) so a second call is a
+-- DROP-then-CREATE; the leading `zz_` keeps this trigger firing last, after
+-- any domain-specific triggers (e.g. search_vector refresh). Callers pass
+-- unqualified table names; the helper scopes to current_schema().
+CREATE OR REPLACE PROCEDURE apply_audit_trigger(target_table text)
+LANGUAGE plpgsql AS $proc$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = current_schema()
+      AND table_name   = target_table
+      AND table_type   = 'BASE TABLE'
+  ) THEN
+    RAISE NOTICE 'apply_audit_trigger: table % not found in schema %; skipping',
+      target_table, current_schema();
+    RETURN;
+  END IF;
+
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS zz_audit_trigger ON %I',
+    target_table
+  );
+  EXECUTE format(
+    'CREATE TRIGGER zz_audit_trigger AFTER INSERT OR UPDATE OR DELETE ON %I '
+    || 'FOR EACH ROW EXECUTE FUNCTION audit_trigger_fn()',
+    target_table
+  );
+  RAISE NOTICE 'apply_audit_trigger: attached to %', target_table;
+END;
+$proc$;
+
+-- Detach the audit trigger from a single table. Idempotent no-op if the
+-- trigger isn't present.
+CREATE OR REPLACE PROCEDURE remove_audit_trigger(target_table text)
+LANGUAGE plpgsql AS $proc$
+BEGIN
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS zz_audit_trigger ON %I',
+    target_table
+  );
+END;
+$proc$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1457,6 +1457,13 @@
       "when": 1787559200000,
       "tag": "0207_qua_688_scorecard_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 210,
+      "version": "7",
+      "when": 1787818000000,
+      "tag": "0210_qua_442_audit_log_universal_trigger",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/audit-context.test.ts
+++ b/apps/wiki-server/src/__tests__/audit-context.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests — audit-context middleware (QUA-442).
+ *
+ * Verifies header parsing, sanitization, and `applyAuditContext` calls
+ * `SET LOCAL` via `set_config(...)`. DB interaction is mocked through
+ * an in-memory fake transaction.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
+import {
+  auditContextMiddleware,
+  getAuditContext,
+  applyAuditContext,
+  setAuditContextRaw,
+  AUDIT_SESSION_HEADER,
+  AUDIT_TOOL_HEADER,
+} from "../middleware/audit-context.js";
+
+describe("auditContextMiddleware", () => {
+  it("stashes session + tool from request headers", async () => {
+    const app = new Hono().use(auditContextMiddleware()).get("/x", (c) => {
+      const ctx = getAuditContext(c);
+      return c.json(ctx);
+    });
+    const res = await app.request("/x", {
+      headers: {
+        [AUDIT_SESSION_HEADER]: "42",
+        [AUDIT_TOOL_HEADER]: "tb.scaffold",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sessionId: "42", tool: "tb.scaffold" });
+  });
+
+  it("returns nulls when headers are absent", async () => {
+    const app = new Hono().use(auditContextMiddleware()).get("/x", (c) => {
+      const ctx = getAuditContext(c);
+      return c.json(ctx);
+    });
+    const res = await app.request("/x");
+    expect(await res.json()).toEqual({ sessionId: null, tool: null });
+  });
+
+  it("trims whitespace and treats empty strings as null", async () => {
+    const app = new Hono().use(auditContextMiddleware()).get("/x", (c) => {
+      const ctx = getAuditContext(c);
+      return c.json(ctx);
+    });
+    const res = await app.request("/x", {
+      headers: {
+        [AUDIT_SESSION_HEADER]: "  ",
+        [AUDIT_TOOL_HEADER]: "  scoped  ",
+      },
+    });
+    expect(await res.json()).toEqual({ sessionId: null, tool: "scoped" });
+  });
+
+  it("truncates pathologically long values", async () => {
+    const longVal = "x".repeat(1000);
+    const app = new Hono().use(auditContextMiddleware()).get("/x", (c) => {
+      const ctx = getAuditContext(c);
+      return c.json(ctx);
+    });
+    const res = await app.request("/x", {
+      headers: {
+        [AUDIT_SESSION_HEADER]: longVal,
+        [AUDIT_TOOL_HEADER]: longVal,
+      },
+    });
+    const body = (await res.json()) as { sessionId: string; tool: string };
+    expect(body.sessionId.length).toBe(256);
+    expect(body.tool.length).toBe(256);
+  });
+
+  it("getAuditContext returns defaults on a context that was never middleware-wrapped", async () => {
+    const app = new Hono().get("/x", (c) => {
+      const ctx = getAuditContext(c);
+      return c.json(ctx);
+    });
+    const res = await app.request("/x");
+    expect(await res.json()).toEqual({ sessionId: null, tool: null });
+  });
+});
+
+describe("applyAuditContext / setAuditContextRaw", () => {
+  function makeFakeTx() {
+    const calls: Array<{ query: string; params: unknown[] }> = [];
+    const fakeTx = {
+      execute: vi.fn(async (query: { queryChunks?: unknown[] } | string) => {
+        // Drizzle sql template: we just record the input so the test can
+        // assert `set_config` was called with the right value.
+        calls.push({ query: JSON.stringify(query), params: [] });
+        return [] as unknown[];
+      }),
+    };
+    return { fakeTx, calls };
+  }
+
+  it("applyAuditContext issues two set_config calls with request values", async () => {
+    const { fakeTx, calls } = makeFakeTx();
+    const app = new Hono().use(auditContextMiddleware()).get("/x", async (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await applyAuditContext(fakeTx as any, c);
+      return c.json({ ok: true });
+    });
+    await app.request("/x", {
+      headers: {
+        [AUDIT_SESSION_HEADER]: "abc",
+        [AUDIT_TOOL_HEADER]: "crux.audit",
+      },
+    });
+    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
+    const stringified = calls.map((c) => c.query).join(" | ");
+    expect(stringified).toMatch(/agent_session_id/);
+    expect(stringified).toMatch(/agent_tool/);
+  });
+
+  it("applyAuditContext writes empty strings when headers are absent", async () => {
+    const { fakeTx } = makeFakeTx();
+    const app = new Hono().use(auditContextMiddleware()).get("/x", async (c) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await applyAuditContext(fakeTx as any, c);
+      return c.json({ ok: true });
+    });
+    await app.request("/x");
+    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("setAuditContextRaw issues two set_config calls with raw values", async () => {
+    const { fakeTx } = makeFakeTx();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await setAuditContextRaw(fakeTx as any, { sessionId: "99", tool: "batch" });
+    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/wiki-server/src/__tests__/audit-context.test.ts
+++ b/apps/wiki-server/src/__tests__/audit-context.test.ts
@@ -12,7 +12,7 @@ import {
   auditContextMiddleware,
   getAuditContext,
   applyAuditContext,
-  setAuditContextRaw,
+  applyAuditContextValues,
   AUDIT_SESSION_HEADER,
   AUDIT_TOOL_HEADER,
 } from "../middleware/audit-context.js";
@@ -83,22 +83,41 @@ describe("auditContextMiddleware", () => {
   });
 });
 
-describe("applyAuditContext / setAuditContextRaw", () => {
+describe("applyAuditContext / applyAuditContextValues", () => {
+  /**
+   * Drizzle's `sql` template tag produces an `SQL` object whose `.queryChunks`
+   * alternate between `StringChunk { value: string[] }` (literal SQL) and the
+   * raw JS values inlined by `${}`. Parameters are the non-StringChunk items.
+   */
+  function extractParams(query: unknown): unknown[] {
+    if (typeof query !== "object" || query === null) return [];
+    const chunks = (query as { queryChunks?: unknown[] }).queryChunks;
+    if (!Array.isArray(chunks)) return [];
+    const params: unknown[] = [];
+    for (const chunk of chunks) {
+      // StringChunk is an object literal `{ value: string[] }`; anything
+      // else (string / number / etc.) is a parameter value.
+      if (chunk && typeof chunk === "object" && "value" in (chunk as Record<string, unknown>)) {
+        continue;
+      }
+      params.push(chunk);
+    }
+    return params;
+  }
+
   function makeFakeTx() {
-    const calls: Array<{ query: string; params: unknown[] }> = [];
+    const queries: unknown[] = [];
     const fakeTx = {
-      execute: vi.fn(async (query: { queryChunks?: unknown[] } | string) => {
-        // Drizzle sql template: we just record the input so the test can
-        // assert `set_config` was called with the right value.
-        calls.push({ query: JSON.stringify(query), params: [] });
+      execute: vi.fn(async (query: unknown) => {
+        queries.push(query);
         return [] as unknown[];
       }),
     };
-    return { fakeTx, calls };
+    return { fakeTx, queries };
   }
 
-  it("applyAuditContext issues two set_config calls with request values", async () => {
-    const { fakeTx, calls } = makeFakeTx();
+  it("applyAuditContext issues one SELECT with both parameters bound", async () => {
+    const { fakeTx, queries } = makeFakeTx();
     const app = new Hono().use(auditContextMiddleware()).get("/x", async (c) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await applyAuditContext(fakeTx as any, c);
@@ -110,27 +129,34 @@ describe("applyAuditContext / setAuditContextRaw", () => {
         [AUDIT_TOOL_HEADER]: "crux.audit",
       },
     });
-    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
-    const stringified = calls.map((c) => c.query).join(" | ");
-    expect(stringified).toMatch(/agent_session_id/);
-    expect(stringified).toMatch(/agent_tool/);
+    expect(fakeTx.execute).toHaveBeenCalledTimes(1);
+    const params = extractParams(queries[0]);
+    expect(params).toContain("abc");
+    expect(params).toContain("crux.audit");
   });
 
-  it("applyAuditContext writes empty strings when headers are absent", async () => {
-    const { fakeTx } = makeFakeTx();
+  it("applyAuditContext binds empty strings when headers are absent", async () => {
+    const { fakeTx, queries } = makeFakeTx();
     const app = new Hono().use(auditContextMiddleware()).get("/x", async (c) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await applyAuditContext(fakeTx as any, c);
       return c.json({ ok: true });
     });
     await app.request("/x");
-    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
+    expect(fakeTx.execute).toHaveBeenCalledTimes(1);
+    const params = extractParams(queries[0]);
+    // Both bindings must be the empty string, not null/undefined — the
+    // trigger function treats '' as NULL but set_config() rejects NULL.
+    expect(params.filter((v) => v === "")).toHaveLength(2);
   });
 
-  it("setAuditContextRaw issues two set_config calls with raw values", async () => {
-    const { fakeTx } = makeFakeTx();
+  it("applyAuditContextValues binds the raw values provided", async () => {
+    const { fakeTx, queries } = makeFakeTx();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await setAuditContextRaw(fakeTx as any, { sessionId: "99", tool: "batch" });
-    expect(fakeTx.execute).toHaveBeenCalledTimes(2);
+    await applyAuditContextValues(fakeTx as any, { sessionId: "99", tool: "batch" });
+    expect(fakeTx.execute).toHaveBeenCalledTimes(1);
+    const params = extractParams(queries[0]);
+    expect(params).toContain("99");
+    expect(params).toContain("batch");
   });
 });

--- a/apps/wiki-server/src/__tests__/audit-log.integration.test.ts
+++ b/apps/wiki-server/src/__tests__/audit-log.integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration tests — universal PG audit log (QUA-442 / migration 0204).
+ *
+ * Verifies the full round trip: an attached trigger writes to
+ * `full_audit_log` on INSERT/UPDATE/DELETE, populates before/after JSONB,
+ * reads session+tool attribution from GUCs set via `SET LOCAL`, and
+ * honors the `app.audit_skip` escape hatch.
+ *
+ * Requires DATABASE_URL; otherwise skipped (same convention as
+ * swap-fk-target-integration.test.ts).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import postgres from "postgres";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+
+const SCHEMA = "audit_log_test";
+
+describeWithDb("full_audit_log trigger (migration 0204 / QUA-442)", () => {
+  let sqlConn: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    sqlConn = postgres(DATABASE_URL!, { max: 2 });
+
+    // Sanity check: the trigger function and helper must be installed.
+    const fnExists = await sqlConn<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE p.proname = 'audit_trigger_fn' AND n.nspname = 'public'
+      ) AS exists
+    `;
+    if (!fnExists[0]?.exists) {
+      throw new Error(
+        "audit_trigger_fn not installed — run migrations up to 0204 before this test.",
+      );
+    }
+    const procExists = await sqlConn<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE p.proname = 'apply_audit_trigger' AND n.nspname = 'public'
+      ) AS exists
+    `;
+    if (!procExists[0]?.exists) {
+      throw new Error(
+        "apply_audit_trigger procedure not installed — run migrations up to 0204.",
+      );
+    }
+
+    await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await sqlConn.unsafe(`CREATE SCHEMA ${SCHEMA}`);
+  });
+
+  afterAll(async () => {
+    await sqlConn.unsafe(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await sqlConn.end();
+  });
+
+  beforeEach(async () => {
+    // Use a test table in the public schema so the trigger function (which
+    // INSERTs into public.full_audit_log) can see the foreign table's OID.
+    // Because apply_audit_trigger scopes to current_schema(), we'll SET
+    // search_path explicitly in each test run.
+    await sqlConn.unsafe(`DROP TABLE IF EXISTS public.audit_test_widgets CASCADE`);
+    await sqlConn.unsafe(`
+      CREATE TABLE public.audit_test_widgets (
+        id   text PRIMARY KEY,
+        name text NOT NULL,
+        qty  integer
+      )
+    `);
+    await sqlConn.unsafe(`CALL apply_audit_trigger('audit_test_widgets')`);
+
+    // Clear audit rows from any prior run on this fixture.
+    await sqlConn.unsafe(`DELETE FROM full_audit_log WHERE table_name = 'audit_test_widgets'`);
+  });
+
+  async function readAuditRows() {
+    return await sqlConn<
+      Array<{
+        id: string;
+        table_name: string;
+        operation: string;
+        old_row: Record<string, unknown> | null;
+        new_row: Record<string, unknown> | null;
+        txn_id: string | null;
+        session_id: string | null;
+        tool: string | null;
+        application_name: string | null;
+      }>
+    >`SELECT id::text, table_name, operation, old_row, new_row,
+              txn_id::text, session_id, tool, application_name
+      FROM full_audit_log
+      WHERE table_name = 'audit_test_widgets'
+      ORDER BY id ASC`;
+  }
+
+  it("records INSERT with new_row populated and old_row NULL", async () => {
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'widget-one', 42)`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].operation).toBe("INSERT");
+    expect(rows[0].old_row).toBeNull();
+    expect(rows[0].new_row).toMatchObject({ id: "w1", name: "widget-one", qty: 42 });
+  });
+
+  it("records UPDATE with both old_row and new_row populated", async () => {
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'orig', 1)`;
+    await sqlConn`UPDATE audit_test_widgets SET name = 'renamed', qty = 2 WHERE id = 'w1'`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(2);
+    const update = rows.find((r) => r.operation === "UPDATE");
+    expect(update).toBeDefined();
+    expect(update?.old_row).toMatchObject({ id: "w1", name: "orig", qty: 1 });
+    expect(update?.new_row).toMatchObject({ id: "w1", name: "renamed", qty: 2 });
+  });
+
+  it("records DELETE with old_row populated and new_row NULL", async () => {
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'doomed', 1)`;
+    await sqlConn`DELETE FROM audit_test_widgets WHERE id = 'w1'`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(2);
+    const del = rows.find((r) => r.operation === "DELETE");
+    expect(del).toBeDefined();
+    expect(del?.old_row).toMatchObject({ id: "w1", name: "doomed", qty: 1 });
+    expect(del?.new_row).toBeNull();
+  });
+
+  it("captures session_id and tool from SET LOCAL GUCs", async () => {
+    // SET LOCAL scopes to a transaction, so wrap the write in BEGIN/COMMIT.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
+    await sqlConn.begin(async (tx: any) => {
+      await tx`SELECT set_config('app.agent_session_id', '12345', true)`;
+      await tx`SELECT set_config('app.agent_tool', 'tb.scaffold', true)`;
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'tracked', 1)`;
+    });
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].session_id).toBe("12345");
+    expect(rows[0].tool).toBe("tb.scaffold");
+  });
+
+  it("records NULL attribution when GUCs are unset", async () => {
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'no-attr', 1)`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].session_id).toBeNull();
+    expect(rows[0].tool).toBeNull();
+  });
+
+  it("skips audit rows when app.audit_skip = 'true'", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
+    await sqlConn.begin(async (tx: any) => {
+      await tx`SELECT set_config('app.audit_skip', 'true', true)`;
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'silent', 1)`;
+      await tx`UPDATE audit_test_widgets SET qty = 2 WHERE id = 'w1'`;
+      await tx`DELETE FROM audit_test_widgets WHERE id = 'w1'`;
+    });
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("groups multi-row writes in one transaction under a single txn_id", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
+    await sqlConn.begin(async (tx: any) => {
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('a', 'x', 1)`;
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('b', 'y', 2)`;
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('c', 'z', 3)`;
+    });
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(3);
+    const uniqueTxns = new Set(rows.map((r) => r.txn_id));
+    expect(uniqueTxns.size).toBe(1);
+  });
+
+  it("re-attaching the trigger is idempotent", async () => {
+    // Two back-to-back attaches should leave exactly one trigger and writes
+    // should produce one audit row, not two.
+    await sqlConn.unsafe(`CALL apply_audit_trigger('audit_test_widgets')`);
+    await sqlConn.unsafe(`CALL apply_audit_trigger('audit_test_widgets')`);
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'once', 1)`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("remove_audit_trigger stops the capture", async () => {
+    await sqlConn.unsafe(`CALL remove_audit_trigger('audit_test_widgets')`);
+    await sqlConn`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'gone', 1)`;
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("apply_audit_trigger silently skips missing tables", async () => {
+    // No row should be inserted (the function returns early with NOTICE).
+    await expect(
+      sqlConn.unsafe(`CALL apply_audit_trigger('does_not_exist_anywhere')`),
+    ).resolves.toBeDefined();
+  });
+
+  it("treats empty-string GUCs as NULL in the audit row", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
+    await sqlConn.begin(async (tx: any) => {
+      await tx`SELECT set_config('app.agent_session_id', '', true)`;
+      await tx`SELECT set_config('app.agent_tool', '', true)`;
+      await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'empty', 1)`;
+    });
+    const rows = await readAuditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].session_id).toBeNull();
+    expect(rows[0].tool).toBeNull();
+  });
+});

--- a/apps/wiki-server/src/__tests__/audit-log.integration.test.ts
+++ b/apps/wiki-server/src/__tests__/audit-log.integration.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import postgres from "postgres";
+import type { CallableTransactionSql } from "../db.js";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeWithDb = DATABASE_URL ? describe : describe.skip;
@@ -131,8 +132,8 @@ describeWithDb("full_audit_log trigger (migration 0204 / QUA-442)", () => {
 
   it("captures session_id and tool from SET LOCAL GUCs", async () => {
     // SET LOCAL scopes to a transaction, so wrap the write in BEGIN/COMMIT.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
-    await sqlConn.begin(async (tx: any) => {
+    await sqlConn.begin(async (rawTx) => {
+      const tx = rawTx as unknown as CallableTransactionSql;
       await tx`SELECT set_config('app.agent_session_id', '12345', true)`;
       await tx`SELECT set_config('app.agent_tool', 'tb.scaffold', true)`;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'tracked', 1)`;
@@ -152,8 +153,8 @@ describeWithDb("full_audit_log trigger (migration 0204 / QUA-442)", () => {
   });
 
   it("skips audit rows when app.audit_skip = 'true'", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
-    await sqlConn.begin(async (tx: any) => {
+    await sqlConn.begin(async (rawTx) => {
+      const tx = rawTx as unknown as CallableTransactionSql;
       await tx`SELECT set_config('app.audit_skip', 'true', true)`;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'silent', 1)`;
       await tx`UPDATE audit_test_widgets SET qty = 2 WHERE id = 'w1'`;
@@ -164,8 +165,8 @@ describeWithDb("full_audit_log trigger (migration 0204 / QUA-442)", () => {
   });
 
   it("groups multi-row writes in one transaction under a single txn_id", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
-    await sqlConn.begin(async (tx: any) => {
+    await sqlConn.begin(async (rawTx) => {
+      const tx = rawTx as unknown as CallableTransactionSql;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('a', 'x', 1)`;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('b', 'y', 2)`;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('c', 'z', 3)`;
@@ -201,8 +202,8 @@ describeWithDb("full_audit_log trigger (migration 0204 / QUA-442)", () => {
   });
 
   it("treats empty-string GUCs as NULL in the audit row", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- postgres.js `TransactionSql` drops the tagged-template call signature via `Omit<>`; see db.ts::beginTransaction for the production workaround. Tests only need the runtime callable.
-    await sqlConn.begin(async (tx: any) => {
+    await sqlConn.begin(async (rawTx) => {
+      const tx = rawTx as unknown as CallableTransactionSql;
       await tx`SELECT set_config('app.agent_session_id', '', true)`;
       await tx`SELECT set_config('app.agent_tool', '', true)`;
       await tx`INSERT INTO audit_test_widgets (id, name, qty) VALUES ('w1', 'empty', 1)`;

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -7,6 +7,7 @@ import {
   rateLimitMiddleware,
   createDefaultRateLimiters,
 } from "./rate-limit.js";
+import { auditContextMiddleware } from "./middleware/audit-context.js";
 // TableBase routes — typed relational entity records
 // Most routes are mounted automatically via TABLEBASE_MOUNTS (QUA-454).
 // The 5 imports below are the ones mounted manually in this file because
@@ -64,6 +65,7 @@ import { qaChecksRoute } from "./routes/operational/qa-checks.js";
 import { dataQualityRoute } from "./routes/operational/data-quality.js";
 import { thingsSearchRefreshRoute } from "./routes/operational/things-search-refresh.js";
 import { operationsLogRoute } from "./routes/operational/operations-log.js";
+import { auditLogRoute } from "./routes/operational/audit-log.js";
 
 let requestCounter = 0;
 
@@ -166,6 +168,13 @@ export function createApp() {
   // API routes — all require a valid API key
   app.use("/api/*", validateApiKey());
 
+  // Audit-context middleware (QUA-442). Reads X-Agent-Session-Id and
+  // X-Agent-Tool from authenticated API requests and stashes them on the
+  // Hono context for `applyAuditContext(tx, c)` to pick up. No DB
+  // interaction here — all SET LOCAL happens inside the route's
+  // transaction.
+  app.use("/api/*", auditContextMiddleware());
+
   // ── Route mounting ───────────────────────────────────────────────────
   // Routes are grouped by which data layer ("Base") they primarily serve.
   // See content/docs/internal/data-architecture.mdx for the Three Bases guide.
@@ -241,6 +250,7 @@ export function createApp() {
   app.route("/api/data-quality", dataQualityRoute);
   app.route("/api/things-search", thingsSearchRefreshRoute);
   app.route("/api/operations-log", operationsLogRoute);
+  app.route("/api/audit-log", auditLogRoute);
 
   return app;
 }

--- a/apps/wiki-server/src/middleware/audit-context.ts
+++ b/apps/wiki-server/src/middleware/audit-context.ts
@@ -1,0 +1,115 @@
+/**
+ * Audit-context middleware + transaction helper (QUA-442).
+ *
+ * Two parts:
+ *
+ * 1. `auditContextMiddleware()` — Hono middleware that reads
+ *    `X-Agent-Session-Id` and `X-Agent-Tool` headers and stashes the
+ *    values on `c.set('auditContext', ...)`.
+ *
+ * 2. `applyAuditContext(tx, c)` — call at the top of every transaction
+ *    callback. Runs `SET LOCAL app.agent_session_id = ... / app.agent_tool
+ *    = ...` so the universal audit trigger (migration 0204) captures
+ *    session + tool attribution for every row written in the transaction.
+ *
+ * The sync-factory wires this automatically; hand-rolled routes need an
+ * explicit call. See `.claude/rules/audit-log.md`.
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type * as schema from "../schema.js";
+
+export interface AuditContext {
+  sessionId: string | null;
+  tool: string | null;
+}
+
+// Header name constants shipped to the crux client so both sides stay in sync.
+export const AUDIT_SESSION_HEADER = "x-agent-session-id";
+export const AUDIT_TOOL_HEADER = "x-agent-tool";
+
+// Loose upper bound to keep a malicious or truncated client from filling
+// the audit log with giant GUC strings. Real session IDs are short numeric
+// strings and tool names are short slugs; 256 chars is ample.
+const MAX_ATTR_LEN = 256;
+
+function sanitizeAttr(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > MAX_ATTR_LEN) return trimmed.slice(0, MAX_ATTR_LEN);
+  return trimmed;
+}
+
+export function auditContextMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const ctx: AuditContext = {
+      sessionId: sanitizeAttr(c.req.header(AUDIT_SESSION_HEADER)),
+      tool: sanitizeAttr(c.req.header(AUDIT_TOOL_HEADER)),
+    };
+    c.set("auditContext", ctx);
+    await next();
+  };
+}
+
+export function getAuditContext(c: Context): AuditContext {
+  const ctx = c.get("auditContext") as AuditContext | undefined;
+  return ctx ?? { sessionId: null, tool: null };
+}
+
+type DrizzleTx = PgTransaction<
+  PostgresJsQueryResultHKT,
+  typeof schema,
+  ExtractTablesWithRelations<typeof schema>
+>;
+
+/**
+ * Apply the request's audit context to the current Drizzle transaction.
+ *
+ * `SET LOCAL` is scoped to the transaction — values reset on COMMIT/ROLLBACK,
+ * so no leakage between requests sharing a pooled connection.
+ *
+ * `set_config(..., true)` is used instead of a bare `SET LOCAL` because
+ * Drizzle's `tx.execute(sql...)` is a single parametrized statement; the
+ * builtin `set_config(name, value, is_local)` function accepts parameterized
+ * values, whereas `SET LOCAL` requires literal identifiers / string
+ * constants and would force unsafe string concatenation.
+ *
+ * Null-or-empty attribution is written as empty strings; the trigger
+ * function treats '' as NULL so recording still works and `IS NULL`
+ * filters behave predictably.
+ */
+export async function applyAuditContext(
+  tx: DrizzleTx,
+  c: Context,
+): Promise<void> {
+  const ctx = getAuditContext(c);
+  // Two calls instead of one; Postgres doesn't have a set_many primitive and
+  // merging into a single SELECT is no cheaper.
+  await tx.execute(
+    sql`SELECT set_config('app.agent_session_id', ${ctx.sessionId ?? ""}, true)`,
+  );
+  await tx.execute(
+    sql`SELECT set_config('app.agent_tool', ${ctx.tool ?? ""}, true)`,
+  );
+}
+
+/**
+ * Convenience for non-Hono callers (background jobs, tests) that want to
+ * seed the audit attribution without a Context object.
+ */
+export async function setAuditContextRaw(
+  tx: DrizzleTx,
+  ctx: AuditContext,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT set_config('app.agent_session_id', ${ctx.sessionId ?? ""}, true)`,
+  );
+  await tx.execute(
+    sql`SELECT set_config('app.agent_tool', ${ctx.tool ?? ""}, true)`,
+  );
+}

--- a/apps/wiki-server/src/middleware/audit-context.ts
+++ b/apps/wiki-server/src/middleware/audit-context.ts
@@ -82,34 +82,29 @@ type DrizzleTx = PgTransaction<
  * Null-or-empty attribution is written as empty strings; the trigger
  * function treats '' as NULL so recording still works and `IS NULL`
  * filters behave predictably.
+ *
+ * Both `set_config` calls are issued in a single SELECT to save a
+ * round-trip per transaction.
  */
 export async function applyAuditContext(
   tx: DrizzleTx,
   c: Context,
 ): Promise<void> {
   const ctx = getAuditContext(c);
-  // Two calls instead of one; Postgres doesn't have a set_many primitive and
-  // merging into a single SELECT is no cheaper.
-  await tx.execute(
-    sql`SELECT set_config('app.agent_session_id', ${ctx.sessionId ?? ""}, true)`,
-  );
-  await tx.execute(
-    sql`SELECT set_config('app.agent_tool', ${ctx.tool ?? ""}, true)`,
-  );
+  await applyAuditContextValues(tx, ctx);
 }
 
 /**
- * Convenience for non-Hono callers (background jobs, tests) that want to
- * seed the audit attribution without a Context object.
+ * Lower-level variant: apply a raw `AuditContext` to the transaction.
+ * Useful for non-Hono callers (background jobs, tests, cron) that don't
+ * have a `Context` but still want to seed attribution.
  */
-export async function setAuditContextRaw(
+export async function applyAuditContextValues(
   tx: DrizzleTx,
   ctx: AuditContext,
 ): Promise<void> {
   await tx.execute(
-    sql`SELECT set_config('app.agent_session_id', ${ctx.sessionId ?? ""}, true)`,
-  );
-  await tx.execute(
-    sql`SELECT set_config('app.agent_tool', ${ctx.tool ?? ""}, true)`,
+    sql`SELECT set_config('app.agent_session_id', ${ctx.sessionId ?? ""}, true),
+               set_config('app.agent_tool', ${ctx.tool ?? ""}, true)`,
   );
 }

--- a/apps/wiki-server/src/routes/operational/audit-log.ts
+++ b/apps/wiki-server/src/routes/operational/audit-log.ts
@@ -1,0 +1,83 @@
+/**
+ * Universal audit log API (QUA-442).
+ *
+ * Reads from the `full_audit_log` table (populated by the `audit_trigger_fn()`
+ * PL/pgSQL trigger). Filters by table, session, txn_id, and time window.
+ * Complements the existing `tablebase_audit_log` (which lives at
+ * `/api/tablebase/audit-log` if and when we ship a route for it).
+ */
+
+import { Hono } from "hono";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { fullAuditLog } from "../../schema.js";
+import { zv, clampedLimit } from "../shared/utils.js";
+import { z } from "zod";
+
+// Schema accepts the primary filter axes. Callers should pass at least one
+// of `table`, `session`, or `txn` — passing none returns recent writes
+// across all tables, which is useful for ops dashboards but clamped hard.
+const ListQuery = z.object({
+  table: z.string().trim().min(1).max(128).optional(),
+  session: z.string().trim().min(1).max(256).optional(),
+  // bigint serialized as string to avoid JSON-number precision loss.
+  txn: z
+    .string()
+    .trim()
+    .regex(/^\d+$/)
+    .optional(),
+  since: z.string().datetime({ offset: true }).optional(),
+  limit: clampedLimit(500, 50),
+});
+
+const auditLogApp = new Hono().get(
+  "/recent",
+  zv("query", ListQuery),
+  async (c) => {
+    const db = getDrizzleDb();
+    const q = c.req.valid("query");
+
+    const conditions = [];
+    if (q.table) {
+      conditions.push(eq(fullAuditLog.tableName, q.table));
+    }
+    if (q.session) {
+      conditions.push(eq(fullAuditLog.sessionId, q.session));
+    }
+    if (q.txn) {
+      // Drizzle's bigint column expects a bigint-typed value.
+      conditions.push(eq(fullAuditLog.txnId, BigInt(q.txn)));
+    }
+    if (q.since) {
+      conditions.push(gte(fullAuditLog.changedAt, new Date(q.since)));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Serialize bigints as strings in the wire format. Drizzle returns
+    // `id` / `txnId` as JS bigints (see schema.ts: mode: "bigint"), and
+    // JSON.stringify would throw.
+    const rows = await db
+      .select({
+        id: sql<string>`${fullAuditLog.id}::text`,
+        tableName: fullAuditLog.tableName,
+        operation: fullAuditLog.operation,
+        oldRow: fullAuditLog.oldRow,
+        newRow: fullAuditLog.newRow,
+        txnId: sql<string | null>`${fullAuditLog.txnId}::text`,
+        sessionId: fullAuditLog.sessionId,
+        tool: fullAuditLog.tool,
+        applicationName: fullAuditLog.applicationName,
+        changedAt: fullAuditLog.changedAt,
+      })
+      .from(fullAuditLog)
+      .where(whereClause)
+      .orderBy(desc(fullAuditLog.changedAt))
+      .limit(q.limit);
+
+    return c.json({ entries: rows });
+  },
+);
+
+export const auditLogRoute = auditLogApp;
+export type AuditLogRoute = typeof auditLogApp;

--- a/apps/wiki-server/src/routes/tablebase/audit-log.ts
+++ b/apps/wiki-server/src/routes/tablebase/audit-log.ts
@@ -53,20 +53,15 @@ export async function logAuditEntries(
   // request set one via `SET LOCAL app.agent_session_id` (middleware +
   // applyAuditContext), pull it from the GUC so the existing rich
   // audit log gets session attribution too. Runs once per call, not
-  // per-row. Empty / unset GUC comes back as an empty string; treat
-  // that as NULL.
-  let gucSession: string | null = null;
-  try {
-    const [row] = (await tx.execute(
-      sql`SELECT current_setting('app.agent_session_id', true) AS session_id`,
-    )) as unknown as Array<{ session_id: string | null }>;
-    const raw = row?.session_id ?? null;
-    gucSession = raw && raw.length > 0 ? raw : null;
-  } catch {
-    // Fail-open: audit attribution is best-effort. If this tx doesn't support
-    // current_setting for any reason, fall back to NULL.
-    gucSession = null;
-  }
+  // per-row. `current_setting(..., true)` with missing_ok=true never
+  // throws for an unset GUC — it returns an empty string — so no
+  // defensive try/catch is needed; a thrown error would mean the tx
+  // is already doomed and the subsequent INSERT would fail anyway.
+  const [gucRow] = (await tx.execute(
+    sql`SELECT current_setting('app.agent_session_id', true) AS session_id`,
+  )) as unknown as Array<{ session_id: string | null }>;
+  const rawSession = gucRow?.session_id ?? null;
+  const gucSession = rawSession && rawSession.length > 0 ? rawSession : null;
 
   await tx.insert(tablebaseAuditLog).values(
     entries.map((e) => ({

--- a/apps/wiki-server/src/routes/tablebase/audit-log.ts
+++ b/apps/wiki-server/src/routes/tablebase/audit-log.ts
@@ -59,7 +59,7 @@ export async function logAuditEntries(
   // is already doomed and the subsequent INSERT would fail anyway.
   const [gucRow] = (await tx.execute(
     sql`SELECT current_setting('app.agent_session_id', true) AS session_id`,
-  )) as unknown as Array<{ session_id: string | null }>;
+  )) as unknown as Array<{ session_id: string | null }>; // as-any-ok: Drizzle's tx.execute returns an untyped row array for raw SQL; narrowing to the known one-column shape is the pattern used elsewhere for current_setting reads.
   const rawSession = gucRow?.session_id ?? null;
   const gucSession = rawSession && rawSession.length > 0 ? rawSession : null;
 

--- a/apps/wiki-server/src/routes/tablebase/audit-log.ts
+++ b/apps/wiki-server/src/routes/tablebase/audit-log.ts
@@ -8,6 +8,7 @@
 import type { PgTransaction } from "drizzle-orm/pg-core";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
 import type { ExtractTablesWithRelations } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type * as schema from "../../schema.js";
 import { tablebaseAuditLog } from "../../schema.js";
 
@@ -48,6 +49,25 @@ export async function logAuditEntries(
 ): Promise<void> {
   if (entries.length === 0) return;
 
+  // QUA-442: if the caller didn't pass an agent_session_id but the
+  // request set one via `SET LOCAL app.agent_session_id` (middleware +
+  // applyAuditContext), pull it from the GUC so the existing rich
+  // audit log gets session attribution too. Runs once per call, not
+  // per-row. Empty / unset GUC comes back as an empty string; treat
+  // that as NULL.
+  let gucSession: string | null = null;
+  try {
+    const [row] = (await tx.execute(
+      sql`SELECT current_setting('app.agent_session_id', true) AS session_id`,
+    )) as unknown as Array<{ session_id: string | null }>;
+    const raw = row?.session_id ?? null;
+    gucSession = raw && raw.length > 0 ? raw : null;
+  } catch {
+    // Fail-open: audit attribution is best-effort. If this tx doesn't support
+    // current_setting for any reason, fall back to NULL.
+    gucSession = null;
+  }
+
   await tx.insert(tablebaseAuditLog).values(
     entries.map((e) => ({
       recordType: e.recordType,
@@ -58,7 +78,7 @@ export async function logAuditEntries(
       sourceUrl: e.sourceUrl ?? null,
       verdict: e.verdict ?? null,
       evidence: e.evidence ?? null,
-      agentSessionId: e.agentSessionId ?? null,
+      agentSessionId: e.agentSessionId ?? gucSession,
       prNumber: e.prNumber ?? null,
     }))
   );

--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -17,6 +17,7 @@ import { sourceSnapshots, resources, resourceTabularSources } from "../../schema
 import { paginationQuery, zv, notFoundError } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { validateEntityRefs } from "../shared/validate-entity-refs.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
 import { generateId } from "@longterm-wiki/factbase";
 
 // ---- Zod schemas ----
@@ -245,6 +246,8 @@ const dataSourcesApp = new Hono()
     let actualStableId = "";
 
     await db.transaction(async (tx) => {
+      // Audit-log attribution (QUA-442).
+      await applyAuditContext(tx, c);
       // Upsert resource row. ON CONFLICT on URL handles the case where
       // a resource was created by resource-ingest with a different ID scheme.
       const [upsertedResource] = await tx

--- a/apps/wiki-server/src/routes/tablebase/data-sources.ts
+++ b/apps/wiki-server/src/routes/tablebase/data-sources.ts
@@ -246,7 +246,6 @@ const dataSourcesApp = new Hono()
     let actualStableId = "";
 
     await db.transaction(async (tx) => {
-      // Audit-log attribution (QUA-442).
       await applyAuditContext(tx, c);
       // Upsert resource row. ON CONFLICT on URL handles the case where
       // a resource was created by resource-ingest with a different ID scheme.

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -21,6 +21,7 @@ import {
   SyncEntitiesBatchSchema,
 } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
 import {
   buildSearchCondition,
   buildTsvectorSearchCondition,
@@ -988,6 +989,8 @@ const entitiesApp = new Hono()
         // Increase statement_timeout for bulk sync — default 30s is too tight
         // for batches of 100 entities with FK cascade checks on referencing tables.
         await tx.execute(sql`SET LOCAL statement_timeout = '120000'`); // 2 min
+        // Audit-log attribution (QUA-442). Scoped to this transaction.
+        await applyAuditContext(tx, c);
         const allVals = items.map((e) => ({
           id: e.id,
           wikiId: e.wikiId ?? null,
@@ -1164,6 +1167,8 @@ const entitiesApp = new Hono()
 
       try {
         await db.transaction(async (tx) => {
+          // Audit-log attribution (QUA-442).
+          await applyAuditContext(tx, c);
           // Delete from things table first (references entities via source_id)
           await tx
             .delete(things)

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -989,7 +989,6 @@ const entitiesApp = new Hono()
         // Increase statement_timeout for bulk sync — default 30s is too tight
         // for batches of 100 entities with FK cascade checks on referencing tables.
         await tx.execute(sql`SET LOCAL statement_timeout = '120000'`); // 2 min
-        // Audit-log attribution (QUA-442). Scoped to this transaction.
         await applyAuditContext(tx, c);
         const allVals = items.map((e) => ({
           id: e.id,
@@ -1167,7 +1166,6 @@ const entitiesApp = new Hono()
 
       try {
         await db.transaction(async (tx) => {
-          // Audit-log attribution (QUA-442).
           await applyAuditContext(tx, c);
           // Delete from things table first (references entities via source_id)
           await tx

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -579,9 +579,6 @@ export function createSyncHandler<
       config.conflictSet ?? deriveConflictSet(table, allVals[0] ?? {});
 
     await db.transaction(async (tx) => {
-      // Seed universal-audit-log attribution (QUA-442) — `SET LOCAL` GUCs
-      // that the `audit_trigger_fn()` trigger reads. Scoped to this
-      // transaction; auto-resets on COMMIT/ROLLBACK.
       await applyAuditContext(tx, c);
 
       // ---- Phase 3: upsert (chunked) + Phase 4: audit ----

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -59,6 +59,7 @@ import {
   type ThingSyncInput,
 } from "../shared/thing-sync.js";
 import { logAuditEntries } from "./audit-log.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
 import {
   writeInlineVerdicts,
   logSourcingCoverage,
@@ -578,6 +579,11 @@ export function createSyncHandler<
       config.conflictSet ?? deriveConflictSet(table, allVals[0] ?? {});
 
     await db.transaction(async (tx) => {
+      // Seed universal-audit-log attribution (QUA-442) — `SET LOCAL` GUCs
+      // that the `audit_trigger_fn()` trigger reads. Scoped to this
+      // transaction; auto-resets on COMMIT/ROLLBACK.
+      await applyAuditContext(tx, c);
+
       // ---- Phase 3: upsert (chunked) + Phase 4: audit ----
       for (let offset = 0; offset < allVals.length; offset += chunkSize) {
         const chunk = allVals.slice(offset, offset + chunkSize);

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -496,7 +496,6 @@ const resourcesApp = new Hono()
     let results: Array<{ id: string; url: string }> = [];
     try {
       await db.transaction(async (tx) => {
-        // Audit-log attribution (QUA-442).
         await applyAuditContext(tx, c);
         // Pre-resolve all citedBy page IDs in one batch query
         const allCitedByIds = [...new Set(items.flatMap((item) => item.citedBy ?? []))];

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -50,6 +50,7 @@ import {
 } from "../../api-types.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
 import { resolveResourceIds } from "../shared/resolve-resource-id.js";
 import { urlVariants } from "../shared/url-variants.js";
 import { generateId } from "@longterm-wiki/factbase";
@@ -495,6 +496,8 @@ const resourcesApp = new Hono()
     let results: Array<{ id: string; url: string }> = [];
     try {
       await db.transaction(async (tx) => {
+        // Audit-log attribution (QUA-442).
+        await applyAuditContext(tx, c);
         // Pre-resolve all citedBy page IDs in one batch query
         const allCitedByIds = [...new Set(items.flatMap((item) => item.citedBy ?? []))];
         const intIdMap = allCitedByIds.length > 0

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1875,6 +1875,7 @@ export const fullAuditLog = pgTable(
     ),
     index("idx_full_audit_log_session").on(table.sessionId),
     index("idx_full_audit_log_txn").on(table.txnId),
+    index("idx_full_audit_log_changed_at").on(table.changedAt),
   ],
 );
 

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1857,7 +1857,7 @@ export const fullAuditLog = pgTable(
   {
     id: bigserial("id", { mode: "bigint" }).primaryKey(),
     tableName: text("table_name").notNull(),
-    operation: text("operation").notNull(), // INSERT / UPDATE / DELETE
+    operation: text("operation").$type<"INSERT" | "UPDATE" | "DELETE">().notNull(),
     oldRow: jsonb("old_row"),
     newRow: jsonb("new_row"),
     txnId: bigint("txn_id", { mode: "bigint" }),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1839,6 +1839,46 @@ export const sourcingUrlSuggestions = pgTable(
 );
 
 /**
+ * Universal PG audit log (QUA-442).
+ *
+ * Written by the `audit_trigger_fn()` PL/pgSQL trigger attached to every
+ * non-excluded table. Captures every INSERT/UPDATE/DELETE with full before
+ * and after JSONB, plus session attribution pulled from `SET LOCAL`
+ * GUCs (`app.agent_session_id`, `app.agent_tool`).
+ *
+ * This is the comprehensive floor; `tablebase_audit_log` (below) stays as
+ * the richer application-layer log for TableBase sync handlers that want
+ * verdict/source-URL/evidence attribution.
+ *
+ * Migration: 0204_qua_442_audit_log_universal_trigger.sql
+ */
+export const fullAuditLog = pgTable(
+  "full_audit_log",
+  {
+    id: bigserial("id", { mode: "bigint" }).primaryKey(),
+    tableName: text("table_name").notNull(),
+    operation: text("operation").notNull(), // INSERT / UPDATE / DELETE
+    oldRow: jsonb("old_row"),
+    newRow: jsonb("new_row"),
+    txnId: bigint("txn_id", { mode: "bigint" }),
+    sessionId: text("session_id"),
+    tool: text("tool"),
+    applicationName: text("application_name"),
+    changedAt: timestamp("changed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_full_audit_log_table_time").on(
+      table.tableName,
+      table.changedAt,
+    ),
+    index("idx_full_audit_log_session").on(table.sessionId),
+    index("idx_full_audit_log_txn").on(table.txnId),
+  ],
+);
+
+/**
  * Audit log for TableBase changes — records every insert/update/delete
  * to PG-primary tables (personnel, grants, funding_rounds, etc.).
  * Provides git-like change history for data that bypasses git.

--- a/crux/commands/audit.ts
+++ b/crux/commands/audit.ts
@@ -1,0 +1,165 @@
+/**
+ * Audit Command Handlers — universal PG audit log (QUA-442)
+ *
+ * Usage:
+ *   crux audit recent [--table=T] [--session=S] [--txn=N] [--since=ISO] [--limit=N]
+ *     Print the most recent audit entries. Filters compose (AND).
+ *   crux audit recent --json
+ *     Emit newline-delimited JSON for scripting.
+ *
+ * Data source: `full_audit_log` in PG, written by the `audit_trigger_fn()`
+ * trigger. Every write to an allow-listed table creates one row here with
+ * before/after JSONB plus session+tool attribution.
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import {
+  listRecentAuditEntries,
+  type AuditRecentResponse,
+} from '../lib/wiki-server/audit-log.ts';
+
+interface CommandOptions extends BaseOptions {
+  ci?: boolean;
+  json?: boolean;
+  table?: string;
+  session?: string;
+  txn?: string;
+  since?: string;
+  limit?: string;
+}
+
+type AuditEntry = AuditRecentResponse['entries'][number];
+
+function parseLimit(raw: string | undefined, fallback: number, max: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+function formatChangedAt(value: AuditEntry['changedAt']): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return d.toISOString().slice(0, 19).replace('T', ' ') + 'Z';
+}
+
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, max - 1) + '…';
+}
+
+function summarizeRow(row: Record<string, unknown> | null | undefined): string {
+  if (!row) return '';
+  const id = row.id ?? row.stable_id ?? row.stableId ?? null;
+  const title =
+    row.title ?? row.name ?? row.display_name ?? row.displayName ?? null;
+  const parts: string[] = [];
+  if (id !== null && id !== undefined) parts.push(`id=${String(id)}`);
+  if (title !== null && title !== undefined) parts.push(`title=${truncate(String(title), 40)}`);
+  if (parts.length === 0) {
+    // Fall back to a short key list so callers know something is there.
+    const keys = Object.keys(row).slice(0, 4).join(',');
+    return keys ? `{${keys}…}` : '';
+  }
+  return parts.join(' ');
+}
+
+async function recent(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const limit = parseLimit(options.limit, 50, 500);
+
+  const result = await listRecentAuditEntries({
+    table: options.table,
+    session: options.session,
+    txn: options.txn,
+    since: options.since,
+    limit,
+  });
+
+  if (!result.ok) {
+    const message =
+      result.error === 'unavailable'
+        ? `wiki-server unavailable: ${result.message}`
+        : `audit log request failed: ${result.message}`;
+    return { output: message, exitCode: 1 };
+  }
+
+  const { entries } = result.data;
+
+  if (options.json) {
+    const lines = entries.map((e) => JSON.stringify(e));
+    return { output: lines.join('\n'), exitCode: 0 };
+  }
+
+  if (entries.length === 0) {
+    return {
+      output: 'No audit entries match the given filters.',
+      exitCode: 0,
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} (filters: ${describeFilters(options)})`,
+  );
+  for (const e of entries) {
+    const when = formatChangedAt(e.changedAt);
+    const attr = [
+      e.sessionId ? `session=${e.sessionId}` : null,
+      e.tool ? `tool=${e.tool}` : null,
+      e.txnId ? `txn=${e.txnId}` : null,
+    ]
+      .filter((v): v is string => Boolean(v))
+      .join(' ');
+    const summary =
+      e.operation === 'DELETE'
+        ? summarizeRow(e.oldRow as Record<string, unknown> | null)
+        : summarizeRow(e.newRow as Record<string, unknown> | null);
+    lines.push(
+      `  ${when}  ${e.operation.padEnd(6)} ${e.tableName.padEnd(28)}  ${summary}${attr ? `  [${attr}]` : ''}`,
+    );
+  }
+  return { output: lines.join('\n'), exitCode: 0 };
+}
+
+function describeFilters(options: CommandOptions): string {
+  const parts: string[] = [];
+  if (options.table) parts.push(`table=${options.table}`);
+  if (options.session) parts.push(`session=${options.session}`);
+  if (options.txn) parts.push(`txn=${options.txn}`);
+  if (options.since) parts.push(`since=${options.since}`);
+  parts.push(`limit=${parseLimit(options.limit, 50, 500)}`);
+  return parts.join(' ');
+}
+
+export const commands = {
+  default: recent,
+  recent,
+};
+
+export function getHelp(): string {
+  return `
+Audit Domain - Universal PG audit log (QUA-442)
+
+Commands:
+  recent                    Show recent audit entries (default)
+
+Options:
+  --table=T        Filter by table name (e.g. --table=personnel)
+  --session=S      Filter by agent session ID
+  --txn=N          Filter by PostgreSQL transaction id
+  --since=ISO      Only entries newer than this ISO timestamp (e.g. 2026-04-10T00:00:00Z)
+  --limit=N        Maximum number of entries to return (default: 50, max: 500)
+  --json           Output one JSON object per entry (newline-delimited)
+
+Examples:
+  crux audit recent                                   50 most recent entries across all tables
+  crux audit recent --table=personnel --limit=100     recent personnel writes
+  crux audit recent --session=12345                    all writes from one session
+  crux audit recent --txn=98765                        all rows changed in one transaction
+  crux audit recent --since=2026-04-20T00:00:00Z --table=grants --json
+
+Data lives in the PG \`full_audit_log\` table. Every allow-listed table
+has an AFTER INSERT/UPDATE/DELETE trigger (\`zz_audit_trigger\`) that
+writes a row here with before/after JSONB + session attribution.
+`.trim();
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -131,6 +131,8 @@ import * as linearCommands from './commands/linear.ts';
 import * as flagshipCurateCommands from './commands/flagship-curate.ts';
 import * as sessionFinalizeCommands from './commands/session-finalize.ts';
 import * as dispatchCommands from './commands/dispatch.ts';
+import * as auditCommands from './commands/audit.ts';
+import { primeAuditSessionId } from './lib/wiki-server/audit-context.ts';
 
 const domains = {
   validate: validateCommands,
@@ -226,6 +228,7 @@ const domains = {
   'flagship-curate': flagshipCurateCommands,
   'session-finalize': sessionFinalizeCommands,
   dispatch: dispatchCommands,
+  audit: auditCommands,
 };
 
 const shortcutMap = buildShortcutMap();
@@ -483,6 +486,20 @@ async function main() {
     }
     process.exit(1);
   }
+
+  // Publish the current crux command so client.ts can stamp
+  // X-Agent-Tool on every wiki-server request (QUA-442). Set before
+  // the audit-session-id priming so both headers are ready by the
+  // time the command issues its first request.
+  if (!process.env.CRUX_COMMAND) {
+    process.env.CRUX_COMMAND = `${domain} ${commandName}`.trim();
+  }
+
+  // Prime the X-Agent-Session-Id cache (best-effort, never blocks on
+  // errors). Fire-and-forget into a bounded promise; individual
+  // commands that hit the server right away will await the same
+  // promise via the internal cache guard.
+  primeAuditSessionId().catch(() => {});
 
   // Run the command
   try {

--- a/crux/lib/wiki-server/audit-context.test.ts
+++ b/crux/lib/wiki-server/audit-context.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests — crux-side audit-context cache (QUA-442).
+ *
+ * Covers getCruxToolName() env handling and the cache semantics of
+ * primeAuditSessionId() / getCachedAuditSessionId(). We don't hit the
+ * wiki-server here — priming is a best-effort call that can return
+ * without contacting the server when required env vars are missing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getCachedAuditSessionId,
+  getCruxToolName,
+  primeAuditSessionId,
+  _resetAuditContextForTesting,
+  _setAuditContextForTesting,
+} from './audit-context.ts';
+
+describe('getCruxToolName', () => {
+  const originalCrux = process.env.CRUX_COMMAND;
+
+  afterEach(() => {
+    if (originalCrux === undefined) {
+      delete process.env.CRUX_COMMAND;
+    } else {
+      process.env.CRUX_COMMAND = originalCrux;
+    }
+  });
+
+  it('returns the trimmed CRUX_COMMAND env var when set', () => {
+    process.env.CRUX_COMMAND = '  tb scaffold ';
+    expect(getCruxToolName()).toBe('tb scaffold');
+  });
+
+  it('returns null when CRUX_COMMAND is unset', () => {
+    delete process.env.CRUX_COMMAND;
+    expect(getCruxToolName()).toBeNull();
+  });
+
+  it('returns null when CRUX_COMMAND is empty or whitespace-only', () => {
+    process.env.CRUX_COMMAND = '   ';
+    expect(getCruxToolName()).toBeNull();
+  });
+});
+
+describe('audit-session cache', () => {
+  const originalUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const originalProdUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  const originalEnvId = process.env.LW_AGENT_SESSION_ID;
+
+  beforeEach(() => {
+    _resetAuditContextForTesting();
+  });
+
+  afterEach(() => {
+    _resetAuditContextForTesting();
+    if (originalUrl === undefined) delete process.env.LONGTERMWIKI_SERVER_URL;
+    else process.env.LONGTERMWIKI_SERVER_URL = originalUrl;
+    if (originalProdUrl === undefined) delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    else process.env.PROD_LONGTERMWIKI_SERVER_URL = originalProdUrl;
+    if (originalEnvId === undefined) delete process.env.LW_AGENT_SESSION_ID;
+    else process.env.LW_AGENT_SESSION_ID = originalEnvId;
+  });
+
+  it('returns null before priming', () => {
+    expect(getCachedAuditSessionId()).toBeNull();
+  });
+
+  it('prefers LW_AGENT_SESSION_ID env var when set', async () => {
+    process.env.LW_AGENT_SESSION_ID = 'env-override-123';
+    // Forcing no wiki-server URLs so the DB lookup branch would be skipped
+    // anyway; the env var is resolved before the URL check.
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    await primeAuditSessionId();
+    expect(getCachedAuditSessionId()).toBe('env-override-123');
+  });
+
+  it('leaves the cache at null when no server URL is configured', async () => {
+    delete process.env.LW_AGENT_SESSION_ID;
+    delete process.env.LONGTERMWIKI_SERVER_URL;
+    delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    await primeAuditSessionId();
+    expect(getCachedAuditSessionId()).toBeNull();
+  });
+
+  it('priming is a no-op on the second call (cache-first)', async () => {
+    _setAuditContextForTesting('first-value');
+    await primeAuditSessionId();
+    expect(getCachedAuditSessionId()).toBe('first-value');
+  });
+
+  it('_setAuditContextForTesting + _resetAuditContextForTesting work as documented', () => {
+    _setAuditContextForTesting('seeded');
+    expect(getCachedAuditSessionId()).toBe('seeded');
+    _resetAuditContextForTesting();
+    expect(getCachedAuditSessionId()).toBeNull();
+  });
+});

--- a/crux/lib/wiki-server/audit-context.ts
+++ b/crux/lib/wiki-server/audit-context.ts
@@ -1,0 +1,113 @@
+/**
+ * Audit-context — client-side complement to the wiki-server universal
+ * audit log (QUA-442).
+ *
+ * Provides the X-Agent-Session-Id / X-Agent-Tool values that
+ * `buildHeaders()` stamps on every crux→wiki-server request. The server
+ * picks these up in `auditContextMiddleware` and propagates them to the
+ * trigger via `SET LOCAL app.agent_session_id / app.agent_tool`.
+ *
+ * The session id is looked up once per process via
+ * `primeAuditSessionId()` (called from crux.mjs). `getCachedAuditSessionId()`
+ * is synchronous so `buildHeaders()` can read it without awaiting anything.
+ *
+ * The tool name is the current crux command (e.g. `tb.scaffold`,
+ * `sourcing.recheck`) and is published via `process.env.CRUX_COMMAND`.
+ * Set by `crux.mjs::main()` once the command has been parsed.
+ *
+ * Priming is best-effort — if the wiki-server is unreachable or no
+ * agent session exists for the current branch, the cache is left as
+ * null and the audit row will simply record `session_id = NULL`. This
+ * never blocks the crux command from running.
+ */
+
+import { currentBranch } from '../git.ts';
+import { getAgentSessionByBranch } from './agent-sessions.ts';
+
+// `undefined` = not yet attempted, `null` = attempted and no value found
+// (so `buildHeaders()` doesn't retry on every request), `string` = value
+// available to ship as X-Agent-Session-Id.
+let cachedSessionId: string | null | undefined = undefined;
+let priming: Promise<void> | null = null;
+
+/**
+ * Attempt to prime the audit session id once for this crux process.
+ * Returns the same Promise on repeat calls so concurrent callers
+ * don't each kick off a lookup.
+ *
+ * Safe to call even when wiki-server is down: any error sets the
+ * cache to null and the function returns normally.
+ */
+export function primeAuditSessionId(): Promise<void> {
+  if (cachedSessionId !== undefined) return Promise.resolve();
+  if (priming) return priming;
+
+  priming = (async () => {
+    try {
+      const envId = process.env.LW_AGENT_SESSION_ID;
+      if (envId && envId.length > 0) {
+        cachedSessionId = envId;
+        return;
+      }
+
+      // Skip the DB lookup when the CLI hasn't configured a server URL or
+      // API key yet. Commands that don't use the wiki-server (e.g. local
+      // validate) shouldn't pay for the lookup.
+      if (!process.env.LONGTERMWIKI_SERVER_URL && !process.env.PROD_LONGTERMWIKI_SERVER_URL) {
+        cachedSessionId = null;
+        return;
+      }
+
+      let branch: string | null = null;
+      try {
+        branch = currentBranch();
+      } catch {
+        branch = null;
+      }
+      if (!branch) {
+        cachedSessionId = null;
+        return;
+      }
+
+      const result = await getAgentSessionByBranch(branch);
+      if (result.ok && result.data && typeof result.data.id !== 'undefined') {
+        cachedSessionId = String(result.data.id);
+      } else {
+        cachedSessionId = null;
+      }
+    } catch {
+      cachedSessionId = null;
+    } finally {
+      priming = null;
+    }
+  })();
+
+  return priming;
+}
+
+/** Synchronous read of the cached session id. Returns null when unset. */
+export function getCachedAuditSessionId(): string | null {
+  return typeof cachedSessionId === 'string' ? cachedSessionId : null;
+}
+
+/**
+ * The tool name published via `process.env.CRUX_COMMAND` by crux.mjs.
+ * Returns null if unset (e.g. non-crux callers of the client lib).
+ */
+export function getCruxToolName(): string | null {
+  const raw = process.env.CRUX_COMMAND;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Test-only helper: reset the module-level cache. */
+export function _resetAuditContextForTesting(): void {
+  cachedSessionId = undefined;
+  priming = null;
+}
+
+/** Test-only helper: seed the cache to a known value. */
+export function _setAuditContextForTesting(sessionId: string | null): void {
+  cachedSessionId = sessionId;
+}

--- a/crux/lib/wiki-server/audit-context.ts
+++ b/crux/lib/wiki-server/audit-context.ts
@@ -23,6 +23,7 @@
 
 import { currentBranch } from '../git.ts';
 import { getAgentSessionByBranch } from './agent-sessions.ts';
+import { getServerUrl } from './client.ts';
 
 // `undefined` = not yet attempted, `null` = attempted and no value found
 // (so `buildHeaders()` doesn't retry on every request), `string` = value
@@ -50,10 +51,13 @@ export function primeAuditSessionId(): Promise<void> {
         return;
       }
 
-      // Skip the DB lookup when the CLI hasn't configured a server URL or
-      // API key yet. Commands that don't use the wiki-server (e.g. local
-      // validate) shouldn't pay for the lookup.
-      if (!process.env.LONGTERMWIKI_SERVER_URL && !process.env.PROD_LONGTERMWIKI_SERVER_URL) {
+      // Skip the DB lookup when no server URL is configured for the
+      // active env prefix. `getServerUrl()` honors `WIKI_SERVER_ENV` and
+      // the slot auto-detection logic, so e.g. an explicit
+      // `WIKI_SERVER_ENV=local` with only `PROD_*` vars set will
+      // correctly return empty and skip — a raw dual-env-var check
+      // would have tried to prime against the wrong URL.
+      if (!getServerUrl()) {
         cachedSessionId = null;
         return;
       }

--- a/crux/lib/wiki-server/audit-context.ts
+++ b/crux/lib/wiki-server/audit-context.ts
@@ -93,12 +93,17 @@ export function getCachedAuditSessionId(): string | null {
 /**
  * The tool name published via `process.env.CRUX_COMMAND` by crux.mjs.
  * Returns null if unset (e.g. non-crux callers of the client lib).
+ *
+ * Capped at 256 chars to match the server-side header sanitizer. Even
+ * though normal `<domain> <command>` is much shorter, clamp defensively.
  */
+const TOOL_NAME_MAX = 256;
 export function getCruxToolName(): string | null {
   const raw = process.env.CRUX_COMMAND;
   if (!raw) return null;
   const trimmed = raw.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  if (trimmed.length === 0) return null;
+  return trimmed.length > TOOL_NAME_MAX ? trimmed.slice(0, TOOL_NAME_MAX) : trimmed;
 }
 
 /** Test-only helper: reset the module-level cache. */

--- a/crux/lib/wiki-server/audit-log.ts
+++ b/crux/lib/wiki-server/audit-log.ts
@@ -1,0 +1,38 @@
+/**
+ * Audit-log API client (QUA-442). Talks to `/api/audit-log/*` on
+ * wiki-server; served by `apps/wiki-server/src/routes/operational/audit-log.ts`.
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { AuditLogRoute } from '../../../apps/wiki-server/src/routes/operational/audit-log.ts';
+
+type RpcClient = ReturnType<typeof hc<AuditLogRoute>>;
+
+/** Shape returned by GET /recent (200 success). */
+export type AuditRecentResponse = InferResponseType<
+  RpcClient['recent']['$get'],
+  200
+>;
+
+export interface AuditRecentOptions {
+  table?: string;
+  session?: string;
+  txn?: string;
+  since?: string;
+  limit?: number;
+}
+
+export async function listRecentAuditEntries(
+  opts: AuditRecentOptions = {},
+): Promise<ApiResult<AuditRecentResponse>> {
+  const params = new URLSearchParams();
+  if (opts.table) params.set('table', opts.table);
+  if (opts.session) params.set('session', opts.session);
+  if (opts.txn) params.set('txn', opts.txn);
+  if (opts.since) params.set('since', opts.since);
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const qs = params.toString();
+  const path = `/api/audit-log/recent${qs ? `?${qs}` : ''}`;
+  return apiRequest<AuditRecentResponse>('GET', path);
+}

--- a/crux/lib/wiki-server/client.ts
+++ b/crux/lib/wiki-server/client.ts
@@ -18,6 +18,10 @@ import {
   WIKI_SERVER_BATCH_TIMEOUT_MS as BATCH_TIMEOUT_MS,
 } from '../config.ts';
 import { findSlotFromAncestors } from '../session/session-context.ts';
+import {
+  getCachedAuditSessionId,
+  getCruxToolName,
+} from './audit-context.ts';
 export { BATCH_TIMEOUT_MS };
 
 /**
@@ -65,12 +69,29 @@ export function getApiKey(): string {
 
 /**
  * Build HTTP headers with the API key for wiki-server requests.
+ *
+ * Also stamps QUA-442 audit-attribution headers when known:
+ *   - `X-Agent-Session-Id`: the current agent-checklist session id, if
+ *     primed by `primeAuditSessionId()` (called from crux.mjs).
+ *   - `X-Agent-Tool`: the current crux subcommand
+ *     (e.g. `tb.scaffold`), set via `process.env.CRUX_COMMAND`.
+ *
+ * Missing values are simply omitted — the server middleware treats absent
+ * headers as unknown attribution, not as an error.
  */
 export function buildHeaders(): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   const apiKey = getApiKey();
   if (apiKey) {
     headers['Authorization'] = `Bearer ${apiKey}`;
+  }
+  const sessionId = getCachedAuditSessionId();
+  if (sessionId) {
+    headers['X-Agent-Session-Id'] = sessionId;
+  }
+  const tool = getCruxToolName();
+  if (tool) {
+    headers['X-Agent-Tool'] = tool;
   }
   return headers;
 }


### PR DESCRIPTION
## Summary

Implements the universal PG audit log (QUA-442), the first ticket in the
data-versioning arm of the QUA-408 data-model unwind.

- **PG-level capture via generic trigger**. Every INSERT/UPDATE/DELETE on
  an allow-listed domain table writes one row to `full_audit_log` with
  before/after state as JSONB and a grouping `txn_id`. ~30-line
  `audit_trigger_fn()` function, `apply_audit_trigger()` / `remove_audit_trigger()`
  helpers. Attached to 28 tables on v1 (TableBase domain + `entities`, `facts`,
  `resources`). Expansion is a one-line migration per table.
- **Session + tool attribution via `SET LOCAL`**. Crux client stamps
  `X-Agent-Session-Id` / `X-Agent-Tool` headers → `auditContextMiddleware`
  reads them → `applyAuditContext(tx, c)` writes them to per-transaction
  GUCs via parameterized `set_config()`. Trigger reads GUCs at row time.
  Single-SELECT round-trip cost. Auto-resets on COMMIT/ROLLBACK (no
  cross-request leakage across pooled connections).
- **Automatic for 28 factory-using routes** via the sync-factory's
  transaction callback. Wired into the 5 hand-rolled routes that write to
  allow-listed tables (`entities.ts` ×2, `data-sources.ts`, `wikibase/resources.ts`,
  `tablebase/sync-factory.ts`).
- **Existing `tablebase_audit_log` stays**. `logAuditEntries()` now reads
  `current_setting('app.agent_session_id')` as a fallback so the 4
  existing callers pick up attribution for free.
- **`app.audit_skip = 'true'` escape hatch** for bulk migrations documented
  in `.claude/rules/database-migrations.md`.
- **`crux audit recent`** CLI + `GET /api/audit-log/recent` API for
  immediate utility. Filters on table / session / txn / time.
- **Complete subsystem map** at `.claude/rules/audit-log.md`.

## Coordination with QUA-408 Phase 4b

Per the parent ticket's comment thread, this should ship **before** Phase 4b-B
bulk `things` rewrites so the rewrites are themselves captured with session
attribution (using the `app.audit_skip` escape hatch only when a migration
author knowingly opts out).

## Key design decisions

- **Allow-list, not deny-list** — high-volume time-series (`*_snapshots`),
  system/pipeline state, derived caches (`things`), and the claims pipeline
  (already attributed) are deliberately excluded from v1.
- **Single SELECT per transaction** for `set_config` — halves the
  per-transaction round trip.
- **Fail-open everywhere** — missing GUCs, unknown tables, unset env vars.
  Attribution is best-effort; no path breaks a write.
- **Typed `operation` column** — Drizzle `$type<"INSERT"|"UPDATE"|"DELETE">()`
  preserves the discriminant through the RPC client so CLI comparisons
  are compile-time checked.
- **Byte-identical `helpers/audit_log_trigger.sql`** alongside the install
  migration, following the QUA-600 `swap_fk_target` precedent.

## Test plan

- [x] `audit-context.test.ts` — 8 middleware unit tests (header parsing,
  sanitization, truncation, parameter binding assertions)
- [x] `audit-log.integration.test.ts` — 10 trigger integration tests
  (INSERT/UPDATE/DELETE capture, `txn_id` grouping, GUC attribution,
  `audit_skip` escape hatch, idempotent re-attachment, trigger removal,
  missing-table tolerance, empty-string GUC → NULL). Gated on `DATABASE_URL`.
- [x] `crux/lib/wiki-server/audit-context.test.ts` — 8 client-side cache tests
  (env-var override, priming cache, no-op on repeat)
- [x] `pnpm test` — all 1429 wiki-server tests pass (sync-factory + grants +
  personnel still green after the attribution wiring)
- [x] `pnpm crux w validate gate --fix` — all 52 blocking gate checks pass
- [x] `crux audit recent --help` smoke-test; request flow verified (404 from
  prod is expected pre-deploy)

## Review

- [x] `/agent-review-pr` adaptive review: 13 findings; 5 Medium fixed,
  4 Low fixed, 2 Low deferred to follow-ups, 2 Low dismissed as false
  positive
- [x] `/simplify` three-agent pass: 3 actionable findings addressed
  (`getServerUrl()` reuse, `CallableTransactionSql` in integration test,
  typed `operation` union)

Closes QUA-442


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0204 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New API route "audit-log" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/audit-log/recent?limit=1" -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" -o /dev/null -w "%{http_code}"`
- [ ] `manual` Verify the trigger actually writes after a real sync — run any allow-listed sync (e.g. `pnpm crux tb personnel sync --dry-run=false` or a grants sync) and then `WIKI_SERVER_ENV=prod pnpm crux audit recent --limit=5`. Expect to see 1+ rows with non-null `session_id` + `tool` matching the session that ran the sync.
- [ ] `manual` Regression check: confirm no wiki-server writes are failing post-deploy. New triggers are the #1 source of "why is every write returning 500" incidents. Watch the health endpoint and error logs for ~10 minutes after rollout; if 5xx on any `/api/*/sync` spikes, roll back the migration (`CALL remove_audit_trigger('<offending_table>')` per-table; `DROP FUNCTION audit_trigger_fn()` removes the whole layer).
- [ ] `manual` Smoke-check storage growth. Initial audit-log insert volume depends entirely on how busy the allow-listed tables are. After 1 hour of traffic, run `SELECT count(*), pg_size_pretty(pg_total_relation_size('full_audit_log')) FROM full_audit_log;`. If the table is growing faster than ~10k rows/hour, open a follow-up to add retention (not blocking this deploy).

Note: the two auto-detected `env` false positives were removed — `CRUX_COMMAND` is set at runtime by `crux.mjs`, and `LW_AGENT_SESSION_ID` is an optional client-side override. Neither needs to be configured in prod.
<!-- /deploy-tasks -->
