### PR TITLE
QUA-882: improve-entity-suite runner — orchestrate the closed loop across the entity suite

### DIFF
--- a/crux/benchmarks/entity-suite.yaml
+++ b/crux/benchmarks/entity-suite.yaml
@@ -1,0 +1,41 @@
+# Entity Benchmark Suite (v1, policy-only)
+#
+# Owned canonically by QUA-873 (read-only benchmark-suite). The runner in
+# QUA-882 (`crux tb improve-entity-suite`) reads this file to drive a
+# closed-loop sweep over every supported entity. Editing this file is a
+# deliberate review action, not a casual change.
+#
+# v1 caveat: policy entities only. Non-policy types are added as analyzers
+# land (QUA-876 for organization, follow-ups for person, ai-model). Each
+# entry must point at a slug present in `data/entities/responses.yaml`.
+#
+# Fields:
+#   slug                  — id in responses.yaml
+#   type                  — policy | organization | person | ai-model
+#   expected_min_coverage — coverage_score floor (0..1) for benchmark-suite
+#                           regression checks (QUA-871). Informational here;
+#                           the runner does not enforce it directly.
+- slug: fisa-702
+  type: policy
+  expected_min_coverage: 0.9
+- slug: eu-ai-act
+  type: policy
+  expected_min_coverage: 0.9
+- slug: california-sb1047
+  type: policy
+  expected_min_coverage: 0.85
+- slug: nist-ai-rmf
+  type: policy
+  expected_min_coverage: 0.8
+- slug: us-executive-order
+  type: policy
+  expected_min_coverage: 0.85
+- slug: seoul-declaration
+  type: policy
+  expected_min_coverage: 0.75
+- slug: voluntary-commitments
+  type: policy
+  expected_min_coverage: 0.75
+- slug: colorado-ai-act
+  type: policy
+  expected_min_coverage: 0.8

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -56,6 +56,7 @@ function makeResult(slug: string, overrides: Partial<ImproveResult> = {}): Impro
   return {
     entity_slug: slug,
     entity_id: slug,
+    entity_type: "policy",
     iterations,
     final_coverage: 0.9,
     final_facts: { provisions: 6, stakeholders: 5 },

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Tests for `crux tb improve-entity-suite` (QUA-882).
+ *
+ * Pure helpers (loadSuite, filterToSupportedTypes, computePerEntityCap,
+ * median/p25, aggregateResult, computeAggregate) are tested directly. The
+ * suite runner is tested with a mocked improver function injected via
+ * SuiteRunOptions.improver — no LLM, no YAML writes, no network.
+ */
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  MIN_USEFUL_BUDGET_USD,
+  aggregateResult,
+  computeAggregate,
+  computePerEntityCap,
+  filterToSupportedTypes,
+  loadSuite,
+  median,
+  p25,
+  runSuite,
+  type PerEntityRecord,
+  type SuiteEntry,
+} from "./research-improve-entity-suite.ts";
+import type { ImproveResult, IterationMetrics } from "./research-improve-entity.ts";
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+function makeIter(overrides: Partial<IterationMetrics> = {}): IterationMetrics {
+  return {
+    iter: 1,
+    gaps_identified: 3,
+    sources_found: 5,
+    claims_extracted: 10,
+    claims_filtered_out: 2,
+    claims_proposed: 8,
+    claims_verified: 6,
+    claims_partial: 1,
+    claims_contradicted: 0,
+    claims_unverifiable: 1,
+    verified_rate: 7 / 8,
+    applied_to_yaml: 5,
+    cost_research_usd: 0.02,
+    cost_extract_usd: 0.01,
+    duration_s: 30,
+    ...overrides,
+  };
+}
+
+function makeResult(slug: string, overrides: Partial<ImproveResult> = {}): ImproveResult {
+  const iterations = overrides.iterations ?? [makeIter()];
+  return {
+    entity_slug: slug,
+    entity_id: slug,
+    iterations,
+    final_coverage: 0.9,
+    final_facts: { provisions: 6, stakeholders: 5 },
+    total_cost_usd: iterations.reduce((s, m) => s + m.cost_research_usd + m.cost_extract_usd, 0),
+    total_duration_s: iterations.reduce((s, m) => s + m.duration_s, 0),
+    hit_target: true,
+    reason: "target-hit",
+    ...overrides,
+  };
+}
+
+function tmpdir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+// ── loadSuite ──────────────────────────────────────────────────────────────
+
+describe("loadSuite", () => {
+  it("parses a valid suite YAML", () => {
+    const dir = tmpdir("suite-yaml");
+    const filePath = path.join(dir, "suite.yaml");
+    fs.writeFileSync(
+      filePath,
+      `- slug: foo
+  type: policy
+  expected_min_coverage: 0.9
+- slug: bar
+  type: organization
+`,
+    );
+    const entries = loadSuite(filePath);
+    expect(entries).toEqual([
+      { slug: "foo", type: "policy", expected_min_coverage: 0.9 },
+      { slug: "bar", type: "organization" },
+    ]);
+  });
+
+  it("rejects entries missing required fields", () => {
+    const dir = tmpdir("suite-bad");
+    const filePath = path.join(dir, "suite.yaml");
+    fs.writeFileSync(filePath, `- slug: foo\n`); // missing `type`
+    expect(() => loadSuite(filePath)).toThrow();
+  });
+
+  it("rejects an out-of-range expected_min_coverage", () => {
+    const dir = tmpdir("suite-bad-cov");
+    const filePath = path.join(dir, "suite.yaml");
+    fs.writeFileSync(filePath, `- slug: foo\n  type: policy\n  expected_min_coverage: 1.5\n`);
+    expect(() => loadSuite(filePath)).toThrow();
+  });
+});
+
+// ── filterToSupportedTypes ─────────────────────────────────────────────────
+
+describe("filterToSupportedTypes", () => {
+  it("keeps only policy entries (v1)", () => {
+    const entries: SuiteEntry[] = [
+      { slug: "a", type: "policy" },
+      { slug: "b", type: "organization" },
+      { slug: "c", type: "policy" },
+      { slug: "d", type: "person" },
+    ];
+    expect(filterToSupportedTypes(entries).map((e) => e.slug)).toEqual(["a", "c"]);
+  });
+
+  it("returns empty for an all-unsupported list", () => {
+    const entries: SuiteEntry[] = [
+      { slug: "a", type: "organization" },
+      { slug: "b", type: "ai-model" },
+    ];
+    expect(filterToSupportedTypes(entries)).toEqual([]);
+  });
+});
+
+// ── computePerEntityCap ────────────────────────────────────────────────────
+
+describe("computePerEntityCap", () => {
+  it("returns 2× the equal-share allocation", () => {
+    expect(computePerEntityCap(10, 8)).toBeCloseTo(2.5, 6); // (10/8)*2
+    expect(computePerEntityCap(5, 5)).toBeCloseTo(2.0, 6);
+  });
+
+  it("returns 0 on N=0 (no division by zero)", () => {
+    expect(computePerEntityCap(10, 0)).toBe(0);
+  });
+
+  it("scales linearly with budget", () => {
+    expect(computePerEntityCap(20, 8)).toBeCloseTo(5.0, 6);
+  });
+});
+
+// ── median + p25 ───────────────────────────────────────────────────────────
+
+describe("median", () => {
+  it("returns 0 for an empty list", () => {
+    expect(median([])).toBe(0);
+  });
+
+  it("handles a single element", () => {
+    expect(median([0.5])).toBe(0.5);
+  });
+
+  it("averages middle two for even-length", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it("returns the middle element for odd-length", () => {
+    expect(median([5, 1, 3])).toBe(3); // sorted [1,3,5]
+  });
+});
+
+describe("p25", () => {
+  it("returns 0 for an empty list", () => {
+    expect(p25([])).toBe(0);
+  });
+
+  it("handles a single element", () => {
+    expect(p25([0.7])).toBe(0.7);
+  });
+
+  it("matches NumPy linear interpolation", () => {
+    // NumPy: np.percentile([1,2,3,4,5], 25) → 2.0
+    expect(p25([1, 2, 3, 4, 5])).toBeCloseTo(2.0, 6);
+    // NumPy: np.percentile([10,20,30,40], 25) → 17.5
+    expect(p25([10, 20, 30, 40])).toBeCloseTo(17.5, 6);
+  });
+});
+
+// ── aggregateResult ────────────────────────────────────────────────────────
+
+describe("aggregateResult", () => {
+  it("sums per-iter counts and computes verified_rate", () => {
+    const result = makeResult("foo", {
+      iterations: [
+        makeIter({ claims_proposed: 5, claims_verified: 4, claims_partial: 0, applied_to_yaml: 4 }),
+        makeIter({ claims_proposed: 3, claims_verified: 2, claims_partial: 1, applied_to_yaml: 3 }),
+      ],
+    });
+    const r = aggregateResult("foo", "policy", result);
+    expect(r.claims_proposed).toBe(8);
+    expect(r.claims_verified).toBe(6);
+    expect(r.claims_partial).toBe(1);
+    expect(r.applied_to_yaml).toBe(7);
+    // verified+partial / proposed = 7/8
+    expect(r.verified_rate).toBeCloseTo(7 / 8, 6);
+    expect(r.status).toBe("completed");
+  });
+
+  it("reports verified_rate=0 when no claims proposed", () => {
+    const result = makeResult("empty", {
+      iterations: [makeIter({ claims_proposed: 0, claims_verified: 0, claims_partial: 0 })],
+    });
+    const r = aggregateResult("empty", "policy", result);
+    expect(r.verified_rate).toBe(0);
+  });
+});
+
+// ── computeAggregate ───────────────────────────────────────────────────────
+
+describe("computeAggregate", () => {
+  function recordWithRate(slug: string, rate: number, status: PerEntityRecord["status"] = "completed", cost = 0): PerEntityRecord {
+    return {
+      slug,
+      type: "policy",
+      status,
+      iterations: [],
+      claims_proposed: 0,
+      claims_verified: 0,
+      claims_partial: 0,
+      claims_contradicted: 0,
+      claims_unverifiable: 0,
+      verified_rate: rate,
+      applied_to_yaml: 0,
+      cost_usd: cost,
+      duration_s: 0,
+    };
+  }
+
+  it("counts entities by status and computes percentiles over completed only", () => {
+    const records: PerEntityRecord[] = [
+      recordWithRate("a", 0.9, "completed", 0.04),
+      recordWithRate("b", 0.85, "completed", 0.05),
+      recordWithRate("c", 0.7, "completed", 0.03),
+      recordWithRate("d", 0, "skipped_budget", 0),
+      recordWithRate("e", 0, "failed", 0),
+    ];
+    const agg = computeAggregate(records);
+    expect(agg.entities_completed).toBe(3);
+    expect(agg.entities_skipped_budget).toBe(1);
+    expect(agg.entities_failed).toBe(1);
+    expect(agg.median_verified_rate).toBeCloseTo(0.85, 6);
+    // p25 of [0.7, 0.85, 0.9] → 0.775 (linear interp at idx 0.5)
+    expect(agg.p25_verified_rate).toBeCloseTo(0.775, 6);
+    expect(agg.total_cost_usd).toBeCloseTo(0.12, 6);
+  });
+
+  it("returns zeros when no entities completed", () => {
+    const records: PerEntityRecord[] = [recordWithRate("a", 0, "failed")];
+    const agg = computeAggregate(records);
+    expect(agg.median_verified_rate).toBe(0);
+    expect(agg.p25_verified_rate).toBe(0);
+    expect(agg.entities_completed).toBe(0);
+  });
+});
+
+// ── runSuite (integration with mocked improver) ────────────────────────────
+
+function writeFixtureSuite(...entries: Array<{ slug: string; type: string }>): {
+  suitePath: string;
+  snapshotDir: string;
+} {
+  const dir = tmpdir("suite-run");
+  const suitePath = path.join(dir, "suite.yaml");
+  const lines = entries.map((e) => `- slug: ${e.slug}\n  type: ${e.type}`).join("\n");
+  fs.writeFileSync(suitePath, lines + "\n");
+  return { suitePath, snapshotDir: path.join(dir, "snapshots") };
+}
+
+describe("runSuite", () => {
+  it("happy path: runs improver once per supported entity, writes snapshot", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "alpha", type: "policy" },
+      { slug: "beta", type: "policy" },
+    );
+    const calls: string[] = [];
+    const improver = async ({ slug }: { slug: string }) => {
+      calls.push(slug);
+      return makeResult(slug, {
+        iterations: [makeIter({ cost_research_usd: 0.02, cost_extract_usd: 0.01 })],
+      });
+    };
+    const snap = await runSuite({
+      tag: "happy",
+      totalBudgetUsd: 4.0,
+      maxIters: 2,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(calls).toEqual(["alpha", "beta"]);
+    expect(snap.entities).toHaveLength(2);
+    expect(snap.entities.every((r) => r.status === "completed")).toBe(true);
+    expect(snap.aggregate.entities_completed).toBe(2);
+    expect(snap.aggregate.entities_skipped_budget).toBe(0);
+    expect(snap.aggregate.entities_failed).toBe(0);
+    expect(snap.tag).toBe("happy");
+    expect(snap.budget_usd).toBe(4.0);
+    expect(snap.per_entity_cap_usd).toBeCloseTo(4.0, 6); // (4/2)*2
+
+    // Snapshot file written.
+    const written = fs.readdirSync(snapshotDir);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatch(/__happy\.json$/);
+    const onDisk = JSON.parse(fs.readFileSync(path.join(snapshotDir, written[0]), "utf8"));
+    expect(onDisk.tag).toBe("happy");
+    expect(onDisk.entities.map((e: { slug: string }) => e.slug)).toEqual(["alpha", "beta"]);
+  });
+
+  it("filters out unsupported types before running", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "alpha", type: "policy" },
+      { slug: "beta", type: "organization" }, // unsupported in v1
+      { slug: "gamma", type: "policy" },
+    );
+    const calls: string[] = [];
+    const improver = async ({ slug }: { slug: string }) => {
+      calls.push(slug);
+      return makeResult(slug);
+    };
+    const snap = await runSuite({
+      tag: "filter",
+      totalBudgetUsd: 2.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(calls).toEqual(["alpha", "gamma"]);
+    expect(snap.entities.map((r) => r.slug)).toEqual(["alpha", "gamma"]);
+  });
+
+  it("halts early and marks remaining entities skipped_budget when total budget exhausted", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "spendthrift", type: "policy" },
+      { slug: "second", type: "policy" },
+      { slug: "third", type: "policy" },
+    );
+    const calls: string[] = [];
+    const improver = async ({ slug, budgetUsd }: { slug: string; budgetUsd?: number }) => {
+      calls.push(slug);
+      // Entity 1 burns its entire budget allocation.
+      const cost = slug === "spendthrift" ? (budgetUsd ?? 0) : 0.01;
+      return makeResult(slug, {
+        iterations: [makeIter({ cost_research_usd: cost, cost_extract_usd: 0 })],
+      });
+    };
+    // Total = 0.10, per-entity cap = (0.10/3)*2 = 0.0667. spendthrift burns 0.0667.
+    // Remaining after entity 1 = 0.10 - 0.0667 = 0.0333, which is below
+    // MIN_USEFUL_BUDGET_USD ($0.05) → halt.
+    const snap = await runSuite({
+      tag: "halt",
+      totalBudgetUsd: 0.1,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(calls).toEqual(["spendthrift"]);
+    expect(snap.entities[0].status).toBe("completed");
+    expect(snap.entities[1].status).toBe("skipped_budget");
+    expect(snap.entities[2].status).toBe("skipped_budget");
+    expect(snap.aggregate.entities_completed).toBe(1);
+    expect(snap.aggregate.entities_skipped_budget).toBe(2);
+  });
+
+  it("passes the per-entity cap as the inner budget; never exceeds remaining", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "a", type: "policy" },
+      { slug: "b", type: "policy" },
+    );
+    const budgetsSeen: Array<{ slug: string; budget: number }> = [];
+    const improver = async ({ slug, budgetUsd }: { slug: string; budgetUsd?: number }) => {
+      budgetsSeen.push({ slug, budget: budgetUsd ?? -1 });
+      // Spend nothing so subsequent entities still see plenty of remaining budget.
+      return makeResult(slug, { iterations: [makeIter({ cost_research_usd: 0, cost_extract_usd: 0 })] });
+    };
+    // Total=$2, N=2 → per-entity cap = $2.
+    await runSuite({
+      tag: "cap",
+      totalBudgetUsd: 2.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(budgetsSeen).toEqual([
+      { slug: "a", budget: 2.0 },
+      { slug: "b", budget: 2.0 },
+    ]);
+  });
+
+  it("records failures without aborting subsequent entities", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite(
+      { slug: "boom", type: "policy" },
+      { slug: "ok", type: "policy" },
+    );
+    const improver = async ({ slug }: { slug: string }) => {
+      if (slug === "boom") throw new Error("synthetic blast");
+      return makeResult(slug);
+    };
+    const snap = await runSuite({
+      tag: "fail",
+      totalBudgetUsd: 4.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(snap.entities[0].status).toBe("failed");
+    expect(snap.entities[0].error).toContain("synthetic blast");
+    expect(snap.entities[1].status).toBe("completed");
+    expect(snap.aggregate.entities_failed).toBe(1);
+    expect(snap.aggregate.entities_completed).toBe(1);
+  });
+
+  it("returns a snapshot with empty entities when the suite has no supported types", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite({ slug: "x", type: "organization" });
+    const improver = async () => makeResult("never-called");
+    const snap = await runSuite({
+      tag: "empty",
+      totalBudgetUsd: 1.0,
+      maxIters: 1,
+      suitePath,
+      snapshotDir,
+      improver,
+    });
+    expect(snap.entities).toEqual([]);
+    expect(snap.aggregate.entities_completed).toBe(0);
+    // per_entity_cap_usd is 0 when N=0.
+    expect(snap.per_entity_cap_usd).toBe(0);
+  });
+});
+
+// ── exported constant sanity ───────────────────────────────────────────────
+
+describe("constants", () => {
+  it("MIN_USEFUL_BUDGET_USD matches the inner-loop floor in research-improve-entity", () => {
+    // Mirrors the `budgetRemaining <= 0.05` guard in research-improve-entity.ts.
+    expect(MIN_USEFUL_BUDGET_USD).toBe(0.05);
+  });
+});

