### PR TITLE
QUA-723: flagship-curate reset writes needsRecheck=true so cron picks orphans up

### DIFF
--- a/apps/wiki-server/drizzle/0213_qua_723_flagship_curate_orphan_backfill.sql
+++ b/apps/wiki-server/drizzle/0213_qua_723_flagship_curate_orphan_backfill.sql
@@ -1,0 +1,27 @@
+-- QUA-723: Backfill flagship-curate reset orphans.
+--
+-- `crux flagship-curate` previously wrote `unchecked` reset verdicts with
+-- `needs_recheck=false` and `next_check_due=NULL`, so the weekly
+-- `sourcing-recheck` cron skipped them permanently. The code path is fixed
+-- in this PR (set both fields on every reset write), but existing orphan
+-- rows need a one-shot rescue so the next cron run picks them up.
+--
+-- Match criteria:
+--   - reasoning ILIKE '%flagship-curate%'  (matches the canonical
+--     "Reset by flagship-curate before re-verification" message)
+--   - verdict = 'unchecked'
+--   - next_check_due IS NULL                (only the orphans, not rows
+--                                            that already have a recheck
+--                                            scheduled)
+--
+-- Idempotent: safe to re-run; the WHERE clause excludes any row whose
+-- next_check_due has already been backfilled.
+
+UPDATE "source_check_verdicts"
+SET
+  "needs_recheck" = true,
+  "next_check_due" = NOW(),
+  "updated_at" = NOW()
+WHERE "reasoning" ILIKE '%flagship-curate%'
+  AND "verdict" = 'unchecked'
+  AND "next_check_due" IS NULL;

--- a/apps/wiki-server/drizzle/0213_qua_723_flagship_curate_orphan_backfill.sql
+++ b/apps/wiki-server/drizzle/0213_qua_723_flagship_curate_orphan_backfill.sql
@@ -6,22 +6,31 @@
 -- in this PR (set both fields on every reset write), but existing orphan
 -- rows need a one-shot rescue so the next cron run picks them up.
 --
--- Match criteria:
---   - reasoning ILIKE '%flagship-curate%'  (matches the canonical
---     "Reset by flagship-curate before re-verification" message)
---   - verdict = 'unchecked'
---   - next_check_due IS NULL                (only the orphans, not rows
---                                            that already have a recheck
---                                            scheduled)
+-- Match criteria (exact match on the single literal written by
+-- crux/commands/flagship-curate.ts::resetStaleVerdicts — substring
+-- ILIKE would risk colliding with LLM-generated reasoning text from
+-- other source-check writers, which can be up to 5000 chars):
+--   - reasoning = 'Reset by flagship-curate before re-verification'
+--   - verdict   = 'unchecked'
+--   - next_check_due IS NULL  (only the orphans, not rows that already
+--                              have a recheck scheduled)
 --
 -- Idempotent: safe to re-run; the WHERE clause excludes any row whose
 -- next_check_due has already been backfilled.
 
-UPDATE "source_check_verdicts"
-SET
-  "needs_recheck" = true,
-  "next_check_due" = NOW(),
-  "updated_at" = NOW()
-WHERE "reasoning" ILIKE '%flagship-curate%'
-  AND "verdict" = 'unchecked'
-  AND "next_check_due" IS NULL;
+DO $$
+DECLARE
+  rows_updated INT;
+BEGIN
+  UPDATE "source_check_verdicts"
+  SET
+    "needs_recheck" = true,
+    "next_check_due" = NOW(),
+    "updated_at" = NOW()
+  WHERE "reasoning" = 'Reset by flagship-curate before re-verification'
+    AND "verdict" = 'unchecked'
+    AND "next_check_due" IS NULL;
+
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RAISE NOTICE 'QUA-723 backfill: re-armed % flagship-curate reset orphan(s)', rows_updated;
+END $$;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1478,6 +1478,13 @@
       "when": 1787818500000,
       "tag": "0212_qua_702_benchmark_link_queue",
       "breakpoints": true
