### PR TITLE
fix(divisions): correct "120 of 101 records sourcinged" header

### DIFF
--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -118,6 +118,7 @@ const SIMPLE_PAGES = [
   "/frontier-safety-frameworks/methodology",  // QUA-709 methodology
   "/scorecards",  // QUA-688 scorecards directory
   "/scorecards/fli_index",  // QUA-837 per-scorecard detail route
+  "/divisions",  // QUA-897 sourcing-summary header
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -208,6 +209,31 @@ test.describe("Render audit — sidebar-only pages", () => {
       checkAntiPatterns(await getMainText(page), url);
     });
   }
+});
+
+test.describe("Render audit — QUA-897 sourcing summary banner", () => {
+  // Regression check: /divisions header used to render
+  //   "120 of 101 records sourcinged"
+  // Two defects: a non-word ("sourcinged" — botched mass rename of
+  // "source-checked") and an impossible ratio (numerator > denominator,
+  // because the page deduplicates raw division rows but the banner counted
+  // every verdict).
+  test("/divisions banner has no 'sourcinged' typo and checked <= total", async ({ page }) => {
+    await loadPage(page, "/divisions");
+    const text = await getMainText(page);
+
+    expect(text, "the non-word 'sourcinged' must not appear anywhere on /divisions")
+      .not.toContain("sourcinged");
+
+    // Find the banner ratio "<checked> of <total> records sourced".
+    const m = text.match(/(\d+)\s+of\s+(\d+)\s+records\s+sourced/);
+    expect(m, "banner 'X of Y records sourced' must render on /divisions").not.toBeNull();
+    if (m) {
+      const checked = Number(m[1]);
+      const total = Number(m[2]);
+      expect(checked).toBeLessThanOrEqual(total);
+    }
+  });
 });
 
 test.describe("Render audit — critical data tables", () => {

--- a/apps/web/e2e/render-audit.spec.ts
+++ b/apps/web/e2e/render-audit.spec.ts
@@ -225,13 +225,17 @@ test.describe("Render audit — QUA-897 sourcing summary banner", () => {
     expect(text, "the non-word 'sourcinged' must not appear anywhere on /divisions")
       .not.toContain("sourcinged");
 
-    // Find the banner ratio "<checked> of <total> records sourced".
+    // SourcingSummaryBanner returns null when no verdicts exist, so the regex
+    // may not match in fresh-data environments. When it DOES match, the
+    // numerator must not exceed the denominator (the QUA-897 invariant).
     const m = text.match(/(\d+)\s+of\s+(\d+)\s+records\s+sourced/);
-    expect(m, "banner 'X of Y records sourced' must render on /divisions").not.toBeNull();
     if (m) {
       const checked = Number(m[1]);
       const total = Number(m[2]);
-      expect(checked).toBeLessThanOrEqual(total);
+      expect(
+        checked,
+        `banner ratio inverted: ${checked} of ${total} (QUA-897 regression)`,
+      ).toBeLessThanOrEqual(total);
     }
   });
 });

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -119,6 +119,10 @@ export default function DivisionsPage() {
   const totalDivisions = rows.length;
   const uniqueOrgs = new Set(rows.map((r) => r.parentName)).size;
   const divisionsWithData = rows.filter((r) => r.hasData).length;
+  // Restrict the sourcing-summary banner to visible (deduped) division keys —
+  // raw rows count includes merged duplicates and would produce checked>total
+  // (QUA-897).
+  const visibleDivisionIds = new Set(rows.map((r) => String(r.key)));
 
   // Type breakdown (across all divisions)
   const typeCounts = new Map<string, number>();
@@ -145,7 +149,7 @@ export default function DivisionsPage() {
         </p>
       </div>
 
-      <SourcingSummaryBanner recordType="division" totalOverride={totalDivisions} />
+      <SourcingSummaryBanner recordType="division" recordIds={visibleDivisionIds} />
 
       <DivisionsTable
         rows={rows}

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -119,12 +119,9 @@ export default function DivisionsPage() {
   const totalDivisions = rows.length;
   const uniqueOrgs = new Set(rows.map((r) => r.parentName)).size;
   const divisionsWithData = rows.filter((r) => r.hasData).length;
-  // Restrict the sourcing-summary banner to visible (deduped) division keys —
-  // raw rows count includes merged duplicates and would produce checked>total
-  // (QUA-897). Each row's `key` is the dedup winner; verdicts on dropped
-  // duplicate keys are intentionally not counted so the banner stays
-  // consistent with the per-row verdict shown in the table (which also uses
-  // the winner key).
+  // Each row's `key` is the dedup winner; verdicts on dropped duplicate keys
+  // are intentionally not counted so the banner stays consistent with the
+  // per-row verdict shown in the table.
   const visibleDivisionIds = new Set(rows.map((r) => r.key));
 
   // Type breakdown (across all divisions)

--- a/apps/web/src/app/divisions/page.tsx
+++ b/apps/web/src/app/divisions/page.tsx
@@ -121,8 +121,11 @@ export default function DivisionsPage() {
   const divisionsWithData = rows.filter((r) => r.hasData).length;
   // Restrict the sourcing-summary banner to visible (deduped) division keys —
   // raw rows count includes merged duplicates and would produce checked>total
-  // (QUA-897).
-  const visibleDivisionIds = new Set(rows.map((r) => String(r.key)));
+  // (QUA-897). Each row's `key` is the dedup winner; verdicts on dropped
+  // duplicate keys are intentionally not counted so the banner stays
+  // consistent with the per-row verdict shown in the table (which also uses
+  // the winner key).
+  const visibleDivisionIds = new Set(rows.map((r) => r.key));
 
   // Type breakdown (across all divisions)
   const typeCounts = new Map<string, number>();

--- a/apps/web/src/app/internal/entities/entities-data-table.tsx
+++ b/apps/web/src/app/internal/entities/entities-data-table.tsx
@@ -981,7 +981,7 @@ const columns: ColumnDef<UnifiedEntityRow>[] = [
   {
     accessorKey: "scUnchecked",
     sortUndefined: "last",
-    header: ({ column }) => <SortableHeader column={column} title="Records not yet sourcinged">Unchk</SortableHeader>,
+    header: ({ column }) => <SortableHeader column={column} title="Records not yet sourced">Unchk</SortableHeader>,
     cell: ({ row }) => <VerdictCount value={row.original.scUnchecked} color="text-muted-foreground/60" icon="&#x25CB;" />,
   },
   {

--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -392,7 +392,7 @@ export async function SourcingCoverageContent() {
             Coverage Matrix
           </h2>
           <p className="text-sm text-muted-foreground mb-3">
-            Per-record-type breakdown: total records in each table vs how many have been sourcinged,
+            Per-record-type breakdown: total records in each table vs how many have been sourced,
             and what percentage are confirmed green.
             {exemptTables.length > 0 && (
               <> Exempt types (data ingested from canonical APIs) are shown separately and excluded from totals.</>

--- a/apps/web/src/app/things/[id]/page.tsx
+++ b/apps/web/src/app/things/[id]/page.tsx
@@ -644,7 +644,7 @@ export default async function ThingDetailPage({ params }: PageProps) {
           </h2>
           <div className="rounded-lg border border-dashed border-border/60 p-4">
             <p className="text-sm text-muted-foreground">
-              This record has not been sourcinged yet.
+              This record has not been sourced yet.
             </p>
             <Link
               href={getStoredVerdictHref(recordType, thing.sourceId)}

--- a/apps/web/src/components/directory/SourcingSummaryBanner.tsx
+++ b/apps/web/src/components/directory/SourcingSummaryBanner.tsx
@@ -14,16 +14,14 @@ import { getRecordVerdictStats, getRecordVerdictStatsForIds } from "@data/tableb
 
 export function SourcingSummaryBanner({
   recordType,
-  totalOverride,
   recordIds,
 }: {
   recordType: string;
-  /** Override the total count (useful when the table filters records). */
-  totalOverride?: number;
   /**
-   * If supplied, sourcing stats are restricted to these record IDs and the
-   * unscoped totalOverride is ignored. Use this whenever the page dedupes or
-   * filters rows so the banner ratio always satisfies checked <= total.
+   * If supplied, sourcing stats are restricted to these record IDs. Pass this
+   * whenever the page dedupes or filters rows so the banner ratio always
+   * satisfies checked <= total. When omitted, the banner counts every verdict
+   * for `recordType` and uses (checked + unchecked) as the total.
    */
   recordIds?: ReadonlySet<string>;
 }) {
@@ -31,9 +29,7 @@ export function SourcingSummaryBanner({
     ? getRecordVerdictStatsForIds(recordType, recordIds)
     : getRecordVerdictStats(recordType);
   const checked = stats.confirmed + stats.contradicted + stats.outdated + stats.partial + stats.unverifiable;
-  const total = recordIds
-    ? stats.total
-    : totalOverride ?? checked + stats.unchecked;
+  const total = recordIds ? stats.total : checked + stats.unchecked;
 
   if (checked === 0) return null;
 

--- a/apps/web/src/components/directory/SourcingSummaryBanner.tsx
+++ b/apps/web/src/components/directory/SourcingSummaryBanner.tsx
@@ -1,23 +1,39 @@
 /**
  * Section-level sourcing coverage summary.
  *
- * Shows "12 of 47 records sourcinged" above a table, with a breakdown
- * of verdict counts. Only renders when at least one record has been checked.
- * Server component — calls getRecordVerdictStats() directly.
+ * Shows "12 of 47 records sourced" above a table, with a breakdown of verdict
+ * counts. Only renders when at least one record has been checked. Server
+ * component — calls getRecordVerdictStats* directly.
+ *
+ * If the directory page deduplicates / filters before rendering (e.g.
+ * /divisions collapses raw rows by owner+name), pass `recordIds` so the stats
+ * are restricted to the visible rows. Otherwise the count of recorded
+ * verdicts can exceed the visible row total (QUA-897).
  */
-import { getRecordVerdictStats } from "@data/tablebase";
+import { getRecordVerdictStats, getRecordVerdictStatsForIds } from "@data/tablebase";
 
 export function SourcingSummaryBanner({
   recordType,
   totalOverride,
+  recordIds,
 }: {
   recordType: string;
   /** Override the total count (useful when the table filters records). */
   totalOverride?: number;
+  /**
+   * If supplied, sourcing stats are restricted to these record IDs and the
+   * unscoped totalOverride is ignored. Use this whenever the page dedupes or
+   * filters rows so the banner ratio always satisfies checked <= total.
+   */
+  recordIds?: ReadonlySet<string>;
 }) {
-  const stats = getRecordVerdictStats(recordType);
+  const stats = recordIds
+    ? getRecordVerdictStatsForIds(recordType, recordIds)
+    : getRecordVerdictStats(recordType);
   const checked = stats.confirmed + stats.contradicted + stats.outdated + stats.partial + stats.unverifiable;
-  const total = totalOverride ?? checked + stats.unchecked;
+  const total = recordIds
+    ? stats.total
+    : totalOverride ?? checked + stats.unchecked;
 
   if (checked === 0) return null;
 
@@ -44,7 +60,7 @@ export function SourcingSummaryBanner({
         <span className="font-medium text-foreground/80">{checked}</span>
         {" of "}
         <span className="font-medium text-foreground/80">{total}</span>
-        {" records sourcinged"}
+        {" records sourced"}
         {parts.length > 0 && (
           <span className="text-muted-foreground/80">
             {" \u00b7 "}

--- a/apps/web/src/data/__tests__/field-verdicts.test.ts
+++ b/apps/web/src/data/__tests__/field-verdicts.test.ts
@@ -250,15 +250,7 @@ describe("getRecordVerdict / getFieldVerdict — QUA-423 composite-key guard", (
   });
 });
 
-// ── QUA-897: scoped stats for deduped/filtered directories ────────────────
-//
-// /divisions dedupes raw division records by (owner, name), so 120 raw rows
-// collapse to 101 visible rows. The unscoped getRecordVerdictStats counts all
-// 120 verdicts, producing the impossible "120 of 101 records sourced" header.
-// getRecordVerdictStatsForIds restricts the count to a caller-supplied set of
-// record IDs (the visible rows) so the ratio stays sane.
-
-describe("getRecordVerdictStatsForIds — QUA-897 scoped counting", () => {
+describe("getRecordVerdictStatsForIds — scoped counting", () => {
   beforeEach(() => {
     vi.resetModules();
     const mockVerdicts = buildMockVerdicts();
@@ -311,7 +303,7 @@ describe("getRecordVerdictStatsForIds — QUA-897 scoped counting", () => {
     expect(stats.contradicted).toBe(0);
   });
 
-  it("returns checked <= total for any ID set (the QUA-897 invariant)", async () => {
+  it("returns checked <= total for any ID set", async () => {
     const { getRecordVerdictStatsForIds } = await import("../tablebase");
     const stats = getRecordVerdictStatsForIds(
       "grant",

--- a/apps/web/src/data/__tests__/field-verdicts.test.ts
+++ b/apps/web/src/data/__tests__/field-verdicts.test.ts
@@ -249,3 +249,88 @@ describe("getRecordVerdict / getFieldVerdict — QUA-423 composite-key guard", (
     warn.mockRestore();
   });
 });
+
+// ── QUA-897: scoped stats for deduped/filtered directories ────────────────
+//
+// /divisions dedupes raw division records by (owner, name), so 120 raw rows
+// collapse to 101 visible rows. The unscoped getRecordVerdictStats counts all
+// 120 verdicts, producing the impossible "120 of 101 records sourced" header.
+// getRecordVerdictStatsForIds restricts the count to a caller-supplied set of
+// record IDs (the visible rows) so the ratio stays sane.
+
+describe("getRecordVerdictStatsForIds — QUA-897 scoped counting", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const mockVerdicts = buildMockVerdicts();
+    vi.mocked(fs.readFileSync).mockImplementation((filePath: unknown) => {
+      const p = String(filePath);
+      if (p.includes("record-verdicts.json")) return JSON.stringify(mockVerdicts);
+      if (p.includes("database.json")) return JSON.stringify(mockDatabase);
+      if (p.includes("factbase-data.json")) {
+        return JSON.stringify({ entities: {}, facts: {}, slugToEntityId: {} });
+      }
+      return "{}";
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it("only counts verdicts for the supplied record IDs", async () => {
+    const { getRecordVerdictStatsForIds } = await import("../tablebase");
+    // Mock has g_001 (confirmed), g_002 (contradicted), g_003 (partial).
+    // Restrict to g_001 + g_002 only.
+    const stats = getRecordVerdictStatsForIds(
+      "grant",
+      new Set(["g_001", "g_002"]),
+    );
+    expect(stats.total).toBe(2);
+    expect(stats.confirmed).toBe(1);
+    expect(stats.contradicted).toBe(1);
+    expect(stats.partial).toBe(0);
+    expect(stats.unchecked).toBe(0);
+  });
+
+  it("counts an ID with no verdict as unchecked", async () => {
+    const { getRecordVerdictStatsForIds } = await import("../tablebase");
+    const stats = getRecordVerdictStatsForIds(
+      "grant",
+      new Set(["g_001", "g_does_not_exist"]),
+    );
+    expect(stats.total).toBe(2);
+    expect(stats.confirmed).toBe(1);
+    expect(stats.unchecked).toBe(1);
+  });
+
+  it("ignores per-field verdicts even when the row ID matches", async () => {
+    const { getRecordVerdictStatsForIds } = await import("../tablebase");
+    // Mock has both grant:g_001 (row-level, confirmed) and
+    // grant:g_001:amount + grant:g_001:recipient (per-field). Only the
+    // row-level one should be counted.
+    const stats = getRecordVerdictStatsForIds("grant", new Set(["g_001"]));
+    expect(stats.total).toBe(1);
+    expect(stats.confirmed).toBe(1);
+    expect(stats.contradicted).toBe(0);
+  });
+
+  it("returns checked <= total for any ID set (the QUA-897 invariant)", async () => {
+    const { getRecordVerdictStatsForIds } = await import("../tablebase");
+    const stats = getRecordVerdictStatsForIds(
+      "grant",
+      new Set(["g_001", "g_002", "g_003"]),
+    );
+    const checked =
+      stats.confirmed +
+      stats.contradicted +
+      stats.outdated +
+      stats.partial +
+      stats.unverifiable;
+    expect(checked).toBeLessThanOrEqual(stats.total);
+  });
+
+  it("returns all-zero stats for an empty ID set", async () => {
+    const { getRecordVerdictStatsForIds } = await import("../tablebase");
+    const stats = getRecordVerdictStatsForIds("grant", new Set());
+    expect(stats.total).toBe(0);
+    expect(stats.confirmed).toBe(0);
+    expect(stats.unchecked).toBe(0);
+  });
+});

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1164,14 +1164,15 @@ export type RecordVerdictStats = {
   unchecked: number;
 };
 
-const VALID_VERDICT_KEYS = new Set([
+type VerdictKey = Exclude<keyof RecordVerdictStats, "total">;
+const VALID_VERDICT_KEYS: ReadonlySet<string> = new Set<VerdictKey>([
   "confirmed",
   "contradicted",
   "unverifiable",
   "outdated",
   "partial",
   "unchecked",
-] as const);
+]);
 
 /** Get sourcing stats for a specific record type */
 export function getRecordVerdictStats(recordType: string): RecordVerdictStats {
@@ -1183,8 +1184,8 @@ export function getRecordVerdictStats(recordType: string): RecordVerdictStats {
     // Only count row-level entries (two segments: "grant:g_abc123")
     if (key.split(":").length > 2) continue;
     stats.total++;
-    if (VALID_VERDICT_KEYS.has(v.verdict as never)) {
-      stats[v.verdict as keyof RecordVerdictStats]++;
+    if (VALID_VERDICT_KEYS.has(v.verdict)) {
+      stats[v.verdict as VerdictKey]++;
     }
   }
   return stats;
@@ -1212,9 +1213,10 @@ export function getRecordVerdictStatsForIds(
   for (const id of recordIds) {
     stats.total++;
     const v = verdicts[`${recordType}:${id}`];
-    const verdictName = v && VALID_VERDICT_KEYS.has(v.verdict as never)
-      ? (v.verdict as keyof RecordVerdictStats)
-      : "unchecked";
+    const verdictName: VerdictKey =
+      v && VALID_VERDICT_KEYS.has(v.verdict)
+        ? (v.verdict as VerdictKey)
+        : "unchecked";
     stats[verdictName]++;
   }
   return stats;

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -37,7 +37,10 @@ import type { ValidSubcategory } from "./valid-subcategories";
 import { isSid, isAnySid, SID_PREFIX } from "@/lib/stable-id";
 import { extractDomain } from "@/lib/resource-types";
 import { isCandidateRecordId } from "@wiki-server/api-types";
-import { SOURCE_CHECK_VERDICT_PRIORITY } from "@/components/shared/verdict-styles";
+import {
+  SOURCE_CHECK_VERDICT_PRIORITY,
+  type SourcingVerdictType,
+} from "@/components/shared/verdict-styles";
 
 // Re-export for consumers
 export type { WithSource };
@@ -1156,16 +1159,9 @@ export function getFieldVerdicts(recordType: string, recordId: string): Record<s
 
 export type RecordVerdictStats = {
   total: number;
-  confirmed: number;
-  contradicted: number;
-  unverifiable: number;
-  outdated: number;
-  partial: number;
-  unchecked: number;
-};
+} & Record<SourcingVerdictType, number>;
 
-type VerdictKey = Exclude<keyof RecordVerdictStats, "total">;
-const VALID_VERDICT_KEYS: ReadonlySet<string> = new Set<VerdictKey>([
+const VALID_VERDICT_KEYS: ReadonlySet<string> = new Set<SourcingVerdictType>([
   "confirmed",
   "contradicted",
   "unverifiable",
@@ -1174,48 +1170,47 @@ const VALID_VERDICT_KEYS: ReadonlySet<string> = new Set<VerdictKey>([
   "unchecked",
 ]);
 
+function emptyVerdictStats(): RecordVerdictStats {
+  return { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
+}
+
 /** Get sourcing stats for a specific record type */
 export function getRecordVerdictStats(recordType: string): RecordVerdictStats {
   const verdicts = getRecordVerdicts();
-  const stats: RecordVerdictStats = { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
+  const stats = emptyVerdictStats();
   for (const [key, v] of Object.entries(verdicts)) {
     if (!key.startsWith(`${recordType}:`)) continue;
-    // Skip per-field entries (three segments: "grant:g_abc123:amount")
-    // Only count row-level entries (two segments: "grant:g_abc123")
+    // Per-field entries are three-segment keys ("grant:g_abc:amount") — skip.
     if (key.split(":").length > 2) continue;
     stats.total++;
     if (VALID_VERDICT_KEYS.has(v.verdict)) {
-      stats[v.verdict as VerdictKey]++;
+      stats[v.verdict as SourcingVerdictType]++;
     }
   }
   return stats;
 }
 
 /**
- * Sourcing stats restricted to a caller-supplied set of record IDs (QUA-897).
+ * Sourcing stats restricted to a caller-supplied set of record IDs.
  *
  * Use this when the directory page deduplicates or filters records before
- * rendering — the unscoped getRecordVerdictStats counts every verdict in the
- * record-verdicts map, which can exceed the visible row count and produce an
- * impossible "120 of 101" header. /divisions is the canonical case (raw rows
- * with the same owner+name collapse to a single visible row).
- *
- * IDs absent from the verdict map are counted as `unchecked` so total always
- * equals the size of `recordIds`. Per-field verdicts (3-segment keys like
- * `grant:g_001:amount`) are ignored — only row-level verdicts count.
+ * rendering, so the count of recorded verdicts cannot exceed the visible row
+ * total. IDs absent from the verdict map are counted as `unchecked` so total
+ * always equals `recordIds.size`. Per-field verdicts (3-segment keys) are
+ * ignored.
  */
 export function getRecordVerdictStatsForIds(
   recordType: string,
   recordIds: ReadonlySet<string>,
 ): RecordVerdictStats {
   const verdicts = getRecordVerdicts();
-  const stats: RecordVerdictStats = { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
+  const stats = emptyVerdictStats();
   for (const id of recordIds) {
     stats.total++;
     const v = verdicts[`${recordType}:${id}`];
-    const verdictName: VerdictKey =
+    const verdictName: SourcingVerdictType =
       v && VALID_VERDICT_KEYS.has(v.verdict)
-        ? (v.verdict as VerdictKey)
+        ? (v.verdict as SourcingVerdictType)
         : "unchecked";
     stats[verdictName]++;
   }

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -1154,8 +1154,7 @@ export function getFieldVerdicts(recordType: string, recordId: string): Record<s
   return result;
 }
 
-/** Get sourcing stats for a specific record type */
-export function getRecordVerdictStats(recordType: string): {
+export type RecordVerdictStats = {
   total: number;
   confirmed: number;
   contradicted: number;
@@ -1163,19 +1162,60 @@ export function getRecordVerdictStats(recordType: string): {
   outdated: number;
   partial: number;
   unchecked: number;
-} {
+};
+
+const VALID_VERDICT_KEYS = new Set([
+  "confirmed",
+  "contradicted",
+  "unverifiable",
+  "outdated",
+  "partial",
+  "unchecked",
+] as const);
+
+/** Get sourcing stats for a specific record type */
+export function getRecordVerdictStats(recordType: string): RecordVerdictStats {
   const verdicts = getRecordVerdicts();
-  const stats = { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
-  const validVerdicts = new Set(['confirmed', 'contradicted', 'unverifiable', 'outdated', 'partial', 'unchecked']);
+  const stats: RecordVerdictStats = { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
   for (const [key, v] of Object.entries(verdicts)) {
     if (!key.startsWith(`${recordType}:`)) continue;
     // Skip per-field entries (three segments: "grant:g_abc123:amount")
     // Only count row-level entries (two segments: "grant:g_abc123")
     if (key.split(":").length > 2) continue;
     stats.total++;
-    if (validVerdicts.has(v.verdict)) {
-      stats[v.verdict as 'confirmed' | 'contradicted' | 'unverifiable' | 'outdated' | 'partial' | 'unchecked']++;
+    if (VALID_VERDICT_KEYS.has(v.verdict as never)) {
+      stats[v.verdict as keyof RecordVerdictStats]++;
     }
+  }
+  return stats;
+}
+
+/**
+ * Sourcing stats restricted to a caller-supplied set of record IDs (QUA-897).
+ *
+ * Use this when the directory page deduplicates or filters records before
+ * rendering — the unscoped getRecordVerdictStats counts every verdict in the
+ * record-verdicts map, which can exceed the visible row count and produce an
+ * impossible "120 of 101" header. /divisions is the canonical case (raw rows
+ * with the same owner+name collapse to a single visible row).
+ *
+ * IDs absent from the verdict map are counted as `unchecked` so total always
+ * equals the size of `recordIds`. Per-field verdicts (3-segment keys like
+ * `grant:g_001:amount`) are ignored — only row-level verdicts count.
+ */
+export function getRecordVerdictStatsForIds(
+  recordType: string,
+  recordIds: ReadonlySet<string>,
+): RecordVerdictStats {
+  const verdicts = getRecordVerdicts();
+  const stats: RecordVerdictStats = { total: 0, confirmed: 0, contradicted: 0, unverifiable: 0, outdated: 0, partial: 0, unchecked: 0 };
+  for (const id of recordIds) {
+    stats.total++;
+    const v = verdicts[`${recordType}:${id}`];
+    const verdictName = v && VALID_VERDICT_KEYS.has(v.verdict as never)
+      ? (v.verdict as keyof RecordVerdictStats)
+      : "unchecked";
+    stats[verdictName]++;
   }
   return stats;
 }

--- a/content/docs/internal/data-architecture-overview.mdx
+++ b/content/docs/internal/data-architecture-overview.mdx
@@ -615,7 +615,7 @@ The architecture has known limitations and missing pieces. Documenting them prev
 | **No incremental builds** | `build-data.mjs` rebuilds everything from scratch each time (≈30s for content-only, ~2min full). No caching or dirty-file detection | Use `--scope=content` for faster content-only builds |
 | **No real-time updates** | Wiki content is fully static — changes require a build + deploy cycle. ISR helps dashboards but content pages are build-time only | Deploy pipeline; auto-update runs daily |
 | **No FactBase → WikiBase auto-sync** | When a FactBase fact changes, the wiki page prose isn't automatically updated to match | `crux w improve` can update pages, but must be triggered manually |
-| **Source-check coverage is partial** | Only about 15% of wiki pages have been sourcinged. Many facts lack source URLs entirely | `crux fb sourcing` and `crux w sourcing-wiki-pages` are available but expensive (about \$0.07/page) |
+| **Source-check coverage is partial** | Only about 15% of wiki pages have been sourced. Many facts lack source URLs entirely | `crux fb sourcing` and `crux w sourcing-wiki-pages` are available but expensive (about \$0.07/page) |
 | **No rollback for PG-primary data** | YAML-primary data has full git history. PG-primary data (grants, personnel) has no version history beyond edit logs | Consider adding a changelog table for PG-primary records |
 | **`things` table can go stale** | The cross-base index is synced at build time. Between builds, newly created PG records won't appear in `things` search | Rebuild or wait for next deploy |
 

--- a/content/docs/internal/entity-sourcing-dashboard.mdx
+++ b/content/docs/internal/entity-sourcing-dashboard.mdx
@@ -8,6 +8,6 @@ hideSidebar: true
 lastEdited: "2026-03-22"
 ---
 
-Verdict counts for sourcinged FactBase facts, grouped by entity. Each fact is checked against its cited source URL and receives a verdict: **confirmed** (source supports the claim), **contradicted** (source disagrees), or **undecidable** (source doesn't address the claim). Prioritize contradicted facts for correction, then undecidable for re-sourcing. Run `pnpm crux fb sourcing --entity=<id>` to check a specific entity.
+Verdict counts for sourced FactBase facts, grouped by entity. Each fact is checked against its cited source URL and receives a verdict: **confirmed** (source supports the claim), **contradicted** (source disagrees), or **undecidable** (source doesn't address the claim). Prioritize contradicted facts for correction, then undecidable for re-sourcing. Run `pnpm crux fb sourcing --entity=<id>` to check a specific entity.
 
 <EntitySourcingContent />

--- a/content/docs/internal/verification-sourcing-hub.mdx
+++ b/content/docs/internal/verification-sourcing-hub.mdx
@@ -101,6 +101,6 @@ The dashboards group by these verdicts so you can prioritize: contradicted > und
 
 <CardGrid>
   <LinkCard title="Research & Discovery" href="/wiki/E2166" description="Where the sources being verified come from" />
-  <LinkCard title="FactBase & Entities" href="/wiki/E2168" description="What's being sourcinged, for fact verification" />
+  <LinkCard title="FactBase & Entities" href="/wiki/E2168" description="What's being sourced, for fact verification" />
   <LinkCard title="Content Pipelines" href="/wiki/E2169" description="Verification runs as part of page creation/improvement" />
 </CardGrid>

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -347,6 +347,15 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    // QUA-897: block the non-word "sourcinged" — a mass-rename artifact
+    // from QUA-237 that surfaced on /divisions and 4 other pages.
+    id: 'no-sourcinged',
+    name: 'No "sourcinged" non-word (QUA-897 regression check)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-no-sourcinged.ts'],
+    cwd: PROJECT_ROOT,
+  },
+  {
     // QUA-730: any newly added/modified manifest in data/tablebase-manifests/
     // must have at least one record with sourcing data. Catches the
     // "agent ran with --skip-sourcing because the billing key was missing"

--- a/crux/validate/validate-no-sourcinged.test.ts
+++ b/crux/validate/validate-no-sourcinged.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { runCheck } from "./validate-no-sourcinged.ts";
+
+describe("validate-no-sourcinged", () => {
+  it("passes on the current codebase (QUA-897 fix landed)", () => {
+    const result = runCheck();
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+    expect(result.violations).toEqual([]);
+  });
+});

--- a/crux/validate/validate-no-sourcinged.ts
+++ b/crux/validate/validate-no-sourcinged.ts
@@ -10,7 +10,7 @@
  * This validator catches a regression if a future rename re-introduces
  * the artifact.
  *
- * Scoped to user-visible content surfaces (TS/TSX/MDX/MD/YAML). The dist/
+ * Scoped to user-visible content surfaces (TS/TSX/MDX/YAML). The dist/
  * `.next/`, `node_modules/`, and `.cache/` trees are skipped.
  *
  * Usage: npx tsx crux/validate/validate-no-sourcinged.ts

--- a/crux/validate/validate-no-sourcinged.ts
+++ b/crux/validate/validate-no-sourcinged.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+/**
+ * Block the non-word "sourcinged" from re-entering user-visible strings.
+ *
+ * QUA-237 mass-renamed legacy verification terminology to the "sourcing"
+ * vocabulary. Because the rename was a mechanical substring replace, the
+ * past-participle form "...checked" was turned into "...inged" in five
+ * places, including the /divisions header. QUA-897 corrected the typos.
+ * This validator catches a regression if a future rename re-introduces
+ * the artifact.
+ *
+ * Scoped to user-visible content surfaces (TS/TSX/MDX/MD/YAML). The dist/
+ * `.next/`, `node_modules/`, and `.cache/` trees are skipped.
+ *
+ * Usage: npx tsx crux/validate/validate-no-sourcinged.ts
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { PROJECT_ROOT } from "../lib/content-types.ts";
+import { getColors } from "../lib/output.ts";
+
+const SCAN_DIRS = ["apps/web/src", "apps/wiki-server/src", "content", "crux"];
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".next",
+  ".cache",
+  "dist",
+  "playwright-report",
+  "test-results",
+]);
+const SCAN_EXTENSIONS = [".ts", ".tsx", ".mdx", ".md", ".yaml", ".yml"];
+const BANNED = "sourcinged";
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function collectFiles(dir: string): string[] {
+  const out: string[] = [];
+  function walk(current: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry)) continue;
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (SCAN_EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+        out.push(fullPath);
+      }
+    }
+  }
+  walk(dir);
+  return out;
+}
+
+function checkFile(filePath: string): Violation[] {
+  const content = readFileSync(filePath, "utf-8");
+  if (!content.includes(BANNED)) return [];
+  const violations: Violation[] = [];
+  const lines = content.split("\n");
+  const relPath = relative(PROJECT_ROOT, filePath);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(BANNED)) {
+      // Allow this validator file itself to mention the banned string.
+      if (relPath.endsWith("validate-no-sourcinged.ts")) continue;
+      if (relPath.endsWith("validate-no-sourcinged.test.ts")) continue;
+      // Allow the gate registry to reference the validator's id/comments.
+      if (relPath.endsWith("validate-gate.ts")) continue;
+      violations.push({ file: relPath, line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return violations;
+}
+
+export function runCheck(): {
+  passed: boolean;
+  errors: number;
+  violations: Violation[];
+} {
+  const c = getColors();
+  console.log(
+    `${c.blue}Checking for the banned non-word "${BANNED}"...${c.reset}\n`,
+  );
+  const allFiles: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    allFiles.push(...collectFiles(join(PROJECT_ROOT, dir)));
+  }
+  const all: Violation[] = [];
+  for (const file of allFiles) {
+    all.push(...checkFile(file));
+  }
+  if (all.length === 0) {
+    console.log(
+      `${c.green}No "${BANNED}" occurrences found (${allFiles.length} files checked)${c.reset}`,
+    );
+  } else {
+    console.log(
+      `${c.red}Found ${all.length} occurrence(s) of "${BANNED}" — replace with "sourced":${c.reset}\n`,
+    );
+    for (const v of all) {
+      console.log(`  ${c.red}${v.file}:${v.line}${c.reset}`);
+      console.log(`    ${c.dim}${v.text}${c.reset}\n`);
+    }
+  }
+  return { passed: all.length === 0, errors: all.length, violations: all };
+}
+
+if (process.argv[1]?.includes("validate-no-sourcinged")) {
+  const result = runCheck();
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-no-sourcinged.ts
+++ b/crux/validate/validate-no-sourcinged.ts
@@ -30,8 +30,20 @@ const SKIP_DIRS = new Set([
   "playwright-report",
   "test-results",
 ]);
-const SCAN_EXTENSIONS = [".ts", ".tsx", ".mdx", ".md", ".yaml", ".yml"];
+// .json intentionally omitted: build outputs (database.json, factbase-data.json)
+// are generated and not edited by hand. .md is omitted because user-visible
+// content lives in .mdx; .md files outside this validator's scope are docs.
+const SCAN_EXTENSIONS = [".ts", ".tsx", ".mdx", ".yaml", ".yml"];
 const BANNED = "sourcinged";
+
+// Path-equality allowlist (relative to PROJECT_ROOT) for files that must
+// reference the banned string by name (the validator itself, its test, and
+// the gate registry entry that points at it).
+const ALLOWLIST = new Set([
+  "crux/validate/validate-no-sourcinged.ts",
+  "crux/validate/validate-no-sourcinged.test.ts",
+  "crux/validate/validate-gate.ts",
+]);
 
 interface Violation {
   file: string;
@@ -71,16 +83,12 @@ function collectFiles(dir: string): string[] {
 function checkFile(filePath: string): Violation[] {
   const content = readFileSync(filePath, "utf-8");
   if (!content.includes(BANNED)) return [];
+  const relPath = relative(PROJECT_ROOT, filePath);
+  if (ALLOWLIST.has(relPath)) return [];
   const violations: Violation[] = [];
   const lines = content.split("\n");
-  const relPath = relative(PROJECT_ROOT, filePath);
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].includes(BANNED)) {
-      // Allow this validator file itself to mention the banned string.
-      if (relPath.endsWith("validate-no-sourcinged.ts")) continue;
-      if (relPath.endsWith("validate-no-sourcinged.test.ts")) continue;
-      // Allow the gate registry to reference the validator's id/comments.
-      if (relPath.endsWith("validate-gate.ts")) continue;
       violations.push({ file: relPath, line: i + 1, text: lines[i].trim() });
     }
   }


### PR DESCRIPTION
## Summary

Fix the `/divisions` directory header that rendered:

> **120 of 101 records sourcinged · 64 confirmed · 3 disputed · 11 partial**

Two defects, both traced to the QUA-237 sourcing rename:

1. **Typo**: `"sourcinged"` is a non-word — the substring rename `source-check → sourcing` mechanically turned `source-checked` into `sourcinged` in 5 user-visible places (banner, /things detail, /internal/sourcing-coverage, /internal/entities, plus 3 internal MDX dashboards). All replaced with `"sourced"`.

2. **Impossible ratio (120 > 101)**: `/divisions` deduplicates raw division records by `(owner, name)` before rendering, but the banner counted every verdict in the record-verdicts map. After the fix, the banner shows `99 of 101 records sourced · 50 confirmed · 2 disputed · 10 partial` against current prod data — `checked <= total` is now an invariant.

## Key changes

- **`getRecordVerdictStatsForIds(recordType, recordIds)`** — new data-layer helper that restricts verdict counting to a caller-supplied ID set. Reuses the canonical `SourcingVerdictType` from `verdict-styles.ts` so the verdict bucket list cannot drift.
- **`SourcingSummaryBanner`** — accepts a `recordIds` prop; the deprecated `totalOverride` prop was removed (no remaining callers after this fix).
- **`apps/web/src/app/divisions/page.tsx`** — passes the dedup-winner keys.
- **`crux/validate/validate-no-sourcinged.ts`** — gate validator that blocks the non-word from re-entering the codebase.
- **Regression tests**: 5 new unit tests for `getRecordVerdictStatsForIds`, plus `/divisions` added to the e2e render-audit `SIMPLE_PAGES` list and a focused QUA-897 banner-invariant test.

## Test plan

- [x] `pnpm crux w validate gate --fix` (68 checks passed; legacy-terminology baseline unchanged)
- [x] `pnpm vitest run apps/web/src/data/__tests__/field-verdicts.test.ts` (13 tests)
- [x] `pnpm vitest run crux/validate/validate-no-sourcinged.test.ts`
- [x] `pnpm build` (Next.js production build green)
- [x] Playwright `e2e/render-audit.spec.ts` — `/divisions` and the QUA-897 banner test both pass
- [x] Manual verification on dev: `99 of 101 records sourced · 50 confirmed · 2 disputed · 10 partial`
- [x] `/agent-review-pr` (hostile reviewer subagent + simplification pass — see commits 44c2c35a + c1d27a63)

Closes QUA-897
