### PR TITLE
QUA-864: source-check verdict generation for scorecard_grades cells

### DIFF
--- a/apps/web/src/lib/sourcing/record-type-table-map.ts
+++ b/apps/web/src/lib/sourcing/record-type-table-map.ts
@@ -35,6 +35,12 @@ export const RECORD_TYPE_TO_TABLE = {
   // `entities` and matches by slug, so /sourcing/ai-model/<slug> resolves
   // to the model's entity row.
   "ai-model": "entities",
+  // QUA-864: scorecard_grade verdicts reference the `scorecard_grades`
+  // table (one row per (snapshot, entity, dimension)). Used by the
+  // /sourcing/scorecard_grade/<id> record-lookup page if/when that
+  // detail view exists; for now the dot rendering on /scorecards reads
+  // verdicts via the scorecard-grades sync handler's LEFT JOIN.
+  scorecard_grade: "scorecard_grades",
 } as const satisfies Record<string, string>;
 
 export type KnownRecordType = keyof typeof RECORD_TYPE_TO_TABLE;

--- a/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
+++ b/apps/wiki-server/src/__tests__/api-types-record-id.test.ts
@@ -43,7 +43,11 @@ describe("VALID_RECORD_TYPES", () => {
     // orchestrator with a special `/api/entities/export?entityType=ai-model`
     // collection path since ai-model lives in the entities table rather than
     // a per-type record table.
-    expect(VALID_RECORD_TYPES.length).toBe(17);
+    // QUA-864: scorecard_grade added (18th type) — wired through
+    // /api/scorecard-grades/all with snapshotSourceUrl fallback. The
+    // underscored slug matches the existing SCORECARD_GRADE_RECORD_TYPE
+    // constant on the route side (predates QUA-864).
+    expect(VALID_RECORD_TYPES.length).toBe(18);
   });
 });
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -82,6 +82,14 @@ export const VALID_RECORD_TYPES = [
   // collected from `/api/entities/export?entityType=ai-model` rather than
   // a dedicated /api/<type>/all endpoint — see crux/lib/sourcing/item-collectors.ts.
   "ai-model",
+  // QUA-864: each scorecard_grades row asserts "publisher X scored entity Y
+  // as Z on dimension D in wave W". The grade's own sourceUrl (when present)
+  // or the parent snapshot's sourceUrl is the evidence URL. Underscored to
+  // match the route's existing SCORECARD_GRADE_RECORD_TYPE constant
+  // (apps/wiki-server/src/routes/tablebase/scorecard-grades.ts), which is
+  // already what the LEFT JOIN against source_check_verdicts uses for the
+  // QUA-839 rendering layer on /scorecards and the org scorecards tab.
+  "scorecard_grade",
 ] as const;
 
 export type RecordType = (typeof VALID_RECORD_TYPES)[number];

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -136,6 +136,7 @@ const LIVE_RECORDS_CTE = sql`
     UNION ALL SELECT 'citation', id::text FROM citation_quotes WHERE accuracy_verdict IS NOT NULL
     UNION ALL SELECT 'wiki-page', id::text FROM wiki_pages
     UNION ALL SELECT 'fact', fact_id FROM facts
+    UNION ALL SELECT 'scorecard_grade', id::text FROM scorecard_grades
   )
 `;
 
@@ -1963,6 +1964,8 @@ const sourcingApp = new Hono()
       SELECT 'wiki-page', count(*)::int FROM wiki_pages
       UNION ALL
       SELECT 'fact', count(DISTINCT fact_id)::int FROM facts
+      UNION ALL
+      SELECT 'scorecard_grade', count(*)::int FROM scorecard_grades
     `);
 
     const totalsByType: Record<string, number> = {};
@@ -2235,6 +2238,8 @@ const sourcingApp = new Hono()
       SELECT 'wiki-page', count(*)::int FROM wiki_pages
       UNION ALL
       SELECT 'fact', count(DISTINCT fact_id)::int FROM facts
+      UNION ALL
+      SELECT 'scorecard_grade', count(*)::int FROM scorecard_grades
     `);
 
     const totalsByType: Record<string, number> = {};

--- a/apps/wiki-server/src/routes/tablebase/record-lookup.ts
+++ b/apps/wiki-server/src/routes/tablebase/record-lookup.ts
@@ -32,6 +32,7 @@ import {
   resources,
   researchAreas,
   facts,
+  scorecardGrades,
 } from "../../schema.js";
 import { isAnySid } from "@longterm-wiki/id-utils";
 import { notFoundError, validationError } from "../shared/utils.js";
