### PR TITLE
QUA-788: clean up FactBase record-ref orphans + Tier 2 visibility

### DIFF
--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -70,6 +70,7 @@ import {
   syncPolicyStakeholders,
   fetchResourcesFromPG,
   fetchEntityResourceLinks,
+  fetchAllEntityStableIds,
   buildPageReferenceIndex,
   getWikiServerWarningCount,
   getSkippedDataSources,
@@ -614,8 +615,34 @@ async function main() {
     stableIdToSlug,
     byStableId: { ...byStableId },
     stableIdBySlug: { ...stableIdBySlug },
+    // pgEntityStableIds: union of YAML stableIds + Tier 2 PG-only entities.
+    // Tier 2 entities (lightweight personnel, paper authors, minor people)
+    // are stored in the PG entities table but have no YAML/MDX representation.
+    // Validators (e.g. validate-factbase-record-refs) treat refs to them as
+    // resolvable via this list, even though they aren't routable wiki pages.
+    // Populated below; falls back to YAML-only set on wiki-server failure.
+    pgEntityStableIds: [...Object.keys(byStableId)],
   };
   database.idRegistry = idRegistryOutput;
+
+  // Augment pgEntityStableIds with Tier 2 PG-only entities (QUA-788).
+  if (!CONTENT_ONLY) {
+    const pgStableIds = await fetchAllEntityStableIds();
+    if (pgStableIds && pgStableIds.length > 0) {
+      const merged = new Set(idRegistryOutput.pgEntityStableIds);
+      for (const sid of pgStableIds) merged.add(sid);
+      idRegistryOutput.pgEntityStableIds = [...merged].sort();
+      const yamlCount = Object.keys(byStableId).length;
+      const tier2Count = idRegistryOutput.pgEntityStableIds.length - yamlCount;
+      console.log(
+        `  pgEntityStableIds: ${idRegistryOutput.pgEntityStableIds.length} total (${yamlCount} YAML + ${tier2Count} Tier 2 PG-only)`,
+      );
+    } else {
+      console.log(
+        `  pgEntityStableIds: ${idRegistryOutput.pgEntityStableIds.length} (YAML only — wiki-server unavailable for Tier 2)`,
+      );
+    }
+  }
 
   // Generate MDX stubs for entities with YAML-first content
   console.log('\nGenerating MDX from YAML content...');

--- a/apps/web/scripts/build-data.mjs
+++ b/apps/web/scripts/build-data.mjs
@@ -609,40 +609,38 @@ async function main() {
       stableIdToSlug[e.stableId] = e.id;
     }
   }
+  // pgEntityStableIds: union of YAML stableIds + Tier 2 PG-only entities.
+  // Tier 2 entities (lightweight personnel, paper authors, minor people) are
+  // stored in the PG entities table but have no YAML/MDX representation.
+  // Validators (e.g. validate-factbase-record-refs) treat refs to them as
+  // resolvable via this list, even though they aren't routable wiki pages.
+  // Sorted for deterministic output across runs.
+  // Falls back to YAML-only set on wiki-server failure or content-only mode.
+  const pgStableIdSet = new Set(Object.keys(byStableId));
+  const yamlCount = pgStableIdSet.size;
+  if (!CONTENT_ONLY) {
+    const pgFetched = await fetchAllEntityStableIds();
+    if (pgFetched && pgFetched.length > 0) {
+      for (const sid of pgFetched) pgStableIdSet.add(sid);
+      const tier2Count = pgStableIdSet.size - yamlCount;
+      console.log(
+        `  pgEntityStableIds: ${pgStableIdSet.size} total (${yamlCount} YAML + ${tier2Count} Tier 2 PG-only)`,
+      );
+    } else {
+      console.log(
+        `  pgEntityStableIds: ${pgStableIdSet.size} (YAML only — wiki-server unavailable for Tier 2)`,
+      );
+    }
+  }
   const idRegistryOutput = {
     byWikiId: { ...wikiIdToSlug },
     bySlug: { ...slugToWikiId },
     stableIdToSlug,
     byStableId: { ...byStableId },
     stableIdBySlug: { ...stableIdBySlug },
-    // pgEntityStableIds: union of YAML stableIds + Tier 2 PG-only entities.
-    // Tier 2 entities (lightweight personnel, paper authors, minor people)
-    // are stored in the PG entities table but have no YAML/MDX representation.
-    // Validators (e.g. validate-factbase-record-refs) treat refs to them as
-    // resolvable via this list, even though they aren't routable wiki pages.
-    // Populated below; falls back to YAML-only set on wiki-server failure.
-    pgEntityStableIds: [...Object.keys(byStableId)],
+    pgEntityStableIds: [...pgStableIdSet].sort(),
   };
   database.idRegistry = idRegistryOutput;
