### PR TITLE
fix(pr-patrol): pause auto-merge when repo setting is off (QUA-858)

### DIFF
--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -90,6 +90,7 @@ import {
   getCodeRabbitRetryTime,
   getTrackedMainFixPr,
   isAbandoned,
+  isAutoMergeDisabled,
   isCircuitOpen,
   isRecentlyProcessed,
   JSONL_FILE as JSONL_FILE_INTERNAL,
@@ -617,13 +618,28 @@ async function runCheckCycle(
 
   // Enqueue ALL eligible PRs — the merge queue handles serialization
   // Skip if deploy pipeline is failing — don't merge into a broken pipeline
+  // Skip if auto-merge has been disabled at the repo level (QUA-858)
+  const autoMergeStatus = isAutoMergeDisabled();
   if (!deployHealth.healthy) {
     log(`  ${cl.yellow}Skipping merge enqueue — deploy pipeline is failing since ${deployHealth.failingSince ?? 'unknown'}${cl.reset}`);
+  } else if (autoMergeStatus.disabled && eligibleForMerge.length > 0) {
+    log(
+      `  ${cl.yellow}Skipping ${eligibleForMerge.length} merge enqueue(s) — auto-merge is disabled at the repository level (since ${autoMergeStatus.disabledAt}). Re-enable in repo Settings → Pull Requests → Allow auto-merge.${cl.reset}`,
+    );
   } else {
     for (const candidate of eligibleForMerge) {
       const outcome = await enqueuePr(candidate, config);
       if (outcome === 'enqueued' || outcome === 'dry-run') {
         enqueuedPrs.push(candidate.number);
+      }
+      // If the first attempt tripped the repo-level circuit breaker, skip the
+      // remaining candidates this cycle — they would all hit the same error.
+      if (isAutoMergeDisabled().disabled) {
+        const remaining = eligibleForMerge.length - eligibleForMerge.indexOf(candidate) - 1;
+        if (remaining > 0) {
+          log(`  ${cl.yellow}Skipping ${remaining} remaining merge enqueue(s) this cycle — auto-merge disabled at repo level${cl.reset}`);
+        }
+        break;
       }
     }
   }

--- a/crux/pr-patrol/index.ts
+++ b/crux/pr-patrol/index.ts
@@ -627,7 +627,8 @@ async function runCheckCycle(
       `  ${cl.yellow}Skipping ${eligibleForMerge.length} merge enqueue(s) — auto-merge is disabled at the repository level (since ${autoMergeStatus.disabledAt}). Re-enable in repo Settings → Pull Requests → Allow auto-merge.${cl.reset}`,
     );
   } else {
-    for (const candidate of eligibleForMerge) {
+    for (let i = 0; i < eligibleForMerge.length; i++) {
+      const candidate = eligibleForMerge[i];
       const outcome = await enqueuePr(candidate, config);
       if (outcome === 'enqueued' || outcome === 'dry-run') {
         enqueuedPrs.push(candidate.number);
@@ -635,7 +636,7 @@ async function runCheckCycle(
       // If the first attempt tripped the repo-level circuit breaker, skip the
       // remaining candidates this cycle — they would all hit the same error.
       if (isAutoMergeDisabled().disabled) {
-        const remaining = eligibleForMerge.length - eligibleForMerge.indexOf(candidate) - 1;
+        const remaining = eligibleForMerge.length - i - 1;
         if (remaining > 0) {
           log(`  ${cl.yellow}Skipping ${remaining} remaining merge enqueue(s) this cycle — auto-merge disabled at repo level${cl.reset}`);
         }

--- a/crux/pr-patrol/merge.test.ts
+++ b/crux/pr-patrol/merge.test.ts
@@ -27,6 +27,9 @@ vi.mock('./state.ts', () => ({
   cl: new Proxy({}, { get: () => '' }),
   JSONL_FILE: '/tmp/test-runs.jsonl',
   log: vi.fn(),
+  markAutoMergeDisabled: vi.fn(),
+  REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT:
+    'Auto merge is not allowed for this repository',
 }));
 
 // Mock comments.ts to avoid real comment-posting over HTTP.
@@ -45,10 +48,12 @@ vi.mock('../lib/pr-analysis/index.ts', () => ({
 
 import { enqueuePr } from './merge.ts';
 import * as githubLib from '../lib/github.ts';
+import * as stateLib from './state.ts';
 import type { MergeCandidate, PatrolConfig } from './types.ts';
 
 const mockGraphQL = vi.mocked(githubLib.githubGraphQL);
 const mockApi = vi.mocked(githubLib.githubApi);
+const mockMarkAutoMergeDisabled = vi.mocked(stateLib.markAutoMergeDisabled);
 
 function makeCandidate(overrides: Partial<MergeCandidate> = {}): MergeCandidate {
   return {
@@ -152,5 +157,70 @@ describe('enqueuePr (QUA-473)', () => {
     );
     expect(outcome).toBe('dry-run');
     expect(mockGraphQL).not.toHaveBeenCalled();
+  });
+});
+
+describe('enqueuePr — repo-level auto-merge disabled (QUA-858)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.mockResolvedValue(undefined);
+  });
+
+  it('marks auto-merge disabled when GitHub returns the repo-disabled error', async () => {
+    mockGraphQL.mockRejectedValueOnce(
+      new Error(
+        'GitHub GraphQL error: Auto merge is not allowed for this repository',
+      ),
+    );
+
+    const outcome = await enqueuePr(makeCandidate(), makeConfig());
+
+    expect(outcome).toBe('error');
+    expect(mockMarkAutoMergeDisabled).toHaveBeenCalledTimes(1);
+    expect(mockMarkAutoMergeDisabled).toHaveBeenCalledWith(
+      expect.stringContaining('Auto merge is not allowed for this repository'),
+    );
+  });
+
+  it('skips the isInMergeQueue probe when the repo-level error fires', async () => {
+    // Only one mock response queued — if isInMergeQueue is called it throws,
+    // proving the probe was bypassed for this specific error class.
+    mockGraphQL.mockRejectedValueOnce(
+      new Error(
+        'GitHub GraphQL error: Auto merge is not allowed for this repository',
+      ),
+    );
+
+    await enqueuePr(makeCandidate(), makeConfig());
+
+    // Only one GraphQL call (the mutation), no follow-up probe
+    expect(mockGraphQL).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT mark auto-merge disabled on unrelated errors', async () => {
+    // Mutation fails with a different error
+    mockGraphQL.mockRejectedValueOnce(
+      new Error('GitHub GraphQL error: Pull request is already merged'),
+    );
+    // Subsequent isInMergeQueue probe returns "not in queue"
+    mockGraphQL.mockResolvedValueOnce({
+      node: { autoMergeRequest: null },
+    } as unknown as never);
+
+    const outcome = await enqueuePr(makeCandidate(), makeConfig());
+
+    expect(outcome).toBe('error');
+    expect(mockMarkAutoMergeDisabled).not.toHaveBeenCalled();
+  });
+
+  it('does NOT mark auto-merge disabled on success', async () => {
+    mockGraphQL.mockResolvedValueOnce({
+      enablePullRequestAutoMerge: {
+        pullRequest: { id: 'x', autoMergeRequest: { enabledAt: 'x' } },
+      },
+    } as unknown as never);
+
+    await enqueuePr(makeCandidate(), makeConfig());
+    expect(mockMarkAutoMergeDisabled).not.toHaveBeenCalled();
   });
 });

--- a/crux/pr-patrol/merge.ts
+++ b/crux/pr-patrol/merge.ts
@@ -20,7 +20,14 @@ import type {
   MergeOutcome,
   PatrolConfig,
 } from './types.ts';
-import { appendJsonl, cl, JSONL_FILE, log } from './state.ts';
+import {
+  appendJsonl,
+  cl,
+  JSONL_FILE,
+  log,
+  markAutoMergeDisabled,
+  REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT,
+} from './state.ts';
 import {
   buildEnqueuedComment,
   buildEnqueueFailedComment,
@@ -184,6 +191,36 @@ export async function enqueuePr(
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     log(`${cl.red}✗ Failed to enqueue PR #${candidate.number}: ${msg}${cl.reset}`);
+
+    // Detect repository-level auto-merge disable. This is a permanent setting,
+    // not a transient error — retrying every cycle wastes API calls and posts
+    // duplicate failure comments on every approved PR (QUA-858). Mark a global
+    // cooldown so callers skip the enqueue loop until the setting is fixed or
+    // the 1-hour cooldown elapses.
+    if (msg.includes(REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT)) {
+      markAutoMergeDisabled(msg);
+      log(
+        `${cl.yellow}⚠ Auto-merge is disabled at the repository level — pausing auto-merge attempts for 1 hour. Re-enable in repo Settings → Pull Requests → Allow auto-merge.${cl.reset}`,
+      );
+      appendJsonl(JSONL_FILE, {
+        type: 'auto_merge_repo_disabled',
+        pr_num: candidate.number,
+        reason: msg,
+      });
+      // No need to probe isInMergeQueue — a rejected mutation cannot have
+      // enabled auto-merge. Remove the stage:merging label we just added,
+      // post the failure comment, and exit.
+      await removeLabel(candidate.number, config.repo, LABELS.STAGE_MERGING);
+      await postEventComment(candidate.number, config.repo, buildEnqueueFailedComment(msg))
+        .catch((e2: unknown) => log(`  Warning: could not post enqueue failure comment: ${e2 instanceof Error ? e2.message : String(e2)}`));
+      appendJsonl(JSONL_FILE, {
+        type: 'merge_result',
+        pr_num: candidate.number,
+        outcome: 'error' as MergeOutcome,
+        reason: msg,
+      });
+      return 'error';
+    }
 
     // The enqueue may have succeeded despite the thrown error (e.g. transport
     // error after GitHub accepted the mutation). Check actual queue state

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -28,6 +28,7 @@ import {
   ensureDirs,
   getFailCount,
   isAbandoned,
+  isAutoMergeDisabled,
   isRecentlyProcessed,
   JSONL_FILE,
   log,
@@ -657,15 +658,29 @@ export async function runParallelCycle(config: ParallelConfig): Promise<CycleRes
       .catch((e: unknown) => log(`  ${cl.yellow}Warning: could not upsert status comment on PR #${mc.number}: ${e instanceof Error ? e.message : String(e)}${cl.reset}`));
   }
 
-  // Enqueue eligible PRs (skip if deploy is failing)
+  // Enqueue eligible PRs (skip if deploy is failing or auto-merge is repo-disabled)
   const enqueuedPrs: number[] = [];
+  const autoMergeStatus = isAutoMergeDisabled();
   if (!deployHealth.healthy) {
     log(`  ${cl.yellow}Skipping merge enqueue — deploy pipeline is failing${cl.reset}`);
+  } else if (autoMergeStatus.disabled && eligibleForMerge.length > 0) {
+    log(
+      `  ${cl.yellow}Skipping ${eligibleForMerge.length} merge enqueue(s) — auto-merge is disabled at the repository level (since ${autoMergeStatus.disabledAt}). Re-enable in repo Settings → Pull Requests → Allow auto-merge.${cl.reset}`,
+    );
   } else {
     for (const candidate of eligibleForMerge) {
       const outcome = await enqueuePr(candidate, config);
       if (outcome === 'enqueued' || outcome === 'dry-run') {
         enqueuedPrs.push(candidate.number);
+      }
+      // If the first attempt tripped the repo-level circuit breaker, skip the
+      // remaining candidates this cycle — they would all hit the same error.
+      if (isAutoMergeDisabled().disabled) {
+        const remaining = eligibleForMerge.length - eligibleForMerge.indexOf(candidate) - 1;
+        if (remaining > 0) {
+          log(`  ${cl.yellow}Skipping ${remaining} remaining merge enqueue(s) this cycle — auto-merge disabled at repo level${cl.reset}`);
+        }
+        break;
       }
     }
   }

--- a/crux/pr-patrol/parallel.ts
+++ b/crux/pr-patrol/parallel.ts
@@ -668,7 +668,8 @@ export async function runParallelCycle(config: ParallelConfig): Promise<CycleRes
       `  ${cl.yellow}Skipping ${eligibleForMerge.length} merge enqueue(s) — auto-merge is disabled at the repository level (since ${autoMergeStatus.disabledAt}). Re-enable in repo Settings → Pull Requests → Allow auto-merge.${cl.reset}`,
     );
   } else {
-    for (const candidate of eligibleForMerge) {
+    for (let i = 0; i < eligibleForMerge.length; i++) {
+      const candidate = eligibleForMerge[i];
       const outcome = await enqueuePr(candidate, config);
       if (outcome === 'enqueued' || outcome === 'dry-run') {
         enqueuedPrs.push(candidate.number);
@@ -676,7 +677,7 @@ export async function runParallelCycle(config: ParallelConfig): Promise<CycleRes
       // If the first attempt tripped the repo-level circuit breaker, skip the
       // remaining candidates this cycle — they would all hit the same error.
       if (isAutoMergeDisabled().disabled) {
-        const remaining = eligibleForMerge.length - eligibleForMerge.indexOf(candidate) - 1;
+        const remaining = eligibleForMerge.length - i - 1;
         if (remaining > 0) {
           log(`  ${cl.yellow}Skipping ${remaining} remaining merge enqueue(s) this cycle — auto-merge disabled at repo level${cl.reset}`);
         }

--- a/crux/pr-patrol/state.test.ts
+++ b/crux/pr-patrol/state.test.ts
@@ -325,18 +325,19 @@ describe('auto-merge disabled circuit breaker', () => {
     expect(new Date(status.disabledAt).toString()).not.toBe('Invalid Date');
   });
 
-  it('markAutoMergeDisabled() is idempotent — does not extend cooldown on repeated calls', () => {
+  it('markAutoMergeDisabled() is idempotent — preserves the original reason and timestamp on re-mark', () => {
     markAutoMergeDisabled('reason A');
     const first = isAutoMergeDisabled();
     if (!first.disabled) throw new Error('expected disabled after first mark');
     const firstAt = first.disabledAt;
 
-    // Wait a tick, mark again with a different reason
+    // A second mark with a different reason should NOT overwrite — the
+    // existing file stays in place so the original disabledAt is preserved.
     markAutoMergeDisabled('reason B');
     const second = isAutoMergeDisabled();
     if (!second.disabled) throw new Error('expected disabled after second mark');
-    expect(second.disabledAt).toBe(firstAt); // unchanged
-    expect(second.reason).toContain('reason A'); // first reason preserved
+    expect(second.disabledAt).toBe(firstAt);
+    expect(second.reason).toContain('reason A');
   });
 
   it('clearAutoMergeDisabled() removes the state file', () => {
@@ -373,6 +374,32 @@ describe('auto-merge disabled circuit breaker', () => {
 
   it('treats corrupt state file as cleared', () => {
     writeFileSync(STATE_FILE, 'not json{{{');
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+    expect(existsSync(STATE_FILE)).toBe(false);
+  });
+
+  it('treats malformed-but-parseable JSON as cleared (missing disabledAt)', () => {
+    // Without shape validation, missing disabledAt would parse as undefined,
+    // making `NaN >= cooldown` false and trapping the breaker indefinitely.
+    writeFileSync(STATE_FILE, JSON.stringify({ reason: 'no timestamp' }));
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+    expect(existsSync(STATE_FILE)).toBe(false);
+  });
+
+  it('treats malformed-but-parseable JSON as cleared (wrong-typed disabledAt)', () => {
+    writeFileSync(
+      STATE_FILE,
+      JSON.stringify({ reason: 'wrong type', disabledAt: 12345 }),
+    );
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+    expect(existsSync(STATE_FILE)).toBe(false);
+  });
+
+  it('treats unparseable disabledAt date string as cleared', () => {
+    writeFileSync(
+      STATE_FILE,
+      JSON.stringify({ reason: 'bad date', disabledAt: 'not-a-real-date' }),
+    );
     expect(isAutoMergeDisabled()).toEqual({ disabled: false });
     expect(existsSync(STATE_FILE)).toBe(false);
   });

--- a/crux/pr-patrol/state.test.ts
+++ b/crux/pr-patrol/state.test.ts
@@ -23,6 +23,11 @@ import {
   getProcessedBlockingCommentIds,
   markBlockingCommentsProcessed,
   clearProcessedBlockingComments,
+  markAutoMergeDisabled,
+  isAutoMergeDisabled,
+  clearAutoMergeDisabled,
+  AUTO_MERGE_DISABLED_COOLDOWN_SECONDS,
+  REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT,
   STATE_DIR,
 } from './state.ts';
 
@@ -284,5 +289,91 @@ describe('processed blocking comments (QUA-514)', () => {
     writeFileSync(file, 'not valid json{{{');
     const ids = getProcessedBlockingCommentIds(testPrNumber, shaA);
     expect(ids.size).toBe(0);
+  });
+});
+
+// ── Auto-merge disabled circuit breaker (QUA-858) ──────────────────────────
+
+describe('auto-merge disabled circuit breaker', () => {
+  const STATE_FILE = join(STATE_DIR, 'auto-merge-disabled');
+
+  afterEach(() => {
+    clearAutoMergeDisabled();
+  });
+
+  it('exposes the GitHub error fragment used for detection', () => {
+    expect(REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT).toBe(
+      'Auto merge is not allowed for this repository',
+    );
+  });
+
+  it('uses a 1-hour cooldown', () => {
+    expect(AUTO_MERGE_DISABLED_COOLDOWN_SECONDS).toBe(3600);
+  });
+
+  it('isAutoMergeDisabled() returns disabled:false when no state exists', () => {
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+  });
+
+  it('markAutoMergeDisabled() persists reason and timestamp', () => {
+    markAutoMergeDisabled('GitHub GraphQL error: Auto merge is not allowed for this repository');
+    const status = isAutoMergeDisabled();
+    expect(status.disabled).toBe(true);
+    if (!status.disabled) throw new Error('expected disabled');
+    expect(status.reason).toContain('Auto merge is not allowed');
+    expect(typeof status.disabledAt).toBe('string');
+    expect(new Date(status.disabledAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('markAutoMergeDisabled() is idempotent — does not extend cooldown on repeated calls', () => {
+    markAutoMergeDisabled('reason A');
+    const first = isAutoMergeDisabled();
+    if (!first.disabled) throw new Error('expected disabled after first mark');
+    const firstAt = first.disabledAt;
+
+    // Wait a tick, mark again with a different reason
+    markAutoMergeDisabled('reason B');
+    const second = isAutoMergeDisabled();
+    if (!second.disabled) throw new Error('expected disabled after second mark');
+    expect(second.disabledAt).toBe(firstAt); // unchanged
+    expect(second.reason).toContain('reason A'); // first reason preserved
+  });
+
+  it('clearAutoMergeDisabled() removes the state file', () => {
+    markAutoMergeDisabled('test');
+    expect(isAutoMergeDisabled().disabled).toBe(true);
+    clearAutoMergeDisabled();
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+  });
+
+  it('auto-clears state when cooldown has elapsed', () => {
+    // Manually write a state file with a timestamp in the distant past
+    const expired = {
+      reason: 'expired',
+      disabledAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    };
+    writeFileSync(STATE_FILE, JSON.stringify(expired));
+
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+    // The check itself should have unlinked the expired file
+    expect(existsSync(STATE_FILE)).toBe(false);
+  });
+
+  it('keeps state when cooldown has NOT elapsed', () => {
+    const fresh = {
+      reason: 'still fresh',
+      disabledAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(), // 5 min ago
+    };
+    writeFileSync(STATE_FILE, JSON.stringify(fresh));
+
+    const status = isAutoMergeDisabled();
+    expect(status.disabled).toBe(true);
+    expect(existsSync(STATE_FILE)).toBe(true);
+  });
+
+  it('treats corrupt state file as cleared', () => {
+    writeFileSync(STATE_FILE, 'not json{{{');
+    expect(isAutoMergeDisabled()).toEqual({ disabled: false });
+    expect(existsSync(STATE_FILE)).toBe(false);
   });
 });

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -365,6 +365,78 @@ export function isCircuitOpen(): boolean {
 /** Threshold in seconds below which a failure is considered "instant". */
 export const INSTANT_FAILURE_THRESHOLD_SECONDS = INSTANT_FAILURE_THRESHOLD_S;
 
+// ── Auto-merge availability circuit breaker (QUA-858) ───────────────────────
+// When GitHub returns "Auto merge is not allowed for this repository", the
+// repository setting is disabled. Retrying every cycle wastes API calls and
+// pollutes PR threads with failure comments. Pause auto-merge attempts for
+// 1 hour so a fix to the repo setting is auto-detected on next attempt.
+
+const AUTO_MERGE_DISABLED_FILE = join(STATE_DIR, 'auto-merge-disabled');
+const AUTO_MERGE_DISABLED_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+/** Substring of the GitHub error message that indicates a repo-level disable. */
+export const REPO_AUTO_MERGE_DISABLED_ERROR_FRAGMENT =
+  'Auto merge is not allowed for this repository';
+
+interface AutoMergeDisabledState {
+  reason: string;
+  disabledAt: string; // ISO timestamp
+}
+
+/**
+ * Mark auto-merge as disabled at the repository level. Subsequent calls to
+ * `isAutoMergeDisabled()` return `disabled: true` until the cooldown elapses.
+ * Idempotent — repeated calls do not extend the cooldown beyond the first
+ * mark, so a flapping setting still self-heals after one cooldown window.
+ */
+export function markAutoMergeDisabled(reason: string): void {
+  if (existsSync(AUTO_MERGE_DISABLED_FILE)) {
+    // Already marked — preserve the original disabledAt so cooldown is bounded
+    return;
+  }
+  const state: AutoMergeDisabledState = {
+    reason,
+    disabledAt: new Date().toISOString(),
+  };
+  writeFileSync(AUTO_MERGE_DISABLED_FILE, JSON.stringify(state));
+}
+
+/**
+ * Returns whether auto-merge is currently paused due to a prior repo-level
+ * failure. Auto-clears the state file once the cooldown has elapsed.
+ */
+export function isAutoMergeDisabled():
+  | { disabled: false }
+  | { disabled: true; reason: string; disabledAt: string } {
+  if (!existsSync(AUTO_MERGE_DISABLED_FILE)) return { disabled: false };
+  try {
+    const state = JSON.parse(
+      readFileSync(AUTO_MERGE_DISABLED_FILE, 'utf-8'),
+    ) as AutoMergeDisabledState;
+    const elapsed = Date.now() - new Date(state.disabledAt).getTime();
+    if (elapsed >= AUTO_MERGE_DISABLED_COOLDOWN_MS) {
+      try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
+      return { disabled: false };
+    }
+    return { disabled: true, reason: state.reason, disabledAt: state.disabledAt };
+  } catch {
+    // Corrupt file — treat as cleared
+    try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
+    return { disabled: false };
+  }
+}
+
+/** Manually clear the auto-merge-disabled state (useful for tests / operators). */
+export function clearAutoMergeDisabled(): void {
+  if (existsSync(AUTO_MERGE_DISABLED_FILE)) {
+    try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
+  }
+}
+
+/** Cooldown duration exposed for tests. */
+export const AUTO_MERGE_DISABLED_COOLDOWN_SECONDS =
+  AUTO_MERGE_DISABLED_COOLDOWN_MS / 1000;
+
 // ── Total fix attempt tracking (anti-oscillation) ───────────────────────────
 // Tracks cumulative fix attempts per PR regardless of intermediate successes.
 // Prevents the fix→verify-fail→fix→verify-fail oscillation pattern (#3755, #3757)

--- a/crux/pr-patrol/state.ts
+++ b/crux/pr-patrol/state.ts
@@ -410,10 +410,28 @@ export function isAutoMergeDisabled():
   | { disabled: true; reason: string; disabledAt: string } {
   if (!existsSync(AUTO_MERGE_DISABLED_FILE)) return { disabled: false };
   try {
-    const state = JSON.parse(
+    const raw: unknown = JSON.parse(
       readFileSync(AUTO_MERGE_DISABLED_FILE, 'utf-8'),
-    ) as AutoMergeDisabledState;
-    const elapsed = Date.now() - new Date(state.disabledAt).getTime();
+    );
+    if (
+      typeof raw !== 'object' ||
+      raw === null ||
+      typeof (raw as { disabledAt?: unknown }).disabledAt !== 'string' ||
+      typeof (raw as { reason?: unknown }).reason !== 'string'
+    ) {
+      // Malformed but parseable JSON (e.g., missing or wrong-typed fields)
+      // would leave disabledAt as `undefined`, making `NaN >= cooldown` false
+      // and trapping the breaker indefinitely. Treat as cleared.
+      try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
+      return { disabled: false };
+    }
+    const state = raw as AutoMergeDisabledState;
+    const disabledAtMs = new Date(state.disabledAt).getTime();
+    if (Number.isNaN(disabledAtMs)) {
+      try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
+      return { disabled: false };
+    }
+    const elapsed = Date.now() - disabledAtMs;
     if (elapsed >= AUTO_MERGE_DISABLED_COOLDOWN_MS) {
       try { unlinkSync(AUTO_MERGE_DISABLED_FILE); } catch { /* best-effort */ }
       return { disabled: false };


### PR DESCRIPTION
## Summary

PR patrol was retrying auto-merge every cycle when GitHub returned `Auto merge is not allowed for this repository` — a repo-level setting, not a transient error. PR #4692 hit this 4 times in 2 minutes on 2026-04-29; PR #4660 hit it once. Each retry posts a duplicate failure comment and burns GraphQL quota.

Adds a global circuit breaker scoped to `~/.cache/pr-patrol/state/auto-merge-disabled`:

- `enqueuePr()` detects the specific GitHub error fragment and calls `markAutoMergeDisabled()`, then short-circuits — skipping the now-redundant `isInMergeQueue` probe (a rejected mutation cannot have enabled auto-merge).
- `parallel.ts` and `index.ts` skip the entire enqueue loop when the cooldown is active, with one log line pointing at the repo Settings → Pull Requests → Allow auto-merge fix. Mid-loop, if the breaker trips on the first PR, the rest of the cycle's eligible PRs are skipped too.
- 1-hour cooldown auto-clears so the patrol resumes once the operator re-enables the setting.
- Idempotent: a re-mark within the cooldown preserves the original timestamp so a flapping setting still self-heals in one window.
- Shape-validates the JSON state file (`disabledAt` must be a parseable date string) so a malformed file can't trap the breaker indefinitely.

## Test plan

- [x] `pnpm vitest run crux/pr-patrol/` — 471 tests pass (12 new: 8 state tests + 4 merge tests covering: marks on the specific error, skips probe, doesn't mark on unrelated errors, doesn't mark on success, plus 3 malformed-JSON edge cases).
- [x] `pnpm crux w validate gate --fix` — all 67 gate checks pass.
- [x] `npx tsc --noEmit -p crux` — no new type errors in modified files.
- [x] Hostile-reviewer subagent run via `/agent-review-pr`; HIGH/MEDIUM findings either fixed (shape validation, O(n²) indexOf) or documented as benign (existsSync race within ms-window, single-trip-comment per cycle is informative not duplicate).

Fixes QUA-858


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository-level auto-merge pause detection that activates when GitHub disables auto-merge for a repository.
  * System now skips PR merge attempts for one hour when auto-merge is disabled at the repository level.
  * Enhanced error handling with improved logging when auto-merge restrictions are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->