### PR TITLE
fix(patrol): exit daemon on missing GITHUB_TOKEN instead of silent cycle (QUA-799)

### DIFF
--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -150,9 +150,6 @@ describe('isMissingTokenError', () => {
   });
 });
 
-// Shared preflight used by every long-running patrol entry point — see
-// QUA-799 for the silent-degradation incident that motivated extracting this
-// from three duplicated copies in the patrol code.
 describe('requireGitHubTokenOrExit', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -5,6 +5,7 @@ import {
   MissingTokenError,
   MISSING_TOKEN_HELP_MESSAGE,
   MISSING_TOKEN_SUMMARY,
+  requireGitHubTokenOrExit,
 } from './github.ts';
 
 // Use `vi.stubEnv()` instead of mutating `process.env` directly. This is
@@ -146,5 +147,59 @@ describe('isMissingTokenError', () => {
     expect(isMissingTokenError('MissingTokenError')).toBe(false);
     expect(isMissingTokenError(42)).toBe(false);
     expect(isMissingTokenError({})).toBe(false);
+  });
+});
+
+// Shared preflight used by every long-running patrol entry point — see
+// QUA-799 for the silent-degradation incident that motivated extracting this
+// from three duplicated copies in the patrol code.
+describe('requireGitHubTokenOrExit', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not log or exit when GITHUB_TOKEN is set', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_abc123');
+    const logs: string[] = [];
+    const exits: number[] = [];
+    requireGitHubTokenOrExit(
+      (msg) => logs.push(msg),
+      ((code: number) => {
+        exits.push(code);
+        return undefined as never;
+      }),
+    );
+    expect(logs).toHaveLength(0);
+    expect(exits).toHaveLength(0);
+  });
+
+  it('logs the canonical summary and calls exit(1) when GITHUB_TOKEN is missing', () => {
+    vi.stubEnv('GITHUB_TOKEN', undefined as unknown as string);
+    const logs: string[] = [];
+    const exits: number[] = [];
+    requireGitHubTokenOrExit(
+      (msg) => logs.push(msg),
+      ((code: number) => {
+        exits.push(code);
+        return undefined as never;
+      }),
+    );
+    expect(logs).toEqual([`ERROR: ${MISSING_TOKEN_SUMMARY}`]);
+    expect(exits).toEqual([1]);
+  });
+
+  it('logs and exits when GITHUB_TOKEN is whitespace-only (delegates to getGitHubToken)', () => {
+    vi.stubEnv('GITHUB_TOKEN', '   \n');
+    const logs: string[] = [];
+    const exits: number[] = [];
+    requireGitHubTokenOrExit(
+      (msg) => logs.push(msg),
+      ((code: number) => {
+        exits.push(code);
+        return undefined as never;
+      }),
+    );
+    expect(exits).toEqual([1]);
+    expect(logs[0]).toContain(MISSING_TOKEN_SUMMARY);
   });
 });

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -151,6 +151,38 @@ export function getGitHubToken(): string {
 }
 
 /**
+ * Daemon preflight helper used by every long-running patrol entry point
+ * (`runDaemon`, `runParallelDaemon`, `runBranchAgent`). Verifies a non-empty
+ * `GITHUB_TOKEN` is present in the environment; if missing, logs the canonical
+ * one-liner via `log` and exits with code 1 via `exit`.
+ *
+ * Centralised here so the three daemons share a single tested implementation
+ * — without it, each daemon hand-rolls the same try/catch/exit block and the
+ * code drifts (one daemon already had no preflight at all, see QUA-799).
+ *
+ * `log` and `exit` are injectable so unit tests can assert on the side
+ * effects without actually killing the test runner.
+ */
+export function requireGitHubTokenOrExit(
+  log: (msg: string) => void,
+  exit: (code: number) => never = process.exit as (code: number) => never,
+): void {
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      log(`ERROR: ${MISSING_TOKEN_SUMMARY}`);
+      exit(1);
+      // In production `exit` does not return; this path is only reached when
+      // a test injects a mock that doesn't kill the runner. Return to avoid
+      // re-throwing the MissingTokenError after the mock-exit swallows it.
+      return;
+    }
+    throw e;
+  }
+}
+
+/**
  * Check a string for signs of shell-expansion corruption or ANSI escape codes
  * before it gets posted to GitHub.
  *

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -173,10 +173,7 @@ export function requireGitHubTokenOrExit(
     if (isMissingTokenError(e)) {
       log(`ERROR: ${MISSING_TOKEN_SUMMARY}`);
       exit(1);
-      // In production `exit` does not return; this path is only reached when
-      // a test injects a mock that doesn't kill the runner. Return to avoid
-      // re-throwing the MissingTokenError after the mock-exit swallows it.
-      return;
+      return; // Test-only: real process.exit() never returns; bare return prevents re-throw under mocked exit.
     }
     throw e;
   }

--- a/crux/pr-patrol/branch-agent.ts
+++ b/crux/pr-patrol/branch-agent.ts
@@ -16,12 +16,7 @@
  * Phase 1 of the persistent patrol brain design described in discussion #1882.
  */
 
