### PR TITLE
feat(sourcing): add resolve-contradicted sweep tool (QUA-728)

### DIFF
--- a/crux/commands/sourcing-resolve-contradicted.test.ts
+++ b/crux/commands/sourcing-resolve-contradicted.test.ts
@@ -129,6 +129,7 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: null,
+      entitySlug: 'anthropic',
       entityQid: 'Q108542504',
     });
     expect(c.bucket).toBe('no-source-url');
@@ -139,6 +140,7 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: 'https://nytimes.com/article/123',
+      entitySlug: 'anthropic',
       entityQid: 'Q108542504',
     });
     expect(c.bucket).toBe('indeterminate');
@@ -150,6 +152,7 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: 'https://www.wikidata.org/wiki/Q42',
+      entitySlug: null,
       entityQid: null,
     });
     expect(c.bucket).toBe('indeterminate');
@@ -161,6 +164,7 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: 'https://www.wikidata.org/wiki/Q108542504',
+      entitySlug: 'anthropic',
       entityQid: 'Q108542504',
     });
     expect(c.bucket).toBe('subject-match');
@@ -171,6 +175,7 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: 'https://www.wikidata.org/wiki/Q63041604', // xAI
+      entitySlug: 'anthropic',
       entityQid: 'Q108542504', // Anthropic
     });
     expect(c.bucket).toBe('subject-mismatch');
@@ -182,9 +187,20 @@ describe('classifyContradicted (pure)', () => {
     const c = classifyContradicted({
       verdict: baseVerdict,
       existingUrl: 'https://www.wikidata.org/entity/Q42',
+      entitySlug: 'fortytwo',
       entityQid: 'Q42',
     });
     expect(c.bucket).toBe('subject-match');
+  });
+
+  it('threads entitySlug through onto the result', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://www.wikidata.org/wiki/Q42',
+      entitySlug: 'fortytwo',
+      entityQid: 'Q42',
+    });
+    expect(c.entitySlug).toBe('fortytwo');
   });
 });
 
@@ -483,6 +499,127 @@ describe('sourcing-resolve-contradicted command', () => {
     expect(mockGetEntityWikidataQid).toHaveBeenCalledWith('anthropic');
   });
 
