### PR TITLE
feat: external scorecard mirror — schema + sync + directory + org tab (QUA-688)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -764,15 +764,27 @@ export default async function OrgProfilePage({
   }
 
   // ── Scorecards tab — external safety/transparency scorecards (QUA-688) ──
-  if (scorecardsData && scorecardsData.groups.length > 0) {
-    tabs.push({
-      id: "scorecards",
-      label: "Scorecards",
-      count: scorecardsData.groups.length,
-      group: "governance",
-      icon: <Award className={ICON_CLASS} />,
-      content: <ScorecardsSection groups={scorecardsData.groups} />,
-    });
+  if (scorecardsData) {
+    if ("fetchError" in scorecardsData) {
+      // Transient wiki-server failure — surface an unavailable state rather
+      // than silently dropping the tab.
+      tabs.push({
+        id: "scorecards",
+        label: "Scorecards",
+        group: "governance",
+        icon: <Award className={ICON_CLASS} />,
+        content: <ScorecardsSection groups={[]} fetchError />,
+      });
+    } else if (scorecardsData.groups.length > 0) {
+      tabs.push({
+        id: "scorecards",
+        label: "Scorecards",
+        count: scorecardsData.groups.length,
+        group: "governance",
+        icon: <Award className={ICON_CLASS} />,
+        content: <ScorecardsSection groups={scorecardsData.groups} />,
+      });
+    }
   }
 
   // ── Projects tab: projects founded by this org ──

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -108,6 +108,12 @@ import { fetchFromWikiServer } from "@/lib/wiki-server";
 import type { RpcGrantsByEntityResult } from "@/lib/wiki-server";
 import Markdown from "react-markdown";
 
+// External scorecard mirror (QUA-688)
+import {
+  loadScorecardsForEntity,
+  ScorecardsSection,
+} from "./scorecards-section";
+
 import type { ProfileTab as OrgTab, ProfileTabGroup } from "@/components/directory";
 import {
   Home,
@@ -131,6 +137,7 @@ import {
   Database,
   ListTree,
   Clock,
+  Award,
 } from "lucide-react";
 
 const ORG_TAB_GROUPS: ProfileTabGroup[] = [
@@ -192,7 +199,7 @@ export default async function OrgProfilePage({
 
   // ── Fetch PG data (personnel + market data + grants + sourcing) in parallel ──
   const entityStableId = entity.stableId ?? entity.id;
-  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData, sourcingSummary] = await Promise.all([
+  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData, sourcingSummary, scorecardsData] = await Promise.all([
     fetchPgPersonnel(entityStableId),
     fetchMarketData(entity.id),
     fetchFromWikiServer<RpcGrantsByEntityResult>(
@@ -204,6 +211,7 @@ export default async function OrgProfilePage({
       { revalidate: 3600, timeoutMs: 10_000 },
     ),
     fetchEntitySourcingSummary([entity.id, entityStableId, slug]),
+    loadScorecardsForEntity(entityStableId),
   ]);
   const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
@@ -752,6 +760,18 @@ export default async function OrgProfilePage({
       content: (
         <PolicyPositionsSection positions={policyPositions} />
       ),
+    });
+  }
+
+  // ── Scorecards tab — external safety/transparency scorecards (QUA-688) ──
+  if (scorecardsData && scorecardsData.groups.length > 0) {
+    tabs.push({
+      id: "scorecards",
+      label: "Scorecards",
+      count: scorecardsData.groups.length,
+      group: "governance",
+      icon: <Award className={ICON_CLASS} />,
+      content: <ScorecardsSection groups={scorecardsData.groups} />,
     });
   }
 

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -172,21 +172,19 @@ export function ScorecardsSection({
             ) : null}
 
             {dimensionRows.length > 0 ? (
-              <table className="w-full text-sm">
-                <tbody>
-                  {dimensionRows.map((r) => (
-                    <tr
-                      key={r.id}
-                      className="border-b border-border/30 last:border-b-0"
-                    >
-                      <td className="py-1.5 pr-3">{r.dimensionLabel}</td>
-                      <td className="py-1.5 font-mono tabular-nums text-right">
-                        {formatScoreCell(r)}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <dl className="w-full text-sm grid grid-cols-[1fr_auto] gap-x-3">
+                {dimensionRows.map((r) => (
+                  <div
+                    key={r.id}
+                    className="contents border-b border-border/30 last:border-b-0"
+                  >
+                    <dt className="py-1.5">{r.dimensionLabel}</dt>
+                    <dd className="py-1.5 font-mono tabular-nums text-right">
+                      {formatScoreCell(r)}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
             ) : null}
           </article>
         );

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -1,0 +1,189 @@
+/**
+ * Scorecards section on an organization's profile (QUA-688 Phase 1).
+ *
+ * Fetches every grade for the org from `/api/scorecard-grades/by-entity/...`
+ * (latest snapshot per source) and renders one panel per source with
+ * dimension grades.
+ */
+
+import Link from "next/link";
+import { fetchDetailed } from "@lib/wiki-server";
+import {
+  SCORECARD_SOURCES,
+  getScorecardSourceMeta,
+  type ScorecardSourceKey,
+} from "@/app/scorecards/scorecards-constants";
+
+interface GradeRow {
+  id: string;
+  snapshotId: string;
+  scorecardSource: string | null;
+  publishedAt: string | null;
+  isLatest: boolean | null;
+  entityId: string;
+  entityDisplayName: string;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+  notes: string | null;
+}
+
+interface ByEntityResponse {
+  items: GradeRow[];
+  total: number;
+}
+
+interface SourceGroup {
+  source: ScorecardSourceKey;
+  rows: GradeRow[];
+  publishedAt: string | null;
+}
+
+/**
+ * Fetch + group an org's scorecard grades. Returns null when there are no
+ * grades — caller suppresses the tab in that case.
+ */
+export async function loadScorecardsForEntity(
+  entityStableId: string,
+): Promise<{ groups: SourceGroup[]; totalRows: number } | null> {
+  const result = await fetchDetailed<ByEntityResponse>(
+    `/api/scorecard-grades/by-entity/${encodeURIComponent(entityStableId)}`,
+    { revalidate: 300 },
+  );
+  if (!result.ok) return null;
+  if (result.data.items.length === 0) return null;
+
+  const groupsBySource = new Map<string, SourceGroup>();
+  for (const r of result.data.items) {
+    if (!r.scorecardSource) continue;
+    const existing = groupsBySource.get(r.scorecardSource);
+    if (existing) {
+      existing.rows.push(r);
+    } else {
+      groupsBySource.set(r.scorecardSource, {
+        source: r.scorecardSource as ScorecardSourceKey,
+        rows: [r],
+        publishedAt: r.publishedAt,
+      });
+    }
+  }
+
+  // Order groups by SCORECARD_SOURCES list (defines display order).
+  const groups: SourceGroup[] = [];
+  for (const meta of SCORECARD_SOURCES) {
+    const group = groupsBySource.get(meta.source);
+    if (group) groups.push(group);
+  }
+
+  return { groups, totalRows: result.data.items.length };
+}
+
+export function ScorecardsSection({
+  groups,
+}: {
+  groups: SourceGroup[];
+}) {
+  if (groups.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No external scorecard grades on file.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Grades from external scorecards. We mirror published grades only;
+        per-source methodology lives at the link in each panel header. See
+        the{" "}
+        <Link href="/scorecards" className="text-primary hover:underline">
+          scorecards directory
+        </Link>{" "}
+        for cross-org comparison.
+      </p>
+
+      {groups.map((group) => {
+        const meta = getScorecardSourceMeta(group.source);
+        // Pull overall row first if present; render the rest below as a
+        // dimensions table.
+        const overallRow = group.rows.find((r) => r.dimensionSlug === "overall");
+        const dimensionRows = group.rows.filter(
+          (r) => r.dimensionSlug !== "overall",
+        );
+
+        return (
+          <article
+            key={group.source}
+            className="rounded-lg border border-border/60 bg-card p-4"
+          >
+            <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+              <h3 className="font-semibold">
+                {meta?.fullLabel ?? group.source}
+              </h3>
+              {meta?.publisher ? (
+                <span className="text-xs text-muted-foreground">
+                  by {meta.publisher}
+                </span>
+              ) : null}
+              {group.publishedAt ? (
+                <span className="text-xs text-muted-foreground">
+                  Published {group.publishedAt}
+                </span>
+              ) : null}
+              {meta?.homeUrl ? (
+                <Link
+                  href={meta.homeUrl}
+                  className="text-xs text-primary hover:underline ml-auto"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Source ↗
+                </Link>
+              ) : null}
+            </header>
+
+            {overallRow ? (
+              <div className="mb-3 flex items-baseline gap-3">
+                <span className="text-sm text-muted-foreground">Overall:</span>
+                <span className="text-2xl font-mono tabular-nums">
+                  {overallRow.scoreLetter ??
+                    (overallRow.scoreNumeric != null
+                      ? overallRow.scoreNumeric
+                      : overallRow.scoreRaw)}
+                </span>
+              </div>
+            ) : null}
+
+            {dimensionRows.length > 0 ? (
+              <table className="w-full text-sm">
+                <tbody>
+                  {dimensionRows.map((r) => {
+                    const display =
+                      r.scoreLetter ??
+                      (r.scoreNumeric != null
+                        ? `${r.scoreNumeric}`
+                        : r.scoreRaw);
+                    return (
+                      <tr
+                        key={r.id}
+                        className="border-b border-border/30 last:border-b-0"
+                      >
+                        <td className="py-1.5 pr-3">{r.dimensionLabel}</td>
+                        <td className="py-1.5 font-mono tabular-nums text-right">
+                          {display}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -1,5 +1,5 @@
 /**
- * Scorecards section on an organization's profile (QUA-688 Phase 1).
+ * Scorecards section on an organization's profile.
  *
  * Fetches every grade for the org from `/api/scorecard-grades/by-entity/...`
  * (latest snapshot per source) and renders one panel per source with
@@ -11,6 +11,8 @@ import { fetchDetailed } from "@lib/wiki-server";
 import {
   SCORECARD_SOURCES,
   getScorecardSourceMeta,
+  formatScoreCell,
+  DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
 
@@ -107,11 +109,11 @@ export function ScorecardsSection({
 
       {groups.map((group) => {
         const meta = getScorecardSourceMeta(group.source);
-        // Pull overall row first if present; render the rest below as a
-        // dimensions table.
-        const overallRow = group.rows.find((r) => r.dimensionSlug === "overall");
+        const overallRow = group.rows.find(
+          (r) => r.dimensionSlug === DIMENSION_OVERALL,
+        );
         const dimensionRows = group.rows.filter(
-          (r) => r.dimensionSlug !== "overall",
+          (r) => r.dimensionSlug !== DIMENSION_OVERALL,
         );
 
         return (
@@ -149,10 +151,7 @@ export function ScorecardsSection({
               <div className="mb-3 flex items-baseline gap-3">
                 <span className="text-sm text-muted-foreground">Overall:</span>
                 <span className="text-2xl font-mono tabular-nums">
-                  {overallRow.scoreLetter ??
-                    (overallRow.scoreNumeric != null
-                      ? overallRow.scoreNumeric
-                      : overallRow.scoreRaw)}
+                  {formatScoreCell(overallRow)}
                 </span>
               </div>
             ) : null}
@@ -160,24 +159,17 @@ export function ScorecardsSection({
             {dimensionRows.length > 0 ? (
               <table className="w-full text-sm">
                 <tbody>
-                  {dimensionRows.map((r) => {
-                    const display =
-                      r.scoreLetter ??
-                      (r.scoreNumeric != null
-                        ? `${r.scoreNumeric}`
-                        : r.scoreRaw);
-                    return (
-                      <tr
-                        key={r.id}
-                        className="border-b border-border/30 last:border-b-0"
-                      >
-                        <td className="py-1.5 pr-3">{r.dimensionLabel}</td>
-                        <td className="py-1.5 font-mono tabular-nums text-right">
-                          {display}
-                        </td>
-                      </tr>
-                    );
-                  })}
+                  {dimensionRows.map((r) => (
+                    <tr
+                      key={r.id}
+                      className="border-b border-border/30 last:border-b-0"
+                    >
+                      <td className="py-1.5 pr-3">{r.dimensionLabel}</td>
+                      <td className="py-1.5 font-mono tabular-nums text-right">
+                        {formatScoreCell(r)}
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             ) : null}

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -44,17 +44,23 @@ interface SourceGroup {
 }
 
 /**
- * Fetch + group an org's scorecard grades. Returns null when there are no
- * grades — caller suppresses the tab in that case.
+ * Fetch + group an org's scorecard grades.
+ * - Returns null when the org has no grades (caller suppresses the tab).
+ * - Returns { fetchError: true } on transient wiki-server failure (caller renders
+ *   an "unavailable" state instead of dropping the tab).
  */
+export type ScorecardsLoadResult =
+  | { groups: SourceGroup[]; totalRows: number }
+  | { fetchError: true };
+
 export async function loadScorecardsForEntity(
   entityStableId: string,
-): Promise<{ groups: SourceGroup[]; totalRows: number } | null> {
+): Promise<ScorecardsLoadResult | null> {
   const result = await fetchDetailed<ByEntityResponse>(
     `/api/scorecard-grades/by-entity/${encodeURIComponent(entityStableId)}`,
     { revalidate: 300 },
   );
-  if (!result.ok) return null;
+  if (!result.ok) return { fetchError: true };
   if (result.data.items.length === 0) return null;
 
   const groupsBySource = new Map<string, SourceGroup>();
@@ -84,9 +90,18 @@ export async function loadScorecardsForEntity(
 
 export function ScorecardsSection({
   groups,
+  fetchError,
 }: {
   groups: SourceGroup[];
+  fetchError?: boolean;
 }) {
+  if (fetchError) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Scorecard grades are temporarily unavailable. Try again later.
+      </p>
+    );
+  }
   if (groups.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">

--- a/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   SCORECARD_SOURCES,
-  SCORECARD_SOURCE_LOOKUP,
   getScorecardSourceMeta,
+  formatScoreCell,
+  DIMENSION_OVERALL,
 } from "../scorecards-constants";
 
 describe("scorecards-constants", () => {
@@ -18,9 +19,8 @@ describe("scorecards-constants", () => {
     ]);
   });
 
-  it("lookup returns the same record as the array exposes", () => {
+  it("getScorecardSourceMeta returns the array record by source key", () => {
     for (const meta of SCORECARD_SOURCES) {
-      expect(SCORECARD_SOURCE_LOOKUP[meta.source]).toBe(meta);
       expect(getScorecardSourceMeta(meta.source)).toBe(meta);
     }
   });
@@ -28,6 +28,33 @@ describe("scorecards-constants", () => {
   it("returns null for unknown sources", () => {
     expect(getScorecardSourceMeta("unknown-source")).toBeNull();
     expect(getScorecardSourceMeta("")).toBeNull();
+  });
+
+  it("DIMENSION_OVERALL is a stable slug", () => {
+    expect(DIMENSION_OVERALL).toBe("overall");
+  });
+
+  describe("formatScoreCell", () => {
+    it("prefers letter grade when present", () => {
+      expect(
+        formatScoreCell({ scoreLetter: "C+", scoreNumeric: 70, scoreRaw: "70%" }),
+      ).toBe("C+");
+    });
+    it("falls back to numeric when no letter", () => {
+      expect(
+        formatScoreCell({ scoreLetter: null, scoreNumeric: 84, scoreRaw: "84.5" }),
+      ).toBe("84");
+    });
+    it("falls back to raw string when neither numeric nor letter", () => {
+      expect(
+        formatScoreCell({ scoreLetter: null, scoreNumeric: null, scoreRaw: "Fulfilled" }),
+      ).toBe("Fulfilled");
+    });
+    it("handles 0 numeric scores correctly (not falsy-coerced)", () => {
+      expect(
+        formatScoreCell({ scoreLetter: null, scoreNumeric: 0, scoreRaw: "should-not-show" }),
+      ).toBe("0");
+    });
   });
 
   it("each source has a non-empty home URL and description", () => {

--- a/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  SCORECARD_SOURCES,
+  SCORECARD_SOURCE_LOOKUP,
+  getScorecardSourceMeta,
+} from "../scorecards-constants";
+
+describe("scorecards-constants", () => {
+  it("declares exactly five known scorecard sources", () => {
+    expect(SCORECARD_SOURCES).toHaveLength(5);
+    const sources = SCORECARD_SOURCES.map((s) => s.source).sort();
+    expect(sources).toEqual([
+      "ailabwatch",
+      "fli_index",
+      "fmti",
+      "saferai",
+      "seoul_tracker",
+    ]);
+  });
+
+  it("lookup returns the same record as the array exposes", () => {
+    for (const meta of SCORECARD_SOURCES) {
+      expect(SCORECARD_SOURCE_LOOKUP[meta.source]).toBe(meta);
+      expect(getScorecardSourceMeta(meta.source)).toBe(meta);
+    }
+  });
+
+  it("returns null for unknown sources", () => {
+    expect(getScorecardSourceMeta("unknown-source")).toBeNull();
+    expect(getScorecardSourceMeta("")).toBeNull();
+  });
+
+  it("each source has a non-empty home URL and description", () => {
+    for (const meta of SCORECARD_SOURCES) {
+      expect(meta.homeUrl).toMatch(/^https?:\/\//);
+      expect(meta.description.length).toBeGreaterThan(20);
+      expect(meta.shortLabel.length).toBeGreaterThan(0);
+      expect(meta.publisher.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("AI Lab Watch is flagged as no longer maintained", () => {
+    const meta = getScorecardSourceMeta("ailabwatch");
+    expect(meta?.active).toBe(false);
+  });
+
+  it("active sources are flagged as active", () => {
+    for (const slug of ["fli_index", "saferai", "fmti", "seoul_tracker"]) {
+      const meta = getScorecardSourceMeta(slug);
+      expect(meta?.active).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -9,7 +9,6 @@ import {
 } from "./scorecards-matrix";
 import {
   SCORECARD_SOURCES,
-  getScorecardSourceMeta,
   type ScorecardSourceKey,
 } from "./scorecards-constants";
 
@@ -248,5 +247,3 @@ export default async function ScorecardsPage() {
     </div>
   );
 }
-
-void getScorecardSourceMeta;

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -11,7 +11,7 @@ import {
   SCORECARD_SOURCES,
   DIMENSION_OVERALL,
   type ScorecardSourceKey,
-} from "./scorecards-constants";
+} from "@/app/scorecards/scorecards-constants";
 
 export const metadata: Metadata = {
   title: "Scorecards",
@@ -56,6 +56,43 @@ interface GradeRow {
   scoreRaw: string;
 }
 
+/**
+ * Fetch every `overall=true` grade for the latest snapshots, paginating
+ * through `/api/scorecard-grades/all` until `total` is exhausted. Returns
+ * `{ ok: false }` if any page fetch fails so callers can surface an
+ * unavailable state instead of silently rendering a truncated matrix.
+ *
+ * Hard-capped at MAX_OVERALL_GRADES rows as a safety net — if hit, we log
+ * and return what we have rather than looping forever on a misbehaving API.
+ */
+const PAGE_SIZE = 200;
+const MAX_OVERALL_GRADES = 5000;
+
+async function fetchAllOverallGrades(): Promise<
+  { ok: true; items: GradeRow[] } | { ok: false }
+> {
+  const items: GradeRow[] = [];
+  let offset = 0;
+  while (items.length < MAX_OVERALL_GRADES) {
+    const res = await fetchDetailed<{ items: GradeRow[]; total: number }>(
+      `/api/scorecard-grades/all?limit=${PAGE_SIZE}&offset=${offset}&latest=true&overall=true`,
+      { revalidate: 300 },
+    );
+    if (!res.ok) return { ok: false };
+    items.push(...res.data.items);
+    if (res.data.items.length < PAGE_SIZE || items.length >= res.data.total) {
+      break;
+    }
+    offset += PAGE_SIZE;
+  }
+  if (items.length >= MAX_OVERALL_GRADES) {
+    console.warn(
+      `[scorecards] hit MAX_OVERALL_GRADES=${MAX_OVERALL_GRADES}; matrix may be truncated`,
+    );
+  }
+  return { ok: true, items };
+}
+
 export default async function ScorecardsPage() {
   // Load latest snapshots (one per source) and overall-dimension grades in
   // parallel. Per-dimension drill-down lives on the org's profile tab, not
@@ -65,14 +102,11 @@ export default async function ScorecardsPage() {
       "/api/scorecard-snapshots/all?limit=50&latest=true",
       { revalidate: 300 },
     ),
-    fetchDetailed<{ items: GradeRow[]; total: number }>(
-      "/api/scorecard-grades/all?limit=1000&latest=true&overall=true",
-      { revalidate: 300 },
-    ),
+    fetchAllOverallGrades(),
   ]);
 
   const snapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
-  const grades = gradesRes.ok ? gradesRes.data.items : [];
+  const grades = gradesRes.ok ? gradesRes.items : [];
   const fetchOk = snapshotsRes.ok && gradesRes.ok;
 
   // Index latest snapshot per source (defensive — partial unique index

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { fetchDetailed } from "@lib/wiki-server";
+import { ProfileStatCard } from "@/components/directory";
+import {
+  ScorecardsMatrix,
+  type ScorecardCell,
+  type ScorecardOrgRow,
+} from "./scorecards-matrix";
+import {
+  SCORECARD_SOURCES,
+  getScorecardSourceMeta,
+  type ScorecardSourceKey,
+} from "./scorecards-constants";
+
+export const metadata: Metadata = {
+  title: "Scorecards",
+  description:
+    "Side-by-side view of external AI-safety scorecards: FLI AI Safety Index, SaferAI Ratings, AI Lab Watch, Stanford FMTI, and the Seoul Commitment Tracker.",
+};
+
+/**
+ * Wiki-server response shapes — keep narrow to the fields rendered.
+ * The full Hono RPC types would require importing route types into the
+ * web app; the directory page reads enough fields that hand-typing is
+ * less coupling than a full type import.
+ */
+interface SnapshotRow {
+  id: string;
+  scorecardSource: string;
+  waveLabel: string | null;
+  publishedAt: string;
+  sourceUrl: string;
+  methodologyUrl: string | null;
+  license: string | null;
+  orgCount: number;
+  dimensionCount: number;
+  isLatest: boolean;
+  sourceActive: boolean;
+  notes: string | null;
+}
+
+interface GradeRow {
+  id: string;
+  snapshotId: string;
+  scorecardSource: string | null;
+  publishedAt: string | null;
+  isLatest: boolean | null;
+  entityId: string;
+  entityDisplayName: string;
+  entitySlug: string | null;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+}
+
+export default async function ScorecardsPage() {
+  // Load latest snapshots (one per source) and overall-dimension grades.
+  // The page caps load by filtering grades to dimensionSlug='overall'
+  // — per-dimension drill-down lives on the org's profile tab, not here.
+  const snapshotsRes = await fetchDetailed<{
+    items: SnapshotRow[];
+    total: number;
+  }>("/api/scorecard-snapshots/all?limit=50&latest=true", { revalidate: 300 });
+
+  const gradesRes = await fetchDetailed<{
+    items: GradeRow[];
+    total: number;
+  }>("/api/scorecard-grades/all?limit=1000&latest=true", { revalidate: 300 });
+
+  const snapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
+  const grades = gradesRes.ok ? gradesRes.data.items : [];
+  const fetchOk = snapshotsRes.ok && gradesRes.ok;
+
+  // Index latest snapshot per source (defensive — partial unique index
+  // already enforces this, but the UI should not crash if it's somehow
+  // violated).
+  const latestPerSource = new Map<string, SnapshotRow>();
+  for (const s of snapshots) {
+    if (s.isLatest) latestPerSource.set(s.scorecardSource, s);
+  }
+
+  // Build the org × source matrix from `overall` rows only.
+  const orgMap = new Map<string, ScorecardOrgRow>();
+  for (const g of grades) {
+    if (g.dimensionSlug !== "overall") continue;
+    if (!g.scorecardSource) continue;
+    const existing = orgMap.get(g.entityId);
+    const cell: ScorecardCell = {
+      source: g.scorecardSource as ScorecardSourceKey,
+      scoreNumeric: g.scoreNumeric,
+      scoreLetter: g.scoreLetter,
+      scoreRaw: g.scoreRaw,
+      publishedAt: g.publishedAt,
+    };
+    if (existing) {
+      existing.cells[g.scorecardSource] = cell;
+    } else {
+      orgMap.set(g.entityId, {
+        entityId: g.entityId,
+        displayName: g.entityDisplayName,
+        slug: g.entitySlug,
+        cells: { [g.scorecardSource]: cell },
+      });
+    }
+  }
+  const orgRows = [...orgMap.values()].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  );
+
+  const totalOrgs = orgRows.length;
+  const totalCellsRendered = orgRows.reduce(
+    (sum, row) => sum + Object.keys(row.cells).length,
+    0,
+  );
+  const sourcesWithData = new Set(
+    [...orgMap.values()].flatMap((r) => Object.keys(r.cells)),
+  ).size;
+
+  const stats = [
+    { label: "Scorecards", value: String(SCORECARD_SOURCES.length) },
+    { label: "Sources w/ Data", value: String(sourcesWithData) },
+    { label: "Organizations", value: String(totalOrgs) },
+    { label: "Cells", value: String(totalCellsRendered) },
+  ];
+
+  return (
+    <div className="container max-w-6xl mx-auto px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold mb-3">External Scorecards</h1>
+        <p className="text-muted-foreground max-w-3xl">
+          Side-by-side overall grades from the five major external AI-safety
+          scorecards. Click any row to view per-dimension grades on the
+          organization&apos;s profile.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        {stats.map((stat) => (
+          <ProfileStatCard
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+          />
+        ))}
+      </div>
+
+      {!fetchOk ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 p-4 text-sm">
+          The wiki-server was unreachable; scorecard data is temporarily
+          unavailable. The matrix and methodology sections will populate once
+          the server responds.
+        </div>
+      ) : null}
+
+      {fetchOk && totalOrgs === 0 ? (
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-6 text-sm space-y-2 mb-8">
+          <p className="font-medium">No scorecard grades ingested yet.</p>
+          <p className="text-muted-foreground">
+            The scorecard schema and sync API are live, but per-source
+            ingesters land in follow-up tickets — see QUA-688 for status.
+            Methodology and source links below are usable today.
+          </p>
+        </div>
+      ) : null}
+
+      {orgRows.length > 0 ? (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-4">
+            Overall grades — latest wave per scorecard
+          </h2>
+          <ScorecardsMatrix orgRows={orgRows} />
+        </section>
+      ) : null}
+
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">Methodology</h2>
+        <div className="space-y-3">
+          {SCORECARD_SOURCES.map((meta) => {
+            const snapshot = latestPerSource.get(meta.source);
+            return (
+              <article
+                key={meta.source}
+                className="rounded-lg border border-border/60 bg-card p-4"
+              >
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
+                  <h3 className="font-semibold">{meta.fullLabel}</h3>
+                  <span className="text-xs text-muted-foreground">
+                    by {meta.publisher}
+                  </span>
+                  {!meta.active ? (
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                      No longer maintained
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-sm text-muted-foreground mb-2">
+                  {meta.description}
+                </p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                  <Link
+                    href={snapshot?.sourceUrl ?? meta.homeUrl}
+                    className="text-primary hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Source ↗
+                  </Link>
+                  {snapshot?.methodologyUrl ? (
+                    <Link
+                      href={snapshot.methodologyUrl}
+                      className="text-primary hover:underline"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Methodology ↗
+                    </Link>
+                  ) : null}
+                  {snapshot ? (
+                    <span className="text-muted-foreground">
+                      Latest: {snapshot.waveLabel ?? snapshot.publishedAt}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground italic">
+                      not yet ingested
+                    </span>
+                  )}
+                  {snapshot?.license ? (
+                    <span className="text-muted-foreground">
+                      License: {snapshot.license}
+                    </span>
+                  ) : null}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <p className="text-xs text-muted-foreground">
+        Grades are mirrored from upstream sources. We do not score
+        organizations ourselves — see each row&apos;s source link for
+        methodology and full per-dimension grades. Citation of published
+        grades is consistent with fair-use attribution.
+      </p>
+    </div>
+  );
+}
+
+void getScorecardSourceMeta;

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -67,7 +67,13 @@ export default async function ScorecardsPage() {
   const gradesRes = await fetchDetailed<{
     items: GradeRow[];
     total: number;
-  }>("/api/scorecard-grades/all?limit=1000&latest=true", { revalidate: 300 });
+  }>(
+    // overall=true server-side filter — matrix only renders the rollup row.
+    // Without it we'd fetch ~4,000 FMTI indicator rows just to throw them
+    // away; with it we get one cell per (org, source).
+    "/api/scorecard-grades/all?limit=1000&latest=true&overall=true",
+    { revalidate: 300 },
+  );
 
   const snapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
   const grades = gradesRes.ok ? gradesRes.data.items : [];

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "./scorecards-matrix";
 import {
   SCORECARD_SOURCES,
+  DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "./scorecards-constants";
 
@@ -56,24 +57,19 @@ interface GradeRow {
 }
 
 export default async function ScorecardsPage() {
-  // Load latest snapshots (one per source) and overall-dimension grades.
-  // The page caps load by filtering grades to dimensionSlug='overall'
-  // — per-dimension drill-down lives on the org's profile tab, not here.
-  const snapshotsRes = await fetchDetailed<{
-    items: SnapshotRow[];
-    total: number;
-  }>("/api/scorecard-snapshots/all?limit=50&latest=true", { revalidate: 300 });
-
-  const gradesRes = await fetchDetailed<{
-    items: GradeRow[];
-    total: number;
-  }>(
-    // overall=true server-side filter — matrix only renders the rollup row.
-    // Without it we'd fetch ~4,000 FMTI indicator rows just to throw them
-    // away; with it we get one cell per (org, source).
-    "/api/scorecard-grades/all?limit=1000&latest=true&overall=true",
-    { revalidate: 300 },
-  );
+  // Load latest snapshots (one per source) and overall-dimension grades in
+  // parallel. Per-dimension drill-down lives on the org's profile tab, not
+  // here — `overall=true` keeps this query bounded as FMTI lands.
+  const [snapshotsRes, gradesRes] = await Promise.all([
+    fetchDetailed<{ items: SnapshotRow[]; total: number }>(
+      "/api/scorecard-snapshots/all?limit=50&latest=true",
+      { revalidate: 300 },
+    ),
+    fetchDetailed<{ items: GradeRow[]; total: number }>(
+      "/api/scorecard-grades/all?limit=1000&latest=true&overall=true",
+      { revalidate: 300 },
+    ),
+  ]);
 
   const snapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
   const grades = gradesRes.ok ? gradesRes.data.items : [];
@@ -87,10 +83,13 @@ export default async function ScorecardsPage() {
     if (s.isLatest) latestPerSource.set(s.scorecardSource, s);
   }
 
-  // Build the org × source matrix from `overall` rows only.
+  // Build the org × source matrix from `overall` rows only. The fetch
+  // above already filters to `overall=true`, but we double-check here so
+  // an upstream change to that query never silently mixes per-dimension
+  // rows into the matrix.
   const orgMap = new Map<string, ScorecardOrgRow>();
   for (const g of grades) {
-    if (g.dimensionSlug !== "overall") continue;
+    if (g.dimensionSlug !== DIMENSION_OVERALL) continue;
     if (!g.scorecardSource) continue;
     const existing = orgMap.get(g.entityId);
     const cell: ScorecardCell = {

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -1,0 +1,110 @@
+/**
+ * Display metadata for the five external scorecard sources tracked by
+ * QUA-688 Phase 1. Order is the order columns appear in the matrix.
+ */
+
+export interface ScorecardSourceMeta {
+  /** Enum value used in PG / sync API. */
+  source: ScorecardSourceKey;
+  /** Short display label for headers and pills. */
+  shortLabel: string;
+  /** Full display label for tooltips and methodology panels. */
+  fullLabel: string;
+  /** Org/maintainer of the scorecard. */
+  publisher: string;
+  /** Default canonical URL for the source's home page. */
+  homeUrl: string;
+  /**
+   * One-line description for the methodology / "about this scorecard" panel.
+   * Keep neutral, factual; surfaced verbatim on the directory page.
+   */
+  description: string;
+  /**
+   * Whether the source is still actively updated. Mirrors
+   * `scorecard_snapshots.source_active` for display defaults.
+   */
+  active: boolean;
+}
+
+export type ScorecardSourceKey =
+  | "fli_index"
+  | "saferai"
+  | "ailabwatch"
+  | "fmti"
+  | "seoul_tracker";
+
+export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
+  {
+    source: "fli_index",
+    shortLabel: "FLI Index",
+    fullLabel: "FLI AI Safety Index",
+    publisher: "Future of Life Institute",
+    homeUrl: "https://futureoflife.org/ai-safety-index-summer-2025/",
+    description:
+      "Letter-grade ratings of frontier AI labs across six safety domains: risk assessment, current harms, safety frameworks, existential safety, governance, and information sharing.",
+    active: true,
+  },
+  {
+    source: "saferai",
+    shortLabel: "SaferAI",
+    fullLabel: "SaferAI Ratings",
+    publisher: "SaferAI",
+    homeUrl: "https://ratings.safer-ai.org",
+    description:
+      "Continuously-updated risk-management ratings for frontier developers across four pillars: risk identification, analysis & evaluation, treatment, and governance.",
+    active: true,
+  },
+  {
+    source: "ailabwatch",
+    shortLabel: "AI Lab Watch",
+    fullLabel: "AI Lab Watch",
+    publisher: "Zach Stein-Perlman",
+    homeUrl: "https://ailabwatch.org",
+    description:
+      "Weighted scorecard across seven categories (risk assessment, scheming prevention, safety research, misuse prevention, security, info sharing, planning).",
+    active: false,
+  },
+  {
+    source: "fmti",
+    shortLabel: "FMTI",
+    fullLabel: "Foundation Model Transparency Index",
+    publisher: "Stanford CRFM",
+    homeUrl: "https://crfm.stanford.edu/fmti/",
+    description:
+      "Transparency-focused index scoring developers on 100 indicators across upstream resources, the model itself, and downstream use.",
+    active: true,
+  },
+  {
+    source: "seoul_tracker",
+    shortLabel: "Seoul Tracker",
+    fullLabel: "Seoul Commitment Tracker",
+    publisher: "The Midas Project",
+    homeUrl: "https://www.seoul-tracker.org",
+    description:
+      "Tracks adherence to the Seoul Frontier AI Safety Commitments via 'Fulfilled / Partial / Unfulfilled' verdicts on five red-line components.",
+    active: true,
+  },
+] as const;
+
+export const SCORECARD_SOURCE_LOOKUP: Record<
+  ScorecardSourceKey,
+  ScorecardSourceMeta
+> = SCORECARD_SOURCES.reduce(
+  (acc, meta) => {
+    acc[meta.source] = meta;
+    return acc;
+  },
+  {} as Record<ScorecardSourceKey, ScorecardSourceMeta>,
+);
+
+/**
+ * Look up display metadata for a scorecard source. Returns null when the
+ * source key is unknown — caller should display a fallback (raw string).
+ */
+export function getScorecardSourceMeta(
+  source: string,
+): ScorecardSourceMeta | null {
+  return (
+    SCORECARD_SOURCE_LOOKUP[source as ScorecardSourceKey] ?? null
+  );
+}

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -86,17 +86,6 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
   },
 ] as const;
 
-export const SCORECARD_SOURCE_LOOKUP: Record<
-  ScorecardSourceKey,
-  ScorecardSourceMeta
-> = SCORECARD_SOURCES.reduce(
-  (acc, meta) => {
-    acc[meta.source] = meta;
-    return acc;
-  },
-  {} as Record<ScorecardSourceKey, ScorecardSourceMeta>,
-);
-
 /**
  * Look up display metadata for a scorecard source. Returns null when the
  * source key is unknown — caller should display a fallback (raw string).
@@ -104,7 +93,28 @@ export const SCORECARD_SOURCE_LOOKUP: Record<
 export function getScorecardSourceMeta(
   source: string,
 ): ScorecardSourceMeta | null {
+  return SCORECARD_SOURCES.find((meta) => meta.source === source) ?? null;
+}
+
+/**
+ * Slug used for the per-(org, source) aggregate row in `scorecard_grades`.
+ * Sibling rows hold per-dimension grades; the aggregate is treated as a
+ * regular dimension to keep matrix queries uniform.
+ */
+export const DIMENSION_OVERALL = "overall";
+
+/**
+ * Render the user-visible cell text for a scorecard grade. Letter grades
+ * win when present (sources like FLI publish letters); numeric falls back
+ * to the raw string from the source for audit fidelity.
+ */
+export function formatScoreCell(cell: {
+  scoreLetter: string | null;
+  scoreNumeric: number | null;
+  scoreRaw: string;
+}): string {
   return (
-    SCORECARD_SOURCE_LOOKUP[source as ScorecardSourceKey] ?? null
+    cell.scoreLetter ??
+    (cell.scoreNumeric != null ? String(cell.scoreNumeric) : cell.scoreRaw)
   );
 }

--- a/apps/web/src/app/scorecards/scorecards-matrix.tsx
+++ b/apps/web/src/app/scorecards/scorecards-matrix.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import {
   SCORECARD_SOURCES,
+  formatScoreCell,
   type ScorecardSourceKey,
 } from "./scorecards-constants";
 
@@ -76,11 +77,6 @@ export function ScorecardsMatrix({
                     </td>
                   );
                 }
-                const display =
-                  cell.scoreLetter ??
-                  (cell.scoreNumeric != null
-                    ? `${cell.scoreNumeric}`
-                    : cell.scoreRaw);
                 return (
                   <td
                     key={meta.source}
@@ -89,7 +85,7 @@ export function ScorecardsMatrix({
                       cell.publishedAt ? ` — ${cell.publishedAt}` : ""
                     }`}
                   >
-                    {display}
+                    {formatScoreCell(cell)}
                   </td>
                 );
               })}

--- a/apps/web/src/app/scorecards/scorecards-matrix.tsx
+++ b/apps/web/src/app/scorecards/scorecards-matrix.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import {
+  SCORECARD_SOURCES,
+  type ScorecardSourceKey,
+} from "./scorecards-constants";
+
+export interface ScorecardCell {
+  source: ScorecardSourceKey;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+  publishedAt: string | null;
+}
+
+export interface ScorecardOrgRow {
+  entityId: string;
+  displayName: string;
+  /** Slug for /organizations/<slug> linking; null when entity isn't in catalog. */
+  slug: string | null;
+  /** Map of source enum → cell. Missing key = no grade for that source. */
+  cells: Record<string, ScorecardCell>;
+}
+
+/**
+ * Pure, server-renderable matrix table. No client interactivity yet —
+ * sort/filter UI lives in a follow-up. Keeping this server-only avoids
+ * shipping a client bundle for a dense data table.
+ */
+export function ScorecardsMatrix({
+  orgRows,
+}: {
+  orgRows: ScorecardOrgRow[];
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/60">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-muted/40 text-left">
+            <th className="px-3 py-2 font-semibold border-b border-border/60">
+              Organization
+            </th>
+            {SCORECARD_SOURCES.map((meta) => (
+              <th
+                key={meta.source}
+                className="px-3 py-2 font-semibold border-b border-border/60 whitespace-nowrap"
+              >
+                {meta.shortLabel}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {orgRows.map((row) => (
+            <tr key={row.entityId} className="hover:bg-muted/20">
+              <td className="px-3 py-2 border-b border-border/30">
+                {row.slug ? (
+                  <Link
+                    href={`/organizations/${row.slug}`}
+                    className="text-primary hover:underline"
+                  >
+                    {row.displayName}
+                  </Link>
+                ) : (
+                  <span>{row.displayName}</span>
+                )}
+              </td>
+              {SCORECARD_SOURCES.map((meta) => {
+                const cell = row.cells[meta.source];
+                if (!cell) {
+                  return (
+                    <td
+                      key={meta.source}
+                      className="px-3 py-2 border-b border-border/30 text-muted-foreground"
+                    >
+                      —
+                    </td>
+                  );
+                }
+                const display =
+                  cell.scoreLetter ??
+                  (cell.scoreNumeric != null
+                    ? `${cell.scoreNumeric}`
+                    : cell.scoreRaw);
+                return (
+                  <td
+                    key={meta.source}
+                    className="px-3 py-2 border-b border-border/30 font-mono tabular-nums"
+                    title={`${meta.fullLabel}${
+                      cell.publishedAt ? ` — ${cell.publishedAt}` : ""
+                    }`}
+                  >
+                    {display}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/scorecards/scorecards-matrix.tsx
+++ b/apps/web/src/app/scorecards/scorecards-matrix.tsx
@@ -3,7 +3,7 @@ import {
   SCORECARD_SOURCES,
   formatScoreCell,
   type ScorecardSourceKey,
-} from "./scorecards-constants";
+} from "@/app/scorecards/scorecards-constants";
 
 export interface ScorecardCell {
   source: ScorecardSourceKey;

--- a/apps/web/src/lib/nav-links.ts
+++ b/apps/web/src/lib/nav-links.ts
@@ -42,6 +42,7 @@ export const NAV_ITEMS: NavItem[] = [
       { href: "/legislation", label: "Legislation" },
       { href: "/politicians", label: "Politicians" },
       { href: "/races", label: "Races" },
+      { href: "/scorecards", label: "Safety Scorecards" },
     ],
   },
   {

--- a/apps/wiki-server/drizzle/0207_qua_688_scorecard_tables.sql
+++ b/apps/wiki-server/drizzle/0207_qua_688_scorecard_tables.sql
@@ -1,0 +1,75 @@
+-- QUA-688 Phase 1: External scorecard mirror.
+--
+-- Two tables:
+--   scorecard_snapshots — one row per (source, wave) e.g. "FLI Summer 2025".
+--   scorecard_grades    — one row per (snapshot, org, dimension); cells.
+--
+-- Authoritative source is data/scorecards/snapshots/*.yaml. PG mirrors that
+-- via the standard sync-factory POST /sync flow.
+--
+-- ## Invariants
+--   * Exactly one snapshot per scorecard_source has is_latest=true (partial
+--     unique index below + sync-factory upsert reset).
+--   * (snapshot_id, entity_id, dimension_slug) is unique in scorecard_grades.
+--   * entity_id references entities.stable_id (FK) — guarantees rendering
+--     can look up canonical names.
+--
+-- No CHECK constraint on scorecard_source yet — sources are added one wave
+-- at a time and the value list is a five-element closed set today, but per
+-- .claude/rules/database-migrations.md we'd need a prod enumeration before
+-- locking it. Defer to a follow-up after Phase 1 prod data exists.
+
+CREATE TABLE IF NOT EXISTS "scorecard_snapshots" (
+  "id" text PRIMARY KEY NOT NULL,
+  "scorecard_source" text NOT NULL,
+  "wave_label" text,
+  "published_at" date NOT NULL,
+  "captured_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "source_url" text NOT NULL,
+  "methodology_url" text,
+  "license" text,
+  "org_count" integer NOT NULL DEFAULT 0,
+  "dimension_count" integer NOT NULL DEFAULT 0,
+  "notes" text,
+  "is_latest" boolean NOT NULL DEFAULT false,
+  "source_active" boolean NOT NULL DEFAULT true,
+  "synced_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_scorecard_snapshots_source"
+  ON "scorecard_snapshots" ("scorecard_source");
+CREATE INDEX IF NOT EXISTS "idx_scorecard_snapshots_published"
+  ON "scorecard_snapshots" ("published_at" DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_scorecard_snapshots_latest_per_source"
+  ON "scorecard_snapshots" ("scorecard_source")
+  WHERE "is_latest" = true;
+
+CREATE TABLE IF NOT EXISTS "scorecard_grades" (
+  "id" text PRIMARY KEY NOT NULL,
+  "snapshot_id" text NOT NULL REFERENCES "scorecard_snapshots"("id") ON DELETE CASCADE,
+  "entity_id" text NOT NULL REFERENCES "entities"("stable_id") ON DELETE CASCADE,
+  "entity_display_name" text NOT NULL,
+  "dimension_slug" text NOT NULL,
+  "dimension_label" text NOT NULL,
+  "dimension_weight" numeric,
+  "dimension_parent_slug" text,
+  "score_numeric" numeric,
+  "score_letter" text,
+  "score_raw" text NOT NULL,
+  "notes" text,
+  "source_url" text,
+  "synced_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_scorecard_grades_snapshot"
+  ON "scorecard_grades" ("snapshot_id");
+CREATE INDEX IF NOT EXISTS "idx_scorecard_grades_entity"
+  ON "scorecard_grades" ("entity_id");
+CREATE INDEX IF NOT EXISTS "idx_scorecard_grades_dimension"
+  ON "scorecard_grades" ("dimension_slug");
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_scorecard_grades_natural_key"
+  ON "scorecard_grades" ("snapshot_id", "entity_id", "dimension_slug");

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1450,6 +1450,13 @@
       "when": 1787472800000,
       "tag": "0206_qua_691_safety_frameworks",
       "breakpoints": true
+    },
+    {
+      "idx": 207,
+      "version": "7",
+      "when": 1787559200000,
+      "tag": "0207_qua_688_scorecard_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
+++ b/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression test for the `is_latest` invariant on scorecard_snapshots.
+ *
+ * Reproduces the bug found in PR #4589 review: a naive
+ * `INSERT ... is_latest=true + postUpsert reset` would trip the partial
+ * unique index `uq_scorecard_snapshots_latest_per_source` on every
+ * multi-wave sync.
+ *
+ * The fix is to insert with `is_latest=false` (so the index is never
+ * tripped) and then in postUpsert reset siblings + promote the new row
+ * inside the same transaction.
+ *
+ * This test asserts the SQL ordering the route emits on a multi-wave
+ * sync, against an in-memory mock of the db driver.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+interface SnapshotRow {
+  id: string;
+  scorecard_source: string;
+  is_latest: boolean;
+  published_at: string;
+}
+
+let store: Map<string, SnapshotRow>;
+const sqlLog: string[] = [];
+
+function resetStore() {
+  store = new Map();
+  sqlLog.length = 0;
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+  sqlLog.push(q);
+
+  // SELECT pre-fetch for audit log (Drizzle: select ... from "scorecard_snapshots" where ... in (...))
+  if (q.includes("select") && q.includes('"scorecard_snapshots"') && q.includes("where") && !q.includes("update")) {
+    return params
+      .filter((p) => store.has(p as string))
+      .map((p) => store.get(p as string)!);
+  }
+
+  // INSERT INTO "scorecard_snapshots"
+  // The sync-factory chunks by column count; we can't reconstruct the row
+  // exactly without parsing column ordering. Instead, capture that an
+  // insert happened with these param values and treat the items array
+  // (passed in via the test) as the source of truth for what got inserted.
+  if (q.includes("insert into") && q.includes('"scorecard_snapshots"')) {
+    return [];
+  }
+
+  // UPDATE "scorecard_snapshots" SET is_latest=false WHERE source=X AND is_latest=true
+  // and UPDATE ... SET is_latest=true WHERE id=X
+  if (q.includes("update") && q.includes('"scorecard_snapshots"')) {
+    return [];
+  }
+
+  // tablebase_audit_log inserts
+  if (q.includes("insert into") && q.includes("tablebase_audit_log")) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { scorecardSnapshotsRoute } = await import(
+  "../routes/tablebase/scorecard-snapshots.js"
+);
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/", scorecardSnapshotsRoute);
+  return app;
+}
+
+describe("scorecard_snapshots is_latest invariant", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("INSERT does not set is_latest=true (toRow forces false)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "fli-summer-2025",
+          scorecardSource: "fli_index",
+          publishedAt: "2025-07-17",
+          sourceUrl: "https://example.com",
+          orgCount: 7,
+          dimensionCount: 7,
+          isLatest: true,
+          sourceActive: true,
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    // Find the INSERT statement on scorecard_snapshots and assert that
+    // it ran. The exact INSERT params can't be inspected reliably without
+    // parsing Drizzle's column ordering, but we assert ordering of
+    // statements: INSERT must happen BEFORE the UPDATE that promotes
+    // is_latest=true.
+    const insertIdx = sqlLog.findIndex(
+      (q) =>
+        q.includes("insert into") && q.includes('"scorecard_snapshots"'),
+    );
+    expect(insertIdx).toBeGreaterThanOrEqual(0);
+
+    // The promote UPDATE must come strictly after the INSERT.
+    const promoteIdx = sqlLog.findIndex(
+      (q, i) =>
+        i > insertIdx &&
+        q.includes("update") &&
+        q.includes('"scorecard_snapshots"') &&
+        q.includes('"is_latest"'),
+    );
+    expect(promoteIdx).toBeGreaterThan(insertIdx);
+  });
+
+  it("emits a clear-then-promote pair of UPDATEs per source, in that order", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "fli-summer-2025",
+          scorecardSource: "fli_index",
+          publishedAt: "2025-07-17",
+          sourceUrl: "https://example.com/fli",
+          orgCount: 7,
+          dimensionCount: 7,
+          isLatest: true,
+          sourceActive: true,
+        },
+        {
+          id: "fmti-dec-2025",
+          scorecardSource: "fmti",
+          publishedAt: "2025-12-01",
+          sourceUrl: "https://example.com/fmti",
+          orgCount: 14,
+          dimensionCount: 100,
+          isLatest: true,
+          sourceActive: true,
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    // Filter to UPDATE statements on scorecard_snapshots.
+    const updates = sqlLog.filter(
+      (q) => q.includes("update") && q.includes('"scorecard_snapshots"'),
+    );
+
+    // We expect at least 4 UPDATEs: clear+promote per source × 2 sources.
+    // The exact count may include the auto-derived ON CONFLICT DO UPDATE
+    // from the INSERT, so >= 4 is the floor.
+    expect(updates.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("rejects an invalid scorecardSource via Zod enum", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "bogus-2025",
+          scorecardSource: "not-a-real-source",
+          publishedAt: "2025-01-01",
+          sourceUrl: "https://example.com",
+          orgCount: 1,
+          dimensionCount: 1,
+          isLatest: true,
+          sourceActive: true,
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
+++ b/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
@@ -34,6 +34,83 @@ function resetStore() {
   sqlLog.length = 0;
 }
 
+/**
+ * Enforce `uq_scorecard_snapshots_latest_per_source` — at most one row with
+ * is_latest=true per scorecard_source. Mirrors the partial unique index in
+ * migration 0206. Throws on violation so a regression to the naive
+ * "INSERT with is_latest=true" pattern fails the test loudly.
+ */
+function assertLatestUniqueness(): void {
+  const latestBySource = new Map<string, string[]>();
+  for (const row of store.values()) {
+    if (!row.is_latest) continue;
+    const ids = latestBySource.get(row.scorecard_source) ?? [];
+    ids.push(row.id);
+    latestBySource.set(row.scorecard_source, ids);
+  }
+  for (const [source, ids] of latestBySource) {
+    if (ids.length > 1) {
+      throw new Error(
+        `uq_scorecard_snapshots_latest_per_source violation: source=${source} has ${ids.length} latest rows (${ids.join(", ")})`,
+      );
+    }
+  }
+}
+
+/**
+ * Parse an INSERT into scorecard_snapshots and mutate `store`. The
+ * sync-factory emits one row at a time via the audit-log pre-fetch then a
+ * batched INSERT ... ON CONFLICT DO UPDATE; the schema column order (from
+ * schema.ts) fixes the param positions:
+ *   [id, scorecard_source, wave_label, published_at, source_url,
+ *    methodology_url, license, org_count, dimension_count, notes,
+ *    is_latest, source_active, synced_at, updated_at]  = 14 params per row
+ * (captured_at and created_at use SQL defaults, so are not in params.)
+ */
+const COLS_PER_ROW = 14;
+
+function applyInsert(params: unknown[]): void {
+  for (let i = 0; i < params.length; i += COLS_PER_ROW) {
+    const row: SnapshotRow = {
+      id: params[i] as string,
+      scorecard_source: params[i + 1] as string,
+      is_latest: Boolean(params[i + 10]),
+      published_at: params[i + 3] as string,
+    };
+    store.set(row.id, row);
+  }
+  assertLatestUniqueness();
+}
+
+/**
+ * Parse an UPDATE on scorecard_snapshots and mutate `store`.
+ *
+ * The route emits two UPDATE shapes:
+ *   1. SET is_latest=$1, updated_at=$2 WHERE scorecard_source=$3 AND is_latest=$4
+ *      (clear prior latest for a source)
+ *   2. SET is_latest=$1, updated_at=$2 WHERE id=$3
+ *      (promote a specific row to latest)
+ */
+function applyUpdate(q: string, params: unknown[]): void {
+  const newIsLatest = Boolean(params[0]);
+  if (q.includes("scorecard_source")) {
+    // Shape 1: clear matching source rows.
+    const source = params[2] as string;
+    const matchIsLatest = Boolean(params[3]);
+    for (const row of store.values()) {
+      if (row.scorecard_source === source && row.is_latest === matchIsLatest) {
+        row.is_latest = newIsLatest;
+      }
+    }
+  } else if (q.includes('"id"')) {
+    // Shape 2: promote by id.
+    const id = params[2] as string;
+    const row = store.get(id);
+    if (row) row.is_latest = newIsLatest;
+  }
+  assertLatestUniqueness();
+}
+
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
   sqlLog.push({ q, params });
@@ -45,18 +122,15 @@ function dispatch(query: string, params: unknown[]): unknown[] {
       .map((p) => store.get(p as string)!);
   }
 
-  // INSERT INTO "scorecard_snapshots"
-  // The sync-factory chunks by column count; we can't reconstruct the row
-  // exactly without parsing column ordering. Instead, capture that an
-  // insert happened with these param values and treat the items array
-  // (passed in via the test) as the source of truth for what got inserted.
+  // INSERT INTO "scorecard_snapshots" — mutate store + enforce unique index.
   if (q.includes("insert into") && q.includes('"scorecard_snapshots"')) {
+    applyInsert(params);
     return [];
   }
 
-  // UPDATE "scorecard_snapshots" SET is_latest=false WHERE source=X AND is_latest=true
-  // and UPDATE ... SET is_latest=true WHERE id=X
+  // UPDATE "scorecard_snapshots" — mutate store + enforce unique index.
   if (q.includes("update") && q.includes('"scorecard_snapshots"')) {
+    applyUpdate(q, params);
     return [];
   }
 
@@ -196,6 +270,42 @@ describe("scorecard_snapshots is_latest invariant", () => {
 
     assertClearBeforePromote("fli_index", "fli-summer-2025");
     assertClearBeforePromote("fmti", "fmti-dec-2025");
+  });
+
+  it("allows a new wave for a source that already has an is_latest=true row (clear must precede promote)", async () => {
+    // Seed a prior latest row that the store now actively enforces via
+    // assertLatestUniqueness. If the route ever regressed to inserting
+    // is_latest=true before running the clear, the INSERT would push a
+    // second latest row into the store and the invariant check would throw.
+    store.set("fli-spring-2024", {
+      id: "fli-spring-2024",
+      scorecard_source: "fli_index",
+      is_latest: true,
+      published_at: "2024-04-01",
+    });
+
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "fli-summer-2025",
+          scorecardSource: "fli_index",
+          publishedAt: "2025-07-17",
+          sourceUrl: "https://example.com/fli",
+          orgCount: 7,
+          dimensionCount: 7,
+          isLatest: true,
+          sourceActive: true,
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    // Final state: exactly one is_latest=true for the source, on the new id.
+    const latestRows = [...store.values()].filter(
+      (r) => r.scorecard_source === "fli_index" && r.is_latest,
+    );
+    expect(latestRows.map((r) => r.id)).toEqual(["fli-summer-2025"]);
   });
 
   it("rejects an invalid scorecardSource via Zod enum", async () => {

--- a/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
+++ b/apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts
@@ -26,7 +26,8 @@ interface SnapshotRow {
 }
 
 let store: Map<string, SnapshotRow>;
-const sqlLog: string[] = [];
+interface SqlEntry { q: string; params: unknown[]; }
+const sqlLog: SqlEntry[] = [];
 
 function resetStore() {
   store = new Map();
@@ -35,7 +36,7 @@ function resetStore() {
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
-  sqlLog.push(q);
+  sqlLog.push({ q, params });
 
   // SELECT pre-fetch for audit log (Drizzle: select ... from "scorecard_snapshots" where ... in (...))
   if (q.includes("select") && q.includes('"scorecard_snapshots"') && q.includes("where") && !q.includes("update")) {
@@ -108,14 +109,14 @@ describe("scorecard_snapshots is_latest invariant", () => {
     // statements: INSERT must happen BEFORE the UPDATE that promotes
     // is_latest=true.
     const insertIdx = sqlLog.findIndex(
-      (q) =>
+      ({ q }) =>
         q.includes("insert into") && q.includes('"scorecard_snapshots"'),
     );
     expect(insertIdx).toBeGreaterThanOrEqual(0);
 
     // The promote UPDATE must come strictly after the INSERT.
     const promoteIdx = sqlLog.findIndex(
-      (q, i) =>
+      ({ q }, i) =>
         i > insertIdx &&
         q.includes("update") &&
         q.includes('"scorecard_snapshots"') &&
@@ -152,15 +153,49 @@ describe("scorecard_snapshots is_latest invariant", () => {
     });
     expect(res.status).toBe(200);
 
-    // Filter to UPDATE statements on scorecard_snapshots.
-    const updates = sqlLog.filter(
-      (q) => q.includes("update") && q.includes('"scorecard_snapshots"'),
-    );
+    // For each source, the clear (is_latest=false) UPDATE must precede the
+    // promote (is_latest=true) UPDATE in the SQL log. A reordered or
+    // missing pair would have tripped the partial unique index pre-fix.
+    // Identify clear/promote by SQL shape:
+    //   clear:   WHERE scorecard_source = $X AND is_latest = $Y, params include source name + true (clearing the prior latest)
+    //   promote: WHERE id = $X, params include the new item id + true
+    function assertClearBeforePromote(source: string, itemId: string) {
+      const updates = sqlLog
+        .map((entry, i) => ({ ...entry, i }))
+        .filter(
+          ({ q }) =>
+            q.includes("update") &&
+            q.includes('"scorecard_snapshots"') &&
+            q.includes('"is_latest"'),
+        );
+      const clearIdx = updates.find(
+        ({ q, params }) =>
+          q.includes("scorecard_source") &&
+          params.includes(source) &&
+          params.includes(false),
+      )?.i;
+      const promoteIdx = updates.find(
+        ({ q, params }) =>
+          !q.includes("scorecard_source") &&
+          params.includes(itemId) &&
+          params.includes(true),
+      )?.i;
+      expect(
+        clearIdx,
+        `clear UPDATE missing for source=${source}`,
+      ).toBeDefined();
+      expect(
+        promoteIdx,
+        `promote UPDATE missing for id=${itemId}`,
+      ).toBeDefined();
+      expect(
+        clearIdx! < promoteIdx!,
+        `clear must precede promote for ${itemId} (clear=${clearIdx}, promote=${promoteIdx})`,
+      ).toBe(true);
+    }
 
-    // We expect at least 4 UPDATEs: clear+promote per source × 2 sources.
-    // The exact count may include the auto-derived ON CONFLICT DO UPDATE
-    // from the INSERT, so >= 4 is the floor.
-    expect(updates.length).toBeGreaterThanOrEqual(4);
+    assertClearBeforePromote("fli_index", "fli-summer-2025");
+    assertClearBeforePromote("fmti", "fmti-dec-2025");
   });
 
   it("rejects an invalid scorecardSource via Zod enum", async () => {

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -67,6 +67,8 @@ import { safetyFrameworkVersionsRoute } from "./safety-framework-versions.js";
 import { frameworkCapabilityThresholdsRoute } from "./framework-capability-thresholds.js";
 import { frameworkDiffsRoute } from "./framework-diffs.js";
 import { frameworkDiffItemsRoute } from "./framework-diff-items.js";
+import { scorecardSnapshotsRoute } from "./scorecard-snapshots.js";
+import { scorecardGradesRoute } from "./scorecard-grades.js";
 
 /**
  * The widest Hono route type that still satisfies `app.route()`. Every
@@ -139,6 +141,8 @@ export const TABLEBASE_MOUNTS: readonly TablebaseMount[] = [
   { path: "/api/framework-capability-thresholds", route: frameworkCapabilityThresholdsRoute },
   { path: "/api/framework-diffs", route: frameworkDiffsRoute },
   { path: "/api/framework-diff-items", route: frameworkDiffItemsRoute },
+  { path: "/api/scorecard-snapshots", route: scorecardSnapshotsRoute },
+  { path: "/api/scorecard-grades", route: scorecardGradesRoute },
 ];
 
 /**

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -4,7 +4,7 @@ import { eq, and, count, desc } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { scorecardGrades, scorecardSnapshots, entities } from "../../schema.js";
-import { zv, clampedLimit } from "../shared/utils.js";
+import { zv, clampedLimit, qBool } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
 
@@ -20,12 +20,12 @@ const AllQuery = z.object({
   snapshotId: z.string().max(100).optional(),
   entityId: z.string().max(200).optional(),
   scorecardSource: z.string().max(50).optional(),
-  latest: z.coerce.boolean().optional(),
+  latest: qBool.optional(),
   // overall=true filters to the per-org rollup row only. Lets the
   // /scorecards directory pull one cell per (org, source) without
   // scanning thousands of FMTI indicator rows just to throw them away
   // client-side.
-  overall: z.coerce.boolean().optional(),
+  overall: qBool.optional(),
 });
 
 // ---- Sync schema ----

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -21,6 +21,11 @@ const AllQuery = z.object({
   entityId: z.string().max(200).optional(),
   scorecardSource: z.string().max(50).optional(),
   latest: z.coerce.boolean().optional(),
+  // overall=true filters to the per-org rollup row only. Lets the
+  // /scorecards directory pull one cell per (org, source) without
+  // scanning thousands of FMTI indicator rows just to throw them away
+  // client-side.
+  overall: z.coerce.boolean().optional(),
 });
 
 // ---- Sync schema ----
@@ -83,7 +88,7 @@ function formatRow(r: GradeRow) {
 const scorecardGradesApp = new Hono()
   // GET /all
   .get("/all", zv("query", AllQuery), async (c) => {
-    const { limit, offset, snapshotId, entityId, scorecardSource, latest } =
+    const { limit, offset, snapshotId, entityId, scorecardSource, latest, overall } =
       c.req.valid("query");
     const db = getDrizzleDb();
 
@@ -94,6 +99,8 @@ const scorecardGradesApp = new Hono()
       conditions.push(eq(scorecardSnapshots.scorecardSource, scorecardSource));
     if (latest !== undefined)
       conditions.push(eq(scorecardSnapshots.isLatest, latest));
+    if (overall === true)
+      conditions.push(eq(scorecardGrades.dimensionSlug, "overall"));
 
     const where =
       conditions.length === 0

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -102,12 +102,7 @@ const scorecardGradesApp = new Hono()
     if (overall === true)
       conditions.push(eq(scorecardGrades.dimensionSlug, "overall"));
 
-    const where =
-      conditions.length === 0
-        ? undefined
-        : conditions.length === 1
-          ? conditions[0]
-          : and(...conditions);
+    const where = conditions.length ? and(...conditions) : undefined;
 
     const rows = await db
       .select({

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -1,0 +1,216 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, and, count, desc } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { scorecardGrades, scorecardSnapshots, entities } from "../../schema.js";
+import { zv, clampedLimit } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 1000;
+
+// ---- Query schemas ----
+
+const AllQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
+  offset: z.coerce.number().int().min(0).default(0),
+  snapshotId: z.string().max(100).optional(),
+  entityId: z.string().max(200).optional(),
+  scorecardSource: z.string().max(50).optional(),
+  latest: z.coerce.boolean().optional(),
+});
+
+// ---- Sync schema ----
+
+const SyncScorecardGradesItemSchema = z.object({
+  id: z.string().min(1).max(300),
+  snapshotId: z.string().min(1).max(100),
+  entityId: z.string().min(1).max(200),
+  entityDisplayName: z.string().min(1).max(500),
+  dimensionSlug: z.string().min(1).max(200),
+  dimensionLabel: z.string().min(1).max(500),
+  dimensionWeight: z.number().min(0).max(1).nullable().optional(),
+  dimensionParentSlug: z.string().max(200).nullable().optional(),
+  scoreNumeric: z.number().min(-1000).max(10000).nullable().optional(),
+  scoreLetter: z.string().max(50).nullable().optional(),
+  scoreRaw: z.string().min(1).max(500),
+  notes: z.string().max(5000).nullable().optional(),
+  sourceUrl: z.string().max(2000).nullable().optional(),
+});
+
+// ---- Helpers ----
+
+interface GradeRow {
+  grade: typeof scorecardGrades.$inferSelect;
+  entityTitle: string | null;
+  entitySlug: string | null;
+  scorecardSource: string | null;
+  publishedAt: string | null;
+  isLatest: boolean | null;
+}
+
+function formatRow(r: GradeRow) {
+  const g = r.grade;
+  return {
+    id: g.id,
+    snapshotId: g.snapshotId,
+    scorecardSource: r.scorecardSource,
+    publishedAt: r.publishedAt,
+    isLatest: r.isLatest,
+    entityId: g.entityId,
+    entityDisplayName: g.entityDisplayName,
+    entitySlug: r.entitySlug,
+    entityTitle: r.entityTitle,
+    dimensionSlug: g.dimensionSlug,
+    dimensionLabel: g.dimensionLabel,
+    dimensionWeight:
+      g.dimensionWeight == null ? null : Number(g.dimensionWeight),
+    dimensionParentSlug: g.dimensionParentSlug,
+    scoreNumeric: g.scoreNumeric == null ? null : Number(g.scoreNumeric),
+    scoreLetter: g.scoreLetter,
+    scoreRaw: g.scoreRaw,
+    notes: g.notes,
+    sourceUrl: g.sourceUrl,
+    syncedAt: g.syncedAt,
+  };
+}
+
+// ---- Route ----
+
+const scorecardGradesApp = new Hono()
+  // GET /all
+  .get("/all", zv("query", AllQuery), async (c) => {
+    const { limit, offset, snapshotId, entityId, scorecardSource, latest } =
+      c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions: SQL[] = [];
+    if (snapshotId) conditions.push(eq(scorecardGrades.snapshotId, snapshotId));
+    if (entityId) conditions.push(eq(scorecardGrades.entityId, entityId));
+    if (scorecardSource)
+      conditions.push(eq(scorecardSnapshots.scorecardSource, scorecardSource));
+    if (latest !== undefined)
+      conditions.push(eq(scorecardSnapshots.isLatest, latest));
+
+    const where =
+      conditions.length === 0
+        ? undefined
+        : conditions.length === 1
+          ? conditions[0]
+          : and(...conditions);
+
+    const rows = await db
+      .select({
+        grade: scorecardGrades,
+        entityTitle: entities.title,
+        entitySlug: entities.id,
+        scorecardSource: scorecardSnapshots.scorecardSource,
+        publishedAt: scorecardSnapshots.publishedAt,
+        isLatest: scorecardSnapshots.isLatest,
+      })
+      .from(scorecardGrades)
+      .leftJoin(
+        scorecardSnapshots,
+        eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
+      )
+      .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
+      .where(where)
+      .orderBy(
+        desc(scorecardSnapshots.publishedAt),
+        scorecardGrades.entityDisplayName,
+        scorecardGrades.dimensionSlug,
+      )
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(scorecardGrades)
+      .leftJoin(
+        scorecardSnapshots,
+        eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
+      )
+      .where(where);
+
+    return c.json({
+      items: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // GET /by-entity/:entityId — every grade for one org, latest snapshot per source
+  .get("/by-entity/:entityId", async (c) => {
+    const entityId = c.req.param("entityId");
+    const db = getDrizzleDb();
+
+    const rows = await db
+      .select({
+        grade: scorecardGrades,
+        entityTitle: entities.title,
+        entitySlug: entities.id,
+        scorecardSource: scorecardSnapshots.scorecardSource,
+        publishedAt: scorecardSnapshots.publishedAt,
+        isLatest: scorecardSnapshots.isLatest,
+      })
+      .from(scorecardGrades)
+      .leftJoin(
+        scorecardSnapshots,
+        eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
+      )
+      .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
+      .where(
+        and(
+          eq(scorecardGrades.entityId, entityId),
+          eq(scorecardSnapshots.isLatest, true),
+        ),
+      )
+      .orderBy(
+        scorecardSnapshots.scorecardSource,
+        scorecardGrades.dimensionSlug,
+      );
+
+    return c.json({ items: rows.map(formatRow), total: rows.length });
+  })
+
+  // POST /sync
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "scorecard-grades",
+      table: scorecardGrades,
+      syncSchema: SyncScorecardGradesItemSchema,
+      entityRefs: ["entityId"],
+      auditRecordType: "scorecard_grades",
+      // Drizzle's numeric() insert type is `string`; the Zod schema emits
+      // numbers. Coerce explicitly.
+      toRow: (item, now) => ({
+        id: item.id,
+        snapshotId: item.snapshotId,
+        entityId: item.entityId,
+        entityDisplayName: item.entityDisplayName,
+        dimensionSlug: item.dimensionSlug,
+        dimensionLabel: item.dimensionLabel,
+        dimensionWeight:
+          item.dimensionWeight == null ? null : String(item.dimensionWeight),
+        dimensionParentSlug: item.dimensionParentSlug ?? null,
+        scoreNumeric:
+          item.scoreNumeric == null ? null : String(item.scoreNumeric),
+        scoreLetter: item.scoreLetter ?? null,
+        scoreRaw: item.scoreRaw,
+        notes: item.notes ?? null,
+        sourceUrl: item.sourceUrl ?? null,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+    }),
+  )
+
+  .post("/delete-batch", deleteBatchHandler(scorecardGrades, null, { maxIdLength: 300 }));
+
+export const scorecardGradesRoute = scorecardGradesApp;
+export type ScorecardGradesRoute = typeof scorecardGradesApp;

--- a/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
@@ -81,12 +81,7 @@ const scorecardSnapshotsApp = new Hono()
     if (latest !== undefined)
       conditions.push(eq(scorecardSnapshots.isLatest, latest));
 
-    const where =
-      conditions.length === 0
-        ? undefined
-        : conditions.length === 1
-          ? conditions[0]
-          : and(...conditions);
+    const where = conditions.length ? and(...conditions) : undefined;
 
     const rows = await db
       .select()

--- a/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, desc, and, ne, inArray } from "drizzle-orm";
+import { eq, count, desc, and, ne } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { scorecardSnapshots } from "../../schema.js";
 import { zv, clampedLimit } from "../shared/utils.js";
@@ -178,9 +178,6 @@ const scorecardSnapshotsApp = new Hono()
   )
 
   .post("/delete-batch", deleteBatchHandler(scorecardSnapshots, null, { maxIdLength: 100 }));
-
-// Type-check unused imports
-void inArray;
 
 export const scorecardSnapshotsRoute = scorecardSnapshotsApp;
 export type ScorecardSnapshotsRoute = typeof scorecardSnapshotsApp;

--- a/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { eq, count, desc, and } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { scorecardSnapshots } from "../../schema.js";
-import { zv, clampedLimit } from "../shared/utils.js";
+import { zv, clampedLimit, qBool } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
 
@@ -25,7 +25,7 @@ const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 100),
   offset: z.coerce.number().int().min(0).default(0),
   source: z.enum(VALID_SOURCES).optional(),
-  latest: z.coerce.boolean().optional(),
+  latest: qBool.optional(),
 });
 
 // ---- Sync schema ----

--- a/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
@@ -1,0 +1,186 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, count, desc, and, ne, inArray } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { scorecardSnapshots } from "../../schema.js";
+import { zv, clampedLimit } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 200;
+
+const VALID_SOURCES = [
+  "fli_index",
+  "saferai",
+  "ailabwatch",
+  "fmti",
+  "seoul_tracker",
+] as const;
+
+// ---- Query schemas ----
+
+const AllQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
+  offset: z.coerce.number().int().min(0).default(0),
+  source: z.enum(VALID_SOURCES).optional(),
+  latest: z.coerce.boolean().optional(),
+});
+
+// ---- Sync schema ----
+
+const SyncScorecardSnapshotsItemSchema = z.object({
+  id: z.string().min(1).max(100),
+  scorecardSource: z.enum(VALID_SOURCES),
+  waveLabel: z.string().max(200).nullable().optional(),
+  publishedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "ISO date YYYY-MM-DD"),
+  sourceUrl: z.string().max(2000).min(1),
+  methodologyUrl: z.string().max(2000).nullable().optional(),
+  license: z.string().max(100).nullable().optional(),
+  orgCount: z.number().int().min(0).max(1000).default(0),
+  dimensionCount: z.number().int().min(0).max(1000).default(0),
+  notes: z.string().max(5000).nullable().optional(),
+  isLatest: z.boolean().default(false),
+  sourceActive: z.boolean().default(true),
+});
+
+// ---- Helpers ----
+
+function formatRow(r: typeof scorecardSnapshots.$inferSelect) {
+  return {
+    id: r.id,
+    scorecardSource: r.scorecardSource,
+    waveLabel: r.waveLabel,
+    publishedAt: r.publishedAt,
+    capturedAt: r.capturedAt,
+    sourceUrl: r.sourceUrl,
+    methodologyUrl: r.methodologyUrl,
+    license: r.license,
+    orgCount: r.orgCount,
+    dimensionCount: r.dimensionCount,
+    notes: r.notes,
+    isLatest: r.isLatest,
+    sourceActive: r.sourceActive,
+    syncedAt: r.syncedAt,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// ---- Route ----
+
+const scorecardSnapshotsApp = new Hono()
+  // GET /all
+  .get("/all", zv("query", AllQuery), async (c) => {
+    const { limit, offset, source, latest } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (source) conditions.push(eq(scorecardSnapshots.scorecardSource, source));
+    if (latest !== undefined)
+      conditions.push(eq(scorecardSnapshots.isLatest, latest));
+
+    const where =
+      conditions.length === 0
+        ? undefined
+        : conditions.length === 1
+          ? conditions[0]
+          : and(...conditions);
+
+    const rows = await db
+      .select()
+      .from(scorecardSnapshots)
+      .where(where)
+      .orderBy(
+        desc(scorecardSnapshots.publishedAt),
+        scorecardSnapshots.scorecardSource,
+      )
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(scorecardSnapshots)
+      .where(where);
+
+    return c.json({
+      items: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // GET /stats — used by /scorecards directory
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+    const rows = await db
+      .select({
+        source: scorecardSnapshots.scorecardSource,
+        total: count(),
+      })
+      .from(scorecardSnapshots)
+      .groupBy(scorecardSnapshots.scorecardSource);
+
+    const [{ totalSnapshots }] = await db
+      .select({ totalSnapshots: count() })
+      .from(scorecardSnapshots);
+
+    return c.json({
+      bySources: rows.map((r) => ({
+        source: r.source,
+        snapshots: r.total,
+      })),
+      totalSnapshots,
+    });
+  })
+
+  // POST /sync
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "scorecard-snapshots",
+      table: scorecardSnapshots,
+      syncSchema: SyncScorecardSnapshotsItemSchema,
+      auditRecordType: "scorecard_snapshots",
+      // is_latest invariant: at most one TRUE per scorecardSource. The
+      // partial unique index enforces it at the storage level; this hook
+      // resets siblings to FALSE when a new is_latest=true row is upserted,
+      // so the upsert can succeed without a unique-violation.
+      postUpsert: async (tx, items) => {
+        const latestPerSource = new Map<string, string>();
+        for (const item of items) {
+          if (item.isLatest) {
+            // If multiple items in the batch claim is_latest for the same
+            // source, the last one wins — sync handlers are not the place
+            // to enforce intra-batch uniqueness on this field; ingesters
+            // should send at most one is_latest=true per source.
+            latestPerSource.set(item.scorecardSource, item.id);
+          }
+        }
+        if (latestPerSource.size === 0) return;
+
+        for (const [source, latestId] of latestPerSource) {
+          await tx
+            .update(scorecardSnapshots)
+            .set({ isLatest: false, updatedAt: new Date() })
+            .where(
+              and(
+                eq(scorecardSnapshots.scorecardSource, source),
+                ne(scorecardSnapshots.id, latestId),
+                eq(scorecardSnapshots.isLatest, true),
+              ),
+            );
+        }
+      },
+    }),
+  )
+
+  .post("/delete-batch", deleteBatchHandler(scorecardSnapshots, null, { maxIdLength: 100 }));
+
+// Type-check unused imports
+void inArray;
+
+export const scorecardSnapshotsRoute = scorecardSnapshotsApp;
+export type ScorecardSnapshotsRoute = typeof scorecardSnapshotsApp;

--- a/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, desc, and, ne } from "drizzle-orm";
+import { eq, count, desc, and } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { scorecardSnapshots } from "../../schema.js";
 import { zv, clampedLimit } from "../shared/utils.js";
@@ -144,34 +144,67 @@ const scorecardSnapshotsApp = new Hono()
       table: scorecardSnapshots,
       syncSchema: SyncScorecardSnapshotsItemSchema,
       auditRecordType: "scorecard_snapshots",
-      // is_latest invariant: at most one TRUE per scorecardSource. The
-      // partial unique index enforces it at the storage level; this hook
-      // resets siblings to FALSE when a new is_latest=true row is upserted,
-      // so the upsert can succeed without a unique-violation.
+      // is_latest invariant: at most one TRUE per scorecardSource, enforced
+      // by the partial unique index uq_scorecard_snapshots_latest_per_source.
+      //
+      // The naive shape — INSERT with is_latest=true + postUpsert reset of
+      // siblings — fails on every multi-wave sync: the partial index blocks
+      // the INSERT before postUpsert ever runs (ON CONFLICT (id) doesn't
+      // catch this — the conflict is on (source) WHERE is_latest=true).
+      //
+      // Instead: force is_latest=false on every INSERT so the index is
+      // never tripped, then in postUpsert (still inside the tx) reset old
+      // siblings and promote the just-inserted row to is_latest=true.
+      // Between the two UPDATE statements, no row has is_latest=true, so
+      // the partial unique index never fires.
+      toRow: (item, now) => ({
+        id: item.id,
+        scorecardSource: item.scorecardSource,
+        waveLabel: item.waveLabel ?? null,
+        publishedAt: item.publishedAt,
+        sourceUrl: item.sourceUrl,
+        methodologyUrl: item.methodologyUrl ?? null,
+        license: item.license ?? null,
+        orgCount: item.orgCount,
+        dimensionCount: item.dimensionCount,
+        notes: item.notes ?? null,
+        // Force false at insert time; postUpsert promotes the latest row.
+        isLatest: false,
+        sourceActive: item.sourceActive,
+        syncedAt: now,
+        updatedAt: now,
+      }),
       postUpsert: async (tx, items) => {
-        const latestPerSource = new Map<string, string>();
+        const promoteByLatestId = new Map<string, string>();
         for (const item of items) {
           if (item.isLatest) {
-            // If multiple items in the batch claim is_latest for the same
-            // source, the last one wins — sync handlers are not the place
-            // to enforce intra-batch uniqueness on this field; ingesters
-            // should send at most one is_latest=true per source.
-            latestPerSource.set(item.scorecardSource, item.id);
+            // Last-write-wins if a batch sends multiple is_latest=true for
+            // the same source; ingesters should only send one per source.
+            promoteByLatestId.set(item.scorecardSource, item.id);
           }
         }
-        if (latestPerSource.size === 0) return;
+        if (promoteByLatestId.size === 0) return;
 
-        for (const [source, latestId] of latestPerSource) {
+        const now = new Date();
+        for (const [source, latestId] of promoteByLatestId) {
+          // Step 1: clear any existing is_latest=true for this source
+          // (both old siblings and, defensively, our newly-inserted row
+          // even though toRow already set it false). Single statement
+          // touches at most one row thanks to the partial unique index.
           await tx
             .update(scorecardSnapshots)
-            .set({ isLatest: false, updatedAt: new Date() })
+            .set({ isLatest: false, updatedAt: now })
             .where(
               and(
                 eq(scorecardSnapshots.scorecardSource, source),
-                ne(scorecardSnapshots.id, latestId),
                 eq(scorecardSnapshots.isLatest, true),
               ),
             );
+          // Step 2: promote the new row.
+          await tx
+            .update(scorecardSnapshots)
+            .set({ isLatest: true, updatedAt: now })
+            .where(eq(scorecardSnapshots.id, latestId));
         }
       },
     }),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -4420,3 +4420,144 @@ export const frameworkIngestLog = pgTable(
     index("idx_fil_fetched_at").on(sql`${table.fetchedAt} DESC`),
   ],
 );
+
+// ── External scorecard mirror (QUA-688 / QUA-687 Phase 1) ─────────────────
+//
+// Mirrors the five major external AI-safety scorecards (FLI AI Safety Index,
+// SaferAI, AI Lab Watch, Stanford FMTI, Seoul Commitment Tracker) into a
+// unified parent + child table.
+//
+// Two tables instead of one because dimension counts vary by 25× (4 for
+// SaferAI vs 100 for FMTI). A flat shape would force NULL overload or drop
+// subdomain structure.
+//
+// Authoritative source is data/scorecards/snapshots/*.yaml; PG is a read
+// mirror. is_latest is held to "exactly one TRUE per scorecard_source" by a
+// partial unique index + the sync handler.
+
+export const scorecardSnapshots = pgTable(
+  "scorecard_snapshots",
+  {
+    /** Stable, human-readable id, e.g. `fli-summer-2025`, `fmti-dec-2025`. */
+    id: text("id").primaryKey(),
+    /**
+     * Source enum: `fli_index`, `saferai`, `ailabwatch`, `fmti`,
+     * `seoul_tracker`. CHECK constraint enumerated against prod when
+     * additional sources are added (see .claude/rules/database-migrations.md).
+     */
+    scorecardSource: text("scorecard_source").notNull(),
+    /** Human label for the wave, e.g. "Summer 2025" or "v1.1 May 2024". */
+    waveLabel: text("wave_label"),
+    /** Publication date of this wave. */
+    publishedAt: date("published_at").notNull(),
+    /** When we ingested this snapshot. */
+    capturedAt: timestamp("captured_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    /** Canonical URL for this wave (top-level page on source site). */
+    sourceUrl: text("source_url").notNull(),
+    /** Methodology PDF / arXiv / docs URL. */
+    methodologyUrl: text("methodology_url"),
+    /** Reuse license. e.g. `CC-BY-4.0`, `fair-use-citation`. */
+    license: text("license"),
+    /** Denormalized counts for dashboards. */
+    orgCount: integer("org_count").notNull().default(0),
+    dimensionCount: integer("dimension_count").notNull().default(0),
+    /** Free-form notes (e.g. "maintenance ceased 2025-09"). */
+    notes: text("notes"),
+    /**
+     * Exactly one TRUE per scorecardSource — enforced by a partial unique
+     * index below + the sync handler.
+     */
+    isLatest: boolean("is_latest").notNull().default(false),
+    /**
+     * Whether the source is still actively updated. AI Lab Watch is frozen
+     * (Sept 2025); we keep its snapshot but mark it inactive so the UI can
+     * label it appropriately.
+     */
+    sourceActive: boolean("source_active").notNull().default(true),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_scorecard_snapshots_source").on(table.scorecardSource),
+    index("idx_scorecard_snapshots_published").on(sql`${table.publishedAt} DESC`),
+    uniqueIndex("uq_scorecard_snapshots_latest_per_source")
+      .on(table.scorecardSource)
+      .where(sql`${table.isLatest} = true`),
+  ]
+);
+
+export const scorecardGrades = pgTable(
+  "scorecard_grades",
+  {
+    /** Composite-derived id: `<snapshot>__<entity>__<dim>`, max 200 chars. */
+    id: text("id").primaryKey(),
+    /** Parent snapshot. */
+    snapshotId: text("snapshot_id")
+      .notNull()
+      .references(() => scorecardSnapshots.id, { onDelete: "cascade" }),
+    /** FK to entities.stable_id — the scored organization. */
+    entityId: text("entity_id")
+      .notNull()
+      .references(() => entities.stableId, { onDelete: "cascade" }),
+    /**
+     * Display-name cache (sibling pattern, see
+     * docs/audits/things-denormalization-audit.md). Backfilled at ingest.
+     */
+    entityDisplayName: text("entity_display_name").notNull(),
+    /**
+     * Dimension key. `overall` is the aggregate row; per-source slugs
+     * otherwise (e.g. `risk-assessment`, `fmti-indicator-42`).
+     */
+    dimensionSlug: text("dimension_slug").notNull(),
+    /** Human label, e.g. "Risk Assessment". */
+    dimensionLabel: text("dimension_label").notNull(),
+    /** Optional weight (0..1). NULL when the source is unweighted. */
+    dimensionWeight: numeric("dimension_weight"),
+    /**
+     * Optional rollup parent slug — lets FMTI's 100 indicators nest under
+     * 13 subdomains without a third table.
+     */
+    dimensionParentSlug: text("dimension_parent_slug"),
+    /** Normalized 0–100 percent where the source provides numeric scoring. */
+    scoreNumeric: numeric("score_numeric"),
+    /**
+     * Letter or categorical grade (`A-`, `C+`, `F`, `Fulfilled`, `Partial`).
+     * Either `scoreNumeric` or `scoreLetter` is set; both may be set.
+     */
+    scoreLetter: text("score_letter"),
+    /** The exact string from the source for audit (`"2.64"`, `"34%"`, `"C+"`). */
+    scoreRaw: text("score_raw").notNull(),
+    /** Per-cell free-form notes from the source. */
+    notes: text("notes"),
+    /** Deep-link URL to this specific row on the source page when available. */
+    sourceUrl: text("source_url"),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_scorecard_grades_snapshot").on(table.snapshotId),
+    index("idx_scorecard_grades_entity").on(table.entityId),
+    index("idx_scorecard_grades_dimension").on(table.dimensionSlug),
+    uniqueIndex("uq_scorecard_grades_natural_key").on(
+      table.snapshotId,
+      table.entityId,
+      table.dimensionSlug
+    ),
+  ]
+);

--- a/crux/lib/wiki-server/scorecard-grades.ts
+++ b/crux/lib/wiki-server/scorecard-grades.ts
@@ -1,0 +1,38 @@
+/**
+ * ScorecardGrades API — wiki-server client module
+ *
+ * Response types are inferred from the Hono RPC route type via
+ * InferResponseType<>, except SyncResult which comes from the shared
+ * factory response type (Hono RPC can't narrow through createSyncHandler).
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ScorecardGradesRoute } from '../../../apps/wiki-server/src/routes/tablebase/scorecard-grades.ts';
+import type { SyncResponse } from '../../../apps/wiki-server/src/routes/tablebase/sync-factory.ts';
+
+type RpcClient = ReturnType<typeof hc<ScorecardGradesRoute>>;
+
+export type ScorecardGradesAllResult = InferResponseType<RpcClient['all']['$get'], 200>;
+export type ScorecardGradesSyncResult = SyncResponse;
+
+/** Fetch all scorecard-grades rows with pagination. */
+export async function getAllScorecardGrades(
+  options?: { limit?: number; offset?: number },
+): Promise<ApiResult<ScorecardGradesAllResult>> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.offset != null) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<ScorecardGradesAllResult>(
+    'GET',
+    `/api/scorecard-grades/all${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Sync scorecard-grades (upsert). */
+export async function syncScorecardGrades(
+  items: Array<Record<string, unknown>>,
+): Promise<ApiResult<ScorecardGradesSyncResult>> {
+  return apiRequest<ScorecardGradesSyncResult>('POST', '/api/scorecard-grades/sync', { items });
+}

--- a/crux/lib/wiki-server/scorecard-snapshots.ts
+++ b/crux/lib/wiki-server/scorecard-snapshots.ts
@@ -1,0 +1,38 @@
+/**
+ * ScorecardSnapshots API — wiki-server client module
+ *
+ * Response types are inferred from the Hono RPC route type via
+ * InferResponseType<>, except SyncResult which comes from the shared
+ * factory response type (Hono RPC can't narrow through createSyncHandler).
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ScorecardSnapshotsRoute } from '../../../apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts';
+import type { SyncResponse } from '../../../apps/wiki-server/src/routes/tablebase/sync-factory.ts';
+
+type RpcClient = ReturnType<typeof hc<ScorecardSnapshotsRoute>>;
+
+export type ScorecardSnapshotsAllResult = InferResponseType<RpcClient['all']['$get'], 200>;
+export type ScorecardSnapshotsSyncResult = SyncResponse;
+
+/** Fetch all scorecard-snapshots rows with pagination. */
+export async function getAllScorecardSnapshots(
+  options?: { limit?: number; offset?: number },
+): Promise<ApiResult<ScorecardSnapshotsAllResult>> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.offset != null) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<ScorecardSnapshotsAllResult>(
+    'GET',
+    `/api/scorecard-snapshots/all${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Sync scorecard-snapshots (upsert). */
+export async function syncScorecardSnapshots(
+  items: Array<Record<string, unknown>>,
+): Promise<ApiResult<ScorecardSnapshotsSyncResult>> {
+  return apiRequest<ScorecardSnapshotsSyncResult>('POST', '/api/scorecard-snapshots/sync', { items });
+}

--- a/crux/tablebase/table-registry.ts
+++ b/crux/tablebase/table-registry.ts
@@ -343,6 +343,33 @@ const TABLE_CONFIGS: Record<string, TableConfig> = {
     deletePath: '/api/framework-diff-items/delete-batch',
     thingsSourceTable: null,
   },
+
+  // QUA-688: External scorecard mirror (FLI, SaferAI, AI Lab Watch, FMTI,
+  // Seoul Tracker). Parent + child shape — `scorecard_snapshots` is one row
+  // per (source, wave); `scorecard_grades` is one row per (snapshot, org,
+  // dimension). Neither syncs to `things` because they're aggregated /
+  // dimensional, not first-class entities.
+  'scorecard-snapshots': {
+    // Snapshots aren't keyed to an entity; the by-entity endpoint is unused.
+    // Kept consistent in case a discovery pass needs it later.
+    fetchByEntityPath: (id) => `/api/scorecard-snapshots/all?source=${encodeURIComponent(id)}`,
+    resultKey: 'items',
+    syncPath: '/api/scorecard-snapshots/sync',
+    syncMethod: 'POST',
+    syncBodyKey: 'items',
+    deletePath: '/api/scorecard-snapshots/delete-batch',
+    thingsSourceTable: null,
+  },
+
+  'scorecard-grades': {
+    fetchByEntityPath: (id) => `/api/scorecard-grades/by-entity/${encodeURIComponent(id)}`,
+    resultKey: 'items',
+    syncPath: '/api/scorecard-grades/sync',
+    syncMethod: 'POST',
+    syncBodyKey: 'items',
+    deletePath: '/api/scorecard-grades/delete-batch',
+    thingsSourceTable: null,
+  },
 };
 
 // Scanner uses underscored table names — map them to the canonical hyphenated form

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -521,6 +521,19 @@ const PARALLEL_STEPS: Step[] = [
     emitOutputInCi: true,
   },
   {
+    id: 'scorecard-refs',
+    name: 'Scorecard data integrity (is_latest invariant + entity refs)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-scorecard-refs.ts'],
+    cwd: PROJECT_ROOT,
+    // Advisory: requires the wiki-server (scorecard tables live only in PG).
+    // Skips silently when offline. QUA-688 — will promote to blocking once
+    // ingesters land and the data baseline stabilizes.
+    advisory: true,
+    requiresServer: true,
+    emitOutputInCi: true,
+  },
+  {
     id: 'sid-display',
     name: 'No sid_ values in display name columns',
     command: 'npx',

--- a/crux/validate/validate-scorecard-refs.ts
+++ b/crux/validate/validate-scorecard-refs.ts
@@ -71,9 +71,11 @@ interface EntitiesResponse {
 }
 
 async function fetchAllSnapshots(): Promise<ApiResult<SnapshotRow[]>> {
+  // Only is_latest=true rows are relevant to the is_latest invariant. At most
+  // one per source, so 200 is a generous cap (5 sources × ~few waves max).
   const result = await apiRequest<SnapshotsResponse>(
     "GET",
-    `/api/scorecard-snapshots/all?limit=200`,
+    `/api/scorecard-snapshots/all?latest=true&limit=200`,
   );
   if (!result.ok) return result;
   return { ok: true, data: result.data.items };

--- a/crux/validate/validate-scorecard-refs.ts
+++ b/crux/validate/validate-scorecard-refs.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+/**
+ * Scorecard data integrity (QUA-688 Phase 1).
+ *
+ * Two checks against the wiki-server's `/api/scorecard-*` endpoints:
+ *
+ *   1. **is_latest invariant** — at most one snapshot per `scorecardSource`
+ *      has `isLatest=true`. The PG partial unique index enforces this at
+ *      the storage layer, but a client validator catches drift earlier.
+ *   2. **Entity reference resolution** — every `entity_id` on a
+ *      `scorecard_grades` row resolves to a PG entity. The `entity_id` FK
+ *      already points at `entities.stable_id`, but if an entity is later
+ *      pruned, ON DELETE CASCADE removes the grade — so this check is
+ *      really catching the bypass of "soft-orphan" rows where the
+ *      entities row was renamed but its stable_id remained.
+ *
+ * Network dependency: skips silently when wiki-server is unreachable
+ * (advisory tier — we'd rather miss a check than fail PRs offline).
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-scorecard-refs.ts
+ *   npx tsx crux/validate/validate-scorecard-refs.ts --ci
+ *
+ * Exit codes:
+ *   0 = All checks pass (or server unreachable)
+ *   1 = Invariant violation found
+ */
+
+import { fileURLToPath } from "url";
+import { getColors } from "../lib/output.ts";
+import { apiRequest, type ApiResult } from "../lib/wiki-server/client.ts";
+import type { ValidatorResult, ValidatorOptions } from "./types.ts";
+
+interface SnapshotRow {
+  id: string;
+  scorecardSource: string;
+  isLatest: boolean;
+  publishedAt: string;
+}
+
+interface GradeRow {
+  id: string;
+  snapshotId: string;
+  scorecardSource: string | null;
+  entityId: string;
+  entityDisplayName: string;
+  dimensionSlug: string;
+}
+
+interface SnapshotsResponse {
+  items: SnapshotRow[];
+  total: number;
+}
+
+interface GradesResponse {
+  items: GradeRow[];
+  total: number;
+}
+
+interface EntityRow {
+  id: string;
+  stableId: string | null;
+}
+
+interface EntitiesResponse {
+  entities: EntityRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+async function fetchAllSnapshots(): Promise<ApiResult<SnapshotRow[]>> {
+  const result = await apiRequest<SnapshotsResponse>(
+    "GET",
+    `/api/scorecard-snapshots/all?limit=200`,
+  );
+  if (!result.ok) return result;
+  return { ok: true, data: result.data.items };
+}
+
+async function fetchAllGrades(): Promise<ApiResult<GradeRow[]>> {
+  const PAGE_SIZE = 1000;
+  const MAX_PAGES = 50; // 50,000-row safety cap
+  const all: GradeRow[] = [];
+  let offset = 0;
+  let total = Infinity;
+
+  for (let i = 0; i < MAX_PAGES && offset < total; i++) {
+    const result = await apiRequest<GradesResponse>(
+      "GET",
+      `/api/scorecard-grades/all?limit=${PAGE_SIZE}&offset=${offset}`,
+    );
+    if (!result.ok) return result;
+    all.push(...result.data.items);
+    total = result.data.total;
+    offset += PAGE_SIZE;
+  }
+  return { ok: true, data: all };
+}
+
+async function fetchAllEntityStableIds(): Promise<ApiResult<Set<string>>> {
+  const PAGE_SIZE = 500;
+  const MAX_PAGES = 100;
+  const stableIds = new Set<string>();
+  let offset = 0;
+  let total = Infinity;
+
+  for (let i = 0; i < MAX_PAGES && offset < total; i++) {
+    const result = await apiRequest<EntitiesResponse>(
+      "GET",
+      `/api/entities?limit=${PAGE_SIZE}&offset=${offset}`,
+    );
+    if (!result.ok) return result;
+    for (const e of result.data.entities) {
+      if (e.stableId) stableIds.add(e.stableId);
+    }
+    total = result.data.total;
+    offset += PAGE_SIZE;
+  }
+  return { ok: true, data: stableIds };
+}
+
+interface CheckResult {
+  serverAvailable: boolean;
+  snapshotCount: number;
+  gradeCount: number;
+  isLatestViolations: Array<{ source: string; snapshotIds: string[] }>;
+  unresolvedEntityRefs: Array<{ id: string; entityId: string; entityDisplayName: string }>;
+}
+
+async function detect(): Promise<CheckResult> {
+  const snapshots = await fetchAllSnapshots();
+  if (!snapshots.ok) {
+    return {
+      serverAvailable: false,
+      snapshotCount: 0,
+      gradeCount: 0,
+      isLatestViolations: [],
+      unresolvedEntityRefs: [],
+    };
+  }
+
+  // is_latest invariant
+  const latestPerSource = new Map<string, string[]>();
+  for (const s of snapshots.data) {
+    if (!s.isLatest) continue;
+    const list = latestPerSource.get(s.scorecardSource) ?? [];
+    list.push(s.id);
+    latestPerSource.set(s.scorecardSource, list);
+  }
+  const isLatestViolations: CheckResult["isLatestViolations"] = [];
+  for (const [source, ids] of latestPerSource) {
+    if (ids.length > 1) {
+      isLatestViolations.push({ source, snapshotIds: ids });
+    }
+  }
+
+  const grades = await fetchAllGrades();
+  if (!grades.ok) {
+    return {
+      serverAvailable: true,
+      snapshotCount: snapshots.data.length,
+      gradeCount: 0,
+      isLatestViolations,
+      unresolvedEntityRefs: [],
+    };
+  }
+
+  const entityIds = await fetchAllEntityStableIds();
+  if (!entityIds.ok) {
+    return {
+      serverAvailable: true,
+      snapshotCount: snapshots.data.length,
+      gradeCount: grades.data.length,
+      isLatestViolations,
+      unresolvedEntityRefs: [],
+    };
+  }
+
+  const unresolved: CheckResult["unresolvedEntityRefs"] = [];
+  for (const g of grades.data) {
+    if (!entityIds.data.has(g.entityId)) {
+      unresolved.push({
+        id: g.id,
+        entityId: g.entityId,
+        entityDisplayName: g.entityDisplayName,
+      });
+    }
+  }
+
+  return {
+    serverAvailable: true,
+    snapshotCount: snapshots.data.length,
+    gradeCount: grades.data.length,
+    isLatestViolations,
+    unresolvedEntityRefs: unresolved,
+  };
+}
+
+export async function runCheck(
+  options: ValidatorOptions = {},
+): Promise<ValidatorResult> {
+  const colors = getColors();
+  const ciMode = options.ci ?? false;
+
+  const result = await detect();
+
+  if (!result.serverAvailable) {
+    if (!ciMode) {
+      console.log(
+        `\n${colors.dim}  Wiki-server unreachable — skipping scorecard checks${colors.reset}`,
+      );
+    }
+    return { passed: true, errors: 0, warnings: 0 };
+  }
+
+  if (ciMode) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(
+      `\n  Snapshots: ${result.snapshotCount}  ·  Grades: ${result.gradeCount}`,
+    );
+
+    if (result.isLatestViolations.length === 0) {
+      console.log(
+        `${colors.green}  ✓ is_latest invariant: at most one TRUE per source${colors.reset}`,
+      );
+    } else {
+      console.log(
+        `${colors.red}  ✗ is_latest invariant violated:${colors.reset}`,
+      );
+      for (const v of result.isLatestViolations) {
+        console.log(
+          `    ${colors.red}${v.source}${colors.reset}: ${v.snapshotIds.join(", ")}`,
+        );
+      }
+    }
+
+    if (result.unresolvedEntityRefs.length === 0) {
+      console.log(
+        `${colors.green}  ✓ Every grade entity_id resolves to an entities row${colors.reset}`,
+      );
+    } else {
+      console.log(
+        `${colors.red}  ✗ ${result.unresolvedEntityRefs.length} grade rows reference unknown entity:${colors.reset}`,
+      );
+      for (const u of result.unresolvedEntityRefs.slice(0, 20)) {
+        console.log(
+          `    ${colors.red}${u.id}${colors.reset} → ${u.entityId} (${u.entityDisplayName})`,
+        );
+      }
+      if (result.unresolvedEntityRefs.length > 20) {
+        console.log(
+          `    ${colors.dim}... and ${result.unresolvedEntityRefs.length - 20} more${colors.reset}`,
+        );
+      }
+    }
+  }
+
+  const errors =
+    result.isLatestViolations.length + result.unresolvedEntityRefs.length;
+  return { passed: errors === 0, errors, warnings: 0 };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const result = await runCheck({ ci: args.includes("--ci") });
+  process.exit(result.passed ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/crux/validate/validate-scorecard-refs.ts
+++ b/crux/validate/validate-scorecard-refs.ts
@@ -118,7 +118,9 @@ async function fetchAllEntityStableIds(): Promise<ApiResult<Set<string>>> {
       if (e.stableId) stableIds.add(e.stableId);
     }
     total = result.data.total;
-    offset += PAGE_SIZE;
+    // Use the response's actual limit rather than PAGE_SIZE — defensive
+    // against silent server-side clamping (e.g. if maxLimit shrinks).
+    offset += result.data.limit ?? PAGE_SIZE;
   }
   return { ok: true, data: stableIds };
 }


### PR DESCRIPTION
## Summary

Phase 1 of QUA-687 (AI safety data layer): mirrors the five external AI-safety scorecards (FLI Index, SaferAI, AI Lab Watch, Stanford FMTI, Seoul Tracker) into a unified parent + child PG model that surfaces side-by-side on a `/scorecards` directory and as a Scorecards tab on organization profiles.

This PR ships **the framework only** — schema, sync handlers, directory, tab, and gate validator. Per-source data ingesters are filed as **QUA-697** (FMTI CSV — easiest, has CC-BY-4.0 CSVs on GitHub) and **QUA-698** (FLI / SaferAI / AI Lab Watch / Seoul, all of which need scrape + LLM-extraction).

Fixes QUA-688.

## Schema

* `scorecard_snapshots` (one row per source × wave) with `is_latest` partial unique index enforcing exactly-one-per-source + a `postUpsert` hook that resets siblings to FALSE on each rewave.
* `scorecard_grades` (one row per snapshot × org × dimension) with:
  * `dimension_parent_slug` so FMTI's 100 indicators can roll up under 13 subdomains without a third table
  * `score_numeric` + `score_letter` + `score_raw` to preserve native scoring across letter/percent/categorical sources
  * FK to `entities.stable_id` + `entity_display_name` cache column (sibling pattern per `things-denormalization-audit.md`)

Migration `0204_qua_688_scorecard_tables.sql` — small tables (~5K rows max), plain `CREATE TABLE`/`CREATE INDEX`, no `NOT VALID` needed yet.

## Routes (sync-factory pilot)

Both routes are factory-driven (`createSyncHandler`) per `.claude/rules/tablebase-sync-factory.md`:

* `POST /api/scorecard-snapshots/sync` — `is_latest` is set via a `postUpsert` clear-then-promote sequence inside the same tx, so the partial unique index is never tripped on multi-wave syncs (caught in self-review; regression test in `apps/wiki-server/src/__tests__/scorecard-snapshots-is-latest.test.ts`).
* `POST /api/scorecard-grades/sync` — entity-FK validation on `entityId`; numeric coercion in `toRow`.

Mount registry, table registry, and CLI client modules wired up. Validators (tablebase-completeness, tablebase-registry) green.

## Validator

`crux/validate/validate-scorecard-refs.ts` (advisory) — checks:
1. `is_latest` invariant: at most one TRUE per `scorecardSource`
2. Every grade `entity_id` resolves to an entities row

Gracefully skips when wiki-server is unreachable. Will promote to blocking once data baseline stabilizes (tracked under QUA-698).

## UI

* `/scorecards` directory: matrix view (rows = orgs, cols = scorecards) of overall grades. Methodology panel per source. Empty-state copy explains the framework is live but ingesters are pending. Linked from header nav under Policy. Snapshot + grades fetched in parallel; `?overall=true` server-side filter keeps the query bounded as FMTI lands.
* `/organizations/<slug>` profile: new **Scorecards** tab in the governance group (Award icon), only rendered when grades exist for the org. Per-source panels with overall + dimension drill-down.

Score-display logic is unified through a single `formatScoreCell()` helper used by the matrix, the org section, and the test fixtures.

## Out of scope (filed as follow-ups)

* **QUA-697** — FMTI ingester (CSV from GitHub). Cheapest data path; ~3 waves × 14 orgs × ~100 indicators ≈ 4,200 rows.
* **QUA-698** — FLI / SaferAI / AI Lab Watch / Seoul ingesters. ~350 rows aggregate. AI Lab Watch is frozen (Sept 2025) — flagged via `source_active=false`.

The framework PR is intentionally data-free: shipping unverified hand-transcribed grades would let us claim coverage we don't actually have. Each ingester ticket is independently shippable.

## Test plan

- [x] `pnpm --filter wiki-server typecheck` — green
- [x] `cd apps/web && npx tsc --noEmit` — green
- [x] Tests pass on changed files: 14 tests across `scorecards-constants.test.ts` and `scorecard-snapshots-is-latest.test.ts`
- [x] Pre-existing 5 failures in `crux/wiki-server/snapshot-resources.test.ts` (data drift on `resources-snapshot.json`, present on main, unrelated to this PR)
- [x] `WIKI_SERVER_ENV=prod pnpm crux w validate gate --no-cache` — 54/54 pass, 4 advisory warnings (none from this PR)
- [x] `pnpm build` — green; `/scorecards` route present
- [x] `/agent-review-pr` self-review pass (caught the `is_latest` race blocker before merge)
- [x] `/simplify` pass — `formatScoreCell()` extracted, `DIMENSION_OVERALL` constant, redundant lookup map dropped, snapshot+grades fetches parallelized

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0204 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New API route "scorecard-grades" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/scorecard-grades/all?limit=1" -o /dev/null -w "%{http_code}"`
- [ ] `route` New API route "scorecard-snapshots" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/scorecard-snapshots/all?limit=1" -o /dev/null -w "%{http_code}"`
- [ ] `manual` Visit `https://www.longtermwiki.com/scorecards` after Vercel redeploy — expect five methodology panels with "not yet ingested" labels and an empty-state matrix message. The framework is data-free; matrix rows will only appear once QUA-697 / QUA-698 land their ingesters.
- [ ] `manual` Visit a frontier-lab org profile (e.g. `/organizations/anthropic`) — expect NO Scorecards tab yet (tab is conditional on grades existing). Tab will appear once ingesters populate the table.
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Safety Scorecards" navigation link in the Policy dropdown.
  * Introduced new Scorecards page displaying organizations and their external safety scorecard grades across multiple sources.
  * Added Scorecards tab to organization pages showing external scorecard data with grades, scores, and publication dates.
  * Integrated five external safety scorecard sources with source metadata, publisher links, and methodology information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->