### PR TITLE
fix: tighten --skip-sourcing escape hatch + gate manifests with no sourcing (QUA-730)

### DIFF
--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -76,21 +76,13 @@ interface CommandOptions extends BaseOptions {
 }
 
 /**
- * QUA-730: shared --skip-sourcing reason check for any tablebase command that
- * forwards `skipSourcing` into the agent / loop / field-improve layers.
- * Returns a CommandResult to surface as exit-2 if the reason is missing or
- * outside the controlled vocabulary, or null when the flag is absent.
+ * QUA-730: thin wrapper around the shared `checkSkipSourcingReason` helper
+ * so command handlers can `if (err) return err` without dynamic-importing.
+ * The actual logic lives in `crux/tablebase/skip-sourcing-reasons.ts`.
  */
 async function checkSkipSourcingReason(options: CommandOptions): Promise<CommandResult | null> {
-  if (!options.skipSourcing) return null;
-  const { isSkipSourcingReason, formatSkipSourcingReasonError } = await import(
-    '../tablebase/skip-sourcing-reasons.ts'
-  );
-  const provided = options.skipSourcingReason?.trim();
-  if (!isSkipSourcingReason(provided)) {
-    return { exitCode: 2, output: formatSkipSourcingReasonError(provided) };
-  }
-  return null;
+  const { checkSkipSourcingReason: check } = await import('../tablebase/skip-sourcing-reasons.ts');
+  return check(options);
 }
 
 async function persistScanResults(scan: import('../tablebase/types.ts').ScanSummary): Promise<void> {
@@ -404,15 +396,15 @@ async function submitCommand(args: string[], options: CommandOptions): Promise<C
   }
 
   // QUA-730: --skip-sourcing requires a controlled-vocabulary reason.
-  let skipSourcingReason: import('../tablebase/skip-sourcing-reasons.ts').SkipSourcingReason | undefined;
-  if (options.skipSourcing) {
-    const { isSkipSourcingReason, formatSkipSourcingReasonError } = await import('../tablebase/skip-sourcing-reasons.ts');
-    const provided = options.skipSourcingReason?.trim();
-    if (!isSkipSourcingReason(provided)) {
-      return { exitCode: 1, output: formatSkipSourcingReasonError(provided) };
-    }
-    skipSourcingReason = provided;
-  }
+  // Reuse the shared helper so submit + improve + loop all return the same
+  // exit code (2) for the same misconfiguration.
+  const skipSourcingErr = await checkSkipSourcingReason(options);
+  if (skipSourcingErr) return skipSourcingErr;
+  // Re-narrow the type — checkSkipSourcingReason guarantees the reason is
+  // valid when it returns null AND skipSourcing is set.
+  const skipSourcingReason = options.skipSourcing
+    ? (options.skipSourcingReason!.trim() as import('../tablebase/skip-sourcing-reasons.ts').SkipSourcingReason)
+    : undefined;
 
   // Read records from --records-file or stdin
   let recordsJson: string;
@@ -504,22 +496,22 @@ async function submitCommand(args: string[], options: CommandOptions): Promise<C
   if (tableConfig.requireSourcing) params.set('requireSourcing', 'true');
   if (options.skipSourcing) {
     // forceSkipSourcing bypasses server-side sourcing enforcement.
-    // QUA-730: skipSourcingReason was validated against the allowlist at the top of submitCommand.
+    // QUA-730: skipSourcingReason was validated by checkSkipSourcingReason() above.
     if (!skipSourcingReason) {
-      // Defensive — the earlier check should have rejected this path. Belt + suspenders.
-      return { exitCode: 1, output: 'Internal error: --skip-sourcing reached submission without a validated reason (QUA-730).' };
+      // Defensive — checkSkipSourcingReason should have rejected this path. Belt + suspenders.
+      return { exitCode: 2, output: 'Internal error: --skip-sourcing reached submission without a validated reason (QUA-730).' };
     }
-    const { formatSkipSourcingAuditReason } = await import('../tablebase/skip-sourcing-reasons.ts');
+    const { formatSkipSourcingAuditReason, formatSkipSourcingBanner } = await import('../tablebase/skip-sourcing-reasons.ts');
     params.set('forceSkipSourcing', 'true');
     params.set('reason', formatSkipSourcingAuditReason(skipSourcingReason, 'cli'));
 
     // Loud warning so CI logs and reviewers see what's about to ship unverified.
-    const banner = '═'.repeat(72);
-    console.warn(`\x1b[33m${banner}\x1b[0m`);
-    console.warn(`\x1b[33m  ⚠  --skip-sourcing: shipping ${recordsToSubmit.length} ${table} record(s)\x1b[0m`);
-    console.warn(`\x1b[33m     to production WITHOUT sourcing verification.\x1b[0m`);
-    console.warn(`\x1b[33m     Reason: ${skipSourcingReason}\x1b[0m`);
-    console.warn(`\x1b[33m${banner}\x1b[0m`);
+    console.warn(formatSkipSourcingBanner({
+      source: 'cli',
+      recordCount: recordsToSubmit.length,
+      table,
+      reason: skipSourcingReason,
+    }));
   }
   const qs = params.toString();
   const syncPath = qs ? `${tableConfig.syncPath}?${qs}` : tableConfig.syncPath;
@@ -1661,7 +1653,7 @@ Options:
   --records-file=<path>     JSON file for submit command
   --skip-sourcing       Skip sourcing before submit. Requires
                             --skip-sourcing-reason=<migration|backfill|testing|key-unavailable|manual-verified> (QUA-730).
-  --skip-sourcing-reason=<value>   Controlled-vocabulary justification for --skip-sourcing.
+  --skip-sourcing-reason=<value>   Controlled-vocabulary justification (only valid with --skip-sourcing).
   --via-propose             Route supported record types (grants, Phase 1) through
                             /api/enrichment/propose instead of direct /sync (QUA-655)
   --apply                   For source-discover: also link discovered resources to records

--- a/crux/commands/tablebase.ts
+++ b/crux/commands/tablebase.ts
@@ -48,6 +48,8 @@ interface CommandOptions extends BaseOptions {
   /** Required when --skipEntityValidation is set. */
   skipEntityValidationReason?: string;
   skipSourcing?: boolean;
+  /** Required when --skipSourcing is set. Must be in SKIP_SOURCING_REASONS (QUA-730). */
+  skipSourcingReason?: string;
   /** QUA-655: route supported record types through `/api/enrichment/propose` */
   viaPropose?: boolean;
   fix?: boolean;
@@ -71,6 +73,24 @@ interface CommandOptions extends BaseOptions {
   /** QUA-552: dollar budget cap for the whole run */
   budgetUsd?: string;
   fields?: boolean;
+}
+
+/**
+ * QUA-730: shared --skip-sourcing reason check for any tablebase command that
+ * forwards `skipSourcing` into the agent / loop / field-improve layers.
+ * Returns a CommandResult to surface as exit-2 if the reason is missing or
+ * outside the controlled vocabulary, or null when the flag is absent.
+ */
+async function checkSkipSourcingReason(options: CommandOptions): Promise<CommandResult | null> {
+  if (!options.skipSourcing) return null;
+  const { isSkipSourcingReason, formatSkipSourcingReasonError } = await import(
+    '../tablebase/skip-sourcing-reasons.ts'
+  );
+  const provided = options.skipSourcingReason?.trim();
+  if (!isSkipSourcingReason(provided)) {
+    return { exitCode: 2, output: formatSkipSourcingReasonError(provided) };
+  }
+  return null;
 }
 
 async function persistScanResults(scan: import('../tablebase/types.ts').ScanSummary): Promise<void> {
@@ -251,6 +271,9 @@ async function improveCommand(args: string[], options: CommandOptions): Promise<
     };
   }
 
+  const skipSourcingErr = await checkSkipSourcingReason(options);
+  if (skipSourcingErr) return skipSourcingErr;
+
   const { findTaskById } = await import('../tablebase/loop.ts');
   const { runEnrichmentAgent } = await import('../tablebase/agent.ts');
 
@@ -265,6 +288,7 @@ async function improveCommand(args: string[], options: CommandOptions): Promise<
     dryRun,
     model,
     skipSourcing: !!options.skipSourcing,
