### PR TITLE
QUA-928: split sourcing coverage into checkability + checkable coverage

### DIFF
--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -24,13 +24,18 @@ interface UnifiedSourcingStatsResult {
  * `coveragePercent` field was ambiguous — it equaled
  * `checkedRecords / totalRecords`, which conflated "no source supplied" with
  * "source supplied but not yet checked".
+ *
+ * The new fields are typed as optional so the dashboard can render against
+ * a wiki-server that hasn't been deployed yet (the web build fetches data
+ * from prod at SSG time). Once the server-side change ships and the next
+ * web build runs, the `??` fallbacks become no-ops.
  */
 interface CoverageMatrixResult {
   tables: Array<{
     recordType: string;
     totalRecords: number;
-    checkableRecords: number;
-    checkedRecords: number;
+    checkableRecords?: number;
+    checkedRecords?: number;
     verdicts: {
       confirmed: number;
       partial: number;
@@ -40,23 +45,27 @@ interface CoverageMatrixResult {
       unchecked: number;
     };
     /** checkable / total — what fraction of authored records are eligible for sourcing */
-    checkabilityPercent: number;
+    checkabilityPercent?: number;
     /** checked / checkable — what fraction of checkable records have a verdict */
-    checkableCoveragePercent: number;
+    checkableCoveragePercent?: number;
     /** checked / total — joint metric (capped by checkability) */
-    fullCoveragePercent: number;
+    fullCoveragePercent?: number;
+    /** @deprecated Use fullCoveragePercent. Kept here for the SSG-against-old-prod transition window. */
+    coveragePercent?: number;
     greenPercent: number;
     /** Whether this record type is exempt from sourcing verification */
     exempt?: boolean;
   }>;
   totals: {
     totalRecords: number;
-    checkableRecords: number;
+    checkableRecords?: number;
     totalVerdicts: number;
     confirmedPercent: number;
-    checkabilityPercent: number;
-    checkableCoveragePercent: number;
-    fullCoveragePercent: number;
+    checkabilityPercent?: number;
+    checkableCoveragePercent?: number;
+    fullCoveragePercent?: number;
+    /** @deprecated Use fullCoveragePercent. */
+    coveragePercent?: number;
   };
   /** Record types that are exempt from sourcing verification */
   exemptTypes?: string[];
@@ -458,9 +467,30 @@ export async function SourcingCoverageContent() {
               </thead>
               <tbody>
                 {nonExemptTables.map((t) => {
+                  // Fall back to legacy field shape during the
+                  // wiki-server-not-yet-deployed window. Once both ship,
+                  // the `??` paths become unreachable.
+                  const checkable = t.checkableRecords ?? t.totalRecords;
+                  const checked = t.checkedRecords ?? 0;
+                  const checkability =
+                    t.checkabilityPercent ??
+                    (t.totalRecords > 0
+                      ? Math.round((checkable / t.totalRecords) * 1000) / 10
+                      : 0);
+                  const checkableCov =
+                    t.checkableCoveragePercent ??
+                    (checkable > 0
+                      ? Math.round((checked / checkable) * 1000) / 10
+                      : 0);
+                  const fullCov =
+                    t.fullCoveragePercent ??
+                    t.coveragePercent ??
+                    (t.totalRecords > 0
+                      ? Math.round((checked / t.totalRecords) * 1000) / 10
+                      : 0);
                   const checkabilityGap =
                     t.totalRecords > 0
-                      ? Math.round(((t.totalRecords - t.checkableRecords) / t.totalRecords) * 1000) / 10
+                      ? Math.round(((t.totalRecords - checkable) / t.totalRecords) * 1000) / 10
                       : 0;
                   return (
                     <tr
@@ -472,16 +502,16 @@ export async function SourcingCoverageContent() {
                         {t.totalRecords.toLocaleString()}
                       </td>
                       <td className="text-right py-2 px-3 tabular-nums">
-                        {t.checkableRecords.toLocaleString()}
+                        {checkable.toLocaleString()}
                       </td>
                       <td className="text-right py-2 px-3 tabular-nums">
-                        {t.checkedRecords.toLocaleString()}
+                        {checked.toLocaleString()}
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums font-medium ${
-                          t.checkabilityPercent >= 95
+                          checkability >= 95
                             ? "text-muted-foreground"
-                            : t.checkabilityPercent >= 80
+                            : checkability >= 80
                               ? "text-amber-600"
                               : "text-red-600"
                         }`}
@@ -491,29 +521,29 @@ export async function SourcingCoverageContent() {
                             : undefined
                         }
                       >
-                        {t.checkabilityPercent}%
+                        {checkability}%
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums font-medium ${
-                          t.checkableCoveragePercent >= 90
+                          checkableCov >= 90
                             ? "text-emerald-600"
-                            : t.checkableCoveragePercent >= 60
+                            : checkableCov >= 60
                               ? "text-amber-600"
                               : "text-red-600"
                         }`}
                       >
-                        {t.checkableCoveragePercent}%
+                        {checkableCov}%
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums ${
-                          t.fullCoveragePercent >= 80
+                          fullCov >= 80
                             ? "text-emerald-600"
-                            : t.fullCoveragePercent >= 40
+                            : fullCov >= 40
                               ? "text-amber-600"
                               : "text-muted-foreground"
                         }`}
                       >
-                        {t.fullCoveragePercent}%
+                        {fullCov}%
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums font-medium ${
@@ -568,19 +598,19 @@ export async function SourcingCoverageContent() {
                     {coverageMatrix.totals.totalRecords.toLocaleString()}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.checkableRecords.toLocaleString()}
+                    {(coverageMatrix.totals.checkableRecords ?? coverageMatrix.totals.totalRecords).toLocaleString()}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.totalVerdicts.toLocaleString()} verdicts
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.checkabilityPercent}%
+                    {coverageMatrix.totals.checkabilityPercent ?? "—"}%
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.checkableCoveragePercent}%
+                    {coverageMatrix.totals.checkableCoveragePercent ?? "—"}%
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.fullCoveragePercent}%
+                    {coverageMatrix.totals.fullCoveragePercent ?? coverageMatrix.totals.coveragePercent ?? "—"}%
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.confirmedPercent}%

--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -15,12 +15,22 @@ interface UnifiedSourcingStatsResult {
   by_type: Record<string, number>;
 }
 
-/** Shape returned by GET /api/sourcing/coverage-matrix */
+/**
+ * Shape returned by GET /api/sourcing/coverage-matrix.
+ *
+ * QUA-928: coverage is split into three explicit percentages so the dashboard
+ * can show authoring-quality (`checkabilityPercent`) separately from
+ * verification-quality (`checkableCoveragePercent`). The previous
+ * `coveragePercent` field was ambiguous — it equaled
+ * `checkedRecords / totalRecords`, which conflated "no source supplied" with
+ * "source supplied but not yet checked".
+ */
 interface CoverageMatrixResult {
   tables: Array<{
     recordType: string;
     totalRecords: number;
-    checkedRecords?: number;
+    checkableRecords: number;
+    checkedRecords: number;
     verdicts: {
       confirmed: number;
       partial: number;
@@ -29,16 +39,24 @@ interface CoverageMatrixResult {
       outdated: number;
       unchecked: number;
     };
-    coveragePercent: number;
+    /** checkable / total — what fraction of authored records are eligible for sourcing */
+    checkabilityPercent: number;
+    /** checked / checkable — what fraction of checkable records have a verdict */
+    checkableCoveragePercent: number;
+    /** checked / total — joint metric (capped by checkability) */
+    fullCoveragePercent: number;
     greenPercent: number;
     /** Whether this record type is exempt from sourcing verification */
     exempt?: boolean;
   }>;
   totals: {
     totalRecords: number;
+    checkableRecords: number;
     totalVerdicts: number;
     confirmedPercent: number;
-    coveragePercent: number;
+    checkabilityPercent: number;
+    checkableCoveragePercent: number;
+    fullCoveragePercent: number;
   };
   /** Record types that are exempt from sourcing verification */
   exemptTypes?: string[];
@@ -90,7 +108,15 @@ async function loadSourcingStats() {
 function emptyCoverageMatrix(): CoverageMatrixResult {
   return {
     tables: [],
-    totals: { totalRecords: 0, totalVerdicts: 0, confirmedPercent: 0, coveragePercent: 0 },
+    totals: {
+      totalRecords: 0,
+      checkableRecords: 0,
+      totalVerdicts: 0,
+      confirmedPercent: 0,
+      checkabilityPercent: 0,
+      checkableCoveragePercent: 0,
+      fullCoveragePercent: 0,
+    },
   };
 }
 
@@ -392,8 +418,11 @@ export async function SourcingCoverageContent() {
             Coverage Matrix
           </h2>
           <p className="text-sm text-muted-foreground mb-3">
-            Per-record-type breakdown: total records in each table vs how many have been sourced,
-            and what percentage are confirmed green.
+            Per-record-type breakdown of the sourcing pipeline. <strong>Checkability</strong> is the
+            authoring-quality metric (fraction of records eligible for sourcing — has a source
+            URL and a verifiable property). <strong>Checkable Coverage</strong> is the verification
+            metric the orchestrator gates on (of the eligible records, fraction with a verdict).
+            <strong> Full Coverage</strong> is verified ÷ total, capped by checkability.
             {exemptTables.length > 0 && (
               <> Exempt types (data ingested from canonical APIs) are shown separately and excluded from totals.</>
             )}
@@ -403,22 +432,36 @@ export async function SourcingCoverageContent() {
               <thead>
                 <tr className="border-b border-border/60">
                   <th className="text-left py-2 px-3 font-medium">Record Type</th>
-                  <th className="text-right py-2 px-3 font-medium">Total Records</th>
+                  <th className="text-right py-2 px-3 font-medium">Total</th>
+                  <th className="text-right py-2 px-3 font-medium">Checkable</th>
                   <th className="text-right py-2 px-3 font-medium">Checked</th>
-                  <th className="text-right py-2 px-3 font-medium">Unchecked</th>
-                  <th className="text-right py-2 px-3 font-medium">Coverage %</th>
+                  <th
+                    className="text-right py-2 px-3 font-medium"
+                    title="Checkable / Total — authoring quality"
+                  >
+                    Checkability %
+                  </th>
+                  <th
+                    className="text-right py-2 px-3 font-medium"
+                    title="Checked / Checkable — verification quality (gate metric)"
+                  >
+                    Checkable Cov %
+                  </th>
+                  <th
+                    className="text-right py-2 px-3 font-medium"
+                    title="Checked / Total — joint metric, capped by checkability"
+                  >
+                    Full Cov %
+                  </th>
                   <th className="text-right py-2 px-3 font-medium">Green %</th>
                 </tr>
               </thead>
               <tbody>
                 {nonExemptTables.map((t) => {
-                  const checked =
-                    t.checkedRecords ??
-                    (t.verdicts.confirmed +
-                    t.verdicts.partial +
-                    t.verdicts.unverifiable +
-                    t.verdicts.contradicted +
-                    t.verdicts.outdated);
+                  const checkabilityGap =
+                    t.totalRecords > 0
+                      ? Math.round(((t.totalRecords - t.checkableRecords) / t.totalRecords) * 1000) / 10
+                      : 0;
                   return (
                     <tr
                       key={t.recordType}
@@ -429,21 +472,48 @@ export async function SourcingCoverageContent() {
                         {t.totalRecords.toLocaleString()}
                       </td>
                       <td className="text-right py-2 px-3 tabular-nums">
-                        {checked.toLocaleString()}
+                        {t.checkableRecords.toLocaleString()}
                       </td>
                       <td className="text-right py-2 px-3 tabular-nums">
-                        {t.verdicts.unchecked.toLocaleString()}
+                        {t.checkedRecords.toLocaleString()}
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums font-medium ${
-                          t.coveragePercent >= 80
+                          t.checkabilityPercent >= 95
+                            ? "text-muted-foreground"
+                            : t.checkabilityPercent >= 80
+                              ? "text-amber-600"
+                              : "text-red-600"
+                        }`}
+                        title={
+                          checkabilityGap > 0
+                            ? `${checkabilityGap}% of records lack a source URL or are on a non-verifiable property`
+                            : undefined
+                        }
+                      >
+                        {t.checkabilityPercent}%
+                      </td>
+                      <td
+                        className={`text-right py-2 px-3 tabular-nums font-medium ${
+                          t.checkableCoveragePercent >= 90
                             ? "text-emerald-600"
-                            : t.coveragePercent >= 40
+                            : t.checkableCoveragePercent >= 60
                               ? "text-amber-600"
                               : "text-red-600"
                         }`}
                       >
-                        {t.coveragePercent}%
+                        {t.checkableCoveragePercent}%
+                      </td>
+                      <td
+                        className={`text-right py-2 px-3 tabular-nums ${
+                          t.fullCoveragePercent >= 80
+                            ? "text-emerald-600"
+                            : t.fullCoveragePercent >= 40
+                              ? "text-amber-600"
+                              : "text-muted-foreground"
+                        }`}
+                      >
+                        {t.fullCoveragePercent}%
                       </td>
                       <td
                         className={`text-right py-2 px-3 tabular-nums font-medium ${
@@ -462,7 +532,7 @@ export async function SourcingCoverageContent() {
                 {exemptTables.length > 0 && (
                   <>
                     <tr className="border-t border-border/40">
-                      <td colSpan={6} className="py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      <td colSpan={8} className="py-2 px-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">
                         Exempt (canonical API sources)
                       </td>
                     </tr>
@@ -478,7 +548,7 @@ export async function SourcingCoverageContent() {
                         <td className="text-right py-2 px-3 tabular-nums text-muted-foreground">
                           {t.totalRecords.toLocaleString()}
                         </td>
-                        <td colSpan={4} className="text-center py-2 px-3 text-xs text-muted-foreground italic">
+                        <td colSpan={6} className="text-center py-2 px-3 text-xs text-muted-foreground italic">
                           Not subject to sourcing verification
                         </td>
                       </tr>
@@ -497,11 +567,20 @@ export async function SourcingCoverageContent() {
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.totalRecords.toLocaleString()}
                   </td>
-                  <td colSpan={2} className="text-right py-2 px-3 tabular-nums">
+                  <td className="text-right py-2 px-3 tabular-nums">
+                    {coverageMatrix.totals.checkableRecords.toLocaleString()}
+                  </td>
+                  <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.totalVerdicts.toLocaleString()} verdicts
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.coveragePercent}%
+                    {coverageMatrix.totals.checkabilityPercent}%
+                  </td>
+                  <td className="text-right py-2 px-3 tabular-nums">
+                    {coverageMatrix.totals.checkableCoveragePercent}%
+                  </td>
+                  <td className="text-right py-2 px-3 tabular-nums">
+                    {coverageMatrix.totals.fullCoveragePercent}%
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.confirmedPercent}%

--- a/apps/wiki-server/package.json
+++ b/apps/wiki-server/package.json
@@ -22,6 +22,7 @@
     "hono": "^4.12.4",
     "pino": "^10.3.1",
     "postgres": "^3.4.5",
+    "yaml": "^2.7.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/wiki-server/src/__tests__/property-metadata.test.ts
+++ b/apps/wiki-server/src/__tests__/property-metadata.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the property-metadata helper that backs the QUA-928 coverage
+ * refactor. The helper reads `packages/factbase/data/properties.yaml` once
+ * at startup and returns the set of properties marked `verifiable: false`.
+ *
+ * The coverage endpoints use this set to compute `checkableRecords` for the
+ * `fact` recordType, so a regression here silently corrupts the gate metric.
+ * These tests pin (a) that the read succeeds against the workspace YAML and
+ * (b) that the well-known non-verifiable properties are present — both as a
+ * smoke test for the loader and as a tripwire if someone drops a property
+ * from `properties.yaml` without bumping the gate.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  getNonVerifiablePropertyIds,
+  _resetPropertyMetadataCache,
+} from "../property-metadata";
+
+describe("getNonVerifiablePropertyIds", () => {
+  it("loads the non-verifiable property IDs from properties.yaml", () => {
+    _resetPropertyMetadataCache();
+    const ids = getNonVerifiablePropertyIds();
+    expect(ids.size).toBeGreaterThan(0);
+  });
+
+  it("includes the well-known social-media + wikipedia + estimate properties", () => {
+    _resetPropertyMetadataCache();
+    const ids = getNonVerifiablePropertyIds();
+    // These three families are the canonical reasons a property is flagged
+    // verifiable:false:
+    //   1. self-referential URLs (`wikipedia-url`, `social-media`)
+    //   2. third-party-blocking handles (`twitter-handle`/`x-handle`)
+    //   3. unsourced estimates (`safety-staffing-ratio`, `equity-stake-percent`)
+    // Pick one canonical member of each family — losing any of these to a
+    // YAML edit would silently expand the "checkable" set and break the gate.
+    expect(ids.has("wikipedia-url")).toBe(true);
+    expect(ids.has("social-media")).toBe(true);
+    expect(ids.has("safety-staffing-ratio")).toBe(true);
+  });
+
+  it("does NOT include verifiable properties", () => {
+    _resetPropertyMetadataCache();
+    const ids = getNonVerifiablePropertyIds();
+    // Spot-check: revenue is an authored, verifiable financial property.
+    expect(ids.has("revenue")).toBe(false);
+    expect(ids.has("ceo")).toBe(false);
+  });
+
+  it("caches the parsed set across calls", () => {
+    _resetPropertyMetadataCache();
+    const a = getNonVerifiablePropertyIds();
+    const b = getNonVerifiablePropertyIds();
+    // Identity equality, not just deep equality — second call is a cache hit.
+    expect(a).toBe(b);
+  });
+});

--- a/apps/wiki-server/src/__tests__/property-metadata.test.ts
+++ b/apps/wiki-server/src/__tests__/property-metadata.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from "vitest";
 import {
   getNonVerifiablePropertyIds,
+  parseNonVerifiablePropertyIds,
   _resetPropertyMetadataCache,
 } from "../property-metadata";
 
@@ -52,5 +53,72 @@ describe("getNonVerifiablePropertyIds", () => {
     const b = getNonVerifiablePropertyIds();
     // Identity equality, not just deep equality — second call is a cache hit.
     expect(a).toBe(b);
+  });
+});
+
+describe("parseNonVerifiablePropertyIds — adversarial inputs", () => {
+  it("returns the verifiable:false IDs for a well-formed map", () => {
+    const ids = parseNonVerifiablePropertyIds(`
+properties:
+  good-prop:
+    verifiable: true
+  bad-prop:
+    verifiable: false
+  silent-prop: {}
+`);
+    expect([...ids]).toEqual(["bad-prop"]);
+  });
+
+  it("treats an entirely empty file as zero non-verifiable properties", () => {
+    expect(parseNonVerifiablePropertyIds("")).toEqual(new Set());
+    expect(parseNonVerifiablePropertyIds("properties: {}")).toEqual(new Set());
+  });
+
+  // Scalar root → reject with a clear message. A YAML with `properties: false`
+  // at the root or a bare `42` would otherwise silently parse to garbage.
+  it("throws when the YAML root is not an object", () => {
+    expect(() => parseNonVerifiablePropertyIds("42")).toThrow(/expected an object at the root/);
+    expect(() => parseNonVerifiablePropertyIds('"a string"')).toThrow(/expected an object/);
+    expect(() => parseNonVerifiablePropertyIds("- list\n- items")).toThrow(/expected an object/);
+  });
+
+  it("throws when `properties` is present but not a map", () => {
+    expect(() => parseNonVerifiablePropertyIds("properties: oops")).toThrow(
+      /must be a map/,
+    );
+    expect(() =>
+      parseNonVerifiablePropertyIds("properties:\n  - bad\n  - shape"),
+    ).toThrow(/must be a map/);
+  });
+
+  it("ignores property entries that aren't objects (no crash)", () => {
+    // YAML where a property's value is a string/null instead of a map.
+    // Before validation this would have crashed on `def.verifiable === false`.
+    const ids = parseNonVerifiablePropertyIds(`
+properties:
+  bare-string: just a name
+  null-prop: ~
+  real-prop:
+    verifiable: false
+`);
+    expect([...ids]).toEqual(["real-prop"]);
+  });
+
+  it("requires verifiable === false (truthy/missing/null all keep the prop)", () => {
+    const ids = parseNonVerifiablePropertyIds(`
+properties:
+  verifiable-true:
+    verifiable: true
+  verifiable-missing: {}
+  verifiable-null:
+    verifiable: ~
+  verifiable-zero:
+    verifiable: 0
+  the-real-one:
+    verifiable: false
+`);
+    // Only strict false should make it into the non-verifiable set —
+    // null / missing / 0 are all kept as checkable.
+    expect([...ids]).toEqual(["the-real-one"]);
   });
 });

--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -128,9 +128,12 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
 
   it("returns the new checkability fields for the fact recordType", async () => {
     // Mirror the prod numbers from the QUA-928 description: 2,744 total
-    // facts, ~1,834 checkable, ~1,816 actually checked.
+    // facts, ~1,834 checkable, ~1,816 actually checked. The new strict-
+    // checked count (excluding 'unchecked' + 'not_applicable') drives the
+    // new percentages; `verified` is kept only for the legacy `percentage`.
     tableTotals = [{ table_name: "fact", total: 2744 }];
     verifiedCounts = [{ record_type: "fact", verified: 1816 }];
+    checkedCounts = [{ record_type: "fact", checked_records: 1816 }];
     checkableFacts = 1834;
 
     const res = await app.request("/api/sourcing/coverage");
@@ -158,6 +161,10 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
       { record_type: "grant", verified: 5873 },
       { record_type: "personnel", verified: 1124 },
     ];
+    checkedCounts = [
+      { record_type: "grant", checked_records: 5873 },
+      { record_type: "personnel", checked_records: 1124 },
+    ];
     checkableFacts = 0; // no facts in this test
 
     const res = await app.request("/api/sourcing/coverage");
@@ -178,6 +185,7 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
   it("guards against divide-by-zero for empty tables", async () => {
     tableTotals = [{ table_name: "wiki-page", total: 0 }];
     verifiedCounts = [];
+    checkedCounts = [];
     checkableFacts = 0;
 
     const res = await app.request("/api/sourcing/coverage");
@@ -197,6 +205,7 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     // checkable must not exceed total — that would push percentages > 100%.
     tableTotals = [{ table_name: "fact", total: 100 }];
     verifiedCounts = [{ record_type: "fact", verified: 80 }];
+    checkedCounts = [{ record_type: "fact", checked_records: 80 }];
     checkableFacts = 105; // stale; higher than current total
 
     const res = await app.request("/api/sourcing/coverage");
@@ -206,6 +215,65 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
     expect(fact!.total).toBe(100);
     expect(fact!.checkable).toBe(100);
     expect(fact!.checkabilityPercent).toBe(100);
+  });
+
+  it("clamps the numerator so percentages cannot exceed 100% under race conditions", async () => {
+    // Race: a verdict still exists for a record whose property was just
+    // flipped from `verifiable: true` to `verifiable: false`, so
+    // `checked_records > checkable`. Without the clamp,
+    // `checkableCoveragePercent` would render as e.g. 105%, looking like
+    // a bug. The clamp inside coveragePercents() caps it at 100.
+    tableTotals = [{ table_name: "fact", total: 100 }];
+    verifiedCounts = [{ record_type: "fact", verified: 95 }];
+    checkedCounts = [{ record_type: "fact", checked_records: 90 }];
+    checkableFacts = 80; // intentionally lower than checked_records
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const fact = body.coverage.find((r) => r.recordType === "fact");
+
+    expect(fact!.checkable).toBe(80);
+    // Without the clamp this would be 90/80 = 112.5%
+    expect(fact!.checkableCoveragePercent).toBe(100);
+    // fullCoveragePercent is checked / total but the clamp pulls checked
+    // down to 80 too, so it lands at 80% (matches the cap on numerator).
+    expect(fact!.fullCoveragePercent).toBe(80);
+    expect(fact!.fullCoveragePercent).toBeLessThanOrEqual(100);
+  });
+
+  it("never reports `checkableCoveragePercent` numbers that disagree between /coverage and /coverage-matrix", async () => {
+    // Pin the cross-endpoint consistency contract: same recordType, same
+    // input data, same percentage value on both endpoints. Under the bug
+    // /coverage used `verified` (which counts unchecked rows) and
+    // /coverage-matrix used the strict `checked_records`, producing
+    // different numbers under the same field name.
+    tableTotals = [{ table_name: "fact", total: 100 }];
+    verifiedCounts = [{ record_type: "fact", verified: 90 }]; // includes 'unchecked'
+    checkedCounts = [{ record_type: "fact", checked_records: 70 }]; // strict
+    checkableFacts = 80;
+
+    const coverageRes = await app.request("/api/sourcing/coverage");
+    const coverageBody = (await coverageRes.json()) as CoverageResponse;
+    const coverageFact = coverageBody.coverage.find(
+      (r) => r.recordType === "fact",
+    );
+
+    // Reset for the matrix call (handlers share dispatch but query
+    // shapes differ — same canned data drives both).
+    tableTotals = [{ record_type: "fact", total: 100 }];
+    checkedCounts = [{ record_type: "fact", checked_records: 70 }];
+    verdictRows = [];
+    checkableFacts = 80;
+
+    const matrixRes = await app.request("/api/sourcing/coverage-matrix");
+    const matrixBody = (await matrixRes.json()) as MatrixResponse;
+    const matrixFact = matrixBody.tables.find((t) => t.recordType === "fact");
+
+    expect(coverageFact!.checkableCoveragePercent).toBe(
+      matrixFact!.checkableCoveragePercent,
+    );
+    expect(coverageFact!.fullCoveragePercent).toBe(matrixFact!.fullCoveragePercent);
+    expect(coverageFact!.checkabilityPercent).toBe(matrixFact!.checkabilityPercent);
   });
 
   it("never emits a `coveragePercent` field — the ambiguous name is removed", async () => {

--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for the QUA-928 coverage-metric refactor.
+ *
+ * The /coverage and /coverage-matrix endpoints now expose three explicit
+ * percentages instead of a single ambiguous `coveragePercent`:
+ *
+ *   - checkabilityPercent       = checkable / total
+ *   - checkableCoveragePercent  = checked   / checkable
+ *   - fullCoveragePercent       = checked   / total
+ *
+ * The split distinguishes authoring quality (do facts have sources, are their
+ * properties verifiable?) from verification quality (of the eligible records,
+ * how many have a verdict?). The all-facts denominator was mathematically
+ * unreachable for facts because ~33% are excluded by collector design, so the
+ * QUA-852 enforcement gate now references `checkableCoveragePercent` rather
+ * than the joint metric.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { type SqlDispatcher, mockDbModule } from "./test-utils";
+
+let capturedQueries: string[] = [];
+
+let tableTotals: Array<{ table_name?: string; record_type?: string; total: number }> = [];
+let verifiedCounts: Array<{ record_type: string; verified: number }> = [];
+let checkedCounts: Array<{ record_type: string; checked_records: number }> = [];
+let verdictRows: Array<{ record_type: string; verdict: string; cnt: number }> = [];
+let checkableFacts = 0;
+
+const dispatch: SqlDispatcher = (query, _params) => {
+  capturedQueries.push(query);
+
+  // Order matters: the LIVE_RECORDS_CTE for the matrix queries also contains
+  // `AS record_type` inside its CTE body, so the union-totals patterns must
+  // be guarded by "no leading WITH" / a specific shape from the SELECT line.
+  const hasCte = /^\s*WITH\s+live_records/i.test(query);
+
+  // QUA-928 checkable-facts query — distinct fact_ids with source filter.
+  if (!hasCte && /FROM\s+facts/i.test(query) && /AS\s+checkable\b/i.test(query)) {
+    return [{ checkable: checkableFacts }];
+  }
+  // /coverage UNION ALL totals — column alias is `table_name`.
+  if (!hasCte && /UNION ALL/i.test(query) && /AS\s+table_name/i.test(query)) {
+    return tableTotals.map((r) => ({ table_name: r.table_name, total: r.total }));
+  }
+  // /coverage-matrix UNION ALL totals — column alias is `record_type` AND the
+  // outer query also selects `count(*)::int AS total`. The CTE has `id::text AS record_id`
+  // (no `AS total`), so the `AS total` distinguishes them.
+  if (!hasCte && /UNION ALL/i.test(query) && /AS\s+record_type/i.test(query) && /AS\s+total/i.test(query)) {
+    return tableTotals.map((r) => ({ record_type: r.record_type, total: r.total }));
+  }
+  // /coverage-matrix verdict row counts: `count(*) AS cnt`, GROUP BY (record_type, verdict).
+  if (hasCte && /AS\s+cnt\b/i.test(query) && /GROUP\s+BY\s+v\.record_type\s*,\s*v\.verdict/i.test(query)) {
+    return verdictRows;
+  }
+  // /coverage-matrix checked-records: `AS checked_records`.
+  if (hasCte && /AS\s+checked_records\b/i.test(query)) {
+    return checkedCounts;
+  }
+  // /coverage verified count: `AS verified`.
+  if (hasCte && /AS\s+verified\b/i.test(query)) {
+    return verifiedCounts;
+  }
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+interface CoverageRow {
+  recordType: string;
+  total: number;
+  checkable: number;
+  verified: number;
+  percentage: number;
+  checkabilityPercent: number;
+  checkableCoveragePercent: number;
+  fullCoveragePercent: number;
+  exempt: boolean;
+}
+
+interface CoverageResponse {
+  coverage: CoverageRow[];
+  exemptTypes: string[];
+}
+
+interface MatrixRow {
+  recordType: string;
+  totalRecords: number;
+  checkableRecords: number;
+  checkedRecords: number;
+  verdicts: Record<string, number>;
+  checkabilityPercent: number;
+  checkableCoveragePercent: number;
+  fullCoveragePercent: number;
+  greenPercent: number;
+  exempt: boolean;
+}
+
+interface MatrixResponse {
+  tables: MatrixRow[];
+  totals: {
+    totalRecords: number;
+    checkableRecords: number;
+    totalVerdicts: number;
+    confirmedPercent: number;
+    checkabilityPercent: number;
+    checkableCoveragePercent: number;
+    fullCoveragePercent: number;
+  };
+  exemptTypes: string[];
+}
+
+describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    tableTotals = [];
+    verifiedCounts = [];
+    checkedCounts = [];
+    verdictRows = [];
+    checkableFacts = 0;
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("returns the new checkability fields for the fact recordType", async () => {
+    // Mirror the prod numbers from the QUA-928 description: 2,744 total
+    // facts, ~1,834 checkable, ~1,816 actually checked.
+    tableTotals = [{ table_name: "fact", total: 2744 }];
+    verifiedCounts = [{ record_type: "fact", verified: 1816 }];
+    checkableFacts = 1834;
+
+    const res = await app.request("/api/sourcing/coverage");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as CoverageResponse;
+    const fact = body.coverage.find((r) => r.recordType === "fact");
+
+    expect(fact).toBeDefined();
+    expect(fact!.total).toBe(2744);
+    expect(fact!.checkable).toBe(1834);
+    expect(fact!.verified).toBe(1816);
+
+    // Three explicit percentages, all rounded to one decimal.
+    expect(fact!.checkabilityPercent).toBeCloseTo(66.8, 1);
+    expect(fact!.checkableCoveragePercent).toBeCloseTo(99.0, 1);
+    expect(fact!.fullCoveragePercent).toBeCloseTo(66.2, 1);
+  });
+
+  it("treats non-fact recordTypes as fully checkable (checkable == total)", async () => {
+    tableTotals = [
+      { table_name: "grant", total: 5876 },
+      { table_name: "personnel", total: 1699 },
+    ];
+    verifiedCounts = [
+      { record_type: "grant", verified: 5873 },
+      { record_type: "personnel", verified: 1124 },
+    ];
+    checkableFacts = 0; // no facts in this test
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+
+    const grant = body.coverage.find((r) => r.recordType === "grant");
+    const personnel = body.coverage.find((r) => r.recordType === "personnel");
+
+    expect(grant!.checkable).toBe(5876);
+    expect(grant!.checkabilityPercent).toBe(100);
+    expect(grant!.checkableCoveragePercent).toBeCloseTo(99.9, 1);
+
+    expect(personnel!.checkable).toBe(1699);
+    expect(personnel!.checkabilityPercent).toBe(100);
+    expect(personnel!.checkableCoveragePercent).toBeCloseTo(66.2, 1);
+  });
+
+  it("guards against divide-by-zero for empty tables", async () => {
+    tableTotals = [{ table_name: "wiki-page", total: 0 }];
+    verifiedCounts = [];
+    checkableFacts = 0;
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const wikiPage = body.coverage.find((r) => r.recordType === "wiki-page");
+
+    expect(wikiPage!.total).toBe(0);
+    expect(wikiPage!.checkable).toBe(0);
+    expect(wikiPage!.checkabilityPercent).toBe(0);
+    expect(wikiPage!.checkableCoveragePercent).toBe(0);
+    expect(wikiPage!.fullCoveragePercent).toBe(0);
+  });
+
+  it("clamps checkable facts to total when the helper returns a stale count", async () => {
+    // Defensive: if countCheckableFacts() races ahead of the table count
+    // (e.g. a fact was deleted between the two queries), the row-level
+    // checkable must not exceed total — that would push percentages > 100%.
+    tableTotals = [{ table_name: "fact", total: 100 }];
+    verifiedCounts = [{ record_type: "fact", verified: 80 }];
+    checkableFacts = 105; // stale; higher than current total
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const fact = body.coverage.find((r) => r.recordType === "fact");
+
+    expect(fact!.total).toBe(100);
+    expect(fact!.checkable).toBe(100);
+    expect(fact!.checkabilityPercent).toBe(100);
+  });
+
+  it("never emits a `coveragePercent` field — the ambiguous name is removed", async () => {
+    tableTotals = [{ table_name: "grant", total: 100 }];
+    verifiedCounts = [{ record_type: "grant", verified: 80 }];
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const grant = body.coverage.find((r) => r.recordType === "grant");
+
+    expect(grant).toBeDefined();
+    expect(grant! as unknown as Record<string, unknown>).not.toHaveProperty(
+      "coveragePercent",
+    );
+  });
+
+  it("preserves the legacy `percentage` field for backwards-compat callers", async () => {
+    // CoverageBars and EntitySourcingViewer still consume `percentage`.
+    // Removing it would break those surfaces; the new explicit *Percent
+    // fields are added alongside, not in place of, this legacy alias.
+    tableTotals = [{ table_name: "grant", total: 100 }];
+    verifiedCounts = [{ record_type: "grant", verified: 80 }];
+
+    const res = await app.request("/api/sourcing/coverage");
+    const body = (await res.json()) as CoverageResponse;
+    const grant = body.coverage.find((r) => r.recordType === "grant");
+
+    expect(grant!.percentage).toBe(80);
+  });
+
+  it("scopes the checkable-facts query to verifiable properties", async () => {
+    // Sanity check: the SQL must actually filter the fact set rather than
+    // count everything. If the WHERE clause is dropped, the metric becomes
+    // a copy of `total` and the gate loses its meaning.
+    tableTotals = [{ table_name: "fact", total: 100 }];
+    verifiedCounts = [];
+
+    await app.request("/api/sourcing/coverage");
+
+    const checkableQuery = capturedQueries.find(
+      (q) => /FROM\s+facts/i.test(q) && /AS\s+checkable/i.test(q),
+    );
+    expect(
+      checkableQuery,
+      "expected a dedicated query that scopes facts to checkable subset",
+    ).toBeDefined();
+    expect(/source\s+IS\s+NOT\s+NULL/i.test(checkableQuery!)).toBe(true);
+    expect(/measure\s*=\s*ANY/i.test(checkableQuery!)).toBe(true);
+  });
+});
+
+describe("QUA-928: GET /api/sourcing/coverage-matrix — checkability split", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    tableTotals = [];
+    verifiedCounts = [];
+    checkedCounts = [];
+    verdictRows = [];
+    checkableFacts = 0;
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  it("emits per-row checkable fields and grand totals matching the gate semantics", async () => {
+    tableTotals = [
+      { record_type: "fact", total: 2744 },
+      { record_type: "grant", total: 5876 },
+      { record_type: "citation", total: 3490 }, // exempt — see SOURCING_EXEMPT_TYPES
+    ];
+    checkedCounts = [
+      { record_type: "fact", checked_records: 1816 },
+      { record_type: "grant", checked_records: 5873 },
+    ];
+    verdictRows = [
+      { record_type: "fact", verdict: "confirmed", cnt: 1150 },
+      { record_type: "grant", verdict: "confirmed", cnt: 4906 },
+    ];
+    checkableFacts = 1834;
+
+    const res = await app.request("/api/sourcing/coverage-matrix");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as MatrixResponse;
+
+    const fact = body.tables.find((t) => t.recordType === "fact");
+    expect(fact!.checkableRecords).toBe(1834);
+    expect(fact!.checkabilityPercent).toBeCloseTo(66.8, 1);
+    expect(fact!.checkableCoveragePercent).toBeCloseTo(99.0, 1);
+    expect(fact!.fullCoveragePercent).toBeCloseTo(66.2, 1);
+
+    const grant = body.tables.find((t) => t.recordType === "grant");
+    expect(grant!.checkableRecords).toBe(5876);
+    expect(grant!.checkabilityPercent).toBe(100);
+    expect(grant!.checkableCoveragePercent).toBeCloseTo(99.9, 1);
+
+    // Grand totals exclude the exempt wiki-page rows.
+    expect(body.totals.totalRecords).toBe(2744 + 5876);
+    expect(body.totals.checkableRecords).toBe(1834 + 5876);
+    expect(body.totals.checkableCoveragePercent).toBeCloseTo(
+      ((1816 + 5873) / (1834 + 5876)) * 100,
+      1,
+    );
+  });
+
+  it("removes the ambiguous `coveragePercent` field from every row and the totals block", async () => {
+    tableTotals = [{ record_type: "fact", total: 2744 }];
+    checkedCounts = [{ record_type: "fact", checked_records: 1816 }];
+    verdictRows = [];
+    checkableFacts = 1834;
+
+    const res = await app.request("/api/sourcing/coverage-matrix");
+    const body = (await res.json()) as MatrixResponse;
+
+    const fact = body.tables.find((t) => t.recordType === "fact")!;
+    expect(fact as unknown as Record<string, unknown>).not.toHaveProperty(
+      "coveragePercent",
+    );
+    expect(body.totals as unknown as Record<string, unknown>).not.toHaveProperty(
+      "coveragePercent",
+    );
+  });
+
+  it("returns zero for every percentage when total = 0 (no NaN, no Infinity)", async () => {
+    tableTotals = [{ record_type: "fact", total: 0 }];
+    checkedCounts = [];
+    verdictRows = [];
+    checkableFacts = 0;
+
+    const res = await app.request("/api/sourcing/coverage-matrix");
+    const body = (await res.json()) as MatrixResponse;
+    const fact = body.tables.find((t) => t.recordType === "fact");
+
+    expect(fact!.totalRecords).toBe(0);
+    expect(fact!.checkableRecords).toBe(0);
+    expect(fact!.checkabilityPercent).toBe(0);
+    expect(fact!.checkableCoveragePercent).toBe(0);
+    expect(fact!.fullCoveragePercent).toBe(0);
+    expect(Number.isFinite(fact!.checkabilityPercent)).toBe(true);
+  });
+
+  it("treats non-fact recordTypes as fully checkable in the matrix", async () => {
+    tableTotals = [{ record_type: "personnel", total: 1699 }];
+    checkedCounts = [{ record_type: "personnel", checked_records: 1124 }];
+    verdictRows = [];
+    checkableFacts = 0;
+
+    const res = await app.request("/api/sourcing/coverage-matrix");
+    const body = (await res.json()) as MatrixResponse;
+    const personnel = body.tables.find((t) => t.recordType === "personnel");
+
+    expect(personnel!.checkableRecords).toBe(1699);
+    expect(personnel!.checkabilityPercent).toBe(100);
+    expect(personnel!.checkableCoveragePercent).toBeCloseTo(66.2, 1);
+    expect(personnel!.fullCoveragePercent).toBeCloseTo(66.2, 1);
+  });
+});

--- a/apps/wiki-server/src/index.ts
+++ b/apps/wiki-server/src/index.ts
@@ -3,6 +3,7 @@ import { createApp } from "./app.js";
 import { initDb, closeDb } from "./db.js";
 import { logger } from "./logger.js";
 import { setMigrationError } from "./migration-state.js";
+import { getNonVerifiablePropertyIds } from "./property-metadata.js";
 
 const PORT = parseInt(process.env.PORT || "3100", 10);
 
@@ -31,6 +32,20 @@ async function main() {
         "Fix the migration issue and restart the pod."
       );
     }
+  }
+
+  // QUA-928: prime the property-metadata cache so a missing or malformed
+  // properties.yaml fails the boot rather than the first /api/sourcing/*
+  // request hours later. Coverage metrics depend on this set.
+  try {
+    const count = getNonVerifiablePropertyIds().size;
+    logger.info({ nonVerifiableProperties: count }, "Loaded property metadata");
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to load properties.yaml — sourcing coverage metrics will be wrong",
+    );
+    throw err;
   }
 
   const app = createApp();

--- a/apps/wiki-server/src/property-metadata.ts
+++ b/apps/wiki-server/src/property-metadata.ts
@@ -38,20 +38,19 @@ function isObject(x: unknown): x is Record<string, unknown> {
 }
 
 /**
- * Returns the set of property IDs that are marked `verifiable: false` in
- * `properties.yaml`. Throws if the file can't be read or parsed — these are
- * load-bearing for sourcing coverage metrics, so a silent empty set would
- * skew dashboards.
- *
- * Read once on first call and cached for the lifetime of the process. Call
- * site is also reachable at server boot (see `index.ts`) so that a missing
- * or malformed file fails the deploy rather than the first request.
+ * Parse the `verifiable: false` property IDs out of a YAML string. Pure
+ * function — exported only for unit tests covering malformed YAML
+ * (`getNonVerifiablePropertyIds` reads the canonical workspace file and is
+ * harder to exercise with adversarial inputs).
  */
-export function getNonVerifiablePropertyIds(): ReadonlySet<string> {
-  if (cachedNonVerifiable !== null) return cachedNonVerifiable;
-
-  const raw = readFileSync(PROPERTIES_YAML_PATH, "utf-8");
-  const parsed = parseYaml(raw);
+export function parseNonVerifiablePropertyIds(yamlText: string): Set<string> {
+  const parsed = parseYaml(yamlText);
+  // Empty file or `~`/`null` → no properties at all. Treat as zero
+  // non-verifiable properties rather than an error: the production file
+  // is populated, but a future minimal-config setup shouldn't fail boot.
+  if (parsed === null || parsed === undefined) {
+    return new Set();
+  }
   if (!isObject(parsed)) {
     throw new Error(
       `properties.yaml: expected an object at the root, got ${typeof parsed}`,
@@ -67,8 +66,24 @@ export function getNonVerifiablePropertyIds(): ReadonlySet<string> {
   for (const [id, def] of Object.entries(properties ?? {})) {
     if (isObject(def) && def.verifiable === false) ids.add(id);
   }
-  cachedNonVerifiable = ids;
   return ids;
+}
+
+/**
+ * Returns the set of property IDs that are marked `verifiable: false` in
+ * `properties.yaml`. Throws if the file can't be read or parsed — these are
+ * load-bearing for sourcing coverage metrics, so a silent empty set would
+ * skew dashboards.
+ *
+ * Read once on first call and cached for the lifetime of the process. Call
+ * site is also reachable at server boot (see `index.ts`) so that a missing
+ * or malformed file fails the deploy rather than the first request.
+ */
+export function getNonVerifiablePropertyIds(): ReadonlySet<string> {
+  if (cachedNonVerifiable !== null) return cachedNonVerifiable;
+  const raw = readFileSync(PROPERTIES_YAML_PATH, "utf-8");
+  cachedNonVerifiable = parseNonVerifiablePropertyIds(raw);
+  return cachedNonVerifiable;
 }
 
 /**

--- a/apps/wiki-server/src/property-metadata.ts
+++ b/apps/wiki-server/src/property-metadata.ts
@@ -31,26 +31,41 @@ const PROPERTIES_YAML_PATH = resolve(
   "../../../packages/factbase/data/properties.yaml",
 );
 
-interface PropertiesFile {
-  properties?: Record<string, { verifiable?: boolean }>;
-}
-
 let cachedNonVerifiable: ReadonlySet<string> | null = null;
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
 
 /**
  * Returns the set of property IDs that are marked `verifiable: false` in
  * `properties.yaml`. Throws if the file can't be read or parsed — these are
  * load-bearing for sourcing coverage metrics, so a silent empty set would
  * skew dashboards.
+ *
+ * Read once on first call and cached for the lifetime of the process. Call
+ * site is also reachable at server boot (see `index.ts`) so that a missing
+ * or malformed file fails the deploy rather than the first request.
  */
 export function getNonVerifiablePropertyIds(): ReadonlySet<string> {
   if (cachedNonVerifiable !== null) return cachedNonVerifiable;
 
   const raw = readFileSync(PROPERTIES_YAML_PATH, "utf-8");
-  const parsed = parseYaml(raw) as PropertiesFile;
+  const parsed = parseYaml(raw);
+  if (!isObject(parsed)) {
+    throw new Error(
+      `properties.yaml: expected an object at the root, got ${typeof parsed}`,
+    );
+  }
+  const properties = parsed.properties;
+  if (properties !== undefined && !isObject(properties)) {
+    throw new Error(
+      `properties.yaml: \`properties\` must be a map, got ${typeof properties}`,
+    );
+  }
   const ids = new Set<string>();
-  for (const [id, def] of Object.entries(parsed.properties ?? {})) {
-    if (def.verifiable === false) ids.add(id);
+  for (const [id, def] of Object.entries(properties ?? {})) {
+    if (isObject(def) && def.verifiable === false) ids.add(id);
   }
   cachedNonVerifiable = ids;
   return ids;

--- a/apps/wiki-server/src/property-metadata.ts
+++ b/apps/wiki-server/src/property-metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * Loads metadata about FactBase properties from
+ * `packages/factbase/data/properties.yaml`.
+ *
+ * Currently surfaces only the `verifiable: false` flag, which the sourcing
+ * coverage endpoints (QUA-928) need to compute the "checkable" subset of facts
+ * — properties marked `verifiable: false` are excluded by design from the
+ * sourcing pipeline (e.g. social-media handles, self-referential URLs,
+ * unsourced estimates), so coverage against the all-facts denominator is
+ * mathematically unreachable and the dashboard splits the metric in two:
+ * `checkabilityPercent` and `checkableCoveragePercent`.
+ *
+ * Read once at first call and cached for the lifetime of the process.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Path to properties.yaml. From `apps/wiki-server/src/property-metadata.ts`,
+ * walk three levels up to the repo root, then descend into the factbase data
+ * dir. Works in both dev (workspace) and Docker (`/repo` layout — see
+ * `apps/wiki-server/Dockerfile`).
+ */
+const PROPERTIES_YAML_PATH = resolve(
+  __dirname,
+  "../../../packages/factbase/data/properties.yaml",
+);
+
+interface PropertiesFile {
+  properties?: Record<string, { verifiable?: boolean }>;
+}
+
+let cachedNonVerifiable: ReadonlySet<string> | null = null;
+
+/**
+ * Returns the set of property IDs that are marked `verifiable: false` in
+ * `properties.yaml`. Throws if the file can't be read or parsed — these are
+ * load-bearing for sourcing coverage metrics, so a silent empty set would
+ * skew dashboards.
+ */
+export function getNonVerifiablePropertyIds(): ReadonlySet<string> {
+  if (cachedNonVerifiable !== null) return cachedNonVerifiable;
+
+  const raw = readFileSync(PROPERTIES_YAML_PATH, "utf-8");
+  const parsed = parseYaml(raw) as PropertiesFile;
+  const ids = new Set<string>();
+  for (const [id, def] of Object.entries(parsed.properties ?? {})) {
+    if (def.verifiable === false) ids.add(id);
+  }
+  cachedNonVerifiable = ids;
+  return ids;
+}
+
+/**
+ * Test seam — reset the cache so a different yaml path or content can be
+ * exercised. Not exported from production code paths.
+ */
+export function _resetPropertyMetadataCache(): void {
+  cachedNonVerifiable = null;
+}

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -46,6 +46,7 @@ import {
   SOURCING_EXEMPT_TYPES,
   isSourcingExempt,
 } from "../../api-types.js";
+import { getNonVerifiablePropertyIds } from "../../property-metadata.js";
 import { coerceDisplayName } from "../shared/display-name-coerce.js";
 import {
   recomputeVerdict,
@@ -105,6 +106,53 @@ const VALID_VERDICT_TYPES = [...VALID_VERDICTS, "unchecked"] as const;
  */
 export const CURRENT_CHECKER_MODEL = "claude-haiku-4-5-20251001";
 export const DEAD_LINK_CHECKER_MODEL = "dead-link-detector";
+
+// ---- Coverage helpers (QUA-928) ----
+
+/**
+ * Round to one decimal place — used for percent values returned by the
+ * coverage endpoints. Centralised so all three percentages
+ * (`checkabilityPercent`, `checkableCoveragePercent`, `fullCoveragePercent`)
+ * share rounding behavior.
+ */
+function pct1(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+/**
+ * Count facts that are eligible for sourcing verification. Mirrors the inclusion
+ * logic in `crux/lib/sourcing/item-collectors.ts::collectFactItems`:
+ * facts must carry a source URL AND their property must not be flagged
+ * `verifiable: false` in properties.yaml. The set of non-verifiable
+ * property IDs is read from `properties.yaml` once at startup.
+ */
+async function countCheckableFacts(
+  db: ReturnType<typeof getDrizzleDb>,
+): Promise<number> {
+  const nonVerifiable = [...getNonVerifiablePropertyIds()];
+  const rows = (await db.execute(sql`
+    SELECT count(DISTINCT fact_id)::int AS checkable
+    FROM facts
+    WHERE source IS NOT NULL
+      AND (measure IS NULL OR NOT (measure = ANY(${nonVerifiable}::text[])))
+  `)) as Array<{ checkable: number | null }>;
+  return rows[0]?.checkable ?? 0;
+}
+
+/**
+ * For a given recordType, return the number of records that are eligible for
+ * sourcing. Currently only the `fact` recordType has per-record
+ * exclusion criteria; everything else is treated as fully checkable.
+ */
+function checkableCountFor(
+  recordType: string,
+  totalRecords: number,
+  checkableFacts: number,
+): number {
+  if (recordType === "fact") return Math.min(checkableFacts, totalRecords);
+  return totalRecords;
+}
 
 // ---- Shared CTE ----
 
@@ -1976,6 +2024,14 @@ const sourcingApp = new Hono()
       }
     }
 
+    // QUA-928: count "checkable" facts — those eligible for sourcing by
+    // collector design. A fact is checkable when it carries a source URL AND
+    // its property is not flagged `verifiable: false` in properties.yaml
+    // (e.g. social-media handles, wikipedia-url self-references, unsourced
+    // estimates). Non-fact record types have no per-record exclusion logic
+    // upstream, so checkable == total for them.
+    const checkableFactsCount = await countCheckableFacts(db);
+
     // Count distinct verified records per record_type from source_check_verdicts.
     //
     // QUA-422: INNER JOIN against LIVE_RECORDS_CTE to exclude orphan verdicts
@@ -2020,10 +2076,25 @@ const sourcingApp = new Hono()
       .map((recordType) => {
         const total = totalsByType[recordType] ?? 0;
         const verified = verifiedByType[recordType] ?? 0;
+        const checkable = checkableCountFor(recordType, total, checkableFactsCount);
         const exempt = isSourcingExempt(recordType);
+        // `percentage` retains its legacy semantics (verified / total, where
+        // "verified" includes verdict='unchecked') for the existing callers
+        // (`CoverageBars`, `EntitySourcingViewer`). New callers should consume
+        // the explicit `*Percent` fields below — see QUA-928.
         const percentage =
           total > 0 ? Math.round((verified / total) * 10000) / 100 : 0;
-        return { recordType, total, verified, percentage, exempt };
+        return {
+          recordType,
+          total,
+          checkable,
+          verified,
+          percentage,
+          checkabilityPercent: pct1(checkable, total),
+          checkableCoveragePercent: pct1(verified, checkable),
+          fullCoveragePercent: pct1(verified, total),
+          exempt,
+        };
       })
       .sort((a, b) => a.recordType.localeCompare(b.recordType));
 
@@ -2295,6 +2366,10 @@ const sourcingApp = new Hono()
       verdictsByType[row.record_type][row.verdict] = row.cnt;
     }
 
+    // QUA-928: count checkable facts (the only recordType with per-record
+    // exclusion logic — see countCheckableFacts above).
+    const checkableFactsCount = await countCheckableFacts(db);
+
     // 4. Merge into tables array
     const allTypes = new Set([
       ...Object.keys(totalsByType),
@@ -2303,6 +2378,7 @@ const sourcingApp = new Hono()
 
     // Grand totals exclude exempt types — they don't participate in coverage metrics
     let grandTotalRecords = 0;
+    let grandCheckableRecords = 0;
     let grandCheckedRecords = 0;
     let grandTotalVerdicts = 0;
     let grandConfirmed = 0;
@@ -2312,6 +2388,11 @@ const sourcingApp = new Hono()
         const totalRecords = totalsByType[recordType] ?? 0;
         const verdicts = verdictsByType[recordType] ?? {};
         const checkedRecords = checkedByType[recordType] ?? 0;
+        const checkableRecords = checkableCountFor(
+          recordType,
+          totalRecords,
+          checkableFactsCount,
+        );
         const exempt = isSourcingExempt(recordType);
 
         const confirmed = verdicts["confirmed"] ?? 0;
@@ -2324,19 +2405,12 @@ const sourcingApp = new Hono()
         const totalVerdicts =
           confirmed + partial + unverifiable + contradicted + outdated + unchecked;
 
-        // Coverage is based on distinct checked records, not verdict row counts
-        const coveragePercent =
-          totalRecords > 0
-            ? Math.round((checkedRecords / totalRecords) * 1000) / 10
-            : 0;
-        const greenPercent =
-          totalVerdicts > 0
-            ? Math.round((confirmed / totalVerdicts) * 1000) / 10
-            : 0;
+        const greenPercent = pct1(confirmed, totalVerdicts);
 
         // Only non-exempt types contribute to grand totals
         if (!exempt) {
           grandTotalRecords += totalRecords;
+          grandCheckableRecords += checkableRecords;
           grandCheckedRecords += checkedRecords;
           grandTotalVerdicts += totalVerdicts;
           grandConfirmed += confirmed;
@@ -2345,6 +2419,7 @@ const sourcingApp = new Hono()
         return {
           recordType,
           totalRecords,
+          checkableRecords,
           checkedRecords,
           verdicts: {
             confirmed,
@@ -2354,7 +2429,18 @@ const sourcingApp = new Hono()
             outdated,
             unchecked,
           },
-          coveragePercent,
+          // QUA-928: split coverage into three explicit percentages.
+          // - checkabilityPercent: authoring-quality metric (do facts have
+          //   sources? are properties verifiable?)
+          // - checkableCoveragePercent: verification-quality metric (of the
+          //   checkable subset, what fraction has a verdict?) — this is the
+          //   one the QUA-852 enforcement gate uses.
+          // - fullCoveragePercent: verified / total, the previous
+          //   `coveragePercent` field. Useful for tracking the joint metric
+          //   but mathematically capped by checkability.
+          checkabilityPercent: pct1(checkableRecords, totalRecords),
+          checkableCoveragePercent: pct1(checkedRecords, checkableRecords),
+          fullCoveragePercent: pct1(checkedRecords, totalRecords),
           greenPercent,
           exempt,
         };
@@ -2365,15 +2451,12 @@ const sourcingApp = new Hono()
       tables,
       totals: {
         totalRecords: grandTotalRecords,
+        checkableRecords: grandCheckableRecords,
         totalVerdicts: grandTotalVerdicts,
-        confirmedPercent:
-          grandTotalVerdicts > 0
-            ? Math.round((grandConfirmed / grandTotalVerdicts) * 1000) / 10
-            : 0,
-        coveragePercent:
-          grandTotalRecords > 0
-            ? Math.round((grandCheckedRecords / grandTotalRecords) * 1000) / 10
-            : 0,
+        confirmedPercent: pct1(grandConfirmed, grandTotalVerdicts),
+        checkabilityPercent: pct1(grandCheckableRecords, grandTotalRecords),
+        checkableCoveragePercent: pct1(grandCheckedRecords, grandCheckableRecords),
+        fullCoveragePercent: pct1(grandCheckedRecords, grandTotalRecords),
       },
       exemptTypes: [...SOURCING_EXEMPT_TYPES],
     });

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -110,10 +110,8 @@ export const DEAD_LINK_CHECKER_MODEL = "dead-link-detector";
 // ---- Coverage helpers (QUA-928) ----
 
 /**
- * Round to one decimal place — used for percent values returned by the
- * coverage endpoints. Centralised so all three percentages
- * (`checkabilityPercent`, `checkableCoveragePercent`, `fullCoveragePercent`)
- * share rounding behavior.
+ * Round to one decimal place. Returns 0 for zero/negative denominators
+ * (avoids NaN / Infinity in JSON output).
  */
 function pct1(numerator: number, denominator: number): number {
   if (denominator <= 0) return 0;
@@ -121,11 +119,40 @@ function pct1(numerator: number, denominator: number): number {
 }
 
 /**
+ * Compute the three QUA-928 coverage percentages from a (total, checkable,
+ * checked) triple. Centralised so `/coverage` and `/coverage-matrix` cannot
+ * silently diverge — same field names, same definitions on both endpoints.
+ *
+ * Numerators are clamped so the percentages can never exceed 100% even if
+ * the three counts are inconsistent (e.g. a fact was deleted between the
+ * `count(facts)` and the verdict-count queries, or a property was flipped
+ * from `verifiable: true` to `verifiable: false` after verdicts were
+ * already written for it). The three queries are not transaction-wrapped,
+ * so this clamp is the cheap defence against the resulting >100% noise.
+ */
+function coveragePercents(
+  totalRecords: number,
+  checkableRecords: number,
+  checkedRecords: number,
+): {
+  checkabilityPercent: number;
+  checkableCoveragePercent: number;
+  fullCoveragePercent: number;
+} {
+  const checkable = Math.min(checkableRecords, totalRecords);
+  const checked = Math.min(checkedRecords, checkable);
+  return {
+    checkabilityPercent: pct1(checkable, totalRecords),
+    checkableCoveragePercent: pct1(checked, checkable),
+    fullCoveragePercent: pct1(checked, totalRecords),
+  };
+}
+
+/**
  * Count facts that are eligible for sourcing verification. Mirrors the inclusion
  * logic in `crux/lib/sourcing/item-collectors.ts::collectFactItems`:
  * facts must carry a source URL AND their property must not be flagged
- * `verifiable: false` in properties.yaml. The set of non-verifiable
- * property IDs is read from `properties.yaml` once at startup.
+ * `verifiable: false` in properties.yaml.
  */
 async function countCheckableFacts(
   db: ReturnType<typeof getDrizzleDb>,
@@ -134,7 +161,7 @@ async function countCheckableFacts(
   const rows = (await db.execute(sql`
     SELECT count(DISTINCT fact_id)::int AS checkable
     FROM facts
-    WHERE source IS NOT NULL
+    WHERE source IS NOT NULL AND source <> ''
       AND (measure IS NULL OR NOT (measure = ANY(${nonVerifiable}::text[])))
   `)) as Array<{ checkable: number | null }>;
   return rows[0]?.checkable ?? 0;
@@ -2066,6 +2093,28 @@ const sourcingApp = new Hono()
       verifiedByType[row.record_type] = row.verified;
     }
 
+    // QUA-928: separate "checked" count for the new percentages, using the
+    // strict semantic that matches /coverage-matrix (excludes both
+    // 'unchecked' and 'not_applicable'). Without this, /coverage and
+    // /coverage-matrix would emit different `checkableCoveragePercent`
+    // numbers under the same field name. The legacy `verified` count
+    // (above) is preserved for the unchanged `percentage` field that
+    // `CoverageBars` + `EntitySourcingViewer` consume.
+    const checkedRowsRaw = (await db.execute(sql`
+      WITH ${LIVE_RECORDS_CTE}
+      SELECT v.record_type, count(DISTINCT v.record_id)::int AS checked_records
+      FROM source_check_verdicts v
+      INNER JOIN live_records lr
+        ON lr.record_type = v.record_type AND lr.record_id = v.record_id
+      WHERE v.verdict NOT IN ('unchecked', 'not_applicable')
+      GROUP BY v.record_type
+    `)) as Array<{ record_type: string; checked_records: number }>;
+
+    const checkedByType: Record<string, number> = {};
+    for (const row of checkedRowsRaw) {
+      checkedByType[row.record_type] = row.checked_records;
+    }
+
     // Merge into coverage array — include all known types
     const allTypes = new Set([
       ...Object.keys(totalsByType),
@@ -2076,6 +2125,7 @@ const sourcingApp = new Hono()
       .map((recordType) => {
         const total = totalsByType[recordType] ?? 0;
         const verified = verifiedByType[recordType] ?? 0;
+        const checked = checkedByType[recordType] ?? 0;
         const checkable = checkableCountFor(recordType, total, checkableFactsCount);
         const exempt = isSourcingExempt(recordType);
         // `percentage` retains its legacy semantics (verified / total, where
@@ -2090,9 +2140,7 @@ const sourcingApp = new Hono()
           checkable,
           verified,
           percentage,
-          checkabilityPercent: pct1(checkable, total),
-          checkableCoveragePercent: pct1(verified, checkable),
-          fullCoveragePercent: pct1(verified, total),
+          ...coveragePercents(total, checkable, checked),
           exempt,
         };
       })
@@ -2429,18 +2477,11 @@ const sourcingApp = new Hono()
             outdated,
             unchecked,
           },
-          // QUA-928: split coverage into three explicit percentages.
-          // - checkabilityPercent: authoring-quality metric (do facts have
-          //   sources? are properties verifiable?)
-          // - checkableCoveragePercent: verification-quality metric (of the
-          //   checkable subset, what fraction has a verdict?) — this is the
-          //   one the QUA-852 enforcement gate uses.
-          // - fullCoveragePercent: verified / total, the previous
-          //   `coveragePercent` field. Useful for tracking the joint metric
-          //   but mathematically capped by checkability.
-          checkabilityPercent: pct1(checkableRecords, totalRecords),
-          checkableCoveragePercent: pct1(checkedRecords, checkableRecords),
-          fullCoveragePercent: pct1(checkedRecords, totalRecords),
+          // QUA-928: three explicit percentages — see coveragePercents().
+          // - checkabilityPercent: authoring quality (sources present? properties verifiable?)
+          // - checkableCoveragePercent: verification quality (gate metric for QUA-852)
+          // - fullCoveragePercent: joint metric, capped by checkability
+          ...coveragePercents(totalRecords, checkableRecords, checkedRecords),
           greenPercent,
           exempt,
         };
@@ -2454,9 +2495,11 @@ const sourcingApp = new Hono()
         checkableRecords: grandCheckableRecords,
         totalVerdicts: grandTotalVerdicts,
         confirmedPercent: pct1(grandConfirmed, grandTotalVerdicts),
-        checkabilityPercent: pct1(grandCheckableRecords, grandTotalRecords),
-        checkableCoveragePercent: pct1(grandCheckedRecords, grandCheckableRecords),
-        fullCoveragePercent: pct1(grandCheckedRecords, grandTotalRecords),
+        ...coveragePercents(
+          grandTotalRecords,
+          grandCheckableRecords,
+          grandCheckedRecords,
+        ),
       },
       exemptTypes: [...SOURCING_EXEMPT_TYPES],
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
       zod:
         specifier: ^3.25.76
         version: 3.25.76


### PR DESCRIPTION
## Summary

The `/api/sourcing/coverage` and `/api/sourcing/coverage-matrix` endpoints previously returned a single `coveragePercent` field that conflated two distinct properties:

1. **Checkability** — what fraction of authored facts can theoretically be source-checked (depends on whether facts have sources + are on verifiable properties)
2. **Checkable coverage** — of the checkable subset, what fraction has a verdict

The all-facts denominator was mathematically unreachable for facts because ~33% are excluded by collector design (`verifiable: false` properties + facts without source URLs). Current coverage was 67.1%, ceiling ~67%. Checkable-subset coverage was already ~99%. The QUA-852 enforcement gate's `>90% coverage` rule had no usable threshold.

This PR splits the metric into three explicit fields:

```
checkabilityPercent      = checkable / total      (authoring quality)
checkableCoveragePercent = checked   / checkable  (verification gate metric)
fullCoveragePercent      = checked   / total      (joint, capped by checkability)
```

Both endpoints emit identical semantics under the same field names — no cross-endpoint divergence. The dashboard at `/internal/sourcing-coverage` shows all three with hover tooltips.

## What changed

- **`apps/wiki-server/src/property-metadata.ts`** (new) — reads `packages/factbase/data/properties.yaml` once, exposes the set of property IDs flagged `verifiable: false`. Runtime-validated (no blind casts), eagerly primed at server boot so a missing/malformed file fails the deploy.
- **`apps/wiki-server/src/routes/sourcing/sourcing.ts`** — adds `coveragePercents()` shared helper (returns the three percentages with numerators clamped 0..100), `countCheckableFacts()`, and per-recordType `checkableCountFor()`. `/coverage` now also runs a strict-checked SQL query so it matches `/coverage-matrix` semantics. Removes the ambiguous `coveragePercent` field on `/coverage-matrix`. Preserves the legacy `percentage` field on `/coverage` for `CoverageBars` + `EntitySourcingViewer`.
- **`apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx`** — replaces the single Coverage % column with Checkability / Checkable Cov / Full Cov, with hover tooltips.
- **Tests** — `sourcing-coverage-checkability.test.ts` (13 cases) and `property-metadata.test.ts` (4 cases). Coverage includes both endpoints, exempt types, divide-by-zero, the stale-checkable race, the >100% race when verdicts outlast a `verifiable` flip, the cross-endpoint consistency contract, and absence of the dropped `coveragePercent` field.

Hostile-reviewer findings against the first commit caught two HIGH issues that are addressed in the second commit:

- `checkableCoveragePercent` had different semantics on `/coverage` vs `/coverage-matrix` (`verified` count includes `verdict='unchecked'`, `checked_records` excludes it). Fixed by adding a strict-checked query to `/coverage` and centralising percentage computation in `coveragePercents()`.
- The `Math.min` clamp only defended one race direction (`checkable > total`). The reverse race (`checked > checkable` after a property flip) was unguarded and would have rendered as `>100%`. Fixed by clamping both counts inside `coveragePercents()`.

## Why YAML over a PG sync

The `properties` PG table is vestigial — defined in schema, no rows, no sync, no API. Adding a `verifiable` column would have required new sync infra for one boolean. The Dockerfile already copies `packages/factbase/` into the wiki-server image, so reading `properties.yaml` once at startup is exactly as authoritative without the new moving parts.

## Acceptance (from QUA-928)

- [x] `/api/sourcing/coverage-matrix` returns both `checkableCoveragePercent` and `fullCoveragePercent` (also `checkabilityPercent`)
- [x] `/internal/sourcing-coverage` UI shows all three
- [x] All callers of `coveragePercent` migrated (only matrix caller is the dashboard, updated in this PR)
- [ ] QUA-852 acceptance updated to gate on `checkableCoveragePercent >= 90` (already met at 99%) — comment to follow on QUA-852 once this PR merges

## Test plan

- [x] `pnpm test` — 1566 passing, 57 skipped (full wiki-server suite)
- [x] `pnpm crux w validate gate --fix` — 68/68 checks pass (2 advisory warnings unrelated to this PR)
- [x] `pnpm build` — apps/web builds cleanly
- [x] Existing regression tests for `/coverage` (QUA-422 orphan filter) still pass
- [x] New cross-endpoint consistency test pins that `/coverage` and `/coverage-matrix` return identical percentage values for the same input
- [ ] After merge, eyeball the `/internal/sourcing-coverage` dashboard in prod to confirm the three-column rendering looks right (no broken layout, tooltips show)

Fixes QUA-928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coverage metrics now split into three measurements: checkability %, checkable-coverage %, and full-coverage % (legacy single coverage kept as deprecated fallback).
  * Non-verifiable properties are recognized so coverage excludes them where appropriate.

* **Bug Fixes**
  * More accurate coverage and totals calculations (rounding, clamping to 0–100, handling empty totals, non-fact rows treated as fully checkable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->