### PR TITLE
qa-sweep: count visual indicators as filled cells (QUA-900)

### DIFF
--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -206,6 +206,7 @@ Launch agents to fetch pages from `https://www.longtermwiki.com` using WebFetch.
 - Does it load (not 404/500)?
 - Count consistency: does the filter badge total match the body count?
 - Column fill rates: what percentage of rows have data in each column? Flag columns with >80% empty.
+  - **A cell is "filled" if it carries any of: text content, an `aria-label` (e.g. `aria-label="Coverage: 75%"`), a `title` attribute, a `role="img"` element (CoverageDots / SourceCheckDot / RecordStatusDots all render this), an `<svg>`, or a colored badge `<span>`.** Do NOT flag a column as empty just because the visible `<td>` has no plain text — many directory tables render coverage / verdict / status as small SVG-style dot indicators with no inline text. If you are unsure whether a cell renders a visual indicator, fetch the page and grep the HTML for `aria-label=` or `role="img"` inside its row before flagging the column. (False positives here led to QUA-900 being filed against /research-areas, /funding-programs, /publications, /projects, /approaches, /divisions when those columns actually rendered varied coverage dots for every row.)
 - Are there columns that should exist but don't? (e.g., tracked people count, completeness indicator, subentity counts)
 - Do any values show raw IDs or slugs instead of human-readable names?
 - Is the default sort order sensible?

--- a/.claude/commands/maintain-qa-sweep.md
+++ b/.claude/commands/maintain-qa-sweep.md
@@ -206,7 +206,13 @@ Launch agents to fetch pages from `https://www.longtermwiki.com` using WebFetch.
 - Does it load (not 404/500)?
 - Count consistency: does the filter badge total match the body count?
 - Column fill rates: what percentage of rows have data in each column? Flag columns with >80% empty.
-  - **A cell is "filled" if it carries any of: text content, an `aria-label` (e.g. `aria-label="Coverage: 75%"`), a `title` attribute, a `role="img"` element (CoverageDots / SourceCheckDot / RecordStatusDots all render this), an `<svg>`, or a colored badge `<span>`.** Do NOT flag a column as empty just because the visible `<td>` has no plain text — many directory tables render coverage / verdict / status as small SVG-style dot indicators with no inline text. If you are unsure whether a cell renders a visual indicator, fetch the page and grep the HTML for `aria-label=` or `role="img"` inside its row before flagging the column. (False positives here led to QUA-900 being filed against /research-areas, /funding-programs, /publications, /projects, /approaches, /divisions when those columns actually rendered varied coverage dots for every row.)
+  - **Definition of "filled": a `<td>` is filled if it contains any of the following.** Many directory columns render visual-only indicators with no inline text — do NOT count those as empty.
+    - Visible text content (the obvious case).
+    - A descendant element with `role="img"` (`CoverageDots`, `SourcingDot`, `RecordStatusDots`, `FactSourceCheckDot` all set this).
+    - A descendant element with `aria-label` whose value names data (e.g. `aria-label="Coverage: 75%"`, `aria-label="Sourcing: confirmed"`). Ignore decorative `aria-label` like `"chevron"`.
+    - A descendant `<svg>` (icons, indicators).
+    - A descendant `<span>` whose `class` matches a badge / pill pattern (e.g. `bg-*-100`, `rounded-full`, `inline-flex` color classes). Ignore plain `<span>` with no semantic class — those are layout wrappers.
+  - When in doubt, fetch the raw HTML and grep for the criteria above inside the row's `<td>`. Do not rely on rendered text alone. (Background: QUA-900 was filed in error against /research-areas, /funding-programs, /publications, /projects, /approaches, /divisions because the agent only counted text and missed the per-row Coverage dots.)
 - Are there columns that should exist but don't? (e.g., tracked people count, completeness indicator, subentity counts)
 - Do any values show raw IDs or slugs instead of human-readable names?
 - Is the default sort order sensible?

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -361,37 +361,55 @@ test.describe("Render audit — no dead entity sourcing links (QUA-418)", () => 
   }
 });
 
