### PR TITLE
QUA-698: scorecard ingesters — FLI / SaferAI / AI Lab Watch / Seoul

### DIFF
--- a/crux/commands/import-scorecards.ts
+++ b/crux/commands/import-scorecards.ts
@@ -1,0 +1,180 @@
+/**
+ * Import external AI-safety scorecards into wiki-server Postgres (QUA-698).
+ *
+ * Sources (FMTI lives in QUA-697 — separate command):
+ *   - fli_index       FLI AI Safety Index (LLM-extracted from HTML/PDF)
+ *   - saferai         SaferAI Ratings (snapshot of the live ratings site)
+ *   - ailabwatch      AI Lab Watch (frozen Sept 2025)
+ *   - seoul_tracker   The Midas Project Seoul Commitment Tracker
+ *
+ * Each adapter reads from `data/scorecards/raw/<source>/<wave>/grades.json`.
+ * The fetch + extract steps that produce those files are intentionally
+ * out-of-band (manual or LLM-assisted) — this command only handles the
+ * pipeline from cached JSON to wiki-server. Re-runs are idempotent
+ * because IDs are deterministic (`<snapshotId>|<entityId>|<dimensionSlug>`).
+ *
+ * Usage:
+ *   pnpm crux tb import-scorecards analyze                # all sources
+ *   pnpm crux tb import-scorecards analyze --source=fli_index
+ *   pnpm crux tb import-scorecards sync --dry-run         # all, no writes
+ *   pnpm crux tb import-scorecards sync --source=saferai
+ */
+
+import { ALL_SOURCES, getAdapter, listSourceKeys } from "../lib/scorecard-import/sources/index.ts";
+import { buildOrgResolver } from "../lib/scorecard-import/org-aliases.ts";
+import { analyzeSource, syncSource } from "../lib/scorecard-import/sync.ts";
+import type { ScorecardSourceAdapter, ScorecardSourceKey } from "../lib/scorecard-import/types.ts";
+
+type CommandResult = { exitCode?: number; output?: string };
+
+function pickSources(sourceFilter?: string): ScorecardSourceAdapter[] {
+  if (!sourceFilter) return [...ALL_SOURCES];
+  const adapter = ALL_SOURCES.find((a) => a.source === sourceFilter);
+  if (!adapter) {
+    throw new Error(
+      `Unknown scorecard source "${sourceFilter}". Available: ${listSourceKeys().join(", ")}`,
+    );
+  }
+  return [adapter];
+}
+
+async function cmdAnalyze(sourceFilter?: string): Promise<CommandResult> {
+  const sources = pickSources(sourceFilter);
+  const ctx = buildOrgResolver();
+
+  console.log("=== Scorecard Import Analysis ===\n");
+
+  let allUnresolved: string[] = [];
+  for (const adapter of sources) {
+    const a = analyzeSource(adapter, ctx);
+    const unresolvedCount = a.unresolved.length;
+    const status = unresolvedCount === 0 ? "✓" : "✗";
+    console.log(
+      `${status} ${adapter.name} (${a.source})`,
+    );
+    console.log(
+      `    snapshots: ${a.snapshots}  grades: ${a.grades}  orgs: ${a.uniqueOrgs}  resolved: ${a.resolved}/${a.grades}`,
+    );
+    if (unresolvedCount > 0) {
+      console.log(`    unresolved orgs:`);
+      for (const name of a.unresolved) {
+        console.log(`      - ${name}`);
+      }
+      allUnresolved.push(...a.unresolved.map((n) => `${a.source}: ${n}`));
+    }
+    console.log("");
+  }
+
+  if (allUnresolved.length > 0) {
+    console.log(
+      `\n${allUnresolved.length} unresolved org name(s) total. Add aliases to data/scorecards/org-aliases.yaml or to the entity's aliases: block in data/entities/.`,
+    );
+    return { exitCode: 1 };
+  }
+  return { exitCode: 0 };
+}
+
+async function cmdSync(
+  dryRun: boolean,
+  sourceFilter: string | undefined,
+  verbose: boolean,
+): Promise<CommandResult> {
+  const sources = pickSources(sourceFilter);
+  const ctx = buildOrgResolver();
+
+  console.log(`=== Scorecard Import Sync${dryRun ? " (dry run)" : ""} ===\n`);
+
+  for (const adapter of sources) {
+    try {
+      const r = await syncSource(adapter, ctx, { dryRun, verbose });
+      const verb = dryRun ? "would sync" : "synced";
+      console.log(
+        `✓ ${adapter.name}: ${verb} ${r.snapshots} snapshot(s), ${r.grades} grade(s)`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`✗ ${adapter.name}: ${message}`);
+      return { exitCode: 1 };
+    }
+  }
+
+  return { exitCode: 0 };
+}
+
+async function cmdList(): Promise<CommandResult> {
+  console.log("=== Scorecard Sources ===\n");
+  const ctx = buildOrgResolver();
+  for (const adapter of ALL_SOURCES) {
+    const a = analyzeSource(adapter, ctx);
+    console.log(`  ${adapter.source.padEnd(16)} ${adapter.name}`);
+    console.log(
+      `    ${a.snapshots} snapshot(s) on disk, ${a.grades} grade(s), ${a.unresolved.length} unresolved`,
+    );
+  }
+  console.log("");
+  return { exitCode: 0 };
+}
+
+// ---- Crux command exports ----
+
+async function analyzeCommand(
+  _args: string[],
+  options: Record<string, unknown>,
+): Promise<CommandResult> {
+  return cmdAnalyze((options.source as string) || undefined);
+}
+
+async function syncCommand(
+  _args: string[],
+  options: Record<string, unknown>,
+): Promise<CommandResult> {
+  const dryRun = !!options.dryRun || !!options["dry-run"];
+  const verbose = !!options.verbose;
+  const sourceFilter = (options.source as string) || undefined;
+  return cmdSync(dryRun, sourceFilter, verbose);
+}
+
+async function listCommand(
+  _args: string[],
+  _options: Record<string, unknown>,
+): Promise<CommandResult> {
+  return cmdList();
+}
+
+export const commands = {
+  analyze: analyzeCommand,
+  sync: syncCommand,
+  list: listCommand,
+  default: analyzeCommand,
+};
+
+export function getHelp(): string {
+  return `
+Import Scorecards — Mirror external AI-safety scorecards (QUA-698)
+
+Commands:
+  analyze              Preview snapshots, grades, and unresolved orgs
+  sync                 Upsert all snapshots + grades to wiki-server
+  sync --dry-run       Show what would be synced without writing
+  list                 List available source adapters and on-disk state
+
+Options:
+  --source=<key>       Filter to a single source (fli_index, saferai,
+                       ailabwatch, seoul_tracker)
+  --verbose            Print API payloads (debug)
+  --dry-run            Skip the wiki-server POST
+
+Sources:
+  ${ALL_SOURCES.map((s) => `- ${s.source.padEnd(16)} (${s.name})`).join("\n  ")}
+
+Raw input layout:
+  data/scorecards/raw/<source>/<wave-slug>/grades.json
+
+Reruns are idempotent — IDs are derived from snapshotId + entityId +
+dimensionSlug. Add new aliases to data/scorecards/org-aliases.yaml.
+`;
+}
+
+export function _internalGetAdapter(source: ScorecardSourceKey) {
+  return getAdapter(source);
+}

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -82,6 +82,7 @@ import * as factbaseImport990Commands from './commands/factbase-import-990.ts';
 import * as footnotesCommands from './commands/footnotes.ts';
 import * as agentWorkspaceCommands from './commands/agent-workspace.ts';
 import * as importGrantsCommands from './commands/import-grants.ts';
+import * as importScorecardsCommands from './commands/import-scorecards.ts';
 import * as backfillGranteeIdsCommands from './commands/backfill-grantee-ids.ts';
 import * as backfillProgramIdsCommands from './commands/backfill-program-ids.ts';
 import * as importDivisionsCommands from './commands/import-divisions.ts';
