### PR TITLE
QUA-747: auto-detect slot CWD in apps/web build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ crux/coverage/
 # MCP config (contains tokens)
 .mcp.json
 
+# Serena MCP server local config (cache + project.local.yml)
+.serena/
+
 # Session logs (operational state — stored in PostgreSQL via wiki-server)
 .claude/sessions/
 

--- a/apps/web/scripts/assign-ids.mjs
+++ b/apps/web/scripts/assign-ids.mjs
@@ -25,6 +25,7 @@ import { CONTENT_DIR, DATA_DIR, TOP_LEVEL_CONTENT_DIRS, REPO_ROOT } from './lib/
 import { scanFrontmatterEntities } from './lib/frontmatter-scanner.mjs';
 import { buildIdMaps, filterEligiblePages } from './lib/id-assignment.mjs';
 import { isServerAvailable, allocateIds, fetchServerEntityIdMap } from './lib/id-client.mjs';
+import { getServerUrl } from './lib/wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // .env loading — must run before any process.env access
@@ -157,7 +158,7 @@ async function main() {
   // only fail if we actually need to allocate new IDs.
   const serverAvailable = await isServerAvailable();
   if (serverAvailable) {
-    console.log(`  Using wiki server at ${process.env.LONGTERMWIKI_SERVER_URL}`);
+    console.log(`  Using wiki server at ${getServerUrl()}`);
   } else if (DRY_RUN) {
     console.log('  Wiki server unavailable — dry-run will show entities needing IDs but cannot preview assignments');
   } else {

--- a/apps/web/scripts/audit-factbase-pg.mjs
+++ b/apps/web/scripts/audit-factbase-pg.mjs
@@ -25,6 +25,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 import { fetchJsonWithRetry } from "./lib/wiki-server-data.mjs";
+import { getServerUrl, getApiKey, getEnvPrefix } from "./lib/wiki-server-env.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..", "..", "..");
@@ -32,17 +33,12 @@ const AUDIT_DIR = join(REPO_ROOT, "docs", "audits");
 const FACTBASE_DATA_DIR = join(REPO_ROOT, "packages", "factbase", "data");
 const OUT_MD_DIR = join(REPO_ROOT, "apps", "web", "src", "data");
 
-const envPrefix =
-  process.env.WIKI_SERVER_ENV === "prod" ||
-  process.env.WIKI_SERVER_ENV === "production"
-    ? "PROD_"
-    : "";
-const SERVER_URL = process.env[`${envPrefix}LONGTERMWIKI_SERVER_URL`];
-const API_KEY = process.env[`${envPrefix}LONGTERMWIKI_SERVER_API_KEY`];
+const SERVER_URL = getServerUrl();
+const API_KEY = getApiKey();
 
 if (!SERVER_URL) {
   console.error(
-    `error: ${envPrefix}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
+    `error: ${getEnvPrefix()}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
   );
   process.exit(1);
 }

--- a/apps/web/scripts/build-data-from-pg.mjs
+++ b/apps/web/scripts/build-data-from-pg.mjs
@@ -52,6 +52,7 @@ import { buildUrlToResourceMap } from "./lib/unconverted-links.mjs";
 import { buildIdRegistry } from "./lib/id-registry.mjs";
 import { collectPageWikiIds } from "./lib/frontmatter-scanner.mjs";
 import { fetchJsonWithRetry } from "./lib/wiki-server-data.mjs";
+import { getServerUrl, getApiKey, getEnvPrefix } from "./lib/wiki-server-env.mjs";
 import { fetchPersistentIdRegistry } from "./lib/id-client.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,17 +66,12 @@ const AUDIT_DIR = join(REPO_ROOT, "docs", "audits");
 const SAMPLE_ARG = process.argv.find((a) => a.startsWith("--sample="));
 const SAMPLE = SAMPLE_ARG ? Number(SAMPLE_ARG.split("=")[1]) : Infinity;
 
-const envPrefix =
-  process.env.WIKI_SERVER_ENV === "prod" ||
-  process.env.WIKI_SERVER_ENV === "production"
-    ? "PROD_"
-    : "";
-const SERVER_URL = process.env[`${envPrefix}LONGTERMWIKI_SERVER_URL`];
-const API_KEY = process.env[`${envPrefix}LONGTERMWIKI_SERVER_API_KEY`];
+const SERVER_URL = getServerUrl();
+const API_KEY = getApiKey();
 
 if (!SERVER_URL) {
   console.error(
-    `error: ${envPrefix}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
+    `error: ${getEnvPrefix()}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
   );
   process.exit(1);
 }

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -26,6 +26,17 @@ import { resolveEntityType } from '../../../crux/lib/hallucination-risk.ts';
 import { filterBulkImportDates } from './lib/git-date-utils.mjs';
 import { computeRedundancy } from './lib/redundancy.mjs';
 import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
+
+// Load .env from repo root so wiki-server env vars are available without
+// pre-setting them in the shell. Mirrors the pattern in assign-ids.mjs.
+// dotenv.config() is a no-op when the file is absent or vars are already set.
+try {
+  const { config } = await import('dotenv');
+  config({ path: join(REPO_ROOT, '.env') });
+} catch {
+  // dotenv not available or .env missing — rely on shell environment
+}
+
 import { generateLLMFiles } from './generate-llm-files.mjs';
 import { buildUrlToResourceMap, urlKey as resourceUrlKey } from './lib/unconverted-links.mjs';
 import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';
@@ -86,6 +97,7 @@ import {
   generateLinkHealth,
   generateEntityMatrix,
 } from './lib/output-writer.mjs';
+import { getServerUrl } from './lib/wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // Scope flag — `--scope=content` or `--quick` skips expensive non-content steps
@@ -1014,7 +1026,7 @@ async function main() {
   // Sync page links to wiki-server (optional — skips if server unavailable)
   if (CONTENT_ONLY) {
     console.log('  linkSync: skipped (content-only scope)');
-  } else if (process.env.LONGTERMWIKI_SERVER_URL) {
+  } else if (getServerUrl()) {
     const linkSignals = collectLinkSignals(entities, pages, contentInbound, tagIndex, byStableId);
     await syncLinksAndRefreshGraph(linkSignals);
   }
@@ -1032,7 +1044,7 @@ async function main() {
     let pageChangeHistory = null;
     let changeHistorySource = 'yaml';
 
-    const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+    const serverUrl = getServerUrl();
     if (serverUrl) {
       try {
         const headers = buildHeaders();
@@ -1161,7 +1173,7 @@ async function main() {
   // =========================================================================
   if (CONTENT_ONLY) {
     console.log('  buildMetricsSync: skipped (content-only scope)');
-  } else if (process.env.LONGTERMWIKI_SERVER_URL) {
+  } else if (getServerUrl()) {
     await syncBuildMetrics({ pages, updateScheduleItems });
   }
 

--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -162,12 +162,19 @@ describe('fetchJsonWithRetry', () => {
 
 describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-var override)', () => {
   const originalServerUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const originalProdServerUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  const originalWikiServerEnv = process.env.WIKI_SERVER_ENV;
   const originalCi = process.env.CI;
   const originalStrict = process.env.STRICT_VERDICTS;
   const noSleep = async () => {};
 
   beforeEach(() => {
     process.env.LONGTERMWIKI_SERVER_URL = 'http://fake-server';
+    // Disable QUA-747 slot-CWD auto-detect so tests are hermetic when run
+    // from inside an a<N> slot. Also clear PROD_ vars in case they're set
+    // from .env so getServerUrl() doesn't fall through to them.
+    process.env.WIKI_SERVER_ENV = 'local';
+    delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
     delete process.env.CI;
     delete process.env.STRICT_VERDICTS;
     setFullBuildMode(false);
@@ -178,6 +185,16 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-
       process.env.LONGTERMWIKI_SERVER_URL = originalServerUrl;
     } else {
       delete process.env.LONGTERMWIKI_SERVER_URL;
+    }
+    if (originalProdServerUrl !== undefined) {
+      process.env.PROD_LONGTERMWIKI_SERVER_URL = originalProdServerUrl;
+    } else {
+      delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    }
+    if (originalWikiServerEnv !== undefined) {
+      process.env.WIKI_SERVER_ENV = originalWikiServerEnv;
+    } else {
+      delete process.env.WIKI_SERVER_ENV;
     }
     if (originalCi !== undefined) {
       process.env.CI = originalCi;

--- a/apps/web/scripts/lib/__tests__/id-client.test.mjs
+++ b/apps/web/scripts/lib/__tests__/id-client.test.mjs
@@ -9,14 +9,20 @@ beforeEach(() => {
   savedEnv = {
     LONGTERMWIKI_SERVER_URL: process.env.LONGTERMWIKI_SERVER_URL,
     LONGTERMWIKI_SERVER_API_KEY: process.env.LONGTERMWIKI_SERVER_API_KEY,
+    PROD_LONGTERMWIKI_SERVER_URL: process.env.PROD_LONGTERMWIKI_SERVER_URL,
+    PROD_LONGTERMWIKI_SERVER_API_KEY: process.env.PROD_LONGTERMWIKI_SERVER_API_KEY,
     WIKI_SERVER_ENV: process.env.WIKI_SERVER_ENV,
   };
   // Default: no server configured, and no PROD_ prefix routing.
   // WIKI_SERVER_ENV=prod would make getEnv() read PROD_LONGTERMWIKI_SERVER_URL,
   // which tests never set — unset it so tests are hermetic regardless of shell env.
+  // WIKI_SERVER_ENV=local disables the QUA-747 slot-CWD auto-detect that
+  // would otherwise pick up PROD_ vars when tests run from inside an a<N> slot.
   delete process.env.LONGTERMWIKI_SERVER_URL;
   delete process.env.LONGTERMWIKI_SERVER_API_KEY;
-  delete process.env.WIKI_SERVER_ENV;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+  process.env.WIKI_SERVER_ENV = "local";
 });
 
 afterEach(() => {

--- a/apps/web/scripts/lib/__tests__/wiki-server-env.test.mjs
+++ b/apps/web/scripts/lib/__tests__/wiki-server-env.test.mjs
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  findSlotFromAncestors,
+  getEnvPrefix,
+  getEnv,
+  getServerUrl,
+  getApiKey,
+} from '../wiki-server-env.mjs';
+
+let savedEnv;
+
+beforeEach(() => {
+  savedEnv = {
+    LONGTERMWIKI_SERVER_URL: process.env.LONGTERMWIKI_SERVER_URL,
+    LONGTERMWIKI_SERVER_API_KEY: process.env.LONGTERMWIKI_SERVER_API_KEY,
+    PROD_LONGTERMWIKI_SERVER_URL: process.env.PROD_LONGTERMWIKI_SERVER_URL,
+    PROD_LONGTERMWIKI_SERVER_API_KEY: process.env.PROD_LONGTERMWIKI_SERVER_API_KEY,
+    WIKI_SERVER_ENV: process.env.WIKI_SERVER_ENV,
+  };
+  delete process.env.LONGTERMWIKI_SERVER_URL;
+  delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+  // Default to "local" so tests are hermetic regardless of where they run
+  // (cwd-based slot auto-detect would otherwise leak in from real slots).
+  process.env.WIKI_SERVER_ENV = 'local';
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('findSlotFromAncestors', () => {
+  it('returns slot number when cwd is inside an a<N> directory', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/a3/apps/web')).toBe(3);
+    expect(findSlotFromAncestors('/Users/x/lw/a17')).toBe(17);
+  });
+
+  it('returns null when no ancestor matches a<N> pattern', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/main')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/lw/coord')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/Documents/code')).toBeNull();
+  });
+
+  it('rejects non-numeric a<X> directories', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/abc')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/lw/a1b')).toBeNull();
+  });
+
+  it('returns null at the filesystem root', () => {
+    expect(findSlotFromAncestors('/')).toBeNull();
+  });
+});
+
+describe('getEnvPrefix', () => {
+  it('returns PROD_ when WIKI_SERVER_ENV=prod', () => {
+    process.env.WIKI_SERVER_ENV = 'prod';
+    expect(getEnvPrefix()).toBe('PROD_');
+  });
+
+  it('returns PROD_ when WIKI_SERVER_ENV=production', () => {
+    process.env.WIKI_SERVER_ENV = 'production';
+    expect(getEnvPrefix()).toBe('PROD_');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV=local', () => {
+    process.env.WIKI_SERVER_ENV = 'local';
+    expect(getEnvPrefix()).toBe('');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV=dev', () => {
+    process.env.WIKI_SERVER_ENV = 'dev';
+    expect(getEnvPrefix()).toBe('');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV is set to an unknown value', () => {
+    process.env.WIKI_SERVER_ENV = 'staging';
+    expect(getEnvPrefix()).toBe('');
+  });
+});
+
+describe('getEnv / getServerUrl / getApiKey', () => {
+  it('reads the unprefixed var by default', () => {
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3130';
+    expect(getServerUrl()).toBe('http://localhost:3130');
+  });
+
+  it('reads the PROD_-prefixed var when WIKI_SERVER_ENV=prod', () => {
+    process.env.WIKI_SERVER_ENV = 'prod';
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3130';
+    process.env.PROD_LONGTERMWIKI_SERVER_URL = 'https://prod';
+    expect(getServerUrl()).toBe('https://prod');
+  });
+
+  it('returns empty string when the relevant var is unset', () => {
+    expect(getServerUrl()).toBe('');
+    expect(getApiKey()).toBe('');
+    expect(getEnv('LONGTERMWIKI_SERVER_URL')).toBe('');
+  });
+
+  it('respects WIKI_SERVER_ENV=local even when PROD_ vars are set', () => {
+    process.env.WIKI_SERVER_ENV = 'local';
+    process.env.PROD_LONGTERMWIKI_SERVER_URL = 'https://prod';
+    expect(getServerUrl()).toBe('');
+  });
+});

--- a/apps/web/scripts/lib/hallucination-risk-build.mjs
+++ b/apps/web/scripts/lib/hallucination-risk-build.mjs
@@ -8,6 +8,7 @@
  */
 
 import { recordRiskSnapshots } from './risk-client.mjs';
+import { getServerUrl } from './wiki-server-env.mjs';
 
 /**
  * Compute hallucination risk for all pages and build aggregated stats.
@@ -82,7 +83,7 @@ export async function syncRiskSnapshots(pages, contentOnly) {
     return;
   }
 
-  if (!process.env.LONGTERMWIKI_SERVER_URL) return;
+  if (!getServerUrl()) return;
 
   const snapshots = pages
     .filter(p => p.hallucinationRisk)

--- a/apps/web/scripts/lib/id-client.mjs
+++ b/apps/web/scripts/lib/id-client.mjs
@@ -9,21 +9,10 @@
  * If you change the shared client, update these too.
  */
 
+import { getServerUrl, getApiKey } from './wiki-server-env.mjs';
+
 const TIMEOUT_MS = 5000;
 const BATCH_TIMEOUT_MS = 30000;
-
-function getEnv(name) {
-  const prefix = process.env.WIKI_SERVER_ENV === "prod" ? "PROD_" : "";
-  return process.env[`${prefix}${name}`] || "";
-}
-
-function getServerUrl() {
-  return getEnv("LONGTERMWIKI_SERVER_URL");
-}
-
-function getApiKey() {
-  return getEnv("LONGTERMWIKI_SERVER_API_KEY");
-}
 
 function buildHeaders() {
   const headers = { "Content-Type": "application/json" };

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { getServerUrl, getApiKey } from './wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // Shared ID detection helpers
@@ -77,7 +78,7 @@ function logWikiServerWarning(context, reason) {
 /** Build headers for wiki-server API requests, including auth if configured. */
 export function buildHeaders() {
   const headers = { 'Content-Type': 'application/json' };
-  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+  const apiKey = getApiKey();
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
   return headers;
 }
@@ -170,7 +171,7 @@ export async function fetchJsonWithRetry(url, opts = {}) {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildEditLogDateMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  editLogDates: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -209,7 +210,7 @@ export async function buildEditLogDateMap() {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildEarliestEditLogDateMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  earliestEditLogDates: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -247,7 +248,7 @@ export async function buildEarliestEditLogDateMap() {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildCitationStatsMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  citationStats: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -294,7 +295,7 @@ export async function buildCitationStatsMap() {
  * Returns { [pageId]: CitationQuote[] } or empty object if unavailable.
  */
 export async function buildCitationQuotesBundle() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  citationQuotes: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -396,7 +397,7 @@ export function buildRatingsFromAssessment(assessment, fmRatings) {
  * Falls back to empty map if wiki-server is unavailable.
  */
 export async function fetchAssessments() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  assessments: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -472,7 +473,7 @@ export async function fetchAssessments() {
  * Falls back to empty object if wiki-server is unavailable.
  */
 export async function fetchBenchmarkResults() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  benchmark-results: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -555,7 +556,7 @@ export async function fetchBenchmarkResults() {
  * Falls back to empty array if wiki-server is unavailable.
  */
 export async function fetchResearchAreas() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  research-areas: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return [];
@@ -599,7 +600,7 @@ export async function fetchResearchAreas() {
  * This replaces the ISR-based per-page fetch that was unreliable during builds.
  */
 export async function fetchResearchAreaDetails(areaIds) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl || areaIds.length === 0) {
     console.log('  research-area-details: skipped (no server or no areas)');
     return {};
@@ -681,7 +682,7 @@ function isStrictVerdictsMode() {
  *     and discarding everything
  */
 export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  record-verdicts: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -759,7 +760,7 @@ export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
  * making PG the source of truth for facts.
  */
 export async function fetchFactBaseFromServer() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  factbase-export: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;
@@ -794,7 +795,7 @@ export async function fetchFactBaseFromServer() {
  * the entity stableId when looking up — not the slug.
  */
 export async function fetchPolicyStakeholderIds() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  policy-stakeholder-ids: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -852,7 +853,7 @@ export async function fetchPolicyStakeholderIds() {
  * @param {Array} typedEntities — the full typedEntities array from database
  */
 export async function syncPolicyStakeholders(typedEntities) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  policy-stakeholder-sync: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return;
@@ -1341,7 +1342,7 @@ function normalizePGEntityId(id) {
  * Returns facts grouped by entityId in the KB Fact shape, or null if unavailable.
  */
 export async function fetchFactsFromPG() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  kb-facts-pg: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;
@@ -1367,7 +1368,7 @@ export async function fetchFactsFromPG() {
 }
 
 export async function mergePGRecordsIntoKB(kb) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  kb-pg: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return { personnel: 0, grants: 0, fundingRounds: 0, investments: 0, equityPositions: 0, divisions: 0, fundingPrograms: 0, divisionPersonnel: 0, entityEvents: 0, entityAssessments: 0, publications: 0 };
@@ -1668,7 +1669,7 @@ export async function mergePGRecordsIntoKB(kb) {
  * Falls back to null if the server is unavailable (caller should use YAML).
  */
 export async function fetchResourcesFromPG() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) return null;
 
   const headers = buildHeaders();
@@ -1798,7 +1799,7 @@ export async function fetchResourcesFromPG() {
  * Falls back to an empty object if the server is unavailable.
  */
 export async function buildPageReferenceIndex() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  pageReferenceIndex: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -1850,7 +1851,7 @@ export async function buildPageReferenceIndex() {
  * Returns: { [stableId]: { authored: resourceId[], subject: resourceId[] } }
  */
 export async function fetchEntityResourceLinks() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  entityResourceLinks: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;

--- a/apps/web/scripts/lib/wiki-server-env.mjs
+++ b/apps/web/scripts/lib/wiki-server-env.mjs
@@ -1,0 +1,65 @@
+/**
+ * wiki-server-env.mjs — env-prefix resolution for wiki-server URL/API key.
+ *
+ * Mirrors the logic in `crux/lib/wiki-server/client.ts::getEnvPrefix()`
+ * (QUA-616). Plain ESM so it can be imported by `node`-run scripts that
+ * cannot use tsx (e.g. assign-ids.mjs, build-data.mjs).
+ *
+ * Resolution order:
+ *   1. `WIKI_SERVER_ENV=prod`/`production`  → `PROD_` prefix
+ *   2. `WIKI_SERVER_ENV=local`/`dev`        → no prefix (force local)
+ *   3. CWD inside an `a<N>` slot directory  → `PROD_` prefix
+ *      (slot agents have no local wiki-server)
+ *   4. Otherwise                            → no prefix (default local)
+ *
+ * If you change this, update `crux/lib/wiki-server/client.ts` too.
+ */
+
+import { basename, dirname } from 'path';
+
+/**
+ * Walk up from `cwd` looking for a directory named `a<N>` (the agent-slot
+ * root). Returns the slot number when found, or null. Mirror of
+ * `crux/lib/session/session-context.ts::findSlotFromAncestors`.
+ */
+export function findSlotFromAncestors(cwd) {
+  let current = cwd;
+  for (let i = 0; i < 10; i++) {
+    const match = basename(current).match(/^a(\d+)$/);
+    if (match) {
+      const n = Number.parseInt(match[1], 10);
+      if (Number.isSafeInteger(n)) return n;
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return null;
+}
+
+export function getEnvPrefix() {
+  const env = process.env.WIKI_SERVER_ENV;
+  if (env === 'prod' || env === 'production') return 'PROD_';
+  if (env === 'local' || env === 'dev') return '';
+  if (env === undefined && findSlotFromAncestors(process.cwd()) !== null) {
+    return 'PROD_';
+  }
+  return '';
+}
+
+/**
+ * Read a `LONGTERMWIKI_*` env var, honoring the active prefix.
+ * Returns '' if unset.
+ */
+export function getEnv(name) {
+  const prefix = getEnvPrefix();
+  return process.env[`${prefix}${name}`] || '';
+}
+
+export function getServerUrl() {
+  return getEnv('LONGTERMWIKI_SERVER_URL');
+}
+
+export function getApiKey() {
+  return getEnv('LONGTERMWIKI_SERVER_API_KEY');
+}


### PR DESCRIPTION
## Summary

Ports the QUA-616 slot-aware env-prefix resolution from `crux/lib/wiki-server/client.ts` into a plain-ESM helper that the `node`-run build scripts under `apps/web/scripts/` can import. With this, `pnpm sync:data` from a slot reaches the prod wiki-server without needing `WIKI_SERVER_ENV=prod` on every invocation, matching crux ergonomics (QUA-616).

## Why

A user running `pnpm run --filter longterm-next sync:data` from `lw/a1` saw:
```
Wiki server not available — will skip if no new IDs are needed
WARNING: Server unavailable — skipping verification of 934 manually-set YAML entity wikiIds.
```
The slot's `.env` points `LONGTERMWIKI_SERVER_URL` at `localhost:3130` (which doesn't run in slots), and `id-client.mjs` / `build-data.mjs` had no auto-detect. After this PR, the same command works end-to-end:
```
Using wiki server at https://wiki-server.k8s.quantifieduncertainty.org
Verifying 934 manually-set YAML entity wikiIds against server...
Verification complete: 934 wikiIds verified OK.
…
riskSnapshots: recorded 765 snapshots to wiki server
pageReferenceIndex: 165 pages, 0 claim refs, 5021 citations
```

## What changed

**New helper** `apps/web/scripts/lib/wiki-server-env.mjs`:
- `findSlotFromAncestors(cwd)` — walks up looking for `a<N>`
- `getEnvPrefix()` — `'PROD_'` when `WIKI_SERVER_ENV=prod` OR cwd inside a slot, `''` otherwise
- `getServerUrl()` / `getApiKey()` / `getEnv(name)` — convenience wrappers

**Callsites updated** (every `process.env.LONGTERMWIKI_*` raw read in `apps/web/scripts/`, plus 2 ad-hoc `envPrefix` patterns):
- `lib/id-client.mjs`, `lib/wiki-server-data.mjs` (~17 reads), `lib/hallucination-risk-build.mjs`
- `build-data.mjs` (3 reads + dotenv loading so it works as a standalone process, mirroring `assign-ids.mjs`)
- `assign-ids.mjs` (diagnostic line)
- `audit-factbase-pg.mjs`, `build-data-from-pg.mjs` (replace local `envPrefix` block with the shared helper)

**Tests**:
- 13 new tests for the helper (slot detection, env precedence, escape hatch)
- `id-client.test.mjs` / `fetch-retry.test.mjs` setup updated to clear `PROD_` vars and force `WIKI_SERVER_ENV=local`

**Side-effect fixes**: tests in `id-client.test.mjs` and `fetch-retry.test.mjs` previously failed when `WIKI_SERVER_ENV=prod` was set in the parent shell — that env-leak issue is fixed by the new test setup. Closes QUA-560 and QUA-402.

## Test plan

- [x] `pnpm test` (apps/web) — 1719/1719 pass
- [x] `pnpm crux w validate gate --fix` — all 61 checks pass
- [x] `pnpm run --filter longterm-next sync:data` from slot a1 — reaches prod, all wiki-server-dependent steps succeed
- [x] `WIKI_SERVER_ENV=local` from slot — verified to force local
- [x] `WIKI_SERVER_ENV=prod` from slot — verified explicit prefix still works
- [x] Tests pass with `WIKI_SERVER_ENV=prod` set in shell (regression check for QUA-560)

Closes QUA-747
Closes QUA-560
Closes QUA-402

## Deploy Checklist

- [ ] build-data.mjs changed — verify build-data produces correct database.json after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for wiki server environment configuration to ensure configuration handling works reliably across different deployment contexts.

* **Chores**
  * Extended `.gitignore` to exclude the `.serena/` directory, which stores local Serena MCP server state including cache and local configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->