### PR TITLE
fix(admin-setup): export GITHUB_TOKEN in Section 1c patrol start (QUA-853)

### DIFF
--- a/.claude/skills/admin-setup/SKILL.md
+++ b/.claude/skills/admin-setup/SKILL.md
@@ -67,8 +67,9 @@ pgrep -f "crux gh pr-patrol run" && echo "✓ PR patrol already running" || echo
 
 If not running, start it:
 ```bash
-cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main
-nohup pnpm crux gh pr-patrol run > /tmp/lw-pr-patrol.log 2>&1 &
+cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && \
+  export GITHUB_TOKEN=$(gh auth token) && \
+  nohup pnpm crux gh pr-patrol run > /tmp/lw-pr-patrol.log 2>&1 &
 disown
 echo "Started PR patrol, PID $!"
 ```


### PR DESCRIPTION
## Summary

`/admin-setup` Section 1c starts the PR-patrol daemon without `GITHUB_TOKEN` exported, so the daemon comes up blind. The health gate logs `health_gate_missing_token` events on every cycle, defeating fleet-incident detection.

## Cause

- `crux/lib/github.ts` reads `process.env.GITHUB_TOKEN` directly.
- pnpm does not auto-load `.env.base`, and crux only loads dotenv in specific commands — not in the patrol path.
- Section 1c's start block runs `pnpm crux gh pr-patrol run` without an `export GITHUB_TOKEN=$(gh auth token)` line, so the daemon inherits an empty token from the parent shell.

Verified live: PID 21053 (running patrol on coord box) had no `GITHUB_TOKEN` in its env (`ps -E`), and `~/.cache/pr-patrol/runs.jsonl` shows `health_gate_missing_token` events on 2026-04-24 and 2026-04-25.

## Fix

Match the existing Section 6 restart-block pattern (lines 224–226), prepending `export GITHUB_TOKEN=$(gh auth token)` and chaining the three commands with `&& \`. One change in `.claude/skills/admin-setup/SKILL.md`. No code changes, no test changes — docs-only.

## Test plan

- [x] Visual diff matches Section 6 reference pattern exactly
- [x] Shell syntax validated with `bash -n`
- [x] Narrow-patch detector: no matches
- [x] Review marker (SHA + diff hash) recorded

<!-- deploy-tasks:v1 -->
## Deploy Checklist

- [ ] `manual` After merge, restart the running PR-patrol daemon on the coord box so it picks up `GITHUB_TOKEN` — `pkill -f "crux[[:space:]]+(gh[[:space:]]+)?pr-patrol[[:space:]]+(run|parallel)" 2>/dev/null && sleep 2 && cd /Users/ozziegooen/Documents/GitHub.nosync/lw/main && export GITHUB_TOKEN=$(gh auth token) && nohup pnpm crux gh pr-patrol run > /tmp/lw-pr-patrol.log 2>&1 & disown` — expect: subsequent entries in `~/.cache/pr-patrol/runs.jsonl` no longer contain `health_gate_missing_token` events.
<!-- /deploy-tasks:v1 -->

Closes QUA-853
