### PR TITLE
QUA-812: extend linear audit to In Review state

### DIFF
--- a/.claude/rules/linear-integration.md
+++ b/.claude/rules/linear-integration.md
@@ -92,6 +92,8 @@ Linear has built-in Git automation that triggers state changes independent of th
 
 These are configured in Linear's team settings (not in this repo). The `crux` commands duplicate some of these transitions intentionally -- belt-and-suspenders for cases where Linear's automation doesn't fire (e.g., branch created before Linear integration was installed, or PR body reference without branch name match).
 
+**The In-Review → Done transition is empirically unreliable.** Even when a PR has both a `claude/qua-NNN-*` branch name AND a `Fixes QUA-NNN` body line, ~1.4–5% of merged PRs leave their issue stuck in "In Review" indefinitely (QUA-812 measurement). The fallback is `crux linear audit --fix` (see § 6), which classifies any active issue (In Progress + In Review) with a merged PR as `shipped` and moves it to Done. Run after every batch of merges, or include it in the maintenance sweep.
+
 ## 6. Available commands
 
 ```bash
@@ -107,6 +109,11 @@ crux linear done QUA-NNN [--pr=URL]   # Move to In Review (with PR) or Done
 # Communication
 crux linear comment QUA-NNN <message>           # Post a comment
 crux linear comment QUA-NNN --body-file=<path>  # Comment from file (multiline-safe)
+
+# Maintenance
+crux linear audit                     # Classify active issues (In Progress + In Review) by PR health
+crux linear audit --fix               # Auto-close SHIPPED + PARENT-EPIC (covers In-Review → Done failures, QUA-812)
+crux linear audit --bucket=shipped --json  # Machine-readable shipped list
 
 # Admin
 crux linear states-list               # Show current QUA team workflow state IDs

--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -110,7 +110,7 @@ pnpm crux sys maintain triage-linear
 
 This replaces the manual GraphQL queries. If `LINEAR_API_KEY` is not set, it reports that and skips gracefully.
 
-**4b. Actionable In Progress audit** — correlates Linear In Progress state with GitHub PR activity. Surfaces `SHIPPED` (PR merged but state not updated) and `PARENT-EPIC` (all sub-issues resolved) — these are one-keystroke cleanups that `triage-linear` doesn't catch because it only looks at staleness by time.
+**4b. Actionable active-issue audit** — correlates Linear In Progress + In Review state with GitHub PR activity. Surfaces `SHIPPED` (PR merged but state not updated) and `PARENT-EPIC` (all sub-issues resolved) — these are one-keystroke cleanups that `triage-linear` doesn't catch because it only looks at staleness by time. The In-Review case is QUA-812: Linear's GitHub integration occasionally drops the In-Review → Done transition on PR merge (~1.4–5% rate), and the audit catches the gap mechanically.
 
 ```bash
 # Run the audit once and split by bucket in Python to avoid doubling the
@@ -122,7 +122,7 @@ try:
   shipped = [e for e in entries if e.get('bucket') == 'shipped']
   parent_epics = [e for e in entries if e.get('bucket') == 'parent-epic']
   if shipped:
-    print(f'⚠ {len(shipped)} issue(s) SHIPPED but still In Progress:')
+    print(f'⚠ {len(shipped)} issue(s) SHIPPED but still In Progress / In Review:')
     for e in shipped:
       print(f\"  {e['issue']['identifier']} — {e['reason']}\")
     print('  Run: pnpm crux linear audit --fix')

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -36,7 +36,7 @@ import {
   type UpdateProjectInput,
 } from '../lib/linear/projects.ts';
 import {
-  auditInProgress,
+  auditActive,
   extractFixesIds,
   STALE_DAYS,
   type AuditBucket,
@@ -766,7 +766,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
     };
   }
 
-  const entries = await auditInProgress();
+  const entries = await auditActive();
 
   if (options.json) {
     const filtered = bucketFilter ? entries.filter((e) => e.bucket === bucketFilter) : entries;
@@ -775,7 +775,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
 
   if (entries.length === 0) {
     return {
-      output: `${c.green}✓${c.reset} No issues currently In Progress.\n`,
+      output: `${c.green}✓${c.reset} No issues currently In Progress or In Review.\n`,
       exitCode: 0,
     };
   }
@@ -821,7 +821,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
   }
 
   let out = '';
