### PR TITLE
feat(QUA-767): close out Phase 1 of QUA-90 — lead_investor fallback + formatting tests

### DIFF
--- a/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
@@ -5,6 +5,7 @@ import {
   ENTITY_REF_FALLBACKS,
   tryParseNumeric,
   formatPercentage,
+  resolveFallbackValue,
 } from "../format-numeric";
 
 describe("tryParseNumeric (QUA-767)", () => {
@@ -103,14 +104,17 @@ describe("formatPercentage (QUA-767)", () => {
 });
 
 describe("CURRENCY_COLUMNS membership (QUA-767)", () => {
-  it("includes the columns named in the QUA-767 task list", () => {
-    const required = [
+  it("includes every column the set is documented to contain", () => {
+    // Locking down the full membership so a future drop / rename / typo
+    // surfaces as a test failure instead of a silent regression in formatting.
+    const expected = [
       "amount", "raised", "raised_low", "raised_high",
       "valuation", "valuation_low", "valuation_high",
       "amount_low", "amount_high", "total_budget",
-      "usd_equivalent",
+      "usd_equivalent", "cost_usd",
     ];
-    for (const col of required) {
+    expect(CURRENCY_COLUMNS.size).toBe(expected.length);
+    for (const col of expected) {
       expect(CURRENCY_COLUMNS.has(col), `expected ${col} in CURRENCY_COLUMNS`).toBe(true);
     }
   });
@@ -147,7 +151,68 @@ describe("ENTITY_REF_FALLBACKS (QUA-767)", () => {
     // arrive with camelCase keys, so a snake_case fallback target would
     // silently miss every row.
     for (const fallback of Object.values(ENTITY_REF_FALLBACKS)) {
+      if (fallback === undefined) continue;
       expect(fallback, `fallback ${fallback} must be camelCase`).not.toMatch(/_/);
     }
+  });
+});
+
+describe("resolveFallbackValue (QUA-767)", () => {
+  const row = {
+    leadInvestor: "Sequoia Capital",
+    leadInvestorEntityId: null,
+    notes: "ok",
+  };
+
+  it("returns the primary value untouched when it is non-empty", () => {
+    const r = resolveFallbackValue("sid_abc", "lead_investor_entity_id", row);
+    expect(r).toEqual({ value: "sid_abc", isFallback: false });
+  });
+
+  it("falls back to the legacy text column when primary is null", () => {
+    const r = resolveFallbackValue(null, "lead_investor_entity_id", row);
+    expect(r).toEqual({ value: "Sequoia Capital", isFallback: true });
+  });
+
+  it("falls back when primary is undefined", () => {
+    const r = resolveFallbackValue(undefined, "lead_investor_entity_id", row);
+    expect(r).toEqual({ value: "Sequoia Capital", isFallback: true });
+  });
+
+  it("falls back when primary is the empty string", () => {
+    const r = resolveFallbackValue("", "lead_investor_entity_id", row);
+    expect(r).toEqual({ value: "Sequoia Capital", isFallback: true });
+  });
+
+  it("does NOT fall back when the column has no fallback configured", () => {
+    const r = resolveFallbackValue(null, "company_entity_id", row);
+    expect(r).toEqual({ value: null, isFallback: false });
+  });
+
+  it("does NOT fall back when the fallback row key is missing on the row", () => {
+    const r = resolveFallbackValue(null, "lead_investor_entity_id", { foo: "bar" });
+    expect(r).toEqual({ value: null, isFallback: false });
+  });
+
+  it("does NOT fall back when the fallback row key is the empty string", () => {
+    const r = resolveFallbackValue(null, "lead_investor_entity_id", { leadInvestor: "" });
+    expect(r).toEqual({ value: null, isFallback: false });
+  });
+
+  it("rejects non-string fallback candidates so a 'Lead Investor' column never renders a JSON blob", () => {
+    // A stray numeric / object / boolean in the legacy column would otherwise
+    // flow into `CellValue` and render through the JsonValue / boolean paths,
+    // producing absurd output in a column labeled "Lead Investor".
+    expect(resolveFallbackValue(null, "lead_investor_entity_id", { leadInvestor: 42 }))
+      .toEqual({ value: null, isFallback: false });
+    expect(resolveFallbackValue(null, "lead_investor_entity_id", { leadInvestor: { name: "x" } }))
+      .toEqual({ value: null, isFallback: false });
+    expect(resolveFallbackValue(null, "lead_investor_entity_id", { leadInvestor: true }))
+      .toEqual({ value: null, isFallback: false });
+  });
+
+  it("returns the primary value untouched when row is undefined", () => {
+    const r = resolveFallbackValue(null, "lead_investor_entity_id", undefined);
+    expect(r).toEqual({ value: null, isFallback: false });
   });
 });

--- a/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  CURRENCY_COLUMNS,
+  PERCENTAGE_COLUMNS,
+  ENTITY_REF_FALLBACKS,
+  tryParseNumeric,
+  formatPercentage,
+} from "../format-numeric";
+
+describe("tryParseNumeric (QUA-767)", () => {
+  it("accepts plain numbers", () => {
+    expect(tryParseNumeric(0)).toBe(0);
+    expect(tryParseNumeric(42)).toBe(42);
+    expect(tryParseNumeric(-1.5)).toBe(-1.5);
+    expect(tryParseNumeric(450_000_000)).toBe(450_000_000);
+  });
+
+  it("accepts numeric strings (Drizzle returns numeric() as string)", () => {
+    expect(tryParseNumeric("450000000")).toBe(450_000_000);
+    expect(tryParseNumeric("0.07")).toBe(0.07);
+    expect(tryParseNumeric("-1.5")).toBe(-1.5);
+    expect(tryParseNumeric("1e9")).toBe(1_000_000_000);
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(tryParseNumeric("  450  ")).toBe(450);
+  });
+
+  it("returns null for null/undefined/non-string-non-number", () => {
+    expect(tryParseNumeric(null)).toBeNull();
+    expect(tryParseNumeric(undefined)).toBeNull();
+    expect(tryParseNumeric({})).toBeNull();
+    expect(tryParseNumeric([1, 2])).toBeNull();
+    expect(tryParseNumeric(true)).toBeNull();
+  });
+
+  it("returns null for empty / whitespace-only strings", () => {
+    expect(tryParseNumeric("")).toBeNull();
+    expect(tryParseNumeric("   ")).toBeNull();
+  });
+
+  it('returns null for non-numeric strings like "not-a-number"', () => {
+    expect(tryParseNumeric("not-a-number")).toBeNull();
+    expect(tryParseNumeric("Menlo Park, CA")).toBeNull();
+    expect(tryParseNumeric("sid_abc123")).toBeNull();
+  });
+
+  it('returns null for range strings like "[0.07, 0.15]" so they fall through to JSON renderer', () => {
+    expect(tryParseNumeric("[0.07, 0.15]")).toBeNull();
+    expect(tryParseNumeric("[1, 2, 3]")).toBeNull();
+    expect(tryParseNumeric('{"low": 0.07}')).toBeNull();
+  });
+
+  it("returns null for NaN / Infinity / -Infinity", () => {
+    expect(tryParseNumeric(NaN)).toBeNull();
+    expect(tryParseNumeric(Infinity)).toBeNull();
+    expect(tryParseNumeric(-Infinity)).toBeNull();
+    expect(tryParseNumeric("NaN")).toBeNull();
+    expect(tryParseNumeric("Infinity")).toBeNull();
+  });
+
+  it("handles very large numeric strings without precision loss for typical funding amounts", () => {
+    // $4 billion — the largest funding round in QUA-90 acceptance criteria
+    expect(tryParseNumeric("4000000000")).toBe(4_000_000_000);
+    // Above Number.MAX_SAFE_INTEGER would lose precision, but tryParseNumeric
+    // still returns *some* finite number rather than null. Worth a regression
+    // marker so anyone changing the helper notices.
+    const huge = tryParseNumeric("9007199254740993"); // MAX_SAFE_INTEGER + 2
+    expect(huge).not.toBeNull();
+    expect(Number.isFinite(huge)).toBe(true);
+  });
+});
+
+describe("formatPercentage (QUA-767)", () => {
+  it("formats 0–1 decimals as X.X% (multiplies by 100)", () => {
+    expect(formatPercentage(0.07)).toBe("7%");
+    expect(formatPercentage(0.15)).toBe("15%");
+    expect(formatPercentage(0.123)).toBe("12.3%");
+    expect(formatPercentage(0.5)).toBe("50%");
+    expect(formatPercentage(1)).toBe("100%");
+  });
+
+  it("treats values > 1 as already-percent-points (legacy data)", () => {
+    expect(formatPercentage(15)).toBe("15%");
+    expect(formatPercentage(7.5)).toBe("7.5%");
+  });
+
+  it("strips trailing .0 for clean display", () => {
+    expect(formatPercentage(0.07)).toBe("7%"); // not "7.0%"
+    expect(formatPercentage(0.5)).toBe("50%"); // not "50.0%"
+  });
+
+  it("preserves one decimal when the value has fractional precision", () => {
+    expect(formatPercentage(0.073)).toBe("7.3%");
+    expect(formatPercentage(0.155)).toBe("15.5%");
+  });
+
+  it("handles zero and negative values", () => {
+    expect(formatPercentage(0)).toBe("0%");
+    // Negative stake is unusual but should not crash; formatter preserves sign.
+    expect(formatPercentage(-0.05)).toBe("-5%");
+  });
+});
+
+describe("CURRENCY_COLUMNS membership (QUA-767)", () => {
+  it("includes the columns named in the QUA-767 task list", () => {
+    const required = [
+      "amount", "raised", "raised_low", "raised_high",
+      "valuation", "valuation_low", "valuation_high",
+      "amount_low", "amount_high", "total_budget",
+      "usd_equivalent",
+    ];
+    for (const col of required) {
+      expect(CURRENCY_COLUMNS.has(col), `expected ${col} in CURRENCY_COLUMNS`).toBe(true);
+    }
+  });
+
+  it("does NOT include obviously-non-currency columns", () => {
+    expect(CURRENCY_COLUMNS.has("stake_low")).toBe(false);
+    expect(CURRENCY_COLUMNS.has("stake_high")).toBe(false);
+    expect(CURRENCY_COLUMNS.has("entity_id")).toBe(false);
+    expect(CURRENCY_COLUMNS.has("title")).toBe(false);
+    expect(CURRENCY_COLUMNS.has("notes")).toBe(false);
+  });
+});
+
+describe("PERCENTAGE_COLUMNS membership (QUA-767)", () => {
+  it("includes the stake columns named in the QUA-767 task list", () => {
+    expect(PERCENTAGE_COLUMNS.has("stake_low")).toBe(true);
+    expect(PERCENTAGE_COLUMNS.has("stake_high")).toBe(true);
+  });
+
+  it("does NOT overlap with CURRENCY_COLUMNS", () => {
+    for (const col of PERCENTAGE_COLUMNS) {
+      expect(CURRENCY_COLUMNS.has(col), `${col} should not be in both sets`).toBe(false);
+    }
+  });
+});
+
+describe("ENTITY_REF_FALLBACKS (QUA-767)", () => {
+  it("maps lead_investor_entity_id to the legacy raw text column", () => {
+    expect(ENTITY_REF_FALLBACKS["lead_investor_entity_id"]).toBe("leadInvestor");
+  });
+
+  it("uses camelCase keys on the right-hand side (matches Drizzle row shape)", () => {
+    // The viewer reads `row[ENTITY_REF_FALLBACKS[col.name]]`. Drizzle rows
+    // arrive with camelCase keys, so a snake_case fallback target would
+    // silently miss every row.
+    for (const fallback of Object.values(ENTITY_REF_FALLBACKS)) {
+      expect(fallback, `fallback ${fallback} must be camelCase`).not.toMatch(/_/);
+    }
+  });
+});

--- a/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
+++ b/apps/web/src/app/internal/entity-profile/__tests__/formatting.test.ts
@@ -60,15 +60,9 @@ describe("tryParseNumeric (QUA-767)", () => {
     expect(tryParseNumeric("Infinity")).toBeNull();
   });
 
-  it("handles very large numeric strings without precision loss for typical funding amounts", () => {
-    // $4 billion — the largest funding round in QUA-90 acceptance criteria
+  it("handles very large numeric strings for typical funding amounts", () => {
+    // $4 billion — the largest funding round in QUA-90 acceptance criteria.
     expect(tryParseNumeric("4000000000")).toBe(4_000_000_000);
-    // Above Number.MAX_SAFE_INTEGER would lose precision, but tryParseNumeric
-    // still returns *some* finite number rather than null. Worth a regression
-    // marker so anyone changing the helper notices.
-    const huge = tryParseNumeric("9007199254740993"); // MAX_SAFE_INTEGER + 2
-    expect(huge).not.toBeNull();
-    expect(Number.isFinite(huge)).toBe(true);
   });
 });
 

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -26,6 +26,13 @@ import {
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { isEntityRefColumn } from "./entity-ref-columns";
 import {
+  CURRENCY_COLUMNS,
+  PERCENTAGE_COLUMNS,
+  ENTITY_REF_FALLBACKS,
+  tryParseNumeric,
+  formatPercentage,
+} from "./format-numeric";
+import {
   sanitizeRawIds,
   isClickableFactId,
   isOpaqueLegacyFactId,
@@ -269,37 +276,6 @@ const GLOBAL_HIDDEN_COLUMNS = new Set(["id"]);
 
 /** Max rows to show initially before "Show all" */
 const INITIAL_ROW_LIMIT = 20;
-
-// ── Numeric formatting columns ────────────────────────────────────────────
-
-/** Columns representing monetary amounts (Drizzle returns numeric() as strings) */
-const CURRENCY_COLUMNS = new Set([
-  "amount", "raised", "raised_low", "raised_high",
-  "valuation", "valuation_low", "valuation_high",
-  "amount_low", "amount_high", "total_budget",
-  "usd_equivalent", "cost_usd",
-]);
-
-/** Columns representing 0-1 decimal fractions displayed as percentages */
-const PERCENTAGE_COLUMNS = new Set([
-  "stake_low", "stake_high",
-]);
-
-function formatPercentage(n: number): string {
-  // Values > 1 are likely already percentages (e.g., 15 = 15%), not decimals
-  const pct = Math.abs(n) > 1 ? n : n * 100;
-  return `${pct.toFixed(1).replace(/\.0$/, "")}%`;
-}
-
-/** Try to parse a value as a number. Returns null if not parseable or is a range string like "[0.07, 0.15]". */
-function tryParseNumeric(value: unknown): number | null {
-  if (typeof value === "number") return isFinite(value) ? value : null;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.startsWith("[") || trimmed.startsWith("{")) return null;
-  const n = Number(trimmed);
-  return isFinite(n) ? n : null;
-}
 
 // ── Expandable text ───────────────────────────────────────────────────────
 
@@ -774,7 +750,15 @@ function ProfileSection({
                     })()}
                     {visibleColumns.map((col) => {
                       const camelKey = snakeToCamel(col.name);
-                      const value = camelKey in row ? row[camelKey] : row[col.name];
+                      let value = camelKey in row ? row[camelKey] : row[col.name];
+                      // Fall back to a raw legacy column when the entity-ref FK is
+                      // null. Without this, funding rounds whose `lead_investor`
+                      // never resolved render as em-dash even though the legacy
+                      // text column has a usable display name.
+                      if ((value === null || value === undefined || value === "") && ENTITY_REF_FALLBACKS[col.name]) {
+                        const fallback = row[ENTITY_REF_FALLBACKS[col.name]];
+                        if (fallback != null && fallback !== "") value = fallback;
+                      }
                       return (
                         <td key={col.name} className="px-3 py-2 align-top">
                           <CellValue value={value} columnName={col.name} displayNames={displayNames} row={row} />

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -28,9 +28,9 @@ import { isEntityRefColumn } from "./entity-ref-columns";
 import {
   CURRENCY_COLUMNS,
   PERCENTAGE_COLUMNS,
-  ENTITY_REF_FALLBACKS,
   tryParseNumeric,
   formatPercentage,
+  resolveFallbackValue,
 } from "./format-numeric";
 import {
   sanitizeRawIds,
@@ -750,18 +750,22 @@ function ProfileSection({
                     })()}
                     {visibleColumns.map((col) => {
                       const camelKey = snakeToCamel(col.name);
-                      let value = camelKey in row ? row[camelKey] : row[col.name];
-                      // Fall back to a raw legacy column when the entity-ref FK is
-                      // null. Without this, funding rounds whose `lead_investor`
-                      // never resolved render as em-dash even though the legacy
-                      // text column has a usable display name.
-                      if ((value === null || value === undefined || value === "") && ENTITY_REF_FALLBACKS[col.name]) {
-                        const fallback = row[ENTITY_REF_FALLBACKS[col.name]];
-                        if (fallback != null && fallback !== "") value = fallback;
-                      }
+                      const primary = camelKey in row ? row[camelKey] : row[col.name];
+                      // Resolve through the entity-ref fallback map so funding
+                      // rounds whose `lead_investor` FK never resolved still
+                      // render the legacy raw text instead of em-dash. The
+                      // helper rejects non-string fallback candidates so a
+                      // column labeled "Lead Investor" can never accidentally
+                      // render a JSON blob.
+                      const { value, isFallback } = resolveFallbackValue(primary, col.name, row);
+                      const cell = <CellValue value={value} columnName={col.name} displayNames={displayNames} row={row} />;
                       return (
-                        <td key={col.name} className="px-3 py-2 align-top">
-                          <CellValue value={value} columnName={col.name} displayNames={displayNames} row={row} />
+                        <td
+                          key={col.name}
+                          className="px-3 py-2 align-top"
+                          title={isFallback ? "Fallback: entity FK is null, showing legacy raw text" : undefined}
+                        >
+                          {isFallback ? <span className="italic text-muted-foreground">{cell}</span> : cell}
                         </td>
                       );
                     })}

--- a/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
+++ b/apps/web/src/app/internal/entity-profile/entity-profile-viewer.tsx
@@ -751,12 +751,6 @@ function ProfileSection({
                     {visibleColumns.map((col) => {
                       const camelKey = snakeToCamel(col.name);
                       const primary = camelKey in row ? row[camelKey] : row[col.name];
-                      // Resolve through the entity-ref fallback map so funding
-                      // rounds whose `lead_investor` FK never resolved still
-                      // render the legacy raw text instead of em-dash. The
-                      // helper rejects non-string fallback candidates so a
-                      // column labeled "Lead Investor" can never accidentally
-                      // render a JSON blob.
                       const { value, isFallback } = resolveFallbackValue(primary, col.name, row);
                       const cell = <CellValue value={value} columnName={col.name} displayNames={displayNames} row={row} />;
                       return (

--- a/apps/web/src/app/internal/entity-profile/format-numeric.ts
+++ b/apps/web/src/app/internal/entity-profile/format-numeric.ts
@@ -24,11 +24,44 @@ export const PERCENTAGE_COLUMNS = new Set([
 /** Visible entity-ref columns that should fall back to a raw legacy text
  *  column (typically also in HIDDEN_COLUMNS) when the FK is null. Avoids
  *  showing em-dash on funding-round rows that only have legacy raw text. */
-export const ENTITY_REF_FALLBACKS: Record<string, string> = {
+export const ENTITY_REF_FALLBACKS: Partial<Record<string, string>> = {
   // lead_investor_entity_id renders as the "Lead Investor" column. When the
   // FK is unresolved, fall back to the raw legacy text column.
   lead_investor_entity_id: "leadInvestor",
 };
+
+/**
+ * Resolve the value for a cell in the entity-profile rendering loop, applying
+ * the `ENTITY_REF_FALLBACKS` mapping when the primary value is empty.
+ *
+ * Returns `{ value, isFallback }` so the caller can visually mark fallback
+ * renders — the admin DB Records tab is a debugging surface, and silently
+ * substituting legacy text for a null FK could hide data-quality issues if
+ * we didn't call it out.
+ *
+ * Fallback only fires when:
+ *   - the column has an entry in `ENTITY_REF_FALLBACKS`,
+ *   - the primary value is `null` / `undefined` / empty string,
+ *   - the fallback row key resolves to a non-empty *string* (objects /
+ *     numbers / booleans are rejected — a column labeled "Lead Investor"
+ *     showing a JSON blob would be worse than em-dash).
+ */
+export function resolveFallbackValue(
+  primary: unknown,
+  columnName: string,
+  row: Record<string, unknown> | undefined,
+): { value: unknown; isFallback: boolean } {
+  if (primary !== null && primary !== undefined && primary !== "") {
+    return { value: primary, isFallback: false };
+  }
+  const fallbackKey = ENTITY_REF_FALLBACKS[columnName];
+  if (!fallbackKey || !row) return { value: primary, isFallback: false };
+  const candidate = row[fallbackKey];
+  if (typeof candidate !== "string" || candidate === "") {
+    return { value: primary, isFallback: false };
+  }
+  return { value: candidate, isFallback: true };
+}
 
 /**
  * Try to parse a value as a finite number. Accepts both `number` (already

--- a/apps/web/src/app/internal/entity-profile/format-numeric.ts
+++ b/apps/web/src/app/internal/entity-profile/format-numeric.ts
@@ -1,0 +1,58 @@
+/**
+ * Numeric formatting helpers for the entity-profile Database Records tab.
+ * Extracted from entity-profile-viewer.tsx so they're testable in isolation.
+ *
+ * The viewer's `CellValue` consults these to decide whether a column should
+ * render as compact currency (`$450M`), a percentage (`7.0%`), a generic
+ * compact number (`1.7B`), or fall through to the string renderer.
+ */
+
+/** Columns representing monetary amounts. Drizzle's `numeric()` arrives as a
+ *  string in the row, so the formatter must accept either. */
+export const CURRENCY_COLUMNS = new Set([
+  "amount", "raised", "raised_low", "raised_high",
+  "valuation", "valuation_low", "valuation_high",
+  "amount_low", "amount_high", "total_budget",
+  "usd_equivalent", "cost_usd",
+]);
+
+/** Columns storing 0–1 decimal fractions that should render as `X.X%`. */
+export const PERCENTAGE_COLUMNS = new Set([
+  "stake_low", "stake_high",
+]);
+
+/** Visible entity-ref columns that should fall back to a raw legacy text
+ *  column (typically also in HIDDEN_COLUMNS) when the FK is null. Avoids
+ *  showing em-dash on funding-round rows that only have legacy raw text. */
+export const ENTITY_REF_FALLBACKS: Record<string, string> = {
+  // lead_investor_entity_id renders as the "Lead Investor" column. When the
+  // FK is unresolved, fall back to the raw legacy text column.
+  lead_investor_entity_id: "leadInvestor",
+};
+
+/**
+ * Try to parse a value as a finite number. Accepts both `number` (already
+ * parsed) and `string` (Drizzle numeric()/bigint encoding). Rejects:
+ *   - null / undefined / non-numeric types
+ *   - empty / whitespace-only strings
+ *   - range strings like "[0.07, 0.15]" or JSON object/array literals
+ *   - NaN, Infinity, -Infinity
+ */
+export function tryParseNumeric(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("[") || trimmed.startsWith("{")) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Format a numeric stake/percentage value. PG stores stakes as 0–1 decimals
+ * (`0.07` = 7%), but a few legacy rows already encode them as percent points
+ * (`15` = 15%). We disambiguate on `Math.abs(n) > 1`.
+ */
+export function formatPercentage(n: number): string {
+  const pct = Math.abs(n) > 1 ? n : n * 100;
+  return `${pct.toFixed(1).replace(/\.0$/, "")}%`;
+}

--- a/apps/web/src/app/internal/entity-profile/format-numeric.ts
+++ b/apps/web/src/app/internal/entity-profile/format-numeric.ts
@@ -63,14 +63,8 @@ export function resolveFallbackValue(
   return { value: candidate, isFallback: true };
 }
 
-/**
- * Try to parse a value as a finite number. Accepts both `number` (already
- * parsed) and `string` (Drizzle numeric()/bigint encoding). Rejects:
- *   - null / undefined / non-numeric types
- *   - empty / whitespace-only strings
- *   - range strings like "[0.07, 0.15]" or JSON object/array literals
- *   - NaN, Infinity, -Infinity
- */
+/** Parse a value as a finite number, accepting Drizzle's string encoding for
+ *  numeric() and rejecting JSON-array / range-string literals like "[0.07, 0.15]". */
 export function tryParseNumeric(value: unknown): number | null {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   if (typeof value !== "string") return null;
@@ -80,11 +74,9 @@ export function tryParseNumeric(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/**
- * Format a numeric stake/percentage value. PG stores stakes as 0–1 decimals
- * (`0.07` = 7%), but a few legacy rows already encode them as percent points
- * (`15` = 15%). We disambiguate on `Math.abs(n) > 1`.
- */
+/** Format a numeric stake as `X.X%`. Legacy rows encode percent points
+ *  directly (`15` = 15%) while modern rows use 0–1 decimals (`0.15` = 15%) —
+ *  disambiguate on `Math.abs(n) > 1`. */
 export function formatPercentage(n: number): string {
   const pct = Math.abs(n) > 1 ? n : n * 100;
   return `${pct.toFixed(1).replace(/\.0$/, "")}%`;


### PR DESCRIPTION
## Summary

Closes the remaining gaps in **QUA-767** (Phase 1 of QUA-90, "Database Records Tab — number formatting + text truncation"). Phase 1's main work — `CURRENCY_COLUMNS` / `PERCENTAGE_COLUMNS` detection, `tryParseNumeric` guards, `ExpandableText` line-clamp, currency-aware compact formatting — was largely shipped 3 weeks ago in commit `9e1b459c2`. This PR finishes the two remaining items from the QUA-767 task list:

- **`lead_investor` fallback** — funding-round rows whose `lead_investor_entity_id` FK never resolved used to render as em-dash even when the legacy `leadInvestor` text column had a usable display name. Added `ENTITY_REF_FALLBACKS` + a pure `resolveFallbackValue(primary, columnName, row)` helper that the rendering loop in `ProfileSection` calls per cell. Fallback renders are visually marked **italic + muted-foreground** with a `title=` tooltip ("Fallback: entity FK is null, showing legacy raw text") so admins can tell at a glance which rows resolved through the FK and which fell back — this is a debugging surface, so silently substituting legacy text for a null FK would hide data-quality issues.
- **`__tests__/formatting.test.ts`** — extracted the format helpers (`CURRENCY_COLUMNS`, `PERCENTAGE_COLUMNS`, `ENTITY_REF_FALLBACKS`, `tryParseNumeric`, `formatPercentage`, `resolveFallbackValue`) into a small `format-numeric.ts` module so they're testable in isolation, and added 29 unit tests covering the QUA-767 edge-case list (NaN, Infinity, empty/null, non-numeric strings, JSON-array range strings, non-string fallback rejection, FK-missing fallback, etc.).

The helper extraction is a behavior-preserving refactor — the viewer re-imports the same identifiers it used to define inline.

## Verification

- 1750 web tests pass (29 new in `formatting.test.ts`)
- `pnpm build` clean
- `pnpm crux w validate gate --fix` — all 58 gate checks pass (2 pre-existing advisories: orphan entity detection, TableBase sourcing coverage)
- TypeScript clean across all three projects
- Prod `/organizations/anthropic/data?tab=database` already renders the QUA-767 acceptance amounts (`$450M`, `$580M`, `$4B`, `$3.5B`, `$2B`, `$1B`) with zero bare 9+ digit runs in the body
- /agent-review-pr surfaced 3 HIGH + 3 MEDIUM findings — all addressed (test coverage for fallback branch, type narrowing, visual fallback marker, full-membership lock-down on `CURRENCY_COLUMNS`)
- /simplify pass trimmed verbose JSDoc and dropped a precision-loss test marker that pinned bad behavior

## Test plan

- [x] Run `pnpm crux w validate gate` — all checks pass
- [x] Run `pnpm test` (apps/web) — 1750/1750 pass
- [x] Run `pnpm build` — clean
- [x] Verify prod entity Database Records tab still shows compact currency
- [ ] After merge: spot-check `/organizations/anthropic/data?tab=database` and a funding-round entity that hits the fallback path (italic+muted "Lead Investor" cell with tooltip)

Closes QUA-767
