### PR TITLE
fix(factbase): backfill-sources verify chain — count 'Fact not found' no-op as failed (QUA-963 CRITICAL)

### DIFF
--- a/crux/commands/factbase-backfill-sources.test.ts
+++ b/crux/commands/factbase-backfill-sources.test.ts
@@ -279,6 +279,169 @@ describe('crux fb backfill-sources — --apply path', () => {
     expect(mockSourcingCommand).toHaveBeenCalledWith([], { fact: target.fact.id });
   });
 
+  it('counts sourcingCommand "Fact not found" no-op as failed, not succeeded (QUA-963)', async () => {
+    // CRITICAL regression: sourcingCommand returns { exitCode: 0, output:
+    // "Fact not found or has no source URL: <id>" } when its post-write
+    // reload doesn't see the fact (race, fact-id collision, slug rename,
+    // atomic-rename lag). Pre-fix the wrapper counted this as `succeeded`,
+    // silently lying about how many verdicts actually landed. Post-fix it
+    // must count as `failed`.
+    const kb = await loadGraphFull();
+    const facts = collectUnsourcedFacts(kb, { property: 'born-year', limit: 1 });
+    if (facts.length === 0) return;
+
+    const target = facts[0];
+    const slug = kb.filenameMap.get(target.entity.id);
+    findEntityFilePathMock.mockImplementation((s: string) => `/fake/${s}.yaml`);
+    fakeFiles.set(
+      `/fake/${slug}.yaml`,
+      `facts:\n  - id: ${target.fact.id}\n    propertyId: ${target.fact.propertyId}\n    value: 1990\n`,
+    );
+
+    mockDiscoverSourceForFact.mockResolvedValue({
+      candidates: [{ url: 'https://example.com/x', confidence: 0.9, summary: 's' }],
+      best: 'https://example.com/x',
+      reason: 'good',
+      costUsd: 0.04,
+    });
+
+    // Simulate the no-op path: sourcingCommand returns exit 0 with the
+    // "Fact not found" output. (This is exactly what factbase-sourcing.ts
+    // returns when collectFacts produces zero hits — see line ~395.)
+    mockSourcingCommand.mockResolvedValue({
+      exitCode: 0,
+      output: `Fact not found or has no source URL: ${target.fact.id}`,
+    });
+
+    const res = await backfill([], {
+      property: 'born-year',
+      entity: target.entity.id,
+      limit: '1',
+      apply: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(mockSourcingCommand).toHaveBeenCalledTimes(1);
+    expect(parsed.summary.verifyAttempted).toBe(1);
+    expect(parsed.summary.verifySucceeded).toBe(0);
+    expect(parsed.summary.verifyFailed).toBe(1);
+  });
+
+  it('counts genuine sourcingCommand success (exit 0, non-no-op output) as succeeded', async () => {
+    // Companion test: confirms the no-op detection doesn't have false
+    // positives that would suppress legitimate verify successes.
+    const kb = await loadGraphFull();
+    const facts = collectUnsourcedFacts(kb, { property: 'born-year', limit: 1 });
+    if (facts.length === 0) return;
+
+    const target = facts[0];
+    const slug = kb.filenameMap.get(target.entity.id);
+    findEntityFilePathMock.mockImplementation((s: string) => `/fake/${s}.yaml`);
+    fakeFiles.set(
+      `/fake/${slug}.yaml`,
+      `facts:\n  - id: ${target.fact.id}\n    propertyId: ${target.fact.propertyId}\n    value: 1990\n`,
+    );
+
+    mockDiscoverSourceForFact.mockResolvedValue({
+      candidates: [{ url: 'https://example.com/x', confidence: 0.9, summary: 's' }],
+      best: 'https://example.com/x',
+      reason: 'good',
+      costUsd: 0.04,
+    });
+
+    // Real success output looks like "Verifying 1 fact(s)... confirmed".
+    // Doesn't match either no-op pattern.
+    mockSourcingCommand.mockResolvedValue({
+      exitCode: 0,
+      output: `Verifying 1 fact(s)...\n  [1/1] target / born-year (${target.fact.id})\n    confirmed (confidence: 90%)\n`,
+    });
+
+    const res = await backfill([], {
+      property: 'born-year',
+      entity: target.entity.id,
+      limit: '1',
+      apply: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(parsed.summary.verifyAttempted).toBe(1);
+    expect(parsed.summary.verifySucceeded).toBe(1);
+    expect(parsed.summary.verifyFailed).toBe(0);
+  });
+
+  it('counts non-zero exit from sourcingCommand as failed', async () => {
+    const kb = await loadGraphFull();
+    const facts = collectUnsourcedFacts(kb, { property: 'born-year', limit: 1 });
+    if (facts.length === 0) return;
+
+    const target = facts[0];
+    const slug = kb.filenameMap.get(target.entity.id);
+    findEntityFilePathMock.mockImplementation((s: string) => `/fake/${s}.yaml`);
+    fakeFiles.set(
+      `/fake/${slug}.yaml`,
+      `facts:\n  - id: ${target.fact.id}\n    propertyId: ${target.fact.propertyId}\n    value: 1990\n`,
+    );
+
+    mockDiscoverSourceForFact.mockResolvedValue({
+      candidates: [{ url: 'https://example.com/x', confidence: 0.9, summary: 's' }],
+      best: 'https://example.com/x',
+      reason: 'good',
+      costUsd: 0.04,
+    });
+
+    // sourcingCommand returns exit 1 (e.g., contradicted verdict or storage
+    // error). The wrapper's verify chain should count this as failed.
+    mockSourcingCommand.mockResolvedValue({
+      exitCode: 1,
+      output: `Verifying 1 fact(s)...\n  [1/1] target / born-year (${target.fact.id})\n    contradicted\n`,
+    });
+
+    const res = await backfill([], {
+      property: 'born-year',
+      entity: target.entity.id,
+      limit: '1',
+      apply: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(parsed.summary.verifyFailed).toBe(1);
+    expect(parsed.summary.verifySucceeded).toBe(0);
+  });
+
+  it('counts sourcingCommand throwing as failed (QUA-963 coverage of catch branch)', async () => {
+    const kb = await loadGraphFull();
+    const facts = collectUnsourcedFacts(kb, { property: 'born-year', limit: 1 });
+    if (facts.length === 0) return;
+
+    const target = facts[0];
+    const slug = kb.filenameMap.get(target.entity.id);
+    findEntityFilePathMock.mockImplementation((s: string) => `/fake/${s}.yaml`);
+    fakeFiles.set(
+      `/fake/${slug}.yaml`,
+      `facts:\n  - id: ${target.fact.id}\n    propertyId: ${target.fact.propertyId}\n    value: 1990\n`,
+    );
+
+    mockDiscoverSourceForFact.mockResolvedValue({
+      candidates: [{ url: 'https://example.com/x', confidence: 0.9, summary: 's' }],
+      best: 'https://example.com/x',
+      reason: 'good',
+      costUsd: 0.04,
+    });
+
+    mockSourcingCommand.mockRejectedValue(new Error('wiki-server unreachable'));
+
+    const res = await backfill([], {
+      property: 'born-year',
+      entity: target.entity.id,
+      limit: '1',
+      apply: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(parsed.summary.verifyFailed).toBe(1);
+    expect(parsed.summary.verifySucceeded).toBe(0);
+  });
+
   it('does NOT run verify chain when --no-verify-chain is set', async () => {
     const kb = await loadGraphFull();
     const facts = collectUnsourcedFacts(kb, { property: 'born-year', limit: 1 });

--- a/crux/commands/factbase-backfill-sources.ts
+++ b/crux/commands/factbase-backfill-sources.ts
@@ -574,6 +574,31 @@ function applyToYaml(
 // ── Verify chain ─────────────────────────────────────────────────────
 
 /**
+ * Patterns sourcingCommand uses to signal "nothing to do" via exit code 0.
+ * These are NOT verify successes — they indicate the post-write reload
+ * couldn't find the fact (race, slug rename, atomic-rename lag, fact-id
+ * collision) or the fact lacks a source URL the verifier can fetch. The
+ * wrapper must NOT count these as verdicts landed.
+ *
+ * See `crux/commands/factbase-sourcing.ts` (sourcingCommand: "if
+ * factsToVerify.length === 0" branch) for the canonical message strings.
+ * The patterns here are anchored to the start-of-output to avoid matching
+ * legitimate verify output that happens to embed the substring.
+ */
+const VERIFY_NO_OP_PATTERNS = [
+  /^Fact not found or has no source URL:/,
+  /^No facts with source URLs found/,
+];
+
+function isVerifyNoOp(output: string | undefined): boolean {
+  if (!output) return false;
+  for (const pat of VERIFY_NO_OP_PATTERNS) {
+    if (pat.test(output)) return true;
+  }
+  return false;
+}
+
+/**
  * After --apply writes succeed, run the existing fact-sourcing pipeline
  * inline on the freshly-sourced facts. Calls `sourcingCommand({ fact: id })`
  * once per fact ID (the command reloads the KB on each call, so writes are
@@ -588,6 +613,14 @@ function applyToYaml(
  * fetches source content + calls the LLM + stores a verdict. Concurrency
  * here would race against per-fact storage and the wiki-server's verdict
  * upsert; sequential is simpler and matches how `crux fb sourcing` runs.
+ *
+ * QUA-963 CRITICAL fix: `sourcingCommand` returns exit code 0 with output
+ * `"Fact not found or has no source URL: <id>"` when the post-write reload
+ * doesn't see the fact (race, fact-id collision, slug rename, etc.). Without
+ * the no-op detection below, the wrapper would silently count those as
+ * `succeeded` while zero verdicts actually landed — operators would see
+ * "Verify succeeded: N" and trust it. Match the no-op patterns and re-classify
+ * as `failed` so the count reflects actual verdict landings.
  */
 async function runVerifyChain(
   factIds: string[],
@@ -601,8 +634,12 @@ async function runVerifyChain(
     summary.attempted++;
     try {
       const res = await sourcingCommand([], { fact: factId });
-      if (res.exitCode === 0) summary.succeeded++;
-      else {
+      if (res.exitCode === 0 && !isVerifyNoOp(res.output)) {
+        summary.succeeded++;
+      } else if (res.exitCode === 0 && isVerifyNoOp(res.output)) {
+        summary.failed++;
+        log(`  [verify] ${factId}: no-op (verifier did not see the fact post-write — race, collision, or missing source)`);
+      } else {
         summary.failed++;
         log(`  [verify] ${factId}: exit ${res.exitCode}`);
       }


### PR DESCRIPTION
## Summary

Fixes the **CRITICAL finding** from QUA-963's hostile-review punch list against PR #4749 (QUA-933 backfill-sources wrapper).

`runVerifyChain` was treating `sourcingCommand({ fact: id })`'s exit-code-0 "Fact not found or has no source URL" branch as a verify success. `crux/commands/factbase-sourcing.ts:395` returns `{ exitCode: 0, output: "Fact not found or has no source URL: <id>" }` when its post-write `loadGraphFull()` doesn't see the fact — possible under: race between YAML atomic-rename and reload, slug rename, fact-id collision (`collectFacts` breaks on first match), or transient KB cache desync.

**Operator impact:** running `crux fb backfill-sources --apply` would print `Verify succeeded: N` and people would trust the count. With this fix, no-op responses are re-classified as failed and a clear diagnostic line names the fact ID.

## Test coverage

4 new tests, total 15 → 19, all passing locally and gate green:

- **QUA-963 regression**: simulate the no-op output → assert `verifyFailed: 1, verifySucceeded: 0`
- **No false-positives**: genuine success output (`"Verifying 1 fact(s)..."`) still counts as `succeeded`
- **Non-zero exit**: `exitCode: 1` from sourcingCommand counts as failed
- **Throw branch**: `sourcingCommand` rejecting (e.g., wiki-server unreachable) counts as failed (was previously uncovered per QUA-963 finding 7)

## Why ship as a small focused PR

QUA-963 lists 1 CRITICAL + 2 HIGH + 3 MEDIUM + 2 LOW. The CRITICAL is the only one that affects correctness of the verify-chain output — operators reading `Verify succeeded: N` won't know it's lying. The others (cost-drift, customId reconciliation, write-failure recovery, etc.) are real but have honest-failure-mode signals operators can read. Shipping the CRITICAL alone now unblocks safe use of the wrapper at `--limit=10` per invocation; the HIGH/MEDIUM fixes can ship as PR-B/C/D in any order.

## Test plan

- [x] Build green
- [x] Type check green on `crux/`, `apps/web/`, `apps/wiki-server/`
- [x] Gate green (62/62 checks)
- [x] 19/19 unit tests pass (`npx vitest run crux/commands/factbase-backfill-sources.test.ts`)
- [x] No-op detection verified against the exact string `factbase-sourcing.ts` returns

Closes part of QUA-963 (CRITICAL only — HIGH/MEDIUM/LOW remain open in QUA-963 for follow-up PRs B-F).

Fixes QUA-963