--- a/crux/commands/research-improve-entity-suite.test.ts
+++ b/crux/commands/research-improve-entity-suite.test.ts
@@ -18,6 +18,7 @@ import {
   computeAggregate,
   computePerEntityCap,
   filterToSupportedTypes,
+  isValidTag,
   loadSuite,
   median,
   p25,
@@ -126,6 +127,43 @@ describe("filterToSupportedTypes", () => {
       { slug: "b", type: "ai-model" },
     ];
     expect(filterToSupportedTypes(entries)).toEqual([]);
+  });
+});
+
+// ── isValidTag ─────────────────────────────────────────────────────────────
+
+describe("isValidTag", () => {
+  it("accepts plain alphanumerics, dot, underscore, hyphen", () => {
+    expect(isValidTag("baseline")).toBe(true);
+    expect(isValidTag("after-token-filter")).toBe(true);
+    expect(isValidTag("v1.0_run-2")).toBe(true);
+    expect(isValidTag("ABC123")).toBe(true);
+  });
+
+  it("rejects path traversal sequences", () => {
+    expect(isValidTag("../etc/passwd")).toBe(false);
+    expect(isValidTag("..\\\\windows")).toBe(false);
+    expect(isValidTag("foo/bar")).toBe(false);
+    expect(isValidTag("foo\\bar")).toBe(false);
+  });
+
+  it("rejects shell/filesystem metacharacters", () => {
+    expect(isValidTag("foo;rm -rf /")).toBe(false);
+    expect(isValidTag("foo bar")).toBe(false); // space
+    expect(isValidTag("foo$bar")).toBe(false);
+    expect(isValidTag("foo`bar`")).toBe(false);
+    expect(isValidTag("foo|bar")).toBe(false);
+  });
+
+  it("rejects empty and oversize tags", () => {
+    expect(isValidTag("")).toBe(false);
+    expect(isValidTag("a".repeat(81))).toBe(false);
+    expect(isValidTag("a".repeat(80))).toBe(true);
+  });
+
+  it("rejects unicode-control / null bytes", () => {
+    expect(isValidTag("foo\x00bar")).toBe(false);
+    expect(isValidTag("foo\nbar")).toBe(false);
   });
 });
 
