### PR TITLE
QUA-875: classify stakeholder positions in improve-entity claim extractor

### DIFF
--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -48,9 +48,11 @@ import {
   applyVerdictsToOrganization,
   applyVerdictsToPolicy,
   canonicalizePersonKey,
+  MIN_POSITION_CONFIDENCE,
   type ApplyResult,
   type PersonEntityResolver,
   type StakeholderEntityResolver,
+  type StakeholderPosition,
   type VerifiedVerdict,
 } from "../lib/research/apply-verdicts.ts";
 import { canonicalSlug } from "../lib/research/canonical-names.ts";
@@ -114,21 +116,48 @@ export interface ImproveOptions {
   quiet?: boolean;
 }
 
+/** Zod runtime guard for {@link StakeholderPosition}. The literal list MUST
+ *  match the type alias exported from `apply-verdicts.ts`; the
+ *  `satisfies readonly StakeholderPosition[]` assertion makes a typo a
+ *  compile error. */
+const STAKEHOLDER_POSITIONS = ["support", "oppose", "reform", "neutral"] as const satisfies readonly StakeholderPosition[];
+const StakeholderPositionSchema = z.enum(STAKEHOLDER_POSITIONS);
+
 const ExtractedSchema = z.array(
   z.object({
     targetField: z.string().min(1),
     claimText: z.string().min(1),
     proposedValue: z.string().nullable().optional(),
     displayHint: z.string().nullable().optional(),
+    position: StakeholderPositionSchema.nullable().optional(),
+    positionConfidence: z.number().min(0).max(1).nullable().optional(),
   }),
 );
 
-interface ExtractedClaim {
+export interface ExtractedClaim {
   targetField: string;
   claimText: string;
   proposedValue: string | null;
   displayHint: string | null;
+  position: StakeholderPosition | null;
+  positionConfidence: number | null;
 }
+
+/** Stem patterns (with word boundaries) to look for in source content for
+ *  each classified position. Used by the pre-filter to drop stakeholder
+ *  claims whose claimed position has no textual support in the source
+ *  (e.g. "ACLU opposes" with no "oppos*" word in the source).
+ *
+ *  Word boundaries (`\b`) prevent false positives like "neutralize"
+ *  matching "neutral" or "supportive technologies" matching "support".
+ *  These are regex source strings — the pre-filter compiles them with
+ *  the `i` flag for case-insensitive matching. */
+const POSITION_STEM_PATTERNS: Record<StakeholderPosition, string[]> = {
+  support: ["\\bsupport"],   // support, supports, supported, supporter, supporting
+  oppose: ["\\boppos"],       // oppose, opposes, opposed, opposition, opposing
+  reform: ["\\breform"],      // reform, reforms, reformer, reforming
+  neutral: ["\\bneutral\\b"], // neutral, neutrality (NOT neutralize/neutralized)
+};
 
 // ──────────────────────────────────────────────────────────────────────────────
 // YAML I/O — locate the entity's source file by scanning data/entities/
@@ -387,10 +416,20 @@ For each fact you can extract from the source that fills one of the gaps, return
 - claimText: a concise, paraphrased assertion that can be verified against the source. Avoid overly-specific dates or figures unless the source states them verbatim.
 - proposedValue: the actual value to write into YAML (a sentence for product/keyDate description / provision / stakeholder / description, a short string for billNumber/dates/etc., a date string for keyDate.*).
 - displayHint: human label for new array entries (e.g. "Claude 3.5 Sonnet", "Dario Amodei", "Founded as Anthropic PBC").
+- position (stakeholder claims ONLY): one of "support" | "oppose" | "reform" | "neutral", or null if the source does not support a confident classification. Apply these rules strictly:
+    * "support"  — the stakeholder endorses, defends, advocates for, lobbies for, or formally votes in favor of the policy. Example: a senator who introduced/co-sponsored the bill, an industry group that filed a brief in its favor.
+    * "oppose"   — the stakeholder challenges, litigates against, sues over, votes against, or publicly campaigns to repeal/strike down the policy. Example: ACLU suing the NSA over surveillance, a senator voting "no", a group filing an amicus brief against the law.
+    * "reform"   — the stakeholder accepts the policy's existence but pushes for meaningful changes (sunset provisions, narrower scope, added safeguards, additional oversight) — NOT outright repeal. Example: a coalition urging stronger warrant requirements without seeking to abolish the program.
+    * "neutral"  — the stakeholder has an oversight or implementation role with no public position, is described as merely "on-record" or "involved", or whose role is procedural. Example: a court that adjudicates cases under the policy, an executive agency that implements it.
+- positionConfidence (stakeholder claims ONLY): a number from 0 to 1 reflecting how strongly the source language supports the classification.
+    * ≥0.8 — the source uses unambiguous language ("ACLU sued", "voted in favor", "endorsed").
+    * ${MIN_POSITION_CONFIDENCE.toFixed(1)}–0.8 — strong implication (filed an amicus, joined a coalition).
+    * <${MIN_POSITION_CONFIDENCE.toFixed(1)} — return position: null. We will leave the position empty rather than guess.
 
 CRITICAL:
 - Only extract claims explicitly supported by the source.
-- Do NOT fabricate data, positions, valuations, or vote tallies.
+- Do NOT fabricate data, positions, valuations, or vote tallies. If the source doesn't clearly state a stakeholder's stance, return position: null.
+- The position word's stem must appear as a whole-word match in the source content for the classification to be valid. Required stems: "support" (matches support/supports/supporting), "oppos" (matches oppose/opposes/opposed/opposition), "reform" (matches reform/reforms/reformer), "neutral" (matches only the exact word neutral or neutrality — NOT neutralize/neutralized). If the required stem is missing, return position: null instead.
 - Prefer paraphrased claims over exact quotes; the verifier will reject claims whose specific tokens aren't in the source.
 - Return at most 8 claims per call.
 
@@ -423,25 +462,50 @@ async function extractGapClaims(
   }
 
   const cost = (inT / 1_000_000) * HAIKU_PRICING.inputPerM + (outT / 1_000_000) * HAIKU_PRICING.outputPerM;
+  return { claims: parseExtractedClaims(raw), cost };
+}
 
+/** Parse Haiku's JSON-array response into normalized {@link ExtractedClaim}s.
+ *  Exported for testing — handles leading/trailing prose, malformed JSON,
+ *  Zod-mismatched payloads, and the position normalization rules:
+ *  - position fields on non-stakeholder claims are stripped (Haiku occasionally
+ *    leaks them onto provision claims by mistake)
+ *  - position is nulled when no confidence was provided (a position without
+ *    any confidence signal is not useful downstream) */
+export function parseExtractedClaims(raw: string): ExtractedClaim[] {
   const match = raw.match(/\[[\s\S]*\]/);
-  if (!match) return { claims: [], cost };
+  if (!match) return [];
   let parsed: unknown;
   try {
     parsed = JSON.parse(match[0]);
   } catch {
-    return { claims: [], cost };
+    return [];
   }
   const result = ExtractedSchema.safeParse(parsed);
-  if (!result.success) return { claims: [], cost };
-  const claims: ExtractedClaim[] = result.data.map((c) => ({
-    targetField: c.targetField,
-    claimText: c.claimText,
-    proposedValue: c.proposedValue ?? null,
-    displayHint: c.displayHint ?? null,
-  }));
-  return { claims, cost };
+  if (!result.success) return [];
+  return result.data.map((c) => {
+    // Position only applies to stakeholder claims. Discard it for any other
+    // targetField — Haiku occasionally returns it on provision claims by mistake.
+    const isStakeholder = c.targetField.startsWith("stakeholder.");
+    const rawPosition = isStakeholder ? c.position ?? null : null;
+    const rawConfidence = isStakeholder ? c.positionConfidence ?? null : null;
+    // Normalize: a position without any confidence signal is not useful
+    // downstream. Carry sub-threshold confidence through — the apply step
+    // owns the threshold gate so changing one place changes both.
+    const position = rawConfidence == null && rawPosition != null ? null : rawPosition;
+    return {
+      targetField: c.targetField,
+      claimText: c.claimText,
+      proposedValue: c.proposedValue ?? null,
+      displayHint: c.displayHint ?? null,
+      position,
+      positionConfidence: rawConfidence,
+    };
+  });
 }
