### PR TITLE
QUA-710: /internal/framework-review dashboard (Phase 4-C)

### DIFF
--- a/apps/web/src/app/api/framework-review-proxy/route.ts
+++ b/apps/web/src/app/api/framework-review-proxy/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getWikiServerConfig } from "@lib/wiki-server";
+
+/**
+ * Proxy for /api/framework-review/* (QUA-710 / Phase 4-C).
+ *
+ * The browser doesn't have wiki-server credentials, so the dashboard's
+ * client components POST through this Next.js route, which forwards to
+ * the upstream framework-review endpoints with the server-side API key.
+ *
+ * The `path` query param picks the upstream endpoint. We allow:
+ *
+ *   - GET path=stats|pending-versions|unreviewed-diffs
+ *   - GET path=version/<id> | diff/<id>          (id constrained to a safe set)
+ *   - POST path=threshold/<id>
+ *   - POST path=version/<id>/publish
+ *   - POST path=diff/<id>
+ *
+ * Unknown paths return 400 — the allowlist is the security boundary
+ * (no path-traversal, no hitting other wiki-server routes).
+ */
+
+const ID_RE = /^[A-Za-z0-9_-]{1,200}$/;
+
+type AllowedPath =
+  | { method: "GET"; pattern: "stats" | "pending-versions" | "unreviewed-diffs" }
+  | { method: "GET"; pattern: "version/:id" | "diff/:id"; id: string }
+  | { method: "POST"; pattern: "threshold/:id" | "version/:id/publish" | "diff/:id"; id: string };
+
+function resolvePath(method: "GET" | "POST", raw: string | null): AllowedPath | null {
+  if (!raw) return null;
+
+  if (method === "GET") {
+    if (raw === "stats" || raw === "pending-versions" || raw === "unreviewed-diffs") {
+      return { method: "GET", pattern: raw };
+    }
+    const versionMatch = raw.match(/^version\/([^/]+)$/);
+    if (versionMatch && ID_RE.test(versionMatch[1])) {
+      return { method: "GET", pattern: "version/:id", id: versionMatch[1] };
+    }
+    const diffMatch = raw.match(/^diff\/([^/]+)$/);
+    if (diffMatch && ID_RE.test(diffMatch[1])) {
+      return { method: "GET", pattern: "diff/:id", id: diffMatch[1] };
+    }
+    return null;
+  }
+
+  // POST
+  const thresholdMatch = raw.match(/^threshold\/([^/]+)$/);
+  if (thresholdMatch && ID_RE.test(thresholdMatch[1])) {
+    return { method: "POST", pattern: "threshold/:id", id: thresholdMatch[1] };
+  }
+  const publishMatch = raw.match(/^version\/([^/]+)\/publish$/);
+  if (publishMatch && ID_RE.test(publishMatch[1])) {
+    return { method: "POST", pattern: "version/:id/publish", id: publishMatch[1] };
+  }
+  const diffMatch = raw.match(/^diff\/([^/]+)$/);
+  if (diffMatch && ID_RE.test(diffMatch[1])) {
+    return { method: "POST", pattern: "diff/:id", id: diffMatch[1] };
+  }
+  return null;
+}
+
+function buildUpstreamPath(p: AllowedPath): string {
+  switch (p.pattern) {
+    case "stats":
+    case "pending-versions":
+    case "unreviewed-diffs":
+      return `/api/framework-review/${p.pattern}`;
+    case "version/:id":
+      return `/api/framework-review/version/${encodeURIComponent(p.id)}`;
+    case "diff/:id":
+      return `/api/framework-review/diff/${encodeURIComponent(p.id)}`;
+    case "threshold/:id":
+      return `/api/framework-review/threshold/${encodeURIComponent(p.id)}`;
+    case "version/:id/publish":
+      return `/api/framework-review/version/${encodeURIComponent(p.id)}/publish`;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return forward(request, "GET");
+}
+
+export async function POST(request: NextRequest) {
+  return forward(request, "POST");
+}
+
+async function forward(request: NextRequest, method: "GET" | "POST") {
+  const config = getWikiServerConfig();
+  if (!config) {
+    return NextResponse.json(
+      { error: "not_configured", message: "Wiki server not configured" },
+      { status: 503 },
+    );
+  }
+
+  const allowed = resolvePath(method, request.nextUrl.searchParams.get("path"));
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "validation_error", message: "Invalid or missing path" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const url = `${config.serverUrl}${buildUpstreamPath(allowed)}`;
+    const init: RequestInit = {
+      method,
+      headers: {
+        ...config.headers,
+        ...(method === "POST" ? { "content-type": "application/json" } : {}),
+      },
+      signal: AbortSignal.timeout(15_000),
+    };
+    if (method === "POST") {
+      const body = await request.text();
+      init.body = body;
+    }
+    const res = await fetch(url, init);
+    return new NextResponse(res.body, {
+      status: res.status,
+      headers: { "content-type": res.headers.get("content-type") ?? "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "connection_error",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/internal/framework-review/diff-actions.tsx
+++ b/apps/web/src/app/internal/framework-review/diff-actions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useProxyAction } from "./use-proxy-action";
 
 interface Props {
   diffId: string;
@@ -37,36 +37,19 @@ const VERDICTS = [
  * not just what.
  */
 export function DiffActions({ diffId, currentVerdict }: Props) {
-  const router = useRouter();
-  const [pending, startTransition] = useTransition();
+  const { pending, error, submit } = useProxyAction();
   const [pickedVerdict, setPickedVerdict] = useState<string | null>(null);
   const [notes, setNotes] = useState("");
-  const [error, setError] = useState<string | null>(null);
 
   function callProxy(verdict: string) {
-    setError(null);
-    startTransition(async () => {
-      try {
-        const res = await fetch(
-          `/api/framework-review-proxy?path=diff/${encodeURIComponent(diffId)}`,
-          {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ verdict, notes: notes || null }),
-          },
-        );
-        if (!res.ok) {
-          const errBody: { message?: string } = await res.json().catch(() => ({}));
-          setError(errBody.message ?? `Request failed (${res.status})`);
-          return;
-        }
+    submit(
+      `diff/${encodeURIComponent(diffId)}`,
+      { verdict, notes: notes || null },
+      () => {
         setPickedVerdict(null);
         setNotes("");
-        router.refresh();
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      }
-    });
+      },
+    );
   }
 
   return (

--- a/apps/web/src/app/internal/framework-review/diff-actions.tsx
+++ b/apps/web/src/app/internal/framework-review/diff-actions.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  diffId: string;
+  currentVerdict: string;
+}
+
+const VERDICTS = [
+  {
+    value: "confirmed_weakening",
+    label: "Confirm weakening",
+    color: "bg-red-600 hover:bg-red-700",
+  },
+  {
+    value: "confirmed_strengthening",
+    label: "Confirm strengthening",
+    color: "bg-emerald-600 hover:bg-emerald-700",
+  },
+  {
+    value: "false_positive",
+    label: "False positive",
+    color: "bg-slate-600 hover:bg-slate-700",
+  },
+  {
+    value: "nuanced",
+    label: "Nuanced",
+    color: "bg-amber-600 hover:bg-amber-700",
+  },
+] as const;
+
+/**
+ * Per-diff verdict picker (QUA-710). Forces a free-text rationale for
+ * weakening/strengthening confirmations so the audit trail captures why,
+ * not just what.
+ */
+export function DiffActions({ diffId, currentVerdict }: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [pickedVerdict, setPickedVerdict] = useState<string | null>(null);
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function callProxy(verdict: string) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/framework-review-proxy?path=diff/${encodeURIComponent(diffId)}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ verdict, notes: notes || null }),
+          },
+        );
+        if (!res.ok) {
+          const errBody: { message?: string } = await res.json().catch(() => ({}));
+          setError(errBody.message ?? `Request failed (${res.status})`);
+          return;
+        }
+        setPickedVerdict(null);
+        setNotes("");
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return (
+    <div className="border border-border/60 rounded p-3">
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span className="text-xs font-mono px-2 py-0.5 rounded bg-muted text-muted-foreground">
+          {currentVerdict}
+        </span>
+        {pickedVerdict === null &&
+          VERDICTS.map((v) => (
+            <button
+              key={v.value}
+              type="button"
+              disabled={pending}
+              className={`text-xs px-2 py-1 rounded text-white disabled:opacity-50 ${v.color}`}
+              onClick={() => setPickedVerdict(v.value)}
+            >
+              {v.label}
+            </button>
+          ))}
+      </div>
+
+      {pickedVerdict !== null && (
+        <div className="mt-2 space-y-2">
+          <p className="text-xs text-muted-foreground">
+            Selected: <span className="font-mono">{pickedVerdict}</span>
+          </p>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            placeholder="Reviewer rationale (recommended for weakening/strengthening verdicts)"
+            className="w-full text-sm rounded border border-border/60 p-2"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-foreground text-background hover:opacity-90 disabled:opacity-50"
+              onClick={() => callProxy(pickedVerdict)}
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-muted hover:bg-muted/80 disabled:opacity-50"
+              onClick={() => {
+                setPickedVerdict(null);
+                setNotes("");
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-red-600 mt-2">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/framework-review/diff/[id]/page.tsx
+++ b/apps/web/src/app/internal/framework-review/diff/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { DiffReviewContent } from "../../framework-review-content";
+
+export const dynamic = "force-dynamic";
+
+export default async function DiffReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <DiffReviewContent diffId={id} />;
+}

--- a/apps/web/src/app/internal/framework-review/framework-review-content.tsx
+++ b/apps/web/src/app/internal/framework-review/framework-review-content.tsx
@@ -1,0 +1,598 @@
+/**
+ * Framework Review dashboard — Phase 4-C of QUA-706 (QUA-710).
+ *
+ * Admin-only dashboard for human-in-the-loop review of frontier-safety
+ * framework ingest. Two queues: pending versions (for threshold-by-
+ * threshold approval before publish) and unreviewed diffs (for
+ * weakening/strengthening verdicts). Both queues drive directly off
+ * `safety_framework_versions.ingest_status` and
+ * `framework_diffs.review_verdict` so they go to zero as the reviewer
+ * works through them.
+ *
+ * Routing:
+ *   /wiki/E2505                                  → overview (this file's
+ *                                                  exported FrameworkReviewContent)
+ *   /internal/framework-review/version/[id]      → VersionReviewContent
+ *   /internal/framework-review/diff/[id]         → DiffReviewContent
+ *
+ * `/wiki/E<id>` is statically generated — searchParams don't reach it,
+ * so drill-downs live as separate dynamic routes rather than query
+ * params on the overview page.
+ */
+
+import {
+  fetchDetailed,
+  type FetchResult,
+  type ApiErrorReason,
+} from "@lib/wiki-server";
+import type {
+  RpcFrameworkReviewStatsResult,
+  RpcFrameworkReviewPendingVersionsResult,
+  RpcFrameworkReviewUnreviewedDiffsResult,
+  RpcFrameworkReviewVersionResult,
+  RpcFrameworkReviewDiffResult,
+} from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { ThresholdActions } from "./threshold-actions";
+import { DiffActions } from "./diff-actions";
+import { PublishButton } from "./publish-button";
+
+const OVERVIEW_HREF = "/wiki/E2505";
+const VERSION_HREF = "/internal/framework-review/version";
+const DIFF_HREF = "/internal/framework-review/diff";
+
+// ─── Overview (used by the wiki page MDX) ────────────────────────────────
+
+export async function FrameworkReviewContent() {
+  const [statsResult, versionsResult, diffsResult] = await Promise.all([
+    fetchDetailed<RpcFrameworkReviewStatsResult>(
+      "/api/framework-review/stats",
+      { revalidate: 0 },
+    ),
+    fetchDetailed<RpcFrameworkReviewPendingVersionsResult>(
+      "/api/framework-review/pending-versions",
+      { revalidate: 0 },
+    ),
+    fetchDetailed<RpcFrameworkReviewUnreviewedDiffsResult>(
+      "/api/framework-review/unreviewed-diffs",
+      { revalidate: 0 },
+    ),
+  ]);
+
+  const apiUnavailable =
+    !statsResult.ok || !versionsResult.ok || !diffsResult.ok;
+  const apiError = firstError(statsResult, versionsResult, diffsResult);
+  const stats = statsResult.ok
+    ? statsResult.data
+    : {
+        pendingVersions: 0,
+        publishedVersions: 0,
+        rejectedVersions: 0,
+        unreviewedDiffs: 0,
+        confirmedWeakenings: 0,
+        falsePositives: 0,
+      };
+  const versions = versionsResult.ok ? versionsResult.data.versions : [];
+  const diffs = diffsResult.ok ? diffsResult.data.diffs : [];
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Human-in-the-loop review queue for the frontier-safety framework
+        tracker (QUA-691). Each pending version needs every extracted threshold
+        approved (or skipped) before publish; each unreviewed diff needs a
+        verdict before its weakening flag can surface on the public site.
+      </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 my-6">
+        <StatCard label="Pending versions" value={stats.pendingVersions} />
+        <StatCard label="Published versions" value={stats.publishedVersions} />
+        <StatCard label="Rejected versions" value={stats.rejectedVersions} />
+        <StatCard label="Unreviewed diffs" value={stats.unreviewedDiffs} />
+        <StatCard
+          label="Confirmed weakenings"
+          value={stats.confirmedWeakenings}
+        />
+        <StatCard label="False positives" value={stats.falsePositives} />
+      </div>
+
+      {apiUnavailable && (
+        <div className="rounded border border-amber-300 bg-amber-50 p-3 my-6">
+          <p className="text-sm text-amber-900 font-medium">
+            Wiki-server unavailable — review actions cannot be taken until it
+            comes back online.
+          </p>
+        </div>
+      )}
+
+      <h2 className="text-lg font-semibold mt-8 mb-3">
+        Pending versions ({versions.length})
+      </h2>
+      {versions.length === 0 ? (
+        <EmptyHint label="No versions waiting for review." />
+      ) : (
+        <ul className="space-y-2">
+          {versions.map((v) => (
+            <li
+              key={v.id}
+              className="border border-border/60 rounded p-3 hover:border-border transition"
+            >
+              <a
+                href={`${VERSION_HREF}/${encodeURIComponent(v.id)}`}
+                className="block"
+              >
+                <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                  <p className="font-medium">
+                    {v.frameworkShortName ?? v.frameworkName ?? v.frameworkId}
+                    {" — "}
+                    <span className="font-mono text-sm">{v.versionLabel}</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground tabular-nums">
+                    {v.thresholdsReviewed}/{v.thresholdCount} thresholds reviewed
+                  </p>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {v.orgDisplayName ?? "—"} · discovered {v.discoveredDate}
+                  {v.publishedDate ? ` · published ${v.publishedDate}` : ""}
+                </p>
+                {v.summary && (
+                  <p className="text-sm mt-2 text-muted-foreground line-clamp-2">
+                    {v.summary}
+                  </p>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <h2 className="text-lg font-semibold mt-8 mb-3">
+        Unreviewed diffs ({diffs.length})
+      </h2>
+      {diffs.length === 0 ? (
+        <EmptyHint label="No diffs waiting for verdict." />
+      ) : (
+        <ul className="space-y-2">
+          {diffs.map((d) => (
+            <li
+              key={d.id}
+              className="border border-border/60 rounded p-3 hover:border-border transition"
+            >
+              <a
+                href={`${DIFF_HREF}/${encodeURIComponent(d.id)}`}
+                className="block"
+              >
+                <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                  <p className="font-medium">
+                    {d.framework?.shortName ??
+                      d.framework?.name ??
+                      "Unknown framework"}
+                    {": "}
+                    <span className="font-mono text-sm">
+                      {d.fromVersion?.versionLabel ?? d.fromVersionId} →{" "}
+                      {d.toVersion?.versionLabel ?? d.toVersionId}
+                    </span>
+                  </p>
+                  <div className="flex gap-2 text-xs">
+                    {d.weakeningFlagged && (
+                      <span className="px-2 py-0.5 rounded bg-red-100 text-red-700 font-mono">
+                        weakening flagged
+                      </span>
+                    )}
+                    {d.strengtheningFlagged && (
+                      <span className="px-2 py-0.5 rounded bg-emerald-100 text-emerald-700 font-mono">
+                        strengthening flagged
+                      </span>
+                    )}
+                    {d.overallDirection && (
+                      <span className="px-2 py-0.5 rounded bg-muted font-mono">
+                        {d.overallDirection}
+                      </span>
+                    )}
+                    <span className="px-2 py-0.5 rounded bg-muted font-mono">
+                      {d.itemCount} items
+                    </span>
+                  </div>
+                </div>
+                <p className="text-sm mt-2 text-muted-foreground line-clamp-2">
+                  {d.changeSummary}
+                </p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <DataSourceBanner
+        source={apiUnavailable ? "local" : "api"}
+        apiError={apiError}
+      />
+    </>
+  );
+}
+
+// ─── Per-version review screen ───────────────────────────────────────────
+
+export async function VersionReviewContent({
+  versionId,
+}: {
+  versionId: string;
+}) {
+  const result = await fetchDetailed<RpcFrameworkReviewVersionResult>(
+    `/api/framework-review/version/${encodeURIComponent(versionId)}`,
+    { revalidate: 0 },
+  );
+
+  if (!result.ok) {
+    return (
+      <ErrorView
+        backHref={OVERVIEW_HREF}
+        title="Failed to load version"
+        error={result.error}
+      />
+    );
+  }
+
+  const { version, framework, thresholds } = result.data;
+  const reviewedCount = thresholds.filter((t) => t.humanReviewed).length;
+  const ready = thresholds.length > 0 && reviewedCount === thresholds.length;
+  const ingestStatus =
+    typeof version.ingestStatus === "string"
+      ? version.ingestStatus
+      : "unknown";
+
+  return (
+    <main className="container mx-auto max-w-4xl px-4 py-6">
+      <p>
+        <a
+          href={OVERVIEW_HREF}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          ← Back to review queue
+        </a>
+      </p>
+
+      <h1 className="text-xl font-semibold mt-4">
+        {framework?.shortName ?? framework?.name ?? "Unknown framework"} —{" "}
+        <span className="font-mono">{version.versionLabel}</span>
+      </h1>
+      <p className="text-sm text-muted-foreground mt-1">
+        {framework?.orgDisplayName ?? "—"}
+        {" · "}
+        ingestStatus:{" "}
+        <span className="font-mono">{ingestStatus}</span>
+        {version.publishedDate ? ` · published ${version.publishedDate}` : ""}
+        {version.discoveredDate
+          ? ` · discovered ${version.discoveredDate}`
+          : ""}
+      </p>
+
+      {version.summary && (
+        <p className="text-sm mt-3 leading-relaxed">{version.summary}</p>
+      )}
+
+      <div className="flex flex-wrap gap-3 mt-3 text-sm">
+        {version.sourceUrl && (
+          <a
+            href={version.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Source ↗
+          </a>
+        )}
+        {version.waybackSnapshotUrl && (
+          <a
+            href={version.waybackSnapshotUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Wayback snapshot ↗
+          </a>
+        )}
+        {version.pdfArchiveUrl && (
+          <a
+            href={version.pdfArchiveUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            Archived PDF ↗
+          </a>
+        )}
+      </div>
+
+      {ingestStatus === "pending_review" && (
+        <div className="mt-6 border-t pt-4">
+          <PublishButton
+            versionId={versionId}
+            ready={ready}
+            thresholdCount={thresholds.length}
+            thresholdsReviewed={reviewedCount}
+          />
+        </div>
+      )}
+
+      <h2 className="text-lg font-semibold mt-8 mb-3">
+        Thresholds ({thresholds.length})
+      </h2>
+      {thresholds.length === 0 ? (
+        <EmptyHint label="No thresholds extracted from this version. The extraction may have failed; reject the version or re-run extraction." />
+      ) : (
+        <ul className="space-y-4">
+          {thresholds.map((t) => (
+            <li key={t.id} className="border border-border/60 rounded p-4">
+              <div className="flex items-baseline justify-between gap-3 flex-wrap mb-2">
+                <p className="font-medium">
+                  <span className="text-xs px-2 py-0.5 rounded bg-muted font-mono mr-2">
+                    {t.tierLabel}
+                  </span>
+                  {t.riskDomainLabel}{" "}
+                  <span className="text-xs text-muted-foreground font-mono">
+                    ({t.riskDomainCanonical})
+                  </span>
+                </p>
+                {t.commitmentLanguage && (
+                  <span className="text-xs px-2 py-0.5 rounded bg-muted font-mono">
+                    {t.commitmentLanguage}
+                  </span>
+                )}
+              </div>
+
+              <p className="text-sm leading-relaxed mt-2">
+                <span className="font-medium text-xs uppercase tracking-wide text-muted-foreground">
+                  Trigger:{" "}
+                </span>
+                {t.triggerDescription}
+              </p>
+
+              <blockquote className="border-l-2 border-border/60 pl-3 mt-3 text-sm italic text-muted-foreground">
+                <span className="font-medium not-italic text-xs uppercase tracking-wide text-foreground">
+                  Source quote
+                  {t.sourcePageHint ? ` (${t.sourcePageHint})` : ""}:
+                </span>{" "}
+                “{t.sourceQuote}”
+              </blockquote>
+
+              <div className="mt-3">
+                <ThresholdActions
+                  thresholdId={t.id}
+                  currentVerdict={t.reviewVerdict}
+                  currentNotes={t.reviewNotes}
+                  fields={{
+                    triggerDescription: t.triggerDescription,
+                    sourceQuote: t.sourceQuote,
+                    sourcePageHint: t.sourcePageHint,
+                    tierLabel: t.tierLabel,
+                    riskDomainLabel: t.riskDomainLabel,
+                  }}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+// ─── Per-diff review screen ──────────────────────────────────────────────
+
+export async function DiffReviewContent({ diffId }: { diffId: string }) {
+  const result = await fetchDetailed<RpcFrameworkReviewDiffResult>(
+    `/api/framework-review/diff/${encodeURIComponent(diffId)}`,
+    { revalidate: 0 },
+  );
+
+  if (!result.ok) {
+    return (
+      <ErrorView
+        backHref={OVERVIEW_HREF}
+        title="Failed to load diff"
+        error={result.error}
+      />
+    );
+  }
+
+  const { diff, items, fromVersion, toVersion, framework } = result.data;
+  const verdict =
+    typeof diff.reviewVerdict === "string" ? diff.reviewVerdict : "unreviewed";
+
+  return (
+    <main className="container mx-auto max-w-4xl px-4 py-6">
+      <p>
+        <a
+          href={OVERVIEW_HREF}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          ← Back to review queue
+        </a>
+      </p>
+
+      <h1 className="text-xl font-semibold mt-4">
+        {framework?.shortName ?? framework?.name ?? "Unknown framework"}:{" "}
+        <span className="font-mono">
+          {fromVersion?.versionLabel ?? diff.fromVersionId} →{" "}
+          {toVersion?.versionLabel ?? diff.toVersionId}
+        </span>
+      </h1>
+      <p className="text-sm text-muted-foreground mt-1">
+        {framework?.orgDisplayName ?? "—"}
+        {" · "}
+        verdict: <span className="font-mono">{verdict}</span>
+        {diff.classifiedByModel
+          ? ` · classified by ${diff.classifiedByModel}`
+          : ""}
+      </p>
+
+      <p className="text-sm mt-3 leading-relaxed">{diff.changeSummary}</p>
+
+      <div className="flex flex-wrap gap-3 mt-3 text-sm">
+        {fromVersion?.sourceUrl && (
+          <a
+            href={fromVersion.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            From source ↗
+          </a>
+        )}
+        {toVersion?.sourceUrl && (
+          <a
+            href={toVersion.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            To source ↗
+          </a>
+        )}
+      </div>
+
+      <div className="mt-6">
+        <DiffActions diffId={diffId} currentVerdict={verdict} />
+      </div>
+
+      <h2 className="text-lg font-semibold mt-8 mb-3">
+        Change items ({items.length})
+      </h2>
+      {items.length === 0 ? (
+        <EmptyHint label="No atomic items recorded for this diff." />
+      ) : (
+        <ul className="space-y-4">
+          {items.map((item) => (
+            <li key={item.id} className="border border-border/60 rounded p-4">
+              <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                <p className="font-medium">
+                  <span className="text-xs px-2 py-0.5 rounded bg-muted font-mono mr-2">
+                    {item.changeType}
+                  </span>
+                  {item.riskDomainCanonical && (
+                    <span className="text-xs text-muted-foreground font-mono">
+                      {item.riskDomainCanonical}
+                    </span>
+                  )}
+                </p>
+                {item.classifierTag && (
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded font-mono ${classifierColor(item.classifierTag)}`}
+                  >
+                    {item.classifierTag}
+                  </span>
+                )}
+              </div>
+
+              {item.rationale && (
+                <p className="text-sm mt-2 text-muted-foreground">
+                  {item.rationale}
+                </p>
+              )}
+
+              <div className="grid md:grid-cols-2 gap-3 mt-3">
+                <div className="border border-border/60 rounded p-2 bg-muted/30">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+                    Before
+                  </p>
+                  <pre className="text-xs whitespace-pre-wrap break-words">
+                    {item.beforeSnapshot
+                      ? JSON.stringify(item.beforeSnapshot, null, 2)
+                      : "—"}
+                  </pre>
+                </div>
+                <div className="border border-border/60 rounded p-2 bg-muted/30">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+                    After
+                  </p>
+                  <pre className="text-xs whitespace-pre-wrap break-words">
+                    {item.afterSnapshot
+                      ? JSON.stringify(item.afterSnapshot, null, 2)
+                      : "—"}
+                  </pre>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function EmptyHint({ label }: { label: string }) {
+  return (
+    <div className="rounded border border-border/60 bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+      {label}
+    </div>
+  );
+}
+
+function classifierColor(tag: string): string {
+  switch (tag) {
+    case "weaker":
+      return "bg-red-100 text-red-700";
+    case "stronger":
+      return "bg-emerald-100 text-emerald-700";
+    case "rewrite_equivalent":
+    case "clarification":
+      return "bg-slate-200 text-slate-700";
+    case "scope_narrowed":
+      return "bg-amber-100 text-amber-700";
+    case "scope_broadened":
+      return "bg-blue-100 text-blue-700";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+function ErrorView({
+  backHref,
+  title,
+  error,
+}: {
+  backHref: string;
+  title: string;
+  error: ApiErrorReason;
+}) {
+  return (
+    <main className="container mx-auto max-w-4xl px-4 py-6">
+      <p>
+        <a href={backHref} className="text-sm text-blue-600 hover:underline">
+          ← Back
+        </a>
+      </p>
+      <div className="mt-4 rounded border border-red-300 bg-red-50 p-4">
+        <p className="font-medium text-red-700">{title}</p>
+        <p className="text-sm text-red-700 mt-1">{describeError(error)}</p>
+      </div>
+    </main>
+  );
+}
+
+function describeError(error: ApiErrorReason): string {
+  if (error.type === "not-configured") return "Wiki server is not configured.";
+  if (error.type === "connection-error") return error.message;
+  return `Server returned ${error.status} ${error.statusText}`;
+}
+
+function firstError<T1, T2, T3>(
+  ...results: [FetchResult<T1>, FetchResult<T2>, FetchResult<T3>]
+): ApiErrorReason | undefined {
+  for (const r of results) {
+    if (!r.ok) return r.error;
+  }
+  return undefined;
+}

--- a/apps/web/src/app/internal/framework-review/page.tsx
+++ b/apps/web/src/app/internal/framework-review/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function FrameworkReviewPage() {
+  redirect("/wiki/E2505");
+}

--- a/apps/web/src/app/internal/framework-review/publish-button.tsx
+++ b/apps/web/src/app/internal/framework-review/publish-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useProxyAction } from "./use-proxy-action";
 
 interface Props {
   versionId: string;
@@ -30,36 +31,22 @@ export function PublishButton({
   thresholdCount,
 }: Props) {
   const router = useRouter();
-  const [pending, startTransition] = useTransition();
+  const { pending, error, submit } = useProxyAction();
   const [mode, setMode] = useState<"idle" | "rejecting">("idle");
   const [notes, setNotes] = useState("");
-  const [error, setError] = useState<string | null>(null);
 
   function publish(verdict: "published" | "rejected") {
-    setError(null);
-    startTransition(async () => {
-      try {
-        const res = await fetch(
-          `/api/framework-review-proxy?path=version/${encodeURIComponent(versionId)}/publish`,
-          {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ verdict, notes: notes || null }),
-          },
-        );
-        if (!res.ok) {
-          const errBody: { message?: string } = await res.json().catch(() => ({}));
-          setError(errBody.message ?? `Request failed (${res.status})`);
-          return;
-        }
+    submit(
+      `version/${encodeURIComponent(versionId)}/publish`,
+      { verdict, notes: notes || null },
+      () => {
         setMode("idle");
         setNotes("");
-        router.refresh();
+        // Navigate back to the queue overview after a successful action.
+        // useProxyAction has already called router.refresh().
         router.push("/wiki/E2505");
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      }
-    });
+      },
+    );
   }
 
   if (mode === "rejecting") {

--- a/apps/web/src/app/internal/framework-review/publish-button.tsx
+++ b/apps/web/src/app/internal/framework-review/publish-button.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  versionId: string;
+  /** Disabled when not every threshold is reviewed. */
+  ready: boolean;
+  thresholdsReviewed: number;
+  thresholdCount: number;
+}
+
+/**
+ * Publish-or-reject action for one pending framework version (QUA-710).
+ *
+ * The "Publish" path is gated client-side on the `ready` prop; the
+ * server-side check in `/api/framework-review/version/:id/publish` is
+ * authoritative — the disabled state is just UX (so reviewers can see
+ * why the button is dim before clicking it).
+ *
+ * The "Reject" path is always available and prompts for a reason —
+ * rejecting a whole version is a destructive call so we want a paper
+ * trail.
+ */
+export function PublishButton({
+  versionId,
+  ready,
+  thresholdsReviewed,
+  thresholdCount,
+}: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [mode, setMode] = useState<"idle" | "rejecting">("idle");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  function publish(verdict: "published" | "rejected") {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/framework-review-proxy?path=version/${encodeURIComponent(versionId)}/publish`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ verdict, notes: notes || null }),
+          },
+        );
+        if (!res.ok) {
+          const errBody: { message?: string } = await res.json().catch(() => ({}));
+          setError(errBody.message ?? `Request failed (${res.status})`);
+          return;
+        }
+        setMode("idle");
+        setNotes("");
+        router.refresh();
+        router.push("/wiki/E2505");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  if (mode === "rejecting") {
+    return (
+      <div className="space-y-2 border border-red-300 rounded p-3 bg-red-50">
+        <p className="text-sm font-medium text-red-700">
+          Reject this whole version? This marks the version as not-publishable —
+          its thresholds will not appear on the public site.
+        </p>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          placeholder="Reason (e.g. wrong document, draft never published, paywalled)"
+          className="w-full text-sm rounded border border-red-300 p-2 bg-white"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={pending}
+            className="text-sm px-3 py-1 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+            onClick={() => publish("rejected")}
+          >
+            Confirm reject
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            className="text-sm px-3 py-1 rounded bg-muted hover:bg-muted/80 disabled:opacity-50"
+            onClick={() => {
+              setMode("idle");
+              setNotes("");
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+        {error && <p className="text-xs text-red-700">{error}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        disabled={!ready || pending}
+        className="text-sm px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+        onClick={() => publish("published")}
+      >
+        Publish version
+      </button>
+      <button
+        type="button"
+        disabled={pending}
+        className="text-sm px-4 py-2 rounded border border-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
+        onClick={() => setMode("rejecting")}
+      >
+        Reject version
+      </button>
+      <p className="text-xs text-muted-foreground">
+        {thresholdsReviewed}/{thresholdCount} thresholds reviewed
+        {!ready && (thresholdCount > 0 ? " — review remaining first" : " — extraction has zero thresholds; reject or re-extract")}
+      </p>
+      {error && <p className="text-xs text-red-700 w-full">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/app/internal/framework-review/threshold-actions.tsx
+++ b/apps/web/src/app/internal/framework-review/threshold-actions.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  thresholdId: string;
+  currentVerdict: "approved" | "rejected" | "skip" | "edited" | null;
+  currentNotes: string | null;
+  fields: {
+    triggerDescription: string;
+    sourceQuote: string;
+    sourcePageHint: string | null;
+    tierLabel: string;
+    riskDomainLabel: string;
+  };
+}
+
+type Mode = "idle" | "rejecting" | "skipping" | "editing";
+
+/**
+ * One-click action row for a single capability threshold (QUA-710).
+ *
+ * Approve has no follow-up modal; reject/skip take a free-text reason;
+ * edit lets the reviewer rewrite the trigger description and source
+ * quote (the two fields most likely to need cleanup post-extraction).
+ *
+ * Posts to /api/framework-review-proxy?path=threshold/<id> with a
+ * verdict + optional notes/edits. On success the page is refreshed
+ * server-side via `router.refresh()` so the new verdict + threshold-
+ * count flows back into the publish gate.
+ */
+export function ThresholdActions({
+  thresholdId,
+  currentVerdict,
+  currentNotes,
+  fields,
+}: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [mode, setMode] = useState<Mode>("idle");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [edits, setEdits] = useState({
+    triggerDescription: fields.triggerDescription,
+    sourceQuote: fields.sourceQuote,
+  });
+
+  function callProxy(verdict: string, body: Record<string, unknown>) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/framework-review-proxy?path=threshold/${encodeURIComponent(thresholdId)}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ verdict, ...body }),
+          },
+        );
+        if (!res.ok) {
+          const errBody: { message?: string } = await res.json().catch(() => ({}));
+          setError(errBody.message ?? `Request failed (${res.status})`);
+          return;
+        }
+        setMode("idle");
+        setNotes("");
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return (
+    <div className="border border-border/60 rounded p-3">
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        {currentVerdict ? (
+          <span
+            className={`text-xs font-mono px-2 py-0.5 rounded ${verdictColor(currentVerdict)}`}
+            title={currentNotes ?? undefined}
+          >
+            {currentVerdict}
+          </span>
+        ) : (
+          <span className="text-xs font-mono px-2 py-0.5 rounded bg-muted text-muted-foreground">
+            unreviewed
+          </span>
+        )}
+
+        {mode === "idle" && (
+          <>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-2 py-1 rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
+              onClick={() => callProxy("approved", {})}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-2 py-1 rounded bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50"
+              onClick={() => setMode("editing")}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-2 py-1 rounded bg-slate-600 text-white hover:bg-slate-700 disabled:opacity-50"
+              onClick={() => setMode("skipping")}
+            >
+              Skip
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+              onClick={() => setMode("rejecting")}
+            >
+              Reject
+            </button>
+          </>
+        )}
+      </div>
+
+      {(mode === "rejecting" || mode === "skipping") && (
+        <div className="mt-2 space-y-2">
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder={
+              mode === "rejecting"
+                ? "Why is this threshold not a real commitment? (e.g. was a footnote, illustrative example, etc.)"
+                : "Why skip? (e.g. duplicate of an earlier tier, scope outside frontier safety)"
+            }
+            rows={3}
+            maxLength={2000}
+            className="w-full text-sm rounded border border-border/60 p-2"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-foreground text-background hover:opacity-90 disabled:opacity-50"
+              onClick={() => callProxy(mode === "rejecting" ? "rejected" : "skip", { notes })}
+            >
+              Confirm {mode === "rejecting" ? "reject" : "skip"}
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-muted hover:bg-muted/80 disabled:opacity-50"
+              onClick={() => {
+                setMode("idle");
+                setNotes("");
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mode === "editing" && (
+        <div className="mt-2 space-y-2">
+          <label className="block text-xs font-medium">
+            Trigger description
+            <textarea
+              value={edits.triggerDescription}
+              onChange={(e) =>
+                setEdits((prev) => ({ ...prev, triggerDescription: e.target.value }))
+              }
+              rows={3}
+              maxLength={5000}
+              className="w-full text-sm rounded border border-border/60 p-2 mt-1"
+            />
+          </label>
+          <label className="block text-xs font-medium">
+            Source quote
+            <textarea
+              value={edits.sourceQuote}
+              onChange={(e) =>
+                setEdits((prev) => ({ ...prev, sourceQuote: e.target.value }))
+              }
+              rows={3}
+              maxLength={5000}
+              className="w-full text-sm rounded border border-border/60 p-2 mt-1"
+            />
+          </label>
+          <label className="block text-xs font-medium">
+            Reviewer notes (optional)
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              maxLength={2000}
+              className="w-full text-sm rounded border border-border/60 p-2 mt-1"
+              placeholder="Why was the edit needed?"
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-foreground text-background hover:opacity-90 disabled:opacity-50"
+              onClick={() =>
+                callProxy("edited", {
+                  notes,
+                  edits: {
+                    triggerDescription: edits.triggerDescription,
+                    sourceQuote: edits.sourceQuote,
+                  },
+                })
+              }
+            >
+              Save edits + approve
+            </button>
+            <button
+              type="button"
+              disabled={pending}
+              className="text-xs px-3 py-1 rounded bg-muted hover:bg-muted/80 disabled:opacity-50"
+              onClick={() => {
+                setMode("idle");
+                setEdits({
+                  triggerDescription: fields.triggerDescription,
+                  sourceQuote: fields.sourceQuote,
+                });
+                setNotes("");
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-red-600 mt-2">{error}</p>}
+    </div>
+  );
+}
+
+function verdictColor(v: "approved" | "rejected" | "skip" | "edited"): string {
+  switch (v) {
+    case "approved":
+      return "bg-emerald-100 text-emerald-700";
+    case "rejected":
+      return "bg-red-100 text-red-700";
+    case "skip":
+      return "bg-slate-200 text-slate-700";
+    case "edited":
+      return "bg-amber-100 text-amber-700";
+  }
+}

--- a/apps/web/src/app/internal/framework-review/threshold-actions.tsx
+++ b/apps/web/src/app/internal/framework-review/threshold-actions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useProxyAction } from "./use-proxy-action";
 
 interface Props {
   thresholdId: string;
@@ -36,40 +36,23 @@ export function ThresholdActions({
   currentNotes,
   fields,
 }: Props) {
-  const router = useRouter();
-  const [pending, startTransition] = useTransition();
+  const { pending, error, submit } = useProxyAction();
   const [mode, setMode] = useState<Mode>("idle");
   const [notes, setNotes] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [edits, setEdits] = useState({
     triggerDescription: fields.triggerDescription,
     sourceQuote: fields.sourceQuote,
   });
 
   function callProxy(verdict: string, body: Record<string, unknown>) {
-    setError(null);
-    startTransition(async () => {
-      try {
-        const res = await fetch(
-          `/api/framework-review-proxy?path=threshold/${encodeURIComponent(thresholdId)}`,
-          {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ verdict, ...body }),
-          },
-        );
-        if (!res.ok) {
-          const errBody: { message?: string } = await res.json().catch(() => ({}));
-          setError(errBody.message ?? `Request failed (${res.status})`);
-          return;
-        }
+    submit(
+      `threshold/${encodeURIComponent(thresholdId)}`,
+      { verdict, ...body },
+      () => {
         setMode("idle");
         setNotes("");
-        router.refresh();
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      }
-    });
+      },
+    );
   }
 
   return (

--- a/apps/web/src/app/internal/framework-review/use-proxy-action.ts
+++ b/apps/web/src/app/internal/framework-review/use-proxy-action.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Shared submit-and-refresh helper for the framework-review action panels.
+ *
+ * Three client islands (threshold-actions, diff-actions, publish-button)
+ * share an identical shape: POST to /api/framework-review-proxy with a
+ * path + JSON body, surface server errors, then router.refresh() on
+ * success. This hook centralizes the fetch + error parsing + transition
+ * wrapping so each island only writes its own UI.
+ *
+ * `error` is null after a successful submit — clearing it on retry is
+ * the consumer's responsibility (just call submit() again).
+ */
+export function useProxyAction() {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function submit(
+    path: string,
+    body: Record<string, unknown>,
+    onSuccess?: () => void,
+  ) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(
+          `/api/framework-review-proxy?path=${encodeURIComponent(path)}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(body),
+          },
+        );
+        if (!res.ok) {
+          const errBody: { message?: string } = await res
+            .json()
+            .catch(() => ({}));
+          setError(errBody.message ?? `Request failed (${res.status})`);
+          return;
+        }
+        onSuccess?.();
+        router.refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return { pending, error, submit };
+}

--- a/apps/web/src/app/internal/framework-review/version/[id]/page.tsx
+++ b/apps/web/src/app/internal/framework-review/version/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { VersionReviewContent } from "../../framework-review-content";
+
+export const dynamic = "force-dynamic";
+
+export default async function VersionReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <VersionReviewContent versionId={id} />;
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -85,6 +85,7 @@ import { ResourcePipelineDashboardContent } from "@/app/internal/resource-pipeli
 import { DataSourcesContent } from "@/app/data-sources/data-sources-content";
 import { TablebaseCoverageContent } from "@/app/internal/tablebase-coverage/tablebase-coverage-content";
 import { AutomationLandscapeContent } from "@/app/internal/automation-landscape/automation-landscape-content";
+import { FrameworkReviewContent } from "@/app/internal/framework-review/framework-review-content";
 
 // Ported stub components — high priority
 import { Section } from "@/components/wiki/Section";
@@ -252,6 +253,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   DataSourcesContent,
   TablebaseCoverageContent,
   AutomationLandscapeContent,
+  FrameworkReviewContent,
 
   // Table view components
   SafetyApproachesTableView,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -288,6 +288,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Talent Flows", href: internalHref("talent-flows-dashboard") },
         { label: "Jobs", href: internalHref("jobs-dashboard") },
         { label: "System Cards", href: internalHref("system-cards-dashboard") },
+        { label: "Framework Review", href: internalHref("framework-review-dashboard") },
         { label: "Coverage", href: internalHref("tablebase-coverage-dashboard") },
       ],
     },

--- a/apps/web/src/lib/wiki-server.ts
+++ b/apps/web/src/lib/wiki-server.ts
@@ -211,6 +211,7 @@ import type { PoliticalOfficesRoute } from "@wiki-server/political-offices-route
 import type { PoliticalVotesRoute } from "@wiki-server/political-votes-route";
 import type { CampaignFinanceRoute } from "@wiki-server/campaign-finance-route";
 import type { ModelSystemCardsRoute } from "@wiki-server/model-system-cards-route";
+import type { FrameworkReviewRoute } from "@wiki-server/framework-review-route";
 
 /**
  * Create a typed Hono RPC client for the facts API.
@@ -624,4 +625,52 @@ export type RpcModelSystemCardRow = RpcModelSystemCardsAllResult['items'][number
 
 /** Inferred response type for GET /api/model-system-cards/by-model/:modelId */
 export type RpcModelSystemCardsByModelResult = InferResponseType<ModelSystemCardsClient['by-model'][':modelId']['$get'], 200>;
+
+// ============================================================================
+// Hono RPC client — Framework Review API (QUA-710)
+// ============================================================================
+
+type FrameworkReviewClient = ReturnType<typeof hc<FrameworkReviewRoute>>;
+
+/** Inferred response type for GET /api/framework-review/stats */
+export type RpcFrameworkReviewStatsResult = InferResponseType<
+  FrameworkReviewClient['stats']['$get'],
+  200
+>;
+
+/** Inferred response type for GET /api/framework-review/pending-versions */
+export type RpcFrameworkReviewPendingVersionsResult = InferResponseType<
+  FrameworkReviewClient['pending-versions']['$get'],
+  200
+>;
+
+/** A single pending version row from /pending-versions */
+export type RpcFrameworkReviewPendingVersion =
+  RpcFrameworkReviewPendingVersionsResult['versions'][number];
+
+/** Inferred response type for GET /api/framework-review/version/:id */
+export type RpcFrameworkReviewVersionResult = InferResponseType<
+  FrameworkReviewClient['version'][':id']['$get'],
+  200
+>;
+
+/** A single threshold (with parsed verdict) from /version/:id */
+export type RpcFrameworkReviewThreshold =
+  RpcFrameworkReviewVersionResult['thresholds'][number];
+
+/** Inferred response type for GET /api/framework-review/unreviewed-diffs */
+export type RpcFrameworkReviewUnreviewedDiffsResult = InferResponseType<
+  FrameworkReviewClient['unreviewed-diffs']['$get'],
+  200
+>;
+
+/** A single unreviewed diff row from /unreviewed-diffs */
+export type RpcFrameworkReviewUnreviewedDiff =
+  RpcFrameworkReviewUnreviewedDiffsResult['diffs'][number];
+
+/** Inferred response type for GET /api/framework-review/diff/:id */
+export type RpcFrameworkReviewDiffResult = InferResponseType<
+  FrameworkReviewClient['diff'][':id']['$get'],
+  200
+>;
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -41,7 +41,8 @@
       "@wiki-server/political-votes-route": ["../wiki-server/src/routes/tablebase/political-votes.ts"],
       "@wiki-server/campaign-finance-route": ["../wiki-server/src/routes/tablebase/campaign-finance.ts"],
       "@wiki-server/resources-route": ["../wiki-server/src/routes/wikibase/resources.ts"],
-      "@wiki-server/model-system-cards-route": ["../wiki-server/src/routes/tablebase/model-system-cards.ts"]
+      "@wiki-server/model-system-cards-route": ["../wiki-server/src/routes/tablebase/model-system-cards.ts"],
+      "@wiki-server/framework-review-route": ["../wiki-server/src/routes/operational/framework-review.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/wiki-server/src/__tests__/framework-review.test.ts
+++ b/apps/wiki-server/src/__tests__/framework-review.test.ts
@@ -1,0 +1,553 @@
+/**
+ * Tests for /api/framework-review (QUA-710 / Phase 4-C).
+ *
+ * Two test surfaces:
+ *
+ *   1. Pure helpers (parseThresholdVerdict / formatThresholdNotes) — verify the
+ *      verdict-prefix encoding round-trips and rejects malformed strings.
+ *
+ *   2. Route behaviour with a mocked DB — focused on the rules that gate the
+ *      review workflow (the publish CTA can't fire while thresholds are
+ *      unreviewed; payload schemas reject malformed bodies; verdicts cap the
+ *      "edits" field).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import {
+  type SqlDispatcher,
+  mockDbModule,
+  postJson,
+} from "./test-utils.js";
+
+// ---- Pure helper tests (no DB) ----
+
+describe("framework-review verdict encoding", () => {
+  describe("parseThresholdVerdict", () => {
+    it("returns null for null/empty input", () => {
+      expect(parseThresholdVerdict(null)).toBeNull();
+      expect(parseThresholdVerdict("")).toBeNull();
+    });
+
+    it("returns null for unprefixed text", () => {
+      expect(parseThresholdVerdict("just a free-text note")).toBeNull();
+      expect(parseThresholdVerdict("approved without brackets")).toBeNull();
+    });
+
+    it("parses each canonical verdict tag", () => {
+      expect(parseThresholdVerdict("[approved]")).toEqual({
+        verdict: "approved",
+        notes: null,
+      });
+      expect(parseThresholdVerdict("[rejected] not the right tier")).toEqual({
+        verdict: "rejected",
+        notes: "not the right tier",
+      });
+      expect(parseThresholdVerdict("[skip] non-substantive")).toEqual({
+        verdict: "skip",
+        notes: "non-substantive",
+      });
+      expect(parseThresholdVerdict("[edited] tier label refined")).toEqual({
+        verdict: "edited",
+        notes: "tier label refined",
+      });
+    });
+
+    it("preserves multi-line notes", () => {
+      const notes = "line one\nline two\nline three";
+      const parsed = parseThresholdVerdict(`[approved] ${notes}`);
+      expect(parsed?.verdict).toBe("approved");
+      expect(parsed?.notes).toBe(notes);
+    });
+
+    it("rejects unknown verdict tags", () => {
+      expect(parseThresholdVerdict("[maybe] something")).toBeNull();
+      expect(parseThresholdVerdict("[APPROVED]")).toBeNull(); // case-sensitive
+    });
+  });
+
+  describe("formatThresholdNotes", () => {
+    it("emits bare tag when no notes provided", () => {
+      expect(formatThresholdNotes("approved", null)).toBe("[approved]");
+      expect(formatThresholdNotes("approved", undefined)).toBe("[approved]");
+      expect(formatThresholdNotes("approved", "")).toBe("[approved]");
+      expect(formatThresholdNotes("approved", "   ")).toBe("[approved]");
+    });
+
+    it("includes trimmed notes after the tag", () => {
+      expect(formatThresholdNotes("rejected", "  bad source  ")).toBe(
+        "[rejected] bad source",
+      );
+    });
+
+    it("round-trips with parseThresholdVerdict", () => {
+      const cases = [
+        { verdict: "approved" as const, notes: null },
+        { verdict: "rejected" as const, notes: "tier mismatch" },
+        { verdict: "skip" as const, notes: "duplicate of T1" },
+        { verdict: "edited" as const, notes: "trigger description rewritten for clarity" },
+      ];
+      for (const c of cases) {
+        const encoded = formatThresholdNotes(c.verdict, c.notes);
+        const parsed = parseThresholdVerdict(encoded);
+        expect(parsed?.verdict).toBe(c.verdict);
+        expect(parsed?.notes ?? null).toBe(c.notes);
+      }
+    });
+  });
+});
+
+// ---- Route tests with mocked DB ----
+//
+// We model just enough of the framework_capability_thresholds and
+// safety_framework_versions rows to exercise the route's gating behaviour.
+
+interface ThresholdRow {
+  id: string;
+  version_id: string;
+  human_reviewed: boolean;
+  human_review_notes: string | null;
+  trigger_description: string;
+  source_quote: string;
+  source_page_hint: string | null;
+  tier_label: string;
+  tier_sort_order: number;
+  risk_domain_canonical: string;
+  risk_domain_label: string;
+  commitment_language: string | null;
+  required_mitigations: Record<string, unknown> | null;
+  associated_evals: Record<string, unknown> | null;
+  extracted_by_model: string | null;
+  extraction_confidence: number | null;
+  synced_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface VersionRow {
+  id: string;
+  framework_id: string;
+  version_label: string;
+  version_sort_order: number;
+  published_date: string | null;
+  discovered_date: string;
+  source_url: string;
+  ingest_status: string;
+  content_hash: string;
+  is_draft: boolean;
+  synced_at: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface DiffRow {
+  id: string;
+  from_version_id: string;
+  to_version_id: string;
+  change_summary: string;
+  weakening_flagged: boolean;
+  strengthening_flagged: boolean;
+  human_reviewed: boolean;
+  review_verdict: string;
+  review_notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+let thresholdsStore: Map<string, ThresholdRow>;
+let versionsStore: Map<string, VersionRow>;
+let diffsStore: Map<string, DiffRow>;
+
+function resetStores() {
+  thresholdsStore = new Map();
+  versionsStore = new Map();
+  diffsStore = new Map();
+}
+
+function seedVersion(partial: Partial<VersionRow> & { id: string; framework_id: string }): VersionRow {
+  const now = new Date();
+  const v: VersionRow = {
+    version_label: "1.0",
+    version_sort_order: 1,
+    published_date: "2025-01-01",
+    discovered_date: "2025-01-02",
+    source_url: "https://example.com",
+    ingest_status: "pending_review",
+    content_hash: `hash-${partial.id}`,
+    is_draft: false,
+    synced_at: now,
+    created_at: now,
+    updated_at: now,
+    ...partial,
+  } as VersionRow;
+  versionsStore.set(v.id, v);
+  return v;
+}
+
+function seedThreshold(partial: Partial<ThresholdRow> & { id: string; version_id: string }): ThresholdRow {
+  const now = new Date();
+  const t: ThresholdRow = {
+    human_reviewed: false,
+    human_review_notes: null,
+    trigger_description: "Trigger",
+    source_quote: "Source quote",
+    source_page_hint: null,
+    tier_label: "Tier 1",
+    tier_sort_order: 1,
+    risk_domain_canonical: "cyber",
+    risk_domain_label: "Cybersecurity",
+    commitment_language: "committed",
+    required_mitigations: null,
+    associated_evals: null,
+    extracted_by_model: null,
+    extraction_confidence: null,
+    synced_at: now,
+    created_at: now,
+    updated_at: now,
+    ...partial,
+  } as ThresholdRow;
+  thresholdsStore.set(t.id, t);
+  return t;
+}
+
+function seedDiff(partial: Partial<DiffRow> & { id: string; from_version_id: string; to_version_id: string }): DiffRow {
+  const now = new Date();
+  const d: DiffRow = {
+    change_summary: "summary",
+    weakening_flagged: false,
+    strengthening_flagged: false,
+    human_reviewed: false,
+    review_verdict: "unreviewed",
+    review_notes: null,
+    created_at: now,
+    updated_at: now,
+    ...partial,
+  } as DiffRow;
+  diffsStore.set(d.id, d);
+  return d;
+}
+
+const dispatch: SqlDispatcher = (query, params) => {
+  const q = query.toLowerCase();
+
+  // Health/sequence noise from createApp().
+  if (q.includes("entity_ids") && q.includes("count(*)")) return [{ count: 0 }];
+  if (q.includes("last_value")) return [{ last_value: 0, is_called: false }];
+
+  // GUC writes from applyAuditContext.
+  if (q.includes("set_config")) return [];
+
+  // Audit log inserts — accept silently.
+  if (q.includes("insert into") && q.includes("tablebase_audit_log")) return [];
+
+  // current_setting reads from logAuditEntries.
+  if (q.includes("current_setting")) return [{ session_id: null }];
+
+  // ---- SELECT framework_capability_thresholds by id (single row) ----
+  if (
+    q.includes("from \"framework_capability_thresholds\"") &&
+    q.includes("\"id\"") &&
+    !q.includes("count(") &&
+    !q.includes("filter")
+  ) {
+    const id = params[0] as string;
+    const row = thresholdsStore.get(id);
+    return row ? [row] : [];
+  }
+
+  // ---- SELECT count of thresholds for publish gate ----
+  if (
+    q.includes("framework_capability_thresholds") &&
+    q.includes("filter") &&
+    q.includes("human_reviewed")
+  ) {
+    const versionId = params[0] as string;
+    const rows = [...thresholdsStore.values()].filter((t) => t.version_id === versionId);
+    return [{
+      total: rows.length,
+      reviewed: rows.filter((t) => t.human_reviewed).length,
+    }];
+  }
+
+  // ---- SELECT safety_framework_versions by id (no joins) ----
+  if (
+    q.includes("from \"safety_framework_versions\"") &&
+    q.includes("\"id\"") &&
+    !q.includes("left join") &&
+    !q.includes("filter")
+  ) {
+    const id = params[0] as string;
+    const row = versionsStore.get(id);
+    return row ? [row] : [];
+  }
+
+  // ---- SELECT framework_diffs by id ----
+  if (
+    q.includes("from \"framework_diffs\"") &&
+    q.includes("\"id\"") &&
+    !q.includes("filter")
+  ) {
+    const id = params[0] as string;
+    const row = diffsStore.get(id);
+    return row ? [row] : [];
+  }
+
+  // ---- UPDATE framework_capability_thresholds ----
+  if (q.includes("update \"framework_capability_thresholds\"")) {
+    // Last param is the id in the WHERE clause.
+    const id = params[params.length - 1] as string;
+    const row = thresholdsStore.get(id);
+    if (!row) return [];
+    // We don't try to parse the SET clause faithfully — for the tests below
+    // we only need the route to succeed. Mark the row as reviewed and
+    // capture the notes from the params (the schema sends humanReviewNotes
+    // as one of the bound parameters).
+    row.human_reviewed = true;
+    const notesParam = params.find(
+      (p) => typeof p === "string" && (p.startsWith("[approved]") || p.startsWith("[rejected]") || p.startsWith("[skip]") || p.startsWith("[edited]")),
+    );
+    if (typeof notesParam === "string") row.human_review_notes = notesParam;
+    return [row];
+  }
+
+  // ---- UPDATE safety_framework_versions ----
+  if (q.includes("update \"safety_framework_versions\"")) {
+    const id = params[params.length - 1] as string;
+    const row = versionsStore.get(id);
+    if (!row) return [];
+    const statusParam = params.find(
+      (p) => p === "published" || p === "rejected",
+    );
+    if (typeof statusParam === "string") row.ingest_status = statusParam;
+    return [row];
+  }
+
+  // ---- UPDATE safety_frameworks (bump latestVersionId) ----
+  if (q.includes("update \"safety_frameworks\"")) {
+    return [];
+  }
+
+  // ---- UPDATE framework_diffs ----
+  if (q.includes("update \"framework_diffs\"")) {
+    const id = params[params.length - 1] as string;
+    const row = diffsStore.get(id);
+    if (!row) return [];
+    const verdictParam = params.find(
+      (p) =>
+        p === "confirmed_weakening" ||
+        p === "confirmed_strengthening" ||
+        p === "false_positive" ||
+        p === "nuanced",
+    );
+    if (typeof verdictParam === "string") row.review_verdict = verdictParam;
+    row.human_reviewed = true;
+    return [row];
+  }
+
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+const { parseThresholdVerdict, formatThresholdNotes } = await import(
+  "../routes/operational/framework-review.js"
+);
+
+describe("POST /api/framework-review/threshold/:id", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns 404 when the threshold does not exist", async () => {
+    const res = await postJson(app, "/api/framework-review/threshold/nonexistent", {
+      verdict: "approved",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("approves a threshold with no notes", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {
+      verdict: "approved",
+    });
+    expect(res.status).toBe(200);
+    expect(thresholdsStore.get("t1")?.human_reviewed).toBe(true);
+    expect(thresholdsStore.get("t1")?.human_review_notes).toBe("[approved]");
+  });
+
+  it("rejects a threshold with a reason", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {
+      verdict: "rejected",
+      notes: "extracted from a footnote, not a binding commitment",
+    });
+    expect(res.status).toBe(200);
+    expect(thresholdsStore.get("t1")?.human_review_notes).toBe(
+      "[rejected] extracted from a footnote, not a binding commitment",
+    );
+  });
+
+  it("rejects malformed verdicts with 400", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {
+      verdict: "maybe",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty body with 400", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("blocks edits when the verdict is not 'edited'", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {
+      verdict: "approved",
+      edits: { triggerDescription: "rewritten" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects oversized notes payloads", async () => {
+    seedThreshold({ id: "t1", version_id: "v1" });
+    const res = await postJson(app, "/api/framework-review/threshold/t1", {
+      verdict: "approved",
+      notes: "x".repeat(2001),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects path-traversal in the id param", async () => {
+    const res = await postJson(app, "/api/framework-review/threshold/..%2Fbad", {
+      verdict: "approved",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/framework-review/version/:id/publish", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns 404 when the version does not exist", async () => {
+    const res = await postJson(app, "/api/framework-review/version/v-missing/publish", {
+      verdict: "published",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks publish while thresholds remain unreviewed", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1" });
+    seedThreshold({ id: "t1", version_id: "v1", human_reviewed: true });
+    seedThreshold({ id: "t2", version_id: "v1", human_reviewed: false });
+
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "published",
+    });
+    expect(res.status).toBe(400);
+    expect(versionsStore.get("v1")?.ingest_status).toBe("pending_review");
+  });
+
+  it("blocks publish when there are zero thresholds (incomplete extraction)", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1" });
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "published",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("publishes when every threshold is reviewed", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1" });
+    seedThreshold({ id: "t1", version_id: "v1", human_reviewed: true });
+    seedThreshold({ id: "t2", version_id: "v1", human_reviewed: true });
+
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "published",
+    });
+    expect(res.status).toBe(200);
+    expect(versionsStore.get("v1")?.ingest_status).toBe("published");
+  });
+
+  it("allows reject without requiring threshold review (the whole version is being thrown out)", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1" });
+    seedThreshold({ id: "t1", version_id: "v1", human_reviewed: false });
+
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "rejected",
+      notes: "wrong document — this was a press release, not the policy",
+    });
+    expect(res.status).toBe(200);
+    expect(versionsStore.get("v1")?.ingest_status).toBe("rejected");
+  });
+
+  it("refuses to re-publish a version that already moved past pending_review", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1", ingest_status: "published" });
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "published",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed verdict values", async () => {
+    seedVersion({ id: "v1", framework_id: "fw1" });
+    const res = await postJson(app, "/api/framework-review/version/v1/publish", {
+      verdict: "maybe-later",
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/framework-review/diff/:id", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns 404 for a missing diff", async () => {
+    const res = await postJson(app, "/api/framework-review/diff/d-missing", {
+      verdict: "false_positive",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("records each canonical verdict", async () => {
+    const verdicts = [
+      "confirmed_weakening",
+      "confirmed_strengthening",
+      "false_positive",
+      "nuanced",
+    ] as const;
+    for (const v of verdicts) {
+      seedDiff({ id: `d-${v}`, from_version_id: "v1", to_version_id: "v2" });
+      const res = await postJson(app, `/api/framework-review/diff/d-${v}`, {
+        verdict: v,
+        notes: "reviewer rationale",
+      });
+      expect(res.status).toBe(200);
+      expect(diffsStore.get(`d-${v}`)?.review_verdict).toBe(v);
+    }
+  });
+
+  it("rejects 'unreviewed' as a verdict (you cannot un-review)", async () => {
+    seedDiff({ id: "d1", from_version_id: "v1", to_version_id: "v2" });
+    const res = await postJson(app, "/api/framework-review/diff/d1", {
+      verdict: "unreviewed",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -66,6 +66,7 @@ import { dataQualityRoute } from "./routes/operational/data-quality.js";
 import { thingsSearchRefreshRoute } from "./routes/operational/things-search-refresh.js";
 import { operationsLogRoute } from "./routes/operational/operations-log.js";
 import { auditLogRoute } from "./routes/operational/audit-log.js";
+import { frameworkReviewRoute } from "./routes/operational/framework-review.js";
 
 let requestCounter = 0;
 
@@ -251,6 +252,7 @@ export function createApp() {
   app.route("/api/things-search", thingsSearchRefreshRoute);
   app.route("/api/operations-log", operationsLogRoute);
   app.route("/api/audit-log", auditLogRoute);
+  app.route("/api/framework-review", frameworkReviewRoute);
 
   return app;
 }

--- a/apps/wiki-server/src/routes/operational/framework-review.ts
+++ b/apps/wiki-server/src/routes/operational/framework-review.ts
@@ -1,0 +1,660 @@
+/**
+ * Framework Review (QUA-710 / Phase 4-C).
+ *
+ * Admin-only review workflow for the human-in-the-loop step of the
+ * frontier safety framework tracker (QUA-691). Two queues:
+ *
+ *   1. Pending versions — `safety_framework_versions.ingest_status =
+ *      'pending_review'`. The reviewer approves/edits/rejects each
+ *      extracted threshold, then publishes (or rejects) the version.
+ *
+ *   2. Unreviewed diffs — `framework_diffs.review_verdict = 'unreviewed'`.
+ *      The reviewer assigns a verdict (confirmed_weakening,
+ *      false_positive, etc.). Public weakening UI must gate on the
+ *      verdict — see `framework-diffs.ts` header.
+ *
+ * Verdict encoding for thresholds: the schema has only a boolean
+ * `human_reviewed` column, so we prefix `human_review_notes` with a
+ * machine-parsable tag — `[approved]`, `[rejected] <why>`, `[skip] <why>`,
+ * `[edited] <notes>`. Helpers below own that encoding so callers never
+ * see the raw string format.
+ *
+ * Mutations are written inside a transaction and audit-logged via
+ * `logAuditEntries()` so reviewer actions show up in the standard
+ * tablebase audit trail (record types `framework_capability_thresholds`,
+ * `safety_framework_versions`, `framework_diffs`).
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { eq, and, count, sql, inArray } from "drizzle-orm";
+import { getDrizzleDb } from "../../db.js";
+import {
+  safetyFrameworks,
+  safetyFrameworkVersions,
+  frameworkCapabilityThresholds,
+  frameworkDiffs,
+  frameworkDiffItems,
+} from "../../schema.js";
+import { logAuditEntries } from "../tablebase/audit-log.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
+import {
+  zv,
+  notFoundError,
+  validationError,
+} from "../shared/utils.js";
+
+// ─── Verdict encoding helpers ─────────────────────────────────────────────
+
+const VERDICT_TAGS = ["approved", "rejected", "skip", "edited"] as const;
+type ThresholdVerdict = (typeof VERDICT_TAGS)[number];
+
+// `[\s\S]` instead of `.` so notes can contain newlines without needing
+// the `s` (dotAll) flag — that flag is ES2018+ and apps/web still targets
+// ES2017. Equivalent semantics, broader runtime support.
+const VERDICT_PREFIX_RE = /^\[(approved|rejected|skip|edited)\](?:\s+([\s\S]*))?$/;
+
+/** Read the verdict tag (if any) from a `humanReviewNotes` string. */
+export function parseThresholdVerdict(
+  notes: string | null,
+): { verdict: ThresholdVerdict; notes: string | null } | null {
+  if (!notes) return null;
+  const match = notes.match(VERDICT_PREFIX_RE);
+  if (!match) return null;
+  return {
+    verdict: match[1] as ThresholdVerdict,
+    notes: match[2] ?? null,
+  };
+}
+
+/** Encode a verdict + free-text notes back into the `humanReviewNotes` string. */
+export function formatThresholdNotes(
+  verdict: ThresholdVerdict,
+  notes: string | null | undefined,
+): string {
+  const trimmed = notes?.trim();
+  return trimmed ? `[${verdict}] ${trimmed}` : `[${verdict}]`;
+}
+
+// ─── Schemas ──────────────────────────────────────────────────────────────
+
+const VALID_RISK_DOMAINS = [
+  "cbrn", "bio", "chem", "nuclear", "radiological",
+  "cyber", "autonomy_replication", "ai_rd",
+  "scheming", "persuasion", "loss_of_control", "other",
+] as const;
+
+const VALID_COMMITMENT_LANG = [
+  "committed", "aspirational", "conditional", "informational",
+] as const;
+
+const VALID_DIFF_VERDICTS = [
+  "confirmed_weakening",
+  "confirmed_strengthening",
+  "false_positive",
+  "nuanced",
+] as const;
+
+const ThresholdReviewBody = z.object({
+  verdict: z.enum(VERDICT_TAGS),
+  notes: z.string().max(2000).nullable().optional(),
+  edits: z
+    .object({
+      triggerDescription: z.string().min(1).max(5000).optional(),
+      sourceQuote: z.string().min(1).max(5000).optional(),
+      sourcePageHint: z.string().max(200).nullable().optional(),
+      tierLabel: z.string().min(1).max(200).optional(),
+      tierSortOrder: z.number().int().min(1).max(5).optional(),
+      riskDomainCanonical: z.enum(VALID_RISK_DOMAINS).optional(),
+      riskDomainLabel: z.string().min(1).max(200).optional(),
+      commitmentLanguage: z.enum(VALID_COMMITMENT_LANG).nullable().optional(),
+    })
+    .optional(),
+});
+
+const PublishVersionBody = z.object({
+  verdict: z.enum(["published", "rejected"]),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+const DiffReviewBody = z.object({
+  verdict: z.enum(VALID_DIFF_VERDICTS),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+const ID_RE = /^[A-Za-z0-9_-]{1,200}$/;
+function validId(id: string): boolean {
+  return ID_RE.test(id);
+}
+
+// ─── Route ────────────────────────────────────────────────────────────────
+
+const frameworkReviewApp = new Hono()
+
+  // Versions awaiting review, with framework info + threshold counts.
+  .get("/pending-versions", async (c) => {
+    const db = getDrizzleDb();
+
+    // Aggregate threshold counts per pending version. Total, plus a
+    // reviewed-count derived from the verdict-prefix encoding.
+    const pendingVersions = await db
+      .select({
+        id: safetyFrameworkVersions.id,
+        frameworkId: safetyFrameworkVersions.frameworkId,
+        versionLabel: safetyFrameworkVersions.versionLabel,
+        publishedDate: safetyFrameworkVersions.publishedDate,
+        discoveredDate: safetyFrameworkVersions.discoveredDate,
+        sourceUrl: safetyFrameworkVersions.sourceUrl,
+        waybackSnapshotUrl: safetyFrameworkVersions.waybackSnapshotUrl,
+        pdfArchiveUrl: safetyFrameworkVersions.pdfArchiveUrl,
+        summary: safetyFrameworkVersions.summary,
+        contentLengthChars: safetyFrameworkVersions.contentLengthChars,
+        ingestStatus: safetyFrameworkVersions.ingestStatus,
+        createdAt: safetyFrameworkVersions.createdAt,
+        frameworkName: safetyFrameworks.name,
+        frameworkShortName: safetyFrameworks.shortName,
+        orgDisplayName: safetyFrameworks.orgDisplayName,
+      })
+      .from(safetyFrameworkVersions)
+      .leftJoin(
+        safetyFrameworks,
+        eq(safetyFrameworks.id, safetyFrameworkVersions.frameworkId),
+      )
+      .where(eq(safetyFrameworkVersions.ingestStatus, "pending_review"))
+      .orderBy(safetyFrameworkVersions.discoveredDate);
+
+    if (pendingVersions.length === 0) {
+      return c.json({ versions: [] });
+    }
+
+    const versionIds = pendingVersions.map((v) => v.id);
+
+    const thresholdCounts = await db
+      .select({
+        versionId: frameworkCapabilityThresholds.versionId,
+        total: count(),
+        reviewed: sql<number>`count(*) filter (where ${frameworkCapabilityThresholds.humanReviewed})`,
+      })
+      .from(frameworkCapabilityThresholds)
+      .where(inArray(frameworkCapabilityThresholds.versionId, versionIds))
+      .groupBy(frameworkCapabilityThresholds.versionId);
+
+    const countsByVersion = new Map(
+      thresholdCounts.map((r) => [r.versionId, r]),
+    );
+
+    return c.json({
+      versions: pendingVersions.map((v) => {
+        const counts = countsByVersion.get(v.id);
+        const total = counts ? Number(counts.total) : 0;
+        const reviewed = counts ? Number(counts.reviewed) : 0;
+        return {
+          ...v,
+          thresholdCount: total,
+          thresholdsReviewed: reviewed,
+          allThresholdsReviewed: total > 0 && reviewed === total,
+        };
+      }),
+    });
+  })
+
+  // Full review payload for one version: framework + thresholds with parsed verdicts.
+  .get("/version/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!validId(id)) return validationError(c, "Invalid version id");
+    const db = getDrizzleDb();
+
+    const versionRows = await db
+      .select({
+        version: safetyFrameworkVersions,
+        framework: safetyFrameworks,
+      })
+      .from(safetyFrameworkVersions)
+      .leftJoin(
+        safetyFrameworks,
+        eq(safetyFrameworks.id, safetyFrameworkVersions.frameworkId),
+      )
+      .where(eq(safetyFrameworkVersions.id, id))
+      .limit(1);
+
+    if (versionRows.length === 0) {
+      return notFoundError(c, `Framework version ${id} not found`);
+    }
+
+    const thresholds = await db
+      .select()
+      .from(frameworkCapabilityThresholds)
+      .where(eq(frameworkCapabilityThresholds.versionId, id))
+      .orderBy(
+        frameworkCapabilityThresholds.tierSortOrder,
+        frameworkCapabilityThresholds.riskDomainCanonical,
+      );
+
+    const enriched = thresholds.map((t) => {
+      const parsed = parseThresholdVerdict(t.humanReviewNotes);
+      return {
+        ...t,
+        extractionConfidence:
+          t.extractionConfidence == null ? null : Number(t.extractionConfidence),
+        reviewVerdict: parsed?.verdict ?? null,
+        reviewNotes: parsed?.notes ?? null,
+      };
+    });
+
+    return c.json({
+      version: versionRows[0].version,
+      framework: versionRows[0].framework,
+      thresholds: enriched,
+    });
+  })
+
+  // Approve / edit / reject / skip a single threshold.
+  .post(
+    "/threshold/:id",
+    zv("json", ThresholdReviewBody),
+    async (c) => {
+      const id = c.req.param("id");
+      if (!validId(id)) return validationError(c, "Invalid threshold id");
+      const body = c.req.valid("json");
+      const db = getDrizzleDb();
+
+      const existingRows = await db
+        .select()
+        .from(frameworkCapabilityThresholds)
+        .where(eq(frameworkCapabilityThresholds.id, id))
+        .limit(1);
+
+      if (existingRows.length === 0) {
+        return notFoundError(c, `Threshold ${id} not found`);
+      }
+      const existing = existingRows[0];
+
+      // Edits without 'edited' verdict are a contradiction — reject early.
+      if (body.edits && Object.keys(body.edits).length > 0 && body.verdict !== "edited") {
+        return validationError(
+          c,
+          "edits provided but verdict is not 'edited'",
+        );
+      }
+
+      const reviewNotes = formatThresholdNotes(body.verdict, body.notes);
+
+      const updated = await db.transaction(async (tx) => {
+        await applyAuditContext(tx, c);
+
+        const updateValues: Record<string, unknown> = {
+          humanReviewed: true,
+          humanReviewNotes: reviewNotes,
+          updatedAt: new Date(),
+        };
+        if (body.verdict === "edited" && body.edits) {
+          for (const [k, v] of Object.entries(body.edits)) {
+            if (v !== undefined) updateValues[k] = v;
+          }
+        }
+
+        const rows = await tx
+          .update(frameworkCapabilityThresholds)
+          .set(updateValues)
+          .where(eq(frameworkCapabilityThresholds.id, id))
+          .returning();
+
+        if (rows.length > 0) {
+          await logAuditEntries(tx, [
+            {
+              recordType: "framework_capability_thresholds",
+              recordId: id,
+              operation: "update",
+              oldData: { ...existing },
+              newData: { ...rows[0] },
+              verdict: body.verdict,
+            },
+          ]);
+        }
+
+        return rows[0];
+      });
+
+      const parsed = parseThresholdVerdict(updated.humanReviewNotes);
+      return c.json({
+        ok: true,
+        threshold: {
+          ...updated,
+          extractionConfidence:
+            updated.extractionConfidence == null
+              ? null
+              : Number(updated.extractionConfidence),
+          reviewVerdict: parsed?.verdict ?? null,
+          reviewNotes: parsed?.notes ?? null,
+        },
+      });
+    },
+  )
+
+  // Publish (or reject) a version. Requires every threshold to have been touched.
+  .post(
+    "/version/:id/publish",
+    zv("json", PublishVersionBody),
+    async (c) => {
+      const id = c.req.param("id");
+      if (!validId(id)) return validationError(c, "Invalid version id");
+      const body = c.req.valid("json");
+      const db = getDrizzleDb();
+
+      const versionRows = await db
+        .select()
+        .from(safetyFrameworkVersions)
+        .where(eq(safetyFrameworkVersions.id, id))
+        .limit(1);
+
+      if (versionRows.length === 0) {
+        return notFoundError(c, `Framework version ${id} not found`);
+      }
+      const existing = versionRows[0];
+
+      if (existing.ingestStatus !== "pending_review") {
+        return validationError(
+          c,
+          `Version is already ${existing.ingestStatus}; cannot re-publish`,
+        );
+      }
+
+      // Publish requires every threshold reviewed. Reject can short-circuit.
+      if (body.verdict === "published") {
+        const [counts] = await db
+          .select({
+            total: count(),
+            reviewed: sql<number>`count(*) filter (where ${frameworkCapabilityThresholds.humanReviewed})`,
+          })
+          .from(frameworkCapabilityThresholds)
+          .where(eq(frameworkCapabilityThresholds.versionId, id));
+
+        const total = Number(counts?.total ?? 0);
+        const reviewed = Number(counts?.reviewed ?? 0);
+        if (total === 0 || reviewed !== total) {
+          return validationError(
+            c,
+            `Cannot publish: ${reviewed}/${total} thresholds reviewed`,
+          );
+        }
+      }
+
+      const updated = await db.transaction(async (tx) => {
+        await applyAuditContext(tx, c);
+
+        const rows = await tx
+          .update(safetyFrameworkVersions)
+          .set({
+            ingestStatus: body.verdict,
+            updatedAt: new Date(),
+          })
+          .where(eq(safetyFrameworkVersions.id, id))
+          .returning();
+
+        if (rows.length > 0) {
+          await logAuditEntries(tx, [
+            {
+              recordType: "safety_framework_versions",
+              recordId: id,
+              operation: "update",
+              oldData: { ...existing },
+              newData: { ...rows[0] },
+              verdict: body.verdict,
+              evidence: body.notes ?? null,
+            },
+          ]);
+        }
+
+        // Bump the parent framework's latest_version_id only on a real publish.
+        if (body.verdict === "published") {
+          await tx
+            .update(safetyFrameworks)
+            .set({
+              latestVersionId: id,
+              updatedAt: new Date(),
+            })
+            .where(eq(safetyFrameworks.id, existing.frameworkId));
+        }
+
+        return rows[0];
+      });
+
+      return c.json({ ok: true, version: updated });
+    },
+  )
+
+  // Diffs awaiting reviewer verdict, with version + framework labels.
+  .get("/unreviewed-diffs", async (c) => {
+    const db = getDrizzleDb();
+
+    // Two-query strategy: one for diffs, then a single batched lookup of
+    // every referenced version + framework. Self-joining
+    // safety_framework_versions twice to alias from/to in one SQL would
+    // need either Drizzle's `alias()` (heavier setup) or raw SQL — the
+    // batched approach is cheaper and the row count is small (~22 diffs
+    // pending at most, each pointing at 2 versions).
+    const diffs = await db
+      .select()
+      .from(frameworkDiffs)
+      .where(eq(frameworkDiffs.reviewVerdict, "unreviewed"))
+      .orderBy(frameworkDiffs.createdAt);
+
+    if (diffs.length === 0) {
+      return c.json({ diffs: [] });
+    }
+
+    const versionIds = Array.from(
+      new Set(diffs.flatMap((d) => [d.fromVersionId, d.toVersionId])),
+    );
+
+    const versions = await db
+      .select({
+        id: safetyFrameworkVersions.id,
+        frameworkId: safetyFrameworkVersions.frameworkId,
+        versionLabel: safetyFrameworkVersions.versionLabel,
+        publishedDate: safetyFrameworkVersions.publishedDate,
+      })
+      .from(safetyFrameworkVersions)
+      .where(inArray(safetyFrameworkVersions.id, versionIds));
+
+    const versionMap = new Map(versions.map((v) => [v.id, v]));
+
+    const frameworkIds = Array.from(
+      new Set(versions.map((v) => v.frameworkId).filter((x): x is string => !!x)),
+    );
+
+    const frameworks = frameworkIds.length
+      ? await db
+          .select({
+            id: safetyFrameworks.id,
+            name: safetyFrameworks.name,
+            shortName: safetyFrameworks.shortName,
+            orgDisplayName: safetyFrameworks.orgDisplayName,
+          })
+          .from(safetyFrameworks)
+          .where(inArray(safetyFrameworks.id, frameworkIds))
+      : [];
+
+    const frameworkMap = new Map(frameworks.map((f) => [f.id, f]));
+
+    const itemCounts = await db
+      .select({
+        diffId: frameworkDiffItems.diffId,
+        total: count(),
+      })
+      .from(frameworkDiffItems)
+      .where(
+        inArray(
+          frameworkDiffItems.diffId,
+          diffs.map((d) => d.id),
+        ),
+      )
+      .groupBy(frameworkDiffItems.diffId);
+
+    const itemCountMap = new Map(
+      itemCounts.map((r) => [r.diffId, Number(r.total)]),
+    );
+
+    return c.json({
+      diffs: diffs.map((d) => {
+        const fromVer = versionMap.get(d.fromVersionId);
+        const toVer = versionMap.get(d.toVersionId);
+        const framework = fromVer
+          ? frameworkMap.get(fromVer.frameworkId)
+          : null;
+        return {
+          ...d,
+          fromVersion: fromVer ?? null,
+          toVersion: toVer ?? null,
+          framework: framework ?? null,
+          itemCount: itemCountMap.get(d.id) ?? 0,
+        };
+      }),
+    });
+  })
+
+  // Full diff payload for the review screen: items + version metadata.
+  .get("/diff/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!validId(id)) return validationError(c, "Invalid diff id");
+    const db = getDrizzleDb();
+
+    const diffRows = await db
+      .select()
+      .from(frameworkDiffs)
+      .where(eq(frameworkDiffs.id, id))
+      .limit(1);
+
+    if (diffRows.length === 0) {
+      return notFoundError(c, `Diff ${id} not found`);
+    }
+    const diff = diffRows[0];
+
+    const items = await db
+      .select()
+      .from(frameworkDiffItems)
+      .where(eq(frameworkDiffItems.diffId, id))
+      .orderBy(frameworkDiffItems.changeType);
+
+    const versionIds = [diff.fromVersionId, diff.toVersionId];
+    const versions = await db
+      .select({
+        id: safetyFrameworkVersions.id,
+        frameworkId: safetyFrameworkVersions.frameworkId,
+        versionLabel: safetyFrameworkVersions.versionLabel,
+        publishedDate: safetyFrameworkVersions.publishedDate,
+        sourceUrl: safetyFrameworkVersions.sourceUrl,
+        waybackSnapshotUrl: safetyFrameworkVersions.waybackSnapshotUrl,
+      })
+      .from(safetyFrameworkVersions)
+      .where(inArray(safetyFrameworkVersions.id, versionIds));
+
+    const fromVersion = versions.find((v) => v.id === diff.fromVersionId) ?? null;
+    const toVersion = versions.find((v) => v.id === diff.toVersionId) ?? null;
+
+    const frameworkId = fromVersion?.frameworkId ?? toVersion?.frameworkId ?? null;
+    const frameworkRows = frameworkId
+      ? await db
+          .select()
+          .from(safetyFrameworks)
+          .where(eq(safetyFrameworks.id, frameworkId))
+          .limit(1)
+      : [];
+
+    return c.json({
+      diff,
+      items,
+      fromVersion,
+      toVersion,
+      framework: frameworkRows[0] ?? null,
+    });
+  })
+
+  // Confirm / mark false-positive / mark nuanced — sets reviewVerdict.
+  .post(
+    "/diff/:id",
+    zv("json", DiffReviewBody),
+    async (c) => {
+      const id = c.req.param("id");
+      if (!validId(id)) return validationError(c, "Invalid diff id");
+      const body = c.req.valid("json");
+      const db = getDrizzleDb();
+
+      const existingRows = await db
+        .select()
+        .from(frameworkDiffs)
+        .where(eq(frameworkDiffs.id, id))
+        .limit(1);
+
+      if (existingRows.length === 0) {
+        return notFoundError(c, `Diff ${id} not found`);
+      }
+      const existing = existingRows[0];
+
+      const updated = await db.transaction(async (tx) => {
+        await applyAuditContext(tx, c);
+
+        const rows = await tx
+          .update(frameworkDiffs)
+          .set({
+            humanReviewed: true,
+            reviewVerdict: body.verdict,
+            reviewNotes: body.notes ?? null,
+            updatedAt: new Date(),
+          })
+          .where(eq(frameworkDiffs.id, id))
+          .returning();
+
+        if (rows.length > 0) {
+          await logAuditEntries(tx, [
+            {
+              recordType: "framework_diffs",
+              recordId: id,
+              operation: "update",
+              oldData: { ...existing },
+              newData: { ...rows[0] },
+              verdict: body.verdict,
+              evidence: body.notes ?? null,
+            },
+          ]);
+        }
+
+        return rows[0];
+      });
+
+      return c.json({ ok: true, diff: updated });
+    },
+  )
+
+  // Aggregate stats for the dashboard header.
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+
+    const [versionStats] = await db
+      .select({
+        pendingVersions: sql<number>`count(*) filter (where ${safetyFrameworkVersions.ingestStatus} = 'pending_review')`,
+        publishedVersions: sql<number>`count(*) filter (where ${safetyFrameworkVersions.ingestStatus} = 'published')`,
+        rejectedVersions: sql<number>`count(*) filter (where ${safetyFrameworkVersions.ingestStatus} = 'rejected')`,
+      })
+      .from(safetyFrameworkVersions);
+
+    const [diffStats] = await db
+      .select({
+        unreviewedDiffs: sql<number>`count(*) filter (where ${frameworkDiffs.reviewVerdict} = 'unreviewed')`,
+        confirmedWeakenings: sql<number>`count(*) filter (where ${frameworkDiffs.reviewVerdict} = 'confirmed_weakening')`,
+        falsePositives: sql<number>`count(*) filter (where ${frameworkDiffs.reviewVerdict} = 'false_positive')`,
+      })
+      .from(frameworkDiffs);
+
+    return c.json({
+      pendingVersions: Number(versionStats?.pendingVersions ?? 0),
+      publishedVersions: Number(versionStats?.publishedVersions ?? 0),
+      rejectedVersions: Number(versionStats?.rejectedVersions ?? 0),
+      unreviewedDiffs: Number(diffStats?.unreviewedDiffs ?? 0),
+      confirmedWeakenings: Number(diffStats?.confirmedWeakenings ?? 0),
+      falsePositives: Number(diffStats?.falsePositives ?? 0),
+    });
+  });
+
+export const frameworkReviewRoute = frameworkReviewApp;
+export type FrameworkReviewRoute = typeof frameworkReviewApp;

--- a/apps/wiki-server/src/routes/operational/framework-review.ts
+++ b/apps/wiki-server/src/routes/operational/framework-review.ts
@@ -43,6 +43,11 @@ import {
   notFoundError,
   validationError,
 } from "../shared/utils.js";
+import {
+  VALID_RISK_DOMAINS,
+  VALID_COMMITMENT_LANGUAGES as VALID_COMMITMENT_LANG,
+  VALID_DASHBOARD_DIFF_VERDICTS as VALID_DIFF_VERDICTS,
+} from "../shared/framework-constants.js";
 
 // ─── Verdict encoding helpers ─────────────────────────────────────────────
 
@@ -75,25 +80,6 @@ export function formatThresholdNotes(
   const trimmed = notes?.trim();
   return trimmed ? `[${verdict}] ${trimmed}` : `[${verdict}]`;
 }
-
-// ─── Schemas ──────────────────────────────────────────────────────────────
-
-const VALID_RISK_DOMAINS = [
-  "cbrn", "bio", "chem", "nuclear", "radiological",
-  "cyber", "autonomy_replication", "ai_rd",
-  "scheming", "persuasion", "loss_of_control", "other",
-] as const;
-
-const VALID_COMMITMENT_LANG = [
-  "committed", "aspirational", "conditional", "informational",
-] as const;
-
-const VALID_DIFF_VERDICTS = [
-  "confirmed_weakening",
-  "confirmed_strengthening",
-  "false_positive",
-  "nuanced",
-] as const;
 
 const ThresholdReviewBody = z.object({
   verdict: z.enum(VERDICT_TAGS),
@@ -161,7 +147,7 @@ const frameworkReviewApp = new Hono()
         eq(safetyFrameworks.id, safetyFrameworkVersions.frameworkId),
       )
       .where(eq(safetyFrameworkVersions.ingestStatus, "pending_review"))
-      .orderBy(safetyFrameworkVersions.discoveredDate);
+      .orderBy(safetyFrameworkVersions.discoveredDate, safetyFrameworkVersions.id);
 
     if (pendingVersions.length === 0) {
       return c.json({ versions: [] });

--- a/apps/wiki-server/src/routes/operational/index.ts
+++ b/apps/wiki-server/src/routes/operational/index.ts
@@ -22,3 +22,4 @@ export { monitoringRoute, type MonitoringRoute } from "./monitoring.js";
 export { qaChecksRoute, type QaChecksRoute } from "./qa-checks.js";
 export { dataQualityRoute, type DataQualityRoute } from "./data-quality.js";
 export { operationsLogRoute, type OperationsLogRoute } from "./operations-log.js";
+export { frameworkReviewRoute, type FrameworkReviewRoute } from "./framework-review.js";

--- a/apps/wiki-server/src/routes/shared/framework-constants.ts
+++ b/apps/wiki-server/src/routes/shared/framework-constants.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared enums for the QUA-691 frontier-safety-framework tables.
+ *
+ * Mirror the CHECK allowlists in migration 0206. Imported by:
+ *   - tablebase/framework-capability-thresholds.ts
+ *   - tablebase/framework-diffs.ts
+ *   - tablebase/framework-diff-items.ts
+ *   - operational/framework-review.ts
+ *
+ * Keep these in sync with the SQL CHECK constraints — adding a value here
+ * without an ALTER on the constraint will fail at insert time.
+ */
+
+export const VALID_RISK_DOMAINS = [
+  "cbrn",
+  "bio",
+  "chem",
+  "nuclear",
+  "radiological",
+  "cyber",
+  "autonomy_replication",
+  "ai_rd",
+  "scheming",
+  "persuasion",
+  "loss_of_control",
+  "other",
+] as const;
+
+export const VALID_COMMITMENT_LANGUAGES = [
+  "committed",
+  "aspirational",
+  "conditional",
+  "informational",
+] as const;
+
+export const VALID_OVERALL_DIRECTIONS = [
+  "weaker",
+  "stronger",
+  "mixed",
+  "neutral",
+  "rewrite",
+] as const;
+
+/**
+ * All review verdicts that can appear in `framework_diffs.review_verdict`,
+ * including the default `unreviewed` state.
+ */
+export const VALID_REVIEW_VERDICTS = [
+  "confirmed_weakening",
+  "confirmed_strengthening",
+  "false_positive",
+  "nuanced",
+  "unreviewed",
+] as const;
+
+/**
+ * Verdicts the dashboard can apply to a diff. Excludes `unreviewed` —
+ * review actions always move a row out of the unreviewed bucket.
+ */
+export const VALID_DASHBOARD_DIFF_VERDICTS = [
+  "confirmed_weakening",
+  "confirmed_strengthening",
+  "false_positive",
+  "nuanced",
+] as const;

--- a/apps/wiki-server/src/routes/tablebase/framework-capability-thresholds.ts
+++ b/apps/wiki-server/src/routes/tablebase/framework-capability-thresholds.ts
@@ -21,32 +21,13 @@ import {
 } from "../shared/utils.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import {
+  VALID_RISK_DOMAINS,
+  VALID_COMMITMENT_LANGUAGES as VALID_COMMITMENT_LANG,
+} from "../shared/framework-constants.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 const MAX_PAGE_SIZE = 500;
-
-// Mirror of migration 0206 CHECK allowlist.
-const VALID_RISK_DOMAINS = [
-  "cbrn",
-  "bio",
-  "chem",
-  "nuclear",
-  "radiological",
-  "cyber",
-  "autonomy_replication",
-  "ai_rd",
-  "scheming",
-  "persuasion",
-  "loss_of_control",
-  "other",
-] as const;
-
-const VALID_COMMITMENT_LANG = [
-  "committed",
-  "aspirational",
-  "conditional",
-  "informational",
-] as const;
 
 const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 200),

--- a/apps/wiki-server/src/routes/tablebase/framework-diff-items.ts
+++ b/apps/wiki-server/src/routes/tablebase/framework-diff-items.ts
@@ -47,11 +47,7 @@ const VALID_CLASSIFIER_TAG = [
   "clarification",
 ] as const;
 
-const VALID_RISK_DOMAINS = [
-  "cbrn", "bio", "chem", "nuclear", "radiological",
-  "cyber", "autonomy_replication", "ai_rd",
-  "scheming", "persuasion", "loss_of_control", "other",
-] as const;
+import { VALID_RISK_DOMAINS } from "../shared/framework-constants.js";
 
 const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 500),

--- a/apps/wiki-server/src/routes/tablebase/framework-diffs.ts
+++ b/apps/wiki-server/src/routes/tablebase/framework-diffs.ts
@@ -21,18 +21,13 @@ import {
 } from "../shared/utils.js";
 import { paginatedQuery } from "../shared/paginated-query.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import {
+  VALID_OVERALL_DIRECTIONS as VALID_OVERALL,
+  VALID_REVIEW_VERDICTS as VALID_VERDICT,
+} from "../shared/framework-constants.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 const MAX_PAGE_SIZE = 500;
-
-const VALID_OVERALL = ["weaker", "stronger", "mixed", "neutral", "rewrite"] as const;
-const VALID_VERDICT = [
-  "confirmed_weakening",
-  "confirmed_strengthening",
-  "false_positive",
-  "nuanced",
-  "unreviewed",
-] as const;
 
 const AllQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 200),

--- a/content/docs/internal/framework-review-dashboard.mdx
+++ b/content/docs/internal/framework-review-dashboard.mdx
@@ -1,0 +1,10 @@
+---
+wikiId: E2505
+title: "Framework Review Dashboard"
+description: "Human-in-the-loop review queue for frontier-safety framework versions and inter-version diffs"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-25"
+---
+
+<FrameworkReviewContent />


### PR DESCRIPTION
## Summary

Phase 4-C of [QUA-706](https://linear.app/quantifieduncertainty/issue/QUA-706) — admin-only Pattern A dashboard for the human-in-the-loop step of the frontier-safety framework tracker (foundation: QUA-691, PR #4594).

Two queues drive the workflow:

- **Pending versions** (`safety_framework_versions.ingest_status = 'pending_review'`) → per-threshold approve/edit/reject/skip, then a Publish CTA gated server-side on every threshold being reviewed.
- **Unreviewed diffs** (`framework_diffs.review_verdict = 'unreviewed'`) → per-diff verdict picker (`confirmed_weakening` / `confirmed_strengthening` / `false_positive` / `nuanced`) with before/after snapshots + LLM classifier tag per item.

Closes QUA-710.

## What's in the PR

**Wiki-server** (`/api/framework-review`):
- `GET /stats` — header counts (pending versions, published, unreviewed diffs, confirmed weakenings, ...)
- `GET /pending-versions` — versions awaiting review with framework label + threshold counts
- `GET /version/:id` — full version + thresholds with parsed verdicts (for the review screen)
- `POST /threshold/:id` — approve / edit / reject / skip; rejects edits when verdict ≠ `edited`
- `POST /version/:id/publish` — publish or reject; refuses publish if any threshold is unreviewed and refuses re-publish on a non-pending version
- `GET /unreviewed-diffs` — diffs awaiting verdict with version labels and item counts
- `GET /diff/:id` — diff + atomic items + endpoint version metadata
- `POST /diff/:id` — set review verdict (rejects `unreviewed` as a value)

All mutations run inside a transaction with `applyAuditContext` + `logAuditEntries` so every reviewer action lands in `tablebase_audit_log` for the standard audit trail.

**Frontend** (Pattern A):
- Entity ID **E2505** (`framework-review-dashboard`) allocated via `crux tb ids allocate`
- `content/docs/internal/framework-review-dashboard.mdx` renders `<FrameworkReviewContent />`
- `/internal/framework-review` redirects to `/wiki/E2505`
- Drill-downs at `/internal/framework-review/version/[id]` and `/internal/framework-review/diff/[id]` (dynamic routes — the wiki page is statically generated so query-param drill-downs aren't viable)
- All client→server POSTs go through one `/api/framework-review-proxy?path=...` Next.js route with an explicit path allowlist as the security boundary
- Sidebar entry under TableBase → "Framework Review"

## Verdict encoding

The schema only has `humanReviewed: boolean` + `humanReviewNotes: text` per threshold (no migration in this PR). Verdict states are encoded as a structured prefix in the notes column:

```
[approved]
[rejected] <reason>
[skip] <reason>
[edited] <notes>
```

`parseThresholdVerdict` and `formatThresholdNotes` own the encoding and round-trip. If a future ticket needs typed verdict queries we can promote to a column then.

## Tests

26 new tests in `apps/wiki-server/src/__tests__/framework-review.test.ts`:
- Helper round-trips (`parseThresholdVerdict` ⟷ `formatThresholdNotes`, multi-line notes, unknown tags, case sensitivity)
- Threshold review: 404 on missing, approve/reject success, malformed verdict 400, empty body 400, edits-without-edited-verdict 400, oversized notes 400, path-traversal id 400
- Publish gate: 404 on missing, blocked while thresholds unreviewed, blocked when zero thresholds extracted, success when all reviewed, reject can short-circuit, refuse re-publish on non-pending, malformed verdict 400
- Diff review: 404 on missing, all four canonical verdicts succeed, `unreviewed` is rejected as a verdict value

## Test plan

- [x] `pnpm test` — 1414 wiki-server tests pass; 26 new in `framework-review.test.ts`
- [x] `pnpm crux w validate gate --fix` — 57/57 gate checks pass
- [x] `pnpm build` — production build clean
- [x] Typecheck clean (`apps/wiki-server`, `apps/web`)
- [ ] Manual: open `/wiki/E2505` once deployed, verify the queue lists render and drill-downs work end-to-end (will exercise once QUA-707 has ingested some pending versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
