### PR TITLE
Canonicalize stakeholder names in apply-verdicts (QUA-872)

### DIFF
--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -50,8 +50,10 @@ import {
   canonicalizePersonKey,
   type ApplyResult,
   type PersonEntityResolver,
+  type StakeholderEntityResolver,
   type VerifiedVerdict,
 } from "../lib/research/apply-verdicts.ts";
+import { canonicalSlug } from "../lib/research/canonical-names.ts";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const ENTITIES_DIR = path.join(ROOT, "data/entities");
@@ -213,7 +215,38 @@ async function applyVerdictsToEntity(
   verdicts: VerifiedVerdict[],
 ): Promise<ApplyResult<EntityWithType>> {
   if (entity.type === "policy") {
-    const r = applyVerdictsToPolicy(entity as unknown as PolicyEntity, verdicts);
+    // Build a stakeholder resolver from verdict displayHints. Pre-fetch entity
+    // search once per unique candidate; the resolver closure is synchronous
+    // because the applier is pure.
+    const candidateNames = new Set<string>();
+    for (const v of verdicts) {
+      if (!v.targetField.startsWith("stakeholder.")) continue;
+      const name = v.displayHint ?? v.targetField.slice("stakeholder.".length);
+      if (name) candidateNames.add(name);
+    }
+    const resolved = new Map<string, string>();
+    for (const name of candidateNames) {
+      try {
+        const sr = await searchEntities(name, 5);
+        if (!sr.ok) continue;
+        const data = sr.data as { results?: Array<{ id: string; title?: string; entityType?: string }> };
+        const results = data.results ?? [];
+        const targetCanon = canonicalSlug(name);
+        // Match if any search result's title or id canonicalizes to the same slug.
+        const match = results.find((r) => {
+          const rcanon = canonicalSlug(r.title ?? "") || canonicalSlug(r.id);
+          return rcanon === targetCanon;
+        });
+        if (match) resolved.set(targetCanon, match.id);
+      } catch {
+        // network/api error — skip cross-ref for this candidate
+      }
+    }
+    const stakeholderResolver: StakeholderEntityResolver = (canon) =>
+      resolved.get(canon) ?? null;
+    const r = applyVerdictsToPolicy(entity as unknown as PolicyEntity, verdicts, {
+      resolveStakeholderEntity: stakeholderResolver,
+    });
     return r as unknown as ApplyResult<EntityWithType>;
   }
   if (entity.type === "organization") {

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -216,8 +216,8 @@ async function applyVerdictsToEntity(
 ): Promise<ApplyResult<EntityWithType>> {
   if (entity.type === "policy") {
     // Build a stakeholder resolver from verdict displayHints. Pre-fetch entity
-    // search once per unique candidate; the resolver closure is synchronous
-    // because the applier is pure.
+    // search once per unique candidate (in parallel) — the resolver closure
+    // itself is synchronous because the applier is pure.
     const candidateNames = new Set<string>();
     for (const v of verdicts) {
       if (!v.targetField.startsWith("stakeholder.")) continue;
@@ -225,23 +225,27 @@ async function applyVerdictsToEntity(
       if (name) candidateNames.add(name);
     }
     const resolved = new Map<string, string>();
-    for (const name of candidateNames) {
-      try {
-        const sr = await searchEntities(name, 5);
-        if (!sr.ok) continue;
-        const data = sr.data as { results?: Array<{ id: string; title?: string; entityType?: string }> };
-        const results = data.results ?? [];
-        const targetCanon = canonicalSlug(name);
-        // Match if any search result's title or id canonicalizes to the same slug.
-        const match = results.find((r) => {
-          const rcanon = canonicalSlug(r.title ?? "") || canonicalSlug(r.id);
-          return rcanon === targetCanon;
-        });
-        if (match) resolved.set(targetCanon, match.id);
-      } catch {
-        // network/api error — skip cross-ref for this candidate
-      }
-    }
+    await Promise.all(
+      Array.from(candidateNames).map(async (name) => {
+        try {
+          const sr = await searchEntities(name, 5);
+          if (!sr.ok) return;
+          const data = sr.data as { results?: Array<{ id: string; title?: string; entityType?: string }> };
+          const results = data.results ?? [];
+          const targetCanon = canonicalSlug(name);
+          if (!targetCanon) return;
+          // Match if any search result's title or id canonicalizes to the same slug.
+          const match = results.find((r) => {
+            const rcanon = canonicalSlug(r.title ?? "") || canonicalSlug(r.id);
+            return rcanon === targetCanon;
+          });
+          if (match) resolved.set(targetCanon, match.id);
+        } catch (e) {
+          // network/api error — skip cross-ref for this candidate
+          void e;
+        }
+      }),
+    );
     const stakeholderResolver: StakeholderEntityResolver = (canon) =>
       resolved.get(canon) ?? null;
     const r = applyVerdictsToPolicy(entity as unknown as PolicyEntity, verdicts, {

--- a/crux/lib/research/__tests__/apply-verdicts.test.ts
+++ b/crux/lib/research/__tests__/apply-verdicts.test.ts
@@ -64,6 +64,257 @@ describe("applyVerdictsToPolicy", () => {
     expect(result.entity.billNumber).toBeUndefined();
     expect(result.applied).toEqual([]);
   });
+
+  // ─── Stakeholder canonicalization (QUA-872) ──────────────────────────────
+  describe("stakeholder canonicalization", () => {
+    it("collapses FISC and foreign-intelligence-surveillance-court targetFields", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.fisc",
+          displayHint: "Foreign Intelligence Surveillance Court (FISC)",
+          extractedValue: "Approves Section 702 targeting procedures.",
+        }),
+        v({
+          targetField: "stakeholder.foreign-intelligence-surveillance-court",
+          displayHint: "Foreign Intelligence Surveillance Court",
+          extractedValue: "Reviews FBI queries of US-person data.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(1);
+      expect(result.applied[0].action).toBe("added");
+      expect(result.applied[1].action).toMatch(/updated|skipped/);
+    });
+
+    it("collapses FBI vs Federal Bureau of Investigation vs FBI (Federal Bureau of Investigation)", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.fbi",
+          displayHint: "FBI",
+          extractedValue: "Queries Section 702 data for FBI investigations.",
+        }),
+        v({
+          targetField: "stakeholder.federal-bureau-of-investigation",
+          displayHint: "Federal Bureau of Investigation",
+          extractedValue: "A much more comprehensive description of FBI's role here.",
+        }),
+        v({
+          targetField: "stakeholder.fbi-federal-bureau-of-investigation",
+          displayHint: "FBI (Federal Bureau of Investigation)",
+          extractedValue: "Performs queries of 702 data.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(1);
+    });
+
+    it("collapses DOJ vs U.S. Department of Justice vs Department of Justice", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.doj",
+          displayHint: "DOJ",
+          extractedValue: "Oversight role in 702.",
+        }),
+        v({
+          targetField: "stakeholder.us-department-of-justice",
+          displayHint: "U.S. Department of Justice",
+          extractedValue: "Oversees compliance.",
+        }),
+        v({
+          targetField: "stakeholder.department-of-justice",
+          displayHint: "Department of Justice",
+          extractedValue: "Reports semiannually to Congress.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(1);
+    });
+
+    it("collapses ACLU and EFF aliases", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.aclu",
+          displayHint: "ACLU",
+          extractedValue: "Opposes Section 702 reauthorization.",
+        }),
+        v({
+          targetField: "stakeholder.american-civil-liberties-union",
+          displayHint: "American Civil Liberties Union",
+          extractedValue: "Litigates FISA cases.",
+        }),
+        v({
+          targetField: "stakeholder.eff",
+          displayHint: "EFF",
+          extractedValue: "Advocates for end to backdoor searches.",
+        }),
+        v({
+          targetField: "stakeholder.electronic-frontier-foundation",
+          displayHint: "Electronic Frontier Foundation",
+          extractedValue: "Files amicus briefs in FISC.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(2);
+      const names = result.entity.stakeholders!.map((s) => s.name).sort();
+      // Display names come from the *first* verdict that won the slot.
+      expect(names).toEqual(["ACLU", "EFF"]);
+    });
+
+    it("collapses NSA, ODNI, CIA aliases", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({ targetField: "stakeholder.nsa", displayHint: "NSA", extractedValue: "Collects signals." }),
+        v({
+          targetField: "stakeholder.national-security-agency",
+          displayHint: "National Security Agency",
+          extractedValue: "Operates upstream collection.",
+        }),
+        v({ targetField: "stakeholder.odni", displayHint: "ODNI", extractedValue: "Coordinates IC." }),
+        v({ targetField: "stakeholder.dni", displayHint: "DNI", extractedValue: "Reports to Congress." }),
+        v({ targetField: "stakeholder.cia", displayHint: "CIA", extractedValue: "Targets foreigners." }),
+        v({
+          targetField: "stakeholder.central-intelligence-agency",
+          displayHint: "Central Intelligence Agency",
+          extractedValue: "Operates abroad.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(3);
+      const names = result.entity.stakeholders!.map((s) => s.name).sort();
+      expect(names).toEqual(["CIA", "NSA", "ODNI"]);
+    });
+
+    it("FISA-702 adversarial input — full duplicate scenario from QUA-872", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      // Two slugs proposed for FISC, two for DOJ, three for FBI — the case
+      // documented in the ticket. Should collapse to 3 entries total.
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.fisc",
+          displayHint: "Foreign Intelligence Surveillance Court (FISC)",
+          extractedValue: "Approves targeting procedures.",
+        }),
+        v({
+          targetField: "stakeholder.foreign-intelligence-surveillance-court",
+          displayHint: "Foreign Intelligence Surveillance Court (FISC)",
+          extractedValue: "Reviews queries.",
+        }),
+        v({
+          targetField: "stakeholder.doj",
+          displayHint: "Department of Justice (DOJ)",
+          extractedValue: "Oversight reports.",
+        }),
+        v({
+          targetField: "stakeholder.us-department-of-justice",
+          displayHint: "Department of Justice (DOJ)",
+          extractedValue: "Compliance oversight.",
+        }),
+        v({
+          targetField: "stakeholder.fbi",
+          displayHint: "FBI",
+          extractedValue: "Queries 702 data.",
+        }),
+        v({
+          targetField: "stakeholder.federal-bureau-of-investigation",
+          displayHint: "FBI (Federal Bureau of Investigation)",
+          extractedValue: "Investigates threats.",
+        }),
+        v({
+          targetField: "stakeholder.fbi-federal-bureau-of-investigation",
+          displayHint: "Federal Bureau of Investigation",
+          extractedValue: "Performs U.S.-person queries.",
+        }),
+      ]);
+      // Three canonical stakeholders, no duplicates.
+      expect(result.entity.stakeholders).toHaveLength(3);
+      const names = result.entity.stakeholders!.map((s) => s.name);
+      // Each name should be unique under canonicalSlug.
+      const canonicals = new Set(names.map((n) =>
+        n.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+      ));
+      expect(canonicals.size).toBe(3);
+    });
+
+    it("dedupes against pre-existing stakeholders with alias name", () => {
+      const entity: PolicyEntity = {
+        id: "fisa-702",
+        type: "policy",
+        stakeholders: [{ name: "FBI", position: "support", reason: "Existing" }],
+      };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.federal-bureau-of-investigation",
+          displayHint: "Federal Bureau of Investigation",
+          extractedValue: "Much more detailed and comprehensive description of FBI role here.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(1);
+      expect(result.entity.stakeholders![0].name).toBe("FBI");
+      expect(result.entity.stakeholders![0].reason).toMatch(/comprehensive description/);
+      expect(result.applied[0].action).toBe("updated");
+    });
+
+    it("uses resolveStakeholderEntity to attach entityId on new stakeholder", () => {
+      const entity: PolicyEntity = { id: "fisa-702", type: "policy" };
+      const result = applyVerdictsToPolicy(
+        entity,
+        [
+          v({
+            targetField: "stakeholder.fbi",
+            displayHint: "FBI",
+            extractedValue: "Queries 702 data.",
+          }),
+        ],
+        {
+          resolveStakeholderEntity: (canon) =>
+            canon === "federal-bureau-of-investigation" ? "sid_fbi123" : null,
+        },
+      );
+      expect(result.entity.stakeholders).toHaveLength(1);
+      expect(result.entity.stakeholders![0].entityId).toBe("sid_fbi123");
+    });
+
+    it("backfills entityId on existing stakeholder match", () => {
+      const entity: PolicyEntity = {
+        id: "fisa-702",
+        type: "policy",
+        stakeholders: [{ name: "FBI", position: "support", reason: "Long enough existing reason." }],
+      };
+      const result = applyVerdictsToPolicy(
+        entity,
+        [
+          v({
+            targetField: "stakeholder.federal-bureau-of-investigation",
+            displayHint: "Federal Bureau of Investigation",
+            // Shorter than existing — would normally skip.
+            extractedValue: "Short.",
+          }),
+        ],
+        {
+          resolveStakeholderEntity: (canon) =>
+            canon === "federal-bureau-of-investigation" ? "sid_fbi123" : null,
+        },
+      );
+      expect(result.entity.stakeholders![0].entityId).toBe("sid_fbi123");
+      expect(result.applied[0].action).toBe("updated");
+    });
+
+    it("does not corrupt entries with no canonical match", () => {
+      const entity: PolicyEntity = { id: "x", type: "policy" };
+      const result = applyVerdictsToPolicy(entity, [
+        v({
+          targetField: "stakeholder.some-novel-org",
+          displayHint: "Some Novel Org",
+          extractedValue: "Reason 1.",
+        }),
+        v({
+          targetField: "stakeholder.another-novel-org",
+          displayHint: "Another Novel Org",
+          extractedValue: "Reason 2.",
+        }),
+      ]);
+      expect(result.entity.stakeholders).toHaveLength(2);
+    });
+  });
 });
 
 // ─── applyVerdictsToOrganization ───────────────────────────────────────────