@@ -180,6 +181,7 @@ const domains = {
   footnotes: footnotesCommands,
   'agent-workspace': agentWorkspaceCommands,
   'import-grants': importGrantsCommands,
+  'import-scorecards': importScorecardsCommands,
   'backfill-grantee-ids': backfillGranteeIdsCommands,
   'backfill-program-ids': backfillProgramIdsCommands,
   'import-divisions': importDivisionsCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -96,6 +96,7 @@ export const GROUPS: Record<string, GroupDef> = {
       // dash-form aliases (`import-divisions-sync`, etc.) still resolve via
       // the flattened path.
       'import-grants',
+      'import-scorecards',
       'import-divisions',
       'import-funding-programs',
       'data-sources',

--- a/crux/lib/scorecard-import/__tests__/fixtures/ailabwatch-2025-09.json
+++ b/crux/lib/scorecard-import/__tests__/fixtures/ailabwatch-2025-09.json
@@ -1,0 +1,43 @@
+{
+  "publishedAt": "2025-09-01",
+  "waveLabel": "Final (Sept 2025)",
+  "sourceUrl": "https://ailabwatch.org",
+  "isLatest": true,
+  "dimensions": [
+    { "slug": "risk-assessment", "label": "Risk Assessment", "weight": 0.2 },
+    { "slug": "scheming-prevention", "label": "Scheming Prevention", "weight": 0.15 },
+    { "slug": "safety-research", "label": "Safety Research", "weight": 0.15 },
+    { "slug": "misuse-prevention", "label": "Misuse Prevention", "weight": 0.1 },
+    { "slug": "security", "label": "Security", "weight": 0.1 },
+    { "slug": "info-sharing", "label": "Info Sharing", "weight": 0.15 },
+    { "slug": "planning", "label": "Planning", "weight": 0.15 }
+  ],
+  "grades": [
+    {
+      "org": "Anthropic",
+      "scores": {
+        "overall": "55%",
+        "risk-assessment": "60%",
+        "scheming-prevention": "45%",
+        "safety-research": "70%",
+        "misuse-prevention": "50%",
+        "security": "60%",
+        "info-sharing": "50%",
+        "planning": "55%"
+      }
+    },
+    {
+      "org": "OpenAI",
+      "scores": {
+        "overall": "30%",
+        "risk-assessment": "35%",
+        "scheming-prevention": "20%",
+        "safety-research": "40%",
+        "misuse-prevention": "30%",
+        "security": "30%",
+        "info-sharing": "25%",
+        "planning": "30%"
+      }
+    }
+  ]
+}

--- a/crux/lib/scorecard-import/__tests__/fixtures/fli-summer-2025.json
+++ b/crux/lib/scorecard-import/__tests__/fixtures/fli-summer-2025.json
@@ -1,0 +1,54 @@
+{
+  "publishedAt": "2025-07-15",
+  "waveLabel": "Summer 2025",
+  "sourceUrl": "https://futureoflife.org/ai-safety-index-summer-2025/",
+  "methodologyUrl": "https://futureoflife.org/document/ai-safety-index-2025-methodology/",
+  "license": "CC BY 4.0",
+  "isLatest": true,
+  "dimensions": [
+    { "slug": "risk-assessment", "label": "Risk Assessment" },
+    { "slug": "current-harms", "label": "Current Harms" },
+    { "slug": "safety-frameworks", "label": "Safety Frameworks" },
+    { "slug": "existential-safety", "label": "Existential Safety Strategy" },
+    { "slug": "governance", "label": "Governance & Accountability" },
+    { "slug": "info-sharing", "label": "Information Sharing" }
+  ],
+  "grades": [
+    {
+      "org": "Anthropic",
+      "scores": {
+        "overall": "C+",
+        "risk-assessment": "C+",
+        "current-harms": "B-",
+        "safety-frameworks": "C+",
+        "existential-safety": "D+",
+        "governance": "C",
+        "info-sharing": "C+"
+      }
+    },
+    {
+      "org": "Google DeepMind",
+      "scores": {
+        "overall": "C-",
+        "risk-assessment": "D+",
+        "current-harms": "C",
+        "safety-frameworks": "C-",
+        "existential-safety": "D",
+        "governance": "C-",
+        "info-sharing": "C"
+      }
+    },
+    {
+      "org": "OpenAI",
+      "scores": {
+        "overall": "D+",
+        "risk-assessment": "D",
+        "current-harms": "C-",
+        "safety-frameworks": "C-",
+        "existential-safety": "F",
+        "governance": "D",
+        "info-sharing": "D+"
+      }
+    }
+  ]
+}

--- a/crux/lib/scorecard-import/__tests__/fixtures/fli-winter-2025.json
+++ b/crux/lib/scorecard-import/__tests__/fixtures/fli-winter-2025.json
@@ -1,0 +1,28 @@
+{
+  "publishedAt": "2025-02-15",
+  "waveLabel": "Winter 2025",
+  "sourceUrl": "https://futureoflife.org/ai-safety-index-winter-2025/",
+  "isLatest": false,
+  "dimensions": [
+    { "slug": "risk-assessment", "label": "Risk Assessment" },
+    { "slug": "current-harms", "label": "Current Harms" }
+  ],
+  "grades": [
+    {
+      "org": "Anthropic",
+      "scores": {
+        "overall": "C",
+        "risk-assessment": "C",
+        "current-harms": "C+"
+      }
+    },
+    {
+      "org": "OpenAI",
+      "scores": {
+        "overall": "D",
+        "risk-assessment": "D-",
+        "current-harms": "D+"
+      }
+    }
+  ]
+}

--- a/crux/lib/scorecard-import/__tests__/fixtures/saferai-2026-04.json
+++ b/crux/lib/scorecard-import/__tests__/fixtures/saferai-2026-04.json
@@ -1,0 +1,45 @@
+{
+  "publishedAt": "2026-04-01",
+  "waveLabel": "April 2026",
+  "sourceUrl": "https://ratings.safer-ai.org",
+  "license": "CC BY-SA 4.0",
+  "isLatest": true,
+  "dimensions": [
+    { "slug": "risk-identification", "label": "Risk Identification", "weight": 0.25 },
+    { "slug": "risk-analysis", "label": "Risk Analysis & Evaluation", "weight": 0.25 },
+    { "slug": "risk-treatment", "label": "Risk Treatment", "weight": 0.25 },
+    { "slug": "governance", "label": "Governance", "weight": 0.25 }
+  ],
+  "grades": [
+    {
+      "org": "Anthropic",
+      "scores": {
+        "overall": "73%",
+        "risk-identification": "85%",
+        "risk-analysis": "70%",
+        "risk-treatment": "65%",
+        "governance": "72%"
+      }
+    },
+    {
+      "org": "OpenAI",
+      "scores": {
+        "overall": "42%",
+        "risk-identification": "55%",
+        "risk-analysis": "40%",
+        "risk-treatment": "35%",
+        "governance": "38%"
+      }
+    },
+    {
+      "org": "Mistral AI",
+      "scores": {
+        "overall": "12%",
+        "risk-identification": "10%",
+        "risk-analysis": "N/A",
+        "risk-treatment": "15%",
+        "governance": "10%"
+      }
+    }
+  ]
+}

--- a/crux/lib/scorecard-import/__tests__/fixtures/seoul-2025-09.json
+++ b/crux/lib/scorecard-import/__tests__/fixtures/seoul-2025-09.json
@@ -1,0 +1,38 @@
+{
+  "publishedAt": "2025-09-01",
+  "waveLabel": "September 2025",
+  "sourceUrl": "https://www.seoul-tracker.org",
+  "license": "CC BY 4.0",
+  "isLatest": true,
+  "dimensions": [
+    { "slug": "risk-thresholds", "label": "Risk Thresholds" },
+    { "slug": "safe-development", "label": "Safe Development" },
+    { "slug": "risk-evaluation", "label": "Risk Evaluation" },
+    { "slug": "transparency", "label": "Transparency" },
+    { "slug": "governance", "label": "Governance" }
+  ],
+  "grades": [
+    {
+      "org": "Anthropic",
+      "scores": {
+        "overall": "Fulfilled",
+        "risk-thresholds": "Fulfilled",
+        "safe-development": "Fulfilled",
+        "risk-evaluation": "Fulfilled",
+        "transparency": "Partial",
+        "governance": "Fulfilled"
+      }
+    },
+    {
+      "org": "OpenAI",
+      "scores": {
+        "overall": "Partial",
+        "risk-thresholds": "Partial",
+        "safe-development": "Partial",
+        "risk-evaluation": "Partial",
+        "transparency": "Unfulfilled",
+        "governance": "Partial"
+      }
+    }
+  ]
+}

--- a/crux/lib/scorecard-import/__tests__/org-aliases.test.ts
+++ b/crux/lib/scorecard-import/__tests__/org-aliases.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Org resolver tests (QUA-698).
+ *
+ * Exercises `resolveOrg` against synthetic matcher + override maps
+ * (no fs, no database.json read). The real `buildOrgResolver` is left
+ * as an integration concern.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveOrg } from "../org-aliases.ts";
+import type { OrgResolverContext } from "../org-aliases.ts";
+import type { EntityMatcher } from "../../grant-import/types.ts";
+
+function makeMatcher(map: Record<string, string>): EntityMatcher {
+  const nameMap = new Map(
+    Object.entries(map).map(([name, stableId]) => [
+      name.toLowerCase(),
+      { stableId, slug: name, name },
+    ]),
+  );
+  return {
+    allNames: nameMap,
+    match: (name: string) => nameMap.get(name.toLowerCase().trim()) || null,
+  };
+}
+
+function ctx(
+  matchMap: Record<string, string>,
+  overrides: Record<string, string> = {},
+): OrgResolverContext {
+  // Mirror the lower-case normalization that loadOverrides() does.
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(overrides)) lower[k.toLowerCase()] = v;
+  return { matcher: makeMatcher(matchMap), overrides: lower };
+}
+
+describe("resolveOrg", () => {
+  it("returns null for empty / whitespace input", () => {
+    const c = ctx({ anthropic: "sid_aaa" });
+    expect(resolveOrg(c, "")).toBeNull();
+    expect(resolveOrg(c, "   ")).toBeNull();
+  });
+
+  it("resolves via override before direct match", () => {
+    const c = ctx(
+      { anthropic: "sid_aaa", openai: "sid_bbb" },
+      // Override redirects "Mystery Lab" → openai (would otherwise fail).
+      { "Mystery Lab": "openai" },
+    );
+    expect(resolveOrg(c, "Mystery Lab")?.entityId).toBe("sid_bbb");
+  });
+
+  it("override lookup is case-insensitive on the key", () => {
+    const c = ctx(
+      { anthropic: "sid_aaa" },
+      { "ANTHROPIC PBC": "anthropic" },
+    );
+    // Override key was "ANTHROPIC PBC" but user supplies mixed case.
+    expect(resolveOrg(c, "anthropic pbc")?.entityId).toBe("sid_aaa");
+    expect(resolveOrg(c, "Anthropic Pbc")?.entityId).toBe("sid_aaa");
+  });
+
+  it("falls through to direct title/alias match when no override", () => {
+    const c = ctx({ anthropic: "sid_aaa" });
+    expect(resolveOrg(c, "Anthropic")?.entityId).toBe("sid_aaa");
+    expect(resolveOrg(c, "anthropic")?.entityId).toBe("sid_aaa");
+  });
+
+  it("falls through to normalized match (suffix-stripped)", () => {
+    const c = ctx({ anthropic: "sid_aaa" });
+    // "Anthropic, Inc." -> normalized "Anthropic" -> match.
+    expect(resolveOrg(c, "Anthropic, Inc.")?.entityId).toBe("sid_aaa");
+  });
+
+  it("returns null when nothing matches — never fabricates a sid", () => {
+    const c = ctx({ anthropic: "sid_aaa" });
+    expect(resolveOrg(c, "Some Lab That Does Not Exist")).toBeNull();
+  });
+
+  it("throws if an override points to a slug that doesn't resolve", () => {
+    // Override claims "X Corp" → "ghost-org" but the matcher has no
+    // such entity. This is a data bug in the YAML — surface loudly.
+    const c = ctx({ anthropic: "sid_aaa" }, { "X Corp": "ghost-org" });
+    expect(() => resolveOrg(c, "X Corp")).toThrow(
+      /override.*X Corp.*ghost-org/,
+    );
+  });
+
+  it("returns the canonical name from the matcher (not the override key)", () => {
+    const c = ctx(
+      { anthropic: "sid_aaa" },
+      { "Anthropic PBC": "anthropic" },
+    );
+    const r = resolveOrg(c, "Anthropic PBC");
+    // Canonical name comes from database.json (the matcher). The
+    // override is only for routing the lookup.
+    expect(r?.canonicalName).toBe("anthropic");
+  });
+});

