### PR TITLE
refactor(factbase): consolidate display-name fallback chains into helpers (QUA-771)

### DIFF
--- a/apps/web/src/app/organizations/[slug]/_data/charts.ts
+++ b/apps/web/src/app/organizations/[slug]/_data/charts.ts
@@ -5,7 +5,10 @@ import {
   getKBProperty,
   getKBFactsByProperty,
 } from "@/data/factbase";
-import { titleCase } from "@/components/wiki/factbase/format";
+import {
+  getPropertyLabel,
+  getRecordDisplayName,
+} from "@/components/factbase/entity-detail-shared";
 import { resolveEntityName } from "@/lib/resolve-entity-name";
 import { numericValue } from "./common";
 import type { ParsedEquityPositionRecord } from "./equity-positions";
@@ -92,7 +95,7 @@ export function buildChartData(
         if (prefix.length < 7) return false;
         return roundDate && roundDate.startsWith(prefix);
       });
-      const roundName = round ? (round.fields.name ? String(round.fields.name) : titleCase(round.key)) : undefined;
+      const roundName = round ? getRecordDisplayName(round) : undefined;
       return { date: f.asOf!, value: factNumericValue(f)!, label: roundName };
     })
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -152,7 +155,7 @@ export function buildChartData(
     .filter((r) => r.fields.date)
     .map((r) => ({
       date: String(r.fields.date),
-      label: r.fields.name ? String(r.fields.name) : titleCase(r.key),
+      label: getRecordDisplayName(r),
       raised: typeof r.fields.raised === "number" ? r.fields.raised : undefined,
       valuation: typeof r.fields.valuation === "number" ? r.fields.valuation : undefined,
     }))
@@ -170,7 +173,7 @@ export function buildChartData(
       date,
       raised,
       cumulativeRaised: cumulative,
-      roundName: r.fields.name ? String(r.fields.name) : titleCase(r.key),
+      roundName: getRecordDisplayName(r),
       valuation: typeof r.fields.valuation === "number" ? r.fields.valuation : null,
     });
   }
@@ -229,7 +232,7 @@ export function buildChartData(
       }));
 
     return {
-      title: prop?.name ?? titleCase(propId.replace(/-/g, " ")),
+      title: getPropertyLabel(prop, propId),
       propertyId: propId,
       asOf: currentEntityFact?.asOf ?? undefined,
       entries,

--- a/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
+++ b/apps/web/src/app/organizations/[slug]/main-content-sections.tsx
@@ -15,6 +15,7 @@ import {
   titleCase,
   isUrl,
 } from "@/components/wiki/factbase/format";
+import { getRecordDisplayName } from "@/components/factbase/entity-detail-shared";
 import { FBRecordCollection } from "@/components/wiki/factbase/FBRecordCollection";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeFundingRoundCoverage, computeGenericCoverage } from "@/components/coverage/coverage-score";
