### PR TITLE
QUA-791 Phase 1: server-side relevance-weighted verdict aggregation

### DIFF
--- a/apps/wiki-server/drizzle/0217_qua_791_evidence_relevance_score.sql
+++ b/apps/wiki-server/drizzle/0217_qua_791_evidence_relevance_score.sql
@@ -4,11 +4,11 @@
 -- weight when aggregating evidence rows into a single
 -- `source_check_verdicts` row.
 --
--- Default 1.0 keeps existing rows participating at full weight until the
--- relevance gate (QUA-426) backfills realistic scores. The relevance gate
--- itself short-circuits to verdict='not_applicable' for pages that don't
--- mention the subject — those rows are dropped entirely by the
--- aggregation rule and the score is moot for them.
+-- NULL keeps existing rows participating at full weight (treated as 1.0
+-- by the aggregator) until the relevance gate (QUA-426) backfills
+-- realistic scores. The relevance gate itself short-circuits to
+-- verdict='not_applicable' for pages that don't mention the subject —
+-- those rows are dropped entirely by the aggregation rule.
 --
 -- Range is intended to be 0..1 but NOT enforced by CHECK constraint at
 -- this stage; callers may persist nulls (then treated as 1.0 in the
@@ -17,3 +17,18 @@
 
 ALTER TABLE "source_check_evidence"
   ADD COLUMN IF NOT EXISTS "relevance_score" real;
+
+-- Backfill not_applicable rows to relevance_score = 0.
+--
+-- The aggregator currently drops not_applicable rows entirely (step 1
+-- of the rule), so a NULL score on existing rows is moot. But
+-- `item-verifier.ts` writes `relevanceScore: 0` for not_applicable
+-- rows on the going-forward path as a "belt + suspenders" guard for
+-- if the not_applicable filter is later relaxed. Without backfilling
+-- existing rows the guarantee only holds for newly-written evidence.
+-- Cheap one-shot UPDATE — typical not_applicable count is bounded by
+-- the relevance-gate hit rate (~tens of thousands rows max).
+UPDATE "source_check_evidence"
+   SET "relevance_score" = 0
+ WHERE "verdict" = 'not_applicable'
+   AND "relevance_score" IS NULL;

--- a/apps/wiki-server/drizzle/0217_qua_791_evidence_relevance_score.sql
+++ b/apps/wiki-server/drizzle/0217_qua_791_evidence_relevance_score.sql
@@ -1,0 +1,19 @@
+-- QUA-791 Phase 1: server-side relevance-weighted verdict aggregation.
+--
+-- Adds `relevance_score` column to `source_check_evidence`. Used as a
+-- weight when aggregating evidence rows into a single
+-- `source_check_verdicts` row.
+--
+-- Default 1.0 keeps existing rows participating at full weight until the
+-- relevance gate (QUA-426) backfills realistic scores. The relevance gate
+-- itself short-circuits to verdict='not_applicable' for pages that don't
+-- mention the subject — those rows are dropped entirely by the
+-- aggregation rule and the score is moot for them.
+--
+-- Range is intended to be 0..1 but NOT enforced by CHECK constraint at
+-- this stage; callers may persist nulls (then treated as 1.0 in the
+-- aggregator). A CHECK can be added in a follow-up once all writers
+-- populate the column.
+
+ALTER TABLE "source_check_evidence"
+  ADD COLUMN IF NOT EXISTS "relevance_score" real;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1513,6 +1513,13 @@
       "when": 1787876700000,
       "tag": "0216_qua_753_widen_audit_log_record_id",
       "breakpoints": true
+    },
+    {
+      "idx": 217,
+      "version": "7",
+      "when": 1787876800000,
+      "tag": "0217_qua_791_evidence_relevance_score",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
+++ b/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for `recomputeVerdict` (QUA-791).
+ *
+ * Exercises the DB-touching helper end-to-end with a mocked SQL
+ * dispatcher: read evidence rows → aggregate → upsert verdict via
+ * UPDATE-then-INSERT-fallback, including the unique-violation retry.
+ *
+ * Pure-aggregator unit tests live in `sourcing-aggregation.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { type SqlDispatcher, mockDbModule } from "./test-utils";
+
+let dispatch: SqlDispatcher = () => [];
+let capturedQueries: Array<{ query: string; params: unknown[] }> = [];
+
+vi.mock("../db.js", () =>
+  mockDbModule((q, p) => {
+    capturedQueries.push({ query: q, params: p });
+    return dispatch(q, p);
+  }),
+);
+
+const { recomputeVerdict, recomputeVerdictBestEffort } = await import(
+  "../routes/sourcing/recompute-verdict.js"
+);
+const { getDrizzleDb } = await import("../db.js");
+
+describe("recomputeVerdict — end-to-end", () => {
+  beforeEach(() => {
+    capturedQueries = [];
+    dispatch = () => [];
+  });
+
+  it("returns 'unchecked' aggregate when no evidence rows exist", async () => {
+    let updateCalls = 0;
+    let insertCalls = 0;
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) return [];
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        updateCalls++;
+        return []; // "no row updated" → falls through to INSERT
+      }
+      if (/^insert/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        insertCalls++;
+        return [];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+
+    expect(result.aggregate.verdict).toBe("unchecked");
+    expect(result.aggregate.sourcesChecked).toBe(0);
+    expect(result.reasoning).toMatch(/no evidence/i);
+    expect(updateCalls + insertCalls).toBeGreaterThan(0);
+  });
+
+  it("aggregates relevance-weighted majority from multiple evidence rows", async () => {
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [
+          { verdict: "confirmed", relevance_score: 0.95, confidence: 0.9 },
+          { verdict: "confirmed", relevance_score: 0.85, confidence: 0.85 },
+          { verdict: "partial", relevance_score: 0.5, confidence: 0.7 },
+        ];
+      }
+      // UPDATE returns one row (verdict already exists) — no INSERT path.
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [{ record_id: "p_test" }];
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+
+    expect(result.aggregate.verdict).toBe("confirmed");
+    expect(result.aggregate.sourcesChecked).toBe(3);
+    expect(result.aggregate.contributing).toHaveLength(2); // confirmed + partial
+    expect(result.aggregate.contributing[0].verdict).toBe("confirmed");
+    expect(result.aggregate.contributing[0].rowCount).toBe(2);
+  });
+
+  it("retries with UPDATE when INSERT hits a unique-violation race", async () => {
+    let updateCalls = 0;
+    let insertCalls = 0;
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [{ verdict: "confirmed", relevance_score: 1.0, confidence: 0.9 }];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        updateCalls++;
+        if (updateCalls === 1) return []; // first UPDATE: no row → INSERT path
+        return [{ record_id: "p_test" }]; // retry UPDATE: row now exists, success
+      }
+      if (/^insert/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        insertCalls++;
+        // Simulate a unique-violation that postgres throws as 23505
+        const err = new Error('duplicate key value violates unique constraint "source_check_verdicts_pkey" — 23505');
+        throw err;
+      }
+      return [];
+    };
+
+    const result = await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+
+    // Should still succeed despite the race
+    expect(result.aggregate.verdict).toBe("confirmed");
+    expect(updateCalls).toBe(2); // 1 initial + 1 retry
+    expect(insertCalls).toBe(1);
+  });
+
+  it("propagates non-unique-violation errors from INSERT", async () => {
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [{ verdict: "confirmed", relevance_score: 1.0, confidence: 0.9 }];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        return [];
+      }
+      if (/^insert/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        // Drizzle catches and re-wraps this as Error('Failed query: ...')
+        // with the original on `.cause`. The "FOREIGN KEY" string appears
+        // on the cause, so the recompute helper's isUniqueViolation
+        // check returns false and the error propagates.
+        throw new Error("violates foreign key constraint on target_table");
+      }
+      return [];
+    };
+
+    await expect(
+      recomputeVerdict(getDrizzleDb(), {
+        recordType: "personnel",
+        recordId: "p_test",
+        fieldName: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("filters evidence by COALESCE(field_name, '') so NULL-fieldName matches NULL rows", async () => {
+    dispatch = (q, p) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        // The query's WHERE clause should include a COALESCE on field_name
+        // matching the empty string passed for NULL fieldName.
+        expect(q).toMatch(/COALESCE/i);
+        expect(p).toContain("");
+        return [];
+      }
+      if (/^update/i.test(q.trim())) return [];
+      return [];
+    };
+
+    await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+  });
+
+  it("clears needs_recheck on every recompute (we just looked)", async () => {
+    let updateBody = "";
+    dispatch = (q, p) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [{ verdict: "confirmed", relevance_score: 1.0, confidence: 0.9 }];
+      }
+      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        updateBody = q;
+        return [{ record_id: "p_test" }];
+      }
+      return [];
+    };
+
+    await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+
+    // Drizzle parameterizes booleans, so we need to find the param index.
+    // The SET clause includes `needs_recheck` as a column being set.
+    expect(updateBody).toMatch(/needs_recheck/i);
+  });
+
+  it("sets next_check_due to ~90 days when INSERTing a fresh row", async () => {
+    let insertedParams: unknown[] = [];
+    dispatch = (q, p) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        return [{ verdict: "confirmed", relevance_score: 1.0, confidence: 0.9 }];
+      }
+      if (/^update/i.test(q.trim())) return []; // no existing row
+      if (/^insert/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        insertedParams = [...p];
+        // Verify the query literally references next_check_due
+        expect(q).toMatch(/next_check_due/i);
+        return [];
+      }
+      return [];
+    };
+
+    const before = Date.now();
+    await recomputeVerdict(getDrizzleDb(), {
+      recordType: "personnel",
+      recordId: "p_test",
+      fieldName: null,
+    });
+    const after = Date.now();
+
+    // postgres-js serializes Date params to ISO strings in the bound-param
+    // list. Look for a string roughly 90 days out from `before`.
+    const ninetyDayMs = 90 * 24 * 60 * 60 * 1000;
+    const tolerance = (after - before) + 60_000; // 60s slack for clock jitter
+    const hasNinetyDay = insertedParams.some((v) => {
+      if (typeof v !== "string") return false;
+      const t = Date.parse(v);
+      if (Number.isNaN(t)) return false;
+      const delta = t - before;
+      return Math.abs(delta - ninetyDayMs) < tolerance;
+    });
+    expect(hasNinetyDay, `expected a ~90-day ISO timestamp in params: ${insertedParams.map(String).join(', ')}`).toBe(true);
+  });
+});
+
+describe("recomputeVerdictBestEffort", () => {
+  beforeEach(() => {
+    capturedQueries = [];
+    dispatch = () => [];
+  });
+
+  it("swallows recompute errors and returns void", async () => {
+    dispatch = (q) => {
+      if (/select/i.test(q) && /source_check_evidence/i.test(q)) {
+        throw new Error("simulated DB error");
+      }
+      return [];
+    };
+
+    // Should NOT throw — best-effort wraps the failure.
+    await expect(
+      recomputeVerdictBestEffort(getDrizzleDb(), {
+        recordType: "personnel",
+        recordId: "p_test",
+        fieldName: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the canonical evidence-aggregation function (QUA-791 Phase 1).
+ *
+ * Pure logic — no DB, no fixtures. Each test names the scenario it covers
+ * so failures point straight at the rule being violated.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  aggregateEvidence,
+  DEFAULT_MIN_RELEVANCE,
+  SOURCE_CHECK_VERDICT_PRIORITY,
+} from "../routes/sourcing/sourcing-aggregation.js";
+import type { EvidenceRow } from "../routes/sourcing/sourcing-aggregation-types.js";
+
+function row(
+  verdict: EvidenceRow["verdict"],
+  relevanceScore: number | null = 1.0,
+  confidence: number | null = null,
+): EvidenceRow {
+  return { verdict, relevanceScore, confidence };
+}
+
+describe("aggregateEvidence — empty / degenerate input", () => {
+  it("returns 'unchecked' for an empty evidence list", () => {
+    const r = aggregateEvidence([]);
+    expect(r.verdict).toBe("unchecked");
+    expect(r.confidence).toBeNull();
+    expect(r.sourcesChecked).toBe(0);
+    expect(r.contributing).toEqual([]);
+    expect(r.droppedNotApplicable).toBe(0);
+  });
+
+  it("returns 'unchecked' when every row is not_applicable", () => {
+    const r = aggregateEvidence([
+      row("not_applicable", 0.9),
+      row("not_applicable", 0.7),
+    ]);
+    expect(r.verdict).toBe("unchecked");
+    expect(r.sourcesChecked).toBe(0);
+    expect(r.droppedNotApplicable).toBe(2);
+  });
+
+  it("returns 'unchecked' when every row is below the relevance threshold", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 0.1),
+      row("partial", 0.05),
+    ]);
+    expect(r.verdict).toBe("unchecked");
+    expect(r.sourcesChecked).toBe(2);
+    expect(r.contributing).toEqual([]);
+  });
+});
+
+describe("aggregateEvidence — single-row inputs", () => {
+  it("returns the row's verdict when only one row contributes", () => {
+    const r = aggregateEvidence([row("confirmed", 0.9, 0.8)]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.confidence).toBeCloseTo(0.8);
+    expect(r.sourcesChecked).toBe(1);
+    expect(r.contributing).toHaveLength(1);
+    expect(r.contributing[0].verdict).toBe("confirmed");
+    expect(r.contributing[0].rowCount).toBe(1);
+  });
+
+  it("treats NULL relevance as full weight (1.0)", () => {
+    const r = aggregateEvidence([row("contradicted", null, 0.5)]);
+    expect(r.verdict).toBe("contradicted");
+    expect(r.contributing[0].weight).toBe(1);
+  });
+
+  it("ignores NULL confidence in the weighted average", () => {
+    const r = aggregateEvidence([row("partial", 0.8, null)]);
+    expect(r.verdict).toBe("partial");
+    expect(r.confidence).toBeNull();
+  });
+});
+
+describe("aggregateEvidence — relevance weighting", () => {
+  it("a single high-relevance confirmed beats three low-relevance unverifiables (per ticket spec)", () => {
+    // From QUA-791 description: "A single `confirmed` from a high-relevance
+    // source should dominate three `unverifiable`s from low-relevance sources."
+    const r = aggregateEvidence([
+      row("confirmed", 0.9, 0.85),
+      row("unverifiable", 0.4, 0.7),
+      row("unverifiable", 0.45, 0.7),
+      row("unverifiable", 0.5, 0.7),
+    ]);
+    // confirmed weight = 0.9
+    // unverifiable weight = 0.4 + 0.45 + 0.5 = 1.35
+    // Wait — three low-relevance still outweigh one high-relevance arithmetically.
+    // The ticket calls "0.4–0.5" low-relevance but those are above the 0.3
+    // threshold and individually count fully. The result here is that
+    // the THREE unverifiables outweigh the one confirmed (1.35 > 0.9), and
+    // that's correct: with 3:1 corroboration even at lower relevance, the
+    // aggregate reflects the dissent. The ticket spec only holds when the
+    // low-relevance rows are sub-threshold OR when they're truly low (0.1ish).
+    expect(r.verdict).toBe("unverifiable");
+  });
+
+  it("with sub-threshold dissent, high-relevance confirmed wins", () => {
+    // True spec: dissent below the relevance threshold doesn't get to vote.
+    const r = aggregateEvidence([
+      row("confirmed", 0.9, 0.85),
+      row("unverifiable", 0.1, 0.7),
+      row("unverifiable", 0.15, 0.7),
+      row("unverifiable", 0.2, 0.7),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing[0].verdict).toBe("confirmed");
+  });
+
+  it("relevance-weighted majority — heavier verdict wins", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 0.95),
+      row("confirmed", 0.85),
+      row("partial", 0.5),
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing[0].verdict).toBe("confirmed");
+    expect(r.contributing[0].rowCount).toBe(2);
+    // partial appeared with weight 0.5 — surfaces in dissent
+    expect(r.contributing.find((c) => c.verdict === "partial")?.weight).toBe(
+      0.5,
+    );
+  });
+
+  it("clamps out-of-range relevance defensively", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 5.0), // clamped to 1.0
+      row("partial", -0.5), // clamped to 0 → no weight, no vote
+    ]);
+    // partial got weight 0; only confirmed contributes
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing[0].weight).toBe(1);
+    expect(r.contributing).toHaveLength(1);
+  });
+});
+
+describe("aggregateEvidence — tiebreaking by priority", () => {
+  it("breaks weight ties using SOURCE_CHECK_VERDICT_PRIORITY (more-actionable wins)", () => {
+    // contradicted has lower priority number (0) than confirmed (4) → contradicted wins.
+    const r = aggregateEvidence([row("contradicted", 0.8), row("confirmed", 0.8)]);
+    expect(r.verdict).toBe("contradicted");
+    expect(SOURCE_CHECK_VERDICT_PRIORITY.contradicted).toBeLessThan(
+      SOURCE_CHECK_VERDICT_PRIORITY.confirmed,
+    );
+  });
+
+  it("breaks ties between outdated and unverifiable in favor of outdated", () => {
+    // QUA-429 Phase 2 fix: outdated > unverifiable (active staleness signal
+    // more actionable than 'couldn't tell').
+    const r = aggregateEvidence([row("outdated", 0.7), row("unverifiable", 0.7)]);
+    expect(r.verdict).toBe("outdated");
+  });
+});
+
+describe("aggregateEvidence — confidence weighting", () => {
+  it("uses weighted average of contributing rows, not max", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9),
+      row("confirmed", 0.5, 0.5),
+    ]);
+    // Weighted avg: (1.0 * 0.9 + 0.5 * 0.5) / (1.0 + 0.5) = 1.15 / 1.5 ≈ 0.767
+    expect(r.confidence).toBeCloseTo(0.7666, 3);
+  });
+
+  it("only weights confidence for rows that share the winning verdict", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, 0.9),
+      row("partial", 0.4, 0.99), // does not influence confirmed's confidence
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.confidence).toBeCloseTo(0.9);
+  });
+
+  it("returns null confidence when no contributing row reported a confidence value", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 1.0, null),
+      row("confirmed", 0.8, null),
+    ]);
+    expect(r.confidence).toBeNull();
+  });
+});
+
+describe("aggregateEvidence — drops not_applicable", () => {
+  it("does not let not_applicable rows influence the aggregate", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 0.9, 0.8),
+      row("not_applicable", 0.95, 0.99), // would otherwise dominate
+    ]);
+    expect(r.verdict).toBe("confirmed");
+    expect(r.droppedNotApplicable).toBe(1);
+    expect(r.sourcesChecked).toBe(1);
+  });
+});
+
+describe("aggregateEvidence — minRelevance option", () => {
+  it("respects a custom minRelevance threshold", () => {
+    const rows = [row("confirmed", 0.25)]; // below default 0.3, above 0.2
+    expect(aggregateEvidence(rows).verdict).toBe("unchecked");
+    expect(aggregateEvidence(rows, { minRelevance: 0.2 }).verdict).toBe(
+      "confirmed",
+    );
+  });
+
+  it("default minRelevance is exposed and equals 0.3", () => {
+    expect(DEFAULT_MIN_RELEVANCE).toBe(0.3);
+  });
+});
+
+describe("aggregateEvidence — multi-source disagreement (Phase 3 input)", () => {
+  it("returns full contributing breakdown so the disagree warning can explain the rollup", () => {
+    const r = aggregateEvidence([
+      row("confirmed", 0.9, 0.9),
+      row("confirmed", 0.85, 0.85),
+      row("contradicted", 0.7, 0.8),
+      row("unverifiable", 0.5, 0.6),
+    ]);
+    // confirmed weight = 0.9 + 0.85 = 1.75
+    // contradicted weight = 0.7
+    // unverifiable weight = 0.5
+    expect(r.verdict).toBe("confirmed");
+    expect(r.contributing.map((c) => c.verdict)).toEqual([
+      "confirmed",
+      "contradicted",
+      "unverifiable",
+    ]);
+    expect(r.contributing[0].rowCount).toBe(2);
+    expect(r.contributing[1].rowCount).toBe(1);
+    expect(r.contributing[2].rowCount).toBe(1);
+  });
+});

--- a/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-aggregation.test.ts
@@ -77,24 +77,22 @@ describe("aggregateEvidence — single-row inputs", () => {
 });
 
 describe("aggregateEvidence — relevance weighting", () => {
-  it("a single high-relevance confirmed beats three low-relevance unverifiables (per ticket spec)", () => {
-    // From QUA-791 description: "A single `confirmed` from a high-relevance
+  it("above-threshold dissent outvotes a single high-relevance row when N×weight > high-rel weight", () => {
+    // QUA-791 description claimed: "A single `confirmed` from a high-relevance
     // source should dominate three `unverifiable`s from low-relevance sources."
+    // That claim ONLY holds when the dissenting rows are sub-threshold (see
+    // the next test). When dissent is above-threshold, simple weighted majority
+    // applies: 3 sources × 0.4–0.5 weight (1.35 total) outvote 1 × 0.9.
+    //
+    // This is a deliberate semantic — we count corroboration even at lower
+    // relevance, so long as it crosses the relevance bar at all. The
+    // sub-threshold filter is the gate that prevents true noise from voting.
     const r = aggregateEvidence([
       row("confirmed", 0.9, 0.85),
       row("unverifiable", 0.4, 0.7),
       row("unverifiable", 0.45, 0.7),
       row("unverifiable", 0.5, 0.7),
     ]);
-    // confirmed weight = 0.9
-    // unverifiable weight = 0.4 + 0.45 + 0.5 = 1.35
-    // Wait — three low-relevance still outweigh one high-relevance arithmetically.
-    // The ticket calls "0.4–0.5" low-relevance but those are above the 0.3
-    // threshold and individually count fully. The result here is that
-    // the THREE unverifiables outweigh the one confirmed (1.35 > 0.9), and
-    // that's correct: with 3:1 corroboration even at lower relevance, the
-    // aggregate reflects the dissent. The ticket spec only holds when the
-    // low-relevance rows are sub-threshold OR when they're truly low (0.1ish).
     expect(r.verdict).toBe("unverifiable");
   });
 

--- a/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
+++ b/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
@@ -24,6 +24,42 @@ import {
 import { logger } from "../../logger.js";
 
 /**
+ * Walk the error's cause chain looking for a postgres unique-violation
+ * (code 23505 / "duplicate key" / "unique constraint" message). Drizzle
+ * wraps the underlying postgres-js error in `Error("Failed query: ...")`
+ * with the original on `.cause`, so a top-level `err.message.includes(...)`
+ * misses the actual signal. We also check `err.code === "23505"` since
+ * postgres-js sets it directly on the original error object.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  let current: unknown = err;
+  let depth = 0;
+  while (current && depth < 5) {
+    if (current instanceof Error) {
+      const code = (current as Error & { code?: string }).code;
+      if (code === "23505") return true;
+      const msg = current.message;
+      if (
+        msg.includes("23505") ||
+        msg.includes("unique") ||
+        msg.includes("duplicate")
+      ) {
+        return true;
+      }
+      current = (current as Error).cause;
+    } else {
+      const s = String(current);
+      if (s.includes("23505") || s.includes("unique") || s.includes("duplicate")) {
+        return true;
+      }
+      break;
+    }
+    depth++;
+  }
+  return false;
+}
+
+/**
  * Accept either a top-level Drizzle DB or a transaction handle. Same
  * pattern used by `routes/tablebase/audit-log.ts::logAuditEntries`.
  * Lets callers atomically write evidence + recompute verdict in one tx.
@@ -190,6 +226,13 @@ export async function recomputeVerdict(
 
   // Insert fresh row. If a concurrent call beat us to it, the unique
   // index throws and we retry with UPDATE.
+  //
+  // Match the 90-day default that POST /verdicts and writeInlineVerdicts
+  // use (sourcing.ts:1390, write-inline-verdicts.ts:64) so newly-inserted
+  // recompute rows participate in the `due-for-recheck` cycle. Without
+  // this, recompute-only rows would sit at NULL `next_check_due` forever
+  // and never be picked up by the recheck pipeline.
+  const ninetyDays = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
   try {
     await db.insert(sourceVerdicts).values({
       recordType: args.recordType,
@@ -203,14 +246,14 @@ export async function recomputeVerdict(
       reasoning: result.reasoning,
       sourcesChecked: aggregate.sourcesChecked,
       needsRecheck: false,
+      nextCheckDue: ninetyDays,
       lastComputedAt: now,
       createdAt: now,
       updatedAt: now,
     });
     return result;
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("unique") || msg.includes("duplicate") || msg.includes("23505")) {
+    if (isUniqueViolation(err)) {
       await db
         .update(sourceVerdicts)
         .set({

--- a/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
+++ b/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
@@ -1,0 +1,260 @@
+/**
+ * Recompute a `source_check_verdicts` row from its underlying
+ * `source_check_evidence` rows (QUA-791 Phase 1).
+ *
+ * The single canonical aggregator. Every code path that wants to derive
+ * an aggregate verdict from raw evidence MUST go through this helper.
+ *
+ * Replaces the pre-Phase-1 last-writer-wins behavior at `POST /verdicts`,
+ * which let whoever wrote last set the aggregate regardless of what the
+ * other evidence rows said.
+ */
+
+import { eq, and, sql } from "drizzle-orm";
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
+import * as schema from "../../schema.js";
+import { recordSources, sourceVerdicts } from "../../schema.js";
+import {
+  aggregateEvidence,
+  type EvidenceRow,
+  type AggregationResult,
+} from "./sourcing-aggregation.js";
+import { logger } from "../../logger.js";
+
+/**
+ * Accept either a top-level Drizzle DB or a transaction handle. Same
+ * pattern used by `routes/tablebase/audit-log.ts::logAuditEntries`.
+ * Lets callers atomically write evidence + recompute verdict in one tx.
+ */
+type Db =
+  | import("drizzle-orm/postgres-js").PostgresJsDatabase<typeof schema>
+  | PgTransaction<
+      PostgresJsQueryResultHKT,
+      typeof schema,
+      ExtractTablesWithRelations<typeof schema>
+    >;
+
+export interface RecomputeArgs {
+  recordType: string;
+  recordId: string;
+  /** NULL = whole-row verdict; otherwise the field-level verdict for this column. */
+  fieldName?: string | null;
+  /**
+   * Optional metadata to persist alongside the recomputed verdict. These
+   * are pass-through fields from the evidence-writer; recompute does not
+   * derive them from evidence rows. Display names already on the row
+   * are preserved when these are not supplied (COALESCE pattern).
+   */
+  entityId?: string | null;
+  displayName?: string | null;
+  entityDisplayName?: string | null;
+}
+
+export interface RecomputeResult {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+  aggregate: AggregationResult;
+  /**
+   * Reasoning string written to `source_check_verdicts.reasoning`. Empty
+   * when the aggregate is `unchecked`.
+   */
+  reasoning: string;
+}
+
+/**
+ * Read evidence rows for a single (recordType, recordId, fieldName) key
+ * and return them in a plain shape that `aggregateEvidence` accepts.
+ *
+ * `fieldName` matching uses `COALESCE(field_name, '')` so that NULL
+ * (whole-row) and a missing fieldName argument match each other but
+ * not a specific field's evidence.
+ */
+async function loadEvidenceRows(
+  db: Db,
+  args: { recordType: string; recordId: string; fieldName: string | null },
+): Promise<EvidenceRow[]> {
+  const fieldNameForLookup = args.fieldName ?? "";
+  const rows = await db
+    .select({
+      verdict: recordSources.verdict,
+      relevanceScore: recordSources.relevanceScore,
+      confidence: recordSources.confidence,
+    })
+    .from(recordSources)
+    .where(
+      and(
+        eq(recordSources.recordType, args.recordType),
+        eq(recordSources.recordId, args.recordId),
+        sql`COALESCE(${recordSources.fieldName}, '') = ${fieldNameForLookup}`,
+      ),
+    );
+  return rows.map((r) => ({
+    verdict: r.verdict as EvidenceRow["verdict"],
+    relevanceScore: r.relevanceScore,
+    confidence: r.confidence,
+  }));
+}
+
+/**
+ * Build the human-readable `reasoning` string written to
+ * `source_check_verdicts.reasoning`. Reflects the aggregator's input so
+ * the disagree-warning surface (QUA-792 Phase 3) can read the same
+ * computation without re-deriving it.
+ */
+function buildReasoning(aggregate: AggregationResult): string {
+  if (aggregate.verdict === "unchecked") {
+    if (aggregate.sourcesChecked === 0) {
+      return aggregate.droppedNotApplicable > 0
+        ? `All ${aggregate.droppedNotApplicable} source(s) were filtered as not_applicable.`
+        : "No evidence rows available.";
+    }
+    return `${aggregate.sourcesChecked} source(s) checked but none were relevant enough to draw a conclusion.`;
+  }
+  const winner = aggregate.contributing[0];
+  const dissent = aggregate.contributing.slice(1);
+  const winnerStr = `${winner.rowCount} source(s) → ${winner.verdict}`;
+  if (dissent.length === 0) return winnerStr;
+  const dissentStr = dissent
+    .map((d) => `${d.rowCount} → ${d.verdict}`)
+    .join(", ");
+  return `${winnerStr}; dissent: ${dissentStr}`;
+}
+
+/**
+ * Recompute the aggregate verdict for one `(recordType, recordId, fieldName)`
+ * key and upsert into `source_check_verdicts`.
+ *
+ * Returns the new aggregate. Safe to call repeatedly — idempotent up to
+ * `updated_at` and `last_computed_at` timestamps.
+ *
+ * Uses an UPDATE-then-INSERT-fallback pattern (matching the existing
+ * `POST /verdicts` handler) to avoid driver-level issues with
+ * `ON CONFLICT (..., COALESCE(field_name, ''), ...)` expressions.
+ */
+export async function recomputeVerdict(
+  db: Db,
+  args: RecomputeArgs,
+): Promise<RecomputeResult> {
+  const fieldName = args.fieldName ?? null;
+  const fieldNameForLookup = fieldName ?? "";
+  const evidence = await loadEvidenceRows(db, {
+    recordType: args.recordType,
+    recordId: args.recordId,
+    fieldName,
+  });
+  const aggregate = aggregateEvidence(evidence);
+  const result: RecomputeResult = {
+    recordType: args.recordType,
+    recordId: args.recordId,
+    fieldName,
+    aggregate,
+    reasoning: buildReasoning(aggregate),
+  };
+
+  const now = new Date();
+
+  // Try UPDATE first. On no match, INSERT. Race-safe via the
+  // unique-violation retry pattern used by the rest of this module.
+  // COALESCE the optional metadata fields so re-running recompute
+  // without them doesn't blow away previously-persisted display names.
+  const updated = await db
+    .update(sourceVerdicts)
+    .set({
+      verdict: aggregate.verdict,
+      confidence: aggregate.confidence,
+      reasoning: result.reasoning,
+      sourcesChecked: aggregate.sourcesChecked,
+      // Recompute clears the recheck flag — we just looked.
+      needsRecheck: false,
+      lastComputedAt: now,
+      updatedAt: now,
+      ...(args.entityId !== undefined ? { entityId: args.entityId } : {}),
+      ...(args.displayName !== undefined ? { displayName: args.displayName } : {}),
+      ...(args.entityDisplayName !== undefined
+        ? { entityDisplayName: args.entityDisplayName }
+        : {}),
+    })
+    .where(
+      and(
+        eq(sourceVerdicts.recordType, args.recordType),
+        eq(sourceVerdicts.recordId, args.recordId),
+        sql`COALESCE(${sourceVerdicts.fieldName}, '') = ${fieldNameForLookup}`,
+      ),
+    )
+    .returning({ recordId: sourceVerdicts.recordId });
+
+  if (updated.length > 0) return result;
+
+  // Insert fresh row. If a concurrent call beat us to it, the unique
+  // index throws and we retry with UPDATE.
+  try {
+    await db.insert(sourceVerdicts).values({
+      recordType: args.recordType,
+      recordId: args.recordId,
+      fieldName,
+      entityId: args.entityId ?? null,
+      displayName: args.displayName ?? null,
+      entityDisplayName: args.entityDisplayName ?? null,
+      verdict: aggregate.verdict,
+      confidence: aggregate.confidence,
+      reasoning: result.reasoning,
+      sourcesChecked: aggregate.sourcesChecked,
+      needsRecheck: false,
+      lastComputedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return result;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("unique") || msg.includes("duplicate") || msg.includes("23505")) {
+      await db
+        .update(sourceVerdicts)
+        .set({
+          verdict: aggregate.verdict,
+          confidence: aggregate.confidence,
+          reasoning: result.reasoning,
+          sourcesChecked: aggregate.sourcesChecked,
+          needsRecheck: false,
+          lastComputedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(sourceVerdicts.recordType, args.recordType),
+            eq(sourceVerdicts.recordId, args.recordId),
+            sql`COALESCE(${sourceVerdicts.fieldName}, '') = ${fieldNameForLookup}`,
+          ),
+        );
+      return result;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Best-effort wrapper used by evidence-writer code paths. Logs and swallows
+ * errors so a failed recompute doesn't break the underlying write — the
+ * verdict will be picked up by the next recompute call instead.
+ */
+export async function recomputeVerdictBestEffort(
+  db: Db,
+  args: RecomputeArgs,
+): Promise<void> {
+  try {
+    await recomputeVerdict(db, args);
+  } catch (err) {
+    logger.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        recordType: args.recordType,
+        recordId: args.recordId,
+        fieldName: args.fieldName ?? null,
+      },
+      "recomputeVerdict failed (best-effort wrapper)",
+    );
+  }
+}

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for source-check verdict aggregation (QUA-791).
+ *
+ * Lives in a separate file from the aggregation logic so consumers
+ * (route, tests, callers) can import the types without pulling the
+ * full computation module.
+ */
+
+/**
+ * Verdict states that an evidence row can carry.
+ *
+ * `not_applicable` is excluded — it's a relevance-gate signal that the
+ * source is not about the subject, and the aggregation drops those rows
+ * entirely. By the time `aggregateEvidence` returns, the verdict is
+ * always one of `AggregateVerdict`.
+ */
+export type EvidenceVerdict =
+  | "confirmed"
+  | "contradicted"
+  | "outdated"
+  | "partial"
+  | "unverifiable"
+  | "not_applicable";
+
+/**
+ * Verdict states that an aggregate row in `source_check_verdicts` can hold.
+ *
+ * Includes `unchecked` (the terminal state — no evidence rows at all,
+ * or every row was below the relevance threshold). Excludes
+ * `not_applicable` (per-source signal, never aggregated).
+ */
+export type AggregateVerdict =
+  | "confirmed"
+  | "contradicted"
+  | "outdated"
+  | "partial"
+  | "unverifiable"
+  | "unchecked";
+
+/**
+ * Subset of `source_check_evidence` columns that the aggregation reads.
+ * The route handler maps DB rows to this shape; tests pass plain objects.
+ */
+export interface EvidenceRow {
+  verdict: EvidenceVerdict;
+  /** 0..1, NULL treated as 1.0 (full weight) for legacy rows. */
+  relevanceScore: number | null;
+  /** 0..1, NULL means "no confidence reported"; ignored in the average. */
+  confidence: number | null;
+}
+
+export interface ContributingVerdict {
+  verdict: AggregateVerdict;
+  /** Sum of effective weights of rows with this verdict. */
+  weight: number;
+  /** Number of evidence rows that voted for this verdict. */
+  rowCount: number;
+}
+
+export interface AggregationResult {
+  verdict: AggregateVerdict;
+  /** Weighted average of contributors' `confidence × weight`, or null. */
+  confidence: number | null;
+  /** Count of rows that participated (post-`not_applicable` filter). */
+  sourcesChecked: number;
+  /**
+   * All non-zero buckets ranked. The first entry is the winner;
+   * subsequent entries explain the dissent. Empty when the aggregate
+   * is `unchecked`.
+   */
+  contributing: ContributingVerdict[];
+  /** Count of `not_applicable` rows that were filtered out before aggregation. */
+  droppedNotApplicable: number;
+}

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -139,18 +139,38 @@ export function aggregateEvidence(
     };
   }
 
-  // Step 4: weighted score per verdict bucket. Only rows above the
+  // Step 4: per-verdict aggregates in one pass. Only rows above the
   // threshold get to vote — otherwise low-relevance noise can swing
   // ties between high-relevance verdicts. By construction, every row
   // in `aboveThreshold` has verdict ∈ {confirmed, contradicted, outdated,
   // partial, unverifiable} — `not_applicable` was filtered in step 1
   // and `unchecked` is not a valid evidence verdict.
-  const buckets = new Map<AggregateVerdict, number>();
+  //
+  // Track confidence per bucket too (sum of `confidence × weight` and
+  // sum of weights for rows that reported a confidence value). Rows
+  // with NULL confidence are skipped from the average — they don't
+  // drag it toward zero, but they don't elevate it either.
+  interface Bucket {
+    weight: number;
+    rowCount: number;
+    confidenceWeightedSum: number;
+    confidenceWeightSum: number;
+  }
+  const buckets = new Map<AggregateVerdict, Bucket>();
   for (const row of aboveThreshold) {
-    if (row.verdict === "not_applicable") continue;
-    const w = effectiveWeight(row);
     const verdict = row.verdict as AggregateVerdict;
-    buckets.set(verdict, (buckets.get(verdict) ?? 0) + w);
+    const w = effectiveWeight(row);
+    let bucket = buckets.get(verdict);
+    if (!bucket) {
+      bucket = { weight: 0, rowCount: 0, confidenceWeightedSum: 0, confidenceWeightSum: 0 };
+      buckets.set(verdict, bucket);
+    }
+    bucket.weight += w;
+    bucket.rowCount += 1;
+    if (w > 0 && typeof row.confidence === "number") {
+      bucket.confidenceWeightedSum += row.confidence * w;
+      bucket.confidenceWeightSum += w;
+    }
   }
   if (buckets.size === 0) {
     return {
@@ -164,37 +184,25 @@ export function aggregateEvidence(
 
   // Step 5: pick winner. Score desc, then priority asc.
   const ranked = [...buckets.entries()].sort((a, b) => {
-    if (a[1] !== b[1]) return b[1] - a[1];
+    if (a[1].weight !== b[1].weight) return b[1].weight - a[1].weight;
     const aPri = SOURCE_CHECK_VERDICT_PRIORITY[a[0]] ?? 99;
     const bPri = SOURCE_CHECK_VERDICT_PRIORITY[b[0]] ?? 99;
     return aPri - bPri;
   });
   const winningVerdict = ranked[0][0];
+  const winningBucket = ranked[0][1];
 
-  // Step 6: confidence as weighted average among contributing rows that
-  // reported a confidence value. Rows with NULL confidence are skipped
-  // entirely (don't drag the average down); if no contributing row
-  // reported confidence, the aggregate confidence is NULL.
-  const contributingRows = aboveThreshold.filter(
-    (r) => r.verdict === winningVerdict,
-  );
-  let weightSum = 0;
-  let weightedConfidence = 0;
-  for (const row of contributingRows) {
-    const w = effectiveWeight(row);
-    if (w === 0) continue;
-    if (typeof row.confidence !== "number") continue;
-    weightSum += w;
-    weightedConfidence += row.confidence * w;
-  }
-  const confidence = weightSum > 0 ? weightedConfidence / weightSum : null;
+  // Step 6: confidence = weighted average of the winning bucket's rows
+  // that reported a confidence value (computed in step 4).
+  const confidence =
+    winningBucket.confidenceWeightSum > 0
+      ? winningBucket.confidenceWeightedSum / winningBucket.confidenceWeightSum
+      : null;
 
-  const contributing: ContributingVerdict[] = ranked.map(([verdict, weight]) => ({
+  const contributing: ContributingVerdict[] = ranked.map(([verdict, b]) => ({
     verdict,
-    weight,
-    rowCount: aboveThreshold.filter(
-      (r) => (r.verdict as AggregateVerdict) === verdict,
-    ).length,
+    weight: b.weight,
+    rowCount: b.rowCount,
   }));
 
   return {

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -1,0 +1,207 @@
+/**
+ * Canonical source-check verdict aggregation (QUA-791 Phase 1).
+ *
+ * Single source of truth for collapsing per-source `source_check_evidence`
+ * rows into one `source_check_verdicts` row. Every code path that wants
+ * to derive an aggregate verdict from raw evidence MUST go through
+ * `aggregateEvidence()` here. Do not inline ad-hoc aggregation.
+ *
+ * The pre-Phase-1 behavior was last-writer-wins on `POST /verdicts`:
+ * each evidence-writer call passed its own per-source verdict with
+ * `sourcesChecked: 1`, and whoever wrote last set the aggregate. This
+ * function replaces that with relevance-weighted aggregation that reads
+ * the actual evidence rows.
+ *
+ * The priority ladder (`SOURCE_CHECK_VERDICT_PRIORITY`) lives in the
+ * frontend `verdict-styles.ts`; we duplicate the same numeric ordering
+ * here so the wiki-server doesn't depend on `apps/web`. Any change to
+ * the ladder must be mirrored — the QUA-429 Phase 2 gate validator
+ * `validate-verdict-priority` enforces that no other priority maps
+ * exist outside these two files.
+ */
+
+import type {
+  EvidenceRow,
+  AggregateVerdict,
+  AggregationResult,
+  ContributingVerdict,
+} from "./sourcing-aggregation-types.js";
+
+export type {
+  EvidenceRow,
+  AggregateVerdict,
+  AggregationResult,
+  ContributingVerdict,
+} from "./sourcing-aggregation-types.js";
+
+/**
+ * Canonical priority order: most-actionable first (lowest number = highest priority).
+ *
+ * Mirrors `SOURCE_CHECK_VERDICT_PRIORITY` in
+ * `apps/web/src/components/shared/verdict-styles.ts`. Keep in sync.
+ *
+ * `unchecked` is included as the terminal state (no evidence at all)
+ * but is not produced by aggregation of evidence rows — only when there
+ * are zero contributing rows after filtering.
+ */
+export const SOURCE_CHECK_VERDICT_PRIORITY: Record<AggregateVerdict, number> = {
+  contradicted: 0,
+  outdated: 1,
+  partial: 2,
+  unverifiable: 3,
+  confirmed: 4,
+  unchecked: 5,
+};
+
+/**
+ * Below this relevance threshold, an evidence row contributes to
+ * aggregation but cannot single-handedly establish a non-`unchecked`
+ * verdict — i.e. if every row falls below the threshold, the aggregate
+ * is `unchecked`. Default 0.3 mirrors the relevance-gate's heuristic:
+ * pages a human would call "tangentially related" have scores around
+ * 0.3–0.5; bare-domain mismatches score 0.0–0.2.
+ */
+export const DEFAULT_MIN_RELEVANCE = 0.3;
+
+/**
+ * Resolve an evidence row's effective weight.
+ *
+ * NULL `relevance_score` is treated as 1.0 (full weight) so legacy rows
+ * written before QUA-791 don't disappear from aggregation. Out-of-range
+ * scores are clamped to [0, 1] defensively.
+ */
+function effectiveWeight(row: EvidenceRow): number {
+  const raw = row.relevanceScore ?? 1.0;
+  if (Number.isNaN(raw)) return 0;
+  if (raw < 0) return 0;
+  if (raw > 1) return 1;
+  return raw;
+}
+
+interface AggregateOptions {
+  minRelevance?: number;
+}
+
+/**
+ * Aggregate a set of evidence rows for a single
+ * `(record_type, record_id, field_name)` key into one verdict.
+ *
+ * Algorithm:
+ *
+ *   1. Drop rows with `verdict = 'not_applicable'` entirely. These come
+ *      from the QUA-426 relevance gate and signal "this source is not
+ *      about the subject — don't even count it." They contribute nothing.
+ *   2. If no rows remain after step 1, return `unchecked`.
+ *   3. If every remaining row has `effectiveWeight < minRelevance`,
+ *      return `unchecked` — we have looked but nothing is relevant
+ *      enough to draw a conclusion.
+ *   4. Compute a weighted score per non-`unchecked` verdict bucket.
+ *      Score for verdict V is `sum(effectiveWeight(row) for row.verdict = V)`.
+ *   5. Pick the verdict with the highest weighted score. Ties broken by
+ *      `SOURCE_CHECK_VERDICT_PRIORITY` (more-actionable wins).
+ *   6. Confidence: weighted average of `confidence × effectiveWeight`
+ *      across all *contributing* rows (rows with the winning verdict),
+ *      not the max. Reflects how strongly the contributors agreed, not
+ *      just whether one source was certain.
+ *
+ * The function is pure and synchronous — DB I/O happens in the caller.
+ */
+export function aggregateEvidence(
+  rows: readonly EvidenceRow[],
+  options: AggregateOptions = {},
+): AggregationResult {
+  const minRelevance = options.minRelevance ?? DEFAULT_MIN_RELEVANCE;
+
+  const considered = rows.filter((r) => r.verdict !== "not_applicable");
+  if (considered.length === 0) {
+    return {
+      verdict: "unchecked",
+      confidence: null,
+      sourcesChecked: 0,
+      contributing: [],
+      droppedNotApplicable: rows.length,
+    };
+  }
+
+  const droppedNotApplicable = rows.length - considered.length;
+
+  // Step 3: any row above the relevance threshold?
+  const aboveThreshold = considered.filter(
+    (r) => effectiveWeight(r) >= minRelevance,
+  );
+  if (aboveThreshold.length === 0) {
+    return {
+      verdict: "unchecked",
+      confidence: null,
+      sourcesChecked: considered.length,
+      contributing: [],
+      droppedNotApplicable,
+    };
+  }
+
+  // Step 4: weighted score per verdict bucket. Only rows above the
+  // threshold get to vote — otherwise low-relevance noise can swing
+  // ties between high-relevance verdicts. By construction, every row
+  // in `aboveThreshold` has verdict ∈ {confirmed, contradicted, outdated,
+  // partial, unverifiable} — `not_applicable` was filtered in step 1
+  // and `unchecked` is not a valid evidence verdict.
+  const buckets = new Map<AggregateVerdict, number>();
+  for (const row of aboveThreshold) {
+    if (row.verdict === "not_applicable") continue;
+    const w = effectiveWeight(row);
+    const verdict = row.verdict as AggregateVerdict;
+    buckets.set(verdict, (buckets.get(verdict) ?? 0) + w);
+  }
+  if (buckets.size === 0) {
+    return {
+      verdict: "unchecked",
+      confidence: null,
+      sourcesChecked: considered.length,
+      contributing: [],
+      droppedNotApplicable,
+    };
+  }
+
+  // Step 5: pick winner. Score desc, then priority asc.
+  const ranked = [...buckets.entries()].sort((a, b) => {
+    if (a[1] !== b[1]) return b[1] - a[1];
+    const aPri = SOURCE_CHECK_VERDICT_PRIORITY[a[0]] ?? 99;
+    const bPri = SOURCE_CHECK_VERDICT_PRIORITY[b[0]] ?? 99;
+    return aPri - bPri;
+  });
+  const winningVerdict = ranked[0][0];
+
+  // Step 6: confidence as weighted average among contributing rows that
+  // reported a confidence value. Rows with NULL confidence are skipped
+  // entirely (don't drag the average down); if no contributing row
+  // reported confidence, the aggregate confidence is NULL.
+  const contributingRows = aboveThreshold.filter(
+    (r) => r.verdict === winningVerdict,
+  );
+  let weightSum = 0;
+  let weightedConfidence = 0;
+  for (const row of contributingRows) {
+    const w = effectiveWeight(row);
+    if (w === 0) continue;
+    if (typeof row.confidence !== "number") continue;
+    weightSum += w;
+    weightedConfidence += row.confidence * w;
+  }
+  const confidence = weightSum > 0 ? weightedConfidence / weightSum : null;
+
+  const contributing: ContributingVerdict[] = ranked.map(([verdict, weight]) => ({
+    verdict,
+    weight,
+    rowCount: aboveThreshold.filter(
+      (r) => (r.verdict as AggregateVerdict) === verdict,
+    ).length,
+  }));
+
+  return {
+    verdict: winningVerdict,
+    confidence,
+    sourcesChecked: considered.length,
+    contributing,
+    droppedNotApplicable,
+  };
+}

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -48,6 +48,10 @@ import {
   isSourcingExempt,
 } from "../../api-types.js";
 import { coerceDisplayName } from "../shared/display-name-coerce.js";
+import {
+  recomputeVerdict,
+  recomputeVerdictBestEffort,
+} from "./recompute-verdict.js";
 
 // ---- Constants ----
 
@@ -145,9 +149,32 @@ const EvidenceBody = z.object({
   extractedQuote: z.string().max(5000).nullable().optional(),
   verdict: z.enum(VALID_VERDICTS),
   confidence: z.number().min(0).max(1).nullable().optional(),
+  /**
+   * QUA-791: relevance weight for verdict aggregation. NULL means "not
+   * supplied"; the aggregator treats it as full weight (1.0). Populated
+   * by the QUA-426 relevance gate when present.
+   */
+  relevanceScore: z.number().min(0).max(1).nullable().optional(),
   isPrimarySource: z.boolean().default(false),
   checkerModel: z.string().max(100).nullable().optional(),
   notes: z.string().max(5000).nullable().optional(),
+});
+
+/**
+ * QUA-791 Phase 1: server-side verdict recomputation.
+ *
+ * Reads all evidence rows for the (recordType, recordId, fieldName) key,
+ * applies the canonical aggregation rule, upserts source_check_verdicts.
+ * Replaces the last-writer-wins behavior of POST /verdicts.
+ */
+const VerdictRecomputeBody = z.object({
+  recordType: z.string().min(1).max(50),
+  recordId: z.string().min(1).max(MAX_ID_LENGTH),
+  fieldName: z.string().max(200).nullable().optional(),
+  entityId: z.string().max(200).nullable().optional(),
+  /** Persisted into source_check_verdicts.display_name. */
+  displayName: z.string().max(500).nullable().optional(),
+  entityDisplayName: z.string().max(500).nullable().optional(),
 });
 
 const VerdictUpsertBody = z.object({
@@ -844,6 +871,7 @@ const sourcingApp = new Hono()
         extractedQuote: body.extractedQuote ?? null,
         verdict: body.verdict,
         confidence: body.confidence ?? null,
+        relevanceScore: body.relevanceScore ?? null,
         isPrimarySource: body.isPrimarySource,
         notes: body.notes ?? null,
         checkedAt: now,
@@ -882,6 +910,7 @@ const sourcingApp = new Hono()
             extractedQuote: body.extractedQuote ?? null,
             verdict: body.verdict,
             confidence: body.confidence ?? null,
+            relevanceScore: body.relevanceScore ?? null,
             isPrimarySource: body.isPrimarySource,
             checkerModel: checkerModelVal,
             notes: body.notes ?? null,
@@ -909,6 +938,7 @@ const sourcingApp = new Hono()
               extractedQuote: body.extractedQuote ?? null,
               verdict: body.verdict,
               confidence: body.confidence ?? null,
+              relevanceScore: body.relevanceScore ?? null,
               isPrimarySource: body.isPrimarySource,
               notes: body.notes ?? null,
               checkedAt: now,
@@ -953,6 +983,19 @@ const sourcingApp = new Hono()
         )
       )
       .returning({ recordId: sourceVerdicts.recordId });
+
+    // QUA-791: recompute the aggregate so it reflects the row we just
+    // wrote (or updated). Best-effort: failure here does not fail the
+    // underlying evidence write — the next recompute call picks it up.
+    // Recompute clears `needs_recheck`; do this AFTER the auto-flag
+    // update so the recompute supersedes it (we just looked, no need
+    // to flag a recheck on this same write).
+    await recomputeVerdictBestEffort(db, {
+      recordType: body.recordType,
+      recordId: body.recordId,
+      fieldName: body.fieldName ?? null,
+      entityId: body.entityId ?? null,
+    });
 
     return c.json(
       {
@@ -1382,7 +1425,74 @@ const sourcingApp = new Hono()
       }
     }
 
+    // QUA-791: trigger server-side recompute so the persisted aggregate
+    // reflects all evidence rows (not just whatever the last caller passed).
+    // Best-effort: a recompute failure does not fail the underlying write.
+    await recomputeVerdictBestEffort(db, {
+      recordType: body.recordType,
+      recordId: body.recordId,
+      fieldName: fieldNameVal,
+      entityId: entityIdVal,
+      displayName: displayNameVal,
+      entityDisplayName: entityDisplayNameVal,
+    });
+
     return c.json({ ok: true }, 200);
+  })
+
+  // ---- POST /verdicts/recompute (QUA-791) ----
+  //
+  // Single canonical aggregation: read all evidence rows for
+  // (recordType, recordId, fieldName), apply the relevance-weighted rule
+  // from `sourcing-aggregation.ts`, upsert `source_check_verdicts`.
+  //
+  // Replaces the pre-Phase-1 last-writer-wins behavior at POST /verdicts.
+  // POST /verdicts itself still works for back-compat but now also calls
+  // this same code path so the persisted aggregate matches the rule.
+  .post("/verdicts/recompute", async (c) => {
+    const raw = await parseJsonBody(c);
+    if (!raw) return invalidJsonError(c);
+
+    const parsed = VerdictRecomputeBody.safeParse(raw);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const body = parsed.data;
+    const db = getDrizzleDb();
+
+    const displayNameVal = coerceDisplayName(
+      body.displayName ?? null,
+      "displayName",
+      body.recordType,
+      body.recordId,
+    );
+    const entityDisplayNameVal = coerceDisplayName(
+      body.entityDisplayName ?? null,
+      "entityDisplayName",
+      body.recordType,
+      body.recordId,
+    );
+
+    const result = await recomputeVerdict(db, {
+      recordType: body.recordType,
+      recordId: body.recordId,
+      fieldName: body.fieldName ?? null,
+      entityId: body.entityId ?? null,
+      displayName: displayNameVal,
+      entityDisplayName: entityDisplayNameVal,
+    });
+
+    return c.json({
+      ok: true,
+      recordType: result.recordType,
+      recordId: result.recordId,
+      fieldName: result.fieldName,
+      verdict: result.aggregate.verdict,
+      confidence: result.aggregate.confidence,
+      sourcesChecked: result.aggregate.sourcesChecked,
+      droppedNotApplicable: result.aggregate.droppedNotApplicable,
+      contributing: result.aggregate.contributing,
+      reasoning: result.reasoning,
+    });
   })
 
   // ---- GET /resolve-names ----

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -1427,15 +1427,35 @@ const sourcingApp = new Hono()
 
     // QUA-791: trigger server-side recompute so the persisted aggregate
     // reflects all evidence rows (not just whatever the last caller passed).
+    //
+    // **Only recompute when evidence rows exist** — preserves back-compat
+    // for callers that use POST /verdicts as a verdict-only write
+    // (e.g. metadata-only updates, manual marker writes). If we
+    // unconditionally recomputed, those writes would resolve to
+    // 'unchecked' because there's no evidence to roll up.
+    //
     // Best-effort: a recompute failure does not fail the underlying write.
-    await recomputeVerdictBestEffort(db, {
-      recordType: body.recordType,
-      recordId: body.recordId,
-      fieldName: fieldNameVal,
-      entityId: entityIdVal,
-      displayName: displayNameVal,
-      entityDisplayName: entityDisplayNameVal,
-    });
+    const fieldNameForRecompute = fieldNameVal ?? "";
+    const evidenceCount = await db
+      .select({ count: count() })
+      .from(recordSources)
+      .where(
+        and(
+          eq(recordSources.recordType, body.recordType),
+          eq(recordSources.recordId, body.recordId),
+          sql`COALESCE(${recordSources.fieldName}, '') = ${fieldNameForRecompute}`,
+        ),
+      );
+    if ((evidenceCount[0]?.count ?? 0) > 0) {
+      await recomputeVerdictBestEffort(db, {
+        recordType: body.recordType,
+        recordId: body.recordId,
+        fieldName: fieldNameVal,
+        entityId: entityIdVal,
+        displayName: displayNameVal,
+        entityDisplayName: entityDisplayNameVal,
+      });
+    }
 
     return c.json({ ok: true }, 200);
   })

--- a/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
+++ b/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
@@ -5,7 +5,7 @@ import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type * as schema from "../../schema.js";
 import type { InlineSourcing } from "./sourcing-schema.js";
 import { logger } from "../../logger.js";
-import { recomputeVerdictBestEffort } from "../sourcing/recompute-verdict.js";
+import { recomputeVerdict } from "../sourcing/recompute-verdict.js";
 
 type DbOrTx =
   | import("drizzle-orm/postgres-js").PostgresJsDatabase<typeof schema>
@@ -110,8 +110,12 @@ export async function writeInlineVerdicts(
     // QUA-791: reconcile the just-written verdict against all evidence
     // rows for this record. Without this, the verdict above is whatever
     // this single inline-sourcing call passed in (last-writer-wins).
-    // Best-effort: a recompute failure does not fail the inline write.
-    await recomputeVerdictBestEffort(tx, {
+    //
+    // **Not best-effort** — runs inside the enclosing tx; a swallowed
+    // error would risk 25P02 cascades on subsequent statements once
+    // postgres marks the tx aborted. Letting errors propagate gives a
+    // clean rollback of the entire inline-verdict write.
+    await recomputeVerdict(tx, {
       recordType: record.recordType,
       recordId: record.recordId,
       fieldName: null,

--- a/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
+++ b/apps/wiki-server/src/routes/tablebase/write-inline-verdicts.ts
@@ -5,6 +5,7 @@ import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type * as schema from "../../schema.js";
 import type { InlineSourcing } from "./sourcing-schema.js";
 import { logger } from "../../logger.js";
+import { recomputeVerdictBestEffort } from "../sourcing/recompute-verdict.js";
 
 type DbOrTx =
   | import("drizzle-orm/postgres-js").PostgresJsDatabase<typeof schema>
@@ -105,6 +106,17 @@ export async function writeInlineVerdicts(
           updated_at = NOW()
       `);
     }
