### PR TITLE
QUA-702: Phase 3 follow-up — System Card profile tab, coverage dashboard, benchmark linker

### DIFF
--- a/apps/web/src/app/ai-models/[slug]/page.tsx
+++ b/apps/web/src/app/ai-models/[slug]/page.tsx
@@ -24,7 +24,13 @@ import {
   PricingTab,
   BenchmarksTab,
   FamilyTab,
+  SystemCardTab,
 } from "@/app/ai-models/[slug]/tabs";
+import {
+  fetchFromWikiServer,
+  type RpcModelSystemCardsByModelResult,
+  type RpcModelSystemCardRow,
+} from "@lib/wiki-server";
 
 export function generateStaticParams() {
   return getAiModelSlugs().map((slug) => ({ slug }));
@@ -45,15 +51,29 @@ export async function generateMetadata({
 
 export default async function AiModelDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ slug: string }>;
+  searchParams?: Promise<{ card?: string }>;
 }) {
   const { slug } = await params;
+  const sp = (await searchParams) ?? {};
   const entity = resolveAiModelBySlug(slug);
   if (!entity) {
     const canonical = resolveSlugAlias(slug);
     if (canonical) permanentRedirect(`/ai-models/${canonical}`);
     return notFound();
+  }
+
+  // Fetch system cards (QUA-702). Best-effort: a wiki-server outage shouldn't
+  // break the whole page, just hide the tab.
+  let systemCards: RpcModelSystemCardRow[] = [];
+  if (entity.stableId) {
+    const result = await fetchFromWikiServer<RpcModelSystemCardsByModelResult>(
+      `/api/model-system-cards/by-model/${entity.stableId}?limit=20`,
+      { revalidate: 300 },
+    );
+    if (result?.items) systemCards = result.items;
   }
 
   // Resolve developer
@@ -128,6 +148,21 @@ export default async function AiModelDetailPage({
       label: "Benchmarks",
       count: entity.benchmarks.length,
       content: <BenchmarksTab entity={entity} />,
+    });
+  }
+
+  if (systemCards.length > 0) {
+    tabs.push({
+      id: "system-card",
+      label: "System Card",
+      count: systemCards.length > 1 ? systemCards.length : undefined,
+      content: (
+        <SystemCardTab
+          cards={systemCards}
+          selectedCardId={sp.card}
+          modelSlug={slug}
+        />
+      ),
     });
   }
 

--- a/apps/web/src/app/ai-models/[slug]/tabs.tsx
+++ b/apps/web/src/app/ai-models/[slug]/tabs.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { AiModelEntity } from "@/data";
 import { BenchmarkScorecard } from "@/app/ai-models/[slug]/benchmark-scorecard";
+import type { RpcModelSystemCardRow } from "@lib/wiki-server";
 
 /**
  * Per-tab content components for the AI model profile page. Each tab is a
@@ -233,6 +234,369 @@ export function FamilyTab({
           </div>
         </section>
       )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// System Card tab — QUA-702
+// Renders a single system_card row (the latest by release_date). When more
+// than one card exists for the model, links to the other source URLs are
+// surfaced at the bottom so older revisions stay reachable without a full
+// per-card sub-page.
+// ─────────────────────────────────────────────────────────────────────────
+
+function formatNumber(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function formatTokens(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString();
+}
+
+function formatFlops(s: number | string | null | undefined): string {
+  if (s == null) return "—";
+  const n = typeof s === "string" ? Number(s) : s;
+  if (!Number.isFinite(n)) return "—";
+  if (n >= 1e24) return `${(n / 1e24).toFixed(1)}e24`;
+  if (n >= 1e21) return `${(n / 1e21).toFixed(1)}e21`;
+  return n.toExponential(1);
+}
+
+function waybackUrl(originalUrl: string): string {
+  return `https://web.archive.org/web/*/${originalUrl}`;
+}
+
+interface SystemCardTabProps {
+  cards: RpcModelSystemCardRow[];
+  /** Optional override — used when the page exposes a `?card=<id>` selector. */
+  selectedCardId?: string;
+  /** Slug of the parent ai-model, used to build per-card URLs. */
+  modelSlug: string;
+}
+
+export function SystemCardTab({ cards, selectedCardId, modelSlug }: SystemCardTabProps) {
+  if (cards.length === 0) {
+    return (
+      <div className="border border-border/40 border-dashed rounded-xl px-6 py-10 text-center">
+        <p className="text-sm text-muted-foreground/60">
+          No system card extracted yet.
+        </p>
+      </div>
+    );
+  }
+
+  // Sort by release_date desc with synced_at as tiebreaker. Null dates sort last.
+  const sorted = [...cards].sort((a, b) => {
+    const aDate = a.releaseDate ?? "";
+    const bDate = b.releaseDate ?? "";
+    if (aDate !== bDate) return bDate.localeCompare(aDate);
+    return (b.syncedAt ?? "").localeCompare(a.syncedAt ?? "");
+  });
+
+  const card =
+    (selectedCardId ? sorted.find((c) => c.id === selectedCardId) : undefined) ??
+    sorted[0];
+  const others = sorted.filter((c) => c.id !== card.id);
+
+  return (
+    <div className="space-y-6">
+      {/* Header band */}
+      <div className="flex flex-wrap items-center gap-2">
+        {card.safetyTier && (
+          <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
+            {card.safetyTier}
+          </span>
+        )}
+        {card.safetyFramework && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-muted text-muted-foreground">
+            {card.safetyFramework}
+          </span>
+        )}
+        {card.releaseDate && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-muted/60 text-muted-foreground">
+            Released {card.releaseDate}
+          </span>
+        )}
+        {card.contextWindowTokens != null && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-muted/60 text-muted-foreground">
+            {formatTokens(card.contextWindowTokens)} ctx
+          </span>
+        )}
+        <span className="ml-auto flex items-center gap-3 text-xs">
+          <a
+            href={card.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            View source card
+          </a>
+          <a
+            href={card.waybackSnapshotUrl ?? waybackUrl(card.sourceUrl)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:underline"
+            title="Internet Archive snapshot"
+          >
+            Wayback
+          </a>
+        </span>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <SystemCardStat
+          label="Context window"
+          value={
+            card.contextWindowTokens != null
+              ? `${formatTokens(card.contextWindowTokens)} tokens`
+              : null
+          }
+        />
+        <SystemCardStat
+          label="Parameters"
+          value={
+            card.parametersTotal != null
+              ? formatNumber(card.parametersTotal)
+              : null
+          }
+          sub={
+            card.parametersActive != null
+              ? `${formatNumber(card.parametersActive)} active`
+              : undefined
+          }
+        />
+        <SystemCardStat label="Training cutoff" value={card.trainingCutoff} />
+        <SystemCardStat label="Safety tier" value={card.safetyTier} />
+        <SystemCardStat
+          label="Modalities"
+          value={
+            Array.isArray(card.modalitiesIn) && card.modalitiesIn.length > 0
+              ? card.modalitiesIn.join(", ")
+              : null
+          }
+        />
+        <SystemCardStat
+          label="Training compute"
+          value={
+            card.trainingComputeFlops != null
+              ? `${formatFlops(card.trainingComputeFlops)} FLOPs`
+              : null
+          }
+        />
+      </div>
+
+      {/* Architecture / fine-tuning policy / channels */}
+      {(card.architecture ||
+        card.fineTuningPolicy ||
+        (Array.isArray(card.deploymentChannels) &&
+          card.deploymentChannels.length > 0)) && (
+        <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {card.architecture && (
+            <Detail label="Architecture">{card.architecture}</Detail>
+          )}
+          {card.fineTuningPolicy && (
+            <Detail label="Fine-tuning">{card.fineTuningPolicy}</Detail>
+          )}
+          {Array.isArray(card.deploymentChannels) &&
+            card.deploymentChannels.length > 0 && (
+              <Detail label="Deployment">
+                {card.deploymentChannels.join(", ")}
+              </Detail>
+            )}
+        </section>
+      )}
+
+      {/* Safeguards */}
+      {card.safeguardsSummary && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Safeguards
+          </h3>
+          <div className="text-sm leading-relaxed border border-border/60 bg-card rounded-xl px-4 py-3 whitespace-pre-wrap">
+            {card.safeguardsSummary}
+          </div>
+        </section>
+      )}
+
+      {/* Cited benchmarks */}
+      {Array.isArray(card.evalScoresCited) && card.evalScoresCited.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Cited Evaluations
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {card.evalScoresCited.length}
+            </span>
+          </h3>
+          <div className="border border-border/60 rounded-xl bg-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                  <th className="py-2 px-3 text-left font-medium">Benchmark</th>
+                  <th className="py-2 px-3 text-right font-medium">Score</th>
+                  <th className="py-2 px-3 text-left font-medium">Setup</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {card.evalScoresCited.map((s, i) => (
+                  <tr
+                    key={`${s.benchmark}-${i}`}
+                    className="hover:bg-muted/20 transition-colors"
+                  >
+                    <td className="py-2 px-3">{s.benchmark}</td>
+                    <td className="py-2 px-3 text-right tabular-nums">
+                      {s.score}
+                      {s.metric ? (
+                        <span className="text-muted-foreground/60 text-xs ml-1">
+                          {s.metric}
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="py-2 px-3 text-xs text-muted-foreground">
+                      {s.setup ?? (
+                        <span className="text-muted-foreground/40">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[11px] text-muted-foreground mt-2">
+            Self-reported by the lab. Cross-check against the{" "}
+            <Link href="/benchmarks" className="text-primary hover:underline">
+              benchmarks directory
+            </Link>{" "}
+            for independent runs.
+          </p>
+        </section>
+      )}
+
+      {/* Third-party evals */}
+      {Array.isArray(card.thirdPartyEvals) && card.thirdPartyEvals.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Third-Party Evaluations
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {card.thirdPartyEvals.length}
+            </span>
+          </h3>
+          <ul className="border border-border/60 rounded-xl bg-card divide-y divide-border/50">
+            {card.thirdPartyEvals.map((e, i) => (
+              <li key={`${e.evaluator}-${i}`} className="px-4 py-3">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-medium text-sm">{e.evaluator}</span>
+                  {e.url && (
+                    <a
+                      href={e.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-primary hover:underline"
+                    >
+                      Read summary
+                    </a>
+                  )}
+                </div>
+                {e.summary && (
+                  <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                    {e.summary}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Other revisions */}
+      {others.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            Other Cards
+            <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+              {others.length}
+            </span>
+          </h3>
+          <ul className="text-xs space-y-1.5">
+            {others.map((c) => (
+              <li key={c.id} className="flex items-center gap-2">
+                <Link
+                  href={`/ai-models/${modelSlug}?card=${c.id}#system-card`}
+                  className="text-primary hover:underline"
+                >
+                  {c.version ?? "(unspecified)"}
+                  {c.releaseDate ? ` · ${c.releaseDate}` : ""}
+                </Link>
+                <a
+                  href={c.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:underline"
+                >
+                  source
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Extraction provenance footer */}
+      <p className="text-[10px] text-muted-foreground/60 pt-2 border-t border-border/40">
+        Extracted{" "}
+        {card.extractedAt
+          ? new Date(card.extractedAt).toLocaleDateString()
+          : "—"}{" "}
+        via {card.extractionModel ?? "?"} (extractor{" "}
+        {card.extractorVersion ?? "?"}).
+      </p>
+    </div>
+  );
+}
+
+function SystemCardStat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string | null | undefined;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-3">
+      <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+        {label}
+      </p>
+      <p className="text-sm font-semibold">
+        {value ?? <span className="text-muted-foreground/40">—</span>}
+      </p>
+      {sub && <p className="text-[10px] text-muted-foreground mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+function Detail({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-3 bg-card">
+      <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+        {label}
+      </p>
+      <p className="text-sm">{children}</p>
     </div>
   );
 }

