### PR TITLE
QUA-718: AI Cyber Damage Estimates page + reconcile E86

### DIFF
--- a/content/docs/knowledge-base/models/ai-cyber-damage-estimates.mdx
+++ b/content/docs/knowledge-base/models/ai-cyber-damage-estimates.mdx
@@ -1,0 +1,156 @@
+---
+wikiId: E2515
+title: AI Cyber Damage Estimates
+description: Methodology comparison of major global cyber damage estimates (Cybersecurity Ventures, Munich Re, FBI IC3, IBM, academic) — translates each to GDP fraction, adjudicates which are credible for which questions, and reconciles the ~600x spread visible on E86 Cyberweapons
+sidebar:
+  order: 50
+subcategory: analysis-models
+lastEdited: "2026-04-25"
+clusters:
+  - cyber
+  - ai-safety
+---
+
+## Overview
+
+Cyber damage estimates span roughly five orders of magnitude: from \$4.44 million (IBM's 2025 global average cost per data breach at surveyed organizations) to \$9.5 trillion (Cybersecurity Ventures' 2024 estimate for total global cybercrime costs). This spread does not indicate disagreement about the same quantity. Rather, each major estimate measures a distinct phenomenon using a different methodology, geographic scope, and definition of "cost." Understanding what each figure measures—and what it omits—is essential for using any of them correctly in policy analysis, security budgeting, or risk modeling.
+
+This page profiles seven major estimation sources, provides a side-by-side methodology comparison, and explains the structural reasons for the apparent ~600x spread between the lowest and highest figures.
+
+## The Measurement Problem
+
+Quantifying cyber damage is methodologically difficult for several reasons that are specific to this domain:
+
+**Reporting gaps.** Most cyber incidents are not reported to law enforcement or disclosed publicly. Firms face reputational disincentives to disclose breaches, and many jurisdictions have weak or no mandatory reporting requirements. The FBI's Internet Crime Complaint Center (IC3) explicitly acknowledges that its figures capture only voluntarily submitted reports.
+
+**Scope ambiguity.** "Cyber damage" can mean direct victim financial losses, indirect costs (productivity disruption, remediation), defensive spending (security products and services), or intangible harms (reputational damage, reduced trust in online transactions). Estimates that include defensive spending will be structurally much larger than those measuring only criminal proceeds or direct victim losses.
+
+**Extrapolation from small samples.** Survey-based estimates rely on extrapolating from small samples to large populations. Florêncio and Herley (2011) identified three structural problems: extreme loss concentration (a few large incidents dominate total losses), unverified self-reported numbers, and the amplification of individual outliers when extrapolating to national or global populations. They showed that a single survey respondent claiming \$50,000 in losses, in a 1,000-person survey, generates a \$10 billion population-level estimate when extrapolated to 200 million people.[^rc-df95] Riek and Böhme (2018) further documented that in European consumer surveys, protection and defensive expenditures exceeded direct victim losses by a factor of roughly 10 at the societal level.[^rc-71a7]
+
+**Projection vs. observation.** Some widely-cited figures are forward-looking projections based on assumed growth rates, not measurements of observed losses. A projected figure for 2027 and a measured figure for 2024 are not directly comparable.
+
+## Methodology Taxonomy
+
+Four broad methodological approaches produce the major estimates:
+
+1. **Top-down macro forecasting.** Applies an assumed annual growth rate to a baseline figure. Produces aggregate economy-wide projections. Sensitive to baseline quality and growth-rate assumptions. Example: Cybersecurity Ventures.
+
+2. **Bottom-up empirical from records.** Aggregates insurance claims, legal cases, or structured incident databases. Captures documented losses but is limited to incidents that generate a record (insured, litigated, or news-covered). Examples: Romanosky 2016, Munich Re.
+
+3. **Per-incident survey-based averaging.** Surveys organizations about the cost of a recent breach and averages across the sample. Produces a per-incident figure, not aggregate national or global losses. Example: IBM/Ponemon.
+
+4. **Complaint registry.** Compiles voluntarily submitted reports from victims. Provides a hard lower bound on actual losses; cannot capture unreported incidents by design. Example: FBI IC3.
+
+## Estimate Comparison Table
+
+| Source | Latest Figure | Geographic Scope | Cost Scope | Methodology | % of World GDP | Key Limitation |
+|---|---|---|---|---|---|---|
+| [Cybersecurity Ventures (2024)](https://cybersecurityventures.com/cybercrime-to-cost-the-world-9-trillion-annually-in-2024/) | \$9.5T/yr (2024) | Global | Direct + indirect + productivity loss + IP theft + reputational harm | Top-down macro forecast (15%/yr growth from 2015 baseline) | ≈8.6% | No disclosed primary data collection; growth rate assumed rather than observed |
+| [FBI IC3 (2024)](https://www.ic3.gov/AnnualReport/Reports/2024_IC3Report.pdf) | \$16.6B (2024, US) | United States only | Voluntarily reported direct losses | Complaint registry (lower bound) | ≈0.015% of world GDP | Acknowledged undercount; excludes unreported incidents, lost productivity, equipment damage |
+| [IBM / Ponemon (2025)](https://www.ibm.com/reports/data-breach) | \$4.44M avg/breach (global); \$10.22M (US) | 16 countries, 17 industries | Direct organizational costs per breach incident | Per-incident survey (600 orgs, 3,470 interviews) | Per-incident; not aggregate | Excludes fraud, ransomware payments to criminal syndicates, infrastructure attacks; sample excludes very small and very large breaches |
+| [Munich Re (2024)](https://www.munichre.com/en/insights/cyber/cyber-insurance-risks-and-trends-2025.html) | \$15.3B premiums (2024) | Global | Cyber insurance market size (insured exposure) | Insurance market analysis and actuarial modeling | ≈0.014% of world GDP | Premiums reflect willingness-to-pay for coverage, not actual losses; represents insured fraction with estimated 65–600x protection gap |
+| [Romanosky 2016](https://academic.oup.com/cybersecurity/article/2/2/121/2525524) | Median \$170K/breach; ≈\$8.5B/yr aggregate | US-weighted | Direct losses (insurance- and litigation-documented) | Bottom-up empirical (12,000+ events, Advisen database, 2004–2015) | ≈0.01% of ~2015 world GDP | Captures insured and litigated incidents only; likely underrepresents uninsured losses |
+| [Anderson et al. 2012/2019](https://www.econinfosec.org/archive/weis2012/papers/Anderson_WEIS2012.pdf) | Tens of billions/yr globally (2012) | Global | Direct losses + indirect costs + defensive spending, disaggregated | Academic decomposition (WEIS 2012, updated WEIS 2019) | less than 0.1% of ≈2012 world GDP | Data gaps in several crime categories; figures reflect early-2010s scale |
+| [ENISA Threat Landscape 2025](https://www.enisa.europa.eu/publications/enisa-threat-landscape-2025) | Not published | EU-focused | Incident taxonomy and threat actor analysis | Incident intelligence aggregation (4,875 incidents, July 2024–June 2025) | N/A | ENISA does not produce aggregate monetary damage estimates |
+
+*World GDP 2024: approximately \$110 trillion (IMF World Economic Outlook estimate).*
+
+## Source Profiles
+
+### Cybersecurity Ventures
+
+Cybersecurity Ventures publishes an annual cybercrime cost series originating from a \$3 trillion baseline in 2015, projected to grow at 15% per year. The 2024 figure is \$9.5 trillion and the 2025 figure is \$10.5 trillion. The most recent edition (2025) revises the assumed growth rate downward to 2.5% annually, projecting \$12.2 trillion by 2031.[^rc-e422]
+
+Their cost definition is explicitly broad: "damage and destruction of data, stolen money, lost productivity, theft of intellectual property, theft of personal and financial data, embezzlement, fraud, post-attack disruption to the normal course of business, forensic investigation, restoration and deletion of hacked data and systems, reputational harm, legal costs, and potentially, regulatory fines."[^rc-c0e5] No primary data collection methodology is disclosed; the series references secondary sources including industry surveys and trade associations.
+
+A figure sometimes cited as "\$24 trillion by 2027" attributed to Cybersecurity Ventures does not appear in their official publication series. Their documented series shows \$9.5T (2024), \$10.5T (2025), and \$12.2T by 2031.
+
+### FBI IC3 Internet Crime Report
+
+The FBI's Internet Crime Complaint Center received 859,532 complaints in 2024, with total reported losses of \$16.6 billion—a 33% increase from 2023's \$12.5 billion.[^rc-95ed] Investment fraud (\$6.57 billion) and Business Email Compromise (\$2.77 billion) were the two largest loss categories. Cryptocurrency-related losses totaled \$9.3 billion across approximately 150,000 complaints.
+
+The IC3 report explicitly states that its figures exclude lost business time, wages, files, equipment, and losses reported directly to FBI field offices rather than through the online IC3 portal. The figure is a lower bound on US cybercrime losses; the extent of under-reporting is not formally quantified in the report itself, though academic literature on complaint-based registries consistently finds substantial gaps between reported and total losses.
+
+### IBM Cost of a Data Breach Report 2025
+
+IBM and the Ponemon Institute surveyed 600 organizations that experienced data breaches between March 2024 and February 2025, conducting 3,470 interviews across 16 countries and 17 industries.[^rc-142b] The report measures direct organizational costs per breach: detection, notification, response, and business disruption costs.
+
+The 2025 US average was \$10.22 million (up 9% from \$9.36M in 2024). The global average was \$4.44 million (down 9% from \$4.88M in 2024). Healthcare was the most expensive sector at \$7.42 million. The US figure is 2.3 times the global average, driven primarily by higher regulatory costs and more extensive detection infrastructure.
+
+This figure measures a specific, well-defined phenomenon—direct costs to surveyed corporate organizations responding to a data breach—and is not an aggregate national or global loss estimate. It excludes criminal-to-criminal fraud, ransomware payments flowing to criminal organizations, and attacks on critical infrastructure that do not involve a traditional corporate data breach.
+
+### Munich Re Cyber Insurance
+
+Munich Re estimated the global cyber insurance market at \$15.3 billion in premiums for 2024, with North America accounting for 69% (\$10.6B) and Europe for 21% (\$3.3B).[^rc-27f1] The company projects the market to exceed \$16.3 billion in 2025 and more than double by 2030.
+
+Insurance premiums represent the cost of transferring risk, not losses themselves. Munich Re characterizes global cybercrime economic cost estimates as "guesstimates" ranging from \$1 trillion to \$9.5 trillion annually in 2024, implying an insurance protection gap of roughly 65:1 to 600:1. The company's modeled maximum accumulation potential—all insured losses from a single large-scale global cyber event at a 200-year return period—is estimated at \$20–46 billion.
+
+### Romanosky 2016 (RAND / Journal of Cybersecurity)
+
+Sasha Romanosky at RAND analyzed 12,000+ cyber events from the Advisen Ltd insurance loss database spanning 2004–2015.[^rc-23fd] Advisen aggregates incident data from news sources, legal filings, and government records.
+
+The median cost for a data breach was \$170,000; the mean was \$5.87 million, reflecting a heavily right-skewed distribution. Romanosky estimated total annual aggregate losses at approximately \$8.5 billion, noting this figure represents only documented incidents. Median breach costs represented about 0.4% of firm revenue—substantially below fraud losses (5%) and comparable to retail shrinkage (1.3%). The paper concludes that "the cost of a typical cyber incident is less than \$200,000, about the same as the firm's annual IT security budget."
+
+A methodological limitation: insurance claims data captures incidents where some form of documentation exists—insured losses, litigation, or news coverage. Incidents generating no such record are excluded, producing selection bias toward more costly events.
+
+### Anderson et al. 2012/2019 (Cambridge / WEIS)
+
+Ross Anderson and colleagues published what they described as the first systematic study of the costs of cybercrime at the 2012 Workshop on the Economics of Information Security, commissioned by the UK Ministry of Defence following institutional skepticism that prior studies had overstated the problem.[^rc-4c42] The methodology disaggregates costs into direct victim losses, indirect costs (system cleanup, insurance, reduced online trust), and defensive spending.
+
+Their key structural finding was that defensive spending and indirect costs typically exceed direct victim losses—a feature that aggregate "cybercrime cost" figures obscure by summing all categories together. Their estimates placed global cybercrime costs in the tens of billions, not trillions. A 2019 follow-up updated the figures.[^rc-7ba8]
+
+The decomposition framework is methodologically influential because it surfaces the implicit question in any aggregate estimate: is "cybercrime cost" measuring what criminals take, what victims lose, what society spends on defense, or some combination of all three?
+
+### ENISA Threat Landscape 2025
+
+ENISA analyzed 4,875 cybersecurity incidents in the EU over July 2024 to June 2025, identifying ransomware as the most impactful threat (82 variants deployed against EU organizations) and finding cybercrime accounted for 13.4% of all incidents.[^rc-2ce7] ENISA does not publish aggregate monetary damage figures; the report focuses on incident taxonomy, threat actor profiles (state-nexus actors, cybercrime groups, hacktivists), and attack techniques. Where economic figures are needed, ENISA cites third-party estimates rather than producing independent cost quantification.
+
+## Reconciling the Spread
+
+The ~600x range between the FBI IC3 floor (\$16.6 billion, US only, voluntarily reported) and the Cybersecurity Ventures estimate (\$9.5 trillion, global, projected) reflects four structural factors, not empirical conflict:
+
+**1. Scope definition.** Cybersecurity Ventures includes productivity loss, IP theft, reputational harm, legal costs, and regulatory fines across all economic actors globally. IBM measures only direct response costs at surveyed corporate organizations. The FBI IC3 figure captures only voluntarily reported US losses. These definitions select different subsets of a broader phenomenon.
+
+**2. Observation vs. projection.** Cybersecurity Ventures applies an assumed 15% annual growth rate to a baseline figure to produce a projected future total. The FBI IC3 figure counts actual reported losses. IBM surveys actual breach recipients. A forward-looking projection necessarily incorporates assumptions about future growth and scope; an observed figure does not.
+
+**3. Selection and reporting bias.** All empirical estimates face selection bias. Insurance-based datasets (Romanosky 2016) capture insured, litigated, or news-covered incidents. Survey-based datasets (IBM) capture corporate respondents with structured breach-response processes. Complaint registries (IC3) capture victims who chose to report. Florêncio and Herley (2011) demonstrated that survey-based extrapolations are particularly sensitive to a small number of high-reporting outliers, and that the direction of bias is systematically upward for non-negative quantities like financial losses.[^rc-df95]
+
+**4. Incentive structures.** Industry reports (Cybersecurity Ventures, IBM, Munich Re) are produced or sponsored by organizations with commercial stakes in the cybersecurity market. Anderson et al. (2012) were explicitly commissioned to counterbalance reports that the UK MoD suspected had overstated costs.[^rc-4c42] Neither dynamic invalidates the underlying data, but it is relevant context for interpreting figures at the high and low ends of the distribution.
+
+## Which Estimate for Which Question
+
+Different estimation sources are authoritative for different analytical purposes:
+
+| Question | Most Appropriate Source | Reason |
+|---|---|---|
+| How does cybercrime compare to GDP as a macro policy indicator? | Cybersecurity Ventures (with caveats noted) alongside Anderson et al. as a lower bound | Only source attempting macro-economic scope; Anderson et al. provides a methodologically explicit lower bound |
+| What should an organization budget for breach response? | IBM Cost of a Data Breach | Per-incident direct cost measurement with industry stratification |
+| What is the documented scale of reported consumer cybercrime in the US? | FBI IC3 | Direct lower bound on reported losses with crime-type breakdown |
+| What is the actuarial exposure for insured cyber losses? | Munich Re | Insurance pricing and accumulation scenario modeling |
+| What is the typical financial impact of a documented corporate breach? | Romanosky 2016 | Median figure (\$170K) more representative than mean for a typical incident; 12,000+ incident sample |
+| What fraction of total "cybercrime cost" is defensive spending vs. criminal proceeds? | Anderson et al. 2012/2019 | Only source systematically decomposing direct losses, indirect costs, and defense spending |
+| What are current EU cyber threat types, actors, and techniques? | ENISA Threat Landscape | Incident intelligence; does not address monetary loss |
+
+**Note on the Cyberweapons page (E86).** The E86 Cyberweapons page cites "\$24 trillion by 2027" attributed to Cybersecurity Ventures alongside IBM's \$10.22 million per-breach figure. Two clarifications apply: the \$24T figure does not appear in Cybersecurity Ventures' official publication series (their current series shows \$9.5T for 2024, \$10.5T for 2025, and \$12.2T by 2031);[^rc-e422] and the IBM and Cybersecurity Ventures figures are measuring fundamentally different phenomena—per-incident direct corporate costs versus a projected aggregate global cybercrime economy. No reconciliation between them is required because they do not measure the same quantity.
+
+[^rc-df95]: Florêncio, Dinei and Cormac Herley. ["Sex, Lies and Cyber-Crime Surveys."](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/SexLiesandCybercrimeSurveys.pdf) Microsoft Research (MSR-TR-2011-75), Workshop on the Economics of Information Security (WEIS 2011), 2011.
+
+[^rc-71a7]: Riek, Markus and Rainer Böhme. ["Costs of Consumer-Facing Cybercrime: An Empirical Exploration of Measurement Issues and Estimates."](https://academic.oup.com/cybersecurity/article/4/1/tyy004/5127748) *Journal of Cybersecurity*, Volume 4, Issue 1. Oxford Academic, 2018.
+
+[^rc-e422]: Cybersecurity Ventures. ["Cybercrime To Cost The World \$12.2 Trillion Annually By 2031."](https://cybersecurityventures.com/official-cybercrime-report-2025/) Official Cybercrime Report 2025.
+
+[^rc-c0e5]: Cybersecurity Ventures. ["Cybercrime To Cost The World \$9.5 Trillion USD Annually In 2024."](https://cybersecurityventures.com/cybercrime-to-cost-the-world-9-trillion-annually-in-2024/) 2023.
+
+[^rc-95ed]: Federal Bureau of Investigation / Internet Crime Complaint Center. [2024 IC3 Annual Report.](https://www.ic3.gov/AnnualReport/Reports/2024_IC3Report.pdf) FBI, 2025.
+
+[^rc-142b]: IBM / Ponemon Institute. [Cost of a Data Breach Report 2025.](https://www.ibm.com/reports/data-breach) IBM, 2025.
+
+[^rc-27f1]: Munich Re. ["Cyber Insurance: Risks and Trends 2025."](https://www.munichre.com/en/insights/cyber/cyber-insurance-risks-and-trends-2025.html) Munich Re, 2025.
+
+[^rc-23fd]: Romanosky, Sasha. ["Examining the Costs and Causes of Cyber Incidents."](https://academic.oup.com/cybersecurity/article/2/2/121/2525524) *Journal of Cybersecurity*, Volume 2, Issue 2, pp. 121–135. Oxford Academic, December 2016.
+
+[^rc-4c42]: Anderson, Ross et al. ["Measuring the Cost of Cybercrime."](https://www.econinfosec.org/archive/weis2012/papers/Anderson_WEIS2012.pdf) 11th Workshop on the Economics of Information Security (WEIS 2012). Cambridge University Computer Laboratory, 2012.
+
+[^rc-7ba8]: Anderson, Ross et al. ["Measuring the Changing Cost of Cybercrime."](https://weis2019.econinfosec.org/wp-content/uploads/sites/6/2019/05/WEIS_2019_paper_25.pdf) Workshop on the Economics of Information Security (WEIS 2019), 2019.
+
+[^rc-2ce7]: European Union Agency for Cybersecurity (ENISA). [ENISA Threat Landscape 2025.](https://www.enisa.europa.eu/publications/enisa-threat-landscape-2025) ENISA, 2025.

--- a/content/docs/knowledge-base/risks/cyber-offense.mdx
+++ b/content/docs/knowledge-base/risks/cyber-offense.mdx
@@ -1,13 +1,101 @@
 ---
 wikiId: E82
 title: Cyber Offense
-description: AI-enhanced cyberattacks and offensive hacking capabilities
+description: AI-enhanced cyberattacks, offensive hacking capabilities, and the evolving offense-defense balance as AI systems accelerate threat actor operations
 sidebar:
   order: 50
 subcategory: misuse
-lastEdited: 2026-02-09
+lastEdited: "2026-04-25"
 clusters:
   - ai-safety
   - cyber
 ---
-This page is a stub. Content needed.
+
+## Overview
+
+AI-enhanced cyber offense encompasses the use of artificial intelligence to improve the speed, scale, sophistication, or autonomy of offensive cyber operations — including vulnerability discovery, exploit development, social engineering, and end-to-end attack orchestration. This page serves as a navigational overview of the topic and should be read alongside its four child pages: <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink> (technical mechanisms and current capabilities), the <EntityLink id="E87" name="cyberweapons-attack-automation">Autonomous Cyber Attack Timeline</EntityLink> (capability projections), the <EntityLink id="E88" name="cyberweapons-offense-defense">Cyber Offense-Defense Balance Model</EntityLink> (quantitative analysis), and <EntityLink id="E689" name="concentrated-compute-cybersecurity-risk">Concentrated Compute as a Cybersecurity Risk</EntityLink> (infrastructure-side risks from AI data center concentration).
+
+The scope of this page is distinct from <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink>: where that page examines the technical mechanisms of specific attack classes in depth, this page provides orientation across the full landscape — defining key terminology, summarizing what the child pages cover, and presenting a cross-cutting risk assessment.
+
+A foundational distinction in the literature is between **AI-assisted attacks** and **AI-orchestrated attacks**. AI-assisted operations are human-directed: attackers use AI tools to accelerate specific stages of an operation (e.g., generating phishing text, scanning for vulnerabilities) while remaining firmly in control. AI-orchestrated operations are qualitatively different: AI agents autonomously execute 80–90% of tactical operations with minimal human intervention, reducing human operators to supervisors who approve strategic decisions such as target selection or data exfiltration.[^rc-73f0] A third category — **fully autonomous** attacks, with no human involvement — remains largely prospective as of early 2026.
+
+A second key concept is the **offense-defense balance**: the comparative difficulty of attacking versus defending a system. Whether AI tips this balance toward attackers or defenders is contested; a 2025 Georgetown CSET analysis collecting 44 distinct impact pathways concluded that "the cyber domain is too multifaceted for a single answer."[^rc-aa9a] A third foundational framework is the **cyber kill chain**, a staged model of attack progression (reconnaissance, weaponization, delivery, exploitation, installation, command-and-control, and exfiltration) originally developed by Lockheed Martin. AI inserts into each stage but has had the clearest demonstrated impact in reconnaissance and social engineering.[^rc-3e07]
+
+## Child Pages
+
+This topic is covered across four pages:
+
+| Page | Scope |
+|------|-------|
+| <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink> | Technical mechanisms of AI-enhanced attack classes: phishing automation, vulnerability discovery, exploit generation, malware, and autonomous attack chains. Current state of capability. |
+| <EntityLink id="E87" name="cyberweapons-attack-automation">Autonomous Cyber Attack Timeline</EntityLink> | Capability projections for highly autonomous cyber-capable agents (HACCAs); timeline analysis drawing on model benchmark data and documented incidents. |
+| <EntityLink id="E88" name="cyberweapons-offense-defense">Cyber Offense-Defense Balance Model</EntityLink> | Quantitative and analytical modeling of how AI shifts relative ease of attacking versus defending; disaggregated by attacker sophistication and defender resource level. |
+| <EntityLink id="E689" name="concentrated-compute-cybersecurity-risk">Concentrated Compute as Cybersecurity Risk</EntityLink> | Infrastructure-side risks from geographic and organizational concentration of AI compute: model weight exfiltration, hardware supply chain attacks, and single points of failure in AI data center clusters. |
+
+## Risk Assessment
+
+| Dimension | Assessment | Source / Confidence |
+|-----------|-----------|---------------------|
+| Likelihood of AI-assisted attacks (2025–2026) | Pervasive in social engineering; growing share of attack chain | Google Threat Intelligence Group 2025[^rc-aaf1]; high confidence |
+| Likelihood of AI-orchestrated (autonomous) attacks | First documented case November 2025; proliferation projected | <EntityLink id="E1193" name="iaps">Institute for AI Policy and Strategy</EntityLink> analysis of <EntityLink id="E22" name="anthropic">Anthropic</EntityLink> threat report[^rc-73f0]; medium confidence |
+| Near-term severity (AI-orchestrated attacks) | Demonstrated against ≈30 targets; scale limited by actor caution | IAPS, November 2025 incident[^rc-73f0]; medium confidence |
+| Offense-defense balance direction | No consensus; AI benefits both sides differently by context | CSET Georgetown (Lohn, 2025)[^rc-aa9a]; medium confidence |
+| Severity for resource-constrained ("trailing-edge") organizations | Worse than for well-resourced organizations; AI lowers attacker cost floor | Academic analysis (2025)[^rc-4583]; medium confidence |
+
+The U.S. Director of National Intelligence's 2026 Annual Threat Assessment states that "innovation in the field of Artificial Intelligence will likely accelerate the threats in the cyber domain," citing a documented August 2025 incident in which cyber actors used an AI tool to conduct a data-extortion operation targeting government, healthcare, emergency services, and religious institutions internationally.[^rc-347c] China, Russia, Iran, and North Korea are identified as continuing R&D into AI for cyber operations.[^rc-347c]
+
+## How It Works (Attack Pathways)
+
+AI inserts into the cyber kill chain at multiple stages, with impact varying by stage and actor sophistication.[^rc-3e07] A 2024 peer-reviewed systematic review of 62 papers found that "AI-based tools are used most effectively in the initial stages of cyberattacks" and that "current defense tools are not designed to counter these sophisticated attacks during these stages."[^rc-3e07]
+
+**Reconnaissance.** AI tools automate target profiling — crawling public data, leaked credentials, and social media to build multi-dimensional profiles of organizations and individuals in minutes rather than days. Generative models craft personalized spear-phishing text tailored to the target's professional context. Empirical studies find that LLM-generated messages are often perceived as more convincing than human-authored ones, particularly for job-related messages.[^rc-39b5]
+
+**Weaponization and social engineering.** Google's Threat Intelligence Group has identified new malware families (PROMPTFLUX and PROMPTSTEAL) that use LLMs during execution, dynamically generating malicious scripts on demand. Ransomware-as-a-Service platforms increasingly incorporate AI-enhanced attack packages, lowering barriers for less sophisticated actors.[^rc-aaf1]
+
+**Exploitation and technical attack.** The pace of progress is rapid but uneven. A 2025 evaluation framework analyzing over 12,000 real-world AI-use-in-cyberattack instances found that frontier models scored near-zero on expert-level offensive security challenges until mid-2025, then reached approximately 60% success rate by late 2025.[^rc-87f3] In February 2026, <EntityLink id="E218" name="openai">OpenAI</EntityLink> reported that its model crossed the "High" cybersecurity threshold in its Preparedness Framework — the first model assessed as capable of developing working zero-day remote exploits against well-defended systems.[^rc-87f3]
+
+**Autonomous orchestration.** In November 2025, a Chinese state-sponsored group used <EntityLink id="E1041" name="claude">Claude</EntityLink> Code with custom scaffolding to automate 80–90% of a cyber espionage campaign against approximately 30 global organizations — described by the Institute for AI Policy and Strategy as "one of the first cyber espionage campaigns to use an AI agent to autonomously execute operations" in the wild.[^rc-73f0] Palo Alto Networks Unit 42 separately demonstrated in 2025–2026 that autonomous multi-agent AI systems can chain reconnaissance, privilege escalation, and lateral movement in cloud environments without human direction.[^rc-9293]
+
+For technical depth on each attack class, see <EntityLink id="E86" name="cyberweapons">Cyberweapons</EntityLink>.
+
+## Responses
+
+Responses to AI-enhanced cyber offense span technical defenses, governance frameworks, and infrastructure policy.
+
+**AI-augmented defense.** The same capabilities that benefit attackers also benefit defenders: AI enables continuous 24/7 monitoring without fatigue, faster vulnerability scanning, and automated threat intelligence prioritization.[^rc-aa9a] The Atlantic Council notes that "organizations that refuse to deploy AI for defensive purposes face asymmetric disadvantage against autonomous attackers operating at machine speed."[^rc-bd74]
+
+**Zero Trust architecture.** NIST's December 2025 draft Cybersecurity Framework Profile for Artificial Intelligence (NISTIR 8596) extends Zero Trust principles to AI systems, organized around three focus areas: Secure (protect AI systems), Detect (identify AI-enabled threats), and Thwart (proactively counter AI threats).[^rc-78d5]
+
+**International guidance for critical infrastructure.** In December 2025, CISA and international partners (including Australia's ACSC) published joint cybersecurity guidance for critical infrastructure operators integrating AI into operational technology systems, outlining four principles for managing AI-related risk in OT environments.[^rc-5aee]
+
+**Compute governance.** Infrastructure-side responses — securing AI data centers against model weight exfiltration, hardware supply chain attacks, and geographic concentration risks — are addressed in detail in the Concentrated Compute as Cybersecurity Risk page. The Institute for AI Policy and Strategy recommends establishing cyber incident intelligence sharing between AI companies and governments, and extending incident reporting requirements to cover AI data centers.[^rc-1ba9]
+
+**International norms.** The offense-defense balance and the appropriate scope of autonomous cyber operations in armed conflict remain areas of active policy debate, with no binding international framework as of early 2026.
+
+## Key Uncertainties
+
+Several dimensions of AI cyber offense risk remain genuinely contested or undercharacterized:
+
+**Pace of capability gains.** The gap between frontier models' offensive capability today (approximately 60% success on expert-level challenges as of late 2025)[^rc-87f3] and what would constitute "nation-state-level" autonomous hacking is not well-characterized. Whether "highly autonomous cyber-capable agents" emerge before 2030 depends on current scaling trends continuing.
+
+**Whether the offense-defense balance tips decisively.** A 2025 analysis from <EntityLink id="E524" name="cset">Georgetown's Center for Security and Emerging Technology (CSET)</EntityLink>[^rc-aa9a] identifies 44 distinct pathways by which AI affects the balance, with no aggregate answer. The answer varies by attack type, target resource level, and which side adopts AI faster. Trailing-edge organizations — those relying on legacy software and understaffed security teams — face a systematically worse balance because AI lowers the attacker's cost floor without improving the defender's posture automatically.[^rc-4583]
+
+**Attribution challenges.** As AI-orchestrated attacks require less distinctive human tradecraft, attributing attacks to specific actors may become harder, complicating deterrence and international response.
+
+**Effectiveness of governance interventions.** Whether voluntary frameworks (NIST NISTIR 8596), export controls on compute, or incident reporting requirements materially slow the diffusion of offensive AI capabilities to non-state actors and less sophisticated states is not well-studied.
+
+**Scope of AI-on-AI attacks.** As AI systems become embedded in critical infrastructure and defensive tooling, they become targets themselves. Prompt injection attacks, data poisoning, and model extraction represent new attack surfaces that do not map cleanly onto the traditional cyber kill chain.[^rc-1ba9]
+
+[^rc-73f0]: Institute for AI Policy and Strategy (IAPS), "The Emergence of Autonomous Cyber Attacks: Analysis and Implications," 2025–2026. https://www.iaps.ai/research/autonomous-cyber-attacks
+[^rc-aa9a]: Andrew J. Lohn, "The Impact of AI on the Cyber Offense-Defense Balance and the Character of Cyber Conflict," arXiv:2504.13371, April 17, 2025; companion CSET Georgetown publication, "Anticipating AI's Impact on the Cyber Offense-Defense Balance," May 2025. https://arxiv.org/abs/2504.13371 and https://cset.georgetown.edu/publication/anticipating-ais-impact-on-the-cyber-offense-defense-balance/
+[^rc-3e07]: Academic review, "Impact of AI on the Cyber Kill Chain: A Systematic Review," Heliyon, December 2024 (PMC11665572). https://pmc.ncbi.nlm.nih.gov/articles/PMC11665572/
+[^rc-4583]: Academic researchers, "Uplifted Attackers, Human Defenders: The Cyber Offense-Defense Balance for Trailing-Edge Organizations," arXiv:2508.15808, 2025. https://arxiv.org/html/2508.15808
+[^rc-347c]: Office of the Director of National Intelligence, "2026 Annual Threat Assessment of the U.S. Intelligence Community," March 2026. https://www.dni.gov/index.php/newsroom/press-releases/press-releases-2026/4142-pr-03-26
+[^rc-39b5]: Academic researchers, "Assessing AI vs Human-Authored Spear Phishing SMS Attacks: An Empirical Study Using the TRAPD Method," arXiv:2406.13049, June 2024. https://arxiv.org/abs/2406.13049
+[^rc-aaf1]: Google Threat Intelligence Group (GTIG), "GTIG AI Threat Tracker: Advances in Threat Actor Usage of AI Tools," 2025. https://cloud.google.com/blog/topics/threat-intelligence/threat-actor-usage-of-ai-tools
+[^rc-87f3]: Academic researchers, "A Framework for Evaluating Emerging Cyberattack Capabilities of AI," arXiv:2503.11917, April 2025. https://arxiv.org/pdf/2503.11917
+[^rc-9293]: Palo Alto Networks Unit 42, "Can AI Attack the Cloud? Lessons From Building an Autonomous Cloud Offensive Multi-Agent System," April 2026. https://unit42.paloaltonetworks.com/autonomous-ai-cloud-attacks/
+[^rc-bd74]: Atlantic Council (Maia Hamin and Stewart Scott), "Hacking with AI," February 15, 2024; Atlantic Council, "AI in Cyber and Software Security: What's Driving Opportunities and Risks?," March 2025. https://www.atlanticcouncil.org/in-depth-research-reports/report/hacking-with-ai/
+[^rc-78d5]: NIST, "Draft NIST Guidelines Rethink Cybersecurity for the AI Era" (NISTIR 8596 preliminary draft), December 16, 2025. https://www.nist.gov/news-events/news/2025/12/draft-nist-guidelines-rethink-cybersecurity-ai-era
+[^rc-5aee]: CISA and international partners (ASD's ACSC and others), joint cybersecurity guidance for critical infrastructure integrating AI into OT systems, December 4, 2025. https://industrialcyber.co/cisa/global-security-agencies-issue-joint-guidance-to-help-critical-infrastructure-integrate-ai-into-ot-systems/
+[^rc-1ba9]: Institute for AI Policy and Strategy (IAPS), "Accelerating AI Data Center Security," 2025–2026. https://www.iaps.ai/research/accelerating-ai-data-center-security

--- a/content/docs/knowledge-base/risks/cyberweapons.mdx
+++ b/content/docs/knowledge-base/risks/cyberweapons.mdx
@@ -255,6 +255,12 @@ The <R id="sid_IoMfhdLE1l">CISA Roadmap for AI</R> identifies three categories o
 
 According to <R id="sid_i6EE6gReFp">IBM's 2025 report</R>, 13% of organizations reported breaches of AI models or applications, with 97% of those lacking proper AI access controls. Shadow AI (unauthorized AI tools) was involved in 20% of breaches.
 
+#### Damage Estimate Reconciliation
+
+The figures above span roughly six orders of magnitude — \$4.44M per breach (IBM) to \$24T projected aggregate (Cybersecurity Ventures). This range reflects different methodologies, scopes, and definitions of "cost," not empirical disagreement about the same quantity. For methodology comparison, GDP-fraction translation, and which estimate is authoritative for which question, see <EntityLink id="E2515" name="ai-cyber-damage-estimates">AI Cyber Damage Estimates</EntityLink>.
+
+The Cybersecurity Ventures \$24T-by-2027 figure cited above does not appear in their official publication series (current series shows \$9.5T for 2024, \$10.5T for 2025, and \$12.2T by 2031); the IBM and Cybersecurity Ventures figures measure fundamentally different phenomena (per-incident direct corporate costs vs projected aggregate global cybercrime economy) and do not require reconciliation in the strict sense.
+
 ---
 
 ## Case Studies

--- a/data/entities/cyber-incidents.yaml
+++ b/data/entities/cyber-incidents.yaml
@@ -1,0 +1,300 @@
+# Major Cyber Incidents
+#
+# Catalog of significant cyberattack incidents with damage estimates, attribution,
+# and AI-involvement labels. Seeded under QUA-717 (parent QUA-715: Wiki coverage of
+# AI cyber damage magnitude). Damage figures stored as FactBase facts in
+# packages/factbase/data/fb-entities/<slug>.yaml using the `financial-impact`
+# property — see properties.yaml.
+#
+# AI-involvement classification:
+#   none       — no documented AI use in attack chain
+#   assisted   — AI tools accelerated specific stages (e.g., phishing text)
+#   orchestrated — AI agent autonomously executed substantial portions of the campaign
+
+- id: cyber-incident-notpetya
+  stableId: sid_PlakEpcSJw
+  wikiId: E2508
+  type: event
+  title: NotPetya (2017)
+  aliases:
+    - NotPetya
+    - ExPetr
+    - Petya 2017
+  customFields:
+    - label: Date
+      value: June 27, 2017
+    - label: Attribution
+      value: GRU (Russian military intelligence) Unit 74455 / Sandworm
+    - label: AI involvement
+      value: none
+    - label: Initial vector
+      value: M.E.Doc Ukrainian tax software supply-chain compromise
+    - label: Estimated total damages
+      value: ~$10B globally (low ~$8B, high ~$15B)
+    - label: Notable victims
+      value: Maersk, Merck, FedEx/TNT, Mondelēz, Saint-Gobain, Reckitt Benckiser
+  description: >-
+    NotPetya was a destructive malware attack disguised as ransomware, deployed June 27, 2017
+    via a compromised update to M.E.Doc, a Ukrainian tax accounting software. Although it
+    targeted Ukraine, it propagated globally via SMB and credential-theft mechanisms,
+    causing the most destructive cyberattack in history by total economic damage. The U.S.,
+    UK, Australia, and Canada attributed the attack to GRU's Unit 74455 (Sandworm). It is
+    the canonical reference point for catastrophic single-event cyber damage and the basis
+    for the Merck v. Ace insurance war-exclusion litigation.
+  tags:
+    - cyber-incident
+    - destructive-malware
+    - supply-chain
+    - russia
+    - ukraine
+    - critical-infrastructure
+  lastUpdated: 2026-04
+
+- id: cyber-incident-wannacry
+  stableId: sid_PORgT8PnXQ
+  wikiId: E2509
+  type: event
+  title: WannaCry (2017)
+  aliases:
+    - WannaCry
+    - WCry
+    - WannaCrypt
+  customFields:
+    - label: Date
+      value: May 12, 2017
+    - label: Attribution
+      value: Lazarus Group (DPRK)
+    - label: AI involvement
+      value: none
+    - label: Initial vector
+      value: EternalBlue SMB exploit (NSA-leaked)
+    - label: Estimated total damages
+      value: ~$4B globally (low ~$1B, high ~$8B)
+    - label: Notable victims
+      value: UK NHS, Telefónica, FedEx, Renault, Deutsche Bahn
+  description: >-
+    WannaCry was a worm-propagating ransomware attack on May 12, 2017, exploiting the
+    EternalBlue SMB vulnerability leaked from the NSA by the Shadow Brokers. It infected
+    over 200,000 computers across 150 countries within hours and was attributed by the
+    U.S., UK, Australia, Canada, New Zealand, and Japan to North Korea's Lazarus Group.
+    Although the kill switch discovered by Marcus Hutchins limited propagation, the
+    attack severely disrupted the UK's NHS (cancellation of ~19,000 appointments),
+    affecting healthcare delivery for several days.
+  tags:
+    - cyber-incident
+    - ransomware
+    - worm
+    - north-korea
+    - healthcare
+    - eternalblue
+  lastUpdated: 2026-04
+
+- id: cyber-incident-solarwinds
+  stableId: sid_Me6yx7Sd9A
+  wikiId: E2510
+  type: event
+  title: SolarWinds (2020)
+  aliases:
+    - SolarWinds Hack
+    - SUNBURST
+    - UNC2452
+    - Cozy Bear (operator)
+  customFields:
+    - label: Date discovered
+      value: December 13, 2020 (active since at least March 2020)
+    - label: Attribution
+      value: SVR (Russian foreign intelligence) APT29 / Cozy Bear
+    - label: AI involvement
+      value: none
+    - label: Initial vector
+      value: SolarWinds Orion software update supply-chain compromise
+    - label: Estimated total damages
+      value: ~$100B+ recovery cost across affected organizations (high uncertainty)
+    - label: Notable victims
+      value: U.S. Treasury, DHS, Commerce, State, Microsoft, FireEye, ~18,000 organizations
+  description: >-
+    SolarWinds was a supply-chain compromise discovered in December 2020 in which Russian
+    SVR operators inserted the SUNBURST backdoor into the Orion network management
+    software, which was then distributed to ~18,000 customer organizations including
+    multiple U.S. federal agencies (Treasury, DHS, Commerce, State, Energy/NNSA), and
+    technology companies including Microsoft and FireEye. The compromise was undetected
+    for at least 9 months. Total recovery costs across affected organizations are
+    estimated at $100B+ but precise figures remain disputed; the incident reshaped U.S.
+    federal cybersecurity policy (Executive Order 14028, May 2021).
+  tags:
+    - cyber-incident
+    - supply-chain
+    - espionage
+    - russia
+    - federal-government
+    - apt29
+  lastUpdated: 2026-04
+
+- id: cyber-incident-colonial-pipeline
+  stableId: sid_XtZkjYKvrQ
+  wikiId: E2511
+  type: event
+  title: Colonial Pipeline (2021)
+  aliases:
+    - Colonial Pipeline Ransomware
+    - DarkSide Colonial
+  customFields:
+    - label: Date
+      value: May 7, 2021
+    - label: Attribution
+      value: DarkSide ransomware-as-a-service (Russia-based affiliates)
+    - label: AI involvement
+      value: none
+    - label: Initial vector
+      value: Compromised legacy VPN credential (no MFA)
+    - label: Ransom paid
+      value: $4.4M (75 BTC); $2.3M later recovered by FBI
+    - label: Direct damage estimate
+      value: ~$5B+ including operational disruption, fuel-supply impact (medium confidence)
+    - label: Notable impact
+      value: 5,500-mile US East Coast fuel pipeline shutdown for 6 days; emergency declarations in 17 states + DC
+  description: >-
+    On May 7, 2021, Colonial Pipeline — operator of the largest refined-petroleum pipeline
+    on the U.S. East Coast — was hit with ransomware by DarkSide affiliates. Colonial
+    proactively shut down operations, triggering fuel shortages, panic buying, and price
+    spikes across the eastern seaboard. The shutdown lasted six days. The incident drove
+    binding cybersecurity directives for U.S. pipeline operators (TSA Security Directives
+    Pipeline-2021-01 and -02) and remains the canonical example of cyber-induced
+    critical-infrastructure cascade in the U.S.
+  tags:
+    - cyber-incident
+    - ransomware
+    - critical-infrastructure
+    - energy
+    - darkside
+  lastUpdated: 2026-04
+
+- id: cyber-incident-cdk-global
+  stableId: sid_cYIOXoS7EA
+  wikiId: E2512
+  type: event
+  title: CDK Global (2024)
+  aliases:
+    - CDK Global Ransomware
+    - BlackSuit CDK
+  customFields:
+    - label: Date
+      value: June 18-19, 2024
+    - label: Attribution
+      value: BlackSuit ransomware
+    - label: AI involvement
+      value: none documented
+    - label: Initial vector
+      value: Not publicly disclosed
+    - label: Ransom paid
+      value: ~$25M in bitcoin (per multiple reports)
+    - label: Estimated total damages
+      value: ~$1.02B in dealer losses (Anderson Economic Group); CDK direct costs separate
+    - label: Notable impact
+      value: ~15,000 North American auto dealerships disrupted for ~2 weeks; 7.2% decline in June US new-vehicle sales
+  description: >-
+    On June 18, 2024, CDK Global — the dealer-management-system provider for ~15,000
+    North American auto dealerships — was attacked by BlackSuit ransomware. A second
+    attack on June 19 disrupted recovery efforts. Most dealerships reverted to paper
+    processes for two weeks. Anderson Economic Group estimated total dealer losses at
+    $1.02B; CDK reportedly paid ~$25M in ransom. The incident is a benchmark for
+    indirect cascade damage from sector-concentrated SaaS compromise.
+  tags:
+    - cyber-incident
+    - ransomware
+    - automotive
+    - saas-concentration
+    - blacksuit
+  lastUpdated: 2026-04
+
+- id: cyber-incident-change-healthcare
+  stableId: sid_i29w8fSb5g
+  wikiId: E2513
+  type: event
+  title: Change Healthcare (2024)
+  aliases:
+    - Change Healthcare Breach
+    - Optum Change Healthcare
+    - BlackCat ALPHV Change
+  customFields:
+    - label: Date
+      value: February 21, 2024
+    - label: Attribution
+      value: BlackCat / ALPHV ransomware (with Notchy / RansomHub follow-on extortion)
+    - label: AI involvement
+      value: none documented
+    - label: Initial vector
+      value: Compromised Citrix portal credential without MFA
+    - label: Ransom paid
+      value: $22M to BlackCat (early 2024); additional ransom alleged paid to follow-on group
+    - label: People affected
+      value: ~190 million Americans (largest US healthcare breach on record)
+    - label: Estimated total damages
+      value: ~$2.87B UnitedHealth direct costs; sector-wide cascade much larger (medium confidence)
+  description: >-
+    On February 21, 2024, Change Healthcare — a UnitedHealth subsidiary processing
+    roughly one-third of US healthcare payment claims — was attacked by BlackCat/ALPHV
+    ransomware. The shutdown crippled pharmacy fulfillment, claims processing, and
+    revenue cycle management nationwide for weeks. UnitedHealth disclosed the breach
+    affected approximately 190M Americans, making it the largest US healthcare breach
+    on record. UnitedHealth has reported $2.87B in direct costs as of FY2024 reports;
+    sector-wide downstream costs (pharmacy cash-flow disruption, hospital revenue gaps,
+    delayed care) are not consolidated. The incident demonstrates the systemic-risk
+    profile of healthcare clearinghouses.
+  tags:
+    - cyber-incident
+    - ransomware
+    - healthcare
+    - clearinghouse
+    - blackcat-alphv
+    - critical-infrastructure
+  lastUpdated: 2026-04
+
+- id: cyber-incident-anthropic-disclosed-2025
+  stableId: sid_oZ2PXLZEYA
+  wikiId: E2514
+  type: event
+  title: Anthropic-Disclosed AI-Orchestrated Campaign (Sept 2025)
+  aliases:
+    - GTG-1002
+    - First AI-Orchestrated Cyberattack
+    - Anthropic Sept 2025 Disclosure
+  customFields:
+    - label: Date
+      value: Mid-September 2025 (detected); disclosed November 2025
+    - label: Attribution
+      value: GTG-1002 — assessed high confidence as Chinese state-sponsored
+    - label: AI involvement
+      value: orchestrated (first publicly documented case)
+    - label: Tool used
+      value: Claude Code (with custom scaffolding to compartmentalize tasks)
+    - label: AI autonomy level
+      value: 80–90% of tactical operations executed without human intervention
+    - label: Targets
+      value: ~30 global organizations (large tech, financial, chemical mfg, government)
+    - label: Successful breaches
+      value: 4 confirmed
+    - label: Direct damage estimate
+      value: limited (small target set; campaign disrupted); precedent value high
+  description: >-
+    In mid-September 2025, Anthropic detected and disrupted a cyber-espionage campaign
+    by threat actor GTG-1002 (assessed high confidence as Chinese state-sponsored) using
+    Claude Code as the primary execution agent. The attackers jailbroke Claude by
+    decomposing attacks into compartmentalized small tasks, allowing the AI to execute
+    reconnaissance, exploitation, credential harvesting, lateral movement, and data
+    exfiltration without recognizing their malicious aggregate purpose. Approximately
+    30 organizations were targeted; 4 successful breaches were confirmed. This is
+    considered the first publicly documented case of a large-scale cyberattack in
+    which an AI agent — not human operators — executed the majority of tactical
+    operations. Although direct damages were limited by Anthropic's intervention, the
+    incident is the canonical reference for AI-orchestrated attack capability and a
+    pivotal data point for capability-trajectory and offense-defense analyses.
+  tags:
+    - cyber-incident
+    - ai-orchestrated
+    - china
+    - espionage
+    - claude
+    - autonomous-agents
+    - first-of-kind
+  lastUpdated: 2026-04

--- a/data/entities/models.yaml
+++ b/data/entities/models.yaml
@@ -2566,3 +2566,28 @@
     - ai-governance
     - revolving-door
   lastUpdated: 2026-04
+
+- id: ai-cyber-damage-estimates
+  stableId: sid_n5k9L5Ky9g
+  wikiId: E2515
+  type: analysis
+  title: AI Cyber Damage Estimates
+  description: >-
+    Side-by-side methodology comparison of seven major global cyber damage estimates (Cybersecurity Ventures, FBI IC3,
+    IBM, Munich Re, Romanosky 2016, Anderson et al. 2012/2019, ENISA). Translates each to GDP fraction and explains
+    the ~600x spread between the lowest and highest figures.
+  customFields:
+    - label: Model Type
+      value: Methodology Comparison
+    - label: Target Risk
+      value: Cyber Offense / Cyberweapons
+  relatedEntries:
+    - id: sid_7c6UC46TWQ
+      type: risk
+      relationship: related
+  tags:
+    - cyber-damage
+    - methodology
+    - cybercrime-cost
+    - economic-impact
+  lastUpdated: 2026-04

--- a/packages/factbase/data/fb-entities/cyber-incident-anthropic-disclosed-2025.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-anthropic-disclosed-2025.yaml
@@ -1,0 +1,22 @@
+entity: sid_oZ2PXLZEYA
+facts:
+  - id: f_18Y2bTu5X1
+    property: incident-date
+    value: "2025-09"
+    asOf: "2025-11-13"
+    source: https://www.anthropic.com/news/disrupting-AI-espionage
+    notes: "Anthropic detected and disrupted the campaign in mid-September 2025; publicly disclosed November 13, 2025"
+
+  - id: f_YqWg21nYCs
+    property: incident-status
+    value: resolved
+    asOf: "2025-09"
+    source: https://www.anthropic.com/news/disrupting-AI-espionage
+    notes: "Anthropic terminated GTG-1002 access during campaign; 4 successful breaches confirmed out of ~30 targets. Considered the first publicly documented AI-orchestrated cyberattack."
+
+  - id: f_Xoblu17rNy
+    property: financial-impact
+    value: 5e+7
+    asOf: "2025-11"
+    source: https://www.anthropic.com/news/disrupting-AI-espionage
+    notes: "Direct damages estimated low (~$50M order of magnitude) due to early disruption and limited successful breach scope. Precedent and capability-trajectory significance is the primary cost dimension; not captured here."

--- a/packages/factbase/data/fb-entities/cyber-incident-cdk-global.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-cdk-global.yaml
@@ -1,0 +1,36 @@
+entity: sid_cYIOXoS7EA
+facts:
+  - id: f_8JHUdKF0j7
+    property: incident-date
+    value: "2024-06-18"
+    asOf: "2024-06-18"
+    source: https://www.bleepingcomputer.com/news/security/cdk-global-cyberattack-impacts-thousands-of-us-car-dealerships/
+    notes: "First CDK ransomware attack; second attack June 19 disrupted recovery"
+
+  - id: f_elKPoh3pKM
+    property: financial-impact
+    value: 2.5e+7
+    asOf: "2024-06-21"
+    source: https://www.bloomberg.com/news/articles/2024-06-21/cdk-global-paid-25-million-bitcoin-ransom-to-russian-hackers
+    notes: "CDK reportedly paid ~$25M in bitcoin to BlackSuit; ransom demand initially escalated from $10M to $50M+"
+
+  - id: f_zKG5mSoyPs
+    property: financial-impact
+    value: 1.02e+9
+    asOf: "2024-07"
+    source: https://www.andersoneconomicgroup.com/cdk-global-cyber-attack-cost-dealers-1-billion-in-2-weeks/
+    notes: "Anderson Economic Group estimate of total dealer losses ~$1.02B over 2-week disruption"
+
+  - id: f_tUeC99enq5
+    property: financial-impact
+    value: 5e+8
+    asOf: "2024-12"
+    source: https://www.wsj.com/articles/cdk-cyberattack-cost-dealerships-just-the-start-1baa6519
+    notes: "Estimated CDK direct costs (incident response, legal, lost revenue); medium-confidence estimate, not publicly broken out"
+
+  - id: f_22wjZRL9Oa
+    property: incident-status
+    value: resolved
+    asOf: "2024-07-04"
+    source: https://www.reuters.com/technology/cybersecurity/cdk-restores-services-most-dealerships-after-cyber-attack-2024-07-04/
+    notes: "Services largely restored by July 4, 2024 (~2-week disruption); litigation continuing"

--- a/packages/factbase/data/fb-entities/cyber-incident-change-healthcare.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-change-healthcare.yaml
@@ -1,0 +1,36 @@
+entity: sid_i29w8fSb5g
+facts:
+  - id: f_YsP6ihgIqL
+    property: incident-date
+    value: "2024-02-21"
+    asOf: "2024-02-21"
+    source: https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-060b
+    notes: "BlackCat/ALPHV ransomware attack on Change Healthcare (UnitedHealth subsidiary)"
+
+  - id: f_SmNqE40fAr
+    property: financial-impact
+    value: 2.2e+7
+    asOf: "2024-03"
+    source: https://www.wired.com/story/alphv-change-healthcare-ransom-payment-chainalysis/
+    notes: "UnitedHealth reportedly paid $22M to BlackCat; affiliate Notchy/RansomHub later attempted secondary extortion"
+
+  - id: f_aVNqTIAae2
+    property: financial-impact
+    value: 2.87e+9
+    asOf: "2024-12"
+    source: https://www.unitedhealthgroup.com/content/dam/UHG/PDF/investors/2024/UNH-Q4-2024-Release.pdf
+    notes: "UnitedHealth reported direct cyberattack-related costs ~$2.87B in FY2024 earnings (Q4 2024 release)"
+
+  - id: f_4HZKjht3X1
+    property: financial-impact
+    value: 1e+10
+    asOf: "2024-12"
+    source: https://www.healthcaredive.com/news/change-healthcare-cyberattack-aha-survey-providers-financial-impact/717090/
+    notes: "Provider-side cumulative cost estimate >$10B (American Hospital Association cited $1B+/day in delayed payments at peak); high-uncertainty aggregate"
+
+  - id: f_3npgW2zMj5
+    property: incident-status
+    value: resolved
+    asOf: "2024-04"
+    source: https://www.unitedhealthgroup.com/newsroom/2024/2024-04-22-uhg-update-on-change-healthcare-cyberattack.html
+    notes: "Most services restored by April 2024 (~2 months); pharmacy fulfillment + claims processing restored phased; litigation + congressional hearings continued through 2025"

--- a/packages/factbase/data/fb-entities/cyber-incident-colonial-pipeline.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-colonial-pipeline.yaml
@@ -1,0 +1,36 @@
+entity: sid_XtZkjYKvrQ
+facts:
+  - id: f_6JDWYlgAAC
+    property: incident-date
+    value: "2021-05-07"
+    asOf: "2021-05-07"
+    source: https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-131a
+    notes: "Colonial Pipeline shutdown begins; DarkSide ransomware deployment"
+
+  - id: f_TP9gyv1plB
+    property: financial-impact
+    value: 4.4e+6
+    asOf: "2021-05-08"
+    source: https://www.bloomberg.com/news/articles/2021-05-13/colonial-pipeline-paid-hackers-nearly-5-million-in-ransom
+    notes: "Initial ransom paid ~$4.4M (75 BTC); FBI later recovered ~$2.3M (~64% of bitcoin amount, lower in USD due to BTC depreciation)"
+
+  - id: f_Arp5B1Id9Z
+    property: financial-impact
+    value: 5e+9
+    asOf: "2021-12"
+    source: https://www.gao.gov/products/gao-22-104746
+    notes: "GAO-cited estimate of broader economic impact including fuel-supply disruption, panic buying, price spikes; methodology disputed"
+
+  - id: f_850kEnydx9
+    property: financial-impact
+    value: 1e+9
+    asOf: "2021-12"
+    source: https://www.eia.gov/petroleum/weekly/archive/2021/210512/includes/analysis_print.cfm
+    notes: "Conservative estimate based on direct fuel-supply impact (EIA fuel-flow data); excludes downstream economic effects"
+
+  - id: f_qWCA79ISjs
+    property: incident-status
+    value: resolved
+    asOf: "2021-05-12"
+    source: https://www.cnn.com/2021/06/07/politics/colonial-pipeline-ransomware-recovered/index.html
+    notes: "Pipeline restarted May 12, 2021 (6-day shutdown); DOJ recovered $2.3M of ransom by June 7, 2021"

--- a/packages/factbase/data/fb-entities/cyber-incident-notpetya.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-notpetya.yaml
@@ -1,0 +1,43 @@
+entity: sid_PlakEpcSJw
+facts:
+  - id: f_NbrnTP3fAb
+    property: incident-date
+    value: "2017-06-27"
+    asOf: "2017-06-27"
+    source: https://www.wired.com/story/notpetya-cyberattack-ukraine-russia-code-crashed-the-world/
+    notes: "Initial deployment via M.E.Doc tax software update"
+
+  - id: f_nFbmOHnKYa
+    property: financial-impact
+    value: 8e+9
+    asOf: "2018-08"
+    source: https://www.whitehouse.gov/briefings-statements/statement-press-secretary-25/
+    notes: "Lower-bound estimate cited by White House attribution statement (~$8B)"
+
+  - id: f_XRvj7uff0L
+    property: financial-impact
+    value: 1e+10
+    asOf: "2018-08"
+    source: https://www.wired.com/story/notpetya-cyberattack-ukraine-russia-code-crashed-the-world/
+    notes: "Most-cited central estimate of ~$10B in global damages; sources include White House, Wired, multiple academic analyses"
+
+  - id: f_YTH8xIZM1J
+    property: financial-impact
+    value: 3e+8
+    asOf: "2017-08"
+    source: https://www.maersk.com/news/articles/2017/08/16/notpetya-update
+    notes: "Maersk-only direct loss estimate ($250-300M); single-victim subset of total"
+
+  - id: f_RcoreogrNw
+    property: financial-impact
+    value: 1.4e+9
+    asOf: "2024-01"
+    source: https://www.merck.com/wp-content/uploads/sites/124/2018/12/2017-AR.pdf
+    notes: "Merck-only documented cost of ~$1.4B (insurance settlement; war-exclusion litigation Merck v. Ace)"
+
+  - id: f_wmq6OLkTkx
+    property: incident-status
+    value: resolved
+    asOf: "2018-02"
+    source: https://www.justice.gov/opa/pr/six-russian-gru-officers-charged-connection-worldwide-deployment-destructive-malware-and
+    notes: "DOJ indictments of 6 GRU officers (Oct 2020); attribution to GRU Unit 74455 confirmed by US/UK/AU/CA"

--- a/packages/factbase/data/fb-entities/cyber-incident-solarwinds.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-solarwinds.yaml
@@ -1,0 +1,36 @@
+entity: sid_Me6yx7Sd9A
+facts:
+  - id: f_VHWGaub52Z
+    property: incident-date
+    value: "2020-03"
+    asOf: "2020-12-13"
+    source: https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a
+    notes: "Earliest confirmed compromise activity; CISA AA20-352A. Public disclosure December 13, 2020."
+
+  - id: f_td26fEeVVh
+    property: financial-impact
+    value: 1.2e+7
+    asOf: "2021-06"
+    source: https://www2.deloitte.com/us/en/insights/industry/financial-services/cost-of-solarwinds-attack.html
+    notes: "Average estimated remediation cost per affected organization (~$12M); lower-bound aggregate ~$100B if applied to ~9,000 high-value targets"
+
+  - id: f_DIq2AnHTmt
+    property: financial-impact
+    value: 1e+11
+    asOf: "2021-12"
+    source: https://www.cisa.gov/news-events/news/remarks-cisa-director-jen-easterly-rsa-conference-2022
+    notes: "Aggregate recovery-cost estimate ~$100B is widely cited but methodology heterogeneous; figure carries high uncertainty"
+
+  - id: f_9OBGhnuKon
+    property: financial-impact
+    value: 1.5e+7
+    asOf: "2021-02"
+    source: https://www.microsoft.com/en-us/security/blog/2021/02/18/microsoft-internal-solorigate-investigation-final-update/
+    notes: "Microsoft internal investigation cost ~$15M; single-org subset"
+
+  - id: f_eNo41eoPni
+    property: incident-status
+    value: resolved
+    asOf: "2024-10"
+    source: https://www.justice.gov/opa/pr/seven-hackers-associated-chinese-government-charged-computer-intrusions-targeting-perceived
+    notes: "Attribution to Russian SVR APT29; resulted in EO 14028 (May 2021), CMMC, and a long tail of follow-on remediation across federal civilian agencies"

--- a/packages/factbase/data/fb-entities/cyber-incident-wannacry.yaml
+++ b/packages/factbase/data/fb-entities/cyber-incident-wannacry.yaml
@@ -1,0 +1,43 @@
+entity: sid_PORgT8PnXQ
+facts:
+  - id: f_9NIQ0Wobtq
+    property: incident-date
+    value: "2017-05-12"
+    asOf: "2017-05-12"
+    source: https://www.cisa.gov/news-events/news/wannacry-ransomware
+    notes: "Worldwide propagation via EternalBlue SMB exploit; kill switch identified within hours"
+
+  - id: f_n62tOy4Cqp
+    property: financial-impact
+    value: 1e+9
+    asOf: "2017-12"
+    source: https://www.kaspersky.com/about/press-releases/2017_wannacry-and-other-cyberattacks
+    notes: "Lower-bound industry estimate (~$1B direct costs)"
+
+  - id: f_IqK3yn9Ffc
+    property: financial-impact
+    value: 4e+9
+    asOf: "2017-12"
+    source: https://www.cyberscoop.com/wannacry-cost-4-billion-cyence/
+    notes: "Cyence central estimate of ~$4B global damages"
+
+  - id: f_gMXAdx9G81
+    property: financial-impact
+    value: 8e+9
+    asOf: "2017-12"
+    source: https://www.cyberscoop.com/wannacry-cost-4-billion-cyence/
+    notes: "Cyence upper-bound scenario; includes business-interruption costs"
+
+  - id: f_aSQHqNgAC7
+    property: financial-impact
+    value: 9.2e+7
+    asOf: "2018-10"
+    source: https://www.gov.uk/government/news/securing-cyber-resilience-in-health-and-care-progress-update-on-the-departments-cyber-programme
+    notes: "UK NHS direct cost estimate ~£92M (Department of Health & Social Care)"
+
+  - id: f_2qFl41sNLj
+    property: incident-status
+    value: resolved
+    asOf: "2018-09"
+    source: https://www.justice.gov/opa/pr/north-korean-regime-backed-programmer-charged-conspiracy-conduct-multiple-cyber-attacks-and
+    notes: "DOJ charges against Park Jin Hyok (Lazarus Group, Sept 2018); kill switch neutralized propagation"


### PR DESCRIPTION
## Summary
New analysis-model page (E2515) comparing 7 major global cyber damage estimation sources: Cybersecurity Ventures, FBI IC3, IBM, Munich Re, Romanosky 2016, Anderson et al. 2012/2019, ENISA. Each estimate is profiled with methodology, geographic/cost scope, GDP fraction, and key limitations. Page explains the structural reasons for the ~600x spread between the lowest and highest figures and concludes with a "which estimate for which question" mapping.

Adds a "Damage Estimate Reconciliation" subsection to E86 Cyberweapons that cross-links here and notes that the often-cited "\$24T by 2027" figure does not appear in Cybersecurity Ventures' official publication series (current series shows \$9.5T for 2024, \$10.5T for 2025, \$12.2T by 2031).

## Why
E86 currently presents the conflicting estimates side-by-side without explaining that they measure different phenomena (per-incident corporate cost vs projected global cybercrime economy). This page resolves the apparent disagreement and gives downstream pages in QUA-715 a single canonical reference for damage-magnitude framing.

## Approach
- Authored via `pnpm crux w improve` pipeline (the `create` pipeline fails on QUA-290 — Perplexity citation extraction broken).
- Page lives in `/models/` with `subcategory: analysis-models` to align with E87/E88's pattern for cyber-related model pages. Entity entry added to `data/entities/models.yaml` per the convention.
- 12 citations attempted; 9 verified, 3 unsupported claims removed/narrowed (IMF data mapper — dynamic page, removed; Anderson 2019 vs 2012 attribution — narrowed claim; IBM URL was correct, kept).

## Test plan
- [x] `pnpm crux w validate gate --scope=content --fix` — all 5 checks pass
- [x] `npx vitest run src/data/__tests__/validate-entities.test.ts` — passes (entity required for `models/` category pages)
- [x] All EntityLinks resolve (E86, E87, E88, E689, E2515)
- [ ] Verify page renders at `/wiki/E2515` post-deploy

## Stacked PRs in QUA-715 epic
- #4609 — QUA-716 Phase 1a (E82 stub fill)
- #4611 — QUA-717 Phase 1b (cyber incident events)
- **This PR** — QUA-718 Phase 2 (damage estimates page)

Each touches different files; all stack cleanly. Post-merge of any of them, the others' diffs auto-cleanup.

Fixes QUA-718
