### PR TITLE
feat(scorecards): render SourcingDot on matrix cells + panel grades (QUA-839)

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -262,6 +262,63 @@ test.describe("Render audit — critical data tables", () => {
   });
 });
 
+test.describe("Render audit — scorecards sourcing dots (QUA-839)", () => {
+  // Scorecard grades got SourceCheckDot indicators in QUA-839. Each
+  // populated matrix cell renders one dot via SourcingDot
+  // (role="img", aria-label starts with "Sourcing:"). Empty cells (em-dash
+  // placeholders) render no dot. Regression check: at least one dot must
+  // appear on /scorecards once any grade has been ingested.
+  test("/scorecards renders sourcing dots in matrix cells", async ({ page }) => {
+    await loadPage(page, "/scorecards");
+
+    const text = await getMainText(page);
+    const hasMatrix = !text.includes("No scorecard grades ingested yet");
+
+    if (hasMatrix) {
+      const dots = await page
+        .locator('[role="img"][aria-label^="Sourcing:"]')
+        .count();
+      expect(
+        dots,
+        "/scorecards should render at least one sourcing dot once grades are ingested",
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  // Org-tab scorecards section must also render a dot for each panel grade.
+  // Anthropic is a stable target — it's covered by all five scorecard sources.
+  test("/organizations/anthropic ?tab=scorecards renders sourcing dots", async ({ page }) => {
+    await loadPage(page, "/organizations/anthropic");
+
+    // Click the Scorecards tab if present. The tab is suppressed when the
+    // org has no grades, so a missing tab is acceptable in CI builds where
+    // wiki-server isn't reachable.
+    const scorecardsTab = page.getByRole("tab", { name: /scorecards/i });
+    if ((await scorecardsTab.count()) === 0) return;
+
+    await scorecardsTab.click();
+    await page.waitForTimeout(800);
+
+    // Scope to the scorecards panels rather than the whole page — the
+    // EntityProfileShell header always renders its own rollup sourcing
+    // dot, so a global page count would pass even without QUA-839's
+    // per-grade dots. Each scorecard panel is keyed by its publisher
+    // ("by Future of Life Institute"), so we look for sourcing dots that
+    // live inside one of those panels.
+    const fliPanel = page.locator('article', {
+      hasText: "Future of Life Institute",
+    });
+    if ((await fliPanel.count()) === 0) return; // no FLI grades yet
+    const dotsInPanel = await fliPanel
+      .locator('[role="img"][aria-label^="Sourcing:"]')
+      .count();
+    expect(
+      dotsInPanel,
+      "FLI scorecard panel should render at least one sourcing dot",
+    ).toBeGreaterThan(0);
+  });
+});
+
 test.describe("Render audit — no dead entity sourcing links (QUA-418)", () => {
   // Entity profile pages render a SourcingDot in the header. It must NOT
   // link to /sourcing/entity/<id> — that path is not a real record_type

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -271,18 +271,27 @@ test.describe("Render audit — scorecards sourcing dots (QUA-839)", () => {
   test("/scorecards renders sourcing dots in matrix cells", async ({ page }) => {
     await loadPage(page, "/scorecards");
 
-    const text = await getMainText(page);
-    const hasMatrix = !text.includes("No scorecard grades ingested yet");
+    // Gate on the matrix's own h2, which only renders when `orgRows.length > 0`.
+    // Three failure modes look different in the page text and we want to skip
+    // all of them, not just the "no grades ingested" one:
+    //   1. wiki-server unreachable in CI (LONGTERMWIKI_SERVER_URL unset) →
+    //      "The wiki-server was unreachable" panel
+    //   2. wiki-server reachable but no grades ingested →
+    //      "No scorecard grades ingested yet" panel
+    //   3. wiki-server reachable + grades ingested → matrix h2 visible
+    // A negation check on the "no grades" string falsely passes case 1.
+    const matrixHeading = page.getByRole("heading", {
+      name: /overall grades.*latest wave/i,
+    });
+    if ((await matrixHeading.count()) === 0) return;
 
-    if (hasMatrix) {
-      const dots = await page
-        .locator('[role="img"][aria-label^="Sourcing:"]')
-        .count();
-      expect(
-        dots,
-        "/scorecards should render at least one sourcing dot once grades are ingested",
-      ).toBeGreaterThan(0);
-    }
+    const dots = await page
+      .locator('[role="img"][aria-label^="Sourcing:"]')
+      .count();
+    expect(
+      dots,
+      "/scorecards should render at least one sourcing dot once grades are ingested",
+    ).toBeGreaterThan(0);
   });
 
   // Org-tab scorecards section must also render a dot for each panel grade.

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -290,6 +290,10 @@ test.describe("Render audit — scorecards sourcing dots (QUA-839)", () => {
   test("/organizations/anthropic ?tab=scorecards renders sourcing dots", async ({ page }) => {
     await loadPage(page, "/organizations/anthropic");
 
+    // Positive load assertion — fail loudly if the org page itself broke
+    // (vs. silently passing every "no scorecards tab" branch below).
+    await expect(page.locator("h1, h2").first()).toBeVisible({ timeout: 10000 });
+
     // Click the Scorecards tab if present. The tab is suppressed when the
     // org has no grades, so a missing tab is acceptable in CI builds where
     // wiki-server isn't reachable.
@@ -297,7 +301,6 @@ test.describe("Render audit — scorecards sourcing dots (QUA-839)", () => {
     if ((await scorecardsTab.count()) === 0) return;
 
     await scorecardsTab.click();
-    await page.waitForTimeout(800);
 
     // Scope to the scorecards panels rather than the whole page — the
     // EntityProfileShell header always renders its own rollup sourcing
@@ -305,10 +308,18 @@ test.describe("Render audit — scorecards sourcing dots (QUA-839)", () => {
     // per-grade dots. Each scorecard panel is keyed by its publisher
     // ("by Future of Life Institute"), so we look for sourcing dots that
     // live inside one of those panels.
-    const fliPanel = page.locator('article', {
+    //
+    // Use toBeAttached() polling instead of a hardcoded waitForTimeout —
+    // QUA-822 retrospective showed fixed timeouts flake on slow renders
+    // and waste time on fast ones.
+    const fliPanel = page.locator("article", {
       hasText: "Future of Life Institute",
     });
-    if ((await fliPanel.count()) === 0) return; // no FLI grades yet
+    try {
+      await expect(fliPanel.first()).toBeAttached({ timeout: 5000 });
+    } catch {
+      return; // tab present but no FLI grades — acceptable; nothing to assert
+    }
     const dotsInPanel = await fliPanel
       .locator('[role="img"][aria-label^="Sourcing:"]')
       .count();

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -35,13 +35,11 @@ interface GradeRow {
   /**
    * Inline sourcing verdict (QUA-839). Null when never checked —
    * `recordVerdictToStatus` then renders an `unchecked` (white) dot.
+   * The wiki-server returns more fields (confidence, sourcesChecked) but
+   * panels only render verdict + checkedAt; widen this only when a tooltip
+   * surface starts using them.
    */
-  sourcing: {
-    verdict: string;
-    confidence: number | null;
-    sourcesChecked: number;
-    checkedAt: string | null;
-  } | null;
+  sourcing: { verdict: string; checkedAt: string | null } | null;
 }
 
 interface ByEntityResponse {

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -15,6 +15,8 @@ import {
   DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
+import { SourcingDot } from "@/components/sourcing/SourcingDot";
+import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
 
 interface GradeRow {
   id: string;
@@ -30,6 +32,16 @@ interface GradeRow {
   scoreLetter: string | null;
   scoreRaw: string;
   notes: string | null;
+  /**
+   * Inline sourcing verdict (QUA-839). Null when never checked —
+   * `recordVerdictToStatus` then renders an `unchecked` (white) dot.
+   */
+  sourcing: {
+    verdict: string;
+    confidence: number | null;
+    sourcesChecked: number;
+    checkedAt: string | null;
+  } | null;
 }
 
 interface ByEntityResponse {
@@ -165,8 +177,16 @@ export function ScorecardsSection({
             {overallRow ? (
               <div className="mb-3 flex items-baseline gap-3">
                 <span className="text-sm text-muted-foreground">Overall:</span>
-                <span className="text-2xl font-mono tabular-nums">
-                  {formatScoreCell(overallRow)}
+                <span className="inline-flex items-baseline gap-2">
+                  <span className="text-2xl font-mono tabular-nums">
+                    {formatScoreCell(overallRow)}
+                  </span>
+                  <SourcingDot
+                    status={recordVerdictToStatus(overallRow.sourcing?.verdict)}
+                    originalVerdict={overallRow.sourcing?.verdict ?? null}
+                    lastChecked={overallRow.sourcing?.checkedAt ?? null}
+                    size="md"
+                  />
                 </span>
               </div>
             ) : null}
@@ -180,7 +200,15 @@ export function ScorecardsSection({
                   >
                     <dt className="py-1.5">{r.dimensionLabel}</dt>
                     <dd className="py-1.5 font-mono tabular-nums text-right">
-                      {formatScoreCell(r)}
+                      <span className="inline-flex items-center gap-1.5 justify-end">
+                        <span>{formatScoreCell(r)}</span>
+                        <SourcingDot
+                          status={recordVerdictToStatus(r.sourcing?.verdict)}
+                          originalVerdict={r.sourcing?.verdict ?? null}
+                          lastChecked={r.sourcing?.checkedAt ?? null}
+                          size="sm"
+                        />
+                      </span>
                     </dd>
                   </div>
                 ))}

--- a/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
@@ -110,6 +110,41 @@ describe("ScorecardsMatrix — source-check dots", () => {
     expect(screen.getByText("B+")).toBeInTheDocument();
   });
 
+  // Cover every TableBase verdict state the unified mapping exposes
+  // (see apps/web/src/components/sourcing/sourcing-status.ts). If the
+  // mapping regresses for one state, this catches it without relying
+  // on the matrix component being aware of every value.
+  const VERDICT_CASES: Array<{ verdict: string; label: RegExp }> = [
+    { verdict: "outdated", label: /Needs attention/i },
+    { verdict: "partial", label: /Needs attention/i },
+    { verdict: "unverifiable", label: /Needs attention/i },
+    { verdict: "not_applicable", label: /Not checked/i },
+  ];
+
+  for (const { verdict, label } of VERDICT_CASES) {
+    it(`renders the right dot for verdict=${verdict}`, () => {
+      render(
+        <ScorecardsMatrix
+          orgRows={[
+            row({
+              fmti: {
+                source: "fmti",
+                scoreNumeric: 50,
+                scoreLetter: null,
+                scoreRaw: "50",
+                publishedAt: "2025-08-01",
+                sourcing: { verdict, checkedAt: null },
+              },
+            }),
+          ]}
+        />,
+      );
+
+      const dot = screen.getByRole("img", { name: /sourcing/i });
+      expect(dot.getAttribute("aria-label")).toMatch(label);
+    });
+  }
+
   it("does not render a dot when the cell is missing (em-dash placeholder)", () => {
     render(<ScorecardsMatrix orgRows={[row({})]} />);
 

--- a/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  ScorecardsMatrix,
+  type ScorecardOrgRow,
+} from "../scorecards-matrix";
+
+/**
+ * QUA-839: matrix cells must render a SourcingDot next to each value, in
+ * `not_run` (white) state when no verdict row exists. The dot's tooltip
+ * must include the verdict label when one is present.
+ */
+describe("ScorecardsMatrix — source-check dots", () => {
+  function row(cells: ScorecardOrgRow["cells"]): ScorecardOrgRow {
+    return {
+      entityId: "sid_anthropic1",
+      displayName: "Anthropic",
+      slug: "anthropic",
+      cells,
+    };
+  }
+
+  it("renders an unchecked (white) dot when no sourcing verdict is present", () => {
+    render(
+      <ScorecardsMatrix
+        orgRows={[
+          row({
+            fli_index: {
+              source: "fli_index",
+              scoreNumeric: null,
+              scoreLetter: "C+",
+              scoreRaw: "C+",
+              publishedAt: "2025-07-01",
+              sourcing: null,
+            },
+          }),
+        ]}
+      />,
+    );
+
+    const dot = screen.getByRole("img", { name: /sourcing/i });
+    expect(dot).toBeInTheDocument();
+    expect(dot.getAttribute("aria-label")).toMatch(/Not checked/i);
+  });
+
+  it("renders a verified (green) dot when verdict=confirmed", () => {
+    render(
+      <ScorecardsMatrix
+        orgRows={[
+          row({
+            saferai: {
+              source: "saferai",
+              scoreNumeric: 84,
+              scoreLetter: null,
+              scoreRaw: "84",
+              publishedAt: "2025-08-01",
+              sourcing: { verdict: "confirmed", checkedAt: "2026-04-29" },
+            },
+          }),
+        ]}
+      />,
+    );
+
+    const dot = screen.getByRole("img", { name: /sourcing/i });
+    expect(dot.getAttribute("aria-label")).toMatch(/Verified/i);
+    expect(dot.getAttribute("title")).toContain("Verdict: confirmed");
+  });
+
+  it("renders a failed (red) dot when verdict=contradicted", () => {
+    render(
+      <ScorecardsMatrix
+        orgRows={[
+          row({
+            fli_index: {
+              source: "fli_index",
+              scoreNumeric: null,
+              scoreLetter: "F",
+              scoreRaw: "F",
+              publishedAt: "2025-08-01",
+              sourcing: { verdict: "contradicted", checkedAt: null },
+            },
+          }),
+        ]}
+      />,
+    );
+
+    const dot = screen.getByRole("img", { name: /sourcing/i });
+    expect(dot.getAttribute("aria-label")).toMatch(/Failed/i);
+  });
+
+  it("renders the formatted score text alongside the dot", () => {
+    render(
+      <ScorecardsMatrix
+        orgRows={[
+          row({
+            fli_index: {
+              source: "fli_index",
+              scoreNumeric: null,
+              scoreLetter: "B+",
+              scoreRaw: "B+",
+              publishedAt: null,
+              sourcing: null,
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("B+")).toBeInTheDocument();
+  });
+
+  it("does not render a dot when the cell is missing (em-dash placeholder)", () => {
+    render(<ScorecardsMatrix orgRows={[row({})]} />);
+
+    // Empty cells rendered as em-dashes should not have any sourcing dot.
+    const dots = screen.queryAllByRole("img", { name: /sourcing/i });
+    expect(dots).toHaveLength(0);
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -54,13 +54,13 @@ interface GradeRow {
   scoreNumeric: number | null;
   scoreLetter: string | null;
   scoreRaw: string;
-  /** Inline sourcing verdict (QUA-839). Null when never checked. */
-  sourcing: {
-    verdict: string;
-    confidence: number | null;
-    sourcesChecked: number;
-    checkedAt: string | null;
-  } | null;
+  /**
+   * Inline sourcing verdict (QUA-839). Null when never checked.
+   * The wiki-server returns more fields (confidence, sourcesChecked) but
+   * the matrix only renders verdict + checkedAt; pull more fields through
+   * here only when a tooltip surface starts using them.
+   */
+  sourcing: { verdict: string; checkedAt: string | null } | null;
 }
 
 /**

--- a/apps/web/src/app/scorecards/page.tsx
+++ b/apps/web/src/app/scorecards/page.tsx
@@ -54,6 +54,13 @@ interface GradeRow {
   scoreNumeric: number | null;
   scoreLetter: string | null;
   scoreRaw: string;
+  /** Inline sourcing verdict (QUA-839). Null when never checked. */
+  sourcing: {
+    verdict: string;
+    confidence: number | null;
+    sourcesChecked: number;
+    checkedAt: string | null;
+  } | null;
 }
 
 /**
@@ -132,6 +139,9 @@ export default async function ScorecardsPage() {
       scoreLetter: g.scoreLetter,
       scoreRaw: g.scoreRaw,
       publishedAt: g.publishedAt,
+      sourcing: g.sourcing
+        ? { verdict: g.sourcing.verdict, checkedAt: g.sourcing.checkedAt }
+        : null,
     };
     if (existing) {
       existing.cells[g.scorecardSource] = cell;

--- a/apps/web/src/app/scorecards/scorecards-matrix.tsx
+++ b/apps/web/src/app/scorecards/scorecards-matrix.tsx
@@ -4,6 +4,13 @@ import {
   formatScoreCell,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
+import { SourcingDot } from "@/components/sourcing/SourcingDot";
+import { recordVerdictToStatus } from "@/components/sourcing/sourcing-status";
+
+export interface ScorecardCellSourcing {
+  verdict: string | null;
+  checkedAt: string | null;
+}
 
 export interface ScorecardCell {
   source: ScorecardSourceKey;
@@ -11,6 +18,13 @@ export interface ScorecardCell {
   scoreLetter: string | null;
   scoreRaw: string;
   publishedAt: string | null;
+  /**
+   * Sourcing verdict for this grade (QUA-839). Null when no verdict
+   * row exists yet — the verdict-generation pipeline is a separate ticket
+   * (see `.claude/rules/sourcing-system.md`). Renders an `unchecked`
+   * white dot in that case.
+   */
+  sourcing: ScorecardCellSourcing | null;
 }
 
 export interface ScorecardOrgRow {
@@ -85,7 +99,15 @@ export function ScorecardsMatrix({
                       cell.publishedAt ? ` — ${cell.publishedAt}` : ""
                     }`}
                   >
-                    {formatScoreCell(cell)}
+                    <span className="inline-flex items-center gap-1.5">
+                      <span>{formatScoreCell(cell)}</span>
+                      <SourcingDot
+                        status={recordVerdictToStatus(cell.sourcing?.verdict)}
+                        originalVerdict={cell.sourcing?.verdict ?? null}
+                        lastChecked={cell.sourcing?.checkedAt ?? null}
+                        size="sm"
+                      />
+                    </span>
                   </td>
                 );
               })}

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -3,10 +3,33 @@ import { z } from "zod";
 import { eq, and, count, desc } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { scorecardGrades, scorecardSnapshots, entities } from "../../schema.js";
+import {
+  scorecardGrades,
+  scorecardSnapshots,
+  entities,
+  sourceVerdicts,
+} from "../../schema.js";
 import { zv, clampedLimit, qBool } from "../shared/utils.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
+import {
+  verdictJoinCondition,
+  verdictSelectFields,
+  formatSourcing,
+  type VerdictJoinFields,
+} from "../shared/sourcing-join.js";
 import { createSyncHandler } from "./sync-factory.js";
+
+/**
+ * Record-type identifier for `source_check_verdicts.record_type`.
+ *
+ * Singular, matching the existing convention (`personnel`, `grant`,
+ * `division`, etc.). Renders the `SourcingDot` on `/scorecards` matrix
+ * cells and on the org-tab scorecards panels.
+ *
+ * Verdict generation is out of scope for QUA-839 — all grades currently
+ * have no row here, so the dot renders in `not_run` (white) state.
+ */
+const SCORECARD_GRADE_RECORD_TYPE = "scorecard_grade";
 
 // ---- Constants ----
 
@@ -48,7 +71,7 @@ const SyncScorecardGradesItemSchema = z.object({
 
 // ---- Helpers ----
 
-interface GradeRow {
+interface GradeRow extends VerdictJoinFields {
   grade: typeof scorecardGrades.$inferSelect;
   entityTitle: string | null;
   entitySlug: string | null;
@@ -80,6 +103,7 @@ function formatRow(r: GradeRow) {
     notes: g.notes,
     sourceUrl: g.sourceUrl,
     syncedAt: g.syncedAt,
+    sourcing: formatSourcing(r),
   };
 }
 
@@ -112,6 +136,7 @@ const scorecardGradesApp = new Hono()
         scorecardSource: scorecardSnapshots.scorecardSource,
         publishedAt: scorecardSnapshots.publishedAt,
         isLatest: scorecardSnapshots.isLatest,
+        ...verdictSelectFields,
       })
       .from(scorecardGrades)
       .leftJoin(
@@ -119,6 +144,13 @@ const scorecardGradesApp = new Hono()
         eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
       )
       .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
+      .leftJoin(
+        sourceVerdicts,
+        verdictJoinCondition(
+          SCORECARD_GRADE_RECORD_TYPE,
+          scorecardGrades.id,
+        ),
+      )
       .where(where)
       .orderBy(
         desc(scorecardSnapshots.publishedAt),
@@ -158,6 +190,7 @@ const scorecardGradesApp = new Hono()
         scorecardSource: scorecardSnapshots.scorecardSource,
         publishedAt: scorecardSnapshots.publishedAt,
         isLatest: scorecardSnapshots.isLatest,
+        ...verdictSelectFields,
       })
       .from(scorecardGrades)
       .leftJoin(
@@ -165,6 +198,13 @@ const scorecardGradesApp = new Hono()
         eq(scorecardGrades.snapshotId, scorecardSnapshots.id),
       )
       .leftJoin(entities, eq(scorecardGrades.entityId, entities.stableId))
+      .leftJoin(
+        sourceVerdicts,
+        verdictJoinCondition(
+          SCORECARD_GRADE_RECORD_TYPE,
+          scorecardGrades.id,
+        ),
+      )
       .where(
         and(
           eq(scorecardGrades.entityId, entityId),


### PR DESCRIPTION
## Summary

Adds the standard `SourcingDot` indicator to `/scorecards` matrix cells and to the org-tab scorecards section. Per QUA-839's verification against prod (2026-04-29), these were the only directory surfaces in the wiki without sourcing/verdict indicators — every other directory page (organizations, people, AI models, benchmarks, projects) renders the dot. This closes that gap.

The verdict-generation pipeline (an LLM check that the published grade matches the source PDF) is **out of scope for this ticket** per the issue body — all grades currently render in the `not_run` (white) state until a future ticket writes verdict rows.

## Key changes

**Wiki-server** — `apps/wiki-server/src/routes/tablebase/scorecard-grades.ts`
- LEFT JOIN `source_check_verdicts` (record_type=`scorecard_grade`) in both `GET /api/scorecard-grades/all` and `GET .../by-entity/:entityId`
- Reuses the existing `verdictJoinCondition` / `verdictSelectFields` / `formatSourcing` shared helpers (same pattern as `personnel.ts`, `grants.ts`)
- Adds an inline `sourcing` field to the response, matching the structure other tablebase routes already return

**Web — matrix cells** — `apps/web/src/app/scorecards/scorecards-matrix.tsx`, `page.tsx`
- `ScorecardCell.sourcing: { verdict, checkedAt } | null`
- `<SourcingDot>` rendered next to each formatted score, size=sm
- Tooltip shows verdict + last-checked timestamp via the existing `SourcingDot` tooltip pipeline

**Web — org-tab panel grades** — `apps/web/src/app/organizations/[slug]/scorecards-section.tsx`
- `GradeRow.sourcing` carries the verdict
- Overall grade renders size=md dot; per-dimension rows render size=sm dot

## Out of scope

- **Verdict-generation pipeline** — file separately if/when there's appetite. Ticket explicitly says "render in `unchecked` state for all grades initially."
- **Per-snapshot vs per-grade verdict granularity** — defer to the verdict-generation ticket above.
- **Sourcing detail link target** (`/sourcing/scorecard_grade/[id]`) — not added; per QUA-418 dead sourcing links must be avoided. The verdict-generation ticket should land the route + href together.

## Test plan

- [x] `pnpm build` — clean exit
- [x] `pnpm crux w validate gate --fix` — all 64 checks pass (2 unrelated advisory warnings)
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] 9 new unit tests in `scorecards-matrix.test.tsx` covering 6 verdict states (`null`, `confirmed`, `contradicted`, `outdated`, `partial`, `unverifiable`, `not_applicable`) + the empty-cell em-dash placeholder + score-text-renders case
- [x] 2 new e2e checks in `render-audit.spec.ts` for `/scorecards` matrix and the FLI panel on `/organizations/anthropic` — verified against prod (correctly fail today; will pass after deploy)
- [x] Existing `sourcing-join.test.ts` (3 tests) and `scorecard-snapshots-is-latest.test.ts` (4 tests) still pass

## Review

- `/agent-review-pr` ran; 8 findings — 4 fixed (trimmed dead `confidence`/`sourcesChecked` type fields, replaced hardcoded `waitForTimeout(800)` with `toBeAttached()` polling, added positive load assertion to e2e org-tab test, added 4 verdict-state tests). 4 LOW findings dismissed or addressed inline. Marker: `069e5650`.

Closes QUA-839
