### PR TITLE
QUA-764: fix investments rows with sid_ leaks (10 rows)

### DIFF
--- a/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
+++ b/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
@@ -11,9 +11,22 @@
 --   - Title-with-prefix (2 rows): `sid_Storyworth` and `sid_Playground`.
 --     Real entities exist (`storyworth` / sid_kT85f91plA, `playground-ai` /
 --     sid_kh5x0eezrQ). Normalize: set the FK + slug, keep the row.
---   - Orphan sids (8 rows total: 5 company-side + 3 investor-side): no
---     matching entity in `entities`. Delete; `company_id`/`investor_id` are
---     NOT NULL so the ticket's "null both columns" option isn't available.
+--   - Orphan sids (8 rows total: 5 company-side + 3 investor-side, with 2
+--     rows having both): no matching entity in `entities`. Delete the row;
+--     `company_id`/`investor_id` are NOT NULL so the ticket's "null both
+--     columns" option isn't available.
+--
+-- F3 trade-off — single-side investor leaks: the 3 "investor-only" leak
+-- rows (6GS_vh6msp Algolia/Seed/2014, G7xvfoDpI3 Rippling/Series A/$45M,
+-- Wq9J6mOQFe Rippling/Series C/2021) have valid resolved companies. The
+-- DELETE WHERE clause uses `OR` between company-leak and investor-leak
+-- predicates, so these 3 rows are deleted along with their orphan-company
+-- counterparts. We accept the loss (small, partial-data rows) for
+-- consistent treatment — preserving the row would require either keeping
+-- the raw sid in investor_id (still leaks) or substituting a placeholder
+-- that doesn't resolve (would make future re-syncs fail entityRefs
+-- validation). The ticket's acceptance language ("delete or null both")
+-- is consistent with delete here.
 --
 -- Idempotent: every step is gated on the bug pattern (sid_ in the raw
 -- column AND no resolved FK). Safe to re-run on a fresh DB or after partial
@@ -37,6 +50,16 @@
 -- `validateEntityRefs()` (sync-factory `entityRefFields` config), which
 -- rejects any companyId/investorId not matching an entity. These 10 rows
 -- predate that protection. No code change required.
+--
+-- things_search materialized view: this migration deletes 8 things rows
+-- and rewrites parent_thing_id on 2 more. We do NOT issue an explicit
+-- `REFRESH MATERIALIZED VIEW` here — the things_search MV is 78MB / 40k
+-- rows (per migration 0190) and a non-CONCURRENT refresh inside the
+-- migration transaction would hold AccessExclusiveLock for ~30-60s,
+-- blocking user-facing search. The hourly groundskeeper REFRESH
+-- (CONCURRENTLY) picks the changes up within ~1h. Acceptable staleness
+-- for a 10-row data fix; the deleted sids never appeared in user-friendly
+-- search anyway (they were displayed as raw `sid_*`).
 
 -- Phase 0: pre-flight — verify target entities exist before normalizing.
 -- The UPDATE in Phase 1 would otherwise fail loudly on a FK violation, but
@@ -83,6 +106,25 @@ BEGIN
     AND "company_entity_id" IS NULL;
   GET DIAGNOSTICS playground_updated = ROW_COUNT;
   RAISE NOTICE 'QUA-764: normalized sid_Playground → playground-ai on % row(s)', playground_updated;
+
+  -- Phase 1c: keep `things.parent_thing_id` in sync with the normalized
+  -- company_id. The route's `toThing` writes parent_thing_id = companyId at
+  -- sync time, so the existing things rows for these 2 investments still
+  -- hold 'sid_Storyworth' / 'sid_Playground'. The hourly things_search MV
+  -- refresh (groundskeeper) propagates parent_thing_id into the search
+  -- index — leaving them stale would let the bad sids resurface in search
+  -- until the next re-sync. Idempotent via the predicate match.
+  UPDATE "things"
+  SET "parent_thing_id" = 'storyworth',
+      "updated_at"      = NOW()
+  WHERE "source_table" = 'investments'
+    AND "parent_thing_id" = 'sid_Storyworth';
+
+  UPDATE "things"
+  SET "parent_thing_id" = 'playground-ai',
+      "updated_at"      = NOW()
+  WHERE "source_table" = 'investments'
+    AND "parent_thing_id" = 'sid_Playground';
 
   -- Phase 2: Delete `things` rows for orphan investments first (FK-safe ordering).
   -- Match criteria: investments rows where either `company_id` or `investor_id`