--- a/crux/lib/scorecard-import/__tests__/sources.test.ts
+++ b/crux/lib/scorecard-import/__tests__/sources.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Per-source adapter tests (QUA-698).
+ *
+ * Each adapter is exercised against fixture wave files in
+ * `__tests__/fixtures/`. Fixtures are copied into a temp directory laid
+ * out as `data/scorecards/raw/<source>/<wave-slug>/grades.json`, and the
+ * adapter's `createXxxAdapter(rawDir)` factory is pointed at the temp
+ * dir so we never touch real data.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, copyFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createFliAdapter, letterToGpa } from "../sources/fli.ts";
+import {
+  createSaferaiAdapter,
+  parsePercent,
+  percentToBand,
+} from "../sources/saferai.ts";
+import { createAiLabWatchAdapter } from "../sources/ailabwatch.ts";
+import { createSeoulAdapter, verdictToNumeric } from "../sources/seoul.ts";
+
+const FIXTURES = join(__dirname, "fixtures");
+
+/**
+ * Build a temp `data/scorecards/raw/<source>/...` layout populated with
+ * the named fixture files. Returns the path to the source's raw dir.
+ */
+function setupRawDir(
+  fixtureMappings: Array<{ wave: string; fixture: string }>,
+): { rawDir: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "scorecard-test-"));
+  for (const { wave, fixture } of fixtureMappings) {
+    const waveDir = join(root, wave);
+    mkdirSync(waveDir, { recursive: true });
+    copyFileSync(join(FIXTURES, fixture), join(waveDir, "grades.json"));
+  }
+  return {
+    rawDir: root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("letterToGpa", () => {
+  it("maps A+ to 4.3 and F to 0", () => {
+    expect(letterToGpa("A+")).toBe(4.3);
+    expect(letterToGpa("A")).toBe(4);
+    expect(letterToGpa("A-")).toBeCloseTo(3.7);
+    expect(letterToGpa("B+")).toBeCloseTo(3.3);
+    expect(letterToGpa("C")).toBe(2);
+    expect(letterToGpa("D-")).toBeCloseTo(0.7);
+    expect(letterToGpa("F")).toBe(0);
+  });
+
+  it("returns null for unparseable strings", () => {
+    expect(letterToGpa("Pending")).toBeNull();
+    expect(letterToGpa("N/A")).toBeNull();
+    expect(letterToGpa("")).toBeNull();
+    expect(letterToGpa("Z")).toBeNull();
+  });
+
+  it("clamps F- to 0 (not -0.3)", () => {
+    expect(letterToGpa("F-")).toBe(0);
+  });
+});
+
+describe("parsePercent", () => {
+  it("parses standard percent strings", () => {
+    expect(parsePercent("73%")).toBe(73);
+    expect(parsePercent("0%")).toBe(0);
+    expect(parsePercent("100%")).toBe(100);
+    expect(parsePercent("12.5%")).toBe(12.5);
+    expect(parsePercent("  42%  ")).toBe(42);
+  });
+
+  it("accepts bare numbers without %", () => {
+    expect(parsePercent("73")).toBe(73);
+  });
+
+  it("returns null for unparseable strings", () => {
+    expect(parsePercent("N/A")).toBeNull();
+    expect(parsePercent("—")).toBeNull();
+    expect(parsePercent("Pending")).toBeNull();
+    expect(parsePercent("")).toBeNull();
+  });
+});
+
+describe("percentToBand", () => {
+  it("partitions 0-100 into 4 bands at quartile boundaries", () => {
+    expect(percentToBand(0)).toBe("Very Weak");
+    expect(percentToBand(24)).toBe("Very Weak");
+    expect(percentToBand(25)).toBe("Weak");
+    expect(percentToBand(49)).toBe("Weak");
+    expect(percentToBand(50)).toBe("Moderate");
+    expect(percentToBand(74)).toBe("Moderate");
+    expect(percentToBand(75)).toBe("Strong");
+    expect(percentToBand(100)).toBe("Strong");
+  });
+
+  it("returns null for null input", () => {
+    expect(percentToBand(null)).toBeNull();
+  });
+});
+
+describe("verdictToNumeric", () => {
+  it("maps the three Seoul verdicts to 0 / 0.5 / 1", () => {
+    expect(verdictToNumeric("Fulfilled")).toBe(1);
+    expect(verdictToNumeric("Partial")).toBe(0.5);
+    expect(verdictToNumeric("Unfulfilled")).toBe(0);
+    expect(verdictToNumeric("Partially Fulfilled")).toBe(0.5);
+    expect(verdictToNumeric("Not Fulfilled")).toBe(0);
+    expect(verdictToNumeric("FULFILLED")).toBe(1);
+  });
+
+  it("returns null for unrecognized verdicts", () => {
+    expect(verdictToNumeric("Not Applicable")).toBeNull();
+    expect(verdictToNumeric("Pending")).toBeNull();
+    expect(verdictToNumeric("")).toBeNull();
+  });
+});
+
+describe("FLI adapter", () => {
+  let setup: ReturnType<typeof setupRawDir>;
+  beforeEach(() => {
+    setup = setupRawDir([
+      { wave: "summer-2025", fixture: "fli-summer-2025.json" },
+      { wave: "winter-2025", fixture: "fli-winter-2025.json" },
+    ]);
+  });
+  afterEach(() => setup.cleanup());
+
+  it("returns one snapshot per wave with deterministic IDs", () => {
+    const adapter = createFliAdapter(setup.rawDir);
+    const snaps = adapter.listSnapshots();
+    expect(snaps).toHaveLength(2);
+    const ids = snaps.map((s) => s.id);
+    expect(ids).toContain("fli_index-summer-2025");
+    expect(ids).toContain("fli_index-winter-2025");
+  });
+
+  it("marks the most recent wave isLatest=true (and exactly one)", () => {
+    const adapter = createFliAdapter(setup.rawDir);
+    const snaps = adapter.listSnapshots();
+    const latest = snaps.filter((s) => s.isLatest);
+    expect(latest).toHaveLength(1);
+    expect(latest[0].id).toBe("fli_index-summer-2025");
+    expect(latest[0].publishedAt).toBe("2025-07-15");
+  });
+
+  it("emits an `overall` row per org plus one row per dimension", () => {
+    const adapter = createFliAdapter(setup.rawDir);
+    const snap = adapter
+      .listSnapshots()
+      .find((s) => s.id === "fli_index-summer-2025")!;
+    const grades = adapter.parseGrades(snap);
+    // 3 orgs × (overall + 6 dimensions) = 21
+    expect(grades).toHaveLength(21);
+    const anthropicGrades = grades.filter((g) => g.orgName === "Anthropic");
+    expect(anthropicGrades.map((g) => g.dimensionSlug).sort()).toEqual(
+      [
+        "current-harms",
+        "existential-safety",
+        "governance",
+        "info-sharing",
+        "overall",
+        "risk-assessment",
+        "safety-frameworks",
+      ],
+    );
+  });
+
+  it("populates scoreLetter / scoreRaw / scoreNumeric for letter grades", () => {
+    const adapter = createFliAdapter(setup.rawDir);
+    const snap = adapter
+      .listSnapshots()
+      .find((s) => s.id === "fli_index-summer-2025")!;
+    const grades = adapter.parseGrades(snap);
+    const overallA = grades.find(
+      (g) => g.orgName === "Anthropic" && g.dimensionSlug === "overall",
+    )!;
+    expect(overallA.scoreLetter).toBe("C+");
+    expect(overallA.scoreRaw).toBe("C+");
+    expect(overallA.scoreNumeric).toBeCloseTo(2.3);
+    expect(overallA.dimensionLabel).toBe("Overall");
+    expect(overallA.dimensionWeight).toBeNull();
+  });
+
+  it("returns [] when raw dir does not exist", () => {
+    const adapter = createFliAdapter("/nonexistent/path");
+    expect(adapter.listSnapshots()).toEqual([]);
+  });
+
+  it("rejects waves with unknown dimensions", () => {
+    const broken = setupRawDir([
+      { wave: "broken", fixture: "fli-summer-2025.json" },
+    ]);
+    // Tamper: write a wave file that references an unknown dimension.
+    const tampered = JSON.stringify({
+      publishedAt: "2025-01-01",
+      waveLabel: "Tampered",
+      sourceUrl: "https://example.org",
+      dimensions: [{ slug: "x", label: "X" }],
+      grades: [
+        {
+          org: "Anthropic",
+          scores: { overall: "B", "x": "A", "unknown-dim": "C" },
+        },
+      ],
+    });
+    rmSync(join(broken.rawDir, "broken", "grades.json"));
+    require("fs").writeFileSync(
+      join(broken.rawDir, "broken", "grades.json"),
+      tampered,
+    );
+    const adapter = createFliAdapter(broken.rawDir);
+    expect(() => adapter.listSnapshots()).toThrow(/unknown dimension/);
+    broken.cleanup();
+  });
+
+  it("rejects waves missing the overall score for any org", () => {
+    const broken = setupRawDir([
+      { wave: "broken", fixture: "fli-summer-2025.json" },
+    ]);
+    const tampered = JSON.stringify({
+      publishedAt: "2025-01-01",
+      waveLabel: "Missing overall",
+      sourceUrl: "https://example.org",
+      dimensions: [{ slug: "a", label: "A" }],
+      grades: [{ org: "Anthropic", scores: { a: "B" } }],
+    });
+    rmSync(join(broken.rawDir, "broken", "grades.json"));
+    require("fs").writeFileSync(
+      join(broken.rawDir, "broken", "grades.json"),
+      tampered,
+    );
+    const adapter = createFliAdapter(broken.rawDir);
+    expect(() => adapter.listSnapshots()).toThrow(/missing overall/);
+    broken.cleanup();
+  });
+});
+
+describe("SaferAI adapter", () => {
+  let setup: ReturnType<typeof setupRawDir>;
+  beforeEach(() => {
+    setup = setupRawDir([
+      { wave: "2026-04", fixture: "saferai-2026-04.json" },
+    ]);
+  });
+  afterEach(() => setup.cleanup());
+
+  it("derives scoreLetter band from percent", () => {
+    const adapter = createSaferaiAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    const grades = adapter.parseGrades(snap);
+    const overallA = grades.find(
+      (g) => g.orgName === "Anthropic" && g.dimensionSlug === "overall",
+    )!;
+    expect(overallA.scoreNumeric).toBe(73);
+    expect(overallA.scoreLetter).toBe("Moderate");
+    expect(overallA.scoreRaw).toBe("73%");
+  });
+
+  it("preserves verbatim raw for unparseable cells (N/A)", () => {
+    const adapter = createSaferaiAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    const grades = adapter.parseGrades(snap);
+    const mistralAnalysis = grades.find(
+      (g) => g.orgName === "Mistral AI" && g.dimensionSlug === "risk-analysis",
+    )!;
+    expect(mistralAnalysis.scoreRaw).toBe("N/A");
+    expect(mistralAnalysis.scoreNumeric).toBeNull();
+    expect(mistralAnalysis.scoreLetter).toBeNull();
+  });
+
+  it("propagates dimension weights into RawGrade", () => {
+    const adapter = createSaferaiAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    const grades = adapter.parseGrades(snap);
+    const dim = grades.find(
+      (g) =>
+        g.orgName === "Anthropic" && g.dimensionSlug === "risk-identification",
+    )!;
+    expect(dim.dimensionWeight).toBe(0.25);
+    // Overall row carries a null weight.
+    const overall = grades.find(
+      (g) => g.orgName === "Anthropic" && g.dimensionSlug === "overall",
+    )!;
+    expect(overall.dimensionWeight).toBeNull();
+  });
+});
+
+describe("AI Lab Watch adapter", () => {
+  let setup: ReturnType<typeof setupRawDir>;
+  beforeEach(() => {
+    setup = setupRawDir([
+      { wave: "2025-09", fixture: "ailabwatch-2025-09.json" },
+    ]);
+  });
+  afterEach(() => setup.cleanup());
+
+  it("forces sourceActive=false on every snapshot (frozen source)", () => {
+    const adapter = createAiLabWatchAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    expect(snap.sourceActive).toBe(false);
+  });
+
+  it("attaches the freeze-notice when notes is unset on the wave", () => {
+    const adapter = createAiLabWatchAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    expect(snap.notes).toMatch(/frozen/i);
+    expect(snap.notes).toMatch(/September 2025/);
+  });
+});
+
+describe("Seoul Tracker adapter", () => {
+  let setup: ReturnType<typeof setupRawDir>;
+  beforeEach(() => {
+    setup = setupRawDir([
+      { wave: "2025-09", fixture: "seoul-2025-09.json" },
+    ]);
+  });
+  afterEach(() => setup.cleanup());
+
+  it("preserves verbatim categorical verdicts in scoreRaw + scoreLetter", () => {
+    const adapter = createSeoulAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    const grades = adapter.parseGrades(snap);
+    const overallA = grades.find(
+      (g) => g.orgName === "Anthropic" && g.dimensionSlug === "overall",
+    )!;
+    expect(overallA.scoreRaw).toBe("Fulfilled");
+    expect(overallA.scoreLetter).toBe("Fulfilled");
+    expect(overallA.scoreNumeric).toBe(1);
+  });
+
+  it("emits Partial cells with numeric 0.5", () => {
+    const adapter = createSeoulAdapter(setup.rawDir);
+    const snap = adapter.listSnapshots()[0];
+    const grades = adapter.parseGrades(snap);
+    const transA = grades.find(
+      (g) => g.orgName === "Anthropic" && g.dimensionSlug === "transparency",
+    )!;
+    expect(transA.scoreRaw).toBe("Partial");
+    expect(transA.scoreNumeric).toBe(0.5);
+  });
+});
+
+describe("idempotent rerun", () => {
+  it("returns identical snapshot + grade payloads across reruns (FLI)", () => {
+    const setup = setupRawDir([
+      { wave: "summer-2025", fixture: "fli-summer-2025.json" },
+    ]);
+    try {
+      const adapter = createFliAdapter(setup.rawDir);
+      const snap1 = adapter.listSnapshots();
+      const snap2 = adapter.listSnapshots();
+      expect(snap2).toEqual(snap1);
+      const grades1 = adapter.parseGrades(snap1[0]);
+      const grades2 = adapter.parseGrades(snap1[0]);
+      expect(grades2).toEqual(grades1);
+    } finally {
+      setup.cleanup();
+    }
+  });
+});

--- a/crux/lib/scorecard-import/__tests__/sync.test.ts
+++ b/crux/lib/scorecard-import/__tests__/sync.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Sync engine tests (QUA-698).
+ *
+ * Exercises the resolver/payload/dry-run pipeline with synthetic adapters
+ * and a hand-built EntityMatcher — no network, no fixture files needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveSnapshot,
+  snapshotToPayload,
+  gradeToPayload,
+  syncSource,
+  analyzeSource,
+} from "../sync.ts";
+import type {
+  RawGrade,
+  RawSnapshot,
+  ScorecardSourceAdapter,
+} from "../types.ts";
+import type { OrgResolverContext } from "../org-aliases.ts";
+import type { EntityMatcher } from "../../grant-import/types.ts";
+
+function makeMatcher(map: Record<string, string>): EntityMatcher {
+  const nameMap = new Map(
+    Object.entries(map).map(([name, stableId]) => [
+      name.toLowerCase(),
+      { stableId, slug: name, name },
+    ]),
+  );
+  return {
+    allNames: nameMap,
+    match: (name: string) => nameMap.get(name.toLowerCase().trim()) || null,
+  };
+}
+
+function makeCtx(
+  matchMap: Record<string, string>,
+  overrides: Record<string, string> = {},
+): OrgResolverContext {
+  // Lower-case override keys to match the loadOverrides() normalization.
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(overrides)) lower[k.toLowerCase()] = v;
+  return { matcher: makeMatcher(matchMap), overrides: lower };
+}
+
+function snap(id: string, source: "fli_index" | "saferai" = "fli_index"): RawSnapshot {
+  return {
+    id,
+    scorecardSource: source,
+    waveLabel: "Test wave",
+    publishedAt: "2026-01-01",
+    sourceUrl: "https://example.org",
+    methodologyUrl: null,
+    license: null,
+    notes: null,
+    isLatest: true,
+    sourceActive: true,
+  };
+}
+
+function grade(
+  snapshotId: string,
+  org: string,
+  dimSlug: string,
+  raw: string,
+): RawGrade {
+  return {
+    snapshotId,
+    orgName: org,
+    dimensionSlug: dimSlug,
+    dimensionLabel: dimSlug === "overall" ? "Overall" : dimSlug,
+    scoreRaw: raw,
+    scoreLetter: raw,
+    scoreNumeric: null,
+  };
+}
+
+describe("resolveSnapshot", () => {
+  it("partitions resolved + unresolved", () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa", openai: "sid_bbb" });
+    const grades = [
+      grade("s1", "Anthropic", "overall", "B"),
+      grade("s1", "MysteryLab", "overall", "A"),
+    ];
+    const r = resolveSnapshot(ctx, grades);
+    expect(r.resolved).toHaveLength(1);
+    expect(r.resolved[0].entityId).toBe("sid_aaa");
+    expect(r.unresolved).toEqual(["MysteryLab"]);
+  });
+
+  it("dedupes unresolved names across rows from the same org", () => {
+    const ctx = makeCtx({});
+    const grades = [
+      grade("s1", "MysteryLab", "overall", "B"),
+      grade("s1", "MysteryLab", "risk", "C"),
+    ];
+    const r = resolveSnapshot(ctx, grades);
+    expect(r.unresolved).toEqual(["MysteryLab"]);
+  });
+
+  it("uses overrides before direct match", () => {
+    const ctx = makeCtx(
+      { anthropic: "sid_aaa" },
+      { "AnthropIc PBC": "anthropic" },
+    );
+    const r = resolveSnapshot(ctx, [
+      grade("s1", "Anthropic PBC", "overall", "B"),
+    ]);
+    expect(r.resolved[0].entityId).toBe("sid_aaa");
+  });
+});
+
+describe("snapshotToPayload", () => {
+  it("derives orgCount + dimensionCount from resolved grades", () => {
+    const s = snap("s1");
+    const ctx = makeCtx({ anthropic: "sid_aaa", openai: "sid_bbb" });
+    const r = resolveSnapshot(ctx, [
+      grade("s1", "Anthropic", "overall", "B"),
+      grade("s1", "Anthropic", "risk", "C"),
+      grade("s1", "OpenAI", "overall", "D"),
+    ]);
+    const payload = snapshotToPayload(s, r.resolved);
+    expect(payload).toMatchObject({
+      id: "s1",
+      orgCount: 2,
+      dimensionCount: 2,
+      isLatest: true,
+      sourceActive: true,
+    });
+  });
+});
+
+describe("gradeToPayload — ID determinism", () => {
+  it("derives a pipe-joined ID from snapshot + entity + dimension", () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa" });
+    const r = resolveSnapshot(ctx, [grade("s1", "Anthropic", "overall", "B")]);
+    const p = gradeToPayload(r.resolved[0]);
+    expect(p.id).toBe("s1|sid_aaa|overall");
+    expect(p.snapshotId).toBe("s1");
+    expect(p.entityId).toBe("sid_aaa");
+    expect(p.dimensionSlug).toBe("overall");
+  });
+
+  it("produces identical IDs across reruns (idempotent upsert)", () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa" });
+    const ids = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      const r = resolveSnapshot(ctx, [
+        grade("s1", "Anthropic", "overall", "B"),
+      ]);
+      ids.add(gradeToPayload(r.resolved[0]).id as string);
+    }
+    expect(ids.size).toBe(1);
+  });
+});
+
+describe("syncSource — dry run", () => {
+  function adapter(
+    snapshots: RawSnapshot[],
+    gradesBySnap: Record<string, RawGrade[]>,
+  ): ScorecardSourceAdapter {
+    return {
+      source: "fli_index",
+      name: "Fake",
+      listSnapshots: () => snapshots,
+      parseGrades: (snap) => gradesBySnap[snap.id] ?? [],
+    };
+  }
+
+  it("returns counts without writing on dryRun", async () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa" });
+    const a = adapter(
+      [snap("s1")],
+      { s1: [grade("s1", "Anthropic", "overall", "B")] },
+    );
+    const r = await syncSource(a, ctx, { dryRun: true });
+    expect(r).toMatchObject({
+      source: "fli_index",
+      snapshots: 1,
+      grades: 1,
+    });
+    expect(r.snapshotResp).toBeUndefined();
+    expect(r.gradesResp).toBeUndefined();
+  });
+
+  it("hard-fails on unresolved org names — never silently drops", async () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa" });
+    const a = adapter(
+      [snap("s1")],
+      {
+        s1: [
+          grade("s1", "Anthropic", "overall", "B"),
+          grade("s1", "MysteryLab", "overall", "A"),
+        ],
+      },
+    );
+    await expect(syncSource(a, ctx, { dryRun: true })).rejects.toThrow(
+      /unresolved org names/i,
+    );
+  });
+
+  it("includes the snapshot ID + suggested fix in the unresolved error", async () => {
+    const ctx = makeCtx({});
+    const a = adapter(
+      [snap("s1")],
+      { s1: [grade("s1", "MysteryLab", "overall", "A")] },
+    );
+    await expect(syncSource(a, ctx, { dryRun: true })).rejects.toThrow(
+      /MysteryLab/,
+    );
+    await expect(syncSource(a, ctx, { dryRun: true })).rejects.toThrow(
+      /org-aliases\.yaml/,
+    );
+  });
+
+  it("returns 0/0 for empty source (no snapshots)", async () => {
+    const ctx = makeCtx({});
+    const a = adapter([], {});
+    const r = await syncSource(a, ctx, { dryRun: true });
+    expect(r).toEqual({ source: "fli_index", snapshots: 0, grades: 0 });
+  });
+});
+
+describe("analyzeSource", () => {
+  function adapter(
+    snapshots: RawSnapshot[],
+    gradesBySnap: Record<string, RawGrade[]>,
+  ): ScorecardSourceAdapter {
+    return {
+      source: "fli_index",
+      name: "Fake",
+      listSnapshots: () => snapshots,
+      parseGrades: (snap) => gradesBySnap[snap.id] ?? [],
+    };
+  }
+
+  it("collects unresolved across all snapshots without throwing", () => {
+    const ctx = makeCtx({ anthropic: "sid_aaa" });
+    const a = adapter(
+      [snap("s1"), snap("s2")],
+      {
+        s1: [
+          grade("s1", "Anthropic", "overall", "B"),
+          grade("s1", "MysteryLab1", "overall", "A"),
+        ],
+        s2: [
+          grade("s2", "Anthropic", "overall", "C"),
+          grade("s2", "MysteryLab2", "overall", "D"),
+        ],
+      },
+    );
+    const r = analyzeSource(a, ctx);
+    expect(r).toMatchObject({
+      source: "fli_index",
+      snapshots: 2,
+      grades: 4,
+      uniqueOrgs: 3,
+      resolved: 2,
+    });
+    expect(r.unresolved.sort()).toEqual(["MysteryLab1", "MysteryLab2"]);
+  });
+});

