### PR TITLE
release: 2026-04-26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ crux/coverage/
 # MCP config (contains tokens)
 .mcp.json
 
+# Serena MCP server local config (cache + project.local.yml)
+.serena/
+
 # Session logs (operational state — stored in PostgreSQL via wiki-server)
 .claude/sessions/
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -67,7 +67,13 @@ COPY crux/ ./crux/
 # via node_modules above).
 COPY packages/ ./packages/
 
-# NOTE: No apps/wiki-server/ files needed — all imports are type-only (erased by tsx)
+# crux/lib/wiki-server/agent-sessions.ts does a runtime value re-export of PR_OUTCOMES
+# from this file. All other apps/wiki-server/ imports in crux are type-only and erased
+# by tsx; this single file is the only runtime value crossing that boundary.
+# See QUA-746.
+COPY apps/wiki-server/src/api-types.ts ./apps/wiki-server/src/api-types.ts
+
+# NOTE: No other apps/wiki-server/ files needed — all other imports are type-only (erased by tsx)
 # NOTE: No content/, data/, apps/web/ needed — worker is stateless
 # NOTE: Only stateless handlers (claim-verification, ping) work in this image.
 # citation-verify shells out to crux CLI (needs full monorepo deps).

--- a/apps/web/scripts/assign-ids.mjs
+++ b/apps/web/scripts/assign-ids.mjs
@@ -25,6 +25,7 @@ import { CONTENT_DIR, DATA_DIR, TOP_LEVEL_CONTENT_DIRS, REPO_ROOT } from './lib/
 import { scanFrontmatterEntities } from './lib/frontmatter-scanner.mjs';
 import { buildIdMaps, filterEligiblePages } from './lib/id-assignment.mjs';
 import { isServerAvailable, allocateIds, fetchServerEntityIdMap } from './lib/id-client.mjs';