-  out += `${c.bold}Linear In-Progress audit (${entries.length} issues)${c.reset}\n\n`;
+  out += `${c.bold}Linear active-issue audit (${entries.length} issues — In Progress + In Review)${c.reset}\n\n`;
 
   const order: AuditBucket[] = ['shipped', 'parent-epic', 'orphan', 'stuck', 'active'];
   for (const bucket of order) {
@@ -1274,7 +1274,7 @@ Commands:
   comment <QUA-NNN> <message>   Post a comment on an issue
   start <QUA-NNN>               Move issue to In Progress + post start comment
   done <QUA-NNN> [--pr=URL]     Move to In Review (with PR) or Done, post comment
-  audit                         Classify In Progress issues by PR health (shipped/orphan/epic/active)
+  audit                         Classify active issues (In Progress + In Review) by PR health
   hygiene                       Metadata hygiene scan: orphans, label coverage, priority gaps, stuck tickets
   verify-pr <PR>                Watchdog: ensure merged PR's Fixes QUA-NNN issues are actually Done
   leak-check                    Scan current session for QUA refs beyond the primary; warn about leaks

--- a/crux/commands/linear.ts
+++ b/crux/commands/linear.ts
@@ -789,7 +789,9 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
     shipped: {
       label: 'SHIPPED (state-update missed)',
       color: c.yellow,
-      action: 'PR merged. Move to Done: crux linear done QUA-NNN --pr=URL',
+      // `crux linear done QUA-NNN` (no --pr) moves directly to Done. The
+      // --pr variant moves to In Review, which is where these are stuck.
+      action: 'PR merged. Move to Done: crux linear done QUA-NNN  (or --fix to batch)',
     },
     'parent-epic': {
       label: 'PARENT EPIC (sub-issues resolved)',
@@ -841,7 +843,7 @@ async function audit(args: string[], options: CommandOptions): Promise<CommandRe
   if (actionable > 0) {
     out += `${c.bold}${actionable} issue(s) need action.${c.reset} Use ${c.cyan}--bucket=shipped${c.reset}/etc. to filter, ${c.cyan}--fix${c.reset} to auto-close SHIPPED + PARENT EPIC, or ${c.cyan}--json${c.reset} for scripting.\n`;
   } else {
-    out += `${c.green}✓${c.reset} All In Progress issues look healthy.\n`;
+    out += `${c.green}✓${c.reset} All active issues look healthy.\n`;
   }
 
   let fixFailures = 0;

--- a/crux/lib/linear/__tests__/audit.test.ts
+++ b/crux/lib/linear/__tests__/audit.test.ts
@@ -314,6 +314,20 @@ describe('classifyEntry — parent epic with open children', () => {
     const e = classifyEntry(issue, items, makeChildrenResult([]));
     expect(e.bucket).toBe('shipped');
   });
+
+  it('In-Review issue with merged PR classifies as SHIPPED (QUA-812)', () => {
+    // Linear's GitHub integration occasionally fails the In-Review → Done
+    // transition on PR merge (~1.4–5% of merges). The audit must detect
+    // these so `--fix` can auto-close them; In-Review and In-Progress share
+    // Linear's `started` workflow type, so classifyEntry is state-agnostic.
+    const issue = makeIssue({ state: { name: 'In Review', type: 'started' } });
+    const items = [
+      makePr({ number: 4573, state: 'closed', mergedAt: '2026-04-24T21:05:10Z' }),
+    ];
+    const e = classifyEntry(issue, items, makeChildrenResult([]));
+    expect(e.bucket).toBe('shipped');
+    expect(e.reason).toContain('#4573');
+  });
 });
 
 describe('classifyEntry — no-auto-close label', () => {

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -308,7 +308,15 @@ export function classifyEntry(
 export async function auditActive(): Promise<AuditEntry[]> {
   // Hard cap at 200 to bound concurrent fan-out; teams with more than that
   // many simultaneously-active issues have bigger problems than this audit.
-  const issues = await listIssuesByStateType(['started'], 200);
+  const all = await listIssuesByStateType(['started'], 200);
+
+  // Linear's `started` state type currently maps 1:1 to {In Progress, In Review}
+  // on the QUA team, but a future custom workflow state could share the type
+  // (e.g., "Reviewing", "In QA"). Filter explicitly so the audit's behavior
+  // stays bounded to what's documented and tested.
+  const issues = all.filter(
+    (i) => i.state.name === 'In Progress' || i.state.name === 'In Review',
+  );
 
   if (issues.length === 0) return [];
 

--- a/crux/lib/linear/audit.ts
+++ b/crux/lib/linear/audit.ts
@@ -293,19 +293,22 @@ export function classifyEntry(
 }
 
 /**
- * Fetch In Progress issues and classify each.
+ * Fetch active (In Progress + In Review) issues and classify each.
+ *
+ * Both states share Linear's `started` workflow type. The audit covers both
+ * because Linear's GitHub integration is empirically unreliable on the
+ * In-Review → Done transition: ~1.4–5% of merged PRs leave their issue stuck
+ * "In Review" indefinitely (QUA-812). Including In Review here lets the
+ * existing `shipped` bucket detect and auto-close the gap.
  *
  * Concurrency: Linear children queries run with a small concurrency cap to
  * stay under Linear's GraphQL rate limits even on teams with many issues.
  * GitHub PR search runs one query per id with the same cap.
  */
-export async function auditInProgress(): Promise<AuditEntry[]> {
-  // Linear's `started` state type covers In Progress AND In Review. Audit
-  // focuses on In Progress — In Review is naturally waiting on PR merge.
+export async function auditActive(): Promise<AuditEntry[]> {
   // Hard cap at 200 to bound concurrent fan-out; teams with more than that
   // many simultaneously-active issues have bigger problems than this audit.
-  const all = await listIssuesByStateType(['started'], 200);
-  const issues = all.filter((i) => i.state.name === 'In Progress');
+  const issues = await listIssuesByStateType(['started'], 200);
 
   if (issues.length === 0) return [];
 
@@ -326,6 +329,13 @@ export async function auditInProgress(): Promise<AuditEntry[]> {
     return classifyEntry(issue, items, children);
   });
 }
+
+/**
+ * @deprecated Use {@link auditActive} — preserved as a name-only alias for any
+ * external caller that imports `auditInProgress`. The behavior changed in
+ * QUA-812: this function now covers both In Progress and In Review.
+ */
+export const auditInProgress = auditActive;
 
 // ---------------------------------------------------------------------------
 // Watchdog: re-verify Linear state after a PR merge


### PR DESCRIPTION
## Summary

Extends `crux linear audit` to cover both **In Progress** and **In Review** state types. The existing `audit --fix` infrastructure already classifies issues with a merged PR but no Done state as `shipped` — it just had the In-Review case explicitly filtered out, with the rationale "naturally waiting on PR merge". That assumption is empirically wrong.

## Why

Linear's GitHub integration is supposed to auto-move issues to Done on PR merge when the branch name (`claude/qua-NNN-*`) or PR body (`Fixes QUA-NNN`) references the issue. **It silently drops the transition** on a non-trivial fraction of merges:

- **Last 30 days, 285 merged-PR Fixes-refs sampled**: 4 stuck (1.4%)
- **Last ~10 days, 56 fresh sample**: 3 stuck (5.4%)
- **All stuck cases were specifically In Review → Done** failures — never In Progress, never other states

## Change

Two behavioral changes in `crux/lib/linear/audit.ts`:

1. **Removed the In-Progress-only filter.** `auditInProgress()` is renamed to `auditActive()` (with an `auditInProgress` alias preserved for any external import) and now classifies any issue whose `state.name` is "In Progress" OR "In Review". The function-level comment documents the QUA-812 finding.
2. **Explicit name allowlist** rather than relying on `state.type === 'started'` alone, so a future custom workflow state of the same type doesn't silently expand audit scope.

`classifyEntry()`, `classifyPRs()`, `extractFixesIds()` are unchanged — they were already state-agnostic, and the existing 35 unit tests verify all bucket transitions.

## Output text fixes (per /agent-review-pr findings)

- **HIGH**: SHIPPED bucket action text told users to run `crux linear done` with the `--pr=URL` variant, but that moves to In Review (where the issue already is). Updated to suggest the no-`--pr` variant or `--fix` for batch cleanup.
- **MEDIUM**: Footer "All In Progress issues look healthy" → "All active issues look healthy".

## Live verification

After the change, `pnpm crux linear audit` correctly identifies 4 stuck "In Review" issues, all with `state.name === "In Review"`, correct `Fixes QUA-NNN` body lines, and correct `claude/qua-NNN-*` branch names — the exact failure mode the ticket describes:

| Issue | PR | Merged |
| -- | -- | -- |
| QUA-838 | #4709 | 0d ago |
| QUA-761 | #4658 | 1d ago |
| QUA-705 | #4601 | 5d ago |
| QUA-733 | #4623 | 4d ago |

`pnpm crux linear audit --fix` will move them to Done with a `🤖 Auto-closed by ...` comment.

## What I considered but did NOT do

- **Don't fix the Linear-side webhook**: I have no admin access to Linear's webhook log and no way to validate a fix from outside. The mechanical cleanup is faster than escalation and equally robust.
- **Don't run `audit --fix` in this PR**: shipping the code is the value; the fix runs during normal maintenance sweeps.
- **Don't try to harden the GitHub-search truncation case**: the audit's chunked OR-query is independently noisy on Linear seed issues whose IDs appear in test fixtures of an unrelated PR. Those issues classify as ACTIVE (open PR linked) so `--fix` won't touch them. Out of scope here.

## Acceptance criteria

- [x] **Document the failure rate**: 1.4% over 30d, 5.4% on a fresh sample — both 100% concentrated in the In-Review state
- [x] **Identify the failure mode**: Linear's webhook drops the In-Review → Done transition. Branch name and PR body are both correct.
- [x] **Ship the heuristic**: `audit --fix` now covers both states; the existing `shipped` classifier and auto-close logic do the rest

## Test plan

- [x] All 36 audit unit tests pass (35 pre-existing + 1 new for In-Review SHIPPED case)
- [x] `pnpm crux w validate gate --fix` — 67/67 blocking checks pass
- [x] Live audit run identifies the 4 expected stuck cases
- [x] /agent-review-pr ran (1 HIGH + 3 MEDIUM findings addressed)

Fixes QUA-812
