### PR TITLE
fix(patrol): cap scan-failure halts at 30min + add fetch timeout (QUA-823)

### DIFF
--- a/.claude/rules/patrol-health-gate.md
+++ b/.claude/rules/patrol-health-gate.md
@@ -49,6 +49,20 @@ cycle start
 
 Per-fingerprint cooldown (30min) prevents spam when an underlying issue takes hours to resolve. The same "deploy-stuck" signal is re-emitted at most once per 30min, but the patrol still halts PR work on every cycle that sees unhealthy state — the cooldown only affects whether we write another escalation line, not whether we keep touching PRs.
 
+## Scanner failure modes (QUA-823)
+
+The scanner itself can fail (GitHub API outage, DNS hiccup, TLS glitch). Behavior depends on streak duration:
+
+| Streak duration | Cycles | Behavior |
+|---|---|---|
+| 1st-2nd consecutive failure | 1-2 | Proceed with caution; log warning, write `health_scan_error` event |
+| ≥ `MAX_CONSECUTIVE_SCAN_ERRORS` (3), under 30min | 3+ | **Halt** PR work; log halt warning |
+| ≥ `SCAN_FAILURE_PROCEED_AFTER_MINUTES` (30) | varies | **Fail-open** (proceed without fleet visibility); log loud warning, write `health_gate_proceed_blind` event |
+
+The 30-minute cap exists because count-based halts blocked patrol for 3+ hours during transient API outages (QUA-823). Past 30min we assume the scanner is broken (not prod), so patrol resumes — with the trade-off that a real prod incident during this window won't trip the gate. Each error event records `streak_duration_minutes` so operators can see progress toward fail-open.
+
+GitHub API requests have a 30s `AbortSignal` timeout (`GITHUB_API_TIMEOUT_MS`); a hung connection no longer waits indefinitely. Fetch errors include URL + method context (e.g. `GitHub API GET /repos/.../runs fetch failed: ENOTFOUND api.github.com`) instead of bare "fetch failed".
+
 ## When the gate misbehaves
 
 `PATROL_DISABLE_HEALTH_GATE=1` bypasses the gate entirely. Use this only when the gate itself is broken and needs debugging — NOT when prod is red and you want the patrol to "keep working anyway."

--- a/crux/lib/github.test.ts
+++ b/crux/lib/github.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   getGitHubToken,
+  GITHUB_API_TIMEOUT_MS,
+  githubApi,
+  githubGraphQL,
   isMissingTokenError,
   MissingTokenError,
   MISSING_TOKEN_HELP_MESSAGE,
