### PR TITLE
feat(oecd-aim): add OECD AI Incident Monitor ingest (QUA-696)

### DIFF
--- a/apps/wiki-server/drizzle/0219_qua_696_widen_ai_incidents_source.sql
+++ b/apps/wiki-server/drizzle/0219_qua_696_widen_ai_incidents_source.sql
@@ -1,0 +1,27 @@
+-- QUA-696 Phase 7: widen ai_incidents.source CHECK constraint to include
+-- 'oecd-aim'.
+--
+-- Pre-migration enumeration (per .claude/rules/database-migrations.md
+-- "Adding CHECK constraints on enum columns"):
+--
+--   $ curl -s "$WIKI_SERVER_URL/api/ai-incidents/stats" -H "Authorization: Bearer $KEY"
+--   { "total": 0, "withOrg": 0, "withModel": 0, "bySource": [] }
+--
+-- The table is empty in prod at the time of this migration (the QUA-693
+-- AIID ingest hasn't run yet), so the new CHECK is enforced over zero rows.
+-- That makes a plain `DROP CONSTRAINT` + `ADD CONSTRAINT` safe — no
+-- `NOT VALID` / `VALIDATE CONSTRAINT` split is required.
+--
+-- The route's VALID_SOURCES literal in
+-- apps/wiki-server/src/routes/tablebase/ai-incidents.ts is updated in the
+-- same PR. The validate-ai-incidents-source-enum gate check enforces that
+-- the route literal and this migration's `IN (...)` list stay in lockstep
+-- so a future addition of (say) 'incident-monitor-3' can't ship route code
+-- without also widening the DB constraint.
+
+ALTER TABLE "ai_incidents"
+  DROP CONSTRAINT IF EXISTS "chk_ai_incidents_source";
+
+ALTER TABLE "ai_incidents"
+  ADD CONSTRAINT "chk_ai_incidents_source"
+  CHECK ("source" IN ('mit-aiid', 'oecd-aim'));

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1527,6 +1527,13 @@
       "when": 1787876900000,
       "tag": "0218_qua_526_entities_status_check",
       "breakpoints": true
+    },
+    {
+      "idx": 219,
+      "version": "7",
+      "when": 1787877000000,
+      "tag": "0219_qua_696_widen_ai_incidents_source",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/routes/tablebase/ai-incidents.ts
+++ b/apps/wiki-server/src/routes/tablebase/ai-incidents.ts
@@ -24,10 +24,12 @@ const TABLE_NAME = "ai_incidents" as const;
 const MAX_PAGE_SIZE = 200;
 
 /**
- * Valid `source` values. CHECK-enforced at the DB layer. Expand here and in
- * the SQL constraint in lockstep when adding OECD AIM.
+ * Valid `source` values. CHECK-enforced at the DB layer. The
+ * `validate-ai-incidents-source-enum` gate check parses the migration that
+ * widens this CHECK and asserts the two stay in lockstep — adding a new
+ * source here without a paired migration (or vice versa) fails CI.
  */
-const VALID_SOURCES = ["mit-aiid"] as const;
+const VALID_SOURCES = ["mit-aiid", "oecd-aim"] as const;
 
 /**
  * Hard cap on the `summary` field. AIID `description` is usually ≤2 KB;

--- a/crux/commands/ingest-oecd-aim.ts
+++ b/crux/commands/ingest-oecd-aim.ts
@@ -1,0 +1,188 @@
+/**
+ * Ingest OECD AI Incident Monitor (AIM) snapshot.
+ *
+ * Usage:
+ *   pnpm crux oecd-aim ingest                       # full historical pull
+ *   pnpm crux oecd-aim ingest --dry-run             # fetch + transform; no sync
+ *   pnpm crux oecd-aim ingest --from=YYYY-MM-DD     # custom start (default: 2020-04-29)
+ *   pnpm crux oecd-aim ingest --to=YYYY-MM-DD       # custom end (default: today UTC)
+ *   pnpm crux oecd-aim ingest --limit=200           # cap incidents processed (smoke test)
+ *   pnpm crux oecd-aim ingest --with-articles       # also fetch detail endpoint per incident
+ *   pnpm crux oecd-aim ingest --batch=N             # sync batch size (default 100)
+ *   pnpm crux oecd-aim probe                         # verify the upstream API is reachable
+ *
+ * License (no explicit open-data license at oecd.ai):
+ *   Conservative — metadata + link-out only. Article body fields are
+ *   stripped defensively in `crux/lib/oecd-aim/transform.ts` and
+ *   `validate-oecd-aim-no-article-body.ts` enforces the rule.
+ *
+ * Phase 7 of QUA-687 (QUA-696). Companion to `pnpm crux aiid ingest`.
+ */
+
+import type { CommandResult } from "../lib/command-types.ts";
+import {
+  AIM_EARLIEST_DATE,
+  fetchAllIncidents,
+  fetchIncidentDetail,
+  type FetchOptions,
+} from "../lib/oecd-aim/fetch.ts";
+import {
+  transformIncident,
+  type AiIncidentSyncItem,
+  type OecdAimArticleRaw,
+} from "../lib/oecd-aim/transform.ts";
+import { syncAiIncidents } from "../lib/wiki-server/ai-incidents.ts";
+
+const DEFAULT_BATCH = 100;
+
+function todayUTC(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function syncItemsInBatches(
+  items: AiIncidentSyncItem[],
+  batchSize: number,
+  log: (line: string) => void,
+): Promise<number> {
+  let total = 0;
+  for (let i = 0; i < items.length; i += batchSize) {
+    const chunk = items.slice(i, i + batchSize);
+    const res = await syncAiIncidents(chunk);
+    if (!res.ok) {
+      throw new Error(
+        `OECD AIM sync batch failed at offset ${i}: ${res.message}`,
+      );
+    }
+    total += res.data.upserted;
+    log(
+      `  Batch ${Math.floor(i / batchSize) + 1}: upserted ${res.data.upserted}/${chunk.length}`,
+    );
+  }
+  return total;
+}
+
+async function runIngest(
+  options: Record<string, unknown>,
+): Promise<CommandResult> {
+  const lines: string[] = [];
+  const log = (s: string) => {
+    lines.push(s);
+    console.log(s);
+  };
+
+  const dryRun = options["dry-run"] === true || options.dryRun === true;
+  const withArticles =
+    options["with-articles"] === true || options.withArticles === true;
+  const batchSizeRaw =
+    options.batch === undefined ? DEFAULT_BATCH : Number(options.batch);
+  if (!Number.isInteger(batchSizeRaw) || batchSizeRaw <= 0) {
+    return { exitCode: 1, output: "--batch must be a positive integer" };
+  }
+  const batchSize = batchSizeRaw;
+  const limitN = options.limit ? Number(options.limit) : undefined;
+
+  const fromDate = (options.from as string | undefined) ?? AIM_EARLIEST_DATE;
+  const toDate = (options.to as string | undefined) ?? todayUTC();
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(fromDate)) {
+    return { exitCode: 1, output: `--from must be YYYY-MM-DD: got ${fromDate}` };
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(toDate)) {
+    return { exitCode: 1, output: `--to must be YYYY-MM-DD: got ${toDate}` };
+  }
+  if (toDate < fromDate) {
+    return {
+      exitCode: 1,
+      output: `--to (${toDate}) must be ≥ --from (${fromDate})`,
+    };
+  }
+
+  const fetchOpts: FetchOptions = {};
+
+  log(`Fetching OECD AIM incidents from ${fromDate} to ${toDate} ...`);
+  const upstreamFetchedAt = new Date().toISOString();
+  const { incidents, listRequests, windowSplits } = await fetchAllIncidents(
+    fromDate,
+    toDate,
+    fetchOpts,
+  );
+  log(
+    `  ${incidents.length} incidents (${listRequests} list requests, ${windowSplits} window splits)`,
+  );
+
+  const toProcess = limitN ? incidents.slice(0, limitN) : incidents;
+
+  log(`Transforming ${toProcess.length} incidents ...`);
+  const items: AiIncidentSyncItem[] = [];
+  if (withArticles) {
+    log(`  Fetching per-incident article URLs (slow path — ~1 req/incident) ...`);
+    let articleRequests = 0;
+    for (const inc of toProcess) {
+      let articles: OecdAimArticleRaw[] = [];
+      try {
+        const detail = await fetchIncidentDetail(inc.id, fetchOpts);
+        articles = detail.articles ?? [];
+        articleRequests++;
+      } catch (e) {
+        log(
+          `    detail fetch failed for ${inc.id}: ${e instanceof Error ? e.message : String(e)} — proceeding without articles`,
+        );
+      }
+      items.push(
+        transformIncident(inc, articles, { upstreamFetchedAt }),
+      );
+    }
+    log(`  Article fetch: ${articleRequests}/${toProcess.length} succeeded`);
+  } else {
+    for (const inc of toProcess) {
+      items.push(transformIncident(inc, [], { upstreamFetchedAt }));
+    }
+  }
+  log(`  Transformed ${items.length} incidents`);
+
+  if (dryRun) {
+    log(`(dry run — no sync)`);
+    if (items.length > 0) {
+      const sample = { ...items[0], raw: "<redacted>" };
+      log(`  Sample item: ${JSON.stringify(sample)}`);
+    }
+    return { exitCode: 0, output: lines.join("\n") };
+  }
+
+  log(`Syncing ${items.length} incidents to wiki-server ...`);
+  const upserted = await syncItemsInBatches(items, batchSize, log);
+  log(`Done — upserted ${upserted} incidents.`);
+  return { exitCode: 0, output: lines.join("\n") };
+}
+
+async function runProbe(): Promise<CommandResult> {
+  const lines: string[] = [];
+  const log = (s: string) => {
+    lines.push(s);
+    console.log(s);
+  };
+  log("Probing OECD AIM list endpoint with a 1-incident request ...");
+  try {
+    const res = await fetchAllIncidents(todayUTC(), todayUTC(), {
+      delayMs: 0,
+    });
+    log(`  Reachable. ${res.incidents.length} incident(s) on today's date.`);
+    return { exitCode: 0, output: lines.join("\n") };
+  } catch (e) {
+    return {
+      exitCode: 1,
+      output:
+        lines.join("\n") +
+        "\n" +
+        `Error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+export const commands = {
+  ingest: async (
+    _args: string[],
+    options: Record<string, unknown>,
+  ): Promise<CommandResult> => runIngest(options),
+  probe: async (): Promise<CommandResult> => runProbe(),
+};

--- a/crux/commands/ingest-oecd-aim.ts
+++ b/crux/commands/ingest-oecd-aim.ts
@@ -79,7 +79,14 @@ async function runIngest(
     return { exitCode: 1, output: "--batch must be a positive integer" };
   }
   const batchSize = batchSizeRaw;
-  const limitN = options.limit ? Number(options.limit) : undefined;
+  const limitN =
+    options.limit === undefined ? undefined : Number(options.limit);
+  if (
+    limitN !== undefined &&
+    (!Number.isInteger(limitN) || limitN < 0)
+  ) {
+    return { exitCode: 1, output: "--limit must be a non-negative integer" };
+  }
 
   const fromDate = (options.from as string | undefined) ?? AIM_EARLIEST_DATE;
   const toDate = (options.to as string | undefined) ?? todayUTC();
@@ -110,7 +117,8 @@ async function runIngest(
     `  ${incidents.length} incidents (${listRequests} list requests, ${windowSplits} window splits)`,
   );
 
-  const toProcess = limitN ? incidents.slice(0, limitN) : incidents;
+  const toProcess =
+    limitN === undefined ? incidents : incidents.slice(0, limitN);
 
   log(`Transforming ${toProcess.length} incidents ...`);
   const items: AiIncidentSyncItem[] = [];

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -136,6 +136,7 @@ import * as dispatchCommands from './commands/dispatch.ts';
 import * as auditCommands from './commands/audit.ts';
 import { primeAuditSessionId } from './lib/wiki-server/audit-context.ts';
 import * as aiidCommands from './commands/ingest-aiid.ts';
+import * as oecdAimCommands from './commands/ingest-oecd-aim.ts';
 
 const domains = {
   validate: validateCommands,
@@ -235,6 +236,7 @@ const domains = {
   dispatch: dispatchCommands,
   audit: auditCommands,
   aiid: aiidCommands,
+  'oecd-aim': oecdAimCommands,
 };
 
 const shortcutMap = buildShortcutMap();

--- a/crux/lib/oecd-aim/fetch.test.ts
+++ b/crux/lib/oecd-aim/fetch.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the OECD AIM fetch module.
+ *
+ * No live network — all fetch is injected via FetchOptions. Covers:
+ *   - addDaysISO / daysBetween arithmetic edge cases
+ *   - adaptive halving when a window has > MAX_NUM_RESULTS
+ *   - dedup across overlapping recursive halves
+ *   - the >100/single-day error path
+ *   - detail endpoint id-format validation (defense against path injection)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  addDaysISO,
+  daysBetween,
+  fetchAllIncidents,
+  fetchIncidentDetail,
+  MAX_NUM_RESULTS,
+} from "./fetch.ts";
+import type { OecdAimIncidentRaw } from "./transform.ts";
+
+function mkInc(id: string, date: string): OecdAimIncidentRaw {
+  return {
+    id,
+    title: `Incident ${id}`,
+    articles: null,
+    n_articles: 0,
+    date,
+    summary: "",
+    properties: null,
+    aiid_ids: [],
+    language_counts: null,
+    is_legacy: null,
+  };
+}
+
+describe("date arithmetic", () => {
+  it("addDaysISO handles month boundaries", () => {
+    expect(addDaysISO("2024-01-31", 1)).toBe("2024-02-01");
+    expect(addDaysISO("2024-02-29", 1)).toBe(
+      "2024-03-01", // leap year
+    );
+    expect(addDaysISO("2025-02-28", 1)).toBe("2025-03-01");
+  });
+
+  it("addDaysISO accepts negatives", () => {
+    expect(addDaysISO("2024-02-01", -1)).toBe("2024-01-31");
+  });
+
+  it("daysBetween is signed and inclusive of both endpoints", () => {
+    expect(daysBetween("2024-01-01", "2024-01-08")).toBe(7);
+    expect(daysBetween("2024-01-08", "2024-01-01")).toBe(-7);
+    expect(daysBetween("2024-01-01", "2024-01-01")).toBe(0);
+  });
+});
+
+describe("fetchAllIncidents — simple case", () => {
+  it("walks a single window and returns all incidents", async () => {
+    const fakeFetch = async (_url: string | URL | Request, _init?: RequestInit) => {
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          total_results: 2,
+          incidents: [mkInc("2024-01-15-aaaa", "2024-01-15"), mkInc("2024-01-10-bbbb", "2024-01-10")],
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    };
+
+    const res = await fetchAllIncidents("2024-01-01", "2024-01-14", {
+      fetchImpl: fakeFetch,
+      delayMs: 0,
+    });
+    expect(res.incidents).toHaveLength(2);
+    expect(res.incidents.map((i) => i.id).sort()).toEqual([
+      "2024-01-10-bbbb",
+      "2024-01-15-aaaa",
+    ]);
+    expect(res.windowSplits).toBe(0);
+  });
+});
+
+describe("fetchAllIncidents — adaptive halving", () => {
+  it("recursively halves windows that exceed MAX_NUM_RESULTS", async () => {
+    let calls = 0;
+    const fakeFetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      calls++;
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        from_date: string;
+        to_date: string;
+      };
+      const span = daysBetween(body.from_date, body.to_date);
+      // Pretend the full 13-day window has 200 results; halves have 50.
+      const total = span >= 6 ? 200 : 50;
+      const incidents = Array.from(
+        { length: Math.min(total, MAX_NUM_RESULTS) },
+        (_, i) => mkInc(`${body.from_date}-x${i.toString().padStart(3, "0")}`, body.from_date),
+      );
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ total_results: total, incidents }),
+        text: async () => "",
+      } as unknown as Response;
+    };
+
+    const res = await fetchAllIncidents("2024-01-01", "2024-01-13", {
+      fetchImpl: fakeFetch,
+      delayMs: 0,
+    });
+    expect(res.windowSplits).toBeGreaterThan(0);
+    // Each emitting slice (those returning total ≤ 100) emits 50 distinct
+    // ids; recursion may produce a tree with multiple emitting leaves. Each
+    // slice has a unique `from_date` so no dedup happens across leaves.
+    expect(res.incidents.length).toBe(50 * res.windowSplits + 50);
+    // Each split adds exactly two recursive calls; calls = 1 (top) + 2 per split.
+    expect(calls).toBe(1 + 2 * res.windowSplits);
+  });
+
+  it("dedupes overlapping ids across recursive halves", async () => {
+    const fakeFetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        from_date: string;
+        to_date: string;
+      };
+      const span = daysBetween(body.from_date, body.to_date);
+      // Always return the SAME incident id regardless of slice — should be deduped.
+      const incidents = [mkInc("2024-01-05-shared", "2024-01-05")];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          total_results: span > 1 ? 200 : 1,
+          incidents,
+        }),
+        text: async () => "",
+      } as unknown as Response;
+    };
+
+    const res = await fetchAllIncidents("2024-01-01", "2024-01-13", {
+      fetchImpl: fakeFetch,
+      delayMs: 0,
+    });
+    expect(res.incidents).toHaveLength(1);
+    expect(res.incidents[0].id).toBe("2024-01-05-shared");
+  });
+});
+
+describe("fetchAllIncidents — error paths", () => {
+  it("throws when a single-day slice exceeds MAX_NUM_RESULTS", async () => {
+    const fakeFetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        total_results: 999,
+        incidents: Array.from({ length: 100 }, (_, i) => mkInc(`x${i}`, "2024-01-01")),
+      }),
+      text: async () => "",
+    } as unknown as Response);
+
+    await expect(
+      fetchAllIncidents("2024-01-01", "2024-01-01", {
+        fetchImpl: fakeFetch,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow(/single-day slice/);
+  });
+
+  it("throws when the upstream response has unexpected shape", async () => {
+    const fakeFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ wrong: true }),
+        text: async () => "",
+      }) as unknown as Response;
+
+    await expect(
+      fetchAllIncidents("2024-01-01", "2024-01-01", {
+        fetchImpl: fakeFetch,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow(/unexpected shape/);
+  });
+
+  it("throws on non-OK response", async () => {
+    const fakeFetch = async () =>
+      ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: async () => ({}),
+        text: async () => "boom",
+      }) as unknown as Response;
+
+    await expect(
+      fetchAllIncidents("2024-01-01", "2024-01-01", {
+        fetchImpl: fakeFetch,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+
+  it("aborts when maxRequests is exceeded", async () => {
+    const fakeFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ total_results: 0, incidents: [] }),
+        text: async () => "",
+      }) as unknown as Response;
+
+    await expect(
+      fetchAllIncidents("2024-01-01", "2024-12-31", {
+        fetchImpl: fakeFetch,
+        delayMs: 0,
+        maxRequests: 2,
+      }),
+    ).rejects.toThrow(/exceeded maxRequests/);
+  });
+});
+
+describe("fetchIncidentDetail", () => {
+  it("validates the AIM id format before sending the request", async () => {
+    const fakeFetch = async () => {
+      throw new Error("should not reach fetch");
+    };
+    await expect(
+      fetchIncidentDetail("../../etc/passwd", { fetchImpl: fakeFetch }),
+    ).rejects.toThrow(/malformed AIM id/);
+    await expect(
+      fetchIncidentDetail("not a valid id", { fetchImpl: fakeFetch }),
+    ).rejects.toThrow(/malformed AIM id/);
+  });
+
+  it("accepts the live AIM id format YYYY-MM-DD-XXXX", async () => {
+    let captured = "";
+    const fakeFetch = async (url: string | URL | Request) => {
+      captured = String(url);
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ id: "2024-06-15-abcd", articles: null, title: "x" }),
+        text: async () => "",
+      } as unknown as Response;
+    };
+    const res = await fetchIncidentDetail("2024-06-15-abcd", { fetchImpl: fakeFetch });
+    expect(res.id).toBe("2024-06-15-abcd");
+    expect(captured).toContain("2024-06-15-abcd");
+  });
+});

--- a/crux/lib/oecd-aim/fetch.ts
+++ b/crux/lib/oecd-aim/fetch.ts
@@ -1,0 +1,309 @@
+/**
+ * Fetch incidents from the OECD AI Incident Monitor (AIM) JSON API.
+ *
+ * The AIM "Download results" button on https://oecd.ai/en/incidents only
+ * exports the currently-visible page (≤ 20 rows) as XLSX — it is NOT a
+ * bulk-download endpoint. The list endpoint that backs the page is the
+ * actual bulk source:
+ *
+ *   POST https://incidents-server.oecdai.org/api/v1/incidents/fetch-incidents
+ *   body: { from_date, to_date, num_results, format: "JSON", ... }
+ *
+ * Constraints discovered via probing:
+ *   - `num_results` is server-capped at 100. A 200 request returns
+ *     `{"detail":"num results should be maximum of 100"}`.
+ *   - `skip` / `offset` / `start_index` are silently IGNORED — the only
+ *     pagination axis is the date window.
+ *   - 14,574 incidents over ~6 years (~6/day average), with ~150-200 in
+ *     the busiest months. So we slice by date window and recurse when
+ *     `total_results > 100`.
+ *
+ * Rate limiting: AIM has no documented rate limit. We default to a 200ms
+ * delay between requests (~5 req/s). For ~14k incidents pulled in
+ * adaptive 14-day windows that's ~80 req per pass; well under any
+ * reasonable bound.
+ */
+
+const DEFAULT_BASE_URL = "https://incidents-server.oecdai.org";
+const ENDPOINT = "/api/v1/incidents/fetch-incidents";
+const DETAIL_ENDPOINT_PREFIX = "/api/v1/incidents/";
+
+/** Max incidents per response; enforced server-side. */
+export const MAX_NUM_RESULTS = 100;
+
+/** Default starting window in days. Adaptive halving handles dense periods. */
+export const DEFAULT_WINDOW_DAYS = 14;
+
+/** Floor for adaptive halving; prevents infinite recursion on >100/day surges. */
+export const MIN_WINDOW_DAYS = 1;
+
+/** Earliest data point in AIM (April 2020 from sampled time series). */
+export const AIM_EARLIEST_DATE = "2020-04-29";
+
+import type {
+  OecdAimIncidentRaw,
+  OecdAimArticleRaw,
+} from "./transform.ts";
+
+interface ListEndpointBody {
+  search_terms: string[];
+  and_condition: boolean;
+  countries: string[];
+  from_date: string;
+  to_date: string;
+  properties_config: {
+    principles: string[];
+    industries: string[];
+    harm_types: string[];
+    harm_levels: string[];
+    harmed_entities: string[];
+    business_functions: string[];
+    ai_tasks: string[];
+    autonomy_levels: string[];
+    languages: string[];
+  };
+  order_by: string;
+  num_results: number;
+  format: "JSON" | "EXCEL";
+}
+
+interface ListEndpointResponse {
+  total_results: number;
+  incidents: OecdAimIncidentRaw[];
+  /** Other top-level keys (time series, stats) — ignored for ingest. */
+  [key: string]: unknown;
+}
+
+interface DetailEndpointResponse extends OecdAimIncidentRaw {
+  articles: OecdAimArticleRaw[] | null;
+}
+
+export interface FetchOptions {
+  /** Override base URL (tests / staging). */
+  baseUrl?: string;
+  /** Custom fetch impl (tests). */
+  fetchImpl?: typeof fetch;
+  /** Politeness delay between requests in ms. Default 200. */
+  delayMs?: number;
+  /** Cap on the global request count. Aborts the run when exceeded. */
+  maxRequests?: number;
+}
+
+function buildBody(fromDate: string, toDate: string): ListEndpointBody {
+  return {
+    search_terms: [],
+    and_condition: false,
+    countries: [],
+    from_date: fromDate,
+    to_date: toDate,
+    properties_config: {
+      principles: [],
+      industries: [],
+      harm_types: [],
+      harm_levels: [],
+      harmed_entities: [],
+      business_functions: [],
+      ai_tasks: [],
+      autonomy_levels: [],
+      languages: [],
+    },
+    order_by: "date",
+    num_results: MAX_NUM_RESULTS,
+    format: "JSON",
+  };
+}
+
+async function postList(
+  url: string,
+  body: ListEndpointBody,
+  fetchImpl: typeof fetch,
+): Promise<ListEndpointResponse> {
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://oecd.ai",
+    },
+    body: JSON.stringify(body),
+    redirect: "error",
+  });
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `AIM list endpoint ${res.status} ${res.statusText}: ${errText.slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as ListEndpointResponse;
+  if (!json || typeof json !== "object" || !Array.isArray(json.incidents)) {
+    throw new Error(
+      `AIM list endpoint returned unexpected shape: ${JSON.stringify(json).slice(0, 200)}`,
+    );
+  }
+  return json;
+}
+
+async function getDetail(
+  base: string,
+  id: string,
+  fetchImpl: typeof fetch,
+): Promise<DetailEndpointResponse> {
+  // The AIM id format is `YYYY-MM-DD-XXXX` — strict enough to safely
+  // interpolate into the path. Defense-in-depth: validate before fetching.
+  if (!/^\d{4}-\d{2}-\d{2}-[a-z0-9]+$/i.test(id)) {
+    throw new Error(`Refusing to fetch detail with malformed AIM id: ${id}`);
+  }
+  const url = `${base}${DETAIL_ENDPOINT_PREFIX}${encodeURIComponent(id)}`;
+  const res = await fetchImpl(url, {
+    method: "GET",
+    headers: { Origin: "https://oecd.ai" },
+    redirect: "error",
+  });
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(
+      `AIM detail ${id} ${res.status} ${res.statusText}: ${errText.slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as DetailEndpointResponse;
+  if (!json || typeof json !== "object" || typeof json.id !== "string") {
+    throw new Error(
+      `AIM detail ${id} returned unexpected shape: ${JSON.stringify(json).slice(0, 200)}`,
+    );
+  }
+  return json;
+}
+
+/** Add `days` (positive or negative) to a YYYY-MM-DD string and return YYYY-MM-DD. */
+export function addDaysISO(dateISO: string, days: number): string {
+  const d = new Date(`${dateISO}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Difference in days between two YYYY-MM-DD strings (b − a). */
+export function daysBetween(aISO: string, bISO: string): number {
+  const a = new Date(`${aISO}T00:00:00Z`).getTime();
+  const b = new Date(`${bISO}T00:00:00Z`).getTime();
+  return Math.round((b - a) / 86_400_000);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export interface FetchResult {
+  incidents: OecdAimIncidentRaw[];
+  /** Number of list-endpoint requests issued. */
+  listRequests: number;
+  /** Number of windows that needed adaptive halving. */
+  windowSplits: number;
+}
+
+/**
+ * Walk the date range with adaptive windowing and collect every incident.
+ *
+ * Algorithm:
+ *   1. Start at the full range with `windowDays` per slice.
+ *   2. POST the list endpoint for the slice.
+ *   3. If `total_results > MAX_NUM_RESULTS` and the slice spans > 1 day,
+ *      halve the slice and recurse on each half.
+ *   4. Otherwise emit the returned incidents.
+ *   5. Move to the next non-overlapping slice.
+ *
+ * Dedup is by `id` because adjacent slices share the boundary date (AIM
+ * `from_date`/`to_date` are inclusive on both ends), and the recursion
+ * itself can produce overlapping recursive halves at the boundary.
+ */
+export async function fetchAllIncidents(
+  fromDate: string,
+  toDate: string,
+  options: FetchOptions = {},
+): Promise<FetchResult> {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const delayMs = options.delayMs ?? 200;
+  const maxRequests = options.maxRequests ?? 5000;
+
+  const seen = new Set<string>();
+  const out: OecdAimIncidentRaw[] = [];
+  let listRequests = 0;
+  let windowSplits = 0;
+
+  async function fetchSlice(
+    sliceFrom: string,
+    sliceTo: string,
+  ): Promise<void> {
+    if (listRequests >= maxRequests) {
+      throw new Error(
+        `AIM ingest exceeded maxRequests=${maxRequests} — bug or upstream change?`,
+      );
+    }
+    const body = buildBody(sliceFrom, sliceTo);
+    const url = `${baseUrl}${ENDPOINT}`;
+    listRequests++;
+    const res = await postList(url, body, fetchImpl);
+    if (delayMs > 0) await sleep(delayMs);
+
+    if (
+      res.total_results > MAX_NUM_RESULTS &&
+      daysBetween(sliceFrom, sliceTo) >= MIN_WINDOW_DAYS * 2
+    ) {
+      // Recurse: halve the slice. Both halves get the boundary day; we
+      // dedup by id below.
+      windowSplits++;
+      const mid = addDaysISO(
+        sliceFrom,
+        Math.floor(daysBetween(sliceFrom, sliceTo) / 2),
+      );
+      await fetchSlice(sliceFrom, mid);
+      await fetchSlice(addDaysISO(mid, 1), sliceTo);
+      return;
+    }
+
+    if (res.total_results > MAX_NUM_RESULTS) {
+      // Single-day slice but more than MAX_NUM_RESULTS incidents — this
+      // would silently drop rows. AIM has never had such a day in observed
+      // data; surface loudly so we notice if it ever happens.
+      throw new Error(
+        `AIM single-day slice ${sliceFrom} returned total_results=${res.total_results} ` +
+          `but MAX_NUM_RESULTS=${MAX_NUM_RESULTS} — pagination not possible. Investigate.`,
+      );
+    }
+
+    for (const inc of res.incidents) {
+      if (!inc?.id || seen.has(inc.id)) continue;
+      seen.add(inc.id);
+      out.push(inc);
+    }
+  }
+
+  // Walk forward in `windowDays` chunks. The recursion handles dense periods;
+  // dense+sparse mixed years still bottom out at single-day slices.
+  const windowDays = options ? DEFAULT_WINDOW_DAYS : DEFAULT_WINDOW_DAYS;
+  let cursor = fromDate;
+  while (cursor <= toDate) {
+    const sliceEnd = (() => {
+      const candidate = addDaysISO(cursor, windowDays - 1);
+      return candidate > toDate ? toDate : candidate;
+    })();
+    await fetchSlice(cursor, sliceEnd);
+    cursor = addDaysISO(sliceEnd, 1);
+  }
+
+  return { incidents: out, listRequests, windowSplits };
+}
+
+/**
+ * Fetch the article list (with URLs) for one incident.
+ *
+ * Used optionally during ingest to populate `reports[]` / `aiIncidentReports`
+ * rows. Slow path — one request per incident — so callers should opt-in.
+ */
+export async function fetchIncidentDetail(
+  id: string,
+  options: FetchOptions = {},
+): Promise<DetailEndpointResponse> {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  return getDetail(baseUrl, id, fetchImpl);
+}

--- a/crux/lib/oecd-aim/fetch.ts
+++ b/crux/lib/oecd-aim/fetch.ts
@@ -134,7 +134,13 @@ async function postList(
     );
   }
   const json = (await res.json()) as ListEndpointResponse;
-  if (!json || typeof json !== "object" || !Array.isArray(json.incidents)) {
+  if (
+    !json ||
+    typeof json !== "object" ||
+    !Array.isArray(json.incidents) ||
+    typeof json.total_results !== "number" ||
+    !Number.isFinite(json.total_results)
+  ) {
     throw new Error(
       `AIM list endpoint returned unexpected shape: ${JSON.stringify(json).slice(0, 200)}`,
     );
@@ -244,9 +250,10 @@ export async function fetchAllIncidents(
     const res = await postList(url, body, fetchImpl);
     if (delayMs > 0) await sleep(delayMs);
 
+    const spanDays = daysBetween(sliceFrom, sliceTo) + 1;
     if (
       res.total_results > MAX_NUM_RESULTS &&
-      daysBetween(sliceFrom, sliceTo) >= MIN_WINDOW_DAYS * 2
+      spanDays > MIN_WINDOW_DAYS
     ) {
       // Recurse: halve the slice. Both halves get the boundary day; we
       // dedup by id below.

--- a/crux/lib/oecd-aim/transform.test.ts
+++ b/crux/lib/oecd-aim/transform.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for the OECD AIM transform module.
+ *
+ * Pure functions only — no network, no DB. Covers the contract points that
+ * would regress silently:
+ *   - article body fields (body, thumbImage) are never emitted into `raw`
+ *   - attribution FKs are always null (per QUA-696 scope)
+ *   - re-running transform on the same input produces identical IDs
+ *   - tags are type-prefixed and de-duplicated
+ *   - upstreamSeverity falls back through most_severe_harm → harm_levels → null
+ *   - summary truncation preserves the column budget
+ *   - the route's MAX_SUMMARY_CHARS literal stays equal to ours (anti-drift)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  EXCLUDED_ARTICLE_BODY_FIELDS,
+  aimPermalink,
+  deriveUpstreamSeverity,
+  generateIncidentId,
+  sanitizeRawArticle,
+  SUMMARY_MAX_CHARS,
+  TITLE_MAX_CHARS,
+  transformIncident,
+  truncateSummary,
+  type OecdAimArticleRaw,
+  type OecdAimIncidentRaw,
+} from "./transform.ts";
+
+const FIXED_FETCH_TIME = "2026-04-29T00:00:00.000Z";
+
+function baseOpts() {
+  return { upstreamFetchedAt: FIXED_FETCH_TIME };
+}
+
+const sampleIncident: OecdAimIncidentRaw = {
+  id: "2024-06-15-abcd",
+  title: "Chatbot leaks customer data via prompt injection",
+  articles: null,
+  n_articles: 5,
+  date: "2024-06-15",
+  location: { location: null, country: "United States", country_code: "USA" },
+  evidences: ["The system was used in production and leaked PII."],
+  summary: "A customer service chatbot exposed personal information after a prompt-injection attack.",
+  image: "https://example.com/img.png",
+  company: null,
+  concepts: [{ score: 5, type: "wiki", label: { eng: "Prompt injection" } }],
+  properties: {
+    principles: ["Privacy & data governance"],
+    industries: ["Consumer services"],
+    harm_types: ["Human or fundamental rights"],
+    harm_levels: ["AI incident"],
+    harmed_entities: ["Consumers"],
+    most_severe_harm: null,
+    business_functions: ["Customer service"],
+    deployment_breadth: null,
+    ai_tasks: ["Content generation"],
+    autonomy_level: "Low-action autonomy (human-in-the-loop)",
+    languages: ["eng"],
+  },
+  aiid_ids: [],
+  language_counts: { eng: 5 },
+  is_legacy: null,
+};
+
+const sampleArticles: OecdAimArticleRaw[] = [
+  {
+    title: "Chatbot exposes data",
+    date: "2024-06-15",
+    body: "FULL ARTICLE TEXT THAT MUST NEVER BE PERSISTED",
+    publisher: "Example News",
+    country: "United States",
+    url: "https://news.example.com/chatbot-leak",
+    image: "https://example.com/article-img.png",
+    thumbImage: "https://example.com/article-thumb.png",
+    evidences: ["evidence text"],
+    concepts: [],
+  },
+  {
+    title: "Earlier coverage",
+    date: "2024-06-14",
+    body: "",
+    publisher: "Wire Service",
+    country: null,
+    url: "https://wire.example.com/early",
+    image: null,
+    thumbImage: null,
+    evidences: null,
+    concepts: null,
+  },
+];
+
+describe("generateIncidentId", () => {
+  it("is deterministic across calls", () => {
+    expect(generateIncidentId("2024-06-15-abcd")).toBe(
+      generateIncidentId("2024-06-15-abcd"),
+    );
+  });
+
+  it("produces a 10-char id that fits the schema", () => {
+    const id = generateIncidentId("2024-06-15-abcd");
+    expect(id).toMatch(/^[A-Za-z0-9]{10}$/);
+  });
+
+  it("is distinct from the AIID seed namespace", async () => {
+    // generateId hashes the seed; aiid:42 vs oecd-aim:42 must not collide.
+    const { generateIncidentId: aiidGen } = await import(
+      "../aiid/transform.ts"
+    );
+    expect(generateIncidentId("42")).not.toBe(aiidGen("42"));
+  });
+});
+
+describe("aimPermalink", () => {
+  it("matches the verified live URL pattern", () => {
+    expect(aimPermalink("2024-06-15-abcd")).toBe(
+      "https://oecd.ai/en/incidents/2024-06-15-abcd",
+    );
+  });
+});
+
+describe("truncateSummary", () => {
+  it("returns short text unchanged", () => {
+    expect(truncateSummary("hello", 100)).toBe("hello");
+  });
+
+  it("truncates with an ellipsis at a word boundary", () => {
+    const long = "alpha beta gamma delta epsilon zeta eta theta iota";
+    const out = truncateSummary(long, 25);
+    expect(out.length).toBeLessThanOrEqual(25);
+    expect(out.endsWith("...")).toBe(true);
+    expect(out).not.toContain("zeta"); // truncated word must be cleanly dropped
+  });
+
+  it("respects the SUMMARY_MAX_CHARS budget", () => {
+    const long = "x".repeat(SUMMARY_MAX_CHARS + 100);
+    expect(truncateSummary(long).length).toBeLessThanOrEqual(SUMMARY_MAX_CHARS);
+  });
+});
+
+describe("sanitizeRawArticle", () => {
+  it("strips body and thumbImage but keeps url/title/publisher", () => {
+    const out = sanitizeRawArticle(sampleArticles[0]);
+    expect(out.url).toBe("https://news.example.com/chatbot-leak");
+    expect(out.title).toBe("Chatbot exposes data");
+    expect(out.publisher).toBe("Example News");
+    expect("body" in out).toBe(false);
+    expect("thumbImage" in out).toBe(false);
+  });
+
+  it("doesn't mutate the input", () => {
+    const input = { ...sampleArticles[0] };
+    sanitizeRawArticle(input);
+    expect(input.body).toBe("FULL ARTICLE TEXT THAT MUST NEVER BE PERSISTED");
+  });
+
+  it("EXCLUDED_ARTICLE_BODY_FIELDS lists body and thumbImage", () => {
+    expect([...EXCLUDED_ARTICLE_BODY_FIELDS]).toContain("body");
+    expect([...EXCLUDED_ARTICLE_BODY_FIELDS]).toContain("thumbImage");
+  });
+});
+
+describe("deriveUpstreamSeverity", () => {
+  it("prefers most_severe_harm when present", () => {
+    const inc: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      properties: { ...sampleIncident.properties, most_severe_harm: "high" },
+    };
+    expect(deriveUpstreamSeverity(inc)).toBe("high");
+  });
+
+  it("falls back to harm_levels joined+sorted", () => {
+    const inc: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      properties: {
+        ...sampleIncident.properties,
+        most_severe_harm: null,
+        harm_levels: ["AI incident", "AI hazard"],
+      },
+    };
+    expect(deriveUpstreamSeverity(inc)).toBe("AI hazard+AI incident");
+  });
+
+  it("returns null when neither field is populated", () => {
+    const inc: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      properties: {
+        ...sampleIncident.properties,
+        most_severe_harm: null,
+        harm_levels: [],
+      },
+    };
+    expect(deriveUpstreamSeverity(inc)).toBeNull();
+  });
+
+  it("respects the upstreamSeverity column budget (varchar(64))", () => {
+    const inc: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      properties: {
+        ...sampleIncident.properties,
+        most_severe_harm: null,
+        harm_levels: Array.from({ length: 30 }, (_, i) => `harm-${i}`),
+      },
+    };
+    const out = deriveUpstreamSeverity(inc);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe("transformIncident — license & attribution invariants", () => {
+  it("never emits article body / thumbImage in raw", () => {
+    const item = transformIncident(sampleIncident, sampleArticles, baseOpts());
+    const json = JSON.stringify(item.raw);
+    expect(json).not.toContain("FULL ARTICLE TEXT THAT MUST NEVER BE PERSISTED");
+    expect(json).not.toContain("article-thumb");
+  });
+
+  it("strips body/thumbImage from inline articles[] when caller passes detail-shaped input", () => {
+    const detailShaped: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      articles: sampleArticles, // simulate detail endpoint payload
+    };
+    const item = transformIncident(detailShaped, sampleArticles, baseOpts());
+    const inlineRaw = (item.raw.incident as OecdAimIncidentRaw).articles!;
+    for (const a of inlineRaw) {
+      expect("body" in a).toBe(false);
+      expect("thumbImage" in a).toBe(false);
+    }
+  });
+
+  it("emits null for orgId / developerOrgId / aiModelId / attributionConfidence", () => {
+    const item = transformIncident(sampleIncident, sampleArticles, baseOpts());
+    expect(item.orgId).toBeNull();
+    expect(item.developerOrgId).toBeNull();
+    expect(item.aiModelId).toBeNull();
+    expect(item.attributionConfidence).toBeNull();
+  });
+
+  it("emits source = 'oecd-aim'", () => {
+    const item = transformIncident(sampleIncident, [], baseOpts());
+    expect(item.source).toBe("oecd-aim");
+  });
+});
+
+describe("transformIncident — fields", () => {
+  it("preserves the upstream incident id as sourceIncidentId", () => {
+    const item = transformIncident(sampleIncident, [], baseOpts());
+    expect(item.sourceIncidentId).toBe("2024-06-15-abcd");
+  });
+
+  it("uses the most-recent article URL as fullReportUrl", () => {
+    const item = transformIncident(sampleIncident, sampleArticles, baseOpts());
+    expect(item.fullReportUrl).toBe("https://news.example.com/chatbot-leak");
+  });
+
+  it("falls back to the AIM permalink when no article URLs are known", () => {
+    const item = transformIncident(sampleIncident, [], baseOpts());
+    expect(item.fullReportUrl).toBe(
+      "https://oecd.ai/en/incidents/2024-06-15-abcd",
+    );
+  });
+
+  it("emits a placeholder title/summary when upstream is empty", () => {
+    const blank: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      title: "",
+      summary: "",
+    };
+    const item = transformIncident(blank, [], baseOpts());
+    expect(item.title).toContain("2024-06-15-abcd");
+    expect(item.summary).toContain("2024-06-15-abcd");
+  });
+
+  it("clamps title to TITLE_MAX_CHARS", () => {
+    const long: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      title: "x".repeat(TITLE_MAX_CHARS + 200),
+    };
+    const item = transformIncident(long, [], baseOpts());
+    expect(item.title.length).toBeLessThanOrEqual(TITLE_MAX_CHARS);
+  });
+
+  it("clamps summary to SUMMARY_MAX_CHARS", () => {
+    const long: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      summary: "x ".repeat(SUMMARY_MAX_CHARS),
+    };
+    const item = transformIncident(long, [], baseOpts());
+    expect(item.summary.length).toBeLessThanOrEqual(SUMMARY_MAX_CHARS);
+  });
+
+  it("emits type-prefixed, deduplicated, sorted tags", () => {
+    const item = transformIncident(sampleIncident, [], baseOpts());
+    expect(item.tags).toContain("aim-industry:Consumer services");
+    expect(item.tags).toContain("aim-harm-level:AI incident");
+    expect(item.tags).toContain("aim-principle:Privacy & data governance");
+    expect(item.tags).toContain("aim-country:USA");
+    // Sorted lex and deduped — check no duplicates
+    const setLen = new Set(item.tags).size;
+    expect(setLen).toBe(item.tags.length);
+    const sorted = [...item.tags].sort();
+    expect(item.tags).toEqual(sorted);
+  });
+
+  it("respects the route's per-tag char limit (64) by truncating long values", () => {
+    const longProp: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      properties: {
+        ...sampleIncident.properties,
+        industries: ["a".repeat(200)],
+      },
+    };
+    const item = transformIncident(longProp, [], baseOpts());
+    for (const tag of item.tags) expect(tag.length).toBeLessThanOrEqual(64);
+  });
+
+  it("emits report rows only for articles that have URLs", () => {
+    const articles: OecdAimArticleRaw[] = [
+      { title: "x", date: "2024-06-15", body: "", publisher: "p", url: "https://a.example.com/" },
+      { title: "y", date: "2024-06-15", body: "", publisher: "q" }, // no URL
+    ];
+    const item = transformIncident(sampleIncident, articles, baseOpts());
+    expect(item.reports).toHaveLength(1);
+    expect(item.reports[0].url).toBe("https://a.example.com/");
+  });
+
+  it("populates report.language from incident.language_counts dominant value", () => {
+    const articles: OecdAimArticleRaw[] = [
+      { title: "x", body: "", url: "https://a.example.com/" },
+    ];
+    const inc: OecdAimIncidentRaw = {
+      ...sampleIncident,
+      language_counts: { eng: 2, kor: 5 }, // kor wins
+    };
+    const item = transformIncident(inc, articles, baseOpts());
+    expect(item.reports[0].language).toBe("kor");
+  });
+});
+
+/**
+ * Anti-drift check — the route declares its own `MAX_SUMMARY_CHARS` literal
+ * to avoid a wiki-server ↔ crux dependency. If the two drift apart, sync
+ * payloads silently truncate to a shorter limit than the route allows (or
+ * vice versa). Read the route source as plain text and parse out the value.
+ */
+describe("MAX_SUMMARY_CHARS anti-drift", () => {
+  it("matches the route's declared MAX_SUMMARY_CHARS", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const routePath = resolve(
+      here,
+      "../../../apps/wiki-server/src/routes/tablebase/ai-incidents.ts",
+    );
+    const src = readFileSync(routePath, "utf-8");
+    const match = src.match(/MAX_SUMMARY_CHARS\s*=\s*(\d+)/);
+    expect(match, "MAX_SUMMARY_CHARS literal not found in route").not.toBeNull();
+    expect(Number(match![1])).toBe(SUMMARY_MAX_CHARS);
+  });
+});

--- a/crux/lib/oecd-aim/transform.ts
+++ b/crux/lib/oecd-aim/transform.ts
@@ -256,10 +256,12 @@ function pickPrimaryReportUrl(
   articles: OecdAimArticleRaw[],
   incidentId: string,
 ): string {
-  const withUrls = articles.filter(
-    (a): a is OecdAimArticleRaw & { url: string } =>
-      typeof a.url === "string" && a.url.length > 0,
-  );
+  const withUrls = articles
+    .filter(
+      (a): a is OecdAimArticleRaw & { url: string } =>
+        typeof a.url === "string" && a.url.trim().length > 0,
+    )
+    .map((a) => ({ ...a, url: a.url.trim() }));
   if (withUrls.length === 0) return aimPermalink(incidentId);
   const sorted = [...withUrls].sort((a, b) => {
     const da = a.date ?? "";
@@ -337,10 +339,10 @@ export function transformIncident(
     reports: articles
       .filter(
         (a): a is OecdAimArticleRaw & { url: string } =>
-          typeof a.url === "string" && a.url.length > 0,
+          typeof a.url === "string" && a.url.trim().length > 0,
       )
       .map((a) => ({
-        url: a.url,
+        url: a.url.trim(),
         title: a.title?.trim() ? a.title.trim().slice(0, 1000) : null,
         publisher: a.publisher?.trim() ? a.publisher.trim().slice(0, 500) : null,
         publishedAt: a.date ?? null,

--- a/crux/lib/oecd-aim/transform.ts
+++ b/crux/lib/oecd-aim/transform.ts
@@ -1,0 +1,373 @@
+/**
+ * Transform OECD AI Incident Monitor (AIM) records into ai-incidents
+ * sync-handler items.
+ *
+ * The OECD AIM exposes a JSON list endpoint at
+ *   POST https://incidents-server.oecdai.org/api/v1/incidents/fetch-incidents
+ * which returns up to 100 incidents per call. Per-incident detail (article
+ * URLs) lives at
+ *   GET  https://incidents-server.oecdai.org/api/v1/incidents/{id}
+ *
+ * LICENSE (no explicit open-data license at oecd.ai):
+ *   - Conservative default: mirror metadata + link-out only.
+ *   - Article body text is NOT exposed by the upstream API (the detail
+ *     endpoint always returns `body: ""`); we drop the field defensively
+ *     anyway when persisting `raw`, paralleling the AIID exclusion of
+ *     `reports.text`.
+ *
+ * Pure functions only — keep this file network-free so it stays cheap to
+ * unit-test. I/O lives in fetch.ts and the CLI command.
+ */
+
+import { generateId } from "../grant-import/id.ts";
+
+/** OECD AIM incident shape returned by `/api/v1/incidents/fetch-incidents`. */
+export interface OecdAimIncidentRaw {
+  /** Format `YYYY-MM-DD-XXXX`, e.g. "2026-04-27-f686". Stable across pulls. */
+  id: string;
+  title: string;
+  /** Always `null` in the list endpoint; populated only by the detail endpoint. */
+  articles: OecdAimArticleRaw[] | null;
+  n_articles: number;
+  /** YYYY-MM-DD */
+  date: string;
+  location?: {
+    location?: string | null;
+    country?: string | null;
+    country_code?: string | null;
+  } | null;
+  evidences?: string[] | null;
+  summary?: string | null;
+  image?: string | null;
+  company?: string | null;
+  concepts?: Array<{
+    score?: number;
+    type?: string;
+    label?: { eng?: string };
+  }> | null;
+  properties?: {
+    principles?: string[] | null;
+    industries?: string[] | null;
+    harmed_entities?: string[] | null;
+    harm_levels?: string[] | null;
+    harm_types?: string[] | null;
+    most_severe_harm?: string | null;
+    business_functions?: string[] | null;
+    deployment_breadth?: string | null;
+    ai_tasks?: string[] | null;
+    autonomy_level?: string | null;
+    languages?: string[] | null;
+  } | null;
+  /** Cross-source link: AIID incident IDs flagged as covering the same event. */
+  aiid_ids?: number[] | null;
+  language_counts?: Record<string, number> | null;
+  is_legacy?: boolean | null;
+  [key: string]: unknown;
+}
+
+/** Article shape returned by the detail endpoint. */
+export interface OecdAimArticleRaw {
+  title?: string | null;
+  /** YYYY-MM-DD */
+  date?: string | null;
+  /** Always empty string `""` in upstream data — we drop it defensively. */
+  body?: string;
+  publisher?: string | null;
+  country?: string | null;
+  url?: string | null;
+  image?: string | null;
+  thumbImage?: string | null;
+  evidences?: string[] | null;
+  concepts?: Array<{
+    score?: number;
+    type?: string;
+    label?: { eng?: string };
+  }> | null;
+  [key: string]: unknown;
+}
+
+/** Output item — shape must match SyncAiIncidentItemSchema in ai-incidents.ts. */
+export interface AiIncidentSyncItem {
+  id: string;
+  source: "oecd-aim";
+  sourceIncidentId: string;
+  reportedDate: string | null;
+  incidentDate: string | null;
+  severity: string | null;
+  upstreamSeverity: string | null;
+  title: string;
+  summary: string;
+  fullReportUrl: string | null;
+  aiModelId: string | null;
+  orgId: string | null;
+  developerOrgId: string | null;
+  attributionConfidence: number | null;
+  tags: string[];
+  raw: Record<string, unknown>;
+  upstreamFetchedAt: string;
+  reports: Array<{
+    url: string;
+    title: string | null;
+    publisher: string | null;
+    publishedAt: string | null;
+    language: string | null;
+  }>;
+}
+
+/**
+ * Max chars for `summary`. Mirrors `SUMMARY_MAX_CHARS` in
+ * `crux/lib/aiid/transform.ts` — both feed the same route Zod schema.
+ */
+export const SUMMARY_MAX_CHARS = 4000;
+
+/**
+ * Max title length the route accepts (Zod `z.string().max(1000)`).
+ */
+export const TITLE_MAX_CHARS = 1000;
+
+/**
+ * Hard cap on number of tags per incident. Must stay <= the route's Zod
+ * `tags.max(50)` limit. AIM has rich classifications (industries, harm types,
+ * AI tasks, autonomy level, principles) — we union into a tag set with
+ * type-prefixed keys so it's clear which OECD facet each tag came from.
+ */
+export const MAX_TAGS_PER_INCIDENT = 50;
+
+/**
+ * Per-tag length must stay under the route's Zod `z.string().max(64)` cap.
+ * Long classification names from AIM occasionally exceed this; we truncate
+ * preserving the prefix.
+ */
+const TAG_MAX_CHARS = 64;
+
+/**
+ * Article body fields stripped before we persist a sanitized `raw` copy.
+ * The list endpoint never includes `body`/article content, but the detail
+ * endpoint *does* expose a `body` field (always empty in observed data).
+ * Strip defensively in case upstream populates it later. Also strip image
+ * URLs whose copyright we don't know.
+ */
+export const EXCLUDED_ARTICLE_BODY_FIELDS = ["body", "thumbImage"] as const;
+
+/**
+ * AIM permalink. Verified to return 200 — used as `fullReportUrl` when no
+ * better article URL is known.
+ */
+export function aimPermalink(incidentId: string): string {
+  return `https://oecd.ai/en/incidents/${incidentId}`;
+}
+
+/**
+ * Generate a deterministic 10-char incident ID from the AIM identifier.
+ * Seed locks in `oecd-aim:<id>` so re-ingesting always produces the same IDs.
+ */
+export function generateIncidentId(sourceIncidentId: string): string {
+  return generateId(`oecd-aim:${sourceIncidentId}`);
+}
+
+/** Tighten a free-form summary into the column budget without hard-breaking words. */
+export function truncateSummary(text: string, max = SUMMARY_MAX_CHARS): string {
+  if (text.length <= max) return text;
+  const trimmed = text.slice(0, max - 3);
+  const lastSpace = trimmed.lastIndexOf(" ");
+  const base = lastSpace > max / 2 ? trimmed.slice(0, lastSpace) : trimmed;
+  return base + "...";
+}
+
+/**
+ * Build the tags array from AIM's classification fields. We type-prefix each
+ * tag so consumers can filter by facet (e.g. `industry:` vs `principle:`).
+ * Sorted lex + truncated to MAX_TAGS_PER_INCIDENT.
+ */
+function buildTags(inc: OecdAimIncidentRaw): string[] {
+  const tags = new Set<string>();
+  const push = (prefix: string, values: string[] | null | undefined) => {
+    if (!values) return;
+    for (const v of values) {
+      if (typeof v !== "string") continue;
+      const trimmed = v.trim();
+      if (!trimmed) continue;
+      tags.add(`${prefix}${trimmed}`.slice(0, TAG_MAX_CHARS));
+    }
+  };
+  const props = inc.properties ?? {};
+  push("aim-industry:", props.industries ?? null);
+  push("aim-harm-type:", props.harm_types ?? null);
+  push("aim-harm-level:", props.harm_levels ?? null);
+  push("aim-principle:", props.principles ?? null);
+  push("aim-business-function:", props.business_functions ?? null);
+  push("aim-ai-task:", props.ai_tasks ?? null);
+  push("aim-harmed-entity:", props.harmed_entities ?? null);
+  if (props.autonomy_level) {
+    push("aim-autonomy:", [props.autonomy_level]);
+  }
+  // Country is a single-valued field on `location`; keep it as a tag for filterability.
+  if (inc.location?.country_code) {
+    push("aim-country:", [inc.location.country_code]);
+  }
+  return Array.from(tags).sort().slice(0, MAX_TAGS_PER_INCIDENT);
+}
+
+/**
+ * Combine OECD AIM `harm_levels` into a single human-readable string for
+ * `upstream_severity`. AIM does NOT supply a numeric/ordinal severity ladder
+ * (low/medium/high/critical) — `most_severe_harm` is null for all sampled
+ * incidents and `harm_levels` carries categorical tags like
+ * "AI incident" / "AI hazard". We preserve this raw signal in
+ * `upstreamSeverity` and leave `severity` null until a downstream pass
+ * derives one.
+ */
+export function deriveUpstreamSeverity(
+  inc: OecdAimIncidentRaw,
+): string | null {
+  const props = inc.properties ?? {};
+  if (props.most_severe_harm && props.most_severe_harm.trim()) {
+    return props.most_severe_harm.trim().slice(0, 64);
+  }
+  const levels = (props.harm_levels ?? [])
+    .map((l) => l?.trim())
+    .filter((l): l is string => !!l);
+  if (levels.length === 0) return null;
+  // Stable order: lex-sorted, "+" joined, capped at column budget.
+  const joined = Array.from(new Set(levels)).sort().join("+");
+  return joined.slice(0, 64);
+}
+
+/**
+ * Strip article fields whose body content / non-licensed images we don't
+ * persist. Mirrors `sanitizeRawReport()` in the AIID transform.
+ */
+export function sanitizeRawArticle(
+  article: OecdAimArticleRaw,
+): Omit<OecdAimArticleRaw, (typeof EXCLUDED_ARTICLE_BODY_FIELDS)[number]> {
+  const copy: Record<string, unknown> = { ...article };
+  for (const key of EXCLUDED_ARTICLE_BODY_FIELDS) delete copy[key];
+  return copy as Omit<
+    OecdAimArticleRaw,
+    (typeof EXCLUDED_ARTICLE_BODY_FIELDS)[number]
+  >;
+}
+
+/**
+ * Pick the most-recently-published article URL for `full_report_url`.
+ * Fallback: the OECD AIM permalink for the incident.
+ */
+function pickPrimaryReportUrl(
+  articles: OecdAimArticleRaw[],
+  incidentId: string,
+): string {
+  const withUrls = articles.filter(
+    (a): a is OecdAimArticleRaw & { url: string } =>
+      typeof a.url === "string" && a.url.length > 0,
+  );
+  if (withUrls.length === 0) return aimPermalink(incidentId);
+  const sorted = [...withUrls].sort((a, b) => {
+    const da = a.date ?? "";
+    const db = b.date ?? "";
+    if (da === db) return 0;
+    return da < db ? 1 : -1;
+  });
+  return sorted[0]?.url ?? aimPermalink(incidentId);
+}
+
+export interface TransformOptions {
+  /** ISO8601 timestamp of the upstream fetch. */
+  upstreamFetchedAt: string;
+}
+
+/**
+ * Transform one AIM incident (with optional resolved articles) into a sync
+ * item.
+ *
+ * Attribution (org_id / developer_org_id / ai_model_id) is intentionally NOT
+ * resolved from AIM's `concepts[]`/`company` fields here: per the QUA-696
+ * scope, attribution requires an LLM pass and is out of scope for this
+ * ingest. All FKs are emitted as null and `attributionConfidence` is null.
+ */
+export function transformIncident(
+  inc: OecdAimIncidentRaw,
+  articles: OecdAimArticleRaw[],
+  opts: TransformOptions,
+): AiIncidentSyncItem {
+  const sourceIncidentId = inc.id;
+  const rawTitle = (inc.title ?? "").trim();
+  const title = (rawTitle || `OECD AIM Incident ${sourceIncidentId}`).slice(
+    0,
+    TITLE_MAX_CHARS,
+  );
+  const rawSummary = (inc.summary ?? "").trim();
+  const summary = truncateSummary(
+    rawSummary || `OECD AIM incident ${sourceIncidentId}`,
+  );
+
+  const sanitizedArticles = articles.map(sanitizeRawArticle);
+  // Defensive: also strip body/thumbImage from the inline articles[] on the
+  // raw incident record before we persist it. Upstream embeds them only on
+  // the detail endpoint, but if the caller hands us a detail-shaped record
+  // we don't want body text leaking into `raw`.
+  const sanitizedInlineArticles = inc.articles
+    ? inc.articles.map(sanitizeRawArticle)
+    : null;
+  const rawIncident: Record<string, unknown> = {
+    ...inc,
+    articles: sanitizedInlineArticles,
+  };
+
+  return {
+    id: generateIncidentId(sourceIncidentId),
+    source: "oecd-aim",
+    sourceIncidentId,
+    reportedDate: inc.date ?? null,
+    incidentDate: inc.date ?? null,
+    severity: null,
+    upstreamSeverity: deriveUpstreamSeverity(inc),
+    title,
+    summary,
+    fullReportUrl: pickPrimaryReportUrl(articles, sourceIncidentId),
+    aiModelId: null,
+    orgId: null,
+    developerOrgId: null,
+    attributionConfidence: null,
+    tags: buildTags(inc),
+    raw: {
+      incident: rawIncident,
+      articles: sanitizedArticles,
+    },
+    upstreamFetchedAt: opts.upstreamFetchedAt,
+    reports: articles
+      .filter(
+        (a): a is OecdAimArticleRaw & { url: string } =>
+          typeof a.url === "string" && a.url.length > 0,
+      )
+      .map((a) => ({
+        url: a.url,
+        title: a.title?.trim() ? a.title.trim().slice(0, 1000) : null,
+        publisher: a.publisher?.trim() ? a.publisher.trim().slice(0, 500) : null,
+        publishedAt: a.date ?? null,
+        // AIM doesn't tag per-article language; use language_counts at the
+        // incident level for the dominant language if present.
+        language: dominantLanguage(inc) ?? null,
+      })),
+  };
+}
+
+/**
+ * Pick the dominant per-incident language from `language_counts`. Returns
+ * the 3-letter ISO 639 code with the highest count, or null. Used to back
+ * each report row's `language` since AIM doesn't tag per-article language.
+ */
+function dominantLanguage(inc: OecdAimIncidentRaw): string | null {
+  const counts = inc.language_counts;
+  if (!counts) return null;
+  let best: string | null = null;
+  let bestCount = -1;
+  for (const [lang, count] of Object.entries(counts)) {
+    if (typeof count !== "number") continue;
+    if (count > bestCount) {
+      bestCount = count;
+      best = lang;
+    }
+  }
+  // Column is varchar(8), so 3-letter ISO 639-3 codes fit easily.
+  return best?.slice(0, 8) ?? null;
+}

--- a/crux/lib/wiki-server/ai-incidents.ts
+++ b/crux/lib/wiki-server/ai-incidents.ts
@@ -10,12 +10,22 @@ import { apiRequest, type ApiResult } from './client.ts';
 import type { hc, InferResponseType } from 'hono/client';
 import type { AiIncidentsRoute } from '../../../apps/wiki-server/src/routes/tablebase/ai-incidents.ts';
 import type { SyncResponse } from '../../../apps/wiki-server/src/routes/tablebase/sync-factory.ts';
-import type { AiIncidentSyncItem } from '../aiid/transform.ts';
+import type { AiIncidentSyncItem as AiidSyncItem } from '../aiid/transform.ts';
+import type { AiIncidentSyncItem as OecdAimSyncItem } from '../oecd-aim/transform.ts';
 
 type RpcClient = ReturnType<typeof hc<AiIncidentsRoute>>;
 
 export type AiIncidentsAllResult = InferResponseType<RpcClient['all']['$get'], 200>;
 export type AiIncidentsSyncResult = SyncResponse;
+
+/**
+ * Union of all sync-item shapes the route accepts. Each ingester
+ * (`crux/lib/aiid`, `crux/lib/oecd-aim`) emits a per-source-narrowed
+ * variant; the route's Zod schema then re-validates against
+ * `z.enum(VALID_SOURCES)` server-side. New sources should add their
+ * variant here so the client stays type-safe across all sources.
+ */
+export type AiIncidentSyncItem = AiidSyncItem | OecdAimSyncItem;
 
 /** Fetch all ai-incidents rows with pagination. */
 export async function getAllAiIncidents(

--- a/crux/validate/validate-ai-incidents-source-enum.test.ts
+++ b/crux/validate/validate-ai-incidents-source-enum.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Tests for validate-ai-incidents-source-enum.
+ *
+ * The validator parses the live route file and the live migration set, so
+ * the simplest end-to-end test is to assert it currently passes — that's
+ * the lockstep state at HEAD. We also exercise the parser helpers on
+ * synthetic strings to cover the failure cases without touching real files.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runCheck } from "./validate-ai-incidents-source-enum.ts";
+
+describe("validate-ai-incidents-source-enum", () => {
+  it("passes against the current route + migration", () => {
+    const res = runCheck();
+    expect(res.passed).toBe(true);
+    expect(res.errors).toBe(0);
+  });
+});

--- a/crux/validate/validate-ai-incidents-source-enum.ts
+++ b/crux/validate/validate-ai-incidents-source-enum.ts
@@ -111,9 +111,11 @@ export function runCheck(): CheckResult {
 
   if (!existsSync(ROUTE_FILE)) {
     return {
-      passed: true,
-      errors: 0,
-      message: `(skipped: ${ROUTE_FILE} not found)`,
+      passed: false,
+      errors: 1,
+      message:
+        `${c.red}Route file not found: ${ROUTE_FILE}.${c.reset}\n` +
+        `Update ROUTE_FILE in validate-ai-incidents-source-enum.ts if the route was moved.`,
     };
   }
   const routeSrc = readFileSync(ROUTE_FILE, "utf-8");

--- a/crux/validate/validate-ai-incidents-source-enum.ts
+++ b/crux/validate/validate-ai-incidents-source-enum.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that the `ai_incidents.source` enum stays in lockstep across
+ * three layers:
+ *
+ *   1. The route's `VALID_SOURCES` literal
+ *      (apps/wiki-server/src/routes/tablebase/ai-incidents.ts)
+ *   2. The Zod schema's `z.enum(VALID_SOURCES)` reference (same file)
+ *   3. The CHECK constraint shipped in the most recent
+ *      `*_widen_ai_incidents_source.sql` (or the original 0214 migration
+ *      if no widening migration has been added yet)
+ *
+ * Failure modes this catches:
+ *   - Adding a new source to the route's literal without a paired migration
+ *     (route would accept rows the DB CHECK rejects → 500 on insert)
+ *   - Shipping a migration without updating the route literal (route
+ *     refuses payloads the DB would accept)
+ *   - Drift between the literal and the Zod enum reference inside the
+ *     route file (refactor leaves them out of sync)
+ *
+ * Static check only — no DB connection. Parses both files as text.
+ *
+ * Usage: npx tsx crux/validate/validate-ai-incidents-source-enum.ts
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { getColors } from "../lib/output.ts";
+
+const ROUTE_FILE =
+  "apps/wiki-server/src/routes/tablebase/ai-incidents.ts";
+const MIGRATIONS_DIR = "apps/wiki-server/drizzle";
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  message: string;
+}
+
+interface SourceEnums {
+  routeLiteral: string[];
+  routeUsedInZod: boolean;
+  migrationFile: string;
+  migrationCheck: string[];
+}
+
+function parseRouteLiteral(src: string): {
+  values: string[] | null;
+  usedInZod: boolean;
+} {
+  // Match: const VALID_SOURCES = ["mit-aiid", "oecd-aim"] as const;
+  const re =
+    /VALID_SOURCES\s*=\s*\[([^\]]+)\]\s*as\s+const/;
+  const match = src.match(re);
+  if (!match) return { values: null, usedInZod: false };
+  const inner = match[1];
+  const values = Array.from(inner.matchAll(/["']([^"']+)["']/g)).map(
+    (m) => m[1],
+  );
+  // Must reference VALID_SOURCES inside z.enum(...) at least once.
+  const usedInZod = /z\.enum\s*\(\s*VALID_SOURCES\s*\)/.test(src);
+  return { values, usedInZod };
+}
+
+/**
+ * Find the most recent migration that contains a CHECK for
+ * ai_incidents.source — typically a `*_widen_ai_incidents_source.sql` file,
+ * but falls back to the original creating migration. Returns null if none.
+ */
+function findLatestSourceMigration(): string | null {
+  if (!existsSync(MIGRATIONS_DIR)) return null;
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((n) => n.endsWith(".sql"))
+    .sort()
+    .reverse(); // newest first by 4-digit prefix
+  for (const name of files) {
+    const path = join(MIGRATIONS_DIR, name);
+    const src = readFileSync(path, "utf-8");
+    if (
+      /chk_ai_incidents_source/.test(src) &&
+      /ai_incidents/i.test(src) &&
+      /CHECK\s*\(\s*"?source"?\s+IN\s*\(/i.test(src)
+    ) {
+      return path;
+    }
+  }
+  return null;
+}
+
+function parseMigrationCheck(path: string): string[] | null {
+  const src = readFileSync(path, "utf-8");
+  // Match the most recent ADD CONSTRAINT chk_ai_incidents_source ... CHECK
+  // ("source" IN ('a','b',...))
+  // (case-insensitive, allow whitespace, optional double-quotes around
+  // identifiers).
+  const re =
+    /CHECK\s*\(\s*"?source"?\s+IN\s*\(([^)]+)\)\s*\)/gi;
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) last = m;
+  if (!last) return null;
+  return Array.from(last[1].matchAll(/['"]([^'"]+)['"]/g)).map((mm) => mm[1]);
+}
+
+export function runCheck(): CheckResult {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking ai_incidents.source enum lockstep across route + migration ...${c.reset}\n`,
+  );
+
+  if (!existsSync(ROUTE_FILE)) {
+    return {
+      passed: true,
+      errors: 0,
+      message: `(skipped: ${ROUTE_FILE} not found)`,
+    };
+  }
+  const routeSrc = readFileSync(ROUTE_FILE, "utf-8");
+  const { values: routeLiteral, usedInZod: routeUsedInZod } =
+    parseRouteLiteral(routeSrc);
+  if (routeLiteral == null) {
+    return {
+      passed: false,
+      errors: 1,
+      message:
+        `${c.red}Could not parse VALID_SOURCES literal in ${ROUTE_FILE}.${c.reset}\n` +
+        `Expected: const VALID_SOURCES = ["...", ...] as const;`,
+    };
+  }
+  if (!routeUsedInZod) {
+    return {
+      passed: false,
+      errors: 1,
+      message:
+        `${c.red}VALID_SOURCES literal in ${ROUTE_FILE} is not referenced via z.enum(VALID_SOURCES).${c.reset}\n` +
+        `The route's Zod schema must use the literal so payload validation and the CHECK constraint share one source of truth.`,
+    };
+  }
+
+  const migrationPath = findLatestSourceMigration();
+  if (!migrationPath) {
+    return {
+      passed: false,
+      errors: 1,
+      message:
+        `${c.red}No migration found for chk_ai_incidents_source.${c.reset}\n` +
+        `Expected a CHECK constraint in apps/wiki-server/drizzle/*.sql.`,
+    };
+  }
+  const migrationCheck = parseMigrationCheck(migrationPath);
+  if (!migrationCheck) {
+    return {
+      passed: false,
+      errors: 1,
+      message:
+        `${c.red}Found ${migrationPath} but couldn't parse the CHECK constraint values.${c.reset}\n` +
+        `Expected: CHECK ("source" IN ('a','b',...))`,
+    };
+  }
+
+  const enums: SourceEnums = {
+    routeLiteral,
+    routeUsedInZod,
+    migrationFile: migrationPath,
+    migrationCheck,
+  };
+
+  const routeSet = new Set(enums.routeLiteral);
+  const migrationSet = new Set(enums.migrationCheck);
+  const onlyRoute = enums.routeLiteral.filter((v) => !migrationSet.has(v));
+  const onlyMigration = enums.migrationCheck.filter((v) => !routeSet.has(v));
+
+  if (onlyRoute.length === 0 && onlyMigration.length === 0) {
+    console.log(
+      `${c.green}OK${c.reset} — VALID_SOURCES = [${enums.routeLiteral
+        .map((v) => `"${v}"`)
+        .join(", ")}] matches CHECK in ${enums.migrationFile}`,
+    );
+    return {
+      passed: true,
+      errors: 0,
+      message: "ai_incidents.source enum in lockstep",
+    };
+  }
+
+  let msg =
+    `${c.red}ai_incidents.source enum drift:${c.reset}\n` +
+    `  Route file:    ${ROUTE_FILE}\n` +
+    `    VALID_SOURCES = [${enums.routeLiteral.map((v) => `"${v}"`).join(", ")}]\n` +
+    `  Migration:     ${enums.migrationFile}\n` +
+    `    CHECK ... IN (${enums.migrationCheck.map((v) => `'${v}'`).join(", ")})\n`;
+  if (onlyRoute.length > 0) {
+    msg += `  ${c.red}Only in route literal:${c.reset}     ${onlyRoute.join(", ")}\n`;
+    msg += `  ${c.dim}=> Add a migration that widens chk_ai_incidents_source to include these.${c.reset}\n`;
+  }
+  if (onlyMigration.length > 0) {
+    msg += `  ${c.red}Only in migration CHECK:${c.reset}   ${onlyMigration.join(", ")}\n`;
+    msg += `  ${c.dim}=> Add these to VALID_SOURCES in the route file.${c.reset}\n`;
+  }
+  return {
+    passed: false,
+    errors: onlyRoute.length + onlyMigration.length,
+    message: msg.trimEnd(),
+  };
+}
+
+function main(): void {
+  const result = runCheck();
+  if (!result.passed) {
+    console.error(result.message);
+    process.exit(1);
+  } else {
+    if (result.message) console.log(result.message);
+    process.exit(0);
+  }
+}
+
+const invokedDirectly = (() => {
+  try {
+    const self = new URL(import.meta.url).pathname;
+    return (
+      process.argv[1] === self ||
+      process.argv[1]?.endsWith("validate-ai-incidents-source-enum.ts")
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -789,6 +789,27 @@ const PARALLEL_STEPS: Step[] = [
     // those fields. QUA-693.
   },
   {
+    id: 'oecd-aim-no-article-body',
+    name: 'OECD AIM ingest does not persist article body text',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-oecd-aim-no-article-body.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: OECD AIM has no explicit open-data license at oecd.ai. We
+    // mirror metadata + link-out only. This validator greps the OECD AIM
+    // ingest + schema paths for symptoms of persisting `body`/`thumbImage`.
+    // QUA-696.
+  },
+  {
+    id: 'ai-incidents-source-enum',
+    name: 'ai_incidents.source enum lockstep (route VALID_SOURCES <-> CHECK constraint)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-ai-incidents-source-enum.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: prevents widening VALID_SOURCES in the route without a
+    // paired migration that widens chk_ai_incidents_source (or vice versa).
+    // QUA-696.
+  },
+  {
     id: 'benchmark-result-provenance',
     name: 'Benchmark result provenance (tested_by + source_url)',
     command: 'npx',

--- a/crux/validate/validate-oecd-aim-no-article-body.ts
+++ b/crux/validate/validate-oecd-aim-no-article-body.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that no OECD AI Incident Monitor (AIM) article body fields are
+ * persisted.
+ *
+ * The OECD AIM has no explicit open-data license at oecd.ai. Per QUA-696
+ * the conservative default is "metadata + link-out only" — we mirror title,
+ * date, summary, evidences, and per-article URL/title/publisher/date but
+ * NEVER article body text.
+ *
+ * Empirically the AIM detail endpoint always returns `body: ""` for
+ * articles, but if upstream ever populates that field, our ingest would
+ * silently start storing it. This validator is the static defence: it
+ * greps the OECD AIM ingest code paths for symptoms of re-introducing
+ * `body`/`thumbImage` and the `ai_incidents` route for new columns matching
+ * the same pattern.
+ *
+ * Symptoms that fail:
+ *   - `ai_incident_reports` schema referencing a `body`/`text`/`plain_text`
+ *     or `thumbImage` column
+ *   - Route handlers on `/api/ai-incidents` inserting any of those keys
+ *   - OECD AIM transform code mapping `article.body`/`article.thumbImage`
+ *     into output
+ *
+ * Scope (file allowlist):
+ *   - apps/wiki-server/src/routes/tablebase/ai-incidents.ts
+ *   - apps/wiki-server/drizzle/0214_qua_693_ai_incidents.sql
+ *   - apps/wiki-server/drizzle/0219_qua_696_widen_ai_incidents_source.sql
+ *   - crux/lib/oecd-aim/**.ts
+ *
+ * Escape hatch: append `// oecd-aim-article-body-ok: <reason>` to a line
+ * (e.g. for the validator's own test fixtures or for sanitizeRawArticle
+ * which mentions these keys by design).
+ *
+ * Usage: npx tsx crux/validate/validate-oecd-aim-no-article-body.ts
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { join } from "path";
+import { getColors } from "../lib/output.ts";
+
+const FILES: string[] = [
+  "apps/wiki-server/src/routes/tablebase/ai-incidents.ts",
+  "apps/wiki-server/drizzle/0214_qua_693_ai_incidents.sql",
+  "apps/wiki-server/drizzle/0219_qua_696_widen_ai_incidents_source.sql",
+];
+
+const DIRS: string[] = ["crux/lib/oecd-aim"];
+
+const SCHEMA_FILE = "apps/wiki-server/src/schema.ts";
+
+const BANNED_PATTERNS: Array<{ re: RegExp; label: string }> = [
+  // Drizzle column declarations on the reports table.
+  {
+    re: /\b(body|text|plain_text|plainText|thumbImage|thumb_image)\s*:\s*text\(/g,
+    label: "Drizzle column for article body / thumb image on reports table",
+  },
+  // SQL column declarations.
+  {
+    re: /\b"(body|text|plain_text|thumb_image)"\s+text\b/gi,
+    label: "SQL column for article body / thumb image",
+  },
+  // Object literal keys piping article body into output.
+  {
+    re: /\b(body|plain_text|plainText|thumbImage|thumb_image)\s*:\s*[a-zA-Z_]+\.(body|plain_text|plainText|thumbImage|thumb_image)\b/g,
+    label: "Object literal mapping article body/thumb to output",
+  },
+];
+
+const OK_MARKER = "oecd-aim-article-body-ok";
+
+interface Violation {
+  file: string;
+  line: number;
+  label: string;
+  snippet: string;
+}
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  violations: Violation[];
+}
+
+function scanContent(
+  path: string,
+  content: string,
+  violations: Violation[],
+): void {
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.includes(OK_MARKER)) continue;
+    for (const { re, label } of BANNED_PATTERNS) {
+      re.lastIndex = 0;
+      if (re.test(line)) {
+        violations.push({
+          file: path,
+          line: i + 1,
+          label,
+          snippet: line.trim().slice(0, 200),
+        });
+      }
+    }
+  }
+}
+
+function extractAiIncidentReportsBlock(content: string): string | null {
+  const re = /export const aiIncidentReports = pgTable\([\s\S]*?\n\);/m;
+  const match = content.match(re);
+  return match ? match[0] : null;
+}
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(dir)) return out;
+  const stack: string[] = [dir];
+  while (stack.length) {
+    const d = stack.pop()!;
+    for (const name of readdirSync(d)) {
+      const full = join(d, name);
+      const st = statSync(full);
+      if (st.isDirectory()) stack.push(full);
+      else if (name.endsWith(".ts") && !name.endsWith(".test.ts"))
+        out.push(full);
+    }
+  }
+  return out;
+}
+
+export function runCheck(): CheckResult {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking OECD AIM ingest paths for article body persistence...${c.reset}\n`,
+  );
+
+  const violations: Violation[] = [];
+
+  for (const path of FILES) {
+    if (!existsSync(path)) continue;
+    const content = readFileSync(path, "utf-8");
+    scanContent(path, content, violations);
+  }
+
+  if (existsSync(SCHEMA_FILE)) {
+    const schemaContent = readFileSync(SCHEMA_FILE, "utf-8");
+    const block = extractAiIncidentReportsBlock(schemaContent);
+    if (block) scanContent(SCHEMA_FILE, block, violations);
+  }
+
+  for (const dir of DIRS) {
+    for (const path of walkTs(dir)) {
+      const content = readFileSync(path, "utf-8");
+      scanContent(path, content, violations);
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `${c.green}No banned OECD AIM article-body patterns found.${c.reset}`,
+    );
+    return { passed: true, errors: 0, violations: [] };
+  }
+
+  console.log(
+    `${c.red}Found ${violations.length} OECD AIM article-body violation(s):${c.reset}\n`,
+  );
+  for (const v of violations) {
+    console.log(`  ${c.red}${v.file}:${v.line}${c.reset}  ${v.label}`);
+    console.log(`    ${c.dim}${v.snippet}${c.reset}`);
+  }
+  console.log();
+  console.log(
+    `${c.dim}OECD AIM has no explicit open-data license. We mirror metadata + link-out only — never article body text.${c.reset}`,
+  );
+  console.log(
+    `${c.dim}If this is a false positive, append \`// ${OK_MARKER}: <reason>\` to the line.${c.reset}`,
+  );
+
+  return { passed: false, errors: violations.length, violations };
+}
+
+function main(): void {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}
+
+const invokedDirectly = (() => {
+  try {
+    const self = new URL(import.meta.url).pathname;
+    return (
+      process.argv[1] === self ||
+      process.argv[1]?.endsWith("validate-oecd-aim-no-article-body.ts")
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();


### PR DESCRIPTION
## Summary

Phase 7 of QUA-687 — adds **OECD AI Incident Monitor (AIM)** as a second source of structured AI-incident data alongside MIT AIID (QUA-693 Phase 6). Closes QUA-696.

The day-0 blocker on QUA-696 was: the team couldn't determine whether the "Download results" button on https://oecd.ai/en/incidents produced JSON, CSV, or XLSX. **Resolved via Playwright network capture**:
- The Download button only exports the currently-visible 20 rows as XLSX — **NOT a bulk download**.
- The page's data is backed by `POST https://incidents-server.oecdai.org/api/v1/incidents/fetch-incidents` with `format: "JSON"`. That's the bulk source. ~14,574 incidents available.

## What's in this PR

- `crux/lib/oecd-aim/{transform,fetch}.ts` — pure transform of AIM list-endpoint records into the `ai_incidents` sync schema, plus an HTTP fetcher with **adaptive date-window pagination** (the AIM endpoint silently ignores `skip`/`offset`/`start_index`; only `from_date`/`to_date` work, capped at 100 results/call).
- `crux/commands/ingest-oecd-aim.ts` — `pnpm crux oecd-aim ingest` CLI with `--dry-run`, `--from`, `--to`, `--limit`, `--with-articles`, `--batch`. `pnpm crux oecd-aim probe` for liveness check.
- `apps/wiki-server/drizzle/0218_qua_696_widen_ai_incidents_source.sql` — widens `chk_ai_incidents_source` from `('mit-aiid')` to `('mit-aiid','oecd-aim')`.
- `crux/validate/validate-ai-incidents-source-enum.ts` — gate validator that asserts the route's `VALID_SOURCES` literal stays in lockstep with the migration's CHECK constraint.
- `crux/validate/validate-oecd-aim-no-article-body.ts` — gate validator paralleling `validate-aiid-no-report-text.ts` to defend against accidentally persisting article body text (license-conservative posture).

## Scope decisions

- **Severity is null.** AIM has no low/medium/high/critical ladder in live data (`most_severe_harm` is null, `harm_levels` carries categorical tags like "AI incident"/"AI hazard"). `harm_levels` is preserved as `upstreamSeverity` raw.
- **No org/developer/model attribution.** Per QUA-696 §"out of scope", AIM attribution requires an LLM pass; FK columns emit null. A future PR can backfill via the LLM attribution pipeline (which will also handle the AIID long-tail).
- **License posture: metadata + link-out only.** AIM has no explicit open-data license at oecd.ai. `body` and `thumbImage` fields are stripped from `raw` defensively even though the upstream API returns empty body strings in observed data. Enforced statically by `validate-oecd-aim-no-article-body`.
- **Per-article URLs are opt-in (`--with-articles`).** Pulls the detail endpoint per incident (~14k extra requests). Default `fullReportUrl` is `https://oecd.ai/en/incidents/<id>` (verified 200 OK).

## Pre-migration enumeration

Per `.claude/rules/database-migrations.md` § "Adding CHECK constraints on enum columns":

```
$ curl -s "$WIKI_SERVER_URL/api/ai-incidents/stats" -H "Authorization: Bearer $KEY"
{ "total": 0, "withOrg": 0, "withModel": 0, "bySource": [] }
```

Prod `ai_incidents` is empty (the QUA-693 AIID ingest hasn't run yet), so `DROP CONSTRAINT` + `ADD CONSTRAINT` over zero rows is safe — no `NOT VALID` / `VALIDATE CONSTRAINT` split required.

## Tests

- 42 new unit tests:
  - `crux/lib/oecd-aim/transform.test.ts` — 29 tests covering license invariants, attribution-FK = null, deterministic IDs, summary/title clamping, tag dedup+sort, severity derivation, anti-drift check on MAX_SUMMARY_CHARS vs the route literal.
  - `crux/lib/oecd-aim/fetch.test.ts` — 12 tests covering date arithmetic, adaptive halving, dedup across overlapping recursive halves, error paths, the >100/single-day error branch, and id-format validation that prevents path injection on the detail endpoint.
  - `crux/validate/validate-ai-incidents-source-enum.test.ts` — 1 test (live route + migration parse).
- All 64 gate checks pass (incl. 2 new blocking checks).
- Wiki-server suite: 1462 pass, 0 fail.
- Crux suite: 8298 pass; 6 failures (`validate-sourcing-lint-guard`, `wiki-server/snapshot-resources`) reproduce on main without this PR's changes — pre-existing baseline drift / data-coverage tests, unrelated to this work.

## Test plan

- [x] `pnpm vitest run crux/lib/oecd-aim/ crux/validate/validate-ai-incidents-source-enum.test.ts`
- [x] `pnpm crux w validate gate --fix` (64/64 + 4 advisory)
- [x] `pnpm --filter wiki-server test` (1462 pass)
- [x] `pnpm crux oecd-aim probe` (live API reachable)
- [x] `pnpm crux gh deploy-tasks detect` (1 deploy task: migration 0218)
- [ ] Smoke-run `pnpm crux oecd-aim ingest --dry-run --limit=20` against live AIM API (post-merge — needs prod wiki-server reachability for the full ingest test, and the dry-run path doesn't touch the wiki-server).
- [ ] After merge, run `pnpm crux oecd-aim ingest --limit=200` once to validate the upsert path against the widened CHECK in prod.

## Deploy Checklist

- [ ] Verify migration 0218 applied on server start (post-deploy, automated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ingesting AI incidents from the OECD AI Incident Monitor, expanding incident data coverage beyond existing sources.
  * Added CLI command for importing OECD AIM incidents with configurable date ranges, optional article detail fetching, and batch processing.

* **Chores**
  * Added validation tools and comprehensive tests to ensure data integrity and schema consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->