### PR TITLE
QUA-951: Add structured-body overload to validationError

### DIFF
--- a/apps/wiki-server/src/__tests__/validation-error.test.ts
+++ b/apps/wiki-server/src/__tests__/validation-error.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { validationError, type ValidationErrorBody } from "../routes/shared/utils.js";
+
+/**
+ * QUA-951: validationError now exposes two overloads — a legacy string form
+ * and a structured-body form. Both must produce a 400 with the same
+ * `error: "validation_error"` envelope; the structured form carries an
+ * additional `code` discriminator plus optional context fields so canary
+ * dual-write callers can branch on `code` instead of pattern-matching the
+ * message string.
+ */
+
+describe("validationError", () => {
+  it("string overload returns 400 with the legacy envelope", async () => {
+    const app = new Hono().get("/x", (c) => validationError(c, "bad input"));
+    const res = await app.request("/x");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "validation_error",
+      message: "bad input",
+    });
+  });
+
+  it("body overload returns 400 with the structured envelope", async () => {
+    const app = new Hono().get("/x", (c) =>
+      validationError(c, {
+        code: "fk_missing",
+        message: "entity not found",
+        field: "personId",
+        value: "sid_unknown",
+      })
+    );
+    const res = await app.request("/x");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "validation_error",
+      code: "fk_missing",
+      message: "entity not found",
+      field: "personId",
+      value: "sid_unknown",
+    });
+  });
+
+  it("body overload omits unset optional fields", async () => {
+    const app = new Hono().get("/x", (c) =>
+      validationError(c, { code: "zod", message: "schema failed" })
+    );
+    const res = await app.request("/x");
+    const body = await res.json();
+
+    expect(body).toEqual({
+      error: "validation_error",
+      code: "zod",
+      message: "schema failed",
+    });
+    expect(body).not.toHaveProperty("field");
+    expect(body).not.toHaveProperty("value");
+    expect(body).not.toHaveProperty("allowed");
+    expect(body).not.toHaveProperty("similar");
+  });
+
+  it("body overload carries allowed[] and similar[] when provided", async () => {
+    const app = new Hono().get("/x", (c) =>
+      validationError(c, {
+        code: "enum_violation",
+        message: "invalid status",
+        field: "status",
+        value: "actiev",
+        allowed: ["active", "pending", "archived"],
+        similar: ["active"],
+      })
+    );
+    const res = await app.request("/x");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "validation_error",
+      code: "enum_violation",
+      message: "invalid status",
+      field: "status",
+      value: "actiev",
+      allowed: ["active", "pending", "archived"],
+      similar: ["active"],
+    });
+  });
+
+  it("both overloads produce the same envelope shape and status (additive contract)", async () => {
+    const stringApp = new Hono().get("/x", (c) =>
+      validationError(c, "natural key collision")
+    );
+    const bodyApp = new Hono().get("/x", (c) =>
+      validationError(c, {
+        code: "natural_key",
+        message: "natural key collision",
+      })
+    );
+
+    const stringRes = await stringApp.request("/x");
+    const bodyRes = await bodyApp.request("/x");
+
+    expect(stringRes.status).toBe(bodyRes.status);
+    expect(stringRes.status).toBe(400);
+
+    const stringBody = await stringRes.json();
+    const bodyBody = await bodyRes.json();
+
+    expect(stringBody.error).toBe("validation_error");
+    expect(bodyBody.error).toBe("validation_error");
+    expect(stringBody.message).toBe(bodyBody.message);
+  });
+
+  it("body overload accepts open-ended code strings (forward compat)", async () => {
+    const future: ValidationErrorBody = {
+      code: "some_future_code",
+      message: "future shape",
+    };
+    const app = new Hono().get("/x", (c) => validationError(c, future));
+    const res = await app.request("/x");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "validation_error",
+      code: "some_future_code",
+      message: "future shape",
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/validation-error.test.ts
+++ b/apps/wiki-server/src/__tests__/validation-error.test.ts
@@ -127,4 +127,25 @@ describe("validationError", () => {
       message: "future shape",
     });
   });
