### PR TITLE
QUA-724: subject-identity gate at suggest-urls

### DIFF
--- a/crux/commands/sourcing-suggest-urls.test.ts
+++ b/crux/commands/sourcing-suggest-urls.test.ts
@@ -210,6 +210,7 @@ describe('sourcing-suggest-urls --verdict', () => {
       providersSkipped: [],
       query: 'test',
       costUsd: 0,
+      subjectMismatches: [],
     });
     mockUpsertUrlSuggestions.mockResolvedValueOnce({
       ok: true,
@@ -230,6 +231,44 @@ describe('sourcing-suggest-urls --verdict', () => {
       suggestedUrl: 'https://example.com/a',
       status: 'pending',
     });
+  });
+
+  it('reports subject-mismatch drops in summary and skips upsert when all candidates were dropped (QUA-724)', async () => {
+    // Verifies the CLI plumbs through the gate's drop list: when suggestUrls
+    // returns 0 candidates with subjectMismatches recorded, the CLI counts
+    // the drop, logs it, and skips the upsert step. This is the primary
+    // observability hook for the QUA-650 retro-pattern (xAI sources for
+    // Anthropic records being dropped at suggest time).
+    stubEmptyPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ recordId: 'g_b', entityId: 'anthropic' })], total: 1 },
+    });
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'test',
+      costUsd: 0,
+      subjectMismatches: [
+        {
+          url: 'https://wikidata.org/wiki/Q117104853',
+          candidateQid: 'Q117104853',
+          entityQid: 'Q108542504',
+        },
+      ],
+    });
+
+    const result = await run({ verdict: 'partial', limit: '10', json: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockUpsertUrlSuggestions).not.toHaveBeenCalled();
+    const summary = JSON.parse(result.output as string).summary;
+    expect(summary.subject_mismatches_dropped).toBe(1);
+    expect(summary.suggestions_written).toBe(0);
+    // Generated-for-records counts records that produced ≥1 surviving
+    // candidate. When the gate drops everything, the record contributes 0.
+    expect(summary.generated_for_records).toBe(0);
   });
 });
 

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -37,6 +37,7 @@ import {
   MAX_REASONING_CHARS,
 } from '../lib/sourcing/grade-suggestion.ts';
 import { createClient as createAnthropicClient } from '../lib/anthropic.ts';
+import { getEntityWikidataQid } from '../lib/sourcing/entity-wikidata-qid.ts';
 import type { SourcingVerdict } from '../../apps/wiki-server/src/api-types.ts';
 
 const DEFAULT_LIMIT = 50;
