### PR TITLE
QUA-876: organization gap analyzer + verdict applier

### DIFF
--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -12,8 +12,13 @@
 //   6. polls until settled, then applies verified+partial verdicts to YAML
 //   7. records per-iteration metrics; exits when target hit / iters / budget
 //
+// Supported entity types:
+//   - policy        (data/entities/responses.yaml)
+//   - organization  (data/entities/organizations.yaml)
+//
 // Usage:
 //   pnpm crux tb improve-entity fisa-702 --target=15 --budget=2 --max-iters=3
+//   pnpm crux tb improve-entity anthropic --target=10 --max-iters=1
 
 import fs from "node:fs";
 import path from "node:path";
@@ -24,16 +29,43 @@ import { type CommandResult } from "../lib/cli.ts";
 import { runResearch } from "../lib/search/research-agent.ts";
 import { proposeClaims, getClaimStatus } from "../lib/wiki-server/claims.ts";
 import { suggestResourcesApi } from "../lib/wiki-server/resources.ts";
+import { searchEntities } from "../lib/wiki-server/entities.ts";
 import { createLlmClient, streamingCreate, extractText, MODELS } from "../lib/llm.ts";
 import { escapeXml } from "../lib/prompt-utils.ts";
 
-import { analyzePolicyGaps, policyCoverageScore, type Gap, type PolicyEntity } from "../lib/research/gap-analyzer.ts";
+import {
+  analyzePolicyGaps,
+  analyzeOrganizationGaps,
+  policyCoverageScore,
+  organizationCoverageScore,
+  type CoverageScore,
+  type Gap,
+  type OrganizationEntity,
+  type PolicyEntity,
+} from "../lib/research/gap-analyzer.ts";
 import { preFilterBatch, type PreFilterClaim } from "../lib/research/pre-filter.ts";
-import { applyVerdictsToPolicy, type VerifiedVerdict } from "../lib/research/apply-verdicts.ts";
+import {
+  applyVerdictsToOrganization,
+  applyVerdictsToPolicy,
+  canonicalizePersonKey,
+  type ApplyResult,
+  type PersonEntityResolver,
+  type VerifiedVerdict,
+} from "../lib/research/apply-verdicts.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
-const RESPONSES_YAML = path.join(ROOT, "data/entities/responses.yaml");
+const ENTITIES_DIR = path.join(ROOT, "data/entities");
 const SNAPSHOTS = path.join(ROOT, ".claude/snapshots/improve-entity");
