### PR TITLE
fix(test): update property-metadata tripwire after QUA-927 url-resolves migration

### DIFF
--- a/apps/wiki-server/src/__tests__/property-metadata.test.ts
+++ b/apps/wiki-server/src/__tests__/property-metadata.test.ts
@@ -24,19 +24,18 @@ describe("getNonVerifiablePropertyIds", () => {
     expect(ids.size).toBeGreaterThan(0);
   });
 
-  it("includes the well-known social-media + wikipedia + estimate properties", () => {
+  it("includes the well-known self-referential + estimate properties", () => {
     _resetPropertyMetadataCache();
     const ids = getNonVerifiablePropertyIds();
-    // These three families are the canonical reasons a property is flagged
-    // verifiable:false:
-    //   1. self-referential URLs (`wikipedia-url`, `social-media`)
-    //   2. third-party-blocking handles (`twitter-handle`/`x-handle`)
-    //   3. unsourced estimates (`safety-staffing-ratio`, `equity-stake-percent`)
+    // Two families that remain verifiable:false after QUA-927:
+    //   1. Self-referential URLs (`website`): the fact IS the URL, no external content to verify
+    //      (wikipedia-url and social-media moved to verifierKind:url-resolves in QUA-927)
+    //   2. Unsourced estimates (`safety-staffing-ratio`, `interpretability-team-size`)
     // Pick one canonical member of each family — losing any of these to a
     // YAML edit would silently expand the "checkable" set and break the gate.
-    expect(ids.has("wikipedia-url")).toBe(true);
-    expect(ids.has("social-media")).toBe(true);
+    expect(ids.has("website")).toBe(true);
     expect(ids.has("safety-staffing-ratio")).toBe(true);
+    expect(ids.has("interpretability-team-size")).toBe(true);
   });
 
   it("does NOT include verifiable properties", () => {


### PR DESCRIPTION
## Summary

- QUA-927 moved `wikipedia-url` and `social-media` from `verifiable: false` to `verifierKind: url-resolves`, making them verifiable via lightweight HEAD requests
- The `property-metadata.test.ts` tripwire was pinning those two properties as non-verifiable, so CI failed when they were promoted
- Updated the test to pin `website` (still self-referential, `verifiable: false`) and `interpretability-team-size` alongside the existing `safety-staffing-ratio` check

## Root cause

Run 25203080590 failed in `src/__tests__/property-metadata.test.ts` at:
```
expect(ids.has("wikipedia-url")).toBe(true);  // fails — now verifierKind:url-resolves
```

## Test plan
- [x] All 10 tests in `property-metadata.test.ts` pass locally
- [x] Gate: 52/52 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
