### PR TITLE
fix(QUA-753): widen tablebase_audit_log.record_id to text

### DIFF
--- a/apps/wiki-server/drizzle/0216_qua_753_widen_audit_log_record_id.sql
+++ b/apps/wiki-server/drizzle/0216_qua_753_widen_audit_log_record_id.sql
@@ -1,0 +1,20 @@
+-- QUA-753: widen tablebase_audit_log.record_id from varchar(10) to text.
+--
+-- The 10-char ceiling was inherited from the canonical stableId pattern
+-- (10 alphanumerics, stripped `sid_` prefix). It silently broke for any
+-- record_type whose IDs aren't 10-char stableIds:
+--
+--   - scorecard_snapshots: `<source>-<wave>` (e.g. `fmti-oct-2023`, 13 chars)
+--   - scorecard_grades:    `<snap>|<entity>|<dim>` (30+ chars)
+--   - any future composite/derived ID
+--
+-- The factory's auditRecordType hook tries to insert and fails with
+-- HTTP 500 on every sync, blocking QUA-748..752 (FMTI, FLI, SaferAI,
+-- AILW, Seoul) and likely any other QUA-687 phase whose record IDs
+-- aren't 10-char stableIds.
+--
+-- varchar→text is metadata-only in Postgres (no rewrite). All existing
+-- rows have ≤10-char IDs (varchar(10) hard-limited insertions), so the
+-- widening is lossless.
+
+ALTER TABLE tablebase_audit_log ALTER COLUMN record_id TYPE text;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1506,6 +1506,13 @@
       "when": 1787876600000,
       "tag": "0215_qua_689_safety_benchmark_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 216,
+      "version": "7",
+      "when": 1787876700000,
+      "tag": "0216_qua_753_widen_audit_log_record_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+++ b/apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
@@ -170,9 +170,7 @@ const benchmarkResultsPendingApp = new Hono()
       name: "benchmark-results-pending",
       table: benchmarkResultsPending,
       syncSchema: SyncBenchmarkResultPendingItemSchema,
-      // Why no `auditRecordType`: row IDs (e.g. `brp_quarantine_helm_1`)
-      // can exceed `tablebase_audit_log.record_id`'s varchar(10), so audit
-      // logging would fail with "value too long" on real payloads.
+      auditRecordType: "benchmark_results_pending",
       // Why no factory `naturalKey`: the factory's natural-key dedup runs
       // BEFORE `preValidate`, but `preValidate` is what canonicalizes the
       // benchmarkId (slug → 10-char id). The post-resolution dedup below

--- a/apps/wiki-server/src/routes/tablebase/model-aliases.ts
+++ b/apps/wiki-server/src/routes/tablebase/model-aliases.ts
@@ -178,10 +178,10 @@ const modelAliasesApp = new Hono()
       syncSchema: SyncModelAliasItemSchema,
       // alias is the PK (not id). conflictTarget overrides the factory's
       // default; auditRecordType is omitted because the factory writes
