### PR TITLE
QUA-716: Fill E82 Cyber Offense stub as navigational overview

### DIFF
--- a/content/docs/knowledge-base/risks/cyber-offense.mdx
+++ b/content/docs/knowledge-base/risks/cyber-offense.mdx
@@ -1,13 +1,101 @@
 ---
 wikiId: E82
 title: Cyber Offense
-description: AI-enhanced cyberattacks and offensive hacking capabilities
+description: AI-enhanced cyberattacks, offensive hacking capabilities, and the evolving offense-defense balance as AI systems accelerate threat actor operations
 sidebar:
   order: 50
 subcategory: misuse
-lastEdited: 2026-02-09
+lastEdited: "2026-04-25"
 clusters:
   - ai-safety
   - cyber
 ---
-This page is a stub. Content needed.
+
+## Overview
+
+AI-enhanced cyber offense encompasses the use of artificial intelligence to improve the speed, scale, sophistication, or autonomy of offensive cyber operations — including vulnerability discovery, exploit development, social engineering, and end-to-end attack orchestration. This page serves as a navigational overview of the topic and should be read alongside its four child pages: <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink> (technical mechanisms and current capabilities), the <EntityLink id="E87" name="cyberweapons-attack-automation">Autonomous Cyber Attack Timeline</EntityLink> (capability projections), the <EntityLink id="E88" name="cyberweapons-offense-defense">Cyber Offense-Defense Balance Model</EntityLink> (quantitative analysis), and <EntityLink id="E689" name="concentrated-compute-cybersecurity-risk">Concentrated Compute as a Cybersecurity Risk</EntityLink> (infrastructure-side risks from AI data center concentration).
+
+The scope of this page is distinct from <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink>: where that page examines the technical mechanisms of specific attack classes in depth, this page provides orientation across the full landscape — defining key terminology, summarizing what the child pages cover, and presenting a cross-cutting risk assessment.
+
+A foundational distinction in the literature is between **AI-assisted attacks** and **AI-orchestrated attacks**. AI-assisted operations are human-directed: attackers use AI tools to accelerate specific stages of an operation (e.g., generating phishing text, scanning for vulnerabilities) while remaining firmly in control. AI-orchestrated operations are qualitatively different: AI agents autonomously execute 80–90% of tactical operations with minimal human intervention, reducing human operators to supervisors who approve strategic decisions such as target selection or data exfiltration.[^rc-73f0] A third category — **fully autonomous** attacks, with no human involvement — remains largely prospective as of early 2026.
+
+A second key concept is the **offense-defense balance**: the comparative difficulty of attacking versus defending a system. Whether AI tips this balance toward attackers or defenders is contested; a 2025 Georgetown CSET analysis collecting 44 distinct impact pathways concluded that "the cyber domain is too multifaceted for a single answer."[^rc-aa9a] A third foundational framework is the **cyber kill chain**, a staged model of attack progression (reconnaissance, weaponization, delivery, exploitation, installation, command-and-control, and exfiltration) originally developed by Lockheed Martin. AI inserts into each stage but has had the clearest demonstrated impact in reconnaissance and social engineering.[^rc-3e07]
+
+## Child Pages
+
+This topic is covered across four pages:
+
+| Page | Scope |
+|------|-------|
+| <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink> | Technical mechanisms of AI-enhanced attack classes: phishing automation, vulnerability discovery, exploit generation, malware, and autonomous attack chains. Current state of capability. |
+| <EntityLink id="E87" name="cyberweapons-attack-automation">Autonomous Cyber Attack Timeline</EntityLink> | Capability projections for highly autonomous cyber-capable agents (HACCAs); timeline analysis drawing on model benchmark data and documented incidents. |
+| <EntityLink id="E88" name="cyberweapons-offense-defense">Cyber Offense-Defense Balance Model</EntityLink> | Quantitative and analytical modeling of how AI shifts relative ease of attacking versus defending; disaggregated by attacker sophistication and defender resource level. |
+| <EntityLink id="E689" name="concentrated-compute-cybersecurity-risk">Concentrated Compute as Cybersecurity Risk</EntityLink> | Infrastructure-side risks from geographic and organizational concentration of AI compute: model weight exfiltration, hardware supply chain attacks, and single points of failure in AI data center clusters. |
+
+## Risk Assessment
+
+| Dimension | Assessment | Source / Confidence |
+|-----------|-----------|---------------------|
+| Likelihood of AI-assisted attacks (2025–2026) | Pervasive in social engineering; growing share of attack chain | Google Threat Intelligence Group 2025[^rc-aaf1]; high confidence |
+| Likelihood of AI-orchestrated (autonomous) attacks | First documented case November 2025; proliferation projected | <EntityLink id="E1193" name="iaps">Institute for AI Policy and Strategy</EntityLink> analysis of <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> threat report[^rc-73f0]; medium confidence |
+| Near-term severity (AI-orchestrated attacks) | Demonstrated against ≈30 targets; scale limited by actor caution | IAPS, November 2025 incident[^rc-73f0]; medium confidence |
+| Offense-defense balance direction | No consensus; AI benefits both sides differently by context | CSET Georgetown (Lohn, 2025)[^rc-aa9a]; medium confidence |
+| Severity for resource-constrained ("trailing-edge") organizations | Worse than for well-resourced organizations; AI lowers attacker cost floor | Academic analysis (2025)[^rc-4583]; medium confidence |
+
+The U.S. Director of National Intelligence's 2026 Annual Threat Assessment states that "innovation in the field of Artificial Intelligence will likely accelerate the threats in the cyber domain," citing a documented August 2025 incident in which cyber actors used an AI tool to conduct a data-extortion operation targeting government, healthcare, emergency services, and religious institutions internationally.[^rc-347c] China, Russia, Iran, and North Korea are identified as continuing R&D into AI for cyber operations.[^rc-347c]
+
+## How It Works (Attack Pathways)
+
+AI inserts into the cyber kill chain at multiple stages, with impact varying by stage and actor sophistication.[^rc-3e07] A 2024 peer-reviewed systematic review of 62 papers found that "AI-based tools are used most effectively in the initial stages of cyberattacks" and that "current defense tools are not designed to counter these sophisticated attacks during these stages."[^rc-3e07]
+
+**Reconnaissance.** AI tools automate target profiling — crawling public data, leaked credentials, and social media to build multi-dimensional profiles of organizations and individuals in minutes rather than days. Generative models craft personalized spear-phishing text tailored to the target's professional context. Empirical studies find that LLM-generated messages are often perceived as more convincing than human-authored ones, particularly for job-related messages.[^rc-39b5]
+
+**Weaponization and social engineering.** Google's Threat Intelligence Group has identified new malware families (PROMPTFLUX and PROMPTSTEAL) that use LLMs during execution, dynamically generating malicious scripts on demand. Ransomware-as-a-Service platforms increasingly incorporate AI-enhanced attack packages, lowering barriers for less sophisticated actors.[^rc-aaf1]
+
+**Exploitation and technical attack.** The pace of progress is rapid but uneven. A 2025 evaluation framework analyzing over 12,000 real-world AI-use-in-cyberattack instances found that frontier models scored near-zero on expert-level offensive security challenges until mid-2025, then reached approximately 60% success rate by late 2025.[^rc-87f3] In February 2026, <EntityLink id="E218" name="openai">OpenAI</EntityLink> reported that its model crossed the "High" cybersecurity threshold in its Preparedness Framework — the first model assessed as capable of developing working zero-day remote exploits against well-defended systems.[^rc-87f3]
+
+**Autonomous orchestration.** In November 2025, a Chinese state-sponsored group used <EntityLink id="E1041" name="claude">Claude</EntityLink> Code with custom scaffolding to automate 80–90% of a cyber espionage campaign against approximately 30 global organizations — described by the Institute for AI Policy and Strategy as "one of the first cyber espionage campaigns to use an AI agent to autonomously execute operations" in the wild.[^rc-73f0] Palo Alto Networks Unit 42 separately demonstrated in 2025–2026 that autonomous multi-agent AI systems can chain reconnaissance, privilege escalation, and lateral movement in cloud environments without human direction.[^rc-9293]
+
+For technical depth on each attack class, see <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink>.
+
+## Responses
+
+Responses to AI-enhanced cyber offense span technical defenses, governance frameworks, and infrastructure policy.
+
+**AI-augmented defense.** The same capabilities that benefit attackers also benefit defenders: AI enables continuous 24/7 monitoring without fatigue, faster vulnerability scanning, and automated threat intelligence prioritization.[^rc-aa9a] The Atlantic Council notes that "organizations that refuse to deploy AI for defensive purposes face asymmetric disadvantage against autonomous attackers operating at machine speed."[^rc-bd74]
+
+**Zero Trust architecture.** NIST's December 2025 draft Cybersecurity Framework Profile for Artificial Intelligence (NISTIR 8596) extends Zero Trust principles to AI systems, organized around three focus areas: Secure (protect AI systems), Detect (identify AI-enabled threats), and Thwart (proactively counter AI threats).[^rc-78d5]
+
+**International guidance for critical infrastructure.** In December 2025, CISA and international partners (including Australia's ACSC) published joint cybersecurity guidance for critical infrastructure operators integrating AI into operational technology systems, outlining four principles for managing AI-related risk in OT environments.[^rc-5aee]
+
+**Compute governance.** Infrastructure-side responses — securing AI data centers against model weight exfiltration, hardware supply chain attacks, and geographic concentration risks — are addressed in detail in the Concentrated Compute as Cybersecurity Risk page. The Institute for AI Policy and Strategy recommends establishing cyber incident intelligence sharing between AI companies and governments, and extending incident reporting requirements to cover AI data centers.[^rc-1ba9]
+
+**International norms.** The offense-defense balance and the appropriate scope of autonomous cyber operations in armed conflict remain areas of active policy debate, with no binding international framework as of early 2026.
+
+## Key Uncertainties
+
+Several dimensions of AI cyber offense risk remain genuinely contested or undercharacterized:
+
+**Pace of capability gains.** The gap between frontier models' offensive capability today (approximately 60% success on expert-level challenges as of late 2025)[^rc-87f3] and what would constitute "nation-state-level" autonomous hacking is not well-characterized. Whether "highly autonomous cyber-capable agents" emerge before 2030 depends on current scaling trends continuing.
+
+**Whether the offense-defense balance tips decisively.** A 2025 analysis from <EntityLink id="E524" name="cset">Georgetown's Center for Security and Emerging Technology (CSET)</EntityLink>[^rc-aa9a] identifies 44 distinct pathways by which AI affects the balance, with no aggregate answer. The answer varies by attack type, target resource level, and which side adopts AI faster. Trailing-edge organizations — those relying on legacy software and understaffed security teams — face a systematically worse balance because AI lowers the attacker's cost floor without improving the defender's posture automatically.[^rc-4583]
+
+**Attribution challenges.** As AI-orchestrated attacks require less distinctive human tradecraft, attributing attacks to specific actors may become harder, complicating deterrence and international response.
+
+**Effectiveness of governance interventions.** Whether voluntary frameworks (NIST NISTIR 8596), export controls on compute, or incident reporting requirements materially slow the diffusion of offensive AI capabilities to non-state actors and less sophisticated states is not well-studied.
+
+**Scope of AI-on-AI attacks.** As AI systems become embedded in critical infrastructure and defensive tooling, they become targets themselves. Prompt injection attacks, data poisoning, and model extraction represent new attack surfaces that do not map cleanly onto the traditional cyber kill chain.[^rc-1ba9]
+
+[^rc-73f0]: Institute for AI Policy and Strategy (IAPS), "The Emergence of Autonomous Cyber Attacks: Analysis and Implications," 2025–2026. https://www.iaps.ai/research/autonomous-cyber-attacks
+[^rc-aa9a]: Andrew J. Lohn, "The Impact of AI on the Cyber Offense-Defense Balance and the Character of Cyber Conflict," arXiv:2504.13371, April 17, 2025; companion CSET Georgetown publication, "Anticipating AI's Impact on the Cyber Offense-Defense Balance," May 2025. https://arxiv.org/abs/2504.13371 and https://cset.georgetown.edu/publication/anticipating-ais-impact-on-the-cyber-offense-defense-balance/
+[^rc-3e07]: Academic review, "Impact of AI on the Cyber Kill Chain: A Systematic Review," Heliyon, December 2024 (PMC11665572). https://pmc.ncbi.nlm.nih.gov/articles/PMC11665572/
+[^rc-4583]: Academic researchers, "Uplifted Attackers, Human Defenders: The Cyber Offense-Defense Balance for Trailing-Edge Organizations," arXiv:2508.15808, 2025. https://arxiv.org/html/2508.15808
+[^rc-347c]: Office of the Director of National Intelligence, "2026 Annual Threat Assessment of the U.S. Intelligence Community," March 2026. https://www.dni.gov/index.php/newsroom/press-releases/press-releases-2026/4142-pr-03-26
+[^rc-39b5]: Academic researchers, "Assessing AI vs Human-Authored Spear Phishing SMS Attacks: An Empirical Study Using the TRAPD Method," arXiv:2406.13049, June 2024. https://arxiv.org/abs/2406.13049
+[^rc-aaf1]: Google Threat Intelligence Group (GTIG), "GTIG AI Threat Tracker: Advances in Threat Actor Usage of AI Tools," 2025. https://cloud.google.com/blog/topics/threat-intelligence/threat-actor-usage-of-ai-tools
+[^rc-87f3]: Academic researchers, "A Framework for Evaluating Emerging Cyberattack Capabilities of AI," arXiv:2503.11917, April 2025. https://arxiv.org/pdf/2503.11917
+[^rc-9293]: Palo Alto Networks Unit 42, "Can AI Attack the Cloud? Lessons From Building an Autonomous Cloud Offensive Multi-Agent System," April 2026. https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/
+[^rc-bd74]: Atlantic Council (Maia Hamin and Stewart Scott), "Hacking with AI," February 15, 2024; Atlantic Council, "AI in Cyber and Software Security: What's Driving Opportunities and Risks?," March 2025. https://www.atlanticcouncil.org/in-depth-research-reports/report/hacking-with-ai/
+[^rc-78d5]: NIST, "Draft NIST Guidelines Rethink Cybersecurity for the AI Era" (NISTIR 8596 preliminary draft), December 16, 2025. https://www.nist.gov/news-events/news/2025/12/draft-nist-guidelines-rethink-cybersecurity-ai-era
+[^rc-5aee]: CISA and international partners (ASD's ACSC and others), joint cybersecurity guidance for critical infrastructure integrating AI into OT systems, December 4, 2025. https://industrialcyber.co/cisa/global-security-agencies-issue-joint-guidance-to-help-critical-infrastructure-integrate-ai-into-ot-systems/
+[^rc-1ba9]: Institute for AI Policy and Strategy (IAPS), "Accelerating AI Data Center Security," 2025–2026. https://www.iaps.ai/research/accelerating-ai-data-center-security


### PR DESCRIPTION
## Summary
Replaces the `This page is a stub. Content needed.` placeholder on E82 Cyber Offense with a navigational overview page that orients readers and cross-links to its four child pages: E86 Cyberweapons, E87 Autonomous Cyber Attack Timeline, E88 Cyber Offense-Defense Balance Model, and E689 Concentrated Compute as Cybersecurity Risk.

## Why
E82 was a top-level misuse risk page rendering as an empty stub for any reader landing on it from `/risks`. Filling it as a parent overview (rather than duplicating E86's depth) gives readers a place to orient and lets the wiki's other AI cyber pages link here as canonical scope.

## Approach
- Drafted via `pnpm crux w improve E82 --tier=standard --apply`.
- 4 unsupported citations from the LLM draft were either rephrased to match their actual sources (NIST CSF 2.0 framework claim) or removed (HACCA pre-2030 timeline, ENISA severity assessment) per `.claude/rules/page-authoring.md`.
- 1 misattribution fixed (CAIS → CSET — the source is Lohn at Georgetown CSET, not Center for AI Safety).
- 11 of 11 remaining citations verified by the citation audit.

## Test plan
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass
- [x] `pnpm crux w fix escaping` / `fix markdown` — no fixable issues
- [x] All 9 EntityLinks resolve to existing entities (E86, E87, E88, E689, E22, E218, E524, E1041, E1193)
- [ ] Page renders without errors on prod (verify post-deploy)

## Part of QUA-715 epic
Phase 1a of the [Wiki coverage of AI cyber damage magnitude](https://linear.app/quantifieduncertainty/issue/QUA-715) epic.

Fixes QUA-716
