### PR TITLE
QUA-930: cascade-delete dependent source_check_verdicts when facts are pruned

### DIFF
--- a/apps/wiki-server/src/__tests__/facts.test.ts
+++ b/apps/wiki-server/src/__tests__/facts.test.ts
@@ -12,6 +12,8 @@ let verdictsStore: Map<string, Record<string, unknown>>;
 let evidenceStore: Map<string, Record<string, unknown>>;
 /** key: `${recordType}::${recordId}::${suggestedUrl}` */
 let suggestionsStore: Map<string, Record<string, unknown>>;
+/** key: `${claimId}::${recordType}::${recordId}` (matches uq_crl_claim_record) */
+let claimLinksStore: Map<string, Record<string, unknown>>;
 let nextId: number;
 
 function resetStores() {
@@ -20,6 +22,7 @@ function resetStores() {
   verdictsStore = new Map();
   evidenceStore = new Map();
   suggestionsStore = new Map();
+  claimLinksStore = new Map();
   nextId = 1;
 }
 
@@ -81,6 +84,23 @@ function injectSuggestion(
     source_provider: "exa",
     generator_model: null,
     status: "pending",
+    ...extra,
+  });
+}
+
+/** Inject a claim_record_links row directly. */
+function injectClaimLink(
+  recordType: string,
+  recordId: string,
+  claimId: number,
+  extra: Record<string, unknown> = {},
+) {
+  claimLinksStore.set(`${claimId}::${recordType}::${recordId}`, {
+    claim_id: claimId,
+    record_type: recordType,
+    record_id: recordId,
+    match_verdict: null,
+    match_confidence: null,
     ...extra,
   });
 }
