### PR TITLE
QUA-927 follow-up: refine HTTP status mapping + stop LLM fallthrough

### DIFF
--- a/crux/lib/sourcing/item-verifier.ts
+++ b/crux/lib/sourcing/item-verifier.ts
@@ -297,7 +297,23 @@ export async function verifySingleItem(
       const urlResolvesResult = await tryUrlResolvesVerify(item);
       if (urlResolvesResult) return urlResolvesResult;
     } catch (e: unknown) {
-      console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${e instanceof Error ? e.message : String(e)}`);
+      // Don't fall through to LLM content-claim — these properties (wikipedia-url,
+      // github-profile, …) have no claim text to verify; the LLM path is meaningless
+      // here. Return unverifiable so the orchestrator records *something* and a
+      // future pass retries.
+      const message = e instanceof Error ? e.message : String(e);
+      console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${message}`);
+      return {
+        itemId: item.id,
+        kind: item.kind,
+        description: item.description,
+        verdict: 'unverifiable' as SourcingVerdict,
+        confidence: 0.7,
+        extractedValue: '',
+        reasoning: `[url-resolves] verifier threw: ${message}`,
+        sourceUrl: item.sourceUrl ?? '',
+        checkerModel: 'url-resolves',
+      };
     }
   }
 

--- a/crux/lib/sourcing/orchestrator.ts
+++ b/crux/lib/sourcing/orchestrator.ts
@@ -310,7 +310,33 @@ async function runBatchExecution(
           return;
         }
       } catch (e: unknown) {
-        console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${e instanceof Error ? e.message : String(e)}`);
+        // Don't fall through to LLM batch — these properties have no claim text.
+        // Record an unverifiable verdict so the orchestrator counts it correctly,
+        // and skip the rest of the prepare flow for this item.
+        const message = e instanceof Error ? e.message : String(e);
+        console.warn(`[sourcing] url-resolves verifier failed for ${item.id}: ${message}`);
+        const errorVerdict: VerifyResult = {
+          itemId: item.id,
+          kind: item.kind,
+          description: item.description,
+          verdict: 'unverifiable',
+          confidence: 0.7,
+          extractedValue: '',
+          reasoning: `[url-resolves] verifier threw: ${message}`,
+          sourceUrl: item.sourceUrl ?? '',
+          checkerModel: 'url-resolves',
+        };
+        summary.unverifiable++;
+        summary.actualVerified++;
+        summary.byKind[item.kind].verified++;
+        summary.results.push(errorVerdict);
+        try {
+          await storeResult(item, errorVerdict);
+        } catch (storageErr: unknown) {
+          summary.storageErrors++;
+          console.warn(`[sourcing] Storage failed: ${storageErr instanceof Error ? storageErr.message : String(storageErr)}`);
+        }
+        return;
       }
     }
 

--- a/crux/lib/sourcing/url-resolves-verifier.test.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.test.ts
@@ -188,9 +188,21 @@ describe('URL pre-validation', () => {
   });
 
   it('returns unverifiable on empty rawValue', async () => {
-    const item = makeFactItem({ rawValue: '' });
+    const item = makeFactItem({ rawValue: '', formattedValue: '' });
     const result = await tryUrlResolvesVerify(item);
     expect(result?.verdict).toBe('unverifiable');
+  });
+
+  it('falls back to formattedValue when rawValue is undefined', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 200 }) as never);
+    const item = makeFactItem({
+      propertyId: 'github-profile',
+      rawValue: undefined,
+      formattedValue: 'https://github.com/anthropics',
+    });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(getCitationContentByUrlMock).toHaveBeenCalledWith('https://github.com/anthropics');
   });
 });
 
@@ -217,7 +229,7 @@ describe('cached citation_content', () => {
     expect(result?.verdict).toBe('confirmed');
   });
 
-  it.each([400, 403, 404, 410, 500, 503])('contradicted on %i (link rot)', async (status) => {
+  it.each([400, 404, 410])('contradicted on %i (link rot)', async (status) => {
     getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: status }) as never);
     const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
     const result = await tryUrlResolvesVerify(item);
@@ -225,8 +237,40 @@ describe('cached citation_content', () => {
     expect(result?.reasoning).toMatch(new RegExp(`HTTP ${status}`));
   });
 
+  it.each([401, 403, 451])('confirmed on %i (URL alive, body blocked)', async (status) => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: status }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('confirmed');
+    expect(result?.confidence).toBe(0.85);
+    expect(result?.reasoning).toContain('URL alive, body blocked');
+  });
+
+  it.each([429, 500, 502, 503, 504])('unverifiable on %i (transient — retry next pass)', async (status) => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: status }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    const result = await tryUrlResolvesVerify(item);
+    expect(result?.verdict).toBe('unverifiable');
+    expect(result?.confidence).toBe(0.7);
+    expect(result?.reasoning).toContain('transient');
+  });
+
   it('contradicted does NOT enqueue a fresh ingest job', async () => {
     getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 404 }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    await tryUrlResolvesVerify(item);
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
+  });
+
+  it('confirmed-on-403 does NOT enqueue a fresh ingest job', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 403 }) as never);
+    const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
+    await tryUrlResolvesVerify(item);
+    expect(suggestResourcesApiMock).not.toHaveBeenCalled();
+  });
+
+  it('unverifiable-on-503 does NOT enqueue a fresh ingest job (info already cached)', async () => {
+    getCitationContentByUrlMock.mockResolvedValueOnce(citationContent({ httpStatus: 503 }) as never);
     const item = makeFactItem({ propertyId: 'github-profile', rawValue: 'https://github.com/x' });
     await tryUrlResolvesVerify(item);
     expect(suggestResourcesApiMock).not.toHaveBeenCalled();
@@ -268,9 +312,13 @@ describe('Wikipedia title check', () => {
     expect(result?.reasoning).toMatch(/does not contain/);
   });
 
-  it('handles em-dash separator in pageTitle', async () => {
+  it.each([
+    ['hyphen-minus', 'Anthropic - Wikipedia'],
+    ['en-dash', 'Anthropic – Wikipedia'],
+    ['em-dash', 'Anthropic — Wikipedia'],
+  ])('strips trailing Wikipedia suffix with %s separator', async (_label, pageTitle) => {
     getCitationContentByUrlMock.mockResolvedValueOnce(
-      citationContent({ httpStatus: 200, pageTitle: 'Anthropic – Wikipedia' }) as never,
+      citationContent({ httpStatus: 200, pageTitle }) as never,
     );
     const item = makeFactItem();
     const result = await tryUrlResolvesVerify(item);

--- a/crux/lib/sourcing/url-resolves-verifier.ts
+++ b/crux/lib/sourcing/url-resolves-verifier.ts
@@ -71,9 +71,10 @@ export async function tryUrlResolvesVerify(item: VerifyItem): Promise<VerifyResu
   const data = item.data;
   if (data.verifierKind !== 'url-resolves') return null;
 
-  // Use rawValue only — formattedValue can include display formatting (units,
-  // wrappers) that would parse as garbage.
-  const urlToCheck = data.rawValue;
+  // Prefer rawValue; fall back to formattedValue for legacy/external producers
+  // that didn't populate rawValue. For URL-typed properties they are the same
+  // string — the display-formatting concern only applies to numeric fields.
+  const urlToCheck = data.rawValue ?? data.formattedValue;
   if (!urlToCheck || !looksLikeUrl(urlToCheck)) {
     return {
       itemId: item.id,
@@ -140,6 +141,31 @@ export async function resolveFromResourcePipeline(
     }
 
     if (httpStatus != null && httpStatus >= 400) {
+      // Distinguish "URL alive, body blocked" from "URL gone". 401/403/451 mean
+      // the resource exists but the server refuses to serve the body to us
+      // (auth required, anti-bot block, legal removal). For url-resolves
+      // properties the truth being verified is "this URL is the canonical
+      // pointer for the entity" — body access is not required. Match the
+      // paywall branch below: confirmed at HIGH confidence.
+      // 429 + 5xx are transient (rate limit / server error) — unverifiable so
+      // we re-check next pass instead of flipping a previously-confirmed URL
+      // to contradicted on a hiccup.
+      if (httpStatus === 401 || httpStatus === 403 || httpStatus === 451) {
+        return {
+          verdict: 'confirmed' as SourcingVerdict,
+          confidence: CONFIDENCE_HIGH,
+          reasoning: `[url-resolves] resource-ingest recorded HTTP ${httpStatus} (URL alive, body blocked)`,
+          finalUrl: url,
+        };
+      }
+      if (httpStatus === 429 || httpStatus >= 500) {
+        return {
+          verdict: 'unverifiable' as SourcingVerdict,
+          confidence: CONFIDENCE_MEDIUM,
+          reasoning: `[url-resolves] resource-ingest recorded HTTP ${httpStatus} — transient, re-check on next pass`,
+          finalUrl: url,
+        };
+      }
       return {
         verdict: 'contradicted' as SourcingVerdict,
         confidence: CONFIDENCE_DEFINITE,
@@ -218,7 +244,9 @@ function verdictFromWikipediaCachedContent(
   cached: { httpStatus: number | null; pageTitle: string | null; fetchedAt: string },
   entityName: string,
 ): ResolveResult {
-  const title = (cached.pageTitle ?? '').replace(/\s*[-–]\s*Wikipedia\s*$/i, '').trim();
+  // Strip trailing " - Wikipedia" / " – Wikipedia" / " — Wikipedia" suffix.
+  // Wikipedia uses hyphen-minus, en-dash, or em-dash depending on locale/render.
+  const title = (cached.pageTitle ?? '').replace(/\s*[-‐-―]\s*Wikipedia\s*$/i, '').trim();
   if (!title) {
     return {
       verdict: 'confirmed' as SourcingVerdict,


### PR DESCRIPTION
## Summary

Follow-up to PR #4736 (now merged) addressing review findings from `/agent-review-pr` that didn't make it before the merge.

## What changed

### HTTP status semantics (HIGH-severity finding)

The previous mapping bucketed all 4xx as `contradicted`, which contradicts the resource-row branch where `fetch_status: paywall` is `confirmed`. Both states mean the same thing: **URL alive, body blocked**. New mapping:

| Status | Verdict | Reason |
|---|---|---|
| 2xx | `confirmed` | URL fetched OK (Wikipedia: also title-match) |
| **401, 403, 451** | **`confirmed` (HIGH conf)** | **URL alive, body blocked (auth / anti-bot / legal removal)** |
| **429, 5xx** | **`unverifiable` (MEDIUM conf)** | **Transient — re-check next pass** |
| Other 4xx (400, 404, 410, …) | `contradicted` | Link rot |

This also resolves a regression risk for the social-media properties that were re-enabled in #4736 — Twitter/X 403s no longer flip handles to `contradicted` in bulk.

### LLM fallthrough on verifier exception (MEDIUM-severity finding)

Previously, `tryUrlResolvesVerify` throwing in either `item-verifier.ts` (sequential path) or `orchestrator.ts` (batch path) was logged-and-ignored, so the item fell through to LLM content-claim verification. For url-resolves properties (wikipedia-url, github-profile, …) there's no claim text — the LLM path is meaningless. Now both sites return `unverifiable` directly with `checkerModel: 'url-resolves'`.

### Smaller improvements

- `urlToCheck` falls back to `formattedValue` when `rawValue` is undefined (legacy/external producers). For URL-typed properties they're the same string.
- Wikipedia title-suffix regex now accepts em-dash (U+2014) alongside hyphen-minus and en-dash. Wikipedia uses different separators by locale/render.

## Test plan

- [x] `npx vitest run crux/lib/sourcing/url-resolves-verifier.test.ts` — 56/56 pass (10 new cases)
- [x] `npx vitest run crux/lib/sourcing/` — 640/640 pass
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — clean for changed files
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — clean
- [x] `pnpm crux w validate gate` — 53/53 pass
- [x] `/agent-review-pr` ran on the parent PR; this PR addresses its HIGH/MEDIUM findings

## Why a follow-up PR

The hostile-reviewer pass against PR #4736 ran after I'd already pushed to that branch but before I could push these refinements. The original PR merged in the meantime, so these review-driven improvements land here instead of as additional commits on the merged branch.

The Linear dedup check flagged release PR #4742 as a collision — that's the release rollup that includes the parent PR #4736, not a competing claim. Forced past with this reason.

Fixes QUA-927
