### PR TITLE
qua-731: stop sync-content concurrency cancels from tripping main-ci-red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,10 +370,13 @@ jobs:
     needs: [ci]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     # Serialize syncs so concurrent pushes don't saturate the wiki-server rate limiter.
-    # cancel-in-progress: true drops stale queued runs — the latest state always subsumes them.
+    # cancel-in-progress: false — queue, don't cancel. Cancelling left the LATEST
+    # commit's sync incomplete (so the wiki-server missed that commit's content)
+    # AND turned the workflow rollup into FAILURE for cancelled commits, tripping
+    # the patrol's main-ci-red gate on phantom failures (QUA-731).
     concurrency:
       group: sync-content-main
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,10 @@ jobs:
     # commit's sync incomplete (so the wiki-server missed that commit's content)
     # AND turned the workflow rollup into FAILURE for cancelled commits, tripping
     # the patrol's main-ci-red gate on phantom failures (QUA-731).
+    # Trade-off: an N-PR burst now serializes (≈N × sync duration ≈ 5 min for 5
+    # PRs) instead of cancel-and-replace (~1 min). Each queued run still
+    # checks-out at its own SHA and syncs that snapshot, so the queue tail's
+    # final state matches the latest main commit. Acceptable for the volume.
     concurrency:
       group: sync-content-main
       cancel-in-progress: false

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -1024,13 +1024,20 @@ describe('mapRollupState — cancellation-only rollup failures', () => {
     expect(mapRollupState('NEUTRAL', cancelledOnly)).toBe('neutral');
   });
 
