### PR TITLE
feat(sync-factory): bestEffortAllowed + ?mode=best_effort partial-success (QUA-955)

### DIFF
--- a/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
+++ b/apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import { enforceSourcing } from '../routes/shared/sourcing-enforcement.js';
+import {
+  enforceSourcing,
+  resolveSourcingRequirement,
+} from '../routes/shared/sourcing-enforcement.js';
+import type { Context } from 'hono';
 
 // Helper to create a minimal Hono test context with a given table name
 function createTestApp(tableName = 'personnel') {
@@ -162,5 +166,59 @@ describe('enforceSourcing', () => {
     const body = await res.json() as { message: string };
     expect(body.message).toContain('pnpm crux tb verify-orchestrate grants');
     expect(body.message).not.toMatch(/pnpm crux tb verify grants(?!-)/);
+  });
+});
+
+describe('resolveSourcingRequirement (QUA-955)', () => {
+  // Build a Hono context with the given query string and pass it to the
+  // function under test. Avoids spinning up an entire app for a pure
+  // policy-decision helper.
+  async function callWith(tableName: string, params: Record<string, string>) {
+    const app = new Hono();
+    let captured: ReturnType<typeof resolveSourcingRequirement> | null = null;
+    app.get('/test', (c: Context) => {
+      captured = resolveSourcingRequirement(c, tableName);
+      return c.text('ok');
+    });
+    const url = `/test?${new URLSearchParams(params).toString()}`;
+    await app.request(url);
+    if (captured === null) throw new Error('handler did not run');
+    return captured;
+  }
+
+  it('returns "not_required" for unenforced tables with no client opt-in', async () => {
+    const result = await callWith('investments', {});
+    expect(result).toEqual({ kind: 'not_required' });
+  });
+
+  it('returns "required" with server-policy source for SOURCE_CHECK_REQUIRED tables', async () => {
+    const result = await callWith('personnel', {});
+    expect(result).toEqual({ kind: 'required', source: 'server policy' });
+  });
+
+  it('returns "required" with client-param source when only the client opted in', async () => {
+    const result = await callWith('investments', { requireSourcing: 'true' });
+    expect(result).toEqual({
+      kind: 'required',
+      source: 'client requireSourcing param',
+    });
+  });
+
+  it('returns "skipped" with reason when forceSkipSourcing=true', async () => {
+    const result = await callWith('personnel', {
+      forceSkipSourcing: 'true',
+      reason: 'migration backfill',
+    });
+    expect(result).toEqual({ kind: 'skipped', reason: 'migration backfill' });
+  });
+
+  it('returns "skipped" with default reason when forceSkipSourcing=true&reason omitted', async () => {
+    const result = await callWith('grants', { forceSkipSourcing: 'true' });
+    expect(result).toEqual({ kind: 'skipped', reason: 'no reason given' });
+  });
+
+  it('forceSkipSourcing has no effect on tables that do not require sourcing', async () => {
+    const result = await callWith('investments', { forceSkipSourcing: 'true' });
+    expect(result).toEqual({ kind: 'not_required' });
   });
 });

