### PR TITLE
feat(crux): require --project on linear create to prevent orphans

### DIFF
--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -324,7 +324,7 @@ Include the coverage table in the report.
 
 - **File one Linear issue per finding** (P0, P1, and P2). Do not batch unrelated issues into umbrella issues.
 - Closely related findings (e.g., 5 entities with the same data problem) may be grouped into one issue.
-- Use `pnpm crux linear create "title" --description="..."` for each.
+- Use `pnpm crux linear create "title" --description="..." --project="<Project Name>"` for each (`--project` is required; see `.claude/rules/linear-project-ownership.md`).
 - **Expected volume:** 5-15 issues per deep sweep is normal.
 - **Do NOT skip P1 and P2 filing.** Every confirmed finding must become a Linear issue. If you compiled it into the report, file it.
 

--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -55,10 +55,11 @@ The report categorizes work into priority tiers. Review the output and decide wh
 
 ### Filing new issues
 
-When the sweep reveals problems too large to fix now, **create Linear issues** so they aren't lost:
+When the sweep reveals problems too large to fix now, **create Linear issues** so they aren't lost. `--project` is required (see `.claude/rules/linear-project-ownership.md` to pick one):
 ```bash
 pnpm crux linear create "Descriptive title" \
-  --description="What's wrong and why it matters"
+  --description="What's wrong and why it matters" \
+  --project="<Project Name>"
 ```
 
 To update existing Linear issues with context:

--- a/.claude/rules/github-issue-tracking.md
+++ b/.claude/rules/github-issue-tracking.md
@@ -75,9 +75,13 @@ pnpm crux gh issues done <ISSUE_NUM> --pr=<PR_URL>
 # Search first:
 pnpm crux linear search "your topic here"
 
-# Create:
-pnpm crux linear create "Descriptive title" --description="What's wrong and why it matters"
+# Create (--project is required, or --parent inherits one):
+pnpm crux linear create "Descriptive title" \
+  --description="What's wrong and why it matters" \
+  --project="<Project Name>"
 ```
+
+The CLI refuses with exit 2 if `--project` is omitted and no parent inherits one. See `.claude/rules/linear-project-ownership.md` to pick the right project. Bypass with `--allow-no-project` only when the issue genuinely has no home.
 
 Do NOT use `gh issue create` or `pnpm crux gh issues create` for new issues. See `.claude/rules/proactive-issue-filing.md` for when and how to file.
 

--- a/.claude/rules/proactive-github-filing.md
+++ b/.claude/rules/proactive-github-filing.md
@@ -51,8 +51,11 @@ pnpm crux linear search "your topic here"
 
 ```bash
 pnpm crux linear create "Descriptive title" \
-  --description="What's wrong and why it matters"
+  --description="What's wrong and why it matters" \
+  --project="<Project Name>"
 ```
+
+`--project` is **required** (or pass `--parent=QUA-NNN` to inherit). The CLI refuses with exit 2 otherwise — see `.claude/rules/linear-project-ownership.md` for which project to pick. Bypass with `--allow-no-project` only if the issue genuinely has no home yet.
 
 For longer descriptions, use `--description-file=/tmp/description.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ pnpm crux tb people discover                 # Discover people entities
 
 # Linear (primary issue tracker)
 pnpm crux linear search "query"              # Search Linear issues
-pnpm crux linear create "title" --description="..."  # Create a new Linear issue
+pnpm crux linear create "title" --description="..." --project="..."  # Create a new Linear issue (--project required)
 pnpm crux linear start QUA-NNN              # Signal work start on issue
 pnpm crux linear done QUA-NNN --pr=URL      # Signal completion
 pnpm crux linear view QUA-NNN              # View issue details

--- a/crux/commands/__tests__/linear.test.ts
+++ b/crux/commands/__tests__/linear.test.ts
@@ -234,21 +234,32 @@ describe('linear create', () => {
     expect(r.output).toContain('Usage');
   });
 