-  it('treats SKIPPED checks as not-a-failure (same as success)', () => {
+  it('SKIPPED + CANCELLED + SUCCESS still maps to neutral (SKIPPED is not a failure)', () => {
     const contexts: RollupContext[] = [
       checkRun('SUCCESS'),
       checkRun('SKIPPED'),
       checkRun('CANCELLED'),
     ];
     expect(mapRollupState('FAILURE', contexts)).toBe('neutral');
+  });
+
+  it('SKIPPED-only (no cancellation) is degenerate — falls through to failure', () => {
+    // GitHub shouldn't return rollup FAILURE without a real failing or
+    // cancelled check, but if it does we should not silently reclassify.
+    const contexts: RollupContext[] = [checkRun('SUCCESS'), checkRun('SKIPPED')];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
   });
 
   it('treats null check conclusion as ignorable (in-progress at rollup time)', () => {
@@ -1040,6 +1047,33 @@ describe('mapRollupState — cancellation-only rollup failures', () => {
       checkRun('CANCELLED'),
     ];
     expect(mapRollupState('FAILURE', contexts)).toBe('neutral');
+  });
+
+  it('applies the same cancellation logic to ERROR rollup state', () => {
+    const cancelledOnly: RollupContext[] = [checkRun('SUCCESS'), checkRun('CANCELLED')];
+    expect(mapRollupState('ERROR', cancelledOnly)).toBe('neutral');
+
+    const realFailure: RollupContext[] = [checkRun('CANCELLED'), checkRun('FAILURE')];
+    expect(mapRollupState('ERROR', realFailure)).toBe('failure');
+  });
+
+  it('fails closed (returns failure) when contexts are truncated — a real failure could hide past the page', () => {
+    // If GitHub's contexts(first: 100) hit pagination and we only see the
+    // first page, a real failure could be lurking past the cutoff. Treat
+    // FAILURE as failure rather than reclassify based on partial info.
+    const visibleCancelledOnly: RollupContext[] = [checkRun('SUCCESS'), checkRun('CANCELLED')];
+    expect(
+      mapRollupState('FAILURE', visibleCancelledOnly, { contextsTruncated: true }),
+    ).toBe('failure');
+    // Sanity: same context list without truncation still returns neutral.
+    expect(mapRollupState('FAILURE', visibleCancelledOnly)).toBe('neutral');
+  });
+
+  it('contextsTruncated: false behaves the same as omitting the flag', () => {
+    const cancelledOnly: RollupContext[] = [checkRun('SUCCESS'), checkRun('CANCELLED')];
+    expect(
+      mapRollupState('FAILURE', cancelledOnly, { contextsTruncated: false }),
+    ).toBe('neutral');
   });
 });
 

--- a/crux/pr-patrol/health-scan.test.ts
+++ b/crux/pr-patrol/health-scan.test.ts
@@ -9,6 +9,7 @@ import {
   checkRatchetDriftForFile,
   readBaselineTotal,
   mapRollupState,
+  rollupFailureIsCancellationOnly,
   DEPLOY_STUCK_MIN_CONSECUTIVE_FAILURES,
   MAIN_CI_RED_STREAK_MIN,
   DEPLOY_STALE_THRESHOLD_HOURS,
@@ -21,6 +22,8 @@ import {
   type CommitStatus,
   type BaselineObservation,
   type RatchetDriftResult,
+  type RollupContext,
+  type CheckConclusion,
 } from './health-scan.ts';
 import type { RatchetConfig } from './ratchet-config.ts';
 
@@ -927,5 +930,170 @@ describe('mapRollupState', () => {
   });
   it('maps null → null', () => {
     expect(mapRollupState(null)).toBeNull();
+  });
+});
+
+// ── mapRollupState — cancellation-only failures (QUA-731) ───────────────────
+
+describe('mapRollupState — cancellation-only rollup failures', () => {
+  function checkRun(conclusion: CheckConclusion): RollupContext {
+    return { __typename: 'CheckRun', conclusion };
+  }
+  function statusCtx(state: 'SUCCESS' | 'FAILURE' | 'ERROR' | 'PENDING' | 'EXPECTED'): RollupContext {
+    return { __typename: 'StatusContext', state };
+  }
+
+  it('maps FAILURE → neutral when contexts contain only success + cancelled checks', () => {
+    // Real QUA-731 scenario: every test/build job passed, but sync-content was
+    // cancelled by its concurrency group, flipping the rollup to FAILURE.
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('SUCCESS'),
+      checkRun('CANCELLED'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('neutral');
+  });
+
+  it('maps FAILURE → failure when any check actually failed alongside a cancellation', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('FAILURE'),
+      checkRun('CANCELLED'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when a check timed out (real failure, not cancellation)', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('TIMED_OUT'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when a check had STARTUP_FAILURE', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('STARTUP_FAILURE'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when a status context is in FAILURE state', () => {
+    const contexts: RollupContext[] = [
+      checkRun('CANCELLED'),
+      statusCtx('FAILURE'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when a status context is in ERROR state', () => {
+    const contexts: RollupContext[] = [
+      checkRun('CANCELLED'),
+      statusCtx('ERROR'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when contexts list is empty (no info — preserve existing behaviour)', () => {
+    expect(mapRollupState('FAILURE', [])).toBe('failure');
+    // Same when called without the contexts arg at all.
+    expect(mapRollupState('FAILURE')).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when contexts contain no cancellations (just real failures)', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('FAILURE'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('maps FAILURE → failure when contexts are all SUCCESS with no cancellation (degenerate — fall through)', () => {
+    // GitHub shouldn't return rollup FAILURE with all-success contexts, but
+    // be defensive: without a cancellation observed we shouldn't reclassify.
+    const contexts: RollupContext[] = [checkRun('SUCCESS'), checkRun('SUCCESS')];
+    expect(mapRollupState('FAILURE', contexts)).toBe('failure');
+  });
+
+  it('does not affect SUCCESS / PENDING / NEUTRAL mappings', () => {
+    const cancelledOnly: RollupContext[] = [checkRun('CANCELLED')];
+    // The contexts arg is only consulted when the rollup state is FAILURE/ERROR.
+    expect(mapRollupState('SUCCESS', cancelledOnly)).toBe('success');
+    expect(mapRollupState('PENDING', cancelledOnly)).toBe('pending');
+    expect(mapRollupState('NEUTRAL', cancelledOnly)).toBe('neutral');
+  });
+
+  it('treats SKIPPED checks as not-a-failure (same as success)', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun('SKIPPED'),
+      checkRun('CANCELLED'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('neutral');
+  });
+
+  it('treats null check conclusion as ignorable (in-progress at rollup time)', () => {
+    const contexts: RollupContext[] = [
+      checkRun('SUCCESS'),
+      checkRun(null),
+      checkRun('CANCELLED'),
+    ];
+    expect(mapRollupState('FAILURE', contexts)).toBe('neutral');
+  });
+});
+
+describe('rollupFailureIsCancellationOnly', () => {
+  function checkRun(conclusion: CheckConclusion): RollupContext {
+    return { __typename: 'CheckRun', conclusion };
+  }
+  function statusCtx(state: 'SUCCESS' | 'FAILURE' | 'ERROR'): RollupContext {
+    return { __typename: 'StatusContext', state };
+  }
+
+  it('returns false on an empty list (no cancellation observed)', () => {
+    expect(rollupFailureIsCancellationOnly([])).toBe(false);
+  });
+
+  it('returns true when only cancellations and successes are present', () => {
+    expect(
+      rollupFailureIsCancellationOnly([checkRun('SUCCESS'), checkRun('CANCELLED')]),
+    ).toBe(true);
+  });
+
+  it('returns false when there is a real CheckRun failure', () => {
+    expect(
+      rollupFailureIsCancellationOnly([checkRun('CANCELLED'), checkRun('FAILURE')]),
+    ).toBe(false);
+  });
+
+  it('returns false when a StatusContext is in ERROR state', () => {
+    expect(
+      rollupFailureIsCancellationOnly([checkRun('CANCELLED'), statusCtx('ERROR')]),
+    ).toBe(false);
+  });
+
+  it('returns false when nothing was cancelled (degenerate input)', () => {
+    expect(rollupFailureIsCancellationOnly([checkRun('SUCCESS')])).toBe(false);
+  });
+});
+
+// ── evaluateMainCi — concurrency-cancelled commits should not trip red streak ─
+
+describe('evaluateMainCi — cancelled-only commits do not count as failures', () => {
+  it('does NOT trip main-ci-red when 4 consecutive commits are cancelled-only (real QUA-731 burst)', () => {
+    // Simulates what happens when 5 PRs merge in rapid succession: each
+    // commit's sync-content is cancelled by the next, so the rollup is
+    // FAILURE even though every test/build job succeeded. Pre-fix this
+    // would trip a 4-streak; post-fix the commits map to neutral.
+    const commits: CommitStatus[] = [
+      commit({ sha: 'a', conclusion: 'neutral' }),
+      commit({ sha: 'b', conclusion: 'neutral' }),
+      commit({ sha: 'c', conclusion: 'neutral' }),
+      commit({ sha: 'd', conclusion: 'neutral' }),
+    ];
+    const result = evaluateMainCi(commits);
+    expect(result.healthy).toBe(true);
+    expect(result.failingCount).toBe(0);
   });
 });

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -693,6 +693,34 @@ export async function checkDeployStatus(
   return evaluateDeployStatus(runs, options.now);
 }
 
+/**
+ * Conclusions GitHub returns on individual checks. We only care about
+ * distinguishing real failures from cancellations; everything else falls
+ * through to the rollup state.
+ */
+export type CheckConclusion =
+  | 'SUCCESS'
+  | 'FAILURE'
+  | 'CANCELLED'
+  | 'TIMED_OUT'
+  | 'STARTUP_FAILURE'
+  | 'ACTION_REQUIRED'
+  | 'STALE'
+  | 'NEUTRAL'
+  | 'SKIPPED'
+  | null;
+
+export type StatusContextState = 'ERROR' | 'EXPECTED' | 'FAILURE' | 'PENDING' | 'SUCCESS';
+
+/**
+ * One leaf check on a commit's status-check rollup. Either a CheckRun (with
+ * `conclusion`) or a StatusContext (with `state`). We use the `__typename`
+ * discriminator to decide which field to read.
+ */
+export type RollupContext =
+  | { __typename: 'CheckRun'; conclusion: CheckConclusion }
+  | { __typename: 'StatusContext'; state: StatusContextState };
+
 interface MainCommitsGql {
   repository: {
     ref: {
@@ -704,6 +732,9 @@ interface MainCommitsGql {
             url: string;
             statusCheckRollup: {
               state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL';
+              contexts: {
+                nodes: RollupContext[];
+              };
             } | null;
           }>;
         };
@@ -725,6 +756,17 @@ const MAIN_COMMITS_QUERY = /* GraphQL */ `
                 url
                 statusCheckRollup {
                   state
+                  contexts(first: 100) {
+                    nodes {
+                      __typename
+                      ... on CheckRun {
+                        conclusion
+                      }
+                      ... on StatusContext {
+                        state
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -760,20 +802,75 @@ export async function checkMainCi(
     sha: n.oid,
     url: n.url,
     createdAt: n.committedDate,
-    conclusion: mapRollupState(n.statusCheckRollup?.state ?? null),
+    conclusion: mapRollupState(
+      n.statusCheckRollup?.state ?? null,
+      n.statusCheckRollup?.contexts?.nodes ?? [],
+    ),
   }));
 
   return evaluateMainCi(commits);
 }
 
+/**
+ * Map GitHub's aggregate `statusCheckRollup.state` to our internal CommitStatus
+ * conclusion. When the rollup is FAILURE/ERROR we examine the individual checks
+ * via `contexts`: a rollup that failed only because some checks were CANCELLED
+ * (with no real failures alongside) is treated as `neutral`, not `failure`.
+ *
+ * Why: GitHub's rollup is FAILURE if any check is cancelled, even if every
+ * test/build job passed. When a workflow uses `cancel-in-progress: true` on a
+ * concurrency group (e.g. `sync-content`), back-to-back merges to main produce
+ * commits whose rollup is FAILURE even though the actual CI completed cleanly.
+ * The patrol's main-ci-red gate would then trip on phantom failures and halt
+ * PR work indefinitely (QUA-731).
+ *
+ * `contexts` is optional for backwards-compat with callers that haven't been
+ * updated to fetch it; without contexts we fall back to the rollup state alone.
+ */
 export function mapRollupState(
   state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL' | null,
+  contexts: RollupContext[] = [],
 ): CommitStatus['conclusion'] {
   if (state === 'SUCCESS') return 'success';
-  if (state === 'FAILURE' || state === 'ERROR') return 'failure';
   if (state === 'PENDING' || state === 'EXPECTED') return 'pending';
   if (state === 'NEUTRAL') return 'neutral';
+  if (state === 'FAILURE' || state === 'ERROR') {
+    // Without contexts we can't distinguish cancellation from real failure —
+    // err on the side of the existing behaviour (treat as failure).
+    if (contexts.length === 0) return 'failure';
+    if (rollupFailureIsCancellationOnly(contexts)) return 'neutral';
+    return 'failure';
+  }
   return null;
+}
+
+/**
+ * Return true when every non-success leaf in the rollup is a CANCELLED check
+ * (with at least one cancellation observed). A rollup with any real failure
+ * — `FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`, `STALE`, or a
+ * status context in the `FAILURE` / `ERROR` state — is not cancellation-only.
+ *
+ * Exported for testing.
+ */
+export function rollupFailureIsCancellationOnly(contexts: RollupContext[]): boolean {
+  let sawCancellation = false;
+  for (const ctx of contexts) {
+    if (ctx.__typename === 'CheckRun') {
+      const c = ctx.conclusion;
+      if (c === 'SUCCESS' || c === 'NEUTRAL' || c === 'SKIPPED' || c == null) continue;
+      if (c === 'CANCELLED') {
+        sawCancellation = true;
+        continue;
+      }
+      // Any other conclusion (FAILURE, TIMED_OUT, STARTUP_FAILURE, ACTION_REQUIRED,
+      // STALE) is a real failure.
+      return false;
+    } else {
+      // StatusContext has no CANCELLED state; FAILURE/ERROR are always real.
+      if (ctx.state === 'FAILURE' || ctx.state === 'ERROR') return false;
+    }
+  }
+  return sawCancellation;
 }
 
 /**

--- a/crux/pr-patrol/health-scan.ts
+++ b/crux/pr-patrol/health-scan.ts
@@ -733,6 +733,7 @@ interface MainCommitsGql {
             statusCheckRollup: {
               state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL';
               contexts: {
+                pageInfo: { hasNextPage: boolean };
                 nodes: RollupContext[];
               };
             } | null;
@@ -757,6 +758,9 @@ const MAIN_COMMITS_QUERY = /* GraphQL */ `
                 statusCheckRollup {
                   state
                   contexts(first: 100) {
+                    pageInfo {
+                      hasNextPage
+                    }
                     nodes {
                       __typename
                       ... on CheckRun {
@@ -805,6 +809,7 @@ export async function checkMainCi(
     conclusion: mapRollupState(
       n.statusCheckRollup?.state ?? null,
       n.statusCheckRollup?.contexts?.nodes ?? [],
+      { contextsTruncated: n.statusCheckRollup?.contexts?.pageInfo?.hasNextPage ?? false },
     ),
   }));
 
@@ -813,9 +818,10 @@ export async function checkMainCi(
 
 /**
  * Map GitHub's aggregate `statusCheckRollup.state` to our internal CommitStatus
- * conclusion. When the rollup is FAILURE/ERROR we examine the individual checks
- * via `contexts`: a rollup that failed only because some checks were CANCELLED
- * (with no real failures alongside) is treated as `neutral`, not `failure`.
+ * conclusion. When the rollup is FAILURE or ERROR we examine the individual
+ * checks via `contexts`: a rollup that failed only because some checks were
+ * CANCELLED (with no real failures alongside) is treated as `neutral`, not
+ * `failure`.
  *
  * Why: GitHub's rollup is FAILURE if any check is cancelled, even if every
  * test/build job passed. When a workflow uses `cancel-in-progress: true` on a
@@ -824,20 +830,26 @@ export async function checkMainCi(
  * The patrol's main-ci-red gate would then trip on phantom failures and halt
  * PR work indefinitely (QUA-731).
  *
- * `contexts` is optional for backwards-compat with callers that haven't been
- * updated to fetch it; without contexts we fall back to the rollup state alone.
+ * Fail-closed: if `contexts` is empty (caller didn't fetch them) or
+ * `contextsTruncated` is true (more checks exist than were fetched, so a real
+ * failure could be hiding in the tail), we preserve the original FAILURE/ERROR
+ * mapping rather than reclassifying based on incomplete data.
+ *
+ * `contexts` defaults to `[]` for backwards-compat with existing callers and
+ * tests that don't pass check-context info.
  */
 export function mapRollupState(
   state: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | 'EXPECTED' | 'NEUTRAL' | null,
   contexts: RollupContext[] = [],
+  options: { contextsTruncated?: boolean } = {},
 ): CommitStatus['conclusion'] {
   if (state === 'SUCCESS') return 'success';
   if (state === 'PENDING' || state === 'EXPECTED') return 'pending';
   if (state === 'NEUTRAL') return 'neutral';
   if (state === 'FAILURE' || state === 'ERROR') {
-    // Without contexts we can't distinguish cancellation from real failure —
-    // err on the side of the existing behaviour (treat as failure).
-    if (contexts.length === 0) return 'failure';
+    // Without complete context info we can't safely distinguish cancellation
+    // from real failure — preserve the existing FAILURE mapping.
+    if (contexts.length === 0 || options.contextsTruncated) return 'failure';
     if (rollupFailureIsCancellationOnly(contexts)) return 'neutral';
     return 'failure';
   }


### PR DESCRIPTION
Fixes QUA-731

## Summary

When ≥3-4 PRs merged to main in rapid succession, the `sync-content` job's `cancel-in-progress: true` cancelled each commit's run as the next merge arrived. Two bad downstream effects:

1. **Wiki-server data drift.** The LAST commit's sync was also cancelled (its content never reached the wiki-server PG mirror until manual recovery).
2. **Patrol false-red.** GitHub's `statusCheckRollup.state` reports `FAILURE` for cancelled-job rollups, so the patrol's `evaluateMainCi` saw 4 consecutive "failures" and tripped `main-ci-red`, halting all PR-fixing work indefinitely on a phantom signal.

Two complementary fixes per the issue's recommendations.

## Key changes

**Fix A — workflow (root cause):** `sync-content` now uses `cancel-in-progress: false`. Every commit's content sync runs to completion in order. Trade-off: an N-PR burst takes ≈N × sync duration (~5 min for 5 PRs) instead of cancel-and-replace (~1 min). Each queued run still checks-out at its own SHA so the queue tail's final state matches the latest main commit.

**Fix B — scanner (defense-in-depth):** `mapRollupState` now considers the rollup's individual check `contexts`. When the rollup state is `FAILURE`/`ERROR` but every non-success check is `CANCELLED` with no real failures alongside, the commit maps to `neutral` instead of `failure`. Generalizes beyond `sync-content` to any concurrency-cancel pattern in any workflow.

Pagination safety: the GraphQL query fetches `contexts.pageInfo.hasNextPage`. If contexts are truncated past the first 100, the new logic falls back to the original `FAILURE → 'failure'` mapping rather than reclassifying on partial info — a real failure could be hiding past the cutoff.

Backwards compat: `mapRollupState`'s new `contexts` arg defaults to `[]` and `options.contextsTruncated` defaults to `false`, so existing callers and tests preserve the old behaviour.

## Test plan

- [x] `npx vitest run --config crux/vitest.config.ts crux/pr-patrol/health-scan.test.ts` — 85/85 pass (14 new tests)
- [x] `npx vitest run --config crux/vitest.config.ts crux/pr-patrol/` — 430/430 pass across 15 files
- [x] `pnpm build` — exits 0
- [x] `pnpm crux w validate gate --fix` — 60/60 gate checks pass
- [x] Reviewed by hostile-reviewer subagent (`/agent-review-pr`); HIGH finding on `contexts(first: 100)` overflow addressed via `hasNextPage` fail-closed
- [x] Three simplification reviewers (reuse, quality, efficiency); diff confirmed clean

New test scenarios:
- FAILURE rollup with only SUCCESS + CANCELLED contexts → `neutral` (real QUA-731 burst)
- FAILURE rollup with FAILURE / TIMED_OUT / STARTUP_FAILURE / StatusContext FAILURE → `failure` (preserve real failures)
- FAILURE rollup with empty contexts → `failure` (backwards compat)
- FAILURE rollup with truncated contexts → `failure` (fail-closed on partial info)
- ERROR rollup with cancellation-only contexts → `neutral` (parity with FAILURE)
- `evaluateMainCi` against 4 cancelled-only commits → healthy (regression test for the 2026-04-25 burst)
- `rollupFailureIsCancellationOnly` predicate isolated tests

## Deploy / post-merge verification

<!-- deploy-tasks:v1 -->
- [ ] `auto` Modified workflow "ci" — verify it runs successfully after merge — `gh run list -R quantified-uncertainty/longterm-wiki --workflow=ci.yml --branch=main -L 1`
- [ ] `manual` Next 3+ PR burst to main: confirm every commit's `sync-content` job runs to completion (no cancellations) — `gh run list -R quantified-uncertainty/longterm-wiki --workflow=ci.yml --branch=main --json conclusion,jobs -L 10 | jq '.[] | {conclusion, jobs: (.jobs // [])}'`
- [ ] `manual` Verify the patrol's `main-ci-red` does not trip after a multi-merge burst — `pnpm crux gh pr-patrol health-scan --ci`
- [ ] `manual` Confirm the wiki-server PG mirror has the latest content after a burst — spot-check a page on `https://www.longtermwiki.com` modified by the latest PR in the burst and verify it reflects the merged change within ~15 min
<!-- /deploy-tasks:v1 -->
