### PR TITLE
review(QUA-755): minor follow-ups from /agent-review-pr pass

### DIFF
--- a/crux/commands/__tests__/agent-workspace-rename.test.ts
+++ b/crux/commands/__tests__/agent-workspace-rename.test.ts
@@ -18,16 +18,11 @@ vi.mock('child_process', async () => {
       execCalls.push({ cmd, opts });
       return execScript(cmd);
     }),
-    // execFileSync calls are also recorded as a synthesized command string so
-    // the existing assertions (which match on `cmd.includes('rename-window')`,
-    // `-t "1"`, etc.) keep working after the QUA-755 shell-injection fixes
-    // converted template-literal execSync calls to execFileSync arg arrays.
+    // After QUA-755 converted template-literal execSync calls to execFileSync
+    // arg arrays, recreate a shell-style command string so the existing
+    // assertions (`-t "1"`, `"LW"`, `rename-window`, `A3:feature-x`) still
+    // match. Flags stay unquoted, value args get wrapped in quotes.
     execFileSync: vi.fn((file: string, args: readonly string[], opts?: unknown) => {
-      // Synthesize a shell-style command string so the existing assertions
-      // — which match on substrings like `rename-window`, `-t "1"`, `"LW"` —
-      // keep working. Flag-like args (-t, --foo) stay unquoted; everything
-      // else is quoted so the assertions see the same surface they did
-      // before the QUA-755 execSync→execFileSync conversion.
       const quote = (a: string) => (a.startsWith('-') ? a : `"${a}"`);
       const cmd = [file, ...args.map(quote)].join(' ');
       execCalls.push({ cmd, opts });

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -9,10 +9,9 @@
  * tracking, and claim labels. New subcommand: `crux pr-patrol parallel`.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
-import { statSync } from 'fs';
 import { tryRebaseAndVerify } from './rebase-verify.ts';
 import { gitIn, gitSafe, gitSafeIn } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -37,16 +37,19 @@
 
 import { execSync, execFileSync, spawn, type ChildProcess } from 'child_process';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { config as dotenvConfig } from 'dotenv';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 
 // Load .env so child validators inherit PROD_LONGTERMWIKI_SERVER_URL etc.
 // Without this, validators that fetch from wiki-server fall back to the local
 // snapshot (often stale), which manifests as gate-baseline-drift between
-// local and CI. See QUA-755.
+// local and CI. See QUA-755. Falls back to fileURLToPath(import.meta.url) when
+// import.meta.dirname is undefined (older tsx CJS transforms).
+const HERE = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
 dotenvConfig({
-  path: resolve(import.meta.dirname!, '..', '..', '.env'),
+  path: resolve(HERE, '..', '..', '.env'),
   quiet: true,
   override: false,
 });

--- a/crux/validate/validate-unified.ts
+++ b/crux/validate/validate-unified.ts
@@ -21,7 +21,7 @@
  */
 
 import { fileURLToPath } from 'url';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
 import { config as dotenvConfig } from 'dotenv';
 import { ValidationEngine, Severity, type Issue } from '../lib/validation/validation-engine.ts';
 import { allRules } from '../lib/rules/index.ts';
@@ -32,8 +32,11 @@ import { getColors } from '../lib/output.ts';
 // that fetch from the wiki-server (resource-ref-integrity) fall back to the
 // stale local snapshot and emit thousands of false-positive errors. Quiet mode
 // + override:false respects already-set env vars (e.g. CI). See QUA-755.
+// Falls back to fileURLToPath(import.meta.url) when import.meta.dirname is
+// undefined (older tsx CJS transforms).
+const HERE = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
 dotenvConfig({
-  path: resolve(import.meta.dirname!, '..', '..', '.env'),
+  path: resolve(HERE, '..', '..', '.env'),
   quiet: true,
   override: false,
 });


### PR DESCRIPTION
## Summary

Two minor follow-ups from the `/agent-review-pr` pass on PR #4630 (QUA-755). Both address review findings without changing functional behavior.

## Changes

1. **`crux/pr-patrol/parallel.ts`** — Folded a duplicate `from 'fs'` import line. The QUA-755 conversion added `statSync` on a separate import line; this collapses it into the existing `fs` import that already pulls `existsSync`, `readFileSync`, etc.

2. **`crux/validate/{validate-unified,validate-gate}.ts`** — Replaced `import.meta.dirname!` non-null assertion with `import.meta.dirname ?? dirname(fileURLToPath(import.meta.url))`. Defensive fallback for tsx CJS transforms that don't populate `import.meta.dirname`. The non-null assertion would have thrown a cryptic error at runtime if that ever happened. Verified both files still load `.env` correctly.

3. **`crux/commands/__tests__/agent-workspace-rename.test.ts`** — Consolidated two adjacent doc comments on the `execFileSync` mock into one, dropping redundant prose.

## Verification

- `npx vitest run crux/commands/__tests__/agent-workspace-rename.test.ts` → 3/3 pass
- `npx tsx -e "import('./crux/validate/validate-unified.ts')..."` → confirms `PROD_LONGTERMWIKI_SERVER_URL` still loads
- No behavior change. Pure code-quality cleanup.

## Test plan

- [x] Affected unit tests pass
- [x] Dotenv loading still works in both validators
- [x] No new exports or behavior changes

Fixes QUA-755
