### PR TITLE
fix(jobs): register claim-sourcing handler (QUA-699)

### DIFF
--- a/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
+++ b/apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx
@@ -65,7 +65,7 @@ const entries: AutomationEntry[] = [
     type: "GHA (scheduled + dispatch)",
     schedule: "Every 30 min + on-demand dispatch",
     description:
-      "Polls wiki-server job queue, claims and executes jobs. Types: ping, citation-verify, page-improve, page-create, batch-commit, auto-update-digest, claim-verification, resource-ingest, resource-enrich.",
+      "Polls wiki-server job queue, claims and executes jobs. Types: ping, citation-verify, page-improve, page-create, batch-commit, auto-update-digest, claim-sourcing, resource-ingest, resource-enrich.",
     status: "active",
     file: "job-worker.yml",
   },

--- a/crux/health/checks/job-queue.test.ts
+++ b/crux/health/checks/job-queue.test.ts
@@ -65,7 +65,7 @@ describe('issue #3692: resource-ingest 59% failure + 146 pending', () => {
       totalJobs: 8155,
       hours: 48,
       byType: {
-        'claim-verification': makeStats({ pending: 0, running: 0, failed: 0, failureRate: 0, recentTotal: 5, recentFailed: 0 }), // server-side job type name
+        'claim-sourcing': makeStats({ pending: 0, running: 0, failed: 0, failureRate: 0, recentTotal: 5, recentFailed: 0 }), // server-side job type name
         'ping': makeStats({ pending: 0, running: 0, failed: 0, failureRate: 0, recentTotal: 2, recentFailed: 0 }),
         'resource-enrich': makeStats({ pending: 0, running: 0, failed: 0, failureRate: 0, recentTotal: 3, recentFailed: 0 }),
         'resource-ingest': makeStats({

--- a/crux/lib/job-handlers/claim-sourcing.ts
+++ b/crux/lib/job-handlers/claim-sourcing.ts
@@ -1,7 +1,7 @@
 /**
  * Claim Source-Check Job Handler
  *
- * Processes `claim-verification` jobs (server-side job type name) created by POST /api/claims/propose.
+ * Processes `claim-sourcing` jobs (server-side job type name) created by POST /api/claims/propose.
  * Each job verifies a batch of claims against a shared resource's content.
  *
  * Flow:

--- a/crux/lib/job-handlers/index.ts
+++ b/crux/lib/job-handlers/index.ts
@@ -87,8 +87,7 @@ const handlers: Record<string, JobHandler> = {
     (await import('./auto-update-digest.ts')).handleAutoUpdateDigest),
 
   // Claims-first sourcing (#3253) — lazy to avoid Anthropic SDK cycle
-  // Note: job type key 'claim-verification' matches the server-side job type name
-  'claim-verification': lazyHandler(async () =>
+  'claim-sourcing': lazyHandler(async () =>
     (await import('./claim-sourcing.ts')).handleClaimSourcing),
 
   // Resource ingestion: fetch, cache content, persist metadata (#3209)

--- a/crux/lib/job-handlers/job-handlers.test.ts
+++ b/crux/lib/job-handlers/job-handlers.test.ts
@@ -36,8 +36,18 @@ describe('job-handlers/index', () => {
     expect(types).toContain('page-create');
     expect(types).toContain('batch-commit');
     expect(types).toContain('auto-update-digest');
+    expect(types).toContain('claim-sourcing');
     expect(types).toContain('resource-ingest');
     expect(types).toContain('resource-enrich');
+  });
+
+  // QUA-699: server-side job type was renamed claim-verification → claim-sourcing
+  // in QUA-237 but the handler registry was missed, causing 100% failure on every
+  // claim-sourcing job ("Unknown job type: claim-sourcing").
+  it('dispatches the server-side claim-sourcing job type to a handler', async () => {
+    const { getHandler, isKnownType } = await import('./index.ts');
+    expect(isKnownType('claim-sourcing')).toBe(true);
+    expect(typeof getHandler('claim-sourcing')).toBe('function');
   });
 
   it('isKnownType returns true for registered types', async () => {


### PR DESCRIPTION
## Summary

The QUA-237 rename (`claim-verification` → `claim-sourcing`, commit `acf8a120a`) renamed the server-side job type but missed the handler registry in `crux/lib/job-handlers/index.ts`. Workers claimed `claim-sourcing` jobs, the dispatcher returned `undefined`, and every job failed with `Unknown job type: claim-sourcing. Known types: ping, citation-verify, page-improve, page-create, batch-commit, auto-update-digest, claim-verification, resource-ingest, resource-enrich, resource-verify`.

The wellness probe has been firing for 5 days; 424 claim-sourcing jobs failed in the last 48h alone (100% failure rate). The resource-enrich "100% failure rate" alert from QUA-676 was small-sample noise (7 jobs in 48h, all genuine but unrelated failures: Anthropic credit, validation, missing resources); resource-enrich currently sits at 1% failure.

## Key changes

- `crux/lib/job-handlers/index.ts` — rename handler key from `claim-verification` to `claim-sourcing` to match the server-side enqueue in `apps/wiki-server/src/routes/claims/claims.ts:235`. No legacy alias kept: zero pending `claim-verification` jobs (all 28 historical ones completed).
- `crux/lib/job-handlers/job-handlers.test.ts` — regression test asserting `claim-sourcing` is dispatchable. This test would have caught the original miss.
- `crux/health/checks/job-queue.test.ts`, `crux/lib/job-handlers/claim-sourcing.ts`, `apps/web/src/app/internal/automation-landscape/automation-landscape-content.tsx` — update three stale `claim-verification` references that the rename also missed (test fixture, JSDoc, user-visible UI text).

## Verification

Confirmed via prod query:
```
$ curl /api/jobs?status=failed&type=claim-sourcing
"error": "Unknown job type: claim-sourcing. Known types: ping, citation-verify, ..."
```

After this PR merges, the next scheduled GHA worker run will pick up the new code (workers `actions/checkout` main on each invocation; no separate deploy step). Wellness should return to passing within a polling cycle.

## Test plan

- [x] Build (`apps/web` tsc + `apps/wiki-server` tsc, both clean)
- [x] Tests (`pnpm vitest run crux/lib/job-handlers/ crux/health/checks/job-queue.test.ts` — 139/139 pass; new regression test included)
- [x] Gate (`pnpm crux w validate gate --fix` — 51/51 pass, 3 advisory pre-existing)
- [x] `/agent-review-pr` (SHA + diff hash match HEAD)
- [ ] Post-merge: confirm `pnpm crux health` reports `claim-sourcing` PASS within 1h of next worker run

Fixes QUA-699
