### PR TITLE
fix(e2e): scope stat-card check via data-testid (QUA-763)

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -63,13 +63,23 @@ const TABBED_PAGES = [
   "/ai-models/gpt-4o",
 ];
 
-/** Pages with stat cards — check for empty values. */
+/**
+ * Pages that MUST render at least one [data-testid="stat-card"]. Used to
+ * verify (a) stat cards are present and (b) each card has a non-empty value.
+ *
+ * Microsoft is intentionally excluded — its data has no HERO_STATS facts,
+ * so 0 stat cards is the expected state, not a regression.
+ *
+ * If you add a page here, make sure it actually uses `ProfileStatCard` or
+ * `StatCard` (org-shared) — both tag their root with `data-testid="stat-card"`.
+ * Inline stat-card markup elsewhere in the codebase is not tagged and would
+ * cause this assertion to fail.
+ */
 const STAT_CARD_PAGES = [
   "/organizations/anthropic",
   "/organizations/openai",
   "/organizations/google-deepmind",
   "/organizations/meta-ai",
-  "/organizations/microsoft",
   "/ai-models/claude-opus-4-5",
   "/ai-models/gemini-2-5-pro",
 ];
@@ -128,6 +138,12 @@ test.describe("Render audit — tabbed pages", () => {
       if (STAT_CARD_PAGES.includes(url)) {
         const cards = page.locator('[data-testid="stat-card"]');
         const count = await cards.count();
+        // Guard against silent no-op if data-testid is removed by a refactor.
+        // Pages in STAT_CARD_PAGES are guaranteed to have stat cards (see the
+        // list comment above — Microsoft is excluded for that reason).
+        expect
+          .soft(count > 0, `No [data-testid="stat-card"] elements on ${url}`)
+          .toBe(true);
         for (let i = 0; i < count; i++) {
           const value = (await cards.nth(i).locator(".text-xl, .text-2xl, .text-3xl, .tabular-nums").first().textContent())?.trim() ?? "";
           expect.soft(value.length > 0, `Empty stat card in ${url} (${i + 1}/${count})`).toBe(true);

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -116,6 +116,24 @@ test.describe("Render audit — tabbed pages", () => {
     test(url, async ({ page }) => {
       await loadPage(page, url);
 
+      // Stat card check runs BEFORE the tab loop because on some pages
+      // (organizations) stat cards live inside the Overview tab, which is
+      // active on initial load but gets unmounted when later tabs are clicked.
+      // Targets [data-testid="stat-card"] tagged on ProfileStatCard +
+      // StatCard (org-shared.tsx) — narrower than the old class-based
+      // filter, which over-matched Family tables, the Details sidebar, and
+      // other rounded containers with `tabular-nums` descendants and produced
+      // an `nth(N).textContent` race when DOM mutated between count and
+      // access (QUA-763).
+      if (STAT_CARD_PAGES.includes(url)) {
+        const cards = page.locator('[data-testid="stat-card"]');
+        const count = await cards.count();
+        for (let i = 0; i < count; i++) {
+          const value = (await cards.nth(i).locator(".text-xl, .text-2xl, .text-3xl, .tabular-nums").first().textContent())?.trim() ?? "";
+          expect.soft(value.length > 0, `Empty stat card in ${url} (${i + 1}/${count})`).toBe(true);
+        }
+      }
+
       const tabs = page.locator("[role='tab'], button[data-state]");
       const tabCount = await tabs.count();
 
@@ -131,18 +149,6 @@ test.describe("Render audit — tabbed pages", () => {
         }
       } else {
         checkAntiPatterns(await getMainText(page), url);
-      }
-
-      // Stat card check for org pages
-      if (STAT_CARD_PAGES.includes(url)) {
-        const cards = page.locator(".rounded-xl.border, .rounded-lg.border").filter({
-          has: page.locator(".text-xl, .text-2xl, .text-3xl, .tabular-nums"),
-        });
-        const count = await cards.count();
-        for (let i = 0; i < count; i++) {
-          const value = (await cards.nth(i).locator(".text-xl, .text-2xl, .text-3xl, .tabular-nums").first().textContent())?.trim() ?? "";
-          expect.soft(value.length > 0, `Empty stat card in ${url} (${i + 1}/${count})`).toBe(true);
-        }
       }
     });
   }

--- a/apps/web/src/app/organizations/[slug]/org-shared.tsx
+++ b/apps/web/src/app/organizations/[slug]/org-shared.tsx
@@ -49,7 +49,10 @@ export function StatCard({
   sub?: string;
 }) {
   return (
-    <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4">
+    <div
+      data-testid="stat-card"
+      className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4"
+    >
       <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1.5">
         {label}
       </div>

--- a/apps/web/src/components/directory/ProfileStatCard.tsx
+++ b/apps/web/src/components/directory/ProfileStatCard.tsx
@@ -36,6 +36,7 @@ export function ProfileStatCard({
     return (
       <Link
         href={href}
+        data-testid="stat-card"
         className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4 hover:border-primary/30 hover:shadow-md transition-all"
       >
         {content}
@@ -44,7 +45,10 @@ export function ProfileStatCard({
   }
 
   return (
-    <div className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4">
+    <div
+      data-testid="stat-card"
+      className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4"
+    >
       {content}
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes the `e2e-post-deploy.yml` red streak on `/ai-models/claude-opus-4-5`. The render-audit stat-card check used a CSS selector (`.rounded-xl.border, .rounded-lg.border` filtered by `has: .text-xl, .text-2xl, .text-3xl, .tabular-nums`) that over-matched any rounded container with a `tabular-nums` descendant — Family tables, the EntityProfileShell Details sidebar, popover content, etc. When the count captured 6+ matches, DOM mutation between `cards.count()` and `cards.nth(N).textContent()` produced the 60-second timeout.

## Changes

- **Tag stat cards explicitly** with `data-testid="stat-card"` on `ProfileStatCard` (both the linked and unlinked branches) and on `StatCard` in `apps/web/src/app/organizations/[slug]/org-shared.tsx`.
- **Switch the e2e selector** to `[data-testid="stat-card"]` — narrow, race-free, no longer coupled to layout classes.
- **Reorder the stat-card check** to run *before* the tab loop. On organization pages, hero stat cards live inside the Overview tab; clicking through later tabs unmounts Overview and the cards disappear, so the check would otherwise see count=0.
- **Add a `count > 0` soft assertion** so a future refactor that drops the data-testid can't silently no-op the test.
- **Drop `/organizations/microsoft` from `STAT_CARD_PAGES`** — Microsoft has no HERO_STATS facts on prod (verified), so 0 cards is the expected state, not a regression.
- **Document the data-testid contract** in a comment above `STAT_CARD_PAGES` so anyone adding a new page knows to use `ProfileStatCard` / `StatCard`, or tag inline markup.

## Test plan

- [x] `pnpm build` — exit 0
- [x] `npx tsc --noEmit` — clean across all three projects
- [x] `pnpm crux w validate gate --fix` — 62 checks pass (4 advisory, unrelated)
- [x] Local Playwright (`PLAYWRIGHT_BASE_URL=http://localhost:3013 npx playwright test e2e/render-audit.spec.ts`) — 30/30 pass
- [x] Hostile-review subagent (`/agent-review-pr`) — 5 findings; 2 HIGH addressed in commit `ed6447a9c`, 1 MEDIUM documented as intentional, 2 LOW dismissed
- [x] Prod Playwright sanity check — anthropic / claude-opus-4-5 / etc. now correctly fail the new `count > 0` guard against current prod (data-testid not yet deployed); will pass once this PR ships and `e2e-post-deploy.yml` runs against the new build.

## Backwards compatibility

The new `expect.soft(count > 0)` guard will trip against prod *until* this PR deploys. That's intended: `e2e-post-deploy.yml` runs after Vercel deploys the merged code, so by the time it tests, the data-testid is present. Pre-deploy ad-hoc runs against prod will report the (intended) failure — which is the same fail-then-self-resolve pattern any new e2e assertion has.

Closes QUA-763
