### PR TITLE
QUA-840: cover Policy dropdown + scorecards reachability in e2e tests

### DIFF
--- a/apps/web/e2e/header-dropdowns.spec.ts
+++ b/apps/web/e2e/header-dropdowns.spec.ts
@@ -36,6 +36,37 @@ test.describe("Header dropdown menus", () => {
     ).toBeVisible();
   });
 
+  test("Policy dropdown surfaces Safety Scorecards (QUA-840)", async ({ page }) => {
+    await page.goto("/");
+
+    const policyButton = page.locator("header button", { hasText: "Policy" });
+    await expect(policyButton).toBeVisible({ timeout: 10000 });
+    await policyButton.click();
+
+    const scorecardsLink = page.locator("header a", {
+      hasText: "Safety Scorecards",
+    });
+    await expect(scorecardsLink).toBeVisible({ timeout: 10000 });
+    await expect(scorecardsLink).toHaveAttribute("href", "/scorecards");
+
+    await expect(
+      page.locator("header a", { hasText: "Legislation" })
+    ).toBeVisible();
+    await expect(
+      page.locator("header a", { hasText: "Politicians" })
+    ).toBeVisible();
+  });
+
+  test("Safety Scorecards link navigates to /scorecards (QUA-840)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.locator("header button", { hasText: "Policy" }).click();
+    await page.locator("header a", { hasText: "Safety Scorecards" }).click();
+    await expect(page).toHaveURL(/\/scorecards/, { timeout: 15000 });
+  });
+
   test("dropdown items are not clipped by overflow", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
## Summary

QUA-840 reported that `/scorecards` was missing from the header navigation in prod. **Verified against `https://www.longtermwiki.com/` via Playwright**: the link IS present in the Policy dropdown as "Safety Scorecards" with `href="/scorecards"`, and clicking through navigates correctly. It was added by QUA-688 (commit `722d68488`) on 2026-04-24, before QUA-840 was filed on 2026-04-29 — the misdiagnosis was almost certainly the reporter not opening the Policy dropdown.

The genuinely unmet acceptance criterion was **test coverage**. The existing `header-dropdowns.spec.ts` only exercised Entities and Research dropdowns; Policy and Sources had no Playwright coverage. This PR adds two tests for the Policy dropdown to lock in scorecards reachability against future regressions:

- `Policy dropdown surfaces Safety Scorecards (QUA-840)` — asserts the link is visible inside the Policy dropdown, has `href="/scorecards"`, and is rendered alongside the other Policy items (Legislation, Politicians).
- `Safety Scorecards link navigates to /scorecards (QUA-840)` — clicks through to verify routing works end-to-end.

All 6 tests in the file pass against prod.

## What this PR doesn't do

- **No nav restructure.** The placement under Policy is consistent with QUA-688's design and not obviously wrong, even if a case can be made for moving Safety Scorecards next to Benchmarks under Research. That's a judgement call out of scope for a low-priority discoverability ticket.
- **No "1-click" promotion.** The acceptance criterion "reachable from the header within 1 click" technically isn't met — it's 2 clicks (open dropdown, click link), but every directory page in this nav follows the same pattern. Promoting one item to top-level inconsistently would worsen the nav.

## Test plan

- [x] `pnpm crux w validate gate --fix` passes (64 checks, 2 unrelated advisory warnings)
- [x] `cd apps/web && PLAYWRIGHT_BASE_URL=https://www.longtermwiki.com npx playwright test e2e/header-dropdowns.spec.ts` — 6/6 pass against prod
- [ ] CI green

Fixes QUA-840
