### PR TITLE
feat(linear): inherit parent project + add crux linear update (QUA-516)

### DIFF
--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -114,6 +114,7 @@ beforeEach(() => {
   // and leaves queued `mockResolvedValueOnce` values intact. Without this,
   // a test that queues a Once value without consuming it will poison the
   // next test's mock queue.
+  getIssueMock.mockReset();
   getCommentsMock.mockReset();
   githubApiMock.mockReset();
   // Default: dedup checks find nothing. Individual tests override.

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -598,6 +598,105 @@ describe('linear update', () => {
     expect(parsed.identifier).toBe('QUA-184');
     expect(parsed.changed).toEqual(['priority=medium']);
   });
+
+  // ── Bare-flag rejection (boolean coercion guard) ────────────────────────
+
+  it('rejects bare --project (boolean true) instead of crashing', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      // Mimics the CLI parser: `--project` with no value becomes boolean true.
+      project: true as unknown as string,
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('--project requires a value');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects bare --parent', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      parent: true as unknown as string,
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('--parent requires a value');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects bare --title', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      title: true as unknown as string,
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('--title requires a value');
+  });
+
+  it('rejects empty --title (would clobber the issue title)', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      title: '',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('--title cannot be empty');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('updates description from --description-file', async () => {
+    const { writeFileSync, unlinkSync, mkdtempSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const dir = mkdtempSync(join(tmpdir(), 'linear-test-'));
+    const file = join(dir, 'desc.md');
+    writeFileSync(file, '## New body');
+
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      descriptionFile: file,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      description: '## New body',
+    });
+    unlinkSync(file);
+  });
+
+  it('reports failure when parent issue does not exist', async () => {
+    getIssueMock
+      .mockResolvedValueOnce(mockIssue) // initial issue lookup OK
+      .mockResolvedValueOnce(null);     // parent lookup fails
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      parent: 'QUA-9999',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Parent issue not found');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative priority', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      priority: '-1',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Invalid priority');
+  });
+
+  it('rejects priority above 4', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      priority: '5',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Invalid priority');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 const {
   getIssueMock,
   getCommentsMock,
+  updateIssueMock,
   updateIssueStateMock,
   commentOnIssueMock,
   searchIssuesMock,
@@ -24,6 +25,7 @@ const {
 } = vi.hoisted(() => ({
   getIssueMock: vi.fn(),
   getCommentsMock: vi.fn(),
+  updateIssueMock: vi.fn(),
   updateIssueStateMock: vi.fn(),
   commentOnIssueMock: vi.fn(),
   searchIssuesMock: vi.fn(),
@@ -45,6 +47,7 @@ const {
 vi.mock('../../lib/linear/issues.ts', () => ({
   getIssue: getIssueMock,
   getComments: getCommentsMock,
+  updateIssue: updateIssueMock,
   updateIssueState: updateIssueStateMock,
   commentOnIssue: commentOnIssueMock,
   searchIssues: searchIssuesMock,
@@ -308,6 +311,78 @@ describe('linear create', () => {
     });
   });
 
+  // ── QUA-516: parent-project inheritance ───────────────────────────────────
+
+  it('inherits the parent project when --project is omitted', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Epic',
+      project: { id: 'inherited-project-uuid', name: 'Data Model Unwind' },
+    });
+    const r = await commands.create(['Child ticket'], {
+      ci: true,
+      parent: 'QUA-408',
+    });
+    expect(r.exitCode).toBe(0);
+    // No getProject lookup needed — the inherited UUID is on the parent.
+    expect(getProjectMock).not.toHaveBeenCalled();
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentId: 'parent-uuid',
+        projectId: 'inherited-project-uuid',
+      }),
+    );
+    expect(r.output).toContain('Data Model Unwind');
+    expect(r.output).toContain('inherited from parent');
+  });
+
+  it('explicit --project overrides parent inheritance', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Epic',
+      project: { id: 'parent-project-uuid', name: 'Parent Project' },
+    });
+    getProjectMock.mockResolvedValueOnce({
+      id: 'override-project-uuid',
+      name: 'Other Project',
+    });
+    const r = await commands.create(['Child'], {
+      ci: true,
+      parent: 'QUA-408',
+      project: 'Other Project',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(getProjectMock).toHaveBeenCalledWith('Other Project');
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentId: 'parent-uuid',
+        projectId: 'override-project-uuid',
+      }),
+    );
+    expect(r.output).toContain('Other Project');
+    expect(r.output).not.toContain('inherited from parent');
+  });
+
+  it('does not set a project when parent has none and --project is omitted', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Epic',
+      project: null,
+    });
+    const r = await commands.create(['Child'], { ci: true, parent: 'QUA-408' });
+    expect(r.exitCode).toBe(0);
+    expect(createIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentId: 'parent-uuid',
+        projectId: undefined,
+      }),
+    );
+    expect(r.output).not.toContain('inherited from parent');
+  });
+
   // ── Ticket-sizing red flags (QUA-575) ────────────────────────────────────
 
   it('refuses creation with exit=2 when title contains red-flag tokens', async () => {
@@ -380,6 +455,148 @@ describe('linear create', () => {
     expect(parsed.flags[0].kind).toBe('phase-or-wave');
     expect(parsed.hint).toContain('--allow-big');
     expect(createIssueMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update — QUA-516
+// ---------------------------------------------------------------------------
+
+describe('linear update', () => {
+  beforeEach(() => {
+    updateIssueMock.mockResolvedValue({ identifier: 'QUA-184' });
+  });
+
+  it('prints usage when no ID is given', async () => {
+    const r = await commands.update([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+  });
+
+  it('prints not-found when the issue does not exist', async () => {
+    getIssueMock.mockResolvedValueOnce(null);
+    const r = await commands.update(['QUA-9999'], {
+      ci: true,
+      project: 'Some Project',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('not found');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when no fields are provided', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Nothing to update');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('updates the project by name', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getProjectMock.mockResolvedValueOnce({
+      id: 'project-uuid',
+      name: 'Data Model Unwind',
+    });
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      project: 'Data Model Unwind',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      projectId: 'project-uuid',
+    });
+    expect(r.output).toContain('Data Model Unwind');
+  });
+
+  it('clears the project with --project=none', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      project: 'none',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(getProjectMock).not.toHaveBeenCalled();
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      projectId: null,
+    });
+    expect(r.output).toContain('cleared');
+  });
+
+  it('fails cleanly when --project does not match a known project', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    getProjectMock.mockResolvedValueOnce(null);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      project: 'Nonexistent',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Project not found');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('updates priority + title in one call', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      priority: '2',
+      title: 'Clearer title',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      priority: 2,
+      title: 'Clearer title',
+    });
+  });
+
+  it('rejects an out-of-range priority', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      priority: '99',
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Invalid priority');
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the parent with --parent=none', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      parent: 'none',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      parentId: null,
+    });
+  });
+
+  it('resolves --parent QUA-NNN to the parent UUID', async () => {
+    getIssueMock
+      .mockResolvedValueOnce(mockIssue) // initial issue lookup
+      .mockResolvedValueOnce({ ...mockIssue, id: 'parent-uuid', identifier: 'QUA-408' }); // parent lookup
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      parent: 'QUA-408',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueMock).toHaveBeenCalledWith('QUA-184', {
+      parentId: 'parent-uuid',
+    });
+  });
+
+  it('emits JSON when --json is set', async () => {
+    getIssueMock.mockResolvedValueOnce(mockIssue);
+    const r = await commands.update(['QUA-184'], {
+      ci: true,
+      json: true,
+      priority: '3',
+    });
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.output);
+    expect(parsed.identifier).toBe('QUA-184');
+    expect(parsed.changed).toEqual(['priority=medium']);
   });
 });
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -8,6 +8,7 @@
  *   crux linear view <QUA-NNN>          Show full issue + comments
  *   crux linear search <query>          Search QUA team issues
  *   crux linear create <title>          Create a new issue
