### PR TITLE
fix(QUA-684): render date-shaped integers as dates, not magnitudes

### DIFF
--- a/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
@@ -95,6 +95,51 @@ describe("formatFactValueString (QUA-673)", () => {
   });
 });
 
+describe("formatFactValueString — date-shaped integers (QUA-684)", () => {
+  it("renders 14-digit YYYYMMDDhhmmss as a date, not a magnitude", () => {
+    // Without the date-shape check this would render as "$20.2T" — the
+    // openai render-audit-flagged value 20240601000000 (a Wayback Machine
+    // timestamp) being mistaken for a financial magnitude.
+    expect(formatFactValueString("20240601000000", "USD")).toBe(
+      "Jun 1, 2024 00:00:00 UTC"
+    );
+    expect(formatFactValueString("20240601000000", null)).toBe(
+      "Jun 1, 2024 00:00:00 UTC"
+    );
+  });
+
+  it("renders 12-digit YYYYMMDDhhmm as a date with hh:mm UTC", () => {
+    expect(formatFactValueString("202406011830", "USD")).toBe(
+      "Jun 1, 2024 18:30 UTC"
+    );
+  });
+
+  it("renders 8-digit YYYYMMDD as a date with no time", () => {
+    expect(formatFactValueString("20240601", null)).toBe("Jun 1, 2024");
+  });
+
+  it("date-shape check fires regardless of the 1000-magnitude floor", () => {
+    // 19500101 = 19.5M — well above the floor anyway, but the test asserts
+    // that the date branch wins even when both branches would otherwise fire.
+    expect(formatFactValueString("19500101", "USD")).toBe("Jan 1, 1950");
+    // 20240229 (Feb 29 of a leap year) — calendar-valid date.
+    expect(formatFactValueString("20240229", null)).toBe("Feb 29, 2024");
+  });
+
+  it("8-digit numbers that aren't valid dates stay raw or compact-formatted", () => {
+    // 19000000 has month=00 → not a date → falls through to magnitude path → "19M".
+    expect(formatFactValueString("19000000", null)).toBe("19M");
+    // 12345678 — not a date (12=month=12 valid? yes 12; day=34 invalid → not a date) → "12M".
+    expect(formatFactValueString("12345678", null)).toBe("12M");
+  });
+
+  it("does not trip the render-audit regex for date-shaped 12/14-digit values", () => {
+    const bigDigitRegex = /(?<![a-zA-Z_])\d{10,}(?![a-zA-Z])/;
+    expect(formatFactValueString("20240601000000", "USD")).not.toMatch(bigDigitRegex);
+    expect(formatFactValueString("202406011830", null)).not.toMatch(bigDigitRegex);
+  });
+});
+
 describe("sanitizeRawLargeNumbers (QUA-673)", () => {
   it("rewrites a bare 10+ digit run inside a label: value description", () => {
     // formatCompactNumber rounds to 1-decimal precision only below 10 of a

--- a/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/format-cell-value.test.ts
@@ -127,9 +127,9 @@ describe("formatFactValueString — date-shaped integers (QUA-684)", () => {
   });
 
   it("8-digit numbers that aren't valid dates stay raw or compact-formatted", () => {
-    // 19000000 has month=00 → not a date → falls through to magnitude path → "19M".
+    // 19000000 → year=1900 valid, month=00 invalid → not a date → "19M".
     expect(formatFactValueString("19000000", null)).toBe("19M");
-    // 12345678 — not a date (12=month=12 valid? yes 12; day=34 invalid → not a date) → "12M".
+    // 12345678 → year=1234 outside 1900-2099 → not a date → "12M".
     expect(formatFactValueString("12345678", null)).toBe("12M");
   });
 

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -21,6 +21,7 @@ import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 import {
   formatCompactCurrency,
   formatCompactNumber,
+  formatDateShapedInteger,
   sanitizeRawLargeNumbers,
 } from "@/lib/format-compact";
 import { isAnySid } from "@longterm-wiki/id-utils";
@@ -455,9 +456,13 @@ function CellValue({
 
   // Generic number values (real/doublePrecision columns arrive as typeof number)
   if (typeof value === "number" && isFinite(value)) {
-    const formatted = Math.abs(value) >= 1000
-      ? formatCompactNumber(value)
-      : Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2);
+    // Date-shaped integers take priority over magnitude formatting (QUA-684).
+    const dateShape = formatDateShapedInteger(value);
+    const formatted = dateShape ?? (
+      Math.abs(value) >= 1000
+        ? formatCompactNumber(value)
+        : Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2)
+    );
     return (
       <span className="text-[11px] tabular-nums" title={String(value)}>
         {formatted}

--- a/apps/web/src/app/internal/entity-profile/format-cell-value.ts
+++ b/apps/web/src/app/internal/entity-profile/format-cell-value.ts
@@ -1,4 +1,8 @@
-import { formatCompactCurrency, formatCompactNumber } from "@/lib/format-compact";
+import {
+  formatCompactCurrency,
+  formatCompactNumber,
+  formatDateShapedInteger,
+} from "@/lib/format-compact";
 
 /** Pure numeric literal: optionally signed, decimal, or scientific notation. */
 export const PURE_NUMERIC_STRING_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
@@ -8,11 +12,18 @@ export const PURE_NUMERIC_STRING_RE = /^-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
  * compact-formatted form; otherwise return null so the caller falls through
  * to its generic string renderer. The magnitude floor keeps small counts
  * (63 market-share, 1500 headcount) rendering as-is without distortion.
+ *
+ * Date-shaped integers (8/12/14 digits, YYYYMMDD[hhmm[ss]]) take priority
+ * over the magnitude formatter — `"20240601000000"` renders as
+ * `"Jun 1, 2024 00:00:00 UTC"`, not `"$20.2T"`. QUA-684.
  */
 export function formatFactValueString(value: string, currency?: string | null): string | null {
   const trimmed = value.trim();
   if (!trimmed || !PURE_NUMERIC_STRING_RE.test(trimmed)) return null;
   const n = Number(trimmed);
-  if (!Number.isFinite(n) || Math.abs(n) < 1000) return null;
+  if (!Number.isFinite(n)) return null;
+  const dateShape = formatDateShapedInteger(n);
+  if (dateShape) return dateShape;
+  if (Math.abs(n) < 1000) return null;
   return currency ? formatCompactCurrency(n, currency) : formatCompactNumber(n);
 }

--- a/apps/web/src/lib/__tests__/format-compact.test.ts
+++ b/apps/web/src/lib/__tests__/format-compact.test.ts
@@ -278,6 +278,13 @@ describe("formatDateShapedInteger (QUA-684)", () => {
       expect(formatDateShapedInteger(20240229)).toBe("Feb 29, 2024");
     });
 
+    it("applies the Gregorian century-year leap rule", () => {
+      // 1900 is divisible by 100 but not 400 → NOT a leap year.
+      expect(formatDateShapedInteger(19000229)).toBeNull();
+      // 2000 is divisible by 400 → IS a leap year.
+      expect(formatDateShapedInteger(20000229)).toBe("Feb 29, 2000");
+    });
+
     it("rejects invalid hour/minute/second in 12/14-digit shapes", () => {
       expect(formatDateShapedInteger(202406012400)).toBeNull(); // hour 24
       expect(formatDateShapedInteger(202406010060)).toBeNull(); // minute 60

--- a/apps/web/src/lib/__tests__/format-compact.test.ts
+++ b/apps/web/src/lib/__tests__/format-compact.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatCompactCurrency, formatCompactNumber, formatIntroducedDate } from "../format-compact";
+import {
+  formatCompactCurrency,
+  formatCompactNumber,
+  formatDateShapedInteger,
+  formatIntroducedDate,
+  sanitizeRawLargeNumbers,
+} from "../format-compact";
 
 describe("formatCompactCurrency", () => {
   it("formats trillions", () => {
@@ -206,5 +212,120 @@ describe("formatIntroducedDate", () => {
       // Day 32 is invalid — fall through to unknown-format branch
       expect(formatIntroducedDate("2021-01-32")).toBe("2021-01-32");
     });
+  });
+});
+
+describe("formatDateShapedInteger (QUA-684)", () => {
+  describe("recognized shapes", () => {
+    it("formats 14-digit YYYYMMDDhhmmss with full timestamp", () => {
+      // The exact value the QUA-684 issue cited from the openai render audit.
+      expect(formatDateShapedInteger(20240601000000)).toBe(
+        "Jun 1, 2024 00:00:00 UTC"
+      );
+      expect(formatDateShapedInteger(19991231235959)).toBe(
+        "Dec 31, 1999 23:59:59 UTC"
+      );
+    });
+
+    it("formats 12-digit YYYYMMDDhhmm with hours and minutes", () => {
+      expect(formatDateShapedInteger(202406010000)).toBe(
+        "Jun 1, 2024 00:00 UTC"
+      );
+      expect(formatDateShapedInteger(202312311800)).toBe(
+        "Dec 31, 2023 18:00 UTC"
+      );
+    });
+
+    it("formats 8-digit YYYYMMDD as date only", () => {
+      expect(formatDateShapedInteger(20240601)).toBe("Jun 1, 2024");
+      expect(formatDateShapedInteger(19501225)).toBe("Dec 25, 1950");
+      expect(formatDateShapedInteger(20991231)).toBe("Dec 31, 2099");
+    });
+  });
+
+  describe("rejects shapes that aren't dates", () => {
+    it("rejects 9, 10, 11, 13 digit lengths (Unix epoch — too ambiguous)", () => {
+      // 10 digit: ~2001-2033 epoch seconds, but also a plausible billion-scale
+      // count. Skip per QUA-684 issue note.
+      expect(formatDateShapedInteger(1700000000)).toBeNull();
+      expect(formatDateShapedInteger(1700000000000)).toBeNull(); // 13-digit ms
+      expect(formatDateShapedInteger(170000000)).toBeNull(); // 9-digit
+      expect(formatDateShapedInteger(17000000000)).toBeNull(); // 11-digit
+    });
+
+    it("rejects years outside 1900-2099", () => {
+      expect(formatDateShapedInteger(18991231)).toBeNull();
+      expect(formatDateShapedInteger(21000101)).toBeNull();
+    });
+
+    it("rejects invalid month (00 or 13+)", () => {
+      expect(formatDateShapedInteger(20240001)).toBeNull(); // month 00
+      expect(formatDateShapedInteger(20241301)).toBeNull(); // month 13
+    });
+
+    it("rejects invalid day (00 or 32+)", () => {
+      expect(formatDateShapedInteger(20240100)).toBeNull(); // day 00
+      expect(formatDateShapedInteger(20240132)).toBeNull(); // day 32
+    });
+
+    it("rejects calendar-invalid dates (Feb 30, Feb 29 in non-leap years)", () => {
+      expect(formatDateShapedInteger(20240230)).toBeNull(); // Feb 30
+      expect(formatDateShapedInteger(20230229)).toBeNull(); // Feb 29 in non-leap year
+      expect(formatDateShapedInteger(20240431)).toBeNull(); // Apr 31
+    });
+
+    it("accepts Feb 29 in leap years", () => {
+      expect(formatDateShapedInteger(20240229)).toBe("Feb 29, 2024");
+    });
+
+    it("rejects invalid hour/minute/second in 12/14-digit shapes", () => {
+      expect(formatDateShapedInteger(202406012400)).toBeNull(); // hour 24
+      expect(formatDateShapedInteger(202406010060)).toBeNull(); // minute 60
+      expect(formatDateShapedInteger(20240601235960)).toBeNull(); // second 60
+    });
+
+    it("rejects non-positive integers", () => {
+      expect(formatDateShapedInteger(0)).toBeNull();
+      expect(formatDateShapedInteger(-20240601)).toBeNull();
+    });
+
+    it("rejects non-finite and non-integer values", () => {
+      expect(formatDateShapedInteger(NaN)).toBeNull();
+      expect(formatDateShapedInteger(Infinity)).toBeNull();
+      expect(formatDateShapedInteger(20240601.5)).toBeNull();
+    });
+
+    it("rejects plausible 8-digit magnitudes that don't form a calendar date", () => {
+      // 19,000,000 → "19000000" — month 00, rejected.
+      expect(formatDateShapedInteger(19000000)).toBeNull();
+      // 20,240,000 → "20240000" — month 00, rejected.
+      expect(formatDateShapedInteger(20240000)).toBeNull();
+    });
+  });
+});
+
+describe("sanitizeRawLargeNumbers + dates (QUA-684)", () => {
+  it("rewrites 14-digit timestamps as dates, not magnitudes", () => {
+    expect(sanitizeRawLargeNumbers("Last seen: 20240601000000")).toBe(
+      "Last seen: Jun 1, 2024 00:00:00 UTC"
+    );
+  });
+
+  it("rewrites 12-digit timestamps as dates", () => {
+    expect(sanitizeRawLargeNumbers("Captured 202406010000")).toBe(
+      "Captured Jun 1, 2024 00:00 UTC"
+    );
+  });
+
+  it("preserves 10-digit financial magnitudes (compact form, not dates)", () => {
+    expect(sanitizeRawLargeNumbers("Revenue: 1700000000")).toBe(
+      "Revenue: 1.7B"
+    );
+  });
+
+  it("8-digit dates are below the 10-digit sanitize threshold and stay raw", () => {
+    // sanitizeRawLargeNumbers only fires on 10+ digit runs; 8-digit dates
+    // are not its concern. They're handled by the cell renderer directly.
+    expect(sanitizeRawLargeNumbers("Released 20240601")).toBe("Released 20240601");
   });
 });

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -89,10 +89,17 @@ const MONTH_ABBR = [
  *
  * 9, 10, 11, 13 digit lengths (Unix epoch seconds/ms) are intentionally
  * NOT detected — they overlap the plausible-magnitude range for headcount
- * and revenue facts. Caller must opt-in for those via a column-name hint.
+ * and revenue facts.
  */
 export function formatDateShapedInteger(n: number): string | null {
-  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  // Range gate skips String(n) allocation for the vast majority of non-date
+  // numbers (small counts, sub-1900 values, magnitudes beyond Dec 31, 2099).
+  if (
+    !Number.isFinite(n) ||
+    !Number.isInteger(n) ||
+    n < 19000101 ||
+    n > 20991231235959
+  ) return null;
   const s = String(n);
   if (s.length !== 8 && s.length !== 12 && s.length !== 14) return null;
 

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -69,7 +69,7 @@ export function formatCompactNumber(n: number | null | undefined): string {
   return n.toLocaleString();
 }
 
-const MONTH_ABBR_FULL = [
+const MONTH_ABBR = [
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
@@ -124,7 +124,7 @@ export function formatDateShapedInteger(n: number): string | null {
     d.getUTCDate() !== day
   ) return null;
 
-  const datePart = `${MONTH_ABBR_FULL[month - 1]} ${day}, ${year}`;
+  const datePart = `${MONTH_ABBR[month - 1]} ${day}, ${year}`;
   if (s.length === 8) return datePart;
   const hh = String(hour).padStart(2, "0");
   const mm = String(minute).padStart(2, "0");
@@ -166,11 +166,6 @@ export function sanitizeRawLargeNumbers(s: string): string {
 export function safeHref(url: string): string {
   return /^https?:\/\//i.test(url) ? url : "#";
 }
-
-const MONTH_ABBR = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
 
 /**
  * Format a legislation `introduced` date string with appropriate precision:

--- a/apps/web/src/lib/format-compact.ts
+++ b/apps/web/src/lib/format-compact.ts
@@ -69,9 +69,76 @@ export function formatCompactNumber(n: number | null | undefined): string {
   return n.toLocaleString();
 }
 
+const MONTH_ABBR_FULL = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * If `n` is a plausible YYYYMMDD-family timestamp encoded as a single
+ * positive integer (8/12/14 digits, year 1900-2099, calendar-valid
+ * month/day, valid hour/minute/second when present), return a human
+ * date string; otherwise return null.
+ *
+ * Catches BIGINT timestamp columns surfacing on the Database tab as raw
+ * integers (e.g. `20240601000000` from a `*_at` column stored as bigint
+ * encoded YYYYMMDDhhmmss instead of TIMESTAMPTZ). Without this check the
+ * compact-number formatter would render the value as a magnitude
+ * (`"$20.2T"` / `"20.2T"`) — technically not a 10+ digit leak but a
+ * misleading display. QUA-684.
+ *
+ * 9, 10, 11, 13 digit lengths (Unix epoch seconds/ms) are intentionally
+ * NOT detected — they overlap the plausible-magnitude range for headcount
+ * and revenue facts. Caller must opt-in for those via a column-name hint.
+ */
+export function formatDateShapedInteger(n: number): string | null {
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return null;
+  const s = String(n);
+  if (s.length !== 8 && s.length !== 12 && s.length !== 14) return null;
+
+  const year = Number(s.slice(0, 4));
+  const month = Number(s.slice(4, 6));
+  const day = Number(s.slice(6, 8));
+  if (year < 1900 || year > 2099) return null;
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  let hour = 0;
+  let minute = 0;
+  let second = 0;
+  if (s.length >= 12) {
+    hour = Number(s.slice(8, 10));
+    minute = Number(s.slice(10, 12));
+    if (hour > 23 || minute > 59) return null;
+  }
+  if (s.length === 14) {
+    second = Number(s.slice(12, 14));
+    if (second > 59) return null;
+  }
+
+  // Calendar-validity check (Feb 30, Feb 29 in non-leap years, etc.)
+  const d = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  if (
+    d.getUTCFullYear() !== year ||
+    d.getUTCMonth() !== month - 1 ||
+    d.getUTCDate() !== day
+  ) return null;
+
+  const datePart = `${MONTH_ABBR_FULL[month - 1]} ${day}, ${year}`;
+  if (s.length === 8) return datePart;
+  const hh = String(hour).padStart(2, "0");
+  const mm = String(minute).padStart(2, "0");
+  if (s.length === 12) return `${datePart} ${hh}:${mm} UTC`;
+  const ss = String(second).padStart(2, "0");
+  return `${datePart} ${hh}:${mm}:${ss} UTC`;
+}
+
 /**
  * Rewrite bare 10+ digit runs inside a display string as compact numbers
- * (`"Revenue: 1700000000"` → `"Revenue: 1.7B"`).
+ * (`"Revenue: 1700000000"` → `"Revenue: 1.7B"`). 12/14-digit runs that
+ * match a YYYYMMDD[hhmm[ss]] shape render as dates instead, so a stray
+ * `20240601000000` in a description is rewritten as `Jun 1, 2024 ...` not
+ * `20.2T`. QUA-684.
  *
  * Boundaries are tuned so embedded digit runs stay untouched:
  *   - Look-behind blocks letters, digits, underscores, and `.` so hashes
@@ -88,6 +155,8 @@ export function sanitizeRawLargeNumbers(s: string): string {
     (m) => {
       const n = Number(m);
       if (!Number.isFinite(n) || Math.abs(n) < 1000) return m;
+      const dateShape = formatDateShapedInteger(n);
+      if (dateShape) return dateShape;
       return formatCompactNumber(n);
     },
   );


### PR DESCRIPTION
## Summary

- New `formatDateShapedInteger` in `apps/web/src/lib/format-compact.ts` detects 8/12/14-digit YYYYMMDD[hhmm[ss]] integers (year 1900-2099, calendar-valid month/day/time, Date round-trip — rejects Feb 30, Feb 29 in non-leap years, etc.) and renders them as human dates.
- Wired into three call sites:
  - `formatFactValueString` (the fact `value` column on the `/organizations/*` Database tab) — `"20240601000000"` now renders as `Jun 1, 2024 00:00:00 UTC` instead of `$20.2T`.
  - The generic `typeof value === "number"` path in the entity-profile cell renderer.
  - `sanitizeRawLargeNumbers` (description columns) — embedded date-shaped runs route to date format instead of compact magnitude.

## Why

QUA-673 + QUA-675 healed the original symptom on prod (URL-embedded timestamps in `notes` columns). This PR closes the latent class flagged in the QUA-684 issue: any BIGINT timestamp column that ever surfaces a value like `20240601000000` on the Database tab will render as a date, not a misleading magnitude.

9/10/11/13-digit Unix epochs (seconds and milliseconds) are intentionally NOT detected — they overlap the plausible-magnitude range for headcount and revenue facts. The QUA-684 issue explicitly flagged these as too ambiguous.

## Test plan

- [x] 89 unit tests in `format-compact.test.ts` and `format-cell-value.test.ts` (62 + 26 + 1 new century-leap test): happy paths for 8/12/14 digit shapes, year/month/day/hour/minute/second bounds, Gregorian century-year leap rule (1900 not leap, 2000 leap), Feb 29 in non-leap years, NaN/Infinity/non-integer/negative rejection, render-audit `\d{10,}` regex compliance.
- [x] Adversarial fuzz against `formatDateShapedInteger` with 20 boundary inputs (2^53, scientific notation results, hour 24, minute 60, century leap edge cases) — all behave correctly.
- [x] Full apps/web suite (`pnpm vitest run`): 1745 tests pass.
- [x] `pnpm build`: 0 errors.
- [x] Full gate (`pnpm crux w validate gate --fix`): 62 blocking checks pass.
- [x] Render audit against prod (`PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts`): 30/30 pass.

## Reviewer notes

- The Date round-trip check is novel to this codebase — `formatIntroducedDate` and friends only do range-validity, not Feb-29-in-non-leap-year detection. Worth keeping local for now; if a second caller appears, extract `isValidUtcDate(year, month, day)` as a follow-up.
- Range gate `n < 19000101 || n > 20991231235959` skips the `String(n)` allocation for the vast majority of cell-render calls (small counts, large magnitudes outside the date envelope) — matters because the function runs per cell per row.

Closes QUA-684