@@ -66,6 +67,10 @@ const VALID_SOURCE_TABLES = [
   "research_areas",
   "facts",
   "entities",
+  // QUA-864: scorecard cells need a record-lookup target so per-cell
+  // /sourcing/scorecard_grade/<id> URLs can resolve to the underlying row
+  // (matches the pattern other verdictable record types follow).
+  "scorecard_grades",
 ] as const;
 
 type SourceTableName = (typeof VALID_SOURCE_TABLES)[number];
@@ -90,6 +95,7 @@ const TABLE_MAP: Record<SourceTableName, PgTable> = {
   research_areas: researchAreas,
   facts,
   entities,
+  scorecard_grades: scorecardGrades,
 };
 
 const sourceTableSchema = z.enum(VALID_SOURCE_TABLES);

--- a/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
+++ b/apps/wiki-server/src/routes/tablebase/scorecard-grades.ts
@@ -78,6 +78,7 @@ interface GradeRow extends VerdictJoinFields {
   scorecardSource: string | null;
   publishedAt: string | null;
   isLatest: boolean | null;
+  snapshotSourceUrl: string | null;
 }
 
 function formatRow(r: GradeRow) {
@@ -102,6 +103,11 @@ function formatRow(r: GradeRow) {
     scoreRaw: g.scoreRaw,
     notes: g.notes,
     sourceUrl: g.sourceUrl,
+    // QUA-864: parent snapshot's sourceUrl used as fallback by the
+    // sourcing orchestrator when a per-grade sourceUrl is missing.
+    // Most grades inherit evidence from the wave's PDF/page rather than
+    // having a unique deep-link.
+    snapshotSourceUrl: r.snapshotSourceUrl,
     syncedAt: g.syncedAt,
     sourcing: formatSourcing(r),
   };
@@ -136,6 +142,7 @@ const scorecardGradesApp = new Hono()
         scorecardSource: scorecardSnapshots.scorecardSource,
         publishedAt: scorecardSnapshots.publishedAt,
         isLatest: scorecardSnapshots.isLatest,
+        snapshotSourceUrl: scorecardSnapshots.sourceUrl,
         ...verdictSelectFields,
       })
       .from(scorecardGrades)
@@ -190,6 +197,7 @@ const scorecardGradesApp = new Hono()
         scorecardSource: scorecardSnapshots.scorecardSource,
         publishedAt: scorecardSnapshots.publishedAt,
         isLatest: scorecardSnapshots.isLatest,
+        snapshotSourceUrl: scorecardSnapshots.sourceUrl,
         ...verdictSelectFields,
       })
       .from(scorecardGrades)

