### PR TITLE
QUA-878: pilot — /organizations to path-based tabs

### DIFF
--- a/apps/web/e2e/organizations-path-tabs.spec.ts
+++ b/apps/web/e2e/organizations-path-tabs.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * QUA-878 — path-based tabs on /organizations/[slug].
+ *
+ * Verifies the routing-precedence claim from `tabs.test.ts`:
+ *   - bare `/organizations/<slug>/<tab-id>` → catch-all renders the tab
+ *   - `/organizations/<slug>/divisions/<div-slug>` → division detail (sub-record route wins)
+ *   - `/organizations/<slug>/data` → data sub-page (sub-record route wins)
+ *   - `/organizations/<slug>?tab=<id>` → 308 to path form
+ *   - `/organizations/<slug>/<bogus>` → 200 with "Unknown tab" notice
+ *
+ * Routing precedence is a load-bearing Next.js 15 behavior — the static-metadata
+ * tabs.test.ts unit test cannot validate it. This e2e covers the gap.
+ */
+
+test.describe("/organizations path-based tabs (QUA-878)", () => {
+  test("every tab id resolves at /organizations/<slug>/<tab>", async ({ page }) => {
+    // Probe a representative subset (full enumeration lives in the render-audit
+    // spec, QUA-879). Tabs picked to cover all six tab-groups: entity, about,
+    // business, governance, output, data.
+    const tabs = [
+      "people",
+      "timeline",
+      "divisions",
+      "funding-rounds",
+      "policy",
+      "scorecards",
+      "publications",
+      "facts",
+      "database",
+    ];
+    for (const tab of tabs) {
+      const response = await page.goto(`/organizations/anthropic/${tab}`, {
+        waitUntil: "domcontentloaded",
+      });
+      expect(response?.status(), `tab=${tab}`).toBe(200);
+
+      const activeTrigger = page.locator(
+        `[data-tab-id="${tab}"][data-state="active"]`,
+      );
+      await expect(activeTrigger, `tab=${tab} active state`).toHaveCount(1);
+    }
+  });
+
+  test("bare /organizations/<slug> renders the default Overview tab", async ({ page }) => {
+    const response = await page.goto("/organizations/anthropic", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.locator('[data-tab-id="overview"][data-state="active"]'),
+    ).toHaveCount(1);
+  });
+
+  test("legacy ?tab=<id> 308-redirects to the path form", async ({ page }) => {
+    const response = await page.goto("/organizations/anthropic?tab=people", {
+      waitUntil: "domcontentloaded",
+    });
+    // After following the 308, the final URL should be the path form.
+    expect(page.url()).toMatch(/\/organizations\/anthropic\/people/);
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.locator('[data-tab-id="people"][data-state="active"]'),
+    ).toHaveCount(1);
+  });
+
+  test("unknown tab segment renders default tab + UnknownTabNotice", async ({ page }) => {
+    const response = await page.goto(
+      "/organizations/anthropic/this-is-not-a-real-tab",
+      { waitUntil: "domcontentloaded" },
+    );
+    expect(response?.status()).toBe(200);
+    // Default tab is active.
+    await expect(
+      page.locator('[data-tab-id="overview"][data-state="active"]'),
+    ).toHaveCount(1);
+    // Notice mentions the bogus segment.
+    await expect(
+      page.getByText("this-is-not-a-real-tab", { exact: false }),
+    ).toBeVisible();
+  });
+
+  test("sub-record route /data wins over the catch-all", async ({ page }) => {
+    const response = await page.goto("/organizations/anthropic/data", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(response?.status()).toBe(200);
+    // The data sub-page renders OrgDataBody (not the tabbed shell). Heuristic:
+    // the breadcrumb suffix is "Data" and there's no Radix tablist.
+    await expect(page.getByRole("heading", { name: "Anthropic" })).toBeVisible();
+    // No path-mode tab triggers should be present (they exist only on the
+    // tabbed shell).
+    await expect(page.locator('[data-tab-id]')).toHaveCount(0);
+  });
+
+  test("sub-record route /divisions/<divSlug> wins over the catch-all", async ({ page }) => {
+    // Anthropic's "alignment" division is a stable ID for this test (from
+    // data/personnel and existing div-page.tsx routing).
+    const response = await page.goto(
+      "/organizations/anthropic/divisions/alignment",
+      { waitUntil: "domcontentloaded" },
+    );
+    expect(response?.status()).toBe(200);
+    // The division detail page has its own breadcrumbs and no path-mode tabs.
+    await expect(page.locator('[data-tab-id]')).toHaveCount(0);
+  });
+
+  test("bare /divisions (no divSlug) falls through to the catch-all", async ({ page }) => {
+    const response = await page.goto("/organizations/anthropic/divisions", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(response?.status()).toBe(200);
+    // The catch-all renders the Divisions tab as active.
+    await expect(
+      page.locator('[data-tab-id="divisions"][data-state="active"]'),
+    ).toHaveCount(1);
+  });
+
+  test("slug alias preserves a known tab segment in the redirect", async ({ page }) => {
+    // google-deepmind aliases to deepmind via next.config.ts. The catch-all
+    // forwards `/people` so the deep link resolves to the canonical org's
+    // People tab.
+    await page.goto("/organizations/google-deepmind/people", {
+      waitUntil: "domcontentloaded",
+    });
+    expect(page.url()).toMatch(/\/organizations\/deepmind\/people$/);
+    await expect(
+      page.locator('[data-tab-id="people"][data-state="active"]'),
+    ).toHaveCount(1);
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -485,9 +485,14 @@ const nextConfig: NextConfig = {
       // /organizations only — other directories still use query-mode tabs and
       // would 404 if redirected to a path that doesn't exist yet. The sweep
       // ticket (QUA-880) broadens this to the remaining 14 directories.
+      //
+      // The regex `[a-z0-9-]+` matches the tab-id format used by `ORG_TAB_IDS`
+      // (kebab-case, lowercase, no slashes). A permissive `.+` would let
+      // attacker-controlled values like `..`, `foo/bar`, or `%2F` flow into
+      // the redirect destination.
       {
         source: "/organizations/:slug",
-        has: [{ type: "query", key: "tab", value: "(?<tab>.+)" }],
+        has: [{ type: "query", key: "tab", value: "(?<tab>[a-z0-9-]+)" }],
         destination: "/organizations/:slug/:tab",
         permanent: true,
       },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -480,6 +480,17 @@ const nextConfig: NextConfig = {
         destination: "/benchmarks/browsecomp",
         permanent: true,
       },
+      // QUA-878: Legacy `?tab=<id>` URLs on /organizations/<slug> redirect to
+      // the path-based form (`/organizations/<slug>/<id>`). Scoped to
+      // /organizations only — other directories still use query-mode tabs and
+      // would 404 if redirected to a path that doesn't exist yet. The sweep
+      // ticket (QUA-880) broadens this to the remaining 14 directories.
+      {
+        source: "/organizations/:slug",
+        has: [{ type: "query", key: "tab", value: "(?<tab>.+)" }],
+        destination: "/organizations/:slug/:tab",
+        permanent: true,
+      },
     ];
   },
 };

--- a/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
@@ -24,7 +24,7 @@ import {
   FactsPanel,
 } from "@/components/directory";
 
-import { buildOrgShellSlots } from "./org-profile-header";
+import { buildOrgShellSlots } from "../org-profile-header";
 import { EntityProfileShell } from "@/components/entity/EntityProfileShell";
 import {
   fetchEntitySourcingSummary,
@@ -42,7 +42,7 @@ import {
   SectionHeader,
   field,
   safeHref,
-} from "./org-shared";
+} from "../org-shared";
 
 // Data loading & constants
 import {
@@ -55,23 +55,23 @@ import {
   ORG_STATUS_LABELS,
   ORG_STATUS_COLORS,
   type OrgEntity,
-} from "./org-data";
+} from "../org-data";
 
 // Section components
 
-import { EquityPositionsSection } from "./equity-section";
-import { DivisionsSection, DivisionsOverview } from "./divisions-section";
-import { FundingProgramsSection } from "./programs-section";
-import { AiModelsSection } from "./ai-models-section";
-import { PolicyPositionsSection, getOrgPolicyPositions } from "./policy-positions-section";
+import { EquityPositionsSection } from "../equity-section";
+import { DivisionsSection, DivisionsOverview } from "../divisions-section";
+import { FundingProgramsSection } from "../programs-section";
+import { AiModelsSection } from "../ai-models-section";
+import { PolicyPositionsSection, getOrgPolicyPositions } from "../policy-positions-section";
 
 // Section components — publications
 
 // Section components — grants (main content column)
-import { GrantsSection } from "./grants-section";
+import { GrantsSection } from "../grants-section";
 
 // Section components — resources
-import { OrgResourcesSection } from "./resources-section";
+import { OrgResourcesSection } from "../resources-section";
 
 // Section components — main content column
 import {
@@ -81,10 +81,10 @@ import {
   SafetyMilestonesSection,
   StrategicPartnershipsSection,
   OtherDataSection,
-} from "./main-content-sections";
+} from "../main-content-sections";
 
 // Charts
-import { ChartsSection } from "./charts-section";
+import { ChartsSection } from "../charts-section";
 
 // People section — PG personnel data integration
 import {
@@ -93,7 +93,7 @@ import {
   mergePgPersonnel,
   PeopleSection,
   type PersonEntry,
-} from "./people-section";
+} from "../people-section";
 
 // Market data section — secondary market prices + prediction markets
 import {
@@ -102,7 +102,7 @@ import {
   getMarketDataCount,
   MarketDataSection,
   MarketHighlights,
-} from "./market-data-section";
+} from "../market-data-section";
 
 // PG grants integration — fetch grants from wiki-server for orgs that are funders
 import { fetchFromWikiServer } from "@/lib/wiki-server";
@@ -113,9 +113,13 @@ import Markdown from "react-markdown";
 import {
   loadScorecardsForEntity,
   ScorecardsSection,
-} from "./scorecards-section";
+} from "../scorecards-section";
 
-import type { ProfileTab as OrgTab, ProfileTabGroup } from "@/components/directory";
+import type { ProfileTab as OrgTab } from "@/components/directory";
+import {
+  ORG_TAB_GROUPS,
+  ORG_TAB_ICON_CLASS as ICON_CLASS,
+} from "../tabs";
 import {
   Home,
   Users,
@@ -141,28 +145,21 @@ import {
   Award,
 } from "lucide-react";
 
-const ORG_TAB_GROUPS: ProfileTabGroup[] = [
-  { id: "entity", label: "Entity" },
-  { id: "about", label: "About" },
-  { id: "business", label: "Business" },
-  { id: "governance", label: "Policy & Governance" },
-  { id: "output", label: "Output & Research" },
-  { id: "data", label: "Data" },
-];
-
-const ICON_CLASS = "w-4 h-4";
-
 // ISR revalidation: refresh PG personnel data every hour (matches divisions/grants pages)
 export const revalidate = 3600;
 
+// Pre-render the bare profile URL for every org. Tab-segment URLs (e.g.
+// `/organizations/anthropic/people`) are served via ISR — they render the
+// same DOM and only differ in the active tab styling, so pre-rendering the
+// 5,500-page Cartesian product (orgs × tabs) is wasteful.
 export function generateStaticParams() {
-  return getOrgSlugs().map((slug) => ({ slug }));
+  return getOrgSlugs().map((slug) => ({ slug, tab: undefined }));
 }
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; tab?: string[] }>;
 }): Promise<Metadata> {
   const { slug } = await params;
   const resolved = resolveOrgBySlug(slug);
@@ -187,13 +184,19 @@ export async function generateMetadata({
 export default async function OrgProfilePage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string; tab?: string[] }>;
 }) {
-  const { slug } = await params;
+  const { slug, tab } = await params;
 
   const result = resolveOrgEntity(slug);
   if (!result) return notFound();
-  if ("redirect" in result) permanentRedirect(`/organizations/${result.redirect}`);
+  if ("redirect" in result) {
+    // Preserve the tab segment when an org slug aliases to its canonical
+    // form so deep links (e.g. /organizations/google-deepmind/people) keep
+    // pointing at the same tab after the redirect.
+    const tabSuffix = tab && tab.length > 0 ? `/${tab.join("/")}` : "";
+    permanentRedirect(`/organizations/${result.redirect}${tabSuffix}`);
+  }
 
   const { entity } = result;
   const data = loadOrgPageData(entity, slug);
@@ -960,6 +963,7 @@ export default async function OrgProfilePage({
       tabsAriaLabel="Organization sections"
       tabsLayout="vertical"
       tabGroups={ORG_TAB_GROUPS}
+      tabRouting={{ mode: "path", basePath: `/organizations/${slug}` }}
     />
   );
 }

--- a/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
+++ b/apps/web/src/app/organizations/[slug]/[[...tab]]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
+import { ORG_TAB_IDS } from "../tabs";
 import { resolveOrgBySlug, getOrgSlugs } from "@/app/organizations/org-utils";
 import { getTypedEntityById, getTypedEntityByStableId, getTypedEntities, isOrganization, isProject } from "@/data";
 
@@ -116,10 +117,12 @@ import {
 } from "../scorecards-section";
 
 import type { ProfileTab as OrgTab } from "@/components/directory";
-import {
-  ORG_TAB_GROUPS,
-  ORG_TAB_ICON_CLASS as ICON_CLASS,
-} from "../tabs";
+import { ORG_TAB_GROUPS, ORG_TAB_ICON_CLASS as ICON_CLASS } from "../tabs";
+
+// `ORG_TAB_IDS` is the canonical list of path-routable tab ids — link-tabs
+// (e.g. `wiki`, which navigates to `/wiki/E<N>`) are excluded by construction,
+// so a `Set` over the catalog is the validation surface.
+const PATH_ROUTABLE_TAB_IDS: ReadonlySet<string> = new Set(ORG_TAB_IDS);
 import {
   Home,
   Users,
@@ -153,7 +156,9 @@ export const revalidate = 3600;
 // same DOM and only differ in the active tab styling, so pre-rendering the
 // 5,500-page Cartesian product (orgs × tabs) is wasteful.
 export function generateStaticParams() {
-  return getOrgSlugs().map((slug) => ({ slug, tab: undefined }));
+  // Empty array tells Next.js "no extra path segments" for the optional
+  // catch-all — pre-renders the bare `/organizations/<slug>` URL only.
+  return getOrgSlugs().map((slug) => ({ slug, tab: [] as string[] }));
 }
 
 export async function generateMetadata({
@@ -188,13 +193,26 @@ export default async function OrgProfilePage({
 }) {
   const { slug, tab } = await params;
 
+  // Defensive: Next.js 15 always passes an array for `[[...tab]]`, but guard
+  // against unexpected shapes leaking through (e.g. middleware tampering).
+  const tabSegments: string[] = Array.isArray(tab) ? tab : [];
+
   const result = resolveOrgEntity(slug);
   if (!result) return notFound();
   if ("redirect" in result) {
-    // Preserve the tab segment when an org slug aliases to its canonical
+    // Preserve the first tab segment when an org slug aliases to its canonical
     // form so deep links (e.g. /organizations/google-deepmind/people) keep
-    // pointing at the same tab after the redirect.
-    const tabSuffix = tab && tab.length > 0 ? `/${tab.join("/")}` : "";
+    // pointing at the same tab after the redirect. Only forward known-valid
+    // tab ids — an attacker-controlled or stale segment falls back to the
+    // bare canonical URL rather than producing a redirect chain into a
+    // suspicious path. Sub-record routes (`data`, `db`, `divisions/<slug>`,
+    // `funding`, `grants/<id>`) never reach this catch-all because Next.js
+    // resolves the more-specific route first.
+    const firstSegment = tabSegments[0];
+    const tabSuffix =
+      firstSegment && PATH_ROUTABLE_TAB_IDS.has(firstSegment)
+        ? `/${firstSegment}`
+        : "";
     permanentRedirect(`/organizations/${result.redirect}${tabSuffix}`);
   }
 

--- a/apps/web/src/app/organizations/[slug]/__tests__/tabs.test.ts
+++ b/apps/web/src/app/organizations/[slug]/__tests__/tabs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORG_TAB_GROUPS,
+  ORG_TAB_IDS,
+  ORG_DEFAULT_TAB_ID,
+} from "../tabs";
+
+describe("organizations/[slug]/tabs", () => {
+  it("declares unique tab ids", () => {
+    const set = new Set(ORG_TAB_IDS);
+    expect(set.size).toBe(ORG_TAB_IDS.length);
+  });
+
+  it("includes the default tab id in the tab list", () => {
+    expect(ORG_TAB_IDS).toContain(ORG_DEFAULT_TAB_ID);
+  });
+
+  it("declares unique group ids", () => {
+    const ids = ORG_TAB_GROUPS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // QUA-878: `data`, `db`, `funding`, `grants`, `divisions` are existing
+  // sub-record routes under /organizations/[slug]/. App Router resolves more
+  // specific routes before the catch-all, so a tab id matching any of those
+  // would silently fail to route — clicking the tab would trigger the static
+  // route instead. Catch this at build time.
+  it("has no tab id that collides with an existing sub-record route", () => {
+    const subRecordRoutes = ["data", "db", "funding", "grants"];
+    for (const route of subRecordRoutes) {
+      expect(ORG_TAB_IDS).not.toContain(route);
+    }
+  });
+
+  // The `divisions` tab id intentionally matches the `divisions/[divSlug]`
+  // route, but the sub-record route requires a divSlug — bare `/divisions`
+  // falls through to the catch-all. Document that allowance here.
+  it("allows `divisions` because the sub-record route requires a divSlug", () => {
+    expect(ORG_TAB_IDS).toContain("divisions");
+  });
+});

--- a/apps/web/src/app/organizations/[slug]/__tests__/tabs.test.ts
+++ b/apps/web/src/app/organizations/[slug]/__tests__/tabs.test.ts
@@ -34,8 +34,22 @@ describe("organizations/[slug]/tabs", () => {
 
   // The `divisions` tab id intentionally matches the `divisions/[divSlug]`
   // route, but the sub-record route requires a divSlug — bare `/divisions`
-  // falls through to the catch-all. Document that allowance here.
+  // falls through to the catch-all. Document that allowance here. The actual
+  // routing precedence (bare `/divisions` → catch-all, `/divisions/<slug>` →
+  // sub-record) is verified by the Playwright e2e at
+  // `apps/web/e2e/organizations-path-tabs.spec.ts`.
   it("allows `divisions` because the sub-record route requires a divSlug", () => {
     expect(ORG_TAB_IDS).toContain("divisions");
+  });
+
+  // The `wiki` tab is rendered as a link-tab pointing at `/wiki/E<N>`. It is
+  // intentionally NOT a path-routable id — `/organizations/<slug>/wiki`
+  // would surface "Unknown tab" rather than navigating to the wiki page.
+  it("excludes `wiki` (link-tab, not path-routable)", () => {
+    expect(ORG_TAB_IDS).not.toContain("wiki");
+  });
+
+  it("declares the default tab id `overview`", () => {
+    expect(ORG_DEFAULT_TAB_ID).toBe("overview");
   });
 });

--- a/apps/web/src/app/organizations/[slug]/tabs.ts
+++ b/apps/web/src/app/organizations/[slug]/tabs.ts
@@ -24,14 +24,12 @@ export const ORG_TAB_GROUPS: ProfileTabGroup[] = [
  *   - validate-tab-routes gate check (QUA-881)
  *
  * Keep in sync with the conditional `tabs.push(...)` calls in the catch-all
- * `[[...tab]]/page.tsx` builder. The "wiki" tab is included because it's
- * mounted as a link-tab — its URL is `/wiki/E<N>` rather than a tab segment,
- * so it never appears in the path, but the id is still part of the surface
- * area.
+ * `[[...tab]]/page.tsx` builder. The "wiki" link-tab is intentionally
+ * excluded — it navigates to `/wiki/E<N>` rather than a tab segment, so
+ * `/organizations/<slug>/wiki` is not a meaningful URL.
  */
 export const ORG_TAB_IDS = [
   "overview",
-  "wiki",
   "facts",
   "database",
   "people",

--- a/apps/web/src/app/organizations/[slug]/tabs.ts
+++ b/apps/web/src/app/organizations/[slug]/tabs.ts
@@ -1,0 +1,63 @@
+import type { ProfileTabGroup } from "@/components/directory";
+
+/**
+ * Vertical-nav group metadata for the organization profile page.
+ * Order controls display order on the left rail.
+ */
+export const ORG_TAB_GROUPS: ProfileTabGroup[] = [
+  { id: "entity", label: "Entity" },
+  { id: "about", label: "About" },
+  { id: "business", label: "Business" },
+  { id: "governance", label: "Policy & Governance" },
+  { id: "output", label: "Output & Research" },
+  { id: "data", label: "Data" },
+];
+
+/**
+ * Every tab id that can appear on `/organizations/<slug>`. Tabs are rendered
+ * conditionally based on the entity's available data, but any URL using one
+ * of these segments is a valid path-routing target — the catch-all route
+ * matches it and `ProfileTabsPathMode` picks the active tab.
+ *
+ * Used for:
+ *   - Render-audit enumeration (QUA-879)
+ *   - validate-tab-routes gate check (QUA-881)
+ *
+ * Keep in sync with the conditional `tabs.push(...)` calls in the catch-all
+ * `[[...tab]]/page.tsx` builder. The "wiki" tab is included because it's
+ * mounted as a link-tab — its URL is `/wiki/E<N>` rather than a tab segment,
+ * so it never appears in the path, but the id is still part of the surface
+ * area.
+ */
+export const ORG_TAB_IDS = [
+  "overview",
+  "wiki",
+  "facts",
+  "database",
+  "people",
+  "timeline",
+  "funding-rounds",
+  "shareholders",
+  "grants-made",
+  "grants-received",
+  "funding-programs",
+  "partnerships",
+  "market-data",
+  "products",
+  "safety",
+  "publications",
+  "announcements",
+  "press",
+  "divisions",
+  "policy",
+  "scorecards",
+  "projects",
+] as const;
+
+export type OrgTabId = (typeof ORG_TAB_IDS)[number];
+
+/** Default tab when the URL is the bare `/organizations/<slug>`. */
+export const ORG_DEFAULT_TAB_ID: OrgTabId = "overview";
+
+/** Shared tailwind size class for tab icons in the vertical nav. */
+export const ORG_TAB_ICON_CLASS = "w-4 h-4";

--- a/apps/web/src/components/entity/EntityProfileShell.tsx
+++ b/apps/web/src/components/entity/EntityProfileShell.tsx
@@ -5,6 +5,7 @@ import {
   ProfileTabs,
   type ProfileTab,
   type ProfileTabGroup,
+  type TabRouting,
 } from "@/components/directory";
 import { CoveragePopover } from "@/components/coverage/CoveragePopover";
 import { SourcingDot } from "@/components/sourcing/SourcingDot";
@@ -99,6 +100,13 @@ export interface EntityProfileShellProps {
   /** Ordered group metadata for vertical tab nav. See `ProfileTabGroup`. */
   tabGroups?: ProfileTabGroup[];
   /**
+   * URL routing mode for the active tab. Defaults to `{ mode: "query" }`,
+   * which preserves the legacy `?tab=` behavior. Pass
+   * `{ mode: "path", basePath: "/organizations/anthropic" }` to read/write
+   * the active tab as a path segment after `basePath`.
+   */
+  tabRouting?: TabRouting;
+  /**
    * Body content for the main column. Used when the page has no tabs, or
    * when tabs are passed and additional content should render below them.
    */
@@ -129,6 +137,7 @@ export function EntityProfileShell({
   tabsAriaLabel = "Entity sections",
   tabsLayout = "horizontal",
   tabGroups,
+  tabRouting,
   children,
   sidebar,
 }: EntityProfileShellProps) {
@@ -137,7 +146,13 @@ export function EntityProfileShell({
 
   const horizontalBody = (
     <>
-      {hasTabs && <ProfileTabs tabs={tabs} ariaLabel={tabsAriaLabel} />}
+      {hasTabs && (
+        <ProfileTabs
+          tabs={tabs}
+          ariaLabel={tabsAriaLabel}
+          tabRouting={tabRouting}
+        />
+      )}
       {children}
     </>
   );
@@ -148,6 +163,7 @@ export function EntityProfileShell({
       ariaLabel={tabsAriaLabel}
       layout="vertical"
       groups={tabGroups}
+      tabRouting={tabRouting}
     />
   ) : null;
 


### PR DESCRIPTION
## Summary

Migrate `/organizations/[slug]` to a catch-all route with path-based tabs.
Establishes the per-directory pattern that the sweep ticket (QUA-880) replicates
across the remaining 14 directories.

- Move `[slug]/page.tsx` → `[slug]/[[...tab]]/page.tsx`
- New `tabs.ts` exports `ORG_TAB_GROUPS`, `ORG_TAB_IDS`, `ORG_DEFAULT_TAB_ID` for routing validation reuse (QUA-879/881)
- `EntityProfileShell` forwards a `tabRouting` prop to `ProfileTabs` (horizontal + vertical)
- `next.config.ts`: 308 redirect `/organizations/:slug?tab=:tab` → `/organizations/:slug/:tab`. Tab regex tightened to `[a-z0-9-]+` so attacker-controlled values can't flow into the redirect destination.
- Slug aliases keep their tab segment (`/google-deepmind/people` → `/deepmind/people`). Unknown tab segments fall back to the bare canonical URL.
- Sub-record routes (`data`, `db`, `divisions/[divSlug]`, `funding`, `grants/[grantId]`) keep working — App Router resolves the more-specific route first.

## Tab id audit

No collisions with sub-record routes `data`, `db`, `funding`, `grants`. The
`divisions` tab id matches the `divisions/[divSlug]` route, but the dynamic
segment requires content; bare `/divisions` falls through to the catch-all.
Codified in both `tabs.test.ts` (static metadata) and
`e2e/organizations-path-tabs.spec.ts` (actual Next.js routing precedence).

`wiki` is intentionally NOT in `ORG_TAB_IDS` — it's a link-tab pointing at
`/wiki/E<N>` and `/organizations/<slug>/wiki` is not a meaningful URL.

## Verification

Local dev (port 3022 against prod wiki-server):

- Every Anthropic tab URL → 200 with the matching tab active
- `/organizations/anthropic?tab=people` → 308 → `/organizations/anthropic/people`
- `/organizations/anthropic?tab=../malicious` → 200 (no redirect — regex blocks `..`)
- `/organizations/anthropic/totally-bogus` → 200 with `UnknownTabNotice`
- `/organizations/anthropic/data` → 200 (data sub-page, sub-record route wins)
- `/organizations/anthropic/divisions/alignment` → 200 (division detail)
- `/organizations/google-deepmind/people` → 308 → `/organizations/deepmind/people`
- `/organizations/this-org-does-not-exist` → 404

`pnpm build` succeeds; `pnpm test` 1899 passing; `pnpm crux w validate gate --fix` 67/67 checks pass; `e2e/organizations-path-tabs.spec.ts` 8/8 pass; `e2e/render-audit.spec.ts` 39/39 pass against prod.

Closes QUA-878

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm test` 1899/1899
- [x] Gate 67/67
- [x] New e2e (`organizations-path-tabs.spec.ts`) 8/8 against local dev
- [x] `render-audit.spec.ts` 39/39 against prod (no regression)
- [x] `/agent-review-pr` complete; HIGH-severity findings addressed
- [ ] CI green
- [ ] Spot-check a handful of org tabs after deploy (`/organizations/anthropic/people`, `/organizations/openai/products`, `/organizations/coefficient-giving/grants-made`)
- [ ] Confirm `/organizations/anthropic?tab=people` 308-redirects on prod
- [ ] Confirm `/organizations/google-deepmind/people` redirects to `/organizations/deepmind/people`
