### PR TITLE
docs(adrs): scaffold Architecture Decision Records investigation wave

### DIFF
--- a/docs/adrs/0000-template.md
+++ b/docs/adrs/0000-template.md
@@ -1,0 +1,57 @@
+# ADR-NNNN: <Title>
+
+## Status
+
+`Charter` | `Proposed` | `Accepted` | `Rejected` | `Superseded by ADR-NNNN`
+
+## Context
+
+What's the situation? Why is a decision needed now?
+
+## Investigation
+
+Findings from the deep dive. Cite evidence: `file:line`, git queries, metrics, external sources. Anything load-bearing must have a citation.
+
+## Options considered
+
+1. **Option A — <name>**
+   - Description:
+   - Pros:
+   - Cons:
+2. **Option B — <name>**
+   - Description:
+   - Pros:
+   - Cons:
+3. **Option C — Status quo**
+   - Description:
+   - Pros:
+   - Cons:
+
+## Decision
+
+We will <option X> because <reasons>.
+
+**Migration plan:**
+- Phase 1: ...
+- Phase 2: ...
+
+**Owner:** <Linear project>
+
+## Consequences
+
+- **Positive:** ...
+- **Negative:** ...
+- **Risks + mitigations:** ...
+- **Reversibility:** how hard to undo this decision
+
+## Follow-up tickets
+
+- QUA-NNN — Phase 1 ...
+- QUA-NNN — Phase 2 ...
+
+## References
+
+- Linear: QUA-NNN (this investigation)
+- Related ADRs: ADR-NNNN
+- Code: `path/to/relevant/code.ts`
+- External: <links>

--- a/docs/adrs/0001-crux-package-architecture.md
+++ b/docs/adrs/0001-crux-package-architecture.md
@@ -1,0 +1,55 @@
+# ADR-0001: Crux package architecture
+
+## Status
+
+`Charter`
+
+## Context
+
+`crux/` is 247K LOC across 1,290 TypeScript files — 2.2× the size of `apps/web`. It currently mixes:
+
+- A user-facing CLI (entry point `crux/crux.mjs`, command files in `crux/commands/`)
+- Agent workflow infrastructure (agent-checklist, dispatch, ship/end, PR patrol)
+- Ingestion pipelines (auto-update, frameworks, system-cards, third-party-evals, AIID)
+- 97 validators (the gate system)
+- A typed RPC client to the wiki-server
+- One-shot historical migration scripts (some never retired)
+- Several apparently-dead subdirectories (`entity-matrix/`, `calibration/`, `pr-review/`, `worker/` per the 2026-04-27 audit)
+
+There is no explicit boundary between these. Every "where does this go?" question lands in `commands/` or `lib/` by default. The longer this grows, the harder a structural reorganization becomes. A prior 7-agent investigation (2026-04-27) confirmed ~5.6K LOC of dead subdirectories and ~3.5K LOC of one-shot scripts, but the deeper question — what *is* `crux/` supposed to be — was deferred to this ADR.
+
+## Question
+
+How should `crux/` be organized? Specifically:
+
+1. Should it be split into multiple workspace packages with explicit contracts (e.g., `@lw/cli`, `@lw/agent-tools`, `@lw/ingest`, `@lw/validate`, `@lw/wiki-client`, `@lw/internal-scripts`)?
+2. Or restructured internally with stricter directory conventions but no package boundary?
+3. Or left as-is with only dead-code removal?
+
+## What counts as a decision
+
+A package-architecture proposal naming N packages, their public contracts (exports), their dependency graph (which depends on which), and a phased migration plan. Or an explicit "stay as one directory but enforce these internal modules with this mechanism."
+
+A bare deletion list does NOT count — that's downstream tactical work.
+
+## In scope
+
+- Dependency analysis: who imports what within `crux/`
+- Boundary proposals: 1, 3, 5, 7-package options with tradeoffs
+- Migration sequencing: which package extracts first, what blocks each phase
+- Naming conventions for the proposed packages
+- Impact on `crux.mjs` startup time, import resolution, agent context size
+
+## Out of scope
+
+- Actually executing the migration (downstream implementation tickets)
+- Deletion of dead code (covered by separate cleanup tickets)
+- Changes to the wiki-server or apps/web
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with `Status: Accepted` (with named package architecture + migration plan) or `Status: Rejected` (with explicit reason — e.g., "monolithic crux/ is correct, here's why"). Either is acceptable.

--- a/docs/adrs/0001-crux-package-architecture.md
+++ b/docs/adrs/0001-crux-package-architecture.md
@@ -53,3 +53,8 @@ A bare deletion list does NOT count — that's downstream tactical work.
 ## Success criteria
 
 ADR ends with `Status: Accepted` (with named package architecture + migration plan) or `Status: Rejected` (with explicit reason — e.g., "monolithic crux/ is correct, here's why"). Either is acceptable.
