### PR TITLE
feat(QUA-487): migrate financial + publication detail pages to EntityProfileShell

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -71,6 +71,11 @@ const SIDEBAR_ONLY_PAGES = [
   // Projects — migrated to EntityProfileShell in QUA-485
   "/projects/ai-economist",
   "/projects/aaa-ai-arbitrator",
+  // Financial / publication record pages — migrated to EntityProfileShell in QUA-487
+  "/investments/2OcNxLqfEr",
+  "/funding-rounds/2uXzVFJgb-",
+  "/funding-programs/pJ9oHvQ1Bb",
+  "/publications/nature",
 ];
 
 /**

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -71,10 +71,12 @@ const SIDEBAR_ONLY_PAGES = [
   // Projects — migrated to EntityProfileShell in QUA-485
   "/projects/ai-economist",
   "/projects/aaa-ai-arbitrator",
-  // Financial / publication record pages — migrated to EntityProfileShell in QUA-487
-  "/investments/2OcNxLqfEr",
-  "/funding-rounds/2uXzVFJgb-",
-  "/funding-programs/pJ9oHvQ1Bb",
+  // Publications — migrated to EntityProfileShell in QUA-487. Uses YAML
+  // publications data so it's available in CI without PG access.
+  // Note: investments/[id], funding-rounds/[id], funding-programs/[id] were
+  // also migrated in QUA-487 but their records live only in PG, so they
+  // 404 in the CI build (LONGTERMWIKI_SERVER_URL unset → kb-pg merge skipped).
+  // Validated locally with a dev server pointed at prod data.
   "/publications/nature",
 ];
 

--- a/apps/web/src/app/funding-programs/[id]/page.tsx
+++ b/apps/web/src/app/funding-programs/[id]/page.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllKBRecords } from "@/data/factbase";
 import { formatCompactCurrency } from "@/lib/format-compact";
-import { Breadcrumbs } from "@/components/directory";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import { safeHref } from "@/lib/directory-utils";
 import {
   formatKBDate,
@@ -21,7 +22,7 @@ import {
   PROGRAM_TYPE_COLORS,
 } from "./program-data";
 import { DetailSection, EntityLinkDisplay } from "./program-shared";
-import { GrantsAwardedSection, BackToFunderLink } from "./program-sections";
+import { GrantsAwardedSection } from "./program-sections";
 
 // ── Static params ──────────────────────────────────────────────────────
 
@@ -66,171 +67,177 @@ export default async function FundingProgramDetailPage({ params }: PageProps) {
 
   const data = loadProgramPageData(record);
 
+  const titlePills = (
+    <>
+      {data.program.status && (
+        <span
+          className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+            STATUS_COLORS[data.program.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          }`}
+        >
+          {titleCase(data.program.status)}
+        </span>
+      )}
+      <span
+        className={`inline-block px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
+          PROGRAM_TYPE_COLORS[data.program.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+        }`}
+      >
+        {PROGRAM_TYPE_LABELS[data.program.programType] ?? titleCase(data.program.programType)}
+      </span>
+    </>
+  );
+
+  const stats: Array<{ label: string; value: string }> = [];
+  if (data.program.totalBudget != null) {
+    stats.push({
+      label: "Budget",
+      value: formatCompactCurrency(data.program.totalBudget, data.program.currency),
+    });
+  }
+  if (data.program.openDate) {
+    stats.push({ label: "Opens", value: formatKBDate(data.program.openDate) });
+  }
+  if (data.program.deadline) {
+    stats.push({ label: "Deadline", value: formatKBDate(data.program.deadline) });
+  }
+
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
+    </div>
+  );
+
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <Breadcrumbs
-        items={[
-          { label: "Organizations", href: "/organizations" },
-          ...(data.funder.href
-            ? [{ label: data.funder.name, href: data.funder.href }]
-            : []),
-          { label: data.program.name },
-        ]}
-      />
-
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-3 mb-3">
-          <h1 className="text-2xl font-extrabold tracking-tight flex-1">
-            {data.program.name}
-          </h1>
-          {data.program.status && (
-            <span
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${
-                STATUS_COLORS[data.program.status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              }`}
-            >
-              {titleCase(data.program.status)}
-            </span>
-          )}
-        </div>
-
-        <div className="flex items-center gap-3 flex-wrap">
-          <span
-            className={`inline-block px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${
-              PROGRAM_TYPE_COLORS[data.program.programType] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-            }`}
-          >
-            {PROGRAM_TYPE_LABELS[data.program.programType] ?? titleCase(data.program.programType)}
-          </span>
-        </div>
-
-        {/* Budget hero */}
-        {data.program.totalBudget != null && (
-          <div className="text-3xl font-bold tabular-nums tracking-tight text-primary mt-3 mb-1">
-            {formatCompactCurrency(data.program.totalBudget, data.program.currency)}
-            <span className="text-sm font-normal text-muted-foreground ml-2">budget</span>
-          </div>
-        )}
-      </div>
-
-      {/* Details grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        {/* Left column: key details */}
-        <div className="space-y-4">
-          <DetailSection title="Funder Organization">
-            <EntityLinkDisplay
-              name={data.funder.name}
-              href={data.funder.href}
-            />
-            {data.funderWikiPageId && (
-              <Link
-                href={`/wiki/${data.funderWikiPageId}`}
-                className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
-                title="Wiki page"
-              >
-                wiki
-              </Link>
-            )}
-          </DetailSection>
-
-          {data.divisionName && (
-            <DetailSection title="Division">
-              {data.divisionHref ? (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Organizations", href: "/organizations" },
+        ...(data.funder.href
+          ? [{ label: data.funder.name, href: data.funder.href }]
+          : []),
+        { label: data.program.name },
+      ]}
+      title={data.program.name}
+      titlePills={titlePills}
+      statCards={statCards}
+    >
+      <div className="space-y-8">
+        {/* Details grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Left column: key details */}
+          <div className="space-y-4">
+            <DetailSection title="Funder Organization">
+              <EntityLinkDisplay
+                name={data.funder.name}
+                href={data.funder.href}
+              />
+              {data.funderWikiPageId && (
                 <Link
-                  href={data.divisionHref}
-                  className="text-sm font-medium text-primary hover:underline"
+                  href={`/wiki/${data.funderWikiPageId}`}
+                  className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                  title="Wiki page"
                 >
-                  {data.divisionName}
+                  wiki
                 </Link>
-              ) : (
-                <span className="text-sm text-foreground">{data.divisionName}</span>
               )}
             </DetailSection>
-          )}
 
