### PR TITLE
feat(pr): refuse crux gh pr create without fresh /agent-review-pr marker (QUA-849 #7)

### DIFF
--- a/crux/commands/pr.ts
+++ b/crux/commands/pr.ts
@@ -24,6 +24,7 @@ import {
   findOpenPrsMentioningLinearId,
   type OpenPrMatch,
 } from '../lib/linear/dedup.ts';
+import { checkReviewMarker } from '../lib/review-marker.ts';
 import type { CommandOptions, CommandResult } from '../lib/command-types.ts';
 
 // ── Test plan validation ─────────────────────────────────────────────────────
@@ -319,12 +320,23 @@ async function detect(_args: string[], options: CommandOptions): Promise<Command
  * to constructing curl commands with jq in bash.
  *
  * Options:
- *   --title="PR title"      Required. Title for the PR.
- *   --body="PR body"        Body as inline string (vulnerable to shell expansion).
- *   --body-file=<path>      Body from a file (safe for markdown with backticks).
- *   --base=main             Base branch (default: main).
- *   --draft                 Create as draft PR.
+ *   --title="PR title"          Required. Title for the PR.
+ *   --body="PR body"            Body as inline string (vulnerable to shell expansion).
+ *   --body-file=<path>          Body from a file (safe for markdown with backticks).
+ *   --base=main                 Base branch (default: main).
+ *   --draft                     Create as draft PR.
+ *   --skip-review-check         Bypass the /agent-review-pr marker check.
+ *      --reason="<why>"           REQUIRED with --skip-review-check.
+ *   --force                     Bypass Linear-ID dedup check (existing).
+ *   --allow-empty-body          Allow PR body to be empty (existing, discouraged).
+ *   --skip-test-plan            Bypass test-plan validation (existing).
  *   (default: ready — agents verify before creating PRs)
+ *
+ * Pre-checks (in order, all refuse with exit 2 unless bypassed):
+ *   1. Body not empty                                (--allow-empty-body)
+ *   2. Test plan section present                     (--skip-test-plan)
+ *   3. /agent-review-pr marker fresh against HEAD    (--skip-review-check, QUA-849 #7)
+ *   4. No open PR already claims a referenced Linear (--force)
  *
  * If a PR already exists for this branch, reports it instead of creating a duplicate.
  */
@@ -400,6 +412,53 @@ async function create(_args: string[], options: CommandOptions): Promise<Command
       output: `${c.red}Usage: crux gh pr create --title="PR title" --body="PR body" [--body-file=<path>] [--base=main] [--draft]${c.reset}\n`,
       exitCode: 1,
     };
+  }
+
+  // ── Review-marker check (QUA-849 #7) ────────────────────────────────────
+  // Refuse PR creation unless `.claude/review-done` exists and is fresh
+  // against HEAD's commit + diff hash. This catches the failure mode where
+  // an agent goes straight from `git push` to `crux gh pr create` without
+  // running `/agent-review-pr` (the upstream cousin of QUA-849's
+  // "ran skill, lied about phases" — see the QUA-728 incident PR #4689).
+  //
+  // Bypass: --skip-review-check with a required --reason. We require the
+  // reason because the rule's purpose is to make "I considered it" not a
+  // possible path; an empty bypass would defeat the gate.
+  const skipReviewCheck = Boolean(
+    options.skipReviewCheck ?? options['skip-review-check'],
+  );
+  const reviewReason = (options.reason as string | undefined) ?? '';
+  if (skipReviewCheck) {
+    if (!reviewReason.trim()) {
+      return {
+        output:
+          `${c.red}--skip-review-check requires --reason="<why>".${c.reset}\n` +
+          `  The reason gets logged to PR creation telemetry so a forced\n` +
+          `  bypass stays traceable. Empty bypasses defeat the gate.\n`,
+        exitCode: 1,
+      };
+    }
+    log.warn(`⚠ Skipping /agent-review-pr marker check (--reason: ${reviewReason})`);
+  } else {
+    const marker = checkReviewMarker();
+    if (!marker.ok) {
+      return {
+        output:
+          `${c.red}✗ Review marker check failed (code: ${marker.code}).${c.reset}\n` +
+          `  ${marker.message}\n\n` +
+          `  ${c.yellow}Why this exists:${c.reset} skipping /agent-review-pr has shipped\n` +
+          `  HIGH-severity correctness bugs that the agent's own tests didn't catch\n` +
+          `  (see QUA-728 incident PR #4689). The hostile-reviewer subagent in\n` +
+          `  /agent-review-pr reads the diff with no context and catches things\n` +
+          `  CodeRabbit and automated checks miss.\n\n` +
+          `  ${c.bold}To fix:${c.reset} run ${c.cyan}/agent-review-pr${c.reset} now, address its findings,\n` +
+          `  then re-run this command.\n\n` +
+          `  ${c.dim}Genuine emergencies only: re-run with --skip-review-check\n` +
+          `  --reason="<why>" to bypass.${c.reset}\n`,
+        exitCode: 2,
+      };
+    }
+    log.info(marker.message);
   }
 
   // Quality checks on PR body: dedup (#819) and copy-paste detection