+    },
+    {
+      "idx": 213,
+      "version": "7",
+      "when": 1787876400000,
+      "tag": "0213_qua_723_flagship_curate_orphan_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/crux/commands/flagship-curate.test.ts
+++ b/crux/commands/flagship-curate.test.ts
@@ -936,6 +936,41 @@ describe('flagship-curate', () => {
       expect(resetCalls()).toEqual([]);
     });
 
+    it('reset payload sets needsRecheck=true and nextCheckDue (QUA-723)', async () => {
+      // Without these fields, the weekly sourcing-recheck cron skips
+      // reset rows permanently — they become orphans if Step 5's
+      // in-process verify is cut off by budget/timeout.
+      mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
+      mockGetVerdictsByEntity.mockResolvedValue(
+        makeVerdicts([
+          { recordType: 'personnel', recordId: 'p1', verdict: 'partial', displayName: 'Alice' },
+        ]),
+      );
+      mockGetPersonnelByEntity.mockResolvedValue(makePersonnel([{ id: 'p1' }]));
+      mockStoreVerdict.mockResolvedValue({ ok: true });
+
+      const before = Date.now();
+      const result = await commands.default([], {
+        entity: 'anthropic',
+        budget: '5',
+        'skip-research': true,
+        iterations: '1',
+      });
+      const after = Date.now();
+
+      expect(result.exitCode).toBe(0);
+      const resets = mockStoreVerdict.mock.calls
+        .map((call) => call[0] as Record<string, unknown>)
+        .filter((arg) => arg?.['verdict'] === 'unchecked');
+      expect(resets).toHaveLength(1);
+      const payload = resets[0]!;
+      expect(payload['needsRecheck']).toBe(true);
+      expect(typeof payload['nextCheckDue']).toBe('string');
+      const due = new Date(payload['nextCheckDue'] as string).getTime();
+      expect(due).toBeGreaterThanOrEqual(before);
+      expect(due).toBeLessThanOrEqual(after);
+    });
+
     it('does not reset contradicted records (only unverifiable/partial/outdated are resettable)', async () => {
       mockGetEntity.mockResolvedValue(makeEntity('anthropic', 'Anthropic'));
       mockGetVerdictsByEntity.mockResolvedValue(

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -579,6 +579,8 @@ async function resetStaleVerdicts(
         recordId: record.recordId,
         verdict: 'unchecked',
         confidence: 0,
+        // Migration 0213 (QUA-723) matches this exact literal to backfill
+        // historical orphans — do not change without a follow-up migration.
         reasoning: 'Reset by flagship-curate before re-verification',
         sourcesChecked: 0,
         needsRecheck: true,

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -569,6 +569,11 @@ async function resetStaleVerdicts(
     if (allowedRecordIds !== null && !allowedRecordIds.has(record.recordId)) continue;
 
     try {
+      // QUA-723: set needsRecheck=true and nextCheckDue=NOW() so the weekly
+      // sourcing-recheck cron picks these up if the in-process verify step
+      // fails or is cut off by budget/timeout. Without this, reset verdicts
+      // become permanent orphans (`getDueForRecheck()` only matches rows
+      // with needs_recheck=true OR next_check_due <= NOW()).
       await storeVerdict({
         recordType: record.recordType,
         recordId: record.recordId,
@@ -576,6 +581,8 @@ async function resetStaleVerdicts(
         confidence: 0,
         reasoning: 'Reset by flagship-curate before re-verification',
         sourcesChecked: 0,
+        needsRecheck: true,
+        nextCheckDue: new Date().toISOString(),
         ...(record.entityId ? { entityId: record.entityId } : {}),
       });
       resetCount++;


### PR DESCRIPTION
## Summary

`crux flagship-curate` step 4 reset stale verdicts to `unchecked` but wrote them with `needs_recheck=false` and an empty `next_check_due`. The weekly `sourcing-recheck` cron's `getDueForRecheck()` only matches rows where `needs_recheck=true OR next_check_due <= NOW()`, so any reset whose in-process verify (step 5) failed or was cut off by budget became a permanent orphan.

As of 2026-04-24, Anthropic alone had 18 such rows aged 4–11 days; system-wide impact is likely in the 100s.

## Changes

- **`crux/commands/flagship-curate.ts`** — reset write now passes `needsRecheck: true` and `nextCheckDue: new Date().toISOString()`. Either field is sufficient for the cron to pick the row up; setting both is unambiguous and predicate-change-proof. Comment marks the canonical `reasoning` literal as the anchor for the migration.
- **`apps/wiki-server/drizzle/0213_qua_723_flagship_curate_orphan_backfill.sql`** — one-shot UPDATE that re-arms historical orphans. Matches `reasoning` by exact equality (not `ILIKE '%flagship-curate%'`) to avoid colliding with LLM-generated reasoning text from other source-check writers. Wraps in a `DO` block with `RAISE NOTICE` of the affected row count for ops visibility. Idempotent — re-running is a no-op because the WHERE excludes rows whose `next_check_due` has been backfilled.
- **`crux/commands/flagship-curate.test.ts`** — new test asserts the reset payload includes `needsRecheck=true` and a recent `nextCheckDue` ISO string.

## Test plan

- [x] `pnpm vitest run crux/commands/flagship-curate.test.ts` — 59/59 pass (1 new)
- [x] `pnpm build` — exits 0
- [x] `pnpm test` — 7906 pass / 26 skipped, no new failures
- [x] `pnpm crux w validate gate --fix` — 55/55 pass
- [x] `npx tsc --noEmit` on apps/web, apps/wiki-server, and crux flagship-curate files — clean
- [x] Adaptive `/agent-review-pr` (4 files / 76 lines): hostile diff review found 6 findings; 3 fixed (ILIKE→exact, RAISE NOTICE, coupling comment), 2 documented as conservative (issue acceptance pinned WHERE to `IS NULL`), 1 dismissed
- [ ] After merge: monitor next `sourcing-recheck` cron run; expect Anthropic's 18 reset verdicts to flip away from `unchecked`

Fixes QUA-723


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0213 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `manual` Confirm the migration re-armed historical orphans (expect a non-zero `RAISE NOTICE` row count in the deploy logs, then `psql "$DATABASE_URL" -c "SELECT count(*) FROM source_check_verdicts WHERE reasoning='Reset by flagship-curate before re-verification' AND verdict='unchecked' AND next_check_due IS NULL;"` should return 0).
- [ ] `manual` After the next weekly `sourcing-recheck` cron run, verify Anthropic's 18 known orphans have flipped away from `unchecked` — `pnpm crux fb show anthropic` and inspect the verdict mix.
<!-- /deploy-tasks -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where certain source check verdicts were left in an incomplete state; they are now properly re-armed for rechecking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->