@@ -191,6 +192,8 @@ interface RunSummary {
   skippedNoClaim: number;
   generatedForRecords: number;
   suggestionsWritten: number;
+  /** Candidates dropped by the subject-identity gate (QUA-724). */
+  subjectMismatchesDropped: number;
   providerErrors: number;
   costUsd: number;
   budgetExhausted: boolean;
@@ -207,6 +210,7 @@ function makeSummary(): RunSummary {
     skippedNoClaim: 0,
     generatedForRecords: 0,
     suggestionsWritten: 0,
+    subjectMismatchesDropped: 0,
     providerErrors: 0,
     costUsd: 0,
     budgetExhausted: false,
@@ -232,6 +236,7 @@ function summaryToJson(s: RunSummary, dryRun: boolean) {
     skipped_no_claim: s.skippedNoClaim,
     generated_for_records: s.generatedForRecords,
     suggestions_written: s.suggestionsWritten,
+    subject_mismatches_dropped: s.subjectMismatchesDropped,
     provider_errors: s.providerErrors,
     cost_usd: Number(s.costUsd.toFixed(4)),
     budget_exhausted: s.budgetExhausted,
@@ -263,6 +268,7 @@ Skipped (had pending):  ${s.skippedHadSuggestion}
 Skipped (no claim):     ${s.skippedNoClaim}
 Generated for records:  ${s.generatedForRecords}
 Suggestions written:    ${s.suggestionsWritten}${dryRun ? ' (dry-run)' : ''}
+Subject mismatch drops: ${s.subjectMismatchesDropped}
 Provider errors:        ${s.providerErrors}
 Cost:                   $${s.costUsd.toFixed(4)}
 Budget exhausted:       ${s.budgetExhausted ? 'yes' : 'no'}
@@ -470,12 +476,19 @@ async function suggestCommand(
       return;
     }
 
+    // QUA-724: pass the entity's Wikidata QID (if known) so suggestUrls'
+    // subject-identity gate can drop candidates that point at a different
+    // Wikidata entity. Fail-open for entities with no recorded QID — the gate
+    // returns all candidates unchanged in that case.
+    const entityWikidataQid = getEntityWikidataQid(v.entityId);
+
     const result = await suggestUrls({
       entityName,
       claimText,
       fieldName: v.fieldName ?? undefined,
       existingUrl,
       maxCandidates,
+      entityWikidataQid,
     });
 
     summary.costUsd += result.costUsd;
@@ -483,6 +496,17 @@ async function suggestCommand(
     for (const p of result.providersSkipped) {
       summary.providersSkipped.add(p);
       if (!p.endsWith(':no-key')) summary.providerErrors++;
+    }
+    if (result.subjectMismatches.length > 0) {
+      summary.subjectMismatchesDropped += result.subjectMismatches.length;
+      // Per-record line so the dropped URL + offending QID are auditable
+      // alongside the existing dry-run/processing log entries.
+      for (const mm of result.subjectMismatches) {
+        log(
+          `  [subject-mismatch] ${v.recordType}/${v.recordId} ` +
+            `entity=${v.entityId ?? '?'} (Q=${mm.entityQid}) dropped ${mm.url} (Q=${mm.candidateQid})`,
+        );
+      }
     }
 
     if (result.candidates.length === 0) return;

--- a/crux/lib/sourcing/entity-wikidata-qid.test.ts
+++ b/crux/lib/sourcing/entity-wikidata-qid.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for crux/lib/sourcing/entity-wikidata-qid.ts (QUA-724).
+ *
+ * Validates the QID lookup against the actual `data/external-links.yaml` —
+ * if the file or its schema changes, these tests catch the contract break.
+ * Uses real entries (anthropic, geoffrey-hinton) so the test pins the file
+ * shape, not a fixture's.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getEntityWikidataQid,
+  clearEntityWikidataQidCache,
+} from './entity-wikidata-qid.ts';
+
+describe('getEntityWikidataQid', () => {
+  beforeEach(() => {
+    clearEntityWikidataQidCache();
+  });
+
+  it('returns null for an unknown slug', () => {
+    expect(getEntityWikidataQid('this-entity-definitely-does-not-exist-xyz')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty input (fail-open)', () => {
+    expect(getEntityWikidataQid(null)).toBeNull();
+    expect(getEntityWikidataQid(undefined)).toBeNull();
+    expect(getEntityWikidataQid('')).toBeNull();
+  });
+
+  it('returns a Q-number for an entity with a recorded Wikidata link', () => {
+    // `agi` has a Wikidata link in data/external-links.yaml. Asserting on the
+    // shape (Q\d+) — not the specific QID — keeps this stable if Wikidata
+    // re-IDs the page.
+    const qid = getEntityWikidataQid('agi');
+    expect(qid).toMatch(/^Q\d+$/);
+  });
+
+  it('caches results — repeated lookups return the same value', () => {
+    const a = getEntityWikidataQid('agi');
+    const b = getEntityWikidataQid('agi');
+    expect(a).toBe(b);
+  });
+});

--- a/crux/lib/sourcing/entity-wikidata-qid.ts
+++ b/crux/lib/sourcing/entity-wikidata-qid.ts
@@ -52,8 +52,19 @@ function loadCache(): Map<string, string> {
         if (qid) out.set(entry.pageId, qid);
       }
     }
-  } catch {
-    // Fail-open: missing file → empty map, all gate calls return null.
+  } catch (e: unknown) {
+    // Fail-open per QUA-724: any read/parse failure (missing file, EPERM,
+    // YAML syntax error, ...) means the gate stays disabled rather than
+    // tripping every caller. We log at warn so file-shape regressions are
+    // still visible; per `.claude/rules/error-handling.md` no catch is
+    // silent.
+    if (process.env.NODE_ENV !== 'test') {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `[entity-wikidata-qid] Failed to load ${EXTERNAL_LINKS_PATH}: ${msg}. ` +
+          `Subject-identity gate (QUA-724) is fail-open for this run.`,
+      );
+    }
   }
   cachedQidBySlug = out;
   return out;

--- a/crux/lib/sourcing/entity-wikidata-qid.ts
+++ b/crux/lib/sourcing/entity-wikidata-qid.ts
@@ -1,0 +1,73 @@
+/**
+ * Entity → Wikidata QID lookup for the subject-identity gate (QUA-724).
+ *
+ * Wikidata QIDs for wiki entities are stored in `data/external-links.yaml`,
+ * keyed by `pageId` (the entity slug, e.g. `anthropic`). This module loads
+ * that file once per process and exposes a fast `getEntityWikidataQid(slug)`
+ * lookup that the suggest-urls CLI uses to wire the parent entity's QID into
+ * `suggestUrls()`.
+ *
+ * Returns `null` when:
+ *   - The slug isn't in the file (most entities don't have a Wikidata link).
+ *   - The file is missing or malformed (treated as "no QIDs known" so the
+ *     gate is fail-open per QUA-724's contract).
+ *   - The wikidata link exists but doesn't reference a Q-number (e.g.
+ *     `Property:P856` or a malformed URL).
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { DATA_DIR_ABS } from '../content-types.ts';
+import { extractQid } from './wikidata-matcher.ts';
+
+const EXTERNAL_LINKS_PATH = join(DATA_DIR_ABS, 'external-links.yaml');
+
+interface ExternalLinksEntry {
+  pageId: string;
+  links?: { wikidata?: string };
+}
+
+let cachedQidBySlug: Map<string, string> | null = null;
+
+/**
+ * Reset the in-memory cache. Tests use this between cases that mutate the
+ * underlying file or want to assert on cold-load behaviour.
+ */
+export function clearEntityWikidataQidCache(): void {
+  cachedQidBySlug = null;
+}
+
+function loadCache(): Map<string, string> {
+  if (cachedQidBySlug) return cachedQidBySlug;
+  const out = new Map<string, string>();
+  try {
+    const raw = readFileSync(EXTERNAL_LINKS_PATH, 'utf-8');
+    const entries = parseYaml(raw) as ExternalLinksEntry[] | null;
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        const wikidataUrl = entry?.links?.wikidata;
+        if (!entry?.pageId || !wikidataUrl) continue;
+        const qid = extractQid(wikidataUrl);
+        if (qid) out.set(entry.pageId, qid);
+      }
+    }
+  } catch {
+    // Fail-open: missing file → empty map, all gate calls return null.
+  }
+  cachedQidBySlug = out;
+  return out;
+}
+
+/**
+ * Look up an entity's Wikidata QID by its `pageId` slug
+ * (e.g. `anthropic`, `geoffrey-hinton`). Returns null when the entity has
+ * no Wikidata link recorded.
+ *
+ * The lookup is case-sensitive — slugs in `external-links.yaml` are kebab
+ * lower-case so callers should pass them as-is from `entities.id`.
+ */
+export function getEntityWikidataQid(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return loadCache().get(slug) ?? null;
+}

