### PR TITLE
docs: require prod-symptom reproduction before bug-fix work

### DIFF
--- a/.claude/rules/implementation-quality.md
+++ b/.claude/rules/implementation-quality.md
@@ -18,11 +18,22 @@ Applies to sessions that write or modify code (not content-only MDX/YAML edits).
 - **Mock fidelity**: Test mocks for the same DB table must share a single in-memory store. Don't create parallel mock stores (e.g., separate `suggestResourceStore`) for different endpoints that hit the same table. When a table pair is accessed from many mock branches, extract a typed store helper — `apps/wiki-server/src/__tests__/_helpers/resources-store.ts` (QUA-604) is the canonical pattern: one class encapsulates `resources` + `resource_citations` with `seedResource` / `seedCitation` for tests and `setResource` / `insertCitation` / `joinCitationsByPage` for the dispatcher.
 
 **Bug fixes — TDD workflow:**
-1. Write a failing test that reproduces the bug FIRST
-2. Confirm the test fails
-3. Fix the bug
-4. Confirm the test passes
-5. Do NOT edit code without a reproducing test
+
+For tickets claiming a prod symptom ("X is leaking on /<page>", "Y returns wrong value", "Z is broken in production"), the first step is to reproduce the symptom against current prod, NOT to write code:
+
+0. **Reproduce the symptom against current prod first.** Run the existing acceptance test that would catch it (render-audit, e2e spec, integration test, manual browser check). If it passes, the bug is already fixed by an earlier change — halt, comment on the ticket with the test result, and close it. Do not proceed to write a fix. Tickets get fixed between filing and dispatch all the time; verify the symptom still exists before spending compute on it.
+
+Then for any bug fix:
+
+1. Write a failing unit test that reproduces the bug.
+2. Confirm the test fails.
+3. Fix the bug.
+4. Confirm the test passes.
+5. Do NOT edit code without a reproducing test.
+
+Reference incident: QUA-684 / PR #4650 (Apr 2026). Ticket claimed `/organizations/openai` Database tab still leaked `20240601000000`. The render-audit had passed since QUA-675 shipped 4 days earlier — running `PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts -g openai` would have caught this in 10 seconds. PR was written, reviewed, and closed without merging.
+
+**Latent-class framing is a yellow flag.** If your fix's stated purpose is "close a latent class flagged in the issue" rather than "fix this observed instance," halt and require evidence the class has fired beyond the original (possibly already-fixed) instance. PR descriptions like "QUA-X healed the original symptom on prod. This PR closes the latent class flagged in the issue" are the agent telling you, in plain English, that the observable bug is gone and the rest is speculative. That's the moment to stop and check current data — not to ship coverage for hypothetical scenarios. Same logic as `proactive-github-filing.md` § "Hypothetical problems you have not observed," applied to fixes rather than filings.
 
 ## Simplicity
 

--- a/.claude/rules/proactive-github-filing.md
+++ b/.claude/rules/proactive-github-filing.md
@@ -65,6 +65,7 @@ For longer descriptions, use `--description-file=/tmp/description.md`.
 
 - **Evidence required**: You must have *observed* the problem in the current session — do not file speculative or hypothetical issues. Point to a specific file, error message, or behavior you encountered.
 - **Volume target**: 0-2 issues per session is normal. If you're finding 10+ problems, file the top 2-3 and batch the rest into one umbrella issue.
+- **Re-verify before dispatching** *(applies when picking up a previously-filed ticket, not when filing a new one)*: tickets get fixed between filing and dispatch. Before starting work on a ticket that claims a prod symptom, run the acceptance test that would catch it (render-audit, e2e spec, etc.) and confirm it still fails. If it passes, comment with the test result and close — don't write a fix for a bug that's already gone. See `implementation-quality.md` § "Bug fixes — TDD workflow" step 0.
 
 ## Mandatory tracking — red flags that MUST produce a ticket
 


### PR DESCRIPTION
## Summary

Two rule edits to close a process gap surfaced by closing PR #4650 / QUA-684:

- `.claude/rules/implementation-quality.md` — TDD workflow now starts with step 0 (reproduce against current prod) for prod-symptom tickets, plus a "latent-class framing is a yellow flag" paragraph for the second-order pattern. Reference incident named with the exact command that would have caught it.
- `.claude/rules/proactive-github-filing.md` — one-line cross-reference under existing guardrails, scoped to picking up a previously-filed ticket (not filing a new one), so it doesn't muddy the existing evidence-at-filing rule.

## Why

QUA-684 was filed claiming `/organizations/openai` Database tab still leaked `20240601000000`. The agent who picked it up wrote a 272-line PR adding a date-shape detector. Investigation found:

- The render-audit had passed since QUA-675 shipped 4 days earlier — the bug was already gone.
- The PR's own description acknowledged this ("QUA-673 + QUA-675 healed the original symptom on prod. This PR closes the latent class flagged in the issue") but proceeded anyway.
- The "latent class" had zero observed instances in current data.

The rule we already had (`Bug fixes — TDD workflow`) only said "write a failing unit test." For prod-symptom tickets, the more important step is verifying the symptom still reproduces against prod before writing any code. One command (`PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts -g openai`) would have caught this in 10 seconds.

## Test plan

- [x] Docs-only change. Verified rule files render in markdown viewer.
- [x] Cross-reference between the two files is accurate (`implementation-quality.md` § "Bug fixes — TDD workflow").
- [x] Reference incident details match git history: PR #4650, QUA-684, QUA-675 / PR #4570 4 days earlier.

Note: not using `Fixes QUA-684` because QUA-684 is already closed. This PR is the retrospective process improvement, not the fix for that ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
