### PR TITLE
QUA-705: Phase 5 backfill driver (third-party evaluations)

### DIFF
--- a/crux/commands/third-party-evals.test.ts
+++ b/crux/commands/third-party-evals.test.ts
@@ -49,4 +49,29 @@ describe("third-party-evals CLI dispatcher", () => {
     expect(r.exitCode).toBe(1);
     expect(r.output).toContain("Usage: crux tb third-party-evals extract");
   });
+
+  it("backfill requires evaluator name", async () => {
+    const r = await commands.backfill([], {});
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("Usage: crux tb third-party-evals backfill");
+  });
+
+  it("backfill requires --evaluator flag", async () => {
+    const r = await commands.backfill(["uk-aisi"], {});
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("--evaluator=");
+  });
+
+  it("default routes to backfill on 'backfill' verb", async () => {
+    const r = await commands.default(["backfill"], {});
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("Usage: crux tb third-party-evals backfill");
+  });
+
+  it("default rejects unknown verb with new error message", async () => {
+    const r = await commands.default(["bogus"], {});
+    expect(r.exitCode).toBe(1);
+    // mentions all three valid verbs
+    expect(r.output).toMatch(/ingest.*extract.*backfill/);
+  });
 });

--- a/crux/commands/third-party-evals.test.ts
+++ b/crux/commands/third-party-evals.test.ts
@@ -74,4 +74,31 @@ describe("third-party-evals CLI dispatcher", () => {
     // mentions all three valid verbs
     expect(r.output).toMatch(/ingest.*extract.*backfill/);
   });