+
+/** Exported for testing — see {@link parseExtractedClaims}. */
+export { POSITION_STEM_PATTERNS };
 
 // ──────────────────────────────────────────────────────────────────────────────
 // One iteration of the loop
@@ -538,16 +602,32 @@ async function runIteration(
     return { entity, metrics: m };
   }
 
-  // 4. Pre-submission token filter — key by sourceUrl.
-  const preFilterInput: PreFilterClaim[] = allClaims.map((c) => ({
-    claimText: c.claimText,
-    proposedValue: c.proposedValue,
-    resourceId: c.sourceUrl,
-    sourceUrl: c.sourceUrl,
-    realResourceId: c.resourceId,
-    targetField: c.targetField,
-    displayHint: c.displayHint,
-  }));
+  // 4. Pre-submission token filter — key by sourceUrl (not resourceId).
+  const preFilterInput: PreFilterClaim[] = allClaims.map((c) => {
+    // For stakeholder claims with a classified position, require the
+    // position word's stem to appear in the source as a whole-word match
+    // (e.g. `\boppos` for oppose). This catches cases where Haiku
+    // synthesizes a position from context that doesn't actually use the
+    // position word.
+    const requiredPatterns =
+      c.targetField.startsWith("stakeholder.") && c.position
+        ? POSITION_STEM_PATTERNS[c.position]
+        : undefined;
+    return {
+      claimText: c.claimText,
+      proposedValue: c.proposedValue,
+      // Stuff sourceUrl into the resourceId slot so preFilterBatch's content
+      // lookup hits our contentByKey map (which keys on URL).
+      resourceId: c.sourceUrl,
+      sourceUrl: c.sourceUrl,
+      realResourceId: c.resourceId,
+      targetField: c.targetField,
+      displayHint: c.displayHint,
+      position: c.position,
+      positionConfidence: c.positionConfidence,
+      requiredPatterns,
+    };
+  });
   const filterResult = preFilterBatch(preFilterInput, contentByKey);
   m.claims_filtered_out = filterResult.dropped.length;
   console.log(`[iter ${iter}] pre-filter: kept ${filterResult.kept.length}, dropped ${filterResult.dropped.length}`);
@@ -626,14 +706,20 @@ async function runIteration(
     else if (status === "contradicted") m.claims_contradicted++;
     else if (status === "unverifiable") m.claims_unverifiable++;
     if (status === "verified" || status === "partial") {
+      const submitted = submittedByOrder[i] as PreFilterClaim & {
+        position?: StakeholderPosition | null;
+        positionConfidence?: number | null;
+      };
       verifiedVerdicts.push({
-        targetField: String(submittedByOrder[i].targetField ?? ""),
+        targetField: String(submitted.targetField ?? ""),
         claimText: v.claimText,
         extractedValue: v.extractedValue,
-        proposedValue: submittedByOrder[i].proposedValue as string | null | undefined,
-        sourceUrl: String(submittedByOrder[i].sourceUrl),
+        proposedValue: submitted.proposedValue as string | null | undefined,
+        sourceUrl: String(submitted.sourceUrl),
         status,
-        displayHint: (submittedByOrder[i].displayHint as string | null) ?? undefined,
+        displayHint: (submitted.displayHint as string | null) ?? undefined,
+        position: submitted.position ?? null,
+        positionConfidence: submitted.positionConfidence ?? null,
       });
     }
   }

--- a/crux/lib/research/__tests__/apply-verdicts.test.ts
+++ b/crux/lib/research/__tests__/apply-verdicts.test.ts
@@ -3,6 +3,7 @@ import {
   applyVerdictsToOrganization,
   applyVerdictsToPolicy,
   canonicalizePersonKey,
+  MIN_POSITION_CONFIDENCE,
   type VerifiedVerdict,
 } from "../apply-verdicts.ts";
 import type { OrganizationEntity, OrganizationKeyPersonObject, PolicyEntity } from "../gap-analyzer.ts";
@@ -577,5 +578,244 @@ describe("applyVerdictsToOrganization", () => {
       v({ targetField: "product.q", displayHint: "Q" }),
     ]);
     expect(JSON.stringify(entity)).toBe(before);