--- a/crux/lib/review-marker.test.ts
+++ b/crux/lib/review-marker.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the review-marker check (QUA-849 #7).
+ *
+ * Covers parsing, the four mismatch modes (missing / malformed / stale-sha
+ * / stale-diff), and the happy path. Uses a temp git repo per test so we
+ * don't pollute the real working copy.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseMarker,
+  computeDiffHash,
+  checkReviewMarker,
+} from './review-marker.ts';
+
+let tmpRepo: string;
+
+function git(cmd: string): string {
+  return execSync(`git ${cmd}`, {
+    cwd: tmpRepo,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    encoding: 'utf-8',
+  }).trim();
+}
+
+function writeMarker(content: string) {
+  mkdirSync(join(tmpRepo, '.claude'), { recursive: true });
+  writeFileSync(join(tmpRepo, '.claude', 'review-done'), content);
+}
+
+beforeEach(() => {
+  tmpRepo = mkdtempSync(join(tmpdir(), 'review-marker-test-'));
+  // Init repo with a `main` branch that has one commit, then branch off
+  // and add a feature commit so HEAD differs from merge-base.
+  git('init -q -b main');
+  git('config user.email "test@example.com"');
+  git('config user.name "test"');
+  writeFileSync(join(tmpRepo, 'a.txt'), 'a\n');
+  git('add .');
+  git('commit -q -m base');
+  git('checkout -q -b feature');
+  writeFileSync(join(tmpRepo, 'b.txt'), 'b\n');
+  git('add .');
+  git('commit -q -m feature');
+});
+
+afterEach(() => {
+  rmSync(tmpRepo, { recursive: true, force: true });
+});
+
+describe('parseMarker', () => {
+  it('parses a well-formed marker line', () => {
+    const m = parseMarker(
+      'reviewed 05f97cfa1b51b57e4b4f53d41dec1f93adefa409 2026-04-29T22:09:14Z ec22bfc68c62',
+    );
+    expect(m).toEqual({
+      commitSha: '05f97cfa1b51b57e4b4f53d41dec1f93adefa409',
+      isoTime: '2026-04-29T22:09:14Z',
+      diffHash: 'ec22bfc68c62',
+    });
+  });
+
+  it('lowercases the SHA and diff hash for case-insensitive compare', () => {
+    const m = parseMarker(
+      'reviewed 05F97CFA1B51B57E4B4F53D41DEC1F93ADEFA409 2026-04-29T22:09:14Z EC22BFC68C62',
+    );
+    expect(m?.commitSha).toBe('05f97cfa1b51b57e4b4f53d41dec1f93adefa409');
+    expect(m?.diffHash).toBe('ec22bfc68c62');
+  });
+
+  it('tolerates surrounding whitespace and trailing newline', () => {
+    const m = parseMarker(
+      '  reviewed 05f97cfa1b51b57e4b4f53d41dec1f93adefa409 2026-04-29T22:09:14Z ec22bfc68c62  \n',
+    );
+    expect(m).not.toBeNull();
+  });
+
+  it('rejects a SHA that is not exactly 40 hex chars', () => {
+    expect(parseMarker('reviewed abc123 2026-04-29T22:09:14Z ec22bfc68c62')).toBeNull();
+    expect(
+      parseMarker(
+        'reviewed 05f97cfa1b51b57e4b4f53d41dec1f93adefa40 2026-04-29T22:09:14Z ec22bfc68c62',
+      ),
+    ).toBeNull(); // 39 chars
+  });
+
+  it('rejects a diff hash that is not exactly 12 hex chars', () => {
+    expect(
+      parseMarker(
+        'reviewed 05f97cfa1b51b57e4b4f53d41dec1f93adefa409 2026-04-29T22:09:14Z xyz',
+      ),
+    ).toBeNull();
+    expect(
+      parseMarker(
+        'reviewed 05f97cfa1b51b57e4b4f53d41dec1f93adefa409 2026-04-29T22:09:14Z ec22bfc68c62extra',
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects empty / unrelated input', () => {
+    expect(parseMarker('')).toBeNull();
+    expect(parseMarker('hello world')).toBeNull();
+    expect(parseMarker('not-a-marker')).toBeNull();
+  });
+
+  it('rejects a marker that omits the leading `reviewed`', () => {
+    expect(
+      parseMarker(
+        '05f97cfa1b51b57e4b4f53d41dec1f93adefa409 2026-04-29T22:09:14Z ec22bfc68c62',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('computeDiffHash', () => {
+  it('produces a stable 12-char hex hash for an unchanged HEAD', () => {
+    const h1 = computeDiffHash(tmpRepo);
+    const h2 = computeDiffHash(tmpRepo);
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('changes when a new commit lands on the branch', () => {
+    const before = computeDiffHash(tmpRepo);
+    writeFileSync(join(tmpRepo, 'c.txt'), 'c\n');
+    git('add .');
+    git('commit -q -m more');
+    const after = computeDiffHash(tmpRepo);
+    expect(after).not.toBe(before);
+  });
+
+  it('matches the shell pipeline `git diff ... | shasum -a 256 | cut -c1-12`', () => {
+    // Cross-check: the marker writer in /agent-review-pr.md uses the shell
+    // pipeline. This test ensures our Node-side hash agrees byte-for-byte.
+    const mergeBase = execSync('git merge-base HEAD main', {
+      cwd: tmpRepo,
+      encoding: 'utf-8',
+    }).trim();
+    const shellHash = execSync(
+      `git diff ${mergeBase}...HEAD | shasum -a 256 | cut -c1-12`,
+      { cwd: tmpRepo, encoding: 'utf-8' },
+    ).trim();
+    expect(computeDiffHash(tmpRepo)).toBe(shellHash);
+  });
+});
+
+describe('checkReviewMarker', () => {
+  it('returns code=missing when the marker file does not exist', () => {
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('missing');
+    expect(result.message).toContain('/agent-review-pr');
+  });
+
+  it('returns code=malformed when the marker file is junk', () => {
+    writeMarker('this is not a valid marker line\n');
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('malformed');
+    expect(result.message).toContain('malformed');
+  });
+
+  it('returns code=stale-sha when HEAD has advanced past the reviewed commit', () => {
+    const headSha = git('rev-parse HEAD');
+    const diffHash = computeDiffHash(tmpRepo);
+    writeMarker(`reviewed ${headSha} 2026-04-29T22:09:14Z ${diffHash}\n`);
+    // Add a new commit — marker is now stale.
+    writeFileSync(join(tmpRepo, 'd.txt'), 'd\n');
+    git('add .');
+    git('commit -q -m later');
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('stale-sha');
+    expect(result.message).toContain('stale');
+  });
+
+  it('returns code=stale-diff when SHA matches but diff hash differs', () => {
+    const headSha = git('rev-parse HEAD');
+    // Write a marker with the right SHA but a fake diff hash.
+    writeMarker(`reviewed ${headSha} 2026-04-29T22:09:14Z 000000000000\n`);
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('stale-diff');
+    expect(result.message).toContain('diff hash differs');
+  });
+
+  it('returns ok=true when SHA and diff hash both match HEAD', () => {
+    const headSha = git('rev-parse HEAD');
+    const diffHash = computeDiffHash(tmpRepo);
+    writeMarker(`reviewed ${headSha} 2026-04-29T22:09:14Z ${diffHash}\n`);
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('ok');
+    expect(result.message).toContain('fresh');
+  });
+
+  it('returns code=no-base when run outside a git repo', () => {
+    const nonRepo = mkdtempSync(join(tmpdir(), 'review-marker-nonrepo-'));
+    try {
+      // Write a syntactically-valid marker so we get past the malformed check.
+      mkdirSync(join(nonRepo, '.claude'), { recursive: true });
+      writeFileSync(
+        join(nonRepo, '.claude', 'review-done'),
+        'reviewed 0123456789abcdef0123456789abcdef01234567 2026-04-29T22:09:14Z 0123456789ab\n',
+      );
+      const result = checkReviewMarker(nonRepo);
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('no-base');
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('treats uppercase hex in the marker as equivalent to lowercase', () => {
+    const headSha = git('rev-parse HEAD');
+    const diffHash = computeDiffHash(tmpRepo);
+    writeMarker(
+      `reviewed ${headSha.toUpperCase()} 2026-04-29T22:09:14Z ${diffHash.toUpperCase()}\n`,
+    );
+    const result = checkReviewMarker(tmpRepo);
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('ok');
+  });
+});

--- a/crux/lib/review-marker.ts
+++ b/crux/lib/review-marker.ts
@@ -25,7 +25,7 @@
  * `git push` to `crux gh pr create`.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 
@@ -78,16 +78,21 @@ export function parseMarker(line: string): ParsedMarker | null {
  * (likely fresh worktree, no main reference) or rethrow.
  */
 export function computeDiffHash(cwd: string = process.cwd()): string {
+  // Use execFileSync everywhere instead of execSync so interpolated values
+  // (mergeBase) cannot be shell-interpreted. The unified-rule validator
+  // `no-exec-sync` rejects template-literal execSync for exactly this
+  // reason — defense-in-depth even though `git merge-base` output is
+  // always a 40-char hex SHA in practice.
   let mergeBase: string;
   try {
-    mergeBase = execSync('git merge-base HEAD origin/main', {
+    mergeBase = execFileSync('git', ['merge-base', 'HEAD', 'origin/main'], {
       cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8',
     }).trim();
   } catch {
     // Fallback to local `main` ref.
-    mergeBase = execSync('git merge-base HEAD main', {
+    mergeBase = execFileSync('git', ['merge-base', 'HEAD', 'main'], {
       cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8',
@@ -96,9 +101,10 @@ export function computeDiffHash(cwd: string = process.cwd()): string {
   if (!mergeBase) {
     throw new Error('Could not resolve merge-base with main / origin/main');
   }
-  // Use Buffer mode so binary diffs hash identically to shasum's behavior.
-  // The marker writer pipes the raw `git diff` output to `shasum -a 256`.
-  const diffOutput = execSync(`git diff ${mergeBase}...HEAD`, {
+  // Use Buffer mode (no encoding) so binary diffs hash identically to
+  // shasum's behavior. The marker writer pipes the raw `git diff` output
+  // to `shasum -a 256`.
+  const diffOutput = execFileSync('git', ['diff', `${mergeBase}...HEAD`], {
     cwd,
     stdio: ['ignore', 'pipe', 'ignore'],
     maxBuffer: 256 * 1024 * 1024, // 256MB; large enough for any realistic PR
@@ -111,7 +117,7 @@ export function computeDiffHash(cwd: string = process.cwd()): string {
 
 /** Get current HEAD SHA. */
 function getHeadSha(cwd: string = process.cwd()): string {
-  return execSync('git rev-parse HEAD', {
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
     cwd,
     stdio: ['ignore', 'pipe', 'ignore'],
     encoding: 'utf-8',

--- a/crux/lib/review-marker.ts
+++ b/crux/lib/review-marker.ts
@@ -1,0 +1,226 @@
+/**
+ * Review-marker check — QUA-849 #7
+ *
+ * `crux gh pr create` refuses unless `.claude/review-done` exists and is
+ * fresh against the current HEAD's commit + diff hash. The marker is
+ * written by the `/agent-review-pr` skill at the end of its review pass:
+ *
+ *   reviewed <commit-sha> <iso-time> <diff-hash>
+ *
+ * Where `<diff-hash>` is the first 12 chars of `sha256(git diff <merge-base
+ * with main>...HEAD)`. The check verifies BOTH the commit SHA and the diff
+ * hash so:
+ *
+ *   - Adding a commit after the review invalidates the marker (SHA mismatch).
+ *   - Force-pushing a different commit with the same SHA but different diff
+ *     content is also caught (diff hash mismatch — defense-in-depth, this
+ *     case is unlikely in practice but cheap to check).
+ *   - A missing or zero-byte marker means the review skill never ran.
+ *
+ * Filed as part of QUA-849 (Inflated review summaries). Companion fixes
+ * (artifact-per-phase, force-subagent-execution) catch the "ran skill but
+ * lied about phase X" pattern; this check catches the upstream "didn't
+ * run the skill at all" pattern, which is the failure mode that produced
+ * 2 HIGH bugs on QUA-728 (PR #4689) when the agent went straight from
+ * `git push` to `crux gh pr create`.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+const MARKER_PATH = '.claude/review-done';
+const DIFF_HASH_LENGTH = 12;
+
+export interface MarkerCheckResult {
+  ok: boolean;
+  /** Stable machine-readable code for branching on the failure mode. */
+  code: 'ok' | 'missing' | 'malformed' | 'stale-sha' | 'stale-diff' | 'no-base';
+  /** Human-readable detail to surface to the operator. */
+  message: string;
+}
+
+interface ParsedMarker {
+  commitSha: string;
+  isoTime: string;
+  diffHash: string;
+}
+
+/**
+ * Parse a marker line. Format: `reviewed <sha> <iso> <12-char-hex>`.
+ * Returns null if the line doesn't match. Whitespace is tolerated at the
+ * start/end and between fields.
+ */
+export function parseMarker(line: string): ParsedMarker | null {
+  // Match the four-token shape; we don't enforce strict ISO format because
+  // shells can vary in `date -u` output, and the timestamp is informational
+  // (the SHA + diff-hash are what get verified).
+  const trimmed = line.trim();
+  const match = trimmed.match(
+    /^reviewed\s+([0-9a-f]{40})\s+(\S+)\s+([0-9a-f]{12})\s*$/i,
+  );
+  if (!match) return null;
+  return {
+    commitSha: match[1].toLowerCase(),
+    isoTime: match[2],
+    diffHash: match[3].toLowerCase(),
+  };
+}
+
+/**
+ * Compute the diff hash the same way `/agent-review-pr` writes it:
+ *   sha256(git diff <merge-base with main>...HEAD).slice(0, 12)
+ *
+ * Falls back from `origin/main` to `main` so the check works in worktrees
+ * that haven't fetched origin yet (rare but the fallback is cheap).
+ *
+ * Throws on git failure — caller decides whether to surface as `no-base`
+ * (likely fresh worktree, no main reference) or rethrow.
+ */
+export function computeDiffHash(cwd: string = process.cwd()): string {
+  let mergeBase: string;
+  try {
+    mergeBase = execSync('git merge-base HEAD origin/main', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    // Fallback to local `main` ref.
+    mergeBase = execSync('git merge-base HEAD main', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+    }).trim();
+  }
+  if (!mergeBase) {
+    throw new Error('Could not resolve merge-base with main / origin/main');
+  }
+  // Use Buffer mode so binary diffs hash identically to shasum's behavior.
+  // The marker writer pipes the raw `git diff` output to `shasum -a 256`.
+  const diffOutput = execSync(`git diff ${mergeBase}...HEAD`, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    maxBuffer: 256 * 1024 * 1024, // 256MB; large enough for any realistic PR
+  });
+  return createHash('sha256')
+    .update(diffOutput)
+    .digest('hex')
+    .slice(0, DIFF_HASH_LENGTH);
+}
+
+/** Get current HEAD SHA. */
+function getHeadSha(cwd: string = process.cwd()): string {
+  return execSync('git rev-parse HEAD', {
+    cwd,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    encoding: 'utf-8',
+  }).trim().toLowerCase();
+}
+
+/**
+ * Verify the review marker is present and matches HEAD. Pure of CLI flags
+ * — caller decides whether to bypass (e.g. via `--skip-review-check`).
+ *
+ * Returns `{ ok: true, code: 'ok' }` only when both the SHA and diff hash
+ * match. Any mismatch or missing file returns a specific code so the
+ * caller can surface differentiated guidance.
+ */
+export function checkReviewMarker(cwd: string = process.cwd()): MarkerCheckResult {
+  const markerPath = `${cwd}/${MARKER_PATH}`;
+
+  if (!existsSync(markerPath)) {
+    return {
+      ok: false,
+      code: 'missing',
+      message:
+        `No review marker found at ${MARKER_PATH}. ` +
+        `Run \`/agent-review-pr\` to do a hostile-reviewer pass on this branch, ` +
+        `then re-run this command.`,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(markerPath, 'utf-8');
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      code: 'malformed',
+      message:
+        `Could not read ${MARKER_PATH}: ${e instanceof Error ? e.message : String(e)}. ` +
+        `Re-run \`/agent-review-pr\` to regenerate.`,
+    };
+  }
+  const parsed = parseMarker(raw);
+  if (!parsed) {
+    return {
+      ok: false,
+      code: 'malformed',
+      message:
+        `Review marker at ${MARKER_PATH} is malformed (expected ` +
+        `\`reviewed <40-char-sha> <iso-time> <12-char-hex>\`). ` +
+        `Got: ${JSON.stringify(raw.slice(0, 200))}. ` +
+        `Re-run \`/agent-review-pr\` to regenerate.`,
+    };
+  }
+
+  let headSha: string;
+  try {
+    headSha = getHeadSha(cwd);
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      code: 'no-base',
+      message:
+        `Could not resolve HEAD: ${e instanceof Error ? e.message : String(e)}. ` +
+        `If you're not in a git repository, this command doesn't apply. ` +
+        `Otherwise, check that the working tree is intact.`,
+    };
+  }
+  if (parsed.commitSha !== headSha) {
+    return {
+      ok: false,
+      code: 'stale-sha',
+      message:
+        `Review marker is stale: marker covers commit ${parsed.commitSha.slice(0, 12)} ` +
+        `but HEAD is ${headSha.slice(0, 12)}. ` +
+        `New commits landed since the review pass — re-run \`/agent-review-pr\` ` +
+        `to verify the new diff.`,
+    };
+  }
+
+  let currentDiffHash: string;
+  try {
+    currentDiffHash = computeDiffHash(cwd);
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      code: 'no-base',
+      message:
+        `Could not compute diff hash to verify review marker: ` +
+        `${e instanceof Error ? e.message : String(e)}. ` +
+        `This usually means the branch has no merge-base with main / origin/main. ` +
+        `If this is intentional (e.g. a totally new history), pass ` +
+        `\`--skip-review-check --reason=...\` to bypass.`,
+    };
+  }
+
+  if (parsed.diffHash !== currentDiffHash) {
+    return {
+      ok: false,
+      code: 'stale-diff',
+      message:
+        `Review marker SHA matches HEAD but diff hash differs ` +
+        `(marker: ${parsed.diffHash}, current: ${currentDiffHash}). ` +
+        `The branch was force-pushed or rebased after the review. ` +
+        `Re-run \`/agent-review-pr\` to verify the new diff content.`,
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'ok',
+    message: `Review marker fresh (commit ${parsed.commitSha.slice(0, 12)}, ${parsed.isoTime}).`,
+  };
+}


### PR DESCRIPTION
## Summary

`crux gh pr create` now refuses unless `.claude/review-done` exists and
matches HEAD's commit + diff hash. Catches the upstream "didn't run
`/agent-review-pr` at all" failure mode that QUA-849's existing
brainstorm items (#1 phase artifacts, #2 force-subagent-execution,
#4 audit-the-summary) don't catch — they all assume the skill was at
least started.

## Real-world incident this catches

QUA-728 (PR #4689, 2026-04-29). Agent went straight from `git push -u
origin <branch>` to `crux gh pr create`, never invoked
`/agent-review-pr`. The user asked "did you do the full checklist?"
When the agent then ran the skill, the hostile-reviewer subagent
immediately found 2 HIGH correctness bugs (wrong "latest URL" pick from
misreading server evidence ordering; budget-skipped records mis-bucketed
into `noReplacement`) plus 4 MEDIUM. Both HIGH bugs the agent's own
28 tests didn't catch. CodeRabbit didn't catch them either.

The gap: there's no checkpoint between `git push` and
`crux gh pr create` that verifies a review happened. CR runs *after*
PR open, returns "No actionable comments" on logic-correctness bugs,
and produces false confidence. This PR adds the missing gate.

## How it works

- New `crux/lib/review-marker.ts` parses `.claude/review-done`
  (`reviewed <40-char-sha> <iso-time> <12-char-hex>`) and verifies BOTH:
  - The SHA matches `git rev-parse HEAD` exactly
  - The diff hash matches `sha256(git diff <merge-base>...HEAD).slice(0, 12)`

  Both checks are needed: SHA-only would miss a force-pushed branch with
  the same SHA but different content; diff-only would miss a new commit
  that didn't change the diff against the merge-base.

- `crux gh pr create` calls `checkReviewMarker()` after title validation,
  before the heavy quality checks. Refuses with exit 2 and a structured
  error code on mismatch:

  | Code | Meaning |
  |------|---------|
  | `missing` | `.claude/review-done` doesn't exist — `/agent-review-pr` never ran |
  | `malformed` | File exists but doesn't match the expected format |
  | `stale-sha` | Marker covers an older commit; new commits landed since review |
  | `stale-diff` | SHA matches but diff content differs (force-push or rebase since review) |
  | `no-base` | Can't resolve merge-base or HEAD (corrupt git state) |

- Bypass: `--skip-review-check --reason="<why>"`. Reason is **required** —
  empty bypasses defeat the gate's purpose. The bypass logs a warning so
  it's traceable in PR-creation telemetry.

## Cross-check against the shell pipeline

The `/agent-review-pr` skill writes the marker via:

```bash
DIFF_HASH=$(git diff <merge-base>...HEAD | shasum -a 256 | cut -c1-12)
```

A test (`computeDiffHash matches the shell pipeline ...`) compares the
Node-side hash to the shell pipeline byte-for-byte in a temp git repo.
If the skill ever changes its hash format, that test fails loudly
rather than silently mismatching markers.

## Bypass philosophy

The bypass exists because we live in the real world (genuine emergencies,
non-agent humans, debugging the gate itself). It mirrors the same shape
as other refusal-style checks in this command:

- `--allow-empty-body` for empty PR bodies
- `--skip-test-plan` for missing test plans
- `--force` for Linear-ID dedup collisions
- `--skip-review-check --reason=...` (this PR)

The required `--reason=` is unique to this check because the failure
mode it prevents (skipping review under context pressure) is the exact
behavior an empty bypass would invite.

## Tests

17 unit tests in `crux/lib/review-marker.test.ts`:

- `parseMarker`: well-formed, lowercased hex, whitespace tolerance,
  rejects 39-char SHAs, rejects malformed diff hashes, rejects empty
  / unrelated input, rejects missing `reviewed` keyword.
- `computeDiffHash`: stable across repeated calls, changes when a
  commit lands, **matches the shell pipeline byte-for-byte**.
- `checkReviewMarker`: 5 codes (missing, malformed, stale-sha,
  stale-diff, no-base, ok) — uses a temp git repo per test so the
  real working copy isn't polluted.

48 existing `pr.ts` tests still pass.

## Limits & follow-ups

This catches the "didn't run the skill" pattern. It does NOT catch
the "ran the skill, lied about phase X" pattern that QUA-849's body
describes — for that, items #1 (artifacts per phase) and #2 (force
subagent to execute adversarial commands) are still needed. The full
structural fix is to gate at three points in the funnel:

1. **This PR** — refuse PR create without marker
2. **QUA-849 #1** — refuse marker write without per-phase artifacts
3. **QUA-849 #2** — force adversarial-command execution into the
   subagent, captured to disk

The three together leave no "I considered it" path open.

## Test plan

- [x] `pnpm vitest run crux/lib/review-marker.test.ts` — 17/17 pass
- [x] `pnpm vitest run crux/commands/pr.test.ts` — 48/48 pass
- [x] `pnpm crux w validate gate --fix --no-cache` — all 56 gate checks pass
- [x] CLI smoke-test: missing marker → exit 2 with `code: missing`
- [x] CLI smoke-test: malformed marker → exit 2 with `code: malformed`
- [x] CLI smoke-test: `--skip-review-check` without `--reason` → exit 1
- [x] CLI smoke-test: this PR's own creation succeeds (marker fresh
      against HEAD)
- [ ] Operator: confirm the bypass log message is visible enough in
      practice; tune wording if it's missed in real PR-creation runs

## Deploy considerations

None. The check is pure local-side: reads `.claude/review-done`, runs
`git diff` and `git rev-parse`, compares. No server side, no migrations,
no env vars.

Closes part of QUA-849 (item #7 from the brainstorm). Does NOT close
QUA-849 itself — items #1, #2, #4 from that ticket are still open.

Fixes QUA-849