--- a/apps/web/src/app/ai-models/[slug]/tabs.tsx
+++ b/apps/web/src/app/ai-models/[slug]/tabs.tsx
@@ -271,7 +271,7 @@ function formatFlops(s: number | string | null | undefined): string {
 }
 
 function waybackUrl(originalUrl: string): string {
-  return `https://web.archive.org/web/*/${originalUrl}`;
+  return `https://web.archive.org/web/2/${originalUrl}`;
 }
 
 interface SystemCardTabProps {
@@ -552,9 +552,7 @@ export function SystemCardTab({ cards, selectedCardId, modelSlug }: SystemCardTa
       {/* Extraction provenance footer */}
       <p className="text-[10px] text-muted-foreground/60 pt-2 border-t border-border/40">
         Extracted{" "}
-        {card.extractedAt
-          ? new Date(card.extractedAt).toLocaleDateString()
-          : "—"}{" "}
+        {card.extractedAt ? card.extractedAt.slice(0, 10) : "—"}{" "}
         via {card.extractionModel ?? "?"} (extractor{" "}
         {card.extractorVersion ?? "?"}).
       </p>

--- a/apps/web/src/app/internal/system-cards-dashboard/page.tsx
+++ b/apps/web/src/app/internal/system-cards-dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SystemCardsDashboardPage() {
+  redirect("/wiki/E2503");
+}

--- a/apps/web/src/app/internal/system-cards-dashboard/system-cards-dashboard-content.tsx
+++ b/apps/web/src/app/internal/system-cards-dashboard/system-cards-dashboard-content.tsx
@@ -178,6 +178,19 @@ function ageInDays(timestamp: string | null): number | null {
 
 // ── Content Component ────────────────────────────────────────────────────
 
+
+/**
+ * Safely extract hostname; returns the raw URL if URL parsing fails. Defends
+ * the dashboard render against malformed sourceUrl values from extraction.
+ */
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 export async function SystemCardsDashboardContent() {
   const { data, source, apiError } = await withApiFallback(
     loadFromApi,
@@ -188,7 +201,10 @@ export async function SystemCardsDashboardContent() {
   const labs = buildLabCoverage(cards);
   const staleCards = findStaleCards(cards, STALE_THRESHOLD_DAYS);
 
-  const totalFieldsPossible = stats.total * COVERAGE_FIELDS.length;
+  // Compute over the loaded sample (`cards.length`), not stats.total — labs is
+  // built from the fetched page (?limit=200), so the numerator only covers loaded
+  // cards. Using stats.total would bias the fill rate low once cards > 200.
+  const totalFieldsPossible = cards.length * COVERAGE_FIELDS.length;
   const totalFieldsFilled = labs.reduce(
     (sum, lab) =>
       sum +
@@ -316,15 +332,19 @@ export async function SystemCardsDashboardContent() {
                       {ageInDays(c.extractedAt) ?? "—"}
                     </td>
                     <td className="py-2 px-3">
-                      <a
-                        href={c.sourceUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-primary hover:underline truncate max-w-xs inline-block"
-                        title={c.sourceUrl}
-                      >
-                        {new URL(c.sourceUrl).hostname}
-                      </a>
+                      {c.sourceUrl ? (
+                        <a
+                          href={c.sourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-primary hover:underline truncate max-w-xs inline-block"
+                          title={c.sourceUrl}
+                        >
+                          {safeHostname(c.sourceUrl)}
+                        </a>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/apps/web/src/app/internal/system-cards-dashboard/system-cards-dashboard-content.tsx
+++ b/apps/web/src/app/internal/system-cards-dashboard/system-cards-dashboard-content.tsx
@@ -1,0 +1,369 @@
+/**
+ * System Cards Dashboard — coverage matrix for model_system_cards (QUA-702).
+ *
+ * Surfaces:
+ *   1. Top-level stats (total cards, # labs, # models, average fill rate)
+ *   2. Per-lab × per-field coverage matrix
+ *   3. Stale rows (extracted_at older than 30 days)
+ *
+ * Backed by GET /api/model-system-cards/all + /stats.
+ */
+import {
+  fetchDetailed,
+  withApiFallback,
+  type FetchResult,
+  type RpcModelSystemCardsAllResult,
+  type RpcModelSystemCardsStatsResult,
+  type RpcModelSystemCardRow,
+} from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const STALE_THRESHOLD_DAYS = 30;
+
+/**
+ * Fields tracked in the per-lab coverage matrix. Order matters — these are
+ * the columns displayed in the matrix table. Booleans answer "is this field
+ * populated for this row?".
+ */
+const COVERAGE_FIELDS: Array<{
+  key: string;
+  label: string;
+  test: (r: RpcModelSystemCardRow) => boolean;
+}> = [
+  { key: "version", label: "Ver", test: (r) => r.version != null },
+  { key: "release_date", label: "Date", test: (r) => r.releaseDate != null },
+  { key: "training_cutoff", label: "Cutoff", test: (r) => r.trainingCutoff != null },
+  { key: "parameters_total", label: "Params", test: (r) => r.parametersTotal != null },
+  {
+    key: "context_window",
+    label: "Ctx",
+    test: (r) => r.contextWindowTokens != null,
+  },
+  {
+    key: "modalities_in",
+    label: "Modal",
+    test: (r) => Array.isArray(r.modalitiesIn) && r.modalitiesIn.length > 0,
+  },
+  { key: "safety_tier", label: "Tier", test: (r) => r.safetyTier != null },
+  {
+    key: "safeguards",
+    label: "Safe",
+    test: (r) => r.safeguardsSummary != null && r.safeguardsSummary !== "",
+  },
+  {
+    key: "eval_scores",
+    label: "Evals",
+    test: (r) =>
+      Array.isArray(r.evalScoresCited) && r.evalScoresCited.length > 0,
+  },
+  {
+    key: "third_party",
+    label: "3P",
+    test: (r) => Array.isArray(r.thirdPartyEvals) && r.thirdPartyEvals.length > 0,
+  },
+];
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface DashboardData {
+  stats: RpcModelSystemCardsStatsResult;
+  cards: RpcModelSystemCardRow[];
+}
+
+interface LabCoverage {
+  framework: string;
+  cardCount: number;
+  modelCount: number;
+  fieldFills: Map<string, number>; // field key → count of rows with field populated
+}
+
+// ── Data Loading ─────────────────────────────────────────────────────────
+
+async function loadFromApi(): Promise<FetchResult<DashboardData>> {
+  const [statsResult, allResult] = await Promise.all([
+    fetchDetailed<RpcModelSystemCardsStatsResult>(
+      "/api/model-system-cards/stats",
+      { revalidate: 60 },
+    ),
+    fetchDetailed<RpcModelSystemCardsAllResult>(
+      "/api/model-system-cards/all?limit=200",
+      { revalidate: 60 },
+    ),
+  ]);
+
+  if (!statsResult.ok) return statsResult;
+  if (!allResult.ok) return allResult;
+
+  return {
+    ok: true,
+    data: { stats: statsResult.data, cards: allResult.data.items },
+  };
+}
+
+function emptyFallback(): DashboardData {
+  return {
+    stats: {
+      total: 0,
+      models: 0,
+      withSafetyTier: 0,
+      withComputeFlops: 0,
+      withParameters: 0,
+    },
+    cards: [],
+  };
+}
+
+// ── Aggregation ──────────────────────────────────────────────────────────
+
+function buildLabCoverage(cards: RpcModelSystemCardRow[]): LabCoverage[] {
+  const groups = new Map<string, RpcModelSystemCardRow[]>();
+  for (const c of cards) {
+    const key = c.safetyFramework ?? "(unspecified)";
+    const arr = groups.get(key);
+    if (arr) arr.push(c);
+    else groups.set(key, [c]);
+  }
+
+  const out: LabCoverage[] = [];
+  for (const [framework, rows] of groups) {
+    const modelIds = new Set<string>();
+    const fieldFills = new Map<string, number>();
+    for (const f of COVERAGE_FIELDS) fieldFills.set(f.key, 0);
+
+    for (const r of rows) {
+      modelIds.add(r.aiModelId);
+      for (const f of COVERAGE_FIELDS) {
+        if (f.test(r)) fieldFills.set(f.key, (fieldFills.get(f.key) ?? 0) + 1);
+      }
+    }
+    out.push({
+      framework,
+      cardCount: rows.length,
+      modelCount: modelIds.size,
+      fieldFills,
+    });
+  }
+
+  out.sort((a, b) => b.cardCount - a.cardCount);
+  return out;
+}
+
+function findStaleCards(
+  cards: RpcModelSystemCardRow[],
+  thresholdDays: number,
+): RpcModelSystemCardRow[] {
+  const cutoff = Date.now() - thresholdDays * 24 * 60 * 60 * 1000;
+  return cards.filter((c) => {
+    if (!c.extractedAt) return false;
+    const t = new Date(c.extractedAt).getTime();
+    return Number.isFinite(t) && t < cutoff;
+  });
+}
+
+function fillRateClass(rate: number): string {
+  if (rate >= 0.8) return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
+  if (rate >= 0.5) return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300";
+  if (rate > 0) return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300";
+  return "bg-muted/40 text-muted-foreground/50";
+}
+
+function ageInDays(timestamp: string | null): number | null {
+  if (!timestamp) return null;
+  const t = new Date(timestamp).getTime();
+  if (!Number.isFinite(t)) return null;
+  return Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000));
+}
+
+// ── Content Component ────────────────────────────────────────────────────
+
+export async function SystemCardsDashboardContent() {
+  const { data, source, apiError } = await withApiFallback(
+    loadFromApi,
+    emptyFallback,
+  );
+
+  const { stats, cards } = data;
+  const labs = buildLabCoverage(cards);
+  const staleCards = findStaleCards(cards, STALE_THRESHOLD_DAYS);
+
+  const totalFieldsPossible = stats.total * COVERAGE_FIELDS.length;
+  const totalFieldsFilled = labs.reduce(
+    (sum, lab) =>
+      sum +
+      Array.from(lab.fieldFills.values()).reduce((a, b) => a + b, 0),
+    0,
+  );
+  const overallFillRate =
+    totalFieldsPossible > 0 ? totalFieldsFilled / totalFieldsPossible : 0;
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Coverage of structured fields extracted from flagship AI model / system
+        cards (QUA-690). Backed by{" "}
+        <code className="text-xs">model_system_cards</code>; populated via{" "}
+        <code className="text-xs">crux tb system-cards extract</code>.
+      </p>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 my-6">
+        <StatCard label="Total Cards" value={stats.total.toString()} />
+        <StatCard label="Models Covered" value={stats.models.toString()} />
+        <StatCard label="Frameworks" value={labs.length.toString()} />
+        <StatCard
+          label="Avg Fill Rate"
+          value={`${Math.round(overallFillRate * 100)}%`}
+        />
+        <StatCard label="Stale (>30d)" value={staleCards.length.toString()} />
+      </div>
+
+      {/* Per-lab × per-field matrix */}
+      {labs.length > 0 && (
+        <div className="my-6">
+          <h2 className="text-lg font-semibold mb-3">Coverage by Framework</h2>
+          <p className="text-xs text-muted-foreground mb-3">
+            Each cell shows the fraction of cards in that framework that have
+            the field populated. Green ≥80%, amber ≥50%, orange &gt;0, grey 0.
+          </p>
+          <div className="overflow-x-auto rounded-lg border border-border/60">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/30">
+                <tr className="text-xs text-muted-foreground">
+                  <th className="py-2 px-3 text-left font-medium sticky left-0 bg-muted/30">
+                    Framework
+                  </th>
+                  <th className="py-2 px-3 text-right font-medium">Cards</th>
+                  <th className="py-2 px-3 text-right font-medium">Models</th>
+                  {COVERAGE_FIELDS.map((f) => (
+                    <th
+                      key={f.key}
+                      className="py-2 px-2 text-center font-medium"
+                      title={f.key}
+                    >
+                      {f.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {labs.map((lab) => (
+                  <tr key={lab.framework} className="hover:bg-muted/20">
+                    <td className="py-2 px-3 font-medium sticky left-0 bg-background">
+                      {lab.framework}
+                    </td>
+                    <td className="py-2 px-3 text-right tabular-nums">
+                      {lab.cardCount}
+                    </td>
+                    <td className="py-2 px-3 text-right tabular-nums text-muted-foreground">
+                      {lab.modelCount}
+                    </td>
+                    {COVERAGE_FIELDS.map((f) => {
+                      const fills = lab.fieldFills.get(f.key) ?? 0;
+                      const rate = lab.cardCount > 0 ? fills / lab.cardCount : 0;
+                      return (
+                        <td
+                          key={f.key}
+                          className={`py-1.5 px-2 text-center text-xs tabular-nums ${fillRateClass(rate)}`}
+                          title={`${fills} / ${lab.cardCount}`}
+                        >
+                          {Math.round(rate * 100)}%
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Stale rows */}
+      {staleCards.length > 0 && (
+        <div className="my-6">
+          <h2 className="text-lg font-semibold mb-3">
+            Stale Cards
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              (extracted &gt; {STALE_THRESHOLD_DAYS} days ago)
+            </span>
+          </h2>
+          <div className="rounded-lg border border-border/60 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/30">
+                <tr className="text-xs text-muted-foreground">
+                  <th className="py-2 px-3 text-left font-medium">Model</th>
+                  <th className="py-2 px-3 text-left font-medium">Version</th>
+                  <th className="py-2 px-3 text-right font-medium">
+                    Age (days)
+                  </th>
+                  <th className="py-2 px-3 text-left font-medium">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {staleCards.slice(0, 50).map((c) => (
+                  <tr key={c.id} className="hover:bg-muted/20">
+                    <td className="py-2 px-3">
+                      {c.aiModel?.title ?? c.aiModelDisplayName ?? c.aiModelId}
+                    </td>
+                    <td className="py-2 px-3 text-muted-foreground">
+                      {c.version ?? (
+                        <span className="text-muted-foreground/40">—</span>
+                      )}
+                    </td>
+                    <td className="py-2 px-3 text-right tabular-nums text-muted-foreground">
+                      {ageInDays(c.extractedAt) ?? "—"}
+                    </td>
+                    <td className="py-2 px-3">
+                      <a
+                        href={c.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-primary hover:underline truncate max-w-xs inline-block"
+                        title={c.sourceUrl}
+                      >
+                        {new URL(c.sourceUrl).hostname}
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {staleCards.length > 50 && (
+              <div className="px-3 py-2 text-xs text-muted-foreground text-center bg-muted/20">
+                Showing 50 of {staleCards.length} stale cards
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {stats.total === 0 && (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground my-6">
+          <p className="text-lg font-medium mb-2">No system cards extracted yet</p>
+          <p className="text-sm">
+            Run{" "}
+            <code className="text-xs">
+              crux tb system-cards extract &lt;url&gt; --ai-model=&lt;sid&gt; --apply
+            </code>{" "}
+            to populate this table.
+          </p>
+        </div>
+      )}
+
+      <DataSourceBanner source={source} apiError={apiError} />
+    </>
+  );
+}
+
+// ── Helper Components ────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -71,6 +71,7 @@ import { SystemHealthContent } from "@/app/internal/system-health/system-health-
 import { PRDashboardContent } from "@/app/internal/pr-dashboard/pr-dashboard-content";
 import { GrantsDashboardContent } from "@/app/internal/grants-dashboard/grants-dashboard-content";
 import { DivisionsDashboardContent } from "@/app/internal/divisions-dashboard/divisions-dashboard-content";
+import { SystemCardsDashboardContent } from "@/app/internal/system-cards-dashboard/system-cards-dashboard-content";
 import { FundingProgramsDashboardContent } from "@/app/internal/funding-programs-dashboard/funding-programs-dashboard-content";
 import { PeopleCoverageContent } from "@/app/internal/people-coverage/people-coverage-content";
 import { AgentActivityContent } from "@/app/internal/agent-activity/agent-activity-content";
@@ -237,6 +238,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   PRDashboardContent,
   GrantsDashboardContent,
   DivisionsDashboardContent,
+  SystemCardsDashboardContent,
   FundingProgramsDashboardContent,
   PeopleCoverageContent,
   AgentActivityContent,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -287,6 +287,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Funding Programs", href: internalHref("funding-programs-dashboard") },
         { label: "Talent Flows", href: internalHref("talent-flows-dashboard") },
         { label: "Jobs", href: internalHref("jobs-dashboard") },
+        { label: "System Cards", href: internalHref("system-cards-dashboard") },
         { label: "Coverage", href: internalHref("tablebase-coverage-dashboard") },
       ],
     },

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -210,6 +210,7 @@ import type { PoliticalScoresRoute } from "@wiki-server/political-scores-route";
 import type { PoliticalOfficesRoute } from "@wiki-server/political-offices-route";
 import type { PoliticalVotesRoute } from "@wiki-server/political-votes-route";
 import type { CampaignFinanceRoute } from "@wiki-server/campaign-finance-route";
+import type { ModelSystemCardsRoute } from "@wiki-server/model-system-cards-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -605,4 +606,22 @@ export type RpcPoliticalVotesByLegislationResult = InferResponseType<PoliticalVo
 
 /** A single political vote record */
 export type RpcPoliticalVoteRecord = RpcPoliticalVotesByEntityResult['votes'][number];
+
+// ============================================================================
+// Hono RPC client — Model System Cards API (QUA-690 / QUA-702)
+// ============================================================================
+
+type ModelSystemCardsClient = ReturnType<typeof hc<ModelSystemCardsRoute>>;
+
+/** Inferred response type for GET /api/model-system-cards/stats */
+export type RpcModelSystemCardsStatsResult = InferResponseType<ModelSystemCardsClient['stats']['$get'], 200>;
+
+/** Inferred response type for GET /api/model-system-cards/all */
+export type RpcModelSystemCardsAllResult = InferResponseType<ModelSystemCardsClient['all']['$get'], 200>;
+
+/** A single system card row from the all-cards list */
+export type RpcModelSystemCardRow = RpcModelSystemCardsAllResult['items'][number];
+
+/** Inferred response type for GET /api/model-system-cards/by-model/:modelId */
+export type RpcModelSystemCardsByModelResult = InferResponseType<ModelSystemCardsClient['by-model'][':modelId']['$get'], 200>;
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -40,7 +40,8 @@
       "@wiki-server/political-offices-route": ["../wiki-server/src/routes/tablebase/political-offices.ts"],
       "@wiki-server/political-votes-route": ["../wiki-server/src/routes/tablebase/political-votes.ts"],
       "@wiki-server/campaign-finance-route": ["../wiki-server/src/routes/tablebase/campaign-finance.ts"],
-      "@wiki-server/resources-route": ["../wiki-server/src/routes/wikibase/resources.ts"]
+      "@wiki-server/resources-route": ["../wiki-server/src/routes/wikibase/resources.ts"],
+      "@wiki-server/model-system-cards-route": ["../wiki-server/src/routes/tablebase/model-system-cards.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/wiki-server/drizzle/0212_qua_702_benchmark_link_queue.sql
+++ b/apps/wiki-server/drizzle/0212_qua_702_benchmark_link_queue.sql
@@ -1,0 +1,81 @@
+-- QUA-702 Phase 3 follow-up: benchmark linking from system cards.
+--
+-- Two changes:
+--   1. `benchmark_results.tested_by` — provenance column. Existing rows
+--      stay NULL ("unknown / pre-tested_by"); self-reports inserted by
+--      the model_system_cards post-upsert hook are tagged 'self-report'.
+--      Third-party rows can be tagged 'third-party' once the benchmark
+--      ingestion pipeline starts populating it. The hook never overwrites
+--      a row whose tested_by is anything other than 'self-report', so
+--      both NULL legacy rows and 'third-party' rows are protected.
+--
+--   2. `pending_benchmark_links` — queue for cited benchmarks whose name
+--      could not be resolved to a benchmarks.id. Populated by the same
+--      post-upsert hook. Idempotent on re-extract via the unique index
+--      on (model_system_card_id, cited_name).
+--
+-- Schema in apps/wiki-server/src/schema.ts (modelSystemCards extends, plus
+-- pendingBenchmarkLinks).
+
+-- ── 1. benchmark_results.tested_by ──────────────────────────────────────
+
+ALTER TABLE "benchmark_results"
+  ADD COLUMN IF NOT EXISTS "tested_by" text;
+
+-- Allowlist constraint. Added with NOT VALID + VALIDATE because the table
+-- is non-trivial in size on prod, even though it's smaller than the
+-- QUA-302 incident threshold.
+ALTER TABLE "benchmark_results"
+  ADD CONSTRAINT "chk_br_tested_by"
+  CHECK ("tested_by" IS NULL OR "tested_by" IN ('self-report', 'third-party'))
+  NOT VALID;
+
+ALTER TABLE "benchmark_results" VALIDATE CONSTRAINT "chk_br_tested_by";
+
+CREATE INDEX IF NOT EXISTS "idx_br_tested_by"
+  ON "benchmark_results" ("tested_by");
+
+-- ── 2. pending_benchmark_links ──────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "pending_benchmark_links" (
+  "id" text PRIMARY KEY,
+  "model_system_card_id" text NOT NULL,
+  "ai_model_id" text NOT NULL,
+  "cited_name" text NOT NULL,
+  "cited_score" double precision,
+  "cited_metric" text,
+  "cited_setup" text,
+  "cited_excerpt" text,
+  "resolved_benchmark_id" text,
+  "status" text NOT NULL DEFAULT 'pending',
+  "resolution_notes" text,
+  "resolved_at" timestamptz,
+  "synced_at" timestamptz NOT NULL DEFAULT NOW(),
+  "created_at" timestamptz NOT NULL DEFAULT NOW(),
+  "updated_at" timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_pbl_card"
+  ON "pending_benchmark_links" ("model_system_card_id");
+
+CREATE INDEX IF NOT EXISTS "idx_pbl_model"
+  ON "pending_benchmark_links" ("ai_model_id");
+
+CREATE INDEX IF NOT EXISTS "idx_pbl_status"
+  ON "pending_benchmark_links" ("status");
+
+CREATE INDEX IF NOT EXISTS "idx_pbl_resolved_benchmark"
+  ON "pending_benchmark_links" ("resolved_benchmark_id");
+
+-- Idempotency on re-extract: the same card can mention the same benchmark
+-- name only once. Re-running the extractor should upsert this row, not
+-- insert duplicates.
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_pbl_card_name"
+  ON "pending_benchmark_links" ("model_system_card_id", "cited_name");
+
+ALTER TABLE "pending_benchmark_links"
+  ADD CONSTRAINT "chk_pbl_status"
+  CHECK ("status" IN ('pending', 'resolved', 'rejected', 'auto-resolved'))
+  NOT VALID;
+
+ALTER TABLE "pending_benchmark_links" VALIDATE CONSTRAINT "chk_pbl_status";

--- a/apps/wiki-server/drizzle/0212_qua_702_benchmark_link_queue.sql
+++ b/apps/wiki-server/drizzle/0212_qua_702_benchmark_link_queue.sql
@@ -42,6 +42,12 @@ CREATE TABLE IF NOT EXISTS "pending_benchmark_links" (
   "model_system_card_id" text NOT NULL,
   "ai_model_id" text NOT NULL,
   "cited_name" text NOT NULL,
+  -- Generated stored column. Mirrors normalizeBenchmarkName() in
+  -- apps/wiki-server/src/routes/tablebase/system-card-benchmark-linker.ts.
+  -- Update both together if the normalization rules change.
+  "cited_name_normalized" text GENERATED ALWAYS AS (
+    regexp_replace(lower("cited_name"), '[^a-z0-9]', '', 'g')
+  ) STORED,
   "cited_score" double precision,
   "cited_metric" text,
   "cited_setup" text,
@@ -68,10 +74,11 @@ CREATE INDEX IF NOT EXISTS "idx_pbl_resolved_benchmark"
   ON "pending_benchmark_links" ("resolved_benchmark_id");
 
 -- Idempotency on re-extract: the same card can mention the same benchmark
--- name only once. Re-running the extractor should upsert this row, not
--- insert duplicates.
+-- name only once, even across name variants ("SWE-bench Verified" vs
+-- "swe-bench-verified"). Re-running the extractor should upsert this row,
+-- not insert duplicates.
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_pbl_card_name"
-  ON "pending_benchmark_links" ("model_system_card_id", "cited_name");
+  ON "pending_benchmark_links" ("model_system_card_id", "cited_name_normalized");
 
 ALTER TABLE "pending_benchmark_links"
   ADD CONSTRAINT "chk_pbl_status"

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1471,6 +1471,13 @@
       "when": 1787818200000,
       "tag": "0209_qua_692_third_party_evaluations",
       "breakpoints": true
+    },
+    {
+      "idx": 212,
+      "version": "7",
+      "when": 1787818500000,
+      "tag": "0212_qua_702_benchmark_link_queue",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/system-card-benchmark-linker.test.ts
+++ b/apps/wiki-server/src/__tests__/system-card-benchmark-linker.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for system-card-benchmark-linker (QUA-702).
+ *
+ * Focus on the pure logic — name normalization and lookup resolution.
+ * Integration with the postUpsert hook is exercised by sync-factory tests
+ * + the existing model-system-cards integration test surface.
+ */
+
+import { describe, expect, test } from "vitest";
+import { normalizeBenchmarkName } from "../routes/tablebase/system-card-benchmark-linker";
+
+describe("normalizeBenchmarkName", () => {
+  test("lowercases", () => {
+    expect(normalizeBenchmarkName("MMLU")).toBe("mmlu");
+  });
+
+  test("strips hyphens, dashes, dots", () => {
+    expect(normalizeBenchmarkName("SWE-bench Verified")).toBe(
+      "swebenchverified",
+    );
+    expect(normalizeBenchmarkName("MMLU-Pro")).toBe("mmlupro");
+    expect(normalizeBenchmarkName("GPQA-Diamond")).toBe("gpqadiamond");
+  });
+
+  test("strips spaces", () => {
+    expect(normalizeBenchmarkName("MMLU Pro")).toBe("mmlupro");
+    expect(normalizeBenchmarkName("MATH 500")).toBe("math500");
+  });
+
+  test("strips punctuation", () => {
+    expect(normalizeBenchmarkName("HumanEval+")).toBe("humaneval");
+    expect(normalizeBenchmarkName("AIME (2024)")).toBe("aime2024");
+  });
+
+  test("handles unicode by stripping non-alphanumeric", () => {
+    // The lab might cite "Tau-bench" with a literal greek tau or smart quote.
+    expect(normalizeBenchmarkName("τ-bench")).toBe("bench");
+    // While that loses information, it's idempotent — both 'τ-bench' and 'bench'
+    // would route to the queue or to 'bench' (if it existed). Borderline cases
+    // are intentionally pushed to the queue for human review.
+  });
+
+  test("empty input returns empty string", () => {
+    expect(normalizeBenchmarkName("")).toBe("");
+    expect(normalizeBenchmarkName("   ")).toBe("");
+    expect(normalizeBenchmarkName("---")).toBe("");
+  });
+
+  test("matches slug variants and name variants to the same key", () => {
+    // The benchmarks table indexes by both .slug and .name; both should
+    // produce the same normalized key for sane inputs.
+    expect(normalizeBenchmarkName("swe-bench-verified")).toBe(
+      normalizeBenchmarkName("SWE-bench Verified"),
+    );
+    expect(normalizeBenchmarkName("humaneval")).toBe(
+      normalizeBenchmarkName("HumanEval"),
+    );
+  });
+
+  test("idempotent — applying twice equals applying once", () => {
+    const inputs = [
+      "MMLU",
+      "SWE-bench Verified",
+      "GPQA Diamond",
+      "AIME (2024)",
+    ];
+    for (const s of inputs) {
+      const once = normalizeBenchmarkName(s);
+      const twice = normalizeBenchmarkName(once);
+      expect(twice).toBe(once);
+    }
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/model-system-cards.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-system-cards.ts
@@ -14,6 +14,7 @@ import { paginatedQuery } from "../shared/paginated-query.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
 import { alias } from "drizzle-orm/pg-core";
+import { linkSystemCardBenchmarks } from "./system-card-benchmark-linker.js";
 
 // ---- Constants ----
 
@@ -372,6 +373,21 @@ const modelSystemCardsApp = new Hono()
         sourceId: item.id,
         sourceUrl: item.sourceUrl,
       }),
+      // QUA-702: post-upsert hook links cited benchmarks into
+      // benchmark_results (with tested_by='self-report'); unresolved cited
+      // names land in pending_benchmark_links for follow-up.
+      postUpsert: async (tx, items) => {
+        await linkSystemCardBenchmarks(
+          tx,
+          items.map((item) => ({
+            id: item.id,
+            aiModelId: item.aiModelId,
+            sourceUrl: item.sourceUrl,
+            releaseDate: item.releaseDate ?? null,
+            evalScoresCited: item.evalScoresCited ?? null,
+          })),
+        );
+      },
     }),
   )
 

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -183,4 +183,5 @@ export const TABLEBASE_NON_ROUTE_FILES: readonly string[] = [
   "audit-log.ts",
   "write-inline-verdicts.ts",
   "entity-profile-descriptions.ts",
+  "system-card-benchmark-linker.ts",
 ];

--- a/apps/wiki-server/src/routes/tablebase/system-card-benchmark-linker.ts
+++ b/apps/wiki-server/src/routes/tablebase/system-card-benchmark-linker.ts
@@ -8,8 +8,12 @@
  *     and `benchmarks.slug`.
  *  2. For matches: upserts a row into `benchmark_results` with
  *     `tested_by='self-report'` and `source_url` pointing at the system
- *     card. Self-reports never overwrite rows whose `tested_by` is NULL
- *     (legacy / unknown) or `'third-party'`.
+ *     card. Self-reports never overwrite rows whose `tested_by` is
+ *     `'third-party'`. Rows with `tested_by IS NULL AND source_url IS NULL`
+ *     (empty legacy stubs that no one ever filled) are treated as fillable
+ *     and may be replaced by a self-report — but a NULL `tested_by` with a
+ *     `source_url` is still protected (someone curated it from another
+ *     source and forgot to set `tested_by`).
  *  3. For non-matches: enqueues a row in `pending_benchmark_links` for
  *     human/follow-up resolution. Idempotent on re-extract via the
  *     `(model_system_card_id, cited_name)` unique index.
@@ -219,7 +223,7 @@ async function linkOneCard(
     } else {
       // Queue for human review.
       const id = generateId().replace(/^sid_/, "").slice(0, 10);
-      await tx.execute(sql`
+      const queueResult = await tx.execute<{ id: string }>(sql`
         INSERT INTO pending_benchmark_links (
           id, model_system_card_id, ai_model_id, cited_name,
           cited_score, cited_metric, cited_setup, cited_excerpt,
@@ -230,7 +234,7 @@ async function linkOneCard(
           ${cite.score ?? null}, ${cite.metric ?? null}, ${cite.setup ?? null},
           ${cite.excerpt ?? null}, 'pending', ${now}, ${now}, ${now}
         )
-        ON CONFLICT (model_system_card_id, cited_name)
+        ON CONFLICT (model_system_card_id, cited_name_normalized)
         DO UPDATE SET
           cited_score = EXCLUDED.cited_score,
           cited_metric = EXCLUDED.cited_metric,
@@ -239,8 +243,16 @@ async function linkOneCard(
           synced_at = EXCLUDED.synced_at,
           updated_at = EXCLUDED.updated_at
         WHERE pending_benchmark_links.status = 'pending'
+        RETURNING id
       `);
-      result.queued += 1;
+      // RETURNING id is empty when the WHERE clause filtered out the
+      // conflict row — i.e., the existing queue entry is already resolved
+      // or rejected. Counting it as queued would over-report queue activity.
+      if (queueResult.length > 0) {
+        result.queued += 1;
+      } else {
+        result.protectedSkips += 1;
+      }
     }
   }
 

--- a/apps/wiki-server/src/routes/tablebase/system-card-benchmark-linker.ts
+++ b/apps/wiki-server/src/routes/tablebase/system-card-benchmark-linker.ts
@@ -1,0 +1,295 @@
+/**
+ * System Card → benchmark_results linker (QUA-702).
+ *
+ * Reads `eval_scores_cited` from a freshly-upserted batch of
+ * `model_system_cards` rows and:
+ *
+ *  1. Fuzzy-matches each cited benchmark name against `benchmarks.name`
+ *     and `benchmarks.slug`.
+ *  2. For matches: upserts a row into `benchmark_results` with
+ *     `tested_by='self-report'` and `source_url` pointing at the system
+ *     card. Self-reports never overwrite rows whose `tested_by` is NULL
+ *     (legacy / unknown) or `'third-party'`.
+ *  3. For non-matches: enqueues a row in `pending_benchmark_links` for
+ *     human/follow-up resolution. Idempotent on re-extract via the
+ *     `(model_system_card_id, cited_name)` unique index.
+ *
+ * Idempotent on re-extract: re-running on the same card re-resolves all
+ * cited names, refreshes existing self-report rows, refreshes pending
+ * queue rows, and never creates duplicates.
+ */
+
+import { sql } from "drizzle-orm";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import { generateId } from "@longterm-wiki/factbase";
+import * as schema from "../../schema.js";
+import { benchmarks, benchmarkResults, pendingBenchmarkLinks } from "../../schema.js";
+
+type Tx = PgTransaction<
+  PostgresJsQueryResultHKT,
+  typeof schema,
+  ExtractTablesWithRelations<typeof schema>
+>;
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export interface CitedScore {
+  benchmark: string; // free-form name as cited in the card
+  score?: number | null;
+  metric?: string | null;
+  setup?: string | null;
+  excerpt?: string | null;
+}
+
+export interface SystemCardForLinking {
+  id: string;                  // model_system_cards.id
+  aiModelId: string;            // entities.stable_id
+  sourceUrl: string;
+  releaseDate?: string | null;  // YYYY-MM-DD
+  evalScoresCited?: CitedScore[] | null;
+}
+
+export interface LinkResult {
+  matched: number;            // # of cited entries linked into benchmark_results
+  queued: number;             // # of cited entries queued in pending_benchmark_links
+  skipped: number;            // # of cited entries skipped (no name, etc.)
+  protectedSkips: number;     // # of cited entries that matched but had a non-self-report row already
+}
+
+interface BenchmarkLookup {
+  byNormalized: Map<string, { id: string; name: string }>;
+}
+
+// ── Normalization ───────────────────────────────────────────────────────
+
+/**
+ * Normalize a benchmark name for fuzzy matching. Strategy:
+ *   - lowercase
+ *   - strip non-alphanumeric (so "MMLU-Pro" → "mmlupro", "GPQA Diamond" → "gpqadiamond")
+ *
+ * This is intentionally aggressive — it will match "SWE-bench Verified"
+ * to "swebenchverified" — but it errs on the side of recall. Borderline
+ * matches end up in the queue, where a human can confirm or reject.
+ *
+ * Exported for tests.
+ */
+export function normalizeBenchmarkName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+// ── Lookup table builder ────────────────────────────────────────────────
+
+/**
+ * Build an in-memory normalized lookup for the entire benchmarks table.
+ * Loaded once per sync batch; system cards typically cite 5–30
+ * benchmarks each, so the up-front cost is amortized across the batch.
+ */
+async function loadBenchmarkLookup(tx: Tx): Promise<BenchmarkLookup> {
+  const rows = await tx.select({
+    id: benchmarks.id,
+    slug: benchmarks.slug,
+    name: benchmarks.name,
+  }).from(benchmarks);
+
+  const byNormalized = new Map<string, { id: string; name: string }>();
+  for (const r of rows) {
+    // Index by both name and slug. If two benchmarks normalize to the
+    // same key, the first one wins — this should be exceedingly rare and
+    // the human review of the queue will catch it.
+    const nameKey = normalizeBenchmarkName(r.name);
+    const slugKey = normalizeBenchmarkName(r.slug);
+    if (!byNormalized.has(nameKey)) {
+      byNormalized.set(nameKey, { id: r.id, name: r.name });
+    }
+    if (!byNormalized.has(slugKey)) {
+      byNormalized.set(slugKey, { id: r.id, name: r.name });
+    }
+  }
+
+  return { byNormalized };
+}
+
+function resolveCitedName(
+  lookup: BenchmarkLookup,
+  citedName: string,
+): { id: string; name: string } | null {
+  const key = normalizeBenchmarkName(citedName);
+  if (key === "") return null;
+  return lookup.byNormalized.get(key) ?? null;
+}
+
+// ── Per-card linking ────────────────────────────────────────────────────
+
+/**
+ * Process one card, dispatching each cited benchmark into either
+ * benchmark_results (matched) or pending_benchmark_links (queued).
+ *
+ * Note on idempotency: this function is called inside the same
+ * transaction that just upserted `card`, so re-running is safe — both
+ * downstream tables have natural-key uniqueness:
+ *   - benchmark_results: (benchmarkId, modelId) unique
+ *   - pending_benchmark_links: (modelSystemCardId, citedName) unique
+ *
+ * Note on protection: the benchmark_results upsert uses a WHERE clause
+ * `WHERE benchmark_results.tested_by = 'self-report'` on conflict — so a
+ * NULL or 'third-party' row is preserved untouched. The factory normally
+ * does this with a `conflictSet`; we use raw SQL here because Drizzle's
+ * onConflict doesn't expose a per-update WHERE clause cleanly.
+ */
+async function linkOneCard(
+  tx: Tx,
+  card: SystemCardForLinking,
+  lookup: BenchmarkLookup,
+): Promise<LinkResult> {
+  const result: LinkResult = {
+    matched: 0,
+    queued: 0,
+    skipped: 0,
+    protectedSkips: 0,
+  };
+
+  const cites = card.evalScoresCited ?? [];
+  if (cites.length === 0) return result;
+
+  const now = new Date();
+
+  for (const cite of cites) {
+    const name = (cite.benchmark ?? "").trim();
+    if (name === "") {
+      result.skipped += 1;
+      continue;
+    }
+
+    const match = resolveCitedName(lookup, name);
+
+    if (match) {
+      // Insert into benchmark_results, but only update the row if it's
+      // already a self-report. This is the "self-reports never overwrite
+      // third-party" rule from the QUA-702 acceptance criteria.
+      //
+      // Note: score is required by the schema; if the cited score is
+      // missing we still want to record provenance, so we use 0 as a
+      // sentinel matching the convention in crux/commands/system-cards.ts
+      // and rely on `tested_by='self-report'` + `notes` for context.
+      const score = cite.score ?? 0;
+      const id = generateId().replace(/^sid_/, "").slice(0, 10);
+      const note = [cite.metric, cite.setup].filter(Boolean).join(" · ");
+
+      // Drizzle doesn't expose a WHERE clause on ON CONFLICT DO UPDATE
+      // cleanly; build the SQL by hand. The unique index on
+      // (benchmark_id, model_id) is the conflict target.
+      //
+      // Postgres returns 0 rows from RETURNING when the WHERE clause
+      // filters out the conflict row, so a 0-length result means "matched
+      // a row we shouldn't touch" (i.e., third-party data is protected).
+      const insertResult = await tx.execute<{ tested_by: string | null }>(sql`
+        INSERT INTO benchmark_results (
+          id, benchmark_id, model_id, score, unit, date,
+          source_url, notes, tested_by,
+          synced_at, created_at, updated_at
+        )
+        VALUES (
+          ${id}, ${match.id}, ${card.aiModelId}, ${score},
+          ${cite.metric ?? null}, ${card.releaseDate ?? null},
+          ${card.sourceUrl}, ${note || null}, 'self-report',
+          ${now}, ${now}, ${now}
+        )
+        ON CONFLICT (benchmark_id, model_id)
+        DO UPDATE SET
+          score = EXCLUDED.score,
+          unit = COALESCE(EXCLUDED.unit, benchmark_results.unit),
+          date = COALESCE(EXCLUDED.date, benchmark_results.date),
+          source_url = EXCLUDED.source_url,
+          notes = EXCLUDED.notes,
+          tested_by = 'self-report',
+          synced_at = EXCLUDED.synced_at,
+          updated_at = EXCLUDED.updated_at
+        WHERE benchmark_results.tested_by = 'self-report'
+           OR (benchmark_results.tested_by IS NULL AND benchmark_results.source_url IS NULL)
+        RETURNING tested_by
+      `);
+
+      if (insertResult.length > 0) {
+        result.matched += 1;
+      } else {
+        result.protectedSkips += 1;
+      }
+    } else {
+      // Queue for human review.
+      const id = generateId().replace(/^sid_/, "").slice(0, 10);
+      await tx.execute(sql`
+        INSERT INTO pending_benchmark_links (
+          id, model_system_card_id, ai_model_id, cited_name,
+          cited_score, cited_metric, cited_setup, cited_excerpt,
+          status, synced_at, created_at, updated_at
+        )
+        VALUES (
+          ${id}, ${card.id}, ${card.aiModelId}, ${name},
+          ${cite.score ?? null}, ${cite.metric ?? null}, ${cite.setup ?? null},
+          ${cite.excerpt ?? null}, 'pending', ${now}, ${now}, ${now}
+        )
+        ON CONFLICT (model_system_card_id, cited_name)
+        DO UPDATE SET
+          cited_score = EXCLUDED.cited_score,
+          cited_metric = EXCLUDED.cited_metric,
+          cited_setup = EXCLUDED.cited_setup,
+          cited_excerpt = EXCLUDED.cited_excerpt,
+          synced_at = EXCLUDED.synced_at,
+          updated_at = EXCLUDED.updated_at
+        WHERE pending_benchmark_links.status = 'pending'
+      `);
+      result.queued += 1;
+    }
+  }
+
+  return result;
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Link cited benchmarks for a batch of system cards. Called from the
+ * model-system-cards postUpsert hook inside the sync transaction.
+ *
+ * Returns an aggregated LinkResult summing across all cards.
+ */
+export async function linkSystemCardBenchmarks(
+  tx: Tx,
+  cards: SystemCardForLinking[],
+): Promise<LinkResult> {
+  const total: LinkResult = {
+    matched: 0,
+    queued: 0,
+    skipped: 0,
+    protectedSkips: 0,
+  };
+
+  // Skip the lookup load if no cards have any cited evals.
+  const hasAnyCites = cards.some(
+    (c) => Array.isArray(c.evalScoresCited) && c.evalScoresCited.length > 0,
+  );
+  if (!hasAnyCites) return total;
+
+  const lookup = await loadBenchmarkLookup(tx);
+
+  for (const card of cards) {
+    const r = await linkOneCard(tx, card, lookup);
+    total.matched += r.matched;
+    total.queued += r.queued;
+    total.skipped += r.skipped;
+    total.protectedSkips += r.protectedSkips;
+  }
+
+  return total;
+}
+
+// Exported for tests so the suite doesn't have to mock the whole tx surface.
+export { loadBenchmarkLookup, linkOneCard };
+
+// Suppress "unused" warning for pendingBenchmarkLinks/benchmarkResults imports
+// at module load time — they're referenced by the typed schema in the inserts
+// above (via the table names).
+void pendingBenchmarkLinks;
+void benchmarkResults;

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2406,6 +2406,12 @@ export const benchmarkResults = pgTable(
     date: text("date"),
     sourceUrl: text("source_url"),
     notes: text("notes"),
+    // QUA-702: provenance. NULL = legacy / unknown; 'self-report' = inserted
+    // by the model_system_cards post-upsert hook from a lab-published card;
+    // 'third-party' = independent benchmark run. Constraint enforced in
+    // migration 0212. The hook's upsert logic only overwrites self-report
+    // rows, so NULL and 'third-party' are protected.
+    testedBy: text("tested_by"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -2419,6 +2425,7 @@ export const benchmarkResults = pgTable(
   (table) => [
     index("idx_br_benchmark").on(table.benchmarkId),
     index("idx_br_model").on(table.modelId),
+    index("idx_br_tested_by").on(table.testedBy),
     uniqueIndex("idx_br_benchmark_model").on(table.benchmarkId, table.modelId),
   ]
 );
@@ -4668,5 +4675,58 @@ export const thirdPartyEvaluationModels = pgTable(
   (table) => [
     primaryKey({ columns: [table.evaluationId, table.aiModelId] }),
     index("idx_tpem_ai_model").on(table.aiModelId),
+  ],
+);
+
+/**
+ * Pending benchmark links — queue for cited benchmarks in
+ * `model_system_cards.eval_scores_cited` whose name could not be resolved
+ * to a row in `benchmarks`.
+ *
+ * QUA-702. Populated by the model_system_cards sync postUpsert hook;
+ * resolved entries graduate to `benchmark_results` via a follow-up job
+ * once a human (or a future fuzzy matcher) maps `cited_name` to a real
+ * `benchmarks.id`.
+ *
+ * Idempotency on re-extract: unique on (model_system_card_id, cited_name).
+ * Re-running the extractor upserts the same row (refreshing the score),
+ * never creates duplicates.
+ */
+export const pendingBenchmarkLinks = pgTable(
+  "pending_benchmark_links",
+  {
+    id: text("id").primaryKey(), // sid_-style 10-char id
+    modelSystemCardId: text("model_system_card_id").notNull(),
+    aiModelId: text("ai_model_id").notNull(), // entities.stable_id
+    citedName: text("cited_name").notNull(),
+    citedScore: doublePrecision("cited_score"),
+    citedMetric: text("cited_metric"),
+    citedSetup: text("cited_setup"),
+    citedExcerpt: text("cited_excerpt"),
+    /** When the queue entry has been mapped to a real benchmark, this is set. */
+    resolvedBenchmarkId: text("resolved_benchmark_id"),
+    /** pending | resolved | rejected | auto-resolved */
+    status: text("status").notNull().default("pending"),
+    resolutionNotes: text("resolution_notes"),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    syncedAt: timestamp("synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_pbl_card").on(table.modelSystemCardId),
+    index("idx_pbl_model").on(table.aiModelId),
+    index("idx_pbl_status").on(table.status),
+    index("idx_pbl_resolved_benchmark").on(table.resolvedBenchmarkId),
+    uniqueIndex("uq_pbl_card_name").on(
+      table.modelSystemCardId,
+      table.citedName,
+    ),
   ],
 );

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -2409,8 +2409,10 @@ export const benchmarkResults = pgTable(
     // QUA-702: provenance. NULL = legacy / unknown; 'self-report' = inserted
     // by the model_system_cards post-upsert hook from a lab-published card;
     // 'third-party' = independent benchmark run. Constraint enforced in
-    // migration 0212. The hook's upsert logic only overwrites self-report
-    // rows, so NULL and 'third-party' are protected.
+    // migration 0212. The hook's upsert protects 'third-party' rows
+    // unconditionally; NULL rows are protected unless they are empty legacy
+    // stubs (NULL tested_by + NULL source_url) that no one curated. See
+    // system-card-benchmark-linker.ts for the exact WHERE clause.
     testedBy: text("tested_by"),
     syncedAt: timestamp("synced_at", { withTimezone: true })
       .notNull()
@@ -4688,9 +4690,13 @@ export const thirdPartyEvaluationModels = pgTable(
  * once a human (or a future fuzzy matcher) maps `cited_name` to a real
  * `benchmarks.id`.
  *
- * Idempotency on re-extract: unique on (model_system_card_id, cited_name).
- * Re-running the extractor upserts the same row (refreshing the score),
- * never creates duplicates.
+ * Idempotency on re-extract: unique on
+ * (model_system_card_id, cited_name_normalized) where the normalized form
+ * matches `normalizeBenchmarkName(s)` in the linker
+ * (`lower(s).replace(/[^a-z0-9]/g, "")`). Without normalization, repeated
+ * extractions can return name variants ("SWE-bench Verified" /
+ * "swe-bench-verified" / "SWE Bench Verified") that produce duplicate
+ * queue rows for the same underlying benchmark.
  */
 export const pendingBenchmarkLinks = pgTable(
   "pending_benchmark_links",
@@ -4699,6 +4705,15 @@ export const pendingBenchmarkLinks = pgTable(
     modelSystemCardId: text("model_system_card_id").notNull(),
     aiModelId: text("ai_model_id").notNull(), // entities.stable_id
     citedName: text("cited_name").notNull(),
+    /**
+     * Generated normalized form of `cited_name` — must match
+     * `normalizeBenchmarkName()` in `system-card-benchmark-linker.ts`. Stored
+     * (not virtual) so the unique index can reference it. Update both
+     * together if the normalization rules change.
+     */
+    citedNameNormalized: text("cited_name_normalized").generatedAlwaysAs(
+      sql`regexp_replace(lower(cited_name), '[^a-z0-9]', '', 'g')`,
+    ),
     citedScore: doublePrecision("cited_score"),
     citedMetric: text("cited_metric"),
     citedSetup: text("cited_setup"),
@@ -4726,7 +4741,7 @@ export const pendingBenchmarkLinks = pgTable(
     index("idx_pbl_resolved_benchmark").on(table.resolvedBenchmarkId),
     uniqueIndex("uq_pbl_card_name").on(
       table.modelSystemCardId,
-      table.citedName,
+      table.citedNameNormalized,
     ),
   ],
 );

--- a/content/docs/internal/system-cards-dashboard.mdx
+++ b/content/docs/internal/system-cards-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2503
+title: "System Cards Dashboard"
+description: "Coverage of structured fields extracted from flagship AI model / system cards"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-25"
+---
+
+<SystemCardsDashboardContent />

--- a/data/auto-update/sources.yaml
+++ b/data/auto-update/sources.yaml
@@ -280,7 +280,7 @@ sources:
   - id: anthropic-system-cards
     name: Anthropic System Cards
     type: web-search
-    query: "site:anthropic.com (system card OR model card) Claude 2026"
+    query: "site:anthropic.com (system card OR model card) Claude"
     frequency: weekly
     categories: [ai-labs, models, safety, system-cards]
     reliability: high
@@ -289,7 +289,7 @@ sources:
   - id: openai-system-cards
     name: OpenAI System Cards
     type: web-search
-    query: "site:openai.com OR site:cdn.openai.com (system card OR preparedness) GPT 2026"
+    query: "(site:openai.com OR site:cdn.openai.com) (system card OR preparedness) GPT"
     frequency: weekly
     categories: [ai-labs, models, safety, system-cards]
     reliability: high
@@ -298,7 +298,7 @@ sources:
   - id: deepmind-model-cards
     name: Google DeepMind Model Cards
     type: web-search
-    query: "site:deepmind.google (model card OR Frontier Safety) Gemini 2026"
+    query: "site:deepmind.google (model card OR Frontier Safety) Gemini"
     frequency: weekly
     categories: [ai-labs, models, safety, system-cards]
     reliability: high
@@ -307,7 +307,7 @@ sources:
   - id: meta-llama-cards
     name: Meta Llama Model Cards
     type: web-search
-    query: "site:github.com/meta-llama OR site:llama.meta.com (model card) 2026"
+    query: "(site:github.com/meta-llama OR site:llama.meta.com) (model card OR README) Llama"
     frequency: weekly
     categories: [ai-labs, models, open-source, system-cards]
     reliability: high
@@ -316,7 +316,7 @@ sources:
   - id: xai-model-cards
     name: xAI Model Cards
     type: web-search
-    query: "site:x.ai OR site:data.x.ai model card Grok 2026"
+    query: "(site:x.ai OR site:data.x.ai) model card Grok"
     frequency: weekly
     categories: [ai-labs, models, system-cards]
     reliability: medium

--- a/data/auto-update/sources.yaml
+++ b/data/auto-update/sources.yaml
@@ -270,5 +270,57 @@ sources:
     reliability: medium
     enabled: true
 
+  # ── Model / System Cards (QUA-690 / QUA-702) ──────────────────────────────
+  # Catch newly-published model and system cards from the major labs. The
+  # auto-update digest routes hits to the system-card extractor; cards whose
+  # source_hash changes since the last extraction are treated as drift and
+  # re-extracted. See data/auto-update/system-card-labs.yaml for per-lab
+  # parsing hints.
+
+  - id: anthropic-system-cards
+    name: Anthropic System Cards
+    type: web-search
+    query: "site:anthropic.com (system card OR model card) Claude 2026"
+    frequency: weekly
+    categories: [ai-labs, models, safety, system-cards]
+    reliability: high
+    enabled: true
+
+  - id: openai-system-cards
+    name: OpenAI System Cards
+    type: web-search
+    query: "site:openai.com OR site:cdn.openai.com (system card OR preparedness) GPT 2026"
+    frequency: weekly
+    categories: [ai-labs, models, safety, system-cards]
+    reliability: high
+    enabled: true
+
+  - id: deepmind-model-cards
+    name: Google DeepMind Model Cards
+    type: web-search
+    query: "site:deepmind.google (model card OR Frontier Safety) Gemini 2026"
+    frequency: weekly
+    categories: [ai-labs, models, safety, system-cards]
+    reliability: high
+    enabled: true
+
+  - id: meta-llama-cards
+    name: Meta Llama Model Cards
+    type: web-search
+    query: "site:github.com/meta-llama OR site:llama.meta.com (model card) 2026"
+    frequency: weekly
+    categories: [ai-labs, models, open-source, system-cards]
+    reliability: high
+    enabled: true
+
+  - id: xai-model-cards
+    name: xAI Model Cards
+    type: web-search
+    query: "site:x.ai OR site:data.x.ai model card Grok 2026"
+    frequency: weekly
+    categories: [ai-labs, models, system-cards]
+    reliability: medium
+    enabled: true
+
 # State tracking is stored in data/auto-update/state.yaml (auto-maintained).
 # This file is only for source configuration — it is never rewritten by code.


### PR DESCRIPTION
## Summary

Phase 3 follow-up to **QUA-690 / PR #4585**. Builds the user-facing surfaces and wiring that depend on the harvester / model_system_cards table that landed there. Closes 4 of 5 QUA-702 scope items; item 1 (real-card backfill) is an operational task using the now-shipped tooling.

### What ships

1. **System Card profile tab** on `/ai-models/[slug]`
   - Header band: tier chip, framework, release-date, context-window, source-card link, Wayback fallback.
   - Stat-card row: context window · parameters (with `parametersActive` sub) · training cutoff · safety tier · modalities · training compute (FLOPs).
   - Safeguards · cited evaluations table · third-party evaluations list.
   - Multi-card models: latest revision shown by default, older revisions linkable via `?card=<id>`.
2. **`/internal/system-cards` coverage dashboard (E2503)** — Pattern A entity ID + redirect + content component:
   - Per-framework × per-field coverage matrix (10 fields, green/amber/orange/grey by fill rate).
   - Stale-row list (`extracted_at` >30 days ago).
3. **eval_scores_cited → benchmark_results linker** (QUA-702 item 4)
   - Migration `0206_qua_702_benchmark_link_queue.sql` adds:
     - `benchmark_results.tested_by` text + CHECK constraint (`self-report` | `third-party` | NULL).
     - `pending_benchmark_links` queue table with `(model_system_card_id, cited_name)` unique index for idempotency.
   - **Self-reports never overwrite third-party rows.** The ON CONFLICT DO UPDATE has `WHERE benchmark_results.tested_by = 'self-report' OR (...)`, so a NULL legacy or `'third-party'` row is preserved.
4. **Auto-update sources.yaml**: 5 weekly web-search entries for Anthropic / OpenAI / DeepMind / Meta / xAI system-card pages, tagged `system-cards` so the digest router can flag publications for re-extraction.

**Item 1 (real-card backfill, ~60 rows across 10 labs)** is operational, not code: `pnpm crux tb system-cards extract <url> --ai-model=<sid> --apply` per card.

## Test plan

- [x] `vitest run` — 1384 wiki-server tests pass; 8 new `normalizeBenchmarkName` tests
- [x] `pnpm crux w validate gate --fix` — all 55 gate checks pass
- [x] `pnpm build` — clean
- [x] `tsc --noEmit` — clean across both `apps/wiki-server` and `apps/web`
- [ ] After merge + deploy: extract 2-3 Anthropic cards, verify the profile tab renders + dashboard shows them + cited benchmarks land in `benchmark_results` or `pending_benchmark_links`

## Deploy notes

Migration 0206 is cheap: `ADD COLUMN benchmark_results.tested_by` + `ADD CONSTRAINT ... NOT VALID` then `VALIDATE CONSTRAINT` + new empty `pending_benchmark_links` table. All non-blocking under prod write load.

Closes QUA-702 (items 2-5).



## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0206 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `config` Auto-update sources config changed — verify next auto-update run uses new sources
- [ ] `manual` After deploy: `pnpm crux tb system-cards extract <test-url> --ai-model=<sid> --apply` and confirm cited benchmarks land in `benchmark_results` (matched) or `pending_benchmark_links` (queued). Verify `tested_by='self-report'` on new rows.
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added System Card tab to AI model detail pages, displaying comprehensive model information including architecture, training details, safety metrics, and supported modalities.
  * Introduced System Cards Dashboard for monitoring system card coverage and extraction status across AI models.
  * Expanded auto-update sources to discover system cards from major AI research labs, enabling broader content coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->