--- a/crux/lib/scorecard-import/org-aliases.ts
+++ b/crux/lib/scorecard-import/org-aliases.ts
@@ -1,0 +1,132 @@
+/**
+ * Org-name resolution for scorecard ingesters (QUA-698).
+ *
+ * Wraps `entity-matcher.ts` from grant-import (which already loads
+ * database.json titles + aliases) and layers the scorecard-specific
+ * `data/scorecards/org-aliases.yaml` on top.
+ *
+ * Resolution order (per QUA-698 — never silently drop):
+ *   1. exact case-insensitive match in `org-aliases.yaml`
+ *   2. exact entity title/alias match (via grant-import matcher)
+ *   3. normalized match (Inc./Ltd./Corp./AI/Labs suffix stripped)
+ *   4. throw — caller decides whether to print + skip or hard-fail
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { parse as parseYaml } from "yaml";
+import {
+  buildEntityMatcher,
+  normalizeGranteeName,
+} from "../grant-import/entity-matcher.ts";
+import type { EntityMatcher } from "../grant-import/types.ts";
+
+const ALIASES_PATH = resolve("data/scorecards/org-aliases.yaml");
+
+/** Loaded once at process start. */
+function loadOverrides(): Record<string, string> {
+  const raw = readFileSync(ALIASES_PATH, "utf8");
+  const parsed = parseYaml(raw) as { overrides: Record<string, string> };
+  if (!parsed?.overrides || typeof parsed.overrides !== "object") {
+    throw new Error(
+      `data/scorecards/org-aliases.yaml: missing or invalid 'overrides' map`,
+    );
+  }
+  // Normalize keys to lowercase for case-insensitive lookup.
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed.overrides)) {
+    out[key.toLowerCase().trim()] = value;
+  }
+  return out;
+}
+
+export interface OrgResolver {
+  /** entities.stable_id (sid_…) of the resolved org. */
+  entityId: string;
+  /** Canonical title from database.json. */
+  canonicalName: string;
+  /** Slug used to derive the override (for debugging). */
+  slug: string;
+}
+
+export interface OrgResolverContext {
+  matcher: EntityMatcher;
+  overrides: Record<string, string>;
+}
+
+/**
+ * Build the resolver context once per CLI invocation. Exposed so that
+ * ingesters can share a single matcher (loads database.json — non-trivial)
+ * across many `resolveOrg` calls.
+ */
+export function buildOrgResolver(): OrgResolverContext {
+  const matcher = buildEntityMatcher();
+  const overrides = loadOverrides();
+  return { matcher, overrides };
+}
+
+/**
+ * Lookup by-slug helper. The grant-import matcher exposes
+ * `match(name)` which already accepts slugs as a key. We re-use that
+ * but expose a cleaner name + return shape.
+ */
+function matchBySlug(
+  ctx: OrgResolverContext,
+  slug: string,
+): OrgResolver | null {
+  const m = ctx.matcher.match(slug);
+  if (!m) return null;
+  return { entityId: m.stableId, canonicalName: m.name, slug: m.slug };
+}
+
+/**
+ * Resolve an org name from a scorecard source to a wiki entity.
+ *
+ * Returns `null` when nothing matches — the caller decides whether to
+ * collect unresolved names for batch reporting (analyze) or to throw
+ * (sync). Per QUA-698, sync MUST hard-fail on unresolved orgs.
+ */
+export function resolveOrg(
+  ctx: OrgResolverContext,
+  rawName: string,
+): OrgResolver | null {
+  const trimmed = rawName.trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+
+  // 1. Override map.
+  const overrideSlug = ctx.overrides[lower];
+  if (overrideSlug) {
+    const m = matchBySlug(ctx, overrideSlug);
+    if (m) return m;
+    // Override pointed to a slug that doesn't resolve — that's a data
+    // bug in the YAML, surface loudly.
+    throw new Error(
+      `org-aliases.yaml: override "${rawName}" → "${overrideSlug}" but no entity with that slug exists in database.json. Run \`pnpm build-data:content\` or fix the override.`,
+    );
+  }
+
+  // 2. Direct match against title / alias / slug.
+  const direct = ctx.matcher.match(trimmed);
+  if (direct)
+    return {
+      entityId: direct.stableId,
+      canonicalName: direct.name,
+      slug: direct.slug,
+    };
+
+  // 3. Normalized match (strip Inc., Ltd., AI suffix etc.). Reuse the
+  // grant-import normalization — it already handles a long list.
+  const normalized = normalizeGranteeName(trimmed);
+  if (normalized !== trimmed) {
+    const norm = ctx.matcher.match(normalized);
+    if (norm)
+      return {
+        entityId: norm.stableId,
+        canonicalName: norm.name,
+        slug: norm.slug,
+      };
+  }
+
+  return null;
+}

--- a/crux/lib/scorecard-import/sources/ailabwatch.ts
+++ b/crux/lib/scorecard-import/sources/ailabwatch.ts
@@ -1,0 +1,184 @@
+/**
+ * AI Lab Watch adapter (QUA-698).
+ *
+ * https://ailabwatch.org
+ *
+ * Author: Zach Stein-Perlman. Weighted scorecard across seven categories
+ * (risk assessment, scheming prevention, safety research, misuse prevention,
+ * security, info sharing, planning) for ~7 frontier labs.
+ *
+ * Status: FROZEN as of September 2025 (per the QUA-688 framework
+ * `SCORECARD_SOURCES.active=false` flag). Treat any imported snapshot as
+ * the final wave — `sourceActive=false` on the snapshot row tells the
+ * directory to render a "no longer maintained" pill.
+ *
+ * Numeric scores are 0-100 percentages. Letter mapping mirrors SaferAI's
+ * 4-band qualitative scale for matrix display.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { resolve, join } from "path";
+import { percentToBand, parsePercent } from "./saferai.ts";
+import type {
+  RawSnapshot,
+  RawGrade,
+  ScorecardSourceAdapter,
+} from "../types.ts";
+
+const SOURCE_KEY = "ailabwatch";
+const DEFAULT_RAW_DIR = resolve("data/scorecards/raw/ailabwatch");
+
+interface AILabWatchDimension {
+  slug: string;
+  label: string;
+  /** AI Lab Watch publishes per-category weights summing to 1.0. */
+  weight?: number | null;
+}
+
+interface AILabWatchWaveFile {
+  publishedAt: string;
+  waveLabel: string;
+  sourceUrl: string;
+  methodologyUrl?: string | null;
+  license?: string | null;
+  notes?: string | null;
+  isLatest?: boolean;
+  dimensions: AILabWatchDimension[];
+  grades: Array<{
+    org: string;
+    aliases?: string[];
+    /** dimensionSlug → percent string (e.g. "42%"). */
+    scores: Record<string, string>;
+    sourceUrls?: Record<string, string>;
+  }>;
+}
+
+function loadWaves(rawDir: string): Array<{ waveSlug: string; data: AILabWatchWaveFile }> {
+  if (!existsSync(rawDir)) return [];
+  const out: Array<{ waveSlug: string; data: AILabWatchWaveFile }> = [];
+  for (const entry of readdirSync(rawDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const path = join(rawDir, entry.name, "grades.json");
+    if (!existsSync(path)) continue;
+    const data = JSON.parse(readFileSync(path, "utf8")) as AILabWatchWaveFile;
+    validateWave(entry.name, data);
+    out.push({ waveSlug: entry.name, data });
+  }
+  out.sort((a, b) => a.data.publishedAt.localeCompare(b.data.publishedAt));
+  return out;
+}
+
+function validateWave(waveSlug: string, data: AILabWatchWaveFile): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(data.publishedAt)) {
+    throw new Error(
+      `ailabwatch/${waveSlug}/grades.json: publishedAt must be YYYY-MM-DD, got "${data.publishedAt}"`,
+    );
+  }
+  if (!data.sourceUrl) {
+    throw new Error(`ailabwatch/${waveSlug}/grades.json: sourceUrl required`);
+  }
+  if (!Array.isArray(data.dimensions) || data.dimensions.length === 0) {
+    throw new Error(
+      `ailabwatch/${waveSlug}/grades.json: dimensions[] required`,
+    );
+  }
+  if (!Array.isArray(data.grades) || data.grades.length === 0) {
+    throw new Error(`ailabwatch/${waveSlug}/grades.json: grades[] required`);
+  }
+  const dimSlugs = new Set(data.dimensions.map((d) => d.slug));
+  for (const g of data.grades) {
+    if (!g.org) {
+      throw new Error(`ailabwatch/${waveSlug}/grades.json: grade missing org`);
+    }
+    if (g.scores.overall == null) {
+      throw new Error(
+        `ailabwatch/${waveSlug}/grades.json: org "${g.org}" missing overall`,
+      );
+    }
+    for (const slug of Object.keys(g.scores)) {
+      if (slug !== "overall" && !dimSlugs.has(slug)) {
+        throw new Error(
+          `ailabwatch/${waveSlug}/grades.json: org "${g.org}" has score for unknown dimension "${slug}"`,
+        );
+      }
+    }
+  }
+}
+
+function snapshotId(waveSlug: string): string {
+  return `${SOURCE_KEY}-${waveSlug}`;
+}
+
+export function createAiLabWatchAdapter(rawDir: string = DEFAULT_RAW_DIR): ScorecardSourceAdapter {
+  return {
+    source: SOURCE_KEY,
+    name: "AI Lab Watch",
+
+    listSnapshots(): RawSnapshot[] {
+      const waves = loadWaves(rawDir);
+      if (waves.length === 0) return [];
+      const latestId = snapshotId(waves[waves.length - 1].waveSlug);
+      return waves.map(({ waveSlug, data }) => {
+        const id = snapshotId(waveSlug);
+        return {
+          id,
+          scorecardSource: SOURCE_KEY,
+          waveLabel: data.waveLabel,
+          publishedAt: data.publishedAt,
+          sourceUrl: data.sourceUrl,
+          methodologyUrl: data.methodologyUrl ?? null,
+          license: data.license ?? null,
+          notes:
+            data.notes ??
+            "AI Lab Watch was frozen by its author in September 2025. " +
+              "This snapshot reflects the last published state.",
+          isLatest: data.isLatest ?? id === latestId,
+          // The defining quirk of this source — the snapshot row carries
+          // the "no longer maintained" signal so the directory can render it.
+          sourceActive: false,
+        };
+      });
+    },
+
+    parseGrades(snapshot: RawSnapshot): RawGrade[] {
+      const waves = loadWaves(rawDir);
+      const wave = waves.find((w) => snapshotId(w.waveSlug) === snapshot.id);
+      if (!wave) {
+        throw new Error(
+          `[ailabwatch] cannot parse grades for snapshot "${snapshot.id}" — raw file missing`,
+        );
+      }
+      const dimByslug = new Map(wave.data.dimensions.map((d) => [d.slug, d]));
+      const out: RawGrade[] = [];
+      for (const g of wave.data.grades) {
+        for (const [slug, value] of Object.entries(g.scores)) {
+          const isOverall = slug === "overall";
+          const dim = isOverall ? null : dimByslug.get(slug);
+          if (!isOverall && !dim) {
+            throw new Error(
+              `[ailabwatch] org "${g.org}" has score for unknown dimension "${slug}"`,
+            );
+          }
+          const numeric = parsePercent(value);
+          out.push({
+            snapshotId: snapshot.id,
+            orgName: g.org,
+            orgAliases: g.aliases,
+            dimensionSlug: slug,
+            dimensionLabel: isOverall ? "Overall" : dim!.label,
+            dimensionWeight: isOverall ? null : (dim!.weight ?? null),
+            dimensionParentSlug: null,
+            scoreNumeric: numeric,
+            scoreLetter: percentToBand(numeric),
+            scoreRaw: value,
+            notes: null,
+            sourceUrl: g.sourceUrls?.[slug] ?? null,
+          });
+        }
+      }
+      return out;
+    },
+  };
+}
+
+export const aiLabWatchAdapter = createAiLabWatchAdapter();

