### PR TITLE
fix(validate): entity-schema drift validator — --update corrupts baseline + phantom comment violations (QUA-966)

### DIFF
--- a/crux/validate/.entity-schema-drift-allowlist.txt
+++ b/crux/validate/.entity-schema-drift-allowlist.txt
@@ -9,7 +9,8 @@
 # while migration is in progress. Goal: this file is empty when QUA-943 closes.
 #
 # Suppressing a single line (e.g., a legitimate query-string enum that should
-# not be migrated): add `// schema-drift-ok` on the same line as the marker.
+# not be migrated): add `// schema-drift-ok: <reason>` on the same line as the
+# marker. Reason is mandatory.
 #
 # Format: one file path per line, relative to repo root. Empty lines and
 # comments (lines starting with `#`) are ignored.

--- a/crux/validate/validate-entity-schema-drift.test.ts
+++ b/crux/validate/validate-entity-schema-drift.test.ts
@@ -9,9 +9,6 @@ describe("validate-entity-schema-drift checkLine", () => {
     expect(checkLine('const VALID_POSITIONS = ["support", "oppose"] as const;')).toBe("VALID_CONST");
   });
 
-  // Multi-line declarations (`const VALID_X\n  = [...]`) are caught by the
-  // file-level multi-line pass in checkFile, not by checkLine.
-
   it("flags exported VALID_*", () => {
     expect(checkLine('export const VALID_RISK_DOMAINS = [')).toBe("VALID_CONST");
   });
@@ -29,13 +26,23 @@ describe("validate-entity-schema-drift checkLine", () => {
     expect(checkLine(' * z.enum(["x"])')).toBeNull();
   });
 
-  it("respects // schema-drift-ok suppression", () => {
-    expect(checkLine('const VALID_QUERY_DIR = ["asc","desc"]; // schema-drift-ok')).toBeNull();
-    expect(checkLine('  dir: z.enum(["asc","desc"]), // schema-drift-ok')).toBeNull();
+  it("respects // schema-drift-ok: <reason> suppression", () => {
+    expect(checkLine('const VALID_QUERY_DIR = ["asc","desc"]; // schema-drift-ok: query enum, not entity wire shape')).toBeNull();
+    expect(checkLine('  dir: z.enum(["asc","desc"]), // schema-drift-ok: query enum')).toBeNull();
+  });
+
+  it("rejects bare suppression marker without reason", () => {
+    // buildSuppressionRegex requires `<marker>: <reason>`; a bare marker
+    // does not suppress.
+    expect(checkLine('const VALID_X = ["a"]; // schema-drift-ok')).toBe("VALID_CONST");
   });
 
   it("does not match VALID_ inside string literal", () => {
-    expect(checkLine('const msg = "Use a const VALID_FOO declaration"')).toBeNull();
+    expect(checkLine('const msg = "Use a const VALID_FOO = declaration"')).toBeNull();
+  });
+
+  it("does not match z.enum([ inside string literal", () => {
+    expect(checkLine('const msg = "see z.enum([\\"x\\"]) docs";')).toBeNull();
   });
 
   it("ignores plain `valid` (case-sensitive)", () => {
@@ -130,14 +137,22 @@ describe("validate-entity-schema-drift runCheck", () => {
     expect(result.newViolations[0].kind).toBe("INLINE_ENUM");
   });
 
-  it("respects per-line // schema-drift-ok suppression even outside allowlist", () => {
+  it("respects per-line // schema-drift-ok: <reason> suppression even outside allowlist", () => {
     writeFileSync(
       join(routesDir, "queries.ts"),
-      'const sortDir = z.enum(["asc","desc"]); // schema-drift-ok\n',
+      'const sortDir = z.enum(["asc","desc"]); // schema-drift-ok: query enum\n',
     );
     writeFileSync(allowlistPath, "");
     const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
     expect(result.passed).toBe(true);
+  });
+
+  it("attaches file path to violations in result.newViolations", () => {
+    writeFileSync(join(routesDir, "n.ts"), 'const VALID_N = ["a"];\n');
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.newViolations[0].file).toBe("routes/tablebase/n.ts");
+    expect(result.newViolations[0].line).toBe(1);
   });
 });
 

--- a/crux/validate/validate-entity-schema-drift.test.ts
+++ b/crux/validate/validate-entity-schema-drift.test.ts
@@ -191,8 +191,8 @@ describe("validate-entity-schema-drift runCheck", () => {
     );
     writeFileSync(allowlistPath, "");
     const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
-    expect(result.newViolations.length).toBeGreaterThanOrEqual(1);
-    expect(result.newViolations.some(v => v.kind === "VALID_CONST")).toBe(true);
+    expect(result.newViolations).toHaveLength(1);
+    expect(result.newViolations[0].kind).toBe("VALID_CONST");
   });
 });
 

