### PR TITLE
feat(build): fail-closed on YAML errors and wiki-server unreachable in CI

### DIFF
--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -91,6 +91,27 @@ Every fail-open exception in the gate must have a comment explaining why. Curren
 - **mdx-compile**: Advisory smoke-test; full Next.js build is authoritative
 - **gate-triage LLM call**: Optimization only; timeout/error means run everything
 
+### Fail-Closed in `build-data.mjs` (QUA-772)
+
+The build pipeline (`apps/web/scripts/build-data.mjs`) abandons output and exits 1 BEFORE writing `database.json` when any of the following hold. The previous `database.json` is preserved on disk, so a failed build never overwrites a known-good one with a partial copy.
+
+| Condition | Detection | When fatal |
+|-----------|-----------|------------|
+| YAML parse error in `data/*.yaml` or `data/entities/*.yaml` | `loadYaml` / `loadYamlDir` increment `yamlParseErrorCount` | always |
+| YAML parse error in MDX frontmatter | `extractFrontmatter` increments `getPagesBuilderYamlErrors()` | always |
+| YAML parse error in `packages/factbase/data/**/*.yaml` | `parseYamlWithPath` re-throws with the file path prepended (`[kb/loader] YAML parse error in <path>: <yaml-msg>`) | always |
+| Duplicate entity IDs across YAML | counted at line ~580; exits 1 | always |
+| `wikiId` collision between an entity and a page | `pageIdConflicts` array; exits 1 | always |
+| Wiki-server fetch failure (any of the `logWikiServerWarning` callsites) | `getWikiServerWarningCount() > 0` | only when `isStrictWikiServerMode()` returns true — i.e. `CI=true` AND `--scope=content` is NOT in use |
+
+**Why CI-only for wiki-server failures.** CI runs against authenticated prod, so a missed fetch indicates a real regression worth halting the build over. Local dev / agent slots may legitimately lack server access (offline iteration, slot doesn't have prod creds, transient prod outage), and treating that as fatal would block the agent's iteration loop for reasons unrelated to the change being tested. Hence the split: warn locally, abort in CI.
+
+**Why content-only opts out.** `--scope=content` (alias `--quick`) explicitly tells build-data to skip server-dependent steps. Treating wiki-server unavailability as fatal there would defeat the flag's purpose.
+
+**Bypass for emergency builds.** If a CI run must complete despite wiki-server warnings (e.g. to ship a hotfix unrelated to the failing data source), unset `CI` for the build step. Don't add a `STRICT_WIKI_SERVER=0` escape hatch — past experience (the QUA-448 removal of `STRICT_VERDICTS=0`) is that "panic button" env vars become load-bearing over time and silently defeat the fail-closed intent.
+
+The aggregate post-build summary in `--- Build Health ---` is informational only — by the time it runs, the pre-write fail-closed checks have already aborted any build that would ship corrupt data.
+
 ### Fail-Open (only for non-critical paths)
 
 Fail-open is appropriate when:

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -74,6 +74,7 @@ import {
   getWikiServerWarningCount,
   getSkippedDataSources,
   setFullBuildMode,
+  isStrictWikiServerMode,
 } from './lib/wiki-server-data.mjs';
 import {
   buildPagesRegistry,
@@ -1220,10 +1221,39 @@ async function main() {
   // =========================================================================
   // PRE-WRITE SAFETY CHECK — abort before writing if data is corrupt
   // =========================================================================
+  // Two classes of fail-closed errors block the build before output is written:
+  //   1. YAML parse errors (always fatal — the YAML files are authoritative,
+  //      and a parse error means we'd silently drop data the wiki depends on).
+  //   2. Wiki-server unreachable IN CI (full build only). CI runs against
+  //      authenticated prod, so a missed fetch indicates a real regression —
+  //      shipping a partial database.json would surface as broken UI in prod.
+  //      Local dev / agent slots fall through to a warning so offline iteration
+  //      keeps working. See `isStrictWikiServerMode()` for the policy.
   const totalYamlErrors = yamlParseErrorCount + getPagesBuilderYamlErrors();
   if (totalYamlErrors > 0) {
     console.error(`\n❌ Build aborted: ${totalYamlErrors} YAML parse error(s) found. Fix them before building.`);
     console.error('database.json was NOT written — the previous version is preserved.');
+    process.exit(1);
+  }
+  const totalWikiServerWarningsPreWrite = getWikiServerWarningCount();
+  if (
+    totalWikiServerWarningsPreWrite > 0 &&
+    isStrictWikiServerMode({ contentOnly: CONTENT_ONLY })
+  ) {
+    const skipped = getSkippedDataSources();
+    console.error(
+      `\n❌ Build aborted: ${totalWikiServerWarningsPreWrite} wiki-server API call(s) failed in CI.`,
+    );
+    console.error('   CI builds require complete wiki-server data; the missing sources were:');
+    for (const source of skipped) {
+      console.error(`     - ${source}`);
+    }
+    console.error(
+      '   Investigate wiki-server availability and retry. To bypass for an emergency build,',
+    );
+    console.error(
+      '   re-run with `CI=` (unset). database.json was NOT written — the previous version is preserved.',
+    );
     process.exit(1);
   }
 
@@ -1306,8 +1336,10 @@ async function main() {
   // ==========================================================================
   // BUILD HEALTH REPORT
   // ==========================================================================
-  // Note: YAML errors are already checked before writing output files above.
-  // If we reach this point, totalYamlErrors is guaranteed to be 0.
+  // Note: YAML errors AND (in CI) wiki-server warnings were already checked
+  // pre-write above. If we reach this point, the build either had no failures,
+  // or wiki-server warnings were encountered outside CI (degraded but not
+  // fatal). The summary below is informational.
   const totalWikiServerWarnings = getWikiServerWarningCount();
 
   console.log('\n--- Build Health ---');
@@ -1323,7 +1355,7 @@ async function main() {
     for (const source of skipped) {
       console.warn(`     - ${source}`);
     }
-    console.warn('   If this is CI, the build output is incomplete — investigate wiki-server availability.');
+    console.warn('   This is non-fatal outside CI; in CI the pre-write check would have aborted the build.');
   } else if (totalWikiServerWarnings > 0) {
     console.warn(`\nNote: ${totalWikiServerWarnings} wiki-server API call(s) failed (expected in content-only mode).`);
   }

--- a/apps/web/scripts/lib/__tests__/build-fail-closed.test.mjs
+++ b/apps/web/scripts/lib/__tests__/build-fail-closed.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Tests for build-data fail-closed behavior (QUA-772).
+ *
+ * Two complementary classes of fail-closed errors block the build before
+ * `database.json` is written:
+ *
+ *   1. YAML parse errors in source data (`data/`, `packages/factbase/data/`)
+ *   2. Wiki-server unreachable IN CI mode (full build only)
+ *
+ * Local dev and content-only builds keep degraded fallback behavior so
+ * offline iteration / agent slots without prod creds aren't blocked.
+ *
+ * These tests verify the policy helpers used by build-data.mjs in isolation,
+ * since exercising the full build script end-to-end is too expensive for unit
+ * tests. The integration is covered by the `pnpm build` step that runs
+ * automatically in CI.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  isStrictWikiServerMode,
+  setFullBuildMode,
+  getWikiServerWarningCount,
+  getSkippedDataSources,
+  _resetWikiServerWarningsForTests,
+} from '../wiki-server-data.mjs';
+
+describe('isStrictWikiServerMode — QUA-772 fail-closed CI policy', () => {
+  it('is strict when CI=true and content-only is false (typical CI build)', () => {
+    expect(isStrictWikiServerMode({ contentOnly: false, env: { CI: 'true' } })).toBe(true);
+  });
+
+  it('is NOT strict when CI=true but content-only is true', () => {
+    // content-only mode explicitly opts out of server-dependent steps.
+    // Treating wiki-server unavailability as fatal there would defeat the flag.
+    expect(isStrictWikiServerMode({ contentOnly: true, env: { CI: 'true' } })).toBe(false);
+  });
+
+  it('is NOT strict in local dev (CI unset)', () => {
+    // Agents working in slots may not have prod credentials; we don't want
+    // a wiki-server outage to block their iteration loop.
+    expect(isStrictWikiServerMode({ contentOnly: false, env: {} })).toBe(false);
+  });
+
+  it('is NOT strict when CI is set to anything other than the literal string "true"', () => {
+    // Some CI providers set CI to "1" or "yes". We deliberately match the
+    // GitHub Actions / Vercel convention (CI=true) to avoid false positives.
+    expect(isStrictWikiServerMode({ contentOnly: false, env: { CI: '1' } })).toBe(false);
+    expect(isStrictWikiServerMode({ contentOnly: false, env: { CI: 'yes' } })).toBe(false);
+    expect(isStrictWikiServerMode({ contentOnly: false, env: { CI: 'TRUE' } })).toBe(false);
+  });
+
+  it('reads from process.env by default', () => {
+    const original = process.env.CI;
+    try {
+      process.env.CI = 'true';
+      expect(isStrictWikiServerMode({ contentOnly: false })).toBe(true);
+      delete process.env.CI;
+      expect(isStrictWikiServerMode({ contentOnly: false })).toBe(false);
+    } finally {
+      if (original !== undefined) process.env.CI = original;
+      else delete process.env.CI;
+    }
+  });
+});
+
+describe('wiki-server warning counter — used by the pre-write CI gate', () => {
+  beforeEach(() => {
+    _resetWikiServerWarningsForTests();
+    setFullBuildMode(false);
+  });
+
+  afterEach(() => {
+    _resetWikiServerWarningsForTests();
+    setFullBuildMode(false);
+  });
+
+  it('starts at zero with no skipped data sources', () => {
+    expect(getWikiServerWarningCount()).toBe(0);
+    expect(getSkippedDataSources()).toEqual([]);
+  });
+
+  it('returns a snapshot (not a live reference) of skipped sources', () => {
+    // Defensive: ensure callers can't mutate internal state by holding the
+    // returned array. A live reference would let a buggy consumer corrupt
+    // the build-health summary.
+    const snapshot = getSkippedDataSources();
+    snapshot.push('not-a-real-source');
+    expect(getSkippedDataSources()).toEqual([]);
+  });
+});

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -61,6 +61,42 @@ export function getSkippedDataSources() {
 }
 
 /**
+ * Reset wiki-server warning state — for tests only.
+ * Production code should never call this; the counters are intended to be
+ * monotonic across a single build process.
+ * @internal
+ */
+export function _resetWikiServerWarningsForTests() {
+  wikiServerWarningCount = 0;
+  skippedDataSources.length = 0;
+}
+
+/**
+ * Should the build FAIL HARD on wiki-server warnings?
+ *
+ * Strict in CI only (`CI=true`) AND only in full builds (not content-only).
+ * Mirrors `isStrictVerdictsMode()` but applies to the aggregate post-build
+ * decision rather than a single fetcher.
+ *
+ * Why CI-only: CI runs against authenticated prod, so any wiki-server failure
+ * means a real regression worth halting the build over. Local dev / agent
+ * slots may not have server access for legitimate reasons (offline, prod
+ * outage, slot doesn't have prod creds), and we'd rather degrade gracefully
+ * with a loud warning than block the agent's iteration loop.
+ *
+ * Why not in content-only mode: `--scope=content` explicitly opts out of
+ * server-dependent steps. Treating wiki-server unavailability as fatal there
+ * defeats the purpose of the flag.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.contentOnly] - whether build is in content-only mode
+ * @param {NodeJS.ProcessEnv} [opts.env] - env for testing (default process.env)
+ */
+export function isStrictWikiServerMode({ contentOnly = false, env = process.env } = {}) {
+  return env.CI === 'true' && !contentOnly;
+}
+
+/**
  * Log a wiki-server API failure and increment the warning counter.
  * In full build mode, uses console.error for visibility.
  * In content-only mode, uses console.log (expected behavior).

--- a/packages/factbase/src/loader.ts
+++ b/packages/factbase/src/loader.ts
@@ -496,6 +496,25 @@ function parseFact(
 
 // ── Helper: read all .yaml files from a directory ─────────────────────
 
+/**
+ * Parse YAML content with file-path context attached on failure.
+ *
+ * Why: the `yaml` package's parse errors include line/column but not the file
+ * path, so a build that surfaces "implicit map keys need to be on a single
+ * line at line 47, column 3" gives the operator no way to find the broken
+ * file in a tree of ~700 YAMLs. We rethrow with the path prepended so
+ * fail-closed messages name the file explicitly (per QUA-772 acceptance:
+ * "block the build with a clear message naming the file + line").
+ */
+function parseYamlWithPath(content: string, filePath: string): unknown {
+  try {
+    return parseYaml(content, { customTags: CUSTOM_TAGS });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`[kb/loader] YAML parse error in ${filePath}: ${msg}`);
+  }
+}
+
 async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unknown }[]> {
   let entries: string[];
   try {
@@ -513,8 +532,9 @@ async function readYamlFiles(dir: string): Promise<{ name: string; parsed: unkno
 
   const results = await Promise.all(
     yamlFiles.map(async (filename) => {
-      const content = await readFile(join(dir, filename), "utf-8");
-      return { name: filename, parsed: parseYaml(content, { customTags: CUSTOM_TAGS }) };
+      const filePath = join(dir, filename);
+      const content = await readFile(filePath, "utf-8");
+      return { name: filename, parsed: parseYamlWithPath(content, filePath) };
     })
   );
 
@@ -559,10 +579,11 @@ async function discoverEntityFiles(
       seenSlugs.add(slug);
 
       // Single-file entity (existing behavior)
-      const content = await readFile(join(entitiesDir, entry.name), "utf-8");
+      const filePath = join(entitiesDir, entry.name);
+      const content = await readFile(filePath, "utf-8");
       results.push({
         name: entry.name,
-        parsed: parseYaml(content, { customTags: CUSTOM_TAGS }),
+        parsed: parseYamlWithPath(content, filePath),
       });
     } else if (entry.isDirectory()) {
       if (seenSlugs.has(entry.name)) {
@@ -738,12 +759,10 @@ export async function loadKB(dataDir: string, options?: LoadOptions): Promise<Lo
 
   // 1. Load properties
   let properties = new Map<string, Property>();
+  const propertiesPath = join(dataDir, "properties.yaml");
   try {
-    const propertiesContent = await readFile(
-      join(dataDir, "properties.yaml"),
-      "utf-8"
-    );
-    properties = parseProperties(parseYaml(propertiesContent));
+    const propertiesContent = await readFile(propertiesPath, "utf-8");
+    properties = parseProperties(parseYamlWithPath(propertiesContent, propertiesPath));
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error; // Malformed YAML or permission errors should surface

--- a/packages/factbase/tests/yaml-parse-errors.test.ts
+++ b/packages/factbase/tests/yaml-parse-errors.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for FactBase YAML parse error reporting (QUA-772).
+ *
+ * Acceptance criterion: "Make YAML parse errors block the build with a clear
+ * message naming the file + line."
+ *
+ * The `yaml` package's parse errors carry line/column but no file path. We
+ * rethrow with the path prepended so a fail-closed build pinpoints the
+ * broken file in a tree of ~700 YAMLs without forcing the operator to
+ * grep for a snippet of the error message.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadKB } from "../src/loader";
+
+describe("FactBase loader — YAML parse error context (QUA-772)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "fb-yaml-err-"));
+    // Minimal scaffold: properties.yaml + fb-entities/ subdir.
+    await writeFile(
+      join(tempDir, "properties.yaml"),
+      "properties:\n  name:\n    name: Name\n    description: ''\n    appliesTo: ['organization']\n    dataType: text\n",
+      "utf-8",
+    );
+    await mkdir(join(tempDir, "fb-entities"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("rethrows fb-entities/<slug>.yaml parse errors with the file path", async () => {
+    const brokenPath = join(tempDir, "fb-entities", "broken.yaml");
+    // Hard YAML syntax error: tab indent inside a mapping (yaml@2 forbids it).
+    await writeFile(brokenPath, "thing:\n\tid: bad-tab-indent\n", "utf-8");
+
+    await expect(loadKB(tempDir)).rejects.toThrow(
+      // Error must name the file path so the operator can find it. We don't
+      // pin the exact YAML library wording — it's specific to yaml@2.x and
+      // could change across versions.
+      new RegExp(
+        `\\[kb/loader\\] YAML parse error in .*${brokenPath
+          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+          .replace(/\\\\/g, "[\\\\/]")}`,
+      ),
+    );
+  });
+
+  it("rethrows properties.yaml parse errors with the file path", async () => {
+    const propertiesPath = join(tempDir, "properties.yaml");
+    // Same forbidden tab-indent pattern.
+    await writeFile(propertiesPath, "properties:\n\tname: bad\n", "utf-8");
+
+    await expect(loadKB(tempDir)).rejects.toThrow(/properties\.yaml/);
+  });
+
+  it("rethrows per-entity-directory file parse errors with the file path", async () => {
+    // Per-entity dir layout: fb-entities/<slug>/<file>.yaml
+    const slugDir = join(tempDir, "fb-entities", "broken-slug");
+    await mkdir(slugDir, { recursive: true });
+    const brokenPath = join(slugDir, "facts.yaml");
+    await writeFile(brokenPath, "facts:\n\t- id: bad\n", "utf-8");
+
+    await expect(loadKB(tempDir)).rejects.toThrow(
+      new RegExp(
+        `\\[kb/loader\\] YAML parse error in .*${brokenPath
+          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+          .replace(/\\\\/g, "[\\\\/]")}`,
+      ),
+    );
+  });
+
+  it("does NOT swallow parse errors as warnings — the build must fail-closed", async () => {
+    const brokenPath = join(tempDir, "fb-entities", "swallow-test.yaml");
+    await writeFile(brokenPath, "thing:\n\tid: x\n", "utf-8");
+    // Per QUA-772: every YAML parse error in `data/` or
+    // `packages/factbase/data/` must throw, not warn-and-skip. A skip would
+    // silently drop facts the wiki depends on.
+    await expect(loadKB(tempDir)).rejects.toThrow(/YAML parse error/);
+  });
+});


### PR DESCRIPTION
## Summary

Make `apps/web/scripts/build-data.mjs` fail-closed on YAML errors and on
wiki-server unreachability **in CI**, so a partial `database.json` never
overwrites a known-good one. Closes QUA-772 acceptance criteria 1, 2, 3, 4.

## What changed

- **`isStrictWikiServerMode()`** in `wiki-server-data.mjs` — strict iff
  `CI === 'true'` AND not content-only. Mirrors the existing
  `isStrictVerdictsMode()` policy. Local dev / agent slots without prod
  credentials keep degraded fallback behavior.
- **Pre-write CI gate** in `build-data.mjs` — moved the wiki-server warning
  check from informational (post-write) to fail-closed (pre-write). When CI
  hits any wiki-server failure during a full build, the build aborts before
  writing `database.json`, so the previous (known-good) version is preserved.
- **`parseYamlWithPath()`** in `packages/factbase/src/loader.ts` — wraps
  `parseYaml()` to rethrow with the file path prepended, so YAML parse
  errors include "broken file is `<path>`" rather than just the `yaml@2`
  line/column. Operators can pinpoint the bad file in a tree of ~700 YAMLs
  without grepping for the error wording.
- **Docs**: extends `.claude/rules/error-handling.md` with a dedicated
  "Fail-Closed in build-data.mjs" section enumerating every pre-write
  fail-closed condition and the CI-only policy for wiki-server failures.

## Why CI-only for wiki-server failures

CI runs against authenticated prod, so a missed fetch indicates a real
regression worth halting the build over. Local dev / agent slots may
legitimately lack server access (offline iteration, slot doesn't have
prod creds, transient prod outage), and treating that as fatal would
block the agent's iteration loop for reasons unrelated to the change
being tested. Same split as the existing `isStrictVerdictsMode()` for
record-verdicts (QUA-421 / QUA-448).

## No `STRICT_WIKI_SERVER=0` panic-button env var

The QUA-448 retro applies: "escape hatches become load-bearing over
time and silently defeat the fail-closed intent." For emergency builds
that must complete despite wiki-server warnings, unset `CI` for that
build step. There is no env-var bypass.

## What's NOT in this PR

The "make missing FactBase references for `<FBF>`/`<FBFactValue>` block
the build" task in the QUA-772 ticket body (NOT in acceptance criteria)
is deferred to **QUA-854**. The existing gate validator
`validate-component-refs.ts` already detects them, but treats all 161
sid_-form refs as warnings due to a sid_ form gap. Promoting
`brokenKbfRefs` from warning to error without first closing that gap
would break every CI run on main.

## Tests

- `apps/web/scripts/lib/__tests__/build-fail-closed.test.mjs` — 7 new
  tests covering `isStrictWikiServerMode` policy (CI strict, content-only
  opt-out, non-`'true'` CI values) and the warning-counter snapshot
  invariant.
- `packages/factbase/tests/yaml-parse-errors.test.ts` — 4 new tests
  covering YAML error context for `fb-entities/<slug>.yaml`,
  `properties.yaml`, per-entity-directory subfiles, and the no-swallow
  invariant.

## Test plan

- [x] `pnpm test` (apps/web) — 218 / 218 pass (16 files, 0 regressions)
- [x] `pnpm test yaml-parse-errors` (packages/factbase) — 4 / 4 pass
- [x] `pnpm crux w validate gate --scope=content --fix` — 5 / 5 checks pass
- [x] Full `pnpm crux w validate gate --fix` — 64 / 64 checks pass
      (2 advisory warnings: `typecheck-crux` baseline, orphan-entity advisory — both pre-existing, unrelated)
- [x] `pnpm crux w fix escaping` / `fix markdown` — clean
- [x] `node --import tsx/esm scripts/build-data.mjs --quick` succeeds
      (765 pages, 2062 entities, 0 YAML errors, 0 wiki-server warnings)

## Acceptance criteria

- [x] `pnpm build` exits 1 on any YAML syntax error in `data/` or
      `packages/factbase/data/` — covered by `parseYamlWithPath` (factbase)
      and existing `yamlParseErrorCount` (data/) + pre-write check
- [x] `pnpm build` exits 1 in CI when wiki-server is unreachable —
      `isStrictWikiServerMode` + new pre-write check
- [x] No regression in successful build path — `pnpm build` with `--quick`
      runs cleanly, all 218 unit tests pass
- [x] Updated docs in `.claude/rules/error-handling.md` § "Fail-closed
      defaults" — new "Fail-Closed in build-data.mjs (QUA-772)" subsection

## Observed this session

- Acceptance criteria 1, 2, 3, 4 → fixed (this PR)
- Task-list item "make missing FactBase refs for `<FBF>`/`<FBFactValue>`
  block the build" → filed:QUA-854 (sid_ form support gap in
  `validate-component-refs.ts` produces 161 false positives; needs to be
  fixed before promoting to fatal)
- Stale `.next/types/app/scorecards/[source]/page.ts` from a previous
  build caused a local typecheck failure unrelated to my changes →
  deferred (local-cache cleanup; not reproducible in CI which always
  starts from a fresh `.next/`)

Closes QUA-772.


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"`
<!-- /deploy-tasks -->