### PR TITLE
fix(lint-guard): rename source-check to sourcing-check in research-agent comment

### DIFF
--- a/crux/lib/search/research-agent.ts
+++ b/crux/lib/search/research-agent.ts
@@ -94,7 +94,7 @@ export interface ResearchRequest {
    * Hostnames (or registrable suffixes) to drop from results before fetching.
    * Useful when the caller knows certain domains are "self" / circular and
    * fetching them is wasted spend (e.g. backfill-sources doesn't want to
-   * source-check our own wiki against itself).
+   * sourcing-check our own wiki against itself).
    */
   excludeHosts?: string[];
   /** Optional page context to narrow research focus. */


### PR DESCRIPTION
## Summary

One-word change to a code comment to restore the sourcing lint-guard baseline. Main went red after #4671 merged because the ratchet only enforces on main (not on PR branches), so the new \`source-check\` reference slipped through.

## Test plan

- [x] \`npx tsx crux/validate/validate-sourcing-lint-guard.ts\` — at baseline (1 ref).