--- a/crux/lib/research/__tests__/canonical-names.test.ts
+++ b/crux/lib/research/__tests__/canonical-names.test.ts
@@ -107,6 +107,48 @@ describe("generateSlugCandidates", () => {
   });
 });
 
+describe("canonicalSlug — edge cases & no-false-match", () => {
+  it("'FBI Warning' (compound name with FBI prefix) does NOT match FBI", () => {
+    expect(canonicalSlug("FBI Warning")).toBe("fbi-warning");
+  });
+
+  it("'Senate cafeteria' does NOT match the senate canonical", () => {
+    expect(canonicalSlug("Senate cafeteria")).toBe("senate-cafeteria");
+  });
+
+  it("'Treasury bonds' does NOT match treasury canonical", () => {
+    expect(canonicalSlug("Treasury bonds")).toBe("treasury-bonds");
+  });
+
+  it("does not truncate long compound names (slugify-60-char-cap regression)", () => {
+    // Build a long name that, under apply-verdicts.ts's 60-char slugify, would
+    // truncate. canonicalSlug uses fullSlug to avoid silent alias misses.
+    const long =
+      "Office of the Director of National Intelligence and Other Offices and Bodies";
+    // The substring "office of the director of national intelligence" still
+    // matches via the prefix-stripped path? Actually no — the candidate
+    // generator only does parens-split + U.S.-prefix-strip, not arbitrary
+    // substring splitting. So this should slug to its full form (no truncation).
+    const got = canonicalSlug(long);
+    expect(got.length).toBeGreaterThan(60);
+    expect(got).toBe(
+      "office-of-the-director-of-national-intelligence-and-other-offices-and-bodies",
+    );
+  });
+
+  it("handles unicode (non-ASCII) input by collapsing to slug", () => {
+    expect(canonicalSlug("Comisión Federal")).toBe("comisi-n-federal");
+  });
+
+  it("handles trailing/leading whitespace", () => {
+    expect(canonicalSlug("  FBI  ")).toBe("federal-bureau-of-investigation");
+  });
+
+  it("returns the raw slug when no alias matches and no candidates collide", () => {
+    expect(canonicalSlug("Some Brand New Org")).toBe("some-brand-new-org");
+  });
+});
+
 describe("STAKEHOLDER_ALIASES dictionary integrity", () => {
   it("every canonical key is itself in its alias list", () => {
     for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {

--- a/crux/lib/research/__tests__/canonical-names.test.ts
+++ b/crux/lib/research/__tests__/canonical-names.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  STAKEHOLDER_ALIASES,
+  canonicalSlug,
+  generateSlugCandidates,
+} from "../canonical-names.ts";
+
+describe("canonicalSlug", () => {
+  // ── Acronyms collapse to canonical ────────────────────────────────────────
+  it.each([
+    ["ACLU", "american-civil-liberties-union"],
+    ["aclu", "american-civil-liberties-union"],
+    ["American Civil Liberties Union", "american-civil-liberties-union"],
+    ["EFF", "electronic-frontier-foundation"],
+    ["Electronic Frontier Foundation", "electronic-frontier-foundation"],
+    ["NSA", "national-security-agency"],
+    ["National Security Agency", "national-security-agency"],
+    ["FBI", "federal-bureau-of-investigation"],
+    ["Federal Bureau of Investigation", "federal-bureau-of-investigation"],
+    ["ODNI", "office-of-the-director-of-national-intelligence"],
+    ["DNI", "office-of-the-director-of-national-intelligence"],
+    ["FISC", "foreign-intelligence-surveillance-court"],
+    ["FISA Court", "foreign-intelligence-surveillance-court"],
+    ["Foreign Intelligence Surveillance Court", "foreign-intelligence-surveillance-court"],
+    ["DOJ", "department-of-justice"],
+    ["Department of Justice", "department-of-justice"],
+    ["CIA", "central-intelligence-agency"],
+    ["Central Intelligence Agency", "central-intelligence-agency"],
+  ])("collapses %s → %s", (input, expected) => {
+    expect(canonicalSlug(input)).toBe(expected);
+  });
+
+  // ── Parenthetical and prefix variants ─────────────────────────────────────
+  it("handles 'FBI (Federal Bureau of Investigation)'", () => {
+    expect(canonicalSlug("FBI (Federal Bureau of Investigation)")).toBe(
+      "federal-bureau-of-investigation",
+    );
+  });
+
+  it("handles 'Federal Bureau of Investigation (FBI)'", () => {
+    expect(canonicalSlug("Federal Bureau of Investigation (FBI)")).toBe(
+      "federal-bureau-of-investigation",
+    );
+  });
+
+  it("strips 'U.S.' prefix on Department of Justice", () => {
+    expect(canonicalSlug("U.S. Department of Justice")).toBe("department-of-justice");
+  });
+
+  it("strips 'United States' prefix on Department of Defense", () => {
+    expect(canonicalSlug("United States Department of Defense")).toBe("department-of-defense");
+  });
+
+  it("strips 'U.S.A.' prefix", () => {
+    expect(canonicalSlug("U.S.A. Department of State")).toBe("department-of-state");
+  });
+
+  // ── No-match fallback ─────────────────────────────────────────────────────
+  it("returns slugified input when no alias matches", () => {
+    expect(canonicalSlug("Some Unknown Org")).toBe("some-unknown-org");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(canonicalSlug("")).toBe("");
+  });
+
+  it("handles already-slugified input", () => {
+    expect(canonicalSlug("aclu")).toBe("american-civil-liberties-union");
+    expect(canonicalSlug("federal-bureau-of-investigation")).toBe(
+      "federal-bureau-of-investigation",
+    );
+  });
+
+  it("is case-insensitive on parenthetical splits", () => {
+    expect(canonicalSlug("aclu (American Civil Liberties Union)")).toBe(
+      "american-civil-liberties-union",
+    );
+  });
+});
+
+describe("generateSlugCandidates", () => {
+  it("returns a single slug for a plain name", () => {
+    expect(generateSlugCandidates("Anthropic")).toEqual(["anthropic"]);
+  });
+
+  it("returns full slug, before-paren, and inside-paren", () => {
+    const got = generateSlugCandidates("FBI (Federal Bureau of Investigation)");
+    expect(got).toContain("fbi-federal-bureau-of-investigation");
+    expect(got).toContain("fbi");
+    expect(got).toContain("federal-bureau-of-investigation");
+  });
+
+  it("returns prefix-stripped variant", () => {
+    const got = generateSlugCandidates("U.S. Department of Justice");
+    expect(got).toContain("u-s-department-of-justice");
+    expect(got).toContain("department-of-justice");
+  });
+
+  it("dedupes candidates", () => {
+    const got = generateSlugCandidates("Anthropic");
+    const set = new Set(got);
+    expect(got.length).toBe(set.size);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(generateSlugCandidates("")).toEqual([]);
+  });
+});
+
+describe("STAKEHOLDER_ALIASES dictionary integrity", () => {
+  it("every canonical key is itself in its alias list", () => {
+    for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
+      expect(
+        aliases.includes(canonical),
+        `canonical "${canonical}" must appear in its own alias list`,
+      ).toBe(true);
+    }
+  });
+
+  it("aliases are all in slug form (lowercase, hyphenated)", () => {
+    for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
+      for (const a of aliases) {
+        expect(
+          a,
+          `alias "${a}" of "${canonical}" must be slug-form`,
+        ).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+      }
+    }
+  });
+
+  it("no two canonical entries share an alias", () => {
+    const aliasOwner = new Map<string, string>();
+    for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
+      for (const a of aliases) {
+        const prev = aliasOwner.get(a);
+        expect(prev, `alias "${a}" claimed by both "${prev}" and "${canonical}"`).toBeUndefined();
+        aliasOwner.set(a, canonical);
+      }
+    }
+  });
+});

--- a/crux/lib/research/apply-verdicts.ts
+++ b/crux/lib/research/apply-verdicts.ts
@@ -13,6 +13,7 @@
 // rather than writing them into local YAML.
 
 import type { OrganizationEntity, OrganizationKeyPerson, PolicyEntity } from "./gap-analyzer.ts";
+import { canonicalSlug } from "./canonical-names.ts";
 
 export interface VerifiedVerdict {
   /** The seed key — encodes target type + identifier. */
@@ -68,10 +69,23 @@ export function canonicalizePersonKey(input: string): string {
   return slugify(s);
 }
 
+/**
+ * Resolves a stakeholder canonical slug + display name to a wiki entityId
+ * (stableId or slug). Called once per added/updated stakeholder. Return null
+ * if no match. The applier stores the result on the stakeholder's `entityId`
+ * field when matched.
+ */
+export type StakeholderEntityResolver = (canonicalSlug: string, displayName: string) => string | null;
+
+export interface ApplyPolicyOptions {
+  resolveStakeholderEntity?: StakeholderEntityResolver;
+}
+
 /** Apply a batch of verdicts to a PolicyEntity. Returns updated entity + change log. */
 export function applyVerdictsToPolicy(
   entity: PolicyEntity,
   verdicts: VerifiedVerdict[],
+  options: ApplyPolicyOptions = {},
 ): ApplyResult<PolicyEntity> {
   // Deep-clone the parts we mutate.
   const next: PolicyEntity = {
@@ -148,31 +162,53 @@ export function applyVerdictsToPolicy(
       const slug = tf.slice("stakeholder.".length);
       const name = v.displayHint ?? titleCase(slug);
       next.stakeholders ??= [];
-      // Dedupe by both targetField slug AND displayHint slug — the LLM
-      // sometimes produces different targetField slugs ("foreign-intelligence-surveillance-court"
-      // vs "...-fisc") that map to the same display name.
-      const nameSlug = slugify(name);
-      const existing = next.stakeholders.find(
-        (s) => slugify(s.name) === slug || slugify(s.name) === nameSlug,
-      );
+      // Canonicalize both the targetField slug and the display name. This
+      // collapses aliases like "fbi" + "federal-bureau-of-investigation"
+      // and "FBI (Federal Bureau of Investigation)" + "FBI" + "Federal Bureau
+      // of Investigation" to a single canonical slug, so the LLM extractor
+      // can no longer produce duplicates by varying the surface form.
+      const canonFromSlug = canonicalSlug(slug);
+      const canonFromName = canonicalSlug(name);
+      const matchKey = (existingName: string) => {
+        const c = canonicalSlug(existingName);
+        return c === canonFromSlug || c === canonFromName;
+      };
+      const existing = next.stakeholders.find((s) => matchKey(s.name));
       if (existing) {
+        let updated = false;
         if (!existing.reason || existing.reason.length < value.length) {
           existing.reason = value;
           if (!existing.source) existing.source = v.sourceUrl;
-          applied.push({ targetField: tf, action: "updated" });
-        } else {
-          applied.push({ targetField: tf, action: "skipped", reason: "existing reason longer" });
+          updated = true;
         }
+        // Backfill entityId on the existing entry when a resolver is supplied.
+        if (!existing.entityId && options.resolveStakeholderEntity) {
+          const eid = options.resolveStakeholderEntity(canonFromName || canonFromSlug, name);
+          if (eid) {
+            existing.entityId = eid;
+            updated = true;
+          }
+        }
+        applied.push({
+          targetField: tf,
+          action: updated ? "updated" : "skipped",
+          reason: updated ? undefined : "existing reason longer",
+        });
         continue;
       }
       // Default to position=reform when unknown — least-controversial.
-      next.stakeholders.push({
+      const newEntry: NonNullable<PolicyEntity["stakeholders"]>[number] = {
         name,
         position: "reform",
         importance: "medium",
         reason: value,
         source: v.sourceUrl,
-      });
+      };
+      if (options.resolveStakeholderEntity) {
+        const eid = options.resolveStakeholderEntity(canonFromName || canonFromSlug, name);
+        if (eid) newEntry.entityId = eid;
+      }
+      next.stakeholders.push(newEntry);
       applied.push({ targetField: tf, action: "added" });
       continue;
     }

--- a/crux/lib/research/apply-verdicts.ts
+++ b/crux/lib/research/apply-verdicts.ts
@@ -74,8 +74,11 @@ export function canonicalizePersonKey(input: string): string {
  * (stableId or slug). Called once per added/updated stakeholder. Return null
  * if no match. The applier stores the result on the stakeholder's `entityId`
  * field when matched.
+ *
+ * Parameter is named `canonical` (not `canonicalSlug`) to avoid shadowing
+ * the imported `canonicalSlug` function in callers.
  */
-export type StakeholderEntityResolver = (canonicalSlug: string, displayName: string) => string | null;
+export type StakeholderEntityResolver = (canonical: string, displayName: string) => string | null;
 
 export interface ApplyPolicyOptions {
   resolveStakeholderEntity?: StakeholderEntityResolver;
@@ -171,6 +174,7 @@ export function applyVerdictsToPolicy(
       const canonFromName = canonicalSlug(name);
       const matchKey = (existingName: string) => {
         const c = canonicalSlug(existingName);
+        if (!c) return false; // an existing entry with empty name shouldn't gobble new entries
         return c === canonFromSlug || c === canonFromName;
       };
       const existing = next.stakeholders.find((s) => matchKey(s.name));

--- a/crux/lib/research/canonical-names.ts
+++ b/crux/lib/research/canonical-names.ts
@@ -11,15 +11,26 @@
 //   1. Generate slug candidates from the input (full slug, parenthetical
 //      splits like "FBI (Federal Bureau of Investigation)" → "fbi" + "federal-bureau-of-investigation",
 //      and prefix-stripped variants like "U.S. Department of Justice" → "department-of-justice").
-//   2. Look each candidate up in STAKEHOLDER_ALIASES.
+//   2. Look each candidate up in STAKEHOLDER_ALIASES (via a reverse-index Map
+//      built once at module load — O(1) lookups).
 //   3. Return the canonical slug if any candidate matches; else the first candidate.
 //
-// The dictionary is a hand-curated allowlist, seeded from common federal
+// The dictionary is a hand-curated allowlist scoped to **U.S. federal**
 // agencies, civil-liberties orgs, and major intelligence/justice bodies that
-// recur in policy stakeholder lists. Extend it over time as new aliases are
-// observed in pipeline runs.
+// recur in U.S. policy stakeholder lists. Extend it over time as new aliases
+// are observed in pipeline runs. Bare aliases like "senate", "treasury",
+// "congress" mean the U.S. ones — non-US institutions should not use this
+// module without scoping (see comment on STAKEHOLDER_ALIASES below).
 
-import { slugify } from "./apply-verdicts.ts";
+// Slug helper, intentionally separate from apply-verdicts.ts::slugify which
+// truncates at 60 chars. Truncation can silently break alias lookups when
+// long compound names are run through this module, so we use the full slug.
+function fullSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
 /**
  * Map of canonical slug → list of accepted aliases (already in slug form).
@@ -27,7 +38,13 @@ import { slugify } from "./apply-verdicts.ts";
  * so we can also use this dictionary for cross-base entityId linking.
  *
  * Always include the canonical slug itself in its own alias list for
- * symmetry — we look up by `aliases.includes(candidate)`.
+ * symmetry — we look up via the reverse index built below, which seeds
+ * itself from each (canonical, alias) pair.
+ *
+ * **Scope: U.S. federal institutions only.** Bare aliases like "senate",
+ * "congress", "treasury" are interpreted as the U.S. ones. Do not extend
+ * this dictionary with non-U.S. institutions sharing those names without
+ * also re-scoping the existing entries (e.g. rename "senate" → "us-senate").
  */
 export const STAKEHOLDER_ALIASES: Record<string, string[]> = {
   // ── Intelligence community ────────────────────────────────────────────────
@@ -121,9 +138,35 @@ export const STAKEHOLDER_ALIASES: Record<string, string[]> = {
     "us-house-of-representatives",
     "u-s-house-of-representatives",
   ],
-  senate: ["senate", "us-senate", "u-s-senate", "united-states-senate"],
-  congress: ["congress", "us-congress", "u-s-congress", "united-states-congress"],
+  "senate": ["senate", "us-senate", "u-s-senate", "united-states-senate"],
+  "congress": ["congress", "us-congress", "u-s-congress", "united-states-congress"],
 };
+
+/**
+ * Reverse index: alias slug → canonical slug. Built once at module load,
+ * so canonicalSlug() does an O(1) Map lookup instead of an O(N×M) scan.
+ *
+ * Throws on duplicate alias (two canonicals claiming the same alias) — the
+ * dictionary integrity test enforces this, but the runtime check provides
+ * a second line of defense.
+ */
+const ALIAS_INDEX: Map<string, string> = (() => {
+  const index = new Map<string, string>();
+  for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
+    for (const alias of aliases) {
+      const prev = index.get(alias);
+      if (prev !== undefined && prev !== canonical) {
+        throw new Error(
+          `STAKEHOLDER_ALIASES: alias "${alias}" claimed by both "${prev}" and "${canonical}"`,
+        );
+      }
+      index.set(alias, canonical);
+    }
+    // Also ensure canonical maps to itself.
+    if (!index.has(canonical)) index.set(canonical, canonical);
+  }
+  return index;
+})();
 
 /**
  * Generate slug candidates from a name. Tries:
@@ -131,7 +174,8 @@ export const STAKEHOLDER_ALIASES: Record<string, string[]> = {
  *  - Parenthetical split: "FBI (Federal Bureau of Investigation)" yields "fbi" and "federal-bureau-of-investigation".
  *  - Prefix-stripped variants: "U.S. Department of Justice" yields "department-of-justice".
  *
- * Used by canonicalSlug() to widen the alias-lookup search.
+ * Used by canonicalSlug() to widen the alias-lookup search. Uses fullSlug
+ * (no truncation) so long compound names match correctly.
  */
 export function generateSlugCandidates(input: string): string[] {
   if (!input) return [];
@@ -139,7 +183,7 @@ export function generateSlugCandidates(input: string): string[] {
   const seen = new Set<string>();
   const add = (s: string | undefined | null) => {
     if (!s) return;
-    const slug = slugify(s);
+    const slug = fullSlug(s);
     if (slug && !seen.has(slug)) {
       seen.add(slug);
       out.push(slug);
@@ -165,17 +209,16 @@ export function generateSlugCandidates(input: string): string[] {
  * Resolve a name (display string or slug) to a canonical slug. Returns the
  * canonical slug if any candidate (full slug, parenthetical split, prefix-
  * stripped variant) matches an alias in STAKEHOLDER_ALIASES; otherwise
- * returns the first candidate slug, or the slugified input as a last resort.
+ * returns the first candidate slug, or the full slug as a last resort.
+ *
+ * Returns "" only when the input is empty/whitespace-only.
  */
 export function canonicalSlug(input: string): string {
   if (!input) return "";
   const candidates = generateSlugCandidates(input);
   for (const candidate of candidates) {
-    for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
-      if (canonical === candidate || aliases.includes(candidate)) {
-        return canonical;
-      }
-    }
+    const canonical = ALIAS_INDEX.get(candidate);
+    if (canonical) return canonical;
   }
-  return candidates[0] ?? slugify(input);
+  return candidates[0] ?? fullSlug(input);
 }

--- a/crux/lib/research/canonical-names.ts
+++ b/crux/lib/research/canonical-names.ts
@@ -1,0 +1,181 @@
+// Canonical-name resolution for stakeholders.
+//
+// The closed-loop entity improver (apply-verdicts.ts) needs to dedupe array
+// entries when the LLM extractor proposes multiple targetField slugs that
+// map to the same real-world entity:
+//
+//   - "fbi" + "federal-bureau-of-investigation" → both → "federal-bureau-of-investigation"
+//   - "doj" + "u.s. department of justice" + "department of justice" → all three → "department-of-justice"
+//
+// The strategy:
+//   1. Generate slug candidates from the input (full slug, parenthetical
+//      splits like "FBI (Federal Bureau of Investigation)" → "fbi" + "federal-bureau-of-investigation",
+//      and prefix-stripped variants like "U.S. Department of Justice" → "department-of-justice").
+//   2. Look each candidate up in STAKEHOLDER_ALIASES.
+//   3. Return the canonical slug if any candidate matches; else the first candidate.
+//
+// The dictionary is a hand-curated allowlist, seeded from common federal
+// agencies, civil-liberties orgs, and major intelligence/justice bodies that
+// recur in policy stakeholder lists. Extend it over time as new aliases are
+// observed in pipeline runs.
+
+import { slugify } from "./apply-verdicts.ts";
+
+/**
+ * Map of canonical slug → list of accepted aliases (already in slug form).
+ * The canonical slug should match the wiki entity slug when one exists,
+ * so we can also use this dictionary for cross-base entityId linking.
+ *
+ * Always include the canonical slug itself in its own alias list for
+ * symmetry — we look up by `aliases.includes(candidate)`.
+ */
+export const STAKEHOLDER_ALIASES: Record<string, string[]> = {
+  // ── Intelligence community ────────────────────────────────────────────────
+  "national-security-agency": ["nsa", "national-security-agency"],
+  "central-intelligence-agency": ["cia", "central-intelligence-agency"],
+  "federal-bureau-of-investigation": [
+    "fbi",
+    "federal-bureau-of-investigation",
+    "fbi-federal-bureau-of-investigation",
+    "federal-bureau-of-investigation-fbi",
+  ],
+  "office-of-the-director-of-national-intelligence": [
+    "odni",
+    "dni",
+    "office-of-the-director-of-national-intelligence",
+    "director-of-national-intelligence",
+  ],
+  "defense-intelligence-agency": ["dia", "defense-intelligence-agency"],
+  "national-geospatial-intelligence-agency": ["nga", "national-geospatial-intelligence-agency"],
+  "national-reconnaissance-office": ["nro", "national-reconnaissance-office"],
+
+  // ── Justice / law enforcement ─────────────────────────────────────────────
+  "department-of-justice": [
+    "doj",
+    "department-of-justice",
+    "us-department-of-justice",
+    "u-s-department-of-justice",
+    "united-states-department-of-justice",
+  ],
+  "department-of-homeland-security": [
+    "dhs",
+    "department-of-homeland-security",
+    "us-department-of-homeland-security",
+  ],
+  "drug-enforcement-administration": ["dea", "drug-enforcement-administration"],
+
+  // ── Surveillance courts / oversight ───────────────────────────────────────
+  "foreign-intelligence-surveillance-court": [
+    "fisc",
+    "fisa-court",
+    "foreign-intelligence-surveillance-court",
+    "fisa-c",
+  ],
+  "privacy-and-civil-liberties-oversight-board": [
+    "pclob",
+    "privacy-and-civil-liberties-oversight-board",
+  ],
+
+  // ── Civil-liberties organizations ─────────────────────────────────────────
+  "american-civil-liberties-union": [
+    "aclu",
+    "american-civil-liberties-union",
+    "aclu-american-civil-liberties-union",
+  ],
+  "electronic-frontier-foundation": [
+    "eff",
+    "electronic-frontier-foundation",
+    "eff-electronic-frontier-foundation",
+  ],
+  "center-for-democracy-and-technology": [
+    "cdt",
+    "center-for-democracy-and-technology",
+  ],
+  "electronic-privacy-information-center": [
+    "epic",
+    "electronic-privacy-information-center",
+  ],
+
+  // ── Executive / state / regulatory ────────────────────────────────────────
+  "department-of-state": ["dos", "department-of-state", "us-department-of-state", "state-department"],
+  "department-of-defense": [
+    "dod",
+    "department-of-defense",
+    "us-department-of-defense",
+    "u-s-department-of-defense",
+  ],
+  "department-of-the-treasury": [
+    "treasury",
+    "department-of-the-treasury",
+    "us-department-of-the-treasury",
+    "u-s-department-of-the-treasury",
+    "treasury-department",
+  ],
+  "federal-trade-commission": ["ftc", "federal-trade-commission"],
+  "federal-communications-commission": ["fcc", "federal-communications-commission"],
+  "securities-and-exchange-commission": ["sec", "securities-and-exchange-commission"],
+
+  // ── Legislative ───────────────────────────────────────────────────────────
+  "house-of-representatives": [
+    "house-of-representatives",
+    "us-house-of-representatives",
+    "u-s-house-of-representatives",
+  ],
+  senate: ["senate", "us-senate", "u-s-senate", "united-states-senate"],
+  congress: ["congress", "us-congress", "u-s-congress", "united-states-congress"],
+};
+
+/**
+ * Generate slug candidates from a name. Tries:
+ *  - The full slug.
+ *  - Parenthetical split: "FBI (Federal Bureau of Investigation)" yields "fbi" and "federal-bureau-of-investigation".
+ *  - Prefix-stripped variants: "U.S. Department of Justice" yields "department-of-justice".
+ *
+ * Used by canonicalSlug() to widen the alias-lookup search.
+ */
+export function generateSlugCandidates(input: string): string[] {
+  if (!input) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (s: string | undefined | null) => {
+    if (!s) return;
+    const slug = slugify(s);
+    if (slug && !seen.has(slug)) {
+      seen.add(slug);
+      out.push(slug);
+    }
+  };
+  add(input);
+  // Parenthetical: "FBI (Federal Bureau)" -> "FBI" and "Federal Bureau".
+  const parenMatch = input.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+  if (parenMatch) {
+    add(parenMatch[1]);
+    add(parenMatch[2]);
+  }
+  // Strip leading "U.S." / "United States" / "U.S.A." qualifiers.
+  const stripped = input.replace(
+    /^(U\.S\.A?\.?|U\s*\.\s*S\.?|United\s+States(?:\s+of\s+America)?)\s+/i,
+    "",
+  );
+  if (stripped !== input) add(stripped);
+  return out;
+}
+
+/**
+ * Resolve a name (display string or slug) to a canonical slug. Returns the
+ * canonical slug if any candidate (full slug, parenthetical split, prefix-
+ * stripped variant) matches an alias in STAKEHOLDER_ALIASES; otherwise
+ * returns the first candidate slug, or the slugified input as a last resort.
+ */
+export function canonicalSlug(input: string): string {
+  if (!input) return "";
+  const candidates = generateSlugCandidates(input);
+  for (const candidate of candidates) {
+    for (const [canonical, aliases] of Object.entries(STAKEHOLDER_ALIASES)) {
+      if (canonical === candidate || aliases.includes(candidate)) {
+        return canonical;
+      }
+    }
+  }
+  return candidates[0] ?? slugify(input);
+}


### PR DESCRIPTION
## Summary

Fixes QUA-872 — duplicate stakeholders in the closed-loop entity improver caused by the LLM extractor proposing multiple `targetField` slugs for the same real-world entity (FBI/DOJ/FISC variants etc.).

The new `crux/lib/research/canonical-names.ts` module owns:

- **`STAKEHOLDER_ALIASES`** — hand-curated dictionary mapping canonical slug → known aliases for ~25 federal agencies, civil-liberties orgs, surveillance courts, and legislative bodies. Easy to extend over time.
- **`generateSlugCandidates(name)`** — produces full-slug, parenthetical-split, and prefix-stripped variants. Handles "FBI (Federal Bureau of Investigation)" and "U.S. Department of Justice" correctly.
- **`canonicalSlug(name)`** — looks up candidates against the alias dictionary and returns the canonical slug (or the slugified input as fallback).

`apply-verdicts.ts`:

- Stakeholder dedup now uses `canonicalSlug` on both `targetField` slug, `displayHint`, and existing entry names — so all alias variants collapse to a single entry.
- New `ApplyPolicyOptions.resolveStakeholderEntity` resolver hook (mirrors `resolvePersonEntity` for orgs). Used to backfill `entityId` on matched stakeholders, enabling cross-base links to TableBase entities. Existing stakeholders with no `entityId` get backfilled when the resolver returns a match.

`research-improve-entity.ts`:

- Pre-fetches entity search results once per unique stakeholder display name and supplies a synchronous resolver to `applyVerdictsToPolicy`. Mirrors the existing `keyPerson` resolver pattern.

The script `crux/scripts/apply-batches-to-fisa-702.ts` keeps working unchanged — the new `options` argument defaults to `{}`.

### Acceptance criteria

- ✅ Stakeholders dedupe across alias variants (FBI/Federal Bureau of Investigation/FBI (Federal Bureau of Investigation), DOJ/U.S. Department of Justice/Department of Justice, FISC/Foreign Intelligence Surveillance Court).
- ✅ Stakeholders that match TableBase entities get `entityId: <id>` set via the resolver hook.
- ✅ Tests cover ACLU, EFF, NSA, FBI, ODNI, FISC, DOJ, CIA aliases plus the full FISA-702 adversarial input from the ticket (7 slug variants → 3 canonical entries).
- ✅ Provision dedup unchanged from PR #4711's existing `slugify(title)` equality (v2 ticket exists for cosine-similarity merging).

### Out of scope

- Provision cosine-similarity merging — separate v2 ticket per the QUA-872 description.
- Re-running `crux tb improve-entity fisa-702` end-to-end against fresh prod — gated on the QUA-883 epic harness.

## Test plan

- [x] `pnpm vitest run crux/lib/research/__tests__/canonical-names.test.ts crux/lib/research/__tests__/apply-verdicts.test.ts` — 67 tests pass
- [x] `pnpm crux w validate gate --fix` — all 67 gate checks pass
- [x] `pnpm build` (apps/web) — builds clean
- [x] Edge-case smoke tests (empty input, parenthetical splits, U.S. prefix variants, case-insensitive)
