### PR TITLE
feat(validate): entity-schema drift validator for tablebase routes (QUA-944)

### DIFF
--- a/crux/validate/.entity-schema-drift-allowlist.txt
+++ b/crux/validate/.entity-schema-drift-allowlist.txt
@@ -1,0 +1,47 @@
+# QUA-943: Files in apps/wiki-server/src/routes/tablebase/ allowed to contain
+# entity-schema drift markers (`const VALID_*` declarations or inline `z.enum([`
+# literals) pending migration to canonical entity schemas in
+# packages/entity-schemas (per Plan v2).
+#
+# This list is the QUA-943 closure metric. As routes migrate to canonical
+# schemas, remove entries from this file. The validator fails if a route NOT
+# on this list contains drift markers — preventing new drift from accumulating
+# while migration is in progress. Goal: this file is empty when QUA-943 closes.
+#
+# Suppressing a single line (e.g., a legitimate query-string enum that should
+# not be migrated): add `// schema-drift-ok` on the same line as the marker.
+#
+# Format: one file path per line, relative to repo root. Empty lines and
+# comments (lines starting with `#`) are ignored.
+apps/wiki-server/src/routes/tablebase/ai-incidents.ts
+apps/wiki-server/src/routes/tablebase/benchmark-results-pending.ts
+apps/wiki-server/src/routes/tablebase/benchmark-shared.ts
+apps/wiki-server/src/routes/tablebase/benchmarks.ts
+apps/wiki-server/src/routes/tablebase/data-sources.ts
+apps/wiki-server/src/routes/tablebase/divisions.ts
+apps/wiki-server/src/routes/tablebase/entities.ts
+apps/wiki-server/src/routes/tablebase/entity-assessments.ts
+apps/wiki-server/src/routes/tablebase/entity-events.ts
+apps/wiki-server/src/routes/tablebase/framework-diff-items.ts
+apps/wiki-server/src/routes/tablebase/framework-ingest-log.ts
+apps/wiki-server/src/routes/tablebase/funding-programs.ts
+apps/wiki-server/src/routes/tablebase/grants.ts
+apps/wiki-server/src/routes/tablebase/model-aliases.ts
+apps/wiki-server/src/routes/tablebase/model-system-cards.ts
+apps/wiki-server/src/routes/tablebase/personnel.ts
+apps/wiki-server/src/routes/tablebase/platform-accounts.ts
+apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+apps/wiki-server/src/routes/tablebase/political-offices.ts
+apps/wiki-server/src/routes/tablebase/political-races.ts
+apps/wiki-server/src/routes/tablebase/political-votes.ts
+apps/wiki-server/src/routes/tablebase/prediction-markets.ts
+apps/wiki-server/src/routes/tablebase/publications.ts
+apps/wiki-server/src/routes/tablebase/record-lookup.ts
+apps/wiki-server/src/routes/tablebase/research-areas.ts
+apps/wiki-server/src/routes/tablebase/safety-framework-versions.ts
+apps/wiki-server/src/routes/tablebase/safety-frameworks.ts
+apps/wiki-server/src/routes/tablebase/scorecard-snapshots.ts
+apps/wiki-server/src/routes/tablebase/secondary-market-prices.ts
+apps/wiki-server/src/routes/tablebase/things.ts
+apps/wiki-server/src/routes/tablebase/third-party-evaluations.ts
+apps/wiki-server/src/routes/tablebase/website-sources.ts