--- a/crux/validate/validate-entity-schema-drift.test.ts
+++ b/crux/validate/validate-entity-schema-drift.test.ts
@@ -154,6 +154,46 @@ describe("validate-entity-schema-drift runCheck", () => {
     expect(result.newViolations[0].file).toBe("routes/tablebase/n.ts");
     expect(result.newViolations[0].line).toBe(1);
   });
+
+  it("does not double-count when a comment precedes a real VALID_* declaration", () => {
+    // Regression: the multi-line pass used to join the comment line with the
+    // next code line and re-match the pattern, producing a phantom violation
+    // on the comment line in addition to the real one on line 2.
+    writeFileSync(
+      join(routesDir, "x.ts"),
+      '// kept VALID_OLD comment\nconst VALID_X = ["a"];\n',
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.newViolations).toHaveLength(1);
+    expect(result.newViolations[0].line).toBe(2);
+  });
+
+  it("does not double-count when a JSDoc closer precedes a real declaration", () => {
+    writeFileSync(
+      join(routesDir, "x.ts"),
+      '/**\n * doc\n */\nconst VALID_X = ["a"];\n',
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.newViolations).toHaveLength(1);
+    expect(result.newViolations[0].line).toBe(4);
+  });
+
+  it("multi-line match is not blocked by an unrelated string literal on the prior line", () => {
+    // Regression: the prior multi-line guard `pattern.test(joined) &&
+    // !pattern.test(lines[i])` mis-fired when lines[i] contained a string
+    // literal whose contents matched the pattern, suppressing the legit
+    // multi-line match that followed.
+    writeFileSync(
+      join(routesDir, "x.ts"),
+      'const msg = "see const VALID_FAKE = pattern"; const VALID_REAL\n  = ["a"];\n',
+    );
+    writeFileSync(allowlistPath, "");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot });
+    expect(result.newViolations.length).toBeGreaterThanOrEqual(1);
+    expect(result.newViolations.some(v => v.kind === "VALID_CONST")).toBe(true);
+  });
 });
 
 describe("validate-entity-schema-drift --update mode", () => {
@@ -193,6 +233,26 @@ describe("validate-entity-schema-drift --update mode", () => {
     expect(() => runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot, updateBaseline: true })).not.toThrow();
     const written = readFileSync(allowlistPath, "utf-8");
     expect(written).toContain("routes/tablebase/x.ts");
+  });
+
+  it("preserves header without gluing it to the first entry (production baseline shape)", () => {
+    // Regression: the prior implementation produced
+    // `# last comment\napps/.../first.ts...` (no newline) when the input
+    // header had no trailing blank line — corrupting the allowlist on next
+    // read. The shipped baseline file has exactly this shape.
+    writeFileSync(join(routesDir, "a.ts"), 'const VALID_A = ["x"];\n');
+    writeFileSync(join(routesDir, "b.ts"), 'const VALID_B = ["y"];\n');
+    writeFileSync(allowlistPath, "# header line 1\n# header line 2\n");
+    const result = runCheck({ rootDir: routesDir, allowlistPath, baseDir: tmpRoot, updateBaseline: true });
+    expect(result.passed).toBe(true);
+    const written = readFileSync(allowlistPath, "utf-8");
+    expect(written).toBe(
+      "# header line 1\n# header line 2\nroutes/tablebase/a.ts\nroutes/tablebase/b.ts\n",
+    );
+    // And the readback round-trips:
+    const readBack = readAllowlist(allowlistPath);
+    expect(readBack.has("routes/tablebase/a.ts")).toBe(true);
+    expect(readBack.has("routes/tablebase/b.ts")).toBe(true);
   });
 
   it("writes empty list when no drift exists", () => {

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Entity-schema drift validator (QUA-943 — Plan v2 step 0c).
+ * Entity-schema drift validator.
  *
  * Bans new `const VALID_*` declarations and inline `z.enum([...])` literals in
  * apps/wiki-server/src/routes/tablebase/ — both are markers of an entity wire
@@ -10,112 +10,93 @@
  *
  * The current baseline of files containing drift markers is recorded in
  * .entity-schema-drift-allowlist.txt. As routes migrate to canonical schemas
- * (Plan v2 PRs 5a/5b), entries are removed from the allowlist. This file
- * reaches zero entries when QUA-943 closes.
+ * entries are removed from the allowlist. The file reaches zero entries when
+ * QUA-943 closes.
  *
- * Suppression for legitimate inline enums (e.g., query-string enums that are
- * not entity wire shapes): add `// schema-drift-ok` on the same line as the
- * marker.
+ * Suppression: add `// schema-drift-ok: <reason>` on the same line. The
+ * reason is mandatory (matches the buildSuppressionRegex contract used by
+ * other validators).
  *
  * Usage:
  *   npx tsx crux/validate/validate-entity-schema-drift.ts            # check
  *   npx tsx crux/validate/validate-entity-schema-drift.ts --update   # rewrite allowlist
  */
 
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
 import { getColors } from '../lib/output.ts';
+import {
+  buildSuppressionRegex,
+  findInlineCommentStart,
+  isInsideStringAt,
+} from './lib/comment-utils.ts';
+import { collectTsFiles } from './lib/file-walker.ts';
 
 const TABLEBASE_ROUTES_DIR = join(PROJECT_ROOT, 'apps/wiki-server/src/routes/tablebase');
 const ALLOWLIST_PATH = join(PROJECT_ROOT, 'crux/validate/.entity-schema-drift-allowlist.txt');
-const SUPPRESS_COMMENT = 'schema-drift-ok';
+const SUPPRESSION_MARKER = 'schema-drift-ok';
+const SUPPRESSION_REGEX = buildSuppressionRegex(SUPPRESSION_MARKER);
 
-// Single-line patterns. The trailing `\s*=` keeps these tight against
-// false-positive matches inside string literals (e.g.
-// `const msg = "Use a const VALID_FOO declaration"` doesn't end with
-// `=` after VALID_FOO so it is not flagged). Multi-line declarations
-// (`const VALID_X\n  = [...]`, formatter-induced) are caught by the
-// MULTILINE_PATTERNS pass below, which joins line N with line N+1.
-const VALID_CONST_RE = /\bconst\s+VALID_[A-Z_]+\s*=/;
-const INLINE_ENUM_RE = /z\.enum\(\[/;
+type Kind = 'VALID_CONST' | 'INLINE_ENUM';
 
-const MULTILINE_PATTERNS: Array<{ pattern: RegExp; kind: Violation['kind'] }> = [
-  { pattern: /\bconst\s+VALID_[A-Z_]+\s*=/, kind: 'VALID_CONST' },
-  { pattern: /z\.enum\(\s*\[/, kind: 'INLINE_ENUM' },
+/**
+ * Patterns shared between single-line and multi-line passes. The `\s*` after
+ * `z.enum(` is harmless on the single-line case and lets the joined-line
+ * pass catch formatter-induced splits like `z.enum(\n  [...])`.
+ */
+const PATTERNS: Array<{ pattern: RegExp; globalPattern: RegExp; kind: Kind }> = [
+  {
+    pattern: /\bconst\s+VALID_[A-Z_]+\s*=/,
+    globalPattern: /\bconst\s+VALID_[A-Z_]+\s*=/g,
+    kind: 'VALID_CONST',
+  },
+  {
+    pattern: /z\.enum\(\s*\[/,
+    globalPattern: /z\.enum\(\s*\[/g,
+    kind: 'INLINE_ENUM',
+  },
 ];
 
 export interface Violation {
-  file: string;
   line: number;
   text: string;
-  kind: 'VALID_CONST' | 'INLINE_ENUM';
+  kind: Kind;
 }
 
-function isSuppressed(line: string): boolean {
-  const commentIdx = findLineCommentStart(line);
-  if (commentIdx === -1) return false;
-  return line.slice(commentIdx).includes(SUPPRESS_COMMENT);
+function isCommentLine(trimmed: string): boolean {
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
 }
 
-function findLineCommentStart(line: string): number {
-  let inSingle = false;
-  let inDouble = false;
-  let inTemplate = false;
-  for (let i = 0; i < line.length; i++) {
-    if (i > 0 && line[i - 1] === '\\') continue;
-    const ch = line[i];
-    if (ch === "'" && !inDouble && !inTemplate) { inSingle = !inSingle; continue; }
-    if (ch === '"' && !inSingle && !inTemplate) { inDouble = !inDouble; continue; }
-    if (ch === '`' && !inSingle && !inDouble) { inTemplate = !inTemplate; continue; }
-    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '/') {
-      return i;
+function lineIsSuppressed(line: string): boolean {
+  if (!line.includes(SUPPRESSION_MARKER)) return false;
+  const commentStart = findInlineCommentStart(line);
+  if (commentStart === -1) return false;
+  return SUPPRESSION_REGEX.test(line.slice(commentStart + 2));
+}
+
+/**
+ * Run all patterns against `line`, filtering out matches that fall inside a
+ * string literal. Returns the kind of the first real match, or null.
+ *
+ * Exported for unit tests.
+ */
+export function checkLine(line: string): Kind | null {
+  if (isCommentLine(line.trimStart())) return null;
+  if (lineIsSuppressed(line)) return null;
+  const commentStart = findInlineCommentStart(line);
+  for (const { globalPattern, kind } of PATTERNS) {
+    for (const match of line.matchAll(globalPattern)) {
+      const idx = match.index ?? 0;
+      if (commentStart !== -1 && idx >= commentStart) continue;
+      if (isInsideStringAt(line, idx)) continue;
+      return kind;
     }
   }
-  return -1;
-}
-
-export function checkLine(line: string): Violation['kind'] | null {
-  const trimmed = line.trimStart();
-  if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
-    return null;
-  }
-  if (isSuppressed(line)) return null;
-  if (VALID_CONST_RE.test(line)) return 'VALID_CONST';
-  if (INLINE_ENUM_RE.test(line)) return 'INLINE_ENUM';
   return null;
 }
 
-function collectTsFiles(dir: string): string[] {
-  const results: string[] = [];
-  function walk(current: string): void {
-    let entries: string[];
-    try {
-      entries = readdirSync(current);
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const fullPath = join(current, entry);
-      let stat;
-      try {
-        stat = statSync(fullPath);
-      } catch {
-        continue;
-      }
-      if (stat.isDirectory()) {
-        if (entry === '__tests__' || entry === 'node_modules') continue;
-        walk(fullPath);
-      } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
-        results.push(fullPath);
-      }
-    }
-  }
-  walk(dir);
-  return results;
-}
-
-function checkFile(filePath: string, baseDir: string): Violation[] {
+function checkFile(filePath: string, baseDir: string): { relPath: string; violations: Violation[] } {
   const content = readFileSync(filePath, 'utf-8');
   const lines = content.split('\n');
   const violations: Violation[] = [];
@@ -123,21 +104,22 @@ function checkFile(filePath: string, baseDir: string): Violation[] {
   for (let i = 0; i < lines.length; i++) {
     const kind = checkLine(lines[i]);
     if (kind) {
-      violations.push({ file: relPath, line: i + 1, text: lines[i].trimStart(), kind });
+      violations.push({ line: i + 1, text: lines[i].trimStart(), kind });
       continue;
     }
-    // Multi-line check: join current line with next to catch declarations split
-    // across lines (e.g. `const VALID_X\n  = [...]`).
+    // Multi-line pass: catches formatter-induced splits like
+    // `const VALID_X\n  = [...]` or `z.enum(\n  ["a"])`.
     if (i + 1 >= lines.length) continue;
     const nextLine = lines[i + 1];
     const nextTrim = nextLine.trimStart();
-    if (nextTrim.startsWith('//') || nextTrim.startsWith('*') || nextTrim.startsWith('/*')) continue;
-    if (isSuppressed(lines[i]) || isSuppressed(nextLine)) continue;
+    if (isCommentLine(nextTrim)) continue;
+    if (lineIsSuppressed(lines[i]) || lineIsSuppressed(nextLine)) continue;
     const joined = lines[i].trimEnd() + ' ' + nextTrim;
-    for (const { pattern, kind: mlKind } of MULTILINE_PATTERNS) {
+    for (const { pattern, kind: mlKind } of PATTERNS) {
+      // Only report if the joined-line match wasn't already a single-line
+      // match on `lines[i]` (which would have been caught above).
       if (pattern.test(joined) && !pattern.test(lines[i])) {
         violations.push({
-          file: relPath,
           line: i + 1,
           text: `${lines[i].trimStart()} ${nextTrim}`.trim(),
           kind: mlKind,
@@ -146,7 +128,7 @@ function checkFile(filePath: string, baseDir: string): Violation[] {
       }
     }
   }
-  return violations;
+  return { relPath, violations };
 }
 
 export function readAllowlist(path: string = ALLOWLIST_PATH): Set<string> {
@@ -168,7 +150,7 @@ export function readAllowlist(path: string = ALLOWLIST_PATH): Set<string> {
 interface CheckResult {
   passed: boolean;
   errors: number;
-  newViolations: Violation[];
+  newViolations: Array<Violation & { file: string }>;
   staleEntries: string[];
   allowlistedFileCount: number;
   fileCountWithDrift: number;
@@ -195,8 +177,8 @@ export function runCheck(
 
   const filesWithDrift = new Map<string, Violation[]>();
   for (const file of allFiles) {
-    const v = checkFile(file, baseDir);
-    if (v.length > 0) filesWithDrift.set(v[0].file, v);
+    const { relPath, violations } = checkFile(file, baseDir);
+    if (violations.length > 0) filesWithDrift.set(relPath, violations);
   }
 
   if (opts.updateBaseline) {
@@ -207,12 +189,20 @@ export function runCheck(
     } catch {
       existing = '';
     }
-    const header = existing.split('\n')
-      .filter(l => l.startsWith('#') || l.trim() === '')
-      .join('\n')
-      .replace(/\n+$/, '\n');
+    // Preserve only the leading run of comment/blank lines as the header.
+    // A scan that keeps comments and blanks anywhere in the file would mix
+    // gaps between entries into the header and reorder them.
+    const headerLines: string[] = [];
+    for (const line of existing.split('\n')) {
+      if (line.startsWith('#') || line.trim() === '') {
+        headerLines.push(line);
+      } else {
+        break;
+      }
+    }
+    const header = headerLines.join('\n').replace(/\n+$/, '\n');
     const body = sorted.join('\n') + '\n';
-    writeFileSync(allowlistPath, header + body);
+    writeFileSync(allowlistPath, (header.length > 0 ? header : '') + body);
     console.log(`${c.green}Wrote ${sorted.length} entries to ${relative(baseDir, allowlistPath)}${c.reset}`);
     return {
       passed: true, errors: 0, newViolations: [], staleEntries: [],
@@ -221,9 +211,11 @@ export function runCheck(
   }
 
   const allowed = readAllowlist(allowlistPath);
-  const newViolations: Violation[] = [];
+  const newViolations: Array<Violation & { file: string }> = [];
   for (const [file, vs] of filesWithDrift) {
-    if (!allowed.has(file)) newViolations.push(...vs);
+    if (!allowed.has(file)) {
+      for (const v of vs) newViolations.push({ ...v, file });
+    }
   }
 
   const staleEntries: string[] = [];
@@ -239,13 +231,14 @@ export function runCheck(
     }
   } else {
     if (newViolations.length > 0) {
-      console.log(`${c.red}Found ${newViolations.length} drift marker(s) in ${new Set(newViolations.map(v => v.file)).size} non-allowlisted file(s):${c.reset}\n`);
+      const fileCount = new Set(newViolations.map(v => v.file)).size;
+      console.log(`${c.red}Found ${newViolations.length} drift marker(s) in ${fileCount} non-allowlisted file(s):${c.reset}\n`);
       for (const v of newViolations) {
         console.log(`  ${c.red}${v.file}:${v.line}${c.reset} [${v.kind}]`);
         console.log(`    ${c.dim}${v.text}${c.reset}`);
       }
       console.log(`\n${c.dim}Fix: import the canonical schema from packages/entity-schemas (QUA-943) instead of hand-writing.${c.reset}`);
-      console.log(`${c.dim}Suppress a single legitimate use (e.g., query-string enum): add \`// ${SUPPRESS_COMMENT}\` on the same line.${c.reset}`);
+      console.log(`${c.dim}Suppress a single legitimate use (e.g., query-string enum): add \`// ${SUPPRESSION_MARKER}: <reason>\` on the same line.${c.reset}`);
       console.log(`${c.dim}If migration to canonical schemas is not yet possible, add the file to ${relative(PROJECT_ROOT, allowlistPath)}.${c.reset}\n`);
     }
     if (staleEntries.length > 0) {
@@ -265,7 +258,7 @@ export function runCheck(
   };
 }
 
-const __isMain = process.argv[1]?.includes('validate-entity-schema-drift');
+const __isMain = process.argv[1]?.endsWith('validate-entity-schema-drift.ts');
 if (__isMain) {
   const updateBaseline = process.argv.includes('--update');
   const result = runCheck({ updateBaseline });

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -45,17 +45,9 @@ type Kind = 'VALID_CONST' | 'INLINE_ENUM';
  * `z.enum(` is harmless on the single-line case and lets the joined-line
  * pass catch formatter-induced splits like `z.enum(\n  [...])`.
  */
-const PATTERNS: Array<{ pattern: RegExp; globalPattern: RegExp; kind: Kind }> = [
-  {
-    pattern: /\bconst\s+VALID_[A-Z_]+\s*=/,
-    globalPattern: /\bconst\s+VALID_[A-Z_]+\s*=/g,
-    kind: 'VALID_CONST',
-  },
-  {
-    pattern: /z\.enum\(\s*\[/,
-    globalPattern: /z\.enum\(\s*\[/g,
-    kind: 'INLINE_ENUM',
-  },
+const PATTERNS: Array<{ globalPattern: RegExp; kind: Kind }> = [
+  { globalPattern: /\bconst\s+VALID_[A-Z_]+\s*=/g, kind: 'VALID_CONST' },
+  { globalPattern: /z\.enum\(\s*\[/g, kind: 'INLINE_ENUM' },
 ];
 
 export interface Violation {
@@ -118,12 +110,6 @@ function checkFile(filePath: string, baseDir: string): { relPath: string; violat
     const nextTrim = nextLine.trimStart();
     if (isCommentLine(nextTrim)) continue;
     if (lineIsSuppressed(nextLine)) continue;
-    // Don't fire on the joined line if `lines[i]` ALREADY would single-line
-    // match (already reported on this iteration's first branch is impossible
-    // because we continued; this guards against the edge case where the
-    // single-line regex matches inside a string literal that checkLine
-    // filtered, but the joined regex would also match the same string).
-    if (checkLine(lines[i]) !== null) continue;
     const joined = lines[i].trimEnd() + ' ' + nextTrim;
     const joinedKind = checkLine(joined);
     if (joinedKind !== null) {

--- a/crux/validate/validate-entity-schema-drift.ts
+++ b/crux/validate/validate-entity-schema-drift.ts
@@ -108,24 +108,30 @@ function checkFile(filePath: string, baseDir: string): { relPath: string; violat
       continue;
     }
     // Multi-line pass: catches formatter-induced splits like
-    // `const VALID_X\n  = [...]` or `z.enum(\n  ["a"])`.
+    // `const VALID_X\n  = [...]` or `z.enum(\n  ["a"])`. Use checkLine
+    // semantics on the joined line so string-literal / comment / suppression
+    // filters apply (raw `pattern.test` would mis-fire on string literals
+    // that contain example code, and on a comment-then-real-code pair).
     if (i + 1 >= lines.length) continue;
+    if (isCommentLine(lines[i].trimStart())) continue;
     const nextLine = lines[i + 1];
     const nextTrim = nextLine.trimStart();
     if (isCommentLine(nextTrim)) continue;
-    if (lineIsSuppressed(lines[i]) || lineIsSuppressed(nextLine)) continue;
+    if (lineIsSuppressed(nextLine)) continue;
+    // Don't fire on the joined line if `lines[i]` ALREADY would single-line
+    // match (already reported on this iteration's first branch is impossible
+    // because we continued; this guards against the edge case where the
+    // single-line regex matches inside a string literal that checkLine
+    // filtered, but the joined regex would also match the same string).
+    if (checkLine(lines[i]) !== null) continue;
     const joined = lines[i].trimEnd() + ' ' + nextTrim;
-    for (const { pattern, kind: mlKind } of PATTERNS) {
-      // Only report if the joined-line match wasn't already a single-line
-      // match on `lines[i]` (which would have been caught above).
-      if (pattern.test(joined) && !pattern.test(lines[i])) {
-        violations.push({
-          line: i + 1,
-          text: `${lines[i].trimStart()} ${nextTrim}`.trim(),
-          kind: mlKind,
-        });
-        break;
-      }
+    const joinedKind = checkLine(joined);
+    if (joinedKind !== null) {
+      violations.push({
+        line: i + 1,
+        text: `${lines[i].trimStart()} ${nextTrim}`.trim(),
+        kind: joinedKind,
+      });
     }
   }
   return { relPath, violations };
@@ -200,9 +206,16 @@ export function runCheck(
         break;
       }
     }
-    const header = headerLines.join('\n').replace(/\n+$/, '\n');
+    // Always normalize the header to end in exactly one `\n`. Without this,
+    // a header whose last line is a comment (no trailing blank) would be
+    // glued to the first allowlist entry on `header + body` concatenation,
+    // silently corrupting the file (the next `readAllowlist` call would
+    // treat the merged line as a comment and drop the first entry).
+    const header = headerLines.length > 0
+      ? headerLines.join('\n').replace(/\n+$/, '') + '\n'
+      : '';
     const body = sorted.join('\n') + '\n';
-    writeFileSync(allowlistPath, (header.length > 0 ? header : '') + body);
+    writeFileSync(allowlistPath, header + body);
     console.log(`${c.green}Wrote ${sorted.length} entries to ${relative(baseDir, allowlistPath)}${c.reset}`);
     return {
       passed: true, errors: 0, newViolations: [], staleEntries: [],


### PR DESCRIPTION
## What's broken on main

Two bugs shipped to main in PR #4750 (QUA-944) — found by `/agent-review-pr` after merge. Both are in `crux/validate/validate-entity-schema-drift.ts`:

### Bug 1 — phantom violations on comment-then-code

The multi-line pass joins `lines[i] + lines[i+1]` and re-runs raw `pattern.test()` without the comment filter that `checkLine` uses. Any pair of `// comment that mentions VALID_X` followed by a real `const VALID_X = [...]` produces TWO violations: a phantom on the comment line and the real one on the code line. The phantom's reported text is a confusing mash of comment-prose plus code.

Reproducer (verified against the merged code on main):

```ts
// kept VALID_OLD comment
const VALID_X = ["a"];
```

Reports two violations. Real-world example: any allowlisted route with a `// VALID_FOO renamed to VALID_BAR` comment will trip this.

### Bug 2 — `--update` corrupts the production baseline

When the existing allowlist file's header has no trailing blank line — exactly the shape of the shipped `crux/validate/.entity-schema-drift-allowlist.txt` — the `--update` mode writes `# last comment line\nfirst-entry.ts` glued together with NO newline between. The next `readAllowlist` call treats the merged line as a comment and silently drops the first allowlist entry.

Verified: running `npx tsx crux/validate/validate-entity-schema-drift.ts --update` against the production baseline produces:

```
# comments (lines starting with `#`) are ignored.apps/wiki-server/src/routes/tablebase/ai-incidents.ts
```

The first time anyone runs `--update` to refresh the allowlist as routes migrate (Plan v2 PRs 5a/5b), the baseline is silently corrupted. The QUA-944 test suite missed this because the test data used `# header\n\n` (two trailing newlines) which masks the bug.

## What this PR does

This PR is the simplify+fix work that didn't make it into PR #4750 before merge:

1. **Refactor to use shared lib helpers** (`crux/validate/lib/comment-utils.ts`, `lib/file-walker.ts`) instead of copy-pasted logic. Net –50 LOC; gets the more correct template-expression and double-backslash handling for free.
2. **Adopt `buildSuppressionRegex(SUPPRESSION_MARKER)`** so suppressions require `// schema-drift-ok: <reason>` form (matches the `validate-typed-client.ts` pattern). Bare `// schema-drift-ok` no longer suppresses.
3. **Fix Bug 1**: skip the multi-line block when `lines[i]` is itself a comment line; use `checkLine(joined)` instead of raw `pattern.test(joined)` so all the inside-string / inside-comment / suppression filters apply.
4. **Fix Bug 2**: always normalize the header to end in exactly one `\n`. Drop the brittle `replace(/\n+$/, '\n')` (no-op when there are no trailing newlines).
5. **4 new regression tests** for both bugs and a related edge case (string literal containing `const VALID_FAKE =` no longer blocks legitimate multi-line match).

## Test plan

- [x] 28/28 unit tests pass (`npx vitest run crux/validate/validate-entity-schema-drift.test.ts`)
- [x] Validator passes against the 32-file production baseline
- [x] `--update` round-trips the production baseline cleanly (verified with `diff` against the original)
- [x] TypeScript clean across all 3 projects
- [x] /agent-review-pr executed twice (first found these bugs; second confirmed fixes; review marker fresh)
- [ ] CI green
- [ ] Protected Paths Check: requires `gate:rules-ok` label

## Refs

- Closes QUA-966 (this ticket; renamed from QUA-950 placeholder)
- Refs QUA-944 (the merged validator PR; bugs surfaced in its post-merge review)
- Refs QUA-943 (the parent epic this validator gates)
