### PR TITLE
QUA-820: enforce sourcing ratchet on PR branches

### DIFF
--- a/crux/validate/validate-sourcing-lint-guard.test.ts
+++ b/crux/validate/validate-sourcing-lint-guard.test.ts
@@ -115,18 +115,13 @@ describe('countInText', () => {
   });
 
   it('runCheck passes on the current codebase (baseline must not regress)', () => {
-    // Regression guard: enforce the ratchet only on main. Feature branches
-    // that add source-check-related code naturally increase the count
-    // temporarily; the ratchet catches it when they merge to main via the
-    // gate check. Running it on every PR branch causes cascading CI failures
-    // for PRs that aren't part of the rename effort (see QUA-238).
-    const branch = process.env.GITHUB_REF ?? '';
-    if (branch && !branch.includes('refs/heads/main')) {
-      // On a PR branch — skip the ratchet assertion, just verify the check runs
-      const result = runCheck();
-      expect(result.baseline).not.toBeNull();
-      return;
-    }
+    // Enforced on every branch (QUA-820). Previously this was advisory on PR
+    // branches per QUA-238 — with baseline at ~1,400 references, every rebase
+    // inherited stale counts and broke unrelated PRs. Now that baseline is
+    // frozen at 1, the only legitimate way to fail is to add a new
+    // sourcing-check reference, which is exactly what we want PR CI to catch.
+    // The 2026-04-28/29 incident (3 fix-PRs in 12h) showed that deferring
+    // enforcement to main causes a fix-cycle pattern instead of preventing it.
     const result = runCheck();
     expect(result.passed).toBe(true);
     expect(result.baseline).not.toBeNull();

--- a/crux/validate/validate-sourcing-lint-guard.ts
+++ b/crux/validate/validate-sourcing-lint-guard.ts
@@ -28,7 +28,6 @@
  */
 
 import { readFileSync, readdirSync, statSync, writeFileSync, existsSync } from 'fs';
-import { execSync } from 'child_process';
 import { join, relative } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
@@ -311,26 +310,17 @@ function main(): void {
   const result = runCheck();
 
   if (!result.passed) {
-    // On non-main branches, the ratchet is advisory — PRs that add
-    // sourcing features naturally increase the count temporarily.
-    // The ratchet enforces on main merges. See QUA-238.
-    const branch = process.env.GITHUB_HEAD_REF
-      || process.env.GITHUB_REF
-      || execSync('git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown').toString().trim();
-    const isMain = branch === 'main' || branch === 'refs/heads/main';
-
-    if (!isMain) {
-      console.log(`${c.yellow}${result.message} (advisory on branch "${branch}")${c.reset}`);
-      console.log(`  ${c.dim}Ratchet only blocks on main. See QUA-238.${c.reset}`);
-      // Exit 0 so the gate check doesn't block PR pushes
-    } else {
-      console.log(`${c.red}${result.message}${c.reset}`);
-      console.log(`\n  Current: ${result.current.total} total`);
-      if (result.baseline) {
-        console.log(`  Baseline: ${result.baseline.total} total`);
-      }
-      process.exit(1);
+    // Blocking on every branch (QUA-820): with baseline frozen at 1, the only
+    // legitimate growth path is the QUA-303 column rename. Any baseline rise
+    // in a PR is exactly the violation we want to surface — catching it on the
+    // PR avoids the cycle of "merge → main red → cosmetic-fix PR" (3 cycles
+    // in 12h on 2026-04-28/29).
+    console.log(`${c.red}${result.message}${c.reset}`);
+    console.log(`\n  Current: ${result.current.total} total`);
+    if (result.baseline) {
+      console.log(`  Baseline: ${result.baseline.total} total`);
     }
+    process.exit(1);
   }
 
   console.log(`${c.green}${result.message}${c.reset}`);


### PR DESCRIPTION
## Summary

Stop the cycle of "merge → main red → cosmetic-fix PR" for the sourcing-lint-guard ratchet by enforcing it on **PR branches**, not just on `main`.

## Why now (QUA-820 incident)

PR patrol logs from 2026-04-28T16:29Z to 2026-04-29T09:39Z recorded **three distinct main-CI failure streaks** caused by the `validate/validate-sourcing-lint-guard.test.ts > runCheck passes on the current codebase (baseline must not regress)` test. Same root cause every time: a merged PR added a new `source-check` reference (typically a docstring or comment), and the ratchet test fires on `main` only.

| Streak | Started | Resolved by | Fix PR |
|---|---|---|---|
| 1 | 2026-04-28T14:29Z | 2026-04-29T01:37Z | #4654 (`fix-main-ci-sourcing-ratchet`) — renamed 4 comment lines |
| 2 | 2026-04-29T00:53Z | 2026-04-29T02:36Z | #4662 (`fix-sourcing-lint-guard-1777426840`, github-actions bot) — same 4 files |
| 3 | 2026-04-29T03:20Z | 2026-04-29T10:07Z | #4673 (`fix-sourcing-lint-guard-v2`) — different file, same fix shape |

Three independent cosmetic patches in 12 hours, all chasing the same systemic gap. This is the **N+ symptoms in narrow window** anti-pattern (`.claude/rules/proactive-github-filing.md` § Mandatory tracking).

## Root cause

`validate-sourcing-lint-guard.ts` and its sibling vitest test both bail out early on non-main branches (`isMain` / `GITHUB_REF` checks). The original rationale (QUA-238) was that with baseline ~1,400, every rebase inherited stale counts and broke unrelated PRs. That concern is dead: baseline is frozen at **1** (the structural Drizzle binding `sourceCheckedAt`, gated behind QUA-303). The only way for the count to rise now is for a contributor to add a new `source-check` reference — which is exactly what we want to surface on the PR.

## Change

- `crux/validate/validate-sourcing-lint-guard.ts::main()` — drop the `isMain` branch check; always exit 1 on regression. Drop unused `execSync` import.
- `crux/validate/validate-sourcing-lint-guard.test.ts` — drop the PR-branch early return; assert `result.passed` on every branch.

Net: 17 insertions, 32 deletions across 2 files.

## Test plan

- [x] `npx tsx crux/validate/validate-sourcing-lint-guard.ts` — at baseline (1 ref, 1696 files).
- [x] `npx vitest run validate/validate-sourcing-lint-guard.test.ts` — 14/14 pass.
- [x] **Adversarial check**: dropped a `// source-check test` line into `crux/lib/_sourcing-test-violation.ts` and re-ran the validator with `GITHUB_REF=refs/heads/claude/test-branch`. Exit was `1` (was `0` advisory before this PR), with output: `Total legacy-term count rose from 1 to 2 (+1) … hyphenated: 0 → 1 (+1)`.
- [x] `pnpm crux w validate gate --scope=content` — passes.
- [ ] CI green on this PR.

## Tradeoff

Any future PR that legitimately needs to add a `source-check` reference (e.g., the QUA-303 column rename when it eventually starts) will have to bump the baseline in the same PR. That's the correct behavior — it forces the change to be visible and explicit, instead of silently breaking main 50 minutes after merge.

Fixes QUA-820
