### PR TITLE
fix(validator): remove unsafe auto-fix for EntityLink name mismatch (QUA-761)

### DIFF
--- a/crux/lib/rules/entitylink-ids.ts
+++ b/crux/lib/rules/entitylink-ids.ts
@@ -10,7 +10,8 @@
  * Checks:
  * 1. ID resolves to a known entity (via pathRegistry, entities DB, or content file)
  * 2. Slug IDs should use numeric format instead (ERROR, auto-fixable)
- * 3. Wiki ID + name: validates name matches the entity's slug (ERROR if mismatch)
+ * 3. Wiki ID + name: validates name matches the entity's slug (ERROR if mismatch,
+ *    NO auto-fix — see QUA-761)
  * 4. Wiki ID without name: advisory (WARNING, auto-fixable)
  * 5. Unknown wiki ID: warning
  */
@@ -115,18 +116,22 @@ export const entityLinkIdsRule = createRule({
             // Wiki ID resolves — check name attribute
             if (nameAttr) {
               if (nameAttr !== slug) {
-                // Name mismatch — ERROR (hallucination or stale reference)
+                // Name mismatch — ERROR. No auto-fix: the wiki ID may have been
+                // reassigned to a different entity since the prose was written
+                // (e.g., E3613 was Michael Kratsios, now Melania Trump). A
+                // mechanical name=→slug rewrite would silently corrupt the
+                // surrounding prose. Human judgment required.
+                // engine.idRegistry is guaranteed non-null here (outer `if`).
+                const idForCurrentName = engine.idRegistry.bySlug[nameAttr];
+                const hint = idForCurrentName
+                  ? ` (name "${nameAttr}" currently maps to ${idForCurrentName} — wiki ID may have been reassigned)`
+                  : '';
                 issues.push(new Issue({
                   rule: this.id,
                   file: content.path,
                   line: lineNum,
-                  message: `EntityLink id="${rawId}" name="${nameAttr}" — name mismatch: ${rawId} is "${slug}", not "${nameAttr}"`,
+                  message: `EntityLink id="${rawId}" name="${nameAttr}" — name mismatch: ${rawId} is "${slug}", not "${nameAttr}"${hint}. Verify the prose and fix manually (no auto-fix: see QUA-761).`,
                   severity: Severity.ERROR,
-                  fix: {
-                    type: FixType.REPLACE_TEXT,
-                    oldText: `name="${nameAttr}"`,
-                    newText: `name="${slug}"`,
-                  },
                 }));
               }
               // else: name matches — perfect, no issue

--- a/crux/lib/rules/entitylink-ids.ts
+++ b/crux/lib/rules/entitylink-ids.ts
@@ -9,11 +9,14 @@
  *
  * Checks:
  * 1. ID resolves to a known entity (via pathRegistry, entities DB, or content file)
- * 2. Slug IDs should use numeric format instead (ERROR, auto-fixable)
- * 3. Wiki ID + name: validates name matches the entity's slug (ERROR if mismatch,
+ * 2. Slug IDs should use numeric format instead (ERROR, auto-fixable from
+ *    user-typed slug — safe)
+ * 3. Bare numeric ID (e.g. "35"): normalize to E-prefix only (ERROR,
+ *    auto-fixable; see QUA-761 — does not inject name= from registry)
+ * 4. Wiki ID + name: validates name matches the entity's slug (ERROR if mismatch,
  *    NO auto-fix — see QUA-761)
- * 4. Wiki ID without name: advisory (WARNING, auto-fixable)
- * 5. Unknown wiki ID: warning
+ * 5. Wiki ID without name: advisory (WARNING, auto-fixable)
+ * 6. Unknown wiki ID: warning
  */
 
 import { createRule, Issue, Severity, FixType, type ContentFile, type ValidationEngine } from '../validation/validation-engine.ts';
@@ -93,7 +96,13 @@ export const entityLinkIdsRule = createRule({
         if (/^\d+$/.test(rawId)) {
           const eId = `E${rawId}`;
           const slug = engine.idRegistry?.byWikiId[eId];
-          const nameStr = slug ? ` name="${slug}"` : '';
+          // Only normalize the E-prefix. Don't auto-inject name="${slug}" —
+          // (a) if the wiki ID was reassigned the registry slug mismatches
+          //     the prose (same hallucination as QUA-761's name-mismatch case),
+          // (b) if the original tag already has a name= attribute, injecting
+          //     produces a duplicate name= which breaks JSX compilation.
+          // The next validation pass surfaces the missing-name advisory if
+          // applicable, where the human can decide what to write.
           issues.push(new Issue({
             rule: this.id,
             file: content.path,
@@ -103,7 +112,7 @@ export const entityLinkIdsRule = createRule({
             fix: {
               type: FixType.REPLACE_TEXT,
               oldText: `id="${rawId}"`,
-              newText: `id="${eId}"${nameStr}`,
+              newText: `id="${eId}"`,
             },
           }));
           continue;

--- a/crux/lib/rules/rules.test.ts
+++ b/crux/lib/rules/rules.test.ts
@@ -1195,6 +1195,22 @@ describe('entitylink-ids rule', () => {
     expect(issues[0].fix!.newText).toBe('id="E42" name="anthropic"');
   });
 
+  it('normalizes bare numeric ID without injecting name= (QUA-761)', () => {
+    // Bare-numeric-ID auto-fix used to inject name="${currentSlug}", which
+    // had the same hallucination risk as the name-mismatch case if the wiki
+    // ID had been reassigned. Now the fix only normalizes the E-prefix.
+    const content = mockContent(
+      '<EntityLink id="42">Anthropic</EntityLink>',
+    );
+    const issues = check(entityLinkIdsRule, content, engineWithRegistry);
+    expect(issues.length).toBe(1);
+    expect(issues[0].severity).toBe(Severity.ERROR);
+    expect(issues[0].message).toContain('bare wiki ID');
+    expect(issues[0].fix).not.toBeNull();
+    expect(issues[0].fix!.oldText).toBe('id="42"');
+    expect(issues[0].fix!.newText).toBe('id="E42"');
+  });
+
   it('passes for wiki ID with correct name', () => {
     const content = mockContent(
       '<EntityLink id="E42" name="anthropic">Anthropic</EntityLink>',

--- a/crux/lib/rules/rules.test.ts
+++ b/crux/lib/rules/rules.test.ts
@@ -1203,7 +1203,10 @@ describe('entitylink-ids rule', () => {
     expect(issues.length).toBe(0);
   });
 
-  it('errors when wiki ID has wrong name (hallucination catch)', () => {
+  it('errors when wiki ID has wrong name, with NO auto-fix (QUA-761)', () => {
+    // No auto-fix: the wiki ID may have been reassigned. A mechanical
+    // name=→slug rewrite would silently corrupt prose like "MIRI is..."
+    // by renaming MIRI to "anthropic" because E42 now points there.
     const content = mockContent(
       '<EntityLink id="E42" name="miri">MIRI</EntityLink>',
     );
@@ -1212,9 +1215,27 @@ describe('entitylink-ids rule', () => {
     expect(issues[0].severity).toBe(Severity.ERROR);
     expect(issues[0].message).toContain('name mismatch');
     expect(issues[0].message).toContain('"anthropic"');
-    expect(issues[0].fix).not.toBeNull();
-    expect(issues[0].fix!.oldText).toBe('name="miri"');
-    expect(issues[0].fix!.newText).toBe('name="anthropic"');
+    // Hint surfaces when the prose-name resolves to a different wiki ID,
+    // strongly suggesting the wiki ID was reassigned.
+    expect(issues[0].message).toContain('"miri" currently maps to E100');
+    expect(issues[0].message).toContain('reassigned');
+    expect(issues[0].message).toContain('Verify the prose');
+    expect(issues[0].fix).toBeNull();
+  });
+
+  it('errors with no hint when name does not match any known slug', () => {
+    // When the name attribute doesn't resolve to any current entity, the
+    // hint about reassignment is omitted (could be a typo, not necessarily
+    // a reassignment).
+    const content = mockContent(
+      '<EntityLink id="E42" name="some-old-name">Old Name</EntityLink>',
+    );
+    const issues = check(entityLinkIdsRule, content, engineWithRegistry);
+    expect(issues.length).toBe(1);
+    expect(issues[0].severity).toBe(Severity.ERROR);
+    expect(issues[0].message).toContain('name mismatch');
+    expect(issues[0].message).not.toContain('reassigned');
+    expect(issues[0].fix).toBeNull();
   });
 
   it('warns when wiki ID used without name, with auto-fix to add name', () => {


### PR DESCRIPTION
## Summary

Removes two unsafe auto-fixes from the `entitylink-ids` validator that silently corrupted page content when wiki IDs got reassigned. Caught during QUA-755 cleanup when `--fix` produced fact-corrupting diffs that looked plausible:

- `E3613` was Michael Kratsios → now Melania Trump. `--fix` renamed "Michael Kratsios" to "Melania Trump" in `india-and-global-south-ai-governance.mdx`.
- `E3009` was Daniel Gross → now Daniel Levy. `--fix` renamed "Daniel Gross" to "Daniel Levy" in `labs-overview.mdx`.
- `E3010` was Daniel Levy → now Vitalik Buterin. `--fix` renamed "Daniel Levy" to "Vitalik Buterin".

The diffs looked plausible (one identifier swapped for another) and would not be caught by a reviewer who didn't already know the entities — exactly the silent-fact-corruption shape the validator should refuse to ship.

## Changes

### Commit 1 — name-mismatch case (the named bug)
- `<EntityLink id="E42" name="miri">` where `E42` now resolves to `anthropic`: previously auto-rewrote `name="miri"` → `name="anthropic"`. Now: ERROR with no auto-fix.
- Severity stays ERROR so violations still block the gate.
- Message now includes a hint when the prose-name resolves to a different wiki ID, strongly suggesting the wiki ID was reassigned and pointing the human at which side is wrong:
  > `EntityLink id="E42" name="miri" — name mismatch: E42 is "anthropic", not "miri" (name "miri" currently maps to E100 — wiki ID may have been reassigned). Verify the prose and fix manually (no auto-fix: see QUA-761).`

### Commit 2 — sister bug found during full-file review
- Bare-numeric-ID auto-fix (`<EntityLink id="35">` → `id="E35" name="...">`) was *also* injecting `name="${currentSlug}"` from the registry, with the same hallucination shape if the wiki ID had been reassigned. It also produced duplicate `name=` attributes when the original tag already had one (broke JSX compilation, but masked the underlying issue).
- Now: only normalizes the `E`-prefix. Doesn't inject a name attribute. The next validation pass surfaces the missing-name advisory if applicable, where a human decides what to write.
- Per `CLAUDE.md` "fix systems, not instances": same root cause as commit 1, applied systematically.

## Test plan

- [x] `npx vitest run --config crux/vitest.config.ts crux/lib/rules/rules.test.ts` — 131 tests pass (2 new: name-mismatch no-fix + bare-numeric no name-injection)
- [x] `pnpm crux w validate unified --rule=entitylink-ids` — passes on all 767 current MDX files (zero new blocking errors today; future reassignments will surface as gate failures until a human fixes them)
- [x] `pnpm crux w validate gate --fix` — 55/55 gate checks pass (4 pre-existing advisories)
- [x] `pnpm build` — Next.js production build clean
- [x] `npx tsc --noEmit` for apps/web, apps/wiki-server, crux — 0 errors in changed files
- [x] `/agent-review-pr` adaptive review — 6 findings, 2 fixed (variable rename + redundant `?.` chain), 1 verified safe, 3 dismissed as structurally impossible

## Pre-existing test failures noted (not caused by this PR)

These fail on `main` too, unrelated to entitylink-ids:
- `validate/validate-sourcing-lint-guard.test.ts` (1 failure — sourcing baseline regressing)
- `wiki-server/snapshot-resources.test.ts` (5 failures — resource enrichment coverage thresholds)
- `scripts/__tests__/scrape-ailabwatch.test.ts` + `lib/scorecard-import/__tests__/parse-ailabwatch.test.ts` (cheerio module missing baseline)

## Discovery context

Caught running `pnpm crux validate unified --blocking-only --errors-only --fix` during QUA-755 cleanup. The validator changed person names in 2 files and required a manual revert. If a future agent or human runs `--fix` without spotting it, fact errors silently propagate.

Closes QUA-761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
