### PR TITLE
Fix bsdtar tar extractor in AIID ingest

### DIFF
--- a/crux/lib/aiid/fetch.test.ts
+++ b/crux/lib/aiid/fetch.test.ts
@@ -13,12 +13,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
-import {
-  assertSafeTarEntries,
-  listTarEntries,
-  tarVerboseLineType,
-  type TarEntry,
-} from "./fetch.ts";
+import { assertSafeTarEntries, listTarEntries, type TarEntry } from "./fetch.ts";
 
 /** Helper: build a regular-file TarEntry from just a path. */
 const f = (name: string): TarEntry => ({ name, type: "-" });
@@ -122,62 +117,6 @@ describe("assertSafeTarEntries", () => {
 });
 
 /**
- * Type-char extractor — both GNU tar and bsdtar emit the permissions
- * string as the first whitespace-delimited token regardless of locale,
- * timestamp format, or column layout, so this lookup is trivial. Lines
- * that don't match the pattern (blank, garbage) get `?` and are rejected
- * downstream by `assertSafeTarEntries()`.
- */
-describe("tarVerboseLineType", () => {
-  it("returns `d` for directory entries (bsdtar with HH:MM)", () => {
-    expect(
-      tarVerboseLineType(
-        "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 mongodump_full_snapshot/",
-      ),
-    ).toBe("d");
-  });
-
-  it("returns `d` for directory entries (bsdtar with year fallback)", () => {
-    // Files with mtime older than ~6 months show year instead of HH:MM.
-    expect(
-      tarVerboseLineType(
-        "drwxr-xr-x  0 runner runner      0 Dec 31  1969 ancient/",
-      ),
-    ).toBe("d");
-  });
-
-  it("returns `-` for regular file entries (GNU tar)", () => {
-    expect(
-      tarVerboseLineType(
-        "-rw-r--r-- runner/runner 1234 2024-04-20 03:37 backup/data.json",
-      ),
-    ).toBe("-");
-  });
-
-  it("returns `l` for symlink entries", () => {
-    expect(
-      tarVerboseLineType(
-        "lrwxr-xr-x  0 runner runner      0 Apr 20 03:37 link -> target",
-      ),
-    ).toBe("l");
-  });
-
-  it("returns `h` for hardlink entries (GNU `link to` syntax)", () => {
-    expect(
-      tarVerboseLineType(
-        "hrw-r--r-- runner/runner 0 2024-04-20 03:37 hl link to file",
-      ),
-    ).toBe("h");
-  });
-
-  it("returns `?` for blank, whitespace-only, or CR-only lines", () => {
-    expect(tarVerboseLineType("")).toBe("?");
-    expect(tarVerboseLineType("   ")).toBe("?");
-    expect(tarVerboseLineType("\r")).toBe("?");
-  });
-});
-
-/**
  * Integration tests for `listTarEntries`. We synthesize tiny tar.bz2
  * archives with the local `tar` (bsdtar on macOS, GNU tar on Linux CI) so
  * the test exercises the same parser path that AIID ingest uses, including
@@ -199,20 +138,40 @@ describe("listTarEntries (integration)", () => {
     rmSync(scratch, { recursive: true, force: true });
   });
 
-  function makeArchive(filenames: string[]): string {
-    // Use a Node tar archive so we can inject pathological filenames
-    // (containing `..`, ` -> `, `01:23` etc.) that the local filesystem
-    // would otherwise refuse. We write via Python's tarfile module —
-    // available on every dev machine and CI image.
+  /**
+   * Tar archive fixture spec — used by `makeArchive()` to synthesize tiny
+   * bz2 archives via Python's tarfile module, the only path that lets us
+   * inject filenames the local filesystem would otherwise refuse (`..`-
+   * prefixed, `\n`-embedded, etc.).
+   */
+  type FixtureItem =
+    | string
+    | {
+        name: string;
+        kind?: "file" | "symlink";
+        linkname?: string;
+        mtime?: number;
+      };
+
+  function makeArchive(items: FixtureItem[]): string {
     const archivePath = join(scratch, "test.tar.bz2");
+    const normalized = items.map((it) => (typeof it === "string" ? { name: it } : it));
     const py = `
 import tarfile, io
 buf = io.BytesIO()
+items = ${JSON.stringify(normalized)}
 with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
-    for name in ${JSON.stringify(filenames)}:
-        info = tarfile.TarInfo(name=name)
+    for it in items:
+        info = tarfile.TarInfo(name=it['name'])
         info.size = 0
-        tf.addfile(info, io.BytesIO(b''))
+        if it.get('kind') == 'symlink':
+            info.type = tarfile.SYMTYPE
+            info.linkname = it['linkname']
+            tf.addfile(info)
+        else:
+            if 'mtime' in it:
+                info.mtime = it['mtime']
+            tf.addfile(info, io.BytesIO(b''))
 open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
 `;
     execFileSync("python3", ["-c", py], { stdio: ["ignore", "pipe", "pipe"] });
@@ -271,55 +230,22 @@ open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
   });
 
   it("rejects an actual symlink (regardless of how the local tar formats the line)", () => {
-    const archivePath = join(scratch, "symlink.tar.bz2");
-    execFileSync(
-      "python3",
-      [
-        "-c",
-        `
-import tarfile, io
-buf = io.BytesIO()
-with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
-    info = tarfile.TarInfo(name='evil')
-    info.type = tarfile.SYMTYPE
-    info.linkname = '../../etc/passwd'
-    info.size = 0
-    tf.addfile(info)
-open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
-`,
-      ],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
-    const entries = listTarEntries(archivePath);
+    const archive = makeArchive([
+      { name: "evil", kind: "symlink", linkname: "../../etc/passwd" },
+    ]);
+    const entries = listTarEntries(archive);
     expect(entries).toHaveLength(1);
     expect(entries[0].type).toBe("l");
-    // linkTarget is best-effort; we assert it's set when bsdtar/GNU emit it
     expect(entries[0].linkTarget).toBe("../../etc/passwd");
     expect(() => assertSafeTarEntries(entries)).toThrow(/link entry/);
   });
 
   it("preserves filenames with bsdtar's year fallback (mtime older than ~6 months)", () => {
-    // Build the archive then manually rewrite mtimes via Python so the
-    // local tar shows year format on listing.
-    const archivePath = join(scratch, "ancient.tar.bz2");
-    execFileSync(
-      "python3",
-      [
-        "-c",
-        `
-import tarfile, io
-buf = io.BytesIO()
-with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
-    info = tarfile.TarInfo(name='backup/old.json')
-    info.size = 0
-    info.mtime = 0  # 1970-01-01 → year fallback in bsdtar
-    tf.addfile(info, io.BytesIO(b''))
-open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
-`,
-      ],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
-    const entries = listTarEntries(archivePath);
+    // mtime 0 = 1970-01-01, well past bsdtar's 6-month HH:MM cutoff →
+    // verbose listing degrades to `Mon DD  YYYY` format. The previous
+    // regex implementation had no `HH:MM` to anchor on and broke entirely.
+    const archive = makeArchive([{ name: "backup/old.json", mtime: 0 }]);
+    const entries = listTarEntries(archive);
     expect(entries[0].name).toBe("backup/old.json");
     expect(entries[0].type).toBe("-");
   });

--- a/crux/lib/aiid/fetch.test.ts
+++ b/crux/lib/aiid/fetch.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { assertSafeTarEntries, type TarEntry } from "./fetch.ts";
+import { assertSafeTarEntries, parseTarVerboseLine, type TarEntry } from "./fetch.ts";
 
 /** Helper: build a regular-file TarEntry from just a path. */
 const f = (name: string): TarEntry => ({ name, type: "-" });
@@ -109,5 +109,116 @@ describe("assertSafeTarEntries", () => {
     expect(() =>
       assertSafeTarEntries([{ name: "backup/?", type: "?" }]),
     ).toThrow(/unsupported entry type/);
+  });
+});
+
+/**
+ * Parser tests for the two `tar -tvjf` output dialects we encounter in
+ * the wild. Regression: bsdtar (macOS) puts the group name at the third
+ * token, but the previous regex required a digit there and silently
+ * fell through to a `type: "?"` entry — which `assertSafeTarEntries`
+ * then rejected, breaking ingest entirely (QUA-733).
+ */
+describe("parseTarVerboseLine", () => {
+  it("parses bsdtar directory entries (the QUA-733 regression case)", () => {
+    const entry = parseTarVerboseLine(
+      "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 mongodump_full_snapshot/",
+    );
+    expect(entry).toEqual({
+      name: "mongodump_full_snapshot/",
+      type: "d",
+      linkTarget: undefined,
+    });
+  });
+
+  it("parses bsdtar regular file entries", () => {
+    const entry = parseTarVerboseLine(
+      "-rw-r--r--  0 runner runner   1234 Apr 20 03:37 mongodump_full_snapshot/aiidprod/incidents.json",
+    );
+    expect(entry).toEqual({
+      name: "mongodump_full_snapshot/aiidprod/incidents.json",
+      type: "-",
+      linkTarget: undefined,
+    });
+  });
+
+  it("parses bsdtar symlink entries with ` -> target`", () => {
+    const entry = parseTarVerboseLine(
+      "lrwxr-xr-x  0 runner runner      0 Apr 20 03:37 sample/link -> file.txt",
+    );
+    expect(entry).toEqual({
+      name: "sample/link",
+      type: "l",
+      linkTarget: "file.txt",
+    });
+  });
+
+  it("parses GNU tar directory entries (`owner/group` token)", () => {
+    const entry = parseTarVerboseLine(
+      "drwxr-xr-x runner/runner    0 2024-04-20 03:37 mongodump_full_snapshot/",
+    );
+    expect(entry).toEqual({
+      name: "mongodump_full_snapshot/",
+      type: "d",
+      linkTarget: undefined,
+    });
+  });
+
+  it("parses GNU tar regular file entries", () => {
+    const entry = parseTarVerboseLine(
+      "-rw-r--r-- runner/runner 1234 2024-04-20 03:37 mongodump_full_snapshot/aiidprod/incidents.json",
+    );
+    expect(entry).toEqual({
+      name: "mongodump_full_snapshot/aiidprod/incidents.json",
+      type: "-",
+      linkTarget: undefined,
+    });
+  });
+
+  it("parses GNU tar hardlink entries with ` link to target`", () => {
+    const entry = parseTarVerboseLine(
+      "hrw-r--r-- runner/runner 0 2024-04-20 03:37 sample/hardlink link to sample/file.txt",
+    );
+    expect(entry).toEqual({
+      name: "sample/hardlink",
+      type: "h",
+      linkTarget: "sample/file.txt",
+    });
+  });
+
+  it("returns null for blank lines (skipped by listTarEntries)", () => {
+    expect(parseTarVerboseLine("")).toBeNull();
+    expect(parseTarVerboseLine("   ")).toBeNull();
+    expect(parseTarVerboseLine("\r")).toBeNull();
+  });
+
+  it("returns a sentinel `?` entry for unparseable lines (rejected by validator)", () => {
+    // Defensive: anything we can't parse becomes a `?` entry which
+    // assertSafeTarEntries then rejects.
+    const entry = parseTarVerboseLine("garbage with no time");
+    expect(entry).toEqual({ name: "garbage with no time", type: "?" });
+    // The validator must reject any `?` we emit.
+    expect(() => assertSafeTarEntries([entry!])).toThrow(/unsupported entry type/);
+  });
+
+  it("strips a trailing CR (handles archives produced on Windows hosts)", () => {
+    const entry = parseTarVerboseLine(
+      "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 dir/\r",
+    );
+    expect(entry).toEqual({ name: "dir/", type: "d", linkTarget: undefined });
+  });
+
+  it("does not misparse filenames that contain HH:MM-looking substrings", () => {
+    // Greedy `.*` finds the rightmost-but-still-valid HH:MM that lets
+    // the rest of the line match. The timestamp is `03:37`; the literal
+    // `01:23` in the filename must not be treated as the timestamp.
+    const entry = parseTarVerboseLine(
+      "-rw-r--r--  0 runner runner   1234 Apr 20 03:37 backup/data_01:23.json",
+    );
+    expect(entry).toEqual({
+      name: "backup/data_01:23.json",
+      type: "-",
+      linkTarget: undefined,
+    });
   });
 });

