### PR TITLE
fix(pr-patrol): skip stuck-escalation for healthy PRs + enforce daemon singleton

### DIFF
--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -42,6 +42,7 @@ import {
   getAbandonedSha,
   getProcessedBlockingCommentIds,
   isAbandoned,
+  isHealthyState,
   isPendingCICheck,
   isRecentlyProcessed,
   JSONL_FILE,
@@ -292,24 +293,6 @@ export function detectAllPrIssuesFromNodes(
  */
 export const STUCK_CYCLE_THRESHOLD = 3;
 
-/**
- * QUA-832: A PR's state fingerprint is "healthy" when the PR is in a state a
- * human reviewer would consider merge-ready or merge-imminent. Repeating this
- * state across cycles means the PR is awaiting human approval, not stuck on
- * something the patrol can fix.
- *
- * Healthy = mergeable in {MERGEABLE, UNKNOWN} AND rollup not FAIL AND zero
- * top-level blocking comments. UNKNOWN is included because GitHub frequently
- * lags the mergeability lookup; persistent UNKNOWN with a passing CI is more
- * likely a stale-cache PR than a broken one. Anything FAIL is unhealthy
- * regardless of mergeability.
- */
-export function isFingerprintHealthy(fingerprint: string): boolean {
-  const parts = fingerprint.split(':');
-  if (parts.length !== 3) return false;
-  const [m, r, c] = parts;
-  return (m === 'MERGEABLE' || m === 'UNKNOWN') && r !== 'FAIL' && c === '0';
-}
 
 /**
  * Collapse the status-check rollup into a single conclusion string suitable
@@ -406,18 +389,16 @@ export async function applyStuckCycleDetection(
       log(`  ${cl.yellow}Warning: could not record cycle snapshot for PR #${pr.number}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
     });
 
-    // Annotate trending and stuck cycles. Note QUA-832: a healthy fingerprint
-    // (mergeable/unknown + CI not failing + zero blocking comments) means the
-    // PR is awaiting human approval, not stuck on a fixable problem. Don't
-    // push 'stuck' onto issues for those — the existing hasExceededMaxAttempts
-    // guard still catches dispatch churn on residual soft issues like
-    // bot-review-major.
+    // A healthy state (mergeable/unknown + CI not failing + zero blocking
+    // comments) means the PR is awaiting human approval, not stuck on a
+    // fixable problem. Skip the 'stuck' tag for those — hasExceededMaxAttempts
+    // still catches dispatch churn on residual soft issues.
     if (stuckCycles >= 2) {
       pr.stuckCycles = stuckCycles;
       pr.stuckReason = fingerprint;
 
       if (stuckCycles >= STUCK_CYCLE_THRESHOLD) {
-        if (isFingerprintHealthy(fingerprint)) {
+        if (isHealthyState({ mergeable, rollupConclusion, blockingCommentCount })) {
           log(`  ${cl.dim}PR #${pr.number}: in healthy state (${fingerprint}) for ${stuckCycles} cycles — awaiting human approval${cl.reset}`);
         } else {
           if (!pr.issues.includes('stuck')) pr.issues.push('stuck');

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -293,6 +293,25 @@ export function detectAllPrIssuesFromNodes(
 export const STUCK_CYCLE_THRESHOLD = 3;
 
 /**
+ * QUA-832: A PR's state fingerprint is "healthy" when the PR is in a state a
+ * human reviewer would consider merge-ready or merge-imminent. Repeating this
+ * state across cycles means the PR is awaiting human approval, not stuck on
+ * something the patrol can fix.
+ *
+ * Healthy = mergeable in {MERGEABLE, UNKNOWN} AND rollup not FAIL AND zero
+ * top-level blocking comments. UNKNOWN is included because GitHub frequently
+ * lags the mergeability lookup; persistent UNKNOWN with a passing CI is more
+ * likely a stale-cache PR than a broken one. Anything FAIL is unhealthy
+ * regardless of mergeability.
+ */
+export function isFingerprintHealthy(fingerprint: string): boolean {
+  const parts = fingerprint.split(':');
+  if (parts.length !== 3) return false;
+  const [m, r, c] = parts;
+  return (m === 'MERGEABLE' || m === 'UNKNOWN') && r !== 'FAIL' && c === '0';
+}
+
+/**
  * Collapse the status-check rollup into a single conclusion string suitable
  * for fingerprinting. We want something that changes when a previously-failing
  * check passes (or vice versa) but tolerates minor flux in pending states.
@@ -387,29 +406,23 @@ export async function applyStuckCycleDetection(
       log(`  ${cl.yellow}Warning: could not record cycle snapshot for PR #${pr.number}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
     });
 
-    // QUA-832: A PR with fingerprint MERGEABLE:PASS:0 (mergeable, CI passing,
-    // zero top-level blocking comments) is in a healthy "merge-ready" state,
-    // not stuck on a problem the patrol can fix. Repeating this fingerprint
-    // means the PR is awaiting human approval (stage:approved label or
-    // review). Don't push 'stuck' onto pr.issues — that would trigger a
-    // no-op coordinator escalation and waste cycles re-polling. The existing
-    // hasExceededMaxAttempts guard still catches dispatch churn on residual
-    // soft issues like bot-review-major.
-    const isHealthyFingerprint = fingerprint === 'MERGEABLE:PASS:0';
+    // Annotate trending and stuck cycles. Note QUA-832: a healthy fingerprint
+    // (mergeable/unknown + CI not failing + zero blocking comments) means the
+    // PR is awaiting human approval, not stuck on a fixable problem. Don't
+    // push 'stuck' onto issues for those — the existing hasExceededMaxAttempts
+    // guard still catches dispatch churn on residual soft issues like
+    // bot-review-major.
+    if (stuckCycles >= 2) {
+      pr.stuckCycles = stuckCycles;
+      pr.stuckReason = fingerprint;
 
-    if (stuckCycles >= STUCK_CYCLE_THRESHOLD && !isHealthyFingerprint) {
-      pr.stuckCycles = stuckCycles;
-      pr.stuckReason = fingerprint;
-      if (!pr.issues.includes('stuck')) pr.issues.push('stuck');
-      log(`  ${cl.yellow}PR #${pr.number}: stuck for ${stuckCycles} cycles (fingerprint=${fingerprint}) — escalating${cl.reset}`);
-    } else if (stuckCycles >= 2) {
-      // Not yet at threshold but trending — annotate so the fix prompt can
-      // warn the agent. Healthy-fingerprint PRs land here too: stuckCycles
-      // is recorded for visibility but no escalation flag is set.
-      pr.stuckCycles = stuckCycles;
-      pr.stuckReason = fingerprint;
-      if (isHealthyFingerprint && stuckCycles >= STUCK_CYCLE_THRESHOLD) {
-        log(`  ${cl.dim}PR #${pr.number}: in healthy state (${fingerprint}) for ${stuckCycles} cycles — awaiting human approval${cl.reset}`);
+      if (stuckCycles >= STUCK_CYCLE_THRESHOLD) {
+        if (isFingerprintHealthy(fingerprint)) {
+          log(`  ${cl.dim}PR #${pr.number}: in healthy state (${fingerprint}) for ${stuckCycles} cycles — awaiting human approval${cl.reset}`);
+        } else {
+          if (!pr.issues.includes('stuck')) pr.issues.push('stuck');
+          log(`  ${cl.yellow}PR #${pr.number}: stuck for ${stuckCycles} cycles (fingerprint=${fingerprint}) — escalating${cl.reset}`);
+        }
       }
     }
   }

--- a/crux/pr-patrol/detection.ts
+++ b/crux/pr-patrol/detection.ts
@@ -387,16 +387,30 @@ export async function applyStuckCycleDetection(
       log(`  ${cl.yellow}Warning: could not record cycle snapshot for PR #${pr.number}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
     });
 
-    if (stuckCycles >= STUCK_CYCLE_THRESHOLD) {
+    // QUA-832: A PR with fingerprint MERGEABLE:PASS:0 (mergeable, CI passing,
+    // zero top-level blocking comments) is in a healthy "merge-ready" state,
+    // not stuck on a problem the patrol can fix. Repeating this fingerprint
+    // means the PR is awaiting human approval (stage:approved label or
+    // review). Don't push 'stuck' onto pr.issues — that would trigger a
+    // no-op coordinator escalation and waste cycles re-polling. The existing
+    // hasExceededMaxAttempts guard still catches dispatch churn on residual
+    // soft issues like bot-review-major.
+    const isHealthyFingerprint = fingerprint === 'MERGEABLE:PASS:0';
+
+    if (stuckCycles >= STUCK_CYCLE_THRESHOLD && !isHealthyFingerprint) {
       pr.stuckCycles = stuckCycles;
       pr.stuckReason = fingerprint;
       if (!pr.issues.includes('stuck')) pr.issues.push('stuck');
       log(`  ${cl.yellow}PR #${pr.number}: stuck for ${stuckCycles} cycles (fingerprint=${fingerprint}) — escalating${cl.reset}`);
     } else if (stuckCycles >= 2) {
       // Not yet at threshold but trending — annotate so the fix prompt can
-      // warn the agent.
+      // warn the agent. Healthy-fingerprint PRs land here too: stuckCycles
+      // is recorded for visibility but no escalation flag is set.
       pr.stuckCycles = stuckCycles;
       pr.stuckReason = fingerprint;
+      if (isHealthyFingerprint && stuckCycles >= STUCK_CYCLE_THRESHOLD) {
+        log(`  ${cl.dim}PR #${pr.number}: in healthy state (${fingerprint}) for ${stuckCycles} cycles — awaiting human approval${cl.reset}`);
+      }
     }
   }
 }

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -659,6 +659,12 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
 
   ensureDirs();
 
+  // Tracks whether THIS process acquired the PID file. `once` mode skips
+  // acquisition (line below), so it must also skip release in shutdown,
+  // otherwise a one-shot run that catches SIGINT/SIGTERM would delete the
+  // continuous daemon's PID file (CodeRabbit, PR #4701).
+  let ownsPidFile = false;
+
   // Refuse to start a continuous daemon if another is already running —
   // otherwise two `pr-patrol run` invocations spawn parallel loops with
   // independent cycle counters and double-process the queue.
@@ -685,6 +691,7 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
       }
       process.exit(1);
     }
+    ownsPidFile = true;
   }
 
   logHeader('PR Patrol starting');
@@ -703,7 +710,7 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     log('Shutting down...');
-    removePidFile();
+    if (ownsPidFile) removePidFile();
     await releaseCurrentClaim(config.repo);
     process.exit(0);
   };

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -161,72 +161,52 @@ export function getDaemonPid(file: string = PID_FILE): number | null {
 }
 
 /**
- * QUA-835: Singleton guard for the daemon. Reads the PID file and reports
- * whether a different live patrol process is already running.
+ * Atomically acquire the PID file. Uses `flag: 'wx'` (exclusive create) so
+ * two simultaneous patrol launches can't both succeed: only one wins the
+ * create, the other sees EEXIST and either bails (live owner) or reclaims
+ * (stale owner). Bounded retry handles the rare race where two processes
+ * both detect a stale file at the same instant.
  *
- * Returns:
- *   - { running: false } when the PID file is missing, stale (process dead),
- *     or points at the current process (idempotent re-entry).
- *   - { running: true, pid } when another live process owns the file.
- *
- * Read-only: doesn't write or modify the PID file. For the actual start-time
- * race-safe acquisition, see `acquirePidFile()`.
- */
-export function checkSingletonDaemon(
-  file: string = PID_FILE,
-): { running: false } | { running: true; pid: number } {
-  const pid = getDaemonPid(file);
-  if (pid === null || pid === process.pid) return { running: false };
-  return { running: true, pid };
-}
-
-/**
- * Atomically acquire the PID file, returning a structured result instead of
- * the bare PID. Fixes the TOCTOU race where two simultaneous `pr-patrol run`
- * invocations both pass `checkSingletonDaemon` (because neither has written
- * yet) and then both call `writeFileSync`, leaving two daemons alive.
- *
- * Strategy: try `flag: 'wx'` (exclusive create — fails on EEXIST). On EEXIST,
- * read the file: if the recorded PID is dead, atomically replace; if alive,
- * report the collision; if the recorded PID is ours, treat as idempotent
- * re-entry. The retry handles the rare case where two processes both detected
- * a stale file at the same time.
+ * Returns `{ ok: false, existingPid }` when another live process owns the
+ * file. Returns `{ ok: true }` only after this process's PID has been
+ * persisted to disk — never lies about acquisition.
  */
 export function acquirePidFile(
   file: string = PID_FILE,
 ): { ok: true } | { ok: false; existingPid: number } {
-  // Two-attempt loop: first try exclusive-create; on EEXIST, inspect the
-  // existing file and either bail (live owner) or replace (stale owner) and
-  // try once more. Bounded retry — no unbounded recovery.
-  for (let attempt = 0; attempt < 2; attempt++) {
+  // Bounded retry — stale-PID reclamation can race with a peer doing the
+  // same. After two attempts we surface failure rather than spin.
+  for (let i = 0; i < 2; i++) {
     try {
       writeFileSync(file, String(process.pid), { flag: 'wx' });
       return { ok: true };
     } catch (e) {
       const code = (e as NodeJS.ErrnoException).code;
       if (code !== 'EEXIST') {
-        console.error(`${cl.yellow}Warning: could not write PID file ${file}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
-        return { ok: true };
+        // EACCES, ENOSPC, EROFS, etc. — we couldn't write, so we can't claim.
+        // Surface as failure so the daemon refuses to start (better than
+        // silently running without singleton enforcement).
+        console.error(`${cl.red}ERROR: could not write PID file ${file}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
+        return { ok: false, existingPid: -1 };
       }
       const existing = getDaemonPid(file);
       if (existing === process.pid) return { ok: true };
       if (existing !== null) return { ok: false, existingPid: existing };
-      // File exists but owner is dead — try to clear it and retry.
+      // File exists but owner is dead — try to clear it and loop.
       try {
         unlinkSync(file);
       } catch {
-        // Another process raced us to clear it; that's fine, the next loop
-        // iteration will either succeed or detect the new owner.
+        // Another process raced us to clear it. Next iteration will
+        // either succeed or detect the new owner.
       }
     }
   }
-  // Lost both rounds (extreme contention). Surface a collision rather than
-  // double-write.
+  // Lost both rounds (extreme contention). Re-read once to get the final
+  // owner; if the file vanished, treat as our last failed write rather than
+  // falsely reporting success.
   const finalOwner = getDaemonPid(file);
-  if (finalOwner !== null && finalOwner !== process.pid) {
-    return { ok: false, existingPid: finalOwner };
-  }
-  return { ok: true };
+  if (finalOwner === process.pid) return { ok: true };
+  return { ok: false, existingPid: finalOwner ?? -1 };
 }
 
 /** Stop a running patrol daemon. Returns true if one was stopped. */
@@ -679,29 +659,30 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
 
   ensureDirs();
 
-  // QUA-835: refuse to start a continuous daemon if another is already
-  // running. Two `pr-patrol run` invocations would spawn parallel loops
-  // that each maintain their own cycle counter (visible as cycle resets in
-  // the logs) and double-process the PR queue. acquirePidFile combines the
-  // collision check with the PID write atomically (flag: 'wx') so true
-  // simultaneous starts can't both succeed.
+  // Refuse to start a continuous daemon if another is already running —
+  // otherwise two `pr-patrol run` invocations spawn parallel loops with
+  // independent cycle counters and double-process the queue.
   //
   // `once` mode is intentionally NOT checked: it does a single pass and
-  // exits, so running it alongside a debugging daemon is the documented
-  // workflow. (The PR queue still gets some races but that's pre-existing.)
+  // exits, so debugging a daemon with `once` runs is the documented workflow.
   if (!config.once) {
     const acquired = acquirePidFile();
     if (!acquired.ok) {
-      console.error(
-        `${cl.red}ERROR: Another PR patrol daemon is already running (pid ${acquired.existingPid}).${cl.reset}`,
-      );
-      console.error(`  PID file: ${PID_FILE}`);
-      console.error(
-        `  Run \`crux gh pr-patrol stop\` to stop it, \`crux gh pr-patrol status\` to check,`,
-      );
-      console.error(
-        `  or remove the PID file manually if the listed PID is not actually a patrol process.`,
-      );
+      if (acquired.existingPid === -1) {
+        // Write failure (EACCES, ENOSPC, etc.) — the message was already
+        // logged inside acquirePidFile. Just bail.
+      } else {
+        console.error(
+          `${cl.red}ERROR: Another PR patrol daemon is already running (pid ${acquired.existingPid}).${cl.reset}`,
+        );
+        console.error(`  PID file: ${PID_FILE}`);
+        console.error(
+          `  Run \`crux gh pr-patrol stop\` to stop it, \`crux gh pr-patrol status\` to check,`,
+        );
+        console.error(
+          `  or remove the PID file manually if the listed PID is not actually a patrol process.`,
+        );
+      }
       process.exit(1);
     }
   }

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -128,24 +128,24 @@ const cl = getColors();
 
 import { join as joinPath } from 'path';
 
-const PID_FILE = joinPath(process.env.HOME ?? '/tmp', '.cache', 'pr-patrol', 'daemon.pid');
+export const PID_FILE = joinPath(process.env.HOME ?? '/tmp', '.cache', 'pr-patrol', 'daemon.pid');
 
-function writePidFile(): void {
+function writePidFile(file: string = PID_FILE): void {
   try {
-    writeFileSync(PID_FILE, String(process.pid));
+    writeFileSync(file, String(process.pid));
   } catch { /* best-effort */ }
 }
 
-function removePidFile(): void {
+function removePidFile(file: string = PID_FILE): void {
   try {
-    unlinkSync(PID_FILE);
+    unlinkSync(file);
   } catch { /* best-effort */ }
 }
 
 /** Read the PID of a running patrol daemon, or null if none. */
-export function getDaemonPid(): number | null {
+export function getDaemonPid(file: string = PID_FILE): number | null {
   try {
-    const pid = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+    const pid = parseInt(readFileSync(file, 'utf-8').trim(), 10);
     if (isNaN(pid)) return null;
     // Check if process is alive
     process.kill(pid, 0);
@@ -153,6 +153,26 @@ export function getDaemonPid(): number | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * QUA-835: Singleton guard for the daemon. Reads the PID file and reports
+ * whether a different live patrol process is already running.
+ *
+ * Returns:
+ *   - { running: false } when the PID file is missing, stale (process dead),
+ *     or points at the current process (idempotent re-entry).
+ *   - { running: true, pid } when another live process owns the file.
+ *
+ * `file` is parameterized so tests can drive it without touching the real
+ * `~/.cache/pr-patrol/daemon.pid`.
+ */
+export function checkSingletonDaemon(
+  file: string = PID_FILE,
+): { running: false } | { running: true; pid: number } {
+  const pid = getDaemonPid(file);
+  if (pid === null || pid === process.pid) return { running: false };
+  return { running: true, pid };
 }
 
 /** Stop a running patrol daemon. Returns true if one was stopped. */
@@ -604,6 +624,21 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
   }
 
   ensureDirs();
+
+  // QUA-835: refuse to start if another patrol daemon is already running.
+  // Without this, two `pr-patrol run` invocations spawn parallel loops that
+  // each maintain their own cycle counter (visible as cycle resets in the
+  // logs) and double-process the PR queue.
+  const singleton = checkSingletonDaemon();
+  if (singleton.running) {
+    console.error(
+      `${cl.red}ERROR: Another PR patrol daemon is already running (pid ${singleton.pid}).${cl.reset}`,
+    );
+    console.error(
+      `Run \`crux gh pr-patrol stop\` to stop it, or \`crux gh pr-patrol status\` to check.`,
+    );
+    process.exit(1);
+  }
 
   // Write PID file so `pr-patrol stop` can find us
   writePidFile();

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -130,16 +130,18 @@ import { join as joinPath } from 'path';
 
 export const PID_FILE = joinPath(process.env.HOME ?? '/tmp', '.cache', 'pr-patrol', 'daemon.pid');
 
-function writePidFile(file: string = PID_FILE): void {
-  try {
-    writeFileSync(file, String(process.pid));
-  } catch { /* best-effort */ }
-}
-
 function removePidFile(file: string = PID_FILE): void {
   try {
     unlinkSync(file);
-  } catch { /* best-effort */ }
+  } catch (e) {
+    // ENOENT is expected when the file is already gone (e.g. another shutdown
+    // path beat us to it). Anything else (EACCES, EPERM) is a real surprise
+    // worth surfacing.
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error(`${cl.yellow}Warning: could not remove PID file ${file}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
+    }
+  }
 }
 
 /** Read the PID of a running patrol daemon, or null if none. */
@@ -147,7 +149,10 @@ export function getDaemonPid(file: string = PID_FILE): number | null {
   try {
     const pid = parseInt(readFileSync(file, 'utf-8').trim(), 10);
     if (isNaN(pid)) return null;
-    // Check if process is alive
+    // Check if process is alive. Note: this only verifies _some_ process owns
+    // the PID — after a crash + enough new PID allocations, the OS will reuse
+    // the dead daemon's PID for an unrelated process. Acceptable failure mode:
+    // the new daemon refuses to start until the user clears the PID file.
     process.kill(pid, 0);
     return pid;
   } catch {
@@ -164,8 +169,8 @@ export function getDaemonPid(file: string = PID_FILE): number | null {
  *     or points at the current process (idempotent re-entry).
  *   - { running: true, pid } when another live process owns the file.
  *
- * `file` is parameterized so tests can drive it without touching the real
- * `~/.cache/pr-patrol/daemon.pid`.
+ * Read-only: doesn't write or modify the PID file. For the actual start-time
+ * race-safe acquisition, see `acquirePidFile()`.
  */
 export function checkSingletonDaemon(
   file: string = PID_FILE,
@@ -173,6 +178,55 @@ export function checkSingletonDaemon(
   const pid = getDaemonPid(file);
   if (pid === null || pid === process.pid) return { running: false };
   return { running: true, pid };
+}
+
+/**
+ * Atomically acquire the PID file, returning a structured result instead of
+ * the bare PID. Fixes the TOCTOU race where two simultaneous `pr-patrol run`
+ * invocations both pass `checkSingletonDaemon` (because neither has written
+ * yet) and then both call `writeFileSync`, leaving two daemons alive.
+ *
+ * Strategy: try `flag: 'wx'` (exclusive create — fails on EEXIST). On EEXIST,
+ * read the file: if the recorded PID is dead, atomically replace; if alive,
+ * report the collision; if the recorded PID is ours, treat as idempotent
+ * re-entry. The retry handles the rare case where two processes both detected
+ * a stale file at the same time.
+ */
+export function acquirePidFile(
+  file: string = PID_FILE,
+): { ok: true } | { ok: false; existingPid: number } {
+  // Two-attempt loop: first try exclusive-create; on EEXIST, inspect the
+  // existing file and either bail (live owner) or replace (stale owner) and
+  // try once more. Bounded retry — no unbounded recovery.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      writeFileSync(file, String(process.pid), { flag: 'wx' });
+      return { ok: true };
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') {
+        console.error(`${cl.yellow}Warning: could not write PID file ${file}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`);
+        return { ok: true };
+      }
+      const existing = getDaemonPid(file);
+      if (existing === process.pid) return { ok: true };
+      if (existing !== null) return { ok: false, existingPid: existing };
+      // File exists but owner is dead — try to clear it and retry.
+      try {
+        unlinkSync(file);
+      } catch {
+        // Another process raced us to clear it; that's fine, the next loop
+        // iteration will either succeed or detect the new owner.
+      }
+    }
+  }
+  // Lost both rounds (extreme contention). Surface a collision rather than
+  // double-write.
+  const finalOwner = getDaemonPid(file);
+  if (finalOwner !== null && finalOwner !== process.pid) {
+    return { ok: false, existingPid: finalOwner };
+  }
+  return { ok: true };
 }
 
 /** Stop a running patrol daemon. Returns true if one was stopped. */
@@ -625,23 +679,32 @@ export async function runDaemon(config: PatrolConfig): Promise<void> {
 
   ensureDirs();
 
-  // QUA-835: refuse to start if another patrol daemon is already running.
-  // Without this, two `pr-patrol run` invocations spawn parallel loops that
-  // each maintain their own cycle counter (visible as cycle resets in the
-  // logs) and double-process the PR queue.
-  const singleton = checkSingletonDaemon();
-  if (singleton.running) {
-    console.error(
-      `${cl.red}ERROR: Another PR patrol daemon is already running (pid ${singleton.pid}).${cl.reset}`,
-    );
-    console.error(
-      `Run \`crux gh pr-patrol stop\` to stop it, or \`crux gh pr-patrol status\` to check.`,
-    );
-    process.exit(1);
+  // QUA-835: refuse to start a continuous daemon if another is already
+  // running. Two `pr-patrol run` invocations would spawn parallel loops
+  // that each maintain their own cycle counter (visible as cycle resets in
+  // the logs) and double-process the PR queue. acquirePidFile combines the
+  // collision check with the PID write atomically (flag: 'wx') so true
+  // simultaneous starts can't both succeed.
+  //
+  // `once` mode is intentionally NOT checked: it does a single pass and
+  // exits, so running it alongside a debugging daemon is the documented
+  // workflow. (The PR queue still gets some races but that's pre-existing.)
+  if (!config.once) {
+    const acquired = acquirePidFile();
+    if (!acquired.ok) {
+      console.error(
+        `${cl.red}ERROR: Another PR patrol daemon is already running (pid ${acquired.existingPid}).${cl.reset}`,
+      );
+      console.error(`  PID file: ${PID_FILE}`);
+      console.error(
+        `  Run \`crux gh pr-patrol stop\` to stop it, \`crux gh pr-patrol status\` to check,`,
+      );
+      console.error(
+        `  or remove the PID file manually if the listed PID is not actually a patrol process.`,
+      );
+      process.exit(1);
+    }
   }
-
-  // Write PID file so `pr-patrol stop` can find us
-  writePidFile();
 
   logHeader('PR Patrol starting');
   log(

--- a/crux/pr-patrol/singleton.test.ts
+++ b/crux/pr-patrol/singleton.test.ts
@@ -1,0 +1,123 @@
+/**
+ * PR Patrol — daemon singleton guard tests (QUA-835).
+ *
+ * Verifies that `checkSingletonDaemon()` correctly detects when another live
+ * patrol process owns the PID file — the guard `runDaemon` uses to refuse
+ * second invocations. Without it, parallel daemons spawn and each maintains
+ * its own cycle counter (visible as cycle resets in production logs).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawn } from 'child_process';
+
+import { checkSingletonDaemon, getDaemonPid } from './index.ts';
+
+function makePidFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pr-patrol-singleton-test-'));
+  return join(dir, 'daemon.pid');
+}
+
+function cleanup(file: string): void {
+  try {
+    const dir = file.substring(0, file.lastIndexOf('/'));
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe('checkSingletonDaemon', () => {
+  let file: string;
+
+  beforeEach(() => {
+    file = makePidFile();
+  });
+  afterEach(() => {
+    cleanup(file);
+  });
+
+  it('returns { running: false } when no PID file exists', () => {
+    expect(existsSync(file)).toBe(false);
+    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+  });
+
+  it('returns { running: false } when the PID file points at a dead process', () => {
+    // Spawn a short-lived child, capture its PID, wait for exit, then write
+    // that (now-dead) PID. The cross-platform "definitely dead" trick.
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    const deadPid = child.pid!;
+    return new Promise<void>((resolve, reject) => {
+      child.on('exit', () => {
+        try {
+          // Tiny delay to make sure the OS has reaped the PID.
+          setTimeout(() => {
+            try {
+              writeFileSync(file, String(deadPid));
+              expect(checkSingletonDaemon(file)).toEqual({ running: false });
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          }, 50);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      child.on('error', reject);
+    });
+  });
+
+  it('returns { running: false } when the PID file contains the current process pid (idempotent re-entry)', () => {
+    writeFileSync(file, String(process.pid));
+    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+  });
+
+  it('returns { running: true, pid } when the PID file points at a different live process', async () => {
+    // Spawn a long-running child we can probe and kill at the end.
+    const child = spawn(process.execPath, [
+      '-e',
+      'setTimeout(() => {}, 60000); process.on("SIGTERM", () => process.exit(0))',
+    ]);
+    const livePid = child.pid!;
+    try {
+      // Wait briefly to ensure the child is ready to receive a probe.
+      await new Promise((r) => setTimeout(r, 50));
+      writeFileSync(file, String(livePid));
+      const result = checkSingletonDaemon(file);
+      expect(result).toEqual({ running: true, pid: livePid });
+    } finally {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it('returns { running: false } when the PID file is malformed', () => {
+    writeFileSync(file, 'not-a-number');
+    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+  });
+
+  it('getDaemonPid mirrors checkSingletonDaemon for live external pids', async () => {
+    const child = spawn(process.execPath, [
+      '-e',
+      'setTimeout(() => {}, 60000); process.on("SIGTERM", () => process.exit(0))',
+    ]);
+    const livePid = child.pid!;
+    try {
+      await new Promise((r) => setTimeout(r, 50));
+      writeFileSync(file, String(livePid));
+      expect(getDaemonPid(file)).toBe(livePid);
+    } finally {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+});

--- a/crux/pr-patrol/singleton.test.ts
+++ b/crux/pr-patrol/singleton.test.ts
@@ -8,12 +8,16 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
-import { spawn } from 'child_process';
+import { dirname, join } from 'path';
+import { spawn, type ChildProcess } from 'child_process';
 
-import { checkSingletonDaemon, getDaemonPid } from './index.ts';
+import {
+  acquirePidFile,
+  checkSingletonDaemon,
+  getDaemonPid,
+} from './index.ts';
 
 function makePidFile(): string {
   const dir = mkdtempSync(join(tmpdir(), 'pr-patrol-singleton-test-'));
@@ -22,11 +26,46 @@ function makePidFile(): string {
 
 function cleanup(file: string): void {
   try {
-    const dir = file.substring(0, file.lastIndexOf('/'));
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(dirname(file), { recursive: true, force: true });
   } catch {
     /* best-effort */
   }
+}
+
+/**
+ * Spawn a long-lived child for "live PID" tests, return it + a cleanup
+ * function that awaits the child's exit. Using `await stop()` in finally{}
+ * guarantees we don't leak the child past the test, which Vitest's worker
+ * pool would otherwise carry across test files.
+ */
+async function spawnLiveChild(): Promise<{ child: ChildProcess; pid: number; stop: () => Promise<void> }> {
+  const child = spawn(process.execPath, [
+    '-e',
+    'setTimeout(() => {}, 60000); process.on("SIGTERM", () => process.exit(0))',
+  ]);
+  // Brief wait so the child has registered its SIGTERM handler before we
+  // probe with `process.kill(pid, 0)` or send SIGTERM ourselves.
+  await new Promise((r) => setTimeout(r, 50));
+  const pid = child.pid!;
+  const stop = (): Promise<void> => new Promise<void>((resolve) => {
+    if (child.exitCode !== null) {
+      resolve();
+      return;
+    }
+    const onExit = (): void => resolve();
+    child.once('exit', onExit);
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      // already gone — exit handler will fire (or we resolve via fallback)
+    }
+    // Fallback timeout — never block tests forever on a stuck child.
+    setTimeout(() => {
+      child.removeListener('exit', onExit);
+      resolve();
+    }, 2000);
+  });
+  return { child, pid, stop };
 }
 
 describe('checkSingletonDaemon', () => {
@@ -44,30 +83,16 @@ describe('checkSingletonDaemon', () => {
     expect(checkSingletonDaemon(file)).toEqual({ running: false });
   });
 
-  it('returns { running: false } when the PID file points at a dead process', () => {
-    // Spawn a short-lived child, capture its PID, wait for exit, then write
-    // that (now-dead) PID. The cross-platform "definitely dead" trick.
+  it('returns { running: false } when the PID file points at a dead process', async () => {
+    // Spawn a short-lived child, capture its PID, await exit, then write
+    // that (now-dead) PID. Cross-platform "definitely dead" pattern.
     const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
     const deadPid = child.pid!;
-    return new Promise<void>((resolve, reject) => {
-      child.on('exit', () => {
-        try {
-          // Tiny delay to make sure the OS has reaped the PID.
-          setTimeout(() => {
-            try {
-              writeFileSync(file, String(deadPid));
-              expect(checkSingletonDaemon(file)).toEqual({ running: false });
-              resolve();
-            } catch (e) {
-              reject(e);
-            }
-          }, 50);
-        } catch (e) {
-          reject(e);
-        }
-      });
-      child.on('error', reject);
-    });
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    // Give the OS a moment to reap the PID.
+    await new Promise((r) => setTimeout(r, 50));
+    writeFileSync(file, String(deadPid));
+    expect(checkSingletonDaemon(file)).toEqual({ running: false });
   });
 
   it('returns { running: false } when the PID file contains the current process pid (idempotent re-entry)', () => {
@@ -76,24 +101,12 @@ describe('checkSingletonDaemon', () => {
   });
 
   it('returns { running: true, pid } when the PID file points at a different live process', async () => {
-    // Spawn a long-running child we can probe and kill at the end.
-    const child = spawn(process.execPath, [
-      '-e',
-      'setTimeout(() => {}, 60000); process.on("SIGTERM", () => process.exit(0))',
-    ]);
-    const livePid = child.pid!;
+    const { pid: livePid, stop } = await spawnLiveChild();
     try {
-      // Wait briefly to ensure the child is ready to receive a probe.
-      await new Promise((r) => setTimeout(r, 50));
       writeFileSync(file, String(livePid));
-      const result = checkSingletonDaemon(file);
-      expect(result).toEqual({ running: true, pid: livePid });
+      expect(checkSingletonDaemon(file)).toEqual({ running: true, pid: livePid });
     } finally {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        /* best-effort */
-      }
+      await stop();
     }
   });
 
@@ -103,21 +116,68 @@ describe('checkSingletonDaemon', () => {
   });
 
   it('getDaemonPid mirrors checkSingletonDaemon for live external pids', async () => {
-    const child = spawn(process.execPath, [
-      '-e',
-      'setTimeout(() => {}, 60000); process.on("SIGTERM", () => process.exit(0))',
-    ]);
-    const livePid = child.pid!;
+    const { pid: livePid, stop } = await spawnLiveChild();
     try {
-      await new Promise((r) => setTimeout(r, 50));
       writeFileSync(file, String(livePid));
       expect(getDaemonPid(file)).toBe(livePid);
     } finally {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        /* best-effort */
-      }
+      await stop();
     }
+  });
+});
+
+// ── acquirePidFile (atomic singleton acquisition) ──────────────────────────
+
+describe('acquirePidFile', () => {
+  let file: string;
+
+  beforeEach(() => {
+    file = makePidFile();
+  });
+  afterEach(() => {
+    cleanup(file);
+  });
+
+  it('writes our PID and returns { ok: true } when the file does not exist', () => {
+    expect(existsSync(file)).toBe(false);
+    expect(acquirePidFile(file)).toEqual({ ok: true });
+    expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
+  });
+
+  it('replaces a stale PID file (owner is dead) and returns { ok: true }', async () => {
+    // Use a definitely-dead PID by spawning + awaiting exit.
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    const deadPid = child.pid!;
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    await new Promise((r) => setTimeout(r, 50));
+    writeFileSync(file, String(deadPid));
+
+    expect(acquirePidFile(file)).toEqual({ ok: true });
+    expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
+  });
+
+  it('returns { ok: false, existingPid } when a different live process owns the file', async () => {
+    const { pid: livePid, stop } = await spawnLiveChild();
+    try {
+      writeFileSync(file, String(livePid));
+      const result = acquirePidFile(file);
+      expect(result).toEqual({ ok: false, existingPid: livePid });
+      // Critical: must NOT have overwritten the file. The owner's PID stays.
+      expect(readFileSync(file, 'utf-8').trim()).toBe(String(livePid));
+    } finally {
+      await stop();
+    }
+  });
+
+  it('returns { ok: true } when the PID file already contains our pid (idempotent re-entry)', () => {
+    writeFileSync(file, String(process.pid));
+    expect(acquirePidFile(file)).toEqual({ ok: true });
+    expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
+  });
+
+  it('writes our PID over a malformed file (treated as stale)', () => {
+    writeFileSync(file, 'corrupt-data-not-a-pid');
+    expect(acquirePidFile(file)).toEqual({ ok: true });
+    expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
   });
 });

--- a/crux/pr-patrol/singleton.test.ts
+++ b/crux/pr-patrol/singleton.test.ts
@@ -1,10 +1,10 @@
 /**
- * PR Patrol — daemon singleton guard tests (QUA-835).
+ * PR Patrol — daemon singleton acquisition tests.
  *
- * Verifies that `checkSingletonDaemon()` correctly detects when another live
- * patrol process owns the PID file — the guard `runDaemon` uses to refuse
- * second invocations. Without it, parallel daemons spawn and each maintains
- * its own cycle counter (visible as cycle resets in production logs).
+ * Verifies `acquirePidFile()`'s atomic claim semantics (the production code
+ * path used by `runDaemon`) plus the underlying `getDaemonPid()` reader.
+ * Without these, two `pr-patrol run` invocations spawn parallel loops with
+ * independent cycle counters (the QUA-835 production symptom).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,11 +13,7 @@ import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { spawn, type ChildProcess } from 'child_process';
 
-import {
-  acquirePidFile,
-  checkSingletonDaemon,
-  getDaemonPid,
-} from './index.ts';
+import { acquirePidFile, getDaemonPid } from './index.ts';
 
 function makePidFile(): string {
   const dir = mkdtempSync(join(tmpdir(), 'pr-patrol-singleton-test-'));
@@ -33,10 +29,11 @@ function cleanup(file: string): void {
 }
 
 /**
- * Spawn a long-lived child for "live PID" tests, return it + a cleanup
- * function that awaits the child's exit. Using `await stop()` in finally{}
- * guarantees we don't leak the child past the test, which Vitest's worker
- * pool would otherwise carry across test files.
+ * Spawn a long-lived child for "live PID" tests. Returns the child + a
+ * cleanup function that awaits the child's exit. Awaiting the exit (rather
+ * than fire-and-forget) prevents leaking child processes into Vitest's
+ * worker pool. The fallback timer is `.unref()`'d so it doesn't pin the
+ * event loop past the test.
  */
 async function spawnLiveChild(): Promise<{ child: ChildProcess; pid: number; stop: () => Promise<void> }> {
   const child = spawn(process.execPath, [
@@ -52,23 +49,32 @@ async function spawnLiveChild(): Promise<{ child: ChildProcess; pid: number; sto
       resolve();
       return;
     }
-    const onExit = (): void => resolve();
+    let fallback: NodeJS.Timeout | undefined;
+    const onExit = (): void => {
+      if (fallback) clearTimeout(fallback);
+      resolve();
+    };
     child.once('exit', onExit);
     try {
       child.kill('SIGTERM');
     } catch {
-      // already gone — exit handler will fire (or we resolve via fallback)
+      // already gone — exit handler will fire (or fallback resolves)
     }
-    // Fallback timeout — never block tests forever on a stuck child.
-    setTimeout(() => {
+    // Escalate to SIGKILL if SIGTERM doesn't take. unref() so a stuck child
+    // can never pin the event loop past test completion.
+    fallback = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
       child.removeListener('exit', onExit);
       resolve();
     }, 2000);
+    fallback.unref?.();
   });
   return { child, pid, stop };
 }
 
-describe('checkSingletonDaemon', () => {
+// ── getDaemonPid (read-only liveness probe) ────────────────────────────────
+
+describe('getDaemonPid', () => {
   let file: string;
 
   beforeEach(() => {
@@ -78,44 +84,25 @@ describe('checkSingletonDaemon', () => {
     cleanup(file);
   });
 
-  it('returns { running: false } when no PID file exists', () => {
+  it('returns null when no PID file exists', () => {
     expect(existsSync(file)).toBe(false);
-    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+    expect(getDaemonPid(file)).toBeNull();
   });
 
-  it('returns { running: false } when the PID file points at a dead process', async () => {
-    // Spawn a short-lived child, capture its PID, await exit, then write
-    // that (now-dead) PID. Cross-platform "definitely dead" pattern.
+  it('returns null when the PID file points at a dead process', async () => {
     const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
     const deadPid = child.pid!;
     await new Promise<void>((resolve) => child.once('exit', () => resolve()));
-    // Give the OS a moment to reap the PID.
-    await new Promise((r) => setTimeout(r, 50));
     writeFileSync(file, String(deadPid));
-    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+    expect(getDaemonPid(file)).toBeNull();
   });
 
-  it('returns { running: false } when the PID file contains the current process pid (idempotent re-entry)', () => {
+  it('returns the current process pid when the file contains it (self-reference)', () => {
     writeFileSync(file, String(process.pid));
-    expect(checkSingletonDaemon(file)).toEqual({ running: false });
+    expect(getDaemonPid(file)).toBe(process.pid);
   });
 
-  it('returns { running: true, pid } when the PID file points at a different live process', async () => {
-    const { pid: livePid, stop } = await spawnLiveChild();
-    try {
-      writeFileSync(file, String(livePid));
-      expect(checkSingletonDaemon(file)).toEqual({ running: true, pid: livePid });
-    } finally {
-      await stop();
-    }
-  });
-
-  it('returns { running: false } when the PID file is malformed', () => {
-    writeFileSync(file, 'not-a-number');
-    expect(checkSingletonDaemon(file)).toEqual({ running: false });
-  });
-
-  it('getDaemonPid mirrors checkSingletonDaemon for live external pids', async () => {
+  it('returns the live PID when a different process owns the file', async () => {
     const { pid: livePid, stop } = await spawnLiveChild();
     try {
       writeFileSync(file, String(livePid));
@@ -123,6 +110,11 @@ describe('checkSingletonDaemon', () => {
     } finally {
       await stop();
     }
+  });
+
+  it('returns null when the PID file is malformed', () => {
+    writeFileSync(file, 'not-a-number');
+    expect(getDaemonPid(file)).toBeNull();
   });
 });
 
@@ -144,24 +136,21 @@ describe('acquirePidFile', () => {
     expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
   });
 
-  it('replaces a stale PID file (owner is dead) and returns { ok: true }', async () => {
-    // Use a definitely-dead PID by spawning + awaiting exit.
+  it('replaces a stale PID file (owner is dead) and writes our pid', async () => {
     const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
     const deadPid = child.pid!;
     await new Promise<void>((resolve) => child.once('exit', () => resolve()));
-    await new Promise((r) => setTimeout(r, 50));
     writeFileSync(file, String(deadPid));
 
     expect(acquirePidFile(file)).toEqual({ ok: true });
     expect(readFileSync(file, 'utf-8').trim()).toBe(String(process.pid));
   });
 
-  it('returns { ok: false, existingPid } when a different live process owns the file', async () => {
+  it('refuses with { ok: false, existingPid } when a different live process owns the file', async () => {
     const { pid: livePid, stop } = await spawnLiveChild();
     try {
       writeFileSync(file, String(livePid));
-      const result = acquirePidFile(file);
-      expect(result).toEqual({ ok: false, existingPid: livePid });
+      expect(acquirePidFile(file)).toEqual({ ok: false, existingPid: livePid });
       // Critical: must NOT have overwritten the file. The owner's PID stays.
       expect(readFileSync(file, 'utf-8').trim()).toBe(String(livePid));
     } finally {

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -684,6 +684,24 @@ export function stateFingerprint(parts: {
 }
 
 /**
+ * A "healthy" fingerprint state means the PR is awaiting human approval, not
+ * stuck on a problem the patrol can fix. UNKNOWN mergeable is included
+ * because GitHub frequently lags the mergeability lookup; persistent UNKNOWN
+ * with passing CI is more likely a stale-cache PR than a broken one. FAIL on
+ * the rollup is unhealthy regardless of mergeability.
+ */
+export function isHealthyState(parts: {
+  mergeable?: string | null;
+  rollupConclusion?: string | null;
+  blockingCommentCount?: number | null;
+}): boolean {
+  const m = (parts.mergeable ?? '').toString().toUpperCase();
+  const r = (parts.rollupConclusion ?? '').toString().toUpperCase();
+  const c = parts.blockingCommentCount ?? 0;
+  return (m === 'MERGEABLE' || m === 'UNKNOWN') && r !== 'FAIL' && c === 0;
+}
+
+/**
  * Read the most-recent N `pr_cycle_snapshot` entries for a PR from JSONL,
  * in newest-first order. Malformed lines are skipped.
  *

--- a/crux/pr-patrol/stuck-cycle.test.ts
+++ b/crux/pr-patrol/stuck-cycle.test.ts
@@ -441,6 +441,51 @@ describe('applyStuckCycleDetection', () => {
     }
   });
 
+  it('does NOT escalate as stuck when fingerprint is MERGEABLE:PASS:0 (QUA-832)', async () => {
+    // QUA-832: A PR whose fingerprint is MERGEABLE:PASS:0 (mergeable, CI
+    // passing, no top-level blocking comments) is in a healthy state — the
+    // PR is awaiting human approval, not stuck on a problem the patrol can
+    // fix. Repeating this state across cycles should NOT push 'stuck' onto
+    // pr.issues; doing so leads to a no-op coordinator escalation that
+    // wastes cycles re-polling the same merge-ready PR.
+    const prNum = 100;
+    const healthyNode = (sha: string): GqlPrNode => makePrNode({
+      number: prNum,
+      headRefOid: sha,
+      mergeable: 'MERGEABLE',
+      // Replace the default failing rollup with a passing one so
+      // computeRollupConclusion() returns 'PASS'.
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                contexts: {
+                  nodes: [{ conclusion: 'SUCCESS', name: 'build' }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    // Run 5 consecutive cycles all with MERGEABLE:PASS:0. Even at cycle 5
+    // (well past STUCK_CYCLE_THRESHOLD = 3) the PR must NOT be flagged.
+    let last: DetectedPr | undefined;
+    for (let cycle = 1; cycle <= 5; cycle++) {
+      const detected = [makeDetectedPr({ number: prNum, issues: ['bot-review-major'] })];
+      await applyStuckCycleDetection(detected, [healthyNode(`sha${cycle}`)], file);
+      last = detected[0];
+    }
+    expect(last).toBeDefined();
+    expect(last!.issues).not.toContain('stuck');
+    // stuckCycles is still annotated (so the prompt layer can warn) but
+    // 'stuck' is the issue tag that drives escalation.
+    expect(last!.stuckCycles).toBeGreaterThanOrEqual(STUCK_CYCLE_THRESHOLD);
+    expect(last!.stuckReason).toBe('MERGEABLE:PASS:0');
+  });
+
   it('persists a pr_cycle_snapshot entry to the JSONL file each cycle', async () => {
     const prNum = 6;
     await applyStuckCycleDetection(

--- a/crux/pr-patrol/stuck-cycle.test.ts
+++ b/crux/pr-patrol/stuck-cycle.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   applyStuckCycleDetection,
   computeRollupConclusion,
+  isFingerprintHealthy,
   STUCK_CYCLE_THRESHOLD,
 } from './detection.ts';
 import type { DetectedPr, GqlPrNode } from './types.ts';
@@ -441,28 +442,56 @@ describe('applyStuckCycleDetection', () => {
     }
   });
 
-  it('does NOT escalate as stuck when fingerprint is MERGEABLE:PASS:0 (QUA-832)', async () => {
-    // QUA-832: A PR whose fingerprint is MERGEABLE:PASS:0 (mergeable, CI
-    // passing, no top-level blocking comments) is in a healthy state — the
-    // PR is awaiting human approval, not stuck on a problem the patrol can
-    // fix. Repeating this state across cycles should NOT push 'stuck' onto
-    // pr.issues; doing so leads to a no-op coordinator escalation that
-    // wastes cycles re-polling the same merge-ready PR.
+  it.each([
+    ['MERGEABLE:PASS:0',  true,  'mergeable + CI pass + no blocking comments'],
+    ['MERGEABLE:NONE:0',  true,  'mergeable + no CI configured (docs PR) + no blockers'],
+    ['UNKNOWN:PASS:0',    true,  'GitHub still computing mergeability + CI pass'],
+    ['MERGEABLE:PASS:1',  false, 'has a blocking comment'],
+    ['MERGEABLE:FAIL:0',  false, 'CI is failing'],
+    ['CONFLICTING:PASS:0', false, 'has merge conflicts'],
+    ['UNKNOWN:FAIL:0',    false, 'CI is failing even if mergeability unknown'],
+    ['MERGEABLE:PENDING:0', true, 'CI still in progress is treated as not-failing'],
+  ])('isFingerprintHealthy(%s) = %s (%s)', (fingerprint, expected, _why) => {
+    expect(isFingerprintHealthy(fingerprint)).toBe(expected);
+  });
+
+  // QUA-832: A PR in a "healthy" state (mergeable in {MERGEABLE, UNKNOWN},
+  // CI not failing, zero top-level blocking comments) is awaiting human
+  // approval, not stuck on a problem the patrol can fix. Repeating this
+  // state across cycles should NOT push 'stuck' onto pr.issues; doing so
+  // triggered a no-op coordinator escalation that wasted cycles re-polling
+  // the same merge-ready PR.
+  it.each([
+    {
+      label: 'MERGEABLE:PASS:0',
+      mergeable: 'MERGEABLE',
+      rollupContexts: [{ conclusion: 'SUCCESS', name: 'build' }],
+      expectedFingerprint: 'MERGEABLE:PASS:0',
+    },
+    {
+      label: 'MERGEABLE:NONE:0 (docs PR with no CI)',
+      mergeable: 'MERGEABLE',
+      rollupContexts: [],
+      expectedFingerprint: 'MERGEABLE:NONE:0',
+    },
+    {
+      label: 'UNKNOWN:PASS:0 (mergeability lookup racing)',
+      mergeable: 'UNKNOWN',
+      rollupContexts: [{ conclusion: 'SUCCESS', name: 'build' }],
+      expectedFingerprint: 'UNKNOWN:PASS:0',
+    },
+  ])('does NOT escalate as stuck for healthy fingerprint $label (QUA-832)', async ({ mergeable, rollupContexts, expectedFingerprint }) => {
     const prNum = 100;
     const healthyNode = (sha: string): GqlPrNode => makePrNode({
       number: prNum,
       headRefOid: sha,
-      mergeable: 'MERGEABLE',
-      // Replace the default failing rollup with a passing one so
-      // computeRollupConclusion() returns 'PASS'.
+      mergeable,
       commits: {
         nodes: [
           {
             commit: {
               statusCheckRollup: {
-                contexts: {
-                  nodes: [{ conclusion: 'SUCCESS', name: 'build' }],
-                },
+                contexts: { nodes: rollupContexts },
               },
             },
           },
@@ -470,8 +499,8 @@ describe('applyStuckCycleDetection', () => {
       },
     });
 
-    // Run 5 consecutive cycles all with MERGEABLE:PASS:0. Even at cycle 5
-    // (well past STUCK_CYCLE_THRESHOLD = 3) the PR must NOT be flagged.
+    // Run 5 consecutive cycles. Even at cycle 5 (well past
+    // STUCK_CYCLE_THRESHOLD = 3) the PR must NOT be flagged.
     let last: DetectedPr | undefined;
     for (let cycle = 1; cycle <= 5; cycle++) {
       const detected = [makeDetectedPr({ number: prNum, issues: ['bot-review-major'] })];
@@ -480,10 +509,44 @@ describe('applyStuckCycleDetection', () => {
     }
     expect(last).toBeDefined();
     expect(last!.issues).not.toContain('stuck');
-    // stuckCycles is still annotated (so the prompt layer can warn) but
-    // 'stuck' is the issue tag that drives escalation.
     expect(last!.stuckCycles).toBeGreaterThanOrEqual(STUCK_CYCLE_THRESHOLD);
-    expect(last!.stuckReason).toBe('MERGEABLE:PASS:0');
+    expect(last!.stuckReason).toBe(expectedFingerprint);
+  });
+
+  it('still escalates as stuck when fingerprint transitions from healthy to unhealthy', async () => {
+    // 3 healthy cycles followed by 3 conflicting cycles: must escalate at
+    // the 3rd conflicting cycle. Verifies the healthy-fingerprint guard
+    // doesn't somehow leak across fingerprint transitions.
+    const prNum = 101;
+
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      const detected = [makeDetectedPr({ number: prNum })];
+      await applyStuckCycleDetection(
+        detected,
+        [makePrNode({
+          number: prNum,
+          headRefOid: `sha${cycle}`,
+          mergeable: 'MERGEABLE',
+          commits: { nodes: [{ commit: { statusCheckRollup: { contexts: { nodes: [{ conclusion: 'SUCCESS', name: 'build' }] } } } }] },
+        })],
+        file,
+      );
+      expect(detected[0].issues).not.toContain('stuck');
+    }
+
+    let last: DetectedPr | undefined;
+    for (let cycle = 4; cycle <= 6; cycle++) {
+      const detected = [makeDetectedPr({ number: prNum })];
+      await applyStuckCycleDetection(
+        detected,
+        [makePrNode({ number: prNum, headRefOid: `sha${cycle}` })], // CONFLICTING:FAIL default
+        file,
+      );
+      last = detected[0];
+    }
+    expect(last).toBeDefined();
+    expect(last!.issues).toContain('stuck');
+    expect(last!.stuckReason).toBe('CONFLICTING:FAIL:0');
   });
 
   it('persists a pr_cycle_snapshot entry to the JSONL file each cycle', async () => {

--- a/crux/pr-patrol/stuck-cycle.test.ts
+++ b/crux/pr-patrol/stuck-cycle.test.ts
@@ -18,13 +18,13 @@ import {
   appendJsonl,
   appendJsonlLocked,
   countConsecutiveCycles,
+  isHealthyState,
   readRecentPrCycles,
   stateFingerprint,
 } from './state.ts';
 import {
   applyStuckCycleDetection,
   computeRollupConclusion,
-  isFingerprintHealthy,
   STUCK_CYCLE_THRESHOLD,
 } from './detection.ts';
 import type { DetectedPr, GqlPrNode } from './types.ts';
@@ -443,24 +443,21 @@ describe('applyStuckCycleDetection', () => {
   });
 
   it.each([
-    ['MERGEABLE:PASS:0',  true,  'mergeable + CI pass + no blocking comments'],
-    ['MERGEABLE:NONE:0',  true,  'mergeable + no CI configured (docs PR) + no blockers'],
-    ['UNKNOWN:PASS:0',    true,  'GitHub still computing mergeability + CI pass'],
-    ['MERGEABLE:PASS:1',  false, 'has a blocking comment'],
-    ['MERGEABLE:FAIL:0',  false, 'CI is failing'],
-    ['CONFLICTING:PASS:0', false, 'has merge conflicts'],
-    ['UNKNOWN:FAIL:0',    false, 'CI is failing even if mergeability unknown'],
-    ['MERGEABLE:PENDING:0', true, 'CI still in progress is treated as not-failing'],
-  ])('isFingerprintHealthy(%s) = %s (%s)', (fingerprint, expected, _why) => {
-    expect(isFingerprintHealthy(fingerprint)).toBe(expected);
+    { mergeable: 'MERGEABLE',  rollupConclusion: 'PASS',    blockingCommentCount: 0, expected: true,  desc: 'mergeable + CI pass + no blocking comments' },
+    { mergeable: 'MERGEABLE',  rollupConclusion: 'NONE',    blockingCommentCount: 0, expected: true,  desc: 'mergeable + no CI configured (docs PR) + no blockers' },
+    { mergeable: 'UNKNOWN',    rollupConclusion: 'PASS',    blockingCommentCount: 0, expected: true,  desc: 'GitHub still computing mergeability + CI pass' },
+    { mergeable: 'MERGEABLE',  rollupConclusion: 'PENDING', blockingCommentCount: 0, expected: true,  desc: 'CI still in progress is treated as not-failing' },
+    { mergeable: 'MERGEABLE',  rollupConclusion: 'PASS',    blockingCommentCount: 1, expected: false, desc: 'has a blocking comment' },
+    { mergeable: 'MERGEABLE',  rollupConclusion: 'FAIL',    blockingCommentCount: 0, expected: false, desc: 'CI is failing' },
+    { mergeable: 'CONFLICTING', rollupConclusion: 'PASS',   blockingCommentCount: 0, expected: false, desc: 'has merge conflicts' },
+    { mergeable: 'UNKNOWN',    rollupConclusion: 'FAIL',    blockingCommentCount: 0, expected: false, desc: 'CI is failing even if mergeability unknown' },
+  ])('isHealthyState($desc) = $expected', ({ mergeable, rollupConclusion, blockingCommentCount, expected }) => {
+    expect(isHealthyState({ mergeable, rollupConclusion, blockingCommentCount })).toBe(expected);
   });
 
-  // QUA-832: A PR in a "healthy" state (mergeable in {MERGEABLE, UNKNOWN},
-  // CI not failing, zero top-level blocking comments) is awaiting human
-  // approval, not stuck on a problem the patrol can fix. Repeating this
-  // state across cycles should NOT push 'stuck' onto pr.issues; doing so
-  // triggered a no-op coordinator escalation that wasted cycles re-polling
-  // the same merge-ready PR.
+  // A PR in a "healthy" state (mergeable in {MERGEABLE, UNKNOWN}, CI not
+  // failing, zero top-level blocking comments) is awaiting human approval,
+  // not stuck on a problem the patrol can fix.
   it.each([
     {
       label: 'MERGEABLE:PASS:0',
@@ -480,7 +477,7 @@ describe('applyStuckCycleDetection', () => {
       rollupContexts: [{ conclusion: 'SUCCESS', name: 'build' }],
       expectedFingerprint: 'UNKNOWN:PASS:0',
     },
-  ])('does NOT escalate as stuck for healthy fingerprint $label (QUA-832)', async ({ mergeable, rollupContexts, expectedFingerprint }) => {
+  ])('does NOT escalate as stuck for healthy fingerprint $label', async ({ mergeable, rollupContexts, expectedFingerprint }) => {
     const prNum = 100;
     const healthyNode = (sha: string): GqlPrNode => makePrNode({
       number: prNum,
@@ -499,18 +496,18 @@ describe('applyStuckCycleDetection', () => {
       },
     });
 
-    // Run 5 consecutive cycles. Even at cycle 5 (well past
-    // STUCK_CYCLE_THRESHOLD = 3) the PR must NOT be flagged.
-    let last: DetectedPr | undefined;
+    // Run 5 consecutive cycles. EVERY cycle must not escalate, not just
+    // the last one — a transient flip at cycle 3 followed by an unflip
+    // at cycle 4 would otherwise pass.
     for (let cycle = 1; cycle <= 5; cycle++) {
       const detected = [makeDetectedPr({ number: prNum, issues: ['bot-review-major'] })];
       await applyStuckCycleDetection(detected, [healthyNode(`sha${cycle}`)], file);
-      last = detected[0];
+      expect(detected[0].issues, `cycle ${cycle}`).not.toContain('stuck');
+      if (cycle >= STUCK_CYCLE_THRESHOLD) {
+        expect(detected[0].stuckCycles, `cycle ${cycle}`).toBeGreaterThanOrEqual(STUCK_CYCLE_THRESHOLD);
+        expect(detected[0].stuckReason, `cycle ${cycle}`).toBe(expectedFingerprint);
+      }
     }
-    expect(last).toBeDefined();
-    expect(last!.issues).not.toContain('stuck');
-    expect(last!.stuckCycles).toBeGreaterThanOrEqual(STUCK_CYCLE_THRESHOLD);
-    expect(last!.stuckReason).toBe(expectedFingerprint);
   });
 
   it('still escalates as stuck when fingerprint transitions from healthy to unhealthy', async () => {


### PR DESCRIPTION
## Summary

Two PR-patrol bugs fixed in the same subsystem:

**QUA-832 — MERGEABLE+PASS PRs no longer escalated as 'stuck'.** A PR in a healthy "merge-ready" state (mergeable + CI not failing + zero blocking comments) is awaiting human approval, not stuck on a problem the patrol can fix. The stuck-cycle detector previously flagged these after 3 cycles and the executor escalated them with a no-op coordinator comment, wasting cycles re-polling. Now the detector skips the `stuck` tag for any healthy state — `MERGEABLE:PASS:0`, `MERGEABLE:NONE:0` (docs PRs), and `UNKNOWN:PASS:0` (GitHub racing the mergeability lookup) all qualify. The existing `hasExceededMaxAttempts` guard still catches dispatch churn on residual soft issues like bot-review-major. Healthy-state PRs log `awaiting human approval` instead of `escalating`.

**QUA-835 — `runDaemon` enforces single-instance.** Previously, a second `pr-patrol run` invocation silently overwrote the PID file and ran a parallel loop with its own cycle counter — visible in production as cycle 219 → cycle 1 resets while the original daemon was still active. New `acquirePidFile()` uses `flag: 'wx'` (O_EXCL) for atomic claim, with a bounded retry that reclaims a stale PID file (dead owner). Returns `{ ok: true }` only after the PID has been persisted to disk — never lies about acquisition. `once` mode intentionally skips the check so debugging via single-cycle runs alongside a daemon stays usable.

## Key changes

- `crux/pr-patrol/state.ts` — new `isHealthyState()` predicate next to `stateFingerprint()`
- `crux/pr-patrol/detection.ts` — stuck-cycle detector skips escalation for healthy states
- `crux/pr-patrol/index.ts` — `acquirePidFile()` replaces non-atomic `writePidFile()`; `runDaemon` calls it before continuous-mode startup; PID-file management hardened (logs non-ENOENT errors, removed dead `checkSingletonDaemon` wrapper)
- Tests: 16 new (8 truth-table cases for `isHealthyState`, 5 for `acquirePidFile`, 5 for `getDaemonPid`, 3 fingerprint-driven `applyStuckCycleDetection` cases, 1 healthy→unhealthy transition). All 455 pr-patrol tests pass.

## Test plan

- [x] Unit: 8 truth-table cases for `isHealthyState` (mergeable/conclusion/blocker truth table)
- [x] Unit: per-cycle assertions for 3 healthy fingerprints across 5 cycles each (catches transient flips)
- [x] Unit: healthy → unhealthy transition still escalates correctly (no leak across fingerprint changes)
- [x] Unit: `acquirePidFile` happy path (empty file), stale reclamation, live-owner refusal, idempotent re-entry, malformed file
- [x] Unit: `getDaemonPid` for missing/dead/live/self/malformed PID files
- [x] Adversarial: empty + multi-line + whitespace + non-numeric PID file inputs
- [x] CLI smoke: `crux gh pr-patrol status` and `--help` still work
- [x] Local gate (`pnpm crux w validate gate --fix`) — all 57 checks pass
- [x] CI green (PR #4701, run 25138792979 — all 58 checks pass)

Fixes QUA-832


Fixes QUA-835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed false "stuck PR" detection for pull requests awaiting human approval.
  * Improved daemon initialization to prevent duplicate running instances with clearer error messages when conflicts occur.

* **Improvements**
  * Enhanced pull request state evaluation logic for more accurate stuck cycle detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
