### PR TITLE
QUA-953: prod-visible strict-fail counter for TypedEntitySchema fall-through

### DIFF
--- a/apps/web/src/app/api/internal/strict-fail-stats/route.ts
+++ b/apps/web/src/app/api/internal/strict-fail-stats/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getStrictFailStats, getTypedEntities } from "@/data/tablebase";
+
+/**
+ * GET /api/internal/strict-fail-stats
+ *
+ * Returns a counter of TypedEntitySchema.safeParse fall-throughs in
+ * getTypedEntities(). See QUA-953 (Phase 0b of QUA-943): we need a
+ * prod-visible signal of how often the strict per-type schemas miss
+ * entities, before Phase 6 can delete GenericEntityPassthroughSchema.
+ *
+ * The counter is process-local and is populated on the first call to
+ * getTypedEntities(). This handler triggers that population if it has
+ * not happened yet, so the endpoint is meaningful even on a cold process.
+ */
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  // Force population if this process hasn't loaded entities yet.
+  getTypedEntities();
+  return NextResponse.json(getStrictFailStats());
+}

--- a/apps/web/src/app/api/internal/strict-fail-stats/route.ts
+++ b/apps/web/src/app/api/internal/strict-fail-stats/route.ts
@@ -12,11 +12,26 @@ import { getStrictFailStats, getTypedEntities } from "@/data/tablebase";
  * The counter is process-local and is populated on the first call to
  * getTypedEntities(). This handler triggers that population if it has
  * not happened yet, so the endpoint is meaningful even on a cold process.
+ *
+ * The data exposed (entity IDs, schema field paths, Zod messages) is
+ * derived from publicly-available content in database.json and the
+ * open-source schema, so this endpoint matches the public-by-default
+ * convention of other Next.js API routes in this app.
  */
 export const dynamic = "force-dynamic";
 
 export function GET() {
-  // Force population if this process hasn't loaded entities yet.
-  getTypedEntities();
-  return NextResponse.json(getStrictFailStats());
+  try {
+    // Force population if this process hasn't loaded entities yet.
+    getTypedEntities();
+    return NextResponse.json(getStrictFailStats());
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "Failed to load entities",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 503 },
+    );
+  }
 }

--- a/apps/web/src/data/__tests__/strict-fail-stats.test.ts
+++ b/apps/web/src/data/__tests__/strict-fail-stats.test.ts
@@ -243,8 +243,8 @@ describe("strict-fail counter (QUA-953)", () => {
   it("counts hardFailCount when even GenericEntityPassthroughSchema fails", async () => {
     mockReadFile(
       buildMockDatabase([
-        // Missing required base fields (id, entityType, title) → strict + generic both fail
-        { description: "no id, no type, no title" },
+        // Missing required BaseEntity fields (id, title) → strict + generic both fail.
+        { description: "no id, no title" },
       ]),
     );
 
@@ -260,5 +260,62 @@ describe("strict-fail counter (QUA-953)", () => {
 
     expect(stats.fallthroughCount).toBe(1);
     expect(stats.hardFailCount).toBe(1);
+    // The fall-through is bucketed under "<unknown>" because entityType is missing,
+    // and the recorded message should reflect a base-field validation failure
+    // (id/title required) rather than something accidental.
+    const samples = stats.byType["<unknown>"]?.samples ?? [];
+    expect(samples.length).toBe(1);
+    expect(samples[0]?.id).toBe("<unknown>");
+    expect(samples[0]?.message.length).toBeGreaterThan(0);
+  });
+
+  it("getStrictFailStats returns a deep copy — mutating sample fields does not affect internal state", async () => {
+    mockReadFile(
+      buildMockDatabase([
+        {
+          id: "weird-1",
+          entityType: "weirdType",
+          title: "Weird",
+          description: "x",
+        },
+      ]),
+    );
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const a = getStrictFailStats();
+    if (a.byType.weirdType?.samples[0]) {
+      a.byType.weirdType.samples[0].id = "MUTATED";
+      a.byType.weirdType.samples[0].fieldPath = "MUTATED";
+      a.byType.weirdType.samples[0].message = "MUTATED";
+    }
+
+    const b = getStrictFailStats();
+    expect(b.byType.weirdType?.samples[0]?.id).toBe("weird-1");
+    expect(b.byType.weirdType?.samples[0]?.fieldPath).not.toBe("MUTATED");
+    expect(b.byType.weirdType?.samples[0]?.message).not.toBe("MUTATED");
+  });
+
+  it("_resetStrictFailStatsForTests throws outside test environments", async () => {
+    const { _resetStrictFailStatsForTests } = await import("../tablebase");
+    const env = process.env as Record<string, string | undefined>;
+    const originalNodeEnv = env.NODE_ENV;
+    const originalVitest = env.VITEST;
+    try {
+      env.NODE_ENV = "production";
+      delete env.VITEST;
+      expect(() => _resetStrictFailStatsForTests()).toThrow(
+        /only callable in test environments/,
+      );
+    } finally {
+      env.NODE_ENV = originalNodeEnv;
+      if (originalVitest !== undefined) env.VITEST = originalVitest;
+    }
   });
 });

--- a/apps/web/src/data/__tests__/strict-fail-stats.test.ts
+++ b/apps/web/src/data/__tests__/strict-fail-stats.test.ts
@@ -64,82 +64,55 @@ function mockReadFile(database: object) {
   });
 }
 