-import {
-  githubApi,
-  getGitHubToken,
-  isMissingTokenError,
-  MISSING_TOKEN_SUMMARY,
-} from '../lib/github.ts';
+import { githubApi, requireGitHubTokenOrExit } from '../lib/github.ts';
 import { appendJsonl, cl, log, JSONL_FILE } from './state.ts';
 import { fetchSinglePr } from '../lib/pr-analysis/index.ts';
 import { detectIssues, computeScore } from '../lib/pr-analysis/index.ts';
@@ -152,17 +147,8 @@ export async function runBranchAgent(config: BranchAgentConfig): Promise<void> {
 
   // Preflight: GITHUB_TOKEN is mandatory — every cycle calls fetchSinglePr
   // and label endpoints. Without it the agent loops forever, swallowing 401s
-  // into generic "failed to fetch" log lines (QUA-799). Match runDaemon /
-  // runParallelDaemon behaviour: log loud + exit 1.
-  try {
-    getGitHubToken();
-  } catch (e) {
-    if (isMissingTokenError(e)) {
-      log(`${cl.red}ERROR: ${MISSING_TOKEN_SUMMARY}${cl.reset}`);
-      process.exit(1);
-    }
-    throw e;
-  }
+  // into generic "failed to fetch" log lines (QUA-799).
+  requireGitHubTokenOrExit((msg) => log(`${cl.red}${msg}${cl.reset}`));
 
   log(`${cl.bold}Branch Agent — PR #${prNumber}${cl.reset} (${repo})`);
   log(`  Max invocations: ${maxInvocations}, per-session timeout: ${config.timeoutMinutes}m`);

--- a/crux/pr-patrol/branch-agent.ts
+++ b/crux/pr-patrol/branch-agent.ts
@@ -16,7 +16,12 @@
  * Phase 1 of the persistent patrol brain design described in discussion #1882.
  */
 
-import { githubApi } from '../lib/github.ts';
+import {
+  githubApi,
+  getGitHubToken,
+  isMissingTokenError,
+  MISSING_TOKEN_SUMMARY,
+} from '../lib/github.ts';
 import { appendJsonl, cl, log, JSONL_FILE } from './state.ts';
 import { fetchSinglePr } from '../lib/pr-analysis/index.ts';
 import { detectIssues, computeScore } from '../lib/pr-analysis/index.ts';
@@ -144,6 +149,20 @@ function hasMergeableIssues(pr: GqlPrNode, staleThresholdMs: number): boolean {
 export async function runBranchAgent(config: BranchAgentConfig): Promise<void> {
   const { prNumber, repo, maxInvocations, ciPollIntervalSeconds, ciTimeoutSeconds } = config;
   const staleThresholdMs = config.staleHours * 60 * 60 * 1000;
+
+  // Preflight: GITHUB_TOKEN is mandatory — every cycle calls fetchSinglePr
+  // and label endpoints. Without it the agent loops forever, swallowing 401s
+  // into generic "failed to fetch" log lines (QUA-799). Match runDaemon /
+  // runParallelDaemon behaviour: log loud + exit 1.
+  try {
+    getGitHubToken();
+  } catch (e) {
+    if (isMissingTokenError(e)) {
+      log(`${cl.red}ERROR: ${MISSING_TOKEN_SUMMARY}${cl.reset}`);
+      process.exit(1);
+    }
+    throw e;
+  }
 
   log(`${cl.bold}Branch Agent — PR #${prNumber}${cl.reset} (${repo})`);
   log(`  Max invocations: ${maxInvocations}, per-session timeout: ${config.timeoutMinutes}m`);

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -128,6 +128,9 @@ describe('runHealthGate — env escape hatch', () => {
     const decision = await runHealthGate({ ...deps, scan });
     expect(decision.proceed).toBe(true);
     expect(decision.bypassed).toBe(true);
+    // Bypass NEVER reports a permanent fault — the operator explicitly opted
+    // into ignoring the gate, so the daemon must not exit on this path.
+    expect(decision.permanentFault).toBe(false);
     expect(deps.logs.some((l) => l.includes('BYPASSED'))).toBe(true);
     expect(deps.events).toHaveLength(0);
   });
@@ -202,6 +205,7 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
     expect(scanCalled).toBe(false);
     expect(decision.proceed).toBe(false);
     expect(decision.bypassed).toBe(false);
+    expect(decision.permanentFault).toBe(true);
     expect(decision.reason).toContain('GITHUB_TOKEN');
     expect(deps.events).toHaveLength(1);
     expect(deps.events[0]).toMatchObject({
@@ -219,6 +223,7 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
     });
     expect(decision.proceed).toBe(false);
     expect(decision.reason).toContain('GITHUB_TOKEN');
+    expect(decision.permanentFault).toBe(true);
   });
 
   it('resets the consecutive-error counter when halting on missing token', async () => {
@@ -266,6 +271,7 @@ describe('runHealthGate — missing GITHUB_TOKEN', () => {
 
     expect(decision.proceed).toBe(false);
     expect(decision.reason).toContain('GITHUB_TOKEN');
+    expect(decision.permanentFault).toBe(true);
     // Counter did not tick up — permanent errors shouldn't use streak budget.
     expect(store.getCount('__scan_error_count__')).toBe(0);
     expect(deps.events.some((e) => e.type === 'health_gate_missing_token')).toBe(true);
@@ -321,6 +327,7 @@ describe('runHealthGate — scanner error', () => {
       },
     });
     expect(decision.proceed).toBe(true);
+    expect(decision.permanentFault).toBe(false);
     expect(deps.events).toHaveLength(1);
     expect(deps.events[0]).toMatchObject({
       type: 'health_scan_error',
@@ -343,6 +350,10 @@ describe('runHealthGate — scanner error', () => {
     // First N-1 proceed; Nth halts
     expect(lastDecision!.proceed).toBe(false);
     expect(lastDecision!.reason).toContain('consecutively');
+    // QUA-799: a transient streak halt is NOT a permanent fault — the
+    // daemon should keep cycling (the streak may clear when GitHub recovers),
+    // unlike a missing-token halt which exits the daemon outright.
+    expect(lastDecision!.permanentFault).toBe(false);
     expect(store.getCount('__scan_error_count__')).toBe(MAX_CONSECUTIVE_SCAN_ERRORS);
   });
 
@@ -414,6 +425,19 @@ describe('runHealthGate — unhealthy', () => {
     expect(decision.emittedIssues).toHaveLength(0);
     expect(decision.suppressedIssues).toHaveLength(1);
     expect(deps.events).toHaveLength(0); // no new JSONL emission
+  });
+
+  it('reports permanentFault=false for fleet-level signals (deploy-stuck etc.)', async () => {
+    // QUA-799 regression: deploy-stuck and similar signals are transient by
+    // construction — the patrol should keep cycling and re-checking. Only
+    // missing-token sets permanentFault.
+    const deps = makeDeps();
+    const decision = await runHealthGate({
+      ...deps,
+      scan: async () => unhealthyScan([deployStuckIssue()]),
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.permanentFault).toBe(false);
   });
 });
 

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -9,6 +9,7 @@ import {
   DISABLE_ENV_VAR,
   type HealthGateDeps,
 } from './health-gate.ts';
+import { handlePermanentFault, type PermanentFaultDeps } from './index.ts';
 import type { HealthScanResult, HealthIssue } from './health-scan.ts';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -646,5 +647,78 @@ describe('fingerprintIssue', () => {
     expect(a).toBe('ratchet-drift:foo');
     expect(b).toBe('ratchet-drift:bar');
     expect(a).not.toBe(b);
+  });
+});
+
+// ── Permanent-fault handling (QUA-799) ───────────────────────────────────────
+
+describe('handlePermanentFault', () => {
+  function makeFaultDeps() {
+    const logs: string[] = [];
+    const exits: number[] = [];
+    let claimReleased = 0;
+    const removed: number[] = [];
+    const deps: PermanentFaultDeps = {
+      log: (msg) => logs.push(msg),
+      removePidFile: () => removed.push(removed.length),
+      releaseClaim: async () => {
+        claimReleased += 1;
+      },
+      exit: ((code: number) => {
+        exits.push(code);
+        // Mock exit must throw to abort the awaiting caller — production
+        // process.exit never returns, and tests need a reliable abort signal.
+        throw new Error(`__test_exit_${code}__`);
+      }) as (code: number) => never,
+    };
+    return {
+      deps,
+      logs,
+      exits,
+      removed,
+      claimReleasedCount: () => claimReleased,
+    };
+  }
+
+  it('logs the reason, releases the claim, removes the pid file, and exits 1', async () => {
+    const t = makeFaultDeps();
+    await expect(
+      handlePermanentFault('GITHUB_TOKEN not set in environment', t.deps),
+    ).rejects.toThrow('__test_exit_1__');
+
+    expect(t.exits).toEqual([1]);
+    // Claim release must happen BEFORE exit so the next daemon process can
+    // pick up the PR — the SIGTERM `shutdown` handler does the same thing.
+    expect(t.claimReleasedCount()).toBe(1);
+    expect(t.removed).toHaveLength(1);
+    expect(t.logs.some((l) => l.includes('GITHUB_TOKEN not set'))).toBe(true);
+    expect(t.logs.some((l) => l.includes('Exiting daemon'))).toBe(true);
+  });
+
+  it('still exits 1 even if releaseClaim rejects (logs the warning)', async () => {
+    // Realistic case: wiki-server is also down or the claim row was already
+    // removed manually. The fault path must not get stuck waiting on cleanup.
+    const logs: string[] = [];
+    const exits: number[] = [];
+    const deps: PermanentFaultDeps = {
+      log: (msg) => logs.push(msg),
+      removePidFile: () => {},
+      releaseClaim: async () => {
+        throw new Error('wiki-server unreachable');
+      },
+      exit: ((code: number) => {
+        exits.push(code);
+        throw new Error(`__test_exit_${code}__`);
+      }) as (code: number) => never,
+    };
+    await expect(handlePermanentFault('test reason', deps)).rejects.toThrow(
+      '__test_exit_1__',
+    );
+    expect(exits).toEqual([1]);
+    expect(
+      logs.some((l) =>
+        l.includes('failed to release claim during permanent-fault exit'),
+      ),
+    ).toBe(true);
   });
 });

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -351,9 +351,9 @@ describe('runHealthGate — scanner error', () => {
     // First N-1 proceed; Nth halts
     expect(lastDecision!.proceed).toBe(false);
     expect(lastDecision!.reason).toContain('consecutively');
-    // QUA-799: a transient streak halt is NOT a permanent fault — the
-    // daemon should keep cycling (the streak may clear when GitHub recovers),
-    // unlike a missing-token halt which exits the daemon outright.
+    // A transient streak halt is NOT a permanent fault — the daemon should
+    // keep cycling (the streak may clear when GitHub recovers), unlike a
+    // missing-token halt which exits the daemon outright.
     expect(lastDecision!.permanentFault).toBe(false);
     expect(store.getCount('__scan_error_count__')).toBe(MAX_CONSECUTIVE_SCAN_ERRORS);
   });
@@ -429,9 +429,8 @@ describe('runHealthGate — unhealthy', () => {
   });
 
   it('reports permanentFault=false for fleet-level signals (deploy-stuck etc.)', async () => {
-    // QUA-799 regression: deploy-stuck and similar signals are transient by
-    // construction — the patrol should keep cycling and re-checking. Only
-    // missing-token sets permanentFault.
+    // Deploy-stuck and similar signals are transient — the patrol should keep
+    // cycling and re-checking. Only missing-token sets permanentFault.
     const deps = makeDeps();
     const decision = await runHealthGate({
       ...deps,

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -66,6 +66,16 @@ export interface HealthGateDecision {
   suppressedIssues: HealthIssue[];
   /** True when the env escape hatch was engaged. */
   bypassed: boolean;
+  /**
+   * True when the gate detected a permanent config fault that the daemon
+   * loop cannot recover from on its own (e.g. `GITHUB_TOKEN` missing). The
+   * daemon should EXIT (not just halt the cycle), so a process supervisor
+   * sees the failure and an operator can fix the env. Without this, a
+   * missing token would let the daemon cycle forever, silently emitting
+   * `health_gate_missing_token` events into JSONL while the rest of the
+   * fleet stays blind to fleet-level incidents (QUA-799).
+   */
+  permanentFault: boolean;
 }
 
 export interface HealthGateDeps {
@@ -226,6 +236,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: true,
+      permanentFault: false,
     };
   }
 
@@ -239,7 +250,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
   if (!env.GITHUB_TOKEN) {
     log(
       `${cl.red}✗ ${MISSING_TOKEN_SUMMARY} — health gate cannot scan GitHub. ` +
-        `Halting patrol until token is set.${cl.reset}`,
+        `Exiting patrol so a supervisor restart picks up the corrected env (QUA-799).${cl.reset}`,
     );
     writeEvent({
       type: 'health_gate_missing_token',
@@ -256,6 +267,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: false,
+      permanentFault: true,
     };
   }
 
@@ -285,7 +297,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
         reason: message,
       });
       log(
-        `${cl.red}✗ GITHUB_TOKEN became unavailable during scan — halting patrol.${cl.reset}`,
+        `${cl.red}✗ GITHUB_TOKEN became unavailable during scan — exiting patrol (QUA-799).${cl.reset}`,
       );
       return {
         proceed: false,
@@ -294,6 +306,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
         emittedIssues: [],
         suppressedIssues: [],
         bypassed: false,
+        permanentFault: true,
       };
     }
 
@@ -320,6 +333,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
         emittedIssues: [],
         suppressedIssues: [],
         bypassed: false,
+        permanentFault: false,
       };
     }
 
@@ -334,6 +348,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: false,
+      permanentFault: false,
     };
   }
 
