### PR TITLE
QUA-709: /frontier-safety-frameworks directory + per-framework detail pages

### DIFF
--- a/apps/web/e2e/frontier-safety-frameworks.spec.ts
+++ b/apps/web/e2e/frontier-safety-frameworks.spec.ts
@@ -53,7 +53,13 @@ test.describe("QUA-709 — /frontier-safety-frameworks", () => {
     // on review_verdict and never shown for unreviewed diffs.
     const lower = text.toLowerCase();
     expect(lower).toContain("unreviewed diff");
-    expect(lower).toMatch(/(never|no directional summary).*unreviewed|unreviewed.*(never|no directional)/);
+    // [\s\S] instead of . — innerText() inserts \n between block-level
+    // elements, and the default JS regex `.` does not cross newlines, so the
+    // policy clause + "unreviewed" landing in different paragraphs would have
+    // failed the assertion even though the page satisfied the policy.
+    expect(lower).toMatch(
+      /(never|no directional summary)[\s\S]*unreviewed|unreviewed[\s\S]*(never|no directional)/,
+    );
   });
 
   test("unreviewed diffs do not surface directional language on directory", async ({ page }) => {

--- a/apps/web/e2e/frontier-safety-frameworks.spec.ts
+++ b/apps/web/e2e/frontier-safety-frameworks.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * QUA-709 — frontier safety frameworks UI smoke checks.
+ *
+ * Verifies that:
+ *  1. Directory page renders, has matrix + timeline view toggles
+ *  2. Methodology page renders
+ *  3. Detail page (when any framework exists) loads via EntityProfileShell
+ *  4. Unreviewed diffs never display "weakened" or "strengthened" labels
+ *     (acceptance criterion: directional language gated on review_verdict)
+ */
+
+test.describe("QUA-709 — /frontier-safety-frameworks", () => {
+  test("directory page renders with matrix + timeline toggle", async ({ page }) => {
+    const res = await page.goto("/frontier-safety-frameworks", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(res?.status()).toBeLessThan(400);
+
+    await expect(page.getByRole("heading", { name: /Frontier Safety Frameworks/i, level: 1 })).toBeVisible();
+
+    // The matrix view button is present; if no frameworks ingested yet,
+    // the toggle is simply not rendered, but the heading and stats still
+    // appear so the page is usable in the empty-data case.
+    const matrixBtn = page.getByRole("tab", { name: "Matrix" });
+    const timelineBtn = page.getByRole("tab", { name: "Timeline" });
+
+    // Stats section — 4 ProfileStatCards
+    await expect(page.getByText("Frameworks", { exact: true })).toBeVisible();
+    await expect(page.getByText("Labs", { exact: true })).toBeVisible();
+
+    // If toggles are present, click through both and confirm both render.
+    const hasToggle = (await matrixBtn.count()) > 0;
+    if (hasToggle) {
+      await timelineBtn.click();
+      await page.waitForTimeout(200);
+      await matrixBtn.click();
+      await page.waitForTimeout(200);
+    }
+  });
+
+  test("methodology page renders", async ({ page }) => {
+    const res = await page.goto("/frontier-safety-frameworks/methodology", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(res?.status()).toBeLessThan(400);
+    await expect(page.getByRole("heading", { name: "Methodology", level: 1 })).toBeVisible();
+    await expect(page.getByText(/source quote/i).first()).toBeVisible();
+    // Critical claim: methodology must explain the unreviewed-diff gating.
+    const text = await page.locator("article").innerText();
+    // Critical: methodology must explain that directional language is gated
+    // on review_verdict and never shown for unreviewed diffs.
+    const lower = text.toLowerCase();
+    expect(lower).toContain("unreviewed diff");
+    expect(lower).toMatch(/(never|no directional summary).*unreviewed|unreviewed.*(never|no directional)/);
+  });
+
+  test("unreviewed diffs do not surface directional language on directory", async ({ page }) => {
+    await page.goto("/frontier-safety-frameworks", {
+      waitUntil: "domcontentloaded",
+    });
+    // Switch to Timeline view if the toggle exists.
+    const timelineBtn = page.getByRole("tab", { name: "Timeline" });
+    if ((await timelineBtn.count()) > 0) {
+      await timelineBtn.click();
+      await page.waitForTimeout(300);
+    }
+
+    // For every "Pending review" pill on the timeline, the same row must
+    // NOT contain the words "Weakening" or "Strengthening" — i.e., we
+    // never gate to the directional badge for an unreviewed diff.
+    const pendingPills = page.locator("text=Pending review");
+    const pendingCount = await pendingPills.count();
+    for (let i = 0; i < pendingCount; i++) {
+      const pill = pendingPills.nth(i);
+      // The closest <li> is the timeline entry. Use locator XPath fallback.
+      const entry = pill.locator("xpath=ancestor::li[1]");
+      if ((await entry.count()) === 0) continue;
+      const entryText = (await entry.first().innerText()).toLowerCase();
+      expect.soft(
+        entryText.includes("weakening") || entryText.includes("strengthening"),
+        `Pending-review timeline entry leaked directional language: "${entryText.slice(0, 200)}"`,
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/web/e2e/frontier-safety-frameworks.spec.ts
+++ b/apps/web/e2e/frontier-safety-frameworks.spec.ts
@@ -72,16 +72,31 @@ test.describe("QUA-709 — /frontier-safety-frameworks", () => {
     // never gate to the directional badge for an unreviewed diff.
     const pendingPills = page.locator("text=Pending review");
     const pendingCount = await pendingPills.count();
+    let checkedEntries = 0;
     for (let i = 0; i < pendingCount; i++) {
       const pill = pendingPills.nth(i);
-      // The closest <li> is the timeline entry. Use locator XPath fallback.
-      const entry = pill.locator("xpath=ancestor::li[1]");
+      // Walk up to whatever ancestor encloses the timeline entry. <li> is the
+      // current implementation, but tolerate role=listitem and div wrappers
+      // so a layout refactor doesn't silently make this assertion vacuous.
+      const entry = pill.locator(
+        "xpath=ancestor::*[self::li or @role='listitem' or @data-timeline-entry][1]",
+      );
       if ((await entry.count()) === 0) continue;
+      checkedEntries++;
       const entryText = (await entry.first().innerText()).toLowerCase();
       expect.soft(
         entryText.includes("weakening") || entryText.includes("strengthening"),
         `Pending-review timeline entry leaked directional language: "${entryText.slice(0, 200)}"`,
       ).toBe(false);
+    }
+    if (pendingCount > 0) {
+      // Guard against the test silently passing when the timeline ancestor
+      // selector drifts away from <li>: if there were "Pending review" pills,
+      // we must have actually exercised the directional-language check.
+      expect(
+        checkedEntries,
+        "Found 'Pending review' pills but no resolvable timeline entries — selector drifted from <li>",
+      ).toBeGreaterThan(0);
     }
   });
 });

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -87,6 +87,8 @@ const SIMPLE_PAGES = [
   "/wiki/E815",  // Anthropic Stakeholders — critical table page
   "/browse",
   "/data-sources/ea-funds",  // Data source detail page (QUA-81)
+  "/frontier-safety-frameworks",  // QUA-709 directory page
+  "/frontier-safety-frameworks/methodology",  // QUA-709 methodology
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/diffs-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/diffs-tab.tsx
@@ -1,12 +1,12 @@
 import {
   isVerdictPublished,
   REVIEW_VERDICT_LABELS,
-} from "../risk-domain-constants";
+} from "@/app/frontier-safety-frameworks/risk-domain-constants";
 import type {
   DiffRow,
   DiffItemRow,
   FrameworkVersionRow,
-} from "../frameworks-data";
+} from "@/app/frontier-safety-frameworks/frameworks-data";
 
 export interface DiffWithItems {
   diff: DiffRow;

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/diffs-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/diffs-tab.tsx
@@ -1,0 +1,213 @@
+import {
+  isVerdictPublished,
+  REVIEW_VERDICT_LABELS,
+} from "../risk-domain-constants";
+import type {
+  DiffRow,
+  DiffItemRow,
+  FrameworkVersionRow,
+} from "../frameworks-data";
+
+export interface DiffWithItems {
+  diff: DiffRow;
+  items: DiffItemRow[];
+}
+
+interface DiffsTabProps {
+  /** Diffs ordered by chronological direction (newest pair first). */
+  diffs: DiffWithItems[];
+  versionsById: Map<string, FrameworkVersionRow>;
+}
+
+function diffHeaderBadge(diff: DiffRow) {
+  if (isVerdictPublished(diff.reviewVerdict)) {
+    if (diff.reviewVerdict === "confirmed_weakening") {
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-red-50 text-red-800 border border-red-300 dark:bg-red-950/40 dark:text-red-200">
+          Weakening
+        </span>
+      );
+    }
+    if (diff.reviewVerdict === "confirmed_strengthening") {
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-50 text-emerald-800 border border-emerald-300 dark:bg-emerald-950/40 dark:text-emerald-200">
+          Strengthening
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-amber-50 text-amber-900 border border-amber-300 dark:bg-amber-950/40 dark:text-amber-200">
+        Nuanced
+      </span>
+    );
+  }
+  // Unreviewed and false_positive: NEVER show directional language. The
+  // factual change list below is what users see.
+  return (
+    <span
+      className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-muted text-muted-foreground border border-border/50"
+      title={REVIEW_VERDICT_LABELS[diff.reviewVerdict] ?? diff.reviewVerdict}
+    >
+      Pending review
+    </span>
+  );
+}
+
+function snapshotPretty(snapshot: Record<string, unknown> | null) {
+  if (!snapshot) return null;
+  const tier =
+    typeof snapshot.tierLabel === "string"
+      ? snapshot.tierLabel
+      : typeof snapshot.tier === "string"
+      ? snapshot.tier
+      : null;
+  const trigger =
+    typeof snapshot.triggerDescription === "string"
+      ? snapshot.triggerDescription
+      : typeof snapshot.trigger === "string"
+      ? snapshot.trigger
+      : null;
+  return { tier, trigger };
+}
+
+export function DiffsTab({ diffs, versionsById }: DiffsTabProps) {
+  if (diffs.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No diffs computed yet — diffs require at least two published
+        versions.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {diffs.map(({ diff, items }) => {
+        const fromV = versionsById.get(diff.fromVersionId);
+        const toV = versionsById.get(diff.toVersionId);
+        const verdictPublished = isVerdictPublished(diff.reviewVerdict);
+        return (
+          <details
+            key={diff.id}
+            className="rounded-lg border border-border/60 bg-card overflow-hidden"
+            open={items.length <= 6}
+          >
+            <summary className="cursor-pointer px-4 py-3 hover:bg-muted/20 transition-colors">
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <span className="text-sm font-semibold text-foreground">
+                  {fromV?.versionLabel ?? "Earlier"}
+                  <span className="mx-1.5 text-muted-foreground">→</span>
+                  {toV?.versionLabel ?? "Later"}
+                </span>
+                {diffHeaderBadge(diff)}
+                <span className="text-xs text-muted-foreground">
+                  {items.length} change{items.length === 1 ? "" : "s"}
+                </span>
+                {(toV?.publishedDate || toV?.discoveredDate) && (
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {toV.publishedDate ?? toV.discoveredDate}
+                  </span>
+                )}
+              </div>
+              {verdictPublished ? (
+                <p className="text-sm text-foreground/80 mt-2 max-w-3xl leading-relaxed">
+                  {diff.changeSummary}
+                </p>
+              ) : (
+                // Unreviewed: no narrative summary — only show the factual
+                // change list below. This satisfies the QUA-709 acceptance
+                // criterion that unreviewed diffs never display "weakened"
+                // or "strengthened" without verdict.
+                <p className="text-xs text-muted-foreground mt-2 italic">
+                  Showing factual change list — diff has not been
+                  reviewer-confirmed yet, so no directional summary is shown.
+                </p>
+              )}
+              {diff.reviewNotes && verdictPublished && (
+                <p className="text-xs text-muted-foreground mt-1.5 italic">
+                  Reviewer notes: {diff.reviewNotes}
+                </p>
+              )}
+            </summary>
+            <div className="border-t border-border/60 divide-y divide-border/30">
+              {items.length === 0 ? (
+                <p className="px-4 py-3 text-xs text-muted-foreground italic">
+                  No itemized changes recorded.
+                </p>
+              ) : (
+                items.map((item) => {
+                  const before = snapshotPretty(item.beforeSnapshot);
+                  const after = snapshotPretty(item.afterSnapshot);
+                  return (
+                    <div
+                      key={item.id}
+                      className="px-4 py-3 grid grid-cols-1 md:grid-cols-2 gap-3"
+                    >
+                      <div>
+                        <div className="flex items-baseline gap-2 mb-1">
+                          <span className="text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                            {item.changeType.replace(/_/g, " ")}
+                          </span>
+                          {item.riskDomainCanonical && (
+                            <span className="text-[10px] text-muted-foreground">
+                              {item.riskDomainCanonical}
+                            </span>
+                          )}
+                        </div>
+                        {before ? (
+                          <div>
+                            <p className="text-[11px] text-muted-foreground mb-0.5">
+                              Before
+                            </p>
+                            {before.tier && (
+                              <p className="text-xs font-medium">{before.tier}</p>
+                            )}
+                            {before.trigger && (
+                              <p className="text-xs text-foreground/80 leading-relaxed">
+                                {before.trigger}
+                              </p>
+                            )}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground italic">
+                            (no prior version of this row)
+                          </p>
+                        )}
+                      </div>
+                      <div>
+                        {after ? (
+                          <div>
+                            <p className="text-[11px] text-muted-foreground mb-0.5">
+                              After
+                            </p>
+                            {after.tier && (
+                              <p className="text-xs font-medium">{after.tier}</p>
+                            )}
+                            {after.trigger && (
+                              <p className="text-xs text-foreground/80 leading-relaxed">
+                                {after.trigger}
+                              </p>
+                            )}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-muted-foreground italic">
+                            (removed)
+                          </p>
+                        )}
+                        {item.rationale && (
+                          <p className="text-[11px] text-muted-foreground mt-1.5 italic">
+                            {item.rationale}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </details>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
@@ -133,7 +133,7 @@ export function LatestVersionTab({ version, thresholds }: LatestVersionTabProps)
             </table>
           </div>
           <p className="text-xs text-muted-foreground mt-2">
-            See the <Link href="#threshold-matrix" className="underline">Threshold Matrix tab</Link> for trigger language and source quotes.
+            See the <Link href="?tab=thresholds" className="underline">Threshold Matrix tab</Link> for trigger language and source quotes.
           </p>
         </section>
       )}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
@@ -1,0 +1,147 @@
+import Link from "next/link";
+import {
+  RISK_DOMAIN_LABELS,
+  RISK_DOMAIN_SHORT_LABELS,
+  tierColor,
+  type CanonicalRiskDomain,
+} from "../risk-domain-constants";
+import type { ThresholdRow, FrameworkVersionRow } from "../frameworks-data";
+import { rowsToCellsForVersion, activeDomains } from "../matrix-aggregation";
+
+interface LatestVersionTabProps {
+  version: FrameworkVersionRow | null;
+  thresholds: ThresholdRow[];
+}
+
+export function LatestVersionTab({ version, thresholds }: LatestVersionTabProps) {
+  if (!version) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground space-y-2">
+        <p className="font-medium text-foreground">
+          No published version yet.
+        </p>
+        <p>
+          The framework has been registered but no version has reached
+          published status. Pending versions appear under{" "}
+          <span className="font-medium">Version History</span>.
+        </p>
+      </div>
+    );
+  }
+
+  const cells = rowsToCellsForVersion(thresholds);
+  const domains = activeDomains([cells]) as CanonicalRiskDomain[];
+  const reviewedCount = thresholds.filter((t) => t.humanReviewed).length;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-border/60 bg-card p-5">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
+          <h2 className="text-xl font-semibold">{version.versionLabel}</h2>
+          {version.publishedDate && (
+            <span className="text-sm text-muted-foreground tabular-nums">
+              published {version.publishedDate}
+            </span>
+          )}
+        </div>
+        {version.summary && (
+          <p className="text-sm text-foreground/90 leading-relaxed mb-3 max-w-3xl">
+            {version.summary}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+          <a
+            href={version.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            Read source ↗
+          </a>
+          {version.waybackSnapshotUrl && (
+            <a
+              href={version.waybackSnapshotUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Wayback ↗
+            </a>
+          )}
+          {version.pdfArchiveUrl && (
+            <a
+              href={version.pdfArchiveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              PDF ↗
+            </a>
+          )}
+        </div>
+      </div>
+
+      {domains.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+            Capability domains at a glance
+          </h3>
+          <div className="overflow-x-auto rounded-lg border border-border/60">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-muted/40 text-xs text-muted-foreground">
+                  <th className="text-left py-2 px-3 font-semibold">Domain</th>
+                  {domains.map((d) => (
+                    <th
+                      key={d}
+                      className="text-center py-2 px-2 font-semibold whitespace-nowrap"
+                      title={RISK_DOMAIN_LABELS[d]}
+                    >
+                      {RISK_DOMAIN_SHORT_LABELS[d]}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="py-2.5 px-3 text-xs text-muted-foreground italic">
+                    Most-severe tier
+                  </td>
+                  {domains.map((d) => {
+                    const cell = cells[d];
+                    if (!cell) {
+                      return (
+                        <td key={d} className="py-2 px-2 text-center text-[11px] text-muted-foreground/40">
+                          —
+                        </td>
+                      );
+                    }
+                    const styles = tierColor(cell.tierSortOrder);
+                    return (
+                      <td key={d} className="py-2 px-2 text-center">
+                        <span
+                          className={`inline-block min-w-[3rem] rounded px-1.5 py-0.5 text-[11px] font-semibold border ${styles.bg} ${styles.text} ${styles.border}`}
+                          title={cell.reviewed ? "" : "Pending review"}
+                        >
+                          {cell.tierLabel}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="text-xs text-muted-foreground mt-2">
+            See the <Link href="#threshold-matrix" className="underline">Threshold Matrix tab</Link> for trigger language and source quotes.
+          </p>
+        </section>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        {thresholds.length} threshold{thresholds.length === 1 ? "" : "s"} extracted ·
+        {reviewedCount} human-reviewed.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/latest-version-tab.tsx
@@ -4,9 +4,9 @@ import {
   RISK_DOMAIN_SHORT_LABELS,
   tierColor,
   type CanonicalRiskDomain,
-} from "../risk-domain-constants";
-import type { ThresholdRow, FrameworkVersionRow } from "../frameworks-data";
-import { rowsToCellsForVersion, activeDomains } from "../matrix-aggregation";
+} from "@/app/frontier-safety-frameworks/risk-domain-constants";
+import type { ThresholdRow, FrameworkVersionRow } from "@/app/frontier-safety-frameworks/frameworks-data";
+import { rowsToCellsForVersion, activeDomains } from "@/app/frontier-safety-frameworks/matrix-aggregation";
 
 interface LatestVersionTabProps {
   version: FrameworkVersionRow | null;

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
@@ -1,0 +1,304 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
+import {
+  ProfileStatCard,
+  type ProfileTab,
+} from "@/components/directory";
+import {
+  fetchAllFrameworks,
+  fetchFramework,
+  fetchVersionsForFramework,
+  fetchThresholdsForVersion,
+  fetchDiffsForVersion,
+  fetchDiffItemsForDiff,
+  frameworkSlug,
+  type FrameworkVersionRow,
+  type DiffRow,
+} from "../frameworks-data";
+import { LatestVersionTab } from "./latest-version-tab";
+import { VersionHistoryTab } from "./version-history-tab";
+import { ThresholdMatrixTab } from "./threshold-matrix-tab";
+import { DiffsTab, type DiffWithItems } from "./diffs-tab";
+import { SourcesTab } from "./sources-tab";
+
+export const revalidate = 300;
+
+export async function generateStaticParams() {
+  const res = await fetchAllFrameworks();
+  if (!res.ok) return [];
+  return res.items.map((f) => ({ slug: frameworkSlug(f) }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const framework = await fetchFramework(slug);
+  if (!framework) {
+    return { title: "Framework not found | Frontier Safety Frameworks" };
+  }
+  const display = framework.shortName ?? framework.name;
+  return {
+    title: `${display} | Frontier Safety Frameworks`,
+    description: `Versioned ${framework.name} commitments published by ${framework.org.displayName}, with capability thresholds and cross-version diffs.`,
+  };
+}
+
+export default async function FrameworkDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const framework = await fetchFramework(slug);
+  if (!framework) return notFound();
+
+  const allVersions = await fetchVersionsForFramework(framework.id);
+  const publishedVersions = allVersions.filter(
+    (v) => v.ingestStatus === "published",
+  );
+  const latestPublished =
+    publishedVersions.length === 0
+      ? null
+      : publishedVersions.reduce<FrameworkVersionRow | null>((best, v) => {
+          if (!best || v.versionSortOrder > best.versionSortOrder) return v;
+          return best;
+        }, null);
+
+  // Versions ordered newest → oldest, used to fetch all inbound diffs.
+  const versionsNewestFirst = [...publishedVersions].sort(
+    (a, b) => b.versionSortOrder - a.versionSortOrder,
+  );
+  const versionsById = new Map<string, FrameworkVersionRow>(
+    allVersions.map((v) => [v.id, v]),
+  );
+
+  // Fetch latest-version thresholds + all diffs for published versions in
+  // parallel. Diffs for the earliest version are typically empty (no prior).
+  const [latestThresholds, allDiffsByVersion] = await Promise.all([
+    latestPublished
+      ? fetchThresholdsForVersion(latestPublished.id)
+      : Promise.resolve([]),
+    Promise.all(
+      versionsNewestFirst.map(async (v) => ({
+        toVersionId: v.id,
+        diffs: await fetchDiffsForVersion(v.id),
+      })),
+    ),
+  ]);
+
+  // Flatten + dedupe diffs (by id).
+  const flatDiffs: DiffRow[] = [];
+  const seenDiffIds = new Set<string>();
+  for (const { diffs } of allDiffsByVersion) {
+    for (const d of diffs) {
+      if (!seenDiffIds.has(d.id)) {
+        seenDiffIds.add(d.id);
+        flatDiffs.push(d);
+      }
+    }
+  }
+  // Order diffs by `to_version_id` sort order (newest first).
+  flatDiffs.sort((a, b) => {
+    const aOrder = versionsById.get(a.toVersionId)?.versionSortOrder ?? 0;
+    const bOrder = versionsById.get(b.toVersionId)?.versionSortOrder ?? 0;
+    return bOrder - aOrder;
+  });
+
+  // Fetch diff items for each diff in parallel.
+  const diffsWithItems: DiffWithItems[] = await Promise.all(
+    flatDiffs.map(async (diff) => ({
+      diff,
+      items: await fetchDiffItemsForDiff(diff.id),
+    })),
+  );
+
+  // ── Sourcing rollup (org-level — frameworks inherit the org's verdict) ──
+  const sourcingSummary = await fetchEntitySourcingSummary([
+    framework.orgId,
+    framework.org.slug ?? "",
+  ]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
+
+  // ── Tabs ──
+  const tabs: ProfileTab[] = [
+    {
+      id: "latest",
+      label: "Latest Version",
+      content: (
+        <LatestVersionTab
+          version={latestPublished}
+          thresholds={latestThresholds}
+        />
+      ),
+    },
+  ];
+
+  if (allVersions.length > 0) {
+    tabs.push({
+      id: "history",
+      label: "Version History",
+      count: allVersions.length,
+      content: <VersionHistoryTab versions={allVersions} />,
+    });
+  }
+
+  if (latestPublished && latestThresholds.length > 0) {
+    tabs.push({
+      id: "thresholds",
+      label: "Threshold Matrix",
+      count: latestThresholds.length,
+      content: (
+        <ThresholdMatrixTab
+          thresholds={latestThresholds}
+          versionLabel={latestPublished.versionLabel}
+        />
+      ),
+    });
+  }
+
+  if (diffsWithItems.length > 0) {
+    tabs.push({
+      id: "diffs",
+      label: "Diffs",
+      count: diffsWithItems.length,
+      content: (
+        <DiffsTab diffs={diffsWithItems} versionsById={versionsById} />
+      ),
+    });
+  }
+
+  if (allVersions.length > 0) {
+    tabs.push({
+      id: "sources",
+      label: "Sources & Archive",
+      count: allVersions.length,
+      content: <SourcesTab versions={allVersions} />,
+    });
+  }
+
+  // ── Header slots ──
+  const titlePills = (
+    <>
+      {framework.shortName && framework.shortName !== framework.name && (
+        <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+          {framework.name}
+        </span>
+      )}
+      {framework.currentStatus && (
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold capitalize ${
+            framework.currentStatus === "active"
+              ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300"
+              : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          }`}
+        >
+          {framework.currentStatus}
+        </span>
+      )}
+    </>
+  );
+
+  const headerLinks = [
+    ...(framework.org.slug
+      ? [{ label: framework.org.displayName, href: `/organizations/${framework.org.slug}` }]
+      : []),
+    { label: "Methodology", href: "/frontier-safety-frameworks/methodology" },
+    { label: "All frameworks", href: "/frontier-safety-frameworks" },
+  ];
+
+  const stats = [
+    {
+      label: "Versions",
+      value: String(allVersions.length),
+      sub: `${publishedVersions.length} published`,
+    },
+    {
+      label: "Latest",
+      value: latestPublished?.versionLabel ?? "—",
+      sub: latestPublished?.publishedDate ?? undefined,
+    },
+    {
+      label: "Thresholds",
+      value: String(latestThresholds.length),
+      sub:
+        latestPublished == null
+          ? "no published version"
+          : `for ${latestPublished.versionLabel}`,
+    },
+    {
+      label: "Diffs",
+      value: String(diffsWithItems.length),
+    },
+  ];
+
+  const statCards = (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
+    </div>
+  );
+
+  const subtitle = framework.notes ? (
+    <p>{framework.notes}</p>
+  ) : (
+    <p>
+      Published commitment from {framework.org.displayName} governing how the
+      lab approaches frontier-AI risk thresholds.
+    </p>
+  );
+
+  const sidebar = (
+    <section>
+      <h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+        About this tracker
+      </h2>
+      <div className="text-xs text-muted-foreground space-y-2 leading-relaxed">
+        <p>
+          Each framework version is fetched, hashed, and archived. Capability
+          thresholds are LLM-extracted with mandatory source quotes; diffs
+          between consecutive versions are classified before any directional
+          summary is shown publicly.
+        </p>
+        <p>
+          See the{" "}
+          <Link
+            href="/frontier-safety-frameworks/methodology"
+            className="underline hover:text-primary"
+          >
+            methodology page
+          </Link>{" "}
+          for extraction, classification, and review-state details.
+        </p>
+      </div>
+    </section>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Frontier Safety Frameworks", href: "/frontier-safety-frameworks" },
+        { label: framework.shortName ?? framework.name },
+      ]}
+      entityId={framework.id}
+      title={framework.shortName ?? framework.name}
+      titlePills={titlePills}
+      verdict={rollupVerdict}
+      subtitle={subtitle}
+      headerLinks={headerLinks}
+      statCards={statCards}
+      tabs={tabs}
+      tabsAriaLabel="Framework sections"
+      sidebar={sidebar}
+    />
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/page.tsx
@@ -20,12 +20,12 @@ import {
   frameworkSlug,
   type FrameworkVersionRow,
   type DiffRow,
-} from "../frameworks-data";
-import { LatestVersionTab } from "./latest-version-tab";
-import { VersionHistoryTab } from "./version-history-tab";
-import { ThresholdMatrixTab } from "./threshold-matrix-tab";
-import { DiffsTab, type DiffWithItems } from "./diffs-tab";
-import { SourcesTab } from "./sources-tab";
+} from "@/app/frontier-safety-frameworks/frameworks-data";
+import { LatestVersionTab } from "@/app/frontier-safety-frameworks/[slug]/latest-version-tab";
+import { VersionHistoryTab } from "@/app/frontier-safety-frameworks/[slug]/version-history-tab";
+import { ThresholdMatrixTab } from "@/app/frontier-safety-frameworks/[slug]/threshold-matrix-tab";
+import { DiffsTab, type DiffWithItems } from "@/app/frontier-safety-frameworks/[slug]/diffs-tab";
+import { SourcesTab } from "@/app/frontier-safety-frameworks/[slug]/sources-tab";
 
 export const revalidate = 300;
 

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/sources-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/sources-tab.tsx
@@ -1,4 +1,4 @@
-import type { FrameworkVersionRow } from "../frameworks-data";
+import type { FrameworkVersionRow } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 interface SourcesTabProps {
   versions: FrameworkVersionRow[];

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/sources-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/sources-tab.tsx
@@ -1,0 +1,89 @@
+import type { FrameworkVersionRow } from "../frameworks-data";
+
+interface SourcesTabProps {
+  versions: FrameworkVersionRow[];
+}
+
+export function SourcesTab({ versions }: SourcesTabProps) {
+  if (versions.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No sources recorded yet.
+      </div>
+    );
+  }
+
+  const sorted = [...versions].sort(
+    (a, b) => b.versionSortOrder - a.versionSortOrder,
+  );
+
+  return (
+    <div className="space-y-4">
+      {sorted.map((v) => (
+        <article
+          key={v.id}
+          className="rounded-lg border border-border/60 bg-card p-4"
+        >
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-2">
+            <h3 className="font-semibold text-foreground">{v.versionLabel}</h3>
+            {v.publishedDate && (
+              <span className="text-xs text-muted-foreground tabular-nums">
+                published {v.publishedDate}
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground tabular-nums">
+              · discovered {v.discoveredDate}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <a
+              href={v.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline break-all"
+            >
+              Source ↗
+            </a>
+            {v.waybackSnapshotUrl && (
+              <a
+                href={v.waybackSnapshotUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Wayback snapshot ↗
+              </a>
+            )}
+            {v.pdfArchiveUrl && (
+              <a
+                href={v.pdfArchiveUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Archived PDF ↗
+              </a>
+            )}
+            {v.contentLengthChars != null && (
+              <span className="text-muted-foreground">
+                {v.contentLengthChars.toLocaleString()} chars
+              </span>
+            )}
+            <span
+              className="text-muted-foreground/60 font-mono"
+              title="Content hash (SHA-256, normalized text)"
+            >
+              {v.contentHash.slice(0, 12)}…
+            </span>
+          </div>
+        </article>
+      ))}
+      <p className="text-xs text-muted-foreground">
+        Source URLs are fetched live; archived versions (Wayback Machine + PDF
+        capture) preserve every ingested revision so silent edits are
+        detectable. Content hashes are computed against normalized text so
+        whitespace-only changes don&apos;t register as new versions.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/threshold-matrix-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/threshold-matrix-tab.tsx
@@ -1,0 +1,113 @@
+import {
+  RISK_DOMAIN_LABELS,
+  tierColor,
+} from "../risk-domain-constants";
+import type { ThresholdRow } from "../frameworks-data";
+
+interface ThresholdMatrixTabProps {
+  thresholds: ThresholdRow[];
+  versionLabel: string;
+}
+
+/**
+ * Renders the threshold matrix for a single framework version: rows ordered
+ * by tier severity, columns showing threshold + trigger + source quote.
+ */
+export function ThresholdMatrixTab({
+  thresholds,
+  versionLabel,
+}: ThresholdMatrixTabProps) {
+  if (thresholds.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No thresholds extracted for {versionLabel} yet.
+      </div>
+    );
+  }
+
+  const sorted = [...thresholds].sort((a, b) => {
+    if (a.tierSortOrder !== b.tierSortOrder) {
+      return b.tierSortOrder - a.tierSortOrder;
+    }
+    return a.riskDomainCanonical.localeCompare(b.riskDomainCanonical);
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto rounded-lg border border-border/60">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-muted/40 text-xs text-muted-foreground">
+              <th className="text-left py-2 px-3 font-semibold">Domain</th>
+              <th className="text-left py-2 px-3 font-semibold">Tier</th>
+              <th className="text-left py-2 px-3 font-semibold">Trigger</th>
+              <th className="text-left py-2 px-3 font-semibold w-24">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/40">
+            {sorted.map((t) => {
+              const styles = tierColor(t.tierSortOrder);
+              return (
+                <tr key={t.id} className="hover:bg-muted/15 transition-colors">
+                  <td className="py-2.5 px-3 align-top">
+                    <span className="font-medium text-foreground">
+                      {RISK_DOMAIN_LABELS[t.riskDomainCanonical]}
+                    </span>
+                    {t.riskDomainLabel !== RISK_DOMAIN_LABELS[t.riskDomainCanonical] && (
+                      <span className="block text-[11px] text-muted-foreground italic">
+                        “{t.riskDomainLabel}” in source
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2.5 px-3 align-top">
+                    <span
+                      className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold border ${styles.bg} ${styles.text} ${styles.border}`}
+                    >
+                      {t.tierLabel}
+                    </span>
+                  </td>
+                  <td className="py-2.5 px-3 align-top text-foreground/80 max-w-2xl">
+                    <div className="text-sm leading-relaxed">
+                      {t.triggerDescription}
+                    </div>
+                    {t.sourceQuote && (
+                      <blockquote className="mt-1.5 text-xs text-muted-foreground border-l-2 border-border/60 pl-2 italic">
+                        “{t.sourceQuote}”
+                        {t.sourcePageHint && (
+                          <span className="not-italic ml-1 text-muted-foreground/60">
+                            ({t.sourcePageHint})
+                          </span>
+                        )}
+                      </blockquote>
+                    )}
+                  </td>
+                  <td className="py-2.5 px-3 align-top text-[11px]">
+                    {t.humanReviewed ? (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-800 border border-emerald-300 dark:bg-emerald-950/40 dark:text-emerald-200 dark:border-emerald-700">
+                        Reviewed
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-amber-50 text-amber-900 border border-amber-300 dark:bg-amber-950/40 dark:text-amber-200">
+                        Pending
+                      </span>
+                    )}
+                    {t.commitmentLanguage && (
+                      <span className="block mt-1 text-muted-foreground capitalize">
+                        {t.commitmentLanguage}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Each row is grounded in a source quote from the framework document.
+        “Pending” rows have not yet been spot-checked against the source — see
+        the methodology page for review criteria.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/threshold-matrix-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/threshold-matrix-tab.tsx
@@ -1,8 +1,8 @@
 import {
   RISK_DOMAIN_LABELS,
   tierColor,
-} from "../risk-domain-constants";
-import type { ThresholdRow } from "../frameworks-data";
+} from "@/app/frontier-safety-frameworks/risk-domain-constants";
+import type { ThresholdRow } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 interface ThresholdMatrixTabProps {
   thresholds: ThresholdRow[];

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/version-history-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/version-history-tab.tsx
@@ -1,4 +1,4 @@
-import type { FrameworkVersionRow } from "../frameworks-data";
+import type { FrameworkVersionRow } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 interface VersionHistoryTabProps {
   versions: FrameworkVersionRow[];

--- a/apps/web/src/app/frontier-safety-frameworks/[slug]/version-history-tab.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/[slug]/version-history-tab.tsx
@@ -1,0 +1,86 @@
+import type { FrameworkVersionRow } from "../frameworks-data";
+
+interface VersionHistoryTabProps {
+  versions: FrameworkVersionRow[];
+}
+
+const STATUS_BADGES: Record<string, { label: string; cls: string }> = {
+  published: {
+    label: "Published",
+    cls: "bg-emerald-50 text-emerald-800 border-emerald-300 dark:bg-emerald-950/40 dark:text-emerald-200",
+  },
+  pending_review: {
+    label: "Pending review",
+    cls: "bg-amber-50 text-amber-900 border-amber-300 dark:bg-amber-950/40 dark:text-amber-200",
+  },
+  rejected: {
+    label: "Rejected",
+    cls: "bg-gray-100 text-gray-600 border-gray-300 dark:bg-gray-800 dark:text-gray-400",
+  },
+};
+
+export function VersionHistoryTab({ versions }: VersionHistoryTabProps) {
+  if (versions.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No versions ingested for this framework yet.
+      </div>
+    );
+  }
+
+  const sorted = [...versions].sort(
+    (a, b) => b.versionSortOrder - a.versionSortOrder,
+  );
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/60">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-muted/40 text-xs text-muted-foreground">
+            <th className="text-left py-2 px-3 font-semibold">Version</th>
+            <th className="text-left py-2 px-3 font-semibold">Published</th>
+            <th className="text-left py-2 px-3 font-semibold">Discovered</th>
+            <th className="text-left py-2 px-3 font-semibold">Status</th>
+            <th className="text-left py-2 px-3 font-semibold">Hash</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/40">
+          {sorted.map((v) => {
+            const status = STATUS_BADGES[v.ingestStatus] ?? {
+              label: v.ingestStatus,
+              cls: "bg-muted text-muted-foreground border-border/50",
+            };
+            return (
+              <tr key={v.id} className="hover:bg-muted/15 transition-colors">
+                <td className="py-2 px-3">
+                  <span className="font-medium">{v.versionLabel}</span>
+                  {v.isDraft && (
+                    <span className="ml-2 inline-flex items-center px-1.5 py-0 rounded text-[10px] font-semibold bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+                      Draft
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 px-3 text-muted-foreground tabular-nums text-xs">
+                  {v.publishedDate ?? "—"}
+                </td>
+                <td className="py-2 px-3 text-muted-foreground tabular-nums text-xs">
+                  {v.discoveredDate}
+                </td>
+                <td className="py-2 px-3">
+                  <span
+                    className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-semibold border ${status.cls}`}
+                  >
+                    {status.label}
+                  </span>
+                </td>
+                <td className="py-2 px-3 text-[10px] font-mono text-muted-foreground/70">
+                  {v.contentHash.slice(0, 12)}…
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/__tests__/matrix-aggregation.test.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/__tests__/matrix-aggregation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  rowsToCellsForVersion,
+  activeDomains,
+} from "../matrix-aggregation";
+import type { ThresholdRow } from "../frameworks-data";
+
+function makeRow(over: Partial<ThresholdRow>): ThresholdRow {
+  return {
+    id: over.id ?? "sid_test12345",
+    versionId: over.versionId ?? "v1",
+    riskDomainCanonical: over.riskDomainCanonical ?? "cbrn",
+    riskDomainLabel: over.riskDomainLabel ?? "CBRN",
+    tierLabel: over.tierLabel ?? "T1",
+    tierSortOrder: over.tierSortOrder ?? 1,
+    triggerDescription: over.triggerDescription ?? "trigger",
+    sourceQuote: over.sourceQuote ?? "quote",
+    sourcePageHint: over.sourcePageHint ?? null,
+    commitmentLanguage: over.commitmentLanguage ?? null,
+    humanReviewed: over.humanReviewed ?? false,
+  };
+}
+
+describe("rowsToCellsForVersion", () => {
+  it("returns the most-severe tier per domain", () => {
+    const rows = [
+      makeRow({ riskDomainCanonical: "cbrn", tierLabel: "Low", tierSortOrder: 1 }),
+      makeRow({ riskDomainCanonical: "cbrn", tierLabel: "Critical", tierSortOrder: 4 }),
+      makeRow({ riskDomainCanonical: "cbrn", tierLabel: "Medium", tierSortOrder: 2 }),
+    ];
+    const cells = rowsToCellsForVersion(rows);
+    expect(cells.cbrn?.tierLabel).toBe("Critical");
+    expect(cells.cbrn?.tierSortOrder).toBe(4);
+    expect(cells.cbrn?.count).toBe(3);
+  });
+
+  it("groups rows by canonical domain", () => {
+    const rows = [
+      makeRow({ riskDomainCanonical: "cbrn", tierSortOrder: 3 }),
+      makeRow({ riskDomainCanonical: "cyber", tierSortOrder: 2 }),
+      makeRow({ riskDomainCanonical: "ai_rd", tierSortOrder: 4 }),
+    ];
+    const cells = rowsToCellsForVersion(rows);
+    expect(cells.cbrn?.tierSortOrder).toBe(3);
+    expect(cells.cyber?.tierSortOrder).toBe(2);
+    expect(cells.ai_rd?.tierSortOrder).toBe(4);
+    expect(Object.keys(cells)).toHaveLength(3);
+  });
+
+  it("prefers a reviewed row over an unreviewed row at the same tier", () => {
+    const rows = [
+      makeRow({ tierLabel: "Tier-3 unreviewed", tierSortOrder: 3, humanReviewed: false }),
+      makeRow({ tierLabel: "Tier-3 reviewed", tierSortOrder: 3, humanReviewed: true }),
+    ];
+    const cells = rowsToCellsForVersion(rows);
+    expect(cells.cbrn?.tierLabel).toBe("Tier-3 reviewed");
+    expect(cells.cbrn?.reviewed).toBe(true);
+  });
+
+  it("does not downgrade tier when a later row has lower severity", () => {
+    const rows = [
+      makeRow({ tierLabel: "Severe", tierSortOrder: 5 }),
+      makeRow({ tierLabel: "Low", tierSortOrder: 1 }),
+    ];
+    const cells = rowsToCellsForVersion(rows);
+    expect(cells.cbrn?.tierLabel).toBe("Severe");
+    expect(cells.cbrn?.tierSortOrder).toBe(5);
+  });
+
+  it("returns an empty object for no rows", () => {
+    expect(rowsToCellsForVersion([])).toEqual({});
+  });
+});
+
+describe("activeDomains", () => {
+  it("returns canonical-order union across all versions", () => {
+    const v1 = rowsToCellsForVersion([
+      makeRow({ riskDomainCanonical: "cyber", tierSortOrder: 2 }),
+    ]);
+    const v2 = rowsToCellsForVersion([
+      makeRow({ riskDomainCanonical: "cbrn", tierSortOrder: 3 }),
+      makeRow({ riskDomainCanonical: "ai_rd", tierSortOrder: 4 }),
+    ]);
+    // Canonical order is cbrn before cyber before ai_rd.
+    expect(activeDomains([v1, v2])).toEqual(["cbrn", "cyber", "ai_rd"]);
+  });
+
+  it("returns an empty array when no version has any cells", () => {
+    expect(activeDomains([])).toEqual([]);
+    expect(activeDomains([{}])).toEqual([]);
+  });
+});

--- a/apps/web/src/app/frontier-safety-frameworks/__tests__/matrix-aggregation.test.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/__tests__/matrix-aggregation.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   rowsToCellsForVersion,
   activeDomains,
-} from "../matrix-aggregation";
-import type { ThresholdRow } from "../frameworks-data";
+} from "@/app/frontier-safety-frameworks/matrix-aggregation";
+import type { ThresholdRow } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 function makeRow(over: Partial<ThresholdRow>): ThresholdRow {
   return {

--- a/apps/web/src/app/frontier-safety-frameworks/frameworks-data.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/frameworks-data.ts
@@ -1,0 +1,236 @@
+/**
+ * Server-side data fetchers for the /frontier-safety-frameworks pages.
+ * Pulls from wiki-server PG via the existing Hono routes (QUA-691 schema,
+ * QUA-707 ingest). All fetches are ISR-cached at 5 min.
+ *
+ * Hand-typed response shapes — keep narrow to fields rendered. The full
+ * Hono RPC types are not exported in a way that imports cleanly into the
+ * web app for these routes (mount-registry uses `any` parameterization).
+ */
+
+import { fetchDetailed } from "@lib/wiki-server";
+import type { CanonicalRiskDomain } from "./risk-domain-constants";
+
+export interface FrameworkRow {
+  id: string;
+  orgId: string;
+  orgDisplayName: string | null;
+  name: string;
+  shortName: string | null;
+  latestVersionId: string | null;
+  firstPublishedDate: string | null;
+  currentStatus: string | null;
+  frameworkFamily: string | null;
+  notes: string | null;
+  org: {
+    id: string;
+    slug: string | null;
+    title: string | null;
+    displayName: string;
+  };
+}
+
+export interface FrameworkVersionRow {
+  id: string;
+  frameworkId: string;
+  versionLabel: string;
+  versionSortOrder: number;
+  publishedDate: string | null;
+  discoveredDate: string;
+  sourceUrl: string;
+  sourceUrlCanonical: string | null;
+  waybackSnapshotUrl: string | null;
+  pdfArchiveUrl: string | null;
+  contentHash: string;
+  contentLengthChars: number | null;
+  summary: string | null;
+  isDraft: boolean;
+  supersededByVersionId: string | null;
+  ingestStatus: string;
+}
+
+export interface ThresholdRow {
+  id: string;
+  versionId: string;
+  riskDomainCanonical: CanonicalRiskDomain;
+  riskDomainLabel: string;
+  tierLabel: string;
+  tierSortOrder: number;
+  triggerDescription: string;
+  sourceQuote: string;
+  sourcePageHint: string | null;
+  commitmentLanguage: string | null;
+  humanReviewed: boolean;
+}
+
+export interface DiffRow {
+  id: string;
+  fromVersionId: string;
+  toVersionId: string;
+  changeSummary: string;
+  weakeningFlagged: boolean;
+  strengtheningFlagged: boolean;
+  neutralChangesCount: number | null;
+  overallDirection: string | null;
+  humanReviewed: boolean;
+  reviewVerdict: string;
+  reviewNotes: string | null;
+}
+
+export interface DiffItemRow {
+  id: string;
+  diffId: string;
+  changeType: string;
+  riskDomainCanonical: string | null;
+  beforeSnapshot: Record<string, unknown> | null;
+  afterSnapshot: Record<string, unknown> | null;
+  severity: number | null;
+  classifierTag: string | null;
+  rationale: string | null;
+}
+
+const REVALIDATE_SECONDS = 300;
+const PAGE_SIZE = 200;
+
+/**
+ * Fetches all framework rows with org join. Returns empty array on failure
+ * so the UI degrades to a "no data yet" state instead of throwing.
+ */
+export async function fetchAllFrameworks(): Promise<{
+  ok: boolean;
+  items: FrameworkRow[];
+}> {
+  const items: FrameworkRow[] = [];
+  let offset = 0;
+  while (true) {
+    const res = await fetchDetailed<{ items: FrameworkRow[]; total: number }>(
+      `/api/safety-frameworks/all?limit=${PAGE_SIZE}&offset=${offset}`,
+      { revalidate: REVALIDATE_SECONDS },
+    );
+    if (!res.ok) return { ok: false, items };
+    items.push(...res.data.items);
+    if (
+      res.data.items.length < PAGE_SIZE ||
+      items.length >= res.data.total
+    ) {
+      break;
+    }
+    offset += PAGE_SIZE;
+    // Defensive: 12 frameworks expected; bail if we ever see >500.
+    if (offset > 500) break;
+  }
+  return { ok: true, items };
+}
+
+/**
+ * Fetches a single framework. Tries by `id` (sid_ prefixed) first, then
+ * resolves by slug-style shortName scan. Returns null if neither matches.
+ */
+export async function fetchFramework(slug: string): Promise<FrameworkRow | null> {
+  // Try direct ID lookup first (sid_-prefixed slugs hit this path).
+  if (slug.startsWith("sid_")) {
+    const res = await fetchDetailed<FrameworkRow>(
+      `/api/safety-frameworks/${encodeURIComponent(slug)}`,
+      { revalidate: REVALIDATE_SECONDS },
+    );
+    if (res.ok) return res.data;
+    return null;
+  }
+  // Otherwise scan all frameworks and match by friendly slug.
+  const all = await fetchAllFrameworks();
+  if (!all.ok) return null;
+  const wanted = slug.toLowerCase();
+  return (
+    all.items.find((f) => frameworkSlug(f) === wanted) ?? null
+  );
+}
+
+/**
+ * Builds a stable URL slug for a framework: prefer `shortName` (lowercased,
+ * non-alphanumeric → `-`), fall back to the org slug + framework name, and
+ * finally to the framework id.
+ */
+export function frameworkSlug(f: FrameworkRow): string {
+  if (f.shortName) {
+    const base = f.shortName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    if (base) return base;
+  }
+  if (f.org.slug) {
+    const orgPart = f.org.slug.toLowerCase();
+    const namePart = f.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    if (namePart) return `${orgPart}-${namePart}`;
+  }
+  return f.id;
+}
+
+export async function fetchVersionsForFramework(
+  frameworkId: string,
+  publishedOnly = false,
+): Promise<FrameworkVersionRow[]> {
+  const res = await fetchDetailed<{
+    items: FrameworkVersionRow[];
+    total: number;
+  }>(
+    `/api/safety-framework-versions/by-framework/${encodeURIComponent(
+      frameworkId,
+    )}?limit=200&offset=0`,
+    { revalidate: REVALIDATE_SECONDS },
+  );
+  if (!res.ok) return [];
+  return publishedOnly
+    ? res.data.items.filter((v) => v.ingestStatus === "published")
+    : res.data.items;
+}
+
+export async function fetchThresholdsForVersion(
+  versionId: string,
+): Promise<ThresholdRow[]> {
+  const res = await fetchDetailed<{ items: ThresholdRow[]; total: number }>(
+    `/api/framework-capability-thresholds/by-version/${encodeURIComponent(
+      versionId,
+    )}?limit=500&offset=0`,
+    { revalidate: REVALIDATE_SECONDS },
+  );
+  if (!res.ok) return [];
+  return res.data.items;
+}
+
+export async function fetchDiffsForVersion(
+  toVersionId: string,
+): Promise<DiffRow[]> {
+  const res = await fetchDetailed<{ items: DiffRow[]; total: number }>(
+    `/api/framework-diffs/all?to_version_id=${encodeURIComponent(
+      toVersionId,
+    )}&limit=200&offset=0`,
+    { revalidate: REVALIDATE_SECONDS },
+  );
+  if (!res.ok) return [];
+  return res.data.items;
+}
+
+export async function fetchAllPublishedVersions(
+  limit = 500,
+): Promise<FrameworkVersionRow[]> {
+  const res = await fetchDetailed<{
+    items: FrameworkVersionRow[];
+    total: number;
+  }>(
+    `/api/safety-framework-versions/all?ingest_status=published&limit=${limit}&offset=0`,
+    { revalidate: REVALIDATE_SECONDS },
+  );
+  if (!res.ok) return [];
+  return res.data.items;
+}
+
+export async function fetchDiffItemsForDiff(
+  diffId: string,
+): Promise<DiffItemRow[]> {
+  const res = await fetchDetailed<{ items: DiffItemRow[]; total: number }>(
+    `/api/framework-diff-items/by-diff/${encodeURIComponent(
+      diffId,
+    )}?limit=500&offset=0`,
+    { revalidate: REVALIDATE_SECONDS },
+  );
+  if (!res.ok) return [];
+  return res.data.items;
+}

--- a/apps/web/src/app/frontier-safety-frameworks/frameworks-data.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/frameworks-data.ts
@@ -9,7 +9,7 @@
  */
 
 import { fetchDetailed } from "@lib/wiki-server";
-import type { CanonicalRiskDomain } from "./risk-domain-constants";
+import type { CanonicalRiskDomain } from "@/app/frontier-safety-frameworks/risk-domain-constants";
 
 export interface FrameworkRow {
   id: string;

--- a/apps/web/src/app/frontier-safety-frameworks/frameworks-view-toggle.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/frameworks-view-toggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+export type ViewMode = "matrix" | "timeline";
+
+interface ViewToggleProps {
+  defaultView?: ViewMode;
+  matrix: React.ReactNode;
+  timeline: React.ReactNode;
+}
+
+/**
+ * Client toggle between the matrix and timeline views. Both panels are
+ * rendered server-side and passed in as `ReactNode` slots; the toggle just
+ * shows/hides them with CSS so swapping is instant and no extra fetch fires.
+ */
+export function FrameworksViewToggle({
+  defaultView = "matrix",
+  matrix,
+  timeline,
+}: ViewToggleProps) {
+  const [view, setView] = useState<ViewMode>(defaultView);
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Frameworks view"
+        className="inline-flex items-center gap-1 rounded-lg border border-border/60 bg-muted/30 p-1 mb-4"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "matrix"}
+          onClick={() => setView("matrix")}
+          className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+            view === "matrix"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Matrix
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "timeline"}
+          onClick={() => setView("timeline")}
+          className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+            view === "timeline"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Timeline
+        </button>
+      </div>
+      <div hidden={view !== "matrix"}>{matrix}</div>
+      <div hidden={view !== "timeline"}>{timeline}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/matrix-aggregation.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/matrix-aggregation.ts
@@ -6,8 +6,8 @@
 import {
   CANONICAL_RISK_DOMAINS,
   type CanonicalRiskDomain,
-} from "./risk-domain-constants";
-import type { ThresholdRow } from "./frameworks-data";
+} from "@/app/frontier-safety-frameworks/risk-domain-constants";
+import type { ThresholdRow } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 export interface MatrixCell {
   /** Highest tier_label found for (framework version × domain). */

--- a/apps/web/src/app/frontier-safety-frameworks/matrix-aggregation.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/matrix-aggregation.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure aggregation helpers for the matrix view. Extracted so they can be
+ * unit-tested independently of fetch / render.
+ */
+
+import {
+  CANONICAL_RISK_DOMAINS,
+  type CanonicalRiskDomain,
+} from "./risk-domain-constants";
+import type { ThresholdRow } from "./frameworks-data";
+
+export interface MatrixCell {
+  /** Highest tier_label found for (framework version × domain). */
+  tierLabel: string;
+  /** tier_sort_order of that highest tier (1-5). Drives color. */
+  tierSortOrder: number;
+  /** Total threshold rows in this cell (≥1). */
+  count: number;
+  /** Whether at least one row in this cell is human-reviewed. */
+  reviewed: boolean;
+}
+
+/**
+ * Reduces a flat list of threshold rows for a single version into
+ * (canonicalDomain → most-severe MatrixCell). The "most severe" cell is the
+ * one with the highest `tier_sort_order`. Ties resolve to the row with
+ * `human_reviewed=true` first, then to first occurrence in the input.
+ */
+export function rowsToCellsForVersion(
+  rows: readonly ThresholdRow[],
+): Partial<Record<CanonicalRiskDomain, MatrixCell>> {
+  const cells: Partial<Record<CanonicalRiskDomain, MatrixCell>> = {};
+
+  for (const row of rows) {
+    const domain = row.riskDomainCanonical;
+    const existing = cells[domain];
+    if (!existing) {
+      cells[domain] = {
+        tierLabel: row.tierLabel,
+        tierSortOrder: row.tierSortOrder,
+        count: 1,
+        reviewed: row.humanReviewed,
+      };
+      continue;
+    }
+    const priorReviewed = existing.reviewed;
+    existing.count += 1;
+    existing.reviewed = priorReviewed || row.humanReviewed;
+    if (
+      row.tierSortOrder > existing.tierSortOrder ||
+      (row.tierSortOrder === existing.tierSortOrder &&
+        row.humanReviewed &&
+        !priorReviewed)
+    ) {
+      existing.tierLabel = row.tierLabel;
+      existing.tierSortOrder = row.tierSortOrder;
+    }
+  }
+
+  return cells;
+}
+
+/**
+ * Returns the ordered list of canonical domains that appear in any of the
+ * provided cell maps. Uses CANONICAL_RISK_DOMAINS order and drops empty
+ * columns to keep the matrix compact when only a few domains are populated.
+ */
+export function activeDomains(
+  cellsByVersion: Iterable<Partial<Record<CanonicalRiskDomain, MatrixCell>>>,
+): CanonicalRiskDomain[] {
+  const seen = new Set<CanonicalRiskDomain>();
+  for (const cells of cellsByVersion) {
+    for (const domain of CANONICAL_RISK_DOMAINS) {
+      if (cells[domain]) seen.add(domain);
+    }
+  }
+  return CANONICAL_RISK_DOMAINS.filter((d) => seen.has(d));
+}

--- a/apps/web/src/app/frontier-safety-frameworks/matrix-view.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/matrix-view.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link";
+import {
+  RISK_DOMAIN_LABELS,
+  RISK_DOMAIN_SHORT_LABELS,
+  tierColor,
+  type CanonicalRiskDomain,
+} from "./risk-domain-constants";
+import type { MatrixCell } from "./matrix-aggregation";
+import type { FrameworkRow, FrameworkVersionRow } from "./frameworks-data";
+import { frameworkSlug } from "./frameworks-data";
+
+export interface MatrixRow {
+  framework: FrameworkRow;
+  /** Latest published version (if any). */
+  latestVersion: FrameworkVersionRow | null;
+  /** Aggregated cells per canonical domain for the latest published version. */
+  cells: Partial<Record<CanonicalRiskDomain, MatrixCell>>;
+}
+
+export interface MatrixViewProps {
+  rows: MatrixRow[];
+  domains: CanonicalRiskDomain[];
+}
+
+export function MatrixView({ rows, domains }: MatrixViewProps) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No frameworks ingested yet.
+      </div>
+    );
+  }
+  if (domains.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        Frameworks are registered but no published thresholds exist yet — the
+        matrix will populate once published versions land. See the methodology
+        page for context.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/60">
+      <table className="w-full text-sm border-separate border-spacing-0">
+        <thead>
+          <tr className="bg-muted/40">
+            <th className="text-left text-xs font-semibold text-muted-foreground py-2.5 px-3 sticky left-0 bg-muted/40 border-b border-border/60">
+              Framework
+            </th>
+            <th className="text-left text-xs font-semibold text-muted-foreground py-2.5 px-3 border-b border-border/60">
+              Latest version
+            </th>
+            {domains.map((d) => (
+              <th
+                key={d}
+                className="text-center text-[11px] font-semibold text-muted-foreground py-2.5 px-2 border-b border-border/60 whitespace-nowrap"
+                title={RISK_DOMAIN_LABELS[d]}
+              >
+                {RISK_DOMAIN_SHORT_LABELS[d]}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/40">
+          {rows.map(({ framework, latestVersion, cells }) => {
+            const slug = frameworkSlug(framework);
+            const cellCount = Object.keys(cells).length;
+            return (
+              <tr key={framework.id} className="hover:bg-muted/15 transition-colors">
+                <td className="py-2.5 px-3 align-top sticky left-0 bg-background hover:bg-muted/15">
+                  <Link
+                    href={`/frontier-safety-frameworks/${slug}`}
+                    className="text-foreground hover:text-primary font-medium block"
+                  >
+                    {framework.shortName ?? framework.name}
+                  </Link>
+                  <span className="text-[11px] text-muted-foreground block">
+                    {framework.org.displayName}
+                  </span>
+                </td>
+                <td className="py-2.5 px-3 align-top text-xs text-muted-foreground">
+                  {latestVersion ? (
+                    <>
+                      <span className="font-medium text-foreground/80">
+                        {latestVersion.versionLabel}
+                      </span>
+                      {latestVersion.publishedDate && (
+                        <span className="block text-[11px]">
+                          {latestVersion.publishedDate}
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="italic">no published version</span>
+                  )}
+                </td>
+                {domains.map((d) => {
+                  const cell = cells[d];
+                  if (!cell) {
+                    return (
+                      <td
+                        key={d}
+                        className="py-2 px-2 text-center text-[11px] text-muted-foreground/50"
+                        title={`${RISK_DOMAIN_LABELS[d]} — no threshold defined`}
+                      >
+                        —
+                      </td>
+                    );
+                  }
+                  const styles = tierColor(cell.tierSortOrder);
+                  return (
+                    <td
+                      key={d}
+                      className="py-2 px-2 text-center"
+                      title={`${RISK_DOMAIN_LABELS[d]} — ${cell.tierLabel}${
+                        cell.count > 1 ? ` (${cell.count} thresholds)` : ""
+                      }${cell.reviewed ? "" : " — pending review"}`}
+                    >
+                      <span
+                        className={`inline-block min-w-[3.5rem] rounded px-1.5 py-0.5 text-[11px] font-semibold border ${styles.bg} ${styles.text} ${styles.border}`}
+                      >
+                        {cell.tierLabel}
+                      </span>
+                    </td>
+                  );
+                })}
+                {cellCount === 0 && (
+                  <td colSpan={Math.max(0, domains.length - 1)} />
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/matrix-view.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/matrix-view.tsx
@@ -4,10 +4,10 @@ import {
   RISK_DOMAIN_SHORT_LABELS,
   tierColor,
   type CanonicalRiskDomain,
-} from "./risk-domain-constants";
-import type { MatrixCell } from "./matrix-aggregation";
-import type { FrameworkRow, FrameworkVersionRow } from "./frameworks-data";
-import { frameworkSlug } from "./frameworks-data";
+} from "@/app/frontier-safety-frameworks/risk-domain-constants";
+import type { MatrixCell } from "@/app/frontier-safety-frameworks/matrix-aggregation";
+import type { FrameworkRow, FrameworkVersionRow } from "@/app/frontier-safety-frameworks/frameworks-data";
+import { frameworkSlug } from "@/app/frontier-safety-frameworks/frameworks-data";
 
 export interface MatrixRow {
   framework: FrameworkRow;
@@ -65,7 +65,6 @@ export function MatrixView({ rows, domains }: MatrixViewProps) {
         <tbody className="divide-y divide-border/40">
           {rows.map(({ framework, latestVersion, cells }) => {
             const slug = frameworkSlug(framework);
-            const cellCount = Object.keys(cells).length;
             return (
               <tr key={framework.id} className="hover:bg-muted/15 transition-colors">
                 <td className="py-2.5 px-3 align-top sticky left-0 bg-background hover:bg-muted/15">
@@ -125,9 +124,6 @@ export function MatrixView({ rows, domains }: MatrixViewProps) {
                     </td>
                   );
                 })}
-                {cellCount === 0 && (
-                  <td colSpan={Math.max(0, domains.length - 1)} />
-                )}
               </tr>
             );
           })}

--- a/apps/web/src/app/frontier-safety-frameworks/methodology/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/methodology/page.tsx
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Methodology | Frontier Safety Frameworks",
+  description:
+    "How frontier safety framework thresholds are extracted, how diffs between versions are classified, and what the review states mean.",
+};
+
+export default function MethodologyPage() {
+  return (
+    <article className="container max-w-3xl mx-auto px-4 py-8 prose prose-neutral dark:prose-invert">
+      <nav className="text-xs text-muted-foreground not-prose mb-3">
+        <Link href="/frontier-safety-frameworks" className="hover:text-primary">
+          ← Frontier Safety Frameworks
+        </Link>
+      </nav>
+
+      <h1>Methodology</h1>
+
+      <p className="lead">
+        This tracker mirrors versioned safety commitments from frontier AI
+        labs — Responsible Scaling Policies, Preparedness Frameworks, and
+        Frontier Safety Frameworks. Capability thresholds are
+        LLM-extracted from each version, grounded in source quotes, and
+        cross-version diffs are classified before any directional summary is
+        shown publicly.
+      </p>
+
+      <h2>Threshold extraction</h2>
+
+      <p>
+        For each published framework version, an LLM (Claude or GPT-class
+        model) reads the source document and extracts capability tiers. Each
+        extracted threshold row carries:
+      </p>
+
+      <ul>
+        <li>
+          <strong>Canonical risk domain</strong> — one of CBRN, bio, chem,
+          nuclear, radiological, cyber, autonomy & replication, AI R&amp;D,
+          scheming, persuasion, loss-of-control, or other. This normalized
+          domain enables cross-lab comparison; the lab&apos;s native domain
+          label is preserved separately.
+        </li>
+        <li>
+          <strong>Tier label and severity</strong> — the lab&apos;s own tier
+          name (e.g., &quot;ASL-3&quot;, &quot;High&quot;) plus a 1–5 sort
+          order so cells can be color-coded uniformly across labs.
+        </li>
+        <li>
+          <strong>Trigger description</strong> — the capability that activates
+          the tier.
+        </li>
+        <li>
+          <strong>Source quote</strong> — mandatory. Every row must cite a
+          quoted span from the source document. Rows without a verbatim
+          source quote are rejected at extraction time.
+        </li>
+        <li>
+          <strong>Commitment language tag</strong> — committed, aspirational,
+          conditional, or informational. Distinguishes binding promises from
+          forward-looking statements.
+        </li>
+      </ul>
+
+      <p>
+        Each row is then optionally human-reviewed. Reviewed rows show a
+        green &quot;Reviewed&quot; pill; pending rows show an amber
+        &quot;Pending&quot; pill in the threshold matrix.
+      </p>
+
+      <h2>Diff classification</h2>
+
+      <p>
+        When a new version supersedes the previous one, an LLM compares the
+        two versions and produces both an aggregate{" "}
+        <code>framework_diffs</code> row and per-change{" "}
+        <code>framework_diff_items</code> rows. Each item is tagged as one of:
+        threshold added/removed, mitigation softened/strengthened, commitment
+        weakened/strengthened, scope narrowed/broadened, eval changed,
+        clarification, or other.
+      </p>
+
+      <p>
+        Each diff also carries an <code>overall_direction</code> from the
+        classifier (weaker, stronger, mixed, neutral, or rewrite) — but{" "}
+        <strong>that classification is never displayed publicly until a human
+        reviewer confirms it.</strong>
+      </p>
+
+      <h2>Review states</h2>
+
+      <p>Public diffs are gated on the <code>review_verdict</code> column:</p>
+
+      <ul>
+        <li>
+          <strong>Confirmed weakening / strengthening</strong> — a reviewer
+          has read the diff items, agrees with the classifier&apos;s direction,
+          and surfaced a directional badge.
+        </li>
+        <li>
+          <strong>Nuanced</strong> — the change is significant but
+          directionally ambiguous (e.g., one threshold weakened, another
+          strengthened); displayed with an amber &quot;Nuanced&quot; badge
+          and the reviewer&apos;s notes.
+        </li>
+        <li>
+          <strong>False positive</strong> — the classifier flagged a change
+          but a human determined it&apos;s editorial / non-substantive. No
+          directional badge is shown.
+        </li>
+        <li>
+          <strong>Pending review</strong> — the diff exists but has not been
+          reviewer-confirmed. The factual change list is shown, but no
+          directional summary like &quot;weakened&quot; or
+          &quot;strengthened&quot; ever appears for an unreviewed diff.
+        </li>
+      </ul>
+
+      <p>
+        This gating is intentional. Saying a lab &quot;weakened&quot; its
+        commitments is a non-trivial editorial judgment; we want a human to
+        endorse that framing before showing it on the public page.
+      </p>
+
+      <h2>Source preservation</h2>
+
+      <p>
+        Every ingested version captures both the live source URL and an
+        archived snapshot (Wayback Machine + PDF where applicable), so silent
+        edits to the underlying document don&apos;t lose evidence. Content is
+        normalized and SHA-256 hashed; whitespace-only changes don&apos;t
+        register as new versions, but any substantive textual change does.
+      </p>
+
+      <h2>Limitations</h2>
+
+      <ul>
+        <li>
+          The canonical risk-domain mapping is opinionated; some lab-native
+          categories don&apos;t map cleanly (e.g., a single lab&apos;s
+          &quot;model autonomy&quot; tier may straddle{" "}
+          <em>autonomy &amp; replication</em>, <em>AI R&amp;D</em>, and{" "}
+          <em>scheming</em>). The original lab-native label is preserved on
+          every threshold row.
+        </li>
+        <li>
+          Tier sort order is normalized 1–5 across labs but is{" "}
+          <strong>not</strong> a calibrated severity scale. A &quot;tier-3&quot;
+          at one lab is not directly comparable to &quot;tier-3&quot; at
+          another — the matrix view helps spot which labs cover which
+          domains, not which lab&apos;s thresholds are objectively stricter.
+        </li>
+        <li>
+          Diff classification uses the LLM that extracted thresholds — if the
+          extraction missed a row, the diff classifier won&apos;t see it
+          either.
+        </li>
+      </ul>
+
+      <h2>Schema and code</h2>
+
+      <p>
+        Schema, sync routes, and ingest pipeline land under tickets QUA-691
+        (foundation), QUA-707 (ingest 12 frameworks), QUA-709 (this UI), and
+        QUA-710 (internal review dashboard). The PG schema is in{" "}
+        <code>apps/wiki-server/src/schema.ts</code> under the QUA-691 Phase 4
+        section.
+      </p>
+
+      <p className="not-prose text-xs text-muted-foreground mt-8">
+        <Link href="/frontier-safety-frameworks" className="underline hover:text-primary">
+          ← Back to all frameworks
+        </Link>
+      </p>
+    </article>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/page.tsx
@@ -8,11 +8,11 @@ import {
   fetchDiffsForVersion,
   type FrameworkRow,
   type FrameworkVersionRow,
-} from "./frameworks-data";
-import { rowsToCellsForVersion, activeDomains } from "./matrix-aggregation";
-import { MatrixView, type MatrixRow } from "./matrix-view";
-import { TimelineView, type TimelineEntry } from "./timeline-view";
-import { FrameworksViewToggle } from "./frameworks-view-toggle";
+} from "@/app/frontier-safety-frameworks/frameworks-data";
+import { rowsToCellsForVersion, activeDomains } from "@/app/frontier-safety-frameworks/matrix-aggregation";
+import { MatrixView, type MatrixRow } from "@/app/frontier-safety-frameworks/matrix-view";
+import { TimelineView, type TimelineEntry } from "@/app/frontier-safety-frameworks/timeline-view";
+import { FrameworksViewToggle } from "@/app/frontier-safety-frameworks/frameworks-view-toggle";
 
 export const metadata: Metadata = {
   title: "Frontier Safety Frameworks",
@@ -30,7 +30,20 @@ export default async function FrontierSafetyFrameworksPage() {
   // For matrix view: latest published version per framework + its thresholds.
   // We fetch all published versions and pick the highest-sort one per framework
   // in a single pass, then fan out threshold queries.
-  const allPublishedVersions = await fetchAllPublishedVersions(500);
+  //
+  // Cap is intentionally generous — current dataset is ~50 versions across all
+  // frameworks (12 frameworks × ~3-5 versions each). If the count grows past
+  // PUBLISHED_VERSIONS_FETCH_LIMIT we silently truncate the timeline + matrix,
+  // so we assert below to catch that early. Switch to pagination if this fires.
+  const PUBLISHED_VERSIONS_FETCH_LIMIT = 500;
+  const allPublishedVersions = await fetchAllPublishedVersions(
+    PUBLISHED_VERSIONS_FETCH_LIMIT,
+  );
+  if (allPublishedVersions.length >= PUBLISHED_VERSIONS_FETCH_LIMIT) {
+    console.warn(
+      `[frontier-safety-frameworks] fetchAllPublishedVersions returned ${allPublishedVersions.length} rows — at or near the ${PUBLISHED_VERSIONS_FETCH_LIMIT} cap. Timeline + matrix may be truncated; switch to pagination.`,
+    );
+  }
   const latestVersionByFramework = new Map<string, FrameworkVersionRow>();
   for (const v of allPublishedVersions) {
     const existing = latestVersionByFramework.get(v.frameworkId);

--- a/apps/web/src/app/frontier-safety-frameworks/page.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ProfileStatCard } from "@/components/directory";
+import {
+  fetchAllFrameworks,
+  fetchAllPublishedVersions,
+  fetchThresholdsForVersion,
+  fetchDiffsForVersion,
+  type FrameworkRow,
+  type FrameworkVersionRow,
+} from "./frameworks-data";
+import { rowsToCellsForVersion, activeDomains } from "./matrix-aggregation";
+import { MatrixView, type MatrixRow } from "./matrix-view";
+import { TimelineView, type TimelineEntry } from "./timeline-view";
+import { FrameworksViewToggle } from "./frameworks-view-toggle";
+
+export const metadata: Metadata = {
+  title: "Frontier Safety Frameworks",
+  description:
+    "Tracker of frontier-AI safety frameworks (RSPs, Preparedness Frameworks, FSFs) — versioned thresholds, capability domains, and diffs across published revisions.",
+};
+
+export const revalidate = 300;
+
+export default async function FrontierSafetyFrameworksPage() {
+  const frameworksRes = await fetchAllFrameworks();
+  const frameworks = frameworksRes.items;
+  const fetchOk = frameworksRes.ok;
+
+  // For matrix view: latest published version per framework + its thresholds.
+  // We fetch all published versions and pick the highest-sort one per framework
+  // in a single pass, then fan out threshold queries.
+  const allPublishedVersions = await fetchAllPublishedVersions(500);
+  const latestVersionByFramework = new Map<string, FrameworkVersionRow>();
+  for (const v of allPublishedVersions) {
+    const existing = latestVersionByFramework.get(v.frameworkId);
+    if (!existing || v.versionSortOrder > existing.versionSortOrder) {
+      latestVersionByFramework.set(v.frameworkId, v);
+    }
+  }
+
+  const matrixRowsRaw = await Promise.all(
+    frameworks.map(async (framework): Promise<MatrixRow> => {
+      const latestVersion = latestVersionByFramework.get(framework.id) ?? null;
+      const thresholds = latestVersion
+        ? await fetchThresholdsForVersion(latestVersion.id)
+        : [];
+      return {
+        framework,
+        latestVersion,
+        cells: rowsToCellsForVersion(thresholds),
+      };
+    }),
+  );
+
+  // Sort: published frameworks first, then by org name alphabetical.
+  const matrixRows = [...matrixRowsRaw].sort((a, b) => {
+    const aHas = a.latestVersion ? 0 : 1;
+    const bHas = b.latestVersion ? 0 : 1;
+    if (aHas !== bHas) return aHas - bHas;
+    return a.framework.org.displayName.localeCompare(
+      b.framework.org.displayName,
+    );
+  });
+
+  const domains = activeDomains(matrixRows.map((r) => r.cells));
+
+  // Timeline view: all published versions in chronological order, with diffs.
+  const sortedVersions = [...allPublishedVersions].sort((a, b) => {
+    const aDate = a.publishedDate ?? a.discoveredDate;
+    const bDate = b.publishedDate ?? b.discoveredDate;
+    return bDate.localeCompare(aDate);
+  });
+  const frameworksById = new Map(frameworks.map((f) => [f.id, f]));
+  const inboundDiffsByVersion = await Promise.all(
+    sortedVersions.map(async (v) => {
+      const diffs = await fetchDiffsForVersion(v.id);
+      return [v.id, diffs[0] ?? null] as const;
+    }),
+  );
+  const inboundDiffMap = new Map(inboundDiffsByVersion);
+
+  const timelineEntries: TimelineEntry[] = sortedVersions
+    .map((v): TimelineEntry | null => {
+      const framework = frameworksById.get(v.frameworkId);
+      if (!framework) return null;
+      return {
+        version: v,
+        framework,
+        inboundDiff: inboundDiffMap.get(v.id) ?? null,
+      };
+    })
+    .filter((e): e is TimelineEntry => e !== null);
+
+  // Stats
+  const totalFrameworks = frameworks.length;
+  const totalPublishedVersions = allPublishedVersions.length;
+  const totalLabs = new Set(frameworks.map((f) => f.orgId)).size;
+  const totalDomainsCovered = domains.length;
+
+  return (
+    <div className="container max-w-6xl mx-auto px-4 py-8">
+      <header className="mb-8">
+        <div className="flex items-baseline justify-between flex-wrap gap-3 mb-3">
+          <h1 className="text-3xl font-bold">Frontier Safety Frameworks</h1>
+          <Link
+            href="/frontier-safety-frameworks/methodology"
+            className="text-xs text-primary hover:underline"
+          >
+            Methodology →
+          </Link>
+        </div>
+        <p className="text-muted-foreground max-w-3xl text-sm">
+          Versioned commitments published by frontier AI labs (Responsible
+          Scaling Policies, Preparedness Frameworks, Frontier Safety
+          Frameworks). Thresholds extracted by an LLM, sourced to specific
+          quotes, and cross-version diffs are flagged for human review before
+          any directional summary is shown.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        <ProfileStatCard label="Frameworks" value={String(totalFrameworks)} />
+        <ProfileStatCard label="Labs" value={String(totalLabs)} />
+        <ProfileStatCard
+          label="Published versions"
+          value={String(totalPublishedVersions)}
+        />
+        <ProfileStatCard
+          label="Risk domains covered"
+          value={String(totalDomainsCovered)}
+        />
+      </div>
+
+      {!fetchOk && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 p-4 text-sm mb-6">
+          The wiki-server was unreachable; frameworks data is temporarily
+          unavailable. The matrix and timeline will populate once the server
+          responds.
+        </div>
+      )}
+
+      {fetchOk && totalFrameworks === 0 && (
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-6 text-sm space-y-2 mb-8">
+          <p className="font-medium">No frameworks ingested yet.</p>
+          <p className="text-muted-foreground">
+            The schema and sync API are live, but per-lab ingest lands in
+            QUA-707. Methodology is usable today.
+          </p>
+        </div>
+      )}
+
+      {totalFrameworks > 0 && (
+        <FrameworksViewToggle
+          matrix={<MatrixView rows={matrixRows} domains={domains} />}
+          timeline={<TimelineView entries={timelineEntries} />}
+        />
+      )}
+
+      <p className="text-xs text-muted-foreground mt-8">
+        Thresholds are LLM-extracted from each framework version and grounded
+        in quoted source text. See{" "}
+        <Link
+          href="/frontier-safety-frameworks/methodology"
+          className="underline hover:text-primary"
+        >
+          methodology
+        </Link>{" "}
+        for extraction, classification, and review-state details.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/risk-domain-constants.ts
+++ b/apps/web/src/app/frontier-safety-frameworks/risk-domain-constants.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical risk domains used across all frontier-safety frameworks.
+ * Mirrors the CHECK constraint allowlist in
+ * `apps/wiki-server/drizzle/0206_*` and the validators in
+ * `framework-capability-thresholds.ts` / `framework-diff-items.ts`.
+ */
+
+export const CANONICAL_RISK_DOMAINS = [
+  "cbrn",
+  "bio",
+  "chem",
+  "nuclear",
+  "radiological",
+  "cyber",
+  "autonomy_replication",
+  "ai_rd",
+  "scheming",
+  "persuasion",
+  "loss_of_control",
+  "other",
+] as const;
+
+export type CanonicalRiskDomain = (typeof CANONICAL_RISK_DOMAINS)[number];
+
+export const RISK_DOMAIN_LABELS: Record<CanonicalRiskDomain, string> = {
+  cbrn: "CBRN",
+  bio: "Bio",
+  chem: "Chem",
+  nuclear: "Nuclear",
+  radiological: "Radiological",
+  cyber: "Cyber",
+  autonomy_replication: "Autonomy & Replication",
+  ai_rd: "AI R&D",
+  scheming: "Scheming",
+  persuasion: "Persuasion",
+  loss_of_control: "Loss of Control",
+  other: "Other",
+};
+
+export const RISK_DOMAIN_SHORT_LABELS: Record<CanonicalRiskDomain, string> = {
+  cbrn: "CBRN",
+  bio: "Bio",
+  chem: "Chem",
+  nuclear: "Nuc",
+  radiological: "Rad",
+  cyber: "Cyber",
+  autonomy_replication: "Auto",
+  ai_rd: "R&D",
+  scheming: "Scheme",
+  persuasion: "Persuade",
+  loss_of_control: "LoC",
+  other: "Other",
+};
+
+/**
+ * Tier color tokens — keyed by `tier_sort_order` (1 = lowest, 5 = severe).
+ * Reused for matrix cells and detail-page tier pills.
+ */
+export const TIER_COLORS: Record<number, { bg: string; text: string; border: string }> = {
+  1: { bg: "bg-emerald-50 dark:bg-emerald-950/40", text: "text-emerald-800 dark:text-emerald-200", border: "border-emerald-300 dark:border-emerald-700" },
+  2: { bg: "bg-amber-50 dark:bg-amber-950/40", text: "text-amber-900 dark:text-amber-200", border: "border-amber-300 dark:border-amber-700" },
+  3: { bg: "bg-orange-50 dark:bg-orange-950/40", text: "text-orange-900 dark:text-orange-200", border: "border-orange-300 dark:border-orange-700" },
+  4: { bg: "bg-red-50 dark:bg-red-950/40", text: "text-red-900 dark:text-red-200", border: "border-red-300 dark:border-red-700" },
+  5: { bg: "bg-rose-100 dark:bg-rose-950/50", text: "text-rose-900 dark:text-rose-200", border: "border-rose-400 dark:border-rose-700" },
+};
+
+export function tierColor(sortOrder: number | null | undefined) {
+  if (sortOrder == null) {
+    return { bg: "bg-muted/30", text: "text-muted-foreground", border: "border-border/40" };
+  }
+  return TIER_COLORS[sortOrder] ?? TIER_COLORS[3];
+}
+
+/**
+ * Public-facing label for the diff `review_verdict`. Critical: "unreviewed"
+ * diffs must NEVER show "weakened" / "strengthened" labels — only the raw
+ * factual change list. See QUA-709 acceptance criteria.
+ */
+export const REVIEW_VERDICT_LABELS: Record<string, string> = {
+  confirmed_weakening: "Confirmed weakening",
+  confirmed_strengthening: "Confirmed strengthening",
+  nuanced: "Nuanced",
+  false_positive: "Reviewed — no material change",
+  unreviewed: "Pending review",
+};
+
+/**
+ * Returns true when a diff's verdict is published-safe to render with a
+ * directional summary ("weakened"/"strengthened"). Falsy verdicts and
+ * "unreviewed" return false — UI must show the factual change list only.
+ */
+export function isVerdictPublished(reviewVerdict: string | null | undefined): boolean {
+  return (
+    reviewVerdict === "confirmed_weakening" ||
+    reviewVerdict === "confirmed_strengthening" ||
+    reviewVerdict === "nuanced"
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
-import type { FrameworkRow, FrameworkVersionRow, DiffRow } from "./frameworks-data";
-import { frameworkSlug } from "./frameworks-data";
-import { isVerdictPublished, REVIEW_VERDICT_LABELS } from "./risk-domain-constants";
+import type { FrameworkRow, FrameworkVersionRow, DiffRow } from "@/app/frontier-safety-frameworks/frameworks-data";
+import { frameworkSlug } from "@/app/frontier-safety-frameworks/frameworks-data";
+import { isVerdictPublished, REVIEW_VERDICT_LABELS } from "@/app/frontier-safety-frameworks/risk-domain-constants";
 
 export interface TimelineEntry {
   version: FrameworkVersionRow;
@@ -100,7 +100,7 @@ export function TimelineView({ entries }: TimelineViewProps) {
                 {version.summary}
               </p>
             )}
-            {inboundDiff && (
+            {inboundDiff && isVerdictPublished(inboundDiff.reviewVerdict) && (
               <p className="text-xs text-muted-foreground mt-1.5 max-w-3xl">
                 <span className="font-medium text-foreground/70">
                   What changed:

--- a/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import type { FrameworkRow, FrameworkVersionRow, DiffRow } from "./frameworks-data";
+import { frameworkSlug } from "./frameworks-data";
+import { isVerdictPublished, REVIEW_VERDICT_LABELS } from "./risk-domain-constants";
+
+export interface TimelineEntry {
+  version: FrameworkVersionRow;
+  framework: FrameworkRow;
+  /** Diff *into* this version (`to_version_id = version.id`). */
+  inboundDiff: DiffRow | null;
+}
+
+export interface TimelineViewProps {
+  entries: TimelineEntry[];
+}
+
+function diffBadge(diff: DiffRow | null) {
+  if (!diff) return null;
+  if (isVerdictPublished(diff.reviewVerdict)) {
+    if (diff.reviewVerdict === "confirmed_weakening") {
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-red-50 text-red-800 border border-red-300 dark:bg-red-950/40 dark:text-red-200 dark:border-red-700">
+          Weakening
+        </span>
+      );
+    }
+    if (diff.reviewVerdict === "confirmed_strengthening") {
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-800 border border-emerald-300 dark:bg-emerald-950/40 dark:text-emerald-200 dark:border-emerald-700">
+          Strengthening
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-50 text-amber-900 border border-amber-300 dark:bg-amber-950/40 dark:text-amber-200 dark:border-amber-700">
+        Nuanced
+      </span>
+    );
+  }
+  // Unreviewed (or other non-published verdict): neutral pill, NEVER directional.
+  // This satisfies the QUA-709 acceptance criterion that unreviewed diffs
+  // never display the word "weakened" / "strengthened".
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground border border-border/50">
+      Pending review
+    </span>
+  );
+}
+
+export function TimelineView({ entries }: TimelineViewProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        No published framework versions yet.
+      </div>
+    );
+  }
+
+  return (
+    <ol className="relative border-l-2 border-border/50 pl-5 space-y-6">
+      {entries.map(({ version, framework, inboundDiff }) => {
+        const slug = frameworkSlug(framework);
+        const dateStr = version.publishedDate ?? version.discoveredDate;
+        return (
+          <li key={version.id} className="relative">
+            <span className="absolute -left-[1.7rem] top-1.5 h-3 w-3 rounded-full border-2 border-border bg-background" />
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-1">
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {dateStr}
+              </span>
+              <Link
+                href={`/frontier-safety-frameworks/${slug}`}
+                className="font-medium text-foreground hover:text-primary"
+              >
+                {framework.shortName ?? framework.name}
+              </Link>
+              <span className="text-xs text-muted-foreground">
+                {version.versionLabel}
+              </span>
+              {version.isDraft && (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-50 text-amber-900 border border-amber-300 dark:bg-amber-950/40 dark:text-amber-200">
+                  Draft
+                </span>
+              )}
+              {diffBadge(inboundDiff)}
+              {inboundDiff && (
+                <span
+                  className="text-[11px] text-muted-foreground/70"
+                  title={REVIEW_VERDICT_LABELS[inboundDiff.reviewVerdict] ?? inboundDiff.reviewVerdict}
+                >
+                  ({inboundDiff.neutralChangesCount ?? 0} changes)
+                </span>
+              )}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {framework.org.displayName}
+            </div>
+            {version.summary && (
+              <p className="text-sm text-foreground/80 mt-1.5 max-w-3xl leading-relaxed">
+                {version.summary}
+              </p>
+            )}
+            {inboundDiff && (
+              <p className="text-xs text-muted-foreground mt-1.5 max-w-3xl">
+                <span className="font-medium text-foreground/70">
+                  What changed:
+                </span>{" "}
+                {inboundDiff.changeSummary}
+              </p>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
+++ b/apps/web/src/app/frontier-safety-frameworks/timeline-view.tsx
@@ -83,12 +83,19 @@ export function TimelineView({ entries }: TimelineViewProps) {
                 </span>
               )}
               {diffBadge(inboundDiff)}
-              {inboundDiff && (
+              {inboundDiff && (inboundDiff.neutralChangesCount ?? 0) > 0 && (
+                // Label is "neutral changes" (not just "changes") because
+                // weakeningFlagged / strengtheningFlagged are separate booleans
+                // on DiffRow, not counts — folding them in here would
+                // overstate, and showing "(0 changes)" next to a directional
+                // pill (when only flagged changes occurred) reads as a
+                // contradiction.
                 <span
                   className="text-[11px] text-muted-foreground/70"
                   title={REVIEW_VERDICT_LABELS[inboundDiff.reviewVerdict] ?? inboundDiff.reviewVerdict}
                 >
-                  ({inboundDiff.neutralChangesCount ?? 0} changes)
+                  ({inboundDiff.neutralChangesCount} neutral change
+                  {inboundDiff.neutralChangesCount === 1 ? "" : "s"})
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary

Phase 4-B of QUA-706 frontier safety framework tracker. Public UI on top of QUA-691 schema (`safety_frameworks`, `safety_framework_versions`, `framework_capability_thresholds`, `framework_diffs`, `framework_diff_items`) and QUA-707 ingest pipeline.

## What lands

- **`/frontier-safety-frameworks`** — directory with toggleable **Matrix** view (orgs × canonical risk domains, most-severe tier per cell, color-coded by `tier_sort_order`) and **Timeline** view (chronological published versions with diff badges).
- **`/frontier-safety-frameworks/[slug]`** — per-framework detail page using `EntityProfileShell` with tabs: Latest Version | Version History | Threshold Matrix | Diffs | Sources & Archive.
- **`/frontier-safety-frameworks/methodology`** — short prose explainer of threshold extraction, diff classification, and review-state gating. Linked from both directory and detail pages.

## Verdict gating (acceptance criterion)

`isVerdictPublished()` in `risk-domain-constants.ts` returns true only for `confirmed_weakening | confirmed_strengthening | nuanced`. Both timeline-view and the diffs tab branch on this — unreviewed diffs render the factual change list with a neutral "Pending review" pill but **never** display directional language like "weakened" or "strengthened". Verified by an e2e spec that scans every "Pending review" timeline entry.

## Empty-state handling

- 0 frameworks ingested → "No frameworks ingested yet" panel; no 404
- Framework with no published version → tabs collapse appropriately, "no published version" state on Latest Version tab
- Wiki-server unreachable → amber "temporarily unavailable" banner; rest of page still renders

## Tests

- **7 unit tests** in `__tests__/matrix-aggregation.test.ts` covering tier severity selection, domain grouping, reviewed-row tie-breaking, downgrade prevention, empty input, and active-domain ordering.
- **3 e2e specs** in `e2e/frontier-safety-frameworks.spec.ts`: directory renders + view toggle, methodology renders, unreviewed-diff directional-language gating.
- `/frontier-safety-frameworks` and `/methodology` added to `render-audit.spec.ts` simple-pages list.

## Notes

- **No new wiki-server endpoints** — QUA-691 already shipped `/all`, `/by-entity`, `/:id`, `/by-framework`, `/by-version`, `/by-version-pair`, `/by-diff` for all five framework tables.
- **Matrix aggregation extracted as a pure function** so it's unit-testable independent of fetch/render.
- **Hand-typed response shapes** (same approach as `/scorecards/page.tsx`) — the mount-registry parameterizes route types as `any` so RPC type inference doesn't propagate cleanly into `apps/web/`.

Closes QUA-709

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm crux w validate gate --fix` — 57/57 passed (4 pre-existing advisories unrelated to this PR)
- [x] `pnpm test src/app/frontier-safety-frameworks` — 7/7 passed
- [x] Playwright `e2e/frontier-safety-frameworks.spec.ts` against local dev — 3/3 passed
- [x] Playwright `e2e/render-audit.spec.ts` for the two new pages — 2/2 passed
- [ ] CI green on PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Frontier Safety Frameworks area: directory with Matrix and Timeline views, per-framework detail pages (latest version, threshold matrix, version history, sources, diffs) and a Methodology page.
  * Interactive components: matrix, timeline, version tabs, diffs viewer, sources listing, and view toggle.

* **Tests**
  * New end-to-end and unit tests covering pages, timeline/table behaviors, matrix aggregation, and anti-pattern render checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->