+
+  it("backfill rejects non-numeric --concurrency (would otherwise hang on pLimit(NaN))", async () => {
+    const r = await commands.backfill(["uk-aisi"], {
+      evaluator: "sid_aX0jkoaekQ",
+      concurrency: "abc",
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("--concurrency must be a positive integer");
+  });
+
+  it("backfill rejects zero/negative --batch-size", async () => {
+    const r = await commands.backfill(["uk-aisi"], {
+      evaluator: "sid_aX0jkoaekQ",
+      batchSize: "0",
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("--batch-size must be a positive integer");
+  });
+
+  it("backfill rejects non-numeric --limit", async () => {
+    const r = await commands.backfill(["uk-aisi"], {
+      evaluator: "sid_aX0jkoaekQ",
+      limit: "many",
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toContain("--limit must be a positive integer");
+  });
 });

--- a/crux/commands/third-party-evals.ts
+++ b/crux/commands/third-party-evals.ts
@@ -31,11 +31,7 @@ import {
 } from "../third-party-evals/extract-eval-report.ts";
 import { verifyExtractedReport } from "../third-party-evals/span-verify.ts";
 import { resolveAiModel } from "../lib/ai-model-resolver.ts";
-import { ingestUkAisi } from "../third-party-evals/ingesters/uk-aisi-sitemap.ts";
-import { ingestMetr } from "../third-party-evals/ingesters/metr-rss.ts";
-import { ingestApollo } from "../third-party-evals/ingesters/apollo-research.ts";
-import { ingestCaisi } from "../third-party-evals/ingesters/caisi-blog.ts";
-import type { IngestResult } from "../third-party-evals/ingesters/types.ts";
+import { dispatchIngest } from "../third-party-evals/ingesters/dispatch.ts";
 import { backfillEvaluator } from "../third-party-evals/backfill.ts";
 
 interface ThirdPartyEvalOptions extends CommandOptions {
@@ -83,28 +79,6 @@ function resolveLlmModel(name?: string): string {
   return name;
 }
 
-async function ingesterFor(
-  evaluator: string,
-  options: ThirdPartyEvalOptions,
-): Promise<IngestResult> {
-  const key = evaluator.trim().toLowerCase();
-  if (key === "uk-aisi" || key === "ukaisi") {
-    return ingestUkAisi({ sinceDate: options.since });
-  }
-  if (key === "us-aisi" || key === "caisi" || key === "usaisi") {
-    return ingestCaisi();
-  }
-  if (key === "metr") {
-    return ingestMetr();
-  }
-  if (key === "apollo" || key === "apollo-research") {
-    return ingestApollo();
-  }
-  throw new Error(
-    `Unknown evaluator '${evaluator}'. Valid: uk-aisi, us-aisi, metr, apollo`,
-  );
-}
-
 async function ingestSubcommand(
   args: string[],
   options: ThirdPartyEvalOptions,
@@ -122,9 +96,9 @@ async function ingestSubcommand(
     };
   }
 
-  let result: IngestResult;
+  let result;
   try {
-    result = await ingesterFor(evaluator, options);
+    result = await dispatchIngest(evaluator, { since: options.since });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return { output: msg, exitCode: 1 };
@@ -377,13 +351,17 @@ async function backfillSubcommand(
     }
   }
 
-  const exitCode =
-    result.syncFailures.length > 0
-      ? 2
-      : result.extractFailures.length === result.candidates && result.candidates > 0
-        ? 2
-        : 0;
-  return { output: lines.join("\n"), exitCode };
+  return { output: lines.join("\n"), exitCode: backfillExitCode(result) };
+}
+
+function backfillExitCode(result: {
+  candidates: number;
+  extractFailures: unknown[];
+  syncFailures: unknown[];
+}): number {
+  if (result.syncFailures.length > 0) return 2;
+  if (result.candidates > 0 && result.extractFailures.length === result.candidates) return 2;
+  return 0;
 }
 
 /**

--- a/crux/commands/third-party-evals.ts
+++ b/crux/commands/third-party-evals.ts
@@ -53,6 +53,27 @@ interface ThirdPartyEvalOptions extends CommandOptions {
   dryRun?: boolean;
 }
 
+/**
+ * Parse a CLI numeric flag. Returns:
+ *   - undefined when the flag wasn't passed (caller falls back to default)
+ *   - Error with a usage message when the value is non-numeric or non-positive
+ *     (NaN would otherwise silently propagate to `pLimit(NaN)` and hang)
+ *   - the parsed positive integer otherwise
+ */
+function parsePositiveInt(
+  value: string | undefined,
+  flagName: string,
+): number | undefined | Error {
+  if (value === undefined) return undefined;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    return new Error(
+      `--${flagName} must be a positive integer (got '${value}')`,
+    );
+  }
+  return n;
+}
+
 function resolveLlmModel(name?: string): string {
   if (!name) return MODELS.haiku;
   const lower = name.toLowerCase();
@@ -300,13 +321,12 @@ async function backfillSubcommand(
     };
   }
 
-  const concurrency = options.concurrency
-    ? Math.max(1, parseInt(options.concurrency, 10))
-    : undefined;
-  const batchSize = options.batchSize
-    ? Math.max(1, parseInt(options.batchSize, 10))
-    : undefined;
-  const limit = options.limit ? Math.max(1, parseInt(options.limit, 10)) : undefined;
+  const concurrency = parsePositiveInt(options.concurrency, "concurrency");
+  if (concurrency instanceof Error) return { output: concurrency.message, exitCode: 1 };
+  const batchSize = parsePositiveInt(options.batchSize, "batch-size");
+  if (batchSize instanceof Error) return { output: batchSize.message, exitCode: 1 };
+  const limit = parsePositiveInt(options.limit, "limit");
+  if (limit instanceof Error) return { output: limit.message, exitCode: 1 };
 
   const result = await backfillEvaluator({
     evaluator,

--- a/crux/commands/third-party-evals.ts
+++ b/crux/commands/third-party-evals.ts
@@ -36,6 +36,7 @@ import { ingestMetr } from "../third-party-evals/ingesters/metr-rss.ts";
 import { ingestApollo } from "../third-party-evals/ingesters/apollo-research.ts";
 import { ingestCaisi } from "../third-party-evals/ingesters/caisi-blog.ts";
 import type { IngestResult } from "../third-party-evals/ingesters/types.ts";
+import { backfillEvaluator } from "../third-party-evals/backfill.ts";
 
 interface ThirdPartyEvalOptions extends CommandOptions {
   evaluator?: string;
@@ -46,6 +47,10 @@ interface ThirdPartyEvalOptions extends CommandOptions {
   sourceSystem?: "sitemap" | "rss" | "html-scrape" | "manual";
   maxSourceChars?: string;
   ci?: boolean;
+  concurrency?: string;
+  batchSize?: string;
+  limit?: string;
+  dryRun?: boolean;
 }
 
 function resolveLlmModel(name?: string): string {
@@ -274,9 +279,96 @@ async function extractSubcommand(
   return { output: lines.join("\n"), exitCode: 0 };
 }
 
+async function backfillSubcommand(
+  args: string[],
+  options: ThirdPartyEvalOptions,
+): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  const evaluator = args[0];
+  if (!evaluator) {
+    return {
+      output:
+        "Usage: crux tb third-party-evals backfill <uk-aisi|us-aisi|metr|apollo> --evaluator=<orgStableId> [--limit=N] [--concurrency=N] [--batch-size=N] [--since=YYYY-MM-DD] [--dry-run] [--model=haiku|sonnet]",
+      exitCode: 1,
+    };
+  }
+  if (!options.evaluator) {
+    return {
+      output:
+        "--evaluator=<orgStableId> is required (the stableId of the evaluator org entity).",
+      exitCode: 1,
+    };
+  }
+
+  const concurrency = options.concurrency
+    ? Math.max(1, parseInt(options.concurrency, 10))
+    : undefined;
+  const batchSize = options.batchSize
+    ? Math.max(1, parseInt(options.batchSize, 10))
+    : undefined;
+  const limit = options.limit ? Math.max(1, parseInt(options.limit, 10)) : undefined;
+
+  const result = await backfillEvaluator({
+    evaluator,
+    evaluatorOrgId: options.evaluator,
+    llmModel: resolveLlmModel(options.model),
+    concurrency,
+    batchSize,
+    limit,
+    since: options.since,
+    dryRun: Boolean(options.dryRun),
+    onProgress: (event) => {
+      if (event.kind === "extracted") {
+        log.dim(`  [${event.index}/${event.total}] ✓ ${event.url}`);
+      } else if (event.kind === "extract-error") {
+        log.warn(`  [${event.index}/${event.total}] ✗ ${event.url} — ${event.error}`);
+      } else if (event.kind === "synced") {
+        log.info(`  → synced batch ${event.batchIndex} (${event.count} rows)`);
+      } else {
+        log.error(`  → sync batch ${event.batchIndex} failed: ${event.error}`);
+      }
+    },
+  });
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`Backfill complete: ${result.evaluator}`);
+  lines.push(`  candidates:        ${result.candidates}`);
+  lines.push(`  extracted:         ${result.extracted}`);
+  lines.push(`  extract failures:  ${result.extractFailures.length}`);
+  lines.push(`  synced:            ${result.synced}${options.dryRun ? "  (dry-run, nothing posted)" : ""}`);
+  lines.push(`  sync failures:     ${result.syncFailures.length}`);
+  lines.push(`  duration:          ${(result.durationMs / 1000).toFixed(1)}s`);
+  if (result.extractFailures.length > 0) {
+    lines.push(``);
+    lines.push(`Extract failures:`);
+    for (const f of result.extractFailures.slice(0, 20)) {
+      lines.push(`  ${f.url}\n    ${f.error}`);
+    }
+    if (result.extractFailures.length > 20) {
+      lines.push(`  ... and ${result.extractFailures.length - 20} more`);
+    }
+  }
+  if (result.syncFailures.length > 0) {
+    lines.push(``);
+    lines.push(`Sync failures:`);
+    for (const f of result.syncFailures) {
+      lines.push(`  batch ${f.batchIndex}: ${f.error}`);
+    }
+  }
+
+  const exitCode =
+    result.syncFailures.length > 0
+      ? 2
+      : result.extractFailures.length === result.candidates && result.candidates > 0
+        ? 2
+        : 0;
+  return { output: lines.join("\n"), exitCode };
+}
+
 /**
  * Default dispatcher — reads the first positional arg as the
- * sub-subcommand verb and routes to ingest/extract.
+ * sub-subcommand verb and routes to ingest/extract/backfill.
  */
 async function defaultCommand(
   args: string[],
@@ -292,8 +384,11 @@ async function defaultCommand(
   if (verb === "extract") {
     return extractSubcommand(args.slice(1), options);
   }
+  if (verb === "backfill") {
+    return backfillSubcommand(args.slice(1), options);
+  }
   return {
-    output: `Unknown subcommand '${verb}'. Use 'ingest' or 'extract'.\n\n${getHelp()}`,
+    output: `Unknown subcommand '${verb}'. Use 'ingest', 'extract', or 'backfill'.\n\n${getHelp()}`,
     exitCode: 1,
   };
 }
@@ -304,6 +399,7 @@ export const commands: Record<
 > = {
   ingest: async (args, options) => ingestSubcommand(args, options),
   extract: async (args, options) => extractSubcommand(args, options),
+  backfill: async (args, options) => backfillSubcommand(args, options),
   default: defaultCommand,
 };
 
@@ -329,13 +425,25 @@ Subcommands:
                           --model=haiku|sonnet    LLM (default haiku)
                           --json                  raw JSON output
 
+  backfill <evaluator>  Ingest + extract + sync end-to-end (QUA-705)
+                          --evaluator=<orgId>     stableId of evaluator org (required)
+                          --concurrency=N         parallel extract calls (default 4)
+                          --batch-size=N          items per /sync POST (default 25)
+                          --limit=N               cap candidates (smoke test)
+                          --since=YYYY-MM-DD      skip older URLs (UK AISI only)
+                          --dry-run               extract but don't POST
+                          --model=haiku|sonnet    LLM (default haiku)
+
 Examples:
   crux tb third-party-evals ingest uk-aisi --since=2026-01-01
 
   crux tb third-party-evals extract https://www.aisi.gov.uk/blog/foo \\
       --evaluator=sid_aX0jkoaekQ --source-system=sitemap
 
-  crux tb third-party-evals extract https://metr.org/blog/bar \\
-      --evaluator=sid_rQEkFJxS5w --source-system=rss --apply
+  crux tb third-party-evals backfill uk-aisi --evaluator=sid_aX0jkoaekQ \\
+      --since=2025-01-01 --concurrency=4
+
+  crux tb third-party-evals backfill metr --evaluator=sid_rQEkFJxS5w \\
+      --limit=2 --dry-run
 `.trim();
 }

--- a/crux/third-party-evals/backfill.test.ts
+++ b/crux/third-party-evals/backfill.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the ingester modules and the extract/sync paths so the test runs
+// without network or LLM calls.
+vi.mock("./ingesters/uk-aisi-sitemap.ts", () => ({
+  ingestUkAisi: vi.fn(),
+}));
+vi.mock("./ingesters/metr-rss.ts", () => ({
+  ingestMetr: vi.fn(),
+}));
+vi.mock("./ingesters/apollo-research.ts", () => ({
+  ingestApollo: vi.fn(),
+}));
+vi.mock("./ingesters/caisi-blog.ts", () => ({
+  ingestCaisi: vi.fn(),
+}));
+vi.mock("./extract-eval-report.ts", () => ({
+  extractEvalReport: vi.fn(),
+  toSyncItem: vi.fn((extract: unknown, ctx: { id: string; reportUrl: string }) => ({
+    id: ctx.id,
+    reportUrl: ctx.reportUrl,
+  })),
+  EXTRACTOR_VERSION: "test@1.0",
+}));
+vi.mock("./span-verify.ts", () => ({
+  verifyExtractedReport: vi.fn(() => ({
+    verifiedReport: { modelsNamed: [] },
+    droppedFields: [],
+    ungroundedFields: [],
+    confidenceMap: {},
+  })),
+}));
+vi.mock("../lib/wiki-server/third-party-evaluations.ts", () => ({
+  syncThirdPartyEvaluations: vi.fn(),
+}));
+vi.mock("../lib/ai-model-resolver.ts", () => ({
+  resolveAiModel: vi.fn(() => []),
+}));
+
+import { ingestUkAisi } from "./ingesters/uk-aisi-sitemap.ts";
+import { ingestMetr } from "./ingesters/metr-rss.ts";
+import { extractEvalReport } from "./extract-eval-report.ts";
+import { syncThirdPartyEvaluations } from "../lib/wiki-server/third-party-evaluations.ts";
+import { backfillEvaluator } from "./backfill.ts";
+
+const makeCandidates = (n: number, prefix = "https://example.com/r") =>
+  Array.from({ length: n }, (_, i) => ({
+    url: `${prefix}${i}`,
+    title: `Report ${i}`,
+    publishedDate: null,
+    sourceSystem: "sitemap" as const,
+  }));
+
+const okExtract = {
+  report: {},
+  sourceText: "abc",
+  sourceFormat: "html",
+  sourceHash: "deadbeef",
+  waybackSnapshotUrl: null,
+  usage: { input_tokens: 10, output_tokens: 5 },
+  extractorVersion: "test@1.0",
+  extractionModel: "haiku",
+  extractedAt: "2026-04-25T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("backfillEvaluator", () => {
+  it("rejects unknown evaluator names", async () => {
+    await expect(
+      backfillEvaluator({
+        evaluator: "orange-aisi",
+        evaluatorOrgId: "sid_test12345",
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/Unknown evaluator/);
+  });
+
+  it("dispatches uk-aisi → ingestUkAisi (passing --since)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: [],
+      errors: [],
+    });
+    await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      since: "2025-01-01",
+      dryRun: true,
+    });
+    expect(vi.mocked(ingestUkAisi)).toHaveBeenCalledWith({ sinceDate: "2025-01-01" });
+  });
+
+  it("dispatches metr → ingestMetr", async () => {
+    vi.mocked(ingestMetr).mockResolvedValue({
+      evaluator: "metr",
+      candidates: [],
+      errors: [],
+    });
+    await backfillEvaluator({
+      evaluator: "metr",
+      evaluatorOrgId: "sid_rQEkFJxS5w",
+      dryRun: true,
+    });
+    expect(vi.mocked(ingestMetr)).toHaveBeenCalledOnce();
+  });
+
+  it("respects --limit by capping candidates passed to extract", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(20),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      limit: 3,
+      dryRun: true,
+    });
+
+    expect(result.candidates).toBe(3);
+    expect(result.extracted).toBe(3);
+    expect(vi.mocked(extractEvalReport)).toHaveBeenCalledTimes(3);
+  });
+
+  it("dryRun=true skips sync (no /sync POST)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(2),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      dryRun: true,
+    });
+
+    expect(result.extracted).toBe(2);
+    expect(result.synced).toBe(0);
+    expect(vi.mocked(syncThirdPartyEvaluations)).not.toHaveBeenCalled();
+  });
+
+  it("posts to /sync when dryRun is false, batched by batchSize", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(7),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    } as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      batchSize: 3,
+    });
+
+    expect(result.extracted).toBe(7);
+    expect(result.synced).toBe(7);
+    // 7 items / batch of 3 = 3 calls (3, 3, 1)
+    expect(vi.mocked(syncThirdPartyEvaluations)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(syncThirdPartyEvaluations).mock.calls[0][0]).toHaveLength(3);
+    expect(vi.mocked(syncThirdPartyEvaluations).mock.calls[2][0]).toHaveLength(1);
+  });
+
+  it("collects extract failures without aborting the run", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(3),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport)
+      .mockResolvedValueOnce(okExtract as never)
+      .mockRejectedValueOnce(new Error("LLM 502"))
+      .mockResolvedValueOnce(okExtract as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      dryRun: true,
+    });
+
+    expect(result.candidates).toBe(3);
+    expect(result.extracted).toBe(2);
+    expect(result.extractFailures).toHaveLength(1);
+    expect(result.extractFailures[0].error).toContain("LLM 502");
+  });
+
+  it("collects sync failures without aborting later batches", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(4),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(syncThirdPartyEvaluations)
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "SERVER_ERROR",
+        message: "boom",
+      } as never)
+      .mockResolvedValueOnce({
+        ok: true,
+        data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+      } as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      batchSize: 2,
+    });
+
+    expect(result.synced).toBe(2); // only the 2nd batch succeeded
+    expect(result.syncFailures).toHaveLength(1);
+    expect(result.syncFailures[0].error).toContain("boom");
+  });
+
+  it("emits onProgress events for extract and sync", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(2),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport)
+      .mockResolvedValueOnce(okExtract as never)
+      .mockRejectedValueOnce(new Error("nope"));
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    } as never);
+
+    const events: string[] = [];
+    await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      onProgress: (e) => events.push(e.kind),
+    });
+
+    expect(events).toContain("extracted");
+    expect(events).toContain("extract-error");
+    expect(events).toContain("synced");
+  });
+});

--- a/crux/third-party-evals/backfill.test.ts
+++ b/crux/third-party-evals/backfill.test.ts
@@ -205,7 +205,7 @@ describe("backfillEvaluator", () => {
     vi.mocked(syncThirdPartyEvaluations)
       .mockResolvedValueOnce({
         ok: false,
-        error: "SERVER_ERROR",
+        error: "server_error",
         message: "boom",
       } as never)
       .mockResolvedValueOnce({
@@ -222,6 +222,92 @@ describe("backfillEvaluator", () => {
     expect(result.synced).toBe(2); // only the 2nd batch succeeded
     expect(result.syncFailures).toHaveLength(1);
     expect(result.syncFailures[0].error).toContain("boom");
+  });
+
+  it("handles zero-candidates input cleanly (no extract/sync calls)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: [],
+      errors: [],
+    });
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+    });
+
+    expect(result.candidates).toBe(0);
+    expect(result.extracted).toBe(0);
+    expect(result.synced).toBe(0);
+    expect(vi.mocked(extractEvalReport)).not.toHaveBeenCalled();
+    expect(vi.mocked(syncThirdPartyEvaluations)).not.toHaveBeenCalled();
+  });
+
+  it("handles exact batch-size boundary (no spurious empty trailing batch)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(6),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    } as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      batchSize: 3,
+    });
+
+    expect(result.synced).toBe(6);
+    // 6 / 3 = 2 batches exactly — no third call with empty array
+    expect(vi.mocked(syncThirdPartyEvaluations)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(syncThirdPartyEvaluations).mock.calls[0][0]).toHaveLength(3);
+    expect(vi.mocked(syncThirdPartyEvaluations).mock.calls[1][0]).toHaveLength(3);
+  });
+
+  it("handles multiple consecutive sync-batch failures", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(6),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: false,
+      error: "unavailable",
+      message: "wiki-server down",
+    } as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      batchSize: 2,
+    });
+
+    expect(result.synced).toBe(0);
+    expect(result.syncFailures).toHaveLength(3);
+    expect(result.syncFailures.map((f) => f.batchIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("serial concurrency=1 still works", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(3),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+
+    const result = await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      concurrency: 1,
+      dryRun: true,
+    });
+
+    expect(result.extracted).toBe(3);
   });
 
   it("emits onProgress events for extract and sync", async () => {

--- a/crux/third-party-evals/backfill.ts
+++ b/crux/third-party-evals/backfill.ts
@@ -1,0 +1,257 @@
+/**
+ * Third-party-evals backfill driver (QUA-705).
+ *
+ * Wraps the existing `ingest` + `extract` + sync flow into a single batch
+ * pass over an evaluator's published reports. Each candidate URL goes
+ * through:
+ *
+ *   1. `extractEvalReport()` — LLM extraction with span verification
+ *   2. `resolveAiModel()`     — match every named model against entities
+ *   3. `toSyncItem()`         — build the wiki-server sync payload
+ *   4. `syncThirdPartyEvaluations()` (batched) — POST to /api/.../sync
+ *
+ * Concurrency is capped (default 4) for the extract step. Sync items are
+ * batched (default 25 per request) to stay well under the 500-item limit
+ * and amortize HTTP/rate-limit overhead. Errors are non-fatal — failed
+ * extractions are logged and skipped, succeeded items still ship.
+ */
+import { generateId } from "../lib/grant-import/id.ts";
+import { resolveAiModel } from "../lib/ai-model-resolver.ts";
+import { syncThirdPartyEvaluations } from "../lib/wiki-server/third-party-evaluations.ts";
+import {
+  extractEvalReport,
+  toSyncItem,
+} from "./extract-eval-report.ts";
+import { verifyExtractedReport } from "./span-verify.ts";
+import {
+  ingestUkAisi,
+} from "./ingesters/uk-aisi-sitemap.ts";
+import { ingestMetr } from "./ingesters/metr-rss.ts";
+import { ingestApollo } from "./ingesters/apollo-research.ts";
+import { ingestCaisi } from "./ingesters/caisi-blog.ts";
+import type {
+  IngestCandidate,
+  IngestResult,
+} from "./ingesters/types.ts";
+
+export interface BackfillOptions {
+  /** Evaluator key — uk-aisi | metr | apollo | caisi (us-aisi). */
+  evaluator: string;
+  /** stableId of the evaluator org entity (required). */
+  evaluatorOrgId: string;
+  /** LLM model. Default haiku (cheap; reports are short). */
+  llmModel?: string;
+  /** Max parallel extract calls. Default 4. */
+  concurrency?: number;
+  /** Items per /sync POST. Default 25 (sync schema caps at 500). */
+  batchSize?: number;
+  /** Skip URLs older than this date (UK AISI sitemap only). */
+  since?: string;
+  /** Dry run — don't POST to /sync. */
+  dryRun?: boolean;
+  /** Cap candidates (for smoke testing). */
+  limit?: number;
+  /** Per-URL progress callback. */
+  onProgress?: (event: BackfillProgress) => void;
+}
+
+export type BackfillProgress =
+  | { kind: "extracted"; url: string; index: number; total: number }
+  | { kind: "extract-error"; url: string; error: string; index: number; total: number }
+  | { kind: "synced"; count: number; batchIndex: number }
+  | { kind: "sync-error"; error: string; batchIndex: number };
+
+export interface BackfillResult {
+  evaluator: string;
+  candidates: number;
+  extracted: number;
+  extractFailures: Array<{ url: string; error: string }>;
+  synced: number;
+  syncFailures: Array<{ batchIndex: number; error: string }>;
+  durationMs: number;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_BATCH_SIZE = 25;
+
+/**
+ * Map evaluator key → ingester. Mirrors the same dispatch in the CLI.
+ */
+async function ingestFor(
+  evaluator: string,
+  options: BackfillOptions,
+): Promise<IngestResult> {
+  const key = evaluator.trim().toLowerCase();
+  if (key === "uk-aisi" || key === "ukaisi") {
+    return ingestUkAisi({ sinceDate: options.since });
+  }
+  if (key === "us-aisi" || key === "caisi" || key === "usaisi") {
+    return ingestCaisi();
+  }
+  if (key === "metr") return ingestMetr();
+  if (key === "apollo" || key === "apollo-research") return ingestApollo();
+  throw new Error(
+    `Unknown evaluator '${evaluator}'. Valid: uk-aisi, us-aisi, metr, apollo`,
+  );
+}
+
+/**
+ * Minimal concurrency limiter — same shape used in citation-auditor.ts.
+ * Avoids pulling in p-limit as a dependency.
+ */
+function pLimit(concurrencyLimit: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  function next() {
+    if (queue.length > 0 && active < concurrencyLimit) {
+      active++;
+      queue.shift()!();
+    }
+  }
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = () => {
+        fn()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      };
+      queue.push(run);
+      next();
+    });
+}
+
+/**
+ * Extract one candidate. Returns a sync item ready to POST, or
+ * `{ url, error }` if extraction failed.
+ */
+async function extractOne(
+  candidate: IngestCandidate,
+  options: BackfillOptions,
+): Promise<
+  | { kind: "ok"; item: Record<string, unknown> }
+  | { kind: "err"; url: string; error: string }
+> {
+  try {
+    const extract = await extractEvalReport({
+      url: candidate.url,
+      evaluatorOrgId: options.evaluatorOrgId,
+      llmModel: options.llmModel,
+    });
+
+    const verify = verifyExtractedReport(extract.report, extract.sourceText);
+
+    const modelLinks = verify.verifiedReport.modelsNamed
+      .map((rawName) => {
+        const top = resolveAiModel(rawName, { maxResults: 1 })[0];
+        if (!top) return null;
+        return {
+          aiModelId: top.stableId,
+          aiModelDisplayName: top.title,
+          rawNameInReport: rawName,
+          matchConfidence: top.matchConfidence,
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+
+    const id = generateId(`third-party-eval:${candidate.url}:${extract.sourceHash}`);
+    const item = toSyncItem(extract, {
+      id,
+      evaluatorOrgId: options.evaluatorOrgId,
+      reportUrl: candidate.url,
+      sourceSystem: candidate.sourceSystem,
+      models: modelLinks,
+      confidenceMap: verify.confidenceMap,
+    });
+
+    return { kind: "ok", item };
+  } catch (e) {
+    return {
+      kind: "err",
+      url: candidate.url,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * Backfill a single evaluator end-to-end. See BackfillOptions for knobs.
+ */
+export async function backfillEvaluator(
+  options: BackfillOptions,
+): Promise<BackfillResult> {
+  const start = Date.now();
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const onProgress = options.onProgress ?? (() => {});
+
+  const ingest = await ingestFor(options.evaluator, options);
+  let candidates = ingest.candidates;
+  if (options.limit != null && options.limit > 0) {
+    candidates = candidates.slice(0, options.limit);
+  }
+  const total = candidates.length;
+
+  // Extract phase — concurrent.
+  const limit = pLimit(concurrency);
+  const items: Array<Record<string, unknown>> = [];
+  const extractFailures: Array<{ url: string; error: string }> = [];
+
+  await Promise.all(
+    candidates.map((c, idx) =>
+      limit(async () => {
+        const r = await extractOne(c, options);
+        if (r.kind === "ok") {
+          items.push(r.item);
+          onProgress({ kind: "extracted", url: c.url, index: idx + 1, total });
+        } else {
+          extractFailures.push({ url: r.url, error: r.error });
+          onProgress({
+            kind: "extract-error",
+            url: r.url,
+            error: r.error,
+            index: idx + 1,
+            total,
+          });
+        }
+      }),
+    ),
+  );
+
+  // Sync phase — batched.
+  let synced = 0;
+  const syncFailures: Array<{ batchIndex: number; error: string }> = [];
+  if (!options.dryRun) {
+    for (let i = 0; i < items.length; i += batchSize) {
+      const chunk = items.slice(i, i + batchSize);
+      const batchIndex = Math.floor(i / batchSize);
+      const r = await syncThirdPartyEvaluations(chunk);
+      if (r.ok) {
+        synced += chunk.length;
+        onProgress({ kind: "synced", count: chunk.length, batchIndex });
+      } else {
+        syncFailures.push({
+          batchIndex,
+          error: `${r.error}: ${r.message}`,
+        });
+        onProgress({
+          kind: "sync-error",
+          error: `${r.error}: ${r.message}`,
+          batchIndex,
+        });
+      }
+    }
+  }
+
+  return {
+    evaluator: ingest.evaluator,
+    candidates: total,
+    extracted: items.length,
+    extractFailures,
+    synced,
+    syncFailures,
+    durationMs: Date.now() - start,
+  };
+}

--- a/crux/third-party-evals/backfill.ts
+++ b/crux/third-party-evals/backfill.ts
@@ -1,19 +1,10 @@
 /**
  * Third-party-evals backfill driver (QUA-705).
  *
- * Wraps the existing `ingest` + `extract` + sync flow into a single batch
- * pass over an evaluator's published reports. Each candidate URL goes
- * through:
- *
- *   1. `extractEvalReport()` — LLM extraction with span verification
- *   2. `resolveAiModel()`     — match every named model against entities
- *   3. `toSyncItem()`         — build the wiki-server sync payload
- *   4. `syncThirdPartyEvaluations()` (batched) — POST to /api/.../sync
- *
- * Concurrency is capped (default 4) for the extract step. Sync items are
- * batched (default 25 per request) to stay well under the 500-item limit
- * and amortize HTTP/rate-limit overhead. Errors are non-fatal — failed
- * extractions are logged and skipped, succeeded items still ship.
+ * Errors are non-fatal: failed extractions are logged and skipped so a single
+ * bad source doesn't waste the LLM spend on the rest of the batch; failed sync
+ * batches don't abort later batches so a transient wiki-server hiccup doesn't
+ * lose previous progress.
  */
 import { generateId } from "../lib/grant-import/id.ts";
 import { resolveAiModel } from "../lib/ai-model-resolver.ts";
@@ -23,16 +14,8 @@ import {
   toSyncItem,
 } from "./extract-eval-report.ts";
 import { verifyExtractedReport } from "./span-verify.ts";
-import {
-  ingestUkAisi,
-} from "./ingesters/uk-aisi-sitemap.ts";
-import { ingestMetr } from "./ingesters/metr-rss.ts";
-import { ingestApollo } from "./ingesters/apollo-research.ts";
-import { ingestCaisi } from "./ingesters/caisi-blog.ts";
-import type {
-  IngestCandidate,
-  IngestResult,
-} from "./ingesters/types.ts";
+import { dispatchIngest } from "./ingesters/dispatch.ts";
+import type { IngestCandidate } from "./ingesters/types.ts";
 
 export interface BackfillOptions {
   /** Evaluator key — uk-aisi | metr | apollo | caisi (us-aisi). */
@@ -74,31 +57,8 @@ export interface BackfillResult {
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_BATCH_SIZE = 25;
 
-/**
- * Map evaluator key → ingester. Mirrors the same dispatch in the CLI.
- */
-async function ingestFor(
-  evaluator: string,
-  options: BackfillOptions,
-): Promise<IngestResult> {
-  const key = evaluator.trim().toLowerCase();
-  if (key === "uk-aisi" || key === "ukaisi") {
-    return ingestUkAisi({ sinceDate: options.since });
-  }
-  if (key === "us-aisi" || key === "caisi" || key === "usaisi") {
-    return ingestCaisi();
-  }
-  if (key === "metr") return ingestMetr();
-  if (key === "apollo" || key === "apollo-research") return ingestApollo();
-  throw new Error(
-    `Unknown evaluator '${evaluator}'. Valid: uk-aisi, us-aisi, metr, apollo`,
-  );
-}
-
-/**
- * Minimal concurrency limiter — same shape used in citation-auditor.ts.
- * Avoids pulling in p-limit as a dependency.
- */
+// Same shape as crux/lib/citation/citation-auditor.ts::pLimit. Two callers
+// today; if a third appears, extract to crux/lib/.
 function pLimit(concurrencyLimit: number) {
   let active = 0;
   const queue: Array<() => void> = [];
@@ -187,7 +147,7 @@ export async function backfillEvaluator(
   const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
   const onProgress = options.onProgress ?? (() => {});
 
-  const ingest = await ingestFor(options.evaluator, options);
+  const ingest = await dispatchIngest(options.evaluator, { since: options.since });
   let candidates = ingest.candidates;
   if (options.limit != null && options.limit > 0) {
     candidates = candidates.slice(0, options.limit);
@@ -232,15 +192,9 @@ export async function backfillEvaluator(
         synced += chunk.length;
         onProgress({ kind: "synced", count: chunk.length, batchIndex });
       } else {
-        syncFailures.push({
-          batchIndex,
-          error: `${r.error}: ${r.message}`,
-        });
-        onProgress({
-          kind: "sync-error",
-          error: `${r.error}: ${r.message}`,
-          batchIndex,
-        });
+        const errorMsg = `${r.error}: ${r.message}`;
+        syncFailures.push({ batchIndex, error: errorMsg });
+        onProgress({ kind: "sync-error", error: errorMsg, batchIndex });
       }
     }
   }

--- a/crux/third-party-evals/ingesters/dispatch.ts
+++ b/crux/third-party-evals/ingesters/dispatch.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared evaluator → ingester dispatch (QUA-705).
+ *
+ * Used by both `crux tb third-party-evals ingest` and `crux tb third-party-evals
+ * backfill`. Adding a 5th evaluator requires touching one place.
+ */
+import { ingestUkAisi } from "./uk-aisi-sitemap.ts";
+import { ingestMetr } from "./metr-rss.ts";
+import { ingestApollo } from "./apollo-research.ts";
+import { ingestCaisi } from "./caisi-blog.ts";
+import type { IngestResult } from "./types.ts";
+
+export const VALID_EVALUATORS = [
+  "uk-aisi",
+  "us-aisi",
+  "metr",
+  "apollo",
+] as const;
+
+export type EvaluatorKey = (typeof VALID_EVALUATORS)[number];
+
+export interface DispatchOptions {
+  since?: string;
+}
+
+export async function dispatchIngest(
+  evaluator: string,
+  options: DispatchOptions = {},
+): Promise<IngestResult> {
+  const key = evaluator.trim().toLowerCase();
+  if (key === "uk-aisi" || key === "ukaisi") {
+    return ingestUkAisi({ sinceDate: options.since });
+  }
+  if (key === "us-aisi" || key === "caisi" || key === "usaisi") {
+    return ingestCaisi();
+  }
+  if (key === "metr") return ingestMetr();
+  if (key === "apollo" || key === "apollo-research") return ingestApollo();
+  throw new Error(
+    `Unknown evaluator '${evaluator}'. Valid: ${VALID_EVALUATORS.join(", ")}`,
+  );
+}


### PR DESCRIPTION
## Summary

Builds the backfill driver for Phase 5 (third-party evaluation index). Wraps the existing ingest + extract + sync pipeline into a single end-to-end command:

```bash
pnpm crux tb third-party-evals backfill <evaluator> --evaluator=<orgStableId> \
    [--limit=N] [--concurrency=N] [--batch-size=N] [--since=YYYY-MM-DD] [--dry-run]
```

The driver routes to the matching ingester (UK AISI / METR / Apollo / CAISI) via the new shared `dispatchIngest()` helper, extracts each candidate URL via the LLM with a configurable concurrency cap (default 4), batches the resulting sync items (default 25 per `/sync` POST), and reports per-URL outcomes plus a summary. Errors are non-fatal — extract failures don't abort the run, sync failures don't abort later batches.

## Status — execution blocked on QUA-692 merging

**This PR ships only the driver.** The actual backfill runs cannot proceed until PR #4595 (QUA-692) merges and deploys, because prod `/api/third-party-evaluations/sync` currently returns 404 (route doesn't exist on prod yet). Verified empirically:

```
$ pnpm crux tb third-party-evals backfill caisi --evaluator=sid_pKeaWwP6sQ --limit=1
  [1/1] ✓ https://www.nist.gov/blogs/caisi-research-blog/insights-…
  → sync batch 0 failed: bad_request: 404: 404 Not Found
```

PR #4595 also has merge conflicts (`mergeStateStatus: DIRTY`) that need to be resolved first.

This PR is **stacked on `claude/qua-692-third-party-eval-index`** and targets that branch as its base. Once QUA-692 lands, this rebases cleanly onto main and a coordinator can execute the backfill (see the manual deploy task below).

## Smoke test (dry-run)

```
$ pnpm crux tb third-party-evals backfill caisi --evaluator=sid_pKeaWwP6sQ --dry-run --limit=2
  [1/2] ✓ https://…/insights-ai-agent-security-large-scale-red-teaming-competition
  [2/2] ✓ https://…/analyzing-transcripts-ai-agent-evaluations
Backfill complete: us-aisi
  candidates: 2  extracted: 2  duration: 6.2s
```

Ingest counts (verified): **UK AISI 107, METR 75, Apollo 24, CAISI 4 → 210 total** (matches the ~200 estimate).

## Review trail

- `/agent-review-pr` (hostile-reviewer pass) → 2 HIGH bugs found and fixed:
  - `parseInt("abc")` → `NaN` → `pLimit(NaN)` would silently hang. Added `parsePositiveInt()` that rejects non-numeric flag values with a usage error.
  - Test mock used `"SERVER_ERROR"` (uppercase) but real `ApiError` is lowercase. Fixed.
  - Added 4 edge-case tests (zero-candidates, exact batch boundary, multiple sync failures, concurrency=1).
  - Filed QUA-713 as a follow-up for `generateId(url:sourceHash)` → cosmetic source changes break upsert (matches existing extract path; out of scope for QUA-705).
- `/simplify` pass → 5 simplifications applied:
  - Extracted shared `dispatchIngest()` helper (was duplicated 4-way dispatch in `ingestSubcommand` and `backfillEvaluator`)
  - `EvaluatorKey` union type + `VALID_EVALUATORS` const
  - Hoisted duplicated `${error}: ${message}` string
  - Replaced nested-ternary exit code with named `backfillExitCode()` helper
  - Trimmed WHAT-comment header to WHY-only

## Files

- `crux/third-party-evals/backfill.ts` (NEW, 196 LOC) — `backfillEvaluator()`
- `crux/third-party-evals/backfill.test.ts` (NEW, 339 LOC) — 13 unit tests
- `crux/third-party-evals/ingesters/dispatch.ts` (NEW, 43 LOC) — shared 4-way dispatch
- `crux/commands/third-party-evals.ts` — adds `backfill` subcommand + `parsePositiveInt` helper; `ingestSubcommand` now uses `dispatchIngest`
- `crux/commands/third-party-evals.test.ts` — adds 7 CLI tests (dispatch, NaN-rejection)

## Test plan

- [x] Unit tests: `pnpm vitest run crux/third-party-evals/ crux/commands/third-party-evals.test.ts` — 78 passed
- [x] Build: `pnpm build` — green
- [x] Gate: `pnpm crux w validate gate --fix` — all 53 checks pass
- [x] Smoke test (dry-run): see above
- [x] Smoke test (--apply against prod): confirms 404 (expected — endpoint not deployed)
- [x] Smoke test (`ingest` subcommand still works after `dispatchIngest` refactor): CAISI returned 4 candidates
- [ ] Live backfill execution — blocked on QUA-692 merge (see manual deploy task)

Closes QUA-705 (driver delivery — full backfill execution will land as a follow-up after QUA-692 merges and prod deploys).

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0209 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New API route "third-party-evaluations" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/third-party-evaluations/stats" -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" -o /dev/null -w "%{http_code}"`
- [ ] `manual` Run the four backfill commands end-to-end now that the route exists. Expect ~210 rows total. `pnpm crux tb third-party-evals backfill caisi --evaluator=sid_pKeaWwP6sQ` then apollo / metr / uk-aisi (see QUA-705 Linear comment for verified org stableIds and concurrency knobs)
- [ ] `manual` Spot-check 5 rows in `/internal/entity-source-checks` and via `pnpm crux tb third-party-evals ingest --json` — verify titles, models linked, and risk_domain populated. If extraction quality looks off, file follow-ups before running larger batches.
<!-- /deploy-tasks -->
