### PR TITLE
feat(QUA-329): wire previousContentHash through to resource-ingest

### DIFF
--- a/.claude/rules/source-check-system.md
+++ b/.claude/rules/source-check-system.md
@@ -78,6 +78,27 @@ If you're about to add a "show source-check status on X page", first grep for `R
 - **Data Quality** (E2600) — `/internal/data-quality/`
 - **People Coverage** (E1099) — entity coverage scores for people
 
+## 6a. Content-change detection — the re-classify-on-fetch flow (QUA-312 / QUA-329)
+
+When a resource's underlying content changes upstream, source-check verdicts that were generated against the old content are no longer trustworthy. The pipeline detects this automatically via a content hash:
+
+1. **Persist** — `crux/lib/job-handlers/resource-ingest.ts` computes a SHA-256 (first 16 hex) of the freshly-fetched content and writes it to `resources.content_hash` via `PATCH /api/resources/:id/fetch-status` (QUA-329).
+2. **Surface** — list / suggest endpoints return `contentHash` so callers enqueueing re-ingest jobs can pass it as `previousContentHash`.
+3. **Compare** — on the next ingest, `resource-ingest` compares the freshly-computed hash to `previousContentHash` and sets `contentChanged: true` when they differ.
+4. **Bypass skip-guard** — `resource-enrich` normally skips already-enriched resources, but `contentChanged: true` bypasses that guard so enrichment re-runs on the new content (QUA-312 Phase 2).
+5. **Re-classify** — re-enrichment cascades into a fresh source-check verdict against the updated content. Stale verdicts get refreshed; previously-confirmed verdicts that no longer hold flip to `contradicted` / `outdated`.
+
+**Production callers passing `previousContentHash`** (QUA-329):
+- `crux/commands/jobs.ts` `enqueueResourceReingest` (the `crux sys jobs enqueue-resource-reingest` periodic loop)
+- `apps/wiki-server/src/routes/wikibase/resources.ts` `POST /api/resources/suggest` (the claims-pipeline batch enqueue)
+
+**Callers that intentionally omit it** — these enqueue jobs for resources with no prior fetch (no hash to compare against):
+- `crux/commands/jobs.ts` `enqueueResourceIngest` — filters for `lastFetchedAt === null`
+- `crux/lib/sourcing/source-fetcher.ts` (cache-miss self-healing path) — URL has never been seen
+- `crux/commands/sourcing-orchestrate.ts` — uncached URLs only
+
+**Don't bypass the hash for re-fetches.** Skipping `previousContentHash` from a caller that has access to the prior hash silently disables QUA-312's temporal fix — the enrich skip-guard will block re-enrichment even on changed content. Test coverage: `crux/lib/job-handlers/__tests__/resource-ingest.test.ts` "round-trips contentHash from ingest #1 to previousContentHash on ingest #2".
+
 ## 7. Conventions
 
 - **Entity coverage scale**: 1=stub, 2=basic, 3=moderate, 4=comprehensive. Typical record is 2, not 3.

