### PR TITLE
fix: update legacy source-check terminology in comments to unblock main CI

### DIFF
--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -1,5 +1,5 @@
 /**
- * Shared types for source-check verdict aggregation (QUA-791).
+ * Shared types for sourcing verdict aggregation (QUA-791).
  *
  * Lives in a separate file from the aggregation logic so consumers
  * (route, tests, callers) can import the types without pulling the

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical source-check verdict aggregation.
+ * Canonical sourcing verdict aggregation.
  *
  * Single source of truth for collapsing per-source `source_check_evidence`
  * rows into one `source_check_verdicts` row. Every code path that derives

--- a/crux/scripts/recompute-source-verdicts.ts
+++ b/crux/scripts/recompute-source-verdicts.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --import tsx/esm
 /**
- * One-time backfill: recompute every source-check verdict from its
+ * One-time backfill: recompute every sourcing verdict from its
  * underlying evidence rows (QUA-791).
  *
  * The pre-Phase-1 `POST /verdicts` endpoint was last-writer-wins —

--- a/crux/validate/validate-verdict-priority.ts
+++ b/crux/validate/validate-verdict-priority.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Validate that source-check verdict severity/priority is defined in exactly
+ * Validate that sourcing verdict severity/priority is defined in exactly
  * one place: SOURCE_CHECK_VERDICT_PRIORITY in apps/web/src/components/shared/verdict-styles.ts.
  *
  * QUA-429 found two helpers (`pickWorstVerdict`, `rollupVerdictFromSummary`)


### PR DESCRIPTION
## Summary

- `validate-sourcing-lint-guard` ratchet test was failing on main CI since PR #4639 (QUA-429) merged
- Four new files added by PRs #4639 and #4645 used "source-check" in doc comments, bumping the ratchet count from 1 → 4
- Fixed by changing `source-check` → `sourcing` in 4 comment lines (no logic changes)

## Root cause

Files affected:
- `crux/validate/validate-verdict-priority.ts` — added by QUA-429 / PR #4639
- `apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts` — added by QUA-791 / PR #4645
- `apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts` — added by QUA-791 / PR #4645
- `crux/scripts/recompute-source-verdicts.ts` — added by QUA-791 / PR #4645

The ratchet (`QUA-102/QUA-237` rename effort) enforces that new code uses "sourcing" not "source-check".

## Test plan

- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` → "At baseline (1 references across 1669 files)"
- [x] `GITHUB_REF=refs/heads/main npx vitest run crux/validate/validate-sourcing-lint-guard.test.ts` → 14 tests passed

Fixes CI failure from run #25065115841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in documentation and comments across the platform for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->