+
+  it("body overload cannot clobber the error envelope discriminator", async () => {
+    // The interface doesn't list `error`, but excess-property checks only
+    // fire on object literals — a value cast through `as any` (or arriving
+    // from a wider source like a generic helper) could carry an `error` key.
+    // The implementation must spread first and write the literal last.
+    const evil = {
+      code: "fk_missing",
+      message: "y",
+      error: "not_validation_error",
+    } as unknown as ValidationErrorBody;
+    const app = new Hono().get("/x", (c) => validationError(c, evil));
+    const res = await app.request("/x");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "validation_error",
+      code: "fk_missing",
+      message: "y",
+    });
+  });
 });

--- a/apps/wiki-server/src/routes/shared/utils.test-d.ts
+++ b/apps/wiki-server/src/routes/shared/utils.test-d.ts
@@ -1,0 +1,77 @@
+/**
+ * Type-level test for the `validationError` overload (QUA-951).
+ *
+ * The overload's stated purpose is to preserve Hono RPC inference. The string
+ * overload should expose its 400 body as `{ error: "validation_error";
+ * message: string }`, and the structured overload should expose
+ * `{ error: "validation_error" } & ValidationErrorBody` (with
+ * `JSONParsed<...>` applied by Hono).
+ *
+ * If a future refactor (e.g. swapping the overloads back to a bare `Response`
+ * return type) breaks RPC inference, this file should fail to compile —
+ * surfacing the regression at PR-time instead of silently degrading
+ * `InferResponseType<...>` for every consumer of `api-response-types.ts`.
+ *
+ * Run via: `pnpm tsc --noEmit -p apps/wiki-server/tsconfig.json`
+ */
+
+import { Hono } from "hono";
+import type { InferResponseType } from "hono/client";
+import { hc } from "hono/client";
+import { validationError } from "./utils.js";
+
+// ---------------------------------------------------------------------------
+// String-overload route
+// ---------------------------------------------------------------------------
+
+const stringApp = new Hono().get("/x", (c) =>
+  validationError(c, "bad input"),
+);
+
+type StringRpc = ReturnType<typeof hc<typeof stringApp>>;
+type StringErr = InferResponseType<StringRpc["x"]["$get"], 400>;
+
+// String overload's 400 body must expose `error` and `message` fields.
+// If the return type ever degrades to bare `Response`, both assignments fail.
+const _stringErr: { error: "validation_error"; message: string } =
+  null as unknown as StringErr; // as-any-ok: type-level RPC inference assertion
+const _stringErrReverse: StringErr = {
+  error: "validation_error",
+  message: "x",
+};
+
+// ---------------------------------------------------------------------------
+// Structured-body-overload route
+// ---------------------------------------------------------------------------
+
+const bodyApp = new Hono().get("/x", (c) =>
+  validationError(c, {
+    code: "fk_missing",
+    message: "missing",
+    field: "personId",
+    value: "sid_unknown",
+  }),
+);
+
+type BodyRpc = ReturnType<typeof hc<typeof bodyApp>>;
+type BodyErr = InferResponseType<BodyRpc["x"]["$get"], 400>;
+
+// Structured-body-overload's 400 body exposes the documented optional fields.
+// `JSONParsed<...>` widens `value?: unknown` to a JSON-compatible shape, so
+// we pin only the keys we care about and let Hono's parser widen the rest.
+const _bodyErr: BodyErr = {
+  error: "validation_error",
+  code: "fk_missing",
+  message: "missing",
+  field: "personId",
+  value: "sid_unknown",
+};
+
+// `code` must be present in the inferred shape — if it ever vanishes the
+// canary dual-write callers lose their structural discriminator.
+type CodePresent = "code" extends keyof BodyErr ? true : false;
+const _codePresent: CodePresent = true;
+
+// `error` must be the literal `"validation_error"`, not widened to `string`.
+type ErrorIsLiteral = BodyErr["error"] extends "validation_error" ? true : false;
+const _errorIsLiteral: ErrorIsLiteral = true;

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -109,8 +109,15 @@ export type ValidationErrorCode =
  * canary dual-write callers that need to distinguish 400-class causes
  * structurally rather than by string-matching the message field.
  *