--- a/crux/lib/sourcing/subject-identity-gate.test.ts
+++ b/crux/lib/sourcing/subject-identity-gate.test.ts
@@ -24,6 +24,8 @@ describe('subjectIdentityGate', () => {
     expect(result.kept).toEqual([]);
     expect(result.dropped).toHaveLength(1);
     expect(result.dropped[0].reason).toBe('subject-mismatch');
+    expect(result.dropped[0].candidateQid).toBe(XAI_QID);
+    expect(result.dropped[0].entityQid).toBe(ANTHROPIC_QID);
     expect(result.dropped[0].detail).toBe(`${XAI_QID} != ${ANTHROPIC_QID}`);
     expect(result.dropped[0].candidate.url).toBe(
       `https://www.wikidata.org/wiki/${XAI_QID}`,
@@ -61,6 +63,8 @@ describe('subjectIdentityGate', () => {
     });
     expect(result.kept).toEqual([]);
     expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].candidateQid).toBe(XAI_QID);
+    expect(result.dropped[0].entityQid).toBe(ANTHROPIC_QID);
     expect(result.dropped[0].detail).toBe(`${XAI_QID} != ${ANTHROPIC_QID}`);
   });
 

--- a/crux/lib/sourcing/subject-identity-gate.test.ts
+++ b/crux/lib/sourcing/subject-identity-gate.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for crux/lib/sourcing/subject-identity-gate.ts (QUA-724).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  subjectIdentityGate,
+  type SubjectIdentityCandidate,
+} from './subject-identity-gate.ts';
+
+const ANTHROPIC_QID = 'Q108542504';
+const XAI_QID = 'Q117104853';
+
+function cand(url: string, html?: string): SubjectIdentityCandidate {
+  return html === undefined ? { url } : { url, html };
+}
+
+describe('subjectIdentityGate', () => {
+  it('drops a candidate whose URL points at a different Wikidata entity', () => {
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [cand(`https://www.wikidata.org/wiki/${XAI_QID}`)],
+    });
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].reason).toBe('subject-mismatch');
+    expect(result.dropped[0].detail).toBe(`${XAI_QID} != ${ANTHROPIC_QID}`);
+    expect(result.dropped[0].candidate.url).toBe(
+      `https://www.wikidata.org/wiki/${XAI_QID}`,
+    );
+  });
+
+  it('keeps a candidate whose URL points at the matching Wikidata entity', () => {
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [cand(`https://www.wikidata.org/wiki/${ANTHROPIC_QID}`)],
+    });
+    expect(result.dropped).toEqual([]);
+    expect(result.kept).toHaveLength(1);
+  });
+
+  it('keeps non-Wikidata candidates with no HTML (URL alone is not enough to judge)', () => {
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [
+        cand('https://www.reuters.com/some-article'),
+        cand('https://techcrunch.com/anthropic-news'),
+      ],
+    });
+    expect(result.kept).toHaveLength(2);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it('drops a non-Wikidata candidate whose HTML references a different Wikidata entity', () => {
+    const html = `<html><head>
+      <link rel="alternate" href="https://www.wikidata.org/wiki/${XAI_QID}">
+    </head><body>...</body></html>`;
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [cand('https://example.com/x-launch', html)],
+    });
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].detail).toBe(`${XAI_QID} != ${ANTHROPIC_QID}`);
+  });
+
+  it('keeps a non-Wikidata candidate whose HTML references the matching Wikidata entity', () => {
+    const html = `schema.org sameAs: https://www.wikidata.org/wiki/${ANTHROPIC_QID}`;
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [cand('https://example.com/anthropic-news', html)],
+    });
+    expect(result.dropped).toEqual([]);
+    expect(result.kept).toHaveLength(1);
+  });
+
+  it('fail-open: keeps everything when entity QID is null', () => {
+    const result = subjectIdentityGate({
+      entityQid: null,
+      candidates: [
+        cand(`https://www.wikidata.org/wiki/${XAI_QID}`),
+        cand('https://example.com/x'),
+      ],
+    });
+    expect(result.kept).toHaveLength(2);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it('fail-open: keeps a candidate when neither URL nor HTML reveals a QID', () => {
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [
+        cand('https://example.com/article', '<html>no wikidata reference</html>'),
+      ],
+    });
+    expect(result.kept).toHaveLength(1);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it('preserves order among kept candidates', () => {
+    const candidates = [
+      cand('https://a.com/'),
+      cand(`https://www.wikidata.org/wiki/${XAI_QID}`),
+      cand('https://b.com/'),
+      cand(`https://www.wikidata.org/wiki/${ANTHROPIC_QID}`),
+      cand('https://c.com/'),
+    ];
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates,
+    });
+    expect(result.kept.map((c) => c.url)).toEqual([
+      'https://a.com/',
+      'https://b.com/',
+      `https://www.wikidata.org/wiki/${ANTHROPIC_QID}`,
+      'https://c.com/',
+    ]);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].candidate.url).toBe(
+      `https://www.wikidata.org/wiki/${XAI_QID}`,
+    );
+  });
+
+  it('handles an empty candidate list cleanly', () => {
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [],
+    });
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it('preserves arbitrary candidate fields on kept and dropped items', () => {
+    type Tagged = SubjectIdentityCandidate & { provider: string };
+    const candidates: Tagged[] = [
+      { url: 'https://a.com/', provider: 'exa' },
+      { url: `https://www.wikidata.org/wiki/${XAI_QID}`, provider: 'perplexity' },
+    ];
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates,
+    });
+    expect(result.kept[0].provider).toBe('exa');
+    expect(result.dropped[0].candidate.provider).toBe('perplexity');
+  });
+
+  it('URL match takes precedence over HTML (does not waste an HTML scan)', () => {
+    // If both signals are present and disagree, URL wins. This is a guard
+    // against a candidate URL whose page body links to many other Wikidata
+    // entries — the URL is the authoritative subject signal.
+    const result = subjectIdentityGate({
+      entityQid: ANTHROPIC_QID,
+      candidates: [
+        {
+          url: `https://www.wikidata.org/wiki/${ANTHROPIC_QID}`,
+          html: `noise: https://www.wikidata.org/wiki/${XAI_QID}`,
+        },
+      ],
+    });
+    expect(result.kept).toHaveLength(1);
+    expect(result.dropped).toEqual([]);
+  });
+});

