### PR TITLE
fix(ci): bump scheduled-maintenance max-turns 60 → 80 (QUA-754)

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -119,7 +119,7 @@ jobs:
           ANTHROPIC_BILLING_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 60 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
+          claude_args: '--max-turns 80 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Task,TodoWrite,WebFetch"'
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Summary

Bumps `--max-turns` in `.github/workflows/scheduled-maintenance.yml` from 60 to 80. The daily maintenance sweep has hit the 60-turn cap on 4 consecutive days (2026-04-23, 04-24, 04-26, 04-27), and the previous fix attempt under #4138 / QUA-236 closed without applying any change.

## Root cause (unaddressed)

This is a **symptom patch**, not a fix. The maintenance sweep scope (review 100+ PRs, run audits, detect fix-chains, propagate learnings) consistently grows past the configured turn budget. Bump history:

| Date         | PR        | Bump        |
|--------------|-----------|-------------|
| 2026-03-04   | #1578     | 15 → 30     |
| 2026-03-06   | #1783     | 30 → 60     |
| 2026-04-29   | this PR   | 60 → 80     |

Each prior bump held for ~6 weeks. 80 will likely hold for a similar window, then recur.

## Followups filed (the actual fix)

- **QUA-816** — Measure actual turn usage to right-size `--max-turns` (medium-term)
- **QUA-817** — Split the monolithic sweep into per-task workflows (long-term, blocked by QUA-816)

QUA-754 itself can close on this merge — it's the immediate-fix ticket. The recurring root cause now lives in QUA-816 / QUA-817.

## Test plan

- [x] `pnpm crux w validate gate` — all 57 blocking checks pass
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Next scheduled-maintenance run completes within 80 turns (verified post-merge)

## Deploy Checklist

No deploy actions needed — the workflow change takes effect on the next scheduled cron firing.

Fixes QUA-754