--- a/crux/lib/scorecard-import/sources/fli.ts
+++ b/crux/lib/scorecard-import/sources/fli.ts
@@ -1,0 +1,230 @@
+/**
+ * FLI AI Safety Index adapter (QUA-698).
+ *
+ * https://futureoflife.org/ai-safety-index-summer-2025/
+ *
+ * Format: each wave is published as a long HTML page + downloadable PDF
+ * with letter grades (A through F, including +/-) for ~7 frontier labs
+ * across 6-7 weighted safety domains plus an overall grade.
+ *
+ * Strategy: keep raw HTML in `data/scorecards/raw/fli/<wave>/page.html` for
+ * audit, and store the extracted grades in a sibling `grades.json` file.
+ * Extraction is a separate offline step (LLM-assisted on the raw HTML)
+ * because (a) the page layout drifts wave-to-wave and (b) the LLM call
+ * has cost — this lets us re-sync after schema tweaks without re-paying.
+ *
+ * The shape on disk lives at `data/scorecards/raw/fli/<wave>/grades.json`:
+ *
+ *   {
+ *     "publishedAt": "2025-07-15",
+ *     "waveLabel": "Summer 2025",
+ *     "sourceUrl": "https://futureoflife.org/ai-safety-index-summer-2025/",
+ *     "methodologyUrl": "https://futureoflife.org/.../methodology",
+ *     "license": "CC BY 4.0",
+ *     "dimensions": [
+ *       { "slug": "risk-assessment", "label": "Risk Assessment", "weight": null }
+ *       ...
+ *     ],
+ *     "grades": [
+ *       {
+ *         "org": "Anthropic",
+ *         "scores": {
+ *           "overall": "C+",
+ *           "risk-assessment": "C",
+ *           ...
+ *         }
+ *       }
+ *     ]
+ *   }
+ */
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { resolve, join } from "path";
+import type {
+  RawSnapshot,
+  RawGrade,
+  ScorecardSourceAdapter,
+} from "../types.ts";
+
+const SOURCE_KEY = "fli_index";
+const DEFAULT_RAW_DIR = resolve("data/scorecards/raw/fli");
+
+interface FLIDimension {
+  slug: string;
+  label: string;
+  weight?: number | null;
+}
+
+interface FLIWaveFile {
+  publishedAt: string;
+  waveLabel: string;
+  sourceUrl: string;
+  methodologyUrl?: string | null;
+  license?: string | null;
+  notes?: string | null;
+  /** True for the most recent wave (only one per source). */
+  isLatest?: boolean;
+  dimensions: FLIDimension[];
+  grades: Array<{
+    org: string;
+    aliases?: string[];
+    /** dimensionSlug → "B+" / "Partial" / etc. Always include "overall". */
+    scores: Record<string, string>;
+    /** Per-cell URLs (rare). Same key set as `scores`. */
+    sourceUrls?: Record<string, string>;
+  }>;
+}
+
+function loadWaves(rawDir: string): Array<{ waveSlug: string; data: FLIWaveFile }> {
+  if (!existsSync(rawDir)) return [];
+  const out: Array<{ waveSlug: string; data: FLIWaveFile }> = [];
+  for (const entry of readdirSync(rawDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const gradesPath = join(rawDir, entry.name, "grades.json");
+    if (!existsSync(gradesPath)) continue;
+    const raw = readFileSync(gradesPath, "utf8");
+    const parsed = JSON.parse(raw) as FLIWaveFile;
+    validateWave(entry.name, parsed);
+    out.push({ waveSlug: entry.name, data: parsed });
+  }
+  // Sort by publishedAt ascending so latest is unambiguous in `listSnapshots`.
+  out.sort((a, b) =>
+    a.data.publishedAt.localeCompare(b.data.publishedAt),
+  );
+  return out;
+}
+
+function validateWave(waveSlug: string, data: FLIWaveFile): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(data.publishedAt)) {
+    throw new Error(
+      `fli/${waveSlug}/grades.json: publishedAt must be YYYY-MM-DD, got "${data.publishedAt}"`,
+    );
+  }
+  if (!data.sourceUrl) {
+    throw new Error(`fli/${waveSlug}/grades.json: sourceUrl is required`);
+  }
+  if (!Array.isArray(data.dimensions) || data.dimensions.length === 0) {
+    throw new Error(`fli/${waveSlug}/grades.json: dimensions[] required`);
+  }
+  if (!Array.isArray(data.grades) || data.grades.length === 0) {
+    throw new Error(`fli/${waveSlug}/grades.json: grades[] required`);
+  }
+  const dimSlugs = new Set(data.dimensions.map((d) => d.slug));
+  for (const g of data.grades) {
+    if (!g.org) {
+      throw new Error(`fli/${waveSlug}/grades.json: grade missing org`);
+    }
+    if (g.scores.overall == null) {
+      throw new Error(
+        `fli/${waveSlug}/grades.json: org "${g.org}" missing overall score`,
+      );
+    }
+    for (const slug of Object.keys(g.scores)) {
+      if (slug !== "overall" && !dimSlugs.has(slug)) {
+        throw new Error(
+          `fli/${waveSlug}/grades.json: org "${g.org}" has score for unknown dimension "${slug}"`,
+        );
+      }
+    }
+  }
+}
+
+function snapshotId(waveSlug: string): string {
+  return `${SOURCE_KEY}-${waveSlug}`;
+}
+
+/**
+ * Letter grades A-F (with +/-) numerically from 4.3 (A+) to 0.0 (F).
+ * Used to populate scoreNumeric so directory queries can sort/aggregate
+ * without re-parsing the letter every time. Returns null on unparseable
+ * inputs (e.g., "N/A", "Pending") — the verbatim string still lives in
+ * scoreRaw.
+ */
+export function letterToGpa(letter: string): number | null {
+  const m = /^([A-F])([+-])?$/.exec(letter.trim().toUpperCase());
+  if (!m) return null;
+  const base: Record<string, number> = { A: 4, B: 3, C: 2, D: 1, F: 0 };
+  let val = base[m[1]];
+  if (m[2] === "+") val += 0.3;
+  else if (m[2] === "-") val -= 0.3;
+  // Clamp to [0, 4.3] — A+ = 4.3, F- (rare) = 0 not -0.3.
+  if (val < 0) val = 0;
+  if (val > 4.3) val = 4.3;
+  return val;
+}
+
+/**
+ * Build an adapter rooted at `rawDir` (default: `data/scorecards/raw/fli`).
+ * Exposed for tests, which point at fixture directories instead.
+ */
+export function createFliAdapter(rawDir: string = DEFAULT_RAW_DIR): ScorecardSourceAdapter {
+  return {
+    source: SOURCE_KEY,
+    name: "FLI AI Safety Index",
+
+    listSnapshots(): RawSnapshot[] {
+      const waves = loadWaves(rawDir);
+      if (waves.length === 0) return [];
+      const latestId = snapshotId(waves[waves.length - 1].waveSlug);
+      return waves.map(({ waveSlug, data }) => {
+        const id = snapshotId(waveSlug);
+        return {
+          id,
+          scorecardSource: SOURCE_KEY,
+          waveLabel: data.waveLabel,
+          publishedAt: data.publishedAt,
+          sourceUrl: data.sourceUrl,
+          methodologyUrl: data.methodologyUrl ?? null,
+          license: data.license ?? null,
+          notes: data.notes ?? null,
+          // File-level isLatest wins if explicitly set; otherwise pick the
+          // most recent wave by date.
+          isLatest: data.isLatest ?? id === latestId,
+          sourceActive: true,
+        };
+      });
+    },
+
+    parseGrades(snapshot: RawSnapshot): RawGrade[] {
+      const waves = loadWaves(rawDir);
+      const wave = waves.find((w) => snapshotId(w.waveSlug) === snapshot.id);
+      if (!wave) {
+        throw new Error(
+          `[fli_index] cannot parse grades for snapshot "${snapshot.id}" — raw file missing`,
+        );
+      }
+
+      const dimByslug = new Map(wave.data.dimensions.map((d) => [d.slug, d]));
+      const out: RawGrade[] = [];
+      for (const g of wave.data.grades) {
+        for (const [slug, letter] of Object.entries(g.scores)) {
+          const isOverall = slug === "overall";
+          const dim = isOverall ? null : dimByslug.get(slug);
+          if (!isOverall && !dim) {
+            // Should be caught by validateWave but defensive.
+            throw new Error(
+              `[fli_index] org "${g.org}" has score for unknown dimension "${slug}"`,
+            );
+          }
+          out.push({
+            snapshotId: snapshot.id,
+            orgName: g.org,
+            orgAliases: g.aliases,
+            dimensionSlug: slug,
+            dimensionLabel: isOverall ? "Overall" : (dim!.label),
+            dimensionWeight: isOverall ? null : (dim!.weight ?? null),
+            dimensionParentSlug: null,
+            scoreNumeric: letterToGpa(letter),
+            scoreLetter: letter,
+            scoreRaw: letter,
+            notes: null,
+            sourceUrl: g.sourceUrls?.[slug] ?? null,
+          });
+        }
+      }
+      return out;
+    },
+  };
+}
+
+export const fliAdapter = createFliAdapter();

