### PR TITLE
Backfill missing scorecard publisher entities (QUA-836)

### DIFF
--- a/data/entities/organizations.yaml
+++ b/data/entities/organizations.yaml
@@ -9577,3 +9577,58 @@
     Cloud-computing arm of Alibaba Group. Develops the Qwen series of
     foundation models. Surfaced through FLI AI Safety Index ingestion.
 
+# QUA-836 — backfill missing scorecard publisher entities (Stanford CRFM, Midas Project)
+- id: stanford-crfm
+  stableId: sid_sZYjreyZPA
+  wikiId: E2535
+  type: organization
+  orgType: academic
+  title: Stanford Center for Research on Foundation Models (CRFM)
+  aliases:
+    - CRFM
+    - Stanford CRFM
+    - Center for Research on Foundation Models
+  website: https://crfm.stanford.edu
+  description: >-
+    Interdisciplinary research center at Stanford HAI founded in 2021 to
+    advance research on foundation models. Coined the term "foundation model"
+    in its 2021 report "On the Opportunities and Risks of Foundation Models."
+    Publishes the Foundation Model Transparency Index (FMTI), a recurring
+    scorecard evaluating major model developers across domains, resources,
+    and downstream impact. Led by Percy Liang.
+  tags:
+    - ai-safety
+    - ai-governance
+    - foundation-models
+    - academic
+    - transparency
+  relatedEntries:
+    - id: stanford-university
+      type: organization
+      relationship: part-of
+    - id: stanford-hai
+      type: organization
+      relationship: part-of
+  lastUpdated: 2026-04
+
+- id: the-midas-project
+  stableId: sid_iIWDCVhdBw
+  wikiId: E2536
+  type: organization
+  orgType: safety-org
+  title: The Midas Project
+  aliases:
+    - Midas Project
+  website: https://www.themidasproject.com
+  description: >-
+    Nonprofit AI corporate accountability watchdog. Tracks AI labs' safety
+    commitments and policy positions, publishes the Seoul Tracker monitoring
+    signatories' implementation of the 2024 AI Seoul Summit Frontier AI
+    Safety Commitments.
+  tags:
+    - ai-safety
+    - ai-governance
+    - corporate-accountability
+    - transparency
+  lastUpdated: 2026-04
+

--- a/data/entities/people.yaml
+++ b/data/entities/people.yaml
@@ -7864,3 +7864,23 @@
   type: person
   title: Hugo Zylberberg
   description: Co-founder of The Future Society.
+
+# QUA-836 — backfill missing scorecard publisher entity
+- id: zach-stein-perlman
+  stableId: sid_vYltmfWMag
+  wikiId: E2537
+  type: person
+  title: Zach Stein-Perlman
+  description: >-
+    AI safety researcher and sole maintainer of AI Lab Watch
+    (ailabwatch.org), an independent project evaluating frontier AI labs
+    on their safety commitments and practices. Publishes regular analyses
+    of lab policy changes on the AI Lab Watch Substack.
+  tags:
+    - ai-safety-advocacy
+    - ai-governance
+    - transparency
+  customFields:
+    - label: Role
+      value: Founder & sole maintainer, AI Lab Watch
+  lastUpdated: 2026-04


### PR DESCRIPTION
## Summary

Adds 3 entities referenced by the AI safety scorecards mirrored under QUA-688 that were missing from the wiki entity catalog:

| Publisher | Entity | URL |
| -- | -- | -- |
| Stanford CRFM | `stanford-crfm` (E2535) | `/organizations/stanford-crfm` |
| The Midas Project | `the-midas-project` (E2536) | `/organizations/the-midas-project` |
| Zach Stein-Perlman | `zach-stein-perlman` (E2537) | `/people/zach-stein-perlman` |

Stanford CRFM publishes the Foundation Model Transparency Index (FMTI). The Midas Project publishes the Seoul Tracker. Zach Stein-Perlman is the sole maintainer of AI Lab Watch. Unblocks the panel-header internal-link work in NEW-3 — those publishers can now be linked to live wiki pages instead of 404s.

Lightweight YAML-only entries per the issue's "stub OK" guidance — sufficient to satisfy the acceptance criteria. The 5 scorecard publishers are now all in-catalog (FLI ✓, SaferAI ✓, Stanford CRFM ✓, The Midas Project ✓, Zach Stein-Perlman ✓).

## Test plan

- [x] `pnpm crux w validate gate --fix` → all 64 checks pass (3 unrelated advisory warnings)
- [x] `/organizations/stanford-crfm` → 200 (verified locally)
- [x] `/organizations/the-midas-project` → 200 (verified locally)
- [x] `/people/zach-stein-perlman` → 200 (verified locally)
- [x] CI passes

Fixes QUA-836