-
-  // Augment pgEntityStableIds with Tier 2 PG-only entities (QUA-788).
-  if (!CONTENT_ONLY) {
-    const pgStableIds = await fetchAllEntityStableIds();
-    if (pgStableIds && pgStableIds.length > 0) {
-      const merged = new Set(idRegistryOutput.pgEntityStableIds);
-      for (const sid of pgStableIds) merged.add(sid);
-      idRegistryOutput.pgEntityStableIds = [...merged].sort();
-      const yamlCount = Object.keys(byStableId).length;
-      const tier2Count = idRegistryOutput.pgEntityStableIds.length - yamlCount;
-      console.log(
-        `  pgEntityStableIds: ${idRegistryOutput.pgEntityStableIds.length} total (${yamlCount} YAML + ${tier2Count} Tier 2 PG-only)`,
-      );
-    } else {
-      console.log(
-        `  pgEntityStableIds: ${idRegistryOutput.pgEntityStableIds.length} (YAML only — wiki-server unavailable for Tier 2)`,
-      );
-    }
-  }
 
   // Generate MDX stubs for entities with YAML-first content
   console.log('\nGenerating MDX from YAML content...');

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -1883,6 +1883,52 @@ export async function buildPageReferenceIndex() {
 }
 
 /**
+ * Fetch the set of all entity stableIds known to PG (YAML + Tier 2).
+ *
+ * The build pipeline only loads YAML+frontmatter entities into idRegistry,
+ * but FactBase records (grants, investments, personnel) reference Tier 2
+ * entities that exist only in PG. Returning this superset lets validators
+ * (e.g. validate-factbase-record-refs) recognize Tier 2 stableIds as
+ * resolvable rather than flagging them as unresolvable orphans (QUA-788).
+ *
+ * Returns null on wiki-server failure (caller falls back to YAML-only set).
+ *
+ * @returns {Promise<string[] | null>}
+ */
+export async function fetchAllEntityStableIds() {
+  const serverUrl = getServerUrl();
+  if (!serverUrl) return null;
+  const headers = buildHeaders();
+  const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
+
+  const stableIds = [];
+  const pageSize = 500;
+  let offset = 0;
+  try {
+    while (true) {
+      const url = `${serverUrl}/api/entities?limit=${pageSize}&offset=${offset}`;
+      const resp = await fetch(url, fetchOpts);
+      if (!resp.ok) {
+        logWikiServerWarning('allEntityStableIds', `HTTP ${resp.status} at offset=${offset}`);
+        return null;
+      }
+      const data = await resp.json();
+      const items = data.entities || [];
+      for (const e of items) {
+        if (e.stableId) stableIds.push(e.stableId);
+      }
+      if (items.length < pageSize) break;
+      offset += pageSize;
+      if (offset > 50_000) break; // safety bound
+    }
+  } catch (err) {
+    logWikiServerWarning('allEntityStableIds', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+  return stableIds;
+}
+
+/**
  * Fetch entity_resources from wiki-server and group by entityId.
  * Returns: { [stableId]: { authored: resourceId[], subject: resourceId[] } }
  */

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -1901,31 +1901,48 @@ export async function fetchAllEntityStableIds() {
   const headers = buildHeaders();
   const fetchOpts = { headers, signal: AbortSignal.timeout(30_000) };
 
-  const stableIds = [];
+  // Dedupe at the source — offset-based pagination + concurrent inserts can
+  // return the same row twice or skip rows. The downstream Set-merge in
+  // build-data also handles dups, but doing it here keeps the function name
+  // honest and avoids surfacing duplicate counts to callers.
+  const stableIds = new Set();
   const pageSize = 500;
+  const SAFETY_BOUND = 50_000; // hard cap — log a warning if approached
   let offset = 0;
   try {
     while (true) {
       const url = `${serverUrl}/api/entities?limit=${pageSize}&offset=${offset}`;
       const resp = await fetch(url, fetchOpts);
       if (!resp.ok) {
+        // Mid-pagination failure → return null (matches the surrounding
+        // fetchAllPages pattern). Caller falls back to the YAML-only set;
+        // partial results would be worse than nothing because validators
+        // would mis-flag late-page entities as orphans.
         logWikiServerWarning('allEntityStableIds', `HTTP ${resp.status} at offset=${offset}`);
         return null;
       }
       const data = await resp.json();
       const items = data.entities || [];
       for (const e of items) {
-        if (e.stableId) stableIds.push(e.stableId);
+        if (e.stableId) stableIds.add(e.stableId);
       }
       if (items.length < pageSize) break;
       offset += pageSize;
-      if (offset > 50_000) break; // safety bound
+      if (offset >= SAFETY_BOUND) {
+        // Loud failure — silent truncation would let validators flag
+        // legitimate Tier 2 entities as orphans with no discoverable cause.
+        logWikiServerWarning(
+          'allEntityStableIds',
+          `safety-bound ${SAFETY_BOUND} reached — entities past offset ${offset} not loaded; raise SAFETY_BOUND in fetchAllEntityStableIds`,
+        );
+        break;
+      }
     }
   } catch (err) {
     logWikiServerWarning('allEntityStableIds', err instanceof Error ? err.message : String(err));
     return null;
   }
-  return stableIds;
+  return [...stableIds];
 }
 
 /**

--- a/apps/wiki-server/src/__tests__/grants-batch-update-grantee.test.ts
+++ b/apps/wiki-server/src/__tests__/grants-batch-update-grantee.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule } from "./test-utils.js";
+
+// QUA-788 — batch-update-grantee must keep grantee_entity_id and
+// grantee_display_name consistent with grantee_id when the value changes.
+// Without resolveEntityFKs running after the UPDATE, callers (e.g. the
+// normalize-ids tool) would leave granteeEntityId pointing at the old entity
+// while granteeId pointed at a different one — exactly the failure mode that
+// produced the "lighthaven points at sid_7E2ylGl7Ug after we re-targeted to
+// lightcone-infrastructure" scenario in the QUA-788 cleanup.
+
+interface GrantRow {
+  id: string;
+  grantee_id: string | null;
+  grantee_entity_id: string | null;
+  grantee_display_name: string | null;
+}
+
+interface EntityRow {
+  id: string;
+  stable_id: string;
+  entity_type: string;
+}
+
+let grantsStore: Map<string, GrantRow>;
+let entitiesStore: Map<string, EntityRow>;
+
+function resetStores() {
+  grantsStore = new Map();
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // -- batch-update-grantee main UPDATE: SET grantee_id = v.grantee_id, ...
+  // Drizzle generates a parameterized UPDATE ... FROM (VALUES ...) AS v.
+  if (
+    q.includes("update grants") &&
+    q.includes("set grantee_id = v.grantee_id") &&
+    q.includes("from (values")
+  ) {
+    // Pairs of (id, granteeId) come in as flat params.
+    let updated = 0;
+    for (let i = 0; i < params.length; i += 2) {
+      const id = params[i] as string;
+      const granteeId = (params[i + 1] ?? null) as string | null;
+      const row = grantsStore.get(id);
+      if (!row) continue;
+      const changed = row.grantee_id !== granteeId;
+      row.grantee_id = granteeId;
+      if (changed) {
+        row.grantee_entity_id = null;
+        row.grantee_display_name = null;
+      }
+      updated++;
+    }
+    const result: unknown[] = [];
+    (result as { rowCount?: number }).rowCount = updated;
+    return result;
+  }
+
+  // -- resolveEntityFKs Step 1: SET grantee_entity_id = e.stable_id FROM entities WHERE ...
+  if (
+    q.includes("update grants t") &&
+    q.includes("set grantee_entity_id = e.stable_id") &&
+    q.includes("from entities e")
+  ) {
+    // params end with the scope IDs from sqlInList; we update only those rows.
+    const scopeIds = new Set(params.map((p) => String(p)));
+    let updated = 0;
+    for (const row of grantsStore.values()) {
+      if (!scopeIds.has(row.id)) continue;
+      if (row.grantee_entity_id !== null) continue;
+      const raw = row.grantee_id;
+      if (raw == null) continue;
+      if (raw.startsWith("new:")) continue;
+      const match = [...entitiesStore.values()].find(
+        (e) => e.stable_id === raw || e.id === raw,
+      );
+      if (match) {
+        row.grantee_entity_id = match.stable_id;
+        updated++;
+      }
+    }
+    const result: unknown[] = [];
+    (result as { rowCount?: number }).rowCount = updated;
+    return result;
+  }
+
+  // -- resolveEntityFKs Step 2: backfill display name when entityId is still null
+  if (
+    q.includes("update grants t") &&
+    q.includes("set grantee_display_name = t.grantee_id")
+  ) {
+    const scopeIds = new Set(params.map((p) => String(p)));
+    let updated = 0;
+    for (const row of grantsStore.values()) {
+      if (!scopeIds.has(row.id)) continue;
+      if (row.grantee_entity_id !== null) continue;
+      if (row.grantee_display_name !== null) continue;
+      const raw = row.grantee_id;
+      if (raw == null) continue;
+      if (raw.startsWith("sid_") || raw.startsWith("new:")) continue;
+      row.grantee_display_name = raw;
+      updated++;
+    }
+    const result: unknown[] = [];
+    (result as { rowCount?: number }).rowCount = updated;
+    return result;
+  }
+
+  // -- things UPDATE (touch updatedAt) — no-op
+  if (q.includes("update things")) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+function patchJson(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/grants/batch-update-grantee — FK consistency (QUA-788)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("re-resolves granteeEntityId after granteeId changes to a known entity", async () => {
+    // Seed: an entity for the *new* recipient
+    entitiesStore.set("conjecture", {
+      id: "conjecture",
+      stable_id: "sid_0u4J70VqFY",
+      entity_type: "organization",
+    });
+    // Grant currently points at an orphan sid (the QUA-788 cohort 1 case)
+    grantsStore.set("alKANFxGsy", {
+      id: "alKANFxGsy",
+      grantee_id: "sid_orphan_pseudo",
+      grantee_entity_id: null,
+      grantee_display_name: null,
+    });
+
+    const res = await patchJson(app, "/api/grants/batch-update-grantee", {
+      items: [{ id: "alKANFxGsy", granteeId: "sid_0u4J70VqFY" }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = grantsStore.get("alKANFxGsy")!;
+    expect(row.grantee_id).toBe("sid_0u4J70VqFY");
+    expect(row.grantee_entity_id).toBe("sid_0u4J70VqFY");
+  });
+
+  it("clears stale granteeEntityId when granteeId changes to an unknown sid", async () => {
+    // Seed: an entity that USED to be the resolved target
+    entitiesStore.set("lighthaven", {
+      id: "lighthaven",
+      stable_id: "sid_7E2ylGl7Ug",
+      entity_type: "organization",
+    });
+    // Grant has a stale entity_id pointing at the wrong entity
+    grantsStore.set("SWev_3EIDG", {
+      id: "SWev_3EIDG",
+      grantee_id: "sid_lighthaven",
+      grantee_entity_id: "sid_7E2ylGl7Ug",
+      grantee_display_name: null,
+    });
+
+    // Caller is re-targeting to a different sid that doesn't resolve to a
+    // seeded entity. The stale entity_id MUST be cleared.
+    const res = await patchJson(app, "/api/grants/batch-update-grantee", {
+      items: [{ id: "SWev_3EIDG", granteeId: "sid_unknownSid" }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = grantsStore.get("SWev_3EIDG")!;
+    expect(row.grantee_id).toBe("sid_unknownSid");
+    expect(row.grantee_entity_id).toBe(null);
+  });
+
+  it("clears entity_id and display_name when granteeId is set to null", async () => {
+    grantsStore.set("NyBsffiZlC", {
+      id: "NyBsffiZlC",
+      grantee_id: "sid_GlobalGive",
+      grantee_entity_id: "sid_oldMatch",
+      grantee_display_name: "Old Name",
+    });
+
+    const res = await patchJson(app, "/api/grants/batch-update-grantee", {
+      items: [{ id: "NyBsffiZlC", granteeId: null }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = grantsStore.get("NyBsffiZlC")!;
+    expect(row.grantee_id).toBe(null);
+    expect(row.grantee_entity_id).toBe(null);
+    expect(row.grantee_display_name).toBe(null);
+  });
+
+  it("backfills display name when granteeId is a non-sid string", async () => {
+    grantsStore.set("someGrant1", {
+      id: "someGrant1",
+      grantee_id: null,
+      grantee_entity_id: null,
+      grantee_display_name: null,
+    });
+
+    const res = await patchJson(app, "/api/grants/batch-update-grantee", {
+      items: [{ id: "someGrant1", granteeId: "Some Display Name" }],
+    });
+    expect(res.status).toBe(200);
+
+    const row = grantsStore.get("someGrant1")!;
+    expect(row.grantee_id).toBe("Some Display Name");
+    expect(row.grantee_entity_id).toBe(null);
+    expect(row.grantee_display_name).toBe("Some Display Name");
+  });
+});

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -421,6 +421,16 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
   // link stays consistent with the new granteeId. Without this, batch updates
   // would leave granteeEntityId pointing at the old entity (or stale display
   // name) — see QUA-788 for context.
+  //
+  // FK-resolution behavior: granteeId is a legacy field that may hold either
+  // a sid_-prefixed stableId, a slug, or a display-name string (the same
+  // contract as POST /sync). resolveEntityFKs matches granteeId against
+  // entities.stable_id OR entities.id (slug); a free-text granteeId that
+  // happens to equal an entity slug (e.g. "anthropic") will silently FK to
+  // that entity. This matches /sync's behavior exactly and is intentional —
+  // callers who want a free-text display name without entity linking should
+  // pass a value that doesn't collide with any slug (in practice, slugs are
+  // kebab-case-lowercase, so any string with spaces or capitalization is safe).
   .patch("/batch-update-grantee", async (c) => {
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);

--- a/apps/wiki-server/src/routes/tablebase/grants.ts
+++ b/apps/wiki-server/src/routes/tablebase/grants.ts
@@ -28,6 +28,7 @@ import { formatEntityRef } from "../shared/entity-ref.js";
 import { InlineSourcingSchema } from "./sourcing-schema.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { shouldSkipEntityValidation } from "../shared/validate-entity-refs.js";
+import { resolveEntityFKs } from "../shared/resolve-entity-fks.js";
 import { createSyncHandler } from "./sync-factory.js";
 
 // ---- Constants ----
@@ -414,6 +415,12 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
   // ---- PATCH /batch-update-grantee ----
   // Updates granteeId for multiple grants in a single transaction.
   // Used by the backfill command to link grantees to entity stableIds.
+  //
+  // Also resets the resolved FK fields (granteeEntityId, granteeDisplayName)
+  // for the affected rows and re-runs resolveEntityFKs so the resolved entity
+  // link stays consistent with the new granteeId. Without this, batch updates
+  // would leave granteeEntityId pointing at the old entity (or stale display
+  // name) — see QUA-788 for context.
   .patch("/batch-update-grantee", async (c) => {
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
@@ -438,11 +445,38 @@ const grantsApp = new Hono<{ Variables: ResolvedEntityVars }>()
     );
 
     const result = await db.transaction(async (tx) => {
+      // Update grantee_id AND clear stale FK / display-name fields whenever
+      // the value actually changes. resolveEntityFKs (below) will re-populate
+      // them based on the new grantee_id.
       const res = await tx.execute(sql`
-        UPDATE grants SET grantee_id = v.grantee_id, updated_at = now()
+        UPDATE grants
+        SET grantee_id = v.grantee_id,
+            grantee_entity_id = CASE
+              WHEN grants.grantee_id IS DISTINCT FROM v.grantee_id THEN NULL
+              ELSE grants.grantee_entity_id
+            END,
+            grantee_display_name = CASE
+              WHEN grants.grantee_id IS DISTINCT FROM v.grantee_id THEN NULL
+              ELSE grants.grantee_display_name
+            END,
+            updated_at = now()
         FROM (VALUES ${valuesList}) AS v(id, grantee_id)
         WHERE grants.id = v.id
       `);
+
+      // Re-resolve FKs for the touched rows so granteeEntityId reflects the
+      // new granteeId. Scoped to grantIds to avoid sweeping the whole table.
+      await resolveEntityFKs(tx, {
+        tableName: "grants",
+        fields: [
+          {
+            rawIdColumn: "grantee_id",
+            entityIdColumn: "grantee_entity_id",
+            displayNameColumn: "grantee_display_name",
+          },
+        ],
+        scopeIds: grantIds,
+      });
 
       // Touch things.updatedAt for affected grants
       await tx.execute(sql`

--- a/crux/validate/validate-factbase-record-refs.test.ts
+++ b/crux/validate/validate-factbase-record-refs.test.ts
@@ -131,6 +131,26 @@ describe("buildEntityLookup", () => {
     expect(lookup.hasSid("sid_anything")).toBe(false);
     expect(lookup.hasSlug("anything")).toBe(false);
   });
+
+  // QUA-788: Tier 2 PG-only entities are surfaced via idRegistry.pgEntityStableIds
+  it("recognizes Tier 2 PG-only stableIds via pgEntityStableIds", () => {
+    const lookup = buildEntityLookup({
+      idRegistry: {
+        // Only one YAML entity in byStableId
+        byStableId: { sid_yaml000001: "yaml-entity" },
+        // pgEntityStableIds is the superset (YAML + Tier 2 PG-only)
+        pgEntityStableIds: [
+          "sid_yaml000001",
+          "sid_pgOnly0001", // Tier 2 person, no YAML
+          "sid_pgOnly0002", // Tier 2 org, no YAML
+        ],
+      },
+    });
+    expect(lookup.hasSid("sid_yaml000001")).toBe(true);
+    expect(lookup.hasSid("sid_pgOnly0001")).toBe(true);
+    expect(lookup.hasSid("sid_pgOnly0002")).toBe(true);
+    expect(lookup.hasSid("sid_notKnown01")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/crux/validate/validate-factbase-record-refs.ts
+++ b/crux/validate/validate-factbase-record-refs.ts
@@ -171,17 +171,17 @@ export function buildEntityLookup(database: {
  *         surfaces them via idRegistry.pgEntityStableIds (QUA-788).
  *       - 2 cohort 2 missing-VC sids (Kleiner Perkins, Sequoia) →
  *         display-name string written to investorId.
- *     Unresolved (kept in baseline):
+ *     Unresolved (kept in baseline) → QUA-885:
  *       - 2 investment records (7ErgqWHiQf, xEh3nQtAaD) reference companies
  *         (sid_QwuDJJ2oCQ, sid_JSTlUS21fw) that don't exist in PG entities
- *         at all — see follow-up ticket. The investorIds (sid_F1bFJHm9RA,
- *         sid_B5JzHeWvow) can't be cleaned up via /sync because the
- *         upsertThings step fails the parent_thing_id FK on the missing
- *         company. Cleanup requires either creating stub company entities
- *         + things, or deleting the records.
+ *         at all. The investorIds (sid_F1bFJHm9RA, sid_B5JzHeWvow) can't be
+ *         cleaned up via /sync because the upsertThings step fails the
+ *         parent_thing_id FK on the missing company. Cleanup requires
+ *         either creating stub company entities + things, or deleting the
+ *         records.
  */
 const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set<string>([
-  // QUA-788 follow-up: dangling-company investment records
+  // QUA-885: dangling-company investment records (parent in QUA-788)
   "sid_F1bFJHm9RA", // Khosla Ventures, in 7ErgqWHiQf (Rejuvenation Technologies — company missing from PG)
   "sid_B5JzHeWvow", // Index Ventures, in xEh3nQtAaD (Curtsy — company missing from PG)
 ]);

--- a/crux/validate/validate-factbase-record-refs.ts
+++ b/crux/validate/validate-factbase-record-refs.ts
@@ -62,6 +62,14 @@ interface IdRegistry {
   stableIdToSlug?: Record<string, string>;
   stableIdBySlug?: Record<string, string>;
   byStableId?: Record<string, string>;
+  /**
+   * Superset of all stableIds known to PG, including Tier 2 entities
+   * (lightweight personnel, paper authors, minor people) that exist only
+   * in the PG `entities` table and have no YAML/MDX representation.
+   * Populated by build-data when wiki-server is reachable. Validators use
+   * this to recognize Tier 2 refs as resolvable (QUA-788).
+   */
+  pgEntityStableIds?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +121,15 @@ export function buildEntityLookup(database: {
       stableIds.add(sid);
     }
   }
+  // Tier 2 PG-only entities (QUA-788). build-data populates this with the
+  // full set of stableIds known to PG so refs to lightweight entities
+  // (personnel, paper authors) without YAML/MDX representation resolve
+  // here too.
+  if (database.idRegistry?.pgEntityStableIds) {
+    for (const sid of database.idRegistry.pgEntityStableIds) {
+      stableIds.add(sid);
+    }
+  }
   if (database.idRegistry?.stableIdBySlug) {
     for (const slug of Object.keys(database.idRegistry.stableIdBySlug)) {
       slugs.add(slug);
@@ -140,39 +157,33 @@ export function buildEntityLookup(database: {
 /**
  * Allow specific orphan refs through as warnings; populate per QUA ticket.
  *
- * Current entries: 34 sid_ references that resurfaced after the 2026-04-13
- * baseline clear (commit aded8ac69). Tracked in QUA-459 for cleanup. Each
- * entry is an orphan that exists in prod FactBase records but has no
- * matching entity in `packages/factbase/data/fb-entities/`. Do NOT add to this
- * list without a linked ticket — new orphans are bugs, not noise.
+ * Do NOT add to this list without a linked ticket — new orphans are bugs,
+ * not noise. Each entry is an orphan that exists in prod FactBase records
+ * but has no matching entity in PG.
+ *
+ * History:
+ *   - QUA-459 / QUA-788: 23 sid_ refs from grants/investments/personnel.
+ *     Resolved (2026-04-29):
+ *       - 8 grant pseudo-sids (sid_conjecture, sid_lighthaven, etc.) →
+ *         remapped to real entity sids or nullified via `crux grants/sync`.
+ *       - 11 cohort 2/3 sids (mina-foundation, aleph, james-fox, etc.) →
+ *         these always existed in PG as Tier 2 entities; build-data now
+ *         surfaces them via idRegistry.pgEntityStableIds (QUA-788).
+ *       - 2 cohort 2 missing-VC sids (Kleiner Perkins, Sequoia) →
+ *         display-name string written to investorId.
+ *     Unresolved (kept in baseline):
+ *       - 2 investment records (7ErgqWHiQf, xEh3nQtAaD) reference companies
+ *         (sid_QwuDJJ2oCQ, sid_JSTlUS21fw) that don't exist in PG entities
+ *         at all — see follow-up ticket. The investorIds (sid_F1bFJHm9RA,
+ *         sid_B5JzHeWvow) can't be cleaned up via /sync because the
+ *         upsertThings step fails the parent_thing_id FK on the missing
+ *         company. Cleanup requires either creating stub company entities
+ *         + things, or deleting the records.
  */
 const KNOWN_BASELINE_REFS: ReadonlySet<string> = new Set<string>([
-  // Grant recipient orphans (QUA-459)
-  "sid_GlobalGive",
-  "sid_Orthogonal",
-  "sid_conjecture",
-  "sid_Kurzgesagt",
-  "sid_Futurewise",
-  "sid_lighthaven",
-  "sid_Janaagraha",
-  "sid_Exscientia",
-  // Investment investor orphans (QUA-459)
-  "sid_B5JzHeWvow",
-  "sid_dbDEGrJbUp",
-  "sid_69J7QKcqyX",
-  "sid_Kvfo7x5bqf",
-  "sid_rWgCE08sfW",
-  "sid_dzlCIZ45dZ",
-  "sid_B6ZUV8iv17",
-  "sid_F1bFJHm9RA",
-  "sid_ntlgFVJrPg",
-  "sid_oEH5GwWtow",
-  // Personnel / board-seat person orphans (QUA-459)
-  "sid_QAmTpCO5iQ",
-  "sid_t1PPwNe3x7",
-  "sid_2WGRkU8nio",
-  "sid_L0huEH4GSF",
-  "sid_PUlCEEDFup",
+  // QUA-788 follow-up: dangling-company investment records
+  "sid_F1bFJHm9RA", // Khosla Ventures, in 7ErgqWHiQf (Rejuvenation Technologies — company missing from PG)
+  "sid_B5JzHeWvow", // Index Ventures, in xEh3nQtAaD (Curtsy — company missing from PG)
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves 21 of 23 baselined orphan `sid_` refs in `validate-factbase-record-refs`, reducing the baseline from 23 entries to 2 (filed as QUA-885 follow-up).

Three coordinated changes:

1. **Tier 2 entity visibility (build-data)** — `idRegistry.pgEntityStableIds` is now populated from `/api/entities`, exposing 1,359 PG-only Tier 2 entities (lightweight personnel, paper authors, minor people) to local validators. The 11 cohort 2/3 baseline entries that referenced real PG entities (mina-foundation, aleph, james-fox, etc.) were never broken — they were just invisible.

2. **Latent `batch-update-grantee` FK consistency bug fix** — the endpoint updated `grantee_id` without re-resolving `grantee_entity_id`, leaving FKs stale. Discovered while remapping `sid_lighthaven` → `sid_47Rkb1DGmw` would have left the FK pointing at the wrong entity (lighthaven's stableId, not lightcone-infrastructure's). Endpoint now clears stale FK + display-name fields when granteeId changes and runs `resolveEntityFKs`. 4 unit tests added.

3. **Validator baseline shrunk** — `KNOWN_BASELINE_REFS` reduced from 23 entries to 2 (the QUA-885 dangling-company investments).

The actual data fixes (15 grants + 3 investments) were applied to prod separately via `/grants/sync` and `/investments/sync`. This PR contains only the supporting code changes.

## Heads-up: Protected-paths label

This PR touches `crux/validate/validate-factbase-record-refs.ts`, which is in the protected-paths list. The Protected Paths Check will fail until a reviewer applies the `gate:rules-ok` label after confirming the validator change is appropriate (shrinking the baseline from 23 → 2 entries with documentation pointing at the QUA-788/QUA-885 cleanup trail).

## Out of scope (filed as QUA-885)

Two investment records (`7ErgqWHiQf`, `xEh3nQtAaD`) reference `companyId` values that don't exist in PG entities at all. `/sync` fails with a 500 because `upsertThings` fails the FK on `parent_thing_id`. Cleanup requires either creating stub company entities or deleting the records.

## Test plan

- [x] `pnpm test grants-batch-update-grantee` — 4 new endpoint tests pass
- [x] `pnpm test validate-factbase-record-refs` — 28 tests pass (1 new test for `pgEntityStableIds`)
- [x] `pnpm test` — 8771 pass, 5 pre-existing snapshot-resources failures unrelated to this PR
- [x] `pnpm crux w validate gate` — all 65 gate checks pass (3 advisory warnings, all pre-existing)
- [x] Validator against prod — 0 errors, 2 baseline warnings (down from 23)

## Deploy Checklist
<!-- deploy-tasks:v1 -->
- [ ] `build` build-data.mjs changed — verify build-data produces correct database.json after deploy — `pnpm build-data:content && echo "Build data OK"`
<!-- /deploy-tasks -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