-test.describe("Render audit — directory Coverage/Status columns render dots (QUA-900)", () => {
-  // QA-900 was filed against six directory pages claiming the Coverage /
-  // Status column was 100% empty. The columns actually render a CoverageDots
-  // or RecordStatusDots indicator in every row — the QA sweep counted text
-  // content only and missed the aria-label / role="img" dots. This test
-  // pins down the invariant so the sweep tool can't false-positive again
-  // without a CI failure here.
-  for (const { url, label, allowZeroRows } of [
-    { url: "/research-areas", label: "Coverage" },
-    { url: "/funding-programs", label: "Coverage" },
-    { url: "/publications", label: "Coverage" },
-    { url: "/projects", label: "Coverage" },
-    { url: "/approaches", label: "Coverage" },
-    // /divisions filters by hasData by default; if the build has zero
-    // hasData rows (e.g., CI without PG access) the table is empty.
-    { url: "/divisions", label: "Coverage", allowZeroRows: true },
-  ] as Array<{ url: string; label: string; allowZeroRows?: boolean }>) {
-    test(`${url} has a ${label} dot in every row`, async ({ page }) => {
+test.describe("Render audit — directory Coverage columns render dots (QUA-900)", () => {
+  // QUA-900 was filed against six directory pages claiming the Coverage
+  // column was 100% empty. The columns actually render a CoverageDots
+  // (or RecordStatusDots, which embeds CoverageDots) indicator in every
+  // row — the QA sweep counted text content only and missed the
+  // aria-label="Coverage: <pct>%" dot. This test pins down the
+  // invariant so the sweep tool can't false-positive again without a
+  // CI failure here.
+  //
+  // Robustness:
+  //   - Per-row assertion (not total dot count) so a row that grows a
+  //     second indicator doesn't false-fail the whole page.
+  //   - Skips when the table has zero rows (CI builds without
+  //     LONGTERMWIKI_SERVER_URL → kb-pg merge skipped → most directory
+  //     tables empty). The render-audit runs against prod nightly, so
+  //     the assertion still fires there. Each url must verify the page
+  //     rendered (h1 present) so an empty table from a real bug — not
+  //     a missing data source — still surfaces.
+  for (const url of [
+    "/research-areas",
+    "/funding-programs",
+    "/publications",
+    "/projects",
+    "/approaches",
+    "/divisions",
+  ]) {
+    test(`${url} renders a Coverage dot in every row`, async ({ page }) => {
       await loadPage(page, url);
-      const rowCount = await page.locator("table tbody tr").count();
+      // Sanity: the page itself rendered (catches blank-page regressions
+      // that empty the table for a real reason rather than data absence).
+      await expect(page.locator("h1").first()).toBeVisible();
+
+      const rows = page.locator("table tbody tr");
+      const rowCount = await rows.count();
       if (rowCount === 0) {
-        if (allowZeroRows) return;
-        throw new Error(`${url} table rendered no rows`);
+        // Trivially passes — no data to check. CI without PG access
+        // hits this path. Prod runs always have rows.
+        return;
       }
-      const dotCount = await page
-        .locator(`table tbody [aria-label^="${label}:"]`)
-        .count();
-      expect(
-        dotCount,
-        `${url} expected ${rowCount} ${label} dots but found ${dotCount}`,
-      ).toBe(rowCount);
+      for (let i = 0; i < rowCount; i++) {
+        const dots = await rows
+          .nth(i)
+          .locator('[aria-label^="Coverage:"]')
+          .count();
+        expect(
+          dots,
+          `${url} row ${i + 1}/${rowCount} has ${dots} Coverage dot(s) (expected ≥1)`,
+        ).toBeGreaterThan(0);
+      }
     });
   }
 });

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -360,3 +360,38 @@ test.describe("Render audit — no dead entity sourcing links (QUA-418)", () => 
     });
   }
 });
+
+test.describe("Render audit — directory Coverage/Status columns render dots (QUA-900)", () => {
+  // QA-900 was filed against six directory pages claiming the Coverage /
+  // Status column was 100% empty. The columns actually render a CoverageDots
+  // or RecordStatusDots indicator in every row — the QA sweep counted text
+  // content only and missed the aria-label / role="img" dots. This test
+  // pins down the invariant so the sweep tool can't false-positive again
+  // without a CI failure here.
+  for (const { url, label, allowZeroRows } of [
+    { url: "/research-areas", label: "Coverage" },
+    { url: "/funding-programs", label: "Coverage" },
+    { url: "/publications", label: "Coverage" },
+    { url: "/projects", label: "Coverage" },
+    { url: "/approaches", label: "Coverage" },
+    // /divisions filters by hasData by default; if the build has zero
+    // hasData rows (e.g., CI without PG access) the table is empty.
+    { url: "/divisions", label: "Coverage", allowZeroRows: true },
+  ] as Array<{ url: string; label: string; allowZeroRows?: boolean }>) {
+    test(`${url} has a ${label} dot in every row`, async ({ page }) => {
+      await loadPage(page, url);
+      const rowCount = await page.locator("table tbody tr").count();
+      if (rowCount === 0) {
+        if (allowZeroRows) return;
+        throw new Error(`${url} table rendered no rows`);
+      }
+      const dotCount = await page
+        .locator(`table tbody [aria-label^="${label}:"]`)
+        .count();
+      expect(
+        dotCount,
+        `${url} expected ${rowCount} ${label} dots but found ${dotCount}`,
+      ).toBe(rowCount);
+    });
+  }
+});

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -393,7 +393,10 @@ test.describe("Render audit — directory Coverage columns render dots (QUA-900)
       // that empty the table for a real reason rather than data absence).
       await expect(page.locator("h1").first()).toBeVisible();
 
-      const rows = page.locator("table tbody tr");
+      // Exclude empty-state rows (single <td colspan=N> "No X match" rows).
+      // CI without PG data hits these — they're a UI placeholder, not a real
+      // table row, so they have no Coverage dot by design.
+      const rows = page.locator("table tbody tr:not(:has(td[colspan]))");
       const rowCount = await rows.count();
       if (rowCount === 0) {
         // Trivially passes — no data to check. CI without PG access


### PR DESCRIPTION
## Summary

QUA-900 was filed by the `/maintain-qa-sweep` skill claiming six directory pages (`/research-areas`, `/funding-programs`, `/publications`, `/projects`, `/approaches`, `/divisions`) had **100%-empty Coverage / Status columns**. Verification against prod showed this is a **misdiagnosis** — every row in those tables actually renders a `CoverageDots` / `RecordStatusDots` indicator with a populated `aria-label="Coverage: <pct>%"`. The QA sweep agent was counting only `textContent` and missing the dot indicators.

This PR fixes the source of the false positive (the skill's column-fill heuristic) and locks the invariant (the dots actually rendering) into CI so the next regression — in either direction — produces a real failure.

## Evidence (from prod)

| Page | Rows | Coverage `aria-label` distribution |
|---|---|---|
| /research-areas | 50 | 22×50%, 28×75% |
| /funding-programs | 50 | 11×50%, 31×75%, 8×100% |
| /publications | 152 | 14×50%, 13×75%, 125×100% |
| /projects | 62 | 30×75%, 32×100% |
| /approaches | 82 | 21×50%, 61×75% |
| /divisions | 101 | 101×100% (all uniform — see follow-up below) |

Raw-HTML on `/research-areas` (curl, no JS): 50 body `<tr>` + 50 `aria-label="Coverage:"` + 50 `role="img"`. The dots are in SSR; they just have no inline text.

## Changes

1. **`.claude/commands/maintain-qa-sweep.md`** § "2a. Index pages" — restructured the column-fill criterion as a sub-bulleted list. A `<td>` is "filled" if it has visible text OR a descendant with `role="img"` OR a descendant `aria-label` naming data OR a descendant `<svg>` OR a descendant `<span>` with a badge/pill class pattern. Calls out which classes / aria-labels to ignore (decorative tooltips, `aria-label="chevron"`, layout-only spans). Includes the QUA-900 incident as a footnote so the next sweep doesn't re-make the mistake.

2. **`apps/web/e2e/render-audit.spec.ts`** — new describe block asserting every body row in the six flagged tables has at least one `aria-label^="Coverage:"` indicator. Per-row check (not totals) so a row that legitimately grows a second indicator doesn't false-fail. Empty tables are skipped (CI without `LONGTERMWIKI_SERVER_URL` filters everything out for some pages); an `h1` visibility check still fires so a blank-page regression surfaces.

## Self-review applied

`/agent-review-pr` hostile-reviewer caught five MEDIUM-severity structural issues — all addressed in commit `87d4b7177`:

- Switched dot-count vs row-count strict-equality to per-row "≥1 dot".
- Removed asymmetric `/divisions allowZeroRows` carve-out; all six pages now share the same zero-rows-skip path.
- Added page-rendered (h1 visible) sanity check so a real blank-page bug isn't masked by the zero-rows skip.
- Restructured the skill's prose blob into discrete bullets per criterion.
- Tightened "colored badge span" criterion to a class-pattern match; dropped over-broad `title` attribute.

## Follow-up filed

QUA-932 (low) — `/divisions` Coverage column shows 100% on 101/101 visible rows (zero discrimination because the page already filters by `hasData`, which is one of the three signals). `/approaches`, `/research-areas`, `/projects` only ever show 2 distinct scores. Calibration concern, not in scope here.

## Test plan
- [x] `pnpm crux w validate gate --scope=content` passes
- [x] `npx tsc --noEmit` (apps/web) clean
- [x] All 6 new render-audit tests pass against prod
- [x] `/agent-review-pr` hostile reviewer findings addressed in commit `87d4b7177`
- [ ] CI green on push

Fixes QUA-900