-      // `recordId: row.id` (which model_aliases doesn't have) into
-      // `tablebase_audit_log.record_id` varchar(10). entityRefs shorthand
-      // is skipped because the FK target is entities.stable_id, not .id —
-      // the PG constraint catches unknown stable_ids at upsert time.
+      // `recordId: row.id`, which model_aliases doesn't have. entityRefs
+      // shorthand is skipped because the FK target is entities.stable_id,
+      // not .id — the PG constraint catches unknown stable_ids at upsert
+      // time.
       conflictTarget: modelAliases.alias,
       naturalKey: (item) => item.alias,
       naturalKeyError:

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1889,7 +1889,10 @@ export const tablebaseAuditLog = pgTable(
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     recordType: text("record_type").notNull(),
-    recordId: varchar("record_id", { length: 10 }).notNull(),
+    // QUA-753: widened from varchar(10) to text. Composite/derived record IDs
+    // (e.g. scorecard snapshot IDs `<source>-<wave>` or grade IDs
+    // `<snap>|<entity>|<dim>`) blew through the 10-char ceiling and 500'd.
+    recordId: text("record_id").notNull(),
     operation: text("operation").notNull(), // 'insert', 'update', 'delete'
     oldData: jsonb("old_data"),
     newData: jsonb("new_data").notNull(),


### PR DESCRIPTION
## Summary

`tablebase_audit_log.record_id` was `varchar(10)` — inherited from the canonical 10-char stableId pattern. The factory's `auditRecordType` hook fails the insert with HTTP 500 on every sync where record IDs aren't 10 chars:

- **scorecard_snapshots**: `<source>-<wave>` (13 chars, e.g. `fmti-oct-2023`)
- **scorecard_grades**: `<snap>|<entity>|<dim>` (30+ chars)

This blocks QUA-748 (FMTI ingest, where it was discovered) and likely every other QUA-687 phase whose record IDs aren't 10-char stableIds.

## Changes

- **Migration `0216`** widens `tablebase_audit_log.record_id` from `varchar(10)` to `text`. `varchar→text` is metadata-only in Postgres (no rewrite, no NOT VALID needed). All existing rows are ≤10 chars (varchar(10) hard-limited inserts), so widening is lossless.
- **`schema.ts`** — `recordId: varchar("record_id", { length: 10 })` → `recordId: text("record_id")` to match.
- **`benchmark-results-pending.ts`** — re-enables `auditRecordType: "benchmark_results_pending"`. The route had previously omitted it because `brp_quarantine_helm_*` row IDs overflowed the column; the workaround is no longer needed.
- **`model-aliases.ts`** — refreshes the comment that cited `varchar(10)`. The route still doesn't audit (different reason — alias is the PK, no `id` field for the factory's audit hook).

## Verification

- All 1,435 wiki-server tests pass; targeted runs on `benchmark-results-pending` and `model-aliases` green.
- TypeScript clean (`pnpm typecheck` in `apps/wiki-server`).
- Drizzle journal validator clean (only pre-existing warnings on unrelated migrations).
- `/agent-review-pr` ran a hostile reviewer subagent — caught the `benchmark-results-pending` workaround and surfaced the `record_verifications`/`record_verdicts` sibling concern (already dropped in 0127, confirmed safe).

## Discovery context

Found while running QUA-748 (`pnpm crux scorecards fmti ingest --ensure-stubs`):

```
Sync: snapshot=0, grades=0
Error: Snapshot sync failed: 500: {"error":"internal_error","message":"[scorecard-snapshots/audit] Failed query: insert into "tablebase_audit_log" ...
params: scorecard_snapshots,fmti-oct-2023,insert,...
```

All 3 FMTI waves failed identically. After this lands and deploys, QUA-748 resumes.

## Side-effects on related work

- **QUA-748** (FMTI prod run): unblocked once this deploys.
- **QUA-749, QUA-750, QUA-751, QUA-752** (FLI / SaferAI / AILW / Seoul ingest): same blocker; all unblocked.
- **QUA-755** (filed): pre-push gate's local validators flag 117 errors in files this PR doesn't touch (`crux/lib/epoch-benchmark/ingest.ts`, `crux/pr-patrol/parallel.ts`, `crux/validate/validate-gate.ts`, `crux/visual/visual-review.ts`, content MDX). Pushed with `--no-verify` after user authorization. The gate-baseline drift is unrelated to this PR's correctness.

## Test plan

- [x] `pnpm --filter wiki-server typecheck` — green
- [x] `pnpm --filter wiki-server test --run` — 1435 pass, 57 skipped (no regressions)
- [x] `npx tsx crux/validate/validate-drizzle-journal.ts` — clean (only pre-existing warnings)
- [x] `npx tsx crux/pr-review/detect-narrow-patch.ts` — no matches
- [x] `/agent-review-pr` hostile-reviewer subagent — 1 MEDIUM addressed in `5e1fa8320`, others dismissed with reasons
- [ ] Post-deploy: re-run QUA-748 (`pnpm crux scorecards fmti ingest --ensure-stubs`) and verify all 3 waves succeed

Fixes QUA-753


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0216 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended audit log record ID capacity to support longer identifiers.

* **Bug Fixes**
  * Enabled audit logging for benchmark results pending sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->