### PR TITLE
Fix main branch CI failure: replace source-check with sourcing in JSDoc comments

### DIFF
--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts
@@ -1,5 +1,5 @@
 /**
- * Shared types for source-check verdict aggregation (QUA-791).
+ * Shared types for sourcing verdict aggregation (QUA-791).
  *
  * Lives in a separate file from the aggregation logic so consumers
  * (route, tests, callers) can import the types without pulling the

--- a/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical source-check verdict aggregation.
+ * Canonical sourcing verdict aggregation.
  *
  * Single source of truth for collapsing per-source `source_check_evidence`
  * rows into one `source_check_verdicts` row. Every code path that derives

--- a/crux/scripts/recompute-source-verdicts.ts
+++ b/crux/scripts/recompute-source-verdicts.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --import tsx/esm
 /**
- * One-time backfill: recompute every source-check verdict from its
+ * One-time backfill: recompute every sourcing verdict from its
  * underlying evidence rows (QUA-791).
  *
  * The pre-Phase-1 `POST /verdicts` endpoint was last-writer-wins —

--- a/crux/validate/validate-verdict-priority.ts
+++ b/crux/validate/validate-verdict-priority.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Validate that source-check verdict severity/priority is defined in exactly
+ * Validate that sourcing verdict severity/priority is defined in exactly
  * one place: SOURCE_CHECK_VERDICT_PRIORITY in apps/web/src/components/shared/verdict-styles.ts.
  *
  * QUA-429 found two helpers (`pickWorstVerdict`, `rollupVerdictFromSummary`)


### PR DESCRIPTION
## Summary

Fixes CI failure from run #25085556285.

The `validate-sourcing-lint-guard` baseline test failed because 4 recently-added files contained `source-check` in JSDoc/file-header comments, raising the ratchet count from 1 to 5.

**Root cause**: Recent PRs introduced new files (`sourcing-aggregation.ts`, `sourcing-aggregation-types.ts`, `validate-verdict-priority.ts`, `recompute-source-verdicts.ts`) with JSDoc comments still using the legacy `source-check` terminology.

**Fix**: Changed 4 comment strings to use `sourcing` terminology per the QUA-102/QUA-237 rename:
- `apps/wiki-server/src/routes/sourcing/sourcing-aggregation.ts`
- `apps/wiki-server/src/routes/sourcing/sourcing-aggregation-types.ts`
- `crux/scripts/recompute-source-verdicts.ts`
- `crux/validate/validate-verdict-priority.ts`

No logic changes — only JSDoc comment text updated.

## Test plan

- [x] \\`npx tsx crux/validate/validate-sourcing-lint-guard.ts\\` passes (count at baseline: 1)
- [x] No functional code changed, only comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)