+  });
+});
+
+// ─── stakeholder position classification (QUA-875) ─────────────────────────
+
+const baseEntity: PolicyEntity = {
+  id: "fisa-702",
+  type: "policy",
+  title: "FISA Section 702",
+  stakeholders: [],
+};
+
+function verdict(overrides: Partial<VerifiedVerdict>): VerifiedVerdict {
+  return {
+    targetField: "stakeholder.american-civil-liberties-union",
+    claimText: "ACLU has sued the NSA over 702 surveillance.",
+    extractedValue: null,
+    proposedValue: "ACLU has challenged 702 surveillance in federal court.",
+    sourceUrl: "https://example.com/aclu-702",
+    status: "verified",
+    displayHint: "American Civil Liberties Union",
+    ...overrides,
+  };
+}
+
+describe("applyVerdictsToPolicy — stakeholder positions", () => {
+  it("applies the extractor's confident position to a new stakeholder", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ position: "oppose", positionConfidence: 0.9 }),
+    ]);
+    expect(result.applied).toEqual([
+      { targetField: "stakeholder.american-civil-liberties-union", action: "added" },
+    ]);
+    expect(result.entity.stakeholders).toHaveLength(1);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.name).toBe("American Civil Liberties Union");
+    expect(sh.position).toBe("oppose");
+    expect(sh.importance).toBe("medium");
+    expect(sh.reason).toBe("ACLU has challenged 702 surveillance in federal court.");
+  });
+
+  it("omits position entirely when extractor returns null (no 'reform' default)", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ position: null, positionConfidence: null }),
+    ]);
+    expect(result.entity.stakeholders).toHaveLength(1);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.name).toBe("American Civil Liberties Union");
+    // Critical: no fallback to "reform". The previous behavior was to set
+    // position: "reform" when unknown, which produced obviously-wrong values
+    // (NSA marked "reform"). After QUA-875 we leave it unset.
+    expect(sh.position).toBeUndefined();
+    expect("position" in sh).toBe(false);
+    expect(sh.reason).toBe("ACLU has challenged 702 surveillance in federal court.");
+  });
+
+  it("treats below-threshold confidence as no opinion (omits position)", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ position: "oppose", positionConfidence: 0.3 }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBeUndefined();
+    expect("position" in sh).toBe(false);
+  });
+
+  it("applies position at exactly the threshold", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ position: "support", positionConfidence: MIN_POSITION_CONFIDENCE }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBe("support");
+  });
+
+  it("uses extractor's value over any prior default — extractor is single source of truth", () => {
+    // Acceptance criterion 3: "position mismatched between extractor and apply-step
+    // → take extractor's value". The legacy code unconditionally wrote "reform";
+    // the new code writes whatever the extractor (with confidence) classified,
+    // even when that classification differs from the old hardcoded default.
+    const cases: Array<{ pos: "support" | "oppose" | "reform" | "neutral"; expected: string }> = [
+      { pos: "support", expected: "support" },
+      { pos: "oppose", expected: "oppose" },
+      { pos: "neutral", expected: "neutral" },
+      { pos: "reform", expected: "reform" },
+    ];
+    for (const c of cases) {
+      const result = applyVerdictsToPolicy(baseEntity, [
+        verdict({
+          targetField: `stakeholder.test-${c.pos}`,
+          displayHint: `Test ${c.pos}`,
+          position: c.pos,
+          positionConfidence: 0.9,
+        }),
+      ]);
+      const sh = result.entity.stakeholders![0];
+      expect(sh.position).toBe(c.expected);
+    }
+  });
+
+  it("backfills position on an existing stakeholder that has no position set", () => {
+    const seeded: PolicyEntity = {
+      ...baseEntity,
+      stakeholders: [
+        {
+          name: "American Civil Liberties Union",
+          importance: "medium",
+          reason: "short",
+        },
+      ],
+    };
+    const result = applyVerdictsToPolicy(seeded, [
+      verdict({ position: "oppose", positionConfidence: 0.9 }),
+    ]);
+    expect(result.entity.stakeholders).toHaveLength(1);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBe("oppose");
+    // The reason was shorter than the new value, so it gets updated.
+    expect(sh.reason).toBe("ACLU has challenged 702 surveillance in federal court.");
+  });
+
+  it("backfills position even when existing reason is LONGER than new value", () => {
+    // QUA-875 hostile-review HIGH #1: position backfill must not be gated on
+    // reason replacement. If the existing reason is longer, we skip the reason
+    // update — but a missing position should still be filled in when the
+    // extractor is confident. Otherwise high-confidence positions are silently
+    // discarded for any stakeholder that already has a thorough description.
+    const seeded: PolicyEntity = {
+      ...baseEntity,
+      stakeholders: [
+        {
+          name: "American Civil Liberties Union",
+          importance: "medium",
+          reason:
+            "A long, detailed, human-curated reason that exceeds anything the new verdict will say. Lots of context, history, and references. Already comprehensive and not in need of replacement.",
+          // No position field — eligible for backfill.
+        },
+      ],
+    };
+    const result = applyVerdictsToPolicy(seeded, [
+      verdict({ position: "oppose", positionConfidence: 0.9 }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    // Reason is preserved (it was longer)
+    expect(sh.reason).toMatch(/^A long, detailed/);
+    // Position IS backfilled even though reason wasn't replaced
+    expect(sh.position).toBe("oppose");
+  });
+
+  it("does NOT overwrite a curated position with a less-confident guess", () => {
+    const seeded: PolicyEntity = {
+      ...baseEntity,
+      stakeholders: [
+        {
+          name: "American Civil Liberties Union",
+          position: "oppose", // Human-curated
+          importance: "medium",
+          reason: "short",
+        },
+      ],
+    };
+    // Even with high confidence, the existing position wins. The apply step
+    // never overwrites a position field that was already set.
+    const result = applyVerdictsToPolicy(seeded, [
+      verdict({ position: "support", positionConfidence: 0.95 }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBe("oppose");
+  });
+
+  it("does not write position on existing stakeholder when extractor is below threshold", () => {
+    const seeded: PolicyEntity = {
+      ...baseEntity,
+      stakeholders: [
+        {
+          name: "American Civil Liberties Union",
+          importance: "medium",
+          reason: "short",
+        },
+      ],
+    };
+    const result = applyVerdictsToPolicy(seeded, [
+      verdict({ position: "oppose", positionConfidence: 0.4 }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBeUndefined();
+  });
+
+  it("ignores position fields on non-stakeholder verdicts", () => {
+    // Defense-in-depth: even if position somehow leaks onto a provision verdict,
+    // it must not affect the provision branch.
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({
+        targetField: "provision.targeting-non-us-persons",
+        displayHint: "Targeting Non-US Persons",
+        proposedValue: "Authorizes targeting non-US persons abroad.",
+        position: "oppose",
+        positionConfidence: 0.9,
+      }),
+    ]);
+    expect(result.entity.provisions).toHaveLength(1);
+    expect(result.entity.stakeholders).toEqual([]);
+    const prov = result.entity.provisions![0];
+    expect(prov.title).toBe("Targeting Non-US Persons");
+    // Provisions don't have a position field; this is just a sanity check.
+    expect("position" in prov).toBe(false);
+  });
+
+  it("only applies verdicts with verified or partial status", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ status: "contradicted", position: "oppose", positionConfidence: 0.9 }),
+      verdict({ status: "unverifiable", position: "support", positionConfidence: 0.9 }),
+    ]);
+    expect(result.entity.stakeholders).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+
+  it("handles partial verdicts the same as verified", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({ status: "partial", position: "oppose", positionConfidence: 0.9 }),
+    ]);
+    const sh = result.entity.stakeholders![0];
+    expect(sh.position).toBe("oppose");
+  });
+
+  it("preserves stakeholder order across multiple verdicts", () => {
+    const result = applyVerdictsToPolicy(baseEntity, [
+      verdict({
+        targetField: "stakeholder.nsa",
+        displayHint: "National Security Agency",
+        position: "support",
+        positionConfidence: 0.9,
+      }),
+      verdict({
+        targetField: "stakeholder.american-civil-liberties-union",
+        displayHint: "ACLU",
+        position: "oppose",
+        positionConfidence: 0.9,
+      }),
+    ]);
+    expect(result.entity.stakeholders!.map((s) => s.position)).toEqual(["support", "oppose"]);
   });
 });

