### PR TITLE
QUA-852: flip SOURCE_CHECK_REQUIRED.fact = true (Phase C)

### DIFF
--- a/apps/wiki-server/src/__tests__/facts.test.ts
+++ b/apps/wiki-server/src/__tests__/facts.test.ts
@@ -525,7 +525,7 @@ function seedFact(
   factId: string,
   opts: Record<string, unknown> = {}
 ) {
-  return postJson(app, "/api/facts/sync", {
+  return postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
     facts: [
       {
         entityId,
@@ -587,7 +587,7 @@ describe("Facts API", () => {
 
   describe("POST /api/facts/sync", () => {
     it("creates new facts", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -621,7 +621,7 @@ describe("Facts API", () => {
         value: "100",
       });
 
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -639,19 +639,19 @@ describe("Facts API", () => {
     });
 
     it("rejects empty batch", async () => {
-      const res = await postJson(app, "/api/facts/sync", { facts: [] });
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", { facts: [] });
       expect(res.status).toBe(400);
     });
 
     it("rejects facts without entityId", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [{ factId: "abc" }],
       });
       expect(res.status).toBe(400);
     });
 
     it("rejects invalid JSON", async () => {
-      const res = await app.request("/api/facts/sync", {
+      const res = await app.request("/api/facts/sync?forceSkipSourcing=true&reason=test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "not json",
@@ -664,7 +664,7 @@ describe("Facts API", () => {
     // Issue #4017 — numeric formats with NULL columns previously got
     // silently coerced to 0 on read. Reject them at the write boundary.
     it("rejects format=number with null numeric (issue #4017)", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -679,7 +679,7 @@ describe("Facts API", () => {
     });
 
     it("rejects format=min with null numeric (issue #4017)", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -694,7 +694,7 @@ describe("Facts API", () => {
     });
 
     it("rejects format=range with null low/high (issue #4017)", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -710,7 +710,7 @@ describe("Facts API", () => {
     });
 
     it("accepts format=number with explicit zero (real zero is not null)", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -727,7 +727,7 @@ describe("Facts API", () => {
     // ---- QUA-850: inline sourcing wiring ----
 
     it("writes a verdict row when a fact carries an inline `sourcing` block", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -771,7 +771,7 @@ describe("Facts API", () => {
     });
 
     it("is backwards-compatible: facts without sourcing succeed and write zero verdicts", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -793,7 +793,7 @@ describe("Facts API", () => {
     });
 
     it("writes verdicts for the subset of facts that carry sourcing in a mixed batch", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -830,7 +830,7 @@ describe("Facts API", () => {
     });
 
     it("rejects an invalid verdict enum value with 400 (not silent fail-open)", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -846,6 +846,97 @@ describe("Facts API", () => {
       // Schema rejection — no rows written.
       expect(factsStore.size).toBe(0);
       expect(verdictsStore.size).toBe(0);
+    });
+
+    // QUA-852 / QUA-729 Phase C: SOURCE_CHECK_REQUIRED.fact = true. Items
+    // without a `sourcing` block are rejected unless the caller passes
+    // `?forceSkipSourcing=true&reason=...` (audit-logged escape hatch).
+    describe("sourcing enforcement (QUA-852)", () => {
+      it("rejects fact items without sourcing when no bypass is provided", async () => {
+        const res = await postJson(app, "/api/facts/sync", {
+          facts: [
+            {
+              entityId: "anthropic",
+              factId: "no-source-1",
+              value: "100",
+              numeric: 100,
+              measure: "revenue",
+            },
+          ],
+        });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { message?: string };
+        expect(body.message ?? "").toMatch(/sourcing/i);
+        // Nothing should have been written.
+        expect(factsStore.size).toBe(0);
+        expect(verdictsStore.size).toBe(0);
+      });
+
+      it("rejects mixed batches where any item lacks sourcing", async () => {
+        const res = await postJson(app, "/api/facts/sync", {
+          facts: [
+            {
+              entityId: "anthropic",
+              factId: "with-sourcing",
+              value: "100",
+              numeric: 100,
+              measure: "revenue",
+              sourcing: { verdict: "confirmed" },
+            },
+            {
+              entityId: "anthropic",
+              factId: "no-sourcing",
+              value: "200",
+              numeric: 200,
+              measure: "revenue",
+            },
+          ],
+        });
+        expect(res.status).toBe(400);
+        // Whole batch fails — no partial writes.
+        expect(factsStore.size).toBe(0);
+        expect(verdictsStore.size).toBe(0);
+      });
+
+      it("accepts items with sourcing without bypass", async () => {
+        const res = await postJson(app, "/api/facts/sync", {
+          facts: [
+            {
+              entityId: "anthropic",
+              factId: "all-sourced",
+              value: "100",
+              numeric: 100,
+              measure: "revenue",
+              sourcing: { verdict: "confirmed", confidence: 0.9 },
+            },
+          ],
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { upserted: number; verdictsWritten: number };
+        expect(body.upserted).toBe(1);
+        expect(body.verdictsWritten).toBe(1);
+      });
+
+      it("accepts unsourced items when forceSkipSourcing=true is provided", async () => {
+        const res = await postJson(
+          app,
+          "/api/facts/sync?forceSkipSourcing=true&reason=bulk%20YAML%20re-sync",
+          {
+            facts: [
+              {
+                entityId: "anthropic",
+                factId: "bypass-1",
+                value: "100",
+                numeric: 100,
+                measure: "revenue",
+              },
+            ],
+          },
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { upserted: number };
+        expect(body.upserted).toBe(1);
+      });
     });
   });
 
@@ -1073,7 +1164,7 @@ describe("Facts API", () => {
 
   describe("Range value facts", () => {
     it("syncs facts with low/high range", async () => {
-      const res = await postJson(app, "/api/facts/sync", {
+      const res = await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -1101,7 +1192,7 @@ describe("Facts API", () => {
       process.env.LONGTERMWIKI_SERVER_API_KEY = "test-secret";
       const authedApp = createApp();
 
-      const res = await postJson(authedApp, "/api/facts/sync", {
+      const res = await postJson(authedApp, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           {
             entityId: "anthropic",
@@ -1118,7 +1209,7 @@ describe("Facts API", () => {
       process.env.LONGTERMWIKI_SERVER_API_KEY = "test-secret";
       const authedApp = createApp();
 
-      const res = await authedApp.request("/api/facts/sync", {
+      const res = await authedApp.request("/api/facts/sync?forceSkipSourcing=true&reason=test", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -1144,7 +1235,7 @@ describe("Facts API", () => {
   describe("POST /api/facts/prune (QUA-462)", () => {
     it("deletes facts whose factId is not in the keep list for an entity", async () => {
       // Seed three facts for anthropic.
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_keep1", label: "Keep 1", value: "1", numeric: 1, asOf: "2025-01", measure: "x" },
           { entityId: "anthropic", factId: "f_keep2", label: "Keep 2", value: "2", numeric: 2, asOf: "2025-02", measure: "x" },
@@ -1168,7 +1259,7 @@ describe("Facts API", () => {
     });
 
     it("deletes ALL facts for an entity when its keep list is empty (constellation case from QUA-462)", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "constellation", factId: "f_alcohol1", label: "Founded", value: "1945", numeric: 1945, asOf: "1945", measure: "founded" },
           { entityId: "constellation", factId: "f_alcohol2", label: "HQ", value: "Victor", measure: "hq" },
@@ -1193,7 +1284,7 @@ describe("Facts API", () => {
     });
 
     it("never touches facts for entities not in the request (cross-entity safety)", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_a", label: "A", value: "1", numeric: 1, measure: "x" },
           { entityId: "openai", factId: "f_b", label: "B", value: "2", numeric: 2, measure: "x" },
@@ -1214,7 +1305,7 @@ describe("Facts API", () => {
     });
 
     it("removes the dual-write things rows for deleted facts", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "constellation", factId: "f_old", label: "Founded", value: "1945", numeric: 1945, measure: "founded" },
         ],
@@ -1238,7 +1329,7 @@ describe("Facts API", () => {
     });
 
     it("returns 0 deleted when all facts in the keep list match what is in PG", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_a", label: "A", value: "1", numeric: 1, measure: "x" },
         ],
@@ -1255,7 +1346,7 @@ describe("Facts API", () => {
     });
 
     it("returns 0 deleted when entries is empty", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_a", label: "A", value: "1", numeric: 1, measure: "x" },
         ],
@@ -1282,7 +1373,7 @@ describe("Facts API", () => {
     });
 
     it("is idempotent — a second prune is a no-op", async () => {
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_keep", label: "K", value: "1", numeric: 1, measure: "x" },
           { entityId: "anthropic", factId: "f_stale", label: "S", value: "2", numeric: 2, measure: "x" },
@@ -1313,7 +1404,7 @@ describe("Facts API", () => {
       // dual-write row is found and deleted.
       const entityId = "sid_with:colon";
       const factId = "f_with space";
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId, factId, label: "X", value: "1", numeric: 1, measure: "x" },
         ],
@@ -1353,7 +1444,7 @@ describe("Facts API", () => {
           });
         }
       }
-      await postJson(app, "/api/facts/sync", { facts });
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", { facts });
       expect(factsStore.size).toBe(150);
 
       const entries = Array.from({ length: 50 }, (_, i) => ({
@@ -1377,7 +1468,7 @@ describe("Facts API", () => {
       // `PruneFactsResult` — inferred from this exact route via Hono RPC in
       // crux/lib/wiki-server/facts.ts. If a future refactor changes the
       // shape, this test catches it before the crux side silently breaks.
-      await postJson(app, "/api/facts/sync", {
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", {
         facts: [
           { entityId: "anthropic", factId: "f_stale", label: "S", value: "1", numeric: 1, measure: "x" },
         ],
@@ -1430,9 +1521,9 @@ describe("Facts API", () => {
       const batch1 = Array.from({ length: 500 }, (_, i) => makeFact(i));
       const batch2 = Array.from({ length: 500 }, (_, i) => makeFact(i + 500));
       const batch3 = Array.from({ length: 2 }, (_, i) => makeFact(i + 1000));
-      await postJson(app, "/api/facts/sync", { facts: batch1 });
-      await postJson(app, "/api/facts/sync", { facts: batch2 });
-      await postJson(app, "/api/facts/sync", { facts: batch3 });
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", { facts: batch1 });
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", { facts: batch2 });
+      await postJson(app, "/api/facts/sync?forceSkipSourcing=true&reason=test", { facts: batch3 });
       expect(factsStore.size).toBe(1002);
 
       const res = await postJson(app, "/api/facts/prune", {

--- a/apps/wiki-server/src/routes/factbase/facts.ts
+++ b/apps/wiki-server/src/routes/factbase/facts.ts
@@ -22,6 +22,7 @@ import {
   zv,
   clampedLimit,
 } from "../shared/utils.js";
+import { enforceSourcing } from "../shared/sourcing-enforcement.js";
 import { SyncFactsBatchSchema } from "../../api-types.js";
 import { upsertThingsInTx } from "../shared/thing-sync.js";
 import { writeInlineVerdicts, logSourcingCoverage } from "../tablebase/write-inline-verdicts.js";
@@ -488,6 +489,18 @@ const factsApp = new Hono()
     if (!parsed.success) return validationError(c, parsed.error.message);
 
     let items = parsed.data.facts;
+
+    // QUA-852 / QUA-729 Phase C: server-side sourcing enforcement.
+    // SOURCE_CHECK_REQUIRED.fact = true → reject items without a `sourcing`
+    // block. Bulk YAML re-sync uses `?forceSkipSourcing=true&reason=...` to
+    // bypass with audit logging — see crux/wiki-server/sync-facts.ts.
+    const enforcementError = enforceSourcing(
+      c,
+      "fact",
+      items as Array<{ sourcing?: unknown }>,
+    );
+    if (enforcementError) return enforcementError;
+
     const db = getDrizzleDb();
 
     // Validate entity references — skip facts whose entities don't exist in PG

--- a/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
@@ -24,6 +24,15 @@ const SOURCE_CHECK_REQUIRED: Record<string, boolean> = {
   "funding-programs": true,
   divisions: true,
   "policy-stakeholders": true,
+  // QUA-852 / QUA-729 Phase C: enabled 2026-05-01.
+  // Gate: checkable-fact coverage 93.7% (1841 verdicts / 1964 checkable facts);
+  // QUA-928 split the metric so this is measured against the checkable subset
+  // (facts with a source URL on a `verifiable: true` property), not all-facts.
+  // Bulk YAML re-sync (crux/wiki-server/sync-facts.ts) uses the
+  // `forceSkipSourcing=true` escape hatch — ~33% of facts are non-checkable
+  // by design (verifiable: false properties or no source URL) and carry no
+  // verdict to attach. Direct callers must include a `sourcing` block.
+  fact: true,
 };
 
 /**

--- a/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
+++ b/apps/wiki-server/src/routes/shared/sourcing-enforcement.ts
@@ -1,6 +1,20 @@
-import type { Context } from "hono";
+import type { Context, TypedResponse } from "hono";
 import { logger as rootLogger } from "../../logger.js";
-import { validationError } from "./utils.js";
+import { validationError, VALIDATION_ERROR } from "./utils.js";
+
+/**
+ * Concrete TypedResponse shape returned on enforcement failure. Declared so
+ * Hono RPC routes that wire `enforceSourcing` directly (rather than going
+ * through `sync-factory`) keep their `InferResponseType<..., 200>` narrowed
+ * to the success branch — without this, the bare `Response | null` return
+ * type collapses the route's response inference to `{}`.
+ */
+export type EnforceSourcingError = Response &
+  TypedResponse<
+    { error: typeof VALIDATION_ERROR; message: string },
+    400,
+    "json"
+  >;
 
 const logger = rootLogger.child({ component: "sourcing-enforcement" });
 
@@ -28,10 +42,17 @@ const SOURCE_CHECK_REQUIRED: Record<string, boolean> = {
   // Gate: checkable-fact coverage 93.7% (1841 verdicts / 1964 checkable facts);
   // QUA-928 split the metric so this is measured against the checkable subset
   // (facts with a source URL on a `verifiable: true` property), not all-facts.
-  // Bulk YAML re-sync (crux/wiki-server/sync-facts.ts) uses the
-  // `forceSkipSourcing=true` escape hatch — ~33% of facts are non-checkable
-  // by design (verifiable: false properties or no source URL) and carry no
-  // verdict to attach. Direct callers must include a `sourcing` block.
+  //
+  // **Scope of enforcement.** Today the only existing /api/facts/sync caller
+  // is `crux/wiki-server/sync-facts.ts` (the CI bulk YAML re-sync), which
+  // hard-codes `?forceSkipSourcing=true&reason=...`. So this gate is *not*
+  // an enforcement against the bulk path — it is a tripwire for any future
+  // ad-hoc /sync POSTs (manual curl, new dashboards, third-party tooling).
+  // Real per-fact sourcing pressure is enforced upstream at fact-creation
+  // time by `crux fb add-fact`, which now requires `--source=URL` for facts
+  // on verifiable properties. The bulk path bypasses because ~33% of facts
+  // are non-checkable by design (`verifiable: false` properties or
+  // legitimately have no source URL) and carry no verdict to attach inline.
   fact: true,
 };
 
@@ -51,7 +72,7 @@ export function enforceSourcing(
   c: Context,
   tableName: string,
   items: Array<{ sourcing?: unknown }>,
-): Response | null {
+): EnforceSourcingError | null {
   const serverRequired = SOURCE_CHECK_REQUIRED[tableName] === true;
   const clientRequired = c.req.query("requireSourcing") === "true";
 

--- a/crux/commands/factbase.test.ts
+++ b/crux/commands/factbase.test.ts
@@ -345,5 +345,20 @@ describe('crux kb add-fact', () => {
     // The error should include the existing fact's ID
     expect(result.output).toMatch(/fact ID: \w+/);
   }, 30_000);
+
+  // QUA-852 / QUA-729 Phase C: --source is required for facts on verifiable
+  // properties. The check runs after value/duplicate validation so existing
+  // tests that exercise those earlier branches don't have to learn about
+  // sourcing.
+  it('rejects new facts on verifiable properties without --source', async () => {
+    // Use a non-duplicate value/asOf so we reach the source check.
+    const result = await commands['add-fact'](
+      ['anthropic', 'revenue', '999e6'],
+      { asOf: '2099-01' },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('--source=URL is required');
+    expect(result.output).toContain('verifiable');
+  }, 30_000);
 });
 

--- a/crux/commands/factbase.test.ts
+++ b/crux/commands/factbase.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { commands, resolveEntityArg } from './factbase.ts';
+import { commands, resolveEntityArg, checkSourceRequirement } from './factbase.ts';
 import { loadGraphFull } from '../lib/factbase-loader.ts';
 import {
   readEntityDocument,
@@ -360,5 +360,93 @@ describe('crux kb add-fact', () => {
     expect(result.output).toContain('--source=URL is required');
     expect(result.output).toContain('verifiable');
   }, 30_000);
+});
+
+// QUA-852: pure-function tests for the source-check helper. Live separately
+// from the integration tests above so we can assert every branch (including
+// the bypass success path) without mutating the on-disk YAML files.
+describe('checkSourceRequirement (QUA-852)', () => {
+  const verifiable = { verifiable: true };
+  const nonVerifiable = { verifiable: false };
+  const urlResolves = { verifiable: false, verifierKind: 'url-resolves' };
+
+  it('rejects when verifiable property is missing --source', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', {});
+    expect(r.error).toContain('--source=URL is required');
+    expect(r.bypassReason).toBeNull();
+  });
+
+  it('accepts when --source is provided', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', {
+      source: 'https://example.com',
+    });
+    expect(r.error).toBeNull();
+    expect(r.bypassReason).toBeNull();
+  });
+
+  it('treats empty-string --source as missing', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', { source: '' });
+    expect(r.error).toContain('--source=URL is required');
+  });
+
+  it('treats whitespace-only --source as missing', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', { source: '   ' });
+    expect(r.error).toContain('--source=URL is required');
+  });
+
+  it('reads --no-source-reason via the kebab key', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', {
+      'no-source-reason': 'estimate',
+    });
+    expect(r.error).toBeNull();
+    expect(r.bypassReason).toBe('estimate');
+  });
+
+  // Regression: the crux argv parser kebab-to-camels every option key, so
+  // `--no-source-reason=foo` arrives as `options.noSourceReason='foo'`.
+  // Reading only `options['no-source-reason']` made the bypass unreachable
+  // via the actual CLI (caught by hostile review on PR for QUA-852).
+  it('reads --no-source-reason via the camelCase key (CLI parser convention)', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', {
+      noSourceReason: 'estimate from secondary source',
+    });
+    expect(r.error).toBeNull();
+    expect(r.bypassReason).toBe('estimate from secondary source');
+  });
+
+  it('rejects when --no-source-reason is empty/whitespace', () => {
+    expect(
+      checkSourceRequirement(verifiable, 'revenue', {
+        'no-source-reason': '',
+      }).error,
+    ).toContain('--source=URL is required');
+    expect(
+      checkSourceRequirement(verifiable, 'revenue', {
+        noSourceReason: '   ',
+      }).error,
+    ).toContain('--source=URL is required');
+  });
+
+  it('exempts properties marked verifiable: false', () => {
+    const r = checkSourceRequirement(nonVerifiable, 'social-media', {});
+    expect(r.error).toBeNull();
+    expect(r.bypassReason).toBeNull();
+  });
+
+  // verifiable: false + verifierKind: url-resolves means the URL-resolves
+  // verifier handles the fact and it DOES need a source URL (per
+  // packages/factbase/src/types.ts:118). Latent today (no property in
+  // properties.yaml uses both flags) but enforced for future-proofing.
+  it('does NOT exempt verifiable: false when verifierKind: url-resolves', () => {
+    const r = checkSourceRequirement(urlResolves, 'wikipedia-url', {});
+    expect(r.error).toContain('--source=URL is required');
+  });
+
+  it('trims the bypass reason', () => {
+    const r = checkSourceRequirement(verifiable, 'revenue', {
+      noSourceReason: '  trim me  ',
+    });
+    expect(r.bypassReason).toBe('trim me');
+  });
 });
 

--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -999,6 +999,54 @@ function coerceValue(raw: string, dataType: string, graph: Graph): { ok: true; v
 
 // ── add-fact command ────────────────────────────────────────────────────
 
+/**
+ * QUA-852 / QUA-729 Phase C: gate `crux fb add-fact` so new facts on
+ * verifiable properties always carry `--source=URL`. Pure helper so it can
+ * be unit-tested without invoking the file-writing flow.
+ *
+ * Properties flagged `verifiable: false` (e.g. social-media handles,
+ * self-referential URLs) are exempt by design, *unless* they declare
+ * `verifierKind: 'url-resolves'` (per `packages/factbase/src/types.ts:118`
+ * the url-resolves verifier explicitly handles those facts and they DO
+ * need a source URL).
+ *
+ * Escape hatch: `--no-source-reason="<reason>"` lets curators add unsourced
+ * facts; the runner emits a stderr warning. Both kebab (`'no-source-reason'`)
+ * and camelCase (`noSourceReason`) keys are accepted because the crux argv
+ * parser (`crux.mjs`) kebab-to-camels every key — direct callers (tests,
+ * helpers) often pass the kebab form. An empty/whitespace reason is treated
+ * as missing so the bypass actually requires a real explanation.
+ *
+ * Exported for unit tests.
+ */
+export function checkSourceRequirement(
+  property: { verifiable?: boolean; verifierKind?: string },
+  propertyArg: string,
+  options: Record<string, unknown>,
+): { error: string | null; bypassReason: string | null } {
+  const hasSource =
+    options.source != null && String(options.source).trim() !== '';
+  const noSourceReasonRaw =
+    options['no-source-reason'] ?? options.noSourceReason;
+  const bypassReason =
+    noSourceReasonRaw != null && String(noSourceReasonRaw).trim() !== ''
+      ? String(noSourceReasonRaw).trim()
+      : null;
+  const requiresSource =
+    property.verifiable !== false || property.verifierKind === 'url-resolves';
+
+  if (!requiresSource || hasSource) {
+    return { error: null, bypassReason: null };
+  }
+  if (bypassReason) {
+    return { error: null, bypassReason };
+  }
+  return {
+    error: `--source=URL is required for property "${propertyArg}" (verifiable). Either:\n  • Provide --source=https://...\n  • Use --no-source-reason="<why this fact has no source>" (logs a stderr warning, no persistent audit trail — keep the reason short and meaningful)\n  • Mark the property \`verifiable: false\` in packages/factbase/data/properties.yaml if it should never carry a source URL`,
+    bypassReason: null,
+  };
+}
+
 async function addFactCommand(
   args: string[],
   options: KBCommandOptions,
@@ -1015,12 +1063,13 @@ async function addFactCommand(
   Use --force to skip the duplicate check.
 
   --source=URL is required for facts on verifiable properties (QUA-852 / QUA-729 Phase C).
-  Use --no-source-reason="<reason>" to override with audit logging when no source exists.
-  Properties marked \`verifiable: false\` (e.g. social-media handles) are exempt.
+  Use --no-source-reason="<reason>" as an escape hatch (logs a stderr warning, no
+  persistent audit trail). Properties marked \`verifiable: false\` (e.g. social-media
+  handles) are exempt unless they declare \`verifierKind: url-resolves\`.
 
 Examples:
   crux fb add-fact anthropic revenue 5e9 --asOf=2025-06 --source=https://example.com
-  crux fb add-fact dario-amodei employed-by mK9pX3rQ7n
+  crux fb add-fact dario-amodei employed-by mK9pX3rQ7n --source=https://anthropic.com/team
   crux fb add-fact openai headcount 3700 --asOf=2025-01 --source=https://openai.com/about --notes="Approximate count"`,
     };
   }
@@ -1084,22 +1133,15 @@ Examples:
   }
 
   // QUA-852 / QUA-729 Phase C: require --source for verifiable properties so
-  // new facts carry a sourcing URL. Properties flagged `verifiable: false`
-  // (e.g. social-media handles, self-referential URLs) are exempt by design.
-  // Escape hatch `--no-source-reason="..."` lets curators add unsourced facts
-  // when justified, mirroring the server-side `?forceSkipSourcing=true` pattern.
-  const hasSource = options.source != null && String(options.source).trim() !== '';
-  const noSourceReason = options['no-source-reason'];
-  const requiresSource = property.verifiable !== false;
-  if (requiresSource && !hasSource && !noSourceReason) {
-    return {
-      exitCode: 1,
-      output: `--source=URL is required for property "${propertyArg}" (verifiable). Either:\n  • Provide --source=https://...\n  • Use --no-source-reason="<why this fact has no source>" to bypass with audit logging\n  • Mark the property \`verifiable: false\` in packages/factbase/data/properties.yaml if it should never carry a source URL`,
-    };
+  // new facts carry a sourcing URL. See `checkSourceRequirement` for the
+  // full reasoning + escape-hatch semantics.
+  const sourcingGate = checkSourceRequirement(property, propertyArg, options);
+  if (sourcingGate.error) {
+    return { exitCode: 1, output: sourcingGate.error };
   }
-  if (requiresSource && !hasSource && noSourceReason) {
+  if (sourcingGate.bypassReason) {
     console.warn(
-      `[add-fact] No --source provided; bypassing source requirement with reason: ${String(noSourceReason)}`,
+      `[add-fact] No --source provided; bypassing source requirement with reason: ${sourcingGate.bypassReason}`,
     );
   }
 

--- a/crux/commands/factbase.ts
+++ b/crux/commands/factbase.ts
@@ -1008,16 +1008,20 @@ async function addFactCommand(
   if (positionalArgs.length < 3) {
     return {
       exitCode: 1,
-      output: `Usage: crux fb add-fact <entity> <property> <value> [--asOf=YYYY-MM] [--source=URL] [--notes=TEXT] [--currency=USD] [--force]
+      output: `Usage: crux fb add-fact <entity> <property> <value> [--asOf=YYYY-MM] [--source=URL] [--notes=TEXT] [--currency=USD] [--force] [--no-source-reason=TEXT]
 
   Add a fact to a KB entity's YAML file.
   Detects duplicates by (property, value, asOf) and errors if a match exists.
   Use --force to skip the duplicate check.
 
+  --source=URL is required for facts on verifiable properties (QUA-852 / QUA-729 Phase C).
+  Use --no-source-reason="<reason>" to override with audit logging when no source exists.
+  Properties marked \`verifiable: false\` (e.g. social-media handles) are exempt.
+
 Examples:
   crux fb add-fact anthropic revenue 5e9 --asOf=2025-06 --source=https://example.com
   crux fb add-fact dario-amodei employed-by mK9pX3rQ7n
-  crux fb add-fact openai headcount 3700 --asOf=2025-01 --notes="Approximate count"`,
+  crux fb add-fact openai headcount 3700 --asOf=2025-01 --source=https://openai.com/about --notes="Approximate count"`,
     };
   }
 
@@ -1077,6 +1081,26 @@ Examples:
         output: `Duplicate fact: property "${propertyArg}" with value ${JSON.stringify(coerced.value)} and asOf "${asOf ?? '(none)'}" already exists (fact ID: ${duplicate.id}).\nUse --force to add anyway.`,
       };
     }
+  }
+
+  // QUA-852 / QUA-729 Phase C: require --source for verifiable properties so
+  // new facts carry a sourcing URL. Properties flagged `verifiable: false`
+  // (e.g. social-media handles, self-referential URLs) are exempt by design.
+  // Escape hatch `--no-source-reason="..."` lets curators add unsourced facts
+  // when justified, mirroring the server-side `?forceSkipSourcing=true` pattern.
+  const hasSource = options.source != null && String(options.source).trim() !== '';
+  const noSourceReason = options['no-source-reason'];
+  const requiresSource = property.verifiable !== false;
+  if (requiresSource && !hasSource && !noSourceReason) {
+    return {
+      exitCode: 1,
+      output: `--source=URL is required for property "${propertyArg}" (verifiable). Either:\n  • Provide --source=https://...\n  • Use --no-source-reason="<why this fact has no source>" to bypass with audit logging\n  • Mark the property \`verifiable: false\` in packages/factbase/data/properties.yaml if it should never carry a source URL`,
+    };
+  }
+  if (requiresSource && !hasSource && noSourceReason) {
+    console.warn(
+      `[add-fact] No --source provided; bypassing source requirement with reason: ${String(noSourceReason)}`,
+    );
   }
 
   const factInput: RawFactInput = {

--- a/crux/wiki-server/sync-facts.test.ts
+++ b/crux/wiki-server/sync-facts.test.ts
@@ -665,3 +665,71 @@ describe("pruneFacts", () => {
     expect(result.cascadedClaimLinks).toBe(0);
   });
 });
+
+// QUA-852 / QUA-729 Phase C: bulk YAML re-sync uses the audit-logged
+// `forceSkipSourcing=true` escape hatch so SOURCE_CHECK_REQUIRED.fact = true
+// does not reject every sync (only ~67% of facts have inline-attachable
+// verdicts and ~33% are non-checkable by design — see sync-facts.ts).
+describe("syncFactsBatch (QUA-852 forceSkipSourcing)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ upserted: 1, verdictsWritten: 0 }), {
+          status: 200,
+        }),
+      );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("appends ?forceSkipSourcing=true with an audit-logged reason", async () => {
+    // Imported here to avoid hoisting issues with vi.spyOn on globalThis.fetch.
+    const { syncFactsBatch } = await import("./sync-facts.ts");
+    await syncFactsBatch(
+      "https://wiki-server.example",
+      [
+        {
+          entityId: "anthropic",
+          factId: "f_test",
+          label: null,
+          value: "1",
+          numeric: 1,
+          low: null,
+          high: null,
+          asOf: null,
+          validEnd: null,
+          currency: null,
+          measure: "test",
+          subject: null,
+          note: null,
+          source: null,
+          format: "number",
+          formatDivisor: null,
+          sourceQuote: null,
+          usdEquivalent: null,
+          exchangeRate: null,
+          exchangeRateDate: null,
+          dollarYear: null,
+        },
+      ],
+      100,
+      // Skip the per-batch pacing delay so the test does not wait 500ms.
+      { _sleep: () => Promise.resolve() },
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const url = String(fetchSpy.mock.calls[0]![0]);
+    expect(url).toContain("/api/facts/sync");
+    expect(url).toContain("forceSkipSourcing=true");
+    expect(url).toContain("reason=");
+    // The reason is URL-encoded — decoding it should mention "bulk".
+    const reasonMatch = url.match(/reason=([^&]+)/);
+    expect(reasonMatch).not.toBeNull();
+    expect(decodeURIComponent(reasonMatch![1]!)).toMatch(/bulk/i);
+  });
+});

--- a/crux/wiki-server/sync-facts.ts
+++ b/crux/wiki-server/sync-facts.ts
@@ -183,6 +183,18 @@ export async function loadAndTransformFacts(
 }
 
 /**
+ * Audit reason logged on every bulk sync that bypasses server-side sourcing
+ * enforcement. QUA-852 / QUA-729 Phase C flipped `SOURCE_CHECK_REQUIRED.fact`
+ * to true, but ~33% of facts are non-checkable by design (verifiable: false
+ * properties or no source URL) and carry no verdict to attach inline. The
+ * bulk YAML re-sync therefore uses the audit-logged escape hatch; ad-hoc
+ * /sync callers without this bypass are still rejected unless they include
+ * a `sourcing` block.
+ */
+const BULK_SYNC_SKIP_REASON =
+  "bulk YAML re-sync (sync-facts.ts); ~33% of facts are non-checkable by design (verifiable=false properties or no source URL) and carry no verdict to attach inline";
+
+/**
  * Sync facts to the wiki-server in batches.
  * Exported for testing.
  */
@@ -194,8 +206,11 @@ export async function syncFactsBatch(
     _sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<{ upserted: number; errors: number }> {
+  const url =
+    `${serverUrl}/api/facts/sync` +
+    `?forceSkipSourcing=true&reason=${encodeURIComponent(BULK_SYNC_SKIP_REASON)}`;
   const result = await batchSync(
-    `${serverUrl}/api/facts/sync`,
+    url,
     items,
     batchSize,
     {


### PR DESCRIPTION
## Summary

Final phase of [QUA-729](https://linear.app/quantifieduncertainty/issue/QUA-729). Gates met now that [QUA-928](https://linear.app/quantifieduncertainty/issue/QUA-928) (PR #4741) split the coverage metric:

- **Checkable-fact coverage: 93.7%** (1,841 verdicts / 1,964 checkable facts) — well above the 90% gate
- All-facts coverage is mathematically capped at ~67% by collector design (verifiable=false properties + no source URL); the QUA-928 PR description explicitly noted "QUA-852 acceptance updated to gate on `checkableCoveragePercent >= 90` (already met at 99%)"

## What changed

- **`apps/wiki-server/src/routes/shared/sourcing-enforcement.ts`** — adds `fact: true` to `SOURCE_CHECK_REQUIRED` with an explicit "tripwire, not bulk-path enforcement" comment block. Also adds an exported `EnforceSourcingError` type so Hono RPC routes that wire `enforceSourcing` directly (rather than via `sync-factory`) keep `InferResponseType<..., 200>` narrowed to the success branch — without this, the bare `Response | null` return collapses route inference to `{}`.

- **`apps/wiki-server/src/routes/factbase/facts.ts`** — wires `enforceSourcing(c, 'fact', items)` in the `/sync` handler after Zod validation, before any DB work. Items without a `sourcing` block are 400'd unless the caller passes `?forceSkipSourcing=true&reason=...` (audit-logged escape hatch).

- **`crux/wiki-server/sync-facts.ts`** — bulk YAML re-sync (CI deploy pipeline) appends `?forceSkipSourcing=true` with an audit-logged reason. Required because YAML never carried inline `sourcing` (Phase A / PR #4698 explicitly course-corrected away from a YAML round-trip — sourcing stays in PG, owned by workers).

- **`crux/commands/factbase.ts`** — `crux fb add-fact` now requires `--source=URL` for facts on verifiable properties. Logic extracted into pure helper `checkSourceRequirement` for unit-test access. Reads both kebab (`'no-source-reason'`) and camelCase (`noSourceReason`) option keys to handle the crux argv parser's kebab-to-camel transform — caught by hostile review on the first commit. `--no-source-reason="<reason>"` is the escape hatch (stderr warning, no persistent audit trail). Properties marked `verifiable: false` are exempt unless they declare `verifierKind: 'url-resolves'` (per types.ts:118 the URL-resolves verifier explicitly handles those facts and they DO need a source URL).

## Tests

- **`apps/wiki-server/src/__tests__/facts.test.ts`** — 4 new cases: rejects unsourced items (400 + zero writes), rejects mixed batches (whole-batch fails — no partial writes), accepts sourced items without bypass, accepts unsourced items with `forceSkipSourcing`. Updated 28 existing `/sync` POSTs to include the bypass query so they keep exercising sync logic instead of the new enforcement gate.
- **`crux/wiki-server/sync-facts.test.ts`** — verifies `syncFactsBatch` URL contains `forceSkipSourcing=true&reason=...` and the reason mentions "bulk".
- **`crux/commands/factbase.test.ts`** — 1 integration test for the rejection branch + a new `describe('checkSourceRequirement')` block with 10 unit tests covering every branch (kebab key, camelCase key, empty/whitespace bypass, `verifiable: false` exemption, `verifierKind: 'url-resolves'` non-exemption, trim behavior, all valid-source variants).

All 53 facts tests + 33 sync-facts tests + 42 factbase command tests green locally. Validation gate: 68/68 checks pass.

## Hostile-review pass (`/agent-review-pr`)

Found and fixed:
- **CRITICAL** — `--no-source-reason` was unreachable via the actual CLI (kebab/camelCase mismatch). Verified end-to-end with `pnpm crux fb add-fact --no-source-reason="..."` after the fix.
- **HIGH** — "audit logging" wording was misleading (implementation is `console.warn`, no persistent record). Updated all three places (help text, error message, comment) to say "stderr warning, no persistent audit trail."
- **HIGH** — bypass success path was untested. Extracted helper + added 10 unit tests.
- **HIGH** — server enforcement comment didn't acknowledge it's a tripwire. The bulk YAML re-sync deliberately bypasses; real per-fact sourcing pressure is enforced upstream by `crux fb add-fact`. Comment now states this explicitly.
- **MEDIUM** — `verifiable: false` exemption now correctly does NOT exempt `verifierKind: 'url-resolves'` (latent today, future-proofed).
- **LOW** — CLI usage example for `employed-by` now includes `--source` (it's verifiable: true).

## Rollout

The same release deploys server enforcement and the CI-side bypass simultaneously, so there is no race window. Pre-existing FactBase syncing flows continue working; only direct ad-hoc `/api/facts/sync` POSTs without a `sourcing` block start getting 400s.

## Test plan

- [x] `pnpm vitest run apps/wiki-server/src/__tests__/facts.test.ts` — 53/53 pass
- [x] `pnpm vitest run crux/wiki-server/sync-facts.test.ts` — 33/33 pass
- [x] `pnpm vitest run crux/commands/factbase.test.ts` — 42/42 pass
- [x] `npx tsc --noEmit -p apps/wiki-server/tsconfig.json` — 0 errors
- [x] `npx tsc --noEmit -p crux/tsconfig.json` — 11 errors (matches origin/main baseline)
- [x] `pnpm crux w validate gate --fix --no-cache` — 68/68 checks pass (3 advisory warnings, all pre-existing)
- [x] `pnpm crux fb add-fact ... --no-source-reason="..."` end-to-end via CLI — bypass works, warning logged
- [x] `pnpm crux fb add-fact ... --source=""` end-to-end — correctly rejects with the source-required error

Closes QUA-852
