### PR TITLE
QUA-952: emit code: discriminators on canary's 3 routes

### DIFF
--- a/apps/wiki-server/src/__tests__/validation-error-code-discriminator.test.ts
+++ b/apps/wiki-server/src/__tests__/validation-error-code-discriminator.test.ts
@@ -1,0 +1,292 @@
+/**
+ * QUA-952 (Phase 0a-ii) — canary `code:` discriminator response shapes.
+ *
+ * Asserts that the 3 canary routes emit structured `code:` discriminators in
+ * their 400 responses so Phase 2 dual-write retry-with-feedback (Phase 3) can
+ * dispatch on `code` instead of pattern-matching `message`:
+ *
+ *   1. `policy-stakeholders` Zod parse → `code: "zod"` or `code: "enum_violation"`
+ *      (emitted by sync-factory's Zod return path; bullet 3 of the ticket).
+ *   2. `validate-entity-refs` FK miss → `code: "fk_missing"` (bullet 2).
+ *   3. Sync-factory Zod parse fields populate `field`/`value`/`allowed` so a
+ *      retry consumer can re-prompt with the rejected input (bullet 3).
+ *
+ * Other 156+ legacy 1-arg `validationError(c, "...")` callsites are NOT in
+ * scope for QUA-952 — see QUA-943 v4 RFC §0a-ii. Their response shapes are
+ * unchanged and intentionally untested here so this file stays focused on
+ * the canary contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { mockDbModule, postJson } from "./test-utils.js";
+
+// ---- In-memory stores ----
+
+let entitiesStore: Map<string, Record<string, unknown>>;
+
+function resetStores() {
+  entitiesStore = new Map();
+}
+
+function dispatch(query: string, params: unknown[]): unknown[] {
+  const q = query.toLowerCase();
+
+  // --- validate-entity-refs: unnest + entities check ---
+  if (q.includes("unnest") && q.includes("from entities")) {
+    return params
+      .filter((p) => {
+        const id = p as string;
+        if (entitiesStore.has(id)) return true;
+        for (const row of entitiesStore.values()) {
+          if (row.stable_id === id) return true;
+        }
+        return false;
+      })
+      .map((p) => ({ ref: p }));
+  }
+
+  // --- source-check enforcement reads (always empty so the bypass param is
+  //     all we need to skip the sourcing phase in these tests) ---
+  if (q.includes("source_check_verdicts") || q.includes("source_check_evidence")) {
+    return [];
+  }
+
+  return [];
+}
+
+vi.mock("../db.js", () => mockDbModule(dispatch));
+
+const { createApp } = await import("../app.js");
+
+// Source-check bypass — these tests focus on validationError shapes, not
+// sourcing enforcement. policy_stakeholders has enforceSourcing: true, so
+// without the bypass any happy-path or post-sourcing 400 would never reach
+// the validation phases we care about here.
+const SC_BYPASS = "forceSkipSourcing=true&reason=test";
+
+function seedEntity(id: string, stableId?: string) {
+  entitiesStore.set(id, {
+    id,
+    stable_id: stableId ?? id,
+    entity_type: "policy",
+    title: `Entity ${id}`,
+  });
+}
+
+describe("QUA-952 — canary `code:` discriminator shapes", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    resetStores();
+    delete process.env.LONGTERMWIKI_SERVER_API_KEY;
+    app = createApp();
+  });
+
+  // --------------------------------------------------------------------------
+  // Bullet 3: sync-factory Zod return path
+  // (covers bullet 1 indirectly — policy-stakeholders body Zod errors flow
+  //  through createSyncHandler.)
+  // --------------------------------------------------------------------------
+
+  describe("sync-factory Zod return path (policy-stakeholders /sync)", () => {
+    it("invalid enum value → code: 'enum_violation' with field/value/allowed", async () => {
+      seedEntity("sid_policy01");
+
+      const res = await postJson(
+        app,
+        `/api/policy-stakeholders/sync?${SC_BYPASS}`,
+        {
+          items: [
+            {
+              id: "aaaaaaaaaa",
+              policyEntityId: "sid_policy01",
+              stakeholderDisplayName: "Acme Corp",
+              // "endorse" is not in VALID_POSITIONS → invalid_enum_value
+              position: "endorse",
+            },
+          ],
+        },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.error).toBe("validation_error");
+      expect(body.code).toBe("enum_violation");
+      // Path is inside an array, so field uses bracket notation.
+      expect(body.field).toBe("items[0].position");
+      expect(body.value).toBe("endorse");
+      expect(body.allowed).toEqual(
+        expect.arrayContaining(["support", "oppose", "neutral", "mixed"]),
+      );
+      // Original Zod error JSON is preserved in `message` for back-compat.
+      expect(typeof body.message).toBe("string");
+      expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    it("non-enum Zod failure → code: 'zod' with field detail (when available)", async () => {
+      seedEntity("sid_policy01");
+
+      const res = await postJson(
+        app,
+        `/api/policy-stakeholders/sync?${SC_BYPASS}`,
+        {
+          items: [
+            {
+              // id must be exactly 10 chars; 5 chars triggers a Zod string-length
+              // issue (code: invalid_string / too_small), NOT invalid_enum_value.
+              id: "short",
+              policyEntityId: "sid_policy01",
+              stakeholderDisplayName: "Acme Corp",
+              position: "support",
+            },
+          ],
+        },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.error).toBe("validation_error");
+      expect(body.code).toBe("zod");
+      // Should NOT classify as enum_violation just because some other field
+      // happens to be an enum.
+      expect(body.allowed).toBeUndefined();
+      // Field path points into the offending item.
+      expect(body.field).toContain("items[0]");
+      expect(body.field).toContain("id");
+      // Message preserves the full ZodError JSON dump for back-compat.
+      expect(typeof body.message).toBe("string");
+    });
+
+    it("missing required field → code: 'zod' with field path", async () => {
+      seedEntity("sid_policy01");
+
+      const res = await postJson(
+        app,
+        `/api/policy-stakeholders/sync?${SC_BYPASS}`,
+        {
+          items: [
+            {
+              id: "aaaaaaaaaa",
+              // policyEntityId omitted entirely → Zod invalid_type (received undefined)
+              stakeholderDisplayName: "Acme Corp",
+              position: "support",
+            },
+          ],
+        },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.error).toBe("validation_error");
+      expect(body.code).toBe("zod");
+      expect(body.field).toContain("policyEntityId");
+      // `value` surfaces the rejected input ("undefined") so a retry consumer
+      // knows the field was absent rather than malformed.
+      expect(body.value).toBe("undefined");
+    });
+
+    it("invalid JSON body → invalid_json envelope (NOT validation_error)", async () => {
+      // Sanity: the structured discriminator is for validation_error only.
+      // Malformed JSON takes a separate envelope (`error: "invalid_json"`),
+      // which must not be conflated with the new `code:` field.
+      const res = await app.request(
+        `/api/policy-stakeholders/sync?${SC_BYPASS}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{ not json",
+        },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("invalid_json");
+      // The discriminator field belongs to validation_error envelopes only.
+      expect(body.code).toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Bullet 2: validate-entity-refs FK miss
+  // --------------------------------------------------------------------------
+
+  describe("validate-entity-refs FK miss (policy-stakeholders /sync)", () => {
+    it("missing entity FK → code: 'fk_missing' with field/value", async () => {
+      // Don't seed sid_policy01 — the FK lookup will fail.
+
+      const res = await postJson(
+        app,
+        `/api/policy-stakeholders/sync?${SC_BYPASS}`,
+        {
+          items: [
+            {
+              id: "aaaaaaaaaa",
+              policyEntityId: "sid_policy01",
+              stakeholderDisplayName: "Acme Corp",
+              position: "support",
+            },
+          ],
+        },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.error).toBe("validation_error");
+      expect(body.code).toBe("fk_missing");
+      expect(body.field).toBe("policyEntityId");
+      // `value` carries the array of missing IDs in that field — a retry
+      // consumer iterates over it to know which references to fix.
+      expect(body.value).toEqual(["sid_policy01"]);
+      // The bypass instruction in the human-readable message is preserved
+      // verbatim for the QUA-940 deny-message contract — `validate-entity-refs`'s
+      // shouldSkipEntityValidation rule depends on this exact wording.
+      expect(body.message).toContain(
+        "skipEntityValidation=true&skipEntityValidationReason=<why>",
+      );
+      // And the structured code does not displace the human-readable detail.
+      expect(body.message).toContain("policyEntityId");
+      expect(body.message).toContain("sid_policy01");
+    });
+
+    it("multiple missing FK fields → code: 'fk_missing' on first field; message lists all", async () => {
+      // Sanity: the structured response is single-field by design (Phase 3
+      // retry-with-feedback only handles one field per re-prompt) but the
+      // legacy `message` enumerates every missing field so a human operator
+      // sees the full picture in one shot.
+      //
+      // policy-stakeholders only validates one FK field (`policyEntityId`) so
+      // we can't trigger multi-field misses on that route. Use the personnel
+      // sync path which validates BOTH `personId` and `organizationId`.
+      const res = await postJson(app, `/api/personnel/sync?${SC_BYPASS}`, {
+        items: [
+          {
+            id: "Pabcde1234",
+            personId: "missPER001",
+            organizationId: "missORG001",
+            role: "CEO",
+            roleType: "key-person",
+          },
+        ],
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.code).toBe("fk_missing");
+      // First missing field populates the structured slot…
+      expect(typeof body.field).toBe("string");
+      expect(["personId", "organizationId"]).toContain(body.field as string);
+      expect(Array.isArray(body.value)).toBe(true);
+      // …and BOTH missing fields appear in the human-readable message.
+      expect(body.message).toContain("personId");
+      expect(body.message).toContain("missPER001");
+      expect(body.message).toContain("organizationId");
+      expect(body.message).toContain("missORG001");
+    });
+  });
+});

--- a/apps/wiki-server/src/__tests__/validation-error-code-discriminator.test.ts
+++ b/apps/wiki-server/src/__tests__/validation-error-code-discriminator.test.ts
@@ -1,20 +1,27 @@
 /**
- * QUA-952 (Phase 0a-ii) — canary `code:` discriminator response shapes.
+ * QUA-952 (Phase 0a-ii) — `code:` discriminator response shapes.
  *
- * Asserts that the 3 canary routes emit structured `code:` discriminators in
- * their 400 responses so Phase 2 dual-write retry-with-feedback (Phase 3) can
- * dispatch on `code` instead of pattern-matching `message`:
+ * Asserts that the canary's three validation paths emit structured `code:`
+ * discriminators in their 400 responses, so Phase 2 dual-write
+ * retry-with-feedback (Phase 3) can dispatch on `code` instead of
+ * pattern-matching `message`:
  *
- *   1. `policy-stakeholders` Zod parse → `code: "zod"` or `code: "enum_violation"`
- *      (emitted by sync-factory's Zod return path; bullet 3 of the ticket).
- *   2. `validate-entity-refs` FK miss → `code: "fk_missing"` (bullet 2).
- *   3. Sync-factory Zod parse fields populate `field`/`value`/`allowed` so a
- *      retry consumer can re-prompt with the rejected input (bullet 3).
+ *   1. policy-stakeholders body Zod parse → `code: "zod"` or
+ *      `code: "enum_violation"` (emitted by sync-factory's Zod return path,
+ *      inherited by every route mounted on `createSyncHandler`).
+ *   2. `validateEntityRefs` FK miss → `code: "fk_missing"`.
+ *   3. Sync-factory Zod parse populates `field`/`value`/`allowed` so a retry
+ *      consumer can re-prompt with the rejected input.
  *
- * Other 156+ legacy 1-arg `validationError(c, "...")` callsites are NOT in
- * scope for QUA-952 — see QUA-943 v4 RFC §0a-ii. Their response shapes are
- * unchanged and intentionally untested here so this file stays focused on
- * the canary contract.
+ * **Scope note.** policy-stakeholders has only one FK field
+ * (`policyEntityId`), so the multi-field `fk_missing` test below uses
+ * `/api/personnel/sync` — not because personnel is a canary route, but
+ * because the change to `validateEntityRefs` is shared infrastructure used
+ * by all sync routes, and personnel is the simplest mount with two FK
+ * fields. Other 156+ legacy 1-arg `validationError(c, "...")` callsites
+ * (which include the entire query-param `zv()` validator path and the
+ * natural-key collision path inside sync-factory) are NOT in scope and are
+ * unchanged.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -242,9 +249,11 @@ describe("QUA-952 — canary `code:` discriminator shapes", () => {
       // `value` carries the array of missing IDs in that field — a retry
       // consumer iterates over it to know which references to fix.
       expect(body.value).toEqual(["sid_policy01"]);
-      // The bypass instruction in the human-readable message is preserved
-      // verbatim for the QUA-940 deny-message contract — `validate-entity-refs`'s
-      // shouldSkipEntityValidation rule depends on this exact wording.
+      // The bypass instruction is preserved verbatim in `message` so an
+      // operator pasting a 400 into chat can read the syntax without
+      // server-log access. (The QUA-940 deny-message contract proper lives
+      // in the error-level log inside `shouldSkipEntityValidation`, not
+      // here — this body string is just the operator-facing mirror.)
       expect(body.message).toContain(
         "skipEntityValidation=true&skipEntityValidationReason=<why>",
       );
@@ -288,5 +297,150 @@ describe("QUA-952 — canary `code:` discriminator shapes", () => {
       expect(body.message).toContain("organizationId");
       expect(body.message).toContain("missORG001");
     });
+
+    it("caps `value` at FK_MISSING_VALUE_CAP for very large batches", async () => {
+      // Sanity: a 60-item batch with every reference missing produces 60
+      // missing IDs in one field. The structured `value` array caps at 50
+      // (FK_MISSING_VALUE_CAP); the full list is still in `message`.
+      // Without a cap a 500-item all-invalid batch would push 10–50KB of
+      // IDs into the response body.
+      // id must be exactly 10 alphanumeric chars (personnel schema regex).
+      const items = Array.from({ length: 60 }, (_, i) => ({
+        id: `Pca${String(i).padStart(7, "0")}`,
+        personId: `nxPER${String(i).padStart(5, "0")}`,
+        organizationId: "nxOrg00000",
+        role: "CEO",
+        roleType: "key-person",
+      }));
+
+      const res = await postJson(app, `/api/personnel/sync?${SC_BYPASS}`, {
+        items,
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+
+      expect(body.code).toBe("fk_missing");
+      expect(Array.isArray(body.value)).toBe(true);
+      // The cap protects only the structured `value`, not `message`, so
+      // both halves of the contract live in this assertion pair.
+      expect((body.value as unknown[]).length).toBeLessThanOrEqual(50);
+      // …and the full set still appears in the message (last item proves
+      // we didn't truncate that side).
+      expect(body.message).toContain("nxPER00059");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct unit tests for the zodErrorToValidationBody helper. These exercise
+// edge cases that no canary route triggers (empty issues array, root-level
+// path, hand-constructed ZodError shapes), so they live here rather than in
+// the route-integration suites above.
+// ---------------------------------------------------------------------------
+
+describe("zodErrorToValidationBody (direct unit)", () => {
+  it("returns code: 'zod' with no field for a root-path issue", async () => {
+    const { z } = await import("zod");
+    const { zodErrorToValidationBody } = await import(
+      "../routes/shared/utils.js"
+    );
+
+    const err = new z.ZodError([
+      {
+        code: "custom",
+        path: [],
+        message: "root-level failure",
+      },
+    ]);
+    const body = zodErrorToValidationBody(err);
+
+    expect(body.code).toBe("zod");
+    // Empty path → no field key (omitted, not literal undefined string).
+    expect(Object.prototype.hasOwnProperty.call(body, "field")).toBe(false);
+    // No `received` on a `custom` issue → no `value` key.
+    expect(Object.prototype.hasOwnProperty.call(body, "value")).toBe(false);
+  });
+
+  it("returns code: 'zod' with the issue's message when issues[] is empty", async () => {
+    const { z } = await import("zod");
+    const { zodErrorToValidationBody } = await import(
+      "../routes/shared/utils.js"
+    );
+
+    // Hand-constructed ZodError with no issues — won't happen in practice
+    // (Zod always populates at least one) but the helper has an explicit
+    // fallback branch that should not throw.
+    const err = new z.ZodError([]);
+    const body = zodErrorToValidationBody(err);
+
+    expect(body.code).toBe("zod");
+    expect(typeof body.message).toBe("string");
+  });
+
+  it("formats array-index path with bracket notation", async () => {
+    const { z } = await import("zod");
+    const { zodErrorToValidationBody } = await import(
+      "../routes/shared/utils.js"
+    );
+
+    const err = new z.ZodError([
+      {
+        code: "invalid_type",
+        path: ["items", 0, "policyEntityId"],
+        message: "Required",
+        expected: "string",
+        received: "undefined",
+      },
+    ]);
+    const body = zodErrorToValidationBody(err);
+
+    expect(body.field).toBe("items[0].policyEntityId");
+  });
+
+  it("formats number-only path as bare bracket", async () => {
+    const { z } = await import("zod");
+    const { zodErrorToValidationBody } = await import(
+      "../routes/shared/utils.js"
+    );
+
+    // Edge case: top-level array with index path. `[0]` is meaningful even
+    // without a parent field; the formatter must not produce `"0"` (which
+    // would be ambiguous with a string-keyed `"0"` field).
+    const err = new z.ZodError([
+      {
+        code: "invalid_type",
+        path: [0, "id"],
+        message: "Required",
+        expected: "string",
+        received: "undefined",
+      },
+    ]);
+    const body = zodErrorToValidationBody(err);
+
+    expect(body.field).toBe("[0].id");
+  });
+
+  it("populates allowed[] from invalid_enum_value options", async () => {
+    const { z } = await import("zod");
+    const { zodErrorToValidationBody } = await import(
+      "../routes/shared/utils.js"
+    );
+
+    const err = new z.ZodError([
+      {
+        code: "invalid_enum_value",
+        path: ["position"],
+        message: "Invalid enum value",
+        received: "endorse",
+        options: ["support", "oppose", "neutral", "mixed"],
+      },
+    ]);
+    const body = zodErrorToValidationBody(err);
+
+    expect(body.code).toBe("enum_violation");
+    expect(body.field).toBe("position");
+    expect(body.value).toBe("endorse");
+    expect(body.allowed).toEqual(["support", "oppose", "neutral", "mixed"]);
   });
 });

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -179,6 +179,69 @@ export function validationError(
   return c.json({ ...arg, error: VALIDATION_ERROR }, 400);
 }
 
+/**
+ * Format a ZodIssue path as a readable dotted string with bracket notation
+ * for array indices. `['items', 0, 'position']` → `'items[0].position'`.
+ *
+ * Empty path (root-level error) returns `""` so callers can omit the field.
+ */
+function formatZodPath(path: ReadonlyArray<string | number>): string {
+  return path.reduce<string>((acc, part) => {
+    if (typeof part === "number") return `${acc}[${part}]`;
+    return acc ? `${acc}.${part}` : String(part);
+  }, "");
+}
+
+/**
+ * Convert a `ZodError` into a structured `ValidationErrorBody` so callers
+ * can pass it to {@link validationError}'s structured overload.
+ *
+ * Detects `invalid_enum_value` issues automatically and emits
+ * `code: "enum_violation"` with `allowed[]` populated from the issue's
+ * `options`. All other Zod issues collapse to `code: "zod"`.
+ *
+ * Picks the first issue when multiple exist — Phase 2 retry-with-feedback
+ * only needs to know about one failure at a time, and the original
+ * `error.message` preserves the full list under `message` for human-readable
+ * fallback (and back-compat with legacy string-matching consumers).
+ *
+ * QUA-952: introduced for the Phase 0a-ii canary slice. Used by
+ * `createSyncHandler` and any new callsite that wants structured Zod codes.
+ */
+export function zodErrorToValidationBody(
+  error: z.ZodError
+): ValidationErrorBody {
+  const issue = error.issues[0];
+  if (!issue) {
+    return { code: "zod", message: error.message };
+  }
+
+  const field = formatZodPath(issue.path) || undefined;
+
+  if (issue.code === "invalid_enum_value") {
+    return {
+      code: "enum_violation",
+      ...(field !== undefined ? { field } : {}),
+      value: issue.received,
+      allowed: [...issue.options],
+      message: error.message,
+    };
+  }
+
+  // Many other ZodIssue variants (`invalid_type`, `invalid_literal`, etc.)
+  // carry a `received` field — surface it as `value` when available so a
+  // retry-with-feedback consumer can reprompt with the rejected input.
+  const issueWithReceived = issue as { received?: unknown };
+  const value =
+    "received" in issue ? issueWithReceived.received : undefined;
+  return {
+    code: "zod",
+    ...(field !== undefined ? { field } : {}),
+    ...(value !== undefined ? { value } : {}),
+    message: error.message,
+  };
+}
+
 /** Return a 400 invalid JSON error response. */
 export function invalidJsonError(c: Context) {
   return c.json(

--- a/apps/wiki-server/src/routes/shared/utils.ts
+++ b/apps/wiki-server/src/routes/shared/utils.ts
@@ -205,6 +205,17 @@ function formatZodPath(path: ReadonlyArray<string | number>): string {
  * `error.message` preserves the full list under `message` for human-readable
  * fallback (and back-compat with legacy string-matching consumers).
  *
+ * **JSON-safety contract.** This helper forwards the issue's `received`
+ * field directly into `value`, inheriting the {@link ValidationErrorBody}
+ * caveat that values must be JSON-safe (no `BigInt`, `Symbol`, function,
+ * or circular reference). For `ZodError`s produced by `safeParse(json)` —
+ * the case sync-factory uses — `received` is a primitive (`string`,
+ * `number`, `boolean`, `null`) or the `ZodParsedType` enum (`"undefined"`,
+ * `"object"`, etc.) and is always JSON-safe. Schemas with custom
+ * `transform` outputs that re-fail downstream Zod checks could in
+ * principle yield non-JSON-safe values; do not pass `ZodError`s from
+ * such pipelines through this helper without sanitizing first.
+ *
  * QUA-952: introduced for the Phase 0a-ii canary slice. Used by
  * `createSyncHandler` and any new callsite that wants structured Zod codes.
  */
@@ -231,9 +242,7 @@ export function zodErrorToValidationBody(
   // Many other ZodIssue variants (`invalid_type`, `invalid_literal`, etc.)
   // carry a `received` field — surface it as `value` when available so a
   // retry-with-feedback consumer can reprompt with the rejected input.
-  const issueWithReceived = issue as { received?: unknown };
-  const value =
-    "received" in issue ? issueWithReceived.received : undefined;
+  const value = (issue as { received?: unknown }).received;
   return {
     code: "zod",
     ...(field !== undefined ? { field } : {}),

--- a/apps/wiki-server/src/routes/shared/validate-entity-refs.ts
+++ b/apps/wiki-server/src/routes/shared/validate-entity-refs.ts
@@ -119,9 +119,18 @@ export async function validateEntityRefs(
     .map((m) => `${m.fieldName}: ${m.missingIds.join(", ")}`)
     .join("; ");
 
-  return validationError(
-    c,
+  // QUA-952 (Phase 0a-ii): emit structured `code: "fk_missing"` so canary
+  // callers can dispatch retry-with-feedback by FK class. The first missing
+  // field populates the structured `field`/`value` slots; the full
+  // multi-field summary stays in `message` (preserved verbatim for back-compat
+  // with existing string-matching consumers and for the QUA-940 deny-message
+  // contract on the bypass instruction).
+  const first = missing[0];
+  return validationError(c, {
+    code: "fk_missing",
+    field: first.fieldName,
+    value: first.missingIds,
     // skipEntityValidation-ok: error message text instructs callers how to bypass after providing a reason
-    `Entity references not found: ${details}. Use ?skipEntityValidation=true&skipEntityValidationReason=<why> to bypass.`,
-  );
+    message: `Entity references not found: ${details}. Use ?skipEntityValidation=true&skipEntityValidationReason=<why> to bypass.`,
+  });
 }

--- a/apps/wiki-server/src/routes/shared/validate-entity-refs.ts
+++ b/apps/wiki-server/src/routes/shared/validate-entity-refs.ts
@@ -119,18 +119,43 @@ export async function validateEntityRefs(
     .map((m) => `${m.fieldName}: ${m.missingIds.join(", ")}`)
     .join("; ");
 
-  // QUA-952 (Phase 0a-ii): emit structured `code: "fk_missing"` so canary
-  // callers can dispatch retry-with-feedback by FK class. The first missing
-  // field populates the structured `field`/`value` slots; the full
-  // multi-field summary stays in `message` (preserved verbatim for back-compat
-  // with existing string-matching consumers and for the QUA-940 deny-message
-  // contract on the bypass instruction).
+  // QUA-952 (Phase 0a-ii): emit structured `code: "fk_missing"` so callers
+  // can dispatch retry-with-feedback by FK class. The first missing field
+  // populates the structured `field`/`value` slots; the full multi-field
+  // summary stays in `message` for human-readable detail and to preserve
+  // back-compat with existing 1-arg-style string-matching consumers.
+  //
+  // The bypass instruction is intentionally repeated in `message` (not just
+  // logged) so an operator pasting a 400 response into a chat can read the
+  // bypass syntax without server-log access. The QUA-940 deny-message
+  // contract proper lives in the `error`-level log inside
+  // `shouldSkipEntityValidation` — this body string just mirrors the
+  // operator-facing hint.
+  //
+  // `value` caps at FK_MISSING_VALUE_CAP IDs to keep 400 responses bounded
+  // when a 500-item batch has every reference invalid. The full list still
+  // appears in `message` for now; a structured-only consumer will need to
+  // page over `field` if it has more than CAP missing IDs (Phase 3 retry
+  // re-prompts on one item at a time anyway).
   const first = missing[0];
+  const value =
+    first.missingIds.length > FK_MISSING_VALUE_CAP
+      ? first.missingIds.slice(0, FK_MISSING_VALUE_CAP)
+      : first.missingIds;
   return validationError(c, {
     code: "fk_missing",
     field: first.fieldName,
-    value: first.missingIds,
+    value,
     // skipEntityValidation-ok: error message text instructs callers how to bypass after providing a reason
     message: `Entity references not found: ${details}. Use ?skipEntityValidation=true&skipEntityValidationReason=<why> to bypass.`,
   });
 }
+
+/**
+ * Cap the size of the `value` array in fk_missing 400 responses. A 500-item
+ * batch with every reference invalid would otherwise serialize 500 IDs into
+ * `value` AND into the human-readable `message` (which already enumerates
+ * all of them), producing 10–50KB+ 400 responses. The full list is still
+ * available in `message`; this cap protects only the structured `value`.
+ */
+const FK_MISSING_VALUE_CAP = 50;

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -40,6 +40,7 @@ import {
   parseJsonBody,
   validationError,
   invalidJsonError,
+  zodErrorToValidationBody,
 } from "../shared/utils.js";
 import {
   validateEntityRefs,
@@ -472,7 +473,9 @@ export function createSyncHandler<
       batchSchema.safeParse(body),
     );
     if (!parsed.success) {
-      return validationError(c, parsed.error.message);
+      // QUA-952 (Phase 0a-ii): emit structured `code` so canary callers
+      // can dispatch retry-with-feedback on `enum_violation` vs generic `zod`.
+      return validationError(c, zodErrorToValidationBody(parsed.error));
     }
     const items = parsed.data.items as TItem[];
 


### PR DESCRIPTION
## Summary

Phase 0a-ii of QUA-943 (machine-write PG-primary transition). Adds structured `code:` discriminators to the three `validationError` sites the canary `policy.stakeholders` route touches, so Phase 2 dual-write retry-with-feedback (Phase 3) can dispatch on `code` instead of pattern-matching `message`.

- **`sync-factory.ts`** — Zod return path now emits `code: "enum_violation"` (with `field`/`value`/`allowed[]`) when the first issue is `invalid_enum_value`, otherwise `code: "zod"` (with `field`/`value` when `received` is available). policy-stakeholders inherits this through `createSyncHandler` — no per-route changes.
- **`validate-entity-refs.ts`** — FK miss now emits `code: "fk_missing"` with the first missing field's `field`/`value` slots; full multi-field summary stays in `message`. The structured `value` array caps at 50 IDs (`FK_MISSING_VALUE_CAP`) so a 500-item all-invalid batch can't push 10–50KB into the response body.
- **shared helper `zodErrorToValidationBody`** in `routes/shared/utils.ts` centralizes the ZodError → ValidationErrorBody mapping for Phase 5 expansion.

Other 156+ legacy 1-arg `validationError(c, "...")` callsites (the `zv()` query-param path, the natural-key collision path, etc.) are intentionally unchanged per QUA-943 v4 RFC §0a-ii.

**Scope note.** `validate-entity-refs.ts` is shared infrastructure used by ~all sync routes, so the new `code: "fk_missing"` discriminator surfaces on every route that calls `validateEntityRefs`, not just the canary. The change is additive (legacy `message` is preserved verbatim), so existing string-matching consumers are unaffected — but a future Phase 3 retry consumer dispatching on `code: "fk_missing"` will trigger across all sync routes, not just `policy-stakeholders`.

## Test plan

- [x] `npx vitest run validation-error-code-discriminator.test.ts` — 11 new specs (6 integration + 5 direct unit on `zodErrorToValidationBody`) all pass
- [x] `npx vitest run policy-stakeholders.test.ts validate-entity-refs.test.ts sourcing-enforcement.test.ts` — 49 specs across all affected suites pass
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` and `apps/web/tsconfig.json` — both clean
- [x] `pnpm crux w validate gate --fix` — 69 checks pass (2 pre-existing advisory warnings)
- [x] `/agent-review-pr` — hostile reviewer subagent ran; 1 HIGH + 5 MEDIUM findings addressed (cap on FK value array, JSON-safety contract docstring, corrected QUA-940 comment, direct unit tests for the helper)
- [x] Adversarial inputs (empty path, number-only path, dotted-key, multi-issue, big `allowed[]`, numeric `received`) hand-tested against `zodErrorToValidationBody`

Fixes QUA-952
