### PR TITLE
fix(QUA-594): clamp suggest-urls candidate title/snippet to server caps

### DIFF
--- a/crux/commands/sourcing-suggest-urls.test.ts
+++ b/crux/commands/sourcing-suggest-urls.test.ts
@@ -34,7 +34,7 @@ vi.mock('../lib/sourcing/grade-suggestion.ts', () => ({
   MAX_REASONING_CHARS: 200,
 }));
 
-import { commands } from './sourcing-suggest-urls.ts';
+import { commands, clampForUpsert } from './sourcing-suggest-urls.ts';
 import { suggestUrls } from '../lib/sourcing/suggest-urls.ts';
 import { gradeSuggestion } from '../lib/sourcing/grade-suggestion.ts';
 
@@ -487,5 +487,65 @@ describe('sourcing-suggest-urls --auto-approve-threshold (QUA-592)', () => {
     // 0.0007 + 0.0003 = 0.001. Anything <= 0 would mean the call site
     // dropped the grader's costUsd field.
     expect(parsed.summary.cost_usd).toBeCloseTo(0.001, 4);
+  });
+});
+
+describe('sourcing-suggest-urls field length clamping', () => {
+  // Server schema rejects suggestions where title > 500 or snippet > 2000
+  // (apps/wiki-server/.../url-suggestions.ts). Search providers occasionally
+  // return values past those caps, which would reject the entire ~100-row
+  // upsert chunk. Real failure observed during the QUA-594 sweep:
+  // `upsert failed at chunk 3: title String must contain at most 500 character(s)`.
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clampForUpsert returns short values unchanged and truncates over-long values', () => {
+    expect(clampForUpsert('short', 500)).toBe('short');
+    expect(clampForUpsert(null, 500)).toBe(null);
+    expect(clampForUpsert(undefined, 500)).toBe(undefined);
+    const long = 'x'.repeat(800);
+    const clamped = clampForUpsert(long, 500);
+    expect(clamped).toHaveLength(500);
+    expect(clamped).toBe('x'.repeat(500));
+  });
+
+  it('clamps over-long candidate titles and snippets before upsert', async () => {
+    stubEmptyPrereqs();
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: true,
+      data: { verdicts: [makeVerdict({ recordId: 'g_long', entityId: 'anthropic' })], total: 1 },
+    });
+    const longTitle = 'T'.repeat(900);
+    const longSnippet = 'S'.repeat(3000);
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [
+        {
+          url: 'https://example.com/long',
+          title: longTitle,
+          snippet: longSnippet,
+          relevanceScore: 0.5,
+          sourceProvider: 'exa',
+        },
+      ],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'test',
+      costUsd: 0,
+    });
+    mockUpsertUrlSuggestions.mockResolvedValueOnce({
+      ok: true,
+      data: { upserted: 1 },
+    });
+
+    const result = await run({ limit: '10' });
+    expect(result.exitCode).toBe(0);
+    expect(mockUpsertUrlSuggestions).toHaveBeenCalledTimes(1);
+    const payload = mockUpsertUrlSuggestions.mock.calls[0][0] as Array<{
+      title: string | null;
+      snippet: string | null;
+    }>;
+    expect(payload[0].title).toHaveLength(500);
+    expect(payload[0].snippet).toHaveLength(2000);
   });
 });

--- a/crux/commands/sourcing-suggest-urls.ts
+++ b/crux/commands/sourcing-suggest-urls.ts
@@ -48,6 +48,11 @@ const PREFETCH_PAGE_SIZE = 200;
 const PREFETCH_MAX = 2000;
 const UPSERT_CHUNK = 100;
 const DEFAULT_CONCURRENCY = 5;
+// Server schema (apps/wiki-server/.../url-suggestions.ts SuggestionInput) caps
+// these fields. Search providers occasionally return values that exceed them,
+// which would reject the entire batch upsert (~100 records). Truncate defensively.
+const MAX_TITLE_CHARS = 500;
+const MAX_SNIPPET_CHARS = 2000;
 
 const DEFAULT_VERDICT: SourcingVerdict = 'unverifiable';
 // Only verdicts where weak source URLs are the suspected root cause.
@@ -77,6 +82,14 @@ const ALLOWED_SUGGEST_VERDICTS: ReadonlySet<string> = new Set<SourcingVerdict>([
 // Guard drift between DEFAULT_VERDICT and the allowlist.
 if (!ALLOWED_SUGGEST_VERDICTS.has(DEFAULT_VERDICT)) {
   throw new Error(`DEFAULT_VERDICT "${DEFAULT_VERDICT}" is not in ALLOWED_SUGGEST_VERDICTS`);
+}
+
+export function clampForUpsert(
+  value: string | null | undefined,
+  max: number,
+): string | null | undefined {
+  if (value == null) return value;
+  return value.length <= max ? value : value.slice(0, max);
 }
 
 interface SuggestOptions extends BaseOptions {
@@ -521,8 +534,8 @@ async function suggestCommand(
         fieldName: v.fieldName,
         entityId: v.entityId,
         suggestedUrl: cand.url,
-        title: cand.title,
-        snippet: cand.snippet,
+        title: clampForUpsert(cand.title, MAX_TITLE_CHARS),
+        snippet: clampForUpsert(cand.snippet, MAX_SNIPPET_CHARS),
         relevanceScore: cand.relevanceScore,
         sourceProvider: cand.sourceProvider,
         generatorModel: GENERATOR_MODEL,


### PR DESCRIPTION
## Summary

- Truncate `cand.title` to 500 chars and `cand.snippet` to 2000 chars before pushing to the URL-suggestions upsert payload — these match the server's `SuggestionInput` Zod constraints.
- Search providers (Exa, Perplexity) occasionally return values past those caps. Pre-fix, a single over-long title rejected the entire ~100-row upsert chunk.
- Adds a `clampForUpsert()` helper + 2 unit tests.

## Why this matters

Discovered during the QUA-594 sweep:

```
upsert failed at chunk 3: 400: validation_error
  String must contain at most 500 character(s)
  path: suggestions.42.title
```

The whole chunk was rejected and the command exited 1, even though chunks 1-2 (~200 suggestions) had landed.

After the fix, the same sweep ran end-to-end:

| Run | Result |
|---|---|
| Pre-fix (run 1) | Failed at chunk 3, ~$0.50 spent, partial writes |
| Post-fix (run 2) | 200 scanned, 79 records → 237 candidates written, 75 auto-approved, $0.56 |

## Test plan

- [x] `pnpm vitest run crux/commands/sourcing-suggest-urls.test.ts` — 22/22 pass (20 existing + 2 new)
- [x] Direct unit test on `clampForUpsert()` (short / null / over-long inputs)
- [x] Integration test: 900-char title + 3000-char snippet → upsert payload is 500/2000 chars
- [x] `pnpm crux w validate gate --fix --scope=content` — all checks pass
- [x] Real prod run completed successfully after fix landed locally

## Followups (filed on QUA-547 sweep comment, not this PR)

- Auto-grader at threshold=0.75 was 0/30 on predicting actual verifiability (see comment).
- 87 candidates awaiting resource-ingest cache — needs a re-run after worker catches up.
- Server-side 200/page cap on `/api/sourcing/verdicts` blocks single-run full-coverage sweeps.

Closes QUA-594.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved URL suggestion processing to automatically enforce server field length requirements: suggestion titles are now limited to 500 characters and descriptions to 2000 characters maximum. Source suggestions containing oversized values are automatically truncated to these limits before processing, preventing potential data handling errors and ensuring more reliable suggestion processing overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->