--- a/crux/validate/validate-entity-schema-drift.test.ts
+++ b/crux/validate/validate-entity-schema-drift.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { checkLine, runCheck, readAllowlist } from "./validate-entity-schema-drift.ts";
+
+describe("validate-entity-schema-drift checkLine", () => {
+  it("flags const VALID_FOO declaration", () => {
+    expect(checkLine('const VALID_POSITIONS = ["support", "oppose"] as const;')).toBe("VALID_CONST");
+  });
+
+  it("flags exported VALID_*", () => {
+    expect(checkLine('export const VALID_RISK_DOMAINS = [')).toBe("VALID_CONST");
+  });
+
+  it("flags inline z.enum([", () => {
+    expect(checkLine('  sort: z.enum(["title", "updated_at"]).default("title"),')).toBe("INLINE_ENUM");
+  });
+
+  it("ignores z.enum(SOMETHING) without [", () => {
+    expect(checkLine('sort: z.enum(SORT_KEYS).default("title")')).toBeNull();
+  });
+
+  it("ignores comments", () => {
+    expect(checkLine('// const VALID_FOO = ["a"]')).toBeNull();
+    expect(checkLine(' * z.enum(["x"])')).toBeNull();
+  });
+
+  it("respects // schema-drift-ok suppression", () => {
+    expect(checkLine('const VALID_QUERY_DIR = ["asc","desc"]; // schema-drift-ok')).toBeNull();
+    expect(checkLine('  dir: z.enum(["asc","desc"]), // schema-drift-ok')).toBeNull();
+  });
+
+  it("does not match VALID_ inside string literal", () => {
+    expect(checkLine('const msg = "Use a const VALID_FOO declaration"')).toBeNull();
+  });
+
+  it("ignores plain `valid` (case-sensitive)", () => {
+    expect(checkLine("const valid = true;")).toBeNull();
+  });
+});
+
+describe("validate-entity-schema-drift runCheck", () => {
+  let tmpRoot: string;
+  let routesDir: string;
+  let allowlistPath: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "qua-943-"));
+    routesDir = join(tmpRoot, "routes/tablebase");
+    mkdirSync(routesDir, { recursive: true });
+    allowlistPath = join(tmpRoot, "allowlist.txt");
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("passes when no drift markers exist anywhere", () => {
+    writeFileSync(join(routesDir, "clean.ts"), "import { z } from 'zod';\nconst schema = z.object({});\n");
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toBe(0);
+  });
+
+  it("passes when drift exists only in allowlisted files", () => {
+    writeFileSync(join(routesDir, "old.ts"), 'const VALID_THINGS = ["a"];\n');
+    writeFileSync(allowlistPath, "routes/tablebase/old.ts\n");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(true);
+    expect(result.fileCountWithDrift).toBe(1);
+  });
+
+  it("fails when a non-allowlisted file contains a VALID_* const", () => {
+    writeFileSync(join(routesDir, "new.ts"), 'const VALID_NEW = ["x", "y"];\n');
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(false);
+    expect(result.newViolations).toHaveLength(1);
+    expect(result.newViolations[0].kind).toBe("VALID_CONST");
+  });
+
+  it("fails when a non-allowlisted file contains inline z.enum([", () => {
+    writeFileSync(join(routesDir, "new.ts"), "const s = z.enum([\"a\", \"b\"]);\n");
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(false);
+    expect(result.newViolations[0].kind).toBe("INLINE_ENUM");
+  });
+
+  it("fails on stale allowlist entry (file no longer contains drift)", () => {
+    writeFileSync(join(routesDir, "clean.ts"), "import { z } from 'zod';\n");
+    writeFileSync(allowlistPath, "routes/tablebase/clean.ts\n");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(false);
+    expect(result.staleEntries).toEqual(["routes/tablebase/clean.ts"]);
+  });
+
+  it("ignores .test.ts files", () => {
+    writeFileSync(join(routesDir, "x.test.ts"), 'const VALID_FOO = ["a"];\n');
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(true);
+  });
+
+  it("respects per-line // schema-drift-ok suppression even outside allowlist", () => {
+    writeFileSync(
+      join(routesDir, "queries.ts"),
+      'const sortDir = z.enum(["asc","desc"]); // schema-drift-ok\n',
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe("validate-entity-schema-drift readAllowlist", () => {
+  it("ignores blank lines and comments", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "qua-943-allow-"));
+    try {
+      const path = join(tmp, "allow.txt");
+      writeFileSync(path, "# header\n\nfoo/bar.ts\n  # indented comment is just data, not allowed\nbaz.ts\n\n");
+      const set = readAllowlist(path);
+      expect(set.has("foo/bar.ts")).toBe(true);
+      expect(set.has("baz.ts")).toBe(true);
+      expect(set.has("# header")).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/crux/validate/validate-entity-schema-drift.test.ts
+++ b/crux/validate/validate-entity-schema-drift.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { checkLine, runCheck, readAllowlist } from "./validate-entity-schema-drift.ts";
@@ -8,6 +8,9 @@ describe("validate-entity-schema-drift checkLine", () => {
   it("flags const VALID_FOO declaration", () => {
     expect(checkLine('const VALID_POSITIONS = ["support", "oppose"] as const;')).toBe("VALID_CONST");
   });
+
+  // Multi-line declarations (`const VALID_X\n  = [...]`) are caught by the
+  // file-level multi-line pass in checkFile, not by checkLine.
 
   it("flags exported VALID_*", () => {
     expect(checkLine('export const VALID_RISK_DOMAINS = [')).toBe("VALID_CONST");
@@ -104,6 +107,29 @@ describe("validate-entity-schema-drift runCheck", () => {
     expect(result.passed).toBe(true);
   });
 
+  it("catches multi-line const VALID_* declarations split across two lines", () => {
+    writeFileSync(
+      join(routesDir, "split.ts"),
+      "const VALID_FOO\n  = [\"a\", \"b\"] as const;\n",
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(false);
+    expect(result.newViolations).toHaveLength(1);
+    expect(result.newViolations[0].kind).toBe("VALID_CONST");
+  });
+
+  it("catches multi-line z.enum split across two lines", () => {
+    writeFileSync(
+      join(routesDir, "split-enum.ts"),
+      "const s = z.enum(\n  [\"a\", \"b\"]\n);\n",
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.passed).toBe(false);
+    expect(result.newViolations[0].kind).toBe("INLINE_ENUM");
+  });
+
   it("respects per-line // schema-drift-ok suppression even outside allowlist", () => {
     writeFileSync(
       join(routesDir, "queries.ts"),
@@ -112,6 +138,56 @@ describe("validate-entity-schema-drift runCheck", () => {
     writeFileSync(allowlistPath, "");
     const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
     expect(result.passed).toBe(true);
+  });
+});
+
+describe("validate-entity-schema-drift --update mode", () => {
+  let tmpRoot: string;
+  let routesDir: string;
+  let allowlistPath: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "qua-944-update-"));
+    routesDir = join(tmpRoot, "routes/tablebase");
+    mkdirSync(routesDir, { recursive: true });
+    allowlistPath = join(tmpRoot, "allowlist.txt");
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("rewrites allowlist with current files containing drift, sorted", () => {
+    writeFileSync(join(routesDir, "z-last.ts"), 'const VALID_X = ["a"];\n');
+    writeFileSync(join(routesDir, "a-first.ts"), 'const VALID_Y = ["b"];\n');
+    writeFileSync(allowlistPath, "# header preserved\n\n");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot, updateBaseline: true });
+    expect(result.passed).toBe(true);
+    const written = readFileSync(allowlistPath, "utf-8");
+    expect(written).toContain("# header preserved");
+    const entries = written.split("\n").filter(l => l && !l.startsWith("#"));
+    expect(entries).toEqual([
+      "routes/tablebase/a-first.ts",
+      "routes/tablebase/z-last.ts",
+    ]);
+  });
+
+  it("does not crash when allowlist file does not exist", () => {
+    writeFileSync(join(routesDir, "x.ts"), 'const VALID_X = ["a"];\n');
+    // allowlistPath intentionally not created
+    expect(() => runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot, updateBaseline: true })).not.toThrow();
+    const written = readFileSync(allowlistPath, "utf-8");
+    expect(written).toContain("routes/tablebase/x.ts");
+  });
+
+  it("writes empty list when no drift exists", () => {
+    writeFileSync(join(routesDir, "clean.ts"), "import { z } from 'zod';\n");
+    writeFileSync(allowlistPath, "# header\n");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot, updateBaseline: true });
+    expect(result.passed).toBe(true);
+    const written = readFileSync(allowlistPath, "utf-8");
+    const entries = written.split("\n").filter(l => l && !l.startsWith("#"));
+    expect(entries).toEqual([]);
   });
 });
 

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -22,7 +22,7 @@
  *   npx tsx crux/validate/validate-entity-schema-drift.ts --update   # rewrite allowlist
  */
 
-import { readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
@@ -31,8 +31,19 @@ const TABLEBASE_ROUTES_DIR = join(PROJECT_ROOT, 'apps/wiki-server/src/routes/tab
 const ALLOWLIST_PATH = join(PROJECT_ROOT, 'crux/validate/.entity-schema-drift-allowlist.txt');
 const SUPPRESS_COMMENT = 'schema-drift-ok';
 
+// Single-line patterns. The trailing `\s*=` keeps these tight against
+// false-positive matches inside string literals (e.g.
+// `const msg = "Use a const VALID_FOO declaration"` doesn't end with
+// `=` after VALID_FOO so it is not flagged). Multi-line declarations
+// (`const VALID_X\n  = [...]`, formatter-induced) are caught by the
+// MULTILINE_PATTERNS pass below, which joins line N with line N+1.
 const VALID_CONST_RE = /\bconst\s+VALID_[A-Z_]+\s*=/;
 const INLINE_ENUM_RE = /z\.enum\(\[/;
+
+const MULTILINE_PATTERNS: Array<{ pattern: RegExp; kind: Violation['kind'] }> = [
+  { pattern: /\bconst\s+VALID_[A-Z_]+\s*=/, kind: 'VALID_CONST' },
+  { pattern: /z\.enum\(\s*\[/, kind: 'INLINE_ENUM' },
+];
 
 export interface Violation {
   file: string;
@@ -112,12 +123,27 @@ function checkFile(filePath: string, baseDir: string): Violation[] {
   for (let i = 0; i < lines.length; i++) {
     const kind = checkLine(lines[i]);
     if (kind) {
-      violations.push({
-        file: relPath,
-        line: i + 1,
-        text: lines[i].trimStart(),
-        kind,
-      });
+      violations.push({ file: relPath, line: i + 1, text: lines[i].trimStart(), kind });
+      continue;
+    }
+    // Multi-line check: join current line with next to catch declarations split
+    // across lines (e.g. `const VALID_X\n  = [...]`).
+    if (i + 1 >= lines.length) continue;
+    const nextLine = lines[i + 1];
+    const nextTrim = nextLine.trimStart();
+    if (nextTrim.startsWith('//') || nextTrim.startsWith('*') || nextTrim.startsWith('/*')) continue;
+    if (isSuppressed(lines[i]) || isSuppressed(nextLine)) continue;
+    const joined = lines[i].trimEnd() + ' ' + nextTrim;
+    for (const { pattern, kind: mlKind } of MULTILINE_PATTERNS) {
+      if (pattern.test(joined) && !pattern.test(lines[i])) {
+        violations.push({
+          file: relPath,
+          line: i + 1,
+          text: `${lines[i].trimStart()} ${nextTrim}`.trim(),
+          kind: mlKind,
+        });
+        break;
+      }
     }
   }
   return violations;
@@ -158,16 +184,14 @@ export function runCheck(
 
   console.log(`${c.blue}Checking entity-schema drift in ${relative(baseDir, rootDir)}/...${c.reset}\n`);
 
-  let allFiles: string[];
-  try {
-    allFiles = collectTsFiles(rootDir);
-  } catch {
+  if (!existsSync(rootDir)) {
     console.log(`${c.dim}Skipping: ${rootDir} not found${c.reset}`);
     return {
       passed: true, errors: 0, newViolations: [], staleEntries: [],
       allowlistedFileCount: 0, fileCountWithDrift: 0,
     };
   }
+  const allFiles = collectTsFiles(rootDir);
 
   const filesWithDrift = new Map<string, Violation[]>();
   for (const file of allFiles) {
@@ -177,7 +201,13 @@ export function runCheck(
 
   if (opts.updateBaseline) {
     const sorted = [...filesWithDrift.keys()].sort();
-    const header = readFileSync(allowlistPath, 'utf-8').split('\n')
+    let existing: string;
+    try {
+      existing = readFileSync(allowlistPath, 'utf-8');
+    } catch {
+      existing = '';
+    }
+    const header = existing.split('\n')
       .filter(l => l.startsWith('#') || l.trim() === '')
       .join('\n')
       .replace(/\n+$/, '\n');

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Entity-schema drift validator (QUA-943 — Plan v2 step 0c).
+ *
+ * Bans new `const VALID_*` declarations and inline `z.enum([...])` literals in
+ * apps/wiki-server/src/routes/tablebase/ — both are markers of an entity wire
+ * schema being hand-written in a sync route instead of imported from the
+ * canonical schema package (target: packages/entity-schemas, per QUA-943).
+ *
+ * The current baseline of files containing drift markers is recorded in
+ * .entity-schema-drift-allowlist.txt. As routes migrate to canonical schemas
+ * (Plan v2 PRs 5a/5b), entries are removed from the allowlist. This file
+ * reaches zero entries when QUA-943 closes.
+ *
+ * Suppression for legitimate inline enums (e.g., query-string enums that are
+ * not entity wire shapes): add `// schema-drift-ok` on the same line as the
+ * marker.
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-entity-schema-drift.ts            # check
+ *   npx tsx crux/validate/validate-entity-schema-drift.ts --update   # rewrite allowlist
+ */
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { join, relative } from 'path';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import { getColors } from '../lib/output.ts';
+
+const TABLEBASE_ROUTES_DIR = join(PROJECT_ROOT, 'apps/wiki-server/src/routes/tablebase');
+const ALLOWLIST_PATH = join(PROJECT_ROOT, 'crux/validate/.entity-schema-drift-allowlist.txt');
+const SUPPRESS_COMMENT = 'schema-drift-ok';
+
+const VALID_CONST_RE = /\bconst\s+VALID_[A-Z_]+\s*=/;
+const INLINE_ENUM_RE = /z\.enum\(\[/;
+
+export interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  kind: 'VALID_CONST' | 'INLINE_ENUM';
+}
+
+function isSuppressed(line: string): boolean {
+  const commentIdx = findLineCommentStart(line);
+  if (commentIdx === -1) return false;
+  return line.slice(commentIdx).includes(SUPPRESS_COMMENT);
+}
+
+function findLineCommentStart(line: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  let inTemplate = false;
+  for (let i = 0; i < line.length; i++) {
+    if (i > 0 && line[i - 1] === '\\') continue;
+    const ch = line[i];
+    if (ch === "'" && !inDouble && !inTemplate) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle && !inTemplate) { inDouble = !inDouble; continue; }
+    if (ch === '`' && !inSingle && !inDouble) { inTemplate = !inTemplate; continue; }
+    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '/') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function checkLine(line: string): Violation['kind'] | null {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+    return null;
+  }
+  if (isSuppressed(line)) return null;
+  if (VALID_CONST_RE.test(line)) return 'VALID_CONST';
+  if (INLINE_ENUM_RE.test(line)) return 'INLINE_ENUM';
+  return null;
+}
+
+function collectTsFiles(dir: string): string[] {
+  const results: string[] = [];
+  function walk(current: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(current, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        if (entry === '__tests__' || entry === 'node_modules') continue;
+        walk(fullPath);
+      } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+function checkFile(filePath: string, baseDir: string): Violation[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+  const relPath = relative(baseDir, filePath);
+  for (let i = 0; i < lines.length; i++) {
+    const kind = checkLine(lines[i]);
+    if (kind) {
+      violations.push({
+        file: relPath,
+        line: i + 1,
+        text: lines[i].trimStart(),
+        kind,
+      });
+    }
+  }
+  return violations;
+}
+
+export function readAllowlist(path: string = ALLOWLIST_PATH): Set<string> {
+  const allowed = new Set<string>();
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf-8');
+  } catch {
+    return allowed;
+  }
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    allowed.add(line);
+  }
+  return allowed;
+}
+
+interface CheckResult {
+  passed: boolean;
+  errors: number;
+  newViolations: Violation[];
+  staleEntries: string[];
+  allowlistedFileCount: number;
+  fileCountWithDrift: number;
+}
+
+export function runCheck(
+  opts: { rootDir?: string; allowlistPath?: string; baseDir?: string; updateBaseline?: boolean } = {},
+): CheckResult {
+  const c = getColors();
+  const rootDir = opts.rootDir ?? TABLEBASE_ROUTES_DIR;
+  const allowlistPath = opts.allowlistPath ?? ALLOWLIST_PATH;
+  const baseDir = opts.baseDir ?? PROJECT_ROOT;
+
+  console.log(`${c.blue}Checking entity-schema drift in ${relative(baseDir, rootDir)}/...${c.reset}\n`);
+
+  let allFiles: string[];
+  try {
+    allFiles = collectTsFiles(rootDir);
+  } catch {
+    console.log(`${c.dim}Skipping: ${rootDir} not found${c.reset}`);
+    return {
+      passed: true, errors: 0, newViolations: [], staleEntries: [],
+      allowlistedFileCount: 0, fileCountWithDrift: 0,
+    };
+  }
+
+  const filesWithDrift = new Map<string, Violation[]>();
+  for (const file of allFiles) {
+    const v = checkFile(file, baseDir);
+    if (v.length > 0) filesWithDrift.set(v[0].file, v);
+  }
+
+  if (opts.updateBaseline) {
+    const sorted = [...filesWithDrift.keys()].sort();
+    const header = readFileSync(allowlistPath, 'utf-8').split('\n')
+      .filter(l => l.startsWith('#') || l.trim() === '')
+      .join('\n')
+      .replace(/\n+$/, '\n');
+    const body = sorted.join('\n') + '\n';
+    writeFileSync(allowlistPath, header + body);
+    console.log(`${c.green}Wrote ${sorted.length} entries to ${relative(baseDir, allowlistPath)}${c.reset}`);
+    return {
+      passed: true, errors: 0, newViolations: [], staleEntries: [],
+      allowlistedFileCount: sorted.length, fileCountWithDrift: sorted.length,
+    };
+  }
+
+  const allowed = readAllowlist(allowlistPath);
+  const newViolations: Violation[] = [];
+  for (const [file, vs] of filesWithDrift) {
+    if (!allowed.has(file)) newViolations.push(...vs);
+  }
+
+  const staleEntries: string[] = [];
+  for (const entry of allowed) {
+    if (!filesWithDrift.has(entry)) staleEntries.push(entry);
+  }
+
+  const errors = newViolations.length + staleEntries.length;
+  if (errors === 0) {
+    console.log(`${c.green}No entity-schema drift outside allowlist (${filesWithDrift.size} files allowlisted, ${allFiles.length} files scanned)${c.reset}`);
+    if (filesWithDrift.size > 0) {
+      console.log(`${c.dim}QUA-943 closure metric: ${filesWithDrift.size} files still need migration to canonical schemas${c.reset}`);
+    }
+  } else {
+    if (newViolations.length > 0) {
+      console.log(`${c.red}Found ${newViolations.length} drift marker(s) in ${new Set(newViolations.map(v => v.file)).size} non-allowlisted file(s):${c.reset}\n`);
+      for (const v of newViolations) {
+        console.log(`  ${c.red}${v.file}:${v.line}${c.reset} [${v.kind}]`);
+        console.log(`    ${c.dim}${v.text}${c.reset}`);
+      }
+      console.log(`\n${c.dim}Fix: import the canonical schema from packages/entity-schemas (QUA-943) instead of hand-writing.${c.reset}`);
+      console.log(`${c.dim}Suppress a single legitimate use (e.g., query-string enum): add \`// ${SUPPRESS_COMMENT}\` on the same line.${c.reset}`);
+      console.log(`${c.dim}If migration to canonical schemas is not yet possible, add the file to ${relative(PROJECT_ROOT, allowlistPath)}.${c.reset}\n`);
+    }
+    if (staleEntries.length > 0) {
+      console.log(`${c.yellow}${staleEntries.length} stale allowlist entr${staleEntries.length === 1 ? 'y' : 'ies'} (file no longer contains drift markers — please remove):${c.reset}`);
+      for (const entry of staleEntries) console.log(`  ${c.yellow}${entry}${c.reset}`);
+      console.log(`\n${c.dim}Update with: npx tsx crux/validate/validate-entity-schema-drift.ts --update${c.reset}\n`);
+    }
+  }
+
+  return {
+    passed: errors === 0,
+    errors,
+    newViolations,
+    staleEntries,
+    allowlistedFileCount: allowed.size,
+    fileCountWithDrift: filesWithDrift.size,
+  };
+}
+
+const __isMain = process.argv[1]?.includes('validate-entity-schema-drift');
+if (__isMain) {
+  const updateBaseline = process.argv.includes('--update');
+  const result = runCheck({ updateBaseline });
+  process.exit(result.passed ? 0 : 1);
+}

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -427,6 +427,20 @@ const PARALLEL_STEPS: Step[] = [
     cwd: PROJECT_ROOT,
   },
   {
+    id: 'entity-schema-drift',
+    name: 'Entity-schema drift in tablebase routes (QUA-943)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-entity-schema-drift.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking. Bans new `const VALID_*` and inline `z.enum([` in
+    // apps/wiki-server/src/routes/tablebase/ outside the allowlist at
+    // crux/validate/.entity-schema-drift-allowlist.txt. The allowlist length
+    // is the QUA-943 closure metric — entries get removed as routes migrate
+    // to canonical schemas in packages/entity-schemas (Plan v2 PRs 5a/5b).
+    // Suppress per-line legitimate uses (e.g., query enums) with
+    // `// schema-drift-ok`.
+  },
+  {
     id: 'prompt-escaping',
     name: 'Prompt XML interpolation escaping',
     command: 'npx',


### PR DESCRIPTION
## Summary

Plan v2 step 0c of the [QUA-943 epic](https://linear.app/quantifieduncertainty/issue/QUA-943): a perpetual gate validator that bans new `const VALID_*` declarations and inline `z.enum([` literals in `apps/wiki-server/src/routes/tablebase/` outside an allowlist. Both are markers of an entity wire schema being hand-written in a sync route instead of imported from the canonical schema package (target: `packages/entity-schemas`, per Plan v2).

This replaces QUA-944's static "drift inventory" with a perpetual validator that emits the drift count on every CI run.

## Why

QUA-941 (FISA-702 silent stakeholder drop) was the symptom of three Zod schemas describing the same entity-type with different strictness — the gate's loose `data/schema.ts::Entity` accepted `position: reform`, the strict sync route Zod rejected it, the `syncPolicyStakeholders` helper swallowed the 400, and the build "succeeded" with rows missing from prod.

This PR adds the closure metric for the QUA-943 epic: a count of files still hand-rolling local enum constants. As routes migrate to canonical schemas (Plan v2 PRs 5a/5b), entries get removed from the allowlist and the metric trends to zero.

## Baseline

**32 of 59 tablebase route files** currently contain drift markers (57 `VALID_*` constants + 6 inline `z.enum([` literals across them). Allowlist sorted at `crux/validate/.entity-schema-drift-allowlist.txt`.

## Mechanics

- **Validator**: `crux/validate/validate-entity-schema-drift.ts`. Standalone runnable; `--update` rewrites the allowlist from current state.
- **Single-line + multi-line detection**: catches both `const VALID_X = [...]` and the formatter-induced `const VALID_X\n  = [...]` (which the single-line regex would bypass).
- **Suppression**: `// schema-drift-ok` on the same line lets legitimate per-line uses (e.g. query-string enums in migrated routes) stay without keeping the file allowlisted.
- **Gate wiring**: blocking entry in `parallelChecks` of `validate-gate.ts`.
- **Tests**: 21 unit tests covering checkLine + checkFile multi-line + runCheck + readAllowlist + --update mode (sorting, missing-file safety, empty case).

## Review-induced fixes

`/agent-review-pr` caught and fixed before this commit:
- HIGH: `--update` mode crashed with ENOENT when allowlist file didn't exist
- HIGH: multi-line `const VALID_X\n  = [...]` declarations bypassed the single-line regex
- MEDIUM: dead try/catch around `collectTsFiles` (which never throws); replaced with `existsSync` check

## Follow-ups

- QUA-948 — Extract shared source-scanner helper for grep-based validators (third validator to copy the same line-scanning triple)

## Closes / Refs

- Closes QUA-944 (Phase 1: Drift inventory — replaced by perpetual validator)
- Refs QUA-943 (epic — many PRs to follow per Plan v2)

## Test plan

- [x] Unit tests pass (`npx vitest run crux/validate/validate-entity-schema-drift.test.ts`) — 21/21
- [x] Validator passes against baseline (`npx tsx crux/validate/validate-entity-schema-drift.ts`)
- [x] Full gate green locally (`pnpm crux w validate gate --fix`)
- [x] TypeScript type check passes for app, wiki-server, and crux
- [x] /agent-review-pr executed (review marker present)
- [ ] CI green