@@ -444,67 +464,39 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // --- DELETE source_check_verdicts ---
-  // Two callers:
-  //   - recomputeVerdict (no IN clause, single-row by composite PK) → no-op for tests
-  //   - QUA-930 prune cascade (record_type=$1 AND record_id IN ($2,...)) → actually delete
-  if (q.includes("delete") && q.includes("source_check_verdicts")) {
-    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
-      const recordType = String(params[0] ?? "");
-      const recordIds = new Set(params.slice(1) as string[]);
-      const deleted: Array<{ record_id: string }> = [];
-      for (const [key, row] of verdictsStore) {
-        if (
-          row.record_type === recordType &&
-          recordIds.has(row.record_id as string)
-        ) {
-          verdictsStore.delete(key);
-          deleted.push({ record_id: row.record_id as string });
+  // --- DELETE FROM <table> WHERE record_type=$1 AND record_id IN ($2..) (QUA-930 cascade) ---
+  // Shared handler for all five (record_type, record_id)-keyed cascade tables.
+  // Also handles the existing recomputeVerdict DELETE on source_check_verdicts
+  // (no IN clause) by falling through to the no-op path.
+  const cascadeStores: Array<[string, Map<string, Record<string, unknown>>]> = [
+    ["source_check_verdicts", verdictsStore],
+    ["source_check_evidence", evidenceStore],
+    ["sourcing_url_suggestions", suggestionsStore],
+    ["claim_record_links", claimLinksStore],
+  ];
+  for (const [tableName, store] of cascadeStores) {
+    if (q.includes("delete") && q.includes(tableName)) {
+      if (
+        q.includes("record_type") &&
+        q.includes("record_id") &&
+        q.includes(" in ")
+      ) {
+        const recordType = String(params[0] ?? "");
+        const recordIds = new Set(params.slice(1) as string[]);
+        const deleted: Array<{ record_id: string }> = [];
+        for (const [key, row] of store) {
+          if (
+            row.record_type === recordType &&
+            recordIds.has(row.record_id as string)
+          ) {
+            store.delete(key);
+            deleted.push({ record_id: row.record_id as string });
+          }
         }
+        return deleted;
       }
-      return deleted;
+      return [];
     }
-    return [];
-  }
-
-  // --- DELETE source_check_evidence (QUA-930 cascade) ---
-  if (q.includes("delete") && q.includes("source_check_evidence")) {
-    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
-      const recordType = String(params[0] ?? "");
-      const recordIds = new Set(params.slice(1) as string[]);
-      const deleted: Array<{ record_id: string }> = [];
-      for (const [key, row] of evidenceStore) {
-        if (
-          row.record_type === recordType &&
-          recordIds.has(row.record_id as string)
-        ) {
-          evidenceStore.delete(key);
-          deleted.push({ record_id: row.record_id as string });
-        }
-      }
-      return deleted;
-    }
-    return [];
-  }
-
-  // --- DELETE sourcing_url_suggestions (QUA-930 cascade) ---
-  if (q.includes("delete") && q.includes("sourcing_url_suggestions")) {
-    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
-      const recordType = String(params[0] ?? "");
-      const recordIds = new Set(params.slice(1) as string[]);
-      const deleted: Array<{ record_id: string }> = [];
-      for (const [key, row] of suggestionsStore) {
-        if (
-          row.record_type === recordType &&
-          recordIds.has(row.record_id as string)
-        ) {
-          suggestionsStore.delete(key);
-          deleted.push({ record_id: row.record_id as string });
-        }
-      }
-      return deleted;
-    }
-    return [];
   }
 
   // --- entity_ids: COUNT (for health check) ---
@@ -1409,8 +1401,9 @@ describe("Facts API", () => {
         "ids",
         "truncated",
       ]);
-      // Cascaded sub-shape: {evidence, suggestions, verdicts} numbers.
+      // Cascaded sub-shape — all 4 cascade-target tables represented.
       expect(Object.keys(body.cascaded).sort()).toEqual([
+        "claimLinks",
         "evidence",
         "suggestions",
         "verdicts",
@@ -1418,6 +1411,7 @@ describe("Facts API", () => {
       expect(typeof body.cascaded.verdicts).toBe("number");
       expect(typeof body.cascaded.evidence).toBe("number");
       expect(typeof body.cascaded.suggestions).toBe("number");
+      expect(typeof body.cascaded.claimLinks).toBe("number");
     });
 
     it("caps the returned `ids` at MAX_PRUNE_RESPONSE_IDS and sets truncated=true", async () => {
@@ -1456,21 +1450,24 @@ describe("Facts API", () => {
   // ---- QUA-930: cascade deletion of dependent sourcing rows ----
 
   describe("POST /api/facts/prune cascade (QUA-930)", () => {
-    it("deletes dependent verdicts/evidence/suggestions when a fact is pruned", async () => {
+    it("deletes dependent verdicts/evidence/suggestions/claim-links when a fact is pruned", async () => {
       // Seed a fact and inject the dependent sourcing rows that the
       // sourcing pipeline would have produced for it.
       await seedFact(app, "anthropic", "f_stale", { measure: "revenue" });
       injectVerdict("fact", "f_stale");
       injectEvidence("fact", "f_stale", "https://example.com/source");
       injectSuggestion("fact", "f_stale", "https://example.com/suggested");
+      injectClaimLink("fact", "f_stale", 100);
       // Also seed an unrelated fact + its dependents to confirm the cascade
       // is scoped to deleted facts only.
       await seedFact(app, "anthropic", "f_keep", { measure: "valuation" });
       injectVerdict("fact", "f_keep");
       injectEvidence("fact", "f_keep", "https://example.com/keep-source");
+      injectClaimLink("fact", "f_keep", 200);
       expect(verdictsStore.size).toBe(2);
       expect(evidenceStore.size).toBe(2);
       expect(suggestionsStore.size).toBe(1);
+      expect(claimLinksStore.size).toBe(2);
 
       const res = await postJson(app, "/api/facts/prune", {
         entries: [{ entityId: "anthropic", factIds: ["f_keep"] }],
@@ -1485,18 +1482,21 @@ describe("Facts API", () => {
         verdicts: 1,
         evidence: 1,
         suggestions: 1,
+        claimLinks: 1,
       });
-      // The kept fact's verdict / evidence are untouched.
+      // The kept fact's verdict / evidence / claim-link are untouched.
       expect(verdictsStore.size).toBe(1);
       expect(Array.from(verdictsStore.values())[0].record_id).toBe("f_keep");
       expect(evidenceStore.size).toBe(1);
       expect(Array.from(evidenceStore.values())[0].record_id).toBe("f_keep");
       expect(suggestionsStore.size).toBe(0);
+      expect(claimLinksStore.size).toBe(1);
+      expect(Array.from(claimLinksStore.values())[0].record_id).toBe("f_keep");
     });
 
     it("returns zero cascade counts when there are no dependents", async () => {
       await seedFact(app, "anthropic", "f_stale", { measure: "revenue" });
-      // No verdicts/evidence/suggestions injected.
+      // No verdicts/evidence/suggestions/claim-links injected.
 
       const res = await postJson(app, "/api/facts/prune", {
         entries: [{ entityId: "anthropic", factIds: [] }],
@@ -1509,6 +1509,7 @@ describe("Facts API", () => {
         verdicts: 0,
         evidence: 0,
         suggestions: 0,
+        claimLinks: 0,
       });
     });
 
@@ -1536,7 +1537,7 @@ describe("Facts API", () => {
       expect(remaining.record_type).toBe("personnel");
     });
 
-    it("returns cascaded={0,0,0} when no facts are stale", async () => {
+    it("returns all-zero cascade counts when no facts are stale", async () => {
       await seedFact(app, "anthropic", "f_keep", { measure: "x" });
       injectVerdict("fact", "f_keep");
 
@@ -1551,6 +1552,7 @@ describe("Facts API", () => {
         verdicts: 0,
         evidence: 0,
         suggestions: 0,
+        claimLinks: 0,
       });
       // Verdict still there.
       expect(verdictsStore.size).toBe(1);
@@ -1566,6 +1568,10 @@ describe("Facts API", () => {
       injectEvidence("fact", "f_a", "https://example.com/a");
       injectEvidence("fact", "f_b", "https://example.com/b1");
       injectEvidence("fact", "f_b", "https://example.com/b2");
+      injectSuggestion("fact", "f_c", "https://example.com/suggested-c");
+      injectClaimLink("fact", "f_a", 10);
+      injectClaimLink("fact", "f_a", 11); // a fact can have multiple links
+      injectClaimLink("fact", "f_b", 12);
 
       const res = await postJson(app, "/api/facts/prune", {
         entries: [{ entityId: "anthropic", factIds: [] }],
@@ -1576,8 +1582,33 @@ describe("Facts API", () => {
       expect(body.deleted).toBe(3);
       expect(body.cascaded.verdicts).toBe(3);
       expect(body.cascaded.evidence).toBe(3);
+      expect(body.cascaded.suggestions).toBe(1);
+      expect(body.cascaded.claimLinks).toBe(3);
       expect(verdictsStore.size).toBe(0);
       expect(evidenceStore.size).toBe(0);
+      expect(suggestionsStore.size).toBe(0);
+      expect(claimLinksStore.size).toBe(0);
+    });
+
+    it("cascades claim_record_links scoped by record_type='fact' only", async () => {
+      // QUA-930: same defense-in-depth check as the verdict test —
+      // claim_record_links rows for a different record_type must survive.
+      await seedFact(app, "anthropic", "f_stale", { measure: "x" });
+      injectClaimLink("fact", "f_stale", 1);
+      injectClaimLink("personnel", "f_stale", 2); // same id, different type
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: [] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(1);
+      expect(body.cascaded.claimLinks).toBe(1);
+      // The personnel link survives.
+      expect(claimLinksStore.size).toBe(1);
+      const remaining = Array.from(claimLinksStore.values())[0];
+      expect(remaining.record_type).toBe("personnel");
     });
   });
 });

--- a/apps/wiki-server/src/__tests__/facts.test.ts
+++ b/apps/wiki-server/src/__tests__/facts.test.ts
@@ -10,6 +10,8 @@ let thingsStore: Map<string, Record<string, unknown>>; // key: `${source_table}:
 let verdictsStore: Map<string, Record<string, unknown>>;
 /** key: `${recordType}::${recordId}::${sourceUrl ?? ''}::${checkerModel ?? ''}` */
 let evidenceStore: Map<string, Record<string, unknown>>;
+/** key: `${recordType}::${recordId}::${suggestedUrl}` */
+let suggestionsStore: Map<string, Record<string, unknown>>;
 let nextId: number;
 
 function resetStores() {
@@ -17,7 +19,70 @@ function resetStores() {
   thingsStore = new Map();
   verdictsStore = new Map();
   evidenceStore = new Map();
+  suggestionsStore = new Map();
   nextId = 1;
+}
+
+/** Inject a verdict row directly. Used by the QUA-930 cascade tests. */
+function injectVerdict(
+  recordType: string,
+  recordId: string,
+  fieldName: string | null = null,
+  extra: Record<string, unknown> = {},
+) {
+  verdictsStore.set(`${recordType}::${recordId}::${fieldName ?? ""}`, {
+    record_type: recordType,
+    record_id: recordId,
+    field_name: fieldName,
+    entity_id: null,
+    verdict: "confirmed",
+    confidence: 0.9,
+    reasoning: null,
+    ...extra,
+  });
+}
+
+/** Inject an evidence row directly. */
+function injectEvidence(
+  recordType: string,
+  recordId: string,
+  sourceUrl: string,
+  extra: Record<string, unknown> = {},
+) {
+  evidenceStore.set(`${recordType}::${recordId}::${sourceUrl}::cm`, {
+    record_type: recordType,
+    record_id: recordId,
+    field_name: null,
+    entity_id: null,
+    source_url: sourceUrl,
+    verdict: "confirmed",
+    confidence: 0.9,
+    checker_model: "cm",
+    ...extra,
+  });
+}
+
+/** Inject a sourcing URL suggestion row directly. */
+function injectSuggestion(
+  recordType: string,
+  recordId: string,
+  suggestedUrl: string,
+  extra: Record<string, unknown> = {},
+) {
+  suggestionsStore.set(`${recordType}::${recordId}::${suggestedUrl}`, {
+    record_type: recordType,
+    record_id: recordId,
+    field_name: null,
+    entity_id: null,
+    suggested_url: suggestedUrl,
+    title: null,
+    snippet: null,
+    relevance_score: null,
+    source_provider: "exa",
+    generator_model: null,
+    status: "pending",
+    ...extra,
+  });
 }
 
 function thingsKey(sourceTable: string, sourceId: string) {
@@ -379,8 +444,66 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // --- recomputeVerdict: DELETE source_check_verdicts (when aggregate=unchecked) ---
+  // --- DELETE source_check_verdicts ---
+  // Two callers:
+  //   - recomputeVerdict (no IN clause, single-row by composite PK) → no-op for tests
+  //   - QUA-930 prune cascade (record_type=$1 AND record_id IN ($2,...)) → actually delete
   if (q.includes("delete") && q.includes("source_check_verdicts")) {
+    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
+      const recordType = String(params[0] ?? "");
+      const recordIds = new Set(params.slice(1) as string[]);
+      const deleted: Array<{ record_id: string }> = [];
+      for (const [key, row] of verdictsStore) {
+        if (
+          row.record_type === recordType &&
+          recordIds.has(row.record_id as string)
+        ) {
+          verdictsStore.delete(key);
+          deleted.push({ record_id: row.record_id as string });
+        }
+      }
+      return deleted;
+    }
+    return [];
+  }
+
+  // --- DELETE source_check_evidence (QUA-930 cascade) ---
+  if (q.includes("delete") && q.includes("source_check_evidence")) {
+    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
+      const recordType = String(params[0] ?? "");
+      const recordIds = new Set(params.slice(1) as string[]);
+      const deleted: Array<{ record_id: string }> = [];
+      for (const [key, row] of evidenceStore) {
+        if (
+          row.record_type === recordType &&
+          recordIds.has(row.record_id as string)
+        ) {
+          evidenceStore.delete(key);
+          deleted.push({ record_id: row.record_id as string });
+        }
+      }
+      return deleted;
+    }
+    return [];
+  }
+
+  // --- DELETE sourcing_url_suggestions (QUA-930 cascade) ---
+  if (q.includes("delete") && q.includes("sourcing_url_suggestions")) {
+    if (q.includes("record_type") && q.includes("record_id") && q.includes(" in ")) {
+      const recordType = String(params[0] ?? "");
+      const recordIds = new Set(params.slice(1) as string[]);
+      const deleted: Array<{ record_id: string }> = [];
+      for (const [key, row] of suggestionsStore) {
+        if (
+          row.record_type === recordType &&
+          recordIds.has(row.record_id as string)
+        ) {
+          suggestionsStore.delete(key);
+          deleted.push({ record_id: row.record_id as string });
+        }
+      }
+      return deleted;
+    }
     return [];
   }
 
@@ -1278,8 +1401,23 @@ describe("Facts API", () => {
       expect(body.ids[0]).toHaveProperty("factId");
       // Exactly these two keys on the id record — no accidental extra fields.
       expect(Object.keys(body.ids[0]).sort()).toEqual(["entityId", "factId"]);
-      // Top-level keys are {deleted, ids, truncated} — no accidental extras.
-      expect(Object.keys(body).sort()).toEqual(["deleted", "ids", "truncated"]);
+      // Top-level keys are {cascaded, deleted, ids, truncated} (QUA-930 added
+      // cascaded for sync-facts cli logging) — no accidental extras.
+      expect(Object.keys(body).sort()).toEqual([
+        "cascaded",
+        "deleted",
+        "ids",
+        "truncated",
+      ]);
+      // Cascaded sub-shape: {evidence, suggestions, verdicts} numbers.
+      expect(Object.keys(body.cascaded).sort()).toEqual([
+        "evidence",
+        "suggestions",
+        "verdicts",
+      ]);
+      expect(typeof body.cascaded.verdicts).toBe("number");
+      expect(typeof body.cascaded.evidence).toBe("number");
+      expect(typeof body.cascaded.suggestions).toBe("number");
     });
 
     it("caps the returned `ids` at MAX_PRUNE_RESPONSE_IDS and sets truncated=true", async () => {
@@ -1312,6 +1450,134 @@ describe("Facts API", () => {
       expect(body.ids).toHaveLength(1000);
       expect(body.truncated).toBe(true);
       expect(factsStore.size).toBe(0);
+    });
+  });
+
+  // ---- QUA-930: cascade deletion of dependent sourcing rows ----
+
+  describe("POST /api/facts/prune cascade (QUA-930)", () => {
+    it("deletes dependent verdicts/evidence/suggestions when a fact is pruned", async () => {
+      // Seed a fact and inject the dependent sourcing rows that the
+      // sourcing pipeline would have produced for it.
+      await seedFact(app, "anthropic", "f_stale", { measure: "revenue" });
+      injectVerdict("fact", "f_stale");
+      injectEvidence("fact", "f_stale", "https://example.com/source");
+      injectSuggestion("fact", "f_stale", "https://example.com/suggested");
+      // Also seed an unrelated fact + its dependents to confirm the cascade
+      // is scoped to deleted facts only.
+      await seedFact(app, "anthropic", "f_keep", { measure: "valuation" });
+      injectVerdict("fact", "f_keep");
+      injectEvidence("fact", "f_keep", "https://example.com/keep-source");
+      expect(verdictsStore.size).toBe(2);
+      expect(evidenceStore.size).toBe(2);
+      expect(suggestionsStore.size).toBe(1);
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: ["f_keep"] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(1);
+      expect(body.ids).toEqual([{ entityId: "anthropic", factId: "f_stale" }]);
+      // Cascade counts surfaced in response so the sync-facts CLI can log them.
+      expect(body.cascaded).toEqual({
+        verdicts: 1,
+        evidence: 1,
+        suggestions: 1,
+      });
+      // The kept fact's verdict / evidence are untouched.
+      expect(verdictsStore.size).toBe(1);
+      expect(Array.from(verdictsStore.values())[0].record_id).toBe("f_keep");
+      expect(evidenceStore.size).toBe(1);
+      expect(Array.from(evidenceStore.values())[0].record_id).toBe("f_keep");
+      expect(suggestionsStore.size).toBe(0);
+    });
+
+    it("returns zero cascade counts when there are no dependents", async () => {
+      await seedFact(app, "anthropic", "f_stale", { measure: "revenue" });
+      // No verdicts/evidence/suggestions injected.
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: [] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(1);
+      expect(body.cascaded).toEqual({
+        verdicts: 0,
+        evidence: 0,
+        suggestions: 0,
+      });
+    });
+
+    it("does NOT cascade across record types — only fact-typed rows are deleted", async () => {
+      // Seed a fact and a same-id dependent row of a different record type.
+      // The cascade must scope by record_type='fact' so a deleted fact_id
+      // does not collide with e.g. a personnel id that happens to share the
+      // same string. (Today PG primary keys make this unlikely, but the
+      // record_type filter is a defense-in-depth guarantee.)
+      await seedFact(app, "anthropic", "f_stale", { measure: "revenue" });
+      injectVerdict("fact", "f_stale");
+      injectVerdict("personnel", "f_stale"); // same id, different record_type
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: [] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(1);
+      expect(body.cascaded.verdicts).toBe(1);
+      // The personnel verdict survives — it's not a fact orphan.
+      expect(verdictsStore.size).toBe(1);
+      const remaining = Array.from(verdictsStore.values())[0];
+      expect(remaining.record_type).toBe("personnel");
+    });
+
+    it("returns cascaded={0,0,0} when no facts are stale", async () => {
+      await seedFact(app, "anthropic", "f_keep", { measure: "x" });
+      injectVerdict("fact", "f_keep");
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: ["f_keep"] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(0);
+      expect(body.cascaded).toEqual({
+        verdicts: 0,
+        evidence: 0,
+        suggestions: 0,
+      });
+      // Verdict still there.
+      expect(verdictsStore.size).toBe(1);
+    });
+
+    it("cascades across multiple stale facts in one call", async () => {
+      await seedFact(app, "anthropic", "f_a", { measure: "x" });
+      await seedFact(app, "anthropic", "f_b", { measure: "y" });
+      await seedFact(app, "anthropic", "f_c", { measure: "z" });
+      injectVerdict("fact", "f_a");
+      injectVerdict("fact", "f_b");
+      injectVerdict("fact", "f_c");
+      injectEvidence("fact", "f_a", "https://example.com/a");
+      injectEvidence("fact", "f_b", "https://example.com/b1");
+      injectEvidence("fact", "f_b", "https://example.com/b2");
+
+      const res = await postJson(app, "/api/facts/prune", {
+        entries: [{ entityId: "anthropic", factIds: [] }],
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(3);
+      expect(body.cascaded.verdicts).toBe(3);
+      expect(body.cascaded.evidence).toBe(3);
+      expect(verdictsStore.size).toBe(0);
+      expect(evidenceStore.size).toBe(0);
     });
   });
 });

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -10,6 +10,7 @@ import {
   sourceVerdicts,
   recordSources,
   sourcingUrlSuggestions,
+  claimRecordLinks,
 } from "../../schema.js";
 import { checkRefsExist } from "../shared/ref-check.js";
 import { resolveEntityStableId } from "../shared/entity-resolution.js";
@@ -707,6 +708,7 @@ const factsApp = new Hono()
               cascadedVerdicts: 0,
               cascadedEvidence: 0,
               cascadedSuggestions: 0,
+              cascadedClaimLinks: 0,
             };
           }
 
@@ -760,6 +762,20 @@ const factsApp = new Hono()
               ),
             )
             .returning({ recordId: sourcingUrlSuggestions.recordId });
+          // claim_record_links uses the same (record_type, record_id) pattern.
+          // It is NOT cleaned up by /api/sourcing/cleanup-orphans (which only
+          // covers verdicts/evidence/suggestions), so without this cascade
+          // deleted facts leak link rows that point at non-existent claim
+          // verifications. Same class of bug as the rest of the cascade.
+          const claimLinkRows = await tx
+            .delete(claimRecordLinks)
+            .where(
+              and(
+                eq(claimRecordLinks.recordType, "fact"),
+                inArray(claimRecordLinks.recordId, staleFactIds),
+              ),
+            )
+            .returning({ recordId: claimRecordLinks.recordId });
 
           await tx.delete(facts).where(inArray(facts.id, staleRowIds));
 
@@ -768,6 +784,7 @@ const factsApp = new Hono()
             cascadedVerdicts: verdictRows.length,
             cascadedEvidence: evidenceRows.length,
             cascadedSuggestions: suggestionRows.length,
+            cascadedClaimLinks: claimLinkRows.length,
           };
         });
 
@@ -776,6 +793,7 @@ const factsApp = new Hono()
           cascadedVerdicts,
           cascadedEvidence,
           cascadedSuggestions,
+          cascadedClaimLinks,
         } = result;
 
         if (stale.length === 0) {
@@ -783,7 +801,12 @@ const factsApp = new Hono()
             deleted: 0,
             ids: [],
             truncated: false,
-            cascaded: { verdicts: 0, evidence: 0, suggestions: 0 },
+            cascaded: {
+              verdicts: 0,
+              evidence: 0,
+              suggestions: 0,
+              claimLinks: 0,
+            },
           });
         }
 
@@ -798,12 +821,13 @@ const factsApp = new Hono()
             cascadedVerdicts,
             cascadedEvidence,
             cascadedSuggestions,
+            cascadedClaimLinks,
             sample: stale
               .slice(0, 100)
               .map((r) => `${r.entityId}/${r.factId}`),
           },
           `Pruned ${stale.length} stale facts across ${entityIds.length} entities` +
-            ` (cascaded ${cascadedVerdicts} verdicts, ${cascadedEvidence} evidence, ${cascadedSuggestions} suggestions)`,
+            ` (cascaded ${cascadedVerdicts} verdicts, ${cascadedEvidence} evidence, ${cascadedSuggestions} suggestions, ${cascadedClaimLinks} claim links)`,
         );
 
         // Cap the response payload. The server already paid the cost of
@@ -823,6 +847,7 @@ const factsApp = new Hono()
             verdicts: cascadedVerdicts,
             evidence: cascadedEvidence,
             suggestions: cascadedSuggestions,
+            claimLinks: cascadedClaimLinks,
           },
         });
       } catch (err) {

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -2,7 +2,15 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, count, asc, sql, isNotNull, lte, inArray } from "drizzle-orm";
 import { getDrizzleDb } from "../../db.js";
-import { facts, entities, resources, things } from "../../schema.js";
+import {
+  facts,
+  entities,
+  resources,
+  things,
+  sourceVerdicts,
+  recordSources,
+  sourcingUrlSuggestions,
+} from "../../schema.js";
 import { checkRefsExist } from "../shared/ref-check.js";
 import { resolveEntityStableId } from "../shared/entity-resolution.js";
 import {
@@ -668,11 +676,18 @@ const factsApp = new Hono()
       }
 
       try {
-        // Both the SELECT and the two DELETEs run inside one transaction so
-        // concurrent writers see a consistent snapshot. In practice sync-facts
-        // is the only writer in the deploy pipeline, but the transactional
-        // read is cheap and prevents TOCTOU edge cases.
-        const stale = await db.transaction(async (tx) => {
+        // Both the SELECT and the cascading DELETEs run inside one transaction
+        // so concurrent writers see a consistent snapshot. In practice
+        // sync-facts is the only writer in the deploy pipeline, but the
+        // transactional read is cheap and prevents TOCTOU edge cases.
+        //
+        // QUA-930 cascade: when a fact is deleted, also drop its dependent
+        // source_check_verdicts / source_check_evidence /
+        // sourcing_url_suggestions rows (record_type='fact', record_id=fact_id).
+        // Without this the /sourcing/coverage-matrix totals stay inflated by
+        // orphan verdicts forever (505 → 1092 between 2026-04 ticket filing
+        // and 2026-04-30).
+        const result = await db.transaction(async (tx) => {
           const currentRows = await tx
             .select({
               id: facts.id,
@@ -686,9 +701,17 @@ const factsApp = new Hono()
             (r) => !keepSet.has(`${r.entityId}\u0000${r.factId}`),
           );
 
-          if (staleRows.length === 0) return staleRows;
+          if (staleRows.length === 0) {
+            return {
+              staleRows,
+              cascadedVerdicts: 0,
+              cascadedEvidence: 0,
+              cascadedSuggestions: 0,
+            };
+          }
 
           const staleRowIds = staleRows.map((r) => r.id);
+          const staleFactIds = staleRows.map((r) => r.factId);
           const staleThingIds = staleRows.map((r) =>
             factThingKey(r.entityId, r.factId),
           );
@@ -704,13 +727,64 @@ const factsApp = new Hono()
               ),
             );
 
+          // QUA-930 cascade: drop dependent sourcing rows. record_id for
+          // fact-typed rows stores fact_id (not the serial PK) — see
+          // LIVE_RECORDS_CTE in the sourcing route. Done before the facts
+          // DELETE so any future FK from these tables → facts.fact_id would
+          // not block the delete; today there is no FK so order is
+          // semantic-only but deliberate.
+          const verdictRows = await tx
+            .delete(sourceVerdicts)
+            .where(
+              and(
+                eq(sourceVerdicts.recordType, "fact"),
+                inArray(sourceVerdicts.recordId, staleFactIds),
+              ),
+            )
+            .returning({ recordId: sourceVerdicts.recordId });
+          const evidenceRows = await tx
+            .delete(recordSources)
+            .where(
+              and(
+                eq(recordSources.recordType, "fact"),
+                inArray(recordSources.recordId, staleFactIds),
+              ),
+            )
+            .returning({ recordId: recordSources.recordId });
+          const suggestionRows = await tx
+            .delete(sourcingUrlSuggestions)
+            .where(
+              and(
+                eq(sourcingUrlSuggestions.recordType, "fact"),
+                inArray(sourcingUrlSuggestions.recordId, staleFactIds),
+              ),
+            )
+            .returning({ recordId: sourcingUrlSuggestions.recordId });
+
           await tx.delete(facts).where(inArray(facts.id, staleRowIds));
 
-          return staleRows;
+          return {
+            staleRows,
+            cascadedVerdicts: verdictRows.length,
+            cascadedEvidence: evidenceRows.length,
+            cascadedSuggestions: suggestionRows.length,
+          };
         });
 
+        const {
+          staleRows: stale,
+          cascadedVerdicts,
+          cascadedEvidence,
+          cascadedSuggestions,
+        } = result;
+
         if (stale.length === 0) {
-          return c.json({ deleted: 0, ids: [], truncated: false });
+          return c.json({
+            deleted: 0,
+            ids: [],
+            truncated: false,
+            cascaded: { verdicts: 0, evidence: 0, suggestions: 0 },
+          });
         }
 
         // Log AFTER commit (a pre-commit log lies if the transaction aborts).
@@ -721,11 +795,15 @@ const factsApp = new Hono()
           {
             count: stale.length,
             entities: entityIds.length,
+            cascadedVerdicts,
+            cascadedEvidence,
+            cascadedSuggestions,
             sample: stale
               .slice(0, 100)
               .map((r) => `${r.entityId}/${r.factId}`),
           },
-          `Pruned ${stale.length} stale facts across ${entityIds.length} entities`,
+          `Pruned ${stale.length} stale facts across ${entityIds.length} entities` +
+            ` (cascaded ${cascadedVerdicts} verdicts, ${cascadedEvidence} evidence, ${cascadedSuggestions} suggestions)`,
         );
 
         // Cap the response payload. The server already paid the cost of
@@ -737,7 +815,16 @@ const factsApp = new Hono()
           .slice(0, MAX_PRUNE_RESPONSE_IDS)
           .map((r) => ({ entityId: r.entityId, factId: r.factId }));
 
-        return c.json({ deleted: stale.length, ids, truncated });
+        return c.json({
+          deleted: stale.length,
+          ids,
+          truncated,
+          cascaded: {
+            verdicts: cascadedVerdicts,
+            evidence: cascadedEvidence,
+            suggestions: cascadedSuggestions,
+          },
+        });
       } catch (err) {
         return dbError(c, "facts prune", err, { entityCount: entityIds.length });
       }

--- a/crux/commands/factbase-verdicts.test.ts
+++ b/crux/commands/factbase-verdicts.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for `crux fb verdicts prune-orphans` (QUA-930).
+ *
+ * The command is a thin wrapper around `cleanupOrphanVerdicts` with
+ * `recordType: 'fact'` baked in. We mock the wiki-server client and
+ * assert call shape, exit codes, and output formatting.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the sourcing-client BEFORE importing the command (vi.mock is hoisted).
+vi.mock("../lib/wiki-server/sourcing-client.ts", () => ({
+  cleanupOrphanVerdicts: vi.fn(),
+}));
+
+import { commands } from "./factbase-verdicts.ts";
+import { cleanupOrphanVerdicts } from "../lib/wiki-server/sourcing-client.ts";
+
+const mockCleanup = vi.mocked(cleanupOrphanVerdicts);
+
+beforeEach(() => {
+  mockCleanup.mockReset();
+});
+
+describe("crux fb verdicts prune-orphans", () => {
+  it("defaults to dryRun=true and recordType=fact", async () => {
+    mockCleanup.mockResolvedValue({
+      ok: true,
+      data: {
+        dryRun: true,
+        deleted: { verdicts: 0, evidence: 0, suggestions: 0 },
+        byType: {},
+      },
+    });
+
+    const result = await commands.default(["prune-orphans"], {});
+    expect(result.exitCode).toBe(0);
+
+    expect(mockCleanup).toHaveBeenCalledWith({
+      dryRun: true,
+      recordType: "fact",
+    });
+  });
+
+  it("--apply switches to dryRun=false", async () => {
+    mockCleanup.mockResolvedValue({
+      ok: true,
+      data: {
+        dryRun: false,
+        deleted: { verdicts: 5, evidence: 7, suggestions: 0 },
+        byType: { fact: { verdicts: 5, evidence: 7, suggestions: 0 } },
+      },
+    });
+
+    await commands.default(["prune-orphans"], { apply: true });
+
+    expect(mockCleanup).toHaveBeenCalledWith({
+      dryRun: false,
+      recordType: "fact",
+    });
+  });
+
+  it("rejects --apply and --dry-run together with exit code 2", async () => {
+    const result = await commands.default(["prune-orphans"], {
+      apply: true,
+      "dry-run": true,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.output).toMatch(/mutually exclusive/);
+    expect(mockCleanup).not.toHaveBeenCalled();
+  });
+
+  it("--ci returns the raw JSON body", async () => {
+    const data = {
+      dryRun: true,
+      deleted: { verdicts: 1092, evidence: 1276, suggestions: 0 },
+      byType: { fact: { verdicts: 1092, evidence: 1276, suggestions: 0 } },
+    };
+    mockCleanup.mockResolvedValue({ ok: true, data });
+
+    const result = await commands.default(["prune-orphans"], { ci: true });
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.output)).toEqual(data);
+  });
+
+  it("formats the human-readable output with fact counts only", async () => {
+    mockCleanup.mockResolvedValue({
+      ok: true,
+      data: {
+        dryRun: true,
+        deleted: { verdicts: 100, evidence: 200, suggestions: 3 },
+        byType: { fact: { verdicts: 100, evidence: 200, suggestions: 3 } },
+      },
+    });
+
+    const result = await commands.default(["prune-orphans"], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/Verdicts:\s+100/);
+    expect(result.output).toMatch(/Evidence:\s+200/);
+    expect(result.output).toMatch(/Suggestions:\s+3/);
+    expect(result.output).toMatch(/dry run/i);
+  });
+
+  it("reports nothing-to-do when result is empty", async () => {
+    mockCleanup.mockResolvedValue({
+      ok: true,
+      data: {
+        dryRun: true,
+        deleted: { verdicts: 0, evidence: 0, suggestions: 0 },
+        byType: {},
+      },
+    });
+
+    const result = await commands.default(["prune-orphans"], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/No orphan fact verdicts found/);
+  });
+
+  it("warns when the server returns non-fact rows in byType (sanity guard)", async () => {
+    // We asked for --type=fact but server reported personnel rows too. The
+    // byType breakdown is hand-aggregated; this guard makes a future server
+    // bug visible.
+    mockCleanup.mockResolvedValue({
+      ok: true,
+      data: {
+        dryRun: false,
+        deleted: { verdicts: 5, evidence: 0, suggestions: 0 },
+        byType: { fact: { verdicts: 3, evidence: 0, suggestions: 0 } },
+        // Note: deleted.verdicts=5 but byType.fact.verdicts=3 → 2 are unattributed
+      },
+    });
+
+    const result = await commands.default(["prune-orphans"], { apply: true });
+    expect(result.output).toMatch(/Warning: server returned non-fact rows/);
+  });
+
+  it("returns exit 1 with the upstream error message on a failed call", async () => {
+    mockCleanup.mockResolvedValue({
+      ok: false,
+      error: "unavailable",
+      message: "ECONNREFUSED",
+    });
+
+    const result = await commands.default(["prune-orphans"], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/ECONNREFUSED/);
+  });
+
+  it("prints help when called with no subcommand", async () => {
+    const result = await commands.default([], {});
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toMatch(/prune-orphans/);
+    expect(mockCleanup).not.toHaveBeenCalled();
+  });
+
+  it("returns exit 1 for unknown subcommands", async () => {
+    const result = await commands.default(["bogus"], {});
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toMatch(/Unknown verdicts subcommand/);
+    expect(mockCleanup).not.toHaveBeenCalled();
+  });
+});

--- a/crux/commands/factbase-verdicts.ts
+++ b/crux/commands/factbase-verdicts.ts
@@ -1,0 +1,185 @@
+/**
+ * FactBase Verdicts — admin commands for source_check_verdicts (QUA-930).
+ *
+ * Handles the FactBase-specific surface of the universal sourcing-cleanup
+ * tool. The underlying endpoint (`POST /api/sourcing/cleanup-orphans`) was
+ * built for QUA-149 to clean up orphan verdicts across every record type;
+ * this wrapper hard-codes `--type=fact` so the FactBase ownership boundary
+ * is discoverable in the `crux fb` namespace and operators can sweep stale
+ * fact verdicts without learning the universal cleanup interface.
+ *
+ * The structural fix that prevents new orphans is in
+ * apps/wiki-server/src/routes/factbase/facts.ts (`/prune` cascade). This
+ * command exists for one-shot cleanup of legacy orphans and as a recovery
+ * tool if the cascade ever regresses.
+ *
+ * Usage:
+ *   crux fb verdicts prune-orphans              Dry-run (default)
+ *   crux fb verdicts prune-orphans --apply      Actually delete
+ *   crux fb verdicts prune-orphans --ci         JSON output
+ */
+
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import {
+  cleanupOrphanVerdicts,
+  type CleanupOrphansResult,
+} from '../lib/wiki-server/sourcing-client.ts';
+
+interface VerdictsOptions extends BaseOptions {
+  apply?: boolean;
+  'dry-run'?: boolean;
+  ci?: boolean;
+}
+
+const FACT_RECORD_TYPE = 'fact';
+
+function formatPruneOrphans(result: CleanupOrphansResult): string {
+  const lines: string[] = [];
+  const { dryRun, deleted, byType } = result;
+  lines.push(
+    dryRun
+      ? '\x1b[1mFactBase Orphan Verdict Prune (dry-run)\x1b[0m'
+      : '\x1b[1;32mFactBase Orphan Verdict Prune — applied\x1b[0m',
+  );
+  lines.push('');
+
+  const factCounts =
+    byType[FACT_RECORD_TYPE] ?? { verdicts: 0, evidence: 0, suggestions: 0 };
+  const total =
+    factCounts.verdicts + factCounts.evidence + factCounts.suggestions;
+
+  if (total === 0) {
+    lines.push('No orphan fact verdicts found. Nothing to do.');
+    return lines.join('\n');
+  }
+
+  lines.push(`  Verdicts:    ${factCounts.verdicts.toLocaleString()}`);
+  lines.push(`  Evidence:    ${factCounts.evidence.toLocaleString()}`);
+  lines.push(`  Suggestions: ${factCounts.suggestions.toLocaleString()}`);
+  lines.push('');
+
+  // Sanity check: deleted.* aggregates across all types, but we asked for
+  // only `fact`. If those drift, the server returned data we didn't expect
+  // and the user should know.
+  if (
+    deleted.verdicts !== factCounts.verdicts ||
+    deleted.evidence !== factCounts.evidence ||
+    deleted.suggestions !== factCounts.suggestions
+  ) {
+    lines.push(
+      '\x1b[33mWarning: server returned non-fact rows in the byType breakdown ' +
+        '(scoped request was --type=fact). Investigate before re-running.\x1b[0m',
+    );
+    lines.push('');
+  }
+
+  if (dryRun) {
+    lines.push(
+      'This was a dry run. Re-run with \x1b[1m--apply\x1b[0m to delete these rows.',
+    );
+  } else {
+    lines.push('\x1b[32mDeletion complete.\x1b[0m');
+  }
+  return lines.join('\n');
+}
+
+async function pruneOrphansCommand(
+  _args: string[],
+  options: VerdictsOptions,
+): Promise<CommandResult> {
+  // QUA-930: --dry-run is documented in the ticket; accept both --dry-run
+  // and the cleanup-orphans --apply convention so users coming from either
+  // command get a working invocation.
+  const explicitApply = Boolean(options.apply);
+  const explicitDryRun = Boolean(options['dry-run']);
+  if (explicitApply && explicitDryRun) {
+    return {
+      exitCode: 2,
+      output: 'Error: --apply and --dry-run are mutually exclusive.',
+    };
+  }
+  const dryRun = explicitDryRun || !explicitApply;
+
+  const response = await cleanupOrphanVerdicts({
+    dryRun,
+    recordType: FACT_RECORD_TYPE,
+  });
+
+  if (!response.ok) {
+    return {
+      exitCode: 1,
+      output: `Failed to prune orphan fact verdicts: ${response.message}`,
+    };
+  }
+
+  const result = response.data;
+
+  if (options.ci) {
+    return {
+      exitCode: 0,
+      output: JSON.stringify(result, null, 2),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    output: formatPruneOrphans(result),
+  };
+}
+
+// ---- Dispatcher (matches the `crux fb sourcing` pattern) ----
+
+async function verdictsCommand(
+  args: string[],
+  options: VerdictsOptions,
+): Promise<CommandResult> {
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  switch (sub) {
+    case 'prune-orphans':
+      return pruneOrphansCommand(rest, options);
+    case undefined:
+    case '--help':
+    case 'help':
+      return {
+        exitCode: 0,
+        output: getHelp(),
+      };
+    default:
+      return {
+        exitCode: 1,
+        output:
+          `Unknown verdicts subcommand: ${sub}\n\n` + getHelp(),
+      };
+  }
+}
+
+export function getHelp(): string {
+  return `
+crux fb verdicts — admin tools for source_check_verdicts (FactBase scope)
+
+Subcommands:
+  prune-orphans              Delete fact verdicts whose record_id no longer
+                             matches a row in the facts table.
+
+Options:
+  --dry-run                  Default. Reports what would be deleted.
+  --apply                    Actually delete (required to mutate).
+  --ci                       JSON output for scripts.
+
+Examples:
+  crux fb verdicts prune-orphans                  Dry-run, fact-typed only
+  crux fb verdicts prune-orphans --apply          Delete orphans
+  crux fb verdicts prune-orphans --apply --ci     JSON output
+
+See also:
+  crux sourcing-cleanup-orphans                   Universal version (all types)
+`.trim();
+}
+
+// ---- Exports ----
+
+export const commands = {
+  default: verdictsCommand,
+};

--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -20,6 +20,7 @@ import { commands as kbMigrateCommands } from './factbase-migrate.ts';
 import { sourcingCommand } from './factbase-sourcing.ts';
 import { commands as sourceBackfillCommands } from './factbase-source-backfill.ts';
 import { commands as migrateEntitiesCommands } from './factbase-migrate-entities.ts';
+import { commands as verdictsCommands } from './factbase-verdicts.ts';
 import { lookupResourceByUrl, upsertResource } from '../lib/wiki-server/resources.ts';
 import { hashId, guessResourceType } from '../resource-utils.ts';
 import { loadGraphFull, loadGraph, resolveEntity, KB_DATA_DIR } from '../lib/factbase-loader.ts';
@@ -1116,6 +1117,8 @@ export const commands = {
   // Consolidated from factbase-migrate-entities domain
   'migrate-entities': migrateEntitiesCommands.run,
   'migrate-entities-status': migrateEntitiesCommands.status,
+  // QUA-930: FactBase-scoped wrapper around POST /api/sourcing/cleanup-orphans
+  'verdicts': verdictsCommands.default,
 };
 
 export function getHelp(): string {
@@ -1142,6 +1145,7 @@ Commands:
   source-backfill       Suggest source URLs for facts that have none (QUA-545) [--apply]
   migrate-entities [--dry-run]  Transform YAML files from thing: to entity: format
   migrate-entities-status       Show migration status (files in each format)
+  verdicts prune-orphans        Delete orphan fact verdicts (QUA-930) [--apply]
 
 Options:
   --type=X              Filter list/search/coverage by entity type (e.g. organization, person)

--- a/crux/wiki-server/sync-facts.test.ts
+++ b/crux/wiki-server/sync-facts.test.ts
@@ -584,9 +584,9 @@ describe("pruneFacts", () => {
   it("aggregates cascade counts across batches (QUA-930)", async () => {
     let call = 0;
     const responses = [
-      { deleted: 1, ids: [{ entityId: "a", factId: "f_1" }], cascaded: { verdicts: 2, evidence: 5, suggestions: 1 } },
-      { deleted: 1, ids: [{ entityId: "b", factId: "f_1" }], cascaded: { verdicts: 0, evidence: 1, suggestions: 0 } },
-      { deleted: 1, ids: [{ entityId: "c", factId: "f_1" }], cascaded: { verdicts: 3, evidence: 0, suggestions: 4 } },
+      { deleted: 1, ids: [{ entityId: "a", factId: "f_1" }], cascaded: { verdicts: 2, evidence: 5, suggestions: 1, claimLinks: 0 } },
+      { deleted: 1, ids: [{ entityId: "b", factId: "f_1" }], cascaded: { verdicts: 0, evidence: 1, suggestions: 0, claimLinks: 2 } },
+      { deleted: 1, ids: [{ entityId: "c", factId: "f_1" }], cascaded: { verdicts: 3, evidence: 0, suggestions: 4, claimLinks: 1 } },
     ];
     vi.spyOn(globalThis, "fetch").mockImplementation(
       async () => new Response(JSON.stringify(responses[call++]), { status: 200 }),
@@ -605,6 +605,7 @@ describe("pruneFacts", () => {
     expect(result.cascadedVerdicts).toBe(5); // 2 + 0 + 3
     expect(result.cascadedEvidence).toBe(6); // 5 + 1 + 0
     expect(result.cascadedSuggestions).toBe(5); // 1 + 0 + 4
+    expect(result.cascadedClaimLinks).toBe(3); // 0 + 2 + 1
   });
 
   it("defaults cascade counts to zero when server omits them (older server compat)", async () => {
@@ -627,7 +628,33 @@ describe("pruneFacts", () => {
     expect(result.cascadedVerdicts).toBe(0);
     expect(result.cascadedEvidence).toBe(0);
     expect(result.cascadedSuggestions).toBe(0);
+    expect(result.cascadedClaimLinks).toBe(0);
     expect(result.errors).toBe(0);
+  });
+
+  it("handles partial cascade objects without producing NaN (mid-deploy server compat)", async () => {
+    // QUA-930: a server mid-deploy could emit a partial cascade object
+    // missing one or two keys. Each missing key must default to 0 — without
+    // the per-field guard, `total += undefined` would produce NaN.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          deleted: 1,
+          ids: [{ entityId: "anthropic", factId: "f_old" }],
+          cascaded: { verdicts: 5 }, // missing evidence/suggestions/claimLinks
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const items = [makeSyncFact("anthropic", "f_keep")];
+    const result = await pruneFacts("http://localhost:3000", items);
+
+    expect(result.cascadedVerdicts).toBe(5);
+    expect(result.cascadedEvidence).toBe(0); // not NaN
+    expect(result.cascadedSuggestions).toBe(0);
+    expect(result.cascadedClaimLinks).toBe(0);
+    expect(Number.isNaN(result.cascadedEvidence)).toBe(false);
   });
 
   it("returns zero cascade counts when entries is empty", async () => {
@@ -635,5 +662,6 @@ describe("pruneFacts", () => {
     expect(result.cascadedVerdicts).toBe(0);
     expect(result.cascadedEvidence).toBe(0);
     expect(result.cascadedSuggestions).toBe(0);
+    expect(result.cascadedClaimLinks).toBe(0);
   });
 });

--- a/crux/wiki-server/sync-facts.test.ts
+++ b/crux/wiki-server/sync-facts.test.ts
@@ -578,4 +578,62 @@ describe("pruneFacts", () => {
     );
     expect(sizes.sort()).toEqual([1, 2, 2]);
   });
+
+  // ---- QUA-930: cascade counts surface in PruneFactsOutcome ----
+
+  it("aggregates cascade counts across batches (QUA-930)", async () => {
+    let call = 0;
+    const responses = [
+      { deleted: 1, ids: [{ entityId: "a", factId: "f_1" }], cascaded: { verdicts: 2, evidence: 5, suggestions: 1 } },
+      { deleted: 1, ids: [{ entityId: "b", factId: "f_1" }], cascaded: { verdicts: 0, evidence: 1, suggestions: 0 } },
+      { deleted: 1, ids: [{ entityId: "c", factId: "f_1" }], cascaded: { verdicts: 3, evidence: 0, suggestions: 4 } },
+    ];
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(JSON.stringify(responses[call++]), { status: 200 }),
+    );
+
+    const items = [
+      makeSyncFact("a", "f_1"),
+      makeSyncFact("b", "f_1"),
+      makeSyncFact("c", "f_1"),
+    ];
+    const result = await pruneFacts("http://localhost:3000", items, [], {
+      batchSize: 1,
+    });
+
+    expect(result.deleted).toBe(3);
+    expect(result.cascadedVerdicts).toBe(5); // 2 + 0 + 3
+    expect(result.cascadedEvidence).toBe(6); // 5 + 1 + 0
+    expect(result.cascadedSuggestions).toBe(5); // 1 + 0 + 4
+  });
+
+  it("defaults cascade counts to zero when server omits them (older server compat)", async () => {
+    // Older server pre-QUA-930 returns only {deleted, ids, truncated}. The
+    // client must not crash and should report zero cascade counts.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          deleted: 1,
+          ids: [{ entityId: "anthropic", factId: "f_old" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const items = [makeSyncFact("anthropic", "f_keep")];
+    const result = await pruneFacts("http://localhost:3000", items);
+
+    expect(result.deleted).toBe(1);
+    expect(result.cascadedVerdicts).toBe(0);
+    expect(result.cascadedEvidence).toBe(0);
+    expect(result.cascadedSuggestions).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("returns zero cascade counts when entries is empty", async () => {
+    const result = await pruneFacts("http://localhost:3000", [], []);
+    expect(result.cascadedVerdicts).toBe(0);
+    expect(result.cascadedEvidence).toBe(0);
+    expect(result.cascadedSuggestions).toBe(0);
+  });
 });

--- a/crux/wiki-server/sync-facts.ts
+++ b/crux/wiki-server/sync-facts.ts
@@ -261,6 +261,13 @@ export interface PruneFactsOutcome {
   ids: Array<{ entityId: string; factId: string }>;
   /** Number of batches that failed (HTTP error or thrown exception). */
   errors: number;
+  /**
+   * QUA-930 cascade totals — sourcing rows deleted alongside the facts.
+   * Aggregated across all batches.
+   */
+  cascadedVerdicts: number;
+  cascadedEvidence: number;
+  cascadedSuggestions: number;
 }
 
 /**
@@ -287,11 +294,21 @@ export async function pruneFacts(
   const entries = groupFactsByEntity(items, entityIdsWithNoFacts);
 
   if (entries.length === 0) {
-    return { deleted: 0, ids: [], errors: 0 };
+    return {
+      deleted: 0,
+      ids: [],
+      errors: 0,
+      cascadedVerdicts: 0,
+      cascadedEvidence: 0,
+      cascadedSuggestions: 0,
+    };
   }
 
   let totalDeleted = 0;
   let totalErrors = 0;
+  let totalCascadedVerdicts = 0;
+  let totalCascadedEvidence = 0;
+  let totalCascadedSuggestions = 0;
   const allDeletedIds: Array<{ entityId: string; factId: string }> = [];
 
   for (let i = 0; i < entries.length; i += batchSize) {
@@ -320,6 +337,13 @@ export async function pruneFacts(
       // client and server cannot drift silently — see PruneFactsResult in
       // crux/lib/wiki-server/facts.ts.
       const result = (await res.json()) as PruneFactsResult;
+      // QUA-930: cascade is always present from a current server, but an older
+      // server in front would emit { deleted, ids, truncated } only. Default
+      // to zero counts so a server lag does not crash the CLI.
+      const cascaded =
+        ("cascaded" in result && result.cascaded)
+          ? result.cascaded
+          : { verdicts: 0, evidence: 0, suggestions: 0 };
       if (result.deleted > 0) {
         const sample = result.ids
           .slice(0, 5)
@@ -327,12 +351,19 @@ export async function pruneFacts(
           .join(", ");
         const more = result.deleted > 5 ? ` ...(+${result.deleted - 5} more)` : "";
         const truncatedNote = result.truncated ? " [ids truncated]" : "";
+        const cascadedNote =
+          cascaded.verdicts + cascaded.evidence + cascaded.suggestions > 0
+            ? ` [cascaded: ${cascaded.verdicts}v/${cascaded.evidence}e/${cascaded.suggestions}s]`
+            : "";
         console.log(
-          `  Prune batch ${batchNum}: removed ${result.deleted} stale facts: ${sample}${more}${truncatedNote}`,
+          `  Prune batch ${batchNum}: removed ${result.deleted} stale facts: ${sample}${more}${truncatedNote}${cascadedNote}`,
         );
         totalDeleted += result.deleted;
         allDeletedIds.push(...result.ids);
       }
+      totalCascadedVerdicts += cascaded.verdicts;
+      totalCascadedEvidence += cascaded.evidence;
+      totalCascadedSuggestions += cascaded.suggestions;
     } catch (err) {
       console.error(
         `  Prune batch ${batchNum}: failed — ${err instanceof Error ? err.message : err}`,
@@ -341,7 +372,14 @@ export async function pruneFacts(
     }
   }
 
-  return { deleted: totalDeleted, ids: allDeletedIds, errors: totalErrors };
+  return {
+    deleted: totalDeleted,
+    ids: allDeletedIds,
+    errors: totalErrors,
+    cascadedVerdicts: totalCascadedVerdicts,
+    cascadedEvidence: totalCascadedEvidence,
+    cascadedSuggestions: totalCascadedSuggestions,
+  };
 }
 
 // --- CLI ---
@@ -434,6 +472,21 @@ async function main() {
     const pruneResult = await pruneFacts(serverUrl, facts, entityIdsWithNoFacts);
     if (pruneResult.deleted > 0) {
       console.log(`  Pruned: ${pruneResult.deleted} stale facts`);
+      const cascadedTotal =
+        pruneResult.cascadedVerdicts +
+        pruneResult.cascadedEvidence +
+        pruneResult.cascadedSuggestions;
+      if (cascadedTotal > 0) {
+        // QUA-930: surface the cascade so operators see the dependent
+        // sourcing rows that disappeared with the facts. Without this, a
+        // routine sync silently drops verdicts and the operator notices
+        // only via dashboard delta.
+        console.log(
+          `  Cascade: ${pruneResult.cascadedVerdicts} verdicts, ` +
+            `${pruneResult.cascadedEvidence} evidence, ` +
+            `${pruneResult.cascadedSuggestions} suggestions`,
+        );
+      }
     } else {
       console.log("  No stale facts to prune");
     }

--- a/crux/wiki-server/sync-facts.ts
+++ b/crux/wiki-server/sync-facts.ts
@@ -262,12 +262,13 @@ export interface PruneFactsOutcome {
   /** Number of batches that failed (HTTP error or thrown exception). */
   errors: number;
   /**
-   * QUA-930 cascade totals — sourcing rows deleted alongside the facts.
+   * QUA-930 cascade totals — dependent rows deleted alongside the facts.
    * Aggregated across all batches.
    */
   cascadedVerdicts: number;
   cascadedEvidence: number;
   cascadedSuggestions: number;
+  cascadedClaimLinks: number;
 }
 
 /**
@@ -301,6 +302,7 @@ export async function pruneFacts(
       cascadedVerdicts: 0,
       cascadedEvidence: 0,
       cascadedSuggestions: 0,
+      cascadedClaimLinks: 0,
     };
   }
 
@@ -309,6 +311,7 @@ export async function pruneFacts(
   let totalCascadedVerdicts = 0;
   let totalCascadedEvidence = 0;
   let totalCascadedSuggestions = 0;
+  let totalCascadedClaimLinks = 0;
   const allDeletedIds: Array<{ entityId: string; factId: string }> = [];
 
   for (let i = 0; i < entries.length; i += batchSize) {
@@ -337,13 +340,21 @@ export async function pruneFacts(
       // client and server cannot drift silently — see PruneFactsResult in
       // crux/lib/wiki-server/facts.ts.
       const result = (await res.json()) as PruneFactsResult;
-      // QUA-930: cascade is always present from a current server, but an older
-      // server in front would emit { deleted, ids, truncated } only. Default
-      // to zero counts so a server lag does not crash the CLI.
-      const cascaded =
-        ("cascaded" in result && result.cascaded)
-          ? result.cascaded
-          : { verdicts: 0, evidence: 0, suggestions: 0 };
+      // QUA-930: cascade is always present from a current server, but an
+      // older server in front would emit { deleted, ids, truncated } only,
+      // and a still-deploying mid-version could emit a partial cascade
+      // object missing some keys. Read each field with `?? 0` so a partial
+      // object never produces NaN aggregation downstream.
+      const rawCascaded =
+        ("cascaded" in result && result.cascaded) || {};
+      const cascaded = {
+        verdicts: (rawCascaded as { verdicts?: number }).verdicts ?? 0,
+        evidence: (rawCascaded as { evidence?: number }).evidence ?? 0,
+        suggestions:
+          (rawCascaded as { suggestions?: number }).suggestions ?? 0,
+        claimLinks:
+          (rawCascaded as { claimLinks?: number }).claimLinks ?? 0,
+      };
       if (result.deleted > 0) {
         const sample = result.ids
           .slice(0, 5)
@@ -351,9 +362,14 @@ export async function pruneFacts(
           .join(", ");
         const more = result.deleted > 5 ? ` ...(+${result.deleted - 5} more)` : "";
         const truncatedNote = result.truncated ? " [ids truncated]" : "";
+        const cascadedTotal =
+          cascaded.verdicts +
+          cascaded.evidence +
+          cascaded.suggestions +
+          cascaded.claimLinks;
         const cascadedNote =
-          cascaded.verdicts + cascaded.evidence + cascaded.suggestions > 0
-            ? ` [cascaded: ${cascaded.verdicts}v/${cascaded.evidence}e/${cascaded.suggestions}s]`
+          cascadedTotal > 0
+            ? ` [cascaded: ${cascaded.verdicts}v/${cascaded.evidence}e/${cascaded.suggestions}s/${cascaded.claimLinks}cl]`
             : "";
         console.log(
           `  Prune batch ${batchNum}: removed ${result.deleted} stale facts: ${sample}${more}${truncatedNote}${cascadedNote}`,
@@ -364,6 +380,7 @@ export async function pruneFacts(
       totalCascadedVerdicts += cascaded.verdicts;
       totalCascadedEvidence += cascaded.evidence;
       totalCascadedSuggestions += cascaded.suggestions;
+      totalCascadedClaimLinks += cascaded.claimLinks;
     } catch (err) {
       console.error(
         `  Prune batch ${batchNum}: failed — ${err instanceof Error ? err.message : err}`,
@@ -379,6 +396,7 @@ export async function pruneFacts(
     cascadedVerdicts: totalCascadedVerdicts,
     cascadedEvidence: totalCascadedEvidence,
     cascadedSuggestions: totalCascadedSuggestions,
+    cascadedClaimLinks: totalCascadedClaimLinks,
   };
 }
 
@@ -475,16 +493,18 @@ async function main() {
       const cascadedTotal =
         pruneResult.cascadedVerdicts +
         pruneResult.cascadedEvidence +
-        pruneResult.cascadedSuggestions;
+        pruneResult.cascadedSuggestions +
+        pruneResult.cascadedClaimLinks;
       if (cascadedTotal > 0) {
         // QUA-930: surface the cascade so operators see the dependent
-        // sourcing rows that disappeared with the facts. Without this, a
-        // routine sync silently drops verdicts and the operator notices
-        // only via dashboard delta.
+        // rows that disappeared with the facts. Without this, a routine
+        // sync silently drops verdicts and the operator notices only via
+        // dashboard delta.
         console.log(
           `  Cascade: ${pruneResult.cascadedVerdicts} verdicts, ` +
             `${pruneResult.cascadedEvidence} evidence, ` +
-            `${pruneResult.cascadedSuggestions} suggestions`,
+            `${pruneResult.cascadedSuggestions} suggestions, ` +
+            `${pruneResult.cascadedClaimLinks} claim links`,
         );
       }
     } else {


### PR DESCRIPTION
## Summary

Adds the missing tear-down step to the FactBase sync pipeline. When a fact is removed from YAML and pruned out of PG via `/api/facts/prune`, dependent rows in `source_check_verdicts`, `source_check_evidence`, `sourcing_url_suggestions`, and `claim_record_links` (the `record_type='fact'` rows whose `record_id=fact_id`) are now deleted in the same transaction.

Without this, every YAML fact deletion silently leaks orphan rows and the `/sourcing/coverage-matrix` totals stay inflated forever — 505 orphan verdicts when QUA-930 was filed → **1092 orphan verdicts + 1276 orphan evidence rows** by 2026-04-30.

## Pieces

**Piece 2 (structural cascade)** — the actual fix:

- `apps/wiki-server/src/routes/factbase/facts.ts` — `/api/facts/prune` now deletes from `sourceVerdicts`, `recordSources`, `sourcingUrlSuggestions`, and `claimRecordLinks` inside the same transaction, gathered via `RETURNING` so cascade counts are exact (no SELECT/DELETE drift). Counts surface in the response as `cascaded: { verdicts, evidence, suggestions, claimLinks }`.
- `crux/wiki-server/sync-facts.ts` — the sync CLI logs cascade counts per batch and in the final summary, with per-field defaults (`?? 0`) so a partial cascade object from a mid-deploy server doesn't produce NaN.

**Piece 1 (tactical CLI)** — `crux fb verdicts prune-orphans [--apply]`:

- New file `crux/commands/factbase-verdicts.ts`. Thin FactBase-namespaced wrapper around the existing `cleanupOrphanVerdicts` (`POST /api/sourcing/cleanup-orphans`) with `recordType: 'fact'` baked in.
- Default is dry-run; `--apply` to delete; `--ci` for JSON.
- The same universal command — `crux sourcing-cleanup-orphans --type=fact --apply` — already existed for QUA-149. The wrapper exists because the ticket explicitly asked for a `crux fb verdicts` entry-point, and the FactBase namespace is the natural place to discover it.

**Note on `claim_record_links`**: the hostile reviewer flagged that `claim_record_links` follows the same `(record_type, record_id)` pattern but is NOT cleaned up by `/api/sourcing/cleanup-orphans`. Same class of bug — included in the cascade. The legacy cleanup tool (`/cleanup-orphans`) does NOT clean up `claim_record_links`; if there are existing fact-typed orphan claim-links on prod, they need a separate sweep. (Out of scope for this PR; can be added in a follow-up if needed.)

## Acceptance criteria status

- [x] `crux fb verdicts prune-orphans --dry-run` reports orphan rows accurately — confirmed against prod: **1092 verdicts, 1276 evidence, 0 suggestions**.
- [ ] `crux fb verdicts prune-orphans --apply` removes them — **deferred to post-deploy** (see Deploy Checklist).
- [x] FactBase sync flow now cascades verdict deletion when facts are removed from YAML — implemented in `/api/facts/prune`.
- [x] Test: delete a fact from YAML → run sync → verdict row gone — covered by the "POST /api/facts/prune cascade (QUA-930)" describe block (6 tests).
- [ ] Post-cleanup: `/api/sourcing/coverage-matrix` totals match YAML fact count — **deferred to post-deploy**.

## Tests

- 6 new cascade tests in `apps/wiki-server/src/__tests__/facts.test.ts` covering the happy path (verdicts/evidence/suggestions/claim-links), no-dependents, cross-record-type isolation for verdicts, cross-record-type isolation for claim-links, no-stale-facts, and multi-fact batch.
- 4 new tests in `crux/wiki-server/sync-facts.test.ts` for cascade aggregation across batches, older-server compat, partial cascade object (NaN guard), and empty-entries.
- 10 new tests in `crux/commands/factbase-verdicts.test.ts` covering exit codes, output formats, mutual exclusivity of `--apply` / `--dry-run`, sanity guard for non-fact rows.
- Test mocks: extracted the duplicated DELETE-by-record-type dispatcher into a single loop over the four cascade tables.
- Total: 91 tests pass across the three affected files.

## Deploy Checklist

- [ ] After merge & deploy, run `WIKI_SERVER_ENV=prod pnpm crux fb verdicts prune-orphans --apply` to clean up the existing orphan verdicts + evidence rows (~1092 + 1276 at PR time, may have grown).
- [ ] Confirm `/api/sourcing/coverage-matrix` totals now match YAML fact counts (no `total > YAML count`).

The cascade is the structural fix; the post-deploy command is the one-shot legacy cleanup. Once cleared, the cascade prevents the orphan set from growing again.

## Test plan

- [x] All 67 gate checks pass locally (`pnpm crux w validate gate --fix`)
- [x] Full vitest sweep across the 3 affected files passes (91 tests)
- [x] TypeScript typecheck clean for `apps/wiki-server`, `apps/web`, `crux`
- [x] `/agent-review-pr` ran and findings addressed (12 LOW; 2 substantive ones — `claim_record_links` cascade + NaN guard — fixed in the second commit)
- [ ] Review CodeRabbit / human findings before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-930
