### PR TITLE
fix(validate): suppress slug-in-display false positives when slug resolves

### DIFF
--- a/crux/validate/__tests__/validate-directory-pages.test.ts
+++ b/crux/validate/__tests__/validate-directory-pages.test.ts
@@ -78,4 +78,89 @@ describe("validate-directory-pages: slug-in-display", () => {
     const slugLeaks = projectIssues.filter((i) => i.issueType === "slug-in-display");
     expect(slugLeaks).toEqual([]);
   });
+
+  it("treats an entity with empty/undefined title as 'resolves' (existence-based, not truthy-based)", () => {
+    // Regression check: the resolved-title skip uses Map.has(slug), not
+    // truthy-checking the title string. An entity with title="" is still a
+    // real entity that the rendering layer can substitute for; flagging it
+    // would re-introduce the QUA-899 false positive.
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "stub-project",
+          entityType: "project",
+          title: "Stub Project",
+          description: "A project pointing at an entity with no title yet.",
+          organization: "placeholder-future-org",
+        },
+        {
+          id: "placeholder-future-org",
+          entityType: "organization",
+          title: "",
+          description: "Stub org awaiting enrichment.",
+          orgType: "generic",
+        },
+      ],
+      filterType: "project",
+    });
+
+    const projectIssues = results.find((r) => r.entityType === "project")?.issues ?? [];
+    const slugLeaks = projectIssues.filter((i) => i.issueType === "slug-in-display");
+    expect(slugLeaks).toEqual([]);
+  });
+});
+
+describe("validate-directory-pages: other issue types", () => {
+  it("flags an entity whose title looks like an unresolved slug", () => {
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "stuck-slug",
+          entityType: "project",
+          title: "stuck-slug-title-here",
+          description: "Title was never resolved from slug.",
+        },
+      ],
+      filterType: "project",
+    });
+
+    const issues = results.find((r) => r.entityType === "project")?.issues ?? [];
+    expect(issues.filter((i) => i.issueType === "title-is-slug")).toHaveLength(1);
+  });
+
+  it("flags entities missing required key fields", () => {
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "minimal-org",
+          entityType: "organization",
+          title: "Minimal Org",
+          // missing description and orgType
+        },
+      ],
+      filterType: "organization",
+    });
+
+    const issues = results.find((r) => r.entityType === "organization")?.issues ?? [];
+    const missing = issues.filter((i) => i.issueType === "missing-field");
+    expect(missing.map((i) => i.field).sort()).toEqual(["description", "orgType"]);
+  });
+
+  it("flags non-standard date formats", () => {
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "weird-event",
+          entityType: "event",
+          title: "Weird Event",
+          description: "An event with a malformed startDate.",
+          startDate: "March 2026",
+        },
+      ],
+      filterType: "event",
+    });
+
+    const issues = results.find((r) => r.entityType === "event")?.issues ?? [];
+    expect(issues.filter((i) => i.issueType === "bad-date-format")).toHaveLength(1);
+  });
 });

