### PR TITLE
ci(linear): auto-run verify-pr on every PR merge to close webhook miss class

### DIFF
--- a/.github/workflows/linear-verify-pr.yml
+++ b/.github/workflows/linear-verify-pr.yml
@@ -30,9 +30,11 @@ on:
         required: false
         type: string
 
-# Per-PR runs use the PR number as the concurrency group so re-merging or
-# rapid close+reopen events don't pile up. Nightly audit + dispatch get their
-# own groups so they don't cancel a per-PR run.
+# Concurrency: queue (don't cancel) duplicate events for the same PR.
+# `pull_request: closed` fires once per close so this is mostly inert, but
+# it covers the close → reopen → close edge case where two events arrive
+# back-to-back. Nightly audit + dispatch get their own groups so they
+# never block per-PR runs.
 concurrency:
   group: linear-verify-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.schedule || github.run_id }}
   cancel-in-progress: false
@@ -50,13 +52,18 @@ jobs:
     #   - PRs to non-main branches (release PRs main → production reuse refs
     #     already verified when each component PR merged into main)
     #   - PRs that closed without merging
+    #   - PRs from forks (defense-in-depth — `merged == true` already means
+    #     the fork code is now in main, but the head.repo gate makes the
+    #     trust boundary explicit and survives if someone refactors this
+    #     condition later)
     #   - manual dispatches with no pr_number (those run audit-fix below)
     if: >-
       vars.AUTOMATION_PAUSED != 'true' &&
       (
         (github.event_name == 'pull_request' &&
          github.event.pull_request.merged == true &&
-         github.event.pull_request.base.ref == 'main') ||
+         github.event.pull_request.base.ref == 'main' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
         (github.event_name == 'workflow_dispatch' &&
          github.event.inputs.pr_number != '')
       )

--- a/.github/workflows/linear-verify-pr.yml
+++ b/.github/workflows/linear-verify-pr.yml
@@ -1,0 +1,116 @@
+name: Linear Verify PR
+run-name: "Linear Verify PR${{ vars.AUTOMATION_PAUSED == 'true' && ' [PAUSED]' || '' }}"
+
+# Closes the "Linear-webhook miss" class (QUA-441).
+#
+# Linear's GitHub integration silently drops webhooks on PR merge, leaving
+# QUA issues stuck "In Review" indefinitely. Most common on batched PRs with
+# multiple `Fixes QUA-NNN` lines — Linear processes the first, drops the rest.
+#
+# Two layers:
+#   1. on PR close → `crux linear verify-pr <PR>` reconciles that PR's refs
+#      within minutes of merge.
+#   2. nightly schedule → `crux linear audit --fix` as a backstop for cases
+#      the per-PR run missed (workflow itself failed, PR re-opened+re-closed,
+#      cross-repo links, etc.).
+#
+# Both verify-pr and audit are conservative: they only reconcile from active
+# workflow states (In Progress / In Review). Issues already in Done, Backlog,
+# Canceled, or Duplicate are respected as deliberate human decisions.
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: "20 8 * * *" # 8:20 AM UTC daily — staggered from ci-pr-health.yml (8:10)
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to verify (leave blank to run nightly audit instead)"
+        required: false
+        type: string
+
+# Per-PR runs use the PR number as the concurrency group so re-merging or
+# rapid close+reopen events don't pile up. Nightly audit + dispatch get their
+# own groups so they don't cancel a per-PR run.
+concurrency:
+  group: linear-verify-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.schedule || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  paused-notice:
+    uses: ./.github/workflows/_paused-notice.yml
+
+  verify-pr:
+    # Per-merge reconciliation. Skips:
+    #   - PRs to non-main branches (release PRs main → production reuse refs
+    #     already verified when each component PR merged into main)
+    #   - PRs that closed without merging
+    #   - manual dispatches with no pr_number (those run audit-fix below)
+    if: >-
+      vars.AUTOMATION_PAUSED != 'true' &&
+      (
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.merged == true &&
+         github.event.pull_request.base.ref == 'main') ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pr_number != '')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Linear refs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: pnpm crux linear verify-pr "$PR_NUMBER"
+
+  audit-fix:
+    # Nightly backstop. Catches issues the per-PR run missed:
+    #   - per-PR workflow run failed (Linear API blip, runner outage)
+    #   - PR closed before workflow existed (historical sweep)
+    #   - PR has no `Fixes QUA-NNN` ref but the work shipped anyway
+    if: >-
+      vars.AUTOMATION_PAUSED != 'true' &&
+      (
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pr_number == '')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Reconcile In-Progress Linear issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: pnpm crux linear audit --fix

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -701,6 +701,22 @@ describe('linear verify-pr', () => {
     expect(githubApiMock).not.toHaveBeenCalled();
   });
 