+    skipSourcingReason: options.skipSourcingReason,
   });
 
   if (!dryRun) {
@@ -291,6 +315,9 @@ async function fieldImproveCommand(options: CommandOptions): Promise<CommandResu
     };
   }
 
+  const skipSourcingErr = await checkSkipSourcingReason(options);
+  if (skipSourcingErr) return skipSourcingErr;
+
   const maxTasks = options.max ? parseInt(options.max, 10) : undefined;
   const model = (options.model as string | undefined) ?? 'auto';
 
@@ -313,6 +340,7 @@ async function fieldImproveCommand(options: CommandOptions): Promise<CommandResu
           model,
           dryRun: !!options.dryRun,
           skipSourcing: !!options.skipSourcing,
+          skipSourcingReason: options.skipSourcingReason,
         })
       : await runScanReportImprove({
           reportPath: options.fromScanReport as string,
@@ -321,6 +349,7 @@ async function fieldImproveCommand(options: CommandOptions): Promise<CommandResu
           model,
           dryRun: !!options.dryRun,
           skipSourcing: !!options.skipSourcing,
+          skipSourcingReason: options.skipSourcingReason,
         });
 
     if (options.ci) {
@@ -372,6 +401,17 @@ async function submitCommand(args: string[], options: CommandOptions): Promise<C
   const validTables = ['personnel', 'grants', 'funding-rounds', 'investments', 'benchmark-results', 'publications', 'divisions'];
   if (!validTables.includes(table)) {
     return { exitCode: 1, output: `Invalid table: ${table}. Valid: ${validTables.join(', ')}` };
+  }
+
+  // QUA-730: --skip-sourcing requires a controlled-vocabulary reason.
+  let skipSourcingReason: import('../tablebase/skip-sourcing-reasons.ts').SkipSourcingReason | undefined;
+  if (options.skipSourcing) {
+    const { isSkipSourcingReason, formatSkipSourcingReasonError } = await import('../tablebase/skip-sourcing-reasons.ts');
+    const provided = options.skipSourcingReason?.trim();
+    if (!isSkipSourcingReason(provided)) {
+      return { exitCode: 1, output: formatSkipSourcingReasonError(provided) };
+    }
+    skipSourcingReason = provided;
   }
 
   // Read records from --records-file or stdin
@@ -463,9 +503,23 @@ async function submitCommand(args: string[], options: CommandOptions): Promise<C
   }
   if (tableConfig.requireSourcing) params.set('requireSourcing', 'true');
   if (options.skipSourcing) {
-    // forceSkipSourcing bypasses server-side sourcing enforcement (used when source URLs aren't cached yet)
+    // forceSkipSourcing bypasses server-side sourcing enforcement.
+    // QUA-730: skipSourcingReason was validated against the allowlist at the top of submitCommand.
+    if (!skipSourcingReason) {
+      // Defensive — the earlier check should have rejected this path. Belt + suspenders.
+      return { exitCode: 1, output: 'Internal error: --skip-sourcing reached submission without a validated reason (QUA-730).' };
+    }
+    const { formatSkipSourcingAuditReason } = await import('../tablebase/skip-sourcing-reasons.ts');
     params.set('forceSkipSourcing', 'true');
-    params.set('reason', 'cli: --skip-sourcing flag set by caller');
+    params.set('reason', formatSkipSourcingAuditReason(skipSourcingReason, 'cli'));
+
+    // Loud warning so CI logs and reviewers see what's about to ship unverified.
+    const banner = '═'.repeat(72);
+    console.warn(`\x1b[33m${banner}\x1b[0m`);
+    console.warn(`\x1b[33m  ⚠  --skip-sourcing: shipping ${recordsToSubmit.length} ${table} record(s)\x1b[0m`);
+    console.warn(`\x1b[33m     to production WITHOUT sourcing verification.\x1b[0m`);
+    console.warn(`\x1b[33m     Reason: ${skipSourcingReason}\x1b[0m`);
+    console.warn(`\x1b[33m${banner}\x1b[0m`);
   }
   const qs = params.toString();
   const syncPath = qs ? `${tableConfig.syncPath}?${qs}` : tableConfig.syncPath;
@@ -1113,6 +1167,9 @@ async function loopCommand(_args: string[], options: CommandOptions): Promise<Co
     : undefined;
   const entityTypes = options.entityType ? [options.entityType as string] : undefined;
 
+  const skipSourcingErr = await checkSkipSourcingReason(options);
+  if (skipSourcingErr) return skipSourcingErr;
+
   const result = await runLoop({
     maxTasks,
     budgetDollars,
@@ -1121,6 +1178,7 @@ async function loopCommand(_args: string[], options: CommandOptions): Promise<Co
     entityTypes,
     model,
     skipSourcing: !!options.skipSourcing,
+    skipSourcingReason: options.skipSourcingReason,
     viaPropose: !!options.viaPropose,
   });
 
@@ -1601,7 +1659,9 @@ Options:
   --budget=N                Budget limit in USD for loop (default: 30)
   --model=<name>            LLM model: haiku, sonnet, opus, or auto (tier by task type)
   --records-file=<path>     JSON file for submit command
-  --skip-sourcing       Skip sourcing before submit (for testing)
+  --skip-sourcing       Skip sourcing before submit. Requires
+                            --skip-sourcing-reason=<migration|backfill|testing|key-unavailable|manual-verified> (QUA-730).
+  --skip-sourcing-reason=<value>   Controlled-vocabulary justification for --skip-sourcing.
   --via-propose             Route supported record types (grants, Phase 1) through
                             /api/enrichment/propose instead of direct /sync (QUA-655)
   --apply                   For source-discover: also link discovered resources to records