@@ -345,6 +360,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       emittedIssues: [],
       suppressedIssues: [],
       bypassed: false,
+      permanentFault: false,
     };
   }
 
@@ -398,5 +414,6 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
     emittedIssues: emitted,
     suppressedIssues: suppressed,
     bypassed: false,
+    permanentFault: false,
   };
 }

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -301,7 +301,10 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
       );
       return {
         proceed: false,
-        reason: `${MISSING_TOKEN_SUMMARY} in environment`,
+        // Include the original error message so operator-visible logs (and
+        // the eventual `crux gh pr-patrol status` view of cycle_summary)
+        // can distinguish "no env var" from a corrupted-token variant.
+        reason: `${MISSING_TOKEN_SUMMARY} in environment: ${message}`,
         result: syntheticScanFailureResult(message),
         emittedIssues: [],
         suppressedIssues: [],

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -290,11 +290,14 @@ function preflightChecks(config: PatrolConfig): string[] {
  * daemon cannot recover from on its own (e.g. missing GITHUB_TOKEN). The
  * daemon loop exits in that case rather than cycling silently — see QUA-799
  * for the silent-degradation incident this guards against.
+ *
+ * Discriminated union so the reason field is only present (and required) on
+ * the fault branch — a future caller can't accidentally read an empty string
+ * as "no problem".
  */
-interface CycleOutcome {
-  permanentFault: boolean;
-  permanentFaultReason: string;
-}
+type CycleOutcome =
+  | { permanentFault: false }
+  | { permanentFault: true; reason: string };
 
 async function runCheckCycle(
   cycleCount: number,
@@ -319,10 +322,9 @@ async function runCheckCycle(
       health_gate_reason: gate.reason,
       permanent_fault: gate.permanentFault,
     });
-    return {
-      permanentFault: gate.permanentFault,
-      permanentFaultReason: gate.permanentFault ? gate.reason : '',
-    };
+    return gate.permanentFault
+      ? { permanentFault: true, reason: gate.reason }
+      : { permanentFault: false };
   }
 
   // 0a. Check if a tracked main-branch fix PR has been merged
@@ -363,8 +365,9 @@ async function runCheckCycle(
       queue_size: 0,
       pr_processed: null,
       main_branch_fix: true,
+      permanent_fault: false,
     });
