### PR TITLE
QUA-961: prune /agent-review-pr to 7 phases

### DIFF
--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -9,6 +9,8 @@ This skill triages the current branch's changes, builds a verification plan from
 
 **When to use:** Before shipping any PR. Called automatically by `/agent-ship` for all code PRs, with verification intensity scaled to PR size and risk.
 
+> **Phase count is intentional, not aspirational.** This skill ran with 11 phases through 2026-04 and three sessions in a row (QUA-928, QUA-933, QUA-936) skipped phases that *felt* duplicate — Phase 4 (simplification) and Phase 5 (coverage audit) reliably found nothing because Phase 3b's hostile reviewer already covered them. QUA-961 folded those two into 3b's prompt items #12 and #5 so the surface is honest about what's happening. **Do not split simplification or coverage audit back out as standalone phases** — strengthen the 3b prompt instead.
+
 ---
 
 ## Phase 1: Triage — Analyze the diff and build a verification plan
@@ -44,18 +46,17 @@ Count the metrics:
 
 ### Build the verification plan
 
-Select steps from the menu below. **The default is to INCLUDE a step** — only exclude if clearly irrelevant (e.g., no .tsx files means skip UI testing). Print the plan before executing:
+Select steps from the menu below. **The default is to INCLUDE a step** — only exclude if clearly irrelevant. Print the plan before executing:
 
 ```
 ═══════════════════════════════════════════════════════════════
   REVIEW PLAN — [N] files changed, [M] lines, categories: [X, Y, Z]
 ═══════════════════════════════════════════════════════════════
-  ✓ Build + type check              (always)
+  ✓ Build                           (frontend paths touched — see Phase 2a)
+  ✓ Type check                      (always)
   ✓ Test suite                      (always for code changes)
-  ✓ Gate check                      (always)
-  ✓ Diff review via subagent        (≥30 lines)
-  ✓ Simplification pass             (≥2 code files or ≥50 lines)
-  ✓ Test coverage audit             (new functions/exports found)
+  ✓ Gate check                      (skip if pre-push gate just ran — see Phase 2d)
+  ✓ Diff review via subagent        (≥30 lines — covers simplification + coverage)
   ✓ Red-team                        (≥100 lines or security/API/data)
   ✓ Interactive UI testing          (UI category detected)
   ✓ API endpoint testing            (API category detected)
@@ -65,21 +66,38 @@ Select steps from the menu below. **The default is to INCLUDE a step** — only 
 ═══════════════════════════════════════════════════════════════
 ```
 
-Mark steps with `✓` (will execute) or `—` (skipping, with reason). Then execute them in order.
+Mark steps with `✓` (will execute) or `—` (skipping, with reason). For Phase 2a and 2d carve-outs, the reason must reference the diff property that triggered the skip (specific paths in scope, or a verified pre-push gate cache hit), not free-form text. Then execute them in order.
 
 ---
 
-## Phase 2: Mechanical verification (always runs)
+## Phase 2: Mechanical verification
 
-These are non-negotiable. Run them first to catch obvious breakage.
+These are non-negotiable except for the documented carve-outs. Run them first to catch obvious breakage.
 
-### 2a. Build
+### 2a. Build — conditional on frontend-touching paths
+
+Run `pnpm build` ONLY if the diff touches any of:
+
+- `apps/web/src/**`
+- `apps/web/scripts/build-data*`
+- `apps/web/next.config.*`
+- `apps/web/tailwind.config.*`
+- any `*.tsx` file (anywhere in the repo)
+
+```bash
+# Detect with:
+git diff --name-only main...HEAD | grep -E '^(apps/web/src/|apps/web/scripts/build-data|apps/web/next\.config\.|apps/web/tailwind\.config\.)|\.tsx$' | head -1
+```
+
+If the grep matches:
 
 ```bash
 pnpm build
 ```
 
 Must exit 0. If it fails, fix before proceeding — nothing else matters if it doesn't build.
