### PR TITLE
QUA-700: gate validator for workflow secret references

### DIFF
--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -347,6 +347,20 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-700: catches `${{ secrets.X }}` references in workflow YAMLs that
+    // don't resolve to a real repo or org-inherited secret (the QUA-676
+    // root cause). Advisory because (a) forks/local environments lack gh
+    // auth — the validator fails open in that case anyway — and (b) at
+    // ship time there are 17 pre-existing pending references being tracked
+    // for cleanup. Flip to blocking once the existing list is at zero.
+    id: 'workflow-secrets',
+    name: 'Workflow secret references resolve',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-workflow-secrets.ts'],
+    cwd: PROJECT_ROOT,
+    advisory: true,
+  },
+  {
     // QUA-388: ESLint with @typescript-eslint/no-floating-promises.
     // Blocking. Catches unhandled-promise patterns that ranked highest
     // in the PR-review survey (~18% of findings). Each future rule

--- a/crux/validate/validate-workflow-secrets.test.ts
+++ b/crux/validate/validate-workflow-secrets.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { findSecretRefs, findMissingSecrets } from './validate-workflow-secrets.ts';
+import {
+  findSecretRefs,
+  findMissingSecrets,
+  parseInheritedAllowlist,
+} from './validate-workflow-secrets.ts';
 
 describe('validate-workflow-secrets', () => {
   describe('findSecretRefs', () => {
@@ -113,6 +117,42 @@ describe('validate-workflow-secrets', () => {
       const refs = [{ file: 'a.yml', line: 1, name: 'FOO' }];
       const missing = findMissingSecrets(refs, new Set(['foo']));
       expect(missing).toEqual(refs);
+    });
+  });
+
+  describe('parseInheritedAllowlist', () => {
+    it('returns empty set for undefined', () => {
+      expect(parseInheritedAllowlist(undefined)).toEqual(new Set());
+    });
+
+    it('returns empty set for empty string', () => {
+      expect(parseInheritedAllowlist('')).toEqual(new Set());
+    });
+
+    it('parses a single name', () => {
+      expect(parseInheritedAllowlist('FOO')).toEqual(new Set(['FOO']));
+    });
+
+    it('parses comma-separated names with whitespace', () => {
+      expect(parseInheritedAllowlist('FOO, BAR ,BAZ')).toEqual(
+        new Set(['FOO', 'BAR', 'BAZ']),
+      );
+    });
+
+    it('drops lowercase entries (GitHub secret names are uppercase)', () => {
+      expect(parseInheritedAllowlist('FOO,bar,Baz')).toEqual(new Set(['FOO']));
+    });
+
+    it('drops entries with disallowed characters', () => {
+      expect(parseInheritedAllowlist('FOO,BAR-X,BAZ.Y,QUX')).toEqual(
+        new Set(['FOO', 'QUX']),
+      );
+    });
+
+    it('accepts digits and underscores', () => {
+      expect(parseInheritedAllowlist('FOO_2,BAR_API_KEY')).toEqual(
+        new Set(['FOO_2', 'BAR_API_KEY']),
+      );
     });
   });
 });

--- a/crux/validate/validate-workflow-secrets.test.ts
+++ b/crux/validate/validate-workflow-secrets.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { findSecretRefs, findMissingSecrets } from './validate-workflow-secrets.ts';
+
+describe('validate-workflow-secrets', () => {
+  describe('findSecretRefs', () => {
+    it('extracts a simple secret reference with line number', () => {
+      const refs = findSecretRefs([
+        {
+          path: '.github/workflows/foo.yml',
+          content: 'jobs:\n  run:\n    env:\n      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}\n',
+        },
+      ]);
+      expect(refs).toEqual([
+        { file: '.github/workflows/foo.yml', line: 4, name: 'LINEAR_API_KEY' },
+      ]);
+    });
+
+    it('extracts multiple references on the same line', () => {
+      const refs = findSecretRefs([
+        {
+          path: 'a.yml',
+          content: 'foo: ${{ secrets.A }} bar: ${{ secrets.B }}\n',
+        },
+      ]);
+      expect(refs.map((r) => r.name)).toEqual(['A', 'B']);
+      expect(refs.every((r) => r.line === 1)).toBe(true);
+    });
+
+    it('extracts references across multiple files', () => {
+      const refs = findSecretRefs([
+        { path: 'a.yml', content: '${{ secrets.A }}\n' },
+        { path: 'b.yml', content: '${{ secrets.B }}\n' },
+      ]);
+      expect(refs).toHaveLength(2);
+      expect(refs.find((r) => r.name === 'A')?.file).toBe('a.yml');
+      expect(refs.find((r) => r.name === 'B')?.file).toBe('b.yml');
+    });
+
+    it('excludes secrets.GITHUB_TOKEN (auto-provided)', () => {
+      const refs = findSecretRefs([
+        {
+          path: 'a.yml',
+          content: 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\nLINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}\n',
+        },
+      ]);
+      expect(refs.map((r) => r.name)).toEqual(['LINEAR_API_KEY']);
+    });
+
+    it('tolerates whitespace inside the expression', () => {
+      const refs = findSecretRefs([
+        { path: 'a.yml', content: '${{secrets.NO_SPACE}}\n${{    secrets.LOTS_OF_SPACE   }}\n' },
+      ]);
+      expect(refs.map((r) => r.name)).toEqual(['NO_SPACE', 'LOTS_OF_SPACE']);
+    });
+
+    it('does not match other expression contexts (e.g. env., vars., inputs.)', () => {
+      const refs = findSecretRefs([
+        {
+          path: 'a.yml',
+          content: '${{ env.FOO }}\n${{ vars.BAR }}\n${{ inputs.BAZ }}\n${{ secrets.QUX }}\n',
+        },
+      ]);
+      expect(refs.map((r) => r.name)).toEqual(['QUX']);
+    });
+
+    it('returns empty array for files with no secret refs', () => {
+      const refs = findSecretRefs([{ path: 'a.yml', content: 'name: hello\non: push\n' }]);
+      expect(refs).toEqual([]);
+    });
+
+    it('returns empty array for empty file list', () => {
+      expect(findSecretRefs([])).toEqual([]);
+    });
+  });
+
+  describe('findMissingSecrets', () => {
+    it('reports a ref whose secret is not in the known set', () => {
+      const refs = [{ file: 'a.yml', line: 1, name: 'MISSING' }];
+      const missing = findMissingSecrets(refs, new Set(['EXISTS']));
+      expect(missing).toEqual(refs);
+    });
+
+    it('accepts a ref whose secret is in the known set', () => {
+      const refs = [{ file: 'a.yml', line: 1, name: 'EXISTS' }];
+      const missing = findMissingSecrets(refs, new Set(['EXISTS']));
+      expect(missing).toEqual([]);
+    });
+
+    it('returns only the missing subset when some refs resolve', () => {
+      const refs = [
+        { file: 'a.yml', line: 1, name: 'OK' },
+        { file: 'a.yml', line: 2, name: 'MISSING1' },
+        { file: 'b.yml', line: 5, name: 'OK' },
+        { file: 'b.yml', line: 9, name: 'MISSING2' },
+      ];
+      const missing = findMissingSecrets(refs, new Set(['OK']));
+      expect(missing.map((r) => r.name)).toEqual(['MISSING1', 'MISSING2']);
+    });
+
+    it('returns empty when known set is empty and refs is empty', () => {
+      expect(findMissingSecrets([], new Set())).toEqual([]);
+    });
+
+    it('reports all refs as missing when known set is empty', () => {
+      const refs = [
+        { file: 'a.yml', line: 1, name: 'A' },
+        { file: 'a.yml', line: 2, name: 'B' },
+      ];
+      expect(findMissingSecrets(refs, new Set())).toEqual(refs);
+    });
+
+    it('treats secret names case-sensitively (GitHub secrets are uppercase)', () => {
+      const refs = [{ file: 'a.yml', line: 1, name: 'FOO' }];
+      const missing = findMissingSecrets(refs, new Set(['foo']));
+      expect(missing).toEqual(refs);
+    });
+  });
+});

