### PR TITLE
QUA-887: sourcing.yml — translate table=fact to --type=fact

### DIFF
--- a/.github/workflows/sourcing.yml
+++ b/.github/workflows/sourcing.yml
@@ -15,7 +15,7 @@ on:
         default: '50'
         type: string
       table:
-        description: 'Table to check (personnel|grants|funding-rounds|divisions|funding-programs|policy-stakeholders|all)'
+        description: 'Table to check (fact|personnel|grants|funding-rounds|divisions|funding-programs|policy-stakeholders|all)'
         required: false
         default: 'all'
         type: string
@@ -74,7 +74,13 @@ jobs:
         run: |
           ARGS="--budget=${INPUT_BUDGET} --batch --verbose"
 
-          if [ "${INPUT_TABLE}" != "all" ]; then
+          # `fact` is not a record type — verify-orchestrate routes facts via
+          # --type=fact, while --table= filters records to a specific record type
+          # (personnel, grant, etc). Translating here keeps the workflow input
+          # uniform for callers (QUA-887).
+          if [ "${INPUT_TABLE}" = "fact" ]; then
+            ARGS="$ARGS --type=fact"
+          elif [ "${INPUT_TABLE}" != "all" ]; then
             ARGS="$ARGS --table=${INPUT_TABLE}"
           fi
 


### PR DESCRIPTION
## Summary

The `sourcing.yml` GitHub workflow's `table=fact` input was a silent no-op. The shell wrapper passed `--table=fact` to `crux verify-orchestrate`, where `--table=` is interpreted as a record-type filter (which implies `--type=record`). No record has type `fact`, so 0 items were collected and the run exited with `"No sourcing items found."` — never reaching fact verification.

This PR translates `INPUT_TABLE=fact` to `--type=fact` in the workflow shell, leaves existing record-type behavior intact, and adds `fact` to the input description.

## Why

Unblocks QUA-851 / QUA-852: the followup needs >90% FactBase fact source-check coverage. With this fix, `gh workflow run sourcing.yml -F table=fact -F budget=50` will run a one-shot batch (50% Anthropic discount) that source-checks the ~1,353 unverified facts in hours, not weeks.

## Behavior matrix (verified via local bash)

| `table=` input | Resulting `verify-orchestrate` args (excluding `--budget --batch --verbose`) |
|----|----|
| `fact` | `--type=fact` ← new |
| `personnel` | `--table=personnel` |
| `grants` | `--table=grants` |
| `all` | (no filter) |

The scheduled cron path is unchanged — it never passes inputs and falls through to default `'all'`.

## Test plan

- [x] Verified the bash translation logic against `fact`, `personnel`, `all`, `grants`, and empty (the workflow's input default fallback prevents the empty case).
- [ ] After merge: `gh workflow run sourcing.yml -F table=fact -F budget=50` — confirm fact items are collected and verified.
- [ ] Post-run: confirm `record_type='fact'` coverage > 90% on `/internal/source-check-coverage`, comment on QUA-852.

Fixes QUA-887.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "fact" as a supported option for the sourcing workflow dispatch input, enabling new data handling capabilities.

* **Refactor**
  * Updated workflow input handling logic to properly route different option types through appropriate processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->