### PR TITLE
feat(improve-entity): add --wait-for-settle to drain pending claims (QUA-939)

### DIFF
--- a/crux/commands/research-improve-entity.test.ts
+++ b/crux/commands/research-improve-entity.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Tests for the wait-for-settle drain logic in `research-improve-entity.ts`
+ * (QUA-939).
+ *
+ * Covers:
+ *   - `buildVerifiedVerdictsFromBatch`: pure helper that joins batch metadata
+ *     with verdict rows. Tests the onlyNew filter, verdict counts, and
+ *     status-mapping (verified/partial/contradicted/unverifiable/pending).
+ *   - `drainPendingBatches`: post-exit drain. The three acceptance scenarios
+ *     from the issue:
+ *       1. target-hit before any pending — drain is a no-op
+ *       2. target-hit with pending — drain catches new verifieds and applies them
+ *       3. target-hit with all settled — drain is a no-op
+ *     Plus: time-cap timeout, multiple batches, idempotency on re-poll, and
+ *     applyFn errors propagate.
+ *
+ * The pure parsing helper `parseExtractedClaims` already has implicit coverage
+ * via its export from research-improve-entity.ts; not re-tested here.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  buildVerifiedVerdictsFromBatch,
+  drainPendingBatches,
+  parseExtractedClaims,
+  type ClaimVerdictRow,
+  type SubmittedBatchInfo,
+} from "./research-improve-entity.ts";
+import type { PreFilterClaim } from "../lib/research/pre-filter.ts";
+import type { ApplyResult, VerifiedVerdict } from "../lib/research/apply-verdicts.ts";
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+interface EntityWithType {
+  id: string;
+  type: string;
+  [k: string]: unknown;
+}
+
+function makeClaim(
+  i: number,
+  overrides: Partial<PreFilterClaim> = {},
+): PreFilterClaim {
+  return {
+    claimText: `claim ${i}`,
+    proposedValue: `value ${i}`,
+    resourceId: `https://example.com/${i}`,
+    sourceUrl: `https://example.com/${i}`,
+    targetField: `provision.gap-${i}`,
+    displayHint: `Gap ${i}`,
+    ...overrides,
+  };
+}
+
+function makeVerdict(
+  id: number,
+  status: string,
+  overrides: Partial<ClaimVerdictRow> = {},
+): ClaimVerdictRow {
+  return {
+    id,
+    status,
+    verdictReasoning: status === "verified" ? "matches source" : null,
+    extractedValue: status === "verified" ? `extracted-${id}` : null,
+    claimText: `claim text ${id}`,
+    ...overrides,
+  };
+}
+
+function makeBatch(
+  overrides: Partial<SubmittedBatchInfo> = {},
+): SubmittedBatchInfo {
+  const submittedByOrder: PreFilterClaim[] = [makeClaim(1), makeClaim(2)];
+  const claimIds: Array<number | undefined> = [101, 102];
+  const lastVerdicts: ClaimVerdictRow[] = [
+    makeVerdict(101, "verified"),
+    makeVerdict(102, "verified"),
+  ];
+  return {
+    iter: 1,
+    batchId: "batch-1",
+    submittedByOrder,
+    claimIds,
+    settled: true,
+    appliedClaimIds: new Set<number>(),
+    lastVerdicts,
+    ...overrides,
+  };
+}
+
+// A no-op apply function — returns the entity unchanged with `added` actions
+// for every verdict it received. Used when the test only cares about counts.
+async function fakeApplyAll(
+  entity: EntityWithType,
+  verdicts: VerifiedVerdict[],
+): Promise<ApplyResult<EntityWithType>> {
+  return {
+    entity: {
+      ...entity,
+      // Stash the verdicts on the entity so the test can assert what was applied.
+      __applied: [...((entity as { __applied?: VerifiedVerdict[] }).__applied ?? []), ...verdicts],
+    } as EntityWithType,
+    applied: verdicts.map((v) => ({ targetField: v.targetField, action: "added" as const })),
+    warnings: [],
+  };
+}
+
+// ── buildVerifiedVerdictsFromBatch ─────────────────────────────────────────
+
+describe("buildVerifiedVerdictsFromBatch", () => {
+  it("returns one VerifiedVerdict per verified+partial verdict, with submitted metadata", () => {
+    const batch = makeBatch({
+      submittedByOrder: [
+        makeClaim(1, { targetField: "provision.alpha", displayHint: "Alpha" }),
+        makeClaim(2, { targetField: "stakeholder.acme", displayHint: "Acme", position: "oppose", positionConfidence: 0.9 }),
+      ],
+      claimIds: [101, 102],
+      lastVerdicts: [makeVerdict(101, "verified"), makeVerdict(102, "partial")],
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, false);
+    expect(out.counts).toEqual({ verified: 1, partial: 1, contradicted: 0, unverifiable: 0 });
+    expect(out.verdicts).toHaveLength(2);
+    expect(out.verdicts[0].targetField).toBe("provision.alpha");
+    expect(out.verdicts[0].displayHint).toBe("Alpha");
+    expect(out.verdicts[0].status).toBe("verified");
+    expect(out.verdicts[0].extractedValue).toBe("extracted-101");
+    expect(out.verdicts[1].targetField).toBe("stakeholder.acme");
+    expect(out.verdicts[1].position).toBe("oppose");
+    expect(out.verdicts[1].positionConfidence).toBe(0.9);
+    expect(out.verdicts[1].status).toBe("partial");
+  });
+
+  it("counts contradicted/unverifiable but does not include them in verdicts[]", () => {
+    const batch = makeBatch({
+      claimIds: [101, 102, 103, 104],
+      submittedByOrder: [makeClaim(1), makeClaim(2), makeClaim(3), makeClaim(4)],
+      lastVerdicts: [
+        makeVerdict(101, "verified"),
+        makeVerdict(102, "contradicted"),
+        makeVerdict(103, "unverifiable"),
+        makeVerdict(104, "expired"), // unknown-to-us — treated as not verified+partial
+      ],
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, false);
+    expect(out.counts).toEqual({ verified: 1, partial: 0, contradicted: 1, unverifiable: 1 });
+    expect(out.verdicts).toHaveLength(1);
+    expect(out.verdicts[0].status).toBe("verified");
+  });
+
+  it("respects onlyNew=true by skipping claim IDs in appliedClaimIds", () => {
+    const batch = makeBatch({
+      claimIds: [101, 102],
+      submittedByOrder: [makeClaim(1), makeClaim(2)],
+      lastVerdicts: [makeVerdict(101, "verified"), makeVerdict(102, "verified")],
+      appliedClaimIds: new Set([101]),
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, true);
+    expect(out.counts).toEqual({ verified: 1, partial: 0, contradicted: 0, unverifiable: 0 });
+    expect(out.verdicts).toHaveLength(1);
+    // Only id=102 should survive the filter.
+    expect(out.verdicts[0].claimText).toBe("claim text 102");
+  });
+
+  it("skips entries whose claim ID is undefined (proposeClaims returned fewer than expected)", () => {
+    const batch = makeBatch({
+      claimIds: [101, undefined],
+      submittedByOrder: [makeClaim(1), makeClaim(2)],
+      lastVerdicts: [makeVerdict(101, "verified")],
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, false);
+    expect(out.counts.verified).toBe(1);
+    expect(out.verdicts).toHaveLength(1);
+  });
+
+  it("skips entries whose claim ID has no matching verdict (worker dropped row)", () => {
+    const batch = makeBatch({
+      claimIds: [101, 102],
+      submittedByOrder: [makeClaim(1), makeClaim(2)],
+      lastVerdicts: [makeVerdict(101, "verified")], // 102 missing
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, false);
+    expect(out.counts.verified).toBe(1);
+    expect(out.verdicts).toHaveLength(1);
+  });
+
+  it("does not count claims with status='pending' or 'verifying' as terminal", () => {
+    const batch = makeBatch({
+      claimIds: [101, 102],
+      submittedByOrder: [makeClaim(1), makeClaim(2)],
+      lastVerdicts: [makeVerdict(101, "pending"), makeVerdict(102, "verifying")],
+    });
+    const out = buildVerifiedVerdictsFromBatch(batch, false);
+    expect(out.counts).toEqual({ verified: 0, partial: 0, contradicted: 0, unverifiable: 0 });
+    expect(out.verdicts).toHaveLength(0);
+  });
+});
+
+// ── drainPendingBatches: 3 acceptance scenarios ────────────────────────────
+
+describe("drainPendingBatches — acceptance scenarios", () => {
+  const entity: EntityWithType = { id: "test-entity", type: "policy" };
+  const POLL_INTERVAL_MS = 5; // fast for tests
+
+  it("scenario 1: target-hit before any pending — drain is a no-op", async () => {
+    // No batches submitted (e.g. iter 0 short-circuited), so there's nothing
+    // to drain. The drain should report zeros across the board and not call
+    // pollFn at all.
+    let pollCount = 0;
+    const result = await drainPendingBatches(entity, [], {
+      pollIntervalMs: POLL_INTERVAL_MS,
+      pollFn: async (id) => {
+        pollCount++;
+        return { allSettled: true, claims: [] };
+      },
+      applyFn: fakeApplyAll,
+    });
+    expect(pollCount).toBe(0);
+    expect(result.pendingAtStart).toBe(0);
+    expect(result.verifiedAfterDrain).toBe(0);
+    expect(result.appliedAfterDrain).toBe(0);
+    expect(result.entity).toBe(entity);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("scenario 2: target-hit with pending — drain catches new verifieds and applies them", async () => {
+    // Setup: a batch with 4 claims. At main-loop exit, 2 are verified (already
+    // applied), 2 are still pending. The pending two will resolve to verified
+    // on the next poll. The drain should apply them and report
+    // verified_after_drain=2.
+    const batch: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "batch-A",
+      submittedByOrder: [
+        makeClaim(1, { targetField: "provision.alpha" }),
+        makeClaim(2, { targetField: "provision.beta" }),
+        makeClaim(3, { targetField: "provision.gamma" }),
+        makeClaim(4, { targetField: "provision.delta" }),
+      ],
+      claimIds: [201, 202, 203, 204],
+      settled: false,
+      appliedClaimIds: new Set([201, 202]), // first two already applied per-iter
+      lastVerdicts: [
+        makeVerdict(201, "verified"),
+        makeVerdict(202, "verified"),
+        makeVerdict(203, "pending"),
+        makeVerdict(204, "verifying"),
+      ],
+    };
+
+    let pollCount = 0;
+    const pollFn = async (batchId: string) => {
+      pollCount++;
+      expect(batchId).toBe("batch-A");
+      // After one poll, all 4 claims have settled. The two new ones become verified.
+      return {
+        allSettled: true,
+        claims: [
+          makeVerdict(201, "verified"),
+          makeVerdict(202, "verified"),
+          makeVerdict(203, "verified"),
+          makeVerdict(204, "verified"),
+        ],
+      };
+    };
+
+    const result = await drainPendingBatches(entity, [batch], {
+      pollIntervalMs: POLL_INTERVAL_MS,
+      pollFn,
+      applyFn: fakeApplyAll,
+    });
+
+    expect(result.pendingAtStart).toBe(2); // 1 pending + 1 verifying
+    expect(result.verifiedAfterDrain).toBe(2);
+    expect(result.partialAfterDrain).toBe(0);
+    expect(result.appliedAfterDrain).toBe(2);
+    expect(result.timedOut).toBe(false);
+    expect(pollCount).toBe(1);
+    // Batch state is mutated to reflect the drain.
+    expect(batch.settled).toBe(true);
+    expect(batch.appliedClaimIds).toEqual(new Set([201, 202, 203, 204]));
+    // Only the new verdicts (203, 204) should have been applied — not the
+    // already-applied ones (201, 202). fakeApplyAll stashes them on the entity.
+    const applied = (result.entity as { __applied?: VerifiedVerdict[] }).__applied ?? [];
+    expect(applied).toHaveLength(2);
+    expect(applied.map((v) => v.targetField).sort()).toEqual(["provision.delta", "provision.gamma"]);
+  });
+
+  it("scenario 3: target-hit with all settled — drain is a no-op", async () => {
+    // The main loop exited with the batch fully drained (settled=true, no
+    // pending verdicts). Drain should not poll and not apply.
+    const batch: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "batch-S",
+      submittedByOrder: [makeClaim(1), makeClaim(2)],
+      claimIds: [301, 302],
+      settled: true,
+      appliedClaimIds: new Set([301, 302]),
+      lastVerdicts: [makeVerdict(301, "verified"), makeVerdict(302, "verified")],
+    };
+
+    let pollCount = 0;
+    const result = await drainPendingBatches(entity, [batch], {
+      pollIntervalMs: POLL_INTERVAL_MS,
+      pollFn: async () => {
+        pollCount++;
+        return { allSettled: true, claims: [] };
+      },
+      applyFn: fakeApplyAll,
+    });
+
+    expect(pollCount).toBe(0);
+    expect(result.pendingAtStart).toBe(0);
+    expect(result.verifiedAfterDrain).toBe(0);
+    expect(result.appliedAfterDrain).toBe(0);
+    expect(result.entity).toBe(entity);
+  });
+});
+
+// ── drainPendingBatches: edge cases ────────────────────────────────────────
+
+describe("drainPendingBatches — edge cases", () => {
+  const entity: EntityWithType = { id: "test-entity", type: "policy" };
+
+  it("reports timedOut=true when maxDurationMs elapses with batches still unsettled", async () => {
+    // Batch never settles. Drain should respect the time cap.
+    const batch: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "stuck",
+      submittedByOrder: [makeClaim(1)],
+      claimIds: [401],
+      settled: false,
+      appliedClaimIds: new Set(),
+      lastVerdicts: [makeVerdict(401, "pending")],
+    };
+
+    const result = await drainPendingBatches(entity, [batch], {
+      pollIntervalMs: 1,
+      maxDurationMs: 20, // ~20ms cap
+      pollFn: async () => ({
+        allSettled: false,
+        claims: [makeVerdict(401, "pending")],
+      }),
+      applyFn: fakeApplyAll,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.verifiedAfterDrain).toBe(0);
+    expect(batch.settled).toBe(false);
+  });
+
+  it("polls multiple batches and tracks them independently", async () => {
+    const batchA: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "A",
+      submittedByOrder: [makeClaim(1, { targetField: "provision.a" })],
+      claimIds: [501],
+      settled: false,
+      appliedClaimIds: new Set(),
+      lastVerdicts: [makeVerdict(501, "pending")],
+    };
+    const batchB: SubmittedBatchInfo = {
+      iter: 2,
+      batchId: "B",
+      submittedByOrder: [makeClaim(2, { targetField: "provision.b" })],
+      claimIds: [601],
+      settled: true, // already settled — should NOT be polled
+      appliedClaimIds: new Set([601]),
+      lastVerdicts: [makeVerdict(601, "verified")],
+    };
+
+    const polledBatchIds: string[] = [];
+    const result = await drainPendingBatches(entity, [batchA, batchB], {
+      pollIntervalMs: 1,
+      pollFn: async (id) => {
+        polledBatchIds.push(id);
+        return { allSettled: true, claims: [makeVerdict(501, "verified")] };
+      },
+      applyFn: fakeApplyAll,
+    });
+
+    expect(polledBatchIds).toEqual(["A"]); // B was already settled
+    expect(result.verifiedAfterDrain).toBe(1);
+    expect(result.appliedAfterDrain).toBe(1);
+    expect(batchA.settled).toBe(true);
+    expect(batchB.settled).toBe(true);
+  });
+
+  it("skips re-applying claim IDs already in appliedClaimIds across multiple poll rounds", async () => {
+    // Round 1: poll says batch is unsettled but verdict 701 is now verified.
+    // Round 2: poll says batch is settled; same 701 is verified plus 702 is verified.
+    // The drain should apply 701 ONCE (round 1) and 702 ONCE (round 2).
+    const batch: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "multi",
+      submittedByOrder: [
+        makeClaim(1, { targetField: "provision.first" }),
+        makeClaim(2, { targetField: "provision.second" }),
+      ],
+      claimIds: [701, 702],
+      settled: false,
+      appliedClaimIds: new Set(),
+      lastVerdicts: [makeVerdict(701, "pending"), makeVerdict(702, "pending")],
+    };
+
+    let round = 0;
+    const result = await drainPendingBatches(entity, [batch], {
+      pollIntervalMs: 1,
+      pollFn: async () => {
+        round++;
+        if (round === 1) {
+          return {
+            allSettled: false,
+            claims: [makeVerdict(701, "verified"), makeVerdict(702, "pending")],
+          };
+        }
+        return {
+          allSettled: true,
+          claims: [makeVerdict(701, "verified"), makeVerdict(702, "verified")],
+        };
+      },
+      applyFn: fakeApplyAll,
+    });
+
+    expect(result.verifiedAfterDrain).toBe(2); // 701 in round 1 + 702 in round 2
+    expect(result.appliedAfterDrain).toBe(2);
+    const applied = (result.entity as { __applied?: VerifiedVerdict[] }).__applied ?? [];
+    expect(applied).toHaveLength(2);
+    expect(applied.map((v) => v.targetField).sort()).toEqual(["provision.first", "provision.second"]);
+  });
+
+  it("continues when pollFn returns null (transient API error)", async () => {
+    // First poll fails (returns null); next poll succeeds. Drain should
+    // tolerate the failure and finish on the second try.
+    const batch: SubmittedBatchInfo = {
+      iter: 1,
+      batchId: "flaky",
+      submittedByOrder: [makeClaim(1)],
+      claimIds: [801],
+      settled: false,
+      appliedClaimIds: new Set(),
+      lastVerdicts: [makeVerdict(801, "pending")],
+    };
+
+    let round = 0;
+    const result = await drainPendingBatches(entity, [batch], {
+      pollIntervalMs: 1,
+      pollFn: async () => {
+        round++;
+        if (round === 1) return null;
+        return { allSettled: true, claims: [makeVerdict(801, "verified")] };
+      },
+      applyFn: fakeApplyAll,
+    });
+
+    expect(result.verifiedAfterDrain).toBe(1);
+    expect(result.timedOut).toBe(false);
+  });
+});
+
+// ── parseExtractedClaims (sanity — already covered by export, repeated lightly) ─
+
+describe("parseExtractedClaims", () => {
+  it("returns empty array on malformed input", () => {
+    expect(parseExtractedClaims("")).toEqual([]);
+    expect(parseExtractedClaims("not a json")).toEqual([]);
+    expect(parseExtractedClaims("[invalid json}")).toEqual([]);
+  });
+
+  it("strips position from non-stakeholder claims (Haiku leaks them sometimes)", () => {
+    const raw = JSON.stringify([
+      {
+        targetField: "provision.alpha",
+        claimText: "Some provision text",
+        proposedValue: "value",
+        position: "support",
+        positionConfidence: 0.9,
+      },
+    ]);
+    const parsed = parseExtractedClaims(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].position).toBeNull();
+    expect(parsed[0].positionConfidence).toBeNull();
+  });
+});

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -133,6 +133,14 @@ export interface ImproveOptions {
 // Wait-for-settle: per-batch tracking + drain helper (QUA-939)
 // ──────────────────────────────────────────────────────────────────────────────
 
+/** Default global wall-clock cap for the post-loop drain (30 min). The drain
+ *  bounds total time spent waiting for stuck batches; matches the
+ *  `MAX_POLL_ROUNDS * 30s = 30 min` per-iteration polling cap. */
+const DEFAULT_DRAIN_MAX_DURATION_MS = 30 * 60 * 1000;
+/** Default sleep between drain polls (30s). Matches the per-iteration polling
+ *  cadence — the worker queue moves on a similar timescale. */
+const DEFAULT_DRAIN_POLL_INTERVAL_MS = 30_000;
+
 /** A claim verdict row as returned by `getClaimStatus`. Mirrors the shape we
  *  consume from `apps/wiki-server/src/routes/claims/claims.ts`. */
 export interface ClaimVerdictRow {
@@ -224,6 +232,18 @@ export function buildVerifiedVerdictsFromBatch(
   return { verdicts: out, counts };
 }
 
+/** Mark every claim ID in `batch` whose latest verdict is verified/partial as
+ *  `appliedClaimIds`. Idempotent — safe to call after each apply. */
+function markAppliedFromLastVerdicts(batch: SubmittedBatchInfo): void {
+  for (let i = 0; i < batch.submittedByOrder.length; i++) {
+    const id = batch.claimIds[i];
+    if (id == null) continue;
+    const v = batch.lastVerdicts.find((x) => x.id === id);
+    if (!v) continue;
+    if (v.status === "verified" || v.status === "partial") batch.appliedClaimIds.add(id);
+  }
+}
+
 /** Count claim verdicts in pending/verifying status across all tracked batches. */
 function countPending(batches: SubmittedBatchInfo[]): number {
   let n = 0;
@@ -269,16 +289,21 @@ export async function drainPendingBatches(
   appliedAfterDrain: number;
   timedOut: boolean;
 }> {
-  const maxDurationMs = opts.maxDurationMs ?? 30 * 60 * 1000;
-  const pollIntervalMs = opts.pollIntervalMs ?? 30_000;
+  const maxDurationMs = opts.maxDurationMs ?? DEFAULT_DRAIN_MAX_DURATION_MS;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_DRAIN_POLL_INTERVAL_MS;
   const pollFn =
     opts.pollFn ??
     (async (batchId: string) => {
       const r = await getClaimStatus(batchId);
       if (!r.ok) return null;
       // The route returns `{ batchId, totalClaims, byStatus, claims, allSettled, estimatedRemaining }`.
-      const d = r.data as unknown as { allSettled: boolean; claims: ClaimVerdictRow[] };
-      return { allSettled: d.allSettled, claims: d.claims };
+      // It returns the FULL claim set (LIMIT 1000) for the batch on every
+      // call — see `apps/wiki-server/src/routes/claims/claims.ts::/status/:batchId`.
+      // If that ever becomes paginated, the merge-vs-replace assumption below
+      // (and in the per-iteration polling) will need revisiting.
+      const d = r.data as unknown as { allSettled?: unknown; claims?: unknown };
+      if (typeof d.allSettled !== "boolean" || !Array.isArray(d.claims)) return null;
+      return { allSettled: d.allSettled, claims: d.claims as ClaimVerdictRow[] };
     });
   const applyFn = opts.applyFn ?? applyVerdictsToEntity;
 
@@ -290,6 +315,7 @@ export async function drainPendingBatches(
   let appliedAfterDrain = 0;
   let timedOut = false;
   const t0 = Date.now();
+  let pollFailureCount = 0;
 
   // Outer loop: keep polling until no batch is unsettled or we time out.
   // The first pass also captures any batches that finished between the
@@ -298,7 +324,8 @@ export async function drainPendingBatches(
   while (true) {
     const unsettled = batches.filter((b) => !b.settled);
     if (unsettled.length === 0) break;
-    if (Date.now() - t0 >= maxDurationMs) {
+    const elapsed = Date.now() - t0;
+    if (elapsed >= maxDurationMs) {
       timedOut = true;
       console.warn(
         `[drain] max duration ${(maxDurationMs / 1000).toFixed(0)}s reached; ` +
@@ -307,7 +334,21 @@ export async function drainPendingBatches(
       break;
     }
 
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    // Cap the sleep to the remaining budget so a 30s default sleep can't
+    // overshoot a near-deadline check by up to 30s.
+    const sleepMs = Math.min(pollIntervalMs, maxDurationMs - elapsed);
+    await new Promise((r) => setTimeout(r, sleepMs));
+
+    // Re-check the deadline after the sleep so a clamped-to-zero sleep doesn't
+    // proceed to poll one more time past the cap.
+    if (Date.now() - t0 >= maxDurationMs) {
+      timedOut = true;
+      console.warn(
+        `[drain] max duration ${(maxDurationMs / 1000).toFixed(0)}s reached after sleep; ` +
+          `${unsettled.length} batch(es) still unsettled`,
+      );
+      break;
+    }
 
     for (const b of unsettled) {
       if (Date.now() - t0 >= maxDurationMs) {
@@ -315,7 +356,13 @@ export async function drainPendingBatches(
         break;
       }
       const sr = await pollFn(b.batchId);
-      if (!sr) continue;
+      if (!sr) {
+        pollFailureCount++;
+        // Log every transient failure at warn so debugging a stuck drain has
+        // a paper trail. The outer while-loop bound prevents indefinite spin.
+        console.warn(`[drain] pollFn returned null for batch ${b.batchId} (failure #${pollFailureCount})`);
+        continue;
+      }
       b.lastVerdicts = sr.claims;
       b.settled = sr.allSettled;
 
@@ -331,15 +378,7 @@ export async function drainPendingBatches(
         // Mark every verified/partial claim ID as applied so a subsequent
         // poll on the same batch (e.g. when the worker is still finalizing
         // others) doesn't re-build the same verdicts.
-        for (let i = 0; i < b.submittedByOrder.length; i++) {
-          const id = b.claimIds[i];
-          if (id == null) continue;
-          const v = b.lastVerdicts.find((x) => x.id === id);
-          if (!v) continue;
-          if (v.status === "verified" || v.status === "partial") {
-            b.appliedClaimIds.add(id);
-          }
-        }
+        markAppliedFromLastVerdicts(b);
       }
     }
   }
@@ -943,13 +982,7 @@ async function runIteration(
 
   // Mark every verified/partial claim ID as applied. The drain phase uses
   // this set to skip already-applied verdicts and only count NEW verifieds.
-  for (let i = 0; i < batch.submittedByOrder.length; i++) {
-    const id = batch.claimIds[i];
-    if (id == null) continue;
-    const v = lastVerdicts.find((x) => x.id === id);
-    if (!v) continue;
-    if (v.status === "verified" || v.status === "partial") batch.appliedClaimIds.add(id);
-  }
+  markAppliedFromLastVerdicts(batch);
 
   m.duration_s = (Date.now() - t0) / 1000;
   return { entity: apply.entity, metrics: m, batch };

--- a/crux/commands/research-improve-entity.ts
+++ b/crux/commands/research-improve-entity.ts
@@ -100,6 +100,13 @@ export interface ImproveResult {
   total_duration_s: number;
   hit_target: boolean;
   reason: string;
+  /** When `--wait-for-settle` is set: count of submitted claims still in
+   *  pending/verifying status when the main loop exited (target/iters/budget).
+   *  Omitted when the flag is off. */
+  pending_at_target_hit?: number;
+  /** When `--wait-for-settle` is set: additional verified+partial claims
+   *  finalized during the post-exit drain phase. Omitted when off. */
+  verified_after_drain?: number;
 }
 
 export interface ImproveOptions {
@@ -114,6 +121,230 @@ export interface ImproveOptions {
   dryRun?: boolean;
   /** When true, suppress the per-entity result dump. Used by the suite runner. */
   quiet?: boolean;
+  /** When true, after the main loop exits (target/iters/budget) keep polling
+   *  any unsettled batches until all claims reach a terminal status, applying
+   *  newly-verified verdicts to YAML. Default false (preserves prior
+   *  fast-exit behavior). Recommended for CI gate suite runs (QUA-871) so
+   *  per-run results aren't sensitive to worker-queue timing. */
+  waitForSettle?: boolean;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Wait-for-settle: per-batch tracking + drain helper (QUA-939)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** A claim verdict row as returned by `getClaimStatus`. Mirrors the shape we
+ *  consume from `apps/wiki-server/src/routes/claims/claims.ts`. */
+export interface ClaimVerdictRow {
+  id: number;
+  status: string;
+  verdictReasoning: string | null;
+  extractedValue: string | null;
+  claimText: string;
+}
+
+/** Per-batch state tracked across iterations so `drainPendingBatches` can
+ *  reconstruct VerifiedVerdicts after the main loop exits. Exported for tests. */
+export interface SubmittedBatchInfo {
+  iter: number;
+  batchId: string;
+  /** Submitted claims in submission order (parallel to `claimIds`). */
+  submittedByOrder: PreFilterClaim[];
+  /** Claim IDs returned by proposeClaims (parallel to `submittedByOrder`).
+   *  An entry is undefined only if the propose response had fewer rows than
+   *  expected — we keep the index aligned so the apply path can skip cleanly. */
+  claimIds: Array<number | undefined>;
+  /** True once a poll returned `allSettled`. */
+  settled: boolean;
+  /** Set of claim IDs (subset of `claimIds`) whose verdicts have already been
+   *  applied to the entity. Pre-filled by the per-iteration apply step;
+   *  the drain only applies claim IDs not in this set. */
+  appliedClaimIds: Set<number>;
+  /** Latest verdict rows seen (used to determine pending-vs-terminal status
+   *  and to construct VerifiedVerdicts on drain). */
+  lastVerdicts: ClaimVerdictRow[];
+}
+
+/** Tally of verdict statuses produced by {@link buildVerifiedVerdictsFromBatch}. */
+export interface VerdictCounts {
+  verified: number;
+  partial: number;
+  contradicted: number;
+  unverifiable: number;
+}
+
+/**
+ * Build {@link VerifiedVerdict}s for a single batch by joining its
+ * `submittedByOrder` (carries targetField/displayHint/position) with
+ * `lastVerdicts` (carries verdict status + extracted value) via the parallel
+ * `claimIds` array.
+ *
+ * When `onlyNew` is true, claim IDs already in `batch.appliedClaimIds` are
+ * skipped — used by the drain phase to compute "verifieds caught after the
+ * main loop exited" without re-applying earlier verdicts.
+ *
+ * Exported for testing.
+ */
+export function buildVerifiedVerdictsFromBatch(
+  batch: SubmittedBatchInfo,
+  onlyNew: boolean,
+): { verdicts: VerifiedVerdict[]; counts: VerdictCounts } {
+  const verdictsByClaimId = new Map(batch.lastVerdicts.map((v) => [v.id, v]));
+  const out: VerifiedVerdict[] = [];
+  const counts: VerdictCounts = { verified: 0, partial: 0, contradicted: 0, unverifiable: 0 };
+  for (let i = 0; i < batch.submittedByOrder.length; i++) {
+    const insertedId = batch.claimIds[i];
+    if (insertedId == null) continue;
+    if (onlyNew && batch.appliedClaimIds.has(insertedId)) continue;
+    const v = verdictsByClaimId.get(insertedId);
+    if (!v) continue;
+    const status = v.status;
+    if (status === "verified") counts.verified++;
+    else if (status === "partial") counts.partial++;
+    else if (status === "contradicted") counts.contradicted++;
+    else if (status === "unverifiable") counts.unverifiable++;
+    if (status === "verified" || status === "partial") {
+      const submitted = batch.submittedByOrder[i] as PreFilterClaim & {
+        position?: StakeholderPosition | null;
+        positionConfidence?: number | null;
+      };
+      out.push({
+        targetField: String(submitted.targetField ?? ""),
+        claimText: v.claimText,
+        extractedValue: v.extractedValue,
+        proposedValue: submitted.proposedValue as string | null | undefined,
+        sourceUrl: String(submitted.sourceUrl),
+        status,
+        displayHint: (submitted.displayHint as string | null) ?? undefined,
+        position: submitted.position ?? null,
+        positionConfidence: submitted.positionConfidence ?? null,
+      });
+    }
+  }
+  return { verdicts: out, counts };
+}
+
+/** Count claim verdicts in pending/verifying status across all tracked batches. */
+function countPending(batches: SubmittedBatchInfo[]): number {
+  let n = 0;
+  for (const b of batches) {
+    for (const v of b.lastVerdicts) {
+      if (v.status === "pending" || v.status === "verifying") n++;
+    }
+  }
+  return n;
+}
+
+export interface DrainOptions {
+  /** Max wall-clock time to spend draining (ms). Default 30 min. */
+  maxDurationMs?: number;
+  /** Sleep between polls (ms). Default 30s — matches per-iteration cadence. */
+  pollIntervalMs?: number;
+  /** Injected for tests. Defaults to the real `getClaimStatus`. Returns the
+   *  unwrapped status payload, or null on transport/API failure. */
+  pollFn?: (batchId: string) => Promise<{ allSettled: boolean; claims: ClaimVerdictRow[] } | null>;
+  /** Injected for tests. Defaults to {@link applyVerdictsToEntity}. */
+  applyFn?: (entity: EntityWithType, verdicts: VerifiedVerdict[]) => Promise<ApplyResult<EntityWithType>>;
+}
+
+/**
+ * Post-exit drain: poll every unsettled batch until allSettled or a global
+ * time cap is hit, applying any verdicts whose claim IDs were not yet in
+ * `appliedClaimIds`. Mutates `batches` in place (updates `settled`,
+ * `lastVerdicts`, `appliedClaimIds`) so the caller can inspect post-drain
+ * state if needed.
+ *
+ * Called from {@link improveSingleEntity} only when `--wait-for-settle` is set.
+ * Exported for testing.
+ */
+export async function drainPendingBatches(
+  entity: EntityWithType,
+  batches: SubmittedBatchInfo[],
+  opts: DrainOptions = {},
+): Promise<{
+  entity: EntityWithType;
+  pendingAtStart: number;
+  verifiedAfterDrain: number;
+  partialAfterDrain: number;
+  appliedAfterDrain: number;
+  timedOut: boolean;
+}> {
+  const maxDurationMs = opts.maxDurationMs ?? 30 * 60 * 1000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 30_000;
+  const pollFn =
+    opts.pollFn ??
+    (async (batchId: string) => {
+      const r = await getClaimStatus(batchId);
+      if (!r.ok) return null;
+      // The route returns `{ batchId, totalClaims, byStatus, claims, allSettled, estimatedRemaining }`.
+      const d = r.data as unknown as { allSettled: boolean; claims: ClaimVerdictRow[] };
+      return { allSettled: d.allSettled, claims: d.claims };
+    });
+  const applyFn = opts.applyFn ?? applyVerdictsToEntity;
+
+  const pendingAtStart = countPending(batches);
+
+  let cur = entity;
+  let verifiedAfterDrain = 0;
+  let partialAfterDrain = 0;
+  let appliedAfterDrain = 0;
+  let timedOut = false;
+  const t0 = Date.now();
+
+  // Outer loop: keep polling until no batch is unsettled or we time out.
+  // The first pass also captures any batches that finished between the
+  // per-iteration poll and now (they'll have `settled=false` but the next
+  // poll returns allSettled=true).
+  while (true) {
+    const unsettled = batches.filter((b) => !b.settled);
+    if (unsettled.length === 0) break;
+    if (Date.now() - t0 >= maxDurationMs) {
+      timedOut = true;
+      console.warn(
+        `[drain] max duration ${(maxDurationMs / 1000).toFixed(0)}s reached; ` +
+          `${unsettled.length} batch(es) still unsettled`,
+      );
+      break;
+    }
+
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+
+    for (const b of unsettled) {
+      if (Date.now() - t0 >= maxDurationMs) {
+        timedOut = true;
+        break;
+      }
+      const sr = await pollFn(b.batchId);
+      if (!sr) continue;
+      b.lastVerdicts = sr.claims;
+      b.settled = sr.allSettled;
+
+      const built = buildVerifiedVerdictsFromBatch(b, /*onlyNew*/ true);
+      if (built.verdicts.length > 0) {
+        const result = await applyFn(cur, built.verdicts);
+        cur = result.entity;
+        verifiedAfterDrain += built.counts.verified;
+        partialAfterDrain += built.counts.partial;
+        appliedAfterDrain += result.applied.filter(
+          (a) => a.action === "added" || a.action === "updated",
+        ).length;
+        // Mark every verified/partial claim ID as applied so a subsequent
+        // poll on the same batch (e.g. when the worker is still finalizing
+        // others) doesn't re-build the same verdicts.
+        for (let i = 0; i < b.submittedByOrder.length; i++) {
+          const id = b.claimIds[i];
+          if (id == null) continue;
+          const v = b.lastVerdicts.find((x) => x.id === id);
+          if (!v) continue;
+          if (v.status === "verified" || v.status === "partial") {
+            b.appliedClaimIds.add(id);
+          }
+        }
+      }
+    }
+  }
+
+  return { entity: cur, pendingAtStart, verifiedAfterDrain, partialAfterDrain, appliedAfterDrain, timedOut };
 }
 
 /** Zod runtime guard for {@link StakeholderPosition}. The literal list MUST
@@ -515,7 +746,7 @@ async function runIteration(
   entity: EntityWithType,
   iter: number,
   budgetRemainingUsd: number,
-): Promise<{ entity: EntityWithType; metrics: IterationMetrics }> {
+): Promise<{ entity: EntityWithType; metrics: IterationMetrics; batch: SubmittedBatchInfo | null }> {
   const t0 = Date.now();
   const m: IterationMetrics = {
     iter,
@@ -540,7 +771,7 @@ async function runIteration(
   if (gaps.length === 0) {
     console.log(`[iter ${iter}] No gaps. Done.`);
     m.duration_s = (Date.now() - t0) / 1000;
-    return { entity, metrics: m };
+    return { entity, metrics: m, batch: null };
   }
   console.log(`[iter ${iter}] gaps: ${gaps.map((g) => g.key).join(", ")}`);
 
@@ -599,7 +830,7 @@ async function runIteration(
 
   if (allClaims.length === 0) {
     m.duration_s = (Date.now() - t0) / 1000;
-    return { entity, metrics: m };
+    return { entity, metrics: m, batch: null };
   }
 
   // 4. Pre-submission token filter — key by sourceUrl (not resourceId).
@@ -634,7 +865,7 @@ async function runIteration(
 
   if (filterResult.kept.length === 0) {
     m.duration_s = (Date.now() - t0) / 1000;
-    return { entity, metrics: m };
+    return { entity, metrics: m, batch: null };
   }
 
   // 5. Submit claims (one batch). Cap at 50 to respect API limits.
@@ -657,7 +888,7 @@ async function runIteration(
   if (!proposeResult.ok) {
     console.warn(`[iter ${iter}] proposeClaims failed: ${proposeResult.error ?? proposeResult.message}`);
     m.duration_s = (Date.now() - t0) / 1000;
-    return { entity, metrics: m };
+    return { entity, metrics: m, batch: null };
   }
   const data = proposeResult.data as {
     batchId: string;
@@ -670,18 +901,12 @@ async function runIteration(
   let settled = false;
   let rounds = 0;
   const MAX_POLL_ROUNDS = 60;
-  let lastVerdicts: Array<{
-    id: number;
-    status: string;
-    verdictReasoning: string | null;
-    extractedValue: string | null;
-    claimText: string;
-  }> = [];
+  let lastVerdicts: ClaimVerdictRow[] = [];
   while (!settled && rounds < MAX_POLL_ROUNDS) {
     await new Promise((r) => setTimeout(r, 30000));
     const sr = await getClaimStatus(data.batchId);
     if (!sr.ok) break;
-    const sd = sr.data as unknown as { allSettled: boolean; claims: typeof lastVerdicts };
+    const sd = sr.data as unknown as { allSettled: boolean; claims: ClaimVerdictRow[] };
     lastVerdicts = sd.claims;
     settled = sd.allSettled;
     rounds++;
@@ -691,49 +916,43 @@ async function runIteration(
     if (settled) break;
   }
 
-  // 7. Apply verified+partial to YAML.
-  const verdictsByClaimId = new Map(lastVerdicts.map((v) => [v.id, v]));
-  const submittedByOrder = filterResult.kept;
-  const verifiedVerdicts: VerifiedVerdict[] = [];
-  for (let i = 0; i < submittedByOrder.length; i++) {
-    const insertedId = data.claims[i]?.id;
-    if (insertedId == null) continue;
-    const v = verdictsByClaimId.get(insertedId);
-    if (!v) continue;
-    const status = v.status;
-    if (status === "verified") m.claims_verified++;
-    else if (status === "partial") m.claims_partial++;
-    else if (status === "contradicted") m.claims_contradicted++;
-    else if (status === "unverifiable") m.claims_unverifiable++;
-    if (status === "verified" || status === "partial") {
-      const submitted = submittedByOrder[i] as PreFilterClaim & {
-        position?: StakeholderPosition | null;
-        positionConfidence?: number | null;
-      };
-      verifiedVerdicts.push({
-        targetField: String(submitted.targetField ?? ""),
-        claimText: v.claimText,
-        extractedValue: v.extractedValue,
-        proposedValue: submitted.proposedValue as string | null | undefined,
-        sourceUrl: String(submitted.sourceUrl),
-        status,
-        displayHint: (submitted.displayHint as string | null) ?? undefined,
-        position: submitted.position ?? null,
-        positionConfidence: submitted.positionConfidence ?? null,
-      });
-    }
-  }
+  // 7. Apply verified+partial to YAML. Build a SubmittedBatchInfo so the
+  //    outer loop can drain pending claims later if `--wait-for-settle` is set.
+  const batch: SubmittedBatchInfo = {
+    iter,
+    batchId: data.batchId,
+    submittedByOrder: filterResult.kept,
+    claimIds: data.claims.map((c) => c?.id),
+    settled,
+    appliedClaimIds: new Set<number>(),
+    lastVerdicts,
+  };
+  const built = buildVerifiedVerdictsFromBatch(batch, /*onlyNew*/ false);
+  m.claims_verified = built.counts.verified;
+  m.claims_partial = built.counts.partial;
+  m.claims_contradicted = built.counts.contradicted;
+  m.claims_unverifiable = built.counts.unverifiable;
   m.verified_rate = m.claims_proposed > 0 ? (m.claims_verified + m.claims_partial) / m.claims_proposed : 0;
 
-  const apply = await applyVerdictsToEntity(entity, verifiedVerdicts);
+  const apply = await applyVerdictsToEntity(entity, built.verdicts);
   m.applied_to_yaml = apply.applied.filter((a) => a.action === "added" || a.action === "updated").length;
   console.log(`[iter ${iter}] applied ${m.applied_to_yaml} new facts to YAML`);
   if (apply.warnings.length > 0) {
     for (const w of apply.warnings) console.warn(`[iter ${iter}] warning: ${w}`);
   }
 
+  // Mark every verified/partial claim ID as applied. The drain phase uses
+  // this set to skip already-applied verdicts and only count NEW verifieds.
+  for (let i = 0; i < batch.submittedByOrder.length; i++) {
+    const id = batch.claimIds[i];
+    if (id == null) continue;
+    const v = lastVerdicts.find((x) => x.id === id);
+    if (!v) continue;
+    if (v.status === "verified" || v.status === "partial") batch.appliedClaimIds.add(id);
+  }
+
   m.duration_s = (Date.now() - t0) / 1000;
-  return { entity: apply.entity, metrics: m };
+  return { entity: apply.entity, metrics: m, batch };
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -775,6 +994,7 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
   let entity = found.entity;
   const t0 = Date.now();
   const iterations: IterationMetrics[] = [];
+  const submittedBatches: SubmittedBatchInfo[] = [];
   let budgetRemaining = budgetUsd;
   let hitTarget = false;
   let reason = "max-iters";
@@ -787,6 +1007,7 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     const out = await runIteration(entity, i, budgetRemaining);
     entity = out.entity;
     iterations.push(out.metrics);
+    if (out.batch) submittedBatches.push(out.batch);
     budgetRemaining -= out.metrics.cost_research_usd + out.metrics.cost_extract_usd;
     const cov = coverageFor(entity);
     console.log(
@@ -803,6 +1024,30 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     }
   }
 
+  // Wait-for-settle drain (QUA-939). Only runs when the flag is set; without
+  // it, behavior matches today (exits as soon as target/iters/budget fires).
+  let pendingAtTargetHit: number | undefined;
+  let verifiedAfterDrain: number | undefined;
+  if (opts.waitForSettle && submittedBatches.length > 0) {
+    const pending = countPending(submittedBatches);
+    pendingAtTargetHit = pending;
+    if (pending > 0 || submittedBatches.some((b) => !b.settled)) {
+      console.log(
+        `[drain] ${pending} pending claim(s) across ${submittedBatches.length} batch(es); polling until settled`,
+      );
+      const drainResult = await drainPendingBatches(entity, submittedBatches);
+      entity = drainResult.entity;
+      verifiedAfterDrain = drainResult.verifiedAfterDrain + drainResult.partialAfterDrain;
+      console.log(
+        `[drain] complete: +${verifiedAfterDrain} verified, +${drainResult.appliedAfterDrain} applied to YAML` +
+          (drainResult.timedOut ? " (timed out)" : ""),
+      );
+    } else {
+      verifiedAfterDrain = 0;
+      console.log(`[drain] all ${submittedBatches.length} batch(es) already settled — no-op`);
+    }
+  }
+
   if (!noWrite) saveEntity(found.filePath, slug, entity);
   const finalCov = coverageFor(entity);
   const result: ImproveResult = {
@@ -816,6 +1061,8 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
     total_duration_s: (Date.now() - t0) / 1000,
     hit_target: hitTarget,
     reason,
+    ...(pendingAtTargetHit !== undefined ? { pending_at_target_hit: pendingAtTargetHit } : {}),
+    ...(verifiedAfterDrain !== undefined ? { verified_after_drain: verifiedAfterDrain } : {}),
   };
 
   // Persist per-entity run snapshot.
@@ -833,16 +1080,17 @@ export async function improveSingleEntity(opts: ImproveOptions): Promise<Improve
 export async function run(args: string[], options: Record<string, unknown>): Promise<CommandResult> {
   const slug = (args[0] || "").trim();
   if (!slug) {
-    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N]", exitCode: 1 };
+    return { output: "Usage: crux tb improve-entity <slug> [--target=N] [--budget=$] [--max-iters=N] [--wait-for-settle]", exitCode: 1 };
   }
   const target = options.target != null ? parseInt(options.target as string, 10) : 12;
   const maxIters = options.maxIters != null ? parseInt(options.maxIters as string, 10) : 3;
   const budgetUsd = options.budget != null ? parseFloat(options.budget as string) : 2.0;
   const noWrite = !!options.dryRun;
+  const waitForSettle = !!options.waitForSettle;
 
   let result: ImproveResult;
   try {
-    result = await improveSingleEntity({ slug, target, maxIters, budgetUsd, dryRun: noWrite });
+    result = await improveSingleEntity({ slug, target, maxIters, budgetUsd, dryRun: noWrite, waitForSettle });
   } catch (err) {
     return { output: err instanceof Error ? err.message : String(err), exitCode: 1 };
   }
@@ -851,7 +1099,7 @@ export async function run(args: string[], options: Record<string, unknown>): Pro
 
 export function help(): CommandResult {
   return {
-    output: `crux tb improve-entity <slug> [--target=N] [--budget=N] [--max-iters=N]
+    output: `crux tb improve-entity <slug> [--target=N] [--budget=N] [--max-iters=N] [--wait-for-settle]
 
 Closed-loop iterative entity improver. Discovers sources via runResearch,
 extracts gap-targeted claims with Haiku, pre-filters by token presence,
@@ -861,10 +1109,15 @@ to the entity's source YAML file under data/entities/.
 Supported entity types: policy, organization.
 
 Options:
-  --target=N      Stop when (provisions+stakeholders for policy, products+keyPeople+keyDates for org) ≥ N (default: 12)
-  --budget=N      Max LLM spend in USD (default: 2.0)
-  --max-iters=N   Max iterations (default: 3)
-  --dry-run       Don't write YAML
+  --target=N           Stop when (provisions+stakeholders for policy, products+keyPeople+keyDates for org) ≥ N (default: 12)
+  --budget=N           Max LLM spend in USD (default: 2.0)
+  --max-iters=N        Max iterations (default: 3)
+  --dry-run            Don't write YAML
+  --wait-for-settle    After the main loop exits (target/iters/budget), keep
+                       polling any unsettled batches until all claims reach a
+                       terminal status, applying any newly-verified verdicts
+                       (capped at 30 min). Recommended for CI gate / suite runs
+                       so per-run results aren't sensitive to worker timing.
 `,
     exitCode: 0,
   };


### PR DESCRIPTION
## Summary

`crux tb improve-entity` exits as soon as the target slot count is reached, even when claim verifications are still in flight. This wastes spend (queued verifications) and loses verifieds that would have applied with more time.

This PR adds `--wait-for-settle` (default off): after the main loop exits (target / max-iters / budget), poll any unsettled batches until every claim reaches a terminal status, applying any newly-verified verdicts to YAML. Capped at 30 min wall-clock.

- New flag: `pnpm crux tb improve-entity <slug> --wait-for-settle`
- New schema fields on the run-snapshot JSON (only present when the flag is set):
  - `pending_at_target_hit: int` — pending/verifying claims still in flight when the main loop exited
  - `verified_after_drain: int` — additional verified+partial claims captured by the drain

Default behavior is unchanged.

## Implementation

- `runIteration` now returns the per-iteration `SubmittedBatchInfo` (batchId, submittedByOrder, claimIds, settled, appliedClaimIds, lastVerdicts) alongside its existing entity + metrics output.
- `improveSingleEntity` collects each iteration's batch and, when `--wait-for-settle` is set, calls the new `drainPendingBatches` helper. The helper polls each unsettled batch, reuses the existing `applyVerdictsToPolicy` / `applyVerdictsToOrganization` paths via `applyVerdictsToEntity`, and is bounded by a 30-min global cap.
- New helpers (`buildVerifiedVerdictsFromBatch`, `drainPendingBatches`, `markAppliedFromLastVerdicts`) are exported for testing. Per-iteration polling logic is otherwise unchanged.
- CLI flag wired through; suite plumbing intentionally left for QUA-871 (the CI gate ticket).

## Tests

15 new tests in `crux/commands/research-improve-entity.test.ts`:

- **`buildVerifiedVerdictsFromBatch`** — verified+partial mapping, contradicted/unverifiable counts, `onlyNew` filter, undefined claim IDs, missing verdicts, pending status.
- **`drainPendingBatches` — 3 acceptance scenarios** (per the issue):
  1. target-hit before any pending — drain is a no-op
  2. target-hit with pending — drain catches new verifieds and applies them
  3. target-hit with all settled — drain is a no-op
- **Edge cases**: 30-min timeout, multiple batches tracked independently, idempotent re-poll across rounds, transient `pollFn` errors tolerated.

```
✓ crux/commands/research-improve-entity.test.ts (15 tests) 38ms
✓ crux/commands/research-improve-entity-suite.test.ts (32 tests, unchanged)
```

Gate: `✅ All 61 gate checks passed`.

## Review fixes (after `/agent-review-pr`)

- Cap inner-loop sleep to remaining budget so a 30s default sleep can't overshoot a near-deadline check (previously the deadline check ran before the sleep, allowing up to a 30s overshoot).
- Re-check the deadline after the sleep so a clamped-to-zero sleep doesn't proceed to one final poll past the cap.
- Validate the default pollFn's response shape (Array.isArray, typeof allSettled === "boolean") before unwrapping; treat malformed responses the same as transport errors.
- Log a console.warn on every null pollFn response so a stuck drain leaves a paper trail.
- Extract `markAppliedFromLastVerdicts` so runIteration and drainPendingBatches share one implementation of the applied-claim backfill.
- Hoist `DEFAULT_DRAIN_MAX_DURATION_MS` / `DEFAULT_DRAIN_POLL_INTERVAL_MS` to module-level constants.
- Document the assumption that `/status/:batchId` returns the full claim set per call (LIMIT 1000, no pagination); flag that the merge-vs-replace pattern would need revisiting if pagination is added.

## Test plan

- [x] Unit tests cover the 3 acceptance scenarios from the issue plus edge cases.
- [x] Existing suite tests still pass (the new `ImproveResult` fields are optional).
- [x] `pnpm crux w validate gate --fix` clean.
- [x] CLI help shows the new flag.
- [x] Review fixes addressed `/agent-review-pr` HIGH/MEDIUM findings.
- [ ] Future (out-of-scope): validate against a real entity (e.g. `anthropic`) once a real run is feasible, and flip the suite default for the CI gate (QUA-871).

Fixes QUA-939
