### PR TITLE
fix(validate-controlled-vocab): propagate exit code on violations (QUA-809)

### DIFF
--- a/crux/validate/validate-controlled-vocab.test.ts
+++ b/crux/validate/validate-controlled-vocab.test.ts
@@ -3,6 +3,7 @@ import {
   suggestCorrection,
   checkValue,
   checkYamlEntities,
+  exitCodeForResult,
   VALID_ENTITY_TYPES,
   VALID_RELATIONSHIPS,
   VALID_MATURITIES,
@@ -418,5 +419,19 @@ describe("suggestCorrection edge cases", () => {
 
   it("handles the exact match edge case (distance=0)", () => {
     expect(suggestCorrection("ab", smallVocab)).toBe("ab");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit code propagation (QUA-809 regression)
+// ---------------------------------------------------------------------------
+
+describe("exitCodeForResult", () => {
+  it("returns 0 when validation passed", () => {
+    expect(exitCodeForResult({ passed: true })).toBe(0);
+  });
+
+  it("returns 1 when validation failed (gate must block)", () => {
+    expect(exitCodeForResult({ passed: false })).toBe(1);
   });
 });

--- a/crux/validate/validate-controlled-vocab.ts
+++ b/crux/validate/validate-controlled-vocab.ts
@@ -511,12 +511,22 @@ export async function validateControlledVocab(options?: {
 // CLI entry point
 // ---------------------------------------------------------------------------
 
+/**
+ * Exit code derivation for the CLI. Exported for testing — the historical
+ * bug was that main() never propagated `result.passed === false` to
+ * process.exitCode, silently flipping the gate to advisory (QUA-809).
+ */
+export function exitCodeForResult(result: { passed: boolean }): number {
+  return result.passed ? 0 : 1;
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const ci = args.includes("--ci");
   const verbose = args.includes("--verbose");
 
-  await validateControlledVocab({ ci, verbose });
+  const result = await validateControlledVocab({ ci, verbose });
+  process.exitCode = exitCodeForResult(result);
 }
 
 main().catch((err) => {

--- a/data/entities/coordination-ecosystem.yaml
+++ b/data/entities/coordination-ecosystem.yaml
@@ -2605,7 +2605,7 @@
     Meta AI agent achieving human-level performance in Diplomacy — a game requiring
     negotiation, alliance formation, and multi-party coordination. Published in Science
     (2022). Demonstrated AI can learn complex multi-party coordination with humans.
-  projectStatus: completed
+  projectStatus: archived
   tags:
     - game-theory
     - negotiation
@@ -2627,7 +2627,7 @@
     policy while agents learn economic behavior. Published in Science Advances (2022).
     Showed RL-designed tax policies improved equality-productivity tradeoffs over US tax
     schedules.
-  projectStatus: completed
+  projectStatus: archived
   tags:
     - mechanism-design
     - reinforcement-learning

--- a/data/entities/epistemic-orgs-projects.yaml
+++ b/data/entities/epistemic-orgs-projects.yaml
@@ -132,7 +132,7 @@
   wikiId: E200
   type: project
   title: Metaforecast
-  projectStatus: unmaintained
+  projectStatus: abandoned
   projectUrl: https://metaforecast.org
   organization: quri
   description: Forecast aggregation platform combining predictions from 10+ sources into a unified search interface.
@@ -264,7 +264,7 @@
   stableId: sid_pF3vNTBCmg
   type: project
   title: Foretold.io
-  projectStatus: deprecated
+  projectStatus: abandoned
   projectUrl: https://www.foretold.io
   organization: quri
   description: >-


### PR DESCRIPTION
## Summary

`crux/validate/validate-controlled-vocab.ts::main()` ran the validator but never propagated `result.passed` to `process.exitCode`. The gate's `controlled-vocab` step is wired as `advisory: false`, but `validate-gate.ts` decides pass/fail by subprocess exit code (`passed: code === 0`), so violations never blocked CI — the check was silently advisory.

## Changes

- **Exit code propagation** — extract `exitCodeForResult()` helper; `main()` now sets `process.exitCode` from it. The helper is exported so the unit test in `validate-controlled-vocab.test.ts` can pin the contract that `passed: false ⇒ exit 1`.
- **Fix 4 pre-existing dirty `projectStatus` values** that were masked by the bug. Mapped to the canonical `ProjectEntitySchema` enum (`active | maintained | archived | abandoned | beta`) instead of extending the vocabulary:
  - `cicero-diplomacy`, `ai-economist`: `completed` → `archived` (research projects with published outputs).
  - `metaforecast`: `unmaintained` → `abandoned` (no active maintenance).
  - `foretold`: `deprecated` → `abandoned` ("currently not functioning, work halted").

## Verification

- `npx tsx crux/validate/validate-controlled-vocab.ts` exits **0** on the cleaned data.
- Re-injecting an invalid value (`projectStatus: unknownvalue`) makes it exit **1** as expected.
- `pnpm test crux/validate/validate-controlled-vocab.test.ts` — 41 tests pass (2 new).
- `pnpm crux w validate gate --scope=content --fix` — all checks green.

## Test plan

- [x] Validator exits 1 on violation, 0 on clean
- [x] Unit test pins `exitCodeForResult` contract
- [x] Existing 39 controlled-vocab tests still pass
- [x] Content-scope gate green

Fixes QUA-809.
