### PR TITLE
feat(qua-950): structural phase tracker for /agent-review-pr

### DIFF
--- a/.claude/commands/agent-end.md
+++ b/.claude/commands/agent-end.md
@@ -124,6 +124,7 @@ Remove untracked session artifacts and discard any unstaged changes (modified ho
 ```bash
 rm -f .claude/wip-checklist.md .claude/wip-context.md
 git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/review-phases-done 2>/dev/null || rm -f .claude/review-phases-done
 git checkout -- .claude/simplify-done 2>/dev/null || rm -f .claude/simplify-done
 git checkout -- .claude/hooks/ 2>/dev/null || true
 ```

--- a/.claude/commands/agent-review-pr.md
+++ b/.claude/commands/agent-review-pr.md
@@ -17,6 +17,14 @@ This skill triages the current branch's changes, builds a verification plan from
 
 **Prerequisite:** Verify the agent checklist exists (`.claude/wip-checklist.md`). If not, run `pnpm crux sys agent-checklist init "PR review" --type=infrastructure` before proceeding.
 
+**Initialize the phase tracker** (QUA-950 — required for the marker write at Step 7):
+
+```bash
+pnpm crux sys review-phase init
+```
+
+This wipes any prior tracker and anchors a new one to the current `HEAD` + diff hash. Every phase below records to `.claude/review-phases-done`; `crux sys review-phase write-marker` refuses to write the review marker until every required phase has either an execution timestamp or an explicit `reason=...` skip.
+
 Run these commands to understand what changed:
 
 ```bash
@@ -67,6 +75,12 @@ Select steps from the menu below. **The default is to INCLUDE a step** — only 
 ```
 
 Mark steps with `✓` (will execute) or `—` (skipping, with reason). For Phase 2a and 2d carve-outs, the reason must reference the diff property that triggered the skip (specific paths in scope, or a verified pre-push gate cache hit), not free-form text. Then execute them in order.
+
+After printing the plan, record Phase 1 completion:
+
+```bash
+pnpm crux sys review-phase record phase-1-triage
+```
 
 ---
 
@@ -138,6 +152,12 @@ If the cache hit is invalid (different SHA, missing file, file corrupted), fall 
 
 When recording the skip, the predicate must reference the cache (e.g. `Phase 2d — N/A: pre-push gate cache hit on $HEAD_SHA`).
 
+After all four 2x checks pass (or are documented as carved-out), record completion:
+
+```bash
+pnpm crux sys review-phase record phase-2-mechanical
+```
+
 ---
 
 ## Phase 3: Diff review (subagent) — ≥30 lines changed
@@ -153,6 +173,12 @@ npx tsx crux/pr-review/detect-narrow-patch.ts
 The detector fires at MEDIUM severity when the diff adds a conditional that *both* gates on a literal column name (`columnName === "..."`, `field.name === "..."`, etc.) *and* probes the value's signature (`.startsWith(`, `.test(`, `.match(`, `.includes(`). Pure formatting transforms (`toFixed`, `Intl.NumberFormat`, `formatCurrency`) are not flagged.
 
 **Action on a hit:** before proceeding with the rest of the review, ask explicitly whether the fix could be content-based (match the value's shape regardless of column) instead of column-name-gated. A content-based fix prevents the recurring per-column patch loop. If you confirm the column-gated version is correct (e.g. the column name genuinely carries meaning beyond the value's shape), document the reasoning in the PR body — otherwise rewrite it before shipping. See `.claude/rules/proactive-github-filing.md` § "N+ related symptoms in a narrow window" for the broader rule.
+
+After running the detector and acting on any hits, record completion:
+
+```bash
+pnpm crux sys review-phase record phase-3a-narrow
+```
 
 ### 3b. Hostile reviewer subagent
 
@@ -198,6 +224,14 @@ Provide it with the full diff (`git diff main...HEAD`) and this prompt:
 
 If the subagent fails (API error, timeout, disconnect), retry once with a chunked diff. If retry also fails, run the same prompt inline in your own context as a fallback — the inline review is weaker than a fresh subagent, but it catches the round-up-to-done loophole where a failed 3b is treated as completed.
 
+After the subagent (or fallback) runs AND any HIGH/CRITICAL fixes are applied, record completion:
+
+```bash
+pnpm crux sys review-phase record phase-3b-hostile
+# OR if the diff is below the 30-line threshold:
+pnpm crux sys review-phase record phase-3b-hostile --reason="N/A: diff under 30 lines"
+```
+
 ---
 
 ## Phase 4: Red-team — ≥100 lines changed, or security/API/data changes
@@ -240,6 +274,14 @@ If the red-team phase finds a bug:
 1. Write a failing test that reproduces it
 2. Fix the bug
 3. Verify the test passes
+
+After threat modeling + execution + any bug fixes, record completion:
+
+```bash
+pnpm crux sys review-phase record phase-4-redteam
+# OR for content-only or trivial diffs that don't meet the trigger:
+pnpm crux sys review-phase record phase-4-redteam --reason="N/A: <100 lines and no security/API/data changes"
+```
 
 ---
 
@@ -319,6 +361,14 @@ If a wiki-server route was modified:
 3. **Config changes**: Verify env vars are documented, defaults are sensible, and no secrets are hardcoded.
 4. **Docker**: Verify the image builds locally if feasible.
 
+After running the sub-categories that apply (5a-5e), record completion. Phase 5 covers all five sub-categories under one record line:
+
+```bash
+pnpm crux sys review-phase record phase-5-category
+# OR if no sub-category triggered:
+pnpm crux sys review-phase record phase-5-category --reason="N/A: no UI/API/CLI/data/infra files in diff"
+```
+
 ---
 
 ## Phase 6: Final verification
@@ -332,6 +382,12 @@ pnpm crux w validate gate --fix
 ```
 
 All three must pass. If no changes were made during review, this phase is redundant with Phase 2 — **skip it**, do not run defensively. Re-running tests on an unchanged tree feels safe but burns context for zero new signal.
+
+Then record completion (this phase is non-skippable — even when no review changes shipped, recording it confirms you considered the question):
+
+```bash
+pnpm crux sys review-phase record phase-6-final
+```
 
 ---
 
@@ -351,12 +407,25 @@ If the review wrote tests, applied simplifications, or fixed bugs, **commit thos
 # Only if there are uncommitted changes from the review:
 git add -A && git commit -m "review: tests, simplifications, and fixes from /agent-review-pr"
 
-# Then write the marker against the final state:
-DIFF_HASH=$(git diff $(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)...HEAD | shasum -a 256 | cut -c1-12)
-echo "reviewed $(git rev-parse HEAD) $(date -u +%Y-%m-%dT%H:%M:%SZ) ${DIFF_HASH}" >| .claude/review-done
+# Validate phase coverage and write the marker in one step (QUA-950):
+pnpm crux sys review-phase write-marker
+```
+
+`crux sys review-phase write-marker` is the sanctioned path to write `.claude/review-done` for full reviews. It validates the phase tracker first and refuses (exit 2) when any of the 7 required phases is missing — each must have either an execution timestamp or an explicit `reason=...` skip.
+
+The marker file lives at a path the agent can also write directly (the auto-approve hook permits it for backwards-compat with `pr-patrol`'s lightweight-fix flow), so the gate is operationally enforced via this skill, not OS-level. If you bypass `write-marker` you also bypass the phase coverage check — don't do that for a real review. For `pr-patrol` lightweight fixes that don't run the full review, pass `--force --reason="patrol-fix: targeted change, full review unnecessary"` to record the bypass in the tracker.
+
+If you committed new changes after the last `record` call, the tracker's diff hash will no longer match HEAD and `write-marker` will refuse. Re-run any phases that need to repeat (typically just `phase-6-final`), then re-init if the diff has substantively changed:
+
+```bash
+pnpm crux sys review-phase init               # only if the diff itself changed
+pnpm crux sys review-phase record phase-6-final
+pnpm crux sys review-phase write-marker
 ```
 
 This file is gitignored. It persists for the life of the session and is read by `/agent-ship` to populate the `reviewed` field in the session log. Both the commit SHA and diff hash are verified — if new commits are added after review or the diff changes, the marker becomes stale.
+
+> **Why the structural enforcement exists.** Earlier reviews could declare "complete" after running phases 1-3 + 6-7, skipping phases 4-5 silently. The hostile reviewer subagent's findings looked thorough enough to anchor the perceived rigor of the whole review, but each phase actually catches a different class of issue — Phase 4 (red-team) found a path-traversal bug on QUA-936 that Phase 3b's passive review missed. The phase tracker turns "I ran the review" into a verifiable claim. See QUA-950 for the original incident write-up.
 
 ---
 

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -131,16 +131,18 @@ Check if a PR exists using `pnpm crux gh pr detect` and update it with: summary,
 
 ### Step 4a: Surface skipped review phases (QUA-950)
 
-If `/agent-review-pr` ran with any phases skipped via `reason=...`, surface that in the PR body so reviewers can see the coverage trail without trusting the agent's summary alone:
+If `/agent-review-pr` ran with any phases skipped via `reason=...`, surface that in the PR body so reviewers can see the coverage trail without trusting the agent's summary alone.
+
+`pnpm` prepends a multi-line prelude (`> longterm-wiki@...\n> DOTENV_CONFIG_QUIET=...`) to its child's stdout, which corrupts the snippet if you capture pnpm's output directly. Use `pnpm --silent` to suppress the prelude (or invoke `node` directly):
 
 ```bash
-SKIPPED=$(pnpm crux sys review-phase summary 2>/dev/null)
+SKIPPED=$(pnpm --silent crux sys review-phase summary 2>/dev/null | sed '/^$/d')
 if [ -n "$SKIPPED" ]; then
   printf '\n## Review Phases Skipped\n\n%s\n\nFull tracker: `.claude/review-phases-done` (gitignored, session-local).\n' "$SKIPPED"
 fi
 ```
 
-If the output is empty (every phase executed), no section is added. The `crux gh pr create` body editor accepts the snippet as a Markdown block — append it to the PR body alongside the test plan.
+When every phase executed, `summary` outputs nothing and the section is omitted. Append the printed block to the PR body alongside the test plan.
 
 ## Step 4b: Deploy task detection and injection (MANDATORY)
 

--- a/.claude/commands/agent-ship.md
+++ b/.claude/commands/agent-ship.md
@@ -129,6 +129,19 @@ Pay special attention to:
 
 Check if a PR exists using `pnpm crux gh pr detect` and update it with: summary, key changes, test plan, issue references. If no PR exists yet, `/agent-push-and-verify` will create one using `crux gh pr create`.
 
+### Step 4a: Surface skipped review phases (QUA-950)
+
+If `/agent-review-pr` ran with any phases skipped via `reason=...`, surface that in the PR body so reviewers can see the coverage trail without trusting the agent's summary alone:
+
+```bash
+SKIPPED=$(pnpm crux sys review-phase summary 2>/dev/null)
+if [ -n "$SKIPPED" ]; then
+  printf '\n## Review Phases Skipped\n\n%s\n\nFull tracker: `.claude/review-phases-done` (gitignored, session-local).\n' "$SKIPPED"
+fi
+```
+
+If the output is empty (every phase executed), no section is added. The `crux gh pr create` body editor accepts the snippet as a Markdown block — append it to the PR body alongside the test plan.
+
 ## Step 4b: Deploy task detection and injection (MANDATORY)
 
 Run the deploy task detector to check if this PR has post-deploy requirements:
@@ -245,6 +258,7 @@ Then clean up session artifacts and discard any unstaged changes (modified hooks
 ```bash
 rm -f .claude/wip-checklist.md .claude/wip-context.md
 git checkout -- .claude/review-done 2>/dev/null || rm -f .claude/review-done
+git checkout -- .claude/review-phases-done 2>/dev/null || rm -f .claude/review-phases-done
 git checkout -- .claude/simplify-done 2>/dev/null || rm -f .claude/simplify-done
 git checkout -- .claude/hooks/ 2>/dev/null || true
 ```

--- a/.claude/hooks/approve-claude-configs.sh
+++ b/.claude/hooks/approve-claude-configs.sh
@@ -27,7 +27,7 @@
 #   Session state (gitignored or agent-managed):
 #     sessions/, memory/, snapshots/, plans/, reviews/
 #     wip-checklist.md, wip-context.md
-#     review-done, simplify-done
+#     review-done, review-phases-done, simplify-done
 #     active-branch, session.pid, session-log.md
 #     maintain-last-run.txt, issue-creates.json
 #
@@ -52,7 +52,7 @@ if [[ "$FILE_PATH" =~ \.claude/(commands|agents|skills|sessions|memory|snapshots
 fi
 
 # Top-level session-state files inside .claude/ (no subdirectory).
-if [[ "$FILE_PATH" =~ \.claude/(wip-checklist\.md|wip-context\.md|review-done|simplify-done|active-branch|session\.pid|session-log\.md|maintain-last-run\.txt|issue-creates\.json)$ ]]; then
+if [[ "$FILE_PATH" =~ \.claude/(wip-checklist\.md|wip-context\.md|review-done|review-phases-done|simplify-done|active-branch|session\.pid|session-log\.md|maintain-last-run\.txt|issue-creates\.json)$ ]]; then
   echo '{"decision":"approve","reason":"auto-approved: .claude session state"}'
   exit 0
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ crux/coverage/
 .claude/session.pid
 .claude/last-heartbeat
 .claude/review-done
+.claude/review-phases-done
 .claude/simplify-done
 .claude/worktree-cleanup.log
 .claude/worktrees/

--- a/crux/commands/agent-reset.ts
+++ b/crux/commands/agent-reset.ts
@@ -365,6 +365,16 @@ function scanCleanupItems(): CleanupItem[] {
     });
   }
 
+  // Stale review-phase tracker (QUA-950)
+  const reviewPhasesDonePath = join(process.cwd(), '.claude', 'review-phases-done');
+  if (existsSync(reviewPhasesDonePath)) {
+    items.push({
+      category: 'checklist',
+      description: 'Stale review-phase tracker (.claude/review-phases-done)',
+      detail: reviewPhasesDonePath,
+    });
+  }
+
   // Stale context file
   const contextPath = join(process.cwd(), '.claude', 'wip-context.md');
   if (existsSync(contextPath)) {

--- a/crux/commands/review-phase.ts
+++ b/crux/commands/review-phase.ts
@@ -1,0 +1,340 @@
+/**
+ * Review Phase Tracker Commands — structural enforcement for /agent-review-pr.
+ *
+ * Records phase execution to `.claude/review-phases-done` so the marker write
+ * (`.claude/review-done`) can be gated on full coverage. Each phase appends a
+ * line; `validate` checks completeness; `write-marker` is the only path that
+ * should write the review marker (replacing the inline `echo > .claude/review-done`
+ * pattern that the agent could bypass).
+ *
+ * See QUA-950 and `.claude/commands/agent-review-pr.md`.
+ */
+
+import { existsSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { createLogger } from '../lib/output.ts';
+import { PROJECT_ROOT } from '../lib/content-types.ts';
+import type { CommandOptions as BaseOptions, CommandResult } from '../lib/command-types.ts';
+import {
+  PHASE_IDS,
+  TRACKER_PATH,
+  type PhaseId,
+  initTracker,
+  recordPhase,
+  validateTracker,
+  readTracker,
+  summarizeSkipped,
+  computeDiffHash,
+  getHeadSha,
+} from '../lib/review-phase-tracker.ts';
+
+const MARKER_PATH = join(PROJECT_ROOT, '.claude/review-done');
+
+interface CommandOptions extends BaseOptions {
+  ci?: boolean;
+  reason?: string;
+  json?: boolean;
+  force?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+async function init(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  let meta;
+  try {
+    meta = initTracker();
+  } catch (err) {
+    return {
+      output: `${c.red}✗ Failed to initialize tracker: ${(err as Error).message}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  if (options.json) {
+    return { output: JSON.stringify({ ok: true, ...meta }) + '\n', exitCode: 0 };
+  }
+
+  return {
+    output:
+      `${c.green}✓${c.reset} Review phase tracker initialized\n` +
+      `  ${c.dim}File:${c.reset}      ${TRACKER_PATH}\n` +
+      `  ${c.dim}Commit:${c.reset}    ${meta.commitSha.slice(0, 12)}\n` +
+      `  ${c.dim}Diff hash:${c.reset} ${meta.diffHash}\n` +
+      `  ${c.dim}Required phases:${c.reset} ${PHASE_IDS.length}\n` +
+      `\n  Use \`crux sys review-phase record <phase-id>\` after each phase.\n`,
+    exitCode: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// record
+// ---------------------------------------------------------------------------
+
+async function record(args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  const phaseId = args.find((a) => !a.startsWith('--'));
+  if (!phaseId) {
+    return {
+      output:
+        `${c.red}Usage: crux sys review-phase record <phase-id> [--reason="..."]${c.reset}\n\n` +
+        `Valid phase IDs:\n  ${PHASE_IDS.join('\n  ')}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const result = recordPhase(phaseId, { reason: options.reason });
+  if (!result.ok) {
+    return {
+      output: `${c.red}✗ ${result.error}${c.reset}\n`,
+      exitCode: 1,
+    };
+  }
+
+  if (options.json) {
+    return { output: JSON.stringify({ ok: true, entry: result.entry }) + '\n', exitCode: 0 };
+  }
+
+  const reasonText = result.entry?.reason ? ` ${c.dim}(reason: ${result.entry.reason})${c.reset}` : '';
+  return {
+    output: `${c.green}✓${c.reset} Recorded ${c.cyan}${phaseId}${c.reset}${reasonText}\n`,
+    exitCode: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validate
+// ---------------------------------------------------------------------------
+
+async function validate(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  if (!existsSync(TRACKER_PATH)) {
+    const msg =
+      `${c.red}✗ Review phase tracker missing.${c.reset}\n` +
+      `  Run \`crux sys review-phase init\` at the start of /agent-review-pr.\n`;
+    if (options.json) {
+      return { output: JSON.stringify({ ok: false, missing: PHASE_IDS, error: 'tracker missing' }) + '\n', exitCode: 2 };
+    }
+    return { output: msg, exitCode: 2 };
+  }
+
+  const result = validateTracker();
+
+  if (options.json) {
+    return {
+      output:
+        JSON.stringify({
+          ok: result.ok,
+          missing: result.missing,
+          inSync: result.inSync,
+          init: result.init,
+          entries: result.entries,
+        }) + '\n',
+      exitCode: result.ok ? 0 : 2,
+    };
+  }
+
+  const lines: string[] = [];
+  for (const id of PHASE_IDS) {
+    const entry = result.entries[id];
+    if (entry?.reason) {
+      lines.push(`  ${c.yellow}~${c.reset} ${id} ${c.dim}(${entry.timestamp}, skipped: ${entry.reason})${c.reset}`);
+    } else if (entry) {
+      lines.push(`  ${c.green}✓${c.reset} ${id} ${c.dim}(${entry.timestamp})${c.reset}`);
+    } else {
+      lines.push(`  ${c.red}✗${c.reset} ${id} ${c.red}(missing)${c.reset}`);
+    }
+  }
+
+  let output = `${c.bold}Review Phase Coverage${c.reset}\n` + lines.join('\n') + '\n';
+
+  if (!result.inSync && result.init) {
+    output +=
+      `\n${c.yellow}⚠ Tracker is out of sync with current branch state.${c.reset}\n` +
+      `  ${c.dim}Tracker init:${c.reset} commit ${result.init.commitSha.slice(0, 12)}, diff ${result.init.diffHash}\n` +
+      `  ${c.dim}Current:${c.reset}      commit ${getHeadSha().slice(0, 12)}, diff ${computeDiffHash()}\n` +
+      `  Re-run \`crux sys review-phase init\` and re-record any phases that need to repeat.\n`;
+  }
+
+  if (!result.ok) {
+    output += `\n${c.red}✗ ${result.missing.length} phase(s) missing — review marker cannot be written.${c.reset}\n`;
+    return { output, exitCode: 2 };
+  }
+
+  output += `\n${c.green}✓ All ${PHASE_IDS.length} phases recorded.${c.reset}\n`;
+  return { output, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// list (alias of validate, but always exit 0 for read-only inspection)
+// ---------------------------------------------------------------------------
+
+async function list(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const result = await validate([], options);
+  return { output: result.output, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// summary — for PR body inclusion
+// ---------------------------------------------------------------------------
+
+async function summary(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const tracker = readTracker();
+  const skippedSummary = summarizeSkipped(tracker);
+
+  if (options.json) {
+    const validation = validateTracker(tracker);
+    return {
+      output:
+        JSON.stringify({
+          phases: PHASE_IDS.map((id) => ({
+            id,
+            executed: validation.entries[id] !== null && !validation.entries[id]?.reason,
+            skipped: validation.entries[id]?.reason ?? null,
+            timestamp: validation.entries[id]?.timestamp ?? null,
+          })),
+          allComplete: validation.ok,
+        }) + '\n',
+      exitCode: 0,
+    };
+  }
+
+  if (!skippedSummary) {
+    return { output: '', exitCode: 0 };
+  }
+  return { output: skippedSummary + '\n', exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// write-marker — the only sanctioned path to write .claude/review-done.
+// Validates phase coverage first; refuses on any missing phase unless --force.
+// ---------------------------------------------------------------------------
+
+async function writeMarker(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+
+  if (!existsSync(TRACKER_PATH)) {
+    return {
+      output:
+        `${c.red}✗ Cannot write review marker — phase tracker missing.${c.reset}\n` +
+        `  Run \`crux sys review-phase init\` then re-run /agent-review-pr from Phase 1.\n`,
+      exitCode: 2,
+    };
+  }
+
+  const result = validateTracker();
+
+  if (!result.ok && !options.force) {
+    const missing = result.missing.join(', ');
+    return {
+      output:
+        `${c.red}✗ Cannot write review marker — ${result.missing.length} phase(s) missing:${c.reset}\n` +
+        `  ${missing}\n\n` +
+        `  Each missing phase must be either executed (record without --reason)\n` +
+        `  or explicitly skipped (record --reason="why this phase doesn't apply").\n\n` +
+        `  Run \`crux sys review-phase validate\` for the full coverage table.\n`,
+      exitCode: 2,
+    };
+  }
+
+  if (!result.inSync && !options.force) {
+    return {
+      output:
+        `${c.red}✗ Cannot write review marker — tracker is out of sync with HEAD.${c.reset}\n` +
+        `  Either re-init and re-run any phases affected by the new commits,\n` +
+        `  or pass --force if you've reviewed the new diff and want to overwrite.\n`,
+      exitCode: 2,
+    };
+  }
+
+  const headSha = getHeadSha();
+  const diffHash = computeDiffHash();
+  const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const line = `reviewed ${headSha} ${timestamp} ${diffHash}\n`;
+  writeFileSync(MARKER_PATH, line, 'utf-8');
+
+  if (options.json) {
+    return {
+      output:
+        JSON.stringify({ ok: true, commitSha: headSha, diffHash, timestamp, marker: MARKER_PATH }) + '\n',
+      exitCode: 0,
+    };
+  }
+
+  const skippedSummary = summarizeSkipped();
+  let output = `${c.green}✓${c.reset} Review marker written at ${MARKER_PATH}\n`;
+  output += `  ${c.dim}Commit:${c.reset}    ${headSha.slice(0, 12)}\n`;
+  output += `  ${c.dim}Diff hash:${c.reset} ${diffHash}\n`;
+  if (skippedSummary) {
+    output += `\n  ${c.dim}Phases skipped:${c.reset}\n`;
+    for (const skipLine of skippedSummary.split('\n')) {
+      output += `  ${skipLine}\n`;
+    }
+  }
+  return { output, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// reset — wipe the tracker (for tests / manual recovery)
+// ---------------------------------------------------------------------------
+
+async function reset(_args: string[], options: CommandOptions): Promise<CommandResult> {
+  const log = createLogger(options.ci);
+  const c = log.colors;
+  if (existsSync(TRACKER_PATH)) {
+    unlinkSync(TRACKER_PATH);
+    return { output: `${c.green}✓${c.reset} Tracker removed: ${TRACKER_PATH}\n`, exitCode: 0 };
+  }
+  return { output: `${c.dim}Tracker not present — nothing to reset.${c.reset}\n`, exitCode: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Command registry
+// ---------------------------------------------------------------------------
+
+export const commands = {
+  default: validate,
+  init,
+  record,
+  validate,
+  list,
+  summary,
+  'write-marker': writeMarker,
+  reset,
+};
+
+export function getHelp(): string {
+  return `
+Review Phase Tracker — structural enforcement for /agent-review-pr phases
+
+Commands:
+  init                    Initialize tracker (Phase 1 of /agent-review-pr)
+  record <phase-id>       Record phase execution (default: validate)
+                          --reason="..."  mark phase as skipped with justification
+                          (rejected for phase-1-triage / phase-2-mechanical / phase-9-final)
+  validate                Check that every required phase has an entry (default)
+  list                    Same as validate but exits 0 (read-only inspection)
+  summary                 Print one-line skip summary for PR body
+  write-marker            Validate + write .claude/review-done atomically
+  reset                   Remove the tracker file
+
+Required phase IDs (10 total):
+  ${PHASE_IDS.join('\n  ')}
+
+Examples:
+  crux sys review-phase init
+  crux sys review-phase record phase-1-triage
+  crux sys review-phase record phase-7-ui --reason="N/A: no .tsx files changed"
+  crux sys review-phase validate
+  crux sys review-phase write-marker
+`;
+}

--- a/crux/commands/review-phase.ts
+++ b/crux/commands/review-phase.ts
@@ -10,7 +10,7 @@
  * See QUA-950 and `.claude/commands/agent-review-pr.md`.
  */
 
-import { existsSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, writeFileSync, unlinkSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { createLogger } from '../lib/output.ts';
 import { PROJECT_ROOT } from '../lib/content-types.ts';
@@ -79,8 +79,8 @@ async function record(args: string[], options: CommandOptions): Promise<CommandR
   const log = createLogger(options.ci);
   const c = log.colors;
 
-  const phaseId = args.find((a) => !a.startsWith('--'));
-  if (!phaseId) {
+  const positional = args.filter((a) => !a.startsWith('--'));
+  if (positional.length === 0) {
     return {
       output:
         `${c.red}Usage: crux sys review-phase record <phase-id> [--reason="..."]${c.reset}\n\n` +
@@ -88,6 +88,18 @@ async function record(args: string[], options: CommandOptions): Promise<CommandR
       exitCode: 1,
     };
   }
+  if (positional.length > 1) {
+    // Silently dropping extra positional args would let an agent type
+    // `record phase-1 phase-2` and only have phase-1 captured. Make it
+    // an explicit error so the second phase isn't lost.
+    return {
+      output:
+        `${c.red}record accepts exactly one phase ID, got ${positional.length}: ${positional.join(', ')}${c.reset}\n` +
+        `  Run \`crux sys review-phase record <id>\` once per phase.\n`,
+      exitCode: 1,
+    };
+  }
+  const phaseId = positional[0];
 
   const result = recordPhase(phaseId, { reason: options.reason });
   if (!result.ok) {
@@ -232,6 +244,31 @@ async function writeMarker(_args: string[], options: CommandOptions): Promise<Co
   }
 
   const result = validateTracker();
+  const reason = typeof options.reason === 'string' ? options.reason.trim() : '';
+
+  // The whole point of QUA-950 is that the marker write is gated on phase
+  // coverage. --force is the only escape hatch but must NOT be a silent
+  // bypass — same pattern as `pr.ts --skip-review-check`: require an
+  // explicit justification, log it loudly, and fail-loud if missing.
+  // Defended against by the hostile-reviewer pass before merge.
+  if (options.force) {
+    if (!reason) {
+      return {
+        output:
+          `${c.red}✗ --force requires --reason="<text>".${c.reset}\n` +
+          `  Bypassing phase coverage without a stated reason defeats the gate.\n` +
+          `  Acceptable reasons: "patrol-fix: targeted change, full review unnecessary",\n` +
+          `  "rebase: re-baselined diff, prior review still covers all changes", etc.\n`,
+        exitCode: 1,
+      };
+    }
+    if (/[\n\r]/.test(reason)) {
+      return {
+        output: `${c.red}✗ --reason must not contain newlines.${c.reset}\n`,
+        exitCode: 1,
+      };
+    }
+  }
 
   if (!result.ok && !options.force) {
     const missing = result.missing.join(', ');
@@ -251,21 +288,42 @@ async function writeMarker(_args: string[], options: CommandOptions): Promise<Co
       output:
         `${c.red}✗ Cannot write review marker — tracker is out of sync with HEAD.${c.reset}\n` +
         `  Either re-init and re-run any phases affected by the new commits,\n` +
-        `  or pass --force if you've reviewed the new diff and want to overwrite.\n`,
+        `  or pass --force --reason="..." if you've reviewed the new diff.\n`,
       exitCode: 2,
     };
   }
 
+  // Snapshot HEAD/diff-hash AFTER the validation check so the marker
+  // describes the same state validation just blessed. Avoids a TOCTOU
+  // window where a commit lands between validateTracker and writeFileSync.
   const headSha = getHeadSha();
   const diffHash = computeDiffHash();
   const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
   const line = `reviewed ${headSha} ${timestamp} ${diffHash}\n`;
   writeFileSync(MARKER_PATH, line, 'utf-8');
 
+  // Append a force-bypass audit line to the tracker so the bypass is
+  // visible in `crux sys review-phase validate` and via `summary --json`.
+  if (options.force) {
+    appendFileSync(
+      TRACKER_PATH,
+      `# force-bypass ${timestamp} reason=${reason}\n`,
+      'utf-8',
+    );
+  }
+
   if (options.json) {
     return {
       output:
-        JSON.stringify({ ok: true, commitSha: headSha, diffHash, timestamp, marker: MARKER_PATH }) + '\n',
+        JSON.stringify({
+          ok: true,
+          commitSha: headSha,
+          diffHash,
+          timestamp,
+          marker: MARKER_PATH,
+          forced: !!options.force,
+          reason: options.force ? reason : undefined,
+        }) + '\n',
       exitCode: 0,
     };
   }
@@ -274,6 +332,10 @@ async function writeMarker(_args: string[], options: CommandOptions): Promise<Co
   let output = `${c.green}✓${c.reset} Review marker written at ${MARKER_PATH}\n`;
   output += `  ${c.dim}Commit:${c.reset}    ${headSha.slice(0, 12)}\n`;
   output += `  ${c.dim}Diff hash:${c.reset} ${diffHash}\n`;
+  if (options.force) {
+    output += `\n  ${c.yellow}⚠ Forced past phase coverage check.${c.reset}\n`;
+    output += `  ${c.dim}Reason:${c.reset} ${reason}\n`;
+  }
   if (skippedSummary) {
     output += `\n  ${c.dim}Phases skipped:${c.reset}\n`;
     for (const skipLine of skippedSummary.split('\n')) {

--- a/crux/crux.mjs
+++ b/crux/crux.mjs
@@ -58,6 +58,7 @@ import * as citationsCommands from './commands/citations.ts';
 import * as grokipediaCommands from './commands/grokipedia.ts';
 import * as issuesCommands from './commands/issues.ts';
 import * as agentChecklistCommands from './commands/agent-checklist.ts';
+import * as reviewPhaseCommands from './commands/review-phase.ts';
 import * as entityCommands from './commands/entity.ts';
 import * as prCommands from './commands/pr.ts';
 import * as wikiServerCommands from './commands/wiki-server.ts';
@@ -163,6 +164,7 @@ const domains = {
   grokipedia: grokipediaCommands,
   issues: issuesCommands,
   'agent-checklist': agentChecklistCommands,
+  'review-phase': reviewPhaseCommands,
   entity: entityCommands,
   'entity-resources': entityResourcesCommands,
   pr: prCommands,

--- a/crux/lib/groups.ts
+++ b/crux/lib/groups.ts
@@ -131,6 +131,7 @@ export const GROUPS: Record<string, GroupDef> = {
       'agents',
       'agent-checklist',
       'agent-session-events',
+      'review-phase',
       'jobs',
       'sessions',
       'edit-log',

--- a/crux/lib/review-phase-tracker.test.ts
+++ b/crux/lib/review-phase-tracker.test.ts
@@ -217,6 +217,17 @@ describe('recordPhase', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toContain('newlines');
   });
+
+  it('rejects reasons longer than 500 chars', () => {
+    const result = recordPhase('phase-7-ui', { reason: 'x'.repeat(501) }, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('too long');
+  });
+
+  it('accepts reasons exactly at the 500-char cap', () => {
+    const result = recordPhase('phase-7-ui', { reason: 'x'.repeat(500) }, TMP_PATH);
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('initTracker', () => {

--- a/crux/lib/review-phase-tracker.test.ts
+++ b/crux/lib/review-phase-tracker.test.ts
@@ -199,6 +199,24 @@ describe('recordPhase', () => {
     const triageLines = fileContent.split('\n').filter((l) => l.startsWith('phase-1-triage'));
     expect(triageLines).toHaveLength(2);
   });
+
+  it('rejects newlines in reason (no forge-via-injection)', () => {
+    const forged = 'N/A: ok\nphase-9-final 2026-04-30T13:00:00Z';
+    const result = recordPhase('phase-7-ui', { reason: forged }, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('newlines');
+    // And nothing got appended to the file
+    const triageLines = readFileSync(TMP_PATH, 'utf-8')
+      .split('\n')
+      .filter((l) => l.startsWith('phase-9-final'));
+    expect(triageLines).toHaveLength(0);
+  });
+
+  it('rejects carriage returns in reason', () => {
+    const result = recordPhase('phase-7-ui', { reason: 'a\rb' }, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('newlines');
+  });
 });
 
 describe('initTracker', () => {

--- a/crux/lib/review-phase-tracker.test.ts
+++ b/crux/lib/review-phase-tracker.test.ts
@@ -40,7 +40,7 @@ describe('parseTracker', () => {
     const content =
       'init abcdef123456 deadbeef0000 2026-04-30T12:00:00Z\n' +
       'phase-1-triage 2026-04-30T12:01:00Z\n' +
-      'phase-7-ui 2026-04-30T12:02:00Z reason=N/A: no .tsx files\n';
+      'phase-5-category 2026-04-30T12:02:00Z reason=N/A: no .tsx files\n';
     const state = parseTracker(content);
     expect(state.init).toEqual({
       commitSha: 'abcdef123456',
@@ -54,7 +54,7 @@ describe('parseTracker', () => {
       reason: undefined,
     });
     expect(state.entries[1]).toEqual({
-      phaseId: 'phase-7-ui',
+      phaseId: 'phase-5-category',
       timestamp: '2026-04-30T12:02:00Z',
       reason: 'N/A: no .tsx files',
     });
@@ -104,21 +104,21 @@ describe('parseTracker', () => {
   it('preserves multi-word skip reasons including spaces and equals signs', () => {
     const content =
       'init aaa bbb 2026-04-30T12:00:00Z\n' +
-      'phase-7-ui 2026-04-30T12:02:00Z reason=N/A: x=1, y=2 (no .tsx)\n';
+      'phase-5-category 2026-04-30T12:02:00Z reason=N/A: x=1, y=2 (no .tsx)\n';
     const state = parseTracker(content);
     expect(state.entries[0].reason).toBe('N/A: x=1, y=2 (no .tsx)');
   });
 });
 
 describe('validateTracker', () => {
-  it('marks all 10 phases missing on a fresh init', () => {
+  it('marks all 7 phases missing on a fresh init', () => {
     initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
     const result = validateTracker(undefined, TMP_PATH);
     expect(result.ok).toBe(false);
-    expect(result.missing.length).toBe(10);
+    expect(result.missing.length).toBe(7);
   });
 
-  it('passes when all 10 phases have entries', () => {
+  it('passes when all 7 phases have entries', () => {
     initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
     for (const id of PHASE_IDS) {
       recordPhase(id, { timestamp: '2026-04-30T13:00:00Z' }, TMP_PATH);
@@ -140,12 +140,12 @@ describe('validateTracker', () => {
 
   it('takes the most recent entry per phase (idempotent re-records)', () => {
     initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
-    recordPhase('phase-4-simplify', { timestamp: '2026-04-30T12:01:00Z', reason: 'N/A: small diff' }, TMP_PATH);
+    recordPhase('phase-4-redteam', { timestamp: '2026-04-30T12:01:00Z', reason: 'N/A: small diff' }, TMP_PATH);
     // Operator changed mind — actually ran the phase
-    recordPhase('phase-4-simplify', { timestamp: '2026-04-30T12:30:00Z' }, TMP_PATH);
+    recordPhase('phase-4-redteam', { timestamp: '2026-04-30T12:30:00Z' }, TMP_PATH);
     const result = validateTracker(undefined, TMP_PATH);
-    expect(result.entries['phase-4-simplify']?.reason).toBeUndefined();
-    expect(result.entries['phase-4-simplify']?.timestamp).toBe('2026-04-30T12:30:00Z');
+    expect(result.entries['phase-4-redteam']?.reason).toBeUndefined();
+    expect(result.entries['phase-4-redteam']?.timestamp).toBe('2026-04-30T12:30:00Z');
   });
 
   it('returns ok=false when init is missing', () => {
@@ -168,7 +168,7 @@ describe('recordPhase', () => {
   });
 
   it('rejects skip-with-reason for non-skippable phases', () => {
-    for (const id of ['phase-1-triage', 'phase-2-mechanical', 'phase-9-final']) {
+    for (const id of ['phase-1-triage', 'phase-2-mechanical', 'phase-6-final']) {
       const result = recordPhase(id, { reason: 'trying to skip' }, TMP_PATH);
       expect(result.ok).toBe(false);
       expect(result.error).toContain('cannot be skipped');
@@ -176,8 +176,8 @@ describe('recordPhase', () => {
   });
 
   it('accepts skip-with-reason for skippable phases', () => {
-    const skippable = ['phase-3a-narrow', 'phase-3b-hostile', 'phase-4-simplify',
-                       'phase-5-coverage', 'phase-6-redteam', 'phase-7-ui', 'phase-8-api'];
+    const skippable = ['phase-3a-narrow', 'phase-3b-hostile', 'phase-4-redteam',
+                       'phase-5-category'];
     for (const id of skippable) {
       const result = recordPhase(id, { reason: `N/A: skip ${id}` }, TMP_PATH);
       expect(result.ok).toBe(true);
@@ -201,31 +201,31 @@ describe('recordPhase', () => {
   });
 
   it('rejects newlines in reason (no forge-via-injection)', () => {
-    const forged = 'N/A: ok\nphase-9-final 2026-04-30T13:00:00Z';
-    const result = recordPhase('phase-7-ui', { reason: forged }, TMP_PATH);
+    const forged = 'N/A: ok\nphase-6-final 2026-04-30T13:00:00Z';
+    const result = recordPhase('phase-5-category', { reason: forged }, TMP_PATH);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('newlines');
     // And nothing got appended to the file
-    const triageLines = readFileSync(TMP_PATH, 'utf-8')
+    const forgedLines = readFileSync(TMP_PATH, 'utf-8')
       .split('\n')
-      .filter((l) => l.startsWith('phase-9-final'));
-    expect(triageLines).toHaveLength(0);
+      .filter((l) => l.startsWith('phase-6-final'));
+    expect(forgedLines).toHaveLength(0);
   });
 
   it('rejects carriage returns in reason', () => {
-    const result = recordPhase('phase-7-ui', { reason: 'a\rb' }, TMP_PATH);
+    const result = recordPhase('phase-5-category', { reason: 'a\rb' }, TMP_PATH);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('newlines');
   });
 
   it('rejects reasons longer than 500 chars', () => {
-    const result = recordPhase('phase-7-ui', { reason: 'x'.repeat(501) }, TMP_PATH);
+    const result = recordPhase('phase-5-category', { reason: 'x'.repeat(501) }, TMP_PATH);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('too long');
   });
 
   it('accepts reasons exactly at the 500-char cap', () => {
-    const result = recordPhase('phase-7-ui', { reason: 'x'.repeat(500) }, TMP_PATH);
+    const result = recordPhase('phase-5-category', { reason: 'x'.repeat(500) }, TMP_PATH);
     expect(result.ok).toBe(true);
   });
 });
@@ -269,10 +269,10 @@ describe('summarizeSkipped', () => {
     const summary = summarizeSkipped(undefined, TMP_PATH);
     expect(summary).toBeTruthy();
     expect(summary).toContain('phase-3a-narrow: N/A: phase-3a-narrow');
-    expect(summary).toContain('phase-7-ui: N/A: phase-7-ui');
+    expect(summary).toContain('phase-5-category: N/A: phase-5-category');
     // Non-skippable phases never appear in the summary
     expect(summary).not.toContain('phase-1-triage');
-    expect(summary).not.toContain('phase-9-final');
+    expect(summary).not.toContain('phase-6-final');
   });
 });
 
@@ -285,18 +285,17 @@ describe('readTracker', () => {
 });
 
 describe('PHASE_IDS canonical list', () => {
-  it('contains exactly the 10 documented phase IDs in order', () => {
+  // Post-QUA-961: 7 phases. Simplification + coverage audit folded into
+  // phase-3b's prompt. Do NOT split them back out without revisiting QUA-961.
+  it('contains exactly the 7 documented phase IDs in order', () => {
     expect(PHASE_IDS).toEqual([
       'phase-1-triage',
       'phase-2-mechanical',
       'phase-3a-narrow',
       'phase-3b-hostile',
-      'phase-4-simplify',
-      'phase-5-coverage',
-      'phase-6-redteam',
-      'phase-7-ui',
-      'phase-8-api',
-      'phase-9-final',
+      'phase-4-redteam',
+      'phase-5-category',
+      'phase-6-final',
     ]);
   });
 
@@ -304,7 +303,7 @@ describe('PHASE_IDS canonical list', () => {
     expect([...NON_SKIPPABLE_PHASES].sort()).toEqual([
       'phase-1-triage',
       'phase-2-mechanical',
-      'phase-9-final',
+      'phase-6-final',
     ]);
   });
 });

--- a/crux/lib/review-phase-tracker.test.ts
+++ b/crux/lib/review-phase-tracker.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the review phase tracker — QUA-950.
+ *
+ * Pure-logic tests: parsing, validation, skip rules, summary. The
+ * file-touching helpers (initTracker, recordPhase, readTracker) take an
+ * optional `path` argument so tests can use a temp file and never touch
+ * the real `.claude/review-phases-done`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  PHASE_IDS,
+  NON_SKIPPABLE_PHASES,
+  parseTracker,
+  validateTracker,
+  initTracker,
+  recordPhase,
+  readTracker,
+  summarizeSkipped,
+} from './review-phase-tracker.ts';
+
+let TMP_DIR: string;
+let TMP_PATH: string;
+
+beforeEach(() => {
+  TMP_DIR = mkdtempSync(join(tmpdir(), 'review-phase-tracker-'));
+  TMP_PATH = join(TMP_DIR, 'review-phases-done');
+});
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe('parseTracker', () => {
+  it('parses init line + phase entries', () => {
+    const content =
+      'init abcdef123456 deadbeef0000 2026-04-30T12:00:00Z\n' +
+      'phase-1-triage 2026-04-30T12:01:00Z\n' +
+      'phase-7-ui 2026-04-30T12:02:00Z reason=N/A: no .tsx files\n';
+    const state = parseTracker(content);
+    expect(state.init).toEqual({
+      commitSha: 'abcdef123456',
+      diffHash: 'deadbeef0000',
+      timestamp: '2026-04-30T12:00:00Z',
+    });
+    expect(state.entries).toHaveLength(2);
+    expect(state.entries[0]).toEqual({
+      phaseId: 'phase-1-triage',
+      timestamp: '2026-04-30T12:01:00Z',
+      reason: undefined,
+    });
+    expect(state.entries[1]).toEqual({
+      phaseId: 'phase-7-ui',
+      timestamp: '2026-04-30T12:02:00Z',
+      reason: 'N/A: no .tsx files',
+    });
+  });
+
+  it('drops unknown phase IDs (forward compatibility)', () => {
+    const content =
+      'init aaa bbb 2026-04-30T12:00:00Z\n' +
+      'phase-1-triage 2026-04-30T12:01:00Z\n' +
+      'phase-99-future 2026-04-30T12:02:00Z\n';
+    const state = parseTracker(content);
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0].phaseId).toBe('phase-1-triage');
+  });
+
+  it('ignores comments and blank lines', () => {
+    const content =
+      '# header comment\n' +
+      '\n' +
+      'init aaa bbb 2026-04-30T12:00:00Z\n' +
+      '# inline comment\n' +
+      'phase-1-triage 2026-04-30T12:01:00Z\n';
+    const state = parseTracker(content);
+    expect(state.init).toBeTruthy();
+    expect(state.entries).toHaveLength(1);
+  });
+
+  it('handles missing init gracefully', () => {
+    const content = 'phase-1-triage 2026-04-30T12:01:00Z\n';
+    const state = parseTracker(content);
+    expect(state.init).toBeNull();
+    expect(state.entries).toHaveLength(1);
+  });
+
+  it('handles malformed lines without crashing', () => {
+    const content =
+      'init aaa\n' + // too few fields
+      'phase-1-triage\n' + // missing timestamp
+      'random garbage\n' +
+      'phase-2-mechanical 2026-04-30T12:00:00Z\n';
+    const state = parseTracker(content);
+    expect(state.init).toBeNull(); // not enough fields
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0].phaseId).toBe('phase-2-mechanical');
+  });
+
+  it('preserves multi-word skip reasons including spaces and equals signs', () => {
+    const content =
+      'init aaa bbb 2026-04-30T12:00:00Z\n' +
+      'phase-7-ui 2026-04-30T12:02:00Z reason=N/A: x=1, y=2 (no .tsx)\n';
+    const state = parseTracker(content);
+    expect(state.entries[0].reason).toBe('N/A: x=1, y=2 (no .tsx)');
+  });
+});
+
+describe('validateTracker', () => {
+  it('marks all 10 phases missing on a fresh init', () => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    const result = validateTracker(undefined, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.missing.length).toBe(10);
+  });
+
+  it('passes when all 10 phases have entries', () => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    for (const id of PHASE_IDS) {
+      recordPhase(id, { timestamp: '2026-04-30T13:00:00Z' }, TMP_PATH);
+    }
+    const result = validateTracker(undefined, TMP_PATH);
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('counts skip-with-reason as covering the phase', () => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    for (const id of PHASE_IDS) {
+      const skipReason = NON_SKIPPABLE_PHASES.has(id) ? undefined : 'N/A: smoke';
+      recordPhase(id, { timestamp: '2026-04-30T13:00:00Z', reason: skipReason }, TMP_PATH);
+    }
+    const result = validateTracker(undefined, TMP_PATH);
+    expect(result.ok).toBe(true);
+  });
+
+  it('takes the most recent entry per phase (idempotent re-records)', () => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    recordPhase('phase-4-simplify', { timestamp: '2026-04-30T12:01:00Z', reason: 'N/A: small diff' }, TMP_PATH);
+    // Operator changed mind — actually ran the phase
+    recordPhase('phase-4-simplify', { timestamp: '2026-04-30T12:30:00Z' }, TMP_PATH);
+    const result = validateTracker(undefined, TMP_PATH);
+    expect(result.entries['phase-4-simplify']?.reason).toBeUndefined();
+    expect(result.entries['phase-4-simplify']?.timestamp).toBe('2026-04-30T12:30:00Z');
+  });
+
+  it('returns ok=false when init is missing', () => {
+    writeFileSync(TMP_PATH, 'phase-1-triage 2026-04-30T12:00:00Z\n', 'utf-8');
+    const result = validateTracker(undefined, TMP_PATH);
+    expect(result.init).toBeNull();
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('recordPhase', () => {
+  beforeEach(() => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+  });
+
+  it('rejects unknown phase IDs', () => {
+    const result = recordPhase('phase-99-bogus', {}, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Unknown phase');
+  });
+
+  it('rejects skip-with-reason for non-skippable phases', () => {
+    for (const id of ['phase-1-triage', 'phase-2-mechanical', 'phase-9-final']) {
+      const result = recordPhase(id, { reason: 'trying to skip' }, TMP_PATH);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('cannot be skipped');
+    }
+  });
+
+  it('accepts skip-with-reason for skippable phases', () => {
+    const skippable = ['phase-3a-narrow', 'phase-3b-hostile', 'phase-4-simplify',
+                       'phase-5-coverage', 'phase-6-redteam', 'phase-7-ui', 'phase-8-api'];
+    for (const id of skippable) {
+      const result = recordPhase(id, { reason: `N/A: skip ${id}` }, TMP_PATH);
+      expect(result.ok).toBe(true);
+      expect(result.entry?.reason).toBe(`N/A: skip ${id}`);
+    }
+  });
+
+  it('refuses to record when tracker has not been init-ed', () => {
+    rmSync(TMP_PATH);
+    const result = recordPhase('phase-1-triage', {}, TMP_PATH);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('not initialized');
+  });
+
+  it('appends multiple entries when called repeatedly (audit trail)', () => {
+    recordPhase('phase-1-triage', { timestamp: '2026-04-30T12:01:00Z' }, TMP_PATH);
+    recordPhase('phase-1-triage', { timestamp: '2026-04-30T12:30:00Z' }, TMP_PATH);
+    const fileContent = readFileSync(TMP_PATH, 'utf-8');
+    const triageLines = fileContent.split('\n').filter((l) => l.startsWith('phase-1-triage'));
+    expect(triageLines).toHaveLength(2);
+  });
+});
+
+describe('initTracker', () => {
+  it('truncates existing tracker on re-init', () => {
+    initTracker({ commitSha: 'old', diffHash: 'old', timestamp: '2026-04-30T11:00:00Z' }, TMP_PATH);
+    recordPhase('phase-1-triage', { timestamp: '2026-04-30T11:01:00Z' }, TMP_PATH);
+    expect(readFileSync(TMP_PATH, 'utf-8')).toContain('phase-1-triage');
+
+    initTracker({ commitSha: 'new', diffHash: 'new', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    const after = readFileSync(TMP_PATH, 'utf-8');
+    expect(after).not.toContain('phase-1-triage');
+    expect(after).toContain('init new new');
+  });
+
+  it('writes the init line with the canonical 4-field format', () => {
+    initTracker({ commitSha: 'sha123', diffHash: 'hash456', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+    const lines = readFileSync(TMP_PATH, 'utf-8').trim().split('\n');
+    expect(lines[0]).toBe('init sha123 hash456 2026-04-30T12:00:00Z');
+  });
+});
+
+describe('summarizeSkipped', () => {
+  beforeEach(() => {
+    initTracker({ commitSha: 'aaa', diffHash: 'bbb', timestamp: '2026-04-30T12:00:00Z' }, TMP_PATH);
+  });
+
+  it('returns null when no phases skipped', () => {
+    for (const id of PHASE_IDS) {
+      recordPhase(id, { timestamp: '2026-04-30T12:01:00Z' }, TMP_PATH);
+    }
+    expect(summarizeSkipped(undefined, TMP_PATH)).toBeNull();
+  });
+
+  it('lists each skipped phase with its reason', () => {
+    for (const id of PHASE_IDS) {
+      const skipReason = NON_SKIPPABLE_PHASES.has(id) ? undefined : `N/A: ${id}`;
+      recordPhase(id, { timestamp: '2026-04-30T12:01:00Z', reason: skipReason }, TMP_PATH);
+    }
+    const summary = summarizeSkipped(undefined, TMP_PATH);
+    expect(summary).toBeTruthy();
+    expect(summary).toContain('phase-3a-narrow: N/A: phase-3a-narrow');
+    expect(summary).toContain('phase-7-ui: N/A: phase-7-ui');
+    // Non-skippable phases never appear in the summary
+    expect(summary).not.toContain('phase-1-triage');
+    expect(summary).not.toContain('phase-9-final');
+  });
+});
+
+describe('readTracker', () => {
+  it('returns empty state when file is missing', () => {
+    const state = readTracker(join(TMP_DIR, 'does-not-exist'));
+    expect(state.init).toBeNull();
+    expect(state.entries).toEqual([]);
+  });
+});
+
+describe('PHASE_IDS canonical list', () => {
+  it('contains exactly the 10 documented phase IDs in order', () => {
+    expect(PHASE_IDS).toEqual([
+      'phase-1-triage',
+      'phase-2-mechanical',
+      'phase-3a-narrow',
+      'phase-3b-hostile',
+      'phase-4-simplify',
+      'phase-5-coverage',
+      'phase-6-redteam',
+      'phase-7-ui',
+      'phase-8-api',
+      'phase-9-final',
+    ]);
+  });
+
+  it('NON_SKIPPABLE_PHASES contains exactly the always-required phases', () => {
+    expect([...NON_SKIPPABLE_PHASES].sort()).toEqual([
+      'phase-1-triage',
+      'phase-2-mechanical',
+      'phase-9-final',
+    ]);
+  });
+});

--- a/crux/lib/review-phase-tracker.ts
+++ b/crux/lib/review-phase-tracker.ts
@@ -6,10 +6,11 @@
  * and `.claude/commands/agent-review-pr.md`.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { PROJECT_ROOT } from './content-types.ts';
+import { computeDiffHash as computeMarkerDiffHash } from './review-marker.ts';
 
 export const TRACKER_PATH = join(PROJECT_ROOT, '.claude/review-phases-done');
 
@@ -67,28 +68,21 @@ export interface TrackerState {
 }
 
 /**
- * Compute the diff hash for the current branch against main. Matches the
- * algorithm in agent-review-pr's marker write so the tracker and the marker
- * stay in sync — re-running review-phase init after a new commit invalidates
- * the previous state.
+ * Re-export the marker's canonical diff-hash so the tracker and the marker
+ * stay in lockstep — drift between the two would defeat the inSync check.
+ *
+ * The hostile-reviewer pass on QUA-950 caught a duplicate implementation
+ * here that used template-literal `execSync` (gate-failing under the
+ * `no-exec-sync` rule) and spawned `shasum` instead of `node:crypto`.
+ * Reuse is the simpler answer.
  */
-export function computeDiffHash(): string {
-  let mergeBase: string;
-  try {
-    mergeBase = execSync('git merge-base HEAD origin/main', {
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-      .toString()
-      .trim();
-  } catch {
-    mergeBase = execSync('git merge-base HEAD main').toString().trim();
-  }
-  const diff = execSync(`git diff ${mergeBase}...HEAD`).toString();
-  return execSync('shasum -a 256', { input: diff }).toString().slice(0, 12);
-}
+export const computeDiffHash = computeMarkerDiffHash;
 
 export function getHeadSha(): string {
-  return execSync('git rev-parse HEAD').toString().trim();
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+    encoding: 'utf-8',
+  }).trim();
 }
 
 function nowIso(): string {
@@ -210,6 +204,17 @@ export function recordPhase(
     return {
       ok: false,
       error: `Phase ${phaseId} cannot be skipped — it must execute on every review.`,
+    };
+  }
+
+  // Reasons round-trip through a one-line file format. A `\n` in the
+  // reason would let the agent forge additional phase entries via a
+  // single --reason argument. Reject up front rather than escape:
+  // valid skip reasons are short prose, never multiline.
+  if (reason && /[\n\r]/.test(reason)) {
+    return {
+      ok: false,
+      error: `--reason must not contain newlines. Use a single-line justification.`,
     };
   }
 

--- a/crux/lib/review-phase-tracker.ts
+++ b/crux/lib/review-phase-tracker.ts
@@ -1,0 +1,297 @@
+/**
+ * Review Phase Tracker — structural enforcement for /agent-review-pr phases.
+ *
+ * Pure logic helpers. The CLI commands and the agent-review-pr skill consume
+ * these to record phase execution and gate the marker file write. See QUA-950
+ * and `.claude/commands/agent-review-pr.md`.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from 'fs';
+import { join } from 'path';
+import { PROJECT_ROOT } from './content-types.ts';
+
+export const TRACKER_PATH = join(PROJECT_ROOT, '.claude/review-phases-done');
+
+/**
+ * Canonical phase IDs that map 1:1 to /agent-review-pr phases.
+ *
+ * `phase-1-triage`, `phase-2-mechanical`, and `phase-9-final` are not
+ * skippable — they always execute. The remaining phases are skippable with
+ * `reason=...`. The marker write requires every phase to have either a
+ * recorded timestamp or a skip reason.
+ */
+export const PHASE_IDS = [
+  'phase-1-triage',
+  'phase-2-mechanical',
+  'phase-3a-narrow',
+  'phase-3b-hostile',
+  'phase-4-simplify',
+  'phase-5-coverage',
+  'phase-6-redteam',
+  'phase-7-ui',
+  'phase-8-api',
+  'phase-9-final',
+] as const;
+
+export type PhaseId = (typeof PHASE_IDS)[number];
+
+/**
+ * Phases that cannot be skipped — `reason=...` is rejected.
+ *
+ * These run on every review regardless of PR shape (a content-only PR still
+ * runs triage and mechanical checks). Skipping them is the exact failure mode
+ * QUA-950 was filed for.
+ */
+export const NON_SKIPPABLE_PHASES = new Set<PhaseId>([
+  'phase-1-triage',
+  'phase-2-mechanical',
+  'phase-9-final',
+]);
+
+export interface PhaseEntry {
+  phaseId: PhaseId;
+  timestamp: string;
+  reason?: string;
+}
+
+export interface InitMetadata {
+  commitSha: string;
+  diffHash: string;
+  timestamp: string;
+}
+
+export interface TrackerState {
+  init: InitMetadata | null;
+  entries: PhaseEntry[];
+}
+
+/**
+ * Compute the diff hash for the current branch against main. Matches the
+ * algorithm in agent-review-pr's marker write so the tracker and the marker
+ * stay in sync — re-running review-phase init after a new commit invalidates
+ * the previous state.
+ */
+export function computeDiffHash(): string {
+  let mergeBase: string;
+  try {
+    mergeBase = execSync('git merge-base HEAD origin/main', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    mergeBase = execSync('git merge-base HEAD main').toString().trim();
+  }
+  const diff = execSync(`git diff ${mergeBase}...HEAD`).toString();
+  return execSync('shasum -a 256', { input: diff }).toString().slice(0, 12);
+}
+
+export function getHeadSha(): string {
+  return execSync('git rev-parse HEAD').toString().trim();
+}
+
+function nowIso(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Parse the tracker file. Format:
+ *
+ *   init <sha> <diff_hash> <timestamp>
+ *   <phase-id> <timestamp>
+ *   <phase-id> <timestamp> reason=<text...>
+ *
+ * Lines beginning with `#` and blank lines are ignored. Unknown phase IDs
+ * are dropped (forward-compatibility — newer trackers in older clients).
+ */
+export function parseTracker(content: string): TrackerState {
+  const state: TrackerState = { init: null, entries: [] };
+  const validIds = new Set<string>(PHASE_IDS);
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    if (line.startsWith('init ')) {
+      const parts = line.split(/\s+/);
+      // init <sha> <diff_hash> <timestamp>
+      if (parts.length >= 4) {
+        state.init = {
+          commitSha: parts[1],
+          diffHash: parts[2],
+          timestamp: parts[3],
+        };
+      }
+      continue;
+    }
+
+    const spaceIdx = line.indexOf(' ');
+    if (spaceIdx === -1) continue;
+    const phaseId = line.slice(0, spaceIdx);
+    if (!validIds.has(phaseId)) continue;
+
+    const rest = line.slice(spaceIdx + 1).trim();
+    const reasonIdx = rest.indexOf('reason=');
+    let timestamp: string;
+    let reason: string | undefined;
+    if (reasonIdx === -1) {
+      timestamp = rest;
+    } else {
+      timestamp = rest.slice(0, reasonIdx).trim();
+      reason = rest.slice(reasonIdx + 'reason='.length).trim();
+    }
+
+    if (!timestamp) continue;
+    state.entries.push({ phaseId: phaseId as PhaseId, timestamp, reason });
+  }
+
+  return state;
+}
+
+export function readTracker(path: string = TRACKER_PATH): TrackerState {
+  if (!existsSync(path)) {
+    return { init: null, entries: [] };
+  }
+  return parseTracker(readFileSync(path, 'utf-8'));
+}
+
+/**
+ * Initialize the tracker. Truncates any existing file — a fresh review starts
+ * with a fresh tracker. The init line records the commit + diff hash so callers
+ * can detect that the tracker is anchored to the right state.
+ *
+ * `path` is injectable so tests can use a temp file without disturbing the
+ * real `.claude/` directory.
+ */
+export function initTracker(meta?: Partial<InitMetadata>, path: string = TRACKER_PATH): InitMetadata {
+  const init: InitMetadata = {
+    commitSha: meta?.commitSha ?? getHeadSha(),
+    diffHash: meta?.diffHash ?? computeDiffHash(),
+    timestamp: meta?.timestamp ?? nowIso(),
+  };
+  const line = `init ${init.commitSha} ${init.diffHash} ${init.timestamp}\n`;
+  writeFileSync(path, line, 'utf-8');
+  return init;
+}
+
+export interface RecordOptions {
+  reason?: string;
+  /** Override the timestamp — for tests. */
+  timestamp?: string;
+}
+
+export interface RecordResult {
+  ok: boolean;
+  error?: string;
+  entry?: PhaseEntry;
+}
+
+/**
+ * Record execution (or skip-with-reason) of a phase. Idempotent: re-recording
+ * the same phase appends a new line — `validate` reads the most recent entry.
+ * Idempotency is intentional: if a phase runs twice (e.g. fixed a HIGH then
+ * re-ran), both timestamps are preserved for audit.
+ */
+export function recordPhase(
+  phaseId: string,
+  options: RecordOptions = {},
+  path: string = TRACKER_PATH,
+): RecordResult {
+  if (!PHASE_IDS.includes(phaseId as PhaseId)) {
+    return {
+      ok: false,
+      error: `Unknown phase: ${phaseId}. Valid IDs: ${PHASE_IDS.join(', ')}`,
+    };
+  }
+
+  const reason = options.reason?.trim();
+  if (reason && NON_SKIPPABLE_PHASES.has(phaseId as PhaseId)) {
+    return {
+      ok: false,
+      error: `Phase ${phaseId} cannot be skipped — it must execute on every review.`,
+    };
+  }
+
+  if (!existsSync(path)) {
+    return {
+      ok: false,
+      error: `Tracker not initialized — run \`crux sys review-phase init\` first.`,
+    };
+  }
+
+  const timestamp = options.timestamp ?? nowIso();
+  const entry: PhaseEntry = { phaseId: phaseId as PhaseId, timestamp, reason };
+  const line = reason
+    ? `${phaseId} ${timestamp} reason=${reason}\n`
+    : `${phaseId} ${timestamp}\n`;
+  appendFileSync(path, line, 'utf-8');
+  return { ok: true, entry };
+}
+
+export interface ValidateResult {
+  ok: boolean;
+  missing: PhaseId[];
+  init: InitMetadata | null;
+  /** True if the tracker's init metadata matches the current branch state. */
+  inSync: boolean;
+  /** Per-phase: most-recent entry or null if missing. */
+  entries: Record<PhaseId, PhaseEntry | null>;
+}
+
+/**
+ * Validate that every required phase has at least one entry. Each entry must
+ * be either a timestamp (executed) or a skip-with-reason (with `reason=...`).
+ *
+ * `inSync` checks whether the recorded init metadata still matches the current
+ * branch — a tracker initialized against an older HEAD is stale. The marker
+ * write should refuse if the tracker is out-of-sync.
+ */
+export function validateTracker(state?: TrackerState, path: string = TRACKER_PATH): ValidateResult {
+  const tracker = state ?? readTracker(path);
+  const entries = {} as Record<PhaseId, PhaseEntry | null>;
+  for (const id of PHASE_IDS) entries[id] = null;
+
+  // Most-recent-wins: each phase's last line is the source of truth.
+  for (const entry of tracker.entries) {
+    entries[entry.phaseId] = entry;
+  }
+
+  const missing = PHASE_IDS.filter((id) => entries[id] === null);
+
+  let inSync = false;
+  if (tracker.init) {
+    try {
+      const headSha = getHeadSha();
+      const diffHash = computeDiffHash();
+      inSync = tracker.init.commitSha === headSha && tracker.init.diffHash === diffHash;
+    } catch {
+      // git unreachable in tests / outside a repo; treat as in-sync.
+      inSync = true;
+    }
+  }
+
+  return {
+    ok: missing.length === 0 && tracker.init !== null,
+    missing,
+    init: tracker.init,
+    inSync,
+    entries,
+  };
+}
+
+/**
+ * Format a one-line summary of skipped phases for the PR body. Returns null
+ * when no phases were skipped (no need to add a section).
+ */
+export function summarizeSkipped(state?: TrackerState, path: string = TRACKER_PATH): string | null {
+  const tracker = state ?? readTracker(path);
+  const validation = validateTracker(tracker, path);
+  const skipped: { phase: PhaseId; reason: string }[] = [];
+  for (const id of PHASE_IDS) {
+    const entry = validation.entries[id];
+    if (entry?.reason) skipped.push({ phase: id, reason: entry.reason });
+  }
+  if (skipped.length === 0) return null;
+  return skipped.map(({ phase, reason }) => `- ${phase}: ${reason}`).join('\n');
+}

--- a/crux/lib/review-phase-tracker.ts
+++ b/crux/lib/review-phase-tracker.ts
@@ -217,6 +217,14 @@ export function recordPhase(
       error: `--reason must not contain newlines. Use a single-line justification.`,
     };
   }
+  // Sanity cap. Real skip reasons are sentence-length, not novel-length.
+  // A 100KB reason would still parse but signals operator confusion.
+  if (reason && reason.length > 500) {
+    return {
+      ok: false,
+      error: `--reason is too long (${reason.length} chars, max 500).`,
+    };
+  }
 
   if (!existsSync(path)) {
     return {

--- a/crux/lib/review-phase-tracker.ts
+++ b/crux/lib/review-phase-tracker.ts
@@ -17,22 +17,26 @@ export const TRACKER_PATH = join(PROJECT_ROOT, '.claude/review-phases-done');
 /**
  * Canonical phase IDs that map 1:1 to /agent-review-pr phases.
  *
- * `phase-1-triage`, `phase-2-mechanical`, and `phase-9-final` are not
- * skippable — they always execute. The remaining phases are skippable with
- * `reason=...`. The marker write requires every phase to have either a
- * recorded timestamp or a skip reason.
+ * QUA-961 (merged 2026-04-30) consolidated the prior 10-phase list down to
+ * 7 by folding the simplification + coverage-audit passes into Phase 3b's
+ * hostile-reviewer prompt — they reliably found nothing on their own
+ * because 3b already covered them. This list tracks the post-QUA-961
+ * structure; do NOT split simplify/coverage back out as standalone
+ * phases (per QUA-961's directive in the skill text).
+ *
+ * `phase-1-triage`, `phase-2-mechanical`, and `phase-6-final` are not
+ * skippable — they always execute. The remaining phases are skippable
+ * with `reason=...`. The marker write requires every phase to have
+ * either a recorded timestamp or a skip reason.
  */
 export const PHASE_IDS = [
   'phase-1-triage',
   'phase-2-mechanical',
   'phase-3a-narrow',
   'phase-3b-hostile',
-  'phase-4-simplify',
-  'phase-5-coverage',
-  'phase-6-redteam',
-  'phase-7-ui',
-  'phase-8-api',
-  'phase-9-final',
+  'phase-4-redteam',
+  'phase-5-category',
+  'phase-6-final',
 ] as const;
 
 export type PhaseId = (typeof PHASE_IDS)[number];
@@ -47,7 +51,7 @@ export type PhaseId = (typeof PHASE_IDS)[number];
 export const NON_SKIPPABLE_PHASES = new Set<PhaseId>([
   'phase-1-triage',
   'phase-2-mechanical',
-  'phase-9-final',
+  'phase-6-final',
 ]);
 
 export interface PhaseEntry {


### PR DESCRIPTION
## Summary

Adds `crux sys review-phase {init,record,validate,write-marker,...}` so the `/agent-review-pr` review marker (`.claude/review-done`) cannot be written until every required phase has either an execution timestamp or an explicit `reason=...` skip.

Replaces self-attestation against the phase list with a structural artifact the marker write actively checks. Closes the QUA-928 failure mode where an agent ran phases 1-3 + 6-7, declared "complete," and shipped — silently skipping phases 4-5 (red-team, category-specific testing).

## Phase list (post-QUA-961)

QUA-961 (merged 2026-04-30) consolidated the prior 10-phase list down to 7. This PR tracks the post-QUA-961 structure:

```
phase-1-triage      (non-skippable)
phase-2-mechanical  (non-skippable)
phase-3a-narrow
phase-3b-hostile
phase-4-redteam
phase-5-category
phase-6-final       (non-skippable)
```

Non-skippable phases must have an execution timestamp (no `--reason` accepted). The other 4 are skippable with `--reason="..."` (rejected: empty, multiline, >500 chars).

## Key changes

- `crux/lib/review-phase-tracker.ts` — pure-logic helpers (parse / init / record / validate / summarize). Reuses `review-marker.ts::computeDiffHash` to keep the tracker and marker in lockstep.
- `crux/commands/review-phase.ts` — CLI: `init`, `record`, `validate`, `list`, `summary`, `write-marker`, `reset`. Registered in the `sys` group.
- `crux/lib/review-phase-tracker.test.ts` — 27 tests covering parsing, validation, skip rules, idempotency, newline/CR injection rejection, length cap, and forward-compat for unknown phase IDs.
- `.claude/commands/agent-review-pr.md` — adds `init` at Phase 1, `record` at each phase boundary (with skip-with-reason examples), replaces inline `echo > .claude/review-done` with `crux sys review-phase write-marker`.
- `.claude/commands/agent-ship.md` — adds Step 4a to surface skipped phases in the PR body via `pnpm --silent crux sys review-phase summary`.
- `.claude/commands/agent-end.md` + `crux/commands/agent-reset.ts` — cleanup hooks add `.claude/review-phases-done` alongside the existing `review-done` and `simplify-done`.
- `.claude/hooks/approve-claude-configs.sh` — auto-approves Edit/Write to `review-phases-done` so dispatched sub-agents don't get permission prompts.
- `.gitignore` — adds `.claude/review-phases-done` (session-local file).

## Marker write semantics

The marker writer refuses (exit 2) when:
- any phase is missing a record line, OR
- the tracker's recorded HEAD/diff hash no longer matches current state.

`--force --reason="<text>"` is the documented bypass for `pr-patrol` and rebases. It records a `# force-bypass <ts> reason=<text>` audit line in the tracker so the bypass is visible in `validate` and `summary --json`. `--force` without `--reason` exits 1 — empty bypasses defeat the gate.

## Self-review

This PR was reviewed using its own new system end-to-end (dogfooded). The hostile-reviewer subagent in Phase 3b found 3 CRITICAL + 5 HIGH issues; all were fixed before continuing the review:

- CRITICAL: Replaced gate-failing template-literal `execSync('git diff ${mergeBase}...HEAD')` with reuse of `review-marker.ts::computeDiffHash` (uses `execFileSync` + `node:crypto`).
- CRITICAL: `--force` on `write-marker` now requires `--reason="<text>"` and refuses with exit 1 when missing.
- HIGH: `pnpm` prelude pollution in agent-ship snippet — fixed via `pnpm --silent | sed '/^$/d'`.
- HIGH: `recordPhase` rejects newlines/CRs in `--reason` (closed the forge-via-injection vector).
- HIGH: `agent-reset` knows about the new tracker file.
- HIGH: Duplicate `computeDiffHash` removed via reuse.

Phase 4 (red-team) found a 100KB-reason acceptance bug; capped at 500 chars.

## Out of scope (filed separately if needed)

- `pr-patrol/prompts.ts` instructs patrol agents to `echo > .claude/review-done` directly with the legacy 3-field format that the marker checker treats as malformed. Pre-existing tech debt; should migrate to `crux sys review-phase write-marker --force --reason="patrol-fix"` in a follow-up.

## Test plan

- [x] `npx vitest run crux/lib/review-phase-tracker.test.ts` — 27 tests pass
- [x] `pnpm crux w validate gate --fix` — 67/67 pass (no-exec-sync rule satisfied)
- [x] `pnpm build` — green
- [x] End-to-end smoke test: init → record (with and without --reason) → validate (refuses on missing) → write-marker (refuses without --force when missing; refuses --force without --reason; succeeds with --force --reason and writes audit line)
- [x] Rebased onto post-QUA-961 main; phase IDs reduced from 10 to 7; tests + gate + build all green after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-950
