### PR TITLE
fix(qua-928): test expectation + CodeRabbit findings (follow-up to #4741)

### DIFF
--- a/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
+++ b/apps/web/src/app/internal/sourcing-coverage/sourcing-coverage-content.tsx
@@ -59,6 +59,13 @@ interface CoverageMatrixResult {
   totals: {
     totalRecords: number;
     checkableRecords?: number;
+    /**
+     * QUA-928 review: aggregate sum of per-record `checkedRecords`
+     * (records with at least one verdict). Distinct from `totalVerdicts`,
+     * which can over-count because a single record may produce multiple
+     * per-field verdict rows.
+     */
+    checkedRecords?: number;
     totalVerdicts: number;
     confirmedPercent: number;
     checkabilityPercent?: number;
@@ -601,16 +608,33 @@ export async function SourcingCoverageContent() {
                     {(coverageMatrix.totals.checkableRecords ?? coverageMatrix.totals.totalRecords).toLocaleString()}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.totalVerdicts.toLocaleString()} verdicts
+                    {/* QUA-928 review: prefer aggregate checkedRecords (one per
+                       record); fall back to totalVerdicts for the deploy
+                       window where the wiki-server may not have shipped the
+                       new field yet. */}
+                    {coverageMatrix.totals.checkedRecords !== undefined
+                      ? coverageMatrix.totals.checkedRecords.toLocaleString()
+                      : `${coverageMatrix.totals.totalVerdicts.toLocaleString()} verdicts`}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.checkabilityPercent ?? "—"}%
+                    {/* QUA-928 review: render `%` only for numeric values to
+                       avoid the "—%" placeholder when the field is absent. */}
+                    {typeof coverageMatrix.totals.checkabilityPercent === "number"
+                      ? `${coverageMatrix.totals.checkabilityPercent}%`
+                      : "—"}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.checkableCoveragePercent ?? "—"}%
+                    {typeof coverageMatrix.totals.checkableCoveragePercent === "number"
+                      ? `${coverageMatrix.totals.checkableCoveragePercent}%`
+                      : "—"}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
-                    {coverageMatrix.totals.fullCoveragePercent ?? coverageMatrix.totals.coveragePercent ?? "—"}%
+                    {(() => {
+                      const v =
+                        coverageMatrix.totals.fullCoveragePercent ??
+                        coverageMatrix.totals.coveragePercent;
+                      return typeof v === "number" ? `${v}%` : "—";
+                    })()}
                   </td>
                   <td className="text-right py-2 px-3 tabular-nums">
                     {coverageMatrix.totals.confirmedPercent}%

--- a/apps/wiki-server/src/__tests__/property-metadata.test.ts
+++ b/apps/wiki-server/src/__tests__/property-metadata.test.ts
@@ -24,19 +24,23 @@ describe("getNonVerifiablePropertyIds", () => {
     expect(ids.size).toBeGreaterThan(0);
   });
 
-  it("includes the well-known social-media + wikipedia + estimate properties", () => {
+  it("includes the well-known estimate + self-referential-URL properties", () => {
     _resetPropertyMetadataCache();
     const ids = getNonVerifiablePropertyIds();
-    // These three families are the canonical reasons a property is flagged
-    // verifiable:false:
-    //   1. self-referential URLs (`wikipedia-url`, `social-media`)
-    //   2. third-party-blocking handles (`twitter-handle`/`x-handle`)
-    //   3. unsourced estimates (`safety-staffing-ratio`, `equity-stake-percent`)
-    // Pick one canonical member of each family — losing any of these to a
-    // YAML edit would silently expand the "checkable" set and break the gate.
-    expect(ids.has("wikipedia-url")).toBe(true);
-    expect(ids.has("social-media")).toBe(true);
+    // QUA-927 moved self-referential-URL properties (`wikipedia-url`,
+    // `social-media`, `google-scholar`, `github-profile`) OUT of the
+    // non-verifiable set and into url-resolves verification — they are now
+    // checkable via cheap HEAD requests. They MUST NOT be in this set.
+    expect(ids.has("wikipedia-url")).toBe(false);
+    expect(ids.has("social-media")).toBe(false);
+    // The remaining canonical reasons a property stays verifiable:false:
+    //   1. unsourced estimates (`safety-staffing-ratio`, `equity-stake-percent`)
+    //   2. self-referential URLs that QUA-927 didn't migrate (`website`)
+    // Pick one canonical member of each — losing any of these to a YAML edit
+    // would silently expand the "checkable" set and break the gate.
     expect(ids.has("safety-staffing-ratio")).toBe(true);
+    expect(ids.has("equity-stake-percent")).toBe(true);
+    expect(ids.has("website")).toBe(true);
   });
 
   it("does NOT include verifiable properties", () => {

--- a/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts
@@ -321,6 +321,10 @@ describe("QUA-928: GET /api/sourcing/coverage — checkability split", () => {
       "expected a dedicated query that scopes facts to checkable subset",
     ).toBeDefined();
     expect(/source\s+IS\s+NOT\s+NULL/i.test(checkableQuery!)).toBe(true);
+    // QUA-928 review: `source IS NOT NULL` alone still lets `source = ''`
+    // through, so without the empty-string guard the metric would silently
+    // count facts with a blank source as checkable. Assert both halves.
+    expect(/source\s*<>\s*''/i.test(checkableQuery!)).toBe(true);
     expect(/measure\s*=\s*ANY/i.test(checkableQuery!)).toBe(true);
   });
 });

--- a/apps/wiki-server/src/routes/sourcing/sourcing.ts
+++ b/apps/wiki-server/src/routes/sourcing/sourcing.ts
@@ -2493,6 +2493,11 @@ const sourcingApp = new Hono()
       totals: {
         totalRecords: grandTotalRecords,
         checkableRecords: grandCheckableRecords,
+        // QUA-928 review: expose checkedRecords in aggregate totals so
+        // downstream consumers can render a semantically correct "Checked"
+        // total instead of falling back to totalVerdicts (which over-counts
+        // because a single record can have multiple per-field verdict rows).
+        checkedRecords: grandCheckedRecords,
         totalVerdicts: grandTotalVerdicts,
         confirmedPercent: pct1(grandConfirmed, grandTotalVerdicts),
         ...coveragePercents(


### PR DESCRIPTION
## Summary

Follow-up to PR #4741 (merged at 05:03 UTC). #4741 shipped with a stale test expectation that's about to break main CI.

## Why a follow-up PR

#4741 was merged before this fix could land on the original branch. Main `property-metadata.test.ts > getNonVerifiablePropertyIds > includes the well-known social-media + wikipedia + estimate properties` will fail on the next main CI run because:

- QUA-927 (commit `2cce11fac`, ancestor of #4741) moved `wikipedia-url` and `social-media` from `verifiable: false` → `verifierKind: url-resolves`
- The test still asserts they're in the non-verifiable set
- Confirmed: the failing test is on main right now (run 25203080590 in progress at the time of this PR)

## What's in this PR

1. **Test fix** (`property-metadata.test.ts`): converts the `wikipedia-url`/`social-media` assertions to NEGATIVE — they MUST NOT be in the non-verifiable set after QUA-927. Adds `equity-stake-percent` and `website` to keep family-coverage spirit.

2. **CodeRabbit MAJOR** (`sourcing.ts:2503`): expose `checkedRecords` in `/coverage-matrix` totals so downstream consumers don't fall back to `totalVerdicts` (which over-counts due to multi-field verdict rows per record).

3. **CodeRabbit MINOR** (`sourcing-coverage-content.tsx:614`): render `%` only for numeric values; replace `—%` placeholder with `—`.

4. **CodeRabbit MINOR** (`sourcing-coverage-checkability.test.ts:325`): assert empty-string source guard (`source IS NOT NULL` alone lets `''` through).

## Test plan
- [x] `npx vitest run apps/wiki-server/src/__tests__/property-metadata.test.ts` (was failing on main, now green)
- [x] `npx vitest run apps/wiki-server/src/__tests__/sourcing-coverage-checkability.test.ts`
- [x] `npx tsc --noEmit -p .` (zero new errors; pre-existing baseline only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverage matrix totals now include a more accurate checked-records count metric.

* **Bug Fixes**
  * Fixed incorrect "—%" placeholder display when percentage values are unavailable.
  * Improved percentage formatting in coverage totals to display "—" correctly for missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->