--- a/crux/validate/validate-workflow-secrets.ts
+++ b/crux/validate/validate-workflow-secrets.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that every `${{ secrets.NAME }}` reference in .github/workflows/*.yml
+ * resolves to a real GitHub secret (repo-level or org-inherited).
+ *
+ * Background: QUA-676 (PR #4581). PR #4559 plumbed
+ * `LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}` into three workflows, but
+ * the repo secret `LINEAR_API_KEY` did not exist. The reference silently
+ * resolved to empty string for 4 days, which broke Linear-side dedup and
+ * caused a duplicate-issue cascade.
+ *
+ * A YAML reference to a non-existent secret is silently truthy at parse
+ * time and produces no signal anywhere — until something downstream notices
+ * the value is empty (often days later).
+ *
+ * Usage: npx tsx crux/validate/validate-workflow-secrets.ts
+ *
+ * Fail-open conditions (exit 0 with a warning):
+ *   - `gh` CLI not installed
+ *   - `gh` not authenticated
+ *   - `gh secret list` returns a network/permission error
+ *
+ * These are the same fail-open shape as `assign-ids` and other gate steps
+ * that depend on external services. The CI environment runs with
+ * GITHUB_TOKEN and full secret-list permission, so the check is effective
+ * there; local/fork environments without auth get an advisory pass.
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, readdirSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const WORKFLOWS_DIR = join(PROJECT_ROOT, '.github/workflows');
+
+/**
+ * Secrets that are auto-provided by GitHub Actions and never need to be
+ * configured manually. Excluding them from the check.
+ */
+const AUTO_PROVIDED_SECRETS = new Set<string>([
+  'GITHUB_TOKEN',
+]);
+
+/** Regex matches `${{ secrets.NAME }}` with optional whitespace. */
+const SECRET_REF_RE = /\$\{\{\s*secrets\.([A-Z0-9_]+)\s*\}\}/g;
+
+export interface SecretRef {
+  /** Workflow file path relative to PROJECT_ROOT. */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  /** Secret name (e.g. "LINEAR_API_KEY"). */
+  name: string;
+}
+
+export interface CheckResult {
+  passed: boolean;
+  errors: number;
+  violations: SecretRef[];
+  /** Whether the check ran (false = fail-open, gh unavailable). */
+  checked: boolean;
+  /** Human-readable reason when checked=false. */
+  skipReason?: string;
+}
+
+/**
+ * Pure function: scan workflow file contents for secrets references.
+ * Exported for testing.
+ */
+export function findSecretRefs(
+  files: Array<{ path: string; content: string }>,
+): SecretRef[] {
+  const refs: SecretRef[] = [];
+  for (const { path, content } of files) {
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Reset lastIndex for global regex on each line.
+      SECRET_REF_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = SECRET_REF_RE.exec(line)) !== null) {
+        const name = m[1];
+        if (AUTO_PROVIDED_SECRETS.has(name)) continue;
+        refs.push({ file: path, line: i + 1, name });
+      }
+    }
+  }
+  return refs;
+}
+
+/**
+ * Pure function: given a set of refs and the set of known-good secret
+ * names, return the refs that don't resolve.
+ * Exported for testing.
+ */
+export function findMissingSecrets(
+  refs: SecretRef[],
+  knownSecrets: Set<string>,
+): SecretRef[] {
+  return refs.filter((r) => !knownSecrets.has(r.name));
+}
+
+function readWorkflowFiles(): Array<{ path: string; content: string }> {
+  let entries: string[];
+  try {
+    entries = readdirSync(WORKFLOWS_DIR);
+  } catch {
+    return [];
+  }
+  const out: Array<{ path: string; content: string }> = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.yml') && !entry.endsWith('.yaml')) continue;
+    const full = join(WORKFLOWS_DIR, entry);
+    let content: string;
+    try {
+      content = readFileSync(full, 'utf-8');
+    } catch {
+      continue;
+    }
+    out.push({ path: relative(PROJECT_ROOT, full), content });
+  }
+  return out;
+}
+
+/**
+ * Read repo + inherited secret names via `gh secret list`. Returns null on
+ * any error (fail-open).
+ */
+function fetchKnownSecrets(repo: string): { secrets: Set<string>; reason?: string } | null {
+  // Runs `gh secret list` once for repo-scoped secrets and once with
+  // --include-inherited for org-level. The union is what the workflows
+  // actually see at runtime.
+  const sets: Set<string> = new Set();
+  for (const args of [
+    ['secret', 'list', '-R', repo, '--json', 'name'],
+    ['secret', 'list', '-R', repo, '--include-inherited', '--json', 'name'],
+  ]) {
+    let raw: string;
+    try {
+      raw = execSync(`gh ${args.map((a) => `'${a}'`).join(' ')}`, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      // --include-inherited may not be supported on older gh versions, or
+      // the user/CI may lack org-level read. Fall through if the
+      // repo-scoped call already gave us names.
+      if (sets.size > 0) continue;
+      const msg = err instanceof Error ? err.message : String(err);
+      return { secrets: sets, reason: `gh secret list failed: ${msg.split('\n')[0]}` };
+    }
+    let parsed: Array<{ name: string }>;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    for (const item of parsed) {
+      if (item && typeof item.name === 'string') sets.add(item.name);
+    }
+  }
+  return { secrets: sets };
+}
+
+function ghAvailable(): { ok: boolean; reason?: string } {
+  try {
+    execSync('gh --version', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch {
+    return { ok: false, reason: 'gh CLI not installed' };
+  }
+  try {
+    execSync('gh auth status', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch {
+    return { ok: false, reason: 'gh CLI not authenticated' };
+  }
+  return { ok: true };
+}
+
+const DEFAULT_REPO = 'quantified-uncertainty/longterm-wiki';
+
+export function runCheck(opts: { repo?: string } = {}): CheckResult {
+  const c = getColors();
+  const repo = opts.repo ?? DEFAULT_REPO;
+
+  console.log(`${c.blue}Checking workflow secret references against ${repo}...${c.reset}\n`);
+
+  const files = readWorkflowFiles();
+  if (files.length === 0) {
+    console.log(`${c.dim}No workflow files found.${c.reset}`);
+    return { passed: true, errors: 0, violations: [], checked: true };
+  }
+
+  const refs = findSecretRefs(files);
+  if (refs.length === 0) {
+    console.log(`${c.dim}No secret references found in ${files.length} workflow(s).${c.reset}`);
+    return { passed: true, errors: 0, violations: [], checked: true };
+  }
+
+  const gh = ghAvailable();
+  if (!gh.ok) {
+    console.log(`${c.yellow}⚠ Skipping: ${gh.reason}.${c.reset}`);
+    console.log(`${c.dim}  This check needs gh CLI auth to read the repo secret list.${c.reset}`);
+    return { passed: true, errors: 0, violations: [], checked: false, skipReason: gh.reason };
+  }
+
+  const fetched = fetchKnownSecrets(repo);
+  if (!fetched) {
+    console.log(`${c.yellow}⚠ Skipping: gh secret list unavailable.${c.reset}`);
+    return {
+      passed: true,
+      errors: 0,
+      violations: [],
+      checked: false,
+      skipReason: 'gh secret list unavailable',
+    };
+  }
+
+  const missing = findMissingSecrets(refs, fetched.secrets);
+
+  if (missing.length === 0) {
+    console.log(
+      `${c.green}All ${refs.length} secret reference(s) resolve to a known secret (${fetched.secrets.size} secrets visible).${c.reset}`,
+    );
+    return { passed: true, errors: 0, violations: [], checked: true };
+  }
+
+  console.log(`${c.red}Found ${missing.length} workflow secret reference(s) with no matching repo/inherited secret:${c.reset}\n`);
+  // Group by secret name for readability.
+  const byName = new Map<string, SecretRef[]>();
+  for (const r of missing) {
+    const arr = byName.get(r.name) ?? [];
+    arr.push(r);
+    byName.set(r.name, arr);
+  }
+  for (const [name, occurrences] of [...byName.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(`  ${c.red}secrets.${name}${c.reset} (${occurrences.length} reference${occurrences.length === 1 ? '' : 's'})`);
+    for (const r of occurrences) {
+      console.log(`    ${c.dim}${r.file}:${r.line}${c.reset}`);
+    }
+  }
+  console.log(`\n${c.dim}Fix: add the secret with \`gh secret set <NAME> -R ${repo}\`,`);
+  console.log(`     or remove the reference from the workflow if it's no longer needed.${c.reset}`);
+
+  return { passed: false, errors: missing.length, violations: missing, checked: true };
+}
+
+if (process.argv[1]?.includes('validate-workflow-secrets')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-workflow-secrets.ts
+++ b/crux/validate/validate-workflow-secrets.ts
@@ -34,7 +34,7 @@
  * get an advisory pass.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { readFileSync, readdirSync } from 'fs';
 import { join, relative } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
@@ -145,7 +145,7 @@ function readWorkflowFiles(): Array<{ path: string; content: string }> {
 function fetchKnownSecrets(repo: string): Set<string> | null {
   let raw: string;
   try {
-    raw = execSync(`gh secret list -R '${repo}' --json name`, {
+    raw = execFileSync('gh', ['secret', 'list', '-R', repo, '--json', 'name'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/crux/validate/validate-workflow-secrets.ts
+++ b/crux/validate/validate-workflow-secrets.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Validate that every `${{ secrets.NAME }}` reference in .github/workflows/*.yml
- * resolves to a real GitHub secret (repo-level or org-inherited).
+ * Validate that every `${{ secrets.NAME }}` reference in
+ * .github/workflows/*.yml resolves to a real GitHub repo secret (or to
+ * an explicitly allowlisted org-inherited secret).
  *
  * Background: QUA-676 (PR #4581). PR #4559 plumbed
  * `LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}` into three workflows, but
@@ -16,15 +17,21 @@
  *
  * Usage: npx tsx crux/validate/validate-workflow-secrets.ts
  *
+ * Org-inherited secrets (those not visible to `gh secret list` from repo
+ * scope) can be allowlisted via the `KNOWN_INHERITED_SECRETS` env var:
+ *
+ *   KNOWN_INHERITED_SECRETS=OPENROUTER_API_KEY,EXA_API_KEY \
+ *     npx tsx crux/validate/validate-workflow-secrets.ts
+ *
  * Fail-open conditions (exit 0 with a warning):
  *   - `gh` CLI not installed
  *   - `gh` not authenticated
  *   - `gh secret list` returns a network/permission error
  *
- * These are the same fail-open shape as `assign-ids` and other gate steps
- * that depend on external services. The CI environment runs with
- * GITHUB_TOKEN and full secret-list permission, so the check is effective
- * there; local/fork environments without auth get an advisory pass.
+ * These match `assign-ids` and other gate steps that depend on external
+ * services. CI runs with GITHUB_TOKEN + full secret-list permission so
+ * the check is effective there; local/fork environments without auth
+ * get an advisory pass.
  */
 
 import { execSync } from 'child_process';
@@ -125,43 +132,64 @@ function readWorkflowFiles(): Array<{ path: string; content: string }> {
 }
 
 /**
- * Read repo + inherited secret names via `gh secret list`. Returns null on
- * any error (fail-open).
+ * Read repo-level secret names via `gh secret list`. Returns null on
+ * error (the caller treats null as fail-open).
+ *
+ * Note: `gh secret list` only enumerates repo-scoped secrets. Org-inherited
+ * secrets visible to a workflow are NOT returned here (the CLI has no
+ * `--include-inherited` flag for `secret list`). For the longterm-wiki
+ * org there are currently zero org-level Action secrets configured —
+ * verified via `gh api repos/.../actions/organization-secrets`. If that
+ * changes, pass an allowlist via `KNOWN_INHERITED_SECRETS=A,B,C` env var.
  */
-function fetchKnownSecrets(repo: string): { secrets: Set<string>; reason?: string } | null {
-  // Runs `gh secret list` once for repo-scoped secrets and once with
-  // --include-inherited for org-level. The union is what the workflows
-  // actually see at runtime.
-  const sets: Set<string> = new Set();
-  for (const args of [
-    ['secret', 'list', '-R', repo, '--json', 'name'],
-    ['secret', 'list', '-R', repo, '--include-inherited', '--json', 'name'],
-  ]) {
-    let raw: string;
-    try {
-      raw = execSync(`gh ${args.map((a) => `'${a}'`).join(' ')}`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-    } catch (err) {
-      // --include-inherited may not be supported on older gh versions, or
-      // the user/CI may lack org-level read. Fall through if the
-      // repo-scoped call already gave us names.
-      if (sets.size > 0) continue;
-      const msg = err instanceof Error ? err.message : String(err);
-      return { secrets: sets, reason: `gh secret list failed: ${msg.split('\n')[0]}` };
-    }
-    let parsed: Array<{ name: string }>;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      continue;
-    }
-    for (const item of parsed) {
-      if (item && typeof item.name === 'string') sets.add(item.name);
+function fetchKnownSecrets(repo: string): Set<string> | null {
+  let raw: string;
+  try {
+    raw = execSync(`gh secret list -R '${repo}' --json name`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const secrets = new Set<string>();
+  for (const item of parsed) {
+    if (
+      item != null &&
+      typeof item === 'object' &&
+      'name' in item &&
+      typeof (item as { name: unknown }).name === 'string'
+    ) {
+      secrets.add((item as { name: string }).name);
     }
   }
-  return { secrets: sets };
+  return secrets;
+}
+
+/**
+ * Parse a comma-separated allowlist of inherited secret names. Empty,
+ * whitespace-only, and lowercase entries are dropped. Exported for
+ * testing.
+ */
+export function parseInheritedAllowlist(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => /^[A-Z0-9_]+$/.test(s)),
+  );
+}
+
+function readInheritedAllowlist(): Set<string> {
+  return parseInheritedAllowlist(process.env.KNOWN_INHERITED_SECRETS);
 }
 
 function ghAvailable(): { ok: boolean; reason?: string } {
@@ -205,9 +233,9 @@ export function runCheck(opts: { repo?: string } = {}): CheckResult {
     return { passed: true, errors: 0, violations: [], checked: false, skipReason: gh.reason };
   }
 
-  const fetched = fetchKnownSecrets(repo);
-  if (!fetched) {
-    console.log(`${c.yellow}⚠ Skipping: gh secret list unavailable.${c.reset}`);
+  const repoSecrets = fetchKnownSecrets(repo);
+  if (!repoSecrets) {
+    console.log(`${c.yellow}⚠ Skipping: gh secret list unavailable (no auth or API error).${c.reset}`);
     return {
       passed: true,
       errors: 0,
@@ -217,11 +245,13 @@ export function runCheck(opts: { repo?: string } = {}): CheckResult {
     };
   }
 
-  const missing = findMissingSecrets(refs, fetched.secrets);
+  const inherited = readInheritedAllowlist();
+  const known = new Set<string>([...repoSecrets, ...inherited]);
+  const missing = findMissingSecrets(refs, known);
 
   if (missing.length === 0) {
     console.log(
-      `${c.green}All ${refs.length} secret reference(s) resolve to a known secret (${fetched.secrets.size} secrets visible).${c.reset}`,
+      `${c.green}All ${refs.length} secret reference(s) resolve (${repoSecrets.size} repo + ${inherited.size} inherited).${c.reset}`,
     );
     return { passed: true, errors: 0, violations: [], checked: true };
   }


### PR DESCRIPTION
## Summary

Closes QUA-700.

Adds `crux/validate/validate-workflow-secrets.ts` — a gate validator that catches the QUA-676 root cause: a workflow YAML references `${{ secrets.X }}` but the secret doesn't exist, so the env var resolves to empty string at runtime and breaks the consumer days later with no signal at parse time.

The validator scans `.github/workflows/*.yml` for every `${{ secrets.NAME }}` (excluding `GITHUB_TOKEN`, which is auto-provided), cross-checks against `gh secret list`, and reports unresolved references.

## Wired as advisory, not blocking

There are **17 pre-existing unresolved references** in the workflows today (10 distinct secret names). I'd have liked to ship this blocking, but each violation needs a per-workflow decision (add the secret vs remove the reference) and that's out of scope for the validator PR. Filed QUA-855 to clean them up; flip to blocking once that count reaches zero.

Until then, the gate will surface the count in its advisory section every run, so the debt stays visible.

## Live findings (as of 2026-04-29)

| Secret | Refs | Workflows |
|---|---|---|
| `OPENROUTER_API_KEY` | 4 | auto-update.yml, auto-update-review-gate.yml, flagship-curate.yml, job-worker.yml |
| `EXA_API_KEY` | 3 | auto-update.yml, auto-update-review-gate.yml, job-worker.yml |
| `FIRECRAWL_KEY` | 2 | auto-update.yml, job-worker.yml |
| `SCRY_API_KEY` | 2 | auto-update.yml, job-worker.yml |
| `AWS_ACCESS_KEY_ID` | 1 | database-backup.yml |
| `AWS_SECRET_ACCESS_KEY` | 1 | database-backup.yml |
| `BACKUP_S3_BUCKET` | 1 | database-backup.yml |
| `DISCORD_FRAMEWORK_WEBHOOK_URL` | 1 | refresh-frameworks.yml |
| `DISCORD_WEBHOOK_URL` | 1 | refresh-frameworks.yml |
| `WIKI_PUBLIC_URL` | 1 | frontend-data-health.yml |

These are real latent QUA-676s — auto-update.yml is paused, but auto-update-review-gate.yml, job-worker.yml, and flagship-curate.yml are active.

## Org-inherited secrets

`gh secret list` only enumerates repo-scoped secrets. Verified via `gh api repos/.../actions/organization-secrets` that this org currently has **zero** org-level Action secrets, so a repo-scoped check is sufficient. For the case org secrets are introduced later, the validator accepts a `KNOWN_INHERITED_SECRETS=A,B,C` env var allowlist.

## Fail-open conditions

The validator returns a "skipping" advisory pass when:
- `gh` CLI is not installed
- `gh` is not authenticated
- `gh secret list` returns a network or permission error

Same shape as `assign-ids` and other gate steps that depend on external services. CI runs with `GITHUB_TOKEN` and full `secret-list` permission so the check is effective there; local/fork environments without auth get advisory pass.

## Test plan

- [x] `npx vitest run crux/validate/validate-workflow-secrets.test.ts` — 21/21 pass
- [x] Standalone run: `npx tsx crux/validate/validate-workflow-secrets.ts` — finds 17 violations, exits 1
- [x] Allowlist run: `KNOWN_INHERITED_SECRETS=EXA_API_KEY,OPENROUTER_API_KEY,FIRECRAWL_KEY,SCRY_API_KEY npx tsx ...` — 17 → 6, exits 1
- [x] `pnpm crux w validate gate --no-cache --no-triage` — new check appears in parallel run, fails advisory, total gate exits 0
- [x] Adversarial inputs: empty file list, no secret refs, multiple refs per line, whitespace variants, `env.X`/`vars.X`/`inputs.X` not matched, lowercase allowlist entries dropped

## Not in scope

- Fixing the 17 existing violations — tracked as QUA-855 (each needs a per-workflow decision).
- The companion process rule "verify the secret exists end-to-end when you plumb an env var" — tracked as QUA-701 (docs-only, separate small PR).

## Deploy notes

`pnpm crux gh deploy-tasks detect` flags `KNOWN_INHERITED_SECRETS` as a new env var. False positive — it's an optional allowlist read by the validator at gate-time, not a runtime production env var. Nothing needs to be set in production.
