### PR TITLE
QUA-734: fix /api/third-party-evaluations/sync 500 on extractedAt (Date coercion)

### DIFF
--- a/apps/wiki-server/src/__tests__/third-party-evaluations-date-coercion.test.ts
+++ b/apps/wiki-server/src/__tests__/third-party-evaluations-date-coercion.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for the /api/third-party-evaluations/upsert 500 error
+ * (`value.toISOString is not a function`).
+ *
+ * Root cause: the Drizzle `extracted_at` column is `timestamp({ withTimezone:
+ * true })` (mode: 'date'), so postgres-js calls `.toISOString()` on the value
+ * during insert. The Zod schema accepts `extractedAt` as an ISO string on the
+ * wire; without coercion in `toRow`, that string flows through to the driver
+ * and explodes inside Drizzle's postgres-js adapter, surfacing as a
+ * SyncPhaseError(500).
+ *
+ * Verified by reverting the toRow coercion: this exact test reproduces the
+ * prod stack trace (`value.toISOString is not a function`) before the fix,
+ * and passes with the fix applied. Same pattern exists in model-system-cards
+ * and is fixed in the same PR.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+let dispatchCalls = 0;
+
+function dispatch(query: string, _params: unknown[]): unknown[] {
+  dispatchCalls++;
+  const q = query.toLowerCase();
+
+  // validate-entity-refs: pretend every supplied entity ref resolves
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return _params.map((p) => ({ ref: p }));
+  }
+
+  // Everything else (insert, audit, things, fan-out, SELECT for audit
+  // pre-fetch): permissive empty result so the route runs to completion.
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { thirdPartyEvaluationsRoute } = await import(
+  "../routes/tablebase/third-party-evaluations.js"
+);
+
+// ---------------------------------------------------------------------------
+
+describe("third-party-evaluations /sync — date coercion (QUA-734)", () => {
+  beforeEach(() => {
+    dispatchCalls = 0;
+  });
+
+  it("accepts ISO string for extractedAt without throwing in postgres-js", async () => {
+    // Pre-fix this returned 500 with `value.toISOString is not a function`
+    // because postgres-js called .toISOString() on the raw string. The fix:
+    // toRow coerces the string to a Date so postgres-js can serialize it.
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0123",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/report.pdf",
+          title: "Smoke-test report",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          extractedAt: "2026-04-25T10:30:00.000Z",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ upserted: 1 });
+  });
+
+  it("accepts null extractedAt and stores null", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0124",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/other.pdf",
+          title: "Smoke-test no extract",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          extractedAt: null,
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts omitted extractedAt", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0125",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/missing.pdf",
+          title: "Smoke-test no field",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/model-system-cards.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-system-cards.ts
@@ -304,14 +304,16 @@ const modelSystemCardsApp = new Hono()
       batchSchema: SyncModelSystemCardsBatchSchema,
       entityRefs: ["aiModelId"],
       // Drizzle's numeric() insert type is `string`; Zod schema emits
-      // numbers. Custom toRow to coerce just the two numeric columns
-      // and let the factory handle the rest.
+      // numbers. timestamp() insert type is Date; Zod schema emits ISO
+      // strings on the wire. Coerce all three before passing to the
+      // factory and let it handle the rest.
       toRow: (item, now) => ({
         ...item,
         trainingComputeFlops:
           item.trainingComputeFlops != null ? String(item.trainingComputeFlops) : null,
         trainingGpuHours:
           item.trainingGpuHours != null ? String(item.trainingGpuHours) : null,
+        extractedAt: item.extractedAt ? new Date(item.extractedAt) : null,
         syncedAt: now,
         updatedAt: now,
       }),

--- a/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
+++ b/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
@@ -399,12 +399,15 @@ const thirdPartyEvaluationsApp = new Hono()
       batchSchema: SyncThirdPartyEvaluationsBatchSchema,
       entityRefs: ["evaluatorOrgId"],
       // Strip the `models` field before insert — it goes to the join table
-      // in postUpsert, not the main row.
+      // in postUpsert, not the main row. Coerce `extractedAt` from the
+      // wire-format ISO string into a Date so postgres-js can serialize the
+      // timestamp column (it calls `.toISOString()` internally).
       toRow: (item, now) => {
-        const { models: _models, ...row } = item;
+        const { models: _models, extractedAt, ...row } = item;
         void _models;
         return {
           ...row,
+          extractedAt: extractedAt ? new Date(extractedAt) : null,
           syncedAt: now,
           updatedAt: now,
         };


### PR DESCRIPTION
## Summary

Fixes a 500 error from the QUA-705 smoke test on `/api/third-party-evaluations/sync`:

```
SyncPhaseError: [third-party-evaluations/upsert] value.toISOString is not a function
```

Root cause: the Drizzle `extracted_at` column is `timestamp({ withTimezone: true })` (mode `'date'`, requires Date), but the Zod sync schema accepts ISO strings on the wire. Without coercion in `toRow`, the raw string flowed into postgres-js, which calls `.toISOString()` on it during serialization — surfacing as a `SyncPhaseError(500)` from the upsert phase.

The fix coerces `extractedAt` from string to `Date` inside `toRow`. Same latent bug existed in `model-system-cards.ts` (identical schema/column pattern); fixed in the same PR per `.claude/rules/code-review-guidelines.md` § "Pattern fixes must be global".

## Files

- `apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts` — coerce `extractedAt` in `toRow`
- `apps/wiki-server/src/routes/tablebase/model-system-cards.ts` — same pattern, same fix (pre-emptive)
- `apps/wiki-server/src/__tests__/third-party-evaluations-date-coercion.test.ts` — regression test (3 cases: ISO string, null, omitted)

## Test plan

- [x] Unit tests: `npx vitest run apps/wiki-server/src/__tests__/third-party-evaluations-date-coercion.test.ts` — 3/3 pass
- [x] Regression test reproduces prod stack trace: verified by reverting the coercion — test failed with the exact `value.toISOString is not a function` error before the fix
- [x] Full wiki-server test suite: `npx vitest run apps/wiki-server/src/` — 1441 passed, 68 skipped, 4 skipped files
- [x] Build: `pnpm build` — green
- [x] Gate: `pnpm crux w validate gate --fix` — all 61 checks pass (3 advisory warnings, all pre-existing)
- [ ] **Post-deploy smoke test** (do this after wiki-server deploys): re-run a backfill against prod and verify rows are synced. Expected: `pnpm crux tb third-party-evals backfill caisi --evaluator=sid_pKeaWwP6sQ --limit=2` returns `upserted: 2` instead of 500.

## Why two files in one PR

The pattern (`extractedAt: z.string().nullable().optional()` → Drizzle `timestamp` column) appears in exactly 2 routes (verified by `grep "z.string()\.nullable()\.optional().*ISO"` across `apps/wiki-server/src/routes/tablebase/`). `model-system-cards.ts` had the same latent bug but had not yet been triggered because no caller was sending a non-null `extractedAt`. Fixing both prevents a follow-up incident on the next path that exercises that field.

Closes QUA-734.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved date field serialization issues in synchronization for model system cards and third-party evaluations, ensuring proper data conversion during sync operations.

* **Tests**
  * Added regression test suite for the synchronization endpoint to validate correct handling of date fields and prevent future timestamp-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->