### PR TITLE
fix(e2e): replace count > 0 snapshot with toBeAttached retry (QUA-822)

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -154,13 +154,16 @@ test.describe("Render audit — tabbed pages", () => {
       // access (QUA-763).
       if (STAT_CARD_PAGES.includes(url)) {
         const cards = page.locator('[data-testid="stat-card"]');
+        // Auto-retry until at least one stat-card is attached. Pages in
+        // STAT_CARD_PAGES are guaranteed to have them (Microsoft is excluded);
+        // if none appear within the timeout, that's a real regression and
+        // toBeAttached fails the test with a clear message. The previous
+        // count > 0 snapshot check flaked on the render-monitor cron when
+        // hitting prod from CI — Suspense boundaries / hydration timing
+        // could produce a transient count of 0 even when the markup was
+        // present (QUA-822).
+        await expect(cards.first()).toBeAttached({ timeout: 5000 });
         const count = await cards.count();
-        // Guard against silent no-op if data-testid is removed by a refactor.
-        // Pages in STAT_CARD_PAGES are guaranteed to have stat cards (see the
-        // list comment above — Microsoft is excluded for that reason).
-        expect
-          .soft(count > 0, `No [data-testid="stat-card"] elements on ${url}`)
-          .toBe(true);
         for (let i = 0; i < count; i++) {
           const value = (await cards.nth(i).locator(".text-xl, .text-2xl, .text-3xl, .tabular-nums").first().textContent())?.trim() ?? "";
           expect.soft(value.length > 0, `Empty stat card in ${url} (${i + 1}/${count})`).toBe(true);


### PR DESCRIPTION
## Summary

The render-audit's stat-card check was a snapshot — if Playwright sampled the locator before hydration completed (or while a Suspense boundary was still pending), `count` would be 0 and the test failed even though the markup was present in the page.

The render-monitor cron hit this 3 times against prod on 2026-04-29, blocking PR patrol's `main-ci-red` health gate for ~12 hours and triggering QUA-822 ("URGENT: Main CI stuck in broken state"). A re-run with no code changes passed in 3 minutes — confirming the failure was transient flakiness, not a real regression.

## Fix

Replace the snapshot `expect.soft(count > 0, …).toBe(true)` with `await expect(cards.first()).toBeAttached({ timeout: 5000 })`, which auto-retries until at least one stat-card is in the DOM. If none appear within 5s, that's a real regression and the test still fails with a clear message. The per-card empty-value check below remains as a soft expect so multiple violations are reported in a single run.

## Test plan

- [x] `PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/render-audit.spec.ts` — 35/35 pass against prod (~1.5min)
- [x] `npx tsc --noEmit` in `apps/web/` — clean
- [x] `pnpm exec eslint apps/web/e2e/render-audit.spec.ts` — clean
- [x] Render-monitor workflow re-triggered without this fix passed at 17:30 UTC, auto-closing issue #4667 — confirms the underlying signal is restored independently. This PR hardens the test against future flakes of the same shape.

## Why this is hardening, not the root-cause fix

The transient signal already cleared (workflow run 25123830066 passed; #4667 auto-closed; patrol re-scan reports `Main branch CI is green`). This PR's value is preventing a repeat: the same hydration-timing pattern would otherwise re-trip the gate the next time CI hits a slow Vercel cold-start. `toBeAttached` is the standard Playwright idiom for "wait until present" and removes the race entirely.

Fixes QUA-822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for tabbed pages by adding explicit wait for required page elements to render, enabling faster failure detection when elements don't display as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->