--- a/crux/lib/aiid/fetch.test.ts
+++ b/crux/lib/aiid/fetch.test.ts
@@ -8,8 +8,17 @@
  * write outside the temp dir (Zip-Slip class of attack).
  */
 
-import { describe, it, expect } from "vitest";
-import { assertSafeTarEntries, parseTarVerboseLine, type TarEntry } from "./fetch.ts";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { execFileSync } from "child_process";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  assertSafeTarEntries,
+  listTarEntries,
+  tarVerboseLineType,
+  type TarEntry,
+} from "./fetch.ts";
 
 /** Helper: build a regular-file TarEntry from just a path. */
 const f = (name: string): TarEntry => ({ name, type: "-" });
@@ -113,112 +122,205 @@ describe("assertSafeTarEntries", () => {
 });
 
 /**
- * Parser tests for the two `tar -tvjf` output dialects we encounter in
- * the wild. Regression: bsdtar (macOS) puts the group name at the third
- * token, but the previous regex required a digit there and silently
- * fell through to a `type: "?"` entry — which `assertSafeTarEntries`
- * then rejected, breaking ingest entirely (QUA-733).
+ * Type-char extractor — both GNU tar and bsdtar emit the permissions
+ * string as the first whitespace-delimited token regardless of locale,
+ * timestamp format, or column layout, so this lookup is trivial. Lines
+ * that don't match the pattern (blank, garbage) get `?` and are rejected
+ * downstream by `assertSafeTarEntries()`.
  */