+ *   crux linear update <QUA-NNN>        Update project, priority, title, description, parent
  *   crux linear comment <QUA-NNN> <msg> Post a comment
  *   crux linear start <QUA-NNN>         Move to In Progress + start comment
  *   crux linear done <QUA-NNN> --pr=URL Move to In Review + done comment
@@ -23,7 +24,9 @@ import {
   getComments,
   getIssue,
   searchIssues,
+  updateIssue,
   updateIssueState,
+  type UpdateIssueInput,
 } from '../lib/linear/issues.ts';
 import {
   createProjectUpdate,
@@ -67,6 +70,7 @@ interface CommandOptions extends BaseOptions {
   priority?: string;
   parent?: string;
   project?: string;
+  title?: string;
   content?: string;
   contentFile?: string;
   name?: string;
@@ -499,6 +503,7 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   // Resolve parent issue (QUA-NNN → internal UUID)
   let parentId: string | undefined;
   let parentLabel: string | undefined;
+  let parentProject: { id: string; name: string } | null = null;
   if (options.parent) {
     const parent = await getIssue(options.parent);
     if (!parent) {
@@ -509,11 +514,15 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     }
     parentId = parent.id;
     parentLabel = `${parent.identifier} — ${parent.title}`;
+    parentProject = parent.project;
   }
 
-  // Resolve project (UUID or case-insensitive exact name)
+  // Resolve project (UUID or case-insensitive exact name).
+  // QUA-516: when --parent has a project and --project is omitted, inherit
+  // it. Explicit --project always wins.
   let projectId: string | undefined;
   let projectLabel: string | undefined;
+  let projectInherited = false;
   if (options.project) {
     const project = await getProject(options.project);
     if (!project) {
@@ -524,6 +533,10 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     }
     projectId = project.id;
     projectLabel = project.name;
+  } else if (parentProject) {
+    projectId = parentProject.id;
+    projectLabel = parentProject.name;
+    projectInherited = true;
   }
 
   const result = await createIssue({ title, description, priority, parentId, projectId });
@@ -535,8 +548,116 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   let out = '';
   out += `${c.green}✓${c.reset} Created ${c.cyan}${result.identifier}${c.reset} — ${title}\n`;
   if (parentLabel) out += `  ${c.dim}parent:${c.reset}  ${parentLabel}\n`;
-  if (projectLabel) out += `  ${c.dim}project:${c.reset} ${projectLabel}\n`;
+  if (projectLabel) {
+    const tag = projectInherited ? ` ${c.dim}(inherited from parent)${c.reset}` : '';
+    out += `  ${c.dim}project:${c.reset} ${projectLabel}${tag}\n`;
+  }
   out += `  ${result.url}\n`;
+  return { output: out, exitCode: 0 };
+}
+
+/**
+ * Update a non-state field on an existing issue (project, priority, title,
+ * description, parent). Workflow-state changes go through `start` / `done`.
+ *
+ * QUA-516: previously the only way to change an issue's project was a one-off
+ * GraphQL script. This exposes the existing `issueUpdate` mutation cleanly.
+ */
+async function update(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const id = parseLinearId(args[0]);
+  if (!id) {
+    return {
+      output: `${c.red}Usage: crux linear update <QUA-NNN> [--project=<name|uuid>] [--priority=1-4] [--title=...] [--description=...] [--description-file=<path>] [--parent=QUA-NNN|none]${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const issue = await getIssue(id);
+  if (!issue) {
+    return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
+  }
+
+  const input: UpdateIssueInput = {};
+  const changed: string[] = [];
+
+  if (options.project !== undefined) {
+    if (options.project === '' || options.project.toLowerCase() === 'none') {
+      input.projectId = null;
+      changed.push('project=(cleared)');
+    } else {
+      const project = await getProject(options.project);
+      if (!project) {
+        return {
+          output: `${c.red}Project not found: ${options.project}${c.reset}\n  Run ${c.cyan}crux linear project list${c.reset} to see available projects.\n`,
+          exitCode: 1,
+        };
+      }
+      input.projectId = project.id;
+      changed.push(`project=${project.name}`);
+    }
+  }
+
+  if (options.priority !== undefined) {
+    const priority = parseInt(options.priority, 10);
+    if (Number.isNaN(priority) || priority < 0 || priority > 4) {
+      return {
+        output: `${c.red}Invalid priority "${options.priority}" — must be 0 (none), 1 (urgent), 2 (high), 3 (medium), or 4 (low)${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+    input.priority = priority;
+    changed.push(`priority=${priorityLabel(priority)}`);
+  }
+
+  if (options.title !== undefined) {
+    input.title = options.title;
+    changed.push('title');
+  }
+
+  const descFromFile = readBodyFlag(options.descriptionFile);
+  if (descFromFile !== null) {
+    input.description = descFromFile;
+    changed.push('description');
+  } else if (options.description !== undefined) {
+    input.description = options.description;
+    changed.push('description');
+  }
+
+  if (options.parent !== undefined) {
+    if (options.parent === '' || options.parent.toLowerCase() === 'none') {
+      input.parentId = null;
+      changed.push('parent=(cleared)');
+    } else {
+      const parent = await getIssue(options.parent);
+      if (!parent) {
+        return {
+          output: `${c.red}Parent issue not found: ${options.parent}${c.reset}\n`,
+          exitCode: 1,
+        };
+      }
+      input.parentId = parent.id;
+      changed.push(`parent=${parent.identifier}`);
+    }
+  }
+
+  if (Object.keys(input).length === 0) {
+    return {
+      output: `${c.red}Nothing to update. Pass --project, --priority, --title, --description, --description-file, or --parent.${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  await updateIssue(id, input);
+
+  if (options.json) {
+    return { output: JSON.stringify({ identifier: id, changed }, null, 2) + '\n', exitCode: 0 };
+  }
+
+  let out = `${c.green}✓${c.reset} Updated ${c.cyan}${id}${c.reset} — ${changed.join(', ')}\n`;
+  out += `  ${issue.url}\n`;
   return { output: out, exitCode: 0 };
 }
 
@@ -1033,6 +1154,7 @@ export const commands = {
   search,
   comment,
   create,
+  update,
   start,
   done,
   audit,
@@ -1052,6 +1174,7 @@ Commands:
   view <QUA-NNN>                Show full issue + recent comments (default)
   search <query>                Search QUA team issues
   create <title>                Create a new issue in the QUA team
+  update <QUA-NNN>              Update project, priority, title, description, or parent
   comment <QUA-NNN> <message>   Post a comment on an issue
   start <QUA-NNN>               Move issue to In Progress + post start comment
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
@@ -1068,8 +1191,18 @@ Options (create):
   --description-file=<path>  Issue description from file (safe for multiline)
   --priority=N               Priority: 1=urgent, 2=high, 3=medium, 4=low (default: none)
   --parent=QUA-NNN           Parent issue (sets the child link to an epic)
-  --project=<name|uuid>      Project (UUID or case-insensitive exact name)
+  --project=<name|uuid>      Project (UUID or case-insensitive exact name).
+                             When --parent has a project and --project is
+                             omitted, the parent's project is inherited.
   --allow-big                Bypass the ticket-sizing red-flag check (see .claude/rules/ticket-sizing.md)
+
+Options (update):
+  --project=<name|uuid|none> Set or clear the project (use "none" to clear)
+  --priority=N               Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low
+  --title=<text>             Rename the issue
+  --description=<text>       Replace the description (inline)
+  --description-file=<path>  Replace the description from file (safe for multiline)
+  --parent=QUA-NNN|none      Set or clear the parent issue link
 
 Options (comment):
   --body-file=<path>  Comment body from file (safe for multiline / escaped content)
@@ -1102,6 +1235,10 @@ Examples:
   crux linear create "Broken login page" --description="The login form crashes on submit"
   crux linear create "Add retry logic" --description-file=/tmp/desc.md --priority=3
   crux linear create "Migrate X" --parent=QUA-408 --project="Data Model Unwind" --priority=2
+  crux linear create "Sub-task" --parent=QUA-408   # inherits QUA-408's project
+  crux linear update QUA-184 --project="Data Model Unwind"
+  crux linear update QUA-184 --priority=2 --title="Clearer title"
+  crux linear update QUA-184 --project=none        # clear the project
   crux linear view QUA-184
   crux linear search "agent checklist"
   crux linear start QUA-184

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -570,7 +570,7 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
   const id = parseLinearId(args[0]);
   if (!id) {
     return {
-      output: `${c.red}Usage: crux linear update <QUA-NNN> [--project=<name|uuid>] [--priority=1-4] [--title=...] [--description=...] [--description-file=<path>] [--parent=QUA-NNN|none]${c.reset}\n`,
+      output: `${c.red}Usage: crux linear update <QUA-NNN> [--project=<name|uuid|none>] [--priority=0-4] [--title=...] [--description=...] [--description-file=<path>] [--parent=QUA-NNN|none]${c.reset}\n`,
       exitCode: 1,
     };
   }
@@ -580,10 +580,30 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
     return { output: `${c.red}Issue ${id} not found${c.reset}\n`, exitCode: 1 };
   }
 
+  // The CLI flag parser turns bare flags (e.g. `--title` with no value) into
+  // boolean `true`. Reject those upfront so we never coerce a boolean into a
+  // GraphQL string field. Each branch below assumes the option is a string.
+  const stringFlags: Array<[keyof CommandOptions, string]> = [
+    ['project', '--project'],
+    ['title', '--title'],
+    ['description', '--description'],
+    ['parent', '--parent'],
+    ['priority', '--priority'],
+  ];
+  for (const [key, flag] of stringFlags) {
+    const v = options[key];
+    if (v !== undefined && typeof v !== 'string') {
+      return {
+        output: `${c.red}${flag} requires a value, e.g. ${flag}="value"${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
   const input: UpdateIssueInput = {};
   const changed: string[] = [];
 
-  if (options.project !== undefined) {
+  if (typeof options.project === 'string') {
     if (options.project === '' || options.project.toLowerCase() === 'none') {
       input.projectId = null;
       changed.push('project=(cleared)');
@@ -600,7 +620,7 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
     }
   }
 
-  if (options.priority !== undefined) {
+  if (typeof options.priority === 'string') {
     const priority = parseInt(options.priority, 10);
     if (Number.isNaN(priority) || priority < 0 || priority > 4) {
       return {
@@ -612,7 +632,13 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
     changed.push(`priority=${priorityLabel(priority)}`);
   }
 
-  if (options.title !== undefined) {
+  if (typeof options.title === 'string') {
+    if (options.title.trim() === '') {
+      return {
+        output: `${c.red}--title cannot be empty${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
     input.title = options.title;
     changed.push('title');
   }
@@ -621,12 +647,12 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
   if (descFromFile !== null) {
     input.description = descFromFile;
     changed.push('description');
-  } else if (options.description !== undefined) {
+  } else if (typeof options.description === 'string') {
     input.description = options.description;
     changed.push('description');
   }
 
-  if (options.parent !== undefined) {
+  if (typeof options.parent === 'string') {
     if (options.parent === '' || options.parent.toLowerCase() === 'none') {
       input.parentId = null;
       changed.push('parent=(cleared)');

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -104,6 +104,26 @@ function priorityLabel(priority: number): string {
   return ['none', 'urgent', 'high', 'medium', 'low'][priority] ?? `P${priority}`;
 }
 
+/**
+ * Parse a CLI priority flag. `create` only accepts 1–4 (Linear creates with no
+ * priority by default); `update` accepts 0 too so users can clear an existing
+ * priority without leaving the field unchanged.
+ */
+function parsePriorityFlag(
+  raw: string,
+  { allowZero }: { allowZero: boolean },
+): { ok: true; value: number } | { ok: false; error: string } {
+  const value = parseInt(raw, 10);
+  const min = allowZero ? 0 : 1;
+  if (Number.isNaN(value) || value < min || value > 4) {
+    const range = allowZero
+      ? '0 (none), 1 (urgent), 2 (high), 3 (medium), or 4 (low)'
+      : '1 (urgent), 2 (high), 3 (medium), or 4 (low)';
+    return { ok: false, error: `Invalid priority "${raw}" — must be ${range}` };
+  }
+  return { ok: true, value };
+}
+
 async function view(args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(options.ci);
   const c = log.colors;
@@ -488,16 +508,13 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
   const sizingRefusal = checkRedFlagsOrRefuse(title, description, options, c);
   if (sizingRefusal) return sizingRefusal;
 
-  // Parse priority (Linear: 1=urgent, 2=high, 3=medium, 4=low)
   let priority: number | undefined;
   if (options.priority) {
-    priority = parseInt(options.priority, 10);
-    if (Number.isNaN(priority) || priority < 1 || priority > 4) {
-      return {
-        output: `${c.red}Invalid priority "${options.priority}" — must be 1 (urgent), 2 (high), 3 (medium), or 4 (low)${c.reset}\n`,
-        exitCode: 1,
-      };
+    const parsed = parsePriorityFlag(options.priority, { allowZero: false });
+    if (!parsed.ok) {
+      return { output: `${c.red}${parsed.error}${c.reset}\n`, exitCode: 1 };
     }
+    priority = parsed.value;
   }
 
   // Resolve parent issue (QUA-NNN → internal UUID)
@@ -559,9 +576,6 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
 /**
  * Update a non-state field on an existing issue (project, priority, title,
  * description, parent). Workflow-state changes go through `start` / `done`.
- *
- * QUA-516: previously the only way to change an issue's project was a one-off
- * GraphQL script. This exposes the existing `issueUpdate` mutation cleanly.
  */
 async function update(args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(options.ci);
@@ -621,15 +635,12 @@ async function update(args: string[], options: CommandOptions): Promise<CommandR
   }
 
   if (typeof options.priority === 'string') {
-    const priority = parseInt(options.priority, 10);
-    if (Number.isNaN(priority) || priority < 0 || priority > 4) {
-      return {
-        output: `${c.red}Invalid priority "${options.priority}" — must be 0 (none), 1 (urgent), 2 (high), 3 (medium), or 4 (low)${c.reset}\n`,
-        exitCode: 1,
-      };
+    const parsed = parsePriorityFlag(options.priority, { allowZero: true });
+    if (!parsed.ok) {
+      return { output: `${c.red}${parsed.error}${c.reset}\n`, exitCode: 1 };
     }
-    input.priority = priority;
-    changed.push(`priority=${priorityLabel(priority)}`);
+    input.priority = parsed.value;
+    changed.push(`priority=${priorityLabel(parsed.value)}`);
   }
 
   if (typeof options.title === 'string') {

--- a/crux/lib/linear/__tests__/issues.test.ts
+++ b/crux/lib/linear/__tests__/issues.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getIssue,
   getComments,
+  updateIssue,
   updateIssueState,
   commentOnIssue,
   createIssue,
@@ -251,6 +252,78 @@ describe('issues.ts — transport helpers', () => {
         updateIssueState('QUA-184', 'Pending')
       ).rejects.toThrow(/Unknown Linear workflow state/);
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateIssue', () => {
+    it('sends projectId in the IssueUpdateInput', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: { identifier: 'QUA-184' },
+            },
+          },
+        })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await updateIssue('QUA-184', { projectId: 'proj-uuid-1' });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.id).toBe('QUA-184');
+      expect(body.variables.input).toEqual({ projectId: 'proj-uuid-1' });
+    });
+
+    it('passes null projectId through to clear the project', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: { issueUpdate: { success: true, issue: { identifier: 'QUA-184' } } },
+        })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await updateIssue('QUA-184', { projectId: null });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.input.projectId).toBeNull();
+    });
+
+    it('supports priority + title + description in one call', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: { issueUpdate: { success: true, issue: { identifier: 'QUA-184' } } },
+        })
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      await updateIssue('QUA-184', {
+        priority: 2,
+        title: 'New title',
+        description: 'New body',
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.variables.input).toEqual({
+        priority: 2,
+        title: 'New title',
+        description: 'New body',
+      });
+    });
+
+    it('throws when issueUpdate reports success=false', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: {
+            issueUpdate: { success: false, issue: { identifier: 'QUA-184' } },
+          },
+        })
+      ) as unknown as typeof fetch;
+
+      await expect(updateIssue('QUA-184', { priority: 1 })).rejects.toThrow(
+        /refused to update QUA-184/
+      );
     });
   });
 

--- a/crux/lib/linear/issues.ts
+++ b/crux/lib/linear/issues.ts
@@ -117,6 +117,45 @@ export async function getComments(
   }
 }
 
+export interface UpdateIssueInput {
+  projectId?: string | null;
+  priority?: number;
+  title?: string;
+  description?: string;
+  parentId?: string | null;
+}
+
+/**
+ * Generic issue update — projectId, priority, title, description, parentId.
+ *
+ * Pass `null` for `projectId` or `parentId` to clear the field. Workflow
+ * state changes go through `updateIssueState()` (which resolves state names
+ * to UUIDs).
+ */
+export async function updateIssue(
+  identifier: string,
+  input: UpdateIssueInput,
+): Promise<{ identifier: string }> {
+  const data = await linearGraphQL<{
+    issueUpdate: {
+      success: boolean;
+      issue: { identifier: string };
+    };
+  }>(
+    `mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+      issueUpdate(id: $id, input: $input) {
+        success
+        issue { identifier }
+      }
+    }`,
+    { id: identifier, input },
+  );
+  if (!data.issueUpdate.success) {
+    throw new Error(`Linear refused to update ${identifier}`);
+  }
+  return { identifier: data.issueUpdate.issue.identifier };
+}
+
 /**
  * Update an issue's workflow state.
  *


### PR DESCRIPTION
## Summary

- `crux linear create --parent=QUA-NNN` now **inherits the parent's project** when `--project` is omitted. Explicit `--project=<other>` always wins. Previously, every child issue under a parent landed project-less, requiring a one-off GraphQL script to reconcile.
- Adds `crux linear update QUA-NNN` so projects, priorities, titles, descriptions, and parents can be changed without writing a custom mutation. Supports `--project=none` and `--parent=none` to clear those fields.
- Adds `updateIssue()` helper in `crux/lib/linear/issues.ts` wrapping Linear's `issueUpdate` mutation.

## Why

QUA-408 coordinator session filed 13 child tickets under a parent and they all landed in the wrong (no) project. Required a one-off `/tmp/make-project.mjs` to reconcile. Inheritance closes that hole; `update` exposes the existing mutation cleanly so future state corrections don't need ad-hoc scripts.

## Test plan
- [x] `crux linear create --parent=QUA-408` (no `--project`) inherits parent's project
- [x] `crux linear create --parent=QUA-408 --project="Other"` overrides inheritance
- [x] `crux linear create --parent=QUA-408` when parent has no project leaves child project-less
- [x] `crux linear update QUA-184 --project="Data Model Unwind"` sets project
- [x] `crux linear update QUA-184 --project=none` clears project
- [x] `crux linear update QUA-184 --priority=2 --title="..."` updates multiple fields atomically
- [x] Bare flags (`--project` without value) reject cleanly with `requires a value` instead of crashing on `.toLowerCase()`
- [x] Empty `--title=""` rejected (would clobber the issue title)
- [x] Out-of-range priority rejected with clear error
- [x] All 128 linear-related tests pass; 7657 total tests pass
- [x] Gate (48 checks) passes

Closes QUA-516
