### PR TITLE
fix(content): rewrite 10 FISA-702 stakeholder positions from invalid `reform` to valid enum (QUA-941)

### DIFF
--- a/data/entities/responses.yaml
+++ b/data/entities/responses.yaml
@@ -1861,14 +1861,14 @@
       source: https://crsreports.congress.gov/product/pdf/R/R44457
     - name: Center for Democracy and Technology (CDT)
       entityId: sid_XkqcWk46oQ
-      position: reform
+      position: oppose
       importance: medium
       reason: >-
         Pushes for stronger US-person query protections and shorter Section 702 reauthorization sunsets; led 2024
         coalition push for FISA 702 reforms.
       source: https://cdt.org/area-of-focus/government-surveillance/
     - name: Foreign Intelligence Surveillance Court (FISC)
-      position: reform
+      position: neutral
       importance: medium
       reason: >-
         The Attorney General must approve the targeting, minimization, and querying procedures, each of which are
@@ -1876,14 +1876,14 @@
         and the Fourth Amendment. Any identified compliance errors are remedied and reported to the FISC and Congress.
       source: https://intelligence.gov/foreign-intelligence-surveillance-act/fisa-section-702
     - name: Department of Justice (DOJ)
-      position: reform
+      position: neutral
       importance: medium
       reason: >-
         The Department of Justice and the Office of the Director of National Intelligence conduct extensive, regular,
         and independent reviews of Section 702 activities.
       source: https://intelligence.gov/foreign-intelligence-surveillance-act/fisa-section-702
     - name: National Security Agency (NSA)
-      position: reform
+      position: support
       importance: medium
       reason: >-
         A 2013 statement on the National Security Agency website calls the program 'the most significant tool' in the
@@ -1892,7 +1892,7 @@
         be replaced 'via other collection sources, via other legal means.'
       source: https://rpc.senate.gov/policy-papers/fisa-section-702
     - name: Privacy and Civil Liberties Oversight Board (PCLOB)
-      position: reform
+      position: support
       importance: medium
       reason: >-
         Najibullah Zazi is in prison for planning to attack the New York City subway system with explosives in 2009. He
@@ -1901,7 +1901,7 @@
         overseas foreigner under Section 702, the subway-bombing plot might have succeeded.'
       source: https://rpc.senate.gov/policy-papers/fisa-section-702
     - name: Senate Intelligence Committee
-      position: reform
+      position: support
       importance: medium
       reason: >-
         At a hearing of the Senate Intelligence Committee on May 11, 2017, the NSA director bluntly said, 'if we were to
@@ -1909,14 +1909,14 @@
         as to what terrorist actors, nation-states, [and] criminal elements are doing that is of concern to our nation.'
       source: https://rpc.senate.gov/policy-papers/fisa-section-702
     - name: Foreign Intelligence Surveillance Court (FISC)
-      position: reform
+      position: neutral
       importance: medium
       reason: >-
         Every year, the FISC reviews these certifications and procedures to ensure they comply with FISA and the Fourth
         Amendment. Every federal court to ever review the Section 702 program has found that it is constitutional.
       source: https://intel.gov/assets/documents/702-documents/FISA_Section_702_Fact_Sheet_JUN2023.pdf
     - name: Department of Justice (DOJ)
-      position: reform
+      position: neutral
       importance: medium
       reason: >-
         DOJ reviews IC compliance with Section 702 targeting, minimization, and querying procedures. DOJ also reviews
@@ -1924,14 +1924,14 @@
         Intelligence Surveillance Court (FISC) and Congress.
       source: https://intel.gov/assets/documents/702-documents/FISA_Section_702_Fact_Sheet_JUN2023.pdf
     - name: National Security Agency (NSA)
-      position: reform
+      position: support
       importance: medium
       reason: >-
         In calendar year (CY) 2022, 59% of President's Daily Brief (PDB) Articles contained Section 702 information
         reported by the National Security Agency (NSA).
       source: https://intel.gov/assets/documents/702-documents/FISA_Section_702_Fact_Sheet_JUN2023.pdf
     - name: Federal Bureau of Investigation (FBI)
-      position: reform
+      position: support
       importance: medium
       reason: >-
         The FBI only receives collection on Section 702 targets relevant to full FBI national security investigations,


### PR DESCRIPTION
## Summary

Quick data fix for FISA-702. Symptom of [QUA-943](https://linear.app/quantifieduncertainty/issue/QUA-943) (the architectural fix — single source of truth for entity Zod schemas).

PR #4711's improve-entity pipeline wrote 10 stakeholders with `position: reform`. The wiki-server `/api/policy-stakeholders/sync` Zod schema only accepts `support|oppose|neutral|mixed`, so all 10 were silently dropped at every build. **Prod PG had 1 stakeholder for FISA-702 vs. 11 in YAML.**

Reproduced live before the fix:

```
$ curl -s "https://wiki-server.k8s.quantifieduncertainty.org/api/policy-stakeholders/by-policy/sid_n7K9yVNCtg" | jq '.total'
1
```

## What's in this PR

10 single-word edits in `data/entities/responses.yaml` for the FISA-702 entry. Position values picked by reading each stakeholder's existing `reason` text:

| Stakeholder | New position | Why |
|---|---|---|
| CDT | `oppose` | reform advocate, opposes status quo |
| FISC ×2 | `neutral` | oversight body |
| DOJ ×2 | `neutral` | review/oversight role |
| NSA ×2 | `support` | program defender ("most significant tool") |
| PCLOB | `support` | program proponent (citing Zazi case) |
| Senate Intel | `support` | program proponent |
| FBI | `support` | operational user, citing reforms |

ODNI (`support`) was already correct from PR #4706 and unchanged.

## What's NOT in this PR (and why)

- **Architectural fix** — there are three Zod schemas defining `policy.stakeholder.position`, each with different strictness. The gate uses the loose one; the sync route uses the strict one. They drift, and `syncPolicyStakeholders` swallows the resulting Zod 400s as "skipped (FK errors)" so build "succeeds" with rows missing. **That's the real bug.** Tracked as parent epic [QUA-943](https://linear.app/quantifieduncertainty/issue/QUA-943) and child [QUA-944](https://linear.app/quantifieduncertainty/issue/QUA-944) (drift inventory — Phase 1).
- **Dedup of FISC×2/DOJ×2/NSA×2** — same name → same hash → ON CONFLICT UPDATE, second overwrites first. So post-fix the page shows 8 unique stakeholders, not 11. Dedup is QUA-872 territory (already Done in the pipeline going forward).

## Test plan

- [x] `pnpm crux w validate gate --scope=content --fix` — green (~47s)
- [x] `pnpm build-data:content` — clean, 2063 entities, 0 YAML parse errors
- [x] Reproduced the sync 400 against prod with `position: reform`
- [x] Verified zero `position: reform` remain in YAML
- [ ] CI green
- [ ] Verify `/legislation/fisa-702` shows 8 stakeholders after deploy (vs. 1 currently)

Closes QUA-941
