### PR TITLE
feat(pipeline-runs): pipeline_runs table + API + withPipelineRun lifecycle (QUA-954)

### DIFF
--- a/apps/web/src/app/internal/pipeline-runs/page.tsx
+++ b/apps/web/src/app/internal/pipeline-runs/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function PipelineRunsPage() {
+  redirect("/wiki/E2545");
+}

--- a/apps/web/src/app/internal/pipeline-runs/pipeline-runs-content.tsx
+++ b/apps/web/src/app/internal/pipeline-runs/pipeline-runs-content.tsx
@@ -33,20 +33,30 @@ interface ApiData {
 
 // ── Data Loading ──────────────────────────────────────────────────────────
 
+function safeIso(value: string | Date): string {
+  // Defensive: if startedAt comes back malformed, `new Date(...).toISOString()`
+  // throws RangeError and kills the entire dashboard render. Fall back to
+  // the original string representation rather than the page erroring out.
+  if (typeof value === "string") return value;
+  const t = value.getTime();
+  if (!Number.isFinite(t)) return String(value);
+  return value.toISOString();
+}
+
 function toDisplayRow(r: PipelineRunRow): PipelineRunDisplayRow {
-  // Drizzle returns Date | string depending on serialization; force string.
-  const startedAt =
-    typeof r.startedAt === "string" ? r.startedAt : new Date(r.startedAt).toISOString();
-  const endedAt =
-    r.endedAt == null
-      ? null
-      : typeof r.endedAt === "string"
-        ? r.endedAt
-        : new Date(r.endedAt).toISOString();
-  const durationMs =
-    endedAt != null
-      ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
-      : null;
+  const startedAt = safeIso(r.startedAt);
+  const endedAt = r.endedAt == null ? null : safeIso(r.endedAt);
+
+  // Compute duration only when both timestamps parse cleanly.
+  let durationMs: number | null = null;
+  if (endedAt != null) {
+    const startMs = new Date(startedAt).getTime();
+    const endMs = new Date(endedAt).getTime();
+    if (Number.isFinite(startMs) && Number.isFinite(endMs)) {
+      durationMs = endMs - startMs;
+    }
+  }
+
   return {
     runId: r.runId,
     pipelineName: r.pipelineName,
@@ -63,7 +73,7 @@ function toDisplayRow(r: PipelineRunRow): PipelineRunDisplayRow {
 
 async function loadFromApi(): Promise<FetchResult<ApiData>> {
   const [runsResult, statsResult] = await Promise.all([
-    fetchDetailed<{ runs: PipelineRunRow[]; total: number }>(
+    fetchDetailed<{ runs: PipelineRunRow[]; count: number }>(
       "/api/pipeline-runs?limit=200",
       { revalidate: 30 }
     ),

--- a/apps/web/src/app/internal/pipeline-runs/pipeline-runs-content.tsx
+++ b/apps/web/src/app/internal/pipeline-runs/pipeline-runs-content.tsx
@@ -1,0 +1,225 @@
+import { fetchDetailed, withApiFallback, type FetchResult } from "@lib/wiki-server";
+import { DataSourceBanner } from "@components/internal/DataSourceBanner";
+import { PipelineRunsTable } from "./pipeline-runs-table";
+import type {
+  PipelineRunRow,
+  PipelineRunsStatsResult,
+} from "@wiki-server/api-response-types";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+/**
+ * Display row — flattened from the API row, with a precomputed
+ * `durationMs` so the table sorts and renders without reaching back
+ * into the timestamps.
+ */
+export interface PipelineRunDisplayRow {
+  runId: string;
+  pipelineName: string;
+  shape: string | null;
+  entityId: string | null;
+  status: string;
+  startedAt: string;
+  endedAt: string | null;
+  durationMs: number | null;
+  failureReason: string | null;
+  errorCode: string | null;
+}
+
+interface ApiData {
+  runs: PipelineRunDisplayRow[];
+  stats: PipelineRunsStatsResult | null;
+}
+
+// ── Data Loading ──────────────────────────────────────────────────────────
+
+function toDisplayRow(r: PipelineRunRow): PipelineRunDisplayRow {
+  // Drizzle returns Date | string depending on serialization; force string.
+  const startedAt =
+    typeof r.startedAt === "string" ? r.startedAt : new Date(r.startedAt).toISOString();
+  const endedAt =
+    r.endedAt == null
+      ? null
+      : typeof r.endedAt === "string"
+        ? r.endedAt
+        : new Date(r.endedAt).toISOString();
+  const durationMs =
+    endedAt != null
+      ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
+      : null;
+  return {
+    runId: r.runId,
+    pipelineName: r.pipelineName,
+    shape: r.shape,
+    entityId: r.entityId,
+    status: r.status,
+    startedAt,
+    endedAt,
+    durationMs,
+    failureReason: r.failureReason,
+    errorCode: r.errorCode,
+  };
+}
+
+async function loadFromApi(): Promise<FetchResult<ApiData>> {
+  const [runsResult, statsResult] = await Promise.all([
+    fetchDetailed<{ runs: PipelineRunRow[]; total: number }>(
+      "/api/pipeline-runs?limit=200",
+      { revalidate: 30 }
+    ),
+    fetchDetailed<PipelineRunsStatsResult>("/api/pipeline-runs/stats", {
+      revalidate: 30,
+    }),
+  ]);
+
+  if (!runsResult.ok) return runsResult;
+
+  const runs: PipelineRunDisplayRow[] = runsResult.data.runs.map(toDisplayRow);
+  const stats: PipelineRunsStatsResult | null = statsResult.ok
+    ? statsResult.data
+    : null;
+
+  return { ok: true, data: { runs, stats } };
+}
+
+function noLocalFallback(): ApiData {
+  return { runs: [], stats: null };
+}
+
+// ── Summary Cards ─────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  subtext,
+  colorClass,
+}: {
+  label: string;
+  value: string | number;
+  subtext?: string;
+  colorClass?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 p-4">
+      <p className="text-xs text-muted-foreground mb-1">{label}</p>
+      <p className={`text-2xl font-semibold tabular-nums ${colorClass ?? ""}`}>
+        {value}
+      </p>
+      {subtext && (
+        <p className="text-xs text-muted-foreground mt-0.5">{subtext}</p>
+      )}
+    </div>
+  );
+}
+
+function statusCount(
+  byStatus: PipelineRunsStatsResult["byStatus"],
+  status: string,
+): number {
+  return byStatus.find((s) => s.status === status)?.count ?? 0;
+}
+
+// ── Content Component ────────────────────────────────────────────────────
+
+export async function PipelineRunsContent() {
+  const { data, source, apiError } = await withApiFallback(
+    loadFromApi,
+    noLocalFallback
+  );
+
+  const { runs, stats } = data;
+  const totalRuns = runs.length;
+  const last24h = stats?.byStatus ?? [];
+  const running = statusCount(last24h, "running");
+  const committed = statusCount(last24h, "committed");
+  const aborted = statusCount(last24h, "aborted");
+  const oscillation = statusCount(last24h, "oscillation");
+  const partialFailure = statusCount(last24h, "partial_failure");
+  const failureReasons = stats?.byFailureReason ?? [];
+
+  return (
+    <>
+      <p className="text-muted-foreground">
+        Per-run lifecycle history for generation / improve / sourcing pipelines.
+        Each row is one execution wrapped by{" "}
+        <code className="text-xs">withPipelineRun()</code>. Use this to see
+        what's running now, what aborted recently, and which failure
+        reasons are recurring.
+      </p>
+
+      {/* Summary cards (last 24h) */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 my-4">
+        <StatCard
+          label="Running"
+          value={running}
+          subtext="last 24h"
+          colorClass={running > 0 ? "text-blue-600" : undefined}
+        />
+        <StatCard
+          label="Committed"
+          value={committed}
+          subtext="last 24h"
+          colorClass={committed > 0 ? "text-green-600" : undefined}
+        />
+        <StatCard
+          label="Aborted"
+          value={aborted}
+          subtext="last 24h"
+          colorClass={aborted > 0 ? "text-red-500" : undefined}
+        />
+        <StatCard
+          label="Oscillation"
+          value={oscillation}
+          subtext="last 24h"
+          colorClass={oscillation > 0 ? "text-orange-600" : undefined}
+        />
+        <StatCard
+          label="Partial failure"
+          value={partialFailure}
+          subtext="last 24h"
+          colorClass={partialFailure > 0 ? "text-yellow-600" : undefined}
+        />
+      </div>
+
+      {/* Failure-reason breakdown */}
+      {failureReasons.length > 0 && (
+        <div className="my-6">
+          <h3 className="text-sm font-semibold text-muted-foreground mb-2">
+            Failure reasons (last 24h)
+          </h3>
+          <div className="rounded-lg border border-border/60 divide-y divide-border/60">
+            {failureReasons
+              .slice()
+              .sort((a, b) => b.count - a.count)
+              .map((row) => (
+                <div
+                  key={row.failureReason ?? "<null>"}
+                  className="flex items-center justify-between p-3"
+                >
+                  <span className="text-sm">{row.failureReason ?? "—"}</span>
+                  <span className="text-sm font-semibold tabular-nums">
+                    {row.count}
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Runs table */}
+      {totalRuns === 0 ? (
+        <div className="rounded-lg border border-border/60 p-8 text-center text-muted-foreground">
+          <p className="text-lg font-medium mb-2">No pipeline runs recorded</p>
+          <p className="text-sm">
+            Runs will appear once a pipeline wraps its execution with{" "}
+            <code className="text-xs">withPipelineRun()</code>.
+          </p>
+        </div>
+      ) : (
+        <PipelineRunsTable data={runs} />
+      )}
+
+      <DataSourceBanner source={source} apiError={apiError} />
+    </>
+  );
+}

--- a/apps/web/src/app/internal/pipeline-runs/pipeline-runs-table.tsx
+++ b/apps/web/src/app/internal/pipeline-runs/pipeline-runs-table.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import {
+  ServerPaginatedTable,
+  type ColumnDef,
+} from "@/components/server-paginated-table";
+import type { PipelineRunDisplayRow } from "./pipeline-runs-content";
+
+// ── Status Badge ─────────────────────────────────────────────────────────
+
+const STATUS_STYLES: Record<string, string> = {
+  running: "bg-blue-500/15 text-blue-600",
+  committed: "bg-green-500/15 text-green-600",
+  aborted: "bg-red-500/15 text-red-500",
+  oscillation: "bg-orange-500/15 text-orange-600",
+  partial_failure: "bg-yellow-500/15 text-yellow-700",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const style = STATUS_STYLES[status] ?? "bg-muted text-muted-foreground";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${style}`}
+    >
+      {status.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+// ── Columns ──────────────────────────────────────────────────────────────
+
+const columns: ColumnDef<PipelineRunDisplayRow>[] = [
+  {
+    id: "startedAt",
+    header: "Started",
+    sortField: "startedAt",
+    accessor: (row) => {
+      const date = new Date(row.startedAt);
+      return (
+        <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+          {date.toLocaleDateString()}{" "}
+          {date.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </span>
+      );
+    },
+  },
+  {
+    id: "pipelineName",
+    header: "Pipeline",
+    sortField: "pipelineName",
+    accessor: (row) => (
+      <span className="text-sm font-medium">{row.pipelineName}</span>
+    ),
+  },
+  {
+    id: "shape",
+    header: "Shape",
+    sortField: "shape",
+    accessor: (row) =>
+      row.shape ? (
+        <span className="text-xs text-muted-foreground">{row.shape}</span>
+      ) : (
+        <span className="text-xs text-muted-foreground/50">&mdash;</span>
+      ),
+  },
+  {
+    id: "entityId",
+    header: "Entity",
+    sortField: "entityId",
+    accessor: (row) =>
+      row.entityId ? (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {row.entityId}
+        </span>
+      ) : (
+        <span className="text-xs text-muted-foreground/50">&mdash;</span>
+      ),
+  },
+  {
+    id: "status",
+    header: "Status",
+    sortField: "status",
+    accessor: (row) => <StatusBadge status={row.status} />,
+  },
+  {
+    id: "durationMs",
+    header: "Duration",
+    sortField: "durationMs",
+    align: "right" as const,
+    accessor: (row) => {
+      const ms = row.durationMs;
+      if (ms === null) {
+        return <span className="text-xs text-muted-foreground/50">&mdash;</span>;
+      }
+      return (
+        <span className="text-xs tabular-nums">
+          {ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`}
+        </span>
+      );
+    },
+  },
+  {
+    id: "failureReason",
+    header: "Failure / Error",
+    accessor: (row) => {
+      const text = row.failureReason ?? row.errorCode;
+      if (!text) {
+        return <span className="text-xs text-muted-foreground/50">&mdash;</span>;
+      }
+      return (
+        <span
+          className="text-xs text-muted-foreground max-w-[280px] block truncate"
+          title={text}
+        >
+          {text}
+        </span>
+      );
+    },
+  },
+  {
+    id: "runId",
+    header: "Run ID",
+    accessor: (row) => (
+      <span
+        className="text-[10px] text-muted-foreground/70 tabular-nums max-w-[120px] block truncate"
+        title={row.runId}
+      >
+        {row.runId.slice(0, 8)}
+      </span>
+    ),
+  },
+];
+
+// ── Table Component ──────────────────────────────────────────────────────
+
+export function PipelineRunsTable({ data }: { data: PipelineRunDisplayRow[] }) {
+  return (
+    <ServerPaginatedTable<PipelineRunDisplayRow>
+      columns={columns}
+      rows={data}
+      rowKey={(row) => row.runId}
+      defaultSortId="startedAt"
+      defaultSortDir="desc"
+      searchPlaceholder="Search runs..."
+      itemLabel="runs"
+      searchFields={[
+        "pipelineName",
+        "shape",
+        "entityId",
+        "status",
+        "failureReason",
+        "errorCode",
+        "runId",
+      ]}
+      staticSort={(a, b, sortId, dir) => {
+        let cmp = 0;
+        if (sortId === "startedAt") {
+          cmp =
+            new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime();
+        } else if (sortId === "durationMs") {
+          cmp = (a.durationMs ?? -1) - (b.durationMs ?? -1);
+        } else if (sortId === "pipelineName") {
+          cmp = a.pipelineName.localeCompare(b.pipelineName);
+        } else if (sortId === "status") {
+          cmp = a.status.localeCompare(b.status);
+        } else if (sortId === "shape") {
+          cmp = (a.shape ?? "").localeCompare(b.shape ?? "");
+        } else if (sortId === "entityId") {
+          cmp = (a.entityId ?? "").localeCompare(b.entityId ?? "");
+        }
+        return dir === "asc" ? cmp : -cmp;
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -67,6 +67,7 @@ import { CitationAccuracyContent } from "@/app/internal/citation-accuracy/citati
 import { CitationContentContent } from "@/app/internal/citation-content/citation-content-content";
 import { HallucinationRiskContent } from "@/app/internal/hallucination-risk/hallucination-risk-content";
 import { GroundskeeperRunsContent } from "@/app/internal/groundskeeper-runs/groundskeeper-runs-content";
+import { PipelineRunsContent } from "@/app/internal/pipeline-runs/pipeline-runs-content";
 import { SystemHealthContent } from "@/app/internal/system-health/system-health-content";
 import { PRDashboardContent } from "@/app/internal/pr-dashboard/pr-dashboard-content";
 import { GrantsDashboardContent } from "@/app/internal/grants-dashboard/grants-dashboard-content";
@@ -236,6 +237,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   CitationContentContent,
   HallucinationRiskContent,
   GroundskeeperRunsContent,
+  PipelineRunsContent,
   SystemHealthContent,
   PRDashboardContent,
   GrantsDashboardContent,

--- a/apps/web/src/lib/wiki-nav.ts
+++ b/apps/web/src/lib/wiki-nav.ts
@@ -303,6 +303,7 @@ export function getInternalNav(): NavSection[] {
         { label: "Page Changes", href: internalHref("page-changes-dashboard") },
         { label: "Update Schedule", href: internalHref("update-schedule-dashboard") },
         { label: "Groundskeeper Runs", href: internalHref("groundskeeper-runs-dashboard") },
+        { label: "Pipeline Runs", href: internalHref("pipeline-runs-dashboard") },
       ],
     },
     {

--- a/apps/wiki-server/drizzle/0222_qua_954_pipeline_runs.sql
+++ b/apps/wiki-server/drizzle/0222_qua_954_pipeline_runs.sql
@@ -1,0 +1,96 @@
+-- QUA-954 (parent QUA-943): pipeline_runs table for the machine-write
+-- PG-primary transition.
+--
+-- Tracks per-run lifecycle of generation/improve/etc. pipelines so the
+-- coordinator can:
+--   * detect dead/stuck runs via heartbeat liveness
+--   * attribute writes to the originating pipeline run via the audit trail
+--   * surface failure patterns (oscillation, abort reasons) on the
+--     /internal/pipeline-runs dashboard.
+--
+-- The table is intentionally additive — Phase 0d ships only the storage
+-- + lifecycle scaffolding. No production caller wires it until Phase 1
+-- (QUA-957). Reversibility: trivial (DROP TABLE).
+--
+-- ## Schema notes
+--
+-- - `agent_session_id` is `bigint` (FK to `agent_sessions.id` which is
+--   bigserial). The QUA-943 RFC §0d spec wrote `uuid` here; the actual
+--   `agent_sessions` PK has been bigserial since QUA-406. Using bigint
+--   matches the parent column type — uuid would fail at FK creation.
+-- - `status` CHECK enumerates the v1 set per the RFC. Per
+--   `.claude/rules/database-migrations.md` § "Adding CHECK constraints
+--   on enum columns", a follow-up migration may widen this AFTER
+--   enumerating prod row distribution; do NOT tighten without first
+--   running `SELECT status, count(*) FROM pipeline_runs GROUP BY status`.
+-- - `failure_reason` is intentionally untyped (text, not CHECK-enum) for
+--   v1: the set of reasons is being discovered through Phase 1 wiring,
+--   and a CHECK constraint here would force every code path to redeploy
+--   the wiki-server when adding a new reason. A validator is the right
+--   layer to enforce known reasons later.
+-- - `error_payload` is jsonb so callers can attach arbitrary structured
+--   error context (stack snippets, HTTP response bodies, validation
+--   errors) without a schema migration per error class.
+-- - `followup_actions` is jsonb (default '[]') so callers can record
+--   what they did after the run failed (e.g. retried, filed ticket,
+--   marked oscillation). Not enforced — the dashboard renders whatever
+--   the caller wrote.
+--
+-- ## Audit trigger (QUA-442)
+--
+-- Allow-listed per the QUA-943 RFC. Pipeline-run writes are attributed
+-- via the universal trigger so cross-table audits (entity write +
+-- pipeline_runs lifecycle) line up by `txn_id` / `session_id`.
+
+CREATE TABLE IF NOT EXISTS "pipeline_runs" (
+  "run_id"            text PRIMARY KEY,
+  "agent_session_id"  bigint REFERENCES "agent_sessions"("id") ON DELETE SET NULL,
+  "pipeline_name"     text NOT NULL,
+  "entity_id"         text,
+  "shape"             text,
+  "status"            text NOT NULL,
+  "failure_reason"    text,
+  "started_at"        timestamptz NOT NULL DEFAULT now(),
+  "heartbeat_at"      timestamptz NOT NULL DEFAULT now(),
+  "ended_at"          timestamptz,
+  "snapshot_path"     text,
+  "error_code"        text,
+  "error_payload"     jsonb,
+  "followup_actions"  jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "created_at"        timestamptz NOT NULL DEFAULT now(),
+  "updated_at"        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "chk_pipeline_runs_status" CHECK ("status" IN (
+    'running',
+    'committed',
+    'aborted',
+    'oscillation',
+    'partial_failure'
+  ))
+);
+
+-- Dashboard / drilldown queries.
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_pipeline_name"
+  ON "pipeline_runs" ("pipeline_name");
+
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_status"
+  ON "pipeline_runs" ("status");
+
+-- "Recent runs" listing — typical dashboard query.
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_started_at"
+  ON "pipeline_runs" ("started_at" DESC);
+
+-- "Stuck runs" sweep — find runs whose heartbeat went silent. Partial
+-- index keeps it small; only running rows are interesting for liveness.
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_running_heartbeat"
+  ON "pipeline_runs" ("heartbeat_at")
+  WHERE "status" = 'running';
+
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_entity_id"
+  ON "pipeline_runs" ("entity_id");
+
+-- Cross-reference with agent_sessions for the dashboard.
+CREATE INDEX IF NOT EXISTS "idx_pipeline_runs_agent_session"
+  ON "pipeline_runs" ("agent_session_id");
+
+-- Universal audit trigger (QUA-442).
+CALL apply_audit_trigger('pipeline_runs');

--- a/apps/wiki-server/drizzle/meta/_journal.json
+++ b/apps/wiki-server/drizzle/meta/_journal.json
@@ -1548,6 +1548,14 @@
       "when": 1787877200000,
       "tag": "0221_qua_956_policy_stakeholders_natural_key",
       "breakpoints": true
+    },
+    {
+      "idx": 222,
+      "version": "7",
+      "when": 1788000000000,
+      "tag": "0222_qua_954_pipeline_runs",
+      "breakpoints": true
     }
   ]
 }
+

--- a/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
+++ b/apps/wiki-server/src/__tests__/pipeline-runs.test.ts
@@ -1,0 +1,566 @@
+/**
+ * Server-side route tests for /api/pipeline-runs (QUA-954).
+ *
+ * Mocks Drizzle at the SQL dispatcher boundary (same pattern as
+ * auto-update-runs.test.ts) so the full Hono pipeline runs:
+ * Zod validation → transaction → applyAuditContext → DB write → JSON.
+ *
+ * Coverage:
+ *   - POST /            happy + 409 collision (TOCTOU-safe via onConflictDoNothing)
+ *                       + Zod validation (missing field, malformed runId, oversize payload)
+ *   - GET /             filter by status + pipelineName, count vs page-size
+ *   - GET /stats        aggregate shape
+ *   - GET /:id          drilldown happy + 404
+ *   - PATCH /:id/heartbeat  bumps + 404 on missing/finished + audit_skip
+ *   - PATCH /:id/end    success status, error_payload bound rejection,
+ *                       followups overwrite, 404
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import {
+  type SqlDispatcher,
+  mockDbModule,
+  postJson,
+} from "./test-utils";
+import type { pipelineRuns as pipelineRunsTable } from "../schema.js";
+
+type Row = typeof pipelineRunsTable.$inferSelect;
+
+// In-memory store. Reset before every test.
+let runStore: Row[] = [];
+
+// Track whether SET LOCAL app.audit_skip was issued in the current
+// transaction so the heartbeat audit-skip behaviour is asserted.
+let auditSkipSeen = false;
+
+function isoNow() {
+  return new Date();
+}
+
+function rowToSql(r: Row): Record<string, unknown> {
+  return {
+    run_id: r.runId,
+    agent_session_id: r.agentSessionId,
+    pipeline_name: r.pipelineName,
+    entity_id: r.entityId,
+    shape: r.shape,
+    status: r.status,
+    failure_reason: r.failureReason,
+    started_at: r.startedAt,
+    heartbeat_at: r.heartbeatAt,
+    ended_at: r.endedAt,
+    snapshot_path: r.snapshotPath,
+    error_code: r.errorCode,
+    error_payload: r.errorPayload,
+    followup_actions: r.followupActions,
+    created_at: r.createdAt,
+    updated_at: r.updatedAt,
+  };
+}
+
+// Best-effort SQL parser that pulls JSON values out of `params` when
+// Drizzle calls .unsafe(query, params). Drizzle binds JSONB params as
+// strings on the SQL side; the dispatcher receives the raw value.
+const dispatch: SqlDispatcher = (query, params) => {
+  const q = query.toLowerCase();
+
+
+
+  // Audit-context middleware writes via tx.execute(sql`...set_config...`).
+  if (q.includes("set_config('app.agent_session_id'")) {
+    return [];
+  }
+  // Heartbeat handler issues `SET LOCAL app.audit_skip = 'true'`.
+  if (q.includes("set local app.audit_skip")) {
+    auditSkipSeen = true;
+    return [];
+  }
+
+  // ---- INSERT INTO pipeline_runs ... ON CONFLICT DO NOTHING RETURNING ----
+  if (q.includes('insert into "pipeline_runs"')) {
+    // Parse the column list and the VALUES clause from the SQL —
+    // Drizzle interleaves `default` keywords with `$N` placeholders for
+    // unset columns, so we need to track which column index maps to
+    // which param index.
+    const colsMatch = query.match(/insert\s+into\s+"pipeline_runs"\s*\(([^)]+)\)/i);
+    if (!colsMatch) return [];
+    const cols = colsMatch[1]
+      .split(",")
+      .map((s) => s.trim().replace(/^"|"$/g, ""));
+    const valuesMatch = query.match(/values\s*\(([^)]+)\)/i);
+    if (!valuesMatch) return [];
+    const valueTokens = valuesMatch[1].split(",").map((s) => s.trim());
+
+    const colToCamel: Record<string, keyof Row> = {
+      run_id: "runId",
+      pipeline_name: "pipelineName",
+      agent_session_id: "agentSessionId",
+      entity_id: "entityId",
+      shape: "shape",
+      status: "status",
+      failure_reason: "failureReason",
+      started_at: "startedAt",
+      heartbeat_at: "heartbeatAt",
+      ended_at: "endedAt",
+      snapshot_path: "snapshotPath",
+      error_code: "errorCode",
+      error_payload: "errorPayload",
+      followup_actions: "followupActions",
+      created_at: "createdAt",
+      updated_at: "updatedAt",
+    };
+
+    const now = isoNow();
+    const row: Row = {
+      runId: "",
+      pipelineName: "",
+      agentSessionId: null,
+      entityId: null,
+      shape: null,
+      status: "running",
+      failureReason: null,
+      startedAt: now,
+      heartbeatAt: now,
+      endedAt: null,
+      snapshotPath: null,
+      errorCode: null,
+      errorPayload: null,
+      followupActions: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    cols.forEach((col, i) => {
+      const key = colToCamel[col];
+      if (!key) return;
+      const token = valueTokens[i];
+      if (!token || token === "default") return; // keep schema default
+      const placeholderMatch = token.match(/^\$(\d+)$/);
+      if (!placeholderMatch) return;
+      const paramIdx = Number(placeholderMatch[1]) - 1;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (row as any)[key] = params[paramIdx] ?? null;
+    });
+
+    if (runStore.some((r) => r.runId === row.runId)) {
+      return []; // ON CONFLICT DO NOTHING — empty returning
+    }
+    runStore.push(row);
+    return [rowToSql(row)];
+  }
+
+  // ---- UPDATE pipeline_runs SET heartbeat_at = $1, updated_at = $2 WHERE run_id = $3 AND status = $4 RETURNING ... ----
+  if (
+    q.startsWith('update "pipeline_runs"') &&
+    q.includes('"heartbeat_at"') &&
+    !q.includes('"ended_at"')
+  ) {
+    // Heartbeat update — params: [heartbeat_at, updated_at, run_id, status]
+    const newHeartbeat = params[0] as Date;
+    const newUpdated = params[1] as Date;
+    const runId = String(params[2]);
+    const requiredStatus = String(params[3]);
+    const row = runStore.find(
+      (r) => r.runId === runId && r.status === requiredStatus,
+    );
+    if (!row) return [];
+    row.heartbeatAt = newHeartbeat;
+    row.updatedAt = newUpdated;
+    return [{ run_id: row.runId, heartbeat_at: row.heartbeatAt }];
+  }
+
+  // ---- UPDATE pipeline_runs SET status, ended_at, ... WHERE run_id RETURNING * ----
+  if (q.startsWith('update "pipeline_runs"') && q.includes('"ended_at"')) {
+    // End-update. Drizzle emits SET clauses in a non-obvious order, so
+    // parse the SET column list out of the SQL and zip with params.
+    const setMatch = query.match(/set\s+(.+?)\s+where/is);
+    if (!setMatch) return [];
+    const setClause = setMatch[1];
+    const setColRe = /"(\w+)"\s*=\s*\$\d+/g;
+    const setCols: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = setColRe.exec(setClause))) setCols.push(m[1]);
+
+    // Last param is the WHERE run_id.
+    const runId = String(params[params.length - 1]);
+    const row = runStore.find((r) => r.runId === runId);
+    if (!row) return [];
+
+    const colToCamel: Record<string, keyof Row> = {
+      run_id: "runId",
+      pipeline_name: "pipelineName",
+      agent_session_id: "agentSessionId",
+      entity_id: "entityId",
+      shape: "shape",
+      status: "status",
+      failure_reason: "failureReason",
+      started_at: "startedAt",
+      heartbeat_at: "heartbeatAt",
+      ended_at: "endedAt",
+      snapshot_path: "snapshotPath",
+      error_code: "errorCode",
+      error_payload: "errorPayload",
+      followup_actions: "followupActions",
+      created_at: "createdAt",
+      updated_at: "updatedAt",
+    };
+    setCols.forEach((col, i) => {
+      const key = colToCamel[col];
+      if (!key) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (row as any)[key] = params[i] ?? null;
+    });
+    return [rowToSql(row)];
+  }
+
+  // ---- Plain SELECT FROM pipeline_runs (drilldown by run_id, or list) ----
+  if (q.startsWith('select') && q.includes('from "pipeline_runs"') && !q.includes("count(*)")) {
+    // Inspect the WHERE clause specifically (column list always references
+    // every column from .select()).
+    const whereMatch = q.match(/where\s+(.+?)(?:\s+order\s+by|\s+group\s+by|\s+limit|\s*$)/);
+    const whereClause = whereMatch ? whereMatch[1] : "";
+
+    // Drilldown: WHERE "run_id" = $1 LIMIT 1
+    if (whereClause.includes('"run_id"') && q.includes("limit")) {
+      const runId = String(params[0]);
+      const row = runStore.find((r) => r.runId === runId);
+      return row ? [rowToSql(row)] : [];
+    }
+
+    // List: optional WHERE on status / pipeline_name + LIMIT.
+    let rows = [...runStore];
+    let pIdx = 0;
+    if (whereClause.includes('"status"')) {
+      const statusVal = String(params[pIdx++]);
+      rows = rows.filter((r) => r.status === statusVal);
+    }
+    if (whereClause.includes('"pipeline_name"')) {
+      const nameVal = String(params[pIdx++]);
+      rows = rows.filter((r) => r.pipelineName === nameVal);
+    }
+    rows.sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime());
+    return rows.map(rowToSql);
+  }
+
+  if (q.startsWith('select') && q.includes('from "pipeline_runs"') && q.includes("count(*)")) {
+    let rows = [...runStore];
+    {
+      // group-by: stats aggregate. The simpler thing is to bucket by status.
+      // Three queries fire from /stats: by status, by pipeline+status, by failure_reason.
+      // Heuristic: detect group-by columns from the query.
+      if (q.includes('group by "status"') && !q.includes('"pipeline_name"')) {
+        const counts = new Map<string, number>();
+        for (const r of rows) counts.set(r.status, (counts.get(r.status) ?? 0) + 1);
+        return [...counts.entries()].map(([status, count]) => ({ status, count }));
+      }
+      if (q.includes('group by "pipeline_name"')) {
+        const counts = new Map<string, number>();
+        for (const r of rows) {
+          const k = `${r.pipelineName}|${r.status}`;
+          counts.set(k, (counts.get(k) ?? 0) + 1);
+        }
+        return [...counts.entries()].map(([k, count]) => {
+          const [pipeline_name, status] = k.split("|");
+          return { pipeline_name, status, count };
+        });
+      }
+      if (q.includes('"failure_reason"')) {
+        const counts = new Map<string, number>();
+        for (const r of rows) {
+          if (r.failureReason)
+            counts.set(r.failureReason, (counts.get(r.failureReason) ?? 0) + 1);
+        }
+        return [...counts.entries()].map(([failure_reason, count]) => ({
+          failure_reason,
+          count,
+        }));
+      }
+    }
+
+    return [];
+  }
+
+  return [];
+};
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+// Now import the route module — must be after vi.mock.
+const { pipelineRunsRoute } = await import("../routes/operational/pipeline-runs.js");
+const { auditContextMiddleware } = await import("../middleware/audit-context.js");
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use("*", auditContextMiddleware());
+  app.route("/api/pipeline-runs", pipelineRunsRoute);
+  return app;
+}
+
+beforeEach(() => {
+  runStore = [];
+  auditSkipSeen = false;
+});
+
+describe("POST /api/pipeline-runs", () => {
+  it("creates a running row with caller-minted runId", async () => {
+    const app = buildApp();
+    const res = await postJson(app, "/api/pipeline-runs", {
+      runId: "run-test-001",
+      pipelineName: "improve-page",
+      entityId: "E42",
+      shape: "standard",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runId).toBe("run-test-001");
+    expect(body.status).toBe("running");
+    expect(body.pipelineName).toBe("improve-page");
+    expect(runStore.length).toBe(1);
+  });
+
+  it("returns 409 on runId collision (atomic via ON CONFLICT)", async () => {
+    const app = buildApp();
+    const r1 = await postJson(app, "/api/pipeline-runs", {
+      runId: "duplicate-id",
+      pipelineName: "improve-page",
+    });
+    expect(r1.status).toBe(201);
+    const r2 = await postJson(app, "/api/pipeline-runs", {
+      runId: "duplicate-id",
+      pipelineName: "improve-page",
+    });
+    expect(r2.status).toBe(409);
+    const body = (await r2.json()) as Record<string, unknown>;
+    expect(body.error).toBe("conflict");
+  });
+
+  it("rejects malformed runId (whitespace, special chars)", async () => {
+    const app = buildApp();
+    const r1 = await postJson(app, "/api/pipeline-runs", {
+      runId: "has whitespace",
+      pipelineName: "improve-page",
+    });
+    expect(r1.status).toBe(400);
+
+    const r2 = await postJson(app, "/api/pipeline-runs", {
+      runId: "<script>",
+      pipelineName: "improve-page",
+    });
+    expect(r2.status).toBe(400);
+
+    const r3 = await postJson(app, "/api/pipeline-runs", {
+      runId: "with\nnewline",
+      pipelineName: "improve-page",
+    });
+    expect(r3.status).toBe(400);
+
+    expect(runStore.length).toBe(0);
+  });
+
+  it("rejects missing required fields", async () => {
+    const app = buildApp();
+    const r = await postJson(app, "/api/pipeline-runs", {
+      pipelineName: "improve-page",
+      // missing runId
+    });
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/pipeline-runs/:id/heartbeat", () => {
+  it("bumps heartbeat_at on a running run + sets app.audit_skip", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "hb-001",
+      pipelineName: "improve-page",
+    });
+
+    expect(auditSkipSeen).toBe(false);
+    const res = await app.request("/api/pipeline-runs/hb-001/heartbeat", {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.runId).toBe("hb-001");
+    // The handler MUST issue SET LOCAL app.audit_skip — heartbeats
+    // would otherwise spam the universal audit log.
+    expect(auditSkipSeen).toBe(true);
+  });
+
+  it("returns 404 when the run id is unknown", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/pipeline-runs/never-existed/heartbeat", {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the run is no longer running (already ended)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "ended-001",
+      pipelineName: "improve-page",
+    });
+    // Manually flip status (simulate /end having run).
+    runStore[0].status = "committed";
+
+    const res = await app.request("/api/pipeline-runs/ended-001/heartbeat", {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/pipeline-runs/:id/end", () => {
+  it("sets status, ended_at, error fields, and 200s", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "end-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/end-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "aborted",
+        failureReason: "phase2_abort",
+        errorCode: "TypeError",
+        errorPayload: { message: "boom", stack: "..." },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("aborted");
+    expect(body.failureReason).toBe("phase2_abort");
+    expect(body.errorCode).toBe("TypeError");
+    expect(body.endedAt).toBeTruthy();
+  });
+
+  it("rejects oversize errorPayload (>32 KiB serialized)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "huge-001",
+      pipelineName: "improve-page",
+    });
+
+    // Build a payload that serializes to > 32 KiB.
+    const huge = "x".repeat(40_000);
+    const res = await app.request("/api/pipeline-runs/huge-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        status: "aborted",
+        errorPayload: { dump: huge },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects > 50 followupActions", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "many-001",
+      pipelineName: "improve-page",
+    });
+
+    const followups = Array.from({ length: 51 }, (_, i) => ({ kind: "retry", attempt: i }));
+    const res = await app.request("/api/pipeline-runs/many-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed", followupActions: followups }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid status enum value", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "bad-status-001",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs/bad-status-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "completed" }), // not an end status
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the run id is unknown", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/pipeline-runs/missing-001/end", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "committed" }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/pipeline-runs", () => {
+  it("returns recent runs, ordered desc, with `count` (page size, not total)", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "list-001",
+      pipelineName: "improve-page",
+    });
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "list-002",
+      pipelineName: "improve-page",
+    });
+
+    const res = await app.request("/api/pipeline-runs");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect((body.runs as unknown[]).length).toBe(2);
+    // Renamed from `total` (which was misleading — it was the page size,
+    // not the total matching rows).
+    expect(body.count).toBe(2);
+    expect(body.total).toBeUndefined();
+  });
+
+  it("filters by pipelineName", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "filt-001",
+      pipelineName: "improve-page",
+    });
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "filt-002",
+      pipelineName: "source-check",
+    });
+
+    const res = await app.request("/api/pipeline-runs?pipelineName=improve-page");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { runs: Row[]; count: number };
+    expect(body.count).toBe(1);
+    expect(body.runs[0].runId).toBe("filt-001");
+  });
+});
+
+describe("GET /api/pipeline-runs/:id", () => {
+  it("drills into one run by id", async () => {
+    const app = buildApp();
+    await postJson(app, "/api/pipeline-runs", {
+      runId: "drill-001",
+      pipelineName: "improve-page",
+      entityId: "E42",
+    });
+
+    const res = await app.request("/api/pipeline-runs/drill-001");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.runId).toBe("drill-001");
+    expect(body.entityId).toBe("E42");
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/pipeline-runs/never-existed");
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/wiki-server/src/api-response-types.ts
+++ b/apps/wiki-server/src/api-response-types.ts
@@ -30,6 +30,7 @@ import type { ArtifactsRoute } from './routes/operational/artifacts.js';
 import type { AutoUpdateRunsRoute } from './routes/operational/auto-update-runs.js';
 import type { AutoUpdateNewsRoute } from './routes/operational/auto-update-news.js';
 import type { GroundskeeperRunsRoute } from './routes/operational/groundskeeper-runs.js';
+import type { PipelineRunsRoute } from './routes/operational/pipeline-runs.js';
 import type { MonitoringRoute } from './routes/operational/monitoring.js';
 import type { GithubPullsRoute } from './routes/operational/github-pulls.js';
 import type { BuildMetricsRoute } from './routes/operational/build-metrics.js';
@@ -53,6 +54,7 @@ type FactsRpc = ReturnType<typeof hc<FactsRoute>>;
 type EntitiesRpc = ReturnType<typeof hc<EntitiesRoute>>;
 type PagesRpc = ReturnType<typeof hc<PagesRoute>>;
 type GroundskeeperRunsRpc = ReturnType<typeof hc<GroundskeeperRunsRoute>>;
+type PipelineRunsRpc = ReturnType<typeof hc<PipelineRunsRoute>>;
 type MonitoringRpc = ReturnType<typeof hc<MonitoringRoute>>;
 type GithubPullsRpc = ReturnType<typeof hc<GithubPullsRoute>>;
 type BuildMetricsRpc = ReturnType<typeof hc<BuildMetricsRoute>>;
@@ -262,6 +264,31 @@ export type GroundskeeperRunRow = GroundskeeperRunsListResult['runs'][number];
 
 /** Groundskeeper stats response. */
 export type GroundskeeperStatsResult = InferResponseType<GroundskeeperRunsRpc['stats']['$get'], 200>;
+
+// ---------------------------------------------------------------------------
+// Pipeline Runs (QUA-954)
+// ---------------------------------------------------------------------------
+
+/** Pipeline runs list response. */
+type PipelineRunsListResult = InferResponseType<PipelineRunsRpc['index']['$get'], 200>;
+
+/** A single pipeline run row. */
+export type PipelineRunRow = PipelineRunsListResult['runs'][number];
+
+/** Pipeline run created on POST /. */
+export type PipelineRunCreated = InferResponseType<PipelineRunsRpc['index']['$post'], 201>;
+
+/** Pipeline run heartbeat response. */
+export type PipelineRunHeartbeatResult = InferResponseType<
+  PipelineRunsRpc[':id']['heartbeat']['$patch'],
+  200
+>;
+
+/** Pipeline run end response. */
+export type PipelineRunEndResult = InferResponseType<PipelineRunsRpc[':id']['end']['$patch'], 200>;
+
+/** Pipeline run aggregate stats. */
+export type PipelineRunsStatsResult = InferResponseType<PipelineRunsRpc['stats']['$get'], 200>;
 
 // ---------------------------------------------------------------------------
 // Monitoring / System Health

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1570,11 +1570,46 @@ export const VALID_PIPELINE_RUN_END_STATUSES = [
 export const PipelineRunEndStatusSchema = z.enum(VALID_PIPELINE_RUN_END_STATUSES);
 export type PipelineRunEndStatus = z.infer<typeof PipelineRunEndStatusSchema>;
 
+// Format constraint: alphanumeric + dash + underscore only. Matches
+// nanoid / uuid v4 / hex tokens but rejects whitespace, control chars,
+// and JSON/SQL/HTML injection vectors slipping through `.max(128)`.
+const PIPELINE_RUN_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+// Cap structured payload size — `errorPayload` and `followupActions`
+// are JSONB columns and a buggy or malicious caller could otherwise
+// post a 100MB blob, blowing up audit log row size and dashboard
+// rendering. Bounds on the JSON-serialized form are checked via a
+// Zod refinement; the array also has an item count cap.
+const MAX_ERROR_PAYLOAD_BYTES = 32_768; // 32 KiB
+const MAX_FOLLOWUPS_COUNT = 50;
+const MAX_FOLLOWUP_BYTES = 4_096; // per item
+
+function jsonByteSize(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    // Circular or non-serializable — reject as oversize.
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+const BoundedJsonObjectSchema = z
+  .record(z.unknown())
+  .refine((v) => jsonByteSize(v) <= MAX_ERROR_PAYLOAD_BYTES, {
+    message: `errorPayload must serialize to <= ${MAX_ERROR_PAYLOAD_BYTES} bytes`,
+  });
+
+const BoundedFollowupSchema = z
+  .record(z.unknown())
+  .refine((v) => jsonByteSize(v) <= MAX_FOLLOWUP_BYTES, {
+    message: `followupActions item must serialize to <= ${MAX_FOLLOWUP_BYTES} bytes`,
+  });
+
 export const StartPipelineRunSchema = z.object({
   // The caller mints the run_id (typically nanoid/uuid v4 from
   // crux/lib/pipeline-runs/lifecycle.ts) so the helper can return it
   // synchronously without waiting for the server response.
-  runId: z.string().min(1).max(128),
+  runId: z.string().min(1).max(128).regex(PIPELINE_RUN_ID_RE),
   pipelineName: z.string().min(1).max(200),
   agentSessionId: z.number().int().positive().nullable().optional(),
   entityId: z.string().max(200).nullable().optional(),
@@ -1586,9 +1621,9 @@ export const EndPipelineRunSchema = z.object({
   status: PipelineRunEndStatusSchema,
   failureReason: z.string().max(200).nullable().optional(),
   errorCode: z.string().max(200).nullable().optional(),
-  errorPayload: z.record(z.unknown()).nullable().optional(),
+  errorPayload: BoundedJsonObjectSchema.nullable().optional(),
   snapshotPath: z.string().max(500).nullable().optional(),
-  followupActions: z.array(z.record(z.unknown())).optional(),
+  followupActions: z.array(BoundedFollowupSchema).max(MAX_FOLLOWUPS_COUNT).optional(),
 });
 export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
 

--- a/apps/wiki-server/src/api-types.ts
+++ b/apps/wiki-server/src/api-types.ts
@@ -1540,6 +1540,59 @@ export const RecordGroundskeeperRunBatchSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Pipeline Runs (QUA-954)
+// ---------------------------------------------------------------------------
+
+/**
+ * v1 status enum. Mirrors the CHECK constraint on `pipeline_runs.status`.
+ * Widening requires a follow-up migration that enumerates prod row
+ * distribution first — see `.claude/rules/database-migrations.md`.
+ */
+export const VALID_PIPELINE_RUN_STATUSES = [
+  "running",
+  "committed",
+  "aborted",
+  "oscillation",
+  "partial_failure",
+] as const;
+
+export const PipelineRunStatusSchema = z.enum(VALID_PIPELINE_RUN_STATUSES);
+export type PipelineRunStatus = z.infer<typeof PipelineRunStatusSchema>;
+
+/** End-state set: the four statuses callers may move to from `running`. */
+export const VALID_PIPELINE_RUN_END_STATUSES = [
+  "committed",
+  "aborted",
+  "oscillation",
+  "partial_failure",
+] as const;
+
+export const PipelineRunEndStatusSchema = z.enum(VALID_PIPELINE_RUN_END_STATUSES);
+export type PipelineRunEndStatus = z.infer<typeof PipelineRunEndStatusSchema>;
+
+export const StartPipelineRunSchema = z.object({
+  // The caller mints the run_id (typically nanoid/uuid v4 from
+  // crux/lib/pipeline-runs/lifecycle.ts) so the helper can return it
+  // synchronously without waiting for the server response.
+  runId: z.string().min(1).max(128),
+  pipelineName: z.string().min(1).max(200),
+  agentSessionId: z.number().int().positive().nullable().optional(),
+  entityId: z.string().max(200).nullable().optional(),
+  shape: z.string().max(100).nullable().optional(),
+});
+export type StartPipelineRun = z.infer<typeof StartPipelineRunSchema>;
+
+export const EndPipelineRunSchema = z.object({
+  status: PipelineRunEndStatusSchema,
+  failureReason: z.string().max(200).nullable().optional(),
+  errorCode: z.string().max(200).nullable().optional(),
+  errorPayload: z.record(z.unknown()).nullable().optional(),
+  snapshotPath: z.string().max(500).nullable().optional(),
+  followupActions: z.array(z.record(z.unknown())).optional(),
+});
+export type EndPipelineRun = z.infer<typeof EndPipelineRunSchema>;
+
+// ---------------------------------------------------------------------------
 // Monitoring / Incident Tracking
 // ---------------------------------------------------------------------------
 

--- a/apps/wiki-server/src/app.ts
+++ b/apps/wiki-server/src/app.ts
@@ -58,6 +58,7 @@ import { integrityRoute } from "./routes/operational/integrity.js";
 import { autoUpdateRunsRoute } from "./routes/operational/auto-update-runs.js";
 import { autoUpdateNewsRoute } from "./routes/operational/auto-update-news.js";
 import { groundskeeperRunsRoute } from "./routes/operational/groundskeeper-runs.js";
+import { pipelineRunsRoute } from "./routes/operational/pipeline-runs.js";
 import { githubIssuesRoute } from "./routes/operational/github-issues.js";
 import { githubPullsRoute } from "./routes/operational/github-pulls.js";
 import { monitoringRoute } from "./routes/operational/monitoring.js";
@@ -247,6 +248,7 @@ export function createApp() {
   app.route("/api/github/issues", githubIssuesRoute);
   app.route("/api/github/pulls", githubPullsRoute);
   app.route("/api/groundskeeper-runs", groundskeeperRunsRoute);
+  app.route("/api/pipeline-runs", pipelineRunsRoute);
   app.route("/api/monitoring", monitoringRoute);
   app.route("/api/build-metrics", buildMetricsRoute);
   app.route("/api/qa-checks", qaChecksRoute);

--- a/apps/wiki-server/src/routes/operational/pipeline-runs.ts
+++ b/apps/wiki-server/src/routes/operational/pipeline-runs.ts
@@ -34,6 +34,7 @@ import {
   EndPipelineRunSchema,
   PipelineRunStatusSchema,
 } from "../../api-types.js";
+import { applyAuditContext } from "../../middleware/audit-context.js";
 
 const ListRunsQuery = z.object({
   status: PipelineRunStatusSchema.optional(),
@@ -43,6 +44,12 @@ const ListRunsQuery = z.object({
 
 const pipelineRunsApp = new Hono()
   // ---- POST / (start a run) ----
+  //
+  // Caller-minted runId: collision yields 409 atomically via
+  // INSERT ... ON CONFLICT DO NOTHING. The previous SELECT-then-INSERT
+  // pattern was a TOCTOU race — two concurrent POSTs with the same
+  // runId would both pass the SELECT and both attempt INSERT, with
+  // the second crashing on PK violation as 500 instead of 409.
   .post("/", async (c) => {
     const body = await parseJsonBody(c);
     if (!body) return invalidJsonError(c);
@@ -53,32 +60,31 @@ const pipelineRunsApp = new Hono()
     const d = parsed.data;
     const db = getDrizzleDb();
 
-    // Caller-minted run_id: if they collide they get 409, not a corrupt
-    // overwrite. Pipelines should always mint a unique id (nanoid/uuid)
-    // so this is a defensive guard, not a happy-path branch.
-    const existing = await db
-      .select({ runId: pipelineRuns.runId })
-      .from(pipelineRuns)
-      .where(eq(pipelineRuns.runId, d.runId))
-      .limit(1);
-    if (existing.length > 0) {
+    const inserted = await db.transaction(async (tx) => {
+      // QUA-442 audit attribution — without this, every pipeline_runs
+      // row would land in full_audit_log with NULL session/tool, breaking
+      // the cross-table audit join the migration header advertises.
+      await applyAuditContext(tx, c);
+      return tx
+        .insert(pipelineRuns)
+        .values({
+          runId: d.runId,
+          pipelineName: d.pipelineName,
+          agentSessionId: d.agentSessionId ?? null,
+          entityId: d.entityId ?? null,
+          shape: d.shape ?? null,
+          status: "running",
+        })
+        .onConflictDoNothing({ target: pipelineRuns.runId })
+        .returning();
+    });
+
+    if (inserted.length === 0) {
       return c.json(
         { error: "conflict", message: `Pipeline run already exists: ${d.runId}` },
         409,
       );
     }
-
-    const inserted = await db
-      .insert(pipelineRuns)
-      .values({
-        runId: d.runId,
-        pipelineName: d.pipelineName,
-        agentSessionId: d.agentSessionId ?? null,
-        entityId: d.entityId ?? null,
-        shape: d.shape ?? null,
-        status: "running",
-      })
-      .returning();
 
     return c.json(firstOrThrow(inserted, "pipeline run insert"), 201);
   })
@@ -102,7 +108,10 @@ const pipelineRunsApp = new Hono()
       .orderBy(desc(pipelineRuns.startedAt))
       .limit(limit);
 
-    return c.json({ runs: rows, total: rows.length });
+    // `count` is the page size, NOT a total-row count for the filter.
+    // Renaming from `total` to avoid the misleading "looks like a total
+    // matching rows" interpretation flagged in QUA-954 review.
+    return c.json({ runs: rows, count: rows.length });
   })
 
   // ---- GET /stats (aggregate by status + pipeline) ----
@@ -225,25 +234,30 @@ const pipelineRunsApp = new Hono()
     const db = getDrizzleDb();
     const now = new Date();
 
-    const updated = await db
-      .update(pipelineRuns)
-      .set({
-        status: d.status,
-        endedAt: now,
-        updatedAt: now,
-        failureReason: d.failureReason ?? null,
-        errorCode: d.errorCode ?? null,
-        errorPayload: d.errorPayload ?? null,
-        snapshotPath: d.snapshotPath ?? null,
-        // Only overwrite followup_actions when the caller passed them
-        // explicitly; otherwise preserve whatever was set in flight
-        // (default '[]' from insert).
-        ...(d.followupActions !== undefined
-          ? { followupActions: d.followupActions }
-          : {}),
-      })
-      .where(eq(pipelineRuns.runId, id))
-      .returning();
+    const updated = await db.transaction(async (tx) => {
+      // QUA-442 audit attribution — end-state writes (status, error_*)
+      // are durable history and must be attributed.
+      await applyAuditContext(tx, c);
+      return tx
+        .update(pipelineRuns)
+        .set({
+          status: d.status,
+          endedAt: now,
+          updatedAt: now,
+          failureReason: d.failureReason ?? null,
+          errorCode: d.errorCode ?? null,
+          errorPayload: d.errorPayload ?? null,
+          snapshotPath: d.snapshotPath ?? null,
+          // Only overwrite followup_actions when the caller passed them
+          // explicitly; otherwise preserve whatever was set in flight
+          // (default '[]' from insert).
+          ...(d.followupActions !== undefined
+            ? { followupActions: d.followupActions }
+            : {}),
+        })
+        .where(eq(pipelineRuns.runId, id))
+        .returning();
+    });
 
     if (updated.length === 0) {
       return notFoundError(c, `No pipeline run with id: ${id}`);

--- a/apps/wiki-server/src/routes/operational/pipeline-runs.ts
+++ b/apps/wiki-server/src/routes/operational/pipeline-runs.ts
@@ -1,0 +1,256 @@
+/**
+ * Pipeline Runs API (QUA-954, parent QUA-943).
+ *
+ * Three-endpoint surface for the `withPipelineRun` lifecycle helper:
+ *   - POST   /          — start a run
+ *   - PATCH  /:id/heartbeat — bump heartbeat_at while running
+ *   - PATCH  /:id/end   — set status / ended_at / error_* / followup_actions
+ *
+ * Plus two read endpoints for the /internal/pipeline-runs dashboard:
+ *   - GET    /          — list runs (filter by status, pipeline_name)
+ *   - GET    /stats     — aggregate by status + pipeline_name (last 24h)
+ *
+ * Hand-rolled (not factory-mounted) — the surface is small and the write
+ * shape doesn't fit the `/sync` factory's "batch upsert + things sync"
+ * contract.
+ */
+
+import { Hono } from "hono";
+import { eq, desc, and, sql, gte } from "drizzle-orm";
+import { z } from "zod";
+import { getDrizzleDb } from "../../db.js";
+import { pipelineRuns } from "../../schema.js";
+import {
+  parseJsonBody,
+  validationError,
+  invalidJsonError,
+  firstOrThrow,
+  clampedLimit,
+  notFoundError,
+  zv,
+} from "../shared/utils.js";
+import {
+  StartPipelineRunSchema,
+  EndPipelineRunSchema,
+  PipelineRunStatusSchema,
+} from "../../api-types.js";
+
+const ListRunsQuery = z.object({
+  status: PipelineRunStatusSchema.optional(),
+  pipelineName: z.string().min(1).max(200).optional(),
+  limit: clampedLimit(500, 100),
+});
+
+const pipelineRunsApp = new Hono()
+  // ---- POST / (start a run) ----
+  .post("/", async (c) => {
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = StartPipelineRunSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const d = parsed.data;
+    const db = getDrizzleDb();
+
+    // Caller-minted run_id: if they collide they get 409, not a corrupt
+    // overwrite. Pipelines should always mint a unique id (nanoid/uuid)
+    // so this is a defensive guard, not a happy-path branch.
+    const existing = await db
+      .select({ runId: pipelineRuns.runId })
+      .from(pipelineRuns)
+      .where(eq(pipelineRuns.runId, d.runId))
+      .limit(1);
+    if (existing.length > 0) {
+      return c.json(
+        { error: "conflict", message: `Pipeline run already exists: ${d.runId}` },
+        409,
+      );
+    }
+
+    const inserted = await db
+      .insert(pipelineRuns)
+      .values({
+        runId: d.runId,
+        pipelineName: d.pipelineName,
+        agentSessionId: d.agentSessionId ?? null,
+        entityId: d.entityId ?? null,
+        shape: d.shape ?? null,
+        status: "running",
+      })
+      .returning();
+
+    return c.json(firstOrThrow(inserted, "pipeline run insert"), 201);
+  })
+
+  // ---- GET / (list runs) ----
+  .get("/", zv("query", ListRunsQuery), async (c) => {
+    const { status, pipelineName, limit } = c.req.valid("query");
+    const db = getDrizzleDb();
+
+    const conditions = [
+      status ? eq(pipelineRuns.status, status) : undefined,
+      pipelineName ? eq(pipelineRuns.pipelineName, pipelineName) : undefined,
+    ].filter((x): x is NonNullable<typeof x> => x !== undefined);
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const rows = await db
+      .select()
+      .from(pipelineRuns)
+      .where(where)
+      .orderBy(desc(pipelineRuns.startedAt))
+      .limit(limit);
+
+    return c.json({ runs: rows, total: rows.length });
+  })
+
+  // ---- GET /stats (aggregate by status + pipeline) ----
+  .get("/stats", async (c) => {
+    const db = getDrizzleDb();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const byStatusRows = await db
+      .select({
+        status: pipelineRuns.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(pipelineRuns)
+      .where(gte(pipelineRuns.startedAt, since))
+      .groupBy(pipelineRuns.status);
+
+    const byPipelineRows = await db
+      .select({
+        pipelineName: pipelineRuns.pipelineName,
+        status: pipelineRuns.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(pipelineRuns)
+      .where(gte(pipelineRuns.startedAt, since))
+      .groupBy(pipelineRuns.pipelineName, pipelineRuns.status);
+
+    const byFailureReasonRows = await db
+      .select({
+        failureReason: pipelineRuns.failureReason,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(pipelineRuns)
+      .where(
+        and(
+          gte(pipelineRuns.startedAt, since),
+          sql`${pipelineRuns.failureReason} IS NOT NULL`,
+        ),
+      )
+      .groupBy(pipelineRuns.failureReason);
+
+    return c.json({
+      since: since.toISOString(),
+      byStatus: byStatusRows,
+      byPipeline: byPipelineRows,
+      byFailureReason: byFailureReasonRows,
+    });
+  })
+
+  // ---- GET /:id (drilldown) ----
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Missing run id");
+
+    const db = getDrizzleDb();
+    const rows = await db
+      .select()
+      .from(pipelineRuns)
+      .where(eq(pipelineRuns.runId, id))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return notFoundError(c, `No pipeline run with id: ${id}`);
+    }
+
+    return c.json(rows[0]);
+  })
+
+  // ---- PATCH /:id/heartbeat (bump heartbeat_at) ----
+  //
+  // Audit-skipped per QUA-954 red-team finding #1: a 30-min run produces
+  // ~60 heartbeats × 1 audit row each = ~60 rows of audit log per run.
+  // Multiplied by ~700 entities/night that would be ~42K spurious audit
+  // rows daily. Heartbeats are not durable history — start, end, and
+  // status changes still write to the audit log. See
+  // `.claude/rules/audit-log.md` § "Bulk backfills — skip the universal
+  // audit trigger" for the same mechanism on bulk migrations.
+  .patch("/:id/heartbeat", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Missing run id");
+
+    const db = getDrizzleDb();
+    const now = new Date();
+    const updated = await db.transaction(async (tx) => {
+      // SET LOCAL is scoped to the transaction so it never leaks into
+      // other writes on this pooled connection.
+      await tx.execute(sql`SET LOCAL app.audit_skip = 'true'`);
+      return tx
+        .update(pipelineRuns)
+        .set({ heartbeatAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(pipelineRuns.runId, id),
+            // Defensive: only bump heartbeat for running rows. A late
+            // heartbeat after `end` shouldn't reanimate a finished run.
+            eq(pipelineRuns.status, "running"),
+          ),
+        )
+        .returning({ runId: pipelineRuns.runId, heartbeatAt: pipelineRuns.heartbeatAt });
+    });
+
+    if (updated.length === 0) {
+      return notFoundError(c, `No running pipeline run with id: ${id}`);
+    }
+
+    return c.json({ ok: true, runId: id, heartbeatAt: updated[0].heartbeatAt });
+  })
+
+  // ---- PATCH /:id/end (mark run finished) ----
+  .patch("/:id/end", async (c) => {
+    const id = c.req.param("id");
+    if (!id) return validationError(c, "Missing run id");
+
+    const body = await parseJsonBody(c);
+    if (!body) return invalidJsonError(c);
+
+    const parsed = EndPipelineRunSchema.safeParse(body);
+    if (!parsed.success) return validationError(c, parsed.error.message);
+
+    const d = parsed.data;
+    const db = getDrizzleDb();
+    const now = new Date();
+
+    const updated = await db
+      .update(pipelineRuns)
+      .set({
+        status: d.status,
+        endedAt: now,
+        updatedAt: now,
+        failureReason: d.failureReason ?? null,
+        errorCode: d.errorCode ?? null,
+        errorPayload: d.errorPayload ?? null,
+        snapshotPath: d.snapshotPath ?? null,
+        // Only overwrite followup_actions when the caller passed them
+        // explicitly; otherwise preserve whatever was set in flight
+        // (default '[]' from insert).
+        ...(d.followupActions !== undefined
+          ? { followupActions: d.followupActions }
+          : {}),
+      })
+      .where(eq(pipelineRuns.runId, id))
+      .returning();
+
+    if (updated.length === 0) {
+      return notFoundError(c, `No pipeline run with id: ${id}`);
+    }
+
+    return c.json(updated[0]);
+  });
+
+export const pipelineRunsRoute = pipelineRunsApp;
+export type PipelineRunsRoute = typeof pipelineRunsApp;

--- a/apps/wiki-server/src/schema.ts
+++ b/apps/wiki-server/src/schema.ts
@@ -1424,6 +1424,66 @@ export const groundskeeperRuns = pgTable(
   ]
 );
 
+/**
+ * Pipeline runs (QUA-954) — per-run lifecycle tracking for generation /
+ * improve / sourcing pipelines.
+ *
+ * Phase 0d of QUA-943: additive table. Wired by `withPipelineRun()` in
+ * crux/lib/pipeline-runs/lifecycle.ts. No production caller until
+ * Phase 1 (QUA-957).
+ *
+ * `agent_session_id` joins to `agent_sessions.id` (bigserial) so
+ * dashboards can correlate pipeline lifecycle with the originating
+ * agent session.
+ *
+ * `status` is CHECK-constrained to the v1 enum (running / committed /
+ * aborted / oscillation / partial_failure). Widening requires the
+ * enum-enumeration procedure in `.claude/rules/database-migrations.md`.
+ */
+export const pipelineRuns = pgTable(
+  "pipeline_runs",
+  {
+    runId: text("run_id").primaryKey(),
+    agentSessionId: bigint("agent_session_id", { mode: "number" })
+      .references(() => agentSessions.id, { onDelete: "set null" }),
+    pipelineName: text("pipeline_name").notNull(),
+    entityId: text("entity_id"),
+    shape: text("shape"),
+    status: text("status").notNull(),
+    failureReason: text("failure_reason"),
+    startedAt: timestamp("started_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    heartbeatAt: timestamp("heartbeat_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    endedAt: timestamp("ended_at", { withTimezone: true }),
+    snapshotPath: text("snapshot_path"),
+    errorCode: text("error_code"),
+    errorPayload: jsonb("error_payload").$type<Record<string, unknown>>(),
+    followupActions: jsonb("followup_actions")
+      .$type<Array<Record<string, unknown>>>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_pipeline_runs_pipeline_name").on(table.pipelineName),
+    index("idx_pipeline_runs_status").on(table.status),
+    index("idx_pipeline_runs_started_at").on(table.startedAt),
+    index("idx_pipeline_runs_running_heartbeat")
+      .on(table.heartbeatAt)
+      .where(sql`${table.status} = 'running'`),
+    index("idx_pipeline_runs_entity_id").on(table.entityId),
+    index("idx_pipeline_runs_agent_session").on(table.agentSessionId),
+  ]
+);
+
 export const serviceHealthIncidents = pgTable(
   "service_health_incidents",
   {

--- a/content/docs/internal/pipeline-runs-dashboard.mdx
+++ b/content/docs/internal/pipeline-runs-dashboard.mdx
@@ -1,0 +1,12 @@
+---
+wikiId: E2545
+title: "Pipeline Runs"
+description: "Per-run lifecycle history for generation / improve / sourcing pipelines — live status, failure-reason breakdown, drilldown by run id"
+subcategory: dashboards
+contentFormat: dashboard
+lastEdited: "2026-04-30"
+---
+
+Per-run lifecycle for pipeline executions wrapped by `withPipelineRun()` (QUA-954). Each row is one pipeline invocation: when it started, whether it committed cleanly, aborted, oscillated, or partial-failed, and the failure reason if any. Use this to spot recurring failure modes, stuck runs, or oscillations across the wiki's generation pipelines.
+
+<PipelineRunsContent />

--- a/crux/lib/pipeline-runs/lifecycle.test.ts
+++ b/crux/lib/pipeline-runs/lifecycle.test.ts
@@ -337,5 +337,32 @@ describe('withPipelineRun', () => {
         expect.stringContaining('/end failed'),
       );
     });
+
+    it('rethrows the body error even if /end itself throws (review fix)', async () => {
+      // Regression for the QUA-954 hostile-review finding: if `finalize`
+      // throws (or, here, /end fails AND endPipelineRun rejects), the
+      // body's original exception must still reach the caller. Previously
+      // a rejected /end would mask the body's TypeError with the network
+      // error, which is exactly the situation where the original error
+      // matters most for debugging.
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockRejectedValue(new Error('network down'));
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const original = new TypeError('the actual bug');
+      await expect(
+        withPipelineRun(
+          { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+          async () => {
+            throw original;
+          },
+        ),
+      ).rejects.toBe(original);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('finalize threw after body abort'),
+      );
+    });
   });
 });

--- a/crux/lib/pipeline-runs/lifecycle.test.ts
+++ b/crux/lib/pipeline-runs/lifecycle.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Unit tests for withPipelineRun (QUA-954).
+ *
+ * Acceptance coverage:
+ *   - success path → status=committed
+ *   - body throws → re-throw + status=aborted with errorPayload
+ *   - body markStatus override (partial_failure) wins over default
+ *   - heartbeat fires every interval while body runs
+ *   - /start fail → throw by default; allowOffline returns no-op runCtx
+ *   - /end fail → caller still receives body's value/exception
+ *
+ * Mocks at the wiki-server client boundary so we don't need a real
+ * server.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockStart = vi.fn();
+const mockHeartbeat = vi.fn();
+const mockEnd = vi.fn();
+
+vi.mock('../wiki-server/pipeline-runs.ts', () => ({
+  startPipelineRun: (...args: unknown[]) => mockStart(...args),
+  heartbeatPipelineRun: (...args: unknown[]) => mockHeartbeat(...args),
+  endPipelineRun: (...args: unknown[]) => mockEnd(...args),
+}));
+
+// Suppress console output during tests — withPipelineRun warn()/error()
+// helpers go through console directly. We assert on mock call counts.
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('withPipelineRun', () => {
+  beforeEach(() => {
+    mockStart.mockReset();
+    mockHeartbeat.mockReset();
+    mockEnd.mockReset();
+    consoleWarnSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('success path', () => {
+    it('starts → runs body → ends with status=committed', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: { runId: 'mocked' } });
+      mockEnd.mockResolvedValue({ ok: true, data: { runId: 'mocked' } });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const result = await withPipelineRun(
+        {
+          pipelineName: 'improve-page',
+          entityId: 'E42',
+          shape: 'standard',
+          // Disable heartbeat for this specific test so we don't need to
+          // advance fake timers.
+          heartbeatIntervalMs: 1_000_000_000,
+        },
+        async (ctx) => {
+          expect(ctx.runId).toBeTruthy();
+          expect(ctx.offline).toBe(false);
+          return { rows: 3 };
+        },
+      );
+
+      expect(result).toEqual({ rows: 3 });
+      expect(mockStart).toHaveBeenCalledOnce();
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pipelineName: 'improve-page',
+          entityId: 'E42',
+          shape: 'standard',
+          runId: expect.any(String),
+        }),
+      );
+      expect(mockEnd).toHaveBeenCalledOnce();
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: 'committed' }),
+      );
+    });
+
+    it('passes followups + caller-set status through to /end', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      await withPipelineRun(
+        { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+        async (ctx) => {
+          ctx.markFollowup({ kind: 'retry', attempt: 1 });
+          ctx.markStatus('partial_failure', { reason: 'phase2_abort' });
+        },
+      );
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: 'partial_failure',
+          failureReason: 'phase2_abort',
+          followupActions: [{ kind: 'retry', attempt: 1 }],
+        }),
+      );
+    });
+  });
+
+  describe('throw on /start fail (fail-closed default)', () => {
+    it('throws when /start returns non-ok and allowOffline is unset', async () => {
+      mockStart.mockResolvedValue({
+        ok: false,
+        error: 'unavailable',
+        message: 'connection refused',
+      });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const bodySpy = vi.fn();
+      await expect(
+        withPipelineRun(
+          { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+          bodySpy,
+        ),
+      ).rejects.toThrow(/failed to register run/);
+
+      // Body never ran, no heartbeat, no /end call — fail-closed semantics.
+      expect(bodySpy).not.toHaveBeenCalled();
+      expect(mockHeartbeat).not.toHaveBeenCalled();
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('allowOffline=true degrades to no-op', () => {
+    it('returns body result without ever calling /heartbeat or /end', async () => {
+      mockStart.mockResolvedValue({
+        ok: false,
+        error: 'unavailable',
+        message: 'connection refused',
+      });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const result = await withPipelineRun(
+        {
+          pipelineName: 'improve-page',
+          allowOffline: true,
+          heartbeatIntervalMs: 1_000_000_000,
+        },
+        async (ctx) => {
+          expect(ctx.offline).toBe(true);
+          // markStatus / markFollowup must be no-ops in offline mode.
+          ctx.markStatus('aborted');
+          ctx.markFollowup({ kind: 'whatever' });
+          return 'offline-result';
+        },
+      );
+
+      expect(result).toBe('offline-result');
+      expect(mockHeartbeat).not.toHaveBeenCalled();
+      expect(mockEnd).not.toHaveBeenCalled();
+      // The warning is logged so the offline degradation is visible.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('running offline (allowOffline=true)'),
+      );
+    });
+  });
+
+  describe('body throws → status=aborted with errorPayload', () => {
+    it('records the abort, then re-throws to caller', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const boom = new TypeError('boom');
+      await expect(
+        withPipelineRun(
+          { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+          async () => {
+            throw boom;
+          },
+        ),
+      ).rejects.toBe(boom);
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: 'aborted',
+          errorCode: 'TypeError',
+          failureReason: 'boom',
+          errorPayload: expect.objectContaining({
+            name: 'TypeError',
+            message: 'boom',
+          }),
+        }),
+      );
+    });
+
+    it('preserves caller-set status when the body also throws', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      await expect(
+        withPipelineRun(
+          { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+          async (ctx) => {
+            ctx.markStatus('oscillation', { reason: 'flapping' });
+            throw new Error('detected flap');
+          },
+        ),
+      ).rejects.toThrow('detected flap');
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          status: 'oscillation',
+          failureReason: 'flapping',
+        }),
+      );
+    });
+  });
+
+  describe('heartbeat interval', () => {
+    it('fires heartbeats while body is awaiting', async () => {
+      vi.useFakeTimers();
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockHeartbeat.mockResolvedValue({ ok: true, data: { ok: true } });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      // The body waits for a manually-resolved promise so we control
+      // exactly when it returns.
+      let releaseBody: (() => void) | null = null;
+      const blocked = new Promise<void>((resolve) => {
+        releaseBody = resolve;
+      });
+
+      const promise = withPipelineRun(
+        { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000 },
+        async () => {
+          await blocked;
+        },
+      );
+
+      // Tick three intervals — heartbeat should have fired three times.
+      // We need to flush microtasks between advances so the
+      // setInterval callback's mockHeartbeat() actually resolves.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(mockHeartbeat).toHaveBeenCalledTimes(3);
+
+      // Release the body, drain real timers/microtasks.
+      releaseBody?.();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      // After end, no further heartbeats.
+      const callsAtEnd = mockHeartbeat.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(mockHeartbeat).toHaveBeenCalledTimes(callsAtEnd);
+
+      // /end was reached.
+      expect(mockEnd).toHaveBeenCalledOnce();
+    });
+
+    it('survives a heartbeat /api error without aborting the body', async () => {
+      vi.useFakeTimers();
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockHeartbeat.mockResolvedValue({
+        ok: false,
+        error: 'server_error',
+        message: '503',
+      });
+      mockEnd.mockResolvedValue({ ok: true, data: {} });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      let releaseBody: (() => void) | null = null;
+      const blocked = new Promise<void>((resolve) => {
+        releaseBody = resolve;
+      });
+
+      const promise = withPipelineRun(
+        { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000 },
+        async () => {
+          await blocked;
+          return 'ok';
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Heartbeat warned but did not abort.
+      expect(mockHeartbeat).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('heartbeat failed (non-fatal)'),
+      );
+
+      releaseBody?.();
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe('ok');
+
+      expect(mockEnd).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: 'committed' }),
+      );
+    });
+  });
+
+  describe('/end failure handling', () => {
+    it('logs error but still returns body result on /end failure', async () => {
+      mockStart.mockResolvedValue({ ok: true, data: {} });
+      mockEnd.mockResolvedValue({
+        ok: false,
+        error: 'server_error',
+        message: '500',
+      });
+
+      const { withPipelineRun } = await import('./lifecycle.ts');
+
+      const result = await withPipelineRun(
+        { pipelineName: 'improve-page', heartbeatIntervalMs: 1_000_000_000 },
+        async () => 'body-result',
+      );
+
+      expect(result).toBe('body-result');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/end failed'),
+      );
+    });
+  });
+});

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -143,25 +143,37 @@ export async function withPipelineRun<T>(
   // the body is awaiting a long network call. Errors are best-effort:
   // a failed heartbeat doesn't kill the body, but we log so silent
   // outages are visible.
+  //
+  // Overlap guard: if the previous heartbeat is still in flight when
+  // the next interval fires (e.g. wiki-server is responding slowly),
+  // we skip rather than stack pending requests. Prevents unbounded
+  // queue growth during prod incidents.
+  let heartbeatInFlight = false;
   const heartbeatTimer = setInterval(() => {
-    void heartbeatPipelineRun(runId).then(
-      (res) => {
-        if (!res.ok) {
-          warn('withPipelineRun: heartbeat failed (non-fatal)', {
+    if (heartbeatInFlight) return;
+    heartbeatInFlight = true;
+    void heartbeatPipelineRun(runId)
+      .then(
+        (res) => {
+          if (!res.ok) {
+            warn('withPipelineRun: heartbeat failed (non-fatal)', {
+              runId,
+              pipelineName: options.pipelineName,
+              err: res.message,
+            });
+          }
+        },
+        (err: unknown) => {
+          warn('withPipelineRun: heartbeat threw (non-fatal)', {
             runId,
             pipelineName: options.pipelineName,
-            err: res.message,
+            err: err instanceof Error ? err.message : String(err),
           });
-        }
-      },
-      (err: unknown) => {
-        warn('withPipelineRun: heartbeat threw (non-fatal)', {
-          runId,
-          pipelineName: options.pipelineName,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      },
-    );
+        },
+      )
+      .finally(() => {
+        heartbeatInFlight = false;
+      });
   }, heartbeatIntervalMs);
   // Don't keep the event loop alive on the heartbeat alone — if the
   // body returns and the end call is in flight, we still want the
@@ -183,17 +195,36 @@ export async function withPipelineRun<T>(
     return result;
   } catch (err: unknown) {
     clearInterval(heartbeatTimer);
-    await finalize({
-      runId,
-      pipelineName: options.pipelineName,
-      // overrideStatus wins so a body that did `markStatus('partial_failure')`
-      // and then threw still records the more specific status.
-      status: overrideStatus ?? 'aborted',
-      failureReason: overrideReason ?? errorReason(err),
-      errorCode: overrideErrorCode ?? errorCodeFor(err),
-      errorPayload: errorPayload(err),
-      followups,
-    });
+    // CRITICAL: the original `err` from the body must reach the caller
+    // even if `finalize` itself throws. Wrapping finalize in its own
+    // try/catch ensures the audit-trail failure is logged but never
+    // replaces the actionable exception.
+    try {
+      await finalize({
+        runId,
+        pipelineName: options.pipelineName,
+        // overrideStatus wins so a body that did `markStatus('partial_failure')`
+        // and then threw still records the more specific status.
+        status: overrideStatus ?? 'aborted',
+        failureReason: overrideReason ?? errorReason(err),
+        errorCode: overrideErrorCode ?? errorCodeFor(err),
+        errorPayload: errorPayload(err),
+        followups,
+      });
+    } catch (finalizeErr: unknown) {
+      error(
+        'withPipelineRun: finalize threw after body abort — audit trail lost; rethrowing original body error',
+        {
+          runId,
+          pipelineName: options.pipelineName,
+          finalizeErr:
+            finalizeErr instanceof Error
+              ? finalizeErr.message
+              : String(finalizeErr),
+          originalErr: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
     throw err;
   }
 }

--- a/crux/lib/pipeline-runs/lifecycle.ts
+++ b/crux/lib/pipeline-runs/lifecycle.ts
@@ -1,0 +1,272 @@
+/**
+ * withPipelineRun — lifecycle wrapper for pipeline executions (QUA-954).
+ *
+ * Wraps a pipeline body so the run is registered in `pipeline_runs`
+ * before it begins, heartbeated every 30s while it's running, and
+ * finalized with status + error context regardless of how it exits.
+ *
+ * ## Behavior
+ *
+ * - **Fail-closed by default**: if the wiki-server `/start` call fails,
+ *   we throw — the body never runs and the caller exits non-zero. This
+ *   prevents silent skip of the audit trail.
+ * - **`allowOffline: true`**: degrades to a no-op `runCtx`. Used by
+ *   genuinely-offline scenarios (early-init scripts, agent slots before
+ *   the prod URL is known). Logs a warning.
+ * - **Heartbeat**: a `setInterval` from inside the helper (NOT just
+ *   on entry/exit) bumps `heartbeat_at` every 30s while the body
+ *   runs, including during long polling loops. Fixes red-team finding
+ *   R-B9 from the QUA-954 spec.
+ * - **End status mapping**:
+ *   - body resolves: `committed` (default; caller can override via
+ *     `runCtx.markStatus`).
+ *   - body throws: `aborted`, with `errorCode` derived from the error
+ *     name and `errorPayload` capturing the message + stack.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { withPipelineRun } from 'crux/lib/pipeline-runs/lifecycle.ts';
+ *
+ * await withPipelineRun(
+ *   { pipelineName: 'improve-page', entityId: 'E42', shape: 'standard' },
+ *   async (run) => {
+ *     // ... do work, optionally:
+ *     run.markFollowup({ kind: 'retry', attempt: 1 });
+ *     run.markStatus('partial_failure', { reason: 'phase2_abort' });
+ *   },
+ * );
+ * ```
+ */
+
+import { randomUUID } from 'crypto';
+import {
+  startPipelineRun,
+  heartbeatPipelineRun,
+  endPipelineRun,
+  type PipelineRunEndStatus,
+} from '../wiki-server/pipeline-runs.ts';
+
+// Crux libs log via console (validate-no-console-log only blocks server
+// code under apps/wiki-server). Structured fields are stringified into
+// the message body so dashboards can grep for runId / pipelineName.
+function warn(message: string, fields: Record<string, unknown>): void {
+  console.warn(`[pipeline-runs] ${message} ${JSON.stringify(fields)}`);
+}
+
+function error(message: string, fields: Record<string, unknown>): void {
+  console.error(`[pipeline-runs] ${message} ${JSON.stringify(fields)}`);
+}
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+export interface WithPipelineRunOptions {
+  pipelineName: string;
+  entityId?: string | null;
+  shape?: string | null;
+  agentSessionId?: number | null;
+  /** When true, fall back to a no-op runCtx if /start fails. Default false. */
+  allowOffline?: boolean;
+  /** Override the heartbeat interval (ms). Test-only. */
+  heartbeatIntervalMs?: number;
+}
+
+export interface PipelineRunCtx {
+  /** The minted run id. Stable for the lifetime of the run. */
+  runId: string;
+  /** Mark a non-default end status (overrides the success-→committed default). */
+  markStatus(status: PipelineRunEndStatus, info?: { reason?: string; errorCode?: string }): void;
+  /** Append an entry to followup_actions (written on end). */
+  markFollowup(action: Record<string, unknown>): void;
+  /** True when the lifecycle is operating offline (no-op mode). */
+  readonly offline: boolean;
+}
+
+/**
+ * Run `body(ctx)` inside a registered pipeline_run lifecycle.
+ *
+ * Re-throws any error thrown by `body` after recording the abort. The
+ * caller still gets the original exception; the audit trail is a
+ * side-effect.
+ */
+export async function withPipelineRun<T>(
+  options: WithPipelineRunOptions,
+  body: (ctx: PipelineRunCtx) => Promise<T>,
+): Promise<T> {
+  const runId = randomUUID();
+  const heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+
+  // Start the run. Fail-closed by default.
+  const startResult = await startPipelineRun({
+    runId,
+    pipelineName: options.pipelineName,
+    entityId: options.entityId ?? null,
+    shape: options.shape ?? null,
+    agentSessionId: options.agentSessionId ?? null,
+  });
+
+  if (!startResult.ok) {
+    if (options.allowOffline) {
+      warn('withPipelineRun: /start failed; running offline (allowOffline=true)', {
+        runId,
+        pipelineName: options.pipelineName,
+        err: startResult.message,
+      });
+      return body(makeOfflineCtx(runId));
+    }
+
+    throw new Error(
+      `withPipelineRun: failed to register run for pipeline=${options.pipelineName} runId=${runId}: ${startResult.message}`,
+    );
+  }
+
+  // Mutable end-state — body callbacks can override.
+  let overrideStatus: PipelineRunEndStatus | null = null;
+  let overrideReason: string | null = null;
+  let overrideErrorCode: string | null = null;
+  const followups: Array<Record<string, unknown>> = [];
+
+  const ctx: PipelineRunCtx = {
+    runId,
+    offline: false,
+    markStatus(status, info) {
+      overrideStatus = status;
+      if (info?.reason !== undefined) overrideReason = info.reason;
+      if (info?.errorCode !== undefined) overrideErrorCode = info.errorCode;
+    },
+    markFollowup(action) {
+      followups.push(action);
+    },
+  };
+
+  // Heartbeat timer — fires on a fixed interval regardless of whether
+  // the body is awaiting a long network call. Errors are best-effort:
+  // a failed heartbeat doesn't kill the body, but we log so silent
+  // outages are visible.
+  const heartbeatTimer = setInterval(() => {
+    void heartbeatPipelineRun(runId).then(
+      (res) => {
+        if (!res.ok) {
+          warn('withPipelineRun: heartbeat failed (non-fatal)', {
+            runId,
+            pipelineName: options.pipelineName,
+            err: res.message,
+          });
+        }
+      },
+      (err: unknown) => {
+        warn('withPipelineRun: heartbeat threw (non-fatal)', {
+          runId,
+          pipelineName: options.pipelineName,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      },
+    );
+  }, heartbeatIntervalMs);
+  // Don't keep the event loop alive on the heartbeat alone — if the
+  // body returns and the end call is in flight, we still want the
+  // process to be able to exit.
+  if (typeof heartbeatTimer.unref === 'function') heartbeatTimer.unref();
+
+  try {
+    const result = await body(ctx);
+    clearInterval(heartbeatTimer);
+    await finalize({
+      runId,
+      pipelineName: options.pipelineName,
+      status: overrideStatus ?? 'committed',
+      failureReason: overrideReason,
+      errorCode: overrideErrorCode,
+      errorPayload: null,
+      followups,
+    });
+    return result;
+  } catch (err: unknown) {
+    clearInterval(heartbeatTimer);
+    await finalize({
+      runId,
+      pipelineName: options.pipelineName,
+      // overrideStatus wins so a body that did `markStatus('partial_failure')`
+      // and then threw still records the more specific status.
+      status: overrideStatus ?? 'aborted',
+      failureReason: overrideReason ?? errorReason(err),
+      errorCode: overrideErrorCode ?? errorCodeFor(err),
+      errorPayload: errorPayload(err),
+      followups,
+    });
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function makeOfflineCtx(runId: string): PipelineRunCtx {
+  return {
+    runId,
+    offline: true,
+    markStatus: () => {},
+    markFollowup: () => {},
+  };
+}
+
+interface FinalizeArgs {
+  runId: string;
+  pipelineName: string;
+  status: PipelineRunEndStatus;
+  failureReason: string | null;
+  errorCode: string | null;
+  errorPayload: Record<string, unknown> | null;
+  followups: Array<Record<string, unknown>>;
+}
+
+async function finalize(args: FinalizeArgs): Promise<void> {
+  const result = await endPipelineRun(args.runId, {
+    status: args.status,
+    failureReason: args.failureReason,
+    errorCode: args.errorCode,
+    errorPayload: args.errorPayload,
+    followupActions: args.followups,
+  });
+  if (!result.ok) {
+    // End-call failure is non-fatal: we already swallowed the body's
+    // result/exception above and the caller is past their try-block.
+    // Log loudly so audit-trail loss is detectable.
+    error(
+      'withPipelineRun: /end failed — pipeline_runs row will linger as `running`',
+      {
+        runId: args.runId,
+        pipelineName: args.pipelineName,
+        err: result.message,
+        attemptedStatus: args.status,
+      },
+    );
+  }
+}
+
+function errorCodeFor(err: unknown): string | null {
+  if (err instanceof Error) {
+    return err.name || 'Error';
+  }
+  return null;
+}
+
+function errorReason(err: unknown): string | null {
+  if (err instanceof Error) {
+    // Cap to something sane for the failure_reason text column.
+    return err.message.slice(0, 200);
+  }
+  return null;
+}
+
+function errorPayload(err: unknown): Record<string, unknown> | null {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: err.message,
+      stack: err.stack?.split('\n').slice(0, 20).join('\n'),
+    };
+  }
+  return { value: String(err) };
+}

--- a/crux/lib/wiki-server/pipeline-runs.ts
+++ b/crux/lib/wiki-server/pipeline-runs.ts
@@ -1,0 +1,110 @@
+/**
+ * Pipeline Runs API — wiki-server client (QUA-954).
+ *
+ * Mirrors grants.ts: response types are inferred from the Hono RPC route
+ * via InferResponseType<>, no raw `apiRequest<T>` with hand-written
+ * generics. Used by `crux/lib/pipeline-runs/lifecycle.ts::withPipelineRun`.
+ */
+
+import { apiRequest, type ApiResult } from './client.ts';
+import type { hc, InferResponseType } from 'hono/client';
+import type { PipelineRunsRoute } from '../../../apps/wiki-server/src/routes/operational/pipeline-runs.ts';
+
+// ---------------------------------------------------------------------------
+// Types — response (inferred from Hono RPC route)
+// ---------------------------------------------------------------------------
+
+type RpcClient = ReturnType<typeof hc<PipelineRunsRoute>>;
+
+export type PipelineRunCreated = InferResponseType<RpcClient['index']['$post'], 201>;
+export type PipelineRunHeartbeatResult = InferResponseType<
+  RpcClient[':id']['heartbeat']['$patch'],
+  200
+>;
+export type PipelineRunEndResult = InferResponseType<RpcClient[':id']['end']['$patch'], 200>;
+
+export type PipelineRunsListResult = InferResponseType<RpcClient['index']['$get'], 200>;
+export type PipelineRunRow = PipelineRunsListResult['runs'][number];
+export type PipelineRunsStatsResult = InferResponseType<RpcClient['stats']['$get'], 200>;
+
+// ---------------------------------------------------------------------------
+// Types — request payloads
+// ---------------------------------------------------------------------------
+
+export interface StartPipelineRunInput {
+  runId: string;
+  pipelineName: string;
+  agentSessionId?: number | null;
+  entityId?: string | null;
+  shape?: string | null;
+}
+
+export type PipelineRunEndStatus =
+  | 'committed'
+  | 'aborted'
+  | 'oscillation'
+  | 'partial_failure';
+
+export interface EndPipelineRunInput {
+  status: PipelineRunEndStatus;
+  failureReason?: string | null;
+  errorCode?: string | null;
+  errorPayload?: Record<string, unknown> | null;
+  snapshotPath?: string | null;
+  followupActions?: Array<Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+/** Start a pipeline run. Returns the inserted row. */
+export async function startPipelineRun(
+  input: StartPipelineRunInput,
+): Promise<ApiResult<PipelineRunCreated>> {
+  return apiRequest<PipelineRunCreated>('POST', '/api/pipeline-runs', input);
+}
+
+/** Bump heartbeat_at on a running pipeline run. */
+export async function heartbeatPipelineRun(
+  runId: string,
+): Promise<ApiResult<PipelineRunHeartbeatResult>> {
+  return apiRequest<PipelineRunHeartbeatResult>(
+    'PATCH',
+    `/api/pipeline-runs/${encodeURIComponent(runId)}/heartbeat`,
+  );
+}
+
+/** Finish a pipeline run — sets status, ended_at, and any failure context. */
+export async function endPipelineRun(
+  runId: string,
+  input: EndPipelineRunInput,
+): Promise<ApiResult<PipelineRunEndResult>> {
+  return apiRequest<PipelineRunEndResult>(
+    'PATCH',
+    `/api/pipeline-runs/${encodeURIComponent(runId)}/end`,
+    input,
+  );
+}
+
+/** List pipeline runs, optionally filtered by status / pipeline_name. */
+export async function listPipelineRuns(options?: {
+  status?: 'running' | 'committed' | 'aborted' | 'oscillation' | 'partial_failure';
+  pipelineName?: string;
+  limit?: number;
+}): Promise<ApiResult<PipelineRunsListResult>> {
+  const params = new URLSearchParams();
+  if (options?.status) params.set('status', options.status);
+  if (options?.pipelineName) params.set('pipelineName', options.pipelineName);
+  if (options?.limit != null) params.set('limit', String(options.limit));
+  const qs = params.toString();
+  return apiRequest<PipelineRunsListResult>(
+    'GET',
+    `/api/pipeline-runs${qs ? `?${qs}` : ''}`,
+  );
+}
+
+/** Aggregate stats for the dashboard (last 24h). */
+export async function getPipelineRunsStats(): Promise<ApiResult<PipelineRunsStatsResult>> {
+  return apiRequest<PipelineRunsStatsResult>('GET', '/api/pipeline-runs/stats');
+}


### PR DESCRIPTION
## Summary

Phase 0d of QUA-943 (machine-write PG-primary transition): adds the `pipeline_runs` table, three lifecycle API endpoints, a typed crux client, the `withPipelineRun()` helper, and the `/internal/pipeline-runs` dashboard. Additive — no production caller wires it until Phase 1 (QUA-957).

Closes QUA-954.

## What this ships

| Layer | File | Notes |
|---|---|---|
| Migration | `apps/wiki-server/drizzle/0221_qua_954_pipeline_runs.sql` | Schema + audit trigger via `apply_audit_trigger('pipeline_runs')` (QUA-442) |
| Schema | `apps/wiki-server/src/schema.ts` | `pipelineRuns` Drizzle definition + 6 indexes (incl. partial index on `running` rows) |
| Zod | `apps/wiki-server/src/api-types.ts` | `Start/End/Status` schemas + `VALID_PIPELINE_RUN_STATUSES` |
| API | `apps/wiki-server/src/routes/operational/pipeline-runs.ts` | `POST /`, `GET /`, `GET /stats`, `GET /:id`, `PATCH /:id/heartbeat`, `PATCH /:id/end` (hand-rolled, Hono RPC method-chaining) |
| Mount | `apps/wiki-server/src/app.ts` | `app.route("/api/pipeline-runs", pipelineRunsRoute)` |
| Response types | `apps/wiki-server/src/api-response-types.ts` | `PipelineRunRow`, `PipelineRunsStatsResult`, etc. via `InferResponseType<>` |
| Typed client | `crux/lib/wiki-server/pipeline-runs.ts` | Mirrors `grants.ts` — no raw `apiRequest<T>` |
| Lifecycle | `crux/lib/pipeline-runs/lifecycle.ts` | `withPipelineRun()` — fail-closed, `allowOffline`, 30s heartbeat interval (`setInterval`, unref'd) |
| Tests | `crux/lib/pipeline-runs/lifecycle.test.ts` | 9 tests covering all 4 acceptance scenarios + heartbeat-survives-error + /end-failure |
| Dashboard | `apps/web/src/app/internal/pipeline-runs/{page,*-content,*-table}.tsx` + `content/docs/internal/pipeline-runs-dashboard.mdx` | Pattern A wiki page (E2545), summary cards, failure-reason breakdown, sortable runs table |

## Spec deviations (all from the QUA-954 red-team comment)

### 1. `agent_session_id` is `bigint`, not `uuid`

**Critical** — the v4 RFC spec wrote `uuid REFERENCES agent_sessions(id)`, but `agent_sessions.id` is `bigserial` (`apps/wiki-server/src/schema.ts:1069`). A migration written against the spec would fail at apply with a type-mismatch error. Fixed per the red-team comment:

```ts
agentSessionId: bigint("agent_session_id", { mode: "number" })
  .references(() => agentSessions.id, { onDelete: "set null" }),
```

`ON DELETE SET NULL` (not CASCADE) — runs can outlive the originating session, especially during long polling, and the 30-min stale-sweep on `agent_sessions` shouldn't drop completed-run history.

### 2. Heartbeat endpoint sets `app.audit_skip = 'true'`

Red-team finding #1: a 30-min run produces ~60 heartbeats × 1 audit row each ≈ ~60 audit rows per run. With ~700 entities/night that's ~42K spurious audit rows daily. The PATCH `/:id/heartbeat` handler now wraps the UPDATE in a transaction with `SET LOCAL app.audit_skip = 'true'` (same mechanism documented in `.claude/rules/audit-log.md` § "Bulk backfills"). Start/end/status-change writes are still audited.

## Deferred (acknowledged, not in this PR)

These are red-team findings #2–#4 from the QUA-954 comment. None block Phase 0d's "additive scaffolding" goal; deferring keeps this PR scoped:

- **Heartbeat inheritance from `agent_sessions.heartbeat_at`** (#2) — replacing the clock-driven 30s heartbeat with event-driven (start, commit-batch, abort, retry-attempt) emission, with liveness inherited from `agent_sessions`. The current spec body explicitly says "Heartbeat fires every 30s including during long polling loops" — deviating from the body would force a re-spec discussion. Filing as a Phase 1 follow-up: when Phase 1 wires the first caller, the consumer side decides whether to emit the heartbeat clock or rely on `agent_sessions.heartbeat_at`.
- **Degraded-mode tolerance ≥5min** (#3) — the consumer side decides what to do with N consecutive heartbeat failures. The lifecycle helper currently logs each failure as non-fatal and never aborts the body. A consumer that needs ≥5min tolerance can just not act on a single missed heartbeat; that policy belongs in the dashboard / liveness checker, not in the lifecycle.
- **Migration ordering with QUA-955 / QUA-956** (#4) — Phase 1 (QUA-957) cannot start until QUA-955 (best-effort sync mode) and QUA-956 (natural-key UNIQUE on `policy_stakeholders`) are in prod. Documenting here; no code change in this PR.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Migration applied; `pipeline_runs` exists with allow-listed audit trigger | ✅ `0221_qua_954_pipeline_runs.sql` + `CALL apply_audit_trigger('pipeline_runs')` |
| 3 API endpoints respond as specified | ✅ POST `/start` (as `POST /`), PATCH `/:id/heartbeat`, PATCH `/:id/end` |
| Typed client + InferResponseType<> validated by `validate-typed-client` | ✅ `crux/lib/wiki-server/pipeline-runs.ts` mirrors grants.ts pattern |
| `withPipelineRun` unit tests cover success path, throw-on-/start-fail, heartbeat interval, allowOffline | ✅ 9 tests pass — see `crux/lib/pipeline-runs/lifecycle.test.ts` |
| Dashboard renders against synthetic test rows | ✅ `/internal/pipeline-runs` (E2545) — graceful empty state when 0 runs |
| No production caller wired yet (Phase 1 work) | ✅ `withPipelineRun` is unused in app code |

## Test plan

- [x] `pnpm vitest run crux/lib/pipeline-runs/lifecycle.test.ts` — 9 tests pass
- [x] `pnpm --filter wiki-server test` — 1555 tests pass (no regressions)
- [x] `npx tsc --noEmit` (root + apps/web + apps/wiki-server) — clean
- [x] `pnpm crux w validate gate --fix` — see CI
- [x] `pnpm build` — see CI
- [ ] Verify dashboard renders against prod (will check post-deploy; the page renders the empty-state until a Phase 1 caller writes rows)

## Deploy notes

Migration `0221_qua_954_pipeline_runs.sql` applies on next wiki-server deploy. The migration is fully additive (CREATE TABLE + indexes + audit-trigger attach) — reversibility is `DROP TABLE pipeline_runs`. No backfill needed.