-    return { permanentFault: false, permanentFaultReason: '' }; // Main takes the whole cycle; PRs wait
+    return { permanentFault: false }; // Main takes the whole cycle; PRs wait
   }
 
   // 0b. Check deploy health
@@ -608,9 +611,50 @@ async function runCheckCycle(
     merge_eligible: eligibleForMerge.length,
     deploy_healthy: deployHealth.healthy,
     deploy_failing_since: deployHealth.failingSince ?? undefined,
+    permanent_fault: false,
   });
 
-  return { permanentFault: false, permanentFaultReason: '' };
+  return { permanentFault: false };
+}
+
+// ── Permanent-fault handling ────────────────────────────────────────────────
+
+/**
+ * Side-effect dependencies for {@link handlePermanentFault}, broken out so
+ * unit tests can assert without actually killing the test runner.
+ */
+export interface PermanentFaultDeps {
+  log: (msg: string) => void;
+  removePidFile: () => void;
+  releaseClaim: () => Promise<void>;
+  exit: (code: number) => never;
+}
+
+/**
+ * Handle a permanent fault detected during a cycle: log loudly, release any
+ * held PR claim (otherwise the next daemon process can't pick it up), remove
+ * the PID file, and exit with code 1 so a process supervisor sees the
+ * failure. See QUA-799 for the silent-degradation incident this guards
+ * against.
+ *
+ * Awaits `releaseClaim` so an in-flight claim doesn't leak in PG when the
+ * gate trips mid-cycle. Mirrors the existing SIGTERM `shutdown` handler.
+ */
+export async function handlePermanentFault(
+  reason: string,
+  deps: PermanentFaultDeps,
+): Promise<never> {
+  deps.log(
+    `✗ Patrol cannot continue: ${reason}. ` +
+      `Exiting daemon (QUA-799). Fix the env and restart.`,
+  );
+  await deps.releaseClaim().catch((e: unknown) => {
+    deps.log(
+      `Warning: failed to release claim during permanent-fault exit: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  });
+  deps.removePidFile();
+  return deps.exit(1);
 }
 
 // ── Daemon loop ─────────────────────────────────────────────────────────────
@@ -654,19 +698,19 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
   // The daemon cannot recover from this on its own, so cycling forever just
   // produces silent JSONL churn instead of forcing operator attention. See
   // QUA-799.
-  const exitOnPermanentFault = (outcome: CycleOutcome): void => {
-    if (!outcome.permanentFault) return;
-    log(
-      `${cl.red}✗ Patrol cannot continue: ${outcome.permanentFaultReason}. ` +
-        `Exiting daemon (QUA-799). Fix the env and restart.${cl.reset}`,
-    );
-    removePidFile();
-    process.exit(1);
+  const faultDeps: PermanentFaultDeps = {
+    log: (msg) => log(`${cl.red}${msg}${cl.reset}`),
+    removePidFile,
+    releaseClaim: () => releaseCurrentClaim(config.repo),
+    exit: process.exit as (code: number) => never,
+  };
+  const exitIfFault = async (outcome: CycleOutcome): Promise<void> => {
+    if (outcome.permanentFault) await handlePermanentFault(outcome.reason, faultDeps);
   };
 
   if (config.once) {
     const outcome = await runCheckCycle(1, config);
-    exitOnPermanentFault(outcome);
+    await exitIfFault(outcome);
     return;
   }
 
@@ -675,8 +719,15 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
     cycleCount++;
     try {
       const outcome = await runCheckCycle(cycleCount, config);
-      exitOnPermanentFault(outcome);
+      await exitIfFault(outcome);
     } catch (e) {
+      // If runCheckCycle (or runHealthGate inside it) threw a MissingTokenError
+      // before reaching its return, treat it as a permanent fault — otherwise
+      // the daemon swallows it as a transient cycle error and keeps cycling
+      // silently, defeating the QUA-799 guard.
+      if (isMissingTokenError(e)) {
+        await handlePermanentFault(MISSING_TOKEN_SUMMARY, faultDeps);
+      }
       log(
         `${cl.red}Check cycle failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`,
       );

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -283,10 +283,23 @@ function preflightChecks(config: PatrolConfig): string[] {
 
 // ── Check cycle ──────────────────────────────────────────────────────────────
 
+/**
+ * Outcome of a check cycle.
+ *
+ * `permanentFault` is set when the gate detected a config fault that the
+ * daemon cannot recover from on its own (e.g. missing GITHUB_TOKEN). The
+ * daemon loop exits in that case rather than cycling silently — see QUA-799
+ * for the silent-degradation incident this guards against.
+ */
+interface CycleOutcome {
+  permanentFault: boolean;
+  permanentFaultReason: string;
+}
+
 async function runCheckCycle(
   cycleCount: number,
   config: PatrolConfig,
-): Promise<void> {
+): Promise<CycleOutcome> {
   logHeader(`Check cycle #${cycleCount}`);
 
   // 0. Health gate (QUA-300 Phase 3) — check fleet-level signals FIRST.
@@ -304,8 +317,12 @@ async function runCheckCycle(
       pr_processed: null,
       health_gate_tripped: true,
       health_gate_reason: gate.reason,
+      permanent_fault: gate.permanentFault,
     });
-    return;
+    return {
+      permanentFault: gate.permanentFault,
+      permanentFaultReason: gate.permanentFault ? gate.reason : '',
+    };
   }
 
   // 0a. Check if a tracked main-branch fix PR has been merged
@@ -347,7 +364,7 @@ async function runCheckCycle(
       pr_processed: null,
       main_branch_fix: true,
     });
-    return; // Main takes the whole cycle; PRs wait
+    return { permanentFault: false, permanentFaultReason: '' }; // Main takes the whole cycle; PRs wait
   }
 
   // 0b. Check deploy health
