### PR TITLE
QUA-964: fail-loud syncPolicyStakeholders + strict enum gate validator

### DIFF
--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -955,36 +955,55 @@ export async function syncPolicyStakeholders(typedEntities) {
       } else {
         // Batch failed — try items individually to skip bad FK references
         for (const item of batch) {
+          // Phase 1: send the request. Network/transport failures are the only
+          // legitimate skip-on-throw; anything else must fail loud.
+          let r;
           try {
-            const r = await fetch(`${serverUrl}/api/policy-stakeholders/sync?${skipSourcing}`, {
+            r = await fetch(`${serverUrl}/api/policy-stakeholders/sync?${skipSourcing}`, {
               method: 'POST',
               headers,
               body: JSON.stringify({ items: [item] }),
               signal: AbortSignal.timeout(10_000),
             });
-            if (r.ok) {
-              synced++;
-            } else {
-              // QUA-941 / QUA-964: distinguish FK-missing (legitimate skip — some
-              // YAML stakeholders reference entities not yet in PG) from Zod schema
-              // rejection (data corruption — must fail loud). FK errors from
-              // validateEntityRefs always contain the literal "Entity references
-              // not found"; any other 400 indicates real schema violation.
-              // TODO(QUA-951): switch to body.includes('"code":"fk_missing"') once
-              // the validationError discriminator lands.
-              const body = await r.text();
-              const isFkMissing = body.includes('Entity references not found');
-              if (!isFkMissing) {
-                process.stderr.write(
-                  `syncPolicyStakeholders: non-FK 400 for policy=${item.policyEntityId} stakeholder=${item.stakeholderEntityId ?? item.stakeholderDisplayName} — YAML data corruption (QUA-941).\nResponse: ${body}\n`,
-                );
-                process.exit(1);
-              }
-              skipped++;
-            }
           } catch {
             skipped++;
+            continue;
           }
+          if (r.ok) {
+            synced++;
+            continue;
+          }
+          // Phase 2: classify the 4xx/5xx. QUA-941 / QUA-964 — distinguish
+          // FK-missing (legitimate skip — some YAML stakeholders reference
+          // entities not yet in PG) from any other 400 (data corruption —
+          // must fail loud). FK errors from validateEntityRefs always contain
+          // the literal "Entity references not found"; for this specific
+          // route, any other 400 means a Zod schema rejection (no naturalKey,
+          // no claimSupport, sourcing forced off via forceSkipSourcing).
+          // TODO(QUA-951): switch to body.includes('"code":"fk_missing"') once
+          // the validationError discriminator lands.
+          //
+          // If r.text() itself throws after a non-2xx (rare — interrupted body
+          // stream), do NOT silently skip: we already know the route rejected
+          // the payload. Treat it as the fail-loud case so QUA-941's silent
+          // drop pattern cannot recur via a body-read race.
+          let body;
+          try {
+            body = await r.text();
+          } catch (e) {
+            process.stderr.write(
+              `syncPolicyStakeholders: ${r.status} response body unreadable for policy=${item.policyEntityId}: ${e instanceof Error ? e.message : String(e)} — failing loud (QUA-964).\n`,
+            );
+            process.exit(1);
+          }
+          const isFkMissing = body.includes('Entity references not found');
+          if (!isFkMissing) {
+            process.stderr.write(
+              `syncPolicyStakeholders: non-FK ${r.status} for policy=${item.policyEntityId} stakeholder=${item.stakeholderEntityId ?? item.stakeholderDisplayName} — YAML data corruption (QUA-941).\nResponse: ${body}\n`,
+            );
+            process.exit(1);
+          }
+          skipped++;
         }
       }
     }

--- a/apps/web/scripts/lib/wiki-server-data.mjs
+++ b/apps/web/scripts/lib/wiki-server-data.mjs
@@ -965,6 +965,21 @@ export async function syncPolicyStakeholders(typedEntities) {
             if (r.ok) {
               synced++;
             } else {
+              // QUA-941 / QUA-964: distinguish FK-missing (legitimate skip — some
+              // YAML stakeholders reference entities not yet in PG) from Zod schema
+              // rejection (data corruption — must fail loud). FK errors from
+              // validateEntityRefs always contain the literal "Entity references
+              // not found"; any other 400 indicates real schema violation.
+              // TODO(QUA-951): switch to body.includes('"code":"fk_missing"') once
+              // the validationError discriminator lands.
+              const body = await r.text();
+              const isFkMissing = body.includes('Entity references not found');
+              if (!isFkMissing) {
+                process.stderr.write(
+                  `syncPolicyStakeholders: non-FK 400 for policy=${item.policyEntityId} stakeholder=${item.stakeholderEntityId ?? item.stakeholderDisplayName} — YAML data corruption (QUA-941).\nResponse: ${body}\n`,
+                );
+                process.exit(1);
+              }
               skipped++;
             }
           } catch {

--- a/apps/wiki-server/src/routes/tablebase/mount-registry.ts
+++ b/apps/wiki-server/src/routes/tablebase/mount-registry.ts
@@ -193,4 +193,5 @@ export const TABLEBASE_NON_ROUTE_FILES: readonly string[] = [
   "entity-profile-descriptions.ts",
   "system-card-benchmark-linker.ts",
   "benchmark-shared.ts",
+  "policy-stakeholders-schema.ts",
 ];

--- a/apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts
+++ b/apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts
@@ -1,0 +1,34 @@
+/**
+ * Standalone schema for policy-stakeholders sync.
+ *
+ * Extracted from the route file (QUA-964) so the gate validator
+ * (`crux/validate/validate-policy-stakeholders-strict.ts`) can import
+ * the canonical Zod schema without pulling in Hono / drizzle / db
+ * transitive dependencies.
+ *
+ * Anything strict the route enforces at sync time MUST live here so YAML
+ * gets the same enforcement at PR time. Keeping the schema source-of-truth
+ * here avoids drift between "what the route accepts" and "what the gate
+ * blocks at PR review".
+ */
+
+import { z } from "zod";
+import { InlineSourcingSchema } from "./sourcing-schema.js";
+
+export const VALID_POSITIONS = ["support", "oppose", "neutral", "mixed"] as const;
+export const VALID_IMPORTANCE = ["high", "medium", "low"] as const;
+
+export const SyncStakeholderItemSchema = z.object({
+  id: z.string().length(10),
+  policyEntityId: z.string().min(1).max(200),
+  stakeholderEntityId: z.string().max(200).nullable().optional(),
+  stakeholderDisplayName: z.string().min(1).max(500),
+  position: z.enum(VALID_POSITIONS),
+  importance: z.enum(VALID_IMPORTANCE).nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
+  source: z.string().max(2000).nullable().optional(),
+  context: z.array(z.string()).nullable().optional(),
+  sourcing: InlineSourcingSchema.optional(),
+});
+
+export type SyncStakeholderItem = z.infer<typeof SyncStakeholderItemSchema>;

--- a/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+++ b/apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
@@ -10,29 +10,14 @@ import {
 import { resolveEntityId, type ResolvedEntityVars } from "../shared/resolve-entity-middleware.js";
 import { deleteBatchHandler } from "../shared/delete-batch.js";
 import { createSyncHandler } from "./sync-factory.js";
-import { InlineSourcingSchema } from "./sourcing-schema.js";
+import {
+  SyncStakeholderItemSchema,
+  VALID_POSITIONS,
+} from "./policy-stakeholders-schema.js";
 
 // ---- Constants ----
 
 const MAX_PAGE_SIZE = 200;
-const VALID_POSITIONS = ["support", "oppose", "neutral", "mixed"] as const;
-
-// ---- Schemas ----
-
-const VALID_IMPORTANCE = ["high", "medium", "low"] as const;
-
-const SyncStakeholderItemSchema = z.object({
-  id: z.string().length(10),
-  policyEntityId: z.string().min(1).max(200),
-  stakeholderEntityId: z.string().max(200).nullable().optional(),
-  stakeholderDisplayName: z.string().min(1).max(500),
-  position: z.enum(VALID_POSITIONS),
-  importance: z.enum(VALID_IMPORTANCE).nullable().optional(),
-  reason: z.string().max(5000).nullable().optional(),
-  source: z.string().max(2000).nullable().optional(),
-  context: z.array(z.string()).nullable().optional(),
-  sourcing: InlineSourcingSchema.optional(),
-});
 
 const ByPolicyQuery = z.object({
   position: z.enum(VALID_POSITIONS).optional(),

--- a/crux/validate/.entity-schema-drift-allowlist.txt
+++ b/crux/validate/.entity-schema-drift-allowlist.txt
@@ -31,7 +31,7 @@ apps/wiki-server/src/routes/tablebase/model-aliases.ts
 apps/wiki-server/src/routes/tablebase/model-system-cards.ts
 apps/wiki-server/src/routes/tablebase/personnel.ts
 apps/wiki-server/src/routes/tablebase/platform-accounts.ts
-apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts
+apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts
 apps/wiki-server/src/routes/tablebase/political-offices.ts
 apps/wiki-server/src/routes/tablebase/political-races.ts
 apps/wiki-server/src/routes/tablebase/political-votes.ts

--- a/crux/validate/validate-gate.ts
+++ b/crux/validate/validate-gate.ts
@@ -493,6 +493,20 @@ const PARALLEL_STEPS: Step[] = [
     // error from PG. Static-checkable, so we keep it cheap and CI-blocking.
   },
   {
+    id: 'policy-stakeholders-strict',
+    name: 'Policy stakeholders strict Zod schema (QUA-964 / QUA-941 bridge)',
+    command: 'npx',
+    args: ['tsx', 'crux/validate/validate-policy-stakeholders-strict.ts'],
+    cwd: PROJECT_ROOT,
+    // Blocking: runs the canonical sync-route Zod schema against every
+    // policy.stakeholders[] block in data/entities/. QUA-941 shipped 10
+    // rows of `position: reform` that the route silently rejected with a
+    // 400 and the build helper swallowed; this gate catches the same class
+    // of mistake at PR-review time. Companion fix in
+    // apps/web/scripts/lib/wiki-server-data.mjs makes runtime sync 400s
+    // also fail loud.
+  },
+  {
     id: 'things-denorm-dead',
     name: 'No writes/reads of dropped things.title/description/parent_title (QUA-507)',
     command: 'npx',

--- a/crux/validate/validate-policy-stakeholders-strict.test.ts
+++ b/crux/validate/validate-policy-stakeholders-strict.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for validate-policy-stakeholders-strict (QUA-964).
+ *
+ * The validator reads `data/entities/*.yaml` directly, so the smoke test
+ * is "current YAML passes". Schema-level coverage (catching the QUA-941
+ * `position: reform` regression) is exercised against the SyncStakeholderItemSchema
+ * directly so the test doesn't need to mutate real YAML.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runCheck } from "./validate-policy-stakeholders-strict.ts";
+import {
+  SyncStakeholderItemSchema,
+  VALID_POSITIONS,
+} from "../../apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts";
+
+describe("validate-policy-stakeholders-strict", () => {
+  it("passes against current data/entities/", async () => {
+    const res = await runCheck();
+    expect(res.passed).toBe(true);
+    expect(res.errors).toBe(0);
+    // Sanity: there should be at least a handful of policies/stakeholders.
+    expect(res.checkedPolicies).toBeGreaterThan(0);
+    expect(res.checkedStakeholders).toBeGreaterThan(0);
+  });
+
+  it("VALID_POSITIONS does not include the QUA-941 regressor 'reform'", () => {
+    // If this changes, either the route schema widened (then update the
+    // test) or someone re-introduced the bad value (then this test catches it).
+    expect(VALID_POSITIONS).toEqual(["support", "oppose", "neutral", "mixed"]);
+    expect(VALID_POSITIONS as readonly string[]).not.toContain("reform");
+  });
+
+  it("rejects position: reform via the imported sync schema (QUA-941)", () => {
+    const result = SyncStakeholderItemSchema.safeParse({
+      id: "abcdef0123",
+      policyEntityId: "sid_test",
+      stakeholderDisplayName: "Test",
+      position: "reform",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const positionError = result.error.issues.find(
+        (i) => i.path.join(".") === "position",
+      );
+      expect(positionError).toBeDefined();
+      expect(positionError!.message).toMatch(/Invalid enum value/);
+    }
+  });
+
+  it("rejects empty stakeholderDisplayName", () => {
+    const result = SyncStakeholderItemSchema.safeParse({
+      id: "abcdef0123",
+      policyEntityId: "sid_test",
+      stakeholderDisplayName: "",
+      position: "support",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects id of wrong length", () => {
+    const result = SyncStakeholderItemSchema.safeParse({
+      id: "tooshort",
+      policyEntityId: "sid_test",
+      stakeholderDisplayName: "Test",
+      position: "support",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a fully-populated valid row", () => {
+    const result = SyncStakeholderItemSchema.safeParse({
+      id: "abcdef0123",
+      policyEntityId: "sid_test",
+      stakeholderEntityId: "sid_target",
+      stakeholderDisplayName: "Test Person",
+      position: "support",
+      importance: "high",
+      reason: "rationale",
+      source: "https://example.com",
+      context: ["a", "b"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a minimal row (only required fields)", () => {
+    const result = SyncStakeholderItemSchema.safeParse({
+      id: "abcdef0123",
+      policyEntityId: "sid_test",
+      stakeholderDisplayName: "Test",
+      position: "neutral",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/crux/validate/validate-policy-stakeholders-strict.test.ts
+++ b/crux/validate/validate-policy-stakeholders-strict.test.ts
@@ -8,11 +8,27 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { runCheck } from "./validate-policy-stakeholders-strict.ts";
+import {
+  runCheck,
+  evaluatePolicies,
+} from "./validate-policy-stakeholders-strict.ts";
 import {
   SyncStakeholderItemSchema,
   VALID_POSITIONS,
+  VALID_IMPORTANCE,
 } from "../../apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts";
+
+const SRC = "/synthetic.yaml";
+function policy(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-policy",
+    type: "policy",
+    stableId: "sid_TestPolicy",
+    stakeholders: [],
+    _sourceFile: SRC,
+    ...overrides,
+  };
+}
 
 describe("validate-policy-stakeholders-strict", () => {
   it("passes against current data/entities/", async () => {
@@ -91,5 +107,115 @@ describe("validate-policy-stakeholders-strict", () => {
       position: "neutral",
     });
     expect(result.success).toBe(true);
+  });
+
+  it("VALID_IMPORTANCE matches sync schema", () => {
+    expect(VALID_IMPORTANCE).toEqual(["high", "medium", "low"]);
+  });
+});
+
+describe("evaluatePolicies (negative paths)", () => {
+  it("returns empty findings for current valid input", () => {
+    const policies = [
+      policy({
+        stakeholders: [{ name: "Alice", position: "support" }],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings).toHaveLength(0);
+    expect(r.checkedStakeholders).toBe(1);
+    expect(r.checkedPolicies).toBe(1);
+    expect(r.skippedPolicies).toBe(0);
+  });
+
+  it("emits a finding for position: reform (the QUA-941 regressor)", () => {
+    const policies = [
+      policy({
+        stakeholders: [{ name: "Alice", position: "reform" }],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings.length).toBeGreaterThan(0);
+    const positionFinding = r.findings.find((f) => f.field === "position");
+    expect(positionFinding).toBeDefined();
+    expect(positionFinding!.policyId).toBe("test-policy");
+    expect(positionFinding!.stakeholder).toBe("Alice");
+    expect(positionFinding!.message).toMatch(/Invalid enum value/);
+  });
+
+  it("emits a finding when stakeholder name is missing (Zod rejects displayName)", () => {
+    const policies = [
+      policy({
+        stakeholders: [{ position: "support" } as Record<string, unknown>],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings.length).toBeGreaterThan(0);
+    expect(r.findings.some((f) => f.field.includes("stakeholderDisplayName"))).toBe(true);
+  });
+
+  it("emits a finding when entityId is a number (helper-vs-validator drift fix)", () => {
+    // The runtime helper would forward `entityId: 42` via `s.entityId || null` →
+    // 42 (truthy). The route's Zod schema requires string-or-null. The
+    // validator must catch this same drift at PR time, not silently coerce
+    // to null and pass.
+    const policies = [
+      policy({
+        stakeholders: [
+          { name: "Alice", position: "support", entityId: 42 } as Record<string, unknown>,
+        ],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings.some((f) => f.field === "stakeholderEntityId")).toBe(true);
+  });
+
+  it("emits a finding when context is a string (route schema requires array)", () => {
+    const policies = [
+      policy({
+        stakeholders: [
+          { name: "Alice", position: "support", context: "single" } as Record<
+            string,
+            unknown
+          >,
+        ],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings.some((f) => f.field.startsWith("context"))).toBe(true);
+  });
+
+  it("skips policies missing stableId (mirrors helper)", () => {
+    const policies = [
+      policy({
+        stableId: undefined,
+        stakeholders: [{ name: "Alice", position: "support" }],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.skippedPolicies).toBe(1);
+    expect(r.checkedPolicies).toBe(0);
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it("emits multiple findings per policy (each Zod issue → separate finding)", () => {
+    const policies = [
+      policy({
+        stakeholders: [
+          // Both position invalid AND name missing — should produce 2+ findings.
+          { position: "reform" } as Record<string, unknown>,
+        ],
+      }),
+    ];
+    const r = evaluatePolicies(policies);
+    expect(r.findings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("non-empty findings flow through runCheck()", async () => {
+    // runCheck() reads real YAML — it must currently pass. This is the
+    // smoke test that runCheck still wires `evaluatePolicies` correctly.
+    const r = await runCheck();
+    expect(r.passed).toBe(true);
+    expect(r.errors).toBe(0);
   });
 });

--- a/crux/validate/validate-policy-stakeholders-strict.ts
+++ b/crux/validate/validate-policy-stakeholders-strict.ts
@@ -62,7 +62,7 @@ interface PolicyEntity {
   stakeholders?: Stakeholder[];
 }
 
-interface StrictFinding {
+export interface StrictFinding {
   policyId: string;
   stakeholder: string;
   field: string;
@@ -93,29 +93,40 @@ function loadPolicyEntities(): Array<PolicyEntity & { _sourceFile: string }> {
 }
 
 /**
- * Build the same `item` shape that wiki-server-data.mjs sends to the sync
+ * Build the EXACT `item` shape that wiki-server-data.mjs sends to the sync
  * route. Mirrors the transform at apps/web/scripts/lib/wiki-server-data.mjs:917-929
- * so any drift between the two transforms shows up here as a strict-schema
- * failure.
+ * — including its `||` semantics (any falsy value collapses to null) — so the
+ * validator sends Zod the same payload the runtime helper would, and any
+ * drift between the two transforms shows up here as a strict-schema failure
+ * rather than a false-negative pass.
+ *
+ * If the route's Zod schema would reject a value (e.g. `entityId: 42`,
+ * `context: "string"`, `name: 17`), we let it through unmodified and Zod
+ * catches it — same as the runtime path.
+ *
+ * Returns null only when the helper itself would skip (no policy.stableId).
+ * QUA-964 ticket calls out this exact-mirror property.
  */
 function buildSyncItem(
   policy: PolicyEntity,
   s: Stakeholder,
-): Record<string, unknown> | null {
-  if (!policy.stableId || typeof policy.stableId !== "string") return null;
-  if (typeof s.name !== "string" || !s.name) return null;
+): Record<string, unknown> {
+  // The helper at wiki-server-data.mjs:914 generates the id from `${policyEntityId}:${s.name}`.
+  // If either is non-string, JS coercion produces "[object Object]" / "undefined" / etc.
+  // and Zod catches the bad shape via stakeholderDisplayName (must-string) or
+  // policyEntityId (must-string min(1)) — same as the runtime path would.
+  const nameForId = String(s.name ?? "");
   const policyEntityId = policy.stableId;
-  const id = generateShortId(`${policyEntityId}:${s.name}`);
+  const id = generateShortId(`${String(policyEntityId ?? "")}:${nameForId}`);
   const item: Record<string, unknown> = {
     id,
     policyEntityId,
-    stakeholderEntityId:
-      typeof s.entityId === "string" && s.entityId.length > 0 ? s.entityId : null,
+    stakeholderEntityId: s.entityId || null,
     stakeholderDisplayName: s.name,
     position: s.position,
-    reason: typeof s.reason === "string" && s.reason.length > 0 ? s.reason : null,
-    source: typeof s.source === "string" && s.source.length > 0 ? s.source : null,
-    context: Array.isArray(s.context) ? s.context : null,
+    reason: s.reason || null,
+    source: s.source || null,
+    context: s.context || null,
   };
   if (s.importance) item.importance = s.importance;
   if (s.sourcing) item.sourcing = s.sourcing;
@@ -137,8 +148,19 @@ export interface RunResult extends ValidatorResult {
   checkedPolicies: number;
 }
 
-export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
-  const policies = loadPolicyEntities();
+/**
+ * Pure evaluator — given a list of policies, return findings + counts.
+ * Split from `runCheck` so tests can drive the negative path with synthetic
+ * fixtures instead of mutating real YAML on disk.
+ */
+export function evaluatePolicies(
+  policies: Array<PolicyEntity & { _sourceFile: string }>,
+): {
+  findings: StrictFinding[];
+  checkedStakeholders: number;
+  checkedPolicies: number;
+  skippedPolicies: number;
+} {
   const findings: StrictFinding[] = [];
   let checkedStakeholders = 0;
   let skippedPolicies = 0;
@@ -155,16 +177,6 @@ export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
       const item = buildSyncItem(policy, s);
       const stakeholderLabel =
         typeof s.name === "string" ? s.name : "(missing name)";
-      if (item === null) {
-        findings.push({
-          policyId,
-          stakeholder: stakeholderLabel,
-          field: "name",
-          message: "stakeholder missing required `name` field",
-          sourceFile: policy._sourceFile,
-        });
-        continue;
-      }
       checkedStakeholders++;
       const result = SyncStakeholderItemSchema.safeParse(item);
       if (!result.success) {
@@ -181,12 +193,25 @@ export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
     }
   }
 
+  return {
+    findings,
+    checkedStakeholders,
+    checkedPolicies: policies.length - skippedPolicies,
+    skippedPolicies,
+  };
+}
+
+export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
+  const policies = loadPolicyEntities();
+  const { findings, checkedStakeholders, checkedPolicies, skippedPolicies } =
+    evaluatePolicies(policies);
+
   if (options.ci) {
     process.stdout.write(
       JSON.stringify(
         {
           ok: findings.length === 0,
-          checkedPolicies: policies.length - skippedPolicies,
+          checkedPolicies,
           checkedStakeholders,
           findings,
         },
@@ -196,7 +221,7 @@ export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
     );
   } else if (findings.length === 0) {
     console.log(
-      `✓ policy-stakeholders strict: ${checkedStakeholders} stakeholders across ${policies.length - skippedPolicies} policies pass route Zod schema.`,
+      `✓ policy-stakeholders strict: ${checkedStakeholders} stakeholders across ${checkedPolicies} policies pass route Zod schema.`,
     );
     if (skippedPolicies > 0) {
       console.log(
@@ -233,7 +258,7 @@ export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
     infos: 0,
     findings,
     checkedStakeholders,
-    checkedPolicies: policies.length - skippedPolicies,
+    checkedPolicies,
   };
 }
 

--- a/crux/validate/validate-policy-stakeholders-strict.ts
+++ b/crux/validate/validate-policy-stakeholders-strict.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+/**
+ * Strict policy-stakeholders validator (QUA-964 / QUA-941 bridge).
+ *
+ * Runs the canonical sync-route Zod schema against every
+ * `policy.stakeholders[]` block in `data/entities/responses.yaml` (and any
+ * other YAML file under `data/entities/`).
+ *
+ * Why this exists: the QUA-941 incident was a YAML PR introducing
+ * `position: reform` (an unsupported enum value). The build helper
+ * silently swallowed the resulting Zod 400 from the sync route and 10 rows
+ * never made it to PG. This validator runs the same Zod schema the route
+ * uses, at PR-review time, so the same class of mistake fails CI rather
+ * than corrupts data.
+ *
+ * Schema source-of-truth:
+ *   apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts
+ *
+ * The validator imports `SyncStakeholderItemSchema` directly so any future
+ * tightening of the route schema (new required fields, narrower enums,
+ * etc.) is automatically enforced here too.
+ *
+ * Usage:
+ *   npx tsx crux/validate/validate-policy-stakeholders-strict.ts
+ *   npx tsx crux/validate/validate-policy-stakeholders-strict.ts --ci
+ *
+ * Exit codes:
+ *   0 = OK
+ *   1 = at least one stakeholder fails strict schema
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { createHash } from "crypto";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
+import type { ZodIssue } from "zod";
+import { PROJECT_ROOT, DATA_DIR } from "../lib/content-types.ts";
+import {
+  SyncStakeholderItemSchema,
+  VALID_POSITIONS,
+  VALID_IMPORTANCE,
+} from "../../apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts";
+import type { ValidatorResult } from "./types.ts";
+
+interface Stakeholder {
+  name?: unknown;
+  entityId?: unknown;
+  position?: unknown;
+  importance?: unknown;
+  reason?: unknown;
+  source?: unknown;
+  context?: unknown;
+  sourcing?: unknown;
+}
+
+interface PolicyEntity {
+  id?: string;
+  type?: string;
+  stableId?: string;
+  stakeholders?: Stakeholder[];
+}
+
+interface StrictFinding {
+  policyId: string;
+  stakeholder: string;
+  field: string;
+  message: string;
+  sourceFile: string;
+}
+
+function generateShortId(input: string): string {
+  return createHash("sha256").update(input).digest("base64url").substring(0, 10);
+}
+
+function loadPolicyEntities(): Array<PolicyEntity & { _sourceFile: string }> {
+  const entitiesDir = join(PROJECT_ROOT, DATA_DIR, "entities");
+  if (!existsSync(entitiesDir)) return [];
+  const files = readdirSync(entitiesDir).filter((f) => f.endsWith(".yaml"));
+  const out: Array<PolicyEntity & { _sourceFile: string }> = [];
+  for (const file of files) {
+    const filepath = join(entitiesDir, file);
+    const data = parseYaml(readFileSync(filepath, "utf-8"));
+    if (!Array.isArray(data)) continue;
+    for (const item of data) {
+      if (item?.type === "policy" && Array.isArray(item.stakeholders) && item.stakeholders.length > 0) {
+        out.push({ ...item, _sourceFile: filepath });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the same `item` shape that wiki-server-data.mjs sends to the sync
+ * route. Mirrors the transform at apps/web/scripts/lib/wiki-server-data.mjs:917-929
+ * so any drift between the two transforms shows up here as a strict-schema
+ * failure.
+ */
+function buildSyncItem(
+  policy: PolicyEntity,
+  s: Stakeholder,
+): Record<string, unknown> | null {
+  if (!policy.stableId || typeof policy.stableId !== "string") return null;
+  if (typeof s.name !== "string" || !s.name) return null;
+  const policyEntityId = policy.stableId;
+  const id = generateShortId(`${policyEntityId}:${s.name}`);
+  const item: Record<string, unknown> = {
+    id,
+    policyEntityId,
+    stakeholderEntityId:
+      typeof s.entityId === "string" && s.entityId.length > 0 ? s.entityId : null,
+    stakeholderDisplayName: s.name,
+    position: s.position,
+    reason: typeof s.reason === "string" && s.reason.length > 0 ? s.reason : null,
+    source: typeof s.source === "string" && s.source.length > 0 ? s.source : null,
+    context: Array.isArray(s.context) ? s.context : null,
+  };
+  if (s.importance) item.importance = s.importance;
+  if (s.sourcing) item.sourcing = s.sourcing;
+  return item;
+}
+
+function describeIssue(issue: ZodIssue): string {
+  const path = issue.path.join(".") || "(root)";
+  return `${path}: ${issue.message}`;
+}
+
+export interface RunOptions {
+  ci?: boolean;
+}
+
+export interface RunResult extends ValidatorResult {
+  findings: StrictFinding[];
+  checkedStakeholders: number;
+  checkedPolicies: number;
+}
+
+export async function runCheck(options: RunOptions = {}): Promise<RunResult> {
+  const policies = loadPolicyEntities();
+  const findings: StrictFinding[] = [];
+  let checkedStakeholders = 0;
+  let skippedPolicies = 0;
+
+  for (const policy of policies) {
+    if (!policy.stableId) {
+      // Policies without stableId never get synced — mirror the build helper's
+      // behavior (apps/web/scripts/lib/wiki-server-data.mjs:908-911 skips).
+      skippedPolicies++;
+      continue;
+    }
+    const policyId = policy.id ?? "(unknown)";
+    for (const s of policy.stakeholders ?? []) {
+      const item = buildSyncItem(policy, s);
+      const stakeholderLabel =
+        typeof s.name === "string" ? s.name : "(missing name)";
+      if (item === null) {
+        findings.push({
+          policyId,
+          stakeholder: stakeholderLabel,
+          field: "name",
+          message: "stakeholder missing required `name` field",
+          sourceFile: policy._sourceFile,
+        });
+        continue;
+      }
+      checkedStakeholders++;
+      const result = SyncStakeholderItemSchema.safeParse(item);
+      if (!result.success) {
+        for (const issue of result.error.issues) {
+          findings.push({
+            policyId,
+            stakeholder: stakeholderLabel,
+            field: issue.path.join(".") || "(root)",
+            message: describeIssue(issue),
+            sourceFile: policy._sourceFile,
+          });
+        }
+      }
+    }
+  }
+
+  if (options.ci) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: findings.length === 0,
+          checkedPolicies: policies.length - skippedPolicies,
+          checkedStakeholders,
+          findings,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  } else if (findings.length === 0) {
+    console.log(
+      `✓ policy-stakeholders strict: ${checkedStakeholders} stakeholders across ${policies.length - skippedPolicies} policies pass route Zod schema.`,
+    );
+    if (skippedPolicies > 0) {
+      console.log(
+        `  (${skippedPolicies} polic${skippedPolicies === 1 ? "y" : "ies"} skipped — no stableId, won't sync)`,
+      );
+    }
+  } else {
+    console.error(
+      `✗ policy-stakeholders strict: ${findings.length} schema violation${findings.length === 1 ? "" : "s"} (across ${checkedStakeholders} stakeholders):`,
+    );
+    for (const f of findings) {
+      console.error(
+        `  [${f.policyId} / ${f.stakeholder}] ${f.message}  (${f.sourceFile})`,
+      );
+    }
+    console.error("");
+    console.error(
+      `Allowed positions: ${VALID_POSITIONS.join(", ")}`,
+    );
+    console.error(
+      `Allowed importance: ${VALID_IMPORTANCE.join(", ")}`,
+    );
+    console.error(
+      "\nThe sync route's Zod schema rejects these payloads with a 400. " +
+        "Build now fails loud (QUA-964) — so silent data drops like QUA-941 cannot recur. " +
+        "Fix the YAML or extend the schema in policy-stakeholders-schema.ts.",
+    );
+  }
+
+  return {
+    passed: findings.length === 0,
+    errors: findings.length,
+    warnings: 0,
+    infos: 0,
+    findings,
+    checkedStakeholders,
+    checkedPolicies: policies.length - skippedPolicies,
+  };
+}
+
+async function main(): Promise<void> {
+  const ci = process.argv.includes("--ci") || process.argv.includes("--json");
+  const result = await runCheck({ ci });
+  process.exit(result.passed ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("validate-policy-stakeholders-strict crashed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Closes the QUA-941 vulnerability class (silent stakeholder drop) by:

1. **Fail-loud `syncPolicyStakeholders`** — `apps/web/scripts/lib/wiki-server-data.mjs` now distinguishes FK-missing 400s (legitimate skip — some YAML stakeholders reference entities not yet in PG) from any other 400 (data corruption). Non-FK errors print the offending policy ID + response body to stderr and `process.exit(1)`.
2. **Strict gate validator** — `crux/validate/validate-policy-stakeholders-strict.ts` runs the canonical sync-route Zod schema against every `policy.stakeholders[]` block in `data/entities/` at PR-review time, so a YAML PR introducing `position: reform` (or any other route-rejected enum) fails `pnpm crux w validate gate` instead of getting silently dropped at build-data time.
3. **Schema extracted to standalone file** — `apps/wiki-server/src/routes/tablebase/policy-stakeholders-schema.ts` holds `SyncStakeholderItemSchema`, `VALID_POSITIONS`, `VALID_IMPORTANCE`. The route imports from it; the validator imports from it. Single source of truth — any future schema tightening at the route fires the gate validator automatically.

## Acceptance per ticket

- ✅ `pnpm crux w validate gate` fails on a YAML PR that introduces `position: reform` or any other non-allowed enum (verified manually by injecting + running the validator).
- ✅ A sync route returning `{error: "validation_error", ...}` for a non-FK reason now causes `pnpm build` to exit 1 with the offending policy ID in stderr.
- ✅ Zero `position: reform` rows in `data/entities/responses.yaml` (already cleaned by QUA-941 hotfix #4744 — re-verified: 244 stakeholders across 39 policies, all canonical positions).
- ✅ Existing FK-missing 400s still produce `skipped` counts (matched by `body.includes('Entity references not found')`).

## Why this is independent of QUA-943's full v4 cutover

The QUA-941 mechanism is a 10-line `skipped++` bug + a missing strict-schema import at PR time. Neither requires PG-primary writes. v4 (Phases 0–4) is the structural fix; this PR is the tourniquet that closes the immediate vulnerability while v4 proceeds on its own pace.

## Soft dependency on QUA-951 (validationError discriminator)

The fail-loud check uses string-matching on `"Entity references not found"` to detect FK errors. Once QUA-951 lands the `code:` discriminator, the check switches to `body.includes('"code":"fk_missing"')` — TODO comment in place at the relevant line.

## Review fixes (commit f763ff35)

`/agent-review-pr` flagged 2 HIGH + 1 MEDIUM that landed in the review commit:

- **HIGH**: validator's `buildSyncItem` did NOT mirror the helper's `||` semantics — `typeof === "string"` checks coerced non-string `entityId`/`reason`/`source`/`context` to null, so YAML like `entityId: 42` would silently pass the gate while the runtime helper would now correctly fail loud. Fixed: validator passes values through unchanged, Zod catches drift at both sites.
- **HIGH**: only `runCheck()` against current passing YAML was tested. Split into pure `evaluatePolicies(policies)` + thin `runCheck` wrapper. 8 new fixture tests drive the negative path: `position: reform`, missing name, numeric `entityId`, string-typed `context`, missing stableId, multi-issue policies.
- **MEDIUM**: in `syncPolicyStakeholders`, the outer try/catch swallowed `r.text()` throws (interrupted body stream after a non-2xx) and silently incremented `skipped` — exactly the QUA-941 silent-drop pattern. Fixed: split fetch + body-read error handling so only network errors on `fetch()` skip; a 4xx with unreadable body fails loud.

## Test plan

- [x] `npx tsx crux/validate/validate-policy-stakeholders-strict.ts` against current YAML — passes (244 stakeholders, 39 policies)
- [x] Same with one row mutated to `position: reform` — fails with `Invalid enum value` finding and exit 1
- [x] Same with `entityId: 42` injected — fails with `Expected string, received number` (regression test for the helper-vs-validator drift fix)
- [x] `crux/validate/validate-policy-stakeholders-strict.test.ts` — 16 unit tests (8 schema-level, 8 fixture-driven negative paths)
- [x] `pnpm test` (apps/wiki-server) — 1555 pass (mount-registry covers the new schema file)
- [x] `pnpm test` (apps/web) — 1904 pass
- [x] `tsc --noEmit` (apps/web + apps/wiki-server) — clean
- [x] `pnpm crux w validate gate --fix --no-cache` — 70/70 checks pass (2 unrelated advisories: crux baseline tsc, orphan entities)

Closes QUA-964.
