### PR TITLE
feat(pr): pre-PR Linear dedup — refuse crux gh pr create on open-PR collision (QUA-304)

### DIFF
--- a/.claude/rules/linear-integration.md
+++ b/.claude/rules/linear-integration.md
@@ -55,6 +55,12 @@ IDs already referenced in the body (`Fixes`, `Closes`, `Resolves`) are skipped t
 
 **Always use `crux gh pr create`**, not raw `gh pr create`. The crux wrapper handles Linear injection, body corruption detection, and GitHub API validation. The agent-push-and-verify skill enforces this.
 
+### Pre-PR Linear dedup (QUA-304)
+
+After injecting Linear refs, `crux gh pr create` extracts every `Fixes|Closes|Resolves QUA-NNN` from the final PR body and searches GitHub for other **open** PRs that already reference any of those IDs. If any match, the command exits with code 2 and lists the colliding PRs — no PR is created. This is the last line of defense when two sessions race on the same Linear ticket and `crux linear start`'s dedup (QUA-406/440) was bypassed or never ran (e.g. the second session didn't know the Linear ID until PR creation).
+
+To bypass the check (existing PR abandoned, explicit handoff, etc.) re-run with `--force`. The check fails open on GitHub API errors — a search outage doesn't wedge PR creation.
+
 ## 4. Agent workflow state transitions
 
 The `crux linear` commands manage issue state through the agent session lifecycle:
@@ -124,10 +130,11 @@ The parser in `crux/lib/linear/parse-id.ts` uses an allowlist of known team keys
 | Mistake | Consequence | Fix |
 |---------|------------|-----|
 | Branch `claude/tier0-data-integrity` instead of `claude/qua-155-tier0-data-integrity` | Linear issue stays open after merge | Always include `qua-NNN` in branch name |
-| Using raw `gh pr create` | No `Fixes QUA-NNN` injection, no corruption detection | Use `crux gh pr create` |
+| Using raw `gh pr create` | No `Fixes QUA-NNN` injection, no corruption detection, no pre-PR dedup (QUA-304) | Use `crux gh pr create` |
 | Calling `crux linear done QUA-NNN` without `--pr` when a PR exists | Issue goes to Done instead of In Review; skips the merge-triggered auto-close | Pass `--pr=URL` when shipping a PR |
 | Forgetting `LINEAR_API_KEY` | Silent skip of all Linear state updates | Sync `.env.base` or `export LINEAR_API_KEY=...` |
 | Manually moving issues in Linear UI during active agent session | Agent's `crux linear done` may override the manual state | Let the agent pipeline manage state |