--- a/crux/lib/scorecard-import/sources/index.ts
+++ b/crux/lib/scorecard-import/sources/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Scorecard source registry. Each source ships an adapter; the dispatcher
+ * looks them up here by their PG enum value (`ScorecardSourceKey`).
+ *
+ * FMTI is intentionally absent — it has its own ingester (QUA-697) which
+ * reads CSV from a CC-BY-4.0 GitHub repo and is unrelated to the
+ * scrape/extract pattern these four share.
+ */
+
+import { fliAdapter } from "./fli.ts";
+import { saferaiAdapter } from "./saferai.ts";
+import { aiLabWatchAdapter } from "./ailabwatch.ts";
+import { seoulAdapter } from "./seoul.ts";
+import type {
+  ScorecardSourceAdapter,
+  ScorecardSourceKey,
+} from "../types.ts";
+
+export const ALL_SOURCES: readonly ScorecardSourceAdapter[] = [
+  fliAdapter,
+  saferaiAdapter,
+  aiLabWatchAdapter,
+  seoulAdapter,
+] as const;
+
+const BY_KEY = new Map<ScorecardSourceKey, ScorecardSourceAdapter>(
+  ALL_SOURCES.map((a) => [a.source, a]),
+);
+
+export function getAdapter(
+  source: ScorecardSourceKey,
+): ScorecardSourceAdapter {
+  const a = BY_KEY.get(source);
+  if (!a) {
+    throw new Error(
+      `Unknown scorecard source "${source}". Available: ${[...BY_KEY.keys()].join(", ")}`,
+    );
+  }
+  return a;
+}
+
+export function listSourceKeys(): ScorecardSourceKey[] {
+  return [...BY_KEY.keys()];
+}

--- a/crux/lib/scorecard-import/sources/saferai.ts
+++ b/crux/lib/scorecard-import/sources/saferai.ts
@@ -1,0 +1,209 @@
+/**
+ * SaferAI Ratings adapter (QUA-698).
+ *
+ * https://ratings.safer-ai.org
+ *
+ * Format: continuously-updated ratings across four risk-management pillars
+ * (risk identification, analysis & evaluation, treatment, governance) plus
+ * an overall percentage / letter band per developer (~12 frontier orgs).
+ *
+ * SaferAI's site is a JS app — wave-by-wave HTML scraping is brittle, so
+ * we mirror the FLI pattern: cache an extracted JSON snapshot in
+ * `data/scorecards/raw/saferai/<wave>/grades.json`. Re-snapshots are
+ * captured monthly by re-running the manual `extract` step against the
+ * site's current state. Each snapshot is a point-in-time mirror.
+ *
+ * The shape on disk is identical to FLI's wave file (see fli.ts) with
+ * percentage scores instead of letter grades — `scoreRaw` is the
+ * verbatim "73%" string and `scoreNumeric` the 0-100 number. A derived
+ * letter band ("Strong" / "Moderate" / "Weak" / "Very Weak") is computed
+ * by the adapter and surfaced as `scoreLetter` for matrix display
+ * consistency with FLI.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { resolve, join } from "path";
+import type {
+  RawSnapshot,
+  RawGrade,
+  ScorecardSourceAdapter,
+} from "../types.ts";
+
+const SOURCE_KEY = "saferai";
+const DEFAULT_RAW_DIR = resolve("data/scorecards/raw/saferai");
+
+interface SaferAIDimension {
+  slug: string;
+  label: string;
+  /** Optional weight (0-1). SaferAI publishes pillar weights. */
+  weight?: number | null;
+}
+
+interface SaferAIWaveFile {
+  publishedAt: string;
+  waveLabel: string;
+  sourceUrl: string;
+  methodologyUrl?: string | null;
+  license?: string | null;
+  notes?: string | null;
+  isLatest?: boolean;
+  dimensions: SaferAIDimension[];
+  grades: Array<{
+    org: string;
+    aliases?: string[];
+    /** dimensionSlug → percent string (e.g. "73%") or "N/A". */
+    scores: Record<string, string>;
+    sourceUrls?: Record<string, string>;
+  }>;
+}
+
+function loadWaves(rawDir: string): Array<{ waveSlug: string; data: SaferAIWaveFile }> {
+  if (!existsSync(rawDir)) return [];
+  const out: Array<{ waveSlug: string; data: SaferAIWaveFile }> = [];
+  for (const entry of readdirSync(rawDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const path = join(rawDir, entry.name, "grades.json");
+    if (!existsSync(path)) continue;
+    const data = JSON.parse(readFileSync(path, "utf8")) as SaferAIWaveFile;
+    validateWave(entry.name, data);
+    out.push({ waveSlug: entry.name, data });
+  }
+  out.sort((a, b) => a.data.publishedAt.localeCompare(b.data.publishedAt));
+  return out;
+}
+
+function validateWave(waveSlug: string, data: SaferAIWaveFile): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(data.publishedAt)) {
+    throw new Error(
+      `saferai/${waveSlug}/grades.json: publishedAt must be YYYY-MM-DD, got "${data.publishedAt}"`,
+    );
+  }
+  if (!data.sourceUrl) {
+    throw new Error(`saferai/${waveSlug}/grades.json: sourceUrl is required`);
+  }
+  if (!Array.isArray(data.dimensions) || data.dimensions.length === 0) {
+    throw new Error(`saferai/${waveSlug}/grades.json: dimensions[] required`);
+  }
+  if (!Array.isArray(data.grades) || data.grades.length === 0) {
+    throw new Error(`saferai/${waveSlug}/grades.json: grades[] required`);
+  }
+  const dimSlugs = new Set(data.dimensions.map((d) => d.slug));
+  for (const g of data.grades) {
+    if (!g.org) {
+      throw new Error(`saferai/${waveSlug}/grades.json: grade missing org`);
+    }
+    if (g.scores.overall == null) {
+      throw new Error(
+        `saferai/${waveSlug}/grades.json: org "${g.org}" missing overall score`,
+      );
+    }
+    for (const slug of Object.keys(g.scores)) {
+      if (slug !== "overall" && !dimSlugs.has(slug)) {
+        throw new Error(
+          `saferai/${waveSlug}/grades.json: org "${g.org}" has score for unknown dimension "${slug}"`,
+        );
+      }
+    }
+  }
+}
+
+function snapshotId(waveSlug: string): string {
+  return `${SOURCE_KEY}-${waveSlug}`;
+}
+
+/**
+ * Parse a SaferAI percent string into a 0-100 number. Handles plain
+ * percentages ("73%"), decimal-prefixed ("73.5%"), and "N/A" / "—".
+ * Returns null when unparseable; scoreRaw still preserves the verbatim
+ * source text either way.
+ */
+export function parsePercent(s: string): number | null {
+  const m = /^([\d.]+)\s*%?$/.exec(s.trim());
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  return n;
+}
+
+/**
+ * SaferAI does not publish discrete letter bands, but the matrix display
+ * is letter-first. Map the percentage into a 4-band qualitative label
+ * for display consistency with FLI. Thresholds match SaferAI's own
+ * "Weak / Moderate / Strong" coloring on the site.
+ */
+export function percentToBand(pct: number | null): string | null {
+  if (pct == null) return null;
+  if (pct >= 75) return "Strong";
+  if (pct >= 50) return "Moderate";
+  if (pct >= 25) return "Weak";
+  return "Very Weak";
+}
+
+export function createSaferaiAdapter(rawDir: string = DEFAULT_RAW_DIR): ScorecardSourceAdapter {
+  return {
+    source: SOURCE_KEY,
+    name: "SaferAI Ratings",
+
+    listSnapshots(): RawSnapshot[] {
+      const waves = loadWaves(rawDir);
+      if (waves.length === 0) return [];
+      const latestId = snapshotId(waves[waves.length - 1].waveSlug);
+      return waves.map(({ waveSlug, data }) => {
+        const id = snapshotId(waveSlug);
+        return {
+          id,
+          scorecardSource: SOURCE_KEY,
+          waveLabel: data.waveLabel,
+          publishedAt: data.publishedAt,
+          sourceUrl: data.sourceUrl,
+          methodologyUrl: data.methodologyUrl ?? null,
+          license: data.license ?? null,
+          notes: data.notes ?? null,
+          isLatest: data.isLatest ?? id === latestId,
+          sourceActive: true,
+        };
+      });
+    },
+
+    parseGrades(snapshot: RawSnapshot): RawGrade[] {
+      const waves = loadWaves(rawDir);
+      const wave = waves.find((w) => snapshotId(w.waveSlug) === snapshot.id);
+      if (!wave) {
+        throw new Error(
+          `[saferai] cannot parse grades for snapshot "${snapshot.id}" — raw file missing`,
+        );
+      }
+      const dimByslug = new Map(wave.data.dimensions.map((d) => [d.slug, d]));
+      const out: RawGrade[] = [];
+      for (const g of wave.data.grades) {
+        for (const [slug, value] of Object.entries(g.scores)) {
+          const isOverall = slug === "overall";
+          const dim = isOverall ? null : dimByslug.get(slug);
+          if (!isOverall && !dim) {
+            throw new Error(
+              `[saferai] org "${g.org}" has score for unknown dimension "${slug}"`,
+            );
+          }
+          const numeric = parsePercent(value);
+          out.push({
+            snapshotId: snapshot.id,
+            orgName: g.org,
+            orgAliases: g.aliases,
+            dimensionSlug: slug,
+            dimensionLabel: isOverall ? "Overall" : dim!.label,
+            dimensionWeight: isOverall ? null : (dim!.weight ?? null),
+            dimensionParentSlug: null,
+            scoreNumeric: numeric,
+            scoreLetter: percentToBand(numeric),
+            scoreRaw: value,
+            notes: null,
+            sourceUrl: g.sourceUrls?.[slug] ?? null,
+          });
+        }
+      }
+      return out;
+    },
+  };
+}
+
+export const saferaiAdapter = createSaferaiAdapter();

--- a/crux/lib/scorecard-import/sources/seoul.ts
+++ b/crux/lib/scorecard-import/sources/seoul.ts
@@ -1,0 +1,196 @@
+/**
+ * Seoul Commitment Tracker adapter (QUA-698).
+ *
+ * https://www.seoul-tracker.org
+ *
+ * Author: The Midas Project. Tracks adherence to the Seoul Frontier AI
+ * Safety Commitments — five red-line components signed by 16 frontier
+ * developers in May 2024:
+ *
+ *   1. risk-thresholds      — Define risk thresholds & cases
+ *   2. safe-development     — Halt or modify development past thresholds
+ *   3. risk-evaluation      — Risk-evaluation processes
+ *   4. transparency         — Share approaches publicly
+ *   5. governance           — Internal governance structures
+ *
+ * Verdict per (org, commitment): "Fulfilled" | "Partial" | "Unfulfilled" |
+ * "Not Applicable". The tracker also publishes an "overall" summary
+ * verdict per org (typically the strongest verdict + a qualifier).
+ *
+ * Storage matches the FLI/SaferAI pattern — a JSON snapshot at
+ * `data/scorecards/raw/seoul/<wave>/grades.json`.
+ *
+ * Categorical scores get a numeric encoding for sorting:
+ *   Fulfilled = 1.0, Partial = 0.5, Unfulfilled = 0.0,
+ *   Not Applicable / unparseable = null.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { resolve, join } from "path";
+import type {
+  RawSnapshot,
+  RawGrade,
+  ScorecardSourceAdapter,
+} from "../types.ts";
+
+const SOURCE_KEY = "seoul_tracker";
+const DEFAULT_RAW_DIR = resolve("data/scorecards/raw/seoul");
+
+interface SeoulDimension {
+  slug: string;
+  label: string;
+}
+
+interface SeoulWaveFile {
+  publishedAt: string;
+  waveLabel: string;
+  sourceUrl: string;
+  methodologyUrl?: string | null;
+  license?: string | null;
+  notes?: string | null;
+  isLatest?: boolean;
+  dimensions: SeoulDimension[];
+  grades: Array<{
+    org: string;
+    aliases?: string[];
+    /** dimensionSlug → "Fulfilled" | "Partial" | "Unfulfilled" | "Not Applicable". */
+    scores: Record<string, string>;
+    sourceUrls?: Record<string, string>;
+  }>;
+}
+
+function loadWaves(rawDir: string): Array<{ waveSlug: string; data: SeoulWaveFile }> {
+  if (!existsSync(rawDir)) return [];
+  const out: Array<{ waveSlug: string; data: SeoulWaveFile }> = [];
+  for (const entry of readdirSync(rawDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const path = join(rawDir, entry.name, "grades.json");
+    if (!existsSync(path)) continue;
+    const data = JSON.parse(readFileSync(path, "utf8")) as SeoulWaveFile;
+    validateWave(entry.name, data);
+    out.push({ waveSlug: entry.name, data });
+  }
+  out.sort((a, b) => a.data.publishedAt.localeCompare(b.data.publishedAt));
+  return out;
+}
+
+function validateWave(waveSlug: string, data: SeoulWaveFile): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(data.publishedAt)) {
+    throw new Error(
+      `seoul/${waveSlug}/grades.json: publishedAt must be YYYY-MM-DD, got "${data.publishedAt}"`,
+    );
+  }
+  if (!data.sourceUrl) {
+    throw new Error(`seoul/${waveSlug}/grades.json: sourceUrl required`);
+  }
+  if (!Array.isArray(data.dimensions) || data.dimensions.length === 0) {
+    throw new Error(`seoul/${waveSlug}/grades.json: dimensions[] required`);
+  }
+  if (!Array.isArray(data.grades) || data.grades.length === 0) {
+    throw new Error(`seoul/${waveSlug}/grades.json: grades[] required`);
+  }
+  const dimSlugs = new Set(data.dimensions.map((d) => d.slug));
+  for (const g of data.grades) {
+    if (!g.org) {
+      throw new Error(`seoul/${waveSlug}/grades.json: grade missing org`);
+    }
+    if (g.scores.overall == null) {
+      throw new Error(
+        `seoul/${waveSlug}/grades.json: org "${g.org}" missing overall`,
+      );
+    }
+    for (const slug of Object.keys(g.scores)) {
+      if (slug !== "overall" && !dimSlugs.has(slug)) {
+        throw new Error(
+          `seoul/${waveSlug}/grades.json: org "${g.org}" has score for unknown dimension "${slug}"`,
+        );
+      }
+    }
+  }
+}
+
+function snapshotId(waveSlug: string): string {
+  return `${SOURCE_KEY}-${waveSlug}`;
+}
+
+/**
+ * Map Seoul Tracker categorical verdicts to a 0-1 numeric encoding so
+ * matrix display and aggregations have something to sort on. Returns
+ * null for "Not Applicable" or unrecognized strings — scoreRaw still
+ * preserves the verbatim verdict.
+ */
+export function verdictToNumeric(verdict: string): number | null {
+  const v = verdict.trim().toLowerCase();
+  if (v === "fulfilled" || v === "full") return 1.0;
+  if (v === "partial" || v === "partially fulfilled") return 0.5;
+  if (v === "unfulfilled" || v === "not fulfilled") return 0.0;
+  return null;
+}
+
+export function createSeoulAdapter(rawDir: string = DEFAULT_RAW_DIR): ScorecardSourceAdapter {
+  return {
+    source: SOURCE_KEY,
+    name: "Seoul Commitment Tracker",
+
+    listSnapshots(): RawSnapshot[] {
+      const waves = loadWaves(rawDir);
+      if (waves.length === 0) return [];
+      const latestId = snapshotId(waves[waves.length - 1].waveSlug);
+      return waves.map(({ waveSlug, data }) => {
+        const id = snapshotId(waveSlug);
+        return {
+          id,
+          scorecardSource: SOURCE_KEY,
+          waveLabel: data.waveLabel,
+          publishedAt: data.publishedAt,
+          sourceUrl: data.sourceUrl,
+          methodologyUrl: data.methodologyUrl ?? null,
+          license: data.license ?? null,
+          notes: data.notes ?? null,
+          isLatest: data.isLatest ?? id === latestId,
+          sourceActive: true,
+        };
+      });
+    },
+
+    parseGrades(snapshot: RawSnapshot): RawGrade[] {
+      const waves = loadWaves(rawDir);
+      const wave = waves.find((w) => snapshotId(w.waveSlug) === snapshot.id);
+      if (!wave) {
+        throw new Error(
+          `[seoul_tracker] cannot parse grades for snapshot "${snapshot.id}" — raw file missing`,
+        );
+      }
+      const dimByslug = new Map(wave.data.dimensions.map((d) => [d.slug, d]));
+      const out: RawGrade[] = [];
+      for (const g of wave.data.grades) {
+        for (const [slug, value] of Object.entries(g.scores)) {
+          const isOverall = slug === "overall";
+          const dim = isOverall ? null : dimByslug.get(slug);
+          if (!isOverall && !dim) {
+            throw new Error(
+              `[seoul_tracker] org "${g.org}" has score for unknown dimension "${slug}"`,
+            );
+          }
+          out.push({
+            snapshotId: snapshot.id,
+            orgName: g.org,
+            orgAliases: g.aliases,
+            dimensionSlug: slug,
+            dimensionLabel: isOverall ? "Overall" : dim!.label,
+            dimensionWeight: null,
+            dimensionParentSlug: null,
+            scoreNumeric: verdictToNumeric(value),
+            scoreLetter: value,
+            scoreRaw: value,
+            notes: null,
+            sourceUrl: g.sourceUrls?.[slug] ?? null,
+          });
+        }
+      }
+      return out;
+    },
+  };
+}
+
+export const seoulAdapter = createSeoulAdapter();

