### PR TITLE
QUA-851: add --where-no-verdict to crux fb sourcing

### DIFF
--- a/crux/commands/factbase-sourcing.test.ts
+++ b/crux/commands/factbase-sourcing.test.ts
@@ -219,11 +219,9 @@ describe('crux fb sourcing --dry-run', () => {
 
   it('--where-no-verdict --fact=X bypasses the filter (explicit fact lookup)', async () => {
     const factId = 'f_dW5cR9mJ8q';
-    // Even if the fact's ID is in the verified set, --fact=X should still find it.
-    mockFetchVerdictRecordIds.mockResolvedValueOnce({
-      ok: true,
-      data: new Set([factId]),
-    });
+    // --fact=X skips the verdict fetch entirely so single-fact lookups remain
+    // self-contained and don't fail-close on an unrelated wiki-server outage.
+    mockFetchVerdictRecordIds.mockClear();
 
     const result = await sourcing([], {
       fact: factId,
@@ -232,6 +230,7 @@ describe('crux fb sourcing --dry-run', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('1 fact(s)');
+    expect(mockFetchVerdictRecordIds).not.toHaveBeenCalled();
   });
 
   it('--where-no-verdict applied to all-entities branch (no entity/fact filter)', async () => {

--- a/crux/commands/factbase-sourcing.test.ts
+++ b/crux/commands/factbase-sourcing.test.ts
@@ -24,6 +24,20 @@ vi.mock('../lib/sourcing/verdict-handler.ts', () => ({
   storeAggregateVerdict: (...args: unknown[]) => mockStoreAggregateVerdict(...args),
 }));
 
+// QUA-851: mock fetchVerdictRecordIds so --where-no-verdict tests don't hit
+// the wiki-server. The default returns an empty set (no verdicts yet).
+const mockFetchVerdictRecordIds = vi.fn<
+  (...args: unknown[]) => Promise<{ ok: true; data: Set<string> } | { ok: false; error: string; message: string }>
+>(async () => ({ ok: true, data: new Set<string>() }));
+
+vi.mock('../lib/wiki-server/sourcing-client.ts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    fetchVerdictRecordIds: (...args: unknown[]) => mockFetchVerdictRecordIds(...args),
+  };
+});
+
 describe('crux fb sourcing --dry-run', () => {
   it('lists facts to verify for a specific entity', async () => {
     const result = await sourcing([], {
@@ -121,6 +135,80 @@ describe('crux fb sourcing --dry-run', () => {
       expect(fact.source).toBeTruthy();
       expect(fact.source).toMatch(/^https?:\/\//);
     }
+  });
+
+  it('--where-no-verdict skips facts whose IDs are in the verdict set (QUA-851)', async () => {
+    // Get the full list of fact IDs first, no filter
+    const baseline = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+    });
+    expect(baseline.exitCode).toBe(0);
+    const baselineFacts = JSON.parse(baseline.output) as Array<{ factId: string }>;
+    expect(baselineFacts.length).toBeGreaterThan(1);
+
+    // Mark the first one as already-verified; it should be skipped
+    const skipId = baselineFacts[0].factId;
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: true,
+      data: new Set([skipId]),
+    });
+
+    const result = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+      'where-no-verdict': true,
+    });
+    expect(result.exitCode).toBe(0);
+    const filteredFacts = JSON.parse(result.output) as Array<{ factId: string }>;
+    expect(filteredFacts.map((f) => f.factId)).not.toContain(skipId);
+    expect(filteredFacts.length).toBe(baselineFacts.length - 1);
+
+    expect(mockFetchVerdictRecordIds).toHaveBeenCalledWith('fact');
+  });
+
+  it('--where-no-verdict aborts when verdict fetch fails (fail-closed)', async () => {
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: false,
+      error: 'unavailable',
+      message: 'wiki-server unreachable',
+    });
+
+    const result = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      'where-no-verdict': true,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Failed to fetch existing fact verdicts');
+    expect(result.output).toContain('wiki-server unreachable');
+  });
+
+  it('--where-no-verdict with empty verdict set returns all facts unchanged', async () => {
+    // Default mock returns empty set
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: true,
+      data: new Set<string>(),
+    });
+
+    const baseline = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+    });
+    const baselineFacts = JSON.parse(baseline.output) as Array<{ factId: string }>;
+
+    const result = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+      'where-no-verdict': true,
+    });
+    expect(result.exitCode).toBe(0);
+    const filteredFacts = JSON.parse(result.output) as Array<{ factId: string }>;
+    expect(filteredFacts.length).toBe(baselineFacts.length);
   });
 
   it('skips facts with non-verifiable properties (QUA-247)', async () => {

--- a/crux/commands/factbase-sourcing.test.ts
+++ b/crux/commands/factbase-sourcing.test.ts
@@ -186,6 +186,82 @@ describe('crux fb sourcing --dry-run', () => {
     expect(result.output).toContain('wiki-server unreachable');
   });
 
+  it('--where-no-verdict --limit=N counts AFTER filtering (QUA-851 headline use case)', async () => {
+    // Get baseline list of fact IDs for the entity
+    const baseline = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+    });
+    const baselineFacts = JSON.parse(baseline.output) as Array<{ factId: string }>;
+    expect(baselineFacts.length).toBeGreaterThanOrEqual(3);
+
+    // Mark the first two as already-verified
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: true,
+      data: new Set([baselineFacts[0].factId, baselineFacts[1].factId]),
+    });
+
+    // Ask for 3 — we should get 3 _unverified_ facts, none being the skipped two
+    const result = await sourcing([], {
+      entity: 'anthropic',
+      'dry-run': true,
+      ci: true,
+      'where-no-verdict': true,
+      limit: '3',
+    });
+    expect(result.exitCode).toBe(0);
+    const filteredFacts = JSON.parse(result.output) as Array<{ factId: string }>;
+    expect(filteredFacts.length).toBe(3);
+    expect(filteredFacts.map((f) => f.factId)).not.toContain(baselineFacts[0].factId);
+    expect(filteredFacts.map((f) => f.factId)).not.toContain(baselineFacts[1].factId);
+  });
+
+  it('--where-no-verdict --fact=X bypasses the filter (explicit fact lookup)', async () => {
+    const factId = 'f_dW5cR9mJ8q';
+    // Even if the fact's ID is in the verified set, --fact=X should still find it.
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: true,
+      data: new Set([factId]),
+    });
+
+    const result = await sourcing([], {
+      fact: factId,
+      'dry-run': true,
+      'where-no-verdict': true,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('1 fact(s)');
+  });
+
+  it('--where-no-verdict applied to all-entities branch (no entity/fact filter)', async () => {
+    // Get a sample fact ID that exists in the global pool
+    const sample = await sourcing([], {
+      'dry-run': true,
+      ci: true,
+      limit: '1',
+    });
+    const sampleFacts = JSON.parse(sample.output) as Array<{ factId: string }>;
+    expect(sampleFacts.length).toBe(1);
+    const skipId = sampleFacts[0].factId;
+
+    // Ask for 5 facts globally, with the sample one in the verified set.
+    mockFetchVerdictRecordIds.mockResolvedValueOnce({
+      ok: true,
+      data: new Set([skipId]),
+    });
+    const result = await sourcing([], {
+      'dry-run': true,
+      ci: true,
+      'where-no-verdict': true,
+      limit: '5',
+    });
+    expect(result.exitCode).toBe(0);
+    const filteredFacts = JSON.parse(result.output) as Array<{ factId: string }>;
+    expect(filteredFacts.length).toBe(5);
+    expect(filteredFacts.map((f) => f.factId)).not.toContain(skipId);
+  });
+
   it('--where-no-verdict with empty verdict set returns all facts unchanged', async () => {
     // Default mock returns empty set
     mockFetchVerdictRecordIds.mockResolvedValueOnce({

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -12,6 +12,12 @@
  *   crux fb sourcing --fact=f_dW5cR9mJ8q        Check a single fact
  *   crux fb sourcing --dry-run                   Show what would be checked
  *   crux fb sourcing --limit=10                  Check at most 10 facts
+ *   crux fb sourcing --where-no-verdict --limit=50
+ *                                                 (QUA-851) Skip facts that
+ *                                                 already have a row-level verdict.
+ *                                                 Used by the multi-week backfill
+ *                                                 to target only the ~1,353 facts
+ *                                                 with no verdict at all.
  */
 
 import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
@@ -22,6 +28,7 @@ import type { Entity, Fact, Property } from '../../packages/factbase/src/types.t
 import { createLlmClient, callLlm, MODELS } from '../lib/llm.ts';
 import { parseJsonResponse } from '../lib/anthropic.ts';
 import { storeSourcingEvidence, storeAggregateVerdict } from '../lib/sourcing/verdict-handler.ts';
+import { fetchVerdictRecordIds } from '../lib/wiki-server/sourcing-client.ts';
 import type { SourceFetchErrorType } from '../lib/search/paywall-detection.ts';
 import { fetchSourceContent } from '../lib/sourcing/source-fetcher.ts';
 import {
@@ -49,6 +56,14 @@ interface VerifyCommandOptions extends BaseOptions {
   dryRun?: boolean;
   limit?: string;
   ci?: boolean;
+  /**
+   * QUA-851: skip facts that already have a row-level verdict in
+   * source_check_verdicts. Used by the multi-week backfill to avoid
+   * re-checking the ~1,400 facts that are already verified and target
+   * only the ~1,353 with no verdict at all.
+   */
+  'where-no-verdict'?: boolean;
+  whereNoVerdict?: boolean;
 }
 
 interface SourcingResult {
@@ -274,12 +289,14 @@ function isNonVerifiable(graph: Graph, fact: Fact): boolean {
   return property?.verifiable === false;
 }
 
-function collectFacts(
+export function collectFacts(
   kb: LoadedKB,
   options: VerifyCommandOptions,
+  alreadyVerifiedFactIds?: ReadonlySet<string>,
 ): Array<{ entity: Entity; fact: Fact }> {
   const graph = kb.graph;
   const factsToVerify: Array<{ entity: Entity; fact: Fact }> = [];
+  const skipVerified = alreadyVerifiedFactIds && alreadyVerifiedFactIds.size > 0;
 
   if (options.fact) {
     // Find a specific fact by ID
@@ -288,7 +305,9 @@ function collectFacts(
       const match = facts.find((f: Fact) => f.id === options.fact);
       if (match) {
         if (match.source && !isNonVerifiable(graph, match)) {
-          factsToVerify.push({ entity, fact: match });
+          if (!skipVerified || !alreadyVerifiedFactIds!.has(match.id)) {
+            factsToVerify.push({ entity, fact: match });
+          }
         }
         break;
       }
@@ -300,7 +319,9 @@ function collectFacts(
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
         if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
-          factsToVerify.push({ entity, fact });
+          if (!skipVerified || !alreadyVerifiedFactIds!.has(fact.id)) {
+            factsToVerify.push({ entity, fact });
+          }
         }
       }
     }
@@ -310,7 +331,9 @@ function collectFacts(
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
         if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
-          factsToVerify.push({ entity, fact });
+          if (!skipVerified || !alreadyVerifiedFactIds!.has(fact.id)) {
+            factsToVerify.push({ entity, fact });
+          }
         }
       }
     }
@@ -335,7 +358,30 @@ export async function sourcingCommand(
 
   const kb = await loadGraphFull();
   const graph = kb.graph;
-  const factsToVerify = collectFacts(kb, options);
+
+  // QUA-851: when --where-no-verdict is set, fetch the set of fact IDs that
+  // already have a row-level verdict from the wiki-server and skip them.
+  // Targets the ~1,353 unverified facts directly instead of re-checking all
+  // 2,744. Fail-closed: if we can't fetch verdicts, abort rather than silently
+  // re-verify everything.
+  const whereNoVerdict = options['where-no-verdict'] || options.whereNoVerdict;
+  let alreadyVerifiedFactIds: Set<string> | undefined;
+  if (whereNoVerdict) {
+    const res = await fetchVerdictRecordIds('fact');
+    if (!res.ok) {
+      const detail = res.message || res.error;
+      return {
+        exitCode: 1,
+        output: `Failed to fetch existing fact verdicts (--where-no-verdict): ${detail}`,
+      };
+    }
+    alreadyVerifiedFactIds = res.data;
+    console.log(
+      `[where-no-verdict] ${alreadyVerifiedFactIds.size} fact(s) already have a verdict; will skip them.`,
+    );
+  }
+
+  const factsToVerify = collectFacts(kb, options, alreadyVerifiedFactIds);
 
   if (factsToVerify.length === 0) {
     const hint = options.entity

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -289,14 +289,20 @@ function isNonVerifiable(graph: Graph, fact: Fact): boolean {
   return property?.verifiable === false;
 }
 
-export function collectFacts(
+function collectFacts(
   kb: LoadedKB,
   options: VerifyCommandOptions,
   alreadyVerifiedFactIds?: ReadonlySet<string>,
 ): Array<{ entity: Entity; fact: Fact }> {
   const graph = kb.graph;
   const factsToVerify: Array<{ entity: Entity; fact: Fact }> = [];
-  const skipVerified = alreadyVerifiedFactIds && alreadyVerifiedFactIds.size > 0;
+  // Only filter by verified-set when caller has provided a populated set AND
+  // we're in batch mode (entity-scoped or all-entities). For an explicit
+  // --fact=X lookup the user is asking for that specific fact; respect it.
+  const verified =
+    !options.fact && alreadyVerifiedFactIds && alreadyVerifiedFactIds.size > 0
+      ? alreadyVerifiedFactIds
+      : null;
 
   if (options.fact) {
     // Find a specific fact by ID
@@ -305,9 +311,7 @@ export function collectFacts(
       const match = facts.find((f: Fact) => f.id === options.fact);
       if (match) {
         if (match.source && !isNonVerifiable(graph, match)) {
-          if (!skipVerified || !alreadyVerifiedFactIds!.has(match.id)) {
-            factsToVerify.push({ entity, fact: match });
-          }
+          factsToVerify.push({ entity, fact: match });
         }
         break;
       }
@@ -319,7 +323,7 @@ export function collectFacts(
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
         if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
-          if (!skipVerified || !alreadyVerifiedFactIds!.has(fact.id)) {
+          if (!verified || !verified.has(fact.id)) {
             factsToVerify.push({ entity, fact });
           }
         }
@@ -331,7 +335,7 @@ export function collectFacts(
       const facts = graph.getFacts(entity.id);
       for (const fact of facts) {
         if (fact.source && !fact.id.startsWith('inv_') && !isNonVerifiable(graph, fact)) {
-          if (!skipVerified || !alreadyVerifiedFactIds!.has(fact.id)) {
+          if (!verified || !verified.has(fact.id)) {
             factsToVerify.push({ entity, fact });
           }
         }
@@ -376,7 +380,8 @@ export async function sourcingCommand(
       };
     }
     alreadyVerifiedFactIds = res.data;
-    console.log(
+    // Log to stderr so --ci JSON output stays parseable.
+    console.error(
       `[where-no-verdict] ${alreadyVerifiedFactIds.size} fact(s) already have a verdict; will skip them.`,
     );
   }

--- a/crux/commands/factbase-sourcing.ts
+++ b/crux/commands/factbase-sourcing.ts
@@ -370,7 +370,7 @@ export async function sourcingCommand(
   // re-verify everything.
   const whereNoVerdict = options['where-no-verdict'] || options.whereNoVerdict;
   let alreadyVerifiedFactIds: Set<string> | undefined;
-  if (whereNoVerdict) {
+  if (whereNoVerdict && !options.fact) {
     const res = await fetchVerdictRecordIds('fact');
     if (!res.ok) {
       const detail = res.message || res.error;

--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -1151,6 +1151,7 @@ Options:
   --rule=X              Filter by rule name (validate)
   --entity=X            (sourcing) Check all facts for one entity
   --fact=X              (sourcing) Check a single fact by ID
+  --where-no-verdict    (sourcing) Skip facts that already have a row-level verdict
   --dry-run             Preview changes without writing (sourcing, import-990)
   --ein=XXXXXXXXX       (import-990) Specify EIN directly
   --force               (import-990, add-fact) Overwrite existing facts
@@ -1174,5 +1175,6 @@ Examples:
   crux fb sync-sources                Sync source URLs to wiki-server resources
   crux fb sourcing --entity=anthropic   Check Anthropic facts against sources
   crux fb sourcing --dry-run --limit=5  Preview 5 facts that would be checked
+  crux fb sourcing --where-no-verdict --limit=50  Check 50 facts that have no verdict yet (QUA-851)
 `;
 }

--- a/crux/lib/wiki-server/sourcing-client.test.ts
+++ b/crux/lib/wiki-server/sourcing-client.test.ts
@@ -97,6 +97,100 @@ describe('fetchVerdictRecordIds (QUA-851)', () => {
     expect(secondCall[1]).toContain('offset=200');
   });
 
+  it('terminates correctly when total is an exact multiple of page size', async () => {
+    // 400 rows total = exactly 2 pages of 200. Without `total`-based termination
+    // this is the off-by-one case where naive `length < PAGE_SIZE` would request
+    // a third (empty) page or even loop forever.
+    const PAGE_SIZE = 200;
+    const totalRows = 400;
+
+    mockApiRequest.mockImplementation(async (_method: string, path: string) => {
+      const url = new URL(path, 'http://x');
+      const limit = Number(url.searchParams.get('limit') ?? PAGE_SIZE);
+      const offset = Number(url.searchParams.get('offset') ?? 0);
+      const remaining = Math.max(0, totalRows - offset);
+      const pageCount = Math.min(limit, remaining);
+
+      const verdicts = Array.from({ length: pageCount }, (_, i) => ({
+        recordType: 'fact',
+        recordId: `f_${(offset + i).toString().padStart(10, '0')}`,
+        fieldName: null,
+        entityId: 'sid_x',
+        displayName: 'Test',
+        entityDisplayName: 'TestEntity',
+        verdict: 'confirmed',
+        confidence: 0.9,
+        reasoning: 'r',
+        sourcesChecked: 1,
+        needsRecheck: false,
+        nextCheckDue: null,
+        lastComputedAt: '2026-04-29T00:00:00Z',
+        createdAt: '2026-04-29T00:00:00Z',
+        updatedAt: '2026-04-29T00:00:00Z',
+      }));
+
+      return { ok: true, data: { verdicts, total: totalRows } };
+    });
+
+    const { fetchVerdictRecordIds } = await import('./sourcing-client.ts');
+    const res = await fetchVerdictRecordIds('fact');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.size).toBe(400);
+    // Exactly 2 pages — not 3, not 1.
+    expect(mockApiRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('terminates after one page when server returns fewer rows than requested limit', async () => {
+    // Simulates the server tightening its page-size cap below the client's
+    // requested limit. Without `total`-based termination, naively comparing
+    // `length < REQUESTED_LIMIT` is correct, but lock that in.
+    mockApiRequest.mockImplementation(async () => {
+      const verdicts = Array.from({ length: 50 }, (_, i) => ({
+        recordType: 'fact',
+        recordId: `f_${i.toString().padStart(10, '0')}`,
+        fieldName: null,
+        entityId: 'sid_x',
+        displayName: 'Test',
+        entityDisplayName: 'TestEntity',
+        verdict: 'confirmed',
+        confidence: 0.9,
+        reasoning: 'r',
+        sourcesChecked: 1,
+        needsRecheck: false,
+        nextCheckDue: null,
+        lastComputedAt: '2026-04-29T00:00:00Z',
+        createdAt: '2026-04-29T00:00:00Z',
+        updatedAt: '2026-04-29T00:00:00Z',
+      }));
+      return { ok: true, data: { verdicts, total: 50 } };
+    });
+
+    const { fetchVerdictRecordIds } = await import('./sourcing-client.ts');
+    const res = await fetchVerdictRecordIds('fact');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.size).toBe(50);
+    expect(mockApiRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty set when there are no verdicts', async () => {
+    mockApiRequest.mockResolvedValue({
+      ok: true,
+      data: { verdicts: [], total: 0 },
+    });
+
+    const { fetchVerdictRecordIds } = await import('./sourcing-client.ts');
+    const res = await fetchVerdictRecordIds('fact');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.size).toBe(0);
+    expect(mockApiRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('propagates listVerdicts errors', async () => {
     mockApiRequest.mockResolvedValue({
       ok: false,

--- a/crux/lib/wiki-server/sourcing-client.test.ts
+++ b/crux/lib/wiki-server/sourcing-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { evidenceRecordKey } from './sourcing-client.ts';
 
 describe('evidenceRecordKey', () => {
@@ -19,5 +19,97 @@ describe('evidenceRecordKey', () => {
     expect(evidenceRecordKey('fact', 'F1')).not.toBe(
       evidenceRecordKey('fact', 'F2'),
     );
+  });
+});
+
+// QUA-851: fetchVerdictRecordIds paginates through /api/sourcing/verdicts
+// and returns the set of recordIds with row-level verdicts (fieldName == null).
+// Mock at the HTTP boundary (`apiRequest` in client.ts) since fetchVerdictRecordIds
+// calls listVerdicts via local module binding.
+const mockApiRequest = vi.fn();
+
+vi.mock('./client.ts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  };
+});
+
+describe('fetchVerdictRecordIds (QUA-851)', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset();
+  });
+
+  it('paginates and excludes per-field verdicts', async () => {
+    const PAGE_SIZE = 200;
+    const totalRows = 250;
+
+    mockApiRequest.mockImplementation(async (_method: string, path: string) => {
+      const url = new URL(path, 'http://x');
+      const limit = Number(url.searchParams.get('limit') ?? PAGE_SIZE);
+      const offset = Number(url.searchParams.get('offset') ?? 0);
+      const remaining = Math.max(0, totalRows - offset);
+      const pageCount = Math.min(limit, remaining);
+
+      const verdicts = Array.from({ length: pageCount }, (_, i) => {
+        const idx = offset + i;
+        return {
+          recordType: 'fact',
+          recordId: `f_${idx.toString().padStart(10, '0')}`,
+          // Mark every 5th row as field-level so we can confirm those are skipped.
+          fieldName: idx % 5 === 0 ? 'value' : null,
+          entityId: 'sid_x',
+          displayName: 'Test',
+          entityDisplayName: 'TestEntity',
+          verdict: 'confirmed',
+          confidence: 0.9,
+          reasoning: 'r',
+          sourcesChecked: 1,
+          needsRecheck: false,
+          nextCheckDue: null,
+          lastComputedAt: '2026-04-29T00:00:00Z',
+          createdAt: '2026-04-29T00:00:00Z',
+          updatedAt: '2026-04-29T00:00:00Z',
+        };
+      });
+
+      return { ok: true, data: { verdicts, total: totalRows } };
+    });
+
+    const { fetchVerdictRecordIds } = await import('./sourcing-client.ts');
+    const res = await fetchVerdictRecordIds('fact');
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // 250 total rows, 50 are field-level (every 5th: 0,5,...,245 → 50 rows), so 200 row-level
+    expect(res.data.size).toBe(200);
+
+    // Should have paginated: 200 rows on page 1, then 50 on page 2 (< PAGE_SIZE → stop)
+    expect(mockApiRequest).toHaveBeenCalledTimes(2);
+    const firstCall = mockApiRequest.mock.calls[0];
+    expect(firstCall[0]).toBe('GET');
+    expect(firstCall[1]).toContain('record_type=fact');
+    expect(firstCall[1]).toContain('limit=200');
+    expect(firstCall[1]).toContain('offset=0');
+    const secondCall = mockApiRequest.mock.calls[1];
+    expect(secondCall[1]).toContain('offset=200');
+  });
+
+  it('propagates listVerdicts errors', async () => {
+    mockApiRequest.mockResolvedValue({
+      ok: false,
+      error: 'unavailable',
+      message: 'wiki-server down',
+    });
+
+    const { fetchVerdictRecordIds } = await import('./sourcing-client.ts');
+    const res = await fetchVerdictRecordIds('fact');
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toBe('unavailable');
+    expect(res.message).toBe('wiki-server down');
   });
 });

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -99,22 +99,36 @@ export async function listVerdicts(
 
 /**
  * Fetch the set of record IDs that already have a row-level verdict for the
- * given recordType. Skips per-field verdicts (fieldName != null) since a
- * record with only field-level verdicts has no row-level coverage and should
- * still be considered "no verdict" for the QUA-851 backfill flow.
+ * given recordType. Skips per-field verdicts (fieldName != null) — designed
+ * for record types where a row-level verdict means "fully checked" (e.g.,
+ * facts). Record types that primarily store field-level verdicts (e.g.,
+ * personnel) need a different filter.
  *
- * Paginates server-side at MAX_PAGE_SIZE (200). Used by
- * `crux fb sourcing --where-no-verdict` to skip already-verified facts.
+ * Paginates against the server's natural page size, terminating when
+ * `offset + page.length >= total` so the client doesn't need to know
+ * MAX_PAGE_SIZE (avoids silent truncation if the server tightens it).
+ *
+ * Concurrency note: between page fetches, concurrent verdict writes can
+ * shift row ordering (rows are sorted by lastComputedAt desc) and
+ * skip/duplicate rows across pages. The Set deduplicates duplicates;
+ * skipped rows mean a few facts may be re-verified on the next backfill
+ * run — wasted work but not incorrect output. Acceptable for the
+ * QUA-851 use case.
+ *
+ * Used by `crux fb sourcing --where-no-verdict` to skip already-verified
+ * facts.
  */
 export async function fetchVerdictRecordIds(
   recordType: string,
 ): Promise<ApiResult<Set<string>>> {
-  const PAGE_SIZE = 200;
+  // Request the server's max page size; if the server clamps it lower,
+  // we still terminate correctly via `total`.
+  const REQUESTED_LIMIT = 200;
   const ids = new Set<string>();
   let offset = 0;
 
   while (true) {
-    const res = await listVerdicts({ recordType, limit: PAGE_SIZE, offset });
+    const res = await listVerdicts({ recordType, limit: REQUESTED_LIMIT, offset });
     if (!res.ok) return res;
 
     for (const v of res.data.verdicts) {
@@ -122,8 +136,9 @@ export async function fetchVerdictRecordIds(
       ids.add(v.recordId);
     }
 
-    if (res.data.verdicts.length < PAGE_SIZE) break;
-    offset += PAGE_SIZE;
+    const fetchedSoFar = offset + res.data.verdicts.length;
+    if (res.data.verdicts.length === 0 || fetchedSoFar >= res.data.total) break;
+    offset = fetchedSoFar;
   }
 
   return { ok: true, data: ids };

--- a/crux/lib/wiki-server/sourcing-client.ts
+++ b/crux/lib/wiki-server/sourcing-client.ts
@@ -97,6 +97,38 @@ export async function listVerdicts(
   );
 }
 
+/**
+ * Fetch the set of record IDs that already have a row-level verdict for the
+ * given recordType. Skips per-field verdicts (fieldName != null) since a
+ * record with only field-level verdicts has no row-level coverage and should
+ * still be considered "no verdict" for the QUA-851 backfill flow.
+ *
+ * Paginates server-side at MAX_PAGE_SIZE (200). Used by
+ * `crux fb sourcing --where-no-verdict` to skip already-verified facts.
+ */
+export async function fetchVerdictRecordIds(
+  recordType: string,
+): Promise<ApiResult<Set<string>>> {
+  const PAGE_SIZE = 200;
+  const ids = new Set<string>();
+  let offset = 0;
+
+  while (true) {
+    const res = await listVerdicts({ recordType, limit: PAGE_SIZE, offset });
+    if (!res.ok) return res;
+
+    for (const v of res.data.verdicts) {
+      if (v.fieldName != null) continue;
+      ids.add(v.recordId);
+    }
+
+    if (res.data.verdicts.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+
+  return { ok: true, data: ids };
+}
+
 /** Get verdicts for a specific record. */
 export async function getVerdictByRecord(
   recordType: string,


### PR DESCRIPTION
## Summary

Adds `--where-no-verdict` to `crux fb sourcing` so the QUA-851 multi-week backfill can target only facts that have no row-level verdict, instead of re-checking the ~2,500 facts that are already verified.

The flag fetches the set of fact IDs with row-level verdicts from `/api/sourcing/verdicts?record_type=fact` (paginated, terminating via `response.total` to avoid duplicating the server's `MAX_PAGE_SIZE` constant) and filters those out of the work queue *before* applying `--limit`. Per-field verdicts (fieldName != null) don't count as row-level coverage and are skipped — matches the QUA-851 backfill semantics.

`--fact=X` bypasses the filter (the user is asking for that specific fact; the flag is a backfill optimization, not an absolute exclusion).

Fail-closed: if the verdict fetch fails, the command exits non-zero with a clear error rather than silently re-verifying everything.

## QUA-851 context

- Phase A (QUA-850, schema + plumbing) merged in PR #4698
- Phase B (this work) is described as "multi-week cron run, not a one-shot. Budget-gated, not PR-gated"
- The session-shaped contribution is the `--where-no-verdict` flag the ticket explicitly references
- Verified against prod: **462 facts unverified** (down from 1,353 at ticket-filing time — coverage improved meaningfully via QUA-726 cron)
- Future runs should use `pnpm crux fb sourcing --where-no-verdict --limit=N` to chip away at the backlog without re-checking the 2,483 facts that already have verdicts

## Implementation

| File | Change |
|---|---|
| `crux/lib/wiki-server/sourcing-client.ts` | New `fetchVerdictRecordIds(recordType)` paginating helper |
| `crux/commands/factbase-sourcing.ts` | New flag + filter logic in `collectFacts` |
| `crux/commands/factbase.ts` | Help text + example |
| `*.test.ts` | 9 new tests (3 in sourcing-client, 6 in factbase-sourcing) |

## Test plan

- [x] `pnpm test` — 8700 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm crux w validate gate --fix` — 60 checks pass
- [x] Type check across all 3 projects — clean
- [x] Verified against prod: `--where-no-verdict --dry-run` returns 462 unverified facts; stderr reports 2483 already verified
- [x] Verified `--ci` JSON output is parseable (log goes to stderr)
- [x] Verified `--fact=X` bypasses the filter
- [x] Verified fail-closed when wiki-server unreachable (exit 1)
- [x] Red-team: 10 adversarial CLI inputs tested (SQL/shell metachars, oversize IDs, invalid limits) — no injection paths
- [x] `/agent-review-pr` — addressed CRITICAL pagination finding + 4 others; 6 new tests added from review

## Related

- Filed QUA-860 for pre-existing CLI UX issue: `--limit=abc/0/-5/empty` silently treated as no-limit (out of scope here, observed during red-team)

Fixes QUA-851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--where-no-verdict` flag to the sourcing command to filter out facts that already have an existing row-level verdict, helping you focus on unverified facts.

* **Documentation**
  * Updated command-line help to document the new `--where-no-verdict` option with example usage demonstrating its use with the `--limit` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->