### PR TITLE
fix(playwright-fetcher): catch browser launch errors so resource-ingest jobs don't fail

### DIFF
--- a/crux/lib/search/playwright-fetcher.test.ts
+++ b/crux/lib/search/playwright-fetcher.test.ts
@@ -223,4 +223,53 @@ describe('fetchWithPlaywright', () => {
     expect(result).not.toBeNull();
     expect(mockBrowser.newContext).toHaveBeenCalled();
   });
+
+  // ---- Browser launch failure (QUA-229) ----
+
+  it('returns null (does not throw) when chromium.launch fails', async () => {
+    // Reproduces QUA-229: chromium fails to launch (e.g. OOM-killed in worker
+    // pod during startup) and throws "browserType.launch: Target page, context
+    // or browser has been closed". The fetcher must honor its "returns null
+    // on failure" contract so source-fetcher can fall back to Firecrawl/built-in
+    // and the job doesn't fail.
+    await closeBrowser(); // reset singleton so the next call re-launches
+
+    const { chromium } = await import('playwright');
+    vi.mocked(chromium.launch).mockRejectedValueOnce(
+      new Error(
+        'browserType.launch: Target page, context or browser has been closed\n' +
+          'Browser logs:\n\n<launching> /usr/bin/chromium --disable-field-trial-config'
+      )
+    );
+
+    const result = await fetchWithPlaywright('https://example.com/launch-fails');
+
+    expect(result).toBeNull();
+    // No context creation since the browser never launched
+    expect(mockBrowser.newContext).not.toHaveBeenCalled();
+  });
+
+  it('retries the launch on the next call after a launch failure', async () => {
+    // After a failed launch, the singleton resets so subsequent calls retry.
+    // This handles transient OOMs where the next launch may succeed.
+    await closeBrowser();
+
+    const { chromium } = await import('playwright');
+    vi.mocked(chromium.launch)
+      .mockRejectedValueOnce(new Error('browserType.launch: Target page, context or browser has been closed'))
+      .mockResolvedValueOnce(mockBrowser);
+
+    const failed = await fetchWithPlaywright('https://example.com/first-attempt');
+    expect(failed).toBeNull();
+
+    mockPage.goto.mockResolvedValueOnce({ status: () => 200 });
+    mockPage.title.mockResolvedValueOnce('Recovered');
+    mockPage.evaluate.mockResolvedValueOnce(
+      'After the first launch failed, the second attempt succeeds and returns content.'
+    );
+
+    const recovered = await fetchWithPlaywright('https://example.com/second-attempt');
+    expect(recovered).not.toBeNull();
+    expect(recovered!.title).toBe('Recovered');
+  });
 });

