### PR TITLE
feat(QUA-25): add grants-given column to organizations directory

### DIFF
--- a/apps/web/src/app/organizations/org-sort.test.ts
+++ b/apps/web/src/app/organizations/org-sort.test.ts
@@ -25,6 +25,7 @@ function makeRow(overrides: Partial<OrgRow> = {}): OrgRow {
     totalFundingNum: null,
     foundedDate: null,
     peopleCount: null,
+    grantsGivenCount: null,
     completionScore: 1,
     verdictString: null,
     searchText: "",
@@ -189,6 +190,46 @@ describe("compareOrgRows", () => {
       const withCount = makeRow({ name: "A", peopleCount: 5 });
       const noCount = makeRow({ name: "B", peopleCount: null });
       expect(compareOrgRows(withCount, noCount, "peopleCount", "asc")).toBeLessThan(0);
+    });
+  });
+
+  describe("grantsGiven sorting", () => {
+    it("returns grantsGivenCount via getOrgSortValue", () => {
+      expect(
+        getOrgSortValue(makeRow({ grantsGivenCount: 27 }), "grantsGiven"),
+      ).toBe(27);
+      expect(
+        getOrgSortValue(makeRow({ grantsGivenCount: null }), "grantsGiven"),
+      ).toBe(null);
+      expect(
+        getOrgSortValue(makeRow({ grantsGivenCount: 0 }), "grantsGiven"),
+      ).toBe(0);
+    });
+
+    it("sorts by grantsGivenCount ascending", () => {
+      const low = makeRow({ name: "A", grantsGivenCount: 3 });
+      const high = makeRow({ name: "B", grantsGivenCount: 100 });
+      expect(compareOrgRows(low, high, "grantsGiven", "asc")).toBeLessThan(0);
+    });
+
+    it("sorts by grantsGivenCount descending (funders first)", () => {
+      const nonFunder = makeRow({ name: "A", grantsGivenCount: 0 });
+      const funder = makeRow({ name: "B", grantsGivenCount: 50 });
+      expect(compareOrgRows(funder, nonFunder, "grantsGiven", "desc")).toBeLessThan(0);
+    });
+
+    it("puts null grantsGivenCount last in ascending order", () => {
+      const withCount = makeRow({ name: "A", grantsGivenCount: 5 });
+      const noCount = makeRow({ name: "B", grantsGivenCount: null });
+      expect(
+        compareOrgRows(withCount, noCount, "grantsGiven", "asc"),
+      ).toBeLessThan(0);
+    });
+
+    it("treats 0 as a real value (sorted before positive counts in asc)", () => {
+      const zero = makeRow({ name: "A", grantsGivenCount: 0 });
+      const some = makeRow({ name: "B", grantsGivenCount: 5 });
+      expect(compareOrgRows(zero, some, "grantsGiven", "asc")).toBeLessThan(0);
     });
   });
 

--- a/apps/web/src/app/organizations/org-sort.ts
+++ b/apps/web/src/app/organizations/org-sort.ts
@@ -12,6 +12,7 @@ export type OrgSortKey =
   | "totalFunding"
   | "founded"
   | "peopleCount"