@@ -422,7 +460,11 @@ describe("runSuite", () => {
 
   it("returns a snapshot with empty entities when the suite has no supported types", async () => {
     const { suitePath, snapshotDir } = writeFixtureSuite({ slug: "x", type: "organization" });
-    const improver = async () => makeResult("never-called");
+    let calls = 0;
+    const improver = async () => {
+      calls++;
+      return makeResult("never-called");
+    };
     const snap = await runSuite({
       tag: "empty",
       totalBudgetUsd: 1.0,
@@ -431,10 +473,33 @@ describe("runSuite", () => {
       snapshotDir,
       improver,
     });
+    expect(calls).toBe(0);
     expect(snap.entities).toEqual([]);
     expect(snap.aggregate.entities_completed).toBe(0);
     // per_entity_cap_usd is 0 when N=0.
     expect(snap.per_entity_cap_usd).toBe(0);
+  });
+
+  it("rejects an invalid tag before doing any work", async () => {
+    const { suitePath, snapshotDir } = writeFixtureSuite({ slug: "alpha", type: "policy" });
+    let calls = 0;
+    const improver = async () => {
+      calls++;
+      return makeResult("alpha");
+    };
+    await expect(
+      runSuite({
+        tag: "../etc/passwd",
+        totalBudgetUsd: 4.0,
+        maxIters: 1,
+        suitePath,
+        snapshotDir,
+        improver,
+      }),
+    ).rejects.toThrow(/Invalid --tag/);
+    expect(calls).toBe(0);
+    // No snapshot file written.
+    expect(fs.existsSync(snapshotDir) ? fs.readdirSync(snapshotDir) : []).toEqual([]);
   });
 });
 

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -427,9 +427,12 @@ Options:
   --dry-run         Don't write YAML changes back to data/entities/responses.yaml.
 
 Budget governance:
-  Per-entity hard cap = 2 × (total_budget / N) where N = supported entities.
-  Halts mid-suite if remaining budget falls below $${MIN_USEFUL_BUDGET_USD.toFixed(2)} —
-  remaining entities are recorded as \`skipped_budget\`.
+  Per-entity soft cap = 2 × (total_budget / N) where N = supported entities.
+  This is a soft cap: a single iteration may overshoot it, since runResearch
+  spends until its own budgetCap. The suite halts mid-run when remaining
+  budget falls below $${MIN_USEFUL_BUDGET_USD.toFixed(2)}; remaining entities
+  are recorded as \`skipped_budget\`. \`--budget\` is therefore a target, not
+  a strict bound.
 `,
     exitCode: 0,
   };

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -1,0 +1,399 @@
+// crux tb improve-entity-suite — orchestrates the closed-loop improver across
+// every entity in `crux/benchmarks/entity-suite.yaml`.
+//
+// QUA-882. Pairs with `crux tb benchmark-suite --diff` (QUA-873) which reads
+// the YAML state delta. This command produces the *process* metrics
+// (verified-rate, cost, applied counts) the read-only benchmark can't see.
+//
+// Usage:
+//   pnpm crux tb improve-entity-suite --tag=baseline --budget=10 --max-iters=2
+//   pnpm crux tb improve-entity-suite --tag=after-token-filter --budget=5 --dry-run
+
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import yaml from "js-yaml";
+import { z } from "zod";
+
+import { type CommandResult } from "../lib/cli.ts";
+import {
+  type ImproveOptions,
+  type ImproveResult,
+  improveSingleEntity,
+} from "./research-improve-entity.ts";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const SUITE_YAML = path.join(ROOT, "crux/benchmarks/entity-suite.yaml");
+const SNAPSHOT_DIR = path.join(ROOT, ".claude/snapshots/improve-entity-suite");
+
+// ── Suite YAML schema ───────────────────────────────────────────────────────
+
+const SuiteEntrySchema = z.object({
+  slug: z.string().min(1),
+  type: z.string().min(1),
+  expected_min_coverage: z.number().min(0).max(1).optional(),
+});
+
+const SuiteSchema = z.array(SuiteEntrySchema);
+
+export type SuiteEntry = z.infer<typeof SuiteEntrySchema>;
+
+/** Types the improve loop currently supports end-to-end. v1: policy-only. */
+const SUPPORTED_TYPES = new Set<string>(["policy"]);
+
+/** Per-entity floor below which the inner loop is guaranteed to no-op. */
+export const MIN_USEFUL_BUDGET_USD = 0.05;
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+/** Load + validate the suite YAML. Throws on schema violation. */
+export function loadSuite(filePath: string = SUITE_YAML): SuiteEntry[] {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = yaml.load(raw);
+  return SuiteSchema.parse(parsed);
+}
+
+/** Filter to types the improve loop currently supports. */
+export function filterToSupportedTypes(entries: SuiteEntry[]): SuiteEntry[] {
+  return entries.filter((e) => SUPPORTED_TYPES.has(e.type));
+}
+
+/**
+ * Per-entity hard cap = 2× the equal-share expected cost.
+ * Spec: "Per-entity cap: 2× expected (= total / N × 2)."
+ */
+export function computePerEntityCap(totalBudgetUsd: number, entityCount: number): number {
+  if (entityCount <= 0) return 0;
+  return (totalBudgetUsd / entityCount) * 2;
+}
+
+export interface PerEntityRecord {
+  slug: string;
+  type: string;
+  status: "completed" | "failed" | "skipped_budget";
+  /** Present on `completed` or `failed` (when failure is during a partial run). */
+  result?: ImproveResult;
+  /** Aggregated counts across iterations, derived from `result`. */
+  iterations: ImproveResult["iterations"];
+  claims_proposed: number;
+  claims_verified: number;
+  claims_partial: number;
+  claims_contradicted: number;
+  claims_unverifiable: number;
+  verified_rate: number;
+  applied_to_yaml: number;
+  cost_usd: number;
+  duration_s: number;
+  error?: string;
+}
+
+export interface AggregateMetrics {
+  median_verified_rate: number;
+  p25_verified_rate: number;
+  total_cost_usd: number;
+  total_duration_s: number;
+  entities_completed: number;
+  entities_skipped_budget: number;
+  entities_failed: number;
+}
+
+/** Aggregate iteration metrics into a per-entity row. Pure. */
+export function aggregateResult(slug: string, type: string, result: ImproveResult): PerEntityRecord {
+  const claims_proposed = result.iterations.reduce((s, m) => s + m.claims_proposed, 0);
+  const claims_verified = result.iterations.reduce((s, m) => s + m.claims_verified, 0);
+  const claims_partial = result.iterations.reduce((s, m) => s + m.claims_partial, 0);
+  const claims_contradicted = result.iterations.reduce((s, m) => s + m.claims_contradicted, 0);
+  const claims_unverifiable = result.iterations.reduce((s, m) => s + m.claims_unverifiable, 0);
+  const applied_to_yaml = result.iterations.reduce((s, m) => s + m.applied_to_yaml, 0);
+  const verified_rate =
+    claims_proposed > 0 ? (claims_verified + claims_partial) / claims_proposed : 0;
+  return {
+    slug,
+    type,
+    status: "completed",
+    result,
+    iterations: result.iterations,
+    claims_proposed,
+    claims_verified,
+    claims_partial,
+    claims_contradicted,
+    claims_unverifiable,
+    verified_rate,
+    applied_to_yaml,
+    cost_usd: result.total_cost_usd,
+    duration_s: result.total_duration_s,
+  };
+}
+
+/** Median of a numeric list. Linear interpolation between adjacent samples. */
+export function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = (sorted.length - 1) / 2;
+  const lo = Math.floor(mid);
+  const hi = Math.ceil(mid);
+  return (sorted[lo] + sorted[hi]) / 2;
+}
+
+/**
+ * 25th-percentile via the standard linear-interpolation method (the same
+ * R-7 / NumPy default behavior). Returns 0 for empty input.
+ */
+export function p25(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  if (xs.length === 1) return xs[0];
+  const sorted = [...xs].sort((a, b) => a - b);
+  const idx = (sorted.length - 1) * 0.25;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  const frac = idx - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+/** Compute aggregate metrics across the per-entity rows. Pure. */
+export function computeAggregate(records: PerEntityRecord[]): AggregateMetrics {
+  const completed = records.filter((r) => r.status === "completed");
+  const verifiedRates = completed.map((r) => r.verified_rate);
+  return {
+    median_verified_rate: median(verifiedRates),
+    p25_verified_rate: p25(verifiedRates),
+    total_cost_usd: records.reduce((s, r) => s + r.cost_usd, 0),
+    total_duration_s: records.reduce((s, r) => s + r.duration_s, 0),
+    entities_completed: completed.length,
+    entities_skipped_budget: records.filter((r) => r.status === "skipped_budget").length,
+    entities_failed: records.filter((r) => r.status === "failed").length,
+  };
+}
+
+// ── Suite runner ────────────────────────────────────────────────────────────
+
+export interface SuiteRunOptions {
+  tag: string;
+  totalBudgetUsd: number;
+  maxIters: number;
+  target?: number;
+  dryRun?: boolean;
+  /** Path to the suite YAML. Defaults to crux/benchmarks/entity-suite.yaml. */
+  suitePath?: string;
+  /** Where to write the snapshot. Defaults to .claude/snapshots/improve-entity-suite/. */
+  snapshotDir?: string;
+  /**
+   * Injected for tests — the suite runner calls this once per supported entity.
+   * Default is the real `improveSingleEntity` from research-improve-entity.ts.
+   */
+  improver?: (opts: ImproveOptions) => Promise<ImproveResult>;
+}
+
+export interface SuiteSnapshot {
+  tag: string;
+  git_sha: string | null;
+  started_at: string;
+  ended_at: string;
+  budget_usd: number;
+  per_entity_cap_usd: number;
+  max_iters: number;
+  dry_run: boolean;
+  entities: PerEntityRecord[];
+  aggregate: AggregateMetrics;
+}
+
+function gitSha(): string | null {
+  try {
+    return execSync("git rev-parse --short HEAD", { cwd: ROOT, encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the suite. Returns the snapshot. Side effects:
+ *   - Calls `improver()` once per supported entity in suite order.
+ *   - Writes a snapshot file to `<snapshotDir>/<timestamp>__<tag>.json`.
+ */
+export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
+  const suitePath = opts.suitePath ?? SUITE_YAML;
+  const snapshotDir = opts.snapshotDir ?? SNAPSHOT_DIR;
+  const improver = opts.improver ?? improveSingleEntity;
+
+  const startedAt = new Date().toISOString();
+  const all = loadSuite(suitePath);
+  const supported = filterToSupportedTypes(all);
+
+  const N = supported.length;
+  const perEntityCap = computePerEntityCap(opts.totalBudgetUsd, N);
+
+  const records: PerEntityRecord[] = [];
+  let totalSpent = 0;
+
+  for (const entry of supported) {
+    const remaining = opts.totalBudgetUsd - totalSpent;
+    if (remaining <= MIN_USEFUL_BUDGET_USD) {
+      records.push({
+        slug: entry.slug,
+        type: entry.type,
+        status: "skipped_budget",
+        iterations: [],
+        claims_proposed: 0,
+        claims_verified: 0,
+        claims_partial: 0,
+        claims_contradicted: 0,
+        claims_unverifiable: 0,
+        verified_rate: 0,
+        applied_to_yaml: 0,
+        cost_usd: 0,
+        duration_s: 0,
+      });
+      continue;
+    }
+    // Hard cap is the per-entity 2× expected; never let it exceed remaining.
+    const entityBudget = Math.min(perEntityCap, remaining);
+    console.log(
+      `\n=== [${records.length + 1}/${N}] improve-entity-suite: ${entry.slug} ` +
+        `(budget=$${entityBudget.toFixed(2)}, remaining=$${remaining.toFixed(2)}) ===`,
+    );
+    try {
+      const result = await improver({
+        slug: entry.slug,
+        target: opts.target,
+        budgetUsd: entityBudget,
+        maxIters: opts.maxIters,
+        dryRun: opts.dryRun,
+        quiet: true,
+      });
+      const record = aggregateResult(entry.slug, entry.type, result);
+      records.push(record);
+      totalSpent += result.total_cost_usd;
+      if (result.total_cost_usd >= perEntityCap * 0.99) {
+        console.warn(
+          `[suite] WARNING: ${entry.slug} hit per-entity cap ($${perEntityCap.toFixed(2)}); ` +
+            `inner loop may have been truncated.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[suite] FAILED: ${entry.slug}: ${msg}`);
+      records.push({
+        slug: entry.slug,
+        type: entry.type,
+        status: "failed",
+        iterations: [],
+        claims_proposed: 0,
+        claims_verified: 0,
+        claims_partial: 0,
+        claims_contradicted: 0,
+        claims_unverifiable: 0,
+        verified_rate: 0,
+        applied_to_yaml: 0,
+        cost_usd: 0,
+        duration_s: 0,
+        error: msg,
+      });
+    }
+  }
+
+  const aggregate = computeAggregate(records);
+  const endedAt = new Date().toISOString();
+  const snapshot: SuiteSnapshot = {
+    tag: opts.tag,
+    git_sha: gitSha(),
+    started_at: startedAt,
+    ended_at: endedAt,
+    budget_usd: opts.totalBudgetUsd,
+    per_entity_cap_usd: perEntityCap,
+    max_iters: opts.maxIters,
+    dry_run: !!opts.dryRun,
+    entities: records,
+    aggregate,
+  };
+
+  fs.mkdirSync(snapshotDir, { recursive: true });
+  const stamp = startedAt.replace(/[:.]/g, "-");
+  const fileName = `${stamp}__${opts.tag}.json`;
+  fs.writeFileSync(path.join(snapshotDir, fileName), JSON.stringify(snapshot, null, 2) + "\n");
+
+  return snapshot;
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────────────
+
+export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
+  void args;
+  const tag = String(options.tag ?? "").trim();
+  if (!tag) {
+    return {
+      output:
+        "Usage: crux tb improve-entity-suite --tag=<label> [--budget=10] [--max-iters=2] [--target=N] [--dry-run]",
+      exitCode: 1,
+    };
+  }
+  const totalBudgetUsd = options.budget != null ? parseFloat(options.budget as string) : 10.0;
+  const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 2;
+  const target = options.target != null ? parseInt(options.target as string, 10) : undefined;
+  const dryRun = !!options.dryRun;
+
+  if (!Number.isFinite(totalBudgetUsd) || totalBudgetUsd <= 0) {
+    return { output: `--budget must be a positive number; got ${options.budget}`, exitCode: 1 };
+  }
+  if (!Number.isFinite(maxIters) || maxIters <= 0) {
+    return { output: `--max-iters must be a positive integer; got ${options.maxIters}`, exitCode: 1 };
+  }
+
+  const snapshot = await runSuite({ tag, totalBudgetUsd, maxIters, target, dryRun });
+
+  console.log("\n=== improve-entity-suite result ===");
+  console.log(`tag:                       ${snapshot.tag}`);
+  console.log(`git_sha:                   ${snapshot.git_sha ?? "(unknown)"}`);
+  console.log(`entities_completed:        ${snapshot.aggregate.entities_completed}`);
+  console.log(`entities_skipped_budget:   ${snapshot.aggregate.entities_skipped_budget}`);
+  console.log(`entities_failed:           ${snapshot.aggregate.entities_failed}`);
+  console.log(`median_verified_rate:      ${snapshot.aggregate.median_verified_rate.toFixed(3)}`);
+  console.log(`p25_verified_rate:         ${snapshot.aggregate.p25_verified_rate.toFixed(3)}`);
+  console.log(`total_cost_usd:            $${snapshot.aggregate.total_cost_usd.toFixed(2)}`);
+  console.log(`total_duration_s:          ${snapshot.aggregate.total_duration_s.toFixed(1)}`);
+  for (const r of snapshot.entities) {
+    if (r.status === "completed") {
+      console.log(
+        `  [${r.status}] ${r.slug.padEnd(28)} verified=${r.verified_rate.toFixed(2)} ` +
+          `applied=${r.applied_to_yaml} cost=$${r.cost_usd.toFixed(3)}`,
+      );
+    } else {
+      console.log(`  [${r.status}] ${r.slug.padEnd(28)} ${r.error ?? ""}`);
+    }
+  }
+
+  // Exit code: 0 if any entity completed; 2 if all skipped/failed.
+  const exitCode = snapshot.aggregate.entities_completed > 0 ? 0 : 2;
+  return { output: "", exitCode };
+}
+
+export function help(): CommandResult {
+  return {
+    output: `crux tb improve-entity-suite --tag=<label> [--budget=10] [--max-iters=2] [--target=N] [--dry-run]
+
+Run the closed-loop improve-entity over every supported entity in
+crux/benchmarks/entity-suite.yaml. Produces a structured snapshot under
+.claude/snapshots/improve-entity-suite/<timestamp>__<tag>.json with
+per-entity verified-rate / cost / applied counts plus aggregate metrics.
+
+Pair with \`crux tb benchmark-suite --diff=<a>,<b>\` (QUA-873) for the YAML
+state delta.
+
+Options:
+  --tag=<label>     Required. Snapshot label (e.g. baseline, after-X).
+  --budget=N        Total LLM spend cap across the suite, USD (default 10).
+  --max-iters=N     Max iterations per entity (default 2).
+  --target=N        Per-entity (provisions+stakeholders) target (passed through).
+  --dry-run         Don't write YAML changes back to data/entities/responses.yaml.
+
+Budget governance:
+  Per-entity hard cap = 2 × (total_budget / N) where N = supported entities.
+  Halts mid-suite if remaining budget falls below $${MIN_USEFUL_BUDGET_USD.toFixed(2)} —
+  remaining entities are recorded as \`skipped_budget\`.
+`,
+    exitCode: 0,
+  };
+}
+
+export const commands = { default: run, help };
+export const getHelp = () => help().output;

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -206,6 +206,30 @@ function gitSha(): string | null {
   }
 }
 
+/** Zero-row for entities that never ran (skipped_budget) or threw (failed). */
+function emptyRecord(
+  entry: SuiteEntry,
+  status: "skipped_budget" | "failed",
+  error?: string,
+): PerEntityRecord {
+  return {
+    slug: entry.slug,
+    type: entry.type,
+    status,
+    iterations: [],
+    claims_proposed: 0,
+    claims_verified: 0,
+    claims_partial: 0,
+    claims_contradicted: 0,
+    claims_unverifiable: 0,
+    verified_rate: 0,
+    applied_to_yaml: 0,
+    cost_usd: 0,
+    duration_s: 0,
+    error,
+  };
+}
+
 /**
  * Run the suite. Returns the snapshot. Side effects:
  *   - Calls `improver()` once per supported entity in suite order.
@@ -229,21 +253,7 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
   for (const entry of supported) {
     const remaining = opts.totalBudgetUsd - totalSpent;
     if (remaining <= MIN_USEFUL_BUDGET_USD) {
-      records.push({
-        slug: entry.slug,
-        type: entry.type,
-        status: "skipped_budget",
-        iterations: [],
-        claims_proposed: 0,
-        claims_verified: 0,
-        claims_partial: 0,
-        claims_contradicted: 0,
-        claims_unverifiable: 0,
-        verified_rate: 0,
-        applied_to_yaml: 0,
-        cost_usd: 0,
-        duration_s: 0,
-      });
+      records.push(emptyRecord(entry, "skipped_budget"));
       continue;
     }
     // Hard cap is the per-entity 2× expected; never let it exceed remaining.
@@ -273,22 +283,7 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[suite] FAILED: ${entry.slug}: ${msg}`);
-      records.push({
-        slug: entry.slug,
-        type: entry.type,
-        status: "failed",
-        iterations: [],
-        claims_proposed: 0,
-        claims_verified: 0,
-        claims_partial: 0,
-        claims_contradicted: 0,
-        claims_unverifiable: 0,
-        verified_rate: 0,
-        applied_to_yaml: 0,
-        cost_usd: 0,
-        duration_s: 0,
-        error: msg,
-      });
+      records.push(emptyRecord(entry, "failed", msg));
     }
   }
 

--- a/crux/commands/research-improve-entity-suite.ts
+++ b/crux/commands/research-improve-entity-suite.ts
@@ -44,6 +44,17 @@ const SUPPORTED_TYPES = new Set<string>(["policy"]);
 /** Per-entity floor below which the inner loop is guaranteed to no-op. */
 export const MIN_USEFUL_BUDGET_USD = 0.05;
 
+/**
+ * Tag flows into the snapshot filename. Reject anything that could escape
+ * the snapshot dir (path separators, traversal sequences) or cause shell /
+ * filesystem surprises. Allowlist matches typical labels: alphanumeric,
+ * dot, underscore, hyphen.
+ */
+const VALID_TAG_RE = /^[a-zA-Z0-9._-]+$/;
+export function isValidTag(tag: string): boolean {
+  return tag.length > 0 && tag.length <= 80 && VALID_TAG_RE.test(tag);
+}
+
 // ── Pure helpers (exported for tests) ───────────────────────────────────────
 
 /** Load + validate the suite YAML. Throws on schema violation. */
@@ -240,9 +251,24 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
   const snapshotDir = opts.snapshotDir ?? SNAPSHOT_DIR;
   const improver = opts.improver ?? improveSingleEntity;
 
+  if (!isValidTag(opts.tag)) {
+    throw new Error(
+      `Invalid --tag value: ${JSON.stringify(opts.tag)}. ` +
+        `Tags are interpolated into the snapshot filename and must match ${VALID_TAG_RE} (≤80 chars).`,
+    );
+  }
+
   const startedAt = new Date().toISOString();
   const all = loadSuite(suitePath);
   const supported = filterToSupportedTypes(all);
+
+  if (all.length !== supported.length) {
+    const dropped = all.filter((e) => !SUPPORTED_TYPES.has(e.type));
+    console.log(
+      `[suite] Skipping ${dropped.length} unsupported ${dropped.length === 1 ? "entry" : "entries"}: ` +
+        dropped.map((e) => `${e.slug} (${e.type})`).join(", "),
+    );
+  }
 
   const N = supported.length;
   const perEntityCap = computePerEntityCap(opts.totalBudgetUsd, N);
@@ -256,7 +282,10 @@ export async function runSuite(opts: SuiteRunOptions): Promise<SuiteSnapshot> {
       records.push(emptyRecord(entry, "skipped_budget"));
       continue;
     }
-    // Hard cap is the per-entity 2× expected; never let it exceed remaining.
+    // Per-entity soft cap: 2× the equal-share allocation. The inner loop's
+    // own budget guard runs *between* iterations, so a single iteration that
+    // overshoots the cap is allowed to complete — see `improveSingleEntity`.
+    // The post-iter warning below catches actual cap-hits.
     const entityBudget = Math.min(perEntityCap, remaining);
     console.log(
       `\n=== [${records.length + 1}/${N}] improve-entity-suite: ${entry.slug} ` +
@@ -322,6 +351,13 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
       exitCode: 1,
     };
   }
+  if (!isValidTag(tag)) {
+    return {
+      output:
+        `--tag must match ${VALID_TAG_RE} (≤80 chars). It is interpolated into the snapshot filename.`,
+      exitCode: 1,
+    };
+  }
   const totalBudgetUsd = options.budget != null ? parseFloat(options.budget as string) : 10.0;
   const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 2;
   const target = options.target != null ? parseInt(options.target as string, 10) : undefined;
@@ -333,8 +369,17 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
   if (!Number.isFinite(maxIters) || maxIters <= 0) {
     return { output: `--max-iters must be a positive integer; got ${options.maxIters}`, exitCode: 1 };
   }
+  if (target != null && (!Number.isFinite(target) || target <= 0)) {
+    return { output: `--target must be a positive integer; got ${options.target}`, exitCode: 1 };
+  }
 
-  const snapshot = await runSuite({ tag, totalBudgetUsd, maxIters, target, dryRun });
+  let snapshot;
+  try {
+    snapshot = await runSuite({ tag, totalBudgetUsd, maxIters, target, dryRun });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { output: `improve-entity-suite failed: ${msg}`, exitCode: 1 };
+  }
 
   console.log("\n=== improve-entity-suite result ===");
   console.log(`tag:                       ${snapshot.tag}`);

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -67,7 +67,7 @@ interface EntityWithType {
   [k: string]: unknown;
 }
 
-interface IterationMetrics {
+export interface IterationMetrics {
   iter: number;
   gaps_identified: number;
   sources_found: number;
@@ -85,7 +85,7 @@ interface IterationMetrics {
   duration_s: number;
 }
 
-interface ImproveResult {
+export interface ImproveResult {
   entity_slug: string;
   entity_id: string;
   entity_type: string;
@@ -96,6 +96,20 @@ interface ImproveResult {
   total_duration_s: number;
   hit_target: boolean;
   reason: string;
+}
+
+export interface ImproveOptions {
+  slug: string;
+  /** Stop when (provisions + stakeholders) ≥ target. Default 12. */
+  target?: number;
+  /** Max LLM spend in USD across all iterations. Default 2.0. */
+  budgetUsd?: number;
+  /** Max iterations. Default 3. */
+  maxIters?: number;
+  /** When true, don't write YAML back. */
+  dryRun?: boolean;
+  /** When true, suppress the per-entity result dump. Used by the suite runner. */
+  quiet?: boolean;
 }
 
 const ExtractedSchema = z.array(
@@ -603,31 +617,27 @@ async function runIteration(
 // CLI entry point
 // ──────────────────────────────────────────────────────────────────────────────
 
-export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
-  const slug = (args[0] || "").trim();
-  if (!slug) {
-    return {
-      output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N]",
-      exitCode: 1,
-    };
-  }
-  const target = options.target != null ? parseInt(options.target as string, 10) : 12;
-  const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 3;
-  const budgetUsd = options.budget != null ? parseFloat(options.budget as string) : 2.0;
-  const noWrite = !!options.dryRun;
+/**
+ * Run the closed-loop improvement on a single entity.
+ *
+ * Throws if the entity is missing from `data/entities/*.yaml` or if its type
+ * is not yet supported by the loop. The caller (CLI or suite runner) is
+ * responsible for catching and surfacing these as user-facing errors.
+ */
+export async function improveSingleEntity(opts: ImproveOptions): Promise<ImproveResult> {
+  const slug = opts.slug.trim();
+  if (!slug) throw new Error("improveSingleEntity: slug is required");
+  const target = opts.target ?? 12;
+  const maxIters = opts.maxIters ?? 3;
+  const budgetUsd = opts.budgetUsd ?? 2.0;
+  const noWrite = !!opts.dryRun;
 
   const found = findEntity(slug);
-  if (!found) {
-    return {
-      output: `Entity not found in data/entities/*.yaml: ${slug}`,
-      exitCode: 1,
-    };
-  }
+  if (!found) throw new Error(`Entity not found in data/entities/*.yaml: ${slug}`);
   if (!SUPPORTED_TYPES.has(found.entity.type)) {
-    return {
-      output: `Unsupported entity type "${found.entity.type}" for ${slug}. Supported: ${[...SUPPORTED_TYPES].join(", ")}.`,
-      exitCode: 1,
-    };
+    throw new Error(
+      `Unsupported entity type "${found.entity.type}" for ${slug}. Supported: ${[...SUPPORTED_TYPES].join(", ")}.`,
+    );
   }
 
   let entity = found.entity;
@@ -676,14 +686,35 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
     reason,
   };
 
-  // Persist run snapshot.
+  // Persist per-entity run snapshot.
   fs.mkdirSync(path.join(SNAPSHOTS, slug), { recursive: true });
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   fs.writeFileSync(path.join(SNAPSHOTS, slug, `${stamp}.json`), JSON.stringify(result, null, 2) + "\n");
 
-  console.log("\n=== improve-entity result ===");
-  console.log(JSON.stringify(result, null, 2));
-  return { output: "", exitCode: hitTarget ? 0 : 2 };
+  if (!opts.quiet) {
+    console.log("\n=== improve-entity result ===");
+    console.log(JSON.stringify(result, null, 2));
+  }
+  return result;
+}
+
+export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
+  const slug = (args[0] || "").trim();
+  if (!slug) {
+    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N]", exitCode: 1 };
+  }
+  const target = options.target != null ? parseInt(options.target as string, 10) : 12;
+  const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 3;
+  const budgetUsd = options.budget != null ? parseFloat(options.budget as string) : 2.0;
+  const noWrite = !!options.dryRun;
+
+  let result: ImproveResult;
+  try {
+    result = await improveSingleEntity({ slug, target, maxIters, budgetUsd, dryRun: noWrite });
+  } catch (err) {
+    return { output: err instanceof Error ? err.message : String(err), exitCode: 1 };
+  }
+  return { output: "", exitCode: result.hit_target ? 0 : 2 };
 }
 
 export function help(): CommandResult {

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -630,6 +630,15 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
   const target = opts.target ?? 12;
   const maxIters = opts.maxIters ?? 3;
   const budgetUsd = opts.budgetUsd ?? 2.0;
+  if (!Number.isInteger(target) || target <= 0) {
+    throw new Error(`improveSingleEntity: target must be a positive integer; got ${opts.target}`);
+  }
+  if (!Number.isInteger(maxIters) || maxIters <= 0) {
+    throw new Error(`improveSingleEntity: maxIters must be a positive integer; got ${opts.maxIters}`);
+  }
+  if (!Number.isFinite(budgetUsd) || budgetUsd <= 0) {
+    throw new Error(`improveSingleEntity: budgetUsd must be a positive number; got ${opts.budgetUsd}`);
+  }
   const noWrite = !!opts.dryRun;
 
   const found = findEntity(slug);

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -114,6 +114,7 @@ import * as qaChecksCommands from './commands/qa-checks.ts';
 import * as matrixCommands from './commands/matrix.ts';
 import * as tablebaseCommands from './commands/tablebase.ts';
 import * as improveEntityCommands from './commands/research-improve-entity.ts';
+import * as improveEntitySuiteCommands from './commands/research-improve-entity-suite.ts';
 import * as benchmarkCommands from './commands/research-benchmark.ts';
 import * as pagesCommands from './commands/pages.ts';
 import * as legislationCommands from './commands/legislation.ts';
@@ -219,6 +220,7 @@ const domains = {
   matrix: matrixCommands,
   tablebase: tablebaseCommands,
   'improve-entity': improveEntityCommands,
+  'improve-entity-suite': improveEntitySuiteCommands,
   benchmark: benchmarkCommands,
   pages: pagesCommands,
   legislation: legislationCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -102,6 +102,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'data-sources',
       'website-sources',
       'improve-entity',
+      'improve-entity-suite',
       'benchmark',
     ],
     flattened: ['tablebase'],


### PR DESCRIPTION
## Summary

Adds `pnpm crux tb improve-entity-suite --tag=<label>` (QUA-882) which orchestrates the existing `improve-entity` closed loop across every supported entity in `crux/benchmarks/entity-suite.yaml`. Pairs with `benchmark-suite --diff` (QUA-873) — this command produces the *process* metrics (verified-rate, cost, applied counts) the read-only benchmark can't see.

Refactored `research-improve-entity.ts` to expose `improveSingleEntity()` as a callable function so the suite runner drives it in-process (no CLI subprocess shelling) and tests can inject a mock improver.

## Files

| File | Change |
|---|---|
| `crux/commands/research-improve-entity.ts` | Extracted `improveSingleEntity()` from `run()`. CLI is a thin wrapper. Exported `IterationMetrics`, `ImproveResult`, new `ImproveOptions`. |
| `crux/commands/research-improve-entity-suite.ts` | New runner: `loadSuite`, `filterToSupportedTypes`, `computePerEntityCap`, `aggregateResult`, `computeAggregate`, `runSuite`, plus `isValidTag` / `median` / `p25` helpers. |
| `crux/commands/research-improve-entity-suite.test.ts` | 32 vitest cases — pure helpers + integration with mocked improver. |
| `crux/benchmarks/entity-suite.yaml` | v1 of the suite (8 policy entries). See "Caveat" below. |
| `crux/crux.mjs`, `crux/lib/groups.ts` | Wiring for `tb improve-entity-suite`. |

## Budget governance (per QUA-882 spec)

- **Total budget cap** — `--budget` (default `$10`).
- **Per-entity soft cap** = `2 × (total / N)` where `N` = supported entities. Passed as the inner loop's `--budget`. The inner-loop budget guard runs *between* iterations, so a single overshooting iter completes (matches the spec: "if an entity exceeds, skip remaining iters").
- **Halt early** — before each entity, if `remaining_budget ≤ MIN_USEFUL_BUDGET_USD` ($0.05), stop the sweep. Remaining entities are recorded as `status: "skipped_budget"`.
- **Failure isolation** — a thrown improver records `status: "failed"` with the error message; sweep continues to the next entity.

## Output

`.claude/snapshots/improve-entity-suite/<timestamp>__<tag>.json`:

```json
{
  "tag": "after-token-filter",
  "git_sha": "abc1234",
  "started_at": "...", "ended_at": "...",
  "budget_usd": 10, "per_entity_cap_usd": 2.5,
  "max_iters": 2, "dry_run": false,
  "entities": [
    {
      "slug": "fisa-702", "type": "policy", "status": "completed",
      "iterations": [...],
      "claims_proposed": 20, "claims_verified": 19, "claims_partial": 0,
      "claims_contradicted": 0, "claims_unverifiable": 1,
      "verified_rate": 0.95,
      "applied_to_yaml": 18, "cost_usd": 0.04, "duration_s": 412
    }
  ],
  "aggregate": {
    "median_verified_rate": 0.92, "p25_verified_rate": 0.85,
    "total_cost_usd": 0.31, "total_duration_s": 412,
    "entities_completed": 8, "entities_skipped_budget": 0, "entities_failed": 0
  }
}
```

## Caveat — entity-suite.yaml ownership

`crux/benchmarks/entity-suite.yaml` is canonically owned by **QUA-873** (read-only `benchmark-suite`), which is also `In Progress`. v1 of the file ships here because:

1. The runner is non-functional without it.
2. The QUA-882 acceptance criterion ("runs end-to-end on the 8-entity policy suite") cannot be satisfied otherwise.
3. The 8 entries (fisa-702, eu-ai-act, california-sb1047, nist-ai-rmf, us-executive-order, seoul-declaration, voluntary-commitments, colorado-ai-act) cover diverse policy types (federal, state, international, voluntary). All exist in `data/entities/responses.yaml`.

QUA-873 may refine the entry list / `expected_min_coverage` thresholds.

## /agent-review-pr findings addressed

- **HIGH (path traversal)**: `--tag` flowed into the snapshot filename unsanitized. Added `isValidTag()` (allowlist `/^[a-zA-Z0-9._-]+$/`, ≤80 chars) enforced in both `runSuite()` and the CLI entry.
- **HIGH (cap semantics wording)**: Comment said "Hard cap" but the inner-loop budget guard runs *between* iterations — that's soft-cap semantics and matches the spec. Comment updated to clarify; behavior unchanged.
- **MEDIUM**: `runSuite()` errors (loadSuite parse failure, etc.) now wrapped in CLI try/catch; user gets a clean exit-1 message instead of a stack trace.
- **MEDIUM**: Skipped-by-type entries now log a visible `[suite] Skipping N unsupported entries: ...` line.
- **MEDIUM**: `--target=0` rejected by the CLI.
- **LOW**: Empty-suite test now asserts the improver was never called.

## Test plan

- [x] `pnpm test crux/commands/research-improve-entity-suite.test.ts` — 32 pass (26 from initial commit + 6 from review pass)
- [x] `pnpm test crux/lib` — 4410 pass / 10 skipped (no regressions from the `improveSingleEntity` extraction)
- [x] `pnpm build` — exit 0
- [x] `pnpm crux w validate gate` — 63 checks pass (2 advisory warnings pre-existing)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — no new errors (1 pre-existing baseline error in `research-improve-entity.ts` line 401 unchanged)
- [x] `pnpm crux gh deploy-tasks detect` — none
- [x] CLI red-team: `--tag=../etc/passwd`, `--budget=-5`, `--target=0` — all rejected with clean error messages
- [x] CLI sanity: `--help`, missing `--tag`, missing `--tag=` value all produce usage messages
- [x] `/agent-review-pr` executed; HIGH+MEDIUM findings fixed in `d9d9f58`
- [x] Test fixture suites parse, filter, aggregate, and write snapshot files correctly under tmpdir

## Post-merge follow-ups

- Smoke: `pnpm crux tb improve-entity-suite --tag=baseline --budget=5 --max-iters=1 --dry-run` runs end-to-end on the 8-entity policy suite, produces a structured snapshot. (Not run in this branch — costs real LLM credits.)
- Verify the snapshot file under `.claude/snapshots/improve-entity-suite/` has the documented shape.
- Once QUA-873 ships, confirm `benchmark-suite --diff` reads the same suite YAML and the two commands compose.

## Out of scope (per QUA-882)

- The read-only `benchmark-suite` snapshot/diff commands → QUA-873.
- CI gate that auto-runs this on PRs → QUA-871.
- Non-policy entity types in the suite → QUA-876 (organization) and follow-ups.

Closes QUA-882.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `improve-entity-suite` command to run benchmark improvements across multiple configured entities in batch mode
  * Implements automatic per-entity budget allocation and resource management
  * Generates aggregated performance metrics (including verified-rate percentiles) and JSON snapshots for suite-level analysis
  * Suite configuration defined via YAML with entity slugs and coverage targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->