### PR TITLE
QUA-756: filter release-PR deploy tasks by release diff, not lookback

### DIFF
--- a/crux/commands/release.test.ts
+++ b/crux/commands/release.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   categorizeCommit,
   groupCommits,
   generateReleaseBody,
   evaluateReleasePreflight,
+  fetchSubPrDeployTasks,
 } from './release.ts';
 import type { DeployHealthStatus } from '../lib/pr-analysis/deploy-status.ts';
 
@@ -279,5 +280,170 @@ describe('evaluateReleasePreflight', () => {
     const decision = evaluateReleasePreflight(healthySuccess, { force: true });
     expect(decision.ok).toBe(true);
     if (decision.ok) expect(decision.warning).toBeNull();
+  });
+});
+
+// ── fetchSubPrDeployTasks (QUA-756) ─────────────────────────────────────────
+
+describe('fetchSubPrDeployTasks (QUA-756)', () => {
+  const NOW = new Date().getTime();
+  const DAY = 1000 * 60 * 60 * 24;
+
+  const DEPLOY_TASK_BODY = [
+    '## Deploy Checklist',
+    '<!-- deploy-tasks:v1 -->',
+    '- [ ] Restart wiki-server',
+    '- [ ] Verify endpoint',
+    '<!-- /deploy-tasks -->',
+  ].join('\n');
+
+  function prFixture(overrides: {
+    number: number;
+    sha?: string | null;
+    body?: string | null;
+    mergedDaysAgo?: number;
+  }) {
+    const merged = overrides.mergedDaysAgo ?? 1;
+    return {
+      number: overrides.number,
+      title: `PR ${overrides.number}`,
+      body: overrides.body ?? DEPLOY_TASK_BODY,
+      merged_at: new Date(NOW - merged * DAY).toISOString(),
+      merge_commit_sha:
+        overrides.sha === undefined ? `sha-${overrides.number}` : overrides.sha,
+      updated_at: new Date(NOW - merged * DAY).toISOString(),
+    };
+  }
+
+  it('returns empty array when the release diff is empty (nothing to ship)', async () => {
+    const api = vi.fn();
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas: new Set(),
+      api: api as never,
+    });
+    expect(tasks).toEqual([]);
+    // No PR pagination should occur — empty diff is a fast no-op.
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it('only includes tasks from PRs whose merge commit is in the release diff', async () => {
+    // PRs 100 and 101 are in the release diff; PR 200 (already-shipped) is not.
+    const releaseDiffShas = new Set(['sha-100', 'sha-101']);
+
+    const api = vi.fn(async (endpoint: string) => {
+      if (endpoint.includes('/pulls?')) {
+        return [
+          prFixture({ number: 100 }),
+          prFixture({ number: 101 }),
+          prFixture({ number: 200 }), // already shipped — sha not in diff
+        ];
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas,
+      api: api as never,
+    });
+
+    // Each in-diff PR contributes its 2 unchecked tasks; the already-shipped
+    // PR contributes none. Tasks are tagged with their originating PR.
+    expect(tasks).toHaveLength(4);
+    expect(tasks).toEqual(
+      expect.arrayContaining([
+        'Restart wiki-server _(from PR #100)_',
+        'Verify endpoint _(from PR #100)_',
+        'Restart wiki-server _(from PR #101)_',
+        'Verify endpoint _(from PR #101)_',
+      ]),
+    );
+    // No tasks from PR #200 (already shipped).
+    expect(tasks.some((t) => t.includes('PR #200'))).toBe(false);
+  });
+
+  it('drops PRs with null merge_commit_sha defensively', async () => {
+    // GitHub returns null merge_commit_sha for unmerged PRs and (briefly) for
+    // newly-merged ones whose merge commit is still being computed. Either way
+    // we cannot match SHA membership — drop them rather than over-include.
+    const releaseDiffShas = new Set(['sha-100']);
+    const api = vi.fn(async () => [
+      prFixture({ number: 100 }),
+      prFixture({ number: 101, sha: null }),
+    ]);
+
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas,
+      api: api as never,
+    });
+
+    expect(tasks.every((t) => t.includes('PR #100'))).toBe(true);
+    expect(tasks.some((t) => t.includes('PR #101'))).toBe(false);
+  });
+
+  it('skips PRs without a deploy-tasks block', async () => {
+    const releaseDiffShas = new Set(['sha-100', 'sha-101']);
+    const api = vi.fn(async () => [
+      prFixture({ number: 100 }),
+      prFixture({ number: 101, body: 'A regular PR body with no deploy section.' }),
+    ]);
+
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas,
+      api: api as never,
+    });
+
+    expect(tasks.every((t) => t.includes('PR #100'))).toBe(true);
+    expect(tasks.some((t) => t.includes('PR #101'))).toBe(false);
+  });
+
+  it('skips already-checked tasks within an in-diff PR', async () => {
+    const partiallyCheckedBody = [
+      '## Deploy Checklist',
+      '<!-- deploy-tasks:v1 -->',
+      '- [x] Already done',
+      '- [ ] Still pending',
+      '<!-- /deploy-tasks -->',
+    ].join('\n');
+
+    const releaseDiffShas = new Set(['sha-100']);
+    const api = vi.fn(async () => [
+      prFixture({ number: 100, body: partiallyCheckedBody }),
+    ]);
+
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas,
+      api: api as never,
+    });
+
+    expect(tasks).toEqual(['Still pending _(from PR #100)_']);
+  });
+
+  it('repro for QUA-756: stale shipped tasks do NOT leak into next release', async () => {
+    // Simulate the QUA-756 scenario: prior release (PR #4619) shipped PRs
+    // #4587..#4617 with unchecked deploy tasks. The current release ships only
+    // PRs #4624 + #4625. The new behaviour: only #4624 + #4625 contribute
+    // tasks, even though #4587..#4617 have unchecked items still.
+    const releaseDiffShas = new Set(['sha-4624', 'sha-4625']);
+    const oldShippedPrs = [4587, 4588, 4589, 4590, 4596, 4599, 4600, 4601, 4608, 4613];
+    const newPrs = [4624, 4625];
+    const allPrs = [...oldShippedPrs, ...newPrs].map((n) =>
+      prFixture({ number: n }),
+    );
+    const api = vi.fn(async () => allPrs);
+
+    const tasks = await fetchSubPrDeployTasks({
+      releaseDiffShas,
+      api: api as never,
+    });
+
+    // Every task must be from #4624 or #4625; none from the prior release.
+    for (const task of tasks) {
+      const match = task.match(/from PR #(\d+)/);
+      expect(match).not.toBeNull();
+      const prNum = match ? Number(match[1]) : NaN;
+      expect(newPrs).toContain(prNum);
+    }
+    // Each new PR contributes 2 unchecked tasks → 4 total.
+    expect(tasks).toHaveLength(4);
   });
 });

