### PR TITLE
Migrate approaches, benchmarks, research-areas to EntityProfileShell (QUA-486)

### DIFF
--- a/apps/web/src/app/approaches/[slug]/page.tsx
+++ b/apps/web/src/app/approaches/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Breadcrumbs } from "@/components/directory";
 import { RelatedPages } from "@/components/RelatedPages";
 import {
   getTypedEntities,
@@ -11,6 +10,11 @@ import {
   type ApproachEntity,
 } from "@/data";
 import { getEntityHref, getWikiHref } from "@/data/entity-nav";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 
 function getApproachSlugs(): string[] {
   return getTypedEntities().filter(isApproach).filter((e) => !e.deprecated).map((e) => e.id);
@@ -69,140 +73,117 @@ export default async function ApproachDetailPage({
     })
     .filter(Boolean) as Array<{ name: string; href: string; type: string }>;
 
-  return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      <Breadcrumbs
-        items={[
-          { label: "Approaches", href: "/approaches" },
-          { label: entity.title },
-        ]}
-      />
+  // Sourcing rollup verdict for the header badge
+  const sourcingSummary = await fetchEntitySourcingSummary([
+    entity.id,
+    entity.stableId ?? "",
+    slug,
+  ]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start gap-5">
-          <div
-            className="shrink-0 w-14 h-14 rounded-xl bg-gradient-to-br from-indigo-500/20 to-indigo-500/5 flex items-center justify-center"
-            aria-hidden="true"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="text-indigo-600 dark:text-indigo-400"
-            >
-              <path d="M12 2L2 7l10 5 10-5-10-5z" />
-              <path d="M2 17l10 5 10-5" />
-              <path d="M2 12l10 5 10-5" />
-            </svg>
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-2xl font-extrabold tracking-tight mb-1">
-              {entity.title}
-            </h1>
-            <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap mt-1">
-              {entity.website && (
-                <a
-                  href={entity.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:text-primary/80 font-medium transition-colors"
-                >
-                  Website &#8599;
-                </a>
-              )}
-              {wikiHref && (
-                <Link
-                  href={wikiHref}
-                  className="text-primary hover:text-primary/80 font-medium transition-colors"
-                >
-                  Wiki article &rarr;
-                </Link>
-              )}
-              <Link
-                href={`/approaches/${slug}/data`}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
-              >
-                Data &rarr;
-              </Link>
-            </div>
-            {entity.description && (
-              <p className="text-sm text-muted-foreground leading-relaxed mt-2 max-w-prose">
-                {entity.description}
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-8">
-        <div className="space-y-8">
-          {/* Custom fields */}
-          {entity.customFields.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold mb-4">Details</h2>
-              <div className="space-y-3">
-                {entity.customFields.map((field) => (
-                  <div
-                    key={field.label}
-                    className="px-4 py-3 rounded-lg border border-border/60 bg-card"
-                  >
-                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      {field.label}
-                    </span>
-                    <p className="text-sm mt-0.5">{field.value}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {/* Related entities */}
-          {relatedEntities.length > 0 && (
-            <section>
-              <h2 className="text-lg font-bold mb-4">Related</h2>
-              <div className="flex flex-wrap gap-2">
-                {relatedEntities.map((ref) => (
-                  <Link
-                    key={ref.href}
-                    href={ref.href}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 bg-card hover:bg-muted/50 text-sm transition-colors"
-                  >
-                    <span className="font-medium">{ref.name}</span>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          )}
-
-          <RelatedPages entityId={entity.id} entity={{ entityType: "approach" }} />
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {entity.tags.length > 0 && (
-            <section className="rounded-xl border border-border p-4">
-              <h3 className="text-sm font-bold mb-3">Tags</h3>
-              <div className="flex flex-wrap gap-1.5">
-                {entity.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </section>
-          )}
-        </div>
-      </div>
+  const avatar = (
+    <div
+      className="w-14 h-14 rounded-xl bg-gradient-to-br from-indigo-500/20 to-indigo-500/5 flex items-center justify-center"
+      aria-hidden="true"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-indigo-600 dark:text-indigo-400"
+      >
+        <path d="M12 2L2 7l10 5 10-5-10-5z" />
+        <path d="M2 17l10 5 10-5" />
+        <path d="M2 12l10 5 10-5" />
+      </svg>
     </div>
+  );
+
+  const headerLinks = [
+    ...(entity.website
+      ? [{ label: "Website", href: entity.website, external: true }]
+      : []),
+    ...(wikiHref ? [{ label: "Wiki article", href: wikiHref }] : []),
+    { label: "Data", href: `/approaches/${slug}/data` },
+  ];
+
+  const sidebar = entity.tags.length > 0 ? (
+    <section className="rounded-xl border border-border p-4">
+      <h3 className="text-sm font-bold mb-3">Tags</h3>
+      <div className="flex flex-wrap gap-1.5">
+        {entity.tags.map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </section>
+  ) : null;
+
+  return (
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Approaches", href: "/approaches" },
+        { label: entity.title },
+      ]}
+      entityId={entity.id}
+      avatar={avatar}
+      title={entity.title}
+      verdict={rollupVerdict}
+      subtitle={entity.description || undefined}
+      headerLinks={headerLinks}
+      sidebar={sidebar}
+    >
+      <div className="space-y-8">
+        {/* Custom fields */}
+        {entity.customFields.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold mb-4">Details</h2>
+            <div className="space-y-3">
+              {entity.customFields.map((field) => (
+                <div
+                  key={field.label}
+                  className="px-4 py-3 rounded-lg border border-border/60 bg-card"
+                >
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    {field.label}
+                  </span>
+                  <p className="text-sm mt-0.5">{field.value}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Related entities */}
+        {relatedEntities.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold mb-4">Related</h2>
+            <div className="flex flex-wrap gap-2">
+              {relatedEntities.map((ref) => (
+                <Link
+                  key={ref.href}
+                  href={ref.href}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border/60 bg-card hover:bg-muted/50 text-sm transition-colors"
+                >
+                  <span className="font-medium">{ref.name}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <RelatedPages entityId={entity.id} entity={{ entityType: "approach" }} />
+      </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/app/benchmarks/[slug]/page.tsx
+++ b/apps/web/src/app/benchmarks/[slug]/page.tsx
@@ -7,6 +7,16 @@ import {
   getBenchmarkResultsFromModels,
 } from "../benchmark-utils";
 import { resolveSlugAlias } from "@/data/factbase";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
+import {
+  computeBenchmarkCoverage,
+  getBenchmarkSignals,
+} from "@/components/coverage/coverage-score";
 
 export function generateStaticParams() {
   return getBenchmarkSlugs().map((slug) => ({ slug }));
@@ -119,213 +129,199 @@ export default async function BenchmarkDetailPage({
       : []),
   ];
 
+  // Sourcing rollup verdict
+  const sourcingSummary = await fetchEntitySourcingSummary([
+    entity.id,
+    entity.stableId ?? "",
+    slug,
+  ]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
+
+  const coverageInput = {
+    category: entity.category,
+    scoringMethod: entity.scoringMethod,
+    introducedDate: entity.introducedDate,
+    maintainer: entity.maintainer,
+    description: entity.description,
+    modelsCount: modelCount,
+    wikiId: entity.wikiId,
+  };
+  const coverageScore = computeBenchmarkCoverage(coverageInput);
+  const coverageSignals = getBenchmarkSignals(coverageInput);
+
+  const titlePills = entity.category ? (
+    <span
+      className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+        CATEGORY_COLORS[entity.category] ?? "bg-gray-100 text-gray-600"
+      }`}
+    >
+      {entity.category.charAt(0).toUpperCase() + entity.category.slice(1)}
+    </span>
+  ) : null;
+
+  const headerLinks = [
+    ...(entity.wikiId
+      ? [{ label: "Wiki page", href: `/wiki/${entity.wikiId}` }]
+      : []),
+    ...(entity.website
+      ? [{ label: "Website", href: entity.website, external: true }]
+      : []),
+    { label: "Data", href: `/benchmarks/${slug}/data` },
+  ];
+
+  const statCards = stats.length > 0 && (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {stats.map((stat) => (
+        <ProfileStatCard key={stat.label} label={stat.label} value={stat.value} />
+      ))}
+    </div>
+  );
+
   return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
-        <Link href="/benchmarks" className="hover:text-foreground transition-colors">
-          Benchmarks
-        </Link>
-        <span>/</span>
-        <span className="text-foreground font-medium">{entity.title}</span>
-      </nav>
-
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-3xl font-extrabold tracking-tight">
-            {entity.title}
-          </h1>
-          {entity.category && (
-            <span
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
-                CATEGORY_COLORS[entity.category] ?? "bg-gray-100 text-gray-600"
-              }`}
-            >
-              {entity.category.charAt(0).toUpperCase() + entity.category.slice(1)}
-            </span>
-          )}
-        </div>
-        {entity.description && (
-          <p className="text-muted-foreground text-sm max-w-3xl leading-relaxed">
-            {entity.description}
-          </p>
-        )}
-        <div className="flex items-center gap-4 mt-3 text-sm">
-          {entity.wikiId && (
-            <Link
-              href={`/wiki/${entity.wikiId}`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              Wiki page &rarr;
-            </Link>
-          )}
-          {entity.website && (
-            <a
-              href={entity.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              Website &rarr;
-            </a>
-          )}
-          <Link
-            href={`/benchmarks/${slug}/data`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Data &rarr;
-          </Link>
-        </div>
-      </div>
-
-      {/* Stat cards */}
-      {stats.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-8">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4"
-            >
-              <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
-                {stat.label}
-              </div>
-              <div className="text-2xl font-bold tabular-nums tracking-tight">
-                {stat.value}
-              </div>
+    <EntityProfileShell
+      breadcrumbs={[
+        { label: "Benchmarks", href: "/benchmarks" },
+        { label: entity.title },
+      ]}
+      entityId={entity.id}
+      title={entity.title}
+      titlePills={titlePills}
+      coverage={{ score: coverageScore, signals: coverageSignals }}
+      verdict={rollupVerdict}
+      subtitle={entity.description || undefined}
+      headerLinks={headerLinks}
+      statCards={statCards}
+    >
+      <div className="space-y-8">
+        {/* Details */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+          {entity.scoringMethod && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">Scoring: </span>
+              <span className="font-medium">{entity.scoringMethod}</span>
             </div>
-          ))}
+          )}
+          {entity.introducedDate && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">Introduced: </span>
+              <span className="font-medium">{entity.introducedDate}</span>
+            </div>
+          )}
+          {entity.maintainer && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">Maintainer: </span>
+              <span className="font-medium">{entity.maintainer}</span>
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Details */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-8 text-sm">
-        {entity.scoringMethod && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">Scoring: </span>
-            <span className="font-medium">{entity.scoringMethod}</span>
-          </div>
-        )}
-        {entity.introducedDate && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">Introduced: </span>
-            <span className="font-medium">{entity.introducedDate}</span>
-          </div>
-        )}
-        {entity.maintainer && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">Maintainer: </span>
-            <span className="font-medium">{entity.maintainer}</span>
-          </div>
-        )}
-      </div>
+        {/* Leaderboard */}
+        {sorted.length > 0 ? (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Leaderboard
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {sorted.length} {sorted.length === 1 ? "model" : "models"}
+              </span>
+            </h2>
+            <div className="border border-border rounded-xl overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-3 text-center w-12">#</th>
+                    <th className="py-2.5 px-3 text-left font-medium">Model</th>
+                    <th className="py-2.5 px-3 text-left font-medium">Developer</th>
+                    <th className="py-2.5 px-3 text-left font-medium w-[40%]">Score</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {sorted.map((row, i) => {
+                    // Bar width: normalize score relative to range, with min bar at 15%
+                    // For lower-is-better benchmarks, invert so lower scores get wider bars
+                    const rawNormalized =
+                      maxScore > minScore
+                        ? (row.score - minScore) / (maxScore - minScore)
+                        : 0.5;
+                    const adjusted = entity.higherIsBetter ? rawNormalized : 1 - rawNormalized;
+                    const barPct = 15 + adjusted * 85;
+                    const barColor =
+                      DEVELOPER_BAR_COLORS[row.developer ?? ""] ??
+                      "bg-primary/20 dark:bg-primary/15";
 
-      {/* Leaderboard */}
-      {sorted.length > 0 ? (
-        <section>
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Leaderboard
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {sorted.length} {sorted.length === 1 ? "model" : "models"}
-            </span>
-          </h2>
-          <div className="border border-border rounded-xl overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="py-2.5 px-3 text-center w-12">#</th>
-                  <th className="py-2.5 px-3 text-left font-medium">Model</th>
-                  <th className="py-2.5 px-3 text-left font-medium">Developer</th>
-                  <th className="py-2.5 px-3 text-left font-medium w-[40%]">Score</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {sorted.map((row, i) => {
-                  // Bar width: normalize score relative to range, with min bar at 15%
-                  // For lower-is-better benchmarks, invert so lower scores get wider bars
-                  const rawNormalized =
-                    maxScore > minScore
-                      ? (row.score - minScore) / (maxScore - minScore)
-                      : 0.5;
-                  const adjusted = entity.higherIsBetter ? rawNormalized : 1 - rawNormalized;
-                  const barPct = 15 + adjusted * 85;
-                  const barColor =
-                    DEVELOPER_BAR_COLORS[row.developer ?? ""] ??
-                    "bg-primary/20 dark:bg-primary/15";
-
-                  return (
-                    <tr
-                      key={row.modelId}
-                      className={`hover:bg-muted/20 transition-colors ${
-                        i < 3 ? "font-medium" : ""
-                      }`}
-                    >
-                      <td className="py-2.5 px-3 text-center text-muted-foreground tabular-nums">
-                        {i === 0 ? (
-                          <span className="text-amber-500" title="1st place">
-                            {"\uD83E\uDD47"}
-                          </span>
-                        ) : i === 1 ? (
-                          <span className="text-gray-400" title="2nd place">
-                            {"\uD83E\uDD48"}
-                          </span>
-                        ) : i === 2 ? (
-                          <span className="text-orange-400" title="3rd place">
-                            {"\uD83E\uDD49"}
-                          </span>
-                        ) : (
-                          i + 1
-                        )}
-                      </td>
-                      <td className="py-2.5 px-3">
-                        <Link
-                          href={`/ai-models/${row.modelId}`}
-                          className="hover:text-primary transition-colors"
-                        >
-                          {row.modelTitle}
-                        </Link>
-                      </td>
-                      <td className="py-2.5 px-3">
-                        {row.developer && row.developerName && (
-                          <span
-                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                              DEVELOPER_COLORS[row.developer] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-                            }`}
+                    return (
+                      <tr
+                        key={row.modelId}
+                        className={`hover:bg-muted/20 transition-colors ${
+                          i < 3 ? "font-medium" : ""
+                        }`}
+                      >
+                        <td className="py-2.5 px-3 text-center text-muted-foreground tabular-nums">
+                          {i === 0 ? (
+                            <span className="text-amber-500" title="1st place">
+                              {"🥇"}
+                            </span>
+                          ) : i === 1 ? (
+                            <span className="text-gray-400" title="2nd place">
+                              {"🥈"}
+                            </span>
+                          ) : i === 2 ? (
+                            <span className="text-orange-400" title="3rd place">
+                              {"🥉"}
+                            </span>
+                          ) : (
+                            i + 1
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3">
+                          <Link
+                            href={`/ai-models/${row.modelId}`}
+                            className="hover:text-primary transition-colors"
                           >
-                            {row.developerName}
-                          </span>
-                        )}
-                      </td>
-                      <td className="py-2.5 px-3">
-                        <div className="flex items-center gap-2">
-                          <div className="flex-1 relative h-5 rounded-md bg-muted/30 overflow-hidden">
-                            <div
-                              className={`absolute inset-y-0 left-0 rounded-md ${barColor} transition-all`}
-                              style={{ width: `${barPct}%` }}
-                            />
+                            {row.modelTitle}
+                          </Link>
+                        </td>
+                        <td className="py-2.5 px-3">
+                          {row.developer && row.developerName && (
                             <span
-                              className={`absolute inset-y-0 flex items-center px-2 text-xs tabular-nums ${
-                                i < 3 ? "font-bold" : "font-semibold"
+                              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                                DEVELOPER_COLORS[row.developer] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
                               }`}
                             >
-                              {formatScore(row.score, row.unit)}
+                              {row.developerName}
                             </span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3">
+                          <div className="flex items-center gap-2">
+                            <div className="flex-1 relative h-5 rounded-md bg-muted/30 overflow-hidden">
+                              <div
+                                className={`absolute inset-y-0 left-0 rounded-md ${barColor} transition-all`}
+                                style={{ width: `${barPct}%` }}
+                              />
+                              <span
+                                className={`absolute inset-y-0 flex items-center px-2 text-xs tabular-nums ${
+                                  i < 3 ? "font-bold" : "font-semibold"
+                                }`}
+                              >
+                                {formatScore(row.score, row.unit)}
+                              </span>
+                            </div>
                           </div>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ) : (
+          <div className="text-center py-12 text-muted-foreground border border-border/60 rounded-xl bg-card">
+            No model scores recorded for this benchmark yet.
           </div>
-        </section>
-      ) : (
-        <div className="text-center py-12 text-muted-foreground border border-border/60 rounded-xl bg-card">
-          No model scores recorded for this benchmark yet.
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </EntityProfileShell>
   );
 }
 

--- a/apps/web/src/app/research-areas/[slug]/page.tsx
+++ b/apps/web/src/app/research-areas/[slug]/page.tsx
@@ -9,6 +9,12 @@ import {
   formatCluster,
   formatFunding,
 } from "../research-area-constants";
+import { ProfileStatCard } from "@/components/directory";
+import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
+import {
+  fetchEntitySourcingSummary,
+  rollupVerdictFromSummary,
+} from "@/components/entity/entity-sourcing";
 
 // ---------------------------------------------------------------------------
 // Data helpers
@@ -94,424 +100,396 @@ export default async function ResearchAreaDetailPage({
     { label: "Risks Addressed", value: String(area.riskCount) },
   ].filter((s) => s.value !== "0" && s.value !== "-");
 
-  return (
-    <div className="max-w-[70rem] mx-auto px-6 py-8">
-      {/* Breadcrumbs */}
-      <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
-        <Link
-          href="/research-areas"
-          className="hover:text-foreground transition-colors"
-        >
-          Research Areas
-        </Link>
-        {parent && (
-          <>
-            <span>/</span>
-            <Link
-              href={`/research-areas/${parent.id}`}
-              className="hover:text-foreground transition-colors"
-            >
-              {parent.title}
-            </Link>
-          </>
-        )}
-        <span>/</span>
-        <span className="text-foreground font-medium">{area.title}</span>
-      </nav>
+  // Sourcing rollup verdict
+  const sourcingSummary = await fetchEntitySourcingSummary([area.id, slug]);
+  const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2 flex-wrap">
-          <h1 className="text-3xl font-extrabold tracking-tight">
-            {area.title}
-          </h1>
-          {area.cluster && (
-            <span
-              className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
-                CLUSTER_COLORS[area.cluster] ?? "bg-gray-100 text-gray-600"
-              }`}
-            >
-              {formatCluster(area.cluster)}
-            </span>
-          )}
+  const breadcrumbs: Array<{ label: string; href?: string }> = [
+    { label: "Research Areas", href: "/research-areas" },
+  ];
+  if (parent) {
+    breadcrumbs.push({
+      label: parent.title,
+      href: `/research-areas/${parent.id}`,
+    });
+  }
+  breadcrumbs.push({ label: area.title });
+
+  const titlePills = (
+    <>
+      {area.cluster && (
+        <span
+          className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
+            CLUSTER_COLORS[area.cluster] ?? "bg-gray-100 text-gray-600"
+          }`}
+        >
+          {formatCluster(area.cluster)}
+        </span>
+      )}
+      <span
+        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+          STATUS_COLORS[area.status] ?? ""
+        }`}
+      >
+        {area.status}
+      </span>
+    </>
+  );
+
+  const headerLinks = [
+    ...(area.wikiId
+      ? [{ label: "Wiki page", href: `/wiki/${area.wikiId}` }]
+      : []),
+    { label: "Data", href: `/research-areas/${slug}/data` },
+  ];
+
+  const statCards = stats.length > 0 && (
+    <div
+      className={`grid grid-cols-2 gap-3 ${stats.length >= 4 ? "sm:grid-cols-4" : stats.length >= 3 ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}
+    >
+      {stats.map((stat) => (
+        <ProfileStatCard key={stat.label} label={stat.label} value={stat.value} />
+      ))}
+    </div>
+  );
+
+  const sidebar = area.tags.length > 0 ? (
+    <section className="rounded-xl border border-border p-4">
+      <h3 className="text-sm font-bold mb-3">Tags</h3>
+      <div className="flex flex-wrap gap-1.5">
+        {area.tags.map((tag) => (
           <span
-            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-              STATUS_COLORS[area.status] ?? ""
-            }`}
+            key={tag}
+            className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground"
           >
-            {area.status}
+            {tag}
           </span>
-        </div>
-        {area.description && (
-          <p className="text-muted-foreground text-sm max-w-3xl leading-relaxed">
-            {area.description}
-          </p>
-        )}
-        <div className="flex items-center gap-4 mt-3 text-sm">
-          {area.wikiId && (
-            <Link
-              href={`/wiki/${area.wikiId}`}
-              className="text-primary hover:text-primary/80 font-medium transition-colors"
-            >
-              Wiki page &rarr;
-            </Link>
-          )}
-          <Link
-            href={`/research-areas/${slug}/data`}
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Data &rarr;
-          </Link>
-        </div>
+        ))}
       </div>
+    </section>
+  ) : null;
 
-      {/* Stat cards */}
-      {stats.length > 0 && (
-        <div
-          className={`grid grid-cols-2 gap-3 mb-8 ${stats.length >= 4 ? "sm:grid-cols-4" : stats.length >= 3 ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}
-        >
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4"
-            >
-              <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1">
-                {stat.label}
-              </div>
-              <div className="text-2xl font-bold tabular-nums tracking-tight">
-                {stat.value}
-              </div>
+  return (
+    <EntityProfileShell
+      breadcrumbs={breadcrumbs}
+      entityId={area.id}
+      title={area.title}
+      titlePills={titlePills}
+      verdict={rollupVerdict}
+      subtitle={area.description || undefined}
+      headerLinks={headerLinks}
+      statCards={statCards}
+      sidebar={sidebar}
+    >
+      <div className="space-y-8">
+        {/* Details */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+          {area.firstProposed && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">First Proposed: </span>
+              <span className="font-medium">{area.firstProposed}</span>
             </div>
-          ))}
-        </div>
-      )}
-
-      {/* Details */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-8 text-sm">
-        {area.firstProposed && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">First Proposed: </span>
-            <span className="font-medium">{area.firstProposed}</span>
-          </div>
-        )}
-        {area.cluster && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">Cluster: </span>
-            <span className="font-medium">{formatCluster(area.cluster)}</span>
-          </div>
-        )}
-        {parent && (
-          <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
-            <span className="text-muted-foreground">Parent Area: </span>
-            <Link
-              href={`/research-areas/${parent.id}`}
-              className="font-medium text-primary hover:text-primary/80"
-            >
-              {parent.title}
-            </Link>
-          </div>
-        )}
-      </div>
-
-      {/* Tags */}
-      {area.tags.length > 0 && (
-        <div className="mb-8">
-          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Tags
-          </h2>
-          <div className="flex flex-wrap gap-1.5">
-            {area.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-muted text-muted-foreground"
+          )}
+          {area.cluster && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">Cluster: </span>
+              <span className="font-medium">{formatCluster(area.cluster)}</span>
+            </div>
+          )}
+          {parent && (
+            <div className="px-4 py-3 rounded-lg border border-border/60 bg-card">
+              <span className="text-muted-foreground">Parent Area: </span>
+              <Link
+                href={`/research-areas/${parent.id}`}
+                className="font-medium text-primary hover:text-primary/80"
               >
-                {tag}
+                {parent.title}
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* Organizations */}
+        {organizations.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Organizations
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {organizations.length}
               </span>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Organizations */}
-      {organizations.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Organizations
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {organizations.length}
-            </span>
-          </h2>
-          <div className="border border-border rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="py-2.5 px-3 text-left font-medium">
-                    Organization
-                  </th>
-                  <th className="py-2.5 px-3 text-left font-medium">Role</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {organizations.map((org) => {
-                  const resolved = resolveEntityLink(org.organizationId);
-                  return (
-                    <tr
-                      key={org.organizationId}
-                      className="hover:bg-muted/20 transition-colors"
-                    >
-                      <td className="py-2.5 px-3">
-                        {resolved.href ? (
-                          <Link
-                            href={resolved.href}
-                            className="font-medium hover:text-primary transition-colors"
-                          >
-                            {resolved.name}
-                          </Link>
-                        ) : (
-                          <span className="font-medium">{resolved.name}</span>
-                        )}
-                      </td>
-                      <td className="py-2.5 px-3 text-muted-foreground capitalize">
-                        {org.role}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Grants */}
-      {grants.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Grants
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {area.grantCount > grants.length
-                ? `Top ${grants.length} of ${area.grantCount}`
-                : grants.length}
-            </span>
-          </h2>
-          <div className="border border-border rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="py-2.5 px-3 text-left font-medium">Name</th>
-                  <th className="py-2.5 px-3 text-left font-medium">
-                    Recipient
-                  </th>
-                  <th className="py-2.5 px-3 text-right font-medium">
-                    Amount
-                  </th>
-                  <th className="py-2.5 px-3 text-left font-medium">Funder</th>
-                  <th className="py-2.5 px-3 text-left font-medium">Date</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {grants.map((grant) => {
-                  const funder = resolveEntityName(grant.organizationId);
-                  const grantee = grant.granteeId
-                    ? resolveEntityName(grant.granteeId)
-                    : null;
-                  return (
-                    <tr
-                      key={grant.id}
-                      className="hover:bg-muted/20 transition-colors"
-                    >
-                      <td className="py-2.5 px-3 max-w-[20rem]">
-                        <span className="line-clamp-1">{grant.name}</span>
-                      </td>
-                      <td className="py-2.5 px-3 text-muted-foreground">
-                        {grantee ?? "-"}
-                      </td>
-                      <td className="py-2.5 px-3 text-right tabular-nums">
-                        {grant.amount
-                          ? formatFunding(String(grant.amount))
-                          : "-"}
-                      </td>
-                      <td className="py-2.5 px-3 text-muted-foreground">
-                        {funder}
-                      </td>
-                      <td className="py-2.5 px-3 text-muted-foreground">
-                        {grant.date ?? "-"}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Funding by Funder */}
-      {fundingByOrg.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Funding by Funder
-          </h2>
-          <div className="border border-border rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="py-2.5 px-3 text-left font-medium">Funder</th>
-                  <th className="py-2.5 px-3 text-right font-medium">
-                    Grants
-                  </th>
-                  <th className="py-2.5 px-3 text-right font-medium">
-                    Total Amount
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {fundingByOrg.map((f) => {
-                  const resolved = resolveEntityLink(f.organizationId);
-                  return (
-                    <tr
-                      key={f.organizationId}
-                      className="hover:bg-muted/20 transition-colors"
-                    >
-                      <td className="py-2.5 px-3">
-                        {resolved.href ? (
-                          <Link
-                            href={resolved.href}
-                            className="font-medium hover:text-primary transition-colors"
-                          >
-                            {resolved.name}
-                          </Link>
-                        ) : (
-                          <span className="font-medium">{resolved.name}</span>
-                        )}
-                      </td>
-                      <td className="py-2.5 px-3 text-right tabular-nums">
-                        {f.grantCount}
-                      </td>
-                      <td className="py-2.5 px-3 text-right tabular-nums">
-                        {formatFunding(f.totalAmount)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* Key Papers / Resources */}
-      {papers.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Key Papers &amp; Resources
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {papers.length}
-            </span>
-          </h2>
-          <div className="space-y-2">
-            {papers.map((paper) => (
-              <div
-                key={paper.id}
-                className="px-4 py-3 rounded-lg border border-border/60 bg-card"
-              >
-                <div className="flex items-start gap-2">
-                  {paper.isSeminal && (
-                    <span className="mt-0.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-                      SEMINAL
-                    </span>
-                  )}
-                  <div className="flex-1 min-w-0">
-                    {paper.url ? (
-                      <a
-                        href={paper.url}
-                        className="font-medium text-sm hover:text-primary transition-colors"
-                        target="_blank"
-                        rel="noopener noreferrer"
+            </h2>
+            <div className="border border-border rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-3 text-left font-medium">
+                      Organization
+                    </th>
+                    <th className="py-2.5 px-3 text-left font-medium">Role</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {organizations.map((org) => {
+                    const resolved = resolveEntityLink(org.organizationId);
+                    return (
+                      <tr
+                        key={org.organizationId}
+                        className="hover:bg-muted/20 transition-colors"
                       >
-                        {paper.title}
-                      </a>
-                    ) : (
-                      <span className="font-medium text-sm">{paper.title}</span>
+                        <td className="py-2.5 px-3">
+                          {resolved.href ? (
+                            <Link
+                              href={resolved.href}
+                              className="font-medium hover:text-primary transition-colors"
+                            >
+                              {resolved.name}
+                            </Link>
+                          ) : (
+                            <span className="font-medium">{resolved.name}</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3 text-muted-foreground capitalize">
+                          {org.role}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Grants */}
+        {grants.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Grants
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {area.grantCount > grants.length
+                  ? `Top ${grants.length} of ${area.grantCount}`
+                  : grants.length}
+              </span>
+            </h2>
+            <div className="border border-border rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-3 text-left font-medium">Name</th>
+                    <th className="py-2.5 px-3 text-left font-medium">
+                      Recipient
+                    </th>
+                    <th className="py-2.5 px-3 text-right font-medium">
+                      Amount
+                    </th>
+                    <th className="py-2.5 px-3 text-left font-medium">Funder</th>
+                    <th className="py-2.5 px-3 text-left font-medium">Date</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {grants.map((grant) => {
+                    const funder = resolveEntityName(grant.organizationId);
+                    const grantee = grant.granteeId
+                      ? resolveEntityName(grant.granteeId)
+                      : null;
+                    return (
+                      <tr
+                        key={grant.id}
+                        className="hover:bg-muted/20 transition-colors"
+                      >
+                        <td className="py-2.5 px-3 max-w-[20rem]">
+                          <span className="line-clamp-1">{grant.name}</span>
+                        </td>
+                        <td className="py-2.5 px-3 text-muted-foreground">
+                          {grantee ?? "-"}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums">
+                          {grant.amount
+                            ? formatFunding(String(grant.amount))
+                            : "-"}
+                        </td>
+                        <td className="py-2.5 px-3 text-muted-foreground">
+                          {funder}
+                        </td>
+                        <td className="py-2.5 px-3 text-muted-foreground">
+                          {grant.date ?? "-"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Funding by Funder */}
+        {fundingByOrg.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Funding by Funder
+            </h2>
+            <div className="border border-border rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-3 text-left font-medium">Funder</th>
+                    <th className="py-2.5 px-3 text-right font-medium">
+                      Grants
+                    </th>
+                    <th className="py-2.5 px-3 text-right font-medium">
+                      Total Amount
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {fundingByOrg.map((f) => {
+                    const resolved = resolveEntityLink(f.organizationId);
+                    return (
+                      <tr
+                        key={f.organizationId}
+                        className="hover:bg-muted/20 transition-colors"
+                      >
+                        <td className="py-2.5 px-3">
+                          {resolved.href ? (
+                            <Link
+                              href={resolved.href}
+                              className="font-medium hover:text-primary transition-colors"
+                            >
+                              {resolved.name}
+                            </Link>
+                          ) : (
+                            <span className="font-medium">{resolved.name}</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums">
+                          {f.grantCount}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums">
+                          {formatFunding(f.totalAmount)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Key Papers / Resources */}
+        {papers.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Key Papers &amp; Resources
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {papers.length}
+              </span>
+            </h2>
+            <div className="space-y-2">
+              {papers.map((paper) => (
+                <div
+                  key={paper.id}
+                  className="px-4 py-3 rounded-lg border border-border/60 bg-card"
+                >
+                  <div className="flex items-start gap-2">
+                    {paper.isSeminal && (
+                      <span className="mt-0.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                        SEMINAL
+                      </span>
                     )}
-                    <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
-                      {paper.authors && <span>{paper.authors}</span>}
-                      {paper.publishedDate && <span>{paper.publishedDate}</span>}
-                      {paper.citationCount != null &&
-                        paper.citationCount > 0 && (
-                          <span>{paper.citationCount} citations</span>
-                        )}
+                    <div className="flex-1 min-w-0">
+                      {paper.url ? (
+                        <a
+                          href={paper.url}
+                          className="font-medium text-sm hover:text-primary transition-colors"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {paper.title}
+                        </a>
+                      ) : (
+                        <span className="font-medium text-sm">{paper.title}</span>
+                      )}
+                      <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
+                        {paper.authors && <span>{paper.authors}</span>}
+                        {paper.publishedDate && <span>{paper.publishedDate}</span>}
+                        {paper.citationCount != null &&
+                          paper.citationCount > 0 && (
+                            <span>{paper.citationCount} citations</span>
+                          )}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+              ))}
+            </div>
+          </section>
+        )}
 
-      {/* Child areas */}
-      {children.length > 0 && (
-        <section className="mb-8">
-          <h2 className="text-lg font-bold tracking-tight mb-4">
-            Sub-Areas
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {children.length}
-            </span>
-          </h2>
-          <div className="border border-border rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
-                  <th className="py-2.5 px-3 text-left font-medium">Name</th>
-                  <th className="py-2.5 px-3 text-left font-medium">Status</th>
-                  <th className="py-2.5 px-3 text-right font-medium">Orgs</th>
-                  <th className="py-2.5 px-3 text-right font-medium">
-                    Papers
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {children.map((child) => (
-                  <tr
-                    key={child.id}
-                    className="hover:bg-muted/20 transition-colors"
-                  >
-                    <td className="py-2.5 px-3">
-                      <Link
-                        href={`/research-areas/${child.id}`}
-                        className="font-medium hover:text-primary transition-colors"
-                      >
-                        {child.title}
-                      </Link>
-                      {child.description && (
-                        <span className="block text-xs text-muted-foreground line-clamp-1 mt-0.5">
-                          {child.description}
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2.5 px-3">
-                      <span
-                        className={`text-xs font-medium ${
-                          STATUS_COLORS[child.status] ?? ""
-                        }`}
-                      >
-                        {child.status}
-                      </span>
-                    </td>
-                    <td className="py-2.5 px-3 text-right tabular-nums">
-                      {child.orgCount ?? "-"}
-                    </td>
-                    <td className="py-2.5 px-3 text-right tabular-nums">
-                      {child.paperCount ?? "-"}
-                    </td>
+        {/* Child areas */}
+        {children.length > 0 && (
+          <section>
+            <h2 className="text-lg font-bold tracking-tight mb-4">
+              Sub-Areas
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {children.length}
+              </span>
+            </h2>
+            <div className="border border-border rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-muted-foreground border-b border-border bg-muted/30">
+                    <th className="py-2.5 px-3 text-left font-medium">Name</th>
+                    <th className="py-2.5 px-3 text-left font-medium">Status</th>
+                    <th className="py-2.5 px-3 text-right font-medium">Orgs</th>
+                    <th className="py-2.5 px-3 text-right font-medium">
+                      Papers
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-    </div>
+                </thead>
+                <tbody className="divide-y divide-border/50">
+                  {children.map((child) => (
+                    <tr
+                      key={child.id}
+                      className="hover:bg-muted/20 transition-colors"
+                    >
+                      <td className="py-2.5 px-3">
+                        <Link
+                          href={`/research-areas/${child.id}`}
+                          className="font-medium hover:text-primary transition-colors"
+                        >
+                          {child.title}
+                        </Link>
+                        {child.description && (
+                          <span className="block text-xs text-muted-foreground line-clamp-1 mt-0.5">
+                            {child.description}
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2.5 px-3">
+                        <span
+                          className={`text-xs font-medium ${
+                            STATUS_COLORS[child.status] ?? ""
+                          }`}
+                        >
+                          {child.status}
+                        </span>
+                      </td>
+                      <td className="py-2.5 px-3 text-right tabular-nums">
+                        {child.orgCount ?? "-"}
+                      </td>
+                      <td className="py-2.5 px-3 text-right tabular-nums">
+                        {child.paperCount ?? "-"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </div>
+    </EntityProfileShell>
   );
 }

--- a/apps/web/src/components/coverage/coverage-score.ts
+++ b/apps/web/src/components/coverage/coverage-score.ts
@@ -248,6 +248,19 @@ export function computeBenchmarkCoverage(row: BenchmarkCoverageInput): number {
   return 1;
 }
 
+export function getBenchmarkSignals(row: BenchmarkCoverageInput): string[] {
+  const signals: string[] = [];
+  if (row.description) signals.push("Description");
+  if (row.category) signals.push("Category");
+  if (row.scoringMethod) signals.push("Scoring method");
+  if (row.introducedDate) signals.push("Introduced date");
+  if (row.maintainer) signals.push("Maintainer");
+  if ((row.modelsCount ?? 0) >= 3) signals.push("3+ models tested");
+  if ((row.modelsCount ?? 0) >= 10) signals.push("10+ models tested");
+  if (row.wikiId) signals.push("Wiki page");
+  return signals;
+}
+
 // ── Grant scoring ───────────────────────────────────────────────────
 
 export interface GrantCoverageInput {


### PR DESCRIPTION
## Summary

Part 2 of QUA-362. Migrates three more entity-detail pages to use `<EntityProfileShell>`:

- `apps/web/src/app/approaches/[slug]/page.tsx` (208 → 188 lines)
- `apps/web/src/app/benchmarks/[slug]/page.tsx` (340 → 326 lines)
- `apps/web/src/app/research-areas/[slug]/page.tsx` (517 → 458 lines)

All three use the **children + sidebar** pattern (no tabs), matching `projects/[slug]` from QUA-485.

### What changed per page

- **approaches**: tetrahedron avatar passed via `avatar` slot; tags stay in sidebar; `customFields` / related entities / `RelatedPages` move into the body. Wiki-redirect logic preserved.
- **benchmarks**: category badge as title pill; 3 stat cards now use shared `ProfileStatCard`; details (scoring/introduced/maintainer) and the leaderboard render in the body. Adds `coverage` popover via existing `computeBenchmarkCoverage` + new `getBenchmarkSignals` helper.
- **research-areas**: 3-level breadcrumb (`Research Areas / Parent / Child`) preserved by passing parent into the breadcrumbs array; cluster + status pills in title row; 5 stat cards via `ProfileStatCard`; tags in sidebar; all relational tables (orgs / grants / funding / papers / sub-areas) in body.

### New helper

Adds `getBenchmarkSignals` to `coverage-score.ts`, matching the existing `getXxxSignals` pattern (4 prior helpers — ai-model, org, person, legislation).

### No new wrapper components

Per acceptance criteria — all chrome lives in the shared `EntityProfileShell`.

## Test plan

- [x] `pnpm build` passes (all three SSG'd: 86 approaches, 19 benchmarks, 85 research-areas)
- [x] `pnpm crux w validate gate --fix` — 64/64 checks pass (3 advisory warnings unrelated)
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean (no-floating-promises gate)
- [x] Smoke-tested with Playwright against local dev server:
  - `/approaches/ai-litigation-democracy` — 200, h1 present, no error markers
  - `/benchmarks/mmlu`, `/benchmarks/swe-bench-verified` — 200
  - `/research-areas/ai-control` (no parent), `/research-areas/circuit-breakers` (sub-area) — 200
- [x] 3-level breadcrumb verified on sub-area page (`Research Areas / AI Control / Circuit Breakers`)
- [x] `/data` sub-routes still 200

Closes QUA-486