@@ -592,6 +609,8 @@ async function runCheckCycle(
     deploy_healthy: deployHealth.healthy,
     deploy_failing_since: deployHealth.failingSince ?? undefined,
   });
+
+  return { permanentFault: false, permanentFaultReason: '' };
 }
 
 // ── Daemon loop ─────────────────────────────────────────────────────────────
@@ -631,8 +650,23 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
   process.on('SIGINT', () => void shutdown());
   process.on('SIGTERM', () => void shutdown());
 
+  // Exit cleanly on a permanent config fault (e.g. missing GITHUB_TOKEN).
+  // The daemon cannot recover from this on its own, so cycling forever just
+  // produces silent JSONL churn instead of forcing operator attention. See
+  // QUA-799.
+  const exitOnPermanentFault = (outcome: CycleOutcome): void => {
+    if (!outcome.permanentFault) return;
+    log(
+      `${cl.red}✗ Patrol cannot continue: ${outcome.permanentFaultReason}. ` +
+        `Exiting daemon (QUA-799). Fix the env and restart.${cl.reset}`,
+    );
+    removePidFile();
+    process.exit(1);
+  };
+
   if (config.once) {
-    await runCheckCycle(1, config);
+    const outcome = await runCheckCycle(1, config);
+    exitOnPermanentFault(outcome);
     return;
   }
 