+  it('picks the most recently checked source URL, not rows[0] (server orders by sourceUrl ASC)', async () => {
+    // The /evidence/by-records endpoint orders by (sourceUrl ASC, checkedAt DESC).
+    // For a record with two URLs, rows[0] is the latest checkedAt of the
+    // alphabetically-first URL — NOT the globally most-recently-checked URL.
+    // Bug surfaces here: A-prefixed Wikidata Q42 (older, matches entity)
+    // would beat Z-prefixed Wikidata Q9999 (newer, mismatches entity) under
+    // the naive `.find()` pick. The fix sorts by checkedAt DESC client-side.
+    stubVerdicts([
+      makeVerdict({ recordId: 'f_multi_url', entityId: 'fortytwo' }),
+    ]);
+    stubEvidence({
+      'fact|f_multi_url': [
+        // Alphabetically first URL, OLDER checkedAt — would be picked by buggy code
+        { sourceUrl: 'https://www.wikidata.org/wiki/Q42', checkedAt: '2026-01-01T00:00:00Z' as unknown as Date, checkerModel: 'haiku' } as never,
+        // Alphabetically second URL, NEWER checkedAt — should be picked
+        { sourceUrl: 'https://www.wikidata.org/wiki/Q9999', checkedAt: '2026-04-29T00:00:00Z' as unknown as Date, checkerModel: 'haiku' } as never,
+      ],
+    });
+    mockGetEntityWikidataQid.mockReturnValue('Q42');
+
+    const result = await run({ json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    const record = parsed.records[0];
+    // The latest URL was Q9999 ≠ entity Q42 → subject-mismatch (correct)
+    // Buggy version would have picked Q42 → subject-match (incorrect)
+    expect(record.bucket).toBe('subject-mismatch');
+    expect(record.url_qid).toBe('Q9999');
+  });
+
+  it('counts budget-skipped records separately (not rolled into no-replacement)', async () => {
+    // 8 subject-mismatch records, $0.60 each, $0.50 budget cap. After the
+    // first batch of 5 finishes (cost $3.0), the remaining tasks short-circuit.
+    // The fix: those short-circuited tasks count toward `budget_skipped`,
+    // not `no_replacement`, so a stingy --budget doesn't silently inflate
+    // the no-replacement number.
+    const verdicts = Array.from({ length: 8 }, (_, i) =>
+      makeVerdict({ recordId: `f_${i}`, entityId: 'anthropic', entityDisplayName: 'Anthropic' }),
+    );
+    stubVerdicts(verdicts);
+    const evidenceByKey: Record<string, Array<{ sourceUrl: string; checkerModel: string }>> = {};
+    for (const v of verdicts) {
+      evidenceByKey[`fact|${v.recordId}`] = [
+        { sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' },
+      ];
+    }
+    stubEvidence(evidenceByKey);
+    mockGetEntityWikidataQid.mockReturnValue('Q108542504');
+    mockSuggestUrls.mockResolvedValue({
+      candidates: [],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'q',
+      costUsd: 0.6,
+      subjectMismatches: [],
+    });
+
+    const result = await run({ apply: true, budget: '0.5', json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    // budget_skipped + no_replacement should sum to 8 (the subject-mismatch count).
+    // budget_skipped MUST be > 0 (some tasks short-circuited).
+    expect(parsed.summary.budget_exhausted).toBe(true);
+    expect(parsed.summary.budget_skipped).toBeGreaterThan(0);
+    expect(parsed.summary.no_replacement + parsed.summary.budget_skipped + parsed.summary.replaceable_url_found).toBe(8);
+  });
+
+  it('drops candidates whose URL exceeds the server cap (2048 chars)', async () => {
+    // A pathological provider response can produce a URL longer than the
+    // server's z.string().url().max(2048) cap. Without client-side dropping,
+    // the entire batch upsert would fail with a Zod error, killing dozens
+    // of legitimate suggestions.
+    stubVerdicts([makeVerdict({ recordId: 'f_oversized', entityId: 'anthropic' })]);
+    stubEvidence({
+      'fact|f_oversized': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' }],
+    });
+    mockGetEntityWikidataQid.mockReturnValue('Q108542504');
+    const oversizedUrl = 'https://anthropic.com/news?q=' + 'a'.repeat(2100);
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [
+        // Two candidates: one fits, one doesn't.
+        { url: 'https://anthropic.com/news/short', title: 't', snippet: 's', relevanceScore: null, sourceProvider: 'exa' },
+        { url: oversizedUrl, title: 'huge', snippet: 's', relevanceScore: null, sourceProvider: 'exa' },
+      ],
+      providersUsed: ['exa'], providersSkipped: [],
+      query: 'q', costUsd: 0, subjectMismatches: [],
+    });
+    mockUpsertUrlSuggestions.mockResolvedValueOnce({ ok: true, data: { upserted: 1 } });
+
+    const result = await run({ apply: true, json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.oversized_urls_dropped).toBe(1);
+    // Only the short URL was upserted.
+    expect(mockUpsertUrlSuggestions).toHaveBeenCalledWith([
+      expect.objectContaining({ suggestedUrl: 'https://anthropic.com/news/short' }),
+    ]);
+  });
+
+  it('paginates verdicts across multiple pages (regression for fetchAll loop)', async () => {
+    // Server returns total: 250 with two pages (200 + 50). Confirms the loop
+    // continues past the first page and stops when offset >= serverTotal.
+    const page1 = Array.from({ length: 200 }, (_, i) =>
+      makeVerdict({ recordId: `f_${i}`, entityId: 'anthropic', entityDisplayName: 'Anthropic' }),
+    );
+    const page2 = Array.from({ length: 50 }, (_, i) =>
+      makeVerdict({ recordId: `f_${200 + i}`, entityId: 'anthropic', entityDisplayName: 'Anthropic' }),
+    );
+    mockListVerdicts
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page1, total: 250 } })
+      .mockResolvedValueOnce({ ok: true, data: { verdicts: page2, total: 250 } });
+    stubEvidence({});
+    mockGetEntityWikidataQid.mockReturnValue(null);
+
+    const result = await run({ limit: '300', json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary.scanned).toBe(250);
+    expect(mockListVerdicts).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects --limit that is non-positive', async () => {
     stubVerdicts([]);
     const result = await run({ limit: 'abc' });
@@ -510,7 +647,12 @@ describe('sourcing-resolve-contradicted classification matrix', () => {
     { name: 'mismatching QIDs', existingUrl: 'https://www.wikidata.org/wiki/Q1', entityQid: 'Q2', expected: 'subject-mismatch' },
   ];
   it.each(cases)('$name → $expected', ({ existingUrl, entityQid, expected }) => {
-    const c = classifyContradicted({ verdict: baseVerdict, existingUrl, entityQid });
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl,
+      entitySlug: entityQid ? 'some-slug' : null,
+      entityQid,
+    });
     expect(c.bucket).toBe(expected);
   });
 });

--- a/crux/commands/sourcing-resolve-contradicted.test.ts
+++ b/crux/commands/sourcing-resolve-contradicted.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Tests for sourcing-resolve-contradicted (QUA-728).
+ *
+ * Covers the four classification buckets, the --apply path that calls
+ * suggestUrls + upsertUrlSuggestions, and the dry-run / JSON output shapes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockListVerdicts = vi.fn();
+const mockGetEvidenceByRecords = vi.fn();
+const mockUpsertUrlSuggestions = vi.fn();
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', () => ({
+  listVerdicts: (...args: unknown[]) => mockListVerdicts(...args),
+  getEvidenceByRecords: (...args: unknown[]) => mockGetEvidenceByRecords(...args),
+  upsertUrlSuggestions: (...args: unknown[]) => mockUpsertUrlSuggestions(...args),
+  evidenceRecordKey: (rt: string, rid: string) => `${rt}|${rid}`,
+  MAX_EVIDENCE_BY_RECORDS: 1000,
+}));
+
+vi.mock('../lib/sourcing/suggest-urls.ts', () => ({
+  suggestUrls: vi.fn(),
+  GENERATOR_MODEL: 'test-generator',
+}));
+
+vi.mock('../lib/sourcing/entity-wikidata-qid.ts', () => ({
+  getEntityWikidataQid: vi.fn(),
+}));
+
+import {
+  commands,
+  classifyContradicted,
+  resolveEntitySlug,
+  type ClassifiedRecord,
+} from './sourcing-resolve-contradicted.ts';
+import { suggestUrls } from '../lib/sourcing/suggest-urls.ts';
+import { getEntityWikidataQid } from '../lib/sourcing/entity-wikidata-qid.ts';
+
+const resolve = commands.default;
+const mockSuggestUrls = vi.mocked(suggestUrls);
+const mockGetEntityWikidataQid = vi.mocked(getEntityWikidataQid);
+
+type TestOpts = Record<string, string | boolean | undefined>;
+const run = (opts: TestOpts) => resolve([], opts as Parameters<typeof resolve>[1]);
+
+function makeVerdict(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    recordType: 'fact',
+    recordId: 'f_test_1',
+    fieldName: 'employees',
+    entityId: 'anthropic',
+    displayName: 'Anthropic employees',
+    entityDisplayName: 'Anthropic',
+    verdict: 'contradicted',
+    confidence: 0.85,
+    reasoning: 'Source said 500, fact says 1000',
+    sourcesChecked: 1,
+    needsRecheck: false,
+    nextCheckDue: '2026-05-06',
+    lastComputedAt: '2026-04-29',
+    createdAt: '2026-04-01',
+    updatedAt: '2026-04-29',
+    ...overrides,
+  };
+}
+
+function stubVerdicts(rows: Record<string, unknown>[]) {
+  mockListVerdicts.mockResolvedValueOnce({
+    ok: true,
+    data: { verdicts: rows, total: rows.length },
+  });
+}
+
+function stubEvidence(byKey: Record<string, Array<{ sourceUrl: string | null; checkerModel: string | null }>>) {
+  mockGetEvidenceByRecords.mockResolvedValue({
+    ok: true,
+    data: { evidenceByKey: byKey },
+  });
+}
+
+describe('resolveEntitySlug (pure)', () => {
+  it('prefers verdict.entityId when populated', () => {
+    const v = makeVerdict({ entityId: 'anthropic', recordType: 'fact' }) as never;
+    expect(resolveEntitySlug(v)).toBe('anthropic');
+  });
+
+  it('parses page:<slug>:<fn> for citation recordIds', () => {
+    const v = makeVerdict({
+      recordType: 'citation',
+      recordId: 'page:nist-ai-rmf:fn8',
+      entityId: null,
+    }) as never;
+    expect(resolveEntitySlug(v)).toBe('nist-ai-rmf');
+  });
+
+  it('handles citation slugs with hyphens and digits', () => {
+    const v = makeVerdict({
+      recordType: 'citation',
+      recordId: 'page:openai-2024-10-q3:fn123',
+      entityId: null,
+    }) as never;
+    expect(resolveEntitySlug(v)).toBe('openai-2024-10-q3');
+  });
+
+  it('returns null for non-citation records with no entityId', () => {
+    const v = makeVerdict({
+      recordType: 'personnel',
+      recordId: 'sid_personnel123',
+      entityId: null,
+    }) as never;
+    expect(resolveEntitySlug(v)).toBe(null);
+  });
+
+  it('returns null for malformed citation recordIds', () => {
+    const v = makeVerdict({
+      recordType: 'citation',
+      recordId: 'not-a-page-format',
+      entityId: null,
+    }) as never;
+    expect(resolveEntitySlug(v)).toBe(null);
+  });
+});
+
+describe('classifyContradicted (pure)', () => {
+  const baseVerdict = makeVerdict() as never;
+
+  it('returns no-source-url when existingUrl is null', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: null,
+      entityQid: 'Q108542504',
+    });
+    expect(c.bucket).toBe('no-source-url');
+    expect(c.urlQid).toBe(null);
+  });
+
+  it('returns indeterminate when URL has no Wikidata QID', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://nytimes.com/article/123',
+      entityQid: 'Q108542504',
+    });
+    expect(c.bucket).toBe('indeterminate');
+    expect(c.urlQid).toBe(null);
+    expect(c.entityQid).toBe('Q108542504');
+  });
+
+  it('returns indeterminate when entity has no QID even if URL does', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://www.wikidata.org/wiki/Q42',
+      entityQid: null,
+    });
+    expect(c.bucket).toBe('indeterminate');
+    expect(c.urlQid).toBe('Q42');
+    expect(c.entityQid).toBe(null);
+  });
+
+  it('returns subject-match when URL QID equals entity QID', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://www.wikidata.org/wiki/Q108542504',
+      entityQid: 'Q108542504',
+    });
+    expect(c.bucket).toBe('subject-match');
+    expect(c.urlQid).toBe('Q108542504');
+  });
+
+  it('returns subject-mismatch when URL QID differs from entity QID', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://www.wikidata.org/wiki/Q63041604', // xAI
+      entityQid: 'Q108542504', // Anthropic
+    });
+    expect(c.bucket).toBe('subject-mismatch');
+    expect(c.urlQid).toBe('Q63041604');
+    expect(c.entityQid).toBe('Q108542504');
+  });
+
+  it('handles wikidata.org/entity/Q-form URLs', () => {
+    const c = classifyContradicted({
+      verdict: baseVerdict,
+      existingUrl: 'https://www.wikidata.org/entity/Q42',
+      entityQid: 'Q42',
+    });
+    expect(c.bucket).toBe('subject-match');
+  });
+});
+
+describe('sourcing-resolve-contradicted command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSuggestUrls.mockReset();
+    mockGetEntityWikidataQid.mockReset();
+  });
+
+  it('dry-run by default — does not call suggestUrls or upsertUrlSuggestions', async () => {
+    stubVerdicts([
+      makeVerdict(),
+      makeVerdict({ recordId: 'f_test_2', entityId: 'openai' }),
+    ]);
+    stubEvidence({
+      'fact|f_test_1': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q42', checkerModel: 'haiku' }],
+      'fact|f_test_2': [{ sourceUrl: 'https://nytimes.com/x', checkerModel: 'haiku' }],
+    });
+    mockGetEntityWikidataQid.mockImplementation((slug) => {
+      if (slug === 'anthropic') return 'Q108542504';
+      if (slug === 'openai') return 'Q108547853';
+      return null;
+    });
+
+    const result = await run({});
+    expect(result.exitCode).toBe(0);
+    expect(mockSuggestUrls).not.toHaveBeenCalled();
+    expect(mockUpsertUrlSuggestions).not.toHaveBeenCalled();
+    // Anthropic record: URL Q42 != entity Q108542504 → subject-mismatch
+    // OpenAI record: nytimes URL has no QID → indeterminate
+    expect(result.output).toContain('subject-mismatch:     1');
+    expect(result.output).toContain('indeterminate:        1');
+  });
+
+  it('--apply writes URL suggestions only for subject-mismatch records', async () => {
+    stubVerdicts([
+      // subject-mismatch: URL Q63041604 vs entity Q108542504
+      makeVerdict({ recordId: 'f_mismatch', entityId: 'anthropic' }),
+      // subject-match: URL Q42 vs entity Q42
+      makeVerdict({ recordId: 'f_match', entityId: 'fortytwo' }),
+      // indeterminate: nytimes URL
+      makeVerdict({ recordId: 'f_indeterminate', entityId: 'openai' }),
+      // no-source-url
+      makeVerdict({ recordId: 'f_no_url', entityId: 'mistral' }),
+    ]);
+    stubEvidence({
+      'fact|f_mismatch': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' }],
+      'fact|f_match': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q42', checkerModel: 'haiku' }],
+      'fact|f_indeterminate': [{ sourceUrl: 'https://nytimes.com/x', checkerModel: 'haiku' }],
+      // f_no_url not present in evidenceByKey
+    });
+    mockGetEntityWikidataQid.mockImplementation((slug) => {
+      if (slug === 'anthropic') return 'Q108542504';
+      if (slug === 'fortytwo') return 'Q42';
+      if (slug === 'openai') return 'Q108547853';
+      return null; // mistral
+    });
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [
+        {
+          url: 'https://anthropic.com/news/employees',
+          title: 'Anthropic employees',
+          snippet: 'about 500 employees',
+          relevanceScore: null,
+          sourceProvider: 'exa',
+        },
+      ],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'q',
+      costUsd: 0.01,
+      subjectMismatches: [],
+    });
+    mockUpsertUrlSuggestions.mockResolvedValueOnce({
+      ok: true,
+      data: { upserted: 1 },
+    });
+
+    const result = await run({ apply: true });
+    expect(result.exitCode).toBe(0);
+    // Only the subject-mismatch record should reach suggestUrls.
+    expect(mockSuggestUrls).toHaveBeenCalledTimes(1);
+    expect(mockSuggestUrls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityWikidataQid: 'Q108542504',
+        existingUrl: 'https://www.wikidata.org/wiki/Q63041604',
+      }),
+    );
+    expect(mockUpsertUrlSuggestions).toHaveBeenCalledTimes(1);
+    expect(mockUpsertUrlSuggestions).toHaveBeenCalledWith([
+      expect.objectContaining({
+        recordType: 'fact',
+        recordId: 'f_mismatch',
+        suggestedUrl: 'https://anthropic.com/news/employees',
+        status: 'pending',
+      }),
+    ]);
+    expect(result.output).toContain('1 suggestion(s) written across 1 record(s)');
+  });
+
+  it('--apply with no candidates from suggestUrls counts as no-replacement', async () => {
+    stubVerdicts([makeVerdict({ recordId: 'f_mismatch', entityId: 'anthropic' })]);
+    stubEvidence({
+      'fact|f_mismatch': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' }],
+    });
+    mockGetEntityWikidataQid.mockReturnValue('Q108542504');
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'q',
+      costUsd: 0,
+      subjectMismatches: [
+        { url: 'https://example.com/wrong', candidateQid: 'Q9999', entityQid: 'Q108542504' },
+      ],
+    });
+
+    const result = await run({ apply: true });
+    expect(result.exitCode).toBe(0);
+    expect(mockSuggestUrls).toHaveBeenCalledTimes(1);
+    expect(mockUpsertUrlSuggestions).not.toHaveBeenCalled();
+    expect(result.output).toContain('Replaceable URL found:  0');
+    expect(result.output).toContain('No replacement:         1');
+    expect(result.output).toContain('Provider gate drops:    1');
+  });
+
+  it('--type filter passes through to listVerdicts', async () => {
+    stubVerdicts([]);
+    const result = await run({ type: 'personnel' });
+    expect(result.exitCode).toBe(0);
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ recordType: 'personnel', verdict: 'contradicted' }),
+    );
+  });
+
+  it('--entity filter trims to one entity', async () => {
+    stubVerdicts([
+      makeVerdict({ recordId: 'f_a', entityId: 'anthropic', entityDisplayName: 'Anthropic' }),
+      makeVerdict({ recordId: 'f_b', entityId: 'openai', entityDisplayName: 'OpenAI' }),
+    ]);
+    stubEvidence({});
+    mockGetEntityWikidataQid.mockReturnValue(null);
+    const result = await run({ entity: 'anthropic' });
+    expect(result.exitCode).toBe(0);
+    // Only f_a should appear in scanned counts.
+    expect(result.output).toContain('Scanned:                1');
+  });
+
+  it('--json emits machine-readable output with the four buckets', async () => {
+    stubVerdicts([
+      makeVerdict({ recordId: 'f_mismatch', entityId: 'anthropic' }),
+      makeVerdict({ recordId: 'f_match', entityId: 'fortytwo' }),
+    ]);
+    stubEvidence({
+      'fact|f_mismatch': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' }],
+      'fact|f_match': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q42', checkerModel: 'haiku' }],
+    });
+    mockGetEntityWikidataQid.mockImplementation((slug) => {
+      if (slug === 'anthropic') return 'Q108542504';
+      if (slug === 'fortytwo') return 'Q42';
+      return null;
+    });
+
+    const result = await run({ json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.summary).toMatchObject({
+      scanned: 2,
+      by_bucket: {
+        'subject-mismatch': 1,
+        'subject-match': 1,
+        indeterminate: 0,
+        'no-source-url': 0,
+      },
+      dry_run: true,
+    });
+    expect(parsed.records).toHaveLength(2);
+    const mismatch = parsed.records.find((r: { record_id: string }) => r.record_id === 'f_mismatch');
+    expect(mismatch).toMatchObject({
+      bucket: 'subject-mismatch',
+      url_qid: 'Q63041604',
+      entity_qid: 'Q108542504',
+    });
+  });
+
+  it('surfaces listVerdicts failures with a clear error', async () => {
+    mockListVerdicts.mockResolvedValueOnce({
+      ok: false,
+      message: 'connection refused',
+      error: { code: 'HTTP_500' },
+    });
+    const result = await run({});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Failed to fetch contradicted verdicts');
+    expect(result.output).toContain('connection refused');
+  });
+
+  it('surfaces evidence batch failures with a clear error', async () => {
+    stubVerdicts([makeVerdict()]);
+    mockGetEvidenceByRecords.mockResolvedValueOnce({
+      ok: false,
+      message: 'evidence fetch failed',
+      error: { code: 'HTTP_500' },
+    });
+    const result = await run({});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Failed to batch-fetch evidence');
+  });
+
+  it('surfaces upsert failures during --apply', async () => {
+    stubVerdicts([makeVerdict({ recordId: 'f_mismatch', entityId: 'anthropic' })]);
+    stubEvidence({
+      'fact|f_mismatch': [{ sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' }],
+    });
+    mockGetEntityWikidataQid.mockReturnValue('Q108542504');
+    mockSuggestUrls.mockResolvedValueOnce({
+      candidates: [{
+        url: 'https://anthropic.com/news', title: 't', snippet: 's',
+        relevanceScore: null, sourceProvider: 'exa',
+      }],
+      providersUsed: ['exa'], providersSkipped: [],
+      query: 'q', costUsd: 0, subjectMismatches: [],
+    });
+    mockUpsertUrlSuggestions.mockResolvedValueOnce({
+      ok: false,
+      message: 'duplicate key',
+    });
+
+    const result = await run({ apply: true });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('upsert failed');
+    expect(result.output).toContain('duplicate key');
+  });
+
+  it('honors --budget by short-circuiting tasks past the cap', async () => {
+    // 8 subject-mismatch records, $0.60 each. With internal concurrency 5,
+    // the first batch of 5 all pass the gate (cost=0 at start) and finish
+    // with cost=3.0; the remaining 3 short-circuit before calling suggestUrls
+    // because the gate trips.
+    const verdicts = Array.from({ length: 8 }, (_, i) =>
+      makeVerdict({ recordId: `f_${i}`, entityId: 'anthropic', entityDisplayName: 'Anthropic' }),
+    );
+    stubVerdicts(verdicts);
+    const evidenceByKey: Record<string, Array<{ sourceUrl: string; checkerModel: string }>> = {};
+    for (const v of verdicts) {
+      evidenceByKey[`fact|${v.recordId}`] = [
+        { sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' },
+      ];
+    }
+    stubEvidence(evidenceByKey);
+    mockGetEntityWikidataQid.mockReturnValue('Q108542504');
+    mockSuggestUrls.mockResolvedValue({
+      candidates: [],
+      providersUsed: ['exa'],
+      providersSkipped: [],
+      query: 'q',
+      costUsd: 0.6,
+      subjectMismatches: [],
+    });
+
+    const result = await run({ apply: true, budget: '0.5' });
+    expect(result.exitCode).toBe(0);
+    // First batch runs (5 calls) and exhausts the budget; the remaining 3
+    // short-circuit. Exact call count can vary by scheduling but must be
+    // strictly less than the 8 records.
+    expect(mockSuggestUrls.mock.calls.length).toBeLessThan(verdicts.length);
+    expect(result.output).toContain('Budget exhausted:       yes');
+  });
+
+  it('resolves citation page slug → entity QID even when verdict.entityId is null', async () => {
+    // Citation recordIds carry the wiki page slug (which is the entity slug
+    // in this codebase). Without slug-parsing this row would land in
+    // 'indeterminate' even when external-links.yaml has a QID.
+    stubVerdicts([
+      makeVerdict({
+        recordType: 'citation',
+        recordId: 'page:anthropic:fn3',
+        entityId: null,
+      }),
+    ]);
+    stubEvidence({
+      'citation|page:anthropic:fn3': [
+        { sourceUrl: 'https://www.wikidata.org/wiki/Q63041604', checkerModel: 'haiku' },
+      ],
+    });
+    mockGetEntityWikidataQid.mockImplementation((slug) =>
+      slug === 'anthropic' ? 'Q108542504' : null,
+    );
+
+    const result = await run({});
+    expect(result.exitCode).toBe(0);
+    // URL Q63041604 != entity Q108542504 → subject-mismatch
+    expect(result.output).toContain('subject-mismatch:     1');
+    // Sanity-check: getEntityWikidataQid was called with the parsed slug.
+    expect(mockGetEntityWikidataQid).toHaveBeenCalledWith('anthropic');
+  });
+
+  it('rejects --limit that is non-positive', async () => {
+    stubVerdicts([]);
+    const result = await run({ limit: 'abc' });
+    expect(result.exitCode).toBe(0);
+    // Falls back to default; non-numeric input is logged but not fatal.
+    expect(mockListVerdicts).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 200 }),
+    );
+  });
+});
+
+describe('sourcing-resolve-contradicted classification matrix', () => {
+  // Sanity matrix to lock in the bucket assignment table from the help text.
+  const baseVerdict = makeVerdict() as never;
+  const cases: Array<{
+    name: string;
+    existingUrl: string | null;
+    entityQid: string | null;
+    expected: ClassifiedRecord['bucket'];
+  }> = [
+    { name: 'no URL, has entity QID', existingUrl: null, entityQid: 'Q1', expected: 'no-source-url' },
+    { name: 'URL no QID, has entity QID', existingUrl: 'https://x.com/a', entityQid: 'Q1', expected: 'indeterminate' },
+    { name: 'URL has QID, no entity QID', existingUrl: 'https://www.wikidata.org/wiki/Q1', entityQid: null, expected: 'indeterminate' },
+    { name: 'matching QIDs', existingUrl: 'https://www.wikidata.org/wiki/Q1', entityQid: 'Q1', expected: 'subject-match' },
+    { name: 'mismatching QIDs', existingUrl: 'https://www.wikidata.org/wiki/Q1', entityQid: 'Q2', expected: 'subject-mismatch' },
+  ];
+  it.each(cases)('$name → $expected', ({ existingUrl, entityQid, expected }) => {
+    const c = classifyContradicted({ verdict: baseVerdict, existingUrl, entityQid });
+    expect(c.bucket).toBe(expected);
+  });
+});