--- a/crux/lib/research/__tests__/extracted-claims-pipeline.test.ts
+++ b/crux/lib/research/__tests__/extracted-claims-pipeline.test.ts
@@ -1,0 +1,231 @@
+// Integration test: the position pipeline — extractor JSON → parsed claim →
+// pre-filter (with position-stem requirement) → submitted batch → verdict →
+// applied YAML. Each layer has its own unit tests; this test wires them
+// together to verify the plumbing. See QUA-875.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  parseExtractedClaims,
+  POSITION_STEM_PATTERNS,
+  type ExtractedClaim,
+} from "../../../commands/research-improve-entity.ts";
+import { preFilterBatch, type PreFilterClaim } from "../pre-filter.ts";
+import {
+  applyVerdictsToPolicy,
+  type VerifiedVerdict,
+} from "../apply-verdicts.ts";
+import type { PolicyEntity } from "../gap-analyzer.ts";
+
+const baseEntity: PolicyEntity = {
+  id: "fisa-702",
+  type: "policy",
+  title: "FISA Section 702",
+  stakeholders: [],
+};
+
+/** Build a Haiku-style JSON response from an array of claim objects. The
+ *  extractor's parse logic is tolerant of leading/trailing prose. */
+function fakeHaikuOutput(claims: unknown[]): string {
+  return `Here are the extracted claims:\n${JSON.stringify(claims, null, 2)}\n`;
+}
+
+/** Mirror the runIteration plumbing that turns parsed claims into pre-filter
+ *  inputs. Lifted into the test so we exercise the real shape. */
+function toPreFilterInput(c: ExtractedClaim): PreFilterClaim {
+  const requiredPatterns =
+    c.targetField.startsWith("stakeholder.") && c.position
+      ? POSITION_STEM_PATTERNS[c.position]
+      : undefined;
+  return {
+    claimText: c.claimText,
+    proposedValue: c.proposedValue,
+    resourceId: "u1",
+    sourceUrl: "u1",
+    targetField: c.targetField,
+    displayHint: c.displayHint,
+    position: c.position,
+    positionConfidence: c.positionConfidence,
+    requiredPatterns,
+  };
+}
+
+/** Mirror the verdict-construction at the apply boundary. */
+function toVerifiedVerdict(claim: PreFilterClaim, status: string = "verified"): VerifiedVerdict {
+  const c = claim as PreFilterClaim & {
+    position?: VerifiedVerdict["position"];
+    positionConfidence?: number | null;
+  };
+  return {
+    targetField: String(c.targetField ?? ""),
+    claimText: String(c.claimText),
+    extractedValue: null,
+    proposedValue: c.proposedValue,
+    sourceUrl: String(c.sourceUrl),
+    status,
+    displayHint: (c.displayHint as string | null) ?? undefined,
+    position: c.position ?? null,
+    positionConfidence: c.positionConfidence ?? null,
+  };
+}
+
+describe("position pipeline — extractor → pre-filter → apply", () => {
+  it("end-to-end: confident position survives and lands in YAML", () => {
+    const haikuRaw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.american-civil-liberties-union",
+        claimText: "ACLU opposes Section 702 surveillance.",
+        proposedValue: "ACLU has challenged Section 702 in federal court.",
+        displayHint: "American Civil Liberties Union",
+        position: "oppose",
+        positionConfidence: 0.92,
+      },
+    ]);
+    const claims = parseExtractedClaims(haikuRaw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].position).toBe("oppose");
+    expect(claims[0].positionConfidence).toBe(0.92);
+
+    const content = new Map([
+      ["u1", "The ACLU strongly opposes the renewal of FISA Section 702 in court filings."],
+    ]);
+    const filterResult = preFilterBatch(claims.map(toPreFilterInput), content);
+    expect(filterResult.kept).toHaveLength(1);
+    expect(filterResult.dropped).toEqual([]);
+
+    const verdicts = filterResult.kept.map((c) => toVerifiedVerdict(c, "verified"));
+    const applied = applyVerdictsToPolicy(baseEntity, verdicts);
+    expect(applied.entity.stakeholders).toHaveLength(1);
+    expect(applied.entity.stakeholders![0].position).toBe("oppose");
+  });
+
+  it("end-to-end: position fabricated by Haiku is dropped at pre-filter (saves the verdict step)", () => {
+    // Haiku says "ACLU opposes" but the source content never uses the
+    // "oppose" stem. The pre-filter must drop this before submission.
+    const haikuRaw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.american-civil-liberties-union",
+        claimText: "ACLU opposes Section 702.",
+        proposedValue: "ACLU has expressed disagreement.",
+        displayHint: "ACLU",
+        position: "oppose",
+        positionConfidence: 0.85,
+      },
+    ]);
+    const claims = parseExtractedClaims(haikuRaw);
+    const sourceWithoutOppose = "The ACLU has filed multiple lawsuits regarding Section 702 surveillance practices and is actively engaged in policy advocacy.";
+    const content = new Map([["u1", sourceWithoutOppose]]);
+    const filterResult = preFilterBatch(claims.map(toPreFilterInput), content);
+
+    expect(filterResult.kept).toEqual([]);
+    expect(filterResult.dropped).toHaveLength(1);
+    expect(filterResult.dropped[0].missingRequired).toContain("\\boppos");
+  });
+
+  it("end-to-end: low-confidence position survives pre-filter but gets stripped at apply", () => {
+    // Below MIN_POSITION_CONFIDENCE (0.6) — the apply step is the second
+    // line of defense even when the source contains the stem.
+    const haikuRaw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.american-civil-liberties-union",
+        claimText: "ACLU has spoken about 702.",
+        proposedValue: "ACLU has commented on Section 702.",
+        displayHint: "ACLU",
+        position: "oppose",
+        positionConfidence: 0.4,
+      },
+    ]);
+    const claims = parseExtractedClaims(haikuRaw);
+    const content = new Map([["u1", "ACLU opposes the renewal of Section 702."]]);
+    const filterResult = preFilterBatch(claims.map(toPreFilterInput), content);
+    expect(filterResult.kept).toHaveLength(1);
+
+    const verdicts = filterResult.kept.map((c) => toVerifiedVerdict(c, "verified"));
+    const applied = applyVerdictsToPolicy(baseEntity, verdicts);
+    const sh = applied.entity.stakeholders![0];
+    expect(sh.position).toBeUndefined();
+    expect("position" in sh).toBe(false);
+  });
+
+  it("end-to-end: position on a non-stakeholder claim is stripped at parse time", () => {
+    // Haiku occasionally emits position on provision claims. The parser
+    // strips it; the apply step renders provisions without a position field.
+    const haikuRaw = fakeHaikuOutput([
+      {
+        targetField: "provision.targeting-non-us-persons",
+        claimText: "The Act authorizes targeting non-US persons abroad.",
+        proposedValue: "Authorizes targeting non-US persons abroad.",
+        displayHint: "Targeting Non-US Persons",
+        position: "oppose",       // bogus — provisions don't have positions
+        positionConfidence: 0.95,
+      },
+    ]);
+    const claims = parseExtractedClaims(haikuRaw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].position).toBeNull();
+    expect(claims[0].positionConfidence).toBeNull();
+
+    // No requiredPatterns since position was stripped — token check still
+    // applies normally.
+    const preFilterIn = toPreFilterInput(claims[0]);
+    expect(preFilterIn.requiredPatterns).toBeUndefined();
+  });
+
+  it("end-to-end: parser tolerates malformed JSON (returns empty array)", () => {
+    expect(parseExtractedClaims("not JSON at all")).toEqual([]);
+    expect(parseExtractedClaims("[ { broken")).toEqual([]);
+    expect(parseExtractedClaims("")).toEqual([]);
+  });
+
+  it("end-to-end: parser tolerates Zod-mismatched values", () => {
+    // Position not in the enum — the whole array is rejected because Zod
+    // safeParse fails on the entry. Returning [] instead of crashing is
+    // intentional: a single bad entry shouldn't lose the whole batch
+    // output, but the current implementation chooses safety over partial
+    // recovery. Lock that behavior in.
+    const raw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.aclu",
+        claimText: "ACLU stance.",
+        position: "weakly_opposes", // not in enum
+        positionConfidence: 0.9,
+      },
+    ]);
+    expect(parseExtractedClaims(raw)).toEqual([]);
+  });
+
+  it("end-to-end: Haiku omits position+confidence — claim parses with both null", () => {
+    const raw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.aclu",
+        claimText: "ACLU stance.",
+        proposedValue: "ACLU has been involved.",
+        displayHint: "ACLU",
+      },
+    ]);
+    const claims = parseExtractedClaims(raw);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].position).toBeNull();
+    expect(claims[0].positionConfidence).toBeNull();
+  });
+
+  it("end-to-end: Haiku returns position without confidence — position is nulled", () => {
+    // Defensive: a position with no confidence signal is treated as "no
+    // opinion" and downgraded to null. The apply step would null it out
+    // anyway via the threshold gate, but doing it at parse time prevents
+    // the pre-filter from setting a requiredPatterns gate based on a
+    // non-confident signal.
+    const raw = fakeHaikuOutput([
+      {
+        targetField: "stakeholder.aclu",
+        claimText: "ACLU has spoken.",
+        position: "oppose",
+        // positionConfidence missing
+      },
+    ]);
+    const claims = parseExtractedClaims(raw);
+    expect(claims[0].position).toBeNull();
+    const preFilterIn = toPreFilterInput(claims[0]);
+    expect(preFilterIn.requiredPatterns).toBeUndefined();
+  });
+});

--- a/crux/lib/research/__tests__/pre-filter.test.ts
+++ b/crux/lib/research/__tests__/pre-filter.test.ts
@@ -43,20 +43,20 @@ describe("decide — base behavior", () => {
   });
 });
 
