### PR TITLE
scorecards: internal hyperlinks + drop font-mono on prose verdicts

### DIFF
--- a/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.test.tsx
@@ -1,0 +1,232 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScorecardsSection } from "./scorecards-section";
+
+/**
+ * QUA-838: panel headers on the org-tab scorecards section must link to
+ * the per-source detail page (`/scorecards/[source]`) and the publisher
+ * (when their wiki entity exists) — not be plain text.
+ *
+ * QUA-861: the overall pill and per-dimension cells must drop `font-mono`
+ * for prose verdicts (Fulfilled, Weak, …) and keep it for letter/numeric
+ * grades.
+ */
+
+interface GradeRow {
+  id: string;
+  snapshotId: string;
+  scorecardSource: string | null;
+  publishedAt: string | null;
+  isLatest: boolean | null;
+  entityId: string;
+  entityDisplayName: string;
+  dimensionSlug: string;
+  dimensionLabel: string;
+  scoreNumeric: number | null;
+  scoreLetter: string | null;
+  scoreRaw: string;
+  notes: string | null;
+  sourcing: { verdict: string; checkedAt: string | null } | null;
+}
+
+function makeRow(overrides: Partial<GradeRow>): GradeRow {
+  return {
+    id: "row-1",
+    snapshotId: "snap-1",
+    scorecardSource: "fli_index",
+    publishedAt: "2025-12-02",
+    isLatest: true,
+    entityId: "sid_anthropic",
+    entityDisplayName: "Anthropic",
+    dimensionSlug: "overall",
+    dimensionLabel: "Overall",
+    scoreNumeric: null,
+    scoreLetter: "C+",
+    scoreRaw: "C+",
+    notes: null,
+    sourcing: null,
+    ...overrides,
+  };
+}
+
+describe("ScorecardsSection — internal hyperlinks (QUA-838)", () => {
+  it("links the panel heading to /scorecards/<source>", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [makeRow({ scorecardSource: "fli_index" })],
+          },
+        ]}
+      />,
+    );
+
+    const heading = screen.getByRole("link", { name: "FLI AI Safety Index" });
+    expect(heading).toHaveAttribute("href", "/scorecards/fli_index");
+  });
+
+  it("links the publisher to its wiki entity when publisherSlug is set", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [makeRow({ scorecardSource: "fli_index" })],
+          },
+        ]}
+      />,
+    );
+
+    // FLI is the only source with publisherSlug defined.
+    const publisherLink = screen.getByRole("link", {
+      name: "Future of Life Institute",
+    });
+    expect(publisherLink).toHaveAttribute("href", "/organizations/fli");
+  });
+
+  it("renders the publisher as plain text when no slug is configured", () => {
+    // AI Lab Watch has publisher "Zach Stein-Perlman" with no publisherSlug —
+    // the publisher should appear as plain text, not a link.
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "ailabwatch",
+            publishedAt: "2025-09-01",
+            rows: [makeRow({ scorecardSource: "ailabwatch" })],
+          },
+        ]}
+      />,
+    );
+
+    // Publisher name should be present in the document.
+    expect(screen.getByText(/by Zach Stein-Perlman/)).toBeInTheDocument();
+    // But there should be no link with the publisher name.
+    const publisherLinks = screen
+      .queryAllByRole("link")
+      .filter((el) => /Zach Stein-Perlman/.test(el.textContent ?? ""));
+    expect(publisherLinks).toHaveLength(0);
+  });
+
+  it("keeps the external Source ↗ link open in a new tab", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [makeRow({ scorecardSource: "fli_index" })],
+          },
+        ]}
+      />,
+    );
+
+    const sourceLink = screen.getByRole("link", { name: /Source/ });
+    expect(sourceLink.getAttribute("target")).toBe("_blank");
+    expect(sourceLink.getAttribute("rel")).toContain("noopener");
+  });
+});
+
+describe("ScorecardsSection — conditional font on grade values (QUA-861)", () => {
+  it("renders letter-grade overall in monospace", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [
+              makeRow({
+                dimensionSlug: "overall",
+                scoreLetter: "C+",
+                scoreRaw: "C+",
+              }),
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const overall = screen.getByText("C+");
+    expect(overall.className).toMatch(/font-mono/);
+  });
+
+  it("does NOT render a prose-verdict overall in monospace", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "seoul_tracker",
+            publishedAt: "2025-02-10",
+            rows: [
+              makeRow({
+                scorecardSource: "seoul_tracker",
+                dimensionSlug: "overall",
+                scoreLetter: null,
+                scoreNumeric: null,
+                scoreRaw: "Fulfilled",
+              }),
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const overall = screen.getByText("Fulfilled");
+    expect(overall.className).not.toMatch(/font-mono/);
+  });
+
+  it("does NOT render prose-verdict per-dimension cells in monospace", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "ailabwatch",
+            publishedAt: "2025-09-01",
+            rows: [
+              makeRow({
+                scorecardSource: "ailabwatch",
+                dimensionSlug: "risk-info-sharing",
+                dimensionLabel: "Risk info sharing",
+                scoreLetter: null,
+                scoreNumeric: null,
+                scoreRaw: "Weak",
+              }),
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const dimensionCell = screen.getByText("Weak").closest("dd");
+    expect(dimensionCell?.className).not.toMatch(/font-mono/);
+  });
+
+  it("renders letter-grade per-dimension cells in monospace", () => {
+    render(
+      <ScorecardsSection
+        groups={[
+          {
+            source: "fli_index",
+            publishedAt: "2025-12-02",
+            rows: [
+              makeRow({
+                dimensionSlug: "current-harms",
+                dimensionLabel: "Current Harms",
+                scoreLetter: "B-",
+                scoreRaw: "B-",
+              }),
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const dimensionCell = screen.getByText("B-").closest("dd");
+    expect(dimensionCell?.className).toMatch(/font-mono/);
+  });
+});

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -138,6 +138,7 @@ export function ScorecardsSection({
         const overallRow = group.rows.find(
           (r) => r.dimensionSlug === DIMENSION_OVERALL,
         );
+        const overallText = overallRow ? formatScoreCell(overallRow) : null;
         const dimensionRows = group.rows.filter(
           (r) => r.dimensionSlug !== DIMENSION_OVERALL,
         );
@@ -192,25 +193,22 @@ export function ScorecardsSection({
               ) : null}
             </header>
 
-            {overallRow ? (() => {
-              const overallText = formatScoreCell(overallRow);
-              return (
-                <div className="mb-3 flex items-baseline gap-3">
-                  <span className="text-sm text-muted-foreground">Overall:</span>
-                  <span className="inline-flex items-baseline gap-2">
-                    <span className={`text-2xl ${gradeCellFontClass(overallText)}`}>
-                      {overallText}
-                    </span>
-                    <SourcingDot
-                      status={recordVerdictToStatus(overallRow.sourcing?.verdict)}
-                      originalVerdict={overallRow.sourcing?.verdict ?? null}
-                      lastChecked={overallRow.sourcing?.checkedAt ?? null}
-                      size="md"
-                    />
+            {overallRow && overallText !== null ? (
+              <div className="mb-3 flex items-baseline gap-3">
+                <span className="text-sm text-muted-foreground">Overall:</span>
+                <span className="inline-flex items-baseline gap-2">
+                  <span className={`text-2xl ${gradeCellFontClass(overallText)}`}>
+                    {overallText}
                   </span>
-                </div>
-              );
-            })() : null}
+                  <SourcingDot
+                    status={recordVerdictToStatus(overallRow.sourcing?.verdict)}
+                    originalVerdict={overallRow.sourcing?.verdict ?? null}
+                    lastChecked={overallRow.sourcing?.checkedAt ?? null}
+                    size="md"
+                  />
+                </span>
+              </div>
+            ) : null}
 
             {dimensionRows.length > 0 ? (
               <dl className="w-full text-sm grid grid-cols-[1fr_auto] gap-x-3">

--- a/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/scorecards-section.tsx
@@ -12,6 +12,7 @@ import {
   SCORECARD_SOURCES,
   getScorecardSourceMeta,
   formatScoreCell,
+  gradeCellFontClass,
   DIMENSION_OVERALL,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
@@ -148,11 +149,30 @@ export function ScorecardsSection({
           >
             <header className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
               <h3 className="font-semibold">
-                {meta?.fullLabel ?? group.source}
+                {meta ? (
+                  <Link
+                    href={`/scorecards/${meta.source}`}
+                    className="text-primary hover:underline"
+                  >
+                    {meta.fullLabel}
+                  </Link>
+                ) : (
+                  group.source
+                )}
               </h3>
               {meta?.publisher ? (
                 <span className="text-xs text-muted-foreground">
-                  by {meta.publisher}
+                  by{" "}
+                  {meta.publisherSlug ? (
+                    <Link
+                      href={`/organizations/${meta.publisherSlug}`}
+                      className="text-primary hover:underline"
+                    >
+                      {meta.publisher}
+                    </Link>
+                  ) : (
+                    meta.publisher
+                  )}
                 </span>
               ) : null}
               {group.publishedAt ? (
@@ -172,44 +192,50 @@ export function ScorecardsSection({
               ) : null}
             </header>
 
-            {overallRow ? (
-              <div className="mb-3 flex items-baseline gap-3">
-                <span className="text-sm text-muted-foreground">Overall:</span>
-                <span className="inline-flex items-baseline gap-2">
-                  <span className="text-2xl font-mono tabular-nums">
-                    {formatScoreCell(overallRow)}
+            {overallRow ? (() => {
+              const overallText = formatScoreCell(overallRow);
+              return (
+                <div className="mb-3 flex items-baseline gap-3">
+                  <span className="text-sm text-muted-foreground">Overall:</span>
+                  <span className="inline-flex items-baseline gap-2">
+                    <span className={`text-2xl ${gradeCellFontClass(overallText)}`}>
+                      {overallText}
+                    </span>
+                    <SourcingDot
+                      status={recordVerdictToStatus(overallRow.sourcing?.verdict)}
+                      originalVerdict={overallRow.sourcing?.verdict ?? null}
+                      lastChecked={overallRow.sourcing?.checkedAt ?? null}
+                      size="md"
+                    />
                   </span>
-                  <SourcingDot
-                    status={recordVerdictToStatus(overallRow.sourcing?.verdict)}
-                    originalVerdict={overallRow.sourcing?.verdict ?? null}
-                    lastChecked={overallRow.sourcing?.checkedAt ?? null}
-                    size="md"
-                  />
-                </span>
-              </div>
-            ) : null}
+                </div>
+              );
+            })() : null}
 
             {dimensionRows.length > 0 ? (
               <dl className="w-full text-sm grid grid-cols-[1fr_auto] gap-x-3">
-                {dimensionRows.map((r) => (
-                  <div
-                    key={r.id}
-                    className="contents border-b border-border/30 last:border-b-0"
-                  >
-                    <dt className="py-1.5">{r.dimensionLabel}</dt>
-                    <dd className="py-1.5 font-mono tabular-nums text-right">
-                      <span className="inline-flex items-center gap-1.5 justify-end">
-                        <span>{formatScoreCell(r)}</span>
-                        <SourcingDot
-                          status={recordVerdictToStatus(r.sourcing?.verdict)}
-                          originalVerdict={r.sourcing?.verdict ?? null}
-                          lastChecked={r.sourcing?.checkedAt ?? null}
-                          size="sm"
-                        />
-                      </span>
-                    </dd>
-                  </div>
-                ))}
+                {dimensionRows.map((r) => {
+                  const formatted = formatScoreCell(r);
+                  return (
+                    <div
+                      key={r.id}
+                      className="contents border-b border-border/30 last:border-b-0"
+                    >
+                      <dt className="py-1.5">{r.dimensionLabel}</dt>
+                      <dd className={`py-1.5 text-right ${gradeCellFontClass(formatted)}`}>
+                        <span className="inline-flex items-center gap-1.5 justify-end">
+                          <span>{formatted}</span>
+                          <SourcingDot
+                            status={recordVerdictToStatus(r.sourcing?.verdict)}
+                            originalVerdict={r.sourcing?.verdict ?? null}
+                            lastChecked={r.sourcing?.checkedAt ?? null}
+                            size="sm"
+                          />
+                        </span>
+                      </dd>
+                    </div>
+                  );
+                })}
               </dl>
             ) : null}
           </article>

--- a/apps/web/src/app/scorecards/[source]/page.tsx
+++ b/apps/web/src/app/scorecards/[source]/page.tsx
@@ -8,6 +8,7 @@ import {
   SCORECARD_SOURCES,
   formatScoreCell,
   getScorecardSourceMeta,
+  gradeCellFontClass,
 } from "@/app/scorecards/scorecards-constants";
 import { buildOrgDimensionMatrix, type MatrixGrade } from "@/app/scorecards/[source]/matrix";
 
@@ -330,7 +331,7 @@ export default async function ScorecardDetailPage({
                       return (
                         <td
                           key={dim.slug}
-                          className="px-3 py-2 border-b border-border/30 font-mono tabular-nums"
+                          className={`px-3 py-2 border-b border-border/30 ${gradeCellFontClass(formatted)}`}
                           title={`${dim.label}${rawSuffix}`}
                         >
                           {formatted}

--- a/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
@@ -87,7 +87,6 @@ describe("scorecards-constants", () => {
       "C", "C+", "C-",
       "D", "D+", "D-",
       "F",
-      "a", "b+", "f",
     ])("treats letter grade %s as code-like", (grade) => {
       expect(isCodeLikeGrade(grade)).toBe(true);
     });
@@ -125,6 +124,32 @@ describe("scorecards-constants", () => {
       // Real verdict labels we've seen on prod scorecards.
       expect(isCodeLikeGrade("Acceptable")).toBe(false);
       expect(isCodeLikeGrade("Bad")).toBe(false);
+    });
+
+    it("does not match lowercase letter grades", () => {
+      // Actual scorecards publish "C+", never "c+". Rejecting lowercase
+      // keeps single-letter article ("a") and other prose out.
+      expect(isCodeLikeGrade("a")).toBe(false);
+      expect(isCodeLikeGrade("b+")).toBe(false);
+      expect(isCodeLikeGrade("f")).toBe(false);
+    });
+
+    it("does not match prose that starts with a digit", () => {
+      // Critical: regex must be anchored to end-of-string so a leading
+      // digit doesn't trick us into rendering prose in monospace.
+      expect(isCodeLikeGrade("5 stars met")).toBe(false);
+      expect(isCodeLikeGrade("100% achieved")).toBe(false);
+      expect(isCodeLikeGrade("75 of 100")).toBe(false);
+      expect(isCodeLikeGrade("1.0xfoo")).toBe(false);
+      expect(isCodeLikeGrade("42 things")).toBe(false);
+    });
+
+    it("does not match malformed numeric shapes", () => {
+      // Trailing letters, mixed forms — must not classify as code.
+      expect(isCodeLikeGrade("84%foo")).toBe(false);
+      expect(isCodeLikeGrade("75/")).toBe(false);
+      expect(isCodeLikeGrade(".5")).toBe(false);
+      expect(isCodeLikeGrade("1..0")).toBe(false);
     });
   });
 

--- a/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-constants.test.ts
@@ -3,6 +3,8 @@ import {
   SCORECARD_SOURCES,
   getScorecardSourceMeta,
   formatScoreCell,
+  isCodeLikeGrade,
+  gradeCellFontClass,
   DIMENSION_OVERALL,
 } from "../scorecards-constants";
 
@@ -76,5 +78,73 @@ describe("scorecards-constants", () => {
       const meta = getScorecardSourceMeta(slug);
       expect(meta?.active).toBe(true);
     }
+  });
+
+  describe("isCodeLikeGrade", () => {
+    it.each([
+      "A", "A+", "A-",
+      "B", "B+", "B-",
+      "C", "C+", "C-",
+      "D", "D+", "D-",
+      "F",
+      "a", "b+", "f",
+    ])("treats letter grade %s as code-like", (grade) => {
+      expect(isCodeLikeGrade(grade)).toBe(true);
+    });
+
+    it.each([
+      "84", "0", "100", "84.5", "75/100", "75%", "1.0",
+    ])("treats numeric/scored value %s as code-like", (value) => {
+      expect(isCodeLikeGrade(value)).toBe(true);
+    });
+
+    it.each([
+      "Weak", "Very Weak", "Fulfilled", "Partial", "Unfulfilled",
+      "Moderate", "Strong",
+    ])("treats prose verdict %s as NOT code-like", (verdict) => {
+      expect(isCodeLikeGrade(verdict)).toBe(false);
+    });
+
+    it("treats empty/whitespace as not code-like", () => {
+      expect(isCodeLikeGrade("")).toBe(false);
+      expect(isCodeLikeGrade("   ")).toBe(false);
+    });
+
+    it("trims surrounding whitespace before classifying", () => {
+      expect(isCodeLikeGrade("  C+  ")).toBe(true);
+      expect(isCodeLikeGrade("  Fulfilled  ")).toBe(false);
+    });
+
+    it("does not match alphabetic strings starting beyond F", () => {
+      // "Good" starts with G — must not be classified as a letter grade.
+      expect(isCodeLikeGrade("Good")).toBe(false);
+      expect(isCodeLikeGrade("Great")).toBe(false);
+    });
+
+    it("does not match multi-character letter codes that aren't grades", () => {
+      // Real verdict labels we've seen on prod scorecards.
+      expect(isCodeLikeGrade("Acceptable")).toBe(false);
+      expect(isCodeLikeGrade("Bad")).toBe(false);
+    });
+  });
+
+  describe("gradeCellFontClass", () => {
+    it("returns mono+tabular-nums for letter grades", () => {
+      expect(gradeCellFontClass("C+")).toBe("font-mono tabular-nums");
+    });
+
+    it("returns mono+tabular-nums for numeric values", () => {
+      expect(gradeCellFontClass("84")).toBe("font-mono tabular-nums");
+    });
+
+    it("returns empty string for prose verdicts", () => {
+      expect(gradeCellFontClass("Weak")).toBe("");
+      expect(gradeCellFontClass("Fulfilled")).toBe("");
+      expect(gradeCellFontClass("Very Weak")).toBe("");
+    });
+
+    it("returns empty for blank input", () => {
+      expect(gradeCellFontClass("")).toBe("");
+    });
   });
 });

--- a/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
+++ b/apps/web/src/app/scorecards/__tests__/scorecards-matrix.test.tsx
@@ -154,3 +154,69 @@ describe("ScorecardsMatrix — source-check dots", () => {
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 });
+
+/**
+ * QUA-861: matrix column headers must link to the per-source detail page
+ * (`/scorecards/[source]`). Without this, the directory page is a dead-end
+ * — users can't navigate from cross-org comparison into a single scorecard's
+ * full grades + snapshot history.
+ */
+describe("ScorecardsMatrix — column header links", () => {
+  it("each scorecard column header links to /scorecards/<source>", () => {
+    render(<ScorecardsMatrix orgRows={[]} />);
+
+    const fliLink = screen.getByRole("link", { name: /FLI Index/i });
+    expect(fliLink).toHaveAttribute("href", "/scorecards/fli_index");
+
+    const saferAiLink = screen.getByRole("link", { name: /SaferAI/i });
+    expect(saferAiLink).toHaveAttribute("href", "/scorecards/saferai");
+
+    const seoulLink = screen.getByRole("link", { name: /Seoul Tracker/i });
+    expect(seoulLink).toHaveAttribute("href", "/scorecards/seoul_tracker");
+  });
+});
+
+/**
+ * QUA-861: prose verdicts ("Weak", "Fulfilled") must NOT render in monospace
+ * — letter grades and numbers stay mono, but prose looks wrong as mono and
+ * should fall back to the default sans-serif.
+ */
+describe("ScorecardsMatrix — conditional cell font", () => {
+  function rowWithCell(scoreLetter: string | null, scoreRaw: string) {
+    return {
+      entityId: "sid_test",
+      displayName: "Test Org",
+      slug: "test-org",
+      cells: {
+        seoul_tracker: {
+          source: "seoul_tracker" as const,
+          scoreNumeric: null,
+          scoreLetter,
+          scoreRaw,
+          publishedAt: null,
+          sourcing: null,
+        },
+      },
+    };
+  }
+
+  it("renders letter grades in monospace+tabular-nums", () => {
+    render(<ScorecardsMatrix orgRows={[rowWithCell("C+", "C+")]} />);
+    const cell = screen.getByText("C+").closest("td");
+    expect(cell?.className).toMatch(/font-mono/);
+    expect(cell?.className).toMatch(/tabular-nums/);
+  });
+
+  it("does NOT render prose verdicts in monospace", () => {
+    render(<ScorecardsMatrix orgRows={[rowWithCell(null, "Fulfilled")]} />);
+    const cell = screen.getByText("Fulfilled").closest("td");
+    expect(cell?.className).not.toMatch(/font-mono/);
+    expect(cell?.className).not.toMatch(/tabular-nums/);
+  });
+
+  it("does NOT render multi-word verdicts in monospace", () => {
+    render(<ScorecardsMatrix orgRows={[rowWithCell(null, "Very Weak")]} />);
+    const cell = screen.getByText("Very Weak").closest("td");
+    expect(cell?.className).not.toMatch(/font-mono/);
+  });
+});

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -128,17 +128,26 @@ export function formatScoreCell(cell: {
 
 /**
  * Whether a rendered grade value looks like a code (`A`, `B+`, `D-`, `84`,
- * `75/100`) versus a prose verdict (`Weak`, `Fulfilled`, `Very Weak`).
+ * `75/100`, `75%`) versus a prose verdict (`Weak`, `Fulfilled`, `Very Weak`,
+ * `100% achieved`, `5 stars met`).
  *
  * Used to decide whether to apply `font-mono tabular-nums`: monospace looks
  * right for letter / numeric grades, but rendering prose words like
  * "Fulfilled" in monospace reads like a literal/code and looks wrong.
+ *
+ * Both branches are anchored to end-of-string so prose that *starts* with a
+ * digit ("5 stars met", "100% achieved") or a single letter is not treated
+ * as a code. Letter grades are uppercase-only — actual scorecards (FLI,
+ * SaferAI) publish "C+", never "c+".
  */
 export function isCodeLikeGrade(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
-  if (/^[A-F][+-]?$/i.test(trimmed)) return true;
-  if (/^[\d]/.test(trimmed)) return true;
+  // Letter grade: A, A-, B+, F. Uppercase only, anchored.
+  if (/^[A-F][+-]?$/.test(trimmed)) return true;
+  // Numeric: 84, 84.5, 100%, 75/100, 1.0. Anchored to reject "5 stars",
+  // "100% milk", "1.0xfoo", etc.
+  if (/^\d+(?:\.\d+)?(?:%|\/\d+)?$/.test(trimmed)) return true;
   return false;
 }
 

--- a/apps/web/src/app/scorecards/scorecards-constants.ts
+++ b/apps/web/src/app/scorecards/scorecards-constants.ts
@@ -125,3 +125,27 @@ export function formatScoreCell(cell: {
     (cell.scoreNumeric != null ? String(cell.scoreNumeric) : cell.scoreRaw)
   );
 }
+
+/**
+ * Whether a rendered grade value looks like a code (`A`, `B+`, `D-`, `84`,
+ * `75/100`) versus a prose verdict (`Weak`, `Fulfilled`, `Very Weak`).
+ *
+ * Used to decide whether to apply `font-mono tabular-nums`: monospace looks
+ * right for letter / numeric grades, but rendering prose words like
+ * "Fulfilled" in monospace reads like a literal/code and looks wrong.
+ */
+export function isCodeLikeGrade(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^[A-F][+-]?$/i.test(trimmed)) return true;
+  if (/^[\d]/.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Tailwind classes for a grade cell's text — monospace+tabular-nums for
+ * code-like grades (letters/numbers), empty for prose verdicts.
+ */
+export function gradeCellFontClass(value: string): string {
+  return isCodeLikeGrade(value) ? "font-mono tabular-nums" : "";
+}

--- a/apps/web/src/app/scorecards/scorecards-matrix.tsx
+++ b/apps/web/src/app/scorecards/scorecards-matrix.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   SCORECARD_SOURCES,
   formatScoreCell,
+  gradeCellFontClass,
   type ScorecardSourceKey,
 } from "@/app/scorecards/scorecards-constants";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
@@ -59,7 +60,13 @@ export function ScorecardsMatrix({
                 key={meta.source}
                 className="px-3 py-2 font-semibold border-b border-border/60 whitespace-nowrap"
               >
-                {meta.shortLabel}
+                <Link
+                  href={`/scorecards/${meta.source}`}
+                  className="text-primary hover:underline"
+                  title={meta.fullLabel}
+                >
+                  {meta.shortLabel}
+                </Link>
               </th>
             ))}
           </tr>
@@ -91,16 +98,17 @@ export function ScorecardsMatrix({
                     </td>
                   );
                 }
+                const formatted = formatScoreCell(cell);
                 return (
                   <td
                     key={meta.source}
-                    className="px-3 py-2 border-b border-border/30 font-mono tabular-nums"
+                    className={`px-3 py-2 border-b border-border/30 ${gradeCellFontClass(formatted)}`}
                     title={`${meta.fullLabel}${
                       cell.publishedAt ? ` — ${cell.publishedAt}` : ""
                     }`}
                   >
                     <span className="inline-flex items-center gap-1.5">
-                      <span>{formatScoreCell(cell)}</span>
+                      <span>{formatted}</span>
                       <SourcingDot
                         status={recordVerdictToStatus(cell.sourcing?.verdict)}
                         originalVerdict={cell.sourcing?.verdict ?? null}


### PR DESCRIPTION
## Summary

Two complementary UI fixes for the recently-shipped scorecards stack, surfaced when reviewing the live `/scorecards` directory and `/organizations/anthropic?tab=scorecards` against prod.

## Closes

Closes QUA-838
Closes QUA-861

## QUA-838 — internal hyperlinks in org-tab panels

Before: panel headings and publishers were plain text. The only internal link on the entire scorecards tab was the "scorecards directory" pointer.

After:
- Panel heading (e.g. `FLI AI Safety Index`) → `/scorecards/[source]`
- Publisher (e.g. `Future of Life Institute`) → `/organizations/<slug>` when `publisherSlug` is set; falls back to plain text otherwise (SaferAI, AI Lab Watch, FMTI, Seoul Tracker — `crux linear view QUA-836` covers their entity backfill)
- External `Source ↗` link is preserved
- Internal `/scorecards/*` links on `/organizations/anthropic?tab=scorecards`: **1 → 5** (verified locally)

## QUA-861 — drop `font-mono` on prose verdicts + link matrix headers

Before: every grade cell rendered in `font-mono tabular-nums`. Letter grades (`D-`, `C+`) and numeric scores look right in mono — but Seoul Tracker's `Fulfilled` / `Partial` / `Unfulfilled` and SaferAI's `Weak` / `Very Weak` / `Moderate` are prose words and read like literals when typeset in monospace.

After:
- New `isCodeLikeGrade(value)` + `gradeCellFontClass(value)` helpers in `scorecards-constants.ts`. Both regexes are anchored end-to-end so prose starting with a digit ("5 stars met", "100% achieved") is correctly classified as prose, not code.
- Letter grades (`/^[A-F][+-]?$/`, uppercase only — actual scorecards publish "C+", never "c+") and numeric values (`/^\d+(\.\d+)?(%|\/\d+)?$/`) keep `font-mono tabular-nums`
- Prose verdicts render in default sans
- Applied to all 4 sites: directory matrix, source detail page, org-tab overall pill, org-tab per-dimension cells
- Matrix column headers wrap in `<Link>` to `/scorecards/[source]` so the directory page has navigable rows instead of being a dead-end

## Out of scope

Source-check verdict automation for scorecard cells (every cell currently renders the unchecked white dot). QUA-839 explicitly noted this was out of scope; QUA-841 (Scorecards system end-to-end review) is the umbrella for the follow-up.

## Test plan

- [x] 49 unit tests on `isCodeLikeGrade` + `gradeCellFontClass` covering: letter grades, numeric forms (84, 84.5, 75/100, 75%, 1.0), prose verdicts (Weak, Fulfilled, Very Weak, Partial, Moderate), adversarial cases (`5 stars met`, `100% achieved`, `1.0xfoo`, `84%foo`), lowercase letter rejection, malformed numerics (`.5`, `1..0`, `75/`)
- [x] Matrix tests: column header link assertions + conditional cell font (mono for letter grade, sans for prose, sans for multi-word verdict)
- [x] Org-tab section tests (new file `scorecards-section.test.tsx`): panel-heading link, publisher link with fallback, plain-text fallback when no `publisherSlug`, external `Source ↗` unchanged, conditional font on overall pill + per-dimension cells
- [x] Full test suite green: 70/70 in the touched files
- [x] `pnpm crux w validate gate --fix` — 67/67 checks pass (3 pre-existing advisory warnings)
- [x] `pnpm build` green
- [x] Local Playwright check against `localhost:3017`:
  - `/scorecards`: column headers wrap in `<a>`, `D-` cells stay mono, `Fulfilled` / `Weak` cells render sans
  - `/organizations/anthropic?tab=scorecards`: panel heading → `/scorecards/fli_index`, publisher → `/organizations/fli`, internal `/scorecards/*` link count went from 1 to 5
- [x] `/agent-review-pr` ran. Hostile-reviewer subagent flagged: (1) digit regex too permissive — fixed by anchoring; (2) lowercase letter matching — fixed by removing `i` flag; (3) gratuitous IIFE — refactored to hoist `overallText`. Adversarial test cases added.

## Deploy Checklist

No deploy tasks — pure web app render change, no schema / migration / env / config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