--- a/crux/commands/sourcing-resolve-contradicted.ts
+++ b/crux/commands/sourcing-resolve-contradicted.ts
@@ -1,0 +1,643 @@
+/**
+ * Sourcing Resolve Contradicted — QUA-728
+ *
+ * Sweep tool for the existing `contradicted` source-check verdicts. The QUA-650
+ * retro-scan reasoning indicated many of these are subject-identity mismatches
+ * (the source is about a different entity than the record's). This command
+ * classifies each contradicted verdict by comparing the existing source URL's
+ * Wikidata QID against the record's entity QID, then optionally queues
+ * URL-replacement suggestions for the subject-mismatch bucket.
+ *
+ * Buckets:
+ *   subject-mismatch    Existing URL has a Wikidata QID that differs from
+ *                       the entity QID → URL is wrong, eligible for repair.
+ *   subject-match       Existing URL has a QID that matches the entity QID →
+ *                       URL is about the right entity; the contradiction is
+ *                       likely a data-value error, leave for manual triage.
+ *   indeterminate       URL has no extractable QID OR the entity has no
+ *                       recorded Wikidata QID → cannot decide deterministically.
+ *   no-source-url       No evidence row carries a sourceUrl.
+ *
+ * Two-step workflow:
+ *   1. `crux sourcing-resolve-contradicted --apply` — classifies + writes URL
+ *      suggestions (status='pending') for the `subject-mismatch` bucket. The
+ *      QUA-724 subject-identity gate pre-filters candidate URLs at suggest time
+ *      so the new URLs are guaranteed to point at the right entity.
+ *   2. Operator/auto-approver runs `crux sourcing-apply-suggestions` to swap
+ *      the source URL and re-verify the verdict. That command updates the
+ *      verdict (contradicted → confirmed/partial/etc.) and is what actually
+ *      drops the system contradicted count.
+ *
+ * Defaults to dry-run (preview). Pass `--apply` to write suggestions.
+ */
+
+import type {
+  CommandOptions as BaseOptions,
+  CommandResult,
+} from '../lib/command-types.ts';
+import {
+  listVerdicts,
+  getEvidenceByRecords,
+  evidenceRecordKey,
+  MAX_EVIDENCE_BY_RECORDS,
+  upsertUrlSuggestions,
+  type VerdictListEntry,
+} from '../lib/wiki-server/sourcing-client.ts';
+import { extractQid } from '../lib/sourcing/wikidata-matcher.ts';
+import { getEntityWikidataQid } from '../lib/sourcing/entity-wikidata-qid.ts';
+import { suggestUrls, GENERATOR_MODEL } from '../lib/sourcing/suggest-urls.ts';
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 2000;
+const DEFAULT_BUDGET_USD = 1.0;
+const DEFAULT_MAX_CANDIDATES = 3;
+const MAX_CANDIDATES_PER_RECORD = 10;
+const PAGE_SIZE = 200;
+const UPSERT_CHUNK = 100;
+const DEFAULT_CONCURRENCY = 5;
+// Mirrors the server-side input caps in
+// apps/wiki-server/src/routes/sourcing/url-suggestions.ts SuggestionInput.
+const MAX_TITLE_CHARS = 500;
+const MAX_SNIPPET_CHARS = 2000;
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+/** One of four classification buckets. */
+export type ContradictedBucket =
+  | 'subject-mismatch'
+  | 'subject-match'
+  | 'indeterminate'
+  | 'no-source-url';
+
+export interface ClassifiedRecord {
+  verdict: VerdictListEntry;
+  /** Latest evidence sourceUrl, or null when no evidence carries one. */
+  existingUrl: string | null;
+  /** Wikidata QID extracted from `existingUrl` (or null). */
+  urlQid: string | null;
+  /** Wikidata QID for `verdict.entityId` (or null). */
+  entityQid: string | null;
+  bucket: ContradictedBucket;
+  /** Set after `--apply` if suggestUrls produced ≥1 candidate. */
+  candidatesFound?: number;
+}
+
+interface ResolveOptions extends BaseOptions {
+  limit?: string;
+  type?: string;
+  entity?: string;
+  budget?: string;
+  'max-candidates'?: string;
+  maxCandidates?: string;
+  apply?: boolean;
+  json?: boolean;
+  ci?: boolean;
+}
+
+interface RunSummary {
+  scanned: number;
+  bySource: Record<ContradictedBucket, number>;
+  /** Records where suggestUrls produced ≥1 candidate (subject-mismatch only). */
+  replaceableUrlFound: number;
+  /** Records where suggestUrls returned 0 candidates after the gate. */
+  noReplacement: number;
+  /** Total candidate URLs upserted (across replaceableUrlFound records). */
+  suggestionsWritten: number;
+  costUsd: number;
+  budgetExhausted: boolean;
+  providerErrors: number;
+  /** Records that hit suggestUrls but the gate dropped some candidates. */
+  subjectMismatchesDropped: number;
+}
+
+function makeSummary(): RunSummary {
+  return {
+    scanned: 0,
+    bySource: {
+      'subject-mismatch': 0,
+      'subject-match': 0,
+      indeterminate: 0,
+      'no-source-url': 0,
+    },
+    replaceableUrlFound: 0,
+    noReplacement: 0,
+    suggestionsWritten: 0,
+    costUsd: 0,
+    budgetExhausted: false,
+    providerErrors: 0,
+    subjectMismatchesDropped: 0,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function parseBoundedInt(
+  raw: unknown,
+  fallback: number,
+  max: number,
+  flag: string,
+): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseInt(String(raw), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive integer)\n`);
+    return fallback;
+  }
+  return Math.min(n, max);
+}
+
+function parsePositiveFloat(raw: unknown, fallback: number, flag: string): number {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  const n = parseFloat(String(raw));
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`warning: ignoring --${flag}=${raw} (expected positive number)\n`);
+    return fallback;
+  }
+  return n;
+}
+
+function clampForUpsert(
+  value: string | null | undefined,
+  max: number,
+): string | null | undefined {
+  if (value == null) return value;
+  return value.length <= max ? value : value.slice(0, max);
+}
+
+/** Minimal concurrency pool — same pattern as sourcing-suggest-urls. */
+async function runWithConcurrency<T>(
+  concurrency: number,
+  tasks: Array<() => Promise<T>>,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, worker));
+  return results;
+}
+
+// ── Verdict pagination ────────────────────────────────────────────────
+
+async function fetchAllContradictedVerdicts(opts: {
+  recordType?: string;
+  entity?: string;
+  limit: number;
+}): Promise<{ rows: VerdictListEntry[]; serverTotal: number }> {
+  const collected: VerdictListEntry[] = [];
+  let serverTotal = 0;
+  let offset = 0;
+  while (collected.length < opts.limit) {
+    const pageSize = Math.min(PAGE_SIZE, opts.limit - collected.length);
+    const response = await listVerdicts({
+      verdict: 'contradicted',
+      recordType: opts.recordType,
+      limit: pageSize,
+      offset,
+    });
+    if (!response.ok) {
+      throw new Error(`listVerdicts failed: ${response.message ?? 'unknown error'}`);
+    }
+    serverTotal = response.data.total;
+    const rows = response.data.verdicts;
+    if (rows.length === 0) break;
+    collected.push(...rows);
+    offset += rows.length;
+    if (offset >= serverTotal) break;
+  }
+  // Optional client-side entity filter — same shape as sourcing-suggest-urls.
+  // The server's listVerdicts route doesn't accept an entity filter, so we
+  // page everything and trim here. Acceptable for our scale (<1k rows).
+  if (opts.entity) {
+    const want = opts.entity;
+    return {
+      rows: collected.filter(
+        (v) =>
+          v.entityId === want ||
+          (v.entityDisplayName ?? '').toLowerCase() === want.toLowerCase(),
+      ),
+      serverTotal,
+    };
+  }
+  return { rows: collected, serverTotal };
+}
+
+// ── Entity-slug resolution ────────────────────────────────────────────
+
+/**
+ * Resolve the entity slug for a verdict. Falls back through:
+ *   1. `verdict.entityId` if non-null (preferred — written by recent
+ *      verdict-write paths).
+ *   2. Citation recordIds of the form `page:<slug>:<fn>` — wiki page slugs
+ *      are entity slugs in this codebase (`data/entities/<slug>.yaml`
+ *      pairs with `content/docs/.../<slug>.mdx`), so we can parse the slug
+ *      out of the recordId for free.
+ *
+ * Returns null when neither path yields a slug. The caller treats null as
+ * "indeterminate" — we can't know the entity QID without a slug.
+ *
+ * NOTE: We do NOT fall back to fetching the underlying record (e.g.
+ * personnel → org slug) here. That would require per-record-type API
+ * calls and join logic; the data-quality fix is to backfill
+ * `source_check_verdicts.entity_id` server-side rather than have every
+ * client resolve it. See QUA-728's PR description for the dry-run finding
+ * that 100% of contradicted verdicts currently have `entityId=null`.
+ */
+export function resolveEntitySlug(verdict: VerdictListEntry): string | null {
+  if (verdict.entityId) return verdict.entityId;
+  if (verdict.recordType === 'citation') {
+    // page:<slug>:<fn>  e.g.  page:nist-ai-rmf:fn8
+    const match = verdict.recordId.match(/^page:([^:]+):/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+// ── Classification ────────────────────────────────────────────────────
+
+/**
+ * Classify one verdict by comparing its existing source URL's QID to the
+ * entity's QID. Pure function so tests can exercise the matrix without
+ * setting up the full command.
+ */
+export function classifyContradicted(input: {
+  verdict: VerdictListEntry;
+  existingUrl: string | null;
+  entityQid: string | null;
+}): ClassifiedRecord {
+  const { verdict, existingUrl, entityQid } = input;
+  if (!existingUrl) {
+    return {
+      verdict,
+      existingUrl,
+      urlQid: null,
+      entityQid,
+      bucket: 'no-source-url',
+    };
+  }
+  const urlQid = extractQid(existingUrl);
+  if (!urlQid || !entityQid) {
+    return {
+      verdict,
+      existingUrl,
+      urlQid,
+      entityQid,
+      bucket: 'indeterminate',
+    };
+  }
+  if (urlQid === entityQid) {
+    return {
+      verdict,
+      existingUrl,
+      urlQid,
+      entityQid,
+      bucket: 'subject-match',
+    };
+  }
+  return {
+    verdict,
+    existingUrl,
+    urlQid,
+    entityQid,
+    bucket: 'subject-mismatch',
+  };
+}
+
+// ── Output formatting ─────────────────────────────────────────────────
+
+function summaryToJson(s: RunSummary, dryRun: boolean) {
+  return {
+    scanned: s.scanned,
+    by_bucket: { ...s.bySource },
+    replaceable_url_found: s.replaceableUrlFound,
+    no_replacement: s.noReplacement,
+    suggestions_written: s.suggestionsWritten,
+    subject_mismatches_dropped: s.subjectMismatchesDropped,
+    cost_usd: Number(s.costUsd.toFixed(4)),
+    budget_exhausted: s.budgetExhausted,
+    provider_errors: s.providerErrors,
+    dry_run: dryRun,
+  };
+}
+
+function formatSummary(s: RunSummary, dryRun: boolean): string {
+  const writtenLine = dryRun
+    ? '(dry-run; no writes)'
+    : `${s.suggestionsWritten} suggestion(s) written across ${s.replaceableUrlFound} record(s)`;
+  return `
+=== Summary ===
+Scanned:                ${s.scanned}
+  subject-mismatch:     ${s.bySource['subject-mismatch']} (URL is about wrong entity → repair)
+  subject-match:        ${s.bySource['subject-match']} (URL OK → likely value-mismatch, manual triage)
+  indeterminate:        ${s.bySource.indeterminate} (no QID on URL or entity)
+  no-source-url:        ${s.bySource['no-source-url']}
+Replaceable URL found:  ${s.replaceableUrlFound}
+No replacement:         ${s.noReplacement}
+URL suggestions:        ${writtenLine}
+Provider gate drops:    ${s.subjectMismatchesDropped}
+Provider errors:        ${s.providerErrors}
+Cost:                   $${s.costUsd.toFixed(4)}
+Budget exhausted:       ${s.budgetExhausted ? 'yes' : 'no'}
+`.trim();
+}
+
+// ── Main command ──────────────────────────────────────────────────────
+
+async function resolveContradictedCommand(
+  _args: string[],
+  options: ResolveOptions,
+): Promise<CommandResult> {
+  const limit = parseBoundedInt(options.limit, DEFAULT_LIMIT, MAX_LIMIT, 'limit');
+  const budgetCap = parsePositiveFloat(options.budget, DEFAULT_BUDGET_USD, 'budget');
+  const maxCandidates = parseBoundedInt(
+    options['max-candidates'] ?? options.maxCandidates,
+    DEFAULT_MAX_CANDIDATES,
+    MAX_CANDIDATES_PER_RECORD,
+    'max-candidates',
+  );
+  const recordTypeFilter = options.type?.trim() || undefined;
+  const entityFilter = options.entity?.trim() || undefined;
+  const apply = Boolean(options.apply);
+  const isJson = Boolean(options.json || options.ci);
+
+  const log = (msg: string) => { if (!isJson) console.log(msg); };
+
+  log('Sourcing Resolve Contradicted (QUA-728)');
+  log(`  limit:          ${limit}`);
+  if (recordTypeFilter) log(`  record type:    ${recordTypeFilter}`);
+  if (entityFilter) log(`  entity:         ${entityFilter}`);
+  log(`  apply:          ${apply ? 'yes (writes URL suggestions)' : 'no (dry-run)'}`);
+  if (apply) {
+    log(`  budget:         $${budgetCap.toFixed(2)}`);
+    log(`  max-candidates: ${maxCandidates}`);
+  }
+  log('');
+
+  const summary = makeSummary();
+
+  // ── Step 1: fetch all contradicted verdicts ───────────────────────
+  let pageResult: { rows: VerdictListEntry[]; serverTotal: number };
+  try {
+    pageResult = await fetchAllContradictedVerdicts({
+      recordType: recordTypeFilter,
+      entity: entityFilter,
+      limit,
+    });
+  } catch (e: unknown) {
+    return {
+      exitCode: 1,
+      output: `Failed to fetch contradicted verdicts: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  const verdicts = pageResult.rows;
+  log(`Fetched ${verdicts.length} contradicted verdict(s)${pageResult.serverTotal > verdicts.length ? ` (${pageResult.serverTotal} total on server)` : ''}.`);
+
+  if (verdicts.length === 0) {
+    const output = isJson
+      ? JSON.stringify({ summary: summaryToJson(summary, !apply), records: [] })
+      : `No contradicted verdicts matched.`;
+    return { exitCode: 0, output };
+  }
+
+  // ── Step 2: batch-fetch evidence to learn each record's existing URL ──
+  const existingUrlByKey = new Map<string, string | null>();
+  for (let i = 0; i < verdicts.length; i += MAX_EVIDENCE_BY_RECORDS) {
+    const chunk = verdicts.slice(i, i + MAX_EVIDENCE_BY_RECORDS);
+    const evidenceRes = await getEvidenceByRecords(
+      chunk.map((v) => ({ recordType: v.recordType, recordId: v.recordId })),
+      { limitPerRecord: 5 },
+    );
+    if (!evidenceRes.ok) {
+      return {
+        exitCode: 1,
+        output: `Failed to batch-fetch evidence: ${evidenceRes.message ?? 'unknown error'}`,
+      };
+    }
+    for (const [key, rows] of Object.entries(evidenceRes.data.evidenceByKey)) {
+      // Pick the latest evidence row that carries a sourceUrl. Server returns
+      // rows ordered by `checked_at DESC` so `rows[0]` is the latest. We don't
+      // skip deterministic checkers here (unlike retro-scan-subjects) because
+      // a deterministic checker confirming a `contradicted` outcome already
+      // means the URL is OK and the value is wrong — i.e. the row will land
+      // in `subject-match` if the URL has a Wikidata QID, which is the
+      // correct disposition.
+      existingUrlByKey.set(key, rows.find((r) => r.sourceUrl)?.sourceUrl ?? null);
+    }
+  }
+
+  // ── Step 3: classify each verdict ────────────────────────────────
+  const classified: ClassifiedRecord[] = verdicts.map((v) => {
+    const existingUrl = existingUrlByKey.get(evidenceRecordKey(v.recordType, v.recordId)) ?? null;
+    const entitySlug = resolveEntitySlug(v);
+    const entityQid = getEntityWikidataQid(entitySlug);
+    return classifyContradicted({ verdict: v, existingUrl, entityQid });
+  });
+  for (const c of classified) {
+    summary.scanned++;
+    summary.bySource[c.bucket]++;
+  }
+
+  // ── Step 4: in --apply mode, suggest URL replacements for subject-mismatch ──
+  type UpsertInput = Parameters<typeof upsertUrlSuggestions>[0][number];
+  const toUpsert: UpsertInput[] = [];
+  if (apply) {
+    const eligible = classified.filter((c) => c.bucket === 'subject-mismatch');
+    log(`Generating URL suggestions for ${eligible.length} subject-mismatch record(s)…`);
+
+    const tasks = eligible.map((c) => async () => {
+      // Shared budget gate.
+      if (summary.costUsd >= budgetCap) {
+        if (!summary.budgetExhausted) {
+          summary.budgetExhausted = true;
+          log(`Budget reached ($${summary.costUsd.toFixed(4)} >= $${budgetCap.toFixed(2)}); skipping remaining records.`);
+        }
+        return;
+      }
+      const v = c.verdict;
+      const claimText = v.reasoning?.trim() || v.displayName?.trim() || '';
+      // Prefer the verdict's display name; fall back to the resolved entity
+      // slug. The slug isn't a perfect search query but beats nothing.
+      const resolvedSlug = resolveEntitySlug(v);
+      const entityName =
+        v.entityDisplayName?.trim() || resolvedSlug || v.displayName?.trim() || '';
+      if (!claimText || !entityName) {
+        // Treat as no-replacement; subject-mismatch with no usable text.
+        c.candidatesFound = 0;
+        return;
+      }
+
+      const result = await suggestUrls({
+        entityName,
+        claimText,
+        fieldName: v.fieldName ?? undefined,
+        existingUrl: c.existingUrl,
+        maxCandidates,
+        // Pass the entity QID so the gate pre-filters candidate URLs that
+        // don't point at this entity. Without this we'd risk replacing one
+        // wrong URL with another wrong URL.
+        entityWikidataQid: c.entityQid,
+      });
+
+      summary.costUsd += result.costUsd;
+      for (const p of result.providersSkipped) {
+        if (!p.endsWith(':no-key')) summary.providerErrors++;
+      }
+      if (result.subjectMismatches.length > 0) {
+        summary.subjectMismatchesDropped += result.subjectMismatches.length;
+      }
+      c.candidatesFound = result.candidates.length;
+
+      for (const cand of result.candidates) {
+        toUpsert.push({
+          recordType: v.recordType,
+          recordId: v.recordId,
+          fieldName: v.fieldName,
+          entityId: v.entityId,
+          suggestedUrl: cand.url,
+          title: clampForUpsert(cand.title, MAX_TITLE_CHARS),
+          snippet: clampForUpsert(cand.snippet, MAX_SNIPPET_CHARS),
+          relevanceScore: cand.relevanceScore,
+          sourceProvider: cand.sourceProvider,
+          generatorModel: GENERATOR_MODEL,
+          // Keep contradicted suggestions at 'pending' — humans should approve
+          // before swap+recheck. Conservative posture for high-stakes records.
+          status: 'pending',
+        });
+      }
+    });
+    await runWithConcurrency(DEFAULT_CONCURRENCY, tasks);
+
+    // Tally replaceable vs no-replacement after suggestions ran.
+    for (const c of classified) {
+      if (c.bucket !== 'subject-mismatch') continue;
+      if ((c.candidatesFound ?? 0) > 0) summary.replaceableUrlFound++;
+      else summary.noReplacement++;
+    }
+
+    // Upsert in chunks (server caps at 200; chunk at 100 for headroom).
+    if (toUpsert.length > 0) {
+      for (let i = 0; i < toUpsert.length; i += UPSERT_CHUNK) {
+        const chunk = toUpsert.slice(i, i + UPSERT_CHUNK);
+        const upsert = await upsertUrlSuggestions(chunk);
+        if (!upsert.ok) {
+          return {
+            exitCode: 1,
+            output: `upsert failed at chunk ${i / UPSERT_CHUNK + 1}: ${upsert.message ?? 'unknown error'}`,
+          };
+        }
+        summary.suggestionsWritten += upsert.data.upserted;
+      }
+    }
+  } else {
+    // Dry-run: nothing to do, but the summary needs replaceable/no-replacement
+    // tallies derived purely from classification (without suggestUrls).
+    // In dry-run we cannot know how many candidates suggestUrls would return,
+    // so report subject-mismatch count under "potentially replaceable" without
+    // splitting it. The replaceable_url_found and no_replacement counters stay
+    // at 0 in the JSON to make this distinction explicit.
+  }
+
+  // ── Step 5: emit the report ────────────────────────────────────────
+  const records = classified.map((c) => ({
+    record_type: c.verdict.recordType,
+    record_id: c.verdict.recordId,
+    entity_id: c.verdict.entityId,
+    entity_display_name: c.verdict.entityDisplayName,
+    field_name: c.verdict.fieldName,
+    existing_url: c.existingUrl,
+    url_qid: c.urlQid,
+    entity_qid: c.entityQid,
+    bucket: c.bucket,
+    candidates_found: c.candidatesFound ?? null,
+  }));
+
+  // Per-record table for the human path. Limit to the most actionable bucket
+  // first so operators don't have to scroll past "subject-match" rows.
+  if (!isJson) {
+    const buckets: ContradictedBucket[] = [
+      'subject-mismatch',
+      'indeterminate',
+      'subject-match',
+      'no-source-url',
+    ];
+    for (const bucket of buckets) {
+      const rows = classified.filter((c) => c.bucket === bucket);
+      if (rows.length === 0) continue;
+      log('');
+      log(`── ${bucket} (${rows.length}) ──`);
+      for (const c of rows) {
+        const v = c.verdict;
+        const name = v.displayName ?? v.entityDisplayName ?? v.recordId;
+        const qids = c.urlQid && c.entityQid
+          ? `URL=${c.urlQid} entity=${c.entityQid}`
+          : c.urlQid
+            ? `URL=${c.urlQid} entity=?`
+            : c.entityQid
+              ? `URL=? entity=${c.entityQid}`
+              : 'no QIDs';
+        const cands = c.candidatesFound != null ? ` candidates=${c.candidatesFound}` : '';
+        log(`  ${v.recordType}/${v.recordId}  ${qids}${cands}`);
+        log(`    name:    ${String(name).slice(0, 80)}`);
+        if (c.existingUrl) log(`    url:     ${c.existingUrl.slice(0, 100)}`);
+      }
+    }
+  }
+
+  const output = isJson
+    ? JSON.stringify({ summary: summaryToJson(summary, !apply), records })
+    : formatSummary(summary, !apply);
+  return { exitCode: 0, output };
+}
+
+// ── Exports ───────────────────────────────────────────────────────────
+
+export const commands = {
+  default: resolveContradictedCommand,
+};
+
+export function getHelp(): string {
+  return `
+Sourcing Resolve Contradicted — sweep + classify + queue URL replacements
+                                  for contradicted source-check verdicts (QUA-728).
+
+Usage:
+  crux sourcing-resolve-contradicted [options]
+
+Options:
+  --limit=N            Max verdicts to scan (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})
+  --type=X             Filter by record type (e.g., fact, grant, personnel)
+  --entity=X           Filter by entityId or entityDisplayName
+  --apply              Write URL suggestions for the subject-mismatch bucket.
+                       Without this flag the command runs as a dry-run that only
+                       classifies and reports.
+  --budget=N           USD cap on suggestUrls provider spend (default: $${DEFAULT_BUDGET_USD.toFixed(2)}).
+  --max-candidates=N   Candidates per record (default: ${DEFAULT_MAX_CANDIDATES}, max: ${MAX_CANDIDATES_PER_RECORD})
+  --json / --ci        Machine-readable JSON output
+
+Buckets:
+  subject-mismatch   URL has a Wikidata QID that differs from the entity QID →
+                     URL is wrong, eligible for repair via URL replacement.
+  subject-match      URL QID matches the entity QID → URL is about the right
+                     entity, contradiction is likely a data-value error
+                     (manual triage).
+  indeterminate      URL has no extractable QID OR the entity has no recorded
+                     Wikidata QID — cannot decide deterministically.
+  no-source-url      No evidence row carries a sourceUrl.
+
+Workflow:
+  1. crux sourcing-resolve-contradicted                     # dry-run preview
+  2. crux sourcing-resolve-contradicted --apply             # writes URL suggestions
+  3. (operator) review suggestions in /internal/url-suggestions
+  4. crux sourcing-apply-suggestions --status=approved      # swap + recheck
+
+Step 4 is what actually re-verifies and drops the system contradicted count.
+This command only classifies + queues; it never mutates verdicts directly.
+
+Requires WIKI_SERVER_ENV=prod in agent slots.
+`.trim();
+}

--- a/crux/commands/sourcing-resolve-contradicted.ts
+++ b/crux/commands/sourcing-resolve-contradicted.ts
@@ -59,6 +59,10 @@ const DEFAULT_CONCURRENCY = 5;
 // apps/wiki-server/src/routes/sourcing/url-suggestions.ts SuggestionInput.
 const MAX_TITLE_CHARS = 500;
 const MAX_SNIPPET_CHARS = 2000;
+// Server caps `suggestedUrl` at 2048; a candidate above this would fail the
+// whole batch upsert, so we drop the candidate client-side rather than
+// truncate (a truncated URL points at the wrong page).
+const MAX_URL_CHARS = 2048;
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -75,10 +79,17 @@ export interface ClassifiedRecord {
   existingUrl: string | null;
   /** Wikidata QID extracted from `existingUrl` (or null). */
   urlQid: string | null;
-  /** Wikidata QID for `verdict.entityId` (or null). */
+  /** Resolved entity slug (verdict.entityId or parsed from citation recordId). */
+  entitySlug: string | null;
+  /** Wikidata QID for `entitySlug` (or null). */
   entityQid: string | null;
   bucket: ContradictedBucket;
-  /** Set after `--apply` if suggestUrls produced ≥1 candidate. */
+  /** Set after `--apply`:
+   *   - `> 0`: suggestUrls returned candidates
+   *   - `0`: suggestUrls ran and returned no usable candidates
+   *   - `-1`: short-circuited by the budget gate before suggestUrls ran
+   *   - `undefined`: not in --apply mode, or not in the eligible bucket
+   */
   candidatesFound?: number;
 }
 
@@ -96,11 +107,15 @@ interface ResolveOptions extends BaseOptions {
 
 interface RunSummary {
   scanned: number;
-  bySource: Record<ContradictedBucket, number>;
+  byBucket: Record<ContradictedBucket, number>;
   /** Records where suggestUrls produced ≥1 candidate (subject-mismatch only). */
   replaceableUrlFound: number;
-  /** Records where suggestUrls returned 0 candidates after the gate. */
+  /** Records where suggestUrls ran AND returned 0 candidates after the gate. */
   noReplacement: number;
+  /** Subject-mismatch records that were short-circuited by the budget gate
+   *  before suggestUrls could run. Tracked separately so a stingy --budget
+   *  doesn't silently inflate the noReplacement count. */
+  budgetSkipped: number;
   /** Total candidate URLs upserted (across replaceableUrlFound records). */
   suggestionsWritten: number;
   costUsd: number;
@@ -108,12 +123,15 @@ interface RunSummary {
   providerErrors: number;
   /** Records that hit suggestUrls but the gate dropped some candidates. */
   subjectMismatchesDropped: number;
+  /** Suggestion candidates rejected client-side because their URL exceeded
+   *  the server's 2048-char cap (would otherwise fail the whole batch). */
+  oversizedUrlsDropped: number;
 }
 
 function makeSummary(): RunSummary {
   return {
     scanned: 0,
-    bySource: {
+    byBucket: {
       'subject-mismatch': 0,
       'subject-match': 0,
       indeterminate: 0,
@@ -121,11 +139,13 @@ function makeSummary(): RunSummary {
     },
     replaceableUrlFound: 0,
     noReplacement: 0,
+    budgetSkipped: 0,
     suggestionsWritten: 0,
     costUsd: 0,
     budgetExhausted: false,
     providerErrors: 0,
     subjectMismatchesDropped: 0,
+    oversizedUrlsDropped: 0,
   };
 }
 
@@ -211,8 +231,11 @@ async function fetchAllContradictedVerdicts(opts: {
     if (offset >= serverTotal) break;
   }
   // Optional client-side entity filter — same shape as sourcing-suggest-urls.
-  // The server's listVerdicts route doesn't accept an entity filter, so we
-  // page everything and trim here. Acceptable for our scale (<1k rows).
+  // The server route does support entity_id filtering, but the typed client
+  // wrapper (`crux/lib/wiki-server/sourcing-client.ts::listVerdicts`) doesn't
+  // expose it, and we additionally match against entityDisplayName
+  // case-insensitively which the server doesn't. Trimming here is acceptable
+  // at our scale (<1k contradicted rows).
   if (opts.entity) {
     const want = opts.entity;
     return {
@@ -268,44 +291,22 @@ export function resolveEntitySlug(verdict: VerdictListEntry): string | null {
 export function classifyContradicted(input: {
   verdict: VerdictListEntry;
   existingUrl: string | null;
+  entitySlug: string | null;
   entityQid: string | null;
 }): ClassifiedRecord {
-  const { verdict, existingUrl, entityQid } = input;
+  const { verdict, existingUrl, entitySlug, entityQid } = input;
+  const base = { verdict, existingUrl, entitySlug, entityQid };
   if (!existingUrl) {
-    return {
-      verdict,
-      existingUrl,
-      urlQid: null,
-      entityQid,
-      bucket: 'no-source-url',
-    };
+    return { ...base, urlQid: null, bucket: 'no-source-url' };
   }
   const urlQid = extractQid(existingUrl);
   if (!urlQid || !entityQid) {
-    return {
-      verdict,
-      existingUrl,
-      urlQid,
-      entityQid,
-      bucket: 'indeterminate',
-    };
+    return { ...base, urlQid, bucket: 'indeterminate' };
   }
   if (urlQid === entityQid) {
-    return {
-      verdict,
-      existingUrl,
-      urlQid,
-      entityQid,
-      bucket: 'subject-match',
-    };
+    return { ...base, urlQid, bucket: 'subject-match' };
   }
-  return {
-    verdict,
-    existingUrl,
-    urlQid,
-    entityQid,
-    bucket: 'subject-mismatch',
-  };
+  return { ...base, urlQid, bucket: 'subject-mismatch' };
 }
 
 // ── Output formatting ─────────────────────────────────────────────────
@@ -313,11 +314,13 @@ export function classifyContradicted(input: {
 function summaryToJson(s: RunSummary, dryRun: boolean) {
   return {
     scanned: s.scanned,
-    by_bucket: { ...s.bySource },
+    by_bucket: { ...s.byBucket },
     replaceable_url_found: s.replaceableUrlFound,
     no_replacement: s.noReplacement,
+    budget_skipped: s.budgetSkipped,
     suggestions_written: s.suggestionsWritten,
     subject_mismatches_dropped: s.subjectMismatchesDropped,
+    oversized_urls_dropped: s.oversizedUrlsDropped,
     cost_usd: Number(s.costUsd.toFixed(4)),
     budget_exhausted: s.budgetExhausted,
     provider_errors: s.providerErrors,
@@ -329,18 +332,22 @@ function formatSummary(s: RunSummary, dryRun: boolean): string {
   const writtenLine = dryRun
     ? '(dry-run; no writes)'
     : `${s.suggestionsWritten} suggestion(s) written across ${s.replaceableUrlFound} record(s)`;
+  const oversized = s.oversizedUrlsDropped > 0
+    ? `\nOversized URLs dropped: ${s.oversizedUrlsDropped} (>${MAX_URL_CHARS} chars)`
+    : '';
   return `
 === Summary ===
 Scanned:                ${s.scanned}
-  subject-mismatch:     ${s.bySource['subject-mismatch']} (URL is about wrong entity → repair)
-  subject-match:        ${s.bySource['subject-match']} (URL OK → likely value-mismatch, manual triage)
-  indeterminate:        ${s.bySource.indeterminate} (no QID on URL or entity)
-  no-source-url:        ${s.bySource['no-source-url']}
+  subject-mismatch:     ${s.byBucket['subject-mismatch']} (URL is about wrong entity → repair)
+  subject-match:        ${s.byBucket['subject-match']} (URL OK → likely value-mismatch, manual triage)
+  indeterminate:        ${s.byBucket.indeterminate} (no QID on URL or entity)
+  no-source-url:        ${s.byBucket['no-source-url']}
 Replaceable URL found:  ${s.replaceableUrlFound}
 No replacement:         ${s.noReplacement}
+Budget-skipped:         ${s.budgetSkipped} (subject-mismatch records short-circuited by budget gate)
 URL suggestions:        ${writtenLine}
 Provider gate drops:    ${s.subjectMismatchesDropped}
-Provider errors:        ${s.providerErrors}
+Provider errors:        ${s.providerErrors}${oversized}
 Cost:                   $${s.costUsd.toFixed(4)}
 Budget exhausted:       ${s.budgetExhausted ? 'yes' : 'no'}
 `.trim();
@@ -419,14 +426,27 @@ async function resolveContradictedCommand(
       };
     }
     for (const [key, rows] of Object.entries(evidenceRes.data.evidenceByKey)) {
-      // Pick the latest evidence row that carries a sourceUrl. Server returns
-      // rows ordered by `checked_at DESC` so `rows[0]` is the latest. We don't
-      // skip deterministic checkers here (unlike retro-scan-subjects) because
-      // a deterministic checker confirming a `contradicted` outcome already
-      // means the URL is OK and the value is wrong — i.e. the row will land
-      // in `subject-match` if the URL has a Wikidata QID, which is the
-      // correct disposition.
-      existingUrlByKey.set(key, rows.find((r) => r.sourceUrl)?.sourceUrl ?? null);
+      // Pick the most-recently-checked evidence row that carries a sourceUrl.
+      // The server orders by `(sourceUrl ASC, checkedAt DESC)` for grouping,
+      // so `rows[0]` is the latest entry of the alphabetically-first URL —
+      // NOT the globally-latest URL. Re-sort by checkedAt DESC client-side
+      // so multi-URL records classify against their actual most-recent URL.
+      //
+      // We don't skip deterministic checkers here (unlike retro-scan-subjects)
+      // because a deterministic checker confirming a `contradicted` outcome
+      // already means the URL is OK and the value is wrong — i.e. the row
+      // will land in `subject-match` if the URL has a Wikidata QID, which
+      // is the correct disposition.
+      const withUrl = rows.filter((r) => r.sourceUrl);
+      withUrl.sort((a, b) => {
+        // checkedAt comes back as an ISO string; lexicographic compare is
+        // safe for ISO-8601. Null checkedAt sorts oldest (least recent).
+        const ta = a.checkedAt ? String(a.checkedAt) : '';
+        const tb = b.checkedAt ? String(b.checkedAt) : '';
+        if (ta === tb) return 0;
+        return ta < tb ? 1 : -1;
+      });
+      existingUrlByKey.set(key, withUrl[0]?.sourceUrl ?? null);
     }
   }
 
@@ -435,11 +455,11 @@ async function resolveContradictedCommand(
     const existingUrl = existingUrlByKey.get(evidenceRecordKey(v.recordType, v.recordId)) ?? null;
     const entitySlug = resolveEntitySlug(v);
     const entityQid = getEntityWikidataQid(entitySlug);
-    return classifyContradicted({ verdict: v, existingUrl, entityQid });
+    return classifyContradicted({ verdict: v, existingUrl, entitySlug, entityQid });
   });
   for (const c of classified) {
     summary.scanned++;
-    summary.bySource[c.bucket]++;
+    summary.byBucket[c.bucket]++;
   }
 
   // ── Step 4: in --apply mode, suggest URL replacements for subject-mismatch ──
@@ -450,21 +470,26 @@ async function resolveContradictedCommand(
     log(`Generating URL suggestions for ${eligible.length} subject-mismatch record(s)…`);
 
     const tasks = eligible.map((c) => async () => {
-      // Shared budget gate.
+      // Shared soft budget gate. Note: this is a *soft* cap — with internal
+      // concurrency, up to N tasks already in flight may push past the cap
+      // before any of them notice. Tasks that haven't started yet
+      // short-circuit with `bucket: 'budget-skipped'` (NOT 'no-replacement',
+      // which would conflate "unable to search" with "searched and found
+      // nothing").
       if (summary.costUsd >= budgetCap) {
         if (!summary.budgetExhausted) {
           summary.budgetExhausted = true;
-          log(`Budget reached ($${summary.costUsd.toFixed(4)} >= $${budgetCap.toFixed(2)}); skipping remaining records.`);
+          log(`Budget reached ($${summary.costUsd.toFixed(4)} >= $${budgetCap.toFixed(2)}); short-circuiting remaining records.`);
         }
+        c.candidatesFound = -1; // sentinel: budget-skipped (distinguishes from 0 = searched-empty)
         return;
       }
       const v = c.verdict;
       const claimText = v.reasoning?.trim() || v.displayName?.trim() || '';
       // Prefer the verdict's display name; fall back to the resolved entity
       // slug. The slug isn't a perfect search query but beats nothing.
-      const resolvedSlug = resolveEntitySlug(v);
       const entityName =
-        v.entityDisplayName?.trim() || resolvedSlug || v.displayName?.trim() || '';
+        v.entityDisplayName?.trim() || c.entitySlug || v.displayName?.trim() || '';
       if (!claimText || !entityName) {
         // Treat as no-replacement; subject-mismatch with no usable text.
         c.candidatesFound = 0;
@@ -490,9 +515,19 @@ async function resolveContradictedCommand(
       if (result.subjectMismatches.length > 0) {
         summary.subjectMismatchesDropped += result.subjectMismatches.length;
       }
-      c.candidatesFound = result.candidates.length;
 
-      for (const cand of result.candidates) {
+      // Drop oversized URLs before counting — server caps at 2048 and would
+      // 400 the whole batch.
+      const accepted = result.candidates.filter((cand) => {
+        if (cand.url.length > MAX_URL_CHARS) {
+          summary.oversizedUrlsDropped++;
+          return false;
+        }
+        return true;
+      });
+      c.candidatesFound = accepted.length;
+
+      for (const cand of accepted) {
         toUpsert.push({
           recordType: v.recordType,
           recordId: v.recordId,
@@ -512,22 +547,31 @@ async function resolveContradictedCommand(
     });
     await runWithConcurrency(DEFAULT_CONCURRENCY, tasks);
 
-    // Tally replaceable vs no-replacement after suggestions ran.
+    // Tally replaceable vs no-replacement vs budget-skipped after suggestions ran.
     for (const c of classified) {
       if (c.bucket !== 'subject-mismatch') continue;
-      if ((c.candidatesFound ?? 0) > 0) summary.replaceableUrlFound++;
+      const found = c.candidatesFound;
+      if (found === -1) summary.budgetSkipped++;
+      else if ((found ?? 0) > 0) summary.replaceableUrlFound++;
       else summary.noReplacement++;
     }
 
     // Upsert in chunks (server caps at 200; chunk at 100 for headroom).
     if (toUpsert.length > 0) {
+      let chunkIdx = 0;
       for (let i = 0; i < toUpsert.length; i += UPSERT_CHUNK) {
+        chunkIdx++;
         const chunk = toUpsert.slice(i, i + UPSERT_CHUNK);
         const upsert = await upsertUrlSuggestions(chunk);
         if (!upsert.ok) {
+          // Partial-write observability: include the count of suggestions
+          // already persisted by prior successful chunks so operators know
+          // what's already in PG. (Chunks before this one wrote their full
+          // batch; the failing chunk wrote nothing per server transaction
+          // semantics.)
           return {
             exitCode: 1,
-            output: `upsert failed at chunk ${i / UPSERT_CHUNK + 1}: ${upsert.message ?? 'unknown error'}`,
+            output: `upsert failed at chunk ${chunkIdx}: ${upsert.message ?? 'unknown error'} (${summary.suggestionsWritten} suggestion(s) already persisted by prior chunks)`,
           };
         }
         summary.suggestionsWritten += upsert.data.upserted;
@@ -547,6 +591,7 @@ async function resolveContradictedCommand(
     record_type: c.verdict.recordType,
     record_id: c.verdict.recordId,
     entity_id: c.verdict.entityId,
+    entity_slug: c.entitySlug,
     entity_display_name: c.verdict.entityDisplayName,
     field_name: c.verdict.fieldName,
     existing_url: c.existingUrl,
@@ -615,7 +660,10 @@ Options:
   --apply              Write URL suggestions for the subject-mismatch bucket.
                        Without this flag the command runs as a dry-run that only
                        classifies and reports.
-  --budget=N           USD cap on suggestUrls provider spend (default: $${DEFAULT_BUDGET_USD.toFixed(2)}).
+  --budget=N           Soft USD cap on suggestUrls provider spend (default:
+                       $${DEFAULT_BUDGET_USD.toFixed(2)}). Tasks already in flight may push past
+                       the cap; pending tasks short-circuit once the running
+                       total reaches it.
   --max-candidates=N   Candidates per record (default: ${DEFAULT_MAX_CANDIDATES}, max: ${MAX_CANDIDATES_PER_RECORD})
   --json / --ci        Machine-readable JSON output
 

--- a/crux/commands/sourcing-resolve-contradicted.ts
+++ b/crux/commands/sourcing-resolve-contradicted.ts
@@ -1,7 +1,7 @@
 /**
  * Sourcing Resolve Contradicted — QUA-728
  *
- * Sweep tool for the existing `contradicted` source-check verdicts. The QUA-650
+ * Sweep tool for the existing `contradicted` sourcing verdicts. The QUA-650
  * retro-scan reasoning indicated many of these are subject-identity mismatches
  * (the source is about a different entity than the record's). This command
  * classifies each contradicted verdict by comparing the existing source URL's
@@ -603,7 +603,7 @@ export const commands = {
 export function getHelp(): string {
   return `
 Sourcing Resolve Contradicted — sweep + classify + queue URL replacements
-                                  for contradicted source-check verdicts (QUA-728).
+                                  for contradicted sourcing verdicts (QUA-728).
 
 Usage:
   crux sourcing-resolve-contradicted [options]

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -105,6 +105,7 @@ import * as sourcingSampleCoverageCommands from './commands/sourcing-sample-cove
 import * as sourcingSuggestUrlsCommands from './commands/sourcing-suggest-urls.ts';
 import * as sourcingApplySuggestionsCommands from './commands/sourcing-apply-suggestions.ts';
 import * as sourcingCleanupOrphansCommands from './commands/sourcing-cleanup-orphans.ts';
+import * as sourcingResolveContradictedCommands from './commands/sourcing-resolve-contradicted.ts';
 import * as migrateCitationsCommands from './commands/migrate-citations.ts';
 import * as verifyEntityCommands from './commands/verify-entity.ts';
 import * as sourcingWikiPagesCommands from './commands/sourcing-wiki-pages.ts';
@@ -208,6 +209,7 @@ const domains = {
   'sourcing-suggest-urls': sourcingSuggestUrlsCommands,
   'sourcing-apply-suggestions': sourcingApplySuggestionsCommands,
   'sourcing-cleanup-orphans': sourcingCleanupOrphansCommands,
+  'sourcing-resolve-contradicted': sourcingResolveContradictedCommands,
   'migrate-citations': migrateCitationsCommands,
   'sourcing-wiki-pages': sourcingWikiPagesCommands,
   'qa-sweep': qaSweepCommands,


### PR DESCRIPTION
## Summary

New `crux sourcing-resolve-contradicted` command — sweep + classify + queue
URL replacements for contradicted source-check verdicts, per QUA-728.

For each contradicted verdict:

1. Fetch the latest evidence row to learn the existing source URL.
2. Extract a Wikidata QID from the URL.
3. Resolve the record's entity QID (`verdict.entityId` → `external-links.yaml`,
   with `page:<slug>:<fn>` parsing for citations since wiki page slugs are
   entity slugs in this codebase).
4. Compare; place the verdict in one of four buckets:

   | Bucket             | Meaning                                                                  |
   |--------------------|--------------------------------------------------------------------------|
   | `subject-mismatch` | URL QID ≠ entity QID → URL is wrong, eligible for replacement.            |
   | `subject-match`    | URL QID = entity QID → URL is OK; contradiction is a data-value error.   |
   | `indeterminate`    | URL has no QID OR entity has no QID → cannot decide deterministically.    |
   | `no-source-url`    | No evidence row carries a sourceUrl.                                      |

5. In `--apply` mode (only): for `subject-mismatch` records, call
   `suggestUrls()` with the entity QID gate (QUA-724) and upsert candidates
   as `status='pending'` for the existing review/apply pipeline.

The command never mutates verdicts itself. Operators follow up with the
existing `crux sourcing-apply-suggestions` to swap+recheck — that's what
actually drops the system contradicted count.

## Maps to QUA-728 acceptance

- **Per-record disposition (a/b/c)**: bucket + `replaceable_url_found` /
  `no_replacement` counters.
- **`--apply` report**: summary lines for `replaceable_url_found`,
  `no_replacement`, `suggestions_written`, plus per-record table.
- **Anthropic 5 funding rounds (QUA-725 overlap)**: surface via
  `--entity=anthropic --type=funding-round`. Currently lands in
  `indeterminate` for the same data-quality reason described below.
- **System contradicted count drops**: not directly — this command queues
  suggestions; the count drop happens after operator + apply-suggestions.

## Dry-run finding (and follow-up)

Running on prod (467 contradicted verdicts as of 2026-04-29):

```
scanned: 467
by_bucket:
  subject-mismatch:   0
  subject-match:      0
  indeterminate:    462
  no-source-url:      5
```

Two reasons every record lands in `indeterminate`:

1. **`source_check_verdicts.entity_id` is null for 100% of contradicted
   verdicts** (also confirmed for confirmed/partial — system-wide). The
   verdict-write path doesn't populate it. Citation slug parsing recovered
   ~10 records but most page slugs aren't in `external-links.yaml`'s
   wikidata-linked subset.
2. **Most source URLs are not Wikidata** (Wikipedia, news, source homepages).
   `extractQid` only reads QIDs from `wikidata.org` URLs.

The deterministic-QID approach (per ticket spec) requires both sides to have
a QID. The LLM-based subject-identity check
(`crux sourcing-retro-scan-subjects`, QUA-650) has broader reach for the
bulk of these verdicts. The new tool is correct and ready, and will become
useful as `entity_id` is backfilled and as more Wikidata-grounded sources
arrive.

Filed follow-up: backfill `source_check_verdicts.entity_id` server-side
(blocks both this tool and other classification work that needs entity
context).

## Tests

33 unit tests in `crux/commands/sourcing-resolve-contradicted.test.ts`:

- `classifyContradicted` 4-bucket matrix (6 explicit cases + parameterized
  case table).
- `resolveEntitySlug`: entityId fast-path, citation `page:<slug>:<fn>`
  parsing (incl. hyphens/digits), null fallthrough, malformed citation IDs.
- Command: dry-run default, `--apply` writes only for `subject-mismatch`,
  `--apply` zero-candidates → `no-replacement`, `--type` / `--entity`
  filters, JSON output, listVerdicts/evidence/upsert error surfaces,
  `--budget` short-circuit, multi-page pagination, latest-URL pick under
  multi-URL records, oversized-URL drop, budget-skipped accounting.

## Review fixes (post-/agent-review-pr)

A second commit (`05f97cfa`) addresses 2 HIGH + 4 MEDIUM findings from a
hostile-reviewer pass:

1. **HIGH — wrong "latest URL" pick.** Server orders evidence rows by
   `(sourceUrl ASC, checkedAt DESC)` for grouping, so `rows[0]` is the
   most-recent entry of the alphabetically-first URL, not the
   globally-latest URL. Fixed by re-sorting client-side by `checkedAt DESC`
   before picking. Test pinned.
2. **HIGH — budget-skipped records mis-bucketed as no-replacement.** A new
   `budgetSkipped` counter (sentinel `candidatesFound = -1`) keeps the
   "couldn't even search" tally separate from "searched and found
   nothing". Surfaced in summary text + JSON.
3. **MEDIUM — oversized URLs would 400 the whole batch.** Server caps
   `suggestedUrl` at 2048 chars; oversized candidates are now dropped
   client-side and counted in `oversized_urls_dropped`.
4. **MEDIUM — partial-write observability.** Upsert error message now
   includes the count of suggestions already persisted by prior chunks.
5. **MEDIUM — wrong comment about server entity filter.** Server does
   support `entity_id` filtering; the typed client wrapper just doesn't
   expose it. Comment corrected.
6. **MEDIUM — internal `bySource` rename → `byBucket`** (matches JSON
   output naming).

## Test plan

- [x] `pnpm test crux/commands/sourcing-resolve-contradicted` — 33/33 pass
- [x] `pnpm crux w validate gate --fix` — all 62 gate checks pass
- [x] `pnpm lint` — clean
- [x] `/agent-review-pr` — hostile-reviewer pass; 2 HIGH + 4 MEDIUM fixed,
      LOW findings documented (see `.claude/review-done`)
- [x] Dry-run on prod (`--limit=1000`) — 461 records classified into the
      four buckets per the table above; new counters all zero (consistent
      with no records being eligible for `--apply` work)
- [ ] Operator: review the indeterminate findings + decide whether to invest
      in entity_id backfill or pivot to the LLM path

Closes part of QUA-722 RFC (umbrella). Does NOT close QUA-728 itself —
leaving open until follow-up entity_id backfill is decided + the count
actually drops.

Fixes QUA-728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sourcing-resolve-contradicted` CLI command that classifies contradicted sourcing verdicts into categories, supports dry-run (default) and `--apply` modes for generating replacement URL suggestions with budget enforcement, filtering, and flexible output formats.

* **Tests**
  * Added comprehensive test suite validating command functionality across success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