--- a/crux/validate/__tests__/validate-directory-pages.test.ts
+++ b/crux/validate/__tests__/validate-directory-pages.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { runValidation } from "../validate-directory-pages.ts";
+
+describe("validate-directory-pages: slug-in-display", () => {
+  it("does not flag a slug-shaped value when the slug resolves to a known entity", () => {
+    // Reproduces QUA-899: project entities whose `organization` field stored a
+    // 3+ part kebab-case slug were flagged as slug-leaks even though the
+    // rendering layer (apps/web/src/app/projects/page.tsx) calls
+    // getTypedEntityById(slug) and renders entity.title. As long as the slug
+    // resolves, no slug ever reaches the user.
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "talk-to-the-city",
+          entityType: "project",
+          title: "Talk to the City",
+          description: "An open-source LLM tool for scaling deliberation.",
+          organization: "ai-objectives-institute",
+        },
+        {
+          id: "ai-objectives-institute",
+          entityType: "organization",
+          title: "AI Objectives Institute",
+          description: "Research org working on AI alignment via mechanism design.",
+          orgType: "generic",
+        },
+      ],
+      filterType: "project",
+    });
+
+    const projectIssues = results.find((r) => r.entityType === "project")?.issues ?? [];
+    const slugLeaks = projectIssues.filter((i) => i.issueType === "slug-in-display");
+    expect(slugLeaks).toEqual([]);
+  });
+
+  it("flags a slug-shaped value when the slug does NOT resolve to any entity", () => {
+    // The genuine bug pattern: project references an org slug that isn't in
+    // typedEntities, so the rendering fallback (orgName = orgId) leaks the
+    // raw slug to the user.
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "ghost-project",
+          entityType: "project",
+          title: "Ghost Project",
+          description: "References a missing org.",
+          organization: "nonexistent-missing-org",
+        },
+      ],
+      filterType: "project",
+    });
+
+    const projectIssues = results.find((r) => r.entityType === "project")?.issues ?? [];
+    const slugLeaks = projectIssues.filter((i) => i.issueType === "slug-in-display");
+    expect(slugLeaks).toHaveLength(1);
+    expect(slugLeaks[0].field).toBe("organization");
+    expect(slugLeaks[0].value).toBe("nonexistent-missing-org");
+    expect(slugLeaks[0].detail).toContain("no matching entity");
+  });
+
+  it("ignores 1-2 part slug-shaped values (looksLikeSlug requires 3+ parts)", () => {
+    // Single- or double-word values like "deepmind" or "ai-democracy" are
+    // legitimate display strings and never trigger the heuristic.
+    const { results } = runValidation({
+      typedEntities: [
+        {
+          id: "habermas-machine",
+          entityType: "project",
+          title: "Habermas Machine",
+          description: "A deliberation tool.",
+          organization: "deepmind",
+        },
+      ],
+      filterType: "project",
+    });
+
+    const projectIssues = results.find((r) => r.entityType === "project")?.issues ?? [];
+    const slugLeaks = projectIssues.filter((i) => i.issueType === "slug-in-display");
+    expect(slugLeaks).toEqual([]);
+  });
+});

--- a/crux/validate/validate-directory-pages.ts
+++ b/crux/validate/validate-directory-pages.ts
@@ -19,6 +19,7 @@
 
 import { join } from "path";
 import { readFileSync, existsSync } from "fs";
+import { fileURLToPath } from "url";
 import { PROJECT_ROOT, ensureDataLayer } from "../lib/content-types.ts";
 import { getColors } from "../lib/output.ts";
 