+| Bypassing pre-PR dedup with `--force` without investigating the other PR | Two PRs racing on the same Linear ticket | Read the other PR first; reconcile or close before forcing |
 
 ## 9. Project ownership — which project does an issue belong in?
 

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeClosesSyntax, validateTestPlan, bigramSimilarity, injectLinearRefs } from './pr.ts';
+import {
+  normalizeClosesSyntax,
+  validateTestPlan,
+  bigramSimilarity,
+  injectLinearRefs,
+  extractLinearAutoCloseRefs,
+  checkLinearPrCollisions,
+} from './pr.ts';
 
 describe('normalizeClosesSyntax', () => {
   it('rewrites comma-separated Closes to one-per-line', () => {
@@ -251,5 +258,82 @@ describe('bigramSimilarity', () => {
   it('ignores punctuation', () => {
     const sim = bigramSimilarity('hello, world!', 'hello world');
     expect(sim).toBe(1.0);
+  });
+});
+
+describe('extractLinearAutoCloseRefs', () => {
+  it('extracts Fixes/Closes/Resolves references', () => {
+    const body = 'Fixes QUA-100\nCloses QUA-101\nResolves QUA-102';
+    expect(extractLinearAutoCloseRefs(body).sort()).toEqual(['QUA-100', 'QUA-101', 'QUA-102']);
+  });
+
+  it('dedupes duplicate IDs across keywords', () => {
+    const body = 'Fixes QUA-100\n\nCloses QUA-100';
+    expect(extractLinearAutoCloseRefs(body)).toEqual(['QUA-100']);
+  });
+
+  it('is case-insensitive on both keyword and prefix', () => {
+    const body = 'fixes qua-42\nCLOSES QUA-43';
+    expect(extractLinearAutoCloseRefs(body).sort()).toEqual(['QUA-42', 'QUA-43']);
+  });
+
+  it('ignores bare QUA mentions without a keyword', () => {
+    // Incidental mentions shouldn't trigger the dedup block — only auto-close
+    // refs matter, because only those compete for the Linear claim.
+    const body = 'Related to QUA-500 but not closing it';
+    expect(extractLinearAutoCloseRefs(body)).toEqual([]);
+  });
+
+  it('returns empty for a body without any Linear refs', () => {
+    expect(extractLinearAutoCloseRefs('## Summary\nSome changes')).toEqual([]);
+  });
+});
+
+describe('checkLinearPrCollisions', () => {
+  it('returns empty when no Linear IDs are being claimed', async () => {
+    const lookup = async () => {
+      throw new Error('should not be called');
+    };
+    const collisions = await checkLinearPrCollisions([], lookup);
+    expect(collisions).toEqual([]);
+  });
+
+  it('returns empty when lookup finds no open PRs for any claimed ID', async () => {
+    const lookup = async () => [];
+    const collisions = await checkLinearPrCollisions(['QUA-100', 'QUA-101'], lookup);
+    expect(collisions).toEqual([]);
+  });
+
+  it('returns collisions for each Linear ID with open PRs', async () => {
+    const lookup = async (id: string) => {
+      if (id === 'QUA-100') {
+        return [{ number: 4212, title: 'fix: something', url: 'https://github.com/x/y/pull/4212' }];
+      }
+      return [];
+    };
+    const collisions = await checkLinearPrCollisions(['QUA-100', 'QUA-101'], lookup);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].linearId).toBe('QUA-100');
+    expect(collisions[0].prs).toHaveLength(1);
+    expect(collisions[0].prs[0].number).toBe(4212);
+  });
+
+  it('reports multiple Linear IDs when each has an open PR', async () => {
+    const lookup = async (id: string) => [
+      { number: id === 'QUA-100' ? 10 : 20, title: `fix: ${id}`, url: `https://github.com/x/y/pull/${id}` },
+    ];
+    const collisions = await checkLinearPrCollisions(['QUA-100', 'QUA-101'], lookup);
+    expect(collisions).toHaveLength(2);
+    expect(collisions.map((c) => c.linearId).sort()).toEqual(['QUA-100', 'QUA-101']);
+  });
+
+  it('fails open when lookup returns [] (the real helper swallows API errors)', async () => {
+    // findOpenPrsMentioningLinearId's contract is "fail-open on API error by
+    // returning []". Confirms that contract composes cleanly: an API outage
+    // degrades to "no collision detected" rather than blocking PR creation
+    // on infrastructure glitches.
+    const lookup = async () => [];
+    const collisions = await checkLinearPrCollisions(['QUA-100'], lookup);
+    expect(collisions).toEqual([]);
   });
 });

--- a/crux/commands/pr.test.ts
+++ b/crux/commands/pr.test.ts
@@ -336,4 +336,21 @@ describe('checkLinearPrCollisions', () => {
     const collisions = await checkLinearPrCollisions(['QUA-100'], lookup);
     expect(collisions).toEqual([]);
   });
+
+  it('runs lookups in parallel, not sequentially', async () => {
+    // Regression guard: a sequential implementation would serialize N
+    // GitHub API round-trips for an epic PR. Measure wall-clock against
+    // a slow-lookup stub; parallel total should be ~the single-lookup
+    // cost, not ~N×.
+    const LATENCY_MS = 50;
+    const lookup = async (_id: string) => {
+      await new Promise((r) => setTimeout(r, LATENCY_MS));
+      return [];
+    };
+    const start = Date.now();
+    await checkLinearPrCollisions(['QUA-100', 'QUA-101', 'QUA-102', 'QUA-103'], lookup);
+    const elapsed = Date.now() - start;
+    // Parallel: ~50ms. Sequential: ~200ms. Allow slack for scheduler.
+    expect(elapsed).toBeLessThan(LATENCY_MS * 3);
+  });
 });

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -249,17 +249,19 @@ export interface LinearPrCollision {
  * The `lookupPrs` dependency is injectable so callers can unit-test the
  * decision logic without hitting the GitHub API. In production it defaults
  * to `findOpenPrsMentioningLinearId`, which fails open on API errors.
+ *
+ * Lookups run in parallel — for an epic PR claiming several IDs, sequential
+ * awaits would add a network round-trip per ID. The GitHub Search API's
+ * 30/min rate limit comfortably absorbs the few-at-a-time burst.
  */
 export async function checkLinearPrCollisions(
   linearIds: string[],
   lookupPrs: (id: string) => Promise<OpenPrMatch[]> = findOpenPrsMentioningLinearId,
 ): Promise<LinearPrCollision[]> {
-  const collisions: LinearPrCollision[] = [];
-  for (const id of linearIds) {
-    const prs = await lookupPrs(id);
-    if (prs.length > 0) collisions.push({ linearId: id, prs });
-  }
-  return collisions;
+  const results = await Promise.all(
+    linearIds.map(async (id) => ({ linearId: id, prs: await lookupPrs(id) })),
+  );
+  return results.filter((r) => r.prs.length > 0);
 }
 
 interface GitHubPR {

--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -20,6 +20,10 @@ import { rebaseAllPrs } from '../lib/pr-rebase.ts';
 import { resolveAllConflicts } from '../lib/conflict-resolution.ts';
 import { parseDeployTasksFromBody } from '../lib/deploy-tasks/detect.ts';
 import { parseLinearId } from '../lib/linear/parse-id.ts';
+import {
+  findOpenPrsMentioningLinearId,
+  type OpenPrMatch,
+} from '../lib/linear/dedup.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 
 // ── Test plan validation ─────────────────────────────────────────────────────
@@ -213,6 +217,49 @@ export function injectLinearRefs(
     injected: toInject,
     warnings,
   };
+}
+
+/**
+ * Extract the set of Linear IDs that will auto-close on PR merge, based on
+ * the `Fixes|Closes|Resolves QUA-NNN` markers GitHub/Linear parse. Used by
+ * the pre-PR dedup check to ask "which tickets is this PR about to claim?"
+ *
+ * Deliberately narrower than "any QUA-NNN mention" — we only block on
+ * auto-close collisions. Incidental mentions in the PR description (e.g.
+ * "related to QUA-500") are not a dedup signal.
+ */
+export function extractLinearAutoCloseRefs(body: string): string[] {
+  const ids = new Set<string>();
+  for (const m of body.matchAll(/(?:Fixes|Closes|Resolves)\s+(QUA-\d+)/gi)) {
+    ids.add(m[1].toUpperCase());
+  }
+  return [...ids];
+}
+
+export interface LinearPrCollision {
+  linearId: string;
+  prs: OpenPrMatch[];
+}
+
+/**
+ * For each Linear ID the PR is about to claim, find open PRs already
+ * referencing it. Any hit is a collision (QUA-304 Layer 3) — two sessions
+ * racing to ship the same ticket produces duplicate work.
+ *
+ * The `lookupPrs` dependency is injectable so callers can unit-test the
+ * decision logic without hitting the GitHub API. In production it defaults
+ * to `findOpenPrsMentioningLinearId`, which fails open on API errors.
+ */
+export async function checkLinearPrCollisions(
+  linearIds: string[],
+  lookupPrs: (id: string) => Promise<OpenPrMatch[]> = findOpenPrsMentioningLinearId,
+): Promise<LinearPrCollision[]> {
+  const collisions: LinearPrCollision[] = [];
+  for (const id of linearIds) {
+    const prs = await lookupPrs(id);
+    if (prs.length > 0) collisions.push({ linearId: id, prs });
+  }
+  return collisions;
 }
 
 interface GitHubPR {
@@ -462,6 +509,35 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
         `  ${c.dim}Use \`crux gh pr fix-body\` to update the body if needed.${c.reset}\n`,
       exitCode: 0,
     };
+  }
+
+  // ── Pre-PR Linear dedup (QUA-304 Layer 3) ───────────────────────────────
+  // If this PR is about to claim a Linear ticket that another *open* PR
+  // already claims, refuse — two agents shipping duplicate PRs for the
+  // same QUA-NNN is the exact incident shape that motivated this check.
+  // Fail-open: `findOpenPrsMentioningLinearId` swallows API errors into an
+  // empty list, so a GitHub glitch never blocks PR creation.
+  if (body && !(options.force ?? options['allow-duplicate-linear'])) {
+    const claimedIds = extractLinearAutoCloseRefs(body);
+    if (claimedIds.length > 0) {
+      const collisions = await checkLinearPrCollisions(claimedIds);
+      if (collisions.length > 0) {
+        let msg = `${c.red}✗ Linear dedup collision — another open PR already claims this ticket.${c.reset}\n\n`;
+        for (const col of collisions) {
+          const label = col.prs.length === 1 ? 'Open PR' : `${col.prs.length} open PRs`;
+          msg += `  ${c.bold}${col.linearId}${c.reset} — ${label}:\n`;
+          for (const pr of col.prs) {
+            msg += `    ${c.cyan}#${pr.number}${c.reset} ${pr.title}\n`;
+            msg += `    ${c.dim}${pr.url}${c.reset}\n`;
+          }
+        }
+        msg +=
+          `\n  ${c.yellow}Investigate the existing PR(s) before opening a duplicate.${c.reset}\n` +
+          `  If the other PR is abandoned or you have explicit authorization,\n` +
+          `  re-run with ${c.bold}--force${c.reset} to bypass this check.\n`;
+        return { output: msg, exitCode: 2 };
+      }
+    }
   }
 
   const pr = await githubApi<GitHubPR>(`/repos/${REPO}/pulls`, {
@@ -1074,6 +1150,8 @@ Options (create):
   --skip-test-plan    Skip test plan validation (not recommended).
   --linear=QUA-NNN    Inject Linear issue references (comma-separated for epics: QUA-155,QUA-151).
                       Auto-detected from branch name and .claude/wip-checklist.md if omitted.
+  --force             Bypass the Linear dedup check (QUA-304). Use when the existing open PR is
+                      abandoned or you have explicit authorization to take over the claim.
   (stdin)             If --body and --body-file are absent and stdin is a pipe, body is read from stdin.
 
 Options (ready):


### PR DESCRIPTION
## Summary

Adds a pre-PR Linear dedup check (QUA-304 Layer 3) to `crux gh pr create`.
After Linear refs are injected into the PR body, the command extracts every
`Fixes|Closes|Resolves QUA-NNN` marker and searches GitHub for **other open
PRs** that already reference any of those IDs. If any exist, it refuses with
exit code 2 and lists the colliding PRs — no PR is created. `--force`
bypasses.

This is the missing third layer in the dedup story:

- **Layer 1 (QUA-406/440)** — `crux linear start` and `agent-checklist init`
  refuse when another active session has already claimed the issue. Catches
  cross-slot collisions when both sessions know the Linear ID up front.
- **Layer 2 (QUA-437)** — `crux sys dispatch` runs the same checks before
  dispatching to a slot.
- **Layer 3 (this PR)** — last line of defense at PR creation time. Catches
  the QUA-304 incident shape: a session that didn't know the Linear ID at
  init (branch name lacked `qua-NNN`, no `--linear` flag) but ends up with
  one in the PR body via `injectLinearRefs`. The competing session is
  detected before the duplicate PR is created, regardless of how init was
  run.

The check fails open on GitHub Search API errors so a transient outage
never blocks PR creation.

## Key changes

- `crux/commands/pr.ts`:
  - New pure helpers `extractLinearAutoCloseRefs(body)` and
    `checkLinearPrCollisions(linearIds, lookupPrs)` — both exported so the
    decision logic can be unit-tested without hitting GitHub.
  - Wired into `create()` after Linear-ref injection, before the actual
    PR creation API call. Lookups run in parallel for epic PRs claiming
    multiple IDs.
  - `--force` flag added to `create` to bypass.
- `crux/commands/pr.test.ts` — 12 new tests covering keyword extraction,
  multi-ID handling, fail-open semantics, and a parallelization regression
  guard.
- `.claude/rules/linear-integration.md` — documents Layer 3 and adds an
  anti-pattern row about bypassing `--force` without investigation.

## Follow-up

QUA-704 (low) — both `injectLinearRefs` and `extractLinearAutoCloseRefs`
miss Markdown-linked auto-close refs (`Fixes [QUA-100](url)`) and past-tense
keywords (`Fixed QUA-100`). Symmetric gap — neither false-positives nor
false-negatives compared to the injection side. Filed during review.

## Test plan

- [x] `pnpm vitest run crux/commands/pr.test.ts crux/lib/linear/dedup.test.ts` — 67/67 pass
- [x] `pnpm build` — green
- [x] `pnpm crux w validate gate --fix` — all 55 gate checks pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in pr.ts
- [x] `/agent-review-pr` — hostile-reviewer subagent ran; one finding fixed (sequential→parallel lookups), one filed as QUA-704, others dismissed with rationale
- [x] Adversarial fuzz of `extractLinearAutoCloseRefs` regex — confirmed symmetric with `injectLinearRefs` behavior

Fixes QUA-304
