### PR TITLE
QUA-526 Phase 4a-2: entities.status PG CHECK + trim controlled-vocab validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ data/archive/
 # Only metrics.json + audit doc are committed; corpus + per-item results rebuild on demand
 crux/calibration/data/corpus.json
 crux/calibration/data/results-*.json
+.claude/scratch/

--- a/apps/wiki-server/drizzle/0218_qua_526_entities_status_check.sql
+++ b/apps/wiki-server/drizzle/0218_qua_526_entities_status_check.sql
@@ -13,10 +13,9 @@
 -- (see PR description for the enumeration query output).
 --
 -- Uses the NOT VALID + VALIDATE CONSTRAINT pattern per
--- .claude/rules/database-migrations.md so the ACCESS EXCLUSIVE lock window
--- on the entities table stays minimal. Table is small (~3.4k rows) but
--- the table is wide (jsonb columns) and the same lock would also block any
--- /api/entities reader.
+-- .claude/rules/database-migrations.md. At ~3.4k rows the lock contention
+-- risk is small; following the pattern keeps the migration consistent with
+-- 0169 / 0173 / 0183 and ready for re-use as the table grows.
 
 DO $$ BEGIN
   ALTER TABLE "entities"

--- a/apps/wiki-server/drizzle/0218_qua_526_entities_status_check.sql
+++ b/apps/wiki-server/drizzle/0218_qua_526_entities_status_check.sql
@@ -1,0 +1,29 @@
+-- QUA-526 Phase 4a-2: CHECK constraint on entities.status.
+--
+-- Replaces the YAML-time check in crux/validate/validate-controlled-vocab.ts
+-- for the entities.status column. Other fields covered by that validator
+-- are either already PG-enforced (personnel.role_type and divisions.*
+-- via migrations 0169 + 0173) or are YAML-only (orgType, severity, maturity,
+-- projectStatus, policyStatus, orgStatus, clusters, relatedEntries.*) and
+-- need a separate Zod-at-YAML-load enforcement path.
+--
+-- Allowed values mirror the EntityStatus Zod enum in data/schema.ts
+-- ('stub', 'draft', 'published', 'verified'). NULL is permitted — current
+-- prod state on 2026-04-28 is NULL=3,395 / stub=23 across 3,418 rows
+-- (see PR description for the enumeration query output).
+--
+-- Uses the NOT VALID + VALIDATE CONSTRAINT pattern per
+-- .claude/rules/database-migrations.md so the ACCESS EXCLUSIVE lock window
+-- on the entities table stays minimal. Table is small (~3.4k rows) but
+-- the table is wide (jsonb columns) and the same lock would also block any
+-- /api/entities reader.
+
+DO $$ BEGIN
+  ALTER TABLE "entities"
+    ADD CONSTRAINT chk_entities_status
+    CHECK (status IS NULL OR status IN ('stub', 'draft', 'published', 'verified'))
+    NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "entities" VALIDATE CONSTRAINT chk_entities_status;

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1520,6 +1520,13 @@
       "when": 1787876800000,
       "tag": "0217_qua_791_evidence_relevance_score",
       "breakpoints": true