--- a/crux/commands/release.ts
+++ b/crux/commands/release.ts
@@ -21,6 +21,7 @@ import {
   parseDeployTasksFromBody,
   preserveCheckedState,
 } from '../lib/deploy-tasks/detect.ts';
+import { fetchMergedPrsInWindow } from './deploy-tasks.ts';
 import {
   checkDeployHealth,
   type DeployHealthStatus,
@@ -114,32 +115,62 @@ export function groupCommits(subjects: string[]): Record<CommitCategory, string[
 
 // ── Sub-PR deploy task aggregation ──────────────────────────────────────────
 
-interface SubPrData {
-  number: number;
-  title: string;
-  body: string | null;
-  merged_at: string | null;
+/**
+ * Returns the set of commit SHAs reachable from `origin/main` but not from
+ * `origin/production` — i.e. the commits this release would actually deploy.
+ *
+ * Used by `fetchSubPrDeployTasks` to filter sub-PR tasks down to PRs whose
+ * merge commit is part of this release's diff. PRs whose merge commits are
+ * already on production have, by definition, already shipped — their
+ * checklist items belong to a prior release PR (QUA-756).
+ */
+export function commitShasInReleaseDiff(): Set<string> {
+  const output = git('log', 'origin/production..origin/main', '--format=%H');
+  if (!output) return new Set();
+  return new Set(output.split('\n').filter(Boolean));
 }
 
 /**
- * Fetch unchecked deploy tasks from PRs merged to main since the last release.
- * These are tasks that individual PRs declared but that the file-diff detector
- * wouldn't pick up (e.g., manually added tasks, env vars not yet in code).
+ * Fetch unchecked deploy tasks from PRs whose merge commit is part of this
+ * release's diff (`origin/production..origin/main`). These are tasks that
+ * individual PRs declared but that the file-diff detector wouldn't pick up
+ * (e.g., manually added tasks, env vars not yet in code).
+ *
+ * Filtering by release-diff SHA membership — not by a 14-day lookback —
+ * ensures the checklist for each release PR contains only tasks belonging
+ * to PRs actually being deployed by THIS release. Without this, every new
+ * release PR re-listed unchecked items from prior releases (QUA-756).
+ *
+ * The `lookbackDays` window only bounds the GitHub PR pagination scan; it
+ * is intentionally generous (60 days) so a long-paused release cadence or
+ * a long-lived branch still gets discovered before SHA-membership prunes
+ * the list. PRs outside the window but still in the release diff would be
+ * silently dropped, so prefer over-fetching here.
  */
-export async function fetchSubPrDeployTasks(): Promise<string[]> {
-  const lookbackDays = 14;
+export async function fetchSubPrDeployTasks(opts: {
+  releaseDiffShas?: Set<string>;
+  api?: typeof githubApi;
+  lookbackDays?: number;
+} = {}): Promise<string[]> {
+  const releaseDiffShas = opts.releaseDiffShas ?? commitShasInReleaseDiff();
+
+  // Empty release diff (no commits to ship) → no sub-PR tasks apply.
+  if (releaseDiffShas.size === 0) return [];
+
+  const api = opts.api ?? githubApi;
+  const lookbackDays = opts.lookbackDays ?? 60;
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - lookbackDays);
 
-  const prs = await githubApi<SubPrData[]>(
-    `/repos/${REPO}/pulls?state=closed&base=main&sort=created&direction=desc&per_page=50`
-  );
+  const { prs } = await fetchMergedPrsInWindow(cutoff, api);
 
   const tasks: string[] = [];
 
   for (const pr of prs) {
-    if (!pr.merged_at || !pr.body) continue;
-    if (new Date(pr.merged_at) < cutoff) continue;
+    if (!pr.body || !pr.merge_commit_sha) continue;
+    // Only include PRs whose merge commit is part of this release's diff.
+    // PRs already on production are by definition not in this release.
+    if (!releaseDiffShas.has(pr.merge_commit_sha)) continue;
 
     const parsed = parseDeployTasksFromBody(pr.body);
     if (!parsed || parsed.unchecked === 0) continue;


### PR DESCRIPTION
## Summary

Fixes [QUA-756](https://linear.app/quantifieduncertainty/issue/QUA-756) — `pnpm crux gh release create`'s auto-generated Deploy Checklist included every merged-but-unchecked deploy task in its 14-day lookback window, not just tasks belonging to PRs in this release's diff. Each new release PR re-listed checklist items from prior releases whose boxes were never checked.

Concrete repro (from the QUA-756 description): release PR #4627 ships only PRs #4624 + #4625, but its auto-generated checklist re-listed ~30 tasks from PRs #4587..#4617 — all of which already shipped in #4619.

## Fix

`fetchSubPrDeployTasks()` now filters by membership in `git log origin/production..origin/main` (the commits this release would actually deploy) rather than by "merged in last 14 days." PRs whose merge commit is already on production are by definition not in this release.

The lookback window remains as a pre-filter for GitHub PR pagination but is widened to 60 days; SHA membership decides inclusion. A new exported `commitShasInReleaseDiff()` helper wraps the git call.

The function is now `api`-injectable for testing.

## Test plan

- [x] 6 new unit tests in `crux/commands/release.test.ts`:
  - empty-diff fast no-op
  - filters out PRs whose `merge_commit_sha` is not in the diff
  - drops null `merge_commit_sha` defensively
  - skips PRs without a deploy-tasks block
  - skips already-checked items inside an in-diff PR
  - end-to-end QUA-756 repro — reproduces the #4627 scenario and asserts that no stale tasks from already-shipped PRs leak through
- [x] All 28 existing `release.test.ts` tests still pass (no behavior change to non-task code paths)
- [x] `pnpm crux w validate gate` — 61 checks pass (4 unrelated advisory warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-756