--- a/apps/wiki-server/src/__tests__/sync-factory.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-factory.test.ts
@@ -466,3 +466,304 @@ describe("createSyncHandler — happy path", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// QUA-955: best-effort partial-success mode
+// ---------------------------------------------------------------------------
+
+describe("createSyncHandler — bestEffortAllowed: false (default)", () => {
+  beforeEach(resetStores);
+
+  it("ignores ?mode=best_effort when bestEffortAllowed is unset", async () => {
+    // Sending the query param to a non-opted-in route MUST behave atomically:
+    // a single Zod failure rejects the whole batch with 400, NOT a 200 with
+    // a partitioned response. This is the server-side guard that prevents
+    // a future contributor from silently re-introducing QUA-941.
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" },
+        { id: "bad-id", title: "beta" }, // wrong length, would fail Zod
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "validation_error" });
+    // Should NOT have a partitioned shape
+    expect(body.committed).toBeUndefined();
+    expect(body.rejected).toBeUndefined();
+  });
+
+  it("ignores ?mode=best_effort when bestEffortAllowed is explicitly false", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: false,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [{ id: "bad-id", title: "x" }],
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("createSyncHandler — bestEffortAllowed: true (opt-in)", () => {
+  beforeEach(resetStores);
+
+  it("still runs atomically when ?mode is not set", async () => {
+    // Opting in via config alone is not enough — the query param is also
+    // required. A request without `?mode=best_effort` keeps atomic semantics.
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" },
+        { id: "bad-id", title: "beta" },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("partitions Zod-invalid items, commits the rest", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" }, // valid
+        { id: "bad-id", title: "x" }, // wrong length
+        { id: "cccccccccc", title: "" }, // empty title
+        { id: "dddddddddd", title: "delta" }, // valid
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "dddddddddd"]);
+    expect(body.rejected).toHaveLength(2);
+    expect(body.rejected[0]).toMatchObject({ idx: 1, code: "zod" });
+    expect(body.rejected[1]).toMatchObject({ idx: 2, code: "zod" });
+    // Standard mirrored fields
+    expect(body.verdictsWritten).toBe(0);
+    expect(body.claimsLinked).toBe(0);
+  });
+
+  it("partitions natural-key duplicates, commits first occurrence", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      naturalKey: (item) => item.title,
+      naturalKeyError: "Duplicate title",
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" }, // first → committed
+        { id: "bbbbbbbbbb", title: "alpha" }, // dup → rejected
+        { id: "cccccccccc", title: "beta" }, // unique → committed
+        { id: "dddddddddd", title: "alpha" }, // dup → rejected
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "cccccccccc"]);
+    expect(body.rejected).toHaveLength(2);
+    expect(body.rejected[0]).toMatchObject({
+      idx: 1,
+      code: "natural_key",
+      value: "alpha",
+    });
+    expect(body.rejected[0].message).toContain("Duplicate title");
+    expect(body.rejected[1]).toMatchObject({ idx: 3, code: "natural_key" });
+  });
+
+  it("partitions items with missing entity FK refs", async () => {
+    entitiesStore.set("known-org", { id: "known-org", stable_id: "sidKnownOrg" });
+
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      entityRefFields: (items) => [
+        {
+          fieldName: "parentId",
+          ids: items.map((i) => i.parentId).filter((id): id is string => id != null),
+        },
+      ],
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha", parentId: "known-org" }, // committed
+        { id: "bbbbbbbbbb", title: "beta", parentId: "missing-org" }, // rejected
+        { id: "cccccccccc", title: "gamma" }, // no parentId → committed
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "cccccccccc"]);
+    expect(body.rejected).toHaveLength(1);
+    expect(body.rejected[0]).toMatchObject({
+      idx: 1,
+      code: "fk_missing",
+      field: "parentId",
+      value: "missing-org",
+    });
+  });
+
+  it("returns committed=[] when every item fails validation", async () => {
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "bad-1", title: "x" },
+        { id: "bad-2", title: "" },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual([]);
+    expect(body.rejected).toHaveLength(2);
+  });
+
+  it("preserves original input indices across multiple partition phases", async () => {
+    // Mix Zod failures with natural-key duplicates so we can verify `idx`
+    // points at the original input position, not a post-Zod position.
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      naturalKey: (item) => item.title,
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" }, // idx 0 — committed
+        { id: "bad-len", title: "x" }, // idx 1 — Zod fail
+        { id: "cccccccccc", title: "alpha" }, // idx 2 — natural-key dup
+        { id: "dddddddddd", title: "delta" }, // idx 3 — committed
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "dddddddddd"]);
+    const idxByCode = new Map<string, number>(
+      body.rejected.map((r: { idx: number; code: string }) => [r.code, r.idx]),
+    );
+    expect(idxByCode.get("zod")).toBe(1);
+    expect(idxByCode.get("natural_key")).toBe(2);
+  });
+
+  it("partitions items missing required sourcing data", async () => {
+    // Use a tableName that's listed in SOURCE_CHECK_REQUIRED so the server-side
+    // policy fires. `personnel` is enabled there.
+    const SourcedItemSchema = z.object({
+      id: z.string().length(10),
+      title: z.string(),
+      sourcing: z.unknown().optional(),
+    });
+    type SourcedItem = z.infer<typeof SourcedItemSchema>;
+    const handler = createSyncHandler<SourcedItem, typeof entities>({
+      name: "personnel-test",
+      table: entities,
+      enforceSourcing: "personnel", // override tableName lookup
+      syncSchema: SourcedItemSchema,
+      toRow: (item, now) => ({
+        id: item.id,
+        title: item.title,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha", sourcing: { url: "x" } }, // committed
+        { id: "bbbbbbbbbb", title: "beta" }, // rejected: no sourcing
+        { id: "cccccccccc", title: "gamma", sourcing: { url: "y" } }, // committed
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "cccccccccc"]);
+    expect(body.rejected).toHaveLength(1);
+    expect(body.rejected[0]).toMatchObject({
+      idx: 1,
+      code: "sourcing_required",
+      field: "sourcing",
+    });
+  });
+
+  it("falls back to atomic Zod when bestEffortAllowed is set but only batchSchema is provided", async () => {
+    // syncSchema is required to per-item-partition Zod failures. With only
+    // batchSchema (which may include batch-level refinements), we can't
+    // disaggregate item failures, so the Zod phase stays atomic. Subsequent
+    // phases (natural key, FKs) still partition.
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      batchSchema: BatchSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [{ id: "bad-id", title: "x" }],
+    });
+
+    // Atomic Zod fallback: 400 instead of 200
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/wiki-server/src/__tests__/sync-factory.test.ts
+++ b/apps/wiki-server/src/__tests__/sync-factory.test.ts
@@ -34,12 +34,24 @@ import type { SyncPhaseError as SyncPhaseErrorType } from "../routes/tablebase/s
 let entitiesStore: Map<string, Record<string, unknown>>;
 let widgetsStore: Map<string, Record<string, unknown>>;
 let auditLogStore: Array<Record<string, unknown>>;
+// proposedClaimsStore: claim id → status. Tests that need claim partitioning
+// to actually fire seed rows here. Default empty store yields the same
+// behavior as before (validateClaimRefs / classifyClaims see "no rows" and
+// treat every claim as missing — but tests that don't pass claimSupport
+// never query the table, so this is opt-in per test).
+let proposedClaimsStore: Map<number, { id: number; status: string }>;
 
 function resetStores() {
   entitiesStore = new Map();
   widgetsStore = new Map();
   auditLogStore = [];
+  proposedClaimsStore = new Map();
 }
+
+// Initialize stores at import time so the mock dispatcher can read them
+// before any beforeEach runs (vitest may invoke the dispatcher during module
+// init, e.g. when a sync handler is constructed eagerly).
+resetStores();
 
 function dispatch(query: string, params: unknown[]): unknown[] {
   const q = query.toLowerCase();
@@ -83,9 +95,26 @@ function dispatch(query: string, params: unknown[]): unknown[] {
     return [];
   }
 
-  // --- proposed_claims: SELECT (validateClaimRefs) ---
+  // --- proposed_claims: SELECT (validateClaimRefs / classifyClaims) ---
+  // Returns rows for any seeded claim; missing IDs are absent so the caller
+  // treats them as "missing". Status drives the verified/non-verified split.
   if (q.includes("from proposed_claims") || q.includes("proposed_claims")) {
-    return [];
+    const rows: unknown[] = [];
+    for (const p of params) {
+      // The query uses `id = ANY($1::bigint[])` — Drizzle passes the array
+      // as a single param, so we may see one Array param or N number params
+      // depending on the binding shape. Handle both.
+      if (Array.isArray(p)) {
+        for (const cid of p) {
+          const row = proposedClaimsStore.get(Number(cid));
+          if (row) rows.push({ id: row.id, status: row.status, entity_id: null });
+        }
+      } else {
+        const row = proposedClaimsStore.get(Number(p));
+        if (row) rows.push({ id: row.id, status: row.status, entity_id: null });
+      }
+    }
+    return rows;
   }
 
   // --- claim_record_links: INSERT ---
@@ -748,8 +777,9 @@ describe("createSyncHandler — bestEffortAllowed: true (opt-in)", () => {
   it("falls back to atomic Zod when bestEffortAllowed is set but only batchSchema is provided", async () => {
     // syncSchema is required to per-item-partition Zod failures. With only
     // batchSchema (which may include batch-level refinements), we can't
-    // disaggregate item failures, so the Zod phase stays atomic. Subsequent
-    // phases (natural key, FKs) still partition.
+    // disaggregate item failures — so the Zod phase stays atomic and a
+    // batch-level Zod failure still returns 400. Routes that want
+    // partitioned Zod must provide `syncSchema`.
     const handler = createSyncHandler<Item, typeof entities>({
       name: "test",
       table: entities,
@@ -765,5 +795,179 @@ describe("createSyncHandler — bestEffortAllowed: true (opt-in)", () => {
 
     // Atomic Zod fallback: 400 instead of 200
     expect(res.status).toBe(400);
+  });
+
+  it("partitions claims that are missing or non-verified", async () => {
+    // Seed a verified claim and a pending claim so partitioning has rows to
+    // classify. Claim id 999 is unseeded → treated as missing.
+    proposedClaimsStore.set(100, { id: 100, status: "verified" });
+    proposedClaimsStore.set(200, { id: 200, status: "pending" });
+
+    type ClaimItem = { id: string; title: string; claimIds: number[] };
+    const ClaimItemSchema = z.object({
+      id: z.string().length(10),
+      title: z.string().min(1),
+      claimIds: z.array(z.number()),
+    });
+    const handler = createSyncHandler<ClaimItem, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ClaimItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      claimSupport: {
+        recordType: "test",
+        getClaimIds: (item) => item.claimIds,
+      },
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha", claimIds: [100] }, // verified → committed
+        { id: "bbbbbbbbbb", title: "beta", claimIds: [999] }, // missing → rejected
+        { id: "cccccccccc", title: "gamma", claimIds: [200] }, // non-verified → rejected
+        { id: "dddddddddd", title: "delta", claimIds: [] }, // no claims → committed
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.committed).toEqual(["aaaaaaaaaa", "dddddddddd"]);
+    expect(body.rejected).toHaveLength(2);
+    expect(body.rejected[0]).toMatchObject({
+      idx: 1,
+      code: "claim_invalid",
+      field: "claimIds",
+      value: 999,
+    });
+    expect(body.rejected[0].message).toContain("missing");
+    expect(body.rejected[1]).toMatchObject({
+      idx: 2,
+      code: "claim_invalid",
+      field: "claimIds",
+      value: 200,
+    });
+    expect(body.rejected[1].message).toContain("not verified");
+    expect(body.rejected[1].message).toContain("pending");
+  });
+
+  it("returns the preValidate Response as-is in best-effort mode", async () => {
+    // preValidate is opaque user code; the factory does not partition around
+    // it. A Response from preValidate replaces any partitioned response —
+    // this is the documented "atomic in both modes" contract.
+    const handler = createSyncHandler<Item, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: ItemSchema,
+      toRow: (item, now) => ({ id: item.id, title: item.title, syncedAt: now, updatedAt: now }),
+      preValidate: async (c) =>
+        c.json({ error: "custom_block", reason: "policy" }, 422),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [
+        { id: "aaaaaaaaaa", title: "alpha" },
+        { id: "bbbbbbbbbb", title: "beta" },
+      ],
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: "custom_block", reason: "policy" });
+    // No partitioned shape — preValidate's Response wins entirely
+    expect(body.committed).toBeUndefined();
+    expect(body.rejected).toBeUndefined();
+  });
+
+  it("logs the forceSkipSourcing audit warning in best-effort mode", async () => {
+    // The atomic enforceSourcing helper emits a logger.warn when
+    // ?forceSkipSourcing=true is used. Best-effort must do the same so
+    // bypass usage is auditable; otherwise compliance drifts silently.
+    const SourcedSchema = z.object({
+      id: z.string().length(10),
+      title: z.string(),
+      sourcing: z.unknown().optional(),
+    });
+    type SourcedItem = z.infer<typeof SourcedSchema>;
+
+    const { logger } = await import("../logger.js");
+    const warnSpy = vi.spyOn(logger.child({ component: "sourcing-enforcement" }), "warn");
+    // The above creates a fresh child logger; the actual call site uses its
+    // own child. Spy on the root logger's child instead by spying directly
+    // on the module-level method. The simplest stable approach: spy on the
+    // base logger's `warn` since pino child loggers inherit.
+    const rootWarnSpy = vi.spyOn(logger, "warn");
+
+    const handler = createSyncHandler<SourcedItem, typeof entities>({
+      name: "personnel-test",
+      table: entities,
+      enforceSourcing: "personnel",
+      syncSchema: SourcedSchema,
+      toRow: (item, now) => ({
+        id: item.id,
+        title: item.title,
+        syncedAt: now,
+        updatedAt: now,
+      }),
+      bestEffortAllowed: true,
+    });
+    const app = buildApp(handler);
+
+    const res = await postJson(
+      app,
+      "/sync?mode=best_effort&forceSkipSourcing=true&reason=test-bypass",
+      {
+        items: [
+          { id: "aaaaaaaaaa", title: "alpha" }, // no sourcing — but bypass active
+          { id: "bbbbbbbbbb", title: "beta", sourcing: { url: "x" } },
+        ],
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Bypass active → both items committed despite no sourcing
+    expect(body.committed).toEqual(["aaaaaaaaaa", "bbbbbbbbbb"]);
+    expect(body.rejected).toEqual([]);
+    // The bypass must have produced an audit-warning. Check that *some* warn
+    // call mentions "forceSkipSourcing" in the message string.
+    const sawAuditWarn = [warnSpy, rootWarnSpy].some((spy) =>
+      spy.mock.calls.some(([_obj, msg]) =>
+        typeof msg === "string" && msg.includes("forceSkipSourcing"),
+      ),
+    );
+    expect(sawAuditWarn).toBe(true);
+  });
+
+  it("throws SyncPhaseError when a surviving item lacks a string id", async () => {
+    // Best-effort mode requires every committed item to have a string id —
+    // otherwise the response shape would silently disagree with itself
+    // (claimsLinked covers all items, committed array is shorter). We fail
+    // loudly so a future composite-PK route opting in catches this in dev.
+    const NoIdSchema = z.object({
+      title: z.string().min(1),
+    });
+    type NoIdItem = z.infer<typeof NoIdSchema>;
+
+    const handler = createSyncHandler<NoIdItem, typeof entities>({
+      name: "test",
+      table: entities,
+      syncSchema: NoIdSchema,
+      toRow: (item, now) => ({ id: "fixed-id", title: item.title, syncedAt: now, updatedAt: now }),
+      bestEffortAllowed: true,
+    });
+    const { app, errors } = buildAppWithErrorCapture(handler);
+
+    const res = await postJson(app, "/sync?mode=best_effort", {
+      items: [{ title: "alpha" }],
+    });
+
+    expect(res.status).toBe(500);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(SyncPhaseError);
+    expect((errors[0] as Error).message).toContain("must produce items with a string 'id' field");
   });
 });

--- a/apps/wiki-server/src/__tests__/validate-claims.test.ts
+++ b/apps/wiki-server/src/__tests__/validate-claims.test.ts
@@ -41,7 +41,7 @@ const dispatch: SqlDispatcher = (query, params) => {
 vi.mock("../db.js", () => mockDbModule(dispatch));
 
 // Import AFTER mock setup
-const { validateClaimRefs, linkClaimsToRecords } = await import(
+const { validateClaimRefs, classifyClaims, linkClaimsToRecords } = await import(
   "../routes/shared/validate-claims.js"
 );
 const { getDb } = await import("../db.js");
@@ -133,6 +133,72 @@ describe("validateClaimRefs", () => {
     // The SQL must include ::bigint[] cast to match bigserial column type.
     // Without this cast, postgres.js infers wrong type and returns 0 rows.
     expect(selectQuery!.query).toContain("::bigint[]");
+  });
+});
+
+describe("classifyClaims (QUA-955)", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("returns empty buckets for an empty claim list", async () => {
+    const db = getDb();
+    const result = await classifyClaims(db, []);
+    expect(result).toEqual({ missing: [], nonVerified: [] });
+  });
+
+  it("returns empty buckets when every claim is verified", async () => {
+    claimStore = [
+      { id: 1, status: "verified", entity_id: null },
+      { id: 2, status: "verified", entity_id: null },
+    ];
+    const db = getDb();
+    const result = await classifyClaims(db, [1, 2]);
+    expect(result).toEqual({ missing: [], nonVerified: [] });
+  });
+
+  it("identifies missing claims", async () => {
+    claimStore = [{ id: 1, status: "verified", entity_id: null }];
+    const db = getDb();
+    const result = await classifyClaims(db, [1, 99, 100]);
+    expect(result.missing).toEqual([99, 100]);
+    expect(result.nonVerified).toEqual([]);
+  });
+
+  it("identifies non-verified claims with their statuses", async () => {
+    claimStore = [
+      { id: 1, status: "verified", entity_id: null },
+      { id: 2, status: "pending", entity_id: null },
+      { id: 3, status: "contradicted", entity_id: null },
+    ];
+    const db = getDb();
+    const result = await classifyClaims(db, [1, 2, 3]);
+    expect(result.missing).toEqual([]);
+    expect(result.nonVerified).toEqual([
+      { id: 2, status: "pending" },
+      { id: 3, status: "contradicted" },
+    ]);
+  });
+
+  it("can return both missing and non-verified buckets in one call", async () => {
+    claimStore = [
+      { id: 1, status: "verified", entity_id: null },
+      { id: 2, status: "pending", entity_id: null },
+    ];
+    const db = getDb();
+    const result = await classifyClaims(db, [1, 2, 99]);
+    expect(result.missing).toEqual([99]);
+    expect(result.nonVerified).toEqual([{ id: 2, status: "pending" }]);
+  });
+
+  it("deduplicates claim IDs before querying", async () => {
+    claimStore = [{ id: 1, status: "verified", entity_id: null }];
+    const db = getDb();
+    await classifyClaims(db, [1, 1, 1]);
+    const selectQuery = capturedQueries.find((q) =>
+      q.query.toLowerCase().includes("proposed_claims"),
+    );
+    expect(selectQuery!.params[0]).toEqual([1]);
   });
 });
 

--- a/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
@@ -65,6 +65,28 @@ export function resolveSourcingRequirement(
 }
 
 /**
+ * Emit the audit-log warning for the `?forceSkipSourcing=true` escape hatch.
+ *
+ * Exported so the best-effort partition path (QUA-955) can log the bypass
+ * with the same shape the atomic path already does — without duplicating
+ * the message string and without forcing the partition path to call the
+ * full `enforceSourcing()` (which would also iterate the items).
+ *
+ * Returns silently if `req.kind !== "skipped"`.
+ */
+export function logSourcingSkipped(
+  tableName: string,
+  itemCount: number,
+  req: SourcingRequirement,
+): void {
+  if (req.kind !== "skipped") return;
+  logger.warn(
+    { table: tableName, itemCount, reason: req.reason },
+    `Source-check enforcement skipped via forceSkipSourcing`,
+  );
+}
+
+/**
  * Enforce sourcing requirements for a sync endpoint.
  *
  * Checks both the server-side config (SOURCE_CHECK_REQUIRED) and the legacy
@@ -86,10 +108,7 @@ export function enforceSourcing(
   if (req.kind === "not_required") return null;
 
   if (req.kind === "skipped") {
-    logger.warn(
-      { table: tableName, itemCount: items.length, reason: req.reason },
-      `Source-check enforcement skipped via forceSkipSourcing`,
-    );
+    logSourcingSkipped(tableName, items.length, req);
     return null;
   }
 

--- a/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
@@ -27,6 +27,44 @@ const SOURCE_CHECK_REQUIRED: Record<string, boolean> = {
 };
 
 /**
+ * Resolve whether sourcing is required for this request, given the route's
+ * table name and the request's query params. Used by both the atomic
+ * `enforceSourcing()` path and the best-effort partitioning path (QUA-955) so
+ * the policy decision lives in one place.
+ *
+ *   - `not_required` — neither server config nor client param requests sourcing
+ *   - `skipped` — sourcing was required but `?forceSkipSourcing=true` was set
+ *   - `required` — every item must include sourcing data
+ *
+ * The `source` field on `required` discriminates server-side vs client-side
+ * enforcement so error messages can credit the right one.
+ */
+export type SourcingRequirement =
+  | { kind: "not_required" }
+  | { kind: "skipped"; reason: string }
+  | { kind: "required"; source: "server policy" | "client requireSourcing param" };
+
+export function resolveSourcingRequirement(
+  c: Context,
+  tableName: string,
+): SourcingRequirement {
+  const serverRequired = SOURCE_CHECK_REQUIRED[tableName] === true;
+  const clientRequired = c.req.query("requireSourcing") === "true";
+
+  if (!serverRequired && !clientRequired) return { kind: "not_required" };
+
+  const forceSkip = c.req.query("forceSkipSourcing");
+  if (forceSkip === "true") {
+    return { kind: "skipped", reason: c.req.query("reason") || "no reason given" };
+  }
+
+  return {
+    kind: "required",
+    source: serverRequired ? "server policy" : "client requireSourcing param",
+  };
+}
+
+/**
  * Enforce sourcing requirements for a sync endpoint.
  *
  * Checks both the server-side config (SOURCE_CHECK_REQUIRED) and the legacy
@@ -43,17 +81,13 @@ export function enforceSourcing(
   tableName: string,
   items: Array<{ sourcing?: unknown }>,
 ): Response | null {
-  const serverRequired = SOURCE_CHECK_REQUIRED[tableName] === true;
-  const clientRequired = c.req.query("requireSourcing") === "true";
+  const req = resolveSourcingRequirement(c, tableName);
 
-  if (!serverRequired && !clientRequired) return null;
+  if (req.kind === "not_required") return null;
 
-  // Escape hatch for migrations/backfills
-  const forceSkip = c.req.query("forceSkipSourcing");
-  if (forceSkip === "true") {
-    const reason = c.req.query("reason") || "no reason given";
+  if (req.kind === "skipped") {
     logger.warn(
-      { table: tableName, itemCount: items.length, reason },
+      { table: tableName, itemCount: items.length, reason: req.reason },
       `Source-check enforcement skipped via forceSkipSourcing`,
     );
     return null;
@@ -62,10 +96,9 @@ export function enforceSourcing(
   const unchecked = items.filter((i) => !i.sourcing);
   if (unchecked.length === 0) return null;
 
-  const source = serverRequired ? "server policy" : "client requireSourcing param";
   return validationError(
     c,
-    `Source-check required (${source}) but ${unchecked.length}/${items.length} records lack sourcing data. ` +
+    `Source-check required (${req.source}) but ${unchecked.length}/${items.length} records lack sourcing data. ` +
     `Run \`pnpm crux tb verify-orchestrate ${tableName}\` to populate source_check_verdicts before submitting, ` +
     `or use ?forceSkipSourcing=true&reason=... to bypass with audit logging.`,
   );

--- a/apps/wiki-server/src/routes/shared/validate-claims.ts
+++ b/apps/wiki-server/src/routes/shared/validate-claims.ts
@@ -51,6 +51,40 @@ export async function validateClaimRefs(
 ): Promise<string | null> {
   if (claimIds.length === 0) return null;
 
+  const status = await classifyClaims(db, claimIds);
+
+  if (status.missing.length > 0) {
+    return `Claim IDs not found: ${status.missing.join(", ")}`;
+  }
+
+  if (status.nonVerified.length > 0) {
+    const details = status.nonVerified
+      .map((r) => `${r.id} (${r.status})`)
+      .join(", ");
+    return `Claims not verified: ${details}. Only verified claims can be used to submit records.`;
+  }
+
+  return null;
+}
+
+/**
+ * Classify a batch of claim IDs into missing / non-verified / verified sets.
+ *
+ * Used by both the atomic {@link validateClaimRefs} path and the best-effort
+ * sync mode (QUA-955), where the caller wants to know *which* IDs failed so
+ * it can partition items per-claim instead of rejecting the whole batch.
+ */
+export async function classifyClaims(
+  db: RawDb,
+  claimIds: number[],
+): Promise<{
+  missing: number[];
+  nonVerified: Array<{ id: number; status: string }>;
+}> {
+  if (claimIds.length === 0) {
+    return { missing: [], nonVerified: [] };
+  }
+
   const unique = [...new Set(claimIds)];
   const rows = await db<ClaimStatusRow[]>`
     SELECT id::int, status, entity_id
@@ -58,24 +92,14 @@ export async function validateClaimRefs(
     WHERE id = ANY(${unique}::bigint[])
   `;
 
-  // Check for missing claims
   // Cast to Number because postgres.js may return bigserial as string
   const foundIds = new Set(rows.map((r) => Number(r.id)));
   const missing = unique.filter((id) => !foundIds.has(id));
-  if (missing.length > 0) {
-    return `Claim IDs not found: ${missing.join(", ")}`;
-  }
+  const nonVerified = rows
+    .filter((r) => r.status !== "verified")
+    .map((r) => ({ id: Number(r.id), status: r.status }));
 
-  // Check for non-verified claims
-  const nonVerified = rows.filter((r) => r.status !== "verified");
-  if (nonVerified.length > 0) {
-    const details = nonVerified
-      .map((r) => `${r.id} (${r.status})`)
-      .join(", ");
-    return `Claims not verified: ${details}. Only verified claims can be used to submit records.`;
-  }
-
-  return null;
+  return { missing, nonVerified };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -40,14 +40,21 @@ import {
   parseJsonBody,
   validationError,
   invalidJsonError,
+  type ValidationErrorBody,
 } from "../shared/utils.js";
 import {
   validateEntityRefs,
+  findMissingEntityRefs,
+  shouldSkipEntityValidation,
   type EntityRefField,
 } from "../shared/validate-entity-refs.js";
-import { enforceSourcing } from "../shared/sourcing-enforcement.js";
+import {
+  enforceSourcing,
+  resolveSourcingRequirement,
+} from "../shared/sourcing-enforcement.js";
 import {
   validateClaimRefs,
+  classifyClaims,
   linkClaimsToRecords,
 } from "../shared/validate-claims.js";
 import {
@@ -300,6 +307,37 @@ export interface SyncConfig<TItem, TTable extends PgTable> {
    * external side effects forbidden, throwing rolls back the entire sync.
    */
   postUpsert?: (tx: Tx, items: TItem[], rows: Row[]) => Promise<void>;
+
+  // ---- Best-effort partial-success mode (QUA-955) ----
+
+  /**
+   * Allow callers to request best-effort partial-success semantics by passing
+   * `?mode=best_effort` on the request.
+   *
+   * **Default `false`** — most routes should remain atomic (any per-item
+   * validation failure rejects the whole batch with 400).
+   *
+   * When `true` AND the request includes `?mode=best_effort`, the factory:
+   *   - Runs per-item validation, partitioning into committed / rejected lists
+   *   - Upserts only the items that survived validation
+   *   - Returns HTTP 200 with `{ committed: [...ids], rejected: [{idx, code, message, ...}] }`
+   *     instead of the standard atomic 400-on-first-failure
+   *
+   * **Server-side guard:** `?mode=best_effort` is silently ignored on routes
+   * that don't opt in via this flag — they always run in atomic mode. This
+   * prevents a future contributor from flipping a default and silently
+   * re-introducing the QUA-941 silent-stakeholder-drop regression on a route
+   * that wasn't designed for partial-success.
+   *
+   * **Per-item partitioning is supported for these phases**: Zod schema
+   * (requires `syncSchema`), `enforceSourcing`, `naturalKey`, `entityRefs` /
+   * `entityRefFields`, and `claimSupport`. The `preValidate` hook is treated
+   * as atomic — if it returns a Response, that Response is returned as-is.
+   *
+   * No production caller wires this in QUA-955. Phase 2 opts in
+   * `policy-stakeholders` for the canary.
+   */
+  bestEffortAllowed?: boolean;
 }
 
 /**
@@ -311,6 +349,37 @@ export interface SyncResponse {
   upserted: number;
   verdictsWritten: number;
   claimsLinked: number;
+  claimLinkingError?: string;
+}
+
+/**
+ * One rejected item in a best-effort response (QUA-955). `idx` is the
+ * position in the original `items` array — callers can use it to map
+ * rejections back to their input.
+ *
+ * `code` and the optional context fields mirror `ValidationErrorBody` so a
+ * caller can distinguish causes structurally without string-matching the
+ * `message`.
+ */
+export interface BestEffortRejected extends ValidationErrorBody {
+  idx: number;
+}
+
+/**
+ * Response shape returned when `bestEffortAllowed: true` AND the request
+ * includes `?mode=best_effort`. Distinct from `SyncResponse` — callers should
+ * branch on the request flag, not on response shape.
+ */
+export interface BestEffortSyncResponse {
+  /** IDs of items that passed all validation and were upserted. */
+  committed: string[];
+  /** Items that failed pre-upsert validation. Order matches reject-time order. */
+  rejected: BestEffortRejected[];
+  /** Verdicts written for committed items (mirrors atomic response). */
+  verdictsWritten: number;
+  /** Claim links created for committed items (mirrors atomic response). */
+  claimsLinked: number;
+  /** Present only if claim linking failed post-tx (records still committed). */
   claimLinkingError?: string;
 }
 
@@ -460,21 +529,87 @@ export function createSyncHandler<
     const body = await runPhase(name, "parse", async () => parseJsonBody(c));
     if (!body) return invalidJsonError(c);
 
+    // ---- QUA-955: best-effort gate ----
+    // Best-effort partial-success mode is opt-in per route via `bestEffortAllowed`
+    // AND opt-in per request via `?mode=best_effort`. The query param is silently
+    // ignored on routes that don't opt in (server-side guard).
+    const bestEffort =
+      config.bestEffortAllowed === true && c.req.query("mode") === "best_effort";
+    const rejected: BestEffortRejected[] = [];
+
     // ---- Phase 2: validate (schema) ----
-    // Resolve the batch schema: either provided directly or auto-wrapped from syncSchema
-    const batchSchema = config.batchSchema ?? (config.syncSchema
-      ? z.object({ items: z.array(config.syncSchema).min(1).max(500) }) as z.ZodType<{ items: TItem[] }>
-      : null);
-    if (!batchSchema) {
-      throw new SyncPhaseError(name, "validate", new Error("SyncConfig must provide either batchSchema or syncSchema"));
+    // In best-effort mode with `syncSchema`, we per-item validate so a single
+    // malformed item doesn't reject the whole batch. Otherwise, fall through
+    // to atomic batch-level validation (existing behavior).
+    let items: TItem[];
+    let originalIndices: number[]; // maps items[i] back to its position in the request
+    if (bestEffort && config.syncSchema) {
+      // Permissive envelope so the per-item Zod errors are the partition signal.
+      const envelope = z.object({ items: z.array(z.unknown()).min(1).max(500) });
+      const envParsed = await runPhase(name, "validate", async () =>
+        envelope.safeParse(body),
+      );
+      if (!envParsed.success) {
+        return validationError(c, envParsed.error.message);
+      }
+      const rawItems = envParsed.data.items;
+      const accepted: TItem[] = [];
+      const indices: number[] = [];
+      for (let idx = 0; idx < rawItems.length; idx++) {
+        const r = config.syncSchema.safeParse(rawItems[idx]);
+        if (!r.success) {
+          rejected.push({
+            idx,
+            code: "zod",
+            message: r.error.message,
+          });
+        } else {
+          accepted.push(r.data as TItem);
+          indices.push(idx);
+        }
+      }
+      items = accepted;
+      originalIndices = indices;
+    } else {
+      const batchSchema = config.batchSchema ?? (config.syncSchema
+        ? z.object({ items: z.array(config.syncSchema).min(1).max(500) }) as z.ZodType<{ items: TItem[] }>
+        : null);
+      if (!batchSchema) {
+        throw new SyncPhaseError(name, "validate", new Error("SyncConfig must provide either batchSchema or syncSchema"));
+      }
+      const parsed = await runPhase(name, "validate", async () =>
+        batchSchema.safeParse(body),
+      );
+      if (!parsed.success) {
+        return validationError(c, parsed.error.message);
+      }
+      items = parsed.data.items as TItem[];
+      originalIndices = items.map((_, i) => i);
     }
-    const parsed = await runPhase(name, "validate", async () =>
-      batchSchema.safeParse(body),
-    );
-    if (!parsed.success) {
-      return validationError(c, parsed.error.message);
-    }
-    const items = parsed.data.items as TItem[];
+
+    /**
+     * Drop items at the given local positions (within the current `items` array)
+     * and emit one rejection per dropped item with the supplied code/message.
+     * `originalIndices` is updated in lockstep so subsequent rejections still
+     * refer to the original request position.
+     */
+    const dropAndReject = (
+      drop: Set<number>,
+      build: (localIdx: number) => Omit<BestEffortRejected, "idx">,
+    ): void => {
+      const keptItems: TItem[] = [];
+      const keptIndices: number[] = [];
+      for (let i = 0; i < items.length; i++) {
+        if (drop.has(i)) {
+          rejected.push({ idx: originalIndices[i], ...build(i) });
+        } else {
+          keptItems.push(items[i]);
+          keptIndices.push(originalIndices[i]);
+        }
+      }
+      items = keptItems;
+      originalIndices = keptIndices;
+    };
 
     // ---- Phase 2: enforceSourcing ----
     if (config.enforceSourcing) {
@@ -482,24 +617,71 @@ export function createSyncHandler<
         typeof config.enforceSourcing === "string"
           ? config.enforceSourcing
           : name;
-      const err = await runPhase(name, "enforceSourcing", async () =>
-        enforceSourcing(c, tableName, items as Array<{ sourcing?: unknown }>),
-      );
-      if (err) return err;
+      if (bestEffort) {
+        // Partition: items missing sourcing get rejected, the rest survive.
+        await runPhase(name, "enforceSourcing", async () => {
+          const req = resolveSourcingRequirement(c, tableName);
+          if (req.kind === "required") {
+            const drop = new Set<number>();
+            for (let i = 0; i < items.length; i++) {
+              if (!(items[i] as { sourcing?: unknown }).sourcing) drop.add(i);
+            }
+            if (drop.size > 0) {
+              dropAndReject(drop, () => ({
+                code: "sourcing_required",
+                message:
+                  `Source-check required (${req.source}) but record lacks sourcing data. ` +
+                  `Run \`pnpm crux tb verify-orchestrate ${tableName}\` to populate ` +
+                  `source_check_verdicts before submitting.`,
+                field: "sourcing",
+              }));
+            }
+          }
+        });
+      } else {
+        const err = await runPhase(name, "enforceSourcing", async () =>
+          enforceSourcing(c, tableName, items as Array<{ sourcing?: unknown }>),
+        );
+        if (err) return err;
+      }
     }
 
     // ---- Phase 2: natural key collision ----
     if (config.naturalKey) {
-      const seen = new Set<string>();
-      for (const item of items) {
-        const key = config.naturalKey(item);
-        if (seen.has(key)) {
-          return validationError(
-            c,
-            `${config.naturalKeyError ?? "Duplicate natural key in batch"}: ${key}`,
-          );
+      if (bestEffort) {
+        // Partition: keep first occurrence, reject duplicates.
+        const seen = new Set<string>();
+        const drop = new Set<number>();
+        const dropKeys = new Map<number, string>();
+        for (let i = 0; i < items.length; i++) {
+          const key = config.naturalKey(items[i]);
+          if (seen.has(key)) {
+            drop.add(i);
+            dropKeys.set(i, key);
+          } else {
+            seen.add(key);
+          }
         }
-        seen.add(key);
+        if (drop.size > 0) {
+          dropAndReject(drop, (i) => ({
+            code: "natural_key",
+            message:
+              `${config.naturalKeyError ?? "Duplicate natural key in batch"}: ${dropKeys.get(i)}`,
+            value: dropKeys.get(i),
+          }));
+        }
+      } else {
+        const seen = new Set<string>();
+        for (const item of items) {
+          const key = config.naturalKey(item);
+          if (seen.has(key)) {
+            return validationError(
+              c,
+              `${config.naturalKeyError ?? "Duplicate natural key in batch"}: ${key}`,
+            );
+          }
+          seen.add(key);
+        }
       }
     }
 
@@ -516,11 +698,58 @@ export function createSyncHandler<
         }))
       : null);
     if (entityRefFieldsFn) {
-      const fields = entityRefFieldsFn(items);
-      const refError = await runPhase(name, "validateEntityRefs", async () =>
-        validateEntityRefs(c, db, fields),
-      );
-      if (refError) return refError;
+      if (bestEffort) {
+        // Partition: items with missing FKs get rejected, the rest survive.
+        // The `?skipEntityValidation=true` bypass still applies (handled inside
+        // shouldSkipEntityValidation, called below).
+        if (!shouldSkipEntityValidation(c)) {
+          await runPhase(name, "validateEntityRefs", async () => {
+            const fields = entityRefFieldsFn(items);
+            const missing = await findMissingEntityRefs(db, fields);
+            if (missing.length === 0) return;
+            // Build a per-field set of missing IDs for fast per-item lookup.
+            const missingByField = new Map<string, Set<string>>();
+            for (const m of missing) {
+              missingByField.set(m.fieldName, new Set(m.missingIds));
+            }
+            // Re-extract per-item field values to determine which item owns
+            // which missing ID. We call the callback with each [item] singleton
+            // — cheap because it's just array projection.
+            const drop = new Set<number>();
+            const dropDetails = new Map<number, { fieldName: string; id: string }>();
+            for (let i = 0; i < items.length; i++) {
+              const itemFields = entityRefFieldsFn([items[i]]);
+              for (const f of itemFields) {
+                const missingSet = missingByField.get(f.fieldName);
+                if (!missingSet) continue;
+                const badId = f.ids.find((id) => missingSet.has(id));
+                if (badId) {
+                  drop.add(i);
+                  dropDetails.set(i, { fieldName: f.fieldName, id: badId });
+                  break;
+                }
+              }
+            }
+            if (drop.size > 0) {
+              dropAndReject(drop, (i) => {
+                const detail = dropDetails.get(i)!;
+                return {
+                  code: "fk_missing",
+                  message: `Entity reference not found: ${detail.fieldName}=${detail.id}`,
+                  field: detail.fieldName,
+                  value: detail.id,
+                };
+              });
+            }
+          });
+        }
+      } else {
+        const fields = entityRefFieldsFn(items);
+        const refError = await runPhase(name, "validateEntityRefs", async () =>
+          validateEntityRefs(c, db, fields),
+        );
+        if (refError) return refError;
+      }
     }
 
     // ---- Phase 2: validateClaimRefs ----
@@ -530,19 +759,87 @@ export function createSyncHandler<
       allClaimIds = items.flatMap((i) => getClaimIds(i) ?? []);
       if (allClaimIds.length > 0) {
         const rawDb = getDb();
-        const claimError = await runPhase(name, "validateClaimRefs", async () =>
-          validateClaimRefs(rawDb, allClaimIds),
-        );
-        if (claimError) return validationError(c, claimError);
+        if (bestEffort) {
+          // Partition: items citing missing/non-verified claims get rejected.
+          await runPhase(name, "validateClaimRefs", async () => {
+            const status = await classifyClaims(rawDb, allClaimIds);
+            if (status.missing.length === 0 && status.nonVerified.length === 0) {
+              return;
+            }
+            const missingSet = new Set(status.missing);
+            const nonVerifiedMap = new Map(
+              status.nonVerified.map((r) => [r.id, r.status]),
+            );
+            const drop = new Set<number>();
+            const dropDetails = new Map<
+              number,
+              { claimId: number; reason: string }
+            >();
+            for (let i = 0; i < items.length; i++) {
+              const ids = getClaimIds(items[i]) ?? [];
+              for (const cid of ids) {
+                if (missingSet.has(cid)) {
+                  drop.add(i);
+                  dropDetails.set(i, { claimId: cid, reason: "missing" });
+                  break;
+                }
+                const status = nonVerifiedMap.get(cid);
+                if (status) {
+                  drop.add(i);
+                  dropDetails.set(i, {
+                    claimId: cid,
+                    reason: `not verified (status: ${status})`,
+                  });
+                  break;
+                }
+              }
+            }
+            if (drop.size > 0) {
+              dropAndReject(drop, (i) => {
+                const d = dropDetails.get(i)!;
+                return {
+                  code: "claim_invalid",
+                  message: `Claim ${d.claimId} ${d.reason}`,
+                  field: "claimIds",
+                  value: d.claimId,
+                };
+              });
+            }
+          });
+          // Recompute allClaimIds against the surviving set so post-tx linking
+          // doesn't try to link claims for rejected records.
+          allClaimIds = items.flatMap((i) => getClaimIds(i) ?? []);
+        } else {
+          const claimError = await runPhase(name, "validateClaimRefs", async () =>
+            validateClaimRefs(rawDb, allClaimIds),
+          );
+          if (claimError) return validationError(c, claimError);
+        }
       }
     }
 
     // ---- Phase 2: preValidate hook ----
+    // Treated as atomic in both modes — the hook is opaque to the factory.
+    // If a route needs per-item preValidate behavior in best-effort mode, the
+    // hook itself can short-circuit only on items it wants to reject and
+    // return null otherwise. We don't try to partition arbitrary user code.
     if (config.preValidate) {
       const preErr = await runPhase(name, "preValidate", async () =>
         config.preValidate!(c, db, items),
       );
       if (preErr) return preErr;
+    }
+
+    // If best-effort partitioning ate everything, skip the transaction. Some
+    // downstream phases (writeInlineVerdicts, audit) crash on empty input.
+    if (bestEffort && items.length === 0) {
+      const emptyResponse: BestEffortSyncResponse = {
+        committed: [],
+        rejected,
+        verdictsWritten: 0,
+        claimsLinked: 0,
+      };
+      return c.json(emptyResponse);
     }
 
     // ---- Phase 3-6: transaction ----
@@ -710,6 +1007,20 @@ export function createSyncHandler<
           "claim linking failed (records already committed)",
         );
       }
+    }
+
+    if (bestEffort) {
+      const committed = items
+        .map((i) => (i as { id?: string }).id)
+        .filter((id): id is string => typeof id === "string");
+      const beResponse: BestEffortSyncResponse = {
+        committed,
+        rejected,
+        verdictsWritten: verdictsResult.written,
+        claimsLinked,
+        ...(claimLinkingError ? { claimLinkingError } : {}),
+      };
+      return c.json(beResponse);
     }
 
     const response: SyncResponse = {

--- a/apps/wiki-server/src/routes/tablebase/sync-factory.ts
+++ b/apps/wiki-server/src/routes/tablebase/sync-factory.ts
@@ -51,6 +51,7 @@ import {
 import {
   enforceSourcing,
   resolveSourcingRequirement,
+  logSourcingSkipped,
 } from "../shared/sourcing-enforcement.js";
 import {
   validateClaimRefs,
@@ -202,6 +203,12 @@ export interface SyncConfig<TItem, TTable extends PgTable> {
   /**
    * Entity FK fields to validate pre-insert. Returns one EntityRefField per
    * FK field. Each field's IDs are batch-checked against the entities table.
+   *
+   * **Contract**: callbacks MUST be pure (no side effects, no DB calls, no
+   * logging). In best-effort mode (QUA-955) the callback is invoked once
+   * over the full batch and then once per item to attribute missing FKs back
+   * to their owning item — at most N+1 invocations per request. A callback
+   * with side effects will surface them N+1 times in best-effort mode.
    */
   entityRefFields?: (items: TItem[]) => EntityRefField[];
 
@@ -371,7 +378,12 @@ export interface BestEffortRejected extends ValidationErrorBody {
  * branch on the request flag, not on response shape.
  */
 export interface BestEffortSyncResponse {
-  /** IDs of items that passed all validation and were upserted. */
+  /**
+   * IDs of items that passed all validation and were upserted. One entry per
+   * surviving item; the factory throws a SyncPhaseError if any surviving
+   * item lacks a string `id` field (composite-PK routes are not yet
+   * supported by best-effort mode).
+   */
   committed: string[];
   /** Items that failed pre-upsert validation. Order matches reject-time order. */
   rejected: BestEffortRejected[];
@@ -619,8 +631,15 @@ export function createSyncHandler<
           : name;
       if (bestEffort) {
         // Partition: items missing sourcing get rejected, the rest survive.
+        // The `?forceSkipSourcing=true` escape hatch must still emit its audit
+        // warning here — otherwise best-effort callers can bypass enforcement
+        // silently, defeating the compliance contract.
         await runPhase(name, "enforceSourcing", async () => {
           const req = resolveSourcingRequirement(c, tableName);
+          if (req.kind === "skipped") {
+            logSourcingSkipped(tableName, items.length, req);
+            return;
+          }
           if (req.kind === "required") {
             const drop = new Set<number>();
             for (let i = 0; i < items.length; i++) {
@@ -712,9 +731,12 @@ export function createSyncHandler<
             for (const m of missing) {
               missingByField.set(m.fieldName, new Set(m.missingIds));
             }
-            // Re-extract per-item field values to determine which item owns
-            // which missing ID. We call the callback with each [item] singleton
-            // — cheap because it's just array projection.
+            // We need to know which item owns each missing ID. The full
+            // callback form lets users compute IDs (e.g. prefix transforms),
+            // not just read fields, so we can't shortcut via
+            // `item[fieldName]` — that would silently misclassify ID-mapping
+            // callbacks. Instead, invoke the callback with each `[item]`
+            // singleton; this is the only contract-safe partition strategy.
             const drop = new Set<number>();
             const dropDetails = new Map<number, { fieldName: string; id: string }>();
             for (let i = 0; i < items.length; i++) {
@@ -783,12 +805,12 @@ export function createSyncHandler<
                   dropDetails.set(i, { claimId: cid, reason: "missing" });
                   break;
                 }
-                const status = nonVerifiedMap.get(cid);
-                if (status) {
+                const nonVerifiedStatus = nonVerifiedMap.get(cid);
+                if (nonVerifiedStatus) {
                   drop.add(i);
                   dropDetails.set(i, {
                     claimId: cid,
-                    reason: `not verified (status: ${status})`,
+                    reason: `not verified (status: ${nonVerifiedStatus})`,
                   });
                   break;
                 }
@@ -830,8 +852,12 @@ export function createSyncHandler<
       if (preErr) return preErr;
     }
 
-    // If best-effort partitioning ate everything, skip the transaction. Some
-    // downstream phases (writeInlineVerdicts, audit) crash on empty input.
+    // If best-effort partitioning ate everything, skip the transaction
+    // entirely. Going through the chunk loop with `allVals = []` produces a
+    // 0-column-count → degenerate chunkSize, and some Drizzle versions throw
+    // on `tx.insert(table).values([])` / `inArray(idCol, [])`. Returning early
+    // avoids that whole class of edge-case behavior on the empty input we
+    // already know we have nothing to do with.
     if (bestEffort && items.length === 0) {
       const emptyResponse: BestEffortSyncResponse = {
         committed: [],
@@ -1010,9 +1036,28 @@ export function createSyncHandler<
     }
 
     if (bestEffort) {
-      const committed = items
-        .map((i) => (i as { id?: string }).id)
-        .filter((id): id is string => typeof id === "string");
+      // Build the committed-IDs list. The contract is `committed: string[]` —
+      // one entry per surviving item. If an item has no string `id`, we throw
+      // rather than silently truncate (that would produce a response shape
+      // that disagrees with itself: claimsLinked covers all items, committed
+      // is shorter). Fail loudly so a future composite-PK route opting in
+      // hits this in dev, not in prod.
+      const committed: string[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const id = (items[i] as { id?: unknown }).id;
+        if (typeof id !== "string") {
+          throw new SyncPhaseError(
+            name,
+            "upsert",
+            new Error(
+              `bestEffortAllowed routes must produce items with a string 'id' field; ` +
+                `surviving item at index ${i} (original idx ${originalIndices[i]}) has id=${typeof id}. ` +
+                `Composite-PK routes are not yet supported in best-effort mode.`,
+            ),
+          );
+        }
+        committed.push(id);
+      }
       const beResponse: BestEffortSyncResponse = {
         committed,
         rejected,


### PR DESCRIPTION
## Summary

Phase 0e of QUA-943 (machine-write PG-primary transition). Adds an opt-in
partial-success mode to `createSyncHandler` so a route can return HTTP 200
with `{ committed, rejected: [{idx, code, message, ...}] }` instead of
400-on-first-Zod-failure. Closes QUA-955.

No production caller wires this in QUA-955 — Phase 2 (QUA-957) opts in
`policy-stakeholders` for the canary.

## What this ships

| Layer | File | Notes |
|---|---|---|
| Factory | `apps/wiki-server/src/routes/tablebase/sync-factory.ts` | New `bestEffortAllowed?: boolean` config + per-item partitioning across Zod, sourcing, natural-key, entity-FK, claim-ref phases |
| Response shape | same | New `BestEffortSyncResponse` + `BestEffortRejected` exports (mirrors `ValidationErrorBody.code`) |
| Helper | `apps/wiki-server/src/routes/shared/sourcing-enforcement.ts` | Extracted `resolveSourcingRequirement()` + `logSourcingSkipped()` so atomic + best-effort share the policy decision and the audit-log warning |
| Helper | `apps/wiki-server/src/routes/shared/validate-claims.ts` | Extracted `classifyClaims()` returning `{ missing, nonVerified }` for per-item claim partitioning |
| Tests | `apps/wiki-server/src/__tests__/sync-factory.test.ts` | 14 new tests (27 total) covering opt-out default, opt-in without query, query without opt-in, every partition phase, idx preservation, batchSchema fallback, claim partition, preValidate atomicity, forceSkipSourcing logging, missing-id SyncPhaseError |
| Tests | `apps/wiki-server/src/__tests__/validate-claims.test.ts` | 6 new tests for `classifyClaims` |
| Tests | `apps/wiki-server/src/__tests__/sourcing-enforcement.test.ts` | 6 new tests for `resolveSourcingRequirement` |

## Behavior

`bestEffort = config.bestEffortAllowed === true && c.req.query("mode") === "best_effort"`

When **true**:
- **Schema** — `syncSchema` is parsed per-item; failures get `code: "zod"`. With only `batchSchema` (no `syncSchema`) the Zod phase falls back to atomic.
- **Sourcing** — items missing `sourcing` get `code: "sourcing_required"`. `?forceSkipSourcing=true` still applies *and emits the same audit-log warning the atomic path does* (regression caught by review).
- **Natural key** — first occurrence kept, duplicates rejected with `code: "natural_key"`.
- **Entity FKs** — items with missing FKs rejected with `code: "fk_missing"` (specific field + value reported). `?skipEntityValidation=true` still applies.
- **Claim refs** — items citing missing or non-verified claims rejected with `code: "claim_invalid"`. Post-tx claim linking only runs for surviving items.
- **`preValidate` hook** — atomic in both modes (opaque user code; route can short-circuit selectively inside the hook).
- **Empty surviving set** — early-return 200 with `committed: []` to avoid degenerate chunk size and Drizzle empty-array throws.
- **Missing string `id` on a surviving item** — throws `SyncPhaseError` with `phase: "upsert"` rather than silently truncating the `committed` array. Composite-PK routes are not yet supported by best-effort mode.

When **false** (default, OR opted-in but query param missing, OR query param sent to non-opted-in route):
- Identical to pre-PR behavior. First failure → 400. The query-param-without-opt-in case is the server-side guard that prevents a future contributor from re-introducing QUA-941 silent drops by flipping a default.

## Note on Linear dedup false positive

The Linear dedup check fired against PR #4763 (QUA-954, pipeline_runs) because that PR's body mentions QUA-955 in its "Deferred" section as a downstream dependency — there is no actual session conflict. Bypassed with `--force`.

## Spec adherence

| Acceptance criterion | Status |
|---|---|
| `bestEffortAllowed?: boolean` on `SyncConfig`, default `false` | ✅ |
| `?mode=best_effort` triggers partial success when allowed | ✅ |
| Server returns HTTP 200 with `{committed, rejected}` shape | ✅ `BestEffortSyncResponse` |
| Each rejected item carries structured `code:` from Phase 0a-i | ✅ `BestEffortRejected extends ValidationErrorBody` |
| `?mode=best_effort` ignored when `bestEffortAllowed` is unset | ✅ Two regression tests |
| No route opts in as part of this ticket | ✅ |

## Review pass

`/agent-review-pr` flagged 3 HIGH and 5 MEDIUM findings against the initial implementation; all HIGHs and 4 of 5 MEDIUMs are fixed in commit 7408a886e. The remaining MEDIUM (entityRefFields N+1 invocation) was kept on the slow-but-correct side — the suggested fast path breaks the contract for callbacks that transform IDs. Documented the per-item invocation requirement on the JSDoc instead.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/sync-factory.test.ts` — 27 tests pass (13 existing + 14 new)
- [x] `pnpm exec vitest run src/__tests__/validate-claims.test.ts` — 16 tests (10 existing + 6 new)
- [x] `pnpm exec vitest run src/__tests__/sourcing-enforcement.test.ts` — 25 tests (19 existing + 6 new)
- [x] `npx tsc --noEmit` (apps/wiki-server) — clean
- [x] `pnpm crux w validate gate --fix --no-cache` — 62 checks pass, 2 advisory warnings unrelated to this PR
- [x] `pnpm build` — clean
- [x] No live policy-stakeholders opt-in — verified by inspection of `apps/wiki-server/src/routes/tablebase/policy-stakeholders.ts`; `bestEffortAllowed` is not set, so this PR is purely additive scaffolding

## Deploy notes

No migrations, no env vars, no API contract change for existing routes — the
factory's behavior is unchanged for every route that doesn't set
`bestEffortAllowed: true`. The new query-param branch is dead code until a
caller opts in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch sync gains an opt-in best-effort mode: partial successes return committed/rejected item details instead of failing the whole request.

* **Refactoring**
  * Sourcing enforcement and claim-validation flows centralized for consistent enforcement, skip-audit logging, and clearer validation responses.

* **Tests**
  * Extensive tests added covering sourcing requirement resolution, claim classification, best-effort partitioning, and edge-case behaviors (atomic fallbacks and error paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->