--- a/crux/tablebase/agent.ts
+++ b/crux/tablebase/agent.ts
@@ -18,6 +18,11 @@ export interface AgentRunOptions {
   model?: string;
   /** Skip sourcing before submitting records */
   skipSourcing?: boolean;
+  /**
+   * QUA-730: required when skipSourcing is true. Must be in
+   * SKIP_SOURCING_REASONS. Forwarded to the agent tool layer.
+   */
+  skipSourcingReason?: string;
   /** For source-discovery: also link discovered resources to records */
   apply?: boolean;
   /**
@@ -39,6 +44,7 @@ export async function runEnrichmentAgent(
     dryRun = false,
     model = MODELS.sonnet,
     skipSourcing = false,
+    skipSourcingReason,
     apply = false,
     viaPropose = false,
   } = options;
@@ -49,7 +55,7 @@ export async function runEnrichmentAgent(
   const systemPrompt = getSystemPrompt(task);
   const userPrompt = getUserPrompt(task);
   const { tools: regularTools, serverTools } = getToolDefinitions({ taskType: task.taskType, apply });
-  const toolHandlers = buildToolHandlers(task, dryRun, { skipSourcing, apply, viaPropose });
+  const toolHandlers = buildToolHandlers(task, dryRun, { skipSourcing, skipSourcingReason, apply, viaPropose });
 
   let totalRecordsCreated = 0;
 

--- a/crux/tablebase/field-improve.test.ts
+++ b/crux/tablebase/field-improve.test.ts
@@ -126,10 +126,16 @@ describe('runFieldTargetedImprove', () => {
       budgetUsd: 1,
       dryRun: true,
       skipSourcing: true,
+      // QUA-730: skipSourcing now requires a reason; use 'testing' for the test path.
+      skipSourcingReason: 'testing',
     });
 
     expect(runLoopMock).toHaveBeenCalledWith(
-      expect.objectContaining({ dryRun: true, skipSourcing: true }),
+      expect.objectContaining({
+        dryRun: true,
+        skipSourcing: true,
+        skipSourcingReason: 'testing',
+      }),
     );
   });
 });

--- a/crux/tablebase/field-improve.ts
+++ b/crux/tablebase/field-improve.ts
@@ -32,6 +32,8 @@ export interface FieldTargetOptions {
   dryRun?: boolean;
   /** Skip sourcing gate before submission (advisory). */
   skipSourcing?: boolean;
+  /** QUA-730: required when skipSourcing is true. */
+  skipSourcingReason?: string;
 }
 
 export interface ScanReportOptions {
@@ -47,6 +49,8 @@ export interface ScanReportOptions {
   dryRun?: boolean;
   /** Skip sourcing gate before submission. */
   skipSourcing?: boolean;
+  /** QUA-730: required when skipSourcing is true. */
+  skipSourcingReason?: string;
 }
 
 export interface FieldImproveResult {
@@ -112,6 +116,7 @@ export async function runFieldTargetedImprove(
     taskTypes: [taskType],
     model: options.model ?? 'auto',
     skipSourcing: !!options.skipSourcing,
+    skipSourcingReason: options.skipSourcingReason,
   };
 
   const result = await runLoop(loopOptions);
@@ -196,6 +201,7 @@ export async function runScanReportImprove(
     taskTypes: [...taskTypes],
     model: options.model ?? 'auto',
     skipSourcing: !!options.skipSourcing,
+    skipSourcingReason: options.skipSourcingReason,
   };
 
   const result = await runLoop(loopOptions);

--- a/crux/tablebase/loop.ts
+++ b/crux/tablebase/loop.ts
@@ -88,6 +88,7 @@ export async function runLoop(options: LoopOptions): Promise<LoopResult> {
         dryRun: options.dryRun,
         model,
         skipSourcing: options.skipSourcing,
+        skipSourcingReason: options.skipSourcingReason,
         viaPropose: options.viaPropose,
       });
       results.push(result);

--- a/crux/tablebase/skip-sourcing-reasons.test.ts
+++ b/crux/tablebase/skip-sourcing-reasons.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SKIP_SOURCING_REASONS,
+  isSkipSourcingReason,
+  formatSkipSourcingReasonError,
+  formatSkipSourcingAuditReason,
+} from './skip-sourcing-reasons.ts';
+
+describe('skip-sourcing-reasons (QUA-730)', () => {
+  describe('isSkipSourcingReason', () => {
+    it.each(SKIP_SOURCING_REASONS)('accepts the controlled value %s', (reason) => {
+      expect(isSkipSourcingReason(reason)).toBe(true);
+    });
+
+    it('rejects undefined', () => {
+      expect(isSkipSourcingReason(undefined)).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(isSkipSourcingReason('')).toBe(false);
+    });
+
+    it('rejects strings outside the vocabulary', () => {
+      expect(isSkipSourcingReason('because')).toBe(false);
+      expect(isSkipSourcingReason('temporary')).toBe(false);
+      // The pre-QUA-730 free-form value should not validate.
+      expect(isSkipSourcingReason('cli: --skip-sourcing flag set by caller')).toBe(false);
+    });
+
+    it('rejects non-strings', () => {
+      expect(isSkipSourcingReason(null)).toBe(false);
+      expect(isSkipSourcingReason(0)).toBe(false);
+      expect(isSkipSourcingReason({ reason: 'migration' })).toBe(false);
+    });
+  });
+
+  describe('formatSkipSourcingReasonError', () => {
+    it('explains when no reason was provided', () => {
+      const msg = formatSkipSourcingReasonError(undefined);
+      expect(msg).toContain('--skip-sourcing requires --skip-sourcing-reason');
+      expect(msg).toContain('QUA-730');
+      // Lists every allowed value.
+      for (const reason of SKIP_SOURCING_REASONS) {
+        expect(msg).toContain(reason);
+      }
+    });
+
+    it('echoes the rejected value when an invalid one was provided', () => {
+      const msg = formatSkipSourcingReasonError('whatever');
+      expect(msg).toContain('"whatever"');
+      expect(msg).toContain('not in the controlled vocabulary');
+    });
+  });
+
+  describe('formatSkipSourcingAuditReason', () => {
+    it('embeds caller label and reason for the wiki-server audit log', () => {
+      expect(formatSkipSourcingAuditReason('migration', 'cli')).toBe(
+        'cli: skip-sourcing reason=migration',
+      );
+      expect(formatSkipSourcingAuditReason('key-unavailable', 'agent-tool')).toBe(
+        'agent-tool: skip-sourcing reason=key-unavailable',
+      );
+    });
+  });
+});

