### PR TITLE
fix(pr-patrol): accept Linear refs in missing-issue-ref check (QUA-884)

### DIFF
--- a/crux/lib/pr-analysis/detection.ts
+++ b/crux/lib/pr-analysis/detection.ts
@@ -496,7 +496,7 @@ export function detectIssues(
 
   const body = pr.body ?? '';
   if (!/## Test [Pp]lan/.test(body)) issues.push('missing-testplan');
-  if (!/(Closes|Fixes|Resolves) #\d/i.test(body)) issues.push('missing-issue-ref');
+  if (!/(Closes|Fixes|Resolves)\s+(#\d+|QUA-\d+)/i.test(body)) issues.push('missing-issue-ref');
 
   const updatedMs = new Date(pr.updatedAt || pr.createdAt).getTime();
   if (updatedMs < staleThresholdMs) issues.push('stale');

--- a/crux/pr-patrol/detection.test.ts
+++ b/crux/pr-patrol/detection.test.ts
@@ -281,6 +281,20 @@ describe('detectIssues', () => {
       expect(result.issues).not.toContain('missing-issue-ref');
     }
   });
+
+  it('accepts Linear refs (Closes QUA-NNN) as issue refs (QUA-884)', () => {
+    for (const keyword of ['Closes QUA-815', 'Fixes QUA-876', 'Resolves QUA-1', 'closes qua-42']) {
+      const pr = makePrNode({ body: `## Test plan\n\n${keyword}` });
+      const result = detectIssues(pr, 0);
+      expect(result.issues).not.toContain('missing-issue-ref');
+    }
+  });
+
+  it('still rejects bare QUA-NNN without a closing keyword', () => {
+    const pr = makePrNode({ body: `## Test plan\n\nThis relates to QUA-815 but doesn't close it.` });
+    const result = detectIssues(pr, 0);
+    expect(result.issues).toContain('missing-issue-ref');
+  });
 });
 
 // ── detectAllPrIssuesFromNodes — bot/release PR skipping ──────────────────


### PR DESCRIPTION
## Summary

PR-patrol's `missing-issue-ref` detection regex only matched GitHub-style `#N` refs. Linear-tracked PRs (`Closes QUA-NNN`, `Fixes QUA-NNN`) were flagged as missing an issue ref, which made patrol skip all prep work on them — protected-paths labeling, rebases, CI fixes, bot-finding fixes.

Observed 2026-04-30: 7 open PRs all skipped this way despite each having a proper closing-keyword + Linear ref in the body. Patrol log example: `PR #NNNN: advisory issues (skipped): missing-issue-ref`.

## Change

`crux/lib/pr-analysis/detection.ts`:
```diff
-  if (!/(Closes|Fixes|Resolves) #\d/i.test(body)) issues.push('missing-issue-ref');
+  if (!/(Closes|Fixes|Resolves)\s+(#\d+|QUA-\d+)/i.test(body)) issues.push('missing-issue-ref');
```

Also relaxes the literal space to `\s+` so multi-space / tab / newline separators work.

## Test plan

- [x] `Closes QUA-1`, `Fixes QUA-2`, `Resolves QUA-3`, lowercase `closes qua-42` all pass
- [x] `Closes #1234` still passes (existing behavior preserved)
- [x] Bare `QUA-1` without a closing keyword still triggers the warning
- [x] All 43 tests in `crux/pr-patrol/detection.test.ts` pass (added 2 new for Linear refs)
- [x] Narrow-patch detector: no matches
- [x] Pre-push gate: PASS

Closes QUA-884
