### PR TITLE
QUA-837: add /scorecards/[source] per-scorecard detail route

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -116,6 +116,8 @@ const SIMPLE_PAGES = [
   "/data-sources/ea-funds",  // Data source detail page (QUA-81)
   "/frontier-safety-frameworks",  // QUA-709 directory page
   "/frontier-safety-frameworks/methodology",  // QUA-709 methodology
+  "/scorecards",  // QUA-688 scorecards directory
+  "/scorecards/fli_index",  // QUA-837 per-scorecard detail route
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/scorecards/[source]/__tests__/matrix.test.ts
+++ b/apps/web/src/app/scorecards/[source]/__tests__/matrix.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { buildOrgDimensionMatrix, type MatrixGrade } from "../matrix";
+
+function grade(
+  entityId: string,
+  displayName: string,
+  slug: string | null,
+  dimensionSlug: string,
+  dimensionLabel: string,
+  scoreLetter: string | null = null,
+  scoreNumeric: number | null = null,
+  scoreRaw: string = "",
+): MatrixGrade {
+  return {
+    entityId,
+    entityDisplayName: displayName,
+    entitySlug: slug,
+    dimensionSlug,
+    dimensionLabel,
+    scoreLetter,
+    scoreNumeric,
+    scoreRaw,
+  };
+}
+
+describe("buildOrgDimensionMatrix", () => {
+  it("returns empty result for an empty grade list", () => {
+    const result = buildOrgDimensionMatrix([]);
+    expect(result.orgRows).toEqual([]);
+    expect(result.dimensionOrder).toEqual([]);
+    expect(result.hasOverall).toBe(false);
+  });
+
+  it("groups grades by entity and dimension", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Anthropic", "anthropic", "current-harms", "Current Harms", "B"),
+      grade("e1", "Anthropic", "anthropic", "existential-safety", "Existential Safety", "C+"),
+      grade("e2", "OpenAI", "openai", "current-harms", "Current Harms", "C"),
+    ]);
+    expect(result.orgRows).toHaveLength(2);
+    expect(result.orgRows[0].displayName).toBe("Anthropic");
+    expect(result.orgRows[0].cells["current-harms"]?.scoreLetter).toBe("B");
+    expect(result.orgRows[0].cells["existential-safety"]?.scoreLetter).toBe("C+");
+    expect(result.orgRows[1].displayName).toBe("OpenAI");
+    expect(result.orgRows[1].cells["current-harms"]?.scoreLetter).toBe("C");
+  });
+
+  it("sorts orgs alphabetically by displayName", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e3", "xAI", null, "overall", "Overall"),
+      grade("e1", "Anthropic", "anthropic", "overall", "Overall"),
+      grade("e2", "OpenAI", "openai", "overall", "Overall"),
+    ]);
+    expect(result.orgRows.map((r) => r.displayName)).toEqual([
+      "Anthropic",
+      "OpenAI",
+      "xAI",
+    ]);
+  });
+
+  it("places `overall` as the leftmost dimension when present", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Anthropic", "a", "current-harms", "Current Harms"),
+      grade("e1", "Anthropic", "a", "overall", "Overall"),
+      grade("e1", "Anthropic", "a", "governance", "Governance"),
+    ]);
+    expect(result.dimensionOrder.map((d) => d.slug)).toEqual([
+      "overall",
+      "current-harms",
+      "governance",
+    ]);
+    expect(result.hasOverall).toBe(true);
+  });
+
+  it("returns hasOverall=false when no overall dimension present", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Anthropic", "a", "governance", "Governance"),
+      grade("e1", "Anthropic", "a", "current-harms", "Current Harms"),
+    ]);
+    expect(result.hasOverall).toBe(false);
+    // Alphabetical order by label: "Current Harms" < "Governance"
+    expect(result.dimensionOrder.map((d) => d.slug)).toEqual([
+      "current-harms",
+      "governance",
+    ]);
+  });
+
+  it("handles entities without a slug (renders fallback in caller)", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Some Lab", null, "overall", "Overall", "B"),
+    ]);
+    expect(result.orgRows[0].slug).toBeNull();
+    expect(result.orgRows[0].displayName).toBe("Some Lab");
+  });
+
+  it("last-write-wins on duplicate (entity, dimension) pairs", () => {
+    // Caller is expected to filter to a single snapshot, but defensive
+    // semantics: the second grade overwrites the first.
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Anthropic", "a", "overall", "Overall", "B"),
+      grade("e1", "Anthropic", "a", "overall", "Overall", "A-"),
+    ]);
+    expect(result.orgRows[0].cells["overall"]?.scoreLetter).toBe("A-");
+  });
+
+  it("preserves dimension labels even when they differ from slug", () => {
+    const result = buildOrgDimensionMatrix([
+      grade("e1", "Anthropic", "a", "info-sharing", "Information Sharing"),
+    ]);
+    expect(result.dimensionOrder[0]).toEqual({
+      slug: "info-sharing",
+      label: "Information Sharing",
+    });
+  });
+});