@@ -640,7 +674,8 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
   while (!shuttingDown) {
     cycleCount++;
     try {
-      await runCheckCycle(cycleCount, config);
+      const outcome = await runCheckCycle(cycleCount, config);
+      exitOnPermanentFault(outcome);
     } catch (e) {
       log(
         `${cl.red}Check cycle failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`,

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -721,12 +721,12 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
       const outcome = await runCheckCycle(cycleCount, config);
       await exitIfFault(outcome);
     } catch (e) {
-      // If runCheckCycle (or runHealthGate inside it) threw a MissingTokenError
-      // before reaching its return, treat it as a permanent fault — otherwise
-      // the daemon swallows it as a transient cycle error and keeps cycling
-      // silently, defeating the QUA-799 guard.
+      // A MissingTokenError thrown before runCheckCycle could return is a
+      // permanent fault; without this branch the daemon would log "Check
+      // cycle failed" and keep cycling silently (QUA-799).
       if (isMissingTokenError(e)) {
         await handlePermanentFault(MISSING_TOKEN_SUMMARY, faultDeps);
+        continue; // Unreachable in prod; explicit for test mocks.
       }
       log(
         `${cl.red}Check cycle failed: ${e instanceof Error ? e.message : String(e)}${cl.reset}`,

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -15,12 +15,7 @@ import { execSync } from 'child_process';
 import { tryRebaseAndVerify } from './rebase-verify.ts';
 import { gitIn, gitSafe, gitSafeIn } from '../lib/git.ts';
 import { parseIntOpt } from '../lib/cli.ts';
-import {
-  getGitHubToken,
-  isMissingTokenError,
-  MISSING_TOKEN_SUMMARY,
-  REPO,
-} from '../lib/github.ts';
+import { requireGitHubTokenOrExit, REPO } from '../lib/github.ts';
 import type { PatrolConfig, ScoredPr, FixOutcome } from './types.ts';
 import {
   appendJsonl,
@@ -734,15 +729,7 @@ export async function runParallelDaemon(config: ParallelConfig): Promise<void> {
   log(`  mode=${config.once ? 'single pass' : config.dryRun ? 'dry run' : 'continuous'}`);
   log(`  JSONL: ${JSONL_FILE}`);
 
-  try {
-    getGitHubToken();
-  } catch (e) {
-    if (isMissingTokenError(e)) {
-      log(`${cl.red}ERROR: ${MISSING_TOKEN_SUMMARY}${cl.reset}`);
-      process.exit(1);
-    }
-    throw e;
-  }
+  requireGitHubTokenOrExit((msg) => log(`${cl.red}${msg}${cl.reset}`));
 
   // Signal handlers for graceful shutdown
   let shuttingDown = false;


### PR DESCRIPTION
## Summary

Patrol health gate now treats missing `GITHUB_TOKEN` as a permanent fault — exits the daemon process instead of cycling silently. Closes the QUA-799 silent-degradation symptom (3 events over 2 days while the operator-visible behavior was "patrol keeps running but is blind").

Fixes QUA-799

## Key changes

- **`crux/lib/github.ts`** — extracted `requireGitHubTokenOrExit()` helper (one tested implementation across 3 patrol daemons that previously hand-rolled the same try/catch).
- **`crux/pr-patrol/health-gate.ts`** — added `permanentFault: boolean` field to `HealthGateDecision`. Set `true` on both missing-token paths (entry-time check and scan-throws-MissingTokenError), `false` for healthy / unhealthy / transient scan-error / bypass.
- **`crux/pr-patrol/index.ts`** — `runCheckCycle` returns `CycleOutcome` discriminated union (`{ permanentFault: false } | { permanentFault: true; reason: string }`). New top-level `handlePermanentFault()` helper logs red + awaits `releaseCurrentClaim` (so a held claim doesn't leak in PG mid-fault) + removes the PID file + exits with code 1. The `runDaemon` catch handler also classifies thrown `MissingTokenError`s as permanent faults so a token revocation mid-scan doesn't get swallowed as a transient cycle error.
- **`crux/pr-patrol/branch-agent.ts`** — added the missing preflight (this daemon had zero token validation; without it, every cycle would loop forever swallowing 401s into generic "fetch failed" log lines).
- **`crux/pr-patrol/parallel.ts`** — switched to the shared helper (cosmetic, removes a duplicated try/catch block).
- **`crux/pr-patrol/health-gate.test.ts`, `crux/lib/github.test.ts`** — tests for the new helpers + `permanentFault` flag on every gate return path. Adversarial cases covered: claim-release rejects (logs warning, still exits 1); whitespace-only tokens; transient scan errors do NOT set `permanentFault`; bypass mode does NOT set `permanentFault`.

## Test plan

- [x] `pnpm test` — 451 pr-patrol + github.ts tests pass (5 unrelated baseline failures in `crux/wiki-server/snapshot-resources.test.ts` exist on `main` too — data-content threshold tests reading `data/resources-snapshot.json`)
- [x] `pnpm build` — production build succeeds
- [x] `pnpm crux w validate gate --fix --scope=content` — all 5 content gate checks pass
- [x] Type-check on modified files clean
- [x] `/agent-review-pr` — adaptive review found 4 MEDIUM + 5 LOW findings; all addressed (helper extraction, claim-release await, MissingTokenError-from-throw classification, discriminated union, JSONL field consistency)
- [x] `/simplify` — three findings addressed (dead-code short-circuit, comment trims)