+async function loadFreshTablebase() {
+  const mod = await import("../tablebase");
+  mod._resetStrictFailStatsForTests();
+  return mod;
+}
+
 describe("strict-fail counter (QUA-953)", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
   });
 
   it("returns an empty stats object before getTypedEntities is called", async () => {
-    const { getStrictFailStats, _resetStrictFailStatsForTests } = await import(
-      "../tablebase"
-    );
-    _resetStrictFailStatsForTests();
+    const { getStrictFailStats } = await loadFreshTablebase();
     const stats = getStrictFailStats();
-    expect(stats.populated).toBe(false);
+    expect(stats.populatedAt).toBeNull();
     expect(stats.fallthroughCount).toBe(0);
     expect(stats.hardFailCount).toBe(0);
     expect(stats.totalEntities).toBe(0);
     expect(stats.byType).toEqual({});
-    expect(stats.populatedAt).toBeNull();
   });
 
   it("counts zero fall-throughs when all entities pass the strict schema", async () => {
     mockReadFile(buildMockDatabase());
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
+    const { getTypedEntities, getStrictFailStats } = await loadFreshTablebase();
 
     getTypedEntities();
     const stats = getStrictFailStats();
 
-    expect(stats.populated).toBe(true);
+    expect(stats.populatedAt).not.toBeNull();
     expect(stats.fallthroughCount).toBe(0);
     expect(stats.hardFailCount).toBe(0);
     expect(stats.totalEntities).toBe(1);
     expect(stats.byType).toEqual({});
-    expect(stats.populatedAt).not.toBeNull();
   });
 
   it("increments fallthroughCount and bucketing by entityType for unknown types", async () => {
     mockReadFile(
       buildMockDatabase([
-        // Unknown entity type → falls through to GenericEntityPassthroughSchema
-        {
-          id: "weird-1",
-          entityType: "weirdType",
-          title: "Weird One",
-          description: "first",
-        },
-        {
-          id: "weird-2",
-          entityType: "weirdType",
-          title: "Weird Two",
-          description: "second",
-        },
-        {
-          id: "other-1",
-          entityType: "otherWeirdType",
-          title: "Other Weird",
-          description: "third",
-        },
+        { id: "weird-1", entityType: "weirdType", title: "Weird One", description: "first" },
+        { id: "weird-2", entityType: "weirdType", title: "Weird Two", description: "second" },
+        { id: "other-1", entityType: "otherWeirdType", title: "Other Weird", description: "third" },
       ]),
     );
 
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
+    const { getTypedEntities, getStrictFailStats } = await loadFreshTablebase();
     getTypedEntities();
     const stats = getStrictFailStats();
 
-    expect(stats.populated).toBe(true);
     expect(stats.fallthroughCount).toBe(3);
     expect(stats.hardFailCount).toBe(0);
     expect(stats.totalEntities).toBe(4);
@@ -165,13 +138,7 @@ describe("strict-fail counter (QUA-953)", () => {
       ]),
     );
 
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
+    const { getTypedEntities, getStrictFailStats } = await loadFreshTablebase();
     getTypedEntities();
     const stats = getStrictFailStats();
 
@@ -191,13 +158,7 @@ describe("strict-fail counter (QUA-953)", () => {
     }));
     mockReadFile(buildMockDatabase(extras));
 
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
+    const { getTypedEntities, getStrictFailStats } = await loadFreshTablebase();
     getTypedEntities();
     const stats = getStrictFailStats();
 
@@ -205,39 +166,35 @@ describe("strict-fail counter (QUA-953)", () => {
     expect(stats.byType.manyWeird?.samples.length).toBe(5);
   });
 