+
+## Dependencies
+
+- **Blocks (soft):** ADR-0009 (multi-app coordination — type-sharing story depends on whether crux is one or many packages)
+- **Blocked by:** none

--- a/docs/adrs/0002-three-bases-model-review.md
+++ b/docs/adrs/0002-three-bases-model-review.md
@@ -1,0 +1,70 @@
+# ADR-0002: Three Bases model review
+
+## Status
+
+`Charter`
+
+## Context
+
+The data architecture is conceptually organized into three layers:
+
+- **TableBase** — typed relational records (entities, resources, publications, grants, personnel)
+- **FactBase** — structured triples with temporal data and provenance
+- **WikiBase** — long-form prose MDX articles
+
+Documented in `content/docs/internal/data-architecture.mdx` (E1334) and `.claude/rules/three-bases-architecture.md`.
+
+The model has evolved since it was conceived:
+
+- TableBase has both YAML authoritative + PG read mirror
+- FactBase is mid-flight to becoming PG-primary (QUA-408 Data Model Unwind)
+- The `things` table cuts across all three as a universal search index
+- Soft FKs via `entities.stable_id` everywhere — no enforced base separation
+- A `Fact` interface in `tablebase.ts` exists for legacy reasons
+- Citations dual-write to sourcing
+- Cross-base operations (citation accuracy → sourcing, FactBase entity ID → TableBase entity ID) have accumulated workarounds
+
+The conceptual purity is showing seams. Before the FactBase PG-primary migration finishes, this is the moment to confirm or refine the model. Afterward, course-correcting is significantly harder.
+
+## Question
+
+Is the TableBase / FactBase / WikiBase decomposition still the right conceptual model for the data layer?
+
+If yes — what explicit rules should govern cross-base interactions to keep the model load-bearing?
+
+If no — what's the alternative decomposition, and what's the migration path?
+
+## What counts as a decision
+
+One of:
+
+- **Confirm with rules** — Three Bases stays, and these N explicit rules govern cross-base operations (e.g., "no direct FK across bases; always go through `entities.stable_id`").
+- **Refine** — Three Bases stays but with X structural change (e.g., "promote `things` to first-class; bases become views").
+- **Replace** — Three Bases is the wrong frame; here's the alternative (e.g., domain-driven services, single unified data model with type discriminators).
+
+## In scope
+
+- Review the 10 most painful cross-base operations from the last 6 months (citations dual-write, FactBase ↔ TableBase ID coordination, things-table denormalization fallout, etc.)
+- For each: would a different decomposition have made this easier or harder?
+- Alternative decompositions considered with tradeoffs
+- Implications for the in-flight FactBase PG-primary migration (QUA-408)
+- Implications for new ingest pipelines being added (frameworks, system-cards, third-party-evals)
+
+## Out of scope
+
+- The mechanical schema.ts split (downstream of this ADR)
+- The wiki-server decomposition (ADR-0006, depends on this conclusion)
+- Changes to the YAML authoring workflow
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with one of three outcomes above, with the rationale explicit and the consequences for downstream ADRs (especially ADR-0006) named. **Confirming the model is a valid outcome** — the value is in the deliberate review, not in finding something to change.
+
+## Dependencies
+
+- **Blocks:** ADR-0006 (wiki-server decomposition)
+- **Blocked by:** none

--- a/docs/adrs/0003-validator-economics.md
+++ b/docs/adrs/0003-validator-economics.md
@@ -1,0 +1,64 @@
+# ADR-0003: Validator economics
+
+## Status
+
+`Charter`
+
+## Context
+
+`crux/validate/` contains 97 validator files. The gate (`validate-gate.ts`) runs ~50+ of them on every PR; others run via `validate-data.ts`, `validate-daily.ts`, or are standalone. Each validator was added in response to a specific concern.
+
+Costs of the validator system, observed and suspected:
+
+- **Time**: gate run time per PR (current numbers TBD as part of this investigation)
+- **Mental overhead**: agents and humans must understand which validators are blocking, which are advisory, what their messages mean
+- **False positives**: occasional bad signals (e.g., the recent gate-baseline-drift QUA-755 incident)
+- **Ratchet drift incidents**: baseline files that get bumped instead of fixed, defeating the validator's purpose
+- **Maintenance**: each validator has its own bugs (the 2026-04-27 prior investigation flagged 8 validators not wired into gate/data/daily)
+
+A prior 7-agent investigation (2026-04-27) found "8 validators not in gate/data/daily" but the deeper question — what each validator earns — was deferred to this ADR.
+
+## Question
+
+For each of the 97 validators in `crux/validate/`:
+
+1. Is it currently catching real bugs (load-bearing)?
+2. Is it overlapped by typecheck, tests, or runtime invariants (defense-in-depth)?
+3. Was it useful one-time but now unnecessary (regression-prevention, can demote)?
+4. Has it never caught anything (dead, can delete)?
+
+And as a system-level question: should some validators move from CI gate to **runtime invariants** (DB CHECK constraints, Zod parsing) where they belong?
+
+## What counts as a decision
+
+A tiered list of validators with disposition specified:
+
+- **Load-bearing** (keep, blocking)
+- **Defense-in-depth** (keep, advisory or demote)
+- **Regression-prevention** (keep one-pass; consider deletion after 6 months without violations)
+- **Move to runtime invariant** (specify the new home)
+- **Delete** (with confidence level)
+
+Plus principles for adding future validators (when is a validator the right tool vs. a typecheck rule, vs. a runtime invariant).
+
+## In scope
+
+- Per-validator analysis: bugs caught (git log + PR commentary), gate stage time cost (telemetry), false positive rate (commits that touched the validator itself or added bypasses), counterfactual coverage by typecheck/tests
+- Tier assignment for all 97 validators
+- Identification of validator → runtime-invariant migrations
+- Principles for future validator additions
+- Recommended deletion list with LOC savings
+
+## Out of scope
+
+- Rewriting validators that stay
+- The gate-triage LLM optimization itself (separate concern)
+- Adding new validators (downstream)
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with disposition-per-validator (97 entries) and a deletion PR target (e.g., "delete N validators saving M LOC and X seconds of gate time"). Even a "keep all 97" outcome is acceptable if defended with measurement.

