### PR TITLE
QUA-707: registry-driven frontier-safety-framework ingester

### DIFF
--- a/crux/commands/frameworks.ts
+++ b/crux/commands/frameworks.ts
@@ -435,9 +435,21 @@ async function ingestCommand(
 ): Promise<CommandResult> {
   const log = createLogger(Boolean(options.ci));
 
+  let maxVersions: number | undefined;
+  if (options.max !== undefined) {
+    const n = parseInt(String(options.max), 10);
+    if (!Number.isFinite(n) || n < 1) {
+      return {
+        exitCode: 1,
+        output: `--max must be a positive integer (got "${options.max}")`,
+      };
+    }
+    maxVersions = n;
+  }
+
   const ingestOpts: IngestOptions = {
     frameworkKey: options.only,
-    maxVersions: options.max ? Math.max(1, parseInt(options.max, 10)) : undefined,
+    maxVersions,
     // Default to dry-run unless --apply is given. --dry-run is also accepted
     // as an explicit hint for symmetry with other tooling, but `apply` is
     // the primary opt-in.

--- a/crux/commands/frameworks.ts
+++ b/crux/commands/frameworks.ts
@@ -1,7 +1,8 @@
 /**
- * Frontier-safety-framework subcommands — `crux tb frameworks ...` (QUA-691).
+ * Frontier-safety-framework subcommands — `crux tb frameworks ...`
+ * (QUA-691 foundation, QUA-707 registry-driven ingest).
  *
- * Subcommands:
+ * Per-URL subcommands (manual single-version ingest):
  *   extract <url>  --framework=<sid> --version=<label>
  *                  [--apply]           POST thresholds to wiki-server /sync
  *                  [--model=sonnet]    LLM model override
@@ -16,9 +17,13 @@
  *   fetch <url>    [--skip-wayback]    download + hash + Wayback push
  *                  [--json]            raw JSON output
  *
- * The command wiring is minimal — it exists so agents can ingest a
- * framework end-to-end from the CLI during Phase 4 development. Scheduled
- * re-fetches live in `crux/scripts/refresh-frameworks.ts` (follow-up PR).
+ * Registry-driven subcommands (end-to-end batch from data/frameworks/frameworks.yaml):
+ *   list           Print the loaded registry
+ *   seed [--apply] Sync framework rows
+ *   ingest [--apply] [--only=<key>] [--max=N] [--skip-extract|skip-diffs|...]
+ *
+ * Both `tb frameworks <sub>` (two-word) and `tb frameworks-<sub>` (hyphenated)
+ * dispatches are wired up in `tablebase.ts` and the `default` handler.
  */
 
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
@@ -34,11 +39,29 @@ import {
   structuralDiff,
   aggregateDiff,
   type DiffAggregate,
-  type DiffItem,
 } from '../frameworks/diff.ts';
 import { fetchFramework } from '../frameworks/fetch.ts';
 import { MODELS } from '../lib/anthropic.ts';
 import { createLogger } from '../lib/output.ts';
+import {
+  toThresholdSyncItems,
+  toDiffSyncPayloads,
+} from '../frameworks/sync-payloads.ts';
+import {
+  loadRegistry,
+  type RegistryFramework,
+} from '../frameworks/registry.ts';
+import {
+  buildFrameworkSyncItems,
+  defaultIngestDeps,
+  runIngest,
+  type IngestOptions,
+  type IngestSummary,
+} from '../frameworks/orchestrator.ts';
+
+// Re-export the sync-payload helpers for backward compatibility with the
+// existing `commands/frameworks.test.ts` tests and any external callers.
+export { toThresholdSyncItems, toDiffSyncPayloads };
 
 interface FrameworkOptions extends CommandOptions {
   url?: string;
@@ -61,87 +84,6 @@ function resolveLlmModel(name?: string): string {
   if (lower === 'sonnet') return MODELS.sonnet;
   if (lower === 'opus') return MODELS.opus;
   return name;
-}
-
-/**
- * Build sync-item payloads for `/api/framework-capability-thresholds/sync`
- * from an extract result. Each row gets a deterministic `id` so re-runs
- * upsert cleanly.
- */
-export function toThresholdSyncItems(
-  versionId: string,
-  thresholds: ExtractedThreshold[],
-  meta: { extractionModel: string },
-): Array<Record<string, unknown>> {
-  return thresholds.map((t) => ({
-    id: generateId(
-      `framework-threshold:${versionId}:${t.riskDomainCanonical}:${t.tierSortOrder}`,
-    ),
-    versionId,
-    riskDomainCanonical: t.riskDomainCanonical,
-    riskDomainLabel: t.riskDomainLabel,
-    tierLabel: t.tierLabel,
-    tierSortOrder: t.tierSortOrder,
-    triggerDescription: t.triggerDescription,
-    sourceQuote: t.sourceQuote,
-    sourcePageHint: t.sourcePageHint,
-    requiredMitigations: t.requiredMitigations,
-    associatedEvals: t.associatedEvals,
-    commitmentLanguage: t.commitmentLanguage,
-    extractedByModel: meta.extractionModel,
-    extractionConfidence: t.extractionConfidence,
-    humanReviewed: false,
-    humanReviewNotes: null,
-  }));
-}
-
-/**
- * Build the `framework_diffs` + `framework_diff_items` sync payloads.
- */
-export function toDiffSyncPayloads(
-  fromVersionId: string,
-  toVersionId: string,
-  aggregate: DiffAggregate,
-  meta: { classifiedByModel: string | null },
-): {
-  diff: Record<string, unknown>;
-  items: Array<Record<string, unknown>>;
-} {
-  const diffId = generateId(`framework-diff:${fromVersionId}:${toVersionId}`);
-  return {
-    diff: {
-      id: diffId,
-      fromVersionId,
-      toVersionId,
-      changeSummary: aggregate.changeSummary,
-      weakeningFlagged: aggregate.weakeningFlagged,
-      strengtheningFlagged: aggregate.strengtheningFlagged,
-      neutralChangesCount: aggregate.neutralChangesCount,
-      diffDetails: { itemCount: aggregate.items.length },
-      overallDirection: aggregate.overallDirection,
-      humanReviewed: false,
-      reviewVerdict: 'unreviewed',
-      reviewNotes: null,
-      classifiedByModel: meta.classifiedByModel,
-    },
-    items: aggregate.items.map((item: DiffItem, idx: number) => ({
-      id: generateId(
-        `framework-diff-item:${diffId}:${idx}:${item.changeType}:${item.riskDomainCanonical ?? 'none'}`,
-      ),
-      diffId,
-      changeType: item.changeType,
-      riskDomainCanonical: item.riskDomainCanonical,
-      beforeSnapshot: item.beforeSnapshot
-        ? (item.beforeSnapshot as unknown as Record<string, unknown>)
-        : null,
-      afterSnapshot: item.afterSnapshot
-        ? (item.afterSnapshot as unknown as Record<string, unknown>)
-        : null,
-      severity: item.severity,
-      classifierTag: item.classifierTag,
-      rationale: item.rationale,
-    })),
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -375,21 +317,242 @@ async function fetchCommand(opts: FrameworkOptions): Promise<CommandResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Registration
+// Registry-driven subcommands (QUA-707)
+//
+// These take `(args, options)` per the canonical dispatcher signature
+// (see crux.mjs::main and crux/commands/people.ts for the pattern).
+// `args` is the raw positional tail — `extract`/`diff`/`fetch` above use
+// the older single-arg signature which routes positionals through opts.args;
+// the new commands below intentionally use the two-arg signature so options
+// like `--apply`, `--only`, `--max`, etc. arrive through `options` correctly.
 // ---------------------------------------------------------------------------
+
+interface RegistryDrivenOptions extends CommandOptions {
+  apply?: boolean;
+  json?: boolean;
+  only?: string;
+  max?: string;
+  skipExtract?: boolean;
+  skipDiffs?: boolean;
+  forceReextract?: boolean;
+  skipWayback?: boolean;
+  skipClassifier?: boolean;
+  dryRun?: boolean;
+  model?: string;
+}
+
+async function listCommand(
+  _args: string[],
+  options: RegistryDrivenOptions,
+): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  let registry: RegistryFramework[];
+  try {
+    registry = loadRegistry();
+  } catch (err) {
+    log.error(
+      `Failed to load registry: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { output: '', exitCode: 1 };
+  }
+
+  if (options.json) {
+    const items = buildFrameworkSyncItems(registry).map((item, idx) => ({
+      ...item,
+      key: registry[idx].key,
+      versions: registry[idx].versions.map((v) => ({
+        versionLabel: v.versionLabel,
+        publishedDate: v.publishedDate,
+        sourceUrl: v.sourceUrl,
+        isDraft: v.isDraft,
+        versionSortOrder: v.versionSortOrder,
+      })),
+    }));
+    console.log(JSON.stringify(items, null, 2));
+    return { output: '', exitCode: 0 };
+  }
+
+  log.info(
+    `Loaded ${registry.length} framework(s) with ${registry.reduce((n, e) => n + e.versions.length, 0)} version(s):`,
+  );
+  for (const e of registry) {
+    log.info(
+      `  ${e.key} (${e.frameworkId.slice(0, 8)}…) — ${e.name} [${e.orgId}] — ${e.versions.length} version(s)`,
+    );
+    for (const v of e.versions) {
+      log.info(
+        `    ${v.versionSortOrder}. ${v.versionLabel}  (${v.publishedDate})${v.isDraft ? ' [draft]' : ''}  ${v.sourceUrl}`,
+      );
+    }
+  }
+
+  return { output: '', exitCode: 0 };
+}
+
+async function seedCommand(
+  _args: string[],
+  options: RegistryDrivenOptions,
+): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+  let registry: RegistryFramework[];
+  try {
+    registry = loadRegistry();
+  } catch (err) {
+    log.error(
+      `Failed to load registry: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { output: '', exitCode: 1 };
+  }
+
+  const items = buildFrameworkSyncItems(registry);
+  log.info(`${items.length} framework row(s) ready to sync:`);
+  for (const item of items) {
+    log.info(`  ${item.id.slice(0, 8)}…  ${item.orgId} → ${item.name} (${item.currentStatus})`);
+  }
+
+  if (!options.apply) {
+    log.info('Dry-run; pass --apply to sync to /api/safety-frameworks/sync');
+    return { output: '', exitCode: 0 };
+  }
+
+  const { apiRequest } = await import('../lib/wiki-server/client.ts');
+  const res = await apiRequest<{ upserted: number }>(
+    'POST',
+    '/api/safety-frameworks/sync',
+    { items },
+  );
+  if (!res.ok) {
+    log.error(`Sync failed: ${res.error} — ${res.message}`);
+    return { output: '', exitCode: 2 };
+  }
+  log.info(`✓ Synced ${items.length} framework row(s).`);
+  return { output: '', exitCode: 0 };
+}
+
+async function ingestCommand(
+  _args: string[],
+  options: RegistryDrivenOptions,
+): Promise<CommandResult> {
+  const log = createLogger(Boolean(options.ci));
+
+  const ingestOpts: IngestOptions = {
+    frameworkKey: options.only,
+    maxVersions: options.max ? Math.max(1, parseInt(options.max, 10)) : undefined,
+    // Default to dry-run unless --apply is given. --dry-run is also accepted
+    // as an explicit hint for symmetry with other tooling, but `apply` is
+    // the primary opt-in.
+    dryRun: Boolean(options.dryRun) || !options.apply,
+    skipExtract: Boolean(options.skipExtract),
+    skipDiffs: Boolean(options.skipDiffs),
+    forceReextract: Boolean(options.forceReextract),
+    skipWayback: Boolean(options.skipWayback),
+    skipClassifier: Boolean(options.skipClassifier),
+    llmModel: options.model ? resolveLlmModel(options.model) : undefined,
+  };
+
+  if (ingestOpts.dryRun) {
+    log.info(
+      'Dry-run: fetching + extracting will run, but no /sync POSTs will be issued. Pass --apply to write to wiki-server.',
+    );
+  }
+
+  let summary: IngestSummary;
+  try {
+    const deps = await defaultIngestDeps({
+      log: (level, msg) => {
+        if (level === 'error') log.error(msg);
+        else if (level === 'warn') log.warn(msg);
+        else log.info(msg);
+      },
+    });
+    summary = await runIngest(deps, ingestOpts);
+  } catch (err) {
+    log.error(
+      `Ingest aborted: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { output: '', exitCode: 2 };
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    log.info('');
+    log.info(`Frameworks: ${summary.frameworksSynced}`);
+    log.info(
+      `Versions:  attempted=${summary.versionsAttempted} synced=${summary.versionsSynced} skipped=${summary.versionsSkipped} failed=${summary.versionsFailed}`,
+    );
+    log.info(`Diffs:     synced=${summary.diffsSynced} failed=${summary.diffsFailed}`);
+    if (summary.versionsFailed > 0 || summary.diffsFailed > 0) {
+      log.warn(
+        'One or more versions/diffs failed — see per-line errors above. Re-run after addressing the cause.',
+      );
+    }
+  }
+
+  return {
+    output: '',
+    exitCode: summary.versionsFailed > 0 || summary.diffsFailed > 0 ? 1 : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+//
+// extract / diff / fetch use the legacy `(opts)` single-arg signature which
+// is leftover from how QUA-691 first wrote them — they're left as-is for
+// this PR. The new list / seed / ingest commands use the proper
+// `(args, options)` two-arg signature, since they need flag-driven options.
+//
+// `default` dispatches based on the first positional arg: `crux tb frameworks
+// list` → listCommand; `seed` / `ingest` similarly. Otherwise falls back to
+// listCommand. The hyphenated aliases (`frameworks-list`, `frameworks-seed`,
+// `frameworks-ingest`) registered in tablebase.ts always work too.
+// ---------------------------------------------------------------------------
+
+type ArgsOptionsHandler = (args: string[], options: CommandOptions) => Promise<CommandResult>;
+type LegacyOptsHandler = (opts: FrameworkOptions) => Promise<CommandResult>;
+
+const REGISTRY_DRIVEN: Record<string, ArgsOptionsHandler> = {
+  list: listCommand,
+  seed: seedCommand,
+  ingest: ingestCommand,
+};
+
+const LEGACY: Record<string, LegacyOptsHandler> = {
+  extract: extractCommand,
+  diff: diffCommand,
+  fetch: fetchCommand,
+};
+
+async function defaultCommand(
+  args: string[],
+  options: CommandOptions,
+): Promise<CommandResult> {
+  const first = Array.isArray(args) && typeof args[0] === 'string' ? args[0] : null;
+  if (first && first in REGISTRY_DRIVEN) {
+    return REGISTRY_DRIVEN[first]!(args.slice(1), options);
+  }
+  if (first && first in LEGACY) {
+    return LEGACY[first]!({ ...options, args: args.slice(1) } as FrameworkOptions);
+  }
+  return listCommand(args, options as RegistryDrivenOptions);
+}
 
 export const commands = {
   extract: extractCommand,
   diff: diffCommand,
   fetch: fetchCommand,
-  default: extractCommand,
+  list: listCommand,
+  seed: seedCommand,
+  ingest: ingestCommand,
+  default: defaultCommand,
 };
 
 export function getHelp(): string {
   return `
-Frameworks — Frontier safety framework tracker (QUA-691)
+Frameworks — Frontier safety framework tracker (QUA-691, QUA-707)
 
-Subcommands:
+Per-URL subcommands (low-level, manual ingest of a single version):
   extract <url>   Two-pass LLM extraction of capability thresholds
                   --framework=<sid>         framework stableId (required)
                   --version=<label>         version label (required)
@@ -407,10 +570,31 @@ Subcommands:
                   --skip-wayback            skip the Wayback push
                   --json                    raw JSON output
 
-Examples:
-  crux tb frameworks extract https://anthropic.com/rsp-v3.1.pdf \\
-      --framework=sid_XXXXXXXXXX --version=v3.1
+Registry-driven subcommands (QUA-707, end-to-end batch):
+  list           Print the loaded registry (12 frameworks / ~22 versions)
+                  --json                    raw JSON output
 
-  crux tb frameworks diff sid_FROM sid_TO --apply
+  seed           Sync the framework registry rows
+                  --apply                   POST to /api/safety-frameworks/sync
+                  (without --apply this is a dry-run)
+
+  ingest         Run the full pipeline: fetch → extract → sync versions +
+                  thresholds → diff consecutive pairs → sync diffs
+                  --apply                   actually POST (default is dry-run)
+                  --only=<key>              process only one framework key
+                  --max=N                   cap versions per framework
+                  --skip-extract            skip the LLM extraction pass
+                  --skip-diffs              skip the diff pass
+                  --force-reextract         re-extract even if version exists
+                  --skip-classifier         skip LLM diff classifier
+                  --skip-wayback            skip Wayback push
+                  --model=haiku|sonnet      LLM (default sonnet)
+                  --json                    summary as JSON
+
+Examples:
+  crux tb frameworks list
+  crux tb frameworks seed --apply
+  crux tb frameworks ingest --only=anthropic-rsp --max=1
+  crux tb frameworks ingest --apply
 `.trim();
 }

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -1503,10 +1503,14 @@ export const commands = {
   'system-cards': systemCardsCommands.default,
   'system-cards-extract': systemCardsCommands.extract,
   // QUA-691: frontier-safety-framework tracker.
+  // QUA-707 added registry-driven `list`, `seed`, and `ingest` subcommands.
   'frameworks': frameworksCommands.default,
   'frameworks-extract': frameworksCommands.extract,
   'frameworks-diff': frameworksCommands.diff,
   'frameworks-fetch': frameworksCommands.fetch,
+  'frameworks-list': frameworksCommands.list,
+  'frameworks-seed': frameworksCommands.seed,
+  'frameworks-ingest': frameworksCommands.ingest,
   // QUA-692: third-party evaluation index.
   'third-party-evals': thirdPartyEvalsCommands.default,
   'third-party-evals-ingest': thirdPartyEvalsCommands.ingest,

--- a/crux/frameworks/orchestrator.test.ts
+++ b/crux/frameworks/orchestrator.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  buildFrameworkSyncItems,
+  buildVersionSyncItem,
+  runIngest,
+  type IngestDeps,
+  type FrameworkSyncItem,
+  type VersionSyncItem,
+} from './orchestrator.ts';
+import { _resetRegistryCache, frameworkIdFromKey, versionIdFromHash } from './registry.ts';
+import type { ExtractResult, ExtractedThreshold } from './extract.ts';
+import type { FetchResult } from './fetch.ts';
+import type { DiffAggregate } from './diff.ts';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const REGISTRY_FIXTURE = `
+version: 1
+frameworks:
+  alpha:
+    org_slug: orgalpha
+    name: "Alpha Framework"
+    short_name: "AF"
+    framework_family: "alpha-fam"
+    status: active
+    versions:
+      - version_label: "v1"
+        published_date: "2024-01-01"
+        source_url: "https://example.com/alpha-v1"
+      - version_label: "v2"
+        published_date: "2025-06-01"
+        source_url: "https://example.com/alpha-v2"
+  beta:
+    org_slug: orgbeta
+    name: "Beta Framework"
+    status: active
+    versions:
+      - version_label: "v1"
+        published_date: "2024-08-01"
+        source_url: "https://example.com/beta-v1"
+`;
+
+let fixturePath: string;
+
+beforeEach(() => {
+  _resetRegistryCache();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'frameworks-fixture-'));
+  fixturePath = path.join(tmp, 'frameworks.yaml');
+  fs.writeFileSync(fixturePath, REGISTRY_FIXTURE);
+});
+
+function fakeFetch(contentHash: string, lengthChars = 1234): FetchResult {
+  return {
+    sourceText: 'fake source body',
+    contentLengthChars: lengthChars,
+    contentHash,
+    contentType: 'html',
+    httpStatus: 200,
+    canonicalUrl: 'https://example.com/canonical',
+    waybackSnapshotUrl: null,
+  };
+}
+
+function fakeThreshold(overrides: Partial<ExtractedThreshold> = {}): ExtractedThreshold {
+  return {
+    riskDomainCanonical: 'cbrn',
+    riskDomainLabel: 'CBRN',
+    tierLabel: 'High',
+    tierSortOrder: 3,
+    triggerDescription: 'capability X',
+    sourceQuote: 'a quote',
+    sourcePageHint: null,
+    requiredMitigations: null,
+    associatedEvals: null,
+    commitmentLanguage: 'committed',
+    extractionConfidence: 0.9,
+    ...overrides,
+  };
+}
+
+function fakeExtract(thresholds: ExtractedThreshold[] = [fakeThreshold()]): ExtractResult {
+  return {
+    thresholds,
+    candidateCount: thresholds.length,
+    unverifiedCount: 0,
+    sourceText: 'fake',
+    sourceFormat: 'html',
+    sourceHash: 'hash-from-extract',
+    contentLengthChars: 100,
+    usage: { input_tokens: 1, output_tokens: 1 },
+    pass1Model: 'claude-haiku-test',
+    pass2Model: 'claude-sonnet-test',
+    extractorVersion: 'test@1',
+    extractedAt: new Date().toISOString(),
+  };
+}
+
+function fakeAggregate(items: DiffAggregate['items'] = []): DiffAggregate {
+  return {
+    items,
+    changeSummary: 'no changes',
+    weakeningFlagged: false,
+    strengtheningFlagged: false,
+    neutralChangesCount: 0,
+    overallDirection: 'neutral',
+  };
+}
+
+interface RecordingDeps extends IngestDeps {
+  calls: {
+    fetched: string[];
+    extracted: string[];
+    diffed: number;
+    syncedFrameworks: FrameworkSyncItem[][];
+    syncedVersions: VersionSyncItem[][];
+    syncedThresholds: Array<Record<string, unknown>>[];
+    syncedDiffs: Array<Record<string, unknown>>[];
+    syncedDiffItems: Array<Record<string, unknown>>[];
+    existingChecks: string[];
+  };
+  /** Map of versionId → "exists" so we can simulate skip-if-exists. */
+  existing: Set<string>;
+}
+
+function makeDeps(opts: {
+  /** Map version url → contentHash. Different hash per call would need an array; not needed yet. */
+  hashByUrl?: Record<string, string>;
+  /** Make every fetch fail with this message. */
+  fetchError?: string;
+  /** Make extraction fail (used to test extract_failed status). */
+  extractError?: string;
+  /** Pre-populate the "existing" set so fetchExistingVersion returns truthy. */
+  preExisting?: string[];
+} = {}): RecordingDeps {
+  const calls: RecordingDeps['calls'] = {
+    fetched: [],
+    extracted: [],
+    diffed: 0,
+    syncedFrameworks: [],
+    syncedVersions: [],
+    syncedThresholds: [],
+    syncedDiffs: [],
+    syncedDiffItems: [],
+    existingChecks: [],
+  };
+  const existing = new Set<string>(opts.preExisting ?? []);
+  return {
+    calls,
+    existing,
+    fetchFramework: async (o) => {
+      calls.fetched.push(o.url);
+      if (opts.fetchError) throw new Error(opts.fetchError);
+      const hash = opts.hashByUrl?.[o.url] ?? `hash-${o.url}`;
+      return fakeFetch(hash);
+    },
+    extractFrameworkThresholds: async (o) => {
+      calls.extracted.push(o.url);
+      if (opts.extractError) throw new Error(opts.extractError);
+      return fakeExtract();
+    },
+    diffFrameworkVersions: async () => {
+      calls.diffed++;
+      return fakeAggregate([
+        {
+          changeType: 'mitigation_softened',
+          riskDomainCanonical: 'cbrn',
+          beforeSnapshot: null,
+          afterSnapshot: null,
+          severity: 2,
+          classifierTag: 'weaker',
+          rationale: 'because',
+        },
+      ]);
+    },
+    fetchExistingVersion: async (id) => {
+      calls.existingChecks.push(id);
+      return existing.has(id) ? { id } : null;
+    },
+    syncFrameworks: async (items) => {
+      calls.syncedFrameworks.push(items);
+    },
+    syncVersions: async (items) => {
+      calls.syncedVersions.push(items);
+    },
+    syncThresholds: async (items) => {
+      calls.syncedThresholds.push(items);
+    },
+    syncDiffs: async (items) => {
+      calls.syncedDiffs.push(items);
+    },
+    syncDiffItems: async (items) => {
+      calls.syncedDiffItems.push(items);
+    },
+    log: () => {
+      /* silent in tests */
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildFrameworkSyncItems / buildVersionSyncItem (pure helpers)
+// ---------------------------------------------------------------------------
+
+describe('buildFrameworkSyncItems', () => {
+  it('builds one item per framework with derived firstPublishedDate', () => {
+    const entries = [
+      {
+        key: 'k',
+        frameworkId: frameworkIdFromKey('k'),
+        orgId: 'o',
+        name: 'N',
+        shortName: null,
+        frameworkFamily: null,
+        status: 'active' as const,
+        notes: null,
+        versions: [
+          { versionLabel: 'v1', publishedDate: '2024-01-01', sourceUrl: 'u1', isDraft: false, versionSortOrder: 1 },
+          { versionLabel: 'v2', publishedDate: '2025-01-01', sourceUrl: 'u2', isDraft: false, versionSortOrder: 2 },
+        ],
+      },
+    ];
+    const items = buildFrameworkSyncItems(entries);
+    expect(items.length).toBe(1);
+    expect(items[0].id).toBe(entries[0].frameworkId);
+    expect(items[0].orgId).toBe('o');
+    expect(items[0].firstPublishedDate).toBe('2024-01-01');
+    expect(items[0].currentStatus).toBe('active');
+  });
+
+  it('handles a framework with no versions gracefully (firstPublishedDate=null)', () => {
+    const items = buildFrameworkSyncItems([
+      {
+        key: 'k', frameworkId: 'AAAAAAAAAA', orgId: 'o', name: 'N',
+        shortName: null, frameworkFamily: null, status: 'active', notes: null,
+        versions: [],
+      },
+    ]);
+    expect(items[0].firstPublishedDate).toBe(null);
+  });
+});
+
+describe('buildVersionSyncItem', () => {
+  it('uses the contentHash for the deterministic version id', () => {
+    const fw = {
+      key: 'k', frameworkId: 'FRAMEWORK00', orgId: 'o', name: 'N',
+      shortName: null, frameworkFamily: null, status: 'active' as const, notes: null,
+      versions: [],
+    };
+    const version = {
+      versionLabel: 'v1', publishedDate: '2024-01-01',
+      sourceUrl: 'https://example.com/x', isDraft: false, versionSortOrder: 1,
+    };
+    const fetched = fakeFetch('CONTENT_HASH_AAA');
+    const item = buildVersionSyncItem(fw, version, fetched, new Date('2026-04-24T12:00:00Z'));
+
+    expect(item.id).toBe(versionIdFromHash('FRAMEWORK00', 'v1', 'CONTENT_HASH_AAA'));
+    expect(item.frameworkId).toBe('FRAMEWORK00');
+    expect(item.versionLabel).toBe('v1');
+    expect(item.contentHash).toBe('CONTENT_HASH_AAA');
+    expect(item.discoveredDate).toBe('2026-04-24');
+    expect(item.publishedDate).toBe('2024-01-01');
+    expect(item.ingestStatus).toBe('pending_review');
+  });
+
+  it('sets sourceUrlCanonical only when canonicalUrl differs from sourceUrl', () => {
+    const fw = {
+      key: 'k', frameworkId: 'FRAMEWORK00', orgId: 'o', name: 'N',
+      shortName: null, frameworkFamily: null, status: 'active' as const, notes: null,
+      versions: [],
+    };
+    const version = {
+      versionLabel: 'v1', publishedDate: '2024-01-01',
+      sourceUrl: 'https://example.com/x', isDraft: false, versionSortOrder: 1,
+    };
+    // Same URL: canonical should be null.
+    const a = buildVersionSyncItem(fw, version, {
+      ...fakeFetch('h'),
+      canonicalUrl: 'https://example.com/x',
+    });
+    expect(a.sourceUrlCanonical).toBe(null);
+    // Different URL: canonical should be set.
+    const b = buildVersionSyncItem(fw, version, {
+      ...fakeFetch('h'),
+      canonicalUrl: 'https://example.com/redirected',
+    });
+    expect(b.sourceUrlCanonical).toBe('https://example.com/redirected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — happy-path orchestration
+// ---------------------------------------------------------------------------
+
+describe('runIngest — full pipeline', () => {
+  it('syncs frameworks + versions + thresholds + diffs end-to-end', async () => {
+    const deps = makeDeps({
+      hashByUrl: {
+        'https://example.com/alpha-v1': 'HA1',
+        'https://example.com/alpha-v2': 'HA2',
+        'https://example.com/beta-v1': 'HB1',
+      },
+    });
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: false,
+    });
+
+    // 2 frameworks total.
+    expect(summary.frameworksSynced).toBe(2);
+    expect(deps.calls.syncedFrameworks.length).toBe(1);
+    expect(deps.calls.syncedFrameworks[0].length).toBe(2);
+
+    // 3 versions: alpha v1, alpha v2, beta v1.
+    expect(summary.versionsAttempted).toBe(3);
+    expect(summary.versionsSynced).toBe(3);
+    expect(deps.calls.syncedVersions.length).toBe(3);
+    expect(deps.calls.syncedThresholds.length).toBe(3);
+
+    // Diff: alpha has 2 versions → 1 pair; beta has 1 → 0. Total 1 diff.
+    expect(summary.diffsSynced).toBe(1);
+    expect(deps.calls.syncedDiffs.length).toBe(1);
+    expect(deps.calls.syncedDiffItems.length).toBe(1);
+  });
+
+  it('skips versions whose deterministic id already exists in PG', async () => {
+    // Pre-populate "alpha v1" with the id that fakeFetch returns for HA1.
+    const fwId = frameworkIdFromKey('alpha');
+    const existingId = versionIdFromHash(fwId, 'v1', 'HA1');
+    const deps = makeDeps({
+      hashByUrl: {
+        'https://example.com/alpha-v1': 'HA1',
+        'https://example.com/alpha-v2': 'HA2',
+        'https://example.com/beta-v1': 'HB1',
+      },
+      preExisting: [existingId],
+    });
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: false,
+    });
+
+    expect(summary.versionsAttempted).toBe(3);
+    expect(summary.versionsSynced).toBe(2);
+    expect(summary.versionsSkipped).toBe(1);
+    // 2 extractions ran (alpha v2 + beta v1) — alpha v1 was skipped.
+    expect(deps.calls.extracted.length).toBe(2);
+    expect(deps.calls.extracted).toEqual(
+      expect.arrayContaining([
+        'https://example.com/alpha-v2',
+        'https://example.com/beta-v1',
+      ]),
+    );
+    expect(deps.calls.extracted).not.toContain('https://example.com/alpha-v1');
+  });
+
+  it('forceReextract overrides the skip-if-existing check', async () => {
+    const fwId = frameworkIdFromKey('alpha');
+    const existingId = versionIdFromHash(fwId, 'v1', 'HA1');
+    const deps = makeDeps({
+      hashByUrl: { 'https://example.com/alpha-v1': 'HA1' },
+      preExisting: [existingId],
+    });
+    await runIngest(deps, {
+      registryPath: fixturePath,
+      frameworkKey: 'alpha',
+      maxVersions: 1,
+      forceReextract: true,
+      dryRun: false,
+    });
+
+    expect(deps.calls.extracted).toContain('https://example.com/alpha-v1');
+    expect(deps.calls.existingChecks.length).toBe(0); // skip-check bypassed
+  });
+
+  it('dryRun fetches + extracts but does not POST any sync calls', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: true,
+    });
+
+    expect(summary.versionsAttempted).toBe(3);
+    expect(summary.versionsSynced).toBe(3);
+    expect(deps.calls.syncedFrameworks.length).toBe(0);
+    expect(deps.calls.syncedVersions.length).toBe(0);
+    expect(deps.calls.syncedThresholds.length).toBe(0);
+    expect(deps.calls.syncedDiffs.length).toBe(0);
+    // But fetch + extract still ran (cost visibility — dry run should
+    // never silently lie about what would happen on --apply).
+    expect(deps.calls.fetched.length).toBe(3);
+    expect(deps.calls.extracted.length).toBe(3);
+  });
+
+  it('skipExtract syncs version skeletons without LLM extraction', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      skipExtract: true,
+      skipDiffs: true,
+      dryRun: false,
+    });
+
+    expect(summary.versionsSynced).toBe(3);
+    expect(deps.calls.extracted.length).toBe(0);
+    expect(deps.calls.syncedThresholds.length).toBe(0);
+    expect(deps.calls.syncedVersions.length).toBe(3);
+  });
+
+  it('frameworkKey filter only processes the matching framework', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      frameworkKey: 'beta',
+      dryRun: false,
+    });
+    expect(summary.frameworksSynced).toBe(1);
+    expect(summary.versionsAttempted).toBe(1);
+    expect(deps.calls.fetched).toEqual(['https://example.com/beta-v1']);
+  });
+
+  it('throws for an unknown framework key with the available list', async () => {
+    const deps = makeDeps();
+    await expect(
+      runIngest(deps, { registryPath: fixturePath, frameworkKey: 'gamma' }),
+    ).rejects.toThrow(/Unknown framework key "gamma"/);
+  });
+
+  it('maxVersions caps versions per framework', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      maxVersions: 1,
+      dryRun: false,
+    });
+    expect(summary.versionsAttempted).toBe(2); // 1 from alpha + 1 from beta
+  });
+
+  it('counts fetch failures and continues with the remaining versions', async () => {
+    // Build deps where alpha-v1 fails but alpha-v2 + beta-v1 succeed.
+    const calls = {
+      fetched: [] as string[],
+      extracted: [] as string[],
+      syncedVersions: [] as VersionSyncItem[][],
+    };
+    const deps: IngestDeps = {
+      fetchFramework: async (o) => {
+        calls.fetched.push(o.url);
+        if (o.url === 'https://example.com/alpha-v1') throw new Error('boom');
+        return fakeFetch(`hash-${o.url}`);
+      },
+      extractFrameworkThresholds: async (o) => {
+        calls.extracted.push(o.url);
+        return fakeExtract();
+      },
+      diffFrameworkVersions: async () => fakeAggregate(),
+      fetchExistingVersion: async () => null,
+      syncFrameworks: async () => {},
+      syncVersions: async (items) => {
+        calls.syncedVersions.push(items);
+      },
+      syncThresholds: async () => {},
+      syncDiffs: async () => {},
+      syncDiffItems: async () => {},
+      log: () => {},
+    };
+
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: false,
+    });
+    expect(summary.versionsFailed).toBe(1);
+    expect(summary.versionsSynced).toBe(2);
+    // alpha-v2 wasn't extracted since alpha-v1 fetch failed and the diff
+    // chain breaks — but per-version processing continues, so the v2
+    // version + thresholds are still synced.
+    expect(calls.syncedVersions.length).toBe(2);
+    expect(calls.fetched.length).toBe(3);
+  });
+
+  it('counts extract failures separately from fetch failures', async () => {
+    const deps = makeDeps({ extractError: 'LLM blew up' });
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: false,
+    });
+    expect(summary.versionsFailed).toBe(3);
+    expect(summary.versions.every((v) => v.status === 'extract_failed')).toBe(true);
+    // Even with extract failures we still synced the version rows.
+    expect(deps.calls.syncedVersions.length).toBe(3);
+  });
+
+  it('does not run a diff when one side of a pair failed to extract', async () => {
+    const calls = {
+      diffed: 0,
+      syncedDiffs: 0,
+      extractCalls: 0,
+    };
+    const deps: IngestDeps = {
+      fetchFramework: async (o) => fakeFetch(`hash-${o.url}`),
+      extractFrameworkThresholds: async () => {
+        calls.extractCalls++;
+        // First extract for alpha v1 succeeds, second (alpha v2) fails.
+        if (calls.extractCalls === 2) throw new Error('blow up alpha v2');
+        return fakeExtract();
+      },
+      diffFrameworkVersions: async () => {
+        calls.diffed++;
+        return fakeAggregate();
+      },
+      fetchExistingVersion: async () => null,
+      syncFrameworks: async () => {},
+      syncVersions: async () => {},
+      syncThresholds: async () => {},
+      syncDiffs: async () => {
+        calls.syncedDiffs++;
+      },
+      syncDiffItems: async () => {},
+      log: () => {},
+    };
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      frameworkKey: 'alpha', // 2 versions
+      dryRun: false,
+    });
+    expect(summary.versionsSynced).toBe(1);
+    expect(summary.versionsFailed).toBe(1);
+    // No diff because one side broke.
+    expect(calls.diffed).toBe(0);
+    expect(calls.syncedDiffs).toBe(0);
+  });
+
+  it('skipDiffs disables diffing entirely', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      skipDiffs: true,
+      dryRun: false,
+    });
+    expect(summary.diffsSynced).toBe(0);
+    expect(deps.calls.diffed).toBe(0);
+    expect(deps.calls.syncedDiffs.length).toBe(0);
+  });
+
+  it('skipped-existing pairs do not produce diffs (no in-memory thresholds)', async () => {
+    const fwId = frameworkIdFromKey('alpha');
+    const v1Id = versionIdFromHash(fwId, 'v1', 'HA1');
+    const v2Id = versionIdFromHash(fwId, 'v2', 'HA2');
+    const deps = makeDeps({
+      hashByUrl: {
+        'https://example.com/alpha-v1': 'HA1',
+        'https://example.com/alpha-v2': 'HA2',
+      },
+      preExisting: [v1Id, v2Id], // both alpha versions already synced
+    });
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      frameworkKey: 'alpha',
+      dryRun: false,
+    });
+    expect(summary.versionsSkipped).toBe(2);
+    expect(summary.diffsSynced).toBe(0); // diff skipped — no thresholds
+    expect(deps.calls.extracted.length).toBe(0);
+    expect(deps.calls.diffed).toBe(0);
+  });
+
+  it('returns a structured summary with per-version + per-diff entries', async () => {
+    const deps = makeDeps();
+    const summary = await runIngest(deps, {
+      registryPath: fixturePath,
+      dryRun: false,
+    });
+    expect(summary.versions.length).toBe(3);
+    expect(summary.versions.every((v) => v.frameworkKey && v.versionLabel && v.versionId)).toBe(true);
+    expect(summary.diffs.length).toBe(1);
+    expect(summary.diffs[0].diffItems).toBe(1);
+  });
+});

