### PR TITLE
feat(profile-tabs): add opt-in path-routing mode (QUA-877)

### DIFF
--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -38,6 +38,18 @@ export interface ProfileTabGroup {
   label: string;
 }
 
+/**
+ * URL-routing mode for the active tab.
+ * - `"query"` (default): active tab read from `?tab=<id>`; clicks call
+ *   `router.replace` to update the query.
+ * - `"path"`: active tab read from the path segment after `basePath`; tab
+ *   triggers render as `<Link>` so navigation is SSR-friendly and the URL
+ *   is shareable as `${basePath}/${tabId}` (the default tab is `${basePath}`).
+ */
+export type TabRouting =
+  | { mode: "query" }
+  | { mode: "path"; basePath: string };
+
 export interface ProfileTabsProps {
   tabs: ProfileTab[];
   /** Accessible label for the tab list, e.g. "Organization sections" */
@@ -50,6 +62,8 @@ export interface ProfileTabsProps {
   layout?: "horizontal" | "vertical";
   /** Ordered groups (vertical layout only). */
   groups?: ProfileTabGroup[];
+  /** URL routing mode. Defaults to `{ mode: "query" }` (existing behavior). */
+  tabRouting?: TabRouting;
 }
 
 // ─── Shared helpers ─────────────────────────────────────────────────────
@@ -155,21 +169,107 @@ function bucketByGroup(
   return result;
 }
 
+// ─── Path-mode helpers ─────────────────────────────────────────────────
+
+// Strip a single trailing slash so `${basePath}/${id}` doesn't double-slash
+// when callers pass `basePath="/organizations/anthropic/"`. Empty string and
+// bare `/` are not valid mount points — see invariant in `ProfileTabsPathMode`.
+function normalizeBasePath(basePath: string): string {
+  return basePath.endsWith("/") && basePath.length > 1
+    ? basePath.slice(0, -1)
+    : basePath;
+}
+
+// URL the trigger Link should navigate to. The default tab lives at the bare
+// basePath (no segment); other tabs get `${basePath}/${id}`. Tabs with an
+// explicit `href` keep their own destination — those are link-tabs (e.g. wiki
+// pages) and override path-mode routing.
+function tabHrefFor(tab: ProfileTab, basePath: string, defaultTabId: string): string {
+  if (tab.href) return tab.href;
+  const base = normalizeBasePath(basePath);
+  return tab.id === defaultTabId ? base : `${base}/${tab.id}`;
+}
+
+// Pick the active tab + flag any unknown segment so we can surface a notice.
+function pickActiveTabFromPath(
+  pathname: string,
+  basePath: string,
+  tabs: ProfileTab[],
+  defaultTabId: string,
+): { activeTab: string; unknownRequested: string | null } {
+  const base = normalizeBasePath(basePath);
+  // Bare basePath (or basePath + trailing slash) → default tab.
+  if (pathname === base || pathname === `${base}/`) {
+    return { activeTab: defaultTabId, unknownRequested: null };
+  }
+  if (pathname.startsWith(`${base}/`)) {
+    const remainder = pathname.slice(base.length + 1);
+    const segment = remainder.split("/")[0] ?? "";
+    if (segment === "") {
+      return { activeTab: defaultTabId, unknownRequested: null };
+    }
+    const selectableIds = new Set(tabs.filter((t) => !t.href).map((t) => t.id));
+    if (selectableIds.has(segment)) {
+      return { activeTab: segment, unknownRequested: null };
+    }
+    return { activeTab: defaultTabId, unknownRequested: segment };
+  }
+  // pathname doesn't share the basePath prefix at all (shouldn't happen in
+  // practice, but be tolerant — fall back to default rather than blow up).
+  return { activeTab: defaultTabId, unknownRequested: null };
+}
+
 // ─── Renderers ──────────────────────────────────────────────────────────
 
-function HorizontalTabsList({ tabs, ariaLabel }: { tabs: ProfileTab[]; ariaLabel?: string }) {
+// In path mode, render a Radix-styled Link that visually matches a TabsTrigger
+// but doesn't participate in TabsRoot's controlled value. Active state is
+// driven by aria-selected so the existing CSS targeting `[data-state="active"]`
+// keeps working without coupling to Radix's internal state machine.
+const HORIZONTAL_LINK_TRIGGER = `${HORIZONTAL_TRIGGER} no-underline`;
+const VERTICAL_LINK_TRIGGER = `profile-tab-vertical ${VERTICAL_ROW_BASE} no-underline`;
+
+function HorizontalTabsList({
+  tabs,
+  ariaLabel,
+  pathRouting,
+}: {
+  tabs: ProfileTab[];
+  ariaLabel?: string;
+  /** Set in path mode. Triggers render as `<Link>` with active state derived from `activeTab`. */
+  pathRouting?: { basePath: string; activeTab: string; defaultTabId: string };
+}) {
   return (
     <TabsList aria-label={ariaLabel ?? "Page sections"} className={HORIZONTAL_TABLIST}>
-      {tabs.map((tab) => (
-        <TabsTrigger
-          key={tab.id}
-          value={tab.id}
-          className={HORIZONTAL_TRIGGER}
-          aria-label={ariaLabelFor(tab)}
-        >
-          <TabLabel tab={tab} layout="horizontal" />
-        </TabsTrigger>
-      ))}
+      {tabs.map((tab) => {
+        if (pathRouting) {
+          const isActive = tab.id === pathRouting.activeTab;
+          return (
+            <Link
+              key={tab.id}
+              href={tabHrefFor(tab, pathRouting.basePath, pathRouting.defaultTabId)}
+              prefetch
+              role="tab"
+              aria-label={ariaLabelFor(tab)}
+              aria-selected={isActive}
+              data-state={isActive ? "active" : "inactive"}
+              data-tab-id={tab.id}
+              className={HORIZONTAL_LINK_TRIGGER}
+            >
+              <TabLabel tab={tab} layout="horizontal" />
+            </Link>
+          );
+        }
+        return (
+          <TabsTrigger
+            key={tab.id}
+            value={tab.id}
+            className={HORIZONTAL_TRIGGER}
+            aria-label={ariaLabelFor(tab)}
+          >
+            <TabLabel tab={tab} layout="horizontal" />
+          </TabsTrigger>
+        );
+      })}
     </TabsList>
   );
 }
@@ -182,10 +282,13 @@ function VerticalTabsNav({
   tabs,
   groups,
   ariaLabel,
+  pathRouting,
 }: {
   tabs: ProfileTab[];
   groups?: ProfileTabGroup[];
   ariaLabel?: string;
+  /** Set in path mode. Non-link tabs render as `<Link>` with active state derived from `activeTab`. */
+  pathRouting?: { basePath: string; activeTab: string; defaultTabId: string };
 }) {
   const buckets = bucketByGroup(tabs, groups);
   // TabsList supplies the RovingFocusGroup context that TabsTrigger needs.
@@ -207,17 +310,41 @@ function VerticalTabsNav({
               {bucket.label}
             </div>
           )}
-          {bucket.tabs.map((tab) =>
-            tab.href ? (
-              <Link
-                key={tab.id}
-                href={tab.href}
-                aria-label={ariaLabelFor(tab)}
-                className={VERTICAL_LINK}
-              >
-                <TabLabel tab={tab} layout="vertical" />
-              </Link>
-            ) : (
+          {bucket.tabs.map((tab) => {
+            // Tabs with an explicit `href` are link-tabs in either mode — they
+            // navigate to a fixed destination (e.g. wiki page) rather than
+            // participating in tab routing.
+            if (tab.href) {
+              return (
+                <Link
+                  key={tab.id}
+                  href={tab.href}
+                  aria-label={ariaLabelFor(tab)}
+                  className={VERTICAL_LINK}
+                >
+                  <TabLabel tab={tab} layout="vertical" />
+                </Link>
+              );
+            }
+            if (pathRouting) {
+              const isActive = tab.id === pathRouting.activeTab;
+              return (
+                <Link
+                  key={tab.id}
+                  href={tabHrefFor(tab, pathRouting.basePath, pathRouting.defaultTabId)}
+                  prefetch
+                  role="tab"
+                  aria-label={ariaLabelFor(tab)}
+                  aria-selected={isActive}
+                  data-state={isActive ? "active" : "inactive"}
+                  data-tab-id={tab.id}
+                  className={VERTICAL_LINK_TRIGGER}
+                >
+                  <TabLabel tab={tab} layout="vertical" />
+                </Link>
+              );
+            }
+            return (
               <TabsTrigger
                 key={tab.id}
                 value={tab.id}
@@ -226,8 +353,8 @@ function VerticalTabsNav({
               >
                 <TabLabel tab={tab} layout="vertical" />
               </TabsTrigger>
-            ),
-          )}
+            );
+          })}
         </div>
       ))}
     </TabsList>
@@ -265,16 +392,22 @@ function HorizontalLayout({
   onChange,
   ariaLabel,
   notice,
+  pathRouting,
 }: {
   tabs: ProfileTab[];
   activeTab: string;
   onChange: (value: string) => void;
   ariaLabel?: string;
   notice?: React.ReactNode;
+  pathRouting?: { basePath: string; defaultTabId: string };
 }) {
   return (
     <Tabs value={activeTab} onValueChange={onChange}>
-      <HorizontalTabsList tabs={tabs} ariaLabel={ariaLabel} />
+      <HorizontalTabsList
+        tabs={tabs}
+        ariaLabel={ariaLabel}
+        pathRouting={pathRouting ? { ...pathRouting, activeTab } : undefined}
+      />
       {notice}
       <TabsContentList tabs={tabs} layout="horizontal" />
     </Tabs>
@@ -288,6 +421,7 @@ function VerticalLayout({
   ariaLabel,
   groups,
   notice,
+  pathRouting,
 }: {
   tabs: ProfileTab[];
   activeTab: string;
@@ -295,6 +429,7 @@ function VerticalLayout({
   ariaLabel?: string;
   groups?: ProfileTabGroup[];
   notice?: React.ReactNode;
+  pathRouting?: { basePath: string; defaultTabId: string };
 }) {
   return (
     <Tabs
@@ -305,7 +440,12 @@ function VerticalLayout({
     >
       <div className="grid grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] gap-x-10 gap-y-6">
         <div className="md:sticky md:top-4 md:self-start">
-          <VerticalTabsNav tabs={tabs} groups={groups} ariaLabel={ariaLabel} />
+          <VerticalTabsNav
+            tabs={tabs}
+            groups={groups}
+            ariaLabel={ariaLabel}
+            pathRouting={pathRouting ? { ...pathRouting, activeTab } : undefined}
+          />
         </div>
         <div className="min-w-0">
           {notice}
@@ -466,20 +606,103 @@ function ProfileTabsFallback({
   );
 }
 
+// Path-mode renderer. Skips Suspense — `usePathname()` is sync on both server
+// and client, so the rendered DOM is identical across SSR and hydration. The
+// QUA-656 invariant (Fallback/Inner shape parity) is satisfied trivially:
+// there's no Fallback, and the single render path is structurally stable.
+function ProfileTabsPathMode({
+  tabs,
+  ariaLabel,
+  layout,
+  groups,
+  basePath,
+}: {
+  tabs: ProfileTab[];
+  ariaLabel?: string;
+  layout: "horizontal" | "vertical";
+  groups?: ProfileTabGroup[];
+  basePath: string;
+}) {
+  // basePath must be a non-root absolute path (`/organizations/anthropic`,
+  // not `""` or `"/"`). Mounting at root would produce empty hrefs for the
+  // default tab and ambiguous segment parsing for non-default tabs.
+  if (!basePath || basePath === "/") {
+    throw new Error(
+      `ProfileTabs path mode requires a non-root basePath, got ${JSON.stringify(basePath)}`,
+    );
+  }
+  const pathname = usePathname();
+  const defaultTab = pickDefaultTab(tabs);
+  const { activeTab, unknownRequested } = pickActiveTabFromPath(
+    pathname ?? "",
+    basePath,
+    tabs,
+    defaultTab.id,
+  );
+
+  const notice = unknownRequested ? (
+    <UnknownTabNotice requested={unknownRequested} fallback={defaultTab.label} />
+  ) : null;
+
+  // Triggers are <Link>s, so they handle navigation themselves. Pass noop to
+  // satisfy the controlled <Tabs> wire shape.
+  const pathRouting = { basePath, defaultTabId: defaultTab.id };
+  return layout === "vertical" ? (
+    <VerticalLayout
+      tabs={tabs}
+      activeTab={activeTab}
+      onChange={noop}
+      ariaLabel={ariaLabel}
+      groups={groups}
+      notice={notice}
+      pathRouting={pathRouting}
+    />
+  ) : (
+    <HorizontalLayout
+      tabs={tabs}
+      activeTab={activeTab}
+      onChange={noop}
+      ariaLabel={ariaLabel}
+      notice={notice}
+      pathRouting={pathRouting}
+    />
+  );
+}
+
 /**
  * Reusable tabbed layout for profile pages (organizations, people, etc.).
  * - Filters out tabs where `count === 0`
  * - Renders content directly (no tab chrome) when only one tab remains
- * - Syncs active tab to `?tab=` URL query param for shareable links
+ * - `tabRouting={{ mode: "query" }}` (default) syncs active tab to `?tab=`
+ * - `tabRouting={{ mode: "path", basePath }}` reads/writes the active tab as
+ *   a path segment after `basePath`, with triggers rendered as `<Link>` for
+ *   SSR-friendliness and shareable URLs
  * - `layout="vertical"` renders a grouped left-side nav (see `groups`)
  */
-export function ProfileTabs({ tabs, ariaLabel, layout = "horizontal", groups }: ProfileTabsProps) {
+export function ProfileTabs({
+  tabs,
+  ariaLabel,
+  layout = "horizontal",
+  groups,
+  tabRouting = { mode: "query" },
+}: ProfileTabsProps) {
   const visibleTabs = tabs.filter((t) => t.count !== 0);
   if (visibleTabs.length === 0) return null;
   // Single-tab short-circuit — matches QUA-463 hydration fix: skip Suspense
   // so server and client agree on a plain fragment.
   if (visibleTabs.length === 1) {
     return <>{visibleTabs[0].content}</>;
+  }
+  if (tabRouting.mode === "path") {
+    return (
+      <ProfileTabsPathMode
+        tabs={visibleTabs}
+        ariaLabel={ariaLabel}
+        layout={layout}
+        groups={groups}
+        basePath={tabRouting.basePath}
+      />
+    );
   }
   return (
     <Suspense

--- a/apps/web/src/components/directory/ProfileTabs.tsx
+++ b/apps/web/src/components/directory/ProfileTabs.tsx
@@ -183,11 +183,13 @@ function normalizeBasePath(basePath: string): string {
 // URL the trigger Link should navigate to. The default tab lives at the bare
 // basePath (no segment); other tabs get `${basePath}/${id}`. Tabs with an
 // explicit `href` keep their own destination — those are link-tabs (e.g. wiki
-// pages) and override path-mode routing.
+// pages) and override path-mode routing. Tab ids are URL-encoded so an id
+// containing `/`, `?`, or whitespace can't break the path or be misparsed
+// back into a different segment by `pickActiveTabFromPath`.
 function tabHrefFor(tab: ProfileTab, basePath: string, defaultTabId: string): string {
   if (tab.href) return tab.href;
   const base = normalizeBasePath(basePath);
-  return tab.id === defaultTabId ? base : `${base}/${tab.id}`;
+  return tab.id === defaultTabId ? base : `${base}/${encodeURIComponent(tab.id)}`;
 }
 
 // Pick the active tab + flag any unknown segment so we can surface a notice.
@@ -204,9 +206,18 @@ function pickActiveTabFromPath(
   }
   if (pathname.startsWith(`${base}/`)) {
     const remainder = pathname.slice(base.length + 1);
-    const segment = remainder.split("/")[0] ?? "";
-    if (segment === "") {
+    const rawSegment = remainder.split("/")[0] ?? "";
+    if (rawSegment === "") {
       return { activeTab: defaultTabId, unknownRequested: null };
+    }
+    // Decode so an encoded id (e.g. "foo%2Fbar") matches the registered tab
+    // id ("foo/bar"). Falls back to the raw segment if decoding throws on
+    // malformed input.
+    let segment = rawSegment;
+    try {
+      segment = decodeURIComponent(rawSegment);
+    } catch {
+      // Malformed percent-encoding — keep raw, will surface as unknown.
     }
     const selectableIds = new Set(tabs.filter((t) => !t.href).map((t) => t.id));
     if (selectableIds.has(segment)) {
@@ -223,10 +234,18 @@ function pickActiveTabFromPath(
 
 // In path mode, render a Radix-styled Link that visually matches a TabsTrigger
 // but doesn't participate in TabsRoot's controlled value. Active state is
-// driven by aria-selected so the existing CSS targeting `[data-state="active"]`
+// driven by data-state so the existing CSS targeting `[data-state="active"]`
 // keeps working without coupling to Radix's internal state machine.
 const HORIZONTAL_LINK_TRIGGER = `${HORIZONTAL_TRIGGER} no-underline`;
 const VERTICAL_LINK_TRIGGER = `profile-tab-vertical ${VERTICAL_ROW_BASE} no-underline`;
+
+// Resolved path-mode metadata threaded through the layout components when the
+// triggers should render as Links rather than Radix TabsTriggers.
+type PathRoutingContext = {
+  basePath: string;
+  activeTab: string;
+  defaultTabId: string;
+};
 
 function HorizontalTabsList({
   tabs,
@@ -236,7 +255,7 @@ function HorizontalTabsList({
   tabs: ProfileTab[];
   ariaLabel?: string;
   /** Set in path mode. Triggers render as `<Link>` with active state derived from `activeTab`. */
-  pathRouting?: { basePath: string; activeTab: string; defaultTabId: string };
+  pathRouting?: PathRoutingContext;
 }) {
   return (
     <TabsList aria-label={ariaLabel ?? "Page sections"} className={HORIZONTAL_TABLIST}>
@@ -247,7 +266,6 @@ function HorizontalTabsList({
             <Link
               key={tab.id}
               href={tabHrefFor(tab, pathRouting.basePath, pathRouting.defaultTabId)}
-              prefetch
               role="tab"
               aria-label={ariaLabelFor(tab)}
               aria-selected={isActive}
@@ -288,7 +306,7 @@ function VerticalTabsNav({
   groups?: ProfileTabGroup[];
   ariaLabel?: string;
   /** Set in path mode. Non-link tabs render as `<Link>` with active state derived from `activeTab`. */
-  pathRouting?: { basePath: string; activeTab: string; defaultTabId: string };
+  pathRouting?: PathRoutingContext;
 }) {
   const buckets = bucketByGroup(tabs, groups);
   // TabsList supplies the RovingFocusGroup context that TabsTrigger needs.
@@ -399,7 +417,7 @@ function HorizontalLayout({
   onChange: (value: string) => void;
   ariaLabel?: string;
   notice?: React.ReactNode;
-  pathRouting?: { basePath: string; defaultTabId: string };
+  pathRouting?: Omit<PathRoutingContext, "activeTab">;
 }) {
   return (
     <Tabs value={activeTab} onValueChange={onChange}>
@@ -429,7 +447,7 @@ function VerticalLayout({
   ariaLabel?: string;
   groups?: ProfileTabGroup[];
   notice?: React.ReactNode;
-  pathRouting?: { basePath: string; defaultTabId: string };
+  pathRouting?: Omit<PathRoutingContext, "activeTab">;
 }) {
   return (
     <Tabs

--- a/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
+++ b/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
@@ -7,12 +7,13 @@ import { render, screen, within, fireEvent } from "@testing-library/react";
 // Per-test mutable state so we can drive the mocked router/searchParams.
 const mockState = {
   search: "",
+  pathname: "/organizations/x",
   replace: vi.fn() as ReturnType<typeof vi.fn>,
 };
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(mockState.search),
-  usePathname: () => "/organizations/x",
+  usePathname: () => mockState.pathname,
   useRouter: () => ({ replace: mockState.replace, push: vi.fn() }),
 }));
 
@@ -24,6 +25,7 @@ import {
 
 beforeEach(() => {
   mockState.search = "";
+  mockState.pathname = "/organizations/x";
   mockState.replace = vi.fn();
 });
 
@@ -240,6 +242,252 @@ describe("ProfileTabs", () => {
         />,
       );
       expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+
+  describe("path-mode routing (QUA-877)", () => {
+    const basePath = "/organizations/anthropic";
+
+    it("derives default tab when pathname equals basePath (no segment)", () => {
+      mockState.pathname = basePath;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      const activeTab = screen.getByRole("tab", { selected: true });
+      expect(activeTab.textContent).toMatch(/Overview/);
+      expect(screen.getByTestId("overview-content")).toBeTruthy();
+    });
+
+    it("derives active tab from a known segment in the pathname", () => {
+      mockState.pathname = `${basePath}/facts`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div data-testid="facts-content">f</div>),
+          ]}
+        />,
+      );
+      const activeTab = screen.getByRole("tab", { selected: true });
+      expect(activeTab.textContent).toMatch(/Facts/);
+      expect(screen.getByTestId("facts-content")).toBeTruthy();
+    });
+
+    it("falls back to default tab + shows notice when segment is unknown", () => {
+      mockState.pathname = `${basePath}/shareholders`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      // Banner names the requested unknown segment + the fallback target.
+      const banner = screen.getByRole("status");
+      expect(banner.textContent).toMatch(/shareholders/);
+      expect(banner.textContent).toMatch(/Overview/);
+      // Default tab is active and its content renders.
+      expect(screen.getByTestId("overview-content")).toBeTruthy();
+    });
+
+    it("renders tab triggers as <a> Links with the expected hrefs", () => {
+      mockState.pathname = basePath;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+            tab("people", "People", <div>p</div>),
+          ]}
+        />,
+      );
+      const triggers = screen.getAllByRole("tab");
+      expect(triggers).toHaveLength(3);
+      // Default tab → bare basePath (no segment).
+      expect(triggers[0].tagName).toBe("A");
+      expect(triggers[0].getAttribute("href")).toBe(basePath);
+      // Non-default tabs → ${basePath}/${id}.
+      expect(triggers[1].getAttribute("href")).toBe(`${basePath}/facts`);
+      expect(triggers[2].getAttribute("href")).toBe(`${basePath}/people`);
+    });
+
+    it("active state on the Link trigger matches the pathname segment", () => {
+      mockState.pathname = `${basePath}/people`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+            tab("people", "People", <div>p</div>),
+          ]}
+        />,
+      );
+      const triggers = screen.getAllByRole("tab");
+      // Only the matching segment's trigger is data-state="active".
+      const states = triggers.map((t) => t.getAttribute("data-state"));
+      expect(states).toEqual(["inactive", "inactive", "active"]);
+    });
+
+    it("normalizes basePath with a trailing slash", () => {
+      mockState.pathname = "/organizations/anthropic";
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath: "/organizations/anthropic/" }}
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      // Default tab is active without double-slash in the href either.
+      expect(screen.getByTestId("overview-content")).toBeTruthy();
+      const triggers = screen.getAllByRole("tab");
+      expect(triggers[0].getAttribute("href")).toBe("/organizations/anthropic");
+      expect(triggers[1].getAttribute("href")).toBe("/organizations/anthropic/facts");
+    });
+
+    it("treats trailing slash on pathname as bare basePath", () => {
+      mockState.pathname = `${basePath}/`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      expect(screen.getByTestId("overview-content")).toBeTruthy();
+    });
+
+    it("does not call router.replace in path mode (Link drives navigation)", () => {
+      mockState.pathname = basePath;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      // Click would normally fire navigation; the Link itself handles it via
+      // next/navigation, not via router.replace.
+      fireEvent.click(screen.getByRole("tab", { name: /Facts/ }));
+      expect(mockState.replace).not.toHaveBeenCalled();
+    });
+
+    it("preserves explicit tab.href in path mode (vertical link-tabs)", () => {
+      mockState.pathname = basePath;
+      render(
+        <ProfileTabs
+          layout="vertical"
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("wiki", "Wiki", null, undefined, { href: "/wiki/E1" }),
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div>f</div>),
+          ]}
+        />,
+      );
+      const wikiLink = screen.getByRole("link", { name: /Wiki/ });
+      expect(wikiLink.getAttribute("href")).toBe("/wiki/E1");
+    });
+
+    it("query mode (default) is regression-free when tabRouting is omitted", () => {
+      // No tabRouting prop → query-mode behavior unchanged from baseline tests.
+      mockState.search = "tab=facts";
+      render(
+        <ProfileTabs
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("facts", "Facts", <div data-testid="facts-content">f</div>),
+          ]}
+        />,
+      );
+      const activeTab = screen.getByRole("tab", { selected: true });
+      expect(activeTab.textContent).toMatch(/Facts/);
+      expect(screen.getByTestId("facts-content")).toBeTruthy();
+    });
+
+    it("hydration parity: tablist structure is stable across pathname changes", () => {
+      // Path mode skips Suspense, so there's no Fallback↔Inner swap. The
+      // structural QUA-656 invariant for path mode is: the rendered tablist
+      // (tab count, tag, role, hrefs) must NOT change as the URL changes.
+      // Only `data-state` / `aria-selected` should differ between paths.
+      const tabsArr = [
+        tab("overview", "Overview", <div>o</div>),
+        tab("facts", "Facts", <div>f</div>),
+        tab("people", "People", <div>p</div>),
+      ];
+
+      mockState.pathname = basePath;
+      const { rerender, container } = render(
+        <ProfileTabs tabRouting={{ mode: "path", basePath }} tabs={tabsArr} />,
+      );
+
+      function shape() {
+        const triggers = Array.from(
+          container.querySelectorAll('[role="tab"]'),
+        ) as HTMLElement[];
+        return triggers.map((t) => ({
+          tag: t.tagName,
+          id: t.getAttribute("data-tab-id"),
+          href: t.getAttribute("href"),
+          label: t.textContent,
+        }));
+      }
+      const before = shape();
+
+      // Switch to a different known segment — same tabs, different active.
+      mockState.pathname = `${basePath}/people`;
+      rerender(
+        <ProfileTabs tabRouting={{ mode: "path", basePath }} tabs={tabsArr} />,
+      );
+      expect(shape()).toEqual(before);
+      // But the active state DID change.
+      const states = (
+        Array.from(container.querySelectorAll('[role="tab"]')) as HTMLElement[]
+      ).map((t) => t.getAttribute("data-state"));
+      expect(states).toEqual(["inactive", "inactive", "active"]);
+    });
+
+    it("throws when basePath is empty or just root", () => {
+      // basePath must be a real mount point so default-tab href and segment
+      // parsing are unambiguous. Catch this at render time, not silently in
+      // the URL.
+      const baseTabs = [
+        tab("a", "A", <div>a</div>),
+        tab("b", "B", <div>b</div>),
+      ];
+      // suppress React's error-boundary console output for this assertion
+      const origError = console.error;
+      console.error = () => {};
+      try {
+        expect(() =>
+          render(
+            <ProfileTabs tabRouting={{ mode: "path", basePath: "" }} tabs={baseTabs} />,
+          ),
+        ).toThrow(/non-root basePath/);
+        expect(() =>
+          render(
+            <ProfileTabs tabRouting={{ mode: "path", basePath: "/" }} tabs={baseTabs} />,
+          ),
+        ).toThrow(/non-root basePath/);
+      } finally {
+        console.error = origError;
+      }
     });
   });
 

--- a/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
+++ b/apps/web/src/components/directory/__tests__/ProfileTabs.test.tsx
@@ -463,6 +463,63 @@ describe("ProfileTabs", () => {
       expect(states).toEqual(["inactive", "inactive", "active"]);
     });
 
+    it("URL-encodes tab ids with special characters in the rendered href", () => {
+      mockState.pathname = basePath;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            // Pathological id with characters that would break the URL.
+            tab("a/b c", "Slashes & spaces", <div>s</div>),
+          ]}
+        />,
+      );
+      const triggers = screen.getAllByRole("tab");
+      expect(triggers[1].getAttribute("href")).toBe(`${basePath}/a%2Fb%20c`);
+    });
+
+    it("decodes encoded segments when matching them back to a tab id", () => {
+      mockState.pathname = `${basePath}/a%2Fb%20c`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div>o</div>),
+            tab("a/b c", "Slashes & spaces", <div data-testid="weird-content">s</div>),
+          ]}
+        />,
+      );
+      // The encoded segment should be decoded and matched to the registered id.
+      expect(screen.getByTestId("weird-content")).toBeTruthy();
+    });
+
+    it("renders the active TabsContent panel even though triggers are <Link>s, not <TabsTrigger>s", () => {
+      // Critical guarantee for path mode: Radix <TabsContent value=X> renders
+      // when the parent <Tabs value=X> matches, regardless of whether any
+      // <TabsTrigger> with value=X is registered. Without this, path mode
+      // would render the tab list but no panel content at all.
+      mockState.pathname = `${basePath}/facts`;
+      render(
+        <ProfileTabs
+          tabRouting={{ mode: "path", basePath }}
+          tabs={[
+            tab("overview", "Overview", <div data-testid="overview-content">o</div>),
+            tab("facts", "Facts", <div data-testid="facts-content">f</div>),
+          ]}
+        />,
+      );
+      // Active panel content renders, wrapped in a Radix tabpanel.
+      const facts = screen.getByTestId("facts-content");
+      expect(facts).toBeTruthy();
+      const factsPanel = facts.closest('[role="tabpanel"]');
+      expect(factsPanel).not.toBeNull();
+      expect(factsPanel?.getAttribute("data-state")).toBe("active");
+      // Inactive panel: Radix returns null for non-matching values, so its
+      // testid should not be in the DOM.
+      expect(screen.queryByTestId("overview-content")).toBeNull();
+    });
+
     it("throws when basePath is empty or just root", () => {
       // basePath must be a real mount point so default-tab href and segment
       // parsing are unambiguous. Catch this at render time, not silently in

--- a/apps/web/src/components/directory/index.ts
+++ b/apps/web/src/components/directory/index.ts
@@ -11,7 +11,12 @@ export {
   groupByCategory,
   FACT_CATEGORIES,
 } from "./FactsSection";
-export { ProfileTabs, type ProfileTab, type ProfileTabGroup } from "./ProfileTabs";
+export {
+  ProfileTabs,
+  type ProfileTab,
+  type ProfileTabGroup,
+  type TabRouting,
+} from "./ProfileTabs";
 export {
   PaginationControls,
   type PaginationControlsProps,


### PR DESCRIPTION
## Summary

Adds a `tabRouting` prop to `ProfileTabs` so consumers can opt into path-based active-tab routing (`${basePath}/${tabId}`) instead of the existing `?tab=` query param. Default behavior is unchanged — no consumer is migrated in this PR.

This is the foundational change for [QUA-874](https://linear.app/quantifieduncertainty/issue/QUA-874) (adopt path-based tabs across entity directory pages). Subsequent tickets (QUA-878 pilot, QUA-879 render-audit, QUA-880 sweep, QUA-881 lockdown) will migrate consumers and add gate enforcement.

## Diff shape

`apps/web/src/components/directory/ProfileTabs.tsx`:
- New `TabRouting` discriminated union: `{ mode: "query" }` (default) | `{ mode: "path"; basePath }`.
- New `ProfileTabsPathMode` renderer — derives `activeTab` from `usePathname()`, skips Suspense (sync on both server and client), and renders tab triggers as `<Link href=...>` for SSR-friendliness.
- Path-mode helpers: `normalizeBasePath`, `tabHrefFor` (default tab → bare basePath; others → `${basePath}/${encodeURIComponent(id)}`; explicit `tab.href` preserved), `pickActiveTabFromPath` (handles known segment, unknown segment + notice, trailing slash, encoded segments).
- Existing `HorizontalTabsList` and `VerticalTabsNav` accept an optional `pathRouting: PathRoutingContext` prop; when set, render `<Link>` triggers with `data-state` derived from the active tab so the existing CSS active-state selector still applies. Query mode is regression-free (the prop is omitted by query-mode callers).
- Invariant guard rejects `basePath=""` or `"/"` — those would produce empty hrefs and ambiguous segment parsing.

`__tests__/ProfileTabs.test.tsx` (14 new path-mode tests, 15 existing query-mode tests untouched):
- Active-tab derivation: bare basePath, known segment, unknown segment + notice, trailing slash on basePath/pathname.
- Link href construction: default tab → bare basePath; non-default → `${basePath}/${id}`; explicit `tab.href` preserved.
- URL encoding: tab ids with `/` and spaces round-trip through encode/decode.
- Active-state derivation: `data-state` matches the pathname segment.
- Hostile-reviewer-flagged guarantees: `<TabsContent>` renders the active panel even with no matching `<TabsTrigger>` (Radix invariant); inactive panels are absent from the DOM.
- Structural hydration parity across pathname changes (only `data-state` differs).
- Invariant guard for empty/root basePath throws.
- Query-mode regression-free check.

`directory/index.ts`: re-export the new `TabRouting` type.

## Test plan

- [x] `pnpm vitest run` — 1887 tests pass (29 in `ProfileTabs.test.tsx`, was 15).
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm crux w validate gate --fix` — 67 checks pass (3 advisory unrelated).
- [x] `pnpm build` — succeeds.
- [x] Render-audit against prod (39/39) — confirms no behavioral change to existing consumers (default is query mode).
- [x] `/agent-review-pr` hostile reviewer pass — 9 findings, addressed: URL-encoding bug fixed, prefetch dropped, `PathRoutingContext` type extracted, `<TabsContent>`-without-`<TabsTrigger>` guarantee asserted in test.

## Out of scope

- No consumer migration. `EntityProfileShell` stays untouched — wiring `tabRouting` through is deferred to QUA-878 (pilot).
- No `next.config.ts` redirect rules for legacy `?tab=` URLs.
- No render-audit matrix for path-based tab URLs.

Fixes QUA-877