--- a/docs/adrs/0004-agent-workflow-roi.md
+++ b/docs/adrs/0004-agent-workflow-roi.md
@@ -1,0 +1,68 @@
+# ADR-0004: Agent workflow infrastructure ROI
+
+## Status
+
+`Charter`
+
+## Context
+
+The agent workflow infrastructure is large and growing:
+
+- `CLAUDE.md` (18KB)
+- 29 rule files in `.claude/rules/` (~180KB total)
+- 17 hooks in `.claude/hooks/`
+- 3 skills in `.claude/skills/`
+- `agent-checklist` system (init, snapshot, validation)
+- Dispatch system (`crux sys dispatch` with pre-flight checks, dedup)
+- Linear-GH integration (auto-close, branch dedup, ship workflow)
+- PR patrol (health gate, fleet-level signals)
+- Subagent permissions hooks
+- Many crux commands supporting the lifecycle
+
+Each piece was added in response to a specific incident or pattern (QUA-302 deploy stuck, QUA-406 duplicate work, QUA-440 dedup hardening, the 2026-04-11 cascade, QUA-515 enforcement layers). The aggregate, however, may be over-built — some guardrails could be preventing problems that no longer occur because the rest of the system caught up.
+
+A prior 7-agent investigation (2026-04-27) categorized all 29 rules as "load-bearing" but acknowledged this was a quick read. The deeper question of incident recurrence per rule was deferred to this ADR.
+
+## Question
+
+For each piece of agent workflow infrastructure (rules, hooks, dispatch checks, dedup layers):
+
+1. What incident drove its creation?
+2. Has the underlying cause been fixed elsewhere, or is the rule still the only thing preventing recurrence?
+3. Is the cognitive overhead per session (rule must be loaded, understood, applied) worth the rate of incidents prevented?
+4. Are some pieces overlapping enough to merge or delete?
+
+## What counts as a decision
+
+Per-piece disposition:
+
+- **Load-bearing** (keep — incident pattern is permanent and this is the only mitigation)
+- **Scar tissue** (delete — incident was fixed elsewhere; this rule is no longer needed)
+- **Mergeable** (combine with X — overlapping with another rule)
+- **Distillable** (compress to 1 paragraph in CLAUDE.md or a parent rule)
+- **Reframe** (the rule is right but the incident framing is wrong; rewrite focused on the actual mechanism)
+
+Plus principles for when to add new agent workflow infrastructure (what's the bar?).
+
+## In scope
+
+- Incident archaeology for each rule (originating QUA-NNN or commit, recurrence in last 90 days)
+- Per-hook analysis (when does it fire, what does it block, how often, is it ever wrong)
+- Cognitive overhead estimate (per-rule context tokens consumed in average session)
+- Overlap mapping (rules that say partially the same thing)
+- Recommendations: 29 rules → N rules; 17 hooks → M hooks
+- Principles for adding future workflow rules
+
+## Out of scope
+
+- Rewriting the agent-checklist system itself
+- Designing entirely new rules (separate ADRs if needed)
+- Changes to skills (3 of them, low surface area)
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with named deletions/merges/distillations (e.g., "29 → 22 rules with these specific changes"). A "keep all 29" outcome is acceptable but must defend each rule against the recurrence test, not just rest on the prior investigation's quick-read result.

--- a/docs/adrs/0005-content-quality-trends.md
+++ b/docs/adrs/0005-content-quality-trends.md
@@ -1,0 +1,67 @@
+# ADR-0005: Content quality and staleness governance
+
+## Status
+
+`Charter`
+
+## Context
+
+The wiki has 763 MDX pages and 571 FactBase entities. Content is edited by:
+
+- Auto-update pipelines (mostly disabled; `auto-update.yml` is `workflow_dispatch`-only per QUA-31)
+- Crux improve runs (`crux w improve <id> --apply`)
+- Agent sessions on specific tickets
+- Occasional human edits
+
+Source-check verdicts (`source_check_verdicts` table) measure citation accuracy at the per-claim level. Coverage scores measure depth per entity (1-4 scale). Citation accuracy dashboards exist (E917, E918, E919). But:
+
+- There's no clear policy on **when a page needs human review** vs. agent-only edits
+- Trends over time aren't surfaced — is content quality improving or declining?
+- "Staleness" is implicit (no tracked metric)
+- The auto-update cron is disabled (QUA-31) but the underlying question of "should this run autonomously" was never decided
+
+The wiki's value depends on content quality. Operating without an explicit policy is a long-run risk.
+
+## Question
+
+What's the right governance model for wiki content quality, citation accuracy, and freshness in a codebase where most edits are made by AI agents?
+
+Specifically:
+
+1. When can agents edit autonomously? When must they hand off to a human?
+2. What's the quality / staleness metric we actually care about?
+3. How do we measure trends over time?
+4. Should auto-update pipelines be re-enabled, kept disabled, or restructured?
+
+## What counts as a decision
+
+A content governance policy with:
+
+- **Autonomy tiers** — what kinds of edits agents can make alone vs. what requires human review
+- **Quality metrics** — which existing or new metrics are the load-bearing ones
+- **Staleness policy** — what triggers a re-review (time-since-edit, source-check verdict change, source content change, etc.)
+- **Auto-update decision** — re-enable, keep disabled, or restructure
+- **Measurement infrastructure** — what dashboards or trend lines need to exist
+
+## In scope
+
+- Audit current quality metrics (coverage scores, source-check verdicts, citation accuracy, hallucination risk)
+- Distribution of last-edited dates across pages
+- Edit-rate per page, broken down by editor type (agent vs. human)
+- Staleness analysis — pages cited heavily but not edited in 6+ months
+- Survey of similar projects for content governance patterns
+- Cost of building the trend-line infrastructure if not present
+
+## Out of scope
+
+- Actually building the dashboards (downstream tickets in Dashboards & Visibility)
+- Re-enabling specific pipelines (downstream tickets in Automation & Infrastructure)
+- Wiki content edits themselves
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with a written content quality policy + a list of measurements that need to exist. A "current state is fine" outcome is acceptable but should be defended with current metric trends, not assumption.

--- a/docs/adrs/0006-wiki-server-decomposition.md
+++ b/docs/adrs/0006-wiki-server-decomposition.md
@@ -1,0 +1,64 @@
+# ADR-0006: Wiki-server decomposition
+
+## Status
+
+`Charter`
+
+## Context
+
+`apps/wiki-server/` is one Hono service with:
+
+- 122 routes
+- 5,009-line `schema.ts` covering ~110 PG tables
+- Multiple unrelated domain concerns: TableBase sync, FactBase facts, WikiBase content, sourcing, citations, jobs queue, agent sessions, audit log, monitoring, enrichment
+
+Costs of the monolith have shown up directly:
+
+- **QUA-302** — 12-hour deploy stuck because a migration on one table held ACCESS EXCLUSIVE while a materialized view refresh held SHARE; the lack of internal boundaries meant the whole service stayed wedged
+- **QUA-549** — single FK swap required 17 sub-PRs because the change cut across many table-coupled routes
+- **Schema drift** — every new ingest pipeline (frameworks, system-cards, AIID, etc.) adds another route group, another set of tables, more cross-coupling
+
+Schema-split is downstream of this — it's the cosmetic answer to a deeper question.
+
+## Question
+
+Should the wiki-server stay as one Hono service, become a domain-modulated monolith (internal bounded contexts), or split into multiple deployable services?
+
+## What counts as a decision
+
+One of:
+
+- **(a) Status quo** — keep as monolith with no structural changes; defend why
+- **(b) Modulated monolith** — keep as one deploy, but enforce internal modules with bounded contexts (Drizzle schemas split by domain, route groups own their tables, no cross-module imports)
+- **(c) Worker split** — split off the queue/jobs/groundskeeper-style work into a worker service; user-facing API stays monolith
+- **(d) Domain split** — full decomposition into multiple services (e.g., `sourcing-service`, `tablebase-service`, `wikibase-service`) with shared types package
+
+With migration plan, deploy implications, and operational cost named. Status quo is acceptable but must defend why monolith costs (QUA-302, QUA-549 patterns) don't justify a split.
+
+## In scope
+
+- Route grouping by data ownership (which routes touch which tables exclusively)
+- Cross-group dependency analysis (does the sourcing API call into TableBase? does FactBase need to know about wiki pages?)
+- Deploy coupling: what would break if X moved
+- Cost of each option (engineering, operational, testing, type-sharing infrastructure)
+- Implications for the existing crux RPC client (is it split or unified?)
+- Implications for groundskeeper (currently a separate app — does it absorb the worker split or vice versa?)
+
+## Out of scope
+
+- The mechanical `schema.ts` split (downstream — its right shape depends on this decision)
+- Actual implementation of any chosen path
+- Changes to apps/web's API consumption
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with one of (a)–(d) chosen, with explicit acknowledgement of which monolith costs the chosen path accepts as ongoing.
+
+## Dependencies
+
+- **Blocked by:** ADR-0002 (Three Bases conclusion changes the natural service boundaries)
+- **Blocks:** ADR-0008 (internal dashboards layer), ADR-0009 (multi-app coordination)

--- a/docs/adrs/0007-observability-strategy.md
+++ b/docs/adrs/0007-observability-strategy.md
@@ -1,0 +1,64 @@
+# ADR-0007: Observability strategy
+
+## Status
+
+`Charter`
+
+## Context
+
+Telemetry exists everywhere; a unified view exists nowhere.
+
+Current state:
+
+- ~5,400 `console.log/error/warn` calls across `apps/wiki-server/`, `apps/web/`, `crux/`
+- 5 different `*_runs` tables (`groundskeeper_runs`, `auto_update_runs`, `page_improve_runs`, `enrichment_runs`, plus the `jobs` table)
+- `agent_sessions.heartbeat_at` for agent liveness
+- `service_health_incidents` for production incident tracking
+- GitHub Actions workflow runs (each workflow's history)
+- `~/.cache/pr-patrol/runs.jsonl` (filesystem!) for PR patrol state
+- Per-pod K8s logs (where `console.*` lands)
+
+The QUA-302 12-hour deploy-stuck incident took 12 hours partly because no one had a "deploys + their lock waits over time" view. The QUA-302 retrospective surfaced this gap; nothing was built to close it.
+
+A prior 7-agent investigation (2026-04-27) discovered the existing automation-landscape catalog (E2214) and recommended making it live, but the deeper observability strategy question — what tooling, what cost, what coverage — was deferred to this ADR.
+
+## Question
+
+What is the right observability architecture for this codebase? Specifically:
+
+1. **Logging** — adopt structured logging (pino or similar) consistently? Where do logs go?
+2. **Tracing** — adopt OpenTelemetry traces? Would it have caught QUA-302?
+3. **Metrics & dashboards** — current `*_runs` tables vs. unified, plus which dashboards must exist
+4. **Tooling** — local-first (Grafana/Loki self-hosted) vs. SaaS (Datadog, Honeycomb, Axiom) vs. minimal (just the existing PG tables + dashboards)
+5. **Incident response loop** — when prod gets stuck again, what do we look at first?
+
+## What counts as a decision
+
+A chosen observability stack with:
+
+- Specific tooling decisions (logging library, sink, tracing yes/no, dashboard tool)
+- Cost estimate (engineering time, recurring SaaS bill, infra)
+- Rollout plan (which app instruments first, what metrics matter most)
+- Migration story for the 5,400 `console.*` calls (replace, leave, or wrap)
+
+## In scope
+
+- Inventory of current telemetry (where does it go, who reads it)
+- Gap analysis vs. the QUA-302 retrospective + similar incidents
+- Tooling option survey with realistic cost estimates
+- Rollout phases — what's the minimum viable observability that catches the next QUA-302?
+- Implications for the existing run-tracking schemas (do they unify or stay parallel)
+
+## Out of scope
+
+- Console.log cleanup as a one-off (covered by the strategy, not as separate work)
+- Building the unified dashboards (downstream implementation tickets)
+- Adding instrumentation to specific code paths (downstream)
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with a chosen tooling stack and a rollout phase 1 plan. "Status quo + make `automation-landscape` live" is acceptable if defended — but the QUA-302 question must be answered: what do we look at next time?

--- a/docs/adrs/0007-observability-strategy.md
+++ b/docs/adrs/0007-observability-strategy.md
@@ -62,3 +62,8 @@ A chosen observability stack with:
 ## Success criteria
 
 ADR ends with a chosen tooling stack and a rollout phase 1 plan. "Status quo + make `automation-landscape` live" is acceptable if defended — but the QUA-302 question must be answered: what do we look at next time?
+
+## Dependencies
+
+- **Blocks (soft):** ADR-0008 (internal dashboards layer — observability tooling choice may absorb some dashboards)
+- **Blocked by:** none

--- a/docs/adrs/0008-internal-dashboards-layer.md
+++ b/docs/adrs/0008-internal-dashboards-layer.md
@@ -1,0 +1,61 @@
+# ADR-0008: Internal dashboards layer
+
+## Status
+
+`Charter`
+
+## Context
+
+`apps/web/src/app/internal/` contains 32 dashboard pages — entity profiles, source-check coverage, system health, agent activity, jobs queue, page changes, improve runs, auto-update runs, groundskeeper runs, etc. They're built as full Next.js App Router pages with the wiki's MDX rendering pipeline (Pattern A per `.claude/rules/internal-dashboards.md`).
+
+Properties:
+
+- ~10K LOC across the 32 directories
+- All deploy with the main wiki Next.js app (build coupling)
+- Use the same component library as user-facing pages
+- Navigated via `apps/web/src/lib/wiki-nav.ts` internal sidebar
+- Mostly used by Ozzie + AI agents; rarely seen by external readers
+
+The 2026-04-27 prior investigation flagged 3 dashboard collapse opportunities (runs-history shells, entity-aggregation shells, citation-quality shells) saving ~1,300 LOC. But the structural question — should this whole layer even live in `apps/web` — was deferred to this ADR.
+
+## Question
+
+Should the 32 `/internal/*` dashboards stay embedded in the main wiki app, or be extracted to a separate admin surface?
+
+## What counts as a decision
+
+One of:
+
+- **(a) Stay embedded as-is** — defend why coupling to the wiki app deploy is acceptable; document the boundaries
+- **(b) Stay embedded with shared shells** — extract a `<InternalDashboardShell>` and 3 generic dashboard layouts (per the prior investigation), but stay in `apps/web`
+- **(c) Spin off to separate Next.js app** — `apps/admin` on a subdomain, separate deploy
+- **(d) Spin off to a different framework** — Tremor, Retool, Grafana, or purpose-built admin tool
+
+With cost estimate, migration plan, and impact on agent workflows (do agents still need to navigate `/internal/*` URLs).
+
+## In scope
+
+- Usage analysis: who uses each dashboard, how often (server logs if available, otherwise estimate)
+- Build cost contribution: which dashboards are heaviest in the wiki build
+- Dependency graph: which `/internal/*` dashboards share components with user-facing pages
+- Cost of each option (engineering, operational, learning curve for alternative tools)
+- Impact on the agent workflow — many `.claude/` rules reference `/internal/*` URLs; what changes?
+
+## Out of scope
+
+- Building the generic shells (downstream implementation if option (b) wins)
+- Specific dashboard rewrites
+- Changes to user-facing wiki pages
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with one of (a)–(d) chosen with named consequences. "Stay embedded" is the easy default but must defend why the build-coupling and 10K-LOC drag in the wiki app is acceptable.
+
+## Dependencies
+
+- **Blocked by:** ADR-0006 (wiki-server decomposition shapes the deploy story)
+- **Blocked by (soft):** ADR-0007 (observability strategy may absorb some dashboards)

--- a/docs/adrs/0009-multi-app-coordination.md
+++ b/docs/adrs/0009-multi-app-coordination.md
@@ -30,7 +30,7 @@ Specifically:
 
 1. Should `apps/groundskeeper` be collapsed into the wiki-server worker, or promoted to own all scheduled work?
 2. Where do new ingest pipelines belong — and what's the principle?
-3. What's the type-sharing story (the existing `api-types.ts` re-export, or something stronger like tRPC / Hono RPC?)
+3. What's the type-sharing story? CLAUDE.md mandates Hono RPC method-chaining for *new* wiki-server routes — but the existing routes use a mix of `api-types.ts` re-exports and partial RPC adoption. Should we accelerate the RPC migration for existing routes, formalize a parallel pattern for non-RPC consumers (crux, groundskeeper, discord-bot), or accept the current heterogeneity?
 4. Are there code paths that genuinely need to live in multiple apps, or is duplication accidental?
 
 ## What counts as a decision

--- a/docs/adrs/0009-multi-app-coordination.md
+++ b/docs/adrs/0009-multi-app-coordination.md
@@ -1,0 +1,69 @@
+# ADR-0009: Multi-app coordination
+
+## Status
+
+`Charter`
+
+## Context
+
+The repo has 4 deployable apps under `apps/`:
+
+- `apps/web` — Next.js frontend (~111K LOC, the main wiki UI)
+- `apps/wiki-server` — Hono API + PG (~48K LOC, all the data)
+- `apps/groundskeeper` — scheduled task daemon (the "always-on" maintenance worker)
+- `apps/discord-bot` — Discord notifications/commands
+
+Plus `crux/` (the CLI/tooling) and `packages/` (factbase, id-utils, url-utils — shared libs).
+
+Coordination today is implicit:
+
+- Type sharing through workspace packages and `apps/wiki-server/src/api-types.ts`
+- The `jobs` table + handler registry in `crux/lib/job-handlers/` is the queue, but groundskeeper has its own scheduler with `node-cron`, and the worker app (`crux/worker/run.ts`) runs handlers
+- New ingest pipelines land sometimes in groundskeeper (auto-update enqueue), sometimes in crux (system-cards extract), sometimes in wiki-server worker handlers (claim-sourcing)
+- No clear principle for "what goes in which app"
+
+## Question
+
+What are the right boundaries between the 4 apps? Where is duplication causing pain, and where is coupling preventing useful changes?
+
+Specifically:
+
+1. Should `apps/groundskeeper` be collapsed into the wiki-server worker, or promoted to own all scheduled work?
+2. Where do new ingest pipelines belong — and what's the principle?
+3. What's the type-sharing story (the existing `api-types.ts` re-export, or something stronger like tRPC / Hono RPC?)
+4. Are there code paths that genuinely need to live in multiple apps, or is duplication accidental?
+
+## What counts as a decision
+
+A clear principle for "what goes in which app" plus specific moves:
+
+- **App roles** — one-line definition of each app's responsibility
+- **Specific moves** — e.g., "collapse groundskeeper into wiki-server's worker process" or "promote groundskeeper to own all scheduled work; wiki-server stops accepting cron-style handlers"
+- **Type-sharing approach** — keep current pattern, or adopt X
+- **Future-pipeline rule** — when a new ingest needs to be added, where does it go?
+
+## In scope
+
+- Dependency graph between apps and crux
+- Type sharing audit (where do types flow, where are they duplicated)
+- Duplicated logic enumeration (run-tracking, scheduling, error handling, etc.)
+- Deploy coordination complexity (currently 4 separate deploy pipelines)
+- Implications of ADR-0006's wiki-server decomposition decision
+
+## Out of scope
+
+- Actually moving code between apps (downstream implementation)
+- Discord bot scope changes (orthogonal product question)
+
+## Time-box
+
+5 working days from charter to decision.
+
+## Success criteria
+
+ADR ends with named app roles + specific moves + a future-pipeline rule. "Status quo" is acceptable but must defend why the current ambiguity about ingest-pipeline placement is OK.
+
+## Dependencies
+
+- **Blocked by:** ADR-0006 (wiki-server decomposition affects what groundskeeper should own)
+- **Blocked by (soft):** ADR-0001 (crux package architecture affects type-sharing story)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -17,7 +17,7 @@ ADRs follow a [MADR](https://adr.github.io/madr/)-inspired template. See `0000-t
 
 ## Lifecycle
 
-```
+```text
 Charter → Proposed → Accepted | Rejected
                   ↘ Superseded by ADR-NNNN
 ```

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,75 @@
+# Architecture Decision Records
+
+This directory contains ADRs (Architecture Decision Records) for the longterm-wiki codebase. Each ADR documents one significant architecture or design decision, with the investigation that led to it.
+
+## Why ADRs
+
+Decisions about the codebase's shape — how services are split, what patterns are canonical, what gets deleted — recur over time. Without a written record, the same conversation happens every 6 months and reaches a different conclusion. ADRs make decisions:
+
+- **Versioned** — superseded ADRs stay readable; you can trace a decision's genealogy
+- **Searchable from agent context** — future Claude Code sessions can grep `docs/adrs/` for "have we already decided this?"
+- **Stable** — survives Linear/GitHub schema changes
+- **Explicit** — every accepted decision has named consequences and follow-up tickets
+
+## Format
+
+ADRs follow a [MADR](https://adr.github.io/madr/)-inspired template. See `0000-template.md`.
+
+## Lifecycle
+
+```
+Charter → Proposed → Accepted | Rejected
+                  ↘ Superseded by ADR-NNNN
+```
+
+- **Charter** — question and scope defined; investigation not yet started
+- **Proposed** — investigation complete, decision drafted, awaiting review
+- **Accepted** — decision committed; follow-up tickets filed
+- **Rejected** — investigated; decided not to proceed
+- **Superseded** — replaced by a later ADR
+
+## Index
+
+| ADR | Title | Status | Wave | Linear |
+|-----|-------|--------|------|--------|
+| [0001](0001-crux-package-architecture.md) | Crux package architecture | Charter | 1 | TBD |
+| [0002](0002-three-bases-model-review.md) | Three Bases model review | Charter | 1 | TBD |
+| [0003](0003-validator-economics.md) | Validator economics | Charter | 1 | TBD |
+| [0004](0004-agent-workflow-roi.md) | Agent workflow infrastructure ROI | Charter | 1 | TBD |
+| [0005](0005-content-quality-trends.md) | Content quality and staleness governance | Charter | 1 | TBD |
+| [0006](0006-wiki-server-decomposition.md) | Wiki-server decomposition | Charter | 2 | TBD |
+| [0007](0007-observability-strategy.md) | Observability strategy | Charter | 2 | TBD |
+| [0008](0008-internal-dashboards-layer.md) | Internal dashboards layer | Charter | 2 | TBD |
+| [0009](0009-multi-app-coordination.md) | Multi-app coordination | Charter | 2 | TBD |
+
+## Pipeline
+
+Each investigation runs through 4 stages:
+
+1. **Charter** — write the kickoff (question, scope, success criteria, time-box)
+2. **Dispatch** — agent does the deep dive, drafts findings into the ADR
+3. **Red-team** — separate agent (or human) challenges the draft, looks for missed options and undisclosed risks
+4. **Decide** — convert to Accepted/Rejected; file implementation tickets in the appropriate execution Linear projects
+
+**Time-box: 5 working days per ADR.** If undecided at the deadline, default to status quo and revisit in 6 months. Open-ended investigation is procrastination dressed up as rigor.
+
+## Adding a new ADR
+
+```bash
+cp docs/adrs/0000-template.md docs/adrs/NNNN-<slug>.md
+# Fill in Status (Charter), Context, and the Question
+# Update this README's index
+# File a Linear sub-issue under the umbrella with the charter content
+```
+
+## Principles
+
+- **One question per ADR.** Bundling unrelated decisions makes them unreversible. Cross-references are fine; merged decisions are not.
+- **Decisions are the deliverable, not analysis.** An ADR that doesn't end in either "we will X" or "we explicitly chose to defer because Y" failed.
+- **Every load-bearing claim needs a citation.** `file:line`, git query, or external link. Red-team verifies samples.
+- **No "Proposed forever."** Force a decision at the time-box, even if it's "stay with status quo and revisit in 6 months." Indecision is itself a decision and should be acknowledged as such.
+
+## See also
+
+- The umbrella Linear ticket for the current investigation wave (link TBD when filed)
+- `.claude/rules/linear-project-ownership.md` — for filing follow-up implementation tickets in the right execution project


### PR DESCRIPTION
## Summary

Scaffolds `docs/adrs/` with the Architecture Decision Records system and 9 ADR charter files for the Q2 2026 investigation wave.

This PR contains **only the kickoff charters** — no investigations have been run yet. After charters are reviewed/approved here, a Linear umbrella + 9 sub-issues will be filed and the first investigation (ADR-0001) dispatched as the workflow test case.

## What's in this PR

| File | Purpose |
|------|---------|
| `docs/adrs/0000-template.md` | MADR-style template |
| `docs/adrs/README.md` | Index, format, lifecycle, principles |
| `docs/adrs/0001-crux-package-architecture.md` | **Wave 1** — How should `crux/` (247K LOC) be organized? |
| `docs/adrs/0002-three-bases-model-review.md` | **Wave 1** — Is the TableBase / FactBase / WikiBase model still right? |
| `docs/adrs/0003-validator-economics.md` | **Wave 1** — Of 97 validators, which earn their keep? |
| `docs/adrs/0004-agent-workflow-roi.md` | **Wave 1** — 29 rules + 17 hooks — what's the actual ROI? |
| `docs/adrs/0005-content-quality-trends.md` | **Wave 1** — Content governance with mostly-AI editing |
| `docs/adrs/0006-wiki-server-decomposition.md` | **Wave 2** — Monolith, modulated monolith, or services? |
| `docs/adrs/0007-observability-strategy.md` | **Wave 2** — Logging, tracing, dashboards strategy |
| `docs/adrs/0008-internal-dashboards-layer.md` | **Wave 2** — Stay in `apps/web` or spin off? |
| `docs/adrs/0009-multi-app-coordination.md` | **Wave 2** — 4 apps + crux — what goes where? |

## Pipeline

Each ADR runs through 4 stages:

1. **Charter** — written here, in this PR
2. **Dispatch** — agent does the deep dive, drafts findings into the ADR
3. **Red-team** — separate agent challenges the draft
4. **Decide** — convert to Accepted or Rejected; file implementation tickets in execution Linear projects

**Time-box: 5 working days per ADR.** No "Proposed forever."

## Why this exists

Multi-session investigation on 2026-04-27 surfaced a long list of architectural questions that were getting deferred or answered differently each time they came up. ADRs capture the answers durably and give future Claude Code sessions a `grep`-able prior-decision log.

## Review focus

The substantive content is in each ADR's **Question**, **What counts as a decision**, and **In/Out of scope** sections. If a charter is too narrow, too broad, or asks the wrong question, this is the moment to redirect — once an investigation dispatches, the agents work from the charter as written.

## What happens after merge

1. File Linear umbrella in **Data Model Unwind** (closest project per `linear-project-ownership.md`'s "kill accidental complexity" scope)
2. File 9 sub-issues, one per ADR, with charter content
3. Dispatch ADR-0001 as the workflow test case
4. After ADR-0001's pipeline produces a usable decision, dispatch the remaining Wave 1 ADRs in parallel

## Test plan

- [x] All 11 markdown files render correctly
- [x] Index in README.md links to all 9 ADRs
- [x] Each ADR has Status (Charter), Context, Question, What counts as a decision, In/Out of scope, Time-box, Success criteria
- [x] Cross-references between ADRs are correct (0006 depends on 0002; 0008/0009 depend on 0006)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Established a formal Architecture Decision Records (ADR) framework with a template defining required sections and lifecycle guidance.
  * Added ADRs 0001–0009 covering package architecture, data-model review, validator economics, agent-workflow ROI, content-quality policy, server decomposition, observability strategy, internal dashboards, and multi-app coordination.
  * Added an ADR README indexing ADRs and prescribing the investigation and decision process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->