### PR TITLE
QUA-927: url-resolves verifier — cheap path for URL-only fact properties

### DIFF
--- a/crux/lib/sourcing/item-collectors.ts
+++ b/crux/lib/sourcing/item-collectors.ts
@@ -191,8 +191,12 @@ export function collectFactItems(
       if (!fact.source || fact.id.startsWith('inv_')) continue;
 
       const property = graph.getProperty(fact.propertyId);
-      // Skip properties marked as not verifiable (e.g., social media handles, self-referential URLs)
-      if (property?.verifiable === false) continue;
+      // QUA-927: properties marked as `verifierKind: url-resolves` get a cheap
+      // HEAD-only check, bypassing the `verifiable: false` skip even if it was
+      // historically set (e.g., wikipedia-url / social-media). The url-resolves
+      // verifier kicks in below in item-verifier.ts based on the propagated
+      // verifierKind on FactItemData.
+      if (property?.verifiable === false && property?.verifierKind !== 'url-resolves') continue;
       const formattedValue = formatFactValue(fact, property, graph);
       const existing = existingVerdicts.get(fact.id);
 
@@ -213,8 +217,10 @@ export function collectFactItems(
           entity,
           fact,
           propertyName: property?.name ?? fact.propertyId,
+          propertyId: fact.propertyId,
           formattedValue,
           rawValue: extractRawValue(fact),
+          verifierKind: property?.verifierKind,
         },
       });
     }

--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -25,6 +25,7 @@ import {
 import { matchRecordAgainstSnapshot } from './deterministic-matcher.ts';
 import { tryWikidataMatch } from './wikidata-matcher.ts';
 import { tryOpenAlexMatch } from './openalex-matcher.ts';
+import { tryUrlResolvesVerify } from './url-resolves-verifier.ts';
 import { searchForEntity } from './item-collectors.ts';
 import { isRelevanceGateEnabled, runRelevanceGate } from './relevance-gate.ts';
 import type {
@@ -286,6 +287,20 @@ export async function verifySingleItem(
   client: ReturnType<typeof createLlmClient>,
   useWebSearch: boolean,
 ): Promise<VerifyResult | VerifyError> {
+  // ── URL-resolves verifier (QUA-927) ──
+  // Cheapest path: facts with `verifierKind: url-resolves` are verified by an
+  // HTTP HEAD request, no LLM, no source-content fetch. Returns null when the
+  // fact isn't tagged for url-resolves verification, so this is safe to run
+  // unconditionally.
+  if (item.data.kind === 'fact' && item.data.verifierKind === 'url-resolves') {
+    try {
+      const urlResolvesResult = await tryUrlResolvesVerify(item);
+      if (urlResolvesResult) return urlResolvesResult;
+    } catch (e: unknown) {
+      console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
   // ── Deterministic matching path (Discussion #3567 Phase 3) ──
   // For any record-type item, try deterministic row-matching against a source
   // snapshot before falling back to LLM sourcing. tryDeterministicMatch

--- a/crux/lib/sourcing/orchestrator-types.ts
+++ b/crux/lib/sourcing/orchestrator-types.ts
@@ -62,9 +62,21 @@ export interface FactItemData {
   entity: FBEntity;
   fact: Fact;
   propertyName: string;
+  /**
+   * Property ID (e.g. `wikipedia-url`, `revenue`). Distinct from `propertyName`,
+   * which is the human-readable display name. Used by the url-resolves verifier
+   * to dispatch property-specific behavior (Wikipedia title check vs plain HEAD).
+   * Optional for back-compat; `verifierKind: url-resolves` items always set it.
+   */
+  propertyId?: string;
   formattedValue: string;
   /** Raw numeric/text value from YAML, before display formatting (avoids rounding false positives) */
   rawValue?: string;
+  /**
+   * How this fact should be verified (QUA-927). Default `content-claim`.
+   * `url-resolves` triggers a cheap HTTP HEAD-only check instead of fetch+LLM.
+   */
+  verifierKind?: 'content-claim' | 'url-resolves';
 }
 
 export interface RecordItemData {

--- a/crux/lib/sourcing/orchestrator.ts
+++ b/crux/lib/sourcing/orchestrator.ts
@@ -27,6 +27,7 @@ import {
   buildEntitySourcingPrompt,
   MODELS,
 } from './item-verifier.ts';
+import { tryUrlResolvesVerify } from './url-resolves-verifier.ts';
 import { prefetchWikidataEntities } from './wikidata-matcher.ts';
 import { clampSourcingConcurrency } from './concurrency.ts';
 import { fetchSourceContent } from './source-fetcher.ts';
@@ -286,6 +287,32 @@ async function runBatchExecution(
   async function prepareItem(item: VerifyItem, index: number): Promise<void> {
     preparedCount++;
     const progress = `[${preparedCount}/${itemsToVerify.length}]`;
+
+    // URL-resolves verifier (QUA-927): handle inline, never queue for LLM batch.
+    // These checks are ~10ms each so concurrency is fine, and the result is
+    // final (no LLM second opinion).
+    if (item.data.kind === 'fact' && item.data.verifierKind === 'url-resolves') {
+      try {
+        const urlResolvesResult = await tryUrlResolvesVerify(item);
+        if (urlResolvesResult) {
+          summary[urlResolvesResult.verdict]++;
+          summary.actualVerified++;
+          summary.byKind[item.kind].verified++;
+          summary.results.push(urlResolvesResult);
+          console.log(`  ${progress} ${item.description.slice(0, 80)}`);
+          console.log(`    \x1b[32murl-resolves: ${urlResolvesResult.verdict}\x1b[0m`);
+          try {
+            await storeResult(item, urlResolvesResult);
+          } catch (e: unknown) {
+            summary.storageErrors++;
+            console.warn(`[sourcing] Storage failed: ${e instanceof Error ? e.message : String(e)}`);
+          }
+          return;
+        }
+      } catch (e: unknown) {
+        console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
 
     // Handle deterministic matching for any record type first (falls through
     // to LLM when no manifest matches the source URL)

--- a/crux/lib/sourcing/url-resolves-verifier.test.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.test.ts
@@ -12,6 +12,9 @@ import {
   probeUrlResolves,
   probeWikipediaUrl,
   extractWikipediaTitle,
+  decodeHtmlEntities,
+  titleContainsEntityName,
+  rejectIfInternalHost,
 } from './url-resolves-verifier.ts';
 import type { VerifyItem, FactItemData } from './orchestrator-types.ts';
 
@@ -134,7 +137,7 @@ describe('tryUrlResolvesVerify', () => {
     expect(result).not.toBeNull();
     expect(result!.verdict).toBe('unverifiable');
     expect(result!.checkerModel).toBe('url-resolves');
-    expect(result!.reasoning).toContain('not a URL');
+    expect(result!.reasoning).toContain('not an http(s) URL');
   });
 
   it('returns unverifiable when fact value is empty', async () => {
@@ -145,7 +148,20 @@ describe('tryUrlResolvesVerify', () => {
     });
     const result = await tryUrlResolvesVerify(item);
     expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not a URL');
+    expect(result!.reasoning).toContain('not an http(s) URL');
+  });
+
+  it('returns unverifiable when rawValue is missing (no formattedValue fallback)', async () => {
+    // formattedValue can carry display formatting (units, parens), so we
+    // refuse to fall back to it. rawValue must be present.
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: undefined,
+      formattedValue: 'https://github.com/anthropics',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('not an http(s) URL');
   });
 
   it('returns unverifiable for non-http(s) URLs (e.g., ftp)', async () => {
@@ -156,7 +172,108 @@ describe('tryUrlResolvesVerify', () => {
     });
     const result = await tryUrlResolvesVerify(item);
     expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not a URL');
+    expect(result!.reasoning).toContain('not an http(s) URL');
+  });
+
+  it('returns unverifiable for URLs with embedded credentials', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'https://user:pass@github.com/anthropics',
+      formattedValue: 'https://user:pass@github.com/anthropics',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('not an http(s) URL');
+  });
+
+  it('SSRF: rejects loopback URLs without making any request', async () => {
+    let fetchCalled = false;
+    setMockBehavior(() => {
+      fetchCalled = true;
+      return { status: 200 };
+    });
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'http://127.0.0.1/admin',
+      formattedValue: 'http://127.0.0.1/admin',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(fetchCalled).toBe(false);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toMatch(/loopback|internal/);
+  });
+
+  it('SSRF: rejects RFC1918 private addresses', async () => {
+    const cases = [
+      'http://10.0.0.1/',
+      'http://192.168.1.1/',
+      'http://172.16.0.1/',
+      'http://172.31.255.255/',
+    ];
+    for (const url of cases) {
+      const item = makeFactItem({
+        propertyId: 'github-profile',
+        rawValue: url,
+        formattedValue: url,
+      });
+      const result = await tryUrlResolvesVerify(item);
+      expect(result!.verdict, `${url} should be rejected`).toBe('unverifiable');
+      expect(result!.reasoning).toMatch(/private|loopback|link-local|internal/);
+    }
+  });
+
+  it('SSRF: rejects link-local 169.254/16', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'http://169.254.169.254/latest/meta-data/',
+      formattedValue: 'http://169.254.169.254/latest/meta-data/',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('link-local');
+  });
+
+  it('SSRF: rejects localhost and .internal/.local hostnames', async () => {
+    const cases = [
+      'http://localhost/',
+      'http://wiki-server.internal/',
+      'http://printer.local/',
+    ];
+    for (const url of cases) {
+      const item = makeFactItem({
+        propertyId: 'github-profile',
+        rawValue: url,
+        formattedValue: url,
+      });
+      const result = await tryUrlResolvesVerify(item);
+      expect(result!.verdict, `${url} should be rejected`).toBe('unverifiable');
+    }
+  });
+
+  it('SSRF: rejects IPv6 loopback ::1', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'http://[::1]/',
+      formattedValue: 'http://[::1]/',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toMatch(/loopback IPv6/);
+  });
+
+  it('SSRF: detects redirect to internal host and downgrades verdict', async () => {
+    setMockBehavior(() => ({
+      status: 200,
+      finalUrl: 'http://10.0.0.1/internal-api',
+    }));
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'https://link.example.com/redirect',
+      formattedValue: 'https://link.example.com/redirect',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('internal host');
   });
 });
 
@@ -264,6 +381,55 @@ describe('probeWikipediaUrl', () => {
     expect(result.verdict).toBe('contradicted');
     expect(result.pageTitle).toBe('Disambiguation page');
     expect(result.reasoning).toContain('does not contain');
+  });
+
+  it('does NOT confirm when entity name is a substring of a different word (word-boundary)', async () => {
+    // QUA-927 review fix: "Foo" should not match "Foobar - Wikipedia"
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Foobar') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Foo',
+      'Foo',
+    );
+    expect(result.verdict).toBe('contradicted');
+  });
+
+  it('does NOT confirm short acronym matching part of a larger word', async () => {
+    // "AI" matching "AIDS" or "Aircraft" was the worst-case substring trap
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Aircraft') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/AI',
+      'AI',
+    );
+    expect(result.verdict).toBe('contradicted');
+  });
+
+  it('confirms acronym match at a word boundary', async () => {
+    // "AI" should still match "AI safety - Wikipedia" — whole word
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('AI safety') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/AI_safety',
+      'AI',
+    );
+    expect(result.verdict).toBe('confirmed');
+  });
+
+  it('confirms multi-word entity at word boundaries', async () => {
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Geoffrey Hinton (researcher)') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Geoffrey_Hinton',
+      'Geoffrey Hinton',
+    );
+    expect(result.verdict).toBe('confirmed');
+  });
+
+  it('confirms across hyphen/space differences (normalized)', async () => {
+    // Title may use a hyphen where entity name has a space (or vice versa).
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Foo-Bar Inc') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Foo-Bar',
+      'Foo Bar',
+    );
+    expect(result.verdict).toBe('confirmed');
   });
 
   it('contradicts on 404 (link rot)', async () => {
@@ -374,5 +540,170 @@ describe('tryUrlResolvesVerify (end-to-end)', () => {
     });
     const result = await tryUrlResolvesVerify(item);
     expect(result!.verdict).toBe('unverifiable');
+  });
+});
+
+// ── decodeHtmlEntities ─────────────────────────────────────────────
+
+describe('decodeHtmlEntities', () => {
+  it('decodes named entities used by Wikipedia', () => {
+    expect(decodeHtmlEntities('AT&amp;T')).toBe('AT&T');
+    expect(decodeHtmlEntities('a &lt;b&gt; c')).toBe('a <b> c');
+    expect(decodeHtmlEntities('&quot;Hi&quot;')).toBe('"Hi"');
+    expect(decodeHtmlEntities("don&#39;t")).toBe("don't");
+    expect(decodeHtmlEntities("don&apos;t")).toBe("don't");
+    expect(decodeHtmlEntities('a&nbsp;b')).toBe('a b');
+    expect(decodeHtmlEntities('Foo &mdash; Bar')).toBe('Foo — Bar');
+    expect(decodeHtmlEntities('&copy; 2026')).toBe('© 2026');
+  });
+
+  it('decodes decimal numeric entities (&#NN;)', () => {
+    // Citroën uses &#235; for "ë"
+    expect(decodeHtmlEntities('Citro&#235;n')).toBe('Citroën');
+    // São Paulo uses &#227; for "ã"
+    expect(decodeHtmlEntities('S&#227;o Paulo')).toBe('São Paulo');
+  });
+
+  it('decodes hex numeric entities (&#xNN;)', () => {
+    expect(decodeHtmlEntities('Citro&#xeb;n')).toBe('Citroën');
+    expect(decodeHtmlEntities('S&#xE3;o Paulo')).toBe('São Paulo');
+  });
+
+  it('decodes &amp; LAST so &amp;lt; becomes &lt; not <', () => {
+    expect(decodeHtmlEntities('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('returns input unchanged when no entities present', () => {
+    expect(decodeHtmlEntities('plain text')).toBe('plain text');
+  });
+
+  it('ignores invalid numeric entities (out of unicode range)', () => {
+    expect(decodeHtmlEntities('&#9999999999;')).toBe('');
+    expect(decodeHtmlEntities('&#x110000;')).toBe('');
+  });
+
+  it('Wikipedia title with numeric entity end-to-end', () => {
+    expect(extractWikipediaTitle('<title>Citro&#235;n - Wikipedia</title>')).toBe('Citroën');
+  });
+});
+
+// ── titleContainsEntityName ────────────────────────────────────────
+
+describe('titleContainsEntityName', () => {
+  it('matches whole-word at start, middle, end', () => {
+    expect(titleContainsEntityName('Anthropic - Wikipedia', 'Anthropic')).toBe(true);
+    expect(titleContainsEntityName('History of Anthropic Inc', 'Anthropic')).toBe(true);
+    expect(titleContainsEntityName('Founders of Anthropic', 'Anthropic')).toBe(true);
+  });
+
+  it('rejects substring-of-larger-word', () => {
+    expect(titleContainsEntityName('Foobar', 'Foo')).toBe(false);
+    expect(titleContainsEntityName('Aircraft', 'AI')).toBe(false);
+    expect(titleContainsEntityName('OpenSSL Project', 'Open')).toBe(false);
+  });
+
+  it('case-insensitive', () => {
+    expect(titleContainsEntityName('Anthropic Inc', 'ANTHROPIC')).toBe(true);
+    expect(titleContainsEntityName('ANTHROPIC INC', 'anthropic')).toBe(true);
+  });
+
+  it('returns false on empty input', () => {
+    expect(titleContainsEntityName('', 'Anthropic')).toBe(false);
+    expect(titleContainsEntityName('Anthropic', '')).toBe(false);
+  });
+
+  it('matches across hyphen/space punctuation differences', () => {
+    // hyphens, periods, parens collapse to spaces — words still align as tokens
+    expect(titleContainsEntityName('Foo-Bar Inc', 'Foo Bar')).toBe(true);
+    expect(titleContainsEntityName('Yann Lecun', 'Yann LeCun')).toBe(true);
+  });
+});
+
+// ── rejectIfInternalHost ───────────────────────────────────────────
+
+describe('rejectIfInternalHost', () => {
+  it('accepts public URLs', () => {
+    expect(rejectIfInternalHost('https://en.wikipedia.org/wiki/Foo')).toBeNull();
+    expect(rejectIfInternalHost('https://github.com/anthropics')).toBeNull();
+    expect(rejectIfInternalHost('https://scholar.google.com/citations')).toBeNull();
+  });
+
+  it('rejects loopback IPv4', () => {
+    expect(rejectIfInternalHost('http://127.0.0.1/')).toContain('loopback');
+    expect(rejectIfInternalHost('http://127.255.255.254/')).toContain('loopback');
+  });
+
+  it('rejects 10/8', () => {
+    expect(rejectIfInternalHost('http://10.0.0.1/')).toContain('10/8');
+    expect(rejectIfInternalHost('http://10.255.255.255/')).toContain('10/8');
+  });
+
+  it('rejects 172.16/12', () => {
+    expect(rejectIfInternalHost('http://172.16.0.1/')).toContain('172.16/12');
+    expect(rejectIfInternalHost('http://172.31.255.255/')).toContain('172.16/12');
+  });
+
+  it('accepts 172.32+ (outside private range)', () => {
+    expect(rejectIfInternalHost('http://172.32.0.1/')).toBeNull();
+    expect(rejectIfInternalHost('http://172.15.0.1/')).toBeNull();
+  });
+
+  it('rejects 192.168/16', () => {
+    expect(rejectIfInternalHost('http://192.168.1.1/')).toContain('192.168/16');
+  });
+
+  it('rejects 169.254/16 (link-local / AWS metadata)', () => {
+    expect(rejectIfInternalHost('http://169.254.169.254/')).toContain('link-local');
+  });
+
+  it('rejects CGNAT 100.64-127', () => {
+    expect(rejectIfInternalHost('http://100.64.0.1/')).toContain('CGNAT');
+    expect(rejectIfInternalHost('http://100.127.255.255/')).toContain('CGNAT');
+  });
+
+  it('rejects 0.0.0.0', () => {
+    expect(rejectIfInternalHost('http://0.0.0.0/')).toContain('null route');
+  });
+
+  it('rejects localhost', () => {
+    expect(rejectIfInternalHost('http://localhost/')).toContain('local-only');
+    expect(rejectIfInternalHost('http://api.localhost/')).toContain('local-only');
+  });
+
+  it('rejects .internal/.local/.lan TLDs', () => {
+    expect(rejectIfInternalHost('http://wiki-server.internal/')).toContain('internal-only');
+    expect(rejectIfInternalHost('http://printer.local/')).toContain('internal-only');
+    expect(rejectIfInternalHost('http://router.lan/')).toContain('internal-only');
+  });
+
+  it('rejects IPv6 loopback ::1', () => {
+    expect(rejectIfInternalHost('http://[::1]/')).toContain('loopback IPv6');
+  });
+
+  it('rejects IPv6 link-local fe80::', () => {
+    expect(rejectIfInternalHost('http://[fe80::1]/')).toContain('link-local IPv6');
+  });
+
+  it('rejects IPv6 unique-local fc00::/7', () => {
+    expect(rejectIfInternalHost('http://[fc00::1]/')).toContain('unique-local IPv6');
+    expect(rejectIfInternalHost('http://[fd00::1]/')).toContain('unique-local IPv6');
+  });
+
+  it('rejects IPv4-mapped IPv6 of internal address', () => {
+    const r1 = rejectIfInternalHost('http://[::ffff:127.0.0.1]/');
+    const r2 = rejectIfInternalHost('http://[::ffff:10.0.0.1]/');
+    expect(r1).not.toBeNull();
+    expect(r1).toMatch(/loopback|IPv4-mapped/);
+    expect(r2).not.toBeNull();
+    expect(r2).toMatch(/private|IPv4-mapped/);
+  });
+
+  it('rejects unsupported protocols', () => {
+    expect(rejectIfInternalHost('ftp://example.com/')).toContain('unsupported protocol');
+    expect(rejectIfInternalHost('file:///etc/passwd')).toContain('unsupported protocol');
+  });
+
+  it('rejects unparseable URLs', () => {
+    expect(rejectIfInternalHost('not a url')).toContain('unparseable');
   });
 });

--- a/crux/lib/sourcing/url-resolves-verifier.test.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.test.ts
@@ -1,74 +1,98 @@
 /**
  * Tests for the url-resolves verifier (QUA-927).
  *
- * Mocks `globalThis.fetch` so individual tests can drive the verifier through
- * 2xx, 3xx, 4xx, 5xx, network errors, HEAD-not-allowed, and the Wikipedia
- * title-match path without touching the network.
+ * The verifier consumes the Resource pipeline (`lookupResourceByUrl`,
+ * `getCitationContentByUrl`, `suggestResourcesApi`) — it does not fetch URLs.
+ * Tests mock those three modules and exercise the decision tree:
+ *   - cached citation_content with 2xx httpStatus     → confirmed
+ *   - Wikipedia + 2xx + matching pageTitle            → confirmed
+ *   - Wikipedia + 2xx + non-matching pageTitle        → contradicted
+ *   - cached citation_content with 4xx/5xx            → contradicted
+ *   - resources.fetchStatus is dead/soft_404/etc.     → contradicted
+ *   - resources.fetchStatus is paywall                → confirmed (URL alive)
+ *   - no cached state                                  → unverifiable, ingest enqueued
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   tryUrlResolvesVerify,
-  probeUrlResolves,
-  probeWikipediaUrl,
-  extractWikipediaTitle,
-  decodeHtmlEntities,
+  resolveFromResourcePipeline,
   titleContainsEntityName,
-  rejectIfInternalHost,
 } from './url-resolves-verifier.ts';
 import type { VerifyItem, FactItemData } from './orchestrator-types.ts';
 
-// ── Fetch mock plumbing ─────────────────────────────────────────────
+// ── Module mocks ────────────────────────────────────────────────────
 
-interface MockResponse {
-  status: number;
-  /** Final URL after redirects (defaults to request URL). */
-  finalUrl?: string;
-  /** Body returned by GET. Ignored for HEAD. */
-  body?: string;
-  /**
-   * If set, mark .body as null so readCappedText returns ''. Lets us simulate
-   * a 200-OK Wikipedia response with no body (rare but possible).
-   */
-  noBody?: boolean;
-}
+vi.mock('../wiki-server/citations.ts', () => ({
+  getCitationContentByUrl: vi.fn(async () => ({ ok: false, status: 404, message: 'not found' })),
+}));
 
-interface MockBehavior {
-  /** Hook: return a MockResponse, or `'throw'` to simulate a network error. */
-  (url: string, method: string): MockResponse | 'throw';
-}
+vi.mock('../wiki-server/resources.ts', () => ({
+  lookupResourceByUrl: vi.fn(async () => ({ ok: false, status: 404, message: 'not found' })),
+  suggestResourcesApi: vi.fn(async () => ({ ok: true, data: { suggested: [], skipped: [] } })),
+}));
 
-let currentBehavior: MockBehavior = () => ({ status: 200 });
+import { getCitationContentByUrl } from '../wiki-server/citations.ts';
+import { lookupResourceByUrl, suggestResourcesApi } from '../wiki-server/resources.ts';
 
-function setMockBehavior(b: MockBehavior): void {
-  currentBehavior = b;
-}
+const getCitationContentByUrlMock = vi.mocked(getCitationContentByUrl);
+const lookupResourceByUrlMock = vi.mocked(lookupResourceByUrl);
+const suggestResourcesApiMock = vi.mocked(suggestResourcesApi);
 
 beforeEach(() => {
-  // Default: every request returns 200. Tests override per-case.
-  setMockBehavior(() => ({ status: 200 }));
+  vi.clearAllMocks();
+  // Default: nothing cached anywhere.
+  getCitationContentByUrlMock.mockResolvedValue({ ok: false, status: 404, message: 'not found' } as never);
+  lookupResourceByUrlMock.mockResolvedValue({ ok: false, status: 404, message: 'not found' } as never);
+  suggestResourcesApiMock.mockResolvedValue({ ok: true, data: { suggested: [], skipped: [] } } as never);
 });
 
-vi.stubGlobal(
-  'fetch',
-  vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
-    const method = (init?.method ?? 'GET').toUpperCase();
-    const out = currentBehavior(url, method);
-    if (out === 'throw') {
-      throw new Error('mock network error');
-    }
-    const finalUrl = out.finalUrl ?? url;
-    const body = out.body ?? '';
-    // Build a real Response so .body / .text() / status all behave normally.
-    const init2: ResponseInit = { status: out.status };
-    const responseBody = out.noBody ? null : new Blob([body]);
-    const response = new Response(responseBody, init2);
-    // Response.url is read-only; override via Object.defineProperty so the
-    // verifier sees the final-after-redirects URL like real fetch.
-    Object.defineProperty(response, 'url', { value: finalUrl, configurable: true });
-    return response;
-  }),
-);
+// ── Helpers to construct mock responses ────────────────────────────
+
+function citationContent(overrides: {
+  httpStatus?: number | null;
+  pageTitle?: string | null;
+  fetchedAt?: string;
+  fullText?: string | null;
+}): { ok: true; data: unknown } {
+  return {
+    ok: true,
+    data: {
+      url: 'https://example.com',
+      resourceId: null,
+      fetchedAt: overrides.fetchedAt ?? '2026-04-30T00:00:00.000Z',
+      httpStatus: overrides.httpStatus ?? null,
+      contentType: 'text/html',
+      pageTitle: overrides.pageTitle ?? null,
+      fullTextPreview: null,
+      fullText: overrides.fullText ?? null,
+      contentLength: null,
+      contentHash: null,
+      fetchMethod: 'firecrawl',
+      createdAt: '2026-04-30T00:00:00.000Z',
+      updatedAt: '2026-04-30T00:00:00.000Z',
+    },
+  };
+}
+
+function resourceRow(overrides: {
+  fetchStatus?: 'ok' | 'dead' | 'soft_404' | 'not_found' | 'timeout' | 'unreachable' | 'paywall' | 'error' | null;
+  archiveUrl?: string;
+}): { ok: true; data: unknown } {
+  return {
+    ok: true,
+    data: {
+      id: 'r_test_001',
+      url: 'https://example.com',
+      title: 'Test',
+      type: 'webpage',
+      fetchStatus: overrides.fetchStatus ?? null,
+      archiveUrl: overrides.archiveUrl,
+      contentHash: null,
+      lastFetchedAt: '2026-04-30T00:00:00.000Z',
+    },
+  };
+}
 
 // ── Test fixtures ───────────────────────────────────────────────────
 