--- a/crux/lib/scorecard-import/sync.ts
+++ b/crux/lib/scorecard-import/sync.ts
@@ -1,0 +1,233 @@
+/**
+ * Shared sync engine — converts adapter output to API payloads and POSTs
+ * to the wiki-server scorecard-snapshots / scorecard-grades endpoints.
+ *
+ * The factory-driven sync handlers on the server side handle upsert
+ * semantics (ON CONFLICT DO UPDATE), so reruns are idempotent: the same
+ * (snapshotId, entityId, dimensionSlug) tuple updates in place.
+ *
+ * Hard-failure rule (QUA-698): unresolved org names abort the sync —
+ * never silently drop a row. The CLI `analyze` subcommand surfaces
+ * unresolved names so they can be added to `data/scorecards/org-aliases.yaml`.
+ */
+
+import {
+  syncScorecardSnapshots,
+  type ScorecardSnapshotsSyncResult,
+} from "../wiki-server/scorecard-snapshots.ts";
+import {
+  syncScorecardGrades,
+  type ScorecardGradesSyncResult,
+} from "../wiki-server/scorecard-grades.ts";
+import { resolveOrg, type OrgResolverContext } from "./org-aliases.ts";
+import type {
+  RawSnapshot,
+  RawGrade,
+  ResolvedGrade,
+  ScorecardSourceAdapter,
+  SourceAnalysis,
+} from "./types.ts";
+
+/**
+ * Resolve every grade in a snapshot, partitioning into resolved + unresolved.
+ * Pure — no network calls. Used by both `analyze` (collects unresolved) and
+ * `sync` (throws on unresolved).
+ */
+export function resolveSnapshot(
+  ctx: OrgResolverContext,
+  grades: RawGrade[],
+): { resolved: ResolvedGrade[]; unresolved: string[] } {
+  const resolved: ResolvedGrade[] = [];
+  const unresolved = new Set<string>();
+  for (const g of grades) {
+    const m = resolveOrg(ctx, g.orgName);
+    if (!m) {
+      unresolved.add(g.orgName);
+      continue;
+    }
+    resolved.push({
+      raw: g,
+      entityId: m.entityId,
+      canonicalName: m.canonicalName,
+    });
+  }
+  return { resolved, unresolved: [...unresolved].sort() };
+}
+
+/**
+ * Build the snapshot payload for `/api/scorecard-snapshots/sync`.
+ * Counts (orgCount, dimensionCount) are derived from the resolved grade
+ * set so they reflect what we actually loaded, not what the source claims.
+ */
+export function snapshotToPayload(
+  snapshot: RawSnapshot,
+  resolved: ResolvedGrade[],
+): Record<string, unknown> {
+  const orgs = new Set<string>();
+  const dimensions = new Set<string>();
+  for (const r of resolved) {
+    orgs.add(r.entityId);
+    dimensions.add(r.raw.dimensionSlug);
+  }
+  return {
+    id: snapshot.id,
+    scorecardSource: snapshot.scorecardSource,
+    waveLabel: snapshot.waveLabel,
+    publishedAt: snapshot.publishedAt,
+    sourceUrl: snapshot.sourceUrl,
+    methodologyUrl: snapshot.methodologyUrl ?? null,
+    license: snapshot.license ?? null,
+    notes: snapshot.notes ?? null,
+    orgCount: orgs.size,
+    dimensionCount: dimensions.size,
+    isLatest: snapshot.isLatest,
+    sourceActive: snapshot.sourceActive,
+  };
+}
+
+/**
+ * Build a grade payload. Grade IDs are deterministic so reruns upsert
+ * the same row: `<snapshotId>|<entityId>|<dimensionSlug>`. The pipe is
+ * safe — none of the inputs may legally contain it (Zod max-length
+ * caps are 100/200/200, and slugs are kebab-case alphanumerics).
+ */
+export function gradeToPayload(g: ResolvedGrade): Record<string, unknown> {
+  const id = `${g.raw.snapshotId}|${g.entityId}|${g.raw.dimensionSlug}`;
+  return {
+    id,
+    snapshotId: g.raw.snapshotId,
+    entityId: g.entityId,
+    entityDisplayName: g.canonicalName,
+    dimensionSlug: g.raw.dimensionSlug,
+    dimensionLabel: g.raw.dimensionLabel,
+    dimensionWeight: g.raw.dimensionWeight ?? null,
+    dimensionParentSlug: g.raw.dimensionParentSlug ?? null,
+    scoreNumeric: g.raw.scoreNumeric ?? null,
+    scoreLetter: g.raw.scoreLetter ?? null,
+    scoreRaw: g.raw.scoreRaw,
+    notes: g.raw.notes ?? null,
+    sourceUrl: g.raw.sourceUrl ?? null,
+  };
+}
+
+export interface SyncOptions {
+  dryRun?: boolean;
+  /** Print payloads (debug). */
+  verbose?: boolean;
+}
+
+export interface SyncResult {
+  source: string;
+  snapshots: number;
+  grades: number;
+  snapshotResp?: ScorecardSnapshotsSyncResult;
+  gradesResp?: ScorecardGradesSyncResult;
+}
+
+/**
+ * Sync one source end-to-end: snapshots first (so grade FKs resolve),
+ * then all grades for those snapshots. Aborts on any unresolved org.
+ */
+export async function syncSource(
+  adapter: ScorecardSourceAdapter,
+  ctx: OrgResolverContext,
+  opts: SyncOptions = {},
+): Promise<SyncResult> {
+  const snapshots = adapter.listSnapshots();
+  if (snapshots.length === 0) {
+    return { source: adapter.source, snapshots: 0, grades: 0 };
+  }
+
+  // Resolve every grade up-front so we can hard-fail before any write.
+  const allResolved: ResolvedGrade[] = [];
+  for (const snap of snapshots) {
+    const grades = adapter.parseGrades(snap);
+    const { resolved, unresolved } = resolveSnapshot(ctx, grades);
+    if (unresolved.length > 0) {
+      throw new Error(
+        `[${adapter.source}] unresolved org names in ${snap.id}:\n  ` +
+          unresolved.map((n) => `- ${n}`).join("\n  ") +
+          `\nAdd these to data/scorecards/org-aliases.yaml or to the entity's aliases:`,
+      );
+    }
+    allResolved.push(...resolved);
+  }
+
+  // Group resolved grades by snapshot for payload counts.
+  const bySnapshot = new Map<string, ResolvedGrade[]>();
+  for (const r of allResolved) {
+    const arr = bySnapshot.get(r.raw.snapshotId) ?? [];
+    arr.push(r);
+    bySnapshot.set(r.raw.snapshotId, arr);
+  }
+
+  const snapshotPayloads = snapshots.map((s) =>
+    snapshotToPayload(s, bySnapshot.get(s.id) ?? []),
+  );
+  const gradePayloads = allResolved.map(gradeToPayload);
+
+  if (opts.verbose) {
+    console.log(JSON.stringify({ snapshotPayloads, gradePayloads }, null, 2));
+  }
+  if (opts.dryRun) {
+    return {
+      source: adapter.source,
+      snapshots: snapshotPayloads.length,
+      grades: gradePayloads.length,
+    };
+  }
+
+  const snapResp = await syncScorecardSnapshots(snapshotPayloads);
+  if (!snapResp.ok) {
+    throw new Error(
+      `[${adapter.source}] snapshot sync failed (${snapResp.error}): ${snapResp.message}`,
+    );
+  }
+  const gradesResp = await syncScorecardGrades(gradePayloads);
+  if (!gradesResp.ok) {
+    throw new Error(
+      `[${adapter.source}] grade sync failed (${gradesResp.error}): ${gradesResp.message}`,
+    );
+  }
+
+  return {
+    source: adapter.source,
+    snapshots: snapshotPayloads.length,
+    grades: gradePayloads.length,
+    snapshotResp: snapResp.data,
+    gradesResp: gradesResp.data,
+  };
+}
+
+/**
+ * Analyze a source without writing anything — used by the `analyze`
+ * subcommand to surface unresolved org names + counts.
+ */
+export function analyzeSource(
+  adapter: ScorecardSourceAdapter,
+  ctx: OrgResolverContext,
+): SourceAnalysis {
+  const snapshots = adapter.listSnapshots();
+  const orgs = new Set<string>();
+  const allUnresolved = new Set<string>();
+  let resolvedCount = 0;
+  let totalGrades = 0;
+
+  for (const snap of snapshots) {
+    const grades = adapter.parseGrades(snap);
+    totalGrades += grades.length;
+    for (const g of grades) orgs.add(g.orgName);
+    const { resolved, unresolved } = resolveSnapshot(ctx, grades);
+    resolvedCount += resolved.length;
+    for (const u of unresolved) allUnresolved.add(u);
+  }
+
+  return {
+    source: adapter.source,
+    snapshots: snapshots.length,
+    grades: totalGrades,
+    uniqueOrgs: orgs.size,
+    resolved: resolvedCount,
+    unresolved: [...allUnresolved].sort(),
+  };
+}