+
+If the grep is empty (pure `crux/`, wiki-server, content, or non-frontend changes), **skip 2a** — Phase 2b's typecheck on three projects catches the same TS errors in ~10s vs `pnpm build`'s ~60s+. Record the skip in the plan with the diff predicate that justified it (e.g. `Phase 2a — N/A: 0 frontend paths in diff`).
 
 ### 2b. Type checking
 
@@ -102,11 +120,23 @@ If new test files were added, verify they actually run:
 npx vitest run --config crux/vitest.config.ts <new-test-files>
 ```
 
-### 2d. Gate check
+### 2d. Gate check — conditional on pre-push gate cache freshness
+
+Check whether the pre-push hook already ran the full gate against the current commit. The hook writes a cache file at `.cache/pre-push-gate-cache` after a successful gate run; the line is `<commit-sha> <iso-timestamp>`.
 
 ```bash
-pnpm crux w validate gate --fix
+GATE_CACHE=.cache/pre-push-gate-cache
+HEAD_SHA=$(git rev-parse HEAD)
+if [ -f "$GATE_CACHE" ] && [ "$(awk '{print $1}' "$GATE_CACHE")" = "$HEAD_SHA" ]; then
+  echo "Phase 2d — N/A: pre-push gate cache hit on $HEAD_SHA at $(awk '{print $2}' "$GATE_CACHE")"
+else
+  pnpm crux w validate gate --fix
+fi
 ```
+
+If the cache hit is invalid (different SHA, missing file, file corrupted), fall through to running the gate. Do NOT use `--no-verify` or any other shortcut to bypass — the carve-out is "gate already ran on this exact commit," not "gate seems unnecessary."
+
+When recording the skip, the predicate must reference the cache (e.g. `Phase 2d — N/A: pre-push gate cache hit on $HEAD_SHA`).
 
 ---
 
@@ -122,11 +152,13 @@ npx tsx crux/pr-review/detect-narrow-patch.ts
 
 The detector fires at MEDIUM severity when the diff adds a conditional that *both* gates on a literal column name (`columnName === "..."`, `field.name === "..."`, etc.) *and* probes the value's signature (`.startsWith(`, `.test(`, `.match(`, `.includes(`). Pure formatting transforms (`toFixed`, `Intl.NumberFormat`, `formatCurrency`) are not flagged.
 
-**Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `.claude/rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
+**Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `docs/agent-rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
 
 ### 3b. Hostile reviewer subagent
 
 Use the Agent tool to spawn a fresh subagent (subagent_type: "general-purpose") with NO prior context.
+
+> **Items #5 and #12 absorb prior standalone Phases 4 (simplification) and 5 (coverage audit) per QUA-961 — do not split them back out.** Their matrix-style enumeration is what made the standalone phases redundant; weakening either prompt back to the original one-liner re-creates the rationalization surface that QUA-928, QUA-933, and QUA-936 fell into.
 
 Provide it with the full diff (`git diff main...HEAD`) and this prompt:
 
@@ -137,14 +169,14 @@ Provide it with the full diff (`git diff main...HEAD`) and this prompt:
 > 2. **Security**: Injection (SQL, shell, XSS), secrets in code, unsafe deserialization, path traversal
 > 3. **Dead code**: Unused imports, unreachable branches, commented-out code, unused parameters
 > 4. **Missing exports**: New functions/types not exported where needed
-> 5. **Test gaps**: New behavior without test coverage — list every new function/branch that lacks a test
+> 5. **Test coverage matrix**: For each (a) new exported function/class, (b) new error path (`.catch`, `throw`, `if (error)`, status-non-2xx branch), (c) new conditional branch — produce a row with `name | tested? (yes/no/partial) | test file:line if tested`. Include the **full matrix** in your output (not just uncovered items), so reviewers can verify the enumeration was exhaustive. Flag every uncovered or partially-covered row as a finding.
 > 6. **DRY violations**: Copy-pasted logic (>3 lines similar) that should be extracted
 > 7. **Hardcoded values**: Magic numbers, URLs, paths, timeouts that should be constants
 > 8. **Shell safety**: Unquoted variables, missing error handling in bash/workflow files
 > 9. **Error handling**: Silent `.catch(() => {})`, missing error cases, swallowed exceptions
 > 10. **API contract**: Changed response shapes that might break callers, missing validation on inputs
 > 11. **Naming**: Misleading names, abbreviations that aren't obvious, inconsistent conventions
-> 12. **Complexity**: Functions doing too many things, deep nesting, overly clever code
+> 12. **Simplification matrix**: For each changed source file (not test, not content), list every (a) helper used only once that should be inlined, (b) wrapper that just forwards calls, (c) nested ternary or complex conditional that could be simplified, (d) verbose null check where optional chaining works, (e) manual iteration where `.map`/`.filter` is clearer, (f) function doing too many things, (g) deeply nested code. Include the **full matrix** in your output. For each row, recommend either applying the simplification or explain why not (e.g., "single-use helper retained for testability"). Don't compress to "no findings" — show the enumeration so the reviewer can verify it ran.
 >
 > For each finding:
 > - Rate severity: CRITICAL / HIGH / MEDIUM / LOW
@@ -154,7 +186,7 @@ Provide it with the full diff (`git diff main...HEAD`) and this prompt:
 >
 > Output format: `[SEVERITY] (confidence: N) file:line — description`
 >
-> End with a summary: how many findings at each severity level, and your overall assessment.
+> End with a summary: how many findings at each severity level, and your overall assessment. Include the full test-coverage matrix (item #5) and simplification matrix (item #12) **before** the findings list, so reviewers can see what you enumerated regardless of whether each row produced a finding.
 
 **Action on findings:**
 - CRITICAL (any confidence ≥ 60): Fix immediately before proceeding
@@ -162,49 +194,17 @@ Provide it with the full diff (`git diff main...HEAD`) and this prompt:
 - MEDIUM (confidence ≥ 80): Fix unless there's a strong reason not to (document why)
 - LOW: Note in PR description if relevant, otherwise skip
 
----
+**Action on the matrices:** Read both matrices end-to-end. For the test-coverage matrix, every `no` row is a missing test — write it before continuing unless the row carries a documented "untestable" reason. For the simplification matrix, every "apply" row is a change to make in the diff before shipping. The matrices are deliverables, not commentary — empty cells or "n/a — too many to list" make the phase incomplete.
 
-## Phase 4: Simplification pass — ≥2 code files or ≥50 lines changed
-
-For each changed code file (not test files, not content), read the full file and ask:
-
-1. **Is there unnecessary abstraction?** Helpers/utilities used only once, premature generalization, wrapper functions that just forward calls
-2. **Is there unnecessary complexity?** Nested ternaries, complex conditionals that could be simplified, over-engineered error handling for impossible cases
-3. **Are there redundant patterns?** Multiple similar code blocks that should be a loop or helper, copy-pasted logic
-4. **Is the code longer than it needs to be?** Verbose null checks where optional chaining works, manual iteration where `.map`/`.filter` is clearer
-5. **Are there unnecessary dependencies?** Imports that could be avoided, libraries used for trivial operations
-
-**Concretely**: Read each changed file, identify simplification opportunities, and apply them. This is not optional "nice to have" — simpler code has fewer bugs and is easier to review. If a simplification would change behavior, write a test first.
-
-After simplifications, re-run `pnpm test` and `pnpm build` to verify nothing broke.
+If the subagent fails (API error, timeout, disconnect), retry once with a chunked diff. If retry also fails, run the same prompt inline in your own context as a fallback — the inline review is weaker than a fresh subagent, but it catches the round-up-to-done loophole where a failed 3b is treated as completed.
 
 ---
 
-## Phase 5: Test coverage audit — when new functions/exports exist
+## Phase 4: Red-team — ≥100 lines changed, or security/API/data changes
 
-Grep for new exports in the diff:
+This is the most important phase for catching real bugs. The goal is to **actively try to break the solution**, not passively review it. (See QUA-936 / PR #4748 — red-team caught a path-traversal bug in `--tag` that 3b missed, because adversarial *execution* surfaces what passive code reading does not.)
 
-```bash
-git diff --name-only main...HEAD -- '*.ts' '*.tsx' ':!*.test.*' ':!*.spec.*' | xargs -I{} git diff main...HEAD -- {} | grep -E '^\+.*(export (default |)(function|const|class|async function)|export \{|export \*)'
-```
-
-For each new exported function/class:
-1. Search for a corresponding test: `grep -r "functionName" --include="*.test.ts" --include="*.spec.ts"`
-2. If no test exists, **write one**. Not a trivial assertion — test the core behavior and at least one edge case.
-3. For new error paths (`.catch`, `try/catch`, `if (error)`), verify a test triggers each one.
-
-**Test quality check** — for any new tests (whether you wrote them or they were in the PR):
-- No trivial assertions (`expect(result).toBeDefined()`, `typeof x === 'object'`)
-- Assert on specific values that would catch regressions
-- Each test should fail if the implementation is wrong (mentally remove the code under test — would the test catch it?)
-
----
-
-## Phase 6: Red-team — ≥100 lines changed, or security/API/data changes
-
-This is the most important phase for catching real bugs. The goal is to **actively try to break the solution**, not passively review it.
-
-### 6a. Threat modeling
+### 4a. Threat modeling
 
 For each significant change, ask:
 - **What assumptions does this code make?** List them explicitly. Then try to violate each one.
@@ -213,7 +213,7 @@ For each significant change, ask:
 - **What happens when dependencies fail?** Database down, API timeout, file not found, network error mid-operation.
 - **What state can this leave behind on failure?** Partial writes, orphaned records, inconsistent caches.
 
-### 6b. Construct and execute break scenarios
+### 4b. Construct and execute break scenarios
 
 For each threat identified above, **actually try it**. Don't just think about it — run the code with adversarial inputs.
 
@@ -224,6 +224,7 @@ pnpm crux <command> "'; DROP TABLE--"     # injection attempt
 pnpm crux <command> "$(echo pwned)"       # shell injection
 pnpm crux <command> "a]]]]]]]"            # special chars
 pnpm crux <command> "$(python3 -c 'print("x" * 100000)')"  # huge input
+pnpm crux <command> "../../etc/passwd"    # path traversal (if any arg becomes a path)
 ```
 
 For API routes, construct actual HTTP requests:
@@ -233,7 +234,7 @@ curl -X POST http://localhost:<port>/api/endpoint -d '{}'
 curl -X POST http://localhost:<port>/api/endpoint -d '{"field": "<script>alert(1)</script>"}'
 ```
 
-### 6c. Write tests for any bugs found
+### 4c. Write tests for any bugs found
 
 If the red-team phase finds a bug:
 1. Write a failing test that reproduces it
@@ -242,11 +243,15 @@ If the red-team phase finds a bug:
 
 ---
 
-## Phase 7: Interactive UI testing — when .tsx component files changed
+## Phase 5: Category-specific testing
+
+Run the subsections that match the categories detected in Phase 1. UI is just one category alongside API, CLI, data pipeline, and infrastructure — they all live here.
+
+### 5a. Interactive UI testing — when .tsx component files changed
 
 If UI components were modified, **actually look at them in a browser**.
 
-### 7a. Start the dev server
+#### Start the dev server
 
 ```bash
 # Use the correct port for your agent slot (3010 + slot number)
@@ -258,7 +263,7 @@ echo "Dev server PID: $DEV_PID"
 
 Wait for the server to be ready. If Playwright MCP tools are not available (browser_navigate fails), fall back to checking `pnpm build` output for rendering errors and skip interactive testing.
 
-### 7b. Navigate to affected pages with Playwright
+#### Navigate to affected pages with Playwright
 
 Use the Playwright MCP tools to:
 
@@ -270,7 +275,7 @@ Use the Playwright MCP tools to:
 6. **Check responsive behavior**: `browser_resize` to mobile width, take another snapshot
 7. **Check console for errors**: `browser_console_messages` to catch React warnings, failed fetches
 
-### 7c. Specific UI checks
+#### Specific UI checks
 
 - **New components**: Verify they render without errors in all expected contexts
 - **Changed layouts**: Compare against the expected design (check issue description or screenshots)
@@ -283,11 +288,7 @@ After testing, stop the dev server by PID (job control is unreliable across shel
 kill $DEV_PID  # NEVER use pkill -f "next dev" — that kills ALL dev servers
 ```
 
----
-
-## Phase 8: Category-specific testing
-
-### API endpoint testing (when route files changed)
+### 5b. API endpoint testing — when route files changed
 
 If a wiki-server route was modified:
 1. Start the wiki-server if not running
@@ -297,7 +298,7 @@ If a wiki-server route was modified:
 5. Hit with oversized payloads — verify it doesn't crash
 6. Check that the RPC type inference matches the actual response (if using Hono RPC)
 
-### CLI command testing (when crux/ commands changed)
+### 5c. CLI command testing — when crux/ commands changed
 
 1. Run with `--help` — verify help text is accurate
 2. Run with the happy path — verify correct output
@@ -305,44 +306,44 @@ If a wiki-server route was modified:
 4. Run with invalid args — verify it doesn't crash or produce garbage
 5. Run with edge case inputs (empty strings, paths with spaces, unicode)
 
-### Data pipeline testing (when build-data scripts changed)
+### 5d. Data pipeline testing — when build-data scripts changed
 
 1. Run `pnpm build-data:content` — verify it completes
 2. Spot-check `database.json` for expected changes
 3. Verify no entities were accidentally dropped or corrupted
 
-### Infrastructure testing (when CI, Docker, config, or migrations changed)
+### 5e. Infrastructure testing — when CI, Docker, config, or migrations changed
 
 1. **GitHub Actions**: Verify all referenced commands exist and work locally. Check that action versions are pinned. Review trigger conditions.
-2. **Migrations**: Review SQL for correctness. Check for idempotency. Verify the migration follows patterns in `database-migrations.md`.
+2. **Migrations**: Review SQL for correctness. Check for idempotency. Verify the migration follows patterns in `docs/agent-rules/database-migrations.md`.
 3. **Config changes**: Verify env vars are documented, defaults are sensible, and no secrets are hardcoded.
 4. **Docker**: Verify the image builds locally if feasible.
 
 ---
 
-## Phase 9: Final verification
+## Phase 6: Final verification
 
 **If any review phase made changes** (simplifications, new tests, bug fixes), commit them and re-verify:
 
 ```bash
-pnpm build
+pnpm build           # only if Phase 2a's frontend predicate still applies
 pnpm test
 pnpm crux w validate gate --fix
 ```
 
-All three must pass. If no changes were made during review, this phase is redundant with Phase 2 — skip it.
+All three must pass. If no changes were made during review, this phase is redundant with Phase 2 — **skip it**, do not run defensively. Re-running tests on an unchanged tree feels safe but burns context for zero new signal.
 
 ---
 
-## Phase 10: Update test plan and mark review complete
+## Phase 7: Update test plan and mark review complete
 
-### 10a. Update PR test plan
+### 7a. Update PR test plan
 
 1. Update the PR body's test plan section with checked items reflecting what was actually verified
 2. Add items for any verification steps performed beyond the original plan
 3. Run `pnpm crux gh pr validate-test-plan` to confirm it passes
 
-### 10b. Commit any review-induced changes, then create review marker
+### 7b. Commit any review-induced changes, then create review marker
 
 If the review wrote tests, applied simplifications, or fixed bugs, **commit those changes first**. The marker must be written after the final commit so the diff hash is stable.
 
@@ -368,19 +369,19 @@ Summarize the review with:
   REVIEW COMPLETE
 ═══════════════════════════════════════════════════════════════
   Plan executed:    [N/M steps]
-  Skipped:          [list with reasons]
+  Skipped:          [list with predicates — Phase 2a/2d skips MUST cite the diff property or cache hit]
 
   Diff review:      [N findings — X fixed, Y documented, Z dismissed]
-  Simplifications:  [N applied]
-  Tests written:    [N new tests]
+  Coverage matrix:  [N rows total, M uncovered → tests written / documented]
+  Simplification:   [N rows total, M applied / explained]
   Red-team:         [N scenarios tested, M bugs found and fixed]
   UI verified:      [N pages tested] or N/A
   API verified:     [N endpoints tested] or N/A
   CLI verified:     [N commands tested] or N/A
 
-  Build:            PASS
+  Build:            PASS or N/A (no frontend paths in diff)
   Tests:            PASS ([N] tests)
-  Gate:             PASS
+  Gate:             PASS or N/A (pre-push gate cache hit on $HEAD_SHA)
   Type check:       PASS
 
   Overall confidence: HIGH / MEDIUM / LOW

--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -152,7 +152,7 @@ npx tsx crux/pr-review/detect-narrow-patch.ts
 
 The detector fires at MEDIUM severity when the diff adds a conditional that *both* gates on a literal column name (`columnName === "..."`, `field.name === "..."`, etc.) *and* probes the value's signature (`.startsWith(`, `.test(`, `.match(`, `.includes(`). Pure formatting transforms (`toFixed`, `Intl.NumberFormat`, `formatCurrency`) are not flagged.
 
-**Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `docs/agent-rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
+**Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `.claude/rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
 
 ### 3b. Hostile reviewer subagent
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -62,11 +62,16 @@ if [ "$GATE_EXIT" -ne 0 ]; then
   fi
 else
   # Gate passed cleanly. Record the cache so /agent-review-pr Phase 2d can
-  # skip a redundant gate run on this exact commit (QUA-961).
+  # skip a redundant gate run on this exact commit (QUA-961). Best-effort:
+  # any failure here (disk full, permissions) MUST NOT block the push, since
+  # the gate has already passed. set -euo pipefail is in scope, so wrap
+  # in `|| true`.
   HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
   if [ -n "$HEAD_SHA" ]; then
-    mkdir -p .cache
-    printf '%s %s\n' "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >| .cache/pre-push-gate-cache
+    {
+      mkdir -p .cache &&
+      printf '%s %s\n' "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >| .cache/pre-push-gate-cache
+    } 2>/dev/null || true
   fi
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -60,6 +60,14 @@ if [ "$GATE_EXIT" -ne 0 ]; then
     echo "Main CI is green — this failure is from your changes."
     exit "$GATE_EXIT"
   fi
+else
+  # Gate passed cleanly. Record the cache so /agent-review-pr Phase 2d can
+  # skip a redundant gate run on this exact commit (QUA-961).
+  HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+  if [ -n "$HEAD_SHA" ]; then
+    mkdir -p .cache
+    printf '%s %s\n' "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >| .cache/pre-push-gate-cache
+  fi
 fi
 
 # After gate passes (or is excused), run agent checklist auto-verify.


### PR DESCRIPTION
## Summary

Three sessions in 48h (QUA-928, QUA-933, QUA-936) skipped phases of `/agent-review-pr` that *felt* duplicate of Phase 3b's hostile reviewer. Phase 4 (simplification) and Phase 5 (coverage audit) reliably found nothing because 3b's prompt items #12 and #5 already covered them. This PR prunes the skill from 11 phases to 7 so the surface stops inviting the rationalization "covered by 3b, can skim."

Sibling tickets:
- QUA-950 (slot a7, in flight) — phase-tracker file enforces phase completion at marker write
- QUA-962 — mandatory fill-in matrices for Phase 6/8

## Key changes

**Phase 2a (build) is now conditional** on the diff touching frontend paths (`apps/web/src/`, `apps/web/scripts/build-data*`, `apps/web/next.config.*`, `apps/web/tailwind.config.*`, any `*.tsx`). CLI / wiki-server / content-only PRs skip; Phase 2b's three-project typecheck catches the same TS errors ~6× faster. The skip predicate is the grep itself, not free-form text.

**Phase 2d (full gate) is now conditional** on a fresh pre-push gate cache hit. The pre-push hook now writes `.cache/pre-push-gate-cache` with `<sha> <iso-ts>` after the gate passes cleanly; the skill skips a redundant gate run when the SHA matches HEAD. Cache write is best-effort under `set -euo pipefail` (`{ ... } 2>/dev/null || true`), so disk-full or permissions errors never block a push the gate already approved.

**Phase 4 (simplification) and Phase 5 (coverage audit) deleted.** Their content is folded into Phase 3b's hostile-reviewer prompt as matrix-style enumerations:
- Item #5 — test-coverage matrix listing every new export, error path, and conditional branch + tested? + test file:line
- Item #12 — simplification matrix listing every helper-used-once, wrapper, nested ternary, etc. + apply-or-explain

Both matrices must appear in full in the subagent's output, not compressed to "no findings" — the enumeration is the deliverable. A top-of-file callout forbids re-introducing standalone Phase 4/5.

**Phase 7 (UI testing) merged into Phase 5 (Category-specific testing)** as 5a alongside API/CLI/data/infra. UI is just one category; the standalone surface invited "covered by build" rationalization.

**Renumbered**: old 6→4 (red-team), 7+8→5 (category testing), 9→6 (final verify), 10→7 (mark complete). Net: 11 phases → 7.

## Test plan

- [x] Verified Phase 2a regex against 7 sample paths — frontend hits matched (apps/web/src/, build-data, next.config, .tsx anywhere); server/CLI/content paths skipped
- [x] Verified pre-push cache write: round-tripped `<sha> <iso-ts>` format end-to-end. The very push that opened this PR exercised the new code path — `.cache/pre-push-gate-cache` SHA matches HEAD post-push
- [x] Verified failure suppression: simulated `mkdir -p /no/permission/here` under `set -euo pipefail` — script returns exit 0, push would proceed
- [x] Verified `bash -n .githooks/pre-push` syntax check passes
- [x] Verified all rule path references in the new file resolve (`.claude/rules/proactive-github-filing.md`, `docs/agent-rules/database-migrations.md`)
- [x] Verified no other code references `/agent-review-pr`'s specific Phase 4/5 numbers (`crux/lib/review-marker.ts`, `crux/lib/dispatch-prompt-template.ts`, `crux/pr-patrol/prompts.ts` only reference the skill name)
- [x] Ran `/agent-review-pr` on this PR's diff. Hostile reviewer found 1 CRITICAL (cache-write blocking pushes) + 1 MEDIUM (broken doc path); both fixed in `review:` commit before this PR was opened

## Test failures unrelated to this PR

`pnpm test` shows 8 pre-existing failures in `validate/scope-flag.test.ts`, `wiki-server/snapshot-resources.test.ts`, and `commands/legislation/auto-verify-stakeholders.test.ts`. None touch the files in this diff (markdown + shell). Filing as separate Linear ticket if not already tracked.

## Coordination note

QUA-950 (slot a7, in flight) is the sibling phase-tracker ticket. Both touch `agent-review-pr.md` — QUA-950's tracker file phase IDs will need to align with the new 7-phase numbering. Heads-up may save a merge.

Fixes QUA-961