--- a/crux/tablebase/skip-sourcing-reasons.test.ts
+++ b/crux/tablebase/skip-sourcing-reasons.test.ts
@@ -4,6 +4,8 @@ import {
   isSkipSourcingReason,
   formatSkipSourcingReasonError,
   formatSkipSourcingAuditReason,
+  formatSkipSourcingBanner,
+  checkSkipSourcingReason,
 } from './skip-sourcing-reasons.ts';
 
 describe('skip-sourcing-reasons (QUA-730)', () => {
@@ -60,6 +62,73 @@ describe('skip-sourcing-reasons (QUA-730)', () => {
       expect(formatSkipSourcingAuditReason('key-unavailable', 'agent-tool')).toBe(
         'agent-tool: skip-sourcing reason=key-unavailable',
       );
+    });
+  });
+
+  describe('checkSkipSourcingReason', () => {
+    it('returns null when skipSourcing is absent', () => {
+      expect(checkSkipSourcingReason({})).toBeNull();
+      expect(checkSkipSourcingReason({ skipSourcing: false })).toBeNull();
+    });
+
+    it('returns null when skipSourcing is set with a valid reason', () => {
+      expect(
+        checkSkipSourcingReason({ skipSourcing: true, skipSourcingReason: 'migration' }),
+      ).toBeNull();
+      expect(
+        checkSkipSourcingReason({ skipSourcing: true, skipSourcingReason: 'key-unavailable' }),
+      ).toBeNull();
+    });
+
+    it('returns exit code 2 when skipSourcing is set without a reason', () => {
+      const err = checkSkipSourcingReason({ skipSourcing: true });
+      expect(err).not.toBeNull();
+      expect(err?.exitCode).toBe(2);
+      expect(err?.output).toContain('--skip-sourcing-reason');
+    });
+
+    it('returns exit code 2 when skipSourcing is set with an invalid reason', () => {
+      const err = checkSkipSourcingReason({
+        skipSourcing: true,
+        skipSourcingReason: 'because',
+      });
+      expect(err).not.toBeNull();
+      expect(err?.exitCode).toBe(2);
+      expect(err?.output).toContain('"because"');
+    });
+
+    it('trims whitespace before validating', () => {
+      // Trailing whitespace from manual flag invocation should not reject.
+      expect(
+        checkSkipSourcingReason({ skipSourcing: true, skipSourcingReason: '  testing  ' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('formatSkipSourcingBanner', () => {
+    it('produces a yellow CLI banner', () => {
+      const out = formatSkipSourcingBanner({
+        source: 'cli',
+        recordCount: 20,
+        table: 'personnel',
+        reason: 'key-unavailable',
+      });
+      expect(out).toContain('--skip-sourcing');
+      expect(out).toContain('20 personnel record(s)');
+      expect(out).toContain('Reason: key-unavailable');
+      expect(out).toContain('\x1b[33m'); // yellow
+      expect(out).toContain('═'.repeat(72));
+    });
+
+    it('produces an agent-prefixed banner for the agent path', () => {
+      const out = formatSkipSourcingBanner({
+        source: 'agent',
+        recordCount: 5,
+        table: 'grants',
+        reason: 'testing',
+      });
+      expect(out).toContain('agent --skipSourcing');
+      expect(out).toContain('5 grants record(s)');
     });
   });
 });

--- a/crux/tablebase/skip-sourcing-reasons.ts
+++ b/crux/tablebase/skip-sourcing-reasons.ts
@@ -1,0 +1,74 @@
+/**
+ * Controlled vocabulary for `--skip-sourcing` justifications.
+ *
+ * Background (QUA-730): the original `--skip-sourcing` flag only logged a
+ * generic "cli: --skip-sourcing flag set by caller" string when bypassing
+ * server-side `enforceSourcing`. PR #4612 used it because
+ * `ANTHROPIC_BILLING_KEY` was missing, and 81 personnel records shipped
+ * to production with `verdict: "none"` for every row. Across 71 manifests
+ * (Mar–Apr 2026) only 9% of records ended up with sourcing data attached.
+ *
+ * Requiring a reason from this allowlist forces the caller to acknowledge
+ * which class of bypass they are using, and gives the manifest + audit log
+ * a clean, greppable label.
+ */
+
+export const SKIP_SOURCING_REASONS = [
+  'migration',
+  'backfill',
+  'testing',
+  'key-unavailable',
+  'manual-verified',
+] as const;
+
+export type SkipSourcingReason = (typeof SKIP_SOURCING_REASONS)[number];
+
+const SKIP_SOURCING_REASON_DESCRIPTIONS: Record<SkipSourcingReason, string> = {
+  migration: 'Bulk historical data migration where source URLs predate the cache.',
+  backfill: 'Re-ingesting an existing dataset whose verdicts already exist elsewhere.',
+  testing: 'Local development or CI test run; records are not bound for production.',
+  'key-unavailable': 'ANTHROPIC_BILLING_KEY (or equivalent) missing in the runtime environment.',
+  'manual-verified': 'Operator verified records by inspection before submission.',
+};
+
+export function isSkipSourcingReason(value: unknown): value is SkipSourcingReason {
+  return (
+    typeof value === 'string' &&
+    (SKIP_SOURCING_REASONS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Build a human-readable error message for an invalid (or missing) reason.
+ * Used by both the CLI submit command and the agent-tool handler so callers
+ * see the same vocabulary list.
+ */
+export function formatSkipSourcingReasonError(provided: string | undefined): string {
+  const lines: string[] = [];
+  if (!provided) {
+    lines.push(
+      'Error: --skip-sourcing requires --skip-sourcing-reason=<value> (QUA-730).',
+    );
+  } else {
+    lines.push(
+      `Error: --skip-sourcing-reason="${provided}" is not in the controlled vocabulary (QUA-730).`,
+    );
+  }
+  lines.push('');
+  lines.push('Allowed reasons:');
+  for (const reason of SKIP_SOURCING_REASONS) {
+    lines.push(`  - ${reason}: ${SKIP_SOURCING_REASON_DESCRIPTIONS[reason]}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format the `reason=` query-param value forwarded to wiki-server so the
+ * audit log captures both the controlled-vocabulary tag and the calling path.
+ */
+export function formatSkipSourcingAuditReason(
+  reason: SkipSourcingReason,
+  callerLabel: string,
+): string {
+  return `${callerLabel}: skip-sourcing reason=${reason}`;
+}

--- a/crux/tablebase/skip-sourcing-reasons.ts
+++ b/crux/tablebase/skip-sourcing-reasons.ts
@@ -72,3 +72,65 @@ export function formatSkipSourcingAuditReason(
 ): string {
   return `${callerLabel}: skip-sourcing reason=${reason}`;
 }
+
+/**
+ * Subset of the CLI options used by the reason check. Defined narrowly so the
+ * helper can live next to the vocabulary instead of the CLI-options interface.
+ */
+interface SkipSourcingOptions {
+  skipSourcing?: boolean;
+  skipSourcingReason?: string;
+}
+
+/**
+ * Result returned by `checkSkipSourcingReason` — shaped to match the CLI
+ * `CommandResult` contract so callers can `if (err) return err` without
+ * importing extra types.
+ */
+export interface SkipSourcingCheckError {
+  exitCode: 2;
+  output: string;
+}
+
+/**
+ * Pre-flight reason check shared by every CLI command that forwards the
+ * `--skip-sourcing` flag (submit, improve, field-improve, loop). Exit code 2
+ * matches `crux linear`'s "policy rejection" convention; exit 1 is reserved
+ * for runtime errors.
+ *
+ * Returns `null` when the call is well-formed (or `--skip-sourcing` is
+ * absent). Returns a CommandResult-shaped object that the CLI command should
+ * forward as its own return value when the reason is missing or invalid.
+ */
+export function checkSkipSourcingReason(
+  options: SkipSourcingOptions,
+): SkipSourcingCheckError | null {
+  if (!options.skipSourcing) return null;
+  const provided = options.skipSourcingReason?.trim();
+  if (!isSkipSourcingReason(provided)) {
+    return { exitCode: 2, output: formatSkipSourcingReasonError(provided) };
+  }
+  return null;
+}
+
+/**
+ * Yellow ANSI banner emitted by both the CLI submit command and the agent
+ * tool handler before a `--skip-sourcing` submission. Single source of truth
+ * so the two paths can't drift on width / wording.
+ */
+export function formatSkipSourcingBanner(args: {
+  source: 'cli' | 'agent';
+  recordCount: number;
+  table: string;
+  reason: SkipSourcingReason;
+}): string {
+  const bar = '═'.repeat(72);
+  const sourceLabel = args.source === 'cli' ? '--skip-sourcing' : 'agent --skipSourcing';
+  return [
+    `\x1b[33m${bar}\x1b[0m`,
+    `\x1b[33m  ⚠  ${sourceLabel}: shipping ${args.recordCount} ${args.table} record(s)\x1b[0m`,
+    `\x1b[33m     to production WITHOUT sourcing verification.\x1b[0m`,
+    `\x1b[33m     Reason: ${args.reason}\x1b[0m`,
+    `\x1b[33m${bar}\x1b[0m`,
+  ].join('\n');
+}

--- a/crux/tablebase/tools-via-propose.test.ts
+++ b/crux/tablebase/tools-via-propose.test.ts
@@ -67,7 +67,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -110,7 +110,7 @@ describe('submit_records via /api/enrichment/propose', () => {
   it('skips records whose source URL is not on the T1 allowlist', async () => {
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -151,7 +151,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -187,7 +187,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -229,7 +229,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(personnelTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true, // enabled, but personnel is not in VIA_PROPOSE_TABLES
     });
 
@@ -270,7 +270,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -295,7 +295,7 @@ describe('submit_records via /api/enrichment/propose', () => {
   it('records without source URL are rejected before hitting /propose', async () => {
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: true,
     });
 
@@ -324,7 +324,7 @@ describe('submit_records via /api/enrichment/propose', () => {
 
     const { buildToolHandlers } = await import('./tools.ts');
     const handlers = buildToolHandlers(grantBackfillTask, false, {
-      skipSourcing: true,
+      skipSourcing: true, skipSourcingReason: 'testing',
       viaPropose: false,
     });
 

--- a/crux/tablebase/tools.test.ts
+++ b/crux/tablebase/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { ensureSidPrefix, __testing__ } from './tools.ts';
+import { ensureSidPrefix, __testing__, buildToolHandlers } from './tools.ts';
+import type { EnrichmentTask } from './types.ts';
 
 describe('ensureSidPrefix', () => {
   it('adds sid_ prefix to a bare 10-char stableId', () => {
@@ -84,5 +85,50 @@ describe('resolveNonEntityForeignKeys', () => {
     const records = [{ benchmarkId: 'sid_pDqehtEoiw', modelId: 'sid_cMKB5i2WZQ' }];
     resolveNonEntityForeignKeys('benchmark-results', records, slugMap);
     expect(records[0].modelId).toBe('sid_cMKB5i2WZQ');
+  });
+});
+
+describe('buildToolHandlers — skip-sourcing reason contract (QUA-730)', () => {
+  const task: EnrichmentTask = {
+    id: 't1',
+    taskType: 'personnel-fill',
+    entityId: 'sid_test',
+    entityName: 'Test Org',
+    entityType: 'organization',
+    table: 'personnel',
+    impactScore: 0,
+    reasons: [],
+    existingRecordCount: 0,
+  };
+
+  it('throws when skipSourcing is set without a reason', () => {
+    expect(() =>
+      buildToolHandlers(task, false, { skipSourcing: true }),
+    ).toThrow(/--skip-sourcing-reason/);
+  });
+
+  it('throws when the reason is outside the controlled vocabulary', () => {
+    expect(() =>
+      buildToolHandlers(task, false, {
+        skipSourcing: true,
+        skipSourcingReason: 'because-i-said-so',
+      }),
+    ).toThrow(/controlled vocabulary/);
+  });
+
+  it('accepts each value from the allowlist', () => {
+    const allowlist = ['migration', 'backfill', 'testing', 'key-unavailable', 'manual-verified'];
+    for (const reason of allowlist) {
+      expect(() =>
+        buildToolHandlers(task, false, { skipSourcing: true, skipSourcingReason: reason }),
+      ).not.toThrow();
+    }
+  });
+
+  it('does not require a reason when skipSourcing is false', () => {
+    expect(() => buildToolHandlers(task, false, {})).not.toThrow();
+    expect(() =>
+      buildToolHandlers(task, false, { skipSourcing: false }),
+    ).not.toThrow();
   });
 });

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -24,6 +24,12 @@ import { toSlug } from './types.ts';
 import { getTableConfig } from './table-registry.ts';
 import type { EnrichmentTask, TaskType } from './types.ts';
 import {
+  isSkipSourcingReason,
+  formatSkipSourcingReasonError,
+  formatSkipSourcingAuditReason,
+  type SkipSourcingReason,
+} from './skip-sourcing-reasons.ts';
+import {
   dedupPersonnel,
   dedupFundingRounds,
   dedupInvestments,
@@ -544,6 +550,7 @@ async function handleSubmitRecords(
   dryRun: boolean,
   skipSourcing: boolean = false,
   viaPropose: boolean = false,
+  skipSourcingReason?: SkipSourcingReason,
 ): Promise<string> {
   const table = input.table as string;
   const records = input.records as Array<Record<string, unknown>>;
@@ -728,8 +735,21 @@ async function handleSubmitRecords(
   const syncParams = new URLSearchParams();
   if (syncConfig.requireSourcing) syncParams.set('requireSourcing', 'true');
   if (skipSourcing) {
+    // QUA-730: skipSourcingReason was validated against the allowlist in buildToolHandlers.
+    // Defensive re-check so this entry point fails closed if a future caller adds a path
+    // that bypasses buildToolHandlers.
+    if (!isSkipSourcingReason(skipSourcingReason)) {
+      return `Error: --skipSourcing requires a controlled-vocabulary reason (QUA-730). ${formatSkipSourcingReasonError(skipSourcingReason)}`;
+    }
     syncParams.set('forceSkipSourcing', 'true');
-    syncParams.set('reason', 'agent-tool: --skipSourcing flag set by caller');
+    syncParams.set('reason', formatSkipSourcingAuditReason(skipSourcingReason, 'agent-tool'));
+
+    const banner = '═'.repeat(72);
+    console.warn(`\x1b[33m${banner}\x1b[0m`);
+    console.warn(`\x1b[33m  ⚠  agent --skipSourcing: shipping ${recordsToSubmit.length} ${table} record(s)\x1b[0m`);
+    console.warn(`\x1b[33m     to production WITHOUT sourcing verification.\x1b[0m`);
+    console.warn(`\x1b[33m     Reason: ${skipSourcingReason}\x1b[0m`);
+    console.warn(`\x1b[33m${banner}\x1b[0m`);
   }
   const syncQs = syncParams.toString();
   const syncUrl = syncQs ? `${syncConfig.syncPath}?${syncQs}` : syncConfig.syncPath;
@@ -967,11 +987,23 @@ async function handleLinkSource(
 export function buildToolHandlers(
   task: EnrichmentTask,
   dryRun: boolean,
-  options: { skipSourcing?: boolean; apply?: boolean; viaPropose?: boolean } = {},
+  options: { skipSourcing?: boolean; skipSourcingReason?: string; apply?: boolean; viaPropose?: boolean } = {},
 ): Record<string, (input: Record<string, unknown>) => Promise<string>> {
   const skipSourcing = options.skipSourcing ?? false;
+  const skipSourcingReason = options.skipSourcingReason;
   const viaPropose = options.viaPropose ?? false;
   const isSourceDiscovery = task.taskType === 'source-discovery';
+
+  // QUA-730: enforce the skip-sourcing reason allowlist at the agent-tool entry point.
+  // We throw synchronously rather than per-call so a misconfigured loop fails before
+  // the LLM agent starts, not after it has already burned a budget on tool calls.
+  let validatedReason: SkipSourcingReason | undefined;
+  if (skipSourcing) {
+    if (!isSkipSourcingReason(skipSourcingReason)) {
+      throw new Error(formatSkipSourcingReasonError(skipSourcingReason));
+    }
+    validatedReason = skipSourcingReason;
+  }
 
   const handlers: Record<string, (input: Record<string, unknown>) => Promise<string>> = {
     query_entities: handleQueryEntities,
@@ -980,7 +1012,7 @@ export function buildToolHandlers(
     create_entity: async (input) => dryRun
       ? `[DRY RUN] Would create ${input.entityType} entity: "${input.name}"`
       : handleCreateEntity(input),
-    submit_records: async (input) => handleSubmitRecords(input, task, dryRun, skipSourcing, viaPropose),
+    submit_records: async (input) => handleSubmitRecords(input, task, dryRun, skipSourcing, viaPropose, validatedReason),
     submit_claims: async (input) => dryRun
       ? `[DRY RUN] Would submit ${(input.claims as unknown[])?.length ?? 0} claims for ${input.targetTable}`
       : handleSubmitClaims(input, task),

--- a/crux/tablebase/tools.ts
+++ b/crux/tablebase/tools.ts
@@ -27,6 +27,7 @@ import {
   isSkipSourcingReason,
   formatSkipSourcingReasonError,
   formatSkipSourcingAuditReason,
+  formatSkipSourcingBanner,
   type SkipSourcingReason,
 } from './skip-sourcing-reasons.ts';
 import {
@@ -744,12 +745,12 @@ async function handleSubmitRecords(
     syncParams.set('forceSkipSourcing', 'true');
     syncParams.set('reason', formatSkipSourcingAuditReason(skipSourcingReason, 'agent-tool'));
 
-    const banner = '═'.repeat(72);
-    console.warn(`\x1b[33m${banner}\x1b[0m`);
-    console.warn(`\x1b[33m  ⚠  agent --skipSourcing: shipping ${recordsToSubmit.length} ${table} record(s)\x1b[0m`);
-    console.warn(`\x1b[33m     to production WITHOUT sourcing verification.\x1b[0m`);
-    console.warn(`\x1b[33m     Reason: ${skipSourcingReason}\x1b[0m`);
-    console.warn(`\x1b[33m${banner}\x1b[0m`);
+    console.warn(formatSkipSourcingBanner({
+      source: 'agent',
+      recordCount: recordsToSubmit.length,
+      table,
+      reason: skipSourcingReason,
+    }));
   }
   const syncQs = syncParams.toString();
   const syncUrl = syncQs ? `${syncConfig.syncPath}?${syncQs}` : syncConfig.syncPath;

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -140,6 +140,11 @@ export interface LoopOptions {
   /** Skip sourcing before submitting records */
   skipSourcing?: boolean;
   /**
+   * QUA-730: required when skipSourcing is true. Must be in
+   * SKIP_SOURCING_REASONS. Validated by the agent-tool entry point.
+   */
+  skipSourcingReason?: string;
+  /**
    * QUA-655: route supported record types through
    * `POST /api/enrichment/propose` (tier-aware defensive gate) instead of the
    * direct `/sync` endpoint. Phase 1 supports grants only; non-T1 sources are

--- a/crux/tablebase/types.ts
+++ b/crux/tablebase/types.ts
@@ -140,8 +140,10 @@ export interface LoopOptions {
   /** Skip sourcing before submitting records */
   skipSourcing?: boolean;
   /**
-   * QUA-730: required when skipSourcing is true. Must be in
-   * SKIP_SOURCING_REASONS. Validated by the agent-tool entry point.
+   * QUA-730: required when skipSourcing is true. Validated by the agent-tool
+   * entry point. Typed as `string` here (not `SkipSourcingReason`) because
+   * CLI string values are forwarded raw from `options.skipSourcingReason`;
+   * the runtime check in `buildToolHandlers` narrows them.
    */
   skipSourcingReason?: string;
   /**

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -347,6 +347,17 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-730: any newly added/modified manifest in data/tablebase-manifests/
+    // must have at least one record with sourcing data. Catches the
+    // "agent ran with --skip-sourcing because the billing key was missing"
+    // failure mode (PR #4612, all 81 records shipped with verdict=none).
+    id: 'manifest-sourcing',
+    name: 'TableBase manifest sourcing (no all-unverified bulk drops)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-manifest-sourcing.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // QUA-700: catches `${{ secrets.X }}` references in workflow YAMLs that
     // don't resolve to a real repo or org-inherited secret (the QUA-676
     // root cause). Advisory because (a) forks/local environments lack gh

--- a/crux/validate/validate-manifest-sourcing.test.ts
+++ b/crux/validate/validate-manifest-sourcing.test.ts
@@ -87,6 +87,77 @@ describe('validate-manifest-sourcing (QUA-730)', () => {
       const v = evaluateManifest(REL, { table: 'personnel', recordCount: 50 });
       expect(v).toBeNull();
     });
+
+    it('flags newly-added manifests using the pre-2026-04-09 verificationSummary schema as a regression', () => {
+      // Without this branch, a writer that emits the old schema would slip
+      // through the "absent sourcingSummary → skip" carve-out — exactly the
+      // bug the gate is meant to catch. See QUA-730 review feedback.
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        verificationSummary: { withVerification: 0, withoutVerification: 20 },
+      });
+      expect(v).not.toBeNull();
+      expect(v?.reason).toBe('legacy-schema');
+      expect(v?.withSourcing).toBe(0);
+      expect(v?.withoutSourcing).toBe(20);
+    });
+
+    it('does not flag legacy-schema manifests when sourcingSummary is also present (writer bridging)', () => {
+      // If a writer emits BOTH summaries (e.g. during a migration), trust
+      // the new schema. Only the no-sourcingSummary branch is a regression.
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        verificationSummary: { withVerification: 0, withoutVerification: 20 },
+        sourcingSummary: { withSourcing: 20, withoutSourcing: 0 },
+      });
+      expect(v).toBeNull();
+    });
+
+    it('flags violations with reason="no-sourcing" for the standard failure mode', () => {
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: 20 },
+      });
+      expect(v?.reason).toBe('no-sourcing');
+    });
+
+    it('treats string values for recordCount/withSourcing as zero (adversarial-input guard)', () => {
+      // Without coercion, a JSON authoring bug like `recordCount: "20"` could
+      // either silently pass or silently fail. We coerce non-numbers to 0 so
+      // the manifest never sneaks past with a stringified count.
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        // @ts-expect-error testing wrong-type input
+        recordCount: '20',
+        // @ts-expect-error testing wrong-type input
+        sourcingSummary: { withSourcing: '0', withoutSourcing: '20' },
+      });
+      // recordCount becomes 0 → below MIN_RECORDS_FOR_GATE → skipped.
+      expect(v).toBeNull();
+    });
+
+    it('rejects null/undefined data without throwing', () => {
+      expect(evaluateManifest(REL, null)).toBeNull();
+      // @ts-expect-error testing wrong-type input
+      expect(evaluateManifest(REL, undefined)).toBeNull();
+    });
+
+    it('handles a legacy-schema manifest where the summary fields are stringified', () => {
+      // Coercion still applies on the legacy branch — withSourcing should
+      // surface as 0, not "0".
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        // @ts-expect-error testing wrong-type input
+        verificationSummary: { withVerification: '0', withoutVerification: '20' },
+      });
+      expect(v?.reason).toBe('legacy-schema');
+      expect(v?.withSourcing).toBe(0);
+      expect(v?.withoutSourcing).toBe(0); // both stringified → both coerce to 0
+    });
   });
 
   describe('runCheck', () => {

--- a/crux/validate/validate-manifest-sourcing.test.ts
+++ b/crux/validate/validate-manifest-sourcing.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateManifest, MIN_RECORDS_FOR_GATE, runCheck } from './validate-manifest-sourcing.ts';
+
+const F = '2026-04-30-100000-personnel.json';
+const REL = `data/tablebase-manifests/${F}`;
+
+describe('validate-manifest-sourcing (QUA-730)', () => {
+  describe('evaluateManifest', () => {
+    it('flags a bulk manifest with no sourcing data', () => {
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: 20 },
+      });
+      expect(v).not.toBeNull();
+      expect(v?.recordCount).toBe(20);
+      expect(v?.withSourcing).toBe(0);
+      expect(v?.withoutSourcing).toBe(20);
+      expect(v?.file).toBe(REL);
+      expect(v?.table).toBe('personnel');
+    });
+
+    it('passes when at least one record has sourcing', () => {
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        sourcingSummary: { withSourcing: 1, withoutSourcing: 19 },
+      });
+      expect(v).toBeNull();
+    });
+
+    it('passes when every record has sourcing', () => {
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 20,
+        sourcingSummary: { withSourcing: 20, withoutSourcing: 0 },
+      });
+      expect(v).toBeNull();
+    });
+
+    it(`exempts manifests with <= ${MIN_RECORDS_FOR_GATE} records`, () => {
+      // Boundary: a manifest with exactly MIN_RECORDS_FOR_GATE records is exempt.
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: MIN_RECORDS_FOR_GATE,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: MIN_RECORDS_FOR_GATE },
+      });
+      expect(v).toBeNull();
+    });
+
+    it(`fires at MIN_RECORDS_FOR_GATE + 1`, () => {
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: MIN_RECORDS_FOR_GATE + 1,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: MIN_RECORDS_FOR_GATE + 1 },
+      });
+      expect(v).not.toBeNull();
+    });
+
+    it('skips legacy manifests where sourcingSummary fields are both 0 (pre-2026-04-09 format)', () => {
+      // Both `withSourcing === 0` and `withoutSourcing === 0` is the signal
+      // that the field wasn't populated by the writer. Without this carve-out
+      // every old manifest in the diff would fail the gate.
+      const v = evaluateManifest(REL, {
+        table: 'personnel',
+        recordCount: 50,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: 0 },
+      });
+      expect(v).toBeNull();
+    });
+
+    it('returns null when the manifest body cannot be loaded', () => {
+      expect(evaluateManifest(REL, null)).toBeNull();
+    });
+
+    it('falls back to the basename when the table field is missing', () => {
+      const v = evaluateManifest(REL, {
+        recordCount: 10,
+        sourcingSummary: { withSourcing: 0, withoutSourcing: 10 },
+      });
+      expect(v).not.toBeNull();
+      expect(v?.table).toBe('2026-04-30-100000-personnel');
+    });
+
+    it('treats absent sourcingSummary as legacy and skips', () => {
+      // No sourcingSummary key at all: behave the same as both-zero.
+      const v = evaluateManifest(REL, { table: 'personnel', recordCount: 50 });
+      expect(v).toBeNull();
+    });
+  });
+
+  describe('runCheck', () => {
+    it('returns passed=true with empty diff (smoke test on this branch)', () => {
+      // Sanity check: when invoked from the actual project root, the validator
+      // should at minimum not throw. The actual behavior depends on what's in
+      // the diff — this only asserts the runCheck pathway is wired.
+      const result = runCheck();
+      expect(result).toHaveProperty('passed');
+      expect(result).toHaveProperty('errors');
+      expect(result).toHaveProperty('violations');
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.violations)).toBe(true);
+    });
+  });
+});

--- a/crux/validate/validate-manifest-sourcing.ts
+++ b/crux/validate/validate-manifest-sourcing.ts
@@ -38,9 +38,22 @@ const MIN_RECORDS_FOR_GATE = 5;
 interface ManifestSummary {
   table?: string;
   recordCount?: number;
+  /**
+   * Current schema (post-2026-04-09). The legacy schema below is rejected
+   * for any newly-added manifest because it implies the writer regressed.
+   */
   sourcingSummary?: {
     withSourcing?: number;
     withoutSourcing?: number;
+  };
+  /**
+   * Pre-2026-04-09 schema. Still appears on grandfathered manifests in main,
+   * but new manifests in the diff using this schema are flagged as a
+   * regression — see `evaluateManifest`.
+   */
+  verificationSummary?: {
+    withVerification?: number;
+    withoutVerification?: number;
   };
 }
 
@@ -50,6 +63,12 @@ interface Violation {
   recordCount: number;
   withSourcing: number;
   withoutSourcing: number;
+  /**
+   * Why the manifest failed: 'no-sourcing' = recorded but every record is
+   * unverified; 'legacy-schema' = uses pre-QUA-730 verificationSummary in
+   * a newly-added file (regression).
+   */
+  reason: 'no-sourcing' | 'legacy-schema';
 }
 
 /**
@@ -94,6 +113,14 @@ export function getAddedManifestFiles(): string[] {
     addLines(
       tryGit(['diff', '--name-only', '--diff-filter=AM', base, 'HEAD', '--', `${MANIFEST_DIR}/*.json`]),
     );
+  } else {
+    // Shallow clones / detached HEAD without origin/main: the committed-vs-main
+    // branch is silently dropped. Staged + unstaged + untracked still fire,
+    // which is enough for pre-push gate runs but leaves a coverage gap in CI
+    // environments that lose the merge base. Surface that visibly.
+    console.warn(
+      '[validate-manifest-sourcing] No merge base for HEAD vs origin/main or main — skipping committed-diff scan',
+    );
   }
 
   // 2. Staged changes (vs HEAD) — catches manifests that have been git-add'd
@@ -119,9 +146,18 @@ function loadManifest(absPath: string): ManifestSummary | null {
   try {
     const raw = readFileSync(absPath, 'utf-8');
     return JSON.parse(raw) as ManifestSummary;
-  } catch {
+  } catch (err: unknown) {
+    // Surface malformed manifests instead of silently treating them as
+    // legacy-and-skip. A JSON parse failure in PR review is an authoring bug.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[validate-manifest-sourcing] Could not parse ${absPath}: ${msg}`);
     return null;
   }
+}
+
+/** Coerce a possibly-non-numeric JSON value to a finite integer (or 0). */
+function toCount(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }
 
 /**
@@ -134,24 +170,46 @@ export function evaluateManifest(
 ): Violation | null {
   if (!data) return null;
 
-  const recordCount = data.recordCount ?? 0;
+  const recordCount = toCount(data.recordCount);
   if (recordCount <= MIN_RECORDS_FOR_GATE) return null;
 
-  const summary = data.sourcingSummary ?? {};
-  const withSourcing = summary.withSourcing ?? 0;
-  const withoutSourcing = summary.withoutSourcing ?? 0;
+  const table = data.table ?? basename(relPath, '.json');
 
-  // Manifests written before the sourcingSummary field existed don't have
-  // either count populated; skip them.
+  // QUA-730 regression guard: the legacy `verificationSummary` schema (used
+  // pre-2026-04-09) is grandfathered on main but must NOT appear in newly
+  // added manifests. If a future writer regresses to the old schema, the
+  // current validator's "skip when sourcingSummary is empty" logic would
+  // pass it silently — exactly the failure mode this gate is meant to catch.
+  if (data.verificationSummary && !data.sourcingSummary) {
+    const v = data.verificationSummary;
+    return {
+      file: relPath,
+      table,
+      recordCount,
+      withSourcing: toCount(v.withVerification),
+      withoutSourcing: toCount(v.withoutVerification),
+      reason: 'legacy-schema',
+    };
+  }
+
+  const summary = data.sourcingSummary ?? {};
+  const withSourcing = toCount(summary.withSourcing);
+  const withoutSourcing = toCount(summary.withoutSourcing);
+
+  // Pre-2026-04-09 manifests have neither field populated; skip them. (A new
+  // manifest with no sourcingSummary at all is treated the same — there's
+  // nothing to gate on. The legacy-schema branch above catches the obvious
+  // regression of writing verificationSummary on purpose.)
   if (withSourcing === 0 && withoutSourcing === 0) return null;
 
   if (withSourcing === 0) {
     return {
       file: relPath,
-      table: data.table ?? basename(relPath, '.json'),
+      table,
       recordCount,
       withSourcing,
       withoutSourcing,
+      reason: 'no-sourcing',
     };
   }
   return null;
@@ -194,20 +252,21 @@ export function runCheck(): ValidationResult {
     );
   } else {
     console.log(
-      `${c.red}Found ${violations.length} manifest(s) shipping records WITHOUT any sourcing verification:${c.reset}\n`,
+      `${c.red}Found ${violations.length} manifest(s) failing the sourcing gate:${c.reset}\n`,
     );
     for (const v of violations) {
-      console.log(`  ${c.red}${v.file}${c.reset}`);
+      const tag = v.reason === 'legacy-schema' ? 'legacy-schema regression' : 'all records unverified';
+      console.log(`  ${c.red}${v.file} — ${tag}${c.reset}`);
       console.log(
-        `    ${c.dim}table=${v.table} recordCount=${v.recordCount} withSourcing=0 withoutSourcing=${v.withoutSourcing}${c.reset}`,
+        `    ${c.dim}table=${v.table} recordCount=${v.recordCount} withSourcing=${v.withSourcing} withoutSourcing=${v.withoutSourcing}${c.reset}`,
       );
     }
     console.log('');
     console.log(
-      `${c.dim}This usually means the run used --skip-sourcing (e.g. missing ANTHROPIC_BILLING_KEY).${c.reset}`,
+      `${c.dim}'all records unverified' usually means --skip-sourcing was used (e.g. missing ANTHROPIC_BILLING_KEY).${c.reset}`,
     );
     console.log(
-      `${c.dim}Re-run with sourcing enabled, or split the unverified records out of the PR until they can be sourcing-verified.${c.reset}`,
+      `${c.dim}'legacy-schema regression' means the writer emitted the pre-2026-04-09 verificationSummary field; rewrite to sourcingSummary.${c.reset}`,
     );
     console.log(
       `${c.dim}Manifests with ≤${MIN_RECORDS_FOR_GATE} records are exempt; this gate fires only on bulk drops.${c.reset}`,

--- a/crux/validate/validate-manifest-sourcing.ts
+++ b/crux/validate/validate-manifest-sourcing.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that newly-added TableBase enrichment manifests in
+ * `data/tablebase-manifests/` ship records with sourcing verdicts
+ * attached, not all `verdict: "none"` / `withoutSourcing: N`.
+ *
+ * Background: QUA-730. Across 71 manifests written between Mar–Apr 2026,
+ * only 9% of records ended up with sourcing data attached. PR #4612 was the
+ * inciting case: 81 personnel records shipped with `verdict: "none"` for
+ * every row because the agent ran with `--skip-sourcing` after
+ * `ANTHROPIC_BILLING_KEY` was missing. CodeRabbit happened to flag it; the
+ * gate did not.
+ *
+ * Rule: a manifest in the diff fails if both
+ *   - `recordCount > MIN_RECORDS_FOR_GATE` (small manifests aren't worth a
+ *     gate trip), and
+ *   - `sourcingSummary.withSourcing === 0` (every record shipped without
+ *     sourcing evidence).
+ *
+ * Scope: only files added or modified in the current branch's diff vs main.
+ * Existing manifests on main are grandfathered — adding a check that
+ * scanned all manifests would fail the gate against the baseline.
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-manifest-sourcing.ts
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { execFileSync, execSync } from 'child_process';
+import { join, basename } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const MANIFEST_DIR = 'data/tablebase-manifests';
+const MIN_RECORDS_FOR_GATE = 5;
+
+interface ManifestSummary {
+  table?: string;
+  recordCount?: number;
+  sourcingSummary?: {
+    withSourcing?: number;
+    withoutSourcing?: number;
+  };
+}
+
+interface Violation {
+  file: string;
+  table: string;
+  recordCount: number;
+  withSourcing: number;
+  withoutSourcing: number;
+}
+
+/**
+ * Files added or modified on this branch vs origin/main, plus staged and
+ * untracked manifests in the working tree. Pre-push gate runs need to see
+ * a manifest that's staged but not yet committed; CI runs need to see what
+ * landed on the branch. Returns relative paths (matching git's output).
+ */
+export function getAddedManifestFiles(): string[] {
+  const collected = new Set<string>();
+
+  function tryGit(args: string[]): string {
+    try {
+      return execFileSync('git', args, { cwd: PROJECT_ROOT, encoding: 'utf-8' }).trim();
+    } catch {
+      return '';
+    }
+  }
+
+  function addLines(out: string): void {
+    if (!out) return;
+    for (const line of out.split('\n')) {
+      const f = line.trim();
+      if (!f) continue;
+      if (f.startsWith(`${MANIFEST_DIR}/`) && f.endsWith('.json')) {
+        collected.add(f);
+      }
+    }
+  }
+
+  // 1. Committed changes vs origin/main (or fallback to local main).
+  let base = '';
+  try {
+    base = execSync(
+      'git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null',
+      { cwd: PROJECT_ROOT, encoding: 'utf-8' },
+    ).trim();
+  } catch {
+    base = '';
+  }
+  if (base) {
+    addLines(
+      tryGit(['diff', '--name-only', '--diff-filter=AM', base, 'HEAD', '--', `${MANIFEST_DIR}/*.json`]),
+    );
+  }
+
+  // 2. Staged changes (vs HEAD) — catches manifests that have been git-add'd
+  //    but not yet committed.
+  addLines(
+    tryGit(['diff', '--name-only', '--cached', '--diff-filter=AM', '--', `${MANIFEST_DIR}/*.json`]),
+  );
+
+  // 3. Unstaged tracked modifications.
+  addLines(
+    tryGit(['diff', '--name-only', '--diff-filter=AM', '--', `${MANIFEST_DIR}/*.json`]),
+  );
+
+  // 4. Untracked manifests (new files not yet staged).
+  addLines(
+    tryGit(['ls-files', '--others', '--exclude-standard', '--', `${MANIFEST_DIR}/*.json`]),
+  );
+
+  return [...collected].sort();
+}
+
+function loadManifest(absPath: string): ManifestSummary | null {
+  try {
+    const raw = readFileSync(absPath, 'utf-8');
+    return JSON.parse(raw) as ManifestSummary;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure-function form of the per-manifest check, exported so tests can drive
+ * it without setting up a git repo.
+ */
+export function evaluateManifest(
+  relPath: string,
+  data: ManifestSummary | null,
+): Violation | null {
+  if (!data) return null;
+
+  const recordCount = data.recordCount ?? 0;
+  if (recordCount <= MIN_RECORDS_FOR_GATE) return null;
+
+  const summary = data.sourcingSummary ?? {};
+  const withSourcing = summary.withSourcing ?? 0;
+  const withoutSourcing = summary.withoutSourcing ?? 0;
+
+  // Manifests written before the sourcingSummary field existed don't have
+  // either count populated; skip them.
+  if (withSourcing === 0 && withoutSourcing === 0) return null;
+
+  if (withSourcing === 0) {
+    return {
+      file: relPath,
+      table: data.table ?? basename(relPath, '.json'),
+      recordCount,
+      withSourcing,
+      withoutSourcing,
+    };
+  }
+  return null;
+}
+
+function checkManifest(relPath: string): Violation | null {
+  const absPath = join(PROJECT_ROOT, relPath);
+  if (!existsSync(absPath)) return null; // Modified-then-deleted edge case.
+  return evaluateManifest(relPath, loadManifest(absPath));
+}
+
+export interface ValidationResult {
+  passed: boolean;
+  errors: number;
+  violations: Violation[];
+  filesChecked: number;
+}
+
+export function runCheck(): ValidationResult {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking new tablebase manifests for missing sourcing data (QUA-730)...${c.reset}\n`,
+  );
+
+  const files = getAddedManifestFiles();
+  if (files.length === 0) {
+    console.log(`${c.dim}No new/modified manifests in this diff${c.reset}`);
+    return { passed: true, errors: 0, violations: [], filesChecked: 0 };
+  }
+
+  const violations: Violation[] = [];
+  for (const f of files) {
+    const v = checkManifest(f);
+    if (v) violations.push(v);
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `${c.green}All ${files.length} new manifest(s) have at least one sourcing-verified record${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${violations.length} manifest(s) shipping records WITHOUT any sourcing verification:${c.reset}\n`,
+    );
+    for (const v of violations) {
+      console.log(`  ${c.red}${v.file}${c.reset}`);
+      console.log(
+        `    ${c.dim}table=${v.table} recordCount=${v.recordCount} withSourcing=0 withoutSourcing=${v.withoutSourcing}${c.reset}`,
+      );
+    }
+    console.log('');
+    console.log(
+      `${c.dim}This usually means the run used --skip-sourcing (e.g. missing ANTHROPIC_BILLING_KEY).${c.reset}`,
+    );
+    console.log(
+      `${c.dim}Re-run with sourcing enabled, or split the unverified records out of the PR until they can be sourcing-verified.${c.reset}`,
+    );
+    console.log(
+      `${c.dim}Manifests with ≤${MIN_RECORDS_FOR_GATE} records are exempt; this gate fires only on bulk drops.${c.reset}`,
+    );
+  }
+
+  return {
+    passed: violations.length === 0,
+    errors: violations.length,
+    violations,
+    filesChecked: files.length,
+  };
+}
+
+if (process.argv[1]?.includes('validate-manifest-sourcing')) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}
+
+// Re-export the constant for tests.
+export { MIN_RECORDS_FOR_GATE };


### PR DESCRIPTION
## Summary

Closes the gating gap that let PR #4612 ship 81 personnel records to production with `verdict: "none"` for every row. Across 71 manifests in Mar–Apr 2026, only **9% of records (64/710)** ended up with sourcing data attached. CodeRabbit caught one PR; the gate didn't.

Two layers of defense, picking Option 1 (block) + Option 3 (mark) from the QUA-730 body:

1. **CLI controlled-vocabulary reason** — `--skip-sourcing` now requires `--skip-sourcing-reason=<value>` from `{migration, backfill, testing, key-unavailable, manual-verified}`. The reason propagates through `submit`, `improve`, `loop`, `field-improve`, the agent, and into the wiki-server audit log as a structured `cli|agent-tool: skip-sourcing reason=<vocab>` string. A loud yellow banner prints the count that's about to ship unverified.
2. **Gate validator** (`crux/validate/validate-manifest-sourcing.ts`, blocking) — flags any newly-added or modified manifest in the diff where `withSourcing == 0 && recordCount > 5`. Also catches regressions to the pre-2026-04-09 `verificationSummary` schema. The 71 existing manifests are grandfathered (diff-only scan).

## Why not the full QUA-722 atomic ingest

The architectural answer is QUA-722 (atomic propose-fact ingest). But:
- The CLI fix above closes 100% of the path where every recent failure originated.
- It's a 1-day stop-gap that doesn't conflict with QUA-722's design.
- Server-side `forceSkipSourcing` allowlist is filed as **QUA-862** (separate PR — touches a hotter path).

If QUA-722 lands first, QUA-862 can close as superseded.

## Test plan

- [x] `crux/tablebase/skip-sourcing-reasons.test.ts` — 19 unit tests on the vocabulary, audit-format helper, banner, and `checkSkipSourcingReason`.
- [x] `crux/validate/validate-manifest-sourcing.test.ts` — 16 tests including boundary at `MIN_RECORDS_FOR_GATE`, the legacy-manifest carve-out, the legacy-schema regression branch, and adversarial JSON-input coercion.
- [x] `crux/tablebase/tools.test.ts` — 4 new tests on `buildToolHandlers` reason-validation contract.
- [x] Existing `crux/tablebase/tools-via-propose.test.ts` (8 tests) updated to pass `skipSourcingReason: 'testing'`.
- [x] Existing `crux/tablebase/field-improve.test.ts` updated — the prior test was forwarding `skipSourcing: true` with no reason, which is now an invalid call.
- [x] Verified by hand: synthetic `verdict=none` manifest fires the gate (exit 1); legacy-schema manifest fires the gate (exit 1); clean diff passes silently (exit 0).
- [x] CLI verified: `--skip-sourcing` without reason → exit 2 + help; with bad reason → exit 2 + help echoing rejected value; with valid reason → submit proceeds with banner.
- [x] `pnpm crux w validate gate --fix --no-cache` passes locally (61 blocking checks, 3 pre-existing advisory).
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors in the 8 changed files.

## Caller breakage

`buildToolHandlers` now throws synchronously when `skipSourcing: true` is passed without a valid reason. Existing in-tree callers updated. Any external caller passing `skipSourcing: true` will see a clear error pointing at the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-730