--- a/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
+++ b/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
@@ -61,18 +61,28 @@
 -- for a 10-row data fix; the deleted sids never appeared in user-friendly
 -- search anyway (they were displayed as raw `sid_*`).
 
--- Phase 0: pre-flight — verify target entities exist before normalizing.
--- The UPDATE in Phase 1 would otherwise fail loudly on a FK violation, but
--- raising an explicit exception here gives operators a clearer error
--- (and keeps the migration loudly fail-closed rather than silently
--- skipping rows if someone, e.g., dropped these entities from YAML).
+-- Phase 0: pre-flight — verify target entities exist before normalizing,
+-- but ONLY if bad rows are present. On a fresh DB (CI/test) or after an
+-- idempotent re-run, no bad investment rows exist, so the entity check is
+-- skipped entirely. On prod where the bad rows do exist, the check aborts
+-- loudly if the entity was somehow removed before the migration ran.
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kT85f91plA') THEN
-    RAISE EXCEPTION 'QUA-764 aborted: entity sid_kT85f91plA (storyworth) not found in entities. Cannot link sid_Storyworth investments rows.';
+  IF EXISTS (
+    SELECT 1 FROM "investments"
+    WHERE "company_id" = 'sid_Storyworth' AND "company_entity_id" IS NULL
+  ) THEN
+    IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kT85f91plA') THEN
+      RAISE EXCEPTION 'QUA-764 aborted: entity sid_kT85f91plA (storyworth) not found in entities. Cannot link sid_Storyworth investments rows.';
+    END IF;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kh5x0eezrQ') THEN
-    RAISE EXCEPTION 'QUA-764 aborted: entity sid_kh5x0eezrQ (playground-ai) not found in entities. Cannot link sid_Playground investments rows.';
+  IF EXISTS (
+    SELECT 1 FROM "investments"
+    WHERE "company_id" = 'sid_Playground' AND "company_entity_id" IS NULL
+  ) THEN
+    IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kh5x0eezrQ') THEN
+      RAISE EXCEPTION 'QUA-764 aborted: entity sid_kh5x0eezrQ (playground-ai) not found in entities. Cannot link sid_Playground investments rows.';
+    END IF;
   END IF;
 END $$;
 