@@ -225,19 +226,21 @@ export function runValidation(opts: {
       // when found, so a slug that resolves never reaches the user. Only flag
       // slugs that don't resolve — those genuinely leak via the fallback path
       // in apps/web/src/app/<directory>/page.tsx (e.g. orgName = orgId).
+      // Use Map.has() (existence) rather than truthy-checking the value: an
+      // entity with an empty/undefined title is still a real entity that the
+      // rendering layer would resolve, just to a different display string.
       for (const field of config.displayFields) {
         if (field === "title") continue;
         const value = entity[field];
         if (typeof value === "string" && looksLikeSlug(value)) {
-          const resolvedTitle = entityTitleById.get(value);
-          if (resolvedTitle) continue;
+          if (entityTitleById.has(value)) continue;
           issues.push({
             entityId: id,
             entityTitle: title,
             issueType: "slug-in-display",
             field,
             value,
-            detail: field + " contains slug-like value \"" + value + "\" with no matching entity (will leak to user)",
+            detail: field + " contains slug-like value \"" + value + "\" with no matching entity (will leak to user via rendering fallback)",
           });
         }
       }
@@ -444,7 +447,11 @@ async function main(): Promise<void> {
   console.log("");
 }
 
-if (process.argv[1]?.includes("validate-directory-pages")) {
+// Only run main() when invoked as a script — not when imported by tests.
+// Use exact-path comparison rather than substring match so an importing test
+// file that happens to contain "validate-directory-pages" in its path doesn't
+// trigger the CLI side effects.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main().catch((err) => {
     console.error("Directory page validation crashed:", err);
     process.exit(1);

--- a/crux/validate/validate-directory-pages.ts
+++ b/crux/validate/validate-directory-pages.ts
@@ -150,32 +150,14 @@ function isReasonableDateFormat(value: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Core validation (testable)
 // ---------------------------------------------------------------------------
 
-async function main(): Promise<void> {
-  const verbose = process.argv.includes("--verbose");
-  const ci = process.argv.includes("--ci");
-  const c = getColors(ci);
-
-  const typeArg = process.argv.find((a) => a.startsWith("--type="));
-  const filterType = typeArg ? typeArg.split("=")[1] : null;
-
-  ensureDataLayer();
-
-  const dbPath = join(PROJECT_ROOT, "apps/web/src/data/database.json");
-  if (!existsSync(dbPath)) {
-    console.error(c.red + "database.json not found. Run: pnpm build-data" + c.reset);
-    process.exit(1);
-  }
-
-  const db = JSON.parse(readFileSync(dbPath, "utf-8"));
-  const typedEntities: Record<string, unknown>[] = db.typedEntities || [];
-
-  if (typedEntities.length === 0) {
-    console.error(c.red + "No typedEntities in database.json." + c.reset);
-    process.exit(1);
-  }
+export function runValidation(opts: {
+  typedEntities: Record<string, unknown>[];
+  filterType?: string | null;
+}): { results: DirectoryResult[] } {
+  const { typedEntities, filterType = null } = opts;
 
   const entitiesByType = new Map<string, Record<string, unknown>[]>();
   for (const entity of typedEntities) {
@@ -194,12 +176,6 @@ async function main(): Promise<void> {
   const configs = filterType
     ? DIRECTORY_CONFIGS.filter((d) => d.entityType === filterType)
     : DIRECTORY_CONFIGS;
-
-  if (filterType && configs.length === 0) {
-    console.error(c.red + "Unknown entity type: " + filterType + c.reset);
-    console.error("Valid types: " + DIRECTORY_CONFIGS.map((d) => d.entityType).join(", "));
-    process.exit(1);
-  }
 
   const results: DirectoryResult[] = [];
 
@@ -244,21 +220,24 @@ async function main(): Promise<void> {
         }
       }
 
-      // Check 3: Display fields contain slug-like values
+      // Check 3: Display fields contain slug-like values that won't resolve.
+      // Directory pages call getTypedEntityById(slug) and render entity.title
+      // when found, so a slug that resolves never reaches the user. Only flag
+      // slugs that don't resolve — those genuinely leak via the fallback path
+      // in apps/web/src/app/<directory>/page.tsx (e.g. orgName = orgId).
       for (const field of config.displayFields) {
         if (field === "title") continue;
         const value = entity[field];
         if (typeof value === "string" && looksLikeSlug(value)) {
           const resolvedTitle = entityTitleById.get(value);
+          if (resolvedTitle) continue;
           issues.push({
             entityId: id,
             entityTitle: title,
             issueType: "slug-in-display",
             field,
             value,
-            detail: resolvedTitle
-              ? field + " shows slug \"" + value + "\" instead of \"" + resolvedTitle + "\""
-              : field + " contains slug-like value \"" + value + "\"",
+            detail: field + " contains slug-like value \"" + value + "\" with no matching entity (will leak to user)",
           });
         }
       }
@@ -290,6 +269,45 @@ async function main(): Promise<void> {
       fieldCoverage,
     });
   }
+
+  return { results };
+}
+
+// ---------------------------------------------------------------------------
+// Main (CLI entry point)
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const verbose = process.argv.includes("--verbose");
+  const ci = process.argv.includes("--ci");
+  const c = getColors(ci);
+
+  const typeArg = process.argv.find((a) => a.startsWith("--type="));
+  const filterType = typeArg ? typeArg.split("=")[1] : null;
+
+  ensureDataLayer();
+
+  const dbPath = join(PROJECT_ROOT, "apps/web/src/data/database.json");
+  if (!existsSync(dbPath)) {
+    console.error(c.red + "database.json not found. Run: pnpm build-data" + c.reset);
+    process.exit(1);
+  }
+
+  const db = JSON.parse(readFileSync(dbPath, "utf-8"));
+  const typedEntities: Record<string, unknown>[] = db.typedEntities || [];
+
+  if (typedEntities.length === 0) {
+    console.error(c.red + "No typedEntities in database.json." + c.reset);
+    process.exit(1);
+  }
+
+  if (filterType && !DIRECTORY_CONFIGS.some((d) => d.entityType === filterType)) {
+    console.error(c.red + "Unknown entity type: " + filterType + c.reset);
+    console.error("Valid types: " + DIRECTORY_CONFIGS.map((d) => d.entityType).join(", "));
+    process.exit(1);
+  }
+
+  const { results } = runValidation({ typedEntities, filterType });
 
   // ── Output ──────────────────────────────────────────────────────
 
@@ -426,7 +444,9 @@ async function main(): Promise<void> {
   console.log("");
 }
 
-main().catch((err) => {
-  console.error("Directory page validation crashed:", err);
-  process.exit(1);
-});
+if (process.argv[1]?.includes("validate-directory-pages")) {
+  main().catch((err) => {
+    console.error("Directory page validation crashed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

QA sweep ticket QUA-899 claimed `/projects` showed raw kebab-case slugs in the Organization column for 4 rows. Verified against prod via Playwright — the page actually renders the resolved titles ("AI Objectives Institute", "Computational Democracy Project", "AI & Democracy Foundation"). The slugs only appear in href URLs, which is correct.

The premise of the bug was wrong. The actual issue was the `validate-directory-pages` validator: it flagged any 3+ part kebab-case value in a display field, but the rendering layer (`apps/web/src/app/projects/page.tsx:86-89`) calls `getTypedEntityById(slug)` and uses `entity.title` when found. As long as the slug resolves to a known entity, the user sees the title — never the slug.

This PR tightens the validator to only flag slug-shaped values that **don't** resolve to a known entity, which is the genuine bug pattern (the rendering fallback `orgName = orgId` only fires for unresolved slugs).

### Changes

- `crux/validate/validate-directory-pages.ts`: skip `slug-in-display` issues when the slug resolves to a known entity (existence-based via `Map.has()`, not truthy-based — an entity with empty title is still a real entity).
- Refactored `main()` to extract a testable `runValidation()` and gated auto-run behind a strict `fileURLToPath(import.meta.url) === process.argv[1]` check (matches `validate-orphan-entities.ts` pattern).
- New `crux/validate/__tests__/validate-directory-pages.test.ts` — 7 tests covering the resolved/unresolved slug paths, the empty-title regression, and the other three issue types (title-is-slug, missing-field, bad-date-format).

### Hostile review findings (`/agent-review-pr`)

- **HIGH** — Resolved-title check used truthy-check (`if (resolvedTitle) continue`), which would re-flag entities with empty `title=""`. Fixed to existence-based `entityTitleById.has(value)`.
- **MEDIUM** — Argv guard used substring `includes()` which could fire when a path containing the substring (e.g., a test file) was argv[1]. Tightened to exact path comparison.
- **MEDIUM** — Test coverage was thin (1 issue type out of 4). Expanded to 7 tests covering all four.
- LOW findings (presumptuous detail strings, type cast precision) noted but not addressed in this PR.

## Test plan

- [x] `pnpm vitest run crux/validate/__tests__/` — 38 tests pass (7 new for directory-pages)
- [x] `pnpm crux w validate directory-pages` — 0 slug-in-display issues across all directories (down from 4)
- [x] `pnpm crux w validate gate --fix` — 60 checks pass (2 advisory warnings pre-existing)
- [x] `pnpm crux validate gate --scope=content --no-cache` — exits 0 in 99.5s
- [x] Verified prod /projects renders resolved org titles via Playwright (slugs only appear in `href` URLs)
- [x] CLI invocation works for valid type, invalid type (errors), and `--ci` JSON mode

Note: `pnpm test` reports 1 pre-existing flake in `validate/scope-flag.test.ts` — that test spawns the gate as a subprocess with a 120s timeout, and the gate run takes ~99s standalone, so it intermittently times out under test-runner load. Unrelated to this PR's changes (the modified validator is not part of `--scope=content`).

Closes QUA-899


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive test coverage for directory page validation, including slug resolution and multiple validation issue types.

## Refactor
* Improved slug-in-display detection logic to use entity existence checks instead of title resolution.
* Enhanced error messages for unresolved slugs in directory pages to clarify rendering fallback behavior.
* Restructured validation logic for better testability and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->