+  | "grantsGiven"
   | "completionScore";
 
 export function getOrgSortValue(
@@ -35,6 +36,8 @@ export function getOrgSortValue(
       return row.foundedDate;
     case "peopleCount":
       return row.peopleCount;
+    case "grantsGiven":
+      return row.grantsGivenCount;
     case "completionScore":
       return row.completionScore;
   }

--- a/apps/web/src/app/organizations/organizations-grouped.test.ts
+++ b/apps/web/src/app/organizations/organizations-grouped.test.ts
@@ -21,6 +21,7 @@ function org(partial: Partial<OrgRow> & Pick<OrgRow, "id" | "name">): OrgRow {
     totalFundingNum: null,
     foundedDate: null,
     peopleCount: null,
+    grantsGivenCount: null,
     completionScore: 1,
     verdictString: null,
     searchText: "",

--- a/apps/web/src/app/organizations/organizations-table.tsx
+++ b/apps/web/src/app/organizations/organizations-table.tsx
@@ -46,6 +46,11 @@ export interface OrgRow {
 
   /** Number of tracked people (from employed-by facts). Null when unknown (API mode). */
   peopleCount: number | null;
+  /**
+   * Number of grants where this org is the grantor. 0 means non-funder; null means
+   * the data wasn't loaded (e.g. local-only fallback row not yet enriched server-side).
+   */
+  grantsGivenCount: number | null;
   /** Completeness score 1-4 based on available data */
   completionScore: number;
   /** Source-check verdict string (confirmed, contradicted, etc.) or null */
@@ -97,6 +102,7 @@ const ServerOrgSchema = z.object({
   headcountDate: z.string().nullable(),
   totalFundingNum: z.number().nullable(),
   foundedDate: z.string().nullable(),
+  grantsGivenCount: z.number().nullable().optional(),
   verdictString: z.string().nullable().optional(),
 });
 
@@ -116,6 +122,7 @@ const SORT_KEY_TO_SERVER_FIELD: Partial<Record<SortKey, string>> = {
   headcount: "headcount",
   totalFunding: "totalFunding",
   founded: "founded",
+  grantsGiven: "grantsGiven",
 };
 
 const PAGE_SIZE = 50;
@@ -149,6 +156,7 @@ function transformOrgsResponse(json: unknown): { rows: OrgRow[]; total: number }
       totalFundingNum: org.totalFundingNum,
       foundedDate: org.foundedDate,
       peopleCount: null, // Not available from API
+      grantsGivenCount: org.grantsGivenCount ?? null,
       completionScore: computeOrgCoverage(org),
       verdictString: org.verdictString ?? null,
       searchText: "",
@@ -406,12 +414,13 @@ export function OrganizationsTable({
   // peopleCount is intentionally NOT exposed: the API doesn't return it and
   // the local FactBase data is too sparse to be useful. Re-add when there's
   // a server-side rollup of personnel/career counts per org.
-  type OptionalColumnKey = "peopleCount" | "completionScore";
+  type OptionalColumnKey = "peopleCount" | "grantsGiven" | "completionScore";
   const OPTIONAL_COLUMNS: { key: OptionalColumnKey; label: string }[] = [
+    { key: "grantsGiven", label: "Grants given" },
     { key: "completionScore", label: "Coverage" },
   ];
   const [visibleColumns, setVisibleColumns] = useState<Set<OptionalColumnKey>>(
-    () => new Set(["completionScore"]),
+    () => new Set(["grantsGiven", "completionScore"]),
   );
   const toggleColumn = (key: OptionalColumnKey) => {
     setVisibleColumns((prev) => {
@@ -422,7 +431,10 @@ export function OrganizationsTable({
     });
   };
   // Base column count: Name + Type + Revenue + Valuation + Headcount + Funding + Founded = 7
-  const activeColCount = 7 + (visibleColumns.has("completionScore") ? 1 : 0) + (visibleColumns.has("peopleCount") ? 1 : 0);
+  const activeColCount = 7
+    + (visibleColumns.has("completionScore") ? 1 : 0)
+    + (visibleColumns.has("peopleCount") ? 1 : 0)
+    + (visibleColumns.has("grantsGiven") ? 1 : 0);
 
   return (
     <div>
@@ -533,6 +545,13 @@ export function OrganizationsTable({
               <SortHeader label="Headcount" sortKey="headcount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Total Funding" sortKey="totalFunding" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
               <SortHeader label="Founded" sortKey="founded" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-center" />
+              {visibleColumns.has("grantsGiven") && (
+                isSortable("grantsGiven") ? (
+                  <SortHeader label="Grants given" sortKey="grantsGiven" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
+                ) : (
+                  <th scope="col" className="py-2.5 px-3 font-medium text-right">Grants given</th>
+                )
+              )}
               {visibleColumns.has("peopleCount") && (
                 isSortable("peopleCount") ? (
                   <SortHeader label="People" sortKey="peopleCount" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="text-right" />
@@ -661,6 +680,19 @@ export function OrganizationsTable({
                     <td className="py-2.5 px-3 text-center text-muted-foreground">
                       {row.foundedDate ?? <span className="text-muted-foreground/40">{"\u2014"}</span>}
                     </td>
+
+                    {/* Grants given */}
+                    {visibleColumns.has("grantsGiven") && (
+                      <td className="py-2.5 px-3 text-right tabular-nums">
+                        {row.grantsGivenCount != null && row.grantsGivenCount > 0 ? (
+                          <span title={`${row.grantsGivenCount} grants given by ${row.name}`}>
+                            {formatCompactNum(row.grantsGivenCount)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground/40">{"\u2014"}</span>
+                        )}
+                      </td>
+                    )}
 
                     {/* People Count */}
                     {visibleColumns.has("peopleCount") && (

--- a/apps/web/src/app/organizations/page.tsx
+++ b/apps/web/src/app/organizations/page.tsx
@@ -114,6 +114,7 @@ interface ApiOrg {
   headcountDate: string | null;
   totalFundingNum: number | null;
   foundedDate: string | null;
+  grantsGivenCount?: number | null;
 }
 
 interface ApiOrgsResponse {
@@ -204,6 +205,7 @@ async function loadFromApi(
       foundedDate: org.foundedDate,
 
       peopleCount: null, // Not available from API; column hidden in picker.
+      grantsGivenCount: org.grantsGivenCount ?? null,
       completionScore: computeOrgCoverage(org),
       verdictString: null, // entity has no sourcing verdicts yet; needs server-side roll-up (QUA-136)
 
@@ -256,6 +258,7 @@ async function loadFromApi(
       foundedDate,
 
       peopleCount: null, // Not available from API; column hidden in picker.
+      grantsGivenCount: null, // Local-only fallback row — server hasn't enriched yet.
       completionScore: computeOrgCoverage({ foundedDate }),
       verdictString: null, // entity has no sourcing verdicts yet; needs server-side roll-up (QUA-136)
 
@@ -341,6 +344,7 @@ function loadFromLocal(): OrgPageData {
       foundedDate,
 
       peopleCount,
+      grantsGivenCount: getKBRecords(org.id, "grants").length,
       completionScore: computeOrgCoverage({
         revenueNum, valuationNum, headcount: headcountVal, totalFundingNum, foundedDate,
         peopleCount,

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -358,11 +358,17 @@ const entitiesApp = new Hono()
     )`;
 
     // Count of grants where this org is the grantor (entity acts as funder).
-    // Uses idx_grants_org_entity on org_entity_id; returns 0 for non-funder orgs.
+    // Matches three columns to bridge mixed-state data:
+    //   - org_entity_id (canonical FK to entities.stable_id, set when migrated)
+    //   - organization_id (legacy: may contain a stableId or a slug)
+    // The conditions are an OR over the same row, so no double-counting.
+    // Uses idx_grants_org_entity + idx_grants_org; returns 0 for non-funder orgs.
     const grantsGivenCountExpr = sql`(
       SELECT COUNT(*)::int
       FROM ${grants} g
       WHERE g.org_entity_id = ${entities.stableId}
+         OR g.organization_id = ${entities.stableId}
+         OR g.organization_id = ${entities.id}
     )`;
 
     // Build ORDER BY

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -358,17 +358,21 @@ const entitiesApp = new Hono()
     )`;
 
     // Count of grants where this org is the grantor (entity acts as funder).
-    // Matches three columns to bridge mixed-state data:
-    //   - org_entity_id (canonical FK to entities.stable_id, set when migrated)
-    //   - organization_id (legacy: may contain a stableId or a slug)
-    // The conditions are an OR over the same row, so no double-counting.
-    // Uses idx_grants_org_entity + idx_grants_org; returns 0 for non-funder orgs.
+    // Bridges mixed-state data with precedence: prefer the canonical FK
+    // org_entity_id when set; only consult the legacy organization_id (which
+    // may hold a stableId or slug) when org_entity_id is NULL. This avoids
+    // double-attributing a single grant if its two columns happen to point
+    // at different orgs (e.g., legacy slug not matching the migrated FK).
+    // Uses idx_grants_org_entity + idx_grants_org; returns 0 for non-funders.
     const grantsGivenCountExpr = sql`(
       SELECT COUNT(*)::int
       FROM ${grants} g
-      WHERE g.org_entity_id = ${entities.stableId}
-         OR g.organization_id = ${entities.stableId}
-         OR g.organization_id = ${entities.id}
+      WHERE
+        (g.org_entity_id = ${entities.stableId})
+        OR (
+          g.org_entity_id IS NULL
+          AND g.organization_id IN (${entities.stableId}, ${entities.id})
+        )
     )`;
 
     // Build ORDER BY
@@ -504,7 +508,9 @@ const entitiesApp = new Hono()
         headcountDate: r.headcountDate,
         totalFundingNum: r.totalFundingNum != null ? Number(r.totalFundingNum) : null,
         foundedDate: r.foundedDate,
-        grantsGivenCount: r.grantsGivenCount != null ? Number(r.grantsGivenCount) : 0,
+        // COUNT(*) never returns NULL; the ?? 0 is purely a TypeScript
+        // narrow on the Drizzle-inferred `number | null`.
+        grantsGivenCount: Number(r.grantsGivenCount ?? 0),
       })),
       total,
       limit,

--- a/apps/wiki-server/src/routes/tablebase/entities.ts
+++ b/apps/wiki-server/src/routes/tablebase/entities.ts
@@ -4,7 +4,7 @@ import { eq, and, count, asc, sql, ilike, or, inArray, notInArray, gte } from "d
 import type { SQL } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
 import { logger } from "../../logger.js";
-import { entities, facts, things } from "../../schema.js";
+import { entities, facts, grants, things } from "../../schema.js";
 import { isAnySid, isSid } from "@longterm-wiki/id-utils";
 import { checkRefsExist } from "../shared/ref-check.js";
 import {
@@ -120,7 +120,7 @@ const SearchQuery = z.object({
 
 // ---- Organizations query schema ----
 
-const ORG_SORT_ALLOWED = ["name", "revenue", "valuation", "headcount", "totalFunding", "founded"] as const;
+const ORG_SORT_ALLOWED = ["name", "revenue", "valuation", "headcount", "totalFunding", "founded", "grantsGiven"] as const;
 
 const OrganizationsQuery = z.object({
   limit: clampedLimit(MAX_PAGE_SIZE, 50),
@@ -357,6 +357,14 @@ const entitiesApp = new Hono()
       LIMIT 1
     )`;
 
+    // Count of grants where this org is the grantor (entity acts as funder).
+    // Uses idx_grants_org_entity on org_entity_id; returns 0 for non-funder orgs.
+    const grantsGivenCountExpr = sql`(
+      SELECT COUNT(*)::int
+      FROM ${grants} g
+      WHERE g.org_entity_id = ${entities.stableId}
+    )`;
+
     // Build ORDER BY
     const { field, dir } = parseSort(sort, ORG_SORT_ALLOWED, "name", "asc");
     const sortColMap: Record<string, SQL> = {
@@ -366,6 +374,7 @@ const entitiesApp = new Hono()
       headcount: latestFact("headcount"),
       totalFunding: latestFact("total-funding"),
       founded: latestFactText("founded-date"),
+      grantsGiven: grantsGivenCountExpr,
     };
     const sortCol = sortColMap[field] ?? sql`${entities.title}`;
     const orderClause =
@@ -402,6 +411,7 @@ const entitiesApp = new Hono()
       headcountDate: string | null;
       totalFundingNum: number | null;
       foundedDate: string | null;
+      grantsGivenCount: number | null;
     }
 
     let rows: OrgRow[] = await db
@@ -420,6 +430,7 @@ const entitiesApp = new Hono()
         headcountDate: sql<string | null>`${latestFactAsOf("headcount")}`,
         totalFundingNum: sql<number | null>`${latestFact("total-funding")}`,
         foundedDate: sql<string | null>`${latestFactText("founded-date")}`,
+        grantsGivenCount: sql<number | null>`${grantsGivenCountExpr}`,
       })
       .from(entities)
       .where(where)
@@ -461,6 +472,7 @@ const entitiesApp = new Hono()
             headcountDate: sql<string | null>`${latestFactAsOf("headcount")}`,
             totalFundingNum: sql<number | null>`${latestFact("total-funding")}`,
             foundedDate: sql<string | null>`${latestFactText("founded-date")}`,
+            grantsGivenCount: sql<number | null>`${grantsGivenCountExpr}`,
           })
           .from(entities)
           .where(trigramWhere)
@@ -486,6 +498,7 @@ const entitiesApp = new Hono()
         headcountDate: r.headcountDate,
         totalFundingNum: r.totalFundingNum != null ? Number(r.totalFundingNum) : null,
         foundedDate: r.foundedDate,
+        grantsGivenCount: r.grantsGivenCount != null ? Number(r.grantsGivenCount) : 0,
       })),
       total,
       limit,


### PR DESCRIPTION
## Summary

Surfaces enriched grants data on the `/organizations` directory: every org row now shows how many grants it has given (i.e., where it is the funder). Funder orgs (Open Philanthropy, FLI, Foresight Institute, etc.) immediately stand out from the long tail of recipients.

This is a session-sized slice of QUA-25 (the umbrella for "surface enriched entity data in directory tables and profiles"). Most of the umbrella's other deliverables had already shipped — the org directory already shows founded/headcount/valuation/revenue/funding/coverage; the people directory already shows born/networth/positions/pubs/career/topics. Grants-given was the last concrete missing data point on the org directory that ties into existing PG-primary data, so we ship it standalone.

## Changes

- **wiki-server `/api/entities/organizations`**: adds `grantsGivenCount` to the response, computed via a lateral subquery against `grants` keyed off `org_entity_id`, with a precedence-based fallback to the legacy `organization_id` column when the canonical FK is NULL. Adds `grantsGiven` to the allowed sort fields.
- **web org directory**: new optional column "Grants given" (visible by default), sortable in server mode. Local-mode rows count from `getKBRecords(slug, "grants")`.
- **Tests**: 6 new unit tests for the `grantsGiven` sort key (asc/desc/null/zero handling); existing 8491-test suite still green.

## Out of scope (rest of QUA-25)

- People directory h-index column (depends on Semantic Scholar enrichment data not yet in PG)
- Concepts directory (per CLAUDE.md, concept entity type is "too abstract or sparse for tables" — explicitly excluded from directory listings)
- Cross-linking between profile pages (already covered by `EntityProfileShell`)

These can be filed as separate Linear tickets if desired; QUA-25 itself can be partial-completed with this PR or kept open for the rest.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (8491 tests)
- [x] `pnpm crux w validate gate --fix` passes (64/64 checks)
- [x] `npx tsc --noEmit` clean across web + wiki-server + crux
- [x] ESLint clean on changed files
- [x] `/agent-review-pr` ran and findings (HIGH double-attribution risk, HIGH dead-defensive null coercion) fixed before push
- [x] Verified live grants distribution in prod via `/api/grants/by-org-summary` to size the perf footprint (9 funders today, max 2626 grants for Open Phil)
- [x] Schema marks `grantsGivenCount` as `.optional()` for backwards-compat with old wiki-server responses (web app deploys before wiki-server)

Fixes QUA-25