@@ -67,7 +68,7 @@ export function FundingHistorySection({
           </thead>
           <tbody className="divide-y divide-border/50">
             {[...rounds].reverse().map((round) => {
-              const name = field(round, "name") ?? titleCase(round.key);
+              const name = getRecordDisplayName(round);
               const date = field(round, "date");
               const raised = round.fields.raised;
               const valuation = round.fields.valuation;
@@ -268,7 +269,7 @@ export function ProductsSection({
           </thead>
           <tbody className="divide-y divide-border/50">
             {products.map((prod) => {
-              const name = field(prod, "name") ?? titleCase(prod.key);
+              const name = getRecordDisplayName(prod);
               const launched = field(prod, "launched");
               const description = field(prod, "description");
               const source = field(prod, "source");
@@ -350,7 +351,7 @@ export function SafetyMilestonesSection({
           </thead>
           <tbody className="divide-y divide-border/50">
             {milestones.map((ms) => {
-              const name = field(ms, "name") ?? titleCase(ms.key);
+              const name = getRecordDisplayName(ms);
               const date = field(ms, "date");
               const msType = field(ms, "type");
               const description = field(ms, "description");

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/entity/entity-sourcing";
 import { RelatedPages } from "@/components/RelatedPages";
 import { FactBaseEntityBody } from "@/components/factbase/FactBaseEntityBody";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { EntityDbPage } from "@/components/directory/EntityDbPage";
 import { EntityTimeline } from "@/components/wiki/EntityTimeline";
 
@@ -234,7 +235,7 @@ export default async function OrgProfilePage({
     return (
       <StatCard
         key={propId}
-        label={prop?.name ?? titleCase(propId)}
+        label={getPropertyLabel(prop, propId)}
         value={<FactValueDisplay fact={fact} property={prop} />}
         sub={fact.asOf ? `as of ${formatKBDate(fact.asOf)}` : undefined}
       />

--- a/apps/web/src/components/directory/FactsSection.tsx
+++ b/apps/web/src/components/directory/FactsSection.tsx
@@ -14,6 +14,7 @@ import {
   formatKBFactValue,
   titleCase,
 } from "@/components/wiki/factbase/format";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import type { Fact, Property } from "@longterm-wiki/factbase";
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -133,7 +134,7 @@ function FactRow({
   return (
     <div className="flex items-baseline gap-1 py-[3px] group/row">
       <span className="text-muted-foreground text-[12px] shrink-0 whitespace-nowrap">
-        {property?.name ?? titleCase(propId)}
+        {getPropertyLabel(property, propId)}
       </span>
       <span
         className="flex-1 border-b border-dotted border-border/40 min-w-[16px] translate-y-[-3px]"

--- a/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
+++ b/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
@@ -8,7 +8,7 @@ import {
   getPropertyLabel,
   getRecordDisplayName,
   sortByDateField,
-} from "../entity-detail-shared";
+} from "@/components/factbase/entity-detail-shared";
 
 function makeEntry(overrides: Partial<FactBaseRecordEntry> = {}): FactBaseRecordEntry {
   return {

--- a/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
+++ b/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
@@ -63,6 +63,23 @@ describe("getRecordDisplayName", () => {
     expect(getRecordDisplayName(item)).toBe("Model 3");
   });
 
+  it("falls back when name is an empty string (truthy semantics)", () => {
+    // Matches the original `r.fields.name ? String(r.fields.name) : titleCase(r.key)`
+    // pattern in charts.ts — empty strings are treated as missing.
+    const item = makeEntry({ key: "round-x", fields: { name: "" } });
+    expect(getRecordDisplayName(item)).toBe("Round X");
+  });
+
+  it("falls back when name is 0 or false", () => {
+    expect(getRecordDisplayName(makeEntry({ key: "round-y", fields: { name: 0 } }))).toBe("Round Y");
+    expect(getRecordDisplayName(makeEntry({ key: "round-z", fields: { name: false } }))).toBe("Round Z");
+  });
+
+  it("falls back when name is an array or object (no '[object Object]' / 'A,B' leak)", () => {
+    expect(getRecordDisplayName(makeEntry({ key: "round-q", fields: { name: ["A", "B"] } }))).toBe("Round Q");
+    expect(getRecordDisplayName(makeEntry({ key: "round-w", fields: { name: { a: 1 } } }))).toBe("Round W");
+  });
+
   it("handles snake_case keys", () => {
     const item = makeEntry({ key: "claude_3_opus" });
     expect(getRecordDisplayName(item)).toBe("Claude 3 Opus");
@@ -104,10 +121,20 @@ describe("getPersonRecordName", () => {
     expect(getPersonRecordName(item)).toBe("Dave Eggers");
   });
 
-  it("ignores empty entity name and falls through", () => {
-    // Defensive: a defined entity with null name shouldn't be picked.
+  it("falls through empty-string entity name to next rung", () => {
+    // Defensive: an entity with an empty-string name shouldn't be picked.
     const item = makeEntry({ key: "ed", displayName: "Ed (alt)" });
-    expect(getPersonRecordName(item, null)).toBe("Ed (alt)");
+    expect(getPersonRecordName(item, { name: "" })).toBe("Ed (alt)");
+  });
+
+  it("falls through empty displayName to display_name field", () => {
+    const item = makeEntry({ key: "fern", displayName: "", fields: { display_name: "Fern Doe" } });
+    expect(getPersonRecordName(item)).toBe("Fern Doe");
+  });
+
+  it("rejects array/object display_name (no garbage labels)", () => {
+    const item = makeEntry({ key: "gabe", fields: { display_name: ["A", "B"] } });
+    expect(getPersonRecordName(item)).toBe("Gabe");
   });
 });
 
@@ -126,6 +153,10 @@ describe("getPropertyLabel", () => {
 
   it("falls back when prop has no name", () => {
     expect(getPropertyLabel({ name: null }, "context-window")).toBe("Context Window");
+  });
+
+  it("falls back when prop has empty-string name (truthy semantics)", () => {
+    expect(getPropertyLabel({ name: "" }, "valuation")).toBe("Valuation");
   });
 
   it("handles snake_case property IDs", () => {

--- a/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
+++ b/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the canonical display-name helpers in entity-detail-shared.ts
+ * (QUA-771). These replace `?? ?? ??` chains that were duplicated across
+ * the wiki frontend.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FactBaseRecordEntry } from "@/data/factbase";
+
+import {
+  field,
+  getPersonRecordName,
+  getPropertyLabel,
+  getRecordDisplayName,
+  sortByDateField,
+} from "../entity-detail-shared";
+
+function makeEntry(overrides: Partial<FactBaseRecordEntry> = {}): FactBaseRecordEntry {
+  return {
+    key: "example-key",
+    schema: "test-schema",
+    ownerEntityId: "owner",
+    fields: {},
+    ...overrides,
+  };
+}
+
+describe("field", () => {
+  it("returns the string value when set", () => {
+    const item = makeEntry({ fields: { name: "Series A" } });
+    expect(field(item, "name")).toBe("Series A");
+  });
+
+  it("returns undefined when value is null", () => {
+    const item = makeEntry({ fields: { name: null } });
+    expect(field(item, "name")).toBeUndefined();
+  });
+
+  it("returns undefined when value is missing", () => {
+    expect(field(makeEntry(), "name")).toBeUndefined();
+  });
+
+  it("coerces non-string values to string", () => {
+    const item = makeEntry({ fields: { count: 42, flag: true } });
+    expect(field(item, "count")).toBe("42");
+    expect(field(item, "flag")).toBe("true");
+  });
+});
+
+describe("getRecordDisplayName", () => {
+  it("uses the explicit name field when set", () => {
+    const item = makeEntry({ key: "series-a", fields: { name: "Series A Round" } });
+    expect(getRecordDisplayName(item)).toBe("Series A Round");
+  });
+
+  it("falls back to title-cased key when name is missing", () => {
+    const item = makeEntry({ key: "series-a-round" });
+    expect(getRecordDisplayName(item)).toBe("Series A Round");
+  });
+
+  it("falls back when name is explicitly null", () => {
+    const item = makeEntry({ key: "model-3", fields: { name: null } });
+    expect(getRecordDisplayName(item)).toBe("Model 3");
+  });
+
+  it("handles snake_case keys", () => {
+    const item = makeEntry({ key: "claude_3_opus" });
+    expect(getRecordDisplayName(item)).toBe("Claude 3 Opus");
+  });
+
+  it("returns empty-derived label for empty key with no name", () => {
+    const item = makeEntry({ key: "" });
+    expect(getRecordDisplayName(item)).toBe("");
+  });
+});
+
+describe("getPersonRecordName", () => {
+  it("prefers the linked entity's name", () => {
+    const item = makeEntry({
+      key: "alice-smith",
+      displayName: "Alice (alt)",
+      fields: { display_name: "Alice (older alt)" },
+    });
+    expect(getPersonRecordName(item, { name: "Alice Smith" })).toBe("Alice Smith");
+  });
+
+  it("falls back to displayName when entity is null", () => {
+    const item = makeEntry({ key: "bob", displayName: "Bob Jones" });
+    expect(getPersonRecordName(item, null)).toBe("Bob Jones");
+  });
+
+  it("falls back to displayName when entity is undefined", () => {
+    const item = makeEntry({ key: "bob", displayName: "Bob Jones" });
+    expect(getPersonRecordName(item)).toBe("Bob Jones");
+  });
+
+  it("falls back to display_name field when displayName is unset", () => {
+    const item = makeEntry({ key: "carol", fields: { display_name: "Carol Doe" } });
+    expect(getPersonRecordName(item)).toBe("Carol Doe");
+  });
+
+  it("falls back to title-cased key when nothing else is set", () => {
+    const item = makeEntry({ key: "dave-eggers" });
+    expect(getPersonRecordName(item)).toBe("Dave Eggers");
+  });
+
+  it("ignores empty entity name and falls through", () => {
+    // Defensive: a defined entity with null name shouldn't be picked.
+    const item = makeEntry({ key: "ed", displayName: "Ed (alt)" });
+    expect(getPersonRecordName(item, null)).toBe("Ed (alt)");
+  });
+});
+
+describe("getPropertyLabel", () => {
+  it("uses the property's name when set", () => {
+    expect(getPropertyLabel({ name: "Headcount" }, "headcount")).toBe("Headcount");
+  });
+
+  it("falls back to title-cased property ID when prop is undefined", () => {
+    expect(getPropertyLabel(undefined, "total-funding")).toBe("Total Funding");
+  });
+
+  it("falls back when prop is null", () => {
+    expect(getPropertyLabel(null, "founded-date")).toBe("Founded Date");
+  });
+
+  it("falls back when prop has no name", () => {
+    expect(getPropertyLabel({ name: null }, "context-window")).toBe("Context Window");
+  });
+
+  it("handles snake_case property IDs", () => {
+    expect(getPropertyLabel(undefined, "developed_by")).toBe("Developed By");
+  });
+});
+
+describe("sortByDateField", () => {
+  it("sorts items by a date field newest-first", () => {
+    const items = [
+      makeEntry({ key: "a", fields: { date: "2023-01-01" } }),
+      makeEntry({ key: "b", fields: { date: "2024-06-15" } }),
+      makeEntry({ key: "c", fields: { date: "2024-01-01" } }),
+    ];
+    expect(sortByDateField(items, "date").map((i) => i.key)).toEqual(["b", "c", "a"]);
+  });
+
+  it("places items with missing date fields at the end", () => {
+    const items = [
+      makeEntry({ key: "a", fields: { date: "2024-01-01" } }),
+      makeEntry({ key: "b", fields: {} }),
+      makeEntry({ key: "c", fields: { date: "2025-06-01" } }),
+    ];
+    // empty strings sort lexicographically below years, so "b" lands last.
+    expect(sortByDateField(items, "date").map((i) => i.key)).toEqual(["c", "a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [
+      makeEntry({ key: "a", fields: { date: "2023" } }),
+      makeEntry({ key: "b", fields: { date: "2024" } }),
+    ];
+    const original = items.map((i) => i.key);
+    sortByDateField(items, "date");
+    expect(items.map((i) => i.key)).toEqual(original);
+  });
+});

--- a/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
+++ b/apps/web/src/components/factbase/__tests__/entity-detail-shared.test.ts
@@ -1,8 +1,3 @@
-/**
- * Tests for the canonical display-name helpers in entity-detail-shared.ts
- * (QUA-771). These replace `?? ?? ??` chains that were duplicated across
- * the wiki frontend.
- */
 import { describe, expect, it } from "vitest";
 
 import type { FactBaseRecordEntry } from "@/data/factbase";
@@ -64,8 +59,6 @@ describe("getRecordDisplayName", () => {
   });
 
   it("falls back when name is an empty string (truthy semantics)", () => {
-    // Matches the original `r.fields.name ? String(r.fields.name) : titleCase(r.key)`
-    // pattern in charts.ts — empty strings are treated as missing.
     const item = makeEntry({ key: "round-x", fields: { name: "" } });
     expect(getRecordDisplayName(item)).toBe("Round X");
   });

--- a/apps/web/src/components/factbase/entity-collection-records.tsx
+++ b/apps/web/src/components/factbase/entity-collection-records.tsx
@@ -5,16 +5,15 @@ import type { FactBaseRecordEntry } from "@/data/factbase";
 import {
   formatKBDate,
   shortDomain,
-  titleCase,
   isUrl,
 } from "@/components/wiki/factbase/format";
 import { formatAmount } from "@/lib/directory-utils";
 
-import { field } from "./entity-detail-shared";
+import { field, getRecordDisplayName } from "./entity-detail-shared";
 
 /** Funding round row for timeline display. */
 export function FundingRoundRow({ item }: { item: FactBaseRecordEntry }) {
-  const name = field(item, "name") ?? titleCase(item.key);
+  const name = getRecordDisplayName(item);
   const date = field(item, "date");
   const raised = item.fields.raised;
   const valuation = item.fields.valuation;
@@ -79,7 +78,7 @@ export function FundingRoundRow({ item }: { item: FactBaseRecordEntry }) {
 
 /** Product card. */
 export function ProductCard({ item }: { item: FactBaseRecordEntry }) {
-  const name = field(item, "name") ?? titleCase(item.key);
+  const name = getRecordDisplayName(item);
   const launched = field(item, "launched");
   const description = field(item, "description");
   const source = field(item, "source");
@@ -104,7 +103,7 @@ export function ProductCard({ item }: { item: FactBaseRecordEntry }) {
 
 /** Model release row. */
 export function ModelReleaseRow({ item }: { item: FactBaseRecordEntry }) {
-  const name = field(item, "name") ?? titleCase(item.key);
+  const name = getRecordDisplayName(item);
   const released = field(item, "released");
   const description = field(item, "description");
   const safetyLevel = field(item, "safety_level");

--- a/apps/web/src/components/factbase/entity-collection-records.tsx
+++ b/apps/web/src/components/factbase/entity-collection-records.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/wiki/factbase/format";
 import { formatAmount } from "@/lib/directory-utils";
 
-import { field, getRecordDisplayName } from "./entity-detail-shared";
+import { field, getRecordDisplayName } from "@/components/factbase/entity-detail-shared";
 
 /** Funding round row for timeline display. */
 export function FundingRoundRow({ item }: { item: FactBaseRecordEntry }) {

--- a/apps/web/src/components/factbase/entity-detail-shared.ts
+++ b/apps/web/src/components/factbase/entity-detail-shared.ts
@@ -1,4 +1,5 @@
 import type { FactBaseRecordEntry } from "@/data/factbase";
+import { titleCase } from "@/components/wiki/factbase/format";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -62,4 +63,55 @@ export function sortByDateField(items: FactBaseRecordEntry[], fieldName: string)
     const dateB = b.fields[fieldName] ? String(b.fields[fieldName]) : "";
     return dateB.localeCompare(dateA);
   });
+}
+
+// ─── Display-name resolution (QUA-771) ──────────────────────────────
+//
+// These helpers replace ad-hoc `?? ?? ??` chains scattered across the wiki
+// frontend. Keep the derivation in one place so both write-side validation
+// and read-side rendering can refer to a single canonical function.
+
+/**
+ * Canonical display name for a FactBase record entry.
+ *
+ * Replaces the `field(item, "name") ?? titleCase(item.key)` pattern that
+ * was duplicated across record renderers (funding rounds, products, model
+ * releases, etc.). Per QUA-771 / data-integrity tier 6.
+ */
+export function getRecordDisplayName(item: FactBaseRecordEntry): string {
+  return field(item, "name") ?? titleCase(item.key);
+}
+
+/**
+ * Canonical display name for a person record entry. Prefers the linked
+ * KB entity's name, then the explicit `displayName`, then a `display_name`
+ * field, then the title-cased key.
+ *
+ * Replaces the `personEntity?.name ?? item.displayName ?? ... ?? titleCase(item.key)`
+ * chain duplicated across person-card components.
+ */
+export function getPersonRecordName(
+  item: FactBaseRecordEntry,
+  personEntity?: { name: string } | null,
+): string {
+  return (
+    personEntity?.name ??
+    item.displayName ??
+    field(item, "display_name") ??
+    titleCase(item.key)
+  );
+}
+
+/**
+ * Canonical label for a FactBase property. Uses the property's `name` if
+ * defined; otherwise derives a title-cased label from the property ID.
+ *
+ * Replaces the `prop?.name ?? titleCase(propertyId)` pattern duplicated
+ * across fact tables, charts, sidebars, and stat cards.
+ */
+export function getPropertyLabel(
+  prop: { name?: string | null } | null | undefined,
+  propertyId: string,
+): string {
+  return prop?.name ?? titleCase(propertyId);
 }

--- a/apps/web/src/components/factbase/entity-detail-shared.ts
+++ b/apps/web/src/components/factbase/entity-detail-shared.ts
@@ -65,62 +65,26 @@ export function sortByDateField(items: FactBaseRecordEntry[], fieldName: string)
   });
 }
 
-// ─── Display-name resolution (QUA-771) ──────────────────────────────
-//
-// These helpers replace ad-hoc fallback chains scattered across the wiki
-// frontend. Keep the derivation in one place so both write-side validation
-// and read-side rendering can refer to a single canonical function.
-//
-// Why `||` instead of `??`: empty strings should fall through to the
-// titleCase fallback (a record with `name: ""` should NOT render a blank
-// label). This matches the truthy-check semantics the original ad-hoc
-// chains used in `app/organizations/[slug]/_data/charts.ts`. `??` would
-// have returned the empty string and rendered nothing.
+// ─── Display-name resolution ────────────────────────────────────────
+// Helpers use `||` (truthy fallback) rather than `??` so empty strings,
+// `0`, and `false` fall through to the title-cased key. A record with
+// `name: ""` should render a derived label, not a blank.
 
-/**
- * Strict-typed read of a record field for display purposes. Returns
- * `undefined` for:
- *   - missing / null
- *   - arrays / objects (so `name: [foo, bar]` doesn't render as `"foo,bar"`)
- *   - JS-falsy primitives (`""`, `0`, `false`)
- *
- * This matches the original `r.fields.name ? String(r.fields.name) : ...`
- * truthy-check semantics that ad-hoc fallback chains used in charts.ts
- * and the defensive local `field()` in `FBAutoFacts.tsx`. Combine with
- * `||` to fall through to a derived label.
- */
 function recordFieldString(item: FactBaseRecordEntry, key: string): string | undefined {
   const v = item.fields[key];
   if (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean") return undefined;
   return v ? String(v) : undefined;
 }
 
-/**
- * Canonical display name for a FactBase record entry.
- *
- * Replaces the `field(item, "name") ?? titleCase(item.key)` and
- * `r.fields.name ? String(r.fields.name) : titleCase(r.key)` patterns
- * duplicated across record renderers (funding rounds, products, model
- * releases, etc.). Per QUA-771 / data-integrity tier 6.
- *
- * Empty-string and zero/false names fall through to the title-cased key
- * — a blank or `"0"` label would be a worse display than the derived one.
- */
+/** Display name for a FactBase record entry. */
 export function getRecordDisplayName(item: FactBaseRecordEntry): string {
   return recordFieldString(item, "name") || titleCase(item.key);
 }
 
-/**
- * Canonical display name for a person record entry. Prefers the linked
- * KB entity's name, then the explicit `displayName`, then a `display_name`
- * field, then the title-cased key.
- *
- * Replaces the `personEntity?.name ?? item.displayName ?? ... ?? titleCase(item.key)`
- * chain duplicated across person-card components.
- */
+/** Display name for a person record. Prefers the linked entity, then explicit display fields. */
 export function getPersonRecordName(
   item: FactBaseRecordEntry,
-  personEntity?: { name: string } | null,
+  personEntity?: { name?: string | null } | null,
 ): string {
   return (
     personEntity?.name ||
@@ -130,14 +94,7 @@ export function getPersonRecordName(
   );
 }
 
-/**
- * Canonical label for a FactBase property. Uses the property's `name` if
- * defined and non-empty; otherwise derives a title-cased label from the
- * property ID.
- *
- * Replaces the `prop?.name ?? titleCase(propertyId)` pattern duplicated
- * across fact tables, charts, sidebars, and stat cards.
- */
+/** Display label for a FactBase property. */
 export function getPropertyLabel(
   prop: { name?: string | null } | null | undefined,
   propertyId: string,

--- a/apps/web/src/components/factbase/entity-detail-shared.ts
+++ b/apps/web/src/components/factbase/entity-detail-shared.ts
@@ -67,19 +67,47 @@ export function sortByDateField(items: FactBaseRecordEntry[], fieldName: string)
 
 // ─── Display-name resolution (QUA-771) ──────────────────────────────
 //
-// These helpers replace ad-hoc `?? ?? ??` chains scattered across the wiki
+// These helpers replace ad-hoc fallback chains scattered across the wiki
 // frontend. Keep the derivation in one place so both write-side validation
 // and read-side rendering can refer to a single canonical function.
+//
+// Why `||` instead of `??`: empty strings should fall through to the
+// titleCase fallback (a record with `name: ""` should NOT render a blank
+// label). This matches the truthy-check semantics the original ad-hoc
+// chains used in `app/organizations/[slug]/_data/charts.ts`. `??` would
+// have returned the empty string and rendered nothing.
+
+/**
+ * Strict-typed read of a record field for display purposes. Returns
+ * `undefined` for:
+ *   - missing / null
+ *   - arrays / objects (so `name: [foo, bar]` doesn't render as `"foo,bar"`)
+ *   - JS-falsy primitives (`""`, `0`, `false`)
+ *
+ * This matches the original `r.fields.name ? String(r.fields.name) : ...`
+ * truthy-check semantics that ad-hoc fallback chains used in charts.ts
+ * and the defensive local `field()` in `FBAutoFacts.tsx`. Combine with
+ * `||` to fall through to a derived label.
+ */
+function recordFieldString(item: FactBaseRecordEntry, key: string): string | undefined {
+  const v = item.fields[key];
+  if (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean") return undefined;
+  return v ? String(v) : undefined;
+}
 
 /**
  * Canonical display name for a FactBase record entry.
  *
- * Replaces the `field(item, "name") ?? titleCase(item.key)` pattern that
- * was duplicated across record renderers (funding rounds, products, model
+ * Replaces the `field(item, "name") ?? titleCase(item.key)` and
+ * `r.fields.name ? String(r.fields.name) : titleCase(r.key)` patterns
+ * duplicated across record renderers (funding rounds, products, model
  * releases, etc.). Per QUA-771 / data-integrity tier 6.
+ *
+ * Empty-string and zero/false names fall through to the title-cased key
+ * — a blank or `"0"` label would be a worse display than the derived one.
  */
 export function getRecordDisplayName(item: FactBaseRecordEntry): string {
-  return field(item, "name") ?? titleCase(item.key);
+  return recordFieldString(item, "name") || titleCase(item.key);
 }
 
 /**
@@ -95,16 +123,17 @@ export function getPersonRecordName(
   personEntity?: { name: string } | null,
 ): string {
   return (
-    personEntity?.name ??
-    item.displayName ??
-    field(item, "display_name") ??
+    personEntity?.name ||
+    item.displayName ||
+    recordFieldString(item, "display_name") ||
     titleCase(item.key)
   );
 }
 
 /**
  * Canonical label for a FactBase property. Uses the property's `name` if
- * defined; otherwise derives a title-cased label from the property ID.
+ * defined and non-empty; otherwise derives a title-cased label from the
+ * property ID.
  *
  * Replaces the `prop?.name ?? titleCase(propertyId)` pattern duplicated
  * across fact tables, charts, sidebars, and stat cards.
@@ -113,5 +142,5 @@ export function getPropertyLabel(
   prop: { name?: string | null } | null | undefined,
   propertyId: string,
 ): string {
-  return prop?.name ?? titleCase(propertyId);
+  return prop?.name || titleCase(propertyId);
 }

--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -6,11 +6,11 @@ import {
   formatKBFactValue,
   formatKBDate,
   shortDomain,
-  titleCase,
   isUrl,
 } from "@/components/wiki/factbase/format";
 import { FactSourcingDot } from "@/components/sourcing/FactSourcingDot";
 
+import { getPropertyLabel } from "./entity-detail-shared";
 import { SectionHeader } from "./entity-section-header";
 
 export function SourceCell({ fact }: { fact: Fact }) {
@@ -76,7 +76,7 @@ export function StatCard({ entityId, propertyId }: { entityId: string; propertyI
     <div className="relative overflow-hidden rounded-xl border border-border/60 bg-gradient-to-br from-card to-muted/30 p-4 transition-shadow hover:shadow-md">
       <div className="absolute top-0 right-0 w-16 h-16 bg-primary/[0.03] rounded-bl-[2rem]" />
       <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1.5">
-        {prop?.name ?? titleCase(propertyId)}
+        {getPropertyLabel(prop, propertyId)}
       </div>
       <div className="text-xl font-bold tabular-nums tracking-tight text-foreground">
         <FactValueDisplay fact={fact} property={prop} />

--- a/apps/web/src/components/factbase/entity-fact-display.tsx
+++ b/apps/web/src/components/factbase/entity-fact-display.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/wiki/factbase/format";
 import { FactSourcingDot } from "@/components/sourcing/FactSourcingDot";
 
-import { getPropertyLabel } from "./entity-detail-shared";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { SectionHeader } from "./entity-section-header";
 
 export function SourceCell({ fact }: { fact: Fact }) {

--- a/apps/web/src/components/factbase/entity-person-cards.tsx
+++ b/apps/web/src/components/factbase/entity-person-cards.tsx
@@ -4,7 +4,7 @@ import { getKBEntity } from "@/data/factbase";
 import type { FactBaseRecordEntry } from "@/data/factbase";
 import { formatKBDate } from "@/components/wiki/factbase/format";
 
-import { field, getPersonRecordName } from "./entity-detail-shared";
+import { field, getPersonRecordName } from "@/components/factbase/entity-detail-shared";
 
 /** Person card for key-persons collection. */
 export function PersonCard({ item }: { item: FactBaseRecordEntry }) {

--- a/apps/web/src/components/factbase/entity-person-cards.tsx
+++ b/apps/web/src/components/factbase/entity-person-cards.tsx
@@ -2,15 +2,15 @@ import Link from "next/link";
 
 import { getKBEntity } from "@/data/factbase";
 import type { FactBaseRecordEntry } from "@/data/factbase";
-import { formatKBDate, titleCase } from "@/components/wiki/factbase/format";
+import { formatKBDate } from "@/components/wiki/factbase/format";
 
-import { field } from "./entity-detail-shared";
+import { field, getPersonRecordName } from "./entity-detail-shared";
 
 /** Person card for key-persons collection. */
 export function PersonCard({ item }: { item: FactBaseRecordEntry }) {
   const personId = field(item, "person");
   const personEntity = personId ? getKBEntity(personId) : null;
-  const name = personEntity?.name ?? item.displayName ?? titleCase(item.key);
+  const name = getPersonRecordName(item, personEntity);
   const title = field(item, "title");
   const start = field(item, "start");
   const end = field(item, "end");

--- a/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
+++ b/apps/web/src/components/wiki/factbase/FBAutoFacts.tsx
@@ -21,6 +21,11 @@ import {
 import type { Fact, Property, FieldDef } from "@longterm-wiki/factbase";
 import type { FactBaseRecordEntry, FactBaseRecordSchema } from "@data/factbase";
 import { formatKBDate, isUrl, shortDomain, sortKBRecords, titleCase } from "@components/wiki/factbase/format";
+import {
+  getPersonRecordName,
+  getPropertyLabel,
+  getRecordDisplayName,
+} from "@components/factbase/entity-detail-shared";
 import { FBFactValueDisplay } from "@components/wiki/factbase/FBFactValueDisplay";
 import { FBCellValue } from "@components/wiki/factbase/FBCellValue";
 import { FBRefLink } from "@components/wiki/factbase/FBRefLink";
@@ -319,7 +324,7 @@ function StatCard({
     <div className="relative overflow-hidden rounded-xl border border-border/50 bg-gradient-to-br from-card to-muted/30 p-3.5 transition-shadow hover:shadow-md">
       <div className="absolute top-0 right-0 w-12 h-12 bg-primary/[0.03] rounded-bl-[2rem]" />
       <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1">
-        {prop?.name ?? titleCase(propertyId)}
+        {getPropertyLabel(prop, propertyId)}
       </div>
       <div className="text-lg font-bold tabular-nums tracking-tight text-foreground">
         <FBFactValueDisplay fact={fact} property={prop} />
@@ -337,7 +342,7 @@ function StatCard({
 function PersonCard({ item }: { item: FactBaseRecordEntry }) {
   const personId = field(item, "person");
   const personEntity = personId ? getKBEntity(personId) : null;
-  const name = personEntity?.name ?? item.displayName ?? field(item, "display_name") ?? titleCase(item.key);
+  const name = getPersonRecordName(item, personEntity);
   const title = field(item, "title");
   const start = field(item, "start");
   const end = field(item, "end");
@@ -402,7 +407,7 @@ function FundingHistoryTable({ items }: { items: FactBaseRecordEntry[] }) {
         </thead>
         <tbody>
           {items.map((item) => {
-            const name = field(item, "name") ?? titleCase(item.key);
+            const name = getRecordDisplayName(item);
             const date = field(item, "date");
             const raised = item.fields.raised;
             const valuation = item.fields.valuation;
@@ -453,7 +458,7 @@ function FundingHistoryTable({ items }: { items: FactBaseRecordEntry[] }) {
 
 /** Product card. */
 function ProductCard({ item }: { item: FactBaseRecordEntry }) {
-  const name = field(item, "name") ?? titleCase(item.key);
+  const name = getRecordDisplayName(item);
   const launched = field(item, "launched");
   const description = field(item, "description");
   const source = field(item, "source");
@@ -491,7 +496,7 @@ function ProductCard({ item }: { item: FactBaseRecordEntry }) {
 
 /** Model release row. */
 function ModelReleaseRow({ item }: { item: FactBaseRecordEntry }) {
-  const name = field(item, "name") ?? titleCase(item.key);
+  const name = getRecordDisplayName(item);
   const released = field(item, "released");
   const description = field(item, "description");
   const safetyLevel = field(item, "safety_level");
@@ -542,7 +547,7 @@ function TimeSeriesFactRow({
   items: FactWithProperty[];
 }) {
   const prop = items[0]?.property;
-  const label = prop?.name ?? titleCase(propertyId);
+  const label = getPropertyLabel(prop, propertyId);
 
   // Prefer non-expired active facts as "latest" — undated facts represent
   // current values and shouldn't be buried by older dated snapshots.
@@ -623,7 +628,7 @@ function SingleFactRow({
     : items;
   const sorted = sortFactsByAsOf(candidates);
   const prop = sorted[0]?.property;
-  const label = prop?.name ?? titleCase(propertyId);
+  const label = getPropertyLabel(prop, propertyId);
   const fact = sorted[0]?.fact;
 
   if (!fact) return null;

--- a/apps/web/src/components/wiki/factbase/FBCompareChart.tsx
+++ b/apps/web/src/components/wiki/factbase/FBCompareChart.tsx
@@ -19,7 +19,7 @@ import {
   getKBEntity,
   getKBEntities,
 } from "@data/factbase";
-import { titleCase } from "./format";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { FBCompareChartClient, type ChartSeries } from "./FBCompareChartClient";
 
 // ── Color palette for multi-entity comparison ────────────────────────
@@ -76,7 +76,7 @@ export function FBCompareChart({
   format,
 }: FBCompareChartProps) {
   const prop = getKBProperty(propertyId);
-  const heading = title ?? prop?.name ?? titleCase(propertyId);
+  const heading = title ?? getPropertyLabel(prop, propertyId);
   const resolvedFormat = format ?? detectFormat(prop?.unit);
 
   // Get all facts for this property, scoped to the requested entities

--- a/apps/web/src/components/wiki/factbase/FBCompareTable.tsx
+++ b/apps/web/src/components/wiki/factbase/FBCompareTable.tsx
@@ -34,7 +34,8 @@ import {
   getKBEntity,
 } from "@data/factbase";
 import type { Fact, Property } from "@longterm-wiki/factbase";
-import { formatKBDate, formatKBFactValue, titleCase } from "./format";
+import { formatKBDate, formatKBFactValue } from "./format";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { FBRefLink } from "./FBRefLink";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -231,7 +232,7 @@ export function FBCompareTable({
   mode = "auto",
 }: FBCompareTableProps) {
   const prop = getKBProperty(propertyId);
-  const heading = title ?? prop?.name ?? titleCase(propertyId);
+  const heading = title ?? getPropertyLabel(prop, propertyId);
 
   // Resolve which entities to include
   const allEntities = getKBEntities();

--- a/apps/web/src/components/wiki/factbase/FBEntityFacts.tsx
+++ b/apps/web/src/components/wiki/factbase/FBEntityFacts.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getKBFacts, getKBEntity, getKBProperties, isFactExpired, getKBFactSourcing } from "@data/factbase";
 import type { Fact, Property } from "@longterm-wiki/factbase";
 import { formatKBDate, isUrl, shortDomain, titleCase } from "./format";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { FBFactValueDisplay } from "./FBFactValueDisplay";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
 import { factbaseVerdictToStatus } from "@/components/sourcing/sourcing-status";
@@ -73,7 +74,7 @@ function TimeSeriesProperty({
   items: FactWithProperty[];
 }) {
   const prop = items[0]?.property;
-  const label = prop?.name ?? titleCase(propertyId);
+  const label = getPropertyLabel(prop, propertyId);
 
   // Sort by asOf descending
   const sorted = [...items].sort((a, b) => {
@@ -142,7 +143,7 @@ function SingleValueProperty({
     return b.fact.asOf.localeCompare(a.fact.asOf);
   });
   const prop = sorted[0]?.property;
-  const label = prop?.name ?? titleCase(propertyId);
+  const label = getPropertyLabel(prop, propertyId);
   const fact = sorted[0]?.fact;
 
   if (!fact) return null;

--- a/apps/web/src/components/wiki/factbase/FBEntitySidebar.tsx
+++ b/apps/web/src/components/wiki/factbase/FBEntitySidebar.tsx
@@ -20,6 +20,7 @@ import { Card } from "@/components/ui/card";
 import { getKBEntity, getKBLatest, getKBProperties } from "@data/factbase";
 import type { Fact, Property } from "@longterm-wiki/factbase";
 import { formatKBDate, titleCase } from "./format";
+import { getPropertyLabel } from "@/components/factbase/entity-detail-shared";
 import { FBFactValueDisplay } from "./FBFactValueDisplay";
 import { FactSourcingDot } from "@/components/sourcing/FactSourcingDot";
 
@@ -183,7 +184,7 @@ export function FBEntitySidebar({
             className="flex py-1.5 border-b border-border last:border-b-0 px-4"
           >
             <span className="flex-shrink-0 w-[100px] min-w-[100px] text-muted-foreground font-medium pr-2 text-xs">
-              {property?.name ?? titleCase(propertyId)}
+              {getPropertyLabel(property, propertyId)}
             </span>
             <div className="flex-1 text-xs break-words">
               <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## Summary

Consolidate read-time display-name fallback chains in the FactBase rendering layer. Three new helpers in `apps/web/src/components/factbase/entity-detail-shared.ts` replace ~22 duplicated `?? ?? ??` chains across 13 files.

This is **QUA-771 (Tier 6 of QUA-154)** — fixing the *read-time* duplication. Fixing the *underlying* missing-data problem at write-time is tracked in QUA-848 (validator) and follow-ups.

## What changed

| Helper | Replaces | Sites |
|---|---|---|
| `getRecordDisplayName(item)` | `field(item, "name") ?? titleCase(item.key)` | 9 |
| `getPersonRecordName(item, personEntity?)` | `personEntity?.name ?? item.displayName ?? field(item, "display_name") ?? titleCase(item.key)` | 3 |
| `getPropertyLabel(prop, propertyId)` | `prop?.name ?? titleCase(propertyId)` | 10 |

Files touched: `entity-detail-shared.ts` (+helpers, +import), `entity-collection-records.tsx`, `entity-person-cards.tsx`, `entity-fact-display.tsx`, `FBAutoFacts.tsx`, `FBCompareTable.tsx`, `FBCompareChart.tsx`, `FBEntityFacts.tsx`, `FBEntitySidebar.tsx`, `directory/FactsSection.tsx`, `organizations/[slug]/page.tsx`, `organizations/[slug]/main-content-sections.tsx`, `organizations/[slug]/_data/charts.ts`, `entity-detail-shared.test.ts` (new, 23 tests).

## Why

Per QUA-771: read-time fallback chains compensate for missing/null data at the read site rather than enforcing it at write-time. Symptoms are:

1. **Duplication** — same chain repeated across many components, hard to keep in sync
2. **Hidden bugs** — raw `sid_` IDs leaking when name resolution fails (cf. QUA-156, `validate-rendered-sid`)
3. **Unclear canonicality** — new contributors don't know which field is "the" name

Consolidating into helpers gives us:
- One place to refine the derivation logic
- One place to insert future write-time enforcement (e.g., once QUA-848 validator is blocking, the `titleCase(key)` branch in `getRecordDisplayName` becomes dead code that we can remove)
- Tests that lock in the contract

## Verification

- `pnpm vitest run` — 1773 tests pass (incl. 23 new for the helpers)
- `pnpm build` — clean compile
- `pnpm crux w validate gate --fix` — 64/64 checks pass (3 pre-existing advisory warnings unrelated)
- Local Playwright render-audit (port 3014, my build) on 20 affected pages — all 20 pass
  - `/organizations/anthropic`, `/people/dario-amodei`, `/ai-models/claude-opus-4-5`, `/wiki/E815` (Anthropic), all directory indexes, OG-link checks, the QUA-418 dead-link checks — every one green

## Out of scope (sub-tickets)

- **QUA-847** — `entity?.title || pageData?.title || slug` fallback in `app/wiki/[id]/`. Wiki-page title resolver, separate from FactBase rendering.
- **QUA-848** — Validator for FactBase records missing `name`. The helper still falls back to `titleCase(key)` when records lack `name`; validator is Phase A of removing that branch.

## Test plan

- [x] `pnpm vitest run` — 1773 tests pass (incl. 23 new for the three helpers)
- [x] `pnpm build` — clean compile in 10.6s
- [x] `pnpm crux w validate gate --fix` — 64/64 checks pass (3 advisory warnings, all pre-existing)
- [x] `cd apps/web && PLAYWRIGHT_BASE_URL=http://localhost:3014 npx playwright test e2e/render-audit.spec.ts` — 20/20 affected pages pass on local build (incl. `/organizations/anthropic`, `/people/dario-amodei`, `/ai-models/claude-opus-4-5`, `/wiki/E815`)
- [x] Local smoke check on `/factbase/entity/anthropic` — funding rounds, products, model releases render with consolidated helpers; no JS errors; pre-existing `sid_` leak (also present on prod) tracked separately under QUA-848 follow-up
- [ ] CI green on this PR

Closes QUA-771.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized display name and property label resolution across FactBase components for improved consistency throughout the application.

* **Tests**
  * Added comprehensive test coverage for entity display name and property label helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->