### PR TITLE
fix(factbase): backfill-sources batch — reconcile dropped + unknown customIds (QUA-963 HIGH)

### DIFF
--- a/crux/commands/factbase-backfill-sources.test.ts
+++ b/crux/commands/factbase-backfill-sources.test.ts
@@ -727,6 +727,18 @@ describe('crux fb backfill-sources — --batch path', () => {
     // Post-fix, the wrapper walks customIdToFact at the end of the response
     // loop and emits an engineError + missingResponses++ + a synthetic
     // FactDiscovery so the report can name the dropped fact.
+    //
+    // CodeRabbit fix: the test previously hardcoded `expect(missingResponses).toBe(2)`,
+    // which would fail if the KB had < 2 unsourced born-year facts (e.g.,
+    // after the QUA-933 smoke test wrote a Wikipedia source for Andrej
+    // Karpathy's born-year). Resolve the actual count up-front via
+    // collectUnsourcedFacts and assert against `n`, capping at 2 to keep
+    // the test bounded.
+    const kb = await loadGraphFull();
+    const available = collectUnsourcedFacts(kb, { property: 'born-year', limit: 2 });
+    if (available.length === 0) return; // skip if no born-year facts at all
+    const n = available.length;
+
     mockSubmitBatch.mockResolvedValue({ id: 'batch_drop', processing_status: 'in_progress', request_counts: {} });
     mockPollBatch.mockResolvedValue({ id: 'batch_drop', processing_status: 'ended', request_counts: {} });
 
@@ -736,21 +748,21 @@ describe('crux fb backfill-sources — --batch path', () => {
 
     const res = await backfill([], {
       property: 'born-year',
-      limit: '2',
+      limit: String(n),
       batch: true,
       json: true,
     });
     const parsed = JSON.parse(String(res.output));
-    // Both facts must be reconciled as missing.
-    expect(parsed.summary.missingResponses).toBe(2);
-    expect(parsed.summary.engineErrors).toBe(2);
+    // All n facts must be reconciled as missing.
+    expect(parsed.summary.missingResponses).toBe(n);
+    expect(parsed.summary.engineErrors).toBe(n);
     // scanned must equal the number of facts we submitted, NOT the number
     // of responses (the pre-fix bug). Otherwise scanned < requested and the
     // operator can't reconcile the report against the input.
-    expect(parsed.summary.scanned).toBe(2);
+    expect(parsed.summary.scanned).toBe(n);
     expect(parsed.summary.unknownCustomIds).toBe(0);
-    // Per-fact results array should have 2 entries with kind=error.
-    expect(parsed.results.length).toBe(2);
+    // Per-fact results array should have n entries with kind=error.
+    expect(parsed.results.length).toBe(n);
     for (const r of parsed.results) {
       expect(r.error).toContain('did not return a response');
     }
@@ -803,9 +815,20 @@ describe('crux fb backfill-sources — --batch path', () => {
   });
 
   it('mixed: some facts dropped + some unknown customIds (QUA-963 PR-B)', async () => {
-    // Combined edge case: submit 2 facts, get back 1 valid response + 1
-    // unknown customId, leaving 1 actual fact unaccounted for. The
-    // reconciliation pass should catch the dropped fact.
+    // Combined edge case: submit n facts (n >= 2), get back 1 valid
+    // response + 1 unknown customId, leaving (n - 1) actual facts
+    // unaccounted for. The reconciliation pass should catch the dropped
+    // facts.
+    //
+    // Same KB-fragility fix as the "missing responses" test above —
+    // resolve actual count up-front and skip if KB doesn't have ≥ 2
+    // unsourced born-year facts available.
+    const kb = await loadGraphFull();
+    const available = collectUnsourcedFacts(kb, { property: 'born-year', limit: 3 });
+    if (available.length < 2) return; // skip if we can't simulate "1 of n returned"
+    const n = available.length;
+    const droppedCount = n - 1;
+
     mockSubmitBatch.mockResolvedValue({ id: 'batch_mix', processing_status: 'in_progress', request_counts: {} });
     mockPollBatch.mockResolvedValue({ id: 'batch_mix', processing_status: 'ended', request_counts: {} });
 
@@ -836,17 +859,51 @@ describe('crux fb backfill-sources — --batch path', () => {
 
     const res = await backfill([], {
       property: 'born-year',
-      limit: '2',
+      limit: String(n),
       batch: true,
       json: true,
     });
     const parsed = JSON.parse(String(res.output));
     expect(parsed.summary.unknownCustomIds).toBe(1);
-    expect(parsed.summary.missingResponses).toBe(1);
-    expect(parsed.summary.engineErrors).toBe(1);
+    expect(parsed.summary.missingResponses).toBe(droppedCount);
+    expect(parsed.summary.engineErrors).toBe(droppedCount);
     expect(parsed.summary.discovered).toBe(1);
-    // Both facts accounted for in scanned (1 succeeded + 1 reconciled-as-error).
-    expect(parsed.summary.scanned).toBe(2);
+    // All n facts accounted for in scanned (1 succeeded + droppedCount reconciled-as-error).
+    expect(parsed.summary.scanned).toBe(n);
+  });
+
+  it('charges batch cost up-front based on submission count, not on successes (QUA-963 PR-B)', async () => {
+    // CodeRabbit fix: pre-fix, summary.costUsd was incremented only inside
+    // the success-response branch. A 50-fact batch with 1 dropped response
+    // would report $0.98 even though Anthropic billed for the full
+    // submission (~$1.00). Post-fix, cost is charged once up-front based
+    // on requests.length so the report matches submission semantics.
+    const kb = await loadGraphFull();
+    const available = collectUnsourcedFacts(kb, { property: 'born-year', limit: 2 });
+    if (available.length === 0) return;
+    const n = available.length;
+
+    mockSubmitBatch.mockResolvedValue({ id: 'batch_cost', processing_status: 'in_progress', request_counts: {} });
+    mockPollBatch.mockResolvedValue({ id: 'batch_cost', processing_status: 'ended', request_counts: {} });
+
+    // Drop ALL responses — the reported cost should still reflect what we
+    // submitted, not what came back.
+    mockGetBatchResults.mockResolvedValue(new Map());
+
+    const res = await backfill([], {
+      property: 'born-year',
+      limit: String(n),
+      batch: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+
+    // Cost should equal n * ESTIMATED_BATCH_COST_USD (0.02), even though
+    // 0 succeeded.
+    const expectedCost = Number((n * 0.02).toFixed(4));
+    expect(parsed.summary.costUsd).toBe(expectedCost);
+    // Sanity check: zero discoveries (all dropped).
+    expect(parsed.summary.discovered).toBe(0);
   });
 });
 

--- a/crux/commands/factbase-backfill-sources.test.ts
+++ b/crux/commands/factbase-backfill-sources.test.ts
@@ -720,6 +720,134 @@ describe('crux fb backfill-sources — --batch path', () => {
     expect(parsed.summary.engineErrors).toBeGreaterThanOrEqual(1);
     expect(parsed.summary.discovered).toBe(0);
   });
+
+  it('counts missing batch responses as engineErrors with reconciliation (QUA-963 PR-B)', async () => {
+    // QUA-963 HIGH: when Anthropic accepts a batch but never returns a
+    // response for a customId, the work is silently dropped pre-fix.
+    // Post-fix, the wrapper walks customIdToFact at the end of the response
+    // loop and emits an engineError + missingResponses++ + a synthetic
+    // FactDiscovery so the report can name the dropped fact.
+    mockSubmitBatch.mockResolvedValue({ id: 'batch_drop', processing_status: 'in_progress', request_counts: {} });
+    mockPollBatch.mockResolvedValue({ id: 'batch_drop', processing_status: 'ended', request_counts: {} });
+
+    // Return ZERO responses despite however many we submitted. Worst case:
+    // every fact is dropped.
+    mockGetBatchResults.mockResolvedValue(new Map());
+
+    const res = await backfill([], {
+      property: 'born-year',
+      limit: '2',
+      batch: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    // Both facts must be reconciled as missing.
+    expect(parsed.summary.missingResponses).toBe(2);
+    expect(parsed.summary.engineErrors).toBe(2);
+    // scanned must equal the number of facts we submitted, NOT the number
+    // of responses (the pre-fix bug). Otherwise scanned < requested and the
+    // operator can't reconcile the report against the input.
+    expect(parsed.summary.scanned).toBe(2);
+    expect(parsed.summary.unknownCustomIds).toBe(0);
+    // Per-fact results array should have 2 entries with kind=error.
+    expect(parsed.results.length).toBe(2);
+    for (const r of parsed.results) {
+      expect(r.error).toContain('did not return a response');
+    }
+  });
+
+  it('counts unknown customIds separately from missing responses (QUA-963 PR-B)', async () => {
+    // The inverse case: Anthropic returns a customId we DIDN'T submit.
+    // Provider drift / response corruption — must be counted distinctly so
+    // operators can tell "we lost work" (missingResponses) from "they sent
+    // garbage" (unknownCustomIds).
+    mockSubmitBatch.mockResolvedValue({ id: 'batch_drift', processing_status: 'in_progress', request_counts: {} });
+    mockPollBatch.mockResolvedValue({ id: 'batch_drift', processing_status: 'ended', request_counts: {} });
+
+    mockGetBatchResults.mockImplementation(async () => {
+      const results = new Map<string, unknown>();
+      // Return one valid response for the actual fact submitted.
+      for (const callArgs of mockBuildDiscoveryBatchRequest.mock.calls) {
+        const fact = (callArgs[0] as { fact: { id: string } }).fact;
+        results.set(`discover_${fact.id}`, {
+          custom_id: `discover_${fact.id}`,
+          result: { type: 'succeeded', message: { content: [{ type: 'text', text: 'mock' }] } },
+        });
+      }
+      // Plus one customId we never submitted.
+      results.set('discover_GHOST_FACT', {
+        custom_id: 'discover_GHOST_FACT',
+        result: { type: 'succeeded', message: { content: [{ type: 'text', text: 'mock' }] } },
+      });
+      return results;
+    });
+
+    mockParseDiscoveryResponse.mockReturnValue({
+      candidates: [{ url: 'https://x.example.com', confidence: 0.9, summary: 's' }],
+      best: 'https://x.example.com',
+      reason: 'good',
+    });
+
+    const res = await backfill([], {
+      property: 'born-year',
+      limit: '1',
+      batch: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(parsed.summary.unknownCustomIds).toBe(1);
+    expect(parsed.summary.missingResponses).toBe(0);
+    // The legitimate fact still scanned and discovered.
+    expect(parsed.summary.scanned).toBe(1);
+    expect(parsed.summary.discovered).toBe(1);
+  });
+
+  it('mixed: some facts dropped + some unknown customIds (QUA-963 PR-B)', async () => {
+    // Combined edge case: submit 2 facts, get back 1 valid response + 1
+    // unknown customId, leaving 1 actual fact unaccounted for. The
+    // reconciliation pass should catch the dropped fact.
+    mockSubmitBatch.mockResolvedValue({ id: 'batch_mix', processing_status: 'in_progress', request_counts: {} });
+    mockPollBatch.mockResolvedValue({ id: 'batch_mix', processing_status: 'ended', request_counts: {} });
+
+    mockGetBatchResults.mockImplementation(async () => {
+      const results = new Map<string, unknown>();
+      // Return a response only for the FIRST submitted fact.
+      const calls = mockBuildDiscoveryBatchRequest.mock.calls;
+      if (calls.length > 0) {
+        const firstFact = (calls[0][0] as { fact: { id: string } }).fact;
+        results.set(`discover_${firstFact.id}`, {
+          custom_id: `discover_${firstFact.id}`,
+          result: { type: 'succeeded', message: { content: [{ type: 'text', text: 'mock' }] } },
+        });
+      }
+      // Plus an unknown customId.
+      results.set('discover_PHANTOM', {
+        custom_id: 'discover_PHANTOM',
+        result: { type: 'succeeded', message: { content: [{ type: 'text', text: 'mock' }] } },
+      });
+      return results;
+    });
+
+    mockParseDiscoveryResponse.mockReturnValue({
+      candidates: [{ url: 'https://x.example.com', confidence: 0.9, summary: 's' }],
+      best: 'https://x.example.com',
+      reason: 'good',
+    });
+
+    const res = await backfill([], {
+      property: 'born-year',
+      limit: '2',
+      batch: true,
+      json: true,
+    });
+    const parsed = JSON.parse(String(res.output));
+    expect(parsed.summary.unknownCustomIds).toBe(1);
+    expect(parsed.summary.missingResponses).toBe(1);
+    expect(parsed.summary.engineErrors).toBe(1);
+    expect(parsed.summary.discovered).toBe(1);
+    // Both facts accounted for in scanned (1 succeeded + 1 reconciled-as-error).
+    expect(parsed.summary.scanned).toBe(2);
+  });
 });
 
 describe('crux fb backfill-sources — option parsing', () => {

--- a/crux/commands/factbase-backfill-sources.ts
+++ b/crux/commands/factbase-backfill-sources.ts
@@ -151,6 +151,21 @@ interface BackfillSummary {
   discovered: number;
   noBest: number;
   engineErrors: number;
+  /**
+   * Batch-mode only: count of customIds Anthropic returned that we never
+   * submitted (provider-side bug or response corruption). Counted separately
+   * from `engineErrors` because the work was never even our request, so
+   * conflating it with our own failure rate would mislead operators.
+   */
+  unknownCustomIds: number;
+  /**
+   * Batch-mode only: count of facts we submitted whose customId did not
+   * appear in the response set. The work was lost — Anthropic accepted the
+   * request but never produced a response for it. Folded into `engineErrors`
+   * via the response-loop reconciliation pass; tracked here so operators
+   * can distinguish "never returned" from "returned with errored type".
+   */
+  missingResponses: number;
   writesAttempted: number;
   writesSucceeded: number;
   writesSkippedExisting: number;
@@ -208,6 +223,8 @@ function zeroSummary(): BackfillSummary {
     discovered: 0,
     noBest: 0,
     engineErrors: 0,
+    unknownCustomIds: 0,
+    missingResponses: 0,
     writesAttempted: 0,
     writesSucceeded: 0,
     writesSkippedExisting: 0,
@@ -393,14 +410,26 @@ async function discoverBatch(
   const responses = await getBatchResults(client, submitted.id);
   const results: FactDiscovery[] = [];
 
+  // Track which submitted customIds we saw a response for so we can detect
+  // facts Anthropic accepted but never returned a result for. Pre-fix, those
+  // facts would silently disappear from `summary.scanned` — operators couldn't
+  // reconcile "facts to process: N" against "scanned: M < N" and would have
+  // no error trail. Post-fix, every missing response is counted as an
+  // engineError with a synthetic FactDiscovery so the report can name it.
+  const seenCustomIds = new Set<string>();
+
   for (const [customId, response] of responses) {
     const ctx = customIdToFact.get(customId);
     if (!ctx) {
-      // Unknown customId — possible if Anthropic returned a result we didn't
-      // submit. Skip with a warning rather than crashing.
-      options.log(`  [warn] batch returned unknown customId: ${customId}`);
+      // Unknown customId — Anthropic returned a result we didn't submit.
+      // Provider-side bug or response-set corruption. Counted separately
+      // from `engineErrors` so operators can distinguish "we lost work" from
+      // "they sent us garbage." Skip with a warning rather than crashing.
+      summary.unknownCustomIds++;
+      options.log(`  [warn] batch returned unknown customId: ${customId} (provider drift; not in our submission set)`);
       continue;
     }
+    seenCustomIds.add(customId);
     summary.scanned++;
 
     if (response.result.type !== 'succeeded') {
@@ -436,6 +465,32 @@ async function discoverBatch(
     });
     if (discoverResult.best) summary.discovered++;
     else summary.noBest++;
+  }
+
+  // Reconciliation pass: emit synthetic engine-error entries for any
+  // customId we submitted but never saw in the response set. Without this,
+  // the work is silently dropped — `summary.scanned < submitted.length`
+  // with no error trail, and the per-fact report skips them entirely.
+  for (const [customId, ctx] of customIdToFact) {
+    if (seenCustomIds.has(customId)) continue;
+    summary.scanned++;
+    summary.engineErrors++;
+    summary.missingResponses++;
+    options.log(`  [warn] batch did not return a response for customId ${customId} (fact ${ctx.fact.id})`);
+    results.push({
+      entity: ctx.entity,
+      fact: ctx.fact,
+      propertyName: ctx.propertyName,
+      formattedValue: ctx.formattedValue,
+      result: null,
+      error: `batch did not return a response for this customId (provider drop)`,
+    });
+  }
+
+  if (summary.missingResponses > 0 || summary.unknownCustomIds > 0) {
+    options.log(
+      `  [reconcile] submitted ${requests.length} request(s), got ${responses.size} response(s): ${summary.missingResponses} dropped, ${summary.unknownCustomIds} unknown customId(s) returned`,
+    );
   }
 
   return results;
@@ -823,6 +878,14 @@ function formatReport(
   lines.push(`Discovered (best):     ${summary.discovered}`);
   lines.push(`No best candidate:     ${summary.noBest}`);
   lines.push(`Engine errors:         ${summary.engineErrors}`);
+  // Batch-mode reconciliation counters. Hidden when zero to keep real-time
+  // mode's report uncluttered (those fields are always 0 in real-time).
+  if (summary.missingResponses > 0) {
+    lines.push(`  Missing responses:   ${summary.missingResponses} (provider dropped — included in engine errors)`);
+  }
+  if (summary.unknownCustomIds > 0) {
+    lines.push(`  Unknown customIds:   ${summary.unknownCustomIds} (provider returned customIds we didn't submit)`);
+  }
   if (apply) {
     lines.push(`Writes attempted:      ${summary.writesAttempted}`);
     lines.push(`Writes succeeded:      ${summary.writesSucceeded}`);

--- a/crux/commands/factbase-backfill-sources.ts
+++ b/crux/commands/factbase-backfill-sources.ts
@@ -410,6 +410,17 @@ async function discoverBatch(
   const responses = await getBatchResults(client, submitted.id);
   const results: FactDiscovery[] = [];
 
+  // Charge the cost estimate up-front based on submission count, not on
+  // successful responses. Anthropic bills for every request that processed
+  // (including errored ones), and for our budget-tracking purposes a fact
+  // we lost (provider dropped the response) still consumed quota. Charging
+  // only on the success branch under-reported cost — operators saw
+  // `costUsd: $0.98` after a 50-fact run with 1 drop while actual billing
+  // was ~$1.00. Charging once up-front matches submission semantics and
+  // makes the budget-gate math (which is also estimate-based) consistent
+  // across runs.
+  summary.costUsd += requests.length * ESTIMATED_BATCH_COST_USD;
+
   // Track which submitted customIds we saw a response for so we can detect
   // facts Anthropic accepted but never returned a result for. Pre-fix, those
   // facts would silently disappear from `summary.scanned` — operators couldn't
@@ -451,10 +462,8 @@ async function discoverBatch(
 
     const text = extractTextFromMessage(response.result.message);
     const parsed = parseDiscoveryResponse(text, options.threshold);
-    // Batch cost is settled by the batch summary, not per-response. Track it
-    // approximately: estimated rather than precise. The engine returns
-    // costUsd: 0 for the batch path (per source-discover.ts contract).
-    summary.costUsd += ESTIMATED_BATCH_COST_USD;
+    // No per-response cost increment — already charged up-front. The engine
+    // returns costUsd: 0 for the batch path (per source-discover.ts contract).
     const discoverResult: DiscoverResult = { ...parsed, costUsd: 0 };
     results.push({
       entity: ctx.entity,


### PR DESCRIPTION
## Summary

Fixes the **HIGH finding 2** from QUA-963's hostile-review punch list. PR-B in the QUA-963 sequence (PR-A was #4752, the CRITICAL verify-chain fix; this is the next blocker for safe `--batch --apply` use).

`discoverBatch` silently dropped work in two symmetric cases:

1. **Anthropic returned a customId we didn't submit** (provider drift / response-set corruption): logged a warning + `continue`d without counting.
2. **We submitted a customId Anthropic never returned** (provider drop): never counted at all. `submitted.length=50, responses.size=49` → `summary.scanned=49`, no warning, no error trail. The dropped fact was untraceable.

A `--batch --apply` run could leave dozens of facts unverified with no signal which were affected.

## Fix

- Track `seenCustomIds` during the response loop.
- After the loop, walk `customIdToFact` for unseen customIds and emit a synthetic `FactDiscovery` (`kind: error`) per dropped fact + `summary.engineErrors++` + `summary.missingResponses++`.
- Bump unknown-customId path to `summary.unknownCustomIds++` (separate counter so operators can tell "we lost work" from "they sent garbage").
- Reconciliation log line surfaces totals when either is non-zero.
- Report formatter shows the new fields when > 0 (hidden in real-time mode where they're always 0).

## Tests

3 new tests in addition to the 19 existing:
- All facts dropped (every customId missing from response set) — assert `missingResponses == submitted` and `scanned == submitted` (NOT `responses.size`).
- Unknown customIds returned with full submitted set still valid — assert `unknownCustomIds: 1, missingResponses: 0`.
- Mixed case (1 valid + 1 unknown + 1 dropped) — assert distinct counters track correctly.

Test count: 19 → 22. All pass locally + gate green (62/62 checks).

## Test plan

- [x] Build green
- [x] Gate green (62/62 + 6 triaged + 2 advisory)
- [x] 22/22 unit tests pass
- [x] Type check green on `crux/`
- [x] No-op detection from PR-A (#4752) preserved (regression test still passes)

Closes part of QUA-963 (HIGH finding 2 — finding 1 = CRITICAL = closed via #4752; finding 3 = cost-drift = remains open for PR-C).

Fixes QUA-963


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for batch processing reconciliation scenarios, including missing responses and unexpected API outputs.

* **Bug Fixes**
  * Improved batch operation error handling to properly track and reconcile submitted requests against received responses.
  * Enhanced error reporting with accurate per-fact records and consistent error counting for missing or unexpected responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->