--- a/crux/lib/scorecard-import/types.ts
+++ b/crux/lib/scorecard-import/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Types for the scorecard-import pipeline (QUA-698).
+ *
+ * Each source ships a `ScorecardSourceAdapter` that knows how to:
+ *   1. Enumerate its waves (snapshots).
+ *   2. Parse cached raw input (HTML, PDF text, JSON) into RawGrades.
+ *   3. Optionally fetch fresh raw input into `data/scorecards/raw/<source>/`.
+ *
+ * The shared engine (`sync.ts`) then resolves entity refs via the alias map,
+ * builds the API payloads, and POSTs them to wiki-server.
+ */
+
+import type { ScorecardSourceKey } from "../../../apps/web/src/app/scorecards/scorecards-constants.ts";
+
+export type { ScorecardSourceKey };
+
+/**
+ * One snapshot row (a wave of a scorecard). Maps 1:1 to
+ * `scorecard_snapshots` / the `/api/scorecard-snapshots/sync` payload.
+ *
+ * `id` is the deterministic snapshot ID — must round-trip across reruns so
+ * the upsert is idempotent. Convention: `<source>-<wave-slug>` e.g.
+ * `fli_index-summer-2025`, `saferai-2026-04`.
+ */
+export interface RawSnapshot {
+  id: string;
+  scorecardSource: ScorecardSourceKey;
+  waveLabel: string | null;
+  publishedAt: string; // ISO YYYY-MM-DD
+  sourceUrl: string;
+  methodologyUrl?: string | null;
+  license?: string | null;
+  notes?: string | null;
+  isLatest: boolean;
+  sourceActive: boolean;
+}
+
+/**
+ * One grade row (a cell in a scorecard). The engine resolves `orgName` to
+ * an entity stableId via `org-aliases.yaml` before sync; unresolved names
+ * cause the sync to hard-fail rather than silently drop.
+ *
+ * `dimensionSlug = "overall"` denotes the per-org rollup; the directory
+ * matrix queries with `?overall=true` and ignores everything else.
+ */
+export interface RawGrade {
+  /** Snapshot this grade belongs to (matches `RawSnapshot.id`). */
+  snapshotId: string;
+  /** Display name from the source. Used for entity lookup + audit. */
+  orgName: string;
+  /** Aliases the source publishes for this org (helps fuzzy lookup). */
+  orgAliases?: string[];
+  /** Dimension slug (kebab-case). `overall` for the rollup. */
+  dimensionSlug: string;
+  /** Human label from the source. */
+  dimensionLabel: string;
+  /** 0-1 weight of this dimension (only when source publishes weights). */
+  dimensionWeight?: number | null;
+  /** For nested dimensions (FMTI subdomains, FLI sub-axes). */
+  dimensionParentSlug?: string | null;
+  /** Numeric score if the source publishes one (percent, point total, etc.). */
+  scoreNumeric?: number | null;
+  /** Letter grade if the source publishes one (A, B+, F, "Partial"). */
+  scoreLetter?: string | null;
+  /** Verbatim score string (audit fidelity, always present). */
+  scoreRaw: string;
+  notes?: string | null;
+  /** Per-cell URL when the source links to a justification page. */
+  sourceUrl?: string | null;
+}
+
+/**
+ * A source adapter — one per scorecard publisher. Implementations live in
+ * `crux/lib/scorecard-import/sources/<key>.ts` and are wired into the
+ * dispatcher via `sources/index.ts::ALL_SOURCES`.
+ */
+export interface ScorecardSourceAdapter {
+  /** PG enum value — must match `ScorecardSourceKey`. */
+  source: ScorecardSourceKey;
+  /** Display name for CLI output. */
+  name: string;
+  /**
+   * Build all snapshots this adapter knows about (including historical
+   * waves). Reads from `data/scorecards/raw/<source>/` — does NOT fetch
+   * from the network. `fetch()` is the separate subcommand for that.
+   */
+  listSnapshots(): RawSnapshot[];
+  /**
+   * Parse all grade rows for the given snapshot from cached raw input.
+   * Each row is expected to be already-typed by the adapter; the shared
+   * engine handles entity resolution and API payload construction.
+   *
+   * Throws if raw input is missing — the caller should run `fetch` first.
+   */
+  parseGrades(snapshot: RawSnapshot): RawGrade[];
+  /**
+   * Optional: fetch the source's raw HTML/PDF/JSON into
+   * `data/scorecards/raw/<source>/<wave>/`. When unimplemented, the
+   * adapter is "manual-only" — raw inputs are committed by hand. Most
+   * adapters provide this for convenience but it is not required.
+   */
+  fetch?(snapshot: RawSnapshot): Promise<void>;
+}
+
+/**
+ * Result of resolving a `RawGrade.orgName` against the alias map +
+ * `database.json` entity index.
+ */
+export interface ResolvedGrade {
+  raw: RawGrade;
+  /** entities.stable_id (sid_…). */
+  entityId: string;
+  /** Canonical title from database.json — used as `entityDisplayName`. */
+  canonicalName: string;
+}
+
+/** Counters returned by `analyzeSource()` — used by the CLI summary. */
+export interface SourceAnalysis {
+  source: ScorecardSourceKey;
+  snapshots: number;
+  grades: number;
+  uniqueOrgs: number;
+  resolved: number;
+  unresolved: string[];
+}

--- a/data/scorecards/org-aliases.yaml
+++ b/data/scorecards/org-aliases.yaml
@@ -1,0 +1,37 @@
+# Hand-curated org-name → entity slug overrides for scorecard ingesters
+# (QUA-698). Used when the entity matcher (database.json titles + aliases
+# + suffix normalization) fails to resolve a name a scorecard publisher uses.
+#
+# Lookup order in `resolveOrg()`:
+#   1. exact match in this file (case-insensitive on the key)
+#   2. exact match against entity title or alias in database.json
+#   3. normalized match (strip Inc./Ltd./Corp./LLC suffix etc.)
+#   4. return null — caller hard-fails the sync (analyze prints + exits 1)
+#
+# Keys are the org name as the SOURCE publishes it.
+# Values are the entity slug (matches entities.id in database.json).
+#
+# Prefer adding to the entity's YAML `aliases:` block in `data/entities/`
+# instead — that surfaces the alias everywhere, not just to the scorecard
+# pipeline. Use this file only when:
+#   - The alias is truly scorecard-specific and shouldn't appear elsewhere
+#   - The org doesn't have its own entity yet (rare; create the entity)
+#
+# Most common cases (suffix variants like "Anthropic PBC", "OpenAI Inc.",
+# "Mistral AI" with the trailing "AI") are already handled by the matcher
+# via existing entity aliases or normalization — verify with
+# `pnpm crux tb import-scorecards analyze --source=<key>` before adding
+# an override here.
+
+overrides:
+  # AI Lab Watch occasionally writes "lab" as a suffix on headers. Direct
+  # override since this isn't useful as a real alias on the entity.
+  "Anthropic (lab)": anthropic
+  "OpenAI (lab)": openai
+  "DeepMind (lab)": deepmind
+
+  # Examples — uncomment + edit when you encounter unresolved names in
+  # `analyze` output. Always check `data/entities/organizations.yaml` to
+  # confirm the slug exists before committing.
+  #
+  #   "Some Display Name From Source": entity-slug

--- a/data/scorecards/raw/.gitkeep
+++ b/data/scorecards/raw/.gitkeep
@@ -1,0 +1,11 @@
+# Raw input for scorecard ingesters (QUA-698).
+#
+# Layout: data/scorecards/raw/<source>/<wave-slug>/grades.json
+#
+# `grades.json` is the canonical extracted input — committed to git. Large
+# binary inputs (PDFs, full HTML pages) used during the LLM-extraction
+# step can sit alongside `grades.json` in the same wave directory; commit
+# them when they're useful for audit, gitignore them when they're large.
+#
+# See `crux/lib/scorecard-import/sources/<source>.ts` for the per-source
+# JSON schema.


### PR DESCRIPTION
## Summary

Phase 1 follow-up to QUA-688 (framework PR #4589). Adds the ingester pipeline that fills the `scorecard_snapshots` / `scorecard_grades` tables for the four external scorecards that don't have a clean CSV path: FLI AI Safety Index, SaferAI Ratings, AI Lab Watch (frozen Sept 2025), and the Seoul Commitment Tracker. FMTI is a separate ticket (QUA-697).

The framework PR is intentionally data-free — it ships the schema, sync routes, directory page, and org-profile tab. This PR adds the pipeline that flows extracted JSON into the schema. Real data ingestion (the LLM-extraction step for FLI / HTML scrape for SaferAI / etc.) is the next step and lands as separate per-source PRs once each one is reviewed.

Closes QUA-698.

> Originally stacked on the QUA-688 framework branch; rebased onto `main` after #4589 merged.

## Architecture — shared engine + per-source adapters

```
crux/lib/scorecard-import/
├── types.ts              RawSnapshot / RawGrade / ScorecardSourceAdapter
├── org-aliases.ts        resolveOrg(): override → matcher → normalize → null
├── sync.ts               resolve → derive payloads → POST (idempotent upsert)
└── sources/
    ├── fli.ts            (letter grades → GPA)
    ├── saferai.ts        (percent → 0-100 + qualitative band)
    ├── ailabwatch.ts     (percent + sourceActive=false + freeze-notice)
    ├── seoul.ts          (categorical → 0/0.5/1)
    └── index.ts          registry

crux/commands/import-scorecards.ts        CLI: list / analyze / sync
data/scorecards/raw/<source>/<wave>/grades.json   raw input layout
data/scorecards/org-aliases.yaml          hand-curated overrides
```

Each adapter exposes both a `createXxxAdapter(rawDir)` factory (tests point at fixture dirs) and a default-instance export (`fliAdapter`, etc.) for production callsites.

## CLI surface

```bash
pnpm crux tb import-scorecards list                  # source registry + on-disk state
pnpm crux tb import-scorecards analyze               # all sources, surface unresolved orgs
pnpm crux tb import-scorecards analyze --source=fli_index
pnpm crux tb import-scorecards sync --dry-run        # show payloads, no writes
pnpm crux tb import-scorecards sync --source=saferai
```

## Idempotency + safety

- **Snapshot IDs** are deterministic: `<source>-<wave-slug>` (e.g. `fli_index-summer-2025`).
- **Grade IDs** are deterministic: `<snapshotId>|<entityId>|<dimensionSlug>`.
- The sync-factory upsert handles re-runs in place — same row updates, no duplicates.
- **Unresolved org names hard-fail the sync** per QUA-698 — never silently drop. The error names the snapshot ID and points at the alias YAML; `analyze` collects all unresolved across all sources and exits non-zero.
- Adapters validate wave files at load time: `publishedAt` format, dimensions declared, every org has an `overall` score, no scores for unknown dimensions. Bad raw files surface loudly.

## Per-source quirks captured in the adapters

| Source | Score encoding | sourceActive |
|--------|---------------|--------------|
| FLI    | letter grades → GPA via `letterToGpa` (A+ = 4.3 ... F = 0, F- clamped to 0) | true |
| SaferAI | percent → 0-100 + qualitative band ("Strong" ≥75, "Moderate" ≥50, "Weak" ≥25, "Very Weak" else) | true |
| AI Lab Watch | percent + same band logic | **false** (frozen Sept 2025) |
| Seoul | categorical: Fulfilled = 1.0, Partial = 0.5, Unfulfilled = 0.0; verbatim preserved | true |

`scoreRaw` always preserves the source's verbatim string for audit, regardless of how `scoreNumeric` / `scoreLetter` are derived.

## Tests — 44 passing

- **`sources.test.ts` (25):** per-adapter behavior with fixture wave files + score-encoding helpers + idempotent rerun assertion
- **`sync.test.ts` (11):** resolver partition, ID determinism, dryRun, hard-fail on unresolved with correct error shape, snapshot count derivation
- **`org-aliases.test.ts` (8):** override precedence, normalization fallback, case-insensitive keys, ghost-slug detection (override → non-existent slug throws)

Adversarial inputs covered: unknown dimensions, missing overall, percent unparseable ("N/A"), letter unparseable ("Pending"), F- clamp, override pointing to non-existent slug, dedup of repeated unresolved names.

## Out of scope (intentional)

- **Live `fetch` / `extract` subcommands.** The LLM-assisted FLI extraction and HTML scraping are out-of-band manual steps that produce `grades.json`. Decoupling lets us re-sync after schema tweaks without re-paying LLM costs, and keeps PR diffs focused on the pipeline rather than scraper churn.
- **Real wave data.** The framework is verified end-to-end with fixtures; populating `data/scorecards/raw/<source>/` with real ingested data is the next step (likely a series of source-specific PRs once each one is extracted + reviewed).

## Test plan

- [x] `pnpm vitest run crux/lib/scorecard-import/__tests__/` — 44 pass
- [x] `pnpm --filter wiki-server test -- --run` — 1380 pass (no regressions)
- [x] `cd apps/web && pnpm test` — 1699 pass (no regressions)
- [x] `cd apps/web && pnpm exec tsc --noEmit` — green
- [x] `pnpm exec tsc --noEmit -p crux/tsconfig.json | grep scorecard` — zero errors in new code
- [x] `pnpm crux w validate gate --scope=content --fix` — 5/5 green
- [x] `pnpm crux tb import-scorecards list` — surfaces all 4 sources, 0 grades on disk
- [x] `pnpm crux tb import-scorecards analyze` — exits 0 with empty data
- [x] `pnpm crux tb import-scorecards --help` — help text correct
- [ ] CI green (will verify after push)
