### PR TITLE
feat(QUA-697): FMTI ingester (CC-BY-4.0 CSV from GitHub) — stacked on #4589

### DIFF
--- a/crux/commands/scorecards.ts
+++ b/crux/commands/scorecards.ts
@@ -1,0 +1,216 @@
+/**
+ * Scorecards Command Handlers
+ *
+ * Ingest external safety-scorecard data into the Phase 1 (QUA-688)
+ * `scorecard_snapshots` + `scorecard_grades` PG tables.
+ *
+ * Usage:
+ *   crux scorecards fmti ingest [--wave=WAVE] [--dry-run] [--ensure-stubs]
+ *   crux scorecards list                 List configured FMTI waves
+ */
+
+import type {
+  CommandOptions as BaseOptions,
+  CommandResult,
+} from "../lib/command-types.ts";
+import {
+  FMTI_WAVES,
+  type FmtiWave,
+} from "../lib/scorecards/fmti.ts";
+import {
+  ingestFmtiWaves,
+  type IngestResult,
+} from "../lib/scorecards/fmti-ingest.ts";
+
+interface CommandOptions extends BaseOptions {
+  wave?: string;
+  dryRun?: boolean;
+  ensureStubs?: boolean;
+  ci?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+async function listCommand(
+  _args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify({ waves: FMTI_WAVES }, null, 2),
+    };
+  }
+  const lines = [
+    "FMTI Waves (Stanford CRFM):",
+    "",
+    ...FMTI_WAVES.map(formatWaveRow),
+  ];
+  return { exitCode: 0, output: lines.join("\n") };
+}
+
+function formatWaveRow(w: FmtiWave): string {
+  return `  ${w.snapshotId}  ${w.publishedAt}  ${w.waveLabel}`;
+}
+
+async function fmtiCommand(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const subcommand = args[0];
+  if (subcommand === "ingest") {
+    return fmtiIngestCommand(args.slice(1), options);
+  }
+  if (!subcommand || subcommand === "list" || subcommand === "--help") {
+    return listCommand(args, options);
+  }
+  return {
+    exitCode: 1,
+    output: `Unknown subcommand: ${subcommand}\n\nUsage:\n  crux scorecards fmti list\n  crux scorecards fmti ingest [--wave=ID] [--dry-run] [--ensure-stubs]`,
+  };
+}
+
+async function fmtiIngestCommand(
+  _args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun;
+  const waveId = options.wave;
+
+  if (waveId && !FMTI_WAVES.some((w) => w.snapshotId === waveId)) {
+    return {
+      exitCode: 1,
+      output: [
+        `Unknown wave: "${waveId}"`,
+        `Known waves: ${FMTI_WAVES.map((w) => w.snapshotId).join(", ")}`,
+      ].join("\n"),
+    };
+  }
+
+  const result = await ingestFmtiWaves({
+    waveId,
+    dryRun,
+    ensureStubEntities: !!options.ensureStubs,
+  });
+
+  if (options.ci) {
+    return { exitCode: result.errors.length ? 1 : 0, output: JSON.stringify(result, null, 2) };
+  }
+
+  return formatHumanReadable(result, dryRun);
+}
+
+function formatHumanReadable(result: IngestResult, dryRun: boolean): CommandResult {
+  const lines: string[] = [];
+  lines.push("FMTI Ingest");
+  lines.push(dryRun ? "Mode: DRY RUN (no data synced)" : "Mode: LIVE");
+  lines.push("");
+
+  for (const w of result.waves) {
+    lines.push(`--- ${w.snapshot.waveLabel} (${w.waveId}) ---`);
+    lines.push(`  Published:        ${w.snapshot.publishedAt}`);
+    lines.push(`  isLatest:         ${w.snapshot.isLatest ? "yes" : "no"}`);
+    lines.push(`  Resolved orgs:    ${w.resolvedOrgs}`);
+    if (w.unresolvedOrgs.length > 0) {
+      lines.push(`  Unresolved orgs:  ${w.unresolvedOrgs.join(", ")}`);
+      lines.push(
+        "    (re-run with --ensure-stubs to create lightweight stub entities, or add overrides to data/scorecards/fmti-org-overrides.yaml)",
+      );
+    }
+    lines.push(`  Grade rows:       ${w.gradeCount}`);
+    for (const warning of w.warnings) {
+      lines.push(`  Warning: ${warning}`);
+    }
+    if (!dryRun && w.syncResult) {
+      lines.push(
+        `  Sync: snapshot=${w.syncResult.snapshots}, grades=${w.syncResult.grades}`,
+      );
+      for (const e of w.syncResult.errors) {
+        lines.push(`  Error: ${e}`);
+      }
+    }
+    lines.push("");
+  }
+
+  for (const e of result.errors) {
+    lines.push(`Error: ${e}`);
+  }
+
+  const exitCode =
+    result.errors.length > 0 ||
+    result.waves.some(
+      (w) => w.syncResult && w.syncResult.errors.length > 0,
+    )
+      ? 1
+      : 0;
+
+  return { exitCode, output: lines.join("\n") };
+}
+
+async function defaultCommand(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help") {
+    return helpCommand(args, options);
+  }
+  if (subcommand === "fmti") {
+    return fmtiCommand(args.slice(1), options);
+  }
+  if (subcommand === "list") {
+    return listCommand(args, options);
+  }
+  return {
+    exitCode: 1,
+    output: `Unknown command: ${subcommand}\n\n${getHelp()}`,
+  };
+}
+
+async function helpCommand(
+  _args: string[],
+  _options: CommandOptions,
+): Promise<CommandResult> {
+  return { exitCode: 0, output: getHelp() };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const commands = {
+  fmti: fmtiCommand,
+  list: listCommand,
+  help: helpCommand,
+  default: defaultCommand,
+};
+
+export function getHelp(): string {
+  return [
+    "Scorecards Ingest (QUA-688 / QUA-697)",
+    "",
+    "Mirror external AI-safety scorecards into scorecard_snapshots + scorecard_grades.",
+    "",
+    "Usage:",
+    "  crux scorecards fmti list                                  Show configured FMTI waves",
+    "  crux scorecards fmti ingest [options]                      Fetch + parse + sync FMTI",
+    "",
+    "Options for `fmti ingest`:",
+    "  --wave=<id>       Restrict to one wave (default: all)",
+    `                    Known: ${FMTI_WAVES.map((w) => w.snapshotId).join(", ")}`,
+    "  --dry-run         Fetch + parse but skip POST /sync",
+    "  --ensure-stubs    Create lightweight stub `organization` entities for",
+    "                    org names that don't match an existing entity",
+    "                    (off by default — produces an unresolvedOrgs report",
+    "                    instead so a coverage check is non-mutating)",
+    "  --ci              Emit JSON output for scripting",
+    "",
+    "Notes:",
+    "  - Source: github.com/stanford-crfm/fmti (CC-BY-4.0)",
+    "  - Edit `data/scorecards/fmti-org-overrides.yaml` to map org display",
+    "    names to specific entity slugs.",
+  ].join("\n");
+}
+

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -120,6 +120,7 @@ import * as dataQualityCommands from './commands/data-quality.ts';
 import * as blueskyCommands from './commands/bluesky.ts';
 import * as politicalRacesCommands from './commands/political-races.ts';
 import * as politicalDataCommands from './commands/political-data.ts';
+import * as scorecardsCommands from './commands/scorecards.ts';
 import * as branchesCommands from './commands/branches.ts';
 import * as deployTasksCommands from './commands/deploy-tasks.ts';
 import * as agentResetCommands from './commands/agent-reset.ts';
@@ -216,6 +217,7 @@ const domains = {
   bluesky: blueskyCommands,
   races: politicalRacesCommands,
   political: politicalDataCommands,
+  scorecards: scorecardsCommands,
   branches: branchesCommands,
   'deploy-tasks': deployTasksCommands,
   'agent-reset': agentResetCommands,

--- a/crux/lib/scorecards/__tests__/fixtures/dec2025-indicators-mini.csv
+++ b/crux/lib/scorecards/__tests__/fixtures/dec2025-indicators-mini.csv
@@ -1,0 +1,7 @@
+Domain,Subdomain,Indicator,Definition,Notes,Example disclosure
+Upstream,Data Acquisition,Data acquisition methods,"What methods does the developer use to acquire data used to build the model?","Multi-line
+notes here.",
+Upstream,Data Acquisition,Public datasets,"Are public datasets used?",,
+Upstream,Compute,Compute usage,"How much compute is used?",,
+Model,Capabilities,Model capabilities,"What can the model do?",,
+Downstream,Impact,User impact,"How does the model impact users, including ""quoted"" content?",,

--- a/crux/lib/scorecards/__tests__/fixtures/dec2025-scores-mini.csv
+++ b/crux/lib/scorecards/__tests__/fixtures/dec2025-scores-mini.csv
@@ -1,0 +1,6 @@
+Indicator,AcmeAI,BetaLabs,GammaCorp
+Data acquisition methods,1,0,1
+Public datasets,1,1,0
+Compute usage,0,0,1
+Model capabilities,1,1,1
+User impact,0,1,1

--- a/crux/lib/scorecards/__tests__/fixtures/oct2023-scores-mini.csv
+++ b/crux/lib/scorecards/__tests__/fixtures/oct2023-scores-mini.csv
@@ -1,0 +1,5 @@
+﻿Domain,Subdomain,Indicator,AcmeAI,BetaLabs,GammaCorp,Total
+Upstream,Data,Data size,1,1,0,2
+Upstream,Data,Data sources,0,1,0,1
+Model,Capabilities,Capabilities documented,1,1,1,3
+,,Total,2,3,1,

--- a/crux/lib/scorecards/__tests__/fmti-ingest.test.ts
+++ b/crux/lib/scorecards/__tests__/fmti-ingest.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Integration-shape tests for the FMTI ingester orchestration.
+ *
+ * Exercises fetch-batching across multiple waves, --dry-run behavior,
+ * indicator-enrichment from sibling waves, and unresolved-org reporting.
+ *
+ * Network is mocked via the injectable `fetchImpl` parameter so these tests
+ * never touch GitHub.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ingestFmtiWaves } from "../fmti-ingest.ts";
+import { FMTI_WAVES } from "../fmti.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) =>
+  readFileSync(resolve(__dirname, "fixtures", name), "utf-8");
+
+const DEC2025_IND = fixture("dec2025-indicators-mini.csv");
+const DEC2025_SCO = fixture("dec2025-scores-mini.csv");
+const OCT2023 = fixture("oct2023-scores-mini.csv");
+
+// Mock the wiki-server entity-matcher import — we don't want the test
+// reading the real database.json. The matcher is consulted by the resolver
+// but tests cover the empty-matcher path (everything goes through overrides
+// or stub creation).
+vi.mock("../../grant-import/entity-matcher.ts", async () => {
+  return {
+    buildEntityMatcher: () => ({
+      allNames: new Map(),
+      match: (_name: string) => null,
+    }),
+    normalizeGranteeName: (name: string) => name.trim(),
+    matchGrantee: () => null,
+  };
+});
+
+// Mock the wiki-server sync clients — non-dry-run paths shouldn't hit the
+// network either.
+vi.mock("../../wiki-server/scorecard-snapshots.ts", () => ({
+  syncScorecardSnapshots: vi.fn(async (items: Array<Record<string, unknown>>) => ({
+    ok: true,
+    data: { upserted: items.length, verdictsWritten: 0, claimsLinked: 0 },
+  })),
+}));
+vi.mock("../../wiki-server/scorecard-grades.ts", () => ({
+  syncScorecardGrades: vi.fn(async (items: Array<Record<string, unknown>>) => ({
+    ok: true,
+    data: { upserted: items.length, verdictsWritten: 0, claimsLinked: 0 },
+  })),
+}));
+vi.mock("../../wiki-server/entities.ts", () => ({
+  syncEntities: vi.fn(async () => ({ ok: true, data: { upserted: 1 } })),
+}));
+
+// Override the wiki-server URL so getServerUrl() returns truthy.
+vi.mock("../../wiki-server/client.ts", async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    getServerUrl: () => "https://example.invalid",
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Mock fetch builder
+// ---------------------------------------------------------------------------
+
+function makeMockFetch(byUrl: Record<string, string>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const body = byUrl[url];
+    if (body == null) {
+      return new Response(`not stubbed: ${url}`, { status: 404 });
+    }
+    return new Response(body, { status: 200 });
+  }) as typeof fetch;
+}
+
+const dec2025 = FMTI_WAVES.find((w) => w.snapshotId === "fmti-dec-2025")!;
+const may2024 = FMTI_WAVES.find((w) => w.snapshotId === "fmti-may-2024")!;
+const oct2023 = FMTI_WAVES.find((w) => w.snapshotId === "fmti-oct-2023")!;
+
+const URL_DEC_IND = `https://raw.githubusercontent.com/stanford-crfm/fmti/main/${dec2025.pathPrefix}/${dec2025.indicatorsFile}`;
+const URL_DEC_SCO = `https://raw.githubusercontent.com/stanford-crfm/fmti/main/${dec2025.pathPrefix}/${dec2025.scoresFile}`;
+const URL_MAY_SCO = `https://raw.githubusercontent.com/stanford-crfm/fmti/main/${may2024.pathPrefix}/${may2024.scoresFile}`;
+const URL_OCT_SCO = `https://raw.githubusercontent.com/stanford-crfm/fmti/main/${oct2023.pathPrefix}/${oct2023.scoresFile}`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ingestFmtiWaves — single wave dry-run", () => {
+  it("fetches Dec 2025 and emits unresolvedOrgs without --ensure-stubs", async () => {
+    const fetchImpl = makeMockFetch({
+      [URL_DEC_IND]: DEC2025_IND,
+      [URL_DEC_SCO]: DEC2025_SCO,
+    });
+
+    const result = await ingestFmtiWaves({
+      waveId: "fmti-dec-2025",
+      dryRun: true,
+      fetchImpl,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.waves).toHaveLength(1);
+    const w = result.waves[0];
+    // Three orgs in fixture, none in (empty) matcher and no overrides match.
+    expect(w.resolvedOrgs).toBe(0);
+    expect(w.unresolvedOrgs.sort()).toEqual(["AcmeAI", "BetaLabs", "GammaCorp"]);
+    expect(w.gradeCount).toBe(0);
+    expect(w.dryRun).toBe(true);
+    expect(w.syncResult).toBeNull();
+    expect(w.snapshot.notes).toContain("Unresolved");
+  });
+
+  it("with --ensure-stubs, builds full grade rows for every org", async () => {
+    const fetchImpl = makeMockFetch({
+      [URL_DEC_IND]: DEC2025_IND,
+      [URL_DEC_SCO]: DEC2025_SCO,
+    });
+
+    const result = await ingestFmtiWaves({
+      waveId: "fmti-dec-2025",
+      dryRun: true,
+      ensureStubEntities: true,
+      fetchImpl,
+    });
+
+    const w = result.waves[0];
+    expect(w.resolvedOrgs).toBe(3);
+    expect(w.unresolvedOrgs).toEqual([]);
+    // 3 orgs × (5 indicators + 4 subdomains + 3 domains + 1 overall) = 39.
+    expect(w.gradeCount).toBe(39);
+  });
+
+  it("propagates fetch errors as wave-scoped errors without aborting siblings", async () => {
+    const fetchImpl = makeMockFetch({}); // no URLs stubbed
+
+    const result = await ingestFmtiWaves({
+      waveId: "fmti-dec-2025",
+      dryRun: true,
+      fetchImpl,
+    });
+    expect(result.waves).toHaveLength(0);
+    expect(result.errors[0]).toMatch(/fmti-dec-2025/);
+  });
+
+  it("rejects unknown wave id", async () => {
+    const result = await ingestFmtiWaves({
+      waveId: "fmti-bogus",
+      fetchImpl: makeMockFetch({}),
+    });
+    expect(result.waves).toEqual([]);
+    expect(result.errors[0]).toMatch(/Unknown FMTI wave/);
+  });
+});
+
+describe("ingestFmtiWaves — multi-wave + indicator enrichment", () => {
+  it("borrows domain/subdomain from sibling waves when a wave lacks indicators-defs", async () => {
+    // May 2024 has no indicators-defs file. Inject a reduced May 2024 scores
+    // CSV whose indicator names overlap with Dec 2025 indicators so the
+    // enrichment can match — the missing indicator gets a blank domain.
+    const may2024Scores = [
+      "Indicator,AcmeAI,BetaLabs",
+      // matches Dec 2025
+      "Data acquisition methods,1,0",
+      "Compute usage,0,1",
+      // does NOT match Dec 2025 — should fall through to overall
+      "Mystery May indicator,1,1",
+      "",
+    ].join("\n");
+
+    const fetchImpl = makeMockFetch({
+      [URL_DEC_IND]: DEC2025_IND,
+      [URL_DEC_SCO]: DEC2025_SCO,
+      [URL_MAY_SCO]: may2024Scores,
+    });
+
+    const result = await ingestFmtiWaves({
+      dryRun: true,
+      ensureStubEntities: true,
+      fetchImpl,
+    });
+
+    // Both waves should be present. (Oct 2023 not stubbed → error.)
+    const may = result.waves.find((w) => w.waveId === "fmti-may-2024");
+    expect(may, "May 2024 should be parsed").toBeDefined();
+    // 2 orgs × (3 indicators + 2 subdomains [Data Acquisition, Compute] +
+    // 1 domain [Upstream] + 1 overall) = 14. Mystery indicator has no
+    // domain, so it adds a row but not subdomain/domain rollups.
+    // = 2 × (3 + 2 + 1 + 1) = 14.
+    expect(may!.gradeCount).toBe(14);
+  });
+
+  it("tags only the latest published wave with isLatest=true", async () => {
+    const fetchImpl = makeMockFetch({
+      [URL_DEC_IND]: DEC2025_IND,
+      [URL_DEC_SCO]: DEC2025_SCO,
+      [URL_OCT_SCO]: OCT2023,
+    });
+
+    const result = await ingestFmtiWaves({
+      dryRun: true,
+      ensureStubEntities: true,
+      fetchImpl,
+    });
+
+    const dec = result.waves.find((w) => w.waveId === "fmti-dec-2025")!;
+    const oct = result.waves.find((w) => w.waveId === "fmti-oct-2023")!;
+    expect(dec.snapshot.isLatest).toBe(true);
+    expect(oct.snapshot.isLatest).toBe(false);
+  });
+});
+
+describe("ingestFmtiWaves — live mode", () => {
+  it("calls the snapshot+grades sync endpoints once per wave", async () => {
+    const fetchImpl = makeMockFetch({
+      [URL_DEC_IND]: DEC2025_IND,
+      [URL_DEC_SCO]: DEC2025_SCO,
+    });
+
+    const { syncScorecardSnapshots } = await import(
+      "../../wiki-server/scorecard-snapshots.ts"
+    );
+    const { syncScorecardGrades } = await import(
+      "../../wiki-server/scorecard-grades.ts"
+    );
+
+    const result = await ingestFmtiWaves({
+      waveId: "fmti-dec-2025",
+      dryRun: false,
+      ensureStubEntities: true,
+      fetchImpl,
+    });
+
+    const w = result.waves[0];
+    expect(w.syncResult).not.toBeNull();
+    expect(w.syncResult!.errors).toEqual([]);
+    expect(w.syncResult!.snapshots).toBe(1);
+    expect(w.syncResult!.grades).toBe(39);
+    expect(syncScorecardSnapshots).toHaveBeenCalledTimes(1);
+    expect(syncScorecardGrades).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crux/lib/scorecards/__tests__/fmti.test.ts
+++ b/crux/lib/scorecards/__tests__/fmti.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Unit tests for the FMTI parser + record builder (pure transforms).
+ *
+ * The fetch + sync orchestration is exercised in fmti-ingest.test.ts using
+ * an injected mock fetch.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildFmtiRecords,
+  domainSlug,
+  FMTI_WAVES,
+  fmtiRawUrl,
+  parseCsv,
+  parseFmtiFlatScores,
+  parseFmtiIndicators,
+  parseFmtiOct2023Scores,
+  slugify,
+  subdomainSlug,
+  type FmtiIndicator,
+  type FmtiScoreRow,
+} from "../fmti.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadFixture(name: string): string {
+  return readFileSync(resolve(__dirname, "fixtures", name), "utf-8");
+}
+
+const DEC2025_IND = loadFixture("dec2025-indicators-mini.csv");
+const DEC2025_SCO = loadFixture("dec2025-scores-mini.csv");
+const OCT2023 = loadFixture("oct2023-scores-mini.csv");
+
+// ---------------------------------------------------------------------------
+// CSV parser
+// ---------------------------------------------------------------------------
+
+describe("parseCsv", () => {
+  it("handles a simple CSV", () => {
+    const rows = parseCsv("a,b,c\n1,2,3\n4,5,6\n");
+    expect(rows).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+      ["4", "5", "6"],
+    ]);
+  });
+
+  it("handles quoted fields with embedded commas, newlines, and escaped quotes", () => {
+    const rows = parseCsv('a,b\n"with, comma",ok\n"line\nbreak","escaped ""quote"""\n');
+    expect(rows).toEqual([
+      ["a", "b"],
+      ["with, comma", "ok"],
+      ["line\nbreak", 'escaped "quote"'],
+    ]);
+  });
+
+  it("strips a leading UTF-8 BOM", () => {
+    const rows = parseCsv("\uFEFFa,b\n1,2\n");
+    expect(rows[0]).toEqual(["a", "b"]);
+  });
+
+  it("handles a file without a trailing newline", () => {
+    const rows = parseCsv("a,b\n1,2");
+    expect(rows).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("handles \\r\\n line endings", () => {
+    const rows = parseCsv("a,b\r\n1,2\r\n");
+    expect(rows).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// slugify / domain / subdomain slugs
+// ---------------------------------------------------------------------------
+
+describe("slugify", () => {
+  it("kebab-cases ASCII", () => {
+    expect(slugify("Data acquisition methods")).toBe("data-acquisition-methods");
+  });
+  it("strips punctuation", () => {
+    expect(slugify("AUP enforcement!")).toBe("aup-enforcement");
+  });
+  it("strips combining marks", () => {
+    expect(slugify("naïve approach")).toBe("naive-approach");
+  });
+  it("trims surrounding hyphens", () => {
+    expect(slugify("--hello---")).toBe("hello");
+    expect(slugify("   ")).toBe("");
+  });
+});
+
+describe("domainSlug / subdomainSlug", () => {
+  it("returns lowercase domain slugs", () => {
+    expect(domainSlug("Upstream")).toBe("upstream");
+    expect(domainSlug("Downstream")).toBe("downstream");
+  });
+  it("prefixes subdomains with their domain", () => {
+    expect(subdomainSlug("Upstream", "Data Acquisition")).toBe(
+      "upstream--data-acquisition",
+    );
+    expect(subdomainSlug("Downstream", "Acceptable use policy")).toBe(
+      "downstream--acceptable-use-policy",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Indicators / flat-scores parsers
+// ---------------------------------------------------------------------------
+
+describe("parseFmtiIndicators", () => {
+  it("parses Dec2025-style indicators with multiline fields", () => {
+    const ind = parseFmtiIndicators(DEC2025_IND);
+    expect(ind).toHaveLength(5);
+    expect(ind[0]).toEqual({
+      domain: "Upstream",
+      subdomain: "Data Acquisition",
+      name: "Data acquisition methods",
+    });
+    expect(ind[4]).toEqual({
+      domain: "Downstream",
+      subdomain: "Impact",
+      name: "User impact",
+    });
+  });
+
+  it("throws on malformed header", () => {
+    expect(() =>
+      parseFmtiIndicators("Foo,Bar,Baz\n1,2,3\n"),
+    ).toThrowError(/missing expected columns/);
+  });
+});
+
+describe("parseFmtiFlatScores", () => {
+  it("parses orgs and binary scores", () => {
+    const { orgs, rows } = parseFmtiFlatScores(DEC2025_SCO);
+    expect(orgs).toEqual(["AcmeAI", "BetaLabs", "GammaCorp"]);
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toEqual({
+      indicator: "Data acquisition methods",
+      scores: { AcmeAI: 1, BetaLabs: 0, GammaCorp: 1 },
+    });
+    expect(rows[4].scores.AcmeAI).toBe(0);
+  });
+
+  it("treats blank cells as null", () => {
+    const csv = "Indicator,A,B\nFoo,1,\nBar,,0\n";
+    const { rows } = parseFmtiFlatScores(csv);
+    expect(rows[0].scores).toEqual({ A: 1, B: null });
+    expect(rows[1].scores).toEqual({ A: null, B: 0 });
+  });
+
+  it("throws when first column is not Indicator", () => {
+    expect(() => parseFmtiFlatScores("Foo,A,B\n1,1,0\n")).toThrowError(
+      /first column should be "Indicator"/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Oct 2023 integrated parser
+// ---------------------------------------------------------------------------
+
+describe("parseFmtiOct2023Scores", () => {
+  it("parses domain/subdomain/indicator + scores", () => {
+    const { orgs, rows } = parseFmtiOct2023Scores(OCT2023);
+    expect(orgs).toEqual(["AcmeAI", "BetaLabs", "GammaCorp"]);
+    expect(rows).toHaveLength(3); // Total footer row dropped
+    expect(rows[0]).toEqual({
+      domain: "Upstream",
+      subdomain: "Data",
+      indicator: "Data size",
+      scores: { AcmeAI: 1, BetaLabs: 1, GammaCorp: 0 },
+    });
+  });
+
+  it("drops the trailing Total summary row", () => {
+    const { rows } = parseFmtiOct2023Scores(OCT2023);
+    expect(rows.find((r) => r.indicator.toLowerCase() === "total")).toBeUndefined();
+  });
+
+  it("strips BOM at start of file", () => {
+    // OCT2023 fixture starts with BOM.
+    const { orgs } = parseFmtiOct2023Scores(OCT2023);
+    expect(orgs[0]).toBe("AcmeAI");
+  });
+
+  it("throws on unexpected header layout", () => {
+    expect(() =>
+      parseFmtiOct2023Scores("A,B,C\n1,2,3\n"),
+    ).toThrowError(/expected first columns/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFmtiRecords — record shape, rollups, ID determinism
+// ---------------------------------------------------------------------------
+
+describe("buildFmtiRecords", () => {
+  const wave = FMTI_WAVES[2]; // Dec 2025
+  const indicators: FmtiIndicator[] = parseFmtiIndicators(DEC2025_IND);
+  const flat = parseFmtiFlatScores(DEC2025_SCO);
+
+  // Stable resolver that gives every org a synthetic stableId.
+  const resolveOrg = (name: string) => `sid_${slugify(name).slice(0, 6)}xx`;
+
+  function build() {
+    return buildFmtiRecords({
+      wave,
+      isLatest: true,
+      indicators,
+      scores: flat.rows,
+      orgs: flat.orgs,
+      resolveOrg,
+    });
+  }
+
+  it("emits one snapshot row with expected metadata", () => {
+    const r = build();
+    expect(r.snapshot.id).toBe(wave.snapshotId);
+    expect(r.snapshot.scorecardSource).toBe("fmti");
+    expect(r.snapshot.publishedAt).toBe(wave.publishedAt);
+    expect(r.snapshot.license).toBe("CC-BY-4.0");
+    expect(r.snapshot.isLatest).toBe(true);
+    expect(r.snapshot.sourceActive).toBe(true);
+    expect(r.snapshot.orgCount).toBe(3);
+    // 5 indicators + 4 unique subdomains + 3 domains + 1 overall = 13
+    expect(r.snapshot.dimensionCount).toBe(13);
+  });
+
+  it("emits indicator + subdomain + domain + overall grades per org", () => {
+    const r = build();
+    // Per org: 5 indicators + 4 subdomains (Data Acquisition, Compute,
+    // Capabilities, Impact) + 3 domains + 1 overall = 13.
+    expect(r.grades).toHaveLength(3 * 13);
+
+    // Group by entity for assertion.
+    const byEntity = new Map<string, typeof r.grades>();
+    for (const g of r.grades) {
+      const list = byEntity.get(g.entityId) ?? [];
+      list.push(g);
+      byEntity.set(g.entityId, list);
+    }
+    expect(byEntity.size).toBe(3);
+    for (const [, gs] of byEntity) {
+      expect(gs).toHaveLength(13);
+      expect(gs.filter((g) => g.dimensionSlug === "overall")).toHaveLength(1);
+      expect(
+        gs.filter((g) => ["upstream", "model", "downstream"].includes(g.dimensionSlug)),
+      ).toHaveLength(3);
+    }
+  });
+
+  it("computes overall as percent of indicators scored 1", () => {
+    const r = build();
+    // AcmeAI scores: 1,1,0,1,0 → 3/5 = 60.
+    const overall = r.grades.find(
+      (g) => g.entityDisplayName === "AcmeAI" && g.dimensionSlug === "overall",
+    );
+    expect(overall?.scoreNumeric).toBe(60);
+    expect(overall?.scoreRaw).toBe("3/5");
+  });
+
+  it("computes subdomain rollups as percent and rounds to one decimal", () => {
+    const r = build();
+    // AcmeAI Upstream/Data Acquisition: indicators
+    //   "Data acquisition methods" = 1, "Public datasets" = 1 → 2/2 = 100.
+    const sub = r.grades.find(
+      (g) =>
+        g.entityDisplayName === "AcmeAI" &&
+        g.dimensionSlug === "upstream--data-acquisition",
+    );
+    expect(sub).toBeDefined();
+    expect(sub!.scoreNumeric).toBe(100);
+    expect(sub!.dimensionParentSlug).toBe("upstream");
+    expect(sub!.scoreRaw).toBe("2/2");
+  });
+
+  it("links indicators to their subdomain via dimensionParentSlug", () => {
+    const r = build();
+    const indicatorRow = r.grades.find(
+      (g) =>
+        g.entityDisplayName === "AcmeAI" &&
+        g.dimensionSlug === "data-acquisition-methods",
+    );
+    expect(indicatorRow?.dimensionParentSlug).toBe("upstream--data-acquisition");
+    expect(indicatorRow?.scoreNumeric).toBe(100);
+    expect(indicatorRow?.scoreRaw).toBe("1");
+  });
+
+  it("emits stable, unique ids that fit the natural-key constraint", () => {
+    const r = build();
+    const ids = new Set(r.grades.map((g) => g.id));
+    expect(ids.size).toBe(r.grades.length); // all unique
+    for (const g of r.grades) {
+      expect(g.id.length).toBeLessThanOrEqual(250);
+      // (snapshotId, entityId, dimensionSlug) should be derivable.
+      expect(g.id).toContain(g.snapshotId);
+      expect(g.id).toContain(g.entityId);
+      expect(g.id).toContain(g.dimensionSlug);
+    }
+  });
+
+  it("skips orgs the resolver returns null for", () => {
+    const r = buildFmtiRecords({
+      wave,
+      isLatest: true,
+      indicators,
+      scores: flat.rows,
+      orgs: flat.orgs,
+      resolveOrg: (name) => (name === "BetaLabs" ? null : `sid_${name}xx`),
+    });
+    expect(r.unresolvedOrgs).toEqual(["BetaLabs"]);
+    expect(r.snapshot.orgCount).toBe(2);
+    expect(r.grades.every((g) => g.entityDisplayName !== "BetaLabs")).toBe(
+      true,
+    );
+    expect(r.snapshot.notes).toContain("BetaLabs");
+  });
+
+  it("includes indicators with no matching definition under the overall parent", () => {
+    const orphanScores: FmtiScoreRow[] = [
+      ...flat.rows,
+      { indicator: "Mystery indicator", scores: { AcmeAI: 1, BetaLabs: 0, GammaCorp: 1 } },
+    ];
+    const r = buildFmtiRecords({
+      wave,
+      isLatest: true,
+      indicators, // does NOT contain "Mystery indicator"
+      scores: orphanScores,
+      orgs: flat.orgs,
+      resolveOrg,
+    });
+    const mystery = r.grades.find((g) => g.dimensionSlug === "mystery-indicator");
+    expect(mystery).toBeDefined();
+    expect(mystery!.dimensionParentSlug).toBe("overall");
+  });
+
+  it("never tags isLatest=false snapshots with isLatest=true", () => {
+    const r = buildFmtiRecords({
+      wave,
+      isLatest: false,
+      indicators,
+      scores: flat.rows,
+      orgs: flat.orgs,
+      resolveOrg,
+    });
+    expect(r.snapshot.isLatest).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave config sanity checks
+// ---------------------------------------------------------------------------
+
+describe("FMTI_WAVES configuration", () => {
+  it("has a stable, non-overlapping snapshotId for each wave", () => {
+    const ids = FMTI_WAVES.map((w) => w.snapshotId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("uses raw GitHub URLs for fetched files", () => {
+    const url = fmtiRawUrl(FMTI_WAVES[0], FMTI_WAVES[0].scoresFile);
+    expect(url).toMatch(
+      /^https:\/\/raw\.githubusercontent\.com\/stanford-crfm\/fmti\/main\//,
+    );
+  });
+
+  it("publishedAt is a valid ISO date for each wave", () => {
+    for (const w of FMTI_WAVES) {
+      expect(w.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+});

--- a/crux/lib/scorecards/fmti-ingest.ts
+++ b/crux/lib/scorecards/fmti-ingest.ts
@@ -1,0 +1,503 @@
+/**
+ * Stanford FMTI Ingester — fetch + parse + sync orchestration.
+ *
+ * Public surface:
+ *   ingestFmtiWaves(opts) — fetch all configured waves and POST records to
+ *                            the wiki-server scorecard endpoints.
+ *
+ * Pure transforms live in `./fmti.ts`. This module only handles I/O.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getServerUrl } from "../wiki-server/client.ts";
+import {
+  syncScorecardSnapshots,
+} from "../wiki-server/scorecard-snapshots.ts";
+import { syncScorecardGrades } from "../wiki-server/scorecard-grades.ts";
+import { buildEntityMatcher, normalizeGranteeName } from "../grant-import/entity-matcher.ts";
+import { generateId } from "../grant-import/id.ts";
+import {
+  FMTI_WAVES,
+  buildFmtiRecords,
+  fmtiRawUrl,
+  parseFmtiFlatScores,
+  parseFmtiIndicators,
+  parseFmtiOct2023Scores,
+  type FmtiIndicator,
+  type FmtiScoreRow,
+  type FmtiWave,
+  type ScorecardGradeRecord,
+  type ScorecardSnapshotRecord,
+} from "./fmti.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FETCH_TIMEOUT_MS = 30_000;
+const GRADES_BATCH_SIZE = 500;
+
+const ORG_OVERRIDES_PATH = "data/scorecards/fmti-org-overrides.yaml";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface IngestOptions {
+  /** Restrict to one wave (`fmti-dec-2025` etc.). Defaults to all. */
+  waveId?: string;
+  /** Don't POST anything — just fetch + parse + report counts. */
+  dryRun?: boolean;
+  /**
+   * When unmatched org names are encountered, create lightweight stub
+   * `entities` rows so the FK validation passes. Defaults to false; off by
+   * default makes the ingester safe to run as a coverage check without
+   * mutating the entity registry.
+   */
+  ensureStubEntities?: boolean;
+  /** Override fetch (used in tests). */
+  fetchImpl?: typeof fetch;
+}
+
+export interface WaveIngestResult {
+  waveId: string;
+  snapshot: ScorecardSnapshotRecord;
+  gradeCount: number;
+  resolvedOrgs: number;
+  unresolvedOrgs: string[];
+  warnings: string[];
+  /** Set when --dry-run; null otherwise. */
+  dryRun: boolean;
+  /** Wiki-server upsert result, or null on dry-run / sync skipped. */
+  syncResult: { snapshots: number; grades: number; errors: string[] } | null;
+}
+
+export interface IngestResult {
+  waves: WaveIngestResult[];
+  errors: string[];
+}
+
+export async function ingestFmtiWaves(
+  opts: IngestOptions = {},
+): Promise<IngestResult> {
+  const dryRun = !!opts.dryRun;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  // Pick which waves to run.
+  const waves = opts.waveId
+    ? FMTI_WAVES.filter((w) => w.snapshotId === opts.waveId)
+    : [...FMTI_WAVES];
+  if (waves.length === 0) {
+    return {
+      waves: [],
+      errors: [
+        `Unknown FMTI wave "${opts.waveId}". Known waves: ${FMTI_WAVES.map((w) => w.snapshotId).join(", ")}`,
+      ],
+    };
+  }
+
+  // Build the entity matcher once.
+  const matcher = buildEntityMatcher();
+  const overrides = loadOrgOverrides();
+
+  // First pass: fetch + parse all waves so we can gather the union of org
+  // names, ensure-entities once, and then build records.
+  type ParsedWave = {
+    wave: FmtiWave;
+    indicators: FmtiIndicator[];
+    scores: FmtiScoreRow[];
+    orgs: string[];
+    warnings: string[];
+  };
+  const parsed: ParsedWave[] = [];
+  const errors: string[] = [];
+
+  for (const wave of waves) {
+    try {
+      const p = await parseWave(wave, fetchImpl);
+      parsed.push(p);
+    } catch (err) {
+      errors.push(`${wave.snapshotId}: ${formatErr(err)}`);
+    }
+  }
+
+  if (parsed.length === 0) {
+    return { waves: [], errors };
+  }
+
+  // Cross-wave: enrich May 2024 indicators with metadata from Oct 2023 / Dec
+  // 2025 if available, since May2024_scores.csv has no inline domain info.
+  // (Best-effort; a record without indicator metadata still rolls up at the
+  // overall level but skips subdomain/domain rollups.)
+  enrichMissingIndicators(parsed);
+
+  // Resolve all orgs across all waves in one pass so we hit the entity
+  // matcher / ensure-entities at most once per name.
+  const allOrgs = new Set<string>();
+  for (const p of parsed) for (const o of p.orgs) allOrgs.add(o);
+
+  const orgIndex = await resolveOrgs(
+    [...allOrgs],
+    {
+      matcher,
+      overrides,
+      ensureStubEntities: !!opts.ensureStubEntities,
+      dryRun,
+    },
+  );
+
+  // Tag latest = the most-recently-published wave we're shipping.
+  // (If you only ingest historical waves, none gets tagged latest — that's
+  // intentional: don't downgrade an already-latest snapshot.)
+  const latestId = pickLatestWaveId(parsed.map((p) => p.wave));
+
+  const results: WaveIngestResult[] = [];
+
+  for (const p of parsed) {
+    const built = buildFmtiRecords({
+      wave: p.wave,
+      isLatest: p.wave.snapshotId === latestId,
+      indicators: p.indicators,
+      scores: p.scores,
+      orgs: p.orgs,
+      resolveOrg: (name) => orgIndex.get(name) ?? null,
+    });
+
+    const result: WaveIngestResult = {
+      waveId: p.wave.snapshotId,
+      snapshot: built.snapshot,
+      gradeCount: built.grades.length,
+      resolvedOrgs: built.snapshot.orgCount,
+      unresolvedOrgs: built.unresolvedOrgs,
+      warnings: p.warnings,
+      dryRun,
+      syncResult: null,
+    };
+
+    if (!dryRun) {
+      result.syncResult = await syncWaveToServer(built.snapshot, built.grades);
+    }
+    results.push(result);
+  }
+
+  return { waves: results, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function parseWave(
+  wave: FmtiWave,
+  fetchImpl: typeof fetch,
+): Promise<{
+  wave: FmtiWave;
+  indicators: FmtiIndicator[];
+  scores: FmtiScoreRow[];
+  orgs: string[];
+  warnings: string[];
+}> {
+  const warnings: string[] = [];
+
+  if (wave.scoresHasDomain) {
+    // Oct 2023 — integrated scores file with Domain/Subdomain inline.
+    const text = await fetchText(fmtiRawUrl(wave, wave.scoresFile), fetchImpl);
+    const { orgs, rows } = parseFmtiOct2023Scores(text);
+    const indicators: FmtiIndicator[] = rows.map((r) => ({
+      domain: r.domain,
+      subdomain: r.subdomain,
+      name: r.indicator,
+    }));
+    const scores: FmtiScoreRow[] = rows.map((r) => ({
+      indicator: r.indicator,
+      scores: r.scores,
+    }));
+    return { wave, indicators, scores, orgs, warnings };
+  }
+
+  // Flat scores file (Dec 2025 / May 2024). Fetch indicators if available.
+  const scoresText = await fetchText(
+    fmtiRawUrl(wave, wave.scoresFile),
+    fetchImpl,
+  );
+  const { orgs, rows: scores } = parseFmtiFlatScores(scoresText);
+
+  let indicators: FmtiIndicator[] = [];
+  if (wave.indicatorsFile) {
+    const indText = await fetchText(
+      fmtiRawUrl(wave, wave.indicatorsFile),
+      fetchImpl,
+    );
+    indicators = parseFmtiIndicators(indText);
+  } else {
+    warnings.push(
+      "No indicators-definitions file for this wave — domain/subdomain rollups will be inferred from sibling waves where possible.",
+    );
+  }
+  return { wave, indicators, scores, orgs, warnings };
+}
+
+async function fetchText(url: string, fetchImpl: typeof fetch): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "longterm-wiki-fmti-ingest/1.0",
+        Accept: "text/csv, text/plain;q=0.9, */*;q=0.5",
+      },
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} for ${url}`);
+    }
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * For waves with no indicators-definitions file (e.g. May 2024), borrow the
+ * domain/subdomain mapping from sibling waves whose indicator names overlap.
+ * Best-effort — names that still don't match remain unmapped.
+ */
+function enrichMissingIndicators(
+  parsed: Array<{
+    wave: FmtiWave;
+    indicators: FmtiIndicator[];
+    scores: FmtiScoreRow[];
+  }>,
+): void {
+  const ref = new Map<string, FmtiIndicator>();
+  for (const p of parsed) {
+    for (const i of p.indicators) {
+      if (i.domain && i.subdomain) ref.set(i.name, i);
+    }
+  }
+  for (const p of parsed) {
+    if (p.indicators.length > 0) continue;
+    const enriched: FmtiIndicator[] = [];
+    for (const sr of p.scores) {
+      const known = ref.get(sr.indicator);
+      // Skip entries with no domain/subdomain match — buildFmtiRecords
+      // treats unknown indicators as parent="overall" with no rollup, which
+      // is the right shape for "wave has no indicators-defs and we couldn't
+      // find a sibling match".
+      if (known) enriched.push(known);
+    }
+    p.indicators = enriched;
+  }
+}
+
+function pickLatestWaveId(waves: FmtiWave[]): string | null {
+  if (waves.length === 0) return null;
+  return [...waves].sort((a, b) =>
+    b.publishedAt.localeCompare(a.publishedAt),
+  )[0].snapshotId;
+}
+
+// ---------------------------------------------------------------------------
+// Org resolution
+// ---------------------------------------------------------------------------
+
+interface ResolveOptions {
+  matcher: ReturnType<typeof buildEntityMatcher>;
+  overrides: Record<string, string>;
+  ensureStubEntities: boolean;
+  dryRun: boolean;
+}
+
+/**
+ * Resolve all org names to entity stableIds. Returns a name → stableId map
+ * (missing names are simply absent from the map — caller decides how to
+ * report them).
+ *
+ * When `ensureStubEntities` is true and the resolver reaches an unmatched
+ * name, it creates a lightweight `organization` entity (stub: true) using
+ * the same `generateId(...)` pattern as `tb ensure-entities`.
+ */
+async function resolveOrgs(
+  names: string[],
+  opts: ResolveOptions,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  // Stubs are deduplicated by canonical slug so that aliased display names
+  // (e.g. "Stability" / "Stability AI" → `stability-ai`) collapse to one
+  // stub entity instead of two.
+  const stubsBySlug = new Map<
+    string,
+    { slug: string; displayName: string; stableId: string; aliases: Set<string> }
+  >();
+
+  for (const name of names) {
+    const trimmed = name.trim();
+    if (!trimmed) continue;
+
+    // 1. Exact override → canonical slug.
+    const overrideSlug = opts.overrides[trimmed];
+    if (overrideSlug) {
+      const m = opts.matcher.match(overrideSlug);
+      if (m) {
+        out.set(trimmed, m.stableId);
+        continue;
+      }
+      if (opts.ensureStubEntities) {
+        registerStub(stubsBySlug, overrideSlug, trimmed);
+        out.set(trimmed, stubsBySlug.get(overrideSlug)!.stableId);
+      }
+      continue;
+    }
+
+    // 2. Direct entity matcher (title or alias).
+    const direct = opts.matcher.match(trimmed);
+    if (direct) {
+      out.set(trimmed, direct.stableId);
+      continue;
+    }
+
+    // 3. Normalize (strip Inc., Labs, etc.).
+    const normalized = normalizeGranteeName(trimmed);
+    if (normalized !== trimmed) {
+      const normMatch = opts.matcher.match(normalized);
+      if (normMatch) {
+        out.set(trimmed, normMatch.stableId);
+        continue;
+      }
+    }
+
+    // 4. Ensure-entities (creates stub keyed by derived slug).
+    if (opts.ensureStubEntities) {
+      const slug = toSlug(trimmed);
+      registerStub(stubsBySlug, slug, trimmed);
+      out.set(trimmed, stubsBySlug.get(slug)!.stableId);
+    }
+    // Else: leave unresolved.
+  }
+
+  if (stubsBySlug.size > 0 && !opts.dryRun) {
+    const { syncEntities } = await import("../wiki-server/entities.ts");
+    const stubArr = [...stubsBySlug.values()];
+    const result = await syncEntities(
+      stubArr.map((s) => ({
+        id: s.slug,
+        stableId: s.stableId,
+        entityType: "organization",
+        title: s.displayName,
+        metadata: {
+          stub: true,
+          source: "fmti-ingest",
+          // Capture observed display-name aliases on the metadata blob so
+          // future runs (or a follow-up that promotes these to wiki pages)
+          // can recover the variants. The entities schema has no native
+          // aliases column — those live in YAML.
+          fmtiAliases: [...s.aliases],
+        },
+      })),
+    );
+    if (!result.ok) {
+      // Don't fail hard — strip the un-synced stubs from the resolution map
+      // so the grade sync's FK validation rejects them instead of silently
+      // shipping orphan refs.
+      for (const s of stubArr) {
+        for (const alias of s.aliases) out.delete(alias);
+      }
+    }
+  }
+
+  return out;
+}
+
+function registerStub(
+  bySlug: Map<
+    string,
+    { slug: string; displayName: string; stableId: string; aliases: Set<string> }
+  >,
+  slug: string,
+  displayName: string,
+): void {
+  const existing = bySlug.get(slug);
+  if (existing) {
+    existing.aliases.add(displayName);
+    return;
+  }
+  bySlug.set(slug, {
+    slug,
+    displayName,
+    stableId: generateId(`organization:${slug}`),
+    aliases: new Set([displayName]),
+  });
+}
+
+function toSlug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function loadOrgOverrides(): Record<string, string> {
+  try {
+    const text = readFileSync(resolvePath(ORG_OVERRIDES_PATH), "utf-8");
+    const parsed = parseYaml(text) as { overrides?: Record<string, string> };
+    return parsed.overrides ?? {};
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wiki-server sync
+// ---------------------------------------------------------------------------
+
+async function syncWaveToServer(
+  snapshot: ScorecardSnapshotRecord,
+  grades: ScorecardGradeRecord[],
+): Promise<{ snapshots: number; grades: number; errors: string[] }> {
+  const serverUrl = getServerUrl();
+  const errors: string[] = [];
+  if (!serverUrl) {
+    return {
+      snapshots: 0,
+      grades: 0,
+      errors: ["LONGTERMWIKI_SERVER_URL not configured — cannot sync"],
+    };
+  }
+
+  // The typed sync clients accept `Array<Record<string, unknown>>` (the
+  // server-side validates against a Zod schema, so the runtime check is
+  // authoritative). Our records are stricter than that — assignable but not
+  // structurally identical, hence the cast.
+  const snapResult = await syncScorecardSnapshots([
+    { ...snapshot } as unknown as Record<string, unknown>,
+  ]);
+  if (!snapResult.ok) {
+    errors.push(`Snapshot sync failed: ${snapResult.message}`);
+    return { snapshots: 0, grades: 0, errors };
+  }
+  const snapshotsUpserted = snapResult.data.upserted;
+
+  let gradesUpserted = 0;
+  for (let i = 0; i < grades.length; i += GRADES_BATCH_SIZE) {
+    const batch = grades.slice(i, i + GRADES_BATCH_SIZE);
+    const r = await syncScorecardGrades(
+      batch.map((g) => ({ ...g })) as Array<Record<string, unknown>>,
+    );
+    if (!r.ok) {
+      errors.push(
+        `Grades batch ${Math.floor(i / GRADES_BATCH_SIZE) + 1} (${batch.length} items) failed: ${r.message}`,
+      );
+      continue;
+    }
+    gradesUpserted += r.data.upserted;
+  }
+
+  return { snapshots: snapshotsUpserted, grades: gradesUpserted, errors };
+}
+
+function formatErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/crux/lib/scorecards/fmti.ts
+++ b/crux/lib/scorecards/fmti.ts
@@ -1,0 +1,613 @@
+/**
+ * Stanford FMTI (Foundation Model Transparency Index) Parser & Transformer
+ *
+ * Parses the CC-BY-4.0 CSVs published at github.com/stanford-crfm/fmti and
+ * shapes them into the unified `scorecard_snapshots` + `scorecard_grades`
+ * record types from QUA-688 Phase 1.
+ *
+ * Data structure across waves:
+ *   - Dec 2025: Dec2025_indicators.csv (Domain, Subdomain, Indicator, ...)
+ *               Dec2025_scores.csv     (Indicator, <org1>, <org2>, ...)
+ *   - May 2024: May2024_scores.csv (Indicator, <org1>, ...) — no Domain/Subdomain
+ *   - Oct 2023: October2023_scores.csv (Domain, Subdomain, Indicator, <orgs>, Total)
+ *
+ * This module is pure — it does not fetch, does not POST. See
+ * `fmti-ingest.ts` for the orchestration layer.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single indicator definition (from indicators.csv or inline scores file). */
+export interface FmtiIndicator {
+  domain: string;
+  subdomain: string;
+  name: string;
+}
+
+/** A score row: indicator name + binary 0/1 score per org. */
+export interface FmtiScoreRow {
+  indicator: string;
+  // Per-org score; missing/blank → null. Values are "0" or "1" in the source.
+  scores: Record<string, number | null>;
+}
+
+/** Wave configuration. */
+export interface FmtiWave {
+  /** Stable id for the snapshot row (e.g. `fmti-dec-2025`). */
+  snapshotId: string;
+  /** Human label (e.g. `v1.2 Dec 2025`). */
+  waveLabel: string;
+  /** ISO date `YYYY-MM-DD`. */
+  publishedAt: string;
+  /** Sub-path under repo, e.g. `Dec2025`. */
+  pathPrefix: string;
+  /** Score CSV filename. */
+  scoresFile: string;
+  /**
+   * Indicator-definitions CSV filename — null when the wave's scores CSV
+   * is integrated (Domain, Subdomain, Indicator inline).
+   */
+  indicatorsFile: string | null;
+  /**
+   * True when the scores file's first three columns are
+   * `Domain, Subdomain, Indicator` and a trailing `Total` column is present
+   * (Oct 2023 layout).
+   */
+  scoresHasDomain: boolean;
+  /** GitHub-flavored canonical URL for this wave (used as sourceUrl). */
+  sourceUrl: string;
+  methodologyUrl: string | null;
+}
+
+/** Snapshot record matching the `/api/scorecard-snapshots/sync` schema. */
+export interface ScorecardSnapshotRecord {
+  id: string;
+  scorecardSource: "fmti";
+  waveLabel: string;
+  publishedAt: string;
+  sourceUrl: string;
+  methodologyUrl: string | null;
+  license: string;
+  orgCount: number;
+  dimensionCount: number;
+  notes: string | null;
+  isLatest: boolean;
+  sourceActive: boolean;
+}
+
+/** Grade record matching the `/api/scorecard-grades/sync` schema. */
+export interface ScorecardGradeRecord {
+  id: string;
+  snapshotId: string;
+  entityId: string;
+  entityDisplayName: string;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  dimensionWeight: number | null;
+  dimensionParentSlug: string | null;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+  notes: string | null;
+  sourceUrl: string | null;
+}
+
+/** Result returned by buildGradeRecords for one wave. */
+export interface BuildResult {
+  snapshot: ScorecardSnapshotRecord;
+  grades: ScorecardGradeRecord[];
+  /** Orgs from the CSV that the caller passed `null` for in `orgEntityIds` — skipped. */
+  unresolvedOrgs: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FMTI_REPO_RAW = "https://raw.githubusercontent.com/stanford-crfm/fmti/main";
+
+const DOMAIN_ORDER: Record<string, number> = {
+  Upstream: 1,
+  Model: 2,
+  Downstream: 3,
+};
+
+/** All known FMTI waves, ordered oldest → newest. */
+export const FMTI_WAVES: readonly FmtiWave[] = [
+  {
+    snapshotId: "fmti-oct-2023",
+    waveLabel: "v1.0 October 2023",
+    publishedAt: "2023-10-18",
+    pathPrefix: "October2023",
+    scoresFile: "October2023_scores.csv",
+    indicatorsFile: null,
+    scoresHasDomain: true,
+    sourceUrl: "https://crfm.stanford.edu/fmti/October2023/",
+    methodologyUrl: "https://arxiv.org/abs/2310.12941",
+  },
+  {
+    snapshotId: "fmti-may-2024",
+    waveLabel: "v1.1 May 2024",
+    publishedAt: "2024-05-21",
+    pathPrefix: "May2024",
+    scoresFile: "May2024_scores.csv",
+    indicatorsFile: null,
+    scoresHasDomain: false,
+    sourceUrl: "https://crfm.stanford.edu/fmti/May2024/",
+    methodologyUrl: "https://arxiv.org/abs/2407.12929",
+  },
+  {
+    snapshotId: "fmti-dec-2025",
+    waveLabel: "v1.2 December 2025",
+    publishedAt: "2025-12-01",
+    pathPrefix: "Dec2025",
+    scoresFile: "Dec2025_scores.csv",
+    indicatorsFile: "Dec2025_indicators.csv",
+    scoresHasDomain: false,
+    sourceUrl: "https://crfm.stanford.edu/fmti/",
+    methodologyUrl: "https://crfm.stanford.edu/fmti/",
+  },
+] as const;
+
+/** Build the github raw URL for a wave's CSV file. */
+export function fmtiRawUrl(wave: FmtiWave, file: string): string {
+  return `${FMTI_REPO_RAW}/${wave.pathPrefix}/${file}`;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parser (RFC4180-ish, sufficient for FMTI files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse CSV text into rows of fields. Handles quoted fields with embedded
+ * newlines, commas, and escaped quotes (`""` → `"`).
+ *
+ * Strips a leading UTF-8 BOM if present (Oct 2023 CSV has one).
+ */
+export function parseCsv(csv: string): string[][] {
+  const text = csv.charCodeAt(0) === 0xfeff ? csv.slice(1) : csv;
+  const rows: string[][] = [];
+  let cur: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"' && text[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        field += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        cur.push(field);
+        field = "";
+      } else if (ch === "\n") {
+        cur.push(field);
+        rows.push(cur);
+        cur = [];
+        field = "";
+      } else if (ch === "\r") {
+        // skip — handled by \n
+      } else {
+        field += ch;
+      }
+    }
+  }
+  // Trailing field / row (file may not end with \n).
+  if (field !== "" || cur.length > 0) {
+    cur.push(field);
+    rows.push(cur);
+  }
+  // Drop trailing all-empty row (CSVs that end with \n produce one).
+  while (rows.length > 0 && rows[rows.length - 1].every((f) => f === "")) {
+    rows.pop();
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Wave-specific parsers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Dec2025-style indicators.csv with columns:
+ *   Domain, Subdomain, Indicator, Definition, Notes, Example disclosure
+ *
+ * Returns a list keyed by indicator name (preserving file order).
+ */
+export function parseFmtiIndicators(csv: string): FmtiIndicator[] {
+  const rows = parseCsv(csv);
+  if (rows.length < 2) return [];
+
+  const header = rows[0].map((c) => c.trim());
+  const domainIdx = header.indexOf("Domain");
+  const subdomainIdx = header.indexOf("Subdomain");
+  const indicatorIdx = header.indexOf("Indicator");
+  if (domainIdx === -1 || subdomainIdx === -1 || indicatorIdx === -1) {
+    throw new Error(
+      `FMTI indicators CSV missing expected columns. Got header: ${header.join(", ")}`,
+    );
+  }
+
+  const out: FmtiIndicator[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const name = (r[indicatorIdx] ?? "").trim();
+    if (!name) continue;
+    out.push({
+      domain: (r[domainIdx] ?? "").trim(),
+      subdomain: (r[subdomainIdx] ?? "").trim(),
+      name,
+    });
+  }
+  return out;
+}
+
+/**
+ * Parse a flat scores CSV (Dec2025 / May2024 layout) with header:
+ *   Indicator, <org1>, <org2>, ...
+ *
+ * Returns one row per indicator with per-org binary scores.
+ */
+export function parseFmtiFlatScores(csv: string): {
+  orgs: string[];
+  rows: FmtiScoreRow[];
+} {
+  const rows = parseCsv(csv);
+  if (rows.length < 2) return { orgs: [], rows: [] };
+
+  const header = rows[0].map((c) => c.trim());
+  if (header[0] !== "Indicator") {
+    throw new Error(
+      `FMTI flat scores CSV first column should be "Indicator". Got header: ${header.join(", ")}`,
+    );
+  }
+  const orgs = header.slice(1).filter((h) => h.length > 0);
+
+  const out: FmtiScoreRow[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const indicator = (r[0] ?? "").trim();
+    if (!indicator) continue;
+    const scores: Record<string, number | null> = {};
+    for (let j = 0; j < orgs.length; j++) {
+      const cell = (r[j + 1] ?? "").trim();
+      scores[orgs[j]] = parseScoreCell(cell);
+    }
+    out.push({ indicator, scores });
+  }
+  return { orgs, rows: out };
+}
+
+/**
+ * Parse the Oct 2023 integrated scores CSV with header:
+ *   Domain, Subdomain, Indicator, <org1>, <org2>, ..., Total
+ *
+ * The trailing `Total` column is dropped.
+ */
+export function parseFmtiOct2023Scores(csv: string): {
+  orgs: string[];
+  rows: Array<FmtiScoreRow & { domain: string; subdomain: string }>;
+} {
+  const rows = parseCsv(csv);
+  if (rows.length < 2) return { orgs: [], rows: [] };
+
+  const header = rows[0].map((c) => c.trim());
+  if (
+    header[0] !== "Domain" ||
+    header[1] !== "Subdomain" ||
+    header[2] !== "Indicator"
+  ) {
+    throw new Error(
+      `FMTI Oct2023 scores CSV expected first columns Domain,Subdomain,Indicator. Got: ${header.join(", ")}`,
+    );
+  }
+  // Drop trailing Total column from the org list, if present.
+  const orgEnd = header[header.length - 1] === "Total"
+    ? header.length - 1
+    : header.length;
+  const orgs = header.slice(3, orgEnd).filter((h) => h.length > 0);
+
+  const out: Array<FmtiScoreRow & { domain: string; subdomain: string }> = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const indicator = (r[2] ?? "").trim();
+    if (!indicator) continue;
+    const domain = (r[0] ?? "").trim();
+    const subdomain = (r[1] ?? "").trim();
+    // Skip aggregate footer rows like `,,Total,54,53,...` that the
+    // October 2023 file appends at the bottom.
+    if (!domain && !subdomain && indicator.toLowerCase() === "total") continue;
+    const scores: Record<string, number | null> = {};
+    for (let j = 0; j < orgs.length; j++) {
+      const cell = (r[j + 3] ?? "").trim();
+      scores[orgs[j]] = parseScoreCell(cell);
+    }
+    out.push({ domain, subdomain, indicator, scores });
+  }
+  return { orgs, rows: out };
+}
+
+function parseScoreCell(cell: string): number | null {
+  if (cell === "" || cell === "-" || cell.toLowerCase() === "n/a") return null;
+  const n = Number(cell);
+  if (Number.isFinite(n)) return n;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Slug helpers
+// ---------------------------------------------------------------------------
+
+/** Lowercase kebab-case slug. */
+export function slugify(s: string): string {
+  return s
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "") // strip combining marks
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Compose a parent slug for a domain (e.g. `upstream`). */
+export function domainSlug(domain: string): string {
+  return slugify(domain);
+}
+
+/**
+ * Compose a parent slug for a subdomain. Prefixed with the domain to keep
+ * slugs unique even if subdomain names ever overlap across domains.
+ */
+export function subdomainSlug(domain: string, subdomain: string): string {
+  return `${slugify(domain)}--${slugify(subdomain)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Builder — given parsed indicators + scores + org resolver → records
+// ---------------------------------------------------------------------------
+
+/** Org resolver: org display name → entity stableId or null (unresolved). */
+export type OrgResolver = (orgName: string) => string | null;
+
+interface BuildOptions {
+  wave: FmtiWave;
+  /** True for the wave that should be tagged `is_latest=true`. */
+  isLatest: boolean;
+  /** Indicators with domain/subdomain. */
+  indicators: FmtiIndicator[];
+  /** Score rows aligned by `indicator` name to `indicators`. */
+  scores: FmtiScoreRow[];
+  /** Org names appearing in scores file. */
+  orgs: string[];
+  /** Resolves org display name → entity stableId. */
+  resolveOrg: OrgResolver;
+}
+
+/**
+ * Build a snapshot row + all grade rows for one FMTI wave.
+ *
+ * Per (resolved) org, emits:
+ *   - 100 indicator-level grades (parent: subdomain)
+ *   - ~13–19 subdomain rollups (parent: domain) — mean × 100
+ *   - 3 domain rollups (parent: overall)         — mean × 100
+ *   - 1 overall grade                            — mean × 100
+ *
+ * Indicators present in the scores CSV but missing from the indicators
+ * list are emitted with empty domain/subdomain (parent: overall) — this
+ * keeps degenerate input safe but is signalled via a non-empty
+ * `unresolvedOrgs` list when it happens. (Currently it does not.)
+ */
+export function buildFmtiRecords(opts: BuildOptions): BuildResult {
+  const { wave, isLatest, indicators, scores, orgs, resolveOrg } = opts;
+
+  const indicatorMap = new Map(indicators.map((i) => [i.name, i] as const));
+
+  // Resolve orgs once.
+  const resolved: Array<{ name: string; entityId: string }> = [];
+  const unresolvedOrgs: string[] = [];
+  for (const o of orgs) {
+    const id = resolveOrg(o);
+    if (id) resolved.push({ name: o, entityId: id });
+    else unresolvedOrgs.push(o);
+  }
+
+  // Stable order: domain, subdomain, indicator name.
+  const indicatorOrder = (i: FmtiIndicator) =>
+    `${(DOMAIN_ORDER[i.domain] ?? 9).toString().padStart(2, "0")}|${i.subdomain}|${i.name}`;
+  const orderedIndicators = [...indicators].sort(
+    (a, b) => indicatorOrder(a).localeCompare(indicatorOrder(b)),
+  );
+
+  const grades: ScorecardGradeRecord[] = [];
+
+  for (const { name: orgName, entityId } of resolved) {
+    // Per-indicator grades + accumulators for rollups.
+    const subdomainAcc = new Map<
+      string,
+      { domain: string; subdomain: string; sum: number; n: number }
+    >();
+    const domainAcc = new Map<string, { sum: number; n: number }>();
+    let overallSum = 0;
+    let overallN = 0;
+
+    for (const sr of scores) {
+      const ind = indicatorMap.get(sr.indicator);
+      const score = sr.scores[orgName];
+      if (score == null) continue;
+
+      const indicatorSlug = slugify(sr.indicator);
+      const subSlug = ind ? subdomainSlug(ind.domain, ind.subdomain) : null;
+      const domSlug = ind ? domainSlug(ind.domain) : null;
+
+      grades.push({
+        id: gradeId(wave.snapshotId, entityId, indicatorSlug),
+        snapshotId: wave.snapshotId,
+        entityId,
+        entityDisplayName: orgName,
+        dimensionSlug: indicatorSlug,
+        dimensionLabel: sr.indicator,
+        dimensionWeight: null,
+        dimensionParentSlug: subSlug ?? "overall",
+        scoreNumeric: score * 100, // 0/1 → 0/100 percent
+        scoreLetter: null,
+        scoreRaw: String(score),
+        notes: null,
+        sourceUrl: null,
+      });
+
+      if (ind) {
+        const subKey = subSlug!;
+        const accSub = subdomainAcc.get(subKey) ?? {
+          domain: ind.domain,
+          subdomain: ind.subdomain,
+          sum: 0,
+          n: 0,
+        };
+        accSub.sum += score;
+        accSub.n += 1;
+        subdomainAcc.set(subKey, accSub);
+
+        const accDom = domainAcc.get(domSlug!) ?? { sum: 0, n: 0 };
+        accDom.sum += score;
+        accDom.n += 1;
+        domainAcc.set(domSlug!, accDom);
+      }
+      overallSum += score;
+      overallN += 1;
+    }
+
+    // Sort subdomain rollups by domain order, then subdomain name.
+    const subdomainEntries = [...subdomainAcc.entries()].sort(([, a], [, b]) =>
+      `${(DOMAIN_ORDER[a.domain] ?? 9).toString().padStart(2, "0")}|${a.subdomain}`.localeCompare(
+        `${(DOMAIN_ORDER[b.domain] ?? 9).toString().padStart(2, "0")}|${b.subdomain}`,
+      ),
+    );
+    for (const [slug, acc] of subdomainEntries) {
+      const pct = acc.n === 0 ? 0 : (acc.sum / acc.n) * 100;
+      grades.push({
+        id: gradeId(wave.snapshotId, entityId, slug),
+        snapshotId: wave.snapshotId,
+        entityId,
+        entityDisplayName: orgName,
+        dimensionSlug: slug,
+        dimensionLabel: acc.subdomain,
+        dimensionWeight: null,
+        dimensionParentSlug: domainSlug(acc.domain),
+        scoreNumeric: round1(pct),
+        scoreLetter: null,
+        scoreRaw: `${acc.sum}/${acc.n}`,
+        notes: null,
+        sourceUrl: null,
+      });
+    }
+
+    // Domain rollups (Upstream → Model → Downstream).
+    const domainEntries = [...domainAcc.entries()].sort(([slugA], [slugB]) => {
+      const labelA = invertSlug(slugA, indicators);
+      const labelB = invertSlug(slugB, indicators);
+      return (DOMAIN_ORDER[labelA] ?? 9) - (DOMAIN_ORDER[labelB] ?? 9);
+    });
+    for (const [slug, acc] of domainEntries) {
+      const label = invertSlug(slug, indicators);
+      const pct = acc.n === 0 ? 0 : (acc.sum / acc.n) * 100;
+      grades.push({
+        id: gradeId(wave.snapshotId, entityId, slug),
+        snapshotId: wave.snapshotId,
+        entityId,
+        entityDisplayName: orgName,
+        dimensionSlug: slug,
+        dimensionLabel: label,
+        dimensionWeight: null,
+        dimensionParentSlug: "overall",
+        scoreNumeric: round1(pct),
+        scoreLetter: null,
+        scoreRaw: `${acc.sum}/${acc.n}`,
+        notes: null,
+        sourceUrl: null,
+      });
+    }
+
+    // Overall.
+    const overallPct = overallN === 0 ? 0 : (overallSum / overallN) * 100;
+    grades.push({
+      id: gradeId(wave.snapshotId, entityId, "overall"),
+      snapshotId: wave.snapshotId,
+      entityId,
+      entityDisplayName: orgName,
+      dimensionSlug: "overall",
+      dimensionLabel: "Overall",
+      dimensionWeight: null,
+      dimensionParentSlug: null,
+      scoreNumeric: round1(overallPct),
+      scoreLetter: null,
+      scoreRaw: `${overallSum}/${overallN}`,
+      notes: null,
+      sourceUrl: null,
+    });
+  }
+
+  // Distinct dimensions across all grades for orgCount/dimensionCount.
+  const distinctDimensions = new Set(grades.map((g) => g.dimensionSlug));
+
+  const snapshot: ScorecardSnapshotRecord = {
+    id: wave.snapshotId,
+    scorecardSource: "fmti",
+    waveLabel: wave.waveLabel,
+    publishedAt: wave.publishedAt,
+    sourceUrl: wave.sourceUrl,
+    methodologyUrl: wave.methodologyUrl,
+    license: "CC-BY-4.0",
+    orgCount: resolved.length,
+    dimensionCount: distinctDimensions.size,
+    notes: unresolvedOrgs.length === 0
+      ? null
+      : `Unresolved orgs (skipped): ${unresolvedOrgs.join(", ")}`,
+    isLatest,
+    sourceActive: true,
+  };
+
+  return { snapshot, grades, unresolvedOrgs };
+}
+
+/**
+ * Compose a deterministic grade id within the 200-char primary-key limit.
+ * Format: `<snapshotId>__<entitySidShort>__<dimensionSlug>`. We truncate
+ * `entityId` only if a wildly long stableId surprised us — the schema
+ * caps `id` at 300 chars in the sync schema (Zod), but the `things` table
+ * `id` column is 300 chars too. Stay well under both.
+ */
+function gradeId(
+  snapshotId: string,
+  entityId: string,
+  dimensionSlug: string,
+): string {
+  const id = `${snapshotId}__${entityId}__${dimensionSlug}`;
+  if (id.length <= 250) return id;
+  // Pathological: trim the dimension slug. We never expect this in practice.
+  const room = 250 - snapshotId.length - entityId.length - 4;
+  return `${snapshotId}__${entityId}__${dimensionSlug.slice(0, Math.max(8, room))}`;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Reverse a domain slug back to the original Domain label by scanning the
+ * indicators list. Falls back to a Title-Case approximation.
+ */
+function invertSlug(slug: string, indicators: FmtiIndicator[]): string {
+  for (const i of indicators) {
+    if (slugify(i.domain) === slug) return i.domain;
+  }
+  return slug.replace(/(^|-)(.)/g, (_, sep, ch) => (sep ? " " : "") + ch.toUpperCase()).trim();
+}

--- a/data/scorecards/fmti-org-overrides.yaml
+++ b/data/scorecards/fmti-org-overrides.yaml
@@ -1,0 +1,41 @@
+# Manual org-name → entity-slug overrides for the FMTI ingester.
+#
+# The ingester's resolver tries (1) overrides → (2) direct entity matcher
+# (title/alias) → (3) normalized name (strips Inc., Labs, ...) before falling
+# back to creating a stub entity (only when --ensure-stub-entities is set).
+#
+# Add an entry here for any FMTI display name that doesn't match a real
+# entity slug or alias automatically. Keys MUST match the column header in
+# the FMTI scores CSV exactly (case-sensitive).
+#
+# Source: github.com/stanford-crfm/fmti
+overrides:
+  # Dec 2025 wave (13 orgs)
+  "AI21 Labs": ai21-labs
+  Alibaba: alibaba
+  Amazon: amazon
+  Anthropic: anthropic
+  DeepSeek: deepseek
+  Google: google
+  IBM: ibm
+  Meta: meta-ai
+  Midjourney: midjourney
+  Mistral: mistral-ai
+  OpenAI: openai
+  Writer: writer
+  xAI: xai
+
+  # May 2024 wave (14 orgs) — adds Adept, Aleph Alpha, BigCode, Microsoft,
+  # Stability; drops Alibaba, DeepSeek, Midjourney, xAI.
+  Adept: adept
+  "Aleph Alpha": aleph-alpha
+  BigCode: bigcode
+  Microsoft: microsoft
+  Stability: stability-ai
+
+  # Oct 2023 wave (10 orgs) — adds Cohere, Hugging Face, Inflection, Stability AI;
+  # also "Stability AI" (trailing AI) as an alias.
+  Cohere: cohere
+  "Hugging Face": hugging-face
+  Inflection: inflection-ai
+  "Stability AI": stability-ai


### PR DESCRIPTION
## Summary

Phase 1 follow-up to **QUA-688**: ingests Stanford CRFM's [Foundation Model Transparency Index](https://github.com/stanford-crfm/fmti) CSVs (CC-BY-4.0) into the unified `scorecard_snapshots` + `scorecard_grades` PG tables shipped in PR #4589.

**Stacked on `claude/qua-688-scorecard-mirror`.** This PR depends on #4589 merging first — the schema, sync handlers, and matrix UI it writes into all live there. Re-target to `main` (or rebase) once #4589 lands.

Fixes QUA-697.

## What ships

| File | What |
|---|---|
| `crux/lib/scorecards/fmti.ts` | Pure parser + record builder. RFC4180 CSV parser handles BOM, multiline fields, escaped quotes. Three wave-shape parsers cover Dec 2025 (split indicators+scores files), May 2024 (scores-only), Oct 2023 (integrated with `Total` footer). |
| `crux/lib/scorecards/fmti-ingest.ts` | Fetch + sync orchestration. Cross-wave indicator enrichment: when a wave lacks an indicators-defs file (May 2024), domain/subdomain hierarchy is borrowed from sibling waves by name match. Org resolver: overrides → matcher → normalized name → optional stub. |
| `crux/commands/scorecards.ts` | `crux scorecards fmti ingest [--wave=ID] [--dry-run] [--ensure-stubs]` — `--dry-run` is the safe non-mutating default; `--ensure-stubs` opts into creating lightweight `organization` stub entities for unresolved orgs. |
| `data/scorecards/fmti-org-overrides.yaml` | Display-name → entity-slug overrides for the 14 unique orgs across all three waves (Adept, AI21 Labs, Aleph Alpha, Alibaba, BigCode, Cohere, Hugging Face, Inflection, Microsoft, Midjourney, Mistral, Stability AI, Writer, xAI, …). |
| `crux/lib/scorecards/__tests__/` | 39 tests (32 parser/builder + 7 orchestration) with small fixture CSVs. |

## Per-snapshot grade shape

For each wave + each resolved org:

```
overall (parent: null)
└── upstream (parent: overall)
    └── upstream--data-acquisition (parent: upstream)
        └── data-acquisition-methods (parent: upstream--data-acquisition)
        └── public-datasets (parent: upstream--data-acquisition)
        └── …
```

= 100 indicator grades + N subdomain rollups + 3 domain rollups + 1 overall row per org. The latest wave (Dec 2025) gets `is_latest=true`; older waves stay false. Subdomain/domain rollups are computed as percent-of-indicators-scored-1, rounded to one decimal.

## Test plan

- [x] `pnpm test` — 7793 crux tests + 1380 wiki-server + 1699 apps/web all green
- [x] `pnpm build` — green
- [x] `pnpm crux w validate gate --no-cache` — 55/55 pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — zero new errors in this PR's code
- [x] Real-fetch dry-run, no overrides: correctly resolves 9/13 Dec 2025 orgs, reports 4 unresolved (`AI21 Labs, Alibaba, Midjourney, Writer`) so the operator can choose between adding to overrides or `--ensure-stubs`.
- [x] Real-fetch dry-run with `--ensure-stubs`: all three waves resolve fully — Oct 2023 (10 orgs / 1270 grades), May 2024 (14 / 1848), Dec 2025 (13 / 1599).

## How to ingest after this lands

```bash
# 1. Verify dry-run looks right
pnpm crux scorecards fmti ingest --dry-run --ensure-stubs

# 2. Live ingest (this is idempotent — re-running upserts the same rows)
pnpm crux scorecards fmti ingest --ensure-stubs
```

`--ensure-stubs` creates lightweight `organization` stub entities for the orgs whose entity slugs don't already exist (Midjourney, Writer, etc.). Stub entities have `metadata.stub: true` so directory pages can exclude them; they can be promoted to wiki pages later.

## Out of scope (handled by sibling tickets)

- **QUA-698** — FLI / SaferAI / AI Lab Watch / Seoul Tracker ingesters. ~350 rows aggregate. Those sources need scrape + LLM extraction; this PR is intentionally limited to the cheap CC-BY-4.0 CSV path.
- The deploy tasks GH detected (migration 0207, schema, scorecard-* routes) all belong to PR #4589, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