--- a/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
+++ b/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
@@ -1,0 +1,136 @@
+-- QUA-764: Fix `investments` rows with sid_ leaks (NULL company_entity_id /
+-- investor_entity_id and a sid_-prefixed value in the raw text column).
+--
+-- 7 rows had `company_id LIKE 'sid_%'` with `company_entity_id IS NULL`. The
+-- entity-FK left-join therefore resolved to NULL and the raw `sid_*` value
+-- leaked into UI/reports/backfill claims. The audit step (see PR description)
+-- found 5 additional rows with the same shape on `investor_id` (3 rows
+-- distinct from the 7 above; 2 rows had both leaks).
+--
+-- Two flavors per the ticket:
+--   - Title-with-prefix (2 rows): `sid_Storyworth` and `sid_Playground`.
+--     Real entities exist (`storyworth` / sid_kT85f91plA, `playground-ai` /
+--     sid_kh5x0eezrQ). Normalize: set the FK + slug, keep the row.
+--   - Orphan sids (8 rows total: 5 company-side + 3 investor-side): no
+--     matching entity in `entities`. Delete; `company_id`/`investor_id` are
+--     NOT NULL so the ticket's "null both columns" option isn't available.
+--
+-- Idempotent: every step is gated on the bug pattern (sid_ in the raw
+-- column AND no resolved FK). Safe to re-run on a fresh DB or after partial
+-- application; second run is a no-op.
+--
+-- Pattern-based, not hardcoded by row id (see
+-- .claude/rules/database-migrations.md "Adding unique constraints" —
+-- analogous reasoning: hardcoded ids miss any new rows that match the
+-- same shape, e.g. if the bad sync re-ran).
+--
+-- Other tables audited per ticket scope (prod 2026-04-29, fix-if-found):
+--   - investments.investor_id ........ 5 leaks → covered above
+--   - equity_positions.{company_id, holder_id} ... 0
+--   - funding_rounds.company_id ...... 0
+--   - personnel.{organization_id, person_id} ..... 0
+--   - divisions.parent_org_id ........ N/A — different schema (parent_org_id
+--     IS the FK column with `REFERENCES entities(stable_id)`, so the
+--     orphan-sid pattern is structurally impossible there)
+--
+-- Systemic protection: the `investments POST /sync` route already calls
+-- `validateEntityRefs()` (sync-factory `entityRefFields` config), which
+-- rejects any companyId/investorId not matching an entity. These 10 rows
+-- predate that protection. No code change required.
+
+-- Phase 0: pre-flight — verify target entities exist before normalizing.
+-- The UPDATE in Phase 1 would otherwise fail loudly on a FK violation, but
+-- raising an explicit exception here gives operators a clearer error
+-- (and keeps the migration loudly fail-closed rather than silently
+-- skipping rows if someone, e.g., dropped these entities from YAML).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kT85f91plA') THEN
+    RAISE EXCEPTION 'QUA-764 aborted: entity sid_kT85f91plA (storyworth) not found in entities. Cannot link sid_Storyworth investments rows.';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM "entities" WHERE "stable_id" = 'sid_kh5x0eezrQ') THEN
+    RAISE EXCEPTION 'QUA-764 aborted: entity sid_kh5x0eezrQ (playground-ai) not found in entities. Cannot link sid_Playground investments rows.';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  storyworth_updated INT;
+  playground_updated INT;
+  things_deleted INT;
+  rows_deleted INT;
+BEGIN
+  -- Phase 1a: Normalize sid_Storyworth → entity 'storyworth' (sid_kT85f91plA)
+  UPDATE "investments"
+  SET
+    "company_entity_id" = 'sid_kT85f91plA',
+    "company_id"        = 'storyworth',
+    "company_display_name" = COALESCE("company_display_name", 'StoryWorth'),
+    "updated_at"        = NOW()
+  WHERE "company_id" = 'sid_Storyworth'
+    AND "company_entity_id" IS NULL;
+  GET DIAGNOSTICS storyworth_updated = ROW_COUNT;
+  RAISE NOTICE 'QUA-764: normalized sid_Storyworth → storyworth on % row(s)', storyworth_updated;
+
+  -- Phase 1b: Normalize sid_Playground → entity 'playground-ai' (sid_kh5x0eezrQ)
+  UPDATE "investments"
+  SET
+    "company_entity_id" = 'sid_kh5x0eezrQ',
+    "company_id"        = 'playground-ai',
+    "company_display_name" = COALESCE("company_display_name", 'Playground'),
+    "updated_at"        = NOW()
+  WHERE "company_id" = 'sid_Playground'
+    AND "company_entity_id" IS NULL;
+  GET DIAGNOSTICS playground_updated = ROW_COUNT;
+  RAISE NOTICE 'QUA-764: normalized sid_Playground → playground-ai on % row(s)', playground_updated;
+
+  -- Phase 2: Delete `things` rows for orphan investments first (FK-safe ordering).
+  -- Match criteria: investments rows where either `company_id` or `investor_id`
+  -- is sid_-prefixed, the corresponding entity FK is NULL, and the sid does
+  -- not resolve against the current entities table.
+  DELETE FROM "things"
+  WHERE "source_table" = 'investments'
+    AND "source_id" IN (
+      SELECT i."id" FROM "investments" i
+      WHERE
+        (
+          i."company_id" LIKE 'sid_%'
+          AND i."company_entity_id" IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM "entities" e WHERE e."stable_id" = i."company_id"
+          )
+        )
+        OR
+        (
+          i."investor_id" LIKE 'sid_%'
+          AND i."investor_entity_id" IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM "entities" e WHERE e."stable_id" = i."investor_id"
+          )
+        )
+    );
+  GET DIAGNOSTICS things_deleted = ROW_COUNT;
+  RAISE NOTICE 'QUA-764: deleted % orphan things row(s) for investments', things_deleted;
+
+  -- Phase 3: Delete the orphan investments rows themselves.
+  -- Same predicate as Phase 2.
+  DELETE FROM "investments" i
+  WHERE
+    (
+      i."company_id" LIKE 'sid_%'
+      AND i."company_entity_id" IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "entities" e WHERE e."stable_id" = i."company_id"
+      )
+    )
+    OR
+    (
+      i."investor_id" LIKE 'sid_%'
+      AND i."investor_entity_id" IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "entities" e WHERE e."stable_id" = i."investor_id"
+      )
+    );
+  GET DIAGNOSTICS rows_deleted = ROW_COUNT;
+  RAISE NOTICE 'QUA-764: deleted % orphan investments row(s)', rows_deleted;
+END $$;