@@ -146,5 +149,72 @@ describe('isMissingTokenError', () => {
     expect(isMissingTokenError('MissingTokenError')).toBe(false);
     expect(isMissingTokenError(42)).toBe(false);
     expect(isMissingTokenError({})).toBe(false);
+  });
+});
+
+// QUA-823: bare "fetch failed" errors must be wrapped with URL/method context
+// so the patrol log shows what was being attempted, not just an opaque
+// 5-character TypeError message. Also asserts the timeout constant is in a
+// sensible range so a future tweak doesn't accidentally drop to 0 or balloon
+// past the patrol cycle interval.
+describe('githubApi — fetch error wrapping', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('exposes a sensible timeout constant', () => {
+    expect(GITHUB_API_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+    expect(GITHUB_API_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
+  });
+
+  it('wraps a network error with the method + endpoint context', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    const cause = new Error('getaddrinfo ENOTFOUND api.github.com');
+    const fetchErr = new TypeError('fetch failed');
+    Object.assign(fetchErr, { cause });
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(fetchErr);
+
+    await expect(githubApi('/repos/foo/bar/issues')).rejects.toThrow(
+      /GitHub API GET \/repos\/foo\/bar\/issues fetch failed: fetch failed: getaddrinfo ENOTFOUND/,
+    );
+  });
+
+  it('wraps an AbortError (timeout) with a clear "timed out" message', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    const abort = new Error('The operation was aborted');
+    abort.name = 'TimeoutError';
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(abort);
+
+    await expect(githubApi('/user')).rejects.toThrow(
+      new RegExp(`GitHub API GET /user timed out after ${GITHUB_API_TIMEOUT_MS}ms`),
+    );
+  });
+
+  it('wraps GraphQL fetch errors with a /graphql endpoint marker', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(githubGraphQL('query { viewer { login } }')).rejects.toThrow(
+      /GitHub API POST \/graphql fetch failed: fetch failed/,
+    );
+  });
+
+  it('passes an AbortSignal to fetch (so a hung connection cannot block forever)', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    await githubApi('/user');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0][1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/crux/lib/github.ts
+++ b/crux/lib/github.ts
@@ -18,6 +18,44 @@
 export const REPO = 'quantified-uncertainty/longterm-wiki';
 
 /**
+ * Per-request timeout for GitHub API and GraphQL fetches. Without this, a hung
+ * TCP connection or stalled TLS handshake blocks the caller indefinitely —
+ * which in the patrol loop manifested as "fetch failed" persisting for hours
+ * with no specifics about what was being attempted (QUA-823).
+ *
+ * 30s is generous: GitHub's documented p99 is well under 5s, and our largest
+ * payloads (PR creation with long bodies) finish in single-digit seconds.
+ */
+export const GITHUB_API_TIMEOUT_MS = 30_000;
+
+/**
+ * Wrap a `fetch` rejection (TypeError "fetch failed", AbortError on timeout,
+ * etc.) with the URL/method context so the patrol log shows what was being
+ * attempted. Plain `fetch` errors do not include the URL — see QUA-823 where
+ * 37+ consecutive "fetch failed" log lines gave no hint at the failing
+ * endpoint. Re-throws as a normal `Error` so existing `instanceof
+ * GitHubApiError` / `isMissingTokenError` checks remain unaffected.
+ */
+function wrapFetchError(method: string, endpoint: string, err: unknown): Error {
+  const isAbort =
+    err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+  const cause = err instanceof Error ? err.message : String(err);
+  // Surface the underlying cause too — Node wraps DNS/connection errors as
+  // `error.cause` on the outer TypeError; without this the log loses "ENOTFOUND"
+  // / "ECONNREFUSED" specifics.
+  const inner =
+    err instanceof Error && (err as { cause?: unknown }).cause instanceof Error
+      ? `: ${(err as { cause: Error }).cause.message}`
+      : '';
+  if (isAbort) {
+    return new Error(
+      `GitHub API ${method} ${endpoint} timed out after ${GITHUB_API_TIMEOUT_MS}ms`,
+    );
+  }
+  return new Error(`GitHub API ${method} ${endpoint} fetch failed: ${cause}${inner}`);
+}
+
+/**
  * Short one-liner for display summaries ("GITHUB_TOKEN not set"). Kept in one
  * place so the ~7 display call sites (health-check / pr-quality / ci-main-health
  * summaries, wellness-report warning, github-lookup error, pr-patrol index
@@ -229,13 +267,22 @@ export async function githubApi<T = unknown>(
     Accept: 'application/vnd.github+json',
   };
 
-  const fetchOptions: RequestInit = { method, headers };
+  const fetchOptions: RequestInit = {
+    method,
+    headers,
+    signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+  };
   if (body) {
     headers['Content-Type'] = 'application/json';
     fetchOptions.body = JSON.stringify(body);
   }
 
-  const resp = await fetch(url, fetchOptions);
+  let resp: Response;
+  try {
+    resp = await fetch(url, fetchOptions);
+  } catch (e) {
+    throw wrapFetchError(method, endpoint, e);
+  }
 
   if (!resp.ok) {
     const text = await resp.text().catch(() => '(no body)');
@@ -319,14 +366,20 @@ export async function githubGraphQL<T = unknown>(
     }
   }
 
-  const resp = await fetch('https://api.github.com/graphql', {
-    method: 'POST',
-    headers: {
-      Authorization: `bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  let resp: Response;
+  try {
+    resp = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+  } catch (e) {
+    throw wrapFetchError('POST', '/graphql', e);
+  }
 
   if (!resp.ok) {
     const text = await resp.text().catch(() => '(no body)');

--- a/crux/pr-patrol/health-gate.test.ts
+++ b/crux/pr-patrol/health-gate.test.ts
@@ -6,6 +6,7 @@ import {
   fingerprintIssue,
   HEALTH_GATE_COOLDOWN_MINUTES,
   MAX_CONSECUTIVE_SCAN_ERRORS,
+  SCAN_FAILURE_PROCEED_AFTER_MINUTES,
   DISABLE_ENV_VAR,
   type HealthGateDeps,
 } from './health-gate.ts';
@@ -364,6 +365,80 @@ describe('runHealthGate — scanner error', () => {
       },
     });
     expect(decision.proceed).toBe(true);
+  });
+
+  // QUA-823: prolonged scan failures must not halt patrol indefinitely.
+  it(`fails OPEN after ${SCAN_FAILURE_PROCEED_AFTER_MINUTES}min of consecutive failures (regression: indefinite-halt risk)`, async () => {
+    const store = inMemoryCooldown();
+    const baseDeps = makeDeps({ cooldownStore: store });
+    const scan = async () => {
+      throw new Error('GitHub API GET /repos/.../runs fetch failed: ENOTFOUND api.github.com');
+    };
+
+    // Cycle 1 at NOW: first failure starts the streak.
+    await runHealthGate({ ...baseDeps, scan, now: () => NOW });
+
+    // Cycle 2 at NOW + 5min: still in streak, would halt at MAX_CONSECUTIVE.
+    const fiveMinIn = new Date(NOW.getTime() + 5 * 60_000);
+    await runHealthGate({ ...baseDeps, scan, now: () => fiveMinIn });
+
+    // Cycle N at NOW + 31min: streak duration past the threshold.
+    const pastThreshold = new Date(
+      NOW.getTime() + (SCAN_FAILURE_PROCEED_AFTER_MINUTES + 1) * 60_000,
+    );
+    const decision = await runHealthGate({ ...baseDeps, scan, now: () => pastThreshold });
+
+    expect(decision.proceed).toBe(true);
+    expect(decision.bypassed).toBe(false);
+    expect(
+      baseDeps.events.some((e) => e.type === 'health_gate_proceed_blind'),
+    ).toBe(true);
+    // The "proceeding WITHOUT" warning fires loudly so an operator can see it.
+    expect(
+      baseDeps.logs.some((l) => l.includes('proceeding WITHOUT fleet-health visibility')),
+    ).toBe(true);
+  });
+
+  it('records streak duration on every error event so operators can see progress toward fail-open', async () => {
+    const store = inMemoryCooldown();
+    const baseDeps = makeDeps({ cooldownStore: store });
+    const scan = async () => {
+      throw new Error('fetch failed');
+    };
+
+    await runHealthGate({ ...baseDeps, scan, now: () => NOW });
+    const tenMinIn = new Date(NOW.getTime() + 10 * 60_000);
+    await runHealthGate({ ...baseDeps, scan, now: () => tenMinIn });
+
+    const errors = baseDeps.events.filter((e) => e.type === 'health_scan_error');
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toMatchObject({ streak_duration_minutes: 0 });
+    expect(errors[1]).toMatchObject({ streak_duration_minutes: 10 });
+  });
+
+  it('clears the streak start time on a successful scan', async () => {
+    const store = inMemoryCooldown();
+    const baseDeps = makeDeps({ cooldownStore: store });
+
+    // Build up a streak
+    await runHealthGate({
+      ...baseDeps,
+      scan: async () => {
+        throw new Error('blip');
+      },
+      now: () => NOW,
+    });
+    expect(store.getCount('__scan_error_first_at_ms__')).toBeGreaterThan(0);
+
+    // One successful scan resets both markers
+    const tenMinIn = new Date(NOW.getTime() + 10 * 60_000);
+    await runHealthGate({
+      ...baseDeps,
+      scan: async () => healthyScan(),
+      now: () => tenMinIn,
+    });
+    expect(store.getCount('__scan_error_count__')).toBe(0);
+    expect(store.getCount('__scan_error_first_at_ms__')).toBe(0);
   });
 });
 

--- a/crux/pr-patrol/health-gate.ts
+++ b/crux/pr-patrol/health-gate.ts
@@ -42,6 +42,19 @@ export const HEALTH_GATE_COOLDOWN_MINUTES = 30;
  */
 export const MAX_CONSECUTIVE_SCAN_ERRORS = 3;
 
+/**
+ * Maximum wall-clock time the gate is allowed to halt PR work due to a scan-
+ * failure streak. Once the streak has been ongoing for this long, the gate
+ * flips from "halt" back to "proceed with caution" so patrol can resume PR
+ * processing even though we still can't see fleet health.
+ *
+ * Trade-off: prolonged halt vs blind patrol. QUA-823 documented a 3+ hour
+ * outage where the count-based halt blocked every cycle while no real prod
+ * issue existed — the GitHub API was just intermittently unreachable. After
+ * 30min we have to assume the scanner is the broken thing, not prod.
+ */
+export const SCAN_FAILURE_PROCEED_AFTER_MINUTES = 30;
+
 /** Env var to bypass the gate. Value `1` disables it. */
 export const DISABLE_ENV_VAR = 'PATROL_DISABLE_HEALTH_GATE';
 
@@ -50,6 +63,15 @@ const HEALTH_GATE_STATE_FILE = join(STATE_DIR, 'health-gate-cooldown.json');
 
 /** Reserved fingerprint used to track consecutive scan-error count. */
 const SCAN_ERROR_COUNTER_KEY = '__scan_error_count__';
+
+/**
+ * Reserved fingerprint used to track the wall-clock start of the current
+ * scan-failure streak. Stored as a unix-epoch millisecond timestamp via the
+ * count store. `0` means "no streak active" (set on the first success after
+ * a streak ends). Used by `SCAN_FAILURE_PROCEED_AFTER_MINUTES` to decide
+ * when prolonged halts should fail-open instead.
+ */
+const SCAN_ERROR_FIRST_AT_KEY = '__scan_error_first_at_ms__';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -262,13 +284,17 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
   let result: HealthScanResult;
   try {
     result = await scan();
-    // Successful scan — reset the consecutive-error counter so the halt-
-    // threshold only fires on a true streak, not cumulative failures over days.
+    // Successful scan — reset the consecutive-error counter and the streak
+    // start time so the halt-threshold only fires on a true streak, not
+    // cumulative failures over days.
     cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
+    cooldown.setCount?.(SCAN_ERROR_FIRST_AT_KEY, 0);
   } catch (e) {
     // Scanner failed. Policy: a transient GitHub hiccup shouldn't halt PR
     // work. But if the scanner fails N consecutive times, something's wrong
     // with our observability — flip to halt to prevent silent forever-proceed.
+    // Past SCAN_FAILURE_PROCEED_AFTER_MINUTES we flip back to fail-open so a
+    // multi-hour API outage doesn't block patrol indefinitely (QUA-823).
     const message = e instanceof Error ? e.message : String(e);
 
     // Missing-token errors are permanent config faults, not transient.
@@ -279,6 +305,7 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
     // process.env directly and finds it missing.
     if (isMissingTokenError(e)) {
       cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, 0);
+      cooldown.setCount?.(SCAN_ERROR_FIRST_AT_KEY, 0);
       writeEvent({
         type: 'health_gate_missing_token',
         timestamp: now.toISOString(),
@@ -301,12 +328,50 @@ export async function runHealthGate(deps: HealthGateDeps = {}): Promise<HealthGa
     const newCount = prevCount + 1;
     cooldown.setCount?.(SCAN_ERROR_COUNTER_KEY, newCount);
 
+    // Track when the streak began so prolonged failures fail-open by wall
+    // clock, not by cycle count (which depends on patrol interval).
+    const prevFirstAt = cooldown.getCount?.(SCAN_ERROR_FIRST_AT_KEY) ?? 0;
+    const firstAtMs = prevFirstAt > 0 ? prevFirstAt : now.getTime();
+    if (prevFirstAt === 0) {
+      cooldown.setCount?.(SCAN_ERROR_FIRST_AT_KEY, firstAtMs);
+    }
+    const streakDurationMin = (now.getTime() - firstAtMs) / 60_000;
+
     writeEvent({
       type: 'health_scan_error',
       timestamp: now.toISOString(),
       error: message,
       consecutive_errors: newCount,
+      streak_duration_minutes: Math.round(streakDurationMin * 10) / 10,
     });
+
+    // Time-based fail-open: after SCAN_FAILURE_PROCEED_AFTER_MINUTES we
+    // assume the scanner is the broken thing (intermittent network, GitHub
+    // partial outage, DNS hiccup) rather than a real prod incident, and let
+    // patrol resume with a loud warning. The streak markers are kept so a
+    // subsequent successful scan still resets cleanly.
+    if (streakDurationMin >= SCAN_FAILURE_PROCEED_AFTER_MINUTES) {
+      log(
+        `${cl.yellow}⚠ Health scan has been failing for ${streakDurationMin.toFixed(0)}min ` +
+          `(${newCount} cycles) — proceeding WITHOUT fleet-health visibility. ` +
+          `Last error: ${message}${cl.reset}`,
+      );
+      writeEvent({
+        type: 'health_gate_proceed_blind',
+        timestamp: now.toISOString(),
+        consecutive_errors: newCount,
+        streak_duration_minutes: Math.round(streakDurationMin * 10) / 10,
+        last_error: message,
+      });
+      return {
+        proceed: true,
+        reason: '',
+        result: syntheticScanFailureResult(message),
+        emittedIssues: [],
+        suppressedIssues: [],
+        bypassed: false,
+      };
+    }
 
     if (newCount >= MAX_CONSECUTIVE_SCAN_ERRORS) {
       log(


### PR DESCRIPTION
## Summary

Fixes QUA-823 — patrol health-scan was halting PR work for 3+ hours when GitHub API fetches intermittently failed.

Two root issues:
1. `fetch()` calls in `crux/lib/github.ts` had no timeout, so a hung connection blocked the cycle indefinitely. The error message ("fetch failed") didn't name the URL.
2. `runHealthGate` halts at `MAX_CONSECUTIVE_SCAN_ERRORS` (3) with no wall-clock cap, so a multi-hour outage blocks the patrol the entire time.

## Changes

- **`crux/lib/github.ts`**: 30s `AbortSignal.timeout` per request. Wrap fetch errors with method + endpoint context (e.g. `GitHub API GET /repos/.../runs fetch failed: ENOTFOUND api.github.com`).
- **`crux/pr-patrol/health-gate.ts`**: track wall-clock start of each failure streak via `__scan_error_first_at_ms__`. After `SCAN_FAILURE_PROCEED_AFTER_MINUTES` (30) the gate fail-opens with a loud `health_gate_proceed_blind` warning instead of halting indefinitely. Each `health_scan_error` event now records `streak_duration_minutes` so operators can see progress toward fail-open.
- **`.claude/rules/patrol-health-gate.md`**: documents the new failure-mode table.

## Trade-off

The 30-minute cap means a real prod incident *during* a 30+ min API outage won't trip the gate. This is the right call: the count-based halt empirically blocked patrol for 3+ hours during the QUA-823 incident with no real prod issue. Past 30min we assume the scanner is broken, not prod.

## Test plan

- [x] `pnpm vitest run crux/lib/github.test.ts crux/pr-patrol/health-gate.test.ts` — 51 pass (5 new for fetch wrapping, 3 new for time-based fail-open)
- [x] `pnpm vitest run crux/pr-patrol/` — 433 pass
- [x] `pnpm crux w validate gate --no-cache` — 62 checks pass
- [ ] Monitor patrol logs after merge to confirm `health_gate_proceed_blind` events appear (instead of indefinite halts) on the next API blip