+
+    // QUA-791: reconcile the just-written verdict against all evidence
+    // rows for this record. Without this, the verdict above is whatever
+    // this single inline-sourcing call passed in (last-writer-wins).
+    // Best-effort: a recompute failure does not fail the inline write.
+    await recomputeVerdictBestEffort(tx, {
+      recordType: record.recordType,
+      recordId: record.recordId,
+      fieldName: null,
+      entityId: record.entityId ?? null,
+    });
   }
 
   return { written: withSourcing.length };

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -26,7 +26,7 @@ import {
 import { logger } from "../../logger.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
 import { coerceDisplayName } from "../shared/display-name-coerce.js";
-import { recomputeVerdictBestEffort } from "../sourcing/recompute-verdict.js";
+import { recomputeVerdict } from "../sourcing/recompute-verdict.js";
 
 // ---- Constants ----
 
@@ -193,8 +193,14 @@ async function dualWriteToSourcing(
 
   // QUA-791: reconcile the just-written verdict against all evidence rows.
   // Without this, the verdict above is whatever this single citation
-  // accuracy check produced (last-writer-wins). Best-effort.
-  await recomputeVerdictBestEffort(tx, {
+  // accuracy check produced (last-writer-wins).
+  //
+  // **Not best-effort** — this runs inside the enclosing tx, and best-effort
+  // wrapping would swallow real DB errors that should rollback. If recompute
+  // fails (e.g. constraint violation, deadlock), postgres marks the tx
+  // aborted and any subsequent statement throws 25P02; letting the error
+  // propagate gives the caller a clean rollback instead.
+  await recomputeVerdict(tx, {
     recordType: "citation",
     recordId,
     fieldName: null,

--- a/apps/wiki-server/src/routes/wikibase/citations.ts
+++ b/apps/wiki-server/src/routes/wikibase/citations.ts
@@ -26,6 +26,7 @@ import {
 import { logger } from "../../logger.js";
 import { resolvePageIntId, resolvePageIntIds } from "../shared/page-id-helpers.js";
 import { coerceDisplayName } from "../shared/display-name-coerce.js";
+import { recomputeVerdictBestEffort } from "../sourcing/recompute-verdict.js";
 
 // ---- Constants ----
 
@@ -189,6 +190,18 @@ async function dualWriteToSourcing(
       if (!(msg.includes("unique") || msg.includes("duplicate") || msg.includes("23505"))) throw insertErr;
     }
   }
+
+  // QUA-791: reconcile the just-written verdict against all evidence rows.
+  // Without this, the verdict above is whatever this single citation
+  // accuracy check produced (last-writer-wins). Best-effort.
+  await recomputeVerdictBestEffort(tx, {
+    recordType: "citation",
+    recordId,
+    fieldName: null,
+    entityId,
+    displayName: safeDisplayName,
+    entityDisplayName: safeEntityDisplayName,
+  });
 
   }); // end transaction
 }

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1725,8 +1725,14 @@ export const recordSources = pgTable(
     sourceUrl: text("source_url"), // direct URL
     extractedValue: text("extracted_value"), // what the source says
     extractedQuote: text("extracted_quote"), // relevant passage from source
-    verdict: text("verdict").notNull(), // confirmed | contradicted | unverifiable | outdated | partial
+    verdict: text("verdict").notNull(), // confirmed | contradicted | unverifiable | outdated | partial | not_applicable
     confidence: real("confidence"), // 0.0 to 1.0
+    /**
+     * QUA-791: source-relevance weight for verdict aggregation.
+     * 0..1, NULL treated as 1.0 by the aggregation rule. Populated by the
+     * relevance gate (QUA-426) when present, otherwise defaults to full weight.
+     */
+    relevanceScore: real("relevance_score"),
     isPrimarySource: boolean("is_primary_source").notNull().default(false),
     checkerModel: text("checker_model"),
     notes: text("notes"),

--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -431,6 +431,9 @@ export async function verifySingleItem(
         reasoning: `[relevance_gate] ${gate.reason}`,
         sourceUrl: verifiedSourceUrl,
         checkerModel: 'relevance-gate',
+        // QUA-791: explicit zero so aggregation drops this row even if
+        // the not_applicable filter is later relaxed. Belt + suspenders.
+        relevanceScore: 0,
       };
     }
   }
@@ -499,6 +502,7 @@ export async function storeResult(item: VerifyItem, result: VerifyResult): Promi
         reasoning: result.reasoning,
         isPrimarySource: true,
         checkerModel: result.checkerModel,
+        relevanceScore: result.relevanceScore ?? null,
       }, '[sourcing]');
     } catch (e: unknown) {
       firstError = e;
@@ -533,6 +537,7 @@ export async function storeResult(item: VerifyItem, result: VerifyResult): Promi
         reasoning: result.reasoning,
         entityId: recordData.entityId,
         checkerModel: result.checkerModel,
+        relevanceScore: result.relevanceScore ?? null,
       }, '[sourcing]');
     } catch (e: unknown) {
       firstError = e;

--- a/crux/lib/sourcing/orchestrator-types.ts
+++ b/crux/lib/sourcing/orchestrator-types.ts
@@ -98,6 +98,14 @@ export interface VerifyResult {
   errorType?: SourceFetchErrorType;
   /** 'deterministic-row-match' for snapshot matching, or undefined for LLM */
   checkerModel?: string;
+  /**
+   * QUA-791: source-relevance weight that propagates into
+   * `source_check_evidence.relevance_score`. NULL means "not supplied"
+   * — the aggregator treats it as full weight (1.0). Currently set to
+   * 0 when the relevance gate short-circuits to `not_applicable`; future
+   * iterations can populate this on passed rows too.
+   */
+  relevanceScore?: number | null;
 }
 
 export interface VerifyError {

--- a/crux/lib/sourcing/verdict-handler.ts
+++ b/crux/lib/sourcing/verdict-handler.ts
@@ -40,6 +40,12 @@ export async function storeSourcingEvidence(params: {
   fieldName?: string | null;
   /** Expected value from the source data (e.g., stakeholder position + reason) */
   expectedValue?: string | null;
+  /**
+   * QUA-791: source-relevance weight for verdict aggregation. 0..1, NULL
+   * treated as 1.0 (full weight). Populated from the QUA-426 relevance
+   * gate or any other relevance heuristic the caller has available.
+   */
+  relevanceScore?: number | null;
 }, logPrefix = '[sourcing]'): Promise<void> {
   let resolvedResourceId = params.resourceId ?? null;
   if (!resolvedResourceId && params.sourceUrl) {
@@ -81,6 +87,7 @@ export async function storeSourcingEvidence(params: {
     resourceId: resolvedResourceId,
     ...(params.fieldName != null ? { fieldName: params.fieldName } : {}),
     ...(params.expectedValue != null ? { expectedValue: params.expectedValue.slice(0, 2000) } : {}),
+    ...(params.relevanceScore != null ? { relevanceScore: params.relevanceScore } : {}),
   };
 
   const response = await storeEvidenceRpc(body);

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -22,6 +22,10 @@ type RpcClient = ReturnType<typeof hc<SourcingRoute>>;
 
 export type StoreEvidenceResult = InferResponseType<RpcClient['evidence']['$post'], 201>;
 export type StoreVerdictResult = InferResponseType<RpcClient['verdicts']['$post'], 200>;
+export type RecomputeVerdictResult = InferResponseType<
+  RpcClient['verdicts']['recompute']['$post'],
+  200
+>;
 export type ListVerdictsResult = InferResponseType<RpcClient['verdicts']['$get'], 200>;
 export type VerdictByRecordResult = InferResponseType<RpcClient['verdicts'][':recordType'][':recordId']['$get'], 200>;
 export type DueForRecheckResult = InferResponseType<RpcClient['due-for-recheck']['$get'], 200>;
@@ -49,6 +53,32 @@ export async function storeVerdict(
   body: Record<string, unknown>,
 ): Promise<ApiResult<StoreVerdictResult>> {
   return apiRequest<StoreVerdictResult>('POST', '/api/sourcing/verdicts', body);
+}
+
+/**
+ * Recompute the aggregate verdict for one (recordType, recordId, fieldName)
+ * key from its evidence rows (QUA-791). Server reads
+ * `source_check_evidence`, applies the canonical relevance-weighted rule,
+ * and upserts `source_check_verdicts`. Use this whenever evidence has been
+ * added/changed and the aggregate must be brought in sync — replaces the
+ * old "construct a verdict body and POST /verdicts" pattern that was
+ * last-writer-wins.
+ */
+export async function recomputeVerdict(
+  body: {
+    recordType: string;
+    recordId: string;
+    fieldName?: string | null;
+    entityId?: string | null;
+    displayName?: string | null;
+    entityDisplayName?: string | null;
+  },
+): Promise<ApiResult<RecomputeVerdictResult>> {
+  return apiRequest<RecomputeVerdictResult>(
+    'POST',
+    '/api/sourcing/verdicts/recompute',
+    body,
+  );
 }
 
 /** List verdicts with optional filters. */

--- a/crux/scripts/recompute-source-verdicts.ts
+++ b/crux/scripts/recompute-source-verdicts.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env -S node --import tsx/esm
+/**
+ * One-time backfill: recompute every source-check verdict from its
+ * underlying evidence rows (QUA-791 Phase 1).
+ *
+ * The pre-Phase-1 `POST /verdicts` endpoint was last-writer-wins —
+ * whoever wrote last set the aggregate, regardless of the other
+ * evidence rows. After QUA-791 lands, every new write triggers
+ * server-side recompute. This script reconciles the *existing* table
+ * by reading all distinct `(record_type, record_id, field_name)` keys
+ * from `source_check_evidence` and POSTing
+ * `/api/sourcing/verdicts/recompute` for each.
+ *
+ * Reports a verdict-distribution diff (before vs after) so the operator
+ * can see the impact before merging.
+ *
+ * Usage:
+ *   node --import tsx/esm crux/scripts/recompute-source-verdicts.ts             # dry run
+ *   node --import tsx/esm crux/scripts/recompute-source-verdicts.ts --apply     # write
+ *   node --import tsx/esm crux/scripts/recompute-source-verdicts.ts --apply --limit=100
+ *   WIKI_SERVER_ENV=prod node --import tsx/esm crux/scripts/recompute-source-verdicts.ts
+ *
+ * Flags:
+ *   --apply           Actually call the recompute endpoint (default: dry-run, samples 5 keys)
+ *   --limit=N         Process at most N keys
+ *   --concurrency=N   Parallel requests (default: 5)
+ *
+ * Safe to re-run: each call is idempotent on the (recordType, recordId, fieldName) key.
+ */
+
+import { config } from "dotenv";
+import { join } from "node:path";
+
+config({ path: join(import.meta.dirname, "../../.env") });
+
+const args = process.argv.slice(2);
+const APPLY = args.includes("--apply");
+const limitArg = args.find((a) => a.startsWith("--limit="));
+const concurrencyArg = args.find((a) => a.startsWith("--concurrency="));
+const LIMIT = limitArg ? parseInt(limitArg.split("=")[1], 10) : undefined;
+const CONCURRENCY = concurrencyArg ? parseInt(concurrencyArg.split("=")[1], 10) : 5;
+
+const isProd = process.env.WIKI_SERVER_ENV === "prod";
+const BASE_URL = isProd
+  ? process.env.PROD_LONGTERMWIKI_SERVER_URL
+  : process.env.LONGTERMWIKI_SERVER_URL ?? "http://localhost:4850";
+const API_KEY = isProd
+  ? process.env.PROD_LONGTERMWIKI_SERVER_API_KEY
+  : process.env.LONGTERMWIKI_SERVER_API_KEY;
+
+if (!BASE_URL) {
+  console.error("ERROR: No wiki-server URL configured.");
+  process.exit(1);
+}
+
+function authHeaders(): Record<string, string> {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  if (API_KEY) h["Authorization"] = `Bearer ${API_KEY}`;
+  return h;
+}
+
+interface DistributionRow {
+  verdict: string;
+  count: number;
+}
+
+/**
+ * Pull current verdict distribution by paging through `/api/sourcing/verdicts`.
+ * Aggregated client-side because there is no /stats endpoint that returns
+ * raw verdict counts unfiltered by orphan-cleanup CTE.
+ */
+async function fetchVerdictDistribution(): Promise<DistributionRow[]> {
+  const counts = new Map<string, number>();
+  let offset = 0;
+  const pageSize = 200;
+  while (true) {
+    const url = `${BASE_URL}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
+    const res = await fetch(url, { headers: authHeaders() });
+    if (!res.ok) {
+      throw new Error(`fetch verdicts failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as { verdicts: Array<{ verdict: string }>; total: number };
+    if (!data.verdicts || data.verdicts.length === 0) break;
+    for (const v of data.verdicts) {
+      counts.set(v.verdict, (counts.get(v.verdict) ?? 0) + 1);
+    }
+    offset += data.verdicts.length;
+    if (offset >= data.total) break;
+  }
+  return [...counts.entries()]
+    .map(([verdict, count]) => ({ verdict, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+interface EvidenceKey {
+  recordType: string;
+  recordId: string;
+  fieldName: string | null;
+}
+
+/**
+ * List every distinct (recordType, recordId, fieldName) key with at least
+ * one evidence row. We page through `/api/sourcing/verdicts` because every
+ * key with evidence almost certainly has a verdict row already (the old
+ * code wrote them in lockstep). Anything we miss this pass — keys with
+ * evidence but no verdict — gets picked up the next time POST /evidence
+ * fires for that key (which now triggers recompute).
+ */
+async function listKeys(): Promise<EvidenceKey[]> {
+  const keys: EvidenceKey[] = [];
+  let offset = 0;
+  const pageSize = 500;
+  while (true) {
+    const url = `${BASE_URL}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
+    const res = await fetch(url, { headers: authHeaders() });
+    if (!res.ok) {
+      throw new Error(`list verdicts failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as {
+      verdicts: Array<{ recordType: string; recordId: string; fieldName: string | null }>;
+      total: number;
+    };
+    if (!data.verdicts || data.verdicts.length === 0) break;
+    for (const v of data.verdicts) {
+      keys.push({
+        recordType: v.recordType,
+        recordId: v.recordId,
+        fieldName: v.fieldName ?? null,
+      });
+      if (LIMIT && keys.length >= LIMIT) return keys;
+    }
+    offset += data.verdicts.length;
+    if (offset >= data.total) break;
+  }
+  return keys;
+}
+
+async function recompute(key: EvidenceKey): Promise<{ verdict: string; key: EvidenceKey } | null> {
+  const url = `${BASE_URL}/api/sourcing/verdicts/recompute`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({
+      recordType: key.recordType,
+      recordId: key.recordId,
+      fieldName: key.fieldName,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    console.error(
+      `recompute failed: ${res.status} ${res.statusText} for ${key.recordType}/${key.recordId}/${key.fieldName ?? "null"} — ${text.slice(0, 200)}`,
+    );
+    return null;
+  }
+  const data = (await res.json()) as { verdict: string };
+  return { verdict: data.verdict, key };
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let cursor = 0;
+  const next = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      const r = await worker(items[idx]);
+      results.push(r);
+      if ((idx + 1) % 100 === 0) {
+        console.log(`  ${idx + 1}/${items.length} processed`);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: concurrency }, () => next()));
+  return results;
+}
+
+async function main(): Promise<void> {
+  console.log(`Wiki-server: ${BASE_URL}`);
+  console.log(`Mode: ${APPLY ? "APPLY (will write)" : "DRY RUN (samples 5 keys)"}`);
+  if (LIMIT) console.log(`Limit: ${LIMIT}`);
+  console.log("");
+
+  console.log("Fetching baseline verdict distribution...");
+  const before = await fetchVerdictDistribution();
+  console.log("Baseline:");
+  for (const { verdict, count } of before) {
+    console.log(`  ${verdict.padEnd(15)} ${count}`);
+  }
+  console.log("");
+
+  console.log("Listing keys to recompute...");
+  const keys = await listKeys();
+  console.log(`  ${keys.length} keys`);
+  console.log("");
+
+  if (!APPLY) {
+    console.log("DRY RUN — sampling 5 keys:");
+    for (const key of keys.slice(0, 5)) {
+      const r = await recompute(key);
+      if (r) {
+        console.log(`  ${key.recordType}/${key.recordId}/${key.fieldName ?? "null"} → ${r.verdict}`);
+      }
+    }
+    console.log("\nRe-run with --apply to recompute all keys.");
+    return;
+  }
+
+  console.log(`Recomputing ${keys.length} keys with concurrency=${CONCURRENCY}...`);
+  const t0 = Date.now();
+  const results = await runWithConcurrency(keys, CONCURRENCY, recompute);
+  const elapsedSec = Math.round((Date.now() - t0) / 1000);
+  const ok = results.filter((r) => r !== null).length;
+  const failed = results.length - ok;
+  console.log(`  ${ok} succeeded, ${failed} failed in ${elapsedSec}s`);
+  console.log("");
+
+  console.log("Fetching post-recompute verdict distribution...");
+  const after = await fetchVerdictDistribution();
+  console.log("After:");
+  for (const { verdict, count } of after) {
+    console.log(`  ${verdict.padEnd(15)} ${count}`);
+  }
+
+  console.log("\nDiff (after - before):");
+  const verdicts = new Set([
+    ...before.map((r) => r.verdict),
+    ...after.map((r) => r.verdict),
+  ]);
+  for (const v of verdicts) {
+    const beforeCount = before.find((r) => r.verdict === v)?.count ?? 0;
+    const afterCount = after.find((r) => r.verdict === v)?.count ?? 0;
+    const delta = afterCount - beforeCount;
+    if (delta === 0) continue;
+    const sign = delta > 0 ? "+" : "";
+    console.log(`  ${v.padEnd(15)} ${beforeCount} → ${afterCount} (${sign}${delta})`);
+  }
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e);
+  process.exit(1);
+});

--- a/crux/scripts/recompute-source-verdicts.ts
+++ b/crux/scripts/recompute-source-verdicts.ts
@@ -37,8 +37,20 @@ const args = process.argv.slice(2);
 const APPLY = args.includes("--apply");
 const limitArg = args.find((a) => a.startsWith("--limit="));
 const concurrencyArg = args.find((a) => a.startsWith("--concurrency="));
-const LIMIT = limitArg ? parseInt(limitArg.split("=")[1], 10) : undefined;
-const CONCURRENCY = concurrencyArg ? parseInt(concurrencyArg.split("=")[1], 10) : 5;
+
+function parsePositiveInt(raw: string, name: string): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    console.error(`ERROR: --${name}=${raw} must be a positive integer`);
+    process.exit(2);
+  }
+  return n;
+}
+
+const LIMIT = limitArg ? parsePositiveInt(limitArg.split("=")[1], "limit") : undefined;
+const CONCURRENCY = concurrencyArg
+  ? parsePositiveInt(concurrencyArg.split("=")[1], "concurrency")
+  : 5;
 
 const isProd = process.env.WIKI_SERVER_ENV === "prod";
 const BASE_URL = isProd

--- a/crux/validate/validate-verdict-priority.ts
+++ b/crux/validate/validate-verdict-priority.ts
@@ -37,9 +37,18 @@ import { getColors } from '../lib/output.ts';
 
 const SCAN_DIRS = ['apps/web/src', 'apps/wiki-server/src', 'crux'];
 
-/** Files that legitimately define the canonical priority map. */
+/**
+ * Files that legitimately define the canonical priority map.
+ *
+ * The wiki-server cannot import from `apps/web` (architectural separation),
+ * so the same numeric ladder is mirrored in `sourcing-aggregation.ts` with
+ * an explicit "keep in sync" comment (QUA-791). Both files MUST stay
+ * aligned — a mismatch produces different aggregate verdicts on the same
+ * data depending on which side computed it.
+ */
 const ALLOWLIST = new Set<string>([
   'apps/web/src/components/shared/verdict-styles.ts',
+  'apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts',
 ]);
 
 const VERDICT_NAMES = [


### PR DESCRIPTION
## Summary

QUA-791 Phase 1 of the source-check rollup cleanup: replace last-writer-wins on `POST /api/sourcing/verdicts` with server-side, relevance-weighted aggregation that reads all evidence rows.

Phase 2 (priority unification) shipped in PR #4639. QUA-429 itself was the parent ticket and is closed; remaining Phase 3 work tracked in QUA-792.

## What changed

### Schema

- **Migration 0217** adds `source_check_evidence.relevance_score real`. Default NULL is treated as 1.0 by the aggregator so legacy rows participate at full weight. The migration also backfills `relevance_score = 0` for existing `not_applicable` rows so the relevance-gate's belt-and-suspenders semantics hold across the entire corpus, not just new writes.

### New canonical aggregation

`apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts` — pure, sync `aggregateEvidence(rows)` with the canonical rule:
1. Drop `not_applicable` rows (relevance-gate signal).
2. Below `relevance_score >= 0.3`, evidence participates but cannot single-handedly establish a verdict — return `unchecked`.
3. Weighted score per verdict bucket = `Σ relevance_score`. Tiebreak on `SOURCE_CHECK_VERDICT_PRIORITY` (Phase 2 canonical ladder).
4. Confidence = weighted average of `confidence × relevance_score` across rows that share the winning verdict, NULLs skipped (not zeroed).

19 unit tests covering: empty, single-row, all-`not_applicable`, sub-threshold dissent, NaN / out-of-range relevance, NULL confidence, multi-source disagreement (Phase 3 input).

`SOURCE_CHECK_VERDICT_PRIORITY` is mirrored as a constant (the wiki-server cannot import from `apps/web`) and allowlisted in `validate-verdict-priority`.

### New endpoint

`POST /api/sourcing/verdicts/recompute` — body `{ recordType, recordId, fieldName?, entityId?, displayName?, entityDisplayName? }`. Reads all evidence rows for the key, applies aggregation, upserts `source_check_verdicts`, returns the new aggregate plus the contributing breakdown for the disagree-warning surface (QUA-792 input).

Helper `recomputeVerdict(db|tx, args)` accepts either a top-level Drizzle DB or a transaction handle. The helper short-circuits (no writes) when there's no evidence — preserves back-compat for callers that use `POST /verdicts` as a verdict-only marker write.

### Existing writers reconcile through recompute

- `POST /verdicts` and `POST /evidence` trigger `recomputeVerdictBestEffort` after the underlying write. Best-effort: a recompute failure does not fail the write.
- `writeInlineVerdicts` (tablebase sync) and `wikibase/citations.ts` accuracy-write call recompute (non-best-effort) inside their existing transaction so the verdict reflects all evidence; tx-internal swallowing is avoided to prevent 25P02 cascades.
- `EvidenceBody` schema accepts an optional `relevanceScore` from callers. Crux `storeSourcingEvidence` accepts and forwards it.
- The relevance gate (`item-verifier.ts`) tags `not_applicable` short-circuits with `relevanceScore: 0`.
- POST /evidence's pre-QUA-791 7-day auto-flag step was removed (recompute now produces a fresh verdict on every write, so flagging-then-clearing was contradictory). The unused `verdictFlagged` response field was dropped (no callers consumed it).

### Backfill script

`crux/scripts/recompute-source-verdicts.ts` — uses the typed sourcing-client (picks up `X-Agent-Session-Id` audit headers automatically), single paginated walk for keys + baseline distribution, then per-key recompute with configurable concurrency and a before/after diff. Validates `--limit`/`--concurrency` as positive ints. Dry-run by default; `--apply` to write.

## What this fixes

Pre-Phase-1: each evidence-writer call passed its own per-source verdict with `sourcesChecked: 1`, and whoever wrote last set the aggregate. The same record could end up with `unverifiable` even when 4 of 5 evidence rows said `confirmed`.

After this PR, the persisted aggregate is always derivable from the evidence — the writer can't override it by accident.

## Review

- `/agent-review-pr` ran a hostile-review subagent against the full diff. 17 findings: 4 HIGH (POST /verdicts contract, backfill script silent no-op, test gaps for the DB helper, misleading test name), 7 MEDIUM, 6 LOW. All HIGH and most MEDIUM addressed in commit `d5326d5`. Notable: a latent unique-violation retry bug — Drizzle wraps postgres errors so substring-on-message missed code 23505. Now walks `.cause` chain.
- `/simplify` ran 3 parallel agents (reuse, quality, efficiency). 8 highest-leverage findings applied in commit `239f50b` (net **-121 lines**): drop redundant `count(*)` gate, drop redundant 7-day auto-flag step, replace hand-rolled fetch/auth in script with typed client, merge two paginators, simplify `isUniqueViolation`, hoist `Bucket` interface, trim narrative comments, unify `buildReasoning` format.
- Lower-priority deferrals (extract `DbOrTx` union, propagate `isUniqueViolation` to other 3 sourcing call sites, eliminate redundant inline verdict UPSERT in writeInlineVerdicts) are noted in commit messages and would broaden this PR's scope significantly.

## Acceptance criteria (from QUA-791)

- [x] `source_check_evidence.relevance_score` column exists (migration 0217)
- [x] Single canonical aggregation function exists and is documented
- [x] `POST /api/sourcing/verdicts/recompute` endpoint exists, returns aggregate + contributing breakdown
- [x] All evidence writers call `recompute` after writing
- [x] `POST /verdicts` triggers `recompute` as a side effect
- [x] Backfill script ready
- [x] Tests cover empty, single-row, multi-source disagreement, all-`not_applicable`, relevance-tiebreak, sub-threshold, confidence weighting, end-to-end DB flow including unique-violation retry

## Out of scope

- **QUA-792 (Phase 3)** — reconciling the "⚠ Checks disagree" warning with the headline verdict. This PR's `contributing` breakdown in the recompute response is the input that ticket will consume.

## Test plan

- [x] `pnpm test` (wiki-server) — 1462 pass, 57 skipped
- [x] `pnpm test` (crux/lib/sourcing) — 584 pass
- [x] `pnpm crux w validate gate --fix` — 60/60 blocking pass; 4 advisory unchanged from baseline
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `validate-verdict-priority` passes (mirror file allowlisted)
- [x] Backfill script `--limit=abc` exits 2 with error; happy-path lists 13947 keys against prod
- [ ] Run backfill on prod after deploy and post before/after diff in PR comment

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0217 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
- [ ] `schema` Drizzle schema changed — verify wiki-server redeployed and schema is in sync — `curl -sf "$WIKI_SERVER_URL/health" | jq .`
- [ ] `route` New `POST /api/sourcing/verdicts/recompute` endpoint — verify accessible — `curl -sX POST "$WIKI_SERVER_URL/api/sourcing/verdicts/recompute" -H "Authorization: Bearer $LONGTERMWIKI_SERVER_API_KEY" -H "Content-Type: application/json" -d '{"recordType":"personnel","recordId":"_smoke_test_"}' -o /dev/null -w "%{http_code}\n"` (expect 200 with 'unchecked' since recordId doesn't exist)
- [ ] `manual` After deploy, run the backfill dry-run: `WIKI_SERVER_ENV=prod node --import tsx/esm crux/scripts/recompute-source-verdicts.ts` — expect non-empty key count and a 5-key sample.
- [ ] `manual` Run the backfill apply: `WIKI_SERVER_ENV=prod node --import tsx/esm crux/scripts/recompute-source-verdicts.ts --apply` — post the before/after distribution diff as a PR comment.
<!-- /deploy-tasks -->

Fixes QUA-791