--- a/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
+++ b/apps/wiki-server/drizzle/0220_qua_764_investments_sid_leak_fix.sql
@@ -16,7 +16,7 @@
 --     `company_id`/`investor_id` are NOT NULL so the ticket's "null both
 --     columns" option isn't available.
 --
--- F3 trade-off — single-side investor leaks: the 3 "investor-only" leak
+-- Trade-off — single-side investor leaks: the 3 "investor-only" leak
 -- rows (6GS_vh6msp Algolia/Seed/2014, G7xvfoDpI3 Rippling/Series A/$45M,
 -- Wq9J6mOQFe Rippling/Series C/2021) have valid resolved companies. The
 -- DELETE WHERE clause uses `OR` between company-leak and investor-leak
@@ -125,6 +125,25 @@ BEGIN
       "updated_at"      = NOW()
   WHERE "source_table" = 'investments'
     AND "parent_thing_id" = 'sid_Playground';
+
+  -- Phase 1d: defensive sanity check — confirm no row we just normalized
+  -- ALSO has an orphan investor sid. If one did, Phase 3's OR-predicate
+  -- would delete the row we just fixed (silently undoing Phase 1).
+  -- Verified false against prod 2026-04-29; this assertion converts a
+  -- future regression (e.g., new bad data of this exact shape) from a
+  -- silent data loss into a loud abort.
+  IF EXISTS (
+    SELECT 1 FROM "investments"
+    WHERE "company_id" IN ('storyworth', 'playground-ai')
+      AND "investor_id" LIKE 'sid_%'
+      AND "investor_entity_id" IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "entities" e
+        WHERE e."stable_id" = "investments"."investor_id"
+      )
+  ) THEN
+    RAISE EXCEPTION 'QUA-764 aborted: a normalized investment row also has an orphan investor sid. Phase 3 OR-delete would silently destroy the just-normalized row. Investigate before re-running.';
+  END IF;
 
   -- Phase 2: Delete `things` rows for orphan investments first (FK-safe ordering).
   -- Match criteria: investments rows where either `company_id` or `investor_id`

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1534,6 +1534,13 @@
       "when": 1787877000000,
       "tag": "0219_qua_696_widen_ai_incidents_source",
       "breakpoints": true