--- a/crux/lib/sourcing/subject-identity-gate.ts
+++ b/crux/lib/sourcing/subject-identity-gate.ts
@@ -56,7 +56,12 @@ export interface SubjectIdentityDrop<C extends SubjectIdentityCandidate> {
   candidate: C;
   /** Stable machine-readable code: "subject-mismatch". */
   reason: 'subject-mismatch';
-  /** Human-readable detail (`<candidateQid> != <entityQid>`). */
+  /** Wikidata QID extracted from the candidate URL or HTML. */
+  candidateQid: string;
+  /** Wikidata QID of the parent entity that the candidate disagreed with. */
+  entityQid: string;
+  /** Human-readable detail (`<candidateQid> != <entityQid>`). Kept alongside
+   *  the structured QIDs above for log lines that want a single string. */
   detail: string;
 }
 
@@ -108,6 +113,8 @@ export function subjectIdentityGate<C extends SubjectIdentityCandidate>(
     dropped.push({
       candidate,
       reason: 'subject-mismatch',
+      candidateQid,
+      entityQid,
       detail: `${candidateQid} != ${entityQid}`,
     });
   }

--- a/crux/lib/sourcing/subject-identity-gate.ts
+++ b/crux/lib/sourcing/subject-identity-gate.ts
@@ -1,0 +1,116 @@
+/**
+ * Subject-Identity Gate — QUA-724
+ *
+ * Drops candidate source URLs whose primary subject (Wikidata QID) does not
+ * match the parent entity's QID, before they reach `source_check_evidence` /
+ * `url_suggestions` storage. Sits in the propose-fact pipeline at step 4 (the
+ * RFC layout in QUA-722) — after URL-quality, before the LLM verify step.
+ *
+ * ## Why this exists
+ *
+ * QUA-650's retro-scan caught 76 system-wide verdicts whose source was about
+ * a materially different entity than the claim's subject (e.g. "Microsoft AI"
+ * confirming a fact about "Microsoft", or an xAI press release attached to
+ * an Anthropic funding-round). Every one of those was a paid LLM check that
+ * could have been short-circuited at suggest-time with a deterministic QID
+ * comparison.
+ *
+ * ## Fail-open contract
+ *
+ * The gate **never drops a candidate** unless both QIDs are known and they
+ * disagree. Specifically:
+ *
+ *   - If the entity has no Wikidata QID → all candidates pass.
+ *   - If the candidate URL has no extractable QID and no HTML is supplied →
+ *     pass.
+ *   - If the candidate's HTML doesn't reference Wikidata → pass.
+ *
+ * This is the same fail-open posture that QUA-650 / QUA-426 / `relevance-gate`
+ * use: false-positives (drop a legitimate candidate) are worse than
+ * false-negatives (fail to catch a mismatched candidate) because the
+ * downstream LLM verify step also catches mismatches as a backstop.
+ */
+
+import { extractQid, extractQidFromHtml } from './wikidata-matcher.ts';
+
+/** A candidate URL the gate inspects. Caller may pre-fetch HTML and pass it
+ *  in for a stricter subject check; otherwise only the URL itself is used. */
+export interface SubjectIdentityCandidate {
+  url: string;
+  /** Optional pre-fetched HTML body. The gate scans it for a Wikidata
+   *  reference and uses that as the candidate's QID. Many news pages link
+   *  to the canonical Wikidata entry via `<link rel>` or schema.org
+   *  `sameAs`, so this catches non-Wikidata candidate URLs at the cost
+   *  of one network fetch per candidate. */
+  html?: string;
+}
+
+export interface SubjectIdentityGateInput<C extends SubjectIdentityCandidate> {
+  /** The parent entity's Wikidata QID (e.g. "Q108542504"). Pass `null` to
+   *  disable the gate (all candidates pass — fail-open). */
+  entityQid: string | null;
+  candidates: C[];
+}
+
+export interface SubjectIdentityDrop<C extends SubjectIdentityCandidate> {
+  candidate: C;
+  /** Stable machine-readable code: "subject-mismatch". */
+  reason: 'subject-mismatch';
+  /** Human-readable detail (`<candidateQid> != <entityQid>`). */
+  detail: string;
+}
+
+export interface SubjectIdentityGateResult<C extends SubjectIdentityCandidate> {
+  kept: C[];
+  dropped: SubjectIdentityDrop<C>[];
+}
+
+/**
+ * Apply the subject-identity gate to a list of candidates.
+ *
+ * For each candidate:
+ *   1. Extract a QID from the candidate URL (cheap, sync).
+ *   2. If no URL-QID and `html` was supplied, extract from HTML.
+ *   3. If a candidate QID was found AND it differs from `entityQid`, drop
+ *      with `reason='subject-mismatch'`. Otherwise keep.
+ *
+ * Order is preserved among kept candidates.
+ */
+export function subjectIdentityGate<C extends SubjectIdentityCandidate>(
+  input: SubjectIdentityGateInput<C>,
+): SubjectIdentityGateResult<C> {
+  const { entityQid, candidates } = input;
+
+  // Fail-open: no entity QID → cannot judge identity.
+  if (!entityQid) {
+    return { kept: [...candidates], dropped: [] };
+  }
+
+  const kept: C[] = [];
+  const dropped: SubjectIdentityDrop<C>[] = [];
+
+  for (const candidate of candidates) {
+    const candidateQid =
+      extractQid(candidate.url) ??
+      (candidate.html ? extractQidFromHtml(candidate.html) : null);
+
+    if (!candidateQid) {
+      // Fail-open: can't determine subject → keep.
+      kept.push(candidate);
+      continue;
+    }
+
+    if (candidateQid === entityQid) {
+      kept.push(candidate);
+      continue;
+    }
+
+    dropped.push({
+      candidate,
+      reason: 'subject-mismatch',
+      detail: `${candidateQid} != ${entityQid}`,
+    });
+  }
+
+  return { kept, dropped };
+}