+import { getServerUrl } from './lib/wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // .env loading — must run before any process.env access
@@ -157,7 +158,7 @@ async function main() {
   // only fail if we actually need to allocate new IDs.
   const serverAvailable = await isServerAvailable();
   if (serverAvailable) {
-    console.log(`  Using wiki server at ${process.env.LONGTERMWIKI_SERVER_URL}`);
+    console.log(`  Using wiki server at ${getServerUrl()}`);
   } else if (DRY_RUN) {
     console.log('  Wiki server unavailable — dry-run will show entities needing IDs but cannot preview assignments');
   } else {

--- a/apps/web/scripts/audit-factbase-pg.mjs
+++ b/apps/web/scripts/audit-factbase-pg.mjs
@@ -25,6 +25,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 import { fetchJsonWithRetry } from "./lib/wiki-server-data.mjs";
+import { getServerUrl, getApiKey, getEnvPrefix } from "./lib/wiki-server-env.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..", "..", "..");
@@ -32,17 +33,12 @@ const AUDIT_DIR = join(REPO_ROOT, "docs", "audits");
 const FACTBASE_DATA_DIR = join(REPO_ROOT, "packages", "factbase", "data");
 const OUT_MD_DIR = join(REPO_ROOT, "apps", "web", "src", "data");
 
-const envPrefix =
-  process.env.WIKI_SERVER_ENV === "prod" ||
-  process.env.WIKI_SERVER_ENV === "production"
-    ? "PROD_"
-    : "";
-const SERVER_URL = process.env[`${envPrefix}LONGTERMWIKI_SERVER_URL`];
-const API_KEY = process.env[`${envPrefix}LONGTERMWIKI_SERVER_API_KEY`];
+const SERVER_URL = getServerUrl();
+const API_KEY = getApiKey();
 
 if (!SERVER_URL) {
   console.error(
-    `error: ${envPrefix}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
+    `error: ${getEnvPrefix()}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
   );
   process.exit(1);
 }

--- a/apps/web/scripts/build-data-from-pg.mjs
+++ b/apps/web/scripts/build-data-from-pg.mjs
@@ -52,6 +52,7 @@ import { buildUrlToResourceMap } from "./lib/unconverted-links.mjs";
 import { buildIdRegistry } from "./lib/id-registry.mjs";
 import { collectPageWikiIds } from "./lib/frontmatter-scanner.mjs";
 import { fetchJsonWithRetry } from "./lib/wiki-server-data.mjs";
+import { getServerUrl, getApiKey, getEnvPrefix } from "./lib/wiki-server-env.mjs";
 import { fetchPersistentIdRegistry } from "./lib/id-client.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,17 +66,12 @@ const AUDIT_DIR = join(REPO_ROOT, "docs", "audits");
 const SAMPLE_ARG = process.argv.find((a) => a.startsWith("--sample="));
 const SAMPLE = SAMPLE_ARG ? Number(SAMPLE_ARG.split("=")[1]) : Infinity;
 
-const envPrefix =
-  process.env.WIKI_SERVER_ENV === "prod" ||
-  process.env.WIKI_SERVER_ENV === "production"
-    ? "PROD_"
-    : "";
-const SERVER_URL = process.env[`${envPrefix}LONGTERMWIKI_SERVER_URL`];
-const API_KEY = process.env[`${envPrefix}LONGTERMWIKI_SERVER_API_KEY`];
+const SERVER_URL = getServerUrl();
+const API_KEY = getApiKey();
 
 if (!SERVER_URL) {
   console.error(
-    `error: ${envPrefix}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
+    `error: ${getEnvPrefix()}LONGTERMWIKI_SERVER_URL is not set. Use WIKI_SERVER_ENV=prod.`
   );
   process.exit(1);
 }

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -26,6 +26,17 @@ import { resolveEntityType } from '../../../crux/lib/hallucination-risk.ts';
 import { filterBulkImportDates } from './lib/git-date-utils.mjs';
 import { computeRedundancy } from './lib/redundancy.mjs';
 import { CONTENT_DIR, DATA_DIR, OUTPUT_DIR, REPO_ROOT, TOP_LEVEL_CONTENT_DIRS } from './lib/content-types.mjs';
+
+// Load .env from repo root so wiki-server env vars are available without
+// pre-setting them in the shell. Mirrors the pattern in assign-ids.mjs.
+// dotenv.config() is a no-op when the file is absent or vars are already set.
+try {
+  const { config } = await import('dotenv');
+  config({ path: join(REPO_ROOT, '.env') });
+} catch {
+  // dotenv not available or .env missing — rely on shell environment
+}
+
 import { generateLLMFiles } from './generate-llm-files.mjs';
 import { buildUrlToResourceMap, urlKey as resourceUrlKey } from './lib/unconverted-links.mjs';
 import { normalizeUrlForDedup } from '@longterm-wiki/url-utils';
@@ -86,6 +97,7 @@ import {
   generateLinkHealth,
   generateEntityMatrix,
 } from './lib/output-writer.mjs';
+import { getServerUrl } from './lib/wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // Scope flag — `--scope=content` or `--quick` skips expensive non-content steps
@@ -1014,7 +1026,7 @@ async function main() {
   // Sync page links to wiki-server (optional — skips if server unavailable)
   if (CONTENT_ONLY) {
     console.log('  linkSync: skipped (content-only scope)');
-  } else if (process.env.LONGTERMWIKI_SERVER_URL) {
+  } else if (getServerUrl()) {
     const linkSignals = collectLinkSignals(entities, pages, contentInbound, tagIndex, byStableId);
     await syncLinksAndRefreshGraph(linkSignals);
   }
@@ -1032,7 +1044,7 @@ async function main() {
     let pageChangeHistory = null;
     let changeHistorySource = 'yaml';
 
-    const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+    const serverUrl = getServerUrl();
     if (serverUrl) {
       try {
         const headers = buildHeaders();
@@ -1161,7 +1173,7 @@ async function main() {
   // =========================================================================
   if (CONTENT_ONLY) {
     console.log('  buildMetricsSync: skipped (content-only scope)');
-  } else if (process.env.LONGTERMWIKI_SERVER_URL) {
+  } else if (getServerUrl()) {
     await syncBuildMetrics({ pages, updateScheduleItems });
   }
 

--- a/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
+++ b/apps/web/scripts/lib/__tests__/fetch-retry.test.mjs
@@ -162,12 +162,19 @@ describe('fetchJsonWithRetry', () => {
 
 describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-var override)', () => {
   const originalServerUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const originalProdServerUrl = process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  const originalWikiServerEnv = process.env.WIKI_SERVER_ENV;
   const originalCi = process.env.CI;
   const originalStrict = process.env.STRICT_VERDICTS;
   const noSleep = async () => {};
 
   beforeEach(() => {
     process.env.LONGTERMWIKI_SERVER_URL = 'http://fake-server';
+    // Disable QUA-747 slot-CWD auto-detect so tests are hermetic when run
+    // from inside an a<N> slot. Also clear PROD_ vars in case they're set
+    // from .env so getServerUrl() doesn't fall through to them.
+    process.env.WIKI_SERVER_ENV = 'local';
+    delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
     delete process.env.CI;
     delete process.env.STRICT_VERDICTS;
     setFullBuildMode(false);
@@ -178,6 +185,16 @@ describe('fetchRecordVerdicts — QUA-421 strict-mode behavior (QUA-448: no env-
       process.env.LONGTERMWIKI_SERVER_URL = originalServerUrl;
     } else {
       delete process.env.LONGTERMWIKI_SERVER_URL;
+    }
+    if (originalProdServerUrl !== undefined) {
+      process.env.PROD_LONGTERMWIKI_SERVER_URL = originalProdServerUrl;
+    } else {
+      delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+    }
+    if (originalWikiServerEnv !== undefined) {
+      process.env.WIKI_SERVER_ENV = originalWikiServerEnv;
+    } else {
+      delete process.env.WIKI_SERVER_ENV;
     }
     if (originalCi !== undefined) {
       process.env.CI = originalCi;

--- a/apps/web/scripts/lib/__tests__/id-client.test.mjs
+++ b/apps/web/scripts/lib/__tests__/id-client.test.mjs
@@ -9,14 +9,20 @@ beforeEach(() => {
   savedEnv = {
     LONGTERMWIKI_SERVER_URL: process.env.LONGTERMWIKI_SERVER_URL,
     LONGTERMWIKI_SERVER_API_KEY: process.env.LONGTERMWIKI_SERVER_API_KEY,
+    PROD_LONGTERMWIKI_SERVER_URL: process.env.PROD_LONGTERMWIKI_SERVER_URL,
+    PROD_LONGTERMWIKI_SERVER_API_KEY: process.env.PROD_LONGTERMWIKI_SERVER_API_KEY,
     WIKI_SERVER_ENV: process.env.WIKI_SERVER_ENV,
   };
   // Default: no server configured, and no PROD_ prefix routing.
   // WIKI_SERVER_ENV=prod would make getEnv() read PROD_LONGTERMWIKI_SERVER_URL,
   // which tests never set — unset it so tests are hermetic regardless of shell env.
+  // WIKI_SERVER_ENV=local disables the QUA-747 slot-CWD auto-detect that
+  // would otherwise pick up PROD_ vars when tests run from inside an a<N> slot.
   delete process.env.LONGTERMWIKI_SERVER_URL;
   delete process.env.LONGTERMWIKI_SERVER_API_KEY;
-  delete process.env.WIKI_SERVER_ENV;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+  process.env.WIKI_SERVER_ENV = "local";
 });
 
 afterEach(() => {

--- a/apps/web/scripts/lib/__tests__/wiki-server-env.test.mjs
+++ b/apps/web/scripts/lib/__tests__/wiki-server-env.test.mjs
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  findSlotFromAncestors,
+  getEnvPrefix,
+  getEnv,
+  getServerUrl,
+  getApiKey,
+} from '../wiki-server-env.mjs';
+
+let savedEnv;
+
+beforeEach(() => {
+  savedEnv = {
+    LONGTERMWIKI_SERVER_URL: process.env.LONGTERMWIKI_SERVER_URL,
+    LONGTERMWIKI_SERVER_API_KEY: process.env.LONGTERMWIKI_SERVER_API_KEY,
+    PROD_LONGTERMWIKI_SERVER_URL: process.env.PROD_LONGTERMWIKI_SERVER_URL,
+    PROD_LONGTERMWIKI_SERVER_API_KEY: process.env.PROD_LONGTERMWIKI_SERVER_API_KEY,
+    WIKI_SERVER_ENV: process.env.WIKI_SERVER_ENV,
+  };
+  delete process.env.LONGTERMWIKI_SERVER_URL;
+  delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_URL;
+  delete process.env.PROD_LONGTERMWIKI_SERVER_API_KEY;
+  // Default to "local" so tests are hermetic regardless of where they run
+  // (cwd-based slot auto-detect would otherwise leak in from real slots).
+  process.env.WIKI_SERVER_ENV = 'local';
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe('findSlotFromAncestors', () => {
+  it('returns slot number when cwd is inside an a<N> directory', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/a3/apps/web')).toBe(3);
+    expect(findSlotFromAncestors('/Users/x/lw/a17')).toBe(17);
+  });
+
+  it('returns null when no ancestor matches a<N> pattern', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/main')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/lw/coord')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/Documents/code')).toBeNull();
+  });
+
+  it('rejects non-numeric a<X> directories', () => {
+    expect(findSlotFromAncestors('/Users/x/lw/abc')).toBeNull();
+    expect(findSlotFromAncestors('/Users/x/lw/a1b')).toBeNull();
+  });
+
+  it('returns null at the filesystem root', () => {
+    expect(findSlotFromAncestors('/')).toBeNull();
+  });
+});
+
+describe('getEnvPrefix', () => {
+  it('returns PROD_ when WIKI_SERVER_ENV=prod', () => {
+    process.env.WIKI_SERVER_ENV = 'prod';
+    expect(getEnvPrefix()).toBe('PROD_');
+  });
+
+  it('returns PROD_ when WIKI_SERVER_ENV=production', () => {
+    process.env.WIKI_SERVER_ENV = 'production';
+    expect(getEnvPrefix()).toBe('PROD_');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV=local', () => {
+    process.env.WIKI_SERVER_ENV = 'local';
+    expect(getEnvPrefix()).toBe('');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV=dev', () => {
+    process.env.WIKI_SERVER_ENV = 'dev';
+    expect(getEnvPrefix()).toBe('');
+  });
+
+  it('returns empty string when WIKI_SERVER_ENV is set to an unknown value', () => {
+    process.env.WIKI_SERVER_ENV = 'staging';
+    expect(getEnvPrefix()).toBe('');
+  });
+});
+
+describe('getEnv / getServerUrl / getApiKey', () => {
+  it('reads the unprefixed var by default', () => {
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3130';
+    expect(getServerUrl()).toBe('http://localhost:3130');
+  });
+
+  it('reads the PROD_-prefixed var when WIKI_SERVER_ENV=prod', () => {
+    process.env.WIKI_SERVER_ENV = 'prod';
+    process.env.LONGTERMWIKI_SERVER_URL = 'http://localhost:3130';
+    process.env.PROD_LONGTERMWIKI_SERVER_URL = 'https://prod';
+    expect(getServerUrl()).toBe('https://prod');
+  });
+
+  it('returns empty string when the relevant var is unset', () => {
+    expect(getServerUrl()).toBe('');
+    expect(getApiKey()).toBe('');
+    expect(getEnv('LONGTERMWIKI_SERVER_URL')).toBe('');
+  });
+
+  it('respects WIKI_SERVER_ENV=local even when PROD_ vars are set', () => {
+    process.env.WIKI_SERVER_ENV = 'local';
+    process.env.PROD_LONGTERMWIKI_SERVER_URL = 'https://prod';
+    expect(getServerUrl()).toBe('');
+  });
+});

--- a/apps/web/scripts/lib/hallucination-risk-build.mjs
+++ b/apps/web/scripts/lib/hallucination-risk-build.mjs
@@ -8,6 +8,7 @@
  */
 
 import { recordRiskSnapshots } from './risk-client.mjs';
+import { getServerUrl } from './wiki-server-env.mjs';
 
 /**
  * Compute hallucination risk for all pages and build aggregated stats.
@@ -82,7 +83,7 @@ export async function syncRiskSnapshots(pages, contentOnly) {
     return;
   }
 
-  if (!process.env.LONGTERMWIKI_SERVER_URL) return;
+  if (!getServerUrl()) return;
 
   const snapshots = pages
     .filter(p => p.hallucinationRisk)

--- a/apps/web/scripts/lib/id-client.mjs
+++ b/apps/web/scripts/lib/id-client.mjs
@@ -9,21 +9,10 @@
  * If you change the shared client, update these too.
  */
 
+import { getServerUrl, getApiKey } from './wiki-server-env.mjs';
+
 const TIMEOUT_MS = 5000;
 const BATCH_TIMEOUT_MS = 30000;
-
-function getEnv(name) {
-  const prefix = process.env.WIKI_SERVER_ENV === "prod" ? "PROD_" : "";
-  return process.env[`${prefix}${name}`] || "";
-}
-
-function getServerUrl() {
-  return getEnv("LONGTERMWIKI_SERVER_URL");
-}
-
-function getApiKey() {
-  return getEnv("LONGTERMWIKI_SERVER_API_KEY");
-}
 
 function buildHeaders() {
   const headers = { "Content-Type": "application/json" };

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { getServerUrl, getApiKey } from './wiki-server-env.mjs';
 
 // ---------------------------------------------------------------------------
 // Shared ID detection helpers
@@ -77,7 +78,7 @@ function logWikiServerWarning(context, reason) {
 /** Build headers for wiki-server API requests, including auth if configured. */
 export function buildHeaders() {
   const headers = { 'Content-Type': 'application/json' };
-  const apiKey = process.env.LONGTERMWIKI_SERVER_API_KEY;
+  const apiKey = getApiKey();
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
   return headers;
 }
@@ -170,7 +171,7 @@ export async function fetchJsonWithRetry(url, opts = {}) {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildEditLogDateMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  editLogDates: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -209,7 +210,7 @@ export async function buildEditLogDateMap() {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildEarliestEditLogDateMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  earliestEditLogDates: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -247,7 +248,7 @@ export async function buildEarliestEditLogDateMap() {
  * Falls back to an empty map if the server is unavailable.
  */
 export async function buildCitationStatsMap() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  citationStats: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -294,7 +295,7 @@ export async function buildCitationStatsMap() {
  * Returns { [pageId]: CitationQuote[] } or empty object if unavailable.
  */
 export async function buildCitationQuotesBundle() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  citationQuotes: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -396,7 +397,7 @@ export function buildRatingsFromAssessment(assessment, fmRatings) {
  * Falls back to empty map if wiki-server is unavailable.
  */
 export async function fetchAssessments() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  assessments: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return new Map();
@@ -472,7 +473,7 @@ export async function fetchAssessments() {
  * Falls back to empty object if wiki-server is unavailable.
  */
 export async function fetchBenchmarkResults() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  benchmark-results: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -555,7 +556,7 @@ export async function fetchBenchmarkResults() {
  * Falls back to empty array if wiki-server is unavailable.
  */
 export async function fetchResearchAreas() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  research-areas: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return [];
@@ -599,7 +600,7 @@ export async function fetchResearchAreas() {
  * This replaces the ISR-based per-page fetch that was unreliable during builds.
  */
 export async function fetchResearchAreaDetails(areaIds) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl || areaIds.length === 0) {
     console.log('  research-area-details: skipped (no server or no areas)');
     return {};
@@ -681,7 +682,7 @@ function isStrictVerdictsMode() {
  *     and discarding everything
  */
 export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  record-verdicts: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -759,7 +760,7 @@ export async function fetchRecordVerdicts({ fetchImpl, sleepImpl } = {}) {
  * making PG the source of truth for facts.
  */
 export async function fetchFactBaseFromServer() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  factbase-export: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;
@@ -794,7 +795,7 @@ export async function fetchFactBaseFromServer() {
  * the entity stableId when looking up — not the slug.
  */
 export async function fetchPolicyStakeholderIds() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  policy-stakeholder-ids: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -852,7 +853,7 @@ export async function fetchPolicyStakeholderIds() {
  * @param {Array} typedEntities — the full typedEntities array from database
  */
 export async function syncPolicyStakeholders(typedEntities) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  policy-stakeholder-sync: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return;
@@ -1341,7 +1342,7 @@ function normalizePGEntityId(id) {
  * Returns facts grouped by entityId in the KB Fact shape, or null if unavailable.
  */
 export async function fetchFactsFromPG() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  kb-facts-pg: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;
@@ -1367,7 +1368,7 @@ export async function fetchFactsFromPG() {
 }
 
 export async function mergePGRecordsIntoKB(kb) {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  kb-pg: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return { personnel: 0, grants: 0, fundingRounds: 0, investments: 0, equityPositions: 0, divisions: 0, fundingPrograms: 0, divisionPersonnel: 0, entityEvents: 0, entityAssessments: 0, publications: 0 };
@@ -1668,7 +1669,7 @@ export async function mergePGRecordsIntoKB(kb) {
  * Falls back to null if the server is unavailable (caller should use YAML).
  */
 export async function fetchResourcesFromPG() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) return null;
 
   const headers = buildHeaders();
@@ -1798,7 +1799,7 @@ export async function fetchResourcesFromPG() {
  * Falls back to an empty object if the server is unavailable.
  */
 export async function buildPageReferenceIndex() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  pageReferenceIndex: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return {};
@@ -1850,7 +1851,7 @@ export async function buildPageReferenceIndex() {
  * Returns: { [stableId]: { authored: resourceId[], subject: resourceId[] } }
  */
 export async function fetchEntityResourceLinks() {
-  const serverUrl = process.env.LONGTERMWIKI_SERVER_URL;
+  const serverUrl = getServerUrl();
   if (!serverUrl) {
     console.log('  entityResourceLinks: skipped (LONGTERMWIKI_SERVER_URL not set)');
     return null;

--- a/apps/web/scripts/lib/wiki-server-env.mjs
+++ b/apps/web/scripts/lib/wiki-server-env.mjs
@@ -1,0 +1,65 @@
+/**
+ * wiki-server-env.mjs — env-prefix resolution for wiki-server URL/API key.
+ *
+ * Mirrors the logic in `crux/lib/wiki-server/client.ts::getEnvPrefix()`
+ * (QUA-616). Plain ESM so it can be imported by `node`-run scripts that
+ * cannot use tsx (e.g. assign-ids.mjs, build-data.mjs).
+ *
+ * Resolution order:
+ *   1. `WIKI_SERVER_ENV=prod`/`production`  → `PROD_` prefix
+ *   2. `WIKI_SERVER_ENV=local`/`dev`        → no prefix (force local)
+ *   3. CWD inside an `a<N>` slot directory  → `PROD_` prefix
+ *      (slot agents have no local wiki-server)
+ *   4. Otherwise                            → no prefix (default local)
+ *
+ * If you change this, update `crux/lib/wiki-server/client.ts` too.
+ */
+
+import { basename, dirname } from 'path';
+
+/**
+ * Walk up from `cwd` looking for a directory named `a<N>` (the agent-slot
+ * root). Returns the slot number when found, or null. Mirror of
+ * `crux/lib/session/session-context.ts::findSlotFromAncestors`.
+ */
+export function findSlotFromAncestors(cwd) {
+  let current = cwd;
+  for (let i = 0; i < 10; i++) {
+    const match = basename(current).match(/^a(\d+)$/);
+    if (match) {
+      const n = Number.parseInt(match[1], 10);
+      if (Number.isSafeInteger(n)) return n;
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return null;
+}
+
+export function getEnvPrefix() {
+  const env = process.env.WIKI_SERVER_ENV;
+  if (env === 'prod' || env === 'production') return 'PROD_';
+  if (env === 'local' || env === 'dev') return '';
+  if (env === undefined && findSlotFromAncestors(process.cwd()) !== null) {
+    return 'PROD_';
+  }
+  return '';
+}
+
+/**
+ * Read a `LONGTERMWIKI_*` env var, honoring the active prefix.
+ * Returns '' if unset.
+ */
+export function getEnv(name) {
+  const prefix = getEnvPrefix();
+  return process.env[`${prefix}${name}`] || '';
+}
+
+export function getServerUrl() {
+  return getEnv('LONGTERMWIKI_SERVER_URL');
+}
+
+export function getApiKey() {
+  return getEnv('LONGTERMWIKI_SERVER_API_KEY');
+}

--- a/apps/wiki-server/drizzle/0216_qua_753_widen_audit_log_record_id.sql
+++ b/apps/wiki-server/drizzle/0216_qua_753_widen_audit_log_record_id.sql
@@ -1,0 +1,20 @@
+-- QUA-753: widen tablebase_audit_log.record_id from varchar(10) to text.
+--
+-- The 10-char ceiling was inherited from the canonical stableId pattern
+-- (10 alphanumerics, stripped `sid_` prefix). It silently broke for any
+-- record_type whose IDs aren't 10-char stableIds:
+--
+--   - scorecard_snapshots: `<source>-<wave>` (e.g. `fmti-oct-2023`, 13 chars)
+--   - scorecard_grades:    `<snap>|<entity>|<dim>` (30+ chars)
+--   - any future composite/derived ID
+--
+-- The factory's auditRecordType hook tries to insert and fails with
+-- HTTP 500 on every sync, blocking QUA-748..752 (FMTI, FLI, SaferAI,
+-- AILW, Seoul) and likely any other QUA-687 phase whose record IDs
+-- aren't 10-char stableIds.
+--
+-- varchar→text is metadata-only in Postgres (no rewrite). All existing
+-- rows have ≤10-char IDs (varchar(10) hard-limited insertions), so the
+-- widening is lossless.
+
+ALTER TABLE tablebase_audit_log ALTER COLUMN record_id TYPE text;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1506,6 +1506,13 @@
       "when": 1787876600000,
       "tag": "0215_qua_689_safety_benchmark_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 216,
+      "version": "7",
+      "when": 1787876700000,
+      "tag": "0216_qua_753_widen_audit_log_record_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
@@ -170,9 +170,7 @@ const benchmarkResultsPendingApp = new Hono()
       name: "benchmark-results-pending",
       table: benchmarkResultsPending,
       syncSchema: SyncBenchmarkResultPendingItemSchema,
-      // Why no `auditRecordType`: row IDs (e.g. `brp_quarantine_helm_1`)
-      // can exceed `tablebase_audit_log.record_id`'s varchar(10), so audit
-      // logging would fail with "value too long" on real payloads.
+      auditRecordType: "benchmark_results_pending",
       // Why no factory `naturalKey`: the factory's natural-key dedup runs
       // BEFORE `preValidate`, but `preValidate` is what canonicalizes the
       // benchmarkId (slug → 10-char id). The post-resolution dedup below

--- a/apps/wiki-server/src/routes/tablebase/model-aliases.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-aliases.ts
@@ -178,10 +178,10 @@ const modelAliasesApp = new Hono()
       syncSchema: SyncModelAliasItemSchema,
       // alias is the PK (not id). conflictTarget overrides the factory's
       // default; auditRecordType is omitted because the factory writes
-      // `recordId: row.id` (which model_aliases doesn't have) into
-      // `tablebase_audit_log.record_id` varchar(10). entityRefs shorthand
-      // is skipped because the FK target is entities.stable_id, not .id —
-      // the PG constraint catches unknown stable_ids at upsert time.
+      // `recordId: row.id`, which model_aliases doesn't have. entityRefs
+      // shorthand is skipped because the FK target is entities.stable_id,
+      // not .id — the PG constraint catches unknown stable_ids at upsert
+      // time.
       conflictTarget: modelAliases.alias,
       naturalKey: (item) => item.alias,
       naturalKeyError:

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1889,7 +1889,10 @@ export const tablebaseAuditLog = pgTable(
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     recordType: text("record_type").notNull(),
-    recordId: varchar("record_id", { length: 10 }).notNull(),
+    // QUA-753: widened from varchar(10) to text. Composite/derived record IDs
+    // (e.g. scorecard snapshot IDs `<source>-<wave>` or grade IDs
+    // `<snap>|<entity>|<dim>`) blew through the 10-char ceiling and 500'd.
+    recordId: text("record_id").notNull(),
     operation: text("operation").notNull(), // 'insert', 'update', 'delete'
     oldData: jsonb("old_data"),
     newData: jsonb("new_data").notNull(),


### PR DESCRIPTION
## Release 2026-04-26

**4 commits** since last release.

> [!WARNING]
> Production has **49 commits** not on main (hotfixes or merge commits).
> Review carefully to ensure these won't be overwritten.

### Fixes
- fix(QUA-746): COPY api-types.ts into worker image so PR_OUTCOMES re-export resolves

### Other
- QUA-747: auto-detect slot CWD in apps/web build scripts

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"`
- [ ] `docker` Docker configuration changed — verify container builds and starts correctly — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `manual` After deploy, verify worker rollout succeeds: `kubectl get pods -n longtermwiki | grep worker` — expect 3 pods Running 1/1 on the new replicaset, and the old `fcf4fcd67-*` pods removed. The crashlooping pod `longterm-wiki-worker-worker-7ff966dc5b-bl5p8` should be gone. _(from PR #4624)_
- [ ] `manual` Confirm the worker workflow CI run succeeds: `gh run list -R quantified-uncertainty/longterm-wiki --workflow=worker-docker.yml -L 1 --json status,conclusion` _(from PR #4624)_
- [ ] `migration` Verify migration 0213 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4613)_
- [ ] `manual` Confirm the migration re-armed historical orphans (expect a non-zero `RAISE NOTICE` row count in the deploy logs, then `psql "$DATABASE_URL" -c "SELECT count(*) FROM source_check_verdicts WHERE reasoning='Reset by flagship-curate before re-verification' AND verdict='unchecked' AND next_check_due IS NULL;"` should return 0). _(from PR #4613)_
- [ ] `manual` After the next weekly `sourcing-recheck` cron run, verify Anthropic's 18 known orphans have flipped away from `unchecked` — `pnpm crux fb show anthropic` and inspect the verdict mix. _(from PR #4613)_
- [ ] `env` Set env var DISCORD_FRAMEWORK_WEBHOOK_URL in production _(from PR #4608)_
- [ ] `env` Set env var DISCORD_WEBHOOK_URL in production _(from PR #4608)_
- [ ] `migration` Verify migration 0211 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4608)_
- [ ] `ci` New workflow "refresh frameworks" — verify it runs successfully after merge — `gh run list --workflow="refresh-frameworks.yml" --limit=1 --json status,conclusion` _(from PR #4608)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4608)_
- [ ] `route` New API route "framework-ingest-log" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/framework-ingest-log" -o /dev/null -w "%{http_code}"` _(from PR #4608)_
- [ ] `migration` Verify migration 0209 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4601)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4601)_
- [ ] `route` New API route "third-party-evaluations" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/third-party-evaluations/stats" -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" -o /dev/null -w "%{http_code}"` _(from PR #4601)_
- [ ] `manual` Run the four backfill commands end-to-end now that the route exists. Expect ~210 rows total. `pnpm crux tb third-party-evals backfill caisi --evaluator=sid_pKeaWwP6sQ` then apollo / metr / uk-aisi (see QUA-705 Linear comment for verified org stableIds and concurrency knobs) _(from PR #4601)_
- [ ] `manual` Spot-check 5 rows in `/internal/entity-source-checks` and via `pnpm crux tb third-party-evals ingest --json` — verify titles, models linked, and risk_domain populated. If extraction quality looks off, file follow-ups before running larger batches. _(from PR #4601)_
- [ ] `migration` Verify migration 0206 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4600)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4600)_
- [ ] `config` Auto-update sources config changed — verify next auto-update run uses new sources _(from PR #4600)_
- [ ] `manual` After deploy: `pnpm crux tb system-cards extract <test-url> --ai-model=<sid> --apply` and confirm cited benchmarks land in `benchmark_results` (matched) or `pending_benchmark_links` (queued). Verify `tested_by='self-report'` on new rows. _(from PR #4600)_
- [ ] `migration` Verify migration 0207 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4599)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4599)_
- [ ] `route` New API route "benchmark-results-pending" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/benchmark-results-pending" -o /dev/null -w "%{http_code}"` _(from PR #4599)_
- [ ] `route` New API route "model-aliases" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/model-aliases" -o /dev/null -w "%{http_code}"` _(from PR #4599)_
- [ ] `manual` Confirm CHECK constraints landed on `benchmark_results` and `benchmarks` after deploy — `psql "$DATABASE_URL" -c "SELECT conname FROM pg_constraint WHERE conname IN ('chk_benchmarks_category', 'chk_br_tested_by', 'chk_br_evaluation_date_nonempty', 'chk_brp_status', 'chk_brp_tested_by', 'chk_model_aliases_confidence');"` — expect 6 rows. _(from PR #4599)_
- [ ] `manual` Confirm widened unique index replaced the old narrow one — `psql "$DATABASE_URL" -c "SELECT indexname FROM pg_indexes WHERE tablename='benchmark_results';"` — expect `idx_br_benchmark_model_testedby_date` and NO `idx_br_benchmark_model`. _(from PR #4599)_
- [ ] `manual` Confirm `model_aliases` and `benchmark_results_pending` tables were created — `psql "$DATABASE_URL" -c "\dt model_aliases benchmark_results_pending"` — expect both. _(from PR #4599)_
- [ ] `manual` Hit one new endpoint with the prod API key to confirm route is mounted — `curl -sf -H "Authorization: Bearer $PROD_LONGTERMWIKI_SERVER_API_KEY" "$WIKI_SERVER_URL/api/model-aliases/stats"` — expect `{"total":0,...}`. _(from PR #4599)_
- [ ] `manual` (note) The auto-detected `benchmark-shared` route check above is a FALSE POSITIVE — `benchmark-shared.ts` is a helper module, not a Hono route. Curl will 404 by design. Mark this checked once the model-aliases stats hit succeeds. _(from PR #4599)_
- [ ] `ci` New workflow "linear verify pr" — verify it runs successfully after merge — `gh run list --workflow="linear-verify-pr.yml" --limit=1 --json status,conclusion` _(from PR #4596)_
- [ ] `manual` Confirm `LINEAR_API_KEY` secret exists at the repo level (already used by `ci-pr-health.yml`, but verify visibility from this workflow's runner) — `gh secret list -R quantified-uncertainty/longterm-wiki | grep LINEAR_API_KEY` _(from PR #4596)_
- [ ] `manual` First nightly run of `audit-fix` should fire ~08:20 UTC the day after merge — verify it picked up any pre-existing stuck issues — `gh run list --workflow="linear-verify-pr.yml" --event=schedule --limit=1` _(from PR #4596)_
- [ ] `migration` Verify migration 0205 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4590)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4590)_
- [ ] `route` New API route "ai-incidents" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/ai-incidents" -o /dev/null -w "%{http_code}"` _(from PR #4590)_
- [ ] `manual` Smoke-test the AIID ingest pipeline against prod wiki-server with a small batch before opening it up: `WIKI_SERVER_ENV=prod pnpm crux aiid ingest --limit=100`. Expect `Done — upserted 100 incidents.` and `GET /api/ai-incidents/stats` to show `total >= 100`. _(from PR #4590)_
- [ ] `manual` Confirm the new `aiid-no-report-text` gate check is running in CI on this PR's run (it's blocking; should appear in the green list). _(from PR #4590)_
- [ ] `migration` Verify migration 0204 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4589)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4589)_
- [ ] `route` New API route "scorecard-grades" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/scorecard-grades/all?limit=1" -o /dev/null -w "%{http_code}"` _(from PR #4589)_
- [ ] `route` New API route "scorecard-snapshots" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/scorecard-snapshots/all?limit=1" -o /dev/null -w "%{http_code}"` _(from PR #4589)_
- [ ] `manual` Visit `https://www.longtermwiki.com/scorecards` after Vercel redeploy — expect five methodology panels with "not yet ingested" labels and an empty-state matrix message. The framework is data-free; matrix rows will only appear once QUA-697 / QUA-698 land their ingesters. _(from PR #4589)_
- [ ] `manual` Visit a frontier-lab org profile (e.g. `/organizations/anthropic`) — expect NO Scorecards tab yet (tab is conditional on grades existing). Tab will appear once ingesters populate the table. _(from PR #4589)_
- [ ] `migration` Verify migration 0204 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4588)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4588)_
- [ ] `route` New API route "audit-log" added — verify endpoint is accessible after deploy — `curl -sf "$WIKI_SERVER_URL/api/audit-log/recent?limit=1" -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" -o /dev/null -w "%{http_code}"` _(from PR #4588)_
- [ ] `manual` Verify the trigger actually writes after a real sync — run any allow-listed sync (e.g. `pnpm crux tb personnel sync --dry-run=false` or a grants sync) and then `WIKI_SERVER_ENV=prod pnpm crux audit recent --limit=5`. Expect to see 1+ rows with non-null `session_id` + `tool` matching the session that ran the sync. _(from PR #4588)_
- [ ] `manual` Regression check: confirm no wiki-server writes are failing post-deploy. New triggers are the #1 source of "why is every write returning 500" incidents. Watch the health endpoint and error logs for ~10 minutes after rollout; if 5xx on any `/api/*/sync` spikes, roll back the migration (`CALL remove_audit_trigger('<offending_table>')` per-table; `DROP FUNCTION audit_trigger_fn()` removes the whole layer). _(from PR #4588)_
- [ ] `manual` Smoke-check storage growth. Initial audit-log insert volume depends entirely on how busy the allow-listed tables are. After 1 hour of traffic, run `SELECT count(*), pg_size_pretty(pg_total_relation_size('full_audit_log')) FROM full_audit_log;`. If the table is growing faster than ~10k rows/hour, open a follow-up to add retention (not blocking this deploy). _(from PR #4588)_
- [ ] `migration` Verify migration 0204 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"` _(from PR #4587)_
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .` _(from PR #4587)_
<!-- /deploy-tasks -->

---
[Full diff](https://github.com/quantified-uncertainty/longterm-wiki/compare/production...main)