+  // Without strict validation, `parseInt('4275abc')` returns 4275 — a
+  // workflow_dispatch input of "4275; rm -rf /" would silently verify PR
+  // 4275 instead of failing. Strict `^\d+$` is what gates this.
+  it.each([
+    ['4275abc', 'trailing garbage'],
+    ['4275; echo pwned', 'shell injection attempt'],
+    [' 4275', 'leading whitespace'],
+    ['4275 ', 'trailing whitespace'],
+    ['#', 'just a # with no digits'],
+  ])('rejects %s (%s)', async (input, _label) => {
+    const r = await commands['verify-pr']([input], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Invalid PR number');
+    expect(githubApiMock).not.toHaveBeenCalled();
+  });
+
   it('accepts a leading "#" on the PR number', async () => {
     mockPr({ number: 4275, body: 'no fixes here', merged: true });
     const r = await commands['verify-pr'](['#4275'], { ci: true });
@@ -803,6 +819,42 @@ describe('linear verify-pr', () => {
     expect(r.exitCode).toBe(1);
     expect(r.output).toContain('QUA-300');
     expect(r.output).toContain('timed out');
+  });
+
+  // Real-world transient failure scenario: a 4-issue batched PR where two
+  // Linear calls succeed and two fail (e.g., one timeout + one rate-limit).
+  // The watchdog should reconcile what it can, surface every failure by ID,
+  // and exit non-zero so the workflow run is visibly red.
+  it('aggregates mixed success and failure across multiple refs', async () => {
+    mockPr({
+      body: 'Fixes QUA-501\nFixes QUA-502\nFixes QUA-503\nFixes QUA-504',
+      merged: true,
+    });
+    const inProgress = (id: string) => ({
+      ...mockIssue,
+      identifier: id,
+      state: { id: 'state-active', name: 'In Review', type: 'started' as const },
+    });
+    getIssueMock
+      .mockResolvedValueOnce(inProgress('QUA-501'))
+      .mockRejectedValueOnce(new Error('Linear GraphQL request timed out after 15s'))
+      .mockResolvedValueOnce(inProgress('QUA-503'))
+      .mockRejectedValueOnce(new Error('Linear GraphQL returned 429: rate limited'));
+    updateIssueStateMock.mockResolvedValue({ identifier: '', state: 'Done' });
+    commentOnIssueMock.mockResolvedValue(undefined);
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    // Exit non-zero — the failures must be visible in CI.
+    expect(r.exitCode).toBe(1);
+    // Successes were reconciled.
+    expect(updateIssueStateMock).toHaveBeenCalledTimes(2);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-501', 'Done');
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-503', 'Done');
+    // Both failures are named in the output so the operator knows which to retry.
+    expect(r.output).toContain('QUA-502');
+    expect(r.output).toContain('timed out');
+    expect(r.output).toContain('QUA-504');
+    expect(r.output).toContain('rate limited');
   });
 
   it('reconciles only In-Progress / In-Review (started type), regardless of name spelling', async () => {

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -671,6 +671,159 @@ describe('linear done', () => {
 });
 
 // ---------------------------------------------------------------------------
+// verify-pr — watchdog for the Linear-webhook miss class (QUA-441)
+// ---------------------------------------------------------------------------
+
+describe('linear verify-pr', () => {
+  function mockPr(overrides: Partial<{ number: number; body: string | null; merged: boolean }> = {}) {
+    githubApiMock.mockResolvedValueOnce({
+      number: overrides.number ?? 4275,
+      title: 'test pr',
+      body: overrides.body ?? null,
+      state: 'closed',
+      merged: overrides.merged ?? true,
+      merged_at: '2026-04-25T00:00:00Z',
+      html_url: `https://github.com/quantified-uncertainty/longterm-wiki/pull/${overrides.number ?? 4275}`,
+    });
+  }
+
+  it('prints usage when no PR number is given', async () => {
+    const r = await commands['verify-pr']([], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Usage');
+    expect(githubApiMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric PR argument', async () => {
+    const r = await commands['verify-pr'](['notanumber'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('Invalid PR number');
+    expect(githubApiMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a leading "#" on the PR number', async () => {
+    mockPr({ number: 4275, body: 'no fixes here', merged: true });
+    const r = await commands['verify-pr'](['#4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(githubApiMock).toHaveBeenCalledWith('/repos/quantified-uncertainty/longterm-wiki/pulls/4275');
+  });
+
+  it('returns 0 with no-op message when the PR is not merged', async () => {
+    mockPr({ merged: false });
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('not merged');
+    expect(getIssueMock).not.toHaveBeenCalled();
+    expect(updateIssueStateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the merged PR has no Fixes refs', async () => {
+    mockPr({ body: 'just a refactor — see related #1234', merged: true });
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('no Fixes QUA-NNN refs');
+    expect(getIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('reconciles every Fixes ref on a batched PR (the QUA-441 scenario)', async () => {
+    // Linear's webhook drops 3 of 4 — verify-pr corrects all of them.
+    mockPr({
+      number: 4275,
+      body: 'Fixes QUA-374\nFixes QUA-375\nFixes QUA-376\nFixes QUA-377',
+      merged: true,
+    });
+    const inProgress = (id: string) => ({
+      ...mockIssue,
+      identifier: id,
+      state: { id: 'state-active', name: 'In Review', type: 'started' as const },
+    });
+    getIssueMock
+      .mockResolvedValueOnce(inProgress('QUA-374'))
+      .mockResolvedValueOnce(inProgress('QUA-375'))
+      .mockResolvedValueOnce(inProgress('QUA-376'))
+      .mockResolvedValueOnce(inProgress('QUA-377'));
+    updateIssueStateMock.mockResolvedValue({ identifier: '', state: 'Done' });
+    commentOnIssueMock.mockResolvedValue(undefined);
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalledTimes(4);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-374', 'Done');
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-377', 'Done');
+    expect(commentOnIssueMock).toHaveBeenCalledTimes(4);
+    // The watchdog comment should reference the PR URL so humans can audit
+    // the reconciliation trail.
+    const firstComment = commentOnIssueMock.mock.calls[0][1];
+    expect(firstComment).toContain('https://github.com/quantified-uncertainty/longterm-wiki/pull/4275');
+    expect(firstComment).toContain('reconciled');
+    expect(r.output).toContain('4 issue(s) corrected');
+  });
+
+  it('respects deliberate non-active states (Backlog / Canceled / Done) — no override', async () => {
+    mockPr({
+      body: 'Fixes QUA-100\nFixes QUA-101\nFixes QUA-102',
+      merged: true,
+    });
+    getIssueMock
+      .mockResolvedValueOnce({ ...mockIssue, identifier: 'QUA-100', state: { id: 's', name: 'Done', type: 'completed' } })
+      .mockResolvedValueOnce({ ...mockIssue, identifier: 'QUA-101', state: { id: 's', name: 'Canceled', type: 'canceled' } })
+      .mockResolvedValueOnce({ ...mockIssue, identifier: 'QUA-102', state: { id: 's', name: 'Backlog', type: 'backlog' } });
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).not.toHaveBeenCalled();
+    expect(commentOnIssueMock).not.toHaveBeenCalled();
+    expect(r.output).toContain('not in active state');
+  });
+
+  it('handles a missing-issue ref gracefully and continues to the next', async () => {
+    mockPr({ body: 'Fixes QUA-9999\nFixes QUA-200', merged: true });
+    getIssueMock
+      .mockResolvedValueOnce(null) // QUA-9999 — deleted/never existed
+      .mockResolvedValueOnce({
+        ...mockIssue,
+        identifier: 'QUA-200',
+        state: { id: 's', name: 'In Progress', type: 'started' },
+      });
+    updateIssueStateMock.mockResolvedValueOnce({ identifier: 'QUA-200', state: 'Done' });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain('QUA-9999');
+    expect(r.output).toContain('not found');
+    expect(updateIssueStateMock).toHaveBeenCalledExactlyOnceWith('QUA-200', 'Done');
+  });
+
+  it('exits 1 when a Linear API call fails — surfaces the error to CI', async () => {
+    mockPr({ body: 'Fixes QUA-300', merged: true });
+    getIssueMock.mockRejectedValueOnce(new Error('Linear GraphQL request timed out after 15s'));
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain('QUA-300');
+    expect(r.output).toContain('timed out');
+  });
+
+  it('reconciles only In-Progress / In-Review (started type), regardless of name spelling', async () => {
+    mockPr({ body: 'Fixes QUA-400', merged: true });
+    // Custom workflow state name "Working On" of type 'started' should still
+    // be reconciled — the watchdog gates on type, not name.
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      identifier: 'QUA-400',
+      state: { id: 's', name: 'Working On', type: 'started' },
+    });
+    updateIssueStateMock.mockResolvedValueOnce({ identifier: 'QUA-400', state: 'Done' });
+    commentOnIssueMock.mockResolvedValueOnce(undefined);
+
+    const r = await commands['verify-pr'](['4275'], { ci: true });
+    expect(r.exitCode).toBe(0);
+    expect(updateIssueStateMock).toHaveBeenCalledWith('QUA-400', 'Done');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // comment
 // ---------------------------------------------------------------------------
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -684,13 +684,18 @@ async function verifyPr(args: string[], options: CommandOptions): Promise<Comman
       exitCode: 1,
     };
   }
-  const prNum = parseInt(prArg.replace(/^#/, ''), 10);
-  if (Number.isNaN(prNum)) {
+  // Strict: digits only after an optional leading "#". `parseInt` is too
+  // lenient — `parseInt('4275abc')` returns 4275, so a workflow_dispatch
+  // input of "4275; rm -rf /" would silently verify PR 4275 instead of
+  // failing. Accept only `\d+` to fail loud on any garbage.
+  const prDigits = prArg.replace(/^#/, '');
+  if (!/^\d+$/.test(prDigits)) {
     return {
       output: `${c.red}Invalid PR number: ${prArg}${c.reset}\n`,
       exitCode: 1,
     };
   }
+  const prNum = parseInt(prDigits, 10);
 
   interface GhPullResponse {
     number: number;


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/linear-verify-pr.yml` — auto-runs `crux linear verify-pr <PR>` on every PR merge to `main` to close the Linear-webhook miss class flagged in QUA-441.
- Adds a nightly schedule + manual dispatch fallback that runs `crux linear audit --fix` as a backstop for cases the per-PR run missed.
- Tightens `crux linear verify-pr` input validation (strict `^\d+$` instead of lenient `parseInt`) and adds 15 new tests for the watchdog (was 0 before — only `extractFixesIds` had coverage).

## Why

Linear's GitHub integration silently drops webhooks on PR merge, leaving QUA issues stuck "In Review" indefinitely. Most common on batched PRs with multiple `Fixes QUA-NNN` lines — Linear processes the first, drops the rest. Today's sweep found 9 stuck issues across recent merges (PR #4275 alone left QUA-374/375/376/377 all unclosed). The `crux linear verify-pr` watchdog already exists; this just fires it automatically.

## Design

Two layers:

1. **Per-merge (`pull_request: closed`)** — fires within seconds of merge, scoped to one PR. Filtered to `merged == true`, `base.ref == 'main'`, and `head.repo == github.repository` (defense-in-depth on top of `merged==true` already meaning fork code is in main).
2. **Nightly schedule** — runs `audit --fix` as a backstop for the per-PR run failing, PRs without `Fixes` refs, or historical sweeps. `workflow_dispatch` exposes both modes (`pr_number` empty → audit, filled → verify a specific PR).

Both reconcile only from active workflow states (`state.type === 'started'`). Backlog/Canceled/Done/Duplicate are respected as deliberate human decisions — the watchdog recovers missed webhooks, never overrides humans.

## Test plan

- [x] `pnpm test` — 82 linear tests pass (was 76; added 6: 5 input validation, 1 mixed success/failure aggregation)
- [x] `actionlint` — clean on all `.github/workflows/*.yml`
- [x] `pnpm crux w validate gate` — 51 checks pass
- [x] Self-review covered: bug taxonomy, fork PR security, parseInt lenient parsing, concurrency, mixed success/failure paths, observability
- [ ] After merge: confirm the workflow run for this PR's own merge shows green and the `verify-pr` job actually executes (this PR closes QUA-441, so its own run is the smoke test)

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `ci` New workflow "linear verify pr" — verify it runs successfully after merge — `gh run list --workflow="linear-verify-pr.yml" --limit=1 --json status,conclusion`
- [ ] `manual` Confirm `LINEAR_API_KEY` secret exists at the repo level (already used by `ci-pr-health.yml`, but verify visibility from this workflow's runner) — `gh secret list -R quantified-uncertainty/longterm-wiki | grep LINEAR_API_KEY`
- [ ] `manual` First nightly run of `audit-fix` should fire ~08:20 UTC the day after merge — verify it picked up any pre-existing stuck issues — `gh run list --workflow="linear-verify-pr.yml" --event=schedule --limit=1`
<!-- /deploy-tasks -->

Fixes QUA-441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to reconcile Linear issues with merged pull requests
  * Includes nightly audit reconciliation with pause controls and concurrency handling

* **Tests**
  * Added comprehensive tests for Linear issue verification command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->