### PR TITLE
QUA-791 follow-up: apply /simplify findings (-121 lines)

### DIFF
--- a/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
+++ b/apps/wiki-server/src/__tests__/recompute-verdict.test.ts
@@ -32,17 +32,12 @@ describe("recomputeVerdict — end-to-end", () => {
     dispatch = () => [];
   });
 
-  it("returns 'unchecked' aggregate when no evidence rows exist", async () => {
-    let updateCalls = 0;
-    let insertCalls = 0;
+  it("returns 'unchecked' aggregate and skips writes when no evidence rows exist", async () => {
+    let writeCalls = 0;
     dispatch = (q) => {
       if (/select/i.test(q) && /source_check_evidence/i.test(q)) return [];
-      if (/^update/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
-        updateCalls++;
-        return []; // "no row updated" → falls through to INSERT
-      }
-      if (/^insert/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
-        insertCalls++;
+      if (/^(update|insert)/i.test(q.trim()) && /source_check_verdicts/i.test(q)) {
+        writeCalls++;
         return [];
       }
       return [];
@@ -57,7 +52,10 @@ describe("recomputeVerdict — end-to-end", () => {
     expect(result.aggregate.verdict).toBe("unchecked");
     expect(result.aggregate.sourcesChecked).toBe(0);
     expect(result.reasoning).toMatch(/no evidence/i);
-    expect(updateCalls + insertCalls).toBeGreaterThan(0);
+    // Short-circuit: no UPDATE/INSERT against source_check_verdicts when
+    // there's no evidence to roll up. Preserves back-compat for callers
+    // that use POST /verdicts as a verdict-only marker write.
+    expect(writeCalls).toBe(0);
   });
 
   it("aggregates relevance-weighted majority from multiple evidence rows", async () => {

--- a/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
+++ b/apps/wiki-server/src/routes/sourcing/recompute-verdict.ts
@@ -1,13 +1,7 @@
 /**
  * Recompute a `source_check_verdicts` row from its underlying
- * `source_check_evidence` rows (QUA-791 Phase 1).
- *
- * The single canonical aggregator. Every code path that wants to derive
- * an aggregate verdict from raw evidence MUST go through this helper.
- *
- * Replaces the pre-Phase-1 last-writer-wins behavior at `POST /verdicts`,
- * which let whoever wrote last set the aggregate regardless of what the
- * other evidence rows said.
+ * `source_check_evidence` rows. The canonical write path: every code path
+ * that derives an aggregate verdict from raw evidence MUST go through here.
  */
 
 import { eq, and, sql } from "drizzle-orm";
@@ -24,45 +18,24 @@ import {
 import { logger } from "../../logger.js";
 
 /**
- * Walk the error's cause chain looking for a postgres unique-violation
- * (code 23505 / "duplicate key" / "unique constraint" message). Drizzle
- * wraps the underlying postgres-js error in `Error("Failed query: ...")`
- * with the original on `.cause`, so a top-level `err.message.includes(...)`
- * misses the actual signal. We also check `err.code === "23505"` since
- * postgres-js sets it directly on the original error object.
+ * Detect a postgres unique-violation. Drizzle wraps postgres-js errors as
+ * `Error("Failed query: ...")` with the original on `.cause`, so checking
+ * only `err.message` misses the signal. Check `code === '23505'` and the
+ * canonical substrings on both the top-level error and its cause.
  */
 function isUniqueViolation(err: unknown): boolean {
-  let current: unknown = err;
-  let depth = 0;
-  while (current && depth < 5) {
-    if (current instanceof Error) {
-      const code = (current as Error & { code?: string }).code;
-      if (code === "23505") return true;
-      const msg = current.message;
-      if (
-        msg.includes("23505") ||
-        msg.includes("unique") ||
-        msg.includes("duplicate")
-      ) {
-        return true;
-      }
-      current = (current as Error).cause;
-    } else {
-      const s = String(current);
-      if (s.includes("23505") || s.includes("unique") || s.includes("duplicate")) {
-        return true;
-      }
-      break;
-    }
-    depth++;
-  }
-  return false;
+  const matches = (e: unknown): boolean => {
+    if (!e) return false;
+    if ((e as { code?: string }).code === "23505") return true;
+    const msg = e instanceof Error ? e.message : "";
+    return msg.includes("23505") || msg.includes("unique") || msg.includes("duplicate");
+  };
+  return matches(err) || matches((err as { cause?: unknown } | null)?.cause);
 }
 
 /**
- * Accept either a top-level Drizzle DB or a transaction handle. Same
- * pattern used by `routes/tablebase/audit-log.ts::logAuditEntries`.
- * Lets callers atomically write evidence + recompute verdict in one tx.
+ * Accept either a top-level Drizzle DB or a transaction handle so callers
+ * can write evidence + recompute the verdict atomically in one tx.
  */
 type Db =
   | import("drizzle-orm/postgres-js").PostgresJsDatabase<typeof schema>
@@ -135,10 +108,9 @@ async function loadEvidenceRows(
 }
 
 /**
- * Build the human-readable `reasoning` string written to
- * `source_check_verdicts.reasoning`. Reflects the aggregator's input so
- * the disagree-warning surface (QUA-792 Phase 3) can read the same
- * computation without re-deriving it.
+ * Human-readable `reasoning` string for `source_check_verdicts.reasoning`.
+ * Reflects the aggregator's contributing breakdown so the disagree-warning
+ * surface (QUA-792) can render the same computation without re-deriving it.
  */
 function buildReasoning(aggregate: AggregationResult): string {
   if (aggregate.verdict === "unchecked") {
@@ -149,14 +121,11 @@ function buildReasoning(aggregate: AggregationResult): string {
     }
     return `${aggregate.sourcesChecked} source(s) checked but none were relevant enough to draw a conclusion.`;
   }
-  const winner = aggregate.contributing[0];
-  const dissent = aggregate.contributing.slice(1);
-  const winnerStr = `${winner.rowCount} source(s) → ${winner.verdict}`;
-  if (dissent.length === 0) return winnerStr;
-  const dissentStr = dissent
-    .map((d) => `${d.rowCount} → ${d.verdict}`)
-    .join(", ");
-  return `${winnerStr}; dissent: ${dissentStr}`;
+  const fmt = (c: { rowCount: number; verdict: string }) =>
+    `${c.rowCount} → ${c.verdict}`;
+  const [winner, ...dissent] = aggregate.contributing;
+  if (dissent.length === 0) return fmt(winner);
+  return `${fmt(winner)}; dissent: ${dissent.map(fmt).join(", ")}`;
 }
 
 /**
@@ -190,12 +159,22 @@ export async function recomputeVerdict(
     reasoning: buildReasoning(aggregate),
   };
 
+  // No evidence at all → don't write a verdict row. Preserves back-compat
+  // for callers that use POST /verdicts as a verdict-only marker write
+  // (no evidence to roll up). When evidence later exists, the next
+  // POST /evidence call's recompute will populate the row.
+  if (evidence.length === 0) return result;
+
   const now = new Date();
 
   // Try UPDATE first. On no match, INSERT. Race-safe via the
   // unique-violation retry pattern used by the rest of this module.
-  // COALESCE the optional metadata fields so re-running recompute
-  // without them doesn't blow away previously-persisted display names.
+  // The metadata fields use the conditional-spread idiom so that
+  // `undefined` (caller omitted the field) preserves the existing DB
+  // value, while explicit `null` clears it. Callers like
+  // writeInlineVerdicts omit display-name fields and rely on existing
+  // values being kept; POST /verdicts/recompute may pass null explicitly
+  // (e.g. coerceDisplayName scrubbed a leaked sid_) and expects a clear.
   const updated = await db
     .update(sourceVerdicts)
     .set({
@@ -224,14 +203,9 @@ export async function recomputeVerdict(
 
   if (updated.length > 0) return result;
 
-  // Insert fresh row. If a concurrent call beat us to it, the unique
-  // index throws and we retry with UPDATE.
-  //
-  // Match the 90-day default that POST /verdicts and writeInlineVerdicts
-  // use (sourcing.ts:1390, write-inline-verdicts.ts:64) so newly-inserted
-  // recompute rows participate in the `due-for-recheck` cycle. Without
-  // this, recompute-only rows would sit at NULL `next_check_due` forever
-  // and never be picked up by the recheck pipeline.
+  // INSERT fresh row; on race-loss to a concurrent INSERT, retry as UPDATE.
+  // 90-day `next_check_due` matches POST /verdicts and writeInlineVerdicts
+  // so recompute-inserted rows participate in the `due-for-recheck` cycle.
   const ninetyDays = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
   try {
     await db.insert(sourceVerdicts).values({

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -1,23 +1,15 @@
 /**
- * Canonical source-check verdict aggregation (QUA-791 Phase 1).
+ * Canonical source-check verdict aggregation.
  *
  * Single source of truth for collapsing per-source `source_check_evidence`
- * rows into one `source_check_verdicts` row. Every code path that wants
- * to derive an aggregate verdict from raw evidence MUST go through
- * `aggregateEvidence()` here. Do not inline ad-hoc aggregation.
+ * rows into one `source_check_verdicts` row. Every code path that derives
+ * an aggregate verdict from raw evidence MUST go through `aggregateEvidence()`.
  *
- * The pre-Phase-1 behavior was last-writer-wins on `POST /verdicts`:
- * each evidence-writer call passed its own per-source verdict with
- * `sourcesChecked: 1`, and whoever wrote last set the aggregate. This
- * function replaces that with relevance-weighted aggregation that reads
- * the actual evidence rows.
- *
- * The priority ladder (`SOURCE_CHECK_VERDICT_PRIORITY`) lives in the
- * frontend `verdict-styles.ts`; we duplicate the same numeric ordering
- * here so the wiki-server doesn't depend on `apps/web`. Any change to
- * the ladder must be mirrored — the QUA-429 Phase 2 gate validator
- * `validate-verdict-priority` enforces that no other priority maps
- * exist outside these two files.
+ * `SOURCE_CHECK_VERDICT_PRIORITY` mirrors the canonical ladder in
+ * `apps/web/src/components/shared/verdict-styles.ts`; the wiki-server
+ * cannot import from apps/web, so the constant is duplicated. The
+ * `validate-verdict-priority` gate validator allowlists both files and
+ * blocks any third declaration.
  */
 
 import type {
@@ -82,6 +74,15 @@ interface AggregateOptions {
   minRelevance?: number;
 }
 
+interface Bucket {
+  weight: number;
+  rowCount: number;
+  /** Sum of `confidence × weight` for rows that reported a confidence. */
+  confidenceWeightedSum: number;
+  /** Sum of weights for the same rows (used as the denominator). */
+  confidenceWeightSum: number;
+}
+
 /**
  * Aggregate a set of evidence rows for a single
  * `(record_type, record_id, field_name)` key into one verdict.
@@ -140,22 +141,9 @@ export function aggregateEvidence(
   }
 
   // Step 4: per-verdict aggregates in one pass. Only rows above the
-  // threshold get to vote — otherwise low-relevance noise can swing
-  // ties between high-relevance verdicts. By construction, every row
-  // in `aboveThreshold` has verdict ∈ {confirmed, contradicted, outdated,
-  // partial, unverifiable} — `not_applicable` was filtered in step 1
-  // and `unchecked` is not a valid evidence verdict.
-  //
-  // Track confidence per bucket too (sum of `confidence × weight` and
-  // sum of weights for rows that reported a confidence value). Rows
-  // with NULL confidence are skipped from the average — they don't
-  // drag it toward zero, but they don't elevate it either.
-  interface Bucket {
-    weight: number;
-    rowCount: number;
-    confidenceWeightedSum: number;
-    confidenceWeightSum: number;
-  }
+  // threshold get to vote — low-relevance noise shouldn't swing ties.
+  // Rows with NULL confidence are skipped from the confidence average
+  // (don't drag it down, don't elevate it).
   const buckets = new Map<AggregateVerdict, Bucket>();
   for (const row of aboveThreshold) {
     const verdict = row.verdict as AggregateVerdict;
@@ -167,7 +155,7 @@ export function aggregateEvidence(
     }
     bucket.weight += w;
     bucket.rowCount += 1;
-    if (w > 0 && typeof row.confidence === "number") {
+    if (typeof row.confidence === "number") {
       bucket.confidenceWeightedSum += row.confidence * w;
       bucket.confidenceWeightSum += w;
     }

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -7,7 +7,6 @@ import {
   count,
   sql,
   desc,
-  lt,
   lte,
   gte,
   ne,
@@ -962,34 +961,15 @@ const sourcingApp = new Hono()
       }
     }
 
-    // Auto-flag corresponding verdicts for recheck.
-    //
-    // QUA-313: 7-day cooldown — skip verdicts whose `updated_at` is within the
-    // cooldown window. Without this, any burst of evidence writes (e.g.,
-    // `enrich --force` over already-enriched resources, or multiple source
-    // checks of the same record in quick succession) would spam
-    // `needs_recheck=true` on verdicts that were freshly rechecked.
-    // The cooldown interval matches the `--min-age=7d` default in
-    // `crux sourcing-mark`, so client-side and server-side layers agree.
-    const autoFlagCutoff = new Date(now.getTime() - AUTO_FLAG_COOLDOWN_MS);
-    const verdictUpdated = await db
-      .update(sourceVerdicts)
-      .set({ needsRecheck: true, updatedAt: now })
-      .where(
-        and(
-          eq(sourceVerdicts.recordType, body.recordType),
-          eq(sourceVerdicts.recordId, body.recordId),
-          lt(sourceVerdicts.updatedAt, autoFlagCutoff),
-        )
-      )
-      .returning({ recordId: sourceVerdicts.recordId });
-
     // QUA-791: recompute the aggregate so it reflects the row we just
-    // wrote (or updated). Best-effort: failure here does not fail the
-    // underlying evidence write — the next recompute call picks it up.
-    // Recompute clears `needs_recheck`; do this AFTER the auto-flag
-    // update so the recompute supersedes it (we just looked, no need
-    // to flag a recheck on this same write).
+    // wrote. Best-effort — failure here doesn't fail the evidence write;
+    // the next recompute call (or a periodic backfill) picks it up.
+    //
+    // The pre-QUA-791 handler also had a 7-day-cooldown auto-flag step
+    // that set `needs_recheck=true` on stale verdicts. Recompute now
+    // produces a fresh verdict from current evidence on every write, so
+    // the auto-flag is redundant and was removed; `verdictFlagged` is
+    // correspondingly dropped from the response (no callers consumed it).
     await recomputeVerdictBestEffort(db, {
       recordType: body.recordType,
       recordId: body.recordId,
@@ -1001,7 +981,6 @@ const sourcingApp = new Hono()
       {
         id: evidenceId,
         wasUpdated,
-        verdictFlagged: verdictUpdated.length > 0,
       },
       wasUpdated ? 200 : 201
     );
@@ -1425,37 +1404,18 @@ const sourcingApp = new Hono()
       }
     }
 
-    // QUA-791: trigger server-side recompute so the persisted aggregate
-    // reflects all evidence rows (not just whatever the last caller passed).
-    //
-    // **Only recompute when evidence rows exist** — preserves back-compat
-    // for callers that use POST /verdicts as a verdict-only write
-    // (e.g. metadata-only updates, manual marker writes). If we
-    // unconditionally recomputed, those writes would resolve to
-    // 'unchecked' because there's no evidence to roll up.
-    //
-    // Best-effort: a recompute failure does not fail the underlying write.
-    const fieldNameForRecompute = fieldNameVal ?? "";
-    const evidenceCount = await db
-      .select({ count: count() })
-      .from(recordSources)
-      .where(
-        and(
-          eq(recordSources.recordType, body.recordType),
-          eq(recordSources.recordId, body.recordId),
-          sql`COALESCE(${recordSources.fieldName}, '') = ${fieldNameForRecompute}`,
-        ),
-      );
-    if ((evidenceCount[0]?.count ?? 0) > 0) {
-      await recomputeVerdictBestEffort(db, {
-        recordType: body.recordType,
-        recordId: body.recordId,
-        fieldName: fieldNameVal,
-        entityId: entityIdVal,
-        displayName: displayNameVal,
-        entityDisplayName: entityDisplayNameVal,
-      });
-    }
+    // QUA-791: reconcile the persisted aggregate against all evidence rows.
+    // Best-effort. `recomputeVerdict` is a no-op (no DB writes) when the key
+    // has no evidence rows, which preserves back-compat for verdict-only
+    // marker writes.
+    await recomputeVerdictBestEffort(db, {
+      recordType: body.recordType,
+      recordId: body.recordId,
+      fieldName: fieldNameVal,
+      entityId: entityIdVal,
+      displayName: displayNameVal,
+      entityDisplayName: entityDisplayNameVal,
+    });
 
     return c.json({ ok: true }, 200);
   })

--- a/crux/scripts/recompute-source-verdicts.ts
+++ b/crux/scripts/recompute-source-verdicts.ts
@@ -1,18 +1,21 @@
 #!/usr/bin/env -S node --import tsx/esm
 /**
  * One-time backfill: recompute every source-check verdict from its
- * underlying evidence rows (QUA-791 Phase 1).
+ * underlying evidence rows (QUA-791).
  *
  * The pre-Phase-1 `POST /verdicts` endpoint was last-writer-wins —
  * whoever wrote last set the aggregate, regardless of the other
- * evidence rows. After QUA-791 lands, every new write triggers
- * server-side recompute. This script reconciles the *existing* table
- * by reading all distinct `(record_type, record_id, field_name)` keys
- * from `source_check_evidence` and POSTing
- * `/api/sourcing/verdicts/recompute` for each.
+ * evidence rows. Post-QUA-791, every new write triggers server-side
+ * recompute. This script reconciles the *existing* table by listing
+ * every `(record_type, record_id, field_name)` key with a verdict and
+ * POSTing `/api/sourcing/verdicts/recompute` for each.
  *
- * Reports a verdict-distribution diff (before vs after) so the operator
- * can see the impact before merging.
+ * **Concurrent-write caveat**: `/api/sourcing/verdicts` orders by
+ * `lastComputedAt desc`, so under active enrichment the cursor can
+ * skip rows. Recompute is idempotent — duplicates are harmless — but
+ * skipped keys remain on the legacy aggregate. Run during low-write
+ * periods or accept that ~1-5% of keys may need a follow-up POST
+ * /evidence to pick up the recompute.
  *
  * Usage:
  *   node --import tsx/esm crux/scripts/recompute-source-verdicts.ts             # dry run
@@ -24,14 +27,13 @@
  *   --apply           Actually call the recompute endpoint (default: dry-run, samples 5 keys)
  *   --limit=N         Process at most N keys
  *   --concurrency=N   Parallel requests (default: 5)
- *
- * Safe to re-run: each call is idempotent on the (recordType, recordId, fieldName) key.
  */
 
-import { config } from "dotenv";
-import { join } from "node:path";
-
-config({ path: join(import.meta.dirname, "../../.env") });
+import "dotenv/config";
+import {
+  listVerdicts,
+  recomputeVerdict,
+} from "../lib/wiki-server/sourcing-client.ts";
 
 const args = process.argv.slice(2);
 const APPLY = args.includes("--apply");
@@ -52,58 +54,6 @@ const CONCURRENCY = concurrencyArg
   ? parsePositiveInt(concurrencyArg.split("=")[1], "concurrency")
   : 5;
 
-const isProd = process.env.WIKI_SERVER_ENV === "prod";
-const BASE_URL = isProd
-  ? process.env.PROD_LONGTERMWIKI_SERVER_URL
-  : process.env.LONGTERMWIKI_SERVER_URL ?? "http://localhost:4850";
-const API_KEY = isProd
-  ? process.env.PROD_LONGTERMWIKI_SERVER_API_KEY
-  : process.env.LONGTERMWIKI_SERVER_API_KEY;
-
-if (!BASE_URL) {
-  console.error("ERROR: No wiki-server URL configured.");
-  process.exit(1);
-}
-
-function authHeaders(): Record<string, string> {
-  const h: Record<string, string> = { "Content-Type": "application/json" };
-  if (API_KEY) h["Authorization"] = `Bearer ${API_KEY}`;
-  return h;
-}
-
-interface DistributionRow {
-  verdict: string;
-  count: number;
-}
-
-/**
- * Pull current verdict distribution by paging through `/api/sourcing/verdicts`.
- * Aggregated client-side because there is no /stats endpoint that returns
- * raw verdict counts unfiltered by orphan-cleanup CTE.
- */
-async function fetchVerdictDistribution(): Promise<DistributionRow[]> {
-  const counts = new Map<string, number>();
-  let offset = 0;
-  const pageSize = 200;
-  while (true) {
-    const url = `${BASE_URL}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
-    const res = await fetch(url, { headers: authHeaders() });
-    if (!res.ok) {
-      throw new Error(`fetch verdicts failed: ${res.status} ${res.statusText}`);
-    }
-    const data = (await res.json()) as { verdicts: Array<{ verdict: string }>; total: number };
-    if (!data.verdicts || data.verdicts.length === 0) break;
-    for (const v of data.verdicts) {
-      counts.set(v.verdict, (counts.get(v.verdict) ?? 0) + 1);
-    }
-    offset += data.verdicts.length;
-    if (offset >= data.total) break;
-  }
-  return [...counts.entries()]
-    .map(([verdict, count]) => ({ verdict, count }))
-    .sort((a, b) => b.count - a.count);
-}
-
 interface EvidenceKey {
   recordType: string;
   recordId: string;
@@ -111,62 +61,78 @@ interface EvidenceKey {
 }
 
 /**
- * List every distinct (recordType, recordId, fieldName) key with at least
- * one evidence row. We page through `/api/sourcing/verdicts` because every
- * key with evidence almost certainly has a verdict row already (the old
- * code wrote them in lockstep). Anything we miss this pass — keys with
- * evidence but no verdict — gets picked up the next time POST /evidence
- * fires for that key (which now triggers recompute).
+ * Single paginated walk of `/api/sourcing/verdicts` that returns both
+ * the verdict-key list (input to recompute) and the verdict-distribution
+ * map (the "before" snapshot for diffing).
  */
-async function listKeys(): Promise<EvidenceKey[]> {
+async function fetchVerdictKeysAndDistribution(): Promise<{
+  keys: EvidenceKey[];
+  distribution: Map<string, number>;
+}> {
   const keys: EvidenceKey[] = [];
-  let offset = 0;
+  const distribution = new Map<string, number>();
   const pageSize = 500;
+  let offset = 0;
   while (true) {
-    const url = `${BASE_URL}/api/sourcing/verdicts?limit=${pageSize}&offset=${offset}`;
-    const res = await fetch(url, { headers: authHeaders() });
-    if (!res.ok) {
-      throw new Error(`list verdicts failed: ${res.status} ${res.statusText}`);
+    const result = await listVerdicts({ limit: pageSize, offset });
+    if (!result.ok) {
+      throw new Error(`list verdicts failed: ${result.error}`);
     }
-    const data = (await res.json()) as {
-      verdicts: Array<{ recordType: string; recordId: string; fieldName: string | null }>;
-      total: number;
-    };
-    if (!data.verdicts || data.verdicts.length === 0) break;
-    for (const v of data.verdicts) {
+    const { verdicts, total } = result.data;
+    if (!verdicts || verdicts.length === 0) break;
+    for (const v of verdicts) {
       keys.push({
         recordType: v.recordType,
         recordId: v.recordId,
         fieldName: v.fieldName ?? null,
       });
-      if (LIMIT && keys.length >= LIMIT) return keys;
+      distribution.set(v.verdict, (distribution.get(v.verdict) ?? 0) + 1);
+      if (LIMIT && keys.length >= LIMIT) {
+        return { keys, distribution };
+      }
     }
-    offset += data.verdicts.length;
-    if (offset >= data.total) break;
+    offset += verdicts.length;
+    if (offset >= total) break;
   }
-  return keys;
+  return { keys, distribution };
 }
 
-async function recompute(key: EvidenceKey): Promise<{ verdict: string; key: EvidenceKey } | null> {
-  const url = `${BASE_URL}/api/sourcing/verdicts/recompute`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: authHeaders(),
-    body: JSON.stringify({
-      recordType: key.recordType,
-      recordId: key.recordId,
-      fieldName: key.fieldName,
-    }),
+/** Diff-only walk for the "after" snapshot. */
+async function fetchVerdictDistribution(): Promise<Map<string, number>> {
+  const distribution = new Map<string, number>();
+  const pageSize = 500;
+  let offset = 0;
+  while (true) {
+    const result = await listVerdicts({ limit: pageSize, offset });
+    if (!result.ok) {
+      throw new Error(`list verdicts failed: ${result.error}`);
+    }
+    const { verdicts, total } = result.data;
+    if (!verdicts || verdicts.length === 0) break;
+    for (const v of verdicts) {
+      distribution.set(v.verdict, (distribution.get(v.verdict) ?? 0) + 1);
+    }
+    offset += verdicts.length;
+    if (offset >= total) break;
+  }
+  return distribution;
+}
+
+async function recomputeOne(
+  key: EvidenceKey,
+): Promise<{ verdict: string; key: EvidenceKey } | null> {
+  const result = await recomputeVerdict({
+    recordType: key.recordType,
+    recordId: key.recordId,
+    fieldName: key.fieldName,
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
+  if (!result.ok) {
     console.error(
-      `recompute failed: ${res.status} ${res.statusText} for ${key.recordType}/${key.recordId}/${key.fieldName ?? "null"} — ${text.slice(0, 200)}`,
+      `recompute failed for ${key.recordType}/${key.recordId}/${key.fieldName ?? "null"}: ${result.error}`,
     );
     return null;
   }
-  const data = (await res.json()) as { verdict: string };
-  return { verdict: data.verdict, key };
+  return { verdict: result.data.verdict, key };
 }
 
 async function runWithConcurrency<T, R>(
@@ -190,29 +156,29 @@ async function runWithConcurrency<T, R>(
   return results;
 }
 
+function printDistribution(label: string, dist: Map<string, number>): void {
+  console.log(`${label}:`);
+  const sorted = [...dist.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [verdict, count] of sorted) {
+    console.log(`  ${verdict.padEnd(15)} ${count}`);
+  }
+}
+
 async function main(): Promise<void> {
-  console.log(`Wiki-server: ${BASE_URL}`);
   console.log(`Mode: ${APPLY ? "APPLY (will write)" : "DRY RUN (samples 5 keys)"}`);
   if (LIMIT) console.log(`Limit: ${LIMIT}`);
   console.log("");
 
-  console.log("Fetching baseline verdict distribution...");
-  const before = await fetchVerdictDistribution();
-  console.log("Baseline:");
-  for (const { verdict, count } of before) {
-    console.log(`  ${verdict.padEnd(15)} ${count}`);
-  }
-  console.log("");
-
-  console.log("Listing keys to recompute...");
-  const keys = await listKeys();
+  console.log("Listing keys + baseline distribution...");
+  const { keys, distribution: before } = await fetchVerdictKeysAndDistribution();
   console.log(`  ${keys.length} keys`);
+  printDistribution("Baseline", before);
   console.log("");
 
   if (!APPLY) {
     console.log("DRY RUN — sampling 5 keys:");
     for (const key of keys.slice(0, 5)) {
-      const r = await recompute(key);
+      const r = await recomputeOne(key);
       if (r) {
         console.log(`  ${key.recordType}/${key.recordId}/${key.fieldName ?? "null"} → ${r.verdict}`);
       }
@@ -223,28 +189,21 @@ async function main(): Promise<void> {
 
   console.log(`Recomputing ${keys.length} keys with concurrency=${CONCURRENCY}...`);
   const t0 = Date.now();
-  const results = await runWithConcurrency(keys, CONCURRENCY, recompute);
+  const results = await runWithConcurrency(keys, CONCURRENCY, recomputeOne);
   const elapsedSec = Math.round((Date.now() - t0) / 1000);
   const ok = results.filter((r) => r !== null).length;
   const failed = results.length - ok;
-  console.log(`  ${ok} succeeded, ${failed} failed in ${elapsedSec}s`);
-  console.log("");
+  console.log(`  ${ok} succeeded, ${failed} failed in ${elapsedSec}s\n`);
 
-  console.log("Fetching post-recompute verdict distribution...");
+  console.log("Fetching post-recompute distribution...");
   const after = await fetchVerdictDistribution();
-  console.log("After:");
-  for (const { verdict, count } of after) {
-    console.log(`  ${verdict.padEnd(15)} ${count}`);
-  }
+  printDistribution("After", after);
 
   console.log("\nDiff (after - before):");
-  const verdicts = new Set([
-    ...before.map((r) => r.verdict),
-    ...after.map((r) => r.verdict),
-  ]);
+  const verdicts = new Set([...before.keys(), ...after.keys()]);
   for (const v of verdicts) {
-    const beforeCount = before.find((r) => r.verdict === v)?.count ?? 0;
-    const afterCount = after.find((r) => r.verdict === v)?.count ?? 0;
+    const beforeCount = before.get(v) ?? 0;
+    const afterCount = after.get(v) ?? 0;
     const delta = afterCount - beforeCount;
     if (delta === 0) continue;
     const sign = delta > 0 ? "+" : "";


### PR DESCRIPTION
## Summary

Follow-up to QUA-791 (PR #4645). Applies the 8 highest-leverage findings from the `/simplify` review pass that ran after PR #4645 was already merged.

Net **−121 lines** (296 deletions, 175 insertions across 5 files).

## What changed

- **Drop redundant `count(*)` gate in POST /verdicts.** The no-evidence short-circuit moved inside `recomputeVerdict` itself — one SELECT decides both "do we recompute?" and "what's the aggregate?". Saves one DB round-trip per call.
- **Drop redundant 7-day auto-flag step in POST /evidence.** Recompute now produces a fresh verdict on every write, so flagging-then-clearing was contradictory work that produced a misleading `verdictFlagged` field in the response. Field removed (no callers consumed it). `lt` import dropped.
- **Replace hand-rolled fetch/auth in `crux/scripts/recompute-source-verdicts.ts`** with the typed `sourcing-client` (`listVerdicts` + `recomputeVerdict`). Picks up `X-Agent-Session-Id` audit-attribution headers automatically. Eliminates ~80 lines of manual fetch/header wiring. Satisfies the `code-review-guidelines.md` "use typed wiki-server clients" rule.
- **Merge the script's two paginated walks** of `/api/sourcing/verdicts` into one (was 2× pageSize=200/500 walks of the same endpoint). Larger 500 pageSize used uniformly.
- **Simplify `isUniqueViolation`** from a 30-line cause-chain walker to a 10-line check on `err.code` + `err.cause.code` plus message-substring on either layer. Drops the depth-5 cap and `String(current)` fallthrough that defended against scenarios that don't occur.
- **Hoist `Bucket` interface** out of the function body in `sourcing-aggregation.ts`. Remove the redundant `w > 0` confidence guard (filtered upstream).
- **Trim narrative file docstrings** that explained the change instead of the behavior. Trim the 12-line 90-day comment to 3 lines. Update the misleading "POST /verdicts also calls recompute" comment (it's now gated on evidence).
- **Unify `buildReasoning`** winner/dissent format with a single `fmt()` helper (was inconsistent between the two cases).

## Why this is a follow-up PR (not part of #4645)

PR #4645 merged at 16:30 UTC while `/simplify` was still running. The simplify commits never reached the merged PR. This branch is the rebased simplify commit, ready for review.

## Test plan

- [x] `pnpm test` (wiki-server) — 1462 tests pass
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `pnpm crux w validate gate --fix` — 60/60 blocking checks pass
- [x] Manual run against prod: `node --import tsx/esm crux/scripts/recompute-source-verdicts.ts` lists 13947 keys, dry-run output as expected
- [x] `--limit=abc` exits 2 with error

## Deferred to separate tickets

The simplify pass also surfaced these reuse opportunities. They would broaden the PR's scope and aren't strictly QUA-791 scope; filing as follow-ups instead:

- Extract the `DbOrTx` union type (now 5 copies across `recompute-verdict.ts`, `audit-log.ts`, `write-inline-verdicts.ts`, `resolve-entity-fks.ts`, `thing-sync.ts`)
- Propagate the new `isUniqueViolation` helper to the other 3 sourcing call sites that have the same latent Drizzle-wrapper bug (`sourcing.ts:929`, `:1399`, `citations.ts:140`, `:190`)
- Eliminate the redundant inline verdict UPSERT in `writeInlineVerdicts` that recompute immediately supersedes
- Extract `runWithConcurrency` (3+ copies) and `parsePositiveInt` (2 copies)

Refs QUA-791

Fixes QUA-791