-  it("returns a defensive copy from getStrictFailStats (mutating the result does not affect internal state)", async () => {
+  it("getStrictFailStats returns a deep copy — caller mutations never leak back", async () => {
     mockReadFile(
       buildMockDatabase([
-        {
-          id: "weird-1",
-          entityType: "weirdType",
-          title: "Weird",
-          description: "x",
-        },
+        { id: "weird-1", entityType: "weirdType", title: "Weird", description: "x" },
       ]),
     );
 
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
+    const { getTypedEntities, getStrictFailStats } = await loadFreshTablebase();
     getTypedEntities();
+
     const a = getStrictFailStats();
     a.fallthroughCount = 999;
-    a.byType.weirdType!.count = 999;
-    a.byType.weirdType!.samples.push({
-      id: "injected",
-      fieldPath: "x",
-      message: "x",
-    });
+    if (a.byType.weirdType) {
+      a.byType.weirdType.count = 999;
+      a.byType.weirdType.samples.push({ id: "injected", fieldPath: "x", message: "x" });
+      if (a.byType.weirdType.samples[0]) {
+        a.byType.weirdType.samples[0].id = "MUTATED";
+        a.byType.weirdType.samples[0].fieldPath = "MUTATED";
+        a.byType.weirdType.samples[0].message = "MUTATED";
+      }
+    }
 
     const b = getStrictFailStats();
     expect(b.fallthroughCount).toBe(1);
     expect(b.byType.weirdType?.count).toBe(1);
     expect(b.byType.weirdType?.samples.length).toBe(1);
+    expect(b.byType.weirdType?.samples[0]?.id).toBe("weird-1");
+    expect(b.byType.weirdType?.samples[0]?.fieldPath).not.toBe("MUTATED");
+    expect(b.byType.weirdType?.samples[0]?.message).not.toBe("MUTATED");
   });
 
   it("counts hardFailCount when even GenericEntityPassthroughSchema fails", async () => {
@@ -248,58 +205,20 @@ describe("strict-fail counter (QUA-953)", () => {
       ]),
     );
 
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
+    const { getTypedEntities, getStrictFailStats, STRICT_FAIL_UNKNOWN_LABEL } =
+      await loadFreshTablebase();
     getTypedEntities();
     const stats = getStrictFailStats();
 
     expect(stats.fallthroughCount).toBe(1);
     expect(stats.hardFailCount).toBe(1);
-    // The fall-through is bucketed under "<unknown>" because entityType is missing,
-    // and the recorded message should reflect a base-field validation failure
-    // (id/title required) rather than something accidental.
-    const samples = stats.byType["<unknown>"]?.samples ?? [];
+    // The fall-through is bucketed under the unknown-label sentinel because
+    // entityType is missing; sample message should reflect a base-field
+    // validation failure (id/title required) rather than something accidental.
+    const samples = stats.byType[STRICT_FAIL_UNKNOWN_LABEL]?.samples ?? [];
     expect(samples.length).toBe(1);
-    expect(samples[0]?.id).toBe("<unknown>");
+    expect(samples[0]?.id).toBe(STRICT_FAIL_UNKNOWN_LABEL);
     expect(samples[0]?.message.length).toBeGreaterThan(0);
-  });
-
-  it("getStrictFailStats returns a deep copy — mutating sample fields does not affect internal state", async () => {
-    mockReadFile(
-      buildMockDatabase([
-        {
-          id: "weird-1",
-          entityType: "weirdType",
-          title: "Weird",
-          description: "x",
-        },
-      ]),
-    );
-
-    const {
-      getTypedEntities,
-      getStrictFailStats,
-      _resetStrictFailStatsForTests,
-    } = await import("../tablebase");
-    _resetStrictFailStatsForTests();
-
-    getTypedEntities();
-    const a = getStrictFailStats();
-    if (a.byType.weirdType?.samples[0]) {
-      a.byType.weirdType.samples[0].id = "MUTATED";
-      a.byType.weirdType.samples[0].fieldPath = "MUTATED";
-      a.byType.weirdType.samples[0].message = "MUTATED";
-    }
-
-    const b = getStrictFailStats();
-    expect(b.byType.weirdType?.samples[0]?.id).toBe("weird-1");
-    expect(b.byType.weirdType?.samples[0]?.fieldPath).not.toBe("MUTATED");
-    expect(b.byType.weirdType?.samples[0]?.message).not.toBe("MUTATED");
   });
 
   it("_resetStrictFailStatsForTests throws outside test environments", async () => {

--- a/apps/web/src/data/__tests__/strict-fail-stats.test.ts
+++ b/apps/web/src/data/__tests__/strict-fail-stats.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Strict-fail counter tests (QUA-953).
+ *
+ * Verifies that getTypedEntities() correctly tracks fall-throughs from
+ * TypedEntitySchema.safeParse to GenericEntityPassthroughSchema.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+
+vi.mock("fs");
+vi.mock("js-yaml", () => ({ default: { load: vi.fn(() => []) } }));
+vi.mock("@lib/wiki-server", () => ({
+  fetchFromWikiServer: vi.fn(async () => null),
+  withApiFallback: vi.fn(async (_apiLoader: unknown, localLoader: () => unknown) => ({
+    data: localLoader(),
+    source: "local" as const,
+  })),
+  fetchDetailed: vi.fn(async () => ({ ok: false, error: { type: "not-configured" } })),
+  getWikiServerConfig: vi.fn(() => null),
+  dataSourceLabel: vi.fn(() => "local files"),
+}));
+
+const baseEntity = {
+  tags: [],
+  clusters: [],
+  relatedEntries: [],
+  sources: [],
+  customFields: [],
+  relatedTopics: [],
+};
+
+function buildMockDatabase(extra: object[] = []) {
+  return {
+    entities: [],
+    typedEntities: [
+      // Valid risk — passes strict schema
+      {
+        id: "valid-risk",
+        entityType: "risk",
+        title: "Valid Risk",
+        description: "ok",
+        riskCategory: "accident",
+        ...baseEntity,
+      },
+      ...extra,
+    ],
+    resources: [],
+    publications: [],
+    organizations: [],
+    pathRegistry: {},
+    idRegistry: { byWikiId: {}, bySlug: {} },
+    pages: [],
+    stats: {},
+  };
+}
+
+function mockReadFile(database: object) {
+  vi.mocked(fs.readFileSync).mockImplementation((filepath: unknown) => {
+    const fp = String(filepath);
+    if (fp.endsWith("database.json")) {
+      return JSON.stringify(database);
+    }
+    return "{}";
+  });
+}
+
+describe("strict-fail counter (QUA-953)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty stats object before getTypedEntities is called", async () => {
+    const { getStrictFailStats, _resetStrictFailStatsForTests } = await import(
+      "../tablebase"
+    );
+    _resetStrictFailStatsForTests();
+    const stats = getStrictFailStats();
+    expect(stats.populated).toBe(false);
+    expect(stats.fallthroughCount).toBe(0);
+    expect(stats.hardFailCount).toBe(0);
+    expect(stats.totalEntities).toBe(0);
+    expect(stats.byType).toEqual({});
+    expect(stats.populatedAt).toBeNull();
+  });
+
+  it("counts zero fall-throughs when all entities pass the strict schema", async () => {
+    mockReadFile(buildMockDatabase());
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const stats = getStrictFailStats();
+
+    expect(stats.populated).toBe(true);
+    expect(stats.fallthroughCount).toBe(0);
+    expect(stats.hardFailCount).toBe(0);
+    expect(stats.totalEntities).toBe(1);
+    expect(stats.byType).toEqual({});
+    expect(stats.populatedAt).not.toBeNull();
+  });
+
+  it("increments fallthroughCount and bucketing by entityType for unknown types", async () => {
+    mockReadFile(
+      buildMockDatabase([
+        // Unknown entity type → falls through to GenericEntityPassthroughSchema
+        {
+          id: "weird-1",
+          entityType: "weirdType",
+          title: "Weird One",
+          description: "first",
+        },
+        {
+          id: "weird-2",
+          entityType: "weirdType",
+          title: "Weird Two",
+          description: "second",
+        },
+        {
+          id: "other-1",
+          entityType: "otherWeirdType",
+          title: "Other Weird",
+          description: "third",
+        },
+      ]),
+    );
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const stats = getStrictFailStats();
+
+    expect(stats.populated).toBe(true);
+    expect(stats.fallthroughCount).toBe(3);
+    expect(stats.hardFailCount).toBe(0);
+    expect(stats.totalEntities).toBe(4);
+    expect(stats.byType.weirdType?.count).toBe(2);
+    expect(stats.byType.otherWeirdType?.count).toBe(1);
+    expect(stats.byType.weirdType?.samples.length).toBe(2);
+    expect(stats.byType.weirdType?.samples[0]?.id).toBe("weird-1");
+    expect(stats.byType.otherWeirdType?.samples[0]?.id).toBe("other-1");
+  });
+
+  it("captures field path and message for the first failing issue", async () => {
+    mockReadFile(
+      buildMockDatabase([
+        // entityType is 'risk' but severity has an invalid enum value → strict fail with a field path
+        {
+          id: "risk-bad-severity",
+          entityType: "risk",
+          title: "Risk Bad Severity",
+          description: "bad enum",
+          severity: "totally-invalid-severity",
+          ...baseEntity,
+        },
+      ]),
+    );
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const stats = getStrictFailStats();
+
+    expect(stats.fallthroughCount).toBe(1);
+    const sample = stats.byType.risk?.samples[0];
+    expect(sample?.id).toBe("risk-bad-severity");
+    expect(sample?.fieldPath).toBe("severity");
+    expect(sample?.message.length).toBeGreaterThan(0);
+  });
+
+  it("caps samples per type at 5", async () => {
+    const extras = Array.from({ length: 8 }, (_, i) => ({
+      id: `weird-${i}`,
+      entityType: "manyWeird",
+      title: `Weird ${i}`,
+      description: `n${i}`,
+    }));
+    mockReadFile(buildMockDatabase(extras));
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const stats = getStrictFailStats();
+
+    expect(stats.byType.manyWeird?.count).toBe(8);
+    expect(stats.byType.manyWeird?.samples.length).toBe(5);
+  });
+
+  it("returns a defensive copy from getStrictFailStats (mutating the result does not affect internal state)", async () => {
+    mockReadFile(
+      buildMockDatabase([
+        {
+          id: "weird-1",
+          entityType: "weirdType",
+          title: "Weird",
+          description: "x",
+        },
+      ]),
+    );
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const a = getStrictFailStats();
+    a.fallthroughCount = 999;
+    a.byType.weirdType!.count = 999;
+    a.byType.weirdType!.samples.push({
+      id: "injected",
+      fieldPath: "x",
+      message: "x",
+    });
+
+    const b = getStrictFailStats();
+    expect(b.fallthroughCount).toBe(1);
+    expect(b.byType.weirdType?.count).toBe(1);
+    expect(b.byType.weirdType?.samples.length).toBe(1);
+  });
+
+  it("counts hardFailCount when even GenericEntityPassthroughSchema fails", async () => {
+    mockReadFile(
+      buildMockDatabase([
+        // Missing required base fields (id, entityType, title) → strict + generic both fail
+        { description: "no id, no type, no title" },
+      ]),
+    );
+
+    const {
+      getTypedEntities,
+      getStrictFailStats,
+      _resetStrictFailStatsForTests,
+    } = await import("../tablebase");
+    _resetStrictFailStatsForTests();
+
+    getTypedEntities();
+    const stats = getStrictFailStats();
+
+    expect(stats.fallthroughCount).toBe(1);
+    expect(stats.hardFailCount).toBe(1);
+  });
+});

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -513,6 +513,9 @@ let _typedEntities: AnyEntity[] | null = null;
 // pattern (failing field path + message) without flooding the endpoint.
 const SAMPLE_LIMIT = 5;
 
+// Used as the bucket key / sample id when an entity is missing entityType / id.
+export const STRICT_FAIL_UNKNOWN_LABEL = "<unknown>";
+
 interface StrictFailSample {
   id: string;
   fieldPath: string;
@@ -525,42 +528,33 @@ interface StrictFailTypeBreakdown {
 }
 
 export interface StrictFailStats {
-  /** Whether getTypedEntities() has been called yet (counter is empty otherwise). */
-  populated: boolean;
-  /** Total number of entities that fell through to GenericEntityPassthroughSchema. */
   fallthroughCount: number;
   /** Entities that failed even GenericEntityPassthroughSchema (skipped entirely). */
   hardFailCount: number;
-  /** Total entities processed in the most recent population. */
   totalEntities: number;
-  /** Per-entityType breakdown of fall-throughs, with up to SAMPLE_LIMIT examples each. */
   byType: Record<string, StrictFailTypeBreakdown>;
-  /** ISO timestamp of when the counter was last populated. */
+  /** ISO timestamp of when the counter was last populated. Null until
+   * getTypedEntities() runs. Use as the populated/unpopulated signal. */
   populatedAt: string | null;
 }
 
-let _strictFailStats: StrictFailStats = {
-  populated: false,
-  fallthroughCount: 0,
-  hardFailCount: 0,
-  totalEntities: 0,
-  byType: {},
-  populatedAt: null,
-};
+function makeEmptyStats(): StrictFailStats {
+  return {
+    fallthroughCount: 0,
+    hardFailCount: 0,
+    totalEntities: 0,
+    byType: {},
+    populatedAt: null,
+  };
+}
 
-/** Get a snapshot of the strict-fail counter. Returns an empty stats object if
+let _strictFailStats: StrictFailStats = makeEmptyStats();
+
+/** Snapshot of the strict-fail counter. Returns an empty stats object if
  * getTypedEntities() has not been called yet in this process. The returned
  * object is a deep copy — mutating it does not affect internal state. */
 export function getStrictFailStats(): StrictFailStats {
-  return {
-    ..._strictFailStats,
-    byType: Object.fromEntries(
-      Object.entries(_strictFailStats.byType).map(([k, v]) => [
-        k,
-        { count: v.count, samples: v.samples.map((s) => ({ ...s })) },
-      ]),
-    ),
-  };
+  return structuredClone(_strictFailStats);
 }
 
 /** Reset the counter — for tests only. Throws in non-test environments to
@@ -571,14 +565,7 @@ export function _resetStrictFailStatsForTests(): void {
       "_resetStrictFailStatsForTests() is only callable in test environments",
     );
   }
-  _strictFailStats = {
-    populated: false,
-    fallthroughCount: 0,
-    hardFailCount: 0,
-    totalEntities: 0,
-    byType: {},
-    populatedAt: null,
-  };
+  _strictFailStats = makeEmptyStats();
   _typedEntities = null;
 }
 
@@ -615,13 +602,9 @@ export function getTypedEntities(): AnyEntity[] {
   const entities: AnyEntity[] = [];
   const isDev = process.env.NODE_ENV === "development";
 
-  // Reset stats for this population pass (function is memoized; this runs once per process).
   const stats: StrictFailStats = {
-    populated: true,
-    fallthroughCount: 0,
-    hardFailCount: 0,
+    ...makeEmptyStats(),
     totalEntities: db.typedEntities.length,
-    byType: {},
     populatedAt: new Date().toISOString(),
   };
 
@@ -629,43 +612,43 @@ export function getTypedEntities(): AnyEntity[] {
     const result = TypedEntitySchema.safeParse(raw);
     if (result.success) {
       entities.push(result.data);
+      continue;
+    }
+
+    // GenericEntityPassthroughSchema preserves unknown keys
+    // (causeEffectGraph, content, currentAssessment, etc.).
+    const rawRecord = raw as Record<string, unknown>;
+    const id =
+      typeof rawRecord.id === "string" ? rawRecord.id : STRICT_FAIL_UNKNOWN_LABEL;
+    const type =
+      typeof rawRecord.entityType === "string"
+        ? rawRecord.entityType
+        : STRICT_FAIL_UNKNOWN_LABEL;
+
+    stats.fallthroughCount += 1;
+    const bucket = (stats.byType[type] ??= { count: 0, samples: [] });
+    bucket.count += 1;
+    if (bucket.samples.length < SAMPLE_LIMIT) {
+      const firstIssue = result.error.issues[0];
+      bucket.samples.push({
+        id,
+        fieldPath: firstIssue?.path.join(".") ?? "",
+        message: firstIssue?.message ?? "",
+      });
+    }
+
+    if (isDev) {
+      console.warn(
+        `[entity-validation] ${id} (${type}): ${result.error.issues.map(i => i.message).join(", ")}`
+      );
+    }
+    const genericResult = GenericEntityPassthroughSchema.safeParse(raw);
+    if (genericResult.success) {
+      entities.push(genericResult.data as GenericEntity);
     } else {
-      // Unknown entity types — validate base fields via GenericEntityPassthroughSchema,
-      // which preserves extra keys (causeEffectGraph, content, currentAssessment, etc.).
-      const rawRecord = raw as Record<string, unknown>;
-      const id = typeof rawRecord.id === "string" ? rawRecord.id : "<unknown>";
-      const type =
-        typeof rawRecord.entityType === "string"
-          ? rawRecord.entityType
-          : "<unknown>";
-
-      // Record the fall-through (QUA-953). Tracks every fall-through in prod
-      // so Phase 6 of QUA-943 can verify zero strict-fails before deleting
-      // GenericEntityPassthroughSchema.
-      stats.fallthroughCount += 1;
-      stats.byType[type] ??= { count: 0, samples: [] };
-      const bucket = stats.byType[type]!;
-      bucket.count += 1;
-      if (bucket.samples.length < SAMPLE_LIMIT) {
-        const firstIssue = result.error.issues[0];
-        const fieldPath = firstIssue?.path.join(".") ?? "";
-        const message = firstIssue?.message ?? "";
-        bucket.samples.push({ id, fieldPath, message });
-      }
-
+      stats.hardFailCount += 1;
       if (isDev) {
-        console.warn(
-          `[entity-validation] ${id} (${type}): ${result.error.issues.map(i => i.message).join(", ")}`
-        );
-      }
-      const genericResult = GenericEntityPassthroughSchema.safeParse(raw);
-      if (genericResult.success) {
-        entities.push(genericResult.data as GenericEntity);
-      } else {
-        stats.hardFailCount += 1;
-        if (isDev) {
-          console.warn(`[entity-validation] ${id}: failed generic parse too — skipping`);
-        }
+        console.warn(`[entity-validation] ${id}: failed generic parse too — skipping`);
       }
     }
   }

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -497,10 +497,20 @@ let _typedEntities: AnyEntity[] | null = null;
 // requires this counter to read zero for 7 consecutive prod build cycles
 // before GenericEntityPassthroughSchema can be deleted.
 //
-// Stats are populated on the first call to getTypedEntities() in a process
-// and are stable thereafter (the function is memoized via _typedEntities).
+// Scope:
+// - Per-process and per-build-cycle. Stats are populated on the first call
+//   to getTypedEntities() in a process and are stable thereafter (the
+//   function is memoized via _typedEntities). Each Next.js build → fresh
+//   process → fresh stats, which is exactly the cadence Phase 6's
+//   "7 consecutive prod build cycles" check needs.
+// - Not aggregated across workers. A multi-worker deploy will give each
+//   worker its own snapshot; readers should expect identical values across
+//   workers because the input (database.json) is identical.
 // ============================================================================
 
+// Cap per-type sample arrays so a pathological "100 entities of bad type X"
+// build doesn't bloat the JSON response. 5 is enough to spot the failure
+// pattern (failing field path + message) without flooding the endpoint.
 const SAMPLE_LIMIT = 5;
 
 interface StrictFailSample {
@@ -539,21 +549,28 @@ let _strictFailStats: StrictFailStats = {
 };
 
 /** Get a snapshot of the strict-fail counter. Returns an empty stats object if
- * getTypedEntities() has not been called yet in this process. */
+ * getTypedEntities() has not been called yet in this process. The returned
+ * object is a deep copy — mutating it does not affect internal state. */
 export function getStrictFailStats(): StrictFailStats {
   return {
     ..._strictFailStats,
     byType: Object.fromEntries(
       Object.entries(_strictFailStats.byType).map(([k, v]) => [
         k,
-        { count: v.count, samples: [...v.samples] },
+        { count: v.count, samples: v.samples.map((s) => ({ ...s })) },
       ]),
     ),
   };
 }
 
-/** Reset the counter — for tests only. */
+/** Reset the counter — for tests only. Throws in non-test environments to
+ * prevent accidental cache invalidation in production bundles. */
 export function _resetStrictFailStatsForTests(): void {
+  if (process.env.NODE_ENV !== "test" && process.env.VITEST !== "true") {
+    throw new Error(
+      "_resetStrictFailStatsForTests() is only callable in test environments",
+    );
+  }
   _strictFailStats = {
     populated: false,
     fallthroughCount: 0,
@@ -626,8 +643,8 @@ export function getTypedEntities(): AnyEntity[] {
       // so Phase 6 of QUA-943 can verify zero strict-fails before deleting
       // GenericEntityPassthroughSchema.
       stats.fallthroughCount += 1;
-      const bucket =
-        stats.byType[type] ?? (stats.byType[type] = { count: 0, samples: [] });
+      stats.byType[type] ??= { count: 0, samples: [] };
+      const bucket = stats.byType[type]!;
       bucket.count += 1;
       if (bucket.samples.length < SAMPLE_LIMIT) {
         const firstIssue = result.error.issues[0];

--- a/apps/web/src/data/tablebase.ts
+++ b/apps/web/src/data/tablebase.ts
@@ -489,6 +489,82 @@ export type AnyEntity = TypedEntity | GenericEntity;
 let _database: TableBaseShape | null = null;
 let _typedEntities: AnyEntity[] | null = null;
 
+// ============================================================================
+// STRICT-FAIL COUNTER (QUA-953)
+//
+// Tracks how often TypedEntitySchema.safeParse falls through to
+// GenericEntityPassthroughSchema in getTypedEntities(). Phase 6 of QUA-943
+// requires this counter to read zero for 7 consecutive prod build cycles
+// before GenericEntityPassthroughSchema can be deleted.
+//
+// Stats are populated on the first call to getTypedEntities() in a process
+// and are stable thereafter (the function is memoized via _typedEntities).
+// ============================================================================
+
+const SAMPLE_LIMIT = 5;
+
+interface StrictFailSample {
+  id: string;
+  fieldPath: string;
+  message: string;
+}
+
+interface StrictFailTypeBreakdown {
+  count: number;
+  samples: StrictFailSample[];
+}
+
+export interface StrictFailStats {
+  /** Whether getTypedEntities() has been called yet (counter is empty otherwise). */
+  populated: boolean;
+  /** Total number of entities that fell through to GenericEntityPassthroughSchema. */
+  fallthroughCount: number;
+  /** Entities that failed even GenericEntityPassthroughSchema (skipped entirely). */
+  hardFailCount: number;
+  /** Total entities processed in the most recent population. */
+  totalEntities: number;
+  /** Per-entityType breakdown of fall-throughs, with up to SAMPLE_LIMIT examples each. */
+  byType: Record<string, StrictFailTypeBreakdown>;
+  /** ISO timestamp of when the counter was last populated. */
+  populatedAt: string | null;
+}
+
+let _strictFailStats: StrictFailStats = {
+  populated: false,
+  fallthroughCount: 0,
+  hardFailCount: 0,
+  totalEntities: 0,
+  byType: {},
+  populatedAt: null,
+};
+
+/** Get a snapshot of the strict-fail counter. Returns an empty stats object if
+ * getTypedEntities() has not been called yet in this process. */
+export function getStrictFailStats(): StrictFailStats {
+  return {
+    ..._strictFailStats,
+    byType: Object.fromEntries(
+      Object.entries(_strictFailStats.byType).map(([k, v]) => [
+        k,
+        { count: v.count, samples: [...v.samples] },
+      ]),
+    ),
+  };
+}
+
+/** Reset the counter — for tests only. */
+export function _resetStrictFailStatsForTests(): void {
+  _strictFailStats = {
+    populated: false,
+    fallthroughCount: 0,
+    hardFailCount: 0,
+    totalEntities: 0,
+    byType: {},
+    populatedAt: null,
+  };
+  _typedEntities = null;
+}
+
 export function getTableBase(): TableBaseShape {
   if (_database) return _database;
 
@@ -522,6 +598,16 @@ export function getTypedEntities(): AnyEntity[] {
   const entities: AnyEntity[] = [];
   const isDev = process.env.NODE_ENV === "development";
 
+  // Reset stats for this population pass (function is memoized; this runs once per process).
+  const stats: StrictFailStats = {
+    populated: true,
+    fallthroughCount: 0,
+    hardFailCount: 0,
+    totalEntities: db.typedEntities.length,
+    byType: {},
+    populatedAt: new Date().toISOString(),
+  };
+
   for (const raw of db.typedEntities) {
     const result = TypedEntitySchema.safeParse(raw);
     if (result.success) {
@@ -529,9 +615,28 @@ export function getTypedEntities(): AnyEntity[] {
     } else {
       // Unknown entity types — validate base fields via GenericEntityPassthroughSchema,
       // which preserves extra keys (causeEffectGraph, content, currentAssessment, etc.).
+      const rawRecord = raw as Record<string, unknown>;
+      const id = typeof rawRecord.id === "string" ? rawRecord.id : "<unknown>";
+      const type =
+        typeof rawRecord.entityType === "string"
+          ? rawRecord.entityType
+          : "<unknown>";
+
+      // Record the fall-through (QUA-953). Tracks every fall-through in prod
+      // so Phase 6 of QUA-943 can verify zero strict-fails before deleting
+      // GenericEntityPassthroughSchema.
+      stats.fallthroughCount += 1;
+      const bucket =
+        stats.byType[type] ?? (stats.byType[type] = { count: 0, samples: [] });
+      bucket.count += 1;
+      if (bucket.samples.length < SAMPLE_LIMIT) {
+        const firstIssue = result.error.issues[0];
+        const fieldPath = firstIssue?.path.join(".") ?? "";
+        const message = firstIssue?.message ?? "";
+        bucket.samples.push({ id, fieldPath, message });
+      }
+
       if (isDev) {
-        const id = (raw as Record<string, unknown>).id;
-        const type = (raw as Record<string, unknown>).entityType as string;
         console.warn(
           `[entity-validation] ${id} (${type}): ${result.error.issues.map(i => i.message).join(", ")}`
         );
@@ -539,13 +644,16 @@ export function getTypedEntities(): AnyEntity[] {
       const genericResult = GenericEntityPassthroughSchema.safeParse(raw);
       if (genericResult.success) {
         entities.push(genericResult.data as GenericEntity);
-      } else if (isDev) {
-        const id = (raw as Record<string, unknown>).id;
-        console.warn(`[entity-validation] ${id}: failed generic parse too — skipping`);
+      } else {
+        stats.hardFailCount += 1;
+        if (isDev) {
+          console.warn(`[entity-validation] ${id}: failed generic parse too — skipping`);
+        }
       }
     }
   }
 
+  _strictFailStats = stats;
   _typedEntities = entities;
   return _typedEntities;
 }


### PR DESCRIPTION
## Summary

Adds an in-memory counter inside `getTypedEntities()` (`apps/web/src/data/tablebase.ts`) that records every `TypedEntitySchema.safeParse` fall-through to `GenericEntityPassthroughSchema`, bucketed by `entityType` with up to 5 sample `(id, fieldPath, message)` triples per bucket. Hard-fails (where even the loose generic schema rejects) are tracked separately.

The counter is exposed via `GET /api/internal/strict-fail-stats`. The handler triggers entity population so the endpoint is meaningful even on a cold worker.

Required by Phase 0b of QUA-943 (parent epic). Phase 6 — deleting `GenericEntityPassthroughSchema` — is gated on this counter reading zero for 7 consecutive prod build cycles. Previously the fall-through was silent in prod (only dev-mode `console.warn`).

## Scope and semantics

- **Per-process, per-build-cycle.** Stats populate on the first call to `getTypedEntities()` and stay stable thereafter (the function is memoized). Each Next.js build → fresh process → fresh stats — exactly the cadence Phase 6 needs.
- **Not aggregated across workers.** A multi-worker deploy yields one snapshot per worker; readers should see identical values across workers because `database.json` is identical.
- **Public-by-default.** The exposed data (entity IDs, schema field paths, Zod messages) is derived from publicly-available `database.json` content and the open-source schema, matching the convention of other Next.js API routes in this app.

## Key changes

- `apps/web/src/data/tablebase.ts` — `StrictFailStats` interface, `_strictFailStats` module state, `getStrictFailStats()` (deep-copy via `structuredClone`), counter wiring inside `getTypedEntities()`, test-only reset hook with `NODE_ENV` guard.
- `apps/web/src/app/api/internal/strict-fail-stats/route.ts` — GET handler, returns 503 with generic message on entity-load error (no stack trace leak).
- `apps/web/src/data/__tests__/strict-fail-stats.test.ts` — 8 tests covering: empty initial state, zero fall-throughs, bucketing by entityType, field-path/message capture, sample cap (5 per type), deep-copy semantics, hard-fail counting, and the production guard on the test-only reset.

## Test plan

- [x] `pnpm vitest run src/data/__tests__/strict-fail-stats.test.ts` — 8 tests pass
- [x] `pnpm vitest run src/data/__tests__/` — 111 data tests pass (no regressions)
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm build` — succeeds; new route shows up at `/api/internal/strict-fail-stats`
- [x] `pnpm crux w validate gate --fix` — 66/66 gate checks pass (1 advisory: orphan entity detection, pre-existing)
- [x] Live API smoke test: `curl http://localhost:3021/api/internal/strict-fail-stats` returns the stats object (current prod build: 0 fall-throughs across 2063 entities)

## Review

- `/agent-review-pr` ran with hostile-reviewer subagent + narrow-patch detector. 14 findings; 6 fixed (deep-copy fix, test-env guard, 503 envelope, idiom cleanup, doc clarification, stronger hard-fail test), 5 documented as not-applicable, 3 dismissed.
- `/simplify` ran. 8 cleanups applied: `structuredClone`, drop redundant `populated` field (use `populatedAt: null` as the unpopulated signal), `makeEmptyStats()` factory, `STRICT_FAIL_UNKNOWN_LABEL` constant, single-expression `??=`, early-continue on success-parse path, trim WHAT-comments, `loadFreshTablebase()` test helper.

Closes QUA-953