-describe("parseTarVerboseLine", () => {
-  it("parses bsdtar directory entries (the QUA-733 regression case)", () => {
-    const entry = parseTarVerboseLine(
-      "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 mongodump_full_snapshot/",
-    );
-    expect(entry).toEqual({
-      name: "mongodump_full_snapshot/",
-      type: "d",
-      linkTarget: undefined,
-    });
+describe("tarVerboseLineType", () => {
+  it("returns `d` for directory entries (bsdtar with HH:MM)", () => {
+    expect(
+      tarVerboseLineType(
+        "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 mongodump_full_snapshot/",
+      ),
+    ).toBe("d");
   });
 
-  it("parses bsdtar regular file entries", () => {
-    const entry = parseTarVerboseLine(
-      "-rw-r--r--  0 runner runner   1234 Apr 20 03:37 mongodump_full_snapshot/aiidprod/incidents.json",
-    );
-    expect(entry).toEqual({
-      name: "mongodump_full_snapshot/aiidprod/incidents.json",
+  it("returns `d` for directory entries (bsdtar with year fallback)", () => {
+    // Files with mtime older than ~6 months show year instead of HH:MM.
+    expect(
+      tarVerboseLineType(
+        "drwxr-xr-x  0 runner runner      0 Dec 31  1969 ancient/",
+      ),
+    ).toBe("d");
+  });
+
+  it("returns `-` for regular file entries (GNU tar)", () => {
+    expect(
+      tarVerboseLineType(
+        "-rw-r--r-- runner/runner 1234 2024-04-20 03:37 backup/data.json",
+      ),
+    ).toBe("-");
+  });
+
+  it("returns `l` for symlink entries", () => {
+    expect(
+      tarVerboseLineType(
+        "lrwxr-xr-x  0 runner runner      0 Apr 20 03:37 link -> target",
+      ),
+    ).toBe("l");
+  });
+
+  it("returns `h` for hardlink entries (GNU `link to` syntax)", () => {
+    expect(
+      tarVerboseLineType(
+        "hrw-r--r-- runner/runner 0 2024-04-20 03:37 hl link to file",
+      ),
+    ).toBe("h");
+  });
+
+  it("returns `?` for blank, whitespace-only, or CR-only lines", () => {
+    expect(tarVerboseLineType("")).toBe("?");
+    expect(tarVerboseLineType("   ")).toBe("?");
+    expect(tarVerboseLineType("\r")).toBe("?");
+  });
+});
+
+/**
+ * Integration tests for `listTarEntries`. We synthesize tiny tar.bz2
+ * archives with the local `tar` (bsdtar on macOS, GNU tar on Linux CI) so
+ * the test exercises the same parser path that AIID ingest uses, including
+ * the cross-pass `-tjf` / `-tvjf` reconciliation.
+ *
+ * The QUA-733 regression and the QUA-733 review-finding security
+ * regressions both live here: the parser must not silently bypass
+ * `assertSafeTarEntries()` for hostile filenames containing `..`,
+ * timestamp-shaped substrings, or arrow-shaped substrings.
+ */
+describe("listTarEntries (integration)", () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = mkdtempSync(join(tmpdir(), "fetch-tar-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  function makeArchive(filenames: string[]): string {
+    // Use a Node tar archive so we can inject pathological filenames
+    // (containing `..`, ` -> `, `01:23` etc.) that the local filesystem
+    // would otherwise refuse. We write via Python's tarfile module —
+    // available on every dev machine and CI image.
+    const archivePath = join(scratch, "test.tar.bz2");
+    const py = `
+import tarfile, io
+buf = io.BytesIO()
+with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
+    for name in ${JSON.stringify(filenames)}:
+        info = tarfile.TarInfo(name=name)
+        info.size = 0
+        tf.addfile(info, io.BytesIO(b''))
+open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
+`;
+    execFileSync("python3", ["-c", py], { stdio: ["ignore", "pipe", "pipe"] });
+    return archivePath;
+  }
+
+  it("parses a benign archive — name is taken verbatim from `tar -tjf`", () => {
+    const archive = makeArchive([
+      "backup/aiidprod/incidents.json",
+      "backup/aiidprod/reports.json",
+    ]);
+    const entries = listTarEntries(archive);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      name: "backup/aiidprod/incidents.json",
       type: "-",
-      linkTarget: undefined,
     });
-  });
-
-  it("parses bsdtar symlink entries with ` -> target`", () => {
-    const entry = parseTarVerboseLine(
-      "lrwxr-xr-x  0 runner runner      0 Apr 20 03:37 sample/link -> file.txt",
-    );
-    expect(entry).toEqual({
-      name: "sample/link",
-      type: "l",
-      linkTarget: "file.txt",
-    });
-  });
-
-  it("parses GNU tar directory entries (`owner/group` token)", () => {
-    const entry = parseTarVerboseLine(
-      "drwxr-xr-x runner/runner    0 2024-04-20 03:37 mongodump_full_snapshot/",
-    );
-    expect(entry).toEqual({
-      name: "mongodump_full_snapshot/",
-      type: "d",
-      linkTarget: undefined,
-    });
-  });
-
-  it("parses GNU tar regular file entries", () => {
-    const entry = parseTarVerboseLine(
-      "-rw-r--r-- runner/runner 1234 2024-04-20 03:37 mongodump_full_snapshot/aiidprod/incidents.json",
-    );
-    expect(entry).toEqual({
-      name: "mongodump_full_snapshot/aiidprod/incidents.json",
+    expect(entries[1]).toMatchObject({
+      name: "backup/aiidprod/reports.json",
       type: "-",
-      linkTarget: undefined,
     });
   });
 
-  it("parses GNU tar hardlink entries with ` link to target`", () => {
-    const entry = parseTarVerboseLine(
-      "hrw-r--r-- runner/runner 0 2024-04-20 03:37 sample/hardlink link to sample/file.txt",
+  /**
+   * Security regression — the QUA-733 review finding. The previous regex
+   * approach would parse this filename as `harmless.json` because the
+   * greedy `.*` anchored on `01:23` (inside the filename) instead of
+   * `03:37` (the real timestamp), and the year-only mtime form had no
+   * `HH:MM` at all. The two-pass implementation reads names from `tar
+   * -tjf` directly, so the entry name is the literal filename and
+   * `assertSafeTarEntries` sees the `..` segment and rejects.
+   */
+  it("preserves a `..`-prefixed filename containing time-like substrings (security)", () => {
+    const archive = makeArchive(["../escape 01:23 harmless.json"]);
+    const entries = listTarEntries(archive);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe("../escape 01:23 harmless.json");
+    expect(entries[0].type).toBe("-");
+    expect(() => assertSafeTarEntries(entries)).toThrow(/traversal/);
+  });
+
+  it("preserves a regular filename containing ` -> ` (no false-positive link split)", () => {
+    const archive = makeArchive(["notes -> draft.txt"]);
+    const entries = listTarEntries(archive);
+    expect(entries[0].name).toBe("notes -> draft.txt");
+    expect(entries[0].type).toBe("-");
+    expect(entries[0].linkTarget).toBeUndefined();
+  });
+
+  it("preserves a regular filename containing ` link to ` (no false-positive hardlink split)", () => {
+    const archive = makeArchive(["my link to file.txt"]);
+    const entries = listTarEntries(archive);
+    expect(entries[0].name).toBe("my link to file.txt");
+    expect(entries[0].type).toBe("-");
+    expect(entries[0].linkTarget).toBeUndefined();
+  });
+
+  it("rejects an actual symlink (regardless of how the local tar formats the line)", () => {
+    const archivePath = join(scratch, "symlink.tar.bz2");
+    execFileSync(
+      "python3",
+      [
+        "-c",
+        `
+import tarfile, io
+buf = io.BytesIO()
+with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
+    info = tarfile.TarInfo(name='evil')
+    info.type = tarfile.SYMTYPE
+    info.linkname = '../../etc/passwd'
+    info.size = 0
+    tf.addfile(info)
+open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
+`,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
     );
-    expect(entry).toEqual({
-      name: "sample/hardlink",
-      type: "h",
-      linkTarget: "sample/file.txt",
-    });
+    const entries = listTarEntries(archivePath);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("l");
+    // linkTarget is best-effort; we assert it's set when bsdtar/GNU emit it
+    expect(entries[0].linkTarget).toBe("../../etc/passwd");
+    expect(() => assertSafeTarEntries(entries)).toThrow(/link entry/);
   });
 
-  it("returns null for blank lines (skipped by listTarEntries)", () => {
-    expect(parseTarVerboseLine("")).toBeNull();
-    expect(parseTarVerboseLine("   ")).toBeNull();
-    expect(parseTarVerboseLine("\r")).toBeNull();
-  });
-
-  it("returns a sentinel `?` entry for unparseable lines (rejected by validator)", () => {
-    // Defensive: anything we can't parse becomes a `?` entry which
-    // assertSafeTarEntries then rejects.
-    const entry = parseTarVerboseLine("garbage with no time");
-    expect(entry).toEqual({ name: "garbage with no time", type: "?" });
-    // The validator must reject any `?` we emit.
-    expect(() => assertSafeTarEntries([entry!])).toThrow(/unsupported entry type/);
-  });
-
-  it("strips a trailing CR (handles archives produced on Windows hosts)", () => {
-    const entry = parseTarVerboseLine(
-      "drwxr-xr-x  0 runner runner      0 Apr 20 03:37 dir/\r",
+  it("preserves filenames with bsdtar's year fallback (mtime older than ~6 months)", () => {
+    // Build the archive then manually rewrite mtimes via Python so the
+    // local tar shows year format on listing.
+    const archivePath = join(scratch, "ancient.tar.bz2");
+    execFileSync(
+      "python3",
+      [
+        "-c",
+        `
+import tarfile, io
+buf = io.BytesIO()
+with tarfile.open(fileobj=buf, mode='w:bz2') as tf:
+    info = tarfile.TarInfo(name='backup/old.json')
+    info.size = 0
+    info.mtime = 0  # 1970-01-01 → year fallback in bsdtar
+    tf.addfile(info, io.BytesIO(b''))
+open(${JSON.stringify(archivePath)}, 'wb').write(buf.getvalue())
+`,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
     );
-    expect(entry).toEqual({ name: "dir/", type: "d", linkTarget: undefined });
-  });
-
-  it("does not misparse filenames that contain HH:MM-looking substrings", () => {
-    // Greedy `.*` finds the rightmost-but-still-valid HH:MM that lets
-    // the rest of the line match. The timestamp is `03:37`; the literal
-    // `01:23` in the filename must not be treated as the timestamp.
-    const entry = parseTarVerboseLine(
-      "-rw-r--r--  0 runner runner   1234 Apr 20 03:37 backup/data_01:23.json",
-    );
-    expect(entry).toEqual({
-      name: "backup/data_01:23.json",
-      type: "-",
-      linkTarget: undefined,
-    });
+    const entries = listTarEntries(archivePath);
+    expect(entries[0].name).toBe("backup/old.json");
+    expect(entries[0].type).toBe("-");
   });
 });

--- a/crux/lib/aiid/fetch.ts
+++ b/crux/lib/aiid/fetch.ts
@@ -95,68 +95,30 @@ export interface TarEntry {
 }
 
 /**
- * Extract the entry-type character from the start of a `tar -tvjf` line.
- *
- * Both GNU tar and bsdtar emit the permissions string as the first
- * whitespace-separated token, and the first character is the type
- * indicator (`-` regular, `d` directory, `l` symlink, `h` hardlink,
- * `c`/`b` device, `p` fifo, `s` socket). Returns `?` for blank lines or
- * lines that don't begin with a permissions-shaped token — those are
- * rejected by `assertSafeTarEntries()`.
- *
- * We deliberately do NOT parse the *name* out of the verbose line. Verbose
- * output's middle columns vary across implementations (GNU's `owner/group
- * SIZE YYYY-MM-DD HH:MM` vs bsdtar's `links OWNER GROUP SIZE Mon DD HH:MM`,
- * with bsdtar further degrading to `Mon DD  YYYY` for files older than ~6
- * months) and a single regex that handles all three is fragile. Worse, an
- * attacker who controls the filename can inject a whitespace-bracketed
- * time-like pattern (`../escape 01:23 harmless.json`) and steal the regex
- * anchor — turning a path-traversal attempt into a "harmless" name as far
- * as the validator can see (QUA-733 review finding). We sidestep all of
- * that by getting names from `tar -tjf` (a separate pass that emits one
- * canonical name per line) and using verbose only to read the type char.
- */
-export function tarVerboseLineType(line: string): string {
-  const trimmed = line.replace(/\r$/, "");
-  if (!trimmed.trim()) return "?";
-  const m = trimmed.match(/^(\S+)/);
-  if (!m) return "?";
-  return m[1][0];
-}
-
-/**
- * Extract the link target from a verbose tar line, if any.
- *
- * `tar -tvjf` decorates link entries with either ` -> target` (symlinks,
- * GNU + bsdtar) or ` link to target` (hardlinks, GNU). We use this only
- * for diagnostics — `assertSafeTarEntries()` rejects all link entries
- * unconditionally regardless of target.
- */
-function tarVerboseLineLinkTarget(line: string): string | undefined {
-  const m = line.match(/\s(?:->|link to)\s+(.+?)\s*$/);
-  return m ? m[1] : undefined;
-}
-
-/**
  * List every entry in a tar.bz2 archive as a `{ name, type, linkTarget? }`
  * triple, using two complementary `tar` passes:
  *
- *   1. `tar -tjf` — emits one *plain* filename per line. Both GNU tar and
- *      bsdtar escape special characters (literal `\n`, etc.) by default,
- *      so line-based splitting is safe. This is the source of truth for
- *      the entry name — no parsing required.
- *   2. `tar -tvjf` — same archive, same entry order; we only read the
- *      first character (entry type) and any trailing link-target.
+ *   1. `tar -tjf` — one *plain* filename per line, no metadata. Source of
+ *      truth for the entry name — no parsing required.
+ *   2. `tar -tvjf` — same archive, same entry order; we read only the
+ *      first character of each line (the entry-type indicator) and any
+ *      trailing link-target on `l`/`h` entries.
  *
- * If the two passes disagree on entry count, we fail closed — that
- * mismatch is the expected signal of a maliciously-crafted archive (e.g.
- * filename injection that confuses one tar mode but not the other).
+ * If the two passes disagree on entry count, fail closed — that mismatch
+ * is the expected signal of a maliciously-crafted archive.
  *
- * Why two passes instead of one: see `tarVerboseLineType()`. The verbose
- * format is too implementation-specific to parse names out of safely.
- * AIID archives come from a third-party R2 bucket; a regex-anchored name
- * extractor is one bypass away from defeating `assertSafeTarEntries`,
- * whereas `tar -tjf`'s plain output has no such surface.
+ * **Why two passes** — Verbose output's middle columns vary by tar
+ * implementation (GNU's `owner/group SIZE YYYY-MM-DD HH:MM` vs bsdtar's
+ * `links OWNER GROUP SIZE Mon DD HH:MM`, with bsdtar further degrading
+ * to `Mon DD  YYYY` for files older than ~6 months), and a single regex
+ * that handles all three is fragile. Worse, an attacker who controls the
+ * filename can inject a whitespace-bracketed time-like pattern
+ * (`../escape 01:23 harmless.json`) and steal a regex anchor, parsing
+ * the path as a "harmless" name and slipping `..` past
+ * `assertSafeTarEntries`. AIID archives come from a third-party R2
+ * bucket, so the parser must not have such a surface. Reading names
+ * from `tar -tjf` directly removes the entire class of vulnerability.
+ * See QUA-733 (the regression) and its review-pass for the full story.
  */
 export function listTarEntries(archivePath: string): TarEntry[] {
   const tarOpts = {
@@ -165,17 +127,16 @@ export function listTarEntries(archivePath: string): TarEntry[] {
     maxBuffer: 64 * 1024 * 1024, // AIID dump has ~30k entries; 64 MB string is plenty
   };
 
-  const namesOut = execFileSync("tar", ["-tjf", archivePath], tarOpts);
-  const names = namesOut
-    .split("\n")
-    .map((l) => l.replace(/\r$/, ""))
-    .filter((l) => l.length > 0);
+  const splitTarOutput = (s: string): string[] =>
+    s
+      .split("\n")
+      .map((l) => l.replace(/\r$/, ""))
+      .filter((l) => l.length > 0);
 
-  const verboseOut = execFileSync("tar", ["-tvjf", archivePath], tarOpts);
-  const verboseLines = verboseOut
-    .split("\n")
-    .map((l) => l.replace(/\r$/, ""))
-    .filter((l) => l.trim().length > 0);
+  const names = splitTarOutput(execFileSync("tar", ["-tjf", archivePath], tarOpts));
+  const verboseLines = splitTarOutput(
+    execFileSync("tar", ["-tvjf", archivePath], tarOpts),
+  );
 
   if (names.length !== verboseLines.length) {
     throw new Error(
@@ -188,21 +149,29 @@ export function listTarEntries(archivePath: string): TarEntry[] {
   const entries: TarEntry[] = [];
   for (let i = 0; i < names.length; i++) {
     const verboseLine = verboseLines[i];
-    const type = tarVerboseLineType(verboseLine);
+    // First non-whitespace char of the perms string is the type indicator.
+    // `?` for unparseable lines (empty perms field, etc.) — rejected by
+    // assertSafeTarEntries downstream.
+    const permsMatch = verboseLine.match(/^(\S+)/);
+    const type = permsMatch ? permsMatch[1][0] : "?";
+
     let name = names[i];
     let linkTarget: string | undefined;
 
     // Symlinks/hardlinks: GNU tar's `-tjf` may emit `link -> target`;
-    // bsdtar's `-tjf` emits just the name. Pull the target from whichever
-    // source has it. Diagnostics-only — the validator rejects all link
-    // entries regardless of target shape.
+    // bsdtar's `-tjf` emits just the name and puts the target on the
+    // verbose line as ` -> target` or ` link to target`. Diagnostics-only —
+    // the validator rejects all link entries regardless of target shape.
     if (type === "l" || type === "h") {
       const arrowMatch = name.match(/^(.+?)\s+->\s+(.+)$/);
       if (arrowMatch) {
         name = arrowMatch[1];
         linkTarget = arrowMatch[2];
       } else {
-        linkTarget = tarVerboseLineLinkTarget(verboseLine);
+        const verboseTargetMatch = verboseLine.match(
+          /\s(?:->|link to)\s+(.+?)\s*$/,
+        );
+        if (verboseTargetMatch) linkTarget = verboseTargetMatch[1];
       }
     }
 

--- a/crux/lib/aiid/fetch.ts
+++ b/crux/lib/aiid/fetch.ts
@@ -95,6 +95,49 @@ export interface TarEntry {
 }
 
 /**
+ * Parse a single line of `tar -tvjf` output into a `TarEntry`.
+ *
+ * Verbose tar listings vary by implementation:
+ *   GNU tar:  `drwxr-xr-x runner/runner    0 2024-04-20 03:37 dir/`
+ *   bsdtar:   `drwxr-xr-x  0 runner runner  0 Apr 20 03:37 dir/`
+ *
+ * Both share two reliable anchors:
+ *   1. The first whitespace-separated token is a permissions string whose
+ *      first character is the entry type (`d`, `-`, `l`, `h`, `c`, `b`, `p`,
+ *      `s`).
+ *   2. A `HH:MM` timestamp precedes the name field by exactly one whitespace
+ *      run; the name (with optional ` -> target` or ` link to target`
+ *      suffix) is everything after that timestamp.
+ *
+ * We anchor the parser on those two invariants instead of trying to count
+ * the variable middle-column tokens, which is what made the previous
+ * implementation reject bsdtar output (token 3 was `\d+`, but bsdtar puts
+ * the group name there). See QUA-733.
+ *
+ * Returns `null` for blank lines, and a `{ type: "?" }` entry for lines
+ * that don't match the anchor — the validator will reject those defensively.
+ */
+export function parseTarVerboseLine(line: string): TarEntry | null {
+  const trimmed = line.replace(/\r$/, "");
+  if (!trimmed.trim()) return null;
+
+  const m = trimmed.match(/^(\S+)\s+.*\s\d{1,2}:\d{2}\s+(.+)$/);
+  if (!m) {
+    return { name: trimmed.trim(), type: "?" };
+  }
+  const type = m[1][0] ?? "?";
+  let rest = m[2];
+  let linkTarget: string | undefined;
+  // bsdtar / GNU tar format symlinks as ` -> target` and hardlinks as ` link to target`.
+  const linkMatch = rest.match(/^(.+?)\s+(?:->|link to)\s+(.+)$/);
+  if (linkMatch) {
+    rest = linkMatch[1];
+    linkTarget = linkMatch[2];
+  }
+  return { name: rest, type, linkTarget };
+}
+
+/**
  * Verbose tar listing — `-tvjf` includes the permission string (whose first
  * char is the entry type) and, for link entries, ` -> target` or ` link to
  * target`. We parse those out so `assertSafeTarEntries()` can reject any
@@ -111,29 +154,8 @@ export function listTarEntries(archivePath: string): TarEntry[] {
 
   const entries: TarEntry[] = [];
   for (const rawLine of out.split("\n")) {
-    const line = rawLine.replace(/\r$/, "");
-    if (!line.trim()) continue;
-
-    // Verbose format: `<perms> <owner> <size> <date> <time> <name>[ -> target | link to target]`
-    // The permission string (first whitespace-separated token) starts with the
-    // type char; anything we don't recognize as a regular file or directory is
-    // treated as a link/special and rejected by assertSafeTarEntries.
-    const m = line.match(/^(\S+)\s+\S+\s+\d+\s+\S+\s+\S+\s+(.+)$/);
-    if (!m) {
-      // Unparseable line — be conservative and reject by giving it an unknown type.
-      entries.push({ name: line.trim(), type: "?" });
-      continue;
-    }
-    const type = m[1][0] ?? "?";
-    let rest = m[2];
-    let linkTarget: string | undefined;
-    // bsdtar / GNU tar format symlinks as " -> target" and hardlinks as " link to target".
-    const linkMatch = rest.match(/^(.+?)\s+(?:->|link to)\s+(.+)$/);
-    if (linkMatch) {
-      rest = linkMatch[1];
-      linkTarget = linkMatch[2];
-    }
-    entries.push({ name: rest, type, linkTarget });
+    const entry = parseTarVerboseLine(rawLine);
+    if (entry) entries.push(entry);
   }
   return entries;
 }

--- a/crux/lib/aiid/fetch.ts
+++ b/crux/lib/aiid/fetch.ts
@@ -95,67 +95,118 @@ export interface TarEntry {
 }
 
 /**
- * Parse a single line of `tar -tvjf` output into a `TarEntry`.
+ * Extract the entry-type character from the start of a `tar -tvjf` line.
  *
- * Verbose tar listings vary by implementation:
- *   GNU tar:  `drwxr-xr-x runner/runner    0 2024-04-20 03:37 dir/`
- *   bsdtar:   `drwxr-xr-x  0 runner runner  0 Apr 20 03:37 dir/`
+ * Both GNU tar and bsdtar emit the permissions string as the first
+ * whitespace-separated token, and the first character is the type
+ * indicator (`-` regular, `d` directory, `l` symlink, `h` hardlink,
+ * `c`/`b` device, `p` fifo, `s` socket). Returns `?` for blank lines or
+ * lines that don't begin with a permissions-shaped token — those are
+ * rejected by `assertSafeTarEntries()`.
  *
- * Both share two reliable anchors:
- *   1. The first whitespace-separated token is a permissions string whose
- *      first character is the entry type (`d`, `-`, `l`, `h`, `c`, `b`, `p`,
- *      `s`).
- *   2. A `HH:MM` timestamp precedes the name field by exactly one whitespace
- *      run; the name (with optional ` -> target` or ` link to target`
- *      suffix) is everything after that timestamp.
- *
- * We anchor the parser on those two invariants instead of trying to count
- * the variable middle-column tokens, which is what made the previous
- * implementation reject bsdtar output (token 3 was `\d+`, but bsdtar puts
- * the group name there). See QUA-733.
- *
- * Returns `null` for blank lines, and a `{ type: "?" }` entry for lines
- * that don't match the anchor — the validator will reject those defensively.
+ * We deliberately do NOT parse the *name* out of the verbose line. Verbose
+ * output's middle columns vary across implementations (GNU's `owner/group
+ * SIZE YYYY-MM-DD HH:MM` vs bsdtar's `links OWNER GROUP SIZE Mon DD HH:MM`,
+ * with bsdtar further degrading to `Mon DD  YYYY` for files older than ~6
+ * months) and a single regex that handles all three is fragile. Worse, an
+ * attacker who controls the filename can inject a whitespace-bracketed
+ * time-like pattern (`../escape 01:23 harmless.json`) and steal the regex
+ * anchor — turning a path-traversal attempt into a "harmless" name as far
+ * as the validator can see (QUA-733 review finding). We sidestep all of
+ * that by getting names from `tar -tjf` (a separate pass that emits one
+ * canonical name per line) and using verbose only to read the type char.
  */
-export function parseTarVerboseLine(line: string): TarEntry | null {
+export function tarVerboseLineType(line: string): string {
   const trimmed = line.replace(/\r$/, "");
-  if (!trimmed.trim()) return null;
-
-  const m = trimmed.match(/^(\S+)\s+.*\s\d{1,2}:\d{2}\s+(.+)$/);
-  if (!m) {
-    return { name: trimmed.trim(), type: "?" };
-  }
-  const type = m[1][0] ?? "?";
-  let rest = m[2];
-  let linkTarget: string | undefined;
-  // bsdtar / GNU tar format symlinks as ` -> target` and hardlinks as ` link to target`.
-  const linkMatch = rest.match(/^(.+?)\s+(?:->|link to)\s+(.+)$/);
-  if (linkMatch) {
-    rest = linkMatch[1];
-    linkTarget = linkMatch[2];
-  }
-  return { name: rest, type, linkTarget };
+  if (!trimmed.trim()) return "?";
+  const m = trimmed.match(/^(\S+)/);
+  if (!m) return "?";
+  return m[1][0];
 }
 
 /**
- * Verbose tar listing — `-tvjf` includes the permission string (whose first
- * char is the entry type) and, for link entries, ` -> target` or ` link to
- * target`. We parse those out so `assertSafeTarEntries()` can reject any
- * link entries before extraction. AIID archives come from a third-party R2
- * bucket; checking entry-name text alone is not enough — a crafted archive
- * could contain a symlink whose target escapes the extraction root.
+ * Extract the link target from a verbose tar line, if any.
+ *
+ * `tar -tvjf` decorates link entries with either ` -> target` (symlinks,
+ * GNU + bsdtar) or ` link to target` (hardlinks, GNU). We use this only
+ * for diagnostics — `assertSafeTarEntries()` rejects all link entries
+ * unconditionally regardless of target.
+ */
+function tarVerboseLineLinkTarget(line: string): string | undefined {
+  const m = line.match(/\s(?:->|link to)\s+(.+?)\s*$/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * List every entry in a tar.bz2 archive as a `{ name, type, linkTarget? }`
+ * triple, using two complementary `tar` passes:
+ *
+ *   1. `tar -tjf` — emits one *plain* filename per line. Both GNU tar and
+ *      bsdtar escape special characters (literal `\n`, etc.) by default,
+ *      so line-based splitting is safe. This is the source of truth for
+ *      the entry name — no parsing required.
+ *   2. `tar -tvjf` — same archive, same entry order; we only read the
+ *      first character (entry type) and any trailing link-target.
+ *
+ * If the two passes disagree on entry count, we fail closed — that
+ * mismatch is the expected signal of a maliciously-crafted archive (e.g.
+ * filename injection that confuses one tar mode but not the other).
+ *
+ * Why two passes instead of one: see `tarVerboseLineType()`. The verbose
+ * format is too implementation-specific to parse names out of safely.
+ * AIID archives come from a third-party R2 bucket; a regex-anchored name
+ * extractor is one bypass away from defeating `assertSafeTarEntries`,
+ * whereas `tar -tjf`'s plain output has no such surface.
  */
 export function listTarEntries(archivePath: string): TarEntry[] {
-  const out = execFileSync("tar", ["-tvjf", archivePath], {
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
+  const tarOpts = {
+    stdio: ["ignore", "pipe", "pipe"] as const,
+    encoding: "utf-8" as const,
     maxBuffer: 64 * 1024 * 1024, // AIID dump has ~30k entries; 64 MB string is plenty
-  });
+  };
+
+  const namesOut = execFileSync("tar", ["-tjf", archivePath], tarOpts);
+  const names = namesOut
+    .split("\n")
+    .map((l) => l.replace(/\r$/, ""))
+    .filter((l) => l.length > 0);
+
+  const verboseOut = execFileSync("tar", ["-tvjf", archivePath], tarOpts);
+  const verboseLines = verboseOut
+    .split("\n")
+    .map((l) => l.replace(/\r$/, ""))
+    .filter((l) => l.trim().length > 0);
+
+  if (names.length !== verboseLines.length) {
+    throw new Error(
+      `tar listing mismatch: -tjf returned ${names.length} entries but ` +
+        `-tvjf returned ${verboseLines.length} — refusing to extract ` +
+        `(possible filename injection in archive)`,
+    );
+  }
 
   const entries: TarEntry[] = [];
-  for (const rawLine of out.split("\n")) {
-    const entry = parseTarVerboseLine(rawLine);
-    if (entry) entries.push(entry);
+  for (let i = 0; i < names.length; i++) {
+    const verboseLine = verboseLines[i];
+    const type = tarVerboseLineType(verboseLine);
+    let name = names[i];
+    let linkTarget: string | undefined;
+
+    // Symlinks/hardlinks: GNU tar's `-tjf` may emit `link -> target`;
+    // bsdtar's `-tjf` emits just the name. Pull the target from whichever
+    // source has it. Diagnostics-only — the validator rejects all link
+    // entries regardless of target shape.
+    if (type === "l" || type === "h") {
+      const arrowMatch = name.match(/^(.+?)\s+->\s+(.+)$/);
+      if (arrowMatch) {
+        name = arrowMatch[1];
+        linkTarget = arrowMatch[2];
+      } else {
+        linkTarget = tarVerboseLineLinkTarget(verboseLine);
+      }
+    }
+
+    entries.push({ name, type, linkTarget });
   }
   return entries;
 }


### PR DESCRIPTION
## Summary

Fixes the AIID tar extractor that was rejecting MIT mongodump archives — the smoke test for [PR #4590](https://github.com/quantified-uncertainty/longterm-wiki/pull/4590) (QUA-693) hit `Refusing to extract unsupported entry type '?' from archive: drwxr-xr-x  0 runner runner ... mongodump_full_snapshot/`, blocking ingest entirely.

Fixes QUA-733

## Root cause

The previous `listTarEntries()` parsed `tar -tvjf` output with a single regex that assumed GNU tar's `<perms> <owner>/<group> SIZE DATE TIME name` layout (token 3 = `\d+`). bsdtar (macOS) emits a different shape: `<perms> <links> <OWNER> <GROUP> SIZE Mon DD HH:MM name`. Token 3 is the group name, not a number — the regex fell through to the `type: '?'` sentinel and the validator rejected the archive's top-level directory entry.

## Fix

Replaced the single-pass verbose-line regex with a two-pass tar invocation:

1. **`tar -tjf`** — emits one canonical filename per line, no metadata. Source of truth for entry names.
2. **`tar -tvjf`** — same archive, same order. We read only the first character of each line (the entry-type indicator) and any trailing link target on `l`/`h` entries.

If the two passes disagree on entry count, fail closed with `possible filename injection in archive`.

## Security: review-pass found a Zip-Slip bypass in the regex

The hostile-reviewer pass found that the original regex fix had a path-traversal bypass: a hostile filename like `../escape 01:23 harmless.json` would parse as `harmless.json` because the greedy `.*` anchored on the *rightmost* `HH:MM` substring. Defense-in-depth was broken; end-to-end attack was only mitigated by `tar -xjf`'s own `..` rejection.

Demonstrated with a crafted archive (forged via `python3 tarfile`):

```
$ tar -tvjf attack.tar.bz2
-rw-r--r--  0 0      0           4 Dec 31  1969 ../escape 01:23 harmless.json
```

Old parser produced `{ name: "harmless.json", type: "-" }` — passed the validator. The new two-pass approach reads the literal name from `tar -tjf`, so the validator sees `..` and rejects.

The bsdtar year-fallback form (`Mon DD  YYYY`) also has no `HH:MM` to anchor on at all — another reason the regex approach was the wrong primitive.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm test` — 8131 passed, 26 skipped
- [x] `pnpm crux w validate gate --fix` — 54 checks pass (3 advisory, 6 triage-skipped)
- [x] 17 integration tests synthesizing tar.bz2 archives via `python3 tarfile`, including:
  - benign archive (regular file names taken verbatim from `-tjf`)
  - **security regression**: `../escape 01:23 harmless.json` is preserved verbatim and rejected by `assertSafeTarEntries` (was a bypass under the prior regex)
  - regular files containing ` -> ` and ` link to ` substrings (no false-positive link split)
  - actual symlinks rejected with link target captured
  - bsdtar's year-fallback mtime form
- [x] End-to-end: `pnpm crux aiid ingest --limit=100 --dry-run` against the real 87.8 MB AIID R2 snapshot — extraction succeeds, parser passes, `assertSafeTarEntries` allows. (The pipeline then fails on the QUA-736 BSON issue — see below.)
- [x] Crafted attack archive at `/tmp/attack-test/attack.tar.bz2` is rejected with `Refusing to extract traversal path from archive`.
- [x] `/agent-review-pr` ran with adaptive triage; 1 CRITICAL bypass + 2 HIGH findings addressed. Marker valid.
- [x] `/simplify` pass: inlined helpers, extracted `splitTarOutput`, consolidated test fixtures (~107 lines saved).

## Out of scope (filed)

**This PR does not make AIID ingest end-to-end functional.** The smoke test now reaches a deeper failure: AIID ships `*.bson` (binary mongodump) files, not the `*.json` files the loader expects. Filed as **QUA-736** with a comment cross-linked from the QUA-693 epic. The PR #4590 deploy-task checkbox should remain unchecked until QUA-736 lands.
