### PR TITLE
feat(third-party-evals): wire ingesters to inline sourcing block (QUA-727)

### DIFF
--- a/apps/wiki-server/src/__tests__/third-party-evaluations-sourcing.test.ts
+++ b/apps/wiki-server/src/__tests__/third-party-evaluations-sourcing.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Route test for the /api/third-party-evaluations/sync inline sourcing
+ * block (QUA-727).
+ *
+ * Verifies that:
+ *   - The route accepts `sourcing` on each item and writes to the
+ *     source_check_verdicts + source_check_evidence tables.
+ *   - Items without `sourcing` skip the verdict-write phase but still upsert
+ *     the row (sourcing is optional — the table isn't in SOURCE_CHECK_REQUIRED).
+ *   - The `sourcing` field is stripped from the row insert (it's not a
+ *     column on `third_party_evaluations`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+let insertedRowKeys: string[][] = [];
+let verdictInsertCount = 0;
+let evidenceInsertCount = 0;
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // validate-entity-refs: every supplied entity ref resolves
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params.map((p) => ({ ref: p }));
+  }
+
+  // Capture the third_party_evaluations insert column list so we can assert
+  // `sourcing` is NOT among them.
+  if (q.includes("insert into") && q.includes("third_party_evaluations")) {
+    const match = query.match(/insert into\s+"third_party_evaluations"\s*\(([^)]+)\)/i);
+    if (match) {
+      const cols = match[1]
+        .split(",")
+        .map((c) => c.trim().replace(/^"|"$/g, ""));
+      insertedRowKeys.push(cols);
+    }
+    return [];
+  }
+
+  if (q.includes("insert into") && q.includes("source_check_verdicts")) {
+    verdictInsertCount++;
+    return [];
+  }
+  if (q.includes("insert into") && q.includes("source_check_evidence")) {
+    evidenceInsertCount++;
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { thirdPartyEvaluationsRoute } = await import(
+  "../routes/tablebase/third-party-evaluations.js"
+);
+
+describe("third-party-evaluations /sync — inline sourcing (QUA-727)", () => {
+  beforeEach(() => {
+    insertedRowKeys = [];
+    verdictInsertCount = 0;
+    evidenceInsertCount = 0;
+  });
+
+  it("writes a source_check_verdicts row when sourcing is present", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0001",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/report.pdf",
+          title: "Smoke-test report",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          sourcing: {
+            verdict: "confirmed",
+            confidence: 0.95,
+            evidence: "Pre-deployment evaluation excerpt",
+            checkedBy: "span-verify-v1",
+            checkedAt: "2026-04-25T10:30:00.000Z",
+            sourceContentHash: "deadbeef",
+          },
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ upserted: 1, verdictsWritten: 1 });
+
+    expect(verdictInsertCount).toBeGreaterThan(0);
+    // Evidence row also written when sourceUrl is set (toVerdict passes reportUrl)
+    expect(evidenceInsertCount).toBeGreaterThan(0);
+  });
+
+  it("strips sourcing from the row insert (it's not a third_party_evaluations column)", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0002",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/r2.pdf",
+          title: "Test",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          sourcing: {
+            verdict: "partial",
+            confidence: 0.7,
+            checkedBy: "span-verify-v1",
+            checkedAt: "2026-04-25T10:30:00.000Z",
+          },
+        },
+      ],
+    });
+
+    expect(insertedRowKeys.length).toBeGreaterThan(0);
+    for (const cols of insertedRowKeys) {
+      expect(cols).not.toContain("sourcing");
+    }
+  });
+
+  it("skips verdict write when sourcing is absent", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0003",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/r3.pdf",
+          title: "No sourcing",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+        },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ upserted: 1, verdictsWritten: 0 });
+    expect(verdictInsertCount).toBe(0);
+  });
+
+  it("rejects an invalid sourcing.verdict value", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0004",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/r4.pdf",
+          title: "Bad verdict",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          sourcing: {
+            verdict: "bogus" as unknown as "confirmed",
+            confidence: 0.9,
+          },
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/__tests__/third-party-evaluations-sourcing.test.ts
+++ b/apps/wiki-server/src/__tests__/third-party-evaluations-sourcing.test.ts
@@ -98,7 +98,10 @@ describe("third-party-evaluations /sync — inline sourcing (QUA-727)", () => {
     expect(evidenceInsertCount).toBeGreaterThan(0);
   });
 
-  it("strips sourcing from the row insert (it's not a third_party_evaluations column)", async () => {
+  it("never emits 'sourcing' as a column in the third_party_evaluations INSERT", async () => {
+    // Regression guard: if `toRow` ever stops stripping `sourcing`, postgres
+    // would error with `column "sourcing" of relation "third_party_evaluations"
+    // does not exist`. Verifies the auto-derived SET clause stays clean.
     const app = new Hono().route("/", thirdPartyEvaluationsRoute);
 
     await postJson(app, "/sync", {
@@ -163,6 +166,52 @@ describe("third-party-evaluations /sync — inline sourcing (QUA-727)", () => {
           sourcing: {
             verdict: "bogus" as unknown as "confirmed",
             confidence: 0.9,
+          },
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects sourcing.confidence outside [0,1]", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0005",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/r5.pdf",
+          title: "Bad confidence",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          sourcing: {
+            verdict: "confirmed",
+            confidence: 1.5,
+          },
+        },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects oversized sourcing.evidence (>5000 chars)", async () => {
+    const app = new Hono().route("/", thirdPartyEvaluationsRoute);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        {
+          id: "abcdef0006",
+          evaluatorOrgId: "sid_pKeaWwP6sQ",
+          reportUrl: "https://example.com/r6.pdf",
+          title: "Huge evidence",
+          riskDomain: ["cyber"],
+          sourceSystem: "manual",
+          sourcing: {
+            verdict: "confirmed",
+            evidence: "x".repeat(5001),
           },
         },
       ],

--- a/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
+++ b/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
@@ -33,6 +33,7 @@ import { paginatedQuery } from "../shared/paginated-query.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { sqlInList } from "../shared/query-helpers.js";
 import { createSyncHandler } from "./sync-factory.js";
+import { InlineSourcingSchema } from "./sourcing-schema.js";
 
 // ---- Constants ----
 
@@ -139,6 +140,10 @@ const SyncThirdPartyEvalItemSchema = z.object({
   // Inline join-table fan-out. Empty array clears all links for this evaluation;
   // omitted (undefined) leaves existing links untouched (partial sync).
   models: z.array(EvaluationModelLinkSchema).max(50).optional(),
+  // Inline sourcing verdict (QUA-727). When present, the sync handler writes
+  // a source_check_verdicts row atomically with the evaluation. Ingesters
+  // populate this from span-verify output via `spanVerifyToInlineSourcing()`.
+  sourcing: InlineSourcingSchema.optional(),
 });
 
 export type ThirdPartyEvaluationSyncItem = z.infer<typeof SyncThirdPartyEvalItemSchema>;
@@ -398,13 +403,15 @@ const thirdPartyEvaluationsApp = new Hono()
       table: thirdPartyEvaluations,
       batchSchema: SyncThirdPartyEvaluationsBatchSchema,
       entityRefs: ["evaluatorOrgId"],
-      // Strip the `models` field before insert — it goes to the join table
-      // in postUpsert, not the main row. Coerce `extractedAt` from the
+      // Strip the `models` and `sourcing` fields before insert — `models`
+      // goes to the join table in postUpsert; `sourcing` goes to
+      // source_check_verdicts via toVerdict. Coerce `extractedAt` from the
       // wire-format ISO string into a Date so postgres-js can serialize the
       // timestamp column (it calls `.toISOString()` internally).
       toRow: (item, now) => {
-        const { models: _models, extractedAt, ...row } = item;
+        const { models: _models, sourcing: _sourcing, extractedAt, ...row } = item;
         void _models;
+        void _sourcing;
         return {
           ...row,
           extractedAt: extractedAt ? new Date(extractedAt) : null,
@@ -449,6 +456,16 @@ const thirdPartyEvaluationsApp = new Hono()
         sourceTable: "third_party_evaluations",
         sourceId: item.id,
         sourceUrl: item.reportUrl,
+      }),
+      // Inline sourcing verdict (QUA-727). Ingesters that ran span-verify
+      // populate `item.sourcing`; the factory writes source_check_verdicts
+      // atomically with the row. Items without `sourcing` skip this phase.
+      toVerdict: (item) => ({
+        recordType: "third-party-evaluation",
+        recordId: item.id,
+        entityId: item.evaluatorOrgId,
+        sourceUrl: item.reportUrl,
+        sourcing: item.sourcing ?? null,
       }),
       // Synchronize the join-table fan-out inside the same transaction.
       // Items where `models` is undefined leave existing links untouched

--- a/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
+++ b/apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
@@ -39,6 +39,8 @@ import { InlineSourcingSchema } from "./sourcing-schema.js";
 
 const MAX_PAGE_SIZE = 200;
 
+const RECORD_TYPE = "third-party-evaluation" as const;
+
 // Mirror the CHECK constraint in migration 0206. Source-of-truth for the
 // same vocab also referenced by validate-third-party-eval-refs.ts.
 export const VALID_RISK_DOMAINS = [
@@ -140,9 +142,9 @@ const SyncThirdPartyEvalItemSchema = z.object({
   // Inline join-table fan-out. Empty array clears all links for this evaluation;
   // omitted (undefined) leaves existing links untouched (partial sync).
   models: z.array(EvaluationModelLinkSchema).max(50).optional(),
-  // Inline sourcing verdict (QUA-727). When present, the sync handler writes
-  // a source_check_verdicts row atomically with the evaluation. Ingesters
-  // populate this from span-verify output via `spanVerifyToInlineSourcing()`.
+  // When present, the sync handler writes a source_check_verdicts row
+  // atomically with the evaluation. Ingesters populate this from span-verify
+  // output via `spanVerifyToInlineSourcing()`.
   sourcing: InlineSourcingSchema.optional(),
 });
 
@@ -451,17 +453,17 @@ const thirdPartyEvaluationsApp = new Hono()
       // composed at read time from the source table.
       toThing: (item) => ({
         id: item.id,
-        thingType: "third-party-evaluation" as const,
+        thingType: RECORD_TYPE,
         parentThingId: item.evaluatorOrgId,
         sourceTable: "third_party_evaluations",
         sourceId: item.id,
         sourceUrl: item.reportUrl,
       }),
-      // Inline sourcing verdict (QUA-727). Ingesters that ran span-verify
-      // populate `item.sourcing`; the factory writes source_check_verdicts
-      // atomically with the row. Items without `sourcing` skip this phase.
+      // Ingesters that ran span-verify populate `item.sourcing`; the factory
+      // writes source_check_verdicts atomically with the row. Items without
+      // `sourcing` skip this phase.
       toVerdict: (item) => ({
-        recordType: "third-party-evaluation",
+        recordType: RECORD_TYPE,
         recordId: item.id,
         entityId: item.evaluatorOrgId,
         sourceUrl: item.reportUrl,

--- a/crux/commands/third-party-evals.ts
+++ b/crux/commands/third-party-evals.ts
@@ -185,7 +185,6 @@ async function extractSubcommand(
 
   const sourcing = spanVerifyToInlineSourcing(verify, {
     sourceContentHash: extract.sourceHash,
-    checkedAt: extract.extractedAt,
   });
 
   const item = toSyncItem(extract, {

--- a/crux/commands/third-party-evals.ts
+++ b/crux/commands/third-party-evals.ts
@@ -29,7 +29,10 @@ import {
   toSyncItem,
   EXTRACTOR_VERSION,
 } from "../third-party-evals/extract-eval-report.ts";
-import { verifyExtractedReport } from "../third-party-evals/span-verify.ts";
+import {
+  verifyExtractedReport,
+  spanVerifyToInlineSourcing,
+} from "../third-party-evals/span-verify.ts";
 import { resolveAiModel } from "../lib/ai-model-resolver.ts";
 import { dispatchIngest } from "../third-party-evals/ingesters/dispatch.ts";
 import { backfillEvaluator } from "../third-party-evals/backfill.ts";
@@ -180,6 +183,11 @@ async function extractSubcommand(
 
   const id = generateId(`third-party-eval:${url}:${extract.sourceHash}`);
 
+  const sourcing = spanVerifyToInlineSourcing(verify, {
+    sourceContentHash: extract.sourceHash,
+    checkedAt: extract.extractedAt,
+  });
+
   const item = toSyncItem(extract, {
     id,
     evaluatorOrgId: options.evaluator,
@@ -187,6 +195,7 @@ async function extractSubcommand(
     sourceSystem,
     models: modelLinks,
     confidenceMap: verify.confidenceMap,
+    sourcing,
   });
 
   if (options.json) {

--- a/crux/third-party-evals/backfill.test.ts
+++ b/crux/third-party-evals/backfill.test.ts
@@ -24,11 +24,14 @@ vi.mock("./extract-eval-report.ts", () => ({
 }));
 vi.mock("./span-verify.ts", () => ({
   verifyExtractedReport: vi.fn(() => ({
-    verifiedReport: { modelsNamed: [] },
+    verifiedReport: { modelsNamed: [], excerpts: {} },
+    verdicts: {},
     droppedFields: [],
     ungroundedFields: [],
     confidenceMap: {},
   })),
+  spanVerifyToInlineSourcing: vi.fn(() => null),
+  SPAN_VERIFY_CHECKER: "span-verify-v1",
 }));
 vi.mock("../lib/wiki-server/third-party-evaluations.ts", () => ({
   syncThirdPartyEvaluations: vi.fn(),
@@ -39,7 +42,8 @@ vi.mock("../lib/ai-model-resolver.ts", () => ({
 
 import { ingestUkAisi } from "./ingesters/uk-aisi-sitemap.ts";
 import { ingestMetr } from "./ingesters/metr-rss.ts";
-import { extractEvalReport } from "./extract-eval-report.ts";
+import { extractEvalReport, toSyncItem } from "./extract-eval-report.ts";
+import { spanVerifyToInlineSourcing } from "./span-verify.ts";
 import { syncThirdPartyEvaluations } from "../lib/wiki-server/third-party-evaluations.ts";
 import { backfillEvaluator } from "./backfill.ts";
 
@@ -334,5 +338,68 @@ describe("backfillEvaluator", () => {
     expect(events).toContain("extracted");
     expect(events).toContain("extract-error");
     expect(events).toContain("synced");
+  });
+
+  it("populates sourcing block on each sync item via span-verify (QUA-727)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(2),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(spanVerifyToInlineSourcing).mockReturnValue({
+      verdict: "confirmed",
+      confidence: 0.95,
+      checkedBy: "span-verify-v1",
+      checkedAt: "2026-04-25T00:00:00.000Z",
+      sourceContentHash: "deadbeef",
+      evidence: "Pre-deployment evaluation excerpt",
+    });
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    } as never);
+
+    await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+    });
+
+    // span-verify helper was called once per candidate, with the source hash
+    // and timestamp threaded through from the extract.
+    expect(vi.mocked(spanVerifyToInlineSourcing)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(spanVerifyToInlineSourcing).mock.calls[0][1]).toMatchObject({
+      sourceContentHash: "deadbeef",
+      checkedAt: "2026-04-25T00:00:00.000Z",
+    });
+
+    // toSyncItem received the verdict via opts.sourcing
+    const toSyncOpts = vi.mocked(toSyncItem).mock.calls[0][1];
+    expect(toSyncOpts.sourcing).toMatchObject({
+      verdict: "confirmed",
+      checkedBy: "span-verify-v1",
+    });
+  });
+
+  it("omits sourcing block when span-verify returns null (no checkable fields)", async () => {
+    vi.mocked(ingestUkAisi).mockResolvedValue({
+      evaluator: "uk-aisi",
+      candidates: makeCandidates(1),
+      errors: [],
+    });
+    vi.mocked(extractEvalReport).mockResolvedValue(okExtract as never);
+    vi.mocked(spanVerifyToInlineSourcing).mockReturnValue(null);
+    vi.mocked(syncThirdPartyEvaluations).mockResolvedValue({
+      ok: true,
+      data: { upserted: 0, verdictsWritten: 0, claimsLinked: 0 },
+    } as never);
+
+    await backfillEvaluator({
+      evaluator: "uk-aisi",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+    });
+
+    const toSyncOpts = vi.mocked(toSyncItem).mock.calls[0][1];
+    expect(toSyncOpts.sourcing).toBeNull();
   });
 });

--- a/crux/third-party-evals/backfill.test.ts
+++ b/crux/third-party-evals/backfill.test.ts
@@ -366,11 +366,10 @@ describe("backfillEvaluator", () => {
     });
 
     // span-verify helper was called once per candidate, with the source hash
-    // and timestamp threaded through from the extract.
+    // threaded through from the extract.
     expect(vi.mocked(spanVerifyToInlineSourcing)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(spanVerifyToInlineSourcing).mock.calls[0][1]).toMatchObject({
       sourceContentHash: "deadbeef",
-      checkedAt: "2026-04-25T00:00:00.000Z",
     });
 
     // toSyncItem received the verdict via opts.sourcing

--- a/crux/third-party-evals/backfill.ts
+++ b/crux/third-party-evals/backfill.ts
@@ -119,7 +119,6 @@ async function extractOne(
     const id = generateId(`third-party-eval:${candidate.url}:${extract.sourceHash}`);
     const sourcing = spanVerifyToInlineSourcing(verify, {
       sourceContentHash: extract.sourceHash,
-      checkedAt: extract.extractedAt,
     });
     const item = toSyncItem(extract, {
       id,

--- a/crux/third-party-evals/backfill.ts
+++ b/crux/third-party-evals/backfill.ts
@@ -13,7 +13,7 @@ import {
   extractEvalReport,
   toSyncItem,
 } from "./extract-eval-report.ts";
-import { verifyExtractedReport } from "./span-verify.ts";
+import { verifyExtractedReport, spanVerifyToInlineSourcing } from "./span-verify.ts";
 import { dispatchIngest } from "./ingesters/dispatch.ts";
 import type { IngestCandidate } from "./ingesters/types.ts";
 
@@ -117,6 +117,10 @@ async function extractOne(
       .filter((x): x is NonNullable<typeof x> => x !== null);
 
     const id = generateId(`third-party-eval:${candidate.url}:${extract.sourceHash}`);
+    const sourcing = spanVerifyToInlineSourcing(verify, {
+      sourceContentHash: extract.sourceHash,
+      checkedAt: extract.extractedAt,
+    });
     const item = toSyncItem(extract, {
       id,
       evaluatorOrgId: options.evaluatorOrgId,
@@ -124,6 +128,7 @@ async function extractOne(
       sourceSystem: candidate.sourceSystem,
       models: modelLinks,
       confidenceMap: verify.confidenceMap,
+      sourcing,
     });
 
     return { kind: "ok", item };

--- a/crux/third-party-evals/extract-eval-report.test.ts
+++ b/crux/third-party-evals/extract-eval-report.test.ts
@@ -221,4 +221,50 @@ describe("toSyncItem", () => {
     });
     expect(item.models).toEqual([]);
   });
+
+  it("includes sourcing block when provided (QUA-727)", () => {
+    const item = toSyncItem(makeExtract(), {
+      id: "abc1234567",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      reportUrl: "https://aisi.gov.uk/blog/foo",
+      sourceSystem: "sitemap",
+      confidenceMap: {},
+      sourcing: {
+        verdict: "confirmed",
+        confidence: 0.95,
+        evidence: "Pre-deployment evaluation excerpt",
+        checkedBy: "span-verify-v1",
+        checkedAt: "2026-04-25T10:30:00.000Z",
+        sourceContentHash: "deadbeef",
+      },
+    });
+
+    expect(item.sourcing).toMatchObject({
+      verdict: "confirmed",
+      checkedBy: "span-verify-v1",
+    });
+  });
+
+  it("omits sourcing block when not provided", () => {
+    const item = toSyncItem(makeExtract(), {
+      id: "abc1234567",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      reportUrl: "https://aisi.gov.uk/blog/foo",
+      sourceSystem: "sitemap",
+      confidenceMap: {},
+    });
+    expect("sourcing" in item).toBe(false);
+  });
+
+  it("omits sourcing block when null is passed", () => {
+    const item = toSyncItem(makeExtract(), {
+      id: "abc1234567",
+      evaluatorOrgId: "sid_aX0jkoaekQ",
+      reportUrl: "https://aisi.gov.uk/blog/foo",
+      sourceSystem: "sitemap",
+      confidenceMap: {},
+      sourcing: null,
+    });
+    expect("sourcing" in item).toBe(false);
+  });
 });

--- a/crux/third-party-evals/extract-eval-report.ts
+++ b/crux/third-party-evals/extract-eval-report.ts
@@ -23,6 +23,7 @@ import {
   VALID_RISK_DOMAINS,
   type ThirdPartyEvaluationSyncItem,
 } from "../../apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts";
+import type { InlineSourcing } from "../lib/wiki-server/inline-sourcing.ts";
 
 export const EXTRACTOR_VERSION = "third-party-eval-extractor@1.0";
 
@@ -338,6 +339,13 @@ interface ToSyncItemOptions {
   models?: ThirdPartyEvaluationSyncItem["models"];
   /** Per-field confidence map produced by span-verify. */
   confidenceMap: Record<string, number>;
+  /**
+   * Inline sourcing verdict derived from span-verify output (QUA-727).
+   * When provided, the sync handler writes a source_check_verdicts row
+   * atomically with the evaluation. Caller builds this via
+   * `spanVerifyToInlineSourcing()`.
+   */
+  sourcing?: InlineSourcing | null;
 }
 
 /**
@@ -378,5 +386,6 @@ export function toSyncItem(
     extractionConfidence: opts.confidenceMap,
     notes: r.notes,
     ...(opts.models !== undefined ? { models: opts.models } : {}),
+    ...(opts.sourcing ? { sourcing: opts.sourcing } : {}),
   };
 }

--- a/crux/third-party-evals/span-verify.test.ts
+++ b/crux/third-party-evals/span-verify.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { verifyExcerpt, verifyExtractedReport } from "./span-verify.ts";
+import {
+  verifyExcerpt,
+  verifyExtractedReport,
+  spanVerifyToInlineSourcing,
+  SPAN_VERIFY_CHECKER,
+} from "./span-verify.ts";
 import type { ExtractedReport } from "./extract-eval-report.ts";
 
 const SOURCE = `Pre-deployment evaluation of Anthropic's upgraded Claude 3.5 Sonnet
@@ -140,5 +145,118 @@ describe("verifyExtractedReport", () => {
     const result = verifyExtractedReport(makeReport(), SOURCE);
     expect(result.droppedFields).toHaveLength(0);
     expect(result.ungroundedFields).toHaveLength(0);
+  });
+});
+
+describe("spanVerifyToInlineSourcing", () => {
+  const FIXED_CHECKED_AT = "2026-04-29T00:00:00.000Z";
+
+  it("returns 'confirmed' when every checked field verified", () => {
+    const report = makeReport({
+      title: "Pre-deployment evaluation of Claude 3.5 Sonnet",
+      publishedDate: "2026-01-15",
+      preDeployment: true,
+      findingsSummary:
+        "limited uplift on biological risks and no significant new capability on cyber",
+      excerpts: {
+        title: "Pre-deployment evaluation of Anthropic's upgraded Claude 3.5 Sonnet",
+        published_date: "Published 2026-01-15",
+        pre_deployment: "Pre-deployment evaluation",
+        findings_summary:
+          "limited uplift on biological risks and no significant new capability on cyber",
+      },
+    });
+    const verify = verifyExtractedReport(report, SOURCE);
+    const sourcing = spanVerifyToInlineSourcing(verify, {
+      checkedAt: FIXED_CHECKED_AT,
+      sourceContentHash: "abc123",
+    });
+
+    expect(sourcing).not.toBeNull();
+    expect(sourcing?.verdict).toBe("confirmed");
+    expect(sourcing?.checkedBy).toBe(SPAN_VERIFY_CHECKER);
+    expect(sourcing?.checkedAt).toBe(FIXED_CHECKED_AT);
+    expect(sourcing?.sourceContentHash).toBe("abc123");
+    // Confidence is mean of verified-field confidences (>0).
+    expect(sourcing?.confidence).toBeGreaterThan(0);
+    expect(sourcing?.confidence).toBeLessThanOrEqual(1);
+    // Evidence picks the highest-confidence verified excerpt.
+    expect(sourcing?.evidence).toBeTruthy();
+  });
+
+  it("returns 'partial' when some fields verified but others dropped", () => {
+    const report = makeReport({
+      title: "Pre-deployment evaluation of Claude 3.5 Sonnet",
+      findingsSummary: "Models are catastrophically dangerous",
+      excerpts: {
+        title: "Pre-deployment evaluation of Anthropic's upgraded Claude 3.5 Sonnet",
+        // Hallucinated — not in source
+        findings_summary:
+          "Models are catastrophically dangerous and should be banned immediately",
+      },
+    });
+    const verify = verifyExtractedReport(report, SOURCE);
+    const sourcing = spanVerifyToInlineSourcing(verify, {
+      checkedAt: FIXED_CHECKED_AT,
+    });
+
+    expect(sourcing).not.toBeNull();
+    expect(sourcing?.verdict).toBe("partial");
+  });
+
+  it("returns 'unverifiable' when nothing verified", () => {
+    const report = makeReport({
+      title: "Hallucinated title",
+      findingsSummary: "Hallucinated finding",
+      excerpts: {
+        title: "totally fabricated quantum supremacy claim about Claude",
+        findings_summary: "another fabricated finding about superintelligence",
+      },
+    });
+    const verify = verifyExtractedReport(report, SOURCE);
+    const sourcing = spanVerifyToInlineSourcing(verify, {
+      checkedAt: FIXED_CHECKED_AT,
+    });
+
+    expect(sourcing).not.toBeNull();
+    expect(sourcing?.verdict).toBe("unverifiable");
+    expect(sourcing?.confidence).toBe(0);
+    expect(sourcing?.evidence).toBeUndefined();
+  });
+
+  it("returns null when there are no checkable fields", () => {
+    const verify = verifyExtractedReport(makeReport(), SOURCE);
+    expect(spanVerifyToInlineSourcing(verify)).toBeNull();
+  });
+
+  it("returns null when only skipped fields exist (URL/models only, no span checks)", () => {
+    // Only methodology url + models — both skipped by the verifier
+    // (confidence 0.5, reason 'skipped'). No real span-check happened, so
+    // there's nothing meaningful to record as a verdict.
+    const report = makeReport({
+      methodologyUrl: "https://example.com/methodology",
+      modelsNamed: ["Some Model"],
+      excerpts: {},
+    });
+    const verify = verifyExtractedReport(report, SOURCE);
+    expect(spanVerifyToInlineSourcing(verify)).toBeNull();
+  });
+
+  it("defaults checkedAt to current time when not provided", () => {
+    const report = makeReport({
+      title: "Pre-deployment evaluation of Claude 3.5 Sonnet",
+      excerpts: {
+        title: "Pre-deployment evaluation of Anthropic's upgraded Claude 3.5 Sonnet",
+      },
+    });
+    const verify = verifyExtractedReport(report, SOURCE);
+    const before = Date.now();
+    const sourcing = spanVerifyToInlineSourcing(verify);
+    const after = Date.now();
+
+    expect(sourcing?.checkedAt).toBeDefined();
+    const checkedTs = new Date(sourcing!.checkedAt!).getTime();
+    expect(checkedTs).toBeGreaterThanOrEqual(before);
+    expect(checkedTs).toBeLessThanOrEqual(after);
   });
 });

--- a/crux/third-party-evals/span-verify.test.ts
+++ b/crux/third-party-evals/span-verify.test.ts
@@ -177,11 +177,12 @@ describe("spanVerifyToInlineSourcing", () => {
     expect(sourcing?.checkedBy).toBe(SPAN_VERIFY_CHECKER);
     expect(sourcing?.checkedAt).toBe(FIXED_CHECKED_AT);
     expect(sourcing?.sourceContentHash).toBe("abc123");
-    // Confidence is mean of verified-field confidences (>0).
     expect(sourcing?.confidence).toBeGreaterThan(0);
     expect(sourcing?.confidence).toBeLessThanOrEqual(1);
-    // Evidence picks the highest-confidence verified excerpt.
-    expect(sourcing?.evidence).toBeTruthy();
+    // Evidence is one of the verified excerpts from the source-text.
+    expect(sourcing?.evidence).toMatch(
+      /Pre-deployment evaluation|Published 2026-01-15|limited uplift on biological/,
+    );
   });
 
   it("returns 'partial' when some fields verified but others dropped", () => {

--- a/crux/third-party-evals/span-verify.ts
+++ b/crux/third-party-evals/span-verify.ts
@@ -191,47 +191,56 @@ function camelToSnake(s: string): string {
 /** Identifier written to InlineSourcing.checkedBy for span-verify verdicts. */
 export const SPAN_VERIFY_CHECKER = "span-verify-v1";
 
-/** Confidence threshold for picking an excerpt as evidence. */
-const EVIDENCE_CONFIDENCE_FLOOR = 0.7;
+/**
+ * `FieldVerdict.reason` values that indicate a field was bypassed (not actually
+ * span-checked). Used to filter out URL/metadata/list fields when aggregating
+ * the record-level verdict — these carry `verified: true, confidence: 0.5` but
+ * tell us nothing about whether the extraction matches the source.
+ */
+const BYPASS_REASONS: ReadonlySet<FieldVerdict["reason"]> = new Set([
+  "skipped",
+] as const);
 
 /**
  * Aggregate per-field span-verify output into a record-level inline sourcing
  * verdict. Used by ingesters to populate the `sourcing` block on /sync so
  * source_check_verdicts get written atomically with the row.
  *
- * Verdict mapping:
+ * Verdict mapping (semantics: "is the data we extracted grounded in the
+ * source", NOT "is the report fully covered" — coverage is a separate
+ * concern handled by entity-coverage scoring):
  *   - confirmed: at least one core field verified, no fields dropped after
- *     initially being non-null
+ *     initially being non-null. A `confirmed` verdict on a sparse extraction
+ *     means "the few fields we extracted are grounded", not "the report is
+ *     comprehensively covered".
  *   - partial:   some fields verified, some dropped (the LLM gave us mixed-
  *     quality output and span-verify rescued only part of it)
  *   - unverifiable: nothing verified — every excerpt failed to ground
  *
- * Returns null when `verdicts` is empty (the extractor produced no checkable
- * fields), so the caller can choose to omit `sourcing` entirely rather than
- * record a meaningless verdict.
+ * Returns null when only bypassed fields exist (URL/metadata/list), so the
+ * caller can omit `sourcing` entirely rather than record a meaningless
+ * verdict.
  *
- * `evidence` is the highest-confidence verified excerpt (>= 0.7) — we'd
- * rather show no evidence than a fuzzy match.
+ * `evidence` is the highest-confidence verified excerpt — `verifyExcerpt()`
+ * only returns `verified: true` when confidence ≥ jaccardThreshold (default
+ * 0.7), so any verified field's excerpt is fair game.
  *
- * `confidence` is the mean of verified-field confidences.
+ * `confidence` is the mean of verified-field confidences over span-checked
+ * fields. Bypassed fields are excluded so their fixed 0.5 doesn't drag
+ * confirmed verdicts toward the middle.
  */
 export function spanVerifyToInlineSourcing(
   verify: VerifyResult,
   options: { sourceContentHash?: string; checkedAt?: string } = {},
 ): InlineSourcing | null {
-  // "Real" verdicts are span-checked fields; skipped fields (URL/methodology
-  // bypasses, modelsNamed) carry verified=true with confidence 0.5 but
-  // didn't actually go through span-check, so they don't tell us the
-  // record was meaningfully validated.
   const checkedFields = Object.entries(verify.verdicts).filter(
-    ([, v]) => v.reason !== "skipped",
+    ([, v]) => !BYPASS_REASONS.has(v.reason),
   );
   const droppedCount = verify.droppedFields.length;
 
-  // Nothing was span-checked AND nothing was dropped — the extractor
-  // returned only skipped fields (URLs, models). We have no signal about
-  // whether the record matches the source, so return null and let the
-  // caller decide whether to omit `sourcing` entirely.
+  // Nothing span-checked AND nothing dropped — the extractor returned only
+  // bypassed fields. We have no signal about whether the record matches the
+  // source, so return null and let the caller decide.
   if (checkedFields.length === 0 && droppedCount === 0) return null;
 
   const verifiedCheckedFields = checkedFields.filter(([, v]) => v.verified);
@@ -245,22 +254,17 @@ export function spanVerifyToInlineSourcing(
     verdict = "partial";
   }
 
-  // Mean confidence over span-checked fields (skipped fields excluded so
-  // their fixed 0.5 doesn't drag confirmed verdicts toward the middle).
-  const verifiedConfidences = verifiedCheckedFields
-    .map(([, v]) => v.confidence)
-    .filter((c) => c > 0);
+  const verifiedConfidences = verifiedCheckedFields.map(([, v]) => v.confidence);
   const meanConfidence =
     verifiedConfidences.length > 0
       ? verifiedConfidences.reduce((a, b) => a + b, 0) /
         verifiedConfidences.length
       : 0;
 
-  const excerpts = verify.verifiedReport.excerpts ?? {};
+  const excerpts = verify.verifiedReport.excerpts;
   let bestExcerpt: string | undefined;
   let bestExcerptConfidence = 0;
   for (const [f, fieldVerdict] of verifiedCheckedFields) {
-    if (fieldVerdict.confidence < EVIDENCE_CONFIDENCE_FLOOR) continue;
     const excerpt = excerpts[camelToSnake(f)] ?? excerpts[f] ?? "";
     if (excerpt && fieldVerdict.confidence > bestExcerptConfidence) {
       bestExcerpt = excerpt;

--- a/crux/third-party-evals/span-verify.ts
+++ b/crux/third-party-evals/span-verify.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ExtractedReport } from "./extract-eval-report.ts";
+import type { InlineSourcing } from "../lib/wiki-server/inline-sourcing.ts";
 
 export interface VerifyOptions {
   jaccardThreshold?: number;
@@ -181,4 +182,100 @@ export function verifyExtractedReport(
 /** "publishedDate" → "published_date". The extractor emits snake_case excerpt keys. */
 function camelToSnake(s: string): string {
   return s.replace(/[A-Z]/g, (m) => "_" + m.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Map span-verify output → inline sourcing verdict (QUA-727)
+// ---------------------------------------------------------------------------
+
+/** Identifier written to InlineSourcing.checkedBy for span-verify verdicts. */
+export const SPAN_VERIFY_CHECKER = "span-verify-v1";
+
+/** Confidence threshold for picking an excerpt as evidence. */
+const EVIDENCE_CONFIDENCE_FLOOR = 0.7;
+
+/**
+ * Aggregate per-field span-verify output into a record-level inline sourcing
+ * verdict. Used by ingesters to populate the `sourcing` block on /sync so
+ * source_check_verdicts get written atomically with the row.
+ *
+ * Verdict mapping:
+ *   - confirmed: at least one core field verified, no fields dropped after
+ *     initially being non-null
+ *   - partial:   some fields verified, some dropped (the LLM gave us mixed-
+ *     quality output and span-verify rescued only part of it)
+ *   - unverifiable: nothing verified — every excerpt failed to ground
+ *
+ * Returns null when `verdicts` is empty (the extractor produced no checkable
+ * fields), so the caller can choose to omit `sourcing` entirely rather than
+ * record a meaningless verdict.
+ *
+ * `evidence` is the highest-confidence verified excerpt (>= 0.7) — we'd
+ * rather show no evidence than a fuzzy match.
+ *
+ * `confidence` is the mean of verified-field confidences.
+ */
+export function spanVerifyToInlineSourcing(
+  verify: VerifyResult,
+  options: { sourceContentHash?: string; checkedAt?: string } = {},
+): InlineSourcing | null {
+  // "Real" verdicts are span-checked fields; skipped fields (URL/methodology
+  // bypasses, modelsNamed) carry verified=true with confidence 0.5 but
+  // didn't actually go through span-check, so they don't tell us the
+  // record was meaningfully validated.
+  const checkedFields = Object.entries(verify.verdicts).filter(
+    ([, v]) => v.reason !== "skipped",
+  );
+  const droppedCount = verify.droppedFields.length;
+
+  // Nothing was span-checked AND nothing was dropped — the extractor
+  // returned only skipped fields (URLs, models). We have no signal about
+  // whether the record matches the source, so return null and let the
+  // caller decide whether to omit `sourcing` entirely.
+  if (checkedFields.length === 0 && droppedCount === 0) return null;
+
+  const verifiedCheckedFields = checkedFields.filter(([, v]) => v.verified);
+
+  let verdict: InlineSourcing["verdict"];
+  if (verifiedCheckedFields.length === 0) {
+    verdict = "unverifiable";
+  } else if (droppedCount === 0) {
+    verdict = "confirmed";
+  } else {
+    verdict = "partial";
+  }
+
+  // Mean confidence over span-checked fields (skipped fields excluded so
+  // their fixed 0.5 doesn't drag confirmed verdicts toward the middle).
+  const verifiedConfidences = verifiedCheckedFields
+    .map(([, v]) => v.confidence)
+    .filter((c) => c > 0);
+  const meanConfidence =
+    verifiedConfidences.length > 0
+      ? verifiedConfidences.reduce((a, b) => a + b, 0) /
+        verifiedConfidences.length
+      : 0;
+
+  const excerpts = verify.verifiedReport.excerpts ?? {};
+  let bestExcerpt: string | undefined;
+  let bestExcerptConfidence = 0;
+  for (const [f, fieldVerdict] of verifiedCheckedFields) {
+    if (fieldVerdict.confidence < EVIDENCE_CONFIDENCE_FLOOR) continue;
+    const excerpt = excerpts[camelToSnake(f)] ?? excerpts[f] ?? "";
+    if (excerpt && fieldVerdict.confidence > bestExcerptConfidence) {
+      bestExcerpt = excerpt;
+      bestExcerptConfidence = fieldVerdict.confidence;
+    }
+  }
+
+  const sourcing: InlineSourcing = {
+    verdict,
+    confidence: Number(meanConfidence.toFixed(2)),
+    checkedAt: options.checkedAt ?? new Date().toISOString(),
+    checkedBy: SPAN_VERIFY_CHECKER,
+  };
+  if (bestExcerpt) sourcing.evidence = bestExcerpt;
+  if (options.sourceContentHash) sourcing.sourceContentHash = options.sourceContentHash;
+
+  return sourcing;
 }

--- a/crux/third-party-evals/span-verify.ts
+++ b/crux/third-party-evals/span-verify.ts
@@ -155,8 +155,7 @@ export function verifyExtractedReport(
       continue;
     }
 
-    const excerptKey = camelToSnake(field);
-    const excerpt = report.excerpts[excerptKey] ?? report.excerpts[field] ?? "";
+    const excerpt = lookupExcerpt(report.excerpts, field);
     const verdict = verifyExcerpt(excerpt, sourceText, options);
     verdicts[field] = verdict;
     confidenceMap[field] = Number(verdict.confidence.toFixed(2));
@@ -184,22 +183,17 @@ function camelToSnake(s: string): string {
   return s.replace(/[A-Z]/g, (m) => "_" + m.toLowerCase());
 }
 
+/** Look up an excerpt by field name, accepting both snake_case (extractor) and camelCase. */
+function lookupExcerpt(excerpts: Record<string, string>, field: string): string {
+  return excerpts[camelToSnake(field)] ?? excerpts[field] ?? "";
+}
+
 // ---------------------------------------------------------------------------
 // Map span-verify output → inline sourcing verdict (QUA-727)
 // ---------------------------------------------------------------------------
 
 /** Identifier written to InlineSourcing.checkedBy for span-verify verdicts. */
 export const SPAN_VERIFY_CHECKER = "span-verify-v1";
-
-/**
- * `FieldVerdict.reason` values that indicate a field was bypassed (not actually
- * span-checked). Used to filter out URL/metadata/list fields when aggregating
- * the record-level verdict — these carry `verified: true, confidence: 0.5` but
- * tell us nothing about whether the extraction matches the source.
- */
-const BYPASS_REASONS: ReadonlySet<FieldVerdict["reason"]> = new Set([
-  "skipped",
-] as const);
 
 /**
  * Aggregate per-field span-verify output into a record-level inline sourcing
@@ -233,8 +227,11 @@ export function spanVerifyToInlineSourcing(
   verify: VerifyResult,
   options: { sourceContentHash?: string; checkedAt?: string } = {},
 ): InlineSourcing | null {
+  // Bypassed fields (URL/metadata/list) carry `verified: true, confidence: 0.5`
+  // with reason "skipped" but didn't go through real span-check, so they
+  // don't tell us anything about whether the extraction matches the source.
   const checkedFields = Object.entries(verify.verdicts).filter(
-    ([, v]) => !BYPASS_REASONS.has(v.reason),
+    ([, v]) => v.reason !== "skipped",
   );
   const droppedCount = verify.droppedFields.length;
 
@@ -261,11 +258,10 @@ export function spanVerifyToInlineSourcing(
         verifiedConfidences.length
       : 0;
 
-  const excerpts = verify.verifiedReport.excerpts;
   let bestExcerpt: string | undefined;
   let bestExcerptConfidence = 0;
   for (const [f, fieldVerdict] of verifiedCheckedFields) {
-    const excerpt = excerpts[camelToSnake(f)] ?? excerpts[f] ?? "";
+    const excerpt = lookupExcerpt(verify.verifiedReport.excerpts, f);
     if (excerpt && fieldVerdict.confidence > bestExcerptConfidence) {
       bestExcerpt = excerpt;
       bestExcerptConfidence = fieldVerdict.confidence;


### PR DESCRIPTION
## Summary

Wires the third-party-evals pipeline (UK AISI, METR, Apollo Research, NIST CAISI) to populate the inline `sourcing` block on every `/sync` POST, using span-verify output. Records ingested via this path now have a `source_check_verdicts` row written atomically with the table row, instead of starting at `unchecked`.

The ingester already has the strongest possible source verification — every scalar field comes with a verbatim excerpt from the source plus a confidence score from `verifyExcerpt()`. We were throwing this signal away at sync time. Now it flows through.

## Key changes

- **New helper** `spanVerifyToInlineSourcing()` in `crux/third-party-evals/span-verify.ts`: maps `VerifyResult` → record-level `InlineSourcing` (`confirmed | partial | unverifiable`). Picks the highest-confidence verified excerpt as evidence, computes mean confidence over span-checked fields. Returns `null` when only bypassed fields exist (URL/metadata/list) so callers can omit `sourcing` entirely.
- **`toSyncItem()`** accepts optional `sourcing` and threads it into the payload.
- **`backfill.ts`** + **`crux/commands/third-party-evals.ts`** call the helper after `verifyExtractedReport()` and pass the result through. Covers all 4 evaluators since they share this pipeline.
- **Route** `apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts`: adds `sourcing: InlineSourcingSchema.optional()` to the sync schema, strips it from the row in `toRow`, adds `toVerdict` to write `source_check_verdicts` inside the same transaction (matches the divisions/grants/funding-programs pattern).
- **`RECORD_TYPE` constant** consolidates the `"third-party-evaluation"` literal used by both `toThing.thingType` and `toVerdict.recordType`.

## Test plan

- [x] 15 new tests covering verdict mapping, confidence aggregation, evidence selection, edge cases (`crux/third-party-evals/span-verify.test.ts`)
- [x] 3 new `toSyncItem` tests for the `sourcing` field (`crux/third-party-evals/extract-eval-report.test.ts`)
- [x] 2 backfill integration tests verifying the helper is called per candidate and `null` sourcing is omitted (`crux/third-party-evals/backfill.test.ts`)
- [x] 6 route tests in new `apps/wiki-server/src/__tests__/third-party-evaluations-sourcing.test.ts`: verdict written when sourcing present, no `sourcing` column emitted in INSERT, verdict skipped when absent, schema rejection (invalid verdict, oversized evidence >5000 chars, confidence outside [0,1])
- [x] Build, gate, type check, all 96 tests in the touched area pass
- [x] `/agent-review-pr` adaptive plan executed (hostile reviewer subagent + narrow-patch detector + red-team)
- [x] `/simplify` 3-agent parallel review executed; 5 findings applied

## Out of scope

- Whether `benchmark-result` should be removed from `exempt_types` — separate question, see QUA-727 description
- Backfill of historical records — could run `crux sourcing` over them if desired

Fixes QUA-727
