### PR TITLE
feat(QUA-689): Phase 2 foundation — schema + model_aliases + quarantine

### DIFF
--- a/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
+++ b/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
@@ -199,7 +199,6 @@ CREATE TABLE IF NOT EXISTS "model_aliases" (
   -- match suggested by ingester, awaiting human confirmation; 'manual' =
   -- promoted by a human via /internal/benchmark-quarantine.
   "confidence" text NOT NULL DEFAULT 'exact',
-  "added_at" timestamp with time zone NOT NULL DEFAULT now(),
   "synced_at" timestamp with time zone NOT NULL DEFAULT now(),
   "created_at" timestamp with time zone NOT NULL DEFAULT now(),
   "updated_at" timestamp with time zone NOT NULL DEFAULT now()

--- a/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
+++ b/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
@@ -1,0 +1,282 @@
+-- QUA-689 Phase 2 (foundation): Safety-benchmark ingestion schema extensions.
+--
+-- Three changes to unblock the parallel ingester work in follow-up PRs:
+--
+--   1. benchmarks: extend the category vocabulary via a CHECK constraint and
+--      add sub_category. Prod enumeration confirmed today (2026-04-25):
+--        SELECT category, count(*) FROM benchmarks GROUP BY category
+--          → multimodal:4, safety:1, knowledge:3, coding:8, math:7,
+--            general:6, agentic:8, reasoning:9 (8 distinct, 46 rows total).
+--      The CHECK list below is a strict superset of the live values, plus
+--      the 4 new safety-focused buckets (dangerous-capability, robustness,
+--      honesty, adversarial) Phase 2 ingesters need. NOT VALID + VALIDATE
+--      pattern per .claude/rules/database-migrations.md.
+--
+--   2. benchmark_results: add provenance columns (tested_by,
+--      tested_by_org_id, evaluation_date, methodology_notes), and widen the
+--      unique index from (benchmark_id, model_id) to a composite that lets
+--      the same model have multiple results per benchmark distinguished by
+--      evaluator (self-report vs leaderboard vs AISI etc.) and evaluation
+--      date. The old index is dropped and replaced — no data loss because
+--      the new index is strictly wider.
+--
+--      tested_by uses a CHECK allowlist enumerated from the implementation
+--      plan: self-report, leaderboard, aisi-uk, aisi-us, metr, apollo,
+--      third-party-paper, epoch-ai, unknown. The current 357 prod rows have
+--      no tested_by column today (it's new), so backfilling defaults to
+--      'unknown' is safe — there are no preexisting non-allowlisted values.
+--
+--   3. model_aliases: new table mapping lowercased alias strings (as they
+--      appear on external leaderboards) to entities.stable_id. Replaces the
+--      hardcoded 40-entry maps duplicated across the existing sync code.
+--      Seeded from data/entities/ai-models.yaml `aliases:` arrays in a
+--      follow-up; this migration only creates the table.
+--
+--   4. benchmark_results_pending: new quarantine table for ingester rows
+--      whose source model name didn't resolve to any entity. Reviewed via
+--      the /internal/benchmark-quarantine dashboard (follow-up PR).
+--
+-- Schema lives in apps/wiki-server/src/schema.ts. Sync handlers for the two
+-- new tables live in apps/wiki-server/src/routes/tablebase/.
+
+-- =====================================================================
+-- 1. benchmarks: category CHECK + sub_category column
+-- =====================================================================
+
+ALTER TABLE "benchmarks"
+  ADD COLUMN IF NOT EXISTS "sub_category" text;
+
+-- The CHECK list is a strict superset of the 8 live category values
+-- (multimodal, safety, knowledge, coding, math, general, agentic, reasoning)
+-- plus 4 new safety-focused buckets the Phase 2 ingesters introduce
+-- (dangerous-capability, robustness, honesty, adversarial). Allow NULL for
+-- existing rows that may not have a category set yet.
+ALTER TABLE "benchmarks"
+  ADD CONSTRAINT "chk_benchmarks_category"
+  CHECK ("category" IS NULL OR "category" IN (
+    'general',
+    'reasoning',
+    'math',
+    'coding',
+    'knowledge',
+    'multimodal',
+    'agentic',
+    'safety',
+    'dangerous-capability',
+    'robustness',
+    'honesty',
+    'adversarial'
+  )) NOT VALID;
+
+ALTER TABLE "benchmarks" VALIDATE CONSTRAINT "chk_benchmarks_category";
+
+-- =====================================================================
+-- 2. benchmark_results: provenance columns + widen unique index
+-- =====================================================================
+--
+-- IMPORTANT: migration 0212 (QUA-702) already added a nullable
+-- `tested_by text` column with a CHECK constraint of
+-- `(tested_by IS NULL OR tested_by IN ('self-report', 'third-party'))` and
+-- an index `idx_br_tested_by`. This migration extends that to a wider
+-- allowlist + NOT NULL column, adds three more columns, and widens the
+-- unique index. Steps must be ordered to handle the 0212 state without
+-- failing on duplicate constraint / column / index names.
+--
+-- Live enumeration before writing this migration (per
+-- .claude/rules/database-migrations.md § "Adding CHECK constraints"): the
+-- 0212 allowlist was 'self-report' / 'third-party' / NULL, so the only
+-- legacy values that could exist on prod today are exactly those three.
+-- All three are preserved in the new constraint below ('third-party' kept
+-- explicitly so QUA-702-tagged rows survive the constraint swap).
+
+-- 2a. Drop 0212's narrow CHECK constraint to make room for the wider one.
+ALTER TABLE "benchmark_results"
+  DROP CONSTRAINT IF EXISTS "chk_br_tested_by";
+
+-- 2b. Backfill any NULL legacy rows to 'unknown' so we can tighten the
+-- column to NOT NULL DEFAULT 'unknown' below.
+UPDATE "benchmark_results" SET "tested_by" = 'unknown' WHERE "tested_by" IS NULL;
+
+-- 2c. Tighten the existing column from 0212. ADD COLUMN IF NOT EXISTS is
+-- not enough here because 0212 created the column without NOT NULL or a
+-- default — IF NOT EXISTS would silently leave it nullable.
+ALTER TABLE "benchmark_results"
+  ALTER COLUMN "tested_by" SET DEFAULT 'unknown',
+  ALTER COLUMN "tested_by" SET NOT NULL;
+
+-- 2d. Add the three new provenance columns (genuinely new — not in 0212).
+ALTER TABLE "benchmark_results"
+  ADD COLUMN IF NOT EXISTS "tested_by_org_id" text REFERENCES "entities"("stable_id") ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS "evaluation_date" text,
+  ADD COLUMN IF NOT EXISTS "methodology_notes" text;
+
+CREATE INDEX IF NOT EXISTS "idx_br_tested_by_org_id"
+  ON "benchmark_results" ("tested_by_org_id");
+
+-- 2e. Re-apply the wider CHECK. 'third-party' is kept for backward compat
+-- with rows tagged by the QUA-702 model_system_cards postUpsert hook
+-- before this migration ran.
+ALTER TABLE "benchmark_results"
+  ADD CONSTRAINT "chk_br_tested_by"
+  CHECK ("tested_by" IN (
+    'self-report',
+    'leaderboard',
+    'aisi-uk',
+    'aisi-us',
+    'metr',
+    'apollo',
+    'third-party',
+    'third-party-paper',
+    'epoch-ai',
+    'unknown'
+  )) NOT VALID;
+
+ALTER TABLE "benchmark_results" VALIDATE CONSTRAINT "chk_br_tested_by";
+
+-- 2f. Drop the narrow (benchmark_id, model_id) unique index and replace
+-- with a 4-column composite. With the same (benchmark_id, model_id),
+-- different (tested_by, evaluation_date) combinations are now distinct
+-- rows. This supports e.g. Anthropic self-report MMLU vs HELM-leaderboard
+-- MMLU vs AISI-UK MMLU for the same Claude model. COALESCE on
+-- evaluation_date so NULL doesn't fall through the uniqueness check.
+DROP INDEX IF EXISTS "idx_br_benchmark_model";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_br_benchmark_model_testedby_date"
+  ON "benchmark_results" (
+    "benchmark_id",
+    "model_id",
+    "tested_by",
+    COALESCE("evaluation_date", '')
+  );
+
+-- 2g. idx_br_tested_by already exists from 0212 (IF NOT EXISTS protects
+-- against re-creation). Kept for explicitness so this file documents the
+-- full final shape of benchmark_results indexes.
+CREATE INDEX IF NOT EXISTS "idx_br_tested_by"
+  ON "benchmark_results" ("tested_by");
+
+CREATE INDEX IF NOT EXISTS "idx_br_evaluation_date"
+  ON "benchmark_results" ("evaluation_date" DESC);
+
+-- =====================================================================
+-- 3. model_aliases: alias → entity stable_id mapping
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS "model_aliases" (
+  -- Lowercased alias as the natural primary key — the resolution lookup is
+  -- "given a raw external string, find the canonical model entity". Two
+  -- different sources can supply the same alias for the same model (e.g.
+  -- "Claude 3.5 Sonnet" appears on HELM and on Scale MASK); recording each
+  -- (alias, source) separately would duplicate the resolution data without
+  -- adding signal. If the same alias maps to different models on different
+  -- sources, that's a real conflict the ingester must surface — not silently
+  -- last-write-wins — so a flat PK is correct.
+  "alias" text PRIMARY KEY NOT NULL,
+  "model_stable_id" text NOT NULL REFERENCES "entities"("stable_id") ON DELETE CASCADE,
+  -- Where this alias was observed: 'yaml-seed' for the initial bulk load
+  -- from ai-models.yaml `aliases:` arrays, then leaderboard slugs
+  -- ('helm-safety', 'mask', 'fortress', ...) once ingesters start writing.
+  "source" text NOT NULL DEFAULT 'yaml-seed',
+  -- 'exact' = byte-for-byte match in source data; 'fuzzy' = Levenshtein
+  -- match suggested by ingester, awaiting human confirmation; 'manual' =
+  -- promoted by a human via /internal/benchmark-quarantine.
+  "confidence" text NOT NULL DEFAULT 'exact',
+  "added_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "synced_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE "model_aliases"
+  ADD CONSTRAINT "chk_model_aliases_confidence"
+  CHECK ("confidence" IN ('exact', 'fuzzy', 'manual')) NOT VALID;
+
+ALTER TABLE "model_aliases" VALIDATE CONSTRAINT "chk_model_aliases_confidence";
+
+CREATE INDEX IF NOT EXISTS "idx_model_aliases_model"
+  ON "model_aliases" ("model_stable_id");
+
+CREATE INDEX IF NOT EXISTS "idx_model_aliases_source"
+  ON "model_aliases" ("source");
+
+-- =====================================================================
+-- 4. benchmark_results_pending: quarantine queue for unresolved model names
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS "benchmark_results_pending" (
+  "id" text PRIMARY KEY NOT NULL,
+  "benchmark_id" text NOT NULL REFERENCES "benchmarks"("id") ON DELETE CASCADE,
+  -- The exact string the source emitted (e.g. "claude-3-5-sonnet-2024-10",
+  -- "Claude 3.5 Sonnet (new)"). Preserving the literal string matters: a
+  -- human reviewer matches it against ai-models.yaml entries to add an
+  -- alias. Preserves case for readability — dedup happens via the alias
+  -- table, not here.
+  "raw_model_name" text NOT NULL,
+  "score" double precision,
+  "score_text" text,
+  "unit" text,
+  "evaluation_date" text,
+  "tested_by" text NOT NULL DEFAULT 'unknown',
+  "source_url" text,
+  "methodology_notes" text,
+  -- Whatever extra fields the source exposed that we may want to surface in
+  -- the dashboard but don't yet have first-class columns for (sub-scenario
+  -- breakdowns, prompt-set hashes, etc.).
+  "raw_payload" jsonb,
+  "status" text NOT NULL DEFAULT 'pending',
+  "ingester_source" text NOT NULL,
+  "resolved_to_stable_id" text REFERENCES "entities"("stable_id") ON DELETE SET NULL,
+  "resolved_at" timestamp with time zone,
+  "resolved_by" text,
+  "rejected_reason" text,
+  "synced_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE "benchmark_results_pending"
+  ADD CONSTRAINT "chk_brp_status"
+  CHECK ("status" IN ('pending', 'resolved', 'rejected')) NOT VALID;
+
+ALTER TABLE "benchmark_results_pending" VALIDATE CONSTRAINT "chk_brp_status";
+
+ALTER TABLE "benchmark_results_pending"
+  ADD CONSTRAINT "chk_brp_tested_by"
+  CHECK ("tested_by" IN (
+    'self-report',
+    'leaderboard',
+    'aisi-uk',
+    'aisi-us',
+    'metr',
+    'apollo',
+    'third-party-paper',
+    'epoch-ai',
+    'unknown'
+  )) NOT VALID;
+
+ALTER TABLE "benchmark_results_pending" VALIDATE CONSTRAINT "chk_brp_tested_by";
+
+CREATE INDEX IF NOT EXISTS "idx_brp_benchmark"
+  ON "benchmark_results_pending" ("benchmark_id");
+
+CREATE INDEX IF NOT EXISTS "idx_brp_status"
+  ON "benchmark_results_pending" ("status");
+
+CREATE INDEX IF NOT EXISTS "idx_brp_ingester_source"
+  ON "benchmark_results_pending" ("ingester_source");
+
+CREATE INDEX IF NOT EXISTS "idx_brp_created_at"
+  ON "benchmark_results_pending" ("created_at" DESC);
+
+-- Natural key: don't reinsert the same (source, raw_name, benchmark, eval
+-- date) combination twice — each ingester run should be idempotent on the
+-- quarantine table just like benchmark_results is. Three sources reporting
+-- the same unresolved alias means three rows; one source reporting the same
+-- alias twice in the same wave means one row.
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_brp_natural_key"
+  ON "benchmark_results_pending" (
+    "ingester_source",
+    "benchmark_id",
+    lower("raw_model_name"),
+    COALESCE("evaluation_date", '')
+  );

--- a/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
+++ b/apps/wiki-server/drizzle/0215_qua_689_safety_benchmark_foundation.sql
@@ -1,5 +1,12 @@
 -- QUA-689 Phase 2 (foundation): Safety-benchmark ingestion schema extensions.
 --
+-- Numbering note: this migration is 0207, not 0206. The 0206 prefix is
+-- reserved for QUA-688 (`0206_qua_688_scorecard_tables.sql`), which is in
+-- review on `claude/qua-688-scorecard-mirror`. Skipping 0206 here avoids a
+-- duplicate-prefix collision regardless of merge order. The journal entry
+-- mirrors this gap (idx 205 → 207). The drizzle journal validator allows
+-- non-contiguous idx values; only duplicates are rejected.
+--
 -- Three changes to unblock the parallel ingester work in follow-up PRs:
 --
 --   1. benchmarks: extend the category vocabulary via a CHECK constraint and
@@ -116,6 +123,17 @@ CREATE INDEX IF NOT EXISTS "idx_br_tested_by_org_id"
 -- 2e. Re-apply the wider CHECK. 'third-party' is kept for backward compat
 -- with rows tagged by the QUA-702 model_system_cards postUpsert hook
 -- before this migration ran.
+
+-- Also forbid empty-string evaluation_date so it can't silently collide
+-- with NULL through the COALESCE(evaluation_date, '') in
+-- idx_br_benchmark_model_testedby_date. Either supply a real date string
+-- (preferably ISO YYYY-MM-DD) or NULL.
+ALTER TABLE "benchmark_results"
+  ADD CONSTRAINT "chk_br_evaluation_date_nonempty"
+  CHECK ("evaluation_date" IS NULL OR length("evaluation_date") > 0) NOT VALID;
+
+ALTER TABLE "benchmark_results" VALIDATE CONSTRAINT "chk_br_evaluation_date_nonempty";
+
 ALTER TABLE "benchmark_results"
   ADD CONSTRAINT "chk_br_tested_by"
   CHECK ("tested_by" IN (

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1492,6 +1492,13 @@
       "when": 1787876500000,
       "tag": "0214_qua_693_ai_incidents",
       "breakpoints": true
+    },
+    {
+      "idx": 215,
+      "version": "7",
+      "when": 1787876600000,
+      "tag": "0215_qua_689_safety_benchmark_foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/benchmark-results-pending.test.ts
+++ b/apps/wiki-server/src/__tests__/benchmark-results-pending.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the benchmark_results_pending (quarantine) sync handler.
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer.
+ *
+ * Locks in two route-specific behaviors:
+ *   1. preValidate rejects unknown benchmarkIds with a clear error so
+ *      ingesters can fix references before the quarantine row is written.
+ *   2. Slug benchmarkId is auto-resolved to the 10-char ID — same shape
+ *      as benchmark-results.ts so the two ingest pipelines stay aligned.
+ *
+ * Audit log + FK + factory machinery is covered by sync-factory.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+interface SqlEntry {
+  q: string;
+  params: unknown[];
+}
+const sqlLog: SqlEntry[] = [];
+
+// Pretend benchmarks "mmlu" (slug) → "bench-mmlu1" (id) exists in prod.
+const KNOWN_BENCHMARK_ROW = { id: "bench-mmlu1", slug: "mmlu" };
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+  sqlLog.push({ q, params });
+
+  // The preValidate hook does a SELECT id, slug FROM benchmarks WHERE id IN
+  // (...) OR slug IN (...). Return the known row only when its identifiers
+  // appear in the params list.
+  if (
+    q.includes("select") &&
+    q.includes("from benchmarks") &&
+    (q.includes("id in") || q.includes("slug in"))
+  ) {
+    const wanted = params.map((p) => String(p));
+    if (
+      wanted.includes(KNOWN_BENCHMARK_ROW.id) ||
+      wanted.includes(KNOWN_BENCHMARK_ROW.slug)
+    ) {
+      return [KNOWN_BENCHMARK_ROW];
+    }
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { benchmarkResultsPendingRoute } = await import(
+  "../routes/tablebase/benchmark-results-pending.js"
+);
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/", benchmarkResultsPendingRoute);
+  return app;
+}
+
+describe("benchmark_results_pending /sync", () => {
+  beforeEach(() => {
+    sqlLog.length = 0;
+  });
+
+  it("accepts a known benchmark slug and inserts the quarantine row", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_quarantine_1",
+          benchmarkId: "mmlu", // slug — should resolve to bench-mmlu1
+          rawModelName: "Claude 3.5 Sonnet (new)",
+          score: 0.873,
+          testedBy: "leaderboard",
+          ingesterSource: "helm-safety",
+          status: "pending",
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const insertCount = sqlLog.filter(
+      ({ q }) =>
+        q.includes("insert into") &&
+        q.includes('"benchmark_results_pending"'),
+    ).length;
+    expect(insertCount).toBeGreaterThan(0);
+  });
+
+  it("rejects an unknown benchmarkId with a descriptive message", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_quarantine_2",
+          benchmarkId: "no-such-benchmark",
+          rawModelName: "Some Model",
+          ingesterSource: "fortress",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error?: string; message?: string };
+    const errMessage = body.message ?? body.error ?? "";
+    expect(errMessage).toMatch(/no-such-benchmark/);
+    expect(errMessage.toLowerCase()).toMatch(/benchmark/);
+  });
+
+  it("rejects an invalid status value", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_quarantine_3",
+          benchmarkId: "mmlu",
+          rawModelName: "Some Model",
+          ingesterSource: "fortress",
+          status: "approved", // not in [pending, resolved, rejected]
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid testedBy value", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_quarantine_4",
+          benchmarkId: "mmlu",
+          rawModelName: "Some Model",
+          testedBy: "guesswork", // not in the enum
+          ingesterSource: "fortress",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects intra-batch duplicates on (ingesterSource, benchmarkId, lower(rawModelName), evaluationDate)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_dup_1",
+          benchmarkId: "mmlu",
+          rawModelName: "Claude 3.5 Sonnet",
+          ingesterSource: "fortress",
+          evaluationDate: "2025-09-01",
+        },
+        {
+          id: "brp_dup_2",
+          benchmarkId: "mmlu",
+          // Same source + benchmark + lowercased name + date — should collide.
+          rawModelName: "claude 3.5 sonnet",
+          ingesterSource: "fortress",
+          evaluationDate: "2025-09-01",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/__tests__/benchmark-results-pending.test.ts
+++ b/apps/wiki-server/src/__tests__/benchmark-results-pending.test.ts
@@ -167,4 +167,36 @@ describe("benchmark_results_pending /sync", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("rejects intra-batch duplicates AFTER slug resolution (post-resolution dedup)", async () => {
+    // The factory's naturalKey runs BEFORE preValidate, so without the
+    // post-resolution dedup added by QUA-689 the two items below would
+    // pass intra-batch dedup (different `benchmarkId` values: "mmlu"
+    // vs "bench-mmlu1") and only collide on PG's uq_brp_natural_key
+    // with a confusing SQL-level duplicate-key error instead of a
+    // clean 400. This test locks in the cleaner behavior.
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "brp_postdup_1",
+          benchmarkId: "mmlu", // slug — preValidate rewrites to bench-mmlu1
+          rawModelName: "Claude 3.5 Sonnet",
+          ingesterSource: "helm-safety",
+          evaluationDate: "2025-10-01",
+        },
+        {
+          id: "brp_postdup_2",
+          benchmarkId: "bench-mmlu1", // already canonical
+          rawModelName: "Claude 3.5 Sonnet",
+          ingesterSource: "helm-safety",
+          evaluationDate: "2025-10-01",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string; message?: string };
+    const errMessage = body.message ?? body.error ?? "";
+    expect(errMessage.toLowerCase()).toMatch(/post slug-resolution|duplicate/);
+  });
 });

--- a/apps/wiki-server/src/__tests__/model-aliases.test.ts
+++ b/apps/wiki-server/src/__tests__/model-aliases.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the model_aliases sync handler — the canonical resolution table
+ * used by Phase 2 ingesters (QUA-689).
+ *
+ * Two behaviors to lock in:
+ *   1. Validation rejects mixed-case aliases — the column is meant to be
+ *      lowercased before sync, so callers can do a single case-insensitive
+ *      lookup. Catching mixed case at the schema layer prevents a class of
+ *      "two rows for the same alias, different case" bugs.
+ *   2. Intra-batch dedup catches the same alias submitted twice in one
+ *      payload (e.g. an ingester reading two pages and stitching results
+ *      without a final dedup pass).
+ *
+ * The sync-factory's downstream behavior (audit log, FK validation) is
+ * covered by sync-factory.test.ts; these tests focus on the route-specific
+ * shape.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+interface SqlEntry {
+  q: string;
+  params: unknown[];
+}
+const sqlLog: SqlEntry[] = [];
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+  sqlLog.push({ q, params });
+
+  // Pre-fetch select for audit log
+  if (
+    q.includes("select") &&
+    q.includes('"model_aliases"') &&
+    q.includes("where") &&
+    !q.includes("update")
+  ) {
+    return [];
+  }
+  // INSERT or UPDATE on model_aliases / audit log
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { modelAliasesRoute } = await import(
+  "../routes/tablebase/model-aliases.js"
+);
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/", modelAliasesRoute);
+  return app;
+}
+
+describe("model_aliases /sync", () => {
+  beforeEach(() => {
+    sqlLog.length = 0;
+  });
+
+  it("accepts a lowercase alias and produces an INSERT", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          alias: "claude-3-5-sonnet",
+          modelStableId: "sid_AbCdEfGhIj",
+          source: "yaml-seed",
+          confidence: "exact",
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { upserted: number };
+    expect(body.upserted).toBe(1);
+
+    const insertCount = sqlLog.filter(
+      ({ q }) => q.includes("insert into") && q.includes('"model_aliases"'),
+    ).length;
+    expect(insertCount).toBeGreaterThan(0);
+  });
+
+  it("rejects a mixed-case alias", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          alias: "Claude-3-5-Sonnet",
+          modelStableId: "sid_AbCdEfGhIj",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error?: string; message?: string };
+    const errMessage = body.message ?? body.error ?? "";
+    expect(errMessage.toLowerCase()).toMatch(/lowercase/);
+
+    // No INSERT should have been issued.
+    const insertCount = sqlLog.filter(
+      ({ q }) => q.includes("insert into") && q.includes('"model_aliases"'),
+    ).length;
+    expect(insertCount).toBe(0);
+  });
+
+  it("rejects duplicate aliases within a single batch (natural-key dedup)", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          alias: "claude-3-5-sonnet",
+          modelStableId: "sid_AbCdEfGhIj",
+        },
+        {
+          alias: "claude-3-5-sonnet",
+          modelStableId: "sid_DifferentMo",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid confidence value", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          alias: "claude-3-5-sonnet",
+          modelStableId: "sid_AbCdEfGhIj",
+          confidence: "guessed",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
@@ -1,0 +1,270 @@
+/**
+ * Benchmark results pending — quarantine queue for ingester rows whose source
+ * model name didn't resolve to any entity. Reviewed via the
+ * /internal/benchmark-quarantine dashboard (follow-up PR).
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer.
+ *
+ * Schema: see benchmarkResultsPending in apps/wiki-server/src/schema.ts.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { and, count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import {
+  benchmarkResultsPending,
+  benchmarks,
+} from "../../schema.js";
+import {
+  zv,
+  clampedLimit,
+  validationError,
+} from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 500;
+
+const VALID_STATUS = ["pending", "resolved", "rejected"] as const;
+
+const VALID_TESTED_BY = [
+  "self-report",
+  "leaderboard",
+  "aisi-uk",
+  "aisi-us",
+  "metr",
+  "apollo",
+  "third-party-paper",
+  "epoch-ai",
+  "unknown",
+] as const;
+
+// ---- Query schemas ----
+
+const ListQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 100),
+  offset: z.coerce.number().int().min(0).default(0),
+  status: z.enum(VALID_STATUS).optional(),
+  ingesterSource: z.string().max(100).optional(),
+  benchmarkId: z.string().max(200).optional(),
+  q: z.string().max(200).optional(),
+});
+
+// ---- Sync schema ----
+
+const SyncBenchmarkResultPendingItemSchema = z.object({
+  id: z.string().min(1).max(100),
+  benchmarkId: z.string().min(1).max(200),
+  rawModelName: z.string().min(1).max(500),
+  score: z.number().nullable().optional(),
+  scoreText: z.string().max(500).nullable().optional(),
+  unit: z.string().max(50).nullable().optional(),
+  evaluationDate: z.string().max(20).nullable().optional(),
+  testedBy: z.enum(VALID_TESTED_BY).default("unknown"),
+  sourceUrl: z.string().max(2000).nullable().optional(),
+  methodologyNotes: z.string().max(5000).nullable().optional(),
+  rawPayload: z.record(z.unknown()).nullable().optional(),
+  status: z.enum(VALID_STATUS).default("pending"),
+  ingesterSource: z.string().min(1).max(100),
+  resolvedToStableId: z.string().max(200).nullable().optional(),
+  resolvedAt: z.string().datetime().nullable().optional(),
+  resolvedBy: z.string().max(200).nullable().optional(),
+  rejectedReason: z.string().max(1000).nullable().optional(),
+});
+
+// ---- Helpers ----
+
+function formatRow(r: typeof benchmarkResultsPending.$inferSelect) {
+  return {
+    id: r.id,
+    benchmarkId: r.benchmarkId,
+    rawModelName: r.rawModelName,
+    score: r.score,
+    scoreText: r.scoreText,
+    unit: r.unit,
+    evaluationDate: r.evaluationDate,
+    testedBy: r.testedBy,
+    sourceUrl: r.sourceUrl,
+    methodologyNotes: r.methodologyNotes,
+    rawPayload: r.rawPayload,
+    status: r.status,
+    ingesterSource: r.ingesterSource,
+    resolvedToStableId: r.resolvedToStableId,
+    resolvedAt: r.resolvedAt,
+    resolvedBy: r.resolvedBy,
+    rejectedReason: r.rejectedReason,
+    syncedAt: r.syncedAt,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// ---- Route ----
+
+const benchmarkResultsPendingApp = new Hono()
+
+  // GET /stats — quarantine queue depth, used by the dashboard sidebar.
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(benchmarkResultsPending);
+
+    const byStatus = await db
+      .select({
+        status: benchmarkResultsPending.status,
+        total: count(),
+      })
+      .from(benchmarkResultsPending)
+      .groupBy(benchmarkResultsPending.status);
+
+    const bySource = await db
+      .select({
+        ingesterSource: benchmarkResultsPending.ingesterSource,
+        total: count(),
+      })
+      .from(benchmarkResultsPending)
+      .groupBy(benchmarkResultsPending.ingesterSource);
+
+    return c.json({
+      total,
+      byStatus: byStatus.map((r) => ({ status: r.status, total: r.total })),
+      bySource: bySource.map((r) => ({
+        ingesterSource: r.ingesterSource,
+        total: r.total,
+      })),
+    });
+  })
+
+  // GET /all — paginated, optionally filtered by status / source / benchmark / search.
+  .get("/all", zv("query", ListQuery), async (c) => {
+    const { limit, offset, status, ingesterSource, benchmarkId, q } =
+      c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (status) conditions.push(eq(benchmarkResultsPending.status, status));
+    if (ingesterSource)
+      conditions.push(eq(benchmarkResultsPending.ingesterSource, ingesterSource));
+    if (benchmarkId)
+      conditions.push(eq(benchmarkResultsPending.benchmarkId, benchmarkId));
+    if (q) {
+      const pattern = `%${q.toLowerCase()}%`;
+      conditions.push(
+        or(
+          ilike(benchmarkResultsPending.rawModelName, pattern),
+          ilike(benchmarkResultsPending.benchmarkId, pattern),
+        ),
+      );
+    }
+
+    const where = conditions.length ? and(...conditions) : undefined;
+
+    const rows = await db
+      .select()
+      .from(benchmarkResultsPending)
+      .where(where)
+      .orderBy(desc(benchmarkResultsPending.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(benchmarkResultsPending)
+      .where(where);
+
+    return c.json({
+      items: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // POST /sync — bulk upsert from ingesters.
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "benchmark-results-pending",
+      table: benchmarkResultsPending,
+      syncSchema: SyncBenchmarkResultPendingItemSchema,
+      auditRecordType: "benchmark-results-pending",
+      naturalKey: (item) =>
+        [
+          item.ingesterSource,
+          item.benchmarkId,
+          item.rawModelName.toLowerCase(),
+          item.evaluationDate ?? "",
+        ].join("|"),
+      naturalKeyError:
+        "Duplicate (ingesterSource, benchmarkId, rawModelName, evaluationDate) in batch — see uq_brp_natural_key",
+      // benchmarkId references the benchmarks table (not entities), so we
+      // can't use the factory's `entityRefs` shorthand. Validate it via
+      // preValidate, mirroring benchmark-results.ts. Slug fallback is allowed
+      // for ingesters that submit benchmark slugs rather than 10-char IDs.
+      preValidate: async (c, db, items) => {
+        const benchmarkIds = [...new Set(items.map((i) => i.benchmarkId))];
+        if (benchmarkIds.length === 0) return null;
+        const placeholders = benchmarkIds.map((id) => sql`${id}`);
+        const inList = sql.join(placeholders, sql`, `);
+        const found = await db.execute<{ id: string; slug: string }>(sql`
+          SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
+        `);
+        const foundIdSet = new Set(found.map((r) => r.id));
+        const foundSlugSet = new Set(found.map((r) => r.slug));
+        const slugToId = new Map(found.map((r) => [r.slug, r.id]));
+        const missing = benchmarkIds.filter(
+          (id) => !foundIdSet.has(id) && !foundSlugSet.has(id),
+        );
+        if (missing.length > 0) {
+          return validationError(
+            c,
+            `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first.`,
+          );
+        }
+        for (const item of items) {
+          if (slugToId.has(item.benchmarkId)) {
+            item.benchmarkId = slugToId.get(item.benchmarkId)!;
+          }
+        }
+        return null;
+      },
+      toRow: (item, now) => ({
+        id: item.id,
+        benchmarkId: item.benchmarkId,
+        rawModelName: item.rawModelName,
+        score: item.score ?? null,
+        scoreText: item.scoreText ?? null,
+        unit: item.unit ?? null,
+        evaluationDate: item.evaluationDate ?? null,
+        testedBy: item.testedBy,
+        sourceUrl: item.sourceUrl ?? null,
+        methodologyNotes: item.methodologyNotes ?? null,
+        rawPayload: item.rawPayload ?? null,
+        status: item.status,
+        ingesterSource: item.ingesterSource,
+        resolvedToStableId: item.resolvedToStableId ?? null,
+        // Date string from JSON → Date for the timestamptz column.
+        resolvedAt: item.resolvedAt ? new Date(item.resolvedAt) : null,
+        resolvedBy: item.resolvedBy ?? null,
+        rejectedReason: item.rejectedReason ?? null,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+    }),
+  )
+
+  .post(
+    "/delete-batch",
+    deleteBatchHandler(benchmarkResultsPending, null, {
+      maxIdLength: 100,
+      label: "benchmark-results-pending",
+    }),
+  );
+
+export const benchmarkResultsPendingRoute = benchmarkResultsPendingApp;
+export type BenchmarkResultsPendingRoute = typeof benchmarkResultsPendingApp;

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
@@ -192,16 +192,20 @@ const benchmarkResultsPendingApp = new Hono()
       name: "benchmark-results-pending",
       table: benchmarkResultsPending,
       syncSchema: SyncBenchmarkResultPendingItemSchema,
-      auditRecordType: "benchmark-results-pending",
-      naturalKey: (item) =>
-        [
-          item.ingesterSource,
-          item.benchmarkId,
-          item.rawModelName.toLowerCase(),
-          item.evaluationDate ?? "",
-        ].join("|"),
-      naturalKeyError:
-        "Duplicate (ingesterSource, benchmarkId, rawModelName, evaluationDate) in batch — see uq_brp_natural_key",
+      // No `auditRecordType` — pending row IDs (e.g. `brp_quarantine_helm_1`)
+      // can exceed the 10-char limit on `tablebase_audit_log.record_id`
+      // (varchar(10) NOT NULL). The factory writes `recordId: row.id` into
+      // that column, so audit logging would fail with "value too long" on
+      // every realistic ingester payload. Quarantine rows are also a
+      // short-lived, operator-curated queue — the relevant audit trail is
+      // the `resolved_*` columns recording who promoted/rejected each row.
+      // Note: we deliberately don't use the factory's `naturalKey` for
+      // intra-batch dedup here. The factory runs naturalKey BEFORE
+      // preValidate, but preValidate is what canonicalizes
+      // benchmarkId (slug → 10-char id). Two items with `mmlu` and
+      // `bench-mmlu1` for the same model would dedup-pass on raw input
+      // then collide on `uq_brp_natural_key` post-resolution. We do the
+      // dedup inside preValidate instead, on the post-resolution form.
       // benchmarkId references the benchmarks table (not entities), so we
       // can't use the factory's `entityRefs` shorthand. Validate it via
       // preValidate, mirroring benchmark-results.ts. Slug fallback is allowed
@@ -230,6 +234,27 @@ const benchmarkResultsPendingApp = new Hono()
           if (slugToId.has(item.benchmarkId)) {
             item.benchmarkId = slugToId.get(item.benchmarkId)!;
           }
+        }
+        // Post-resolution intra-batch dedup. Catches batches that mix slug
+        // and 10-char id forms of the same benchmark for the same
+        // (ingesterSource, model, evaluationDate). PG's uq_brp_natural_key
+        // would fail the upsert, but with a confusing duplicate-key SQL
+        // error instead of a clean 400.
+        const seen = new Set<string>();
+        for (const item of items) {
+          const key = [
+            item.ingesterSource,
+            item.benchmarkId,
+            item.rawModelName.toLowerCase(),
+            item.evaluationDate ?? "",
+          ].join("|");
+          if (seen.has(key)) {
+            return validationError(
+              c,
+              `Duplicate (ingesterSource, benchmarkId, rawModelName, evaluationDate) in batch (post slug-resolution): ${key}`,
+            );
+          }
+          seen.add(key);
         }
         return null;
       },

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
@@ -10,37 +10,20 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { and, count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import {
-  benchmarkResultsPending,
-  benchmarks,
-} from "../../schema.js";
-import {
-  zv,
-  clampedLimit,
-  validationError,
-} from "../shared/utils.js";
+import { benchmarkResultsPending } from "../../schema.js";
+import { zv, clampedLimit, validationError } from "../shared/utils.js";
+import { buildSearchCondition } from "../shared/query-helpers.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
+import { VALID_TESTED_BY, resolveBenchmarkRefs } from "./benchmark-shared.js";
 
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 500;
 
 const VALID_STATUS = ["pending", "resolved", "rejected"] as const;
-
-const VALID_TESTED_BY = [
-  "self-report",
-  "leaderboard",
-  "aisi-uk",
-  "aisi-us",
-  "metr",
-  "apollo",
-  "third-party-paper",
-  "epoch-ai",
-  "unknown",
-] as const;
 
 // ---- Query schemas ----
 
@@ -109,27 +92,23 @@ const benchmarkResultsPendingApp = new Hono()
   // GET /stats — quarantine queue depth, used by the dashboard sidebar.
   .get("/stats", async (c) => {
     const db = getDrizzleDb();
-
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(benchmarkResultsPending);
-
-    const byStatus = await db
-      .select({
-        status: benchmarkResultsPending.status,
-        total: count(),
-      })
-      .from(benchmarkResultsPending)
-      .groupBy(benchmarkResultsPending.status);
-
-    const bySource = await db
-      .select({
-        ingesterSource: benchmarkResultsPending.ingesterSource,
-        total: count(),
-      })
-      .from(benchmarkResultsPending)
-      .groupBy(benchmarkResultsPending.ingesterSource);
-
+    const [[{ total }], byStatus, bySource] = await Promise.all([
+      db.select({ total: count() }).from(benchmarkResultsPending),
+      db
+        .select({
+          status: benchmarkResultsPending.status,
+          total: count(),
+        })
+        .from(benchmarkResultsPending)
+        .groupBy(benchmarkResultsPending.status),
+      db
+        .select({
+          ingesterSource: benchmarkResultsPending.ingesterSource,
+          total: count(),
+        })
+        .from(benchmarkResultsPending)
+        .groupBy(benchmarkResultsPending.ingesterSource),
+    ]);
     return c.json({
       total,
       byStatus: byStatus.map((r) => ({ status: r.status, total: r.total })),
@@ -153,29 +132,28 @@ const benchmarkResultsPendingApp = new Hono()
     if (benchmarkId)
       conditions.push(eq(benchmarkResultsPending.benchmarkId, benchmarkId));
     if (q) {
-      const pattern = `%${q.toLowerCase()}%`;
-      conditions.push(
-        or(
-          ilike(benchmarkResultsPending.rawModelName, pattern),
-          ilike(benchmarkResultsPending.benchmarkId, pattern),
-        ),
+      const search = buildSearchCondition(
+        [benchmarkResultsPending.rawModelName, benchmarkResultsPending.benchmarkId],
+        q,
       );
+      if (search) conditions.push(search);
     }
 
     const where = conditions.length ? and(...conditions) : undefined;
 
-    const rows = await db
-      .select()
-      .from(benchmarkResultsPending)
-      .where(where)
-      .orderBy(desc(benchmarkResultsPending.createdAt))
-      .limit(limit)
-      .offset(offset);
-
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(benchmarkResultsPending)
-      .where(where);
+    const [rows, [{ total }]] = await Promise.all([
+      db
+        .select()
+        .from(benchmarkResultsPending)
+        .where(where)
+        .orderBy(desc(benchmarkResultsPending.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ total: count() })
+        .from(benchmarkResultsPending)
+        .where(where),
+    ]);
 
     return c.json({
       items: rows.map(formatRow),
@@ -192,54 +170,18 @@ const benchmarkResultsPendingApp = new Hono()
       name: "benchmark-results-pending",
       table: benchmarkResultsPending,
       syncSchema: SyncBenchmarkResultPendingItemSchema,
-      // No `auditRecordType` — pending row IDs (e.g. `brp_quarantine_helm_1`)
-      // can exceed the 10-char limit on `tablebase_audit_log.record_id`
-      // (varchar(10) NOT NULL). The factory writes `recordId: row.id` into
-      // that column, so audit logging would fail with "value too long" on
-      // every realistic ingester payload. Quarantine rows are also a
-      // short-lived, operator-curated queue — the relevant audit trail is
-      // the `resolved_*` columns recording who promoted/rejected each row.
-      // Note: we deliberately don't use the factory's `naturalKey` for
-      // intra-batch dedup here. The factory runs naturalKey BEFORE
-      // preValidate, but preValidate is what canonicalizes
-      // benchmarkId (slug → 10-char id). Two items with `mmlu` and
-      // `bench-mmlu1` for the same model would dedup-pass on raw input
-      // then collide on `uq_brp_natural_key` post-resolution. We do the
-      // dedup inside preValidate instead, on the post-resolution form.
-      // benchmarkId references the benchmarks table (not entities), so we
-      // can't use the factory's `entityRefs` shorthand. Validate it via
-      // preValidate, mirroring benchmark-results.ts. Slug fallback is allowed
-      // for ingesters that submit benchmark slugs rather than 10-char IDs.
+      // Why no `auditRecordType`: row IDs (e.g. `brp_quarantine_helm_1`)
+      // can exceed `tablebase_audit_log.record_id`'s varchar(10), so audit
+      // logging would fail with "value too long" on real payloads.
+      // Why no factory `naturalKey`: the factory's natural-key dedup runs
+      // BEFORE `preValidate`, but `preValidate` is what canonicalizes the
+      // benchmarkId (slug → 10-char id). The post-resolution dedup below
+      // catches batches that mix slug and id forms.
+      // Why no `entityRefs`: benchmarkId references the `benchmarks` table,
+      // not entities. Validated in `preValidate` via the shared helper.
       preValidate: async (c, db, items) => {
-        const benchmarkIds = [...new Set(items.map((i) => i.benchmarkId))];
-        if (benchmarkIds.length === 0) return null;
-        const placeholders = benchmarkIds.map((id) => sql`${id}`);
-        const inList = sql.join(placeholders, sql`, `);
-        const found = await db.execute<{ id: string; slug: string }>(sql`
-          SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
-        `);
-        const foundIdSet = new Set(found.map((r) => r.id));
-        const foundSlugSet = new Set(found.map((r) => r.slug));
-        const slugToId = new Map(found.map((r) => [r.slug, r.id]));
-        const missing = benchmarkIds.filter(
-          (id) => !foundIdSet.has(id) && !foundSlugSet.has(id),
-        );
-        if (missing.length > 0) {
-          return validationError(
-            c,
-            `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first.`,
-          );
-        }
-        for (const item of items) {
-          if (slugToId.has(item.benchmarkId)) {
-            item.benchmarkId = slugToId.get(item.benchmarkId)!;
-          }
-        }
-        // Post-resolution intra-batch dedup. Catches batches that mix slug
-        // and 10-char id forms of the same benchmark for the same
-        // (ingesterSource, model, evaluationDate). PG's uq_brp_natural_key
-        // would fail the upsert, but with a confusing duplicate-key SQL
-        // error instead of a clean 400.
+        const refErr = await resolveBenchmarkRefs(c, db, items);
+        if (refErr) return refErr;
         const seen = new Set<string>();
         for (const item of items) {
           const key = [

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -1,16 +1,16 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, count, desc, sql } from "drizzle-orm";
+import { eq, count, desc } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { benchmarkResults, benchmarks } from "../../schema.js";
 import {
-  validationError,
   zv,
   clampedLimit,
 } from "../shared/utils.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
+import { VALID_TESTED_BY, resolveBenchmarkRefs } from "./benchmark-shared.js";
 
 // ---- Constants ----
 
@@ -34,19 +34,6 @@ const AllQuery = z.object({
 });
 
 // ---- Sync schema ----
-
-// Must stay in sync with chk_br_tested_by (migration 0207).
-const VALID_TESTED_BY = [
-  "self-report",
-  "leaderboard",
-  "aisi-uk",
-  "aisi-us",
-  "metr",
-  "apollo",
-  "third-party-paper",
-  "epoch-ai",
-  "unknown",
-] as const;
 
 const SyncBenchmarkResultItemSchema = z.object({
   id: z.string().length(10),
@@ -174,37 +161,8 @@ const benchmarkResultsApp = new Hono()
       syncSchema: SyncBenchmarkResultItemSchema,
       entityRefs: ["modelId"],
       // benchmarkId references the `benchmarks` table (not entities), so we
-      // validate and auto-resolve slugs→IDs in a preValidate hook.
-      preValidate: async (c, db, items) => {
-        const benchmarkIds = [...new Set(items.map((i) => i.benchmarkId))];
-        if (benchmarkIds.length === 0) return null;
-        const placeholders = benchmarkIds.map((id) => sql`${id}`);
-        const inList = sql.join(placeholders, sql`, `);
-        // Check both id (10-char hash) and slug (e.g., "mmlu") since the
-        // enrichment agent may submit either format.
-        const found = await db.execute<{ id: string; slug: string }>(sql`
-          SELECT id, slug FROM benchmarks WHERE id IN (${inList}) OR slug IN (${inList})
-        `);
-        const foundIdSet = new Set(found.map((r) => r.id));
-        const foundSlugSet = new Set(found.map((r) => r.slug));
-        const slugToId = new Map(found.map((r) => [r.slug, r.id]));
-        const missing = benchmarkIds.filter(
-          (id) => !foundIdSet.has(id) && !foundSlugSet.has(id),
-        );
-        if (missing.length > 0) {
-          return validationError(
-            c,
-            `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first (pnpm crux wiki-server sync-benchmarks).`,
-          );
-        }
-        // Auto-resolve slugs to IDs so the upsert uses the correct FK
-        for (const item of items) {
-          if (slugToId.has(item.benchmarkId)) {
-            item.benchmarkId = slugToId.get(item.benchmarkId)!;
-          }
-        }
-        return null;
-      },
+      // validate and auto-resolve slugs→IDs via the shared helper.
+      preValidate: (c, db, items) => resolveBenchmarkRefs(c, db, items),
       toThing: (item) => ({
         id: item.id,
         thingType: "benchmark-result" as const,

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results.ts
@@ -35,6 +35,19 @@ const AllQuery = z.object({
 
 // ---- Sync schema ----
 
+// Must stay in sync with chk_br_tested_by (migration 0207).
+const VALID_TESTED_BY = [
+  "self-report",
+  "leaderboard",
+  "aisi-uk",
+  "aisi-us",
+  "metr",
+  "apollo",
+  "third-party-paper",
+  "epoch-ai",
+  "unknown",
+] as const;
+
 const SyncBenchmarkResultItemSchema = z.object({
   id: z.string().length(10),
   benchmarkId: z.string().min(1).max(200),
@@ -44,6 +57,14 @@ const SyncBenchmarkResultItemSchema = z.object({
   date: z.string().max(20).nullable().optional(),
   sourceUrl: z.string().max(2000).nullable().optional(),
   notes: z.string().max(5000).nullable().optional(),
+  // Provenance — added by QUA-689 Phase 2 foundation. Defaults preserve
+  // backwards compatibility with pre-Phase-2 ingesters that didn't supply
+  // these fields. The tested_by default 'unknown' lets the existing 357
+  // prod rows pass the CHECK on first sync without an explicit backfill.
+  testedBy: z.enum(VALID_TESTED_BY).default("unknown"),
+  testedByOrgId: z.string().max(200).nullable().optional(),
+  evaluationDate: z.string().max(20).nullable().optional(),
+  methodologyNotes: z.string().max(5000).nullable().optional(),
   sourcing: InlineSourcingSchema.optional(),
   claimIds: z.array(z.number().int().positive()).optional(),
 });
@@ -60,6 +81,10 @@ function formatRow(r: typeof benchmarkResults.$inferSelect) {
     date: r.date,
     sourceUrl: r.sourceUrl,
     notes: r.notes,
+    testedBy: r.testedBy,
+    testedByOrgId: r.testedByOrgId,
+    evaluationDate: r.evaluationDate,
+    methodologyNotes: r.methodologyNotes,
     syncedAt: r.syncedAt,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,

--- a/apps/wiki-server/src/routes/tablebase/benchmark-shared.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-shared.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared constants and helpers used across benchmark-related sync routes.
+ *
+ * QUA-689 — extracted to keep the `benchmark_results.tested_by` enum and
+ * the slug→id resolution flow in one place. Three routes need this:
+ *   - benchmarks.ts            (validates `category`, no tested_by)
+ *   - benchmark-results.ts     (validates `tested_by`, resolves benchmark slugs)
+ *   - benchmark-results-pending.ts (same)
+ *
+ * The migration `0207_qua_689_safety_benchmark_foundation.sql` defines the
+ * authoritative CHECK constraints (`chk_br_tested_by`, `chk_brp_tested_by`).
+ * Adding a value here without updating the migration will pass schema
+ * validation in TS and then fail at upsert time.
+ */
+
+import type { Context } from "hono";
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type * as schema from "../../schema.js";
+import { validationError } from "../shared/utils.js";
+import { sqlInList } from "../shared/query-helpers.js";
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Allowed values for `benchmark_results.tested_by` and `benchmark_results_pending.tested_by`. */
+export const VALID_TESTED_BY = [
+  "self-report",
+  "leaderboard",
+  "aisi-uk",
+  "aisi-us",
+  "metr",
+  "apollo",
+  "third-party-paper",
+  "epoch-ai",
+  "unknown",
+] as const;
+
+export type TestedBy = (typeof VALID_TESTED_BY)[number];
+
+/**
+ * Validate that every `benchmarkId` in `items` exists in the benchmarks table
+ * (matching by either canonical id or slug), and rewrite slugs in-place to
+ * canonical ids so downstream upserts use the right FK.
+ *
+ * Returns null on success. On a missing reference, returns a 400 Response
+ * via `validationError(c, ...)`.
+ *
+ * Mutates `items` — same shape as the existing benchmark-results.ts
+ * preValidate hook used to expose, now extracted so benchmark-results-pending
+ * can reuse it without copy-paste drift.
+ */
+export async function resolveBenchmarkRefs<
+  T extends { benchmarkId: string },
+>(
+  c: Context,
+  db: Db,
+  items: T[],
+): Promise<Response | null> {
+  const benchmarkIds = [...new Set(items.map((i) => i.benchmarkId))];
+  if (benchmarkIds.length === 0) return null;
+  const found = await db.execute<{ id: string; slug: string }>(sql`
+    SELECT id, slug FROM benchmarks WHERE id IN (${sqlInList(benchmarkIds)}) OR slug IN (${sqlInList(benchmarkIds)})
+  `);
+  const foundIdSet = new Set(found.map((r) => r.id));
+  const foundSlugSet = new Set(found.map((r) => r.slug));
+  const slugToId = new Map(found.map((r) => [r.slug, r.id]));
+  const missing = benchmarkIds.filter(
+    (id) => !foundIdSet.has(id) && !foundSlugSet.has(id),
+  );
+  if (missing.length > 0) {
+    return validationError(
+      c,
+      `Benchmark references not found in benchmarks table: ${missing.join(", ")}. Ensure benchmarks are synced first.`,
+    );
+  }
+  for (const item of items) {
+    const canonical = slugToId.get(item.benchmarkId);
+    if (canonical) item.benchmarkId = canonical;
+  }
+  return null;
+}

--- a/apps/wiki-server/src/routes/tablebase/benchmarks.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmarks.ts
@@ -14,15 +14,22 @@ import { createSyncHandler } from "./sync-factory.js";
 
 const MAX_PAGE_SIZE = 200;
 
+// Must stay in sync with the chk_benchmarks_category CHECK constraint in
+// migration 0207. Adding a value here without updating the constraint will
+// pass schema validation and then fail at upsert time.
 const VALID_CATEGORIES = [
-  "coding",
+  "general",
   "reasoning",
   "math",
+  "coding",
   "knowledge",
   "multimodal",
-  "safety",
   "agentic",
-  "general",
+  "safety",
+  "dangerous-capability",
+  "robustness",
+  "honesty",
+  "adversarial",
 ] as const;
 
 // ---- Query schemas ----
@@ -40,6 +47,9 @@ const SyncBenchmarkItemSchema = z.object({
   slug: z.string().min(1).max(200),
   name: z.string().min(1).max(500),
   category: z.enum(VALID_CATEGORIES).nullable().optional(),
+  // Free-text sub-classification (HELM sub-scenarios, AIR-Bench taxonomy
+  // leaves). Slash-joined hierarchy strings allowed. No CHECK constraint.
+  subCategory: z.string().max(500).nullable().optional(),
   description: z.string().max(5000).nullable().optional(),
   website: z.string().max(2000).nullable().optional(),
   scoringMethod: z.string().max(50).nullable().optional(),
@@ -57,6 +67,7 @@ function formatRow(r: typeof benchmarks.$inferSelect) {
     slug: r.slug,
     name: r.name,
     category: r.category,
+    subCategory: r.subCategory,
     description: r.description,
     website: r.website,
     scoringMethod: r.scoringMethod,

--- a/apps/wiki-server/src/routes/tablebase/model-aliases.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-aliases.ts
@@ -195,7 +195,14 @@ const modelAliasesApp = new Hono()
       // with an unknown model_stable_id surfaces as a constraint-violation
       // error from the upsert phase. Phase 2 ingesters always resolve
       // canonical stable_ids before sync, so this is the right boundary.
-      auditRecordType: "model-aliases",
+      //
+      // No `auditRecordType` — the factory's audit log assumes the table has
+      // an `id` column and writes `recordId: row.id` into
+      // `tablebase_audit_log.record_id` (varchar(10) NOT NULL). model_aliases
+      // uses `alias` as its PK, so audit logging would produce undefined
+      // recordIds and fail at insert time. Audit logging on an alias map is
+      // also low value — the canonical write history lives on the
+      // `model_stable_id` entity itself.
       toRow: (item, now) => ({
         alias: item.alias,
         modelStableId: item.modelStableId,

--- a/apps/wiki-server/src/routes/tablebase/model-aliases.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-aliases.ts
@@ -1,0 +1,222 @@
+/**
+ * Model aliases — maps lowercased external alias strings to canonical AI-model
+ * entity stable_ids. Phase 2 ingesters consult this table at resolution time
+ * (raw model name → entities.stable_id). Misses go to benchmark_results_pending
+ * for human review.
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer.
+ *
+ * Schema: see modelAliases in apps/wiki-server/src/schema.ts.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { and, count, desc, eq, ilike, or } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import { modelAliases } from "../../schema.js";
+import { zv, clampedLimit } from "../shared/utils.js";
+import { deleteBatchHandler } from "../shared/delete-batch.js";
+import { createSyncHandler } from "./sync-factory.js";
+
+// ---- Constants ----
+
+const MAX_PAGE_SIZE = 1000;
+
+const VALID_CONFIDENCE = ["exact", "fuzzy", "manual"] as const;
+
+// ---- Query schemas ----
+
+const AllQuery = z.object({
+  limit: clampedLimit(MAX_PAGE_SIZE, 200),
+  offset: z.coerce.number().int().min(0).default(0),
+  modelStableId: z.string().max(200).optional(),
+  source: z.string().max(100).optional(),
+  confidence: z.enum(VALID_CONFIDENCE).optional(),
+  q: z.string().max(200).optional(),
+});
+
+const ResolveQuery = z.object({
+  alias: z.string().min(1).max(500),
+});
+
+// ---- Sync schema ----
+
+const SyncModelAliasItemSchema = z.object({
+  // The factory uses item.id as the conflict target by default; we override
+  // conflictTarget below to use modelAliases.alias instead. The schema
+  // surfaces alias as the natural key and validates lowercase form.
+  alias: z
+    .string()
+    .min(1)
+    .max(500)
+    .refine((s) => s === s.toLowerCase(), {
+      message: "alias must be lowercased before sync",
+    }),
+  modelStableId: z.string().min(1).max(200),
+  source: z.string().min(1).max(100).default("yaml-seed"),
+  confidence: z.enum(VALID_CONFIDENCE).default("exact"),
+});
+
+// ---- Helpers ----
+
+function formatRow(r: typeof modelAliases.$inferSelect) {
+  return {
+    alias: r.alias,
+    modelStableId: r.modelStableId,
+    source: r.source,
+    confidence: r.confidence,
+    addedAt: r.addedAt,
+    syncedAt: r.syncedAt,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// ---- Route ----
+
+const modelAliasesApp = new Hono()
+
+  // GET /stats — distribution by source + confidence, used by quarantine UI.
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(modelAliases);
+
+    const bySource = await db
+      .select({ source: modelAliases.source, total: count() })
+      .from(modelAliases)
+      .groupBy(modelAliases.source);
+
+    const byConfidence = await db
+      .select({ confidence: modelAliases.confidence, total: count() })
+      .from(modelAliases)
+      .groupBy(modelAliases.confidence);
+
+    return c.json({
+      total,
+      bySource: bySource.map((r) => ({ source: r.source, total: r.total })),
+      byConfidence: byConfidence.map((r) => ({
+        confidence: r.confidence,
+        total: r.total,
+      })),
+    });
+  })
+
+  // GET /all — paginated list, optionally filtered.
+  .get("/all", zv("query", AllQuery), async (c) => {
+    const { limit, offset, modelStableId, source, confidence, q } =
+      c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [];
+    if (modelStableId)
+      conditions.push(eq(modelAliases.modelStableId, modelStableId));
+    if (source) conditions.push(eq(modelAliases.source, source));
+    if (confidence) conditions.push(eq(modelAliases.confidence, confidence));
+    if (q) {
+      const pattern = `%${q.toLowerCase()}%`;
+      conditions.push(
+        or(
+          ilike(modelAliases.alias, pattern),
+          ilike(modelAliases.modelStableId, pattern),
+        ),
+      );
+    }
+
+    const where = conditions.length ? and(...conditions) : undefined;
+
+    const rows = await db
+      .select()
+      .from(modelAliases)
+      .where(where)
+      .orderBy(desc(modelAliases.addedAt), modelAliases.alias)
+      .limit(limit)
+      .offset(offset);
+
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(modelAliases)
+      .where(where);
+
+    return c.json({
+      items: rows.map(formatRow),
+      total,
+      limit,
+      offset,
+    });
+  })
+
+  // GET /resolve?alias=... — single-shot lookup used by ingesters at
+  // resolve time. Returns 404 on miss so callers can branch into the
+  // quarantine path with a single round-trip.
+  .get("/resolve", zv("query", ResolveQuery), async (c) => {
+    const { alias } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const [row] = await db
+      .select()
+      .from(modelAliases)
+      .where(eq(modelAliases.alias, alias.toLowerCase()))
+      .limit(1);
+
+    if (!row) {
+      return c.json(
+        { resolved: false, alias: alias.toLowerCase() },
+        404,
+      );
+    }
+
+    return c.json({
+      resolved: true,
+      alias: row.alias,
+      modelStableId: row.modelStableId,
+      source: row.source,
+      confidence: row.confidence,
+    });
+  })
+
+  // POST /sync — bulk upsert.
+  .post(
+    "/sync",
+    createSyncHandler({
+      name: "model-aliases",
+      table: modelAliases,
+      syncSchema: SyncModelAliasItemSchema,
+      conflictTarget: modelAliases.alias,
+      naturalKey: (item) => item.alias,
+      naturalKeyError:
+        "Duplicate alias in batch — model_aliases.alias is the primary key, intra-batch dedup before sync",
+      // FK target is entities.stable_id, not entities.id, so we can't use the
+      // factory's `entityRefs` shorthand (which assumes entities.id). The FK
+      // constraint in PG (model_aliases.model_stable_id REFERENCES
+      // entities.stable_id) is the authoritative check; an attempted sync
+      // with an unknown model_stable_id surfaces as a constraint-violation
+      // error from the upsert phase. Phase 2 ingesters always resolve
+      // canonical stable_ids before sync, so this is the right boundary.
+      auditRecordType: "model-aliases",
+      toRow: (item, now) => ({
+        alias: item.alias,
+        modelStableId: item.modelStableId,
+        source: item.source,
+        confidence: item.confidence,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+    }),
+  )
+
+  // DELETE batch — mostly used by /internal/benchmark-quarantine when
+  // rejecting a fuzzy alias that should never have been added.
+  .post(
+    "/delete-batch",
+    deleteBatchHandler(modelAliases, null, {
+      pkColumn: modelAliases.alias,
+      maxIdLength: 500,
+      label: "model-aliases",
+    }),
+  );
+
+export const modelAliasesRoute = modelAliasesApp;
+export type ModelAliasesRoute = typeof modelAliasesApp;

--- a/apps/wiki-server/src/routes/tablebase/model-aliases.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-aliases.ts
@@ -11,10 +11,11 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { and, count, desc, eq, ilike, or } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { modelAliases } from "../../schema.js";
 import { zv, clampedLimit } from "../shared/utils.js";
+import { buildSearchCondition } from "../shared/query-helpers.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
 
@@ -65,7 +66,6 @@ function formatRow(r: typeof modelAliases.$inferSelect) {
     modelStableId: r.modelStableId,
     source: r.source,
     confidence: r.confidence,
-    addedAt: r.addedAt,
     syncedAt: r.syncedAt,
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
@@ -79,21 +79,17 @@ const modelAliasesApp = new Hono()
   // GET /stats — distribution by source + confidence, used by quarantine UI.
   .get("/stats", async (c) => {
     const db = getDrizzleDb();
-
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(modelAliases);
-
-    const bySource = await db
-      .select({ source: modelAliases.source, total: count() })
-      .from(modelAliases)
-      .groupBy(modelAliases.source);
-
-    const byConfidence = await db
-      .select({ confidence: modelAliases.confidence, total: count() })
-      .from(modelAliases)
-      .groupBy(modelAliases.confidence);
-
+    const [[{ total }], bySource, byConfidence] = await Promise.all([
+      db.select({ total: count() }).from(modelAliases),
+      db
+        .select({ source: modelAliases.source, total: count() })
+        .from(modelAliases)
+        .groupBy(modelAliases.source),
+      db
+        .select({ confidence: modelAliases.confidence, total: count() })
+        .from(modelAliases)
+        .groupBy(modelAliases.confidence),
+    ]);
     return c.json({
       total,
       bySource: bySource.map((r) => ({ source: r.source, total: r.total })),
@@ -116,29 +112,25 @@ const modelAliasesApp = new Hono()
     if (source) conditions.push(eq(modelAliases.source, source));
     if (confidence) conditions.push(eq(modelAliases.confidence, confidence));
     if (q) {
-      const pattern = `%${q.toLowerCase()}%`;
-      conditions.push(
-        or(
-          ilike(modelAliases.alias, pattern),
-          ilike(modelAliases.modelStableId, pattern),
-        ),
+      const search = buildSearchCondition(
+        [modelAliases.alias, modelAliases.modelStableId],
+        q,
       );
+      if (search) conditions.push(search);
     }
 
     const where = conditions.length ? and(...conditions) : undefined;
 
-    const rows = await db
-      .select()
-      .from(modelAliases)
-      .where(where)
-      .orderBy(desc(modelAliases.addedAt), modelAliases.alias)
-      .limit(limit)
-      .offset(offset);
-
-    const [{ total }] = await db
-      .select({ total: count() })
-      .from(modelAliases)
-      .where(where);
+    const [rows, [{ total }]] = await Promise.all([
+      db
+        .select()
+        .from(modelAliases)
+        .where(where)
+        .orderBy(desc(modelAliases.createdAt), modelAliases.alias)
+        .limit(limit)
+        .offset(offset),
+      db.select({ total: count() }).from(modelAliases).where(where),
+    ]);
 
     return c.json({
       items: rows.map(formatRow),
@@ -184,25 +176,16 @@ const modelAliasesApp = new Hono()
       name: "model-aliases",
       table: modelAliases,
       syncSchema: SyncModelAliasItemSchema,
+      // alias is the PK (not id). conflictTarget overrides the factory's
+      // default; auditRecordType is omitted because the factory writes
+      // `recordId: row.id` (which model_aliases doesn't have) into
+      // `tablebase_audit_log.record_id` varchar(10). entityRefs shorthand
+      // is skipped because the FK target is entities.stable_id, not .id —
+      // the PG constraint catches unknown stable_ids at upsert time.
       conflictTarget: modelAliases.alias,
       naturalKey: (item) => item.alias,
       naturalKeyError:
         "Duplicate alias in batch — model_aliases.alias is the primary key, intra-batch dedup before sync",
-      // FK target is entities.stable_id, not entities.id, so we can't use the
-      // factory's `entityRefs` shorthand (which assumes entities.id). The FK
-      // constraint in PG (model_aliases.model_stable_id REFERENCES
-      // entities.stable_id) is the authoritative check; an attempted sync
-      // with an unknown model_stable_id surfaces as a constraint-violation
-      // error from the upsert phase. Phase 2 ingesters always resolve
-      // canonical stable_ids before sync, so this is the right boundary.
-      //
-      // No `auditRecordType` — the factory's audit log assumes the table has
-      // an `id` column and writes `recordId: row.id` into
-      // `tablebase_audit_log.record_id` (varchar(10) NOT NULL). model_aliases
-      // uses `alias` as its PK, so audit logging would produce undefined
-      // recordIds and fail at insert time. Audit logging on an alias map is
-      // also low value — the canonical write history lives on the
-      // `model_stable_id` entity itself.
       toRow: (item, now) => ({
         alias: item.alias,
         modelStableId: item.modelStableId,

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -190,4 +190,5 @@ export const TABLEBASE_NON_ROUTE_FILES: readonly string[] = [
   "write-inline-verdicts.ts",
   "entity-profile-descriptions.ts",
   "system-card-benchmark-linker.ts",
+  "benchmark-shared.ts",
 ];

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -31,6 +31,7 @@
 import type { Hono } from "hono";
 
 import { benchmarkResultsRoute } from "./benchmark-results.js";
+import { benchmarkResultsPendingRoute } from "./benchmark-results-pending.js";
 import { benchmarksRoute } from "./benchmarks.js";
 import { campaignFinanceRoute } from "./campaign-finance.js";
 import { coverageScansRoute } from "./coverage-scans.js";
@@ -61,6 +62,7 @@ import { scannerResultsRoute } from "./scanner-results.js";
 import { secondaryMarketPricesRoute } from "./secondary-market-prices.js";
 import { talentFlowsRoute } from "./talent-flows.js";
 import { websiteSourcesRoute } from "./website-sources.js";
+import { modelAliasesRoute } from "./model-aliases.js";
 import { modelSystemCardsRoute } from "./model-system-cards.js";
 import { safetyFrameworksRoute } from "./safety-frameworks.js";
 import { safetyFrameworkVersionsRoute } from "./safety-framework-versions.js";
@@ -107,6 +109,7 @@ export interface TablebaseMount {
  */
 export const TABLEBASE_MOUNTS: readonly TablebaseMount[] = [
   { path: "/api/benchmark-results", route: benchmarkResultsRoute },
+  { path: "/api/benchmark-results-pending", route: benchmarkResultsPendingRoute },
   { path: "/api/benchmarks", route: benchmarksRoute },
   { path: "/api/campaign-finance", route: campaignFinanceRoute },
   { path: "/api/coverage-scans", route: coverageScansRoute },
@@ -137,6 +140,7 @@ export const TABLEBASE_MOUNTS: readonly TablebaseMount[] = [
   { path: "/api/secondary-market-prices", route: secondaryMarketPricesRoute },
   { path: "/api/talent-flows", route: talentFlowsRoute },
   { path: "/api/website-sources", route: websiteSourcesRoute },
+  { path: "/api/model-aliases", route: modelAliasesRoute },
   { path: "/api/model-system-cards", route: modelSystemCardsRoute },
   { path: "/api/safety-frameworks", route: safetyFrameworksRoute },
   { path: "/api/safety-framework-versions", route: safetyFrameworkVersionsRoute },

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2412,7 +2412,7 @@ export const benchmarkResults = pgTable(
     notes: text("notes"),
     // Provenance — who ran the eval and when (extended in QUA-689 from
     // QUA-702's nullable tested_by). The CHECK constraint is enforced by
-    // chk_br_tested_by — see migration 0214. Allowed values: self-report,
+    // chk_br_tested_by — see migration 0215. Allowed values: self-report,
     // leaderboard, aisi-uk, aisi-us, metr, apollo, third-party-paper,
     // epoch-ai, unknown, plus the legacy 'third-party' value from QUA-702
     // (kept for backward compat).
@@ -4711,9 +4711,6 @@ export const modelAliases = pgTable(
     //   fuzzy  — Levenshtein match suggested by ingester, awaiting promote
     //   manual — promoted by a human via /internal/benchmark-quarantine
     confidence: text("confidence").notNull().default("exact"),
-    addedAt: timestamp("added_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2365,7 +2365,11 @@ export const benchmarks = pgTable(
     id: text("id").primaryKey(),
     slug: text("slug").notNull().unique(),
     name: text("name").notNull(),
-    category: text("category"), // coding | reasoning | math | knowledge | multimodal | safety | agentic | general
+    // CHECK constraint enforced by chk_benchmarks_category — see migration
+    // 0207. Allowed: general, reasoning, math, coding, knowledge, multimodal,
+    // agentic, safety, dangerous-capability, robustness, honesty, adversarial.
+    category: text("category"),
+    subCategory: text("sub_category"),
     description: text("description"),
     website: text("website"),
     scoringMethod: text("scoring_method"),
@@ -2406,14 +2410,19 @@ export const benchmarkResults = pgTable(
     date: text("date"),
     sourceUrl: text("source_url"),
     notes: text("notes"),
-    // QUA-702: provenance. NULL = legacy / unknown; 'self-report' = inserted
-    // by the model_system_cards post-upsert hook from a lab-published card;
-    // 'third-party' = independent benchmark run. Constraint enforced in
-    // migration 0212. The hook's upsert protects 'third-party' rows
-    // unconditionally; NULL rows are protected unless they are empty legacy
-    // stubs (NULL tested_by + NULL source_url) that no one curated. See
-    // system-card-benchmark-linker.ts for the exact WHERE clause.
-    testedBy: text("tested_by"),
+    // Provenance — who ran the eval and when (extended in QUA-689 from
+    // QUA-702's nullable tested_by). The CHECK constraint is enforced by
+    // chk_br_tested_by — see migration 0214. Allowed values: self-report,
+    // leaderboard, aisi-uk, aisi-us, metr, apollo, third-party-paper,
+    // epoch-ai, unknown, plus the legacy 'third-party' value from QUA-702
+    // (kept for backward compat).
+    testedBy: text("tested_by").notNull().default("unknown"),
+    testedByOrgId: text("tested_by_org_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" },
+    ),
+    evaluationDate: text("evaluation_date"),
+    methodologyNotes: text("methodology_notes"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -2428,7 +2437,19 @@ export const benchmarkResults = pgTable(
     index("idx_br_benchmark").on(table.benchmarkId),
     index("idx_br_model").on(table.modelId),
     index("idx_br_tested_by").on(table.testedBy),
-    uniqueIndex("idx_br_benchmark_model").on(table.benchmarkId, table.modelId),
+    index("idx_br_tested_by_org_id").on(table.testedByOrgId),
+    index("idx_br_evaluation_date").on(sql`${table.evaluationDate} DESC`),
+    // Widened in QUA-689 from (benchmarkId, modelId) so the same model can
+    // have multiple results on the same benchmark distinguished by who ran
+    // the eval and when (self-report vs HELM vs AISI-UK at different dates).
+    // Migration 0214 drops idx_br_benchmark_model and creates this one in
+    // its place.
+    uniqueIndex("idx_br_benchmark_model_testedby_date").on(
+      table.benchmarkId,
+      table.modelId,
+      table.testedBy,
+      sql`COALESCE(${table.evaluationDate}, '')`,
+    ),
   ]
 );
 
@@ -4660,6 +4681,56 @@ export const thirdPartyEvaluations = pgTable(
 );
 
 /**
+ * Model aliases — maps lowercased external alias strings (as they appear on
+ * leaderboards and in vendor publications) to their canonical AI-model
+ * entity. Replaces the hardcoded 40-entry alias maps duplicated across the
+ * older sync code so Phase 2 ingesters can resolve raw model names without
+ * teaching every plugin about every rename.
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer (parent: QUA-687).
+ *
+ * Alias is the natural primary key — the lookup is "given a raw external
+ * string, find the canonical model entity". If the same alias appears on
+ * different sources for the same model that's redundant, not informative;
+ * a flat PK records each alias once. Conflicts (same alias → different
+ * models) must be surfaced by the ingester, not silently last-write-wins.
+ */
+export const modelAliases = pgTable(
+  "model_aliases",
+  {
+    alias: text("alias").primaryKey(),
+    modelStableId: text("model_stable_id")
+      .notNull()
+      .references(() => entities.stableId, { onDelete: "cascade" }),
+    // Where this alias was observed: 'yaml-seed' for the initial bulk load
+    // from ai-models.yaml `aliases:` arrays, then leaderboard slugs once
+    // ingesters start writing.
+    source: text("source").notNull().default("yaml-seed"),
+    // CHECK enforced by chk_model_aliases_confidence (migration 0207):
+    //   exact  — byte-for-byte match in source data
+    //   fuzzy  — Levenshtein match suggested by ingester, awaiting promote
+    //   manual — promoted by a human via /internal/benchmark-quarantine
+    confidence: text("confidence").notNull().default("exact"),
+    addedAt: timestamp("added_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_model_aliases_model").on(table.modelStableId),
+    index("idx_model_aliases_source").on(table.source),
+  ],
+);
+
+/**
  * Many-to-many: a single third-party evaluation report can cover multiple
  * AI models (METR multi-model reviews, Apollo cross-lab evaluations).
  * `match_confidence` tracks how the link was made so we can surface an
@@ -4857,5 +4928,81 @@ export const aiIncidentReports = pgTable(
   (table) => [
     primaryKey({ columns: [table.incidentId, table.url] }),
     index("idx_ai_incident_reports_published_at").on(table.publishedAt),
+  ],
+);
+
+/**
+ * Benchmark results pending — quarantine queue for ingester rows whose
+ * source model name didn't resolve to any entity (no exact alias match,
+ * fuzzy resolution below confidence threshold, or never-seen-before name).
+ *
+ * Reviewed via the /internal/benchmark-quarantine dashboard (follow-up PR).
+ * On resolution the row is promoted to `benchmark_results`, an alias is
+ * added to `model_aliases`, and `status` flips to 'resolved'.
+ *
+ * The natural key includes the literal lowercase form of the raw name so
+ * the same ingester run is idempotent — re-running an ingester that hits
+ * the same unresolved name twice gets one quarantine row, not two.
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer (parent: QUA-687).
+ *
+ * Distinct from `pendingBenchmarkLinks` (QUA-702): that queue holds
+ * citation strings extracted from system cards (where `benchmark_id`
+ * itself is unresolved); this queue holds ingester rows where the
+ * `benchmark_id` is known but the `model_id` is not.
+ */
+export const benchmarkResultsPending = pgTable(
+  "benchmark_results_pending",
+  {
+    id: text("id").primaryKey(),
+    benchmarkId: text("benchmark_id")
+      .notNull()
+      .references(() => benchmarks.id, { onDelete: "cascade" }),
+    // The exact string the source emitted ("Claude 3.5 Sonnet (new)",
+    // "claude-3-5-sonnet-2024-10"). Preserves case for human readability;
+    // dedup happens via the natural-key index using lower(raw_model_name).
+    rawModelName: text("raw_model_name").notNull(),
+    score: doublePrecision("score"),
+    scoreText: text("score_text"),
+    unit: text("unit"),
+    evaluationDate: text("evaluation_date"),
+    testedBy: text("tested_by").notNull().default("unknown"),
+    sourceUrl: text("source_url"),
+    methodologyNotes: text("methodology_notes"),
+    rawPayload: jsonb("raw_payload").$type<Record<string, unknown>>(),
+    // CHECK enforced by chk_brp_status (migration 0215):
+    //   pending  — not yet reviewed
+    //   resolved — promoted to benchmark_results + alias recorded
+    //   rejected — explicitly excluded (e.g. obvious test row, deprecated)
+    status: text("status").notNull().default("pending"),
+    ingesterSource: text("ingester_source").notNull(),
+    resolvedToStableId: text("resolved_to_stable_id").references(
+      () => entities.stableId,
+      { onDelete: "set null" },
+    ),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    resolvedBy: text("resolved_by"),
+    rejectedReason: text("rejected_reason"),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_brp_benchmark").on(table.benchmarkId),
+    index("idx_brp_status").on(table.status),
+    index("idx_brp_ingester_source").on(table.ingesterSource),
+    index("idx_brp_created_at").on(sql`${table.createdAt} DESC`),
+    uniqueIndex("uq_brp_natural_key").on(
+      table.ingesterSource,
+      table.benchmarkId,
+      sql`lower(${table.rawModelName})`,
+      sql`COALESCE(${table.evaluationDate}, '')`,
+    ),
   ],
 );

--- a/crux/lib/wiki-server/benchmark-results-pending.ts
+++ b/crux/lib/wiki-server/benchmark-results-pending.ts
@@ -1,0 +1,71 @@
+/**
+ * BenchmarkResultsPending API — wiki-server client module.
+ *
+ * Phase 2 ingesters write rows here when a raw model name fails alias
+ * resolution. The /internal/benchmark-quarantine dashboard (follow-up PR)
+ * promotes them via syncModelAliases() + syncBenchmarkResults().
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { BenchmarkResultsPendingRoute } from '../../../apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts';
+import type { SyncResponse } from '../../../apps/wiki-server/src/routes/tablebase/sync-factory.ts';
+
+type RpcClient = ReturnType<typeof hc<BenchmarkResultsPendingRoute>>;
+
+export type BenchmarkResultsPendingAllResult = InferResponseType<
+  RpcClient['all']['$get'],
+  200
+>;
+export type BenchmarkResultsPendingStatsResult = InferResponseType<
+  RpcClient['stats']['$get'],
+  200
+>;
+export type BenchmarkResultsPendingSyncResult = SyncResponse;
+
+/** Fetch quarantine rows with pagination + filters. */
+export async function getAllBenchmarkResultsPending(
+  options?: {
+    limit?: number;
+    offset?: number;
+    status?: 'pending' | 'resolved' | 'rejected';
+    ingesterSource?: string;
+    benchmarkId?: string;
+    q?: string;
+  },
+): Promise<ApiResult<BenchmarkResultsPendingAllResult>> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.offset != null) params.set('offset', String(options.offset));
+  if (options?.status) params.set('status', options.status);
+  if (options?.ingesterSource)
+    params.set('ingesterSource', options.ingesterSource);
+  if (options?.benchmarkId) params.set('benchmarkId', options.benchmarkId);
+  if (options?.q) params.set('q', options.q);
+  const qs = params.toString();
+  return apiRequest<BenchmarkResultsPendingAllResult>(
+    'GET',
+    `/api/benchmark-results-pending/all${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Quarantine queue depth + breakdown. */
+export async function getBenchmarkResultsPendingStats(): Promise<
+  ApiResult<BenchmarkResultsPendingStatsResult>
+> {
+  return apiRequest<BenchmarkResultsPendingStatsResult>(
+    'GET',
+    '/api/benchmark-results-pending/stats',
+  );
+}
+
+/** Sync benchmark_results_pending (upsert). */
+export async function syncBenchmarkResultsPending(
+  items: Array<Record<string, unknown>>,
+): Promise<ApiResult<BenchmarkResultsPendingSyncResult>> {
+  return apiRequest<BenchmarkResultsPendingSyncResult>(
+    'POST',
+    '/api/benchmark-results-pending/sync',
+    { items },
+  );
+}

--- a/crux/lib/wiki-server/benchmark-results.ts
+++ b/crux/lib/wiki-server/benchmark-results.ts
@@ -15,6 +15,7 @@ import type { BenchmarkResultsRoute } from '../../../apps/wiki-server/src/routes
 type RpcClient = ReturnType<typeof hc<BenchmarkResultsRoute>>;
 
 export type BenchmarkResultsByModelResult = InferResponseType<RpcClient['by-model'][':modelId']['$get'], 200>;
+export type BenchmarkResultsAllResult = InferResponseType<RpcClient['all']['$get'], 200>;
 export type BenchmarkResultsSyncResult = InferResponseType<RpcClient['sync']['$post'], 200>;
 
 /** A single benchmark result row. */
@@ -35,5 +36,19 @@ export async function getBenchmarkResultsByModel(
   return apiRequest<BenchmarkResultsByModelResult>(
     'GET',
     `/api/benchmark-results/by-model/${encodeURIComponent(modelId)}${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Fetch all benchmark results with pagination. Used by the provenance validator. */
+export async function getAllBenchmarkResults(
+  options?: { limit?: number; offset?: number },
+): Promise<ApiResult<BenchmarkResultsAllResult>> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.offset != null) params.set('offset', String(options.offset));
+  const qs = params.toString();
+  return apiRequest<BenchmarkResultsAllResult>(
+    'GET',
+    `/api/benchmark-results/all${qs ? `?${qs}` : ''}`,
   );
 }

--- a/crux/lib/wiki-server/model-aliases.ts
+++ b/crux/lib/wiki-server/model-aliases.ts
@@ -1,0 +1,77 @@
+/**
+ * ModelAliases API — wiki-server client module.
+ *
+ * Phase 2 ingesters call resolveModelAlias() per row to map a leaderboard's
+ * raw model name to entities.stable_id. Misses are written to
+ * benchmark_results_pending (see benchmark-results-pending.ts).
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { ModelAliasesRoute } from '../../../apps/wiki-server/src/routes/tablebase/model-aliases.ts';
+import type { SyncResponse } from '../../../apps/wiki-server/src/routes/tablebase/sync-factory.ts';
+
+type RpcClient = ReturnType<typeof hc<ModelAliasesRoute>>;
+
+export type ModelAliasesAllResult = InferResponseType<RpcClient['all']['$get'], 200>;
+export type ModelAliasesStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+export type ModelAliasesResolveOk = InferResponseType<RpcClient['resolve']['$get'], 200>;
+export type ModelAliasesResolveMiss = InferResponseType<RpcClient['resolve']['$get'], 404>;
+export type ModelAliasesSyncResult = SyncResponse;
+
+/** Fetch all model_aliases rows with pagination + filters. */
+export async function getAllModelAliases(
+  options?: {
+    limit?: number;
+    offset?: number;
+    modelStableId?: string;
+    source?: string;
+    confidence?: 'exact' | 'fuzzy' | 'manual';
+    q?: string;
+  },
+): Promise<ApiResult<ModelAliasesAllResult>> {
+  const params = new URLSearchParams();
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  if (options?.offset != null) params.set('offset', String(options.offset));
+  if (options?.modelStableId) params.set('modelStableId', options.modelStableId);
+  if (options?.source) params.set('source', options.source);
+  if (options?.confidence) params.set('confidence', options.confidence);
+  if (options?.q) params.set('q', options.q);
+  const qs = params.toString();
+  return apiRequest<ModelAliasesAllResult>(
+    'GET',
+    `/api/model-aliases/all${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Distribution of aliases by source + confidence. */
+export async function getModelAliasesStats(): Promise<
+  ApiResult<ModelAliasesStatsResult>
+> {
+  return apiRequest<ModelAliasesStatsResult>('GET', '/api/model-aliases/stats');
+}
+
+/**
+ * Resolve a single alias to its canonical model stable_id. Returns null on
+ * miss (HTTP 404 from the server). Ingesters use this in the hot loop, so
+ * callers should batch-cache the table client-side via getAllModelAliases
+ * when processing more than ~50 rows.
+ */
+export async function resolveModelAlias(
+  alias: string,
+): Promise<ApiResult<ModelAliasesResolveOk | ModelAliasesResolveMiss>> {
+  const params = new URLSearchParams({ alias });
+  return apiRequest<ModelAliasesResolveOk | ModelAliasesResolveMiss>(
+    'GET',
+    `/api/model-aliases/resolve?${params.toString()}`,
+  );
+}
+
+/** Sync model_aliases (upsert). */
+export async function syncModelAliases(
+  items: Array<Record<string, unknown>>,
+): Promise<ApiResult<ModelAliasesSyncResult>> {
+  return apiRequest<ModelAliasesSyncResult>('POST', '/api/model-aliases/sync', {
+    items,
+  });
+}

--- a/crux/tablebase/table-registry.ts
+++ b/crux/tablebase/table-registry.ts
@@ -111,6 +111,29 @@ const TABLE_CONFIGS: Record<string, TableConfig> = {
     deletePath: '/api/benchmark-results/delete-batch',
     thingsSourceTable: 'benchmark_results',
   },
+  'benchmark-results-pending': {
+    // No by-entity endpoint — quarantine rows are reviewed via the
+    // /internal/benchmark-quarantine dashboard (follow-up PR), not via
+    // entity-page surfaces. Fall back to /all for completeness checks.
+    fetchByEntityPath: () => '/api/benchmark-results-pending/all',
+    resultKey: 'items',
+    syncPath: '/api/benchmark-results-pending/sync',
+    syncMethod: 'POST',
+    syncBodyKey: 'items',
+    deletePath: '/api/benchmark-results-pending/delete-batch',
+    thingsSourceTable: null,
+  },
+  'model-aliases': {
+    // Aliases are not an entity-scoped table — `fetchByEntityPath` falls
+    // back to /all, mirroring `benchmarks`.
+    fetchByEntityPath: () => '/api/model-aliases/all',
+    resultKey: 'items',
+    syncPath: '/api/model-aliases/sync',
+    syncMethod: 'POST',
+    syncBodyKey: 'items',
+    deletePath: '/api/model-aliases/delete-batch',
+    thingsSourceTable: null,
+  },
   'prediction-market-questions': {
     fetchByEntityPath: (id) => `/api/prediction-markets/questions/by-entity/${encodeURIComponent(id)}`,
     resultKey: 'questions',
@@ -416,6 +439,8 @@ const TABLE_ALIASES: Record<string, string> = {
   platform_accounts: 'platform-accounts',
   model_system_cards: 'model-system-cards',
   third_party_evaluations: 'third-party-evaluations',
+  model_aliases: 'model-aliases',
+  benchmark_results_pending: 'benchmark-results-pending',
 };
 
 export function getTableConfig(table: string): TableConfig | null {

--- a/crux/validate/validate-benchmark-result-provenance.ts
+++ b/crux/validate/validate-benchmark-result-provenance.ts
@@ -35,6 +35,7 @@
  * outages.
  */
 
+import { fileURLToPath } from "url";
 import { getAllBenchmarkResults } from "../lib/wiki-server/benchmark-results.ts";
 import { getColors } from "../lib/output.ts";
 
@@ -54,8 +55,11 @@ interface CheckResult {
   errors: string[];
 }
 
+// Server-side `MAX_PAGE_SIZE` on /api/benchmark-results/all is 200 — bumping
+// PAGE_SIZE further would overflow the route's clampedLimit and silently
+// fetch only 200 anyway. 50 pages × 200 = 10,000 row hard cap.
 const PAGE_SIZE = 200;
-const MAX_PAGES = 50; // 10,000 rows hard cap
+const MAX_PAGES = 50;
 
 export async function runCheck(): Promise<CheckResult> {
   const result: CheckResult = {
@@ -88,10 +92,7 @@ export async function runCheck(): Promise<CheckResult> {
 
     for (const row of rows) {
       result.scanned += 1;
-      // The /all endpoint returns testedBy from formatRow (added in this
-      // PR). Older clients used to omit it; defensive fallback to 'unknown'.
-      const testedBy =
-        (row as { testedBy?: string }).testedBy ?? "unknown";
+      const testedBy = row.testedBy ?? "unknown";
       if (testedBy === "unknown") {
         result.soft.push({
           id: row.id,
@@ -174,13 +175,13 @@ async function main(): Promise<void> {
 }
 
 // Only run main() when invoked as a script, not when imported by tests.
-// Strict equality only — a fallback like `endsWith(process.argv[1] ?? "")`
-// becomes `endsWith("")` when argv[1] is undefined, which matches ANY URL
-// and would call process.exit(0) inside test runners that import this module.
-const invokedAsScript =
+// fileURLToPath() is the same pattern 14+ other validators use; safer than
+// import.meta.url string comparison (which is sensitive to trailing-slash
+// and protocol differences).
+if (
   typeof process.argv[1] === "string" &&
-  import.meta.url === `file://${process.argv[1]}`;
-if (invokedAsScript) {
+  process.argv[1] === fileURLToPath(import.meta.url)
+) {
   main().catch((err) => {
     console.error("validate-benchmark-result-provenance crashed:", err);
     process.exit(0); // advisory-only — even crashes shouldn't block

--- a/crux/validate/validate-benchmark-result-provenance.ts
+++ b/crux/validate/validate-benchmark-result-provenance.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * Validate provenance fields on benchmark_results.
+ *
+ * QUA-689 — Phase 2 of the AI safety data layer (parent: QUA-687).
+ *
+ * Phase 2 adds the four provenance columns to benchmark_results:
+ *   - tested_by         (CHECK-enforced enum, default 'unknown')
+ *   - tested_by_org_id  (FK-style ref, optional)
+ *   - evaluation_date   (text)
+ *   - methodology_notes (text)
+ *
+ * The CHECK on tested_by guarantees the *value* is in the allowed set, but
+ * does not guarantee the value is *meaningful*. This validator surfaces
+ * rows where the value is meaningful-but-incomplete (e.g. tested_by set
+ * to a real evaluator but source_url missing) or where the row is still
+ * unattributed (tested_by = 'unknown').
+ *
+ * Reported in two buckets:
+ *   - HARD : tested_by != 'unknown' AND source_url IS NULL
+ *            (impossible to verify the cited evaluator without a URL)
+ *   - SOFT : tested_by = 'unknown'
+ *            (legacy rows + Phase 2 ingesters that haven't backfilled yet)
+ *
+ * **Advisory in the gate** — does not block PRs. Surfaces drift so we can
+ * promote to blocking once Phase 2 ingesters have populated provenance for
+ * the bulk of rows. The plan-doc target is "after one week clean".
+ *
+ * Usage: npx tsx crux/validate/validate-benchmark-result-provenance.ts
+ *
+ * Reads from prod wiki-server (auto-selected when invoked from a slot) via
+ * /api/benchmark-results/all. Falls back to a non-fatal warning if the
+ * server is unreachable — advisory checks should never wedge CI on infra
+ * outages.
+ */
+
+import { getAllBenchmarkResults } from "../lib/wiki-server/benchmark-results.ts";
+import { getColors } from "../lib/output.ts";
+
+interface Violation {
+  id: string;
+  benchmarkId: string;
+  modelId: string;
+  testedBy: string;
+  sourceUrl: string | null;
+}
+
+interface CheckResult {
+  passed: boolean;
+  scanned: number;
+  hard: Violation[];
+  soft: Violation[];
+  errors: string[];
+}
+
+const PAGE_SIZE = 200;
+const MAX_PAGES = 50; // 10,000 rows hard cap
+
+export async function runCheck(): Promise<CheckResult> {
+  const result: CheckResult = {
+    passed: true,
+    scanned: 0,
+    hard: [],
+    soft: [],
+    errors: [],
+  };
+
+  let offset = 0;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const r = await getAllBenchmarkResults({
+      limit: PAGE_SIZE,
+      offset,
+    });
+
+    if (!r.ok) {
+      // Network / auth error. Advisory mode: surface as a single non-fatal
+      // entry on the errors list so the gate run prints it but doesn't
+      // wedge on transient infra issues.
+      result.errors.push(
+        `wiki-server fetch failed at offset=${offset}: ${r.error} ${r.message}`.trim(),
+      );
+      return result;
+    }
+
+    const rows = r.data.benchmarkResults;
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      result.scanned += 1;
+      // The /all endpoint returns testedBy from formatRow (added in this
+      // PR). Older clients used to omit it; defensive fallback to 'unknown'.
+      const testedBy =
+        (row as { testedBy?: string }).testedBy ?? "unknown";
+      if (testedBy === "unknown") {
+        result.soft.push({
+          id: row.id,
+          benchmarkId: row.benchmarkId,
+          modelId: row.modelId,
+          testedBy,
+          sourceUrl: row.sourceUrl,
+        });
+      } else if (!row.sourceUrl) {
+        result.hard.push({
+          id: row.id,
+          benchmarkId: row.benchmarkId,
+          modelId: row.modelId,
+          testedBy,
+          sourceUrl: row.sourceUrl,
+        });
+      }
+    }
+
+    if (rows.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  // Advisory-only: never set passed=false. The gate marks this entry as
+  // advisory so a soft/hard count > 0 doesn't block the merge. Once Phase
+  // 2 ingesters are widely deployed and the soft bucket is empty, flip
+  // this to blocking and start counting violations as failures.
+  return result;
+}
+
+async function main(): Promise<void> {
+  const c = getColors(process.env.CI === "true");
+  const warn = (s: string) => `${c.yellow}!${c.reset} ${s}`;
+  const ok = (s: string) => `${c.green}✓${c.reset} ${s}`;
+  const result = await runCheck();
+
+  if (result.errors.length > 0) {
+    for (const e of result.errors) {
+      console.warn(warn(e));
+    }
+    console.warn(warn("Advisory-only — wiki-server unreachable, skipping"));
+    process.exit(0);
+  }
+
+  console.log(`Scanned ${result.scanned} benchmark_results rows`);
+
+  if (result.hard.length > 0) {
+    console.warn(
+      warn(
+        `${result.hard.length} rows have tested_by set but no source_url — verifiability gap`,
+      ),
+    );
+    for (const v of result.hard.slice(0, 20)) {
+      console.warn(
+        `  - ${v.id}: ${v.benchmarkId} × ${v.modelId} (testedBy=${v.testedBy})`,
+      );
+    }
+    if (result.hard.length > 20) {
+      console.warn(`  ... and ${result.hard.length - 20} more`);
+    }
+  }
+
+  if (result.soft.length > 0) {
+    console.warn(
+      warn(
+        `${result.soft.length} rows have tested_by='unknown' — legacy or unattributed`,
+      ),
+    );
+  }
+
+  if (result.hard.length === 0 && result.soft.length === 0) {
+    console.log(ok("All rows have non-unknown tested_by + source_url"));
+  } else {
+    console.log(
+      `${c.yellow}Advisory${c.reset} — does not block PR; track soft count for promotion to blocking`,
+    );
+  }
+
+  process.exit(0);
+}
+
+// Only run main() when invoked as a script, not when imported by tests.
+const invokedAsScript =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url.endsWith(process.argv[1] ?? "");
+if (invokedAsScript) {
+  main().catch((err) => {
+    console.error("validate-benchmark-result-provenance crashed:", err);
+    process.exit(0); // advisory-only — even crashes shouldn't block
+  });
+}

--- a/crux/validate/validate-benchmark-result-provenance.ts
+++ b/crux/validate/validate-benchmark-result-provenance.ts
@@ -174,9 +174,12 @@ async function main(): Promise<void> {
 }
 
 // Only run main() when invoked as a script, not when imported by tests.
+// Strict equality only — a fallback like `endsWith(process.argv[1] ?? "")`
+// becomes `endsWith("")` when argv[1] is undefined, which matches ANY URL
+// and would call process.exit(0) inside test runners that import this module.
 const invokedAsScript =
-  import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url.endsWith(process.argv[1] ?? "");
+  typeof process.argv[1] === "string" &&
+  import.meta.url === `file://${process.argv[1]}`;
 if (invokedAsScript) {
   main().catch((err) => {
     console.error("validate-benchmark-result-provenance crashed:", err);

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -757,6 +757,19 @@ const PARALLEL_STEPS: Step[] = [
     // greps the AIID ingest + schema paths for symptoms of re-introducing
     // those fields. QUA-693.
   },
+  {
+    id: 'benchmark-result-provenance',
+    name: 'Benchmark result provenance (tested_by + source_url)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-benchmark-result-provenance.ts'],
+    cwd: PROJECT_ROOT,
+    // Advisory until Phase 2 ingesters have populated tested_by + source_url
+    // for the bulk of rows (target: one week clean before promoting to
+    // blocking). Surfaces verifiability gaps without wedging current PRs.
+    advisory: true,
+    requiresServer: true,
+    emitOutputInCi: true,
+  },
 ];
 
 // Phase 4 (--full only): Runs after all validations pass


### PR DESCRIPTION
## Summary

QUA-689 Phase 2 of the AI safety data layer (parent: QUA-687). **Foundation only** — Day 1 of the 5-day plan. Ships the schema migration + sync infrastructure that unblocks parallel ingester work in follow-up PRs.

The 10 source ingesters (HELM Safety, AIR-Bench, AILuminate, FORTRESS, MASK, DecodingTrust, PRISM BET, GAIA, SWE-bench Verified, Epoch AI Hub) ship as independent follow-ups once the schema is in prod and aliases are seeded.

## Schema (migration 0207)

- **`benchmarks.category`** gets a CHECK constraint enumerated against prod (8 live values + 4 new safety buckets: `dangerous-capability`, `robustness`, `honesty`, `adversarial`). NOT VALID + VALIDATE pattern.
- **`benchmarks.sub_category`** added (free-text, no CHECK) for HELM sub-scenarios + AIR-Bench taxonomy leaves.
- **`benchmark_results`** gains four provenance columns: `tested_by` (CHECK enum, default `unknown`), `tested_by_org_id` (FK → entities.stable_id ON DELETE SET NULL), `evaluation_date`, `methodology_notes`.
- **`benchmark_results` unique index widened** from `(benchmark_id, model_id)` to `(benchmark_id, model_id, tested_by, COALESCE(evaluation_date, ''))` so the same model can have multiple results distinguished by evaluator + date. Strict superset — no data loss.
- **`chk_br_evaluation_date_nonempty`** forbids empty-string `evaluation_date` (would silently collide with NULL through the COALESCE).
- **New `model_aliases` table** — alias → entity stable_id, replaces hardcoded 40-entry maps duplicated across the older sync code. CHECK on `confidence` (`exact`/`fuzzy`/`manual`).
- **New `benchmark_results_pending` table** — quarantine queue for rows whose source model name didn't resolve. CHECK on `status` (`pending`/`resolved`/`rejected`). Reviewed via `/internal/benchmark-quarantine` (follow-up PR).

> Note: this migration is `0207`, not `0206`. The `0206` slot is reserved for QUA-688 in review on `claude/qua-688-scorecard-mirror`. Skipping `0206` here avoids a duplicate-prefix collision regardless of merge order.

## Sync handlers

Two new factory-built routes:

- **`POST /api/model-aliases/sync`** — also exposes `/resolve?alias=...` for ingester hot-path resolution and `/all`, `/stats` for the quarantine dashboard. Lowercase-only validation enforced at the Zod layer.
- **`POST /api/benchmark-results-pending/sync`** — preValidate enforces `benchmarkId` resolution against `benchmarks` (slug → id auto-resolve via the shared `resolveBenchmarkRefs()` helper). Post-resolution intra-batch dedup catches batches that mix slug + canonical id forms.

`benchmark-results.ts` and `benchmarks.ts` extended to surface the new columns on the read path and accept them at sync time. Defaults preserve backwards compatibility — pre-Phase-2 ingesters keep working.

## Shared helpers

New `apps/wiki-server/src/routes/tablebase/benchmark-shared.ts` factors out:

- `VALID_TESTED_BY` enum (single source of truth across both `benchmark-results.ts` and `benchmark-results-pending.ts`)
- `resolveBenchmarkRefs()` (the slug→id resolution flow)

Eliminates byte-for-byte copy-paste between the two sync handlers and removes the future-drift risk of triplicating the enum across two TS files + the migration SQL.

## Crux clients + validator

- `crux/lib/wiki-server/{model-aliases,benchmark-results-pending}.ts` + `getAllBenchmarkResults()` for the new endpoints.
- Registered in `crux/tablebase/table-registry.ts` so the completeness validator covers both new routes.
- `validate-benchmark-result-provenance.ts` — advisory check counting rows with `tested_by='unknown'` (legacy) and rows where `tested_by` is set but `source_url` is NULL (verifiability gap). Wired into the gate as advisory + requiresServer + emitOutputInCi. Promote to blocking after Phase 2 ingesters have populated provenance and the soft count drops to zero.

## Tests

- `model-aliases.test.ts` (4 tests): lowercase validation, mixed-case reject, batch dedup, invalid confidence reject.
- `benchmark-results-pending.test.ts` (6 tests): slug resolution, unknown benchmark reject, status enum reject, tested_by enum reject, intra-batch dedup with case-insensitive collision, post-slug-resolution dedup.

All 1386 wiki-server tests pass. Full gate green (54 checks, 3 pre-existing advisory warnings — none introduced by this PR).

## Reviewer notes

- This PR went through `/agent-review-pr` (hostile reviewer subagent found 2 CRITICAL audit-log bugs that were fixed before push) and `/simplify` (3 review agents — applied HIGH-priority findings: extracted shared helper, parallelized `/stats` + `/all`, dropped redundant `added_at` column).
- The deploy-tasks detector lists `benchmark-shared` as a "new route" — false positive; it's a helper module, not a Hono route. Auto-generated smoke check on its (non-existent) endpoint is a harmless no-op.

## Test plan

- [x] Build green (`pnpm build`)
- [x] All 1386 wiki-server tests pass (`pnpm test`)
- [x] Gate green (`pnpm crux w validate gate --no-cache`)
- [x] Wiki-server typecheck clean (`npx tsc --noEmit`)
- [x] Migration verified locally and uses NOT VALID + VALIDATE for all CHECK constraints
- [x] CHECK enum enumerated against prod data before writing the constraint
- [x] Hostile-reviewer subagent run; CRITICAL findings fixed
- [x] Simplification pass run; HIGH findings applied

Closes QUA-689 (foundation only — ingesters tracked in follow-ups).


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0207 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New API route "benchmark-results-pending" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/benchmark-results-pending" -o /dev/null -w "%{http_code}"`
- [ ] `route` New API route "model-aliases" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/model-aliases" -o /dev/null -w "%{http_code}"`
- [ ] `manual` Confirm CHECK constraints landed on `benchmark_results` and `benchmarks` after deploy — `psql "$DATABASE_URL" -c "SELECT conname FROM pg_constraint WHERE conname IN ('chk_benchmarks_category', 'chk_br_tested_by', 'chk_br_evaluation_date_nonempty', 'chk_brp_status', 'chk_brp_tested_by', 'chk_model_aliases_confidence');"` — expect 6 rows.
- [ ] `manual` Confirm widened unique index replaced the old narrow one — `psql "$DATABASE_URL" -c "SELECT indexname FROM pg_indexes WHERE tablename='benchmark_results';"` — expect `idx_br_benchmark_model_testedby_date` and NO `idx_br_benchmark_model`.
- [ ] `manual` Confirm `model_aliases` and `benchmark_results_pending` tables were created — `psql "$DATABASE_URL" -c "\dt model_aliases benchmark_results_pending"` — expect both.
- [ ] `manual` Hit one new endpoint with the prod API key to confirm route is mounted — `curl -sf -H "Authorization: Bearer $PROD_LONGTERMWIKI_SERVER_API_KEY" "$WIKI_SERVER_URL/api/model-aliases/stats"` — expect `{"total":0,...}`.
- [ ] `manual` (note) The auto-detected `benchmark-shared` route check above is a FALSE POSITIVE — `benchmark-shared.ts` is a helper module, not a Hono route. Curl will 404 by design. Mark this checked once the model-aliases stats hit succeeds.
<!-- /deploy-tasks -->
