### PR TITLE
fix(QUA-746): COPY api-types.ts into worker image so PR_OUTCOMES re-export resolves

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -67,7 +67,13 @@ COPY crux/ ./crux/
 # via node_modules above).
 COPY packages/ ./packages/
 
-# NOTE: No apps/wiki-server/ files needed — all imports are type-only (erased by tsx)
+# crux/lib/wiki-server/agent-sessions.ts does a runtime value re-export of PR_OUTCOMES
+# from this file. All other apps/wiki-server/ imports in crux are type-only and erased
+# by tsx; this single file is the only runtime value crossing that boundary.
+# See QUA-746.
+COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts
+
+# NOTE: No other apps/wiki-server/ files needed — all other imports are type-only (erased by tsx)
 # NOTE: No content/, data/, apps/web/ needed — worker is stateless
 # NOTE: Only stateless handlers (claim-verification, ping) work in this image.
 # citation-verify shells out to crux CLI (needs full monorepo deps).


### PR DESCRIPTION
## Summary

- Worker image was CrashLoopBackOff after 2026-04-25 production deploy with `ERR_MODULE_NOT_FOUND: Cannot find module '/repo/apps/wiki-server/src/api-types.ts'`
- `crux/lib/wiki-server/agent-sessions.ts:19` does `export { PR_OUTCOMES } from '../../../apps/wiki-server/src/api-types.ts'` — a **runtime value re-export**, not type-only. tsx does not erase value re-exports.
- `Dockerfile.worker` only COPYs `crux/` and `packages/` — `apps/wiki-server/src/api-types.ts` was never copied, so the path `/repo/apps/wiki-server/src/api-types.ts` was missing in the container.
- Fix: add `COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts` after the packages COPY, and correct the misleading comment that said "no apps/wiki-server/ files needed."

## Verification

- `pnpm test` — 379 test files, 8133 tests, all passing
- `pnpm crux w validate gate` — 61/61 checks passed (3 pre-existing advisory warnings, unchanged)
- Path math confirmed: relative path `../../../apps/wiki-server/src/api-types.ts` from `crux/lib/wiki-server/` resolves to `/repo/apps/wiki-server/src/api-types.ts` ✓

## Test plan

- [x] Gate passed (61/61 blocking checks)
- [x] Full test suite passed (8133 tests)
- [x] Path math verified: COPY destination matches the import path in agent-sessions.ts

## Out of scope

The proper long-term fix is to move `PR_OUTCOMES` into a shared package so the worker doesn't depend on `apps/wiki-server/`. Tracked in QUA-746.

## Deploy Tasks
<!-- deploy-tasks:v1 -->
- [ ] `manual` After deploy, verify worker rollout succeeds: `kubectl get pods -n longtermwiki | grep worker` — expect 3 pods Running 1/1 on the new replicaset, and the old `fcf4fcd67-*` pods removed. The crashlooping pod `longterm-wiki-worker-worker-7ff966dc5b-bl5p8` should be gone.
- [ ] `manual` Confirm the worker workflow CI run succeeds: `gh run list -R quantified-uncertainty/longterm-wiki --workflow=worker-docker.yml -L 1 --json status,conclusion`
<!-- /deploy-tasks -->

Fixes QUA-746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker worker runtime configuration to optimize image building and dependency management.

---

**Note:** This is an internal infrastructure update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->