--- a/apps/web/src/app/scorecards/[source]/__tests__/matrix.test.ts
+++ b/apps/web/src/app/scorecards/[source]/__tests__/matrix.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildOrgDimensionMatrix, type MatrixGrade } from "../matrix";
+import { buildOrgDimensionMatrix, type MatrixGrade } from "@/app/scorecards/[source]/matrix";
 
 function grade(
   entityId: string,

--- a/apps/web/src/app/scorecards/[source]/matrix.ts
+++ b/apps/web/src/app/scorecards/[source]/matrix.ts
@@ -1,0 +1,80 @@
+import { DIMENSION_OVERALL } from "@/app/scorecards/scorecards-constants";
+
+export interface MatrixGrade {
+  entityId: string;
+  entityDisplayName: string;
+  entitySlug: string | null;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+}
+
+export interface OrgDimensionRow {
+  entityId: string;
+  displayName: string;
+  slug: string | null;
+  cells: Record<string, MatrixGrade>;
+}
+
+export interface MatrixDimension {
+  slug: string;
+  label: string;
+}
+
+export interface MatrixResult {
+  orgRows: OrgDimensionRow[];
+  dimensionOrder: MatrixDimension[];
+  hasOverall: boolean;
+}
+
+/**
+ * Pure function: builds an org × dimension matrix from a flat grade list.
+ *
+ * - Orgs: alphabetical by displayName.
+ * - Dimensions: `overall` first when present, then alphabetical by label.
+ *
+ * Last-write-wins on duplicate (entityId, dimensionSlug) pairs — the caller
+ * is expected to filter to a single snapshot before calling, so duplicates
+ * are an upstream invariant violation rather than a normal case.
+ */
+export function buildOrgDimensionMatrix(grades: MatrixGrade[]): MatrixResult {
+  const orgMap = new Map<string, OrgDimensionRow>();
+  const dimensionOrder: MatrixDimension[] = [];
+  const seenDimensions = new Set<string>();
+
+  for (const g of grades) {
+    if (!seenDimensions.has(g.dimensionSlug)) {
+      seenDimensions.add(g.dimensionSlug);
+      dimensionOrder.push({ slug: g.dimensionSlug, label: g.dimensionLabel });
+    }
+    const existing = orgMap.get(g.entityId);
+    if (existing) {
+      existing.cells[g.dimensionSlug] = g;
+    } else {
+      orgMap.set(g.entityId, {
+        entityId: g.entityId,
+        displayName: g.entityDisplayName,
+        slug: g.entitySlug,
+        cells: { [g.dimensionSlug]: g },
+      });
+    }
+  }
+
+  dimensionOrder.sort((a, b) => {
+    if (a.slug === DIMENSION_OVERALL && b.slug !== DIMENSION_OVERALL) return -1;
+    if (b.slug === DIMENSION_OVERALL && a.slug !== DIMENSION_OVERALL) return 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  const orgRows = [...orgMap.values()].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  );
+
+  return {
+    orgRows,
+    dimensionOrder,
+    hasOverall: dimensionOrder.some((d) => d.slug === DIMENSION_OVERALL),
+  };
+}

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { fetchDetailed } from "@lib/wiki-server";
 import { ProfileStatCard } from "@/components/directory";
 import {
+  DIMENSION_OVERALL,
   SCORECARD_SOURCES,
   formatScoreCell,
   getScorecardSourceMeta,
@@ -160,13 +161,14 @@ export default async function ScorecardDetailPage({
     }
   }
 
-  // Surface "overall" as the leftmost grade column when present — readers
-  // expect to see the headline score before the per-pillar breakdown.
+  // Surface the overall column as leftmost when present — readers expect the
+  // headline score before the per-pillar breakdown.
   dimensionOrder.sort((a, b) => {
-    if (a.slug === "overall" && b.slug !== "overall") return -1;
-    if (b.slug === "overall" && a.slug !== "overall") return 1;
+    if (a.slug === DIMENSION_OVERALL && b.slug !== DIMENSION_OVERALL) return -1;
+    if (b.slug === DIMENSION_OVERALL && a.slug !== DIMENSION_OVERALL) return 1;
     return a.label.localeCompare(b.label);
   });
+  const hasOverall = dimensionOrder.some((d) => d.slug === DIMENSION_OVERALL);
 
   const orgRows = [...orgMap.values()].sort((a, b) =>
     a.displayName.localeCompare(b.displayName),
@@ -271,10 +273,7 @@ export default async function ScorecardDetailPage({
           <p className="text-xs text-muted-foreground mb-4">
             Rows are organizations; columns are the dimensions {meta.shortLabel}{" "}
             scores. Cell text is the published grade
-            {dimensionOrder.some((d) => d.slug === "overall")
-              ? " (overall first, then per-pillar)"
-              : ""}
-            .
+            {hasOverall ? " (overall first, then per-pillar)" : ""}.
           </p>
           <div className="overflow-x-auto rounded-lg border border-border/60">
             <table className="w-full text-sm">
@@ -321,17 +320,18 @@ export default async function ScorecardDetailPage({
                           </td>
                         );
                       }
+                      const formatted = formatScoreCell(cell);
+                      const rawSuffix =
+                        cell.scoreRaw && cell.scoreRaw !== formatted
+                          ? ` — raw: ${cell.scoreRaw}`
+                          : "";
                       return (
                         <td
                           key={dim.slug}
                           className="px-3 py-2 border-b border-border/30 font-mono tabular-nums"
-                          title={`${dim.label}${
-                            cell.scoreRaw && cell.scoreRaw !== formatScoreCell(cell)
-                              ? ` — raw: ${cell.scoreRaw}`
-                              : ""
-                          }`}
+                          title={`${dim.label}${rawSuffix}`}
                         >
-                          {formatScoreCell(cell)}
+                          {formatted}
                         </td>
                       );
                     })}

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -1,0 +1,472 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchDetailed } from "@lib/wiki-server";
+import { ProfileStatCard } from "@/components/directory";
+import {
+  SCORECARD_SOURCES,
+  formatScoreCell,
+  getScorecardSourceMeta,
+  type ScorecardSourceKey,
+} from "@/app/scorecards/scorecards-constants";
+
+export const revalidate = 300;
+
+/**
+ * Wiki-server response shapes — narrow to fields rendered. The full Hono
+ * RPC types would force a route-import into the web app; per-source detail
+ * is small enough that hand-typing is cheaper.
+ */
+interface SnapshotRow {
+  id: string;
+  scorecardSource: string;
+  waveLabel: string | null;
+  publishedAt: string;
+  sourceUrl: string;
+  methodologyUrl: string | null;
+  license: string | null;
+  orgCount: number;
+  dimensionCount: number;
+  isLatest: boolean;
+  sourceActive: boolean;
+  notes: string | null;
+}
+
+interface GradeRow {
+  id: string;
+  snapshotId: string;
+  scorecardSource: string | null;
+  publishedAt: string | null;
+  isLatest: boolean | null;
+  entityId: string;
+  entityDisplayName: string;
+  entitySlug: string | null;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+}
+
+const PAGE_SIZE = 200;
+const MAX_GRADES = 5000;
+
+/**
+ * Page through `/api/scorecard-grades/all` for one source's latest snapshot,
+ * returning every dimension (not just `overall`). Returns `{ ok: false }`
+ * on any page failure so the route can render an "unavailable" panel
+ * instead of silently truncating the matrix.
+ */
+async function fetchAllGradesForSource(
+  source: ScorecardSourceKey,
+): Promise<{ ok: true; items: GradeRow[] } | { ok: false }> {
+  const items: GradeRow[] = [];
+  let offset = 0;
+  while (items.length < MAX_GRADES) {
+    const res = await fetchDetailed<{ items: GradeRow[]; total: number }>(
+      `/api/scorecard-grades/all?limit=${PAGE_SIZE}&offset=${offset}&latest=true&scorecardSource=${source}`,
+      { revalidate: 300 },
+    );
+    if (!res.ok) return { ok: false };
+    items.push(...res.data.items);
+    if (res.data.items.length < PAGE_SIZE || items.length >= res.data.total) {
+      break;
+    }
+    offset += PAGE_SIZE;
+  }
+  if (items.length >= MAX_GRADES) {
+    console.warn(
+      `[scorecards/${source}] hit MAX_GRADES=${MAX_GRADES}; matrix may be truncated`,
+    );
+  }
+  return { ok: true, items };
+}
+
+export function generateStaticParams() {
+  return SCORECARD_SOURCES.map((meta) => ({ source: meta.source }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ source: string }>;
+}): Promise<Metadata> {
+  const { source } = await params;
+  const meta = getScorecardSourceMeta(source);
+  if (!meta) return { title: "Scorecard Not Found" };
+  return {
+    title: `${meta.fullLabel} | Scorecards`,
+    description: meta.description,
+  };
+}
+
+interface OrgDimensionRow {
+  entityId: string;
+  displayName: string;
+  slug: string | null;
+  cells: Record<string, GradeRow>;
+}
+
+export default async function ScorecardDetailPage({
+  params,
+}: {
+  params: Promise<{ source: string }>;
+}) {
+  const { source } = await params;
+  const meta = getScorecardSourceMeta(source);
+  if (!meta) return notFound();
+  const sourceKey = meta.source;
+
+  // Latest snapshot for this source + every snapshot (for history table) +
+  // every grade for the latest snapshot (every dimension, not just overall).
+  const [latestRes, allSnapshotsRes, gradesRes] = await Promise.all([
+    fetchDetailed<{ items: SnapshotRow[]; total: number }>(
+      `/api/scorecard-snapshots/all?limit=1&latest=true&source=${sourceKey}`,
+      { revalidate: 300 },
+    ),
+    fetchDetailed<{ items: SnapshotRow[]; total: number }>(
+      `/api/scorecard-snapshots/all?limit=200&source=${sourceKey}`,
+      { revalidate: 300 },
+    ),
+    fetchAllGradesForSource(sourceKey),
+  ]);
+
+  const latestSnapshot = latestRes.ok ? latestRes.data.items[0] ?? null : null;
+  const allSnapshots = allSnapshotsRes.ok ? allSnapshotsRes.data.items : [];
+  const grades = gradesRes.ok ? gradesRes.items : [];
+  const fetchOk = latestRes.ok && allSnapshotsRes.ok && gradesRes.ok;
+
+  // Build org × dimension matrix. `dimensionLabel` order is dictated by
+  // first-seen order in the API response, which itself is sorted by
+  // `entityDisplayName, dimensionSlug`. That gives a stable column order
+  // per source even though the dimension set differs across sources.
+  const orgMap = new Map<string, OrgDimensionRow>();
+  const dimensionOrder: { slug: string; label: string }[] = [];
+  const seenDimensions = new Set<string>();
+
+  for (const g of grades) {
+    if (!seenDimensions.has(g.dimensionSlug)) {
+      seenDimensions.add(g.dimensionSlug);
+      dimensionOrder.push({ slug: g.dimensionSlug, label: g.dimensionLabel });
+    }
+    const existing = orgMap.get(g.entityId);
+    if (existing) {
+      existing.cells[g.dimensionSlug] = g;
+    } else {
+      orgMap.set(g.entityId, {
+        entityId: g.entityId,
+        displayName: g.entityDisplayName,
+        slug: g.entitySlug,
+        cells: { [g.dimensionSlug]: g },
+      });
+    }
+  }
+
+  // Surface "overall" as the leftmost grade column when present — readers
+  // expect to see the headline score before the per-pillar breakdown.
+  dimensionOrder.sort((a, b) => {
+    if (a.slug === "overall" && b.slug !== "overall") return -1;
+    if (b.slug === "overall" && a.slug !== "overall") return 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  const orgRows = [...orgMap.values()].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  );
+
+  const totalOrgs = orgRows.length;
+  const totalDimensions = dimensionOrder.length;
+  const totalSnapshots = allSnapshots.length;
+  const latestWaveLabel =
+    latestSnapshot?.waveLabel ?? latestSnapshot?.publishedAt ?? "—";
+
+  const stats = [
+    { label: "Organizations", value: String(totalOrgs) },
+    { label: "Dimensions", value: String(totalDimensions) },
+    { label: "Snapshots", value: String(totalSnapshots) },
+    { label: "Latest wave", value: latestWaveLabel },
+  ];
+
+  return (
+    <div className="container max-w-6xl mx-auto px-4 py-8">
+      <header className="mb-6">
+        <nav className="text-sm text-muted-foreground mb-2">
+          <Link href="/scorecards" className="hover:underline">
+            Scorecards
+          </Link>
+          <span className="mx-2">/</span>
+          <span>{meta.shortLabel}</span>
+        </nav>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+          <h1 className="text-3xl font-bold">{meta.fullLabel}</h1>
+          {!meta.active ? (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+              No longer maintained
+            </span>
+          ) : null}
+        </div>
+        <p className="text-sm text-muted-foreground mb-3">
+          by{" "}
+          {meta.publisherSlug ? (
+            <Link
+              href={`/organizations/${meta.publisherSlug}`}
+              className="text-primary hover:underline"
+            >
+              {meta.publisher}
+            </Link>
+          ) : (
+            <span>{meta.publisher}</span>
+          )}
+          {latestSnapshot ? (
+            <>
+              <span className="mx-2">·</span>
+              <span>Latest: {latestWaveLabel}</span>
+            </>
+          ) : null}
+          <span className="mx-2">·</span>
+          <Link
+            href={latestSnapshot?.sourceUrl ?? meta.homeUrl}
+            className="text-primary hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Source ↗
+          </Link>
+        </p>
+        <p className="text-muted-foreground max-w-3xl">{meta.description}</p>
+      </header>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+        {stats.map((stat) => (
+          <ProfileStatCard
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+          />
+        ))}
+      </div>
+
+      {!fetchOk ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 p-4 text-sm mb-6">
+          The wiki-server was unreachable; scorecard data is temporarily
+          unavailable. The matrix and snapshot history will populate once the
+          server responds.
+        </div>
+      ) : null}
+
+      {fetchOk && totalOrgs === 0 ? (
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-6 text-sm space-y-2 mb-8">
+          <p className="font-medium">No grades ingested yet.</p>
+          <p className="text-muted-foreground">
+            The {meta.shortLabel} ingester has not produced any grades for the
+            latest snapshot. Methodology and source link below are usable
+            today.
+          </p>
+        </div>
+      ) : null}
+
+      {orgRows.length > 0 && dimensionOrder.length > 0 ? (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-1">
+            Grades by dimension — {latestWaveLabel}
+          </h2>
+          <p className="text-xs text-muted-foreground mb-4">
+            Rows are organizations; columns are the dimensions {meta.shortLabel}{" "}
+            scores. Cell text is the published grade
+            {dimensionOrder.some((d) => d.slug === "overall")
+              ? " (overall first, then per-pillar)"
+              : ""}
+            .
+          </p>
+          <div className="overflow-x-auto rounded-lg border border-border/60">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-muted/40 text-left">
+                  <th className="px-3 py-2 font-semibold border-b border-border/60 sticky left-0 bg-muted/40">
+                    Organization
+                  </th>
+                  {dimensionOrder.map((dim) => (
+                    <th
+                      key={dim.slug}
+                      className="px-3 py-2 font-semibold border-b border-border/60 whitespace-nowrap"
+                      title={dim.slug}
+                    >
+                      {dim.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {orgRows.map((row) => (
+                  <tr key={row.entityId} className="hover:bg-muted/20">
+                    <td className="px-3 py-2 border-b border-border/30 sticky left-0 bg-background">
+                      {row.slug ? (
+                        <Link
+                          href={`/organizations/${row.slug}`}
+                          className="text-primary hover:underline"
+                        >
+                          {row.displayName}
+                        </Link>
+                      ) : (
+                        <span>{row.displayName}</span>
+                      )}
+                    </td>
+                    {dimensionOrder.map((dim) => {
+                      const cell = row.cells[dim.slug];
+                      if (!cell) {
+                        return (
+                          <td
+                            key={dim.slug}
+                            className="px-3 py-2 border-b border-border/30 text-muted-foreground"
+                          >
+                            —
+                          </td>
+                        );
+                      }
+                      return (
+                        <td
+                          key={dim.slug}
+                          className="px-3 py-2 border-b border-border/30 font-mono tabular-nums"
+                          title={`${dim.label}${
+                            cell.scoreRaw && cell.scoreRaw !== formatScoreCell(cell)
+                              ? ` — raw: ${cell.scoreRaw}`
+                              : ""
+                          }`}
+                        >
+                          {formatScoreCell(cell)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
+
+      {allSnapshots.length > 0 ? (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-4">Snapshot history</h2>
+          <div className="overflow-x-auto rounded-lg border border-border/60">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-muted/40 text-left">
+                  <th className="px-3 py-2 font-semibold border-b border-border/60 whitespace-nowrap">
+                    Wave
+                  </th>
+                  <th className="px-3 py-2 font-semibold border-b border-border/60 whitespace-nowrap">
+                    Published
+                  </th>
+                  <th className="px-3 py-2 font-semibold border-b border-border/60 text-right">
+                    Orgs
+                  </th>
+                  <th className="px-3 py-2 font-semibold border-b border-border/60">
+                    License
+                  </th>
+                  <th className="px-3 py-2 font-semibold border-b border-border/60">
+                    Links
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {allSnapshots.map((snap) => (
+                  <tr key={snap.id} className="hover:bg-muted/20">
+                    <td className="px-3 py-2 border-b border-border/30">
+                      {snap.waveLabel ?? snap.publishedAt}
+                      {snap.isLatest ? (
+                        <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                          latest
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-2 border-b border-border/30 tabular-nums">
+                      {snap.publishedAt}
+                    </td>
+                    <td className="px-3 py-2 border-b border-border/30 text-right tabular-nums">
+                      {snap.orgCount}
+                    </td>
+                    <td className="px-3 py-2 border-b border-border/30 text-muted-foreground">
+                      {snap.license ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 border-b border-border/30">
+                      <div className="flex gap-x-3 text-xs">
+                        <Link
+                          href={snap.sourceUrl}
+                          className="text-primary hover:underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Source ↗
+                        </Link>
+                        {snap.methodologyUrl ? (
+                          <Link
+                            href={snap.methodologyUrl}
+                            className="text-primary hover:underline"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Methodology ↗
+                          </Link>
+                        ) : null}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">Methodology</h2>
+        <article className="rounded-lg border border-border/60 bg-card p-4">
+          <p className="text-sm text-muted-foreground mb-3">
+            {meta.description}
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <Link
+              href={latestSnapshot?.sourceUrl ?? meta.homeUrl}
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Source ↗
+            </Link>
+            {latestSnapshot?.methodologyUrl ? (
+              <Link
+                href={latestSnapshot.methodologyUrl}
+                className="text-primary hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Methodology ↗
+              </Link>
+            ) : null}
+            {latestSnapshot?.license ? (
+              <span className="text-muted-foreground">
+                License: {latestSnapshot.license}
+              </span>
+            ) : null}
+            <span className="text-muted-foreground">
+              Status: {meta.active ? "active" : "no longer maintained"}
+            </span>
+          </div>
+          {latestSnapshot?.notes ? (
+            <p className="text-xs text-muted-foreground mt-3 whitespace-pre-line">
+              {latestSnapshot.notes}
+            </p>
+          ) : null}
+        </article>
+      </section>
+
+      <p className="text-xs text-muted-foreground">
+        Grades are mirrored from upstream sources. We do not score
+        organizations ourselves — see the source link for full methodology and
+        per-indicator detail. Citation of published grades is consistent with
+        fair-use attribution.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -117,13 +117,11 @@ export default async function ScorecardDetailPage({
   if (!meta) return notFound();
   const sourceKey = meta.source;
 
-  // Latest snapshot for this source + every snapshot (for history table) +
-  // every grade for the latest snapshot (every dimension, not just overall).
-  const [latestRes, allSnapshotsRes, gradesRes] = await Promise.all([
-    fetchDetailed<{ items: SnapshotRow[]; total: number }>(
-      `/api/scorecard-snapshots/all?limit=1&latest=true&source=${sourceKey}`,
-      { revalidate: 300 },
-    ),
+  // Every snapshot for this source (for history table; the latest is
+  // picked from the same response) + every grade for the latest snapshot
+  // (every dimension, not just overall). The /all endpoint orders by
+  // `publishedAt DESC` so the first `isLatest=true` row is the latest.
+  const [snapshotsRes, gradesRes] = await Promise.all([
     fetchDetailed<{ items: SnapshotRow[]; total: number }>(
       `/api/scorecard-snapshots/all?limit=200&source=${sourceKey}`,
       { revalidate: 300 },
@@ -131,10 +129,10 @@ export default async function ScorecardDetailPage({
     fetchAllGradesForSource(sourceKey),
   ]);
 
-  const latestSnapshot = latestRes.ok ? latestRes.data.items[0] ?? null : null;
-  const allSnapshots = allSnapshotsRes.ok ? allSnapshotsRes.data.items : [];
+  const allSnapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
+  const latestSnapshot = allSnapshots.find((s) => s.isLatest) ?? null;
   const grades = gradesRes.ok ? gradesRes.items : [];
-  const fetchOk = latestRes.ok && allSnapshotsRes.ok && gradesRes.ok;
+  const fetchOk = snapshotsRes.ok && gradesRes.ok;
 
   // Build org × dimension matrix. `dimensionLabel` order is dictated by
   // first-seen order in the API response, which itself is sorted by

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -267,8 +267,19 @@ export default async function ScorecardDetailPage({
               </thead>
               <tbody>
                 {orgRows.map((row) => (
-                  <tr key={row.entityId} className="hover:bg-muted/20">
-                    <td className="px-3 py-2 border-b border-border/30 sticky left-0 z-10 bg-background">
+                  <tr
+                    key={row.entityId}
+                    className="group hover:bg-muted/20"
+                  >
+                    {/*
+                      Sticky org column needs an opaque background so dimension
+                      cells don't paint over it under horizontal scroll, but a
+                      static `bg-background` blocks the row's :hover from
+                      reaching this cell. `group-hover:` re-applies the row's
+                      hover tint to the sticky cell so the row highlight stays
+                      visually contiguous.
+                    */}
+                    <td className="px-3 py-2 border-b border-border/30 sticky left-0 z-10 bg-background group-hover:bg-muted/20">
                       {row.slug ? (
                         <Link
                           href={`/organizations/${row.slug}`}

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -4,12 +4,11 @@ import { notFound } from "next/navigation";
 import { fetchDetailed } from "@lib/wiki-server";
 import { ProfileStatCard } from "@/components/directory";
 import {
-  DIMENSION_OVERALL,
   SCORECARD_SOURCES,
   formatScoreCell,
   getScorecardSourceMeta,
-  type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
+import { buildOrgDimensionMatrix, type MatrixGrade } from "./matrix";
 
 export const revalidate = 300;
 
@@ -33,39 +32,42 @@ interface SnapshotRow {
   notes: string | null;
 }
 
-interface GradeRow {
-  id: string;
+interface GradeRow extends MatrixGrade {
   snapshotId: string;
-  scorecardSource: string | null;
-  publishedAt: string | null;
-  isLatest: boolean | null;
-  entityId: string;
-  entityDisplayName: string;
-  entitySlug: string | null;
-  dimensionSlug: string;
-  dimensionLabel: string;
-  scoreNumeric: number | null;
-  scoreLetter: string | null;
-  scoreRaw: string;
 }
 
 const PAGE_SIZE = 200;
 const MAX_GRADES = 5000;
 
+/** Treat whitespace-only and empty strings the same as null/undefined. */
+function nonEmpty(s: string | null | undefined): string | null {
+  if (s == null) return null;
+  const trimmed = s.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 /**
- * Page through `/api/scorecard-grades/all` for one source's latest snapshot,
- * returning every dimension (not just `overall`). Returns `{ ok: false }`
- * on any page failure so the route can render an "unavailable" panel
- * instead of silently truncating the matrix.
+ * Page through `/api/scorecard-grades/all` for one specific snapshot. Pinning
+ * to `snapshotId=...` (rather than `latest=true`) is critical: offset-based
+ * pagination over an `ORDER BY publishedAt DESC` set is unstable if a new
+ * snapshot lands mid-fetch and flips the latest-marker, but a snapshot's
+ * grades are append-only once published. Returns `{ ok: false }` on any
+ * page failure so the route can render an "unavailable" panel rather than
+ * silently truncating the matrix.
  */
-async function fetchAllGradesForSource(
-  source: ScorecardSourceKey,
-): Promise<{ ok: true; items: GradeRow[] } | { ok: false }> {
+async function fetchAllGradesForSnapshot(
+  snapshotId: string,
+): Promise<
+  { ok: true; items: GradeRow[]; truncated: boolean } | { ok: false }
+> {
   const items: GradeRow[] = [];
   let offset = 0;
+  // URL-encode the snapshotId — it's drawn from a server response but
+  // could contain characters that need escaping (e.g. spaces in wave labels).
+  const encoded = encodeURIComponent(snapshotId);
   while (items.length < MAX_GRADES) {
     const res = await fetchDetailed<{ items: GradeRow[]; total: number }>(
-      `/api/scorecard-grades/all?limit=${PAGE_SIZE}&offset=${offset}&latest=true&scorecardSource=${source}`,
+      `/api/scorecard-grades/all?limit=${PAGE_SIZE}&offset=${offset}&snapshotId=${encoded}`,
       { revalidate: 300 },
     );
     if (!res.ok) return { ok: false };
@@ -75,12 +77,7 @@ async function fetchAllGradesForSource(
     }
     offset += PAGE_SIZE;
   }
-  if (items.length >= MAX_GRADES) {
-    console.warn(
-      `[scorecards/${source}] hit MAX_GRADES=${MAX_GRADES}; matrix may be truncated`,
-    );
-  }
-  return { ok: true, items };
+  return { ok: true, items, truncated: items.length >= MAX_GRADES };
 }
 
 export function generateStaticParams() {
@@ -101,13 +98,6 @@ export async function generateMetadata({
   };
 }
 
-interface OrgDimensionRow {
-  entityId: string;
-  displayName: string;
-  slug: string | null;
-  cells: Record<string, GradeRow>;
-}
-
 export default async function ScorecardDetailPage({
   params,
 }: {
@@ -118,67 +108,41 @@ export default async function ScorecardDetailPage({
   if (!meta) return notFound();
   const sourceKey = meta.source;
 
-  // Every snapshot for this source (for history table; the latest is
-  // picked from the same response) + every grade for the latest snapshot
-  // (every dimension, not just overall). The /all endpoint orders by
-  // `publishedAt DESC` so the first `isLatest=true` row is the latest.
-  const [snapshotsRes, gradesRes] = await Promise.all([
-    fetchDetailed<{ items: SnapshotRow[]; total: number }>(
-      `/api/scorecard-snapshots/all?limit=200&source=${sourceKey}`,
-      { revalidate: 300 },
-    ),
-    fetchAllGradesForSource(sourceKey),
-  ]);
-
+  // Resolve all snapshots first so we can pick the latest snapshot id and
+  // page grades against it deterministically. The /all endpoint orders by
+  // `publishedAt DESC`; the partial unique index
+  // `uq_scorecard_snapshots_latest_per_source` means at most one row per
+  // source has `isLatest=true`.
+  const snapshotsRes = await fetchDetailed<{
+    items: SnapshotRow[];
+    total: number;
+  }>(`/api/scorecard-snapshots/all?limit=200&source=${sourceKey}`, {
+    revalidate: 300,
+  });
   const allSnapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
   const latestSnapshot = allSnapshots.find((s) => s.isLatest) ?? null;
+
+  // Pull grades only when we have a concrete snapshot to pin to. Skipping
+  // the fetch when there's no latest also avoids a wasted request on
+  // sources with no ingested snapshots (FMTI today).
+  const gradesRes = latestSnapshot
+    ? await fetchAllGradesForSnapshot(latestSnapshot.id)
+    : ({ ok: true, items: [] as GradeRow[], truncated: false } as const);
+
   const grades = gradesRes.ok ? gradesRes.items : [];
+  const truncated = gradesRes.ok && gradesRes.truncated;
   const fetchOk = snapshotsRes.ok && gradesRes.ok;
 
-  // Build org × dimension matrix. `dimensionLabel` order is dictated by
-  // first-seen order in the API response, which itself is sorted by
-  // `entityDisplayName, dimensionSlug`. That gives a stable column order
-  // per source even though the dimension set differs across sources.
-  const orgMap = new Map<string, OrgDimensionRow>();
-  const dimensionOrder: { slug: string; label: string }[] = [];
-  const seenDimensions = new Set<string>();
-
-  for (const g of grades) {
-    if (!seenDimensions.has(g.dimensionSlug)) {
-      seenDimensions.add(g.dimensionSlug);
-      dimensionOrder.push({ slug: g.dimensionSlug, label: g.dimensionLabel });
-    }
-    const existing = orgMap.get(g.entityId);
-    if (existing) {
-      existing.cells[g.dimensionSlug] = g;
-    } else {
-      orgMap.set(g.entityId, {
-        entityId: g.entityId,
-        displayName: g.entityDisplayName,
-        slug: g.entitySlug,
-        cells: { [g.dimensionSlug]: g },
-      });
-    }
-  }
-
-  // Surface the overall column as leftmost when present — readers expect the
-  // headline score before the per-pillar breakdown.
-  dimensionOrder.sort((a, b) => {
-    if (a.slug === DIMENSION_OVERALL && b.slug !== DIMENSION_OVERALL) return -1;
-    if (b.slug === DIMENSION_OVERALL && a.slug !== DIMENSION_OVERALL) return 1;
-    return a.label.localeCompare(b.label);
-  });
-  const hasOverall = dimensionOrder.some((d) => d.slug === DIMENSION_OVERALL);
-
-  const orgRows = [...orgMap.values()].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
-  );
+  const matrix = buildOrgDimensionMatrix(grades);
+  const { orgRows, dimensionOrder, hasOverall } = matrix;
 
   const totalOrgs = orgRows.length;
   const totalDimensions = dimensionOrder.length;
   const totalSnapshots = allSnapshots.length;
   const latestWaveLabel =
-    latestSnapshot?.waveLabel ?? latestSnapshot?.publishedAt ?? "—";
+    nonEmpty(latestSnapshot?.waveLabel) ??
+    nonEmpty(latestSnapshot?.publishedAt) ??
+    "—";
 
   const stats = [
     { label: "Organizations", value: String(totalOrgs) },
@@ -254,6 +218,14 @@ export default async function ScorecardDetailPage({
         </div>
       ) : null}
 
+      {truncated ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 p-4 text-sm mb-6">
+          Showing the first {MAX_GRADES.toLocaleString()} grades for this
+          snapshot — the matrix may be truncated. Re-run the ingester to
+          confirm completeness or paginate via the API directly.
+        </div>
+      ) : null}
+
       {fetchOk && totalOrgs === 0 ? (
         <div className="rounded-lg border border-border/60 bg-muted/30 p-6 text-sm space-y-2 mb-8">
           <p className="font-medium">No grades ingested yet.</p>
@@ -279,7 +251,7 @@ export default async function ScorecardDetailPage({
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-muted/40 text-left">
-                  <th className="px-3 py-2 font-semibold border-b border-border/60 sticky left-0 bg-muted/40">
+                  <th className="px-3 py-2 font-semibold border-b border-border/60 sticky left-0 z-20 bg-muted/40">
                     Organization
                   </th>
                   {dimensionOrder.map((dim) => (
@@ -296,7 +268,7 @@ export default async function ScorecardDetailPage({
               <tbody>
                 {orgRows.map((row) => (
                   <tr key={row.entityId} className="hover:bg-muted/20">
-                    <td className="px-3 py-2 border-b border-border/30 sticky left-0 bg-background">
+                    <td className="px-3 py-2 border-b border-border/30 sticky left-0 z-10 bg-background">
                       {row.slug ? (
                         <Link
                           href={`/organizations/${row.slug}`}
@@ -321,9 +293,10 @@ export default async function ScorecardDetailPage({
                         );
                       }
                       const formatted = formatScoreCell(cell);
+                      const rawTrimmed = nonEmpty(cell.scoreRaw);
                       const rawSuffix =
-                        cell.scoreRaw && cell.scoreRaw !== formatted
-                          ? ` — raw: ${cell.scoreRaw}`
+                        rawTrimmed && rawTrimmed !== formatted
+                          ? ` — raw: ${rawTrimmed}`
                           : "";
                       return (
                         <td

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -8,7 +8,7 @@ import {
   formatScoreCell,
   getScorecardSourceMeta,
 } from "@/app/scorecards/scorecards-constants";
-import { buildOrgDimensionMatrix, type MatrixGrade } from "./matrix";
+import { buildOrgDimensionMatrix, type MatrixGrade } from "@/app/scorecards/[source]/matrix";
 
 export const revalidate = 300;
 
@@ -62,6 +62,7 @@ async function fetchAllGradesForSnapshot(
 > {
   const items: GradeRow[] = [];
   let offset = 0;
+  let total = 0;
   // URL-encode the snapshotId — it's drawn from a server response but
   // could contain characters that need escaping (e.g. spaces in wave labels).
   const encoded = encodeURIComponent(snapshotId);
@@ -71,13 +72,14 @@ async function fetchAllGradesForSnapshot(
       { revalidate: 300 },
     );
     if (!res.ok) return { ok: false };
+    total = res.data.total;
     items.push(...res.data.items);
     if (res.data.items.length < PAGE_SIZE || items.length >= res.data.total) {
       break;
     }
     offset += PAGE_SIZE;
   }
-  return { ok: true, items, truncated: items.length >= MAX_GRADES };
+  return { ok: true, items, truncated: items.length < total };
 }
 
 export function generateStaticParams() {
@@ -136,8 +138,8 @@ export default async function ScorecardDetailPage({
   const matrix = buildOrgDimensionMatrix(grades);
   const { orgRows, dimensionOrder, hasOverall } = matrix;
 
-  const totalOrgs = orgRows.length;
-  const totalDimensions = dimensionOrder.length;
+  const totalOrgs = latestSnapshot?.orgCount ?? orgRows.length;
+  const totalDimensions = latestSnapshot?.dimensionCount ?? dimensionOrder.length;
   const totalSnapshots = allSnapshots.length;
   const latestWaveLabel =
     nonEmpty(latestSnapshot?.waveLabel) ??
@@ -355,7 +357,7 @@ export default async function ScorecardDetailPage({
                 {allSnapshots.map((snap) => (
                   <tr key={snap.id} className="hover:bg-muted/20">
                     <td className="px-3 py-2 border-b border-border/30">
-                      {snap.waveLabel ?? snap.publishedAt}
+                      {nonEmpty(snap.waveLabel) ?? snap.publishedAt}
                       {snap.isLatest ? (
                         <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
                           latest

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { fetchDetailed } from "@lib/wiki-server";
+import { getEntityHref } from "@/data/entity-nav";
 import { ProfileStatCard } from "@/components/directory";
 import {
   SCORECARD_SOURCES,
@@ -82,6 +83,26 @@ async function fetchAllGradesForSnapshot(
   return { ok: true, items, truncated: items.length < total };
 }
 
+/** Page through `/api/scorecard-snapshots/all` for one source. */
+async function fetchAllSnapshotsForSource(
+  sourceKey: string,
+): Promise<{ ok: true; items: SnapshotRow[] } | { ok: false }> {
+  const items: SnapshotRow[] = [];
+  let offset = 0;
+  const encoded = encodeURIComponent(sourceKey);
+  while (true) {
+    const res = await fetchDetailed<{ items: SnapshotRow[]; total: number }>(
+      `/api/scorecard-snapshots/all?limit=${PAGE_SIZE}&offset=${offset}&source=${encoded}`,
+      { revalidate: 300 },
+    );
+    if (!res.ok) return { ok: false };
+    items.push(...res.data.items);
+    if (items.length >= res.data.total || res.data.items.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return { ok: true, items };
+}
+
 export function generateStaticParams() {
   return SCORECARD_SOURCES.map((meta) => ({ source: meta.source }));
 }
@@ -115,13 +136,8 @@ export default async function ScorecardDetailPage({
   // `publishedAt DESC`; the partial unique index
   // `uq_scorecard_snapshots_latest_per_source` means at most one row per
   // source has `isLatest=true`.
-  const snapshotsRes = await fetchDetailed<{
-    items: SnapshotRow[];
-    total: number;
-  }>(`/api/scorecard-snapshots/all?limit=200&source=${sourceKey}`, {
-    revalidate: 300,
-  });
-  const allSnapshots = snapshotsRes.ok ? snapshotsRes.data.items : [];
+  const snapshotsRes = await fetchAllSnapshotsForSource(sourceKey);
+  const allSnapshots = snapshotsRes.ok ? snapshotsRes.items : [];
   const latestSnapshot = allSnapshots.find((s) => s.isLatest) ?? null;
 
   // Pull grades only when we have a concrete snapshot to pin to. Skipping
@@ -175,7 +191,7 @@ export default async function ScorecardDetailPage({
           by{" "}
           {meta.publisherSlug ? (
             <Link
-              href={`/organizations/${meta.publisherSlug}`}
+              href={getEntityHref(meta.publisherSlug)}
               className="text-primary hover:underline"
             >
               {meta.publisher}
@@ -284,7 +300,7 @@ export default async function ScorecardDetailPage({
                     <td className="px-3 py-2 border-b border-border/30 sticky left-0 z-10 bg-background group-hover:bg-muted/20">
                       {row.slug ? (
                         <Link
-                          href={`/organizations/${row.slug}`}
+                          href={getEntityHref(row.slug)}
                           className="text-primary hover:underline"
                         >
                           {row.displayName}

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -12,6 +12,12 @@ export interface ScorecardSourceMeta {
   fullLabel: string;
   /** Org/maintainer of the scorecard. */
   publisher: string;
+  /**
+   * Slug for /organizations/<slug> linking when the publisher has a wiki
+   * entity. Optional — sources whose publisher isn't yet in the catalog
+   * render the publisher as plain text.
+   */
+  publisherSlug?: string;
   /** Default canonical URL for the source's home page. */
   homeUrl: string;
   /**
@@ -39,6 +45,7 @@ export const SCORECARD_SOURCES: readonly ScorecardSourceMeta[] = [
     shortLabel: "FLI Index",
     fullLabel: "FLI AI Safety Index",
     publisher: "Future of Life Institute",
+    publisherSlug: "fli",
     homeUrl: "https://futureoflife.org/ai-safety-index-summer-2025/",
     description:
       "Letter-grade ratings of frontier AI labs across six safety domains: risk assessment, current harms, safety frameworks, existential safety, governance, and information sharing.",


### PR DESCRIPTION
## Summary

Adds an internal detail page for each external AI-safety scorecard (`fli_index`, `saferai`, `ailabwatch`, `fmti`, `seoul_tracker`). Closes a UX gap on `/scorecards`: the directory shows the cross-org × cross-source overall matrix, but every per-source surface used to leave the wiki via "Source ↗".

The new page surfaces, for one source:

- **Cross-org × dimension matrix** — rows = orgs, columns = every dimension this source publishes (not just `overall`). Filter via `/api/scorecard-grades/all?snapshotId=<latest>` (pinned to the latest snapshot id for deterministic offset pagination).
- **Snapshot history** — every wave from `scorecard_snapshots` ordered by `publishedAt DESC`, with `latest` pill and per-snapshot source/methodology links.
- **Methodology card** — full description, latest snapshot's methodology URL, license, active/inactive status. `notes` field rendered when present.
- **Stats cards** — Organizations, Dimensions, Snapshots, Latest wave.
- **Empty state** — "No grades ingested yet" panel for sources whose ingester hasn't produced grades (FMTI today).
- **Truncation banner** — visible warning when the matrix hits `MAX_GRADES=5000` so silent truncation can't ship a misleading view.
- **Active state badge** — "No longer maintained" pill on `ailabwatch` (matches the methodology panel on `/scorecards`).

`generateStaticParams` returns all 5 source keys; unknown sources return `notFound()`.

## Implementation notes

- **Pinned snapshotId, not `latest=true`** — offset-based pagination over `ORDER BY publishedAt DESC` is unstable if a new snapshot lands mid-fetch. Resolving the latest snapshot first and paginating against `?snapshotId=<id>` is deterministic. Caught by `/agent-review-pr`.
- **Pure matrix builder** — `buildOrgDimensionMatrix` extracted to its own module so the org/dimension grouping, alphabetical sort, and overall-first column order are unit-testable. 8 new tests cover the edge cases (empty input, duplicates, no overall, null slug).
- **Sticky-column z-index** — `z-20` on header, `z-10` on body cells so dimension cells don't paint over the org column under horizontal scroll.
- **Whitespace-safe text** — small `nonEmpty()` helper trims and treats empty/whitespace as null for `waveLabel`, `publishedAt`, and the cell `raw:` tooltip. Avoids leaking blank stat values when the API returns `""` instead of `null`.

## Verified against prod

Counts match `scorecard_snapshots.dimensionCount` / `orgCount`:

| Source | Orgs | Dims | Snapshots |
|---|---|---|---|
| fli_index | 8 | 7 (+ `overall`) | 3 waves |
| saferai | 12 | 5 | 1 |
| ailabwatch | 7 | 8 | 1 (frozen) |
| seoul_tracker | 16 | 6 | 1 |
| fmti | 0 | 0 | 0 (empty state) |

All 5 routes return 200; unknown source returns 404.

## Out of scope (per ticket)

- Sort/filter UI on the matrix (server-rendered for now)
- Per-snapshot drilldown route `/scorecards/[source]/snapshots/[id]`
- Header-nav for /scorecards (NEW-5)
- Source-check verdict dots on grade cells (NEW-4)
- Publisher → `/organizations/[slug]` link for non-FLI publishers (depends on NEW-1; only `fli_index` has `publisherSlug` set today; the others render publisher as plain text)

## Test plan

- [x] All 5 source pages return 200 against prod data; unknown sources return 404
- [x] FMTI shows "No grades ingested yet" empty state
- [x] AI Lab Watch shows "No longer maintained" pill
- [x] Org names link to `/organizations/[slug]` when slug is present
- [x] Publisher → `/organizations/fli` link present in FLI header
- [x] Snapshot history table populated for FLI (3 waves: Winter 2025 latest, Summer 2025, December 2024)
- [x] `pnpm test` (1758 tests pass — 8 new matrix tests)
- [x] `pnpm crux w validate gate` (all 65 checks pass)
- [x] `pnpm build` (route prerendered as SSG with all 5 paths)
- [x] `npx playwright test e2e/render-audit.spec.ts -g "scorecards"` (2/2 pass)
- [x] `/agent-review-pr` ran; HIGH and MEDIUM findings addressed in commit `d5d13dc34`

Fixes QUA-837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed scorecard pages showing organization ratings in an interactive matrix with dimension ordering, stats, snapshot history, methodology and external links.
  * Publisher linking added for supported scorecard sources.

* **Tests**
  * New unit tests for matrix construction and additional end-to-end render checks covering scorecard pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->