+    },
+    {
+      "idx": 218,
+      "version": "7",
+      "when": 1787876900000,
+      "tag": "0218_qua_526_entities_status_check",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
@@ -11,14 +11,6 @@ const MIGRATION_FILE = path.resolve(
   "../../drizzle/0218_qua_526_entities_status_check.sql",
 );
 
-/**
- * Schema-drift test for migration 0218 (QUA-526 Phase 4a-2).
- *
- * Asserts the migration declares chk_entities_status with the correct
- * allowed-value set, the NULL allowance, and the NOT VALID + VALIDATE
- * pattern. If the file is edited, this test fails until the regexes are
- * updated to match — the regexes are the canonical contract.
- */
 describe("migration 0218 — QUA-526 entities.status CHECK constraint", () => {
   const sql = readFileSync(MIGRATION_FILE, "utf-8");
 
@@ -27,10 +19,10 @@ describe("migration 0218 — QUA-526 entities.status CHECK constraint", () => {
     expect(sql).toMatch(/ADD\s+CONSTRAINT\s+chk_entities_status\b/);
   });
 
-  it("allows NULL and the four EntityStatus values", () => {
-    expect(sql).toMatch(
-      /CHECK\s*\(\s*status\s+IS\s+NULL\s+OR\s+status\s+IN\s*\(\s*'stub'\s*,\s*'draft'\s*,\s*'published'\s*,\s*'verified'\s*\)\s*\)/,
-    );
+  it("permits NULL via 'status IS NULL OR status IN (...)' shape", () => {
+    // Shape only — value list is asserted by the parity guard below so
+    // legitimate reorderings of the enum don't break this test.
+    expect(sql).toMatch(/CHECK\s*\(\s*status\s+IS\s+NULL\s+OR\s+status\s+IN\s*\(/);
   });
 
   it("CHECK allowed-list matches ENTITY_STATUS_VALUES exactly (parity guard)", () => {
@@ -38,16 +30,12 @@ describe("migration 0218 — QUA-526 entities.status CHECK constraint", () => {
     // production incidents. Parse the literal values out of the migration's
     // IN clause and assert set-equality with ENTITY_STATUS_VALUES so the
     // canonical Zod enum and the migration cannot drift independently.
-    const inClause = sql.match(
-      /status\s+IN\s*\(\s*((?:'[a-z_-]+'\s*,?\s*)+)\)/,
-    );
+    const inClause = sql.match(/status\s+IN\s*\(([^)]+)\)/);
     expect(inClause, "could not parse IN clause from migration").not.toBeNull();
-    const migrationValues = (inClause?.[1] ?? "")
-      .match(/'([^']+)'/g)
-      ?.map((s) => s.slice(1, -1)) ?? [];
-    expect([...migrationValues].sort()).toEqual(
-      [...ENTITY_STATUS_VALUES].sort(),
+    const migrationValues = [...(inClause?.[1] ?? "").matchAll(/'([^']+)'/g)].map(
+      (m) => m[1],
     );
+    expect([...migrationValues].sort()).toEqual([...ENTITY_STATUS_VALUES].sort());
   });
 
   it("uses NOT VALID + VALIDATE CONSTRAINT", () => {

--- a/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0218_qua_526_entities_status_check.sql",
+);
+
+/**
+ * Schema-drift test for migration 0218 (QUA-526 Phase 4a-2).
+ *
+ * Asserts the migration declares chk_entities_status with the correct
+ * allowed-value set, the NULL allowance, and the NOT VALID + VALIDATE
+ * pattern. If the file is edited, this test fails until the regexes are
+ * updated to match — the regexes are the canonical contract.
+ */
+describe("migration 0218 — QUA-526 entities.status CHECK constraint", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("declares chk_entities_status on entities", () => {
+    expect(sql).toMatch(/ALTER\s+TABLE\s+"entities"/);
+    expect(sql).toMatch(/ADD\s+CONSTRAINT\s+chk_entities_status\b/);
+  });
+
+  it("allows NULL and the four EntityStatus values", () => {
+    expect(sql).toMatch(
+      /CHECK\s*\(\s*status\s+IS\s+NULL\s+OR\s+status\s+IN\s*\(\s*'stub'\s*,\s*'draft'\s*,\s*'published'\s*,\s*'verified'\s*\)\s*\)/,
+    );
+  });
+
+  it("uses NOT VALID + VALIDATE CONSTRAINT", () => {
+    // Per .claude/rules/database-migrations.md — split DDL into metadata
+    // registration (NOT VALID, milliseconds) and validation
+    // (VALIDATE CONSTRAINT, SHARE UPDATE EXCLUSIVE) so the ACCESS EXCLUSIVE
+    // window stays small.
+    expect(sql).toMatch(
+      /ADD\s+CONSTRAINT\s+chk_entities_status[\s\S]*?NOT\s+VALID/,
+    );
+    expect(sql).toMatch(/VALIDATE\s+CONSTRAINT\s+chk_entities_status\b/);
+  });
+
+  it("wraps ADD CONSTRAINT in a duplicate_object EXCEPTION handler", () => {
+    expect(sql).toMatch(
+      /DO\s*\$\$[\s\S]*?ADD\s+CONSTRAINT\s+chk_entities_status[\s\S]*?EXCEPTION\s+WHEN\s+duplicate_object[\s\S]*?END\s*\$\$/,
+    );
+  });
+});

--- a/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0218-entities-status-check.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
+import { ENTITY_STATUS_VALUES } from "../api-types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,6 +30,23 @@ describe("migration 0218 — QUA-526 entities.status CHECK constraint", () => {
   it("allows NULL and the four EntityStatus values", () => {
     expect(sql).toMatch(
       /CHECK\s*\(\s*status\s+IS\s+NULL\s+OR\s+status\s+IN\s*\(\s*'stub'\s*,\s*'draft'\s*,\s*'published'\s*,\s*'verified'\s*\)\s*\)/,
+    );
+  });
+
+  it("CHECK allowed-list matches ENTITY_STATUS_VALUES exactly (parity guard)", () => {
+    // QUA-283 lesson: enum drift between Zod and PG CHECK has caused real
+    // production incidents. Parse the literal values out of the migration's
+    // IN clause and assert set-equality with ENTITY_STATUS_VALUES so the
+    // canonical Zod enum and the migration cannot drift independently.
+    const inClause = sql.match(
+      /status\s+IN\s*\(\s*((?:'[a-z_-]+'\s*,?\s*)+)\)/,
+    );
+    expect(inClause, "could not parse IN clause from migration").not.toBeNull();
+    const migrationValues = (inClause?.[1] ?? "")
+      .match(/'([^']+)'/g)
+      ?.map((s) => s.slice(1, -1)) ?? [];
+    expect([...migrationValues].sort()).toEqual(
+      [...ENTITY_STATUS_VALUES].sort(),
     );
   });
 

--- a/apps/wiki-server/src/__tests__/sync-entity-status-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-entity-status-schema.test.ts
@@ -1,12 +1,6 @@
-/**
- * Zod parity test for QUA-526 — SyncEntitySchema.status must reject any
- * value outside the EntityStatus enum, matching the chk_entities_status
- * CHECK constraint added in migration 0218.
- *
- * Drift between this Zod enum, the CHECK constraint, and EntityStatus in
- * data/schema.ts has caused real incidents (see QUA-283 / migration 0173).
- * Pin all three together by spot-checking each accepted/rejected value here.
- */
+// Zod parity test for QUA-526 — SyncEntitySchema.status must mirror
+// chk_entities_status (migration 0218). See QUA-283 for prior incidents
+// caused by Zod ↔ CHECK drift.
 
 import { describe, it, expect } from "vitest";
 import {
@@ -24,12 +18,11 @@ const validBase = {
 describe("SyncEntitySchema.status — QUA-526 parity with chk_entities_status", () => {
   it("exports the canonical EntityStatus value list", () => {
     // Source of truth that the migration + data/schema.ts must mirror.
-    expect([...ENTITY_STATUS_VALUES]).toEqual([
-      "stub",
-      "draft",
-      "published",
-      "verified",
-    ]);
+    // Set-equality, not order-equality, so legitimate reorderings don't
+    // break this test — the migration parity guard does the same.
+    expect([...ENTITY_STATUS_VALUES].sort()).toEqual(
+      ["draft", "published", "stub", "verified"].sort(),
+    );
   });
 
   for (const value of ENTITY_STATUS_VALUES) {

--- a/apps/wiki-server/src/__tests__/sync-entity-status-schema.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-entity-status-schema.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Zod parity test for QUA-526 — SyncEntitySchema.status must reject any
+ * value outside the EntityStatus enum, matching the chk_entities_status
+ * CHECK constraint added in migration 0218.
+ *
+ * Drift between this Zod enum, the CHECK constraint, and EntityStatus in
+ * data/schema.ts has caused real incidents (see QUA-283 / migration 0173).
+ * Pin all three together by spot-checking each accepted/rejected value here.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SyncEntitySchema,
+  ENTITY_STATUS_VALUES,
+} from "../api-types.js";
+
+const validBase = {
+  id: "test-entity",
+  stableId: "sid_TEST00001",
+  entityType: "organization",
+  title: "Test Entity",
+};
+
+describe("SyncEntitySchema.status — QUA-526 parity with chk_entities_status", () => {
+  it("exports the canonical EntityStatus value list", () => {
+    // Source of truth that the migration + data/schema.ts must mirror.
+    expect([...ENTITY_STATUS_VALUES]).toEqual([
+      "stub",
+      "draft",
+      "published",
+      "verified",
+    ]);
+  });
+
+  for (const value of ENTITY_STATUS_VALUES) {
+    it(`accepts status='${value}'`, () => {
+      const parsed = SyncEntitySchema.safeParse({ ...validBase, status: value });
+      expect(parsed.success).toBe(true);
+    });
+  }
+
+  it("accepts status=null", () => {
+    const parsed = SyncEntitySchema.safeParse({ ...validBase, status: null });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts status=undefined (field omitted)", () => {
+    const parsed = SyncEntitySchema.safeParse({ ...validBase });
+    expect(parsed.success).toBe(true);
+  });
+
+  it.each([
+    ["pending"],
+    ["active"],
+    ["completed"],
+    ["Stub"], // case-sensitive
+    [""],
+    ["unknown-future-status"],
+  ])("rejects invalid status='%s'", (badValue) => {
+    const parsed = SyncEntitySchema.safeParse({ ...validBase, status: badValue });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      // The failure must specifically mention the status field (not a different
+      // schema violation that happens to fail too).
+      expect(
+        parsed.error.issues.some((i) => i.path.includes("status")),
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1007,6 +1007,13 @@ export type ContentStatus = (typeof CONTENT_STATUS_VALUES)[number];
 // Entities
 // ---------------------------------------------------------------------------
 
+/**
+ * Editorial status values for entities. Matches the EntityStatus Zod enum in
+ * data/schema.ts and the CHECK constraint chk_entities_status added in
+ * migration 0218 (QUA-526). Update all three together if values change.
+ */
+export const ENTITY_STATUS_VALUES = ["stub", "draft", "published", "verified"] as const;
+
 export const SyncEntitySchema = z.object({
   id: z.string().min(1).max(300),
   wikiId: z.string().max(20).nullable().optional(),
@@ -1017,7 +1024,7 @@ export const SyncEntitySchema = z.object({
   website: z.string().max(2000).nullable().optional(),
   tags: z.array(z.string().max(200)).max(100).nullable().optional(),
   clusters: z.array(z.string().max(200)).max(50).nullable().optional(),
-  status: z.string().max(100).nullable().optional(),
+  status: z.enum(ENTITY_STATUS_VALUES).nullable().optional(),
   lastUpdated: z.string().max(50).nullable().optional(),
   customFields: z
     .array(

--- a/crux/validate/validate-controlled-vocab.test.ts
+++ b/crux/validate/validate-controlled-vocab.test.ts
@@ -1,42 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ApiResult } from "../lib/wiki-server/client.ts";
-
-// Mock apiRequest before importing modules that use it
-vi.mock("../lib/wiki-server/client.ts", () => ({
-  apiRequest: vi.fn(),
-  getServerUrl: vi.fn(() => "http://localhost:3002"),
-  getApiKey: vi.fn(() => "test-key"),
-  buildHeaders: vi.fn(() => ({ "Content-Type": "application/json" })),
-}));
-
-import { apiRequest } from "../lib/wiki-server/client.ts";
+import { describe, it, expect } from "vitest";
 import {
   suggestCorrection,
   checkValue,
   checkYamlEntities,
-  checkPersonnel,
-  checkDivisions,
   VALID_ENTITY_TYPES,
   VALID_RELATIONSHIPS,
-  VALID_ORG_TYPES,
-  VALID_SEVERITIES,
   VALID_MATURITIES,
-  VALID_STATUSES,
-  VALID_CLUSTERS,
-  VALID_POLICY_STATUSES,
-  VALID_PROJECT_STATUSES,
-  VALID_ROLE_TYPES,
-  VALID_DIVISION_TYPES,
-  VALID_DIVISION_STATUSES,
   type VocabIssue,
   type EntityData,
 } from "./validate-controlled-vocab.ts";
-
-const mockApiRequest = vi.mocked(apiRequest);
-
-beforeEach(() => {
-  mockApiRequest.mockReset();
-});
 
 // ---------------------------------------------------------------------------
 // suggestCorrection
@@ -232,14 +204,8 @@ describe("checkYamlEntities", () => {
     expect(issues[0].field).toBe("maturity");
   });
 
-  it("flags invalid status", () => {
-    const entities = [
-      makeEntity({ id: "bad-status", type: "risk", status: "pending" }),
-    ];
-    const issues = checkYamlEntities(entities);
-    expect(issues).toHaveLength(1);
-    expect(issues[0].field).toBe("status");
-  });
+  // entity.status is no longer checked here — chk_entities_status (migration
+  // 0218) and SyncEntitySchema's z.enum() now own that contract.
 
   it("flags invalid cluster values", () => {
     const entities = [
@@ -357,223 +323,6 @@ describe("checkYamlEntities", () => {
 });
 
 // ---------------------------------------------------------------------------
-// checkPersonnel (PG checks with mocked API)
-// ---------------------------------------------------------------------------
-
-describe("checkPersonnel", () => {
-  it("returns no issues when all roleTypes are valid", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            roleType: "key-person",
-            personId: "alice",
-            organizationId: "org-a",
-            role: "CEO",
-          },
-          {
-            roleType: "board",
-            personId: "bob",
-            organizationId: "org-b",
-            role: "Director",
-          },
-        ],
-        total: 2,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkPersonnel();
-    expect(issues).toHaveLength(0);
-  });
-
-  it("flags invalid roleType values", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            roleType: "key_person",
-            personId: "alice",
-            organizationId: "org-a",
-            role: "CEO",
-          },
-        ],
-        total: 1,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkPersonnel();
-    expect(issues).toHaveLength(1);
-    expect(issues[0].field).toBe("personnel.roleType");
-    expect(issues[0].value).toBe("key_person");
-    expect(issues[0].suggestion).toBe("key-person");
-  });
-
-  it("returns empty issues when wiki-server is unavailable", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: false,
-      error: "server_error" as const,
-      message: "Connection refused",
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkPersonnel();
-    expect(issues).toHaveLength(0);
-  });
-
-  it("paginates through all personnel records", async () => {
-    // First page: 2 records with total=3
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            roleType: "key-person",
-            personId: "p1",
-            organizationId: "o1",
-            role: "CEO",
-          },
-          {
-            roleType: "board",
-            personId: "p2",
-            organizationId: "o2",
-            role: "Dir",
-          },
-        ],
-        total: 3,
-      },
-    } as ApiResult<Record<string, unknown>>);
-    // Second page: 1 record (invalid)
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            roleType: "invalid-type",
-            personId: "p3",
-            organizationId: "o3",
-            role: "Unknown",
-          },
-        ],
-        total: 3,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkPersonnel();
-    expect(mockApiRequest).toHaveBeenCalledTimes(2);
-    expect(issues).toHaveLength(1);
-    expect(issues[0].value).toBe("invalid-type");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// checkDivisions (PG checks with mocked API)
-// ---------------------------------------------------------------------------
-
-describe("checkDivisions", () => {
-  it("returns no issues when all values are valid", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            divisionType: "team",
-            name: "Safety Team",
-            parentOrgId: "org-a",
-            status: "active",
-          },
-          {
-            divisionType: "fund",
-            name: "Grants Fund",
-            parentOrgId: "org-b",
-            status: null,
-          },
-        ],
-        total: 2,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkDivisions();
-    expect(issues).toHaveLength(0);
-  });
-
-  it("flags invalid divisionType", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            divisionType: "bureau",
-            name: "Some Bureau",
-            parentOrgId: "org-a",
-            status: "active",
-          },
-        ],
-        total: 1,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkDivisions();
-    expect(issues).toHaveLength(1);
-    expect(issues[0].field).toBe("divisions.divisionType");
-    expect(issues[0].value).toBe("bureau");
-  });
-
-  it("flags invalid division status", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            divisionType: "team",
-            name: "Dead Team",
-            parentOrgId: "org-a",
-            status: "closed",
-          },
-        ],
-        total: 1,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkDivisions();
-    expect(issues).toHaveLength(1);
-    expect(issues[0].field).toBe("divisions.status");
-    expect(issues[0].value).toBe("closed");
-  });
-
-  it("skips null division status without flagging", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        items: [
-          {
-            divisionType: "team",
-            name: "No Status",
-            parentOrgId: "org-a",
-            status: null,
-          },
-        ],
-        total: 1,
-      },
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkDivisions();
-    expect(issues).toHaveLength(0);
-  });
-
-  it("returns empty issues when wiki-server is unavailable", async () => {
-    mockApiRequest.mockResolvedValueOnce({
-      ok: false,
-      error: "server_error" as const,
-      message: "Connection refused",
-    } as ApiResult<Record<string, unknown>>);
-
-    const issues = await checkDivisions();
-    expect(issues).toHaveLength(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Vocabulary set correctness — canonical source alignment
 // ---------------------------------------------------------------------------
 
@@ -608,13 +357,9 @@ describe("vocabulary sets align with canonical sources", () => {
     }
   });
 
-  it("VALID_STATUSES matches EntityStatus enum", () => {
-    expect(VALID_STATUSES.has("stub")).toBe(true);
-    expect(VALID_STATUSES.has("draft")).toBe(true);
-    expect(VALID_STATUSES.has("published")).toBe(true);
-    expect(VALID_STATUSES.has("verified")).toBe(true);
-    expect(VALID_STATUSES.size).toBe(4);
-  });
+  // entities.status / EntityStatus is now PG-enforced (chk_entities_status,
+  // migration 0218) so the matching set is no longer exported from the
+  // validator.
 
   it("VALID_MATURITIES matches ResearchMaturity enum", () => {
     expect(VALID_MATURITIES.has("Neglected")).toBe(true);

--- a/crux/validate/validate-controlled-vocab.ts
+++ b/crux/validate/validate-controlled-vocab.ts
@@ -1,27 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * Controlled Vocabulary Validator
+ * Controlled Vocabulary Validator (YAML-only, post-QUA-526).
  *
- * Validates that free-text fields in YAML entities and PG-primary tables
- * match their expected controlled vocabularies. Reports unknown/non-standard
- * values as warnings and suggests corrections for typos.
+ * Validates that free-text fields in YAML entities match their expected
+ * controlled vocabularies. Reports unknown/non-standard values as warnings
+ * and suggests corrections for typos.
  *
- * Checked fields (YAML entities):
+ * **PG-primary fields are no longer checked here.** They have PG `CHECK`
+ * constraints that enforce the same enums at write time:
+ *   - `personnel.role_type` — chk_personnel_role_type (migration 0173)
+ *   - `divisions.division_type` — chk_divisions_division_type (migration 0173)
+ *   - `divisions.status` — chk_divisions_status (migration 0169)
+ *   - `entities.status` — chk_entities_status (migration 0218, this PR)
+ *
+ * Checked fields (YAML entities, no PG column to CHECK):
  *   - type (entityType): canonical entity types + known aliases
  *   - relatedEntries[].relationship: RelationshipType enum
  *   - orgType: organization sub-type enum
  *   - severity: severity level enum
  *   - maturity: ResearchMaturity enum
- *   - status: EntityStatus enum
  *   - clusters: topic cluster enum
  *   - policyStatus: de facto policy status vocabulary
  *   - projectStatus: project status enum
- *
- * Checked fields (PG-primary, via wiki-server API):
- *   - personnel.roleType: VALID_ROLE_TYPES
- *   - divisions.divisionType: VALID_DIVISION_TYPES
- *   - divisions.status: VALID_STATUSES
+ *   - orgStatus: operational status enum
  *
  * Usage:
  *   pnpm crux validate controlled-vocab             # Run full check
@@ -34,13 +36,11 @@
  */
 
 import { readFileSync, readdirSync, existsSync } from "fs";
-import { join, basename } from "path";
+import { join } from "path";
 import { parse as parseYaml } from "yaml";
 import { getColors } from "../lib/output.ts";
 import { PROJECT_ROOT, DATA_DIR } from "../lib/content-types.ts";
-import { fetchAllRecords } from "./validate-soft-fks.ts";
 import type { ValidatorResult } from "./types.ts";
-import type { Colors } from "../lib/output.ts";
 
 // Canonical sources for vocabulary lists
 import {
@@ -48,7 +48,6 @@ import {
 } from "../../apps/web/src/data/entity-type-names.ts";
 import {
   RelationshipType as RelationshipTypeEnum,
-  EntityStatus as EntityStatusEnum,
   ResearchMaturity as ResearchMaturityEnum,
 } from "../../data/schema.ts";
 
@@ -106,13 +105,9 @@ export const VALID_SEVERITIES = new Set([
 export const VALID_MATURITIES = new Set<string>(ResearchMaturityEnum.options);
 
 /**
- * Valid entity status values — imported from data/schema.ts EntityStatus enum.
- */
-export const VALID_STATUSES = new Set<string>(EntityStatusEnum.options);
-
-/**
  * Valid organization operational status values.
- * Distinct from EntityStatus (stub/draft/published/verified) which tracks editorial state.
+ * Distinct from `entities.status` (the editorial state — stub/draft/published/
+ * verified — which is enforced by chk_entities_status, migration 0218).
  */
 export const VALID_ORG_STATUSES = new Set([
   "active", "merged", "acquired", "defunct", "dissolved", "inactive",
@@ -162,41 +157,6 @@ export const VALID_PROJECT_STATUSES = new Set([
   "beta",
 ] as const);
 
-/**
- * Valid personnel roleType values.
- * Canonical source: apps/wiki-server/src/routes/tablebase/personnel.ts VALID_ROLE_TYPES.
- * Last synced: 2026-03-19.
- */
-export const VALID_ROLE_TYPES = new Set([
-  "key-person",
-  "board",
-  "career",
-] as const);
-
-/**
- * Valid division type values.
- * Canonical source: apps/wiki-server/src/routes/tablebase/divisions.ts VALID_DIVISION_TYPES.
- * Last synced: 2026-03-19.
- */
-export const VALID_DIVISION_TYPES = new Set([
-  "fund",
-  "team",
-  "department",
-  "lab",
-  "program-area",
-] as const);
-
-/**
- * Valid division status values.
- * Canonical source: apps/wiki-server/src/routes/tablebase/divisions.ts VALID_STATUSES.
- * Last synced: 2026-03-19.
- */
-export const VALID_DIVISION_STATUSES = new Set([
-  "active",
-  "inactive",
-  "dissolved",
-] as const);
-
 // ---------------------------------------------------------------------------
 // Interfaces
 // ---------------------------------------------------------------------------
@@ -226,22 +186,6 @@ export interface EntityData {
     relationship?: string;
     strength?: string;
   }>;
-  [key: string]: unknown;
-}
-
-interface PersonnelRow {
-  roleType: string;
-  personId: string;
-  organizationId: string;
-  role: string;
-  [key: string]: unknown;
-}
-
-interface DivisionRow {
-  divisionType: string;
-  name: string;
-  parentOrgId: string;
-  status?: string | null;
   [key: string]: unknown;
 }
 
@@ -373,8 +317,7 @@ export function checkYamlEntities(entities: Array<EntityData & { _sourceFile: st
     // 4. maturity
     checkValue("maturity", entity.maturity, VALID_MATURITIES, id, src, issues);
 
-    // 5. status
-    checkValue("status", entity.status, VALID_STATUSES, id, src, issues);
+    // (entity.status is now PG-enforced — chk_entities_status in migration 0218)
 
     // 6. clusters
     if (Array.isArray(entity.clusters)) {
@@ -438,83 +381,12 @@ export function checkYamlEntities(entities: Array<EntityData & { _sourceFile: st
 }
 
 // ---------------------------------------------------------------------------
-// PG-primary data checks (via wiki-server API)
-// ---------------------------------------------------------------------------
-
-export async function checkPersonnel(): Promise<VocabIssue[]> {
-  const issues: VocabIssue[] = [];
-
-  const records = await fetchAllRecords(
-    "/api/tablebase/personnel",
-    "items",
-    200
-  );
-  if (!records) {
-    // Wiki-server unavailable — skip PG checks gracefully
-    return issues;
-  }
-
-  for (const row of records) {
-    const r = row as PersonnelRow;
-    checkValue(
-      "personnel.roleType",
-      r.roleType,
-      VALID_ROLE_TYPES,
-      `personnel:${r.personId}@${r.organizationId}`,
-      "wiki-server:personnel",
-      issues
-    );
-  }
-
-  return issues;
-}
-
-export async function checkDivisions(): Promise<VocabIssue[]> {
-  const issues: VocabIssue[] = [];
-
-  const records = await fetchAllRecords(
-    "/api/tablebase/divisions",
-    "items",
-    200
-  );
-  if (!records) {
-    return issues;
-  }
-
-  for (const row of records) {
-    const r = row as DivisionRow;
-    checkValue(
-      "divisions.divisionType",
-      r.divisionType,
-      VALID_DIVISION_TYPES,
-      `division:${r.name}@${r.parentOrgId}`,
-      "wiki-server:divisions",
-      issues
-    );
-    if (r.status != null) {
-      checkValue(
-        "divisions.status",
-        r.status,
-        VALID_DIVISION_STATUSES,
-        `division:${r.name}@${r.parentOrgId}`,
-        "wiki-server:divisions",
-        issues
-      );
-    }
-  }
-
-  return issues;
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 export interface ControlledVocabResult extends ValidatorResult {
   issues: VocabIssue[];
   checkedEntities: number;
-  checkedPersonnel: boolean;
-  checkedDivisions: boolean;
 }
 
 export async function validateControlledVocab(options?: {
@@ -525,39 +397,8 @@ export async function validateControlledVocab(options?: {
   const verbose = options?.verbose ?? false;
   const c = getColors(ci);
 
-  // Phase 1: Check YAML entities
   const entities = loadYamlEntities();
-  const yamlIssues = checkYamlEntities(entities);
-
-  // Phase 2: Check PG-primary data (best-effort)
-  let personnelIssues: VocabIssue[] = [];
-  let divisionIssues: VocabIssue[] = [];
-  let checkedPersonnel = false;
-  let checkedDivisions = false;
-
-  try {
-    personnelIssues = await checkPersonnel();
-    checkedPersonnel = true;
-  } catch (e: unknown) {
-    if (!ci) {
-      console.log(
-        `${c.dim}  Skipped personnel checks (wiki-server unavailable)${c.reset}`
-      );
-    }
-  }
-
-  try {
-    divisionIssues = await checkDivisions();
-    checkedDivisions = true;
-  } catch (e: unknown) {
-    if (!ci) {
-      console.log(
-        `${c.dim}  Skipped division checks (wiki-server unavailable)${c.reset}`
-      );
-    }
-  }
-
-  const allIssues = [...yamlIssues, ...personnelIssues, ...divisionIssues];
+  const allIssues = checkYamlEntities(entities);
 
   // Group issues by field for readable output
   const byField = new Map<string, VocabIssue[]>();
@@ -572,7 +413,7 @@ export async function validateControlledVocab(options?: {
       `\n${c.bold}Controlled Vocabulary Validation${c.reset}`
     );
     console.log(
-      `${c.dim}  Checked ${entities.length} YAML entities${checkedPersonnel ? ", personnel" : ""}${checkedDivisions ? ", divisions" : ""}${c.reset}\n`
+      `${c.dim}  Checked ${entities.length} YAML entities${c.reset}\n`
     );
 
     if (allIssues.length === 0) {
@@ -616,7 +457,8 @@ export async function validateControlledVocab(options?: {
     }
 
     if (verbose) {
-      // Show summary of all valid vocabularies
+      // Show summary of all valid vocabularies (YAML-only — PG-enforced fields
+      // are CHECK-constrained server-side and don't appear here).
       console.log(`${c.bold}Valid vocabularies:${c.reset}`);
       const vocabs = [
         { name: "type", values: VALID_ENTITY_TYPES },
@@ -625,13 +467,9 @@ export async function validateControlledVocab(options?: {
         { name: "orgStatus", values: VALID_ORG_STATUSES },
         { name: "severity", values: VALID_SEVERITIES },
         { name: "maturity", values: VALID_MATURITIES },
-        { name: "status", values: VALID_STATUSES },
         { name: "clusters", values: VALID_CLUSTERS },
         { name: "policyStatus", values: VALID_POLICY_STATUSES },
         { name: "projectStatus", values: VALID_PROJECT_STATUSES },
-        { name: "personnel.roleType", values: VALID_ROLE_TYPES },
-        { name: "divisions.divisionType", values: VALID_DIVISION_TYPES },
-        { name: "divisions.status", values: VALID_DIVISION_STATUSES },
       ];
       for (const v of vocabs) {
         console.log(
@@ -649,8 +487,6 @@ export async function validateControlledVocab(options?: {
         warnings: allIssues.length,
         errors: 0,
         checkedEntities: entities.length,
-        checkedPersonnel,
-        checkedDivisions,
         issues: allIssues.map((i) => ({
           field: i.field,
           value: i.value,
@@ -668,8 +504,6 @@ export async function validateControlledVocab(options?: {
     warnings: allIssues.length,
     issues: allIssues,
     checkedEntities: entities.length,
-    checkedPersonnel,
-    checkedDivisions,
   };
 }
 
@@ -682,8 +516,7 @@ async function main(): Promise<void> {
   const ci = args.includes("--ci");
   const verbose = args.includes("--verbose");
 
-  const result = await validateControlledVocab({ ci, verbose });
-
+  await validateControlledVocab({ ci, verbose });
 }
 
 main().catch((err) => {

--- a/crux/validate/validate-controlled-vocab.ts
+++ b/crux/validate/validate-controlled-vocab.ts
@@ -319,14 +319,14 @@ export function checkYamlEntities(entities: Array<EntityData & { _sourceFile: st
 
     // (entity.status is now PG-enforced — chk_entities_status in migration 0218)
 
-    // 6. clusters
+    // 5. clusters
     if (Array.isArray(entity.clusters)) {
       for (const cluster of entity.clusters) {
         checkValue("clusters", cluster, VALID_CLUSTERS, id, src, issues);
       }
     }
 
-    // 7. policyStatus (only for policy entities)
+    // 6. policyStatus (only for policy entities)
     if (entity.type === "policy" && entity.policyStatus) {
       checkValue(
         "policyStatus",
@@ -338,7 +338,7 @@ export function checkYamlEntities(entities: Array<EntityData & { _sourceFile: st
       );
     }
 
-    // 8. projectStatus (only for project entities)
+    // 7. projectStatus (only for project entities)
     if (entity.type === "project" && entity.projectStatus) {
       checkValue(
         "projectStatus",
@@ -350,7 +350,7 @@ export function checkYamlEntities(entities: Array<EntityData & { _sourceFile: st
       );
     }
 
-    // 9. relatedEntries — check relationship and entry type
+    // 8. relatedEntries — check relationship and entry type
     if (Array.isArray(entity.relatedEntries)) {
       for (const entry of entity.relatedEntries) {
         if (entry.relationship) {

--- a/crux/wiki-server/sync-entities.test.ts
+++ b/crux/wiki-server/sync-entities.test.ts
@@ -73,7 +73,7 @@ describe("transformEntity", () => {
       website: "https://anthropic.com",
       tags: ["ai-safety", "frontier-lab"],
       clusters: ["ai-labs"],
-      status: "active",
+      status: "published",
       lastUpdated: "2025-06",
       customFields: [{ label: "Founded", value: "2021" }],
       relatedEntries: [{ id: "openai", type: "organization" }],


### PR DESCRIPTION
## Summary

Phase 4a-2 of QUA-408 — migrates the PG-checkable fields covered by `validate-controlled-vocab` to PG `CHECK` constraints + tighter Zod enums.

The four fields in scope:

| Field | PG-enforcement | Status |
|---|---|---|
| `personnel.role_type` | `chk_personnel_role_type` (migration 0173) | already enforced — no migration needed |
| `divisions.division_type` | `chk_divisions_division_type` (migration 0173) | already enforced |
| `divisions.status` | `chk_divisions_status` (migration 0169) | already enforced |
| `entities.status` | **`chk_entities_status` (this PR — migration 0218)** | added |

Only `entities.status` was previously un-CHECKed; this PR closes the gap and tightens `SyncEntitySchema.status` from `z.string().max(100)` to `z.enum(ENTITY_STATUS_VALUES)` so the API rejects out-of-vocab values at the same point the DB does (per the QUA-283 lesson on Zod ↔ CHECK parity).

The four PG-enforced fields are removed from `validate-controlled-vocab.ts`. YAML-only fields (orgType, severity, maturity, projectStatus, policyStatus, orgStatus, clusters, relatedEntries) stay in the validator — they have no PG column to CHECK. Their migration to Zod-at-build-time is QUA-806; the `entities.entity_type` migration (which needs cleanup of the `test-deploy-check` fixture first) is QUA-807.

## Enumeration

Queried prod via wiki-server endpoints (`/api/personnel/stats`, `/api/divisions/all`, `/api/entities`) on 2026-04-28 per `.claude/rules/database-migrations.md` § "Adding CHECK constraints on enum columns":

```
personnel.role_type       (1,699 rows): key-person 621, board 382, career 696
divisions.division_type   (124 rows):   program-area 39, fund 35, team 32, department 12, lab 6
divisions.status          (124 rows):   active 118, dissolved 5, inactive 1
entities.status           (3,418 rows): NULL 3,395, stub 23
```

All four are clean against their respective Zod enums. The `entities.entity_type` enumeration also surfaced one dirty `test` row (`test-deploy-check` / `sid_TESTDEPLOY`) — that cleanup + CHECK is filed as QUA-807.

## Migration

`apps/wiki-server/drizzle/0218_qua_526_entities_status_check.sql` uses `NOT VALID` + `VALIDATE CONSTRAINT`:

```sql
ALTER TABLE "entities"
  ADD CONSTRAINT chk_entities_status
  CHECK (status IS NULL OR status IN ('stub', 'draft', 'published', 'verified'))
  NOT VALID;
ALTER TABLE "entities" VALIDATE CONSTRAINT chk_entities_status;
```

Wrapped in a `DO $$ ... EXCEPTION WHEN duplicate_object` block for idempotency. Allowed values mirror `EntityStatus` Zod enum in `data/schema.ts:622` and the new `ENTITY_STATUS_VALUES` constant in `apps/wiki-server/src/api-types.ts`.

## Tests

- `migration-0218-entities-status-check.test.ts` — schema-drift test (regex shape + parity-guard that parses the IN clause and asserts set-equality with `ENTITY_STATUS_VALUES`)
- `sync-entity-status-schema.test.ts` — Zod parity (accepts each valid value + null + undefined; rejects `pending`, `active`, `completed`, `Stub`, `""`, unknown values)
- `sync-entities.test.ts` — fixture fix (`status: "active"` → `"published"` so the YAML transform test stays consistent with the tightened schema)

## Test plan

- [x] `pnpm crux w validate gate --fix` — all 62 gate checks pass
- [x] `pnpm test` (apps/wiki-server) — 1480 tests pass, 57 skipped
- [x] `pnpm test` (crux validator) — 39 tests pass (drops `checkPersonnel`/`checkDivisions` tests; keeps YAML-only checks)
- [x] `pnpm build` — exit 0
- [x] `npx tsc --noEmit` (apps/web, apps/wiki-server) — clean
- [x] `pnpm crux validate controlled-vocab --verbose` — runs YAML-only check, surfaces 4 pre-existing `projectStatus` violations as warnings (handled in QUA-806 follow-up)

## Follow-ups

- **QUA-806** — Migrate YAML-only fields (orgType, severity, maturity, etc.) to Zod-at-build-time enforcement, then delete `validate-controlled-vocab.ts` entirely.
- **QUA-807** — Cleanup `test-deploy-check` entity + add CHECK on `entities.entity_type` (decision needed on canonical-only vs canonical+aliases vocab).
- **QUA-808** — Pre-existing baseline drift in `validate-sourcing-lint-guard` (4 hyphenated `source-check` references introduced after the QUA-358 freeze; unrelated to this PR but observed during gate run).
- **QUA-809** — Pre-existing bug: `validate-controlled-vocab.ts::main()` doesn't propagate `passed: false` to non-zero exit code, so the gate's `advisory: false` flag is silently ignored. Fixing requires also resolving the 4 stale `projectStatus` violations.

Closes QUA-526.


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0218 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
<!-- /deploy-tasks -->