@@ -102,9 +126,9 @@ function makeFactItem(overrides: Partial<FactItemData> = {}): VerifyItem {
   };
 }
 
-// ── tryUrlResolvesVerify dispatch ──────────────────────────────────
+// ── Dispatch ─────────────────────────────────────────────────────────
 
-describe('tryUrlResolvesVerify', () => {
+describe('tryUrlResolvesVerify dispatch', () => {
   it('returns null when fact has no verifierKind', async () => {
     const item = makeFactItem({ verifierKind: undefined });
     const result = await tryUrlResolvesVerify(item);
@@ -126,584 +150,299 @@ describe('tryUrlResolvesVerify', () => {
     expect(result).toBeNull();
   });
 
+  it('does not call the Resource pipeline when verifierKind is unset', async () => {
+    const item = makeFactItem({ verifierKind: undefined });
+    await tryUrlResolvesVerify(item);
+    expect(lookupResourceByUrlMock).not.toHaveBeenCalled();
+    expect(getCitationContentByUrlMock).not.toHaveBeenCalled();
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('URL pre-validation', () => {
   it('returns unverifiable when fact value is not a URL', async () => {
     const item = makeFactItem({
       propertyId: 'github-profile',
       rawValue: 'just-a-username',
       formattedValue: 'just-a-username',
-      verifierKind: 'url-resolves',
     });
     const result = await tryUrlResolvesVerify(item);
-    expect(result).not.toBeNull();
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.checkerModel).toBe('url-resolves');
-    expect(result!.reasoning).toContain('not an http(s) URL');
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.checkerModel).toBe('url-resolves');
+    expect(result?.reasoning).toContain('not an http(s) URL');
   });
 
-  it('returns unverifiable when fact value is empty', async () => {
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: '',
-      formattedValue: '',
-    });
+  it('rejects ftp:// scheme without enqueueing', async () => {
+    const item = makeFactItem({ rawValue: 'ftp://example.com/file' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not an http(s) URL');
+    expect(result?.verdict).toBe('unverifiable');
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
   });
 
-  it('returns unverifiable when rawValue is missing (no formattedValue fallback)', async () => {
-    // formattedValue can carry display formatting (units, parens), so we
-    // refuse to fall back to it. rawValue must be present.
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: undefined,
-      formattedValue: 'https://github.com/anthropics',
-    });
+  it('rejects URLs with embedded credentials without enqueueing', async () => {
+    const item = makeFactItem({ rawValue: 'https://user:pass@example.com' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not an http(s) URL');
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.reasoning).toContain('not an http(s) URL');
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
   });
 
-  it('returns unverifiable for non-http(s) URLs (e.g., ftp)', async () => {
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'ftp://example.com',
-      formattedValue: 'ftp://example.com',
-    });
+  it('returns unverifiable on empty rawValue', async () => {
+    const item = makeFactItem({ rawValue: '' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not an http(s) URL');
-  });
-
-  it('returns unverifiable for URLs with embedded credentials', async () => {
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'https://user:pass@github.com/anthropics',
-      formattedValue: 'https://user:pass@github.com/anthropics',
-    });
-    const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('not an http(s) URL');
-  });
-
-  it('SSRF: rejects loopback URLs without making any request', async () => {
-    let fetchCalled = false;
-    setMockBehavior(() => {
-      fetchCalled = true;
-      return { status: 200 };
-    });
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'http://127.0.0.1/admin',
-      formattedValue: 'http://127.0.0.1/admin',
-    });
-    const result = await tryUrlResolvesVerify(item);
-    expect(fetchCalled).toBe(false);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toMatch(/loopback|internal/);
-  });
-
-  it('SSRF: rejects RFC1918 private addresses', async () => {
-    const cases = [
-      'http://10.0.0.1/',
-      'http://192.168.1.1/',
-      'http://172.16.0.1/',
-      'http://172.31.255.255/',
-    ];
-    for (const url of cases) {
-      const item = makeFactItem({
-        propertyId: 'github-profile',
-        rawValue: url,
-        formattedValue: url,
-      });
-      const result = await tryUrlResolvesVerify(item);
-      expect(result!.verdict, `${url} should be rejected`).toBe('unverifiable');
-      expect(result!.reasoning).toMatch(/private|loopback|link-local|internal/);
-    }
-  });
-
-  it('SSRF: rejects link-local 169.254/16', async () => {
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'http://169.254.169.254/latest/meta-data/',
-      formattedValue: 'http://169.254.169.254/latest/meta-data/',
-    });
-    const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('link-local');
-  });
-
-  it('SSRF: rejects localhost and .internal/.local hostnames', async () => {
-    const cases = [
-      'http://localhost/',
-      'http://wiki-server.internal/',
-      'http://printer.local/',
-    ];
-    for (const url of cases) {
-      const item = makeFactItem({
-        propertyId: 'github-profile',
-        rawValue: url,
-        formattedValue: url,
-      });
-      const result = await tryUrlResolvesVerify(item);
-      expect(result!.verdict, `${url} should be rejected`).toBe('unverifiable');
-    }
-  });
-
-  it('SSRF: rejects IPv6 loopback ::1', async () => {
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'http://[::1]/',
-      formattedValue: 'http://[::1]/',
-    });
-    const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toMatch(/loopback IPv6/);
-  });
-
-  it('SSRF: detects redirect to internal host and downgrades verdict', async () => {
-    setMockBehavior(() => ({
-      status: 200,
-      finalUrl: 'http://10.0.0.1/internal-api',
-    }));
-    const item = makeFactItem({
-      propertyId: 'github-profile',
-      rawValue: 'https://link.example.com/redirect',
-      formattedValue: 'https://link.example.com/redirect',
-    });
-    const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
-    expect(result!.reasoning).toContain('internal host');
+    expect(result?.verdict).toBe('unverifiable');
   });
 });
 
-// ── probeUrlResolves (non-Wikipedia path) ──────────────────────────
+// ── Cached citation_content path (the happy path) ──────────────────
 
-describe('probeUrlResolves', () => {
-  it('confirms 2xx URLs', async () => {
-    setMockBehavior(() => ({ status: 200 }));
-    const result = await probeUrlResolves('https://github.com/anthropics');
-    expect(result.verdict).toBe('confirmed');
-    expect(result.confidence).toBe(0.95);
-    expect(result.reasoning).toContain('HTTP 200');
-  });
-
-  it('contradicts 404', async () => {
-    setMockBehavior(() => ({ status: 404 }));
-    const result = await probeUrlResolves('https://github.com/dead-user-xyz');
-    expect(result.verdict).toBe('contradicted');
-    expect(result.confidence).toBe(0.95);
-    expect(result.reasoning).toContain('HTTP 404');
-  });
-
-  it('contradicts 500-class server errors', async () => {
-    setMockBehavior(() => ({ status: 503 }));
-    const result = await probeUrlResolves('https://example.com');
-    expect(result.verdict).toBe('contradicted');
-    expect(result.reasoning).toContain('HTTP 503');
-  });
-
-  it('falls back to GET when HEAD returns 405', async () => {
-    let firstCall = true;
-    setMockBehavior((_url, method) => {
-      if (method === 'HEAD' && firstCall) {
-        firstCall = false;
-        return { status: 405 };
-      }
-      // Fallback GET
-      return { status: 200 };
-    });
-    const result = await probeUrlResolves('https://example.com/strict-server');
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('falls back to GET when HEAD returns 501', async () => {
-    let firstCall = true;
-    setMockBehavior((_url, method) => {
-      if (method === 'HEAD' && firstCall) {
-        firstCall = false;
-        return { status: 501 };
-      }
-      return { status: 200 };
-    });
-    const result = await probeUrlResolves('https://example.com/no-head');
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('records the final URL after redirect', async () => {
-    setMockBehavior(() => ({ status: 200, finalUrl: 'https://github.com/anthropic-ai' }));
-    const result = await probeUrlResolves('https://github.com/anthropic');
-    expect(result.verdict).toBe('confirmed');
-    expect(result.finalUrl).toBe('https://github.com/anthropic-ai');
-    expect(result.reasoning).toContain('redirected to');
-  });
-
-  it('returns unverifiable on network error', async () => {
-    setMockBehavior(() => 'throw');
-    const result = await probeUrlResolves('https://timeout.example.com');
-    expect(result.verdict).toBe('unverifiable');
-    expect(result.reasoning).toContain('network error');
-  });
-});
-
-// ── probeWikipediaUrl ──────────────────────────────────────────────
-
-describe('probeWikipediaUrl', () => {
-  const wikipediaBody = (title: string) =>
-    `<!DOCTYPE html><html><head><title>${title} - Wikipedia</title></head><body>...</body></html>`;
-
-  it('confirms when title contains entity name', async () => {
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Anthropic') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Anthropic',
-      'Anthropic',
-    );
-    expect(result.verdict).toBe('confirmed');
-    expect(result.pageTitle).toBe('Anthropic');
-    expect(result.confidence).toBe(0.95);
-  });
-
-  it('confirms case-insensitively', async () => {
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Geoffrey Hinton') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Geoffrey_Hinton',
-      'geoffrey hinton',
-    );
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('contradicts when title does not contain entity name', async () => {
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Disambiguation page') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Anthropic',
-      'Anthropic',
-    );
-    expect(result.verdict).toBe('contradicted');
-    expect(result.pageTitle).toBe('Disambiguation page');
-    expect(result.reasoning).toContain('does not contain');
-  });
-
-  it('does NOT confirm when entity name is a substring of a different word (word-boundary)', async () => {
-    // QUA-927 review fix: "Foo" should not match "Foobar - Wikipedia"
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Foobar') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Foo',
-      'Foo',
-    );
-    expect(result.verdict).toBe('contradicted');
-  });
-
-  it('does NOT confirm short acronym matching part of a larger word', async () => {
-    // "AI" matching "AIDS" or "Aircraft" was the worst-case substring trap
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Aircraft') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/AI',
-      'AI',
-    );
-    expect(result.verdict).toBe('contradicted');
-  });
-
-  it('confirms acronym match at a word boundary', async () => {
-    // "AI" should still match "AI safety - Wikipedia" — whole word
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('AI safety') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/AI_safety',
-      'AI',
-    );
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('confirms multi-word entity at word boundaries', async () => {
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Geoffrey Hinton (researcher)') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Geoffrey_Hinton',
-      'Geoffrey Hinton',
-    );
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('confirms across hyphen/space differences (normalized)', async () => {
-    // Title may use a hyphen where entity name has a space (or vice versa).
-    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Foo-Bar Inc') }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Foo-Bar',
-      'Foo Bar',
-    );
-    expect(result.verdict).toBe('confirmed');
-  });
-
-  it('contradicts on 404 (link rot)', async () => {
-    setMockBehavior(() => ({ status: 404 }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Nonexistent',
-      'Nonexistent',
-    );
-    expect(result.verdict).toBe('contradicted');
-    expect(result.reasoning).toContain('link rot');
-  });
-
-  it('returns unverifiable on network error', async () => {
-    setMockBehavior(() => 'throw');
-    const result = await probeWikipediaUrl(
-      'https://timeout.example.com',
-      'Foo',
-    );
-    expect(result.verdict).toBe('unverifiable');
-    expect(result.reasoning).toContain('network error');
-  });
-
-  it('confirms at lower confidence when title is unparseable', async () => {
-    setMockBehavior(() => ({ status: 200, body: '<html><head></head><body>no title</body></html>' }));
-    const result = await probeWikipediaUrl(
-      'https://en.wikipedia.org/wiki/Anthropic',
-      'Anthropic',
-    );
-    expect(result.verdict).toBe('confirmed');
-    expect(result.confidence).toBe(0.7);
-    expect(result.reasoning).toContain('not parseable');
-  });
-});
-
-// ── extractWikipediaTitle ──────────────────────────────────────────
-
-describe('extractWikipediaTitle', () => {
-  it('strips the " - Wikipedia" suffix', () => {
-    expect(extractWikipediaTitle('<title>Anthropic - Wikipedia</title>')).toBe('Anthropic');
-  });
-
-  it('strips an en-dash variant', () => {
-    expect(extractWikipediaTitle('<title>Anthropic – Wikipedia</title>')).toBe('Anthropic');
-  });
-
-  it('decodes HTML entities', () => {
-    expect(extractWikipediaTitle('<title>AT&amp;T - Wikipedia</title>')).toBe('AT&T');
-  });
-
-  it('returns null when no <title> tag', () => {
-    expect(extractWikipediaTitle('<html><body>no head</body></html>')).toBeNull();
-  });
-
-  it('handles attributes on title tag', () => {
-    expect(extractWikipediaTitle('<title id="x">Foo - Wikipedia</title>')).toBe('Foo');
-  });
-
-  it('returns null when title is empty after suffix strip', () => {
-    expect(extractWikipediaTitle('<title> - Wikipedia</title>')).toBeNull();
-  });
-});
-
-// ── End-to-end via tryUrlResolvesVerify ────────────────────────────
-
-describe('tryUrlResolvesVerify (end-to-end)', () => {
-  it('confirms a github-profile that resolves', async () => {
-    setMockBehavior(() => ({ status: 200 }));
+describe('cached citation_content', () => {
+  it('confirmed when httpStatus is 200 (non-Wikipedia property)', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 200 }) as never);
     const item = makeFactItem({
       propertyId: 'github-profile',
       rawValue: 'https://github.com/anthropics',
-      formattedValue: 'https://github.com/anthropics',
     });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('confirmed');
-    expect(result!.checkerModel).toBe('url-resolves');
-    expect(result!.sourceUrl).toBeTruthy();
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.confidence).toBe(0.95);
+    expect(result?.reasoning).toMatch(/HTTP 200/);
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
   });
 
-  it('contradicts a wikipedia-url whose article is the wrong topic', async () => {
-    setMockBehavior(() => ({
-      status: 200,
-      body:
-        '<html><head><title>Disambiguation - Wikipedia</title></head><body></body></html>',
-    }));
-    const item = makeFactItem(); // defaults to wikipedia-url for Anthropic
+  it.each([200, 201, 204, 299])('confirmed for any 2xx status (%i)', async (status) => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: status }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('contradicted');
-    expect(result!.extractedValue).toBe('Disambiguation');
+    expect(result?.verdict).toBe('confirmed');
   });
 
-  it('contradicts a 404 google-scholar profile', async () => {
-    setMockBehavior(() => ({ status: 404 }));
-    const item = makeFactItem({
-      propertyId: 'google-scholar',
-      rawValue: 'https://scholar.google.com/citations?user=removed',
-      formattedValue: 'https://scholar.google.com/citations?user=removed',
-    });
+  it.each([400, 403, 404, 410, 500, 503])('contradicted on %i (link rot)', async (status) => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: status }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('contradicted');
+    expect(result?.verdict).toBe('contradicted');
+    expect(result?.reasoning).toMatch(new RegExp(`HTTP ${status}`));
   });
 
-  it('returns unverifiable on persistent network failure', async () => {
-    setMockBehavior(() => 'throw');
-    const item = makeFactItem({
-      propertyId: 'social-media',
-      rawValue: 'https://x.com/anthropic',
-      formattedValue: 'https://x.com/anthropic',
-    });
+  it('contradicted does NOT enqueue a fresh ingest job', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 404 }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    await tryUrlResolvesVerify(item);
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to fetchStatus when httpStatus is null but content row exists', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: null }) as never);
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'ok' }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
     const result = await tryUrlResolvesVerify(item);
-    expect(result!.verdict).toBe('unverifiable');
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.reasoning).toContain('citation content pending');
   });
 });
 
-// ── decodeHtmlEntities ─────────────────────────────────────────────
+// ── Wikipedia title-match path ──────────────────────────────────────
 
-describe('decodeHtmlEntities', () => {
-  it('decodes named entities used by Wikipedia', () => {
-    expect(decodeHtmlEntities('AT&amp;T')).toBe('AT&T');
-    expect(decodeHtmlEntities('a &lt;b&gt; c')).toBe('a <b> c');
-    expect(decodeHtmlEntities('&quot;Hi&quot;')).toBe('"Hi"');
-    expect(decodeHtmlEntities("don&#39;t")).toBe("don't");
-    expect(decodeHtmlEntities("don&apos;t")).toBe("don't");
-    expect(decodeHtmlEntities('a&nbsp;b')).toBe('a b');
-    expect(decodeHtmlEntities('Foo &mdash; Bar')).toBe('Foo — Bar');
-    expect(decodeHtmlEntities('&copy; 2026')).toBe('© 2026');
+describe('Wikipedia title check', () => {
+  it('confirmed when cached pageTitle contains entity name', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(
+      citationContent({ httpStatus: 200, pageTitle: 'Anthropic - Wikipedia' }) as never,
+    );
+    const item = makeFactItem(); // entity: Anthropic, propertyId: wikipedia-url
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.extractedValue).toBe('Anthropic');
+    expect(result?.reasoning).toContain('cached title');
+    expect(result?.reasoning).toContain('Anthropic');
   });
 
-  it('decodes decimal numeric entities (&#NN;)', () => {
-    // Citroën uses &#235; for "ë"
-    expect(decodeHtmlEntities('Citro&#235;n')).toBe('Citroën');
-    // São Paulo uses &#227; for "ã"
-    expect(decodeHtmlEntities('S&#227;o Paulo')).toBe('São Paulo');
+  it('contradicted when cached pageTitle does not contain entity name', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(
+      citationContent({ httpStatus: 200, pageTitle: 'Disambiguation - Wikipedia' }) as never,
+    );
+    const item = makeFactItem();
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('contradicted');
+    expect(result?.confidence).toBe(0.85);
+    expect(result?.reasoning).toMatch(/does not contain/);
   });
 
-  it('decodes hex numeric entities (&#xNN;)', () => {
-    expect(decodeHtmlEntities('Citro&#xeb;n')).toBe('Citroën');
-    expect(decodeHtmlEntities('S&#xE3;o Paulo')).toBe('São Paulo');
+  it('handles em-dash separator in pageTitle', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(
+      citationContent({ httpStatus: 200, pageTitle: 'Anthropic – Wikipedia' }) as never,
+    );
+    const item = makeFactItem();
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.extractedValue).toBe('Anthropic');
   });
 
-  it('decodes &amp; LAST so &amp;lt; becomes &lt; not <', () => {
-    expect(decodeHtmlEntities('&amp;lt;')).toBe('&lt;');
+  it('confirmed at lower confidence when pageTitle is null but httpStatus is 200', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(
+      citationContent({ httpStatus: 200, pageTitle: null }) as never,
+    );
+    const item = makeFactItem();
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.confidence).toBe(0.7);
+    expect(result?.reasoning).toContain('no cached pageTitle');
   });
 
-  it('returns input unchanged when no entities present', () => {
-    expect(decodeHtmlEntities('plain text')).toBe('plain text');
-  });
-
-  it('ignores invalid numeric entities (out of unicode range)', () => {
-    expect(decodeHtmlEntities('&#9999999999;')).toBe('');
-    expect(decodeHtmlEntities('&#x110000;')).toBe('');
-  });
-
-  it('Wikipedia title with numeric entity end-to-end', () => {
-    expect(extractWikipediaTitle('<title>Citro&#235;n - Wikipedia</title>')).toBe('Citroën');
+  it('contradicted on Wikipedia 4xx', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 404 }) as never);
+    const item = makeFactItem();
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('contradicted');
   });
 });
 
-// ── titleContainsEntityName ────────────────────────────────────────
+// ── Resource fetchStatus path ───────────────────────────────────────
+
+describe('Resource fetchStatus (no cached citation_content)', () => {
+  it.each(['dead', 'soft_404', 'not_found', 'timeout', 'unreachable'] as const)(
+    'contradicted on dead-variant fetchStatus: %s',
+    async (status) => {
+      lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: status }) as never);
+      const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+      const result = await tryUrlResolvesVerify(item);
+      expect(result?.verdict).toBe('contradicted');
+      expect(result?.reasoning).toContain(`fetch_status: ${status}`);
+    },
+  );
+
+  it('confirmed (high confidence) on paywall — URL is alive', async () => {
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'paywall' }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://nyt.com/article' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.confidence).toBe(0.85);
+    expect(result?.reasoning).toContain('paywall');
+  });
+
+  it('confirmed (high confidence) on fetchStatus=ok with no cached content yet', async () => {
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'ok' }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.confidence).toBe(0.85);
+    expect(result?.reasoning).toContain('citation content pending');
+  });
+
+  it('falls through to enqueue when fetchStatus=error', async () => {
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'error' }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('unverifiable');
+    expect(suggestResourcesApiMock).toHaveBeenCalledWith({ urls: ['https://github.com/x'] });
+  });
+});
+
+// ── Self-healing: unknown URL enqueues ingest ──────────────────────
+
+describe('no cached state — enqueue ingest', () => {
+  it('returns unverifiable and enqueues a resource-ingest job', async () => {
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/anthropics' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.confidence).toBe(0.7);
+    expect(result?.reasoning).toContain('resource-ingest job enqueued');
+    expect(suggestResourcesApiMock).toHaveBeenCalledTimes(1);
+    expect(suggestResourcesApiMock).toHaveBeenCalledWith({ urls: ['https://github.com/anthropics'] });
+  });
+
+  it('reports enqueue failure in reasoning', async () => {
+    suggestResourcesApiMock.mockResolvedValueOnce({ ok: false, status: 500, message: 'wiki-server down' } as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.reasoning).toContain('failed to enqueue ingest');
+    expect(result?.reasoning).toContain('wiki-server down');
+  });
+
+  it('handles thrown errors from suggestResourcesApi', async () => {
+    suggestResourcesApiMock.mockRejectedValueOnce(new Error('network exploded'));
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.reasoning).toContain('failed to enqueue ingest');
+    expect(result?.reasoning).toContain('network exploded');
+  });
+});
+
+// ── End-to-end VerifyResult shape ───────────────────────────────────
+
+describe('VerifyResult shape', () => {
+  it('populates all required fields on confirmed', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(
+      citationContent({ httpStatus: 200, pageTitle: 'Anthropic - Wikipedia' }) as never,
+    );
+    const item = makeFactItem();
+    const result = await tryUrlResolvesVerify(item);
+    expect(result).toMatchObject({
+      itemId: 'fact:f_url_001',
+      kind: 'fact',
+      verdict: 'confirmed',
+      checkerModel: 'url-resolves',
+      sourceUrl: 'https://en.wikipedia.org/wiki/Anthropic',
+    });
+    expect(result?.confidence).toBeGreaterThan(0);
+  });
+
+  it('falls back to checked URL when sourceUrl is unset on the item', async () => {
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'dead' }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://example.com' });
+    item.sourceUrl = undefined;
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.sourceUrl).toBe('https://example.com');
+  });
+});
+
+// ── titleContainsEntityName helper ──────────────────────────────────
 
 describe('titleContainsEntityName', () => {
-  it('matches whole-word at start, middle, end', () => {
-    expect(titleContainsEntityName('Anthropic - Wikipedia', 'Anthropic')).toBe(true);
-    expect(titleContainsEntityName('History of Anthropic Inc', 'Anthropic')).toBe(true);
-    expect(titleContainsEntityName('Founders of Anthropic', 'Anthropic')).toBe(true);
+  it('matches a plain whole-word containment, case insensitive', () => {
+    expect(titleContainsEntityName('Anthropic', 'Anthropic')).toBe(true);
+    expect(titleContainsEntityName('anthropic', 'ANTHROPIC')).toBe(true);
   });
 
-  it('rejects substring-of-larger-word', () => {
-    expect(titleContainsEntityName('Foobar', 'Foo')).toBe(false);
-    expect(titleContainsEntityName('Aircraft', 'AI')).toBe(false);
-    expect(titleContainsEntityName('OpenSSL Project', 'Open')).toBe(false);
+  it('does NOT match a substring across word boundary (Foo vs Foobar)', () => {
+    expect(titleContainsEntityName('Foobar Inc', 'Foo')).toBe(false);
   });
 
-  it('case-insensitive', () => {
-    expect(titleContainsEntityName('Anthropic Inc', 'ANTHROPIC')).toBe(true);
-    expect(titleContainsEntityName('ANTHROPIC INC', 'anthropic')).toBe(true);
+  it('handles minor punctuation differences via permissive normalization', () => {
+    expect(titleContainsEntityName('U.S. Department of State', 'U S Department')).toBe(true);
   });
 
-  it('returns false on empty input', () => {
+  it('handles diacritics and special characters', () => {
+    expect(titleContainsEntityName('Citroën S.A.', 'Citroën')).toBe(true);
+    expect(titleContainsEntityName('São Paulo', 'São Paulo')).toBe(true);
+  });
+
+  it('returns false when entity name is empty after normalization', () => {
+    expect(titleContainsEntityName('Anything', '!!!')).toBe(false);
+  });
+
+  it('returns false on empty title', () => {
     expect(titleContainsEntityName('', 'Anthropic')).toBe(false);
-    expect(titleContainsEntityName('Anthropic', '')).toBe(false);
-  });
-
-  it('matches across hyphen/space punctuation differences', () => {
-    // hyphens, periods, parens collapse to spaces — words still align as tokens
-    expect(titleContainsEntityName('Foo-Bar Inc', 'Foo Bar')).toBe(true);
-    expect(titleContainsEntityName('Yann Lecun', 'Yann LeCun')).toBe(true);
   });
 });
 
-// ── rejectIfInternalHost ───────────────────────────────────────────
+// ── resolveFromResourcePipeline directly ──────────────────────────
 
-describe('rejectIfInternalHost', () => {
-  it('accepts public URLs', () => {
-    expect(rejectIfInternalHost('https://en.wikipedia.org/wiki/Foo')).toBeNull();
-    expect(rejectIfInternalHost('https://github.com/anthropics')).toBeNull();
-    expect(rejectIfInternalHost('https://scholar.google.com/citations')).toBeNull();
+describe('resolveFromResourcePipeline (direct)', () => {
+  it('queries both endpoints in parallel', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 200 }) as never);
+    await resolveFromResourcePipeline('https://example.com', false, 'X');
+    expect(getCitationContentByUrlMock).toHaveBeenCalledWith('https://example.com');
+    expect(lookupResourceByUrlMock).toHaveBeenCalledWith('https://example.com');
   });
 
-  it('rejects loopback IPv4', () => {
-    expect(rejectIfInternalHost('http://127.0.0.1/')).toContain('loopback');
-    expect(rejectIfInternalHost('http://127.255.255.254/')).toContain('loopback');
-  });
-
-  it('rejects 10/8', () => {
-    expect(rejectIfInternalHost('http://10.0.0.1/')).toContain('10/8');
-    expect(rejectIfInternalHost('http://10.255.255.255/')).toContain('10/8');
-  });
-
-  it('rejects 172.16/12', () => {
-    expect(rejectIfInternalHost('http://172.16.0.1/')).toContain('172.16/12');
-    expect(rejectIfInternalHost('http://172.31.255.255/')).toContain('172.16/12');
-  });
-
-  it('accepts 172.32+ (outside private range)', () => {
-    expect(rejectIfInternalHost('http://172.32.0.1/')).toBeNull();
-    expect(rejectIfInternalHost('http://172.15.0.1/')).toBeNull();
-  });
-
-  it('rejects 192.168/16', () => {
-    expect(rejectIfInternalHost('http://192.168.1.1/')).toContain('192.168/16');
-  });
-
-  it('rejects 169.254/16 (link-local / AWS metadata)', () => {
-    expect(rejectIfInternalHost('http://169.254.169.254/')).toContain('link-local');
-  });
-
-  it('rejects CGNAT 100.64-127', () => {
-    expect(rejectIfInternalHost('http://100.64.0.1/')).toContain('CGNAT');
-    expect(rejectIfInternalHost('http://100.127.255.255/')).toContain('CGNAT');
-  });
-
-  it('rejects 0.0.0.0', () => {
-    expect(rejectIfInternalHost('http://0.0.0.0/')).toContain('null route');
-  });
-
-  it('rejects localhost', () => {
-    expect(rejectIfInternalHost('http://localhost/')).toContain('local-only');
-    expect(rejectIfInternalHost('http://api.localhost/')).toContain('local-only');
-  });
-
-  it('rejects .internal/.local/.lan TLDs', () => {
-    expect(rejectIfInternalHost('http://wiki-server.internal/')).toContain('internal-only');
-    expect(rejectIfInternalHost('http://printer.local/')).toContain('internal-only');
-    expect(rejectIfInternalHost('http://router.lan/')).toContain('internal-only');
-  });
-
-  it('rejects IPv6 loopback ::1', () => {
-    expect(rejectIfInternalHost('http://[::1]/')).toContain('loopback IPv6');
-  });
-
-  it('rejects IPv6 link-local fe80::', () => {
-    expect(rejectIfInternalHost('http://[fe80::1]/')).toContain('link-local IPv6');
-  });
-
-  it('rejects IPv6 unique-local fc00::/7', () => {
-    expect(rejectIfInternalHost('http://[fc00::1]/')).toContain('unique-local IPv6');
-    expect(rejectIfInternalHost('http://[fd00::1]/')).toContain('unique-local IPv6');
-  });
-
-  it('rejects IPv4-mapped IPv6 of internal address', () => {
-    const r1 = rejectIfInternalHost('http://[::ffff:127.0.0.1]/');
-    const r2 = rejectIfInternalHost('http://[::ffff:10.0.0.1]/');
-    expect(r1).not.toBeNull();
-    expect(r1).toMatch(/loopback|IPv4-mapped/);
-    expect(r2).not.toBeNull();
-    expect(r2).toMatch(/private|IPv4-mapped/);
-  });
-
-  it('rejects unsupported protocols', () => {
-    expect(rejectIfInternalHost('ftp://example.com/')).toContain('unsupported protocol');
-    expect(rejectIfInternalHost('file:///etc/passwd')).toContain('unsupported protocol');
-  });
-
-  it('rejects unparseable URLs', () => {
-    expect(rejectIfInternalHost('not a url')).toContain('unparseable');
+  it('citation_content takes precedence over resource fetchStatus', async () => {
+    // citation says ok, resource says dead — citation wins (newer info).
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 200 }) as never);
+    lookupResourceByUrlMock.mockResolvedValueOnce(resourceRow({ fetchStatus: 'dead' }) as never);
+    const result = await resolveFromResourcePipeline('https://example.com', false, 'X');
+    expect(result.verdict).toBe('confirmed');
   });
 });

--- a/crux/lib/sourcing/url-resolves-verifier.test.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the url-resolves verifier (QUA-927).
+ *
+ * Mocks `globalThis.fetch` so individual tests can drive the verifier through
+ * 2xx, 3xx, 4xx, 5xx, network errors, HEAD-not-allowed, and the Wikipedia
+ * title-match path without touching the network.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  tryUrlResolvesVerify,
+  probeUrlResolves,
+  probeWikipediaUrl,
+  extractWikipediaTitle,
+} from './url-resolves-verifier.ts';
+import type { VerifyItem, FactItemData } from './orchestrator-types.ts';
+
+// ── Fetch mock plumbing ─────────────────────────────────────────────
+
+interface MockResponse {
+  status: number;
+  /** Final URL after redirects (defaults to request URL). */
+  finalUrl?: string;
+  /** Body returned by GET. Ignored for HEAD. */
+  body?: string;
+  /**
+   * If set, mark .body as null so readCappedText returns ''. Lets us simulate
+   * a 200-OK Wikipedia response with no body (rare but possible).
+   */
+  noBody?: boolean;
+}
+
+interface MockBehavior {
+  /** Hook: return a MockResponse, or `'throw'` to simulate a network error. */
+  (url: string, method: string): MockResponse | 'throw';
+}
+
+let currentBehavior: MockBehavior = () => ({ status: 200 });
+
+function setMockBehavior(b: MockBehavior): void {
+  currentBehavior = b;
+}
+
+beforeEach(() => {
+  // Default: every request returns 200. Tests override per-case.
+  setMockBehavior(() => ({ status: 200 }));
+});
+
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const out = currentBehavior(url, method);
+    if (out === 'throw') {
+      throw new Error('mock network error');
+    }
+    const finalUrl = out.finalUrl ?? url;
+    const body = out.body ?? '';
+    // Build a real Response so .body / .text() / status all behave normally.
+    const init2: ResponseInit = { status: out.status };
+    const responseBody = out.noBody ? null : new Blob([body]);
+    const response = new Response(responseBody, init2);
+    // Response.url is read-only; override via Object.defineProperty so the
+    // verifier sees the final-after-redirects URL like real fetch.
+    Object.defineProperty(response, 'url', { value: finalUrl, configurable: true });
+    return response;
+  }),
+);
+
+// ── Test fixtures ───────────────────────────────────────────────────
+
+function makeFactItem(overrides: Partial<FactItemData> = {}): VerifyItem {
+  const data: FactItemData = {
+    kind: 'fact',
+    entity: { id: 'sid_test_anth', name: 'Anthropic', type: 'organization' } as FactItemData['entity'],
+    fact: {
+      id: 'f_url_001',
+      propertyId: 'wikipedia-url',
+      value: { type: 'text', value: 'https://en.wikipedia.org/wiki/Anthropic' },
+      source: 'https://en.wikipedia.org/wiki/Anthropic',
+    } as FactItemData['fact'],
+    propertyName: 'Wikipedia',
+    propertyId: 'wikipedia-url',
+    formattedValue: 'https://en.wikipedia.org/wiki/Anthropic',
+    rawValue: 'https://en.wikipedia.org/wiki/Anthropic',
+    verifierKind: 'url-resolves',
+    ...overrides,
+  };
+  return {
+    kind: 'fact',
+    id: `fact:${data.fact.id}`,
+    description: `${data.entity.name} / ${data.propertyName} = ${data.formattedValue}`,
+    entityType: data.entity.type ?? 'unknown',
+    entityName: data.entity.name,
+    priority: 1,
+    sourceUrl: data.fact.source,
+    neverVerified: true,
+    data,
+  };
+}
+
+// ── tryUrlResolvesVerify dispatch ──────────────────────────────────
+
+describe('tryUrlResolvesVerify', () => {
+  it('returns null when fact has no verifierKind', async () => {
+    const item = makeFactItem({ verifierKind: undefined });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for non-fact items', async () => {
+    const item: VerifyItem = {
+      kind: 'entity',
+      id: 'entity:foo',
+      description: 'foo',
+      entityType: 'organization',
+      entityName: 'Foo',
+      priority: 1,
+      neverVerified: true,
+      data: { kind: 'entity', entity: { id: 'sid_foo', title: 'Foo', sources: [] } as never },
+    };
+    const result = await tryUrlResolvesVerify(item);
+    expect(result).toBeNull();
+  });
+
+  it('returns unverifiable when fact value is not a URL', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'just-a-username',
+      formattedValue: 'just-a-username',
+      verifierKind: 'url-resolves',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result).not.toBeNull();
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.checkerModel).toBe('url-resolves');
+    expect(result!.reasoning).toContain('not a URL');
+  });
+
+  it('returns unverifiable when fact value is empty', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: '',
+      formattedValue: '',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('not a URL');
+  });
+
+  it('returns unverifiable for non-http(s) URLs (e.g., ftp)', async () => {
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'ftp://example.com',
+      formattedValue: 'ftp://example.com',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+    expect(result!.reasoning).toContain('not a URL');
+  });
+});
+
+// ── probeUrlResolves (non-Wikipedia path) ──────────────────────────
+
+describe('probeUrlResolves', () => {
+  it('confirms 2xx URLs', async () => {
+    setMockBehavior(() => ({ status: 200 }));
+    const result = await probeUrlResolves('https://github.com/anthropics');
+    expect(result.verdict).toBe('confirmed');
+    expect(result.confidence).toBe(0.95);
+    expect(result.reasoning).toContain('HTTP 200');
+  });
+
+  it('contradicts 404', async () => {
+    setMockBehavior(() => ({ status: 404 }));
+    const result = await probeUrlResolves('https://github.com/dead-user-xyz');
+    expect(result.verdict).toBe('contradicted');
+    expect(result.confidence).toBe(0.95);
+    expect(result.reasoning).toContain('HTTP 404');
+  });
+
+  it('contradicts 500-class server errors', async () => {
+    setMockBehavior(() => ({ status: 503 }));
+    const result = await probeUrlResolves('https://example.com');
+    expect(result.verdict).toBe('contradicted');
+    expect(result.reasoning).toContain('HTTP 503');
+  });
+
+  it('falls back to GET when HEAD returns 405', async () => {
+    let firstCall = true;
+    setMockBehavior((_url, method) => {
+      if (method === 'HEAD' && firstCall) {
+        firstCall = false;
+        return { status: 405 };
+      }
+      // Fallback GET
+      return { status: 200 };
+    });
+    const result = await probeUrlResolves('https://example.com/strict-server');
+    expect(result.verdict).toBe('confirmed');
+  });
+
+  it('falls back to GET when HEAD returns 501', async () => {
+    let firstCall = true;
+    setMockBehavior((_url, method) => {
+      if (method === 'HEAD' && firstCall) {
+        firstCall = false;
+        return { status: 501 };
+      }
+      return { status: 200 };
+    });
+    const result = await probeUrlResolves('https://example.com/no-head');
+    expect(result.verdict).toBe('confirmed');
+  });
+
+  it('records the final URL after redirect', async () => {
+    setMockBehavior(() => ({ status: 200, finalUrl: 'https://github.com/anthropic-ai' }));
+    const result = await probeUrlResolves('https://github.com/anthropic');
+    expect(result.verdict).toBe('confirmed');
+    expect(result.finalUrl).toBe('https://github.com/anthropic-ai');
+    expect(result.reasoning).toContain('redirected to');
+  });
+
+  it('returns unverifiable on network error', async () => {
+    setMockBehavior(() => 'throw');
+    const result = await probeUrlResolves('https://timeout.example.com');
+    expect(result.verdict).toBe('unverifiable');
+    expect(result.reasoning).toContain('network error');
+  });
+});
+
+// ── probeWikipediaUrl ──────────────────────────────────────────────
+
+describe('probeWikipediaUrl', () => {
+  const wikipediaBody = (title: string) =>
+    `<!DOCTYPE html><html><head><title>${title} - Wikipedia</title></head><body>...</body></html>`;
+
+  it('confirms when title contains entity name', async () => {
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Anthropic') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Anthropic',
+      'Anthropic',
+    );
+    expect(result.verdict).toBe('confirmed');
+    expect(result.pageTitle).toBe('Anthropic');
+    expect(result.confidence).toBe(0.95);
+  });
+
+  it('confirms case-insensitively', async () => {
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Geoffrey Hinton') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Geoffrey_Hinton',
+      'geoffrey hinton',
+    );
+    expect(result.verdict).toBe('confirmed');
+  });
+
+  it('contradicts when title does not contain entity name', async () => {
+    setMockBehavior(() => ({ status: 200, body: wikipediaBody('Disambiguation page') }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Anthropic',
+      'Anthropic',
+    );
+    expect(result.verdict).toBe('contradicted');
+    expect(result.pageTitle).toBe('Disambiguation page');
+    expect(result.reasoning).toContain('does not contain');
+  });
+
+  it('contradicts on 404 (link rot)', async () => {
+    setMockBehavior(() => ({ status: 404 }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Nonexistent',
+      'Nonexistent',
+    );
+    expect(result.verdict).toBe('contradicted');
+    expect(result.reasoning).toContain('link rot');
+  });
+
+  it('returns unverifiable on network error', async () => {
+    setMockBehavior(() => 'throw');
+    const result = await probeWikipediaUrl(
+      'https://timeout.example.com',
+      'Foo',
+    );
+    expect(result.verdict).toBe('unverifiable');
+    expect(result.reasoning).toContain('network error');
+  });
+
+  it('confirms at lower confidence when title is unparseable', async () => {
+    setMockBehavior(() => ({ status: 200, body: '<html><head></head><body>no title</body></html>' }));
+    const result = await probeWikipediaUrl(
+      'https://en.wikipedia.org/wiki/Anthropic',
+      'Anthropic',
+    );
+    expect(result.verdict).toBe('confirmed');
+    expect(result.confidence).toBe(0.7);
+    expect(result.reasoning).toContain('not parseable');
+  });
+});
+
+// ── extractWikipediaTitle ──────────────────────────────────────────
+
+describe('extractWikipediaTitle', () => {
+  it('strips the " - Wikipedia" suffix', () => {
+    expect(extractWikipediaTitle('<title>Anthropic - Wikipedia</title>')).toBe('Anthropic');
+  });
+
+  it('strips an en-dash variant', () => {
+    expect(extractWikipediaTitle('<title>Anthropic – Wikipedia</title>')).toBe('Anthropic');
+  });
+
+  it('decodes HTML entities', () => {
+    expect(extractWikipediaTitle('<title>AT&amp;T - Wikipedia</title>')).toBe('AT&T');
+  });
+
+  it('returns null when no <title> tag', () => {
+    expect(extractWikipediaTitle('<html><body>no head</body></html>')).toBeNull();
+  });
+
+  it('handles attributes on title tag', () => {
+    expect(extractWikipediaTitle('<title id="x">Foo - Wikipedia</title>')).toBe('Foo');
+  });
+
+  it('returns null when title is empty after suffix strip', () => {
+    expect(extractWikipediaTitle('<title> - Wikipedia</title>')).toBeNull();
+  });
+});
+
+// ── End-to-end via tryUrlResolvesVerify ────────────────────────────
+
+describe('tryUrlResolvesVerify (end-to-end)', () => {
+  it('confirms a github-profile that resolves', async () => {
+    setMockBehavior(() => ({ status: 200 }));
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: 'https://github.com/anthropics',
+      formattedValue: 'https://github.com/anthropics',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('confirmed');
+    expect(result!.checkerModel).toBe('url-resolves');
+    expect(result!.sourceUrl).toBeTruthy();
+  });
+
+  it('contradicts a wikipedia-url whose article is the wrong topic', async () => {
+    setMockBehavior(() => ({
+      status: 200,
+      body:
+        '<html><head><title>Disambiguation - Wikipedia</title></head><body></body></html>',
+    }));
+    const item = makeFactItem(); // defaults to wikipedia-url for Anthropic
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('contradicted');
+    expect(result!.extractedValue).toBe('Disambiguation');
+  });
+
+  it('contradicts a 404 google-scholar profile', async () => {
+    setMockBehavior(() => ({ status: 404 }));
+    const item = makeFactItem({
+      propertyId: 'google-scholar',
+      rawValue: 'https://scholar.google.com/citations?user=removed',
+      formattedValue: 'https://scholar.google.com/citations?user=removed',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('contradicted');
+  });
+
+  it('returns unverifiable on persistent network failure', async () => {
+    setMockBehavior(() => 'throw');
+    const item = makeFactItem({
+      propertyId: 'social-media',
+      rawValue: 'https://x.com/anthropic',
+      formattedValue: 'https://x.com/anthropic',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result!.verdict).toBe('unverifiable');
+  });
+});

--- a/crux/lib/sourcing/url-resolves-verifier.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.ts
@@ -1,0 +1,307 @@
+/**
+ * URL-resolves verifier (QUA-927).
+ *
+ * Cheap, fast verification path for facts whose source-of-truth IS the URL itself
+ * (wikipedia-url, github-profile, google-scholar, social-media handles, …).
+ * Content-claim verification is tautological for these — there's no separate claim
+ * to compare against the source content. But the URL is still checkable: does it
+ * resolve? Does the destination match the entity?
+ *
+ * Cost: $0. Latency: ~10ms vs ~5s+ for an LLM call.
+ *
+ * Verdict mapping:
+ * - 2xx (or same-host 3xx → 2xx) → `confirmed`
+ * - 4xx/5xx → `contradicted` (link rot)
+ * - Network error / timeout → `unverifiable`
+ *
+ * Wikipedia-specific: also fetches the page and checks the `<title>` contains
+ * the entity name. A Wikipedia URL that resolves but points at a different
+ * article (e.g., a redirect from `/wiki/Anthropic_(company)` to a generic
+ * disambiguation page) is `contradicted`, not `confirmed`.
+ */
+
+import type { SourcingVerdict } from '../../../apps/wiki-server/src/api-types.ts';
+import type { VerifyItem, VerifyResult, FactItemData } from './orchestrator-types.ts';
+
+const URL_RESOLVES_TIMEOUT_MS = 10_000;
+const URL_RESOLVES_USER_AGENT =
+  'longterm-wiki url-resolves-verifier (https://www.longtermwiki.com)';
+
+/** Verdict + machine-readable reason returned by the underlying HTTP probe. */
+interface UrlResolvesProbeResult {
+  verdict: SourcingVerdict;
+  confidence: number;
+  reasoning: string;
+  finalUrl?: string;
+  /** HTML <title> text, when fetched (Wikipedia path). */
+  pageTitle?: string;
+}
+
+/**
+ * Public entry point. Returns a VerifyResult to be stored, or null if the item
+ * is not eligible for url-resolves verification (caller should fall through to
+ * content-claim).
+ */
+export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResult | null> {
+  if (item.data.kind !== 'fact') return null;
+  const data = item.data;
+  if (data.verifierKind !== 'url-resolves') return null;
+
+  // The URL we verify is the fact's stored value, not fact.source.
+  // For wikipedia-url / github-profile / etc., the value IS the URL.
+  const urlToCheck = data.rawValue ?? data.formattedValue;
+  if (!urlToCheck || !looksLikeUrl(urlToCheck)) {
+    return {
+      itemId: item.id,
+      kind: item.kind,
+      description: item.description,
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 1.0,
+      extractedValue: '',
+      reasoning: `[url-resolves] fact value is not a URL: ${truncate(urlToCheck ?? '<empty>', 80)}`,
+      sourceUrl: item.sourceUrl ?? '',
+      checkerModel: 'url-resolves',
+    };
+  }
+
+  const isWikipedia = data.propertyId === 'wikipedia-url';
+
+  const probe = isWikipedia
+    ? await probeWikipediaUrl(urlToCheck, data.entity.name)
+    : await probeUrlResolves(urlToCheck);
+
+  return {
+    itemId: item.id,
+    kind: item.kind,
+    description: item.description,
+    verdict: probe.verdict,
+    confidence: probe.confidence,
+    extractedValue: probe.pageTitle ?? probe.finalUrl ?? '',
+    reasoning: probe.reasoning,
+    // Persist the actual checked URL as sourceUrl so the verdict points at the
+    // thing we verified (matches existing fact.source for these properties).
+    sourceUrl: item.sourceUrl ?? urlToCheck,
+    checkerModel: 'url-resolves',
+  };
+}
+
+// ── HEAD/GET probe ──────────────────────────────────────────────────
+
+/**
+ * Probe a URL with HEAD; fall back to GET-no-body if HEAD is rejected (some
+ * servers, notably GitHub raw and a few CDNs, return 405/501 for HEAD).
+ *
+ * Returns the verdict mapping described in this file's docstring.
+ */
+export async function probeUrlResolves(url: string): Promise<UrlResolvesProbeResult> {
+  let response: Response;
+  try {
+    response = await fetchWithRedirectAwareness(url, 'HEAD');
+    if (response.status === 405 || response.status === 501) {
+      // HEAD not allowed — retry with GET (we ignore the body).
+      response = await fetchWithRedirectAwareness(url, 'GET');
+    }
+  } catch (e: unknown) {
+    return {
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 0.7,
+      reasoning: `[url-resolves] network error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  if (response.status >= 200 && response.status < 300) {
+    return {
+      verdict: 'confirmed' as SourcingVerdict,
+      confidence: 0.95,
+      reasoning: `[url-resolves] HTTP ${response.status}${response.url !== url ? ` (redirected to ${response.url})` : ''}`,
+      finalUrl: response.url,
+    };
+  }
+
+  if (response.status >= 400) {
+    return {
+      verdict: 'contradicted' as SourcingVerdict,
+      confidence: 0.95,
+      reasoning: `[url-resolves] HTTP ${response.status} — link rot or removed`,
+      finalUrl: response.url,
+    };
+  }
+
+  // 3xx that wasn't followed (e.g., redirect: 'manual' would land here, but we
+  // use redirect: 'follow' below so this is unusual). Treat as unverifiable.
+  return {
+    verdict: 'unverifiable' as SourcingVerdict,
+    confidence: 0.6,
+    reasoning: `[url-resolves] unexpected HTTP ${response.status}`,
+    finalUrl: response.url,
+  };
+}
+
+/**
+ * Wikipedia-specific probe: fetch the page (GET, not HEAD — we need the title)
+ * and check that the article title contains the entity name. Catches the case
+ * where a wikipedia-url resolves but points at the wrong article (e.g., a
+ * disambiguation page).
+ */
+export async function probeWikipediaUrl(
+  url: string,
+  entityName: string,
+): Promise<UrlResolvesProbeResult> {
+  let response: Response;
+  let body: string;
+  try {
+    response = await fetchWithRedirectAwareness(url, 'GET');
+    if (response.status >= 400) {
+      return {
+        verdict: 'contradicted' as SourcingVerdict,
+        confidence: 0.95,
+        reasoning: `[url-resolves wikipedia] HTTP ${response.status} — link rot`,
+        finalUrl: response.url,
+      };
+    }
+    if (response.status < 200 || response.status >= 300) {
+      return {
+        verdict: 'unverifiable' as SourcingVerdict,
+        confidence: 0.6,
+        reasoning: `[url-resolves wikipedia] unexpected HTTP ${response.status}`,
+        finalUrl: response.url,
+      };
+    }
+    // Cap body read to avoid pulling MB of HTML for the title alone.
+    body = await readCappedText(response, 64 * 1024);
+  } catch (e: unknown) {
+    return {
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 0.7,
+      reasoning: `[url-resolves wikipedia] network error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  const title = extractWikipediaTitle(body);
+  if (!title) {
+    // Page resolved but no title parsed — treat as confirmed (URL is alive)
+    // but at lower confidence. We don't downgrade to unverifiable because
+    // 200-OK Wikipedia pages without a parsable title are extremely rare.
+    return {
+      verdict: 'confirmed' as SourcingVerdict,
+      confidence: 0.7,
+      reasoning: `[url-resolves wikipedia] HTTP ${response.status}, title not parseable`,
+      finalUrl: response.url,
+    };
+  }
+
+  // Title check: case-insensitive substring match. Wikipedia titles are like
+  // "Anthropic - Wikipedia" or "Geoffrey Hinton - Wikipedia". The entity name
+  // must appear somewhere in the title text.
+  const titleNorm = title.toLowerCase();
+  const nameNorm = entityName.toLowerCase();
+  if (titleNorm.includes(nameNorm)) {
+    return {
+      verdict: 'confirmed' as SourcingVerdict,
+      confidence: 0.95,
+      reasoning: `[url-resolves wikipedia] title "${title}" contains "${entityName}"`,
+      finalUrl: response.url,
+      pageTitle: title,
+    };
+  }
+
+  // URL resolved but the destination article is not about the entity.
+  // Could be disambiguation, redirect to broader concept, or wrong link.
+  return {
+    verdict: 'contradicted' as SourcingVerdict,
+    confidence: 0.85,
+    reasoning: `[url-resolves wikipedia] title "${title}" does not contain entity name "${entityName}"`,
+    finalUrl: response.url,
+    pageTitle: title,
+  };
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────
+
+/**
+ * Wrap fetch with a 10s timeout, a friendly UA, and redirect: 'follow'.
+ * Returns the final Response; the caller checks .status and .url.
+ */
+async function fetchWithRedirectAwareness(url: string, method: 'HEAD' | 'GET'): Promise<Response> {
+  return fetch(url, {
+    method,
+    redirect: 'follow',
+    headers: { 'User-Agent': URL_RESOLVES_USER_AGENT },
+    signal: AbortSignal.timeout(URL_RESOLVES_TIMEOUT_MS),
+  });
+}
+
+/** Read at most `cap` bytes of the response body as text. */
+async function readCappedText(response: Response, cap: number): Promise<string> {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+      if (total >= cap) break;
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Best-effort; the reader may already be released.
+    }
+  }
+  // Concatenate chunks then decode as UTF-8. Avoids the Blob<->TS-lib type
+  // friction with newer @types/node where Uint8Array carries an ArrayBuffer
+  // template parameter that BlobPart doesn't accept.
+  let totalLen = 0;
+  for (const c of chunks) totalLen += c.byteLength;
+  const merged = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder('utf-8').decode(merged);
+}
+
+/**
+ * Extract the inner text of the first `<title>...</title>` element.
+ * Returns the text without the trailing " - Wikipedia" suffix when present.
+ */
+export function extractWikipediaTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  if (!match) return null;
+  const title = decodeHtmlEntities(match[1].trim());
+  return title.replace(/\s*[-–]\s*Wikipedia\s*$/, '').trim() || null;
+}
+
+/** Tiny HTML entity decoder (just the handful Wikipedia titles use). */
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+// ── Validation helpers ─────────────────────────────────────────────
+
+function looksLikeUrl(s: string): boolean {
+  try {
+    const u = new URL(s);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}
+
+// Re-export for tests + dispatchers
+export type { FactItemData };

--- a/crux/lib/sourcing/url-resolves-verifier.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.ts
@@ -1,75 +1,76 @@
 /**
  * URL-resolves verifier (QUA-927).
  *
- * Cheap, fast verification path for facts whose source-of-truth IS the URL itself
- * (wikipedia-url, github-profile, google-scholar, social-media handles, …).
- * Content-claim verification is tautological for these — there's no separate claim
- * to compare against the source content. But the URL is still checkable: does it
- * resolve? Does the destination match the entity?
+ * Cheap, fast verification path for facts whose source-of-truth IS the URL
+ * itself (wikipedia-url, github-profile, google-scholar, social-media handles,
+ * …). Content-claim verification is tautological for these — there's no
+ * separate claim to compare against the source content. But the URL is still
+ * checkable: does it resolve? For Wikipedia, does the destination match the
+ * entity?
  *
- * Cost: $0. Latency: ~10ms vs ~5s+ for an LLM call.
+ * **The verifier rides the Resource pipeline; it does not fetch URLs.**
  *
- * Verdict mapping:
- * - 2xx (after redirect-follow) → `confirmed`
- * - 4xx/5xx → `contradicted` (link rot)
- * - Network error / timeout → `unverifiable`
+ * Decision tree:
+ *   1. Look up cached state via `lookupResourceByUrl` + `getCitationContentByUrl`.
+ *   2. If `citation_content.httpStatus` is 2xx:
+ *        - For wikipedia-url: also check `pageTitle` contains entity name.
+ *        - Else: `confirmed`.
+ *   3. If `citation_content.httpStatus` is 4xx/5xx, OR
+ *      `resources.fetchStatus` is a dead variant: `contradicted` (link rot).
+ *   4. Otherwise (URL never fetched): enqueue ingest via `suggestResourcesApi`
+ *      and return `unverifiable` — the next sourcing run will see real state.
  *
- * Wikipedia-specific: also fetches the page and checks the `<title>` contains
- * the entity name as a whole-word match. A Wikipedia URL that resolves but
- * points at a different article (e.g., a redirect from `/wiki/Anthropic_(company)`
- * to a generic disambiguation page) is `contradicted`, not `confirmed`.
+ * Why not a direct HEAD probe? An earlier draft of this verifier issued its
+ * own HEAD/GET against the live URL. That bypassed the rest of the source-
+ * checking pipeline:
+ *   - No `content_hash` change detection (QUA-312/329) — a Wikipedia page
+ *     rewritten to a different topic would still verdict `confirmed` on
+ *     stale data until something else triggered a re-fetch.
+ *   - No `resources` row, so no `archive_url`, no audit trail in operational
+ *     dashboards, no Wayback fallback for dead links.
+ *   - Parallel HTTP code path (SSRF defenses, timeout handling, redirect
+ *     tracking, HTML title parsing) duplicating logic the resource-ingest
+ *     worker already runs.
+ * Going through the Resource pipeline keeps sourcing on one rail.
  *
- * Security:
- * - SSRF defense: hostnames matching private/loopback/internal patterns
- *   (RFC1918, link-local, localhost, .internal/.local) are rejected before
- *   the request fires. Final response URL after redirects is re-validated;
- *   if a redirect lands on an internal host the verdict is `unverifiable`.
- * - URLs with embedded credentials (`user:pass@host`) are rejected.
- * - Only http(s) protocols are accepted.
+ * Cost: $0. Latency: one wiki-server lookup (~10–50ms) — no LLM.
  *
- * Hardening considered out of scope (no observed need): full DNS-pinning to
- * defeat rebinding, robots.txt parsing, per-host token-bucket rate limit
- * (orchestrator-level concurrency cap is the existing knob).
+ * Self-healing: a brand-new URL returns `unverifiable` on its first pass and
+ * enqueues a resource-ingest job. The next pass (after the worker runs) gets
+ * a real verdict from the cached state. This matches the existing
+ * `source-fetcher.ts` "not_cached → enqueue → re-run" flow.
  */
 
+import { isDeadFetchStatus } from '../../../apps/wiki-server/src/api-types.ts';
 import type { SourcingVerdict } from '../../../apps/wiki-server/src/api-types.ts';
+import { getCitationContentByUrl } from '../wiki-server/citations.ts';
+import { lookupResourceByUrl, suggestResourcesApi } from '../wiki-server/resources.ts';
 import type { VerifyItem, VerifyResult } from './orchestrator-types.ts';
 
-const URL_RESOLVES_TIMEOUT_MS = 10_000;
-const URL_RESOLVES_USER_AGENT =
-  'longterm-wiki url-resolves-verifier (https://www.longtermwiki.com)';
-/** Cap on Wikipedia HTML body read; only `<title>` is needed and it's near the top. */
-const WIKIPEDIA_BODY_CAP_BYTES = 64 * 1024;
-
-/** Confidence values used in returned verdicts. */
 const CONFIDENCE_DEFINITE = 0.95;
 const CONFIDENCE_HIGH = 0.85;
 const CONFIDENCE_MEDIUM = 0.7;
 
-/** HTTP statuses where a server has rejected HEAD; retry with GET. */
-const HEAD_NOT_ALLOWED_STATUSES = new Set([405, 501]);
-
-/** Verdict + machine-readable reason returned by the underlying HTTP probe. */
-interface UrlResolvesProbeResult {
+interface ResolveResult {
   verdict: SourcingVerdict;
   confidence: number;
   reasoning: string;
+  /** Final URL after resource-ingest processed redirects, when known. */
   finalUrl?: string;
-  /** HTML <title> text, when fetched (Wikipedia path). */
+  /** Cached `<title>` from citation_content (Wikipedia path). */
   pageTitle?: string;
 }
 
 /**
- * Public entry point. Returns a VerifyResult to be stored, or null if the item
- * is not eligible for url-resolves verification (caller should fall through to
- * content-claim).
+ * Public entry point. Returns a VerifyResult to be stored, or null if the
+ * item is not eligible for url-resolves verification (caller should fall
+ * through to content-claim).
  */
 export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResult | null> {
   if (item.data.kind !== 'fact') return null;
   const data = item.data;
   if (data.verifierKind !== 'url-resolves') return null;
 
-  // The URL we verify is the fact's stored value, not fact.source.
   // Use rawValue only — formattedValue can include display formatting (units,
   // wrappers) that would parse as garbage.
   const urlToCheck = data.rawValue;
@@ -87,328 +88,160 @@ export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResu
     };
   }
 
-  // SSRF defense: reject internal/private/loopback hostnames before any fetch.
-  // The redirect-target is re-validated below; this catches the direct case.
-  const hostnameError = rejectIfInternalHost(urlToCheck);
-  if (hostnameError) {
-    return {
-      itemId: item.id,
-      kind: item.kind,
-      description: item.description,
-      verdict: 'unverifiable' as SourcingVerdict,
-      confidence: 1.0,
-      extractedValue: '',
-      reasoning: `[url-resolves] ${hostnameError}`,
-      sourceUrl: item.sourceUrl ?? urlToCheck,
-      checkerModel: 'url-resolves',
-    };
-  }
-
   const isWikipedia = data.propertyId === 'wikipedia-url';
-
-  const probe = isWikipedia
-    ? await probeWikipediaUrl(urlToCheck, data.entity.name)
-    : await probeUrlResolves(urlToCheck);
+  const result = await resolveFromResourcePipeline(urlToCheck, isWikipedia, data.entity.name);
 
   return {
     itemId: item.id,
     kind: item.kind,
     description: item.description,
-    verdict: probe.verdict,
-    confidence: probe.confidence,
-    extractedValue: probe.pageTitle ?? probe.finalUrl ?? '',
-    reasoning: probe.reasoning,
-    // Persist the actual checked URL as sourceUrl so the verdict points at the
-    // thing we verified (matches existing fact.source for these properties).
+    verdict: result.verdict,
+    confidence: result.confidence,
+    extractedValue: result.pageTitle ?? result.finalUrl ?? '',
+    reasoning: result.reasoning,
     sourceUrl: item.sourceUrl ?? urlToCheck,
     checkerModel: 'url-resolves',
   };
 }
 
-// ── HEAD/GET probe ──────────────────────────────────────────────────
-
 /**
- * Probe a URL with HEAD; fall back to GET-no-body if HEAD is rejected (some
- * servers return 405/501 for HEAD).
+ * Read cached resource + citation_content state and derive a verdict.
  *
- * The GET fallback releases the body via `response.body?.cancel()` so we don't
- * hold the socket open waiting for a body we never read.
+ * `lookupResourceByUrl` and `getCitationContentByUrl` are independent reads:
+ * citation_content is keyed by URL (no resource_id needed) and is populated
+ * by the resource-ingest worker after each successful fetch. We consult both
+ * because a resource may exist (with fetchStatus) before its content has been
+ * cached — e.g., dead-link statuses are written to `resources` even when no
+ * content body is stored.
  */
-export async function probeUrlResolves(url: string): Promise<UrlResolvesProbeResult> {
-  let response: Response;
+export async function resolveFromResourcePipeline(
+  url: string,
+  isWikipedia: boolean,
+  entityName: string,
+): Promise<ResolveResult> {
+  const [resourceLookup, contentLookup] = await Promise.all([
+    lookupResourceByUrl(url),
+    getCitationContentByUrl(url),
+  ]);
+
+  // ── Citation content present (the happy path) ────────────────────
+  if (contentLookup.ok && contentLookup.data) {
+    const cached = contentLookup.data;
+    const httpStatus = cached.httpStatus;
+
+    if (httpStatus != null && httpStatus >= 200 && httpStatus < 300) {
+      if (isWikipedia) return verdictFromWikipediaCachedContent(cached, entityName);
+      return {
+        verdict: 'confirmed' as SourcingVerdict,
+        confidence: CONFIDENCE_DEFINITE,
+        reasoning: `[url-resolves] resource-ingest fetched HTTP ${httpStatus} (cached at ${cached.fetchedAt})`,
+        finalUrl: url,
+      };
+    }
+
+    if (httpStatus != null && httpStatus >= 400) {
+      return {
+        verdict: 'contradicted' as SourcingVerdict,
+        confidence: CONFIDENCE_DEFINITE,
+        reasoning: `[url-resolves] resource-ingest recorded HTTP ${httpStatus} — link rot or removed`,
+        finalUrl: url,
+      };
+    }
+    // Cached but no httpStatus (very rare — pre-QUA-329 row, or fetchMethod that
+    // didn't record one). Fall through to fetchStatus / re-enqueue.
+  }
+
+  // ── Resource row exists with a dead fetchStatus ──────────────────
+  if (resourceLookup.ok && resourceLookup.data) {
+    const fetchStatus = resourceLookup.data.fetchStatus;
+    if (isDeadFetchStatus(fetchStatus)) {
+      return {
+        verdict: 'contradicted' as SourcingVerdict,
+        confidence: CONFIDENCE_DEFINITE,
+        reasoning: `[url-resolves] resource fetch_status: ${fetchStatus}`,
+        finalUrl: url,
+      };
+    }
+    if (fetchStatus === 'paywall') {
+      // Paywalled URLs resolve as far as we can tell — the URL is alive,
+      // we just can't read the body. Treat as confirmed for url-resolves
+      // semantics (the property is "this URL exists", not "we read it").
+      return {
+        verdict: 'confirmed' as SourcingVerdict,
+        confidence: CONFIDENCE_HIGH,
+        reasoning: '[url-resolves] resource fetch_status: paywall (URL alive, body gated)',
+        finalUrl: url,
+      };
+    }
+    if (fetchStatus === 'ok') {
+      // Resource says ok but no citation_content yet (rare ordering window
+      // between resource update and citation upsert). Treat as confirmed.
+      return {
+        verdict: 'confirmed' as SourcingVerdict,
+        confidence: CONFIDENCE_HIGH,
+        reasoning: '[url-resolves] resource fetch_status: ok (citation content pending)',
+        finalUrl: url,
+      };
+    }
+  }
+
+  // ── No info yet: enqueue ingest, return unverifiable for this run ─
+  let enqueued = false;
+  let enqueueError: string | null = null;
   try {
-    response = await fetchWithTimeout(url, 'HEAD');
-    if (HEAD_NOT_ALLOWED_STATUSES.has(response.status)) {
-      // HEAD not allowed — retry with GET. Cancel the HEAD response body
-      // (probably empty for HEAD anyway) and the GET response body once we
-      // have status, so neither connection lingers.
-      await safeCancel(response.body);
-      response = await fetchWithTimeout(url, 'GET');
+    const result = await suggestResourcesApi({ urls: [url] });
+    if (!result.ok) {
+      enqueueError = result.message ?? 'suggestResourcesApi returned ok=false';
+    } else {
+      enqueued = true;
     }
   } catch (e: unknown) {
-    return {
-      verdict: 'unverifiable' as SourcingVerdict,
-      confidence: CONFIDENCE_MEDIUM,
-      reasoning: `[url-resolves] network error: ${e instanceof Error ? e.message : String(e)}`,
-    };
+    enqueueError = e instanceof Error ? e.message : String(e);
   }
 
-  // Always release the body — neither HEAD nor the GET-fallback consumes it.
-  await safeCancel(response.body);
-
-  // If the redirect chain landed on an internal host, treat as unverifiable —
-  // belt-and-suspenders to the pre-fetch check.
-  const finalHostError = rejectIfInternalHost(response.url);
-  if (finalHostError) {
-    return {
-      verdict: 'unverifiable' as SourcingVerdict,
-      confidence: 1.0,
-      reasoning: `[url-resolves] redirected to internal host: ${finalHostError}`,
-      finalUrl: response.url,
-    };
-  }
-
-  if (response.status >= 200 && response.status < 300) {
-    return {
-      verdict: 'confirmed' as SourcingVerdict,
-      confidence: CONFIDENCE_DEFINITE,
-      reasoning: `[url-resolves] HTTP ${response.status}${response.url !== url ? ` (redirected to ${response.url})` : ''}`,
-      finalUrl: response.url,
-    };
-  }
-
-  if (response.status >= 400) {
-    return {
-      verdict: 'contradicted' as SourcingVerdict,
-      confidence: CONFIDENCE_DEFINITE,
-      reasoning: `[url-resolves] HTTP ${response.status} — link rot or removed`,
-      finalUrl: response.url,
-    };
-  }
-
-  // 3xx not normally reachable when redirect: 'follow' is set — fetch follows
-  // up to 20 then throws. Defensive branch.
   return {
     verdict: 'unverifiable' as SourcingVerdict,
-    confidence: 0.6,
-    reasoning: `[url-resolves] unexpected HTTP ${response.status}`,
-    finalUrl: response.url,
+    confidence: CONFIDENCE_MEDIUM,
+    reasoning: enqueued
+      ? '[url-resolves] no cached state — resource-ingest job enqueued; re-run after ingest completes'
+      : `[url-resolves] no cached state — failed to enqueue ingest: ${enqueueError ?? 'unknown error'}`,
+    finalUrl: url,
   };
 }
 
 /**
- * Wikipedia-specific probe: fetch the page (GET, not HEAD — we need the title)
- * and check that the article title contains the entity name as a whole-word
- * match. Catches the case where a wikipedia-url resolves but points at the
- * wrong article (e.g., a disambiguation page).
+ * Wikipedia cached-content branch: the citation_content row already has
+ * `pageTitle` extracted by the resource-ingest worker. Use that directly
+ * (no HTML re-parsing) and check whole-word containment of the entity name.
  */
-export async function probeWikipediaUrl(
-  url: string,
+function verdictFromWikipediaCachedContent(
+  cached: { httpStatus: number | null; pageTitle: string | null; fetchedAt: string },
   entityName: string,
-): Promise<UrlResolvesProbeResult> {
-  let response: Response;
-  let body: string;
-  try {
-    response = await fetchWithTimeout(url, 'GET');
-    if (response.status >= 400) {
-      await safeCancel(response.body);
-      return {
-        verdict: 'contradicted' as SourcingVerdict,
-        confidence: CONFIDENCE_DEFINITE,
-        reasoning: `[url-resolves wikipedia] HTTP ${response.status} — link rot`,
-        finalUrl: response.url,
-      };
-    }
-    if (response.status < 200 || response.status >= 300) {
-      await safeCancel(response.body);
-      return {
-        verdict: 'unverifiable' as SourcingVerdict,
-        confidence: 0.6,
-        reasoning: `[url-resolves wikipedia] unexpected HTTP ${response.status}`,
-        finalUrl: response.url,
-      };
-    }
-    body = await readCappedText(response, WIKIPEDIA_BODY_CAP_BYTES);
-  } catch (e: unknown) {
-    return {
-      verdict: 'unverifiable' as SourcingVerdict,
-      confidence: CONFIDENCE_MEDIUM,
-      reasoning: `[url-resolves wikipedia] network error: ${e instanceof Error ? e.message : String(e)}`,
-    };
-  }
-
-  const finalHostError = rejectIfInternalHost(response.url);
-  if (finalHostError) {
-    return {
-      verdict: 'unverifiable' as SourcingVerdict,
-      confidence: 1.0,
-      reasoning: `[url-resolves wikipedia] redirected to internal host: ${finalHostError}`,
-      finalUrl: response.url,
-    };
-  }
-
-  const title = extractWikipediaTitle(body);
+): ResolveResult {
+  const title = (cached.pageTitle ?? '').replace(/\s*[-–]\s*Wikipedia\s*$/i, '').trim();
   if (!title) {
-    // Page resolved but no title parsed — treat as confirmed (URL is alive)
-    // but at lower confidence. We don't downgrade to unverifiable because
-    // 200-OK Wikipedia pages without a parsable title are extremely rare.
     return {
       verdict: 'confirmed' as SourcingVerdict,
       confidence: CONFIDENCE_MEDIUM,
-      reasoning: `[url-resolves wikipedia] HTTP ${response.status}, title not parseable`,
-      finalUrl: response.url,
+      reasoning: `[url-resolves wikipedia] HTTP ${cached.httpStatus} but no cached pageTitle to verify`,
+      pageTitle: cached.pageTitle ?? undefined,
     };
   }
-
-  // Word-boundary check (not raw substring) — prevents an entity named "Foo"
-  // from matching "Foobar - Wikipedia" or an org "AI" matching "AIDS".
   if (titleContainsEntityName(title, entityName)) {
     return {
       verdict: 'confirmed' as SourcingVerdict,
       confidence: CONFIDENCE_DEFINITE,
-      reasoning: `[url-resolves wikipedia] title "${title}" contains "${entityName}"`,
-      finalUrl: response.url,
+      reasoning: `[url-resolves wikipedia] cached title "${title}" contains "${entityName}"`,
       pageTitle: title,
     };
   }
-
-  // URL resolved but the destination article is not about the entity.
-  // Could be disambiguation, redirect to broader concept, or wrong link.
   return {
     verdict: 'contradicted' as SourcingVerdict,
     confidence: CONFIDENCE_HIGH,
-    reasoning: `[url-resolves wikipedia] title "${title}" does not contain entity name "${entityName}"`,
-    finalUrl: response.url,
+    reasoning: `[url-resolves wikipedia] cached title "${title}" does not contain entity name "${entityName}"`,
     pageTitle: title,
   };
 }
-
-// ── HTTP helpers ────────────────────────────────────────────────────
-
-/**
- * Wrap fetch with a 10s timeout, a friendly UA, and redirect: 'follow'.
- * Returns the final Response; the caller checks .status and .url.
- */
-async function fetchWithTimeout(url: string, method: 'HEAD' | 'GET'): Promise<Response> {
-  return fetch(url, {
-    method,
-    redirect: 'follow',
-    headers: { 'User-Agent': URL_RESOLVES_USER_AGENT },
-    signal: AbortSignal.timeout(URL_RESOLVES_TIMEOUT_MS),
-  });
-}
-
-/** Cancel a response body's reader if present; swallow errors. */
-async function safeCancel(body: ReadableStream<Uint8Array> | null): Promise<void> {
-  if (!body) return;
-  try {
-    await body.cancel();
-  } catch {
-    // best-effort
-  }
-}
-
-/**
- * Read at most `cap` bytes of the response body as text. Slices the trailing
- * chunk if it would push us past `cap` so we don't buffer a multi-MB body
- * just because the network sent one big chunk.
- */
-async function readCappedText(response: Response, cap: number): Promise<string> {
-  if (!response.body) return '';
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (total < cap) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      const remaining = cap - total;
-      if (value.byteLength > remaining) {
-        chunks.push(value.subarray(0, remaining));
-        total = cap;
-        break;
-      }
-      chunks.push(value);
-      total += value.byteLength;
-    }
-  } finally {
-    try {
-      await reader.cancel();
-    } catch {
-      // Best-effort; the reader may already be released.
-    }
-  }
-  // Concatenate chunks then UTF-8 decode. TextDecoder's default replaces
-  // truncated multi-byte sequences with U+FFFD, which is fine — Wikipedia
-  // titles sit in the first few KB so the cap-boundary case is rare.
-  let totalLen = 0;
-  for (const c of chunks) totalLen += c.byteLength;
-  const merged = new Uint8Array(totalLen);
-  let offset = 0;
-  for (const c of chunks) {
-    merged.set(c, offset);
-    offset += c.byteLength;
-  }
-  return new TextDecoder('utf-8').decode(merged);
-}
-
-/**
- * Extract the inner text of the first `<title>...</title>` element.
- * Returns the text without the trailing " - Wikipedia" suffix when present.
- */
-export function extractWikipediaTitle(html: string): string | null {
-  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
-  if (!match) return null;
-  const title = decodeHtmlEntities(match[1].trim());
-  return title.replace(/\s*[-–]\s*Wikipedia\s*$/, '').trim() || null;
-}
-
-/**
- * Decode the HTML entities Wikipedia article titles realistically produce:
- * - Named entities: &amp; &lt; &gt; &quot; &#39; &nbsp; &apos; &copy; &mdash; &ndash; &hellip; &trade;
- * - Numeric entities: decimal (&#233;) and hex (&#xE9;) — used for non-ASCII chars
- *   in titles like "Citroën", "São Paulo", "Encyclopædia Britannica"
- *
- * `&amp;` is processed last so an input like "&amp;lt;" decodes to "&lt;",
- * not "<". Numeric/hex entities are processed first so they don't interact
- * with named-entity replacement.
- */
-export function decodeHtmlEntities(s: string): string {
-  // Numeric entities first
-  let out = s.replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) => safeFromCodePoint(parseInt(hex, 16)));
-  out = out.replace(/&#(\d+);/g, (_m, dec) => safeFromCodePoint(parseInt(dec, 10)));
-  // Common named entities (deliberately small — the realistic set Wikipedia uses).
-  // Order: replace &amp; LAST so an encoded "&amp;lt;" becomes "&lt;" not "<".
-  const named: Array<[RegExp, string]> = [
-    [/&apos;/g, "'"],
-    [/&lt;/g, '<'],
-    [/&gt;/g, '>'],
-    [/&quot;/g, '"'],
-    [/&#39;/g, "'"],
-    [/&nbsp;/g, ' '],
-    [/&copy;/g, '©'],
-    [/&trade;/g, '™'],
-    [/&mdash;/g, '—'],
-    [/&ndash;/g, '–'],
-    [/&hellip;/g, '…'],
-    [/&amp;/g, '&'],
-  ];
-  for (const [pattern, replacement] of named) {
-    out = out.replace(pattern, replacement);
-  }
-  return out;
-}
-
-function safeFromCodePoint(cp: number): string {
-  if (!Number.isFinite(cp) || cp < 0 || cp > 0x10ffff) return '';
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// ── Validation helpers ─────────────────────────────────────────────
 
 /**
  * Word-boundary–aware containment: returns true when `entityName` appears in
@@ -420,102 +253,22 @@ export function titleContainsEntityName(title: string, entityName: string): bool
   const normalize = (s: string): string =>
     s
       .toLowerCase()
-      // Keep letters/numbers as words; collapse all other runs to a single space.
       .replace(/[^\p{L}\p{N}]+/gu, ' ')
       .trim();
   const t = normalize(title);
   const n = normalize(entityName);
   if (!t || !n) return false;
-  // Word-boundary match: the entity-name token sequence must appear at a word
-  // boundary in the normalized title. Padding with spaces gives us cheap
-  // \b-equivalent semantics on the normalized form.
   return ` ${t} `.includes(` ${n} `);
-}
-
-/**
- * Hostname-based SSRF guard. Returns an error string if the URL targets a
- * private/loopback/internal address; null if the host is acceptable.
- *
- * Not bulletproof against DNS rebinding (would need to resolve the host and
- * re-validate the IP), but blocks the obvious local-network probing case.
- */
-export function rejectIfInternalHost(rawUrl: string): string | null {
-  let u: URL;
-  try {
-    u = new URL(rawUrl);
-  } catch {
-    return `unparseable URL: ${truncate(rawUrl, 80)}`;
-  }
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-    return `unsupported protocol: ${u.protocol}`;
-  }
-  const host = u.hostname.toLowerCase();
-  if (!host) return 'missing hostname';
-
-  // Block obvious local DNS suffixes
-  if (host === 'localhost' || host.endsWith('.localhost')) return `local-only hostname: ${host}`;
-  if (host.endsWith('.internal') || host.endsWith('.local') || host.endsWith('.lan'))
-    return `internal-only hostname: ${host}`;
-
-  // IPv4 literal checks
-  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4) {
-    const [, a, b, c, d] = ipv4.map(Number) as [number, number, number, number, number];
-    if (a > 255 || b > 255 || c > 255 || d > 255) return `invalid IPv4: ${host}`;
-    if (a === 10) return `private IPv4 (10/8): ${host}`;
-    if (a === 127) return `loopback IPv4: ${host}`;
-    if (a === 0) return `null route IPv4: ${host}`;
-    if (a === 169 && b === 254) return `link-local IPv4: ${host}`;
-    if (a === 172 && b >= 16 && b <= 31) return `private IPv4 (172.16/12): ${host}`;
-    if (a === 192 && b === 168) return `private IPv4 (192.168/16): ${host}`;
-    if (a === 100 && b >= 64 && b <= 127) return `CGNAT IPv4: ${host}`;
-  }
-
-  // IPv6 literal checks (URL.hostname strips brackets but not always — handle both)
-  const v6 = host.replace(/^\[|\]$/g, '');
-  if (v6.includes(':')) {
-    if (v6 === '::1') return `loopback IPv6: ${host}`;
-    if (v6 === '::' || v6 === '0:0:0:0:0:0:0:0') return `null IPv6: ${host}`;
-    if (/^fe[89ab][0-9a-f]:/i.test(v6)) return `link-local IPv6: ${host}`;
-    if (/^f[cd][0-9a-f]{2}:/i.test(v6)) return `unique-local IPv6: ${host}`;
-    // IPv4-mapped IPv6 — Node canonicalizes "::ffff:127.0.0.1" to "::ffff:7f00:1",
-    // so handle both forms.
-    if (/^::ffff:/i.test(v6)) {
-      const tail = v6.slice('::ffff:'.length);
-      // Dotted form (rare after canonicalization but possible from user input)
-      if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(tail)) {
-        const inner = rejectIfInternalHost(`http://${tail}/`);
-        if (inner) return `IPv4-mapped IPv6 to ${inner}`;
-      } else {
-        // Hex-pair form: high:low (each up to 4 hex chars).
-        const parts = tail.split(':');
-        if (parts.length === 2) {
-          const high = parseInt(parts[0], 16);
-          const low = parseInt(parts[1], 16);
-          if (Number.isFinite(high) && Number.isFinite(low)) {
-            const a = (high >> 8) & 0xff;
-            const b = high & 0xff;
-            const c = (low >> 8) & 0xff;
-            const d = low & 0xff;
-            const dotted = `${a}.${b}.${c}.${d}`;
-            const inner = rejectIfInternalHost(`http://${dotted}/`);
-            if (inner) return `IPv4-mapped IPv6 to ${inner}`;
-          }
-        }
-      }
-    }
-  }
-
-  return null;
 }
 
 /**
  * URL acceptability check at the value-string level. Rejects:
  * - non-http(s) protocols
- * - URLs with embedded credentials (`user:pass@host`) — we never want to
- *   send those in a HEAD/GET probe.
+ * - URLs with embedded credentials (`user:pass@host`)
  *
- * SSRF host-class rejection is handled separately by `rejectIfInternalHost`.
+ * Pre-validation only — actual SSRF defense lives in resource-ingest, where
+ * the URL is fetched. This check just keeps obvious garbage out of the
+ * resource-ingest queue.
  */
 function looksLikeUrl(s: string): boolean {
   let u: URL;

--- a/crux/lib/sourcing/url-resolves-verifier.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.ts
@@ -10,22 +10,44 @@
  * Cost: $0. Latency: ~10ms vs ~5s+ for an LLM call.
  *
  * Verdict mapping:
- * - 2xx (or same-host 3xx → 2xx) → `confirmed`
+ * - 2xx (after redirect-follow) → `confirmed`
  * - 4xx/5xx → `contradicted` (link rot)
  * - Network error / timeout → `unverifiable`
  *
  * Wikipedia-specific: also fetches the page and checks the `<title>` contains
- * the entity name. A Wikipedia URL that resolves but points at a different
- * article (e.g., a redirect from `/wiki/Anthropic_(company)` to a generic
- * disambiguation page) is `contradicted`, not `confirmed`.
+ * the entity name as a whole-word match. A Wikipedia URL that resolves but
+ * points at a different article (e.g., a redirect from `/wiki/Anthropic_(company)`
+ * to a generic disambiguation page) is `contradicted`, not `confirmed`.
+ *
+ * Security:
+ * - SSRF defense: hostnames matching private/loopback/internal patterns
+ *   (RFC1918, link-local, localhost, .internal/.local) are rejected before
+ *   the request fires. Final response URL after redirects is re-validated;
+ *   if a redirect lands on an internal host the verdict is `unverifiable`.
+ * - URLs with embedded credentials (`user:pass@host`) are rejected.
+ * - Only http(s) protocols are accepted.
+ *
+ * Hardening considered out of scope (no observed need): full DNS-pinning to
+ * defeat rebinding, robots.txt parsing, per-host token-bucket rate limit
+ * (orchestrator-level concurrency cap is the existing knob).
  */
 
 import type { SourcingVerdict } from '../../../apps/wiki-server/src/api-types.ts';
-import type { VerifyItem, VerifyResult, FactItemData } from './orchestrator-types.ts';
+import type { VerifyItem, VerifyResult } from './orchestrator-types.ts';
 
 const URL_RESOLVES_TIMEOUT_MS = 10_000;
 const URL_RESOLVES_USER_AGENT =
   'longterm-wiki url-resolves-verifier (https://www.longtermwiki.com)';
+/** Cap on Wikipedia HTML body read; only `<title>` is needed and it's near the top. */
+const WIKIPEDIA_BODY_CAP_BYTES = 64 * 1024;
+
+/** Confidence values used in returned verdicts. */
+const CONFIDENCE_DEFINITE = 0.95;
+const CONFIDENCE_HIGH = 0.85;
+const CONFIDENCE_MEDIUM = 0.7;
+
+/** HTTP statuses where a server has rejected HEAD; retry with GET. */
+const HEAD_NOT_ALLOWED_STATUSES = new Set([405, 501]);
 
 /** Verdict + machine-readable reason returned by the underlying HTTP probe. */
 interface UrlResolvesProbeResult {
@@ -48,8 +70,9 @@ export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResu
   if (data.verifierKind !== 'url-resolves') return null;
 
   // The URL we verify is the fact's stored value, not fact.source.
-  // For wikipedia-url / github-profile / etc., the value IS the URL.
-  const urlToCheck = data.rawValue ?? data.formattedValue;
+  // Use rawValue only — formattedValue can include display formatting (units,
+  // wrappers) that would parse as garbage.
+  const urlToCheck = data.rawValue;
   if (!urlToCheck || !looksLikeUrl(urlToCheck)) {
     return {
       itemId: item.id,
@@ -58,8 +81,25 @@ export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResu
       verdict: 'unverifiable' as SourcingVerdict,
       confidence: 1.0,
       extractedValue: '',
-      reasoning: `[url-resolves] fact value is not a URL: ${truncate(urlToCheck ?? '<empty>', 80)}`,
+      reasoning: `[url-resolves] fact value is not an http(s) URL: ${truncate(urlToCheck ?? '<empty>', 80)}`,
       sourceUrl: item.sourceUrl ?? '',
+      checkerModel: 'url-resolves',
+    };
+  }
+
+  // SSRF defense: reject internal/private/loopback hostnames before any fetch.
+  // The redirect-target is re-validated below; this catches the direct case.
+  const hostnameError = rejectIfInternalHost(urlToCheck);
+  if (hostnameError) {
+    return {
+      itemId: item.id,
+      kind: item.kind,
+      description: item.description,
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 1.0,
+      extractedValue: '',
+      reasoning: `[url-resolves] ${hostnameError}`,
+      sourceUrl: item.sourceUrl ?? urlToCheck,
       checkerModel: 'url-resolves',
     };
   }
@@ -89,30 +129,49 @@ export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResu
 
 /**
  * Probe a URL with HEAD; fall back to GET-no-body if HEAD is rejected (some
- * servers, notably GitHub raw and a few CDNs, return 405/501 for HEAD).
+ * servers return 405/501 for HEAD).
  *
- * Returns the verdict mapping described in this file's docstring.
+ * The GET fallback releases the body via `response.body?.cancel()` so we don't
+ * hold the socket open waiting for a body we never read.
  */
 export async function probeUrlResolves(url: string): Promise<UrlResolvesProbeResult> {
   let response: Response;
   try {
-    response = await fetchWithRedirectAwareness(url, 'HEAD');
-    if (response.status === 405 || response.status === 501) {
-      // HEAD not allowed — retry with GET (we ignore the body).
-      response = await fetchWithRedirectAwareness(url, 'GET');
+    response = await fetchWithTimeout(url, 'HEAD');
+    if (HEAD_NOT_ALLOWED_STATUSES.has(response.status)) {
+      // HEAD not allowed — retry with GET. Cancel the HEAD response body
+      // (probably empty for HEAD anyway) and the GET response body once we
+      // have status, so neither connection lingers.
+      await safeCancel(response.body);
+      response = await fetchWithTimeout(url, 'GET');
     }
   } catch (e: unknown) {
     return {
       verdict: 'unverifiable' as SourcingVerdict,
-      confidence: 0.7,
+      confidence: CONFIDENCE_MEDIUM,
       reasoning: `[url-resolves] network error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  // Always release the body — neither HEAD nor the GET-fallback consumes it.
+  await safeCancel(response.body);
+
+  // If the redirect chain landed on an internal host, treat as unverifiable —
+  // belt-and-suspenders to the pre-fetch check.
+  const finalHostError = rejectIfInternalHost(response.url);
+  if (finalHostError) {
+    return {
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 1.0,
+      reasoning: `[url-resolves] redirected to internal host: ${finalHostError}`,
+      finalUrl: response.url,
     };
   }
 
   if (response.status >= 200 && response.status < 300) {
     return {
       verdict: 'confirmed' as SourcingVerdict,
-      confidence: 0.95,
+      confidence: CONFIDENCE_DEFINITE,
       reasoning: `[url-resolves] HTTP ${response.status}${response.url !== url ? ` (redirected to ${response.url})` : ''}`,
       finalUrl: response.url,
     };
@@ -121,14 +180,14 @@ export async function probeUrlResolves(url: string): Promise<UrlResolvesProbeRes
   if (response.status >= 400) {
     return {
       verdict: 'contradicted' as SourcingVerdict,
-      confidence: 0.95,
+      confidence: CONFIDENCE_DEFINITE,
       reasoning: `[url-resolves] HTTP ${response.status} — link rot or removed`,
       finalUrl: response.url,
     };
   }
 
-  // 3xx that wasn't followed (e.g., redirect: 'manual' would land here, but we
-  // use redirect: 'follow' below so this is unusual). Treat as unverifiable.
+  // 3xx not normally reachable when redirect: 'follow' is set — fetch follows
+  // up to 20 then throws. Defensive branch.
   return {
     verdict: 'unverifiable' as SourcingVerdict,
     confidence: 0.6,
@@ -139,9 +198,9 @@ export async function probeUrlResolves(url: string): Promise<UrlResolvesProbeRes
 
 /**
  * Wikipedia-specific probe: fetch the page (GET, not HEAD — we need the title)
- * and check that the article title contains the entity name. Catches the case
- * where a wikipedia-url resolves but points at the wrong article (e.g., a
- * disambiguation page).
+ * and check that the article title contains the entity name as a whole-word
+ * match. Catches the case where a wikipedia-url resolves but points at the
+ * wrong article (e.g., a disambiguation page).
  */
 export async function probeWikipediaUrl(
   url: string,
@@ -150,16 +209,18 @@ export async function probeWikipediaUrl(
   let response: Response;
   let body: string;
   try {
-    response = await fetchWithRedirectAwareness(url, 'GET');
+    response = await fetchWithTimeout(url, 'GET');
     if (response.status >= 400) {
+      await safeCancel(response.body);
       return {
         verdict: 'contradicted' as SourcingVerdict,
-        confidence: 0.95,
+        confidence: CONFIDENCE_DEFINITE,
         reasoning: `[url-resolves wikipedia] HTTP ${response.status} — link rot`,
         finalUrl: response.url,
       };
     }
     if (response.status < 200 || response.status >= 300) {
+      await safeCancel(response.body);
       return {
         verdict: 'unverifiable' as SourcingVerdict,
         confidence: 0.6,
@@ -167,13 +228,22 @@ export async function probeWikipediaUrl(
         finalUrl: response.url,
       };
     }
-    // Cap body read to avoid pulling MB of HTML for the title alone.
-    body = await readCappedText(response, 64 * 1024);
+    body = await readCappedText(response, WIKIPEDIA_BODY_CAP_BYTES);
   } catch (e: unknown) {
     return {
       verdict: 'unverifiable' as SourcingVerdict,
-      confidence: 0.7,
+      confidence: CONFIDENCE_MEDIUM,
       reasoning: `[url-resolves wikipedia] network error: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  const finalHostError = rejectIfInternalHost(response.url);
+  if (finalHostError) {
+    return {
+      verdict: 'unverifiable' as SourcingVerdict,
+      confidence: 1.0,
+      reasoning: `[url-resolves wikipedia] redirected to internal host: ${finalHostError}`,
+      finalUrl: response.url,
     };
   }
 
@@ -184,21 +254,18 @@ export async function probeWikipediaUrl(
     // 200-OK Wikipedia pages without a parsable title are extremely rare.
     return {
       verdict: 'confirmed' as SourcingVerdict,
-      confidence: 0.7,
+      confidence: CONFIDENCE_MEDIUM,
       reasoning: `[url-resolves wikipedia] HTTP ${response.status}, title not parseable`,
       finalUrl: response.url,
     };
   }
 
-  // Title check: case-insensitive substring match. Wikipedia titles are like
-  // "Anthropic - Wikipedia" or "Geoffrey Hinton - Wikipedia". The entity name
-  // must appear somewhere in the title text.
-  const titleNorm = title.toLowerCase();
-  const nameNorm = entityName.toLowerCase();
-  if (titleNorm.includes(nameNorm)) {
+  // Word-boundary check (not raw substring) — prevents an entity named "Foo"
+  // from matching "Foobar - Wikipedia" or an org "AI" matching "AIDS".
+  if (titleContainsEntityName(title, entityName)) {
     return {
       verdict: 'confirmed' as SourcingVerdict,
-      confidence: 0.95,
+      confidence: CONFIDENCE_DEFINITE,
       reasoning: `[url-resolves wikipedia] title "${title}" contains "${entityName}"`,
       finalUrl: response.url,
       pageTitle: title,
@@ -209,7 +276,7 @@ export async function probeWikipediaUrl(
   // Could be disambiguation, redirect to broader concept, or wrong link.
   return {
     verdict: 'contradicted' as SourcingVerdict,
-    confidence: 0.85,
+    confidence: CONFIDENCE_HIGH,
     reasoning: `[url-resolves wikipedia] title "${title}" does not contain entity name "${entityName}"`,
     finalUrl: response.url,
     pageTitle: title,
@@ -222,7 +289,7 @@ export async function probeWikipediaUrl(
  * Wrap fetch with a 10s timeout, a friendly UA, and redirect: 'follow'.
  * Returns the final Response; the caller checks .status and .url.
  */
-async function fetchWithRedirectAwareness(url: string, method: 'HEAD' | 'GET'): Promise<Response> {
+async function fetchWithTimeout(url: string, method: 'HEAD' | 'GET'): Promise<Response> {
   return fetch(url, {
     method,
     redirect: 'follow',
@@ -231,19 +298,38 @@ async function fetchWithRedirectAwareness(url: string, method: 'HEAD' | 'GET'): 
   });
 }
 
-/** Read at most `cap` bytes of the response body as text. */
+/** Cancel a response body's reader if present; swallow errors. */
+async function safeCancel(body: ReadableStream<Uint8Array> | null): Promise<void> {
+  if (!body) return;
+  try {
+    await body.cancel();
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Read at most `cap` bytes of the response body as text. Slices the trailing
+ * chunk if it would push us past `cap` so we don't buffer a multi-MB body
+ * just because the network sent one big chunk.
+ */
 async function readCappedText(response: Response, cap: number): Promise<string> {
   if (!response.body) return '';
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
-    while (true) {
+    while (total < cap) {
       const { value, done } = await reader.read();
       if (done) break;
+      const remaining = cap - total;
+      if (value.byteLength > remaining) {
+        chunks.push(value.subarray(0, remaining));
+        total = cap;
+        break;
+      }
       chunks.push(value);
       total += value.byteLength;
-      if (total >= cap) break;
     }
   } finally {
     try {
@@ -252,9 +338,9 @@ async function readCappedText(response: Response, cap: number): Promise<string> 
       // Best-effort; the reader may already be released.
     }
   }
-  // Concatenate chunks then decode as UTF-8. Avoids the Blob<->TS-lib type
-  // friction with newer @types/node where Uint8Array carries an ArrayBuffer
-  // template parameter that BlobPart doesn't accept.
+  // Concatenate chunks then UTF-8 decode. TextDecoder's default replaces
+  // truncated multi-byte sequences with U+FFFD, which is fine — Wikipedia
+  // titles sit in the first few KB so the cap-boundary case is rare.
   let totalLen = 0;
   for (const c of chunks) totalLen += c.byteLength;
   const merged = new Uint8Array(totalLen);
@@ -277,31 +363,172 @@ export function extractWikipediaTitle(html: string): string | null {
   return title.replace(/\s*[-–]\s*Wikipedia\s*$/, '').trim() || null;
 }
 
-/** Tiny HTML entity decoder (just the handful Wikipedia titles use). */
-function decodeHtmlEntities(s: string): string {
-  return s
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+/**
+ * Decode the HTML entities Wikipedia article titles realistically produce:
+ * - Named entities: &amp; &lt; &gt; &quot; &#39; &nbsp; &apos; &copy; &mdash; &ndash; &hellip; &trade;
+ * - Numeric entities: decimal (&#233;) and hex (&#xE9;) — used for non-ASCII chars
+ *   in titles like "Citroën", "São Paulo", "Encyclopædia Britannica"
+ *
+ * `&amp;` is processed last so an input like "&amp;lt;" decodes to "&lt;",
+ * not "<". Numeric/hex entities are processed first so they don't interact
+ * with named-entity replacement.
+ */
+export function decodeHtmlEntities(s: string): string {
+  // Numeric entities first
+  let out = s.replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) => safeFromCodePoint(parseInt(hex, 16)));
+  out = out.replace(/&#(\d+);/g, (_m, dec) => safeFromCodePoint(parseInt(dec, 10)));
+  // Common named entities (deliberately small — the realistic set Wikipedia uses).
+  // Order: replace &amp; LAST so an encoded "&amp;lt;" becomes "&lt;" not "<".
+  const named: Array<[RegExp, string]> = [
+    [/&apos;/g, "'"],
+    [/&lt;/g, '<'],
+    [/&gt;/g, '>'],
+    [/&quot;/g, '"'],
+    [/&#39;/g, "'"],
+    [/&nbsp;/g, ' '],
+    [/&copy;/g, '©'],
+    [/&trade;/g, '™'],
+    [/&mdash;/g, '—'],
+    [/&ndash;/g, '–'],
+    [/&hellip;/g, '…'],
+    [/&amp;/g, '&'],
+  ];
+  for (const [pattern, replacement] of named) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+function safeFromCodePoint(cp: number): string {
+  if (!Number.isFinite(cp) || cp < 0 || cp > 0x10ffff) return '';
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
 }
 
 // ── Validation helpers ─────────────────────────────────────────────
 
-function looksLikeUrl(s: string): boolean {
+/**
+ * Word-boundary–aware containment: returns true when `entityName` appears in
+ * `title` as a whole word (or a sequence of whole words), case-insensitive.
+ * Falls back to a permissive normalization (alphanumerics + spaces only) so
+ * minor punctuation differences ("U.S." vs "U S") don't block a match.
+ */
+export function titleContainsEntityName(title: string, entityName: string): boolean {
+  const normalize = (s: string): string =>
+    s
+      .toLowerCase()
+      // Keep letters/numbers as words; collapse all other runs to a single space.
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim();
+  const t = normalize(title);
+  const n = normalize(entityName);
+  if (!t || !n) return false;
+  // Word-boundary match: the entity-name token sequence must appear at a word
+  // boundary in the normalized title. Padding with spaces gives us cheap
+  // \b-equivalent semantics on the normalized form.
+  return ` ${t} `.includes(` ${n} `);
+}
+
+/**
+ * Hostname-based SSRF guard. Returns an error string if the URL targets a
+ * private/loopback/internal address; null if the host is acceptable.
+ *
+ * Not bulletproof against DNS rebinding (would need to resolve the host and
+ * re-validate the IP), but blocks the obvious local-network probing case.
+ */
+export function rejectIfInternalHost(rawUrl: string): string | null {
+  let u: URL;
   try {
-    const u = new URL(s);
-    return u.protocol === 'http:' || u.protocol === 'https:';
+    u = new URL(rawUrl);
+  } catch {
+    return `unparseable URL: ${truncate(rawUrl, 80)}`;
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    return `unsupported protocol: ${u.protocol}`;
+  }
+  const host = u.hostname.toLowerCase();
+  if (!host) return 'missing hostname';
+
+  // Block obvious local DNS suffixes
+  if (host === 'localhost' || host.endsWith('.localhost')) return `local-only hostname: ${host}`;
+  if (host.endsWith('.internal') || host.endsWith('.local') || host.endsWith('.lan'))
+    return `internal-only hostname: ${host}`;
+
+  // IPv4 literal checks
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [, a, b, c, d] = ipv4.map(Number) as [number, number, number, number, number];
+    if (a > 255 || b > 255 || c > 255 || d > 255) return `invalid IPv4: ${host}`;
+    if (a === 10) return `private IPv4 (10/8): ${host}`;
+    if (a === 127) return `loopback IPv4: ${host}`;
+    if (a === 0) return `null route IPv4: ${host}`;
+    if (a === 169 && b === 254) return `link-local IPv4: ${host}`;
+    if (a === 172 && b >= 16 && b <= 31) return `private IPv4 (172.16/12): ${host}`;
+    if (a === 192 && b === 168) return `private IPv4 (192.168/16): ${host}`;
+    if (a === 100 && b >= 64 && b <= 127) return `CGNAT IPv4: ${host}`;
+  }
+
+  // IPv6 literal checks (URL.hostname strips brackets but not always — handle both)
+  const v6 = host.replace(/^\[|\]$/g, '');
+  if (v6.includes(':')) {
+    if (v6 === '::1') return `loopback IPv6: ${host}`;
+    if (v6 === '::' || v6 === '0:0:0:0:0:0:0:0') return `null IPv6: ${host}`;
+    if (/^fe[89ab][0-9a-f]:/i.test(v6)) return `link-local IPv6: ${host}`;
+    if (/^f[cd][0-9a-f]{2}:/i.test(v6)) return `unique-local IPv6: ${host}`;
+    // IPv4-mapped IPv6 — Node canonicalizes "::ffff:127.0.0.1" to "::ffff:7f00:1",
+    // so handle both forms.
+    if (/^::ffff:/i.test(v6)) {
+      const tail = v6.slice('::ffff:'.length);
+      // Dotted form (rare after canonicalization but possible from user input)
+      if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(tail)) {
+        const inner = rejectIfInternalHost(`http://${tail}/`);
+        if (inner) return `IPv4-mapped IPv6 to ${inner}`;
+      } else {
+        // Hex-pair form: high:low (each up to 4 hex chars).
+        const parts = tail.split(':');
+        if (parts.length === 2) {
+          const high = parseInt(parts[0], 16);
+          const low = parseInt(parts[1], 16);
+          if (Number.isFinite(high) && Number.isFinite(low)) {
+            const a = (high >> 8) & 0xff;
+            const b = high & 0xff;
+            const c = (low >> 8) & 0xff;
+            const d = low & 0xff;
+            const dotted = `${a}.${b}.${c}.${d}`;
+            const inner = rejectIfInternalHost(`http://${dotted}/`);
+            if (inner) return `IPv4-mapped IPv6 to ${inner}`;
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * URL acceptability check at the value-string level. Rejects:
+ * - non-http(s) protocols
+ * - URLs with embedded credentials (`user:pass@host`) — we never want to
+ *   send those in a HEAD/GET probe.
+ *
+ * SSRF host-class rejection is handled separately by `rejectIfInternalHost`.
+ */
+function looksLikeUrl(s: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(s);
   } catch {
     return false;
   }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+  if (u.username || u.password) return false;
+  return true;
 }
 
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
 }
-
-// Re-export for tests + dispatchers
-export type { FactItemData };

--- a/packages/factbase/data/properties.yaml
+++ b/packages/factbase/data/properties.yaml
@@ -153,7 +153,7 @@ properties:
     dataType: text
     category: biographical
     appliesTo: [person]
-    verifiable: false  # X.com/Twitter blocks automated access
+    verifierKind: url-resolves  # QUA-927: cheap HEAD-resolves check; no content claim to verify
 
   google-scholar:
     name: Google Scholar
@@ -161,6 +161,7 @@ properties:
     dataType: text
     category: biographical
     appliesTo: [person]
+    verifierKind: url-resolves  # QUA-927: URL itself is the claim — verify via HEAD
 
   github-profile:
     name: GitHub
@@ -168,6 +169,7 @@ properties:
     dataType: text
     category: biographical
     appliesTo: [person]
+    verifierKind: url-resolves  # QUA-927: URL itself is the claim — verify via HEAD
 
   wikipedia-url:
     name: Wikipedia
@@ -175,7 +177,7 @@ properties:
     dataType: text
     category: biographical
     appliesTo: [person]
-    verifiable: false  # Self-referential: the fact IS the URL
+    verifierKind: url-resolves  # QUA-927: cheap HEAD + title check, replaces self-referential skip
 
   founded-by:
     name: Founded By

--- a/packages/factbase/src/types.ts
+++ b/packages/factbase/src/types.ts
@@ -110,6 +110,16 @@ export interface Property {
   temporal?: boolean;
   /** If false, skip automated source-checking (e.g., social media handles, self-referential URLs). Default: true. */
   verifiable?: boolean;
+  /**
+   * How to verify facts on this property (QUA-927).
+   * - `content-claim` (default): fetch source text + LLM checks the claim against it
+   * - `url-resolves`: HTTP HEAD only — verifies the URL itself resolves (cheap, ~10ms, $0)
+   *
+   * Properties with `verifierKind: url-resolves` are NOT skipped by `verifiable: false`
+   * filters — the URL-resolves verifier is precisely the cheap path that handles cases
+   * where content-claim verification would be tautological or impossible.
+   */
+  verifierKind?: 'content-claim' | 'url-resolves';
 }
 
 // ── Type Schemas ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a third verifier kind alongside `content-claim` — `url-resolves` — for the cheap, $0 verification path described in QUA-927. Properties whose stored value IS the URL (Wikipedia article, GitHub profile, Google Scholar, social media) no longer require a content-claim LLM check.

Closes QUA-927.

## Design — verifier rides the Resource pipeline

**The verifier does not fetch URLs.** It consumes cached state from the existing Resource pipeline and self-heals via `suggestResourcesApi` for unknown URLs.

> History: an earlier draft of this PR issued its own HEAD/GET against the live URL with parallel SSRF / timeout / redirect / Wikipedia HTML-parse code. That bypassed `content_hash` change detection (QUA-312/329), didn't produce a `resources` row, and duplicated logic the resource-ingest worker already runs. Switched to Resource-routed in `2094d5f16` per review.

Decision tree:

| Cached state | Verdict | Confidence |
|---|---|---|
| `citation_content.httpStatus` 2xx (non-Wikipedia) | `confirmed` | 0.95 |
| `citation_content.httpStatus` 2xx + Wikipedia pageTitle matches entity | `confirmed` | 0.95 |
| `citation_content.httpStatus` 2xx + Wikipedia pageTitle does NOT match | `contradicted` | 0.85 |
| `citation_content.httpStatus` 4xx/5xx | `contradicted` | 0.95 |
| `resources.fetchStatus` is dead/soft_404/not_found/timeout/unreachable | `contradicted` | 0.95 |
| `resources.fetchStatus` is `paywall` | `confirmed` (URL alive, body gated) | 0.85 |
| `resources.fetchStatus` is `ok` (no content yet) | `confirmed` | 0.85 |
| Nothing cached anywhere | `unverifiable` + enqueue `resource-ingest` job | 0.7 |

Self-healing: a brand-new URL returns `unverifiable` on its first pass and enqueues ingest. The next pass (after the worker runs) gets a real verdict from the cached state. Same flow `source-fetcher.ts` already uses for content-claim.

## What changed

| File | Change |
|------|--------|
| `crux/lib/sourcing/url-resolves-verifier.ts` | Resource-pipeline consumer (~290 lines, was ~535) |
| `crux/lib/sourcing/url-resolves-verifier.test.ts` | 46 tests mocking `lookupResourceByUrl`, `getCitationContentByUrl`, `suggestResourcesApi` |
| `crux/lib/sourcing/item-verifier.ts` | Dispatch url-resolves first, before deterministic matchers |
| `crux/lib/sourcing/orchestrator.ts` | Inline url-resolves in the batch path so these items never queue for the Anthropic Batch API |
| `crux/lib/sourcing/item-collectors.ts` | Stop skipping facts whose property has `verifierKind: url-resolves`; propagate `propertyId` and `verifierKind` onto `FactItemData` |
| `crux/lib/sourcing/orchestrator-types.ts` | New optional fields on `FactItemData`: `propertyId`, `verifierKind` |
| `packages/factbase/src/types.ts` | New `Property.verifierKind` field |
| `packages/factbase/data/properties.yaml` | Mark `wikipedia-url`, `social-media`, `github-profile`, `google-scholar` as `verifierKind: url-resolves` (drops `verifiable: false` on Wikipedia and social-media) |

Cost: $0 per check. Latency: one wiki-server lookup per check (~10–50ms) for known URLs.

## Why route through Resources

- **Content-hash change detection** (QUA-312/329) — a Wikipedia URL rewritten to a different topic flips the `content_hash`, triggers re-enrichment, triggers a fresh source-check verdict. Direct HEAD has no temporal awareness.
- **`resources` row exists** — `archive_url`, `last_fetched_at`, `fetch_status` available to admins. Verdict is no longer a parallel universe.
- **Wayback fallback** for dead links — `source-fetcher.ts` already does this; the url-resolves path now inherits it.
- **One HTTP code path** — SSRF guard, timeout, redirect, HTML title extraction all live in the resource-ingest worker. One place to fix bugs.

## Acceptance criteria — from QUA-927

- [x] New `url-resolves` verifier type implemented + tested (46 tests)
- [x] `wikipedia-url`, `github-profile`, `google-scholar`, `social-media` marked `verifierKind: url-resolves`
- [x] These facts are no longer excluded by `collectFactItems`
- [x] Verdicts land in `source_check_verdicts` with verdict=`confirmed` for valid URLs (uses existing `storeResult` path; `checkerModel='url-resolves'`)

The "expect coverage ceiling rises by ~14pp" criterion is verifiable post-merge by running `pnpm crux fb sourcing --type=fact --table=fact --limit=500` against the now-eligible ~388 facts. First run will enqueue ingest jobs for any not-yet-cached URLs; second run reads the verdicts.

## Test plan

- [x] `npx vitest run crux/lib/sourcing/url-resolves-verifier.test.ts` — 46/46 pass
- [x] `npx vitest run crux/lib/sourcing/` — all 630 sourcing tests pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean for changed files
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `pnpm crux w validate gate --fix` — all 55 checks pass

## Notes for reviewers

- **`website` was deliberately not included.** The ticket explicitly defers it ("optionally `website` after policy review"). A website fact is still self-referential and there's no easy "right page" check; left for a follow-up.
- **Verifier dispatch ordering**: url-resolves runs *before* the Wikidata and OpenAlex deterministic matchers. The matchers wouldn't match a url-resolves fact anyway (different propertyId), but the explicit ordering keeps the cheapest path first.
- **`verifiable: false` semantics preserved**: legacy facts with `verifiable: false` and no `verifierKind` are still skipped — the bypass is gated on the explicit `verifierKind: 'url-resolves'`.
- **First-pass behavior on new URLs**: returns `unverifiable` and enqueues ingest. Second pass gets a real verdict. Operators running a one-shot sourcing pass against a fresh dataset should expect to run twice.

## Commits

- `2cce11fac` — initial implementation (direct HEAD probe path)
- `1d0b7b7ad` — review fixes: SSRF guard, word-boundary match, robust HTML entity decoder, body-leak fix, credential URL block
- `2094d5f16` — **rewrite to consume Resource pipeline** per review feedback (drops 508 lines net)