- * The function adds the literal `error: "validation_error"` envelope; callers
- * supply the discriminator (`code`) plus optional context fields.
+ * The function adds the literal `error: "validation_error"` envelope last so a
+ * caller cannot clobber the discriminator; callers supply `code` plus optional
+ * context fields.
+ *
+ * `value` and `allowed[]` / `similar[]` must be JSON-safe — `c.json()` calls
+ * `JSON.stringify` under the hood, so passing `BigInt`, `Symbol`, functions,
+ * or circular references will surface as a 500 from the error handler rather
+ * than the intended 400. Stringify or coerce server-side before passing them
+ * here.
  */
 export interface ValidationErrorBody {
   code: ValidationErrorCode;
@@ -169,7 +176,7 @@ export function validationError(
   if (typeof arg === "string") {
     return c.json({ error: VALIDATION_ERROR, message: arg }, 400);
   }
-  return c.json({ error: VALIDATION_ERROR, ...arg }, 400);
+  return c.json({ ...arg, error: VALIDATION_ERROR }, 400);
 }
 
 /** Return a 400 invalid JSON error response. */

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -1,4 +1,4 @@
-import type { Context } from "hono";
+import type { Context, TypedResponse } from "hono";
 import { validator } from "hono/validator";
 import { z } from "zod";
 import { logger as rootLogger } from "../../logger.js";
@@ -92,6 +92,35 @@ export function applyTruncation<T>(
 export const VALIDATION_ERROR = "validation_error" as const;
 export const INVALID_JSON_ERROR = "invalid_json" as const;
 
+/**
+ * Documented machine-readable codes for the structured `validationError` body.
+ * Open-ended: the `string & {}` branch keeps autocomplete on documented codes
+ * while still accepting future codes without forcing a type-system change.
+ */
+export type ValidationErrorCode =
+  | "zod"
+  | "fk_missing"
+  | "natural_key"
+  | "enum_violation"
+  | (string & {});
+
+/**
+ * Structured body shape for the `validationError` overload. Used by Phase 2
+ * canary dual-write callers that need to distinguish 400-class causes
+ * structurally rather than by string-matching the message field.
+ *
+ * The function adds the literal `error: "validation_error"` envelope; callers
+ * supply the discriminator (`code`) plus optional context fields.
+ */
+export interface ValidationErrorBody {
+  code: ValidationErrorCode;
+  message: string;
+  field?: string;
+  value?: unknown;
+  allowed?: unknown[];
+  similar?: unknown[];
+}
+
 /** Safely parse JSON body, returning null on parse failure. */
 export function parseJsonBody(c: Context) {
   return c.req.json().catch((e: unknown) => {
@@ -103,9 +132,44 @@ export function parseJsonBody(c: Context) {
   });
 }
 
-/** Return a 400 validation error response. */
-export function validationError(c: Context, message: string) {
-  return c.json({ error: VALIDATION_ERROR, message }, 400);
+/**
+ * Return a 400 validation error response.
+ *
+ * Two overloads:
+ *   validationError(c, "message")    → { error: "validation_error", message }
+ *   validationError(c, { code, message, field?, value?, allowed?, similar? })
+ *     → { error: "validation_error", code, message, field?, value?, allowed?, similar? }
+ *
+ * The structured form is additive: existing string callers are unchanged.
+ * Phase 2 canary callers should pass the structured body so consumers can
+ * branch on `code` instead of pattern-matching `message`.
+ */
+export function validationError(
+  c: Context,
+  message: string
+): Response &
+  TypedResponse<
+    { error: typeof VALIDATION_ERROR; message: string },
+    400,
+    "json"
+  >;
+export function validationError(
+  c: Context,
+  body: ValidationErrorBody
+): Response &
+  TypedResponse<
+    { error: typeof VALIDATION_ERROR } & ValidationErrorBody,
+    400,
+    "json"
+  >;
+export function validationError(
+  c: Context,
+  arg: string | ValidationErrorBody
+): Response {
+  if (typeof arg === "string") {
+    return c.json({ error: VALIDATION_ERROR, message: arg }, 400);
+  }
+  return c.json({ error: VALIDATION_ERROR, ...arg }, 400);
 }
 
 /** Return a 400 invalid JSON error response. */


### PR DESCRIPTION
## Summary

Adds an additive overload to `apps/wiki-server/src/routes/shared/utils.ts::validationError`:

```ts
validationError(c, "msg")                       // legacy — unchanged
validationError(c, { code, message, field?, value?, allowed?, similar? })
```

The structured form lets Phase 2 canary dual-write callers (QUA-943) branch on a `code` discriminator instead of pattern-matching the message string. Both overloads emit a 400 with `{ error: "validation_error", ... }` so existing consumers see no change.

All 158 existing string callsites compile and behave identically (the spec said 159 — drift of 1 since the ticket was filed).

## Implementation notes

- **Return type uses `Response & TypedResponse<{...}, 400, "json">`, not bare `Response`.** The Linear spec illustrated `: Response` annotations on the overloads, but using the bare global `Response` widened Hono's RPC inference and `InferResponseType<...>` collapsed to `{}` (9 errors in `api-response-types.ts`). The precise `TypedResponse` form matches what `c.json()` returns and preserves inference for every consumer.
- **`ValidationErrorCode` uses `"zod" | "fk_missing" | "natural_key" | "enum_violation" | (string & {})`** to keep editor autocomplete on documented codes while accepting future codes without forcing a type-system change.
- **Spread-overwrite hardening (caught in review).** The first impl was `{ error: VALIDATION_ERROR, ...arg }`, which let a caller passing `arg.error` (via `as any` / generic plumbing) clobber the envelope. Swapped to `{ ...arg, error: VALIDATION_ERROR }` so the literal always wins. Regression test included.
- **JSON-safety documented.** `value` / `allowed[]` / `similar[]` are typed `unknown` per the spec, but `c.json()` calls `JSON.stringify`, which throws on `BigInt` and silently strips `Symbol` / functions. The JSDoc on `ValidationErrorBody` calls this out so callers know to coerce server-side.
- **Did not migrate any callsites or touch `zv()`.** The Linear ticket explicitly scopes that to QUA-943 Phase 0a-ii.

## Test plan

- [x] `npx tsc --noEmit` clean (incl. new `utils.test-d.ts` asserting RPC inference shape)
- [x] `pnpm crux w validate gate --fix` — 69/69 passed
- [x] 7 runtime tests in `apps/wiki-server/src/__tests__/validation-error.test.ts`:
  - String overload returns legacy envelope
  - Body overload returns structured envelope with all fields
  - Body overload omits unset optional fields
  - `allowed[]` and `similar[]` carried through
  - Both overloads share the same 400/error-literal
  - Body overload accepts open-ended (forward-compat) `code` strings
  - Body overload **cannot** clobber the `error` envelope discriminator (regression for the spread fix)
- [x] Type-level `.test-d.ts` pinning that `InferResponseType<route, 400>` keeps `error: "validation_error"` as a literal (not widened) and `code` in the body shape
- [x] All 158 existing string callsites compile (verified by full wiki-server tsc)
- [x] Hostile-reviewer subagent: 6 findings — 1 HIGH fixed, 2 MEDIUM addressed, 1 LOW addressed via `.test-d.ts`, 2 LOW dismissed as design tradeoffs

Closes QUA-951
