### PR TITLE
QUA-685: add ai-model as a sourceable record type

### DIFF
--- a/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
+++ b/apps/web/src/app/organizations/[slug]/ai-models-section.tsx
@@ -9,6 +9,7 @@ import { formatCompactNumber } from "@/lib/format-compact";
 import { formatKBDate } from "@/components/wiki/factbase/format";
 import { RecordStatusDots } from "@/components/coverage/RecordStatusDots";
 import { computeAiModelCoverage } from "@/components/coverage/coverage-score";
+import { getSourcingHref } from "@/app/sourcing/sourcing-shared";
 import { SectionHeader, Badge } from "./org-shared";
 import { SAFETY_LEVEL_COLORS } from "./org-data";
 
@@ -92,9 +93,16 @@ function hasVariance<T>(values: (T | null | undefined)[]): boolean {
 export function AiModelsSection({
   models,
   benchmarksByModel,
+  verdictByModelId,
 }: {
   models: AiModelEntry[];
   benchmarksByModel?: Map<string, BenchmarkScore[]>;
+  /**
+   * QUA-685: per-model sourcing verdict keyed by model.id (the entity slug,
+   * which matches the recordId stored in source_check_verdicts). Pass null/undefined
+   * for models that have no verdict — the SourcingDot will render as "unchecked".
+   */
+  verdictByModelId?: Map<string, string>;
 }) {
   if (models.length === 0) return null;
 
@@ -146,7 +154,13 @@ export function AiModelsSection({
           <tbody className="divide-y divide-border/50">
             {models.map((model) => {
               const href = model.wikiId ? `/wiki/${model.wikiId}` : getEntityHref(model.id, model.entityType);
-              const modelVerdict = null; // model-release has no sourcing verdicts yet (QUA-211)
+              // QUA-685: ai-model verdicts are now keyed by model.id (the entity slug,
+              // matching source_check_verdicts.recordId). Falls back to null when no
+              // verdict has been computed yet — RecordStatusDots renders "unchecked".
+              const modelVerdict = verdictByModelId?.get(model.id) ?? null;
+              const modelSourcingHref = modelVerdict
+                ? getSourcingHref("ai-model", model.id)
+                : undefined;
               const benchmarks = benchmarksByModel?.get(model.id);
               const topBenchmarks = benchmarks
                 ? pickTopBenchmarks(benchmarks)
@@ -234,8 +248,7 @@ export function AiModelsSection({
                         wikiId: model.wikiId,
                       })}
                       verdict={modelVerdict}
-                      // QUA-540: model-release has no sourcing verdicts → /sourcing/model-release/:id 404s.
-                      sourcingHref={undefined}
+                      sourcingHref={modelSourcingHref}
                     />
                   </td>
                 </tr>

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -214,9 +214,15 @@ export default async function OrgProfilePage({
     fetchEntitySourcingSummary([entity.id, entityStableId, slug]),
     loadScorecardsForEntity(entityStableId),
     // QUA-685: pull all ai-model verdicts so the Products & Models table dots
-    // can render real sourcing status. The full list is small (~50 rows
-    // total across all labs) so a single shared fetch is cheaper than
-    // per-model lookups, even when only a couple of models match this org.
+    // can render real sourcing status. A single shared fetch (capped at the
+    // wiki-server's MAX_PAGE_SIZE=200) is cheaper than per-model lookups even
+    // when only a couple of models match this org. The truncation check
+    // below logs a warning if the verdicts table grows past 200 rows so we
+    // catch it before silent data loss (~50 entities × multiple verdict
+    // rounds could approach the cap as more labs are backfilled).
+    // typed-client-ok: QUA-685 baseline — single ad-hoc list call against
+    // /api/sourcing/verdicts. A typed client wrapper would be appropriate
+    // when more callers consume this endpoint with a similar shape.
     fetchFromWikiServer<{ verdicts: Array<{ recordType: string; recordId: string; verdict: string; fieldName: string | null }>; total: number }>(
       `/api/sourcing/verdicts?record_type=ai-model&limit=200`,
       { revalidate: 300, timeoutMs: 10_000 },
@@ -228,6 +234,13 @@ export default async function OrgProfilePage({
   // sourcing dot per row without making per-model network calls.
   const aiModelVerdictByModelId = new Map<string, string>();
   if (aiModelVerdictsRaw) {
+    if (aiModelVerdictsRaw.total > aiModelVerdictsRaw.verdicts.length) {
+      console.warn(
+        `[org-profile] ai-model verdicts truncated: total=${aiModelVerdictsRaw.total} ` +
+        `received=${aiModelVerdictsRaw.verdicts.length}. Bump the page-size or paginate ` +
+        `/api/sourcing/verdicts?record_type=ai-model.`,
+      );
+    }
     for (const v of aiModelVerdictsRaw.verdicts) {
       // Skip per-field verdicts (fieldName != null); we display the row-level
       // rollup so each model has at most one dot.

--- a/apps/web/src/app/organizations/[slug]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/page.tsx
@@ -200,7 +200,7 @@ export default async function OrgProfilePage({
 
   // ── Fetch PG data (personnel + market data + grants + sourcing) in parallel ──
   const entityStableId = entity.stableId ?? entity.id;
-  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData, sourcingSummary, scorecardsData] = await Promise.all([
+  const [pgPersonnelRows, marketData, pgGrantsData, pgReceivedData, sourcingSummary, scorecardsData, aiModelVerdictsRaw] = await Promise.all([
     fetchPgPersonnel(entityStableId),
     fetchMarketData(entity.id),
     fetchFromWikiServer<RpcGrantsByEntityResult>(
@@ -213,8 +213,28 @@ export default async function OrgProfilePage({
     ),
     fetchEntitySourcingSummary([entity.id, entityStableId, slug]),
     loadScorecardsForEntity(entityStableId),
+    // QUA-685: pull all ai-model verdicts so the Products & Models table dots
+    // can render real sourcing status. The full list is small (~50 rows
+    // total across all labs) so a single shared fetch is cheaper than
+    // per-model lookups, even when only a couple of models match this org.
+    fetchFromWikiServer<{ verdicts: Array<{ recordType: string; recordId: string; verdict: string; fieldName: string | null }>; total: number }>(
+      `/api/sourcing/verdicts?record_type=ai-model&limit=200`,
+      { revalidate: 300, timeoutMs: 10_000 },
+    ),
   ]);
   const rollupVerdict = rollupVerdictFromSummary(sourcingSummary);
+
+  // QUA-685: build a recordId → verdict map so AiModelsSection can render the
+  // sourcing dot per row without making per-model network calls.
+  const aiModelVerdictByModelId = new Map<string, string>();
+  if (aiModelVerdictsRaw) {
+    for (const v of aiModelVerdictsRaw.verdicts) {
+      // Skip per-field verdicts (fieldName != null); we display the row-level
+      // rollup so each model has at most one dot.
+      if (v.fieldName) continue;
+      aiModelVerdictByModelId.set(v.recordId, v.verdict);
+    }
+  }
 
   // PG grants: check if wiki-server has grants for this org (as funder)
   if (!pgGrantsData && entityStableId) {
@@ -643,7 +663,11 @@ export default async function OrgProfilePage({
       icon: <Package className={ICON_CLASS} />,
       content: (
         <div className="space-y-8">
-          <AiModelsSection models={data.orgModels} benchmarksByModel={data.modelBenchmarks} />
+          <AiModelsSection
+            models={data.orgModels}
+            benchmarksByModel={data.modelBenchmarks}
+            verdictByModelId={aiModelVerdictByModelId}
+          />
           <ProductsSection products={data.products} />
         </div>
       ),

--- a/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.ts
+++ b/apps/web/src/app/sourcing/[recordType]/[recordId]/canonicalize-record-type.ts
@@ -10,6 +10,9 @@ const PLURAL_TO_SINGULAR: Record<string, string> = {
   "policy-stakeholders": "policy-stakeholder",
   citations: "citation",
   "wiki-pages": "wiki-page",
+  // QUA-685: ai-models is a sourceable record type whose CLI subcommand uses
+  // the plural form by analogy with grants/divisions/etc.
+  "ai-models": "ai-model",
 };
 
 export function canonicalizeSourcingRecordType(recordType: string): string | null {

--- a/apps/web/src/lib/sourcing/record-type-table-map.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.ts
@@ -30,11 +30,10 @@ export const RECORD_TYPE_TO_TABLE = {
   citation: "citation_quotes",
   "wiki-page": "wiki_pages",
   fact: "facts",
-  // QUA-685: ai-model verdicts reference the entities table (one entity row
-  // per model). The wiki-server's record-lookup likely doesn't support
-  // entities yet, so the detail page may fall through to notFound() for now —
-  // dots remain interactive at the table-row level via the standard
-  // /sourcing/<type>/<id> URL even when the detail page is bare.
+  // QUA-685: ai-model verdicts reference the `entities` table (one entity
+  // row per model). The wiki-server's record-lookup already supports
+  // `entities` and matches by slug, so /sourcing/ai-model/<slug> resolves
+  // to the model's entity row.
   "ai-model": "entities",
 } as const satisfies Record<string, string>;
 

--- a/apps/web/src/lib/sourcing/record-type-table-map.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.ts
@@ -30,6 +30,12 @@ export const RECORD_TYPE_TO_TABLE = {
   citation: "citation_quotes",
   "wiki-page": "wiki_pages",
   fact: "facts",
+  // QUA-685: ai-model verdicts reference the entities table (one entity row
+  // per model). The wiki-server's record-lookup likely doesn't support
+  // entities yet, so the detail page may fall through to notFound() for now —
+  // dots remain interactive at the table-row level via the standard
+  // /sourcing/<type>/<id> URL even when the detail page is bare.
+  "ai-model": "entities",
 } as const satisfies Record<string, string>;
 
 export type KnownRecordType = keyof typeof RECORD_TYPE_TO_TABLE;

--- a/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
@@ -39,7 +39,11 @@ describe("VALID_RECORD_TYPES", () => {
   });
 
   it("is frozen in length — adding a type is a schema change", () => {
-    expect(VALID_RECORD_TYPES.length).toBe(16);
+    // QUA-685: ai-model added (17th type) — wired into the source-check
+    // orchestrator with a special `/api/entities/export?entityType=ai-model`
+    // collection path since ai-model lives in the entities table rather than
+    // a per-type record table.
+    expect(VALID_RECORD_TYPES.length).toBe(17);
   });
 });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -76,6 +76,12 @@ export const VALID_RECORD_TYPES = [
   "citation",
   "wiki-page",
   "fact",
+  // QUA-685: ai-model is an entity type whose scalar fields (inputPrice,
+  // outputPrice, contextWindow, safetyLevel, releaseDate) are sourceable
+  // against the model's release announcement / docs page. Records are
+  // collected from `/api/entities/export?entityType=ai-model` rather than
+  // a dedicated /api/<type>/all endpoint — see crux/lib/sourcing/item-collectors.ts.
+  "ai-model",
 ] as const;
 
 export type RecordType = (typeof VALID_RECORD_TYPES)[number];

--- a/crux/commands/sourcing-orchestrate.ts
+++ b/crux/commands/sourcing-orchestrate.ts
@@ -61,8 +61,15 @@ async function statsCommand(): Promise<CommandResult> {
 
 // ── Record-type subcommand routing ────────────────────────────────────
 
-/** Map plural/singular CLI subcommand names to RecordType */
-const RECORD_TYPE_MAP: Record<string, RecordType> = {
+/**
+ * Map plural/singular CLI subcommand names to RecordType.
+ *
+ * Exported as `RECORD_TYPE_SUBCOMMAND_TO_TYPE` so `crux/commands/verify-entity.ts`
+ * (the `crux tb verify <subcommand>` entry point) can delegate record-type
+ * subcommands to the orchestrator. Both entry points use this map so they
+ * cannot drift apart.
+ */
+export const RECORD_TYPE_SUBCOMMAND_TO_TYPE: Record<string, RecordType> = {
   grant: 'grant',
   grants: 'grant',
   personnel: 'personnel',
@@ -86,6 +93,11 @@ const RECORD_TYPE_MAP: Record<string, RecordType> = {
   'entity-assessments': 'entity-assessment',
   'secondary-market-price': 'secondary-market-price',
   'secondary-market-prices': 'secondary-market-price',
+  // QUA-685: ai-model entities (claude, gpt-4, gemini, etc.) verified against
+  // their release announcement / model-card URL — see record-descriptions.ts
+  // for the five sourceable scalar fields.
+  'ai-model': 'ai-model',
+  'ai-models': 'ai-model',
 };
 
 /**
@@ -129,7 +141,7 @@ async function verifyCommand(
   }
 
   // Record type subcommands (grants, personnel, etc.)
-  const mapped = subcommand ? RECORD_TYPE_MAP[subcommand] : undefined;
+  const mapped = subcommand ? RECORD_TYPE_SUBCOMMAND_TO_TYPE[subcommand] : undefined;
   if (mapped) {
     // Route to orchestrate with --type=record and table filter for the specific record type
     const recordOptions: OrchestrateOptions = {
@@ -339,6 +351,7 @@ Usage:
   crux tb verify entity-events             Verify entity events
   crux tb verify entity-assessments        Verify entity assessments
   crux tb verify secondary-market-prices   Verify secondary market prices
+  crux tb verify ai-models                 Verify ai-model scalar fields (price, context, ASL, release date)
 
 Options:
   --budget=N             Max dollars to spend on LLM calls (est. ~$0.01/item)

--- a/crux/commands/verify-entity.ts
+++ b/crux/commands/verify-entity.ts
@@ -546,8 +546,7 @@ ${c.bold}Examples:${c.reset}
     // would treat `ai-models` as an entity slug and silently report "no claims".
     // See QUA-685 for the gap.
     {
-      const { orchestrateCommand } = await import('./sourcing-orchestrate.ts');
-      const { RECORD_TYPE_SUBCOMMAND_TO_TYPE } = await import('./sourcing-orchestrate.ts');
+      const { orchestrateCommand, RECORD_TYPE_SUBCOMMAND_TO_TYPE } = await import('./sourcing-orchestrate.ts');
       const mappedRecordType = RECORD_TYPE_SUBCOMMAND_TO_TYPE[subcommand];
       if (mappedRecordType) {
         return orchestrateCommand(args.slice(1), {

--- a/crux/commands/verify-entity.ts
+++ b/crux/commands/verify-entity.ts
@@ -539,6 +539,25 @@ ${c.bold}Examples:${c.reset}
       return orchestrateCommand(args.slice(1), options);
     }
 
+    // Record-type subcommands (`grants`, `personnel`, `ai-models`, etc.)
+    // delegate to the orchestrator with a --table filter so the existing
+    // `crux tb verify <record-type>` syntax (documented in the orchestrator's
+    // help text) routes correctly. Without this, `crux tb verify ai-models`
+    // would treat `ai-models` as an entity slug and silently report "no claims".
+    // See QUA-685 for the gap.
+    {
+      const { orchestrateCommand } = await import('./sourcing-orchestrate.ts');
+      const { RECORD_TYPE_SUBCOMMAND_TO_TYPE } = await import('./sourcing-orchestrate.ts');
+      const mappedRecordType = RECORD_TYPE_SUBCOMMAND_TO_TYPE[subcommand];
+      if (mappedRecordType) {
+        return orchestrateCommand(args.slice(1), {
+          ...options,
+          type: 'record',
+          table: mappedRecordType,
+        });
+      }
+    }
+
     // Per-entity sourcing
     return verifyEntityCommand(subcommand, options);
   },

--- a/crux/lib/sourcing/item-collectors.test.ts
+++ b/crux/lib/sourcing/item-collectors.test.ts
@@ -325,3 +325,123 @@ describe('exempt type filtering', () => {
     expect(items).toEqual([]);
   });
 });
+
+// ── AI model collection (QUA-685) ───────────────────────────────────
+
+describe('ai-model collection', () => {
+  function mockAiModelEntitiesResponse(rows: Record<string, unknown>[]) {
+    return {
+      ok: true as const,
+      data: {
+        entities: rows,
+        total: rows.length,
+        returned: rows.length,
+      },
+    };
+  }
+
+  function setupAiModelMock(rows: Record<string, unknown>[]) {
+    mockApiRequest.mockImplementation(async (_method: unknown, path: unknown) => {
+      const pathStr = String(path);
+      // Match /api/entities/export?entityType=ai-model... — the endpoint we
+      // wired into collectRecordItems for ai-model.
+      if (pathStr.startsWith('/api/entities/export') && pathStr.includes('entityType=ai-model')) {
+        return mockAiModelEntitiesResponse(rows);
+      }
+      return mockEmptyResponse();
+    });
+  }
+
+  it('queries /api/entities/export?entityType=ai-model when filtered to ai-model', async () => {
+    setupAiModelMock([]);
+    await collectRecordItems(new Map(), undefined, 'ai-model');
+    const calls = mockApiRequest.mock.calls.filter(([, p]) =>
+      String(p).startsWith('/api/entities/export') && String(p).includes('entityType=ai-model'),
+    );
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('flattens metadata fields and uses metadata.source as the source URL', async () => {
+    setupAiModelMock([{
+      id: 'claude-2',
+      stableId: 'sid_R3iYKUUe2g',
+      title: 'Claude 2',
+      entityType: 'ai-model',
+      metadata: {
+        developer: 'anthropic',
+        releaseDate: '2023-07-11',
+        inputPrice: 8,
+        outputPrice: 24,
+        contextWindow: 100000,
+        safetyLevel: 'ASL-2',
+        source: 'https://www.anthropic.com/news/claude-2',
+      },
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'ai-model');
+    expect(items).toHaveLength(1);
+
+    const item = items[0];
+    expect(item.id).toBe('record:ai-model:claude-2');
+    expect(item.kind).toBe('record');
+    expect(item.entityType).toBe('ai-model');
+    expect(item.sourceUrl).toBe('https://www.anthropic.com/news/claude-2');
+
+    expect(item.data.kind).toBe('record');
+    if (item.data.kind !== 'record') return;
+    expect(item.data.recordType).toBe('ai-model');
+    expect(item.data.recordId).toBe('claude-2');
+    // QUA-685: rollup keys off the model's own stableId so each ai-model row
+    // gets its own dot on the Products & Models table.
+    expect(item.data.entityId).toBe('sid_R3iYKUUe2g');
+    expect(item.data.entityDisplayName).toBe('Claude 2');
+
+    // The five sourceable scalar fields are extracted into data.fields.
+    expect(item.data.fields).toMatchObject({
+      title: 'Claude 2',
+      developer: 'anthropic',
+      releaseDate: '2023-07-11',
+      inputPrice: 8,
+      outputPrice: 24,
+      contextWindow: 100000,
+      safetyLevel: 'ASL-2',
+    });
+  });
+
+  it('skips ai-model rows without a source URL', async () => {
+    setupAiModelMock([
+      {
+        id: 'claude-2',
+        stableId: 'sid_R3iYKUUe2g',
+        title: 'Claude 2',
+        metadata: {
+          developer: 'anthropic',
+          source: 'https://www.anthropic.com/news/claude-2',
+        },
+      },
+      {
+        // No `source` in metadata — must be skipped to avoid a "No source URL" error.
+        id: 'claude-no-source',
+        stableId: 'sid_xyz',
+        title: 'Claude No-Source',
+        metadata: { developer: 'anthropic' },
+      },
+    ]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'ai-model');
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('record:ai-model:claude-2');
+  });
+
+  it('handles missing metadata gracefully (no crash, just skipped for lack of source)', async () => {
+    setupAiModelMock([{
+      id: 'no-metadata-model',
+      stableId: 'sid_xyz',
+      title: 'No-metadata Model',
+      // metadata omitted entirely
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'ai-model');
+    expect(items).toHaveLength(0);
+  });
+});

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -310,9 +310,11 @@ export async function collectRecordItems(
         // sourceable scalar fields nested under `metadata`. Flatten them
         // so the rest of the loop (source extraction, field extraction,
         // description) works the same as for a typical record row.
+        // The Array.isArray guard rejects JSONB array values, which would
+        // otherwise spread into integer keys (`{0: 'x', 1: 'y', ...row}`).
         const normalizedItems = recordType === 'ai-model'
           ? rawItems.map((row) => {
-              const md = (row.metadata && typeof row.metadata === 'object')
+              const md = (row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata))
                 ? row.metadata as Record<string, unknown>
                 : {};
               return { ...row, ...md };

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -260,6 +260,9 @@ export async function collectRecordItems(
       case 'entity-event': apiBasePath = '/api/entity-events/all'; break;
       case 'entity-assessment': apiBasePath = '/api/entity-assessments/all'; break;
       case 'secondary-market-price': apiBasePath = '/api/secondary-market-prices/all'; break;
+      // QUA-685: ai-model records are entities, not a per-type table. Use the
+      // entities export endpoint and flatten metadata fields below.
+      case 'ai-model': apiBasePath = '/api/entities/export?entityType=ai-model'; break;
       // citation and wiki-page are valid record types for verdicts but don't have
       // /all API endpoints for bulk collection — skip them intentionally.
       case 'citation':
@@ -276,7 +279,8 @@ export async function collectRecordItems(
       let offset = 0;
 
       while (true) {
-        const apiPath = `${apiBasePath}?limit=${API_PAGE_LIMIT}&offset=${offset}`;
+        const sep = apiBasePath.includes('?') ? '&' : '?';
+        const apiPath = `${apiBasePath}${sep}limit=${API_PAGE_LIMIT}&offset=${offset}`;
         // typed-client-ok: QUA-770 baseline — sourcing pipeline, internal write path
         const response = await apiRequest<Record<string, unknown>>('GET', apiPath);
         if (!response.ok) {
@@ -297,10 +301,25 @@ export async function collectRecordItems(
           data.events ?? data.entityEvents ??
           data.assessments ?? data.entityAssessments ??
           data.prices ?? data.secondaryMarketPrices ??
+          // QUA-685: /api/entities/export returns { entities, total, returned }
+          data.entities ??
           (Array.isArray(data) ? data : [])
         ) as Record<string, unknown>[];
 
-        allRawItems.push(...rawItems);
+        // QUA-685: ai-model rows come from the entities table, with the
+        // sourceable scalar fields nested under `metadata`. Flatten them
+        // so the rest of the loop (source extraction, field extraction,
+        // description) works the same as for a typical record row.
+        const normalizedItems = recordType === 'ai-model'
+          ? rawItems.map((row) => {
+              const md = (row.metadata && typeof row.metadata === 'object')
+                ? row.metadata as Record<string, unknown>
+                : {};
+              return { ...row, ...md };
+            })
+          : rawItems;
+
+        allRawItems.push(...normalizedItems);
 
         // Stop if we got fewer items than the page size, or we've reached the total
         const total = typeof data.total === 'number' ? data.total : undefined;

--- a/crux/lib/sourcing/record-descriptions.ts
+++ b/crux/lib/sourcing/record-descriptions.ts
@@ -72,6 +72,13 @@ export function buildRecordDescription(recordType: RecordType, item: Record<stri
       const valuationStr = valuation != null ? ` ($${(valuation / 1e9).toFixed(1)}B)` : '';
       return `Market Price: ${company} on ${platform} (${date})${valuationStr}`;
     }
+    case 'ai-model': {
+      // QUA-685: items are flattened from /api/entities/export rows — the
+      // model's title is the entity title, fields live alongside.
+      const title = strOrNull(item, 'title') ?? str(item, 'id');
+      const developer = strOrNull(item, 'developer');
+      return developer ? `AI Model: ${title} (${developer})` : `AI Model: ${title}`;
+    }
     default:
       return `${recordType}: ${strOrNull(item, 'name') ?? strOrNull(item, 'title') ?? 'unknown'}`;
   }
@@ -148,6 +155,19 @@ export function extractRecordFields(recordType: RecordType, item: Record<string,
         impliedValuation: numOrNull(item, 'impliedValuation'),
         pricePerShare: numOrNull(item, 'pricePerShare'),
         priceType: strOrNull(item, 'priceType'),
+      };
+    case 'ai-model':
+      // QUA-685: the five scalar fields the LLM should verify against the
+      // model's release announcement / pricing page. Other fields like
+      // benchmarks[] have inline sources and are sourced separately.
+      return {
+        title: strOrNull(item, 'title') ?? str(item, 'id'),
+        developer: strOrNull(item, 'developer'),
+        releaseDate: strOrNull(item, 'releaseDate'),
+        inputPrice: numOrNull(item, 'inputPrice'),
+        outputPrice: numOrNull(item, 'outputPrice'),
+        contextWindow: numOrNull(item, 'contextWindow'),
+        safetyLevel: strOrNull(item, 'safetyLevel'),
       };
     default:
       return { name: strOrNull(item, 'name') ?? strOrNull(item, 'title') };

--- a/crux/lib/sourcing/record-fields.test.ts
+++ b/crux/lib/sourcing/record-fields.test.ts
@@ -521,9 +521,9 @@ describe('extractEntityDisplayName', () => {
       expect(extractEntityDisplayName('ai-model', item)).toBe('Claude 2');
     });
 
-    it('falls back to slug id when title is missing', () => {
+    it('returns null (not the slug) when title is missing — avoids slug-as-display-name', () => {
       const item = { id: 'claude-2' };
-      expect(extractEntityDisplayName('ai-model', item)).toBe('claude-2');
+      expect(extractEntityDisplayName('ai-model', item)).toBeNull();
     });
   });
 

--- a/crux/lib/sourcing/record-fields.test.ts
+++ b/crux/lib/sourcing/record-fields.test.ts
@@ -210,6 +210,29 @@ describe('extractEntityId', () => {
     });
   });
 
+  // ── ai-model (QUA-685) ──
+
+  describe('ai-model', () => {
+    it('returns the model\'s own stableId so the rollup keys per-model', () => {
+      const item = {
+        id: 'claude-2',
+        stableId: 'sid_R3iYKUUe2g',
+        title: 'Claude 2',
+      };
+      expect(extractEntityId('ai-model', item)).toBe('sid_R3iYKUUe2g');
+    });
+
+    it('falls back to slug id when stableId is missing', () => {
+      const item = { id: 'claude-2', title: 'Claude 2' };
+      expect(extractEntityId('ai-model', item)).toBe('claude-2');
+    });
+
+    it('returns null when neither stableId nor id is present', () => {
+      const item = { title: 'Mystery' };
+      expect(extractEntityId('ai-model', item)).toBeNull();
+    });
+  });
+
   // ── Unknown record types ──
 
   describe('unknown record types', () => {
@@ -489,6 +512,18 @@ describe('extractEntityDisplayName', () => {
     it('falls back to stakeholderDisplayName', () => {
       const item = { stakeholderDisplayName: 'OpenAI LLC' };
       expect(extractEntityDisplayName('policy-stakeholder', item)).toBe('OpenAI LLC');
+    });
+  });
+
+  describe('ai-model (QUA-685)', () => {
+    it('returns the model title as the entity display name', () => {
+      const item = { title: 'Claude 2', id: 'claude-2' };
+      expect(extractEntityDisplayName('ai-model', item)).toBe('Claude 2');
+    });
+
+    it('falls back to slug id when title is missing', () => {
+      const item = { id: 'claude-2' };
+      expect(extractEntityDisplayName('ai-model', item)).toBe('claude-2');
     });
   });
 

--- a/crux/lib/sourcing/record-fields.ts
+++ b/crux/lib/sourcing/record-fields.ts
@@ -84,9 +84,12 @@ export function extractEntityDisplayName(recordType: string, item: Record<string
     case 'policy-stakeholder':
       return strOrNull(item, 'stakeholderResolvedName') ?? strOrNull(item, 'stakeholderDisplayName') ?? null;
     case 'ai-model':
-      // QUA-685: entityDisplayName is the model itself (used for grouping rollups
-      // by the model's own stableId, see extractEntityId).
-      return strOrNull(item, 'title') ?? strOrNull(item, 'id');
+      // QUA-685: entityDisplayName is the model's title (used for grouping
+      // rollups by the model's own stableId, see extractEntityId).
+      // Returns null (not the slug) when the title is missing — slugs leak
+      // into source_check_verdicts.entity_display_name otherwise and render
+      // as "claude-2" instead of a human name.
+      return strOrNull(item, 'title');
     default:
       return null;
   }
@@ -115,6 +118,12 @@ export function extractEntityId(recordType: string, item: Record<string, unknown
       // `fetchEntitySourcingSummary(modelStableId)` returns the model's rollup.
       // This differs from grants/personnel (which group under the parent org)
       // because each ai-model row gets its own dot on the Products & Models table.
+      //
+      // Side effect: ai-model verdicts do NOT bubble into the developer org's
+      // headline rollup verdict. Per-model dots use a separate per-recordId
+      // lookup (see apps/web/src/app/organizations/[slug]/page.tsx). Whether to
+      // also dual-key by developer is tracked in QUA-870 — keeping the simpler
+      // per-model design here pending that decision.
       return strOrNull(item, 'stableId') ?? strOrNull(item, 'id');
     default:
       return null;

--- a/crux/lib/sourcing/record-fields.ts
+++ b/crux/lib/sourcing/record-fields.ts
@@ -83,6 +83,10 @@ export function extractEntityDisplayName(recordType: string, item: Record<string
       return strOrNull(item, 'orgResolvedName') ?? strOrNull(item, 'orgDisplayName') ?? null;
     case 'policy-stakeholder':
       return strOrNull(item, 'stakeholderResolvedName') ?? strOrNull(item, 'stakeholderDisplayName') ?? null;
+    case 'ai-model':
+      // QUA-685: entityDisplayName is the model itself (used for grouping rollups
+      // by the model's own stableId, see extractEntityId).
+      return strOrNull(item, 'title') ?? strOrNull(item, 'id');
     default:
       return null;
   }
@@ -106,6 +110,12 @@ export function extractEntityId(recordType: string, item: Record<string, unknown
       return strOrNull(item, 'orgEntityId');
     case 'policy-stakeholder':
       return strOrNull(item, 'stakeholderEntityId');
+    case 'ai-model':
+      // QUA-685: ai-model verdicts group under the model's own stableId, so
+      // `fetchEntitySourcingSummary(modelStableId)` returns the model's rollup.
+      // This differs from grants/personnel (which group under the parent org)
+      // because each ai-model row gets its own dot on the Products & Models table.
+      return strOrNull(item, 'stableId') ?? strOrNull(item, 'id');
     default:
       return null;
   }

--- a/data/entities/ai-models.yaml
+++ b/data/entities/ai-models.yaml
@@ -95,6 +95,7 @@
   outputPrice: 24
   contextWindow: 100000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-2"
   openWeight: false
   modality:
     - text
@@ -140,6 +141,7 @@
   outputPrice: 75
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-3-family"
   openWeight: false
   modality:
     - text
@@ -196,6 +198,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-3-family"
   openWeight: false
   modality:
     - text
@@ -253,6 +256,7 @@
   outputPrice: 1.25
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-3-haiku"
   openWeight: false
   modality:
     - text
@@ -310,6 +314,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-3-5-sonnet"
   openWeight: false
   modality:
     - text
@@ -399,6 +404,7 @@
   outputPrice: 4
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/3-5-models-and-computer-use"
   openWeight: false
   modality:
     - text
@@ -454,6 +460,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-3-7-sonnet"
   openWeight: false
   modality:
     - text
@@ -514,6 +521,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-4"
   openWeight: false
   modality:
     - text
@@ -567,6 +575,7 @@
   outputPrice: 75
   contextWindow: 200000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-4"
   openWeight: false
   modality:
     - text
@@ -622,6 +631,7 @@
   outputPrice: 75
   contextWindow: 200000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-opus-4-1"
   openWeight: false
   modality:
     - text
@@ -671,6 +681,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-sonnet-4-5"
   openWeight: false
   modality:
     - text
@@ -730,6 +741,7 @@
   outputPrice: 5
   contextWindow: 200000
   safetyLevel: ASL-2
+  source: "https://www.anthropic.com/news/claude-haiku-4-5"
   openWeight: false
   modality:
     - text
@@ -773,6 +785,7 @@
   outputPrice: 25
   contextWindow: 200000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-opus-4-5"
   openWeight: false
   modality:
     - text
@@ -825,6 +838,7 @@
   outputPrice: 25
   contextWindow: 1000000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-opus-4-6"
   openWeight: false
   modality:
     - text
@@ -884,6 +898,7 @@
   outputPrice: 15
   contextWindow: 200000
   safetyLevel: ASL-3
+  source: "https://www.anthropic.com/news/claude-sonnet-4-6"
   openWeight: false
   modality:
     - text


### PR DESCRIPTION
## Summary

Adds `ai-model` as the 17th sourceable record type in the source-check orchestrator and backfills source-check verdicts for all 15 Claude models — closing the gap that left their pricing, context window, and ASL safety level fields with zero structured provenance (originally identified by QUA-193).

Unlike the prior 16 record types, `ai-model` lives in the `entities` table rather than a per-type record table. Records are pulled from `/api/entities/export?entityType=ai-model` and the five sourceable scalar fields (`inputPrice`, `outputPrice`, `contextWindow`, `safetyLevel`, `releaseDate`) are flattened from `entity.metadata` so the existing `extractRecordFields` / `buildRecordSourcingPrompt` flow consumes them unchanged.

## What's wired up

- `pnpm crux tb verify ai-models` — works via two paths:
  - the existing `verify-orchestrate` domain (parsed by `RECORD_TYPE_SUBCOMMAND_TO_TYPE` in `sourcing-orchestrate.ts`)
  - the `verify` domain (verify-entity.ts now delegates record-type subcommands to the orchestrator instead of treating them as entity slugs and silently reporting "no claims")
- `--entity-type=ai-model` continues to work for entity-level web-search verification
- `data/entities/ai-models.yaml` — added `source:` URLs for all 15 Claude models (Anthropic news/announcement pages)
- The Products & Models table on org pages (`apps/web/src/app/organizations/[slug]/ai-models-section.tsx:149`) now reads real verdicts via a `verdictByModelId` Map fetched in parallel with the org's other data — replaces the forced `null` from QUA-211
- `/sourcing/ai-models/<id>` (plural) canonicalizes to `/sourcing/ai-model/<id>`

## Backfill results (run from this branch against prod, ~$0.15)

| Verdict | Count |
| -- | -- |
| confirmed | 5 |
| partial | 9 |
| contradicted | 1 |

The single `contradicted` verdict is `claude-3-5-sonnet`: YAML has `releaseDate: 2024-06-20` (matches Wikipedia), the Anthropic announcement page header says "Jun 21, 2024" (post publication date) — a documented sourcing-page artifact, our YAML data is right. The 9 `partial` verdicts are typically "announcement covers release date + context window but not pricing or ASL" — both of which require secondary sources outside the scope of this PR.

## Tests

- `crux/lib/sourcing/item-collectors.test.ts` — 4 new tests covering ai-model collection (endpoint routing, metadata flattening, source-URL skip, missing-metadata graceful path)
- `crux/lib/sourcing/record-fields.test.ts` — 5 new tests covering `extractEntityId` / `extractEntityDisplayName` for ai-model
- `apps/wiki-server/src/__tests__/api-types-record-id.test.ts` — bumped frozen length from 16 → 17
- All 67 gate checks pass (2 advisory warnings, both unrelated)

## Review fixes (`/agent-review-pr` round)

The hostile-reviewer pass surfaced 2 HIGH, 4 MEDIUM, 5 LOW findings. Addressed in this PR:

- **HIGH (truncation)** — added a runtime warning when `/api/sourcing/verdicts?record_type=ai-model` returns `total > received` so we catch silent data loss before the verdicts table grows past the page-size cap.
- **MEDIUM (misleading comment)** — fixed the inline comment claiming record-lookup doesn't support entities (it does, via the slug-matching branch).
- **MEDIUM (canonicalize)** — added `ai-models` → `ai-model` to PLURAL_TO_SINGULAR so `/sourcing/ai-models/<id>` redirects rather than 404s.
- **MEDIUM (typed-client-ok marker)** — added the marker so the new `fetchFromWikiServer<...>` call is annotated for the QUA-770 baseline.
- **MEDIUM (array-metadata guard)** — tightened the metadata-flatten with `!Array.isArray(...)` so a JSONB array doesn't spread into integer keys.
- **LOW (display-name fallback)** — `extractEntityDisplayName('ai-model', ...)` now returns `null` instead of falling back to the slug, so we don't leak `claude-2`-style strings into `entity_display_name`.
- **LOW (redundant import)** — combined the two `await import('./sourcing-orchestrate.ts')` calls into one.

The HIGH "rollup gap" finding (ai-model verdicts don't bubble up into the developer org's headline rollup) is a deliberate design choice — per-model dots use a separate per-recordId lookup, and changing to org-grouped `entity_id` would conflict with that. Documented in code + filed as **QUA-870** for the explicit rollup-design decision (Option 1 / 2 / 3 in the ticket).

The contradicted verdict on claude-3-5-sonnet is shipping as-is — verified against Wikipedia + Pierce's June 20 article that our YAML date is correct; the Anthropic page is the source of the discrepancy.

## Out of scope (filing as follow-ups, see QUA-544 comment)

- Other model families (OpenAI, Google, Meta, Mistral, xAI, DeepSeek)
- Per-field verdicts (currently row-level)
- Anthropic pricing page as a secondary source to lift partials → confirmed
- QUA-870 — ai-model rollup design decision

## Test plan

- [x] `pnpm crux tb verify ai-models --dry-run` reports 15 records (Claude family)
- [x] `pnpm crux tb verify ai-models --limit=15` produces 15 verdict rows in `source_check_verdicts`
- [x] Anthropic org page (`/organizations/anthropic`, Products & Models tab) renders 15 sourcing dots with real verdicts (5 verified, 9 needs-attention, 1 contradicted) and `/sourcing/ai-model/<slug>` href targets — verified via Playwright (`/tmp/qua-685-ui.txt`)
- [x] `/sourcing/ai-model/claude-2` detail page returns 200 with the entity rendered
- [x] `/sourcing/ai-models/claude-2` redirects to `/sourcing/ai-model/claude-2`
- [x] `pnpm crux w validate gate --fix` passes (67/67, 0 blocking failures)
- [x] All sourcing unit tests pass (608 tests)

Closes QUA-685

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sourcing verification support for AI models—users can now track verification status across their organization
  * AI models display sourcing status indicators on organization pages
  * Extended command-line tools with AI model verification capabilities

* **Data Updates**
  * Claude model entries updated with official source URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->