### PR TITLE
QUA-429: unify verdict priority on SOURCE_CHECK_VERDICT_PRIORITY

### DIFF
--- a/apps/web/src/data/__tests__/verdict-aggregation.test.ts
+++ b/apps/web/src/data/__tests__/verdict-aggregation.test.ts
@@ -25,10 +25,24 @@ describe("pickWorstVerdict", () => {
     ).toBe("contradicted");
   });
 
-  it("ranks unverifiable above outdated, partial, confirmed", () => {
+  it("ranks outdated above partial, unverifiable, confirmed", () => {
+    // QUA-429: canonical order is contradicted > outdated > partial >
+    // unverifiable > confirmed > unchecked. Previously this helper had its
+    // own ladder with unverifiable above outdated, which conflicted with
+    // rollupVerdictFromSummary on the same record.
     expect(
       pickWorstVerdict(["confirmed", "partial", "unverifiable", "outdated"]),
-    ).toBe("unverifiable");
+    ).toBe("outdated");
+  });
+
+  it("ranks partial above unverifiable and confirmed", () => {
+    expect(
+      pickWorstVerdict(["confirmed", "unverifiable", "partial"]),
+    ).toBe("partial");
+  });
+
+  it("ranks unverifiable above confirmed", () => {
+    expect(pickWorstVerdict(["confirmed", "unverifiable"])).toBe("unverifiable");
   });
 
   it("ranks outdated above partial and confirmed", () => {
@@ -61,9 +75,11 @@ describe("pickWorstVerdict", () => {
     ).toBe("contradicted");
   });
 
-  it("returns null for an empty list containing a bare null equivalent", () => {
-    // Defensive: the severity ladder doesn't include "unchecked" or empty
-    // strings, so they should be ignored.
+  it("treats unchecked as the lowest-priority known verdict", () => {
+    // unchecked is in the canonical priority map (worst in the sense that it
+    // means "no data") but every real verdict outranks it as a "worst" pick.
     expect(pickWorstVerdict(["unchecked", "", "confirmed"])).toBe("confirmed");
+    expect(pickWorstVerdict(["unchecked"])).toBe("unchecked");
+    expect(pickWorstVerdict(["unchecked", "contradicted"])).toBe("contradicted");
   });
 });

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -37,6 +37,7 @@ import type { ValidSubcategory } from "./valid-subcategories";
 import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 import { extractDomain } from "@/lib/resource-types";
 import { isCandidateRecordId } from "@wiki-server/api-types";
+import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
 
 // Re-export for consumers
 export type { WithSource };
@@ -1195,36 +1196,34 @@ export function getPolicyStakeholderId(
   return map[`${policyEntityStableId}:${stakeholderDisplayName}`] ?? null;
 }
 
-// Severity order for sourcing record verdicts. Lower index = worse.
-// Mirrors the display mapping in sourcing-status.ts:
-//   contradicted/unverifiable → failed (red)
-//   outdated/partial          → trouble (orange)
-//   confirmed                 → verified (green)
-// Any verdict string not in this list (including 'unchecked' or unknown
-// values) is treated as "no data" and excluded from aggregation.
-const VERDICT_SEVERITY = [
-  "contradicted",
-  "unverifiable",
-  "outdated",
-  "partial",
-  "confirmed",
-] as const;
-
 /**
  * Pick the worst-case verdict from a list of verdict strings, ignoring any
- * values not in the known severity ladder. Pure function — exported for unit
+ * values not in the canonical priority map. Pure function — exported for unit
  * tests and for any caller that has already resolved a list of verdicts.
+ *
+ * Routes through SOURCE_CHECK_VERDICT_PRIORITY (verdict-styles.ts) so this
+ * helper and rollupVerdictFromSummary stay in sync. Per QUA-429: ordering is
+ * `contradicted > outdated > partial > unverifiable > confirmed > unchecked`
+ * (lower number in the priority map = worse / more actionable).
+ *
+ * Note: `unchecked` is included in the canonical map but is dominated by every
+ * real verdict, so a list like ["confirmed", "unchecked"] still returns
+ * "confirmed".
  */
 export function pickWorstVerdict(
   verdicts: readonly string[],
 ): string | null {
-  let worstIdx = -1;
+  let worst: string | null = null;
+  let worstPriority = Infinity;
   for (const v of verdicts) {
-    const idx = VERDICT_SEVERITY.indexOf(v as (typeof VERDICT_SEVERITY)[number]);
-    if (idx === -1) continue;
-    if (worstIdx === -1 || idx < worstIdx) worstIdx = idx;
+    const p = SOURCE_CHECK_VERDICT_PRIORITY[v];
+    if (p === undefined) continue;
+    if (p < worstPriority) {
+      worstPriority = p;
+      worst = v;
+    }
   }
-  return worstIdx === -1 ? null : VERDICT_SEVERITY[worstIdx];
+  return worst;
 }
 
 /**

--- a/crux/commands/flagship-curate.ts
+++ b/crux/commands/flagship-curate.ts
@@ -283,7 +283,8 @@ async function discoverRecordsNeedingCuration(
     }
   }
 
-  // Priority: unchecked first, then unverifiable, partial, outdated, contradicted
+  // verdict-priority-ok: curation order (unchecked first, needs review most),
+  // intentionally distinct from canonical severity rollup.
   const priority: Record<string, number> = {
     unchecked: 0,
     unverifiable: 1,

--- a/crux/commands/sourcing-apply-suggestions.ts
+++ b/crux/commands/sourcing-apply-suggestions.ts
@@ -62,6 +62,7 @@ const PAGE_SIZE = 200;
 /** Hard cap on pagination loops — see sourcing-recheck.ts for rationale. */
 const MAX_PAGINATION_ITERATIONS = 100;
 
+// verdict-priority-ok: recheck-day intervals, not a severity priority map.
 /** Next-check-due intervals by verdict (in days) — mirrors sourcing-recheck. */
 const RECHECK_INTERVALS: Record<string, number> = {
   confirmed: 90,

--- a/crux/commands/sourcing-recheck.ts
+++ b/crux/commands/sourcing-recheck.ts
@@ -37,6 +37,7 @@ const { ESTIMATED_COST_PER_VERIFICATION } = SOURCE_CHECK_CONSTANTS;
 
 const LOG_PREFIX = '[recheck]';
 
+// verdict-priority-ok: recheck-day intervals, not a severity priority map.
 /** Next-check-due intervals by verdict (in days) */
 const RECHECK_INTERVALS: Record<string, number> = {
   confirmed: 90,
@@ -58,6 +59,10 @@ interface RecheckOptions extends BaseOptions {
   ci?: boolean;
 }
 
+// verdict-priority-ok: recheck scheduling weights (higher = recheck sooner).
+// Same severity intent as canonical SOURCE_CHECK_VERDICT_PRIORITY but uses
+// 0-100 weights instead of 0-5 priorities for budget allocation. Keep in sync
+// with canonical order if either changes.
 const VERDICT_PRIORITY: Record<string, number> = {
   contradicted: 100,
   outdated: 80,

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -387,6 +387,16 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'verdict-priority',
+    name: 'Verdict severity priority is canonical (QUA-429)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-verdict-priority.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: prevents new ad-hoc verdict priority maps from drifting from
+    // SOURCE_CHECK_VERDICT_PRIORITY in verdict-styles.ts. Distinct priorities
+    // (recheck scheduling, curation order) opt out via `// verdict-priority-ok`.
+  },
+  {
     id: 'dangerous-patterns',
     name: 'Data-integrity anti-patterns (silent catch, as any in routes, skipEntityValidation without reason)',
     command: 'npx',

--- a/crux/validate/validate-verdict-priority.test.ts
+++ b/crux/validate/validate-verdict-priority.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { runCheck } from './validate-verdict-priority.ts';
+
+describe('validate-verdict-priority', () => {
+  it('passes on the current codebase (no ad-hoc verdict priority maps)', () => {
+    // QUA-429: only one canonical severity priority should exist
+    // (SOURCE_CHECK_VERDICT_PRIORITY in apps/web/src/components/shared/verdict-styles.ts).
+    // Distinct priorities (recheck scheduling, curation order) must carry
+    // a `// verdict-priority-ok: <reason>` directive.
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+  });
+});

--- a/crux/validate/validate-verdict-priority.ts
+++ b/crux/validate/validate-verdict-priority.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that source-check verdict severity/priority is defined in exactly
+ * one place: SOURCE_CHECK_VERDICT_PRIORITY in apps/web/src/components/shared/verdict-styles.ts.
+ *
+ * QUA-429 found two helpers (`pickWorstVerdict`, `rollupVerdictFromSummary`)
+ * with different priority orders that swapped `outdated` and `unverifiable`,
+ * causing the same record to display different verdicts on profile headers
+ * vs. directory tables on the same page load.
+ *
+ * Detection: a file (other than the canonical source) declares an object
+ * literal with verdict-name keys mapping to DISTINCT integer values within
+ * a small line window. This is unambiguous "priority map" shape — Zod enums,
+ * counters (all zeros), and display-orderings (arrays) don't trigger it.
+ *
+ *   Bad (would be flagged):
+ *     const VERDICT_PRIORITY = { contradicted: 0, outdated: 1, partial: 2, ... }
+ *
+ *   Allowed (won't trigger):
+ *     z.enum(["confirmed", "contradicted", ...])         // type union
+ *     { confirmed: 0, contradicted: 0, partial: 0, ... } // counter (all 0s)
+ *     ["confirmed", "partial", ...] as const             // ordering / display
+ *
+ * Opt-out: add `// verdict-priority-ok: <reason>` on the line before the
+ * declaration if the priority is legitimately distinct from the canonical
+ * severity rollup (e.g. recheck scheduling, curation order). The reason
+ * makes the intent explicit for reviewers.
+ *
+ * Usage: npx tsx crux/validate/validate-verdict-priority.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const SCAN_DIRS = ['apps/web/src', 'apps/wiki-server/src', 'crux'];
+
+/** Files that legitimately define the canonical priority map. */
+const ALLOWLIST = new Set<string>([
+  'apps/web/src/components/shared/verdict-styles.ts',
+]);
+
+const VERDICT_NAMES = [
+  'contradicted',
+  'outdated',
+  'partial',
+  'unverifiable',
+  'confirmed',
+  'unchecked',
+] as const;
+type VerdictName = (typeof VERDICT_NAMES)[number];
+
+interface Violation {
+  file: string;
+  startLine: number;
+  matchedAssignments: Array<{ name: VerdictName; value: number }>;
+  preview: string;
+}
+
+function collectTsFiles(dir: string): string[] {
+  const results: string[] = [];
+  function walk(current: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        if (entry === '__tests__' || entry === 'node_modules' || entry === '.next') continue;
+        walk(fullPath);
+      } else if (
+        (entry.endsWith('.ts') || entry.endsWith('.tsx')) &&
+        !entry.endsWith('.test.ts') &&
+        !entry.endsWith('.test.tsx') &&
+        !entry.endsWith('.test-d.ts')
+      ) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+/**
+ * Match a line that maps a verdict name to an integer literal:
+ *   contradicted: 0,
+ *   "outdated": 1,
+ *   partial: -1
+ */
+function matchPriorityAssignment(
+  line: string,
+): { name: VerdictName; value: number } | null {
+  const trimmed = line.trim();
+  for (const name of VERDICT_NAMES) {
+    const m = new RegExp(
+      `^["']?${name}["']?\\s*:\\s*(-?[0-9]+)\\s*,?\\s*(?://.*)?$`,
+    ).exec(trimmed);
+    if (m) {
+      return { name, value: Number(m[1]) };
+    }
+  }
+  return null;
+}
+
+/** Lines inside an unbalanced backtick template literal — skip them. */
+function computeInTemplateLiteral(lines: string[]): boolean[] {
+  const flags: boolean[] = [];
+  let inTemplate = false;
+  for (const line of lines) {
+    let countAtLineStart = inTemplate;
+    // Count unescaped backticks (rough — ignores ones inside string/comment
+    // contexts but good enough for help-text detection).
+    let i = 0;
+    while (i < line.length) {
+      if (line[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (line[i] === '`') {
+        inTemplate = !inTemplate;
+      }
+      i++;
+    }
+    flags.push(countAtLineStart);
+  }
+  return flags;
+}
+
+function checkFile(filePath: string): Violation[] {
+  const relPath = relative(PROJECT_ROOT, filePath);
+  if (ALLOWLIST.has(relPath)) return [];
+
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const inTemplate = computeInTemplateLiteral(lines);
+  const violations: Violation[] = [];
+
+  // Walk the file, looking for runs of consecutive (modulo blanks/comments)
+  // priority-assignment lines for at least 3 distinct verdict names.
+  let i = 0;
+  while (i < lines.length) {
+    if (inTemplate[i]) {
+      i++;
+      continue;
+    }
+    const first = matchPriorityAssignment(lines[i]);
+    if (!first) {
+      i++;
+      continue;
+    }
+    // Look back up to 6 non-blank lines for an opt-out directive. Walk past
+    // declaration boilerplate (`const X = {`, type annotations) so the
+    // directive can sit on the doc-comment line above the declaration.
+    let optedOut = false;
+    let lookback = i - 1;
+    let nonBlankSeen = 0;
+    while (lookback >= 0 && nonBlankSeen < 6) {
+      const lb = lines[lookback].trim();
+      if (lb === '') {
+        lookback--;
+        continue;
+      }
+      nonBlankSeen++;
+      if (/verdict-priority-ok\b/.test(lb)) {
+        optedOut = true;
+        break;
+      }
+      lookback--;
+    }
+    if (optedOut) {
+      // Skip past the entire run of priority assignments.
+      let j = i + 1;
+      while (j < lines.length) {
+        const trimmed = lines[j].trim();
+        if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('*')) {
+          j++;
+          continue;
+        }
+        if (!matchPriorityAssignment(lines[j])) break;
+        j++;
+      }
+      i = j > i ? j : i + 1;
+      continue;
+    }
+    const assignments: Array<{ name: VerdictName; value: number }> = [first];
+    const startLine = i;
+    let j = i + 1;
+    while (j < lines.length) {
+      const trimmed = lines[j].trim();
+      if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('*')) {
+        j++;
+        continue;
+      }
+      const next = matchPriorityAssignment(lines[j]);
+      if (!next) break;
+      assignments.push(next);
+      j++;
+    }
+    const distinctNames = new Set(assignments.map((a) => a.name));
+    const distinctValues = new Set(assignments.map((a) => a.value));
+    // A priority map needs 3+ distinct verdict keys AND 2+ distinct values
+    // (counters with all-zero values don't trigger).
+    if (distinctNames.size >= 3 && distinctValues.size >= 2) {
+      violations.push({
+        file: relPath,
+        startLine: startLine + 1,
+        matchedAssignments: assignments,
+        preview: lines.slice(startLine, j).join('\n'),
+      });
+    }
+    i = j > i ? j : i + 1;
+  }
+
+  return violations;
+}
+
+export function runCheck(): { passed: boolean; errors: number; violations: Violation[] } {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking for ad-hoc verdict priority maps (QUA-429)...${c.reset}\n`,
+  );
+
+  const allFiles: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    allFiles.push(...collectTsFiles(join(PROJECT_ROOT, dir)));
+  }
+
+  const allViolations: Violation[] = [];
+  for (const file of allFiles) {
+    allViolations.push(...checkFile(file));
+  }
+
+  if (allViolations.length === 0) {
+    console.log(
+      `${c.green}No ad-hoc verdict priority maps found (${allFiles.length} files checked)${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${allViolations.length} ad-hoc verdict priority map(s):${c.reset}\n`,
+    );
+    for (const v of allViolations) {
+      console.log(`  ${c.red}${v.file}:${v.startLine}${c.reset}`);
+      console.log(
+        `    ${c.dim}assignments: ${v.matchedAssignments
+          .map((a) => `${a.name}=${a.value}`)
+          .join(', ')}${c.reset}`,
+      );
+      const previewLines = v.preview.split('\n').slice(0, 8);
+      for (const l of previewLines) {
+        console.log(`    ${c.dim}${l}${c.reset}`);
+      }
+      console.log(
+        `    ${c.dim}Fix: import SOURCE_CHECK_VERDICT_PRIORITY from @/components/shared/verdict-styles${c.reset}\n`,
+      );
+    }
+  }
+
+  return {
+    passed: allViolations.length === 0,
+    errors: allViolations.length,
+    violations: allViolations,
+  };
+}
+
+if (process.argv[1]?.includes('validate-verdict-priority')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

QUA-429 Phase 2: unify the two source-check verdict priority orders.

`pickWorstVerdict` (in `apps/web/src/data/tablebase.ts`) had its own
local severity ladder that swapped `outdated` and `unverifiable`
relative to the canonical `SOURCE_CHECK_VERDICT_PRIORITY` map already
used by `rollupVerdictFromSummary`. The same record could display
different verdicts on entity profile headers vs. directory tables on
the same page load.

This PR routes `pickWorstVerdict` through `SOURCE_CHECK_VERDICT_PRIORITY`
from `verdict-styles.ts` (the single canonical priority map). Order is
now uniformly: `contradicted > outdated > partial > unverifiable > confirmed > unchecked`.

Adds `validate-verdict-priority` gate check to prevent new ad-hoc
verdict priority maps. Pre-existing legitimate distinct priorities
(recheck scheduling in `sourcing-recheck.ts`, curation order in
`flagship-curate.ts`) opt out via a `// verdict-priority-ok: <reason>`
directive — same pattern as `// prompt-escape-ok`.

### Behavior change

For any record where evidence rows include both `outdated` and
`unverifiable`, the rollup now picks `outdated` (active staleness
signal) rather than `unverifiable` (couldn't tell). This matches what
the entity profile header already showed and brings the directory-table
"worst verdict" display in line.

### Out of scope (Phases 1 & 3 of QUA-429)

- Phase 1 (server-side relevance-weighted aggregation) requires a new
  `relevance_score` evidence column + recompute endpoint, and the ticket
  itself notes the relevance-gate ticket should ship first.
- Phase 3 (reconcile "Checks disagree" warning with the headline verdict)
  depends on Phase 1.

I'll add a comment to QUA-429 with the remaining work.

## Test plan

- [x] `pnpm test` — 1721/1721 pass (verdict-aggregation tests rewritten for canonical order)
- [x] `pnpm crux w validate gate --fix` — 62/62 checks pass, including new `validate-verdict-priority`
- [x] `pnpm build` — compiles successfully
- [x] Confirmed validator catches the QUA-429 anti-pattern (deleted `VERDICT_SEVERITY` was structurally an array, not a priority map; new validator targets the map form which is the regression vector now that the array helper is gone)
- [ ] Visual regression on `/organizations/[slug]` and `/organizations` directory header dots once preview deploys

Fixes QUA-429