+
+const SUPPORTED_TYPES = new Set(["policy", "organization"]);
+
+interface EntityWithType {
+  id: string;
+  stableId?: string;
+  type: string;
+  title?: string;
+  [k: string]: unknown;
+}
 
 interface IterationMetrics {
   iter: number;
@@ -56,6 +88,7 @@ interface IterationMetrics {
 interface ImproveResult {
   entity_slug: string;
   entity_id: string;
+  entity_type: string;
   iterations: IterationMetrics[];
   final_coverage: number;
   final_facts: Record<string, number>;
@@ -82,30 +115,48 @@ interface ExtractedClaim {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// YAML I/O — load/save the entity record from data/entities/responses.yaml
+// YAML I/O — locate the entity's source file by scanning data/entities/
 // ──────────────────────────────────────────────────────────────────────────────
 
-function loadResponsesYaml(): unknown[] {
-  const raw = fs.readFileSync(RESPONSES_YAML, "utf8");
-  return yaml.load(raw) as unknown[];
+interface FoundEntity {
+  entity: EntityWithType;
+  filePath: string;
+  index: number;
 }
 
-function findPolicyEntity(slug: string): { entity: PolicyEntity; index: number } | null {
-  const all = loadResponsesYaml();
-  const idx = all.findIndex((e) => (e as PolicyEntity).id === slug);
-  if (idx === -1) return null;
-  return { entity: all[idx] as PolicyEntity, index: idx };
+/** Find an entity by slug across all data/entities/*.yaml files. */
+function findEntity(slug: string): FoundEntity | null {
+  const files = fs
+    .readdirSync(ENTITIES_DIR)
+    .filter((f) => f.endsWith(".yaml"))
+    .map((f) => path.join(ENTITIES_DIR, f));
+  for (const filePath of files) {
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(fs.readFileSync(filePath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(parsed)) continue;
+    const idx = parsed.findIndex((e) => (e as EntityWithType).id === slug);
+    if (idx !== -1) {
+      return { entity: parsed[idx] as EntityWithType, filePath, index: idx };
+    }
+  }
+  return null;
 }
 
-function saveEntity(slug: string, entity: PolicyEntity): void {
-  // Surgical splice: replace ONLY the bytes for this entity's block, leaving
-  // the rest of the file byte-identical. Avoids the diff-bomb that
-  // yaml.dump(allEntities) creates by reformatting every other entity.
-  const raw = fs.readFileSync(RESPONSES_YAML, "utf8");
+/**
+ * Surgical splice: replace ONLY the bytes for this entity's block, leaving
+ * the rest of the file byte-identical. Avoids the diff-bomb that
+ * yaml.dump(allEntities) creates by reformatting every other entity.
+ */
+function saveEntity(filePath: string, slug: string, entity: EntityWithType): void {
+  const raw = fs.readFileSync(filePath, "utf8");
   const lines = raw.split("\n");
   const startMarker = `- id: ${slug}`;
   const startIdx = lines.findIndex((l) => l.startsWith(startMarker));
-  if (startIdx === -1) throw new Error(`Entity ${slug} not found in YAML`);
+  if (startIdx === -1) throw new Error(`Entity ${slug} not found in ${filePath}`);
   // The block ends at the next "- id:" or EOF.
   let endIdx = lines.length;
   for (let i = startIdx + 1; i < lines.length; i++) {
@@ -114,14 +165,93 @@ function saveEntity(slug: string, entity: PolicyEntity): void {
       break;
     }
   }
-  // Serialize JUST this entity wrapped in a list, then strip the leading "- ".
   const blockYaml = yaml
     .dump([entity], { indent: 2, lineWidth: 120, noRefs: true, sortKeys: false })
     .trimEnd();
   const before = lines.slice(0, startIdx).join("\n");
   const after = lines.slice(endIdx).join("\n");
   const out = (before ? before + "\n" : "") + blockYaml + "\n" + after;
-  fs.writeFileSync(RESPONSES_YAML, out, "utf8");
+  fs.writeFileSync(filePath, out, "utf8");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Type-aware dispatch
+// ──────────────────────────────────────────────────────────────────────────────
+
+function gapsFor(entity: EntityWithType): Gap[] {
+  if (entity.type === "policy") return analyzePolicyGaps(entity as unknown as PolicyEntity);
+  if (entity.type === "organization")
+    return analyzeOrganizationGaps(entity as unknown as OrganizationEntity);
+  return [];
+}
+
+function coverageFor(entity: EntityWithType): CoverageScore {
+  if (entity.type === "policy") return policyCoverageScore(entity as unknown as PolicyEntity);
+  if (entity.type === "organization")
+    return organizationCoverageScore(entity as unknown as OrganizationEntity);
+  return { score: 0, components: {}, facts_in_yaml: {} };
+}
+
+function progressMetric(entity: EntityWithType): number {
+  if (entity.type === "policy") {
+    const e = entity as unknown as PolicyEntity;
+    return (e.provisions?.length ?? 0) + (e.stakeholders?.length ?? 0);
+  }
+  if (entity.type === "organization") {
+    const e = entity as unknown as OrganizationEntity;
+    return (
+      (e.products?.length ?? 0) +
+      (e.keyPeople?.length ?? 0) +
+      (e.keyDates?.length ?? 0)
+    );
+  }
+  return 0;
+}
+
+async function applyVerdictsToEntity(
+  entity: EntityWithType,
+  verdicts: VerifiedVerdict[],
+): Promise<ApplyResult<EntityWithType>> {
+  if (entity.type === "policy") {
+    const r = applyVerdictsToPolicy(entity as unknown as PolicyEntity, verdicts);
+    return r as unknown as ApplyResult<EntityWithType>;
+  }
+  if (entity.type === "organization") {
+    // Build a person resolver from the verdicts' display names. We pre-fetch
+    // search results once per unique candidate to keep the closure synchronous.
+    const candidateNames = new Set<string>();
+    for (const v of verdicts) {
+      if (!v.targetField.startsWith("keyPerson.")) continue;
+      const name = v.displayHint ?? v.targetField.slice("keyPerson.".length);
+      if (name) candidateNames.add(name);
+    }
+    const resolved = new Map<string, string>();
+    for (const name of candidateNames) {
+      try {
+        const sr = await searchEntities(name, 5);
+        if (!sr.ok) continue;
+        const data = sr.data as { results?: Array<{ id: string; title?: string; entityType?: string }> };
+        const results = data.results ?? [];
+        const targetCanon = canonicalizePersonKey(name);
+        const match = results.find(
+          (r) => r.entityType === "person" && canonicalizePersonKey(r.title ?? r.id) === targetCanon,
+        );
+        if (match) resolved.set(targetCanon, match.id);
+      } catch {
+        // network/api error — skip cross-ref for this candidate
+      }
+    }
+    const resolver: PersonEntityResolver = (canon) => resolved.get(canon) ?? null;
+    const r = applyVerdictsToOrganization(entity as unknown as OrganizationEntity, verdicts, {
+      resolvePersonEntity: resolver,
+    });
+    return r as unknown as ApplyResult<EntityWithType>;
+  }
+  return {
+    entity,
+    applied: [],
+    warnings: [`unsupported entity type for verdict applier: ${entity.type}`],
+  };
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -136,19 +266,59 @@ function llm() {
   return _llm;
 }
 
-function buildExtractPrompt(entity: PolicyEntity, gaps: Gap[], sourceUrl: string, sourceContent: string): string {
+interface ExtractFieldGuide {
+  scalarFieldsHint: string;
+  arrayTargetsHint: string;
+}
+
+function extractFieldGuide(entityType: string): ExtractFieldGuide {
+  if (entityType === "organization") {
+    return {
+      scalarFieldsHint:
+        '"scalar.<field>" where <field> is description/website/orgType/founded/headquarters/employees/funding/parentOrg/orgStatus/safetyFocus',
+      arrayTargetsHint:
+        '"product.<name-slug>"      e.g. "product.claude-3-5-sonnet"\n' +
+        '    "keyPerson.<name-slug>"    e.g. "keyPerson.dario-amodei"\n' +
+        '    "keyDate.<event-slug>"     e.g. "keyDate.founded-2021"\n' +
+        '    "tag.<value>"\n' +
+        '    "relatedEntry.<entity-slug>"\n' +
+        '    "factbase.revenue" or "factbase.valuation"  (will be routed to FactBase, separate ticket)',
+    };
+  }
+  // policy
+  return {
+    scalarFieldsHint:
+      '"scalar.<field>" where <field> is description/billNumber/introduced/policyStatus/author/jurisdiction/fullTextUrl',
+    arrayTargetsHint:
+      '"provision.<title-slug>"    e.g. "provision.targeting-non-us-persons"\n' +
+      '    "stakeholder.<name-slug>"   e.g. "stakeholder.american-civil-liberties-union"\n' +
+      '    "tag.<value>"\n' +
+      '    "relatedEntry.<entity-slug>"',
+  };
+}
+
+function buildExtractPrompt(
+  entity: EntityWithType,
+  gaps: Gap[],
+  sourceUrl: string,
+  sourceContent: string,
+): string {
   const truncated = sourceContent.slice(0, 8000);
   const gapsXml = gaps
     .map((g) =>
       `  <gap key="${escapeXml(g.key)}" target="${escapeXml(g.target)}">${escapeXml(g.description)}</gap>`,
     )
     .join("\n");
-  return `Extract structured facts from the source document below to fill gaps in the policy entity "${escapeXml(entity.title ?? entity.id)}".
+  const guide = extractFieldGuide(entity.type);
+  const description = typeof entity.description === "string" ? entity.description : "";
+  return `Extract structured facts from the source document below to fill gaps in the ${escapeXml(
+    entity.type,
+  )} entity "${escapeXml(entity.title ?? entity.id)}".
 
 <entity id="${escapeXml(entity.id)}">
   <type>${escapeXml(entity.type)}</type>
   <title>${escapeXml(entity.title ?? "")}</title>
-  <description>${escapeXml((entity.description ?? "").slice(0, 500))}</description>
+  <description>${escapeXml(description.slice(0, 500))}</description>
 </entity>
 
 <gaps_to_fill>
@@ -161,18 +331,15 @@ ${escapeXml(truncated)}
 
 For each fact you can extract from the source that fills one of the gaps, return a JSON object with:
 - targetField: one of:
-    "scalar.<field>"           where <field> is description/billNumber/introduced/policyStatus/author/jurisdiction/fullTextUrl
-    "provision.<title-slug>"    e.g. "provision.targeting-non-us-persons"
-    "stakeholder.<name-slug>"   e.g. "stakeholder.american-civil-liberties-union"
-    "tag.<value>"
-    "relatedEntry.<entity-slug>"
-- claimText: a concise, paraphrased assertion that can be verified against the source. Avoid overly-specific dates or vote tallies unless the source states them verbatim.
-- proposedValue: the actual value to write into YAML (a sentence for provision/stakeholder/description, a short string for billNumber/dates/etc.).
-- displayHint: human title for new provisions/stakeholders (e.g. "Targeting Non-US Persons Abroad", "American Civil Liberties Union (ACLU)").
+    ${guide.scalarFieldsHint}
+    ${guide.arrayTargetsHint}
+- claimText: a concise, paraphrased assertion that can be verified against the source. Avoid overly-specific dates or figures unless the source states them verbatim.
+- proposedValue: the actual value to write into YAML (a sentence for product/keyDate description / provision / stakeholder / description, a short string for billNumber/dates/etc., a date string for keyDate.*).
+- displayHint: human label for new array entries (e.g. "Claude 3.5 Sonnet", "Dario Amodei", "Founded as Anthropic PBC").
 
 CRITICAL:
 - Only extract claims explicitly supported by the source.
-- Do NOT fabricate stakeholder positions or vote tallies.
+- Do NOT fabricate data, positions, valuations, or vote tallies.
 - Prefer paraphrased claims over exact quotes; the verifier will reject claims whose specific tokens aren't in the source.
 - Return at most 8 claims per call.
 
@@ -180,7 +347,7 @@ Return ONLY a JSON array. No prose, no markdown fences.`;
 }
 
 async function extractGapClaims(
-  entity: PolicyEntity,
+  entity: EntityWithType,
   gaps: Gap[],
   sourceUrl: string,
   sourceContent: string,
@@ -206,7 +373,6 @@ async function extractGapClaims(
 
   const cost = (inT / 1_000_000) * HAIKU_PRICING.inputPerM + (outT / 1_000_000) * HAIKU_PRICING.outputPerM;
 
-  // Parse — tolerant of leading/trailing prose.
   const match = raw.match(/\[[\s\S]*\]/);
   if (!match) return { claims: [], cost };
   let parsed: unknown;
@@ -231,10 +397,10 @@ async function extractGapClaims(
 // ──────────────────────────────────────────────────────────────────────────────
 
 async function runIteration(
-  entity: PolicyEntity,
+  entity: EntityWithType,
   iter: number,
   budgetRemainingUsd: number,
-): Promise<{ entity: PolicyEntity; metrics: IterationMetrics }> {
+): Promise<{ entity: EntityWithType; metrics: IterationMetrics }> {
   const t0 = Date.now();
   const m: IterationMetrics = {
     iter,
@@ -254,7 +420,7 @@ async function runIteration(
     duration_s: 0,
   };
 
-  const gaps = analyzePolicyGaps(entity);
+  const gaps = gapsFor(entity);
   m.gaps_identified = gaps.length;
   if (gaps.length === 0) {
     console.log(`[iter ${iter}] No gaps. Done.`);
@@ -287,9 +453,7 @@ async function runIteration(
   m.cost_research_usd = research.metadata.totalCost ?? 0;
   console.log(`[iter ${iter}] research: ${m.sources_found} sources, $${m.cost_research_usd.toFixed(4)}`);
 
-  // 2. Resolve resourceIds for each source by suggesting them again (idempotent).
-  //    runResearch already registered them in PG but doesn't expose the resourceId
-  //    on the SourceCacheEntry; suggestResourcesApi returns the canonical IDs.
+  // 2. Resolve resourceIds for each source.
   const sourceUrls = research.sources.map((s) => s.url);
   const resourceIdByUrl = new Map<string, string>();
   if (sourceUrls.length > 0) {
@@ -301,14 +465,13 @@ async function runIteration(
     }
   }
 
-  // 3. Extract claims from each source — content is already in SourceCacheEntry.content.
+  // 3. Extract claims from each source.
   const allClaims: Array<ExtractedClaim & { resourceId: string; sourceUrl: string }> = [];
   const contentByKey = new Map<string, string>();
   for (const src of research.sources) {
     const content = src.content ?? "";
     if (!content || content.length < 200) continue;
     const resourceId = resourceIdByUrl.get(src.url) ?? "";
-    // Key the pre-filter map by sourceUrl (always present), not resourceId.
     contentByKey.set(src.url, content);
     const ex = await extractGapClaims(entity, gaps, src.url, content);
     m.cost_extract_usd += ex.cost;
@@ -324,12 +487,10 @@ async function runIteration(
     return { entity, metrics: m };
   }
 
-  // 4. Pre-submission token filter — key by sourceUrl (not resourceId).
+  // 4. Pre-submission token filter — key by sourceUrl.
   const preFilterInput: PreFilterClaim[] = allClaims.map((c) => ({
     claimText: c.claimText,
     proposedValue: c.proposedValue,
-    // Stuff sourceUrl into the resourceId slot so preFilterBatch's content
-    // lookup hits our contentByKey map (which keys on URL).
     resourceId: c.sourceUrl,
     sourceUrl: c.sourceUrl,
     realResourceId: c.resourceId,
@@ -374,17 +535,22 @@ async function runIteration(
   m.claims_proposed = data.claims.length;
   console.log(`[iter ${iter}] submitted batch ${data.batchId} (${m.claims_proposed} claims)`);
 
-  // 6. Poll until settled (max ~30 minutes — when no local worker is running,
-  //    prod workers can be slow to claim a 20-claim batch).
+  // 6. Poll until settled.
   let settled = false;
   let rounds = 0;
   const MAX_POLL_ROUNDS = 60;
-  let lastVerdicts: Array<{ id: number; status: string; verdictReasoning: string | null; extractedValue: string | null; claimText: string }> = [];
+  let lastVerdicts: Array<{
+    id: number;
+    status: string;
+    verdictReasoning: string | null;
+    extractedValue: string | null;
+    claimText: string;
+  }> = [];
   while (!settled && rounds < MAX_POLL_ROUNDS) {
     await new Promise((r) => setTimeout(r, 30000));
     const sr = await getClaimStatus(data.batchId);
     if (!sr.ok) break;
-    const sd = sr.data as { allSettled: boolean; claims: typeof lastVerdicts };
+    const sd = sr.data as unknown as { allSettled: boolean; claims: typeof lastVerdicts };
     lastVerdicts = sd.claims;
     settled = sd.allSettled;
     rounds++;
@@ -394,10 +560,9 @@ async function runIteration(
     if (settled) break;
   }
 
-  // 6. Apply verified+partial to YAML.
+  // 7. Apply verified+partial to YAML.
   const verdictsByClaimId = new Map(lastVerdicts.map((v) => [v.id, v]));
   const submittedByOrder = filterResult.kept;
-  // Hono's propose endpoint returns inserted claims in the same order as submitted.
   const verifiedVerdicts: VerifiedVerdict[] = [];
   for (let i = 0; i < submittedByOrder.length; i++) {
     const insertedId = data.claims[i]?.id;
@@ -423,7 +588,7 @@ async function runIteration(
   }
   m.verified_rate = m.claims_proposed > 0 ? (m.claims_verified + m.claims_partial) / m.claims_proposed : 0;
 
-  const apply = applyVerdictsToPolicy(entity, verifiedVerdicts);
+  const apply = await applyVerdictsToEntity(entity, verifiedVerdicts);
   m.applied_to_yaml = apply.applied.filter((a) => a.action === "added" || a.action === "updated").length;
   console.log(`[iter ${iter}] applied ${m.applied_to_yaml} new facts to YAML`);
   if (apply.warnings.length > 0) {
@@ -441,17 +606,28 @@ async function runIteration(
 export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const slug = (args[0] || "").trim();
   if (!slug) {
-    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N]", exitCode: 1 };
+    return {
+      output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N]",
+      exitCode: 1,
+    };
   }
   const target = options.target != null ? parseInt(options.target as string, 10) : 12;
   const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 3;
   const budgetUsd = options.budget != null ? parseFloat(options.budget as string) : 2.0;
   const noWrite = !!options.dryRun;
 
-  const found = findPolicyEntity(slug);
-  if (!found) return { output: `Entity not found in responses.yaml: ${slug}`, exitCode: 1 };
-  if (found.entity.type !== "policy") {
-    return { output: `Only type=policy supported in v1; ${slug} is ${found.entity.type}`, exitCode: 1 };
+  const found = findEntity(slug);
+  if (!found) {
+    return {
+      output: `Entity not found in data/entities/*.yaml: ${slug}`,
+      exitCode: 1,
+    };
+  }
+  if (!SUPPORTED_TYPES.has(found.entity.type)) {
+    return {
+      output: `Unsupported entity type "${found.entity.type}" for ${slug}. Supported: ${[...SUPPORTED_TYPES].join(", ")}.`,
+      exitCode: 1,
+    };
   }
 
   let entity = found.entity;
@@ -470,25 +646,27 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
     entity = out.entity;
     iterations.push(out.metrics);
     budgetRemaining -= out.metrics.cost_research_usd + out.metrics.cost_extract_usd;
-    const cov = policyCoverageScore(entity);
-    console.log(`[iter ${i}] coverage=${cov.score}, facts=${JSON.stringify(cov.facts_in_yaml)}, budget=$${budgetRemaining.toFixed(2)}`);
+    const cov = coverageFor(entity);
+    console.log(
+      `[iter ${i}] coverage=${cov.score}, facts=${JSON.stringify(cov.facts_in_yaml)}, budget=$${budgetRemaining.toFixed(2)}`,
+    );
     if (out.metrics.applied_to_yaml === 0 && i > 1) {
       reason = "no-progress";
       break;
     }
-    const totalProvStake = (entity.provisions?.length ?? 0) + (entity.stakeholders?.length ?? 0);
-    if (totalProvStake >= target) {
+    if (progressMetric(entity) >= target) {
       reason = "target-hit";
       hitTarget = true;
       break;
     }
   }
 
-  if (!noWrite) saveEntity(slug, entity);
-  const finalCov = policyCoverageScore(entity);
+  if (!noWrite) saveEntity(found.filePath, slug, entity);
+  const finalCov = coverageFor(entity);
   const result: ImproveResult = {
     entity_slug: slug,
     entity_id: entity.stableId ?? entity.id,
+    entity_type: entity.type,
     iterations,
     final_coverage: finalCov.score,
     final_facts: finalCov.facts_in_yaml,
@@ -515,10 +693,12 @@ export function help(): CommandResult {
 Closed-loop iterative entity improver. Discovers sources via runResearch,
 extracts gap-targeted claims with Haiku, pre-filters by token presence,
 submits via the claims-first pipeline, and applies verified+partial verdicts
-to data/entities/responses.yaml.
+to the entity's source YAML file under data/entities/.
+
+Supported entity types: policy, organization.
 
 Options:
-  --target=N      Stop when (provisions + stakeholders) ≥ N (default: 12)
+  --target=N      Stop when (provisions+stakeholders for policy, products+keyPeople+keyDates for org) ≥ N (default: 12)
   --budget=N      Max LLM spend in USD (default: 2.0)
   --max-iters=N   Max iterations (default: 3)
   --dry-run       Don't write YAML

--- a/crux/lib/research/__tests__/apply-verdicts.test.ts
+++ b/crux/lib/research/__tests__/apply-verdicts.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyVerdictsToOrganization,
+  applyVerdictsToPolicy,
+  canonicalizePersonKey,
+  type VerifiedVerdict,
+} from "../apply-verdicts.ts";
+import type { OrganizationEntity, OrganizationKeyPersonObject, PolicyEntity } from "../gap-analyzer.ts";
+
+function v(over: Partial<VerifiedVerdict>): VerifiedVerdict {
+  return {
+    targetField: "scalar.description",
+    claimText: "Some claim text",
+    extractedValue: null,
+    proposedValue: null,
+    sourceUrl: "https://example.com",
+    status: "verified",
+    ...over,
+  };
+}
+
+// ─── canonicalizePersonKey ─────────────────────────────────────────────────
+
+describe("canonicalizePersonKey", () => {
+  it("strips degree suffixes", () => {
+    expect(canonicalizePersonKey("Sam Altman, PhD")).toBe("sam-altman");
+    expect(canonicalizePersonKey("Sam Altman PhD")).toBe("sam-altman");
+    expect(canonicalizePersonKey("John Smith Jr.")).toBe("john-smith");
+    expect(canonicalizePersonKey("Jane Doe Sr.")).toBe("jane-doe");
+    expect(canonicalizePersonKey("King George III")).toBe("king-george");
+  });
+
+  it("returns same key for slug and display variants", () => {
+    expect(canonicalizePersonKey("sam-altman")).toBe(canonicalizePersonKey("Sam Altman"));
+    expect(canonicalizePersonKey("Sam Altman, PhD")).toBe(canonicalizePersonKey("Sam Altman"));
+  });
+
+  it("handles empty input", () => {
+    expect(canonicalizePersonKey("")).toBe("");
+  });
+});
+
+// ─── applyVerdictsToPolicy (smoke) ─────────────────────────────────────────
+
+describe("applyVerdictsToPolicy", () => {
+  it("applies a verified scalar to an empty entity", () => {
+    const entity: PolicyEntity = { id: "x", type: "policy" };
+    const result = applyVerdictsToPolicy(entity, [
+      v({
+        targetField: "scalar.billNumber",
+        extractedValue: "S.1234",
+        status: "verified",
+      }),
+    ]);
+    expect(result.entity.billNumber).toBe("S.1234");
+    expect(result.applied[0]).toEqual({ targetField: "scalar.billNumber", action: "added" });
+  });
+
+  it("skips contradicted/unverifiable verdicts", () => {
+    const entity: PolicyEntity = { id: "x", type: "policy" };
+    const result = applyVerdictsToPolicy(entity, [
+      v({ targetField: "scalar.billNumber", status: "contradicted", extractedValue: "X" }),
+    ]);
+    expect(result.entity.billNumber).toBeUndefined();
+    expect(result.applied).toEqual([]);
+  });
+});
+
+// ─── applyVerdictsToOrganization ───────────────────────────────────────────
+
+describe("applyVerdictsToOrganization", () => {
+  it("applies scalar fields to an empty org", () => {
+    const entity: OrganizationEntity = { id: "anthropic", type: "organization", title: "Anthropic" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "scalar.website", extractedValue: "https://anthropic.com" }),
+      v({ targetField: "scalar.headquarters", extractedValue: "San Francisco, CA" }),
+      v({ targetField: "scalar.founded", extractedValue: "2021" }),
+    ]);
+    expect(result.entity.website).toBe("https://anthropic.com");
+    expect(result.entity.headquarters).toBe("San Francisco, CA");
+    expect(result.entity.founded).toBe("2021");
+    expect(result.applied.every((a) => a.action === "added")).toBe(true);
+  });
+
+  it("rejects unknown scalar fields", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "scalar.unknownField", extractedValue: "x" }),
+    ]);
+    expect(result.warnings).toContain("unknown scalar field: unknownField");
+    expect(result.applied[0].action).toBe("skipped");
+  });
+
+  it("skips already-filled scalar (no overwrite)", () => {
+    const entity: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      website: "https://existing.com",
+    };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "scalar.website", extractedValue: "https://new.com" }),
+    ]);
+    expect(result.entity.website).toBe("https://existing.com");
+    expect(result.applied[0]).toMatchObject({ action: "skipped", reason: "already filled" });
+  });
+
+  it("adds new product entries", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization", title: "X" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({
+        targetField: "product.claude-3-5-sonnet",
+        extractedValue: "Claude 3.5 Sonnet is a frontier model.",
+        displayHint: "Claude 3.5 Sonnet",
+        sourceUrl: "https://anthropic.com/news/claude-3-5",
+      }),
+    ]);
+    expect(result.entity.products).toHaveLength(1);
+    expect(result.entity.products![0]).toEqual({
+      name: "Claude 3.5 Sonnet",
+      description: "Claude 3.5 Sonnet is a frontier model.",
+      source: "https://anthropic.com/news/claude-3-5",
+    });
+  });
+
+  it("dedupes products by slugified name", () => {
+    const entity: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      products: [{ name: "Claude 3.5 Sonnet", description: "old short" }],
+    };
+    const result = applyVerdictsToOrganization(entity, [
+      v({
+        targetField: "product.claude-3-5-sonnet",
+        extractedValue: "A much longer and more detailed description.",
+        displayHint: "Claude 3.5 Sonnet",
+      }),
+    ]);
+    expect(result.entity.products).toHaveLength(1);
+    expect(result.entity.products![0].description).toBe("A much longer and more detailed description.");
+    expect(result.applied[0].action).toBe("updated");
+  });
+
+  it("skips product update when existing description is longer", () => {
+    const entity: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      products: [
+        { name: "p", description: "An existing long detailed description that is more comprehensive." },
+      ],
+    };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "product.p", extractedValue: "short" }),
+    ]);
+    expect(result.applied[0]).toMatchObject({ action: "skipped" });
+  });
+
+  it("adds keyPerson as an object with slug+name+source", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({
+        targetField: "keyPerson.dario-amodei",
+        displayHint: "Dario Amodei",
+        sourceUrl: "https://wired.com/anthropic-profile",
+      }),
+    ]);
+    expect(result.entity.keyPeople).toHaveLength(1);
+    const kp = result.entity.keyPeople![0] as OrganizationKeyPersonObject;
+    expect(kp.name).toBe("Dario Amodei");
+    expect(kp.source).toBe("https://wired.com/anthropic-profile");
+  });
+
+  it("dedupes keyPerson against existing bare-slug entries (canonicalization)", () => {
+    const entity: OrganizationEntity = {
+      id: "anthropic",
+      type: "organization",
+      keyPeople: ["dario-amodei", "daniela-amodei"],
+    };
+    const result = applyVerdictsToOrganization(entity, [
+      v({
+        targetField: "keyPerson.dario-amodei",
+        displayHint: "Dario Amodei, PhD", // canonicalizes to dario-amodei
+      }),
+    ]);
+    expect(result.entity.keyPeople).toHaveLength(2); // no new entry
+    // The bare string was upgraded to an object only if there's a new field to add — here
+    // there's no resolver and no source URL on this verdict, so it should remain a string.
+    // But our verdict has a sourceUrl by default from the helper. Let's check:
+    const e0 = result.entity.keyPeople![0];
+    if (typeof e0 === "string") {
+      // Stayed as string when no new info to add
+      expect(e0).toBe("dario-amodei");
+    } else {
+      // Upgraded to object with at least name or source
+      expect(e0.name ?? e0.slug).toMatch(/dario/i);
+    }
+  });
+
+  it("uses resolvePersonEntity to attach entityId on new keyPerson", () => {
+    const entity: OrganizationEntity = { id: "anthropic", type: "organization" };
+    const result = applyVerdictsToOrganization(
+      entity,
+      [
+        v({
+          targetField: "keyPerson.sam-altman",
+          displayHint: "Sam Altman",
+        }),
+      ],
+      {
+        resolvePersonEntity: (canon) => (canon === "sam-altman" ? "sam-altman" : null),
+      },
+    );
+    const kp = result.entity.keyPeople![0] as OrganizationKeyPersonObject;
+    expect(kp.entityId).toBe("sam-altman");
+  });
+
+  it("adds keyDate when extractedValue carries the date", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({
+        targetField: "keyDate.founded",
+        extractedValue: "January 2021",
+        displayHint: "Founded as Anthropic PBC",
+      }),
+    ]);
+    expect(result.entity.keyDates).toEqual([
+      {
+        date: "January 2021",
+        description: "Founded as Anthropic PBC",
+        source: "https://example.com",
+      },
+    ]);
+  });
+
+  it("skips keyDate when no date value present", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "keyDate.founded", extractedValue: null, proposedValue: null }),
+    ]);
+    expect(result.entity.keyDates ?? []).toHaveLength(0);
+    expect(result.applied[0]).toMatchObject({ action: "skipped", reason: "no date value" });
+  });
+
+  it("dedupes tags", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization", tags: ["ai-safety"] };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "tag.ai-safety", extractedValue: "duplicate" }),
+      v({ targetField: "tag.interpretability", extractedValue: "new" }),
+    ]);
+    expect(result.entity.tags).toEqual(["ai-safety", "interpretability"]);
+    expect(result.applied[0].action).toBe("skipped");
+    expect(result.applied[1].action).toBe("added");
+  });
+
+  it("adds relatedEntry once and dedupes by id", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "relatedEntry.openai" }),
+      v({ targetField: "relatedEntry.openai" }), // duplicate
+    ]);
+    expect(result.entity.relatedEntries).toHaveLength(1);
+    expect(result.entity.relatedEntries![0]).toEqual({ id: "openai", type: "organization" });
+    expect(result.applied[0].action).toBe("added");
+    expect(result.applied[1].action).toBe("skipped");
+  });
+
+  it("routes factbase.* to skipped (separate ticket) without warning", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "factbase.revenue", extractedValue: "$2B ARR" }),
+    ]);
+    expect(result.applied[0]).toMatchObject({
+      action: "skipped",
+      reason: expect.stringContaining("factbase"),
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("warns on unrecognized targetField", () => {
+    const entity: OrganizationEntity = { id: "x", type: "organization" };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "garbage.xyz" }),
+    ]);
+    expect(result.warnings).toContain("unrecognized targetField: garbage.xyz");
+    expect(result.applied[0].action).toBe("skipped");
+  });
+
+  it("does not corrupt existing fields when applying new ones", () => {
+    const entity: OrganizationEntity = {
+      id: "anthropic",
+      type: "organization",
+      description: "Existing description",
+      website: "https://anthropic.com",
+      tags: ["ai-safety", "constitutional-ai"],
+      keyPeople: ["dario-amodei"],
+      products: [{ name: "Claude", description: "AI assistant" }],
+    };
+    const result = applyVerdictsToOrganization(entity, [
+      v({ targetField: "scalar.founded", extractedValue: "2021" }),
+      v({ targetField: "tag.frontier-ai" }),
+      v({
+        targetField: "product.claude-3-5-sonnet",
+        extractedValue: "newer model",
+        displayHint: "Claude 3.5 Sonnet",
+      }),
+    ]);
+    expect(result.entity.description).toBe("Existing description");
+    expect(result.entity.website).toBe("https://anthropic.com");
+    expect(result.entity.tags).toEqual(["ai-safety", "constitutional-ai", "frontier-ai"]);
+    expect(result.entity.keyPeople).toEqual(["dario-amodei"]);
+    // Original product preserved + new product appended.
+    expect(result.entity.products).toHaveLength(2);
+    expect(result.entity.products![0].name).toBe("Claude");
+    expect(result.entity.products![1].name).toBe("Claude 3.5 Sonnet");
+  });
+
+  it("does not mutate input entity", () => {
+    const entity: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      tags: ["a"],
+      products: [{ name: "p" }],
+    };
+    const before = JSON.stringify(entity);
+    applyVerdictsToOrganization(entity, [
+      v({ targetField: "tag.b" }),
+      v({ targetField: "product.q", displayHint: "Q" }),
+    ]);
+    expect(JSON.stringify(entity)).toBe(before);
+  });
+});

--- a/crux/lib/research/__tests__/gap-analyzer.test.ts
+++ b/crux/lib/research/__tests__/gap-analyzer.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzePolicyGaps,
+  analyzeOrganizationGaps,
+  policyCoverageScore,
+  organizationCoverageScore,
+  type OrganizationEntity,
+  type PolicyEntity,
+} from "../gap-analyzer.ts";
+
+// ─── Policy ────────────────────────────────────────────────────────────────
+
+describe("analyzePolicyGaps", () => {
+  it("flags missing top-level scalars", () => {
+    const e: PolicyEntity = { id: "x", type: "policy", title: "X" };
+    const gaps = analyzePolicyGaps(e);
+    expect(gaps.find((g) => g.key === "scalar.description")).toBeDefined();
+    expect(gaps.find((g) => g.key === "scalar.billNumber")).toBeDefined();
+  });
+
+  it("orders by priority descending", () => {
+    const e: PolicyEntity = { id: "x", type: "policy", title: "X" };
+    const gaps = analyzePolicyGaps(e);
+    for (let i = 1; i < gaps.length; i++) {
+      expect(gaps[i - 1].priority).toBeGreaterThanOrEqual(gaps[i].priority);
+    }
+  });
+
+  it("computes coverage score in [0,1]", () => {
+    const empty: PolicyEntity = { id: "x", type: "policy" };
+    expect(policyCoverageScore(empty).score).toBe(0);
+    const filled: PolicyEntity = {
+      id: "x",
+      type: "policy",
+      description: "long description blob",
+      billNumber: "S.1234",
+      introduced: "2024-01-01",
+      policyStatus: "enacted",
+      author: "Senator X",
+      jurisdiction: "United States",
+      fullTextUrl: "https://example.com",
+      provisions: Array.from({ length: 6 }, (_, i) => ({ title: `prov ${i}` })),
+      stakeholders: Array.from({ length: 5 }, (_, i) => ({ name: `s${i}` })),
+      tags: ["a", "b", "c"],
+      relatedEntries: [
+        { id: "a", type: "policy" },
+        { id: "b", type: "policy" },
+        { id: "c", type: "policy" },
+      ],
+    };
+    expect(policyCoverageScore(filled).score).toBe(1);
+  });
+});
+
+// ─── Organization ──────────────────────────────────────────────────────────
+
+describe("analyzeOrganizationGaps", () => {
+  it("flags all missing top-level scalars on an empty org", () => {
+    const e: OrganizationEntity = { id: "anthropic", type: "organization", title: "Anthropic" };
+    const gaps = analyzeOrganizationGaps(e);
+    const keys = gaps.map((g) => g.key);
+    expect(keys).toContain("scalar.description");
+    expect(keys).toContain("scalar.website");
+    expect(keys).toContain("scalar.orgType");
+    expect(keys).toContain("scalar.founded");
+    expect(keys).toContain("scalar.headquarters");
+    expect(keys).toContain("scalar.employees");
+  });
+
+  it("flags products / keyPeople / keyDates gaps when below target", () => {
+    const e: OrganizationEntity = { id: "x", type: "organization", title: "X" };
+    const gaps = analyzeOrganizationGaps(e);
+    expect(gaps.find((g) => g.key === "products")).toBeDefined();
+    expect(gaps.find((g) => g.key === "keyPeople")).toBeDefined();
+    expect(gaps.find((g) => g.key === "keyDates")).toBeDefined();
+  });
+
+  it("does NOT flag products gap when target met", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      title: "X",
+      products: [
+        { name: "p1" },
+        { name: "p2" },
+        { name: "p3" },
+      ],
+    };
+    const gaps = analyzeOrganizationGaps(e);
+    expect(gaps.find((g) => g.key === "products")).toBeUndefined();
+  });
+
+  it("counts bare-string keyPeople entries toward the target", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      title: "X",
+      keyPeople: ["alice", "bob", "carol"],
+    };
+    const gaps = analyzeOrganizationGaps(e);
+    expect(gaps.find((g) => g.key === "keyPeople")).toBeUndefined();
+  });
+
+  it("includes existing keyPeople names in the gap description for dedup hint", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      title: "X",
+      keyPeople: ["alice"],
+    };
+    const gaps = analyzeOrganizationGaps(e);
+    const peopleGap = gaps.find((g) => g.key === "keyPeople");
+    expect(peopleGap).toBeDefined();
+    expect(peopleGap!.description).toContain("alice");
+  });
+
+  it("always emits factbase gaps for cross-base routing", () => {
+    const e: OrganizationEntity = { id: "x", type: "organization", title: "X" };
+    const gaps = analyzeOrganizationGaps(e);
+    expect(gaps.find((g) => g.key === "factbase.revenue")).toBeDefined();
+    expect(gaps.find((g) => g.key === "factbase.valuation")).toBeDefined();
+  });
+
+  it("orders gaps by priority descending", () => {
+    const e: OrganizationEntity = { id: "x", type: "organization", title: "X" };
+    const gaps = analyzeOrganizationGaps(e);
+    for (let i = 1; i < gaps.length; i++) {
+      expect(gaps[i - 1].priority).toBeGreaterThanOrEqual(gaps[i].priority);
+    }
+  });
+
+  it("flags scalar gap when value is too short (<4 chars)", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      title: "X",
+      description: "abc", // 3 chars — too short
+    };
+    const gaps = analyzeOrganizationGaps(e);
+    expect(gaps.find((g) => g.key === "scalar.description")).toBeDefined();
+  });
+});
+
+describe("organizationCoverageScore", () => {
+  it("returns 0 for empty entity (factbase weight 0.1 not earned)", () => {
+    const e: OrganizationEntity = { id: "x", type: "organization" };
+    expect(organizationCoverageScore(e).score).toBe(0);
+  });
+
+  it("score caps at 0.9 even when all local fields full (factbase out-of-scope)", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      description: "long enough description string",
+      website: "https://x.com",
+      orgType: "frontier-lab",
+      founded: "2021",
+      headquarters: "San Francisco, CA",
+      employees: "1000",
+      products: [{ name: "p1" }, { name: "p2" }, { name: "p3" }],
+      keyPeople: ["a", "b", "c"],
+      keyDates: [
+        { date: "2021", description: "founded" },
+        { date: "2022", description: "series A" },
+      ],
+    };
+    const cov = organizationCoverageScore(e);
+    // top_level=1*0.4 + products=1*0.2 + keyPeople=1*0.2 + keyDates=1*0.1 + factbase=0*0.1 = 0.9
+    expect(cov.score).toBe(0.9);
+    expect(cov.components.factbase).toBe(0);
+    expect(cov.facts_in_yaml.products).toBe(3);
+  });
+
+  it("partial fill produces partial score", () => {
+    const e: OrganizationEntity = {
+      id: "x",
+      type: "organization",
+      description: "a description",
+      website: "https://x.com",
+      orgType: "frontier-lab",
+      // founded, headquarters, employees missing → 3/6 = 0.5 top-level
+      keyPeople: ["a", "b", "c"], // full
+    };
+    const cov = organizationCoverageScore(e);
+    // 0.5*0.4 + 0*0.2 + 1*0.2 + 0*0.1 + 0 = 0.4
+    expect(cov.score).toBe(0.4);
+  });
+});

--- a/crux/lib/research/apply-verdicts.ts
+++ b/crux/lib/research/apply-verdicts.ts
@@ -1,11 +1,18 @@
-// Apply verified claims back into a policy entity's YAML record.
-// v1: handles `provision.<title-slug>`, `stakeholder.<name-slug>`,
-// scalar top-level fields, tag.<value>, and relatedEntry.<id>.
+// Apply verified claims back into an entity's YAML record.
+// Pure functions: take an entity + verdicts and return an updated entity plus
+// a writeback summary. The caller serializes back to YAML.
 //
-// Pure functions: takes a (PolicyEntity, verdicts[]) and returns an updated
-// PolicyEntity plus a writeback summary. The caller serializes back to YAML.
+// Supported types:
+//   - PolicyEntity  → applyVerdictsToPolicy
+//     scalar.<field>, provision.<slug>, stakeholder.<slug>, tag.<value>, relatedEntry.<id>
+//   - OrganizationEntity → applyVerdictsToOrganization
+//     scalar.<field>, product.<slug>, keyPerson.<slug>, keyDate.<slug>, tag.<value>, relatedEntry.<id>
+//
+// factbase.* targetFields are surfaced by the gap analyzer for cross-base
+// routing (separate ticket); the org applier records them as skipped
+// rather than writing them into local YAML.
 
-import type { PolicyEntity } from "./gap-analyzer.ts";
+import type { OrganizationEntity, OrganizationKeyPerson, PolicyEntity } from "./gap-analyzer.ts";
 
 export interface VerifiedVerdict {
   /** The seed key — encodes target type + identifier. */
@@ -24,15 +31,15 @@ export interface VerifiedVerdict {
   displayHint?: string;
 }
 
-export interface ApplyResult {
-  entity: PolicyEntity;
+export interface ApplyResult<T> {
+  entity: T;
   applied: Array<{ targetField: string; action: "added" | "updated" | "skipped"; reason?: string }>;
   warnings: string[];
 }
 
 const APPLIED_STATUSES = new Set(["verified", "partial"]);
 
-function slugify(s: string): string {
+export function slugify(s: string): string {
   return s
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -40,18 +47,32 @@ function slugify(s: string): string {
     .slice(0, 60);
 }
 
-function titleCase(slug: string): string {
+export function titleCase(slug: string): string {
   return slug
     .split("-")
     .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
     .join(" ");
 }
 
+/**
+ * Canonical comparison key for a person's display name. Strips suffixes
+ * (Jr., Sr., III, PhD, MD), lowercases, and slugifies. Used for keyPerson
+ * dedup so "Sam Altman" and "sam-altman" and "Sam Altman, PhD" canonicalize
+ * to the same key.
+ */
+export function canonicalizePersonKey(input: string): string {
+  if (!input) return "";
+  let s = input.trim();
+  // Strip trailing suffix tokens (degrees, generational suffixes).
+  s = s.replace(/[,\s]+(Jr\.?|Sr\.?|III|II|IV|PhD\.?|Ph\.?D\.?|MD\.?|M\.?D\.?)\b\.?$/i, "");
+  return slugify(s);
+}
+
 /** Apply a batch of verdicts to a PolicyEntity. Returns updated entity + change log. */
 export function applyVerdictsToPolicy(
   entity: PolicyEntity,
   verdicts: VerifiedVerdict[],
-): ApplyResult {
+): ApplyResult<PolicyEntity> {
   // Deep-clone the parts we mutate.
   const next: PolicyEntity = {
     ...entity,
@@ -60,7 +81,7 @@ export function applyVerdictsToPolicy(
     tags: entity.tags ? [...entity.tags] : [],
     relatedEntries: entity.relatedEntries ? entity.relatedEntries.map((r) => ({ ...r })) : [],
   };
-  const applied: ApplyResult["applied"] = [];
+  const applied: ApplyResult<PolicyEntity>["applied"] = [];
   const warnings: string[] = [];
 
   for (const v of verdicts) {
@@ -92,7 +113,7 @@ export function applyVerdictsToPolicy(
         continue;
       }
       // String fields only.
-      (next as Record<string, unknown>)[field as string] = value;
+      (next as unknown as Record<string, unknown>)[field as string] = value;
       applied.push({ targetField: tf, action: "added" });
       continue;
     }
@@ -180,6 +201,255 @@ export function applyVerdictsToPolicy(
       // Type unknown at this stage — caller should backfill, default to 'analysis'.
       next.relatedEntries.push({ id, type: "analysis" });
       applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    warnings.push(`unrecognized targetField: ${tf}`);
+    applied.push({ targetField: tf, action: "skipped", reason: "unrecognized targetField" });
+  }
+
+  return { entity: next, applied, warnings };
+}
+
+/** Existing keyPerson display name for dedup — handles both string and object form. */
+function keyPersonDisplay(p: OrganizationKeyPerson): string {
+  return typeof p === "string" ? p : p.name ?? p.slug ?? "";
+}
+
+/** Optional resolver for cross-referencing keyPerson names against existing
+ *  PG entities. The pure function does not perform IO; the caller may pass
+ *  a synchronous resolver derived from a pre-fetched search.
+ */
+export type PersonEntityResolver = (canonicalKey: string, displayName: string) => string | null;
+
+export interface ApplyOrganizationOptions {
+  /**
+   * Resolves a keyPerson to a wiki entityId (either slug like "sam-altman" or
+   * `sid_*`). Called once per added keyPerson to enable cross-ref. Return null
+   * if no match. The applier stores the result on the keyPerson object's
+   * `entityId` field when matched.
+   */
+  resolvePersonEntity?: PersonEntityResolver;
+}
+
+/** Apply a batch of verdicts to an OrganizationEntity. */
+export function applyVerdictsToOrganization(
+  entity: OrganizationEntity,
+  verdicts: VerifiedVerdict[],
+  options: ApplyOrganizationOptions = {},
+): ApplyResult<OrganizationEntity> {
+  const next: OrganizationEntity = {
+    ...entity,
+    products: entity.products ? entity.products.map((p) => ({ ...p })) : [],
+    keyPeople: entity.keyPeople ? entity.keyPeople.map((p) => (typeof p === "string" ? p : { ...p })) : [],
+    keyDates: entity.keyDates ? entity.keyDates.map((d) => ({ ...d })) : [],
+    tags: entity.tags ? [...entity.tags] : [],
+    relatedEntries: entity.relatedEntries ? entity.relatedEntries.map((r) => ({ ...r })) : [],
+  };
+  const applied: ApplyResult<OrganizationEntity>["applied"] = [];
+  const warnings: string[] = [];
+
+  const ALLOWED_SCALARS = new Set([
+    "description",
+    "website",
+    "orgType",
+    "founded",
+    "headquarters",
+    "employees",
+    "funding",
+    "parentOrg",
+    "orgStatus",
+    "safetyFocus",
+  ]);
+
+  for (const v of verdicts) {
+    if (!APPLIED_STATUSES.has(v.status)) continue;
+
+    const tf = v.targetField;
+    const value = (v.extractedValue?.trim() || v.proposedValue?.trim() || v.claimText).trim();
+
+    // ── scalar.<field> ──────────────────────────────────────────────────
+    if (tf.startsWith("scalar.")) {
+      const field = tf.slice("scalar.".length);
+      if (!ALLOWED_SCALARS.has(field)) {
+        warnings.push(`unknown scalar field: ${field}`);
+        applied.push({ targetField: tf, action: "skipped", reason: "unknown field" });
+        continue;
+      }
+      if ((next as unknown as Record<string, unknown>)[field]) {
+        applied.push({ targetField: tf, action: "skipped", reason: "already filled" });
+        continue;
+      }
+      (next as unknown as Record<string, unknown>)[field] = value;
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── product.<slug> ──────────────────────────────────────────────────
+    if (tf.startsWith("product.")) {
+      const slug = tf.slice("product.".length);
+      const name = v.displayHint ?? titleCase(slug);
+      next.products ??= [];
+      const nameSlug = slugify(name);
+      const existing = next.products.find(
+        (p) => slugify(p.name) === slug || slugify(p.name) === nameSlug,
+      );
+      if (existing) {
+        if (!existing.description || existing.description.length < value.length) {
+          existing.description = value;
+          if (!existing.source) existing.source = v.sourceUrl;
+          applied.push({ targetField: tf, action: "updated" });
+        } else {
+          applied.push({ targetField: tf, action: "skipped", reason: "existing description longer" });
+        }
+        continue;
+      }
+      next.products.push({ name, description: value, source: v.sourceUrl });
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── keyPerson.<slug> ────────────────────────────────────────────────
+    if (tf.startsWith("keyPerson.")) {
+      const slug = tf.slice("keyPerson.".length);
+      const name = v.displayHint ?? titleCase(slug);
+      next.keyPeople ??= [];
+      // Canonical key handles "Sam Altman" vs "sam-altman" vs "Sam Altman, PhD".
+      const canon = canonicalizePersonKey(name);
+      const slugCanon = canonicalizePersonKey(slug);
+      const matchKey = (display: string) =>
+        canonicalizePersonKey(display) === canon || canonicalizePersonKey(display) === slugCanon;
+
+      const existingIdx = next.keyPeople.findIndex((p) => matchKey(keyPersonDisplay(p)));
+      if (existingIdx !== -1) {
+        const existing = next.keyPeople[existingIdx];
+        // If existing is a bare string and we now have a richer object, upgrade it.
+        if (typeof existing === "string") {
+          const obj: import("./gap-analyzer.ts").OrganizationKeyPersonObject = { slug: existing, name };
+          // Resolver gets first crack at attaching entityId.
+          if (options.resolvePersonEntity) {
+            const eid = options.resolvePersonEntity(canon, name);
+            if (eid) obj.entityId = eid;
+          }
+          if (v.sourceUrl) obj.source = v.sourceUrl;
+          // If the existing string is already a clean slug, keep it as a string when no resolver fires.
+          if (!obj.entityId && !obj.source) {
+            applied.push({ targetField: tf, action: "skipped", reason: "duplicate keyPerson" });
+            continue;
+          }
+          next.keyPeople[existingIdx] = obj;
+          applied.push({ targetField: tf, action: "updated" });
+          continue;
+        }
+        // Existing object — only update if we add new info.
+        let updated = false;
+        if (!existing.name) {
+          existing.name = name;
+          updated = true;
+        }
+        if (!existing.entityId && options.resolvePersonEntity) {
+          const eid = options.resolvePersonEntity(canon, name);
+          if (eid) {
+            existing.entityId = eid;
+            updated = true;
+          }
+        }
+        if (!existing.source && v.sourceUrl) {
+          existing.source = v.sourceUrl;
+          updated = true;
+        }
+        applied.push({
+          targetField: tf,
+          action: updated ? "updated" : "skipped",
+          reason: updated ? undefined : "duplicate keyPerson",
+        });
+        continue;
+      }
+      // New keyPerson: prefer object form so we can carry entityId + source.
+      const obj: import("./gap-analyzer.ts").OrganizationKeyPersonObject = {
+        slug: slugify(name),
+        name,
+      };
+      if (options.resolvePersonEntity) {
+        const eid = options.resolvePersonEntity(canon, name);
+        if (eid) obj.entityId = eid;
+      }
+      if (v.sourceUrl) obj.source = v.sourceUrl;
+      next.keyPeople.push(obj);
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── keyDate.<slug> ──────────────────────────────────────────────────
+    if (tf.startsWith("keyDate.")) {
+      const slug = tf.slice("keyDate.".length);
+      // displayHint is the human description; extractedValue/claimText carries the date.
+      const description = v.displayHint ?? titleCase(slug);
+      const date = (v.extractedValue?.trim() || v.proposedValue?.trim() || "").trim();
+      next.keyDates ??= [];
+      const existing = next.keyDates.find((d) => slugify(d.description) === slug);
+      if (existing) {
+        let updated = false;
+        if (!existing.date && date) {
+          existing.date = date;
+          updated = true;
+        }
+        if (!existing.source && v.sourceUrl) {
+          existing.source = v.sourceUrl;
+          updated = true;
+        }
+        applied.push({
+          targetField: tf,
+          action: updated ? "updated" : "skipped",
+          reason: updated ? undefined : "duplicate keyDate",
+        });
+        continue;
+      }
+      if (!date) {
+        applied.push({ targetField: tf, action: "skipped", reason: "no date value" });
+        continue;
+      }
+      next.keyDates.push({ date, description, source: v.sourceUrl });
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── tag.<value> ─────────────────────────────────────────────────────
+    if (tf.startsWith("tag.")) {
+      const tag = slugify(tf.slice("tag.".length));
+      next.tags ??= [];
+      if (next.tags.includes(tag)) {
+        applied.push({ targetField: tf, action: "skipped", reason: "duplicate tag" });
+        continue;
+      }
+      next.tags.push(tag);
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── relatedEntry.<entityId> ─────────────────────────────────────────
+    if (tf.startsWith("relatedEntry.")) {
+      const id = tf.slice("relatedEntry.".length);
+      next.relatedEntries ??= [];
+      if (next.relatedEntries.find((r) => r.id === id)) {
+        applied.push({ targetField: tf, action: "skipped", reason: "duplicate relatedEntry" });
+        continue;
+      }
+      next.relatedEntries.push({ id, type: "organization" });
+      applied.push({ targetField: tf, action: "added" });
+      continue;
+    }
+
+    // ── factbase.<field> ────────────────────────────────────────────────
+    // Cross-base routing happens in a separate pipeline. Skip with a clear
+    // reason rather than warning, so the verdict isn't lost — downstream
+    // FactBase tooling can pick these up.
+    if (tf.startsWith("factbase.")) {
+      applied.push({
+        targetField: tf,
+        action: "skipped",
+        reason: "factbase routing (out of scope for org loop)",
+      });
       continue;
     }
 

--- a/crux/lib/research/gap-analyzer.ts
+++ b/crux/lib/research/gap-analyzer.ts
@@ -1,6 +1,6 @@
 // Gap analyzer — given an entity's current YAML state, produce a list of
 // "missing fact slots" that the next research iteration should try to fill.
-// v1: only handles type=policy.
+// Supported types: policy, organization.
 // Returns gaps in priority order (highest-leverage gaps first).
 
 export interface PolicyEntity {
@@ -30,13 +30,72 @@ export interface PolicyEntity {
   tags?: string[];
 }
 
+export interface OrganizationProduct {
+  name: string;
+  description?: string;
+  source?: string;
+}
+
+export interface OrganizationKeyDate {
+  date: string;
+  description: string;
+  source?: string;
+}
+
+export interface OrganizationKeyPersonObject {
+  slug?: string;
+  name?: string;
+  role?: string;
+  entityId?: string;
+  source?: string;
+}
+
+/**
+ * keyPeople in YAML is a flexible array: most existing entries are bare slug
+ * strings (e.g. ["dario-amodei", "daniela-amodei"]), but the gap analyzer
+ * may add richer object entries with role/source.
+ */
+export type OrganizationKeyPerson = string | OrganizationKeyPersonObject;
+
+export interface OrganizationEntity {
+  id: string;
+  stableId?: string;
+  wikiId?: string;
+  type: string;
+  title?: string;
+  description?: string;
+  website?: string;
+  orgType?: string;
+  founded?: string;
+  headquarters?: string;
+  employees?: string;
+  funding?: string;
+  parentOrg?: string;
+  orgStatus?: string;
+  safetyFocus?: string;
+  products?: OrganizationProduct[];
+  keyPeople?: OrganizationKeyPerson[];
+  keyDates?: OrganizationKeyDate[];
+  relatedEntries?: Array<{ id: string; type: string; relationship?: string }>;
+  tags?: string[];
+}
+
 export interface Gap {
   /** A short slug for this gap, used in research topics and claim targetField. */
   key: string;
   /** Human-readable description for the LLM extractor. */
   description: string;
   /** What field this gap fills (top-level or array). */
-  target: "scalar" | "provision" | "stakeholder" | "relatedEntry" | "tag";
+  target:
+    | "scalar"
+    | "provision"
+    | "stakeholder"
+    | "relatedEntry"
+    | "tag"
+    | "product"
+    | "keyPerson"
+    | "keyDate"
+    | "factbase";
   /** Priority — higher = filled first. */
   priority: number;
   /** Free-form research topic to feed to runResearch. */
@@ -50,6 +109,14 @@ export interface PolicyTargets {
   minRelatedEntries: number;
 }
 
+export interface OrganizationTargets {
+  minProducts: number;
+  minKeyPeople: number;
+  minKeyDates: number;
+  minTags: number;
+  minRelatedEntries: number;
+}
+
 const DEFAULT_POLICY_TARGETS: PolicyTargets = {
   minProvisions: 6,
   minStakeholders: 5,
@@ -57,7 +124,15 @@ const DEFAULT_POLICY_TARGETS: PolicyTargets = {
   minRelatedEntries: 3,
 };
 
-const TOP_LEVEL_FIELDS: Array<{ key: keyof PolicyEntity; topic: string; priority: number }> = [
+const DEFAULT_ORG_TARGETS: OrganizationTargets = {
+  minProducts: 3,
+  minKeyPeople: 3,
+  minKeyDates: 2,
+  minTags: 3,
+  minRelatedEntries: 3,
+};
+
+const POLICY_TOP_LEVEL_FIELDS: Array<{ key: keyof PolicyEntity; topic: string; priority: number }> = [
   { key: "description", topic: "description and overview", priority: 100 },
   { key: "billNumber", topic: "bill number and statutory citation", priority: 90 },
   { key: "introduced", topic: "introduction or enactment date", priority: 85 },
@@ -65,6 +140,15 @@ const TOP_LEVEL_FIELDS: Array<{ key: keyof PolicyEntity; topic: string; priority
   { key: "author", topic: "primary author or sponsor", priority: 70 },
   { key: "jurisdiction", topic: "jurisdiction and scope", priority: 70 },
   { key: "fullTextUrl", topic: "full statutory text URL", priority: 60 },
+];
+
+const ORG_TOP_LEVEL_FIELDS: Array<{ key: keyof OrganizationEntity; topic: string; priority: number }> = [
+  { key: "description", topic: "description and mission", priority: 100 },
+  { key: "website", topic: "official website URL", priority: 95 },
+  { key: "orgType", topic: "organization type (frontier-lab, safety-org, academic, government, funder, startup, generic, other)", priority: 90 },
+  { key: "founded", topic: "year founded", priority: 85 },
+  { key: "headquarters", topic: "headquarters location", priority: 80 },
+  { key: "employees", topic: "approximate employee count", priority: 70 },
 ];
 
 /** Compute gaps for a policy entity. */
@@ -76,7 +160,7 @@ export function analyzePolicyGaps(
   const title = entity.title ?? entity.id;
 
   // Top-level scalars — only flag if missing.
-  for (const f of TOP_LEVEL_FIELDS) {
+  for (const f of POLICY_TOP_LEVEL_FIELDS) {
     if (!entity[f.key] || (typeof entity[f.key] === "string" && (entity[f.key] as string).length < 4)) {
       gaps.push({
         key: `scalar.${String(f.key)}`,
@@ -148,6 +232,127 @@ export function analyzePolicyGaps(
   return gaps.sort((a, b) => b.priority - a.priority);
 }
 
+/** Compute gaps for an organization entity. */
+export function analyzeOrganizationGaps(
+  entity: OrganizationEntity,
+  targets: OrganizationTargets = DEFAULT_ORG_TARGETS,
+): Gap[] {
+  const gaps: Gap[] = [];
+  const title = entity.title ?? entity.id;
+
+  // Top-level scalars — only flag if missing/too-short.
+  for (const f of ORG_TOP_LEVEL_FIELDS) {
+    const v = entity[f.key];
+    const missing = !v || (typeof v === "string" && v.length < 4);
+    if (missing) {
+      gaps.push({
+        key: `scalar.${String(f.key)}`,
+        description: `Provide the ${f.topic} for ${title}.`,
+        target: "scalar",
+        priority: f.priority,
+        researchTopic: `${title} ${f.topic}`,
+      });
+    }
+  }
+
+  // Products — fill up to target.
+  const productCount = entity.products?.length ?? 0;
+  const productGap = Math.max(0, targets.minProducts - productCount);
+  if (productGap > 0) {
+    const existing = (entity.products ?? []).map((p) => p.name).join(", ");
+    gaps.push({
+      key: "products",
+      description: existing
+        ? `Identify ${productGap} additional products, models, or tools released by ${title} not already in: [${existing}].`
+        : `Identify ${productGap} key products, models, or tools released by ${title}.`,
+      target: "product",
+      priority: 88,
+      researchTopic: `${title} products models tools released`,
+    });
+  }
+
+  // Key people — fill up to target. Existing entries may be bare slugs or objects.
+  const peopleCount = entity.keyPeople?.length ?? 0;
+  const peopleGap = Math.max(0, targets.minKeyPeople - peopleCount);
+  if (peopleGap > 0) {
+    const existing = (entity.keyPeople ?? [])
+      .map((p) => (typeof p === "string" ? p : p.name ?? p.slug ?? ""))
+      .filter((s) => s.length > 0)
+      .join(", ");
+    gaps.push({
+      key: "keyPeople",
+      description: existing
+        ? `Identify ${peopleGap} additional founders, executives, or notable researchers at ${title} not already in: [${existing}].`
+        : `Identify ${peopleGap} founders, executives, or notable researchers at ${title}.`,
+      target: "keyPerson",
+      priority: 90,
+      researchTopic: `${title} founders CEO executives notable researchers`,
+    });
+  }
+
+  // Key dates — fill up to target.
+  const datesCount = entity.keyDates?.length ?? 0;
+  const datesGap = Math.max(0, targets.minKeyDates - datesCount);
+  if (datesGap > 0) {
+    const existing = (entity.keyDates ?? []).map((d) => `${d.date}: ${d.description}`).join("; ");
+    gaps.push({
+      key: "keyDates",
+      description: existing
+        ? `Identify ${datesGap} additional milestone dates for ${title} not already in: [${existing}].`
+        : `Identify ${datesGap} milestone dates (founding, major launches, funding rounds, leadership changes) for ${title}.`,
+      target: "keyDate",
+      priority: 75,
+      researchTopic: `${title} history milestones founding major events`,
+    });
+  }
+
+  // Tags — light-touch.
+  const tagCount = entity.tags?.length ?? 0;
+  if (tagCount < targets.minTags) {
+    gaps.push({
+      key: "tags",
+      description: `Suggest ${targets.minTags - tagCount} additional topical tags for ${title}.`,
+      target: "tag",
+      priority: 30,
+      researchTopic: `${title} research focus topic categories`,
+    });
+  }
+
+  // Related entries — light-touch.
+  const relCount = entity.relatedEntries?.length ?? 0;
+  if (relCount < targets.minRelatedEntries) {
+    gaps.push({
+      key: "relatedEntries",
+      description: `Identify ${targets.minRelatedEntries - relCount} related organizations, key partners, or competitors.`,
+      target: "relatedEntry",
+      priority: 40,
+      researchTopic: `${title} partner organizations competitors collaborators`,
+    });
+  }
+
+  // Cross-base FactBase facts — flag for follow-up routing (separate ticket).
+  // We surface these as gaps so that downstream pipelines (FactBase fact
+  // extraction, separate ticket) can pick them up. The applier will skip
+  // factbase.* targetFields gracefully — they're not written into the local
+  // YAML.
+  gaps.push({
+    key: "factbase.revenue",
+    description: `Find recent revenue or annual recurring revenue figure for ${title} (will be routed to FactBase).`,
+    target: "factbase",
+    priority: 20,
+    researchTopic: `${title} revenue annual recurring revenue financials`,
+  });
+  gaps.push({
+    key: "factbase.valuation",
+    description: `Find most recent valuation or post-money valuation for ${title} (will be routed to FactBase).`,
+    target: "factbase",
+    priority: 20,
+    researchTopic: `${title} valuation funding round post-money`,
+  });
+
+  return gaps.sort((a, b) => b.priority - a.priority);
+}
+
 export interface CoverageScore {
   score: number;       // 0 to 1
   components: Record<string, number>;
@@ -163,11 +368,11 @@ export function policyCoverageScore(
 
   // Top-level fields
   let topLevelFilled = 0;
-  for (const f of TOP_LEVEL_FIELDS) {
+  for (const f of POLICY_TOP_LEVEL_FIELDS) {
     const v = entity[f.key];
     if (v && (typeof v !== "string" || v.length >= 4)) topLevelFilled++;
   }
-  components.top_level = topLevelFilled / TOP_LEVEL_FIELDS.length;
+  components.top_level = topLevelFilled / POLICY_TOP_LEVEL_FIELDS.length;
 
   components.provisions = Math.min(1, (entity.provisions?.length ?? 0) / targets.minProvisions);
   components.stakeholders = Math.min(1, (entity.stakeholders?.length ?? 0) / targets.minStakeholders);
@@ -190,6 +395,49 @@ export function policyCoverageScore(
     facts_in_yaml: {
       provisions: entity.provisions?.length ?? 0,
       stakeholders: entity.stakeholders?.length ?? 0,
+      tags: entity.tags?.length ?? 0,
+      relatedEntries: entity.relatedEntries?.length ?? 0,
+      top_level_filled: topLevelFilled,
+    },
+  };
+}
+
+/** Coverage score for an organization. Weights per QUA-876:
+ *  top-level 0.4, products 0.2, keyPeople 0.2, keyDates 0.1, factbase 0.1.
+ *  factbase coverage is currently 0 (out-of-scope for this loop) but is
+ *  tracked so the score is comparable across pipeline upgrades.
+ */
+export function organizationCoverageScore(
+  entity: OrganizationEntity,
+  targets: OrganizationTargets = DEFAULT_ORG_TARGETS,
+): CoverageScore {
+  const components: Record<string, number> = {};
+
+  let topLevelFilled = 0;
+  for (const f of ORG_TOP_LEVEL_FIELDS) {
+    const v = entity[f.key];
+    if (v && (typeof v !== "string" || v.length >= 4)) topLevelFilled++;
+  }
+  components.top_level = topLevelFilled / ORG_TOP_LEVEL_FIELDS.length;
+  components.products = Math.min(1, (entity.products?.length ?? 0) / targets.minProducts);
+  components.keyPeople = Math.min(1, (entity.keyPeople?.length ?? 0) / targets.minKeyPeople);
+  components.keyDates = Math.min(1, (entity.keyDates?.length ?? 0) / targets.minKeyDates);
+  // FactBase routing is out-of-scope in this loop — placeholder until separate ticket.
+  components.factbase = 0;
+
+  const weights = { top_level: 0.4, products: 0.2, keyPeople: 0.2, keyDates: 0.1, factbase: 0.1 };
+  let score = 0;
+  for (const [k, w] of Object.entries(weights)) {
+    score += (components[k] ?? 0) * w;
+  }
+
+  return {
+    score: Math.round(score * 100) / 100,
+    components,
+    facts_in_yaml: {
+      products: entity.products?.length ?? 0,
+      keyPeople: entity.keyPeople?.length ?? 0,
+      keyDates: entity.keyDates?.length ?? 0,
       tags: entity.tags?.length ?? 0,
       relatedEntries: entity.relatedEntries?.length ?? 0,
       top_level_filled: topLevelFilled,


### PR DESCRIPTION
## Summary

Extends the closed-loop entity improver (PR #4711) to support `type: organization`. The v1 loop was policy-only — calling `crux tb improve-entity anthropic` exited with `Only type=policy supported in v1`. Organizations are the largest entity bucket (44 entries in `data/entities/organizations.yaml`), so most pipeline-quality wins were wasted until the loop could run on them.

> ⚠️ **Stacked on top of PR #4711.** This PR's diff includes #4711's changes until #4711 merges, after which GitHub will auto-narrow the diff to just this work. Both PRs share the `crux/lib/research/{gap-analyzer,apply-verdicts}.ts` files. **Merge order: #4711 first, then this PR.**

Fixes QUA-876.

## What's new

### `analyzeOrganizationGaps(entity)` — `crux/lib/research/gap-analyzer.ts`

- Top-level scalars: `description`, `website`, `orgType`, `founded`, `headquarters`, `employees` (priority 100→70).
- Arrays: `products[]` (target ≥3), `keyPeople[]` (target ≥3), `keyDates[]` (target ≥2).
- Light-touch: `tags`, `relatedEntries`.
- Cross-base placeholders: `factbase.revenue`, `factbase.valuation` surfaced for separate FactBase routing (out-of-scope for this loop; the applier records them as `skipped` rather than warned).

### `organizationCoverageScore(entity)` — same file

Weights per the ticket: `top_level=0.4`, `products=0.2`, `keyPeople=0.2`, `keyDates=0.1`, `factbase=0.1`. The `factbase` component is currently 0 (out-of-scope), so a fully-filled local org caps at 0.9 — leaving headroom for the FactBase ticket to lift it to 1.0 once revenue/valuation routing lands.

### `applyVerdictsToOrganization(entity, verdicts, opts?)` — `crux/lib/research/apply-verdicts.ts`

- `scalar.<field>` → top-level scalar (whitelist of 10 fields including `safetyFocus`, `parentOrg`, `orgStatus`).
- `product.<slug>` → upsert `products[]` (dedup by slugified name, prefers longer description).
- `keyPerson.<slug>` → upsert `keyPeople[]`. New entries are objects (`{slug, name, entityId?, source?}`) so we can carry cross-ref + source URL. Dedup canonicalizes both bare-string and object existing entries via `canonicalizePersonKey()`, which strips degree (PhD, MD) and generational (Jr, Sr, II/III/IV) suffixes.
- `keyDate.<slug>` → upsert `keyDates[]`; uses `extractedValue`/`proposedValue` for the date and `displayHint` for the description; skips when no date value present.
- `tag.<value>` → dedup by slug.
- `relatedEntry.<id>` → dedup by id.
- `factbase.*` → recorded as `skipped` (separate ticket).
- Optional `resolvePersonEntity(canonKey, displayName)` callback attaches `entityId` when the wiki-server has a matching person entity.

### Dispatch + multi-file YAML splice — `crux/commands/research-improve-entity.ts`

- `gapsFor(entity)` / `coverageFor(entity)` / `applyVerdictsToEntity(entity, verdicts)` dispatch by `entity.type`. Refuses unsupported types with a clear error.
- LLM extraction prompt is conditioned on `entity.type` so the targetField guide matches the type's schema.
- YAML splice now scans `data/entities/*.yaml` to locate the entity's source file (was: hardcoded to `data/entities/responses.yaml`). Surgical block-replacement preserves byte-identical surroundings.
- For org loops, the applier pre-fetches a single `searchEntities` call per unique keyPerson candidate name, then synchronously matches by canonicalized key inside the pure applier — avoids N+1 fetches.

### Tests

`crux/lib/research/__tests__/{gap-analyzer,apply-verdicts}.test.ts` — 36 cases:

- Gap detection: scalars, products/keyPeople/keyDates targets, bare-string keyPerson counting, factbase surfacing, priority ordering, short-string scalar (<4 char) flagging.
- Coverage: empty=0, fully-filled-local=0.9 (factbase weight not earned), partial fill produces partial score.
- Apply paths: scalar added/skipped, unknown field rejected, product upsert (added/updated/skipped-when-existing-longer), keyPerson dedup against bare-slug existing, resolver attaches entityId, keyDate added/skipped-no-date, tag dedup, relatedEntry dedup, factbase routed-to-skipped without warning, unrecognized targetField warned, input immutability invariant, no-corruption-of-existing-fields.
- Helper: `canonicalizePersonKey` strips degree/generational suffixes, returns same key for slug/display variants.

## Acceptance

- [x] `analyzeOrganizationGaps`, `organizationCoverageScore`, `applyVerdictsToOrganization` implemented per ticket spec.
- [x] `improve-entity.ts` dispatches by type and refuses unsupported types.
- [x] YAML splice picks the right file based on entity location.
- [x] Tests cover org-shaped writes (added/updated/skipped, dedup, immutability).
- [x] All 64 gate checks pass; 8527 vitest tests green.
- [ ] **End-to-end on `anthropic`**: requires API access (Anthropic + Exa + Perplexity); library + dispatch logic verified by tests. The full `pnpm crux tb improve-entity anthropic --target=10 --max-iters=1` run will exercise the live path once a maintainer with billing access can run it.

## Known v1 issues / follow-ups

- FactBase routing for `factbase.revenue` / `factbase.valuation` (skipped here — separate ticket per the QUA-876 description).
- Person, ai-model, approach, project, benchmark, event types — separate tickets (depend on this PR's cross-ref scaffolding).
- Existing PR #4711 stakeholder dedup limitation (different `targetField` slugs mapping to same display name) is mitigated for `keyPerson` here via `canonicalizePersonKey`.

## Test plan

- [x] `pnpm test crux/lib/research` — 36/36 passing
- [x] `pnpm test` — 8527 passing (26 pre-existing skipped)
- [x] `pnpm crux w validate gate --fix` — all 64 checks pass; 2 pre-existing advisory warnings (crux typecheck baseline + orphan entities) unchanged
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Research improve-entity command now supports organization entities in addition to policies
  * Extended gap analysis to identify missing and underfilled organization-specific fields (products, key people, key dates)
  * Enhanced verdict application with improved person key canonicalization and entity resolution

* **Tests**
  * Added comprehensive test suite for verdict application across both entity types
  * Added gap analysis and coverage scoring tests for organization entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->