--- a/crux/commands/sourcing-orchestrate.ts
+++ b/crux/commands/sourcing-orchestrate.ts
@@ -98,6 +98,14 @@ export const RECORD_TYPE_SUBCOMMAND_TO_TYPE: Record<string, RecordType> = {
   // for the five sourceable scalar fields.
   'ai-model': 'ai-model',
   'ai-models': 'ai-model',
+  // QUA-864: scorecard_grade rows verified against the publishing
+  // scorecard's PDF/page (or per-cell deep-link when the grade has its
+  // own sourceUrl). Underscored keyword aliases match the existing
+  // SCORECARD_GRADE_RECORD_TYPE constant on the wiki-server side.
+  'scorecard-grade': 'scorecard_grade',
+  'scorecard-grades': 'scorecard_grade',
+  'scorecard_grade': 'scorecard_grade',
+  'scorecard_grades': 'scorecard_grade',
 };
 
 /**
@@ -352,6 +360,7 @@ Usage:
   crux tb verify entity-assessments        Verify entity assessments
   crux tb verify secondary-market-prices   Verify secondary market prices
   crux tb verify ai-models                 Verify ai-model scalar fields (price, context, ASL, release date)
+  crux tb verify scorecard-grades          Verify scorecard cells against the publishing scorecard's page/PDF
 
 Options:
   --budget=N             Max dollars to spend on LLM calls (est. ~$0.01/item)

--- a/crux/lib/sourcing/item-collectors.test.ts
+++ b/crux/lib/sourcing/item-collectors.test.ts
@@ -336,13 +336,16 @@ describe('scorecard_grade collection', () => {
     });
   }
 
-  it('queries /api/scorecard-grades/all when filtered to scorecard_grade', async () => {
+  it('queries /api/scorecard-grades/all?latest=true when filtered to scorecard_grade', async () => {
     setupScorecardGradesMock([]);
     await collectRecordItems(new Map(), undefined, 'scorecard_grade');
     const calls = mockApiRequest.mock.calls.filter(([, p]) =>
       String(p).startsWith('/api/scorecard-grades/all'),
     );
     expect(calls.length).toBeGreaterThan(0);
+    // QUA-864: scope to the current wave per source. Historic waves are
+    // immutable and don't need re-checking.
+    expect(calls.every(([, p]) => String(p).includes('latest=true'))).toBe(true);
   });
 
   it('uses the per-grade sourceUrl when present', async () => {

--- a/crux/lib/sourcing/item-collectors.test.ts
+++ b/crux/lib/sourcing/item-collectors.test.ts
@@ -311,6 +311,144 @@ describe('benchmark-result name resolution guard', () => {
   });
 });
 
+// ── scorecard_grade collection (QUA-864) ────────────────────────────
+
+describe('scorecard_grade collection', () => {
+  function mockScorecardGradesResponse(rows: Record<string, unknown>[]) {
+    return {
+      ok: true as const,
+      data: {
+        items: rows,
+        total: rows.length,
+        limit: 200,
+        offset: 0,
+      },
+    };
+  }
+
+  function setupScorecardGradesMock(rows: Record<string, unknown>[]) {
+    mockApiRequest.mockImplementation(async (_method: unknown, path: unknown) => {
+      const pathStr = String(path);
+      if (pathStr.startsWith('/api/scorecard-grades/all')) {
+        return mockScorecardGradesResponse(rows);
+      }
+      return mockEmptyResponse();
+    });
+  }
+
+  it('queries /api/scorecard-grades/all when filtered to scorecard_grade', async () => {
+    setupScorecardGradesMock([]);
+    await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    const calls = mockApiRequest.mock.calls.filter(([, p]) =>
+      String(p).startsWith('/api/scorecard-grades/all'),
+    );
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('uses the per-grade sourceUrl when present', async () => {
+    setupScorecardGradesMock([{
+      id: 'fli-summer-2025__sid_anthropic__overall',
+      entityId: 'sid_anthropic',
+      entityTitle: 'Anthropic',
+      entityDisplayName: 'Anthropic',
+      scorecardSource: 'fli_index',
+      publishedAt: '2025-06-15T00:00:00.000Z',
+      dimensionSlug: 'overall',
+      dimensionLabel: 'Overall',
+      scoreLetter: 'C',
+      scoreRaw: 'C',
+      scoreNumeric: 60,
+      sourceUrl: 'https://example.com/fli/summer-2025#anthropic-overall',
+      snapshotSourceUrl: 'https://example.com/fli/summer-2025',
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    expect(items).toHaveLength(1);
+
+    const item = items[0];
+    expect(item.id).toBe('record:scorecard_grade:fli-summer-2025__sid_anthropic__overall');
+    expect(item.sourceUrl).toBe('https://example.com/fli/summer-2025#anthropic-overall');
+    expect(item.entityType).toBe('scorecard_grade');
+
+    if (item.data.kind !== 'record') return;
+    expect(item.data.recordType).toBe('scorecard_grade');
+    expect(item.data.entityId).toBe('sid_anthropic');
+    expect(item.data.entityDisplayName).toBe('Anthropic');
+    expect(item.data.fields).toMatchObject({
+      publisher: 'fli_index',
+      entity: 'Anthropic',
+      dimension: 'Overall',
+      scoreLetter: 'C',
+    });
+  });
+
+  it('falls back to snapshotSourceUrl when the grade has no per-row sourceUrl', async () => {
+    setupScorecardGradesMock([{
+      id: 'fli-summer-2025__sid_anthropic__overall',
+      entityId: 'sid_anthropic',
+      entityTitle: 'Anthropic',
+      scorecardSource: 'fli_index',
+      dimensionSlug: 'overall',
+      scoreLetter: 'C',
+      sourceUrl: null,
+      snapshotSourceUrl: 'https://example.com/fli/summer-2025',
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    expect(items).toHaveLength(1);
+    expect(items[0].sourceUrl).toBe('https://example.com/fli/summer-2025');
+  });
+
+  it('skips rows with neither sourceUrl nor snapshotSourceUrl', async () => {
+    setupScorecardGradesMock([{
+      id: 'fli-summer-2025__sid_x__overall',
+      entityId: 'sid_x',
+      entityTitle: 'Some Org',
+      scorecardSource: 'fli_index',
+      dimensionSlug: 'overall',
+      sourceUrl: null,
+      snapshotSourceUrl: null,
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    expect(items).toHaveLength(0);
+  });
+
+  it('skips rows where the entity name is unresolvable (LLM cannot verify "X scored sid_abc on Y")', async () => {
+    setupScorecardGradesMock([{
+      id: 'fli-summer-2025__sid_unknown__overall',
+      entityId: 'sid_unknown',
+      entityTitle: null,
+      entityDisplayName: 'sid_unknown',
+      scorecardSource: 'fli_index',
+      dimensionSlug: 'overall',
+      scoreLetter: 'C',
+      sourceUrl: 'https://example.com/fli/summer-2025#unknown',
+      snapshotSourceUrl: 'https://example.com/fli/summer-2025',
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    expect(items).toHaveLength(0);
+  });
+
+  it('rolls up verdicts under the scored entityId so org rollups include scorecards', async () => {
+    setupScorecardGradesMock([{
+      id: 'g1',
+      entityId: 'sid_anthropic',
+      entityTitle: 'Anthropic',
+      scorecardSource: 'fli_index',
+      dimensionSlug: 'overall',
+      scoreLetter: 'C',
+      sourceUrl: 'https://example.com/x',
+    }]);
+
+    const items = await collectRecordItems(new Map(), undefined, 'scorecard_grade');
+    expect(items).toHaveLength(1);
+    if (items[0].data.kind !== 'record') return;
+    expect(items[0].data.entityId).toBe('sid_anthropic');
+  });
+});
+
 // ── Exempt type filtering ────────────────────────────────────────────
 
 describe('exempt type filtering', () => {

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -267,7 +267,12 @@ export async function collectRecordItems(
       // "publisher X scored entity Y as Z on dimension D in wave W"; the parent
       // snapshot's sourceUrl is used as fallback when the grade has no per-row
       // deep link (handled below by the source ?? snapshotSourceUrl fallback).
-      case 'scorecard_grade': apiBasePath = '/api/scorecard-grades/all'; break;
+      // `latest=true` scopes to the current wave per source (one row per
+      // source/snapshot has isLatest=true) — historic immutable waves don't
+      // need re-checking, since their grade values can never change once a
+      // newer wave supersedes them. Cuts ~2k+ stale-wave grades from the
+      // collection on each run.
+      case 'scorecard_grade': apiBasePath = '/api/scorecard-grades/all?latest=true'; break;
       // citation and wiki-page are valid record types for verdicts but don't have
       // /all API endpoints for bulk collection — skip them intentionally.
       case 'citation':

--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -263,6 +263,11 @@ export async function collectRecordItems(
       // QUA-685: ai-model records are entities, not a per-type table. Use the
       // entities export endpoint and flatten metadata fields below.
       case 'ai-model': apiBasePath = '/api/entities/export?entityType=ai-model'; break;
+      // QUA-864: scorecard_grade rows live in scorecard_grades. Each row asserts
+      // "publisher X scored entity Y as Z on dimension D in wave W"; the parent
+      // snapshot's sourceUrl is used as fallback when the grade has no per-row
+      // deep link (handled below by the source ?? snapshotSourceUrl fallback).
+      case 'scorecard_grade': apiBasePath = '/api/scorecard-grades/all'; break;
       // citation and wiki-page are valid record types for verdicts but don't have
       // /all API endpoints for bulk collection — skip them intentionally.
       case 'citation':
@@ -330,8 +335,10 @@ export async function collectRecordItems(
       }
 
       for (const item of allRawItems) {
-        // Some record types use 'sourceUrl' instead of 'source' (e.g. benchmark-result)
-        const source = item.source ?? item.sourceUrl;
+        // Some record types use 'sourceUrl' instead of 'source' (e.g. benchmark-result).
+        // QUA-864: scorecard_grade falls back to the parent snapshot's sourceUrl when the
+        // per-row sourceUrl is null — most grades inherit evidence from the wave's PDF/page.
+        const source = item.source ?? item.sourceUrl ?? item.snapshotSourceUrl;
         if (typeof source !== 'string' || !source) continue;
 
         const id = String(item.id ?? '');
@@ -358,6 +365,13 @@ export async function collectRecordItems(
         } else if (recordType === 'benchmark-result') {
           const modelName = resolveName(item, 'modelResolvedName', 'modelDisplayName', 'modelId');
           if (!isResolvableName(modelName)) continue;
+        } else if (recordType === 'scorecard_grade') {
+          // QUA-864: the LLM can't verify "X scored sid_abc on Y" — needs the
+          // org name. The /api/scorecard-grades/all join populates entityTitle
+          // from the entities table; entityDisplayName is the denormalized
+          // backup. Skip rows where neither resolves to a human name.
+          const entity = resolveName(item, 'entityTitle', 'entityDisplayName');
+          if (!isResolvableName(entity)) continue;
         }
 
         const priority = computeRecordPriority(recordType, existing);

--- a/crux/lib/sourcing/priority.ts
+++ b/crux/lib/sourcing/priority.ts
@@ -75,6 +75,11 @@ export function computeRecordPriority(
     'entity-assessment': 10,
     'equity-position': 10,
     'policy-stakeholder': 10,
+    // QUA-864: scorecards are public, dimensional org assessments. Same
+    // priority tier as benchmark-result (15) — both are third-party
+    // measurements of an org/model, both have high downstream visibility
+    // (rendered as colored dots on the directory pages).
+    'scorecard_grade': 15,
   };
   priority += recordTypePriority[recordType] ?? 0;
 

--- a/crux/lib/sourcing/record-descriptions.test.ts
+++ b/crux/lib/sourcing/record-descriptions.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { buildRecordDescription, extractRecordFields } from './record-descriptions.ts';
+
+describe('buildRecordDescription — scorecard_grade (QUA-864)', () => {
+  it('produces a claim-shaped description with publisher / wave / entity / dimension / score', () => {
+    const item = {
+      id: 'fli-summer-2025__sid_anthropic__overall',
+      entityId: 'sid_anthropic',
+      entityTitle: 'Anthropic',
+      entityDisplayName: 'Anthropic',
+      scorecardSource: 'fli_index',
+      publishedAt: '2025-06-15T00:00:00.000Z',
+      dimensionSlug: 'overall',
+      dimensionLabel: 'Overall',
+      scoreLetter: 'C',
+      scoreRaw: 'C',
+      scoreNumeric: 60,
+    };
+    expect(buildRecordDescription('scorecard_grade', item)).toBe(
+      'Scorecard: fli_index 2025-06-15 scored Anthropic on Overall = C',
+    );
+  });
+
+  it('falls back to dimensionSlug when dimensionLabel is missing', () => {
+    const item = {
+      entityTitle: 'Meta',
+      scorecardSource: 'saferai',
+      dimensionSlug: 'risk-assessment',
+      scoreLetter: 'D+',
+    };
+    expect(buildRecordDescription('scorecard_grade', item)).toContain('on risk-assessment');
+  });
+
+  it('uses scoreRaw when scoreLetter is null (fmti-style "Fulfilled" / "Partial")', () => {
+    const item = {
+      entityTitle: 'OpenAI',
+      scorecardSource: 'fmti',
+      dimensionLabel: 'Indicator 42: Risk mitigations',
+      scoreLetter: null,
+      scoreRaw: 'Partial',
+      scoreNumeric: 50,
+    };
+    expect(buildRecordDescription('scorecard_grade', item)).toContain('= Partial');
+  });
+
+  it('uses scoreNumeric when both scoreLetter and scoreRaw are null', () => {
+    const item = {
+      entityTitle: 'OpenAI',
+      scorecardSource: 'ailabwatch',
+      dimensionLabel: 'Score',
+      scoreLetter: null,
+      scoreRaw: null,
+      scoreNumeric: 47,
+    };
+    expect(buildRecordDescription('scorecard_grade', item)).toContain('= 47');
+  });
+
+  it('falls back to N/A when no score field is present', () => {
+    const item = {
+      entityTitle: 'Anthropic',
+      scorecardSource: 'fli_index',
+      dimensionLabel: 'Overall',
+    };
+    expect(buildRecordDescription('scorecard_grade', item)).toContain('= N/A');
+  });
+
+  it('omits the wave date when publishedAt is missing', () => {
+    const item = {
+      entityTitle: 'Anthropic',
+      scorecardSource: 'fli_index',
+      dimensionLabel: 'Overall',
+      scoreLetter: 'C',
+    };
+    const desc = buildRecordDescription('scorecard_grade', item);
+    expect(desc).toBe('Scorecard: fli_index scored Anthropic on Overall = C');
+  });
+});
+
+describe('extractRecordFields — scorecard_grade (QUA-864)', () => {
+  it('extracts publisher / publishedAt / entity / dimension / all three score forms', () => {
+    const item = {
+      id: 'fli-summer-2025__sid_anthropic__overall',
+      entityId: 'sid_anthropic',
+      entityTitle: 'Anthropic',
+      entityDisplayName: 'Anthropic Inc',
+      scorecardSource: 'fli_index',
+      publishedAt: '2025-06-15T00:00:00.000Z',
+      dimensionSlug: 'overall',
+      dimensionLabel: 'Overall',
+      scoreLetter: 'C',
+      scoreRaw: 'C',
+      scoreNumeric: 60,
+    };
+    const fields = extractRecordFields('scorecard_grade', item);
+    expect(fields).toMatchObject({
+      publisher: 'fli_index',
+      publishedAt: '2025-06-15T00:00:00.000Z',
+      entity: 'Anthropic',
+      dimension: 'Overall',
+      scoreLetter: 'C',
+      scoreRaw: 'C',
+      scoreNumeric: 60,
+    });
+  });
+
+  it('returns null for missing optional score fields (no implicit zeroing)', () => {
+    const item = {
+      entityTitle: 'OpenAI',
+      scorecardSource: 'fmti',
+      dimensionSlug: 'indicator-1',
+    };
+    const fields = extractRecordFields('scorecard_grade', item);
+    expect(fields.scoreLetter).toBeNull();
+    expect(fields.scoreRaw).toBeNull();
+    expect(fields.scoreNumeric).toBeNull();
+  });
+
+  it('falls back to dimensionSlug when dimensionLabel is missing', () => {
+    const item = {
+      entityTitle: 'Meta',
+      scorecardSource: 'saferai',
+      dimensionSlug: 'governance',
+    };
+    expect(extractRecordFields('scorecard_grade', item).dimension).toBe('governance');
+  });
+});

--- a/crux/lib/sourcing/record-descriptions.ts
+++ b/crux/lib/sourcing/record-descriptions.ts
@@ -79,6 +79,22 @@ export function buildRecordDescription(recordType: RecordType, item: Record<stri
       const developer = strOrNull(item, 'developer');
       return developer ? `AI Model: ${title} (${developer})` : `AI Model: ${title}`;
     }
+    case 'scorecard_grade': {
+      // QUA-864: claim shape is "publisher X scored entity Y as Z on dimension D
+      // (wave W)". scoreLetter is preferred for display since it's the original
+      // grade (e.g. "B+", "Fulfilled"); scoreRaw covers cases where there's no
+      // letter mapping; scoreNumeric is the normalized 0–100 fallback.
+      const entity = resolveName(item, 'entityTitle', 'entityDisplayName', 'entityId');
+      const dimension = strOrNull(item, 'dimensionLabel') ?? str(item, 'dimensionSlug');
+      const score =
+        strOrNull(item, 'scoreLetter') ??
+        strOrNull(item, 'scoreRaw') ??
+        (numOrNull(item, 'scoreNumeric')?.toString() ?? 'N/A');
+      const source = strOrNull(item, 'scorecardSource') ?? 'unknown source';
+      const publishedAt = strOrNull(item, 'publishedAt');
+      const wave = publishedAt ? ` ${publishedAt.slice(0, 10)}` : '';
+      return `Scorecard: ${source}${wave} scored ${entity} on ${dimension} = ${score}`;
+    }
     default:
       return `${recordType}: ${strOrNull(item, 'name') ?? strOrNull(item, 'title') ?? 'unknown'}`;
   }
@@ -168,6 +184,20 @@ export function extractRecordFields(recordType: RecordType, item: Record<string,
         outputPrice: numOrNull(item, 'outputPrice'),
         contextWindow: numOrNull(item, 'contextWindow'),
         safetyLevel: strOrNull(item, 'safetyLevel'),
+      };
+    case 'scorecard_grade':
+      // QUA-864: fields the LLM verifies against the scorecard's published
+      // page/PDF. The publisher (scorecardSource) is the asserter; the
+      // entity, dimension, and one of the score fields together identify
+      // the cell. publishedAt scopes the claim to a specific wave.
+      return {
+        publisher: strOrNull(item, 'scorecardSource'),
+        publishedAt: strOrNull(item, 'publishedAt'),
+        entity: resolveName(item, 'entityTitle', 'entityDisplayName', 'entityId'),
+        dimension: strOrNull(item, 'dimensionLabel') ?? strOrNull(item, 'dimensionSlug'),
+        scoreLetter: strOrNull(item, 'scoreLetter'),
+        scoreRaw: strOrNull(item, 'scoreRaw'),
+        scoreNumeric: numOrNull(item, 'scoreNumeric'),
       };
     default:
       return { name: strOrNull(item, 'name') ?? strOrNull(item, 'title') };

--- a/crux/lib/sourcing/record-fields.test.ts
+++ b/crux/lib/sourcing/record-fields.test.ts
@@ -233,6 +233,24 @@ describe('extractEntityId', () => {
     });
   });
 
+  // ── scorecard_grade (QUA-864) ──
+
+  describe('scorecard_grade', () => {
+    it('returns entityId so the verdict rolls up under the scored org', () => {
+      const item = {
+        id: 'fli-summer-2025__sid_anthropic__overall',
+        entityId: 'sid_anthropic',
+        entityDisplayName: 'Anthropic',
+      };
+      expect(extractEntityId('scorecard_grade', item)).toBe('sid_anthropic');
+    });
+
+    it('returns null when entityId is missing', () => {
+      const item = { id: 'fli-summer-2025____overall' };
+      expect(extractEntityId('scorecard_grade', item)).toBeNull();
+    });
+  });
+
   // ── Unknown record types ──
 
   describe('unknown record types', () => {
@@ -524,6 +542,32 @@ describe('extractEntityDisplayName', () => {
     it('returns null (not the slug) when title is missing — avoids slug-as-display-name', () => {
       const item = { id: 'claude-2' };
       expect(extractEntityDisplayName('ai-model', item)).toBeNull();
+    });
+  });
+
+  describe('scorecard_grade (QUA-864)', () => {
+    it('returns the joined entityTitle from /api/scorecard-grades/all', () => {
+      const item = {
+        id: 'fli-summer-2025__sid_anthropic__overall',
+        entityId: 'sid_anthropic',
+        entityTitle: 'Anthropic',
+        entityDisplayName: 'Anthropic Inc',
+      };
+      expect(extractEntityDisplayName('scorecard_grade', item)).toBe('Anthropic');
+    });
+
+    it('falls back to entityDisplayName when entityTitle is missing', () => {
+      const item = {
+        id: 'fli-summer-2025__sid_anthropic__overall',
+        entityId: 'sid_anthropic',
+        entityDisplayName: 'Anthropic Inc',
+      };
+      expect(extractEntityDisplayName('scorecard_grade', item)).toBe('Anthropic Inc');
+    });
+
+    it('returns null when both name fields are missing', () => {
+      const item = { id: 'x', entityId: 'sid_anthropic' };
+      expect(extractEntityDisplayName('scorecard_grade', item)).toBeNull();
     });
   });
 

--- a/crux/lib/sourcing/record-fields.ts
+++ b/crux/lib/sourcing/record-fields.ts
@@ -90,6 +90,14 @@ export function extractEntityDisplayName(recordType: string, item: Record<string
       // into source_check_verdicts.entity_display_name otherwise and render
       // as "claude-2" instead of a human name.
       return strOrNull(item, 'title');
+    case 'scorecard_grade':
+      // QUA-864: scorecard_grade verdicts roll up under the scored entity
+      // (the org being graded), not the publishing scorecard, so each org's
+      // sourcing summary aggregates verdicts about its own grades. Use the
+      // joined entityTitle when present (human-readable) and only fall back
+      // to entityDisplayName — never to the raw stableId — for the same
+      // reason ai-model returns null on missing title (avoid sid_ leak).
+      return strOrNull(item, 'entityTitle') ?? strOrNull(item, 'entityDisplayName');
     default:
       return null;
   }
@@ -125,6 +133,13 @@ export function extractEntityId(recordType: string, item: Record<string, unknown
       // also dual-key by developer is tracked in QUA-870 — keeping the simpler
       // per-model design here pending that decision.
       return strOrNull(item, 'stableId') ?? strOrNull(item, 'id');
+    case 'scorecard_grade':
+      // QUA-864: scorecard_grade.entityId is already the scored org's stableId
+      // (FK to entities.stable_id, see scorecard_grades schema). Verdicts
+      // grouped under this entity surface in the org's sourcing rollup
+      // alongside its other records, so the org-level dot reflects whether
+      // its scorecard cells have been verified.
+      return strOrNull(item, 'entityId');
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Wires `scorecard_grade` through the existing source-check orchestrator so the QUA-839 SourcingDot rendering layer on `/scorecards`, `/scorecards/[source]`, and the org scorecards tab finally lights up. QUA-839 explicitly deferred verdict generation; this PR closes that loop.

Each grade row asserts "publisher X scored entity Y as Z on dimension D in wave W". The orchestrator uses the per-row `sourceUrl` when present, else falls back to the parent snapshot's `sourceUrl` (every live snapshot in prod has one). Verdicts roll up under the scored `entityId`, so org-level dots aggregate scorecard cells alongside grants, personnel, etc. Scoped to `latest=true` snapshots — historic immutable waves don't need re-checking.

## Changes by surface

**Wiki-server (data layer)**
- `api-types.ts` — added `"scorecard_grade"` to `VALID_RECORD_TYPES` (now 18 types). Underscored to match the existing `SCORECARD_GRADE_RECORD_TYPE` constant the QUA-839 LEFT JOIN uses.
- `routes/sourcing/sourcing.ts` — added `scorecard_grade` to `LIVE_RECORDS_CTE` and to the table-count UNIONs in `/api/sourcing/coverage` and `/api/sourcing/coverage-matrix`.
- `routes/tablebase/scorecard-grades.ts` — added `snapshotSourceUrl` to `formatRow` (joined from `scorecard_snapshots.source_url`) so the orchestrator's `source ?? sourceUrl ?? snapshotSourceUrl` fallback resolves.
- `routes/tablebase/record-lookup.ts` — added `scorecard_grades` to `VALID_SOURCE_TABLES` + `TABLE_MAP` so per-cell `/sourcing/scorecard_grade/<id>` URLs can resolve.

**Crux orchestrator**
- `lib/sourcing/item-collectors.ts` — `case 'scorecard_grade'` pointing at `/api/scorecard-grades/all?latest=true`, `snapshotSourceUrl` fallback in source extraction, name-resolvability skip (LLM can't verify "X scored sid_abc on Y").
- `lib/sourcing/record-descriptions.ts` — `buildRecordDescription` (`"Scorecard: <publisher> <wave> scored <entity> on <dimension> = <score>"`) and `extractRecordFields` (publisher, publishedAt, entity, dimension, all three score forms).
- `lib/sourcing/record-fields.ts` — `extractEntityId` returns `entityId` (rolls up under the scored org); `extractEntityDisplayName` prefers joined `entityTitle` to avoid sid_ leaks.
- `lib/sourcing/priority.ts` — `recordTypePriority` entry at 15 (same tier as benchmark-result).
- `commands/sourcing-orchestrate.ts` — `RECORD_TYPE_SUBCOMMAND_TO_TYPE` mappings + help text.

**Frontend**
- `apps/web/src/lib/sourcing/record-type-table-map.ts` — added `scorecard_grade -> scorecard_grades`.

## Hostile-review pass (3 actionable findings)

2 fixed in this PR, 1 filed as follow-up:

1. **Missing priority map entry** (LOW) — fixed: `scorecard_grade: 15`.
2. **Stale-wave re-verification cost** (LOW) — fixed: orchestrator scopes to `latest=true`.
3. **ID-length cap drift** (sync schema 300 vs `isCandidateRecordId()` 200) — latent, predates this PR (max prod ID is 88 chars). Filed as **QUA-896** for systemic audit.

## Test plan

- [x] 604 sourcing tests pass (`npx vitest run --root . crux/lib/sourcing/`)
- [x] 1549 wiki-server tests pass (`cd apps/wiki-server && npx vitest run --root .`)
- [x] Full validation gate: 67 checks pass, 2 pre-existing advisories (typecheck-crux, orphan entities)
- [x] Live dry-run against prod: `WIKI_SERVER_ENV=prod pnpm crux tb verify scorecard-grades --dry-run --limit=5` returns 0 items as expected (prod hasn't deployed `snapshotSourceUrl` yet — this PR adds it)
- [x] Inspected prod data: 5076 grade rows have `sourceUrl: NULL`; all 9 snapshots have `sourceUrl` populated. Coverage will jump from 0% to ready-to-check on deploy.
- [ ] **Post-deploy**: Re-run `WIKI_SERVER_ENV=prod pnpm crux tb verify scorecard-grades --dry-run --limit=5` — should now return >0 items
- [ ] **Post-deploy**: `WIKI_SERVER_ENV=prod pnpm crux tb verify scorecard-grades --budget=20 --limit=500` for initial backfill
- [ ] **Post-deploy**: Visit `/scorecards` and `/organizations/anthropic` — verify SourcingDot cells render colored (not white) for the rows we backfilled
- [ ] **Post-deploy**: Visit `/internal/sourcing-coverage` — verify a `scorecard_grade` row appears in the coverage matrix

## What this is NOT

- **No per-sync auto-trigger** (deferred). Consistent with grants/personnel/divisions, which rely on the periodic backfill (`crux tb verify` no-args picks scorecard_grade up via `VALID_RECORD_TYPES` iteration).
- **No frontend rendering changes**. QUA-839 already wired `<SourcingDot>` reading `cell.sourcing?.verdict`. As soon as verdicts populate, dots light up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scorecard grade as a new record type throughout the sourcing system.
  * Scorecard grades now included in coverage statistics and reporting metrics.
  * Added scorecard-grades verification subcommand for CLI validation.
  * Scorecard grades display with entity, dimension, and score information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->