--- a/crux/lib/search/playwright-fetcher.test.ts
+++ b/crux/lib/search/playwright-fetcher.test.ts
@@ -226,13 +226,17 @@ describe('fetchWithPlaywright', () => {
 
   // ---- Browser launch failure (QUA-229) ----
 
-  it('returns null (does not throw) when chromium.launch fails', async () => {
+  it('returns null (does not throw) and logs a warning when chromium.launch fails', async () => {
     // Reproduces QUA-229: chromium fails to launch (e.g. OOM-killed in worker
     // pod during startup) and throws "browserType.launch: Target page, context
     // or browser has been closed". The fetcher must honor its "returns null
     // on failure" contract so source-fetcher can fall back to Firecrawl/built-in
-    // and the job doesn't fail.
+    // and the job doesn't fail. The warning log is asserted so the operator-
+    // visible "Browser launch failed" signal can't be silently dropped by a
+    // future refactor.
     await closeBrowser(); // reset singleton so the next call re-launches
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const { chromium } = await import('playwright');
     vi.mocked(chromium.launch).mockRejectedValueOnce(
@@ -247,6 +251,12 @@ describe('fetchWithPlaywright', () => {
     expect(result).toBeNull();
     // No context creation since the browser never launched
     expect(mockBrowser.newContext).not.toHaveBeenCalled();
+    // Operator-visible signal — must be loud, not silent
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Browser launch failed, skipping Playwright')
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('retries the launch on the next call after a launch failure', async () => {
@@ -255,9 +265,13 @@ describe('fetchWithPlaywright', () => {
     await closeBrowser();
 
     const { chromium } = await import('playwright');
+    // `as any` because mockBrowser is a partial mock — the real Browser type
+    // has many methods we don't stub. The loose typing matches the pattern
+    // already used at the top of the file (`vi.fn().mockResolvedValue(mockBrowser)`).
     vi.mocked(chromium.launch)
       .mockRejectedValueOnce(new Error('browserType.launch: Target page, context or browser has been closed'))
-      .mockResolvedValueOnce(mockBrowser);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce(mockBrowser as any);
 
     const failed = await fetchWithPlaywright('https://example.com/first-attempt');
     expect(failed).toBeNull();

--- a/crux/lib/search/playwright-fetcher.ts
+++ b/crux/lib/search/playwright-fetcher.ts
@@ -231,7 +231,20 @@ export async function fetchWithPlaywright(
     return null;
   }
 
-  const browser = await getBrowser();
+  // Catch launch failures here to honor the "returns null on failure" contract.
+  // QUA-229: chromium can be killed during launch (OOM in worker pod, container
+  // limits) and `getBrowser()` rethrows. Without this catch the error propagates
+  // up through source-fetcher and fails the resource-ingest job — Playwright is
+  // a fallback, so a launch failure should let the caller fall through to
+  // Firecrawl/built-in instead.
+  let browser: any = null;
+  try {
+    browser = await getBrowser();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[playwright-fetcher] Browser launch failed, skipping Playwright: ${msg.slice(0, 200)}`);
+    return null;
+  }
   if (!browser) return null;
 
   let context: any = null;


### PR DESCRIPTION
## Summary

QUA-229: `resource-ingest` jobs have been failing with `browserType.launch: Target page, context or browser has been closed` — 8–44/day, ongoing since 2026-04-10. Investigation shows two distinct issues; this PR fixes the code-level one.

**Root cause (this PR):** `fetchWithPlaywright` calls `getBrowser()` outside its `try/catch`. When `chromium.launch()` rejects, the error propagates through `source-fetcher` and `handleResourceIngest`, marking the whole job failed. The fetcher's documented contract is "returns null on failure" — launch failures must obey it so the caller falls through to Firecrawl / built-in HTTP.

**Underlying cause (ops, not in this PR):** sample failures take 0.2–1.5s, which is too fast for a successful launch — chromium is being killed during startup. Likely worker-pod OOM or container limits. Left for a release session to investigate; flagging in the QUA-229 thread.

## Diagnosis

Sampled 10 failing jobs from the latest comment IDs (66167–66674). All fail in <2s during `browserType.launch`, across diverse URLs:

| Job | URL | Strategy | Duration |
|---|---|---|---|
| 66674 | crfm.stanford.edu/fmti/ | playwright-priority | 0.86s |
| 66212 | pitchbook.com/profiles/... | playwright-priority | 1.55s |
| 66209–66210 | justice.gov/opa/pr/... | default → fallback | 0.2s |
| 66189 | intel.gov/.../FISA_Section_702_Fact_Sheet_JUN2023.pdf | default → fallback | 0.24s |
| 66201 | thefuturesociety.org/our-team/ | default → fallback | 0.37s |

Both the `playwright-priority` strategy (line 713) and the empty-content fallback (line 792) call `playwrightFetch(url)` without a try/catch around it. The throw from `getBrowser()` reaches `handleResourceIngest`'s outer catch and fails the job.

## Change

`crux/lib/search/playwright-fetcher.ts` — wrap the `getBrowser()` call site in a try/catch, log a distinct `Browser launch failed, skipping Playwright: ...` warning, and return null. The existing `browserLaunchPromise = null` reset in `getBrowser()`'s catch means the next call retries — handles transient OOMs.

## Tests

`crux/lib/search/playwright-fetcher.test.ts` — two new tests:

1. `returns null (does not throw) and logs a warning when chromium.launch fails` — mocks `chromium.launch` to reject with the exact error from QUA-229 logs; asserts `fetchWithPlaywright` returns null, never creates a context, and emits the operator-visible warn message (so a future refactor can't silently drop the log).
2. `retries the launch on the next call after a launch failure` — first call fails, second call succeeds; verifies the singleton resets correctly.

Both tests fail without the fix (TDD verified) and pass with it. Full search test suite: 254/254 passing. Job-handlers: 127/127 passing.

## What this does NOT fix

- Why chromium is dying during launch in the worker pod. That's an environment / k8s-resource-limit issue. Slot agents don't touch `ops/`. Posting the operational handoff in the QUA-229 thread.
- Stanford CRFM / Pitchbook URLs will now fall through to Firecrawl/built-in and likely return short content (those are JS-heavy and need Playwright). Net effect: the job no longer fails, but content quality for those domains depends on the underlying chromium issue being fixed.

## Test plan

- [x] `pnpm crux w validate gate --fix` — all 70 checks green
- [x] `npx vitest run crux/lib/search/` — 254/254 passing
- [x] `npx vitest run crux/lib/job-handlers/` — 127/127 passing
- [x] TDD verified: tests fail without the fix, pass with it
- [x] /agent-review-pr — 7/7 phases recorded; hostile reviewer Phase 3b: 0 CRITICAL/HIGH, 2 MEDIUM both addressed (added `console.warn` spy assertion; switched test cast from `as never` to `as any`)
- [ ] CI green
- [ ] After merge: monitor QUA-229 daily failure rate — expect 0 (the symptom) but the upstream chromium-launch issue is a separate ops ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes QUA-229