-describe("decide — requiredTokens (QUA-875 position-stem check)", () => {
+describe("decide — requiredPatterns (QUA-875 position-stem check)", () => {
   it("drops a stakeholder claim when the position stem is absent from source", () => {
     const claim: PreFilterClaim = {
       claimText: "ACLU opposes 702 surveillance.",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["oppos"],
+      requiredPatterns: ["\\boppos"],
     };
     // Source mentions ACLU but never uses "oppose" / "opposes" / "opposition".
     const source = "The ACLU has filed multiple lawsuits regarding Section 702 surveillance practices.";
     const dec = decide(claim, source);
     expect(dec.keep).toBe(false);
-    expect(dec.missingRequired).toEqual(["oppos"]);
-    expect(dec.missing).toContain("oppos");
+    expect(dec.missingRequired).toEqual(["\\boppos"]);
+    expect(dec.missing).toContain("\\boppos");
   });
 
   it("keeps a stakeholder claim when the position stem appears in source", () => {
@@ -64,7 +64,7 @@ describe("decide — requiredTokens (QUA-875 position-stem check)", () => {
       claimText: "ACLU opposes 702 surveillance.",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["oppos"],
+      requiredPatterns: ["\\boppos"],
     };
     const source = "The ACLU strongly opposes the renewal of FISA Section 702.";
     const dec = decide(claim, source);
@@ -77,19 +77,60 @@ describe("decide — requiredTokens (QUA-875 position-stem check)", () => {
       claimText: "Group supports the law.",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["support"],
+      requiredPatterns: ["\\bsupport"],
     };
     const source = "The Group SUPPORTED renewal in 2024.";
     const dec = decide(claim, source);
     expect(dec.keep).toBe(true);
   });
 
-  it("requires ALL requiredTokens to be present (drops if any missing)", () => {
+  it("uses word boundaries to avoid false positives (neutralize ≠ neutral)", () => {
+    // Hostile-review MEDIUM #3: a security article saying "the program seeks
+    // to neutralize threats" should NOT satisfy a "neutral" position
+    // requirement.
+    const claim: PreFilterClaim = {
+      claimText: "The agency is neutral on the bill.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredPatterns: ["\\bneutral\\b"],
+    };
+    const source = "The program seeks to neutralize threats and neutralized prior attacks.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(false);
+    expect(dec.missingRequired).toContain("\\bneutral\\b");
+  });
+
+  it("matches whole-word neutral when present", () => {
+    const claim: PreFilterClaim = {
+      claimText: "The agency is neutral on the bill.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredPatterns: ["\\bneutral\\b"],
+    };
+    const source = "The agency took a neutral stance.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(true);
+  });
+
+  it("treats invalid regex source as missing (fail-closed)", () => {
+    const claim: PreFilterClaim = {
+      claimText: "ACLU opposes the law.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredPatterns: ["[unclosed"],
+    };
+    const source = "The ACLU strongly opposes the law.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(false);
+    expect(dec.missingRequired).toEqual(["[unclosed"]);
+  });
+
+  it("requires ALL requiredPatterns to be present (drops if any missing)", () => {
     const claim: PreFilterClaim = {
       claimText: "Group A and Group B both opposed.",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["group a", "missing-stem"],
+      requiredPatterns: ["\\bgroup a\\b", "missing-stem"],
     };
     const source = "Group A opposed the bill.";
     const dec = decide(claim, source);
@@ -104,19 +145,19 @@ describe("decide — requiredTokens (QUA-875 position-stem check)", () => {
       claimText: "ACLU opposes the 2008 FISA Amendments.",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["oppos"],
+      requiredPatterns: ["\\boppos"],
     };
     const source = "The 2008 FISA Amendments Act addressed surveillance issues.";
     const dec = decide(claim, source);
     expect(dec.keep).toBe(false);
   });
 
-  it("keeps a no-token claim when its required token is present", () => {
+  it("keeps a no-token claim when its required pattern is present", () => {
     const claim: PreFilterClaim = {
       claimText: "the group supports it",
       resourceId: "r1",
       sourceUrl: "https://example.com/1",
-      requiredTokens: ["support"],
+      requiredPatterns: ["\\bsupport"],
     };
     const source = "the group supports the new law";
     const dec = decide(claim, source);
@@ -131,26 +172,47 @@ describe("preFilterBatch", () => {
         claimText: "ACLU opposes the law.",
         resourceId: "u1",
         sourceUrl: "u1",
-        requiredTokens: ["oppos"],
+        requiredPatterns: ["\\boppos"],
       },
     ];
     const content = new Map([["u1", "ACLU has commented on the law."]]);
     const result = preFilterBatch(claims, content);
     expect(result.kept).toEqual([]);
     expect(result.dropped).toHaveLength(1);
-    expect(result.dropped[0].missingRequired).toEqual(["oppos"]);
+    expect(result.dropped[0].missingRequired).toEqual(["\\boppos"]);
   });
 
-  it("treats missing source content as 'cannot pre-filter, let through'", () => {
+  it("drops position-bearing claims with no source content (defensive)", () => {
+    // Hostile-review MEDIUM #2: a claim that ASKED for a position-stem check
+    // is uniquely susceptible to fabrication. If we can't verify the source
+    // content, downstream can't either — drop instead of letting through.
     const claims: PreFilterClaim[] = [
       {
-        claimText: "Some claim.",
+        claimText: "Some position-bearing claim.",
         resourceId: "missing-url",
         sourceUrl: "missing-url",
-        requiredTokens: ["oppos"],
+        requiredPatterns: ["\\boppos"],
       },
     ];
     const content = new Map<string, string>(); // empty
+    const result = preFilterBatch(claims, content);
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].missingRequired).toEqual(["\\boppos"]);
+  });
+
+  it("keeps claims without requiredPatterns when source content is missing", () => {
+    // Existing behavior: claims that don't ask for a hard match (the
+    // common case for non-stakeholder claims) still pass through to the
+    // verifier when the source content is unavailable.
+    const claims: PreFilterClaim[] = [
+      {
+        claimText: "Some ordinary claim.",
+        resourceId: "missing-url",
+        sourceUrl: "missing-url",
+      },
+    ];
+    const content = new Map<string, string>();
     const result = preFilterBatch(claims, content);
     expect(result.kept).toHaveLength(1);
     expect(result.dropped).toEqual([]);

--- a/crux/lib/research/__tests__/pre-filter.test.ts
+++ b/crux/lib/research/__tests__/pre-filter.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { decide, preFilterBatch, extractKeyTokens, type PreFilterClaim } from "../pre-filter.ts";
+
+describe("extractKeyTokens", () => {
+  it("extracts 4-digit years, long acronyms, and capitalized phrases", () => {
+    const tokens = extractKeyTokens("In 2008 the FISA Amendments Act passed.");
+    expect(tokens).toContain("2008");
+    expect(tokens).toContain("FISA");
+    // 3-char acronyms like NSA are dropped (MIN_TOKEN_LEN=4); that's by design.
+    expect(tokens).toContain("Amendments Act");
+  });
+});
+
+describe("decide — base behavior", () => {
+  const claim: PreFilterClaim = {
+    claimText: "The FISA Amendments Act of 2008 codified Section 702.",
+    proposedValue: null,
+    resourceId: "r1",
+    sourceUrl: "https://example.com/1",
+  };
+
+  it("keeps claims whose tokens hit the source content", () => {
+    const dec = decide(claim, "FISA Amendments Act of 2008 ...");
+    expect(dec.keep).toBe(true);
+    expect(dec.hits.length).toBeGreaterThan(0);
+  });
+
+  it("drops claims whose tokens are absent from source", () => {
+    const dec = decide(claim, "Some unrelated content about agriculture.");
+    expect(dec.keep).toBe(false);
+    expect(dec.missing.length).toBeGreaterThan(0);
+  });
+
+  it("keeps claims with no extractable tokens (no signal either way)", () => {
+    const noToken: PreFilterClaim = {
+      claimText: "the law is broad in scope",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+    };
+    const dec = decide(noToken, "anything goes here");
+    expect(dec.keep).toBe(true);
+    expect(dec.tokens).toEqual([]);
+  });
+});
+
+describe("decide — requiredTokens (QUA-875 position-stem check)", () => {
+  it("drops a stakeholder claim when the position stem is absent from source", () => {
+    const claim: PreFilterClaim = {
+      claimText: "ACLU opposes 702 surveillance.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["oppos"],
+    };
+    // Source mentions ACLU but never uses "oppose" / "opposes" / "opposition".
+    const source = "The ACLU has filed multiple lawsuits regarding Section 702 surveillance practices.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(false);
+    expect(dec.missingRequired).toEqual(["oppos"]);
+    expect(dec.missing).toContain("oppos");
+  });
+
+  it("keeps a stakeholder claim when the position stem appears in source", () => {
+    const claim: PreFilterClaim = {
+      claimText: "ACLU opposes 702 surveillance.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["oppos"],
+    };
+    const source = "The ACLU strongly opposes the renewal of FISA Section 702.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(true);
+    expect(dec.missingRequired).toEqual([]);
+  });
+
+  it("matches stems case-insensitively", () => {
+    const claim: PreFilterClaim = {
+      claimText: "Group supports the law.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["support"],
+    };
+    const source = "The Group SUPPORTED renewal in 2024.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(true);
+  });
+
+  it("requires ALL requiredTokens to be present (drops if any missing)", () => {
+    const claim: PreFilterClaim = {
+      claimText: "Group A and Group B both opposed.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["group a", "missing-stem"],
+    };
+    const source = "Group A opposed the bill.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(false);
+    expect(dec.missingRequired).toEqual(["missing-stem"]);
+  });
+
+  it("drops on missing required token even when other tokens hit", () => {
+    // The base token check passes (year 2008 present) but the required
+    // stem is missing — required is a hard gate.
+    const claim: PreFilterClaim = {
+      claimText: "ACLU opposes the 2008 FISA Amendments.",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["oppos"],
+    };
+    const source = "The 2008 FISA Amendments Act addressed surveillance issues.";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(false);
+  });
+
+  it("keeps a no-token claim when its required token is present", () => {
+    const claim: PreFilterClaim = {
+      claimText: "the group supports it",
+      resourceId: "r1",
+      sourceUrl: "https://example.com/1",
+      requiredTokens: ["support"],
+    };
+    const source = "the group supports the new law";
+    const dec = decide(claim, source);
+    expect(dec.keep).toBe(true);
+  });
+});
+
+describe("preFilterBatch", () => {
+  it("includes missingRequired on per-claim decisions", () => {
+    const claims: PreFilterClaim[] = [
+      {
+        claimText: "ACLU opposes the law.",
+        resourceId: "u1",
+        sourceUrl: "u1",
+        requiredTokens: ["oppos"],
+      },
+    ];
+    const content = new Map([["u1", "ACLU has commented on the law."]]);
+    const result = preFilterBatch(claims, content);
+    expect(result.kept).toEqual([]);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].missingRequired).toEqual(["oppos"]);
+  });
+
+  it("treats missing source content as 'cannot pre-filter, let through'", () => {
+    const claims: PreFilterClaim[] = [
+      {
+        claimText: "Some claim.",
+        resourceId: "missing-url",
+        sourceUrl: "missing-url",
+        requiredTokens: ["oppos"],
+      },
+    ];
+    const content = new Map<string, string>(); // empty
+    const result = preFilterBatch(claims, content);
+    expect(result.kept).toHaveLength(1);
+    expect(result.dropped).toEqual([]);
+  });
+});

--- a/crux/lib/research/apply-verdicts.ts
+++ b/crux/lib/research/apply-verdicts.ts
@@ -45,9 +45,9 @@ export interface VerifiedVerdict {
 }
 
 /** Minimum extractor confidence required to commit a position to YAML.
- *  Below this we leave the field unset rather than guessing. Mirrored in
- *  research-improve-entity.ts as MIN_POSITION_CONFIDENCE — they MUST stay
- *  in sync. */
+ *  Below this we leave the field unset rather than guessing. Imported by
+ *  research-improve-entity.ts (extractor prompt + plumbing); this file is
+ *  the single source of truth. */
 export const MIN_POSITION_CONFIDENCE = 0.6;
 
 export interface ApplyResult<T> {

--- a/crux/lib/research/apply-verdicts.ts
+++ b/crux/lib/research/apply-verdicts.ts
@@ -15,6 +15,8 @@
 import type { OrganizationEntity, OrganizationKeyPerson, PolicyEntity } from "./gap-analyzer.ts";
 import { canonicalSlug } from "./canonical-names.ts";
 
+export type StakeholderPosition = "support" | "oppose" | "reform" | "neutral";
+
 export interface VerifiedVerdict {
   /** The seed key — encodes target type + identifier. */
   targetField: string;
@@ -30,7 +32,23 @@ export interface VerifiedVerdict {
   status: string;
   /** Optional: human display name of the stakeholder/provision (for new items). */
   displayHint?: string;
+  /** For stakeholder claims: the position classified by the extractor. The
+   *  apply step is the single source of truth for what lands in YAML — the
+   *  hardcoded "reform" default is gone (QUA-875). When this is null or
+   *  positionConfidence is below MIN_POSITION_CONFIDENCE, the new
+   *  stakeholder is created with no position field, leaving it for human
+   *  curation rather than guessing. */
+  position?: StakeholderPosition | null;
+  /** 0–1 confidence from the extractor; below MIN_POSITION_CONFIDENCE the
+   *  position is treated as unset. */
+  positionConfidence?: number | null;
 }
+
+/** Minimum extractor confidence required to commit a position to YAML.
+ *  Below this we leave the field unset rather than guessing. Mirrored in
+ *  research-improve-entity.ts as MIN_POSITION_CONFIDENCE — they MUST stay
+ *  in sync. */
+export const MIN_POSITION_CONFIDENCE = 0.6;
 
 export interface ApplyResult<T> {
   entity: T;
@@ -178,41 +196,71 @@ export function applyVerdictsToPolicy(
         return c === canonFromSlug || c === canonFromName;
       };
       const existing = next.stakeholders.find((s) => matchKey(s.name));
+      // Decide whether the extractor gave us a confident-enough position to
+      // commit. Below the threshold (or if null), leave the field unset so
+      // a human can curate. The extractor is the single source of truth —
+      // the apply step never invents a default.
+      const confidentPosition: StakeholderPosition | null =
+        v.position && (v.positionConfidence ?? 0) >= MIN_POSITION_CONFIDENCE
+          ? v.position
+          : null;
       if (existing) {
-        let updated = false;
+        // Position backfill is independent of reason replacement: a long
+        // human-curated reason should still receive a missing position from
+        // a confident extractor verdict. (Hostile-review HIGH #1, QUA-875.)
+        // Never overwrite an existing position — first-write-wins by design,
+        // since YAML carries no confidence to compare against.
+        let positionBackfilled = false;
+        if (!existing.position && confidentPosition) {
+          existing.position = confidentPosition;
+          positionBackfilled = true;
+        }
+        let reasonUpdated = false;
         if (!existing.reason || existing.reason.length < value.length) {
           existing.reason = value;
           if (!existing.source) existing.source = v.sourceUrl;
-          updated = true;
+          reasonUpdated = true;
         }
         // Backfill entityId on the existing entry when a resolver is supplied.
+        let entityBackfilled = false;
         if (!existing.entityId && options.resolveStakeholderEntity) {
           const eid = options.resolveStakeholderEntity(canonFromName || canonFromSlug, name);
           if (eid) {
             existing.entityId = eid;
-            updated = true;
+            entityBackfilled = true;
           }
         }
-        applied.push({
-          targetField: tf,
-          action: updated ? "updated" : "skipped",
-          reason: updated ? undefined : "existing reason longer",
-        });
+        if (reasonUpdated) {
+          applied.push({ targetField: tf, action: "updated" });
+        } else if (positionBackfilled || entityBackfilled) {
+          const reason = positionBackfilled
+            ? entityBackfilled
+              ? "position + entityId backfilled"
+              : "position backfilled"
+            : "entityId backfilled";
+          applied.push({ targetField: tf, action: "updated", reason });
+        } else {
+          applied.push({ targetField: tf, action: "skipped", reason: "existing reason longer" });
+        }
         continue;
       }
-      // Default to position=reform when unknown — least-controversial.
-      const newEntry: NonNullable<PolicyEntity["stakeholders"]>[number] = {
+      // New stakeholder: omit `position` entirely when the extractor is
+      // unsure. The YAML field is optional; downstream consumers must
+      // tolerate stakeholders without a position. Previously this defaulted
+      // to "reform", which produced obviously-wrong values like NSA marked
+      // "reform" — see QUA-875.
+      const newStakeholder: NonNullable<PolicyEntity["stakeholders"]>[number] = {
         name,
-        position: "reform",
         importance: "medium",
         reason: value,
         source: v.sourceUrl,
       };
+      if (confidentPosition) newStakeholder.position = confidentPosition;
       if (options.resolveStakeholderEntity) {
         const eid = options.resolveStakeholderEntity(canonFromName || canonFromSlug, name);
-        if (eid) newEntry.entityId = eid;
+        if (eid) newStakeholder.entityId = eid;
       }
-      next.stakeholders.push(newEntry);
+      next.stakeholders.push(newStakeholder);
       applied.push({ targetField: tf, action: "added" });
       continue;
     }

--- a/crux/lib/research/pre-filter.ts
+++ b/crux/lib/research/pre-filter.ts
@@ -9,6 +9,11 @@ export interface PreFilterClaim {
   proposedValue?: string | null;
   resourceId: string;
   sourceUrl: string;
+  /** Tokens that MUST appear in the source content for the claim to survive
+   *  pre-filtering, regardless of whether other extracted tokens hit. Used
+   *  for stakeholder position validation: if the LLM classifies "oppose" we
+   *  require an "oppos*" stem in the source. Case-insensitive substring. */
+  requiredTokens?: string[];
   // Anything else passes through unchanged.
   [k: string]: unknown;
 }
@@ -20,10 +25,14 @@ export interface PreFilterDecision {
   keep: boolean;
   /** Tokens we extracted from claimText + proposedValue. */
   tokens: string[];
-  /** Tokens that were not found in the source content. */
+  /** Tokens that were not found in the source content. Includes both
+   *  extracted tokens and any missing requiredTokens. */
   missing: string[];
   /** Tokens that were found and their first-occurrence index. */
   hits: Array<{ token: string; idx: number }>;
+  /** When the claim was dropped because a requiredToken was missing,
+   *  this is the missing required token. Empty otherwise. */
+  missingRequired: string[];
 }
 
 const MIN_TOKEN_LEN = 4;
@@ -56,11 +65,29 @@ export function decide(
   const minHits = options.minHits ?? 1;
   const text = `${claim.claimText}\n${claim.proposedValue ?? ""}`;
   const tokens = extractKeyTokens(text);
-  if (tokens.length === 0) {
-    // No distinguishing tokens — let it through; we have no signal either way.
-    return { claim, keep: true, tokens, missing: [], hits: [] };
-  }
   const lc = sourceContent.toLowerCase();
+
+  // Required-token check — runs first because a missing required token is
+  // a hard drop regardless of how many discriminating tokens hit.
+  const required = claim.requiredTokens ?? [];
+  const missingRequired: string[] = [];
+  for (const r of required) {
+    if (!r) continue;
+    if (lc.indexOf(r.toLowerCase()) === -1) missingRequired.push(r);
+  }
+
+  if (tokens.length === 0) {
+    // No distinguishing tokens — let it through unless a required token is missing.
+    const keep = missingRequired.length === 0;
+    return {
+      claim,
+      keep,
+      tokens,
+      missing: [...missingRequired],
+      hits: [],
+      missingRequired,
+    };
+  }
   const hits: Array<{ token: string; idx: number }> = [];
   const missing: string[] = [];
   for (const t of tokens) {
@@ -68,8 +95,15 @@ export function decide(
     if (idx === -1) missing.push(t);
     else hits.push({ token: t, idx });
   }
-  const keep = hits.length >= minHits;
-  return { claim, keep, tokens, missing, hits };
+  const keep = hits.length >= minHits && missingRequired.length === 0;
+  return {
+    claim,
+    keep,
+    tokens,
+    missing: [...missing, ...missingRequired],
+    hits,
+    missingRequired,
+  };
 }
 
 /** Filter a batch of claims given a map of resourceId → fetched content. */
@@ -85,7 +119,7 @@ export function preFilterBatch(
     if (!content) {
       // No content — we can't pre-filter. Let the verifier handle it.
       const dec: PreFilterDecision = {
-        claim: c, keep: true, tokens: [], missing: [], hits: [],
+        claim: c, keep: true, tokens: [], missing: [], hits: [], missingRequired: [],
       };
       decisions.push(dec);
       kept.push(c);

--- a/crux/lib/research/pre-filter.ts
+++ b/crux/lib/research/pre-filter.ts
@@ -9,11 +9,15 @@ export interface PreFilterClaim {
   proposedValue?: string | null;
   resourceId: string;
   sourceUrl: string;
-  /** Tokens that MUST appear in the source content for the claim to survive
-   *  pre-filtering, regardless of whether other extracted tokens hit. Used
-   *  for stakeholder position validation: if the LLM classifies "oppose" we
-   *  require an "oppos*" stem in the source. Case-insensitive substring. */
-  requiredTokens?: string[];
+  /** Regex source patterns that MUST match the source content for the
+   *  claim to survive pre-filtering, regardless of whether other extracted
+   *  tokens hit. Used for stakeholder position validation: if the LLM
+   *  classifies "oppose" we require an `\boppos` stem to appear in the
+   *  source. Compiled with the `i` flag for case-insensitive matching.
+   *  Word boundaries (`\b`) are recommended to avoid false positives like
+   *  "neutralize" satisfying a "neutral" requirement. Invalid regexes are
+   *  treated as missing (claim is dropped). */
+  requiredPatterns?: string[];
   // Anything else passes through unchanged.
   [k: string]: unknown;
 }
@@ -30,8 +34,9 @@ export interface PreFilterDecision {
   missing: string[];
   /** Tokens that were found and their first-occurrence index. */
   hits: Array<{ token: string; idx: number }>;
-  /** When the claim was dropped because a requiredToken was missing,
-   *  this is the missing required token. Empty otherwise. */
+  /** When the claim was dropped because a `requiredPatterns` entry was
+   *  missing or invalid, this lists the missing pattern source strings.
+   *  Empty otherwise. */
   missingRequired: string[];
 }
 
@@ -67,13 +72,23 @@ export function decide(
   const tokens = extractKeyTokens(text);
   const lc = sourceContent.toLowerCase();
 
-  // Required-token check — runs first because a missing required token is
-  // a hard drop regardless of how many discriminating tokens hit.
-  const required = claim.requiredTokens ?? [];
+  // Required-pattern check — runs first because a missing required pattern
+  // is a hard drop regardless of how many discriminating tokens hit.
+  // Patterns are regex source strings, compiled with `i` flag. An invalid
+  // pattern is treated as missing (fail-closed: a malformed required-token
+  // requirement should never silently succeed).
+  const required = claim.requiredPatterns ?? [];
   const missingRequired: string[] = [];
   for (const r of required) {
     if (!r) continue;
-    if (lc.indexOf(r.toLowerCase()) === -1) missingRequired.push(r);
+    let re: RegExp;
+    try {
+      re = new RegExp(r, "i");
+    } catch {
+      missingRequired.push(r);
+      continue;
+    }
+    if (!re.test(sourceContent)) missingRequired.push(r);
   }
 
   if (tokens.length === 0) {
@@ -117,7 +132,26 @@ export function preFilterBatch(
   for (const c of claims) {
     const content = contentByResourceId.get(c.resourceId) ?? "";
     if (!content) {
-      // No content — we can't pre-filter. Let the verifier handle it.
+      // No content — we can't pre-filter. For most claims, let the verifier
+      // handle it. But a claim with `requiredPatterns` (e.g. a stakeholder
+      // claim with a classified position) is uniquely susceptible to
+      // fabrication: the LLM was told to ensure the position word appears
+      // in the source. If we can't verify that here, downstream can't
+      // either. Drop these defensively.
+      const requiresContent = (c.requiredPatterns ?? []).some((p) => !!p);
+      if (requiresContent) {
+        const dec: PreFilterDecision = {
+          claim: c,
+          keep: false,
+          tokens: [],
+          missing: c.requiredPatterns ?? [],
+          hits: [],
+          missingRequired: c.requiredPatterns ?? [],
+        };
+        decisions.push(dec);
+        dropped.push(dec);
+        continue;
+      }
       const dec: PreFilterDecision = {
         claim: c, keep: true, tokens: [], missing: [], hits: [], missingRequired: [],
       };


### PR DESCRIPTION
## Summary

Replace the hardcoded `position: "reform"` default in the closed-loop entity improver with extractor-driven classification. Haiku now classifies each stakeholder claim as `support`/`oppose`/`reform`/`neutral` with a 0–1 confidence; the apply step writes the value when confidence ≥ 0.6 and otherwise leaves the field unset for human curation. The pre-filter now requires the position stem (`\bsupport`, `\boppos`, `\breform`, `\bneutral\b`) to appear in the source — using regex with word boundaries so "neutralize" doesn't satisfy "neutral" — before a stakeholder claim with a classified position can be submitted.

This removes the most visible v1 quality issue (NSA marked `reform`, ACLU marked `reform`) without inventing a different wrong default.

## What changed

- **Extractor** (`crux/commands/research-improve-entity.ts`): extend `ExtractedSchema` with `position` (enum) and `positionConfidence` (0–1). `StakeholderPosition` is the single literal-list source of truth (lives in `apply-verdicts.ts`); the Zod enum is built via `satisfies readonly StakeholderPosition[]` so a typo is a compile error. Prompt spells out classification rules with concrete examples and instructs Haiku to ensure the position word's stem appears in source as a whole-word match. Position fields on non-stakeholder claims are stripped at parse time.
- **Apply** (`crux/lib/research/apply-verdicts.ts`): take the extractor's value as the single source of truth. New stakeholders without a confident position get **no** `position` field rather than the legacy `"reform"` default. Position backfill on existing stakeholders runs **independently** of reason replacement (the original PR had a bug where a long existing reason silently dropped the position; fixed and regression-tested). New `MIN_POSITION_CONFIDENCE = 0.6` constant is the canonical threshold and is imported by the extractor.
- **Pre-filter** (`crux/lib/research/pre-filter.ts`): new `requiredPatterns: string[]` field for hard-required source presence, compiled as case-insensitive regex with word-boundary support. Invalid regex sources are treated as missing (fail-closed). When source content is unavailable, position-bearing claims (those with `requiredPatterns`) are dropped defensively rather than waved through — they're uniquely susceptible to fabrication.
- **Tests** (37 total): `apply-verdicts.test.ts` (13) covers the apply-step semantics including the position-backfill regression. `pre-filter.test.ts` (16) covers the new requiredPatterns mechanism including word-boundary, case-insensitivity, fail-closed regex, and the no-content defensive drop. `extracted-claims-pipeline.test.ts` (8) wires parser → pre-filter → apply end-to-end and verifies fabricated positions get dropped before submission, sub-threshold positions get stripped at apply, position fields on non-stakeholder claims get stripped at parse, and the parser is tolerant of malformed JSON / Zod-mismatched payloads.

## Hostile-review findings addressed in this PR

This PR went through `/agent-review-pr` after the initial commit. The hostile-reviewer subagent surfaced 2 HIGH and 5 MEDIUM findings, all addressed in commit `dacde16b6`:

| Severity | Finding | Fix |
|---|---|---|
| HIGH | Position backfill on existing stakeholders was nested inside reason-length conditional (silent drop) | Hoisted backfill out; added regression test |
| HIGH | "MUST stay in sync" comment was factually wrong | Rewrote to reflect single-source-of-truth |
| MEDIUM | DRY: `StakeholderPosition` type was exported but never imported | Threaded through Zod enum + ExtractedClaim + POSITION_STEM_PATTERNS keys + verdict cast |
| MEDIUM | `preFilterBatch` no-content branch let position-bearing claims through | Drop defensively when content is missing |
| MEDIUM | Substring stem `neutral` matched `neutralize` | Switched to regex with word boundaries; added regression test |
| MEDIUM | No integration test for the parser → pre-filter → apply plumbing | Added 8 end-to-end tests |
| MEDIUM | "Don't overwrite curated position" comment didn't match code | Updated to "first-write-wins by design" |

## Why this is the right shape

The ticket specified putting position classification in the extractor and using it as the source of truth in the apply step. The apply step still owns the "should this land in YAML?" decision via `MIN_POSITION_CONFIDENCE`, so the threshold logic lives in one place. The pre-filter's `requiredPatterns` is a generic mechanism (not stakeholder-specific) that defends against hallucinated tokens beyond just position words — useful for future extensions.

## Out of scope (noted, not fixed)

- The `PolicyStakeholder` Zod schema in `apps/web/src/data/entity-schemas.ts` declares `position` as required with values `support|oppose|neutral|mixed`. This is descriptive-only (not enforced at build time) and already diverges from real data — `reform` rows exist because of the legacy default, and at least one `DOJ` value also slipped in. Aligning the schema is a separate concern.
- Stakeholders without a `position` field do not appear in the legislation page's `support`/`oppose`/`mixed-or-neutral` buckets. Neither did `position: "reform"` rows, so this is **not a regression** — it's the same downstream UX surface as before, with the difference that we now honestly omit the field rather than guessing wrong.

## Acceptance from the ticket

- [x] Extractor produces classified `position` + `positionConfidence` for stakeholder claims
- [x] Apply step uses the extractor's value when confidence ≥ 0.6, omits otherwise (no more `"reform"` default)
- [x] Position word's stem must appear in source for the claim to survive pre-filtering (now with word boundaries)
- [x] Tests cover position-set / position-null / extractor-as-source-of-truth scenarios + integration through the full pipeline
- [ ] Run `crux tb improve-entity fisa-702 --max-iters=1 --target=10` and visually review (not done in this PR — would consume LLM budget; the unit + integration tests cover the deterministic logic)

## Test plan
- [x] `npx vitest run --config crux/vitest.config.ts crux/lib/research/__tests__/` (37/37 pass)
- [x] `npx vitest run --config crux/vitest.config.ts` (8796/8796 pass)
- [x] `pnpm crux w validate gate --fix --no-cache` (61/61 pass, 2 advisory warnings unrelated to this change)
- [x] `npx tsc --noEmit -p crux/tsconfig.json` (only 2 pre-existing errors on lines this PR didn't touch)
- [ ] Live-run against `fisa-702` to verify ≥80% of new stakeholders have a non-null `position` (requires `--apply` and an LLM budget; recommend running once before merging the next batch of improve-entity work)

Closes QUA-875