--- a/crux/lib/sourcing/suggest-urls.test.ts
+++ b/crux/lib/sourcing/suggest-urls.test.ts
@@ -195,6 +195,55 @@ describe('suggestUrls', () => {
     expect(result.candidates).toHaveLength(2);
   });
 
+  it('drops candidates that point at a different Wikidata entity (subject-identity gate, QUA-724)', async () => {
+    // Anthropic Q108542504 vs xAI Q117104853 — the canonical mismatch from QUA-722.
+    // (Note: dedupeHits normalizes www-prefixed hosts; we use bare wikidata.org
+    // so the asserted URLs match the normalized output.)
+    mockSearchExa.mockResolvedValue([
+      { url: 'https://wikidata.org/wiki/Q117104853', title: 'xAI', provider: 'exa' },
+      { url: 'https://wikidata.org/wiki/Q108542504', title: 'Anthropic', provider: 'exa' },
+      { url: 'https://reuters.com/anthropic-news', title: 'Reuters', provider: 'exa' },
+    ]);
+    mockSearchPerplexity.mockResolvedValue({ hits: [], cost: 0 });
+
+    const result = await suggestUrls({
+      entityName: 'Anthropic',
+      claimText: 'Anthropic raised $13B Series F',
+      entityWikidataQid: 'Q108542504',
+      maxCandidates: 3,
+    });
+
+    const urls = result.candidates.map((c) => c.url);
+    expect(urls).not.toContain('https://wikidata.org/wiki/Q117104853');
+    expect(urls).toContain('https://wikidata.org/wiki/Q108542504');
+    expect(urls).toContain('https://reuters.com/anthropic-news');
+    expect(result.subjectMismatches).toHaveLength(1);
+    expect(result.subjectMismatches[0]).toEqual({
+      url: 'https://wikidata.org/wiki/Q117104853',
+      candidateQid: 'Q117104853',
+      entityQid: 'Q108542504',
+    });
+  });
+
+  it('subject-identity gate is fail-open when entityWikidataQid is omitted', async () => {
+    // No entityWikidataQid → all candidates pass even when one is a wikidata
+    // URL that would mismatch any other entity.
+    mockSearchExa.mockResolvedValue([
+      { url: 'https://wikidata.org/wiki/Q117104853', title: 'xAI', provider: 'exa' },
+      { url: 'https://reuters.com/news', title: 'R', provider: 'exa' },
+    ]);
+    mockSearchPerplexity.mockResolvedValue({ hits: [], cost: 0 });
+
+    const result = await suggestUrls({
+      entityName: 'Anthropic',
+      claimText: 'fact',
+      maxCandidates: 3,
+    });
+
+    expect(result.candidates).toHaveLength(2);
+    expect(result.subjectMismatches).toEqual([]);
+  });
+
   it('sets sourceProvider per candidate from the search provider', async () => {
     mockSearchExa.mockResolvedValue([
       { url: 'https://a.com/p', title: 'A', provider: 'exa' },

--- a/crux/lib/sourcing/suggest-urls.ts
+++ b/crux/lib/sourcing/suggest-urls.ts
@@ -215,14 +215,11 @@ export async function suggestUrls(input: SuggestUrlsInput): Promise<SuggestUrlsR
     };
   });
 
-  const subjectMismatches = gateResult.dropped.map((d) => {
-    const [candidateQid, entityQidPart] = d.detail.split(' != ');
-    return {
-      url: d.candidate.url,
-      candidateQid,
-      entityQid: entityQidPart,
-    };
-  });
+  const subjectMismatches = gateResult.dropped.map((d) => ({
+    url: d.candidate.url,
+    candidateQid: d.candidateQid,
+    entityQid: d.entityQid,
+  }));
 
   return {
     candidates,

--- a/crux/lib/sourcing/suggest-urls.ts
+++ b/crux/lib/sourcing/suggest-urls.ts
@@ -22,6 +22,7 @@ import {
 } from "../search/research-agent.ts";
 import { getApiKey } from "../api-keys.ts";
 import { normalizeUrlForJoin as normalizeUrl } from "./url-quality.ts";
+import { subjectIdentityGate } from "./subject-identity-gate.ts";
 
 /** Version tag for stored suggestions — bump when the generator changes shape. */
 export const GENERATOR_MODEL = "qua-64/suggest-urls-v1";
@@ -40,6 +41,15 @@ export interface SuggestUrlsInput {
   /** Provider toggles (auto-disabled when the key is missing). */
   useExa?: boolean;
   usePerplexity?: boolean;
+  /**
+   * Parent entity's Wikidata QID (e.g. "Q108542504"). When present, enables
+   * the subject-identity gate (QUA-724): candidates whose URL points at a
+   * different Wikidata entity are dropped with reason `subject-mismatch`
+   * before they are persisted. Pass `null` / omit to disable the gate
+   * (fail-open default — matches today's behaviour for entities without a
+   * known QID).
+   */
+  entityWikidataQid?: string | null;
 }
 
 export type SuggestUrlsProvider = 'manual' | 'exa' | 'perplexity' | 'scry';
@@ -59,6 +69,18 @@ export interface SuggestUrlsResult {
   query: string;
   /** Approximate USD cost (currently only Perplexity reports cost). */
   costUsd: number;
+  /**
+   * Candidates dropped by the subject-identity gate (QUA-724). Empty when
+   * the gate is disabled (no `entityWikidataQid` supplied) or when no
+   * candidate had an extractable Wikidata QID. Each entry records the
+   * dropped URL, the offending QID, and the entity QID so callers can log
+   * for observability without re-running the gate.
+   */
+  subjectMismatches: Array<{
+    url: string;
+    candidateQid: string;
+    entityQid: string;
+  }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +145,7 @@ export async function suggestUrls(input: SuggestUrlsInput): Promise<SuggestUrlsR
   const {
     entityName, claimText, fieldName, existingUrl,
     maxCandidates = 3, useExa = true, usePerplexity = true,
+    entityWikidataQid = null,
   } = input;
 
   const query = buildSearchQuery({ entityName, claimText, fieldName });
@@ -170,15 +193,43 @@ export async function suggestUrls(input: SuggestUrlsInput): Promise<SuggestUrlsR
   ).flat();
 
   const excludeKey = existingUrl ? normalizeUrl(existingUrl) : null;
-  const candidates: UrlSuggestion[] = dedupeHits(allHits, maxCandidates, excludeKey).map(
-    (hit) => ({
+  // Dedupe + cap first, then apply the subject-identity gate (QUA-724).
+  // The gate may shrink the result below `maxCandidates`; we don't backfill
+  // here because the wider pipeline (QUA-722) is the right place to ask the
+  // search providers for more if too many were dropped.
+  const dedupedHits = dedupeHits(allHits, maxCandidates, excludeKey);
+
+  const gateResult = subjectIdentityGate({
+    entityQid: entityWikidataQid,
+    candidates: dedupedHits.map((hit) => ({ url: hit.url, _hit: hit })),
+  });
+
+  const candidates: UrlSuggestion[] = gateResult.kept.map((c) => {
+    const hit = c._hit;
+    return {
       url: hit.url,
       title: hit.title,
       snippet: hit.snippet ?? null,
       relevanceScore: null, // No cross-provider score model yet.
       sourceProvider: hit.provider as SuggestUrlsProvider,
-    }),
-  );
+    };
+  });
 
-  return { candidates, providersUsed, providersSkipped, query, costUsd };
+  const subjectMismatches = gateResult.dropped.map((d) => {
+    const [candidateQid, entityQidPart] = d.detail.split(' != ');
+    return {
+      url: d.candidate.url,
+      candidateQid,
+      entityQid: entityQidPart,
+    };
+  });
+
+  return {
+    candidates,
+    providersUsed,
+    providersSkipped,
+    query,
+    costUsd,
+    subjectMismatches,
+  };
 }

--- a/crux/lib/sourcing/wikidata-matcher.test.ts
+++ b/crux/lib/sourcing/wikidata-matcher.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { tryWikidataMatch, extractQid, clearEntityCache, fetchEntities } from './wikidata-matcher.ts';
+import {
+  tryWikidataMatch,
+  extractQid,
+  extractQidFromHtml,
+  clearEntityCache,
+  fetchEntities,
+} from './wikidata-matcher.ts';
 import type { VerifyItem, FactItemData } from './orchestrator-types.ts';
 
 // ── Mock Wikidata API at HTTP level ─────────────────────────────────
@@ -165,6 +171,40 @@ describe('extractQid', () => {
 
   it('returns null for URL without QID', () => {
     expect(extractQid('https://www.wikidata.org/wiki/Property:P856')).toBeNull();
+  });
+});
+
+describe('extractQidFromHtml', () => {
+  it('extracts QID from a wikidata.org/wiki/Q<n> reference inside HTML', () => {
+    const html = `<link rel="alternate" href="https://www.wikidata.org/wiki/Q108542504">`;
+    expect(extractQidFromHtml(html)).toBe('Q108542504');
+  });
+
+  it('extracts QID from a wikidata.org/entity/Q<n> reference inside HTML', () => {
+    const html = `{"sameAs":"https://www.wikidata.org/entity/Q42"}`;
+    expect(extractQidFromHtml(html)).toBe('Q42');
+  });
+
+  it('returns the first QID when multiple are present', () => {
+    const html = `https://www.wikidata.org/wiki/Q1
+                  https://www.wikidata.org/wiki/Q2`;
+    expect(extractQidFromHtml(html)).toBe('Q1');
+  });
+
+  it('is case-insensitive on the host', () => {
+    const html = `<a href="https://www.WIKIDATA.org/wiki/Q42">`;
+    expect(extractQidFromHtml(html)).toBe('Q42');
+  });
+
+  it('returns null when no Wikidata reference is present', () => {
+    expect(extractQidFromHtml('<html><body>nothing here</body></html>')).toBeNull();
+  });
+
+  it('ignores non-item references like Property:P856', () => {
+    // The regex requires `Q\d+` after the path prefix, so property pages
+    // (which use `Property:P\d+`) are correctly ignored.
+    const html = `<a href="https://www.wikidata.org/wiki/Property:P856">`;
+    expect(extractQidFromHtml(html)).toBeNull();
   });
 });
 

--- a/crux/lib/sourcing/wikidata-matcher.test.ts
+++ b/crux/lib/sourcing/wikidata-matcher.test.ts
@@ -206,6 +206,20 @@ describe('extractQidFromHtml', () => {
     const html = `<a href="https://www.wikidata.org/wiki/Property:P856">`;
     expect(extractQidFromHtml(html)).toBeNull();
   });
+
+  it('caps the scan to bound regex cost on multi-megabyte payloads', () => {
+    // The QID is past the 64KB scan limit — a naive `html.match(...)` would
+    // still find it, but the cap means we deliberately don't scan that far.
+    // This protects against ReDoS-shaped pathological inputs and keeps the
+    // gate's cost predictable per candidate.
+    const padding = 'x'.repeat(70_000);
+    const html = `${padding}https://www.wikidata.org/wiki/Q42`;
+    expect(extractQidFromHtml(html)).toBeNull();
+
+    // Same QID, but inside the cap — found.
+    const small = `prefix https://www.wikidata.org/wiki/Q42 suffix`;
+    expect(extractQidFromHtml(small)).toBe('Q42');
+  });
 });
 
 describe('tryWikidataMatch', () => {

--- a/crux/lib/sourcing/wikidata-matcher.ts
+++ b/crux/lib/sourcing/wikidata-matcher.ts
@@ -104,16 +104,49 @@ export function clearEntityCache(): void {
 const QID_REGEX = /Q(\d+)/;
 
 /**
+ * Match `wikidata.org/wiki/Q<n>` or `wikidata.org/entity/Q<n>` anywhere in a
+ * string, ignoring trailing punctuation. Used by `extractQidFromHtml` to find
+ * Wikidata references inside HTML body, schema.org `sameAs`, `<link rel>`
+ * blocks, etc.
+ */
+const WIKIDATA_REF_RE = /wikidata\.org\/(?:wiki|entity)\/(Q\d+)/i;
+
+/**
  * Extract QID from a source URL.
+ *
  * Handles:
  *   - https://www.wikidata.org/wiki/Q123
  *   - https://www.wikidata.org/wiki/Q123,
  *   - https://www.wikidata.org/entity/Q123
+ *
+ * Returns null for URLs that don't reference wikidata.org or that point at
+ * non-item pages (e.g. `Property:P856`).
  */
 export function extractQid(url: string): string | null {
   if (!url.includes('wikidata.org')) return null;
   const match = url.match(QID_REGEX);
   return match ? `Q${match[1]}` : null;
+}
+
+/**
+ * Find the first Wikidata QID referenced inside an HTML/text payload.
+ *
+ * Looks for `wikidata.org/wiki/Q<n>` or `wikidata.org/entity/Q<n>` patterns,
+ * which cover the common emission paths:
+ *   - `<link rel="alternate" href="https://www.wikidata.org/wiki/Q...">`
+ *   - schema.org `sameAs` arrays
+ *   - article-body links to Wikidata pages
+ *   - Open Graph / Twitter cards that reference the canonical Wikidata URL
+ *
+ * Returns null if no Wikidata reference is found. Callers should treat null
+ * as "unknown subject" (fail-open) rather than "different subject".
+ *
+ * Subject-identity gate (QUA-724) uses this to compare a candidate URL's
+ * primary subject against the entity's QID before persisting suggestions.
+ */
+export function extractQidFromHtml(html: string): string | null {
+  const m = html.match(WIKIDATA_REF_RE);
+  return m ? m[1] : null;
 }
 
 // ── Wikidata API calls ──────────────────────────────────────────────

--- a/crux/lib/sourcing/wikidata-matcher.ts
+++ b/crux/lib/sourcing/wikidata-matcher.ts
@@ -128,6 +128,11 @@ export function extractQid(url: string): string | null {
   return match ? `Q${match[1]}` : null;
 }
 
+/** Cap how much HTML the QID extractor scans. Wikidata references on a page
+ *  are almost always in the head/early body (canonical link, sameAs, og:url);
+ *  we cap to 64KB to bound the regex cost when callers pass full pages. */
+const HTML_SCAN_LIMIT = 64 * 1024;
+
 /**
  * Find the first Wikidata QID referenced inside an HTML/text payload.
  *
@@ -138,6 +143,10 @@ export function extractQid(url: string): string | null {
  *   - article-body links to Wikidata pages
  *   - Open Graph / Twitter cards that reference the canonical Wikidata URL
  *
+ * Only the first `HTML_SCAN_LIMIT` chars are scanned — a limit that comfortably
+ * covers `<head>` plus the first screen of body, where canonical / sameAs links
+ * always live, while bounding regex cost on multi-megabyte payloads.
+ *
  * Returns null if no Wikidata reference is found. Callers should treat null
  * as "unknown subject" (fail-open) rather than "different subject".
  *
@@ -145,7 +154,8 @@ export function extractQid(url: string): string | null {
  * primary subject against the entity's QID before persisting suggestions.
  */
 export function extractQidFromHtml(html: string): string | null {
-  const m = html.match(WIKIDATA_REF_RE);
+  const slice = html.length > HTML_SCAN_LIMIT ? html.slice(0, HTML_SCAN_LIMIT) : html;
+  const m = slice.match(WIKIDATA_REF_RE);
   return m ? m[1] : null;
 }
 


### PR DESCRIPTION
## Summary

Adds a deterministic Wikidata-QID gate inside `suggestUrls()` that drops candidate URLs whose primary subject doesn't match the parent entity. QUA-650's retro-scan caught 76 system-wide verdicts where this pattern hit *after* the fact (e.g. xAI press releases attached to Anthropic funding-rounds); this gate catches the same shape at suggest time, before storage.

Fail-open by design — if either QID is unknown the candidate passes — mirroring the `relevance-gate` / QUA-426 contract. The LLM verify step downstream remains the backstop.

## Changes

- `crux/lib/sourcing/wikidata-matcher.ts` — new `extractQidFromHtml()` so a candidate URL can be checked against pre-fetched HTML (`<link rel>`, `sameAs`, body links).
- `crux/lib/sourcing/subject-identity-gate.ts` (new) — pure gate function; takes any candidate shape with `{ url, html? }`. Accepts a `null` entity QID (full fail-open).
- `crux/lib/sourcing/entity-wikidata-qid.ts` (new) — looks up the parent entity's QID from `data/external-links.yaml`. The ticket's `entities.wikidata` / `wikidata_qid` columns don't actually exist; `external-links.yaml` is the source-of-truth.
- `crux/lib/sourcing/suggest-urls.ts` — accepts `entityWikidataQid`, returns `subjectMismatches[]` for observability. Gate runs after dedup+cap; doesn't backfill from providers (that belongs in the unified pipeline, QUA-722).
- `crux/commands/sourcing-suggest-urls.ts` — looks up the entity's QID per verdict row, plumbs it into `suggestUrls`, prints `[subject-mismatch]` lines and bumps a new `subject_mismatches_dropped` summary counter.

## Acceptance from the ticket

- [x] New gate in `crux/lib/sourcing/suggest-urls.ts`
- [x] Mismatched-QID candidate dropped with `subject-mismatch` reason
- [x] Matching-QID candidate passes
- [x] Null-on-either-side ⇒ pass (fail-open)
- [x] Logging captures dropped candidates with detail for observability (per-record `[subject-mismatch]` log line + summary counter)
- [x] Smoke can be run via `crux sourcing-suggest-urls --entity=anthropic --verdict=contradicted --dry-run` — gate exercises Anthropic's QID `Q108542504` lookup. (Dry-run skips network so HTML-fetch path is untested in dry-run; URL-mode mismatches show in the log.)

## Out of scope (per ticket)

- Retro-sweep over the 76 existing contradicted verdicts → sibling ticket
- Wider entity QID backfill (records without a QID stay fail-open)
- Pre-fetching HTML inside `suggestUrls` itself — that fetch belongs in the unified pipeline (QUA-722) at step 5; the gate accepts pre-fetched HTML via the candidate's optional `html` field

## Test plan

- [x] `pnpm vitest run crux/lib/sourcing/{subject-identity-gate,wikidata-matcher,suggest-urls,entity-wikidata-qid}.test.ts crux/commands/sourcing-suggest-urls.test.ts` — 88 tests pass (24 new)
- [x] Full sourcing test surface: `pnpm vitest run crux/lib/sourcing/ crux/commands/sourcing-suggest-urls.test.ts` — 569 tests pass
- [x] `pnpm crux w validate gate --fix` — 61 checks pass, 4 pre-existing advisory warnings unrelated

Fixes QUA-724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Wikidata identity verification to filter URL candidates that reference different entities
  * Adds entity-to-Wikidata lookup to support subject matching
  * Adds QID extraction from HTML/text to improve identification

* **Bug Fixes / Improvements**
  * Emits audit lines and run-summary metrics for subject-mismatch drops visible in text and JSON output
  * Ensures mismatched candidates are skipped from suggestion outputs

* **Tests**
  * Expanded tests covering subject-identity filtering, QID extraction, caching, and reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->