### PR TITLE
fix(QUA-624): redirect guessable entity tab URLs instead of 404

### DIFF
--- a/apps/web/e2e/entity-tab-redirects.spec.ts
+++ b/apps/web/e2e/entity-tab-redirects.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Entity-detail tab URL regression tests (QUA-624).
+ *
+ * Guessable deep-links like `/organizations/<slug>/people` and
+ * `/people/<slug>/publications` used to 404 because the corresponding
+ * sections live as in-page tabs on the parent profile rather than as
+ * dedicated routes. They now redirect to the parent profile (with
+ * `?tab=` set when a matching tab exists), so a hand-typed URL no
+ * longer hits a dead end.
+ *
+ * Adding a new entity sub-route? Add the redirect page next to the
+ * other tab routes (e.g. `apps/web/src/app/<dir>/[slug]/<tab>/page.tsx`)
+ * and append a case below.
+ */
+
+type RedirectCase = {
+  from: string;
+  to: string;
+};
+
+const TAB_REDIRECTS: RedirectCase[] = [
+  {
+    from: "/organizations/anthropic/people",
+    to: "/organizations/anthropic?tab=people",
+  },
+  {
+    from: "/organizations/ada-lovelace-institute/people",
+    to: "/organizations/ada-lovelace-institute?tab=people",
+  },
+  {
+    from: "/people/max-tegmark/publications",
+    to: "/people/max-tegmark",
+  },
+];
+
+test.describe("Entity tab redirects (QUA-624)", () => {
+  for (const { from, to } of TAB_REDIRECTS) {
+    test(`${from} redirects to ${to}`, async ({ request, baseURL }) => {
+      const res = await request.get(from, { maxRedirects: 0 });
+
+      const status = res.status();
+      const location = res.headers()["location"] ?? "";
+
+      expect(
+        status,
+        `Expected 3xx redirect for ${from}, got ${status}`,
+      ).toBeGreaterThanOrEqual(300);
+      expect(status).toBeLessThan(400);
+
+      const resolved = new URL(location, baseURL ?? "http://localhost");
+      const expected = new URL(to, baseURL ?? "http://localhost");
+      expect(resolved.pathname).toBe(expected.pathname);
+      expect(resolved.search).toBe(expected.search);
+    });
+  }
+});

--- a/apps/web/src/app/organizations/[slug]/people/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/people/page.tsx
@@ -1,0 +1,17 @@
+import { permanentRedirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * QUA-624: `/organizations/[slug]/people` is a guessable deep-link.
+ * The People section lives as the `?tab=people` tab on the parent profile,
+ * so redirect there to preserve user intent rather than 404.
+ */
+export default async function OrgPeopleRedirectPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  permanentRedirect(`/organizations/${slug}?tab=people`);
+}

--- a/apps/web/src/app/people/[slug]/publications/page.tsx
+++ b/apps/web/src/app/people/[slug]/publications/page.tsx
@@ -1,0 +1,17 @@
+import { permanentRedirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * QUA-624: `/people/[slug]/publications` is a guessable deep-link.
+ * Person profiles don't currently have a publications tab — redirect to the
+ * parent profile so the URL no longer 404s.
+ */
+export default async function PersonPublicationsRedirectPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  permanentRedirect(`/people/${slug}`);
+}


### PR DESCRIPTION
## Summary

`/organizations/<slug>/people` and `/people/<slug>/publications` previously returned 404. The matching sections live as in-page tabs on the parent profile, so add small redirect routes (mirroring the existing `/organizations/<slug>/funding` pattern). The org redirect preserves the selected tab via `?tab=people`; the person redirect drops to the parent profile because there is no publications tab on person pages today.

## Changes

- `apps/web/src/app/organizations/[slug]/people/page.tsx` — 308 → `/organizations/<slug>?tab=people`
- `apps/web/src/app/people/[slug]/publications/page.tsx` — 308 → `/people/<slug>`
- `apps/web/e2e/entity-tab-redirects.spec.ts` — regression coverage for all three URLs called out in the ticket

## Test plan

- [x] Verified bug in prod against `https://www.longtermwiki.com` (3 × HTTP 404 reproduced)
- [x] `pnpm build` (apps/web) — PASS
- [x] `pnpm crux w validate gate --fix` — 67/67 PASS
- [x] `pnpm test` — passes (unrelated `auto-verify-stakeholders.test.ts` parallel-execution flake on full suite passes when run alone)
- [x] Local `next start` + `curl -I` — three URLs return 308 with correct Location headers
- [x] Playwright e2e (`entity-tab-redirects.spec.ts`) — 3/3 passing against the local prod build

Closes QUA-624