-  it('creates an issue with just a title', async () => {
-    const r = await commands.create(['My', 'ticket'], { ci: true });
-    expect(r.exitCode).toBe(0);
-    expect(createIssueMock).toHaveBeenCalledWith({
-      title: 'My ticket',
-      description: '',
-      priority: undefined,
-      parentId: undefined,
-      projectId: undefined,
-    });
-    expect(r.output).toContain('QUA-999');
+  it('creates an issue with just a title (when --allow-no-project is set)', async () => {
+    // Capture stderr — the no-project warning prints there even on bypass.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const r = await commands.create(['My', 'ticket'], { ci: true, allowNoProject: true });
+      expect(r.exitCode).toBe(0);
+      expect(createIssueMock).toHaveBeenCalledWith({
+        title: 'My ticket',
+        description: '',
+        priority: undefined,
+        parentId: undefined,
+        projectId: undefined,
+      });
+      expect(r.output).toContain('QUA-999');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
-  it('resolves --parent QUA-NNN to the parent UUID', async () => {
-    getIssueMock.mockResolvedValueOnce({ ...mockIssue, id: 'parent-uuid', title: 'Epic' });
+  it('resolves --parent QUA-NNN to the parent UUID (with project on parent)', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Epic',
+      project: { id: 'parent-project-uuid', name: 'Some Project' },
+    });
     const r = await commands.create(['Child ticket'], { ci: true, parent: 'QUA-184' });
     expect(r.exitCode).toBe(0);
     expect(getIssueMock).toHaveBeenCalledWith('QUA-184');
@@ -366,22 +377,31 @@ describe('linear create', () => {
     expect(r.output).not.toContain('inherited from parent');
   });
 
-  it('does not set a project when parent has none and --project is omitted', async () => {
+  it('does not set a project when parent has none and --allow-no-project is set', async () => {
     getIssueMock.mockResolvedValueOnce({
       ...mockIssue,
       id: 'parent-uuid',
       title: 'Epic',
       project: null,
     });
-    const r = await commands.create(['Child'], { ci: true, parent: 'QUA-408' });
-    expect(r.exitCode).toBe(0);
-    expect(createIssueMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        parentId: 'parent-uuid',
-        projectId: undefined,
-      }),
-    );
-    expect(r.output).not.toContain('inherited from parent');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const r = await commands.create(['Child'], {
+        ci: true,
+        parent: 'QUA-408',
+        allowNoProject: true,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(createIssueMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentId: 'parent-uuid',
+          projectId: undefined,
+        }),
+      );
+      expect(r.output).not.toContain('inherited from parent');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   // ── Ticket-sizing red flags (QUA-575) ────────────────────────────────────
@@ -404,20 +424,29 @@ describe('linear create', () => {
     expect(createIssueMock).not.toHaveBeenCalled();
   });
 
-  it('does not warn on ordinary tickets', async () => {
-    const r = await commands.create(['Fix typo in README'], { ci: true });
-    expect(r.exitCode).toBe(0);
-    expect(r.output).not.toContain('red flag');
-    expect(createIssueMock).toHaveBeenCalled();
+  it('does not warn on ordinary tickets (when --allow-no-project is set)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const r = await commands.create(['Fix typo in README'], {
+        ci: true,
+        allowNoProject: true,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(r.output).not.toContain('red flag');
+      expect(createIssueMock).toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it('proceeds when --allow-big is set despite red flags', async () => {
     // Capture stderr so the test environment doesn't print the warning.
+    // Set allowNoProject too — we're testing red-flag bypass, not no-project.
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
       const r = await commands.create(
         ['Phase 2: migrate 5,000 rows across `foo`, `bar`, `baz`'],
-        { ci: true, allowBig: true },
+        { ci: true, allowBig: true, allowNoProject: true },
       );
       expect(r.exitCode).toBe(0);
       expect(createIssueMock).toHaveBeenCalled();
@@ -456,6 +485,95 @@ describe('linear create', () => {
     expect(parsed.flags[0].kind).toBe('phase-or-wave');
     expect(parsed.hint).toContain('--allow-big');
     expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  // ── Orphan prevention (no-project refusal) ────────────────────────────────
+
+  it('refuses creation with exit=2 when --project is omitted and no parent', async () => {
+    const r = await commands.create(['Ordinary ticket'], { ci: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('without a project');
+    expect(r.output).toContain('--allow-no-project');
+    expect(r.output).toContain('--project=');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses when --parent is given but the parent has no project', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Orphan epic',
+      project: null,
+    });
+    const r = await commands.create(['Child of orphan parent'], {
+      ci: true,
+      parent: 'QUA-408',
+    });
+    expect(r.exitCode).toBe(2);
+    expect(r.output).toContain('without a project');
+    expect(r.output).toContain('QUA-408');
+    expect(r.output).toContain('no project to inherit');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('emits structured JSON on no-project refusal when --json is set', async () => {
+    const r = await commands.create(['Ordinary ticket'], {
+      ci: true,
+      json: true,
+    });
+    expect(r.exitCode).toBe(2);
+    const parsed = JSON.parse(r.output);
+    expect(parsed.error).toBe('no-project');
+    expect(parsed.hint).toContain('--project');
+    expect(parsed.hint).toContain('--allow-no-project');
+    expect(createIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when --allow-no-project bypass is set, prints warning to stderr', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const r = await commands.create(['Ordinary ticket'], {
+        ci: true,
+        allowNoProject: true,
+      });
+      expect(r.exitCode).toBe(0);
+      expect(createIssueMock).toHaveBeenCalled();
+      // Warning was printed to stderr so consumers see the bypass.
+      const stderrContent = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(stderrContent).toContain('without a project');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does not refuse when --project is set', async () => {
+    getProjectMock.mockResolvedValueOnce({
+      id: 'project-uuid',
+      name: 'Automation & Infrastructure',
+    });
+    const r = await commands.create(['Ordinary ticket'], {
+      ci: true,
+      project: 'Automation & Infrastructure',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).not.toContain('without a project');
+    expect(createIssueMock).toHaveBeenCalled();
+  });
+
+  it('does not refuse when --parent has a project (inherits)', async () => {
+    getIssueMock.mockResolvedValueOnce({
+      ...mockIssue,
+      id: 'parent-uuid',
+      title: 'Epic',
+      project: { id: 'parent-project-uuid', name: 'Data Model Unwind' },
+    });
+    const r = await commands.create(['Child ticket'], {
+      ci: true,
+      parent: 'QUA-408',
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.output).not.toContain('without a project');
+    expect(createIssueMock).toHaveBeenCalled();
   });
 });
 

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -88,6 +88,11 @@ interface CommandOptions extends BaseOptions {
   // batching, mixed shapes, multi-table enumeration) refuse the create.
   // See QUA-575 + .claude/rules/ticket-sizing.md.
   allowBig?: boolean;
+  // Bypass the "no project" refusal on `crux linear create`. Without this,
+  // a create with neither --project nor a project-bearing --parent refuses
+  // (orphan-prevention). Use only when the issue genuinely has no home
+  // project yet — e.g. exploratory tickets pending triage.
+  allowNoProject?: boolean;
 }
 
 function readBodyFlag(path: string | undefined): string | null {
@@ -488,6 +493,29 @@ function checkRedFlagsOrRefuse(
   return { output: `${c.yellow}${warning}${c.reset}`, exitCode: 2 };
 }
 
+/**
+ * Format the human-readable refusal when `crux linear create` runs without
+ * a project (and without inheritable parent project). Plain text so it can
+ * be wrapped in color codes by callers and reused for stderr bypass output.
+ */
+function formatNoProjectRefusal(
+  parentArg: string | undefined,
+  parentProject: { id: string; name: string } | null,
+): string {
+  let out = '⚠ Refusing to create an issue without a project.\n\n';
+  if (parentArg && !parentProject) {
+    out += `  --parent=${parentArg} was given, but that issue has no project to inherit from.\n`;
+  }
+  out += 'Why: 9% of recent QUA issues were filed projectless, breaking the\n';
+  out += 'project-ownership doctrine in .claude/rules/linear-project-ownership.md.\n';
+  out += 'Run `pnpm crux linear hygiene` to see current orphan count.\n\n';
+  out += 'Fix: pick one —\n';
+  out += '  1) --project="<name>" — see `pnpm crux linear project list`\n';
+  out += '  2) --parent=QUA-NNN — child inherits the parent\'s project\n';
+  out += '  3) --allow-no-project — bypass (only if the issue genuinely has no home yet)\n';
+  return out;
+}
+
 async function create(args: string[], options: CommandOptions): Promise<CommandResult> {
   const log = createLogger(options.ci);
   const c = log.colors;
@@ -554,6 +582,32 @@ async function create(args: string[], options: CommandOptions): Promise<CommandR
     projectId = parentProject.id;
     projectLabel = parentProject.name;
     projectInherited = true;
+  }
+
+  // Orphan-prevention: refuse a create with no project unless --allow-no-project is set.
+  // Reason: 9% of recent open issues were filed projectless, breaking the project-ownership
+  // doctrine in .claude/rules/linear-project-ownership.md. The hygiene scan catches them
+  // after the fact; this catches them at creation time.
+  if (!projectId) {
+    const refusal = formatNoProjectRefusal(options.parent, parentProject);
+    if (options.allowNoProject) {
+      process.stderr.write(refusal);
+    } else if (options.json) {
+      return {
+        output:
+          JSON.stringify(
+            {
+              error: 'no-project',
+              hint: 'Pass --project=<name>, or --parent=QUA-NNN where the parent has a project, or --allow-no-project to bypass.',
+            },
+            null,
+            2,
+          ) + '\n',
+        exitCode: 2,
+      };
+    } else {
+      return { output: `${c.yellow}${refusal}${c.reset}`, exitCode: 2 };
+    }
   }
 
   const result = await createIssue({ title, description, priority, parentId, projectId });
@@ -1234,9 +1288,13 @@ Options (create):
   --priority=N               Priority: 1=urgent, 2=high, 3=medium, 4=low (default: none)
   --parent=QUA-NNN           Parent issue (sets the child link to an epic)
   --project=<name|uuid>      Project (UUID or case-insensitive exact name).
+                             Required unless --parent inherits a project or
+                             --allow-no-project is set.
                              When --parent has a project and --project is
                              omitted, the parent's project is inherited.
   --allow-big                Bypass the ticket-sizing red-flag check (see .claude/rules/ticket-sizing.md)
+  --allow-no-project         Bypass the no-project refusal (creates an orphan).
+                             Only use when the issue genuinely has no project home yet.
 
 Options (update):
   --project=<name|uuid|none> Set or clear the project (use "none" to clear)


### PR DESCRIPTION
## Summary

`crux linear create` now refuses with exit 2 unless one of:
- `--project=<name>` is passed
- `--parent=QUA-NNN` inherits a parent's project
- `--allow-no-project` explicitly bypasses (with stderr warning)

Mirrors the existing `--allow-big` pattern for ticket-sizing flags.

## Why

The Linear hygiene scan flagged 22 orphan issues (9% of open backlog) — tickets created without a project assigned, breaking the project-ownership doctrine in `.claude/rules/linear-project-ownership.md`. Most were filed by agents that didn't pass `--project`. The hygiene scan catches these after the fact; this catches them at creation time.

Surfaced from the audit pass that just cleaned up the existing 22 orphans + ~50 other backlog problems. Agent A in that pass had to manually triage every orphan into a project — exactly the work this PR makes unnecessary going forward.

## What changed

**Code (`crux/commands/linear.ts`)**:
- New `allowNoProject?: boolean` field on `CommandOptions`
- New `formatNoProjectRefusal()` helper for the human-readable refusal
- Refusal logic added to `create()` after parent/project resolution: if `projectId` is undefined and `--allow-no-project` is unset, refuse with exit 2 (text or JSON)
- Help text updated to mark `--project` as required (and document `--allow-no-project`)

**Tests (`crux/commands/__tests__/linear.test.ts`)**:
- 4 existing tests adapted to pass `allowNoProject: true` where they were testing other behavior (parent resolution, red-flag bypass, etc.)
- 7 new tests covering: refusal with no project, refusal when parent has no project, JSON refusal payload, bypass with stderr warning, success when `--project` is set, success when parent project is inherited

**Docs**:
- `CLAUDE.md`, `.claude/rules/proactive-github-filing.md`, `.claude/rules/github-issue-tracking.md`, `.claude/commands/maintain.md`, `.claude/commands/maintain-qa-sweep.md` — example invocations now show `--project`

## Test plan

- [x] `pnpm vitest run crux/commands/__tests__/linear.test.ts` — 110 tests pass
- [x] `pnpm vitest run crux/lib/linear/` — 189 tests pass
- [x] `pnpm crux w validate gate --fix` — 61 gate checks pass
- [x] Manual smoke test: refusal in plain output (yellow warning, exit 2)
- [x] Manual smoke test: refusal in `--json` output (`{"error": "no-project", "hint": ...}`, exit 2)
- [x] No deploy tasks detected (`pnpm crux gh deploy-tasks detect`)

## Backwards compatibility

Existing callers that don't pass `--project` will start failing with exit 2. The refusal message lists three escape hatches; the most common fix is to add `--project="..."` to the call. Internal docs already updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