--- a/apps/wiki-server/src/__tests__/api-types-fetch-status-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-fetch-status-schema.test.ts
@@ -1,0 +1,77 @@
+/**
+ * QUA-329: schema validation for the new optional `contentHash` field on
+ * UpdateResourceFetchStatusSchema. The PATCH /:id/fetch-status endpoint
+ * persists this hash to `resources.content_hash` so subsequent re-ingest
+ * jobs can detect content drift via `previousContentHash`. Bad input here
+ * silently corrupts the temporal-fix chain, so validate at the boundary.
+ */
+import { describe, it, expect } from "vitest";
+import { UpdateResourceFetchStatusSchema } from "../api-types.js";
+
+describe("UpdateResourceFetchStatusSchema — contentHash", () => {
+  const baseValid = {
+    fetchStatus: "ok" as const,
+    lastFetchedAt: new Date().toISOString(),
+  };
+
+  it("accepts a 16-char lowercase hex hash (production format)", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "abc123def4567890",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a full 64-char lowercase hex SHA-256 (future-compat)", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "0".repeat(64),
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts the patch with contentHash omitted entirely", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse(baseValid);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an empty contentHash", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a contentHash longer than 64 chars", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "a".repeat(65),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects uppercase hex (must be lowercase)", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "ABC123DEF4567890",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects non-hex characters", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "g".repeat(16),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects shell-injection attempts in contentHash", () => {
+    const r = UpdateResourceFetchStatusSchema.safeParse({
+      ...baseValid,
+      contentHash: "abc; DROP TABLE",
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/wiki-server/src/__tests__/resources.test.ts
+++ b/apps/wiki-server/src/__tests__/resources.test.ts
@@ -20,10 +20,13 @@ let nextJobId = 1;
 // Since the mock doesn't model citation_content, we check:
 //   1. An explicit has_content field (set directly by suggest tests), OR
 //   2. content_hash being non-null (proxy for content having been fetched)
+// QUA-329: also surface content_hash so the route can pass it as
+// previousContentHash when enqueueing resource-ingest jobs.
 function toSuggestShape(row: ResourceRow): {
   id: string;
   url: string;
   title: string | null;
+  content_hash: string | null;
   fetched_at: Date | null;
   has_content: boolean;
 } {
@@ -31,6 +34,7 @@ function toSuggestShape(row: ResourceRow): {
     id: row.id,
     url: row.url,
     title: row.title ?? null,
+    content_hash: row.content_hash ?? null,
     fetched_at: row.fetched_at ?? null,
     has_content:
       row.has_content === true || (row.content_hash != null && row.content_hash !== ""),
@@ -232,6 +236,8 @@ function dispatch(query: string, params: unknown[]): unknown[] {
         id: row.id,
         url: row.url,
         title: null,
+        // QUA-329: brand-new rows have no prior content hash.
+        content_hash: null,
         fetched_at: null,
         has_content: false,
       });
@@ -1056,6 +1062,58 @@ describe("Resources API", () => {
       const jobId = body.results[0].jobId;
       const job = jobStore.get(jobId);
       expect(job!.priority).toBe(100); // capped at 100
+    });
+
+    // QUA-329: when re-ingesting a stale resource that has a recorded
+    // content_hash, /suggest must pass it as previousContentHash so the
+    // resource-ingest handler can detect content drift and bypass the
+    // resource-enrich skip-guard (QUA-312 Phase 2).
+    it("passes previousContentHash on the resource-ingest job for stale resources", async () => {
+      // Stale resource: fetched 30 days ago (older than the default 7-day max age),
+      // has cached content (has_content=true), and a known content hash.
+      const STALE_DATE = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      store.seedResource({
+        id: "stale-res",
+        stable_id: "sid_stale-res",
+        url: "https://example.com/stale",
+        title: "Stale Resource",
+        fetched_at: STALE_DATE,
+        has_content: true,
+        content_hash: "abc123def4567890",
+      });
+
+      const res = await postJson(app, "/api/resources/suggest", {
+        urls: ["https://example.com/stale"],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.results[0].contentStatus).toBe("stale");
+      expect(body.results[0].jobId).toBeTruthy();
+      expect(body.results[0].contentHash).toBe("abc123def4567890");
+
+      const job = jobStore.get(body.results[0].jobId);
+      expect(job).toBeDefined();
+      const params = job!.params as Record<string, unknown>;
+      expect(params.resourceId).toBe("stale-res");
+      expect(params.url).toBe("https://example.com/stale");
+      expect(params.previousContentHash).toBe("abc123def4567890");
+    });
+
+    it("omits previousContentHash for brand-new resources with no prior hash", async () => {
+      // Missing resource: brand-new URL, no content_hash on file.
+      const res = await postJson(app, "/api/resources/suggest", {
+        urls: ["https://example.com/brand-new"],
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.results[0].contentStatus).toBe("missing");
+      expect(body.results[0].contentHash).toBeNull();
+
+      const job = jobStore.get(body.results[0].jobId);
+      const params = job!.params as Record<string, unknown>;
+      expect(params).not.toHaveProperty("previousContentHash");
     });
   });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -967,6 +967,14 @@ export const UpdateResourceFetchStatusSchema = z.object({
   fetchStatus: z.enum(["ok", "dead", "soft_404", "not_found", "timeout", "unreachable", "paywall", "error"]),
   lastFetchedAt: z.string().datetime(),
   fetchedTitle: z.string().max(1000).optional(),
+  /**
+   * SHA-256 (first 16 hex) of the freshly-fetched content. When provided,
+   * persisted to `resources.content_hash` so subsequent re-ingest jobs can
+   * pass it as `previousContentHash` and detect content drift via the
+   * QUA-312 Phase 2 skip-guard bypass. Null/empty content (dead links,
+   * paywalls) skips this update.
+   */
+  contentHash: z.string().min(1).max(64).optional(),
 });
 export type UpdateResourceFetchStatus = z.infer<typeof UpdateResourceFetchStatusSchema>;
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -968,13 +968,17 @@ export const UpdateResourceFetchStatusSchema = z.object({
   lastFetchedAt: z.string().datetime(),
   fetchedTitle: z.string().max(1000).optional(),
   /**
-   * SHA-256 (first 16 hex) of the freshly-fetched content. When provided,
-   * persisted to `resources.content_hash` so subsequent re-ingest jobs can
-   * pass it as `previousContentHash` and detect content drift via the
-   * QUA-312 Phase 2 skip-guard bypass. Null/empty content (dead links,
-   * paywalls) skips this update.
+   * SHA-256 prefix (lowercase hex) of the freshly-fetched content. When
+   * provided, persisted to `resources.content_hash` so subsequent re-ingest
+   * jobs can pass it as `previousContentHash` and detect content drift via
+   * the QUA-312 Phase 2 skip-guard bypass. Null/empty content (dead links,
+   * paywalls) skips this update. Soft-404 / cookie-wall responses also
+   * skip — see resource-ingest.ts persistedHash logic.
+   *
+   * Length cap of 64 accommodates any prefix of SHA-256 (production today
+   * uses the first 16 hex via CONTENT_HASH_PREFIX_LENGTH).
    */
-  contentHash: z.string().min(1).max(64).optional(),
+  contentHash: z.string().regex(/^[0-9a-f]+$/, "must be lowercase hex").min(1).max(64).optional(),
 });
 export type UpdateResourceFetchStatus = z.infer<typeof UpdateResourceFetchStatusSchema>;
 

--- a/apps/wiki-server/src/routes/wikibase/resources.ts
+++ b/apps/wiki-server/src/routes/wikibase/resources.ts
@@ -681,11 +681,15 @@ const resourcesApp = new Hono()
       title: string | null;
       fetched_at: string | Date | null;
       has_content: boolean;
+      // QUA-329: include the resource's persisted content_hash so the
+      // resource-ingest job below can pass it as previousContentHash and
+      // detect content drift on re-fetch.
+      content_hash: string | null;
     }
     const existingRows: ResourceWithContent[] =
       allVariants.length > 0
         ? await rawDb<ResourceWithContent[]>`
-            SELECT r.id, r.url, r.title, cc.fetched_at,
+            SELECT r.id, r.url, r.title, r.content_hash, cc.fetched_at,
               (cc.full_text IS NOT NULL AND length(cc.full_text) > 0) AS has_content
             FROM resources r
             LEFT JOIN citation_content cc ON cc.resource_id = r.id
@@ -723,7 +727,7 @@ const resourcesApp = new Hono()
           AS t(id, url, stable_id),
           LATERAL (SELECT 'web'::text AS type, now() AS created_at, now() AS updated_at) defaults
         ON CONFLICT (url) DO UPDATE SET updated_at = now()
-        RETURNING id, url, title, null::timestamptz AS fetched_at, false AS has_content
+        RETURNING id, url, title, content_hash, null::timestamptz AS fetched_at, false AS has_content
       `;
       for (const row of created) {
         // Find which input URL this row corresponds to
@@ -741,7 +745,7 @@ const resourcesApp = new Hono()
         if (!urlToResource.has(url)) {
           const variants = urlVariants(url);
           const fallback = await rawDb<ResourceWithContent[]>`
-            SELECT r.id, r.url, r.title, cc.fetched_at,
+            SELECT r.id, r.url, r.title, r.content_hash, cc.fetched_at,
               (cc.full_text IS NOT NULL AND length(cc.full_text) > 0) AS has_content
             FROM resources r
             LEFT JOIN citation_content cc ON cc.resource_id = r.id
@@ -753,7 +757,7 @@ const resourcesApp = new Hono()
           } else {
             logger.warn({ url, id: hashId(url) }, "suggest: could not resolve resource — using fallback");
             urlToResource.set(url, {
-              id: hashId(url), url, title: null, fetched_at: null, has_content: false,
+              id: hashId(url), url, title: null, fetched_at: null, has_content: false, content_hash: null,
             });
           }
         }
@@ -778,6 +782,9 @@ const resourcesApp = new Hono()
         resourceId: r.id,
         contentStatus,
         title: r.title,
+        // QUA-329: surface the previously-recorded content hash so the
+        // resource-ingest job below can pass it as previousContentHash.
+        contentHash: r.content_hash,
         jobId: null as number | null,
       };
     });
@@ -812,17 +819,29 @@ const resourcesApp = new Hono()
       }
 
       // Insert jobs with dedup keys using raw SQL for ON CONFLICT dedup
-      // (same pattern as jobs.ts DEDUP_INSERT_SQL)
+      // (same pattern as jobs.ts DEDUP_INSERT_SQL).
+      // QUA-329: when the resource has a previously-recorded content_hash
+      // (i.e. it's been fetched before — typical for "stale" status), pass
+      // it as previousContentHash so the ingest handler can detect drift.
+      // For "missing" content, contentHash is null and the field is omitted.
       for (const item of toIngest) {
         const citCount = citationCountMap.get(item.resourceId) ?? 0;
         const priority = Math.min(100, citCount * 5);
         const dedupKey = `batch:${batchId}:${item.resourceId}`;
 
+        const jobParams: Record<string, unknown> = {
+          resourceId: item.resourceId,
+          url: item.url,
+        };
+        if (item.contentHash) {
+          jobParams.previousContentHash = item.contentHash;
+        }
+
         const insertResult = await rawDb<{ id: number }[]>`
           INSERT INTO jobs (type, params, priority, max_retries, dedup_key)
           VALUES (
             'resource-ingest',
-            ${JSON.stringify({ resourceId: item.resourceId, url: item.url })}::jsonb,
+            ${JSON.stringify(jobParams)}::jsonb,
             ${priority},
             3,
             ${dedupKey}
@@ -1502,7 +1521,7 @@ const resourcesApp = new Hono()
     const id = c.req.param("id");
     const db = getDrizzleDb();
 
-    const { fetchStatus, lastFetchedAt, fetchedTitle } = c.req.valid("json");
+    const { fetchStatus, lastFetchedAt, fetchedTitle, contentHash } = c.req.valid("json");
 
     const updateSet: Record<string, unknown> = {
       fetchStatus,
@@ -1513,6 +1532,14 @@ const resourcesApp = new Hono()
     // Optionally update title if provided and resource has no title yet
     if (fetchedTitle) {
       updateSet.title = sql`COALESCE(${resources.title}, ${fetchedTitle})`;
+    }
+
+    // QUA-329: persist the freshly-computed content hash so future re-ingests
+    // can pass it as `previousContentHash` and the skip-guard bypass activates
+    // when content drifts. Always overwrite when provided — the most-recent
+    // fetch wins.
+    if (contentHash) {
+      updateSet.contentHash = contentHash;
     }
 
     const updated = await db

--- a/crux/commands/jobs.ts
+++ b/crux/commands/jobs.ts
@@ -829,7 +829,13 @@ async function enqueueResourceReingest(_args: string[], options: CommandOptions)
   let pageOffset = 0;
   let total = 0;
   const now = Date.now();
-  const stale: Array<{ id: string; url: string; lifecycle: string | null; lastFetchedAt: string }> = [];
+  const stale: Array<{
+    id: string;
+    url: string;
+    lifecycle: string | null;
+    lastFetchedAt: string;
+    contentHash: string | null;
+  }> = [];
   let immutableSkipped = 0;
   let neverFetched = 0;
 
@@ -873,7 +879,13 @@ async function enqueueResourceReingest(_args: string[], options: CommandOptions)
       const ageDays = ageMs / (24 * 60 * 60 * 1000);
 
       if (ageDays >= thresholdDays) {
-        stale.push({ id: r.id, url: r.url, lifecycle: r.contentLifecycle, lastFetchedAt: r.lastFetchedAt });
+        stale.push({
+          id: r.id,
+          url: r.url,
+          lifecycle: r.contentLifecycle,
+          lastFetchedAt: r.lastFetchedAt,
+          contentHash: r.contentHash ?? null,
+        });
       }
     }
 
@@ -928,9 +940,18 @@ async function enqueueResourceReingest(_args: string[], options: CommandOptions)
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
+      // QUA-329: pass previousContentHash so the resource-ingest handler can
+      // compute contentChanged and bypass the resource-enrich skip-guard when
+      // content has shifted since the last fetch (QUA-312 Phase 2). The hash
+      // is the SHA-256 first 16 hex of previously-fetched content, persisted
+      // to `resources.content_hash` by the previous ingest run.
       const result = await createJob({
         type: 'resource-ingest',
-        params: { resourceId: r.id, url: r.url, previousContentHash: undefined },
+        params: {
+          resourceId: r.id,
+          url: r.url,
+          ...(r.contentHash ? { previousContentHash: r.contentHash } : {}),
+        },
         priority: 2,
         maxRetries: 3,
         dedupKey: `reingest:${r.id}`,

--- a/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
+++ b/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
@@ -384,6 +384,56 @@ describe('handleResourceIngest — fetch_status persistence', () => {
     const call = (updateResourceFetchStatus as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call?.[1]).not.toHaveProperty('contentHash');
   });
+
+  // QUA-329 review: soft_404 / cookie_blocked pages still produce a content
+  // body and a hash, but it's the hash of the placeholder, not real content.
+  // Persisting it would lock future re-ingests into contentChanged:false even
+  // after the page recovers, permanently blocking re-enrichment.
+  it('does NOT persist contentHash for soft_404 status', async () => {
+    const { updateResourceFetchStatus } = await import('../../wiki-server/resources.ts');
+    mockFetchSource.mockResolvedValue(mockFetchResult({
+      status: 'ok' as FetchedSourceStatus,
+      httpStatus: 200,
+      content: 'Page not found. The page you requested does not exist.',
+    }));
+
+    const result = await handleResourceIngest(
+      { resourceId: 'res-soft404', url: 'https://example.com/missing' },
+      CTX,
+    );
+
+    expect(result.data.status).toBe('soft_404');
+
+    const calls = (updateResourceFetchStatus as ReturnType<typeof vi.fn>).mock.calls;
+    const softCall = calls.find((c) => (c?.[0] as string) === 'res-soft404');
+    expect(softCall, 'fetch-status patch should be issued for the resource').toBeTruthy();
+    expect(softCall?.[1]).not.toHaveProperty('contentHash');
+  });
+
+  it('does NOT persist contentHash for cookie_blocked status', async () => {
+    const { updateResourceFetchStatus } = await import('../../wiki-server/resources.ts');
+    // A short page with cookie-consent text triggers cookie_blocked internal
+    // status. Note: toFetchStatus() maps cookie_blocked → 'error' for the
+    // wire format, so the patch's fetchStatus is 'error' (not 'cookie_blocked').
+    // The internal-status assertion lives on result.data.status separately.
+    mockFetchSource.mockResolvedValue(mockFetchResult({
+      content: '<html><body><h1>This site requires cookies</h1><p>Please enable cookies to continue.</p></body></html>',
+    }));
+
+    const result = await handleResourceIngest(
+      { resourceId: 'res-cookie', url: 'https://example.com/wall' },
+      CTX,
+    );
+
+    // Confirm the cookie path was actually exercised
+    expect(result.data.status).toBe('cookie_blocked');
+
+    // The persisted patch should NOT carry contentHash (status !== 'reachable')
+    const calls = (updateResourceFetchStatus as ReturnType<typeof vi.fn>).mock.calls;
+    const cookieCall = calls.find((c) => (c?.[0] as string) === 'res-cookie');
+    expect(cookieCall, 'fetch-status patch should be issued for the resource').toBeTruthy();
+    expect(cookieCall?.[1]).not.toHaveProperty('contentHash');
+  });
 });
 
 describe('handleResourceIngest — enrichment chaining', () => {

--- a/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
+++ b/crux/lib/job-handlers/__tests__/resource-ingest.test.ts
@@ -346,6 +346,44 @@ describe('handleResourceIngest — fetch_status persistence', () => {
       expect.objectContaining({ fetchStatus: 'not_found' }),
     );
   });
+
+  // QUA-329: persist freshly-computed contentHash so the next re-ingest can
+  // pass it as previousContentHash and detect drift.
+  it('persists contentHash to resources.content_hash on a reachable fetch', async () => {
+    const { updateResourceFetchStatus } = await import('../../wiki-server/resources.ts');
+    const content = 'A new article version about AI safety.';
+    mockFetchSource.mockResolvedValue(mockFetchResult({ content }));
+
+    await handleResourceIngest(
+      { resourceId: 'res-1', url: 'https://example.com/article' },
+      CTX,
+    );
+
+    expect(updateResourceFetchStatus).toHaveBeenCalledWith(
+      'res-1',
+      expect.objectContaining({
+        fetchStatus: 'ok',
+        contentHash: expectedHash(content),
+      }),
+    );
+  });
+
+  it('does NOT include contentHash in the patch when content is empty', async () => {
+    const { updateResourceFetchStatus } = await import('../../wiki-server/resources.ts');
+    mockFetchSource.mockResolvedValue(mockFetchResult({
+      status: 'ok' as FetchedSourceStatus,
+      httpStatus: 200,
+      content: '',
+    }));
+
+    await handleResourceIngest(
+      { resourceId: 'res-1', url: 'https://example.com/empty' },
+      CTX,
+    );
+
+    const call = (updateResourceFetchStatus as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call?.[1]).not.toHaveProperty('contentHash');
+  });
 });
 
 describe('handleResourceIngest — enrichment chaining', () => {
@@ -454,6 +492,70 @@ describe('handleResourceIngest — enrichment chaining', () => {
         // No contentChanged key on params when content is unchanged
         params: { resourceId: 'res-1', url: 'https://example.com/article' },
         dedupKey: 'resource-enrich:res-1',
+      }),
+    );
+  });
+
+  // QUA-329 end-to-end: this test simulates the temporal flow of the fix.
+  // Ingest #1 fetches initial content and persists its hash. Ingest #2 reads
+  // back the persisted hash (as previousContentHash) and detects a content
+  // change, which propagates contentChanged: true into the resource-enrich
+  // job — this is the bypass that activates QUA-312 Phase 2 in production.
+  it('round-trips contentHash from ingest #1 to previousContentHash on ingest #2', async () => {
+    const { updateResourceFetchStatus } = await import('../../wiki-server/resources.ts');
+
+    // ----- Ingest #1: initial fetch -----
+    const v1 = 'Original article content.';
+    mockFetchSource.mockResolvedValueOnce(mockFetchResult({ content: v1 }));
+
+    const result1 = await handleResourceIngest(
+      { resourceId: 'res-roundtrip', url: 'https://example.com/article' },
+      CTX,
+    );
+    expect(result1.success).toBe(true);
+    expect(result1.data.contentHash).toBe(expectedHash(v1));
+
+    // The hash from ingest #1 is what would be stored in resources.content_hash.
+    expect(updateResourceFetchStatus).toHaveBeenCalledWith(
+      'res-roundtrip',
+      expect.objectContaining({ contentHash: expectedHash(v1) }),
+    );
+
+    // The first ingest enqueued a resource-enrich job WITHOUT contentChanged
+    // (no previousContentHash was supplied) — initial enrichment runs normally.
+    expect(mockCreateJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'resource-enrich',
+        params: { resourceId: 'res-roundtrip', url: 'https://example.com/article' },
+      }),
+    );
+
+    mockCreateJob.mockClear();
+
+    // ----- Ingest #2: re-ingest with the persisted hash and DIFFERENT content -----
+    const v2 = 'Updated article content with new claims.';
+    mockFetchSource.mockResolvedValueOnce(mockFetchResult({ content: v2 }));
+
+    const result2 = await handleResourceIngest(
+      {
+        resourceId: 'res-roundtrip',
+        url: 'https://example.com/article',
+        previousContentHash: expectedHash(v1), // what listResources / /suggest would supply
+      },
+      CTX,
+    );
+    expect(result2.success).toBe(true);
+    expect(result2.data.contentChanged).toBe(true);
+    expect(result2.data.contentHash).toBe(expectedHash(v2));
+
+    // The skip-guard bypass: contentChanged: true reaches resource-enrich.
+    expect(mockCreateJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'resource-enrich',
+        params: expect.objectContaining({
+          resourceId: 'res-roundtrip',
+          contentChanged: true,
+        }),
       }),
     );
   });

--- a/crux/lib/job-handlers/resource-ingest.ts
+++ b/crux/lib/job-handlers/resource-ingest.ts
@@ -312,7 +312,14 @@ export async function handleResourceIngest(
     // Also persist the new contentHash (when present) so the next re-ingest
     // can pass it as previousContentHash and the QUA-312 Phase 2 skip-guard
     // bypass activates when content drifts.
-    await persistFetchStatus(resourceId, status, ctx, contentHash);
+    //
+    // ONLY persist on 'reachable' — soft_404 and cookie_blocked still produce
+    // a content body (and hence a hash), but it's the hash of the placeholder.
+    // Persisting it would lock future re-ingests of the same URL into
+    // `contentChanged: false` even after the page recovers, permanently
+    // blocking re-enrichment via the skip-guard. See QUA-329 review.
+    const persistedHash = status === 'reachable' ? contentHash : null;
+    await persistFetchStatus(resourceId, status, ctx, persistedHash);
 
     // Chain: enqueue resource-enrich job for reachable resources with content.
     // Skip if content is empty — fetchSource returns ok but no content for some

--- a/crux/lib/job-handlers/resource-ingest.ts
+++ b/crux/lib/job-handlers/resource-ingest.ts
@@ -309,7 +309,10 @@ export async function handleResourceIngest(
 
     // Persist fetch_status to the resource record.
     // Content caching is already handled by fetchSource() internally.
-    await persistFetchStatus(resourceId, status, ctx);
+    // Also persist the new contentHash (when present) so the next re-ingest
+    // can pass it as previousContentHash and the QUA-312 Phase 2 skip-guard
+    // bypass activates when content drifts.
+    await persistFetchStatus(resourceId, status, ctx, contentHash);
 
     // Chain: enqueue resource-enrich job for reachable resources with content.
     // Skip if content is empty — fetchSource returns ok but no content for some
@@ -378,17 +381,24 @@ export async function handleResourceIngest(
 /**
  * Update the resource's fetch_status. Fire-and-forget — errors are logged
  * but don't fail the job. Content caching is handled by fetchSource().
+ *
+ * When `contentHash` is provided (non-empty content was fetched), it is
+ * persisted to `resources.content_hash` so future re-ingests can pass it
+ * as `previousContentHash` and detect content drift (QUA-329).
  */
 async function persistFetchStatus(
   resourceId: string,
   status: ResourceStatus,
   ctx: JobHandlerContext,
+  contentHash?: string | null,
 ): Promise<void> {
   try {
-    await updateResourceFetchStatus(resourceId, {
+    const payload: UpdateResourceFetchStatus = {
       fetchStatus: toFetchStatus(status),
       lastFetchedAt: new Date().toISOString(),
-    });
+      ...(contentHash ? { contentHash } : {}),
+    };
+    await updateResourceFetchStatus(resourceId, payload);
     if (ctx.verbose) {
       console.log(`[resource-ingest] Updated fetch_status=${toFetchStatus(status)} for ${resourceId}`);
     }


### PR DESCRIPTION
## Summary

Completes the QUA-312 Phase 2 temporal fix by wiring `previousContentHash` through two production callers of `resource-ingest`. Until now, the enrich skip-guard bypass (`contentChanged: true` → re-enrich on changed content) was implemented but never activated in prod because no caller passed the prior hash.

This PR closes the chain end-to-end:

1. **Persist** — `resource-ingest` now writes its freshly-computed `contentHash` to `resources.content_hash` via `PATCH /:id/fetch-status`. The schema (`UpdateResourceFetchStatusSchema`) gains an optional `contentHash` field with strict lowercase-hex validation.
2. **Read back & propagate** in two production callers:
   - `crux/commands/jobs.ts:enqueueResourceReingest` (the `crux sys jobs enqueue-resource-reingest` periodic stale-content loop) reads `r.contentHash` from `listResources` and passes it as `previousContentHash`.
   - `apps/wiki-server/src/routes/wikibase/resources.ts:/suggest` (the claims-pipeline batch enqueue) adds `r.content_hash` to its existing-resource lookup queries and includes it in the resource-ingest job params for stale resources.
3. **Skip-poisoning fix** (caught by `/agent-review-pr` hostile-reviewer): persistence is gated on `status === 'reachable'`. Soft-404 / cookie-wall responses still produce a content body and a hash, but it's the hash of the placeholder — persisting it would lock future re-ingests into `contentChanged: false` even after the page recovers, permanently blocking re-enrichment.

Three other call sites intentionally omit the field — they enqueue jobs for resources with no prior fetch (no hash to compare): `enqueueResourceIngest` filters `lastFetchedAt=null`, source-fetcher's cache-miss self-heal path, and sourcing-orchestrate's uncached-URL list.

## Key changes

- `apps/wiki-server/src/api-types.ts` — new optional `contentHash` field on `UpdateResourceFetchStatusSchema` with `z.string().regex(/^[0-9a-f]+$/).min(1).max(64)`
- `apps/wiki-server/src/routes/wikibase/resources.ts` — PATCH `/fetch-status` writes the hash; `/suggest` returns + propagates it
- `crux/lib/job-handlers/resource-ingest.ts` — gated persistence (`status === 'reachable'` only)
- `crux/commands/jobs.ts` — reingest-stale loop reads `r.contentHash`
- `.claude/rules/source-check-system.md` — new section 6a documenting the re-classify-on-fetch flow

## Test plan

- [x] `pnpm test` — 8200/8201 pass (1 pre-existing unrelated `validate-sourcing-lint-guard` baseline drift from QUA-429 merge into main)
- [x] `pnpm build` — clean
- [x] Type-check — clean across web, wiki-server, crux
- [x] `pnpm crux w validate gate --fix` — 60/60 gate checks pass
- [x] New: `resource-ingest.test.ts` "round-trips contentHash from ingest #1 to previousContentHash on ingest #2" — end-to-end integration of the temporal fix
- [x] New: `resource-ingest.test.ts` — soft_404 and cookie_blocked statuses do NOT persist contentHash (regression guard for the hash-poisoning bug)
- [x] New: `api-types-fetch-status-schema.test.ts` — Zod schema accepts 16-char and 64-char lowercase hex; rejects empty, uppercase, non-hex, oversize, and shell-injection attempts
- [x] New: `resources.test.ts` — `/suggest` passes `previousContentHash` for stale resources, omits for brand-new

## Acceptance criteria (from QUA-329)

- [x] At least one production `resource-ingest` enqueue site passes `previousContentHash` when available — **two**: `enqueueResourceReingest` and `/suggest`
- [x] Integration test: starting from an enriched resource, re-ingesting with different content triggers a second enrich (proving skip-guard bypass activates)
- [x] Update `.claude/rules/*` docs to reflect the new re-classify-on-fetch story

Closes QUA-329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content-change detection: persisted content hashes and automatic re-running of enrichment and re-classification when content changes, refreshing or flipping stale verdicts.

* **API / UX**
  * Suggested results now surface content-hash info; fetch-status updates accept an optional content-hash.

* **Documentation**
  * Added rules describing content-hash flow and caller requirements for re-ingest jobs.

* **Tests**
  * Added tests covering content-hash validation, persistence, job-enqueue behavior, and end-to-end change-detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->