+    },
+    {
+      "idx": 220,
+      "version": "7",
+      "when": 1787877100000,
+      "tag": "0220_qua_764_investments_sid_leak_fix",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
@@ -13,16 +13,42 @@ const MIGRATION_FILE = path.resolve(
 describe("migration 0220 — QUA-764 investments sid_ leak fix", () => {
   const sql = readFileSync(MIGRATION_FILE, "utf-8");
 
+  /**
+   * Find the single UPDATE statement on the given table whose WHERE clause
+   * contains the given literal. Splits the SQL into individual UPDATE
+   * statements (delimited by `;`) so a regex anchored at the start can't
+   * span two adjacent UPDATEs. Used to assert pair-locality so a sid swap
+   * between Storyworth/Playground UPDATEs is caught.
+   */
+  function findUpdateBlock(table: string, whereLiteral: string): string {
+    const updateRe = new RegExp(`UPDATE "${table}"[\\s\\S]*?;`, "g");
+    const matches = [...sql.matchAll(updateRe)].map((m) => m[0]);
+    const candidates = matches.filter((b) => b.includes(whereLiteral));
+    expect(
+      candidates.length,
+      `expected exactly one UPDATE "${table}" block containing ${whereLiteral}, found ${candidates.length}`,
+    ).toBe(1);
+    return candidates[0];
+  }
+
   it("normalizes sid_Storyworth to entity 'storyworth' (sid_kT85f91plA)", () => {
-    expect(sql).toMatch(
-      /UPDATE "investments"[\s\S]+SET[\s\S]+"company_entity_id" = 'sid_kT85f91plA'[\s\S]+"company_id"\s+= 'storyworth'[\s\S]+WHERE "company_id" = 'sid_Storyworth'[\s\S]+AND "company_entity_id" IS NULL/,
-    );
+    const block = findUpdateBlock("investments", `"company_id" = 'sid_Storyworth'`);
+    expect(block).toMatch(/"company_entity_id" = 'sid_kT85f91plA'/);
+    expect(block).toMatch(/"company_id"\s+= 'storyworth'/);
+    expect(block).toMatch(/"company_entity_id" IS NULL/);
+    // Cross-pair guard: the playground sid must NOT appear in the storyworth block
+    expect(block).not.toMatch(/sid_kh5x0eezrQ/);
+    expect(block).not.toMatch(/playground-ai/);
   });
 
   it("normalizes sid_Playground to entity 'playground-ai' (sid_kh5x0eezrQ)", () => {
-    expect(sql).toMatch(
-      /UPDATE "investments"[\s\S]+SET[\s\S]+"company_entity_id" = 'sid_kh5x0eezrQ'[\s\S]+"company_id"\s+= 'playground-ai'[\s\S]+WHERE "company_id" = 'sid_Playground'[\s\S]+AND "company_entity_id" IS NULL/,
-    );
+    const block = findUpdateBlock("investments", `"company_id" = 'sid_Playground'`);
+    expect(block).toMatch(/"company_entity_id" = 'sid_kh5x0eezrQ'/);
+    expect(block).toMatch(/"company_id"\s+= 'playground-ai'/);
+    expect(block).toMatch(/"company_entity_id" IS NULL/);
+    // Cross-pair guard
+    expect(block).not.toMatch(/sid_kT85f91plA/);
+    expect(block).not.toMatch(/'storyworth'/);
   });
 
   it("preserves existing display name via COALESCE", () => {
@@ -40,23 +66,41 @@ describe("migration 0220 — QUA-764 investments sid_ leak fix", () => {
     // so things rows for these investments still point at 'sid_Storyworth' /
     // 'sid_Playground' until we update them. Otherwise the things_search
     // MV refresh propagates the bad sids into search results.
-    expect(sql).toMatch(
-      /UPDATE "things"[\s\S]+SET "parent_thing_id" = 'storyworth'[\s\S]+WHERE "source_table" = 'investments'[\s\S]+AND "parent_thing_id" = 'sid_Storyworth'/,
-    );
-    expect(sql).toMatch(
-      /UPDATE "things"[\s\S]+SET "parent_thing_id" = 'playground-ai'[\s\S]+WHERE "source_table" = 'investments'[\s\S]+AND "parent_thing_id" = 'sid_Playground'/,
-    );
+    const storyworthBlock = findUpdateBlock("things", `"parent_thing_id" = 'sid_Storyworth'`);
+    expect(storyworthBlock).toMatch(/"parent_thing_id" = 'storyworth'/);
+    expect(storyworthBlock).toMatch(/"source_table" = 'investments'/);
+    expect(storyworthBlock).not.toMatch(/'playground-ai'/);
+
+    const playgroundBlock = findUpdateBlock("things", `"parent_thing_id" = 'sid_Playground'`);
+    expect(playgroundBlock).toMatch(/"parent_thing_id" = 'playground-ai'/);
+    expect(playgroundBlock).toMatch(/"source_table" = 'investments'/);
+    expect(playgroundBlock).not.toMatch(/'storyworth'/);
   });
 
-  it("documents the F3 trade-off (single-side investor leaks)", () => {
-    // Reviewer flagged that `OR` between company-leak and investor-leak
-    // predicates would delete rows where the company side is valid but
-    // the investor is orphan. The migration's header comment must
-    // explicitly acknowledge this trade-off so future readers don't think
-    // it's an oversight.
-    expect(sql).toMatch(/F3 trade-off — single-side investor leaks/);
+  it("documents the trade-off for single-side investor leaks", () => {
+    // The migration's header comment must explicitly acknowledge the
+    // OR-predicate trade-off (single-side investor-leak rows lose valid
+    // company-side data) so future readers don't think it's an oversight.
+    expect(sql).toMatch(/single-side investor leaks/);
     expect(sql).toMatch(/Algolia/);
     expect(sql).toMatch(/Rippling/);
+  });
+
+  it("has a defensive abort if a normalized row also has an orphan investor sid", () => {
+    // Phase 1 normalizes 2 rows; Phase 3's OR-predicate would delete a
+    // row where company normalized but investor is also a sid_ orphan.
+    // The defensive check converts that scenario from silent data loss
+    // into a loud abort.
+    expect(sql).toMatch(
+      /RAISE EXCEPTION 'QUA-764 aborted: a normalized investment row also has an orphan investor sid/,
+    );
+    // Defensive check must run AFTER normalization but BEFORE deletion.
+    const normalizeIdx = sql.indexOf("'sid_Playground'");
+    const checkIdx = sql.indexOf("a normalized investment row also has an orphan");
+    const phase2Idx = sql.indexOf('DELETE FROM "things"');
+    expect(normalizeIdx).toBeGreaterThan(0);
+    expect(checkIdx).toBeGreaterThan(normalizeIdx);
+    expect(checkIdx).toBeLessThan(phase2Idx);
   });
 
   it("notes things_search MV staleness expectation", () => {

--- a/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../../drizzle/0220_qua_764_investments_sid_leak_fix.sql",
+);
+
+describe("migration 0220 — QUA-764 investments sid_ leak fix", () => {
+  const sql = readFileSync(MIGRATION_FILE, "utf-8");
+
+  it("normalizes sid_Storyworth to entity 'storyworth' (sid_kT85f91plA)", () => {
+    expect(sql).toMatch(
+      /UPDATE "investments"[\s\S]+SET[\s\S]+"company_entity_id" = 'sid_kT85f91plA'[\s\S]+"company_id"\s+= 'storyworth'[\s\S]+WHERE "company_id" = 'sid_Storyworth'[\s\S]+AND "company_entity_id" IS NULL/,
+    );
+  });
+
+  it("normalizes sid_Playground to entity 'playground-ai' (sid_kh5x0eezrQ)", () => {
+    expect(sql).toMatch(
+      /UPDATE "investments"[\s\S]+SET[\s\S]+"company_entity_id" = 'sid_kh5x0eezrQ'[\s\S]+"company_id"\s+= 'playground-ai'[\s\S]+WHERE "company_id" = 'sid_Playground'[\s\S]+AND "company_entity_id" IS NULL/,
+    );
+  });
+
+  it("preserves existing display name via COALESCE", () => {
+    // Don't blow away a manually-set display name.
+    expect(sql).toMatch(
+      /COALESCE\("company_display_name", 'StoryWorth'\)/,
+    );
+    expect(sql).toMatch(
+      /COALESCE\("company_display_name", 'Playground'\)/,
+    );
+  });
+
+  it("deletes things rows BEFORE investments rows (FK-safe ordering)", () => {
+    const thingsDeleteIdx = sql.indexOf('DELETE FROM "things"');
+    const investmentsDeleteIdx = sql.indexOf('DELETE FROM "investments"');
+    expect(thingsDeleteIdx).toBeGreaterThan(0);
+    expect(investmentsDeleteIdx).toBeGreaterThan(0);
+    expect(thingsDeleteIdx).toBeLessThan(investmentsDeleteIdx);
+  });
+
+  it("scopes things deletion to source_table = 'investments'", () => {
+    expect(sql).toMatch(
+      /DELETE FROM "things"[\s\S]+WHERE "source_table" = 'investments'[\s\S]+AND "source_id" IN/,
+    );
+  });
+
+  it("uses pattern-based DELETE (not hardcoded row ids)", () => {
+    // .claude/rules/database-migrations.md: never hardcode specific row ids
+    // in dedup-style migrations — they miss future rows that match the same
+    // shape. Match by predicate (LIKE 'sid_%' AND entity_id IS NULL AND no
+    // matching entity).
+    const deleteSection = sql.slice(sql.indexOf('DELETE FROM "investments"'));
+    expect(deleteSection).toMatch(/"company_id" LIKE 'sid_%'/);
+    expect(deleteSection).toMatch(/"investor_id" LIKE 'sid_%'/);
+    expect(deleteSection).toMatch(/"company_entity_id" IS NULL/);
+    expect(deleteSection).toMatch(/"investor_entity_id" IS NULL/);
+    expect(deleteSection).toMatch(
+      /NOT EXISTS \(\s*SELECT 1 FROM "entities" e WHERE e\."stable_id" = i\."company_id"\s*\)/,
+    );
+    expect(deleteSection).toMatch(
+      /NOT EXISTS \(\s*SELECT 1 FROM "entities" e WHERE e\."stable_id" = i\."investor_id"\s*\)/,
+    );
+  });
+
+  it("uses RAISE NOTICE for visibility on each phase", () => {
+    // Operators reading the deploy log should see what happened.
+    expect(sql).toMatch(/RAISE NOTICE 'QUA-764: normalized sid_Storyworth/);
+    expect(sql).toMatch(/RAISE NOTICE 'QUA-764: normalized sid_Playground/);
+    expect(sql).toMatch(/RAISE NOTICE 'QUA-764: deleted % orphan things row\(s\)/);
+    expect(sql).toMatch(/RAISE NOTICE 'QUA-764: deleted % orphan investments row\(s\)/);
+  });
+
+  it("does not opt out of the audit trigger (no app.audit_skip)", () => {
+    // .claude/rules/audit-log.md "When NOT to use it": application
+    // bug fixes should be audited. Only bulk migrations (>>10 rows) opt out.
+    expect(sql).not.toMatch(/SET LOCAL app\.audit_skip/);
+  });
+
+  it("pre-flight aborts loudly if target entities are missing", () => {
+    // Better error than a raw FK violation if storyworth or playground-ai
+    // ever get dropped from the entities table before migration runs.
+    expect(sql).toMatch(
+      /RAISE EXCEPTION 'QUA-764 aborted: entity sid_kT85f91plA \(storyworth\) not found/,
+    );
+    expect(sql).toMatch(
+      /RAISE EXCEPTION 'QUA-764 aborted: entity sid_kh5x0eezrQ \(playground-ai\) not found/,
+    );
+    // Pre-flight must run BEFORE the UPDATEs so we fail before partial state.
+    const preflightIdx = sql.indexOf("QUA-764 aborted");
+    const updateIdx = sql.indexOf('UPDATE "investments"');
+    expect(preflightIdx).toBeLessThan(updateIdx);
+  });
+});

--- a/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
+++ b/apps/wiki-server/src/__tests__/migration-0220-qua-764-investments-sid-leak.test.ts
@@ -35,6 +35,38 @@ describe("migration 0220 — QUA-764 investments sid_ leak fix", () => {
     );
   });
 
+  it("rewrites things.parent_thing_id for the 2 normalized rows", () => {
+    // The route's toThing writes parent_thing_id = companyId at sync time,
+    // so things rows for these investments still point at 'sid_Storyworth' /
+    // 'sid_Playground' until we update them. Otherwise the things_search
+    // MV refresh propagates the bad sids into search results.
+    expect(sql).toMatch(
+      /UPDATE "things"[\s\S]+SET "parent_thing_id" = 'storyworth'[\s\S]+WHERE "source_table" = 'investments'[\s\S]+AND "parent_thing_id" = 'sid_Storyworth'/,
+    );
+    expect(sql).toMatch(
+      /UPDATE "things"[\s\S]+SET "parent_thing_id" = 'playground-ai'[\s\S]+WHERE "source_table" = 'investments'[\s\S]+AND "parent_thing_id" = 'sid_Playground'/,
+    );
+  });
+
+  it("documents the F3 trade-off (single-side investor leaks)", () => {
+    // Reviewer flagged that `OR` between company-leak and investor-leak
+    // predicates would delete rows where the company side is valid but
+    // the investor is orphan. The migration's header comment must
+    // explicitly acknowledge this trade-off so future readers don't think
+    // it's an oversight.
+    expect(sql).toMatch(/F3 trade-off — single-side investor leaks/);
+    expect(sql).toMatch(/Algolia/);
+    expect(sql).toMatch(/Rippling/);
+  });
+
+  it("notes things_search MV staleness expectation", () => {
+    // We deliberately don't REFRESH MATERIALIZED VIEW in the migration —
+    // the comment explains why and reassures operators that the hourly
+    // groundskeeper refresh will catch up.
+    expect(sql).toMatch(/things_search materialized view/);
+    expect(sql).toMatch(/groundskeeper REFRESH/);
+  });
+
   it("deletes things rows BEFORE investments rows (FK-safe ordering)", () => {
     const thingsDeleteIdx = sql.indexOf('DELETE FROM "things"');
     const investmentsDeleteIdx = sql.indexOf('DELETE FROM "investments"');


### PR DESCRIPTION
## Summary

Fixes Linear [QUA-764](https://linear.app/quantifieduncertainty/issue/QUA-764). 10 rows in the `investments` PG table had a `sid_*`-prefixed value in the raw text column with no resolved entity FK, so the entity-FK left-join resolved to NULL and the raw `sid_*` value leaked into UI/reports/backfill claims.

Fixes QUA-764

## Root cause

The 10 rows pre-date the route's `validateEntityRefs` protection. The current `investments POST /sync` route already rejects items with a `companyId`/`investorId` that doesn't match an entity (sync-factory `entityRefFields` config) — no code change required, just data cleanup.

## Two flavors per the ticket

| Disposition | Rows | Treatment |
|---|---|---|
| Title-with-prefix (normalize) | 2 | `sid_Storyworth` → `storyworth` (sid_kT85f91plA), `sid_Playground` → `playground-ai` (sid_kh5x0eezrQ). Set the FK + slug, COALESCE preserves any existing display_name. |
| Orphan sids (delete) | 8 | 5 company-side + 3 investor-side (with 2 rows having both leaks). `company_id`/`investor_id` are NOT NULL, so the ticket's "null both columns" option isn't available. |

## Audit (per ticket scope, prod 2026-04-29)

| Table | Field | Leaks |
|---|---|---|
| investments | company_id | 7 |
| investments | investor_id | 5 (3 distinct from company-side) |
| equity_positions | company_id, holder_id | 0 |
| funding_rounds | company_id | 0 |
| personnel | organization_id, person_id | 0 |
| divisions | parent_org_id | N/A — schema has `parent_org_id REFERENCES entities(stable_id)` directly, structurally impossible to be orphaned |

## Trade-off — single-side investor leaks

3 "investor-only-leak" rows (Algolia/Seed/2014; Rippling Series A/$45M; Rippling Series C/2021) have valid resolved companies. The DELETE WHERE clause uses `OR` between company-leak and investor-leak predicates, so these 3 rows are deleted along with their orphan-company counterparts. Documented explicitly in the migration header. Acceptance language ("delete or null both") permits this.

## Migration safety

- **Pattern-based predicates** (`LIKE 'sid_%' AND <fk> IS NULL AND NOT EXISTS (SELECT 1 FROM entities ...)`) — not hardcoded row IDs. Idempotent; second run is a no-op. Self-healing for future bad data of the same shape.
- **Phase 0 pre-flight**: aborts with `RAISE EXCEPTION 'QUA-764 aborted'` if `storyworth` or `playground-ai` entities are missing — clearer than a raw FK violation.
- **Phase 1d defensive check** (added during /simplify): aborts if a normalized row also has an orphan investor sid (which would mean Phase 3's OR-delete silently destroys the just-normalized row). Verified zero such rows on prod.
- **FK-safe ordering**: `things` rows deleted before `investments` rows.
- **`things.parent_thing_id` synced** for the 2 normalized rows so the next hourly `things_search` MV refresh doesn't propagate the bad sids.
- **No `app.audit_skip`** — the change writes to `full_audit_log` for forensic visibility.
- **No explicit `REFRESH MATERIALIZED VIEW`** — non-CONCURRENT refresh inside the migration tx would hold AccessExclusiveLock for ~30-60s. Hourly groundskeeper REFRESH (CONCURRENTLY) catches up within ~1h. Documented in the migration header.

## Test plan

- [x] `pnpm --filter wiki-server test` — 1538/1538 pass (13 new shape tests for migration 0220, including cross-pair-swap regression guards)
- [x] `pnpm --filter wiki-server typecheck` — clean
- [x] `pnpm crux w validate gate --fix` — 67/67 checks pass (2 pre-existing advisory warnings)
- [x] Verified collision-free against prod's `uq_investments_entity_key` index for both normalizations
- [x] /agent-review-pr (hostile-reviewer subagent) — found 4 HIGH / 4 MEDIUM / 5 LOW; addressed F1 (verified clean), F3 (documented), F9 (added Phase 1c things sync + MV staleness note)
- [x] /simplify pass — 3 findings; added Phase 1d defensive check, hardened test cross-pair guards, renamed "F3 trade-off" to content-descriptive heading

## Post-deploy verification

- [ ] `manual` Verify the 10 specific row IDs no longer leak on prod — `WIKI_SERVER_ENV=prod pnpm crux query stats` then check `/api/investments/all` for any `sid_*` companyId/investorId with NULL FK. Expected: 0 leaks.
- [ ] `manual` Spot-check the 2 normalized rows display the entity titles on the UI (`/organizations/storyworth`, `/organizations/playground-ai` — investments tab) within the next hour after deploy


## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `migration` Verify migration 0220 applied on server start — `psql "$DATABASE_URL" -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 5;"`
<!-- /deploy-tasks -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data integrity issue where certain investment records contained improperly formatted identifiers, preventing them from resolving to correct entities. Affected records have been normalized and orphaned entries removed to restore consistency.

* **Tests**
  * Added comprehensive test coverage validating the investment data migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->