--- a/crux/frameworks/orchestrator.ts
+++ b/crux/frameworks/orchestrator.ts
@@ -1,0 +1,581 @@
+/**
+ * Frontier-safety-framework end-to-end ingester (QUA-707 Phase 4-A).
+ *
+ * Orchestrates the full pipeline for the ~12 published frontier-safety
+ * frameworks listed in `data/frameworks/frameworks.yaml`:
+ *
+ *   1. seed       — upsert one `safety_frameworks` row per framework key
+ *                  (lightweight, no LLM)
+ *   2. ingest     — for each version: fetchFramework → versionId by
+ *                  natural-key → skip-if-already-synced → extract
+ *                  thresholds → sync version + thresholds; then for each
+ *                  consecutive version pair, classify the structural diff
+ *                  and sync diff + diff-items
+ *
+ * Idempotency contract:
+ *   - Framework ids derived from registry key (`frameworkIdFromKey`).
+ *   - Version ids derived from (frameworkId, versionLabel, normalized
+ *     contentHash). Re-running with the same source content produces the
+ *     same id and upserts in place.
+ *   - Threshold ids derived from (versionId, riskDomain, tierSortOrder).
+ *   - Diff + diff-item ids derived from version pair / item index.
+ *   - Before extracting, the orchestrator checks whether the version id
+ *     already exists in PG; if it does and `--force-reextract` was not
+ *     passed, the extraction (and thus the LLM bill) is skipped.
+ *
+ * The orchestrator is intentionally split into pure helpers that the
+ * tests exercise in isolation, plus a top-level `runIngest()` that wires
+ * them together. The wiki-server / LLM / fetch deps are injected so unit
+ * tests can run without touching a network.
+ */
+
+import {
+  diffFrameworkVersions,
+  structuralDiff,
+  aggregateDiff,
+  type DiffAggregate,
+} from './diff.ts';
+import {
+  extractFrameworkThresholds,
+  type ExtractedThreshold,
+  type ExtractResult,
+} from './extract.ts';
+import { fetchFramework, type FetchResult } from './fetch.ts';
+import { generateId } from '../lib/grant-import/id.ts';
+import { MODELS } from '../lib/anthropic.ts';
+import {
+  toThresholdSyncItems,
+  toDiffSyncPayloads,
+} from './sync-payloads.ts';
+import {
+  loadRegistry,
+  versionIdFromHash,
+  type RegistryFramework,
+  type RegistryVersion,
+} from './registry.ts';
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+export interface FrameworkSyncItem {
+  id: string;
+  orgId: string;
+  name: string;
+  shortName: string | null;
+  frameworkFamily: string | null;
+  currentStatus: 'active' | 'archived' | 'superseded' | 'draft';
+  firstPublishedDate: string | null;
+  notes: string | null;
+}
+
+/**
+ * Build sync items for `/api/safety-frameworks/sync` from the registry.
+ * `firstPublishedDate` is derived from the earliest version's
+ * `publishedDate` so we don't need a separate manifest field.
+ */
+export function buildFrameworkSyncItems(
+  entries: RegistryFramework[],
+): FrameworkSyncItem[] {
+  return entries.map((e) => ({
+    id: e.frameworkId,
+    orgId: e.orgId,
+    name: e.name,
+    shortName: e.shortName,
+    frameworkFamily: e.frameworkFamily,
+    currentStatus: e.status,
+    firstPublishedDate: e.versions[0]?.publishedDate ?? null,
+    notes: e.notes,
+  }));
+}
+
+export interface VersionSyncItem {
+  id: string;
+  frameworkId: string;
+  versionLabel: string;
+  versionSortOrder: number;
+  publishedDate: string | null;
+  discoveredDate: string;
+  sourceUrl: string;
+  sourceUrlCanonical: string | null;
+  waybackSnapshotUrl: string | null;
+  pdfArchiveUrl: string | null;
+  contentHash: string;
+  contentLengthChars: number;
+  summary: string | null;
+  isDraft: boolean;
+  ingestStatus: 'pending_review' | 'published' | 'rejected';
+}
+
+/**
+ * Build a version sync item from a fetch result. The fetch result's
+ * normalized `contentHash` is the natural-key for `safety_framework_versions`,
+ * so re-fetching the same content from the same URL produces the same
+ * version id and upserts in place.
+ */
+export function buildVersionSyncItem(
+  framework: RegistryFramework,
+  version: RegistryVersion,
+  fetched: FetchResult,
+  now: Date = new Date(),
+): VersionSyncItem {
+  return {
+    id: versionIdFromHash(framework.frameworkId, version.versionLabel, fetched.contentHash),
+    frameworkId: framework.frameworkId,
+    versionLabel: version.versionLabel,
+    versionSortOrder: version.versionSortOrder,
+    publishedDate: version.publishedDate,
+    discoveredDate: now.toISOString().slice(0, 10),
+    sourceUrl: version.sourceUrl,
+    sourceUrlCanonical: fetched.canonicalUrl !== version.sourceUrl ? fetched.canonicalUrl : null,
+    waybackSnapshotUrl: fetched.waybackSnapshotUrl,
+    pdfArchiveUrl: null,
+    contentHash: fetched.contentHash,
+    contentLengthChars: fetched.contentLengthChars,
+    summary: null,
+    isDraft: version.isDraft,
+    ingestStatus: 'pending_review',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dependency injection — keeps runIngest() testable
+// ---------------------------------------------------------------------------
+
+export interface IngestDeps {
+  /** Fetch + hash + Wayback push. */
+  fetchFramework: (opts: { url: string; skipWayback?: boolean }) => Promise<FetchResult>;
+  /** Extract thresholds via two-pass LLM. */
+  extractFrameworkThresholds: (opts: {
+    url: string;
+    lab?: string | null;
+    llmModel?: string;
+  }) => Promise<ExtractResult>;
+  /** Diff two threshold lists (LLM classifier optional). */
+  diffFrameworkVersions: (
+    before: ExtractedThreshold[],
+    after: ExtractedThreshold[],
+    opts?: { llmModel?: string },
+  ) => Promise<DiffAggregate>;
+  /**
+   * Cheap GET /api/safety-framework-versions/:id used to skip already-ingested
+   * versions before paying the LLM bill. Should return null on 404, not throw.
+   */
+  fetchExistingVersion: (versionId: string) => Promise<{ id: string } | null>;
+  /** POST sync handlers. Each posts the same shape — `{ items: [...] }`. */
+  syncFrameworks: (items: FrameworkSyncItem[]) => Promise<void>;
+  syncVersions: (items: VersionSyncItem[]) => Promise<void>;
+  syncThresholds: (items: Array<Record<string, unknown>>) => Promise<void>;
+  syncDiffs: (items: Array<Record<string, unknown>>) => Promise<void>;
+  syncDiffItems: (items: Array<Record<string, unknown>>) => Promise<void>;
+  /** Logger — caller chooses console / pino / silent. */
+  log: (level: 'info' | 'warn' | 'error', msg: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// runIngest — top-level orchestration
+// ---------------------------------------------------------------------------
+
+export interface IngestOptions {
+  /** Optional registry filter. If set, only this framework key is processed. */
+  frameworkKey?: string;
+  /** Optional cap on versions per framework (smoke-test mode). */
+  maxVersions?: number;
+  /** Skip the actual /sync POSTs. Still calls fetch (and extract unless skipExtract). */
+  dryRun?: boolean;
+  /** Skip the (expensive) LLM extraction pass. Useful to seed version skeletons. */
+  skipExtract?: boolean;
+  /** Skip the diff pass between consecutive versions. */
+  skipDiffs?: boolean;
+  /** Re-run extraction even if version row already exists. */
+  forceReextract?: boolean;
+  /** Skip Wayback push (faster; non-archival). */
+  skipWayback?: boolean;
+  /** LLM model for extract + diff classifier. */
+  llmModel?: string;
+  /** Skip the LLM classifier pass on diffs (use structuralDiff only). */
+  skipClassifier?: boolean;
+  /** Override the registry path (testing). */
+  registryPath?: string;
+}
+
+export interface IngestVersionResult {
+  frameworkKey: string;
+  versionLabel: string;
+  versionId: string;
+  status: 'synced' | 'skipped_existing' | 'fetch_failed' | 'extract_failed';
+  thresholdsSynced: number;
+  unverifiedThresholds: number;
+  errorMessage?: string;
+  /** In-memory thresholds; used for downstream diff computation. */
+  thresholds?: ExtractedThreshold[];
+  /** Extraction model — for the diff `classifiedByModel` field. */
+  extractionModel?: string;
+}
+
+export interface IngestDiffResult {
+  fromVersionId: string;
+  toVersionId: string;
+  diffItems: number;
+  weakeningFlagged: boolean;
+  status: 'synced' | 'skipped' | 'classify_failed';
+  errorMessage?: string;
+}
+
+export interface IngestSummary {
+  frameworksSynced: number;
+  versionsAttempted: number;
+  versionsSynced: number;
+  versionsSkipped: number;
+  versionsFailed: number;
+  diffsSynced: number;
+  diffsFailed: number;
+  versions: IngestVersionResult[];
+  diffs: IngestDiffResult[];
+}
+
+/**
+ * Top-level orchestrator. See module docstring.
+ *
+ * Concurrency: serial. The LLM bills per call, the wiki-server enforces
+ * batch-size limits, and frameworks.yaml is small (~12 entries). Adding
+ * parallelism here would just risk rate-limiting the Anthropic API for
+ * a handful of seconds of speedup.
+ */
+export async function runIngest(
+  deps: IngestDeps,
+  options: IngestOptions = {},
+): Promise<IngestSummary> {
+  const registry = loadRegistry(options.registryPath);
+  const filtered = options.frameworkKey
+    ? registry.filter((e) => e.key === options.frameworkKey)
+    : registry;
+
+  if (options.frameworkKey && filtered.length === 0) {
+    throw new Error(
+      `Unknown framework key "${options.frameworkKey}" — not in frameworks.yaml. ` +
+        `Available: ${registry.map((e) => e.key).join(', ')}`,
+    );
+  }
+
+  const summary: IngestSummary = {
+    frameworksSynced: 0,
+    versionsAttempted: 0,
+    versionsSynced: 0,
+    versionsSkipped: 0,
+    versionsFailed: 0,
+    diffsSynced: 0,
+    diffsFailed: 0,
+    versions: [],
+    diffs: [],
+  };
+
+  // 1. Sync framework rows.
+  const frameworkItems = buildFrameworkSyncItems(filtered);
+  if (!options.dryRun) {
+    await deps.syncFrameworks(frameworkItems);
+  }
+  summary.frameworksSynced = frameworkItems.length;
+  deps.log('info', `Framework rows: ${frameworkItems.length} ${options.dryRun ? '(dry-run)' : 'synced'}`);
+
+  // 2. For each framework, ingest each version.
+  for (const framework of filtered) {
+    const versionsToProcess = options.maxVersions
+      ? framework.versions.slice(0, options.maxVersions)
+      : framework.versions;
+
+    const perFrameworkResults: IngestVersionResult[] = [];
+
+    for (const version of versionsToProcess) {
+      summary.versionsAttempted++;
+      const result = await ingestVersion(deps, framework, version, options);
+      perFrameworkResults.push(result);
+      summary.versions.push(result);
+
+      switch (result.status) {
+        case 'synced':
+          summary.versionsSynced++;
+          break;
+        case 'skipped_existing':
+          summary.versionsSkipped++;
+          break;
+        case 'fetch_failed':
+        case 'extract_failed':
+          summary.versionsFailed++;
+          break;
+      }
+    }
+
+    // 3. Diff consecutive version pairs (only when both ends were synced
+    //    or skipped — failed fetches break the chain). Run in version
+    //    order so weakening flags accumulate against the latest baseline.
+    if (!options.skipDiffs && perFrameworkResults.length >= 2) {
+      for (let i = 1; i < perFrameworkResults.length; i++) {
+        const from = perFrameworkResults[i - 1];
+        const to = perFrameworkResults[i];
+        if (from.status === 'fetch_failed' || from.status === 'extract_failed') continue;
+        if (to.status === 'fetch_failed' || to.status === 'extract_failed') continue;
+
+        const diffResult = await ingestDiff(deps, from, to, options);
+        summary.diffs.push(diffResult);
+        if (diffResult.status === 'synced') summary.diffsSynced++;
+        if (diffResult.status === 'classify_failed') summary.diffsFailed++;
+      }
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Per-version pipeline (extracted for testability)
+// ---------------------------------------------------------------------------
+
+async function ingestVersion(
+  deps: IngestDeps,
+  framework: RegistryFramework,
+  version: RegistryVersion,
+  options: IngestOptions,
+): Promise<IngestVersionResult> {
+  const tag = `${framework.key}/${version.versionLabel}`;
+  let fetched: FetchResult;
+  try {
+    fetched = await deps.fetchFramework({
+      url: version.sourceUrl,
+      skipWayback: options.skipWayback,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    deps.log('error', `[${tag}] fetch failed: ${msg}`);
+    return {
+      frameworkKey: framework.key,
+      versionLabel: version.versionLabel,
+      versionId: '',
+      status: 'fetch_failed',
+      thresholdsSynced: 0,
+      unverifiedThresholds: 0,
+      errorMessage: msg,
+    };
+  }
+
+  const versionItem = buildVersionSyncItem(framework, version, fetched);
+  const versionId = versionItem.id;
+
+  // Skip-if-already-synced (saves an LLM call).
+  if (!options.forceReextract) {
+    const existing = await deps.fetchExistingVersion(versionId).catch(() => null);
+    if (existing) {
+      deps.log('info', `[${tag}] version already synced (${versionId.slice(0, 8)}…) — skipping extraction`);
+      return {
+        frameworkKey: framework.key,
+        versionLabel: version.versionLabel,
+        versionId,
+        status: 'skipped_existing',
+        thresholdsSynced: 0,
+        unverifiedThresholds: 0,
+      };
+    }
+  }
+
+  // Sync the version row before thresholds — versionId is the FK.
+  if (!options.dryRun) {
+    await deps.syncVersions([versionItem]);
+  }
+
+  if (options.skipExtract) {
+    deps.log('info', `[${tag}] version synced (${versionId.slice(0, 8)}…); thresholds skipped`);
+    return {
+      frameworkKey: framework.key,
+      versionLabel: version.versionLabel,
+      versionId,
+      status: 'synced',
+      thresholdsSynced: 0,
+      unverifiedThresholds: 0,
+      thresholds: [],
+    };
+  }
+
+  // Extract thresholds. The extractor does its own fetch — that's a known
+  // double-fetch with the orchestrator, accepted here for simplicity.
+  let extract: ExtractResult;
+  try {
+    extract = await deps.extractFrameworkThresholds({
+      url: version.sourceUrl,
+      lab: framework.orgId,
+      llmModel: options.llmModel,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    deps.log('error', `[${tag}] extract failed: ${msg}`);
+    return {
+      frameworkKey: framework.key,
+      versionLabel: version.versionLabel,
+      versionId,
+      status: 'extract_failed',
+      thresholdsSynced: 0,
+      unverifiedThresholds: 0,
+      errorMessage: msg,
+    };
+  }
+
+  const extractionModel = extract.pass2Model || extract.pass1Model;
+  const thresholdItems = toThresholdSyncItems(versionId, extract.thresholds, {
+    extractionModel,
+  });
+
+  if (thresholdItems.length > 0 && !options.dryRun) {
+    await deps.syncThresholds(thresholdItems);
+  }
+
+  deps.log(
+    'info',
+    `[${tag}] synced version (${versionId.slice(0, 8)}…) + ${thresholdItems.length} threshold(s)` +
+      (extract.unverifiedCount > 0 ? ` (${extract.unverifiedCount} unverified)` : ''),
+  );
+
+  return {
+    frameworkKey: framework.key,
+    versionLabel: version.versionLabel,
+    versionId,
+    status: 'synced',
+    thresholdsSynced: thresholdItems.length,
+    unverifiedThresholds: extract.unverifiedCount,
+    thresholds: extract.thresholds,
+    extractionModel,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-pair diff pipeline
+// ---------------------------------------------------------------------------
+
+async function ingestDiff(
+  deps: IngestDeps,
+  from: IngestVersionResult,
+  to: IngestVersionResult,
+  options: IngestOptions,
+): Promise<IngestDiffResult> {
+  const tag = `${from.frameworkKey}: ${from.versionLabel} → ${to.versionLabel}`;
+  // No in-memory thresholds for either side: both were either skipped (already
+  // synced — diff would need thresholds re-fetched from the API) or skip-extract'd
+  // (no thresholds at all). In either case, skip the diff and let a follow-up
+  // run with --force-reextract or a separate diff command produce it.
+  if (!from.thresholds || !to.thresholds) {
+    deps.log('info', `[${tag}] thresholds unavailable (skipped or already synced) — diff skipped`);
+    return {
+      fromVersionId: from.versionId,
+      toVersionId: to.versionId,
+      diffItems: 0,
+      weakeningFlagged: false,
+      status: 'skipped',
+    };
+  }
+
+  let aggregate: DiffAggregate;
+  let classifiedByModel: string | null = null;
+  try {
+    if (options.skipClassifier) {
+      aggregate = aggregateDiff(structuralDiff(from.thresholds, to.thresholds));
+    } else {
+      aggregate = await deps.diffFrameworkVersions(from.thresholds, to.thresholds, {
+        llmModel: options.llmModel,
+      });
+      classifiedByModel = options.llmModel ?? MODELS.sonnet;
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    deps.log('error', `[${tag}] classify failed: ${msg}`);
+    return {
+      fromVersionId: from.versionId,
+      toVersionId: to.versionId,
+      diffItems: 0,
+      weakeningFlagged: false,
+      status: 'classify_failed',
+      errorMessage: msg,
+    };
+  }
+
+  const payload = toDiffSyncPayloads(from.versionId, to.versionId, aggregate, {
+    classifiedByModel,
+  });
+
+  if (!options.dryRun) {
+    await deps.syncDiffs([payload.diff]);
+    if (payload.items.length > 0) {
+      await deps.syncDiffItems(payload.items);
+    }
+  }
+
+  deps.log(
+    'info',
+    `[${tag}] diff synced — ${payload.items.length} item(s)` +
+      (aggregate.weakeningFlagged ? ' ⚠ weakening flagged (unreviewed)' : ''),
+  );
+
+  return {
+    fromVersionId: from.versionId,
+    toVersionId: to.versionId,
+    diffItems: payload.items.length,
+    weakeningFlagged: aggregate.weakeningFlagged,
+    status: 'synced',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default deps factory — wires up real fetch / extract / wiki-server
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a default `IngestDeps` that hits the real wiki-server and the real
+ * Anthropic API. Tests should pass their own deps instead of calling this.
+ */
+export async function defaultIngestDeps(opts: {
+  log?: (level: 'info' | 'warn' | 'error', msg: string) => void;
+} = {}): Promise<IngestDeps> {
+  const { apiRequest } = await import('../lib/wiki-server/client.ts');
+  const log = opts.log ?? ((level, msg) => {
+    const prefix = level === 'error' ? '✗ ' : level === 'warn' ? '⚠ ' : '  ';
+    // eslint-disable-next-line no-console
+    console.log(prefix + msg);
+  });
+
+  async function postSync(path: string, items: unknown[]): Promise<void> {
+    if (items.length === 0) return;
+    const res = await apiRequest<{ upserted: number }>('POST', path, { items });
+    if (!res.ok) {
+      throw new Error(`${path} sync failed: ${res.error} — ${res.message}`);
+    }
+  }
+
+  return {
+    fetchFramework: (o) => fetchFramework(o),
+    extractFrameworkThresholds: (o) => extractFrameworkThresholds(o),
+    diffFrameworkVersions: (before, after, o) => diffFrameworkVersions(before, after, o),
+    fetchExistingVersion: async (id) => {
+      const res = await apiRequest<{ id: string }>(
+        'GET',
+        `/api/safety-framework-versions/${encodeURIComponent(id)}`,
+      );
+      if (!res.ok) {
+        if (res.error === 'bad_request') return null; // 404 is bad_request via classifyStatus
+        // Surface server / auth / unavailable errors loudly — don't pretend the
+        // version doesn't exist. The caller will skip the LLM bill anyway by
+        // falling through to the rest of the pipeline if forceReextract is set.
+        throw new Error(`fetchExistingVersion ${id}: ${res.error} — ${res.message}`);
+      }
+      return res.data;
+    },
+    syncFrameworks: (items) => postSync('/api/safety-frameworks/sync', items),
+    syncVersions: (items) => postSync('/api/safety-framework-versions/sync', items),
+    syncThresholds: (items) => postSync('/api/framework-capability-thresholds/sync', items),
+    syncDiffs: (items) => postSync('/api/framework-diffs/sync', items),
+    syncDiffItems: (items) => postSync('/api/framework-diff-items/sync', items),
+    log,
+  };
+}
+
+// Re-export id helpers for convenience.
+export { frameworkIdFromKey, versionIdFromHash } from './registry.ts';
+export {
+  generateId as _generateId, // exported only so tests can compute expected ids
+} from '../lib/grant-import/id.ts';

--- a/crux/frameworks/orchestrator.ts
+++ b/crux/frameworks/orchestrator.ts
@@ -362,8 +362,12 @@ async function ingestVersion(
   const versionId = versionItem.id;
 
   // Skip-if-already-synced (saves an LLM call).
+  // Note: do NOT swallow errors here — defaultIngestDeps.fetchExistingVersion
+  // throws loudly on server/auth/unavailable errors so we don't proceed under
+  // a false negative (re-extracting + paying the LLM bill on every transient
+  // 5xx). A "version not found" lookup returns null instead of throwing.
   if (!options.forceReextract) {
-    const existing = await deps.fetchExistingVersion(versionId).catch(() => null);
+    const existing = await deps.fetchExistingVersion(versionId);
     if (existing) {
       deps.log('info', `[${tag}] version already synced (${versionId.slice(0, 8)}…) — skipping extraction`);
       return {
@@ -557,7 +561,14 @@ export async function defaultIngestDeps(opts: {
         `/api/safety-framework-versions/${encodeURIComponent(id)}`,
       );
       if (!res.ok) {
-        if (res.error === 'bad_request') return null; // 404 is bad_request via classifyStatus
+        // The wiki-server's apiRequest coerces all 4xx to `bad_request`, but
+        // 400/422/429 are legitimate errors we don't want to silently swallow
+        // as "not found". Narrow on the "404" message prefix the same way
+        // setup-org.ts::adaptIdLookup does. If classifyStatus ever splits
+        // out a dedicated 'not_found' variant, also accept that.
+        if (res.error === 'bad_request' && /^404[:\s]/.test(res.message)) {
+          return null;
+        }
         // Surface server / auth / unavailable errors loudly — don't pretend the
         // version doesn't exist. The caller will skip the LLM bill anyway by
         // falling through to the rest of the pipeline if forceReextract is set.

--- a/crux/frameworks/registry.test.ts
+++ b/crux/frameworks/registry.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseRegistry,
+  loadRegistry,
+  defaultRegistryPath,
+  frameworkIdFromKey,
+  versionIdFromHash,
+  _resetRegistryCache,
+} from './registry.ts';
+
+const VALID = `
+version: 1
+
+frameworks:
+  alpha:
+    org_slug: orgalpha
+    name: "Alpha Framework"
+    short_name: "AF"
+    framework_family: "alpha-fam"
+    status: active
+    versions:
+      - version_label: "v1"
+        published_date: "2024-01-01"
+        source_url: "https://example.com/v1"
+      - version_label: "v2"
+        published_date: "2025-06-01"
+        source_url: "https://example.com/v2"
+
+  beta:
+    org_slug: orgbeta
+    name: "Beta Framework"
+    status: active
+    notes: "Single version only."
+    versions:
+      - version_label: "v1 draft"
+        published_date: "2024-08-01"
+        source_url: "https://example.com/beta-v1.pdf"
+        is_draft: true
+`;
+
+beforeEach(() => {
+  _resetRegistryCache();
+});
+
+describe('parseRegistry', () => {
+  it('parses two frameworks with their versions', () => {
+    const out = parseRegistry(VALID);
+    expect(out.length).toBe(2);
+    // Sorted by key.
+    expect(out[0].key).toBe('alpha');
+    expect(out[1].key).toBe('beta');
+  });
+
+  it('assigns deterministic frameworkId from key', () => {
+    const out = parseRegistry(VALID);
+    expect(out[0].frameworkId).toBe(frameworkIdFromKey('alpha'));
+    expect(out[1].frameworkId).toBe(frameworkIdFromKey('beta'));
+    expect(out[0].frameworkId).not.toBe(out[1].frameworkId);
+  });
+
+  it('orders versions by publishedDate ascending and assigns sortOrder', () => {
+    const out = parseRegistry(VALID);
+    const alpha = out.find((e) => e.key === 'alpha')!;
+    expect(alpha.versions.map((v) => v.versionLabel)).toEqual(['v1', 'v2']);
+    expect(alpha.versions[0].versionSortOrder).toBe(1);
+    expect(alpha.versions[1].versionSortOrder).toBe(2);
+  });
+
+  it('preserves is_draft on versions', () => {
+    const out = parseRegistry(VALID);
+    const beta = out.find((e) => e.key === 'beta')!;
+    expect(beta.versions[0].isDraft).toBe(true);
+    expect(out[0].versions[0].isDraft).toBe(false); // default
+  });
+
+  it('preserves notes / shortName / frameworkFamily / status', () => {
+    const out = parseRegistry(VALID);
+    expect(out[0].shortName).toBe('AF');
+    expect(out[0].frameworkFamily).toBe('alpha-fam');
+    expect(out[0].status).toBe('active');
+    expect(out[0].notes).toBeNull();
+    expect(out[1].notes).toBe('Single version only.');
+  });
+
+  it('throws on missing org_slug', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    name: "Foo"
+    versions:
+      - version_label: v1
+        published_date: "2024-01-01"
+        source_url: "https://x"
+`),
+    ).toThrow(/missing org_slug/);
+  });
+
+  it('throws on missing name', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    org_slug: x
+    versions:
+      - version_label: v1
+        published_date: "2024-01-01"
+        source_url: "https://x"
+`),
+    ).toThrow(/missing name/);
+  });
+
+  it('throws on a framework with zero versions', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    org_slug: x
+    name: "Foo"
+    versions: []
+`),
+    ).toThrow(/at least one version/);
+  });
+
+  it('throws on missing version_label', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    org_slug: x
+    name: "Foo"
+    versions:
+      - published_date: "2024-01-01"
+        source_url: "https://x"
+`),
+    ).toThrow(/missing version_label/);
+  });
+
+  it('throws on missing published_date', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    org_slug: x
+    name: "Foo"
+    versions:
+      - version_label: v1
+        source_url: "https://x"
+`),
+    ).toThrow(/missing published_date/);
+  });
+
+  it('throws on invalid status', () => {
+    expect(() =>
+      parseRegistry(`
+version: 1
+frameworks:
+  bad:
+    org_slug: x
+    name: "Foo"
+    status: nonsense
+    versions:
+      - version_label: v1
+        published_date: "2024-01-01"
+        source_url: "https://x"
+`),
+    ).toThrow(/invalid status/);
+  });
+
+  it('throws on unsupported registry version', () => {
+    expect(() =>
+      parseRegistry(`
+version: 999
+frameworks: {}
+`),
+    ).toThrow(/unsupported registry version/);
+  });
+
+  it('returns an empty array when frameworks is missing or empty', () => {
+    expect(parseRegistry('version: 1\n').length).toBe(0);
+    expect(parseRegistry('version: 1\nframeworks: {}\n').length).toBe(0);
+  });
+});
+
+describe('frameworkIdFromKey', () => {
+  it('returns a 10-char alphanumeric id', () => {
+    const id = frameworkIdFromKey('anthropic-rsp');
+    expect(id).toMatch(/^[A-Za-z0-9]{10}$/);
+  });
+
+  it('is deterministic — same key produces the same id', () => {
+    expect(frameworkIdFromKey('anthropic-rsp')).toBe(frameworkIdFromKey('anthropic-rsp'));
+  });
+
+  it('different keys produce different ids', () => {
+    expect(frameworkIdFromKey('alpha')).not.toBe(frameworkIdFromKey('beta'));
+  });
+});
+
+describe('versionIdFromHash', () => {
+  it('returns 10-char alphanumeric, deterministic', () => {
+    const id = versionIdFromHash('fid', 'v1', 'abc123');
+    expect(id).toMatch(/^[A-Za-z0-9]{10}$/);
+    expect(versionIdFromHash('fid', 'v1', 'abc123')).toBe(id);
+  });
+
+  it('different content hashes produce different ids', () => {
+    expect(versionIdFromHash('fid', 'v1', 'a')).not.toBe(versionIdFromHash('fid', 'v1', 'b'));
+  });
+
+  it('different version labels produce different ids', () => {
+    expect(versionIdFromHash('fid', 'v1', 'a')).not.toBe(versionIdFromHash('fid', 'v2', 'a'));
+  });
+});
+
+describe('loadRegistry — actual data/frameworks/frameworks.yaml', () => {
+  it('loads the live registry file without error and returns 12 frameworks', () => {
+    const out = loadRegistry();
+    // The QUA-691 manifest declares 12 frameworks. If you add one, update
+    // this expectation explicitly so the change is visible in the diff.
+    expect(out.length).toBe(12);
+    // Smoke-check a couple of well-known entries.
+    const anthropic = out.find((e) => e.key === 'anthropic-rsp');
+    expect(anthropic).toBeDefined();
+    expect(anthropic!.orgId).toBe('anthropic');
+    expect(anthropic!.versions.length).toBeGreaterThanOrEqual(6);
+    const openai = out.find((e) => e.key === 'openai-preparedness');
+    expect(openai).toBeDefined();
+    expect(openai!.versions.length).toBe(2);
+  });
+
+  it('every version has versionSortOrder >= 1 and a published_date', () => {
+    const out = loadRegistry();
+    for (const fw of out) {
+      for (const v of fw.versions) {
+        expect(v.versionSortOrder).toBeGreaterThanOrEqual(1);
+        expect(v.publishedDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(v.sourceUrl).toMatch(/^https?:\/\//);
+      }
+    }
+  });
+
+  it('defaultRegistryPath ends with data/frameworks/frameworks.yaml', () => {
+    const p = defaultRegistryPath('/some/root');
+    expect(p).toMatch(/data\/frameworks\/frameworks\.yaml$/);
+  });
+});

--- a/crux/frameworks/registry.ts
+++ b/crux/frameworks/registry.ts
@@ -1,0 +1,236 @@
+/**
+ * Frontier safety framework registry loader (QUA-707 Phase 4-A).
+ *
+ * Reads + validates `data/frameworks/frameworks.yaml` — the source-of-truth
+ * manifest of the ~12 published frontier-safety frameworks. Used by the
+ * `seed` and `ingest` orchestration commands to know which (orgId, name,
+ * versionLabel, sourceUrl) tuples to materialize.
+ *
+ * Pure: no network calls. Cached after first load.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { generateId } from '../lib/grant-import/id.ts';
+
+export const VALID_STATUS = ['active', 'archived', 'superseded', 'draft'] as const;
+export type FrameworkStatus = (typeof VALID_STATUS)[number];
+
+export interface RegistryVersion {
+  versionLabel: string;
+  publishedDate: string; // ISO date
+  sourceUrl: string;
+  isDraft: boolean;
+  /** Monotonic position within the framework, 1-indexed by published_date asc. */
+  versionSortOrder: number;
+}
+
+export interface RegistryFramework {
+  /** YAML map key, e.g. "anthropic-rsp". */
+  key: string;
+  /** Deterministic stableId-shaped 10-char id. Stored as `safety_frameworks.id`. */
+  frameworkId: string;
+  /** Org slug — wiki-server FK validation accepts slug OR stableId. */
+  orgId: string;
+  name: string;
+  shortName: string | null;
+  frameworkFamily: string | null;
+  status: FrameworkStatus;
+  notes: string | null;
+  versions: RegistryVersion[];
+}
+
+interface RawVersion {
+  version_label?: unknown;
+  published_date?: unknown;
+  source_url?: unknown;
+  is_draft?: unknown;
+}
+
+interface RawFramework {
+  org_slug?: unknown;
+  name?: unknown;
+  short_name?: unknown;
+  framework_family?: unknown;
+  status?: unknown;
+  notes?: unknown;
+  versions?: unknown;
+}
+
+interface RawRegistry {
+  version?: unknown;
+  frameworks?: Record<string, RawFramework>;
+}
+
+const SUPPORTED_REGISTRY_VERSION = 1;
+
+let _cache: RegistryFramework[] | null = null;
+
+function asString(v: unknown, max = 2000): string | null {
+  if (v == null) return null;
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  if (!s) return null;
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+function asBool(v: unknown): boolean {
+  return v === true;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Compute a deterministic, stableId-shaped framework id from the registry key.
+ * Used so re-runs of `seed` upsert in place rather than creating new rows.
+ */
+export function frameworkIdFromKey(key: string): string {
+  return generateId(`framework:${key}`);
+}
+
+/**
+ * Compute a deterministic version id. The `(frameworkId, contentHash)` pair
+ * is the natural key on `safety_framework_versions`, so the hash must be
+ * the canonical normalized content hash from `fetchFramework()` — NOT the
+ * raw-text hash from extract.ts (different hashing strategies).
+ */
+export function versionIdFromHash(
+  frameworkId: string,
+  versionLabel: string,
+  contentHash: string,
+): string {
+  return generateId(`framework-version:${frameworkId}:${versionLabel}:${contentHash}`);
+}
+
+function parseVersion(
+  raw: RawVersion,
+  index: number,
+  frameworkKey: string,
+): RegistryVersion {
+  const label = asString((raw as RawVersion).version_label, 100);
+  if (!label) {
+    throw new Error(
+      `frameworks.yaml: framework "${frameworkKey}" version[${index}] missing version_label`,
+    );
+  }
+  const date = asString((raw as RawVersion).published_date, 20);
+  if (!date) {
+    throw new Error(
+      `frameworks.yaml: framework "${frameworkKey}" version[${index}] missing published_date`,
+    );
+  }
+  const url = asString((raw as RawVersion).source_url, 2000);
+  if (!url) {
+    throw new Error(
+      `frameworks.yaml: framework "${frameworkKey}" version[${index}] missing source_url`,
+    );
+  }
+  return {
+    versionLabel: label,
+    publishedDate: date,
+    sourceUrl: url,
+    isDraft: asBool((raw as RawVersion).is_draft),
+    versionSortOrder: 0, // filled in below after sort
+  };
+}
+
+function parseFramework(key: string, raw: RawFramework): RegistryFramework {
+  const orgId = asString(raw.org_slug, 200);
+  if (!orgId) {
+    throw new Error(`frameworks.yaml: framework "${key}" missing org_slug`);
+  }
+  const name = asString(raw.name, 500);
+  if (!name) {
+    throw new Error(`frameworks.yaml: framework "${key}" missing name`);
+  }
+  const status = asString(raw.status, 50) ?? 'active';
+  if (!(VALID_STATUS as readonly string[]).includes(status)) {
+    throw new Error(
+      `frameworks.yaml: framework "${key}" has invalid status "${status}"`,
+    );
+  }
+
+  const rawVersions = Array.isArray(raw.versions) ? raw.versions : [];
+  if (rawVersions.length === 0) {
+    throw new Error(
+      `frameworks.yaml: framework "${key}" must declare at least one version`,
+    );
+  }
+
+  const versions = rawVersions.map((rv, idx) => {
+    if (!isRecord(rv)) {
+      throw new Error(
+        `frameworks.yaml: framework "${key}" version[${idx}] is not an object`,
+      );
+    }
+    return parseVersion(rv as RawVersion, idx, key);
+  });
+
+  // Stable sort by publishedDate asc, then versionLabel as tiebreaker.
+  versions.sort((a, b) => {
+    if (a.publishedDate !== b.publishedDate) {
+      return a.publishedDate < b.publishedDate ? -1 : 1;
+    }
+    return a.versionLabel < b.versionLabel ? -1 : 1;
+  });
+  versions.forEach((v, i) => {
+    v.versionSortOrder = i + 1;
+  });
+
+  return {
+    key,
+    frameworkId: frameworkIdFromKey(key),
+    orgId,
+    name,
+    shortName: asString(raw.short_name, 100),
+    frameworkFamily: asString(raw.framework_family, 200),
+    status: status as FrameworkStatus,
+    notes: asString(raw.notes, 10_000),
+    versions,
+  };
+}
+
+export function parseRegistry(rawText: string): RegistryFramework[] {
+  const parsed = yaml.load(rawText, { schema: yaml.JSON_SCHEMA }) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('frameworks.yaml: top-level must be a mapping');
+  }
+  const reg = parsed as RawRegistry;
+  if (typeof reg.version === 'number' && reg.version !== SUPPORTED_REGISTRY_VERSION) {
+    throw new Error(
+      `frameworks.yaml: unsupported registry version ${reg.version} (expected ${SUPPORTED_REGISTRY_VERSION})`,
+    );
+  }
+  const frameworks = isRecord(reg.frameworks) ? reg.frameworks : {};
+  const out: RegistryFramework[] = [];
+  for (const [key, value] of Object.entries(frameworks)) {
+    if (!isRecord(value)) {
+      throw new Error(`frameworks.yaml: framework "${key}" is not an object`);
+    }
+    out.push(parseFramework(key, value as RawFramework));
+  }
+  // Stable sort by key for deterministic ordering.
+  out.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return out;
+}
+
+/** Default path resolver for `data/frameworks/frameworks.yaml`. */
+export function defaultRegistryPath(rootDir = process.cwd()): string {
+  return path.join(rootDir, 'data', 'frameworks', 'frameworks.yaml');
+}
+
+export function loadRegistry(filePath?: string): RegistryFramework[] {
+  if (_cache) return _cache;
+  const fp = filePath ?? defaultRegistryPath();
+  const raw = fs.readFileSync(fp, 'utf-8');
+  _cache = parseRegistry(raw);
+  return _cache;
+}
+
+/** Test-only: clear the cache so subsequent loads re-read the file. */
+export function _resetRegistryCache(): void {
+  _cache = null;
+}

--- a/crux/frameworks/registry.ts
+++ b/crux/frameworks/registry.ts
@@ -65,7 +65,7 @@ interface RawRegistry {
 
 const SUPPORTED_REGISTRY_VERSION = 1;
 
-let _cache: RegistryFramework[] | null = null;
+const _cache = new Map<string, RegistryFramework[]>();
 
 function asString(v: unknown, max = 2000): string | null {
   if (v == null) return null;
@@ -223,14 +223,19 @@ export function defaultRegistryPath(rootDir = process.cwd()): string {
 }
 
 export function loadRegistry(filePath?: string): RegistryFramework[] {
-  if (_cache) return _cache;
   const fp = filePath ?? defaultRegistryPath();
+  // Key by resolved path so loadRegistry('/A') followed by loadRegistry('/B')
+  // returns each file's data — the previous shared singleton silently returned
+  // A's data on the second call (only the test suite's beforeEach saved it).
+  const cached = _cache.get(fp);
+  if (cached) return cached;
   const raw = fs.readFileSync(fp, 'utf-8');
-  _cache = parseRegistry(raw);
-  return _cache;
+  const parsed = parseRegistry(raw);
+  _cache.set(fp, parsed);
+  return parsed;
 }
 
 /** Test-only: clear the cache so subsequent loads re-read the file. */
 export function _resetRegistryCache(): void {
-  _cache = null;
+  _cache.clear();
 }

--- a/crux/frameworks/sync-payloads.ts
+++ b/crux/frameworks/sync-payloads.ts
@@ -22,8 +22,13 @@ export function toThresholdSyncItems(
   meta: { extractionModel: string },
 ): Array<Record<string, unknown>> {
   return thresholds.map((t) => ({
+    // Mix tierLabel into the seed so two thresholds within the same
+    // (riskDomain, tierSortOrder) — e.g. an LLM that extracted two distinct
+    // triggers in the same domain/tier — get distinct stable ids. The schema
+    // has no unique constraint on (versionId, riskDomain, tierSortOrder), so
+    // collapsing them silently overwrites the first row in upsert.
     id: generateId(
-      `framework-threshold:${versionId}:${t.riskDomainCanonical}:${t.tierSortOrder}`,
+      `framework-threshold:${versionId}:${t.riskDomainCanonical}:${t.tierSortOrder}:${t.tierLabel}`,
     ),
     versionId,
     riskDomainCanonical: t.riskDomainCanonical,
@@ -72,9 +77,20 @@ export function toDiffSyncPayloads(
       reviewNotes: null,
       classifiedByModel: meta.classifiedByModel,
     },
-    items: aggregate.items.map((item: DiffItem, idx: number) => ({
+    items: aggregate.items.map((item: DiffItem) => {
+      // Discriminator must be stable across diff sorts — using array index
+      // would churn the entire row set whenever structuralDiff happened to
+      // reorder same-domain items, orphaning the previous N and inserting N
+      // new ones with identical content. Prefer the snapshots' tierLabel
+      // (always present on at least one of beforeSnapshot/afterSnapshot for
+      // every changeType in the diff pipeline), with classifierTag as a
+      // tiebreaker for the rare case of two same-tier changes.
+      const tierKey =
+        item.beforeSnapshot?.tierLabel ?? item.afterSnapshot?.tierLabel ?? 'unknown';
+      const tagKey = item.classifierTag ?? 'unclassified';
+      return {
       id: generateId(
-        `framework-diff-item:${diffId}:${idx}:${item.changeType}:${item.riskDomainCanonical ?? 'none'}`,
+        `framework-diff-item:${diffId}:${tierKey}:${tagKey}:${item.changeType}:${item.riskDomainCanonical ?? 'none'}`,
       ),
       diffId,
       changeType: item.changeType,
@@ -88,6 +104,7 @@ export function toDiffSyncPayloads(
       severity: item.severity,
       classifierTag: item.classifierTag,
       rationale: item.rationale,
-    })),
+      };
+    }),
   };
 }

--- a/crux/frameworks/sync-payloads.ts
+++ b/crux/frameworks/sync-payloads.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure mappers from extractor / diff outputs into wiki-server sync payloads
+ * (QUA-691 Phase 4).
+ *
+ * Lives in `crux/frameworks/` so both the CLI (`crux/commands/frameworks.ts`)
+ * and the orchestrator (`crux/frameworks/orchestrator.ts`) can share them
+ * without a circular import.
+ */
+
+import { generateId } from '../lib/grant-import/id.ts';
+import type { ExtractedThreshold } from './extract.ts';
+import type { DiffAggregate, DiffItem } from './diff.ts';
+
+/**
+ * Build sync-item payloads for `/api/framework-capability-thresholds/sync`
+ * from an extract result. Each row gets a deterministic `id` so re-runs
+ * upsert cleanly.
+ */
+export function toThresholdSyncItems(
+  versionId: string,
+  thresholds: ExtractedThreshold[],
+  meta: { extractionModel: string },
+): Array<Record<string, unknown>> {
+  return thresholds.map((t) => ({
+    id: generateId(
+      `framework-threshold:${versionId}:${t.riskDomainCanonical}:${t.tierSortOrder}`,
+    ),
+    versionId,
+    riskDomainCanonical: t.riskDomainCanonical,
+    riskDomainLabel: t.riskDomainLabel,
+    tierLabel: t.tierLabel,
+    tierSortOrder: t.tierSortOrder,
+    triggerDescription: t.triggerDescription,
+    sourceQuote: t.sourceQuote,
+    sourcePageHint: t.sourcePageHint,
+    requiredMitigations: t.requiredMitigations,
+    associatedEvals: t.associatedEvals,
+    commitmentLanguage: t.commitmentLanguage,
+    extractedByModel: meta.extractionModel,
+    extractionConfidence: t.extractionConfidence,
+    humanReviewed: false,
+    humanReviewNotes: null,
+  }));
+}
+
+/**
+ * Build the `framework_diffs` + `framework_diff_items` sync payloads.
+ */
+export function toDiffSyncPayloads(
+  fromVersionId: string,
+  toVersionId: string,
+  aggregate: DiffAggregate,
+  meta: { classifiedByModel: string | null },
+): {
+  diff: Record<string, unknown>;
+  items: Array<Record<string, unknown>>;
+} {
+  const diffId = generateId(`framework-diff:${fromVersionId}:${toVersionId}`);
+  return {
+    diff: {
+      id: diffId,
+      fromVersionId,
+      toVersionId,
+      changeSummary: aggregate.changeSummary,
+      weakeningFlagged: aggregate.weakeningFlagged,
+      strengtheningFlagged: aggregate.strengtheningFlagged,
+      neutralChangesCount: aggregate.neutralChangesCount,
+      diffDetails: { itemCount: aggregate.items.length },
+      overallDirection: aggregate.overallDirection,
+      humanReviewed: false,
+      reviewVerdict: 'unreviewed',
+      reviewNotes: null,
+      classifiedByModel: meta.classifiedByModel,
+    },
+    items: aggregate.items.map((item: DiffItem, idx: number) => ({
+      id: generateId(
+        `framework-diff-item:${diffId}:${idx}:${item.changeType}:${item.riskDomainCanonical ?? 'none'}`,
+      ),
+      diffId,
+      changeType: item.changeType,
+      riskDomainCanonical: item.riskDomainCanonical,
+      beforeSnapshot: item.beforeSnapshot
+        ? (item.beforeSnapshot as unknown as Record<string, unknown>)
+        : null,
+      afterSnapshot: item.afterSnapshot
+        ? (item.afterSnapshot as unknown as Record<string, unknown>)
+        : null,
+      severity: item.severity,
+      classifierTag: item.classifierTag,
+      rationale: item.rationale,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Adds the orchestration layer on top of the QUA-691 foundation so the 12 published frontier-safety frameworks (~20 versions in `data/frameworks/frameworks.yaml`) can be ingested end-to-end from the CLI.

- **`crux/frameworks/registry.ts`** — loads + validates the YAML manifest, derives deterministic 10-char framework ids from registry keys, sorts versions by `published_date` and assigns monotonic `versionSortOrder`.
- **`crux/frameworks/sync-payloads.ts`** — extracted `toThresholdSyncItems` / `toDiffSyncPayloads` from `commands/frameworks.ts` so the CLI and the orchestrator can share them without a circular import.
- **`crux/frameworks/orchestrator.ts`** — the end-to-end pipeline: fetch → versionId by natural-key → skip-if-already-synced → extract thresholds → sync version + thresholds → diff consecutive pairs → sync diff + items. Dependency-injected so unit tests run without a network. `--force-reextract` overrides the skip-if-existing check.
- **New CLI subcommands** `list` / `seed` / `ingest` on `crux tb frameworks`. Both `tb frameworks list` (two-word) and `tb frameworks-list` (hyphenated alias) work. The new commands use the canonical `(args, options)` two-arg dispatcher signature so `--apply`, `--only=<key>`, `--max=N`, `--skip-extract`, `--skip-diffs`, `--force-reextract` arrive correctly through `options`.
- **40 new tests** (registry: 22, orchestrator: 18) covering parsing, validation, id determinism, dry-run, skip-if-existing, force-reextract, frameworkKey filter, maxVersions, fetch/extract failures, broken diff chains, summary shape.

Out of scope (intentional, per `.claude/rules/ticket-sizing.md`): actually running the ingester against prod. That's a batch-shaped follow-up — every threshold + diff still needs human review (`humanReviewed=true`, `reviewVerdict` set) before being surfaced publicly.

## Idempotency contract

- Framework ids = `generateId("framework:" + registryKey)` — re-runs upsert.
- Version ids = `generateId("framework-version:" + frameworkId + ":" + label + ":" + contentHash)` — same source content always produces the same id, so re-fetching is safe.
- Threshold ids = `generateId("framework-threshold:" + versionId + ":" + domain + ":" + tierSortOrder)` — re-extraction with the same inputs upserts in place.
- Before extracting, the orchestrator GETs `/api/safety-framework-versions/:id` to skip already-synced versions (saves the LLM bill on incremental re-runs).

## Smoke tests run

- `pnpm crux tb frameworks list` → prints all 12 frameworks / 20 versions correctly.
- `pnpm crux tb frameworks seed` (dry-run) → shows 12 framework rows ready to sync.
- `pnpm crux tb frameworks ingest --only=anthropic-rsp --max=1 --skip-extract --skip-diffs` → fetches Anthropic RSP, computes a deterministic versionId, exits clean.
- `pnpm crux w validate gate` → ✅ 55/55 blocking + 4 pre-existing advisory.
- `npx vitest run --config crux/vitest.config.ts crux/frameworks/ crux/commands/frameworks.test.ts` → 94 tests pass.

## Test plan

- [x] Existing 54 framework tests still pass
- [x] 40 new tests pass (registry parsing/validation/id determinism, orchestrator happy path / dry-run / skip-if-existing / force-reextract / filter / failures / no-diff-on-skipped-side / summary shape)
- [x] CLI smoke tests (list / seed dry-run / ingest --only filter)
- [x] Full validation gate green

Fixes QUA-707


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `frameworks-list`, `frameworks-seed`, and `frameworks-ingest` CLI commands for streamlined framework management
  * Implemented registry-driven batch ingestion workflow with support for framework fetching, extraction, and synchronization
  * Added `--json` output formatting and `--apply` flag for safe preview of changes

* **Bug Fixes**
  * Enhanced error handling with proper exit codes for version and diff validation failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->