-          {(data.program.openDate || data.program.deadline) && (
-            <DetailSection title="Timeline">
-              <span className="text-sm text-foreground">
-                {data.program.openDate && (
-                  <>
-                    <span className="text-muted-foreground text-xs">Opens:</span>{" "}
-                    {formatKBDate(data.program.openDate)}
-                  </>
+            {data.divisionName && (
+              <DetailSection title="Division">
+                {data.divisionHref ? (
+                  <Link
+                    href={data.divisionHref}
+                    className="text-sm font-medium text-primary hover:underline"
+                  >
+                    {data.divisionName}
+                  </Link>
+                ) : (
+                  <span className="text-sm text-foreground">{data.divisionName}</span>
                 )}
-                {data.program.openDate && data.program.deadline && " — "}
-                {data.program.deadline && (
-                  <>
-                    <span className="text-muted-foreground text-xs">Deadline:</span>{" "}
-                    {formatKBDate(data.program.deadline)}
-                  </>
-                )}
-              </span>
-            </DetailSection>
-          )}
-        </div>
+              </DetailSection>
+            )}
 
-        {/* Right column: supplementary info */}
-        <div className="space-y-4">
-          {data.program.applicationUrl && (
-            <DetailSection title="Application">
-              <a
-                href={safeHref(data.program.applicationUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-primary hover:underline break-all"
-              >
-                {shortDomain(data.program.applicationUrl)}
-                <span className="text-muted-foreground ml-1">{"\u2197"}</span>
-              </a>
-            </DetailSection>
-          )}
+            {(data.program.openDate || data.program.deadline) && (
+              <DetailSection title="Timeline">
+                <span className="text-sm text-foreground">
+                  {data.program.openDate && (
+                    <>
+                      <span className="text-muted-foreground text-xs">Opens:</span>{" "}
+                      {formatKBDate(data.program.openDate)}
+                    </>
+                  )}
+                  {data.program.openDate && data.program.deadline && " — "}
+                  {data.program.deadline && (
+                    <>
+                      <span className="text-muted-foreground text-xs">Deadline:</span>{" "}
+                      {formatKBDate(data.program.deadline)}
+                    </>
+                  )}
+                </span>
+              </DetailSection>
+            )}
+          </div>
 
-          {data.program.source && (
-            <DetailSection title="Source">
-              {isUrl(data.program.source) ? (
+          {/* Right column: supplementary info */}
+          <div className="space-y-4">
+            {data.program.applicationUrl && (
+              <DetailSection title="Application">
                 <a
-                  href={safeHref(data.program.source)}
+                  href={safeHref(data.program.applicationUrl)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-primary hover:underline break-all"
                 >
-                  {shortDomain(data.program.source)}
-                  <span className="text-muted-foreground ml-1">{"\u2197"}</span>
+                  {shortDomain(data.program.applicationUrl)}
+                  <span className="text-muted-foreground ml-1">{"↗"}</span>
                 </a>
-              ) : (
-                <span className="text-sm text-foreground">{data.program.source}</span>
-              )}
-            </DetailSection>
-          )}
+              </DetailSection>
+            )}
 
-          {data.program.description && (
-            <DetailSection title="Description">
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {data.program.description}
-              </p>
-            </DetailSection>
-          )}
+            {data.program.source && (
+              <DetailSection title="Source">
+                {isUrl(data.program.source) ? (
+                  <a
+                    href={safeHref(data.program.source)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline break-all"
+                  >
+                    {shortDomain(data.program.source)}
+                    <span className="text-muted-foreground ml-1">{"↗"}</span>
+                  </a>
+                ) : (
+                  <span className="text-sm text-foreground">{data.program.source}</span>
+                )}
+              </DetailSection>
+            )}
 
-          {data.program.notes && (
-            <DetailSection title="Notes">
-              <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
-                {data.program.notes.replace(/\\n/g, "\n")}
-              </p>
-            </DetailSection>
-          )}
+            {data.program.description && (
+              <DetailSection title="Description">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {data.program.description}
+                </p>
+              </DetailSection>
+            )}
+
+            {data.program.notes && (
+              <DetailSection title="Notes">
+                <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                  {data.program.notes.replace(/\\n/g, "\n")}
+                </p>
+              </DetailSection>
+            )}
+          </div>
         </div>
+
+        {/* Grants awarded through this program */}
+        <GrantsAwardedSection
+          grants={data.programGrants}
+          totalGranted={data.totalGranted}
+        />
       </div>
-
-      {/* Grants awarded through this program */}
-      <GrantsAwardedSection
-        grants={data.programGrants}
-        totalGranted={data.totalGranted}
-      />
-
-      {/* Back to funder */}
-      <BackToFunderLink funder={data.funder} />
-    </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/funding-rounds/[id]/page.tsx
+++ b/apps/web/src/app/funding-rounds/[id]/page.tsx
@@ -9,9 +9,8 @@ import { formatStake } from "@/app/organizations/[slug]/org-data";
 import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
-import { Breadcrumbs } from "@/components/directory";
-import { SourcingDot } from "@/components/sourcing/SourcingDot";
-import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -168,273 +167,244 @@ export default async function FundingRoundDetailPage({ params }: PageProps) {
       return (b.raised ?? 0) - (a.raised ?? 0);
     });
 
-  return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <Breadcrumbs
-        items={[
-          { label: "Organizations", href: "/organizations" },
-          ...(round.companyHref
-            ? [{ label: round.companyName, href: round.companyHref }]
-            : []),
-          { label: round.name },
-        ]}
-      />
+  const titlePills = round.instrument ? (
+    <span
+      className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+        INSTRUMENT_COLORS[round.instrument] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+      }`}
+    >
+      {titleCase(round.instrument)}
+    </span>
+  ) : null;
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-3 mb-3">
-          <h1 className="text-2xl font-extrabold tracking-tight flex-1">
-            {round.name}
-          </h1>
-          {round.instrument && (
-            <span
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold shrink-0 ${
-                INSTRUMENT_COLORS[round.instrument] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-              }`}
-            >
-              {titleCase(round.instrument)}
-            </span>
-          )}
-          <SourcingDot
-            status={recordVerdictToStatus(roundVerdict?.verdict)}
-            originalVerdict={roundVerdict?.verdict}
-            size="md"
-            href={roundVerdict?.verdict ? `/sourcing/funding-round/${encodeURIComponent(String(round.key))}` : undefined}
-          />
-        </div>
+  const stats: Array<{ label: string; value: string }> = [];
+  if (round.raised != null) {
+    stats.push({ label: "Raised", value: formatCompactCurrency(round.raised) });
+  }
+  if (round.valuation != null) {
+    stats.push({ label: "Post-money valuation", value: formatCompactCurrency(round.valuation) });
+  }
+  if (round.date) {
+    stats.push({ label: "Date", value: formatKBDate(round.date) });
+  }
 
-        {/* Amount hero */}
-        {round.raised != null && (
-          <div className="text-3xl font-bold tabular-nums tracking-tight text-primary mb-1">
-            {formatCompactCurrency(round.raised)}
-            <span className="text-sm font-normal text-muted-foreground ml-2">raised</span>
-          </div>
-        )}
-        {round.valuation != null && (
-          <div className="text-lg tabular-nums tracking-tight text-muted-foreground">
-            {formatCompactCurrency(round.valuation)}
-            <span className="text-sm font-normal ml-2">post-money valuation</span>
-          </div>
-        )}
-      </div>
-
-      {/* Details grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        {/* Left column: key details */}
-        <div className="space-y-4">
-          <DetailSection title="Company">
-            <EntityLinkDisplay
-              name={round.companyName}
-              href={round.companyHref}
-            />
-            {companyWikiPageId && (
-              <Link
-                href={`/wiki/${companyWikiPageId}`}
-                className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
-                title="Wiki page"
-              >
-                wiki
-              </Link>
-            )}
-          </DetailSection>
-
-          {round.leadInvestor && (
-            <DetailSection title="Lead Investor">
-              <EntityLinkDisplay
-                name={round.leadInvestorName}
-                href={round.leadInvestorHref}
-              />
-            </DetailSection>
-          )}
-
-          {round.date && (
-            <DetailSection title="Date">
-              <span className="text-sm text-foreground">
-                {formatKBDate(round.date)}
-              </span>
-            </DetailSection>
-          )}
-        </div>
-
-        {/* Right column: supplementary info */}
-        <div className="space-y-4">
-          {round.source && (
-            <DetailSection title="Source">
-              {isUrl(round.source) ? (
-                <a
-                  href={safeHref(round.source)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline break-all"
-                >
-                  {shortDomain(round.source)}
-                  <span className="text-muted-foreground ml-1">{"\u2197"}</span>
-                </a>
-              ) : (
-                <span className="text-sm text-foreground">{round.source}</span>
-              )}
-            </DetailSection>
-          )}
-
-          {round.notes && (
-            <DetailSection title="Notes">
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {round.notes}
-              </p>
-            </DetailSection>
-          )}
-        </div>
-      </div>
-
-      {/* Investments in this round */}
-      {roundInvestments.length > 0 && (
-        <section className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-base font-bold tracking-tight">Investors in This Round</h2>
-            <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              {roundInvestments.length}
-            </span>
-            <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
-          </div>
-          <div className="border border-border/60 rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="text-left py-2 px-3 font-medium">Investor</th>
-                  <th className="text-left py-2 px-3 font-medium">Role</th>
-                  <th className="text-right py-2 px-3 font-medium">Amount</th>
-                  <th className="text-right py-2 px-3 font-medium">Stake</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {roundInvestments.map((inv) => (
-                  <tr key={inv.key} className="hover:bg-muted/20 transition-colors">
-                    <td className="py-2 px-3">
-                      <span className="font-medium text-xs">
-                        {inv.investorHref ? (
-                          <Link href={inv.investorHref} className="text-primary hover:underline">
-                            {inv.investorName}
-                          </Link>
-                        ) : (
-                          <span className="text-foreground">{inv.investorName}</span>
-                        )}
-                      </span>
-                    </td>
-                    <td className="py-2 px-3 text-xs text-muted-foreground">
-                      {inv.role ? titleCase(inv.role) : ""}
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                      {inv.amount != null && (
-                        <span className="font-semibold">{formatCompactCurrency(inv.amount)}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs text-muted-foreground">
-                      {inv.stakeAcquired != null && (
-                        <span>{formatStake(inv.stakeAcquired)}</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Other rounds by same company */}
-      {otherRounds.length > 0 && (
-        <section className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h2 className="text-base font-bold tracking-tight">
-              Other Rounds by {round.companyName}
-            </h2>
-            <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-              {otherRounds.length}
-            </span>
-            <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
-          </div>
-          <div className="border border-border/60 rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="text-left py-2 px-3 font-medium">Round</th>
-                  <th className="text-right py-2 px-3 font-medium">Raised</th>
-                  <th className="text-right py-2 px-3 font-medium">Valuation</th>
-                  <th className="text-left py-2 px-3 font-medium">Lead Investor</th>
-                  <th className="text-center py-2 px-3 font-medium">Date</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {otherRounds.slice(0, 10).map((r) => (
-                  <tr key={r.key} className="hover:bg-muted/20 transition-colors">
-                    <td className="py-2 px-3">
-                      <Link
-                        href={`/funding-rounds/${r.key}`}
-                        className="font-medium text-foreground text-xs hover:text-primary transition-colors"
-                      >
-                        {r.name}
-                      </Link>
-                      {r.instrument && (
-                        <span className="ml-1.5 text-[10px] text-muted-foreground/60">
-                          ({r.instrument})
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                      {r.raised != null && (
-                        <span className="font-semibold">{formatCompactCurrency(r.raised)}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
-                      {r.valuation != null && (
-                        <span className="text-muted-foreground">{formatCompactCurrency(r.valuation)}</span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-xs">
-                      {r.leadInvestorHref ? (
-                        <Link href={r.leadInvestorHref} className="text-primary hover:underline">
-                          {r.leadInvestorName}
-                        </Link>
-                      ) : r.leadInvestorName ? (
-                        <span className="text-muted-foreground">{r.leadInvestorName}</span>
-                      ) : null}
-                    </td>
-                    <td className="py-2 px-3 text-center text-muted-foreground text-xs">
-                      {r.date ? formatKBDate(r.date) : ""}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {otherRounds.length > 10 && (
-            <div className="mt-2 text-xs text-muted-foreground text-center">
-              Showing 10 of {otherRounds.length} rounds
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Back to company */}
-      <div className="mt-8 pt-6 border-t border-border/60">
-        {round.companyHref ? (
-          <Link
-            href={round.companyHref}
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to {round.companyName}
-          </Link>
-        ) : (
-          <Link
-            href="/organizations"
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to organizations
-          </Link>
-        )}
-      </div>
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
     </div>
   );
-}
 
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Organizations", href: "/organizations" },
+        ...(round.companyHref
+          ? [{ label: round.companyName, href: round.companyHref }]
+          : []),
+        { label: round.name },
+      ]}
+      title={round.name}
+      titlePills={titlePills}
+      verdict={roundVerdict?.verdict ?? null}
+      verdictHref={
+        roundVerdict?.verdict
+          ? `/sourcing/funding-round/${encodeURIComponent(String(round.key))}`
+          : undefined
+      }
+      statCards={statCards}
+    >
+      <div className="space-y-8">
+        {/* Details grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Left column: key details */}
+          <div className="space-y-4">
+            <DetailSection title="Company">
+              <EntityLinkDisplay
+                name={round.companyName}
+                href={round.companyHref}
+              />
+              {companyWikiPageId && (
+                <Link
+                  href={`/wiki/${companyWikiPageId}`}
+                  className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                  title="Wiki page"
+                >
+                  wiki
+                </Link>
+              )}
+            </DetailSection>
+
+            {round.leadInvestor && (
+              <DetailSection title="Lead Investor">
+                <EntityLinkDisplay
+                  name={round.leadInvestorName}
+                  href={round.leadInvestorHref}
+                />
+              </DetailSection>
+            )}
+          </div>
+
+          {/* Right column: supplementary info */}
+          <div className="space-y-4">
+            {round.source && (
+              <DetailSection title="Source">
+                {isUrl(round.source) ? (
+                  <a
+                    href={safeHref(round.source)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline break-all"
+                  >
+                    {shortDomain(round.source)}
+                    <span className="text-muted-foreground ml-1">{"↗"}</span>
+                  </a>
+                ) : (
+                  <span className="text-sm text-foreground">{round.source}</span>
+                )}
+              </DetailSection>
+            )}
+
+            {round.notes && (
+              <DetailSection title="Notes">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {round.notes}
+                </p>
+              </DetailSection>
+            )}
+          </div>
+        </div>
+
+        {/* Investments in this round */}
+        {roundInvestments.length > 0 && (
+          <section>
+            <div className="flex items-center gap-3 mb-4">
+              <h2 className="text-base font-bold tracking-tight">Investors in This Round</h2>
+              <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                {roundInvestments.length}
+              </span>
+              <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+            </div>
+            <div className="border border-border/60 rounded-xl overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="text-left py-2 px-3 font-medium">Investor</th>
+                    <th className="text-left py-2 px-3 font-medium">Role</th>
+                    <th className="text-right py-2 px-3 font-medium">Amount</th>
+                    <th className="text-right py-2 px-3 font-medium">Stake</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {roundInvestments.map((inv) => (
+                    <tr key={inv.key} className="hover:bg-muted/20 transition-colors">
+                      <td className="py-2 px-3">
+                        <span className="font-medium text-xs">
+                          {inv.investorHref ? (
+                            <Link href={inv.investorHref} className="text-primary hover:underline">
+                              {inv.investorName}
+                            </Link>
+                          ) : (
+                            <span className="text-foreground">{inv.investorName}</span>
+                          )}
+                        </span>
+                      </td>
+                      <td className="py-2 px-3 text-xs text-muted-foreground">
+                        {inv.role ? titleCase(inv.role) : ""}
+                      </td>
+                      <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                        {inv.amount != null && (
+                          <span className="font-semibold">{formatCompactCurrency(inv.amount)}</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs text-muted-foreground">
+                        {inv.stakeAcquired != null && (
+                          <span>{formatStake(inv.stakeAcquired)}</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Other rounds by same company */}
+        {otherRounds.length > 0 && (
+          <section>
+            <div className="flex items-center gap-3 mb-4">
+              <h2 className="text-base font-bold tracking-tight">
+                Other Rounds by {round.companyName}
+              </h2>
+              <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                {otherRounds.length}
+              </span>
+              <div className="flex-1 h-px bg-gradient-to-r from-border/60 to-transparent" />
+            </div>
+            <div className="border border-border/60 rounded-xl overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="text-left py-2 px-3 font-medium">Round</th>
+                    <th className="text-right py-2 px-3 font-medium">Raised</th>
+                    <th className="text-right py-2 px-3 font-medium">Valuation</th>
+                    <th className="text-left py-2 px-3 font-medium">Lead Investor</th>
+                    <th className="text-center py-2 px-3 font-medium">Date</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {otherRounds.slice(0, 10).map((r) => (
+                    <tr key={r.key} className="hover:bg-muted/20 transition-colors">
+                      <td className="py-2 px-3">
+                        <Link
+                          href={`/funding-rounds/${r.key}`}
+                          className="font-medium text-foreground text-xs hover:text-primary transition-colors"
+                        >
+                          {r.name}
+                        </Link>
+                        {r.instrument && (
+                          <span className="ml-1.5 text-[10px] text-muted-foreground/60">
+                            ({r.instrument})
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                        {r.raised != null && (
+                          <span className="font-semibold">{formatCompactCurrency(r.raised)}</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-right tabular-nums whitespace-nowrap text-xs">
+                        {r.valuation != null && (
+                          <span className="text-muted-foreground">{formatCompactCurrency(r.valuation)}</span>
+                        )}
+                      </td>
+                      <td className="py-2 px-3 text-xs">
+                        {r.leadInvestorHref ? (
+                          <Link href={r.leadInvestorHref} className="text-primary hover:underline">
+                            {r.leadInvestorName}
+                          </Link>
+                        ) : r.leadInvestorName ? (
+                          <span className="text-muted-foreground">{r.leadInvestorName}</span>
+                        ) : null}
+                      </td>
+                      <td className="py-2 px-3 text-center text-muted-foreground text-xs">
+                        {r.date ? formatKBDate(r.date) : ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {otherRounds.length > 10 && (
+              <div className="mt-2 text-xs text-muted-foreground text-center">
+                Showing 10 of {otherRounds.length} rounds
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </EntityProfileShell>
+  );
+}

--- a/apps/web/src/app/investments/[id]/page.tsx
+++ b/apps/web/src/app/investments/[id]/page.tsx
@@ -9,9 +9,8 @@ import { formatStake } from "@/app/organizations/[slug]/org-data";
 import type { KBRecordEntry } from "@/data/factbase";
 import { getTypedEntityById, getRecordVerdict } from "@/data/tablebase";
 import { formatCompactCurrency } from "@/lib/format-compact";
-import { Breadcrumbs } from "@/components/directory";
-import { SourcingDot } from "@/components/sourcing/SourcingDot";
-import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import { safeHref } from "@/lib/directory-utils";
 import {
   resolveEntityLink,
@@ -163,189 +162,164 @@ export default async function InvestmentDetailPage({ params }: PageProps) {
     ? `${investment.investorName} → ${companyDisplayName}`
     : `Investment in ${companyDisplayName}`;
 
-  return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <Breadcrumbs
-        items={[
-          { label: "Organizations", href: "/organizations" },
-          ...(investment.companyHref
-            ? [{ label: companyDisplayName, href: investment.companyHref }]
-            : []),
-          { label: investment.investorName ? `Investment by ${investment.investorName}` : "Investment" },
-        ]}
-      />
-
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-3 mb-3">
-          <h1 className="text-2xl font-extrabold tracking-tight flex-1">
-            {displayTitle}
-          </h1>
-          <div className="flex gap-2 shrink-0">
-            {investment.role && (
-              <span
-                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
-                  ROLE_COLORS[investment.role] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                }`}
-              >
-                {titleCase(investment.role)}
-              </span>
-            )}
-            {investment.instrument && (
-              <span
-                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
-                  INSTRUMENT_COLORS[investment.instrument] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                }`}
-              >
-                {titleCase(investment.instrument)}
-              </span>
-            )}
-            <SourcingDot
-              status={recordVerdictToStatus(investmentVerdict?.verdict)}
-              originalVerdict={investmentVerdict?.verdict}
-              size="md"
-              href={investmentVerdict?.verdict ? `/sourcing/investment/${encodeURIComponent(String(investment.key))}` : undefined}
-            />
-          </div>
-        </div>
-
-        {/* Amount hero */}
-        {investment.amount != null && (
-          <div className="text-3xl font-bold tabular-nums tracking-tight text-primary mb-1">
-            {formatCompactCurrency(investment.amount)}
-          </div>
-        )}
-        {investment.stakeAcquired != null && (
-          <div className="text-lg tabular-nums tracking-tight text-muted-foreground">
-            {formatStake(investment.stakeAcquired)}
-            <span className="text-sm font-normal ml-2">stake acquired</span>
-          </div>
-        )}
-      </div>
-
-      {/* Details grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        {/* Left column: key details */}
-        <div className="space-y-4">
-          <DetailSection title="Company">
-            <EntityLinkDisplay
-              name={companyDisplayName}
-              href={investment.companyHref}
-            />
-            {companyWikiPageId && (
-              <Link
-                href={`/wiki/${companyWikiPageId}`}
-                className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
-                title="Wiki page"
-              >
-                wiki
-              </Link>
-            )}
-          </DetailSection>
-
-          {(investment.investorId || investment.investorName) && (
-            <DetailSection title="Investor">
-              <EntityLinkDisplay
-                name={investment.investorName}
-                href={investment.investorHref}
-              />
-            </DetailSection>
-          )}
-
-          {investment.roundName && (
-            <DetailSection title="Funding Round">
-              {fundingRoundHref ? (
-                <Link
-                  href={fundingRoundHref}
-                  className="text-sm font-medium text-primary hover:underline"
-                >
-                  {investment.roundName}
-                </Link>
-              ) : (
-                <span className="text-sm text-foreground">{investment.roundName}</span>
-              )}
-            </DetailSection>
-          )}
-
-          {investment.date && (
-            <DetailSection title="Date">
-              <span className="text-sm text-foreground">
-                {formatKBDate(investment.date)}
-              </span>
-            </DetailSection>
-          )}
-        </div>
-
-        {/* Right column: supplementary info */}
-        <div className="space-y-4">
-          {investment.source && (
-            <DetailSection title="Source">
-              {isUrl(investment.source) ? (
-                <a
-                  href={safeHref(investment.source)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline break-all"
-                >
-                  {shortDomain(investment.source)}
-                  <span className="text-muted-foreground ml-1">{"\u2197"}</span>
-                </a>
-              ) : (
-                <span className="text-sm text-foreground">{investment.source}</span>
-              )}
-            </DetailSection>
-          )}
-
-          {investment.notes && (
-            <DetailSection title="Notes">
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {investment.notes}
-              </p>
-            </DetailSection>
-          )}
-        </div>
-      </div>
-
-      {/* Other investments in same company */}
-      {otherInSameCompany.length > 0 && (
-        <RelatedInvestmentsSection
-          title={`Other Investments in ${companyDisplayName}`}
-          investments={otherInSameCompany.slice(0, 10)}
-          totalCount={otherInSameCompany.length}
-          showInvestor
-        />
+  const titlePills = (
+    <>
+      {investment.role && (
+        <span
+          className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+            ROLE_COLORS[investment.role] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          }`}
+        >
+          {titleCase(investment.role)}
+        </span>
       )}
-
-      {/* Other investments by same investor */}
-      {otherBySameInvestor.length > 0 && (
-        <RelatedInvestmentsSection
-          title={`Other Investments by ${investment.investorName}`}
-          investments={otherBySameInvestor.slice(0, 10)}
-          totalCount={otherBySameInvestor.length}
-          showCompany
-        />
+      {investment.instrument && (
+        <span
+          className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+            INSTRUMENT_COLORS[investment.instrument] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          }`}
+        >
+          {titleCase(investment.instrument)}
+        </span>
       )}
+    </>
+  );
 
-      {/* Back to company */}
-      <div className="mt-8 pt-6 border-t border-border/60">
-        {investment.companyHref ? (
-          <Link
-            href={investment.companyHref}
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to {companyDisplayName}
-          </Link>
-        ) : (
-          <Link
-            href="/organizations"
-            className="text-sm text-primary hover:underline"
-          >
-            &larr; Back to organizations
-          </Link>
-        )}
-      </div>
+  const stats: Array<{ label: string; value: string }> = [];
+  if (investment.amount != null) {
+    stats.push({ label: "Amount", value: formatCompactCurrency(investment.amount) });
+  }
+  if (investment.stakeAcquired != null) {
+    stats.push({ label: "Stake acquired", value: formatStake(investment.stakeAcquired) });
+  }
+  if (investment.date) {
+    stats.push({ label: "Date", value: formatKBDate(investment.date) });
+  }
+
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {stats.map((s) => (
+        <ProfileStatCard key={s.label} {...s} />
+      ))}
     </div>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Organizations", href: "/organizations" },
+        ...(investment.companyHref
+          ? [{ label: companyDisplayName, href: investment.companyHref }]
+          : []),
+        { label: investment.investorName ? `Investment by ${investment.investorName}` : "Investment" },
+      ]}
+      title={displayTitle}
+      titlePills={titlePills}
+      verdict={investmentVerdict?.verdict ?? null}
+      verdictHref={
+        investmentVerdict?.verdict
+          ? `/sourcing/investment/${encodeURIComponent(String(investment.key))}`
+          : undefined
+      }
+      statCards={statCards}
+    >
+      <div className="space-y-8">
+        {/* Details grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Left column: key details */}
+          <div className="space-y-4">
+            <DetailSection title="Company">
+              <EntityLinkDisplay
+                name={companyDisplayName}
+                href={investment.companyHref}
+              />
+              {companyWikiPageId && (
+                <Link
+                  href={`/wiki/${companyWikiPageId}`}
+                  className="ml-2 text-[10px] text-muted-foreground/50 hover:text-primary transition-colors"
+                  title="Wiki page"
+                >
+                  wiki
+                </Link>
+              )}
+            </DetailSection>
+
+            {(investment.investorId || investment.investorName) && (
+              <DetailSection title="Investor">
+                <EntityLinkDisplay
+                  name={investment.investorName}
+                  href={investment.investorHref}
+                />
+              </DetailSection>
+            )}
+
+            {investment.roundName && (
+              <DetailSection title="Funding Round">
+                {fundingRoundHref ? (
+                  <Link
+                    href={fundingRoundHref}
+                    className="text-sm font-medium text-primary hover:underline"
+                  >
+                    {investment.roundName}
+                  </Link>
+                ) : (
+                  <span className="text-sm text-foreground">{investment.roundName}</span>
+                )}
+              </DetailSection>
+            )}
+          </div>
+
+          {/* Right column: supplementary info */}
+          <div className="space-y-4">
+            {investment.source && (
+              <DetailSection title="Source">
+                {isUrl(investment.source) ? (
+                  <a
+                    href={safeHref(investment.source)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-primary hover:underline break-all"
+                  >
+                    {shortDomain(investment.source)}
+                    <span className="text-muted-foreground ml-1">{"↗"}</span>
+                  </a>
+                ) : (
+                  <span className="text-sm text-foreground">{investment.source}</span>
+                )}
+              </DetailSection>
+            )}
+
+            {investment.notes && (
+              <DetailSection title="Notes">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {investment.notes}
+                </p>
+              </DetailSection>
+            )}
+          </div>
+        </div>
+
+        {/* Other investments in same company */}
+        {otherInSameCompany.length > 0 && (
+          <RelatedInvestmentsSection
+            title={`Other Investments in ${companyDisplayName}`}
+            investments={otherInSameCompany.slice(0, 10)}
+            totalCount={otherInSameCompany.length}
+            showInvestor
+          />
+        )}
+
+        {/* Other investments by same investor */}
+        {otherBySameInvestor.length > 0 && (
+          <RelatedInvestmentsSection
+            title={`Other Investments by ${investment.investorName}`}
+            investments={otherBySameInvestor.slice(0, 10)}
+            totalCount={otherBySameInvestor.length}
+            showCompany
+          />
+        )}
+      </div>
+    </EntityProfileShell>
   );
 }
 
@@ -365,7 +339,7 @@ function RelatedInvestmentsSection({
   showCompany?: boolean;
 }) {
   return (
-    <section className="mb-8">
+    <section>
       <div className="flex items-center gap-3 mb-4">
         <h2 className="text-base font-bold tracking-tight">{title}</h2>
         <span className="text-[11px] font-medium tabular-nums px-2 py-0.5 rounded-full bg-muted text-muted-foreground">

--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import {
-  getAllPublications,
   getPublicationById,
   getResourcesForPublication,
   getPagesForResource,
@@ -11,8 +10,8 @@ import {
 } from "@/data";
 import { getRecordVerdict } from "@/data/tablebase";
 import { CredibilityBadge } from "@/components/wiki/CredibilityBadge";
-import { SourcingDot } from "@/components/sourcing/SourcingDot";
-import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   PublicationResourcesTable,
   type PublicationResourceRow,
@@ -20,12 +19,10 @@ import {
 import { formatType } from "@/app/publications/publication-utils";
 import Link from "next/link";
 import {
-  ExternalLink,
   Globe,
   FileText,
   BookOpen,
   CheckCircle2,
-  ArrowLeft,
 } from "lucide-react";
 
 // Cache for 1 hour — on-demand rendered to reduce build size.
@@ -101,171 +98,138 @@ export default async function PublicationDetailPage({ params }: PageProps) {
   const showPublishedDate =
     resourceRows.length === 0 || datesPopulated / resourceRows.length >= 0.1;
 
-  return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Back link */}
-      <Link
-        href="/publications"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
-      >
-        <ArrowLeft className="w-3.5 h-3.5" />
-        All Publications
-      </Link>
-
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-3 mb-2">
-          <h1 className="text-2xl font-bold flex-1">{pub.name}</h1>
-          <SourcingDot
-            status={recordVerdictToStatus(pubVerdict?.verdict)}
-            originalVerdict={pubVerdict?.verdict}
-            size="md"
-            href={pubVerdict?.verdict ? `/sourcing/publication/${encodeURIComponent(pub.id)}` : undefined}
-          />
-        </div>
-
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm text-muted-foreground">
-          <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-muted">
-            {formatType(pub.type)}
-          </span>
-          {pub.peer_reviewed && (
-            <span className="inline-flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
-              <CheckCircle2 className="w-3.5 h-3.5" />
-              Peer-reviewed
-            </span>
-          )}
-          <CredibilityBadge level={pub.credibility} size="md" showLabel />
-          {pub.website && (
-            <a
-              href={pub.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
-            >
-              <ExternalLink className="w-3 h-3" />
-              Website
-            </a>
-          )}
-        </div>
-
-        {pub.description && (
-          <p className="text-sm text-muted-foreground mt-3">
-            {pub.description}
-          </p>
-        )}
-      </div>
-
-      {/* Credibility Rationale */}
-      <section className="mb-8 p-4 rounded-lg border border-border bg-card">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-          Credibility Rating
-        </h2>
-        <div className="flex items-start gap-4">
-          <div className="shrink-0 text-center">
-            <div className="text-3xl font-bold tabular-nums">
-              {pub.credibility}/5
-            </div>
-            <CredibilityBadge
-              level={pub.credibility}
-              size="md"
-              showLabel
-              className="mt-1"
-            />
-          </div>
-          <div className="text-sm text-muted-foreground leading-relaxed">
-            {pub.credibility_rationale ||
-              CREDIBILITY_DESCRIPTIONS[pub.credibility]}
-          </div>
-        </div>
-      </section>
-
-      {/* Stats */}
-      <div className="grid grid-cols-3 gap-3 mb-8">
-        <div className="rounded-lg border border-border p-3 text-center">
-          <div className="text-2xl font-bold tabular-nums">
-            {resources.length}
-          </div>
-          <div className="text-[11px] text-muted-foreground mt-0.5">
-            Resources
-          </div>
-        </div>
-        <div className="rounded-lg border border-border p-3 text-center">
-          <div className="text-2xl font-bold tabular-nums">{pageSet.size}</div>
-          <div className="text-[11px] text-muted-foreground mt-0.5">
-            Citing pages
-          </div>
-        </div>
-        <div className="rounded-lg border border-border p-3 text-center">
-          <div className="text-2xl font-bold tabular-nums">
-            {pub.domains.length}
-          </div>
-          <div className="text-[11px] text-muted-foreground mt-0.5">
-            Tracked domains
-          </div>
-        </div>
-      </div>
-
-      {/* Tracked Domains */}
-      {pub.domains.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-            <Globe className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Tracked Domains
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {pub.domains.map((domain) => (
-              <span
-                key={domain}
-                className="text-xs px-2.5 py-1 rounded-full border border-border font-mono"
-              >
-                {domain}
-              </span>
-            ))}
-          </div>
-        </section>
+  const titlePills = (
+    <>
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-muted">
+        {formatType(pub.type)}
+      </span>
+      {pub.peer_reviewed && (
+        <span className="inline-flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
+          <CheckCircle2 className="w-3.5 h-3.5" />
+          Peer-reviewed
+        </span>
       )}
+      <CredibilityBadge level={pub.credibility} size="md" showLabel />
+    </>
+  );
 
-      {/* Resources Table */}
-      {resources.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
-            <FileText className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Resources ({resources.length})
-          </h2>
-          <PublicationResourcesTable resources={resourceRows} showPublishedDate={showPublishedDate} />
-        </section>
-      )}
+  const headerLinks = pub.website
+    ? [{ label: "Website", href: pub.website, external: true }]
+    : [];
 
-      {/* Citing pages */}
-      {pageSet.size > 0 && (
-        <section className="mb-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-            <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-            Citing Pages ({pageSet.size})
-          </h2>
-          <div className="flex flex-wrap gap-1.5">
-            {[...pageSet].sort().map((pageId) => {
-              const href = getEntityHref(pageId);
-              const title = getPageTitle(pageId);
-              return (
-                <Link
-                  key={pageId}
-                  href={href}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 bg-muted rounded text-sm text-accent-foreground no-underline transition-colors hover:bg-muted/80"
-                >
-                  {title}
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      {/* Footer */}
-      <div className="text-xs text-muted-foreground border-t border-border pt-4 mt-8">
-        Publication ID:{" "}
-        <code className="px-1 py-0.5 bg-muted rounded">{pub.id}</code>
-      </div>
+  const statCards = (
+    <div className="grid grid-cols-3 gap-3">
+      <ProfileStatCard label="Resources" value={String(resources.length)} />
+      <ProfileStatCard label="Citing pages" value={String(pageSet.size)} />
+      <ProfileStatCard label="Tracked domains" value={String(pub.domains.length)} />
     </div>
+  );
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Publications", href: "/publications" },
+        { label: pub.name },
+      ]}
+      title={pub.name}
+      titlePills={titlePills}
+      verdict={pubVerdict?.verdict ?? null}
+      verdictHref={
+        pubVerdict?.verdict
+          ? `/sourcing/publication/${encodeURIComponent(pub.id)}`
+          : undefined
+      }
+      subtitle={pub.description || undefined}
+      headerLinks={headerLinks}
+      statCards={statCards}
+    >
+      <div className="space-y-8">
+        {/* Credibility Rationale */}
+        <section className="p-4 rounded-lg border border-border bg-card">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+            Credibility Rating
+          </h2>
+          <div className="flex items-start gap-4">
+            <div className="shrink-0 text-center">
+              <div className="text-3xl font-bold tabular-nums">
+                {pub.credibility}/5
+              </div>
+              <CredibilityBadge
+                level={pub.credibility}
+                size="md"
+                showLabel
+                className="mt-1"
+              />
+            </div>
+            <div className="text-sm text-muted-foreground leading-relaxed">
+              {pub.credibility_rationale ||
+                CREDIBILITY_DESCRIPTIONS[pub.credibility]}
+            </div>
+          </div>
+        </section>
+
+        {/* Tracked Domains */}
+        {pub.domains.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              <Globe className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Tracked Domains
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {pub.domains.map((domain) => (
+                <span
+                  key={domain}
+                  className="text-xs px-2.5 py-1 rounded-full border border-border font-mono"
+                >
+                  {domain}
+                </span>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Resources Table */}
+        {resources.length > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+              <FileText className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Resources ({resources.length})
+            </h2>
+            <PublicationResourcesTable resources={resourceRows} showPublishedDate={showPublishedDate} />
+          </section>
+        )}
+
+        {/* Citing pages */}
+        {pageSet.size > 0 && (
+          <section>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+              <BookOpen className="w-4 h-4 inline mr-1.5 -mt-0.5" />
+              Citing Pages ({pageSet.size})
+            </h2>
+            <div className="flex flex-wrap gap-1.5">
+              {[...pageSet].sort().map((pageId) => {
+                const href = getEntityHref(pageId);
+                const title = getPageTitle(pageId);
+                return (
+                  <Link
+                    key={pageId}
+                    href={href}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-muted rounded text-sm text-accent-foreground no-underline transition-colors hover:bg-muted/80"
+                  >
+                    {title}
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Footer */}
+        <div className="text-xs text-muted-foreground border-t border-border pt-4">
+          Publication ID:{" "}
+          <code className="px-1 py-0.5 bg-muted rounded">{pub.id}</code>
+        </div>
+      </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/publications/[id]/page.tsx
+++ b/apps/web/src/app/publications/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   BookOpen,
   CheckCircle2,
 } from "lucide-react";
+import { safeHref } from "@/lib/directory-utils";
 
 // Cache for 1 hour — on-demand rendered to reduce build size.
 export const revalidate = 3600;
@@ -114,7 +115,7 @@ export default async function PublicationDetailPage({ params }: PageProps) {
   );
 
   const headerLinks = pub.website
-    ? [{ label: "Website", href: pub.website, external: true }]
+    ? [{ label: "Website", href: safeHref(pub.website), external: true }]
     : [];
 
   const statCards = (

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -65,6 +65,13 @@ export interface EntityProfileShellProps {
    * so every entity page has a visible sourcing badge.
    */
   verdict?: string | null;
+  /**
+   * Optional href for the SourcingDot. Set this on record-level profile pages
+   * (investments, funding-rounds, publications, etc.) where the verdict points
+   * at a real `/sourcing/<recordType>/<id>` page. Entity-level pages should
+   * leave this unset — see the QUA-418 comment in the shell body.
+   */
+  verdictHref?: string;
   /** Subtitle/description block rendered immediately below the title row. */
   subtitle?: React.ReactNode;
   /** Metadata row — founded date, HQ, website, etc. */
@@ -112,6 +119,7 @@ export function EntityProfileShell({
   titlePills,
   coverage,
   verdict,
+  verdictHref,
   subtitle,
   metadata,
   headerLinks,
@@ -172,9 +180,11 @@ export function EntityProfileShell({
                   status={recordVerdictToStatus(verdict ?? null)}
                   originalVerdict={verdict ?? null}
                   size="md"
-                  // QUA-418: no href — "entity" is not a real record_type in
-                  // VALID_RECORD_TYPES, so /sourcing/entity/<id> always 404s.
-                  // Entity-level rollup pages are deferred to QUA-408 Phase 2.
+                  // QUA-418: entity-level pages omit href — "entity" is not a
+                  // real record_type so /sourcing/entity/<id> always 404s.
+                  // Record-level pages (investments, funding-rounds, etc.)
+                  // pass verdictHref since /sourcing/<recordType>/<id> exists.
+                  href={verdictHref}
                 />
               )}
               {(metadata || (headerLinks && headerLinks.length > 0)) && (


### PR DESCRIPTION
## Summary

Part of [QUA-362](https://linear.app/quantifieduncertainty/issue/QUA-362). Migrates 4 record-level detail pages to the shared `EntityProfileShell`:

- `apps/web/src/app/investments/[id]/page.tsx`
- `apps/web/src/app/funding-rounds/[id]/page.tsx`
- `apps/web/src/app/funding-programs/[id]/page.tsx`
- `apps/web/src/app/publications/[id]/page.tsx`

Hand-rolled hero amounts/stats (e.g. "$34M raised") are now `ProfileStatCard` grids for visual consistency with `/ai-models` and `/organizations`. The redundant "← Back to <company>" footer link is dropped — the breadcrumb already covers it.

## Shell change — `verdictHref` slot

Adds a `verdictHref?: string` prop to `EntityProfileShell` so record-level pages (investments, funding-rounds, publications) can link the SourcingDot to `/sourcing/<recordType>/<id>`. Entity-level pages still leave it unset per QUA-418 (`/sourcing/entity/<id>` 404s). funding-programs has no record-level verdict in the original page, so the dot is omitted (`verdict` prop unset).

This is the slot-extension pattern called out in `.claude/rules/entity-profile-pages.md`: "If the shell is missing a slot you need, add the slot to the shell rather than forking the layout."

## Acceptance

- [x] All 4 pages use `<EntityProfileShell>` — no per-type wrapper components introduced
- [x] `pnpm build` passes
- [x] `pnpm test` passes (1750 tests)
- [x] `pnpm crux w validate gate` passes (61 checks)
- [x] Playwright e2e (render-audit) passes locally for each entity type — added 4 entries to `SIDEBAR_ONLY_PAGES`

## Test plan
- [x] Local Playwright run-audit (against local dev): all 4 pages pass
- [x] Visit `/investments/9aDR5FuNzo` — Y Combinator → Algolia title, Amount $34M / Date May 2024 stat cards, sourcing dot present
- [x] Visit `/funding-rounds/2uXzVFJgb-` — Open Philanthropy General Support, Raised $510K / Date 2018 stat cards
- [x] Visit `/funding-programs/pJ9oHvQ1Bb` — Rise Global Talent Program, program-type + status pills, stat cards, no SourcingDot
- [x] Visit `/publications/nature` — Nature with type/peer-reviewed/credibility pills, 3 stat cards, credibility rationale section

Fixes QUA-487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified layouts for investments, funding rounds, funding programs, and publications for more consistent headers, badges, and stats presentation.

* **Behavior**
  * More consistent handling of sourcing/verdict links and status display across entity pages.

* **Tests**
  * Extended render-audit coverage to include the publications page (YAML-backed route) for sidebar-only checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->